### PR TITLE
perf: apply server-wide performance and reliability optimizations

### DIFF
--- a/src/cache/cacheUtils.ts
+++ b/src/cache/cacheUtils.ts
@@ -3,53 +3,7 @@
  * Helper functions for smart caching with fuzzy matching
  */
 
-/**
- * Calculate Levenshtein distance between two strings
- * Used for fuzzy cache key matching
- */
-export function levenshteinDistance(str1: string, str2: string): number {
-  const len1 = str1.length;
-  const len2 = str2.length;
-  
-  // Create 2D array for dynamic programming
-  const dp: number[][] = Array(len1 + 1)
-    .fill(null)
-    .map(() => Array(len2 + 1).fill(0));
-  
-  // Initialize first row and column
-  for (let i = 0; i <= len1; i++) {
-    dp[i][0] = i;
-  }
-  for (let j = 0; j <= len2; j++) {
-    dp[0][j] = j;
-  }
-  
-  // Fill the DP table
-  for (let i = 1; i <= len1; i++) {
-    for (let j = 1; j <= len2; j++) {
-      const cost = str1[i - 1] === str2[j - 1] ? 0 : 1;
-      dp[i][j] = Math.min(
-        dp[i - 1][j] + 1,      // deletion
-        dp[i][j - 1] + 1,      // insertion
-        dp[i - 1][j - 1] + cost // substitution
-      );
-    }
-  }
-  
-  return dp[len1][len2];
-}
-
-/**
- * Calculate similarity score between two strings (0-1)
- * 1.0 = identical, 0.0 = completely different
- */
-export function similarityScore(str1: string, str2: string): number {
-  const maxLen = Math.max(str1.length, str2.length);
-  if (maxLen === 0) return 1.0;
-  
-  const distance = levenshteinDistance(str1, str2);
-  return 1.0 - distance / maxLen;
-}
+export { levenshteinDistance, similarityScore } from '../utils/fuzzyMatching.js';
 
 /**
  * Normalize a query string for consistent caching

--- a/src/cache/redisCache.ts
+++ b/src/cache/redisCache.ts
@@ -142,12 +142,15 @@ export class RedisCacheService {
       // Normalize the query for comparison
       const normalizedQuery = normalizeQuery(parsed.query);
 
-      // Get all keys with same prefix and type
+      // Get all keys with same prefix and type using SCAN (non-blocking, O(1) per call)
       const pattern = `${parsed.prefix}:${parsed.type}:*`;
-      const allKeys = await this.client.keys(pattern);
-
-      // Limit keys to check
-      const keysToCheck = allKeys.slice(0, this.MAX_FUZZY_KEYS);
+      const keysToCheck: string[] = [];
+      let cursor = '0';
+      do {
+        const [nextCursor, keys] = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+        cursor = nextCursor;
+        keysToCheck.push(...keys);
+      } while (cursor !== '0' && keysToCheck.length < this.MAX_FUZZY_KEYS);
 
       let bestMatch: { key: string; score: number } | null = null;
 

--- a/src/tools/analyzePatterns.ts
+++ b/src/tools/analyzePatterns.ts
@@ -10,7 +10,7 @@ import type { XppServerContext } from '../types/context.js';
 const AnalyzeCodePatternsArgsSchema = z.object({
   scenario: z.string().describe('Scenario or domain to analyze (e.g., "dimension", "validation", "customer")'),
   classPattern: z.string().optional().describe('Class name pattern filter (e.g., "Helper", "Service")'),
-  limit: z.number().optional().default(20).describe('Maximum number of classes to analyze'),
+  limit: z.number().max(100).optional().default(20).describe('Maximum number of classes to analyze'),
 });
 
 export async function analyzeCodePatternsTool(request: CallToolRequest, context: XppServerContext) {

--- a/src/tools/batchSearch.ts
+++ b/src/tools/batchSearch.ts
@@ -24,7 +24,7 @@ const SingleSearchSchema = z.object({
     .optional()
     .default('all')
     .describe('Filter by object type'),
-  limit: z.number().optional().default(10).describe('Maximum results per query'),
+  limit: z.number().max(100).optional().default(10).describe('Maximum results per query'),
   workspacePath: z.string().optional().describe('Optional workspace path'),
   includeWorkspace: z.boolean().optional().default(false).describe('Include workspace files'),
 });

--- a/src/tools/classInfo.ts
+++ b/src/tools/classInfo.ts
@@ -116,6 +116,20 @@ export async function classInfoTool(request: CallToolRequest, context: XppServer
         output += `No methods found in symbol index.\n`;
       }
 
+      // Cache the fallback result so repeated requests skip the parse attempt
+      await cache.setClassInfo(cacheKey, {
+        name: args.className,
+        extendsClass: null,
+        isFinal: false,
+        isAbstract: false,
+        methods: methods.map((m: any) => ({
+          name: m.name,
+          isStatic: false,
+          returnType: m.signature ?? 'void',
+          parameters: [],
+        })),
+      });
+
       return {
         content: [
           {

--- a/src/tools/getTablePatterns.ts
+++ b/src/tools/getTablePatterns.ts
@@ -13,7 +13,7 @@ const GetTablePatternsArgsSchema = z.object({
     .optional()
     .describe('Table group to analyze (Main, Transaction, Parameter, etc.)'),
   similarTo: z.string().optional().describe('Table name to find similar patterns'),
-  limit: z.number().optional().default(10).describe('Maximum number of examples to return'),
+  limit: z.number().max(100).optional().default(10).describe('Maximum number of examples to return'),
 });
 
 export interface FieldPattern {
@@ -60,8 +60,19 @@ export async function handleGetTablePatterns(
 export async function getTablePatternsTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = GetTablePatternsArgsSchema.parse(request.params.arguments);
-    const { symbolIndex } = context;
+    const { symbolIndex, cache } = context;
     const { tableGroup, similarTo, limit } = args;
+
+    // Check cache first - pattern analysis is expensive and semi-static
+    const cacheKey = cache.generateSearchKey(
+      similarTo || tableGroup || 'all',
+      limit,
+      'table_pattern'
+    );
+    const cachedOutput = await cache.get<string>(cacheKey);
+    if (cachedOutput) {
+      return { content: [{ type: 'text', text: cachedOutput }] };
+    }
 
     let output = `# Table Patterns Analysis\n\n`;
 
@@ -76,6 +87,8 @@ export async function getTablePatternsTool(request: CallToolRequest, context: Xp
     } else {
       throw new Error('Either tableGroup or similarTo must be provided');
     }
+
+    await cache.setPatternAnalysis(cacheKey, output);
 
     return {
       content: [{ type: 'text', text: output }],

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -21,7 +21,7 @@ import {
 const SearchArgsSchema = z.object({
   query: z.string().describe('Search query (class name, method name, etc.)'),
   type: z.enum(['class', 'table', 'form', 'field', 'method', 'enum', 'edt', 'query', 'view', 'all']).optional().default('all').describe('Filter by object type (class=AxClass, table=AxTable, form=AxForm, query=AxQuery, view=AxView, enum=AxEnum, edt=AxEdt, all=no filter)'),
-  limit: z.number().optional().default(20).describe('Maximum results to return'),
+  limit: z.number().max(100).optional().default(20).describe('Maximum results to return'),
   workspacePath: z.string().optional().describe('Optional workspace path to search local project files in addition to external metadata'),
   includeWorkspace: z.boolean().optional().default(false).describe('Whether to include workspace files in search results (workspace-aware search)'),
 });

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -136,41 +136,41 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         return getLabelInfoTool(request, context);
       case 'create_label':
         return createLabelTool(request, context);
-      case 'get_table_patterns':
-        return {
-          content: (await handleGetTablePatterns(
-            request.params.arguments as any,
-            context.symbolIndex
-          )).content,
-        };
-      case 'get_form_patterns':
-        return {
-          content: (await handleGetFormPatterns(
-            request.params.arguments as any,
-            context.symbolIndex
-          )).content,
-        };
-      case 'generate_smart_table':
-        return {
-          content: (await handleGenerateSmartTable(
-            request.params.arguments as any,
-            context.symbolIndex
-          )).content,
-        };
-      case 'generate_smart_form':
-        return {
-          content: (await handleGenerateSmartForm(
-            request.params.arguments as any,
-            context.symbolIndex
-          )).content,
-        };
-      case 'suggest_edt':
-        return {
-          content: (await handleSuggestEdt(
-            request.params.arguments as any,
-            context.symbolIndex
-          )).content,
-        };
+      case 'get_table_patterns': {
+        const r = await handleGetTablePatterns(
+          request.params.arguments as any,
+          context.symbolIndex
+        );
+        return { content: r?.content ?? [{ type: 'text', text: 'No results returned' }] };
+      }
+      case 'get_form_patterns': {
+        const r = await handleGetFormPatterns(
+          request.params.arguments as any,
+          context.symbolIndex
+        );
+        return { content: r?.content ?? [{ type: 'text', text: 'No results returned' }] };
+      }
+      case 'generate_smart_table': {
+        const r = await handleGenerateSmartTable(
+          request.params.arguments as any,
+          context.symbolIndex
+        );
+        return { content: r?.content ?? [{ type: 'text', text: 'No results returned' }] };
+      }
+      case 'generate_smart_form': {
+        const r = await handleGenerateSmartForm(
+          request.params.arguments as any,
+          context.symbolIndex
+        );
+        return { content: r?.content ?? [{ type: 'text', text: 'No results returned' }] };
+      }
+      case 'suggest_edt': {
+        const r = await handleSuggestEdt(
+          request.params.arguments as any,
+          context.symbolIndex
+        );
+        return { content: r?.content ?? [{ type: 'text', text: 'No results returned' }] };
+      }
       default:
         return {
           content: [

--- a/src/workspace/hybridSearch.ts
+++ b/src/workspace/hybridSearch.ts
@@ -6,6 +6,7 @@
 import type { XppSymbolIndex } from '../metadata/symbolIndex.js';
 import type { WorkspaceScanner, WorkspaceFile } from './workspaceScanner.js';
 import type { XppSymbol } from '../metadata/types.js';
+import { levenshteinDistance } from '../utils/fuzzyMatching.js';
 
 export interface HybridSearchResult {
   source: 'external' | 'workspace';
@@ -135,41 +136,11 @@ export class HybridSearch {
     // Contains = 50
     if (n.includes(q)) return 50;
 
-    // Fuzzy match = 30
-    const distance = this.levenshteinDistance(q, n);
-    if (distance <= 3) return 30;
+    // Fuzzy match: scale continuously by similarity instead of a flat 30
+    const distance = levenshteinDistance(q, n);
+    const similarity = 1 - distance / Math.max(q.length, n.length);
+    if (similarity >= 0.65) return Math.round(20 + similarity * 30); // 40–50 range
 
     return 10;
-  }
-
-  /**
-   * Levenshtein distance for fuzzy matching
-   */
-  private levenshteinDistance(a: string, b: string): number {
-    const matrix: number[][] = [];
-
-    for (let i = 0; i <= b.length; i++) {
-      matrix[i] = [i];
-    }
-
-    for (let j = 0; j <= a.length; j++) {
-      matrix[0][j] = j;
-    }
-
-    for (let i = 1; i <= b.length; i++) {
-      for (let j = 1; j <= a.length; j++) {
-        if (b.charAt(i - 1) === a.charAt(j - 1)) {
-          matrix[i][j] = matrix[i - 1][j - 1];
-        } else {
-          matrix[i][j] = Math.min(
-            matrix[i - 1][j - 1] + 1,
-            matrix[i][j - 1] + 1,
-            matrix[i - 1][j] + 1
-          );
-        }
-      }
-    }
-
-    return matrix[b.length][a.length];
   }
 }


### PR DESCRIPTION
- Replace Redis KEYS with non-blocking SCAN in getFuzzy (O(1) per call)
- Cache XML-parse fallback path in classInfo to avoid repeated DB hits
- Add cache + long TTL to getTablePatterns (expensive GROUP BY queries)
- Bound limit parameters to max(100) across search, batchSearch, analyzePatterns and getTablePatterns to prevent memory explosion
- Remove duplicate levenshteinDistance/similarityScore from cacheUtils and hybridSearch; consolidate into fuzzyMatching.ts as single source
- Improve hybridSearch relevance scoring from flat 30 to continuous similarity scale (40-50 range) for better result ranking
- Add null-safety (optional chaining + nullish coalescing) to all inline .content unwraps in toolHandler for pattern/smart tools