### PR TITLE
fix: rebuild better-sqlite3 on NMV mismatch + add app deployment pipe…

### DIFF
--- a/.azure-pipelines/d365fo-mcp-app-deploy.yml
+++ b/.azure-pipelines/d365fo-mcp-app-deploy.yml
@@ -1,0 +1,126 @@
+# Azure Pipeline — Deploy MCP Server Application to App Service
+#
+# Compiles better-sqlite3 on ubuntu-latest (same Linux base as App Service)
+# with the same Node.js version as the App Service runtime.
+# Ships pre-built node_modules so no compilation is needed on the server.
+
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'startup.sh'
+      - 'tsconfig.json'
+      - '.azure-pipelines/d365fo-mcp-app-deploy.yml'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  - group: xpp-mcp-server-config
+  - name: nodeVersion
+    value: '24.x'
+
+stages:
+  - stage: Build
+    displayName: 'Build'
+    jobs:
+      - job: BuildJob
+        displayName: 'Compile and package'
+        steps:
+          - checkout: self
+            displayName: 'Checkout'
+            clean: true
+
+          - task: NodeTool@0
+            displayName: 'Use Node.js $(nodeVersion)'
+            inputs:
+              versionSpec: $(nodeVersion)
+
+          # npm ci compiles better-sqlite3 from source on ubuntu-latest.
+          # ubuntu-latest uses the same glibc as App Service Linux, so the
+          # resulting binary works at runtime without any rebuild step.
+          - script: npm ci
+            displayName: 'npm ci (compiles native addons for Node 24 / Linux)'
+
+          - script: npm run build
+            displayName: 'TypeScript compile → dist/'
+
+          # Archive everything the server needs to run.
+          # node_modules ARE included (pre-built for Node 24 / Linux).
+          # Source files, tests, and build tooling are excluded to keep zip small.
+          - task: ArchiveFiles@2
+            displayName: 'Create deployment zip'
+            inputs:
+              rootFolderOrFile: '$(System.DefaultWorkingDirectory)'
+              includeRootFolder: false
+              archiveType: zip
+              archiveFile: '$(Build.ArtifactStagingDirectory)/app.zip'
+              replaceExistingArchive: true
+              exclude: |
+                .git/**
+                .azure-pipelines/**
+                scripts/**
+                tests/**
+                test-data/**
+                coverage/**
+                src/**
+                docs/**
+                infrastructure/**
+                data/**
+                metadata/**
+                database/**
+                *.md
+                tsconfig.json
+                vitest.config.ts
+                .env*
+                .mcp.json*
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact'
+            inputs:
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)/app.zip'
+              ArtifactName: 'app'
+              publishLocation: Container
+
+  - stage: Deploy
+    displayName: 'Deploy to App Service'
+    dependsOn: Build
+    jobs:
+      - deployment: DeployJob
+        displayName: 'Deploy'
+        environment: 'production'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                # Pre-built node_modules are shipped in the zip — disable Oryx
+                # so it does not run a second npm ci on the server.
+                - task: AzureAppServiceSettings@1
+                  displayName: 'Set SCM_DO_BUILD_DURING_DEPLOYMENT=false'
+                  inputs:
+                    azureSubscription: '$(AZURE_SUBSCRIPTION)'
+                    appName: '$(AZURE_APP_SERVICE_NAME)'
+                    appSettings: |
+                      [
+                        { "name": "SCM_DO_BUILD_DURING_DEPLOYMENT", "value": "false" },
+                        { "name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~24" }
+                      ]
+
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy zip to App Service'
+                  inputs:
+                    ConnectionType: AzureRM
+                    azureSubscription: '$(AZURE_SUBSCRIPTION)'
+                    appType: webAppLinux
+                    WebAppName: '$(AZURE_APP_SERVICE_NAME)'
+                    packageForLinux: '$(Pipeline.Workspace)/app/app.zip'
+                    RuntimeStack: 'NODE|24-lts'
+                    StartupCommand: 'bash startup.sh'
+                    deployToSlotOrASE: false
+                    enableCustomDeployment: true
+                    DeploymentType: zipDeploy

--- a/startup.sh
+++ b/startup.sh
@@ -14,8 +14,31 @@ if [ ! -d "dist" ]; then
   exit 1
 fi
 
+# Rebuild better-sqlite3 if it was compiled for a different Node.js version.
+# NODE_MODULE_VERSION is stamped into the binary at compile time and must match
+# the running Node.js version exactly. A version drift (e.g. deploy with Node 22,
+# run with Node 24) causes ERR_DLOPEN_FAILED / "Module did not self-register".
+EXPECTED_NMV=$(node -e "process.stdout.write(String(process.versions.modules))")
+ADDON="node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+if [ -f "$ADDON" ]; then
+  ACTUAL_NMV=$(node -e "
+    try {
+      const b = require('fs').readFileSync('$ADDON');
+      const idx = b.indexOf('NODE_MODULE_VERSION');
+      const m = b.slice(idx, idx + 40).toString().match(/NODE_MODULE_VERSION (\\d+)/);
+      process.stdout.write(m ? m[1] : '0');
+    } catch(e) { process.stdout.write('0'); }
+  ")
+  if [ "$ACTUAL_NMV" != "$EXPECTED_NMV" ]; then
+    echo "Rebuilding better-sqlite3 (binary NMV=$ACTUAL_NMV, runtime NMV=$EXPECTED_NMV)..."
+    npm rebuild better-sqlite3
+    echo "Rebuild complete."
+  fi
+else
+  echo "better-sqlite3 binary not found, running npm rebuild..."
+  npm rebuild better-sqlite3
+fi
+
 # Start the server (database download happens within the app if configured)
-# Note: native addons (better-sqlite3) are compiled by Oryx during deployment
-# via SCM_DO_BUILD_DURING_DEPLOYMENT=true — no rebuild needed at runtime.
 echo "Starting server..."
 exec node dist/index.js


### PR DESCRIPTION
…line

startup.sh:
- On every start, check NODE_MODULE_VERSION stamped in the binary against the running Node.js version; only rebuild when they differ. This is the immediate fix for the current broken App Service instance (binary compiled for Node 22 / NMV 127, runtime is Node 24 / NMV 137).

d365fo-mcp-app-deploy.yml (new):
- Dedicated pipeline to deploy the MCP server application (vs data pipelines which only update the SQLite database and restart the service).
- Compiles better-sqlite3 on ubuntu-latest + Node 24 (same env as App Service) and ships pre-built node_modules, so no rebuild is needed on the server.
- Sets SCM_DO_BUILD_DURING_DEPLOYMENT=false to prevent Oryx from clobbering the pre-built binaries with its own npm ci.