### PR TITLE
fix: add composite PK support and correct find method selectForUpdate…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,11 +83,21 @@ The following built-in tools **MUST NOT** be used on D365FO metadata files (.xml
      generate_smart_table(
        name="MyTable",
        fieldsHint="AccountNum, Name, Description, ValidFrom, ValidTo",
+       primaryKeyFields=["AccountNum", "Name"],
        methods=["find", "exist"]
      )
      ```
    - **NEVER call `modify_d365fo_file` to add missing fields** — it CANNOT write files on Azure/Linux
    - If the response says **⚠️ INCOMPLETE TABLE**, call `generate_smart_table` AGAIN with proper `fieldsHint` — do NOT proceed to `create_d365fo_file` with incomplete XML
+
+12. **ALWAYS pass `primaryKeyFields` when user specifies a composite primary key**
+   - A composite PK = the user says "primary key is X and Y" (two or more fields)
+   - Without `primaryKeyFields` the tool auto-detects PK from the FIRST mandatory field only → composite PK will be WRONG
+   - Single-field PK: omit `primaryKeyFields` — the tool auto-detects it
+   - Composite PK: `primaryKeyFields=["AccountNum", "Name"]` → index contains BOTH fields
+   - Example:
+     - User: "primary key Account number" → `primaryKeyFields` can be omitted (auto-detected)
+     - User: "primary key Account number and Name" → `primaryKeyFields=["AccountNum", "Name"]`
 
 ## Available MCP Tools
 
@@ -139,7 +149,7 @@ The following built-in tools **MUST NOT** be used on D365FO metadata files (.xml
 | `get_table_patterns(tableGroup?, similarTo?)` | Analyze common patterns in tables: field types, indexes, relations. Query by table group (e.g., "Transaction") or find tables similar to an existing one | `get_table_patterns(tableGroup="Transaction")` or `get_table_patterns(similarTo="CustTable")` |
 | `get_form_patterns(formPattern?, tableName?)` | Analyze common patterns in forms: datasource configurations, control hierarchies, form patterns. Find forms using specific table or matching pattern | `get_form_patterns(tableName="SalesTable")` or `get_form_patterns(formPattern="SimpleList")` |
 | `suggest_edt(fieldName, context?)` | Suggest Extended Data Types (EDT) for a field name using fuzzy matching and pattern analysis. Returns confidence-ranked suggestions with EDT properties | `suggest_edt(fieldName="CustomerAccount", context="sales order")` |
-| `generate_smart_table(name, tableGroup?, copyFrom?, fieldsHint?, generateCommonFields?, methods?)` | **AI-driven table generation.** Creates AxTable XML with intelligent field/index/relation suggestions. `methods` param embeds `find`/`exist` directly in XML — **always use this instead of calling `modify_d365fo_file` afterwards.** | `generate_smart_table(name="MyOrderTable", tableGroup="Transaction", methods=["find","exist"])` |
+| `generate_smart_table(name, tableGroup?, copyFrom?, fieldsHint?, primaryKeyFields?, generateCommonFields?, methods?)` | **AI-driven table generation.** Creates AxTable XML with intelligent field/index/relation suggestions. `primaryKeyFields` sets composite PK. `methods` param embeds `find`/`exist` directly in XML — **always use this instead of calling `modify_d365fo_file` afterwards.** | `generate_smart_table(name="MyOrderTable", tableGroup="Transaction", primaryKeyFields=["OrderId"], methods=["find","exist"])` |
 | `generate_smart_form(name, dataSource?, formPattern?, copyFrom?, generateControls?)` | **AI-driven form generation.** Creates AxForm XML with intelligent datasource/control suggestions. Can copy structure, analyze patterns, or auto-generate grids | `generate_smart_form(name="MyOrderForm", dataSource="MyOrderTable", generateControls=true)` |
 
 ### 📝 File & Metadata Operations (3 tools)
@@ -342,6 +352,7 @@ Step 1: generate_smart_table(
           name="MyOrderTable",
           tableGroup="Transaction",
           fieldsHint="OrderId, CustomerAccount, OrderAmount, OrderDate",
+          primaryKeyFields=["OrderId"],
           generateCommonFields=true,
           methods=["find","exist"]    ← embed methods in XML — do NOT call modify_d365fo_file afterwards
         )
@@ -479,6 +490,7 @@ K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxView\{Name}.xml
 - **Never edit .label.txt files with `edit_file` or `replace_string_in_file`** — use `create_label()` which maintains sort order and updates the index
 - **Never call `create_d365fo_file` with incomplete XML** — if `generate_smart_table` response shows ⚠️ INCOMPLETE TABLE, REGENERATE with `fieldsHint` first
 - **Never omit `fieldsHint`** when user describes fields — extract them from natural language and pass explicitly; without them the table is empty
+- **Never omit `primaryKeyFields`** when user specifies a composite PK (two or more fields) — without it only the first mandatory field is used and the PK will be wrong
 - **Never omit `methods=["find","exist"]`** when user asks for those methods — pass in `generate_smart_table`, not via `modify_d365fo_file`
 - Never create a label without first calling `search_labels()` — duplicate labels waste translation effort
 - **Never manually specify EDT types like "String", "Int"** — call `suggest_edt()` to find correct Extended Data Type

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -17,6 +17,7 @@ interface GenerateSmartTableArgs {
   tableGroup?: string;
   copyFrom?: string;
   fieldsHint?: string;
+  primaryKeyFields?: string[];
   generateCommonFields?: boolean;
   modelName?: string;
   projectPath?: string;
@@ -67,6 +68,16 @@ export const generateSmartTableTool: Tool = {
           '"customer" or "customer account" → "CustAccount". ' +
           'Example call: fieldsHint="AccountNum, Name, Description, ValidFrom, ValidTo"',
       },
+      primaryKeyFields: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'REQUIRED when user specifies a composite primary key (multiple fields). ' +
+          'List ALL fields that form the primary key index. ' +
+          'Without this, only the first mandatory field is used as PK — composite PKs will be WRONG. ' +
+          'Example: user says "primary key is Account number and Name" → primaryKeyFields=["AccountNum", "Name"]. ' +
+          'Single-field PK can be omitted — the tool auto-detects it from fieldsHint mandatory fields.',
+      },
       generateCommonFields: {
         type: 'boolean',
         description: 'If true, analyze table group patterns and generate common fields automatically',
@@ -102,12 +113,13 @@ export async function handleGenerateSmartTable(
   args: GenerateSmartTableArgs,
   symbolIndex: XppSymbolIndex
 ): Promise<any> {
-  const { 
-    name, 
-    label, 
-    tableGroup = 'Main', 
-    copyFrom, 
-    fieldsHint, 
+  const {
+    name,
+    label,
+    tableGroup = 'Main',
+    copyFrom,
+    fieldsHint,
+    primaryKeyFields,
     generateCommonFields,
     modelName,
     projectPath,
@@ -285,15 +297,29 @@ export async function handleGenerateSmartTable(
     }
   }
 
+  // If primaryKeyFields is specified, mark those fields as mandatory (overrides auto-detection)
+  if (primaryKeyFields && primaryKeyFields.length > 0) {
+    for (const pkFieldName of primaryKeyFields) {
+      const f = fields.find(f => f.name === pkFieldName);
+      if (f) { f.mandatory = true; }
+    }
+  }
+
   // Ensure primary key index exists
   const hasAnyUniqueIndex = indexes.some(idx => idx.unique || idx.clustered);
   if (!hasAnyUniqueIndex && fields.length > 0) {
-    // Prefer first mandatory non-RecId field, fall back to RecId
-    const pkField = fields.find(f => f.mandatory && f.name !== 'RecId')?.name
-      ?? fields.find(f => f.name === 'RecId')?.name
-      ?? fields[0].name;
-    indexes.unshift(builder.buildPrimaryKeyIndex(name, [pkField]));
-    console.log(`[generateSmartTable] Added primary key index on ${pkField}`);
+    if (primaryKeyFields && primaryKeyFields.length > 0) {
+      // Use explicitly provided composite/single PK fields
+      indexes.unshift(builder.buildPrimaryKeyIndex(name, primaryKeyFields));
+      console.log(`[generateSmartTable] Added primary key index on [${primaryKeyFields.join(', ')}] (from primaryKeyFields)`);
+    } else {
+      // Auto-detect: prefer first mandatory non-RecId field, fall back to RecId
+      const pkField = fields.find(f => f.mandatory && f.name !== 'RecId')?.name
+        ?? fields.find(f => f.name === 'RecId')?.name
+        ?? fields[0].name;
+      indexes.unshift(builder.buildPrimaryKeyIndex(name, [pkField]));
+      console.log(`[generateSmartTable] Added primary key index on ${pkField}`);
+    }
   }
 
   // Determine package path
@@ -396,13 +422,13 @@ export async function handleGenerateSmartTable(
             `{`,
             `    ${finalName}  local;`,
             ``,
-            `    select firstOnly local`,
-            `        where ${whereClause};`,
-            ``,
             `    if (_forupdate)`,
             `    {`,
             `        local.selectForUpdate(_forupdate);`,
             `    }`,
+            ``,
+            `    select firstOnly local`,
+            `        where ${whereClause};`,
             ``,
             `    return local;`,
             `}`,
@@ -439,6 +465,7 @@ export async function handleGenerateSmartTable(
         `generate_smart_table(`,
         `  name="${name}",              ← base name WITHOUT model prefix`,
         `  fieldsHint="Field1, Field2, Field3",  ← extract ALL fields from the user's description`,
+        `  primaryKeyFields=["Field1", "Field2"],  ← ALL fields in the PK (omit for single-field PK)`,
         `  methods=["find", "exist"],   ← include if user requested these`,
         `)`,
         `\`\`\``,


### PR DESCRIPTION
… order

- Add `primaryKeyFields` parameter to generate_smart_table for explicit composite/single primary key specification; without it only the first mandatory field was used causing wrong PK when user specified multiple fields
- Mark fields listed in primaryKeyFields as mandatory after fieldsHint parsing
- Fix find method X++ code: move selectForUpdate call BEFORE select statement (previous order was syntactically incorrect per D365FO pattern)
- Update incompleteWarning regeneration example to include primaryKeyFields
- Add Rule 12 to copilot-instructions.md: always pass primaryKeyFields for composite PKs; update Rule 11 example, tool table, DON'T rules, and hybrid workflow example