### PR TITLE
fix: resolve 6 broken tools found during audit

### DIFF
--- a/src/tools/completion.ts
+++ b/src/tools/completion.ts
@@ -21,8 +21,9 @@ export async function completionTool(request: CallToolRequest, context: XppServe
     const { symbolIndex, cache, workspaceScanner } = context;
     
     // ⚠️ EARLY CHECK: Is this a table? If yes, reject immediately!
-    const tableCheck = symbolIndex.searchSymbols(args.className, 1, ['table']);
-    if (tableCheck.length > 0) {
+    // Use exact-name lookup (not FTS search which does prefix matching and can false-positive)
+    const tableCheck = symbolIndex.getSymbolByName(args.className, 'table');
+    if (tableCheck) {
       return {
         content: [
           {
@@ -80,9 +81,9 @@ export async function completionTool(request: CallToolRequest, context: XppServe
     const completions = symbolIndex.getCompletions(args.className, args.prefix);
 
     if (completions.length === 0) {
-      // Check if the class/table exists at all
-      const classExists = symbolIndex.searchSymbols(args.className, 1, ['class']).length > 0;
-      const tableExists = symbolIndex.searchSymbols(args.className, 1, ['table']).length > 0;
+      // Check if the class/table exists at all (exact-name lookup, not FTS prefix match)
+      const classExists = symbolIndex.getSymbolByName(args.className, 'class') !== null;
+      const tableExists = symbolIndex.getSymbolByName(args.className, 'table') !== null;
       
       // ⚠️ CRITICAL: If it's a table, explicitly reject and redirect to get_table_info
       if (tableExists) {

--- a/src/tools/enumInfo.ts
+++ b/src/tools/enumInfo.ts
@@ -75,12 +75,21 @@ export async function getEnumInfoTool(request: CallToolRequest, context: XppServ
     // Primary: extracted-metadata JSON (always available, no file-path issues)
     rawXml = await readEnumRawXml(enumRow.model, enumName);
 
-    // Secondary: actual XML file (works only on D365FO VM)
+    // Secondary: file at DB path (may be XML on D365FO VM, or JSON metadata)
     if (!rawXml) {
       try {
-        rawXml = await fs.readFile(enumRow.file_path, 'utf-8');
+        const fileContent = await fs.readFile(enumRow.file_path, 'utf-8');
+        const trimmed = fileContent.trimStart();
+        if (trimmed.startsWith('{')) {
+          // JSON file (metadata dir) — extract raw XML from it
+          const data = JSON.parse(fileContent);
+          rawXml = typeof data.raw === 'string' ? data.raw : null;
+        } else {
+          // Actual XML file
+          rawXml = fileContent;
+        }
       } catch {
-        // Build-agent path not accessible
+        // Path not accessible
       }
     }
 

--- a/src/tools/findReferences.ts
+++ b/src/tools/findReferences.ts
@@ -279,7 +279,7 @@ function findClassReferences(symbolIndex: any, className: string, _scope: string
 
   // 3. Find instantiations (new ClassName())
   const instantiationStmt = symbolIndex.db.prepare(`
-    SELECT 
+    SELECT
       s.name,
       s.parent_name,
       s.file_path,
@@ -302,6 +302,44 @@ function findClassReferences(symbolIndex: any, className: string, _scope: string
         referenceType: 'instantiation',
         caller: row.parent_name ? `${row.parent_name}.${row.name}` : row.name,
       });
+    }
+  }
+
+  // 4. Find general type references (classStr(), variable declarations, static calls)
+  const typeRefPatterns = [
+    `%classStr(${className})%`,
+    `%${className}::%`,
+    `%${className} _%`,
+  ];
+
+  const typeRefStmt = symbolIndex.db.prepare(`
+    SELECT
+      s.name,
+      s.parent_name,
+      s.file_path,
+      s.model,
+      s.source_snippet
+    FROM symbols s
+    WHERE s.type = 'method'
+      AND (s.source_snippet LIKE ? OR s.source_snippet LIKE ? OR s.source_snippet LIKE ?)
+    LIMIT ?
+  `);
+
+  const typeRefRows = typeRefStmt.all(...typeRefPatterns, limit);
+  const existingCallers = new Set(references.map(r => r.caller));
+  for (const row of typeRefRows) {
+    const caller = row.parent_name ? `${row.parent_name}.${row.name}` : row.name;
+    if (existingCallers.has(caller)) continue; // skip duplicates
+    const context = extractTableReferenceContext(row.source_snippet, className);
+    if (context) {
+      references.push({
+        file: row.file_path,
+        model: row.model,
+        context: context,
+        referenceType: 'type-reference',
+        caller,
+      });
+      existingCallers.add(caller);
     }
   }
 

--- a/src/tools/formInfo.ts
+++ b/src/tools/formInfo.ts
@@ -113,16 +113,36 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
       throw new Error(`Form "${formName}" not found. Make sure it's indexed or provide workspacePath for local forms.`);
     }
 
-    // 2. Parse XML (file_path may point to build-agent path — not accessible on this server)
-    let xmlContent: string;
+    // 2. Read the form XML
+    // file_path may point to: (a) actual XML on disk, or (b) JSON metadata with sourcePath
+    let xmlContent: string | null = null;
     try {
-      xmlContent = await fs.readFile(formRow.file_path, 'utf-8');
+      const fileContent = await fs.readFile(formRow.file_path, 'utf-8');
+      const trimmed = fileContent.trimStart();
+      if (trimmed.startsWith('{')) {
+        // JSON metadata — extract sourcePath and read actual XML from there
+        const data = JSON.parse(fileContent);
+        if (data.sourcePath) {
+          try {
+            xmlContent = await fs.readFile(data.sourcePath, 'utf-8');
+          } catch {
+            // sourcePath not accessible
+          }
+        }
+      } else {
+        xmlContent = fileContent;
+      }
     } catch {
+      // file_path not accessible
+    }
+
+    if (!xmlContent) {
       return {
         content: [{ type: 'text', text: buildXmlNotAvailableMessage('form', formName, formRow.file_path) }],
         isError: true,
       };
     }
+
     const xmlObj = await parseStringPromise(xmlContent);
 
     // 3. Extract form info
@@ -149,9 +169,9 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
       formInfo.design = extractControls(axForm.Design[0]);
     }
 
-    // Extract methods
-    if (includeMethods && axForm.Methods) {
-      formInfo.methods = extractMethods(axForm.Methods[0]);
+    // Extract methods (form methods are under SourceCode > Methods, not top-level)
+    if (includeMethods && axForm.SourceCode && axForm.SourceCode[0] && axForm.SourceCode[0].Methods) {
+      formInfo.methods = extractMethods(axForm.SourceCode[0].Methods[0]);
     }
 
     // 4. Format output
@@ -176,11 +196,13 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
 function extractDataSources(dataSourcesNode: any): FormDataSource[] {
   const dataSources: FormDataSource[] = [];
 
-  if (!dataSourcesNode.AxFormDataSourceRoot) {
+  // Form XML uses AxFormDataSource (not AxFormDataSourceRoot)
+  const dsArray = dataSourcesNode.AxFormDataSource || dataSourcesNode.AxFormDataSourceRoot;
+  if (!dsArray) {
     return dataSources;
   }
 
-  for (const dsNode of dataSourcesNode.AxFormDataSourceRoot) {
+  for (const dsNode of dsArray) {
     const ds: FormDataSource = {
       name: dsNode.Name ? dsNode.Name[0] : 'Unknown',
       table: dsNode.Table ? dsNode.Table[0] : 'Unknown',
@@ -229,17 +251,12 @@ function extractDataSourceFields(fieldsNode: any): string[] {
 function extractControls(designNode: any): FormControl[] {
   const controls: FormControl[] = [];
 
-  // Find root container (usually FormDesign)
-  const rootKeys = Object.keys(designNode).filter(k => k.startsWith('AxForm'));
-  
-  for (const key of rootKeys) {
-    const nodes = designNode[key];
-    if (Array.isArray(nodes)) {
-      for (const node of nodes) {
-        const control = extractControl(node, key);
-        if (control) {
-          controls.push(control);
-        }
+  // Controls live under Design > Controls > AxFormControl[]
+  if (designNode.Controls && designNode.Controls[0] && designNode.Controls[0].AxFormControl) {
+    for (const node of designNode.Controls[0].AxFormControl) {
+      const control = extractControl(node);
+      if (control) {
+        controls.push(control);
       }
     }
   }
@@ -250,12 +267,12 @@ function extractControls(designNode: any): FormControl[] {
 /**
  * Extract single control
  */
-function extractControl(node: any, nodeType: string): FormControl | null {
+function extractControl(node: any): FormControl | null {
   if (!node) return null;
 
   const control: FormControl = {
     name: node.Name ? node.Name[0] : 'Unknown',
-    type: nodeType.replace('AxForm', ''),
+    type: node.Type ? node.Type[0] : 'Group',
     properties: {},
     children: [],
   };
@@ -281,17 +298,12 @@ function extractControl(node: any, nodeType: string): FormControl | null {
     }
   }
 
-  // Recursively extract child controls
-  const childKeys = Object.keys(node).filter(k => k.startsWith('AxForm') && k !== nodeType);
-  
-  for (const childKey of childKeys) {
-    const childNodes = node[childKey];
-    if (Array.isArray(childNodes)) {
-      for (const childNode of childNodes) {
-        const childControl = extractControl(childNode, childKey);
-        if (childControl) {
-          control.children.push(childControl);
-        }
+  // Recursively extract child controls (nested under Controls > AxFormControl)
+  if (node.Controls && node.Controls[0] && node.Controls[0].AxFormControl) {
+    for (const childNode of node.Controls[0].AxFormControl) {
+      const childControl = extractControl(childNode);
+      if (childControl) {
+        control.children.push(childControl);
       }
     }
   }

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -327,7 +327,13 @@ function buildCoCTemplate(
 
   template += returnType + ' ' + methodName + '(';
 
-  const paramStrings = parameters.map(p => p.type + ' ' + p.name);
+  const paramStrings = parameters.map(p => {
+    let ps = p.type + ' ' + p.name;
+    if (p.defaultValue) {
+      ps += ' = ' + p.defaultValue;
+    }
+    return ps;
+  });
   template += paramStrings.join(', ');
   template += ')\n';
   template += '\t{\n';

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -58,13 +58,34 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       throw new Error(`File not found for ${objectType} "${objectName}". Make sure the object exists and is indexed.`);
     }
 
-    // 2. Create backup if requested
-    if (createBackup) {
-      await createFileBackup(filePath);
+    // 2. Resolve actual XML file path (DB may store JSON metadata with sourcePath)
+    let xmlContent: string;
+    let actualFilePath = filePath;
+    try {
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+      const trimmed = fileContent.trimStart();
+      if (trimmed.startsWith('{')) {
+        const data = JSON.parse(fileContent);
+        if (data.sourcePath) {
+          actualFilePath = data.sourcePath;
+          xmlContent = await fs.readFile(data.sourcePath, 'utf-8');
+        } else {
+          throw new Error(`Metadata file has no sourcePath: ${filePath}`);
+        }
+      } else {
+        xmlContent = fileContent;
+      }
+    } catch (readError) {
+      if (readError instanceof SyntaxError || (readError instanceof Error && readError.message.includes('sourcePath'))) {
+        throw readError;
+      }
+      throw new Error(`Cannot read file: ${filePath}`);
     }
 
-    // 3. Read and parse XML
-    const xmlContent = await fs.readFile(filePath, 'utf-8');
+    // 3. Create backup of the actual XML file
+    if (createBackup) {
+      await createFileBackup(actualFilePath);
+    }
     const xmlObj = await parseStringPromise(xmlContent);
 
     // 4. Perform operation
@@ -113,14 +134,14 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     });
     
     const newXml = builder.buildObject(xmlObj);
-    await fs.writeFile(filePath, newXml, 'utf-8');
+    await fs.writeFile(actualFilePath, newXml, 'utf-8');
 
     // 6. Return success
     return {
       content: [
         {
           type: 'text',
-          text: `✅ ${message}\n\n**File:** ${filePath}\n**Backup:** ${createBackup ? 'Created' : 'Skipped'}\n\n**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate\n- Commit changes to source control`,
+          text: `✅ ${message}\n\n**File:** ${actualFilePath}\n**Backup:** ${createBackup ? 'Created' : 'Skipped'}\n\n**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate\n- Commit changes to source control`,
         },
       ],
     };
@@ -209,16 +230,26 @@ async function addMethod(xmlObj: any, objectType: string, args: any): Promise<bo
   // Navigate to Methods node
   const rootKey = getRootKey(objectType);
   const root = xmlObj[rootKey];
-  
-  if (!root || !root[0]) {
-    throw new Error(`Invalid XML structure: root node not found`);
+
+  if (!root) {
+    throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
   }
 
-  let methodsNode = root[0].Methods;
+  // For classes, methods are under SourceCode > Methods; for tables/forms, under Methods
+  let methodsContainer: any;
+  if (objectType === 'class') {
+    if (!root.SourceCode) {
+      root.SourceCode = [{ Methods: [{ $: { xmlns: '' }, Method: [] }] }];
+    }
+    methodsContainer = root.SourceCode[0];
+  } else {
+    methodsContainer = root;
+  }
+
+  let methodsNode = methodsContainer.Methods;
   if (!methodsNode) {
-    // Create Methods node if it doesn't exist
-    root[0].Methods = [{ Method: [] }];
-    methodsNode = root[0].Methods;
+    methodsContainer.Methods = [{ Method: [] }];
+    methodsNode = methodsContainer.Methods;
   }
 
   if (!methodsNode[0].Method) {
@@ -249,11 +280,17 @@ async function removeMethod(xmlObj: any, objectType: string, args: any): Promise
   const rootKey = getRootKey(objectType);
   const root = xmlObj[rootKey];
 
-  if (!root || !root[0] || !root[0].Methods || !root[0].Methods[0].Method) {
+  if (!root) {
+    throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
+  }
+
+  // For classes, methods are under SourceCode > Methods
+  const methodsContainer = objectType === 'class' ? root.SourceCode?.[0] : root;
+  if (!methodsContainer?.Methods?.[0]?.Method) {
     throw new Error('No methods found in object');
   }
 
-  const methods = root[0].Methods[0].Method;
+  const methods = methodsContainer.Methods[0].Method;
   const index = methods.findIndex((m: any) => m.Name && m.Name[0] === methodName);
 
   if (index === -1) {
@@ -285,14 +322,14 @@ async function addField(xmlObj: any, objectType: string, args: any): Promise<boo
   const rootKey = getRootKey(objectType);
   const root = xmlObj[rootKey];
 
-  if (!root || !root[0]) {
-    throw new Error('Invalid XML structure: root node not found');
+  if (!root) {
+    throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
   }
 
-  let fieldsNode = root[0].Fields;
+  let fieldsNode = root.Fields;
   if (!fieldsNode) {
-    root[0].Fields = [{ $: {}, AxTableField: [] }];
-    fieldsNode = root[0].Fields;
+    root.Fields = [{ $: {}, AxTableField: [] }];
+    fieldsNode = root.Fields;
   }
 
   if (!fieldsNode[0].AxTableField) {
@@ -342,11 +379,11 @@ async function removeField(xmlObj: any, objectType: string, args: any): Promise<
   const rootKey = getRootKey(objectType);
   const root = xmlObj[rootKey];
 
-  if (!root || !root[0] || !root[0].Fields || !root[0].Fields[0].AxTableField) {
+  if (!root?.Fields?.[0]?.AxTableField) {
     throw new Error('No fields found in table');
   }
 
-  const fields = root[0].Fields[0].AxTableField;
+  const fields = root.Fields[0].AxTableField;
   const index = fields.findIndex((f: any) => {
     // Field might be wrapped in different type nodes
     const fieldObj = Object.values(f)[0];
@@ -381,11 +418,9 @@ async function modifyProperty(xmlObj: any, objectType: string, args: any): Promi
   const rootKey = getRootKey(objectType);
   let current = xmlObj[rootKey];
 
-  if (!current || !current[0]) {
-    throw new Error('Invalid XML structure');
+  if (!current) {
+    throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
   }
-
-  current = current[0];
 
   // Navigate to property
   for (let i = 0; i < parts.length - 1; i++) {

--- a/src/utils/metadataResolver.ts
+++ b/src/utils/metadataResolver.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'url';
 // Resolve path relative to this file, not to process.cwd()
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const EXTRACTED_METADATA_BASE = path.resolve(__dirname, '../../extracted-metadata');
+const METADATA_BASE = path.resolve(__dirname, '../../metadata');
 
 export type ExtractedObjectType = 'classes' | 'enums' | 'edts' | 'tables' | 'views';
 
@@ -176,16 +177,19 @@ export async function readEnumRawXml(
   model: string,
   enumName: string
 ): Promise<string | null> {
-  const filePath = await resolveMetadataJsonPath(model, 'enums', enumName);
-  if (!filePath) return null;
-
-  try {
-    const raw = await fs.readFile(filePath, 'utf-8');
-    const data = JSON.parse(raw);
-    return typeof data.raw === 'string' ? data.raw : null;
-  } catch {
-    return null;
+  // Try extracted-metadata/ first, then metadata/ (DB file_path may point here)
+  for (const base of [EXTRACTED_METADATA_BASE, METADATA_BASE]) {
+    const filePath = path.join(base, model, 'enums', `${enumName}.json`);
+    try {
+      await fs.access(filePath);
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      return typeof data.raw === 'string' ? data.raw : null;
+    } catch {
+      continue;
+    }
   }
+  return null;
 }
 
 /**
@@ -196,16 +200,19 @@ export async function readEdtRawXml(
   model: string,
   edtName: string
 ): Promise<string | null> {
-  const filePath = await resolveMetadataJsonPath(model, 'edts', edtName);
-  if (!filePath) return null;
-
-  try {
-    const raw = await fs.readFile(filePath, 'utf-8');
-    const data = JSON.parse(raw);
-    return typeof data.raw === 'string' ? data.raw : null;
-  } catch {
-    return null;
+  // Try extracted-metadata/ first, then metadata/ (DB file_path may point here)
+  for (const base of [EXTRACTED_METADATA_BASE, METADATA_BASE]) {
+    const filePath = path.join(base, model, 'edts', `${edtName}.json`);
+    try {
+      await fs.access(filePath);
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      return typeof data.raw === 'string' ? data.raw : null;
+    } catch {
+      continue;
+    }
   }
+  return null;
 }
 
 export async function readViewMetadata(


### PR DESCRIPTION
## Summary

Full audit of all 24 MCP tools revealed 6 that were crashing or returning incorrect results. This PR fixes all 6:

- **`get_method_signature`** — CoC template was dropping default parameter values (the `buildCoCTemplate()` function didn't include `p.defaultValue` like `buildSignatureString()` already did)
- **`get_enum_info`** — crashed with "Non-whitespace before first tag" when `file_path` pointed to JSON metadata instead of raw XML
- **`find_references`** — `targetType='class'` returned 0 results because `findClassReferences()` only searched inheritance/instantiation, missing `classStr()`, `ClassName::`, and variable declarations
- **`code_completion`** — misidentified classes as tables because `searchSymbols()` uses FTS5 prefix matching which can match across unrelated columns; replaced with exact-match `getSymbolByName()`
- **`get_form_info`** — returned 0 datasources/controls/methods due to three wrong element paths: `AxFormDataSourceRoot` (should be `AxFormDataSource`), direct `Design.AxForm*` lookup (should be `Design.Controls[0].AxFormControl[]`), and `axForm.Methods` (should be `axForm.SourceCode[0].Methods`)
- **`modify_d365fo_file`** — crashed with "root node not found" because `xmlObj.AxClass[0]` is `undefined` (xml2js returns root as plain object, not array); also fixed class method path and added JSON metadata resolution

Also adds `METADATA_BASE` fallback in `metadataResolver.ts` so `readEnumRawXml()` and `readEdtRawXml()` check both `extracted-metadata/` and `metadata/` directories.

## Files Changed (7)

| File | Fix |
|------|-----|
| `src/tools/methodSignature.ts` | Include `defaultValue` in CoC template params |
| `src/tools/enumInfo.ts` | Detect JSON metadata, extract `raw` field |
| `src/tools/findReferences.ts` | Add type-reference search block with dedup |
| `src/tools/completion.ts` | Replace `searchSymbols` with `getSymbolByName` |
| `src/tools/formInfo.ts` | Fix element names, control hierarchy, method path, add JSON fallback |
| `src/tools/modifyD365File.ts` | Remove `[0]` on root, fix class method path, add JSON resolution |
| `src/utils/metadataResolver.ts` | Add `METADATA_BASE` constant, search both metadata dirs |

## Test plan

All 6 fixes verified with both Microsoft standard objects and custom objects:

- [x] `get_method_signature` — `SalesFormLetter.run` (MSFT) + custom HEB class
- [x] `get_enum_info` — `SalesStatus` (MSFT, 5 values) + `hebSQLOpr` (custom, 3 values)
- [x] `find_references` — `SalesFormLetter` targetType=class → 14 results (MSFT) + custom class → 1 result
- [x] `code_completion` — `SalesFormLetter` prefix=post → 1 method, no false table match (MSFT) + custom class correct
- [x] `get_form_info` — `CustTable` → 12 datasources, 633 controls, 44 methods (MSFT) + `hebDBLoggingDetail` → 1 ds, 13 controls, 3 methods (custom)
- [x] `modify_d365fo_file` — add-method + remove-method on custom class both succeed
- [x] `npm run build` — clean, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)