### PR TITLE
fix: normalize path casing via realpathSync to prevent 'Couldn't find…

### DIFF
--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -4,7 +4,7 @@
  */
 
 import * as fs from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { autoDetectD365Project, detectD365Project, type D365ProjectInfo } from './workspaceDetector.js';
@@ -27,6 +27,21 @@ export interface McpConfig {
     [key: string]: any;
     context?: McpContext;
   };
+}
+
+/**
+ * Resolve the actual on-disk casing of a path.
+ * On Windows the filesystem is case-insensitive but VS Code and Copilot compare
+ * paths case-sensitively, causing "Couldn't find file" errors when casing in
+ * .mcp.json / .rnrproj differs from the real directory name (e.g. AOSService vs AosService).
+ * Falls back to the original string when the path does not exist yet.
+ */
+function normalizePath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
 }
 
 class ConfigManager {
@@ -277,10 +292,11 @@ class ConfigManager {
 
     // If packagePath is explicitly set, use it
     if (context.packagePath) {
+      const resolved = normalizePath(context.packagePath);
       console.error(
-        `[ConfigManager] Using explicit packagePath: ${context.packagePath}`
+        `[ConfigManager] Using explicit packagePath: ${resolved}`
       );
-      return context.packagePath;
+      return resolved;
     }
 
     // If workspacePath contains PackagesLocalDirectory, extract the base path
@@ -288,20 +304,21 @@ class ConfigManager {
       const normalized = path.normalize(context.workspacePath);
       
       // If workspacePath points to a specific model, extract base path
-      // Example: K:\AOSService\PackagesLocalDirectory\MyPackage
-      // Should return: K:\AOSService\PackagesLocalDirectory
+      // Example: K:\AosService\PackagesLocalDirectory\MyPackage
+      // Should return: K:\AosService\PackagesLocalDirectory
       const match = normalized.match(/^(.+[\\\/]PackagesLocalDirectory)(?:[\\\/]|$)/i);
       if (match) {
+        const resolved = normalizePath(match[1]);
         console.error(
-          `[ConfigManager] Extracted packagePath from workspacePath: ${match[1]}`
+          `[ConfigManager] Extracted packagePath from workspacePath: ${resolved}`
         );
-        return match[1];
+        return resolved;
       }
     }
 
     // Fallback: check if auto-detection already ran and found packagePath
     if (this.autoDetectedProject?.packagePath) {
-      return this.autoDetectedProject.packagePath;
+      return normalizePath(this.autoDetectedProject.packagePath);
     }
 
     return null;

--- a/src/utils/packageResolver.ts
+++ b/src/utils/packageResolver.ts
@@ -17,7 +17,21 @@
  */
 
 import * as fs from 'fs/promises';
+import { realpathSync } from 'fs';
 import * as path from 'path';
+
+/**
+ * Resolve the actual on-disk casing of a path (Windows is case-insensitive but
+ * VS Code and Copilot compare paths case-sensitively). Falls back to the
+ * original string if the path does not exist yet.
+ */
+function normalizePathCase(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
 
 export interface ResolvedPackage {
   packageName: string;
@@ -91,8 +105,9 @@ export class PackageResolver {
     const map = new Map<string, ResolvedPackage>();
     const lcMap = new Map<string, ResolvedPackage>();
 
-    for (const root of this.roots) {
-      if (!root) continue;
+    for (const rawRoot of this.roots) {
+      if (!rawRoot) continue;
+      const root = normalizePathCase(rawRoot);
 
       let packageDirs: string[];
       try {


### PR DESCRIPTION
This pull request introduces improvements to how filesystem paths are handled, specifically addressing issues with path casing on Windows systems. By normalizing paths to their actual on-disk casing, the changes help prevent errors caused by mismatches between the casing in configuration files and the real filesystem, which is important for tools like VS Code and Copilot that compare paths case-sensitively. The main updates are the addition of path normalization utilities and the integration of these utilities throughout the codebase where paths are resolved.

**Path normalization improvements:**

* Added a `normalizePath` function in `src/utils/configManager.ts` to resolve the actual on-disk casing of a given path, falling back to the original string if the path does not exist. This helps prevent "Couldn't find file" errors due to casing mismatches.
* Updated the `ConfigManager` class in `src/utils/configManager.ts` to use `normalizePath` when resolving `packagePath` and related paths, ensuring all returned paths have the correct casing.
* Added a similar `normalizePathCase` function to `src/utils/packageResolver.ts` for consistent path casing resolution in package-related operations.
* Updated the `PackageResolver` class in `src/utils/packageResolver.ts` to use `normalizePathCase` when iterating over root paths, ensuring all package directory lookups use the correct casing.

**Dependency updates:**

* Updated imports in both `src/utils/configManager.ts` and `src/utils/packageResolver.ts` to include `realpathSync` from the `fs` module, which is used for path normalization. [[1]](diffhunk://#diff-efab9f0a41413dc6c071355523d35ffa774870598b1fe96f0f56c3f102614c89L7-R7) [[2]](diffhunk://#diff-4dfe9f497b795fe6b4951bf9a439bfa6f95bc7b5417e2f85143d0f364a9144feR20-R35)… file' errors

On Windows, the filesystem is case-insensitive but VS Code and Copilot compare file paths case-sensitively. When .mcp.json or .rnrproj contained a path like K:\AOSService\... while the real directory on disk was named K:\AosService\..., MCP tools returned the wrong-cased path and Copilot reported 'Couldn't find file'.

Fix: apply fs.realpathSync() to resolve actual on-disk casing at the earliest point where paths are read:
- configManager.ts: normalizePath() applied in getPackagePath() for all three return sites (explicit packagePath, workspacePath extraction, autoDetectedProject fallback)
- packageResolver.ts: normalizePathCase() applied to each root before the directory scan loop in buildMap()