### PR TITLE
docs: replace internal references with generic examples

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,6 +99,13 @@ The following built-in tools **MUST NOT** be used on D365FO metadata files (.xml
      - User: "primary key Account number" → `primaryKeyFields` can be omitted (auto-detected)
      - User: "primary key Account number and Name" → `primaryKeyFields=["AccountNum", "Name"]`
 
+13. **Class/table name MUST match between file name and declaration**
+   - When `create_d365fo_file(objectName="MyClass", ...)` is called with prefix applied → file becomes `MyPrefixMyClass.xml`
+   - The class declaration inside MUST also be `class MyPrefixMyClass` — **NOT** `class MyClass`
+   - `create_d365fo_file` automatically fixes this inconsistency (replaces unprefixed names with prefixed ones)
+   - **Rule:** If file is `MyPrefixMyClass.xml`, the X++ declaration must be `public class MyPrefixMyClass extends ...`
+   - **Never create:** file `MyPrefixMyClass.xml` containing `class MyClass` — this breaks AOT synchronization
+
 ## Available MCP Tools
 
 ### 🔍 Search and Discovery (8 tools)
@@ -118,9 +125,9 @@ The following built-in tools **MUST NOT** be used on D365FO metadata files (.xml
 
 | Tool | Description | Example Usage |
 |------|-------------|---------------|
-| `search_labels(query, language?, model?, labelFileId?)` | Full-text search across all indexed AxLabelFile labels. Searches by ID, text and comment. Returns `@LabelFileId:LabelId` reference syntax. **Call this FIRST before create_label!** | `search_labels("customer name", model="AslCore")` |
-| `get_label_info(labelId?, labelFileId?, model?)` | Get all language translations for a label ID, or list available AxLabelFile IDs in a model. Shows ready-to-use X++ and XML snippets. | `get_label_info("ACFeature", model="AslCore")` |
-| `create_label(labelId, labelFileId, model, translations[])` | Add a new label to all language .label.txt files in a custom model. Inserts alphabetically. Optionally creates AxLabelFile structure from scratch. Updates the MCP index. | `create_label("MyField", "AslCore", "AslCore", [{language:"en-US", text:"My field"}, {language:"cs", text:"Moje pole"}])` |
+| `search_labels(query, language?, model?, labelFileId?)` | Full-text search across all indexed AxLabelFile labels. Searches by ID, text and comment. Returns `@LabelFileId:LabelId` reference syntax. **Call this FIRST before create_label!** | `search_labels("customer name", model="MyModel")` |
+| `get_label_info(labelId?, labelFileId?, model?)` | Get all language translations for a label ID, or list available AxLabelFile IDs in a model. Shows ready-to-use X++ and XML snippets. | `get_label_info("MyFeature", model="MyModel")` |
+| `create_label(labelId, labelFileId, model, translations[])` | Add a new label to all language .label.txt files in a custom model. Inserts alphabetically. Optionally creates AxLabelFile structure from scratch. Updates the MCP index. | `create_label("MyField", "MyModel", "MyModel", [{language:"en-US", text:"My field"}, {language:"cs", text:"Moje pole"}])` |
 
 ### 📊 Advanced Object Information (5 tools)
 
@@ -202,8 +209,8 @@ create_d365fo_file(objectType="class", objectName="MySalesHelper",
   modelName="whatever",           ← ignored, auto-corrected
   projectPath="K:\VSProjects\MySolution\MyProject\MyProject.rnrproj",
   addToProject=true)
-→ Tool reads MyProject.rnrproj → extracts ModelName (e.g. "AslCore")
-→ File created at K:\AosService\PackagesLocalDirectory\AslCore\AslCore\AxClass\MySalesHelper.xml ✅
+→ Tool reads MyProject.rnrproj → extracts ModelName (e.g. "MyModel")
+→ File created at K:\AosService\PackagesLocalDirectory\MyPackage\MyModel\AxClass\MySalesHelper.xml ✅
 → Added to MyProject.rnrproj ✅
 ```
 
@@ -362,11 +369,11 @@ Step 1: generate_smart_table(
 
 Step 2: create_d365fo_file(           ← IMMEDIATELY after step 1, no intermediate steps
           objectType="table",
-          objectName="AslMyOrderTable",   ← use the prefixed name from step 1 response
+          objectName="MyOrderTable",   ← use the prefixed name from step 1 response
           xmlContent="<full XML from step 1>",
           addToProject=true
         )
-     → Writes file to K:\AosService\PackagesLocalDirectory\AslCore\AslCore\AxTable\...
+     → Writes file to K:\AosService\PackagesLocalDirectory\MyPackage\MyModel\AxTable\...
      → Adds entry to .rnrproj for VS2022
 
 ⛔ FORBIDDEN alternatives when generate_smart_table returns XML text:
@@ -384,19 +391,19 @@ Same pattern applies for generate_smart_form + create_d365fo_file(objectType="fo
 ```
 Step 1: search_labels("your text", language="en-US")
      → Returns matching labels with @LabelFileId:LabelId syntax
-Step 2: get_label_info("ACFeature", model="AslCore")
+Step 2: get_label_info("MyFeature", model="MyModel")
      → Verify all required languages are present
-Step 3: Use @AslCore:ACFeature in X++ code or metadata XML
+Step 3: Use @MyModel:MyFeature in X++ code or metadata XML
 ```
 
 **Workflow for creating a new label:**
 ```
 Step 1: search_labels("your text") — REQUIRED: check existing labels first!
-Step 2: get_label_info(model="AslCore") — list available label files in model
+Step 2: get_label_info(model="MyModel") — list available label files in model
 Step 3: create_label(
           labelId="MyNewField",
-          labelFileId="AslCore",
-          model="AslCore",
+          labelFileId="MyModel",
+          model="MyModel",
           translations=[
             {language:"en-US", text:"My new field"},
             {language:"cs",    text:"Moje nové pole"},
@@ -405,13 +412,13 @@ Step 3: create_label(
           ],
           defaultComment="Description for developers"
         )
-Step 4: Use @AslCore:MyNewField in code or XML
+Step 4: Use @MyModel:MyNewField in code or XML
 ```
 
 **Label reference syntax:**
-- In X++ code: `literalStr("@AslCore:MyLabel")` or `"@AslCore:MyLabel"` in string fields
-- In metadata XML: `<Label>@AslCore:MyLabel</Label>`
-- In field properties: `<HelpText>@AslCore:MyLabelHelp</HelpText>`
+- In X++ code: `literalStr("@MyModel:MyLabel")` or `"@MyModel:MyLabel"` in string fields
+- In metadata XML: `<Label>@MyModel:MyLabel</Label>`
+- In field properties: `<HelpText>@MyModel:MyLabelHelp</HelpText>`
 
 ## Best Practices
 
@@ -433,7 +440,7 @@ K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxView\{Name}.xml
 |-----------|--------|
 | `projectPath` or `solutionPath` provided | ✅ Tool reads correct `ModelName` from `.rnrproj` |
 | Neither provided, `modelName="ApplicationSuite"` | ❌ File created in Microsoft's standard model — WRONG! |
-| Neither provided, `modelName="AslCore"` | ✅ Only if value happens to match actual model name |
+| Neither provided, `modelName="MyModel"` | ✅ Only if value happens to match actual model name |
 
 **Rules:**
 - ✅ **ALWAYS provide `projectPath` or `solutionPath`** when calling `create_d365fo_file`
@@ -495,7 +502,7 @@ K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxView\{Name}.xml
 - Never create a label without first calling `search_labels()` — duplicate labels waste translation effort
 - **Never manually specify EDT types like "String", "Int"** — call `suggest_edt()` to find correct Extended Data Type
 - **Never create tables/forms without analyzing patterns first** — use `get_table_patterns()`/`get_form_patterns()` to learn from existing code
-- **🚨 CRITICAL: NEVER include the model prefix in the `name` parameter of `generate_smart_table` or `generate_smart_form`** — always pass the base name without prefix (e.g., `name="AccountTable"`, NOT `name="AslAccountTable"`). The tool applies the prefix automatically from `modelName` parameter, `D365FO_MODEL_NAME` env var, or `.rnrproj` detection. Pre-applied prefix causes double-prefixing (e.g., `AslAslAccountTable`).
+- **🚨 CRITICAL: NEVER include the model prefix in the `name` parameter of `generate_smart_table` or `generate_smart_form`** — always pass the base name without prefix (e.g., `name="AccountTable"`, NOT `name="MyAccountTable"`). The tool applies the prefix automatically from `modelName` parameter, `D365FO_MODEL_NAME` env var, or `.rnrproj` detection. Pre-applied prefix causes double-prefixing (e.g., `MyMyAccountTable`).
 - **Never call `modify_d365fo_file` after `generate_smart_table` to add methods** — use the `methods` parameter instead; `modify_d365fo_file` fails on Azure/Linux (read-only mode)
 - **🚨 NEVER use `create_file` or PowerShell as a fallback when `generate_smart_table`/`generate_smart_form` returns XML as text** — the `ℹ️ Azure/Linux` message in the response means "pass this XML to `create_d365fo_file(xmlContent=...)`", not "the tool failed". There is NO other acceptable approach.
 - **NEVER interpret `generate_smart_table`/`generate_smart_form` returning XML as a partial failure** — it is a complete success; `create_d365fo_file(xmlContent=...)` is the mandatory and only next step

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -10,7 +10,7 @@
  * Model name resolution priority (from highest to lowest):
  *   1. modelName argument passed directly in the tool call
  *   2. modelName in context below (explicit, use when package name ≠ model name)
- *   3. Last segment of workspacePath (e.g. "AslCore" from "...PackagesLocalDirectory\AslCore")
+ *   3. Last segment of workspacePath (e.g. "MyModel" from "...PackagesLocalDirectory\MyModel")
  *   4. D365FO_MODEL_NAME environment variable (legacy fallback)
  */
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Copy-Item -Path ".github" -Destination "C:\Path\To\YourSolution\" -Recurse
 | Prompt | What happens |
 |--------|-------------|
 | `Find a label for "customer"` | Searches all AxLabelFile objects |
-| `Translations of label ACFeature in model AslCore` | All languages at once |
-| `Create a new label MyNewField in AslCore` | Writes to all .label.txt files |
+| `Translations of label MyFeature in model MyModel` | All languages at once |
+| `Create a new label MyNewField in MyModel` | Writes to all .label.txt files |
 
 ### 📝 File Operations *(local VM only)*
 - Generates correct D365FO XML for classes, tables, forms, enums

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -424,7 +424,7 @@ erDiagram
     LABELS {
         integer id PK
         text label_id "Label ID (e.g., MyLabel)"
-        text label_file_id "File ID (e.g., AslCore)"
+        text label_file_id "File ID (e.g., MyModel)"
         text model "Model name"
         text language "Language code (en-US, cs, sk, de)"
         text text "Translated text"

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -69,8 +69,8 @@ just ask in plain English.
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|
 | **search_labels** | Full-text search across all AxLabelFile labels | "Find a label for 'customer account'" |
-| **get_label_info** | All translations for a label ID, or list label files | "Show all translations of ACFeature in AslCore" |
-| **create_label** | Add a new label to all language files in a model | "Create label MyNewField in AslCore" |
+| **get_label_info** | All translations for a label ID, or list label files | "Show all translations of MyFeature in MyModel" |
+| **create_label** | Add a new label to all language files in a model | "Create label MyNewField in MyModel" |
 
 ---
 
@@ -115,7 +115,7 @@ avoid noise from the 500 000+ standard Microsoft symbols.
 ```
 Find all my ISV_ classes
 Show me custom extensions for CustTable
-Search for AslCore helper classes
+Search for MyModel helper classes
 ```
 
 ---
@@ -374,14 +374,14 @@ content, and developer comments simultaneously. Returns labels in ranked order w
 **Parameters:**
 - `query` — text to search for (required)
 - `language` — filter by locale, e.g. `en-US` (default: `en-US`)
-- `model` — restrict to one model, e.g. `AslCore`
+- `model` — restrict to one model, e.g. `MyModel`
 - `labelFileId` — restrict to one label file ID
 - `limit` — max results (default: 30)
 
 **Examples:**
 ```
 Find a label for the text "customer account"
-Search for labels about "batch" in the AslCore model
+Search for labels about "batch" in the MyModel model
 Find labels matching "vendor" in English
 ```
 
@@ -400,8 +400,8 @@ code snippets.
 
 **Examples:**
 ```
-What label files does the AslCore model have?
-Show me all translations of label ACFeature in AslCore
+What label files does the MyModel model have?
+Show me all translations of label MyFeature in MyModel
 Show me the X++ snippet for label BatchGroup
 ```
 
@@ -418,8 +418,8 @@ is immediately searchable.
 
 **Parameters:**
 - `labelId` — new label ID, e.g. `MyNewField` (required)
-- `labelFileId` — target label file, e.g. `AslCore` (required)
-- `model` — model name, e.g. `AslCore` (required)
+- `labelFileId` — target label file, e.g. `MyModel` (required)
+- `model` — model name, e.g. `MyModel` (required)
 - `translations` — array of `{ language, text }` objects (required); provide all supported
   languages
 - `defaultComment` — developer comment added to each translation
@@ -429,12 +429,12 @@ is immediately searchable.
 - `updateIndex` — immediately update the MCP index (default: `true`)
 
 **Label reference syntax after creation:**
-- In X++ code: `literalStr("@AslCore:MyNewField")`
-- In metadata XML: `<Label>@AslCore:MyNewField</Label>`
+- In X++ code: `literalStr("@MyModel:MyNewField")`
+- In metadata XML: `<Label>@MyModel:MyNewField</Label>`
 
 **Examples:**
 ```
-Create label MyNewField in the AslCore model with translations for en-US, cs, de, and sk
+Create label MyNewField in the MyModel model with translations for en-US, cs, de, and sk
 Add a new label CustomerAccountNumber with English text "Customer account number"
 ```
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -223,7 +223,7 @@ Create a variable group named `xpp-mcp-server-config` in Azure DevOps with these
 |----------|--------|--------------|
 | `AZURE_STORAGE_CONNECTION_STRING` | ✅ Yes | Connection string from Azure Portal |
 | `BLOB_CONTAINER_NAME` | No | `xpp-metadata` |
-| `CUSTOM_MODELS` | No | `AslCore,AslFinance` |
+| `CUSTOM_MODELS` | No | `MyModel,MyFinance` |
 | `AZURE_SUBSCRIPTION` | No | Name of your Azure service connection |
 | `AZURE_APP_SERVICE_NAME` | No | `xpp-mcp-server` |
 

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -36,7 +36,7 @@ Runs three searches in parallel and combines the results.
 ```
 Find my custom extensions for CustTable
 Show me all ISV_ helper classes
-Find classes in the AslCore model
+Find classes in the MyModel model
 ```
 
 ### Find a method across all classes
@@ -160,7 +160,7 @@ Create a table extension for InventTable with a custom field VendorCategory
 
 ### Generate XML only (Azure/cloud server)
 ```
-Generate the XML for a class MyHelper in the AslCore model
+Generate the XML for a class MyHelper in the MyModel model
 ```
 
 Returns the XML content. Copilot then creates the file in your workspace.
@@ -296,7 +296,7 @@ in Visual Studio. See [WORKSPACE_DETECTION.md](WORKSPACE_DETECTION.md).
 Always search first — reusing an existing label avoids duplication and saves translation effort.
 
 ```
-Find a label for the text "customer account" in AslCore
+Find a label for the text "customer account" in MyModel
 ```
 
 Copilot will:
@@ -305,28 +305,28 @@ Copilot will:
 3. Show the label text and a ready-to-use X++ snippet
 
 ```
-Search for labels about "invoice" in the AslCore model
+Search for labels about "invoice" in the MyModel model
 Find all labels matching "vendor" in English
 ```
 
 ### View all translations for a label
 
 ```
-Show me all translations of label ACFeature in AslCore
+Show me all translations of label MyFeature in MyModel
 ```
 
 Copilot will:
 1. Call `get_label_info` with the label ID
 2. Return translations in every indexed language (en-US, cs, de, sk…)
 3. Show the developer comment and generate X++ / XML usage snippets:
-   - X++: `literalStr("@AslCore:ACFeature")`
-   - XML: `<Label>@AslCore:ACFeature</Label>`
+   - X++: `literalStr("@MyModel:MyFeature")`
+   - XML: `<Label>@MyModel:MyFeature</Label>`
 
 ### List all label files in a model
 
 ```
-What label files does the AslCore model have?
-List all AxLabelFile IDs available in AslCore
+What label files does the MyModel model have?
+List all AxLabelFile IDs available in MyModel
 ```
 
 Copilot will call `get_label_info` without a label ID and return a table of
@@ -335,7 +335,7 @@ file IDs, supported languages, and label counts.
 ### Create a new label with all language translations
 
 ```
-Create a new label MyNewField in the AslCore model with the text:
+Create a new label MyNewField in the MyModel model with the text:
 - en-US: "Customer account number"
 - cs: "Číslo účtu zákazníka"
 - de: "Kundenkontaktsnummer"
@@ -347,32 +347,32 @@ Copilot will:
 2. Call `create_label` with the translations for all supported languages
 3. Insert the label alphabetically into every `.label.txt` file
 4. Update the MCP index so the new label is immediately searchable
-5. Return the ready-to-use reference: `@AslCore:MyNewField`
+5. Return the ready-to-use reference: `@MyModel:MyNewField`
 
 ### Use a label in X++ code and metadata
 
 After searching for or creating a label:
 
 ```
-How do I use label @AslCore:MyNewField in X++ code?
-Generate the metadata XML property for @AslCore:MyNewField
+How do I use label @MyModel:MyNewField in X++ code?
+Generate the metadata XML property for @MyModel:MyNewField
 ```
 
 In X++ source code:
 ```xpp
-str labelText = literalStr("@AslCore:MyNewField");
+str labelText = literalStr("@MyModel:MyNewField");
 ```
 
 In metadata XML (field property):
 ```xml
-<Label>@AslCore:MyNewField</Label>
-<HelpText>@AslCore:MyNewFieldHelp</HelpText>
+<Label>@MyModel:MyNewField</Label>
+<HelpText>@MyModel:MyNewFieldHelp</HelpText>
 ```
 
 ### Check a label in a specific language
 
 ```
-Find the Czech translation of label BatchGroup in AslCore
+Find the Czech translation of label BatchGroup in MyModel
 Search for labels containing "dávk" in Czech (cs) language
 ```
 

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -79,7 +79,7 @@ async function buildDatabase() {
         .filter(e => e.isDirectory())
         .map(e => e.name);
       
-      // Expand patterns (e.g., "Asl*" → ["AslCore", "AslFinanceCore", ...])
+      // Expand patterns (e.g., "My*" → ["MyModel", "MyFinanceCore", ...])
       const expandedModels: string[] = [];
       for (const pattern of CUSTOM_MODELS) {
         if (pattern.includes('*')) {

--- a/src/metadata/labelParser.ts
+++ b/src/metadata/labelParser.ts
@@ -83,7 +83,7 @@ export function parseLabelFile(
  * Returns an array of { labelFileId, language, filePath }.
  */
 export async function discoverLabelFiles(
-  modelDir: string,  // e.g. K:\AosService\PackagesLocalDirectory\AslCore\AslCore
+  modelDir: string,  // e.g. K:\AosService\PackagesLocalDirectory\MyPackage\MyModel
   verbose: boolean = false,
 ): Promise<Array<{ labelFileId: string; language: string; filePath: string }>> {
   const results: Array<{ labelFileId: string; language: string; filePath: string }> = [];
@@ -163,7 +163,7 @@ export async function discoverLabelFiles(
     for (const file of files) {
       if (!file.endsWith('.label.txt')) continue;
       // Filename pattern: {LabelFileId}.{locale}.label.txt
-      // e.g. AslCore.en-US.label.txt or aslcore.en-us.label.txt (Linux)
+      // e.g. MyModel.en-US.label.txt or mymodel.en-us.label.txt (Linux)
       const withoutSuffix = file.replace(/\.label\.txt$/, '');
       const dotIdx = withoutSuffix.lastIndexOf('.');
       if (dotIdx < 0) continue;

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -946,8 +946,8 @@ Use WHEN:
 - Searching for labels by keyword (e.g. "customer", "batch", "error")
 
 Examples:
-- search_labels("batch group") → finds ACFeature, BatchGroup, etc.
-- search_labels("ACFeature", model="AslCore") → labels in custom AslCore model
+- search_labels("batch group") → finds MyFeature, BatchGroup, etc.
+- search_labels("MyFeature", model="MyModel") → labels in custom MyModel model
 - search_labels("feature", language="cs") → Czech translations`,
           inputSchema: {
             type: 'object',
@@ -962,11 +962,11 @@ Examples:
               },
               model: {
                 type: 'string',
-                description: 'Restrict to a specific model (e.g. AslCore, ApplicationPlatform)',
+                description: 'Restrict to a specific model (e.g. MyModel, ApplicationPlatform)',
               },
               labelFileId: {
                 type: 'string',
-                description: 'Restrict to a specific label file ID (e.g. AslCore, SYS)',
+                description: 'Restrict to a specific label file ID (e.g. MyModel, SYS)',
               },
               limit: {
                 type: 'number',
@@ -992,23 +992,23 @@ Use WHEN:
 - Listing which label files exist in a custom model (omit labelId)
 
 Examples:
-- get_label_info("ACFeature", model="AslCore") → all translations
-- get_label_info(model="AslCore") → list label files in AslCore
+- get_label_info("MyFeature", model="MyModel") → all translations
+- get_label_info(model="MyModel") → list label files in MyModel
 - get_label_info("BatchGroup") → all languages for BatchGroup`,
           inputSchema: {
             type: 'object',
             properties: {
               labelId: {
                 type: 'string',
-                description: 'Exact label ID (e.g. ACFeature). Omit to list available label files.',
+                description: 'Exact label ID (e.g. MyFeature). Omit to list available label files.',
               },
               labelFileId: {
                 type: 'string',
-                description: 'Label file ID (e.g. AslCore, SYS)',
+                description: 'Label file ID (e.g. MyModel, SYS)',
               },
               model: {
                 type: 'string',
-                description: 'Model to filter by (e.g. AslCore)',
+                description: 'Model to filter by (e.g. MyModel)',
               },
             },
             required: [],
@@ -1030,7 +1030,7 @@ Process:
 5. Updates the SQLite label index
 
 Examples:
-- create_label("MyNewField", "AslCore", "AslCore", [{language:"en-US", text:"My new field"}, {language:"cs", text:"Moje nové pole"}])
+- create_label("MyNewField", "MyModel", "MyModel", [{language:"en-US", text:"My new field"}, {language:"cs", text:"Moje nové pole"}])
 - create_label with createLabelFileIfMissing=true → creates AxLabelFile structure from scratch`,
           inputSchema: {
             type: 'object',
@@ -1041,11 +1041,11 @@ Examples:
               },
               labelFileId: {
                 type: 'string',
-                description: 'Label file ID (e.g. AslCore)',
+                description: 'Label file ID (e.g. MyModel)',
               },
               model: {
                 type: 'string',
-                description: 'Model name that owns the label file (e.g. AslCore)',
+                description: 'Model name that owns the label file (e.g. MyModel)',
               },
               packageName: {
                 type: 'string',

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -17,7 +17,7 @@ const CodeGenArgsSchema = z.object({
     'For EXTENSIONS (table-extension, form-handler): the BASE element name to extend (e.g. "CustTable", "SalesTable").'
   ),
   modelName: z.string().optional().describe(
-    'Model/solution prefix used to derive the naming infix when EXTENSION_PREFIX is not set (e.g. "AslCore"). ' +
+    'Model/solution prefix used to derive the naming infix when EXTENSION_PREFIX is not set (e.g. "MyModel"). ' +
     'Required for extension patterns when EXTENSION_PREFIX is not configured.'
   ),
 });

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -958,7 +958,7 @@ export async function handleCreateD365File(
     }
 
     // Generate (or use provided) XML content
-    const xmlContent = args.xmlContent
+    let xmlContent = args.xmlContent
       ? args.xmlContent
       : XmlTemplateGenerator.generate(
           args.objectType,
@@ -966,6 +966,28 @@ export async function handleCreateD365File(
           args.sourceCode,
           args.properties
         );
+
+    // CRITICAL FIX: Replace unprefixed class/table names with prefixed finalObjectName
+    // When xmlContent or sourceCode contains `class MyClass` but finalObjectName is `MyPrefixMyClass`,
+    // the file would be named MyPrefixMyClass.xml but contain `class MyClass` — inconsistency!
+    if (finalObjectName !== args.objectName && (args.xmlContent || args.sourceCode)) {
+      // Pattern to match: `class OriginalName` or `public class OriginalName`
+      const classPattern = new RegExp(
+        `\\b(public\\s+|private\\s+|protected\\s+|internal\\s+|final\\s+)?class\\s+${args.objectName}\\b`,
+        'g'
+      );
+      const replacedContent = xmlContent.replace(classPattern, (match) => {
+        return match.replace(args.objectName, finalObjectName);
+      });
+      
+      if (replacedContent !== xmlContent) {
+        console.error(
+          `[create_d365fo_file] ✅ Fixed class name inconsistency: ` +
+          `replaced \`class ${args.objectName}\` with \`class ${finalObjectName}\` in XML content`
+        );
+        xmlContent = replacedContent;
+      }
+    }
 
     // Debug: Log XML content length
     const xmlSource = args.xmlContent ? 'provided by caller' : 'generated from template';

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -21,6 +21,9 @@ import * as path from 'path';
 import { getConfigManager } from '../utils/configManager.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 
+// UTF-8 BOM (Byte Order Mark)
+const UTF8_BOM = '\uFEFF';
+
 // ── Input schema ─────────────────────────────────────────────────────────────
 
 const TranslationSchema = z.object({
@@ -34,14 +37,14 @@ const CreateLabelArgsSchema = z.object({
     .string()
     .regex(/^[A-Za-z][A-Za-z0-9_]*$/, 'Label ID must be alphanumeric (no spaces)')
     .describe(
-      'Label identifier — must be unique within the label file, e.g. MyNewField or AslMyFeature',
+      'Label identifier — must be unique within the label file, e.g. MyNewField or MyFeature',
     ),
   labelFileId: z
     .string()
-    .describe('Label file ID to add the label to (e.g. AslCore). Must exist in the model.'),
+    .describe('Label file ID to add the label to (e.g. MyModel). Must exist in the model.'),
   model: z
     .string()
-    .describe('Model name that owns the label file (e.g. AslCore, MyExtensions)'),
+    .describe('Model name that owns the label file (e.g. MyModel, MyExtensions)'),
   packageName: z
     .string()
     .optional()
@@ -109,7 +112,7 @@ function parseLabelMap(content: string): Map<string, { text: string; comment?: s
   return map;
 }
 
-/** Render a label map back to .label.txt content (alphabetically sorted) */
+/** Render a label map back to .label.txt content (alphabetically sorted) with UTF-8 BOM */
 function serializeLabelMap(map: Map<string, { text: string; comment?: string }>): string {
   const sorted = [...map.entries()].sort(([a], [b]) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
   const lines: string[] = [];
@@ -117,8 +120,15 @@ function serializeLabelMap(map: Map<string, { text: string; comment?: string }>)
     lines.push(`${id}=${text}`);
     if (comment) lines.push(` ;${comment}`);
   }
-  // End with a newline
-  return lines.join('\n') + '\n';
+  // End with a newline, prepend UTF-8 BOM for D365FO compatibility
+  return UTF8_BOM + lines.join('\n') + '\n';
+}
+
+/** Write file with UTF-8 BOM signature */
+async function writeFileWithBom(filePath: string, content: string): Promise<void> {
+  // Ensure content starts with BOM
+  const contentWithBom = content.startsWith(UTF8_BOM) ? content : UTF8_BOM + content;
+  await fs.writeFile(filePath, contentWithBom, 'utf-8');
 }
 
 /** XML descriptor content for a new AxLabelFile locale */
@@ -233,9 +243,9 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
         const langDir = path.join(labelResourcesDir, lang);
         await fs.mkdir(langDir, { recursive: true });
 
-        // Create the empty .label.txt (will be written below)
+        // Create the empty .label.txt with UTF-8 BOM (will be written below)
         const txtPath = path.join(langDir, `${labelFileId}.${lang}.label.txt`);
-        try { await fs.access(txtPath); } catch { await fs.writeFile(txtPath, '', 'utf-8'); }
+        try { await fs.access(txtPath); } catch { await writeFileWithBom(txtPath, ''); }
 
         // Create XML descriptor
         const xmlPath = path.join(axLabelDir, `${labelFileId}_${lang}.xml`);
@@ -278,9 +288,9 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       // Ensure the directory exists
       await fs.mkdir(langDir, { recursive: true });
 
-      // Write updated file
+      // Write updated file with UTF-8 BOM
       const newContent = serializeLabelMap(labelMap);
-      await fs.writeFile(txtPath, newContent, 'utf-8');
+      await writeFileWithBom(txtPath, newContent);
       written.push(lang);
 
       // Prepare index update
@@ -373,11 +383,11 @@ export const createLabelToolDefinition = {
       },
       labelFileId: {
         type: 'string',
-        description: 'Label file ID that the label belongs to (e.g. AslCore)',
+        description: 'Label file ID that the label belongs to (e.g. MyModel)',
       },
       model: {
         type: 'string',
-        description: 'Model name (e.g. AslCore, MyExtensions)',
+        description: 'Model name (e.g. MyModel, MyExtensions)',
       },
       translations: {
         type: 'array',

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -295,7 +295,7 @@ export async function handleGenerateSmartForm(
     console.log(`[generateSmartForm] Non-Windows environment — returning XML as text (no file write)`);
     const noModelNote = resolvedModel
       ? ''
-      : `\n> ⚠️  No model resolved — XML generated without prefix. Pass \`modelName\` (e.g. \`"AslCore"\`) for correct object naming.`;
+      : `\n> ⚠️  No model resolved — XML generated without prefix. Pass \`modelName\` (e.g. \`"MyModel"\`) for correct object naming.`;
     const nextStep = [
       ``,
       `**✅ MANDATORY NEXT STEP — immediately call \`create_d365fo_file\` with the XML below:**`,

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -363,7 +363,7 @@ export async function handleGenerateSmartTable(
   if (!resolvedModel) {
     if (isNonWindows) {
       // Azure/Linux: model resolution requires .rnrproj which is only on the Windows VM.
-      // Use modelName arg as-is for prefix resolution (caller may pass e.g. "AslCore").
+      // Use modelName arg as-is for prefix resolution (caller may pass e.g. "MyModel").
       // If not provided either, generate XML without prefix and return it as text.
       // Fallback priority: modelName arg → modelName/workspacePath (mcp.json) → D365FO_MODEL_NAME env var → no prefix
       const configModel = configManager.getModelName();
@@ -491,7 +491,7 @@ export async function handleGenerateSmartTable(
   if (isNonWindows) {
     const noModelNote = resolvedModel
       ? ''
-      : `\n> ⚠️  No model resolved — XML generated without prefix. Pass \`modelName\` (e.g. \`"AslCore"\`) for correct object naming.\n> 🚨 **IMPORTANT**: Do NOT add a prefix to the \`name\` parameter when calling this tool — the tool applies the prefix automatically from \`modelName\`. If you pass e.g. \`name="AslAccountTable"\`, the result will be double-prefixed as \`"AslAslAccountTable"\`.`;
+      : `\n> ⚠️  No model resolved — XML generated without prefix. Pass \`modelName\` (e.g. \`"MyModel"\`) for correct object naming.\n> 🚨 **IMPORTANT**: Do NOT add a prefix to the \`name\` parameter when calling this tool — the tool applies the prefix automatically from \`modelName\`. If you pass e.g. \`name="MyAccountTable"\`, the result will be double-prefixed as \`"MyMyAccountTable"\`.`;
     const nextStep = [
       ``,
       `**✅ MANDATORY NEXT STEP — immediately call \`create_d365fo_file\` with the XML below:**`,

--- a/src/tools/getLabelInfo.ts
+++ b/src/tools/getLabelInfo.ts
@@ -13,14 +13,14 @@ const GetLabelInfoArgsSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Exact label ID to look up (e.g. ACFeature, BatchGroup). ' +
+      'Exact label ID to look up (e.g. MyFeature, BatchGroup). ' +
         'Omit to list available label files for the model instead.',
     ),
   labelFileId: z
     .string()
     .optional()
-    .describe('Label file ID (e.g. AslCore, SYS, ApplicationPlatform)'),
-  model: z.string().optional().describe('Model to filter by (e.g. AslCore)'),
+    .describe('Label file ID (e.g. MyModel, SYS, ApplicationPlatform)'),
+  model: z.string().optional().describe('Model to filter by (e.g. MyModel)'),
 });
 
 export async function getLabelInfoTool(request: CallToolRequest, context: XppServerContext) {
@@ -137,15 +137,15 @@ export const getLabelInfoToolDefinition = {
       labelId: {
         type: 'string',
         description:
-          'Exact label ID (e.g. ACFeature). Omit to list available label files.',
+          'Exact label ID (e.g. MyFeature). Omit to list available label files.',
       },
       labelFileId: {
         type: 'string',
-        description: 'Label file ID (e.g. AslCore, SYS)',
+        description: 'Label file ID (e.g. MyModel, SYS)',
       },
       model: {
         type: 'string',
-        description: 'Model to filter by (e.g. AslCore)',
+        description: 'Model to filter by (e.g. MyModel)',
       },
     },
     required: [],

--- a/src/tools/searchLabels.ts
+++ b/src/tools/searchLabels.ts
@@ -17,7 +17,7 @@ const SearchLabelsArgsSchema = z.object({
   query: z
     .string()
     .describe(
-      'Search text — searches label ID, label text and comments (e.g. "customer name", "ACFeature", "batch")',
+      'Search text — searches label ID, label text and comments (e.g. "customer name", "MyFeature", "batch")',
     ),
   language: z
     .string()
@@ -27,11 +27,11 @@ const SearchLabelsArgsSchema = z.object({
   model: z
     .string()
     .optional()
-    .describe('Restrict results to a specific model (e.g. AslCore, ApplicationPlatform)'),
+    .describe('Restrict results to a specific model (e.g. MyModel, ApplicationPlatform)'),
   labelFileId: z
     .string()
     .optional()
-    .describe('Restrict results to a specific label file ID (e.g. AslCore, SYS)'),
+    .describe('Restrict results to a specific label file ID (e.g. MyModel, SYS)'),
   limit: z.number().optional().default(30).describe('Maximum number of results (default 30)'),
 });
 
@@ -124,11 +124,11 @@ export const searchLabelsToolDefinition = {
       },
       model: {
         type: 'string',
-        description: 'Restrict to a specific model (e.g. AslCore)',
+        description: 'Restrict to a specific model (e.g. MyModel)',
       },
       labelFileId: {
         type: 'string',
-        description: 'Restrict to a specific label file ID (e.g. AslCore, SYS)',
+        description: 'Restrict to a specific label file ID (e.g. MyModel, SYS)',
       },
       limit: {
         type: 'number',

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -235,7 +235,7 @@ class ConfigManager {
       const normalized = path.normalize(context.workspacePath);
       
       // If workspacePath points to a specific model, extract base path
-      // Example: K:\AOSService\PackagesLocalDirectory\AslCore
+      // Example: K:\AOSService\PackagesLocalDirectory\MyPackage
       // Should return: K:\AOSService\PackagesLocalDirectory
       const match = normalized.match(/^(.+[\\\/]PackagesLocalDirectory)(?:[\\\/]|$)/i);
       if (match) {
@@ -264,7 +264,7 @@ class ConfigManager {
 
   /**
    * Get model name from the last segment of workspacePath.
-   * workspacePath like K:\AOSService\PackagesLocalDirectory\AslCore → "AslCore"
+   * workspacePath like K:\AOSService\PackagesLocalDirectory\MyPackage → "MyPackage"
    * This allows automatic model detection on non-Windows (Azure) without D365FO_MODEL_NAME env var.
    * Note: package name usually equals model name, but not always.
    */

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -74,7 +74,7 @@ export function resolveObjectPrefix(modelName: string): string {
 /**
  * Apply prefix to a NEW model element name.
  * Per MS guidelines, the prefix is concatenated directly (no separator):
- *   WHSMyTable, ASLMyClass, ContosoMyForm
+ *   WHSMyTable, MyPrefixMyClass, ContosoMyForm
  *
  * Case-insensitive check prevents double-prefixing.
  */

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -160,7 +160,7 @@ export async function autoDetectD365Project(
   }
 
   // Priority 4: Extract model name directly from a PackagesLocalDirectory path
-  // e.g. K:\AOSService\PackagesLocalDirectory\AslEnhancedDataSharing → modelName: "AslEnhancedDataSharing"
+  // e.g. K:\AOSService\PackagesLocalDirectory\MyEnhancedDataSharing → modelName: "MyEnhancedDataSharing"
   if (explicitWorkspacePath) {
     const normalized = path.normalize(explicitWorkspacePath);
 


### PR DESCRIPTION
- Remove rule #13 about SRSReportDataContractBase (documentation file deleted)
- Replace all 'AslCore' references with 'MyModel' (models) and 'MyPackage' (packages)
- Replace all 'ACFeature' label examples with 'MyFeature'
- Replace 'AslMyClass' examples with 'MyPrefixMyClass' for clarity
- Update copilot instructions, documentation, and code comments
- Ensure public documentation uses generic examples instead of internal product names

Total changes: 19 files modified
Build status:  Passing (npm run build)