### PR TITLE
fix: skip malformed entry points in XppSymbolIndex to prevent SQL errors

### DIFF
--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1523,7 +1523,15 @@ export class XppSymbolIndex {
         });
 
         for (const ep of entryPoints) {
-          insertEntry.run(name, ep.name, ep.objectType, ep.accessLevel, model);
+          // Skip malformed entry points — missing name causes "Too few parameter values" in better-sqlite3
+          if (!ep.name) continue;
+          insertEntry.run(
+            name,
+            ep.name,
+            ep.objectType ?? null,
+            ep.accessLevel ?? null,
+            model
+          );
         }
       } catch (error) {
         console.error(`      ⚠️  Skipped security-privilege ${file}: ${error instanceof Error ? error.message : error}`);


### PR DESCRIPTION
This pull request improves the robustness of the `XppSymbolIndex` class by handling malformed entry points and ensuring that optional properties are correctly stored in the database.

Error handling and data validation:

* Skips entry points with missing names to prevent database errors ("Too few parameter values" in `better-sqlite3`).

Database interaction improvements:

* Ensures that `objectType` and `accessLevel` are stored as `null` when not present, rather than `undefined`, to maintain database integrity.