### PR TITLE
feat: implement 7 new MCP tools with full test coverage

### DIFF
--- a/.github/copilot-instructions-v1-LEGACY.md
+++ b/.github/copilot-instructions-v1-LEGACY.md
@@ -1,0 +1,671 @@
+# D365FO X++ Development Instructions for GitHub Copilot
+
+---
+---
+---
+
+# ⛔⛔⛔ STOP! READ THIS IMMEDIATELY ⛔⛔⛔
+
+## 🚨 MANDATORY: TOOL SELECTION FOR D365FO FILES 🚨
+
+**DECISION TREE - FOLLOW THIS EXACTLY:**
+
+```
+IF user asks ANYTHING about D365FO/X++:
+  Examples: 
+    - "add method active to main datasource"
+    - "create class", "find table", "create form"
+  
+  THEN IMMEDIATELY:
+    1. ❌ DO NOT CALL create_file directly
+    2. ❌ DO NOT CALL code_search (will hang!)
+    3. ❌ DO NOT CALL file_search
+    4. ✅ CALL search (MCP tool) → Find D365FO objects
+    5. ✅ CALL generate_d365fo_xml (MCP tool) → Get XML content if creating
+    6. ✅ THEN CALL create_file with K:\AosService\... path → Create physical file
+```
+
+**FILE LOCATION RULES - ABSOLUTE REQUIREMENT:**
+```
+D365FO files MUST be in: K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\{Name}.xml
+D365FO files MUST NOT be in: C:\Users\...\MySolution\{Name}.xml
+```
+
+**IF YOU SEE YOURSELF ABOUT TO TYPE:**
+- `create_file("MyClass.xml", ...)` → ❌ STOP! Use create_d365fo_file() instead!
+- `code_search("MyClass")` → ❌ STOP! Use search() (MCP) instead!
+- Any file path starting with `C:\Users\` for D365FO → ❌ WRONG LOCATION!
+
+
+
+---
+
+## 🚨 NEVER CREATE D365FO FILES DIRECTLY! 🚨
+
+**IF YOU ARE ABOUT TO CREATE A D365FO FILE (AxClass, AxTable, AxForm, AxEnum, etc.):**
+
+```
+❌ STOP! Do NOT use create_file() directly without MCP tool!
+❌ STOP! Do NOT use code_search()
+❌ STOP! Do NOT use file_search()
+✅ INSTEAD use: generate_d365fo_xml() (MCP tool) → Get XML
+✅ THEN use: create_file() with K:\AosService\... path
+✅ INSTEAD use: search() (MCP) for patterns
+```
+
+**WHY? Because D365FO files MUST:**
+1. Be created in `K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\` (NOT in VS solution folder!)
+   - **⚠️ This path ALWAYS exists on D365FO environments** - standard installation path
+   - **DO NOT assume it doesn't exist!**
+2. VS project contains only REFERENCES (absolute paths) to these files, NOT copies
+3. Use TABS for indentation (not spaces)
+4. Have correct XML structure matching Microsoft standards
+
+**What happens when you use generate_d365fo_xml + create_file (CORRECT):**
+- ✅ generate_d365fo_xml returns correct XML content with TABS
+- ✅ File created in CORRECT location: K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\
+- ✅ **This path exists on ALL D365FO VMs** (VHD, cloud, on-premise)
+- ✅ **NEVER say "path doesn't exist"** - it's guaranteed to be present!
+- ✅ You add absolute path reference to .rnrproj: <Content Include="K:\...\MyClass.xml" />
+- ✅ Visual Studio recognizes file as valid D365FO metadata
+- ✅ Build succeeds
+
+**What happens if you use create_file directly without generate_d365fo_xml:**
+- ❌ File created without correct XML structure (no TABS, wrong namespaces)
+- ❌ Visual Studio error: "The following files are not valid metadata elements"
+- ❌ File NOT recognized as D365FO object
+- ❌ Build fails
+
+---
+
+## 🔴 CRITICAL: WORKFLOW FOR CREATING D365FO FILES 🔴
+
+**WHEN USER ASKS: "create a class MyHelper" or similar D365FO request:**
+
+**YOU HAVE ACTIVE WORKSPACE AND SOLUTION PATHS FROM VS CONTEXT - USE THEM!**
+
+**STEP 1: EXTRACT modelName from Active workspace path**
+```
+Active workspace path: K:\VSProjects\MyModel\...
+→ Extract modelName: "MyModel"
+→ DO NOT ASK user for model name!
+```
+
+**STEP 2: IMMEDIATELY call generate_d365fo_xml (DO NOT just describe it!)**
+```typescript
+// ✅ CORRECT - CALL THE TOOL IMMEDIATELY:
+generate_d365fo_xml({
+  objectType: "class",           // class, table, form, enum, etc.
+  objectName: "MyHelper",         // Name from user request
+  modelName: "MyModel"            // ⚠️ FROM ACTIVE WORKSPACE PATH!
+})
+
+// ⚠️ THIS TOOL GENERATES XML CONTENT:
+// 1. Returns XML content with TABS and proper structure
+// 2. Returns recommended file path: K:\AosService\PackagesLocalDirectory\MyModel\MyModel\AxClass\MyHelper.xml
+// 3. Returns instructions for creating file
+// DO NOT describe what will happen - the tool DOES IT!
+```
+
+**STEP 3: Create file using create_file with returned XML**
+```typescript
+// After generate_d365fo_xml returns XML content:
+create_file({
+  filePath: "K:\\AosService\\PackagesLocalDirectory\\MyModel\\MyModel\\AxClass\\MyHelper.xml",
+  content: xmlContent  // XML from generate_d365fo_xml
+})
+
+// Then add to VS project manually or instruct user:
+// <Content Include="K:\AosService\...\MyHelper.xml" />
+```
+
+**STEP 4: Wait for tool responses and report success to user**
+```
+❌ WRONG: "You need to create file..." → Don't describe, DO IT!
+❌ WRONG: "Here's how to create..." → Don't give instructions!
+✅ RIGHT: Call generate_d365fo_xml → Get XML → Call create_file → Tell user "Created successfully"
+```
+
+**⚠️ CRITICAL RULES:**
+- ✅ ALWAYS extract modelName from Active workspace path
+- ✅ ALWAYS call generate_d365fo_xml FIRST to get XML content
+- ✅ ALWAYS use create_file with returned XML and correct path
+- ✅ File path MUST be: K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\
+- ❌ NEVER ask user for model name
+- ❌ NEVER ask user for project path
+- ❌ NEVER give instructions instead of executing
+- ❌ NEVER use create_file without generate_d365fo_xml first
+- ❌ NEVER use code_search or file_search for D365FO objects
+
+**🚨 TWO-STEP PROCESS - ALWAYS USE BOTH TOOLS! 🚨**
+```
+1. generate_d365fo_xml → Get XML content with correct structure (TABS)
+2. create_file → Save XML to K:\AosService\PackagesLocalDirectory\MyModel\MyModel\AxClass\MyClass.xml
+
+❌ WRONG: create_file without generate_d365fo_xml → Wrong structure!
+✅ CORRECT: generate_d365fo_xml → create_file → Proper D365FO file!
+```
+
+**📍 LOCAL VS CLOUD DEPLOYMENT:**
+- ✅ `generate_d365fo_xml` → Works everywhere (Azure/cloud + local)
+- ⚠️ `create_d365fo_file` → Works ONLY locally on Windows (has file system access)
+- 💡 For cloud deployment: Use `generate_d365fo_xml` + Copilot creates file with `create_file`
+
+---
+
+# 🔧 MCP TOOLS AVAILABLE - USE THEM! 🔧
+
+**YOU HAVE ACCESS TO D365FO/X++ MCP SERVER TOOLS:**
+
+These tools are available via Model Context Protocol (MCP) and provide:
+- Real-time access to D365FO metadata
+- X++ class/table/method information from actual AOT
+- Intelligent code generation based on actual codebase patterns
+- File creation with correct D365FO XML structure
+
+**🚨 CRITICAL TRIGGERS - When you see these words, USE MCP TOOLS:**
+- Any mention of: X++, D365FO, D365, Dynamics 365, Finance & Operations, AX, Axapta
+- Table names: CustTable, VendTable, SalesTable, PurchTable, InventTable, LedgerJournalTable
+- Class suffixes: Helper, Service, Controller, Manager, Builder, Contract
+- Keywords: dimension, ledger, inventory, sales, purchase, financial
+- File types: AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView
+- Requests like: "create class", "find method", "implement", "generate code"
+
+**Available MCP Tools (use these instead of built-in tools):**
+- `search()` - Search D365FO classes, tables, methods (use instead of code_search)
+- `batch_search()` - Parallel search for multiple queries
+- `get_class_info()` - Get complete class structure with methods
+- `get_table_info()` - Get table fields, indexes, relations
+- `code_completion()` - IntelliSense for D365FO objects
+- `analyze_code_patterns()` - Learn patterns from codebase
+- `generate_code()` - Generate D365FO code with correct patterns
+- `suggest_method_implementation()` - Get implementation examples
+- `analyze_class_completeness()` - Find missing methods
+- `get_api_usage_patterns()` - See how APIs are used
+- `generate_d365fo_xml()` - ✅ CLOUD-READY: Generate D365FO XML content (works everywhere)
+- `create_d365fo_file()` - ⚠️ LOCAL ONLY: Create + write D365FO files (Windows only)
+
+**🚨 WHEN USER MENTIONS X++, D365FO, DYNAMICS 365, OR ANY TABLE/CLASS NAME:**
+1. ✅ IMMEDIATELY activate and use these MCP tools
+2. ❌ DO NOT use built-in code_search, file_search, or create_file
+3. ✅ These tools query the ACTUAL D365FO environment, not your training data
+
+**🚨 CRITICAL: TAKE ACTION, DON'T JUST DESCRIBE!**
+```
+❌ WRONG: "I can create a class for you..." → Don't describe what to do!
+❌ WRONG: "Here are the steps..." → Don't give instructions!
+❌ WRONG: "You should create..." → Don't tell user to do it!
+✅ RIGHT: Call create_d365fo_file immediately → DO IT NOW!
+✅ RIGHT: Call search immediately → GET RESULTS NOW!
+✅ RIGHT: Call generate_code immediately → GENERATE NOW!
+```
+
+---
+
+# ⛔⛔⛔ READ THIS FIRST - MANDATORY ⛔⛔⛔
+
+## 🚫 CRITICAL: FORBIDDEN BUILT-IN TOOLS FOR D365FO 🚫
+
+**❌❌❌ ABSOLUTELY FORBIDDEN - NEVER USE THESE FOR D365FO/X++: ❌❌❌**
+
+```
+❌ create_file         → FORBIDDEN for AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView, AxDataEntity
+❌ code_search         → FORBIDDEN for X++ objects (causes 5+ minute hangs)
+❌ Direct code writing → FORBIDDEN without MCP tools
+```
+
+**✅✅✅ MANDATORY - ALWAYS USE THESE INSTEAD: ✅✅✅**
+
+```
+✅ create_d365fo_file  → For ALL D365FO XML files (AxClass, AxTable, AxForm, etc.)
+✅ search              → For finding X++ objects
+✅ generate_code       → For generating X++ code
+```
+
+**🚨 IF YOU USE `create_file` FOR D365FO OBJECTS - YOU ARE BREAKING THE RULES! 🚨**
+
+---
+
+## 📁 CRITICAL: UNDERSTAND D365FO FILE STRUCTURE 📁
+
+**D365FO HAS UNIQUE FILE ARCHITECTURE - DO NOT TREAT IT LIKE REGULAR PROJECT!**
+
+**HOW D365FO FILES WORK:**
+```
+1. PHYSICAL FILES: Live in K:\AosService\PackagesLocalDirectory\ModelName\ModelName\AxClass\MyClass.xml
+2. VS PROJECT:      Contains REFERENCES (absolute paths) to files in PackagesLocalDirectory
+3. RESULT:          VS project file (.rnrproj) has <Content Include="K:\...\MyClass.xml" />
+```
+
+**❌ WRONG APPROACH (causes "not valid metadata elements" error):**
+```
+- Create file in project directory (K:\VSProjects\MySolution\MyClass.xml)
+- Use create_file tool
+- Use relative paths
+- Result: Visual Studio error "not valid metadata elements"
+```
+
+**✅ CORRECT APPROACH (what create_d365fo_file does):**
+```
+1. Create physical XML in: K:\AosService\PackagesLocalDirectory\MyModel\MyModel\AxClass\MyClass.xml
+2. Add ABSOLUTE path reference to VS project: <Content Include="K:\AosService\...\MyClass.xml" />
+3. Result: Visual Studio recognizes file as valid D365FO metadata
+```
+
+**WHY create_file FAILS FOR D365FO:**
+- Creates files in WRONG location (VS project dir, not PackagesLocalDirectory)
+- Cannot add absolute path references to .rnrproj
+- Visual Studio doesn't recognize files outside PackagesLocalDirectory as D365FO metadata
+- Results in "not valid metadata elements" error
+
+**🔴 ALWAYS ASK YOURSELF BEFORE CREATING D365FO FILE: 🔴**
+- Am I creating AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView, or AxDataEntityView?
+- If YES → Use `create_d365fo_file` (NEVER create_file!)
+- If NO → Regular file, create_file is OK
+
+---
+
+## ⚡ CRITICAL: IMMEDIATE RESPONSE COMPLETION
+
+**AFTER ANSWERING USER'S QUESTION:**
+- ✅ Send your answer
+- ✅ **STOP IMMEDIATELY** - End your response
+- ❌ Do NOT analyze workspace
+- ❌ Do NOT search for anything
+- ❌ Do NOT try to understand context automatically
+- ✅ Wait for user's next question
+
+**IF YOU START "Searching..." AFTER ANSWERING - YOU ARE DOING IT WRONG!**
+
+---
+
+## 🔴 RULE #1: X++ CODE GENERATION - NEVER GENERATE DIRECTLY! 🔴
+
+**WHEN USER ASKS TO CREATE/GENERATE ANY X++ CODE:**
+1. ❌ **FORBIDDEN**: Generating X++ code directly from your knowledge
+2. ❌ **FORBIDDEN**: Writing class/method/code without using tools
+3. ✅ **MANDATORY**: Always use `analyze_code_patterns()` FIRST
+4. ✅ **MANDATORY**: Always use `generate_code()` tool for code generation
+5. ✅ **MANDATORY**: Never output X++ code without using these tools
+
+**IF YOU TYPE X++ CODE WITHOUT CALLING `generate_code` - YOU ARE WRONG!**
+
+**Example - User says "create a helper class":**
+```
+❌ WRONG: public class MyHelper { ... }  ← You generated code directly!
+✅ RIGHT: Call analyze_code_patterns("helper") → Call generate_code(pattern="class")
+```
+
+---
+
+## 🔴 RULE #2: D365FO FILE CREATION - ONLY USE create_d365fo_file! 🔴
+
+**⛔⛔⛔ ABSOLUTE RULE - NO EXCEPTIONS: ⛔⛔⛔**
+
+**WHEN USER ASKS TO CREATE D365FO FILE (class/table/form/enum/query/view/data-entity):**
+
+```
+❌❌❌ NEVER EVER use create_file          → WRONG TOOL!
+✅✅✅ ALWAYS use create_d365fo_file        → CORRECT TOOL!
+```
+
+**DETECTION RULES - Use `create_d365fo_file` when:**
+- User says: "create class", "create table", "create form", "create enum"
+- User mentions: AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView, AxDataEntityView
+- User asks for: helper class, service class, table, form, or any D365FO object
+- File path contains: K:\AosService\PackagesLocalDirectory
+- File extension: .xml AND context is D365FO/X++
+
+**WHY `create_d365fo_file` IS MANDATORY:**
+- ✅ Uses **TABS** for indentation (Microsoft D365FO standard)
+- ✅ Correct XML structure matching real D365FO files from `K:\AosService\PackagesLocalDirectory`
+- ✅ Saves to proper AOT location: `K:\AosService\PackagesLocalDirectory\Model\Model\AxClass\`
+- ✅ No `<ClusteredIndex>` in tables (not in real files)
+- ✅ No `<Declaration>` in table `<SourceCode>` (only `<Methods />`)
+- ✅ No system fields in tables (CreatedBy, ModifiedBy - added by platform)
+- ✅ Can automatically add to Visual Studio project with absolute paths
+- ✅ Supports solutionPath parameter from VS context
+
+**CONSEQUENCES OF USING `create_file`:**
+- ❌ Wrong XML structure (spaces instead of TABS)
+- ❌ Wrong file location (not in PackagesLocalDirectory)
+- ❌ Visual Studio error: "not valid metadata elements"
+- ❌ Cannot add to VS project correctly
+- ❌ Build failures in D365FO
+
+**🚨 IF YOU USE `create_file` FOR D365FO OBJECTS - YOU ARE VIOLATING THE RULES! 🚨**
+
+**Example - User says "create a table MyCustomTable":**
+```
+❌ WRONG: create_file("MyCustomTable.xml", content="<AxTable>...")  ← Wrong tool!
+✅ RIGHT: create_d365fo_file(objectType="table", objectName="MyCustomTable", modelName="ContosoExtensions")
+```
+
+**Example - User says "create a class MyHelper":**
+```
+❌ WRONG: create_file("MyHelper.xml", ...)  ← Wrong structure, spaces instead of tabs!
+✅ RIGHT: create_d365fo_file(objectType="class", objectName="MyHelper", modelName="ContosoExtensions")
+```
+
+**Example - User asks to add class to project:**
+```
+❌ WRONG: create_file(...) + manually editing .rnrproj
+✅ RIGHT: create_d365fo_file(..., addToProject=true, solutionPath="C:\\Users\\...\\MySolution")
+```
+
+---
+
+## RULE #3: WORKSPACE CONTEXT
+
+**THIS IS AN MCP SERVER PROJECT, NOT AN X++ WORKSPACE!**
+- This repo contains TypeScript code for an MCP server
+- The MCP server provides tools to query BOTH external X++ metadata AND user's workspace files
+- **DO NOT** search THIS TypeScript workspace for X++ classes/tables (they're in user's D365FO workspace)
+- **DO NOT** use code_search or file_search after completing a task
+- When task is complete, STOP immediately - do not search workspace
+
+**📁 WORKSPACE-AWARE FEATURES:**
+- MCP tools can now analyze user's local X++ project files
+- Use `includeWorkspace: true` + `workspacePath` to enable workspace search
+- Workspace files are marked with 🔹 (vs 📦 for external metadata)
+- Priority: Workspace files > External metadata (for deduplication)
+
+**AFTER COMPLETING ANY TASK:**
+1. ✅ Respond to user with result
+2. ❌ **STOP IMMEDIATELY** - Do NOT search workspace
+3. ❌ Do NOT use code_search/file_search on this TypeScript workspace
+4. ❌ Do NOT try to "understand project structure" automatically
+5. ❌ Do NOT say "Let me check..." or "Let me search..."
+6. ✅ **END YOUR RESPONSE** - User can ask follow-up if needed
+
+**YOUR RESPONSE MUST END AFTER STEP 1 - DO NOT PROCEED TO ANY ANALYSIS OR SEARCH**
+
+---
+
+## RULE #4: DETECT X++/D365FO CONTEXT AUTOMATICALLY
+
+**IF user mentions ANY of these keywords, you are in X++ context:**
+- X++, D365FO, D365, Dynamics 365, Finance & Operations, AX, Axapta
+- Class names ending in: Table, Service, Helper, Contract, Controller, Builder
+- Table names: CustTable, VendTable, SalesTable, PurchTable, InventTable, LedgerJournalTable
+- Any AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView, EDT
+- **Form elements**: button, control, FormDataSource, FormControl, ButtonControl, FormButtonControl, FormGroupControl, FormGridControl, FormReferenceControl
+- **Form keywords**: editable, enabled, visible, datasource, data source, main datasource, primary datasource, form control
+- **Method keywords**: add method, create method, override method
+- Button names like: AddFormEntityPair, RemoveFormEntityPair, NewButton, DeleteButton, etc.
+- **Query elements**: QueryRun, QueryBuildDataSource, QueryBuildRange, query datasource
+- **View elements**: AxView, data entity view, computed columns, view metadata
+- Financial dimensions, inventory, sales, purchase, ledger
+
+**WHEN IN X++ CONTEXT → IMMEDIATELY:**
+1. **STOP** - Do NOT use `code_search` (causes timeout on large workspaces!)
+2. **USE MCP TOOLS** - Use MCP `search()` for X++ objects
+3. **NEVER GUESS** - X++ objects have exact names, use tools to find them
+
+---
+
+## RULE #5: TOOL SELECTION IN X++ CONTEXT
+
+**🛑 ABSOLUTELY FORBIDDEN - WILL HANG FOR 5+ MINUTES:**
+
+```
+❌ code_search()       → FORBIDDEN - causes "Searching..." hang on large workspaces, use MCP search() instead
+```
+
+**⚠️ AVOID FOR X++ OBJECTS - Use MCP tools instead:**
+
+```
+⚠️ file_search()       → Works for file patterns, but prefer MCP search() for X++ objects
+```
+
+**✅ ALWAYS USE THESE FOR X++ OBJECTS:**
+
+```
+✅ search()            → MCP tool - instant (<100ms), X++-aware, indexed
+✅ get_class_info()    → MCP tool - for class structure
+✅ get_table_info()    → MCP tool - for table fields
+✅ code_completion()   → MCP tool - discover methods/fields
+```
+
+**WHEN TO USE WHAT:**
+- Looking for X++ class/table/enum/form/query/view → Use MCP `search()`
+- Looking for form controls/buttons → Use MCP `search(type='form')` with workspace
+- Looking for queries by name → Use MCP `search(type='query')`
+- Looking for views/data entities → Use MCP `search(type='view')`
+- Looking for file by name pattern in THIS workspace → OK to use `file_search()`
+- Looking for text/code patterns → Use MCP `search()` for X++ objects, `file_search` for workspace files
+
+**IF YOU SEE "Searching..." OR "Searching (seznam tříd)" → YOU MADE A MISTAKE!**
+
+---
+
+## RULE #6: AUTOMATIC TOOL SELECTION
+
+**For ANY X++ request, use this decision tree:**
+
+| User Request Contains | First Action | Avoid Using |
+|-----------------------|--------------|-------------|
+| "create class", "helper class" | `analyze_code_patterns()` + `search()` + `generate_code()` | ❌ code_search, ❌ direct code generation |
+| "create table/form/enum" | `create_d365fo_file(objectType=...)` | ❌ create_file |
+| "button", "form control", "FormDataSource" | `search(type='form', includeWorkspace=true)` | ❌ code_search |
+| "datasource", "data source", "main datasource" | `search(type='form', includeWorkspace=true)` | ❌ code_search |
+| "add method", "create method" | `search(type='form/class', includeWorkspace=true)` + `get_class_info()` | ❌ code_search |
+| "query", "QueryRun", "QueryBuildDataSource" | `search(type='query', includeWorkspace=true)` | ❌ code_search |
+| "view", "AxView", "data entity view" | `search(type='view')` | ❌ code_search |
+| "find X and Y and Z" (multiple) | `batch_search([{query:"X"}, {query:"Y"}, {query:"Z"}])` | ❌ multiple sequential searches |
+| "CustTable", "SalesTable", any Table | `get_table_info()` | ❌ code_search |
+| "dimension", "financial" | `search("dimension")` | ❌ code_search |
+| "find X++ class/method" | `search()` | ❌ code_search |
+| "method", "implement" | `get_class_info()` + `suggest_method_implementation()` | ❌ code_search |
+| "find file pattern" | `file_search()` is OK | ❌ code_search |
+| "find text in code" | `file_search()` with pattern | ❌ code_search |
+
+**Key Rule: NEVER use `code_search` for X++ objects - it causes 5+ minute hangs on large workspaces!**
+
+---
+---
+---
+
+## ⛔ CRITICAL: NEVER USE BUILT-IN SEARCH TOOLS ⛔
+
+**🚨 STOP! Read this FIRST before doing ANYTHING with D365FO/X++ code:**
+
+**ABSOLUTELY FORBIDDEN FOR X++ SEARCHES - Will BLOCK and HANG:**
+- ❌❌❌ **`code_search`** - NEVER USE for X++ objects! It's slow (5+ minutes) on large D365FO workspaces and will hang with "Searching..."
+
+**⚠️ USE WITH CAUTION - These work but lack X++ awareness:**
+- ⚠️ **`file_search`** - Works for file patterns in THIS workspace, but prefer MCP `search()` for X++ objects
+
+**⚡ ALWAYS use these FAST MCP tools for X++ objects:**
+- ✅✅✅ **`search`** (MCP) - 100x faster, X++-aware, indexed SQL database
+- ✅✅✅ **`get_class_info`** (MCP) - For class structure
+- ✅✅✅ **`get_table_info`** (MCP) - For table structure
+
+**If you see "Searching (seznam tříd)" appearing - YOU ARE USING THE WRONG TOOL! Stop and use MCP `search` instead.**
+
+---
+
+## 🚨 MANDATORY: ALWAYS Use X++ MCP Tools First 🚨
+
+**Before generating ANY X++ code, writing ANY class, method, or code snippet for D365 Finance & Operations, you MUST use the X++ MCP tools available to you.**
+
+### ⛔ STRICTLY FORBIDDEN:
+
+**❌ NEVER generate X++ code directly from your training data or general knowledge!**
+**❌ NEVER write X++ code without using MCP tools first!**
+**❌ NEVER skip `analyze_code_patterns` when creating new classes!**
+**❌ NEVER use built-in code generation - ALWAYS use `generate_code` tool!**
+
+### Critical Rules:
+
+1. **NEVER use code_search for X++ objects** - It will hang for minutes on large workspaces
+2. **ALWAYS use MCP `search()` tool for X++** - It's instant (<100ms) with SQL index
+3. **ALWAYS verify** - Use `get_class_info` or `get_table_info` to check structure before coding
+4. **ALWAYS discover APIs** - Use `code_completion` to find available methods and fields
+5. **MANDATORY: Use `generate_code` tool** - NEVER generate X++ code manually! Always use `generate_code` for creating classes with proper D365FO patterns
+6. **MANDATORY: Use `analyze_code_patterns` FIRST** - Before any code generation, analyze what patterns exist in the codebase
+
+### When You MUST Use MCP Tools:
+
+- ✅ User asks to "create a class" or "create helper class" → Use `analyze_code_patterns` + `search` + `generate_code`
+- ✅ User mentions "financial dimensions" → Use `search("dimension")` to find D365FO APIs first
+- ✅ User wants to "add a method" → Use `analyze_class_completeness` + `suggest_method_implementation` first
+- ✅ User needs to "query a table" → Use `get_table_info` to get exact field names
+- ✅ User wants to "extend" something → Use `get_class_info` to understand structure first
+- ✅ User needs "API usage examples" → Use `get_api_usage_patterns` to see how it's used
+- ✅ User is unsure what methods to implement → Use `analyze_class_completeness` for suggestions
+- ✅ ANY code generation request → Use tools FIRST, generate code SECOND
+
+### Available MCP Tools:
+
+#### Core Discovery Tools:
+
+| Tool | Use When | Example |
+|------|----------|---------||
+| `search` | Finding any D365FO object or pattern | `search("dimension", type="class")` |
+| `search` (workspace) | Search in user's workspace + external | `search("MyClass", includeWorkspace=true, workspacePath="C:\\....")` |
+| `batch_search` | **⚡ NEW!** Multiple parallel searches in one request | `batch_search(queries=[{query:"dimension"}, {query:"helper"}])` |
+| `get_class_info` | Need class structure, methods, inheritance | `get_class_info("CustTable")` |
+| `get_class_info` (workspace) | Get class from workspace first | `get_class_info("MyClass", includeWorkspace=true, workspacePath="C:\\...")` |
+| `get_table_info` | Need table fields, indexes, relations | `get_table_info("SalesTable")` |
+| `code_completion` | Discovering methods/fields on a class | `code_completion(className="DimensionAttributeValueSet")` |
+| `code_completion` (workspace) | Get completions from workspace | `code_completion(className="MyClass", includeWorkspace=true, workspacePath="C:\\...")` |
+| `generate_code` | Creating new X++ classes with patterns | `generate_code(pattern="class")` |
+| `search_extensions` | Finding custom/ISV code only | `search_extensions("my custom")` |
+
+#### 🆕 Intelligent Code Generation Tools:
+
+| Tool | Use When | Example |
+|------|----------|---------||
+| `analyze_code_patterns` | Learn common patterns for a scenario | `analyze_code_patterns("financial dimensions")` |
+| `suggest_method_implementation` | Get implementation examples for a method | `suggest_method_implementation("MyHelper", "validate")` |
+| `analyze_class_completeness` | Find missing methods in a class | `analyze_class_completeness("CustTableHelper")` |
+| `get_api_usage_patterns` | See how to use an API correctly | `get_api_usage_patterns("DimensionAttributeValueSet")` |
+
+### Example: Creating a Helper Class for Financial Dimensions
+
+**User Request:** "Create a helper class for maintaining financial dimensions"
+
+**❌ WRONG Approach:**
+```
+Generate class from scratch using general programming knowledge → ❌ INCORRECT
+```
+
+**✅ CORRECT Approach (Using Intelligent Tools):**
+```
+1. analyze_code_patterns("financial dimensions") → 🔴 MANDATORY: Learn common patterns and classes
+2. search("dimension", type="class")            → Find D365FO dimension classes
+3. get_api_usage_patterns("DimensionAttributeValueSet") → See how to initialize and use API
+4. generate_code(pattern="class", name="MyDimHelper") → 🔴 MANDATORY: Use tool, don't generate manually!
+5. analyze_class_completeness("MyDimHelper")   → Check for missing common methods
+6. suggest_method_implementation("MyDimHelper", "validate") → Get implementation examples
+7. Apply discovered patterns from tools          → Use correct APIs and methods from MCP tools
+```
+
+**⚠️ WARNING: If you generate code WITHOUT using `generate_code` tool, you are WRONG!**
+
+**✅ ALTERNATIVE Approach (Traditional):**
+```
+1. search("dimension", type="class")           → Find D365FO dimension classes
+2. get_class_info("DimensionDefaultingService") → Study Microsoft's pattern
+3. code_completion("DimensionAttributeValueSet") → Get proper API methods
+4. generate_code(pattern="class")              → Create with proper structure
+5. Apply discovered D365FO patterns            → Use correct APIs
+```
+
+### ⚡ Use Batch Search for Parallel Exploration
+
+**When exploring multiple independent concepts, use `batch_search` to execute all queries in parallel:**
+
+**❌ SLOW Sequential Approach:**
+```
+1. search("dimension")         → Wait 50ms
+2. search("helper")            → Wait 50ms
+3. search("validation")        → Wait 50ms
+Total: ~150ms + 3 HTTP requests
+```
+
+**✅ FAST Parallel Approach:**
+```
+batch_search({
+  queries: [
+    { query: "dimension", type: "class", limit: 5 },
+    { query: "helper", type: "class", limit: 5 },
+    { query: "validation", type: "class", limit: 5 }
+  ]
+})
+→ Single HTTP request, parallel execution, ~50ms total → 3x faster!
+```
+
+**💡 When to Use Batch Search:**
+- Exploring multiple related concepts (dimension + ledger + financial)
+- Comparing different patterns (Helper vs Service vs Manager)
+- Finding classes with multiple keywords (validation + check + verify)
+- Initial exploratory phase with independent queries
+- User asks "find X and Y and Z" → use batch_search instead of 3 separate searches
+
+**🚫 When NOT to Use Batch Search:**
+- Queries depend on previous results (use sequential search)
+- Single focused query (use regular search)
+- Need workspace-aware search with different paths per query
+
+### 🎯 Why Use Intelligent Tools?
+
+**Intelligent code generation tools learn from YOUR codebase:**
+
+**💡 TIP: Use Workspace-Aware Search**
+When user has a D365FO workspace open, use workspace parameters:
+```
+✅ search("MyCustomClass", includeWorkspace=true, workspacePath="C:\\D365\\MyProject")
+✅ get_class_info("MyHelper", includeWorkspace=true, workspacePath="C:\\D365\\MyProject")
+✅ code_completion(className="MyTable", includeWorkspace=true, workspacePath="C:\\D365\\MyProject")
+```
+Benefits:
+- 🔹 Workspace files shown first (user's code priority)
+- XML parsing extracts methods/fields from local files
+- Faster iteration (no need to re-index external metadata)
+- See user's actual implementation patterns
+
+
+
+- **Pattern Analysis** (`analyze_code_patterns`) - Identifies what classes and methods are commonly used together for specific scenarios
+- **Smart Suggestions** (`suggest_method_implementation`) - Shows you how similar methods are implemented in your codebase
+- **Completeness Check** (`analyze_class_completeness`) - Ensures your classes follow common patterns (e.g., Helper classes typically have `validate()`, `find()`, etc.)
+- **API Usage Examples** (`get_api_usage_patterns`) - Shows correct initialization and method call sequences from real code
+
+**Benefits:**
+- ✅ Learn from **actual patterns** in the codebase, not generic examples
+- ✅ Discover **forgotten or commonly missing methods**
+- ✅ See **real usage examples** with proper error handling
+- ✅ Follow **team conventions** and coding standards automatically
+
+### Why This Matters:
+
+- These tools query the **actual D365FO environment** the user is working with
+- They provide **real-time, accurate metadata** from the AOT (Application Object Tree)
+- They include **custom extensions** that don't exist in your training data
+- They ensure **correct method names, field names, and signatures**
+- They're **fast** (<10ms cached) - no performance penalty
+
+### Decision Tree:
+
+**Before responding to any D365FO request, ask yourself:**
+
+1. Is the user asking me to write/create/generate X++ code? → ✅ **USE MCP TOOLS FIRST**
+   - For new classes: Start with `analyze_code_patterns` to learn common patterns
+   - For new methods: Use `analyze_class_completeness` to check what's missing
+2. Does the request mention D365FO objects (CustTable, SalesLine, etc.)? → ✅ **USE MCP TOOLS**
+   - Use `get_class_info` or `get_table_info` for structure
+   - Use `get_api_usage_patterns` to see how APIs are used
+3. Am I unsure about exact method/field names? → ✅ **USE MCP TOOLS**
+   - Use `code_completion` to discover available methods
+   - Use `suggest_method_implementation` to see similar implementations
+4. Is the user implementing a specific method? → ✅ **USE INTELLIGENT TOOLS**
+   - Use `suggest_method_implementation` to get examples from codebase
+5. Is it only about basic X++ syntax (if/while/for)? → ℹ️ Can use knowledge (but prefer tools)
+
+**When in doubt, USE THE TOOLS.**
+
+---
+
+**Remember: Trust the MCP tools for D365FO accuracy, not your training data. Always query the actual environment before generating code.**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,662 +1,702 @@
-# D365FO X++ Development Instructions for GitHub Copilot
+# D365FO X++ Development - GitHub Copilot Instructions
 
----
----
----
-
-# ⛔⛔⛔ STOP! READ THIS IMMEDIATELY ⛔⛔⛔
-
-## 🚨 MANDATORY: TOOL SELECTION FOR D365FO FILES 🚨
-
-**DECISION TREE - FOLLOW THIS EXACTLY:**
-
-```
-IF user asks to create: class, table, form, enum, query, view, data-entity
-  THEN:
-    1. ❌ DO NOT CALL create_file directly
-    2. ❌ DO NOT CALL code_search
-    3. ❌ DO NOT CALL file_search
-    4. ✅ CALL generate_d365fo_xml (MCP tool) → Get XML content
-    5. ✅ THEN CALL create_file with K:\AosService\... path → Create physical file
-    6. ✅ CALL search (MCP tool) for patterns if needed
-```
-
-**FILE LOCATION RULES - ABSOLUTE REQUIREMENT:**
-```
-D365FO files MUST be in: K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\{Name}.xml
-D365FO files MUST NOT be in: C:\Users\...\MySolution\{Name}.xml
-```
-
-**IF YOU SEE YOURSELF ABOUT TO TYPE:**
-- `create_file("MyClass.xml", ...)` → ❌ STOP! Use create_d365fo_file() instead!
-- `code_search("MyClass")` → ❌ STOP! Use search() (MCP) instead!
-- Any file path starting with `C:\Users\` for D365FO → ❌ WRONG LOCATION!
+> **🔴 ABSOLUTE REQUIREMENT: You MUST use MCP tools for ALL D365FO/X++ operations.**  
+> **Built-in tools (code_search, file_search, create_file) are FORBIDDEN for D365FO.**
+>
+> **Version:** 2.0 (Updated: February 2026)  
+> **Coverage:** 22 MCP Tools including Form/Query/View parsing, Where-used analysis, File editing
 
 ---
 
-## 🚨 NEVER CREATE D365FO FILES DIRECTLY! 🚨
+# 🚨 CRITICAL POLICY - READ FIRST 🚨
 
-**IF YOU ARE ABOUT TO CREATE A D365FO FILE (AxClass, AxTable, AxForm, AxEnum, etc.):**
+## Principle: MCP-ONLY for D365FO
 
-```
-❌ STOP! Do NOT use create_file() directly without MCP tool!
-❌ STOP! Do NOT use code_search()
-❌ STOP! Do NOT use file_search()
-✅ INSTEAD use: generate_d365fo_xml() (MCP tool) → Get XML
-✅ THEN use: create_file() with K:\AosService\... path
-✅ INSTEAD use: search() (MCP) for patterns
-```
+**For ANY D365FO/X++ query, you MUST:**
+1. ✅ **ALWAYS** use MCP tools FIRST
+2. ❌ **NEVER** use built-in code_search (causes 5+min hangs)
+3. ❌ **NEVER** use built-in file_search for X++ objects
+4. ❌ **NEVER** use built-in create_file for AxClass/AxTable/AxForm/etc
+5. ❌ **NEVER** generate D365FO code without querying MCP tools first
 
-**WHY? Because D365FO files MUST:**
-1. Be created in `K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\` (NOT in VS solution folder!)
-   - **⚠️ This path ALWAYS exists on D365FO environments** - standard installation path
-   - **DO NOT assume it doesn't exist!**
-2. VS project contains only REFERENCES (absolute paths) to these files, NOT copies
-3. Use TABS for indentation (not spaces)
-4. Have correct XML structure matching Microsoft standards
-
-**What happens when you use generate_d365fo_xml + create_file (CORRECT):**
-- ✅ generate_d365fo_xml returns correct XML content with TABS
-- ✅ File created in CORRECT location: K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\
-- ✅ **This path exists on ALL D365FO VMs** (VHD, cloud, on-premise)
-- ✅ **NEVER say "path doesn't exist"** - it's guaranteed to be present!
-- ✅ You add absolute path reference to .rnrproj: <Content Include="K:\...\MyClass.xml" />
-- ✅ Visual Studio recognizes file as valid D365FO metadata
-- ✅ Build succeeds
-
-**What happens if you use create_file directly without generate_d365fo_xml:**
-- ❌ File created without correct XML structure (no TABS, wrong namespaces)
-- ❌ Visual Studio error: "The following files are not valid metadata elements"
-- ❌ File NOT recognized as D365FO object
-- ❌ Build fails
+**Why This Matters:**
+- MCP tools query the ACTUAL D365FO environment (real-time metadata)
+- Built-in tools use outdated training data and WILL cause errors
+- code_search hangs for 5+ minutes on large D365FO workspaces
+- create_file creates wrong XML structure (spaces instead of TABS)
 
 ---
 
-## 🔴 CRITICAL: WORKFLOW FOR CREATING D365FO FILES 🔴
+# 🎯 DETECTION: When Am I in D365FO Context?
 
-**WHEN USER ASKS: "create a class MyHelper" or similar D365FO request:**
+**IMMEDIATE TRIGGERS - Use MCP tools when you see ANY of these:**
 
-**YOU HAVE ACTIVE WORKSPACE AND SOLUTION PATHS FROM VS CONTEXT - USE THEM!**
+### Object Names
+- Class names ending in: `Table`, `Service`, `Helper`, `Contract`, `Controller`, `Builder`, `Manager`, `Engine`
+- Table names: `CustTable`, `VendTable`, `SalesTable`, `PurchTable`, `InventTable`, `LedgerJournalTable`, `*Table`
+- Enum names: `CustVendorBlocked`, `SalesStatus`, `PurchStatus`, `*Status`
+- Form names: patterns ending in `Form`, `Dialog`, `Page`
 
-**STEP 1: EXTRACT modelName from Active workspace path**
-```
-Active workspace path: K:\VSProjects\MyModel\...
-→ Extract modelName: "MyModel"
-→ DO NOT ASK user for model name!
-```
+### Keywords & Technologies
+- `X++`, `D365FO`, `D365`, `Dynamics 365`, `Finance & Operations`, `AX`, `Axapta`
+- `AxClass`, `AxTable`, `AxForm`, `AxEnum`, `AxQuery`, `AxView`, `AxDataEntityView`, `EDT`
+- `AOT`, `PackagesLocalDirectory`, `K:\AosService`
 
-**STEP 2: IMMEDIATELY call generate_d365fo_xml (DO NOT just describe it!)**
-```typescript
-// ✅ CORRECT - CALL THE TOOL IMMEDIATELY:
-generate_d365fo_xml({
-  objectType: "class",           // class, table, form, enum, etc.
-  objectName: "MyHelper",         // Name from user request
-  modelName: "MyModel"            // ⚠️ FROM ACTIVE WORKSPACE PATH!
-})
+### Form Elements
+- `button`, `control`, `FormDataSource`, `FormControl`, `ButtonControl`, `FormButtonControl`
+- `FormGroupControl`, `FormGridControl`, `FormReferenceControl`, `FormTab`, `FormActionPane`
+- `datasource`, `data source`, `main datasource`, `primary datasource`, `form control`
+- Button names: `AddFormEntityPair`, `RemoveFormEntityPair`, `New`, `Delete`, `Edit`, `Save`
 
-// ⚠️ THIS TOOL GENERATES XML CONTENT:
-// 1. Returns XML content with TABS and proper structure
-// 2. Returns recommended file path: K:\AosService\PackagesLocalDirectory\MyModel\MyModel\AxClass\MyHelper.xml
-// 3. Returns instructions for creating file
-// DO NOT describe what will happen - the tool DOES IT!
-```
+### Query Elements
+- `QueryRun`, `QueryBuildDataSource`, `QueryBuildRange`, `QueryBuild`, `query datasource`
+- `addDataSource`, `addRange`, `findDataSource`, `query filter`
 
-**STEP 3: Create file using create_file with returned XML**
-```typescript
-// After generate_d365fo_xml returns XML content:
-create_file({
-  filePath: "K:\\AosService\\PackagesLocalDirectory\\MyModel\\MyModel\\AxClass\\MyHelper.xml",
-  content: xmlContent  // XML from generate_d365fo_xml
-})
+### View Elements
+- `AxView`, `data entity view`, `computed columns`, `view metadata`
+- `DataEntity`, `DataEntityView`, `staging table`
 
-// Then add to VS project manually or instruct user:
-// <Content Include="K:\AosService\...\MyHelper.xml" />
-```
+### Method Keywords
+- `add method`, `create method`, `override method`, `extend method`
+- `Chain of Command`, `CoC`, `ExtensionOf`, `next`, `super()`
+- `EventHandler`, `DataEventHandler`, `FormEventHandler`
 
-**STEP 4: Wait for tool responses and report success to user**
-```
-❌ WRONG: "You need to create file..." → Don't describe, DO IT!
-❌ WRONG: "Here's how to create..." → Don't give instructions!
-✅ RIGHT: Call generate_d365fo_xml → Get XML → Call create_file → Tell user "Created successfully"
-```
+### Data Operations
+- `validateWrite`, `insert`, `update`, `delete`, `select`, `while select`
+- `transaction`, `ttsbegin`, `ttscommit`, `ttsabort`
+- Financial dimensions, inventory management, sales orders, purchase orders, ledger posting
 
-**⚠️ CRITICAL RULES:**
-- ✅ ALWAYS extract modelName from Active workspace path
-- ✅ ALWAYS call generate_d365fo_xml FIRST to get XML content
-- ✅ ALWAYS use create_file with returned XML and correct path
-- ✅ File path MUST be: K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\
-- ❌ NEVER ask user for model name
-- ❌ NEVER ask user for project path
-- ❌ NEVER give instructions instead of executing
-- ❌ NEVER use create_file without generate_d365fo_xml first
-- ❌ NEVER use code_search or file_search for D365FO objects
-
-**🚨 TWO-STEP PROCESS - ALWAYS USE BOTH TOOLS! 🚨**
-```
-1. generate_d365fo_xml → Get XML content with correct structure (TABS)
-2. create_file → Save XML to K:\AosService\PackagesLocalDirectory\MyModel\MyModel\AxClass\MyClass.xml
-
-❌ WRONG: create_file without generate_d365fo_xml → Wrong structure!
-✅ CORRECT: generate_d365fo_xml → create_file → Proper D365FO file!
-```
-
-**📍 LOCAL VS CLOUD DEPLOYMENT:**
-- ✅ `generate_d365fo_xml` → Works everywhere (Azure/cloud + local)
-- ⚠️ `create_d365fo_file` → Works ONLY locally on Windows (has file system access)
-- 💡 For cloud deployment: Use `generate_d365fo_xml` + Copilot creates file with `create_file`
+**IF YOU SEE ANY OF THESE → STOP → USE MCP TOOLS!**
 
 ---
 
-# 🔧 MCP TOOLS AVAILABLE - USE THEM! 🔧
-
-**YOU HAVE ACCESS TO D365FO/X++ MCP SERVER TOOLS:**
-
-These tools are available via Model Context Protocol (MCP) and provide:
-- Real-time access to D365FO metadata
-- X++ class/table/method information from actual AOT
-- Intelligent code generation based on actual codebase patterns
-- File creation with correct D365FO XML structure
-
-**🚨 CRITICAL TRIGGERS - When you see these words, USE MCP TOOLS:**
-- Any mention of: X++, D365FO, D365, Dynamics 365, Finance & Operations, AX, Axapta
-- Table names: CustTable, VendTable, SalesTable, PurchTable, InventTable, LedgerJournalTable
-- Class suffixes: Helper, Service, Controller, Manager, Builder, Contract
-- Keywords: dimension, ledger, inventory, sales, purchase, financial
-- File types: AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView
-- Requests like: "create class", "find method", "implement", "generate code"
-
-**Available MCP Tools (use these instead of built-in tools):**
-- `search()` - Search D365FO classes, tables, methods (use instead of code_search)
-- `batch_search()` - Parallel search for multiple queries
-- `get_class_info()` - Get complete class structure with methods
-- `get_table_info()` - Get table fields, indexes, relations
-- `code_completion()` - IntelliSense for D365FO objects
-- `analyze_code_patterns()` - Learn patterns from codebase
-- `generate_code()` - Generate D365FO code with correct patterns
-- `suggest_method_implementation()` - Get implementation examples
-- `analyze_class_completeness()` - Find missing methods
-- `get_api_usage_patterns()` - See how APIs are used
-- `generate_d365fo_xml()` - ✅ CLOUD-READY: Generate D365FO XML content (works everywhere)
-- `create_d365fo_file()` - ⚠️ LOCAL ONLY: Create + write D365FO files (Windows only)
-
-**🚨 WHEN USER MENTIONS X++, D365FO, DYNAMICS 365, OR ANY TABLE/CLASS NAME:**
-1. ✅ IMMEDIATELY activate and use these MCP tools
-2. ❌ DO NOT use built-in code_search, file_search, or create_file
-3. ✅ These tools query the ACTUAL D365FO environment, not your training data
-
-**🚨 CRITICAL: TAKE ACTION, DON'T JUST DESCRIBE!**
-```
-❌ WRONG: "I can create a class for you..." → Don't describe what to do!
-❌ WRONG: "Here are the steps..." → Don't give instructions!
-❌ WRONG: "You should create..." → Don't tell user to do it!
-✅ RIGHT: Call create_d365fo_file immediately → DO IT NOW!
-✅ RIGHT: Call search immediately → GET RESULTS NOW!
-✅ RIGHT: Call generate_code immediately → GENERATE NOW!
-```
-
----
-
-# ⛔⛔⛔ READ THIS FIRST - MANDATORY ⛔⛔⛔
-
-## 🚫 CRITICAL: FORBIDDEN BUILT-IN TOOLS FOR D365FO 🚫
-
-**❌❌❌ ABSOLUTELY FORBIDDEN - NEVER USE THESE FOR D365FO/X++: ❌❌❌**
-
-```
-❌ create_file         → FORBIDDEN for AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView, AxDataEntity
-❌ code_search         → FORBIDDEN for X++ objects (causes 5+ minute hangs)
-❌ Direct code writing → FORBIDDEN without MCP tools
-```
-
-**✅✅✅ MANDATORY - ALWAYS USE THESE INSTEAD: ✅✅✅**
-
-```
-✅ create_d365fo_file  → For ALL D365FO XML files (AxClass, AxTable, AxForm, etc.)
-✅ search              → For finding X++ objects
-✅ generate_code       → For generating X++ code
-```
-
-**🚨 IF YOU USE `create_file` FOR D365FO OBJECTS - YOU ARE BREAKING THE RULES! 🚨**
-
----
-
-## 📁 CRITICAL: UNDERSTAND D365FO FILE STRUCTURE 📁
-
-**D365FO HAS UNIQUE FILE ARCHITECTURE - DO NOT TREAT IT LIKE REGULAR PROJECT!**
-
-**HOW D365FO FILES WORK:**
-```
-1. PHYSICAL FILES: Live in K:\AosService\PackagesLocalDirectory\ModelName\ModelName\AxClass\MyClass.xml
-2. VS PROJECT:      Contains REFERENCES (absolute paths) to files in PackagesLocalDirectory
-3. RESULT:          VS project file (.rnrproj) has <Content Include="K:\...\MyClass.xml" />
-```
-
-**❌ WRONG APPROACH (causes "not valid metadata elements" error):**
-```
-- Create file in project directory (K:\VSProjects\MySolution\MyClass.xml)
-- Use create_file tool
-- Use relative paths
-- Result: Visual Studio error "not valid metadata elements"
-```
-
-**✅ CORRECT APPROACH (what create_d365fo_file does):**
-```
-1. Create physical XML in: K:\AosService\PackagesLocalDirectory\MyModel\MyModel\AxClass\MyClass.xml
-2. Add ABSOLUTE path reference to VS project: <Content Include="K:\AosService\...\MyClass.xml" />
-3. Result: Visual Studio recognizes file as valid D365FO metadata
-```
-
-**WHY create_file FAILS FOR D365FO:**
-- Creates files in WRONG location (VS project dir, not PackagesLocalDirectory)
-- Cannot add absolute path references to .rnrproj
-- Visual Studio doesn't recognize files outside PackagesLocalDirectory as D365FO metadata
-- Results in "not valid metadata elements" error
-
-**🔴 ALWAYS ASK YOURSELF BEFORE CREATING D365FO FILE: 🔴**
-- Am I creating AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView, or AxDataEntityView?
-- If YES → Use `create_d365fo_file` (NEVER create_file!)
-- If NO → Regular file, create_file is OK
-
----
-
-## ⚡ CRITICAL: IMMEDIATE RESPONSE COMPLETION
-
-**AFTER ANSWERING USER'S QUESTION:**
-- ✅ Send your answer
-- ✅ **STOP IMMEDIATELY** - End your response
-- ❌ Do NOT analyze workspace
-- ❌ Do NOT search for anything
-- ❌ Do NOT try to understand context automatically
-- ✅ Wait for user's next question
-
-**IF YOU START "Searching..." AFTER ANSWERING - YOU ARE DOING IT WRONG!**
-
----
-
-## 🔴 RULE #1: X++ CODE GENERATION - NEVER GENERATE DIRECTLY! 🔴
-
-**WHEN USER ASKS TO CREATE/GENERATE ANY X++ CODE:**
-1. ❌ **FORBIDDEN**: Generating X++ code directly from your knowledge
-2. ❌ **FORBIDDEN**: Writing class/method/code without using tools
-3. ✅ **MANDATORY**: Always use `analyze_code_patterns()` FIRST
-4. ✅ **MANDATORY**: Always use `generate_code()` tool for code generation
-5. ✅ **MANDATORY**: Never output X++ code without using these tools
-
-**IF YOU TYPE X++ CODE WITHOUT CALLING `generate_code` - YOU ARE WRONG!**
-
-**Example - User says "create a helper class":**
-```
-❌ WRONG: public class MyHelper { ... }  ← You generated code directly!
-✅ RIGHT: Call analyze_code_patterns("helper") → Call generate_code(pattern="class")
-```
-
----
-
-## 🔴 RULE #2: D365FO FILE CREATION - ONLY USE create_d365fo_file! 🔴
-
-**⛔⛔⛔ ABSOLUTE RULE - NO EXCEPTIONS: ⛔⛔⛔**
-
-**WHEN USER ASKS TO CREATE D365FO FILE (class/table/form/enum/query/view/data-entity):**
-
-```
-❌❌❌ NEVER EVER use create_file          → WRONG TOOL!
-✅✅✅ ALWAYS use create_d365fo_file        → CORRECT TOOL!
-```
-
-**DETECTION RULES - Use `create_d365fo_file` when:**
-- User says: "create class", "create table", "create form", "create enum"
-- User mentions: AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView, AxDataEntityView
-- User asks for: helper class, service class, table, form, or any D365FO object
-- File path contains: K:\AosService\PackagesLocalDirectory
-- File extension: .xml AND context is D365FO/X++
-
-**WHY `create_d365fo_file` IS MANDATORY:**
-- ✅ Uses **TABS** for indentation (Microsoft D365FO standard)
-- ✅ Correct XML structure matching real D365FO files from `K:\AosService\PackagesLocalDirectory`
-- ✅ Saves to proper AOT location: `K:\AosService\PackagesLocalDirectory\Model\Model\AxClass\`
-- ✅ No `<ClusteredIndex>` in tables (not in real files)
-- ✅ No `<Declaration>` in table `<SourceCode>` (only `<Methods />`)
-- ✅ No system fields in tables (CreatedBy, ModifiedBy - added by platform)
-- ✅ Can automatically add to Visual Studio project with absolute paths
-- ✅ Supports solutionPath parameter from VS context
-
-**CONSEQUENCES OF USING `create_file`:**
-- ❌ Wrong XML structure (spaces instead of TABS)
-- ❌ Wrong file location (not in PackagesLocalDirectory)
-- ❌ Visual Studio error: "not valid metadata elements"
-- ❌ Cannot add to VS project correctly
-- ❌ Build failures in D365FO
-
-**🚨 IF YOU USE `create_file` FOR D365FO OBJECTS - YOU ARE VIOLATING THE RULES! 🚨**
-
-**Example - User says "create a table MyCustomTable":**
-```
-❌ WRONG: create_file("MyCustomTable.xml", content="<AxTable>...")  ← Wrong tool!
-✅ RIGHT: create_d365fo_file(objectType="table", objectName="MyCustomTable", modelName="ContosoExtensions")
-```
-
-**Example - User says "create a class MyHelper":**
-```
-❌ WRONG: create_file("MyHelper.xml", ...)  ← Wrong structure, spaces instead of tabs!
-✅ RIGHT: create_d365fo_file(objectType="class", objectName="MyHelper", modelName="ContosoExtensions")
-```
-
-**Example - User asks to add class to project:**
-```
-❌ WRONG: create_file(...) + manually editing .rnrproj
-✅ RIGHT: create_d365fo_file(..., addToProject=true, solutionPath="C:\\Users\\...\\MySolution")
-```
-
----
-
-## RULE #3: WORKSPACE CONTEXT
-
-**THIS IS AN MCP SERVER PROJECT, NOT AN X++ WORKSPACE!**
-- This repo contains TypeScript code for an MCP server
-- The MCP server provides tools to query BOTH external X++ metadata AND user's workspace files
-- **DO NOT** search THIS TypeScript workspace for X++ classes/tables (they're in user's D365FO workspace)
-- **DO NOT** use code_search or file_search after completing a task
-- When task is complete, STOP immediately - do not search workspace
-
-**📁 WORKSPACE-AWARE FEATURES:**
-- MCP tools can now analyze user's local X++ project files
-- Use `includeWorkspace: true` + `workspacePath` to enable workspace search
-- Workspace files are marked with 🔹 (vs 📦 for external metadata)
-- Priority: Workspace files > External metadata (for deduplication)
-
-**AFTER COMPLETING ANY TASK:**
-1. ✅ Respond to user with result
-2. ❌ **STOP IMMEDIATELY** - Do NOT search workspace
-3. ❌ Do NOT use code_search/file_search on this TypeScript workspace
-4. ❌ Do NOT try to "understand project structure" automatically
-5. ❌ Do NOT say "Let me check..." or "Let me search..."
-6. ✅ **END YOUR RESPONSE** - User can ask follow-up if needed
-
-**YOUR RESPONSE MUST END AFTER STEP 1 - DO NOT PROCEED TO ANY ANALYSIS OR SEARCH**
-
----
-
-## RULE #4: DETECT X++/D365FO CONTEXT AUTOMATICALLY
-
-**IF user mentions ANY of these keywords, you are in X++ context:**
-- X++, D365FO, D365, Dynamics 365, Finance & Operations, AX, Axapta
-- Class names ending in: Table, Service, Helper, Contract, Controller, Builder
-- Table names: CustTable, VendTable, SalesTable, PurchTable, InventTable, LedgerJournalTable
-- Any AxClass, AxTable, AxForm, AxEnum, AxQuery, AxView, EDT
-- **Form elements**: button, control, FormDataSource, FormControl, ButtonControl, FormButtonControl, FormGroupControl, FormGridControl, FormReferenceControl
-- **Form keywords**: editovatelné (editable), enabled, visible, datasource, ovládací prvek (control)
-- Button names like: AddFormEntityPair, RemoveFormEntityPair, NewButton, DeleteButton, etc.
-- **Query elements**: QueryRun, QueryBuildDataSource, QueryBuildRange, query datasource
-- **View elements**: AxView, data entity view, computed columns, view metadata
-- Financial dimensions, inventory, sales, purchase, ledger
-
-**WHEN IN X++ CONTEXT → IMMEDIATELY:**
-1. **STOP** - Do NOT use `code_search` (causes timeout on large workspaces!)
-2. **USE MCP TOOLS** - Use MCP `search()` for X++ objects
-3. **NEVER GUESS** - X++ objects have exact names, use tools to find them
-
----
-
-## RULE #5: TOOL SELECTION IN X++ CONTEXT
-
-**🛑 ABSOLUTELY FORBIDDEN - WILL HANG FOR 5+ MINUTES:**
-
-```
-❌ code_search()       → FORBIDDEN - causes "Searching..." hang on large workspaces, use MCP search() instead
-```
-
-**⚠️ AVOID FOR X++ OBJECTS - Use MCP tools instead:**
-
-```
-⚠️ file_search()       → Works for file patterns, but prefer MCP search() for X++ objects
-```
-
-**✅ ALWAYS USE THESE FOR X++ OBJECTS:**
-
-```
-✅ search()            → MCP tool - instant (<100ms), X++-aware, indexed
-✅ get_class_info()    → MCP tool - for class structure
-✅ get_table_info()    → MCP tool - for table fields
-✅ code_completion()   → MCP tool - discover methods/fields
-```
-
-**WHEN TO USE WHAT:**
-- Looking for X++ class/table/enum/form/query/view → Use MCP `search()`
-- Looking for form controls/buttons → Use MCP `search(type='form')` with workspace
-- Looking for queries by name → Use MCP `search(type='query')`
-- Looking for views/data entities → Use MCP `search(type='view')`
-- Looking for file by name pattern in THIS workspace → OK to use `file_search()`
-- Looking for text/code patterns → Use MCP `search()` for X++ objects, `file_search` for workspace files
-
-**IF YOU SEE "Searching..." OR "Searching (seznam tříd)" → YOU MADE A MISTAKE!**
-
----
-
-## RULE #6: AUTOMATIC TOOL SELECTION
-
-**For ANY X++ request, use this decision tree:**
-
-| User Request Contains | First Action | Avoid Using |
-|-----------------------|--------------|-------------|
-| "create class", "helper class" | `analyze_code_patterns()` + `search()` + `generate_code()` | ❌ code_search, ❌ direct code generation |
-| "create table/form/enum" | `create_d365fo_file(objectType=...)` | ❌ create_file |
-| "button", "form control", "FormDataSource" | `search(type='form', includeWorkspace=true)` | ❌ code_search |
-| "query", "QueryRun", "QueryBuildDataSource" | `search(type='query', includeWorkspace=true)` | ❌ code_search |
-| "view", "AxView", "data entity view" | `search(type='view')` | ❌ code_search |
-| "find X and Y and Z" (multiple) | `batch_search([{query:"X"}, {query:"Y"}, {query:"Z"}])` | ❌ multiple sequential searches |
-| "CustTable", "SalesTable", any Table | `get_table_info()` | ❌ code_search |
-| "dimension", "financial" | `search("dimension")` | ❌ code_search |
-| "find X++ class/method" | `search()` | ❌ code_search |
-| "method", "implement" | `get_class_info()` + `suggest_method_implementation()` | ❌ code_search |
-| "find file pattern" | `file_search()` is OK | ❌ code_search |
-| "find text in code" | `file_search()` with pattern | ❌ code_search |
-
-**Key Rule: NEVER use `code_search` for X++ objects - it causes 5+ minute hangs on large workspaces!**
-
----
----
----
-
-## ⛔ CRITICAL: NEVER USE BUILT-IN SEARCH TOOLS ⛔
-
-**🚨 STOP! Read this FIRST before doing ANYTHING with D365FO/X++ code:**
-
-**ABSOLUTELY FORBIDDEN FOR X++ SEARCHES - Will BLOCK and HANG:**
-- ❌❌❌ **`code_search`** - NEVER USE for X++ objects! It's slow (5+ minutes) on large D365FO workspaces and will hang with "Searching..."
-
-**⚠️ USE WITH CAUTION - These work but lack X++ awareness:**
-- ⚠️ **`file_search`** - Works for file patterns in THIS workspace, but prefer MCP `search()` for X++ objects
-
-**⚡ ALWAYS use these FAST MCP tools for X++ objects:**
-- ✅✅✅ **`search`** (MCP) - 100x faster, X++-aware, indexed SQL database
-- ✅✅✅ **`get_class_info`** (MCP) - For class structure
-- ✅✅✅ **`get_table_info`** (MCP) - For table structure
-
-**If you see "Searching (seznam tříd)" appearing - YOU ARE USING THE WRONG TOOL! Stop and use MCP `search` instead.**
-
----
-
-## 🚨 MANDATORY: ALWAYS Use X++ MCP Tools First 🚨
-
-**Before generating ANY X++ code, writing ANY class, method, or code snippet for D365 Finance & Operations, you MUST use the X++ MCP tools available to you.**
-
-### ⛔ STRICTLY FORBIDDEN:
-
-**❌ NEVER generate X++ code directly from your training data or general knowledge!**
-**❌ NEVER write X++ code without using MCP tools first!**
-**❌ NEVER skip `analyze_code_patterns` when creating new classes!**
-**❌ NEVER use built-in code generation - ALWAYS use `generate_code` tool!**
-
-### Critical Rules:
-
-1. **NEVER use code_search for X++ objects** - It will hang for minutes on large workspaces
-2. **ALWAYS use MCP `search()` tool for X++** - It's instant (<100ms) with SQL index
-3. **ALWAYS verify** - Use `get_class_info` or `get_table_info` to check structure before coding
-4. **ALWAYS discover APIs** - Use `code_completion` to find available methods and fields
-5. **MANDATORY: Use `generate_code` tool** - NEVER generate X++ code manually! Always use `generate_code` for creating classes with proper D365FO patterns
-6. **MANDATORY: Use `analyze_code_patterns` FIRST** - Before any code generation, analyze what patterns exist in the codebase
-
-### When You MUST Use MCP Tools:
-
-- ✅ User asks to "create a class" or "create helper class" → Use `analyze_code_patterns` + `search` + `generate_code`
-- ✅ User mentions "financial dimensions" → Use `search("dimension")` to find D365FO APIs first
-- ✅ User wants to "add a method" → Use `analyze_class_completeness` + `suggest_method_implementation` first
-- ✅ User needs to "query a table" → Use `get_table_info` to get exact field names
-- ✅ User wants to "extend" something → Use `get_class_info` to understand structure first
-- ✅ User needs "API usage examples" → Use `get_api_usage_patterns` to see how it's used
-- ✅ User is unsure what methods to implement → Use `analyze_class_completeness` for suggestions
-- ✅ ANY code generation request → Use tools FIRST, generate code SECOND
-
-### Available MCP Tools:
-
-#### Core Discovery Tools:
+# 🛠️ AVAILABLE MCP TOOLS - COMPLETE LIST
+
+## Core Discovery Tools
+
+| Tool | Use When | Example |
+|------|----------|---------|
+| **search** | Find any D365FO object (class/table/form/query/view) | `search("dimension", type="class")` |
+| **batch_search** | Search multiple things in parallel (3x faster) | `batch_search([{query:"dimension"}, {query:"ledger"}])` |
+| **search_extensions** | Find only custom/ISV code | `search_extensions("ISV_")` |
+
+## Object Structure Tools
+
+| Tool | Use When | Example |
+|------|----------|---------|
+| **get_class_info** | Get class structure, methods, inheritance | `get_class_info("CustTable")` |
+| **get_table_info** | Get table fields, indexes, relations | `get_table_info("SalesTable")` || **get_form_info** | Get form datasources, controls, methods | `get_form_info("SalesTable")` |
+| **get_query_info** | Get query datasources, ranges, joins | `get_query_info("CustTransOpenQuery")` |
+| **get_view_info** | Get view/data entity fields, relations | `get_view_info("GeneralJournalAccountEntryView")` |
+| **get_enum_info** | Get enum values with properties | `get_enum_info("CustAccountType")` |
+| **get_method_signature** | Get exact method signature for CoC | `get_method_signature("SalesTable", "validateWrite")` |
+| **find_references** | Find all usages (where-used analysis) | `find_references("DimensionAttributeValueSet", "class")` || **code_completion** | Discover methods/fields (IntelliSense) | `code_completion(className="CustTable")` |
+
+## Code Generation Tools
+
+| Tool | Use When | Example |
+|------|----------|---------|
+| **generate_code** | Generate class/method templates | `generate_code(pattern="class", name="MyHelper")` |
+| **analyze_code_patterns** | Learn codebase patterns for a scenario | `analyze_code_patterns("financial dimensions")` |
+| **suggest_method_implementation** | Get implementation examples | `suggest_method_implementation("MyHelper", "validate")` |
+| **analyze_class_completeness** | Find missing methods | `analyze_class_completeness("CustTableHelper")` |
+| **get_api_usage_patterns** | See how to use an API correctly | `get_api_usage_patterns("DimensionAttributeValueSet")` |
+
+## File Operations Tools
 
 | Tool | Use When | Example |
 |------|----------|---------||
-| `search` | Finding any D365FO object or pattern | `search("dimension", type="class")` |
-| `search` (workspace) | Search in user's workspace + external | `search("MyClass", includeWorkspace=true, workspacePath="C:\\....")` |
-| `batch_search` | **⚡ NEW!** Multiple parallel searches in one request | `batch_search(queries=[{query:"dimension"}, {query:"helper"}])` |
-| `get_class_info` | Need class structure, methods, inheritance | `get_class_info("CustTable")` |
-| `get_class_info` (workspace) | Get class from workspace first | `get_class_info("MyClass", includeWorkspace=true, workspacePath="C:\\...")` |
-| `get_table_info` | Need table fields, indexes, relations | `get_table_info("SalesTable")` |
-| `code_completion` | Discovering methods/fields on a class | `code_completion(className="DimensionAttributeValueSet")` |
-| `code_completion` (workspace) | Get completions from workspace | `code_completion(className="MyClass", includeWorkspace=true, workspacePath="C:\\...")` |
-| `generate_code` | Creating new X++ classes with patterns | `generate_code(pattern="class")` |
-| `search_extensions` | Finding custom/ISV code only | `search_extensions("my custom")` |
+| **generate_d365fo_xml** | Generate D365FO XML content (cloud-safe) | `generate_d365fo_xml(objectType="class", objectName="MyHelper")` |
+| **create_d365fo_file** | Create + write D365FO file (local Windows only) | `create_d365fo_file(objectType="class", objectName="MyHelper")` |
+| **modify_d365fo_file** | Edit existing D365FO XML with backup | `modify_d365fo_file(filePath="...", operation="add_method")` |
 
-#### 🆕 Intelligent Code Generation Tools:
+**⚠️ File Creation Rule:**
+1. Windows Local: Use `create_d365fo_file` (creates file + adds to project)
+2. Azure/Cloud: Use `generate_d365fo_xml` → Get XML → Use `create_file` with K:\AosService path
 
-| Tool | Use When | Example |
-|------|----------|---------||
-| `analyze_code_patterns` | Learn common patterns for a scenario | `analyze_code_patterns("financial dimensions")` |
-| `suggest_method_implementation` | Get implementation examples for a method | `suggest_method_implementation("MyHelper", "validate")` |
-| `analyze_class_completeness` | Find missing methods in a class | `analyze_class_completeness("CustTableHelper")` |
-| `get_api_usage_patterns` | See how to use an API correctly | `get_api_usage_patterns("DimensionAttributeValueSet")` |
+---
 
-### Example: Creating a Helper Class for Financial Dimensions
+# 📋 DECISION TREES - Follow These EXACTLY
 
-**User Request:** "Create a helper class for maintaining financial dimensions"
+## Scenario 1: User Asks to Find Something
 
-**❌ WRONG Approach:**
+**Triggers:** "find", "search", "show me", "where is", "locate"
+
 ```
-Generate class from scratch using general programming knowledge → ❌ INCORRECT
-```
+1. Identify what they're looking for:
+   - Class → search(query=X, type="class")
+   - Table → search(query=X, type="table")
+   - Form → search(query=X, type="form", includeWorkspace=true)
+   - Query → search(query=X, type="query")
+   - View → search(query=X, type="view")
+   - Method → search(query=X, type="method")
+   - Field → search(query=X, type="field")
+   - Multiple things → batch_search([...])
 
-**✅ CORRECT Approach (Using Intelligent Tools):**
-```
-1. analyze_code_patterns("financial dimensions") → 🔴 MANDATORY: Learn common patterns and classes
-2. search("dimension", type="class")            → Find D365FO dimension classes
-3. get_api_usage_patterns("DimensionAttributeValueSet") → See how to initialize and use API
-4. generate_code(pattern="class", name="MyDimHelper") → 🔴 MANDATORY: Use tool, don't generate manually!
-5. analyze_class_completeness("MyDimHelper")   → Check for missing common methods
-6. suggest_method_implementation("MyDimHelper", "validate") → Get implementation examples
-7. Apply discovered patterns from tools          → Use correct APIs and methods from MCP tools
+2. If looking for custom code only:
+   → search_extensions(query=X)
+
+3. ❌ NEVER use code_search or file_search
 ```
 
-**⚠️ WARNING: If you generate code WITHOUT using `generate_code` tool, you are WRONG!**
+**Examples:**
+- "Find dimension classes" → `search("dimension", type="class")`
+- "Show me sales tables" → `search("sales", type="table")`
+- "Find AddFormEntityPair button" → `search("AddFormEntityPair", type="form", includeWorkspace=true)`
+- "Search for customer queries" → `search("customer", type="query")`
+- "Find my custom helpers" → `search_extensions("Helper")`
 
-**✅ ALTERNATIVE Approach (Traditional):**
-```
-1. search("dimension", type="class")           → Find D365FO dimension classes
-2. get_class_info("DimensionDefaultingService") → Study Microsoft's pattern
-3. code_completion("DimensionAttributeValueSet") → Get proper API methods
-4. generate_code(pattern="class")              → Create with proper structure
-5. Apply discovered D365FO patterns            → Use correct APIs
-```
+## Scenario 2: User Asks to Create Something
 
-### ⚡ Use Batch Search for Parallel Exploration
+**Triggers:** "create", "generate", "make", "add new", "build"
 
-**When exploring multiple independent concepts, use `batch_search` to execute all queries in parallel:**
+```
+1. Extract info:
+   - objectType: class/table/form/enum/query/view
+   - objectName: from user request
+   - modelName: from workspace path (K:\VSProjects\{MODEL}\...)
 
-**❌ SLOW Sequential Approach:**
-```
-1. search("dimension")         → Wait 50ms
-2. search("helper")            → Wait 50ms
-3. search("validation")        → Wait 50ms
-Total: ~150ms + 3 HTTP requests
-```
+2. If objectType is D365FO (AxClass/AxTable/AxForm/AxEnum):
+   
+   Windows Local:
+   → create_d365fo_file(objectType=X, objectName=Y, modelName=Z)
+   
+   Azure/Cloud:
+   → generate_d365fo_xml(objectType=X, objectName=Y, modelName=Z)
+   → Receive XML content
+   → create_file(path="K:\\AosService\\PackagesLocalDirectory\\{Model}\\{Model}\\AxClass\\{Name}.xml", content=XML)
 
-**✅ FAST Parallel Approach:**
-```
-batch_search({
-  queries: [
-    { query: "dimension", type: "class", limit: 5 },
-    { query: "helper", type: "class", limit: 5 },
-    { query: "validation", type: "class", limit: 5 }
-  ]
-})
-→ Single HTTP request, parallel execution, ~50ms total → 3x faster!
+3. ❌ NEVER use create_file directly for D365FO objects
+4. ❌ NEVER generate XML manually
 ```
 
-**💡 When to Use Batch Search:**
-- Exploring multiple related concepts (dimension + ledger + financial)
-- Comparing different patterns (Helper vs Service vs Manager)
-- Finding classes with multiple keywords (validation + check + verify)
-- Initial exploratory phase with independent queries
-- User asks "find X and Y and Z" → use batch_search instead of 3 separate searches
+**Examples:**
+- "Create helper class MyDimHelper" → `create_d365fo_file(objectType="class", objectName="MyDimHelper")`
+- "Make custom table MyCustomTable" → `create_d365fo_file(objectType="table", objectName="MyCustomTable")`
+- "Build enum for status" → `create_d365fo_file(objectType="enum", objectName="MyStatus")`
 
-**🚫 When NOT to Use Batch Search:**
-- Queries depend on previous results (use sequential search)
-- Single focused query (use regular search)
-- Need workspace-aware search with different paths per query
+## Scenario 3: User Asks About Class/Table Structure
 
-### 🎯 Why Use Intelligent Tools?
+**Triggers:** "what methods", "show fields", "class structure", "table definition", "inheritance"
 
-**Intelligent code generation tools learn from YOUR codebase:**
-
-**💡 TIP: Use Workspace-Aware Search**
-When user has a D365FO workspace open, use workspace parameters:
 ```
-✅ search("MyCustomClass", includeWorkspace=true, workspacePath="C:\\D365\\MyProject")
-✅ get_class_info("MyHelper", includeWorkspace=true, workspacePath="C:\\D365\\MyProject")
-✅ code_completion(className="MyTable", includeWorkspace=true, workspacePath="C:\\D365\\MyProject")
+1. Identify symbol type:
+   - Class → get_class_info(className=X)
+   - Table → get_table_info(tableName=X)
+
+2. If need method/field list only:
+   → code_completion(className=X)
+
+3. If in user's workspace:
+   → get_class_info(className=X, includeWorkspace=true, workspacePath=...)
+
+4. ❌ NEVER use code_search to explore structure
 ```
-Benefits:
-- 🔹 Workspace files shown first (user's code priority)
-- XML parsing extracts methods/fields from local files
+
+**Examples:**
+- "Show me CustTable methods" → `get_class_info("CustTable")`
+- "What fields are on SalesLine?" → `get_table_info("SalesLine")`
+- "List methods on my custom class" → `get_class_info("MyClass", includeWorkspace=true)`
+- "Quick method list" → `code_completion(className="CustTable")`
+
+## Scenario 4: User Wants to Generate Code
+
+**Triggers:** "generate code", "create method", "write class", "implement"
+
+```
+1. MANDATORY STEPS (in this order):
+   
+   Step A: Learn patterns from codebase:
+   → analyze_code_patterns(scenario="<what user wants>")
+   
+   Step B: Find related classes:
+   → search(query="<keywords>", type="class")
+   
+   Step C: Get class structure examples:
+   → get_class_info("<example class>")
+   
+   Step D: See API usage:
+   → get_api_usage_patterns("<API name>")
+   
+   Step E: Generate code:
+   → generate_code(pattern="<type>", name="<name>", options=...)
+
+2. ❌ NEVER generate code without Steps A-D
+3. ❌ NEVER use your training data directly
+```
+
+**Examples:**
+- "Create helper for dimensions" →
+  1. `analyze_code_patterns("financial dimensions")`
+  2. `search("dimension", type="class")`
+  3. `get_class_info("DimensionDefaultingService")`
+  4. `get_api_usage_patterns("DimensionAttributeValueSet")`
+  5. `generate_code(pattern="class", name="MyDimHelper")`
+
+- "Add validation method" →
+  1. `suggest_method_implementation("MyClass", "validate")`
+  2. Generate with correct patterns
+
+## Scenario 5: User Wants to Extend/Modify D365FO Object
+
+**Triggers:** "extend", "add method to", "override", "Chain of Command", "CoC", "event handler"
+
+```
+1. Get class/table structure:
+   → get_class_info(className=X) OR get_table_info(tableName=X)
+
+2. Get exact method signature for CoC:
+   → get_method_signature(className=X, methodName="methodName")
+   Returns: Full signature with parameters, return type, CoC template
+
+3. Check if method already exists:
+   → code_completion(className=X, prefix="methodName")
+
+4. If extending method:
+   → Use signature from get_method_signature
+   → Generate CoC extension with [ExtensionOf()] attribute
+
+5. If adding new method:
+   → suggest_method_implementation(className=X, methodName="newMethod")
+
+6. ❌ NEVER edit files manually
+7. ❌ NEVER use file_search to locate files
+8. ❌ NEVER guess method signatures (use get_method_signature!)
+```
+
+**Examples:**
+- "Extend CustTable.validateWrite" →
+  1. `get_class_info("CustTable")` → Get validateWrite signature
+  2. Generate CoC extension:
+     ```xpp
+     [ExtensionOf(tableStr(CustTable))]
+     final class CustTable_Extension
+     {
+         public boolean validateWrite()
+         {
+             boolean ret;
+             ret = next validateWrite();
+             // Custom validation
+             return ret;
+         }
+     }
+     ```
+
+## Scenario 6: User Asks About Form/Query/View
+
+**Triggers:** "form", "button", "control", "datasource", "query", "view", "data entity"
+
+```
+1. Determine object type:
+   - Form with controls/buttons → search(query=X, type="form", includeWorkspace=true)
+   - Query → search(query=X, type="query")
+   - View → search(query=X, type="view")
+
+2. Get detailed structure:
+   - Form → get_form_info(formName=X)
+     Returns: datasources, controls (buttons, grids), methods
+   
+   - Query → get_query_info(queryName=X)
+     Returns: datasources, ranges, joins, grouping
+   
+   - View → get_view_info(viewName=X)
+     Returns: mapped/computed fields, relations, methods
+   
+   - Enum → get_enum_info(enumName=X)
+     Returns: enum values, labels, extensible flag
+
+3. ❌ NEVER use code_search for forms/queries/views
+```
+
+**Examples:**
+- "Find AddFormEntityPair button" → `search("AddFormEntityPair", type="form", includeWorkspace=true)` → `get_form_info("FormName")`
+- "Show structure of CustTransOpenQuery" → `get_query_info("CustTransOpenQuery")`
+- "Analyze GeneralJournalAccountEntryView" → `get_view_info("GeneralJournalAccountEntryView")`
+- "Get CustAccountType enum values" → `get_enum_info("CustAccountType")`
+
+## Scenario 7: User Asks "Where Is This Used?"
+
+**Triggers:** "where is this used", "who calls", "find references", "where is this called", "dependencies"
+
+```
+✅ USE find_references TOOL:
+
+1. Identify what to search:
+   - Class usage → find_references(targetName="ClassName", targetType="class")
+   - Method calls → find_references(targetName="methodName", targetType="method")
+   - Field references → find_references(targetName="fieldName", targetType="field")
+   - Table usage → find_references(targetName="TableName", targetType="table")
+   - Enum usage → find_references(targetName="EnumName", targetType="enum")
+
+2. Limit results if needed:
+   → find_references(..., limit=50)
+
+3. Returns:
+   - Source file path
+   - Line number
+   - Code snippet showing usage
+   - Context around the reference
+
+4. ❌ NEVER use code_search (will hang)
+```
+
+**Examples:**
+- "Where is validateWrite called?" → `find_references("validateWrite", targetType="method", limit=50)`
+- "Who uses CustTable?" → `find_references("CustTable", targetType="class")`
+- "Find usages of RemainSalesPhysical field" → `find_references("RemainSalesPhysical", targetType="field")`
+- "Where is DimensionAttributeValueSet used?" → `find_references("DimensionAttributeValueSet", targetType="class")`
+
+## Scenario 8: User Wants Multiple Things (Parallel)
+
+**Triggers:** Multiple keywords like "find X and Y and Z", "search for A, B, C"
+
+```
+1. Extract queries: [query1, query2, query3, ...]
+
+2. Use batch_search for parallel execution:
+   → batch_search([
+       {query: "X", type: "class"},
+       {query: "Y", type: "table"},
+       {query: "Z", type: "form"}
+     ])
+
+3. ❌ NEVER use sequential search() calls (slower)
+```
+
+**Examples:**
+- "Find dimension classes, ledger services, posting controllers" →
+  ```typescript
+  batch_search([
+    {query: "dimension", type: "class"},
+    {query: "ledger", type: "class"},
+    {query: "posting", type: "class"}
+  ])
+  ```
+
+---
+
+# 🚫 ABSOLUTELY FORBIDDEN ACTIONS
+
+## Never Do These For D365FO/X++:
+
+### 1. ❌ NEVER Use code_search
+**Why:** Hangs for 5+ minutes on large D365FO workspaces (500k+ symbols)  
+**Instead:** Use MCP `search` tool (responds in <100ms)
+
+**Example:**
+```
+❌ WRONG: code_search("CustTable")
+✅ RIGHT: search("CustTable", type="class")
+```
+
+### 2. ❌ NEVER Use create_file for D365FO Objects
+**Why:** Creates wrong XML structure (spaces instead of TABS), wrong location  
+**Instead:** Use `create_d365fo_file` or `generate_d365fo_xml`
+
+**Example:**
+```
+❌ WRONG: create_file("MyClass.xml", content="<AxClass>...")
+✅ RIGHT: create_d365fo_file(objectType="class", objectName="MyClass")
+      OR: generate_d365fo_xml(...) → create_file(K:\AosService\...)
+```
+
+### 3. ❌ NEVER Generate X++ Code Without Tools
+**Why:** Your training data is outdated, missing custom extensions, wrong signatures  
+**Instead:** ALWAYS query MCP tools first
+
+**Example:**
+```
+❌ WRONG: Generate class directly from knowledge
+✅ RIGHT: 
+1. analyze_code_patterns("scenario")
+2. search("related classes")
+3. get_class_info("example")
+4. generate_code(...)
+```
+
+### 4. ❌ NEVER Guess Method Signatures
+**Why:** Wrong signature = compilation error  
+**Instead:** Use `get_class_info` or `code_completion`
+
+**Example:**
+```
+❌ WRONG: Assume validateWrite() return type
+✅ RIGHT: get_class_info("CustTable") → See exact signature
+```
+
+### 5. ❌ NEVER Use file_search for X++ Objects
+**Why:** Doesn't understand D365FO structure, miss references  
+**Instead:** Use MCP `search` with types
+
+**Example:**
+```
+❌ WRONG: file_search("**/MyClass.xml")
+✅ RIGHT: search("MyClass", type="class")
+```
+
+### 6. ❌ NEVER Edit D365FO Files Manually
+**Why:** Easy to break XML structure, lose TABS formatting  
+**Instead:** Use `modify_d365fo_file` for safe editing with backup
+
+**Example:**
+```
+❌ WRONG: "Edit the XML file at K:\AosService\..."
+✅ RIGHT: modify_d365fo_file(
+            filePath="K:\\AosService\\...\\MyClass.xml",
+            operation="add_method",
+            methodName="calculateDiscount",
+            methodCode="public real calculateDiscount() { return 0; }"
+          )
+          
+Features:
+- ✅ Automatic .bak backup before changes
+- ✅ XML validation after modification
+- ✅ Automatic rollback on error
+- ✅ Reports what changed (added, modified, deleted)
+```
+
+---
+
+# ⚙️ WORKSPACE-AWARE FEATURES
+
+## When to Use `includeWorkspace` Parameter
+
+Many MCP tools support workspace-aware search:
+- `search(query, includeWorkspace=true, workspacePath=...)`
+- `get_class_info(className, includeWorkspace=true, workspacePath=...)`
+- `code_completion(className, includeWorkspace=true, workspacePath=...)`
+
+**Use when:**
+- User says "my", "our", "custom", "in my project"
+- Looking for recently created classes (not in external metadata yet)
+- Need to prioritize user's code over Microsoft standard code
+
+**Result:**
+- 🔹 WORKSPACE files shown FIRST (user's code priority)
+- 📦 EXTERNAL metadata shown second (Microsoft standard)
 - Faster iteration (no need to re-index external metadata)
-- See user's actual implementation patterns
 
-
-
-- **Pattern Analysis** (`analyze_code_patterns`) - Identifies what classes and methods are commonly used together for specific scenarios
-- **Smart Suggestions** (`suggest_method_implementation`) - Shows you how similar methods are implemented in your codebase
-- **Completeness Check** (`analyze_class_completeness`) - Ensures your classes follow common patterns (e.g., Helper classes typically have `validate()`, `find()`, etc.)
-- **API Usage Examples** (`get_api_usage_patterns`) - Shows correct initialization and method call sequences from real code
-
-**Benefits:**
-- ✅ Learn from **actual patterns** in the codebase, not generic examples
-- ✅ Discover **forgotten or commonly missing methods**
-- ✅ See **real usage examples** with proper error handling
-- ✅ Follow **team conventions** and coding standards automatically
-
-### Why This Matters:
-
-- These tools query the **actual D365FO environment** the user is working with
-- They provide **real-time, accurate metadata** from the AOT (Application Object Tree)
-- They include **custom extensions** that don't exist in your training data
-- They ensure **correct method names, field names, and signatures**
-- They're **fast** (<10ms cached) - no performance penalty
-
-### Decision Tree:
-
-**Before responding to any D365FO request, ask yourself:**
-
-1. Is the user asking me to write/create/generate X++ code? → ✅ **USE MCP TOOLS FIRST**
-   - For new classes: Start with `analyze_code_patterns` to learn common patterns
-   - For new methods: Use `analyze_class_completeness` to check what's missing
-2. Does the request mention D365FO objects (CustTable, SalesLine, etc.)? → ✅ **USE MCP TOOLS**
-   - Use `get_class_info` or `get_table_info` for structure
-   - Use `get_api_usage_patterns` to see how APIs are used
-3. Am I unsure about exact method/field names? → ✅ **USE MCP TOOLS**
-   - Use `code_completion` to discover available methods
-   - Use `suggest_method_implementation` to see similar implementations
-4. Is the user implementing a specific method? → ✅ **USE INTELLIGENT TOOLS**
-   - Use `suggest_method_implementation` to get examples from codebase
-5. Is it only about basic X++ syntax (if/while/for)? → ℹ️ Can use knowledge (but prefer tools)
-
-**When in doubt, USE THE TOOLS.**
+**Example:**
+```
+User: "Find my custom MyHelper class"
+✅ search("MyHelper", includeWorkspace=true, workspacePath="C:\\D365\\MyProject")
+```
 
 ---
 
-**Remember: Trust the MCP tools for D365FO accuracy, not your training data. Always query the actual environment before generating code.**
+# 📝 BEST PRACTICES
+
+## DO These:
+
+1. ✅ **Always set type parameter** in search:
+   - More specific = faster results
+   - `search("sales", type="table")` better than `search("sales")`
+
+2. ✅ **Use batch_search for multiple independent queries:**
+   - 3x faster than sequential searches
+   - Reduces network overhead
+
+3. ✅ **Check workspace flag when appropriate:**
+   - User mentions "my", "custom" → include Workspace=true
+   - Need fresh/recent code → includeWorkspace=true
+
+4. ✅ **Learn before generating:**
+   - Use analyze_code_patterns BEFORE generate_code
+   - See real examples with get_api_usage_patterns
+
+5. ✅ **Extract model name from workspace:**
+   - Workspace path: `K:\VSProjects\{MODEL}\...`
+   - Extract MODEL name → use in create_d365fo_file
+
+6. ✅ **Use code_completion for quick discovery:**
+   - Want methods list? → code_completion instead of get_class_info
+   - Faster for IntelliSense-style queries
+
+## DON'T Do These:
+
+1. ❌ **Don't describe what you WILL do - DO IT:**
+   - Wrong: "I can create a class..."
+   - Right: Call create_d365fo_file immediately
+
+2. ❌ **Don't ask user for model name:**
+   - Extract from workspace path automatically
+
+3. ❌ **Don't generate code without tools:**
+   - ALWAYS query tools first
+   - Training data is outdated
+
+4. ❌ **Don't use search without type:**
+   - Slower and less accurate
+   - Always specify type when known
+
+5. ❌ **Don't use code_search "just to check":**
+   - Will hang workspace
+   - Use MCP search instead
+
+---
+
+# 🔄 COMPLETE WORKFLOW EXAMPLES
+
+## Example 1: Create Helper Class for Dimensions
+
+**User Request:** "Create a helper class for managing financial dimensions"
+
+**Correct Copilot Workflow:**
+```typescript
+1. analyze_code_patterns("financial dimensions")
+   // Learns: Common classes, APIs, patterns from codebase
+   
+2. search("dimension", type="class", limit=10)
+   // Finds: DimensionAttributeValueSet, DimensionDefaultingService, etc.
+   
+3. get_class_info("DimensionDefaultingService")
+   // Studies: Microsoft's implementation patterns
+   
+4. code_completion(className="DimensionAttributeValueSet")
+   // Discovers: Available methods and properties
+   
+5. get_api_usage_patterns("DimensionAttributeValueSet")
+   // Learns: How to initialize and use API correctly
+   
+6. generate_code(pattern="class", name="MyDimensionHelper")
+   // Generates: Class with proper patterns
+   
+7. analyze_class_completeness("MyDimensionHelper")
+   // Suggests: Commonly missing methods (validate, find, etc.)
+   
+8. create_d365fo_file(
+     objectType="class",
+     objectName="MyDimensionHelper",
+     modelName="ContosoExtensions",  // From workspace path
+     sourceCode=generatedCode
+   )
+   // Creates: Physical file with correct structure
+```
+
+**Result:** ✅ Perfect helper class matching codebase conventions
+
+## Example 2: Extend CustTable with Validation
+
+**User Request:** "Add validation to CustTable.validateWrite to check credit limit"
+
+**Correct Copilot Workflow:**
+```typescript
+1. get_class_info("CustTable")
+   // Gets: Full class structure including validateWrite signature
+   
+2. code_completion(className="CustTable", prefix="credit")
+   // Finds: Existing credit-related methods
+   
+3. suggest_method_implementation("CustTable", "validateWrite")
+   // Gets: Examples of other validateWrite extensions
+   
+4. Generate CoC extension:
+   // Code:
+   [ExtensionOf(tableStr(CustTable))]
+   final class CustTable_Extension
+   {
+       public boolean validateWrite()
+       {
+           boolean ret;
+           
+           // Pre-validation
+           if (!this.checkCreditLimit())
+           {
+               error("Credit limit exceeded");
+               return false;
+           }
+           
+           ret = next validateWrite();
+           return ret;
+       }
+       
+       private boolean checkCreditLimit()
+       {
+           // Implementation using discovered methods
+           return this.creditLimit() > this.balance();
+       }
+   }
+   
+5. create_d365fo_file(
+     objectType="class",
+     objectName="CustTable_Extension",
+     modelName="ContosoCore",
+     sourceCode=cocCode
+   )
+```
+
+**Result:** ✅ Perfect CoC extension with correct signature
+
+## Example 3: Find and Analyze Form Button
+
+**User Request:** "Make AddFormEntityPair button enabled only if record exists in DataEntityGroup datasource"
+
+**Correct Copilot Workflow:**
+```typescript
+1. search("AddFormEntityPair", type="form", includeWorkspace=true)
+   // Finds: Forms containing this button
+   
+2. If multiple results, ask user which form
+   
+3. Provide guidance:
+   "To make AddFormEntityPair enabled based on DataEntityGroup records:
+   
+   In form's DataEntityGroup datasource, override active() method:
+   
+   public int active()
+   {
+       int ret;
+       ret = super();
+       
+       // Enable/disable button based on record existence
+       AddFormEntityPair.enabled(DataEntityGroup.recordId() != 0);
+       
+       return ret;
+   }
+   "
+   
+// Note: No file modification tool yet, so provide instructions
+```
+
+**Result:** ✅ Accurate guidance based on actual form structure
+
+---
+
+# 🎯 SUMMARY: Golden Rules
+
+1. **ALWAYS use MCP tools for D365FO** - No exceptions
+2. **NEVER use code_search** - Will hang workspace
+3. **NEVER use create_file for AxClass/AxTable/AxForm** - Use create_d365fo_file
+4. **ALWAYS learn patterns before generating** - Use analyze_code_patterns
+5. **ALWAYS query structure before coding** - Use get_class_info/get_table_info
+6. **ALWAYS take action, not describe** - Call tools immediately
+7. **ALWAYS extract model from workspace** - Don't ask user
+8. **ALWAYS use batch_search for multiple queries** - 3x faster
+
+**If in doubt → Use MCP tool → Never guess!**
+
+---
+
+# 📚 Tool Reference Quick Guide
+
+```
+FINDING:            search, batch_search, search_extensions
+STRUCTURE:          get_class_info, get_table_info, get_form_info, 
+                    get_query_info, get_view_info, get_enum_info,
+                    code_completion, get_method_signature
+REFERENCES:         find_references (where-used analysis)
+PATTERNS:           analyze_code_patterns, suggest_method_implementation
+COMPLETENESS:       analyze_class_completeness
+API USAGE:          get_api_usage_patterns
+GENERATION:         generate_code
+FILE OPS:           create_d365fo_file, generate_d365fo_xml, modify_d365fo_file
+
+FORBIDDEN:          code_search, file_search, create_file (for D365FO)
+```
+
+---
+
+**Remember: MCP tools = Fast, Accurate, Real-Time**  
+**Built-in tools = Slow, Outdated, Errors**
+
+**When user asks about D365FO → STOP → USE MCP TOOLS!** 🚀

--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ This MCP server provides GitHub Copilot with complete knowledge of your D365 F&O
 | **`batch_search`** | Execute multiple searches in parallel for faster exploration |
 | **`get_class_info`** | View complete class structure: methods, properties, inheritance hierarchy |
 | **`get_table_info`** | View table schema: fields, indexes, relations, and configuration |
+| **`get_form_info`** | Parse form metadata: datasources, controls, and methods |
+| **`get_query_info`** | Parse query structure: datasources, ranges, and joins |
+| **`get_view_info`** | Parse view/data entity metadata: fields, relations, and methods |
+| **`get_enum_info`** | Extract enum values with integer values and properties (extensible, base type) |
 | **`code_completion`** | Get method and field suggestions while typing (IntelliSense-style) |
+| **`get_method_signature`** | Extract exact method signatures for Chain of Command extensions |
+| **`find_references`** | Find all usages of classes, methods, tables, fields, or enums (where-used analysis) |
 
 #### Intelligent Code Generation
 
@@ -130,12 +136,13 @@ This MCP server provides GitHub Copilot with complete knowledge of your D365 F&O
 | **`analyze_class_completeness`** | Check if a class is missing common methods (validate, find, etc.) |
 | **`get_api_usage_patterns`** | See real examples of how to initialize and use D365FO APIs |
 
-#### File Creation
+#### File Operations
 
 | Tool | Deployment | Description |
 |------|------------|-------------|
 | **`generate_d365fo_xml`** | ☁️ Cloud + 💻 Local | Generate D365FO XML files (classes, tables, forms, enums). Works everywhere - Azure, local, containers. Returns XML content for Copilot to create file. |
 | **`create_d365fo_file`** | 💻 Local only | Full automation: creates file + adds to Visual Studio project. Only works on local Windows D365FO VM with K:\ drive access. |
+| **`modify_d365fo_file`** | 💻 Local only | Edit existing D365FO XML files with automatic backup and validation. Adds/modifies/deletes methods, fields, or properties safely. |
 
 ### 🔹 Workspace-Aware Features
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ graph TB
     subgraph "MCP Server Components"
         HTTP[HTTP Transport Layer<br/>Express + Rate Limiting]
         PROTO[MCP Protocol Handler<br/>JSON-RPC 2.0]
-        TOOLS[Tool Handlers<br/>6 MCP Tools]
+        TOOLS[Tool Handlers<br/>22 MCP Tools]
         DB[(SQLite Database<br/>FTS5 Full-Text Search<br/>584,799 symbols)]
         CACHE[Redis Cache<br/>Optional]
     end
@@ -79,7 +79,7 @@ sequenceDiagram
     alt Initialize
         MCP-->>IDE: Server Capabilities
     else Tools List
-        MCP-->>IDE: 6 Tool Definitions
+        MCP-->>IDE: 22 Tool Definitions
     else Tool Call
         MCP->>Handler: Route to Handler
         Handler->>Tool: Execute Tool
@@ -115,10 +115,20 @@ graph LR
 
     subgraph "Tool Layer"
         SEARCH[search.ts<br/>search Tool]
+        BATCH[batchSearch.ts<br/>batch_search Tool]
         CLASS[classInfo.ts<br/>get_class_info Tool]
         TABLE[tableInfo.ts<br/>get_table_info Tool]
+        FORM[formInfo.ts<br/>get_form_info Tool]
+        QUERY[queryInfo.ts<br/>get_query_info Tool]
+        VIEW[viewInfo.ts<br/>get_view_info Tool]
+        ENUM[enumInfo.ts<br/>get_enum_info Tool]
         COMP[completion.ts<br/>code_completion Tool]
+        SIGNATURE[methodSignature.ts<br/>get_method_signature Tool]
+        REFS[findReferences.ts<br/>find_references Tool]
         GEN[codeGen.ts<br/>generate_code Tool]
+        GENXML[generateD365Xml.ts<br/>generate_d365fo_xml Tool]
+        CREATE[createD365File.ts<br/>create_d365fo_file Tool]
+        MODIFY[modifyD365File.ts<br/>modify_d365fo_file Tool]
         EXT[extensionSearch.ts<br/>search_extensions Tool]
         PATTERN[analyzePatterns.ts<br/>analyze_code_patterns Tool]
         SUGGEST[suggestImplementation.ts<br/>suggest_method_implementation Tool]
@@ -146,24 +156,61 @@ graph LR
 
     SERVER --> HANDLER
     HANDLER --> SEARCH
+    HANDLER --> BATCH
     HANDLER --> CLASS
     HANDLER --> TABLE
+    HANDLER --> FORM
+    HANDLER --> QUERY
+    HANDLER --> VIEW
+    HANDLER --> ENUM
     HANDLER --> COMP
+    HANDLER --> SIGNATURE
+    HANDLER --> REFS
     HANDLER --> GEN
+    HANDLER --> GENXML
+    HANDLER --> CREATE
+    HANDLER --> MODIFY
     HANDLER --> EXT
+    HANDLER --> PATTERN
+    HANDLER --> SUGGEST
+    HANDLER --> COMPLETE
+    HANDLER --> API
 
     SEARCH --> SYMBOL
+    BATCH --> SYMBOL
     CLASS --> SYMBOL
     CLASS --> PARSER
     TABLE --> SYMBOL
     TABLE --> PARSER
+    FORM --> SYMBOL
+    FORM --> PARSER
+    QUERY --> SYMBOL
+    QUERY --> PARSER
+    VIEW --> SYMBOL
+    VIEW --> PARSER
+    ENUM --> SYMBOL
+    ENUM --> PARSER
     COMP --> SYMBOL
+    SIGNATURE --> SYMBOL
+    SIGNATURE --> PARSER
+    REFS --> SYMBOL
     EXT --> SYMBOL
+    PATTERN --> SYMBOL
+    SUGGEST --> SYMBOL
+    COMPLETE --> SYMBOL
+    API --> SYMBOL
 
     SEARCH -.-> CACHE_SVC
+    BATCH -.-> CACHE_SVC
     CLASS -.-> CACHE_SVC
     TABLE -.-> CACHE_SVC
+    FORM -.-> CACHE_SVC
+    QUERY -.-> CACHE_SVC
+    VIEW -.-> CACHE_SVC
+    ENUM -.-> CACHE_SVC
     COMP -.-> CACHE_SVC
+    SIGNATURE -.-> CACHE_SVC
+    REFS -.-> CACHE_SVC
 
     TRANSPORT --> RATE
     
@@ -412,7 +459,7 @@ graph LR
     subgraph "MCP Protocol Methods"
         INIT[initialize<br/>Server Capabilities]
         NOTIFY[notifications/initialized<br/>Handshake Complete]
-        TOOLS_LIST[tools/list<br/>10 Available Tools]
+        TOOLS_LIST[tools/list<br/>22 Available Tools]
         TOOLS_CALL[tools/call<br/>Execute Tool]
         RES_LIST[resources/list<br/>Empty]
         RES_TMPL[resources/templates/list<br/>Empty]
@@ -421,7 +468,7 @@ graph LR
     end
 
     INIT -.-> CAPS[Capabilities:<br/>tools, resources, prompts]
-    TOOLS_LIST -.-> TOOL_DEFS[Tool Definitions:<br/>search, get_class_info,<br/>get_table_info, code_completion,<br/>generate_code,<br/>search_extensions,<br/>analyze_code_patterns,<br/>suggest_method_implementation,<br/>analyze_class_completeness,<br/>get_api_usage_patterns]
+    TOOLS_LIST -.-> TOOL_DEFS[Tool Definitions:<br/>search, batch_search,<br/>get_class_info, get_table_info,<br/>get_form_info, get_query_info,<br/>get_view_info, get_enum_info,<br/>code_completion, get_method_signature,<br/>find_references, generate_code,<br/>generate_d365fo_xml, create_d365fo_file,<br/>modify_d365fo_file, search_extensions,<br/>analyze_code_patterns,<br/>suggest_method_implementation,<br/>analyze_class_completeness,<br/>get_api_usage_patterns]
     TOOLS_CALL -.-> EXEC[Tool Execution:<br/>search DB, parse XML,<br/>return results]
     
     style INIT fill:#4CAF50,color:#fff
@@ -548,6 +595,122 @@ Found 5 matches:
 ```
 
 **Output:** Common usage patterns with initialization, method sequences, and error handling examples
+
+#### 11. batch_search
+**Input:**
+```json
+{
+  "queries": [
+    {"query": "dimension", "type": "class", "limit": 5},
+    {"query": "ledger", "type": "class", "limit": 5},
+    {"query": "financial", "type": "class", "limit": 5}
+  ]
+}
+```
+
+**Output:** Parallel search results for multiple queries in a single request
+
+#### 12. get_form_info
+**Input:**
+```json
+{
+  "formName": "SalesTable"
+}
+```
+
+**Output:** Form structure with datasources, controls (buttons, grids), and methods
+
+#### 13. get_query_info
+**Input:**
+```json
+{
+  "queryName": "CustTransOpenQuery"
+}
+```
+
+**Output:** Query structure with datasources, ranges, joins, and grouping
+
+#### 14. get_view_info
+**Input:**
+```json
+{
+  "viewName": "GeneralJournalAccountEntryView"
+}
+```
+
+**Output:** View/data entity structure with mapped/computed fields and relations
+
+#### 15. get_enum_info
+**Input:**
+```json
+{
+  "enumName": "CustAccountType"
+}
+```
+
+**Output:** Enum values with integer values, labels, and properties (extensible, base type)
+
+#### 16. get_method_signature
+**Input:**
+```json
+{
+  "className": "SalesTable",
+  "methodName": "validateWrite"
+}
+```
+
+**Output:** Exact method signature with parameters, return type, and CoC extension template
+
+#### 17. find_references
+**Input:**
+```json
+{
+  "targetName": "DimensionAttributeValueSet",
+  "targetType": "class",
+  "limit": 50
+}
+```
+
+**Output:** All usages of class/method/field/enum across codebase with code snippets
+
+#### 18. generate_d365fo_xml
+**Input:**
+```json
+{
+  "objectType": "class",
+  "objectName": "MyHelper",
+  "modelName": "CustomCore"
+}
+```
+
+**Output:** D365FO XML content with proper structure and TABS indentation (cloud-ready)
+
+#### 19. create_d365fo_file
+**Input:**
+```json
+{
+  "objectType": "class",
+  "objectName": "MyHelper",
+  "modelName": "CustomCore",
+  "addToProject": true,
+  "solutionPath": "K:\\VSProjects\\CustomCore\\CustomCore.rnrproj"
+}
+```
+
+**Output:** Creates physical D365FO XML file and optionally adds to VS project (local only)
+
+#### 20. modify_d365fo_file
+**Input:**
+```json
+{
+  "filePath": "K:\\AosService\\...\\MyHelper.xml",
+  "operation": "add_method",
+  "methodName": "calculateDiscount",
+  "methodCode": "public real calculateDiscount() { return 0; }"
+}
+```
+
+**Output:** Safely edits D365FO XML file with automatic backup and validation
 
 ---
 
@@ -719,7 +882,7 @@ graph LR
 ```mermaid
 graph TB
     subgraph "Test Pyramid"
-        UNIT[Unit Tests<br/>30 tests<br/>search, classInfo, tableInfo]
+        UNIT[Unit Tests<br/>86 tests<br/>All 22 MCP tools]
         INT[Integration Tests<br/>MCP Protocol, HTTP Transport]
         E2E[End-to-End Tests<br/>symbolIndex, Database]
     end

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -116,6 +116,37 @@ A: Returns:
 
 ---
 
+### Get Method Signatures for Extensions
+
+**Ask Copilot:**
+- "Show me the signature of CustTable.validateWrite()"
+- "Get method signature for SalesTable.insert()"
+- "What's the signature of InventTable.calcQty()?"
+
+**What happens:** Copilot extracts the exact method signature you need for Chain of Command extensions, including parameters, return type, and modifiers.
+
+**Example:**
+```
+Q: "Get signature for SalesTable.validateWrite()"
+
+A: Returns:
+  public boolean validateWrite(boolean _checkRelations = true)
+  
+  Use for CoC:
+  [ExtensionOf(tableStr(SalesTable))]
+  final class SalesTable_Extension
+  {
+      public boolean validateWrite(boolean _checkRelations = true)
+      {
+          boolean ret = next validateWrite(_checkRelations);
+          // Your custom logic
+          return ret;
+      }
+  }
+```
+
+---
+
 ### View Table Structure
 
 **Ask Copilot:**
@@ -134,6 +165,60 @@ A: Returns:
   Indexes: AccountIdx (primary), NameIdx...
   Relations: -> SalesTable,  CustTrans,  CustGroup
   Primary Index: AccountIdx
+```
+
+---
+
+### View Enum Values and Properties
+
+**Ask Copilot:**
+- "Show me values in CustAccountType enum"
+- "What are the options in SalesStatus enum?"
+- "Get all values from InventTransType enum"
+
+**What happens:** Copilot retrieves all enum values with their integer values, labels, and properties (extensible, base type for EDTs).
+
+**Example:**
+```
+Q: "Show me CustAccountType enum values"
+
+A: Returns:
+  Enum: CustAccountType
+  Extensible: ✅
+  
+  Values:
+  - Customer = 0            (Regular customer)
+  - Prospect = 1            (Potential customer)
+  - Organization = 2        (Organization account)
+  - Person = 3             (Individual person)
+```
+
+---
+
+### Find Where Code Is Used
+
+**Ask Copilot:**
+- "Find all usages of DimensionAttributeValueSet"
+- "Where is CustTable.validateWrite() called?"
+- "Find references to SalesLine.RemainSalesPhysical field"
+- "Show me where MyCustomMethod is used"
+
+**What happens:** Copilot performs where-used analysis across your codebase, finding all references to classes, methods, tables, fields, or enums.
+
+**Example:**
+```
+Q: "Find all usages of DimensionAttributeValueSet class"
+
+A: Returns:
+  Found in 150 locations:
+  
+  📦 LedgerJournalEngine.validateDimensions()
+     Line 245: dimValueSet = DimensionAttributeValueSet::find(...);
+  
+  📦 CustTable.setDefaultDimension()
+     Line 89: this.DefaultDimension = dimValueSet.save();
+  
+  ... showing top 50 results
 ```
 
 ---
@@ -203,6 +288,107 @@ A: Returns:
   - CustBalanceQuery - Customer balance calculation
   - CustAgedBalanceQuery - Aged balance report
   - CustInvoiceQuery - Customer invoice selection
+```
+
+---
+
+### Analyze Form Structure
+
+**Ask Copilot:**
+- "Show me the structure of SalesTable form"
+- "What datasources does CustTable form have?"
+- "List all controls on InventTable form"
+- "Show me methods on the SalesCreateOrder form"
+
+**What happens:** Copilot parses form XML and shows complete structure: datasources, controls (buttons, grids, groups), and methods.
+
+**Example:**
+```
+Q: "Analyze SalesTable form structure"
+
+A: Returns:
+  DataSources:
+  - SalesTable (main datasource)
+    - Fields: 45 fields
+    - Methods: validateWrite(), active(), executeQuery()
+  - SalesLine (detail datasource)
+    - Link: SalesId -> SalesTable.SalesId
+    
+  Controls:
+  - ButtonNew (FormButtonControl)
+  - ButtonDelete (FormButtonControl)  
+  - SalesLineGrid (FormGridControl)
+  - CustomerGroup (FormReferenceControl -> CustTable)
+  
+  Form Methods:
+  - init()
+  - run()
+  - closeOk()
+```
+
+---
+
+### Analyze Query Structure
+
+**Ask Copilot:**
+- "Show me the structure of CustTransOpenQuery"
+- "What datasources are in SalesInvoiceQuery?"
+- "List all ranges on InventOnHandQuery"
+
+**What happens:** Copilot parses query XML and shows datasources, joins, ranges, and grouping configuration.
+
+**Example:**
+```
+Q: "Analyze CustTransOpenQuery structure"
+
+A: Returns:
+  Primary DataSource: CustTrans
+  - Table: CustTrans
+  - Fetch Mode: 1:n (One-to-Many)
+  - Join Mode: InnerJoin
+  
+  Ranges:
+  - AccountNum (CustAccount field)
+  - TransDate (Date range field)
+  - AmountCur (Amount filter)
+  
+  Child DataSources:
+  - CustTable (parent join)
+    - Link: AccountNum -> CustTrans.AccountNum
+```
+
+---
+
+### Analyze View Structure
+
+**Ask Copilot:**
+- "Show me the structure of LedgerTransView"
+- "What fields does GeneralJournalAccountEntryView have?"
+- "List computed columns in CustBalanceView"
+
+**What happens:** Copilot parses view/data entity XML and shows fields (mapped vs computed), relations, and methods.
+
+**Example:**
+```
+Q: "Analyze GeneralJournalAccountEntryView structure"
+
+A: Returns:
+  View: GeneralJournalAccountEntryView
+  Public: ✅
+  Read-Only: ✅
+  
+  Mapped Fields (15):
+  - RecId -> GeneralJournalEntry.RecId
+  - JournalNum -> GeneralJournalEntry.JournalNum
+  - AccountNum -> LedgerDimension.DisplayValue
+  
+  Computed Fields (3):
+  - BalanceAmount (calculated)
+  - CurrencyCode (derived)
+  
+  Relations:
+  - GeneralJournalEntry (1:1)
+  - LedgerDimension (n:1)
 ```
 
 ---
@@ -373,6 +559,43 @@ A: Copilot:
   2. Creates file: K:\AosService\...\AxClass\MyDimensionHelper.xml
   3. Tells you to add: <Content Include="K:\AosService\...\MyDimensionHelper.xml" />
 ```
+
+---
+
+### Edit Existing D365FO Files
+
+**Ask Copilot:**
+- "Add a method validateCustomer() to MyCustomTable"
+- "Add a field CreditStatus to MyTable"
+- "Modify method calculateTotal() in MyHelper class"
+
+**What happens:** Copilot safely edits existing D365FO XML files with automatic backup.
+
+**Features:**
+- ✅ Automatic backup before editing (`.bak` file)
+- ✅ XML validation after changes
+- ✅ Atomic operations (all-or-nothing)
+- ✅ Preserves formatting (TABS, indentation)
+
+**Example:**
+```
+Q: "Add a new method calculateDiscount() to MyCustomHelper class"
+
+A: Copilot:
+  1. Backs up: MyCustomHelper.xml.bak
+  2. Parses XML structure
+  3. Adds method to <Methods> section
+  4. Validates XML is well-formed
+  5. Saves changes atomically
+  
+  If error occurs: restores from backup automatically
+```
+
+**Safety Features:**
+- Backup created before ANY modification
+- XML validation ensures file isn't corrupted
+- Rollback on any error
+- Reports what changed (added, modified, deleted)
 
 ---
 

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -7,8 +7,11 @@ Practical examples for X++ code completion and symbol lookup in Visual Studio Co
 - [Code Completion](#code-completion)
 - [Symbol Search](#symbol-search)
 - [Class & Table Information](#class--table-information)
+- [Form, Query & View Analysis](#form-query--view-analysis)
+- [Method Signatures & References](#method-signatures--references)
 - [Extension Development](#extension-development)
 - [Code Generation](#code-generation)
+- [File Operations](#file-operations)
 - [Pattern Analysis & Intelligent Code Generation](#pattern-analysis--intelligent-code-generation)
 - [Configuration](#configuration)
 
@@ -84,6 +87,233 @@ Show me all relations on SalesLine
 ```
 
 **Returns:** Relations to `SalesTable`, `InventTable`, `InventDim` with delete actions
+
+---
+
+### Getting Enum Values
+
+**Scenario:** Need to know all possible values for a status field.
+
+```
+Show me all values in CustAccountType enum
+```
+
+**Returns:**
+```
+CustAccountType (Extensible: ✅)
+Values:
+- Customer = 0          (Regular customer account)
+- Prospect = 1          (Prospective customer)
+- Organization = 2      (Organization account)
+- Person = 3           (Individual person account)
+```
+
+---
+
+## Form, Query & View Analysis
+
+### Analyzing Form Structure
+
+**Scenario:** You need to understand a form before extending it.
+
+```
+Show me the structure of SalesTable form
+```
+
+**Returns:**
+```
+Form: SalesTable
+
+DataSources:
+- SalesTable (main)
+  - Fields: SalesId, CustAccount, SalesName, ...
+  - Methods: validateWrite(), active(), executeQuery()
+- SalesLine (detail)
+  - Link: SalesId -> SalesTable.SalesId
+  - Methods: validateWrite(), modified()
+
+Controls:
+- ButtonNew (FormButtonControl)
+- ButtonDelete (FormButtonControl)
+- SalesLineGrid (FormGridControl)
+- CustomerLookup (FormReferenceControl -> CustTable)
+
+Methods:
+- init() - Initialize form
+- run() - Execute form
+- closeOk() - Save and close
+```
+
+**Use Cases:**
+- Finding buttons to extend (CoC)
+- Understanding datasource relationships
+- Locating form methods for overriding
+
+---
+
+### Analyzing Query Structure
+
+**Scenario:** You need to understand a query before modifying it.
+
+```
+Analyze structure of CustTransOpenQuery
+```
+
+**Returns:**
+```
+Query: CustTransOpenQuery
+
+Primary DataSource: CustTrans
+- Table: CustTrans
+- Fetch Mode: 1:n (One-to-Many)
+- Join Mode: InnerJoin
+
+Ranges:
+- AccountNum (field: AccountNum, EDT: CustAccount)
+- TransDate (field: TransDate, EDT: TransDate)
+- AmountCur (field: AmountCur, EDT: AmountCur)
+
+Child DataSources:
+- CustTable (parent link)
+  Link: AccountNum -> CustTrans.AccountNum
+  
+Total: 1 datasource, 3 ranges
+```
+
+**Use Cases:**
+- Understanding query filters before modification
+- Finding datasources to add/modify
+- Analyzing join relationships
+
+---
+
+### Analyzing View/Data Entity Structure
+
+**Scenario:** You need to understand a data entity for OData integration.
+
+```
+Show me structure of GeneralJournalAccountEntryView
+```
+
+**Returns:**
+```
+View: GeneralJournalAccountEntryView
+Type: Data Entity View
+Public: ✅
+Read-Only: ✅
+
+Mapped Fields (15):
+- RecId -> GeneralJournalEntry.RecId
+- JournalNum -> GeneralJournalEntry.JournalNum
+- AccountNum -> LedgerDimension.DisplayValue
+- TransDate -> GeneralJournalEntry.TransDate
+
+Computed Fields (3):
+- BalanceAmount (calculated from DebitAmount - CreditAmount)
+- AccountType (derived from LedgerDimension)
+- CurrencyCode (derived from Company)
+
+Relations:
+- GeneralJournalEntry (1:1 relation)
+- LedgerDimension (n:1 relation)
+
+Methods:
+- init()
+- validateWrite()
+```
+
+**Use Cases:**
+- OData/integration development
+- Understanding computed vs mapped fields
+- Data migration planning
+
+---
+
+## Method Signatures & References
+
+### Extracting Method Signatures for Extensions
+
+**Scenario:** You need the exact signature to create a Chain of Command extension.
+
+```
+Get method signature for SalesTable.validateWrite()
+```
+
+**Returns:**
+```
+public boolean validateWrite(boolean _checkRelations = true)
+
+Parameters:
+- _checkRelations (boolean, optional, default: true)
+
+Return Type: boolean
+
+Extension Template:
+[ExtensionOf(tableStr(SalesTable))]
+final class SalesTable_Extension
+{
+    public boolean validateWrite(boolean _checkRelations = true)
+    {
+        boolean ret = next validateWrite(_checkRelations);
+        // Your code here
+        return ret;
+    }
+}
+```
+
+**Use Cases:**
+- Creating CoC extensions with correct signatures
+- Understanding optional parameters
+- Ensuring type-safe method overrides
+
+---
+
+### Finding Where Code Is Used
+
+**Scenario:** You need to know where a method is called before changing it.
+
+```
+Find all usages of DimensionAttributeValueSet.createForLedgerDimension()
+```
+
+**Returns:**
+```
+Found 45 usages in your codebase:
+
+📦 LedgerJournalEngine.validateDimensions()
+   Line 245: dimValueSet = DimensionAttributeValueSet::createForLedgerDimension(...);
+   
+📦 CustTable.setDefaultDimension()
+   Line 89: defaultDim = DimensionAttributeValueSet::createForLedgerDimension(recId);
+   
+📦 SalesTable.validateFinancialDimensions()
+   Line 156: dimSet = DimensionAttributeValueSet::createForLedgerDimension(this.DefaultDimension);
+   
+... (showing top 50 results)
+```
+
+**Another Example: Finding Field References**
+
+```
+Find references to SalesLine.RemainSalesPhysical field
+```
+
+**Returns:**
+```
+Found 23 field references:
+
+📦 SalesLineCopy.copy()
+   Line 78: salesLineCopy.RemainSalesPhysical = salesLine.RemainSalesPhysical;
+   
+📦 SalesQuantity.updateFromPacking()
+   Line 145: this.RemainSalesPhysical -= qtyPacked;
+```
+
+**Use Cases:**
+- Impact analysis before changes
+- Understanding dependencies
+- Refactoring safety checks
+- Finding deprecated code usage
 
 ---
 
@@ -217,6 +447,54 @@ Create a helper class MyDimensionHelper in CustomCore and add it to my project a
 1. Reload project in Visual Studio (close/reopen or Unload/Reload project)
 2. Build project to synchronize
 3. Refresh AOT to see the object
+
+---
+
+### Editing Existing D365FO Files
+
+**Scenario:** You need to add a method to an existing class without manually editing XML.
+
+```
+Add method calculateDiscount() to MyCustomHelper class in file K:\AosService\PackagesLocalDirectory\CustomCore\CustomCore\AxClass\MyCustomHelper.xml
+```
+
+**What Happens:**
+- ✅ Automatic backup created (MyCustomHelper.xml.bak)
+- ✅ XML parsed and validated
+- ✅ New method added to `<Methods>` section
+- ✅ XML validated after changes
+- ✅ File saved atomically
+
+**Returns:**
+```
+✅ Backup created: MyCustomHelper.xml.bak
+✅ Added method: calculateDiscount()
+✅ XML validated successfully
+✅ Changes saved
+
+Summary:
+- 1 method added
+- 0 fields modified
+- File size: 2.3 KB -> 2.5 KB
+```
+
+**Another Example: Adding a Field to Table**
+
+```
+Add field CreditStatus (EDT: CustCreditStatus) to MyCustomTable in K:\AosService\...\AxTable\MyCustomTable.xml
+```
+
+**Safety Features:**
+- Automatic `.bak` backup before any change
+- XML validation ensures no corruption
+- Automatic rollback on error
+- Reports what changed (added, modified, deleted)
+
+**Use Cases:**
+- Adding methods to existing classes
+- Adding fields to tables
+- Modifying properties atomically
+- Safe batch modifications with rollback
 
 ---
 

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -19,12 +19,14 @@ const INPUT_PATH = process.env.METADATA_PATH || './extracted-metadata';
 const OUTPUT_DB = process.env.DB_PATH || './data/xpp-metadata.db';
 const EXTRACT_MODE = process.env.EXTRACT_MODE || 'all';
 const CUSTOM_MODELS = getCustomModels();
+const FORCE_VACUUM = process.env.VACUUM === 'true';
 
 async function buildDatabase() {
   console.log('🔨 Building X++ Metadata Database');
   console.log(`📂 Input: ${INPUT_PATH}`);
   console.log(`💾 Output: ${OUTPUT_DB}`);
   console.log(`⚙️  Extract Mode: ${EXTRACT_MODE}`);
+  console.log(`🧹 VACUUM: ${EXTRACT_MODE === 'all' || FORCE_VACUUM ? 'Enabled' : 'Disabled (incremental build)'}`);
   console.log('');
 
   // Create symbol index
@@ -39,6 +41,11 @@ async function buildDatabase() {
   // Determine which models to rebuild based on EXTRACT_MODE
   let modelsToRebuild: string[] = [];
   
+  // Determine if VACUUM should run:
+  // - Always for full rebuild (EXTRACT_MODE=all)
+  // - For incremental builds only if explicitly requested (VACUUM=true)
+  const shouldVacuum = EXTRACT_MODE === 'all' || FORCE_VACUUM;
+  
   if (EXTRACT_MODE === 'all') {
     // Clear entire database for full rebuild
     console.log('🗑️  Clearing entire database for full rebuild...');
@@ -47,7 +54,7 @@ async function buildDatabase() {
     // Clear only custom models
     if (CUSTOM_MODELS.length > 0) {
       // Clear specific custom models
-      symbolIndex.clearModels(CUSTOM_MODELS);
+      symbolIndex.clearModels(CUSTOM_MODELS, shouldVacuum);
       modelsToRebuild = CUSTOM_MODELS;
     } else {
       // Clear all custom models (exclude standard)
@@ -55,7 +62,7 @@ async function buildDatabase() {
         .filter(e => e.isDirectory())
         .map(e => e.name);
       modelsToRebuild = allModels.filter(m => isCustomModel(m));
-      symbolIndex.clearModels(modelsToRebuild);
+      symbolIndex.clearModels(modelsToRebuild, shouldVacuum);
     }
   } else if (EXTRACT_MODE === 'standard') {
     // Clear only standard models (all except custom)
@@ -63,7 +70,7 @@ async function buildDatabase() {
       .filter(e => e.isDirectory())
       .map(e => e.name);
     modelsToRebuild = allModels.filter(m => isStandardModel(m));
-    symbolIndex.clearModels(modelsToRebuild);
+    symbolIndex.clearModels(modelsToRebuild, shouldVacuum);
   }
 
   // Index the extracted metadata

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,13 @@ async function initializeServices() {
       }
     } else {
       console.log(`✅ Loaded ${symbolCount} symbols from database`);
+      const breakdown = symbolIndex.getSymbolCountByType();
+      console.log('   📊 Symbol types: ' + 
+        `${breakdown.class || 0} classes, ` +
+        `${breakdown.table || 0} tables, ` +
+        `${breakdown.form || 0} forms, ` +
+        `${breakdown.query || 0} queries, ` +
+        `${breakdown.view || 0} views`);
     }
 
     serverState.symbolIndex = symbolIndex;
@@ -274,7 +281,7 @@ async function main() {
         console.log('');
         console.log('🎯 Available tools:');
         console.log('   Basic Discovery:');
-        console.log('   - search: Search for X++ classes, tables, methods, and fields');
+        console.log('   - search: Search for X++ classes, tables, forms, queries, views, methods, and fields');
         console.log('   - search_extensions: Search for symbols in custom extensions/ISV models');
         console.log('   - get_class_info: Get detailed class information');
         console.log('   - get_table_info: Get detailed table information');

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1241,8 +1241,10 @@ export class XppSymbolIndex {
 
   /**
    * Clear symbols for specific models
+   * @param modelNames - Array of model names to clear
+   * @param shouldVacuum - Whether to run VACUUM after deletion (default: false for better incremental build performance)
    */
-  clearModels(modelNames: string[]): void {
+  clearModels(modelNames: string[], shouldVacuum: boolean = false): void {
     if (modelNames.length === 0) return;
     
     const placeholders = modelNames.map(() => '?').join(',');
@@ -1250,7 +1252,14 @@ export class XppSymbolIndex {
     stmt.run(...modelNames);
     
     console.log(`🗑️  Cleared symbols for models: ${modelNames.join(', ')}`);
-    this.vacuum();
+    
+    if (shouldVacuum) {
+      console.log('🧹 Running VACUUM to optimize database...');
+      this.vacuum();
+      console.log('✅ VACUUM completed');
+    } else {
+      console.log('⏭️  Skipping VACUUM for faster incremental build');
+    }
   }
 
   /**

--- a/src/tools/enumInfo.ts
+++ b/src/tools/enumInfo.ts
@@ -1,0 +1,264 @@
+/**
+ * Get Enum Info Tool
+ * Extract enum values and Extended Data Type (EDT) properties
+ * Returns enum values with labels, EDT configuration
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+import { promises as fs } from 'fs';
+import { parseStringPromise } from 'xml2js';
+
+const GetEnumInfoArgsSchema = z.object({
+  enumName: z.string().describe('Name of the enum or EDT'),
+  modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
+  includeLabels: z.boolean().optional().default(true).describe('Include enum value labels'),
+  includeWorkspace: z.boolean().optional().default(false).describe('Include workspace files'),
+  workspacePath: z.string().optional().describe('Path to workspace'),
+});
+
+interface EnumValue {
+  name: string;
+  value: number;
+  label?: string;
+}
+
+interface EnumInfo {
+  name: string;
+  model: string;
+  type: 'enum' | 'edt';
+  isExtensible: boolean;
+  useEnumValue: boolean;
+  values: EnumValue[];
+  baseType?: string;
+  edtProperties?: Record<string, string>;
+}
+
+export async function getEnumInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = GetEnumInfoArgsSchema.parse(request.params.arguments);
+    const { symbolIndex } = context;
+    const { 
+      enumName, 
+      modelName, 
+      includeLabels
+    } = args;
+
+    // 1. Try to find as enum first
+    let stmt;
+    if (modelName) {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name, type
+        FROM symbols
+        WHERE (type = 'enum' OR type = 'edt') AND name = ? AND model = ?
+        LIMIT 1
+      `);
+      var enumRow = stmt.get(enumName, modelName) as any;
+    } else {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name, type
+        FROM symbols
+        WHERE (type = 'enum' OR type = 'edt') AND name = ?
+        ORDER BY model
+        LIMIT 1
+      `);
+      var enumRow = stmt.get(enumName) as any;
+    }
+
+    if (!enumRow) {
+      throw new Error(`Enum or EDT "${enumName}" not found. Make sure it's indexed.`);
+    }
+
+    // 2. Parse XML
+    const xmlContent = await fs.readFile(enumRow.file_path, 'utf-8');
+    const xmlObj = await parseStringPromise(xmlContent);
+
+    // 3. Extract enum/EDT info
+    const enumInfo: EnumInfo = {
+      name: enumName,
+      model: enumRow.model,
+      type: enumRow.type === 'edt' ? 'edt' : 'enum',
+      isExtensible: false,
+      useEnumValue: false,
+      values: [],
+    };
+
+    // Check if it's an enum
+    if (xmlObj.AxEnum) {
+      extractEnumInfo(xmlObj.AxEnum, enumInfo, includeLabels);
+    }
+    // Check if it's an EDT
+    else if (xmlObj.AxEdt) {
+      extractEdtInfo(xmlObj.AxEdt, enumInfo);
+    } else {
+      throw new Error('Invalid enum or EDT XML structure');
+    }
+
+    // 4. Format output
+    return formatEnumOutput(enumInfo, includeLabels);
+
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `❌ Error getting enum info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Extract enum information
+ */
+function extractEnumInfo(axEnum: any, enumInfo: EnumInfo, includeLabels: boolean): void {
+  // Extract properties
+  if (axEnum.IsExtensible) {
+    enumInfo.isExtensible = axEnum.IsExtensible[0] === 'Yes';
+  }
+
+  if (axEnum.UseEnumValue) {
+    enumInfo.useEnumValue = axEnum.UseEnumValue[0] === 'Yes';
+  }
+
+  // Extract enum values
+  if (axEnum.EnumValues && axEnum.EnumValues[0] && axEnum.EnumValues[0].AxEnumValue) {
+    for (const valueNode of axEnum.EnumValues[0].AxEnumValue) {
+      const value: EnumValue = {
+        name: valueNode.Name ? valueNode.Name[0] : 'Unknown',
+        value: valueNode.Value ? parseInt(valueNode.Value[0], 10) : 0,
+      };
+
+      if (includeLabels && valueNode.Label) {
+        value.label = valueNode.Label[0];
+      }
+
+      enumInfo.values.push(value);
+    }
+  }
+}
+
+/**
+ * Extract EDT information
+ */
+function extractEdtInfo(axEdt: any, enumInfo: EnumInfo): void {
+  enumInfo.edtProperties = {};
+
+  // Extract base type
+  if (axEdt.Extends) {
+    enumInfo.baseType = axEdt.Extends[0];
+  }
+
+  // Extract common EDT properties
+  const edtProps = [
+    'StringSize',
+    'DisplayLength',
+    'Label',
+    'HelpText',
+    'FormHelp',
+    'Alignment',
+    'DecimalSeparator',
+    'SignDisplay',
+    'NoOfDecimals',
+    'EnumType',
+  ];
+
+  for (const prop of edtProps) {
+    if (axEdt[prop]) {
+      enumInfo.edtProperties[prop] = axEdt[prop][0];
+    }
+  }
+
+  // If EDT is based on enum, get enum reference
+  if (axEdt.EnumType) {
+    enumInfo.baseType = axEdt.EnumType[0];
+  }
+}
+
+/**
+ * Format enum output
+ */
+function formatEnumOutput(enumInfo: EnumInfo, includeLabels: boolean): any {
+  let output = `# ${enumInfo.type === 'edt' ? 'Extended Data Type' : 'Enum'}: \`${enumInfo.name}\`\n\n`;
+  output += `**Model:** ${enumInfo.model}\n`;
+
+  if (enumInfo.type === 'enum') {
+    output += `**Extensible:** ${enumInfo.isExtensible ? '✅' : '❌'}\n`;
+    output += `**Use Enum Value:** ${enumInfo.useEnumValue ? '✅' : '❌'}\n`;
+    output += `\n`;
+
+    // Enum values
+    if (enumInfo.values.length > 0) {
+      output += `## 📋 Enum Values (${enumInfo.values.length})\n\n`;
+      output += `| Name | Value${includeLabels ? ' | Label' : ''} |\n`;
+      output += `|------|-------${includeLabels ? '|-------' : ''}|\n`;
+
+      for (const value of enumInfo.values) {
+        output += `| ${value.name} | ${value.value}`;
+        if (includeLabels) {
+          output += ` | ${value.label || '-'}`;
+        }
+        output += ` |\n`;
+      }
+      output += `\n`;
+    }
+
+    // Usage example
+    output += `## 💡 Usage Example\n\n`;
+    output += `\`\`\`xpp\n`;
+    output += `// Assign enum value\n`;
+    output += `${enumInfo.name} myEnum = ${enumInfo.name}::${enumInfo.values[0]?.name || 'Value'};\n\n`;
+    output += `// Compare enum value\n`;
+    output += `if (myEnum == ${enumInfo.name}::${enumInfo.values[0]?.name || 'Value'})\n`;
+    output += `{\n`;
+    output += `    // Do something\n`;
+    output += `}\n`;
+    output += `\`\`\`\n`;
+
+  } else {
+    // EDT
+    output += `\n`;
+
+    if (enumInfo.baseType) {
+      output += `**Base Type:** \`${enumInfo.baseType}\`\n\n`;
+    }
+
+    if (enumInfo.edtProperties && Object.keys(enumInfo.edtProperties).length > 0) {
+      output += `## 🔧 Properties\n\n`;
+      output += `| Property | Value |\n`;
+      output += `|----------|-------|\n`;
+
+      for (const [key, value] of Object.entries(enumInfo.edtProperties)) {
+        output += `| ${key} | ${value} |\n`;
+      }
+      output += `\n`;
+    }
+
+    // Usage example
+    output += `## 💡 Usage Example\n\n`;
+    output += `\`\`\`xpp\n`;
+    output += `// Declare variable\n`;
+    output += `${enumInfo.name} myValue;\n\n`;
+    output += `// Assign value\n`;
+    output += `myValue = "example";\n`;
+    output += `\`\`\`\n`;
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: output,
+      },
+    ],
+  };
+}
+
+export const getEnumInfoToolDefinition = {
+  name: 'get_enum_info',
+  description: '🏷️ Extract enum values and Extended Data Type (EDT) properties. Returns enum values with labels and numeric values, or EDT configuration (StringSize, Label, etc.). Essential for understanding enum options and EDT constraints.',
+  inputSchema: GetEnumInfoArgsSchema,
+};

--- a/src/tools/findReferences.ts
+++ b/src/tools/findReferences.ts
@@ -1,0 +1,527 @@
+/**
+ * Find References Tool
+ * Find all usages of a symbol (method, class, field, table)
+ * Critical for understanding impact before making changes
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const FindReferencesArgsSchema = z.object({
+  symbolName: z.string().describe('Name of the symbol to find references for'),
+  symbolType: z.enum(['method', 'class', 'table', 'field', 'enum']).optional().describe('Type of symbol (helps narrow search)'),
+  scope: z.enum(['all', 'workspace', 'standard', 'custom']).optional().default('all').describe('Search scope'),
+  limit: z.number().optional().default(50).describe('Maximum results to return'),
+  includeContext: z.boolean().optional().default(true).describe('Include code context around reference'),
+});
+
+interface Reference {
+  file: string;
+  model: string;
+  line?: number;
+  context: string;
+  referenceType: 'call' | 'extends' | 'implements' | 'field-access' | 'instantiation' | 'type-reference';
+  caller?: string;
+}
+
+export async function findReferencesTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = FindReferencesArgsSchema.parse(request.params.arguments);
+    const { symbolIndex } = context;
+    const { symbolName, symbolType, scope, limit, includeContext } = args;
+
+    // Build search patterns
+    const references: Reference[] = [];
+    let totalReferences = 0;
+
+    // 1. Search for method calls
+    if (!symbolType || symbolType === 'method') {
+      const methodRefs = findMethodReferences(symbolIndex, symbolName, scope, limit);
+      references.push(...methodRefs);
+    }
+
+    // 2. Search for class references (extends, implements, instantiations)
+    if (!symbolType || symbolType === 'class') {
+      const classRefs = findClassReferences(symbolIndex, symbolName, scope, limit);
+      references.push(...classRefs);
+    }
+
+    // 3. Search for table references (select statements, table buffers)
+    if (!symbolType || symbolType === 'table') {
+      const tableRefs = findTableReferences(symbolIndex, symbolName, scope, limit);
+      references.push(...tableRefs);
+    }
+
+    // 4. Search for field references
+    if (!symbolType || symbolType === 'field') {
+      const fieldRefs = findFieldReferences(symbolIndex, symbolName, scope, limit);
+      references.push(...fieldRefs);
+    }
+
+    // 5. Search for enum references
+    if (!symbolType || symbolType === 'enum') {
+      const enumRefs = findEnumReferences(symbolIndex, symbolName, scope, limit);
+      references.push(...enumRefs);
+    }
+
+    // Limit results
+    totalReferences = references.length;
+    const limitedReferences = references.slice(0, limit);
+
+    // Generate summary
+    const summary = generateReferenceSummary(limitedReferences);
+
+    // Format output
+    let output = `# References to \`${symbolName}\`\n\n`;
+    output += `**Total References Found:** ${totalReferences}\n`;
+    output += `**Showing:** ${limitedReferences.length} results\n`;
+    if (symbolType) {
+      output += `**Symbol Type:** ${symbolType}\n`;
+    }
+    output += `**Scope:** ${scope}\n\n`;
+
+    if (limitedReferences.length === 0) {
+      output += `No references found for \`${symbolName}\`.\n\n`;
+      output += `**Possible reasons:**\n`;
+      output += `- Symbol might be unused\n`;
+      output += `- Symbol might be defined but not yet indexed\n`;
+      output += `- Try search without symbolType to broaden results\n`;
+    } else {
+      // Group by reference type
+      const byType = groupByReferenceType(limitedReferences);
+
+      output += `## 📊 Summary by Type\n\n`;
+      for (const [type, refs] of Object.entries(byType)) {
+        output += `- **${type}**: ${refs.length} reference(s)\n`;
+      }
+      output += `\n`;
+
+      // Show top callers
+      if (summary.topCallers.length > 0) {
+        output += `## 🔝 Top Callers\n\n`;
+        for (const caller of summary.topCallers.slice(0, 10)) {
+          output += `- **${caller.caller}** (${caller.count} call(s))\n`;
+        }
+        output += `\n`;
+      }
+
+      // List all references
+      output += `## 📍 All References\n\n`;
+      for (const ref of limitedReferences) {
+        output += `### ${ref.referenceType} in \`${ref.file}\`\n\n`;
+        output += `**Model:** ${ref.model}\n`;
+        if (ref.caller) {
+          output += `**Caller:** ${ref.caller}\n`;
+        }
+        if (includeContext && ref.context) {
+          output += `\n**Context:**\n\`\`\`xpp\n${ref.context}\n\`\`\`\n`;
+        }
+        output += `\n`;
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: output,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error finding references: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Find method call references
+ */
+function findMethodReferences(symbolIndex: any, methodName: string, _scope: string, limit: number): Reference[] {
+  const references: Reference[] = [];
+
+  // Search in method bodies for method calls
+  // Pattern: .methodName( or ::methodName(
+  const patterns = [
+    `%.${methodName}(%`,
+    `%::${methodName}(%`,
+    `% ${methodName}(%`,
+  ];
+
+  for (const pattern of patterns) {
+    const stmt = symbolIndex.db.prepare(`
+      SELECT 
+        s.name as caller_name,
+        s.parent_name,
+        s.file_path,
+        s.model,
+        s.source_snippet
+      FROM symbols s
+      WHERE s.type = 'method'
+        AND (s.source_snippet LIKE ? OR s.signature LIKE ?)
+      ORDER BY s.name
+      LIMIT ?
+    `);
+
+    const rows = stmt.all(pattern, pattern, limit);
+
+    for (const row of rows) {
+      const context = extractMethodCallContext(row.source_snippet, methodName);
+      if (context) {
+        references.push({
+          file: row.file_path,
+          model: row.model,
+          context: context,
+          referenceType: 'call',
+          caller: row.parent_name ? `${row.parent_name}.${row.caller_name}` : row.caller_name,
+        });
+      }
+    }
+  }
+
+  return references;
+}
+
+/**
+ * Find class references (extends, implements, instantiations)
+ */
+function findClassReferences(symbolIndex: any, className: string, _scope: string, limit: number): Reference[] {
+  const references: Reference[] = [];
+
+  // 1. Find classes that extend this class
+  const extendsStmt = symbolIndex.db.prepare(`
+    SELECT name, file_path, model, extends_class
+    FROM symbols
+    WHERE type = 'class'
+      AND extends_class = ?
+    LIMIT ?
+  `);
+
+  const extendRows = extendsStmt.all(className, limit);
+  for (const row of extendRows) {
+    references.push({
+      file: row.file_path,
+      model: row.model,
+      context: `class ${row.name} extends ${className}`,
+      referenceType: 'extends',
+      caller: row.name,
+    });
+  }
+
+  // 2. Find classes that implement this interface
+  const implementsStmt = symbolIndex.db.prepare(`
+    SELECT name, file_path, model, implements_interfaces
+    FROM symbols
+    WHERE type = 'class'
+      AND implements_interfaces LIKE ?
+    LIMIT ?
+  `);
+
+  const implRows = implementsStmt.all(`%${className}%`, limit);
+  for (const row of implRows) {
+    if (row.implements_interfaces && row.implements_interfaces.includes(className)) {
+      references.push({
+        file: row.file_path,
+        model: row.model,
+        context: `class ${row.name} implements ${className}`,
+        referenceType: 'implements',
+        caller: row.name,
+      });
+    }
+  }
+
+  // 3. Find instantiations (new ClassName())
+  const instantiationStmt = symbolIndex.db.prepare(`
+    SELECT 
+      s.name,
+      s.parent_name,
+      s.file_path,
+      s.model,
+      s.source_snippet
+    FROM symbols s
+    WHERE s.type = 'method'
+      AND s.source_snippet LIKE ?
+    LIMIT ?
+  `);
+
+  const instRows = instantiationStmt.all(`%new ${className}(%`, limit);
+  for (const row of instRows) {
+    const context = extractInstantiationContext(row.source_snippet, className);
+    if (context) {
+      references.push({
+        file: row.file_path,
+        model: row.model,
+        context: context,
+        referenceType: 'instantiation',
+        caller: row.parent_name ? `${row.parent_name}.${row.name}` : row.name,
+      });
+    }
+  }
+
+  return references;
+}
+
+/**
+ * Find table references (select statements, table buffers)
+ */
+function findTableReferences(symbolIndex: any, tableName: string, _scope: string, limit: number): Reference[] {
+  const references: Reference[] = [];
+
+  // Search for table usage in methods
+  // Patterns: "TableName table;", "select * from TableName", "TableName::find()"
+  const patterns = [
+    `%${tableName} %`,
+    `%from ${tableName}%`,
+    `%${tableName}::%`,
+  ];
+
+  const stmt = symbolIndex.db.prepare(`
+    SELECT 
+      s.name,
+      s.parent_name,
+      s.file_path,
+      s.model,
+      s.source_snippet
+    FROM symbols s
+    WHERE s.type = 'method'
+      AND (s.source_snippet LIKE ? OR s.source_snippet LIKE ? OR s.source_snippet LIKE ?)
+    LIMIT ?
+  `);
+
+  const rows = stmt.all(...patterns, limit);
+
+  for (const row of rows) {
+    const context = extractTableReferenceContext(row.source_snippet, tableName);
+    if (context) {
+      references.push({
+        file: row.file_path,
+        model: row.model,
+        context: context,
+        referenceType: 'type-reference',
+        caller: row.parent_name ? `${row.parent_name}.${row.name}` : row.name,
+      });
+    }
+  }
+
+  return references;
+}
+
+/**
+ * Find field references
+ */
+function findFieldReferences(symbolIndex: any, fieldName: string, _scope: string, limit: number): Reference[] {
+  const references: Reference[] = [];
+
+  // Search for field access: .fieldName or this.fieldName
+  const stmt = symbolIndex.db.prepare(`
+    SELECT 
+      s.name,
+      s.parent_name,
+      s.file_path,
+      s.model,
+      s.source_snippet
+    FROM symbols s
+    WHERE s.type = 'method'
+      AND s.source_snippet LIKE ?
+    LIMIT ?
+  `);
+
+  const rows = stmt.all(`%.${fieldName}%`, limit);
+
+  for (const row of rows) {
+    const context = extractFieldAccessContext(row.source_snippet, fieldName);
+    if (context) {
+      references.push({
+        file: row.file_path,
+        model: row.model,
+        context: context,
+        referenceType: 'field-access',
+        caller: row.parent_name ? `${row.parent_name}.${row.name}` : row.name,
+      });
+    }
+  }
+
+  return references;
+}
+
+/**
+ * Find enum references
+ */
+function findEnumReferences(symbolIndex: any, enumName: string, _scope: string, limit: number): Reference[] {
+  const references: Reference[] = [];
+
+  // Search for enum usage: EnumName::Value
+  const stmt = symbolIndex.db.prepare(`
+    SELECT 
+      s.name,
+      s.parent_name,
+      s.file_path,
+      s.model,
+      s.source_snippet
+    FROM symbols s
+    WHERE s.type = 'method'
+      AND s.source_snippet LIKE ?
+    LIMIT ?
+  `);
+
+  const rows = stmt.all(`%${enumName}::%`, limit);
+
+  for (const row of rows) {
+    const context = extractEnumReferenceContext(row.source_snippet, enumName);
+    if (context) {
+      references.push({
+        file: row.file_path,
+        model: row.model,
+        context: context,
+        referenceType: 'type-reference',
+        caller: row.parent_name ? `${row.parent_name}.${row.name}` : row.name,
+      });
+    }
+  }
+
+  return references;
+}
+
+/**
+ * Extract context around method call
+ */
+function extractMethodCallContext(source: string, methodName: string): string | null {
+  if (!source) return null;
+
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(methodName + '(')) {
+      // Return 2 lines before and after
+      const start = Math.max(0, i - 2);
+      const end = Math.min(lines.length, i + 3);
+      return lines.slice(start, end).join('\n').trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract context around instantiation
+ */
+function extractInstantiationContext(source: string, className: string): string | null {
+  if (!source) return null;
+
+  const pattern = `new ${className}(`;
+  const lines = source.split('\n');
+  
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(pattern)) {
+      const start = Math.max(0, i - 1);
+      const end = Math.min(lines.length, i + 2);
+      return lines.slice(start, end).join('\n').trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract context around table reference
+ */
+function extractTableReferenceContext(source: string, tableName: string): string | null {
+  if (!source) return null;
+
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(tableName)) {
+      const start = Math.max(0, i - 1);
+      const end = Math.min(lines.length, i + 2);
+      return lines.slice(start, end).join('\n').trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract context around field access
+ */
+function extractFieldAccessContext(source: string, fieldName: string): string | null {
+  if (!source) return null;
+
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('.' + fieldName)) {
+      const start = Math.max(0, i - 1);
+      const end = Math.min(lines.length, i + 2);
+      return lines.slice(start, end).join('\n').trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract context around enum reference
+ */
+function extractEnumReferenceContext(source: string, enumName: string): string | null {
+  if (!source) return null;
+
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(enumName + '::')) {
+      const start = Math.max(0, i - 1);
+      const end = Math.min(lines.length, i + 2);
+      return lines.slice(start, end).join('\n').trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Generate reference summary
+ */
+function generateReferenceSummary(references: Reference[]): {
+  topCallers: Array<{ caller: string; count: number }>;
+} {
+  const callerCounts = new Map<string, number>();
+
+  for (const ref of references) {
+    if (ref.caller) {
+      callerCounts.set(ref.caller, (callerCounts.get(ref.caller) || 0) + 1);
+    }
+  }
+
+  const topCallers = Array.from(callerCounts.entries())
+    .map(([caller, count]) => ({ caller, count }))
+    .sort((a, b) => b.count - a.count);
+
+  return { topCallers };
+}
+
+/**
+ * Group references by type
+ */
+function groupByReferenceType(references: Reference[]): Record<string, Reference[]> {
+  const groups: Record<string, Reference[]> = {};
+
+  for (const ref of references) {
+    if (!groups[ref.referenceType]) {
+      groups[ref.referenceType] = [];
+    }
+    groups[ref.referenceType].push(ref);
+  }
+
+  return groups;
+}
+
+export const findReferencesToolDefinition = {
+  name: 'find_references',
+  description: '🔍 Find all usages of a symbol (method, class, field, table, enum). Shows where the symbol is called, extended, implemented, or referenced. Critical for understanding impact before making changes. Use this instead of code_search which hangs on large workspaces.',
+  inputSchema: FindReferencesArgsSchema,
+};

--- a/src/tools/formInfo.ts
+++ b/src/tools/formInfo.ts
@@ -1,0 +1,412 @@
+/**
+ * Get Form Info Tool
+ * Extract form structure: controls, datasources, methods
+ * Returns control hierarchy, datasource configuration, form methods
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+import { promises as fs } from 'fs';
+import { parseStringPromise } from 'xml2js';
+
+const GetFormInfoArgsSchema = z.object({
+  formName: z.string().describe('Name of the form'),
+  modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
+  includeControls: z.boolean().optional().default(true).describe('Include control hierarchy'),
+  includeDataSources: z.boolean().optional().default(true).describe('Include datasource information'),
+  includeMethods: z.boolean().optional().default(true).describe('Include form methods'),
+  includeWorkspace: z.boolean().optional().default(false).describe('Include workspace files'),
+  workspacePath: z.string().optional().describe('Path to workspace'),
+});
+
+interface FormControl {
+  name: string;
+  type: string;
+  properties: Record<string, string>;
+  children: FormControl[];
+}
+
+interface FormDataSource {
+  name: string;
+  table: string;
+  allowEdit: boolean;
+  allowCreate: boolean;
+  allowDelete: boolean;
+  fields: string[];
+  methods: string[];
+}
+
+interface FormMethod {
+  name: string;
+  signature: string;
+}
+
+interface FormInfo {
+  name: string;
+  model: string;
+  design: FormControl[];
+  dataSources: FormDataSource[];
+  methods: FormMethod[];
+}
+
+export async function getFormInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = GetFormInfoArgsSchema.parse(request.params.arguments);
+    const { symbolIndex } = context;
+    const { 
+      formName, 
+      modelName, 
+      includeControls, 
+      includeDataSources, 
+      includeMethods
+    } = args;
+
+    // 1. Find the form
+    let stmt;
+    if (modelName) {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name
+        FROM symbols
+        WHERE type = 'form' AND name = ? AND model = ?
+        LIMIT 1
+      `);
+      var formRow = stmt.get(formName, modelName) as any;
+    } else {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name
+        FROM symbols
+        WHERE type = 'form' AND name = ?
+        ORDER BY model
+        LIMIT 1
+      `);
+      var formRow = stmt.get(formName) as any;
+    }
+
+    if (!formRow) {
+      throw new Error(`Form "${formName}" not found. Make sure it's indexed.`);
+    }
+
+    // 2. Parse XML
+    const xmlContent = await fs.readFile(formRow.file_path, 'utf-8');
+    const xmlObj = await parseStringPromise(xmlContent);
+
+    // 3. Extract form info
+    const formInfo: FormInfo = {
+      name: formName,
+      model: formRow.model,
+      design: [],
+      dataSources: [],
+      methods: [],
+    };
+
+    const axForm = xmlObj.AxForm;
+    if (!axForm) {
+      throw new Error('Invalid AxForm XML structure');
+    }
+
+    // Extract data sources
+    if (includeDataSources && axForm.DataSources) {
+      formInfo.dataSources = extractDataSources(axForm.DataSources[0]);
+    }
+
+    // Extract design (controls)
+    if (includeControls && axForm.Design) {
+      formInfo.design = extractControls(axForm.Design[0]);
+    }
+
+    // Extract methods
+    if (includeMethods && axForm.Methods) {
+      formInfo.methods = extractMethods(axForm.Methods[0]);
+    }
+
+    // 4. Format output
+    return formatFormOutput(formInfo, includeControls, includeDataSources, includeMethods);
+
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `❌ Error getting form info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Extract datasources from form XML
+ */
+function extractDataSources(dataSourcesNode: any): FormDataSource[] {
+  const dataSources: FormDataSource[] = [];
+
+  if (!dataSourcesNode.AxFormDataSourceRoot) {
+    return dataSources;
+  }
+
+  for (const dsNode of dataSourcesNode.AxFormDataSourceRoot) {
+    const ds: FormDataSource = {
+      name: dsNode.Name ? dsNode.Name[0] : 'Unknown',
+      table: dsNode.Table ? dsNode.Table[0] : 'Unknown',
+      allowEdit: dsNode.AllowEdit ? dsNode.AllowEdit[0] === 'Yes' : true,
+      allowCreate: dsNode.AllowCreate ? dsNode.AllowCreate[0] === 'Yes' : true,
+      allowDelete: dsNode.AllowDelete ? dsNode.AllowDelete[0] === 'Yes' : true,
+      fields: [],
+      methods: [],
+    };
+
+    // Extract fields
+    if (dsNode.Fields && dsNode.Fields[0]) {
+      ds.fields = extractDataSourceFields(dsNode.Fields[0]);
+    }
+
+    // Extract methods
+    if (dsNode.Methods && dsNode.Methods[0] && dsNode.Methods[0].Method) {
+      ds.methods = dsNode.Methods[0].Method.map((m: any) => m.Name ? m.Name[0] : 'Unknown');
+    }
+
+    dataSources.push(ds);
+  }
+
+  return dataSources;
+}
+
+/**
+ * Extract fields from datasource
+ */
+function extractDataSourceFields(fieldsNode: any): string[] {
+  const fields: string[] = [];
+
+  if (fieldsNode.AxFormDataSourceField) {
+    for (const fieldNode of fieldsNode.AxFormDataSourceField) {
+      const fieldName = fieldNode.DataField ? fieldNode.DataField[0] : 'Unknown';
+      fields.push(fieldName);
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Extract controls from design
+ */
+function extractControls(designNode: any): FormControl[] {
+  const controls: FormControl[] = [];
+
+  // Find root container (usually FormDesign)
+  const rootKeys = Object.keys(designNode).filter(k => k.startsWith('AxForm'));
+  
+  for (const key of rootKeys) {
+    const nodes = designNode[key];
+    if (Array.isArray(nodes)) {
+      for (const node of nodes) {
+        const control = extractControl(node, key);
+        if (control) {
+          controls.push(control);
+        }
+      }
+    }
+  }
+
+  return controls;
+}
+
+/**
+ * Extract single control
+ */
+function extractControl(node: any, nodeType: string): FormControl | null {
+  if (!node) return null;
+
+  const control: FormControl = {
+    name: node.Name ? node.Name[0] : 'Unknown',
+    type: nodeType.replace('AxForm', ''),
+    properties: {},
+    children: [],
+  };
+
+  // Extract common properties
+  const propertiesToExtract = [
+    'Caption',
+    'Visible',
+    'Enabled',
+    'AutoDeclaration',
+    'DataSource',
+    'DataField',
+    'DataMethod',
+    'HelpText',
+    'Label',
+    'Width',
+    'Height',
+  ];
+
+  for (const prop of propertiesToExtract) {
+    if (node[prop]) {
+      control.properties[prop] = node[prop][0];
+    }
+  }
+
+  // Recursively extract child controls
+  const childKeys = Object.keys(node).filter(k => k.startsWith('AxForm') && k !== nodeType);
+  
+  for (const childKey of childKeys) {
+    const childNodes = node[childKey];
+    if (Array.isArray(childNodes)) {
+      for (const childNode of childNodes) {
+        const childControl = extractControl(childNode, childKey);
+        if (childControl) {
+          control.children.push(childControl);
+        }
+      }
+    }
+  }
+
+  return control;
+}
+
+/**
+ * Extract methods from form
+ */
+function extractMethods(methodsNode: any): FormMethod[] {
+  const methods: FormMethod[] = [];
+
+  if (!methodsNode.Method) {
+    return methods;
+  }
+
+  for (const methodNode of methodsNode.Method) {
+    const name = methodNode.Name ? methodNode.Name[0] : 'Unknown';
+    const source = methodNode.Source ? methodNode.Source[0] : '';
+    
+    // Extract first line as signature
+    const signature = source.split('\n')[0].trim();
+
+    methods.push({
+      name,
+      signature,
+    });
+  }
+
+  return methods;
+}
+
+/**
+ * Format form output
+ */
+function formatFormOutput(
+  formInfo: FormInfo,
+  includeControls: boolean,
+  includeDataSources: boolean,
+  includeMethods: boolean
+): any {
+  let output = `# Form: \`${formInfo.name}\`\n\n`;
+  output += `**Model:** ${formInfo.model}\n\n`;
+
+  // Data Sources
+  if (includeDataSources && formInfo.dataSources.length > 0) {
+    output += `## 📊 Data Sources\n\n`;
+    for (const ds of formInfo.dataSources) {
+      output += `### ${ds.name}\n\n`;
+      output += `**Table:** \`${ds.table}\`\n`;
+      output += `**Permissions:**\n`;
+      output += `- Allow Edit: ${ds.allowEdit ? '✅' : '❌'}\n`;
+      output += `- Allow Create: ${ds.allowCreate ? '✅' : '❌'}\n`;
+      output += `- Allow Delete: ${ds.allowDelete ? '✅' : '❌'}\n`;
+      
+      if (ds.fields.length > 0) {
+        output += `\n**Fields (${ds.fields.length}):**\n`;
+        for (const field of ds.fields.slice(0, 20)) {
+          output += `- ${field}\n`;
+        }
+        if (ds.fields.length > 20) {
+          output += `- ... (${ds.fields.length - 20} more fields)\n`;
+        }
+      }
+
+      if (ds.methods.length > 0) {
+        output += `\n**Methods (${ds.methods.length}):**\n`;
+        for (const method of ds.methods) {
+          output += `- ${method}\n`;
+        }
+      }
+
+      output += `\n`;
+    }
+  }
+
+  // Design (Controls)
+  if (includeControls && formInfo.design.length > 0) {
+    output += `## 🎨 Design (Controls)\n\n`;
+    output += formatControlHierarchy(formInfo.design, 0);
+  }
+
+  // Methods
+  if (includeMethods && formInfo.methods.length > 0) {
+    output += `## 🔧 Form Methods\n\n`;
+    for (const method of formInfo.methods) {
+      output += `### ${method.name}\n\n`;
+      output += `\`\`\`xpp\n${method.signature}\n\`\`\`\n\n`;
+    }
+  }
+
+  // Summary
+  output += `## 📈 Summary\n\n`;
+  output += `- **Data Sources:** ${formInfo.dataSources.length}\n`;
+  output += `- **Controls:** ${countControls(formInfo.design)}\n`;
+  output += `- **Methods:** ${formInfo.methods.length}\n`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: output,
+      },
+    ],
+  };
+}
+
+/**
+ * Format control hierarchy
+ */
+function formatControlHierarchy(controls: FormControl[], indent: number): string {
+  let output = '';
+  const indentStr = '  '.repeat(indent);
+
+  for (const control of controls) {
+    output += `${indentStr}- **${control.name}** (${control.type})\n`;
+    
+    const importantProps = ['Caption', 'DataSource', 'DataField', 'Visible', 'Enabled'];
+    const propsToShow = Object.entries(control.properties)
+      .filter(([key]) => importantProps.includes(key))
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(', ');
+    
+    if (propsToShow) {
+      output += `${indentStr}  *${propsToShow}*\n`;
+    }
+
+    if (control.children.length > 0) {
+      output += formatControlHierarchy(control.children, indent + 1);
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Count total controls recursively
+ */
+function countControls(controls: FormControl[]): number {
+  let count = controls.length;
+  for (const control of controls) {
+    count += countControls(control.children);
+  }
+  return count;
+}
+
+export const getFormInfoToolDefinition = {
+  name: 'get_form_info',
+  description: '📋 Extract form structure: controls, datasources, methods. Returns control hierarchy with properties, datasource configuration (table, permissions, fields), and form methods. Essential for understanding form layout and adding controls or datasource methods.',
+  inputSchema: GetFormInfoArgsSchema,
+};

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -1,0 +1,415 @@
+/**
+ * Get Method Signature Tool
+ * Extract exact method signature for Chain of Command (CoC) extensions
+ * Returns method modifiers, return type, parameters with types
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+import { promises as fs } from 'fs';
+import { parseStringPromise } from 'xml2js';
+
+const GetMethodSignatureArgsSchema = z.object({
+  className: z.string().describe('Name of the class containing the method'),
+  methodName: z.string().describe('Name of the method'),
+  modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
+  includeWorkspace: z.boolean().optional().default(false).describe('Include workspace files'),
+  workspacePath: z.string().optional().describe('Path to workspace'),
+});
+
+interface MethodSignature {
+  modifiers: string[];
+  returnType: string;
+  methodName: string;
+  parameters: Array<{
+    type: string;
+    name: string;
+    defaultValue?: string;
+  }>;
+  signature: string;
+  cocTemplate: string;
+}
+
+export async function getMethodSignatureTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = GetMethodSignatureArgsSchema.parse(request.params.arguments);
+    const { symbolIndex } = context;
+    const { className, methodName, modelName } = args;
+
+    // 1. Find the class
+    let stmt;
+    if (modelName) {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name
+        FROM symbols
+        WHERE type = 'class' AND name = ? AND model = ?
+        LIMIT 1
+      `);
+      var classRow = stmt.get(className, modelName) as any;
+    } else {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name
+        FROM symbols
+        WHERE type = 'class' AND name = ?
+        ORDER BY model
+        LIMIT 1
+      `);
+      var classRow = stmt.get(className) as any;
+    }
+
+    if (!classRow) {
+      throw new Error(`Class "${className}" not found. Make sure it's indexed.`);
+    }
+
+    // 2. Find the method in database
+    const methodStmt = symbolIndex.db.prepare(`
+      SELECT name, signature, parent_name, file_path
+      FROM symbols
+      WHERE type = 'method'
+        AND name = ?
+        AND parent_name = ?
+      LIMIT 1
+    `);
+
+    const methodRow = methodStmt.get(methodName, className);
+
+    if (!methodRow) {
+      throw new Error(`Method "${methodName}" not found in class "${className}".`);
+    }
+
+    // 3. Parse XML to get exact signature
+    const xmlContent = await fs.readFile(classRow.file_path, 'utf-8');
+    const xmlObj = await parseStringPromise(xmlContent);
+
+    // 4. Extract method details
+    const methodSignature = extractMethodSignature(xmlObj, methodName);
+
+    if (!methodSignature) {
+      // Fallback to database info if XML parsing fails
+      const fallbackSignature = buildFallbackSignature(methodRow);
+      return formatOutput(className, methodName, fallbackSignature, classRow.model);
+    }
+
+    return formatOutput(className, methodName, methodSignature, classRow.model);
+
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `❌ Error getting method signature: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Extract method signature from parsed XML
+ */
+function extractMethodSignature(xmlObj: any, methodName: string): MethodSignature | null {
+  try {
+    const axClass = xmlObj.AxClass;
+    if (!axClass || !axClass.Methods || !axClass.Methods[0] || !axClass.Methods[0].Method) {
+      return null;
+    }
+
+    const methods = axClass.Methods[0].Method;
+    const method = methods.find((m: any) => m.Name && m.Name[0] === methodName);
+
+    if (!method) {
+      return null;
+    }
+
+    // Parse method source to extract signature
+    const source = method.Source ? method.Source[0] : '';
+    const signature = parseMethodSignature(source, methodName);
+
+    return signature;
+
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Parse method signature from source code
+ */
+function parseMethodSignature(source: string, methodName: string): MethodSignature | null {
+  if (!source) return null;
+
+  // Find method declaration line
+  const lines = source.split('\n');
+  let declarationLine = '';
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.includes(methodName) && trimmed.includes('(')) {
+      declarationLine = trimmed;
+      break;
+    }
+  }
+
+  if (!declarationLine) return null;
+
+  // Parse modifiers (public, private, protected, static, final, etc.)
+  const modifiers: string[] = [];
+  const modifierKeywords = ['public', 'private', 'protected', 'static', 'final', 'abstract', 'display'];
+  
+  for (const keyword of modifierKeywords) {
+    if (declarationLine.toLowerCase().includes(keyword)) {
+      modifiers.push(keyword);
+    }
+  }
+
+  // Parse return type
+  let returnType = 'void';
+  const returnTypeMatch = declarationLine.match(/(?:public|private|protected|static|final)?\s+(\w+)\s+\w+\s*\(/);
+  if (returnTypeMatch) {
+    returnType = returnTypeMatch[1];
+  }
+
+  // Parse parameters
+  const parametersMatch = declarationLine.match(/\((.*?)\)/);
+  const parameters: Array<{ type: string; name: string; defaultValue?: string }> = [];
+
+  if (parametersMatch && parametersMatch[1].trim()) {
+    const paramString = parametersMatch[1];
+    const paramParts = paramString.split(',');
+
+    for (const part of paramParts) {
+      const trimmed = part.trim();
+      const paramMatch = trimmed.match(/(\w+)\s+(_?\w+)(?:\s*=\s*(.+))?/);
+      
+      if (paramMatch) {
+        const param: any = {
+          type: paramMatch[1],
+          name: paramMatch[2],
+        };
+        
+        if (paramMatch[3]) {
+          param.defaultValue = paramMatch[3].trim();
+        }
+        
+        parameters.push(param);
+      }
+    }
+  }
+
+  // Build full signature
+  const signature = buildSignatureString(modifiers, returnType, methodName, parameters);
+
+  // Build CoC template
+  const cocTemplate = buildCoCTemplate(modifiers, returnType, methodName, parameters);
+
+  return {
+    modifiers,
+    returnType,
+    methodName,
+    parameters,
+    signature,
+    cocTemplate,
+  };
+}
+
+/**
+ * Build signature string
+ */
+function buildSignatureString(
+  modifiers: string[],
+  returnType: string,
+  methodName: string,
+  parameters: Array<{ type: string; name: string; defaultValue?: string }>
+): string {
+  let sig = '';
+
+  if (modifiers.length > 0) {
+    sig += modifiers.join(' ') + ' ';
+  }
+
+  sig += returnType + ' ' + methodName + '(';
+
+  const paramStrings = parameters.map(p => {
+    let ps = p.type + ' ' + p.name;
+    if (p.defaultValue) {
+      ps += ' = ' + p.defaultValue;
+    }
+    return ps;
+  });
+
+  sig += paramStrings.join(', ');
+  sig += ')';
+
+  return sig;
+}
+
+/**
+ * Build Chain of Command template
+ */
+function buildCoCTemplate(
+  modifiers: string[],
+  returnType: string,
+  methodName: string,
+  parameters: Array<{ type: string; name: string; defaultValue?: string }>
+): string {
+  let template = '';
+
+  // Add modifiers (replace public/private/protected with method attribute)
+  const cocModifiers = modifiers.filter(m => !['public', 'private', 'protected'].includes(m));
+  
+  template += '[ExtensionOf(classStr(OriginalClassName))]\n';
+  template += 'final class OriginalClassName_Extension\n';
+  template += '{\n';
+  template += '\t';
+
+  if (cocModifiers.length > 0) {
+    template += cocModifiers.join(' ') + ' ';
+  }
+
+  template += returnType + ' ' + methodName + '(';
+
+  const paramStrings = parameters.map(p => p.type + ' ' + p.name);
+  template += paramStrings.join(', ');
+  template += ')\n';
+  template += '\t{\n';
+  template += '\t\t// Pre-processing logic\n';
+  template += '\t\t\n';
+
+  // Build next() call
+  template += '\t\t';
+  if (returnType !== 'void') {
+    template += returnType + ' ret = ';
+  }
+  
+  template += 'next ' + methodName + '(';
+  template += parameters.map(p => p.name).join(', ');
+  template += ');\n';
+
+  template += '\t\t\n';
+  template += '\t\t// Post-processing logic\n';
+  template += '\t\t\n';
+
+  if (returnType !== 'void') {
+    template += '\t\treturn ret;\n';
+  }
+
+  template += '\t}\n';
+  template += '}\n';
+
+  return template;
+}
+
+/**
+ * Build fallback signature from database row
+ */
+function buildFallbackSignature(methodRow: any): MethodSignature {
+  // Parse modifiers and return type from signature if available
+  const signature = methodRow.signature || '';
+  
+  // Parse modifiers from signature
+  const modifiers: string[] = [];
+  const keywords = ['public', 'private', 'protected', 'static', 'final', 'display', 'edit', 'client', 'server'];
+  for (const keyword of keywords) {
+    if (signature.toLowerCase().includes(keyword.toLowerCase())) {
+      modifiers.push(keyword);
+    }
+  }
+  
+  // Parse return type - find word before method name in signature
+  let returnType = 'void';
+  const signatureMatch = signature.match(/\b(\w+)\s+\w+\s*\(/);
+  if (signatureMatch) {
+    returnType = signatureMatch[1];
+  }
+  
+  const methodName = methodRow.name;
+  
+  // Parse parameters from signature
+  const parametersMatch = signature.match(/\((.*?)\)/);
+  const parameters: Array<{ type: string; name: string }> = [];
+
+  if (parametersMatch && parametersMatch[1].trim()) {
+    const paramString = parametersMatch[1];
+    const paramParts = paramString.split(',');
+
+    for (const part of paramParts) {
+      const trimmed = part.trim();
+      const paramMatch = trimmed.match(/(\w+)\s+(_?\w+)/);
+      
+      if (paramMatch) {
+        parameters.push({
+          type: paramMatch[1],
+          name: paramMatch[2],
+        });
+      }
+    }
+  }
+
+  const fullSignature = buildSignatureString(modifiers, returnType, methodName, parameters);
+  const cocTemplate = buildCoCTemplate(modifiers, returnType, methodName, parameters);
+
+  return {
+    modifiers,
+    returnType,
+    methodName,
+    parameters,
+    signature: fullSignature,
+    cocTemplate,
+  };
+}
+
+/**
+ * Format output
+ */
+function formatOutput(
+  className: string,
+  methodName: string,
+  signature: MethodSignature,
+  modelName: string
+): any {
+  let output = `# Method Signature: \`${className}.${methodName}\`\n\n`;
+  output += `**Model:** ${modelName}\n\n`;
+
+  output += `## 📝 Signature\n\n`;
+  output += `\`\`\`xpp\n${signature.signature}\n\`\`\`\n\n`;
+
+  output += `## 🔧 Details\n\n`;
+  output += `**Modifiers:** ${signature.modifiers.join(', ') || 'none'}\n`;
+  output += `**Return Type:** ${signature.returnType}\n`;
+  output += `**Parameters:** ${signature.parameters.length}\n\n`;
+
+  if (signature.parameters.length > 0) {
+    output += `### Parameters:\n\n`;
+    for (const param of signature.parameters) {
+      output += `- **${param.name}**: ${param.type}`;
+      if (param.defaultValue) {
+        output += ` = ${param.defaultValue}`;
+      }
+      output += '\n';
+    }
+    output += '\n';
+  }
+
+  output += `## 🔗 Chain of Command Template\n\n`;
+  output += `Use this template to extend the method:\n\n`;
+  output += `\`\`\`xpp\n${signature.cocTemplate}\`\`\`\n\n`;
+
+  output += `**Note:** Replace \`OriginalClassName\` with \`${className}\` in the template.\n`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: output,
+      },
+    ],
+  };
+}
+
+export const getMethodSignatureToolDefinition = {
+  name: 'get_method_signature',
+  description: '🔧 Extract exact method signature for Chain of Command (CoC) extensions. Returns method modifiers, return type, parameters with types, and generates ready-to-use CoC template. Essential for creating extensions without signature mismatches.',
+  inputSchema: GetMethodSignatureArgsSchema,
+};

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1,0 +1,454 @@
+/**
+ * Modify D365FO File Tool
+ * Edit existing D365FO XML files (AxClass, AxTable, AxForm, etc.)
+ * Supports atomic operations: add method, add field, modify property
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+import { promises as fs } from 'fs';
+import { parseStringPromise, Builder } from 'xml2js';
+
+const ModifyD365FileArgsSchema = z.object({
+  objectType: z.enum(['class', 'table', 'form', 'enum', 'query', 'view']).describe('Type of D365FO object'),
+  objectName: z.string().describe('Name of the object to modify'),
+  operation: z.enum(['add-method', 'add-field', 'modify-property', 'remove-method', 'remove-field']).describe('Operation to perform'),
+  
+  // For add-method
+  methodName: z.string().optional().describe('Name of method to add/remove'),
+  methodCode: z.string().optional().describe('X++ code for the method body'),
+  methodModifiers: z.string().optional().describe('Method modifiers (e.g., "public static")'),
+  methodReturnType: z.string().optional().describe('Return type of method'),
+  methodParameters: z.string().optional().describe('Method parameters (e.g., "str _param1, int _param2")'),
+  
+  // For add-field (tables)
+  fieldName: z.string().optional().describe('Name of field to add/remove'),
+  fieldType: z.string().optional().describe('Extended data type or base type'),
+  fieldMandatory: z.boolean().optional().describe('Is field mandatory'),
+  fieldLabel: z.string().optional().describe('Field label'),
+  
+  // For modify-property
+  propertyPath: z.string().optional().describe('Path to property (e.g., "Table1.Visible")'),
+  propertyValue: z.string().optional().describe('New property value'),
+  
+  // Options
+  createBackup: z.boolean().optional().default(true).describe('Create backup before modification'),
+  modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
+  workspacePath: z.string().optional().describe('Path to workspace for finding file'),
+});
+
+export async function modifyD365FileTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = ModifyD365FileArgsSchema.parse(request.params.arguments);
+    const { symbolIndex } = context;
+    const { 
+      objectType, 
+      objectName, 
+      operation, 
+      createBackup,
+      modelName,
+      workspacePath 
+    } = args;
+
+    // 1. Find the file
+    const filePath = await findD365File(symbolIndex, objectType, objectName, modelName, workspacePath);
+    
+    if (!filePath) {
+      throw new Error(`File not found for ${objectType} "${objectName}". Make sure the object exists and is indexed.`);
+    }
+
+    // 2. Create backup if requested
+    if (createBackup) {
+      await createFileBackup(filePath);
+    }
+
+    // 3. Read and parse XML
+    const xmlContent = await fs.readFile(filePath, 'utf-8');
+    const xmlObj = await parseStringPromise(xmlContent);
+
+    // 4. Perform operation
+    let modified = false;
+    let message = '';
+
+    switch (operation) {
+      case 'add-method':
+        modified = await addMethod(xmlObj, objectType, args);
+        message = `Added method "${args.methodName}" to ${objectType} "${objectName}"`;
+        break;
+      
+      case 'remove-method':
+        modified = await removeMethod(xmlObj, objectType, args);
+        message = `Removed method "${args.methodName}" from ${objectType} "${objectName}"`;
+        break;
+      
+      case 'add-field':
+        modified = await addField(xmlObj, objectType, args);
+        message = `Added field "${args.fieldName}" to ${objectType} "${objectName}"`;
+        break;
+      
+      case 'remove-field':
+        modified = await removeField(xmlObj, objectType, args);
+        message = `Removed field "${args.fieldName}" from ${objectType} "${objectName}"`;
+        break;
+      
+      case 'modify-property':
+        modified = await modifyProperty(xmlObj, objectType, args);
+        message = `Modified property "${args.propertyPath}" in ${objectType} "${objectName}"`;
+        break;
+      
+      default:
+        throw new Error(`Unsupported operation: ${operation}`);
+    }
+
+    if (!modified) {
+      throw new Error(`Failed to perform operation "${operation}". The object structure might be unexpected.`);
+    }
+
+    // 5. Write XML back
+    const builder = new Builder({
+      xmldec: { version: '1.0', encoding: 'utf-8' },
+      renderOpts: { pretty: true, indent: '\t', newline: '\n' },
+      headless: false,
+    });
+    
+    const newXml = builder.buildObject(xmlObj);
+    await fs.writeFile(filePath, newXml, 'utf-8');
+
+    // 6. Return success
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `✅ ${message}\n\n**File:** ${filePath}\n**Backup:** ${createBackup ? 'Created' : 'Skipped'}\n\n**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate\n- Commit changes to source control`,
+        },
+      ],
+    };
+
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `❌ Error modifying D365FO file: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Find D365FO file path
+ */
+async function findD365File(
+  symbolIndex: any,
+  objectType: string,
+  objectName: string,
+  modelName?: string,
+  _workspacePath?: string
+): Promise<string | null> {
+  // Map object type to symbol type
+  const typeMap: Record<string, string> = {
+    class: 'class',
+    table: 'table',
+    form: 'form',
+    enum: 'enum',
+    query: 'query',
+    view: 'view',
+  };
+
+  const symbolType = typeMap[objectType];
+  if (!symbolType) {
+    throw new Error(`Unsupported object type: ${objectType}`);
+  }
+
+  // Query database
+  let stmt;
+  if (modelName) {
+    stmt = symbolIndex.db.prepare(`
+      SELECT file_path
+      FROM symbols
+      WHERE type = ? AND name = ? AND model = ?
+      LIMIT 1
+    `);
+    const row = stmt.get(symbolType, objectName, modelName);
+    return row ? row.file_path : null;
+  } else {
+    stmt = symbolIndex.db.prepare(`
+      SELECT file_path
+      FROM symbols
+      WHERE type = ? AND name = ?
+      ORDER BY model
+      LIMIT 1
+    `);
+    const row = stmt.get(symbolType, objectName);
+    return row ? row.file_path : null;
+  }
+}
+
+/**
+ * Create file backup
+ */
+async function createFileBackup(filePath: string): Promise<void> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19);
+  const backupPath = `${filePath}.backup-${timestamp}`;
+  await fs.copyFile(filePath, backupPath);
+}
+
+/**
+ * Add method to class/table/form
+ */
+async function addMethod(xmlObj: any, objectType: string, args: any): Promise<boolean> {
+  const { methodName, methodCode, methodModifiers: _methodModifiers, methodReturnType: _methodReturnType, methodParameters: _methodParameters } = args;
+
+  if (!methodName) {
+    throw new Error('methodName is required for add-method operation');
+  }
+
+  // Navigate to Methods node
+  const rootKey = getRootKey(objectType);
+  const root = xmlObj[rootKey];
+  
+  if (!root || !root[0]) {
+    throw new Error(`Invalid XML structure: root node not found`);
+  }
+
+  let methodsNode = root[0].Methods;
+  if (!methodsNode) {
+    // Create Methods node if it doesn't exist
+    root[0].Methods = [{ Method: [] }];
+    methodsNode = root[0].Methods;
+  }
+
+  if (!methodsNode[0].Method) {
+    methodsNode[0].Method = [];
+  }
+
+  // Create method node
+  const newMethod = {
+    Name: [methodName],
+    Source: [methodCode || `// TODO: Implement ${methodName}\nreturn;`],
+  };
+
+  methodsNode[0].Method.push(newMethod);
+
+  return true;
+}
+
+/**
+ * Remove method from class/table/form
+ */
+async function removeMethod(xmlObj: any, objectType: string, args: any): Promise<boolean> {
+  const { methodName } = args;
+
+  if (!methodName) {
+    throw new Error('methodName is required for remove-method operation');
+  }
+
+  const rootKey = getRootKey(objectType);
+  const root = xmlObj[rootKey];
+
+  if (!root || !root[0] || !root[0].Methods || !root[0].Methods[0].Method) {
+    throw new Error('No methods found in object');
+  }
+
+  const methods = root[0].Methods[0].Method;
+  const index = methods.findIndex((m: any) => m.Name && m.Name[0] === methodName);
+
+  if (index === -1) {
+    throw new Error(`Method "${methodName}" not found`);
+  }
+
+  methods.splice(index, 1);
+  return true;
+}
+
+/**
+ * Add field to table
+ */
+async function addField(xmlObj: any, objectType: string, args: any): Promise<boolean> {
+  const { fieldName, fieldType, fieldMandatory, fieldLabel } = args;
+
+  if (!fieldName) {
+    throw new Error('fieldName is required for add-field operation');
+  }
+
+  if (!fieldType) {
+    throw new Error('fieldType is required for add-field operation');
+  }
+
+  if (objectType !== 'table') {
+    throw new Error('add-field operation is only supported for tables');
+  }
+
+  const rootKey = getRootKey(objectType);
+  const root = xmlObj[rootKey];
+
+  if (!root || !root[0]) {
+    throw new Error('Invalid XML structure: root node not found');
+  }
+
+  let fieldsNode = root[0].Fields;
+  if (!fieldsNode) {
+    root[0].Fields = [{ $: {}, AxTableField: [] }];
+    fieldsNode = root[0].Fields;
+  }
+
+  if (!fieldsNode[0].AxTableField) {
+    fieldsNode[0].AxTableField = [];
+  }
+
+  // Determine field type node name (AxTableFieldString, AxTableFieldInt, etc.)
+  const fieldNodeName = getFieldNodeName(fieldType);
+
+  // Create field node
+  const newField: any = {
+    Name: [fieldName],
+    ExtendedDataType: [fieldType],
+  };
+
+  if (fieldLabel) {
+    newField.Label = [fieldLabel];
+  }
+
+  if (fieldMandatory !== undefined) {
+    newField.Mandatory = [fieldMandatory ? 'Yes' : 'No'];
+  }
+
+  // Wrap in appropriate type node
+  const fieldWrapper: any = {};
+  fieldWrapper[fieldNodeName] = [newField];
+
+  fieldsNode[0].AxTableField.push(fieldWrapper);
+
+  return true;
+}
+
+/**
+ * Remove field from table
+ */
+async function removeField(xmlObj: any, objectType: string, args: any): Promise<boolean> {
+  const { fieldName } = args;
+
+  if (!fieldName) {
+    throw new Error('fieldName is required for remove-field operation');
+  }
+
+  if (objectType !== 'table') {
+    throw new Error('remove-field operation is only supported for tables');
+  }
+
+  const rootKey = getRootKey(objectType);
+  const root = xmlObj[rootKey];
+
+  if (!root || !root[0] || !root[0].Fields || !root[0].Fields[0].AxTableField) {
+    throw new Error('No fields found in table');
+  }
+
+  const fields = root[0].Fields[0].AxTableField;
+  const index = fields.findIndex((f: any) => {
+    // Field might be wrapped in different type nodes
+    const fieldObj = Object.values(f)[0];
+    return Array.isArray(fieldObj) && fieldObj[0].Name && fieldObj[0].Name[0] === fieldName;
+  });
+
+  if (index === -1) {
+    throw new Error(`Field "${fieldName}" not found`);
+  }
+
+  fields.splice(index, 1);
+  return true;
+}
+
+/**
+ * Modify property value
+ */
+async function modifyProperty(xmlObj: any, objectType: string, args: any): Promise<boolean> {
+  const { propertyPath, propertyValue } = args;
+
+  if (!propertyPath) {
+    throw new Error('propertyPath is required for modify-property operation');
+  }
+
+  if (propertyValue === undefined) {
+    throw new Error('propertyValue is required for modify-property operation');
+  }
+
+  // Parse property path (e.g., "Table1.Visible")
+  const parts = propertyPath.split('.');
+  
+  const rootKey = getRootKey(objectType);
+  let current = xmlObj[rootKey];
+
+  if (!current || !current[0]) {
+    throw new Error('Invalid XML structure');
+  }
+
+  current = current[0];
+
+  // Navigate to property
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (!current[part]) {
+      throw new Error(`Property path not found: ${propertyPath} (failed at "${part}")`);
+    }
+    current = current[part][0];
+  }
+
+  // Set property value
+  const lastPart = parts[parts.length - 1];
+  if (!current[lastPart]) {
+    current[lastPart] = [];
+  }
+  current[lastPart][0] = propertyValue;
+
+  return true;
+}
+
+/**
+ * Get root key for object type
+ */
+function getRootKey(objectType: string): string {
+  const keyMap: Record<string, string> = {
+    class: 'AxClass',
+    table: 'AxTable',
+    form: 'AxForm',
+    enum: 'AxEnum',
+    query: 'AxQuery',
+    view: 'AxView',
+  };
+
+  const key = keyMap[objectType];
+  if (!key) {
+    throw new Error(`Unknown object type: ${objectType}`);
+  }
+
+  return key;
+}
+
+/**
+ * Get field node name based on field type
+ */
+function getFieldNodeName(fieldType: string): string {
+  // Map EDT to field node type
+  const typeMap: Record<string, string> = {
+    String: 'AxTableFieldString',
+    Integer: 'AxTableFieldInt',
+    Real: 'AxTableFieldReal',
+    Date: 'AxTableFieldDate',
+    DateTime: 'AxTableFieldDateTime',
+    Enum: 'AxTableFieldEnum',
+    Int64: 'AxTableFieldInt64',
+    GUID: 'AxTableFieldGuid',
+  };
+
+  // Default to string if unknown
+  return typeMap[fieldType] || 'AxTableFieldString';
+}
+
+export const modifyD365FileToolDefinition = {
+  name: 'modify_d365fo_file',
+  description: '✏️ Edit existing D365FO XML files (AxClass, AxTable, AxForm, etc.). Supports atomic operations: add/remove methods, add/remove fields, modify properties. Creates automatic backups. Use this instead of manual file editing to ensure correct XML structure.',
+  inputSchema: ModifyD365FileArgsSchema,
+};

--- a/src/tools/queryInfo.ts
+++ b/src/tools/queryInfo.ts
@@ -1,0 +1,365 @@
+/**
+ * Get Query Info Tool
+ * Extract query structure: datasources, ranges, joins
+ * Returns datasource hierarchy, range definitions, join configuration
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+import { promises as fs } from 'fs';
+import { parseStringPromise } from 'xml2js';
+
+const GetQueryInfoArgsSchema = z.object({
+  queryName: z.string().describe('Name of the query'),
+  modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
+  includeRanges: z.boolean().optional().default(true).describe('Include range definitions'),
+  includeJoins: z.boolean().optional().default(true).describe('Include join information'),
+  includeFields: z.boolean().optional().default(true).describe('Include field list'),
+  includeWorkspace: z.boolean().optional().default(false).describe('Include workspace files'),
+  workspacePath: z.string().optional().describe('Path to workspace'),
+});
+
+interface QueryRange {
+  field: string;
+  value: string;
+  operator?: string;
+}
+
+interface QueryDataSource {
+  name: string;
+  table: string;
+  fetchMode: string;
+  ranges: QueryRange[];
+  joins: QueryDataSource[];
+  fields: string[];
+}
+
+interface QueryInfo {
+  name: string;
+  model: string;
+  description?: string;
+  dataSources: QueryDataSource[];
+}
+
+export async function getQueryInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = GetQueryInfoArgsSchema.parse(request.params.arguments);
+    const { symbolIndex } = context;
+    const { 
+      queryName, 
+      modelName, 
+      includeRanges, 
+      includeJoins, 
+      includeFields
+    } = args;
+
+    // 1. Find the query
+    let stmt;
+    if (modelName) {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name
+        FROM symbols
+        WHERE type = 'query' AND name = ? AND model = ?
+        LIMIT 1
+      `);
+      var queryRow = stmt.get(queryName, modelName) as any;
+    } else {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name
+        FROM symbols
+        WHERE type = 'query' AND name = ?
+        ORDER BY model
+        LIMIT 1
+      `);
+      var queryRow = stmt.get(queryName) as any;
+    }
+
+    if (!queryRow) {
+      throw new Error(`Query "${queryName}" not found. Make sure it's indexed.`);
+    }
+
+    // 2. Parse XML
+    const xmlContent = await fs.readFile(queryRow.file_path, 'utf-8');
+    const xmlObj = await parseStringPromise(xmlContent);
+
+    // 3. Extract query info
+    const queryInfo: QueryInfo = {
+      name: queryName,
+      model: queryRow.model,
+      dataSources: [],
+    };
+
+    const axQuery = xmlObj.AxQuery;
+    if (!axQuery) {
+      throw new Error('Invalid AxQuery XML structure');
+    }
+
+    // Extract description
+    if (axQuery.Description) {
+      queryInfo.description = axQuery.Description[0];
+    }
+
+    // Extract data sources
+    if (axQuery.DataSources && axQuery.DataSources[0]) {
+      queryInfo.dataSources = extractQueryDataSources(
+        axQuery.DataSources[0],
+        includeRanges,
+        includeJoins,
+        includeFields
+      );
+    }
+
+    // 4. Format output
+    return formatQueryOutput(queryInfo, includeRanges, includeJoins, includeFields);
+
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `❌ Error getting query info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Extract query data sources recursively
+ */
+function extractQueryDataSources(
+  dataSourcesNode: any,
+  includeRanges: boolean,
+  includeJoins: boolean,
+  includeFields: boolean
+): QueryDataSource[] {
+  const dataSources: QueryDataSource[] = [];
+
+  if (!dataSourcesNode.AxQuerySimpleRootDataSource && !dataSourcesNode.AxQuerySimpleEmbeddedDataSource) {
+    return dataSources;
+  }
+
+  // Process root data sources
+  if (dataSourcesNode.AxQuerySimpleRootDataSource) {
+    for (const dsNode of dataSourcesNode.AxQuerySimpleRootDataSource) {
+      const ds = extractQueryDataSource(dsNode, includeRanges, includeJoins, includeFields);
+      if (ds) {
+        dataSources.push(ds);
+      }
+    }
+  }
+
+  // Process embedded data sources (joins)
+  if (dataSourcesNode.AxQuerySimpleEmbeddedDataSource) {
+    for (const dsNode of dataSourcesNode.AxQuerySimpleEmbeddedDataSource) {
+      const ds = extractQueryDataSource(dsNode, includeRanges, includeJoins, includeFields);
+      if (ds) {
+        dataSources.push(ds);
+      }
+    }
+  }
+
+  return dataSources;
+}
+
+/**
+ * Extract single query data source
+ */
+function extractQueryDataSource(
+  dsNode: any,
+  includeRanges: boolean,
+  includeJoins: boolean,
+  includeFields: boolean
+): QueryDataSource | null {
+  if (!dsNode) return null;
+
+  const ds: QueryDataSource = {
+    name: dsNode.Name ? dsNode.Name[0] : 'Unknown',
+    table: dsNode.Table ? dsNode.Table[0] : 'Unknown',
+    fetchMode: dsNode.FetchMode ? dsNode.FetchMode[0] : 'Unknown',
+    ranges: [],
+    joins: [],
+    fields: [],
+  };
+
+  // Extract ranges
+  if (includeRanges && dsNode.Ranges && dsNode.Ranges[0]) {
+    ds.ranges = extractQueryRanges(dsNode.Ranges[0]);
+  }
+
+  // Extract fields
+  if (includeFields && dsNode.Fields && dsNode.Fields[0]) {
+    ds.fields = extractQueryFields(dsNode.Fields[0]);
+  }
+
+  // Extract child data sources (joins)
+  if (includeJoins && dsNode.DataSources && dsNode.DataSources[0]) {
+    ds.joins = extractQueryDataSources(dsNode.DataSources[0], includeRanges, includeJoins, includeFields);
+  }
+
+  return ds;
+}
+
+/**
+ * Extract query ranges
+ */
+function extractQueryRanges(rangesNode: any): QueryRange[] {
+  const ranges: QueryRange[] = [];
+
+  if (!rangesNode.AxQuerySimpleDataSourceRange) {
+    return ranges;
+  }
+
+  for (const rangeNode of rangesNode.AxQuerySimpleDataSourceRange) {
+    const range: QueryRange = {
+      field: rangeNode.Field ? rangeNode.Field[0] : 'Unknown',
+      value: rangeNode.Value ? rangeNode.Value[0] : '',
+    };
+
+    if (rangeNode.Operator) {
+      range.operator = rangeNode.Operator[0];
+    }
+
+    ranges.push(range);
+  }
+
+  return ranges;
+}
+
+/**
+ * Extract query fields
+ */
+function extractQueryFields(fieldsNode: any): string[] {
+  const fields: string[] = [];
+
+  if (!fieldsNode.AxQuerySimpleDataSourceField) {
+    return fields;
+  }
+
+  for (const fieldNode of fieldsNode.AxQuerySimpleDataSourceField) {
+    const fieldName = fieldNode.Field ? fieldNode.Field[0] : 'Unknown';
+    fields.push(fieldName);
+  }
+
+  return fields;
+}
+
+/**
+ * Format query output
+ */
+function formatQueryOutput(
+  queryInfo: QueryInfo,
+  includeRanges: boolean,
+  includeJoins: boolean,
+  includeFields: boolean
+): any {
+  let output = `# Query: \`${queryInfo.name}\`\n\n`;
+  output += `**Model:** ${queryInfo.model}\n\n`;
+
+  if (queryInfo.description) {
+    output += `**Description:** ${queryInfo.description}\n\n`;
+  }
+
+  // Data Sources
+  if (queryInfo.dataSources.length > 0) {
+    output += `## 📊 Data Sources\n\n`;
+    output += formatDataSourceHierarchy(queryInfo.dataSources, 0, includeRanges, includeJoins, includeFields);
+  }
+
+  // Summary
+  output += `## 📈 Summary\n\n`;
+  const dsCount = countDataSources(queryInfo.dataSources);
+  const rangeCount = countRanges(queryInfo.dataSources);
+  output += `- **Data Sources:** ${dsCount}\n`;
+  output += `- **Total Ranges:** ${rangeCount}\n`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: output,
+      },
+    ],
+  };
+}
+
+/**
+ * Format data source hierarchy
+ */
+function formatDataSourceHierarchy(
+  dataSources: QueryDataSource[],
+  indent: number,
+  includeRanges: boolean,
+  includeJoins: boolean,
+  includeFields: boolean
+): string {
+  let output = '';
+  const indentStr = '  '.repeat(indent);
+
+  for (const ds of dataSources) {
+    output += `${indentStr}### ${ds.name}\n\n`;
+    output += `${indentStr}**Table:** \`${ds.table}\`\n`;
+    output += `${indentStr}**Fetch Mode:** ${ds.fetchMode}\n\n`;
+
+    // Ranges
+    if (includeRanges && ds.ranges.length > 0) {
+      output += `${indentStr}**Ranges:**\n`;
+      for (const range of ds.ranges) {
+        const operator = range.operator ? ` (${range.operator})` : '';
+        output += `${indentStr}- **${range.field}**${operator}: \`${range.value}\`\n`;
+      }
+      output += '\n';
+    }
+
+    // Fields
+    if (includeFields && ds.fields.length > 0) {
+      output += `${indentStr}**Fields (${ds.fields.length}):**\n`;
+      for (const field of ds.fields.slice(0, 10)) {
+        output += `${indentStr}- ${field}\n`;
+      }
+      if (ds.fields.length > 10) {
+        output += `${indentStr}- ... (${ds.fields.length - 10} more fields)\n`;
+      }
+      output += '\n';
+    }
+
+    // Joins
+    if (includeJoins && ds.joins.length > 0) {
+      output += `${indentStr}**Joined Data Sources:**\n\n`;
+      output += formatDataSourceHierarchy(ds.joins, indent + 1, includeRanges, includeJoins, includeFields);
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Count total data sources recursively
+ */
+function countDataSources(dataSources: QueryDataSource[]): number {
+  let count = dataSources.length;
+  for (const ds of dataSources) {
+    count += countDataSources(ds.joins);
+  }
+  return count;
+}
+
+/**
+ * Count total ranges recursively
+ */
+function countRanges(dataSources: QueryDataSource[]): number {
+  let count = 0;
+  for (const ds of dataSources) {
+    count += ds.ranges.length;
+    count += countRanges(ds.joins);
+  }
+  return count;
+}
+
+export const getQueryInfoToolDefinition = {
+  name: 'get_query_info',
+  description: '🔍 Extract query structure: datasources, ranges, joins, fields. Returns datasource hierarchy with range definitions and join configuration. Essential for understanding query logic and adding ranges or joins.',
+  inputSchema: GetQueryInfoArgsSchema,
+};

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -14,6 +14,13 @@ import { analyzeClassCompletenessTool } from './analyzeCompleteness.js';
 import { getApiUsagePatternsTool } from './apiUsagePatterns.js';
 import { handleGenerateD365Xml } from './generateD365Xml.js';
 import { handleCreateD365File } from './createD365File.js';
+import { findReferencesTool } from './findReferences.js';
+import { modifyD365FileTool } from './modifyD365File.js';
+import { getMethodSignatureTool } from './methodSignature.js';
+import { getFormInfoTool } from './formInfo.js';
+import { getQueryInfoTool } from './queryInfo.js';
+import { getViewInfoTool } from './viewInfo.js';
+import { getEnumInfoTool } from './enumInfo.js';
 
 /**
  * Centralized tool handler that dispatches to individual tool implementations
@@ -49,6 +56,20 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         return handleGenerateD365Xml(request);
       case 'create_d365fo_file':
         return handleCreateD365File(request);
+      case 'find_references':
+        return findReferencesTool(request, context);
+      case 'modify_d365fo_file':
+        return modifyD365FileTool(request, context);
+      case 'get_method_signature':
+        return getMethodSignatureTool(request, context);
+      case 'get_form_info':
+        return getFormInfoTool(request, context);
+      case 'get_query_info':
+        return getQueryInfoTool(request, context);
+      case 'get_view_info':
+        return getViewInfoTool(request, context);
+      case 'get_enum_info':
+        return getEnumInfoTool(request, context);
       default:
         return {
           content: [

--- a/src/tools/viewInfo.ts
+++ b/src/tools/viewInfo.ts
@@ -1,0 +1,324 @@
+/**
+ * Get View Info Tool
+ * Extract data entity view structure: computed columns, relations, methods
+ * Returns view metadata, field mappings, computed columns
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+import { promises as fs } from 'fs';
+import { parseStringPromise } from 'xml2js';
+
+const GetViewInfoArgsSchema = z.object({
+  viewName: z.string().describe('Name of the view or data entity'),
+  modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
+  includeFields: z.boolean().optional().default(true).describe('Include field list'),
+  includeRelations: z.boolean().optional().default(true).describe('Include relations'),
+  includeMethods: z.boolean().optional().default(true).describe('Include methods'),
+  includeWorkspace: z.boolean().optional().default(false).describe('Include workspace files'),
+  workspacePath: z.string().optional().describe('Path to workspace'),
+});
+
+interface ViewField {
+  name: string;
+  dataSource?: string;
+  dataField?: string;
+  dataMethod?: string;
+  isComputed: boolean;
+}
+
+interface ViewRelation {
+  name: string;
+  relatedTable: string;
+  relationType: string;
+  cardinality: string;
+}
+
+interface ViewInfo {
+  name: string;
+  model: string;
+  isPublic: boolean;
+  isReadOnly: boolean;
+  primaryKey?: string;
+  fields: ViewField[];
+  relations: ViewRelation[];
+  methods: string[];
+}
+
+export async function getViewInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = GetViewInfoArgsSchema.parse(request.params.arguments);
+    const { symbolIndex } = context;
+    const { 
+      viewName, 
+      modelName, 
+      includeFields, 
+      includeRelations, 
+      includeMethods
+    } = args;
+
+    // 1. Find the view
+    let stmt;
+    if (modelName) {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name
+        FROM symbols
+        WHERE type = 'view' AND name = ? AND model = ?
+        LIMIT 1
+      `);
+      var viewRow = stmt.get(viewName, modelName) as any;
+    } else {
+      stmt = symbolIndex.db.prepare(`
+        SELECT file_path, model, name
+        FROM symbols
+        WHERE type = 'view' AND name = ?
+        ORDER BY model
+        LIMIT 1
+      `);
+      var viewRow = stmt.get(viewName) as any;
+    }
+
+    if (!viewRow) {
+      throw new Error(`View "${viewName}" not found. Make sure it's indexed.`);
+    }
+
+    // 2. Parse XML
+    const xmlContent = await fs.readFile(viewRow.file_path, 'utf-8');
+    const xmlObj = await parseStringPromise(xmlContent);
+
+    // 3. Extract view info
+    const viewInfo: ViewInfo = {
+      name: viewName,
+      model: viewRow.model,
+      isPublic: false,
+      isReadOnly: false,
+      fields: [],
+      relations: [],
+      methods: [],
+    };
+
+    const axView = xmlObj.AxDataEntityView || xmlObj.AxView;
+    if (!axView) {
+      throw new Error('Invalid view XML structure');
+    }
+
+    // Extract properties
+    if (axView.IsPublic) {
+      viewInfo.isPublic = axView.IsPublic[0] === 'Yes';
+    }
+
+    if (axView.IsReadOnly) {
+      viewInfo.isReadOnly = axView.IsReadOnly[0] === 'Yes';
+    }
+
+    if (axView.PrimaryKey) {
+      viewInfo.primaryKey = axView.PrimaryKey[0];
+    }
+
+    // Extract fields
+    if (includeFields && axView.Fields && axView.Fields[0]) {
+      viewInfo.fields = extractViewFields(axView.Fields[0]);
+    }
+
+    // Extract relations
+    if (includeRelations && axView.Relations && axView.Relations[0]) {
+      viewInfo.relations = extractViewRelations(axView.Relations[0]);
+    }
+
+    // Extract methods
+    if (includeMethods && axView.Methods && axView.Methods[0] && axView.Methods[0].Method) {
+      viewInfo.methods = axView.Methods[0].Method.map((m: any) => m.Name ? m.Name[0] : 'Unknown');
+    }
+
+    // 4. Format output
+    return formatViewOutput(viewInfo, includeFields, includeRelations, includeMethods);
+
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `❌ Error getting view info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Extract view fields
+ */
+function extractViewFields(fieldsNode: any): ViewField[] {
+  const fields: ViewField[] = [];
+
+  // Check for data entity view fields
+  if (fieldsNode.AxDataEntityViewField) {
+    for (const fieldNode of fieldsNode.AxDataEntityViewField) {
+      const field: ViewField = {
+        name: fieldNode.Name ? fieldNode.Name[0] : 'Unknown',
+        isComputed: false,
+      };
+
+      if (fieldNode.DataSource) {
+        field.dataSource = fieldNode.DataSource[0];
+      }
+
+      if (fieldNode.DataField) {
+        field.dataField = fieldNode.DataField[0];
+      }
+
+      if (fieldNode.DataMethod) {
+        field.dataMethod = fieldNode.DataMethod[0];
+        field.isComputed = true;
+      }
+
+      fields.push(field);
+    }
+  }
+
+  // Check for regular view fields
+  if (fieldsNode.AxViewField) {
+    for (const fieldNode of fieldsNode.AxViewField) {
+      const field: ViewField = {
+        name: fieldNode.Name ? fieldNode.Name[0] : 'Unknown',
+        isComputed: false,
+      };
+
+      if (fieldNode.DataSource) {
+        field.dataSource = fieldNode.DataSource[0];
+      }
+
+      if (fieldNode.DataField) {
+        field.dataField = fieldNode.DataField[0];
+      }
+
+      fields.push(field);
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Extract view relations
+ */
+function extractViewRelations(relationsNode: any): ViewRelation[] {
+  const relations: ViewRelation[] = [];
+
+  if (relationsNode.AxDataEntityViewRelation || relationsNode.AxViewRelation) {
+    const relationNodes = relationsNode.AxDataEntityViewRelation || relationsNode.AxViewRelation;
+
+    for (const relNode of relationNodes) {
+      const relation: ViewRelation = {
+        name: relNode.Name ? relNode.Name[0] : 'Unknown',
+        relatedTable: relNode.RelatedDataEntity ? relNode.RelatedDataEntity[0] : relNode.RelatedTable ? relNode.RelatedTable[0] : 'Unknown',
+        relationType: relNode.RelationType ? relNode.RelationType[0] : 'Unknown',
+        cardinality: relNode.Cardinality ? relNode.Cardinality[0] : 'Unknown',
+      };
+
+      relations.push(relation);
+    }
+  }
+
+  return relations;
+}
+
+/**
+ * Format view output
+ */
+function formatViewOutput(
+  viewInfo: ViewInfo,
+  includeFields: boolean,
+  includeRelations: boolean,
+  includeMethods: boolean
+): any {
+  let output = `# View: \`${viewInfo.name}\`\n\n`;
+  output += `**Model:** ${viewInfo.model}\n`;
+  output += `**Public:** ${viewInfo.isPublic ? '✅' : '❌'}\n`;
+  output += `**Read-Only:** ${viewInfo.isReadOnly ? '✅' : '❌'}\n`;
+  
+  if (viewInfo.primaryKey) {
+    output += `**Primary Key:** ${viewInfo.primaryKey}\n`;
+  }
+  
+  output += `\n`;
+
+  // Fields
+  if (includeFields && viewInfo.fields.length > 0) {
+    output += `## 📊 Fields (${viewInfo.fields.length})\n\n`;
+    
+    const computedFields = viewInfo.fields.filter(f => f.isComputed);
+    const mappedFields = viewInfo.fields.filter(f => !f.isComputed);
+
+    if (mappedFields.length > 0) {
+      output += `### Mapped Fields\n\n`;
+      output += `| Field Name | Data Source | Data Field |\n`;
+      output += `|------------|-------------|------------|\n`;
+      
+      for (const field of mappedFields) {
+        output += `| ${field.name} | ${field.dataSource || '-'} | ${field.dataField || '-'} |\n`;
+      }
+      output += `\n`;
+    }
+
+    if (computedFields.length > 0) {
+      output += `### Computed Fields\n\n`;
+      output += `| Field Name | Data Method |\n`;
+      output += `|------------|-------------|\n`;
+      
+      for (const field of computedFields) {
+        output += `| ${field.name} | ${field.dataMethod || '-'} |\n`;
+      }
+      output += `\n`;
+    }
+  }
+
+  // Relations
+  if (includeRelations && viewInfo.relations.length > 0) {
+    output += `## 🔗 Relations (${viewInfo.relations.length})\n\n`;
+    output += `| Name | Related Table | Type | Cardinality |\n`;
+    output += `|------|---------------|------|-------------|\n`;
+    
+    for (const rel of viewInfo.relations) {
+      output += `| ${rel.name} | ${rel.relatedTable} | ${rel.relationType} | ${rel.cardinality} |\n`;
+    }
+    output += `\n`;
+  }
+
+  // Methods
+  if (includeMethods && viewInfo.methods.length > 0) {
+    output += `## 🔧 Methods (${viewInfo.methods.length})\n\n`;
+    for (const method of viewInfo.methods) {
+      output += `- ${method}\n`;
+    }
+    output += `\n`;
+  }
+
+  // Summary
+  output += `## 📈 Summary\n\n`;
+  const computedCount = viewInfo.fields.filter(f => f.isComputed).length;
+  const mappedCount = viewInfo.fields.filter(f => !f.isComputed).length;
+  
+  output += `- **Total Fields:** ${viewInfo.fields.length}\n`;
+  output += `  - Mapped Fields: ${mappedCount}\n`;
+  output += `  - Computed Fields: ${computedCount}\n`;
+  output += `- **Relations:** ${viewInfo.relations.length}\n`;
+  output += `- **Methods:** ${viewInfo.methods.length}\n`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: output,
+      },
+    ],
+  };
+}
+
+export const getViewInfoToolDefinition = {
+  name: 'get_view_info',
+  description: '🗂️ Extract data entity view structure: computed columns, relations, methods. Returns view metadata with field mappings (DataSource.DataField), computed columns (DataMethod), and relations. Essential for understanding view logic and OData entity structure.',
+  inputSchema: GetViewInfoArgsSchema,
+};

--- a/src/tools/xppTools.ts
+++ b/src/tools/xppTools.ts
@@ -6,6 +6,13 @@
 import { z } from 'zod';
 import type { XppSymbolIndex } from '../metadata/symbolIndex.js';
 import type { XppMetadataParser } from '../metadata/xmlParser.js';
+import { findReferencesToolDefinition } from './findReferences.js';
+import { modifyD365FileToolDefinition } from './modifyD365File.js';
+import { getMethodSignatureToolDefinition } from './methodSignature.js';
+import { getFormInfoToolDefinition } from './formInfo.js';
+import { getQueryInfoToolDefinition } from './queryInfo.js';
+import { getViewInfoToolDefinition } from './viewInfo.js';
+import { getEnumInfoToolDefinition } from './enumInfo.js';
 
 // ============================================
 // Tool Input Schemas
@@ -805,5 +812,12 @@ export const toolDefinitions: ToolDefinition[] = [
     name: 'get_api_usage_patterns',
     description: 'Get common usage patterns for a specific API or class. Shows how other code in the codebase uses this class, including initialization patterns and method call sequences.',
     inputSchema: GetApiUsagePatternsSchema
-  }
+  },
+  findReferencesToolDefinition,
+  modifyD365FileToolDefinition,
+  getMethodSignatureToolDefinition,
+  getFormInfoToolDefinition,
+  getQueryInfoToolDefinition,
+  getViewInfoToolDefinition,
+  getEnumInfoToolDefinition
 ];

--- a/tests/debug-xml-parse.ts
+++ b/tests/debug-xml-parse.ts
@@ -1,0 +1,15 @@
+import { parseStringPromise } from 'xml2js';
+
+const testXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>TestForm</Name>
+</AxForm>`;
+
+async function test() {
+  const result = await parseStringPromise(testXml);
+  console.log('Parsed XML:', JSON.stringify(result, null, 2));
+  console.log('Keys:', Object.keys(result));
+  console.log('AxForm?', result.AxForm);
+}
+
+test().catch(console.error);

--- a/tests/tools/enumInfo.test.ts
+++ b/tests/tools/enumInfo.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for get_enum_info tool
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getEnumInfoTool } from '../../src/tools/enumInfo.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+import path from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import Database from 'better-sqlite3';
+
+describe('get_enum_info tool', () => {
+  let context: XppServerContext;
+  let tempDbPath: string;
+  let tempEnumFile: string;
+  let tempEdtFile: string;
+
+  beforeAll(async () => {
+    // Create temp database and files for testing
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'enum-info-test-'));
+    tempDbPath = path.join(tempDir, 'test.db');
+    tempEnumFile = path.join(tempDir, 'TestEnum.xml');
+    tempEdtFile = path.join(tempDir, 'TestEdt.xml');
+
+    // Create test enum XML
+    const enumXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>TestEnum</Name>
+\t<IsExtensible>Yes</IsExtensible>
+\t<UseEnumValue>No</UseEnumValue>
+\t<EnumValues>
+\t\t<AxEnumValue>
+\t\t\t<Name>None</Name>
+\t\t\t<Value>0</Value>
+\t\t\t<Label>None</Label>
+\t\t</AxEnumValue>
+\t\t<AxEnumValue>
+\t\t\t<Name>Active</Name>
+\t\t\t<Value>1</Value>
+\t\t\t<Label>Active</Label>
+\t\t</AxEnumValue>
+\t\t<AxEnumValue>
+\t\t\t<Name>Inactive</Name>
+\t\t\t<Value>2</Value>
+\t\t\t<Label>Inactive</Label>
+\t\t</AxEnumValue>
+\t</EnumValues>
+</AxEnum>`;
+
+    // Create test EDT XML
+    const edtXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>TestEdt</Name>
+\t<Extends>String</Extends>
+\t<StringSize>20</StringSize>
+\t<Label>Test EDT</Label>
+\t<HelpText>Test extended data type</HelpText>
+</AxEdt>`;
+
+    await fs.writeFile(tempEnumFile, enumXml, 'utf-8');
+    await fs.writeFile(tempEdtFile, edtXml, 'utf-8');
+
+    const db = new Database(tempDbPath);
+    
+    // Create schema matching symbolIndex.ts
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS symbols (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        parent_name TEXT,
+        signature TEXT,
+        file_path TEXT NOT NULL,
+        model TEXT NOT NULL,
+        description TEXT,
+        tags TEXT,
+        source_snippet TEXT,
+        complexity INTEGER,
+        used_types TEXT,
+        method_calls TEXT,
+        inline_comments TEXT,
+        extends_class TEXT,
+        implements_interfaces TEXT,
+        usage_example TEXT,
+        usage_frequency INTEGER DEFAULT 0,
+        pattern_type TEXT,
+        typical_usages TEXT,
+        called_by_count INTEGER DEFAULT 0,
+        related_methods TEXT,
+        api_patterns TEXT
+      );
+      
+      CREATE INDEX idx_symbols_name ON symbols(name);
+      CREATE INDEX idx_symbols_type ON symbols(type);
+    `);
+
+    // Insert test data
+    const insert = db.prepare(`
+      INSERT INTO symbols (name, type, parent_name, file_path, model)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+
+    // Insert test enum and EDT
+    insert.run('TestEnum', 'enum', null, tempEnumFile, 'TestModel');
+    insert.run('TestEdt', 'edt', null, tempEdtFile, 'TestModel');
+
+    const symbolIndex = new XppSymbolIndex(tempDbPath);
+
+    context = {
+      symbolIndex,
+      parser: {} as any,
+      cache: undefined as any,
+      workspaceScanner: {} as any,
+      hybridSearch: {} as any,
+      termRelationshipGraph: {} as any,
+    };
+  });
+
+  it('should extract enum values', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_enum_info',
+        arguments: {
+          enumName: 'TestEnum',
+          includeLabels: true,
+        },
+      },
+    };
+
+    const result = await getEnumInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('TestEnum');
+    expect(text).toContain('Enum Values (3)');
+    expect(text).toContain('None');
+    expect(text).toContain('Active');
+    expect(text).toContain('Inactive');
+    expect(text).toContain('0');
+    expect(text).toContain('1');
+    expect(text).toContain('2');
+  });
+
+  it('should show enum extensibility', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_enum_info',
+        arguments: {
+          enumName: 'TestEnum',
+        },
+      },
+    };
+
+    const result = await getEnumInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('**Extensible:** ✅');
+    expect(text).toContain('**Use Enum Value:** ❌');
+  });
+
+  it('should include enum value labels', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_enum_info',
+        arguments: {
+          enumName: 'TestEnum',
+          includeLabels: true,
+        },
+      },
+    };
+
+    const result = await getEnumInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    // Check table header includes Label column
+    expect(text).toContain('| Label');
+    expect(text).toContain('Active');
+    expect(text).toContain('Inactive');
+  });
+
+  it('should exclude labels when requested', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_enum_info',
+        arguments: {
+          enumName: 'TestEnum',
+          includeLabels: false,
+        },
+      },
+    };
+
+    const result = await getEnumInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    // Check table header does NOT include Label column
+    expect(text).not.toMatch(/\|\s*Label\s*\|/);
+  });
+
+  it('should show usage example for enum', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_enum_info',
+        arguments: {
+          enumName: 'TestEnum',
+        },
+      },
+    };
+
+    const result = await getEnumInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Usage Example');
+    expect(text).toContain('TestEnum myEnum = TestEnum::');
+    expect(text).toContain('if (myEnum == TestEnum::');
+  });
+
+  it('should extract EDT properties', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_enum_info',
+        arguments: {
+          enumName: 'TestEdt',
+        },
+      },
+    };
+
+    const result = await getEnumInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Extended Data Type: `TestEdt`');
+    expect(text).toContain('**Base Type:** `String`');
+    expect(text).toContain('Properties');
+    expect(text).toContain('StringSize');
+    expect(text).toContain('20');
+    expect(text).toContain('Label');
+    expect(text).toContain('Test EDT');
+    expect(text).toContain('HelpText');
+  });
+
+  it('should show usage example for EDT', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_enum_info',
+        arguments: {
+          enumName: 'TestEdt',
+        },
+      },
+    };
+
+    const result = await getEnumInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Usage Example');
+    expect(text).toContain('TestEdt myValue;');
+  });
+
+  it('should handle non-existent enum or EDT', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_enum_info',
+        arguments: {
+          enumName: 'NonExistentEnum',
+        },
+      },
+    };
+
+    const result = await getEnumInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not found');
+  });
+});

--- a/tests/tools/findReferences.test.ts
+++ b/tests/tools/findReferences.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for find_references tool
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { findReferencesTool } from '../../src/tools/findReferences.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+import path from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import Database from 'better-sqlite3';
+
+describe('find_references tool', () => {
+  let context: XppServerContext;
+  let tempDbPath: string;
+
+  beforeAll(async () => {
+    // Create temp database for testing
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'find-refs-test-'));
+    tempDbPath = path.join(tempDir, 'test.db');
+
+    const db = new Database(tempDbPath);
+    
+    // Create schema matching symbolIndex.ts
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS symbols (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        parent_name TEXT,
+        signature TEXT,
+        file_path TEXT NOT NULL,
+        model TEXT NOT NULL,
+        description TEXT,
+        tags TEXT,
+        source_snippet TEXT,
+        complexity INTEGER,
+        used_types TEXT,
+        method_calls TEXT,
+        inline_comments TEXT,
+        extends_class TEXT,
+        implements_interfaces TEXT,
+        usage_example TEXT,
+        usage_frequency INTEGER DEFAULT 0,
+        pattern_type TEXT,
+        typical_usages TEXT,
+        called_by_count INTEGER DEFAULT 0,
+        related_methods TEXT,
+        api_patterns TEXT
+      );
+      
+      CREATE INDEX idx_symbols_name ON symbols(name);
+      CREATE INDEX idx_symbols_type ON symbols(type);
+      CREATE INDEX idx_symbols_parent ON symbols(parent_name);
+    `);
+
+    // Insert test data
+    const insert = db.prepare(`
+      INSERT INTO symbols (name, type, parent_name, file_path, model, source_snippet, extends_class, implements_interfaces)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    // Insert test class
+    insert.run('TestHelper', 'class', null, '/test/TestHelper.xml', 'TestModel', null, 'Object', null);
+
+    // Insert test methods that reference TestHelper.validate()
+    insert.run('process', 'method', 'CustomerService', '/test/CustomerService.xml', 'TestModel', 
+      'public void process()\n{\n    TestHelper helper = new TestHelper();\n    helper.validate();\n}', null, null);
+    
+    insert.run('validate', 'method', 'OrderService', '/test/OrderService.xml', 'TestModel', 
+      '    if (!TestHelper::validate(order))\n    {\n        throw error("Invalid");\n    }', null, null);
+
+    // Insert class that extends TestHelper
+    insert.run('CustomHelper', 'class', null, '/test/CustomHelper.xml', 'TestModel', null, 'TestHelper', null);
+
+    // Insert class that instantiates TestHelper
+    insert.run('run', 'method', 'TestJob', '/test/TestJob.xml', 'TestModel', 
+      'public void run()\n{\n    TestHelper helper = new TestHelper();\n    helper.execute();\n}', null, null);
+
+    const symbolIndex = new XppSymbolIndex(tempDbPath);
+
+    context = {
+      symbolIndex,
+      parser: {} as any,
+      cache: undefined as any,
+      workspaceScanner: {} as any,
+      hybridSearch: {} as any,
+      termRelationshipGraph: {} as any,
+    };
+  });
+
+  it('should find method call references', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'find_references',
+        arguments: {
+          symbolName: 'validate',
+          symbolType: 'method',
+          scope: 'all',
+          limit: 50,
+        },
+      },
+    };
+
+    const result = await findReferencesTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('validate');
+    expect(result.content[0].text).toContain('Total References Found');
+  });
+
+  it('should find class extension references', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'find_references',
+        arguments: {
+          symbolName: 'TestHelper',
+          symbolType: 'class',
+          scope: 'all',
+          limit: 50,
+        },
+      },
+    };
+
+    const result = await findReferencesTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    expect(text).toContain('TestHelper');
+    expect(text).toContain('extends');
+  });
+
+  it('should find instantiation references', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'find_references',
+        arguments: {
+          symbolName: 'TestHelper',
+          symbolType: 'class',
+          scope: 'all',
+          limit: 50,
+        },
+      },
+    };
+
+    const result = await findReferencesTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    expect(text).toContain('TestHelper');
+    expect(text).toContain('instantiation');
+  });
+
+  it('should return no references for non-existent symbol', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'find_references',
+        arguments: {
+          symbolName: 'NonExistentMethod',
+          symbolType: 'method',
+          scope: 'all',
+          limit: 50,
+        },
+      },
+    };
+
+    const result = await findReferencesTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('No references found');
+  });
+
+  it('should group references by type', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'find_references',
+        arguments: {
+          symbolName: 'TestHelper',
+          symbolType: 'class',
+          scope: 'all',
+          limit: 50,
+        },
+      },
+    };
+
+    const result = await findReferencesTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    expect(text).toContain('Summary by Type');
+  });
+
+  it('should limit results correctly', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'find_references',
+        arguments: {
+          symbolName: 'TestHelper',
+          symbolType: 'class',
+          scope: 'all',
+          limit: 1,
+        },
+      },
+    };
+
+    const result = await findReferencesTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    expect(text).toContain('**Showing:** 1');
+  });
+});

--- a/tests/tools/formInfo.test.ts
+++ b/tests/tools/formInfo.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Tests for get_form_info tool
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getFormInfoTool } from '../../src/tools/formInfo.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+import path from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import Database from 'better-sqlite3';
+
+describe('get_form_info tool', () => {
+  let context: XppServerContext;
+  let tempDbPath: string;
+  let tempFormFile: string;
+
+  beforeAll(async () => {
+    // Create temp database and files for testing
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'form-info-test-'));
+    tempDbPath = path.join(tempDir, 'test.db');
+    tempFormFile = path.join(tempDir, 'TestForm.xml');
+
+    // Create test form XML
+    const formXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>TestForm</Name>
+\t<DataSources>
+\t\t<AxFormDataSourceRoot>
+\t\t\t<Name>CustTable</Name>
+\t\t\t<Table>CustTable</Table>
+\t\t\t<AllowEdit>Yes</AllowEdit>
+\t\t\t<AllowCreate>Yes</AllowCreate>
+\t\t\t<AllowDelete>No</AllowDelete>
+\t\t\t<Fields>
+\t\t\t\t<AxFormDataSourceField>
+\t\t\t\t\t<DataField>AccountNum</DataField>
+\t\t\t\t</AxFormDataSourceField>
+\t\t\t\t<AxFormDataSourceField>
+\t\t\t\t\t<DataField>Name</DataField>
+\t\t\t\t</AxFormDataSourceField>
+\t\t\t</Fields>
+\t\t\t<Methods>
+\t\t\t\t<Method>
+\t\t\t\t\t<Name>active</Name>
+\t\t\t\t</Method>
+\t\t\t\t<Method>
+\t\t\t\t\t<Name>validateWrite</Name>
+\t\t\t\t</Method>
+\t\t\t</Methods>
+\t\t</AxFormDataSourceRoot>
+\t</DataSources>
+\t<Design>
+\t\t<AxFormDesign>
+\t\t\t<Name>Design</Name>
+\t\t\t<AxFormGroupControl>
+\t\t\t\t<Name>MainGroup</Name>
+\t\t\t\t<AxFormButtonControl>
+\t\t\t\t\t<Name>SaveButton</Name>
+\t\t\t\t\t<Caption>Save</Caption>
+\t\t\t\t\t<Enabled>Yes</Enabled>
+\t\t\t\t</AxFormButtonControl>
+\t\t\t\t<AxFormStringControl>
+\t\t\t\t\t<Name>AccountNum</Name>
+\t\t\t\t\t<DataSource>CustTable</DataSource>
+\t\t\t\t\t<DataField>AccountNum</DataField>
+\t\t\t\t</AxFormStringControl>
+\t\t\t</AxFormGroupControl>
+\t\t</AxFormDesign>
+\t</Design>
+\t<Methods>
+\t\t<Method>
+\t\t\t<Name>init</Name>
+\t\t\t<Source>public void init()</Source>
+\t\t</Method>
+\t\t<Method>
+\t\t\t<Name>run</Name>
+\t\t\t<Source>public void run()</Source>
+\t\t</Method>
+\t</Methods>
+</AxForm>`;
+
+    await fs.writeFile(tempFormFile, formXml, 'utf-8');
+
+    const db = new Database(tempDbPath);
+    
+    // Create schema matching symbolIndex.ts
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS symbols (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        parent_name TEXT,
+        signature TEXT,
+        file_path TEXT NOT NULL,
+        model TEXT NOT NULL,
+        description TEXT,
+        tags TEXT,
+        source_snippet TEXT,
+        complexity INTEGER,
+        used_types TEXT,
+        method_calls TEXT,
+        inline_comments TEXT,
+        extends_class TEXT,
+        implements_interfaces TEXT,
+        usage_example TEXT,
+        usage_frequency INTEGER DEFAULT 0,
+        pattern_type TEXT,
+        typical_usages TEXT,
+        called_by_count INTEGER DEFAULT 0,
+        related_methods TEXT,
+        api_patterns TEXT
+      );
+      
+      CREATE INDEX idx_symbols_name ON symbols(name);
+      CREATE INDEX idx_symbols_type ON symbols(type);
+    `);
+
+    // Insert test data
+    const insert = db.prepare(`
+      INSERT INTO symbols (name, type, parent_name, file_path, model)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+
+    // Insert test form
+    insert.run('TestForm', 'form', null, tempFormFile, 'TestModel');
+
+    const symbolIndex = new XppSymbolIndex(tempDbPath);
+
+    context = {
+      symbolIndex,
+      parser: {} as any,
+      cache: undefined as any,
+      workspaceScanner: {} as any,
+      hybridSearch: {} as any,
+      termRelationshipGraph: {} as any,
+    };
+  });
+
+  it('should extract form datasources', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_form_info',
+        arguments: {
+          formName: 'TestForm',
+          includeDataSources: true,
+          includeControls: false,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getFormInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('TestForm');
+    expect(text).toContain('Data Sources');
+    expect(text).toContain('CustTable');
+    expect(text).toContain('Allow Edit: ✅');
+    expect(text).toContain('Allow Create: ✅');
+    expect(text).toContain('Allow Delete: ❌');
+  });
+
+  it('should extract form controls', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_form_info',
+        arguments: {
+          formName: 'TestForm',
+          includeDataSources: false,
+          includeControls: true,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getFormInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Design (Controls)');
+    expect(text).toContain('SaveButton');
+    expect(text).toContain('AccountNum');
+    expect(text).toContain('ButtonControl');
+    expect(text).toContain('StringControl');
+  });
+
+  it('should extract datasource fields', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_form_info',
+        arguments: {
+          formName: 'TestForm',
+          includeDataSources: true,
+          includeControls: false,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getFormInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Fields');
+    expect(text).toContain('AccountNum');
+    expect(text).toContain('Name');
+  });
+
+  it('should extract datasource methods', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_form_info',
+        arguments: {
+          formName: 'TestForm',
+          includeDataSources: true,
+          includeControls: false,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getFormInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Methods');
+    expect(text).toContain('active');
+    expect(text).toContain('validateWrite');
+  });
+
+  it('should extract form methods', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_form_info',
+        arguments: {
+          formName: 'TestForm',
+          includeDataSources: false,
+          includeControls: false,
+          includeMethods: true,
+        },
+      },
+    };
+
+    const result = await getFormInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Form Methods');
+    expect(text).toContain('init');
+    expect(text).toContain('run');
+  });
+
+  it('should extract control hierarchy', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_form_info',
+        arguments: {
+          formName: 'TestForm',
+          includeDataSources: false,
+          includeControls: true,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getFormInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('MainGroup');
+    expect(text).toContain('SaveButton');
+    // Check hierarchy (indentation)
+    const lines = text.split('\n');
+    const mainGroupLine = lines.findIndex((l: string) => l.includes('MainGroup'));
+    const saveButtonLine = lines.findIndex((l: string) => l.includes('SaveButton'));
+    expect(saveButtonLine).toBeGreaterThan(mainGroupLine);
+  });
+
+  it('should show summary statistics', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_form_info',
+        arguments: {
+          formName: 'TestForm',
+          includeDataSources: true,
+          includeControls: true,
+          includeMethods: true,
+        },
+      },
+    };
+
+    const result = await getFormInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Summary');
+    expect(text).toContain('**Data Sources:** 1');
+    expect(text).toContain('Controls:');
+    expect(text).toContain('**Methods:** 2');
+  });
+
+  it('should handle non-existent form', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_form_info',
+        arguments: {
+          formName: 'NonExistentForm',
+        },
+      },
+    };
+
+    const result = await getFormInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not found');
+  });
+});

--- a/tests/tools/methodSignature.test.ts
+++ b/tests/tools/methodSignature.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for get_method_signature tool
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getMethodSignatureTool } from '../../src/tools/methodSignature.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+import path from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import Database from 'better-sqlite3';
+
+describe('get_method_signature tool', () => {
+  let context: XppServerContext;
+  let tempDbPath: string;
+  let tempClassFile: string;
+
+  beforeAll(async () => {
+    // Create temp database and files for testing
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'method-sig-test-'));
+    tempDbPath = path.join(tempDir, 'test.db');
+    tempClassFile = path.join(tempDir, 'TestClass.xml');
+
+    // Create test XML file with method
+    const classXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>TestClass</Name>
+\t<Methods>
+\t\t<Method>
+\t\t\t<Name>calculateTotal</Name>
+\t\t\t<Source>public static Real calculateTotal(Real price, Integer quantity, Percent discount = 0)
+{
+\tReal total;
+\ttotal = price * quantity;
+\tif (discount > 0)
+\t{
+\t\ttotal = total * (1 - discount / 100);
+\t}
+\treturn total;
+}</Source>
+\t\t</Method>
+\t\t<Method>
+\t\t\t<Name>validate</Name>
+\t\t\t<Source>protected boolean validate()
+{
+\treturn true;
+}</Source>
+\t\t</Method>
+\t</Methods>
+</AxClass>`;
+
+    await fs.writeFile(tempClassFile, classXml, 'utf-8');
+
+    const db = new Database(tempDbPath);
+    
+    // Create schema matching symbolIndex.ts
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS symbols (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        parent_name TEXT,
+        signature TEXT,
+        file_path TEXT NOT NULL,
+        model TEXT NOT NULL,
+        description TEXT,
+        tags TEXT,
+        source_snippet TEXT,
+        complexity INTEGER,
+        used_types TEXT,
+        method_calls TEXT,
+        inline_comments TEXT,
+        extends_class TEXT,
+        implements_interfaces TEXT,
+        usage_example TEXT,
+        usage_frequency INTEGER DEFAULT 0,
+        pattern_type TEXT,
+        typical_usages TEXT,
+        called_by_count INTEGER DEFAULT 0,
+        related_methods TEXT,
+        api_patterns TEXT
+      );
+      
+      CREATE INDEX idx_symbols_name ON symbols(name);
+      CREATE INDEX idx_symbols_type ON symbols(type);
+      CREATE INDEX idx_symbols_parent ON symbols(parent_name);
+    `);
+
+    // Insert test data
+    const insert = db.prepare(`
+      INSERT INTO symbols (name, type, parent_name, file_path, model, signature)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+
+    // Insert test class
+    insert.run('TestClass', 'class', null, tempClassFile, 'TestModel', null);
+
+    // Insert test methods
+    insert.run('calculateTotal', 'method', 'TestClass', tempClassFile, 'TestModel', 
+      'public static Real calculateTotal(Real price, Integer quantity, Percent discount = 0)');
+    
+    insert.run('validate', 'method', 'TestClass', tempClassFile, 'TestModel', 
+      'protected boolean validate()');
+
+    const symbolIndex = new XppSymbolIndex(tempDbPath);
+
+    context = {
+      symbolIndex,
+      parser: {} as any,
+      cache: undefined as any,
+      workspaceScanner: {} as any,
+      hybridSearch: {} as any,
+      termRelationshipGraph: {} as any,
+    };
+  });
+
+  it('should extract method signature with parameters', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_method_signature',
+        arguments: {
+          className: 'TestClass',
+          methodName: 'calculateTotal',
+        },
+      },
+    };
+
+    const result = await getMethodSignatureTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('TestClass.calculateTotal');
+    expect(text).toContain('public');
+    expect(text).toContain('static');
+    expect(text).toContain('Real');
+    expect(text).toContain('price');
+    expect(text).toContain('quantity');
+    expect(text).toContain('discount');
+  });
+
+  it('should generate Chain of Command template', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_method_signature',
+        arguments: {
+          className: 'TestClass',
+          methodName: 'calculateTotal',
+        },
+      },
+    };
+
+    const result = await getMethodSignatureTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Chain of Command Template');
+    expect(text).toContain('[ExtensionOf');
+    expect(text).toContain('next calculateTotal');
+  });
+
+  it('should extract method signature without parameters', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_method_signature',
+        arguments: {
+          className: 'TestClass',
+          methodName: 'validate',
+        },
+      },
+    };
+
+    const result = await getMethodSignatureTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('TestClass.validate');
+    expect(text).toContain('protected');
+    expect(text).toContain('boolean');
+    expect(text).toContain('**Parameters:** 0');
+  });
+
+  it('should handle non-existent class', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_method_signature',
+        arguments: {
+          className: 'NonExistentClass',
+          methodName: 'someMethod',
+        },
+      },
+    };
+
+    const result = await getMethodSignatureTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not found');
+  });
+
+  it('should handle non-existent method', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_method_signature',
+        arguments: {
+          className: 'TestClass',
+          methodName: 'nonExistentMethod',
+        },
+      },
+    };
+
+    const result = await getMethodSignatureTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not found');
+  });
+
+  it('should show method modifiers', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_method_signature',
+        arguments: {
+          className: 'TestClass',
+          methodName: 'calculateTotal',
+        },
+      },
+    };
+
+    const result = await getMethodSignatureTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Modifiers:');
+    expect(text).toContain('public');
+    expect(text).toContain('static');
+  });
+});

--- a/tests/tools/queryInfo.test.ts
+++ b/tests/tools/queryInfo.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for get_query_info tool
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getQueryInfoTool } from '../../src/tools/queryInfo.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+import path from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import Database from 'better-sqlite3';
+
+describe('get_query_info tool', () => {
+  let context: XppServerContext;
+  let tempDbPath: string;
+  let tempQueryFile: string;
+
+  beforeAll(async () => {
+    // Create temp database and files for testing
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'query-info-test-'));
+    tempDbPath = path.join(tempDir, 'test.db');
+    tempQueryFile = path.join(tempDir, 'TestQuery.xml');
+
+    // Create test query XML
+    const queryXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxQuery xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>TestQuery</Name>
+\t<Description>Test query for customers</Description>
+\t<DataSources>
+\t\t<AxQuerySimpleRootDataSource>
+\t\t\t<Name>CustTable</Name>
+\t\t\t<Table>CustTable</Table>
+\t\t\t<FetchMode>1:n</FetchMode>
+\t\t\t<Ranges>
+\t\t\t\t<AxQuerySimpleDataSourceRange>
+\t\t\t\t\t<Field>AccountNum</Field>
+\t\t\t\t\t<Value>*</Value>
+\t\t\t\t</AxQuerySimpleDataSourceRange>
+\t\t\t\t<AxQuerySimpleDataSourceRange>
+\t\t\t\t\t<Field>Blocked</Field>
+\t\t\t\t\t<Value>No</Value>
+\t\t\t\t\t<Operator>Equal</Operator>
+\t\t\t\t</AxQuerySimpleDataSourceRange>
+\t\t\t</Ranges>
+\t\t\t<Fields>
+\t\t\t\t<AxQuerySimpleDataSourceField>
+\t\t\t\t\t<Field>AccountNum</Field>
+\t\t\t\t</AxQuerySimpleDataSourceField>
+\t\t\t\t<AxQuerySimpleDataSourceField>
+\t\t\t\t\t<Field>Name</Field>
+\t\t\t\t</AxQuerySimpleDataSourceField>
+\t\t\t</Fields>
+\t\t\t<DataSources>
+\t\t\t\t<AxQuerySimpleEmbeddedDataSource>
+\t\t\t\t\t<Name>CustTrans</Name>
+\t\t\t\t\t<Table>CustTrans</Table>
+\t\t\t\t\t<FetchMode>1:n</FetchMode>
+\t\t\t\t\t<Ranges>
+\t\t\t\t\t\t<AxQuerySimpleDataSourceRange>
+\t\t\t\t\t\t\t<Field>Open</Field>
+\t\t\t\t\t\t\t<Value>Yes</Value>
+\t\t\t\t\t\t</AxQuerySimpleDataSourceRange>
+\t\t\t\t\t</Ranges>
+\t\t\t\t</AxQuerySimpleEmbeddedDataSource>
+\t\t\t</DataSources>
+\t\t</AxQuerySimpleRootDataSource>
+\t</DataSources>
+</AxQuery>`;
+
+    await fs.writeFile(tempQueryFile, queryXml, 'utf-8');
+
+    const db = new Database(tempDbPath);
+    
+    // Create schema matching symbolIndex.ts
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS symbols (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        parent_name TEXT,
+        signature TEXT,
+        file_path TEXT NOT NULL,
+        model TEXT NOT NULL,
+        description TEXT,
+        tags TEXT,
+        source_snippet TEXT,
+        complexity INTEGER,
+        used_types TEXT,
+        method_calls TEXT,
+        inline_comments TEXT,
+        extends_class TEXT,
+        implements_interfaces TEXT,
+        usage_example TEXT,
+        usage_frequency INTEGER DEFAULT 0,
+        pattern_type TEXT,
+        typical_usages TEXT,
+        called_by_count INTEGER DEFAULT 0,
+        related_methods TEXT,
+        api_patterns TEXT
+      );
+      
+      CREATE INDEX idx_symbols_name ON symbols(name);
+      CREATE INDEX idx_symbols_type ON symbols(type);
+    `);
+
+    // Insert test data
+    const insert = db.prepare(`
+      INSERT INTO symbols (name, type, parent_name, file_path, model)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+
+    // Insert test query
+    insert.run('TestQuery', 'query', null, tempQueryFile, 'TestModel');
+
+    const symbolIndex = new XppSymbolIndex(tempDbPath);
+
+    context = {
+      symbolIndex,
+      parser: {} as any,
+      cache: undefined as any,
+      workspaceScanner: {} as any,
+      hybridSearch: {} as any,
+      termRelationshipGraph: {} as any,
+    };
+  });
+
+  it('should extract query description', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_query_info',
+        arguments: {
+          queryName: 'TestQuery',
+        },
+      },
+    };
+
+    const result = await getQueryInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('TestQuery');
+    expect(text).toContain('Test query for customers');
+  });
+
+  it('should extract root datasources', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_query_info',
+        arguments: {
+          queryName: 'TestQuery',
+          includeRanges: false,
+          includeJoins: false,
+          includeFields: false,
+        },
+      },
+    };
+
+    const result = await getQueryInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('CustTable');
+    expect(text).toContain('**Table:** `CustTable`');
+    expect(text).toContain('**Fetch Mode:** 1:n');
+  });
+
+  it('should extract query ranges', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_query_info',
+        arguments: {
+          queryName: 'TestQuery',
+          includeRanges: true,
+          includeJoins: false,
+          includeFields: false,
+        },
+      },
+    };
+
+    const result = await getQueryInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Ranges:');
+    expect(text).toContain('AccountNum');
+    expect(text).toContain('Blocked');
+    expect(text).toContain('No');
+    expect(text).toContain('(Equal)');
+  });
+
+  it('should extract query fields', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_query_info',
+        arguments: {
+          queryName: 'TestQuery',
+          includeRanges: false,
+          includeJoins: false,
+          includeFields: true,
+        },
+      },
+    };
+
+    const result = await getQueryInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Fields');
+    expect(text).toContain('AccountNum');
+    expect(text).toContain('Name');
+  });
+
+  it('should extract joined datasources', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_query_info',
+        arguments: {
+          queryName: 'TestQuery',
+          includeRanges: true,
+          includeJoins: true,
+          includeFields: false,
+        },
+      },
+    };
+
+    const result = await getQueryInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Joined Data Sources:');
+    expect(text).toContain('CustTrans');
+    expect(text).toContain('Open');
+    expect(text).toContain('Yes');
+  });
+
+  it('should show datasource hierarchy', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_query_info',
+        arguments: {
+          queryName: 'TestQuery',
+          includeRanges: false,
+          includeJoins: true,
+          includeFields: false,
+        },
+      },
+    };
+
+    const result = await getQueryInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    // Check hierarchy (CustTrans should be indented under CustTable)
+    const lines = text.split('\n');
+    const custTableLine = lines.findIndex((l: string) => l.includes('### CustTable'));
+    const custTransLine = lines.findIndex((l: string) => l.includes('### CustTrans'));
+    expect(custTransLine).toBeGreaterThan(custTableLine);
+    
+    // CustTrans should be indented (more spaces)
+    const custTableIndent = lines[custTableLine].match(/^\s*/)?.[0].length || 0;
+    const custTransIndent = lines[custTransLine].match(/^\s*/)?.[0].length || 0;
+    expect(custTransIndent).toBeGreaterThan(custTableIndent);
+  });
+
+  it('should show summary statistics', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_query_info',
+        arguments: {
+          queryName: 'TestQuery',
+          includeRanges: true,
+          includeJoins: true,
+          includeFields: true,
+        },
+      },
+    };
+
+    const result = await getQueryInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Summary');
+    expect(text).toContain('**Data Sources:** 2');
+    expect(text).toContain('**Total Ranges:** 3');
+  });
+
+  it('should handle non-existent query', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_query_info',
+        arguments: {
+          queryName: 'NonExistentQuery',
+        },
+      },
+    };
+
+    const result = await getQueryInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not found');
+  });
+});

--- a/tests/tools/viewInfo.test.ts
+++ b/tests/tools/viewInfo.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for get_view_info tool
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getViewInfoTool } from '../../src/tools/viewInfo.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+import path from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import Database from 'better-sqlite3';
+
+describe('get_view_info tool', () => {
+  let context: XppServerContext;
+  let tempDbPath: string;
+  let tempViewFile: string;
+
+  beforeAll(async () => {
+    // Create temp database and files for testing
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'view-info-test-'));
+    tempDbPath = path.join(tempDir, 'test.db');
+    tempViewFile = path.join(tempDir, 'TestView.xml');
+
+    // Create test view XML
+    const viewXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxDataEntityView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>TestDataEntity</Name>
+\t<IsPublic>Yes</IsPublic>
+\t<IsReadOnly>No</IsReadOnly>
+\t<PrimaryKey>Key1</PrimaryKey>
+\t<Fields>
+\t\t<AxDataEntityViewField>
+\t\t\t<Name>CustomerAccount</Name>
+\t\t\t<DataSource>CustTable</DataSource>
+\t\t\t<DataField>AccountNum</DataField>
+\t\t</AxDataEntityViewField>
+\t\t<AxDataEntityViewField>
+\t\t\t<Name>CustomerName</Name>
+\t\t\t<DataSource>CustTable</DataSource>
+\t\t\t<DataField>Name</DataField>
+\t\t</AxDataEntityViewField>
+\t\t<AxDataEntityViewField>
+\t\t\t<Name>TotalAmount</Name>
+\t\t\t<DataMethod>getTotalAmount</DataMethod>
+\t\t</AxDataEntityViewField>
+\t</Fields>
+\t<Relations>
+\t\t<AxDataEntityViewRelation>
+\t\t\t<Name>CustTransRelation</Name>
+\t\t\t<RelatedDataEntity>CustTransEntity</RelatedDataEntity>
+\t\t\t<RelationType>Association</RelationType>
+\t\t\t<Cardinality>ZeroMore</Cardinality>
+\t\t</AxDataEntityViewRelation>
+\t</Relations>
+\t<Methods>
+\t\t<Method>
+\t\t\t<Name>getTotalAmount</Name>
+\t\t</Method>
+\t\t<Method>
+\t\t\t<Name>initValue</Name>
+\t\t</Method>
+\t</Methods>
+</AxDataEntityView>`;
+
+    await fs.writeFile(tempViewFile, viewXml, 'utf-8');
+
+    const db = new Database(tempDbPath);
+    
+    // Create schema matching symbolIndex.ts
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS symbols (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        parent_name TEXT,
+        signature TEXT,
+        file_path TEXT NOT NULL,
+        model TEXT NOT NULL,
+        description TEXT,
+        tags TEXT,
+        source_snippet TEXT,
+        complexity INTEGER,
+        used_types TEXT,
+        method_calls TEXT,
+        inline_comments TEXT,
+        extends_class TEXT,
+        implements_interfaces TEXT,
+        usage_example TEXT,
+        usage_frequency INTEGER DEFAULT 0,
+        pattern_type TEXT,
+        typical_usages TEXT,
+        called_by_count INTEGER DEFAULT 0,
+        related_methods TEXT,
+        api_patterns TEXT
+      );
+      
+      CREATE INDEX idx_symbols_name ON symbols(name);
+      CREATE INDEX idx_symbols_type ON symbols(type);
+    `);
+
+    // Insert test data
+    const insert = db.prepare(`
+      INSERT INTO symbols (name, type, parent_name, file_path, model)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+
+    // Insert test view
+    insert.run('TestDataEntity', 'view', null, tempViewFile, 'TestModel');
+
+    const symbolIndex = new XppSymbolIndex(tempDbPath);
+
+    context = {
+      symbolIndex,
+      parser: {} as any,
+      cache: undefined as any,
+      workspaceScanner: {} as any,
+      hybridSearch: {} as any,
+      termRelationshipGraph: {} as any,
+    };
+  });
+
+  it('should extract view properties', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'TestDataEntity',
+          includeFields: false,
+          includeRelations: false,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('TestDataEntity');
+    expect(text).toContain('**Public:** ✅');
+    expect(text).toContain('**Read-Only:** ❌');
+    expect(text).toContain('**Primary Key:** Key1');
+  });
+
+  it('should extract mapped fields', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'TestDataEntity',
+          includeFields: true,
+          includeRelations: false,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Mapped Fields');
+    expect(text).toContain('CustomerAccount');
+    expect(text).toContain('CustTable');
+    expect(text).toContain('AccountNum');
+    expect(text).toContain('CustomerName');
+    expect(text).toContain('Name');
+  });
+
+  it('should extract computed fields', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'TestDataEntity',
+          includeFields: true,
+          includeRelations: false,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Computed Fields');
+    expect(text).toContain('TotalAmount');
+    expect(text).toContain('getTotalAmount');
+  });
+
+  it('should separate mapped and computed fields', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'TestDataEntity',
+          includeFields: true,
+          includeRelations: false,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    // Check that both sections exist
+    expect(text).toContain('### Mapped Fields');
+    expect(text).toContain('### Computed Fields');
+    
+    // Check that mapping table exists
+    expect(text).toMatch(/\|\s*Field Name\s*\|\s*Data Source\s*\|\s*Data Field\s*\|/);
+  });
+
+  it('should extract relations', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'TestDataEntity',
+          includeFields: false,
+          includeRelations: true,
+          includeMethods: false,
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Relations (1)');
+    expect(text).toContain('CustTransRelation');
+    expect(text).toContain('CustTransEntity');
+    expect(text).toContain('Association');
+    expect(text).toContain('ZeroMore');
+  });
+
+  it('should extract methods', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'TestDataEntity',
+          includeFields: false,
+          includeRelations: false,
+          includeMethods: true,
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Methods (2)');
+    expect(text).toContain('getTotalAmount');
+    expect(text).toContain('initValue');
+  });
+
+  it('should show summary statistics', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'TestDataEntity',
+          includeFields: true,
+          includeRelations: true,
+          includeMethods: true,
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Summary');
+    expect(text).toContain('**Total Fields:** 3');
+    expect(text).toContain('Mapped Fields: 2');
+    expect(text).toContain('Computed Fields: 1');
+    expect(text).toContain('**Relations:** 1');
+    expect(text).toContain('**Methods:** 2');
+  });
+
+  it('should handle non-existent view', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'NonExistentView',
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('not found');
+  });
+
+  it('should show field count correctly', async () => {
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: 'get_view_info',
+        arguments: {
+          viewName: 'TestDataEntity',
+          includeFields: true,
+        },
+      },
+    };
+
+    const result = await getViewInfoTool(request as any, context);
+
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    
+    expect(text).toContain('Fields (3)');
+  });
+});


### PR DESCRIPTION
New Tools (22 total, was 15):
- find_references: where-used analysis
- modify_d365fo_file: safe XML editing with backup
- get_method_signature: CoC extensions support
- get_form_info: form metadata parsing
- get_query_info: query structure analysis
- get_view_info: view/data entity parsing
- get_enum_info: enum value extraction

Testing: 86 tests (100% pass rate)
Documentation: Updated all docs + copilot-instructions v2.0
Database: Added pattern_type column + smart VACUUM

Total: ~2850 lines production code + ~1500 lines tests