### PR TITLE
fix: ValidFrom as wrong PK + suggest_method_implementation/get_api_us…

### DIFF
--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1576,20 +1576,40 @@ export class XppSymbolIndex {
    * Find similar methods based on name and context
    */
   findSimilarMethods(methodName: string, _contextClass?: string, limit: number = 10): any[] {
-    let stmt = this.stmtCache.get('findSimilarMethods');
-    if (!stmt) {
-      stmt = this.db.prepare(`
-        SELECT s.*, parent.name as class_name, parent.pattern_type
+    // Try exact-name match first (fast) — falls back to LIKE only when nothing found
+    const stmtKeyExact = 'findSimilarMethods:exact';
+    let stmtExact = this.stmtCache.get(stmtKeyExact);
+    if (!stmtExact) {
+      stmtExact = this.db.prepare(`
+        SELECT s.name, s.parent_name, s.signature, s.source_snippet, s.complexity, s.tags,
+               parent.pattern_type
         FROM symbols s
         LEFT JOIN symbols parent ON s.parent_name = parent.name AND parent.type = 'class'
-        WHERE s.type = 'method'
-          AND s.name LIKE ?
-        ORDER BY s.complexity ASC, s.name
+        WHERE s.type = 'method' AND s.name = ?
+        ORDER BY s.complexity ASC
         LIMIT ?
       `);
-      this.stmtCache.set('findSimilarMethods', stmt);
+      this.stmtCache.set(stmtKeyExact, stmtExact);
     }
-    const methods = stmt.all(`%${methodName}%`, limit) as any[];
+    let methods = stmtExact.all(methodName, limit) as any[];
+
+    // Fall back to suffix/prefix LIKE only when exact produced nothing, but cap at limit
+    if (methods.length === 0) {
+      let stmtLike = this.stmtCache.get('findSimilarMethods:like');
+      if (!stmtLike) {
+        stmtLike = this.db.prepare(`
+          SELECT s.name, s.parent_name, s.signature, s.source_snippet, s.complexity, s.tags,
+                 parent.pattern_type
+          FROM symbols s
+          LEFT JOIN symbols parent ON s.parent_name = parent.name AND parent.type = 'class'
+          WHERE s.type = 'method' AND s.name LIKE ?
+          ORDER BY s.complexity ASC, s.name
+          LIMIT ?
+        `);
+        this.stmtCache.set('findSimilarMethods:like', stmtLike);
+      }
+      methods = stmtLike.all(`%${methodName}%`, limit) as any[];
+    }
     
     return methods.map(m => ({
       className: m.class_name || m.parent_name,
@@ -1601,15 +1621,17 @@ export class XppSymbolIndex {
       patternType: m.pattern_type
     }));
   }
-
-  /**
-   * Get API usage patterns for a class
-   */
   getApiUsagePatterns(className: string): any[] {
-    // Find all methods that reference this class in their used_types
+    // Find all methods that reference this class in their used_types.
+    // Cap at 20 rows — fetching source_snippet for 50+ rows on a 584K-row table causes timeout.
     let stmt = this.stmtCache.get('getApiUsagePatterns');
     if (!stmt) {
-      stmt = this.db.prepare(`SELECT * FROM symbols WHERE type = 'method' AND used_types LIKE ? LIMIT 50`);
+      stmt = this.db.prepare(
+        `SELECT name, parent_name, method_calls, source_snippet
+           FROM symbols
+          WHERE type = 'method' AND used_types LIKE ?
+          LIMIT 20`
+      );
       this.stmtCache.set('getApiUsagePatterns', stmt);
     }
     const methods = stmt.all(`%${className}%`) as any[];

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -241,10 +241,21 @@ export async function handleGenerateSmartTable(
 
       // Try to suggest EDT based on name
       const edt = suggestEdtFromFieldName(hint);
+      const hintLower = hint.toLowerCase();
+      // Mark as mandatory only when the field name IS an identifier (ends with 'Id',
+      // equals 'RecId', or exactly 'AccountNum'/'CustAccount' patterns).
+      // Do NOT match fields that merely CONTAIN 'id' mid-word (e.g. ValidFrom, Description).
+      const isMandatory =
+        hintLower === 'recid' ||
+        /id$/.test(hintLower) ||          // SalesId, CustId, AccountId …
+        hintLower === 'accountnum' ||      // D365FO conventional PK fields
+        hintLower === 'accountnumber' ||
+        hintLower === 'num' ||
+        hintLower === 'code';
       fields.push({
         name: hint,
         edt,
-        mandatory: hint.toLowerCase().includes('recid') || hint.toLowerCase().includes('id'),
+        mandatory: isMandatory,
       });
     }
 
@@ -467,6 +478,7 @@ export async function handleGenerateSmartTable(
       `\`\`\``,
       `⛔ NEVER use \`create_file\`, PowerShell scripts, or any built-in file tool — they corrupt D365FO metadata and break VS project integration.`,
       `⛔ NEVER call \`modify_d365fo_file\` to add methods — the \`methods\` parameter in \`generate_smart_table\` already embedded them in the XML above.`,
+      `⛔ NEVER call \`suggest_method_implementation\` or \`get_api_usage_patterns\` between this step and \`create_d365fo_file\` — those tools are expensive and their result is not needed for file creation. Call them AFTER the file is created if the user explicitly asks.`,
     ].join('\n');
     return {
       content: [{


### PR DESCRIPTION
…age_patterns timeouts

Three bugs seen in Azure log 2026-02-25T09:34:

1. ValidFrom/ValidTo incorrectly marked mandatory (selected as PK)
   - Bug: includes('id') matched 'val-ID-from' and 'val-ID-to'
   - Fix: replaced with precise check — only fields whose name ENDS with 'Id', equals 'RecId', or is an explicit PK name (AccountNum, Num, Code) are marked mandatory
   - Result: AccountNum is now PK, not ValidFrom

2. suggest_method_implementation 30s timeout
   - Bug: findSimilarMethods always did LIKE '%name%' scan on 584K rows
   - Fix: try exact-name match first (hits index, fast); fall back to LIKE only when exact returns nothing
   - Separate stmtCache keys for exact vs LIKE variants

3. get_api_usage_patterns 30s timeout
   - Bug: LIMIT 50 but each row loaded full source_snippet column
   - Fix: select only needed columns (name, parent_name, method_calls, source_snippet); reduce LIMIT to 20

4. generate_smart_table response: explicitly forbid calling suggest_method_implementation or get_api_usage_patterns between generate_smart_table and create_d365fo_file — these are expensive and not needed for file creation