### PR TITLE
Fix method extraction: parseMethodEnhanced now uses passed XppMethodI…

### DIFF
--- a/scripts/debug-parser.ts
+++ b/scripts/debug-parser.ts
@@ -1,0 +1,49 @@
+/**
+ * Debug parser to test XML parsing
+ */
+
+import * as fs from 'fs/promises';
+import { Parser } from 'xml2js';
+
+async function debugParse() {
+  const parser = new Parser({
+    explicitArray: false,
+    mergeAttrs: true,
+    trim: true,
+  });
+
+  const filePath = 'K:\\AOSService\\PackagesLocalDirectory\\ApplicationSuite\\Foundation\\AxClass\\AdvanceInvoiceContract_W.xml';
+  
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const parsed = await parser.parseStringPromise(content);
+
+    console.log('=== Parsed Structure ===');
+    console.log('AxClass exists:', !!parsed.AxClass);
+    console.log('Name:', parsed.AxClass?.Name);
+    console.log('SourceCode exists:', !!parsed.AxClass?.SourceCode);
+    console.log('SourceCode.Methods exists:', !!parsed.AxClass?.SourceCode?.Methods);
+    console.log('SourceCode.Methods.Method type:', typeof parsed.AxClass?.SourceCode?.Methods?.Method);
+    console.log('SourceCode.Methods.Method is array:', Array.isArray(parsed.AxClass?.SourceCode?.Methods?.Method));
+    
+    if (parsed.AxClass?.SourceCode?.Methods?.Method) {
+      const methods = Array.isArray(parsed.AxClass.SourceCode.Methods.Method) 
+        ? parsed.AxClass.SourceCode.Methods.Method 
+        : [parsed.AxClass.SourceCode.Methods.Method];
+      
+      console.log('\n=== First Method ===');
+      console.log('Count:', methods.length);
+      console.log('First method:', JSON.stringify(methods[0], null, 2));
+    }
+
+    // Try alternative path
+    console.log('\n=== Alternative Path ===');
+    console.log('axClass.Methods exists:', !!parsed.AxClass?.Methods);
+    console.log('axClass.Methods.Method exists:', !!parsed.AxClass?.Methods?.Method);
+
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+debugParse();

--- a/src/metadata/enhancedParser.ts
+++ b/src/metadata/enhancedParser.ts
@@ -209,23 +209,14 @@ export class EnhancedXppParser {
   /**
    * Parse method with enhanced metadata
    */
-  parseMethodEnhanced(method: any, parentClass: string): EnhancedMethodInfo {
-    const source = method.Source || '';
-    const methodName = method.Name || 'unknown';
-    
-    const baseInfo: XppMethodInfo = {
-      name: methodName,
-      visibility: this.parseVisibility(method.Visibility),
-      returnType: this.extractReturnType(source, methodName) || method.ReturnType || 'void',
-      parameters: this.extractParametersFromSource(source, methodName),
-      isStatic: this.isMethodStatic(source),
-      source: source,
-      documentation: method.DeveloperDocumentation || undefined,
-    };
+  parseMethodEnhanced(method: XppMethodInfo, parentClass: string): EnhancedMethodInfo {
+    // method parameter is already a parsed XppMethodInfo object with lowercase properties
+    const source = method.source || '';
+    const methodName = method.name || 'unknown';
     
     // Enhanced metadata
     const enhanced: EnhancedMethodInfo = {
-      ...baseInfo,
+      ...method,
       sourceSnippet: this.getFirstLines(source, 10),
       complexity: this.calculateComplexity(source),
       usedTypes: this.extractUsedTypes(source),
@@ -319,52 +310,5 @@ export class EnhancedXppParser {
     }
     
     return Array.from(tags);
-  }
-
-  // Helper methods (placeholder implementations - these should match xmlParser.ts)
-  
-  private parseVisibility(vis?: string): 'public' | 'private' | 'protected' {
-    if (!vis) return 'public';
-    const lower = vis.toLowerCase();
-    if (lower === 'private') return 'private';
-    if (lower === 'protected') return 'protected';
-    return 'public';
-  }
-
-  private extractReturnType(source: string, methodName: string): string | undefined {
-    // Extract return type from method signature
-    const signaturePattern = new RegExp(
-      `(public|private|protected)?\\s*(static)?\\s*([\\w\\[\\]]+)\\s+${methodName}\\s*\\(`,
-      'i'
-    );
-    const match = source.match(signaturePattern);
-    return match ? match[3] : undefined;
-  }
-
-  private extractParametersFromSource(source: string, methodName: string): any[] {
-    // Simple parameter extraction - enhance as needed
-    const paramPattern = new RegExp(
-      `${methodName}\\s*\\(([^)]*)\\)`,
-      'i'
-    );
-    const match = source.match(paramPattern);
-    
-    if (!match || !match[1].trim()) {
-      return [];
-    }
-    
-    const params = match[1].split(',').map(p => {
-      const parts = p.trim().split(/\s+/);
-      if (parts.length >= 2) {
-        return { type: parts[0], name: parts[1] };
-      }
-      return { type: 'any', name: parts[0] };
-    });
-    
-    return params;
-  }
-
-  private isMethodStatic(source: string): boolean {
-    return /\bstatic\b/i.test(source.substring(0, 200));
   }
 }


### PR DESCRIPTION
…nfo parameter

- Fixed bug where parseMethodEnhanced was trying to extract method.Source and method.Name (capital) instead of using the passed method.source and method.name properties
- This caused all extracted methods to have empty source and 'unknown' name
- Removed duplicate helper methods (parseVisibility, extractReturnType, etc.) that were never used
- Added debug-parser.ts script for troubleshooting XML parsing issues