### PR TITLE
Fix: Enable Express trust proxy for Azure App Service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,10 @@ async function main() {
 
   // Create Express app with transport
   const app = express();
+  
+  // Trust proxy - required for Azure App Service (behind reverse proxy)
+  app.set('trust proxy', 1);
+  
   app.use(express.json());
 
   // Health check endpoint


### PR DESCRIPTION
- Set trust proxy to 1 for Azure reverse proxy compatibility
- Fixes express-rate-limit ValidationError with X-Forwarded-For header