### PR TITLE
Add platform check for create_d365fo_file - Windows only tool

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -239,7 +239,7 @@ workspacePath and includeWorkspace parameters.`,
         },
         {
           name: 'create_d365fo_file',
-          description: 'Creates a physical D365FO XML file in the correct AOT package structure (K:\\AosService\\PackagesLocalDirectory\\ModelName\\ModelName\\AxClass). Generates complete XML metadata for classes, tables, enums, forms, etc. Can automatically add the file to Visual Studio project (.rnrproj) if addToProject is true.',
+          description: '⚠️ WINDOWS ONLY: Creates a physical D365FO XML file in the correct AOT package structure (K:\\AosService\\PackagesLocalDirectory\\ModelName\\ModelName\\AxClass). Generates complete XML metadata for classes, tables, enums, forms, etc. Can automatically add the file to Visual Studio project (.rnrproj) if addToProject is true. IMPORTANT: This tool MUST run locally on Windows D365FO VM - it CANNOT work through Azure HTTP proxy (Linux).',
           inputSchema: {
             type: 'object',
             properties: {

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -568,6 +568,24 @@ export async function handleCreateD365File(
     console.error(
       `[create_d365fo_file] Ensuring directory exists: ${directory}`
     );
+    
+    // Check if this looks like a Windows path on non-Windows system
+    if (process.platform !== 'win32' && /^[A-Z]:\\/.test(normalizedFullPath)) {
+      throw new Error(
+        `❌ Cannot create D365FO file on non-Windows system!\n\n` +
+        `Attempting to create: ${normalizedFullPath}\n` +
+        `Running on: ${process.platform}\n\n` +
+        `The create_d365fo_file tool requires:\n` +
+        `1. Running on Windows (local D365FO VM)\n` +
+        `2. Direct access to K:\\AosService\\PackagesLocalDirectory\n\n` +
+        `This tool CANNOT work through Azure MCP proxy (runs on Linux).\n\n` +
+        `Solutions:\n` +
+        `- Run MCP server locally on D365FO Windows VM\n` +
+        `- Use VS 2022 with local MCP stdio transport\n` +
+        `- DO NOT use Azure HTTP proxy for file creation\n`
+      );
+    }
+    
     try {
       await fs.mkdir(directory, { recursive: true });
       console.error(`[create_d365fo_file] Directory ready: ${directory}`);


### PR DESCRIPTION
CRITICAL: create_d365fo_file CANNOT work through Azure HTTP proxy!

Problem diagnosed from logs:
- Azure runs on Linux (/home/site/wwwroot/)
- path.dirname() on Linux doesn't recognize K:\\ as absolute path
- Returns '.' instead of full Windows path
- Cannot write to K:\\ drive on Linux

Solution:
1. Add platform check before attempting file creation
2. Throw clear error message explaining:
   - Tool requires Windows (local D365FO VM)
   - Cannot work through Azure proxy (Linux)
   - Must use local MCP stdio transport
3. Update tool description with ⚠️ WINDOWS ONLY warning

This prevents confusing EINVAL errors and provides actionable guidance.

Users must:
- Run MCP server locally on Windows D365FO VM
- Use VS 2022 with local stdio transport
- NOT use Azure HTTP proxy for file creation (read-only tools OK)