### PR TITLE
fix: modifyD365File filesystem fallback, addToProject in smart genera…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,13 +74,23 @@ User: "Review the SalesTableType class and check if it follows best practices"
    - Optional: call `generate_d365fo_xml()` first to get XML content, then pass it to `create_d365fo_file()`
    - `create_file` will corrupt D365FO metadata and break project integration
 
-6. **When `generate_smart_table` or `generate_smart_form` returns XML as text — this is SUCCESS, not a failure**
-   - The message `ℹ️ MCP server is running on Azure/Linux — file writing is handled by the local Windows companion` means the tool completed correctly
+6. **`generate_smart_table` / `generate_smart_form` — TWO possible success responses, different required actions**
+
+   **Case A — Azure/Linux response** (contains `ℹ️ MCP server is running on Azure/Linux`):
+   - The tool generated XML but could not write it to disk (no K:\ drive)
    - The **ONLY correct next action** is `create_d365fo_file(objectType=..., objectName=..., xmlContent="<full XML>", addToProject=true)`
-   - ⛔ NEVER try `modify_d365fo_file` as an intermediate or compensating step
-   - ⛔ NEVER fall back to `create_file`, PowerShell scripts, or any built-in file tool
-   - ⛔ NEVER tell the user "the file was not processed correctly" — the XML was generated correctly; only the file write step is pending
-   - The flow is always: `generate_smart_table` → XML text → `create_d365fo_file(xmlContent=...)` — no other alternative exists
+   - ⛔ NEVER try `modify_d365fo_file`, `create_file`, or PowerShell scripts
+   - The flow: `generate_smart_table` → XML text → `create_d365fo_file(xmlContent=...)` → **STOP**
+
+   **Case B — Windows direct-write response** (contains `⛔ DO NOT call create_d365fo_file`):
+   - The tool wrote the file **directly to disk** — the task is already complete
+   - ⛔ **DO NOT call `create_d365fo_file`** — it would overwrite the file unnecessarily
+   - ⛔ **DO NOT call `generate_smart_table` again** — the file exists
+   - Inform the user of the file path and tell them to reload the VS project — **STOP**
+
+   **How to tell them apart:**
+   - Azure/Linux → response contains the XML block and "MANDATORY NEXT STEP"
+   - Windows direct → response contains "DO NOT call `create_d365fo_file`" and a file path
 
 7. **Use specific tools for specific object types**
    - For forms: use `get_form_info()`, not `search(type="form")`
@@ -396,9 +406,7 @@ Step 1: generate_smart_table(
           generateCommonFields=true,
           methods=["find","exist"]    ← embed methods in XML — do NOT call modify_d365fo_file afterwards
         )
-     → Returns "✅ Table XML generated" with ℹ️ Azure/Linux note — this is SUCCESS
-     → The tool response contains MANDATORY NEXT STEP instructions
-     → XML is included in the response
+     → Returns "ℹ️ MCP server is running on Azure/Linux" + XML block + MANDATORY NEXT STEP
 
 Step 2: create_d365fo_file(           ← IMMEDIATELY after step 1, no intermediate steps
           objectType="table",
@@ -408,14 +416,32 @@ Step 2: create_d365fo_file(           ← IMMEDIATELY after step 1, no intermedi
         )
      → Writes file to K:\AosService\PackagesLocalDirectory\MyPackage\MyModel\AxTable\...
      → Adds entry to .rnrproj for VS2022
+     → Returns "TASK COMPLETE" — STOP here, do NOT call generate_smart_table again
 
 ⛔ FORBIDDEN alternatives when generate_smart_table returns XML text:
    - create_file()                  ← NEVER — corrupts D365FO metadata
    - PowerShell / shell scripts     ← NEVER — bypasses AOT structure
    - modify_d365fo_file()           ← NEVER — not a substitute for create_d365fo_file
-   - Telling user to save manually  ← never needed; create_d365fo_file handles it
+   - Calling generate_smart_table again after create_d365fo_file succeeds ← LOOP!
+```
 
-Same pattern applies for generate_smart_form + create_d365fo_file(objectType="form", ...).
+**Workflow for Windows-only (full mode, single server):**
+```
+Step 1: generate_smart_table(
+          name="MyOrderTable",
+          fieldsHint="OrderId, CustomerAccount, OrderAmount, OrderDate",
+          primaryKeyFields=["OrderId"],
+          methods=["find","exist"]
+        )
+     → Returns "✅ Table created directly on the Windows VM" + file path
+     → File is ALREADY written to K:\...\AxTable\MyOrderTable.xml
+
+⛔ STOP — do NOT call create_d365fo_file (file already exists)
+⛔ STOP — do NOT call generate_smart_table again
+→ Tell the user: file path + "reload the VS project and build"
+```
+
+Same patterns apply for generate_smart_form.
 ```
 
 
@@ -541,6 +567,8 @@ K:\AosService\PackagesLocalDirectory\{Model}\{Model}\AxView\{Name}.xml
 - **Never call `modify_d365fo_file` after `generate_smart_table` to add methods** — use the `methods` parameter instead; `modify_d365fo_file` fails on Azure/Linux (read-only mode)
 - **🚨 NEVER use `create_file` or PowerShell as a fallback when `generate_smart_table`/`generate_smart_form` returns XML as text** — the `ℹ️ Azure/Linux` message in the response means "pass this XML to `create_d365fo_file(xmlContent=...)`", not "the tool failed". There is NO other acceptable approach.
 - **NEVER interpret `generate_smart_table`/`generate_smart_form` returning XML as a partial failure** — it is a complete success; `create_d365fo_file(xmlContent=...)` is the mandatory and only next step
+- **🚨 NEVER call `create_d365fo_file` when `generate_smart_table`/`generate_smart_form` response contains `⛔ DO NOT call create_d365fo_file`** — the file was written directly on Windows; calling `create_d365fo_file` creates a loop
+- **🚨 NEVER call `generate_smart_table` or `generate_smart_form` again after a success response** — once either tool reports success (regardless of Windows or Azure path), the task is COMPLETE; calling them again creates duplicates
 
 ## Why MCP Tools Are Required
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,33 +219,33 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.28.2.tgz",
-      "integrity": "sha512-6vYUMvs6kJxJgxaCmHn/F8VxjLHNh7i9wzfwPGf8kyBJ8Gg2yvBXx175Uev8LdrD1F5C4o7qHa2CC4IrhGE1XQ==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.29.0.tgz",
+      "integrity": "sha512-/f3eHkSNUTl6DLQHm+bKecjBKcRQxbd/XLx8lvSYp8Nl/HRyPuIPOijt9Dt0sH50/SxOwQ62RnFCmFlGK+bR/w==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.14.2"
+        "@azure/msal-common": "15.15.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.14.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.14.2.tgz",
-      "integrity": "sha512-n8RBJEUmd5QotoqbZfd+eGBkzuFI1KX6jw2b3WcpSyGjwmzoeI/Jb99opIBPHpb8y312NB+B6+FGi2ZVSR8yfA==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.15.0.tgz",
+      "integrity": "sha512-/n+bN0AKlVa+AOcETkJSKj38+bvFs78BaP4rNtv3MJCmPH0YrHiskMRe74OhyZ5DZjGISlFyxqvf9/4QVEi2tw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.7.tgz",
-      "integrity": "sha512-a+Xnrae+uwLnlw68bplS1X4kuJ9F/7K6afuMFyRkNIskhjgDezl5Fhrx+1pmAlDmC0VaaAxjRQMp1OmcqVwkIg==",
+      "version": "3.8.8",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.8.tgz",
+      "integrity": "sha512-+f1VrJH1iI517t4zgmuhqORja0bL6LDQXfBqkjuMmfTYXTQQnh1EvwwxO3UbKLT05N0obF72SRHFrC1RBDv5Gg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.14.2",
+        "@azure/msal-common": "15.15.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.0.tgz",
-      "integrity": "sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -924,9 +924,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -938,9 +938,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -952,9 +952,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -966,9 +966,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -980,9 +980,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -994,9 +994,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -1008,9 +1008,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -1022,9 +1022,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -1036,9 +1036,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -1050,9 +1050,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -1064,9 +1064,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -1078,9 +1078,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
@@ -1092,9 +1092,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -1106,9 +1106,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -1120,9 +1120,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -1134,9 +1134,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -1148,9 +1148,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -1162,9 +1162,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -1176,9 +1176,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -1190,9 +1190,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -1204,9 +1204,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -1218,9 +1218,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -1232,9 +1232,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -1246,9 +1246,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -2777,9 +2777,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
+      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3290,9 +3290,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -3564,6 +3564,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -3718,9 +3719,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3734,31 +3735,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -422,7 +422,7 @@ ${dataSourceXml}\t\t<Pattern xmlns="">${pattern}</Pattern>
 /**
  * Visual Studio Project (.rnrproj) Manipulator
  */
-class ProjectFileManager {
+export class ProjectFileManager {
   private parser: Parser;
   private builder: Builder;
 
@@ -1175,7 +1175,7 @@ export async function handleCreateD365File(
             `🔧 Type: ${objectFolder}\n` +
             projectMessage +
             `\n${nextSteps}\n` +
-            `File content preview:\n\`\`\`xml\n${xmlContent.substring(0, 500)}...\n\`\`\``,
+            `⛔ TASK COMPLETE — do NOT call \`generate_smart_table\`, \`generate_smart_form\`, or \`create_d365fo_file\` again for this object.`,
         },
       ],
     };

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import fs from 'fs';
 import { getConfigManager } from '../utils/configManager.js';
 import { resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
+import { ProjectFileManager } from './createD365File.js';
 
 interface GenerateSmartFormArgs {
   name: string;
@@ -251,22 +252,31 @@ export async function handleGenerateSmartForm(
 
   if (!resolvedModel) {
     if (isNonWindows) {
-      // Fallback priority: modelName arg → modelName/workspacePath (mcp.json) → D365FO_MODEL_NAME env var → no prefix
+      // Both Windows and Azure/Linux: .rnrproj extraction failed (or wasn't attempted).
+      // Fall back in this order:
+      //   1. .mcp.json context (modelName field or last segment of workspacePath)
+      //   2. Auto-detected model name (async) — e.g. from PackagesLocalDirectory regex / well-known paths
+      //   3. D365FO_MODEL_NAME env var
+      //   4. modelName arg — LAST because the AI often passes a placeholder like "any" or "whatever"
       const configModel = configManager.getModelName();
-      resolvedModel = modelName || configModel || process.env.D365FO_MODEL_NAME || undefined;
+      const autoModel = configModel ? null : (await configManager.getAutoDetectedModelName());
+      resolvedModel = configModel || autoModel || process.env.D365FO_MODEL_NAME || modelName || undefined;
       if (resolvedModel) {
         const ctx = configManager.getContext();
-        const source = modelName ? 'modelName arg'
-          : ctx?.modelName ? 'modelName (mcp.json)'
-          : configModel === resolvedModel ? 'workspacePath (mcp.json)'
-          : 'D365FO_MODEL_NAME env var';
+        const source = configModel === resolvedModel
+          ? (ctx?.modelName ? 'modelName (mcp.json)' : 'workspacePath (mcp.json)')
+          : autoModel === resolvedModel ? 'auto-detected (well-known paths)'
+          : process.env.D365FO_MODEL_NAME === resolvedModel ? 'D365FO_MODEL_NAME env var'
+          : 'modelName arg (fallback)';
         console.log(`[generateSmartForm] Using model from ${source}: ${resolvedModel}`);
+      } else if (!isNonWindows) {
+        // Windows VM: all sources exhausted — tell the user exactly what to configure.
+        throw new Error(
+          'Could not resolve model name. Provide modelName, projectPath, or solutionPath, ' +
+          'or configure projectPath/solutionPath in .mcp.json or set D365FO_MODEL_NAME env var.'
+        );
       }
-    } else {
-      throw new Error(
-        'Could not resolve model name. Provide modelName, projectPath, or solutionPath, ' +
-        'or configure projectPath/solutionPath in .mcp.json or set D365FO_MODEL_NAME env var.'
-      );
+      // Non-Windows: if still null we continue without a prefix.
     }
   }
 
@@ -353,19 +363,53 @@ export async function handleGenerateSmartForm(
   fs.writeFileSync(normalizedPath, xml, 'utf-8');
   console.log(`[generateSmartForm] Created file: ${normalizedPath}`);
 
+  // Add to Visual Studio project if a projectPath is known
+  let projectMessage = '';
+  const effectiveProjectPath = resolvedProjectPath ||
+    (await getConfigManager().getProjectPath()) ||
+    undefined;
+
+  if (effectiveProjectPath) {
+    try {
+      const projectManager = new ProjectFileManager();
+      const wasAdded = await projectManager.addToProject(
+        effectiveProjectPath,
+        'form',
+        finalName,
+        normalizedPath
+      );
+      projectMessage = wasAdded
+        ? `\n✅ Added to Visual Studio project:\n📋 Project: ${effectiveProjectPath}`
+        : `\n✅ Already in Visual Studio project:\n📋 Project: ${effectiveProjectPath}`;
+      console.log(`[generateSmartForm] addToProject result: ${wasAdded ? 'added' : 'already present'}`);
+    } catch (projErr) {
+      projectMessage = `\n⚠️ File created but could not be added to project: ${projErr instanceof Error ? projErr.message : String(projErr)}`;
+      console.error(`[generateSmartForm] addToProject error:`, projErr);
+    }
+  } else {
+    projectMessage = `\n⚠️ addToProject skipped — no projectPath found in .mcp.json or tool args.`;
+  }
+
   return {
     content: [
       {
         type: 'text',
-        text: JSON.stringify({
-          success: true,
-          formName: finalName,
-          filePath: normalizedPath,
-          dataSourcesGenerated: dataSources.length,
-          controlsGenerated: controls.length,
-          strategy: copyFrom ? 'copy' : dataSource ? 'datasource' : formPattern ? 'pattern' : 'default',
-          xml,
-        }, null, 2),
+        text: [
+          `✅ Form **${finalName}** created directly on the Windows VM.`,
+          ``,
+          `📁 File: ${normalizedPath}`,
+          `📦 Model: ${resolvedModel}`,
+          `📊 DataSources: ${dataSources.length}, Controls: ${controls.length}`,
+          projectMessage,
+          ``,
+          `⛔ DO NOT call \`create_d365fo_file\` — the file is already written to disk.`,
+          `⛔ DO NOT call \`generate_smart_form\` again — task is COMPLETE.`,
+          ``,
+          `Next steps for the user:`,
+          `1. Reload the project in Visual Studio (or close/reopen solution)`,
+          `2. Build the project to synchronize the form`,
+          `3. Refresh AOT to see the new object`,
+        ].join('\n'),
       },
     ],
   };

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import fs from 'fs';
 import { getConfigManager } from '../utils/configManager.js';
 import { resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
+import { ProjectFileManager } from './createD365File.js';
 
 interface GenerateSmartTableArgs {
   name: string;
@@ -361,27 +362,32 @@ export async function handleGenerateSmartTable(
   const isNonWindows = process.platform !== 'win32';
 
   if (!resolvedModel) {
-    if (isNonWindows) {
-      // Azure/Linux: model resolution requires .rnrproj which is only on the Windows VM.
-      // Use modelName arg as-is for prefix resolution (caller may pass e.g. "MyModel").
-      // If not provided either, generate XML without prefix and return it as text.
-      // Fallback priority: modelName arg → modelName/workspacePath (mcp.json) → D365FO_MODEL_NAME env var → no prefix
-      const configModel = configManager.getModelName();
-      resolvedModel = modelName || configModel || process.env.D365FO_MODEL_NAME || undefined;
-      if (resolvedModel) {
-        const ctx = configManager.getContext();
-        const source = modelName ? 'modelName arg'
-          : ctx?.modelName ? 'modelName (mcp.json)'
-          : configModel === resolvedModel ? 'workspacePath (mcp.json)'
-          : 'D365FO_MODEL_NAME env var';
-        console.log(`[generateSmartTable] Using model from ${source}: ${resolvedModel}`);
-      }
-    } else {
+    // Both Windows and Azure/Linux: .rnrproj extraction failed (or wasn't attempted).
+    // Fall back in this order:
+    //   1. .mcp.json context (modelName field or last segment of workspacePath) — user explicitly configured
+    //   2. Auto-detected model name (async) — e.g. from PackagesLocalDirectory regex in well-known paths scan
+    //   3. D365FO_MODEL_NAME env var
+    //   4. modelName arg — LAST because the AI often passes a placeholder like "any" or "whatever"
+    // Only throw when every source is exhausted.
+    const configModel = configManager.getModelName();
+    const autoModel = configModel ? null : (await configManager.getAutoDetectedModelName());
+    resolvedModel = configModel || autoModel || process.env.D365FO_MODEL_NAME || modelName || undefined;
+    if (resolvedModel) {
+      const ctx = configManager.getContext();
+      const source = configModel === resolvedModel
+        ? (ctx?.modelName ? 'modelName (mcp.json)' : 'workspacePath (mcp.json)')
+        : autoModel === resolvedModel ? 'auto-detected (well-known paths)'
+        : process.env.D365FO_MODEL_NAME === resolvedModel ? 'D365FO_MODEL_NAME env var'
+        : 'modelName arg (fallback)';
+      console.log(`[generateSmartTable] Using model from ${source}: ${resolvedModel}`);
+    } else if (!isNonWindows) {
+      // Windows VM: all sources exhausted — tell the user exactly what to configure.
       throw new Error(
         'Could not resolve model name. Provide modelName, projectPath, or solutionPath, ' +
         'or configure projectPath/solutionPath in .mcp.json or set D365FO_MODEL_NAME env var.'
       );
     }
+    // Non-Windows: if still null we continue without a prefix (XML will be returned as text).
   }
 
   console.log(`[generateSmartTable] Using model: ${resolvedModel ?? '(none — no prefix)'}`);
@@ -453,26 +459,49 @@ export async function handleGenerateSmartTable(
     }
   }
 
-  // Build incomplete-table warning for when no fieldsHint was provided
-  const incompleteWarning = usedFallback
-    ? [
-        ``,
-        `⚠️ **INCOMPLETE TABLE — \`fieldsHint\` was NOT provided!**`,
-        `Generic default fields were used instead of the user's actual fields.`,
-        ``,
-        `🔄 **YOU MUST REGENERATE** — call \`generate_smart_table\` AGAIN with correct parameters:`,
-        `\`\`\``,
-        `generate_smart_table(`,
-        `  name="${name}",              ← base name WITHOUT model prefix`,
-        `  fieldsHint="Field1, Field2, Field3",  ← extract ALL fields from the user's description`,
-        `  primaryKeyFields=["Field1", "Field2"],  ← ALL fields in the PK (omit for single-field PK)`,
-        `  methods=["find", "exist"],   ← include if user requested these`,
-        `)`,
-        `\`\`\``,
-        `⛔ **NEVER** call \`modify_d365fo_file\` to add missing fields — it CANNOT write on Azure/Linux.`,
-        `⛔ **NEVER** call \`create_d365fo_file\` with this incomplete XML — REGENERATE first.`,
-      ].join('\n')
-    : '';
+  // HARD-BLOCK: when no fieldsHint was provided (and no copyFrom / generateCommonFields),
+  // return an error immediately — do NOT generate any XML that the AI might use.
+  // The AI MUST retry with explicit fieldsHint extracted from the user's description.
+  if (usedFallback) {
+    console.error(`[generateSmartTable] ❌ BLOCKED — fieldsHint not provided for table "${name}"`);
+    return {
+      content: [{
+        type: 'text',
+        text: [
+          `❌ **CANNOT GENERATE TABLE — \`fieldsHint\` is REQUIRED!**`,
+          ``,
+          `The user described specific fields but you did NOT pass \`fieldsHint\`. Without it the table`,
+          `will be empty (no fields, no indexes, no methods). No XML has been generated.`,
+          ``,
+          `🔄 **YOU MUST call \`generate_smart_table\` AGAIN** with ALL fields extracted from the user's description:`,
+          ``,
+          `\`\`\``,
+          `generate_smart_table(`,
+          `  name="${name}",                           ← base name WITHOUT model prefix`,
+          `  fieldsHint="Field1, Field2, Field3",      ← REQUIRED: extract ALL fields from the user`,
+          `  primaryKeyFields=["Field1", "Field2"],    ← ALL PK fields (omit for single-field PK)`,
+          `  methods=["find", "exist"],                ← include if user requested these`,
+          `  tableGroup="${tableGroup}",`,
+          `)`,
+          `\`\`\``,
+          ``,
+          `**Common Czech → D365FO field name mappings:**`,
+          `| User phrase | fieldsHint value |`,
+          `|-------------|-----------------|`,
+          `| "Account number" / "číslo účtu" | \`AccountNum\` |`,
+          `| "Name" / "název" | \`Name\` |`,
+          `| "Description" / "popis" | \`Description\` |`,
+          `| "platnost od" / "from date" / "valid from" | \`ValidFrom\` |`,
+          `| "platnost do" / "to date" / "valid to" | \`ValidTo\` |`,
+          `| "active" / "aktivní" / "flag" | \`Active\` |`,
+          ``,
+          `⛔ NEVER call \`create_d365fo_file\` without first regenerating — there is no XML to use.`,
+          `⛔ NEVER call \`modify_d365fo_file\` to add missing fields — it CANNOT write on Azure/Linux.`,
+        ].join('\n'),
+      }],
+      isError: true,
+    };
+  }
 
   // Generate XML
   const xml = builder.buildTableXml({
@@ -514,7 +543,6 @@ export async function handleGenerateSmartTable(
           `✅ Table XML generated for **${finalName}**` + (resolvedModel ? ` (model: ${resolvedModel})` : ''),
           `   Fields: ${fields.length}, Indexes: ${indexes.length}, Relations: ${relations.length}`,
           noModelNote,
-          incompleteWarning,
           ``,
           `ℹ️  MCP server is running on Azure/Linux — file writing is handled by the local Windows companion. This is the expected hybrid workflow.`,
           nextStep,
@@ -564,20 +592,53 @@ export async function handleGenerateSmartTable(
   fs.writeFileSync(normalizedPath, xml, 'utf-8');
   console.log(`[generateSmartTable] Created file: ${normalizedPath}`);
 
+  // Add to Visual Studio project if a projectPath is known
+  let projectMessage = '';
+  const effectiveProjectPath = resolvedProjectPath ||
+    (await getConfigManager().getProjectPath()) ||
+    undefined;
+
+  if (effectiveProjectPath) {
+    try {
+      const projectManager = new ProjectFileManager();
+      const wasAdded = await projectManager.addToProject(
+        effectiveProjectPath,
+        'table',
+        finalName,
+        normalizedPath
+      );
+      projectMessage = wasAdded
+        ? `\n✅ Added to Visual Studio project:\n📋 Project: ${effectiveProjectPath}`
+        : `\n✅ Already in Visual Studio project:\n📋 Project: ${effectiveProjectPath}`;
+      console.log(`[generateSmartTable] addToProject result: ${wasAdded ? 'added' : 'already present'}`);
+    } catch (projErr) {
+      projectMessage = `\n⚠️ File created but could not be added to project: ${projErr instanceof Error ? projErr.message : String(projErr)}`;
+      console.error(`[generateSmartTable] addToProject error:`, projErr);
+    }
+  } else {
+    projectMessage = `\n⚠️ addToProject skipped — no projectPath found in .mcp.json or tool args.`;
+  }
+
   return {
     content: [
       {
         type: 'text',
-        text: JSON.stringify({
-          success: true,
-          tableName: finalName,
-          filePath: normalizedPath,
-          fieldsGenerated: fields.length,
-          indexesGenerated: indexes.length,
-          relationsGenerated: relations.length,
-          strategy: copyFrom ? 'copy' : generateCommonFields ? 'patterns' : fieldsHint ? 'hints' : 'default',
-          xml,
-        }, null, 2),
+        text: [
+          `✅ Table **${finalName}** created directly on the Windows VM.`,
+          ``,
+          `📁 File: ${normalizedPath}`,
+          `📦 Model: ${resolvedModel}`,
+          `📊 Fields: ${fields.length}, Indexes: ${indexes.length}, Relations: ${relations.length}`,
+          projectMessage,
+          ``,
+          `⛔ DO NOT call \`create_d365fo_file\` — the file is already written to disk.`,
+          `⛔ DO NOT call \`generate_smart_table\` again — task is COMPLETE.`,
+          ``,
+          `Next steps for the user:`,
+          `1. Reload the project in Visual Studio (or close/reopen solution)`,
+          `2. Build the project to synchronize the table`,
+          `3. Refresh AOT to see the new object`,
+        ].join('\n'),
       },
     ],
   };

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -8,7 +8,10 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { promises as fs } from 'fs';
+import path from 'path';
 import { parseStringPromise, Builder } from 'xml2js';
+import { getConfigManager } from '../utils/configManager.js';
+import { PackageResolver } from '../utils/packageResolver.js';
 
 const ModifyD365FileArgsSchema = z.object({
   objectType: z.enum(['class', 'table', 'form', 'enum', 'query', 'view']).describe('Type of D365FO object'),
@@ -185,19 +188,19 @@ async function findD365File(
     throw new Error(`Unsupported object type: ${objectType}`);
   }
 
-  // Query database
-  let stmt;
+  // Query database first
+  let dbResult: string | null = null;
   if (modelName) {
-    stmt = symbolIndex.db.prepare(`
+    const stmt = symbolIndex.db.prepare(`
       SELECT file_path
       FROM symbols
       WHERE type = ? AND name = ? AND model = ?
       LIMIT 1
     `);
     const row = stmt.get(symbolType, objectName, modelName);
-    return row ? row.file_path : null;
+    dbResult = row ? row.file_path : null;
   } else {
-    stmt = symbolIndex.db.prepare(`
+    const stmt = symbolIndex.db.prepare(`
       SELECT file_path
       FROM symbols
       WHERE type = ? AND name = ?
@@ -205,8 +208,103 @@ async function findD365File(
       LIMIT 1
     `);
     const row = stmt.get(symbolType, objectName);
-    return row ? row.file_path : null;
+    dbResult = row ? row.file_path : null;
   }
+
+  if (dbResult) {
+    return dbResult;
+  }
+
+  // Filesystem fallback: handles newly created files not yet in the symbol index
+  return findD365FileOnDisk(objectType, objectName, modelName);
+}
+
+/**
+ * Filesystem fallback for findD365File.
+ * Constructs the expected AOT file path from config/env and checks if it exists on disk.
+ * This handles objects that were just created and are not yet indexed in the symbol database.
+ */
+async function findD365FileOnDisk(
+  objectType: string,
+  objectName: string,
+  modelName?: string
+): Promise<string | null> {
+  const folderMap: Record<string, string> = {
+    class: 'AxClass',
+    table: 'AxTable',
+    form: 'AxForm',
+    enum: 'AxEnum',
+    query: 'AxQuery',
+    view: 'AxView',
+  };
+
+  const objectFolder = folderMap[objectType];
+  if (!objectFolder) return null;
+
+  const configManager = getConfigManager();
+
+  // Resolve model name: explicit arg (if not placeholder) → config → auto-detected
+  const resolvedModel =
+    (modelName && modelName !== 'any' ? modelName : null) ||
+    configManager.getModelName() ||
+    (await configManager.getAutoDetectedModelName());
+
+  if (!resolvedModel) {
+    console.error('[modifyD365File] Filesystem fallback: could not resolve model name');
+    return null;
+  }
+
+  const configPackagePath =
+    configManager.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
+
+  // Traditional mode: package name == model name (most common case)
+  const candidatePath = path.join(
+    configPackagePath,
+    resolvedModel,
+    resolvedModel,
+    objectFolder,
+    `${objectName}.xml`
+  );
+
+  try {
+    await fs.access(candidatePath);
+    console.error(`[modifyD365File] Found via filesystem fallback: ${candidatePath}`);
+    return candidatePath;
+  } catch {
+    // Not at the default package==model path; try UDE layout
+  }
+
+  // UDE mode: package name may differ from model name — use PackageResolver
+  try {
+    const envType = await configManager.getDevEnvironmentType();
+    if (envType === 'ude') {
+      const customPath = await configManager.getCustomPackagesPath();
+      const msPath = await configManager.getMicrosoftPackagesPath();
+      const roots = [customPath, msPath].filter(Boolean) as string[];
+      const resolver = new PackageResolver(roots);
+      const resolved = await resolver.resolve(resolvedModel);
+      if (resolved) {
+        const udePath = path.join(
+          resolved.rootPath,
+          resolved.packageName,
+          resolvedModel,
+          objectFolder,
+          `${objectName}.xml`
+        );
+        try {
+          await fs.access(udePath);
+          console.error(`[modifyD365File] Found via UDE filesystem fallback: ${udePath}`);
+          return udePath;
+        } catch {
+          // Not found at UDE path either
+        }
+      }
+    }
+  } catch {
+    // UDE resolution failed — skip silently
+  }
+
+  return null;
 }
 
 /**
@@ -238,20 +336,31 @@ async function addMethod(xmlObj: any, objectType: string, args: any): Promise<bo
 
   // Methods are always under SourceCode > Methods for all D365FO object types
   // (AxClass, AxTable, AxForm all use <SourceCode><Methods>...</Methods></SourceCode>)
+  //
+  // xml2js edge cases for empty/missing SourceCode:
+  //   - absent entirely          → root.SourceCode is undefined         → falsy ✓
+  //   - <SourceCode></SourceCode> → root.SourceCode is ['']             → truthy array, element is ''
+  //   - <SourceCode/>            → root.SourceCode is ['']             → same
+  // We must check the *element* is a proper object, not just that the array exists.
   let methodsContainer: any;
-  if (!root.SourceCode) {
+  const sourceCodeEl = Array.isArray(root.SourceCode) ? root.SourceCode[0] : root.SourceCode;
+  if (!sourceCodeEl || typeof sourceCodeEl !== 'object') {
+    // Absent or empty element – create the full structure from scratch
     root.SourceCode = [{ Methods: [{ Method: [] }] }];
   }
   methodsContainer = root.SourceCode[0];
 
   let methodsNode = methodsContainer.Methods;
-  if (!methodsNode) {
+  if (!methodsNode || (Array.isArray(methodsNode) && typeof methodsNode[0] !== 'object')) {
     methodsContainer.Methods = [{ Method: [] }];
     methodsNode = methodsContainer.Methods;
   }
 
   if (!methodsNode[0].Method) {
     methodsNode[0].Method = [];
+  } else if (!Array.isArray(methodsNode[0].Method)) {
+    // Single existing method may be parsed as an object instead of a 1-element array
+    methodsNode[0].Method = [methodsNode[0].Method];
   }
 
   // Create method node

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -5,7 +5,7 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { autoDetectD365Project, type D365ProjectInfo } from './workspaceDetector.js';
+import { autoDetectD365Project, detectD365Project, type D365ProjectInfo } from './workspaceDetector.js';
 import { registerCustomModel } from './modelClassifier.js';
 import { XppConfigProvider, type XppEnvironmentConfig } from './xppConfigProvider.js';
 
@@ -76,8 +76,34 @@ class ConfigManager {
     console.error('[ConfigManager] Auto-detecting D365FO project from workspace...');
 
     // Try to detect from provided workspace path or current directory
-    const detectedProject = await autoDetectD365Project(workspacePath);
-    
+    let detectedProject = await autoDetectD365Project(workspacePath);
+
+    // Fallback: if no .rnrproj was found (workspace is the MCP server dir, not the D365FO solution),
+    // scan the configured packagePath directly.
+    // In standard D365FO layout the .rnrproj lives inside:
+    //   PackagesLocalDirectory\<package>\<model>\<model>.rnrproj
+    if (!detectedProject?.projectPath) {
+      const packagePathHint =
+        this.runtimeContext.packagePath ||
+        this.config?.servers.context?.packagePath;
+
+      if (packagePathHint) {
+        console.error(`[ConfigManager] No .rnrproj in workspace — scanning packagePath: ${packagePathHint}`);
+        const pkgScan = await detectD365Project(packagePathHint, 4);
+        if (pkgScan?.projectPath) {
+          detectedProject = {
+            ...pkgScan,
+            // Prefer model name already resolved via Priority 4 (from PackagesLocalDirectory regex)
+            modelName: detectedProject?.modelName || pkgScan.modelName,
+            packagePath: packagePathHint,
+          };
+          console.error(`[ConfigManager] ✅ Found .rnrproj via packagePath scan: ${pkgScan.projectPath}`);
+        } else {
+          console.error(`[ConfigManager] No .rnrproj found in packagePath either`);
+        }
+      }
+    }
+
     // Store in cache (PERFORMANCE FIX)
     this.autoDetectionCache.set(cacheKey, detectedProject);
     
@@ -188,8 +214,13 @@ class ConfigManager {
       this.config = JSON.parse(content);
       console.error('[ConfigManager] Config loaded successfully');
       return this.config;
-    } catch (error) {
-      console.error('[ConfigManager] Failed to load .mcp.json:', error);
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') {
+        // .mcp.json is optional — not present on Azure/cloud deployments, only on local Windows VM.
+        console.error(`[ConfigManager] .mcp.json not found at ${this.configPath} — running without local config (expected on Azure)`);
+      } else {
+        console.error('[ConfigManager] Failed to load .mcp.json:', error);
+      }
       return null;
     }
   }

--- a/src/utils/smartXmlBuilder.ts
+++ b/src/utils/smartXmlBuilder.ts
@@ -99,19 +99,26 @@ export class SmartXmlBuilder {
     xml += `\t<DeleteActions />\n`;
 
     // 5 standard FieldGroups required by VS D365FO project system
+    // Order matches real D365FO AOT: AutoReport, AutoLookup, AutoIdentification, AutoSummary, AutoBrowse
     xml += `\t<FieldGroups>\n`;
-    for (const groupName of ['AutoReport', 'AutoLookup', 'AutoSummary', 'AutoBrowse']) {
+    for (const groupName of ['AutoReport', 'AutoLookup']) {
       xml += `\t\t<AxTableFieldGroup>\n`;
       xml += `\t\t\t<Name>${groupName}</Name>\n`;
       xml += `\t\t\t<Fields />\n`;
       xml += `\t\t</AxTableFieldGroup>\n`;
     }
-    // AutoIdentification requires AutoPopulate=Yes
+    // AutoIdentification is 3rd (requires AutoPopulate=Yes)
     xml += `\t\t<AxTableFieldGroup>\n`;
     xml += `\t\t\t<Name>AutoIdentification</Name>\n`;
     xml += `\t\t\t<AutoPopulate>Yes</AutoPopulate>\n`;
     xml += `\t\t\t<Fields />\n`;
     xml += `\t\t</AxTableFieldGroup>\n`;
+    for (const groupName of ['AutoSummary', 'AutoBrowse']) {
+      xml += `\t\t<AxTableFieldGroup>\n`;
+      xml += `\t\t\t<Name>${groupName}</Name>\n`;
+      xml += `\t\t\t<Fields />\n`;
+      xml += `\t\t</AxTableFieldGroup>\n`;
+    }
     xml += `\t</FieldGroups>\n`;
 
     // Fields

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -38,7 +38,16 @@ async function findProjectFiles(
       const fullPath = path.join(dir, entry.name);
 
       // Skip common directories that won't contain .rnrproj
-      const skipDirs = ['node_modules', 'bin', 'obj', '.git', '.vs', 'PackagesLocalDirectory'];
+      const skipDirs = [
+        'node_modules', 'bin', 'obj', '.git', '.vs', 'PackagesLocalDirectory',
+        // AOT artifact folders inside model directories — skip to avoid crawling thousands of XML files
+        'AxClass', 'AxTable', 'AxForm', 'AxEnum', 'AxQuery', 'AxView',
+        'AxDataEntityView', 'AxTableExtension', 'AxFormExtension',
+        'AxMenuItemAction', 'AxMenuItemDisplay', 'AxMenuItemOutput',
+        'AxMenu', 'AxSecurityRole', 'AxSecurityDuty', 'AxSecurityPrivilege',
+        'AxLabel', 'AxResource', 'AxReport', 'AxWorkflowType',
+        'AxEdt', 'AxExtendedDataType',
+      ];
       if (entry.isDirectory() && skipDirs.includes(entry.name)) {
         continue;
       }
@@ -134,6 +143,7 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
  * 1. Explicitly provided workspacePath parameter
  * 2. Current working directory (process.cwd())
  * 3. Environment variable WORKSPACE_PATH
+ * 4. PackagesLocalDirectory path regex extraction (last resort, no .rnrproj)
  */
 export async function autoDetectD365Project(
   explicitWorkspacePath?: string


### PR DESCRIPTION
…tors, SourceCode xml2js edge case

- modifyD365File: add findD365FileOnDisk() fallback for newly created objects not yet in symbol index
- modifyD365File: fix 'Cannot create property Method on string' — xml2js parses empty <SourceCode/> as ['']
- generateSmartTable/Form: call ProjectFileManager.addToProject() after Windows direct file write
- generateSmartTable/Form: replace JSON response with plain text to prevent creation loop (xml field)
- createD365File: export ProjectFileManager class for reuse; replace XML preview with TASK COMPLETE message
- configManager: scan packagePath for .rnrproj when workspace scan finds none (projectPath in .mcp.json)
- configManager: catch ENOENT separately to avoid Azure log noise on missing .mcp.json
- workspaceDetector: skip AOT artifact folders (AxClass, AxTable, etc.) during recursive scan for performance
- smartXmlBuilder: fix FieldGroups order to match D365FO AOT standard