### PR TITLE
fix: Add intelligent tools to HTTP transport layer

### DIFF
--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -15,6 +15,10 @@ import { tableInfoTool } from '../tools/tableInfo.js';
 import { completionTool } from '../tools/completion.js';
 import { codeGenTool } from '../tools/codeGen.js';
 import { extensionSearchTool } from '../tools/extensionSearch.js';
+import { analyzeCodePatternsTool } from '../tools/analyzePatterns.js';
+import { suggestMethodImplementationTool } from '../tools/suggestImplementation.js';
+import { analyzeClassCompletenessTool } from '../tools/analyzeCompleteness.js';
+import { getApiUsagePatternsTool } from '../tools/apiUsagePatterns.js';
 
 interface McpSession {
   id: string;
@@ -270,6 +274,55 @@ export class StreamableHttpTransport {
               required: ['pattern', 'name'],
             },
           },
+          {
+            name: 'analyze_code_patterns',
+            description: 'Analyze existing codebase for similar code patterns. Essential for creating code based on real D365FO patterns.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                scenario: { type: 'string', description: 'Description of the scenario or functionality to analyze (e.g., "financial dimensions", "inventory transactions")' },
+                classPattern: { type: 'string', description: 'Optional class name pattern to filter results (e.g., "Helper", "Service")' },
+                limit: { type: 'number', description: 'Maximum number of pattern examples to return', default: 5 },
+              },
+              required: ['scenario'],
+            },
+          },
+          {
+            name: 'suggest_method_implementation',
+            description: 'Suggest method body implementation based on similar methods in the codebase. Provides real examples from actual D365FO code.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                className: { type: 'string', description: 'Name of the class containing the method' },
+                methodName: { type: 'string', description: 'Name of the method to implement' },
+                parameters: { type: 'string', description: 'Optional method parameters to help find similar methods' },
+              },
+              required: ['className', 'methodName'],
+            },
+          },
+          {
+            name: 'analyze_class_completeness',
+            description: 'Analyze a class and suggest missing methods based on similar classes. Helps identify methods to follow common patterns.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                className: { type: 'string', description: 'Name of the class to analyze' },
+              },
+              required: ['className'],
+            },
+          },
+          {
+            name: 'get_api_usage_patterns',
+            description: 'Get common usage patterns for a specific API or class. Shows initialization patterns and method call sequences.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                apiName: { type: 'string', description: 'Name of the API/class to get usage patterns for' },
+                context: { type: 'string', description: 'Optional context to filter patterns (e.g., "initialization", "validation")' },
+              },
+              required: ['apiName'],
+            },
+          },
         ],
       },
       id: body.id,
@@ -315,6 +368,18 @@ export class StreamableHttpTransport {
           break;
         case "search_extensions":
           result = await extensionSearchTool(request, this.context);
+          break;
+        case "analyze_code_patterns":
+          result = await analyzeCodePatternsTool(request, this.context);
+          break;
+        case "suggest_method_implementation":
+          result = await suggestMethodImplementationTool(request, this.context);
+          break;
+        case "analyze_class_completeness":
+          result = await analyzeClassCompletenessTool(request, this.context);
+          break;
+        case "get_api_usage_patterns":
+          result = await getApiUsagePatternsTool(request, this.context);
           break;
         default:
           throw new Error(`Unknown tool: ${name}`);


### PR DESCRIPTION
- Added imports for 4 intelligent tools (analyzePatterns, suggestImplementation, analyzeCompleteness, apiUsagePatterns)
- Added tool definitions to handleListTools() method
- Added case handlers to handleCallTool() switch statement
- Fixes issue where Azure-deployed server was missing intelligent tools
- Now all 10 tools are available via HTTP transport (6 basic + 4 intelligent)