### PR TITLE
fix: normalize access levels and source paths in metadata extraction

### DIFF
--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -28,6 +28,24 @@ const EXTRACT_MODE = process.env.EXTRACT_MODE || 'all';
 // Use shared utility for checking custom models
 const isCustomModel = checkIsCustomModel;
 
+/**
+ * Strip machine-specific prefix so that sourcePath stored in JSON is relative
+ * to PackagesLocalDirectory (portable across CI agents and local machines).
+ * e.g. "/home/vsts/work/1/PackagesLocalDirectory/App/App/AxClass/X.xml"
+ *   => "App/App/AxClass/X.xml"
+ */
+function normalizeSourcePath(p: string): string {
+  const m = /[/\\]PackagesLocalDirectory[/\\](.+)$/.exec(p);
+  return m ? m[1].replace(/\\/g, '/') : p;
+}
+
+/** JSON.stringify replacer that normalises all sourcePath values. */
+function sourcePathReplacer(key: string, value: unknown): unknown {
+  return key === 'sourcePath' && typeof value === 'string'
+    ? normalizeSourcePath(value)
+    : value;
+}
+
 let MODELS_TO_EXTRACT: string[] = [];
 let FILTER_MODE: 'all' | 'custom-only' | 'standard-only' = 'all';
 
@@ -532,7 +550,7 @@ async function extractClasses(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'classes');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${classInfo.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(classInfo.data, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify(classInfo.data, sourcePathReplacer, 2));
 
       stats.classes++;
     } catch (error) {
@@ -586,7 +604,7 @@ async function extractTables(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'tables');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${tableInfo.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(tableInfo.data, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify(tableInfo.data, sourcePathReplacer, 2));
 
       stats.tables++;
     } catch (error) {
@@ -642,7 +660,7 @@ async function extractForms(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'forms');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${formInfo.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(formInfo, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify(formInfo, sourcePathReplacer, 2));
 
       stats.forms++;
     } catch (error) {
@@ -696,7 +714,7 @@ async function extractQueries(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'queries');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${queryName}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(queryInfo, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify(queryInfo, sourcePathReplacer, 2));
 
       stats.queries++;
     } catch (error) {
@@ -749,7 +767,7 @@ async function extractViews(
         const outputDir = path.join(OUTPUT_PATH, modelName, 'views');
         await fs.mkdir(outputDir, { recursive: true });
         const outputFile = path.join(outputDir, `${viewInfo.data.name}.json`);
-        await fs.writeFile(outputFile, JSON.stringify(viewInfo.data, null, 2));
+        await fs.writeFile(outputFile, JSON.stringify(viewInfo.data, sourcePathReplacer, 2));
 
         if (viewInfo.data.type === 'data-entity') {
           stats.dataEntities++;
@@ -802,7 +820,7 @@ async function extractEnums(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'enums');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, file.replace('.xml', '.json'));
-      await fs.writeFile(outputFile, JSON.stringify({ raw: content }, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify({ raw: content }, sourcePathReplacer, 2));
 
       stats.enums++;
     } catch (error) {
@@ -858,7 +876,7 @@ async function extractEdts(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'edts');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${edtInfo.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(edtInfo, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify(edtInfo, sourcePathReplacer, 2));
 
       stats.edts++;
     } catch (error) {
@@ -919,7 +937,7 @@ async function extractReports(
       };
 
       const outputFile = path.join(outputDir, `${name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(stub, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify(stub, sourcePathReplacer, 2));
 
       stats.reports++;
     } catch (error) {
@@ -952,7 +970,7 @@ async function extractSecurityPrivileges(
       const result = await parser.parseSecurityPrivilegeFile(filePath);
       if (!result.success || !result.data) { stats.errors++; continue; }
       const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-privilege' }, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-privilege' }, sourcePathReplacer, 2));
       stats.securityPrivileges++;
     } catch (error) {
       console.error(`   ❌ Error extracting security privilege ${file}:`, error);
@@ -984,7 +1002,7 @@ async function extractSecurityDuties(
       const result = await parser.parseSecurityDutyFile(filePath);
       if (!result.success || !result.data) { stats.errors++; continue; }
       const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-duty' }, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-duty' }, sourcePathReplacer, 2));
       stats.securityDuties++;
     } catch (error) {
       console.error(`   ❌ Error extracting security duty ${file}:`, error);
@@ -1016,7 +1034,7 @@ async function extractSecurityRoles(
       const result = await parser.parseSecurityRoleFile(filePath);
       if (!result.success || !result.data) { stats.errors++; continue; }
       const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-role' }, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-role' }, sourcePathReplacer, 2));
       stats.securityRoles++;
     } catch (error) {
       console.error(`   ❌ Error extracting security role ${file}:`, error);
@@ -1055,7 +1073,7 @@ async function extractMenuItems(
       const result = await parser.parseMenuItemFile(filePath, itemType);
       if (!result.success || !result.data) { stats.errors++; continue; }
       const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: `menu-item-${itemType}` }, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: `menu-item-${itemType}` }, sourcePathReplacer, 2));
       (stats as any)[statKey]++;
     } catch (error) {
       console.error(`   ❌ Error extracting menu item (${itemType}) ${file}:`, error);
@@ -1099,7 +1117,7 @@ async function extractExtensions(
       const result = await parser.parseExtensionFile(filePath, extensionType);
       if (!result.success || !result.data) { stats.errors++; continue; }
       const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: extensionType }, null, 2));
+      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: extensionType }, sourcePathReplacer, 2));
       const statKey = statKeyMap[extensionType];
       if (statKey) (stats as any)[statKey]++;
     } catch (error) {

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1525,11 +1525,18 @@ export class XppSymbolIndex {
         for (const ep of entryPoints) {
           // Skip malformed entry points — missing name causes "Too few parameter values" in better-sqlite3
           if (!ep.name) continue;
+          // Safeguard: accessLevel may be an object in older JSONs extracted before
+          // xmlParser normalisation was added. Serialize to string.
+          const accessLevelStr = ep.accessLevel == null
+            ? null
+            : typeof ep.accessLevel === 'object'
+              ? Object.entries(ep.accessLevel as Record<string, string>).map(([k, v]) => `${k}:${v}`).join(',')
+              : String(ep.accessLevel);
           insertEntry.run(
             name,
             ep.name,
             ep.objectType ?? null,
-            ep.accessLevel ?? null,
+            accessLevelStr,
             model
           );
         }

--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -826,11 +826,24 @@ export class XppMetadataParser {
 
       const rawEps = root.EntryPoints?.AxSecurityEntryPointReference;
       const epArray = rawEps ? (Array.isArray(rawEps) ? rawEps : [rawEps]) : [];
-      const entryPoints = epArray.map((ep: any) => ({
-        name: ep.Name || '',
-        objectType: ep.ObjectType || '',
-        accessLevel: ep.Grant || ep.Access || '',
-      })).filter((ep: any) => ep.name);
+      const entryPoints = epArray.map((ep: any) => {
+        // Grant / Access can be a plain string (e.g. "Allow") OR an object
+        // ({ Read: "Allow", Create: "Allow", ... }) depending on the XML structure.
+        // Normalise to a string so it can be stored as TEXT in SQLite.
+        const rawAccess = ep.Grant ?? ep.Access;
+        let accessLevel: string;
+        if (rawAccess == null) {
+          accessLevel = '';
+        } else if (typeof rawAccess === 'object') {
+          // Serialize to "Read:Allow,Create:Allow,..." form
+          accessLevel = Object.entries(rawAccess as Record<string, string>)
+            .map(([k, v]) => `${k}:${v}`)
+            .join(',');
+        } else {
+          accessLevel = String(rawAccess);
+        }
+        return { name: ep.Name || '', objectType: ep.ObjectType || '', accessLevel };
+      }).filter((ep: any) => ep.name);
 
       return { success: true, data: { name, label, sourcePath: filePath, entryPoints } };
     } catch (error) {


### PR DESCRIPTION
This pull request improves the extraction and storage of metadata by ensuring that all `sourcePath` values in the output JSON files are normalized to be portable across different environments, and by standardizing how entry point access levels are serialized for storage. These changes enhance the consistency and reliability of the metadata outputs, especially when working with files generated on different machines or with varying XML structures.

### Metadata extraction and normalization

* Added a utility function (`normalizeSourcePath`) and a custom `JSON.stringify` replacer (`sourcePathReplacer`) in `scripts/extract-metadata.ts` to ensure all `sourcePath` values in output JSON files are stored relative to `PackagesLocalDirectory`, making them portable across CI agents and local machines. All metadata extraction functions now use this replacer when writing JSON files. [[1]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afR31-R48) [[2]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL535-R553) [[3]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL589-R607) [[4]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL645-R663) [[5]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL699-R717) [[6]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL752-R770) [[7]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL805-R823) [[8]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL861-R879) [[9]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL922-R940) [[10]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL955-R973) [[11]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL987-R1005) [[12]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL1019-R1037) [[13]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL1058-R1076) [[14]](diffhunk://#diff-9022db4a1053d21a313910fc7670bd29ddb6612898ee7f862e8f2adba79873afL1102-R1120)

### Entry point access level standardization

* Updated the XML parser in `src/metadata/xmlParser.ts` to normalize entry point access levels: whether the access is a string or an object, it is now serialized to a consistent string format (e.g., `"Read:Allow,Create:Allow"`), ensuring compatibility with SQLite storage.
* Updated the symbol indexer in `src/metadata/symbolIndex.ts` to safeguard against older JSONs where `accessLevel` may be an object, serializing it to a string before database insertion.