### PR TITLE
docs: fix documentation inaccuracies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,8 @@
 # Environment: development, staging, production
 NODE_ENV=development
 
-# Server port (default: 3000 for dev, 8080 for production)
-PORT=3000
+# Server port (default: 8080)
+PORT=8080
 
 # Log level: error, warn, info, debug
 LOG_LEVEL=debug

--- a/docs/ORCHESTRATOR_SETUP.md
+++ b/docs/ORCHESTRATOR_SETUP.md
@@ -195,8 +195,6 @@ Available prompts:
 - **`xpp_system_instructions`** - System instructions for GitHub Copilot (automatically used)
 - **`xpp_code_review`** - Review X++ code for best practices
 - **`xpp_explain_class`** - Detailed explanation of an X++ class
-- **`xpp_refactor_code`** - Refactoring suggestions for code
-- **`xpp_best_practices`** - Best practices for various topics (transactions, error handling, etc.)
 
 ## Testing in Visual Studio
 
@@ -270,7 +268,7 @@ Copilot should:
 **Problem:** Tools return empty results or "not found"
 
 **Solution:**
-1. Verify you have downloaded metadata: `npm run build:db`
+1. Verify you have downloaded metadata: `npm run build-database`
 2. Check Redis cache connection (if using)
 3. Try broader search with `type='all'`
 4. Check spelling of object name (case-sensitive)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -71,7 +71,7 @@ REDIS_URL=redis://localhost:6379
 REDIS_ENABLED=false
 
 # Server Configuration
-PORT=3000
+PORT=8080
 NODE_ENV=development
 ```
 
@@ -105,7 +105,9 @@ npm run dev
 npm start
 ```
 
-Server runs on `http://localhost:3000` with health check at `/health`.
+Server runs on `http://localhost:8080` with health check at `/health`.
+
+> **Note:** The default port is 8080. You can override this with the `PORT` environment variable in `.env`.
 
 ---
 
@@ -309,7 +311,7 @@ Create `.mcp.json` file in your D365FO solution root directory:
 {
   "servers": {
     "xpp-completion": {
-      "url": "http://localhost:3000/mcp/",
+      "url": "http://localhost:8080/mcp/",
       "description": "X++ Code Completion Server (Local)"
     }
   }


### PR DESCRIPTION
- Fix npm script reference (build:db → build-database)
- Remove non-existent prompts from documentation (xpp_refactor_code, xpp_best_practices)
- Update port references from 3000 to 8080 across all docs
- Fix .env.example port default value and comment
- Add port configuration note in SETUP.md