### PR TITLE
fix: ensure configuration is loaded before retrieving package path in…

### DIFF
--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -343,7 +343,10 @@ export async function handleGenerateSmartTable(
   }
 
   // Determine package path
+  // Ensure .mcp.json is loaded before reading packagePath — getPackagePath() is synchronous
+  // and may miss packagePath from config if ensureLoaded() was not yet called.
   const configManager = getConfigManager();
+  await configManager.ensureLoaded();
   const resolvedPackagePath = argPackagePath || configManager.getPackagePath();
   // getPackagePath() already probes C:\ and K:\ well-known locations before returning null,
   // so reaching here with null means neither location exists on this machine.


### PR DESCRIPTION
This pull request addresses an issue in the `handleGenerateSmartTable` function to ensure configuration is properly loaded before determining the package path. The main change is to call `ensureLoaded()` on the configuration manager before accessing the package path, which prevents potential errors when the configuration has not yet been loaded.

Configuration loading reliability:

* Added an explicit call to `await configManager.ensureLoaded()` before reading the package path, ensuring the configuration is loaded and avoiding missing or incorrect values from `getPackagePath()`. (`src/tools/generateSmartTable.ts`, [src/tools/generateSmartTable.tsR346-R349](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR346-R349))… handleGenerateSmartTable