### PR TITLE
provide the correct xml path to table methods

### DIFF
--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -123,7 +123,7 @@ export class XppMetadataParser {
         fields: this.parseFields(axTable.Fields?.AxTableField),
         indexes: this.parseIndexes(axTable.Indexes?.AxTableIndex),
         relations: this.parseRelations(axTable.Relations?.AxTableRelation),
-        methods: this.parseMethods(axTable.Methods?.Method, tableName),
+        methods: this.parseMethods(axTable.SourceCode?.Methods?.Method, tableName),
       };
 
       return { success: true, data: tableInfo };


### PR DESCRIPTION
While testing out the MCP server, I noticed that table methods are not extracted from the metadata. This change fixes that by providing the correct xml path to table methods.

See the following sample of the Microsoft standard `CustTable` xml file in the Foundation model:

``` xml
<?xml version="1.0" encoding="utf-8"?>
<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
	<Name>CustTable</Name>
	<SourceCode>
		<Declaration><![CDATA[
public class CustTable extends common
{
}
]]></Declaration>
		<Methods>
			<Method>
				<Name>address</Name>
				<Source><![CDATA[
    display LogisticsAddressing address()
    {
        return this.postalAddress().Address;
    }

]]></Source>
```