### PR TITLE
fix: simplify null checks for context in getPackagePath method

### DIFF
--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -286,12 +286,9 @@ class ConfigManager {
    */
   getPackagePath(): string | null {
     const context = this.getContext();
-    if (!context) {
-      return null;
-    }
 
     // If packagePath is explicitly set, use it
-    if (context.packagePath) {
+    if (context?.packagePath) {
       const resolved = normalizePath(context.packagePath);
       console.error(
         `[ConfigManager] Using explicit packagePath: ${resolved}`
@@ -300,7 +297,7 @@ class ConfigManager {
     }
 
     // If workspacePath contains PackagesLocalDirectory, extract the base path
-    if (context.workspacePath) {
+    if (context?.workspacePath) {
       const normalized = path.normalize(context.workspacePath);
       
       // If workspacePath points to a specific model, extract base path


### PR DESCRIPTION
This pull request makes minor improvements to the `ConfigManager` class in `src/utils/configManager.ts` by updating how context properties are accessed, improving code safety and robustness.

* Updated the checks for `packagePath` and `workspacePath` to use optional chaining (`context?.packagePath` and `context?.workspacePath`), which prevents potential runtime errors if `context` is null or undefined. [[1]](diffhunk://#diff-efab9f0a41413dc6c071355523d35ffa774870598b1fe96f0f56c3f102614c89L289-R291) [[2]](diffhunk://#diff-efab9f0a41413dc6c071355523d35ffa774870598b1fe96f0f56c3f102614c89L303-R300)