### PR TITLE
feat: add 9 security/extension tools, new generate_code patterns, and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,42 @@
 
 <div align="center">
 
-**GitHub Copilot with full knowledge of your D365 F&O codebase**
+**40 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
 
+*Built for D365FO developers who write X++ in Visual Studio — not for generic web dev*
+
 </div>
 
 ---
 
-## What Is This?
+## Why this exists
 
-An MCP server that gives GitHub Copilot access to your D365 F&O codebase — 584,799+ symbols indexed in SQLite FTS5. Copilot then knows exact method signatures, field types, class hierarchies, and generates X++ code that compiles on the first try.
+GitHub Copilot is great at C#, Python, and JavaScript. It struggles with X++ because it doesn't know your D365FO codebase: method signatures, field types, which CoC extensions already exist, or how your custom ISV code is structured.
+
+This MCP server pre-indexes your entire D365FO installation — 584,799+ symbols — and makes it available to Copilot as 40 specialized tools. Copilot stops guessing and starts generating code that compiles on the first try.
 
 ```
-┌─────────────────────┐    MCP/HTTP     ┌──────────────────────────────────┐
-│  GitHub Copilot     │ ◄────────────► │  D365 F&O MCP Server             │
-│  (Agent Mode)       │                 │                                  │
-│                     │                 │  ┌─────────┐   ┌──────────────┐ │
-│  "Show methods of   │                 │  │ Symbols │   │ Labels       │ │
-│   SalesTable"       │                 │  │  ~1 GB  │   │  ~8 GB       │ │
-│                     │                 │  │ 584K+   │   │ 19M+ labels  │ │
-│  ← answer in 50ms   │                 │  │ symbols │   │ 70 languages │ │
-└─────────────────────┘                 │  └─────────┘   └──────────────┘ │
-                                        └──────────────────────────────────┘
+┌─────────────────────────┐   MCP / HTTP    ┌────────────────────────────────────┐
+│  GitHub Copilot          │ ◄────────────► │  D365 F&O MCP Server               │
+│  (Agent Mode)            │                 │                                    │
+│                          │                 │  ┌──────────────┐  ┌────────────┐ │
+│  "Create a CoC for       │                 │  │ 584K+ symbols │  │ 19M labels │ │
+│   SalesTable.insert()"   │                 │  │ SQLite FTS5   │  │ 70 langs   │ │
+│                          │                 │  │ < 50ms resp.  │  │            │ │
+│  ← compiles first try    │                 │  └──────────────┘  └────────────┘ │
+└─────────────────────────┘                 └────────────────────────────────────┘
 ```
 
 | Without this server | With this server |
 |---------------------|-----------------|
-| Copilot guesses method names → compile errors | Exact signatures → code works |
-| Searching in AOT: 5–30 minutes | Answer in < 50 ms |
-| 584,799 symbols with no fast search | Everything indexed and instantly available |
+| Copilot guesses method signatures → compile errors | Exact signatures from your actual codebase |
+| "Does CustTable.validateWrite() have any CoC wrappers?" requires manual AOT search | `find_coc_extensions` answers in < 50 ms |
+| ISV extensions invisible to Copilot | Custom models fully indexed and searchable |
+| Security hierarchy takes hours to trace manually | `get_security_coverage_for_object` traces Role → Duty → Privilege → Entry Point instantly |
 
 ---
 
@@ -43,17 +47,17 @@ An MCP server that gives GitHub Copilot access to your D365 F&O codebase — 584
 git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git
 cd d365fo-mcp-server
 npm install
-copy .env.example .env          # Fill in PACKAGES_PATH and CUSTOM_MODELS
-npm run extract-metadata         # Extract XML from D365FO packages
+copy .env.example .env          # Set PACKAGES_PATH and CUSTOM_MODELS
+npm run extract-metadata         # Extract XML from D365FO packages (~10–60 min)
 npm run build-database           # Build SQLite index (~5–20 min)
-npm run dev                      # Server running at http://localhost:3000
+npm run dev                      # Server at http://localhost:3000
 ```
 
-> **UDE (Power Platform Tools)?** Run `npm run select-config` instead of setting `PACKAGES_PATH`.
+> **UDE / Power Platform Tools?** Run `npm run select-config` instead of setting `PACKAGES_PATH` manually.
 
 ---
 
-## GitHub Copilot Setup
+## Connect to GitHub Copilot
 
 **1.** Enable *Editor Preview Features* at **github.com/settings/copilot/features**
 
@@ -74,71 +78,86 @@ npm run dev                      # Server running at http://localhost:3000
 }
 ```
 
-The server automatically locates your `.rnrproj`, extracts the correct model name, and writes new files to the right place in AOT. `workspacePath` is the only setting most users ever need.
-
-> **Full options** (UDE paths, explicit projectPath, solutionPath): see [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md)
-
-**4.** Copy Copilot instructions to your solution root:
+**4.** Copy the Copilot instruction files so Copilot knows the D365FO workflow rules:
 
 ```powershell
 Copy-Item -Path ".github" -Destination "C:\Path\To\YourSolution\" -Recurse
 ```
 
+> **Full config options** (UDE paths, explicit projectPath, solutionPath): [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md)
+
 ---
 
-## What It Can Do — 29 Tools
+## What Copilot can do — 40 X++ tools
 
-### 🔍 Code Search & Navigation
-| Prompt | What happens |
-|--------|-------------|
-| `What methods does SalesTable have?` | Returns all methods with their signatures |
-| `Find classes related to invoicing` | Full-text search across 584K+ symbols |
-| `Where is CustTable.validateWrite() used?` | Where-used analysis across the entire codebase |
-| `Show me the structure of CustTable` | Fields with EDTs, indexes, foreign key relations |
+### Search & Discovery
+| Ask Copilot | Tool used |
+|-------------|-----------|
+| `What methods does SalesTable have?` | `get_table_info` |
+| `Find all classes related to dimension validation` | `search` |
+| `Does CustTable have any CoC extensions in our code?` | `find_coc_extensions` |
+| `Show me only our ISV customizations, not Microsoft code` | `search_extensions` |
+| `Who calls SalesFormLetter.run()?` | `find_references` |
+| `Search for "invoice" and "posting" at the same time` | `batch_search` |
 
-### ⚡ Code Generation
-| Prompt | What happens |
-|--------|-------------|
-| `Create a CoC extension for SalesTable.validateWrite()` | Exact signature + boilerplate |
-| `How is LedgerJournalEngine initialized?` | Patterns from your own codebase |
-| `Is my class MyHelper missing any standard methods?` | Class completeness analysis |
-| `Create a batch job for order processing` | Complete batch job template |
+### Code Generation
+| Ask Copilot | Tool used |
+|-------------|-----------|
+| `Write a CoC extension for SalesTable.insert()` | `get_method_signature` + `generate_code` |
+| `Create a SysOperation batch job for order processing` | `generate_code` (sysoperation pattern) |
+| `Add an event handler for CustTable.onInserted` | `generate_code` (event-handler pattern) |
+| `How is LedgerJournalEngine used in our codebase?` | `get_api_usage_patterns` |
+| `Is my new helper class missing any standard methods?` | `analyze_class_completeness` |
 
-### 🎨 Smart Object Generation
-| Prompt | What happens |
-|--------|-------------|
-| `Generate a transaction table with common fields` | AI-driven table with intelligent field/index suggestions |
-| `Create a SimpleList form for MyOrderTable` | AI-driven form with datasource and grid controls |
-| `What EDT should I use for CustomerAccount field?` | Suggests EDTs using fuzzy matching and pattern analysis |
+### Object Inspection
+| Ask Copilot | Tool used |
+|-------------|-----------|
+| `Show me the full source of SalesFormLetter` | `get_class_info` |
+| `What fields and indexes does InventTable have?` | `get_table_info` |
+| `Show me the SalesTable form structure` | `get_form_info` |
+| `What values does SalesStatus enum have?` | `get_enum_info` |
+| `What EDT should I use for a customer account field?` | `suggest_edt` |
+| `Show me the ancestor chain of AccountNum EDT` | `get_edt_info` (hierarchy mode) |
 
-### 🏷️ Label Management
-| Prompt | What happens |
-|--------|-------------|
-| `Find a label for "customer"` | Searches all AxLabelFile objects |
-| `Translations of label MyFeature in model MyModel` | All languages at once |
-| `Create a new label MyNewField in MyModel` | Writes to all .label.txt files |
-| `Rename label OldName to NewName in MyModel` | Renames ID in .label.txt, X++ source and XML metadata |
+### Smart Object Creation *(local VM only)*
+| Ask Copilot | Tool used |
+|-------------|-----------|
+| `Generate a transaction table with common fields` | `generate_smart_table` |
+| `Create a SimpleList form for MyOrderTable` | `generate_smart_form` |
+| `Create a security privilege + duty for our new form` | `generate_code` (security-privilege pattern) |
+| `Add a new field TransQty (EDT: InventQty) to my table` | `modify_d365fo_file` |
+| `Create a new class and add it to the VS project` | `create_d365fo_file` |
 
-### 📝 File Operations *(local VM only)*
-- Generates correct D365FO XML for classes, tables, forms, enums
-- Writes the file directly to the right location in AOT
-- Automatically adds the file to `.rnrproj`
-- Creates a backup before every change
+### Security & Extensions
+| Ask Copilot | Tool used |
+|-------------|-----------|
+| `What roles have access to the CustTable form?` | `get_security_coverage_for_object` |
+| `Show me the full privilege chain for AccountsReceivableClerk` | `get_security_artifact_info` |
+| `What extension points does SalesLine have?` | `analyze_extension_points` |
+| `Which models extend CustTable?` | `get_table_extension_info` |
+| `Is the onInserted event on SalesLine already handled?` | `find_event_handlers` |
+
+### Label Management
+| Ask Copilot | Tool used |
+|-------------|-----------|
+| `Find an existing label for "customer account"` | `search_labels` |
+| `Create label MyNewField in MyModel (EN + CS)` | `create_label` |
+| `Rename label OldName to NewName everywhere` | `rename_label` |
 
 ---
 
 ## Azure Deployment
 
-Host the server on Azure App Service — the entire team shares a single instance.
+Host on Azure App Service so the whole team shares one instance — nobody needs the server running locally.
 
 | Resource | Configuration | Monthly cost |
 |----------|---------------|-------------|
 | App Service P0v3 | 1 vCPU, 4 GB RAM | ~$62 |
-| Blob Storage | 2 GB (symbols + labels) | ~$3 |
+| Blob Storage | 2 GB (symbols + labels DB) | ~$3 |
 | Redis Cache (optional) | Basic C0 | ~$16 |
 | **Total without Redis** | | **~$65 / month** |
 
-The database is automatically downloaded from Azure Blob Storage on server startup.
+The database downloads from Azure Blob Storage automatically on startup.
 
 Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.md](docs/PIPELINES.md)
 
@@ -150,8 +169,8 @@ Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.m
 |------|---------|
 | [docs/SETUP.md](docs/SETUP.md) | Installation, configuration, Azure deployment |
 | [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md) | `.mcp.json` reference — workspace paths, UDE, project settings |
-| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 29 tools with example prompts |
-| [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md) | Practical examples: search, generation, CoC |
+| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 40 tools with parameters and example prompts |
+| [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md) | Practical examples: search, CoC, SysOperation, security |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Technical architecture, dual-database design |
 | [docs/CUSTOM_EXTENSIONS.md](docs/CUSTOM_EXTENSIONS.md) | ISV / custom model configuration |
 | [docs/PIPELINES.md](docs/PIPELINES.md) | Automated metadata extraction via Azure DevOps |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ graph TB
     subgraph "MCP Server Components"
         HTTP[HTTP Transport Layer - Express + Rate Limiting]
         PROTO[MCP Protocol Handler - JSON-RPC 2.0]
-        TOOLS[Tool Handlers - 29 MCP Tools]
+        TOOLS[Tool Handlers - 40 MCP Tools]
         DB[(Symbols Database - FTS5, 584K+ symbols)]
         LDB[(Labels Database - FTS5, 19M+ labels, 70 languages)]
         CACHE[Redis Cache - Optional]
@@ -82,7 +82,7 @@ sequenceDiagram
     alt Initialize
         MCP-->>IDE: Server Capabilities
     else Tools List
-        MCP-->>IDE: 29 Tool Definitions
+        MCP-->>IDE: 40 Tool Definitions
     else Tool Call
         MCP->>Handler: Route to Handler
         Handler->>Tool: Execute Tool
@@ -521,7 +521,7 @@ graph LR
     subgraph "MCP Protocol Methods"
         INIT[initialize - Server Capabilities]
         NOTIFY[notifications/initialized - Handshake Complete]
-        TOOLS_LIST[tools/list - 29 Available Tools]
+        TOOLS_LIST[tools/list - 40 Available Tools]
         TOOLS_CALL[tools/call - Execute Tool]
         RES_LIST[resources/list - Empty]
         RES_TMPL[resources/templates/list - Empty]
@@ -530,7 +530,7 @@ graph LR
     end
 
     INIT -.-> CAPS[Capabilities: tools, resources, prompts]
-    TOOLS_LIST -.-> TOOL_DEFS["29 tools: search, batch_search, search_extensions, get_class_info, get_table_info, code_completion, get_method_signature, find_references, get_form_info, get_query_info, get_view_info, get_enum_info, get_edt_info, generate_code, analyze_code_patterns, suggest_method_implementation, analyze_class_completeness, get_api_usage_patterns, generate_d365fo_xml, create_d365fo_file, modify_d365fo_file, search_labels, get_label_info, create_label, get_table_patterns, get_form_patterns, generate_smart_table, generate_smart_form, suggest_edt"]
+    TOOLS_LIST -.-> TOOL_DEFS["40 tools: search, batch_search, search_extensions, get_class_info, get_table_info, code_completion, get_method_signature, find_references, get_form_info, get_query_info, get_view_info, get_enum_info, get_edt_info, get_report_info, generate_code, analyze_code_patterns, suggest_method_implementation, analyze_class_completeness, get_api_usage_patterns, generate_d365fo_xml, create_d365fo_file, modify_d365fo_file, search_labels, get_label_info, create_label, rename_label, get_table_patterns, get_form_patterns, generate_smart_table, generate_smart_form, suggest_edt, get_security_artifact_info, get_security_coverage_for_object, get_menu_item_info, find_coc_extensions, find_event_handlers, get_table_extension_info, get_data_entity_info, analyze_extension_points, validate_object_naming"]
     TOOLS_CALL -.-> EXEC[Tool Execution: search DB, parse XML, return results]
     style INIT fill:#4CAF50,color:#fff
     style TOOLS_CALL fill:#2196F3,color:#fff

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -225,8 +225,8 @@ When the server starts, it logs the detected mode and tool count:
 **Full mode (local development):**
 ```
 🔧 Server mode: full (from env: not set, defaulting to full)
-🎯 Registered 29 X++ MCP tools (8 discovery + 3 labels + 5 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis)
-[MCP Server] Tool list in full mode: 29 tools (no filtering)
+🎯 Registered 40 X++ MCP tools (8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis + 9 security-extensions)
+[MCP Server] Tool list in full mode: 40 tools (no filtering)
 ```
 
 > **Note:** The local server in `write-only` mode still needs access to the metadata database

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,7 +1,7 @@
 # All Available Tools
 
 When you ask GitHub Copilot a question about D365FO code, it automatically calls one of these
-30 tools to look up the answer or generate code. You do not need to name the tools yourself —
+40 tools to look up the answer or generate code. You do not need to name the tools yourself —
 just ask in plain English.
 
 ---
@@ -65,7 +65,21 @@ just ask in plain English.
 | **create_d365fo_file** | Local Windows VM only | Creates the physical file and adds it to the VS project |
 | **modify_d365fo_file** | Local Windows VM only | Safely edits an existing file with automatic backup |
 
-### Label Management (3 tools)
+### Security & Extensions (9 tools)
+
+| Tool | What it does | Example prompt |
+|------|-------------|---------------|
+| **get_security_artifact_info** | Full privilege/duty/role details with hierarchy chain | "Show me everything in the CustTableFullControl privilege" |
+| **get_security_coverage_for_object** | Which roles have access to a form or table | "What roles can access the CustTable form?" |
+| **get_menu_item_info** | Menu item target, type, and security privilege chain | "What form does the CustTable menu item open?" |
+| **find_coc_extensions** | Which classes wrap a method with CoC | "Does CustTable.validateWrite have any CoC wrappers?" |
+| **find_event_handlers** | All [SubscribesTo] handlers for table or class events | "Who handles the onInserted event of SalesLine?" |
+| **get_table_extension_info** | All extensions of a table: added fields, indexes, methods | "What fields did ISV packages add to CustTable?" |
+| **get_data_entity_info** | Data entity category, OData name, data sources, keys | "Show me CustCustomerV3Entity details" |
+| **analyze_extension_points** | CoC-eligible methods, delegates, events — what can be extended | "What can I extend on SalesLine?" |
+| **validate_object_naming** | Validate proposed extension/object names against D365FO conventions | "Is SalesTableExtension a valid extension class name?" |
+
+### Label Management (4 tools)
 
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -10,11 +10,12 @@ Practical examples you can copy and paste directly into Copilot Chat.
 - [Generating New Classes](#generating-new-classes)
 - [Creating Files](#creating-files)
 - [Where-Used Analysis](#where-used-analysis)
-- [Batch Jobs](#batch-jobs)
+- [Batch Jobs (SysOperation)](#batch-jobs-sysoperation)
 - [Financial Dimensions](#financial-dimensions)
 - [Ledger Journals](#ledger-journals)
 - [Form Extensions](#form-extensions)
 - [Working with Labels](#working-with-labels)
+- [Security and Extensions](#security-and-extensions)
 
 ---
 
@@ -404,3 +405,132 @@ Search for labels containing "dávk" in Czech (cs) language
 
 Use the `language` parameter in `search_labels` to restrict results to a
 specific locale.
+
+---
+
+## Security and Extensions
+
+### Trace the security chain for a form
+
+```
+What roles have access to the CustTable form?
+```
+
+Copilot calls `get_security_coverage_for_object` and returns the complete chain:
+form → menu items → privileges → duties → roles. No AOT browsing required.
+
+```
+Who has access to the SalesTable form?
+Which roles can open the VendTable form?
+```
+
+### Inspect a security privilege
+
+```
+Show me everything in the CustTableFullControl privilege
+What entry points does the CustTableView privilege require?
+```
+
+Copilot calls `get_security_artifact_info` with `artifactType: privilege` and returns
+the privilege label, every entry point name, object type, and access level granted.
+
+### Trace a duty and its privileges
+
+```
+Show me the full privilege chain for the CustTableMaintain duty
+Which privileges are in the AccountsPayableInquire duty?
+```
+
+With `includeChain: true` (the default), Copilot walks: Duty → Privileges → EntryPoints
+and returns the full three-level breakdown in one response.
+
+### Check what CoC extensions already exist
+
+Before you write a new Chain of Command extension, check whether the method is already
+wrapped — avoids duplicating logic or breaking existing wrappers.
+
+```
+Does CustTable.validateWrite have any CoC extensions?
+Are there any CoC wrappers for SalesFormLetter.run()?
+```
+
+Copilot calls `find_coc_extensions` and lists every extension class that wraps the method,
+which model it belongs to, and whether it calls `next`.
+
+### Find event handlers for a table
+
+```
+Who handles the onInserted event of SalesLine?
+Are there any event handlers subscribed to CustTable events?
+```
+
+Copilot calls `find_event_handlers` and lists all `[SubscribesTo]` static methods
+for the table, grouped by event name (onInserted, onUpdated, onValidatedWrite, …).
+
+### See what a table extension adds
+
+```
+What extra fields has any ISV added to CustTable?
+Show me all extensions of the InventTable table
+```
+
+Copilot calls `get_table_extension_info` and returns each extension's model, added fields,
+added indexes, and added methods — plus an effective schema that merges base + extensions.
+
+### Inspect a data entity
+
+```
+Show me the CustCustomerV3Entity data entity
+Is CustCustomerV3Entity available via OData?
+What tables does SalesOrderHeaderV2Entity read from?
+```
+
+Copilot calls `get_data_entity_info` and returns: entity category, `PublicEntityName` (OData
+resource name), whether OData and DMF are enabled, data sources, field-to-table mapping,
+and entity keys.
+
+### Discover what you can extend on an object
+
+Before writing an extension you want to know: which methods are CoC-eligible, which are
+blocked with `final`, and whether any events are already subscribed.
+
+```
+What can I extend on SalesLine?
+What CoC-eligible methods does SalesFormLetter have?
+Are any methods on CustTable blocked from CoC?
+```
+
+Copilot calls `analyze_extension_points`, returns a categorised list: CoC-eligible, final
+(blocked), delegate hooks, table events, and any already-extended points.
+
+### Validate an extension name before you create it
+
+```
+Is SalesTableExtension a valid name for a class extension of SalesTable?
+Validate the name SalesTable.WHSExtension as a table extension
+Is MyOrderTableMaintain a valid security privilege name?
+```
+
+Copilot calls `validate_object_naming`, checks D365FO naming conventions
+(e.g. `{Base}{Prefix}_Extension` for class extensions, `{Base}.{Prefix}Extension` for AOT
+extensions), detects conflicts against the 584K+ symbol index, and suggests the correct name.
+
+### Create a SysOperation batch job
+
+```
+Create a SysOperation batch job for nightly invoice calculation
+Generate a SysOperation DataContract + Controller + Service for vendor aging report processing
+```
+
+Copilot calls `generate_code` with `pattern: sysoperation` and produces all three classes:
+`DataContract`, `Controller`, and `Service` — ready to paste into Visual Studio.
+
+### Create event handlers for a table
+
+```
+Create an event handler class for SalesLine that handles onInserted and onValidatedWrite
+Generate a [SubscribesTo] event handler for CustTable.onInserted
+```
+
+Copilot calls `generate_code` with `pattern: event-handler` and generates a static handler
+class with correctly typed sender arguments and `delegateStr()` references.

--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -65,6 +65,18 @@ interface ExtractionStats {
   enums: number;
   edts: number;
   reports: number;
+  securityPrivileges: number;
+  securityDuties: number;
+  securityRoles: number;
+  menuItemDisplays: number;
+  menuItemActions: number;
+  menuItemOutputs: number;
+  tableExtensions: number;
+  classExtensions: number;
+  formExtensions: number;
+  enumExtensions: number;
+  edtExtensions: number;
+  dataEntityExtensions: number;
   errors: number;
 }
 
@@ -198,6 +210,18 @@ async function extractMetadata() {
     enums: 0,
     edts: 0,
     reports: 0,
+    securityPrivileges: 0,
+    securityDuties: 0,
+    securityRoles: 0,
+    menuItemDisplays: 0,
+    menuItemActions: 0,
+    menuItemOutputs: 0,
+    tableExtensions: 0,
+    classExtensions: 0,
+    formExtensions: 0,
+    enumExtensions: 0,
+    edtExtensions: 0,
+    dataEntityExtensions: 0,
     errors: 0,
   };
 
@@ -404,6 +428,24 @@ async function extractMetadata() {
     // Extract Reports
     await extractReports(modelItem.modelPath, modelItem.modelName, stats);
 
+    // Extract security objects
+    await extractSecurityPrivileges(parser, modelItem.modelPath, modelItem.modelName, stats);
+    await extractSecurityDuties(parser, modelItem.modelPath, modelItem.modelName, stats);
+    await extractSecurityRoles(parser, modelItem.modelPath, modelItem.modelName, stats);
+
+    // Extract menu items
+    await extractMenuItems(parser, modelItem.modelPath, modelItem.modelName, 'display', stats);
+    await extractMenuItems(parser, modelItem.modelPath, modelItem.modelName, 'action', stats);
+    await extractMenuItems(parser, modelItem.modelPath, modelItem.modelName, 'output', stats);
+
+    // Extract extensions
+    await extractExtensions(parser, modelItem.modelPath, modelItem.modelName, 'table-extension', 'AxTableExtension', stats);
+    await extractExtensions(parser, modelItem.modelPath, modelItem.modelName, 'class-extension', 'AxClassExtension', stats);
+    await extractExtensions(parser, modelItem.modelPath, modelItem.modelName, 'form-extension', 'AxFormExtension', stats);
+    await extractExtensions(parser, modelItem.modelPath, modelItem.modelName, 'enum-extension', 'AxEnumExtension', stats);
+    await extractExtensions(parser, modelItem.modelPath, modelItem.modelName, 'edt-extension', 'AxEdtExtension', stats);
+    await extractExtensions(parser, modelItem.modelPath, modelItem.modelName, 'data-entity-extension', 'AxDataEntityViewExtension', stats);
+
     const modelDuration = Date.now() - modelStart;
     cumulativeModelDuration += modelDuration;
     processedModels++;
@@ -432,6 +474,18 @@ async function extractMetadata() {
   console.log(`   Enums: ${formatCount(stats.enums)}`);
   console.log(`   EDTs: ${formatCount(stats.edts)}`);
   console.log(`   Reports: ${formatCount(stats.reports)}`);
+  console.log(`   Security privileges: ${formatCount(stats.securityPrivileges)}`);
+  console.log(`   Security duties: ${formatCount(stats.securityDuties)}`);
+  console.log(`   Security roles: ${formatCount(stats.securityRoles)}`);
+  console.log(`   Menu items (display): ${formatCount(stats.menuItemDisplays)}`);
+  console.log(`   Menu items (action): ${formatCount(stats.menuItemActions)}`);
+  console.log(`   Menu items (output): ${formatCount(stats.menuItemOutputs)}`);
+  console.log(`   Table extensions: ${formatCount(stats.tableExtensions)}`);
+  console.log(`   Class extensions: ${formatCount(stats.classExtensions)}`);
+  console.log(`   Form extensions: ${formatCount(stats.formExtensions)}`);
+  console.log(`   Enum extensions: ${formatCount(stats.enumExtensions)}`);
+  console.log(`   EDT extensions: ${formatCount(stats.edtExtensions)}`);
+  console.log(`   Data entity extensions: ${formatCount(stats.dataEntityExtensions)}`);
   console.log(`   Errors: ${formatCount(stats.errors)}`);
 }
 
@@ -870,6 +924,186 @@ async function extractReports(
       stats.reports++;
     } catch (error) {
       console.error(`   ❌ Error extracting report ${file}:`, error);
+      stats.errors++;
+    }
+  }
+}
+
+async function extractSecurityPrivileges(
+  parser: XppMetadataParser,
+  modelPath: string,
+  modelName: string,
+  stats: ExtractionStats
+) {
+  let dirPath = path.join(modelPath, 'AxSecurityPrivilege');
+  try { await fs.access(dirPath); } catch {
+    dirPath = path.join(modelPath, 'axsecurityprivilege');
+    try { await fs.access(dirPath); } catch { return; }
+  }
+  const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
+  if (files.length === 0) return;
+  console.log(`   Security privileges: ${formatCount(files.length)} files`);
+  const outputDir = path.join(OUTPUT_PATH, modelName, 'security-privileges');
+  await fs.mkdir(outputDir, { recursive: true });
+  for (const file of files) {
+    const filePath = path.join(dirPath, file);
+    stats.totalFiles++;
+    try {
+      const result = await parser.parseSecurityPrivilegeFile(filePath);
+      if (!result.success || !result.data) { stats.errors++; continue; }
+      const outputFile = path.join(outputDir, `${result.data.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-privilege' }, null, 2));
+      stats.securityPrivileges++;
+    } catch (error) {
+      console.error(`   ❌ Error extracting security privilege ${file}:`, error);
+      stats.errors++;
+    }
+  }
+}
+
+async function extractSecurityDuties(
+  parser: XppMetadataParser,
+  modelPath: string,
+  modelName: string,
+  stats: ExtractionStats
+) {
+  let dirPath = path.join(modelPath, 'AxSecurityDuty');
+  try { await fs.access(dirPath); } catch {
+    dirPath = path.join(modelPath, 'axsecurityduty');
+    try { await fs.access(dirPath); } catch { return; }
+  }
+  const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
+  if (files.length === 0) return;
+  console.log(`   Security duties: ${formatCount(files.length)} files`);
+  const outputDir = path.join(OUTPUT_PATH, modelName, 'security-duties');
+  await fs.mkdir(outputDir, { recursive: true });
+  for (const file of files) {
+    const filePath = path.join(dirPath, file);
+    stats.totalFiles++;
+    try {
+      const result = await parser.parseSecurityDutyFile(filePath);
+      if (!result.success || !result.data) { stats.errors++; continue; }
+      const outputFile = path.join(outputDir, `${result.data.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-duty' }, null, 2));
+      stats.securityDuties++;
+    } catch (error) {
+      console.error(`   ❌ Error extracting security duty ${file}:`, error);
+      stats.errors++;
+    }
+  }
+}
+
+async function extractSecurityRoles(
+  parser: XppMetadataParser,
+  modelPath: string,
+  modelName: string,
+  stats: ExtractionStats
+) {
+  let dirPath = path.join(modelPath, 'AxSecurityRole');
+  try { await fs.access(dirPath); } catch {
+    dirPath = path.join(modelPath, 'axsecurityrole');
+    try { await fs.access(dirPath); } catch { return; }
+  }
+  const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
+  if (files.length === 0) return;
+  console.log(`   Security roles: ${formatCount(files.length)} files`);
+  const outputDir = path.join(OUTPUT_PATH, modelName, 'security-roles');
+  await fs.mkdir(outputDir, { recursive: true });
+  for (const file of files) {
+    const filePath = path.join(dirPath, file);
+    stats.totalFiles++;
+    try {
+      const result = await parser.parseSecurityRoleFile(filePath);
+      if (!result.success || !result.data) { stats.errors++; continue; }
+      const outputFile = path.join(outputDir, `${result.data.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-role' }, null, 2));
+      stats.securityRoles++;
+    } catch (error) {
+      console.error(`   ❌ Error extracting security role ${file}:`, error);
+      stats.errors++;
+    }
+  }
+}
+
+async function extractMenuItems(
+  parser: XppMetadataParser,
+  modelPath: string,
+  modelName: string,
+  itemType: 'display' | 'action' | 'output',
+  stats: ExtractionStats
+) {
+  const dirName = itemType === 'display' ? 'AxMenuItemDisplay'
+    : itemType === 'action' ? 'AxMenuItemAction' : 'AxMenuItemOutput';
+  const outDirName = `menu-item-${itemType}s`;
+  const statKey = itemType === 'display' ? 'menuItemDisplays'
+    : itemType === 'action' ? 'menuItemActions' : 'menuItemOutputs';
+
+  let dirPath = path.join(modelPath, dirName);
+  try { await fs.access(dirPath); } catch {
+    dirPath = path.join(modelPath, dirName.toLowerCase());
+    try { await fs.access(dirPath); } catch { return; }
+  }
+  const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
+  if (files.length === 0) return;
+  console.log(`   Menu items (${itemType}): ${formatCount(files.length)} files`);
+  const outputDir = path.join(OUTPUT_PATH, modelName, outDirName);
+  await fs.mkdir(outputDir, { recursive: true });
+  for (const file of files) {
+    const filePath = path.join(dirPath, file);
+    stats.totalFiles++;
+    try {
+      const result = await parser.parseMenuItemFile(filePath, itemType);
+      if (!result.success || !result.data) { stats.errors++; continue; }
+      const outputFile = path.join(outputDir, `${result.data.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: `menu-item-${itemType}` }, null, 2));
+      (stats as any)[statKey]++;
+    } catch (error) {
+      console.error(`   ❌ Error extracting menu item (${itemType}) ${file}:`, error);
+      stats.errors++;
+    }
+  }
+}
+
+async function extractExtensions(
+  parser: XppMetadataParser,
+  modelPath: string,
+  modelName: string,
+  extensionType: string,
+  axDirName: string,
+  stats: ExtractionStats
+) {
+  const outDirName = extensionType + 's'; // table-extensions, class-extensions, etc.
+  const statKeyMap: Record<string, string> = {
+    'table-extension': 'tableExtensions',
+    'class-extension': 'classExtensions',
+    'form-extension': 'formExtensions',
+    'enum-extension': 'enumExtensions',
+    'edt-extension': 'edtExtensions',
+    'data-entity-extension': 'dataEntityExtensions',
+  };
+
+  let dirPath = path.join(modelPath, axDirName);
+  try { await fs.access(dirPath); } catch {
+    dirPath = path.join(modelPath, axDirName.toLowerCase());
+    try { await fs.access(dirPath); } catch { return; }
+  }
+  const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
+  if (files.length === 0) return;
+  console.log(`   ${extensionType}s: ${formatCount(files.length)} files`);
+  const outputDir = path.join(OUTPUT_PATH, modelName, outDirName);
+  await fs.mkdir(outputDir, { recursive: true });
+  for (const file of files) {
+    const filePath = path.join(dirPath, file);
+    stats.totalFiles++;
+    try {
+      const result = await parser.parseExtensionFile(filePath, extensionType);
+      if (!result.success || !result.data) { stats.errors++; continue; }
+      const outputFile = path.join(outputDir, `${result.data.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: extensionType }, null, 2));
+      const statKey = statKeyMap[extensionType];
+      if (statKey) (stats as any)[statKey]++;
+    } catch (error) {
+      console.error(`   ❌ Error extracting ${extensionType} ${file}:`, error);
       stats.errors++;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,13 +309,13 @@ async function main() {
     console.log('✅ Stdio transport connected');
     
     // Log actual tool count based on server mode
-    const totalTools = 30;
+    const totalTools = 40;
     const writeToolCount = WRITE_TOOLS.size;
     const toolCount = SERVER_MODE === 'write-only' ? writeToolCount :
                      SERVER_MODE === 'read-only' ? totalTools - writeToolCount : totalTools;
     const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(WRITE_TOOLS).join(', ')})` :
                     SERVER_MODE === 'read-only' ? '(all except write tools)' :
-                    '(8 discovery + 3 labels + 6 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis)';
+                    '(8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis + 9 security-extensions)';
     console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
@@ -410,7 +410,18 @@ async function main() {
         { icon: '📈', category: 'Pattern Analysis', tools: [
           { name: 'get_table_patterns',           desc: 'Analyze common field/index patterns for table groups' },
           { name: 'get_form_patterns',            desc: 'Analyze common datasource/control patterns for forms' },
-          { name: 'generate_code',                desc: 'Generate X++ boilerplate (class, batch-job, data-entity, …)' },
+          { name: 'generate_code',                desc: 'Generate X++ boilerplate (class, SysOperation, CoC, event-handler, …)' },
+        ]},
+        { icon: '🔐', category: 'Security & Extensions', tools: [
+          { name: 'get_security_artifact_info',   desc: 'Privilege/Duty/Role details and full hierarchy chain' },
+          { name: 'get_security_coverage_for_object', desc: 'Which roles can access a form/table/class?' },
+          { name: 'get_menu_item_info',           desc: 'Menu item target, type, and security privilege chain' },
+          { name: 'find_coc_extensions',          desc: 'Which classes use CoC to wrap a given method?' },
+          { name: 'find_event_handlers',          desc: 'Find all [SubscribesTo] handlers for a table or class event' },
+          { name: 'get_table_extension_info',     desc: 'All extensions of a table: added fields, indexes, methods' },
+          { name: 'get_data_entity_info',         desc: 'Data entity: category, OData settings, data sources, keys' },
+          { name: 'analyze_extension_points',     desc: 'CoC-eligible methods, delegates, events — what can be extended?' },
+          { name: 'validate_object_naming',       desc: 'Validate proposed extensions and object names against D365FO conventions' },
         ]},
       ];
 

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -373,6 +373,88 @@ export class XppSymbolIndex {
       CREATE INDEX IF NOT EXISTS idx_edt_metadata_model ON edt_metadata(model);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_edt_metadata_unique ON edt_metadata(edt_name, model);
     `);
+
+    // ── Security Tables ──────────────────────────────────────────────────────
+
+    // Security Privilege Entry Points
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS security_privilege_entries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        privilege_name TEXT NOT NULL,
+        entry_point_name TEXT NOT NULL,
+        object_type TEXT NOT NULL,
+        access_level TEXT NOT NULL,
+        model TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_spe_privilege ON security_privilege_entries(privilege_name);
+      CREATE INDEX IF NOT EXISTS idx_spe_entry ON security_privilege_entries(entry_point_name);
+      CREATE INDEX IF NOT EXISTS idx_spe_model ON security_privilege_entries(model);
+    `);
+
+    // Security Duty → Privilege references
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS security_duty_privileges (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        duty_name TEXT NOT NULL,
+        privilege_name TEXT NOT NULL,
+        model TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_sdp_duty ON security_duty_privileges(duty_name);
+      CREATE INDEX IF NOT EXISTS idx_sdp_privilege ON security_duty_privileges(privilege_name);
+      CREATE INDEX IF NOT EXISTS idx_sdp_model ON security_duty_privileges(model);
+    `);
+
+    // Security Role → Duty references
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS security_role_duties (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        role_name TEXT NOT NULL,
+        duty_name TEXT NOT NULL,
+        model TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_srd_role ON security_role_duties(role_name);
+      CREATE INDEX IF NOT EXISTS idx_srd_duty ON security_role_duties(duty_name);
+      CREATE INDEX IF NOT EXISTS idx_srd_model ON security_role_duties(model);
+    `);
+
+    // ── Menu Item Targets ─────────────────────────────────────────────────────
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS menu_item_targets (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        menu_item_name TEXT NOT NULL,
+        menu_item_type TEXT NOT NULL,
+        target_object TEXT,
+        target_type TEXT,
+        security_privilege TEXT,
+        label TEXT,
+        model TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_mit_name ON menu_item_targets(menu_item_name);
+      CREATE INDEX IF NOT EXISTS idx_mit_target ON menu_item_targets(target_object);
+      CREATE INDEX IF NOT EXISTS idx_mit_model ON menu_item_targets(model);
+    `);
+
+    // ── Extension Metadata ───────────────────────────────────────────────────
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS extension_metadata (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        extension_name TEXT NOT NULL,
+        extension_type TEXT NOT NULL,
+        base_object_name TEXT NOT NULL,
+        added_fields TEXT,
+        added_methods TEXT,
+        added_indexes TEXT,
+        coc_methods TEXT,
+        event_subscriptions TEXT,
+        model TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_em_base ON extension_metadata(base_object_name);
+      CREATE INDEX IF NOT EXISTS idx_em_type ON extension_metadata(extension_type);
+      CREATE INDEX IF NOT EXISTS idx_em_name ON extension_metadata(extension_name);
+      CREATE INDEX IF NOT EXISTS idx_em_model ON extension_metadata(model);
+    `);
   }
 
   /**
@@ -874,6 +956,45 @@ export class XppSymbolIndex {
         const reportsPath = path.join(modelPath, 'reports');
         if (fs.existsSync(reportsPath)) this.indexReports(reportsPath, model);
 
+        // Security artifacts
+        const secPrivPath = path.join(modelPath, 'security-privileges');
+        if (fs.existsSync(secPrivPath)) this.indexSecurityPrivileges(secPrivPath, model);
+
+        const secDutyPath = path.join(modelPath, 'security-duties');
+        if (fs.existsSync(secDutyPath)) this.indexSecurityDuties(secDutyPath, model);
+
+        const secRolePath = path.join(modelPath, 'security-roles');
+        if (fs.existsSync(secRolePath)) this.indexSecurityRoles(secRolePath, model);
+
+        // Menu items
+        const menuDisplayPath = path.join(modelPath, 'menu-item-displays');
+        if (fs.existsSync(menuDisplayPath)) this.indexMenuItems(menuDisplayPath, model, 'display');
+
+        const menuActionPath = path.join(modelPath, 'menu-item-actions');
+        if (fs.existsSync(menuActionPath)) this.indexMenuItems(menuActionPath, model, 'action');
+
+        const menuOutputPath = path.join(modelPath, 'menu-item-outputs');
+        if (fs.existsSync(menuOutputPath)) this.indexMenuItems(menuOutputPath, model, 'output');
+
+        // Extensions
+        const tableExtPath = path.join(modelPath, 'table-extensions');
+        if (fs.existsSync(tableExtPath)) this.indexExtensions(tableExtPath, model, 'table-extension');
+
+        const classExtPath = path.join(modelPath, 'class-extensions');
+        if (fs.existsSync(classExtPath)) this.indexExtensions(classExtPath, model, 'class-extension');
+
+        const formExtPath = path.join(modelPath, 'form-extensions');
+        if (fs.existsSync(formExtPath)) this.indexExtensions(formExtPath, model, 'form-extension');
+
+        const enumExtPath = path.join(modelPath, 'enum-extensions');
+        if (fs.existsSync(enumExtPath)) this.indexExtensions(enumExtPath, model, 'enum-extension');
+
+        const edtExtPath = path.join(modelPath, 'edt-extensions');
+        if (fs.existsSync(edtExtPath)) this.indexExtensions(edtExtPath, model, 'edt-extension');
+
+        const deExtPath = path.join(modelPath, 'data-entity-extensions');
+        if (fs.existsSync(deExtPath)) this.indexExtensions(deExtPath, model, 'data-entity-extension');
+
         // Mark model as done atomically with its data (same transaction)
         markProgress?.run(model, Date.now());
       });
@@ -924,7 +1045,13 @@ export class XppSymbolIndex {
    * so the most data is committed to disk before any CI pipeline timeout.
    */
   private sortModelsBySize(metadataPath: string, models: string[]): string[] {
-    const subdirs = ['classes', 'tables', 'forms', 'queries', 'views', 'enums', 'edts', 'reports'];
+    const subdirs = [
+      'classes', 'tables', 'forms', 'queries', 'views', 'enums', 'edts', 'reports',
+      'security-privileges', 'security-duties', 'security-roles',
+      'menu-item-displays', 'menu-item-actions', 'menu-item-outputs',
+      'table-extensions', 'class-extensions', 'form-extensions',
+      'enum-extensions', 'edt-extensions', 'data-entity-extensions',
+    ];
     const sized = models.map(model => {
       let count = 0;
       const modelPath = path.join(metadataPath, model);
@@ -1357,6 +1484,191 @@ export class XppSymbolIndex {
       } catch (error) {
         // Only log errors, don't stop processing
         console.error(`      ⚠️  Skipped view ${file}: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+  }
+
+  private indexSecurityPrivileges(dirPath: string, model: string): void {
+    const files = fs.readdirSync(dirPath).filter(f => f.endsWith('.json'));
+    const insertEntry = this.db.prepare(`
+      INSERT OR IGNORE INTO security_privilege_entries
+        (privilege_name, entry_point_name, object_type, access_level, model)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+
+    for (const file of files) {
+      try {
+        const filePath = path.join(dirPath, file);
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        const sourceFilePath = data.sourcePath || filePath;
+        const name = data.name || path.basename(file, '.json');
+        const entryPoints: Array<{ name: string; objectType: string; accessLevel: string }> =
+          data.entryPoints || [];
+
+        this.addSymbol({
+          name,
+          type: 'security-privilege',
+          filePath: sourceFilePath,
+          model,
+          description: data.label || undefined,
+          signature: entryPoints.length > 0 ? `${entryPoints.length} entry point(s)` : undefined,
+        });
+
+        for (const ep of entryPoints) {
+          insertEntry.run(name, ep.name, ep.objectType, ep.accessLevel, model);
+        }
+      } catch (error) {
+        console.error(`      ⚠️  Skipped security-privilege ${file}: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+  }
+
+  private indexSecurityDuties(dirPath: string, model: string): void {
+    const files = fs.readdirSync(dirPath).filter(f => f.endsWith('.json'));
+    const insertPriv = this.db.prepare(`
+      INSERT OR IGNORE INTO security_duty_privileges (duty_name, privilege_name, model)
+      VALUES (?, ?, ?)
+    `);
+
+    for (const file of files) {
+      try {
+        const filePath = path.join(dirPath, file);
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        const sourceFilePath = data.sourcePath || filePath;
+        const name = data.name || path.basename(file, '.json');
+        const privileges: string[] = data.privileges || [];
+
+        this.addSymbol({
+          name,
+          type: 'security-duty',
+          filePath: sourceFilePath,
+          model,
+          description: data.label || undefined,
+          signature: privileges.length > 0 ? `${privileges.length} privilege(s)` : undefined,
+        });
+
+        for (const priv of privileges) {
+          insertPriv.run(name, priv, model);
+        }
+      } catch (error) {
+        console.error(`      ⚠️  Skipped security-duty ${file}: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+  }
+
+  private indexSecurityRoles(dirPath: string, model: string): void {
+    const files = fs.readdirSync(dirPath).filter(f => f.endsWith('.json'));
+    const insertDuty = this.db.prepare(`
+      INSERT OR IGNORE INTO security_role_duties (role_name, duty_name, model)
+      VALUES (?, ?, ?)
+    `);
+
+    for (const file of files) {
+      try {
+        const filePath = path.join(dirPath, file);
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        const sourceFilePath = data.sourcePath || filePath;
+        const name = data.name || path.basename(file, '.json');
+        const duties: string[] = data.duties || [];
+
+        this.addSymbol({
+          name,
+          type: 'security-role',
+          filePath: sourceFilePath,
+          model,
+          description: data.description || data.label || undefined,
+          signature: duties.length > 0 ? `${duties.length} duty(ies)` : undefined,
+        });
+
+        for (const duty of duties) {
+          insertDuty.run(name, duty, model);
+        }
+      } catch (error) {
+        console.error(`      ⚠️  Skipped security-role ${file}: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+  }
+
+  private indexMenuItems(dirPath: string, model: string, menuItemType: 'display' | 'action' | 'output'): void {
+    const files = fs.readdirSync(dirPath).filter(f => f.endsWith('.json'));
+    const symbolType = `menu-item-${menuItemType}` as const;
+    const insertTarget = this.db.prepare(`
+      INSERT OR REPLACE INTO menu_item_targets
+        (menu_item_name, menu_item_type, target_object, target_type, security_privilege, label, model)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    for (const file of files) {
+      try {
+        const filePath = path.join(dirPath, file);
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        const sourceFilePath = data.sourcePath || filePath;
+        const name = data.name || path.basename(file, '.json');
+
+        this.addSymbol({
+          name,
+          type: symbolType,
+          filePath: sourceFilePath,
+          model,
+          description: data.label || undefined,
+          signature: data.targetObject || data.object || undefined,
+        });
+
+        insertTarget.run(
+          name,
+          menuItemType,
+          data.targetObject || data.object || null,
+          data.targetType || data.objectType || null,
+          data.securityPrivilege || null,
+          data.label || null,
+          model
+        );
+      } catch (error) {
+        console.error(`      ⚠️  Skipped menu-item-${menuItemType} ${file}: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+  }
+
+  private indexExtensions(dirPath: string, model: string, extensionType: string): void {
+    const files = fs.readdirSync(dirPath).filter(f => f.endsWith('.json'));
+    const insertMeta = this.db.prepare(`
+      INSERT OR REPLACE INTO extension_metadata
+        (extension_name, extension_type, base_object_name, added_fields, added_methods,
+         added_indexes, coc_methods, event_subscriptions, model)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    for (const file of files) {
+      try {
+        const filePath = path.join(dirPath, file);
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        const sourceFilePath = data.sourcePath || filePath;
+        const name = data.name || path.basename(file, '.json');
+        const baseObjectName = data.baseObjectName || data.extends || '';
+
+        this.addSymbol({
+          name,
+          type: extensionType as any,
+          filePath: sourceFilePath,
+          model,
+          parentName: baseObjectName || undefined,
+          extendsClass: baseObjectName || undefined,
+          signature: baseObjectName || undefined,
+        });
+
+        insertMeta.run(
+          name,
+          extensionType,
+          baseObjectName,
+          data.addedFields ? JSON.stringify(data.addedFields) : null,
+          data.addedMethods ? JSON.stringify(data.addedMethods) : null,
+          data.addedIndexes ? JSON.stringify(data.addedIndexes) : null,
+          data.cocMethods ? JSON.stringify(data.cocMethods) : null,
+          data.eventSubscriptions ? JSON.stringify(data.eventSubscriptions) : null,
+          model
+        );
+      } catch (error) {
+        console.error(`      ⚠️  Skipped ${extensionType} ${file}: ${error instanceof Error ? error.message : error}`);
       }
     }
   }
@@ -1803,6 +2115,11 @@ export class XppSymbolIndex {
     this.db.exec('DELETE FROM table_relations');
     this.db.exec('DELETE FROM form_datasources');
     this.db.exec('DELETE FROM edt_metadata');
+    this.db.exec('DELETE FROM security_privilege_entries');
+    this.db.exec('DELETE FROM security_duty_privileges');
+    this.db.exec('DELETE FROM security_role_duties');
+    this.db.exec('DELETE FROM menu_item_targets');
+    this.db.exec('DELETE FROM extension_metadata');
     this.vacuum();
   }
 
@@ -1829,7 +2146,13 @@ export class XppSymbolIndex {
     
     const stmtEdt = this.db.prepare(`DELETE FROM edt_metadata WHERE model IN (${placeholders})`);
     stmtEdt.run(...modelNames);
-    
+
+    this.db.prepare(`DELETE FROM security_privilege_entries WHERE model IN (${placeholders})`).run(...modelNames);
+    this.db.prepare(`DELETE FROM security_duty_privileges WHERE model IN (${placeholders})`).run(...modelNames);
+    this.db.prepare(`DELETE FROM security_role_duties WHERE model IN (${placeholders})`).run(...modelNames);
+    this.db.prepare(`DELETE FROM menu_item_targets WHERE model IN (${placeholders})`).run(...modelNames);
+    this.db.prepare(`DELETE FROM extension_metadata WHERE model IN (${placeholders})`).run(...modelNames);
+
     console.log(`🗑️  Cleared symbols for models: ${modelNames.join(', ')}`);
     
     if (shouldVacuum) {

--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -126,7 +126,11 @@ export interface XppViewInfo {
 
 export interface XppSymbol {
   name: string;
-  type: 'class' | 'table' | 'form' | 'query' | 'view' | 'method' | 'field' | 'enum' | 'edt' | 'report';
+  type: 'class' | 'table' | 'form' | 'query' | 'view' | 'method' | 'field' | 'enum' | 'edt' | 'report'
+      | 'security-privilege' | 'security-duty' | 'security-role'
+      | 'menu-item-display' | 'menu-item-action' | 'menu-item-output'
+      | 'table-extension' | 'class-extension' | 'form-extension'
+      | 'enum-extension' | 'edt-extension' | 'data-entity-extension';
   parentName?: string;
   signature?: string;
   filePath: string;
@@ -217,4 +221,68 @@ export interface CodePattern {
   frequency: number;            // How many classes follow this pattern
   domain?: string;              // Customer, Inventory, Sales, etc.
   characteristics?: string[];   // Distinguishing features
+}
+
+/**
+ * Security artifact types
+ */
+export interface XppSecurityEntryPoint {
+  name: string;
+  objectType: string;     // MenuItemDisplay / MenuItemAction / MenuItemOutput / WebActionItem
+  accessLevel: string;    // Read / Update / Create / Delete / Correct / Invoke
+}
+
+export interface XppSecurityPrivilegeInfo {
+  name: string;
+  model: string;
+  sourcePath: string;
+  label?: string;
+  entryPoints: XppSecurityEntryPoint[];
+}
+
+export interface XppSecurityDutyInfo {
+  name: string;
+  model: string;
+  sourcePath: string;
+  label?: string;
+  privileges: string[];   // Privilege names
+}
+
+export interface XppSecurityRoleInfo {
+  name: string;
+  model: string;
+  sourcePath: string;
+  label?: string;
+  description?: string;
+  duties: string[];       // Duty names
+}
+
+/**
+ * Menu item types
+ */
+export interface XppMenuItemInfo {
+  name: string;
+  model: string;
+  sourcePath: string;
+  label?: string;
+  menuItemType: 'display' | 'action' | 'output';
+  targetObject?: string;
+  targetType?: string;    // Form / Class / Query / Report
+  securityPrivilege?: string;
+}
+
+/**
+ * Extension metadata types
+ */
+export interface XppExtensionInfo {
+  name: string;
+  model: string;
+  sourcePath: string;
+  extensionType: string;        // table-extension / class-extension / etc.
+  baseObjectName: string;       // The object being extended
+  addedFields?: string[];       // Field names added by this extension
+  addedMethods?: string[];      // Method names added by this extension
+  addedIndexes?: string[];      // Index names added by this extension
+  cocMethods?: string[];        // Methods wrapped via CoC (call next)
+  eventSubscriptions?: string[];// Events subscribed to via [SubscribesTo]
 }

--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -808,4 +808,231 @@ export class XppMetadataParser {
       };
     }
   }
+
+  async parseSecurityPrivilegeFile(filePath: string): Promise<XppParseResult<{
+    name: string;
+    label?: string;
+    sourcePath: string;
+    entryPoints: Array<{ name: string; objectType: string; accessLevel: string }>;
+  }>> {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      const parsed = await this.parser.parseStringPromise(content);
+      const root = parsed?.AxSecurityPrivilege;
+      if (!root) return { success: false, error: 'Not an AxSecurityPrivilege file' };
+
+      const name: string = root.Name || '';
+      const label: string | undefined = root.Label || undefined;
+
+      const rawEps = root.EntryPoints?.AxSecurityEntryPointReference;
+      const epArray = rawEps ? (Array.isArray(rawEps) ? rawEps : [rawEps]) : [];
+      const entryPoints = epArray.map((ep: any) => ({
+        name: ep.Name || '',
+        objectType: ep.ObjectType || '',
+        accessLevel: ep.Grant || ep.Access || '',
+      })).filter((ep: any) => ep.name);
+
+      return { success: true, data: { name, label, sourcePath: filePath, entryPoints } };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async parseSecurityDutyFile(filePath: string): Promise<XppParseResult<{
+    name: string;
+    label?: string;
+    sourcePath: string;
+    privileges: string[];
+  }>> {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      const parsed = await this.parser.parseStringPromise(content);
+      const root = parsed?.AxSecurityDuty;
+      if (!root) return { success: false, error: 'Not an AxSecurityDuty file' };
+
+      const name: string = root.Name || '';
+      const label: string | undefined = root.Label || undefined;
+
+      const rawPrivs = root.Privileges?.AxSecurityRolePermissionSet ??
+                       root.Privileges?.AxSecurityPrivilegePermissionSet;
+      const privArray = rawPrivs ? (Array.isArray(rawPrivs) ? rawPrivs : [rawPrivs]) : [];
+      const privileges: string[] = privArray
+        .map((p: any) => (typeof p === 'string' ? p : p.Name || ''))
+        .filter(Boolean);
+
+      return { success: true, data: { name, label, sourcePath: filePath, privileges } };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async parseSecurityRoleFile(filePath: string): Promise<XppParseResult<{
+    name: string;
+    label?: string;
+    description?: string;
+    sourcePath: string;
+    duties: string[];
+  }>> {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      const parsed = await this.parser.parseStringPromise(content);
+      const root = parsed?.AxSecurityRole;
+      if (!root) return { success: false, error: 'Not an AxSecurityRole file' };
+
+      const name: string = root.Name || '';
+      const label: string | undefined = root.Label || undefined;
+      const description: string | undefined = root.Description || undefined;
+
+      const rawDuties = root.Duties?.AxSecurityRoleDutyPermission ??
+                        root.Duties?.AxSecurityDutyPermission;
+      const dutyArray = rawDuties ? (Array.isArray(rawDuties) ? rawDuties : [rawDuties]) : [];
+      const duties: string[] = dutyArray
+        .map((d: any) => (typeof d === 'string' ? d : d.Name || ''))
+        .filter(Boolean);
+
+      return { success: true, data: { name, label, description, sourcePath: filePath, duties } };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async parseMenuItemFile(
+    filePath: string,
+    itemType: 'display' | 'action' | 'output',
+  ): Promise<XppParseResult<{
+    name: string;
+    label?: string;
+    targetObject?: string;
+    targetType?: string;
+    securityPrivilege?: string;
+    sourcePath: string;
+  }>> {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      const parsed = await this.parser.parseStringPromise(content);
+      const rootKey = itemType === 'display'
+        ? 'AxMenuItemDisplay'
+        : itemType === 'action'
+          ? 'AxMenuItemAction'
+          : 'AxMenuItemOutput';
+      const root = parsed?.[rootKey];
+      if (!root) return { success: false, error: `Not an ${rootKey} file` };
+
+      return {
+        success: true,
+        data: {
+          name: root.Name || '',
+          label: root.Label || undefined,
+          targetObject: root.Object || undefined,
+          targetType: root.ObjectType || undefined,
+          securityPrivilege: root.SecurityPrivilege || undefined,
+          sourcePath: filePath,
+        },
+      };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async parseExtensionFile(
+    filePath: string,
+    extensionType: string,
+  ): Promise<XppParseResult<{
+    name: string;
+    baseObjectName: string;
+    sourcePath: string;
+    addedFields: string[];
+    addedMethods: string[];
+    addedIndexes: string[];
+    cocMethods: string[];
+    eventSubscriptions: string[];
+  }>> {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      const parsed = await this.parser.parseStringPromise(content);
+
+      // Determine XML root element by extensionType
+      const rootKeyMap: Record<string, string> = {
+        'table-extension':       'AxTableExtension',
+        'class-extension':       'AxClassExtension',
+        'form-extension':        'AxFormExtension',
+        'enum-extension':        'AxEnumExtension',
+        'edt-extension':         'AxEdtExtension',
+        'data-entity-extension': 'AxDataEntityViewExtension',
+      };
+      const rootKey = rootKeyMap[extensionType] || Object.keys(parsed || {})[0] || '';
+      const root = parsed?.[rootKey];
+      if (!root) return { success: false, error: `Cannot parse extension type: ${extensionType}` };
+
+      const name: string = root.Name || '';
+      const extendsValue: string = root.Extends || root.BaseObject || '';
+
+      // For class extensions, base object name is inferred from Extends or the name itself
+      // Class extension names follow the pattern "BaseClass.Suffix" or "BaseClass_Suffix_Extension"
+      let baseObjectName = extendsValue;
+      if (!baseObjectName && extensionType === 'class-extension') {
+        // Try to parse from declaration: [ExtensionOf(classStr(BaseName))]
+        const decl: string = root.SourceCode?.Declaration || '';
+        const match = decl.match(/ExtensionOf\s*\(\s*classStr\s*\(\s*(\w+)\s*\)/i)
+          ?? decl.match(/ExtensionOf\s*\(\s*tableStr\s*\(\s*(\w+)\s*\)/i)
+          ?? decl.match(/ExtensionOf\s*\(\s*formStr\s*\(\s*(\w+)\s*\)/i);
+        baseObjectName = match?.[1] || '';
+      }
+
+      // Extract added fields
+      const rawFields = root.Fields?.AxTableField ?? root.Fields?.AxEdtField ?? [];
+      const fieldArr = Array.isArray(rawFields) ? rawFields : rawFields ? [rawFields] : [];
+      const addedFields: string[] = fieldArr.map((f: any) => f.Name || '').filter(Boolean);
+
+      // Extract added indexes
+      const rawIndexes = root.Indexes?.AxTableIndex ?? [];
+      const indexArr = Array.isArray(rawIndexes) ? rawIndexes : rawIndexes ? [rawIndexes] : [];
+      const addedIndexes: string[] = indexArr.map((i: any) => i.Name || '').filter(Boolean);
+
+      // Extract methods + detect CoC and event subscriptions
+      const rawMethods = root.SourceCode?.Methods?.Method ?? root.Methods?.Method ?? [];
+      const methodArr = Array.isArray(rawMethods) ? rawMethods : rawMethods ? [rawMethods] : [];
+
+      const addedMethods: string[] = [];
+      const cocMethods: string[] = [];
+      const eventSubscriptions: string[] = [];
+
+      for (const m of methodArr) {
+        const methodName: string = m.Name || '';
+        const source: string = typeof m.Source === 'string' ? m.Source : (m._ || '');
+        if (!methodName) continue;
+
+        addedMethods.push(methodName);
+
+        // CoC detection: method source calls "next methodName"
+        if (/\bnext\s+\w+\s*\(/i.test(source)) {
+          cocMethods.push(methodName);
+        }
+
+        // Event handler detection: [SubscribesTo(...)]
+        const subMatch = source.match(/\[SubscribesTo\s*\(/i);
+        if (subMatch) {
+          // Extract the subscribes-to target for storage
+          const target = source.match(/\[SubscribesTo\s*\([^)]+\)/)?.[0] || methodName;
+          eventSubscriptions.push(target);
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          name,
+          baseObjectName,
+          sourcePath: filePath,
+          addedFields,
+          addedMethods,
+          addedIndexes,
+          cocMethods,
+          eventSubscriptions,
+        },
+      };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
 }

--- a/src/prompts/codeReview.ts
+++ b/src/prompts/codeReview.ts
@@ -52,6 +52,44 @@ export function registerCodeReviewPrompt(server: Server, context: XppServerConte
             },
           ],
         },
+        {
+          name: 'xpp_extension_guide',
+          description: 'Complete guide for CoC (Chain of Command) extensions and event handlers in D365FO',
+          arguments: [],
+        },
+        {
+          name: 'xpp_security_guide',
+          description: 'D365FO security model creation guide: privilege, duty, role, and menu item workflow',
+          arguments: [
+            {
+              name: 'featureName',
+              description: 'Feature or object name for context (optional)',
+              required: false,
+            },
+          ],
+        },
+        {
+          name: 'xpp_sysoperation_guide',
+          description: 'SysOperation framework reference: DataContract + Controller + Service pattern for batch operations',
+          arguments: [
+            {
+              name: 'operationDescription',
+              description: 'Description of the operation to implement (optional)',
+              required: false,
+            },
+          ],
+        },
+        {
+          name: 'xpp_data_entity_guide',
+          description: 'Data entity development guide: OData, DMF, staging tables, computed columns',
+          arguments: [
+            {
+              name: 'entityCategory',
+              description: 'Entity category: parameter, reference, master, document, or transaction (optional)',
+              required: false,
+            },
+          ],
+        },
       ],
     };
   });
@@ -175,6 +213,374 @@ Class source:
 \`\`\`xpp
 ${classSource}
 \`\`\``,
+            },
+          },
+        ],
+      };
+    }
+
+    if (promptName === 'xpp_extension_guide') {
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `# D365FO Extension Guide: CoC and Event Handlers
+
+## Chain of Command (CoC) Extensions
+
+Use CoC when you need to wrap or augment an existing method's logic.
+
+### Prerequisites
+1. Call \`get_method_signature\` to get exact parameter types and return type
+2. Call \`find_coc_extensions\` to check if the method is already wrapped
+3. Call \`analyze_extension_points\` to verify the method is CoC-eligible (not \`final\` / \`[Hookable(false)]\`)
+
+### Class rule
+\`\`\`xpp
+[ExtensionOf(classStr(SalesFormLetter))]
+final class SalesFormLetterWHS_Extension
+{
+    public void run()
+    {
+        // Pre-processing (optional)
+        next run();     // ALWAYS call next — never skip it
+        // Post-processing (optional)
+    }
+}
+\`\`\`
+
+### Naming
+- Class extensions:  \`{Base}{Prefix}_Extension\`   e.g. \`SalesFormLetterWHS_Extension\`
+- Table/form/enum:   \`{Base}.{Prefix}Extension\`    e.g. \`SalesTable.WHSExtension\` (AOT name)
+
+### Rules
+- ALWAYS call \`next methodName(...)\` with ALL original parameters preserved
+- Place \`next\` at the START for pre-processing, END for post-processing, or BOTH for wrapping
+- Use \`generate_code pattern='table-extension'\` or \`'form-handler'\` for the skeleton
+
+---
+
+## Event Handler Pattern (SubscribesTo)
+
+Use event handlers for loosely-coupled reactions to table/class/form events.
+
+### When to use
+- Need to react to standard table events (onInserted, onUpdated, onDeleted, onValidatedWrite …)
+- Avoid tight coupling — no need to wrap a method
+
+### Workflow
+1. Call \`analyze_extension_points\` with the target class/table to see available events
+2. Call \`find_event_handlers\` to check if the event already has handlers (avoid duplicates)
+3. Use \`generate_code pattern='event-handler' name='{BaseName}EventHandler' baseName='{BaseName}'\`
+
+### Template
+\`\`\`xpp
+public final class CustTableEventHandler
+{
+    [SubscribesTo(tableStr(CustTable),
+                  delegateStr(CustTable, onInserted))]
+    public static void CustTable_onInserted(Common _sender, InsertEventArgs _e)
+    {
+        CustTable record = _sender;
+        // Logic here
+    }
+}
+\`\`\`
+
+### Rules
+- Handler methods MUST be \`static public void\`
+- Table events → use \`tableStr()\`; class events → \`classStr()\`; form events → \`formStr()\`
+- Standard table events: onInserted, onUpdated, onDeleted, onValidatedWrite, onValidatedInsert, onValidatedDelete, onInitialized, onInitValue
+
+---
+
+## When to use CoC vs Event Handlers
+
+| Scenario | Use |
+|---|---|
+| Modify return value of a method | CoC |
+| Add logic before/after a specific method | CoC |
+| React to a data change across the codebase | Event Handler |
+| Avoid dependency on a specific class | Event Handler |
+| Method is \`final\` or \`[Hookable(false)]\` | Neither — use delegate or different approach |
+`,
+            },
+          },
+        ],
+      };
+    }
+
+    if (promptName === 'xpp_security_guide') {
+      const featureName = (request.params.arguments as any)?.featureName || '';
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `# D365FO Security Model Creation Guide${featureName ? ` — ${featureName}` : ''}
+
+## Security Hierarchy
+\`\`\`
+Role (e.g. AccountsReceivableClerk)
+  └── Duty  (e.g. CustTableMaintain)
+        └── Privilege  (e.g. CustTableView, CustTableFullControl)
+              └── Entry Point (e.g. MenuItemDisplay: CustTable)
+\`\`\`
+
+## Step-by-Step Workflow
+
+### 1. Check existing coverage first
+\`\`\`
+get_security_coverage_for_object(objectName: "CustTable", objectType: "form")
+\`\`\`
+
+### 2. Create menu item XML
+\`\`\`
+generate_code(pattern: "menu-item", name: "MyFeature", menuItemType: "display", targetObject: "MyFeatureForm")
+\`\`\`
+
+### 3. Create privilege XML (always create BOTH View + Maintain)
+\`\`\`
+generate_code(pattern: "security-privilege", name: "MyFeature", targetObject: "MyFeature")
+\`\`\`
+
+This generates:
+- **MyFeatureView** — Read access (for inquiry roles)
+- **MyFeatureMaintain** — Update/Create/Delete access (for operational roles)
+
+### 4. Create duty referencing both privileges
+\`\`\`xml
+<AxSecurityDuty>
+  <Name>MyFeatureMaintainDuty</Name>
+  <Label>@LabelId</Label>
+  <Privileges>
+    <AxSecurityRolePermissionSet><Name>MyFeatureView</Name></AxSecurityRolePermissionSet>
+    <AxSecurityRolePermissionSet><Name>MyFeatureMaintain</Name></AxSecurityRolePermissionSet>
+  </Privileges>
+</AxSecurityDuty>
+\`\`\`
+
+### 5. Assign duty to an existing role
+\`\`\`
+get_security_artifact_info(name: "AccountsReceivableClerk", artifactType: "role")
+\`\`\`
+Then add the duty to that role's XML.
+
+## Naming Conventions
+
+| Object | Pattern | Example |
+|---|---|---|
+| Privilege (view) | \`{Object}View\` | \`CustTableView\` |
+| Privilege (maintain) | \`{Object}Maintain\` | \`CustTableMaintain\` |
+| Duty | \`{Object}{Action}Duty\` | \`CustTableMaintainDuty\` |
+| Menu item | Match form/class name | \`CustTable\` |
+
+## Segregation of Duties
+- View and Maintain privileges should be in SEPARATE duties when SoD rules apply
+- Never grant Delete access in the same privilege as Create without business justification
+- Use \`get_security_artifact_info\` to verify existing duty assignments before creating new ones
+`,
+            },
+          },
+        ],
+      };
+    }
+
+    if (promptName === 'xpp_sysoperation_guide') {
+      const operationDescription = (request.params.arguments as any)?.operationDescription || '';
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `# D365FO SysOperation Framework Guide${operationDescription ? `\nOperation: ${operationDescription}` : ''}
+
+## Overview
+SysOperation is the **modern replacement for RunBaseBatch**. Always use SysOperation for new batch/dialog operations.
+Generate the full scaffold with: \`generate_code(pattern: "sysoperation", name: "MyOperation")\`
+
+## Three Classes
+
+### 1. DataContract — stores parameters
+\`\`\`xpp
+[DataContractAttribute]
+public final class MyOperationDataContract
+{
+    TransDate   transDate;
+
+    [DataMemberAttribute('TransDate'),
+     SysOperationLabelAttribute(literalStr("Transaction date"))]
+    public TransDate parmTransDate(TransDate _transDate = transDate)
+    {
+        transDate = _transDate;
+        return transDate;
+    }
+}
+\`\`\`
+
+**Rules:**
+- Each parameter = one field + one \`parmXxx\` method
+- \`[DataMemberAttribute('FieldName')]\` maps to dialog/DMF field name
+- NEVER use \`pack()\`/\`unpack()\` — that's the old RunBase pattern
+
+### 2. Controller — entry point and execution mode
+\`\`\`xpp
+class MyOperationController extends SysOperationServiceController
+{
+    protected ClassDescription defaultCaption()
+    {
+        return "My Operation";
+    }
+
+    public static void main(Args _args)
+    {
+        MyOperationController controller = new MyOperationController(
+            classStr(MyOperationService),
+            methodStr(MyOperationService, processMyOperation),
+            SysOperationExecutionMode::Synchronous);  // or Asynchronous / ScheduledBatch
+        controller.startOperation();
+    }
+}
+\`\`\`
+
+**Execution modes:**
+| Mode | Use case |
+|---|---|
+| \`Synchronous\` | Fast operations, immediate result needed |
+| \`Asynchronous\` | Long-running but user waits |
+| \`ScheduledBatch\` | Background batch processing |
+
+### 3. Service — business logic
+\`\`\`xpp
+class MyOperationService extends SysOperationServiceBase
+{
+    [SysEntryPointAttribute(true)]   // required for security
+    public void processMyOperation(MyOperationDataContract _contract)
+    {
+        TransDate transDate = _contract.parmTransDate();
+
+        ttsbegin;
+        // Business logic here
+        ttscommit;
+    }
+}
+\`\`\`
+
+**Rules:**
+- Service method MUST be marked \`[SysEntryPointAttribute(true)]\`
+- Use \`ttsbegin/ttscommit\` for all database writes
+- Never catch exceptions inside tts block — let the framework roll back
+
+## Error Handling
+\`\`\`xpp
+try
+{
+    ttsbegin;
+    // logic
+    ttscommit;
+}
+catch (Exception::Error)
+{
+    // tts is automatically rolled back
+    error("Operation failed");
+}
+\`\`\`
+
+## Testing
+\`\`\`xpp
+// Programmatic invocation (unit tests / runnable class)
+MyOperationController::main(new Args());
+\`\`\`
+`,
+            },
+          },
+        ],
+      };
+    }
+
+    if (promptName === 'xpp_data_entity_guide') {
+      const entityCategory = (request.params.arguments as any)?.entityCategory || '';
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: `# D365FO Data Entity Development Guide${entityCategory ? `\nCategory: ${entityCategory}` : ''}
+
+## Entity Categories
+
+| Category | Purpose | Example |
+|---|---|---|
+| \`parameter\` | System/module configuration | LedgerParameters |
+| \`reference\` | Lookup/master data without transactions | Currency |
+| \`master\` | Core business objects | Customer, Vendor |
+| \`document\` | Business transactions with header/lines | SalesOrder |
+| \`transaction\` | Posted/immutable records | GeneralJournalEntry |
+
+## Checking Existing Entities
+\`\`\`
+get_data_entity_info(entityName: "CustCustomerV3Entity")
+\`\`\`
+
+## Structure Pattern
+\`\`\`xpp
+[DataEntityViewAttribute,
+ SysOperationContractAttribute,
+ PublicCollectionNameAttribute('Customers'),
+ PublicEntityNameAttribute('Customer')]
+public class CustCustomerV3Entity extends common
+{
+    // Root table datasource fields mapped directly
+    // Cross-datasource fields via computedColumn methods
+}
+\`\`\`
+
+## Key Properties (set in XML)
+| Property | Description |
+|---|---|
+| \`PublicEntityName\` | OData resource name (singular, PascalCase) |
+| \`PublicCollectionName\` | OData collection name (plural) |
+| \`IsPublic\` | Expose via OData endpoint |
+| \`DataManagementEnabled\` | Enable for DMF import/export |
+| \`EntityCategory\` | One of the 5 categories above |
+| \`StagingTable\` | Auto-generated staging table for DMF |
+
+## OData vs DMF Considerations
+- **OData**: Set \`IsPublic = Yes\`, use \`PublicEntityName\` for the resource name
+- **DMF (Data Management)**: Set \`DataManagementEnabled = Yes\` and define a staging table
+- Both can be enabled simultaneously
+
+## Computed Columns
+For fields that come from complex joins or expressions:
+\`\`\`xpp
+private static server str computePartyName()
+{
+    // Return SQL expression as a string
+    return SysComputedColumn::returnField(tableStr(DirPartyTable), identifierStr(Name));
+}
+\`\`\`
+
+## Keys and Indexes
+- Every entity needs at least one **natural key** (for OData upsert and DMF deduplication)
+- Key fields should be the business identifier (AccountNum, ItemId, etc.) — NOT RecId
+
+## Common Pitfalls
+- After adding fields, run **Refresh entity list** in Data Management workspace
+- Computed columns must return a valid SQL expression string, not an X++ value
+- Mandatory fields on staging table must have defaults or be mapped from source
+- Use \`get_view_info\` to inspect the current entity's data sources and fields
+
+## Workflow
+1. \`get_data_entity_info(entityName: "...")\` — check if entity already exists
+2. \`generate_smart_table\` — for the staging table if needed
+3. \`create_d365fo_file(objectType: "view", ...)\` — create the entity file
+4. After deployment: refresh entity list in Data Management
+`,
             },
           },
         ],

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -256,6 +256,57 @@ Before responding to ANY request, ask:
 
 ---
 
+## Creating Security Objects
+
+When the user needs to create security objects (privilege/duty/role/menu item):
+1. Call \`get_security_coverage_for_object\` to understand existing coverage for the target object
+2. Call \`generate_code\` with pattern='security-privilege' (generates View + Maintain XML pair)
+3. Call \`generate_code\` with pattern='menu-item' for the menu item XML
+4. Always create BOTH View (Read) and Maintain (Update/Create/Delete) privilege variants
+5. Associate the privilege with entry point = the menu item name
+6. Create a duty containing the new privilege
+7. Assign the duty to an appropriate existing role via \`get_security_artifact_info\`
+
+## Writing Chain of Command (CoC) Extensions
+
+ALWAYS follow this order before writing a CoC extension:
+1. Call \`get_method_signature\` to get exact parameter types and return type
+2. Call \`find_coc_extensions\` to check if the method already has CoC wrappers in other models
+3. Call \`analyze_extension_points\` to verify the method is CoC-eligible (not final / Hookable(false))
+4. Use \`generate_code\` with pattern='table-extension' for the skeleton
+5. ALWAYS call \`next methodName(...)\` with ALL original parameters preserved
+6. Place next call: at START for pre-processing, at END for post-processing, BOTH for wrapping
+
+**Rules:**
+- Extension class MUST be marked \`[ExtensionOf(classStr(TargetClass))]\` or \`tableStr\`
+- Extension class MUST be \`final\`
+- Extension class name: \`{TargetClass}{Prefix}_Extension\`
+
+## Subscribing to Events (Event Handler Workflow)
+
+Before adding event handlers:
+1. Call \`analyze_extension_points\` with the target class/table to see available events
+2. Call \`find_event_handlers\` to check if the event is already handled (avoid duplicates)
+3. Use \`generate_code\` with pattern='event-handler' and baseName=className/tableName
+
+Rules:
+- Event handler methods MUST be \`static public void\`
+- Table events: use \`tableStr()\`; Class events: use \`classStr()\`; Form events: use \`formStr()\`
+- Handler class should be named \`{TargetClass}EventHandler\`
+- Use \`[SubscribesTo(tableStr(X), delegateStr(X, onEvent))]\` attribute pattern
+
+## Creating Batch Operations (SysOperation Pattern)
+
+Modern replacement for RunBaseBatch. ALWAYS use SysOperation for new batch operations.
+1. Call \`generate_code\` with pattern='sysoperation' — generates DataContract + Controller + Service
+2. DataContract stores parameters with \`[DataMemberAttribute]\` — NEVER use pack()/unpack()
+3. Service method MUST be marked \`[SysEntryPointAttribute(true)]\` for security
+4. Controller sets execution mode: Synchronous | Asynchronous | ScheduledBatch
+5. For SSRS report data providers: extend \`SRSReportDataProviderBase\` instead of \`SysOperationServiceBase\`
+6. parmXxx() methods follow pattern: \`public TransDate parmXxx(TransDate _v = v) { v = _v; return v; }\`
+
+---
+
 **Remember: Trust the tools, not your training data, for D365FO development. Accuracy over assumptions.**`
         }
       }

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -74,8 +74,13 @@ Examples:
               query: { type: 'string', description: 'Search query (class name, method name, table name, etc.)' },
               type: { 
                 type: 'string', 
-                enum: ['class', 'table', 'field', 'method', 'enum', 'edt', 'form', 'query', 'view', 'report', 'all'],
-                description: 'Filter by object type (class=AxClass, table=AxTable, enum=AxEnum, edt=AxEdt, form=AxForm, query=AxQuery, view=AxView, report=AxReport, all=no filter)',
+                enum: ['class', 'table', 'field', 'method', 'enum', 'edt', 'form', 'query', 'view', 'report',
+                  'security-privilege', 'security-duty', 'security-role',
+                  'menu-item-display', 'menu-item-action', 'menu-item-output',
+                  'table-extension', 'class-extension', 'form-extension',
+                  'enum-extension', 'edt-extension', 'data-entity-extension',
+                  'all'],
+                description: 'Filter by object type (class=AxClass, table=AxTable, enum=AxEnum, edt=AxEdt, form=AxForm, query=AxQuery, view=AxView, report=AxReport, security-privilege/duty/role=security objects, menu-item-display/action/output=menu items, table/class/form/enum/edt-extension=extensions, data-entity-extension=DE extensions, all=no filter)',
                 default: 'all'
               },
               limit: { type: 'number', description: 'Maximum results to return', default: 20 },
@@ -118,9 +123,14 @@ workspacePath and includeWorkspace parameters.`,
                     },
                     type: {
                       type: 'string',
-                      enum: ['class', 'table', 'field', 'method', 'enum', 'edt', 'form', 'query', 'view', 'report', 'all'],
+                      enum: ['class', 'table', 'field', 'method', 'enum', 'edt', 'form', 'query', 'view', 'report',
+                        'security-privilege', 'security-duty', 'security-role',
+                        'menu-item-display', 'menu-item-action', 'menu-item-output',
+                        'table-extension', 'class-extension', 'form-extension',
+                        'enum-extension', 'edt-extension', 'data-entity-extension',
+                        'all'],
                       default: 'all',
-                      description: 'Filter by object type',
+                      description: 'Filter by object type. Omit to inherit globalTypeFilter or default to "all"',
                     },
                     limit: {
                       type: 'number',
@@ -139,6 +149,31 @@ workspacePath and includeWorkspace parameters.`,
                   },
                   required: ['query'],
                 },
+              },
+              globalTypeFilter: {
+                type: 'array',
+                maxItems: 5,
+                description:
+                  'Default type filter for queries without an explicit per-query type. ' +
+                  'E.g. ["class"] restricts all untyped queries to classes. ' +
+                  'Multiple values fan out each untyped query into one search per type.',
+                items: {
+                  type: 'string',
+                  enum: [
+                    'class', 'table', 'form', 'field', 'method', 'enum', 'edt', 'query', 'view', 'report',
+                    'security-privilege', 'security-duty', 'security-role',
+                    'menu-item-display', 'menu-item-action', 'menu-item-output',
+                    'table-extension', 'class-extension', 'form-extension',
+                    'enum-extension', 'edt-extension', 'data-entity-extension',
+                  ],
+                },
+              },
+              deduplicate: {
+                type: 'boolean',
+                default: true,
+                description:
+                  'When true, symbols appearing in multiple query results are collapsed. ' +
+                  'Later occurrences are replaced with a reference to the query where they first appeared.',
               },
             },
             required: ['queries'],
@@ -299,36 +334,60 @@ WHEN TO USE (keywords):
 - "create" / "build" / "implement" / "add new" / "generate" / "make"
 - "batch job" = batch-job, "helper class" = helper class, "runnable" = runnable class
 - ANY request to create NEW D365FO class, batch job, form handler, data entity
+- "SysOperation" / "DataContract" / "event handler" / "security privilege" / "menu item"
 
 WORKFLOW (ALWAYS follow):
 1. Call analyze_code_patterns("description") → learn from existing code patterns
 2. Call generate_code(pattern, name) → get X++ source code template
 3. Call create_d365fo_file(objectType="class", objectName=name, sourceCode=<from step 2>, addToProject=true)
 
-PATTERNS:
+PATTERNS (X++ code):
 - "batch-job" → Batch job (extends RunBaseBatch) with dialog, pack/unpack, contract class
 - "class" → Standard helper/utility class
 - "runnable" → Runnable class with main() method
 - "form-handler" → Form event handler (datasource/control event subscribers)
 - "data-entity" → Data entity with staging table
 - "table-extension" → Table extension [ExtensionOf(tableStr(TableName))]
+- "sysoperation" → Full SysOperation: DataContract + Controller + Service (3 classes)
+- "event-handler" → Class with [SubscribesTo] handlers for table/class events
+
+PATTERNS (XML output — use for AOT XML files):
+- "security-privilege" → AxSecurityPrivilege XML (generates View + Maintain privilege pair)
+- "menu-item" → AxMenuItemDisplay/Action/Output XML
 
 EXAMPLES:
-- "Create batch job for processing orders"
-  → generate_code(pattern="batch-job", name="ProcessOpenOrdersBatch")
-- "Create helper class for sales calculations"
-  → generate_code(pattern="class", name="SalesCalculationHelper")
-- "Make runnable class for testing"
-  → generate_code(pattern="runnable", name="MyTestRunnable")`,
+- "Create SysOperation for processing orders"
+  → generate_code(pattern="sysoperation", name="ProcessOrders")
+- "Create event handler for CustTable"
+  → generate_code(pattern="event-handler", name="CustTable")
+- "Create security privilege for CustTable form"
+  → generate_code(pattern="security-privilege", name="CustTable", targetObject="CustTable")
+- "Create menu item for CustTable form"
+  → generate_code(pattern="menu-item", name="CustTable", menuItemType="display", targetObject="CustTable")`,
           inputSchema: {
             type: 'object',
             properties: {
-              pattern: { 
-                type: 'string', 
-                enum: ['class', 'runnable', 'form-handler', 'data-entity', 'batch-job', 'table-extension'],
-                description: 'Code pattern to generate. Use table-extension for [ExtensionOf(tableStr(...))] CoC extensions.' 
+              pattern: {
+                type: 'string',
+                enum: ['class', 'runnable', 'form-handler', 'data-entity', 'batch-job', 'table-extension',
+                       'sysoperation', 'event-handler', 'security-privilege', 'menu-item'],
+                description: 'Code pattern to generate.',
               },
-              name: { type: 'string', description: 'Name for the generated element' },
+              name: { type: 'string', description: 'Name for the generated element. For extensions: base element name.' },
+              modelName: { type: 'string', description: 'Model/solution prefix (auto-detected from EXTENSION_PREFIX env var if omitted).' },
+              menuItemType: {
+                type: 'string',
+                enum: ['display', 'action', 'output'],
+                description: 'For menu-item pattern: type of menu item (display=form, action=class, output=report)',
+              },
+              baseName: {
+                type: 'string',
+                description: 'For event-handler pattern: base class or table name whose events to handle',
+              },
+              targetObject: {
+                type: 'string',
+                description: 'For menu-item and security-privilege patterns: target form/class/report name',
+              },
             },
             required: ['pattern', 'name'],
           },
@@ -1047,6 +1106,12 @@ Examples:
                 type: 'string',
                 description: 'Model name (optional). CAUTION: If EDT not found with specific modelName, omit this and retry - EDT names are globally unique'
               },
+              mode: {
+                type: 'string',
+                enum: ['standard', 'hierarchy'],
+                description: 'standard=normal EDT details (default), hierarchy=show full ancestor chain + direct children + field usages',
+                default: 'standard',
+              },
             },
             required: ['edtName'],
           },
@@ -1526,7 +1591,251 @@ Examples:
             required: ['name'],
           },
         },
-      ],
+      // ── New tools: security, menu items, extensions ──────────────────────────────
+      {
+        name: 'get_security_artifact_info',
+        description: `Get detailed info for a D365FO security privilege, duty, or role.
+Walks the full hierarchy: Role → Duties → Privileges → Entry Points.
+
+Use for:
+- Auditing what a role or duty grants access to
+- Finding which roles cover a specific privilege
+- Understanding the entry-point/access-level details of a privilege
+
+Examples:
+  { name: "CustTableFullControl", artifactType: "privilege" }
+  { name: "CustTableMaintain", artifactType: "duty", includeChain: true }
+  { name: "AccountsReceivableClerk", artifactType: "role" }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Name of the security privilege, duty, or role' },
+            artifactType: {
+              type: 'string',
+              enum: ['privilege', 'duty', 'role'],
+              description: 'Type of security artifact to look up',
+            },
+            includeChain: { type: 'boolean', description: 'Walk the full hierarchy (default: true)', default: true },
+          },
+          required: ['name', 'artifactType'],
+        },
+      },
+      {
+        name: 'get_menu_item_info',
+        description: `Get details for a D365FO menu item including target object and full security chain.
+
+Shows the privilege → duty → role chain that grants access to this menu item.
+
+Examples:
+  { name: "CustTable", itemType: "display" }
+  { name: "LedgerJournalTable", itemType: "any" }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Name of the menu item' },
+            itemType: {
+              type: 'string',
+              enum: ['display', 'action', 'output', 'any'],
+              description: 'Menu item type filter (default: any)',
+              default: 'any',
+            },
+          },
+          required: ['name'],
+        },
+      },
+      {
+        name: 'find_coc_extensions',
+        description: `Find all Chain of Command (CoC) extensions for a D365FO class or table method.
+
+Also shows event handler subscriptions (SubscribesTo) for the target class/table.
+
+Use this before writing a CoC extension to:
+1. Check if the method is already wrapped
+2. Understand which models extend this class
+3. Find potential conflicts
+
+Examples:
+  { className: "SalesFormLetter" }
+  { className: "SalesLine", methodName: "validateWrite" }
+  { className: "CustTable", includeEventHandlers: true }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            className: { type: 'string', description: 'Base class or table name being extended' },
+            methodName: { type: 'string', description: 'Optional: filter to a specific method name' },
+            includeEventHandlers: {
+              type: 'boolean',
+              description: 'Also find static event subscriptions (SubscribesTo) (default: true)',
+              default: true,
+            },
+          },
+          required: ['className'],
+        },
+      },
+      {
+        name: 'get_table_extension_info',
+        description: `Get all extensions for a D365FO table and show the effective merged schema.
+
+Lists every extension across all models that add fields, indexes, or methods to the table.
+
+Examples:
+  { tableName: "CustTable" }
+  { tableName: "SalesLine", includeEffectiveSchema: true }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            tableName: { type: 'string', description: 'Base table name whose extensions to find' },
+            includeEffectiveSchema: {
+              type: 'boolean',
+              description: 'Merge base + extension counts (default: true)',
+              default: true,
+            },
+          },
+          required: ['tableName'],
+        },
+      },
+      {
+        name: 'get_data_entity_info',
+        description: `Get D365FO-specific metadata for a data entity (AxDataEntityView).
+
+Shows OData settings, DMF configuration, staging table, data sources, and keys.
+Use instead of get_view_info when working with entities for OData/DMF integrations.
+
+Examples:
+  { entityName: "CustCustomerV3Entity" }
+  { entityName: "SalesOrderHeaderV2Entity" }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            entityName: { type: 'string', description: 'Name of the data entity (AxDataEntityView name)' },
+          },
+          required: ['entityName'],
+        },
+      },
+      {
+        name: 'find_event_handlers',
+        description: `Find all event handler subscriptions for a D365FO class or table.
+
+Searches for static SubscribesTo handlers and delegate += subscriptions.
+Use before adding event handlers to check for duplicates.
+
+Examples:
+  { targetTable: "CustTable" }
+  { targetClass: "SalesFormLetter", eventName: "onPostRun" }
+  { targetTable: "SalesLine", eventName: "onValidatedWrite" }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            targetClass: { type: 'string', description: 'Class whose events to find handlers for' },
+            targetTable: { type: 'string', description: 'Table whose events to find handlers for' },
+            eventName: { type: 'string', description: 'Filter to a specific event name (e.g. onInserted)' },
+            handlerType: {
+              type: 'string',
+              enum: ['static', 'delegate', 'all'],
+              description: 'Filter by handler type (default: all)',
+              default: 'all',
+            },
+          },
+        },
+      },
+      {
+        name: 'get_security_coverage_for_object',
+        description: `Show what security privileges, duties, and roles cover a D365FO object.
+
+Traces the reverse chain: object → menu items → privileges → duties → roles.
+
+Examples:
+  { objectName: "CustTable" }
+  { objectName: "LedgerJournalTable", objectType: "form" }
+  { objectName: "CustTableListPage", objectType: "menu-item" }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            objectName: { type: 'string', description: 'Name of the form, table, class, or menu item' },
+            objectType: {
+              type: 'string',
+              enum: ['form', 'table', 'class', 'menu-item', 'auto'],
+              description: 'Type of the object (default: auto-detect)',
+              default: 'auto',
+            },
+          },
+          required: ['objectName'],
+        },
+      },
+      {
+        name: 'analyze_extension_points',
+        description: `Analyze available extension points for a D365FO class, table, or form.
+
+For classes: CoC-eligible methods, replaceable methods, delegates, and blocked methods.
+For tables: 8 standard table events + custom delegates.
+For forms: data sources and form methods.
+Shows which extension points are already used by existing extensions.
+
+Use this before writing any extension.
+
+Examples:
+  { objectName: "SalesLine", objectType: "table" }
+  { objectName: "SalesFormLetter", objectType: "class" }
+  { objectName: "CustTable", showExistingExtensions: true }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            objectName: { type: 'string', description: 'Class, table, or form name to analyze' },
+            objectType: {
+              type: 'string',
+              enum: ['class', 'table', 'form', 'auto'],
+              description: 'Object type (default: auto-detect)',
+              default: 'auto',
+            },
+            showExistingExtensions: {
+              type: 'boolean',
+              description: 'Show which extension points are already extended (default: true)',
+              default: true,
+            },
+          },
+          required: ['objectName'],
+        },
+      },
+      {
+        name: 'validate_object_naming',
+        description: `Validate a proposed D365FO object name against naming conventions.
+
+Checks:
+1. Extension naming rules: {Base}{Prefix}_Extension (class) or {Base}.{Prefix}Extension (AOT)
+2. Prefix requirements: custom objects must use ISV/model prefix
+3. Type-specific rules: privilege → View/Maintain suffix, data entity → Entity suffix
+4. Conflict detection: exact match + similar names against the symbol index
+
+Use before creating any new D365FO object to ensure correct naming.
+
+Examples:
+  { proposedName: "SalesTableExtension", objectType: "class-extension", baseObjectName: "SalesTable" }
+  { proposedName: "WHSSalesTable_Extension", objectType: "class-extension", baseObjectName: "SalesTable", modelPrefix: "WHS" }
+  { proposedName: "CustTableFullControl", objectType: "security-privilege" }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            proposedName: { type: 'string', description: 'The proposed object name to validate' },
+            objectType: {
+              type: 'string',
+              enum: ['class', 'table', 'form', 'enum', 'edt', 'query', 'view',
+                'table-extension', 'class-extension', 'form-extension', 'enum-extension', 'edt-extension',
+                'menu-item', 'security-privilege', 'security-duty', 'security-role', 'data-entity'],
+              description: 'Type of the D365FO object',
+            },
+            baseObjectName: {
+              type: 'string',
+              description: 'Required for extension types: name of the object being extended',
+            },
+            modelPrefix: {
+              type: 'string',
+              description: 'Expected ISV/model prefix (2-4 uppercase letters, e.g. "WHS"). Auto-detected if omitted.',
+            },
+          },
+          required: ['proposedName', 'objectType'],
+        },
+      },
+    ],
     };
 
     // Apply server mode filter

--- a/src/tools/analyzeExtensionPoints.ts
+++ b/src/tools/analyzeExtensionPoints.ts
@@ -1,0 +1,276 @@
+/**
+ * Analyze Extension Points Tool
+ * Show available CoC/event extension points for a D365FO class or table,
+ * distinguishing eligible methods from blocked ones, and showing existing extensions
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+// Standard D365FO table events available for subscription
+const TABLE_STANDARD_EVENTS = [
+  'onInserted', 'onUpdated', 'onDeleted',
+  'onValidatedWrite', 'onValidatedInsert', 'onValidatedDelete',
+  'onInitialized', 'onInitValue',
+];
+
+const AnalyzeExtensionPointsArgsSchema = z.object({
+  objectName: z.string().describe('Class or table name to analyze extension points for'),
+  objectType: z.enum(['class', 'table', 'form', 'auto']).optional().default('auto')
+    .describe('Object type (auto=detect from symbol index)'),
+  showExistingExtensions: z.boolean().optional().default(true)
+    .describe('Show which extension points are already wrapped/subscribed by existing extensions'),
+});
+
+export async function analyzeExtensionPointsTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = AnalyzeExtensionPointsArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+    const objName = args.objectName;
+
+    // ── Step 1: Resolve object type ──
+    let resolvedType = args.objectType;
+    if (resolvedType === 'auto') {
+      const sym = db.prepare(
+        `SELECT type FROM symbols WHERE name = ? AND type IN ('class','table','form')
+         ORDER BY CASE type WHEN 'class' THEN 0 WHEN 'table' THEN 1 WHEN 'form' THEN 2 END LIMIT 1`
+      ).get(objName) as any;
+      if (sym) resolvedType = sym.type as any;
+    }
+
+    const baseSymbol = db.prepare(
+      `SELECT name, type, model, file_path FROM symbols WHERE name = ? AND type = ? LIMIT 1`
+    ).get(objName, resolvedType === 'auto' ? 'class' : resolvedType) as any;
+
+    let output = `Extension Points for: ${objName}`;
+    if (resolvedType !== 'auto') output += ` (${resolvedType})`;
+    if (baseSymbol) output += ` — ${baseSymbol.model}`;
+    output += '\n\n';
+
+    // ── Step 2: Load existing extension data ──
+    let existingExtensions: any[] = [];
+    if (args.showExistingExtensions) {
+      try {
+        const extType = resolvedType === 'auto' ? '%' : `${resolvedType}-extension`;
+        existingExtensions = db.prepare(
+          `SELECT extension_name, model, coc_methods, event_subscriptions, added_methods
+           FROM extension_metadata
+           WHERE base_object_name = ? AND extension_type LIKE ?
+           ORDER BY model, extension_name`
+        ).all(objName, extType) as any[];
+      } catch { /**/ }
+    }
+
+    // Build maps of already-extended methods and subscribed events
+    const alreadyWrapped = new Map<string, string[]>(); // methodName → [extName, ...]
+    const alreadySubscribed = new Map<string, string[]>(); // eventName → [handlerClass, ...]
+
+    for (const ext of existingExtensions) {
+      let cocMethods: string[] = [];
+      let eventSubs: string[] = [];
+      try { cocMethods = JSON.parse(ext.coc_methods || '[]'); } catch { /**/ }
+      try { eventSubs = JSON.parse(ext.event_subscriptions || '[]'); } catch { /**/ }
+
+      for (const m of cocMethods) {
+        const key = m.toLowerCase();
+        if (!alreadyWrapped.has(key)) alreadyWrapped.set(key, []);
+        alreadyWrapped.get(key)!.push(ext.extension_name);
+      }
+      for (const ev of eventSubs) {
+        const delegateMatch = ev.match(/delegateStr\([^,]+,\s*(\w+)\)/);
+        if (delegateMatch) {
+          const evName = delegateMatch[1];
+          if (!alreadySubscribed.has(evName)) alreadySubscribed.set(evName, []);
+          alreadySubscribed.get(evName)!.push(ext.extension_name);
+        }
+      }
+    }
+
+    // Also scan symbols for SubscribesTo for this object
+    try {
+      const subHandlers = db.prepare(
+        `SELECT name, parent_name, source_snippet FROM symbols
+         WHERE type='method' AND source_snippet LIKE '%SubscribesTo%' AND source_snippet LIKE ?
+         LIMIT 30`
+      ).all(`%${objName}%`) as any[];
+
+      for (const h of subHandlers) {
+        const delegateMatch = (h.source_snippet || '').match(/delegateStr\([^,]+,\s*(\w+)\)/);
+        if (delegateMatch) {
+          const evName = delegateMatch[1];
+          if (!alreadySubscribed.has(evName)) alreadySubscribed.set(evName, []);
+          const label = `${h.parent_name}.${h.name}`;
+          if (!alreadySubscribed.get(evName)!.includes(label)) {
+            alreadySubscribed.get(evName)!.push(label);
+          }
+        }
+      }
+    } catch { /**/ }
+
+    // ── Step 3: For classes — analyze methods ──
+    if (resolvedType === 'class' || resolvedType === 'auto') {
+      const methods = db.prepare(
+        `SELECT name, signature, source_snippet FROM symbols
+         WHERE parent_name = ? AND type = 'method'
+         ORDER BY name`
+      ).all(objName) as any[];
+
+      if (methods.length > 0) {
+        const cocEligible: any[] = [];
+        const blocked: any[] = [];
+        const delegates: any[] = [];
+        const replaceables: any[] = [];
+
+        for (const m of methods) {
+          const sig = (m.signature || '').toLowerCase();
+          const src = (m.source_snippet || '').toLowerCase();
+
+          if (src.includes('delegate ') || sig.includes('delegate ')) {
+            delegates.push(m);
+          } else if (src.includes('[hookable(false)]') || src.includes('hookable(false)')) {
+            blocked.push({ ...m, reason: 'Hookable(false)' });
+          } else if (sig.includes('final ') || src.includes('\nfinal ')) {
+            blocked.push({ ...m, reason: 'final' });
+          } else if (src.includes('[replaceable]') || src.includes('replaceable]')) {
+            replaceables.push(m);
+          } else if (sig.includes('public ') || sig.includes('protected ')) {
+            // CoC eligible: public or protected, non-final
+            cocEligible.push(m);
+          }
+        }
+
+        if (cocEligible.length > 0) {
+          output += `CoC-eligible methods (${cocEligible.length}):\n`;
+          for (const m of cocEligible.slice(0, 20)) {
+            const wrappedBy = alreadyWrapped.get(m.name.toLowerCase());
+            const status = wrappedBy
+              ? `EXTENDED by ${wrappedBy.slice(0, 2).join(', ')}${wrappedBy.length > 2 ? '...' : ''}`
+              : 'not yet extended';
+            output += `  ✓ ${m.name}()\t[${status}]\n`;
+          }
+          if (cocEligible.length > 20) {
+            output += `  ... and ${cocEligible.length - 20} more methods\n`;
+          }
+          output += '\n';
+        }
+
+        if (replaceables.length > 0) {
+          output += `Replaceable methods (${replaceables.length}):\n`;
+          for (const m of replaceables) {
+            output += `  ↔ ${m.name}() [Replaceable — can be completely replaced]\n`;
+          }
+          output += '\n';
+        }
+
+        if (delegates.length > 0) {
+          output += `Delegate hooks (${delegates.length}):\n`;
+          for (const m of delegates) {
+            const subscribedBy = alreadySubscribed.get(m.name);
+            output += `  ⚡ ${m.name}`;
+            if (subscribedBy && subscribedBy.length > 0) {
+              output += ` → ${subscribedBy.length} subscriber(s): ${subscribedBy.slice(0, 2).join(', ')}`;
+            } else {
+              output += ` → 0 subscribers`;
+            }
+            output += '\n';
+          }
+          output += '\n';
+        }
+
+        if (blocked.length > 0) {
+          output += `Blocked methods (${blocked.length}):\n`;
+          for (const m of blocked.slice(0, 10)) {
+            output += `  ✗ ${m.name}() [${m.reason} — cannot wrap]\n`;
+          }
+          if (blocked.length > 10) output += `  ... and ${blocked.length - 10} more\n`;
+          output += '\n';
+        }
+      }
+    }
+
+    // ── Step 4: For tables — show standard events ──
+    if (resolvedType === 'table' || resolvedType === 'auto') {
+      output += `Table Events (${TABLE_STANDARD_EVENTS.length} standard hooks):\n`;
+      for (const ev of TABLE_STANDARD_EVENTS) {
+        const subscribers = alreadySubscribed.get(ev) || [];
+        // Also check FTS
+        if (subscribers.length === 0) {
+          try {
+            const ftsCheck = db.prepare(
+              `SELECT COUNT(*) as cnt FROM symbols WHERE type='method'
+               AND source_snippet LIKE ? AND source_snippet LIKE ?`
+            ).get(`%SubscribesTo%`, `%${ev}%`) as any;
+            output += `  ${ev.padEnd(22)} [${ftsCheck?.cnt > 0 ? `~${ftsCheck.cnt} handler(s)` : '0 handlers'}]\n`;
+          } catch {
+            output += `  ${ev.padEnd(22)} [${subscribers.length} handler(s)]\n`;
+          }
+        } else {
+          output += `  ${ev.padEnd(22)} [${subscribers.length} handler(s): ${subscribers.slice(0, 2).join(', ')}]\n`;
+        }
+      }
+
+      // Also check custom delegates on the table class
+      const tableMethods = db.prepare(
+        `SELECT name, source_snippet FROM symbols
+         WHERE parent_name = ? AND type = 'method'
+         AND (source_snippet LIKE '%delegate %' OR signature LIKE '%delegate %')
+         LIMIT 10`
+      ).all(objName) as any[];
+
+      if (tableMethods.length > 0) {
+        output += `\nCustom delegates (${tableMethods.length}):\n`;
+        for (const m of tableMethods) {
+          const subCount = alreadySubscribed.get(m.name)?.length ?? 0;
+          output += `  ⚡ ${m.name} → ${subCount} subscriber(s)\n`;
+        }
+      }
+    }
+
+    // ── Step 5: For forms — show data sources and methods ──
+    if (resolvedType === 'form') {
+      const formDataSources = db.prepare(
+        `SELECT name FROM symbols WHERE parent_name = ? AND type = 'datasource' ORDER BY name`
+      ).all(objName) as any[];
+
+      if (formDataSources.length > 0) {
+        output += `Form Data Sources (${formDataSources.length}):\n`;
+        for (const ds of formDataSources) {
+          output += `  ${ds.name} — table events apply + datasource methods extensible\n`;
+        }
+        output += '\n';
+      }
+
+      const formMethods = db.prepare(
+        `SELECT name FROM symbols WHERE parent_name = ? AND type = 'method' ORDER BY name LIMIT 20`
+      ).all(objName) as any[];
+
+      if (formMethods.length > 0) {
+        output += `Form methods (${formMethods.length} shown, CoC-eligible via form extension):\n`;
+        output += `  ${formMethods.slice(0, 10).map((m: any) => m.name + '()').join(', ')}`;
+        if (formMethods.length > 10) output += ` (+${formMethods.length - 10} more)`;
+        output += '\n';
+      }
+    }
+
+    // ── Summary of existing extensions ──
+    if (args.showExistingExtensions && existingExtensions.length > 0) {
+      output += `\nExisting extensions (${existingExtensions.length}):\n`;
+      for (const ext of existingExtensions) {
+        output += `  ${ext.extension_name} [${ext.model}]\n`;
+      }
+    }
+
+    return { content: [{ type: 'text', text: output }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error analyzing extension points: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/batchSearch.ts
+++ b/src/tools/batchSearch.ts
@@ -1,9 +1,9 @@
 /**
  * Batch Search Tool - Priority 3 Optimization
- * 
+ *
  * Allows AI agents to parallelize independent search queries in a single HTTP request.
  * Reduces round-trip overhead and enables concurrent search execution.
- * 
+ *
  * Expected Impact:
  * - 3 HTTP requests → 1 HTTP request (3x faster)
  * - Enable 40% of searches to be parallelized
@@ -15,15 +15,26 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { searchTool } from './search.js';
 
+/** Valid D365FO symbol type values (mirrors SearchArgsSchema) */
+const SYMBOL_TYPES = [
+  'class', 'table', 'form', 'field', 'method', 'enum', 'edt', 'query', 'view', 'report',
+  'security-privilege', 'security-duty', 'security-role',
+  'menu-item-display', 'menu-item-action', 'menu-item-output',
+  'table-extension', 'class-extension', 'form-extension',
+  'enum-extension', 'edt-extension', 'data-entity-extension',
+  'all',
+] as const;
+
+type SymbolType = typeof SYMBOL_TYPES[number];
+
 /**
- * Schema for individual search query
+ * Schema for individual search query.
+ * `type` is optional (no default) so we can distinguish "not specified" from "explicitly set".
  */
 const SingleSearchSchema = z.object({
   query: z.string().describe('Search query (class name, method name, etc.)'),
-  type: z.enum(['class', 'table', 'field', 'method', 'enum', 'all'])
-    .optional()
-    .default('all')
-    .describe('Filter by object type'),
+  type: z.enum(SYMBOL_TYPES).optional()
+    .describe('Filter by object type. Omit to use globalTypeFilter (if set) or default to "all"'),
   limit: z.number().max(100).optional().default(10).describe('Maximum results per query'),
   workspacePath: z.string().optional().describe('Optional workspace path'),
   includeWorkspace: z.boolean().optional().default(false).describe('Include workspace files'),
@@ -37,67 +48,191 @@ export const BatchSearchArgsSchema = z.object({
     .min(1)
     .max(10)
     .describe('Array of search queries to execute in parallel (max 10)'),
+  globalTypeFilter: z.array(z.string()).max(5).optional()
+    .describe(
+      'Default type filter applied to queries that have no per-query type set. ' +
+      'E.g. ["class"] restricts all untyped queries to classes only. ' +
+      'Multiple types fan out each untyped query into one search per type.'
+    ),
+  deduplicate: z.boolean().optional().default(true)
+    .describe(
+      'Remove symbols that appear in more than one query result. ' +
+      'Duplicate entries in later queries are replaced with a reference to the query where they first appeared.'
+    ),
 });
+
+// ── Regex to extract [TYPE] SymbolName from search result lines ──
+const RESULT_LINE_RE =
+  /\[(CLASS|TABLE|FORM|FIELD|METHOD|ENUM|EDT|QUERY|VIEW|REPORT|SECURITY-PRIVILEGE|SECURITY-DUTY|SECURITY-ROLE|MENU-ITEM-DISPLAY|MENU-ITEM-ACTION|MENU-ITEM-OUTPUT|TABLE-EXTENSION|CLASS-EXTENSION|FORM-EXTENSION|ENUM-EXTENSION|EDT-EXTENSION|DATA-ENTITY-EXTENSION|WORKFLOW-TYPE|AGGREGATE-MEASUREMENT|CONFIGURATION-KEY)\]\s+(\w+)/;
+
+/**
+ * Annotate duplicate symbol lines in `text`, given already-seen keys from earlier queries.
+ * Returns { text: annotated text, dupCount: number of duplicates replaced }
+ */
+function annotateDuplicates(
+  text: string,
+  seenKeys: Map<string, number>,
+  currentQueryIdx: number
+): { text: string; dupCount: number } {
+  const lines = text.split('\n');
+  let dupCount = 0;
+  const out: string[] = [];
+
+  for (const line of lines) {
+    const m = line.match(RESULT_LINE_RE);
+    if (m) {
+      const key = `${m[1]}:${m[2]}`;
+      if (seenKeys.has(key)) {
+        out.push(`  (${m[2]} [${m[1]}] → already shown in Query ${seenKeys.get(key)})`);
+        dupCount++;
+        continue;
+      }
+      seenKeys.set(key, currentQueryIdx);
+    }
+    out.push(line);
+  }
+
+  return { text: out.join('\n'), dupCount };
+}
+
+// ── Internal result type ─────────────────────────────────────────────────────
+interface QueryResult {
+  query: string;
+  typeLabel?: string;  // e.g. "CLASS, TABLE" for fan-out queries
+  success: boolean;
+  result?: any;
+  error?: string;
+}
+
+/**
+ * Build a synthetic CallToolRequest for the underlying searchTool.
+ */
+function makeSearchRequest(
+  queryArgs: z.infer<typeof SingleSearchSchema>,
+  overrideType?: string
+): CallToolRequest {
+  return {
+    method: 'tools/call',
+    params: {
+      name: 'search',
+      arguments: {
+        ...queryArgs,
+        type: overrideType ?? queryArgs.type ?? 'all',
+      },
+    },
+  };
+}
 
 /**
  * Batch Search Tool Handler
- * 
- * Executes multiple search queries in parallel and returns aggregated results.
- * 
- * @param request - MCP tool call request with batch search parameters
- * @param context - Server context with symbol index and cache
- * @returns Combined results from all parallel searches
  */
 export async function batchSearchTool(request: CallToolRequest, context: XppServerContext) {
   const startTime = Date.now();
-  
+
   try {
     const args = BatchSearchArgsSchema.parse(request.params.arguments);
-    
-    // Execute all searches in parallel using Promise.all
-    const searchPromises = args.queries.map(async (queryArgs) => {
-      // Create a CallToolRequest for each individual search
-      const searchRequest: CallToolRequest = {
-        method: 'tools/call',
-        params: {
-          name: 'search',
-          arguments: queryArgs,
-        },
+
+    // Validate globalTypeFilter values
+    const validGlobalTypes = (args.globalTypeFilter ?? []).filter(
+      (t): t is SymbolType => (SYMBOL_TYPES as readonly string[]).includes(t)
+    );
+
+    // ── Build flat list of sub-searches ──────────────────────────────────────
+    // Each query either maps 1:1, or fans out into multiple searches (globalTypeFilter).
+    // We track which original query index each sub-search belongs to.
+
+    interface SubSearch {
+      queryIdx: number;         // 0-based index into args.queries
+      query: string;
+      overrideType: string | undefined;
+      queryArgs: z.infer<typeof SingleSearchSchema>;
+    }
+
+    const subSearches: SubSearch[] = [];
+
+    for (let i = 0; i < args.queries.length; i++) {
+      const q = args.queries[i];
+      const hasExplicitType = q.type !== undefined;
+
+      if (!hasExplicitType && validGlobalTypes.length > 0) {
+        // Fan out: one sub-search per type in globalTypeFilter
+        for (const t of validGlobalTypes) {
+          subSearches.push({ queryIdx: i, query: q.query, overrideType: t, queryArgs: q });
+        }
+      } else {
+        subSearches.push({ queryIdx: i, query: q.query, overrideType: q.type, queryArgs: q });
+      }
+    }
+
+    // ── Execute all sub-searches in parallel ─────────────────────────────────
+    const rawResults: Array<SubSearch & { success: boolean; result?: any; error?: string }> =
+      await Promise.all(
+        subSearches.map(async (sub) => {
+          const req = makeSearchRequest(sub.queryArgs, sub.overrideType);
+          try {
+            const result = await searchTool(req, context);
+            return { ...sub, success: !result.isError, result };
+          } catch (err) {
+            return { ...sub, success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+          }
+        })
+      );
+
+    // ── Merge fan-out sub-searches back per original query ────────────────────
+    const mergedResults: QueryResult[] = args.queries.map((q, i) => {
+      const subs = rawResults.filter(r => r.queryIdx === i);
+      if (subs.length === 1) {
+        const s = subs[0];
+        return { query: q.query, success: s.success, result: s.result, error: s.error };
+      }
+      // Multiple sub-searches (fan-out): merge their text outputs
+      const typeLabels = subs.map(s => (s.overrideType ?? 'all').toUpperCase()).join(', ');
+      const successSubs = subs.filter(s => s.success && s.result?.content?.[0]?.text);
+      const combinedText = successSubs
+        .map(s => `[${(s.overrideType ?? 'all').toUpperCase()}]\n${s.result.content[0].text}`)
+        .join('\n\n');
+      const anySuccess = subs.some(s => s.success);
+      return {
+        query: q.query,
+        typeLabel: typeLabels,
+        success: anySuccess,
+        result: anySuccess ? { content: [{ type: 'text', text: combinedText }] } : undefined,
+        error: anySuccess ? undefined : subs.map(s => s.error).filter(Boolean).join('; '),
       };
-      
-      try {
-        const result = await searchTool(searchRequest, context);
-        // Check if the search returned an error
-        const hasError = result.isError === true;
-        return {
-          query: queryArgs.query,
-          success: !hasError,
-          result,
-        };
-      } catch (error) {
-        return {
-          query: queryArgs.query,
-          success: false,
-          error: error instanceof Error ? error.message : 'Unknown error',
+    });
+
+    // ── Deduplication ─────────────────────────────────────────────────────────
+    let dedupStats = { total: 0 };
+    if (args.deduplicate) {
+      const seenKeys = new Map<string, number>(); // key → 1-based query index
+
+      for (let i = 0; i < mergedResults.length; i++) {
+        const r = mergedResults[i];
+        if (!r.success || !r.result?.content?.[0]?.text) continue;
+
+        const { text, dupCount } = annotateDuplicates(
+          r.result.content[0].text,
+          seenKeys,
+          i + 1
+        );
+        dedupStats.total += dupCount;
+        mergedResults[i] = {
+          ...r,
+          result: { ...r.result, content: [{ type: 'text', text }] },
         };
       }
-    });
-    
-    // Wait for all searches to complete
-    const results = await Promise.all(searchPromises);
+    }
+
     const executionTime = Date.now() - startTime;
-    
-    // Format the combined results
-    const output = formatBatchResults(results, executionTime, args.queries.length);
-    
-    return {
-      content: [
-        {
-          type: 'text',
-          text: output,
-        },
-      ],
-    };
+    const output = formatBatchResults(
+      mergedResults,
+      executionTime,
+      args.queries.length,
+      validGlobalTypes,
+      args.deduplicate ? dedupStats.total : -1
+    );
+
+    return { content: [{ type: 'text', text: output }] };
   } catch (error) {
     return {
       content: [
@@ -115,53 +250,51 @@ export async function batchSearchTool(request: CallToolRequest, context: XppServ
  * Format batch search results into readable output
  */
 function formatBatchResults(
-  results: Array<{
-    query: string;
-    success: boolean;
-    result?: any;
-    error?: string;
-  }>,
+  results: QueryResult[],
   executionTime: number,
-  totalQueries: number
+  totalQueries: number,
+  globalTypeFilter: string[],
+  dedupCount: number  // -1 = dedup disabled
 ): string {
-  let output = `# 🔍 Batch Search Results\n\n`;
-  output += `**Executed:** ${totalQueries} parallel ${totalQueries === 1 ? 'query' : 'queries'}\n`;
-  output += `**Time:** ${executionTime}ms (parallel execution)\n`;
-  output += `**Success:** ${results.filter(r => r.success).length}/${totalQueries}\n\n`;
-  output += `---\n\n`;
-  
-  // Display results for each query
+  let output = `# Batch Search Results\n\n`;
+  output += `Executed: ${totalQueries} parallel ${totalQueries === 1 ? 'query' : 'queries'}`;
+  if (globalTypeFilter.length > 0) {
+    output += ` (global type filter: ${globalTypeFilter.join(', ')})`;
+  }
+  output += `\n`;
+  output += `Time: ${executionTime}ms (parallel execution)\n`;
+  output += `Success: ${results.filter(r => r.success).length}/${totalQueries}\n`;
+  if (dedupCount >= 0) {
+    output += `Deduplication: ${dedupCount} duplicate symbol(s) collapsed\n`;
+  }
+  output += `\n---\n\n`;
+
   results.forEach((result, index) => {
-    output += `## Query ${index + 1}: "${result.query}"\n\n`;
-    
+    const typeNote = result.typeLabel ? ` [${result.typeLabel}]` : '';
+    output += `## Query ${index + 1}: "${result.query}"${typeNote}\n\n`;
+
     if (result.result) {
-      // Extract text from the result content (works for both success and error)
-      const resultText = result.result.content?.[0]?.text || 'No results';
-      output += resultText;
+      output += result.result.content?.[0]?.text || 'No results';
     } else if (result.error) {
-      output += `❌ **Error:** ${result.error}\n`;
+      output += `Error: ${result.error}`;
     } else {
-      output += `❌ **Error:** Unknown error\n`;
+      output += `Error: Unknown error`;
     }
-    
+
     output += `\n\n---\n\n`;
   });
-  
-  // Add performance note
-  output += `\n💡 **Performance Note:** All ${totalQueries} searches executed in parallel.\n`;
-  output += `Sequential execution would take ~${totalQueries * 50}ms (estimated), `;
-  output += `parallel execution: ${executionTime}ms → `;
-  
-  // Handle division by zero (when executionTime is 0 or very small)
+
+  // Performance note
+  output += `\n💡 Performance Note: ${totalQueries} searches in ${executionTime}ms (parallel execution). `;
+  const sequentialEstimate = totalQueries * 50;
   if (executionTime > 0) {
-    const speedup = Math.round((totalQueries * 50) / executionTime * 10) / 10;
-    output += `**${speedup}x faster**\n`;
+    const speedup = Math.round(sequentialEstimate / executionTime * 10) / 10;
+    output += `Estimated sequential: ~${sequentialEstimate}ms → ${speedup}x faster.\n`;
   } else {
-    // When execution is too fast to measure, show estimated speedup
-    const estimatedTime = Math.max(1, totalQueries * 10); // Realistic minimum
-    output += `**~${totalQueries * 50 / estimatedTime}x faster** (execution too fast to measure precisely)\n`;
+    const estimatedTime = Math.max(1, totalQueries * 10);
+    output += `~${Math.round(sequentialEstimate / estimatedTime)}x faster (execution too fast to measure precisely).\n`;
   }
-  
+
   return output;
 }
 
@@ -179,6 +312,9 @@ Use cases:
 - Exploring multiple related concepts simultaneously (e.g., "dimension", "helper", "validation")
 - Comparing different search queries at once
 - Reducing workflow time for exploratory searches
+
+globalTypeFilter: restrict all untyped queries to specific object types without repeating the type per query.
+deduplicate: collapse symbols appearing in multiple query results (default: true).
 
 Performance:
 - 3 sequential searches: ~150ms (3 HTTP requests)
@@ -203,9 +339,15 @@ workspacePath and includeWorkspace parameters.`,
             },
             type: {
               type: 'string',
-              enum: ['class', 'table', 'field', 'method', 'enum', 'all'],
-              default: 'all',
-              description: 'Filter by object type',
+              enum: [
+                'class', 'table', 'form', 'field', 'method', 'enum', 'edt', 'query', 'view', 'report',
+                'security-privilege', 'security-duty', 'security-role',
+                'menu-item-display', 'menu-item-action', 'menu-item-output',
+                'table-extension', 'class-extension', 'form-extension',
+                'enum-extension', 'edt-extension', 'data-entity-extension',
+                'all',
+              ],
+              description: 'Filter by object type. Omit to inherit globalTypeFilter or default to "all"',
             },
             limit: {
               type: 'number',
@@ -224,6 +366,31 @@ workspacePath and includeWorkspace parameters.`,
           },
           required: ['query'],
         },
+      },
+      globalTypeFilter: {
+        type: 'array',
+        maxItems: 5,
+        description:
+          'Default type filter for queries without an explicit per-query type. ' +
+          'E.g. ["class"] restricts all untyped queries to classes. ' +
+          'Multiple values fan out each untyped query into one search per type.',
+        items: {
+          type: 'string',
+          enum: [
+            'class', 'table', 'form', 'field', 'method', 'enum', 'edt', 'query', 'view', 'report',
+            'security-privilege', 'security-duty', 'security-role',
+            'menu-item-display', 'menu-item-action', 'menu-item-output',
+            'table-extension', 'class-extension', 'form-extension',
+            'enum-extension', 'edt-extension', 'data-entity-extension',
+          ],
+        },
+      },
+      deduplicate: {
+        type: 'boolean',
+        default: true,
+        description:
+          'When true, symbols appearing in multiple query results are collapsed: ' +
+          'later occurrences are replaced with a reference to the query where they first appeared.',
       },
     },
     required: ['queries'],

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -10,16 +10,24 @@ import { getConfigManager } from '../utils/configManager.js';
 
 const CodeGenArgsSchema = z.object({
   pattern: z
-    .enum(['class', 'runnable', 'form-handler', 'data-entity', 'batch-job', 'table-extension'])
+    .enum(['class', 'runnable', 'form-handler', 'data-entity', 'batch-job', 'table-extension',
+           'sysoperation', 'event-handler', 'security-privilege', 'menu-item'])
     .describe('Code pattern to generate'),
   name: z.string().describe(
-    'For NEW objects (class, runnable, data-entity, batch-job): the object name WITHOUT prefix — prefix is auto-applied from EXTENSION_PREFIX env var or modelName. ' +
-    'For EXTENSIONS (table-extension, form-handler): the BASE element name to extend (e.g. "CustTable", "SalesTable").'
+    'For NEW objects (class, runnable, data-entity, batch-job, sysoperation): the object name WITHOUT prefix — prefix is auto-applied from EXTENSION_PREFIX env var or modelName. ' +
+    'For EXTENSIONS (table-extension, form-handler, event-handler): the BASE element name to extend (e.g. "CustTable", "SalesTable"). ' +
+    'For XML patterns (security-privilege, menu-item): the name for the generated XML object.'
   ),
   modelName: z.string().optional().describe(
     'Model/solution prefix used to derive the naming infix when EXTENSION_PREFIX is not set (e.g. "MyModel"). ' +
     'Required for extension patterns when EXTENSION_PREFIX is not configured.'
   ),
+  menuItemType: z.enum(['display', 'action', 'output']).optional()
+    .describe('For menu-item pattern: type of menu item (display=form, action=class, output=report)'),
+  baseName: z.string().optional()
+    .describe('For event-handler pattern: base class or table name whose events to handle'),
+  targetObject: z.string().optional()
+    .describe('For menu-item pattern: target form/class/report name'),
 });
 
 // Templates for NEW elements: (name already includes prefix)
@@ -163,6 +171,7 @@ class ${name}Service extends SysOperationServiceBase
         info(strFmt("${name} completed successfully"));
     }
 }`,
+  sysoperation: sysOperationTemplate,
 };
 
 // Templates for EXTENSION elements: (baseName = element being extended, prefix = model/ISV infix)
@@ -262,9 +271,163 @@ final class ${className}
 const extensionTemplates: Record<string, (baseName: string, prefix: string) => string> = {
   'form-handler': formHandlerTemplate,
   'table-extension': tableExtensionTemplate,
+  'event-handler': eventHandlerTemplate,
 };
 
-const EXTENSION_PATTERNS = new Set(['table-extension', 'form-handler']);
+// ── SysOperation pattern (3 classes: DataContract + Controller + Service) ──
+function sysOperationTemplate(name: string): string {
+  return `
+// ── 1. DataContract ─────────────────────────────────────────────────────
+[DataContractAttribute]
+public final class ${name}DataContract
+{
+    TransDate   transDate;
+
+    [DataMemberAttribute('TransDate'),
+     SysOperationLabelAttribute(literalStr("Transaction date"))]
+    public TransDate parmTransDate(TransDate _transDate = transDate)
+    {
+        transDate = _transDate;
+        return transDate;
+    }
+}
+
+// ── 2. Controller ────────────────────────────────────────────────────────
+class ${name}Controller extends SysOperationServiceController
+{
+    protected ClassDescription defaultCaption()
+    {
+        return "${name}";
+    }
+
+    public static void main(Args _args)
+    {
+        ${name}Controller controller = new ${name}Controller(
+            classStr(${name}Service),
+            methodStr(${name}Service, process${name}),
+            SysOperationExecutionMode::Synchronous);
+        controller.startOperation();
+    }
+}
+
+// ── 3. Service ───────────────────────────────────────────────────────────
+class ${name}Service extends SysOperationServiceBase
+{
+    [SysEntryPointAttribute(true)]
+    public void process${name}(${name}DataContract _contract)
+    {
+        TransDate transDate = _contract.parmTransDate();
+
+        // TODO: Implement business logic
+        ttsbegin;
+
+        ttscommit;
+    }
+}`;
+}
+
+// ── Event handler pattern (class with SubscribesTo handlers) ─────────────
+function eventHandlerTemplate(baseName: string, _prefix: string): string {
+  return `
+/// <summary>
+/// Event handler class for ${baseName} events.
+/// </summary>
+public final class ${baseName}EventHandler
+{
+    /// <summary>
+    /// Handles the onInserted event of ${baseName}.
+    /// </summary>
+    [SubscribesTo(tableStr(${baseName}),
+                  delegateStr(${baseName}, onInserted))]
+    public static void ${baseName}_onInserted(Common _sender, InsertEventArgs _e)
+    {
+        ${baseName} record = _sender;
+
+        // TODO: Add event handling logic
+    }
+
+    /// <summary>
+    /// Handles the onValidatedWrite event of ${baseName}.
+    /// </summary>
+    [SubscribesTo(tableStr(${baseName}),
+                  delegateStr(${baseName}, onValidatedWrite))]
+    public static void ${baseName}_onValidatedWrite(Common _sender, ValidateEventArgs _e)
+    {
+        ${baseName} record    = _sender;
+        boolean   result     = _e.parmValidateResult();
+
+        if (result)
+        {
+            // TODO: Add validation logic
+        }
+
+        _e.result(result);
+    }
+}`;
+}
+
+// ── Security privilege XML pattern ──────────────────────────────────────
+function securityPrivilegeXmlTemplate(name: string, targetMenuItemName: string): string {
+  const viewName = name.endsWith('View') ? name : `${name}View`;
+  const maintainName = name.endsWith('Maintain') ? name : `${name}Maintain`;
+  return `<!-- ${viewName} (Read access) -->
+<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>${viewName}</Name>
+  <Label>@TODO:LabelId_View</Label>
+  <EntryPoints>
+    <AxSecurityEntryPointReference>
+      <Name>${targetMenuItemName}</Name>
+      <ObjectType>MenuItemDisplay</ObjectType>
+      <Grant>Read</Grant>
+    </AxSecurityEntryPointReference>
+  </EntryPoints>
+</AxSecurityPrivilege>
+
+<!-- ${maintainName} (Update/Create/Delete access) -->
+<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>${maintainName}</Name>
+  <Label>@TODO:LabelId_Maintain</Label>
+  <EntryPoints>
+    <AxSecurityEntryPointReference>
+      <Name>${targetMenuItemName}</Name>
+      <ObjectType>MenuItemDisplay</ObjectType>
+      <Grant>Update</Grant>
+    </AxSecurityEntryPointReference>
+    <AxSecurityEntryPointReference>
+      <Name>${targetMenuItemName}</Name>
+      <ObjectType>MenuItemDisplay</ObjectType>
+      <Grant>Create</Grant>
+    </AxSecurityEntryPointReference>
+    <AxSecurityEntryPointReference>
+      <Name>${targetMenuItemName}</Name>
+      <ObjectType>MenuItemDisplay</ObjectType>
+      <Grant>Delete</Grant>
+    </AxSecurityEntryPointReference>
+  </EntryPoints>
+</AxSecurityPrivilege>`;
+}
+
+// ── Menu item XML pattern ────────────────────────────────────────────────
+function menuItemXmlTemplate(name: string, itemType: string, targetObject: string): string {
+  const elemName = itemType === 'action' ? 'AxMenuItemAction'
+    : itemType === 'output' ? 'AxMenuItemOutput'
+    : 'AxMenuItemDisplay';
+  const objType = itemType === 'action' ? 'Class'
+    : itemType === 'output' ? 'Report'
+    : 'Form';
+  return `<?xml version="1.0" encoding="utf-8"?>
+<${elemName} xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>${name}</Name>
+  <Label>@TODO:LabelId</Label>
+  <Object>${targetObject}</Object>
+  <ObjectType>${objType}</ObjectType>
+</${elemName}>`;
+}
+
+const EXTENSION_PATTERNS = new Set(['table-extension', 'form-handler', 'event-handler']);
+const XML_PATTERNS = new Set(['security-privilege', 'menu-item']);
 
 export async function codeGenTool(request: CallToolRequest) {
   try {
@@ -278,8 +441,43 @@ export async function codeGenTool(request: CallToolRequest) {
     let displayName: string;
     let namingNote: string;
 
-    if (EXTENSION_PATTERNS.has(args.pattern)) {
+    if (XML_PATTERNS.has(args.pattern)) {
+      // XML generation patterns (security-privilege, menu-item)
+      let xml: string;
+      let xmlNote: string;
+
+      if (args.pattern === 'security-privilege') {
+        const targetMenuItem = args.targetObject || args.name;
+        xml = securityPrivilegeXmlTemplate(args.name, targetMenuItem);
+        xmlNote = `📌 Creates two privilege objects: ${args.name}View (Read) and ${args.name}Maintain (Update/Create/Delete)\n` +
+          `  Linked to entry point: ${targetMenuItem}\n\n` +
+          `💡 Next steps:\n` +
+          `1. Replace @TODO:LabelId_View and @TODO:LabelId_Maintain with actual label IDs\n` +
+          `2. Create a duty referencing both privileges\n` +
+          `3. Assign the duty to an appropriate role`;
+      } else {
+        // menu-item
+        const targetObject = args.targetObject || args.name;
+        const itemType = args.menuItemType || 'display';
+        xml = menuItemXmlTemplate(args.name, itemType, targetObject);
+        xmlNote = `📌 Creates AxMenuItem${itemType === 'action' ? 'Action' : itemType === 'output' ? 'Output' : 'Display'}: ${args.name}\n` +
+          `  Target ${itemType === 'action' ? 'class' : itemType === 'output' ? 'report' : 'form'}: ${targetObject}\n\n` +
+          `💡 Next steps:\n` +
+          `1. Replace @TODO:LabelId with actual label ID\n` +
+          `2. Create security privilege referencing this menu item\n` +
+          `3. Add menu item to the appropriate menu`;
+      }
+
+      return {
+        content: [{
+          type: 'text',
+          text: `Generated ${args.pattern} XML for "${args.name}":\n\n` +
+            `\`\`\`xml\n${xml}\n\`\`\`\n\n---\n\n${xmlNote}`,
+        }],
+      };
+    } else if (EXTENSION_PATTERNS.has(args.pattern)) {
       // Extension pattern — args.name is the BASE element; prefix becomes the infix
+      const baseName = args.pattern === 'event-handler' ? (args.baseName || args.name) : args.name;
       const extTemplate = extensionTemplates[args.pattern];
       if (!extTemplate) {
         return {
@@ -287,15 +485,22 @@ export async function codeGenTool(request: CallToolRequest) {
           isError: true,
         };
       }
-      code = extTemplate(args.name, prefix);
-      displayName = args.name;
-      const exampleClass =
-        args.pattern === 'table-extension'
-          ? `${args.name}${prefix}_Extension`
-          : `${args.name}${prefix}Form_Extension`;
-      namingNote = prefix
-        ? `📌 **Naming (MS guidelines):** Generated class: \`${exampleClass}\`\n  Base element: \`${args.name}\`, Prefix infix: \`${prefix}\``
-        : `⚠️ **No prefix resolved** — set \`EXTENSION_PREFIX\` env var or pass \`modelName\` argument.\n  Generated bare name without prefix infix (e.g. \`${args.name}_Extension\`) which is **not MS-compliant**.`;
+      code = extTemplate(baseName, prefix);
+      displayName = baseName;
+
+      if (args.pattern === 'event-handler') {
+        namingNote = `📌 **Generated class:** \`${baseName}EventHandler\`\n` +
+          `  Handles onInserted and onValidatedWrite events of \`${baseName}\`\n` +
+          `  Add more handlers by repeating the [SubscribesTo] pattern.`;
+      } else {
+        const exampleClass =
+          args.pattern === 'table-extension'
+            ? `${baseName}${prefix}_Extension`
+            : `${baseName}${prefix}Form_Extension`;
+        namingNote = prefix
+          ? `📌 **Naming (MS guidelines):** Generated class: \`${exampleClass}\`\n  Base element: \`${baseName}\`, Prefix infix: \`${prefix}\``
+          : `⚠️ **No prefix resolved** — set \`EXTENSION_PREFIX\` env var or pass \`modelName\` argument.\n  Generated bare name without prefix infix (e.g. \`${baseName}_Extension\`) which is **not MS-compliant**.`;
+      }
     } else {
       // New element pattern — apply prefix to the name
       const newTemplate = newElementTemplates[args.pattern];

--- a/src/tools/dataEntityInfo.ts
+++ b/src/tools/dataEntityInfo.ts
@@ -1,0 +1,172 @@
+/**
+ * Data Entity Info Tool
+ * Retrieve rich D365FO-specific metadata for data entities (OData, DMF, staging, sources)
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const DataEntityInfoArgsSchema = z.object({
+  entityName: z.string().describe('Name of the data entity (AxDataEntityView)'),
+});
+
+export async function dataEntityInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = DataEntityInfoArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+
+    // Data entities are indexed under type='view' (they derive from AxDataEntityView)
+    // Also check data-entity-extension as those are indexed separately
+    const symbol = db.prepare(
+      `SELECT name, type, description, signature, model, file_path, source_snippet
+       FROM symbols WHERE name = ? AND type IN ('view', 'data-entity-extension')
+       ORDER BY CASE WHEN type='view' THEN 0 ELSE 1 END LIMIT 1`
+    ).get(args.entityName) as any;
+
+    if (!symbol) {
+      // Search using FTS
+      const suggestions = db.prepare(
+        `SELECT name, type, model FROM symbols
+         WHERE type = 'view' AND name LIKE ?
+         ORDER BY name LIMIT 10`
+      ).all(`%${args.entityName}%`) as any[];
+
+      let text = `Data entity not found: ${args.entityName}\n`;
+      if (suggestions.length > 0) {
+        text += '\nSimilar views/entities:\n';
+        for (const s of suggestions) {
+          text += `  ${s.name} (${s.model})\n`;
+        }
+      }
+      text += '\nTip: Data entities are views — try searching with type="view".';
+      return { content: [{ type: 'text', text }] };
+    }
+
+    let output = `DataEntity: ${symbol.name}\n`;
+    output += `Model: ${symbol.model}\n`;
+    if (symbol.description) output += `Description: ${symbol.description}\n`;
+
+    // Try to parse D365FO-specific properties from source_snippet or signature
+    // These were stored during indexing if available
+    const sig = (symbol.signature || '') as string;
+    // source_snippet available for additional parsing if needed
+
+    // Entity category (stored in signature during indexing, or infer from name)
+    if (sig.includes('EntityCategory:')) {
+      const catMatch = sig.match(/EntityCategory:\s*(\w+)/);
+      if (catMatch) output += `Category: ${catMatch[1]}\n`;
+    } else {
+      // Infer category from common naming patterns
+      const nameUpper = symbol.name.toUpperCase();
+      if (nameUpper.endsWith('V2ENTITY') || nameUpper.endsWith('V3ENTITY') || nameUpper.endsWith('ENTITY')) {
+        output += `Type: Data Entity (AxDataEntityView)\n`;
+      }
+    }
+
+    // Public name for OData (often EntityName without "Entity" suffix)
+    const publicNameMatch = sig.match(/PublicEntityName:\s*(\w+)/);
+    if (publicNameMatch) {
+      output += `Public Name: ${publicNameMatch[1]} (OData resource name)\n`;
+    }
+
+    const collectionMatch = sig.match(/PublicCollectionName:\s*(\w+)/);
+    if (collectionMatch) {
+      output += `Collection: ${collectionMatch[1]}\n`;
+    }
+
+    // OData / DMF enabled flags
+    if (sig.includes('IsPublic:true') || sig.includes('IsPublic: true')) {
+      output += `OData Enabled: Yes\n`;
+    }
+    if (sig.includes('DataManagementEnabled:true') || sig.includes('DataManagementEnabled: true')) {
+      output += `Data Management (DMF): Yes\n`;
+    }
+
+    // Staging table (usually EntityName + 'Staging')
+    const stagingMatch = sig.match(/StagingTable:\s*(\w+)/);
+    if (stagingMatch) {
+      output += `Staging Table: ${stagingMatch[1]}\n`;
+    } else {
+      // Common convention: check if a table with <EntityName minus 'Entity'>Staging exists
+      const baseName = symbol.name.replace(/Entity$/, '').replace(/V\d+$/, '');
+      const stagingTable = db.prepare(
+        `SELECT name FROM symbols WHERE type='table' AND name LIKE ? LIMIT 1`
+      ).get(`${baseName}%Staging`) as any;
+      if (stagingTable) {
+        output += `Staging Table (inferred): ${stagingTable.name}\n`;
+      }
+    }
+
+    // Data sources: fields from this entity that come from different parent tables
+    const fields = db.prepare(
+      `SELECT name, signature FROM symbols
+       WHERE parent_name = ? AND type = 'field'
+       ORDER BY name`
+    ).all(args.entityName) as any[];
+
+    if (fields.length > 0) {
+      // Extract unique source tables from field signatures
+      const sourceTables = new Set<string>();
+      for (const f of fields) {
+        const srcMatch = (f.signature || '').match(/\[(\w+)\]/);
+        if (srcMatch) sourceTables.add(srcMatch[1]);
+      }
+
+      output += `\nFields (${fields.length}): `;
+      const fieldNames = fields.slice(0, 8).map((f: any) => f.name);
+      output += fieldNames.join(', ');
+      if (fields.length > 8) output += ` ... (+${fields.length - 8} more)`;
+      output += '\n';
+
+      if (sourceTables.size > 0) {
+        output += `\nData Sources (${sourceTables.size}): ${[...sourceTables].join(', ')}\n`;
+      }
+    }
+
+    // Methods (computed columns, virtual fields)
+    const methods = db.prepare(
+      `SELECT name, signature FROM symbols
+       WHERE parent_name = ? AND type = 'method'
+       ORDER BY name`
+    ).all(args.entityName) as any[];
+
+    if (methods.length > 0) {
+      const computedCols = methods.filter((m: any) =>
+        (m.signature || '').includes('display') ||
+        (m.name || '').startsWith('get') ||
+        (m.signature || '').includes('SysComputedColumn')
+      );
+      if (computedCols.length > 0) {
+        output += `\nComputed/Virtual Columns (${computedCols.length}): `;
+        output += computedCols.slice(0, 5).map((m: any) => m.name).join(', ');
+        if (computedCols.length > 5) output += ` (+${computedCols.length - 5} more)`;
+        output += '\n';
+      }
+    }
+
+    // Keys
+    const keys = db.prepare(
+      `SELECT name FROM symbols WHERE parent_name = ? AND type = 'index' ORDER BY name`
+    ).all(args.entityName) as any[];
+    if (keys.length > 0) {
+      output += `\nKeys: ${keys.map((k: any) => k.name).join(', ')}\n`;
+    }
+
+    if (symbol.file_path) {
+      output += `\nSource: ${symbol.file_path}\n`;
+    }
+
+    return { content: [{ type: 'text', text: output }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error getting data entity info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/edtInfo.ts
+++ b/src/tools/edtInfo.ts
@@ -15,6 +15,8 @@ const GetEdtInfoArgsSchema = z.object({
   modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
   includeWorkspace: z.boolean().optional().default(false).describe('Include workspace files'),
   workspacePath: z.string().optional().describe('Path to workspace'),
+  mode: z.enum(['standard', 'hierarchy']).optional().default('standard')
+    .describe('standard=normal EDT details, hierarchy=show ancestor chain + children + field usages'),
 });
 
 interface EdtInfo {
@@ -43,6 +45,11 @@ export async function getEdtInfoTool(request: CallToolRequest, context: XppServe
     const args = GetEdtInfoArgsSchema.parse(request.params.arguments);
     const { symbolIndex } = context;
     const { edtName, modelName } = args;
+
+    // ── Hierarchy mode: ancestor chain + children + field usages ─────────────
+    if (args.mode === 'hierarchy') {
+      return getEdtHierarchy(symbolIndex.db, edtName, modelName);
+    }
 
     // ── Step 1: query edt_metadata (rich columns, always present in DB) ──────
     let edtDbRow: any;
@@ -156,6 +163,84 @@ export async function getEdtInfoTool(request: CallToolRequest, context: XppServe
       isError: true,
     };
   }
+}
+
+/**
+ * Hierarchy mode: walk ancestor chain, find children, and show field usages
+ */
+function getEdtHierarchy(db: any, edtName: string, modelName?: string) {
+  // Ancestor chain walk
+  const chain: Array<{ name: string; model: string; extends?: string; label?: string; stringSize?: string }> = [];
+  let current = edtName;
+  const visited = new Set<string>();
+
+  while (current && !visited.has(current)) {
+    visited.add(current);
+    const row = db.prepare(`
+      SELECT edt_name, model, extends, label, string_size
+      FROM edt_metadata WHERE edt_name = ?
+      ${modelName ? 'AND model = ?' : ''}
+      LIMIT 1
+    `).get(...(modelName ? [current, modelName] : [current])) as any;
+
+    if (!row) break;
+    chain.push({ name: row.edt_name, model: row.model, extends: row.extends, label: row.label, stringSize: row.string_size });
+    current = row.extends;
+  }
+
+  if (chain.length === 0) {
+    return { content: [{ type: 'text', text: `EDT not found in edt_metadata: ${edtName}\n\nRun extract-metadata to index EDT metadata.` }] };
+  }
+
+  // Direct children (EDTs that extend this one)
+  const children = db.prepare(
+    `SELECT edt_name, model, label FROM edt_metadata WHERE extends = ? ORDER BY model, edt_name`
+  ).all(edtName) as any[];
+
+  // Field usages (fields using this EDT by name)
+  const fieldUsages = db.prepare(
+    `SELECT parent_name, name, model FROM symbols WHERE type = 'field' AND signature LIKE ? ORDER BY model, parent_name LIMIT 50`
+  ).all(`%${edtName}%`) as any[];
+
+  let output = `EDT Hierarchy: ${edtName}\n\n`;
+
+  // Ancestor chain
+  output += `Ancestor Chain (${chain.length} level(s)):\n`;
+  output += `  ${chain.map(e => e.name).join(' → ')}\n\n`;
+
+  for (const e of chain) {
+    output += `  ${e.name.padEnd(35)} Model: ${e.model}`;
+    if (e.label) output += `, Label: ${e.label}`;
+    if (e.stringSize) output += `, StringSize: ${e.stringSize}`;
+    if (e.extends) output += ` [extends ${e.extends}]`;
+    output += '\n';
+  }
+
+  // Children
+  output += `\nDirect Children (${children.length} EDT(s) extending ${edtName}):\n`;
+  if (children.length === 0) {
+    output += `  (none)\n`;
+  } else {
+    for (const c of children.slice(0, 20)) {
+      output += `  ${c.edt_name} [${c.model}]`;
+      if (c.label) output += ` — ${c.label}`;
+      output += '\n';
+    }
+    if (children.length > 20) output += `  ... and ${children.length - 20} more\n`;
+  }
+
+  // Field usages
+  output += `\nField Usages (top ${Math.min(fieldUsages.length, 50)}):\n`;
+  if (fieldUsages.length === 0) {
+    output += `  No fields indexed with this EDT name in signature\n`;
+  } else {
+    for (const f of fieldUsages.slice(0, 10)) {
+      output += `  ${f.parent_name}.${f.name} [${f.model}]\n`;
+    }
+    if (fieldUsages.length > 10) output += `  ... and ${fieldUsages.length - 10} more (${fieldUsages.length} total)\n`;
+  }
+
+  return { content: [{ type: 'text', text: output }] };
 }
 
 /**

--- a/src/tools/findCocExtensions.ts
+++ b/src/tools/findCocExtensions.ts
@@ -1,0 +1,193 @@
+/**
+ * Find CoC Extensions Tool
+ * Locate Chain of Command (CoC) extensions and event handler subscriptions for a class or table
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const FindCocExtensionsArgsSchema = z.object({
+  className: z.string().describe('Base class or table name being extended'),
+  methodName: z.string().optional().describe('Filter to a specific method name'),
+  includeEventHandlers: z.boolean().optional().default(true)
+    .describe('Also find static event subscriptions (SubscribesTo) for this class/table'),
+});
+
+export async function findCocExtensionsTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = FindCocExtensionsArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+    const className = args.className;
+    const methodName = args.methodName;
+
+    let output = `CoC Extensions of: ${className}\n`;
+    if (methodName) output += `Filtering by method: ${methodName}\n`;
+    output += '\n';
+
+    // 1. Query extension_metadata table for class-extension records
+    let extensionRows: any[] = [];
+    try {
+      extensionRows = db.prepare(
+        `SELECT extension_name, model, base_object_name, coc_methods, added_methods, event_subscriptions
+         FROM extension_metadata
+         WHERE base_object_name = ? AND extension_type = 'class-extension'
+         ORDER BY model, extension_name`
+      ).all(className) as any[];
+    } catch {
+      // extension_metadata table may not exist yet
+    }
+
+    // 2. Fallback: query symbols by extends_class column
+    const symbolExtensions = db.prepare(
+      `SELECT name, model, file_path FROM symbols
+       WHERE type = 'class-extension' AND (extends_class = ? OR name LIKE ?)
+       ORDER BY model, name`
+    ).all(className, `${className}%_Extension`) as any[];
+
+    // Merge: deduplicate by extension_name
+    const seen = new Set<string>();
+    const allExtensions: Array<{
+      name: string; model: string; cocMethods: string[]; addedMethods: string[]; eventSubs: string[];
+    }> = [];
+
+    for (const row of extensionRows) {
+      if (!seen.has(row.extension_name)) {
+        seen.add(row.extension_name);
+        let cocMethods: string[] = [];
+        let addedMethods: string[] = [];
+        let eventSubs: string[] = [];
+        try { cocMethods = JSON.parse(row.coc_methods || '[]'); } catch { /**/ }
+        try { addedMethods = JSON.parse(row.added_methods || '[]'); } catch { /**/ }
+        try { eventSubs = JSON.parse(row.event_subscriptions || '[]'); } catch { /**/ }
+        allExtensions.push({ name: row.extension_name, model: row.model, cocMethods, addedMethods, eventSubs });
+      }
+    }
+
+    for (const row of symbolExtensions) {
+      if (!seen.has(row.name)) {
+        seen.add(row.name);
+        allExtensions.push({ name: row.name, model: row.model, cocMethods: [], addedMethods: [], eventSubs: [] });
+      }
+    }
+
+    // Filter by methodName if provided
+    const filtered = methodName
+      ? allExtensions.filter(e =>
+          e.cocMethods.some(m => m.toLowerCase() === methodName.toLowerCase()) ||
+          e.addedMethods.some(m => m.toLowerCase() === methodName.toLowerCase()) ||
+          e.cocMethods.length === 0 // include unknown ones too
+        )
+      : allExtensions;
+
+    if (filtered.length === 0) {
+      output += `No class extensions found for: ${className}\n`;
+    } else {
+      output += `Found ${filtered.length} extension class(es):\n\n`;
+      for (let i = 0; i < filtered.length; i++) {
+        const ext = filtered[i];
+        output += `[${i + 1}] ${ext.name} (${ext.model})\n`;
+
+        if (ext.cocMethods.length > 0) {
+          const displayMethods = methodName
+            ? ext.cocMethods.filter(m => m.toLowerCase() === methodName.toLowerCase())
+            : ext.cocMethods;
+          if (displayMethods.length > 0) {
+            output += `    Wraps methods: ${displayMethods.join(', ')}\n`;
+            output += `    Uses 'next' keyword: ✓\n`;
+          }
+        }
+
+        if (ext.addedMethods.length > 0) {
+          const newMethods = ext.addedMethods.filter(m =>
+            !ext.cocMethods.some(c => c.toLowerCase() === m.toLowerCase())
+          );
+          if (newMethods.length > 0) {
+            output += `    Added methods: ${newMethods.slice(0, 5).join(', ')}${newMethods.length > 5 ? ` (+${newMethods.length - 5} more)` : ''}\n`;
+          }
+        }
+
+        if (ext.eventSubs.length > 0) {
+          output += `    Event subscriptions: ${ext.eventSubs.slice(0, 3).join(', ')}${ext.eventSubs.length > 3 ? '...' : ''}\n`;
+        }
+      }
+    }
+
+    // 3. Event handlers via extension_metadata.event_subscriptions
+    if (args.includeEventHandlers) {
+      output += '\n';
+
+      // Look for SubscribesTo references in extension_metadata
+      let eventHandlerRows: any[] = [];
+      try {
+        eventHandlerRows = db.prepare(
+          `SELECT extension_name, model, event_subscriptions FROM extension_metadata
+           WHERE (event_subscriptions LIKE ? OR event_subscriptions LIKE ?)
+           ORDER BY model, extension_name`
+        ).all(`%classStr(${className}%`, `%tableStr(${className}%`) as any[];
+      } catch { /**/ }
+
+      // Also search symbols source_snippet for SubscribesTo patterns
+      const ftsHandlers = db.prepare(
+        `SELECT s.name, s.parent_name, s.model, s.source_snippet FROM symbols s
+         WHERE s.type = 'method'
+         AND s.source_snippet LIKE '%SubscribesTo%'
+         AND (s.source_snippet LIKE ? OR s.source_snippet LIKE ?)
+         ORDER BY s.model, s.parent_name, s.name
+         LIMIT 20`
+      ).all(`%${className}%`, `%${className}%`) as any[];
+
+      const handlerSeen = new Set<string>();
+      const allHandlers: Array<{ className: string; method: string; model: string; event?: string }> = [];
+
+      for (const row of ftsHandlers) {
+        const key = `${row.parent_name}.${row.name}`;
+        if (!handlerSeen.has(key)) {
+          handlerSeen.add(key);
+          // Try to extract event name from SubscribesTo attribute
+          let event: string | undefined;
+          const match = (row.source_snippet || '').match(/delegateStr\([^,]+,\s*(\w+)\)/);
+          if (match) event = match[1];
+          allHandlers.push({ className: row.parent_name, method: row.name, model: row.model, event });
+        }
+      }
+
+      for (const row of eventHandlerRows) {
+        let subs: string[] = [];
+        try { subs = JSON.parse(row.event_subscriptions || '[]'); } catch { /**/ }
+        for (const sub of subs) {
+          if (sub.includes(className)) {
+            const key = `${row.extension_name}:${sub}`;
+            if (!handlerSeen.has(key)) {
+              handlerSeen.add(key);
+              allHandlers.push({ className: row.extension_name, method: sub, model: row.model });
+            }
+          }
+        }
+      }
+
+      if (allHandlers.length > 0) {
+        output += `Event Handlers subscribing to ${className} events (${allHandlers.length}):\n`;
+        for (const h of allHandlers) {
+          output += `  ${h.className}.${h.method} [${h.model}]`;
+          if (h.event) output += ` — event: ${className}.${h.event}`;
+          output += '\n';
+        }
+      } else {
+        output += `Event Handlers subscribing to ${className} events: none found\n`;
+      }
+    }
+
+    return { content: [{ type: 'text', text: output }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error finding CoC extensions: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/findEventHandlers.ts
+++ b/src/tools/findEventHandlers.ts
@@ -1,0 +1,206 @@
+/**
+ * Find Event Handlers Tool
+ * Locate static event handler subscriptions (SubscribesTo) and delegate subscriptions
+ * for a given D365FO class or table
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const FindEventHandlersArgsSchema = z.object({
+  targetClass: z.string().optional().describe('Class whose events to find handlers for'),
+  targetTable: z.string().optional().describe('Table whose events to find handlers for'),
+  eventName: z.string().optional()
+    .describe('Filter to a specific event name (e.g. onInserted, onValidatedWrite, onPostRun)'),
+  handlerType: z.enum(['static', 'delegate', 'all']).optional().default('all')
+    .describe('Filter by handler type (static=SubscribesTo delegates, delegate=delegate += syntax, all=both)'),
+});
+
+export async function findEventHandlersTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = FindEventHandlersArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+
+    if (!args.targetClass && !args.targetTable) {
+      return {
+        content: [{ type: 'text', text: 'Provide at least one of: targetClass, targetTable' }],
+        isError: true,
+      };
+    }
+
+    const targetName = args.targetClass || args.targetTable!;
+    const isTable = !!args.targetTable;
+
+    let output = `Event Handlers for: ${targetName} (${isTable ? 'table' : 'class'} events)\n`;
+    if (args.eventName) output += `Filtering by event: ${args.eventName}\n`;
+    output += '\n';
+
+    // ── 1. Static event handlers via extension_metadata.event_subscriptions ──
+    let metaHandlers: any[] = [];
+    if (args.handlerType !== 'delegate') {
+      try {
+        metaHandlers = db.prepare(
+          `SELECT extension_name, model, event_subscriptions
+           FROM extension_metadata
+           WHERE (event_subscriptions LIKE ? OR event_subscriptions LIKE ?)
+           ORDER BY model, extension_name`
+        ).all(`%classStr(${targetName}%`, `%tableStr(${targetName}%`) as any[];
+      } catch { /**/ }
+    }
+
+    // ── 2. FTS search on source_snippet for SubscribesTo ──
+    const subLike1 = `%SubscribesTo(classStr(${targetName}%`;
+    const subLike2 = `%SubscribesTo(tableStr(${targetName}%`;
+    const subLike3 = `%SubscribesTo(formStr(${targetName}%`;
+
+    let ftsHandlers: any[] = [];
+    if (args.handlerType !== 'delegate') {
+      ftsHandlers = db.prepare(
+        `SELECT name, parent_name, model, source_snippet FROM symbols
+         WHERE type = 'method'
+         AND source_snippet LIKE '%SubscribesTo%'
+         AND (source_snippet LIKE ? OR source_snippet LIKE ? OR source_snippet LIKE ?)
+         ORDER BY model, parent_name, name
+         LIMIT 50`
+      ).all(subLike1, subLike2, subLike3) as any[];
+    }
+
+    // ── 3. Delegate subscription search (+= syntax) ──
+    let delegateHandlers: any[] = [];
+    if (args.handlerType !== 'static') {
+      delegateHandlers = db.prepare(
+        `SELECT name, parent_name, model, source_snippet FROM symbols
+         WHERE type = 'method'
+         AND source_snippet LIKE ?
+         ORDER BY model, parent_name, name
+         LIMIT 20`
+      ).all(`%${targetName}.on%+=% `) as any[];
+
+      // Also: find methods with body referencing delegate attach
+      const delegateHandlers2 = db.prepare(
+        `SELECT name, parent_name, model, source_snippet FROM symbols
+         WHERE type = 'method'
+         AND source_snippet LIKE ?
+         ORDER BY model, parent_name, name
+         LIMIT 20`
+      ).all(`%${targetName}%.on%`) as any[];
+
+      for (const h of delegateHandlers2) {
+        if (!(delegateHandlers.some(d => d.name === h.name && d.parent_name === h.parent_name))) {
+          delegateHandlers.push(h);
+        }
+      }
+    }
+
+    // ── Build grouped output by event name ──
+    interface HandlerEntry {
+      handlerClass: string;
+      handlerMethod: string;
+      model: string;
+      event?: string;
+      type: 'static' | 'delegate';
+    }
+
+    const byEvent = new Map<string, HandlerEntry[]>();
+
+    const addHandler = (entry: HandlerEntry) => {
+      const key = entry.event || '(unknown event)';
+      if (!byEvent.has(key)) byEvent.set(key, []);
+      // Deduplicate
+      const list = byEvent.get(key)!;
+      if (!list.some(e => e.handlerClass === entry.handlerClass && e.handlerMethod === entry.handlerMethod)) {
+        list.push(entry);
+      }
+    };
+
+    // Parse FTS handlers
+    for (const h of ftsHandlers) {
+      // Extract event name from SubscribesTo attribute:
+      // [SubscribesTo(tableStr(CustTable), delegateStr(CustTable, onInserted))]
+      const delegateMatch = (h.source_snippet || '').match(/delegateStr\([^,]+,\s*(\w+)\)/);
+      const eventN = delegateMatch ? delegateMatch[1] : undefined;
+
+      if (args.eventName && eventN && eventN.toLowerCase() !== args.eventName.toLowerCase()) continue;
+
+      addHandler({
+        handlerClass: h.parent_name || '(unknown)',
+        handlerMethod: h.name,
+        model: h.model,
+        event: eventN,
+        type: 'static',
+      });
+    }
+
+    // Parse metadata handlers
+    for (const row of metaHandlers) {
+      let subs: string[] = [];
+      try { subs = JSON.parse(row.event_subscriptions || '[]'); } catch { /**/ }
+      for (const sub of subs) {
+        if (sub.includes(targetName)) {
+          const evMatch = sub.match(/delegateStr\([^,]+,\s*(\w+)\)/);
+          const eventN = evMatch ? evMatch[1] : undefined;
+          if (args.eventName && eventN && eventN.toLowerCase() !== args.eventName.toLowerCase()) continue;
+          addHandler({ handlerClass: row.extension_name, handlerMethod: sub, model: row.model, event: eventN, type: 'static' });
+        }
+      }
+    }
+
+    // Parse delegate handlers
+    for (const h of delegateHandlers) {
+      const delegateMatch = (h.source_snippet || '').match(new RegExp(`${targetName}\\.(\\w+)\\s*\\+\\s*=`));
+      const eventN = delegateMatch ? delegateMatch[1] : undefined;
+      if (args.eventName && eventN && eventN.toLowerCase() !== args.eventName.toLowerCase()) continue;
+      addHandler({ handlerClass: h.parent_name || h.name, handlerMethod: h.name, model: h.model, event: eventN, type: 'delegate' });
+    }
+
+    if (byEvent.size === 0) {
+      output += `No event handlers found for ${targetName}.\n`;
+      output += `\nNote: Handler detection requires source_snippet indexing.`;
+      output += `\nFor tables, standard events are: onInserted, onUpdated, onDeleted, onValidatedWrite, onValidatedInsert, onValidatedDelete, onInitialized, onInitValue\n`;
+    } else {
+      // Separate static vs delegate for output
+      const staticByEvent: typeof byEvent = new Map();
+      const delegateByEvent: typeof byEvent = new Map();
+
+      for (const [event, handlers] of byEvent) {
+        const statics = handlers.filter(h => h.type === 'static');
+        const delegates = handlers.filter(h => h.type === 'delegate');
+        if (statics.length > 0) staticByEvent.set(event, statics);
+        if (delegates.length > 0) delegateByEvent.set(event, delegates);
+      }
+
+      if (staticByEvent.size > 0) {
+        output += `Static Event Handlers (SubscribesTo):\n`;
+        for (const [event, handlers] of staticByEvent) {
+          output += `  [${event}]\n`;
+          for (const h of handlers) {
+            output += `    ${h.handlerClass}.${h.handlerMethod} [${h.model}]\n`;
+          }
+        }
+      }
+
+      if (delegateByEvent.size > 0) {
+        output += `\nDelegate Subscriptions:\n`;
+        for (const [event, handlers] of delegateByEvent) {
+          output += `  ${targetName}.${event} →\n`;
+          for (const h of handlers) {
+            output += `    ${h.handlerClass}.${h.handlerMethod} [${h.model}]\n`;
+          }
+        }
+      }
+    }
+
+    return { content: [{ type: 'text', text: output }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error finding event handlers: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/menuItemInfo.ts
+++ b/src/tools/menuItemInfo.ts
@@ -1,0 +1,163 @@
+/**
+ * Menu Item Info Tool
+ * Retrieve details for D365FO menu items including target objects and security chain
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const MenuItemInfoArgsSchema = z.object({
+  name: z.string().describe('Name of the menu item'),
+  itemType: z.enum(['display', 'action', 'output', 'any']).optional().default('any')
+    .describe('Menu item type filter (display=AxMenuItemDisplay, action=AxMenuItemAction, output=AxMenuItemOutput, any=all types)'),
+});
+
+export async function menuItemInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = MenuItemInfoArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+
+    // Build type filter
+    const typeMap: Record<string, string> = {
+      display: 'menu-item-display',
+      action: 'menu-item-action',
+      output: 'menu-item-output',
+    };
+
+    let symbolQuery: string;
+    let symbolParams: any[];
+
+    if (args.itemType === 'any') {
+      symbolQuery = `SELECT name, type, description, signature, model, file_path FROM symbols
+        WHERE name = ? AND type IN ('menu-item-display', 'menu-item-action', 'menu-item-output')
+        ORDER BY type`;
+      symbolParams = [args.name];
+    } else {
+      symbolQuery = `SELECT name, type, description, signature, model, file_path FROM symbols
+        WHERE name = ? AND type = ?`;
+      symbolParams = [args.name, typeMap[args.itemType]];
+    }
+
+    const symbols = db.prepare(symbolQuery).all(...symbolParams) as any[];
+
+    if (symbols.length === 0) {
+      // Try FTS fallback
+      const ftsResult = db.prepare(
+        `SELECT name, type, model FROM symbols
+         WHERE name LIKE ? AND type IN ('menu-item-display', 'menu-item-action', 'menu-item-output')
+         LIMIT 10`
+      ).all(`%${args.name}%`) as any[];
+
+      let notFoundText = `Menu item not found: ${args.name}\n`;
+      if (ftsResult.length > 0) {
+        notFoundText += `\nSimilar menu items:\n`;
+        for (const r of ftsResult) {
+          notFoundText += `  ${r.name} [${r.type}] (${r.model})\n`;
+        }
+      }
+      notFoundText += `\nTip: Run extract-metadata and build-database to index menu items.`;
+      return { content: [{ type: 'text', text: notFoundText }] };
+    }
+
+    let output = '';
+
+    for (const symbol of symbols) {
+      const typeLabel = symbol.type === 'menu-item-display' ? 'MenuItemDisplay'
+        : symbol.type === 'menu-item-action' ? 'MenuItemAction'
+        : 'MenuItemOutput';
+
+      output += `${typeLabel}: ${symbol.name}\n`;
+      if (symbol.description) output += `Label: ${symbol.description}\n`;
+      output += `Model: ${symbol.model}\n`;
+
+      // Get target info from menu_item_targets
+      const target = db.prepare(
+        `SELECT target_object, target_type, security_privilege, label FROM menu_item_targets
+         WHERE menu_item_name = ? AND menu_item_type = ?`
+      ).get(symbol.name, symbol.type.replace('menu-item-', '')) as any;
+
+      if (target) {
+        if (target.target_object) {
+          output += `Target: ${target.target_object}`;
+          if (target.target_type) output += ` (${target.target_type})`;
+          output += '\n';
+        }
+        if (target.security_privilege) {
+          output += `Security Privilege: ${target.security_privilege}\n`;
+        }
+      } else if (symbol.signature) {
+        // Fallback: signature may hold target object
+        output += `Target: ${symbol.signature}\n`;
+      }
+
+      // Security chain: find privileges referencing this menu item as entry point
+      const privileges = db.prepare(
+        `SELECT DISTINCT privilege_name, object_type, access_level FROM security_privilege_entries
+         WHERE entry_point_name = ? ORDER BY privilege_name`
+      ).all(symbol.name) as any[];
+
+      if (privileges.length > 0) {
+        output += `\nSecurity Chain:\n`;
+        for (const priv of privileges) {
+          output += `  Privilege: ${priv.privilege_name} [${priv.access_level}]\n`;
+
+          // Duties using this privilege
+          const duties = db.prepare(
+            `SELECT DISTINCT duty_name FROM security_duty_privileges
+             WHERE privilege_name = ? ORDER BY duty_name LIMIT 5`
+          ).all(priv.privilege_name) as any[];
+
+          for (const duty of duties) {
+            output += `    → Duty: ${duty.duty_name}\n`;
+
+            // Roles using this duty
+            const roles = db.prepare(
+              `SELECT DISTINCT role_name FROM security_role_duties
+               WHERE duty_name = ? ORDER BY role_name LIMIT 5`
+            ).all(duty.duty_name) as any[];
+
+            for (const role of roles) {
+              output += `      → Role: ${role.role_name}\n`;
+            }
+            const totalRoles = (db.prepare(
+              `SELECT COUNT(*) as cnt FROM security_role_duties WHERE duty_name = ?`
+            ).get(duty.duty_name) as any)?.cnt ?? 0;
+            if (totalRoles > 5) {
+              output += `      → ... and ${totalRoles - 5} more roles\n`;
+            }
+          }
+          const totalDuties = (db.prepare(
+            `SELECT COUNT(*) as cnt FROM security_duty_privileges WHERE privilege_name = ?`
+          ).get(priv.privilege_name) as any)?.cnt ?? 0;
+          if (totalDuties > 5) {
+            output += `    → ... and ${totalDuties - 5} more duties\n`;
+          }
+        }
+      }
+
+      // Check if a form/class with the same name exists
+      const matchingObject = db.prepare(
+        `SELECT name, type, model FROM symbols WHERE name = ? AND type IN ('form', 'class', 'query', 'report') LIMIT 1`
+      ).get(symbol.name) as any;
+
+      if (matchingObject) {
+        output += `\nMatching ${matchingObject.type}: ${matchingObject.name} (${matchingObject.model})\n`;
+      }
+
+      if (symbols.length > 1) output += '\n---\n\n';
+    }
+
+    return { content: [{ type: 'text', text: output }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error getting menu item info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -20,7 +20,14 @@ import {
 
 const SearchArgsSchema = z.object({
   query: z.string().describe('Search query (class name, method name, etc.)'),
-  type: z.enum(['class', 'table', 'form', 'field', 'method', 'enum', 'edt', 'query', 'view', 'all']).optional().default('all').describe('Filter by object type (class=AxClass, table=AxTable, form=AxForm, query=AxQuery, view=AxView, enum=AxEnum, edt=AxEdt, all=no filter)'),
+  type: z.enum([
+    'class', 'table', 'form', 'field', 'method', 'enum', 'edt', 'query', 'view', 'report',
+    'security-privilege', 'security-duty', 'security-role',
+    'menu-item-display', 'menu-item-action', 'menu-item-output',
+    'table-extension', 'class-extension', 'form-extension',
+    'enum-extension', 'edt-extension', 'data-entity-extension',
+    'all',
+  ]).optional().default('all').describe('Filter by object type (all=no filter, use specific type to narrow results)'),
   limit: z.number().max(100).optional().default(20).describe('Maximum results to return'),
   workspacePath: z.string().optional().describe('Optional workspace path to search local project files in addition to external metadata'),
   includeWorkspace: z.boolean().optional().default(false).describe('Whether to include workspace files in search results (workspace-aware search)'),

--- a/src/tools/securityArtifactInfo.ts
+++ b/src/tools/securityArtifactInfo.ts
@@ -1,0 +1,188 @@
+/**
+ * Security Artifact Info Tool
+ * Retrieve full details for security privileges, duties, and roles including hierarchy chains
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const SecurityArtifactInfoArgsSchema = z.object({
+  name: z.string().describe('Name of the security privilege, duty, or role'),
+  artifactType: z.enum(['privilege', 'duty', 'role']).describe('Type of security artifact'),
+  includeChain: z.boolean().optional().default(true).describe('Walk the full hierarchy (role→duties→privileges→entry points)'),
+});
+
+export async function securityArtifactInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = SecurityArtifactInfoArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+
+    if (args.artifactType === 'privilege') {
+      return getPrivilegeInfo(db, args.name, args.includeChain ?? true);
+    } else if (args.artifactType === 'duty') {
+      return getDutyInfo(db, args.name, args.includeChain ?? true);
+    } else {
+      return getRoleInfo(db, args.name, args.includeChain ?? true);
+    }
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error getting security artifact info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+function getPrivilegeInfo(db: any, name: string, _includeChain: boolean) {
+  // Get the privilege symbol
+  const symbol = db.prepare(
+    `SELECT name, description, signature, model, file_path FROM symbols WHERE name = ? AND type = 'security-privilege' LIMIT 1`
+  ).get(name) as any;
+
+  if (!symbol) {
+    return {
+      content: [{ type: 'text', text: `Security privilege not found: ${name}\n\nTip: Run extract-metadata and build-database to index security objects.` }],
+    };
+  }
+
+  // Get entry points
+  const entryPoints = db.prepare(
+    `SELECT entry_point_name, object_type, access_level FROM security_privilege_entries WHERE privilege_name = ? ORDER BY entry_point_name`
+  ).all(name) as any[];
+
+  // Find which duties use this privilege
+  const duties = db.prepare(
+    `SELECT DISTINCT duty_name FROM security_duty_privileges WHERE privilege_name = ? ORDER BY duty_name`
+  ).all(name) as any[];
+
+  let output = `SecurityPrivilege: ${symbol.name}\n`;
+  if (symbol.description) output += `Label: ${symbol.description}\n`;
+  output += `Model: ${symbol.model}\n`;
+
+  if (entryPoints.length > 0) {
+    output += `\nEntry Points (${entryPoints.length}):\n`;
+    for (const ep of entryPoints) {
+      output += `  ✓ ${ep.entry_point_name} [${ep.object_type}]  → ${ep.access_level} access\n`;
+    }
+  } else {
+    output += `\nEntry Points: none indexed\n`;
+  }
+
+  if (duties.length > 0) {
+    output += `\nUsed in Duties (${duties.length}):\n`;
+    output += `  ${duties.map((d: any) => d.duty_name).join(', ')}\n`;
+  }
+
+  return { content: [{ type: 'text', text: output }] };
+}
+
+function getDutyInfo(db: any, name: string, includeChain: boolean) {
+  const symbol = db.prepare(
+    `SELECT name, description, signature, model FROM symbols WHERE name = ? AND type = 'security-duty' LIMIT 1`
+  ).get(name) as any;
+
+  if (!symbol) {
+    return {
+      content: [{ type: 'text', text: `Security duty not found: ${name}` }],
+    };
+  }
+
+  const privileges = db.prepare(
+    `SELECT privilege_name FROM security_duty_privileges WHERE duty_name = ? ORDER BY privilege_name`
+  ).all(name) as any[];
+
+  const roles = db.prepare(
+    `SELECT DISTINCT role_name FROM security_role_duties WHERE duty_name = ? ORDER BY role_name`
+  ).all(name) as any[];
+
+  let output = `SecurityDuty: ${symbol.name}\n`;
+  if (symbol.description) output += `Label: ${symbol.description}\n`;
+  output += `Model: ${symbol.model}\n`;
+
+  if (privileges.length > 0) {
+    output += `\nPrivileges (${privileges.length}):\n`;
+    for (const priv of privileges) {
+      if (includeChain) {
+        // Show entry points for each privilege
+        const eps = db.prepare(
+          `SELECT entry_point_name, object_type, access_level FROM security_privilege_entries WHERE privilege_name = ? ORDER BY entry_point_name`
+        ).all(priv.privilege_name) as any[];
+        output += `  • ${priv.privilege_name}`;
+        if (eps.length > 0) {
+          output += ` (${eps.length} entry points: ${eps.slice(0, 3).map((ep: any) => `${ep.entry_point_name}[${ep.access_level}]`).join(', ')}${eps.length > 3 ? '...' : ''})`;
+        }
+        output += '\n';
+      } else {
+        output += `  • ${priv.privilege_name}\n`;
+      }
+    }
+  }
+
+  if (roles.length > 0) {
+    output += `\nAssigned to Roles (${roles.length}):\n`;
+    output += `  ${roles.map((r: any) => r.role_name).join(', ')}\n`;
+  }
+
+  return { content: [{ type: 'text', text: output }] };
+}
+
+function getRoleInfo(db: any, name: string, includeChain: boolean) {
+  const symbol = db.prepare(
+    `SELECT name, description, signature, model FROM symbols WHERE name = ? AND type = 'security-role' LIMIT 1`
+  ).get(name) as any;
+
+  if (!symbol) {
+    return {
+      content: [{ type: 'text', text: `Security role not found: ${name}` }],
+    };
+  }
+
+  const duties = db.prepare(
+    `SELECT duty_name FROM security_role_duties WHERE role_name = ? ORDER BY duty_name`
+  ).all(name) as any[];
+
+  let output = `SecurityRole: ${symbol.name}\n`;
+  if (symbol.description) output += `Description: ${symbol.description}\n`;
+  output += `Model: ${symbol.model}\n`;
+
+  if (duties.length > 0) {
+    output += `\nDuties (${duties.length}):\n`;
+    for (const duty of duties) {
+      output += `  • ${duty.duty_name}`;
+
+      if (includeChain) {
+        const privileges = db.prepare(
+          `SELECT privilege_name FROM security_duty_privileges WHERE duty_name = ? ORDER BY privilege_name`
+        ).all(duty.duty_name) as any[];
+
+        if (privileges.length > 0) {
+          output += ` → ${privileges.length} privilege(s): ${privileges.slice(0, 3).map((p: any) => p.privilege_name).join(', ')}${privileges.length > 3 ? '...' : ''}`;
+        }
+      }
+      output += '\n';
+    }
+
+    if (includeChain) {
+      // Count total entry points across all duties
+      const totalEntryPoints = (db.prepare(`
+        SELECT COUNT(*) as cnt FROM security_privilege_entries spe
+        WHERE spe.privilege_name IN (
+          SELECT privilege_name FROM security_duty_privileges WHERE duty_name IN (
+            SELECT duty_name FROM security_role_duties WHERE role_name = ?
+          )
+        )
+      `).get(name) as any)?.cnt ?? 0;
+
+      output += `\nTotal entry points covered: ${totalEntryPoints}\n`;
+    }
+  } else {
+    output += `\nDuties: none indexed\n`;
+  }
+
+  return { content: [{ type: 'text', text: output }] };
+}

--- a/src/tools/securityCoverageInfo.ts
+++ b/src/tools/securityCoverageInfo.ts
@@ -1,0 +1,177 @@
+/**
+ * Security Coverage Info Tool
+ * Show what security objects (privileges/duties/roles) cover a given D365FO object
+ * by tracing the reverse chain: object → menu items → privileges → duties → roles
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const SecurityCoverageInfoArgsSchema = z.object({
+  objectName: z.string().describe('Name of the form, table, class, or menu item to check security coverage for'),
+  objectType: z.enum(['form', 'table', 'class', 'menu-item', 'auto']).optional().default('auto')
+    .describe('Type of the object (auto=detect from symbol index)'),
+});
+
+export async function securityCoverageInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = SecurityCoverageInfoArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+    const objName = args.objectName;
+
+    // ── Step 1: Detect object type ──
+    let resolvedType = args.objectType;
+    if (resolvedType === 'auto') {
+      const sym = db.prepare(
+        `SELECT type FROM symbols WHERE name = ? AND type IN ('form','table','class','menu-item-display','menu-item-action','menu-item-output')
+         ORDER BY CASE type WHEN 'form' THEN 0 WHEN 'table' THEN 1 WHEN 'class' THEN 2 ELSE 3 END LIMIT 1`
+      ).get(objName) as any;
+      if (sym) {
+        resolvedType = sym.type.startsWith('menu-item') ? 'menu-item' : sym.type as any;
+      }
+    }
+
+    let output = `Security coverage for: ${objName}`;
+    if (resolvedType !== 'auto') output += ` (${resolvedType})`;
+    output += '\n\n';
+
+    // ── Step 2: Find menu items targeting this object ──
+    // From menu_item_targets table
+    let menuItems: any[] = [];
+    try {
+      menuItems = db.prepare(
+        `SELECT menu_item_name, menu_item_type, target_object, target_type FROM menu_item_targets
+         WHERE target_object = ?
+         ORDER BY menu_item_type, menu_item_name`
+      ).all(objName) as any[];
+    } catch { /**/ }
+
+    // Fallback: if the object IS a menu item, use it directly
+    if (menuItems.length === 0 && (resolvedType === 'menu-item' || resolvedType === 'auto')) {
+      const directMenuItem = db.prepare(
+        `SELECT name as menu_item_name, type as menu_item_type FROM symbols
+         WHERE name = ? AND type IN ('menu-item-display','menu-item-action','menu-item-output') LIMIT 1`
+      ).get(objName) as any;
+      if (directMenuItem) {
+        menuItems = [{ ...directMenuItem, target_object: objName, target_type: resolvedType }];
+      }
+    }
+
+    // Also search by name match (a form named CustTable might have a menu item also named CustTable)
+    if (menuItems.length === 0) {
+      const sameNameMenuItems = db.prepare(
+        `SELECT name as menu_item_name, type as menu_item_type FROM symbols
+         WHERE name = ? AND type IN ('menu-item-display','menu-item-action','menu-item-output')`
+      ).all(objName) as any[];
+      menuItems.push(...sameNameMenuItems);
+    }
+
+    if (menuItems.length === 0) {
+      output += `No menu items found targeting: ${objName}\n`;
+      output += `This object may not be directly exposed via a menu item, or menu item indexing has not been run.\n`;
+      output += `\nTip: Security coverage requires both menu item indexing (Phase 1D) and security privilege indexing.\n`;
+      return { content: [{ type: 'text', text: output }] };
+    }
+
+    output += `Exposed via ${menuItems.length} menu item(s):\n\n`;
+
+    const allPrivileges = new Set<string>();
+    const allDuties = new Set<string>();
+    const allRoles = new Set<string>();
+
+    for (const mi of menuItems) {
+      const typeLabel = mi.menu_item_type === 'menu-item-display' ? 'MenuItemDisplay'
+        : mi.menu_item_type === 'menu-item-action' ? 'MenuItemAction'
+        : mi.menu_item_type === 'MenuItemAction' ? 'MenuItemAction'
+        : mi.menu_item_type === 'MenuItemDisplay' ? 'MenuItemDisplay'
+        : mi.menu_item_type || 'MenuItem';
+
+      output += `  ${mi.menu_item_name} (${typeLabel}):\n`;
+
+      // ── Step 3: Find privileges granting this menu item ──
+      const privileges = db.prepare(
+        `SELECT DISTINCT privilege_name, object_type, access_level FROM security_privilege_entries
+         WHERE entry_point_name = ?
+         ORDER BY privilege_name`
+      ).all(mi.menu_item_name) as any[];
+
+      if (privileges.length === 0) {
+        output += `    No privileges found granting this menu item\n`;
+      } else {
+        output += `    Privileges (${privileges.length}):\n`;
+
+        for (const priv of privileges) {
+          allPrivileges.add(priv.privilege_name);
+          output += `      ${priv.privilege_name} [${priv.access_level}]`;
+
+          // ── Step 4: Duties for this privilege ──
+          const duties = db.prepare(
+            `SELECT DISTINCT duty_name FROM security_duty_privileges
+             WHERE privilege_name = ?
+             ORDER BY duty_name LIMIT 5`
+          ).all(priv.privilege_name) as any[];
+
+          const totalDuties = (db.prepare(
+            `SELECT COUNT(*) as cnt FROM security_duty_privileges WHERE privilege_name = ?`
+          ).get(priv.privilege_name) as any)?.cnt ?? 0;
+
+          if (duties.length > 0) {
+            output += ` → Duty: ${duties.map((d: any) => d.duty_name).join(', ')}`;
+            if (totalDuties > 5) output += ` (+${totalDuties - 5} more)`;
+
+            for (const duty of duties) {
+              allDuties.add(duty.duty_name);
+
+              // ── Step 5: Roles for this duty ──
+              const roles = db.prepare(
+                `SELECT DISTINCT role_name FROM security_role_duties
+                 WHERE duty_name = ?
+                 ORDER BY role_name LIMIT 3`
+              ).all(duty.duty_name) as any[];
+
+              const totalRoles = (db.prepare(
+                `SELECT COUNT(*) as cnt FROM security_role_duties WHERE duty_name = ?`
+              ).get(duty.duty_name) as any)?.cnt ?? 0;
+
+              for (const role of roles) {
+                allRoles.add(role.role_name);
+              }
+
+              if (roles.length > 0) {
+                output += ` → Role: ${roles.map((r: any) => r.role_name).join(', ')}`;
+                if (totalRoles > 3) output += ` (+${totalRoles - 3} more)`;
+              }
+            }
+          }
+
+          output += '\n';
+        }
+      }
+      output += '\n';
+    }
+
+    // Summary
+    output += `Summary:\n`;
+    output += `  Total privileges with any access: ${allPrivileges.size}\n`;
+    output += `  Total duties: ${allDuties.size}\n`;
+    output += `  Total roles with any access: ${allRoles.size}\n`;
+
+    if (allRoles.size > 0) {
+      const roleList = [...allRoles].slice(0, 5).join(', ');
+      output += `  Roles: ${roleList}${allRoles.size > 5 ? ` (+${allRoles.size - 5} more)` : ''}\n`;
+    }
+
+    return { content: [{ type: 'text', text: output }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error getting security coverage: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/tableExtensionInfo.ts
+++ b/src/tools/tableExtensionInfo.ts
@@ -1,0 +1,151 @@
+/**
+ * Table Extension Info Tool
+ * Retrieve all extensions for a D365FO table, with effective schema merging
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const TableExtensionInfoArgsSchema = z.object({
+  tableName: z.string().describe('Base table name whose extensions to find'),
+  includeEffectiveSchema: z.boolean().optional().default(true)
+    .describe('Merge base table fields with all extension fields to show the effective full schema'),
+});
+
+export async function tableExtensionInfoTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = TableExtensionInfoArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+    const tableName = args.tableName;
+
+    // Verify the base table exists
+    const baseTable = db.prepare(
+      `SELECT name, model, file_path FROM symbols WHERE name = ? AND type = 'table' LIMIT 1`
+    ).get(tableName) as any;
+
+    let output = `Table Extensions of: ${tableName}\n`;
+    if (baseTable) {
+      output += `Base Model: ${baseTable.model}\n`;
+    }
+    output += '\n';
+
+    // Query extension_metadata for table extensions
+    let extensionRows: any[] = [];
+    try {
+      extensionRows = db.prepare(
+        `SELECT extension_name, model, added_fields, added_indexes, added_methods, coc_methods, event_subscriptions
+         FROM extension_metadata
+         WHERE base_object_name = ? AND extension_type = 'table-extension'
+         ORDER BY model, extension_name`
+      ).all(tableName) as any[];
+    } catch { /**/ }
+
+    // Fallback: symbols with extends_class pointing to the table
+    const symbolExts = db.prepare(
+      `SELECT name, model FROM symbols
+       WHERE type = 'table-extension' AND (extends_class = ? OR name LIKE ?)
+       ORDER BY model, name`
+    ).all(tableName, `${tableName}.%`) as any[];
+
+    const seen = new Set<string>();
+    const allExtensions: Array<{
+      name: string; model: string;
+      addedFields: string[]; addedIndexes: string[]; addedMethods: string[]; cocMethods: string[]; eventSubs: string[];
+    }> = [];
+
+    for (const row of extensionRows) {
+      if (!seen.has(row.extension_name)) {
+        seen.add(row.extension_name);
+        let addedFields: string[] = [];
+        let addedIndexes: string[] = [];
+        let addedMethods: string[] = [];
+        let cocMethods: string[] = [];
+        let eventSubs: string[] = [];
+        try { addedFields = JSON.parse(row.added_fields || '[]'); } catch { /**/ }
+        try { addedIndexes = JSON.parse(row.added_indexes || '[]'); } catch { /**/ }
+        try { addedMethods = JSON.parse(row.added_methods || '[]'); } catch { /**/ }
+        try { cocMethods = JSON.parse(row.coc_methods || '[]'); } catch { /**/ }
+        try { eventSubs = JSON.parse(row.event_subscriptions || '[]'); } catch { /**/ }
+        allExtensions.push({ name: row.extension_name, model: row.model, addedFields, addedIndexes, addedMethods, cocMethods, eventSubs });
+      }
+    }
+
+    for (const row of symbolExts) {
+      if (!seen.has(row.name)) {
+        seen.add(row.name);
+        allExtensions.push({ name: row.name, model: row.model, addedFields: [], addedIndexes: [], addedMethods: [], cocMethods: [], eventSubs: [] });
+      }
+    }
+
+    if (allExtensions.length === 0) {
+      output += `No table extensions found.\n`;
+      output += `Tip: Run extract-metadata and build-database to index table extensions.\n`;
+    } else {
+      for (let i = 0; i < allExtensions.length; i++) {
+        const ext = allExtensions[i];
+        output += `[${i + 1}] ${ext.name} (${ext.model})\n`;
+
+        if (ext.addedFields.length > 0) {
+          output += `    Added Fields (${ext.addedFields.length}): ${ext.addedFields.join(', ')}\n`;
+        }
+        if (ext.addedIndexes.length > 0) {
+          output += `    Added Indexes (${ext.addedIndexes.length}): ${ext.addedIndexes.join(', ')}\n`;
+        }
+        if (ext.cocMethods.length > 0) {
+          output += `    Wraps Methods (CoC) (${ext.cocMethods.length}): ${ext.cocMethods.join(', ')}\n`;
+        }
+        const newMethods = ext.addedMethods.filter(m => !ext.cocMethods.some(c => c.toLowerCase() === m.toLowerCase()));
+        if (newMethods.length > 0) {
+          output += `    Added Methods (${newMethods.length}): ${newMethods.slice(0, 5).join(', ')}${newMethods.length > 5 ? ` (+${newMethods.length - 5} more)` : ''}\n`;
+        }
+        if (ext.eventSubs.length > 0) {
+          output += `    Event Subscriptions (${ext.eventSubs.length}): ${ext.eventSubs.slice(0, 3).join(', ')}${ext.eventSubs.length > 3 ? '...' : ''}\n`;
+        }
+      }
+    }
+
+    // Effective schema summary
+    if (args.includeEffectiveSchema) {
+      output += '\nEffective Schema:\n';
+
+      // Base fields
+      const baseFields = db.prepare(
+        `SELECT name FROM symbols WHERE parent_name = ? AND type = 'field' ORDER BY name`
+      ).all(tableName) as any[];
+
+      const totalExtFields = allExtensions.reduce((sum, e) => sum + e.addedFields.length, 0);
+      const totalExtIndexes = allExtensions.reduce((sum, e) => sum + e.addedIndexes.length, 0);
+
+      output += `  Total fields: ${baseFields.length + totalExtFields}`;
+      if (totalExtFields > 0) output += ` (base: ${baseFields.length}, extensions: ${totalExtFields})`;
+      output += '\n';
+
+      // Base indexes
+      const baseIndexes = db.prepare(
+        `SELECT COUNT(*) as cnt FROM symbols WHERE parent_name = ? AND type = 'index'`
+      ).get(tableName) as any;
+      const baseIndexCount = baseIndexes?.cnt ?? 0;
+
+      output += `  Total indexes: ${baseIndexCount + totalExtIndexes}`;
+      if (totalExtIndexes > 0) output += ` (base: ${baseIndexCount}, extensions: ${totalExtIndexes})`;
+      output += '\n';
+
+      if (allExtensions.length > 0) {
+        output += `  Extensions from models: ${[...new Set(allExtensions.map(e => e.model))].join(', ')}\n`;
+      }
+    }
+
+    return { content: [{ type: 'text', text: output }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error getting table extension info: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -76,30 +76,57 @@ import { handleGetFormPatterns } from './getFormPatterns.js';
 import { handleGenerateSmartTable } from './generateSmartTable.js';
 import { handleGenerateSmartForm } from './generateSmartForm.js';
 import { handleSuggestEdt } from './suggestEdt.js';
+import { securityArtifactInfoTool } from './securityArtifactInfo.js';
+import { menuItemInfoTool } from './menuItemInfo.js';
+import { findCocExtensionsTool } from './findCocExtensions.js';
+import { tableExtensionInfoTool } from './tableExtensionInfo.js';
+import { dataEntityInfoTool } from './dataEntityInfo.js';
+import { findEventHandlersTool } from './findEventHandlers.js';
+import { securityCoverageInfoTool } from './securityCoverageInfo.js';
+import { analyzeExtensionPointsTool } from './analyzeExtensionPoints.js';
+import { validateObjectNamingTool } from './validateObjectNaming.js';
 
 /**
  * Centralized tool handler that dispatches to individual tool implementations
  */
 
-/** Tools whose output must never be truncated (XML blobs, file writes) */
-const UNCAPPED_TOOLS = new Set([
-  'generate_smart_table', 'generate_smart_form',
-  'create_d365fo_file', 'generate_d365fo_xml',
-  'get_report_info',  // report XML + optional full RDL can exceed 3.5k chars
-]);
+/** Per-tool response cap sizes. 'uncapped' = no truncation. */
+const TOOL_CAP_SIZES: Record<string, number | 'uncapped'> = {
+  // Uncapped — XML generation, file writes, or long structured output
+  generate_smart_table:             'uncapped',
+  generate_smart_form:              'uncapped',
+  create_d365fo_file:               'uncapped',
+  generate_d365fo_xml:              'uncapped',
+  get_report_info:                  'uncapped',
+  // New tools with longer output
+  get_security_artifact_info:       8000,
+  get_security_coverage_for_object: 8000,
+  get_table_extension_info:         6000,
+  analyze_extension_points:         6000,
+  find_coc_extensions:              5000,
+  find_event_handlers:              5000,
+  get_data_entity_info:             5000,
+  get_class_info:                   6000,
+  get_table_info:                   6000,
+  get_form_info:                    5000,
+  // Default for everything else
+  default:                          3500,
+};
 
-/** Hard limit on text returned to Copilot per tool call to stay under 64k context budget */
-const MAX_TOOL_RESPONSE_CHARS = 3500;
+function getCapForTool(toolName: string): number | 'uncapped' {
+  return TOOL_CAP_SIZES[toolName] ?? TOOL_CAP_SIZES['default'];
+}
 
 function capToolResponse(toolName: string, result: any): any {
-  if (UNCAPPED_TOOLS.has(toolName) || !result?.content) return result;
+  const cap = getCapForTool(toolName);
+  if (cap === 'uncapped' || !result?.content) return result;
   const content = result.content.map((item: any) => {
     if (item.type !== 'text' || typeof item.text !== 'string') return item;
-    if (item.text.length <= MAX_TOOL_RESPONSE_CHARS) return item;
+    if (item.text.length <= (cap as number)) return item;
     return {
       ...item,
-      text: item.text.slice(0, MAX_TOOL_RESPONSE_CHARS) +
-        `\n\n> ✂️ Response truncated at ${MAX_TOOL_RESPONSE_CHARS} chars. Use more specific parameters (e.g. methodOffset, compact=false for one class) to get remaining content.`,
+      text: item.text.slice(0, cap as number) +
+        `\n\n> ✂️ Response truncated at ${cap} chars. Use more specific parameters (e.g. methodOffset, compact=false for one class) to get remaining content.`,
     };
   });
   return { ...result, content };
@@ -217,6 +244,24 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         );
         return { content: r?.content ?? [{ type: 'text', text: 'No results returned' }] };
       }
+      case 'get_security_artifact_info':
+        return securityArtifactInfoTool(request, context);
+      case 'get_menu_item_info':
+        return menuItemInfoTool(request, context);
+      case 'find_coc_extensions':
+        return findCocExtensionsTool(request, context);
+      case 'get_table_extension_info':
+        return tableExtensionInfoTool(request, context);
+      case 'get_data_entity_info':
+        return dataEntityInfoTool(request, context);
+      case 'find_event_handlers':
+        return findEventHandlersTool(request, context);
+      case 'get_security_coverage_for_object':
+        return securityCoverageInfoTool(request, context);
+      case 'analyze_extension_points':
+        return analyzeExtensionPointsTool(request, context);
+      case 'validate_object_naming':
+        return validateObjectNamingTool(request, context);
       default:
         return {
           content: [

--- a/src/tools/validateObjectNaming.ts
+++ b/src/tools/validateObjectNaming.ts
@@ -1,0 +1,285 @@
+/**
+ * Validate Object Naming Tool
+ * Validate proposed D365FO object names against naming conventions,
+ * detect conflicts against the symbol index, and suggest correct names.
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+const ValidateObjectNamingArgsSchema = z.object({
+  proposedName: z.string().describe('The proposed object name to validate'),
+  objectType: z.enum([
+    'class', 'table', 'form', 'enum', 'edt', 'query', 'view',
+    'table-extension', 'class-extension', 'form-extension',
+    'enum-extension', 'edt-extension',
+    'menu-item', 'security-privilege', 'security-duty', 'security-role',
+    'data-entity',
+  ]).describe('Type of the D365FO object'),
+  baseObjectName: z.string().optional()
+    .describe('Required for extension types: name of the object being extended'),
+  modelPrefix: z.string().optional()
+    .describe('Expected ISV/model prefix (2-4 uppercase letters, e.g. "WHS", "CONT"). Auto-detected if omitted.'),
+});
+
+// Extension types that require base object name
+const EXTENSION_TYPES = new Set([
+  'table-extension', 'class-extension', 'form-extension',
+  'enum-extension', 'edt-extension',
+]);
+
+export async function validateObjectNamingTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = ValidateObjectNamingArgsSchema.parse(request.params.arguments);
+    const db = context.symbolIndex.db;
+
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const suggestions: string[] = [];
+
+    const name = args.proposedName;
+    const isExtension = EXTENSION_TYPES.has(args.objectType);
+
+    // ── Auto-detect model prefix from existing symbols if not provided ─────
+    let prefix = args.modelPrefix?.toUpperCase() || '';
+    if (!prefix) {
+      prefix = detectModelPrefix(db, name);
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // RULE SET 1: Extension naming rules
+    // ══════════════════════════════════════════════════════════════════
+    if (isExtension) {
+      const baseObjectName = args.baseObjectName;
+
+      if (!baseObjectName) {
+        errors.push(`baseObjectName is required for extension types (${args.objectType}).`);
+      } else {
+        if (args.objectType === 'class-extension') {
+          // Class extensions: {Base}{Prefix}_Extension
+          const expectedPattern = `${baseObjectName}${prefix}_Extension`;
+
+          if (!name.startsWith(baseObjectName)) {
+            errors.push(`Class extension names must start with the base class name.\n  Expected format: ${expectedPattern}`);
+            if (prefix) suggestions.push(`Correct name: ${expectedPattern}`);
+          } else if (!name.endsWith('_Extension')) {
+            errors.push(`Class extension names must end with '_Extension'.\n  Expected format: ${expectedPattern}`);
+            if (prefix) suggestions.push(`Correct name: ${expectedPattern}`);
+          } else {
+            // Has correct structure — check prefix is included
+            const middle = name.slice(baseObjectName.length, -'_Extension'.length);
+            if (prefix && middle !== prefix && !middle.includes(prefix)) {
+              warnings.push(`Extension name does not include model prefix "${prefix}".\n  Current: ${name}\n  Recommended: ${expectedPattern}`);
+            }
+          }
+
+          // AOT extension name suggestion
+          if (args.objectType === 'class-extension') {
+            suggestions.push(`AOT label for extension file: ${baseObjectName}.${prefix}Extension (if creating table-extension AOT object instead)`);
+          }
+
+        } else {
+          // AOT extensions (table/form/enum/edt): {Base}.{Prefix}Extension
+          const expectedPattern = `${baseObjectName}.${prefix}Extension`;
+
+          if (!name.includes('.')) {
+            errors.push(`${args.objectType} names must use dot notation: {Base}.{Prefix}Extension.\n  Expected: ${expectedPattern}`);
+            if (prefix) suggestions.push(`Correct name: ${expectedPattern}`);
+          } else {
+            const [basePart, extPart] = name.split('.', 2);
+
+            if (basePart !== baseObjectName) {
+              errors.push(`Extension base (before '.') must exactly match baseObjectName.\n  Expected: ${baseObjectName}.xxx\n  Got: ${basePart}.xxx`);
+            }
+            if (!extPart.endsWith('Extension')) {
+              errors.push(`Extension suffix (after '.') must end with 'Extension'.\n  Expected: ${prefix}Extension\n  Got: ${extPart}`);
+            } else if (prefix && !extPart.startsWith(prefix)) {
+              warnings.push(`Extension suffix should start with model prefix "${prefix}".\n  Current: ${extPart}\n  Recommended: ${prefix}Extension`);
+            }
+          }
+        }
+
+        // Verify base object exists in index
+        const dbTypes = args.objectType.includes('class') ? ['class'] :
+          args.objectType.includes('table') ? ['table'] :
+          args.objectType.includes('form') ? ['form'] :
+          args.objectType.includes('enum') ? ['enum'] : ['edt'];
+
+        const baseExists = db.prepare(
+          `SELECT name FROM symbols WHERE name = ? AND type IN (${dbTypes.map(() => '?').join(',')}) LIMIT 1`
+        ).get(baseObjectName, ...dbTypes) as any;
+
+        if (!baseExists) {
+          warnings.push(`Base object "${baseObjectName}" not found in symbol index for types: ${dbTypes.join(', ')}. Ensure it's indexed.`);
+        }
+      }
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // RULE SET 2: New object naming rules
+    // ══════════════════════════════════════════════════════════════════
+    if (!isExtension) {
+      // No underscores in base names (underscores reserved for extension pattern)
+      if (name.includes('_')) {
+        errors.push(`Non-extension objects must not contain underscores. Underscores are reserved for extension naming (e.g. MyClass_Extension).`);
+      }
+
+      // Must start with a prefix (letter, avoid starting with Microsoft-reserved ones)
+      if (prefix) {
+        if (!name.startsWith(prefix) && !name.toUpperCase().startsWith(prefix)) {
+          warnings.push(`Proposed name does not start with model prefix "${prefix}". All custom objects should be prefixed to avoid conflicts.`);
+          suggestions.push(`Prefixed name: ${prefix}${name}`);
+        }
+      }
+
+      // Security object naming conventions
+      if (args.objectType === 'security-privilege') {
+        if (!/(View|Maintain|Delete|Admin|Invoke|Approve|FullControl)$/.test(name)) {
+          warnings.push(`Security privileges typically end with an action suffix: View, Maintain, Delete, Admin, Invoke, Approve, or FullControl.\n  Examples: ${name}View, ${name}Maintain`);
+        }
+      }
+
+      if (args.objectType === 'security-duty') {
+        if (!/(Maintain|View|Inquire|Admin|Approve|Process)$/.test(name) &&
+            !(name.toLowerCase().includes('maintain') || name.toLowerCase().includes('view'))) {
+          warnings.push(`Security duties typically end with: Maintain, View, Inquire, Admin, Approve, or Process.`);
+        }
+      }
+
+      if (args.objectType === 'data-entity') {
+        if (!name.endsWith('Entity')) {
+          warnings.push(`Data entity names typically end with 'Entity'. Recommendation: ${name}Entity`);
+          suggestions.push(`Data entity name: ${name}Entity`);
+        }
+      }
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // RULE SET 3: Conflict detection
+    // ══════════════════════════════════════════════════════════════════
+    // Exact name collision
+    const dbType = args.objectType === 'class-extension' ? 'class-extension' :
+      args.objectType === 'table-extension' ? 'table-extension' :
+      args.objectType === 'form-extension' ? 'form-extension' :
+      args.objectType === 'enum-extension' ? 'enum-extension' :
+      args.objectType === 'edt-extension' ? 'edt-extension' :
+      args.objectType === 'data-entity' ? 'view' :
+      args.objectType;
+
+    const exactConflict = db.prepare(
+      `SELECT name, type, model FROM symbols WHERE name = ? ORDER BY model LIMIT 5`
+    ).all(name) as any[];
+
+    // Near-match search (same prefix, similar name)
+    const similarSymbols = db.prepare(
+      `SELECT name, type, model FROM symbols WHERE name LIKE ? AND type = ? ORDER BY name LIMIT 5`
+    ).all(`${name.slice(0, Math.max(4, name.length - 3))}%`, dbType) as any[];
+
+    // ══════════════════════════════════════════════════════════════════
+    // FORMAT OUTPUT
+    // ══════════════════════════════════════════════════════════════════
+    let output = `Validation: "${name}" as ${args.objectType}\n`;
+    if (args.baseObjectName) output += `Base Object: ${args.baseObjectName}\n`;
+    if (prefix) output += `Model Prefix: ${prefix}\n`;
+    output += '\n';
+
+    if (errors.length > 0) {
+      output += `ERRORS (${errors.length}):\n`;
+      for (const e of errors) {
+        output += `  ✗ ${e}\n`;
+      }
+      output += '\n';
+    }
+
+    if (warnings.length > 0) {
+      output += `WARNINGS (${warnings.length}):\n`;
+      for (const w of warnings) {
+        output += `  ⚠ ${w}\n`;
+      }
+      output += '\n';
+    }
+
+    if (errors.length === 0 && warnings.length === 0) {
+      output += `✓ Name passes all validation rules\n\n`;
+    }
+
+    if (suggestions.length > 0) {
+      output += `SUGGESTIONS:\n`;
+      for (const s of suggestions) {
+        output += `  → ${s}\n`;
+      }
+      output += '\n';
+    }
+
+    // Conflicts
+    output += `CONFLICT CHECK:\n`;
+    if (exactConflict.length > 0) {
+      output += `  ✗ Name "${name}" already exists:\n`;
+      for (const c of exactConflict) {
+        output += `    ${c.name} [${c.type}] in ${c.model}\n`;
+      }
+    } else {
+      output += `  ✓ No existing objects named "${name}" found\n`;
+    }
+
+    if (similarSymbols.length > 0 && !exactConflict.some(c => c.name === name)) {
+      output += `  Similar ${args.objectType} names:\n`;
+      for (const s of similarSymbols) {
+        output += `    ${s.name} [${s.model}]\n`;
+      }
+    }
+
+    output += '\n';
+
+    // Naming rules applied
+    const rules = isExtension
+      ? ['Extension suffix pattern', 'Model prefix included', 'Base object exists in index']
+      : ['No underscore in non-extension names', 'Model prefix', 'Type-specific conventions'];
+    output += `Naming Rules Applied:\n`;
+    for (const r of rules) {
+      output += `  [${errors.length === 0 ? 'x' : ' '}] ${r}\n`;
+    }
+
+    return { content: [{ type: 'text', text: output }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error validating object name: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Detect common model prefix from existing custom symbols.
+ * Looks for 2-4 char prefix shared by many objects in the index.
+ */
+function detectModelPrefix(db: any, proposedName: string): string {
+  // If proposed name starts with common D365 standard prefixes, return empty
+  const stdPrefixes = ['Cust', 'Vend', 'Sales', 'Purch', 'Ledger', 'Invent', 'Proj', 'WHS',
+    'Sma', 'MCR', 'Retail', 'Ax', 'Sys', 'Global', 'Common', 'Tax', 'Bank'];
+  for (const p of stdPrefixes) {
+    if (proposedName.startsWith(p)) return '';
+  }
+
+  try {
+    // Sample a few symbols starting with the first 3 chars of the proposed name
+    const prefix3 = proposedName.slice(0, 3).toUpperCase();
+    const sample = db.prepare(
+      `SELECT name FROM symbols WHERE type = 'class' AND name LIKE ? LIMIT 20`
+    ).all(`${prefix3}%`) as any[];
+
+    if (sample.length >= 3) return prefix3;
+
+    // Try 2 chars
+    const prefix2 = proposedName.slice(0, 2).toUpperCase();
+    return prefix2.length >= 2 ? prefix2 : '';
+  } catch {
+    return '';
+  }
+}

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -45,7 +45,7 @@ async function findProjectFiles(
         'AxDataEntityView', 'AxTableExtension', 'AxFormExtension',
         'AxMenuItemAction', 'AxMenuItemDisplay', 'AxMenuItemOutput',
         'AxMenu', 'AxSecurityRole', 'AxSecurityDuty', 'AxSecurityPrivilege',
-        'AxLabel', 'AxResource', 'AxReport', 'AxWorkflowType',
+        'AxLabel', 'AxResource', 'AxReport',
         'AxEdt', 'AxExtendedDataType',
       ];
       if (entry.isDirectory() && skipDirs.includes(entry.name)) {


### PR DESCRIPTION
This pull request updates documentation across the project to reflect the expansion from 29 to 40 available MCP tools, with a major emphasis on new security and extension-related capabilities. The README and supporting docs now provide clearer descriptions, more practical usage examples, and improved guidance for D365FO developers working with X++ in Visual Studio. The changes make it easier for users to understand what the MCP server offers, how Copilot interacts with it, and what new tasks can be automated.

**Documentation updates for toolset expansion:**

* Updated `README.md` to describe 40 AI tools (up from 29), clarify the server’s role for D365FO/X++ developers, and provide more detailed, practical examples of what Copilot can do with the MCP server. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R60) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R160) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L153-R173)
* Expanded architecture diagrams and protocol documentation in `docs/ARCHITECTURE.md` to show 40 tools and list new security/extension-related methods, including updates to sequence diagrams and tool definitions. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L38-R38) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L85-R85) [[3]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L524-R524) [[4]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L533-R533)

**Tool reference and configuration:**

* Updated `docs/MCP_CONFIG.md` to log and describe the registration of 40 tools, including breakdowns by category (security, labels, object-info, extension analysis, etc.).
* Revised `docs/MCP_TOOLS.md` to list all 40 tools, add a new section for 9 security & extension tools (e.g., `get_security_artifact_info`, `find_coc_extensions`, `analyze_extension_points`), and clarify label management capabilities. [[1]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L4-R4) [[2]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L68-R82)

**Practical usage examples:**

* Added a comprehensive "Security and Extensions" section to `docs/USAGE_EXAMPLES.md`, with step-by-step prompts and explanations for security chain tracing, privilege inspection, CoC extension discovery, event handler lookup, table extension inspection, data entity analysis, extension point discovery, naming validation, and batch job/event handler generation. [[1]](diffhunk://#diff-7c912a00313e262356400d83024c714e162d759b92e2604f5fa88cf231302547L13-R18) [[2]](diffhunk://#diff-7c912a00313e262356400d83024c714e162d759b92e2604f5fa88cf231302547R408-R536)… updated docs

New tools:
- get_security_artifact_info: Privilege/Duty/Role detail with full hierarchy chain
- get_security_coverage_for_object: reverse chain object → menu items → privileges → roles
- get_menu_item_info: menu item target, type, and security privilege chain
- find_coc_extensions: find CoC wrappers for a class/method
- find_event_handlers: find all [SubscribesTo] handlers for a table/class event
- get_table_extension_info: all extensions of a table (fields, indexes, methods)
- get_data_entity_info: OData/DMF settings, data sources, keys
- analyze_extension_points: CoC-eligible methods, delegates, blocked methods, table events
- validate_object_naming: validate names against D365FO naming conventions

Infrastructure:
- 5 new SQLite tables (security_privilege_entries, security_duty_privileges, security_role_duties, menu_item_targets, extension_metadata)
- 5 new XML parsers (security privilege/duty/role, menu item, extension files)
- 12 new extraction flows in extract-metadata.ts
- XppSymbol.type union extended with 11 new literal types

generate_code patterns: sysoperation, event-handler, security-privilege, menu-item
get_edt_info: new hierarchy mode (ancestor chain + children + field usages)
batch_search: globalTypeFilter fan-out + cross-query deduplication
toolHandler: replaced UNCAPPED_TOOLS with per-tool TOOL_CAP_SIZES map

Remove workflow-type, aggregate-measurement, configuration-key support (not needed yet)

Docs: README, ARCHITECTURE.md, MCP_CONFIG.md, MCP_TOOLS.md, USAGE_EXAMPLES.md all updated to reflect 40 tools and new security/extension capabilities