### PR TITLE
Fix 404 on /mcp during server startup (async init race)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -330,6 +330,29 @@ async function main() {
     
     app.use(express.json());
 
+    // Register /mcp immediately so MCP clients don't get 404 during startup.
+    // While server is initializing, return JSON-RPC 503 so the client retries
+    // instead of treating it as a permanent "method not found" failure.
+    app.use('/mcp', (req, res, next) => {
+      if (!serverState.isReady) {
+        // Only gate POST requests (actual tool calls); let the transport handle
+        // other methods (GET for SSE etc.) once registered.
+        if (req.method === 'POST') {
+          const id = (req.body as any)?.id ?? null;
+          res.status(503).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: `Server is starting up (${serverState.statusMessage}). Please retry in a few seconds.`,
+            },
+            id,
+          });
+          return;
+        }
+      }
+      next();
+    });
+
     // Health check endpoint - responds immediately with current state
     app.get('/health', (_req, res) => {
       if (!serverState.isReady) {


### PR DESCRIPTION
In HTTP mode the /mcp route was only registered after initializeServices() completed (can take 10-30s while downloading the database from Azure Blob). Any MCP tool call that arrived during that window — including VS Copilot's initial capability probe — received a 404, causing FunctionInvoker errors.

Fix: register a /mcp readiness guard middleware immediately at startup. While serverState.isReady is false it returns a JSON-RPC 503 response so the client can retry. Once ready it calls next() and Express forwards to the real transport POST handler that was registered by createStreamableHttpTransport.