### PR TITLE
perf: massive build-database speedup + fix GitHub Copilot hanging + i…

### DIFF
--- a/.azure-pipelines/d365fo-mcp-data-build-standard.yml
+++ b/.azure-pipelines/d365fo-mcp-data-build-standard.yml
@@ -116,7 +116,7 @@ stages:
               METADATA_PATH: $(METADATA_PATH)
               DB_PATH: $(DB_PATH)
               ENABLE_SEARCH_SUGGESTIONS: 'false'  # Disable suggestions in CI/CD to reduce memory usage
-              NODE_OPTIONS: '--max-old-space-size=8192 --expose-gc'  # Increase heap to 8GB for single-transaction indexing
+              NODE_OPTIONS: '--max-old-space-size=4096 --expose-gc'  # Increase heap to 8GB for single-transaction indexing
 
           # ========== Step 7: Upload Database to Blob Storage ==========
           

--- a/.env.example
+++ b/.env.example
@@ -75,7 +75,6 @@ CUSTOM_MODELS=YourCustomModel1,YourCustomModel2
 # EXTRACT_MODE=all
 
 # Compute usage statistics during database build (slow for large databases)
-# Set to 'true' to always compute, or leave unset to compute only on full rebuilds (EXTRACT_MODE=all)
 # COMPUTE_STATS=false
 
 # =============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,14 @@ async function initializeServices() {
 }
 
 async function main() {
+  // CRITICAL: In STDIO mode, redirect all console.log to stderr
+  // GitHub Copilot reads stdout for MCP protocol only!
+  if (isStdioMode) {
+    console.log = (...args: any[]) => process.stderr.write(args.join(' ') + '\n');
+    console.info = (...args: any[]) => process.stderr.write(args.join(' ') + '\n');
+    console.warn = (...args: any[]) => process.stderr.write('[WARN] ' + args.join(' ') + '\n');
+  }
+
   console.log(`📡 Mode: ${isStdioMode ? 'STDIO' : 'HTTP'}`);
 
   if (isStdioMode) {

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -60,7 +60,7 @@ export class StreamableHttpTransport {
         res.setHeader('Mcp-Session-Id', sessionId);
         res.json(result);
       } catch (error) {
-        console.error('MCP request error:', error);
+        process.stderr.write(`MCP request error: ${error}\n`);
         res.status(500).json({
           jsonrpc: '2.0',
           error: {
@@ -336,8 +336,8 @@ export class StreamableHttpTransport {
         arguments?: Record<string, unknown>;
       };
 
-      // Log tool invocation
-      console.log(`[MCP] Tool called: ${name} with args:`, JSON.stringify(args));
+      // Log tool invocation to stderr (not stdout - that's for MCP protocol)
+      process.stderr.write(`[MCP] Tool called: ${name} with args: ${JSON.stringify(args)}\n`);
 
       // Build the CallToolRequest
       const request: CallToolRequest = {
@@ -385,8 +385,8 @@ export class StreamableHttpTransport {
           throw new Error(`Unknown tool: ${name}`);
       }
 
-      // Log the result
-      console.log(`[MCP] Tool ${name} returned:`, JSON.stringify(result).substring(0, 500));
+      // Log the result to stderr (not stdout)
+      process.stderr.write(`[MCP] Tool ${name} returned: ${JSON.stringify(result).substring(0, 500)}\n`);
 
       return {
         jsonrpc: "2.0",


### PR DESCRIPTION
…mprove tool selection

🚀 Performance Improvements (4-5x faster database build):

1. **FTS Trigger Optimization** (BIGGEST WIN - 3-5x speedup):
   - Disable FTS5 triggers during bulk insert (main bottleneck)
   - Each INSERT was triggering FTS update (3-5x slower than plain INSERT)
   - Rebuild FTS index at end using 'rebuild' command (21s vs 300s+)
   - Re-create triggers after indexing for runtime updates
   - Result: 108s indexing + 21s FTS rebuild vs 500s+ with triggers

2. **MEMORY Journal for Build** (2x speedup):
   - Use MEMORY journal mode during database build (fastest mode)
   - Convert to WAL after completion (better runtime concurrency)
   - Add EXCLUSIVE locking and synchronous=OFF during build

3. **Usage Statistics On-Demand** (optional 72s):
   - Disable automatic computation (was adding 1-2 minutes)
   - Only compute when COMPUTE_STATS=true explicitly set
   - Add synchronous=OFF during statistics computation

Root cause: FTS5 triggers + usage_frequency/called_by_count fields added Feb 10 caused automatic statistics + FTS overhead on every INSERT.

Tested: 379 models, 1.3M symbols in 130s (2min) with stats, 109s without
Before: 8-10 minutes minimum

🐛 Fix: GitHub Copilot Chat Hanging After MCP Tool Calls

**Problem:** GitHub Copilot hung indefinitely after calling MCP tools, unable to stop or continue. Root cause: console.log() writing to stdout interfered with MCP protocol communication.

**Solution:**
- Redirect all console.log/info/warn to stderr in STDIO mode
- Use process.stderr.write() in transport.ts for MCP logging
- Keep stdout clean for MCP protocol only

**Result:** MCP tools now respond correctly without hanging GitHub Copilot

📖 System Instructions: Improved Tool Selection Guidance

**Problem:** Orchestrator used wrong tools (code_search, file_search, code_completion) instead of correct MCP tools (search, get_class_info, get_table_info)

**Improvements:**
- Add Decision Tree table for tool selection
- Explicit warnings against built-in VS Code tools (cause 5+ min hangs)
- Clarify when to use search vs code_completion vs get_*_info
- Add examples: inheritance queries, ledger journal creation

**Examples:**
- 'Show inheritance' → get_class_info (not Searching)
- 'Methods related to totals' → search (not code_completion)
- 'Create ledger methods' → analyze_code_patterns + generate_code

**Result:** Orchestrator should now select correct tools avoiding timeouts