### PR TITLE
Improve handling of nested <Style> elements and reconcile TablixCells with TablixColumns

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -1350,52 +1350,64 @@ ${defaultParamGroupXml}
     //     but the correct form is:
     //       <Style><Border><Style>Solid</Style><Color>#000</Color></Border></Style>
     //     Same pattern applies to TopBorderStyle/TopBorderColor/TopBorderWidth etc.
-    xml = xml.replace(/(<Text><!\[CDATA\[)([\s\S]*?)(\]\]><\/Text>)/, (_whole, open, rdl, close) => {
-      // Use lazy match so innermost <Style> is processed first;
-      // the outer <Style> is only matched when there are no inner <Style> tags.
-      const fixedRdl = rdl.replace(
-        /(<Style>)([\s\S]*?)(<\/Style>)/g,
-        (styleMatch: string, styleOpen: string, styleContent: string, styleClose: string) => {
-          // Each entry: [flat name prefix, wrapper element name]
-          const groups: Array<[string, string]> = [
-            ['Border',       'Border'],
-            ['TopBorder',    'TopBorder'],
-            ['BottomBorder', 'BottomBorder'],
-            ['LeftBorder',   'LeftBorder'],
-            ['RightBorder',  'RightBorder'],
-          ];
+    //
+    //     Previous approach (matching <Style>…</Style> blocks non-greedily) had a
+    //     nesting failure: if an outer <Style> contained a nested <Style> element
+    //     (e.g. <Border><Style>Solid</Style>…</Border>) BEFORE a flat <BorderStyle>,
+    //     the non-greedy regex would bind the outer opening <Style> to the inner
+    //     closing </Style>, leaving the flat tag unprocessed.
+    //
+    //     New approach: scan the CDATA directly for flat border-property clusters
+    //     and replace them with the correct wrapper, independent of the containing
+    //     <Style> block.  Adjacent flat tags (same group, separated only by
+    //     whitespace) are collapsed into a single wrapper element.
+    xml = xml.replace(/(<Text><!\[CDATA\[)([\s\S]*?)(\]\]><\/Text>)/g, (_whole, open, rdl, close) => {
+      let fixedRdl = rdl;
+      let changed = false;
 
-          let content = styleContent;
-          let changed = false;
+      const groups: Array<[string, string]> = [
+        ['Border',       'Border'],
+        ['TopBorder',    'TopBorder'],
+        ['BottomBorder', 'BottomBorder'],
+        ['LeftBorder',   'LeftBorder'],
+        ['RightBorder',  'RightBorder'],
+      ];
 
-          for (const [prefix, wrapper] of groups) {
-            const styleTag = `${prefix}Style`;
-            const colorTag = `${prefix}Color`;
-            const widthTag = `${prefix}Width`;
+      for (const [prefix, wrapper] of groups) {
+        const st = `${prefix}Style`;
+        const ct = `${prefix}Color`;
+        const wt = `${prefix}Width`;
 
-            if (!new RegExp(`<(?:${styleTag}|${colorTag}|${widthTag})>`).test(content)) continue;
+        if (!new RegExp(`<(?:${st}|${ct}|${wt})>`).test(fixedRdl)) continue;
 
-            let bStyle = '', bColor = '', bWidth = '';
-            content = content.replace(new RegExp(`<${styleTag}>([^<]*)<\/${styleTag}>`), (_, v) => { bStyle = v; return ''; });
-            content = content.replace(new RegExp(`<${colorTag}>([^<]*)<\/${colorTag}>`), (_, v) => { bColor = v; return ''; });
-            content = content.replace(new RegExp(`<${widthTag}>([^<]*)<\/${widthTag}>`), (_, v) => { bWidth = v; return ''; });
+        // Build a regex that matches a cluster of 1–3 adjacent flat border tags
+        // for this group (in any order, with optional whitespace between them).
+        const singleTag =
+          `(?:<${st}>([^<]*)<\\/${st}>|<${ct}>([^<]*)<\\/${ct}>|<${wt}>([^<]*)<\\/${wt}>)`;
+        const clusterRe = new RegExp(
+          `${singleTag}(?:\\s*${singleTag})?(?:\\s*${singleTag})?`,
+          'g'
+        );
 
-            let inner = '';
-            if (bStyle) inner += `<Style>${bStyle}</Style>`;
-            if (bColor) inner += `<Color>${bColor}</Color>`;
-            if (bWidth) inner += `<Width>${bWidth}</Width>`;
+        fixedRdl = fixedRdl.replace(clusterRe, (match: string) => {
+          // Extract each flat-tag value from the matched cluster via side-effect callbacks.
+          let bStyle = '', bColor = '', bWidth = '';
+          match.replace(new RegExp(`<${st}>([^<]*)<\\/${st}>`), (_: string, v: string) => { bStyle = v; return ''; });
+          match.replace(new RegExp(`<${ct}>([^<]*)<\\/${ct}>`), (_: string, v: string) => { bColor = v; return ''; });
+          match.replace(new RegExp(`<${wt}>([^<]*)<\\/${wt}>`), (_: string, v: string) => { bWidth = v; return ''; });
 
-            // Prepend the corrected wrapper before remaining style content
-            content = `<${wrapper}>${inner}</${wrapper}>` + content;
-            changed = true;
-          }
+          let inner = '';
+          if (bStyle) inner += `<Style>${bStyle}</Style>`;
+          if (bColor) inner += `<Color>${bColor}</Color>`;
+          if (bWidth) inner += `<Width>${bWidth}</Width>`;
 
-          if (!changed) return styleMatch;
-          console.error('[sanitizeReportXml] Wrapped flat border properties into <Border> inside <Style> in embedded RDL');
-          return styleOpen + content + styleClose;
-        }
-      );
-      if (fixedRdl === rdl) return _whole;
+          changed = true;
+          return `<${wrapper}>${inner}</${wrapper}>`;
+        });
+      }
+
+      if (!changed) return _whole;
+      console.error('[sanitizeReportXml] Wrapped flat border properties into <Border> inside <Style> in embedded RDL');
       return open + fixedRdl + close;
     });
 
@@ -1503,6 +1515,122 @@ ${defaultParamGroupXml}
         }
       );
       if (fixedRdl === rdl) return _whole;
+      return open + fixedRdl + close;
+    });
+
+    // 18. Reconcile TablixCells count with TablixColumns count.
+    //     Each TablixRow must have exactly as many TablixCell elements as there
+    //     are TablixColumn entries in the enclosing Tablix's TablixColumns block.
+    //     When the counts are mismatched VS Report Designer throws:
+    //       "Index was out of range. Must be non-negative and less than the size
+    //        of the collection. Parameter name: index"
+    //
+    //     Two cases are handled:
+    //       A) A TablixRow has FEWER cells than TablixColumns → pad with <TablixCell />
+    //       B) TablixColumns has FEWER entries than max cells per row → pad columns
+    //
+    //     The fix finds each top-level <Tablix>…</Tablix> block using depth
+    //     tracking (to handle multiple/nested Tablix controls correctly) and
+    //     reconciles column vs cell counts within each one independently.
+    xml = xml.replace(/(<Text><!\[CDATA\[)([\s\S]*?)(\]\]><\/Text>)/g, (_whole, open, rdl, close) => {
+      let fixedRdl = rdl;
+      let changed = false;
+
+      const processTablix = (block: string): string => {
+        // Count declared TablixColumn entries (exclude TablixColumns container)
+        const colsMatch = block.match(/<TablixColumns>([\s\S]*?)<\/TablixColumns>/);
+        if (!colsMatch) return block;
+        const colCount = (colsMatch[1].match(/<TablixColumn[\s>\/]/g) || []).length;
+        if (colCount === 0) return block;
+
+        // Sub-case A: pad each TablixCells block that has too few cells
+        let result = block.replace(
+          /(<TablixCells>)([\s\S]*?)(<\/TablixCells>)/g,
+          (m: string, o: string, inner: string, c: string) => {
+            const n = (inner.match(/<TablixCell[\s>\/]/g) || []).length;
+            if (n >= colCount) return m;
+            changed = true;
+            const padding = Array(colCount - n).fill('\t\t\t\t<TablixCell />').join('\n');
+            return `${o}${inner}\n${padding}\n\t\t\t${c}`;
+          }
+        );
+
+        // Sub-case B: ensure TablixColumns has enough entries
+        const cellsBlocks = result.match(/<TablixCells>([\s\S]*?)<\/TablixCells>/g) || [];
+        const maxCells = cellsBlocks.reduce((mx, b) => {
+          const n = (b.match(/<TablixCell[\s>\/]/g) || []).length;
+          return n > mx ? n : mx;
+        }, 0);
+        if (maxCells > colCount) {
+          const extra = Array(maxCells - colCount)
+            .fill('\t\t<TablixColumn><Width>1in</Width></TablixColumn>')
+            .join('\n');
+          result = result.replace('</TablixColumns>', `\n${extra}\n\t\t</TablixColumns>`);
+          changed = true;
+        }
+
+        return result;
+      };
+
+      // Depth-tracking scan for each top-level <Tablix>…</Tablix> block.
+      // Child elements (<TablixBody>, <TablixColumns>, <TablixCell>, …) all have
+      // letters immediately after '<Tablix', so the main element is identified by
+      // '<Tablix' followed by '>', ' ', tab, or newline.
+      let pos = 0;
+      while (pos < fixedRdl.length) {
+        const tagStart = fixedRdl.indexOf('<Tablix', pos);
+        if (tagStart < 0) break;
+
+        const ch = fixedRdl[tagStart + 7];
+        if (ch !== '>' && ch !== ' ' && ch !== '\t' && ch !== '\n' && ch !== '\r') {
+          pos = tagStart + 8;
+          continue;
+        }
+
+        // Self-closing <Tablix /> — skip
+        const tagEndIdx = fixedRdl.indexOf('>', tagStart);
+        if (tagEndIdx < 0) break;
+        if (fixedRdl[tagEndIdx - 1] === '/') { pos = tagEndIdx + 1; continue; }
+
+        // Depth-scan for matching </Tablix>
+        let depth = 1;
+        let scan = tagEndIdx + 1;
+        let closeTagPos = -1;
+        while (depth > 0 && scan < fixedRdl.length) {
+          const nxtOpen  = fixedRdl.indexOf('<Tablix', scan);
+          const nxtClose = fixedRdl.indexOf('</Tablix>', scan);
+          if (nxtClose < 0) break;
+
+          if (nxtOpen >= 0 && nxtOpen < nxtClose) {
+            const nc = fixedRdl[nxtOpen + 7];
+            if (nc === '>' || nc === ' ' || nc === '\t' || nc === '\n' || nc === '\r') {
+              depth++;
+              const innerTagEnd = fixedRdl.indexOf('>', nxtOpen);
+              scan = innerTagEnd >= 0 ? innerTagEnd + 1 : nxtOpen + 8;
+            } else {
+              scan = nxtOpen + 8;
+            }
+          } else {
+            depth--;
+            if (depth === 0) closeTagPos = nxtClose;
+            scan = nxtClose + 9; // '</Tablix>'.length === 9
+          }
+        }
+
+        if (closeTagPos < 0) break;
+        const blockEnd = closeTagPos + 9;
+        const block = fixedRdl.substring(tagStart, blockEnd);
+        const fixed  = processTablix(block);
+        if (fixed !== block) {
+          fixedRdl = fixedRdl.substring(0, tagStart) + fixed + fixedRdl.substring(blockEnd);
+          pos = tagStart + fixed.length;
+        } else {
+          pos = blockEnd;
+        }
+      }
+
+      if (!changed) return _whole;
+      console.error('[sanitizeReportXml] Reconciled TablixCell count with TablixColumn count in embedded RDL');
       return open + fixedRdl + close;
     });
 

--- a/tests/tools/sanitizeReportXml.test.ts
+++ b/tests/tools/sanitizeReportXml.test.ts
@@ -698,6 +698,30 @@ describe('XmlTemplateGenerator.sanitizeReportXml()', () => {
       const twice = XmlTemplateGenerator.sanitizeReportXml(once);
       expect(twice).toBe(once);
     });
+
+    it('fixes <BorderStyle> in outer <Style> that also contains nested <Style> via <Border>', () => {
+      // Regression: non-greedy <Style>…</Style> matching would bind the outer <Style>
+      // opening to the inner </Style> (from <Border><Style>Solid</Style></Border>),
+      // leaving the flat <BorderStyle> unprocessed.
+      const rdl = `<?xml version="1.0"?><Report xmlns="${NS}"><Textbox><Style><Border><Style>Solid</Style><Color>Black</Color></Border><BorderStyle>Dotted</BorderStyle></Style></Textbox></Report>`;
+      const xml = wrap(rdl);
+      const result = XmlTemplateGenerator.sanitizeReportXml(xml);
+      expect(result).not.toContain('<BorderStyle>');
+      // The originally-correct <Border><Style>Solid</Style>... should survive
+      expect(result).toContain('<Style>Solid</Style>');
+    });
+
+    it('fixes flat <BorderStyle> in a <Style> that has sibling nested <Style> elements (2008 namespace)', () => {
+      // Regression: same nesting failure with the 2008 RDL namespace
+      const NS2008 = 'http://schemas.microsoft.com/sqlserver/reporting/2008/01/reportdefinition';
+      const wrap2008 = (rdl: string) =>
+        `<AxReport xmlns="Microsoft.Dynamics.AX.Metadata.V2"><Name>R</Name><DataMethods /><Designs><AxReportDesign xmlns="" i:type="AxReportPrecisionDesign"><Name>Report</Name><Text><![CDATA[${rdl}]]></Text></AxReportDesign></Designs></AxReport>`;
+      const rdl = `<?xml version="1.0"?><Report xmlns="${NS2008}"><Textbox><Style><Border><Style>None</Style></Border><BorderStyle>Solid</BorderStyle><FontSize>10pt</FontSize></Style></Textbox></Report>`;
+      const xml = wrap2008(rdl);
+      const result = XmlTemplateGenerator.sanitizeReportXml(xml);
+      expect(result).not.toContain('<BorderStyle>');
+      expect(result).toContain('<FontSize>10pt</FontSize>');
+    });
   });
 
   // ─────────────────────────────────────────────────────────────
@@ -851,4 +875,82 @@ describe('XmlTemplateGenerator.sanitizeReportXml()', () => {
       expect(twice).toBe(once);
     });
   });
+
+  // ─────────────────────────────────────────────────────────────
+  // Fix 18 — TablixCells count must match TablixColumns count
+  // ─────────────────────────────────────────────────────────────
+  describe('fix 18: reconcile TablixCells with TablixColumns count', () => {
+    const NS = 'http://schemas.microsoft.com/sqlserver/reporting/2016/01/reportdefinition';
+    const wrap = (rdl: string) =>
+      `<AxReport xmlns="Microsoft.Dynamics.AX.Metadata.V2"><Name>R</Name><DataMethods /><Designs><AxReportDesign xmlns="" i:type="AxReportPrecisionDesign"><Name>Report</Name><Text><![CDATA[${rdl}]]></Text></AxReportDesign></Designs></AxReport>`;
+
+    // Helper: build a simple Tablix with N declared columns and rows whose cell counts are specified
+    const tablix = (cols: number, ...rowCellCounts: number[]) => {
+      const columns = Array(cols).fill('<TablixColumn><Width>1in</Width></TablixColumn>').join('');
+      const rows = rowCellCounts.map(n => {
+        const cells = Array(n).fill('<TablixCell><CellContents><Textbox Name="X"><Paragraphs><Paragraph><TextRuns><TextRun><Value>v</Value><Style/></TextRun></TextRuns><Style/></Paragraph></Paragraphs><Height>0.25in</Height></Textbox></CellContents></TablixCell>').join('');
+        return `<TablixRow><Height>0.25in</Height><TablixCells>${cells}</TablixCells></TablixRow>`;
+      }).join('');
+      return `<Tablix Name="T1"><TablixBody><TablixColumns>${columns}</TablixColumns><TablixRows>${rows}</TablixRows></TablixBody></Tablix>`;
+    };
+
+    it('pads a TablixRow that has fewer cells than TablixColumns', () => {
+      // 3 declared columns, but data row only has 2 cells
+      const rdl = `<?xml version="1.0"?><Report xmlns="${NS}">${tablix(3, 2)}</Report>`;
+      const xml = wrap(rdl);
+      const result = XmlTemplateGenerator.sanitizeReportXml(xml);
+      // Should now have 3 TablixCell occurrences in the row
+      const cellMatches = result.match(/<TablixCell[\s>\/]/g) || [];
+      expect(cellMatches.length).toBe(3);
+    });
+
+    it('adds a missing TablixColumn when a row has more cells than declared columns', () => {
+      // 2 declared columns, but a row has 3 cells
+      const rdl = `<?xml version="1.0"?><Report xmlns="${NS}">${tablix(2, 3)}</Report>`;
+      const xml = wrap(rdl);
+      const result = XmlTemplateGenerator.sanitizeReportXml(xml);
+      // Should now have 3 TablixColumn occurrences
+      const colMatches = result.match(/<TablixColumn[\s>\/]/g) || [];
+      expect(colMatches.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('handles two rows where one has the right count and one is short', () => {
+      // 3 columns, row 0 has 3 cells (correct), row 1 has 2 cells (needs padding)
+      const rdl = `<?xml version="1.0"?><Report xmlns="${NS}">${tablix(3, 3, 2)}</Report>`;
+      const xml = wrap(rdl);
+      const result = XmlTemplateGenerator.sanitizeReportXml(xml);
+      // Total cells: 3 (row 0 unchanged) + 3 (row 1 padded) = 6
+      const cellMatches = result.match(/<TablixCell[\s>\/]/g) || [];
+      expect(cellMatches.length).toBe(6);
+    });
+
+    it('does not modify a Tablix where all counts already match', () => {
+      // 3 columns, 3 cells per row — already correct
+      const rdl = `<?xml version="1.0"?><Report xmlns="${NS}">${tablix(3, 3)}</Report>`;
+      const xml = wrap(rdl);
+      const result = XmlTemplateGenerator.sanitizeReportXml(xml);
+      expect(result).toBe(xml);
+    });
+
+    it('fix 18 is idempotent', () => {
+      const rdl = `<?xml version="1.0"?><Report xmlns="${NS}">${tablix(3, 2)}</Report>`;
+      const xml = wrap(rdl);
+      const once  = XmlTemplateGenerator.sanitizeReportXml(xml);
+      const twice = XmlTemplateGenerator.sanitizeReportXml(once);
+      expect(twice).toBe(once);
+    });
+
+    it('processes two independent Tablix blocks in the same report correctly', () => {
+      // First Tablix: 2 cols, row with 1 cell. Second Tablix: 3 cols, row with 3 cells.
+      const t1 = `<Tablix Name="T1"><TablixBody><TablixColumns><TablixColumn><Width>1in</Width></TablixColumn><TablixColumn><Width>1in</Width></TablixColumn></TablixColumns><TablixRows><TablixRow><Height>0.25in</Height><TablixCells><TablixCell><CellContents><Textbox Name="A"><Paragraphs><Paragraph><TextRuns><TextRun><Value>v</Value><Style/></TextRun></TextRuns><Style/></Paragraph></Paragraphs><Height>0.25in</Height></Textbox></CellContents></TablixCell></TablixCells></TablixRow></TablixRows></TablixBody></Tablix>`;
+      const t2 = tablix(3, 3);
+      const rdl = `<?xml version="1.0"?><Report xmlns="${NS}">${t1}${t2}</Report>`;
+      const xml = wrap(rdl);
+      const result = XmlTemplateGenerator.sanitizeReportXml(xml);
+      // T1: 1 cell padded to 2. T2: already 3 cells, unchanged. Total = 2 + 3 = 5.
+      const cellMatches = result.match(/<TablixCell[\s>\/]/g) || [];
+      expect(cellMatches.length).toBe(5);
+    });
+  });
 });
+


### PR DESCRIPTION
This pull request improves the robustness of the `sanitizeReportXml` function in `src/tools/createD365File.ts` and expands its test coverage. The main changes address two long-standing XML report formatting issues: handling nested border styles and ensuring that the number of TablixCells matches the number of TablixColumns in report definitions. These fixes prevent rendering errors and ensure compatibility with report designer tools.

**Border property handling improvements:**

* Replaced the previous non-greedy `<Style>…</Style>` regex approach with a new method that directly scans for and wraps clusters of flat border property tags (e.g., `<BorderStyle>`, `<BorderColor>`, `<BorderWidth>`) into their correct wrapper elements, regardless of nesting. This resolves cases where nested `<Style>` tags caused incorrect processing of sibling flat tags. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL1353-R1367) [[2]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL1368-L1398)
* Added regression tests to verify that flat border style tags are correctly wrapped even when nested `<Style>` elements are present, for both standard and 2008 RDL namespaces.

**Tablix cell/column count reconciliation:**

* Implemented logic to reconcile the count of `<TablixCell>` elements in each `<TablixRow>` with the number of `<TablixColumn>` entries in the enclosing `<Tablix>`. The fix pads rows with missing cells and adds columns when there are extra cells, using depth-tracking to handle nested or multiple Tablix blocks.
* Added comprehensive tests for Tablix reconciliation, covering padding, column addition, idempotency, and handling of multiple independent Tablix blocks within a report.…ile TablixCells with TablixColumns count