### PR TITLE
fix: align AxTable/AxForm XML generation with real D365FO AOT structure

### DIFF
--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -229,17 +229,27 @@ export class XppMetadataParser {
     return 'public';
   }
 
+  /**
+   * Parse table fields from <AxTableField xmlns="" i:type="AxTableFieldString"> nodes.
+   * xml2js (explicitArray:false) groups all <AxTableField> children under the AxTableField key.
+   * The field type is carried in the i:type XML attribute → field.$['i:type'].
+   */
   private parseFields(fieldsData: any): XppFieldInfo[] {
     if (!fieldsData) return [];
 
     const fields = Array.isArray(fieldsData) ? fieldsData : [fieldsData];
-    return fields.map(field => ({
-      name: field.Name || 'unknown',
-      type: field.Type || 'String',
-      extendedDataType: field.ExtendedDataType || undefined,
-      mandatory: field.Mandatory === 'Yes' || field.Mandatory === 'true',
-      label: field.Label || undefined,
-    }));
+    return fields.map(field => {
+      // i:type attribute value e.g. 'AxTableFieldString' → strip prefix to get 'String'
+      const rawType: string = field.$?.['i:type'] || 'AxTableFieldString';
+      const xppType = rawType.replace('AxTableField', '') || 'String';
+      return {
+        name: field.Name || 'unknown',
+        type: xppType,
+        extendedDataType: field.ExtendedDataType || undefined,
+        mandatory: field.Mandatory === 'Yes' || field.Mandatory === 'true',
+        label: field.Label || undefined,
+      };
+    });
   }
 
   private parseIndexes(indexesData: any): XppIndexInfo[] {
@@ -249,8 +259,9 @@ export class XppMetadataParser {
     return indexes.map(index => ({
       name: index.Name || 'unknown',
       fields: this.parseIndexFields(index.Fields),
-      unique: index.AllowDuplicates === 'No' || index.AllowDuplicates === 'false',
-      clustered: index.AlternateKey === 'Yes' || index.AlternateKey === 'true',
+      // D365FO uses <AlternateKey>Yes</AlternateKey> to mark unique indexes (NOT AllowDuplicates)
+      unique: index.AlternateKey === 'Yes' || index.AlternateKey === 'true',
+      clustered: index.IsClustered === 'Yes' || index.IsClustered === 'true',
     }));
   }
 

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -130,13 +130,32 @@ ${titleField1Xml}${titleField2Xml}\t<Fields />
   ): string {
     const label = properties?.label || formName;
 
+    // D365FO forms require xmlns="Microsoft.Dynamics.AX.Metadata.V6" and SourceCode first
     return `<?xml version="1.0" encoding="utf-8"?>
-<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
 \t<Name>${formName}</Name>
+\t<SourceCode>
+\t\t<Methods xmlns="">
+\t\t\t<Method>
+\t\t\t\t<Name>classDeclaration</Name>
+\t\t\t\t<Source><!\[CDATA[
+    [Form]
+    public class ${formName} extends FormRun
+    {
+    }
+]]></Source>
+\t\t\t</Method>
+\t\t</Methods>
+\t\t<DataSources xmlns="" />
+\t\t<DataControls xmlns="" />
+\t\t<Members xmlns="" />
+\t</SourceCode>
 \t<Label>${label}</Label>
-\t<Design />
 \t<DataSources />
-\t<Methods />
+\t<Design>
+\t\t<Controls xmlns="" />
+\t</Design>
+\t<Parts />
 </AxForm>
 `;
   }

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -236,16 +236,13 @@ async function addMethod(xmlObj: any, objectType: string, args: any): Promise<bo
     throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
   }
 
-  // For classes, methods are under SourceCode > Methods; for tables/forms, under Methods
+  // Methods are always under SourceCode > Methods for all D365FO object types
+  // (AxClass, AxTable, AxForm all use <SourceCode><Methods>...</Methods></SourceCode>)
   let methodsContainer: any;
-  if (objectType === 'class') {
-    if (!root.SourceCode) {
-      root.SourceCode = [{ Methods: [{ $: { xmlns: '' }, Method: [] }] }];
-    }
-    methodsContainer = root.SourceCode[0];
-  } else {
-    methodsContainer = root;
+  if (!root.SourceCode) {
+    root.SourceCode = [{ Methods: [{ Method: [] }] }];
   }
+  methodsContainer = root.SourceCode[0];
 
   let methodsNode = methodsContainer.Methods;
   if (!methodsNode) {
@@ -285,8 +282,8 @@ async function removeMethod(xmlObj: any, objectType: string, args: any): Promise
     throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
   }
 
-  // For classes, methods are under SourceCode > Methods
-  const methodsContainer = objectType === 'class' ? root.SourceCode?.[0] : root;
+  // Methods are always under SourceCode > Methods for all D365FO object types
+  const methodsContainer = root.SourceCode?.[0];
   if (!methodsContainer?.Methods?.[0]?.Method) {
     throw new Error('No methods found in object');
   }
@@ -327,21 +324,24 @@ async function addField(xmlObj: any, objectType: string, args: any): Promise<boo
     throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
   }
 
-  let fieldsNode = root.Fields;
-  if (!fieldsNode) {
-    root.Fields = [{ $: {}, AxTableField: [] }];
-    fieldsNode = root.Fields;
+  // Ensure Fields container exists
+  if (!root.Fields || root.Fields === '') {
+    root.Fields = [{ AxTableField: [] }];
+  }
+  const fieldsContainer = Array.isArray(root.Fields) ? root.Fields[0] : root.Fields;
+
+  // xml2js with explicitArray:false may store single AxTableField as object, not array
+  if (!fieldsContainer.AxTableField) {
+    fieldsContainer.AxTableField = [];
+  } else if (!Array.isArray(fieldsContainer.AxTableField)) {
+    fieldsContainer.AxTableField = [fieldsContainer.AxTableField];
   }
 
-  if (!fieldsNode[0].AxTableField) {
-    fieldsNode[0].AxTableField = [];
-  }
-
-  // Determine field type node name (AxTableFieldString, AxTableFieldInt, etc.)
-  const fieldNodeName = getFieldNodeName(fieldType);
-
-  // Create field node
+  // D365FO field XML format: <AxTableField xmlns="" i:type="AxTableFieldString">
+  // xml2js represents this as { '$': { xmlns: '', 'i:type': 'AxTableFieldString' }, Name: [...] }
+  const iType = getFieldNodeName(fieldType);
   const newField: any = {
+    '$': { xmlns: '', 'i:type': iType },
     Name: [fieldName],
     ExtendedDataType: [fieldType],
   };
@@ -354,11 +354,7 @@ async function addField(xmlObj: any, objectType: string, args: any): Promise<boo
     newField.Mandatory = [fieldMandatory ? 'Yes' : 'No'];
   }
 
-  // Wrap in appropriate type node
-  const fieldWrapper: any = {};
-  fieldWrapper[fieldNodeName] = [newField];
-
-  fieldsNode[0].AxTableField.push(fieldWrapper);
+  fieldsContainer.AxTableField.push(newField);
 
   return true;
 }

--- a/src/utils/smartXmlBuilder.ts
+++ b/src/utils/smartXmlBuilder.ts
@@ -42,7 +42,8 @@ export interface FormControlSpec {
 
 export class SmartXmlBuilder {
   /**
-   * Build AxTable XML with fields, indexes, and relations
+   * Build AxTable XML with fields, indexes, and relations.
+   * Structure validated against real D365FO AOT XML (K:\AosService\PackagesLocalDirectory).
    */
   buildTableXml(spec: {
     name: string;
@@ -58,14 +59,60 @@ export class SmartXmlBuilder {
     let xml = `<?xml version="1.0" encoding="utf-8"?>\n`;
     xml += `<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">\n`;
     xml += `\t<Name>${name}</Name>\n`;
-    
+
+    // <SourceCode> MUST be first child of <AxTable> — D365FO AOT requirement
+    xml += `\t<SourceCode>\n`;
+    xml += `\t\t<Declaration><![CDATA[\npublic class ${name} extends common\n{\n}\n]]></Declaration>\n`;
+    if (methods && methods.length > 0) {
+      xml += `\t\t<Methods>\n`;
+      for (const method of methods) {
+        xml += `\t\t\t<Method>\n`;
+        xml += `\t\t\t\t<Name>${method.name}</Name>\n`;
+        xml += `\t\t\t\t<Source><![CDATA[\n${method.source}\n]]></Source>\n`;
+        xml += `\t\t\t</Method>\n`;
+      }
+      xml += `\t\t</Methods>\n`;
+    } else {
+      xml += `\t\t<Methods />\n`;
+    }
+    xml += `\t</SourceCode>\n`;
+
+    // Table metadata (after SourceCode)
     if (label) {
       xml += `\t<Label>${this.escapeXml(label)}</Label>\n`;
     }
-    
     xml += `\t<TableGroup>${tableGroup || 'Main'}</TableGroup>\n`;
-    xml += `\t<TitleField1></TitleField1>\n`;
-    xml += `\t<TitleField2></TitleField2>\n`;
+
+    // TitleField1/TitleField2: first two non-RecId fields
+    const titleCandidates = fields.filter(f => f.name !== 'RecId').slice(0, 2);
+    if (titleCandidates[0]) xml += `\t<TitleField1>${titleCandidates[0].name}</TitleField1>\n`;
+    if (titleCandidates[1]) xml += `\t<TitleField2>${titleCandidates[1].name}</TitleField2>\n`;
+
+    // PrimaryIndex and ReplacementKey reference the unique index name
+    const uniqueIdx = indexes?.find(i => i.unique);
+    if (uniqueIdx) {
+      xml += `\t<PrimaryIndex>${uniqueIdx.name}</PrimaryIndex>\n`;
+      xml += `\t<ReplacementKey>${uniqueIdx.name}</ReplacementKey>\n`;
+    }
+
+    // Required D365FO sections — must all be present
+    xml += `\t<DeleteActions />\n`;
+
+    // 5 standard FieldGroups required by VS D365FO project system
+    xml += `\t<FieldGroups>\n`;
+    for (const groupName of ['AutoReport', 'AutoLookup', 'AutoSummary', 'AutoBrowse']) {
+      xml += `\t\t<AxTableFieldGroup>\n`;
+      xml += `\t\t\t<Name>${groupName}</Name>\n`;
+      xml += `\t\t\t<Fields />\n`;
+      xml += `\t\t</AxTableFieldGroup>\n`;
+    }
+    // AutoIdentification requires AutoPopulate=Yes
+    xml += `\t\t<AxTableFieldGroup>\n`;
+    xml += `\t\t\t<Name>AutoIdentification</Name>\n`;
+    xml += `\t\t\t<AutoPopulate>Yes</AutoPopulate>\n`;
+    xml += `\t\t\t<Fields />\n`;
+    xml += `\t\t</AxTableFieldGroup>\n`;
+    xml += `\t</FieldGroups>\n`;
 
     // Fields
     if (fields.length > 0) {
@@ -78,6 +125,8 @@ export class SmartXmlBuilder {
       xml += `\t<Fields />\n`;
     }
 
+    xml += `\t<FullTextIndexes />\n`;
+
     // Indexes
     if (indexes && indexes.length > 0) {
       xml += `\t<Indexes>\n`;
@@ -88,6 +137,8 @@ export class SmartXmlBuilder {
     } else {
       xml += `\t<Indexes />\n`;
     }
+
+    xml += `\t<Mappings />\n`;
 
     // Relations
     if (relations && relations.length > 0) {
@@ -100,24 +151,14 @@ export class SmartXmlBuilder {
       xml += `\t<Relations />\n`;
     }
 
-    // Methods (X++ source code embedded in XML)
-    if (methods && methods.length > 0) {
-      xml += `\t<Methods>\n`;
-      for (const method of methods) {
-        xml += `\t\t<Method>\n`;
-        xml += `\t\t\t<Name>${method.name}</Name>\n`;
-        xml += `\t\t\t<Source><!\[CDATA[\n${method.source}\n\t\t\t]]></Source>\n`;
-        xml += `\t\t</Method>\n`;
-      }
-      xml += `\t</Methods>\n`;
-    }
-
+    xml += `\t<StateMachines />\n`;
     xml += `</AxTable>\n`;
     return xml;
   }
 
   /**
-   * Build AxForm XML with datasources and controls
+   * Build AxForm XML with datasources and controls.
+   * Structure validated against real D365FO AOT XML (K:\AosService\PackagesLocalDirectory).
    */
   buildFormXml(spec: {
     name: string;
@@ -129,18 +170,29 @@ export class SmartXmlBuilder {
     const { name, label, caption, dataSources, controls } = spec;
 
     let xml = `<?xml version="1.0" encoding="utf-8"?>\n`;
-    xml += `<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">\n`;
+    // D365FO forms require the Microsoft.Dynamics.AX.Metadata.V6 default namespace
+    xml += `<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">\n`;
     xml += `\t<Name>${name}</Name>\n`;
-    
+
+    // <SourceCode> with classDeclaration method is required by D365FO forms
+    xml += `\t<SourceCode>\n`;
+    xml += `\t\t<Methods xmlns="">\n`;
+    xml += `\t\t\t<Method>\n`;
+    xml += `\t\t\t\t<Name>classDeclaration</Name>\n`;
+    xml += `\t\t\t\t<Source><!\[CDATA[\n    [Form]\n    public class ${name} extends FormRun\n    {\n    }\n]]></Source>\n`;
+    xml += `\t\t\t</Method>\n`;
+    xml += `\t\t</Methods>\n`;
+    // These xmlns="" sections track form-level code overrides
+    xml += `\t\t<DataSources xmlns="" />\n`;
+    xml += `\t\t<DataControls xmlns="" />\n`;
+    xml += `\t\t<Members xmlns="" />\n`;
+    xml += `\t</SourceCode>\n`;
+
     if (label) {
       xml += `\t<Label>${this.escapeXml(label)}</Label>\n`;
     }
-    
-    if (caption) {
-      xml += `\t<TitleDatasource>${this.escapeXml(caption)}</TitleDatasource>\n`;
-    }
 
-    // DataSources
+    // DataSources (outside SourceCode — form runtime datasources)
     if (dataSources.length > 0) {
       xml += `\t<DataSources>\n`;
       for (const ds of dataSources) {
@@ -152,92 +204,103 @@ export class SmartXmlBuilder {
     }
 
     // Design
+    const primaryDs = dataSources[0];
     xml += `\t<Design>\n`;
+    if (caption || label) {
+      xml += `\t\t<Caption xmlns="">${this.escapeXml(caption || label || name)}</Caption>\n`;
+    }
+    if (primaryDs) {
+      xml += `\t\t<DataSource xmlns="">${primaryDs.name}</DataSource>\n`;
+      xml += `\t\t<Pattern xmlns="">SimpleList</Pattern>\n`;
+      xml += `\t\t<PatternVersion xmlns="">1.1</PatternVersion>\n`;
+      xml += `\t\t<Style xmlns="">SimpleList</Style>\n`;
+    }
+    xml += `\t\t<Controls xmlns="">\n`;
     if (controls && controls.length > 0) {
       for (const control of controls) {
-        xml += this.buildFormControl(control, 2);
+        xml += this.buildFormControl(control, 3);
       }
     }
+    xml += `\t\t</Controls>\n`;
     xml += `\t</Design>\n`;
 
+    xml += `\t<Parts />\n`;
     xml += `</AxForm>\n`;
     return xml;
   }
 
   /**
-   * Build table field XML node
+   * Build table field XML node.
+   * D365FO uses generic <AxTableField xmlns="" i:type="AxTableFieldString"> format,
+   * NOT typed element names like <AxTableFieldString>.
    */
   private buildTableField(field: TableFieldSpec): string {
     const { name, edt, type, mandatory, label } = field;
 
-    // Determine field node type
-    let nodeType = 'AxTableFieldString'; // default
-    
-    if (edt) {
-      // Try to infer from EDT name
-      const edtLower = edt.toLowerCase();
-      if (edtLower.includes('int') || edtLower.includes('num')) {
-        nodeType = 'AxTableFieldInt';
-      } else if (edtLower.includes('real') || edtLower.includes('amount')) {
-        nodeType = 'AxTableFieldReal';
-      } else if (edtLower.includes('date')) {
-        nodeType = 'AxTableFieldDate';
-      } else if (edtLower.includes('datetime')) {
-        nodeType = 'AxTableFieldUtcDateTime';
-      } else if (edtLower.includes('enum')) {
-        nodeType = 'AxTableFieldEnum';
-      }
-    } else if (type) {
-      const typeMap: Record<string, string> = {
-        'String': 'AxTableFieldString',
-        'Integer': 'AxTableFieldInt',
-        'Int64': 'AxTableFieldInt64',
-        'Real': 'AxTableFieldReal',
-        'Date': 'AxTableFieldDate',
-        'DateTime': 'AxTableFieldUtcDateTime',
-        'Enum': 'AxTableFieldEnum',
-        'Container': 'AxTableFieldContainer',
-        'Guid': 'AxTableFieldGuid',
-      };
-      nodeType = typeMap[type] || 'AxTableFieldString';
-    }
+    const iType = this.getAxTableFieldType(edt, type);
 
-    let xml = `\t\t<${nodeType}>\n`;
+    // D365FO field format: <AxTableField xmlns="" i:type="AxTableFieldString">
+    let xml = `\t\t<AxTableField xmlns=""\n\t\t\t\ti:type="${iType}">\n`;
     xml += `\t\t\t<Name>${name}</Name>\n`;
-    
     if (edt) {
       xml += `\t\t\t<ExtendedDataType>${edt}</ExtendedDataType>\n`;
     }
-    
     if (mandatory) {
       xml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
     }
-    
     if (label) {
       xml += `\t\t\t<Label>${this.escapeXml(label)}</Label>\n`;
     }
-    
-    xml += `\t\t</${nodeType}>\n`;
+    xml += `\t\t</AxTableField>\n`;
     return xml;
   }
 
   /**
-   * Build table index XML node
+   * Map EDT/type hint to D365FO AxTableField i:type attribute value.
+   * Based on real XML analysis from K:\AosService\PackagesLocalDirectory.
+   */
+  private getAxTableFieldType(edt?: string, type?: string): string {
+    if (edt) {
+      const e = edt.toLowerCase();
+      if (e === 'recid' || e.endsWith('recid') || e.includes('refrecid')) return 'AxTableFieldInt64';
+      if (e.includes('utcdatetime') || (e.includes('datetime') && !e.includes('transdate'))) return 'AxTableFieldUtcDateTime';
+      if ((e.includes('date') && !e.includes('time') && !e.includes('update'))) return 'AxTableFieldDate';
+      if (e.includes('amount') || e.includes('mst') || e.includes('price') || e.includes('qty')
+          || e.includes('percent') || e === 'real') return 'AxTableFieldReal';
+      if (e === 'noyesid' || e.endsWith('noyesid') || e === 'noyes') return 'AxTableFieldEnum';
+      if ((e.endsWith('int') || e.includes('count') || e.includes('level'))
+          && !e.includes('account') && !e.includes('name')) return 'AxTableFieldInt';
+    }
+    if (type) {
+      const typeMap: Record<string, string> = {
+        String: 'AxTableFieldString',
+        Integer: 'AxTableFieldInt',
+        Int64: 'AxTableFieldInt64',
+        Real: 'AxTableFieldReal',
+        Date: 'AxTableFieldDate',
+        DateTime: 'AxTableFieldUtcDateTime',
+        Enum: 'AxTableFieldEnum',
+        Container: 'AxTableFieldContainer',
+        Guid: 'AxTableFieldGuid',
+      };
+      return typeMap[type] || 'AxTableFieldString';
+    }
+    return 'AxTableFieldString';
+  }
+
+  /**
+   * Build table index XML node.
+   * D365FO uses <AlternateKey>Yes</AlternateKey> for unique indexes — NOT <AllowDuplicates>No>.
    */
   private buildTableIndex(index: TableIndexSpec): string {
-    const { name, fields, unique, clustered } = index;
+    const { name, fields, unique } = index;
 
     let xml = `\t\t<AxTableIndex>\n`;
     xml += `\t\t\t<Name>${name}</Name>\n`;
-    
     if (unique) {
-      xml += `\t\t\t<AllowDuplicates>No</AllowDuplicates>\n`;
+      // AlternateKey=Yes marks the index as a unique surrogate/alternate key
+      xml += `\t\t\t<AlternateKey>Yes</AlternateKey>\n`;
     }
-    
-    if (clustered) {
-      xml += `\t\t\t<IsClustered>Yes</IsClustered>\n`;
-    }
-
     xml += `\t\t\t<Fields>\n`;
     for (const fieldName of fields) {
       xml += `\t\t\t\t<AxTableIndexField>\n`;
@@ -245,87 +308,108 @@ export class SmartXmlBuilder {
       xml += `\t\t\t\t</AxTableIndexField>\n`;
     }
     xml += `\t\t\t</Fields>\n`;
-    
     xml += `\t\t</AxTableIndex>\n`;
     return xml;
   }
 
   /**
-   * Build table relation XML node
+   * Build table relation XML node.
+   * Constraints use <AxTableRelationConstraint xmlns="" i:type="AxTableRelationConstraintField">.
    */
   private buildTableRelation(relation: TableRelationSpec): string {
     const { name, targetTable, constraints } = relation;
 
     let xml = `\t\t<AxTableRelation>\n`;
     xml += `\t\t\t<Name>${name}</Name>\n`;
+    xml += `\t\t\t<Cardinality>ZeroMore</Cardinality>\n`;
     xml += `\t\t\t<RelatedTable>${targetTable}</RelatedTable>\n`;
-    
+    xml += `\t\t\t<RelatedTableCardinality>ExactlyOne</RelatedTableCardinality>\n`;
+    xml += `\t\t\t<RelationshipType>Association</RelationshipType>\n`;
     xml += `\t\t\t<Constraints>\n`;
     for (const constraint of constraints) {
-      xml += `\t\t\t\t<AxTableRelationConstraint>\n`;
+      // Constraints require xmlns="" and i:type to override the default XML namespace
+      xml += `\t\t\t\t<AxTableRelationConstraint xmlns=""\n\t\t\t\t\t\ti:type="AxTableRelationConstraintField">\n`;
+      xml += `\t\t\t\t\t<Name>${constraint.field}</Name>\n`;
       xml += `\t\t\t\t\t<Field>${constraint.field}</Field>\n`;
       xml += `\t\t\t\t\t<RelatedField>${constraint.relatedField}</RelatedField>\n`;
       xml += `\t\t\t\t</AxTableRelationConstraint>\n`;
     }
     xml += `\t\t\t</Constraints>\n`;
-    
     xml += `\t\t</AxTableRelation>\n`;
     return xml;
   }
 
   /**
-   * Build form datasource XML node
+   * Build form datasource XML node.
+   * D365FO: <AxFormDataSource xmlns=""> required to override default form namespace.
    */
   private buildFormDataSource(ds: FormDataSourceSpec): string {
     const { name, table, allowEdit, allowCreate, allowDelete } = ds;
 
-    let xml = `\t\t<AxFormDataSourceRoot>\n`;
+    // xmlns="" resets the default namespace (AxForm root has xmlns="Microsoft.Dynamics.AX.Metadata.V6")
+    let xml = `\t\t<AxFormDataSource xmlns="">\n`;
     xml += `\t\t\t<Name>${name}</Name>\n`;
     xml += `\t\t\t<Table>${table}</Table>\n`;
-    
-    if (allowEdit !== undefined) {
-      xml += `\t\t\t<AllowEdit>${allowEdit ? 'Yes' : 'No'}</AllowEdit>\n`;
-    }
-    
-    if (allowCreate !== undefined) {
-      xml += `\t\t\t<AllowCreate>${allowCreate ? 'Yes' : 'No'}</AllowCreate>\n`;
-    }
-    
-    if (allowDelete !== undefined) {
-      xml += `\t\t\t<AllowDelete>${allowDelete ? 'Yes' : 'No'}</AllowDelete>\n`;
-    }
-    
+    if (allowEdit === false) xml += `\t\t\t<AllowEdit>No</AllowEdit>\n`;
+    if (allowCreate === false) xml += `\t\t\t<AllowCreate>No</AllowCreate>\n`;
+    if (allowDelete === false) xml += `\t\t\t<AllowDelete>No</AllowDelete>\n`;
+    // Empty <Fields /> means all table fields are available in the datasource
     xml += `\t\t\t<Fields />\n`;
-    xml += `\t\t</AxFormDataSourceRoot>\n`;
+    xml += `\t\t\t<ReferencedDataSources />\n`;
+    xml += `\t\t\t<DataSourceLinks />\n`;
+    xml += `\t\t\t<DerivedDataSources />\n`;
+    xml += `\t\t</AxFormDataSource>\n`;
     return xml;
   }
 
   /**
-   * Build form control XML node (recursive)
+   * Build form control XML node (recursive).
+   * D365FO: <AxFormControl xmlns="" i:type="AxFormStringControl"> with required Type and
+   * FormControlExtension properties. xmlns="" resets default form namespace.
    */
   private buildFormControl(control: FormControlSpec, indentLevel: number): string {
     const { name, type, properties, children } = control;
     const indent = '\t'.repeat(indentLevel);
+    const i1 = indent + '\t';
 
-    const nodeType = `AxForm${type}`;
-    let xml = `${indent}<${nodeType}>\n`;
-    xml += `${indent}\t<Name>${name}</Name>\n`;
+    // Map FormControlSpec.type to D365FO i:type attribute and <Type> element value
+    const typeMap: Record<string, { iType: string; typeValue: string }> = {
+      Grid:       { iType: 'AxFormGridControl',       typeValue: 'Grid' },
+      Group:      { iType: 'AxFormGroupControl',      typeValue: 'Group' },
+      String:     { iType: 'AxFormStringControl',     typeValue: 'String' },
+      Int64:      { iType: 'AxFormInt64Control',      typeValue: 'Int64' },
+      Real:       { iType: 'AxFormRealControl',       typeValue: 'Real' },
+      Date:       { iType: 'AxFormDateControl',       typeValue: 'Date' },
+      DateTime:   { iType: 'AxFormDateTimeControl',   typeValue: 'DateTime' },
+      Button:     { iType: 'AxFormButtonControl',     typeValue: 'Button' },
+      ActionPane: { iType: 'AxFormActionPaneControl', typeValue: 'ActionPane' },
+    };
+    const mapped = typeMap[type] ?? { iType: 'AxFormStringControl', typeValue: 'String' };
 
-    // Add properties
+    // All AxFormControl nodes need xmlns="" to override the AxForm default namespace
+    let xml = `${indent}<AxFormControl xmlns=""\n${indent}\ti:type="${mapped.iType}">\n`;
+    xml += `${i1}<Name>${name}</Name>\n`;
+    xml += `${i1}<Type>${mapped.typeValue}</Type>\n`;
+    // FormControlExtension is mandatory on every control
+    xml += `${i1}<FormControlExtension\n${i1}\ti:nil="true" />\n`;
+
+    // Additional D365FO properties (DataField, DataSource, etc.)
     if (properties) {
       for (const [key, value] of Object.entries(properties)) {
-        xml += `${indent}\t<${key}>${this.escapeXml(value)}</${key}>\n`;
+        xml += `${i1}<${key}>${this.escapeXml(value)}</${key}>\n`;
       }
     }
 
-    // Add children recursively
+    // Child controls
     if (children && children.length > 0) {
+      xml += `${i1}<Controls>\n`;
       for (const child of children) {
-        xml += this.buildFormControl(child, indentLevel + 1);
+        xml += this.buildFormControl(child, indentLevel + 2);
       }
+      xml += `${i1}</Controls>\n`;
     }
 
-    xml += `${indent}</${nodeType}>\n`;
+    xml += `${indent}</AxFormControl>\n`;
     return xml;
   }
 


### PR DESCRIPTION
- smartXmlBuilder.ts: complete rewrite of buildTableXml/buildFormXml
  - SourceCode with Declaration moved FIRST in AxTable
  - Fields use <AxTableField xmlns='' i:type='AxTableFieldString'> format
  - Indexes use AlternateKey instead of AllowDuplicates
  - Relations include Cardinality, RelatedTableCardinality, RelationshipType
  - Relation constraints use xmlns='' i:type='AxTableRelationConstraintField'
  - Added mandatory sections: DeleteActions, FieldGroups (5x), FullTextIndexes, Mappings, StateMachines
  - Auto-sets TitleField1/2, PrimaryIndex, ReplacementKey
  - Form root gets xmlns='Microsoft.Dynamics.AX.Metadata.V6'
  - Form DataSources use <AxFormDataSource xmlns=''> (not AxFormDataSourceRoot)
  - Form controls use <AxFormControl xmlns='' i:type='AxFormGridControl'>
  - Form controls include Type element and FormControlExtension i:nil='true'
  - Form includes Parts section and classDeclaration method with [Form] attribute

- generateD365Xml.ts: fix AxTable and AxForm minimal templates to match AOT

- modifyD365File.ts:
  - addMethod/removeMethod always use root.SourceCode[0] for all object types
  - addField uses correct xml2js attribute format with $ key

- xmlParser.ts:
  - parseFields reads field.$['i:type'] for typed field detection
  - parseIndexes uses AlternateKey === 'Yes' for unique index detection