### PR TITLE
fix: correct field XML type mapping and remove backup file creation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ This workspace contains D365FO code. **Always use the specialized MCP tools**  p
 >                      (use when field names contain spaces or are otherwise corrupted)
 >
 > Overwrite whole    → create_d365fo_file  xmlContent="<full XML>"  overwrite=true
-> object XML           (creates .bak backup first; use when the entire XML needs replacing)
+> object XML           (use when the entire XML needs replacing)
 > ```
 >
 > **Pattern:**
@@ -99,6 +99,47 @@ For any D365FO request, **start with MCP tools  never** `code_search`, `grep_sea
 10. **NEVER** use `get_enum_info()` for EDTs  use `get_edt_info()` instead
 11. **NEVER** infer the target model from search results or object names — the `model` field in search/get_table_info results is the SOURCE model of that existing object, NOT where you should create new objects. The target model for ALL create/modify operations is ALWAYS from `.mcp.json` (projectPath/modelName). Example of WRONG reasoning: task involves a report → search returns objects from "AslReports" → ❌ DO NOT use "AslReports". Use the configured model.
 12. **NEVER** create AxReport XML with `create_file` or PowerShell — ALWAYS use `create_d365fo_file(objectType="report", xmlContent=<full XML>, addToProject=true)`. SSRS reports require UTF-8 BOM and correct AOT path which only `create_d365fo_file` guarantees.
+13. **ALWAYS** put class member variable declarations **inside** the class `{ }` body in `sourceCode` — they become `<Declaration>` in the AxClass XML. Variables placed **outside** the `{}` are NOT part of the declaration and will be lost.
+
+### AxClass sourceCode Format — Member Variables in Declaration
+
+D365FO AxClass XML separates a class into two blocks:
+- **`<Declaration>`** — class header + ALL member variable declarations (inside the outer `{ }`)
+- **`<Methods>`** — one `<Method>` entry per method defined **after** the class `{ }` closing brace
+
+When passing `sourceCode` to `create_d365fo_file` or `generate_d365fo_xml` for a class, use this exact layout:
+
+```xpp
+// ✅ CORRECT — variables inside class {}
+[DataContractAttribute]
+public class MyClass extends MyBase
+{
+    int globalPackageNumber;
+    Qty totalExportedOrderUnitQty, totalExportedInventUnitQty;
+}
+
+public int globalPackageNumber(int _v = globalPackageNumber)
+{
+    globalPackageNumber = _v;
+    return globalPackageNumber;
+}
+```
+
+Common mistakes that break the resulting AxClass XML:
+```xpp
+// ❌ WRONG — variables after class {}, will be lost from <Declaration>
+public class MyClass
+{
+}
+int globalPackageNumber;          // ← gets dropped!
+public void myMethod() { ... }
+```
+
+```xpp
+// ❌ WRONG — no class {} at all, everything treated as one method
+public class MyClass
+public void myMethod() { ... }
+```
 
 ### generate_smart_table / generate_smart_form  TWO success cases
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -405,7 +405,7 @@ async function main() {
         { icon: '📝', category: 'File & Metadata Operations', tools: [
           { name: 'generate_d365fo_xml',          desc: 'Generate D365FO XML content (preview / cloud-ready)' },
           { name: 'create_d365fo_file',           desc: 'Create D365FO file in correct AOT location (Windows)' },
-          { name: 'modify_d365fo_file',           desc: 'Safely edit D365FO XML with backup & rollback (Windows)' },
+          { name: 'modify_d365fo_file',           desc: 'Safely edit D365FO XML (Windows)' },
         ]},
         { icon: '📈', category: 'Pattern Analysis', tools: [
           { name: 'get_table_patterns',           desc: 'Analyze common field/index patterns for table groups' },

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -484,6 +484,30 @@ WORKFLOW:
 1. generate_code(pattern="batch-job", name="MyBatch") → Get X++ code
 2. create_d365fo_file(objectType="class", objectName="MyBatch", sourceCode=<step 1>, addToProject=true)
 
+AXCLASS sourceCode FORMAT — CRITICAL:
+The sourceCode string for a class MUST follow this exact layout:
+  • Class header (attributes + class keyword + extends/implements) WITH member variable
+    declarations INSIDE the outer { } — this block becomes <Declaration>
+  • Method bodies follow AFTER the closing } of the class header — each becomes a <Method>
+
+Example (correct):
+  [DataContractAttribute]
+  public class MyClass extends MyBase
+  {
+      int globalPackageNumber;
+      Qty totalExportedQty;
+  }
+  public int globalPackageNumber(int _v = globalPackageNumber)
+  {
+      globalPackageNumber = _v;
+      return globalPackageNumber;
+  }
+
+Common mistakes:
+  ❌ Putting member variables OUTSIDE the class { } (they will be lost in <Declaration>)
+  ❌ Omitting the class { } block entirely (all content treated as one method)
+  ❌ Putting member variables inside a method body
+
 EXAMPLES:
 - "Create batch job for processing orders" → create_d365fo_file(objectType="class", objectName="ProcessOrdersBatch", addToProject=true)
 - "Create helper class for sales calculations" → create_d365fo_file(objectType="class", objectName="SalesCalculationHelper", addToProject=true)`,
@@ -513,7 +537,7 @@ EXAMPLES:
               },
               sourceCode: {
                 type: 'string',
-                description: 'X++ source code for the object (class declaration, methods, etc.)'
+                description: `X++ source code for the object.\n\nFOR CLASSES — the content is split into <Declaration> and <Methods> automatically:\n  • <Declaration> = class keyword line + ALL member variable declarations inside the outer { }\n  • <Methods>     = each method defined AFTER the closing } of the class header\n\nExample for a class with member variables and a method:\n  public class MyClass\n  {\n      int globalPackageNumber;\n      Qty totalExportedQty;\n  }\n  public void myMethod()\n  {\n      // body\n  }\n\nCRITICAL: member variables MUST be inside the class { } block — NOT after it.`
               },
               properties: {
                 type: 'object',
@@ -544,7 +568,7 @@ EXAMPLES:
                 description:
                   'Allow overwriting an existing file. Use together with xmlContent when you need to ' +
                   'completely rewrite an object (e.g. table with corrupted field names, wrong TableType, \u2026). ' +
-                  'A .bak backup is created automatically. Default: false. ' +
+                  'Default: false. ' +
                   '\u274c NEVER use PowerShell/create_file to overwrite D365FO objects \u2014 always use overwrite=true here.',
                 default: false,
               },
@@ -573,7 +597,7 @@ EXAMPLES:
               },
               sourceCode: {
                 type: 'string',
-                description: 'X++ source code for the object (class declaration, methods, etc.)'
+                description: `X++ source code for the object.\n\nFOR CLASSES — same format as create_d365fo_file:\n  • Member variable declarations MUST be inside the class { } header block → goes to <Declaration>\n  • Methods follow AFTER the closing } of the class header → each becomes a <Method>\n\nExample:\n  public class MyClass\n  {\n      int myVar;\n      Qty myQty;\n  }\n  public void myMethod() { }`
               },
               properties: {
                 type: 'object',
@@ -640,7 +664,7 @@ Examples:
         },
         {
           name: 'modify_d365fo_file',
-          description: '⚠️ WINDOWS ONLY: Safely modifies an existing D365FO XML file (class, table, enum, form, query, view). Supports adding/removing/modifying methods and fields, modifying properties. Creates automatic backup (.bak) before changes and validates XML after modification. IMPORTANT: This tool MUST run locally on Windows D365FO VM - it CANNOT work through Azure HTTP proxy (Linux).',
+          description: '⚠️ WINDOWS ONLY: Safely modifies an existing D365FO XML file (class, table, enum, form, query, view). Supports adding/removing/modifying methods and fields, modifying properties. Validates XML after modification. IMPORTANT: This tool MUST run locally on Windows D365FO VM - it CANNOT work through Azure HTTP proxy (Linux).',
           inputSchema: {
             type: 'object',
             properties: {
@@ -698,7 +722,17 @@ Examples:
               },
               fieldType: {
                 type: 'string',
-                description: 'Extended data type or base type (required for add-field; optional for modify-field to change EDT)'
+                description: 'EDT name for the field (required for add-field, e.g. "InventQty", "WHSZoneId", "TransDate"). For modify-field: new EDT to set.'
+              },
+              fieldBaseType: {
+                type: 'string',
+                enum: ['String', 'Integer', 'Real', 'Date', 'DateTime', 'Int64', 'GUID', 'Enum'],
+                description:
+                  'Base type for add-field — determines the XML element (AxTableFieldReal, AxTableFieldDate, …). ' +
+                  'REQUIRED when fieldType is an EDT name. Without it defaults to AxTableFieldString (WRONG for Real/Date/Int64!). ' +
+                  'Examples: fieldType="InventQty" + fieldBaseType="Real" → AxTableFieldReal; ' +
+                  'fieldType="TransDate" + fieldBaseType="Date" → AxTableFieldDate; ' +
+                  'fieldType="WHSZoneId" + fieldBaseType="String" → AxTableFieldString.'
               },
               fieldMandatory: {
                 type: 'boolean',
@@ -714,14 +748,22 @@ Examples:
                   'Full replacement field list for replace-all-fields operation. ' +
                   'Each item: { name: string, edt?: string, type?: string, mandatory?: boolean, label?: string }. ' +
                   'Use when field names are corrupted (contain spaces, wrong casing, wrong EDT). ' +
-                  'All existing fields are replaced atomically. Backup is created automatically. ' +
+                  'All existing fields are replaced atomically. ' +
                   '❌ NEVER use PowerShell/create_file for this — always use replace-all-fields.',
                 items: {
                   type: 'object',
                   properties: {
-                    name: { type: 'string' },
-                    edt: { type: 'string' },
-                    type: { type: 'string' },
+                    name: { type: 'string', description: 'Field name' },
+                    edt:  { type: 'string', description: 'EDT name, e.g. "InventQty", "WHSZoneId"' },
+                    type: {
+                      type: 'string',
+                      enum: ['String', 'Integer', 'Real', 'Date', 'DateTime', 'Int64', 'GUID', 'Enum'],
+                      description:
+                        'Base type — REQUIRED alongside edt to get the correct XML element. ' +
+                        'Determines AxTableFieldReal/AxTableFieldDate/… ' +
+                        'Without it defaults to AxTableFieldString (wrong for numeric/date EDTs!). ' +
+                        'Example: { name:"TransQty", edt:"InventQty", type:"Real" }'
+                    },
                     mandatory: { type: 'boolean' },
                     label: { type: 'string' },
                   },
@@ -749,8 +791,8 @@ Examples:
               },
               createBackup: {
                 type: 'boolean',
-                description: 'Create backup before modification (default: true)',
-                default: true
+                description: 'Create backup before modification (default: false)',
+                default: false
               },
               modelName: {
                 type: 'string',

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -67,8 +67,7 @@ const CreateD365FileArgsSchema = z.object({
     .default(false)
     .describe(
       'Allow overwriting an existing file. Use together with xmlContent when you need to completely ' +
-      'rewrite an object (e.g. table with corrupted field names). A .bak backup is created automatically ' +
-      'before overwriting. Default: false (returns error if file already exists).'
+      'rewrite an object (e.g. table with corrupted field names). Default: false (returns error if file already exists).'
     ),
 });
 
@@ -191,9 +190,34 @@ export class XmlTemplateGenerator {
     }
     if (classEndIdx === -1) return { declaration: fullSource, methods: [] };
 
-    const declaration = fullSource.substring(0, classEndIdx + 1);
+    let declaration = fullSource.substring(0, classEndIdx + 1);
     const rest = fullSource.substring(classEndIdx + 1);
     if (!rest.trim()) return { declaration, methods: [] };
+
+    // ── FIX: Rescue member-variable declarations that appear OUTSIDE the class {}
+    // Some AI generators emit variable declarations after the class closing brace but
+    // before the first method (e.g. "}\nint myVar;\npublic void foo() { }").
+    // D365FO requires them inside the <Declaration> CDATA block. Detect and inject them now.
+    const nextBraceInRest = rest.indexOf('{');
+    if (nextBraceInRest !== -1) {
+      const preMethodText = rest.substring(0, nextBraceInRest);
+      const varLines = preMethodText
+        .split('\n')
+        .filter(l => {
+          const t = l.trim();
+          // A variable declaration ends with ';' and does NOT contain '(' (not a method call/signature)
+          return t.endsWith(';') && !t.includes('(');
+        });
+      if (varLines.length > 0) {
+        // Inject the rescued declarations into the class body, just before the closing '}'
+        const injected = varLines.map(l => '    ' + l.trim()).join('\n');
+        declaration = declaration.replace(/}(\s*)$/, `\n${injected}\n}`);
+        console.error(
+          `[splitXppClassSource] Rescued ${varLines.length} member variable declaration(s) ` +
+          'found outside the class {} block — injected into <Declaration>.'
+        );
+      }
+    }
 
     // Parse each method block from the remaining source
     const methods: Array<{ name: string; source: string }> = [];
@@ -256,15 +280,20 @@ export class XmlTemplateGenerator {
       ? `\t<IsAbstract>Yes</IsAbstract>\n`
       : '';
 
+    // D365FO convention: method source is always indented by 4 spaces inside <Source>.
+    // This matches what VS writes and what the compiler/Designer expect to see.
+    const indentMethodSource = (src: string): string =>
+      src.split('\n').map(line => '    ' + line).join('\n');
+
     const methodsXml =
       methods.length === 0
         ? '\t\t<Methods />\n'
         : `\t\t<Methods>\n${methods
             .map(
               m =>
-                `\t\t\t<Method>\n\t\t\t\t<Name>${m.name}</Name>\n\t\t\t\t<Source><![CDATA[\n${m.source}\n]]></Source>\n\t\t\t</Method>`
+                `\t\t\t<Method>\n\t\t\t\t<Name>${m.name}</Name>\n\t\t\t\t<Source><![CDATA[\n${indentMethodSource(m.source)}\n]]></Source>\n\t\t\t</Method>`
             )
-            .join('\n')}\n\t\t</Methods>\n`;
+            .join('\n\n')}\n\t\t</Methods>\n`;
 
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
@@ -1636,6 +1665,31 @@ ${defaultParamGroupXml}
 
     return xml;
   }
+
+  /**
+   * Convert <Text><![CDATA[…RDL…]]></Text> to XML entity-encoded form.
+   *
+   * D365FO stores and expects the embedded RDL as entity-encoded text, not CDATA:
+   *   <Text>&lt;?xml version="1.0"?&gt;&lt;Report ...&gt;...&lt;/Report&gt;</Text>
+   *
+   * CDATA is valid XML and semantically equivalent, but the VS Designer metadata loader
+   * does not render <Designs> correctly when the <Text> value uses CDATA — the design
+   * appears empty even though no parse error is raised. Using entity encoding matches
+   * what VS writes natively and fixes the empty-design issue.
+   *
+   * This is a SEPARATE method from sanitizeReportXml intentionally:
+   *   - sanitizeReportXml operates on CDATA form (efficient regex over raw XML text)
+   *   - encodeReportTextElement runs AFTER sanitize, just before writing to disk
+   */
+  static encodeReportTextElement(xml: string): string {
+    return xml.replace(/<Text><!\[CDATA\[([\s\S]*?)\]\]><\/Text>/g, (_match, rdlInner: string) => {
+      const encoded = rdlInner
+        .replace(/&/g, '&amp;')   // must be first to avoid double-encoding
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      return `<Text>${encoded}</Text>`;
+    });
+  }
 }
 
 /**
@@ -2207,20 +2261,12 @@ export async function handleCreateD365File(
             {
               type: 'text',
               text: `⚠️ File already exists: ${normalizedFullPath}\n\nOptions:\n` +
-                `  1. Pass overwrite=true together with xmlContent to replace the file (backup created automatically).\n` +
+                `  1. Pass overwrite=true together with xmlContent to replace the file.\n` +
                 `  2. Use modify_d365fo_file to make targeted changes (rename-field, replace-all-fields, modify-property, …).\n` +
                 `  3. Choose a different objectName.`,
             },
           ],
         };
-      }
-      // overwrite=true — create backup before replacing
-      const backupPath = normalizedFullPath + '.bak';
-      try {
-        await fs.copyFile(normalizedFullPath, backupPath);
-        console.error(`[create_d365fo_file] Backup created: ${backupPath}`);
-      } catch (backupErr) {
-        console.error(`[create_d365fo_file] Warning: could not create backup: ${backupErr}`);
       }
     }
 
@@ -2260,6 +2306,10 @@ export async function handleCreateD365File(
     // are always present, regardless of whether xmlContent came from the template or a caller.
     if (args.objectType === 'report') {
       xmlContent = XmlTemplateGenerator.sanitizeReportXml(xmlContent);
+      // Convert remaining <Text><![CDATA[…]]></Text> to entity-encoded form.
+      // sanitizeReportXml operates on CDATA internally; this final step converts
+      // the output so that D365FO VS Designer renders the design correctly.
+      xmlContent = XmlTemplateGenerator.encodeReportTextElement(xmlContent);
     }
 
     // Debug: Log XML content length
@@ -2372,17 +2422,24 @@ export async function handleCreateD365File(
 
           if (wasAdded) {
             console.error(`[create_d365fo_file] Successfully added to project`);
-            projectMessage = `\n✅ Successfully added to Visual Studio project:\n📋 Project: ${projectPath}\n`;
+            projectMessage = `\n✅ Successfully added to Visual Studio project:\n📋 Project: ${projectPath}\n` +
+              `ℹ️  If the file does not appear in VS Solution Explorer, right-click the project → Reload Project.`;
           } else {
             console.error(`[create_d365fo_file] File already exists in project`);
             projectMessage = `\n✅ File already exists in Visual Studio project:\n📋 Project: ${projectPath}\n`;
           }
         } catch (projectError) {
+          const errMsg = projectError instanceof Error ? projectError.message : 'Unknown error';
+          const isLocked = errMsg.includes('EBUSY') || errMsg.includes('EPERM') || errMsg.includes('EACCES');
           console.error(
             `[create_d365fo_file] Failed to add to project:`,
             projectError
           );
-          projectMessage = `\n⚠️ File created but failed to add to project:\n${projectError instanceof Error ? projectError.message : 'Unknown error'}\n`;
+          projectMessage = `\n⚠️ File created but failed to add to project:\n${errMsg}\n` +
+            (isLocked
+              ? `This usually means Visual Studio has the .rnrproj file locked.\n` +
+                `Close Visual Studio (or unload the project), re-run the tool, then reopen.\n`
+              : '');
         }
       } else if (!projectMessage) {
         // No projectPath found from any source — surface this in the response so AI and user see it

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -66,9 +66,22 @@ class XmlTemplateGenerator {
     }
     if (classEndIdx === -1) return { declaration: fullSource, methods: [] };
 
-    const declaration = fullSource.substring(0, classEndIdx + 1);
+    let declaration = fullSource.substring(0, classEndIdx + 1);
     const rest = fullSource.substring(classEndIdx + 1);
     if (!rest.trim()) return { declaration, methods: [] };
+
+    // ── FIX: Rescue member-variable declarations that appear OUTSIDE the class {}
+    const nextBraceInRest = rest.indexOf('{');
+    if (nextBraceInRest !== -1) {
+      const preMethodText = rest.substring(0, nextBraceInRest);
+      const varLines = preMethodText
+        .split('\n')
+        .filter(l => { const t = l.trim(); return t.endsWith(';') && !t.includes('('); });
+      if (varLines.length > 0) {
+        const injected = varLines.map(l => '    ' + l.trim()).join('\n');
+        declaration = declaration.replace(/}(\s*)$/, `\n${injected}\n}`);
+      }
+    }
 
     // Parse each method block from the remaining source
     const methods: Array<{ name: string; source: string }> = [];
@@ -131,15 +144,19 @@ class XmlTemplateGenerator {
       ? `\t<IsAbstract>Yes</IsAbstract>\n`
       : '';
 
+    // D365FO convention: method source is always indented by 4 spaces inside <Source>.
+    const indentMethodSource = (src: string): string =>
+      src.split('\n').map(line => '    ' + line).join('\n');
+
     const methodsXml =
       methods.length === 0
         ? '\t\t<Methods />\n'
         : `\t\t<Methods>\n${methods
             .map(
               m =>
-                `\t\t\t<Method>\n\t\t\t\t<Name>${m.name}</Name>\n\t\t\t\t<Source><![CDATA[\n${m.source}\n]]></Source>\n\t\t\t</Method>`
+                `\t\t\t<Method>\n\t\t\t\t<Name>${m.name}</Name>\n\t\t\t\t<Source><!\[CDATA\[\n${indentMethodSource(m.source)}\n\]\]></Source>\n\t\t\t</Method>`
             )
-            .join('\n')}\n\t\t</Methods>\n`;
+            .join('\n\n')}\n\t\t</Methods>\n`;
 
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
@@ -699,7 +716,10 @@ ${rdlParamLayoutXml}
     const styleLine   = properties?.style   ? `\n\t\t\t<Style>${properties.style}</Style>`       : '';
     const rdlContent  = properties?.rdlContent as string | undefined;
     const rdl         = rdlContent || buildRdlSkeleton();
-    const textElement = `\n\t\t\t<Text><![CDATA[${rdl}]]></Text>`;
+    // D365FO Designer requires entity-encoded <Text> (not CDATA) to render the design.
+    const encodeForText = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const textElement = `\n\t\t\t<Text>${encodeForText(rdl)}</Text>`;
 
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxReport xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V2">
@@ -798,12 +818,23 @@ export async function handleGenerateD365Xml(
     }
 
     // Generate XML content
-    const xmlContent = XmlTemplateGenerator.generate(
+    let xmlContent = XmlTemplateGenerator.generate(
       args.objectType,
       args.objectName,
       args.sourceCode,
       args.properties
     );
+
+    // For reports: convert any remaining CDATA <Text> to entity-encoded form.
+    // The generator now emits entity-encoded directly, but guard against xmlContent
+    // passed in pre-generated form with CDATA.
+    if (args.objectType === 'report') {
+      xmlContent = xmlContent.replace(
+        /<Text><!\[CDATA\[([\s\S]*?)\]\]><\/Text>/g,
+        (_m, inner: string) =>
+          `<Text>${inner.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</Text>`
+      );
+    }
 
     console.error(
       `[generate_d365fo_xml] Generated XML content: ${xmlContent.length} bytes`

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -28,19 +28,26 @@ const ModifyD365FileArgsSchema = z.object({
   // For add-field / modify-field (tables)
   fieldName: z.string().optional().describe('Name of field to add/remove/modify/rename'),
   fieldNewName: z.string().optional().describe('New name for the field (required for rename-field operation)'),
-  fieldType: z.string().optional().describe('Extended data type or base type (for add-field: required; for modify-field: new EDT to set)'),
+  fieldType: z.string().optional().describe('EDT name for the field (for add-field: required — pass the EDT name, e.g. "InventQty", "WHSZoneId"). For modify-field: new EDT to set.'),
+  fieldBaseType: z.string().optional().describe(
+    'Base type that determines the XML element for add-field: String | Integer | Real | Date | DateTime | Int64 | GUID | Enum. ' +
+    'REQUIRED when fieldType is an EDT — pass the EDT base type so the correct AxTableFieldReal/AxTableFieldDate/… is used. ' +
+    'Examples: fieldType="InventQty" fieldBaseType="Real"; fieldType="TransDate" fieldBaseType="Date"; fieldType="ItemId" fieldBaseType="String". ' +
+    'Without this, all EDT fields default to AxTableFieldString which is WRONG for numeric/date types.'
+  ),
   fieldMandatory: z.boolean().optional().describe('Is field mandatory'),
   fieldLabel: z.string().optional().describe('Field label'),
   fields: z.array(z.object({
     name: z.string(),
     edt: z.string().optional(),
-    type: z.string().optional(),
+    type: z.string().optional().describe('Base type for the XML element: String|Real|Integer|Date|DateTime|Int64|GUID|Enum. REQUIRED when edt is an EDT name — without it defaults to AxTableFieldString!'),
     mandatory: z.boolean().optional(),
     label: z.string().optional(),
   })).optional().describe(
     'Full list of fields for replace-all-fields operation. Each item: { name, edt?, type?, mandatory?, label? }. ' +
-    'Use this to completely rewrite the Fields block — e.g. when field names are corrupted/have spaces. ' +
-    'All existing fields are replaced atomically. Backup is created automatically.'
+    'IMPORTANT: always pass type= the base type (String/Real/Integer/Date/DateTime/Int64/GUID) alongside edt= so the correct XML element is used. ' +
+    'Example: { name: "TransQty", edt: "InventQty", type: "Real" }. ' +
+    'All existing fields are replaced atomically.'
   ),
   
   // For modify-property
@@ -56,7 +63,7 @@ const ModifyD365FileArgsSchema = z.object({
   propertyValue: z.string().optional().describe('New property value'),
   
   // Options
-  createBackup: z.boolean().optional().default(true).describe('Create backup before modification'),
+  createBackup: z.boolean().optional().default(false).describe('Create backup before modification (default: false)'),
   modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
   packageName: z.string().optional().describe('Package name. Auto-resolved if omitted.'),
   workspacePath: z.string().optional().describe('Path to workspace for finding file'),
@@ -180,7 +187,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       content: [
         {
           type: 'text',
-          text: `✅ ${message}\n\n**File:** ${actualFilePath}\n**Backup:** ${createBackup ? 'Created' : 'Skipped'}\n\n**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate\n- Commit changes to source control`,
+          text: `✅ ${message}\n\n**File:** ${actualFilePath}\n\n**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate\n- Commit changes to source control`,
         },
       ],
     };
@@ -483,7 +490,7 @@ async function removeMethod(xmlObj: any, objectType: string, args: any): Promise
  * Add field to table
  */
 async function addField(xmlObj: any, objectType: string, args: any): Promise<boolean> {
-  const { fieldName, fieldType, fieldMandatory, fieldLabel } = args;
+  const { fieldName, fieldType, fieldBaseType, fieldMandatory, fieldLabel } = args;
 
   if (!fieldName) {
     throw new Error('fieldName is required for add-field operation');
@@ -526,7 +533,7 @@ async function addField(xmlObj: any, objectType: string, args: any): Promise<boo
 
   // D365FO field XML format: <AxTableField xmlns="" i:type="AxTableFieldString">
   // xml2js represents this as { '$': { xmlns: '', 'i:type': 'AxTableFieldString' }, Name: [...] }
-  const iType = getFieldNodeName(fieldType);
+  const iType = getFieldNodeName(fieldBaseType || fieldType);
   const newField: any = {
     '$': { xmlns: '', 'i:type': iType },
     Name: [fieldName],
@@ -701,7 +708,6 @@ async function renameField(xmlObj: any, objectType: string, args: any): Promise<
 /**
  * Atomically replace ALL fields in a table with a new field list.
  * Use when field names are corrupted (contain spaces, wrong EDTs, etc.).
- * Backup is always created before the operation.
  */
 async function replaceAllFields(xmlObj: any, objectType: string, args: any): Promise<boolean> {
   const { fields } = args as { fields?: Array<{ name: string; edt?: string; type?: string; mandatory?: boolean; label?: string }> };
@@ -745,7 +751,9 @@ async function replaceAllFields(xmlObj: any, objectType: string, args: any): Pro
 
   // Build new AxTableField array
   const newAxTableFields = fields.map(f => {
-    const iType = f.edt ? getFieldNodeName(f.edt) : getFieldNodeName(f.type || 'String');
+    // type= is the explicit base type override (Real/String/Date/…); edt= is the EDT name.
+    // Priority: explicit type > edt name lookup > default String
+    const iType = f.type ? getFieldNodeName(f.type) : getFieldNodeName(f.edt || 'String');
     const node: any = {
       '$': { xmlns: '', 'i:type': iType },
       Name: [f.name],
@@ -943,6 +951,6 @@ function getFieldNodeName(fieldType: string): string {
 
 export const modifyD365FileToolDefinition = {
   name: 'modify_d365fo_file',
-  description: '✏️ Edit existing D365FO XML files (AxClass, AxTable, AxForm, etc.). Supports atomic operations: add/remove methods, add/remove fields, modify properties. Creates automatic backups. Use this instead of manual file editing to ensure correct XML structure.',
+  description: '✏️ Edit existing D365FO XML files (AxClass, AxTable, AxForm, etc.). Supports atomic operations: add/remove methods, add/remove fields, modify properties. Use this instead of manual file editing to ensure correct XML structure.',
   inputSchema: ModifyD365FileArgsSchema,
 };

--- a/tests/tools/createD365File.test.ts
+++ b/tests/tools/createD365File.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for XmlTemplateGenerator — specifically:
+ *  - splitXppClassSource: Declaration / Methods separation
+ *  - generateAxClassXml: full AxClass XML output
+ *
+ * Key scenario covered: member variable declarations that appear OUTSIDE the
+ * class {} body (e.g. emitted by some AI generators) must be automatically
+ * rescued and injected into the <Declaration> block, not silently dropped.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { XmlTemplateGenerator } from '../../src/tools/createD365File';
+
+describe('XmlTemplateGenerator.splitXppClassSource()', () => {
+
+  // ─────────────────────────────────────────────────────────────
+  // Happy path — variables correctly inside class {}
+  // ─────────────────────────────────────────────────────────────
+
+  it('should split class header + member vars (inside {}) from methods', () => {
+    const source = `public class MyClass
+{
+    int globalPackageNumber;
+    Qty totalExportedQty;
+}
+
+public int globalPackageNumber(int _v = globalPackageNumber)
+{
+    globalPackageNumber = _v;
+    return globalPackageNumber;
+}`;
+
+    const { declaration, methods } = XmlTemplateGenerator.splitXppClassSource(source);
+
+    expect(declaration).toContain('int globalPackageNumber;');
+    expect(declaration).toContain('Qty totalExportedQty;');
+    expect(declaration).toMatch(/\}$/); // must end with closing brace
+    expect(methods).toHaveLength(1);
+    expect(methods[0].name).toBe('globalPackageNumber');
+  });
+
+  it('should handle a class with no methods and no member vars', () => {
+    const source = `public class Simple\n{\n}`;
+    const { declaration, methods } = XmlTemplateGenerator.splitXppClassSource(source);
+    expect(declaration).toBe('public class Simple\n{\n}');
+    expect(methods).toHaveLength(0);
+  });
+
+  it('should handle multiple methods correctly', () => {
+    const source = `public class MyDP extends SrsReportDataProviderBase
+{
+    MyTmp tmpTable;
+}
+public void processReport()
+{
+    // fill tmp
+}
+protected void postProcessReport()
+{
+    super();
+}`;
+    const { declaration, methods } = XmlTemplateGenerator.splitXppClassSource(source);
+    expect(declaration).toContain('MyTmp tmpTable;');
+    expect(methods).toHaveLength(2);
+    expect(methods[0].name).toBe('processReport');
+    expect(methods[1].name).toBe('postProcessReport');
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Rescue scenario — variables OUTSIDE the class {} (AI mistake)
+  // ─────────────────────────────────────────────────────────────
+
+  it('should rescue member variable declarations placed OUTSIDE the class {}', () => {
+    // This is the bug pattern: AI emits member vars after the class closing brace
+    const source = `public class CustPackingSlipJournal
+{
+}
+
+int globalPackageNumber;
+Qty totalExportedOrderUnitQty, totalExportedInventUnitQty;
+
+public void newCustPackingSlipJournal()
+{
+    super();
+}`;
+
+    const { declaration, methods } = XmlTemplateGenerator.splitXppClassSource(source);
+
+    // Variables must be injected into the declaration block
+    expect(declaration).toContain('int globalPackageNumber;');
+    expect(declaration).toContain('Qty totalExportedOrderUnitQty, totalExportedInventUnitQty;');
+
+    // Declaration must still close with }
+    expect(declaration.trimEnd()).toMatch(/\}$/);
+
+    // Method should still be parsed correctly
+    expect(methods).toHaveLength(1);
+    expect(methods[0].name).toBe('newCustPackingSlipJournal');
+  });
+
+  it('should not rescue lines that look like method calls (contain parentheses)', () => {
+    const source = `public class MyClass
+{
+}
+
+SomeHelper::construct();   // ← this is a stray call, not a var declaration
+
+public void run()
+{
+    // body
+}`;
+    const { declaration, methods } = XmlTemplateGenerator.splitXppClassSource(source);
+
+    // The stray call line (contains '(') must NOT be injected
+    expect(declaration).not.toContain('SomeHelper::construct()');
+    expect(methods).toHaveLength(1);
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // Edge cases
+  // ─────────────────────────────────────────────────────────────
+
+  it('should return fullSource as declaration when there is no opening brace', () => {
+    const source = 'public class Broken';
+    const { declaration, methods } = XmlTemplateGenerator.splitXppClassSource(source);
+    expect(declaration).toBe(source);
+    expect(methods).toHaveLength(0);
+  });
+
+  it('should handle attribute annotations before the class header', () => {
+    const source = `[DataContractAttribute]
+public class MyContract
+{
+    str myField;
+}
+public str myField(str _v = myField)
+{
+    myField = _v;
+    return myField;
+}`;
+    const { declaration, methods } = XmlTemplateGenerator.splitXppClassSource(source);
+    expect(declaration).toContain('[DataContractAttribute]');
+    expect(declaration).toContain('str myField;');
+    expect(methods).toHaveLength(1);
+    expect(methods[0].name).toBe('myField');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateAxClassXml — XML output shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('XmlTemplateGenerator.generateAxClassXml()', () => {
+
+  it('should produce Declaration block containing member variables inside class {}', () => {
+    const source = `public class MyClass
+{
+    int counter;
+    str description;
+}
+public void increment()
+{
+    counter++;
+}`;
+
+    const xml = XmlTemplateGenerator.generateAxClassXml('MyClass', source);
+
+    // <Declaration> CDATA must include the member variables
+    expect(xml).toContain('int counter;');
+    expect(xml).toContain('str description;');
+
+    // <Methods> section must contain the method
+    expect(xml).toContain('<Name>increment</Name>');
+    expect(xml).toContain('<Source><![CDATA[');
+
+    // D365FO convention: method source always starts with 4-space indent
+    const sourceStart = xml.indexOf('<Source><![CDATA[\n') + '<Source><![CDATA[\n'.length;
+    const firstMethodLine = xml.substring(sourceStart, xml.indexOf('\n', sourceStart));
+    expect(firstMethodLine).toMatch(/^    /); // must start with 4 spaces
+  });
+
+  it('should indent ALL lines of multi-line method bodies with 4 spaces', () => {
+    const source = `public class MyDP
+{
+}
+public void processReport()
+{
+    // line 1
+    // line 2
+}`;
+    const xml = XmlTemplateGenerator.generateAxClassXml('MyDP', source);
+    const sourceMatch = xml.match(/<Source><!\[CDATA\[\n([\s\S]*?)\n\]\]><\/Source>/);
+    expect(sourceMatch).toBeTruthy();
+    const methodLines = sourceMatch![1].split('\n').filter(l => l.trim());
+    // Every non-empty line must be indented by at least 4 spaces
+    for (const line of methodLines) {
+      expect(line).toMatch(/^    /);
+    }
+  });
+
+  it('should separate multiple methods with a single blank line', () => {
+    const source = `public class MyClass
+{
+}
+public void first()
+{
+    // a
+}
+public void second()
+{
+    // b
+}
+public void third()
+{
+    // c
+}`;
+    const xml = XmlTemplateGenerator.generateAxClassXml('MyClass', source);
+
+    // Between </Method> and the next <Method> there must be exactly one blank line
+    const between = xml.match(/<\/Method>\n(\n?)\t\t\t<Method>/g);
+    expect(between).toBeTruthy();
+    // Every gap must contain exactly one \n (making it \n\n total = blank line)
+    for (const gap of between!) {
+      expect(gap).toBe('</Method>\n\n\t\t\t<Method>');
+    }
+  });
+
+  it('should rescue variables from outside {} into <Declaration> in generated XML', () => {
+    // Simulate the common AI mistake: vars emitted after class body
+    const source = `public class MyClass
+{
+}
+int globalPackageNumber;
+Qty totalQty;
+
+public void run()
+{
+    // body
+}`;
+
+    const xml = XmlTemplateGenerator.generateAxClassXml('MyClass', source);
+
+    // Even though vars were outside {}, they must appear in <Declaration>
+    const declStart = xml.indexOf('<Declaration><![CDATA[');
+    const declEnd = xml.indexOf(']]></Declaration>');
+    expect(declStart).toBeGreaterThan(-1);
+    expect(declEnd).toBeGreaterThan(declStart);
+    const declContent = xml.substring(declStart, declEnd);
+
+    expect(declContent).toContain('int globalPackageNumber;');
+    expect(declContent).toContain('Qty totalQty;');
+  });
+
+  it('should produce a default empty class when no sourceCode provided', () => {
+    const xml = XmlTemplateGenerator.generateAxClassXml('EmptyClass');
+    expect(xml).toContain('<Name>EmptyClass</Name>');
+    expect(xml).toContain('<Declaration><![CDATA[');
+    expect(xml).toContain('<Methods />');
+  });
+
+  it('should include Extends property when supplied', () => {
+    const xml = XmlTemplateGenerator.generateAxClassXml('MyBatch', undefined, { extends: 'RunBaseBatch' });
+    expect(xml).toContain('<Extends>RunBaseBatch</Extends>');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// encodeReportTextElement — CDATA → entity encoding for <Text>
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('XmlTemplateGenerator.encodeReportTextElement()', () => {
+
+  it('should convert <Text><![CDATA[...]]></Text> to entity-encoded form', () => {
+    const rdl = '<Report><Body /></Report>';
+    const input = `<AxReport><Designs><AxReportDesign><Text><![CDATA[${rdl}]]></Text></AxReportDesign></Designs></AxReport>`;
+    const result = XmlTemplateGenerator.encodeReportTextElement(input);
+
+    expect(result).toContain('<Text>&lt;Report&gt;&lt;Body /&gt;&lt;/Report&gt;</Text>');
+    expect(result).not.toContain('<![CDATA[');
+  });
+
+  it('should be idempotent — entity-encoded input is not double-encoded', () => {
+    const rdl = '<Report><Body /></Report>';
+    const input = `<AxReport><Designs><AxReportDesign><Text><![CDATA[${rdl}]]></Text></AxReportDesign></Designs></AxReport>`;
+    const once = XmlTemplateGenerator.encodeReportTextElement(input);
+    const twice = XmlTemplateGenerator.encodeReportTextElement(once);
+    expect(twice).toBe(once); // second pass: no CDATA found → unchanged
+  });
+
+  it('should encode & before < and > to avoid double-encoding', () => {
+    const rdl = '<Report>&amp; test <Body /></Report>';
+    const input = `<AxReport><Text><![CDATA[${rdl}]]></Text></AxReport>`;
+    const result = XmlTemplateGenerator.encodeReportTextElement(input);
+    // & → &amp; first, then < → &lt; and > → &gt;
+    expect(result).toContain('&amp;amp;');
+    expect(result).toContain('&lt;Report&gt;');
+  });
+
+  it('should leave non-CDATA <Text> elements unchanged', () => {
+    const input = '<AxReport><Name>R</Name><Text>already encoded</Text></AxReport>';
+    const result = XmlTemplateGenerator.encodeReportTextElement(input);
+    expect(result).toBe(input);
+  });
+});


### PR DESCRIPTION
This pull request introduces several improvements and clarifications to the D365FO MCP toolset, with a particular focus on member variable handling in AxClass source code, schema and documentation updates, and bug fixes for XML generation. The changes help prevent common errors when creating or modifying objects, improve guidance for developers, and enhance the reliability of file operations.

**AxClass Member Variable Handling**

* Added explicit instructions and examples in `.github/copilot-instructions.md` and `src/server/mcpServer.ts` to clarify that member variable declarations must be placed inside the class `{ }` body in `sourceCode` for correct AxClass XML generation. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R102-R142) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R487-R510)
* Updated schema descriptions for `sourceCode` in API input to reinforce the required format for AxClass member variables. [[1]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L516-R540) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L576-R600)
* Implemented logic in `XmlTemplateGenerator.splitXppClassSource` to detect and rescue member variable declarations mistakenly placed outside the class `{}` block, injecting them into the `<Declaration>` section of the generated XML.

**Schema and Documentation Updates**

* Improved the documentation for `modify_d365fo_file` and related APIs, clarifying the usage of backup and the requirements for field types and base types when adding or replacing fields. [[1]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L701-R735) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L717-R766)
* Changed the default for `createBackup` to `false` and updated descriptions to match new backup behavior.
* Updated tool descriptions and UI text to remove references to automatic backup creation during overwrite operations, reflecting the new behavior. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL70-R70) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L643-R667) [[3]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL2210-L2224)

**Bug Fixes and Reliability Improvements**

* Fixed method source indentation in generated AxClass XML to match D365FO conventions, ensuring compatibility with the compiler and Designer.
* Added a new method to convert `<Text><![CDATA[…]]></Text>` to XML entity-encoded form for SSRS reports, ensuring correct rendering in Visual Studio Designer. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR1668-R1692) [[2]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR2309-R2312)
* Improved error handling and messaging when adding files to Visual Studio projects, including guidance for resolving locked project files.

**Minor Instruction and UI Updates**

* Removed references to automatic `.bak` backup creation from overwrite and replace-all-fields operations in documentation and UI. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L43-R43) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L547-R571) [[3]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L717-R766) [[4]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL70-R70) [[5]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL2210-L2224)

These changes collectively help prevent common mistakes, improve the developer experience, and ensure the generated files are compatible with D365FO standards.- add-field: new fieldBaseType param (Real/Date/Int64/etc) ensures correct AxTableFieldReal/AxTableFieldDate/ XML element instead of always AxTableFieldString
- replace-all-fields: type= now takes priority over edt= for XML element lookup, fixing numeric/date fields that were silently written as AxTableFieldString
- remove all .bak / backup file creation (createD365File overwrite path, modifyD365File default createBackup=false)
- addToProject: add VS reload hint on success; detect EBUSY/EPERM file-lock and surface actionable message
- mcpServer schema: fieldBaseType enum, updated fields[].type description
- AxClass: rescue member vars outside class {}, 4-space method indent, blank line between methods
- AxReport: entity-encode Text element so VS Designer renders design correctly