### PR TITLE
fix: Add retry logic to health check to handle cold starts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,8 +81,28 @@ jobs:
       - name: Health check
         run: |
           echo "Waiting for deployment to complete..."
-          sleep 30
-          curl -f https://${{ env.AZURE_WEBAPP_NAME }}.azurewebsites.net/health || exit 1
+          sleep 45
+          
+          MAX_RETRIES=12
+          RETRY_DELAY=15
+          
+          for i in $(seq 1 $MAX_RETRIES); do
+            echo "Health check attempt $i/$MAX_RETRIES..."
+            
+            if curl -f --max-time 30 -s https://${{ env.AZURE_WEBAPP_NAME }}.azurewebsites.net/health > /dev/null 2>&1; then
+              echo "✅ Health check passed!"
+              curl https://${{ env.AZURE_WEBAPP_NAME }}.azurewebsites.net/health
+              exit 0
+            fi
+            
+            if [ $i -lt $MAX_RETRIES ]; then
+              echo "⏳ Server not ready yet, waiting ${RETRY_DELAY}s before retry..."
+              sleep $RETRY_DELAY
+            fi
+          done
+          
+          echo "❌ Health check failed after $MAX_RETRIES attempts"
+          exit 1
 
       - name: Logout from Azure
         run: az logout


### PR DESCRIPTION
- Increased initial wait from 30s to 45s
- Added 12 retry attempts with 15s delay between each
- Set 30s timeout per request to prevent 504 errors
- Total timeout now ~4 minutes to handle cold starts + Redis + blob download
- Added better logging to show progress and health check response