### PR TITLE
feat: Improve metadata extraction and database building

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,11 +56,10 @@ PACKAGES_PATH=C:\AOSService\PackagesLocalDirectory
 # Path where extracted XML metadata will be stored
 METADATA_PATH=./metadata
 
-# Model names to extract (comma-separated list of your models)
+# Comma-separated list of custom model names
 # Find in: Visual Studio > Dynamics 365 > Model Management > View models
-# Example: MODEL_NAMES=CustomModel1,CustomModel2,ApplicationSuite
-MODEL_NAMES=YourCustomModel1,YourCustomModel2
-# MODEL_NAMES_SEPARATOR=,  # Optional: change separator (default is comma)
+# Example: CUSTOM_MODELS=CustomModel1,CustomModel2,ApplicationSuite
+CUSTOM_MODELS=YourCustomModel1,YourCustomModel2
 
 # =============================================================================
 # CUSTOM EXTENSIONS CONFIGURATION (For ISV solutions)

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,9 +45,8 @@ async function main() {
     try {
       await fs.access(METADATA_PATH);
       console.log(`📖 Indexing metadata from: ${METADATA_PATH}`);
-      const modelNamesStr = process.env.MODEL_NAMES || process.env.MODEL_NAME || 'CustomModel';
-      const separator = process.env.MODEL_NAMES_SEPARATOR || ',';
-      const modelNames = modelNamesStr.split(separator).map(m => m.trim()).filter(Boolean);
+      const modelNamesStr = process.env.CUSTOM_MODELS || 'CustomModel';
+      const modelNames = modelNamesStr.split(',').map(m => m.trim()).filter(Boolean);
       console.log(`📦 Using model names: ${modelNames.join(', ')}`);
       
       for (const modelName of modelNames) {


### PR DESCRIPTION
- Add cleanup of extracted-metadata directory before extraction to prevent stale data
- Exclude FormAdaptor models from extraction process
- Fix extract mode logic: 'all' extracts everything, 'custom' excludes standard models, 'standard' extracts only standard models
- Remove deprecated extractCustomExtensionsOnly function
- Merge MODEL_NAMES and CUSTOM_MODELS into single CUSTOM_MODELS variable for consistency
- Add explicit support for symbolic links in package and model directories
- Implement selective model deletion in build-database based on EXTRACT_MODE
- Add VACUUM command after deletions to prevent database file growth
- Add unique constraints on symbols table to prevent duplicates
- Use INSERT OR REPLACE instead of INSERT to handle duplicate symbols gracefully