### PR TITLE
fix: prevent incomplete table generation and eliminate modify_d365fo_…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,27 @@ The following built-in tools **MUST NOT** be used on D365FO metadata files (.xml
    - Only call `create_label()` when no suitable label is found
    - **NEVER edit .label.txt files directly** — use `create_label()` which inserts alphabetically and updates the index
 
+11. **ALWAYS pass `fieldsHint` when user describes table fields**
+   - Extract ALL field names from the user's natural language description before calling `generate_smart_table`
+   - WITHOUT `fieldsHint` the tool generates ONLY generic defaults → table will be INCOMPLETE
+   - Czech/natural language mapping:
+     - "Account number" / "účet" → `AccountNum`
+     - "Name" / "název" → `Name`
+     - "Description" / "popis" → `Description`
+     - "platnost od" / "from date" / "ValidFrom" → `ValidFrom`
+     - "platnost do" / "to date" / "ValidTo" → `ValidTo`
+     - "active" / "flag" → `Active`
+   - Example: user says *"primárním klíčem Account number a Name, přidej popis a platnost od-do, metody find a exist"*
+     ```
+     generate_smart_table(
+       name="MyTable",
+       fieldsHint="AccountNum, Name, Description, ValidFrom, ValidTo",
+       methods=["find", "exist"]
+     )
+     ```
+   - **NEVER call `modify_d365fo_file` to add missing fields** — it CANNOT write files on Azure/Linux
+   - If the response says **⚠️ INCOMPLETE TABLE**, call `generate_smart_table` AGAIN with proper `fieldsHint` — do NOT proceed to `create_d365fo_file` with incomplete XML
+
 ## Available MCP Tools
 
 ### 🔍 Search and Discovery (8 tools)
@@ -456,6 +477,9 @@ K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxView\{Name}.xml
 - Don't use vague search terms — be specific about what you're looking for
 - Don't call `search()` after you already have the complete object from `get_class_info()`
 - **Never edit .label.txt files with `edit_file` or `replace_string_in_file`** — use `create_label()` which maintains sort order and updates the index
+- **Never call `create_d365fo_file` with incomplete XML** — if `generate_smart_table` response shows ⚠️ INCOMPLETE TABLE, REGENERATE with `fieldsHint` first
+- **Never omit `fieldsHint`** when user describes fields — extract them from natural language and pass explicitly; without them the table is empty
+- **Never omit `methods=["find","exist"]`** when user asks for those methods — pass in `generate_smart_table`, not via `modify_d365fo_file`
 - Never create a label without first calling `search_labels()` — duplicate labels waste translation effort
 - **Never manually specify EDT types like "String", "Int"** — call `suggest_edt()` to find correct Extended Data Type
 - **Never create tables/forms without analyzing patterns first** — use `get_table_patterns()`/`get_form_patterns()` to learn from existing code

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -53,7 +53,19 @@ export const generateSmartTableTool: Tool = {
   },
       fieldsHint: {
         type: 'string',
-        description: 'Optional: Comma-separated field hints (e.g., "RecId, Name, Amount, Customer"). Tool will suggest EDTs.',
+        description:
+          'REQUIRED when the user mentions any fields, columns, or data. ' +
+          'Extract ALL field names from the user description and pass them here as a comma-separated list. ' +
+          'WITHOUT this parameter only generic default fields are generated and the table will be INCOMPLETE. ' +
+          'Natural language → fieldsHint mapping examples: ' +
+          '"Account number" → "AccountNum", ' +
+          '"Name" → "Name", ' +
+          '"Description" or "popis" → "Description", ' +
+          '"platnost od" or "ValidFrom" or "from date" → "ValidFrom", ' +
+          '"platnost do" or "ValidTo" or "to date" → "ValidTo", ' +
+          '"active" or "active flag" → "Active", ' +
+          '"customer" or "customer account" → "CustAccount". ' +
+          'Example call: fieldsHint="AccountNum, Name, Description, ValidFrom, ValidTo"',
       },
       generateCommonFields: {
         type: 'boolean',
@@ -75,10 +87,11 @@ export const generateSmartTableTool: Tool = {
         type: 'array',
         items: { type: 'string' },
         description:
-          'Standard method names to generate and embed directly in the table XML. ' +
+          'ALWAYS pass ["find", "exist"] when the user asks for those methods. ' +
+          'Methods are embedded directly in the generated XML. ' +
           'Supported values: "find", "exist". ' +
-          'ALWAYS use this instead of calling modify_d365fo_file after table generation — ' +
-          'on Azure/Linux modify_d365fo_file cannot write files.',
+          '⛔ NEVER omit this and then call modify_d365fo_file to add methods afterwards — ' +
+          'modify_d365fo_file CANNOT write files on Azure/Linux.',
       },
     },
     required: ['name'],
@@ -108,6 +121,7 @@ export async function handleGenerateSmartTable(
   let fields: TableFieldSpec[] = [];
   let indexes: TableIndexSpec[] = [];
   let relations: TableRelationSpec[] = [];
+  let usedFallback = false; // true when fieldsHint was missing and generic defaults were used
 
   // Strategy 1: Copy from existing table
   if (copyFrom) {
@@ -239,7 +253,8 @@ export async function handleGenerateSmartTable(
 
   // Fallback: Generate sensible defaults when no fields were provided at all
   if (fields.length === 0) {
-    console.warn(`[generateSmartTable] No fieldsHint provided — generating default fields. Pass fieldsHint for accurate results.`);
+    usedFallback = true;
+    console.warn(`[generateSmartTable] No fieldsHint provided — generating GENERIC defaults only. The table will be incomplete!`);
     const nameLower = name.toLowerCase();
     // Derive reasonable defaults from table name and group
     if (nameLower.includes('account') || tableGroup === 'Main') {
@@ -401,6 +416,26 @@ export async function handleGenerateSmartTable(
     }
   }
 
+  // Build incomplete-table warning for when no fieldsHint was provided
+  const incompleteWarning = usedFallback
+    ? [
+        ``,
+        `⚠️ **INCOMPLETE TABLE — \`fieldsHint\` was NOT provided!**`,
+        `Generic default fields were used instead of the user's actual fields.`,
+        ``,
+        `🔄 **YOU MUST REGENERATE** — call \`generate_smart_table\` AGAIN with correct parameters:`,
+        `\`\`\``,
+        `generate_smart_table(`,
+        `  name="${name}",              ← base name WITHOUT model prefix`,
+        `  fieldsHint="Field1, Field2, Field3",  ← extract ALL fields from the user's description`,
+        `  methods=["find", "exist"],   ← include if user requested these`,
+        `)`,
+        `\`\`\``,
+        `⛔ **NEVER** call \`modify_d365fo_file\` to add missing fields — it CANNOT write on Azure/Linux.`,
+        `⛔ **NEVER** call \`create_d365fo_file\` with this incomplete XML — REGENERATE first.`,
+      ].join('\n')
+    : '';
+
   // Generate XML
   const xml = builder.buildTableXml({
     name: finalName,
@@ -440,6 +475,7 @@ export async function handleGenerateSmartTable(
           `✅ Table XML generated for **${finalName}**` + (resolvedModel ? ` (model: ${resolvedModel})` : ''),
           `   Fields: ${fields.length}, Indexes: ${indexes.length}, Relations: ${relations.length}`,
           noModelNote,
+          incompleteWarning,
           ``,
           `ℹ️  MCP server is running on Azure/Linux — file writing is handled by the local Windows companion. This is the expected hybrid workflow.`,
           nextStep,


### PR DESCRIPTION
…file fallback

Root cause of the bug: AI was calling generate_smart_table WITHOUT fieldsHint and WITHOUT methods, then trying to fix the empty result via modify_d365fo_file (which fails on Azure/Linux).

Changes:
1. generateSmartTable.ts - strengthen tool parameter descriptions
   - fieldsHint: marked as REQUIRED when user describes fields, with explicit natural language -> field name mapping examples
   - methods: marked as ALWAYS pass when user asks for find/exist, with explicit NEVER omit warning

2. generateSmartTable.ts - add usedFallback tracking
   - Track when generic default fields were used instead of user fields
   - Emit prominent warning in the response:
     * Warns the AI that the table is INCOMPLETE
     * Instructs to REGENERATE with fieldsHint * Explicitly forbids modify_d365fo_file and create_d365fo_file with incomplete XML

3. copilot-instructions.md - add Rule 11 (ALWAYS pass fieldsHint)
   - Moved to non-negotiable rules section
   - Czech/English field name mapping examples
   - explicit: if response shows WARNING INCOMPLETE TABLE, regenerate - do NOT call create_d365fo_file
   - Added to DON'T list: never omit fieldsHint, never omit methods