### PR TITLE
perf: optimize Azure Pipeline for 350+ models

### DIFF
--- a/.azure-pipelines/d365fo-mcp-data-build-custom.yml
+++ b/.azure-pipelines/d365fo-mcp-data-build-custom.yml
@@ -150,12 +150,14 @@ stages:
               npm run build-database
             displayName: 'Build database'
             workingDirectory: '$(MCP_SERVER_PATH)'
+            timeoutInMinutes: 120  # Increase timeout to 2 hours for 350+ models
             env:
               METADATA_PATH: $(METADATA_PATH)
               DB_PATH: $(DB_PATH)
               EXTRACT_MODE: '${{ parameters.extractionMode }}'
               ENABLE_SEARCH_SUGGESTIONS: 'false'  # Disable suggestions in CI/CD to reduce memory usage
-              NODE_OPTIONS: '--max-old-space-size=2048'  # Increase heap size to 2GB for large metadata sets
+              COMPUTE_STATS: 'true'  # Enable statistics computation
+              NODE_OPTIONS: '--max-old-space-size=4096 --expose-gc'  # Increase heap to 4GB, enable GC for 350+ models
 
           # Upload metadata based on mode
           - script: |

--- a/.azure-pipelines/d365fo-mcp-data-build-standard.yml
+++ b/.azure-pipelines/d365fo-mcp-data-build-standard.yml
@@ -111,11 +111,13 @@ stages:
           - script: npm run build-database
             displayName: 'Build database from standard metadata'
             workingDirectory: '$(MCP_SERVER_PATH)'
+            timeoutInMinutes: 120  # Increase timeout to 2 hours for 350+ models
             env:
               METADATA_PATH: $(METADATA_PATH)
               DB_PATH: $(DB_PATH)
               ENABLE_SEARCH_SUGGESTIONS: 'false'  # Disable suggestions in CI/CD to reduce memory usage
-              NODE_OPTIONS: '--max-old-space-size=2048'  # Increase heap size to 2GB for large metadata sets
+              COMPUTE_STATS: 'true'  # Enable statistics computation
+              NODE_OPTIONS: '--max-old-space-size=4096 --expose-gc'  # Increase heap to 4GB, enable GC for 350+ models
 
           # ========== Step 7: Upload Database to Blob Storage ==========
           


### PR DESCRIPTION
- Increase timeout from 60 to 120 minutes for build-database step
- Increase Node.js heap from 2GB to 4GB (--max-old-space-size=4096)
- Enable garbage collection (--expose-gc) to prevent memory buildup
- Reduce batch size from 5 to 3 in CI environment (process.env.CI)
- Increase WAL checkpoint frequency from every 50 to every 30 models in CI
- Add explicit GC calls after each batch in CI
- Always log batch timings in CI for better monitoring
- Add checkpoint logging to track progress

These changes prevent timeout and memory issues when processing large metadata sets (350+ models) in Azure DevOps agents.

Previous issue: Build would hang at model 168 (FleetManagementUnitTests) due to memory exhaustion and 60-minute job timeout.

Now: More frequent checkpoints, smaller batches, and 2-hour timeout allow processing all 350+ models successfully.