### PR TITLE
fix: align Node.js version to 24 across App Service and startup script

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -16,7 +16,7 @@ Complete guide for installing and deploying the D365 F&O MCP Server.
 ## What You Need
 
 ### Software
-- **Node.js** 22.x or later (LTS recommended)
+- **Node.js** 24.x or later (LTS recommended)
 - **Git**
 - **Azure CLI** (for Azure deployment only)
 

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -16,7 +16,7 @@ param location string = resourceGroup().location
 param appServiceSku string = 'P0v3'
 
 @description('Node.js version')
-param nodeVersion string = '22-lts'
+param nodeVersion string = '24-lts'
 
 @description('Storage account SKU')
 @allowed([
@@ -121,7 +121,7 @@ resource appService 'Microsoft.Web/sites@2023-01-01' = {
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
-          value: '~20'
+          value: '~24'
         }
       ]
       appCommandLine: 'bash startup.sh'

--- a/startup.sh
+++ b/startup.sh
@@ -3,17 +3,25 @@
 
 set -e
 
-echo "🚀 Starting D365 F&O MCP Server..."
-echo "   PORT: ${PORT:-8080}"
-echo "   NODE_ENV: ${NODE_ENV:-production}"
+echo "Starting D365 F&O MCP Server..."
+echo "  PORT:     ${PORT:-8080}"
+echo "  NODE_ENV: ${NODE_ENV:-production}"
+echo "  Node:     $(node --version)"
 
 # Verify dist directory exists
 if [ ! -d "dist" ]; then
-  echo "❌ Error: dist directory not found"
-  echo "   Run 'npm run build' before deployment"
+  echo "Error: dist directory not found. Run 'npm run build' before deployment."
   exit 1
 fi
 
+# Rebuild native addons for the current Node.js version and platform.
+# This is required when the deployment package was built on a different
+# Node.js version or architecture than the App Service runtime.
+if ! node -e "require('better-sqlite3')" 2>/dev/null; then
+  echo "Rebuilding better-sqlite3 for current Node.js version..."
+  npm rebuild better-sqlite3
+fi
+
 # Start the server (database download happens within the app if configured)
-echo "🎯 Starting server..."
+echo "Starting server..."
 exec node dist/index.js


### PR DESCRIPTION
- Bump Bicep nodeVersion from 22-lts to 24-lts
- Fix WEBSITE_NODE_DEFAULT_VERSION from ~20 to ~24
- Add npm rebuild guard in startup.sh for better-sqlite3 native addon
- Update SETUP.md Node.js prerequisite to 24.x

Fixes 'Module did not self-register: better_sqlite3.node' health check failure caused by runtime/build Node.js version mismatch.