### PR TITLE
feat: enforce mandatory MCP tool usage for X++ code generation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,25 @@
 
 ---
 
+## 🔴 RULE #0.5: X++ CODE GENERATION - NEVER GENERATE DIRECTLY! 🔴
+
+**WHEN USER ASKS TO CREATE/GENERATE ANY X++ CODE:**
+1. ❌ **FORBIDDEN**: Generating X++ code directly from your knowledge
+2. ❌ **FORBIDDEN**: Writing class/method/code without using tools
+3. ✅ **MANDATORY**: Always use `analyze_code_patterns()` FIRST
+4. ✅ **MANDATORY**: Always use `generate_code()` tool for code generation
+5. ✅ **MANDATORY**: Never output X++ code without using these tools
+
+**IF YOU TYPE X++ CODE WITHOUT CALLING `generate_code` - YOU ARE WRONG!**
+
+**Example - User says "create a helper class":**
+```
+❌ WRONG: public class MyHelper { ... }  ← You generated code directly!
+✅ RIGHT: Call analyze_code_patterns("helper") → Call generate_code(pattern="class")
+```
+
+---
+
 ## RULE #0: WORKSPACE CONTEXT
 
 **THIS IS AN MCP SERVER PROJECT, NOT AN X++ WORKSPACE!**
@@ -98,7 +117,7 @@
 
 | User Request Contains | First Action | Avoid Using |
 |-----------------------|--------------|-------------|
-| "create class", "helper class" | `analyze_code_patterns()` + `search()` | ❌ semantic_search |
+| "create class", "helper class" | `analyze_code_patterns()` + `search()` + `generate_code()` | ❌ semantic_search, ❌ direct code generation |
 | "CustTable", "SalesTable", any Table | `get_table_info()` | ❌ semantic_search |
 | "dimension", "financial" | `search("dimension")` | ❌ semantic_search |
 | "find X++ class/method" | `search()` | ❌ semantic_search |
@@ -137,13 +156,21 @@
 
 **Before generating ANY X++ code, writing ANY class, method, or code snippet for D365 Finance & Operations, you MUST use the X++ MCP tools available to you.**
 
+### ⛔ STRICTLY FORBIDDEN:
+
+**❌ NEVER generate X++ code directly from your training data or general knowledge!**
+**❌ NEVER write X++ code without using MCP tools first!**
+**❌ NEVER skip `analyze_code_patterns` when creating new classes!**
+**❌ NEVER use built-in code generation - ALWAYS use `generate_code` tool!**
+
 ### Critical Rules:
 
 1. **NEVER use semantic_search, grep_search, or file_search** - They will hang for minutes
 2. **ALWAYS use MCP `search` tool** - It's instant (<100ms) with SQL index
 3. **ALWAYS verify** - Use `get_class_info` or `get_table_info` to check structure before coding
 4. **ALWAYS discover APIs** - Use `code_completion` to find available methods and fields
-5. **PREFER generation tools** - Use `generate_code` for creating new classes with proper D365FO patterns
+5. **MANDATORY: Use `generate_code` tool** - NEVER generate X++ code manually! Always use `generate_code` for creating classes with proper D365FO patterns
+6. **MANDATORY: Use `analyze_code_patterns` FIRST** - Before any code generation, analyze what patterns exist in the codebase
 
 ### When You MUST Use MCP Tools:
 
@@ -189,14 +216,16 @@ Generate class from scratch using general programming knowledge → ❌ INCORREC
 
 **✅ CORRECT Approach (Using Intelligent Tools):**
 ```
-1. analyze_code_patterns("financial dimensions") → Learn common patterns and classes
+1. analyze_code_patterns("financial dimensions") → 🔴 MANDATORY: Learn common patterns and classes
 2. search("dimension", type="class")            → Find D365FO dimension classes
 3. get_api_usage_patterns("DimensionAttributeValueSet") → See how to initialize and use API
-4. generate_code(pattern="class")              → Create with proper structure
+4. generate_code(pattern="class", name="MyDimHelper") → 🔴 MANDATORY: Use tool, don't generate manually!
 5. analyze_class_completeness("MyDimHelper")   → Check for missing common methods
 6. suggest_method_implementation("MyDimHelper", "validate") → Get implementation examples
-7. Apply discovered patterns                     → Use correct APIs and methods
+7. Apply discovered patterns from tools          → Use correct APIs and methods from MCP tools
 ```
+
+**⚠️ WARNING: If you generate code WITHOUT using `generate_code` tool, you are WRONG!**
 
 **✅ ALTERNATIVE Approach (Traditional):**
 ```

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -100,11 +100,37 @@ You are GitHub Copilot assisting with Microsoft Dynamics 365 Finance & Operation
 - **Instead of:** Searching all symbols including standard Microsoft code
 - **Example:** Finding team's customizations vs. standard objects
 
-### 6. Code Generation
+### 6. 🔴 Code Pattern Analysis (MANDATORY BEFORE CODE GENERATION)
+- **Tool:** \`analyze_code_patterns\`
+- **When:** ALWAYS use BEFORE creating any new X++ code
+- **Instead of:** Generating code from general knowledge or templates
+- **Purpose:** Discovers real D365FO patterns, common classes, and methods used together
+- **Example:** analyze_code_patterns("financial dimensions") before creating dimension helper
+
+### 7. 🔴 Code Generation (ALWAYS USE - NEVER GENERATE MANUALLY)
 - **Tool:** \`generate_code\`
-- **When:** Creating new X++ code from templates
-- **Instead of:** Writing code from scratch without patterns
-- **Patterns:** 'class', 'runnable', 'form-handler', 'data-entity', 'batch-job'
+- **When:** Creating any new X++ code (classes, methods, extensions)
+- **Instead of:** Writing code from scratch or using built-in generation
+- **Patterns:** 'class', 'runnable', 'form-handler', 'data-entity', 'batch-job', 'coc-extension', 'event-handler', 'service-class'
+- **CRITICAL:** NEVER generate X++ code without using this tool!
+
+### 8. Method Implementation Suggestions
+- **Tool:** \`suggest_method_implementation\`
+- **When:** Implementing a specific method in a class
+- **Instead of:** Guessing implementation patterns
+- **Purpose:** Shows real examples from codebase of how similar methods are implemented
+
+### 9. Class Completeness Analysis
+- **Tool:** \`analyze_class_completeness\`
+- **When:** Want to ensure a class follows common patterns
+- **Instead of:** Manually checking what methods might be missing
+- **Purpose:** Suggests missing methods based on similar classes in the codebase
+
+### 10. API Usage Patterns
+- **Tool:** \`get_api_usage_patterns\`
+- **When:** Need to use a D365FO API/class correctly
+- **Instead of:** Guessing initialization and method sequences
+- **Purpose:** Shows real usage examples from codebase including initialization patterns
 
 ## Workflow Examples for Visual Studio 2022
 
@@ -112,19 +138,23 @@ You are GitHub Copilot assisting with Microsoft Dynamics 365 Finance & Operation
 \`\`\`
 Developer: "Create a helper class for maintaining financial dimensions"
 
-CORRECT Workflow:
-1. Use search("dimension", type="class") → Find existing D365FO dimension classes
-2. Use search("financial dimension", type="all") → Discover D365FO patterns and APIs
-3. Use get_class_info("DimensionDefaultingService") → Study Microsoft's implementation
-4. Use code_completion("DimensionAttributeValueSet") → Get proper API methods
-5. Use generate_code(pattern="class") → Create helper with proper structure
-6. Apply discovered D365FO patterns for dimension handling
+🔴 MANDATORY WORKFLOW (USE TOOLS, NOT BUILT-IN GENERATION):
+1. Use analyze_code_patterns("financial dimensions") → 🔴 MANDATORY: Learn what D365FO classes are used together
+2. Use search("dimension", type="class") → Find existing D365FO dimension classes
+3. Use get_api_usage_patterns("DimensionAttributeValueSet") → See how API is initialized and used
+4. Use get_class_info("DimensionDefaultingService") → Study Microsoft's implementation
+5. Use code_completion("DimensionAttributeValueSet") → Get proper API methods
+6. Use generate_code(pattern="class", name="MyDimHelper") → 🔴 MANDATORY: Use tool, DON'T type code!
+7. Use suggest_method_implementation("MyDimHelper", "validate") → Get real implementation examples
+8. Apply discovered patterns from tools above
 
-WRONG Workflow:
-❌ Generate helper class from scratch without checking D365FO dimension APIs
+❌ ABSOLUTELY FORBIDDEN WORKFLOW:
+❌ Generate helper class from scratch without using analyze_code_patterns
+❌ Type "public class MyHelper { }" without calling generate_code tool
 ❌ Use generic coding patterns instead of D365FO-specific dimension framework
 ❌ Assume method names without querying actual D365FO classes
 ❌ Create code that doesn't integrate with standard dimension infrastructure
+❌ Use built-in code generation instead of MCP tools
 \`\`\`
 
 ### Example 2: Adding Code to Existing Class

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -257,7 +257,7 @@ export async function codeGenTool(request: CallToolRequest) {
       content: [
         {
           type: 'text',
-          text: `Generated ${args.pattern} template for "${args.name}":\n\n\`\`\`xpp${code}\n\`\`\``,
+          text: `Generated ${args.pattern} template for "${args.name}":\n\n\`\`\`xpp${code}\n\`\`\`\n\n---\n\n💡 **Next Steps for Better Code Quality:**\n\n1. ✅ Use \`analyze_code_patterns("<scenario>")\` - Learn what D365FO classes are commonly used together\n2. ✅ Use \`suggest_method_implementation("${args.name}", "<methodName>")\` - Get real implementation examples\n3. ✅ Use \`analyze_class_completeness("${args.name}")\` - Check for missing common methods\n4. ✅ Use \`get_api_usage_patterns("<ClassName>")\` - See how to use D365FO APIs correctly\n\nThese tools provide patterns from the actual codebase, not generic templates.`,
         },
       ],
     };

--- a/src/tools/completion.ts
+++ b/src/tools/completion.ts
@@ -14,38 +14,71 @@ const CompletionArgsSchema = z.object({
 
 export async function completionTool(request: CallToolRequest, context: XppServerContext) {
   const args = CompletionArgsSchema.parse(request.params.arguments);
-  const { symbolIndex } = context;
+  const { symbolIndex, cache } = context;
 
   try {
-    const methods = symbolIndex.getClassMethods(args.className);
-    const fields = symbolIndex.getTableFields(args.className);
+    // Check cache first
+    const cacheKey = `completion:${args.className}:${args.prefix}`;
+    const cachedResults = await cache.get<any[]>(cacheKey);
+    
+    if (cachedResults) {
+      return {
+        content: [{ type: 'text', text: formatCompletions(cachedResults, args.className, args.prefix) }],
+      };
+    }
 
-    const allMembers = [...methods, ...fields].filter((m) =>
-      m.name.toLowerCase().startsWith(args.prefix.toLowerCase())
-    );
+    // Use the built-in getCompletions method that properly handles both classes and tables
+    const completions = symbolIndex.getCompletions(args.className, args.prefix);
 
-    if (allMembers.length === 0) {
+    if (completions.length === 0) {
+      // Check if the class/table exists at all
+      const classExists = symbolIndex.searchSymbols(args.className, 1, ['class']).length > 0;
+      const tableExists = symbolIndex.searchSymbols(args.className, 1, ['table']).length > 0;
+      
+      if (!classExists && !tableExists) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `❌ Class or table "${args.className}" not found in metadata.\n\n` +
+                    `**Possible reasons:**\n` +
+                    `1. The class/table doesn't exist in your D365FO environment\n` +
+                    `2. Typo in the name (use \`search\` tool to find similar names)\n` +
+                    `3. Metadata database hasn't been built yet\n\n` +
+                    `**Next steps:**\n` +
+                    `- Try: \`search("${args.className.substring(0, 5)}", type="class")\`\n` +
+                    `- Try: \`search("${args.className.substring(0, 5)}", type="table")\``,
+            },
+          ],
+        };
+      }
+      
+      const prefixMsg = args.prefix ? ` starting with "${args.prefix}"` : '';
       return {
         content: [
           {
             type: 'text',
-            text: `No members found for "${args.className}" starting with "${args.prefix}"`,
+            text: `Found "${args.className}" but it has no methods or fields${prefixMsg}.\n\n` +
+                  `This could mean:\n` +
+                  `- The class/table has no members\n` +
+                  `- The prefix "${args.prefix}" doesn't match any members\n` +
+                  `- XML metadata is not available (only symbol index)\n\n` +
+                  `Try using \`get_class_info("${args.className}")\` or \`get_table_info("${args.className}")\` for more details.`,
           },
         ],
       };
     }
 
-    const completions = allMembers.map((m) => ({
-      label: m.name,
-      kind: m.type === 'method' ? 'Method' : 'Field',
-      signature: m.signature || '',
-    }));
+    // Cache results
+    await cache.set(cacheKey, completions, 300); // Cache for 5 minutes
+
+    const formatted = formatCompletions(completions, args.className, args.prefix);
 
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify(completions, null, 2),
+          text: formatted,
         },
       ],
     };
@@ -60,4 +93,48 @@ export async function completionTool(request: CallToolRequest, context: XppServe
       isError: true,
     };
   }
+}
+
+/**
+ * Format completions in a human-readable way
+ */
+function formatCompletions(completions: any[], className: string, prefix: string): string {
+  const prefixMsg = prefix ? ` starting with "${prefix}"` : '';
+  let output = `# Code Completion: ${className}${prefixMsg}\n\n`;
+  output += `Found ${completions.length} member(s):\n\n`;
+
+  // Group by kind
+  const methods = completions.filter(c => c.kind === 'Method');
+  const fields = completions.filter(c => c.kind === 'Field');
+
+  if (methods.length > 0) {
+    output += `## Methods (${methods.length})\n\n`;
+    methods.forEach(m => {
+      const sig = m.detail || m.signature || '';
+      output += `- **${m.label}**`;
+      if (sig) {
+        output += `: ${sig}`;
+      }
+      output += '\n';
+    });
+    output += '\n';
+  }
+
+  if (fields.length > 0) {
+    output += `## Fields (${fields.length})\n\n`;
+    fields.forEach(f => {
+      const sig = f.detail || f.signature || '';
+      output += `- **${f.label}**`;
+      if (sig) {
+        output += `: ${sig}`;
+      }
+      output += '\n';
+    });
+  }
+
+  if (prefix && completions.length < 100) {
+    output += `\n---\n\n💡 **Tip:** Remove the prefix to see all available members of ${className}.`;
+  }
+
+  return output;
 }

--- a/src/tools/xppTools.ts
+++ b/src/tools/xppTools.ts
@@ -774,17 +774,17 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'code_completion',
-    description: 'Get method and field completions for a class or table. Use this for IntelliSense-style code completion.',
+    description: '🔍 Get all methods and fields for a class or table (IntelliSense-style completion). Use this to discover what members are available on a D365FO object. Optionally filter by prefix. Leave prefix empty to see ALL members. Works for both classes and tables.',
     inputSchema: CompleteMethodSchema
   },
   {
     name: 'generate_code',
-    description: 'Generate X++ code templates for common patterns like runnable classes, batch jobs, form extensions, Chain of Command extensions, and event handlers.',
+    description: '⚡ ALWAYS USE THIS for creating new X++ code! Generates production-ready X++ code using D365FO best practices and patterns. Creates runnable classes, batch jobs, form extensions, Chain of Command extensions, event handlers, and service classes. DO NOT generate X++ code manually - use this tool to ensure correct D365FO patterns, naming conventions, and structure.',
     inputSchema: GenerateCodeSchema
   },
   {
     name: 'analyze_code_patterns',
-    description: 'Analyze existing codebase for similar code patterns. Use this to find common methods, dependencies, and implementation patterns before generating new code. Essential for creating code based on real D365FO patterns, not templates.',
+    description: '🔍 MANDATORY FIRST STEP before generating any X++ code! Analyzes existing codebase for similar code patterns. Finds common methods, dependencies, classes, and real implementation patterns. Always call this BEFORE generate_code to learn what D365FO classes and methods to use from the actual codebase, not from generic knowledge.',
     inputSchema: AnalyzeCodePatternsSchema
   },
   {


### PR DESCRIPTION
- Add RULE #0.5: Forbid direct X++ code generation without tools
- Strengthen tool descriptions with  and  indicators for mandatory usage
- Update copilot instructions with clear FORBIDDEN/MANDATORY rules
- Enhance system instructions with expanded intelligent tool documentation
- Improve code_completion tool with better error messages and formatting
- Add helpful reminders in generate_code output for next steps
- Fix code_completion to use proper getCompletions method with caching
- Update decision tree to emphasize analyze_code_patterns + generate_code workflow

These changes ensure AI agents cannot skip MCP tools when generating D365FO code, enforcing usage of analyze_code_patterns before generate_code for better quality.