### PR TITLE
fix: add status:complete to responses for orchestrator

### DIFF
--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -405,6 +405,9 @@ export class StreamableHttpTransport {
         jsonrpc: "2.0",
         result,
         id: body.id,
+        _meta: {
+          status: "complete"
+        }
       };
     } catch (error) {
       return {
@@ -414,6 +417,9 @@ export class StreamableHttpTransport {
           message: error instanceof Error ? error.message : 'Tool call failed',
         },
         id: body.id,
+        _meta: {
+          status: "complete"
+        }
       };
     }
   }


### PR DESCRIPTION
- Add _meta.status='complete' to successful responses
- Add _meta.status='complete' to error responses
- Signal to Azure orchestrator that processing is finished
- May resolve hanging state where orchestrator waits indefinitely