### PR TITLE
fix: align modify_d365fo_file schema with implementation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,8 +45,12 @@
 ### Form Elements
 - `button`, `control`, `FormDataSource`, `FormControl`, `ButtonControl`, `FormButtonControl`
 - `FormGroupControl`, `FormGridControl`, `FormReferenceControl`, `FormTab`, `FormActionPane`
-- `datasource`, `data source`, `main datasource`, `primary datasource`, `form control`
+- `datasource`, `data source`, `main datasource`, `primary datasource`, `form datasource`
+- `add method to datasource`, `override datasource method`, `form datasource active`
+- `enable button`, `disable button`, `button enabled based on`, `control visibility`
 - Button names: `AddFormEntityPair`, `RemoveFormEntityPair`, `New`, `Delete`, `Edit`, `Save`
+- Form methods: `init`, `run`, `close`, `canClose`, `active`
+- Datasource methods: `active`, `validateWrite`, `validateDelete`, `create`, `write`, `delete`, `init`, `executeQuery`
 
 ### Query Elements
 - `QueryRun`, `QueryBuildDataSource`, `QueryBuildRange`, `QueryBuild`, `query datasource`
@@ -314,6 +318,119 @@
 - "Analyze GeneralJournalAccountEntryView" → `get_view_info("GeneralJournalAccountEntryView")`
 - "Get CustAccountType enum values" → `get_enum_info("CustAccountType")`
 
+## Scenario 6a: User Wants to Modify Form (Add Method to Datasource)
+
+**Triggers:** 
+- "add method to form", "přidej metodu do formuláře", "add method to datasource", "přidej do datového zdroje metodu"
+- "override form datasource method", "form datasource active", "enable/disable button based on"
+- "modify form behavior", "customize form", "extend form datasource"
+- "hlavní datový zdroj", "main datasource", "primary datasource"
+- "formulář metoda active", "form active method", "datasource active"
+
+**CRITICAL: This is a FORM CUSTOMIZATION request - use get_form_info FIRST!**
+
+**Common User Questions:**
+- "Přidej do formuláře metodu active do hlavního datového zdroje"
+- "Add method active to main datasource of SalesTable form"
+- "Override active method on form datasource to enable button"
+- "Enable button based on datasource record"
+- "Add validation to form datasource validateWrite"
+
+```
+1. Identify the form name from context or ask user
+   
+2. Get form structure:
+   → get_form_info(formName=X, includeWorkspace=true)
+   Returns: datasources list, main datasource, controls, methods
+
+3. Identify target datasource:
+   - User mentions "main datasource" → use primary/first datasource from get_form_info
+   - User mentions specific name → find it in datasources list
+   - Common datasources: table name (e.g., SalesTable, CustTable)
+
+4. Determine method to override:
+   - "active()" → Triggers when user changes record (for button enable/disable)
+   - "validateWrite()" → Validation before saving
+   - "init()" → Form initialization
+   - "create()" → New record creation
+   - "delete()" → Record deletion
+
+5. Generate form extension code:
+   - RECOMMENDED: Use [FormDataSourceEventHandler] for event-based extensions
+   - Show both event-based and direct override approaches
+   - Use exact datasource name from get_form_info results
+
+6. Provide guidance to user:
+   - ❌ DO NOT use modify_d365fo_file automatically
+   - ❌ DO NOT use run_in_terminal to edit files
+   - ✅ ONLY provide generated code and explanation
+   - ✅ Let user decide how to implement (VS extension, XML edit, etc.)
+```
+
+**Complete Example Workflow:**
+
+User asks: "Add method active to main datasource of SalesTable form to enable button"
+
+```typescript
+// Step 1: Find and analyze form
+search("SalesTable", type="form", includeWorkspace=true)
+
+// Step 2: Get form structure
+get_form_info("SalesTable")
+// Returns:
+// - Datasources: [SalesTable (primary), SalesLine, CustTable]
+// - Controls: [AddLine button, DeleteLine button, ...]
+// - Main datasource: SalesTable
+
+// Step 3: Generate extension code
+// OPTION A: Event-based (recommended for most scenarios)
+[Form]
+public class SalesTable_Extension
+{
+    [FormDataSourceEventHandler(formDataSourceStr(SalesTable, SalesTable), FormDataSourceEventType::Activated)]
+    public static void SalesTable_OnActivated(FormDataSource sender, FormDataSourceEventArgs e)
+    {
+        FormRun formRun = sender.formRun();
+        
+        // Enable/disable button based on condition
+        FormButtonControl addLineButton = formRun.design().controlName(formControlStr(SalesTable, AddLine));
+        addLineButton.enabled(sender.cursor().RecId != 0);
+    }
+}
+
+// OPTION B: Direct datasource method override (for complex logic)
+// Note: Requires form XML modification
+public void active()
+{
+    super();
+    
+    // Enable/disable button based on datasource state
+    AddLineButton.enabled(SalesTable.RecId != 0);
+}
+
+// Step 4: Provide code and guidance (DO NOT modify files automatically!)
+"Here's how to add active() method to SalesTable datasource:
+
+RECOMMENDED APPROACH: Event-based extension (shown in code above)
+- Create new X++ class with [Form] attribute
+- No XML modification needed
+- Cleaner and more maintainable
+
+ALTERNATIVE: Direct datasource override
+- Requires manual XML editing in Visual Studio
+- User must add method to form datasource in AOT
+
+⚠️ IMPORTANT: Do not automatically modify files - provide code only!"
+```
+
+**Key Points for Form Datasource Methods:**
+- ✅ ALWAYS call get_form_info first to get datasource names
+- ✅ Generate extension code using exact datasource name from get_form_info
+- ✅ Show both event-based and direct override approaches
+- ❌ NEVER automatically modify files (no modify_d365fo_file, no run_in_terminal)
+- ❌ NEVER run PowerShell scripts to edit XML files
+- ✅ ONLY provide generated code and let user implement it
+
 ## Scenario 7: User Asks "Where Is This Used?"
 
 **Triggers:** "where is this used", "who calls", "find references", "where is this called", "dependencies"
@@ -432,6 +549,25 @@
 ```
 ❌ WRONG: file_search("**/MyClass.xml")
 ✅ RIGHT: search("MyClass", type="class")
+```
+
+### 6. ❌ NEVER Edit D365FO Files Automatically
+**Why:** User needs to decide implementation approach (VS extension vs XML edit)  
+**Instead:** Provide generated code and instructions, let user implement
+
+**Example:**
+```
+❌ WRONG: modify_d365fo_file(...) without asking
+❌ WRONG: run_in_terminal with PowerShell to edit XML
+✅ RIGHT: Generate code + provide instructions → user implements
+```
+
+**For Form Datasource Methods:**
+```
+❌ WRONG: "I'll add the method to the form XML using PowerShell..."
+✅ RIGHT: "Here's the extension code. You can implement it by:
+           Option A: Create X++ extension class (recommended)
+           Option B: Manually add to form XML in Visual Studio"
 ```
 
 ### 6. ❌ NEVER Edit D365FO Files Manually

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -339,45 +339,83 @@ workspacePath and includeWorkspace parameters.`,
         },
         {
           name: 'modify_d365fo_file',
-          description: '⚠️ WINDOWS ONLY: Safely modifies an existing D365FO XML file (class, table, enum, etc.). Supports adding/updating/deleting methods, fields, and properties. Creates automatic backup (.bak) before changes and validates XML after modification. IMPORTANT: This tool MUST run locally on Windows D365FO VM - it CANNOT work through Azure HTTP proxy (Linux).',
+          description: '⚠️ WINDOWS ONLY: Safely modifies an existing D365FO XML file (class, table, enum, form, query, view). Supports adding/removing methods and fields, modifying properties. Creates automatic backup (.bak) before changes and validates XML after modification. IMPORTANT: This tool MUST run locally on Windows D365FO VM - it CANNOT work through Azure HTTP proxy (Linux).',
           inputSchema: {
             type: 'object',
             properties: {
-              filePath: {
+              objectType: {
                 type: 'string',
-                description: 'Full path to the D365FO XML file (e.g., K:\\AosService\\PackagesLocalDirectory\\Model\\Model\\AxClass\\MyClass.xml)'
+                enum: ['class', 'table', 'form', 'enum', 'query', 'view'],
+                description: 'Type of D365FO object to modify'
+              },
+              objectName: {
+                type: 'string',
+                description: 'Name of the object to modify (e.g., CustTable, SalesTable)'
               },
               operation: {
                 type: 'string',
-                enum: ['add_method', 'update_method', 'delete_method', 'add_field', 'update_property'],
+                enum: ['add-method', 'add-field', 'modify-property', 'remove-method', 'remove-field'],
                 description: 'Type of modification to perform'
               },
               methodName: {
                 type: 'string',
-                description: 'Method name (required for add_method, update_method, delete_method)'
+                description: 'Method name (required for add-method, remove-method)'
               },
               methodCode: {
                 type: 'string',
-                description: 'Method source code (required for add_method, update_method)'
+                description: 'X++ code for the method body (required for add-method)'
+              },
+              methodModifiers: {
+                type: 'string',
+                description: 'Method modifiers (e.g., "public static")'
+              },
+              methodReturnType: {
+                type: 'string',
+                description: 'Return type of method (e.g., "void", "str", "boolean")'
+              },
+              methodParameters: {
+                type: 'string',
+                description: 'Method parameters (e.g., "str _param1, int _param2")'
               },
               fieldName: {
                 type: 'string',
-                description: 'Field name (required for add_field)'
+                description: 'Field name (required for add-field, remove-field)'
               },
               fieldType: {
                 type: 'string',
-                description: 'Field data type (required for add_field)'
+                description: 'Extended data type or base type (required for add-field)'
               },
-              propertyName: {
+              fieldMandatory: {
+                type: 'boolean',
+                description: 'Is field mandatory (for add-field)'
+              },
+              fieldLabel: {
                 type: 'string',
-                description: 'Property name (required for update_property)'
+                description: 'Field label (for add-field)'
+              },
+              propertyPath: {
+                type: 'string',
+                description: 'Path to property (e.g., "Table1.Visible", for modify-property)'
               },
               propertyValue: {
                 type: 'string',
-                description: 'Property value (required for update_property)'
+                description: 'New property value (required for modify-property)'
+              },
+              createBackup: {
+                type: 'boolean',
+                description: 'Create backup before modification (default: true)',
+                default: true
+              },
+              modelName: {
+                type: 'string',
+                description: 'Model name (auto-detected if not provided)'
+              },
+              workspacePath: {
+                type: 'string',
+                description: 'Path to workspace for finding file'
               },
             },
-            required: ['filePath', 'operation'],
+            required: ['objectType', 'objectName', 'operation'],
           },
         },
         {


### PR DESCRIPTION
The tool definition in mcpServer.ts was outdated and didn't match the actual implementation in modifyD365File.ts, causing validation errors.

Changes:
- Replace 'filePath' parameter with 'objectType' + 'objectName' (matches implementation)
- Add missing objectType enum values: 'form', 'query', 'view'
- Update operation enum: 'add-method', 'remove-method' (with hyphens, not underscores)
- Add missing parameters: methodModifiers, methodReturnType, methodParameters
- Add field parameters: fieldMandatory, fieldLabel
- Replace propertyName with propertyPath (matches implementation)
- Add workspacePath, modelName, createBackup parameters
- Update required fields to match implementation

This fixes Azure validation errors like 'invalid_value' for objectType.