### PR TITLE
fix: correct deployment zip to let Oryx compile better-sqlite3 on App…

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -134,7 +134,7 @@ az webapp create \
   --name xpp-mcp-server \
   --plan xpp-mcp-plan \
   --resource-group your-rg \
-  --runtime "NODE:22-lts"
+  --runtime "NODE:24-lts"
 ```
 
 For a development/test server B1 SKU is sufficient. For production use P0v3 or higher.
@@ -156,13 +156,23 @@ az webapp config appsettings set \
 
 ```bash
 npm run build
-Compress-Archive -Path dist/* -DestinationPath deploy.zip
+
+# Include package.json and package-lock.json so App Service can run
+# npm ci at deploy time and compile better-sqlite3 for its own environment.
+# Do NOT include node_modules — Oryx builds them on the server.
+Compress-Archive -Path dist, package.json, package-lock.json, startup.sh `
+  -DestinationPath deploy.zip
 
 az webapp deployment source config-zip \
   --resource-group your-rg \
   --name xpp-mcp-server \
   --src deploy.zip
 ```
+
+> `SCM_DO_BUILD_DURING_DEPLOYMENT=true` (set in the Bicep template) tells Oryx
+> to run `npm ci` after the zip is unpacked. This compiles native addons such as
+> `better-sqlite3` against the exact Node.js version running on App Service,
+> avoiding the *"Module did not self-register"* error.
 
 ### 4. Verify
 

--- a/startup.sh
+++ b/startup.sh
@@ -14,14 +14,8 @@ if [ ! -d "dist" ]; then
   exit 1
 fi
 
-# Rebuild native addons for the current Node.js version and platform.
-# This is required when the deployment package was built on a different
-# Node.js version or architecture than the App Service runtime.
-if ! node -e "require('better-sqlite3')" 2>/dev/null; then
-  echo "Rebuilding better-sqlite3 for current Node.js version..."
-  npm rebuild better-sqlite3
-fi
-
 # Start the server (database download happens within the app if configured)
+# Note: native addons (better-sqlite3) are compiled by Oryx during deployment
+# via SCM_DO_BUILD_DURING_DEPLOYMENT=true — no rebuild needed at runtime.
 echo "Starting server..."
 exec node dist/index.js


### PR DESCRIPTION
… Service

The previous deployment zipped only dist/*, so SCM_DO_BUILD_DURING_DEPLOYMENT had nothing to run. App Service ended up with binaries cross-compiled on the pipeline agent (different glibc/Node patchlevel) which caused:
  ERR_DLOPEN_FAILED: Module did not self-register: better_sqlite3.node

Fix:
- Deployment zip now includes package.json + package-lock.json (no node_modules)
- Oryx runs npm ci on App Service, compiling better-sqlite3 in the right env
- Remove redundant npm rebuild guard from startup.sh (Oryx handles this)
- Fix Node:22-lts to Node:24-lts in az webapp create example in SETUP.md