### PR TITLE
fix: enhance modify_d365fo_file() instructions and schema to include …

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,8 +14,20 @@ This workspace contains D365FO code. **Always use the specialized MCP tools**  p
 > - `create_file` on an existing object
 >
 >  **ALWAYS** use:
-> - `modify_d365fo_file()`  edit existing classes, tables, forms (add-method, add-field, modify-property)
+> - `modify_d365fo_file()`  edit existing classes, tables, EDTs, forms, enums (add-method, add-field, modify-field, modify-property, remove-method, remove-field)
 > - `create_d365fo_file()`  create new objects
+>
+> **modify-property covers ALL table/EDT/class-level properties — NEVER use PowerShell for these:**
+> ```
+> TableGroup     → modify-property  propertyPath="TableGroup"    propertyValue="Group"
+> TitleField1/2  → modify-property  propertyPath="TitleField1"   propertyValue="ItemId"
+> TableType      → modify-property  propertyPath="TableType"     propertyValue="TempDB"
+> CacheLookup    → modify-property  propertyPath="CacheLookup"   propertyValue="Found"
+> SaveDataPerCo  → modify-property  propertyPath="SaveDataPerCompany" propertyValue="No"
+> EDT Extends    → modify-property  objectType="edt"  propertyPath="Extends" propertyValue="WHSZoneId"
+> Class Extends  → modify-property  objectType="class" propertyPath="Extends" propertyValue="BaseClass"
+> Label/HelpText → modify-property  propertyPath="Label" propertyValue="@MyModel:MyLabel"
+> ```
 >
 > **Pattern:**
 > ```

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -619,7 +619,7 @@ Examples:
             properties: {
               objectType: {
                 type: 'string',
-                enum: ['class', 'table', 'form', 'enum', 'query', 'view'],
+                enum: ['class', 'table', 'form', 'enum', 'query', 'view', 'edt', 'data-entity', 'report', 'table-extension', 'class-extension', 'form-extension', 'enum-extension'],
                 description: 'Type of D365FO object to modify'
               },
               objectName: {
@@ -669,7 +669,18 @@ Examples:
               },
               propertyPath: {
                 type: 'string',
-                description: 'Path to property (e.g., "Table1.Visible", for modify-property)'
+                description:
+                  'Top-level property name to set on the object root. ' +
+                  'Table properties: TableGroup (Group/Parameter/Main/…), TitleField1, TitleField2, ' +
+                  'TableType (TempDB / InMemory / RegularTable), CacheLookup, ClusteredIndex, ' +
+                  'PrimaryIndex, SaveDataPerCompany (Yes/No), Label, HelpText, Extends. ' +
+                  'EDT properties: Extends, StringSize, Label, HelpText, ReferenceTable, ReferenceField. ' +
+                  'Class properties: Extends, Abstract (true/false), Final (true/false), Label. ' +
+                  'Use dot notation only for truly nested XML nodes (rare). ' +
+                  'Examples: propertyPath="TableGroup" propertyValue="Group" | ' +
+                  'propertyPath="TitleField1" propertyValue="ItemId" | ' +
+                  'propertyPath="TableType" propertyValue="TempDB" | ' +
+                  'propertyPath="Extends" propertyValue="WHSZoneId" (on an EDT)'
               },
               propertyValue: {
                 type: 'string',

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -14,7 +14,7 @@ import { getConfigManager } from '../utils/configManager.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 
 const ModifyD365FileArgsSchema = z.object({
-  objectType: z.enum(['class', 'table', 'form', 'enum', 'query', 'view']).describe('Type of D365FO object'),
+  objectType: z.enum(['class', 'table', 'form', 'enum', 'query', 'view', 'edt', 'data-entity', 'report', 'table-extension', 'class-extension', 'form-extension', 'enum-extension']).describe('Type of D365FO object'),
   objectName: z.string().describe('Name of the object to modify'),
   operation: z.enum(['add-method', 'add-field', 'modify-field', 'modify-property', 'remove-method', 'remove-field']).describe('Operation to perform'),
   
@@ -32,7 +32,15 @@ const ModifyD365FileArgsSchema = z.object({
   fieldLabel: z.string().optional().describe('Field label'),
   
   // For modify-property
-  propertyPath: z.string().optional().describe('Path to property (e.g., "Table1.Visible")'),
+  propertyPath: z.string().optional().describe(
+    'Top-level property name to set. For tables: TableGroup, TitleField1, TitleField2, TableType (TempDB/RegularTable/InMemory), ' +
+    'CacheLookup, ClusteredIndex, PrimaryIndex, SaveDataPerCompany, Label, HelpText, Extends. ' +
+    'For EDTs: Extends, StringSize, Label, HelpText, ReferenceTable, ReferenceField. ' +
+    'For classes: Extends, Abstract, Final, Label. ' +
+    'For nested properties use dot notation, e.g. "Fields.AxTableField.Name" (rare). ' +
+    'Examples: propertyPath="TableGroup" propertyValue="Group"; propertyPath="TitleField1" propertyValue="ItemId"; ' +
+    'propertyPath="TableType" propertyValue="TempDB"; propertyPath="Extends" propertyValue="WHSZoneId"'
+  ),
   propertyValue: z.string().optional().describe('New property value'),
   
   // Options
@@ -241,6 +249,13 @@ export async function findD365FileOnDisk(
     enum: 'AxEnum',
     query: 'AxQuery',
     view: 'AxView',
+    edt: 'AxEdt',
+    'data-entity': 'AxDataEntityView',
+    report: 'AxReport',
+    'table-extension': 'AxTableExtension',
+    'class-extension': 'AxClassExtension',
+    'form-extension': 'AxFormExtension',
+    'enum-extension': 'AxEnumExtension',
   };
 
   const objectFolder = folderMap[objectType];
@@ -593,15 +608,27 @@ async function removeField(xmlObj: any, objectType: string, args: any): Promise<
   const rootKey = getRootKey(objectType);
   const root = xmlObj[rootKey];
 
-  if (!root?.Fields?.[0]?.AxTableField) {
-    throw new Error('No fields found in table');
+  if (!root) {
+    throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
   }
 
-  const fields = root.Fields[0].AxTableField;
+  const rawFields = root.Fields;
+  const fieldsEmpty =
+    !rawFields ||
+    rawFields === '' ||
+    (Array.isArray(rawFields) && (rawFields.length === 0 || rawFields[0] === '' || rawFields[0] == null));
+  if (fieldsEmpty) {
+    throw new Error(`Table has no fields — cannot remove field "${fieldName}"`);
+  }
+
+  const fieldsContainer = Array.isArray(root.Fields) ? root.Fields[0] : root.Fields;
+  if (!Array.isArray(fieldsContainer.AxTableField)) {
+    fieldsContainer.AxTableField = fieldsContainer.AxTableField ? [fieldsContainer.AxTableField] : [];
+  }
+
+  const fields = fieldsContainer.AxTableField;
   const index = fields.findIndex((f: any) => {
-    // Field might be wrapped in different type nodes
-    const fieldObj = Object.values(f)[0];
-    return Array.isArray(fieldObj) && fieldObj[0].Name && fieldObj[0].Name[0] === fieldName;
+    return Array.isArray(f.Name) ? f.Name[0] === fieldName : f.Name === fieldName;
   });
 
   if (index === -1) {
@@ -666,6 +693,13 @@ function getRootKey(objectType: string): string {
     enum: 'AxEnum',
     query: 'AxQuery',
     view: 'AxView',
+    edt: 'AxEdt',
+    'data-entity': 'AxDataEntityView',
+    report: 'AxReport',
+    'table-extension': 'AxTableExtension',
+    'class-extension': 'AxClassExtension',
+    'form-extension': 'AxFormExtension',
+    'enum-extension': 'AxEnumExtension',
   };
 
   const key = keyMap[objectType];


### PR DESCRIPTION
This pull request expands support for D365FO object types and improves the clarity and robustness of the `modify_d365fo_file` tool and its documentation. The changes include extending the list of supported object types, enhancing property modification documentation, and making the field removal logic more resilient.

**Expanded object type support and documentation:**

* Added support for additional D365FO object types (`edt`, `data-entity`, `report`, `table-extension`, `class-extension`, `form-extension`, `enum-extension`) in the `modify_d365fo_file` tool, its schema, and related folder/root key mappings. [[1]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637L17-R17) [[2]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637R252-R258) [[3]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637R696-R702) [[4]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L622-R622)
* Updated documentation and schema descriptions for `modify-property` to clarify which properties can be set for tables, EDTs, and classes, and provided detailed usage examples. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L17-R31) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L672-R683) [[3]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637L35-R43)

**Robustness improvements:**

* Improved the `removeField` logic to handle empty or missing field containers more gracefully, preventing errors when attempting to remove fields from tables with no fields.…EDTs and additional properties