### PR TITLE
fix: auto-probe C: and K: for PackagesLocalDirectory; add packagePath…

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -1970,7 +1970,7 @@ export async function handleCreateD365File(
         'Provide it in one of these ways:\n' +
         '  1. Pass modelName explicitly in the tool call arguments\n' +
         '  2. Add modelName to .mcp.json context: { "context": { "modelName": "YourModel" } }\n' +
-        '  3. Add workspacePath ending with the package/model name: { "context": { "workspacePath": "K:\\\\...\\\\YourModel" } }\n' +
+        '  3. Add workspacePath ending with the package/model name: { "context": { "workspacePath": "C:\\\\AosService\\\\PackagesLocalDirectory\\\\YourModel" } }\n' +
         '  4. Add projectPath or solutionPath to .mcp.json so the model is auto-extracted from .rnrproj';
       console.error(`[create_d365fo_file] ${errorMsg}`);
       return { content: [{ type: 'text', text: errorMsg }] };
@@ -2018,9 +2018,9 @@ export async function handleCreateD365File(
           `  {\n` +
           `    "servers": {\n` +
           `      "context": {\n` +
-          `        "projectPath": "K:\\\\VSProjects\\\\YourSolution\\\\YourProject\\\\YourProject.rnrproj",\n` +
-          `        "solutionPath": "K:\\\\VSProjects\\\\YourSolution",\n` +
-          `        "packagePath": "K:\\\\AosService\\\\PackagesLocalDirectory"\n` +
+          `        "projectPath": "C:\\\\VSProjects\\\\YourSolution\\\\YourProject\\\\YourProject.rnrproj",\n` +
+          `        "solutionPath": "C:\\\\VSProjects\\\\YourSolution",\n` +
+          `        "packagePath": "C:\\\\AosService\\\\PackagesLocalDirectory"\n` +
           `      }\n` +
           `    }\n` +
           `  }\n\n` +
@@ -2141,7 +2141,7 @@ export async function handleCreateD365File(
         `Running on: ${process.platform}\n\n` +
         `The create_d365fo_file tool requires:\n` +
         `1. Running on Windows (local D365FO VM)\n` +
-        `2. Direct access to K:\\AosService\\PackagesLocalDirectory\n\n` +
+        `2. Direct access to PackagesLocalDirectory (e.g. C:\\AosService\\PackagesLocalDirectory)\n\n` +
         `This tool CANNOT work through Azure MCP proxy (runs on Linux).\n\n` +
         `Solutions:\n` +
         `- Run MCP server locally on D365FO Windows VM\n` +

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -23,6 +23,7 @@ interface GenerateSmartTableArgs {
   modelName?: string;
   projectPath?: string;
   solutionPath?: string;
+  packagePath?: string;
   /**
    * Standard method names to generate and embed in the XML.
    * Supported: "find", "exist"
@@ -95,6 +96,12 @@ export const generateSmartTableTool: Tool = {
         type: 'string',
         description: 'Path to solution directory (alternative to projectPath)',
       },
+      packagePath: {
+        type: 'string',
+        description:
+          'Base packages directory path (e.g. "C:\\AosService\\PackagesLocalDirectory"). ' +
+          'Auto-detected from .mcp.json; only needed when the default K: fallback is wrong.',
+      },
       methods: {
         type: 'array',
         items: { type: 'string' },
@@ -125,6 +132,7 @@ export async function handleGenerateSmartTable(
     modelName,
     projectPath,
     solutionPath,
+    packagePath: argPackagePath,
     methods: requestedMethods,
   } = args;
 
@@ -325,7 +333,22 @@ export async function handleGenerateSmartTable(
 
   // Determine package path
   const configManager = getConfigManager();
-  const packagePath = configManager.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
+  const resolvedPackagePath = argPackagePath || configManager.getPackagePath();
+  // getPackagePath() already probes C:\ and K:\ well-known locations before returning null,
+  // so reaching here with null means neither location exists on this machine.
+  if (!resolvedPackagePath && process.platform === 'win32') {
+    throw new Error(
+      '\u274c Cannot determine PackagesLocalDirectory path.\n\n' +
+      'Neither C:\\AosService\\PackagesLocalDirectory nor K:\\AosService\\PackagesLocalDirectory were found.\n\n' +
+      'If your D365FO installation is on a different drive, add one of the following to your .mcp.json:\n' +
+      '  \u2022 "packagePath": "<drive>:\\\\AosService\\\\PackagesLocalDirectory"\n' +
+      '  \u2022 "workspacePath": "<drive>:\\\\AosService\\\\PackagesLocalDirectory\\\\YourModel"\n' +
+      '  \u2022 "projectPath": "<drive>:\\\\VSProjects\\\\YourSolution\\\\YourProject\\\\YourProject.rnrproj"\n\n' +
+      'Or pass packagePath directly to this tool call.\n\n' +
+      'UDE environments: packagePath is not used — configure customPackagesPath/microsoftPackagesPath instead.'
+    );
+  }
+  const packagePath = resolvedPackagePath || 'K:\\AosService\\PackagesLocalDirectory';
 
   // Resolve project/solution path — fall back to configManager (from .mcp.json / auto-detection)
   let resolvedProjectPath = projectPath;

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -321,6 +321,23 @@ class ConfigManager {
       return normalizePath(this.autoDetectedProject.packagePath);
     }
 
+    // Last resort (Windows only): probe well-known PackagesLocalDirectory locations.
+    // Covers the two standard D365FO installation scenarios without requiring .mcp.json config:
+    //   C:\AosService\PackagesLocalDirectory  → VHD / local developer machine
+    //   K:\AosService\PackagesLocalDirectory  → cloud-hosted VM (standard Azure Dev/Test image)
+    if (process.platform === 'win32') {
+      const wellKnownCandidates = [
+        'C:\\AosService\\PackagesLocalDirectory',
+        'K:\\AosService\\PackagesLocalDirectory',
+      ];
+      for (const candidate of wellKnownCandidates) {
+        if (existsSync(candidate)) {
+          console.error(`[ConfigManager] ✅ Auto-probed packagePath: ${candidate}`);
+          return candidate;
+        }
+      }
+    }
+
     return null;
   }
 


### PR DESCRIPTION
This pull request updates the D365FO tooling to improve Windows path handling and configuration flexibility, particularly for the `PackagesLocalDirectory` and related project paths. The changes clarify documentation, add support for specifying `packagePath` directly, and enhance auto-detection logic to cover standard installation scenarios.

**Path handling and configuration improvements:**

* Added `packagePath` as an explicit argument to the `GenerateSmartTableArgs` interface and tool schema, allowing users to override the default path when needed. [[1]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR26) [[2]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR99-R104) [[3]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR135)
* Enhanced the package path resolution logic in `handleGenerateSmartTable` to support direct argument, config file, or auto-detection, with improved error messaging when neither standard location is found.
* Updated the `ConfigManager` to probe both `C:\AosService\PackagesLocalDirectory` and `K:\AosService\PackagesLocalDirectory` as well-known locations on Windows, improving reliability for different D365FO installation types.

**Documentation and user guidance updates:**

* Revised error and usage messages in `handleCreateD365File` to reference `C:` instead of `K:` as the primary example, and clarified instructions for configuring paths in `.mcp.json` or tool arguments. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL1973-R1973) [[2]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL2021-R2023) [[3]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL2144-R2144)… param to generate_smart_table

- configManager.getPackagePath() now probes C:\\AosService\\PackagesLocalDirectory and K:\\AosService\\PackagesLocalDirectory before returning null, so cloud-hosted VMs (K:) and VHD/local installs (C:) both work with zero .mcp.json config
- generate_smart_table tool: add packagePath input parameter so the AI agent can override the resolved path when needed
- generate_smart_table: replace silent K: hardcoded fallback with a clear actionable error that lists both well-known paths and explains UDE is separate
- createD365File: replace K:-only references in error messages with drive-agnostic wording and update example .mcp.json snippets to use C: to avoid confusion