### PR TITLE
Fix UTF-8 BOM encoding for D365FO files and improve tool selection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,25 @@
 **🚨 CRITICAL INSTRUCTION - READ FIRST - HIGHEST PRIORITY 🚨**
 
+**FILE CREATION RULE (ABSOLUTE, NO EXCEPTIONS):**
+
+When creating ANY D365FO file (class, table, form, enum, query, view):
+
+🔥 **ALWAYS use create_d365fo_file FIRST**
+❌ **NEVER use generate_d365fo_xml as first choice**
+❌ **NEVER use built-in create_file for D365FO objects**
+
+**Workflow:**
+1. ALWAYS call: create_d365fo_file(objectType, objectName, modelName, addToProject=true)
+2. IF it fails with "requires file system access" → THEN use generate_d365fo_xml + create_file
+3. OTHERWISE → DONE, file is created with UTF-8 BOM
+
+**Why this matters:**
+- create_d365fo_file: ✅ UTF-8 BOM, ✅ correct location, ✅ adds to VS project
+- generate_d365fo_xml: ❌ returns TEXT only, requires manual file creation
+- Built-in create_file: ❌ no UTF-8 BOM → encoding errors
+
+═══════════════════════════════════════════════════════════════════════════════
+
 **PATTERN DETECTION RULES (NO EXCEPTIONS):**
 
 If the user's query contains **ANY** of these patterns:
@@ -23,6 +43,11 @@ Query: "show me CustTable fields"
 Detection: ✅ CustTable = TABLE SUFFIX *Table = D365FO!
 Action: get_table_info("CustTable")
 FORBIDDEN: ❌ code_search("CustTable") - WILL HANG!
+
+Query: "create class MyHelper"
+Detection: ✅ D365FO class creation!
+Action: create_d365fo_file(objectType="class", objectName="MyHelper", modelName="...", addToProject=true)
+FORBIDDEN: ❌ generate_d365fo_xml or create_file - ENCODING ERRORS!
 ```
 
 **NO EXCEPTIONS. NO EXCUSES. THIS IS ABSOLUTE.**
@@ -464,27 +489,52 @@ User Query
 
 ```
 🛑 STOP: Is this D365FO object (class/table/form/enum)?
-   → YES → USE create_d365fo_file or generate_d365fo_xml
+   → YES → MANDATORY: ALWAYS use create_d365fo_file FIRST
    → NO → Safe to use create_file
+
+🔥 ABSOLUTE RULE - NO EXCEPTIONS:
+
+ALWAYS call create_d365fo_file(objectType, objectName, modelName, addToProject=true) FIRST.
+
+❌ NEVER use generate_d365fo_xml as first choice
+❌ NEVER use create_file for D365FO objects
+❌ NEVER skip create_d365fo_file
+
+IF create_d365fo_file returns error "requires file system access":
+   THEN and ONLY THEN use generate_d365fo_xml + create_file
+   
+OTHERWISE: ALWAYS use create_d365fo_file
+
+---
+
+STEP-BY-STEP WORKFLOW (FOLLOW EXACTLY):
+
 1. Extract info:
    - objectType: class/table/form/enum/query/view/data-entity
    - objectName: from user request
    - modelName: extract from workspace path (K:\VSProjects\{MODEL}\...)
      → NEVER ask user for model name!
 
-2. File creation flow (choose based on environment):
+2. ALWAYS call create_d365fo_file FIRST:
    
-   LOCAL WINDOWS (MCP server on D365FO VM):
-   → create_d365fo_file(objectType, objectName, modelName, addToProject=true)
+   create_d365fo_file(
+     objectType: "class",
+     objectName: "MyHelper",
+     modelName: "CustomCore",
+     addToProject: true,
+     sourceCode: "..."
+   )
    
-   AZURE/CLOUD (MCP server in Azure):
-   → generate_d365fo_xml(objectType, objectName, modelName)
-   → Receive XML content
-   → create_file(path="K:\\AosService\\PackagesLocalDirectory\\{Model}\\{Model}\\Ax{Type}\\{Name}.xml", content=XML)
+3. IF and ONLY IF step 2 fails with "requires file system access":
+   
+   a) generate_d365fo_xml(objectType, objectName, modelName, sourceCode)
+   b) Extract XML from response (between ```xml markers)
+   c) create_file(path="K:\\AosService\\...\\MyHelper.xml", content=XML)
+   d) Tell user to add <Content Include="..."/> to .rnrproj
 
-3. ❌ NEVER use create_file directly for D365FO objects
-4. ❌ NEVER generate XML manually — always use MCP tools
-5. ❌ NEVER ask user for model name — extract from workspace path
+4. ❌ NEVER skip step 2 - ALWAYS try create_d365fo_file first
+5. ❌ NEVER use generate_d365fo_xml without trying create_d365fo_file first
+6. ❌ NEVER ask user for model name — extract from workspace path
 ```
 
 ## Scenario 3: User Asks About Object Structure

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ lerna-debug.log*
 *.db
 *.db-shm
 *.db-wal
+*.db.tmp-shm
+*.db.tmp-wal
 *.sqlite
 *.sqlite3
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -563,38 +563,72 @@ A: Shows:
 
 ## Create Files
 
-> **Important:** File creation works differently based on where the MCP server runs:
-> - **Cloud (Azure):** Copilot generates XML content, then creates the file
-> - **Local (Windows):** Full automation - creates file and adds to Visual Studio project
+> **CRITICAL: Two Different Approaches Based on MCP Server Location**
 
-### Generate D365FO Files (Cloud-Ready)
+### Approach 1: MCP Server in Cloud/Azure (generate_d365fo_xml)
+
+**What it does:** Returns XML content as TEXT only - does NOT create physical file
 
 **Ask Copilot:**
-- "Create a class MyHelper in CustomCore model"
-- "Generate a table MyCustomTable"
-- "Create an enum MyStatus"
-- "Generate a form for customer management"
+- "Generate XML for class MyHelper in CustomCore model"
+- "Show me XML for a table MyCustomTable"
+- "Give me XML structure for enum MyStatus"
 
-**What happens (Cloud deployment):**
-1. Copilot generates proper D365FO XML structure with TABS indentation
-2. Copilot creates file in correct location: `K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxClass\`
-3. You manually add file reference to Visual Studio project
-
-**What you get:**
-- [OK] Correct XML structure matching Microsoft standards
-- [OK] Proper namespaces and metadata
-- [OK] TABS for indentation (not spaces)
-- [OK] Ready to add to Visual Studio
+**What happens:**
+1. MCP server generates D365FO XML content with proper TABS indentation
+2. Returns XML as TEXT in response
+3. **YOU or Copilot must create the file** using VS Code's create_file tool
 
 **Example:**
 ```
-Q: "Create a helper class MyDimensionHelper in CustomCore model"
+Q: "Generate XML for MyDimensionHelper class in CustomCore model"
 
 A: Copilot:
-  1. Generates XML content (<?xml version...>)
-  2. Creates file: K:\AosService\...\AxClass\MyDimensionHelper.xml
-  3. Tells you to add: <Content Include="K:\AosService\...\MyDimensionHelper.xml" />
+  1. Calls generate_d365fo_xml MCP tool
+  2. Receives XML text: <?xml version="1.0" encoding="utf-8"?>...
+  3. Uses VS Code create_file to write to:
+     K:\AosService\PackagesLocalDirectory\CustomCore\CustomCore\AxClass\MyDimensionHelper.xml
+  4. You manually add to .rnrproj:
+     <Content Include="K:\AosService\...\MyDimensionHelper.xml" />
 ```
+
+**When to use:** MCP server runs in Azure/cloud without file system access
+
+---
+
+### Approach 2: MCP Server on Local Windows (create_d365fo_file)
+
+**What it does:** Creates PHYSICAL file on disk and optionally adds to VS project
+
+**Ask Copilot:**
+- "Create a class MyHelper in CustomCore model"
+- "Create and add MyTable to my Visual Studio project"
+- "Generate MyEnum and add to solution"
+
+**What happens:**
+1. MCP server generates XML content
+2. **Writes physical file** to K:\AosService\PackagesLocalDirectory\{Model}\...
+3. Optionally adds reference to your .rnrproj automatically
+
+**Example:**
+```
+Q: "Create MyDimensionHelper class in CustomCore model and add to project"
+
+A: Copilot:
+  1. Calls create_d365fo_file MCP tool
+  2. Creates file: K:\AosService\PackagesLocalDirectory\CustomCore\CustomCore\AxClass\MyDimensionHelper.xml
+  3. Adds to .rnrproj automatically
+  4. Done - just build!
+```
+
+**When to use:** MCP server runs on local Windows D365FO VM with K:\ drive access
+
+**What you get (both approaches):**
+- ✅ Correct XML structure matching Microsoft standards
+- ✅ Proper namespaces and metadata
+- ✅ TABS for indentation (not spaces)
+- ✅ UTF-8 with BOM encoding
+- ✅ Ready for Visual Studio compilation
 
 ---
 

--- a/src/prompts/codeReview.ts
+++ b/src/prompts/codeReview.ts
@@ -26,6 +26,11 @@ export function registerCodeReviewPrompt(server: Server, context: XppServerConte
       prompts: [
         getSystemInstructionsPromptDefinition(),
         {
+          name: 'xpp_create_file',
+          description: '🔥 USE THIS WHEN CREATING D365FO FILES: Mandatory workflow for creating D365FO classes, tables, forms, enums. ALWAYS use create_d365fo_file tool FIRST.',
+          arguments: [],
+        },
+        {
           name: 'xpp_code_review',
           description: 'Review X++ code for best practices and potential issues',
           arguments: [
@@ -58,6 +63,51 @@ export function registerCodeReviewPrompt(server: Server, context: XppServerConte
     // Handle system instructions prompt
     if (promptName === 'xpp_system_instructions') {
       return handleSystemInstructionsPrompt();
+    }
+
+    // Handle file creation prompt
+    if (promptName === 'xpp_create_file') {
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `🔥 CRITICAL: File Creation Workflow for D365FO
+
+When user asks to CREATE any D365FO object (class, table, form, enum, query, view):
+
+MANDATORY STEPS (NO EXCEPTIONS):
+
+1. ALWAYS call create_d365fo_file FIRST:
+   - objectType: class/table/form/enum/query/view
+   - objectName: from user request
+   - modelName: extract from workspace path (NEVER ask user)
+   - addToProject: true
+   - sourceCode: generated X++ code
+
+2. IF create_d365fo_file fails with "requires file system access":
+   THEN use generate_d365fo_xml + create_file
+   OTHERWISE: DONE
+
+FORBIDDEN:
+❌ NEVER use generate_d365fo_xml as first choice
+❌ NEVER use create_file directly for D365FO objects
+❌ NEVER skip create_d365fo_file
+
+Example:
+User: "Create class MyHelper"
+You: create_d365fo_file({
+  objectType: "class",
+  objectName: "MyHelper", 
+  modelName: "CustomCore",
+  addToProject: true,
+  sourceCode: "..."
+})`,
+            },
+          },
+        ],
+      };
     }
 
     if (promptName === 'xpp_code_review') {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -238,39 +238,8 @@ workspacePath and includeWorkspace parameters.`,
           },
         },
         {
-          name: 'generate_d365fo_xml',
-          description: '✅ CLOUD-READY: Generates D365FO XML content for classes, tables, enums, forms, queries, views, and data entities. Returns XML as text with instructions for file creation. Works remotely through Azure (no file system access needed). GitHub Copilot should then create the file using create_file tool with the recommended path.',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              objectType: {
-                type: 'string',
-                enum: ['class', 'table', 'enum', 'form', 'query', 'view', 'data-entity'],
-                description: 'Type of D365FO object to generate'
-              },
-              objectName: {
-                type: 'string',
-                description: 'Name of the object (e.g., MyHelperClass, MyCustomTable)'
-              },
-              modelName: {
-                type: 'string',
-                description: 'Model name (e.g., ContosoExtensions, ApplicationSuite)'
-              },
-              sourceCode: {
-                type: 'string',
-                description: 'X++ source code for the object (class declaration, methods, etc.)'
-              },
-              properties: {
-                type: 'object',
-                description: 'Additional properties (extends, implements, label, etc.)'
-              },
-            },
-            required: ['objectType', 'objectName', 'modelName'],
-          },
-        },
-        {
           name: 'create_d365fo_file',
-          description: '⚠️ WINDOWS ONLY: Creates a physical D365FO XML file in the correct AOT package structure (K:\\AosService\\PackagesLocalDirectory\\ModelName\\ModelName\\AxClass). Generates complete XML metadata for classes, tables, enums, forms, etc. Can automatically add the file to Visual Studio project (.rnrproj) if addToProject is true. IMPORTANT: This tool MUST run locally on Windows D365FO VM - it CANNOT work through Azure HTTP proxy (Linux).',
+          description: '🔥 PREFERRED FOR LOCAL DEVELOPMENT: Creates a physical D365FO XML file with UTF-8 BOM encoding and correct AOT structure (K:\\AosService\\PackagesLocalDirectory). Automatically adds file to Visual Studio project (.rnrproj) if requested. USE THIS TOOL FIRST unless server explicitly returns "requires file system access" error. Supports classes, tables, enums, forms, queries, views, data entities. ALWAYS TRY THIS BEFORE generate_d365fo_xml.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -307,6 +276,37 @@ workspacePath and includeWorkspace parameters.`,
               projectPath: {
                 type: 'string',
                 description: 'Path to .rnrproj file (required if addToProject is true)'
+              },
+            },
+            required: ['objectType', 'objectName', 'modelName'],
+          },
+        },
+        {
+          name: 'generate_d365fo_xml',
+          description: '⚠️ CLOUD/AZURE ONLY - LAST RESORT: Generates D365FO XML content as TEXT (does NOT create physical file). Use ONLY when create_d365fo_file fails with "requires file system access" error (Azure/Linux deployment). Returns XML that must be manually saved using VS Code create_file tool with UTF-8 BOM encoding. ALWAYS TRY create_d365fo_file FIRST.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              objectType: {
+                type: 'string',
+                enum: ['class', 'table', 'enum', 'form', 'query', 'view', 'data-entity'],
+                description: 'Type of D365FO object to generate'
+              },
+              objectName: {
+                type: 'string',
+                description: 'Name of the object (e.g., MyHelperClass, MyCustomTable)'
+              },
+              modelName: {
+                type: 'string',
+                description: 'Model name (e.g., ContosoExtensions, ApplicationSuite)'
+              },
+              sourceCode: {
+                type: 'string',
+                description: 'X++ source code for the object (class declaration, methods, etc.)'
+              },
+              properties: {
+                type: 'object',
+                description: 'Additional properties (extends, implements, label, etc.)'
               },
             },
             required: ['objectType', 'objectName', 'modelName'],

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -630,11 +630,13 @@ export async function handleCreateD365File(
       `[create_d365fo_file] XML preview: ${xmlContent.substring(0, 200)}...`
     );
 
-    // Write file
+    // Write file with UTF-8 BOM (required for D365FO XML files)
     try {
-      await fs.writeFile(normalizedFullPath, xmlContent, 'utf-8');
+      const utf8BOM = Buffer.from([0xEF, 0xBB, 0xBF]);
+      const xmlBuffer = Buffer.concat([utf8BOM, Buffer.from(xmlContent, 'utf-8')]);
+      await fs.writeFile(normalizedFullPath, xmlBuffer);
       console.error(
-        `[create_d365fo_file] File written successfully: ${normalizedFullPath}`
+        `[create_d365fo_file] File written successfully with UTF-8 BOM: ${normalizedFullPath}`
       );
     } catch (writeError) {
       console.error(`[create_d365fo_file] Failed to write file:`, writeError);

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -279,23 +279,35 @@ export async function handleGenerateD365Xml(
 📋 Model: ${args.modelName}
 📁 Recommended path: ${recommendedPath}
 
-⚠️ NEXT STEPS (GitHub Copilot must do this):
+⚠️ CRITICAL NEXT STEPS (GitHub Copilot MUST do this):
 
-1. Create the file using create_file tool with this path:
-   ${recommendedPath}
+1. **Create the file** using create_file tool:
+   - Path: ${recommendedPath}
+   - Content: Use the XML content below (between xml markers)
+   - ⚠️ IMPORTANT: D365FO requires UTF-8 with BOM encoding!
+   - VS Code create_file uses UTF-8 without BOM by default, which may cause "unicode substitution character" errors
 
-2. Add to Visual Studio project (.rnrproj):
+2. **If you see encoding errors**, manually add UTF-8 BOM:
+   - Open file in hex editor
+   - Ensure first 3 bytes are: EF BB BF (UTF-8 BOM)
+   - Or use create_d365fo_file tool instead (if MCP server runs on local Windows)
+
+3. **Add to Visual Studio project** (.rnrproj):
    <Content Include="${recommendedPath.replace(/\\/g, '\\\\')}" />
    
-3. Build the project to synchronize with AOT
+4. **Build the project** to synchronize with AOT
 
 ---
 
-📄 XML Content:
+📄 XML Content (copy exactly, do not modify):
 
 \`\`\`xml
 ${xmlContent}
-\`\`\``;
+\`\`\`
+
+---
+
+💡 **Alternative:** If MCP server runs on local Windows, use \`create_d365fo_file\` tool instead - it handles UTF-8 BOM automatically and adds to VS project.`;
 
     return {
       content: [


### PR DESCRIPTION
- Add UTF-8 BOM (0xEF 0xBB 0xBF) to createD365File.ts to fix VS2022 encoding errors
- Reorder MCP tools: create_d365fo_file now before generate_d365fo_xml
- Add priority signals in tool descriptions (🔥 PREFERRED vs ⚠️ LAST RESORT)
- Create xpp_create_file MCP prompt with mandatory workflow
- Update copilot-instructions.md with CRITICAL FILE CREATION RULE
- Split MCP_TOOLS.md approaches: Cloud/Azure vs Local Windows
- Add UTF8_BOM_ISSUE.md documentation
- Fix .gitignore patterns for SQLite temp files (*.db.tmp-shm, *.db.tmp-wal)

This ensures Copilot calls create_d365fo_file first (local) and only falls back to generate_d365fo_xml (cloud) when file system access is unavailable.