### PR TITLE
fix: improve model name resolution logic and error messaging in modif…

### DIFF
--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -243,14 +243,21 @@ async function findD365FileOnDisk(
 
   const configManager = getConfigManager();
 
-  // Resolve model name: explicit arg (if not placeholder) → config → auto-detected
+  // Resolve model name (same priority order as generateSmartTable):
+  //   1. Explicit arg (skip placeholders like "any")
+  //   2. .mcp.json context (modelName field or last segment of workspacePath)
+  //   3. Auto-detected model name (async, from .rnrproj scan)
+  //   4. D365FO_MODEL_NAME env var
   const resolvedModel =
     (modelName && modelName !== 'any' ? modelName : null) ||
     configManager.getModelName() ||
-    (await configManager.getAutoDetectedModelName());
+    (await configManager.getAutoDetectedModelName()) ||
+    process.env.D365FO_MODEL_NAME ||
+    null;
 
   if (!resolvedModel) {
-    console.error('[modifyD365File] Filesystem fallback: could not resolve model name');
+    console.error('[modifyD365File] Filesystem fallback: could not resolve model name. ' +
+      'Provide modelName parameter, configure .mcp.json with modelName/projectPath, or set D365FO_MODEL_NAME env var.');
     return null;
   }
 

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -308,15 +308,23 @@ class ConfigManager {
 
   /**
    * Get model name from configuration.
-   * Priority: 1) Explicit modelName in mcp.json context  2) Last segment of workspacePath
-   * Use this as the primary fallback instead of D365FO_MODEL_NAME env var.
+   * Priority:
+   *   1) Explicit modelName in mcp.json context
+   *   2) Last segment of workspacePath (only when it looks like a D365FO package, i.e. no hyphens)
+   *   3) D365FO_MODEL_NAME env var
    */
   getModelName(): string | null {
     const context = this.getContext();
     if (context?.modelName) {
       return context.modelName;
     }
-    return this.getModelNameFromWorkspacePath();
+    const fromWorkspace = this.getModelNameFromWorkspacePath();
+    // Skip workspace-derived name when it clearly isn't a D365FO package
+    // (D365FO package names use PascalCase/underscore, not kebab-case like repo names)
+    if (fromWorkspace && !fromWorkspace.includes('-')) {
+      return fromWorkspace;
+    }
+    return process.env.D365FO_MODEL_NAME || null;
   }
 
   /**


### PR DESCRIPTION
This pull request refines the logic for resolving the D365 model name throughout the codebase, ensuring more robust and predictable behavior. The changes clarify the priority order for model name resolution and improve fallback handling, especially when the workspace path does not match expected D365FO package naming conventions.

Model name resolution improvements:

* Updated the priority order for resolving the model name in `findD365FileOnDisk` to match `generateSmartTable`, now including explicit arguments, `.mcp.json` context, auto-detection, and the `D365FO_MODEL_NAME` environment variable as the last fallback. Improved the error message to guide users on configuration options. (`src/tools/modifyD365File.ts`)
* Modified `ConfigManager.getModelName()` to skip workspace-derived names if they contain hyphens (which are not typical in D365FO package names), and use the `D365FO_MODEL_NAME` environment variable as a fallback when needed. (`src/utils/configManager.ts`)…yD365FileTool