### PR TITLE
feat: MS naming guidelines compliance + EXTENSION_PREFIX support

### DIFF
--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -5,15 +5,24 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
 
 const CodeGenArgsSchema = z.object({
   pattern: z
     .enum(['class', 'runnable', 'form-handler', 'data-entity', 'batch-job', 'table-extension'])
     .describe('Code pattern to generate'),
-  name: z.string().describe('Name for the generated element'),
+  name: z.string().describe(
+    'For NEW objects (class, runnable, data-entity, batch-job): the object name WITHOUT prefix — prefix is auto-applied from EXTENSION_PREFIX env var or modelName. ' +
+    'For EXTENSIONS (table-extension, form-handler): the BASE element name to extend (e.g. "CustTable", "SalesTable").'
+  ),
+  modelName: z.string().optional().describe(
+    'Model/solution prefix used to derive the naming infix when EXTENSION_PREFIX is not set (e.g. "AslCore"). ' +
+    'Required for extension patterns when EXTENSION_PREFIX is not configured.'
+  ),
 });
 
-const templates: Record<string, (name: string) => string> = {
+// Templates for NEW elements: (name already includes prefix)
+const newElementTemplates: Record<string, (name: string) => string> = {
   class: (name) => `
 /// <summary>
 /// ${name} class
@@ -51,41 +60,6 @@ internal final class ${name}
     }
 }`,
 
-  'form-handler': (name) => `
-/// <summary>
-/// Form extension for ${name}
-/// </summary>
-[ExtensionOf(formStr(${name}))]
-final class ${name}Form_Extension
-{
-    /// <summary>
-    /// Form initialization
-    /// </summary>
-    public void init()
-    {
-        next init();
-        // TODO: Add custom initialization logic
-    }
-
-    /// <summary>
-    /// Form close
-    /// </summary>
-    public void close()
-    {
-        // TODO: Add cleanup logic
-        next close();
-    }
-
-    /// <summary>
-    /// Data source active
-    /// </summary>
-    [FormDataSourceEventHandler(formDataSourceStr(${name}, <DataSourceName>), FormDataSourceEventType::Activated)]
-    public static void <DataSourceName>_OnActivated(FormDataSource sender, FormDataSourceEventArgs e)
-    {
-        // TODO: Handle data source activation
-    }
-}`,
-
   'data-entity': (name) => `
 /// <summary>
 /// Data entity for ${name}
@@ -101,12 +75,12 @@ public class ${name}Entity extends common
     public static ${name}Entity find(RecId _recId, boolean _forUpdate = false)
     {
         ${name}Entity entity;
-        
+
         entity.selectForUpdate(_forUpdate);
-        
+
         select firstonly entity
             where entity.RecId == _recId;
-            
+
         return entity;
     }
 
@@ -117,9 +91,9 @@ public class ${name}Entity extends common
     public boolean validateWrite()
     {
         boolean ret = super();
-        
+
         // TODO: Add custom validation
-        
+
         return ret;
     }
 }`,
@@ -180,21 +154,71 @@ class ${name}Service extends SysOperationServiceBase
     {
         // TODO: Implement batch processing logic
         ttsbegin;
-        
+
         // Your logic here
-        
+
         ttscommit;
-        
+
         info(strFmt("${name} completed successfully"));
     }
 }`,
+};
 
-  'table-extension': (name) => `
+// Templates for EXTENSION elements: (baseName = element being extended, prefix = model/ISV infix)
+// Naming rules per https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/naming-guidelines-extensions:
+//   table-extension class : {BaseTable}{Prefix}_Extension   (e.g. CustTableWHS_Extension)
+//   form-handler class    : {BaseForm}{Prefix}Form_Extension (e.g. SalesTableWHSForm_Extension)
+
+function formHandlerTemplate(baseName: string, prefix: string): string {
+  // Class name: {BaseForm}{Prefix}Form_Extension
+  const className = baseName + prefix + 'Form_Extension';
+  return `
 /// <summary>
-/// Table extension for ${name}
+/// Form extension class for ${baseName} (prefix: ${prefix})
+/// Naming: {BaseForm}{Prefix}Form_Extension per MS naming guidelines
 /// </summary>
-[ExtensionOf(tableStr(${name}))]
-final class ${name}_Extension
+[ExtensionOf(formStr(${baseName}))]
+final class ${className}
+{
+    /// <summary>
+    /// Form initialization
+    /// </summary>
+    public void init()
+    {
+        next init();
+        // TODO: Add custom initialization logic
+    }
+
+    /// <summary>
+    /// Form close
+    /// </summary>
+    public void close()
+    {
+        // TODO: Add cleanup logic
+        next close();
+    }
+
+    /// <summary>
+    /// Data source active event handler
+    /// </summary>
+    [FormDataSourceEventHandler(formDataSourceStr(${baseName}, DataSourceName), FormDataSourceEventType::Activated)]
+    public static void DataSourceName_OnActivated(FormDataSource sender, FormDataSourceEventArgs e)
+    {
+        // TODO: Handle data source activation
+    }
+}`;
+}
+
+function tableExtensionTemplate(baseName: string, prefix: string): string {
+  // Class name: {BaseTable}{Prefix}_Extension
+  const className = baseName + prefix + '_Extension';
+  return `
+/// <summary>
+/// Table extension class for ${baseName} (prefix: ${prefix})
+/// Naming: {BaseTable}{Prefix}_Extension per MS naming guidelines
+/// </summary>
+[ExtensionOf(tableStr(${baseName}))]
+final class ${className}
 {
     /// <summary>
     /// Validate write
@@ -202,9 +226,9 @@ final class ${name}_Extension
     public boolean validateWrite()
     {
         boolean ret = next validateWrite();
-        
+
         // TODO: Add custom validation
-        
+
         return ret;
     }
 
@@ -214,9 +238,9 @@ final class ${name}_Extension
     public void insert()
     {
         // TODO: Add pre-insert logic
-        
+
         next insert();
-        
+
         // TODO: Add post-insert logic
     }
 
@@ -226,37 +250,82 @@ final class ${name}_Extension
     public void update()
     {
         // TODO: Add pre-update logic
-        
+
         next update();
-        
+
         // TODO: Add post-update logic
     }
-}`,
+}`;
+}
+
+const extensionTemplates: Record<string, (baseName: string, prefix: string) => string> = {
+  'form-handler': formHandlerTemplate,
+  'table-extension': tableExtensionTemplate,
 };
+
+const EXTENSION_PATTERNS = new Set(['table-extension', 'form-handler']);
 
 export async function codeGenTool(request: CallToolRequest) {
   try {
     const args = CodeGenArgsSchema.parse(request.params.arguments);
-    const template = templates[args.pattern];
-    if (!template) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Unknown pattern: ${args.pattern}`,
-          },
-        ],
-        isError: true,
-      };
-    }
 
-    const code = template(args.name);
+    // Resolve prefix: EXTENSION_PREFIX env var (stripped of trailing '_') or modelName arg or empty
+    const prefix = resolveObjectPrefix(args.modelName ?? '');
+
+    let code: string;
+    let displayName: string;
+    let namingNote: string;
+
+    if (EXTENSION_PATTERNS.has(args.pattern)) {
+      // Extension pattern — args.name is the BASE element; prefix becomes the infix
+      const extTemplate = extensionTemplates[args.pattern];
+      if (!extTemplate) {
+        return {
+          content: [{ type: 'text', text: `Unknown extension pattern: ${args.pattern}` }],
+          isError: true,
+        };
+      }
+      code = extTemplate(args.name, prefix);
+      displayName = args.name;
+      const exampleClass =
+        args.pattern === 'table-extension'
+          ? `${args.name}${prefix}_Extension`
+          : `${args.name}${prefix}Form_Extension`;
+      namingNote = prefix
+        ? `📌 **Naming (MS guidelines):** Generated class: \`${exampleClass}\`\n  Base element: \`${args.name}\`, Prefix infix: \`${prefix}\``
+        : `⚠️ **No prefix resolved** — set \`EXTENSION_PREFIX\` env var or pass \`modelName\` argument.\n  Generated bare name without prefix infix (e.g. \`${args.name}_Extension\`) which is **not MS-compliant**.`;
+    } else {
+      // New element pattern — apply prefix to the name
+      const newTemplate = newElementTemplates[args.pattern];
+      if (!newTemplate) {
+        return {
+          content: [{ type: 'text', text: `Unknown pattern: ${args.pattern}` }],
+          isError: true,
+        };
+      }
+      const finalName = applyObjectPrefix(args.name, prefix);
+      code = newTemplate(finalName);
+      displayName = finalName;
+      namingNote = prefix
+        ? `📌 **Naming (MS guidelines):** Object name with prefix: \`${finalName}\``
+        : `⚠️ **No prefix resolved** — set \`EXTENSION_PREFIX\` env var or pass \`modelName\` to auto-prefix new objects.`;
+    }
 
     return {
       content: [
         {
           type: 'text',
-          text: `Generated ${args.pattern} template for "${args.name}":\n\n\`\`\`xpp${code}\n\`\`\`\n\n---\n\n💡 **Next Steps for Better Code Quality:**\n\n1. ✅ Use \`analyze_code_patterns("<scenario>")\` - Learn what D365FO classes are commonly used together\n2. ✅ Use \`suggest_method_implementation("${args.name}", "<methodName>")\` - Get real implementation examples\n3. ✅ Use \`analyze_class_completeness("${args.name}")\` - Check for missing common methods\n4. ✅ Use \`get_api_usage_patterns("<ClassName>")\` - See how to use D365FO APIs correctly\n\nThese tools provide patterns from the actual codebase, not generic templates.`,
+          text:
+            `Generated ${args.pattern} template for "${displayName}":\n\n` +
+            `\`\`\`xpp${code}\n\`\`\`\n\n` +
+            `---\n\n` +
+            `${namingNote}\n\n` +
+            `💡 **Next Steps for Better Code Quality:**\n\n` +
+            `1. ✅ Use \`analyze_code_patterns("<scenario>")\` - Learn what D365FO classes are commonly used together\n` +
+            `2. ✅ Use \`suggest_method_implementation("${displayName}", "<methodName>")\` - Get real implementation examples\n` +
+            `3. ✅ Use \`analyze_class_completeness("${displayName}")\` - Check for missing common methods\n` +
+            `4. ✅ Use \`get_api_usage_patterns("<ClassName>")\` - See how to use D365FO APIs correctly\n\n` +
+            `These tools provide patterns from the actual codebase, not generic templates.`,
         },
       ],
     };

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -9,7 +9,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { Parser, Builder } from 'xml2js';
 import { getConfigManager } from '../utils/configManager.js';
-import { registerCustomModel } from '../utils/modelClassifier.js';
+import { registerCustomModel, resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 
 const CreateD365FileArgsSchema = z.object({
@@ -762,6 +762,13 @@ export async function handleCreateD365File(
       `[create_d365fo_file] Final ModelName to use: ${actualModelName}${wasAutoExtracted ? ' (auto-extracted ✓)' : ' (as-is, NOT auto-extracted ⚠️)'}`
     );
 
+    // Apply extension prefix to object name
+    const objectPrefix = resolveObjectPrefix(actualModelName);
+    const finalObjectName = applyObjectPrefix(args.objectName, objectPrefix);
+    if (finalObjectName !== args.objectName) {
+      console.error(`[create_d365fo_file] Applied prefix "${objectPrefix}": ${args.objectName} → ${finalObjectName}`);
+    }
+
     // Determine object folder based on type
     const objectFolderMap: Record<string, string> = {
       class: 'AxClass',
@@ -832,7 +839,7 @@ export async function handleCreateD365File(
       actualModelName,
       objectFolder,
     );
-    const fileName = `${args.objectName}.xml`;
+    const fileName = `${finalObjectName}.xml`;
     const fullPath = path.join(modelPath, fileName);
     
     // Normalize path to Windows format (backslashes) for consistency
@@ -920,7 +927,7 @@ export async function handleCreateD365File(
     // Generate XML content
     const xmlContent = XmlTemplateGenerator.generate(
       args.objectType,
-      args.objectName,
+      finalObjectName,
       args.sourceCode,
       args.properties
     );
@@ -1028,7 +1035,7 @@ export async function handleCreateD365File(
           const wasAdded = await projectManager.addToProject(
             projectPath,
             args.objectType,
-            args.objectName,
+            finalObjectName,
             absoluteXmlPath
           );
 
@@ -1078,7 +1085,7 @@ export async function handleCreateD365File(
           type: 'text',
           text: `✅ Successfully created D365FO ${args.objectType} file:\n\n` +
             `📁 Path: ${normalizedFullPath}\n` +
-            `📄 Object: ${args.objectName}\n` +
+            `📄 Object: ${finalObjectName}${finalObjectName !== args.objectName ? ` (prefixed from "${args.objectName}")` : ''}\n` +
             `📦 Model: ${actualModelName}\n` +
             `🔧 Type: ${objectFolder}\n` +
             projectMessage +

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -10,6 +10,7 @@ import { handleGetFormPatterns } from './getFormPatterns.js';
 import path from 'path';
 import fs from 'fs';
 import { getConfigManager } from '../utils/configManager.js';
+import { resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
 
 interface GenerateSmartFormArgs {
   name: string;
@@ -210,10 +211,62 @@ export async function handleGenerateSmartForm(
     console.warn(`[generateSmartForm] No datasource configured, form will be empty`);
   }
 
+  // Determine package path
+  const configManager = getConfigManager();
+  const packagePath = configManager.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
+
+  // Resolve project/solution path — fall back to configManager (from .mcp.json / auto-detection)
+  let resolvedProjectPath = projectPath;
+  let resolvedSolutionPath = solutionPath;
+  if (!resolvedProjectPath && !resolvedSolutionPath) {
+    resolvedProjectPath = (await configManager.getProjectPath()) || undefined;
+    resolvedSolutionPath = (await configManager.getSolutionPath()) || undefined;
+    if (resolvedProjectPath) {
+      console.log(`[generateSmartForm] Using projectPath from config/auto-detect: ${resolvedProjectPath}`);
+    } else if (resolvedSolutionPath) {
+      console.log(`[generateSmartForm] Using solutionPath from config/auto-detect: ${resolvedSolutionPath}`);
+    }
+  }
+
+  // Resolve actual model name — always prefer extracting from .rnrproj over using modelName arg
+  let resolvedModel = modelName;
+  if (resolvedProjectPath) {
+    const extracted = extractModelFromProject(resolvedProjectPath);
+    if (extracted) {
+      resolvedModel = extracted;
+      console.log(`[generateSmartForm] Extracted model from .rnrproj: ${resolvedModel}`);
+    }
+  } else if (resolvedSolutionPath) {
+    const project = findProjectInSolution(resolvedSolutionPath);
+    if (project) {
+      const extracted = extractModelFromProject(project);
+      if (extracted) {
+        resolvedModel = extracted;
+        console.log(`[generateSmartForm] Extracted model from solution .rnrproj: ${resolvedModel}`);
+      }
+    }
+  }
+
+  if (!resolvedModel) {
+    throw new Error(
+      'Could not resolve model name. Provide modelName, projectPath, or solutionPath, ' +
+      'or configure projectPath/solutionPath in .mcp.json.'
+    );
+  }
+
+  console.log(`[generateSmartForm] Using model: ${resolvedModel}`);
+
+  // Apply extension prefix to form name
+  const objectPrefix = resolveObjectPrefix(resolvedModel);
+  const finalName = applyObjectPrefix(name, objectPrefix);
+  if (finalName !== name) {
+    console.log(`[generateSmartForm] Applied prefix "${objectPrefix}": ${name} → ${finalName}`);
+  }
+
   // Generate XML
   const xml = builder.buildFormXml({
-    name,
-    label: label || name,
+    name: finalName,
+    label: label || finalName,
     caption,
     dataSources,
     controls,
@@ -221,38 +274,42 @@ export async function handleGenerateSmartForm(
 
   console.log(`[generateSmartForm] Generated XML (${xml.length} bytes)`);
 
-  // Determine package path
-  const packagePath = getConfigManager().getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
-
   // Write to file
-  let targetPath: string;
+  const targetPath = path.join(packagePath, resolvedModel, resolvedModel, 'AxForm', `${finalName}.xml`);
 
-  if (modelName) {
-    targetPath = path.join(packagePath, modelName, modelName, 'AxForm', `${name}.xml`);
-  } else if (projectPath) {
-    const model = extractModelFromProject(projectPath);
-    targetPath = path.join(packagePath, model, model, 'AxForm', `${name}.xml`);
-  } else if (solutionPath) {
-    const project = findProjectInSolution(solutionPath);
-    if (project) {
-      const model = extractModelFromProject(project);
-      targetPath = path.join(packagePath, model, model, 'AxForm', `${name}.xml`);
-    } else {
-      throw new Error('No .rnrproj file found in solution');
-    }
-  } else {
-    throw new Error('Must provide modelName, projectPath, or solutionPath');
+  // Normalize path to Windows format (backslashes) for consistency
+  const normalizedPath = targetPath.replace(/\//g, '\\');
+
+  // Reject Windows paths when running on non-Windows (e.g. Linux Azure proxy)
+  if (process.platform !== 'win32' && /^[A-Z]:\\/.test(normalizedPath)) {
+    throw new Error(
+      `❌ Cannot create D365FO file on non-Windows system!\n\n` +
+      `Attempting to create: ${normalizedPath}\n` +
+      `Running on: ${process.platform}\n\n` +
+      `The generate_smart_form tool requires direct access to the D365FO Windows VM.\n` +
+      `Run the MCP server locally on the D365FO Windows VM.`
+    );
+  }
+
+  // Verify drive/root exists before attempting recursive mkdir
+  const driveOrRoot = path.parse(normalizedPath).root;
+  if (driveOrRoot && !fs.existsSync(driveOrRoot)) {
+    throw new Error(
+      `❌ Drive or root path does not exist: ${driveOrRoot}\n\n` +
+      `Attempting to create: ${normalizedPath}\n\n` +
+      `Update "packagePath" in .mcp.json to match your actual D365FO installation.`
+    );
   }
 
   // Create directory if needed
-  const dir = path.dirname(targetPath);
+  const dir = path.dirname(normalizedPath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
 
   // Write file
-  fs.writeFileSync(targetPath, xml, 'utf-8');
-  console.log(`[generateSmartForm] Created file: ${targetPath}`);
+  fs.writeFileSync(normalizedPath, xml, 'utf-8');
+  console.log(`[generateSmartForm] Created file: ${normalizedPath}`);
 
   return {
     content: [
@@ -260,8 +317,8 @@ export async function handleGenerateSmartForm(
         type: 'text',
         text: JSON.stringify({
           success: true,
-          formName: name,
-          filePath: targetPath,
+          formName: finalName,
+          filePath: normalizedPath,
           dataSourcesGenerated: dataSources.length,
           controlsGenerated: controls.length,
           strategy: copyFrom ? 'copy' : dataSource ? 'datasource' : formPattern ? 'pattern' : 'default',

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -9,6 +9,7 @@ import { SmartXmlBuilder, TableFieldSpec, TableIndexSpec, TableRelationSpec } fr
 import path from 'path';
 import fs from 'fs';
 import { getConfigManager } from '../utils/configManager.js';
+import { resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
 
 interface GenerateSmartTableArgs {
   name: string;
@@ -240,10 +241,62 @@ export async function handleGenerateSmartTable(
     console.log(`[generateSmartTable] Added primary key index on RecId`);
   }
 
+  // Determine package path
+  const configManager = getConfigManager();
+  const packagePath = configManager.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
+
+  // Resolve project/solution path — fall back to configManager (from .mcp.json / auto-detection)
+  let resolvedProjectPath = projectPath;
+  let resolvedSolutionPath = solutionPath;
+  if (!resolvedProjectPath && !resolvedSolutionPath) {
+    resolvedProjectPath = (await configManager.getProjectPath()) || undefined;
+    resolvedSolutionPath = (await configManager.getSolutionPath()) || undefined;
+    if (resolvedProjectPath) {
+      console.log(`[generateSmartTable] Using projectPath from config/auto-detect: ${resolvedProjectPath}`);
+    } else if (resolvedSolutionPath) {
+      console.log(`[generateSmartTable] Using solutionPath from config/auto-detect: ${resolvedSolutionPath}`);
+    }
+  }
+
+  // Resolve actual model name — always prefer extracting from .rnrproj over using modelName arg
+  let resolvedModel = modelName;
+  if (resolvedProjectPath) {
+    const extracted = extractModelFromProject(resolvedProjectPath);
+    if (extracted) {
+      resolvedModel = extracted;
+      console.log(`[generateSmartTable] Extracted model from .rnrproj: ${resolvedModel}`);
+    }
+  } else if (resolvedSolutionPath) {
+    const project = findProjectInSolution(resolvedSolutionPath);
+    if (project) {
+      const extracted = extractModelFromProject(project);
+      if (extracted) {
+        resolvedModel = extracted;
+        console.log(`[generateSmartTable] Extracted model from solution .rnrproj: ${resolvedModel}`);
+      }
+    }
+  }
+
+  if (!resolvedModel) {
+    throw new Error(
+      'Could not resolve model name. Provide modelName, projectPath, or solutionPath, ' +
+      'or configure projectPath/solutionPath in .mcp.json.'
+    );
+  }
+
+  console.log(`[generateSmartTable] Using model: ${resolvedModel}`);
+
+  // Apply extension prefix to table name
+  const objectPrefix = resolveObjectPrefix(resolvedModel);
+  const finalName = applyObjectPrefix(name, objectPrefix);
+  if (finalName !== name) {
+    console.log(`[generateSmartTable] Applied prefix "${objectPrefix}": ${name} → ${finalName}`);
+  }
+
   // Generate XML
   const xml = builder.buildTableXml({
-    name,
-    label: label || name,
+    name: finalName,
+    label: label || finalName,
     tableGroup,
     fields,
     indexes,
@@ -252,40 +305,42 @@ export async function handleGenerateSmartTable(
 
   console.log(`[generateSmartTable] Generated XML (${xml.length} bytes)`);
 
-  // Determine package path
-  const packagePath = getConfigManager().getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
-
   // Write to file
-  let targetPath: string;
-  
-  if (modelName) {
-    targetPath = path.join(packagePath, modelName, modelName, 'AxTable', `${name}.xml`);
-  } else if (projectPath) {
-    // Extract model from project file
-    const model = extractModelFromProject(projectPath);
-    targetPath = path.join(packagePath, model, model, 'AxTable', `${name}.xml`);
-  } else if (solutionPath) {
-    // Find .rnrproj in solution
-    const project = findProjectInSolution(solutionPath);
-    if (project) {
-      const model = extractModelFromProject(project);
-      targetPath = path.join(packagePath, model, model, 'AxTable', `${name}.xml`);
-    } else {
-      throw new Error('No .rnrproj file found in solution');
-    }
-  } else {
-    throw new Error('Must provide modelName, projectPath, or solutionPath');
+  const targetPath = path.join(packagePath, resolvedModel, resolvedModel, 'AxTable', `${finalName}.xml`);
+
+  // Normalize path to Windows format (backslashes) for consistency
+  const normalizedPath = targetPath.replace(/\//g, '\\');
+
+  // Reject Windows paths when running on non-Windows (e.g. Linux Azure proxy)
+  if (process.platform !== 'win32' && /^[A-Z]:\\/.test(normalizedPath)) {
+    throw new Error(
+      `❌ Cannot create D365FO file on non-Windows system!\n\n` +
+      `Attempting to create: ${normalizedPath}\n` +
+      `Running on: ${process.platform}\n\n` +
+      `The generate_smart_table tool requires direct access to the D365FO Windows VM.\n` +
+      `Run the MCP server locally on the D365FO Windows VM.`
+    );
+  }
+
+  // Verify drive/root exists before attempting recursive mkdir
+  const driveOrRoot = path.parse(normalizedPath).root;
+  if (driveOrRoot && !fs.existsSync(driveOrRoot)) {
+    throw new Error(
+      `❌ Drive or root path does not exist: ${driveOrRoot}\n\n` +
+      `Attempting to create: ${normalizedPath}\n\n` +
+      `Update "packagePath" in .mcp.json to match your actual D365FO installation.`
+    );
   }
 
   // Create directory if needed
-  const dir = path.dirname(targetPath);
+  const dir = path.dirname(normalizedPath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
 
   // Write file
-  fs.writeFileSync(targetPath, xml, 'utf-8');
-  console.log(`[generateSmartTable] Created file: ${targetPath}`);
+  fs.writeFileSync(normalizedPath, xml, 'utf-8');
+  console.log(`[generateSmartTable] Created file: ${normalizedPath}`);
 
   return {
     content: [
@@ -293,8 +348,8 @@ export async function handleGenerateSmartTable(
         type: 'text',
         text: JSON.stringify({
           success: true,
-          tableName: name,
-          filePath: targetPath,
+          tableName: finalName,
+          filePath: normalizedPath,
           fieldsGenerated: fields.length,
           indexesGenerated: indexes.length,
           relationsGenerated: relations.length,

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -51,6 +51,78 @@ export function getExtensionPrefix(): string {
 }
 
 /**
+ * Resolve the clean prefix to use when naming newly created D365FO objects.
+ *
+ * Microsoft naming guidelines (https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/naming-guidelines-extensions):
+ *  - New model elements  → prefix concatenated directly: {Prefix}{ObjectName}  (e.g. WHSMyTable)
+ *  - Extension elements  → {BaseElement}.{Prefix}Extension                     (e.g. HCMWorker.WHSExtension)
+ *  - Extension classes   → {BaseElement}{Prefix}_Extension                     (e.g. ContactPersonWHS_Extension)
+ *  - Fields in extensions→ {Prefix}{FieldName}                                 (e.g. WHSApprovingWorker)
+ *
+ * Priority:
+ * 1. EXTENSION_PREFIX env var (trailing '_' stripped — the underscore is NOT part of the prefix)
+ * 2. modelName as fallback
+ *
+ * Returns empty string when both are empty.
+ */
+export function resolveObjectPrefix(modelName: string): string {
+  const envPrefix = process.env.EXTENSION_PREFIX?.trim();
+  const raw = (envPrefix || modelName).replace(/_+$/, ''); // strip trailing underscores
+  return raw;
+}
+
+/**
+ * Apply prefix to a NEW model element name.
+ * Per MS guidelines, the prefix is concatenated directly (no separator):
+ *   WHSMyTable, ASLMyClass, ContosoMyForm
+ *
+ * Case-insensitive check prevents double-prefixing.
+ */
+export function applyObjectPrefix(objectName: string, prefix: string): string {
+  if (!prefix) return objectName;
+  if (objectName.toLowerCase().startsWith(prefix.toLowerCase())) return objectName;
+  return `${prefix}${objectName}`;
+}
+
+/**
+ * Build the name of an EXTENSION ELEMENT (table extension, form extension, etc.)
+ * Format: {BaseElementName}.{Prefix}Extension
+ * Example: HCMWorker.WHSExtension, ContactPerson.ContosoCustomizations
+ *
+ * Never use just {BaseElement}.Extension — the prefix/infix is required to avoid conflicts.
+ */
+export function buildExtensionElementName(baseElement: string, prefix: string): string {
+  if (!prefix) {
+    throw new Error(
+      `Extension element name requires a prefix. ` +
+      `Set EXTENSION_PREFIX in .env or pass modelName. ` +
+      `Bad pattern: "${baseElement}.Extension" (too generic, risk of conflicts).`
+    );
+  }
+  return `${baseElement}.${prefix}Extension`;
+}
+
+/**
+ * Build the name of an EXTENSION CLASS (Chain of Command / augmentation class).
+ * Format: {BaseElement}{Prefix}_Extension
+ * Example: ContactPersonWHS_Extension, CustTableForm{Prefix}_Extension
+ *
+ * Never use just {BaseClass}_Extension — the infix is required.
+ */
+export function buildExtensionClassName(baseClass: string, prefix: string): string {
+  if (!prefix) {
+    throw new Error(
+      `Extension class name requires a prefix/infix. ` +
+      `Set EXTENSION_PREFIX in .env or pass modelName. ` +
+      `Bad pattern: "${baseClass}_Extension" (too generic, risk of conflicts).`
+    );
+  }
+  // Avoid double infix if baseClass already contains the prefix
+  const infix = baseClass.toLowerCase().includes(prefix.toLowerCase()) ? '' : prefix;
+  return `${baseClass}${infix}_Extension`;
+}
+
+/**
  * Check if a pattern matches a model name (supports wildcards)
  * @param pattern - Pattern to match (e.g., "Custom*", "*Test", "*Extension*")
  * @param modelName - Model name to check

--- a/tests/tools/codeGen.test.ts
+++ b/tests/tools/codeGen.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for codeGen tool — MS D365FO naming guidelines compliance
+ * https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/naming-guidelines-extensions
+ *
+ * Rules:
+ *  - New objects       : {Prefix}{Name}               e.g. WHSMyTable
+ *  - table-extension   : {BaseTable}{Prefix}_Extension e.g. CustTableWHS_Extension
+ *  - form-handler      : {BaseForm}{Prefix}Form_Extension e.g. SalesTableWHSForm_Extension
+ *  - Bare _Extension   : FORBIDDEN (MS guideline violation)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { codeGenTool } from '../../src/tools/codeGen';
+
+const makeRequest = (args: Record<string, unknown>): CallToolRequest =>
+  ({
+    method: 'tools/call',
+    params: { name: 'generate_code', arguments: args },
+  }) as CallToolRequest;
+
+describe('codeGen tool', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.EXTENSION_PREFIX;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // NEW element patterns (class, runnable, data-entity, batch-job)
+  // ─────────────────────────────────────────────────────────────
+
+  describe('pattern: class', () => {
+    it('should prefix the class name with EXTENSION_PREFIX', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'MyHelper' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('WHSMyHelper');
+      expect(text).not.toContain('public class MyHelper');
+    });
+
+    it('should prefix from modelName when EXTENSION_PREFIX not set', async () => {
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'MyHelper', modelName: 'AslCore' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('AslCoreMyHelper');
+    });
+
+    it('should NOT double-prefix when name already starts with prefix', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'WHSMyHelper' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('WHSMyHelper');
+      expect(text).not.toContain('WHSWHSMyHelper');
+    });
+
+    it('should warn when no prefix is available', async () => {
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'MyHelper' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('No prefix');
+    });
+
+    it('should generate valid X++ class template', async () => {
+      process.env.EXTENSION_PREFIX = 'ASL';
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'OrderHelper' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('public class ASLOrderHelper');
+      expect(text).toContain('```xpp');
+    });
+  });
+
+  describe('pattern: runnable', () => {
+    it('should prefix the runnable class with EXTENSION_PREFIX', async () => {
+      process.env.EXTENSION_PREFIX = 'ASL';
+      const result = await codeGenTool(makeRequest({ pattern: 'runnable', name: 'FixCustomers' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('ASLFixCustomers');
+    });
+
+    it('should fall back to modelName for prefix', async () => {
+      const result = await codeGenTool(makeRequest({ pattern: 'runnable', name: 'FixCustomers', modelName: 'Con' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('ConFixCustomers');
+    });
+  });
+
+  describe('pattern: batch-job', () => {
+    it('should prefix the batch-job class with EXTENSION_PREFIX', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'batch-job', name: 'ProcessOrders' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('WHSProcessOrders');
+    });
+
+    it('should generate Controller and Service classes', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'batch-job', name: 'ProcessOrders' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('WHSProcessOrdersController');
+      expect(text).toContain('WHSProcessOrdersService');
+    });
+  });
+
+  describe('pattern: data-entity', () => {
+    it('should prefix data entity class', async () => {
+      process.env.EXTENSION_PREFIX = 'Con';
+      const result = await codeGenTool(makeRequest({ pattern: 'data-entity', name: 'SalesOrder' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('ConSalesOrder');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // EXTENSION patterns — MS naming: {Base}{Prefix}_Extension / Form_Extension
+  // ─────────────────────────────────────────────────────────────
+
+  describe('pattern: table-extension', () => {
+    it('should generate {Base}{Prefix}_Extension class name (MS guideline)', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'table-extension', name: 'CustTable' }));
+      const text = result.content[0].text as string;
+      // MS rule: CustTableWHS_Extension
+      expect(text).toContain('CustTableWHS_Extension');
+    });
+
+    it('should NOT generate bare CustTable_Extension (MS guideline violation)', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'table-extension', name: 'CustTable' }));
+      const text = result.content[0].text as string;
+      // Bare _Extension without prefix is forbidden
+      expect(text).not.toMatch(/\bCustTable_Extension\b/);
+    });
+
+    it('should use [ExtensionOf(tableStr(...))] with the BASE table name', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'table-extension', name: 'CustTable' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('[ExtensionOf(tableStr(CustTable))]');
+    });
+
+    it('should use modelName as prefix when EXTENSION_PREFIX not set', async () => {
+      const result = await codeGenTool(makeRequest({ pattern: 'table-extension', name: 'CustTable', modelName: 'Contoso' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('CustTableContoso_Extension');
+    });
+
+    it('should include validateWrite, insert, update methods', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'table-extension', name: 'CustTable' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('validateWrite');
+      expect(text).toContain('insert');
+      expect(text).toContain('update');
+    });
+
+    it('should warn when no prefix available', async () => {
+      const result = await codeGenTool(makeRequest({ pattern: 'table-extension', name: 'CustTable' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('No prefix');
+    });
+  });
+
+  describe('pattern: form-handler', () => {
+    it('should generate {Base}{Prefix}Form_Extension class name (MS guideline)', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'form-handler', name: 'SalesTable' }));
+      const text = result.content[0].text as string;
+      // MS rule: SalesTableWHSForm_Extension
+      expect(text).toContain('SalesTableWHSForm_Extension');
+    });
+
+    it('should NOT generate bare SalesTableForm_Extension (MS guideline violation)', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'form-handler', name: 'SalesTable' }));
+      const text = result.content[0].text as string;
+      // SalesTableForm_Extension without prefix infix is forbidden — ensure it's the full name
+      expect(text).not.toMatch(/\bSalesTableForm_Extension\b/);
+    });
+
+    it('should use [ExtensionOf(formStr(...))] with the BASE form name', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'form-handler', name: 'SalesTable' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('[ExtensionOf(formStr(SalesTable))]');
+    });
+
+    it('should use modelName as prefix when EXTENSION_PREFIX not set', async () => {
+      const result = await codeGenTool(makeRequest({ pattern: 'form-handler', name: 'SalesTable', modelName: 'Contoso' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('SalesTableContosoForm_Extension');
+    });
+
+    it('should include init, close, and event handler methods', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'form-handler', name: 'SalesTable' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('init');
+      expect(text).toContain('close');
+      expect(text).toContain('FormDataSourceEventHandler');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Error handling
+  // ─────────────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('should return error for unknown pattern', async () => {
+      const result = await codeGenTool(makeRequest({ pattern: 'unknown-pattern', name: 'Test' }));
+      expect(result.isError).toBe(true);
+    });
+
+    it('should return error when required arguments are missing', async () => {
+      const result = await codeGenTool(makeRequest({}));
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Output format
+  // ─────────────────────────────────────────────────────────────
+
+  describe('output format', () => {
+    it('should include xpp code block in output', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'Test' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('```xpp');
+    });
+
+    it('should include naming note about prefix', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'Test' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('WHSTest');
+    });
+
+    it('should include Next Steps section with tool suggestions', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'Test' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('Next Steps');
+      expect(text).toContain('analyze_code_patterns');
+    });
+
+    it('should strip trailing underscore from EXTENSION_PREFIX in named output', async () => {
+      process.env.EXTENSION_PREFIX = 'WHS_';
+      const result = await codeGenTool(makeRequest({ pattern: 'class', name: 'MyClass' }));
+      const text = result.content[0].text as string;
+      expect(text).toContain('WHSMyClass');
+      expect(text).not.toContain('WHS_MyClass');
+    });
+  });
+});

--- a/tests/utils/modelClassifier.test.ts
+++ b/tests/utils/modelClassifier.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { isCustomModel, isStandardModel, getCustomModels, filterModelsByType } from '../../src/utils/modelClassifier';
+import {
+  isCustomModel,
+  isStandardModel,
+  getCustomModels,
+  filterModelsByType,
+  resolveObjectPrefix,
+  applyObjectPrefix,
+  buildExtensionElementName,
+  buildExtensionClassName,
+} from '../../src/utils/modelClassifier';
 
 describe('modelClassifier', () => {
   const originalEnv = process.env;
@@ -225,6 +234,99 @@ describe('modelClassifier', () => {
       expect(isCustomModel('SpecificModel')).toBe(true);
       expect(isCustomModel('MyExtension')).toBe(true);
       expect(isStandardModel('OtherModel')).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // NEW NAMING HELPERS (MS D365FO naming guidelines)
+  // https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/naming-guidelines-extensions
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  describe('resolveObjectPrefix', () => {
+    it('should return EXTENSION_PREFIX when set', () => {
+      process.env.EXTENSION_PREFIX = 'WHS';
+      expect(resolveObjectPrefix('AnyModel')).toBe('WHS');
+    });
+
+    it('should strip trailing underscores from EXTENSION_PREFIX', () => {
+      process.env.EXTENSION_PREFIX = 'WHS_';
+      expect(resolveObjectPrefix('AnyModel')).toBe('WHS');
+    });
+
+    it('should strip multiple trailing underscores', () => {
+      process.env.EXTENSION_PREFIX = 'ASL___';
+      expect(resolveObjectPrefix('AnyModel')).toBe('ASL');
+    });
+
+    it('should fall back to modelName when EXTENSION_PREFIX not set', () => {
+      delete process.env.EXTENSION_PREFIX;
+      expect(resolveObjectPrefix('AslCore')).toBe('AslCore');
+    });
+
+    it('should return empty string when both EXTENSION_PREFIX and modelName are empty', () => {
+      delete process.env.EXTENSION_PREFIX;
+      expect(resolveObjectPrefix('')).toBe('');
+    });
+
+    it('should prefer EXTENSION_PREFIX over modelName', () => {
+      process.env.EXTENSION_PREFIX = 'CONTOSO';
+      expect(resolveObjectPrefix('AslCore')).toBe('CONTOSO');
+    });
+  });
+
+  describe('applyObjectPrefix', () => {
+    it('should prepend prefix to object name without separator', () => {
+      expect(applyObjectPrefix('MyTable', 'WHS')).toBe('WHSMyTable');
+    });
+
+    it('should return unchanged name when prefix is empty', () => {
+      expect(applyObjectPrefix('MyTable', '')).toBe('MyTable');
+    });
+
+    it('should not double-prefix (case-insensitive guard)', () => {
+      expect(applyObjectPrefix('WHSMyTable', 'WHS')).toBe('WHSMyTable');
+      expect(applyObjectPrefix('whsMyTable', 'WHS')).toBe('whsMyTable');
+    });
+
+    it('should handle different casing between prefix and objectName', () => {
+      expect(applyObjectPrefix('NoPrefixYet', 'ASL')).toBe('ASLNoPrefixYet');
+    });
+  });
+
+  describe('buildExtensionElementName', () => {
+    it('should return {base}.{prefix}Extension', () => {
+      expect(buildExtensionElementName('HCMWorker', 'WHS')).toBe('HCMWorker.WHSExtension');
+    });
+
+    it('should handle different prefix values', () => {
+      expect(buildExtensionElementName('ContactPerson', 'Contoso')).toBe('ContactPerson.ContosoExtension');
+    });
+
+    it('should throw an error when prefix is empty (bare .Extension forbidden by MS guidelines)', () => {
+      expect(() => buildExtensionElementName('HCMWorker', '')).toThrow('requires a prefix');
+    });
+  });
+
+  describe('buildExtensionClassName', () => {
+    it('should return {base}{prefix}_Extension for table CoC', () => {
+      expect(buildExtensionClassName('CustTable', 'WHS')).toBe('CustTableWHS_Extension');
+    });
+
+    it('should return {base}{prefix}_Extension for form CoC', () => {
+      expect(buildExtensionClassName('SalesTable', 'Contoso')).toBe('SalesTableContoso_Extension');
+    });
+
+    it('should throw an error when prefix is empty (bare _Extension forbidden by MS guidelines)', () => {
+      expect(() => buildExtensionClassName('CustTable', '')).toThrow('requires a prefix');
+    });
+
+    it('should avoid double infix when base already contains prefix', () => {
+      // e.g. base was already derived with the prefix in it
+      expect(buildExtensionClassName('CustTableWHS', 'WHS')).toBe('CustTableWHS_Extension');
+    });
+
+    it('should be case-insensitive for double-infix guard', () => {
+      expect(buildExtensionClassName('custtablewhs', 'WHS')).toBe('custtablewhs_Extension');
     });
   });
 });


### PR DESCRIPTION
modelClassifier: add resolveObjectPrefix, applyObjectPrefix, buildExtensionElementName, buildExtensionClassName
createD365File: apply prefix to object names
generateSmartTable/Form: path normalization, platform guard, configManager fallback, model from .rnrproj
codeGen: split templates, MS-compliant naming for extensions, modelName param

Tests: +17 in modelClassifier.test.ts, +45 in new codeGen.test.ts (271 passed total)

Ref: https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/naming-guidelines-extensions