### PR TITLE
Fix server mode configuration and add tool filtering visibility

### DIFF
--- a/.azure-pipelines/d365fo-mcp-app-deploy.yml
+++ b/.azure-pipelines/d365fo-mcp-app-deploy.yml
@@ -128,7 +128,8 @@ stages:
                     appSettings: |
                       [
                         { "name": "SCM_DO_BUILD_DURING_DEPLOYMENT", "value": "false" },
-                        { "name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~24" }
+                        { "name": "WEBSITE_NODE_DEFAULT_VERSION", "value": "~24" },
+                        { "name": "MCP_SERVER_MODE", "value": "read-only" }
                       ]
 
                 - task: AzureRmWebAppDeployment@4

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -204,12 +204,41 @@ GitHub Copilot connects to both servers at the same time and selects the right o
 4. When Copilot calls `create_d365fo_file`, it goes to the local server which has K:\ access
 5. When Copilot calls `search`, it goes to the Azure server with the full metadata database
 
+### Verifying the tool filtering
+
+When the server starts, it logs the detected mode and tool count:
+
+**Write-only mode (local companion):**
+```
+🔧 Server mode: write-only (from env: write-only)
+🎯 Registered 3 X++ MCP tools (create_d365fo_file, modify_d365fo_file, create_label)
+[MCP Server] Tool list filtered for write-only mode: 3 tools (create_d365fo_file, modify_d365fo_file, create_label)
+```
+
+**Read-only mode (Azure server):**
+```
+🔧 Server mode: read-only (from env: read-only)
+🎯 Registered 26 X++ MCP tools (all except write tools)
+[MCP Server] Tool list filtered for read-only mode: 26 tools (write tools excluded)
+```
+
+**Full mode (local development):**
+```
+🔧 Server mode: full (from env: not set, defaulting to full)
+🎯 Registered 29 X++ MCP tools (8 discovery + 3 labels + 5 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis)
+[MCP Server] Tool list in full mode: 29 tools (no filtering)
+```
+
 > **Note:** The local server in `write-only` mode still needs access to the metadata database
 > (for path resolution and model detection), but it doesn't need Redis or Azure Blob Storage.
 
 ### Azure App Service settings for read-only mode
 
-In your Azure App Service configuration, add:
+The `MCP_SERVER_MODE=read-only` environment variable is **automatically set** when deploying via:
+- The Bicep infrastructure template (`infrastructure/main.bicep`)
+- The Azure DevOps deployment pipeline (`.azure-pipelines/d365fo-mcp-app-deploy.yml`)
+
+If you're deploying manually or through a different method, ensure you add this setting in your Azure App Service configuration:
 
 ```
 MCP_SERVER_MODE=read-only

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -123,6 +123,10 @@ resource appService 'Microsoft.Web/sites@2023-01-01' = {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
           value: '~24'
         }
+        {
+          name: 'MCP_SERVER_MODE'
+          value: 'read-only'
+        }
       ]
       appCommandLine: 'bash startup.sh'
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ const serverState: ServerState = {
 
 async function initializeServices() {
   console.log('🚀 Starting X++ MCP Code Completion Server...');
+  console.log(`🔧 Server mode: ${SERVER_MODE} (from env: ${process.env.MCP_SERVER_MODE || 'not set, defaulting to full'})`);
 
   // -----------------------------------------------------------------------
   // write-only mode: skip all database/symbol work — file-operation tools
@@ -297,6 +298,7 @@ async function main() {
   }
 
   console.log(`📡 Mode: ${isStdioMode ? 'STDIO' : 'HTTP'}`);
+  console.log(`🔧 Server mode: ${SERVER_MODE}`);
 
   if (isStdioMode) {
     // STDIO mode - initialize synchronously before connecting
@@ -305,7 +307,14 @@ async function main() {
     const transport = new StdioServerTransport();
     await mcpServer.connect(transport);
     console.log('✅ Stdio transport connected');
-    console.log('🎯 Registered 29 X++ MCP tools (8 discovery + 3 labels + 5 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis)');
+    
+    // Log actual tool count based on server mode
+    const toolCount = SERVER_MODE === 'write-only' ? 3 : 
+                     SERVER_MODE === 'read-only' ? 26 : 29;
+    const toolDesc = SERVER_MODE === 'write-only' ? '(create_d365fo_file, modify_d365fo_file, create_label)' :
+                    SERVER_MODE === 'read-only' ? '(all except write tools)' :
+                    '(8 discovery + 3 labels + 5 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis)';
+    console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
     serverState.statusMessage = 'Ready';
@@ -349,6 +358,7 @@ async function main() {
     app.listen(PORT, host, () => {
       console.log(`✅ D365 F&O MCP Server listening on ${host}:${PORT}`);
       console.log(`🏥 Health check: http://localhost:${PORT}/health`);
+      console.log(`🔧 Server mode: ${SERVER_MODE}`);
       console.log('⏳ Initializing services asynchronously...');
     });
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1303,8 +1303,12 @@ Examples:
     // Apply server mode filter
     if (SERVER_MODE === 'read-only') {
       allTools.tools = allTools.tools.filter(t => !WRITE_TOOLS.has(t.name));
+      console.error(`[MCP Server] Tool list filtered for read-only mode: ${allTools.tools.length} tools (write tools excluded)`);
     } else if (SERVER_MODE === 'write-only') {
       allTools.tools = allTools.tools.filter(t => WRITE_TOOLS.has(t.name));
+      console.error(`[MCP Server] Tool list filtered for write-only mode: ${allTools.tools.length} tools (${Array.from(WRITE_TOOLS).join(', ')})`);
+    } else {
+      console.error(`[MCP Server] Tool list in full mode: ${allTools.tools.length} tools (no filtering)`);
     }
 
     return allTools;


### PR DESCRIPTION
- Add MCP_SERVER_MODE=read-only to Azure Bicep template and deployment pipeline
- Add comprehensive logging showing detected server mode and filtered tool count
- Fix hardcoded tool count log message to reflect actual mode (3/26/29 tools)
- Update documentation with verification examples for each server mode
- Ensure Azure deployments properly run in read-only mode by default