### PR TITLE
feat: add comprehensive AOT object type support across all file tools

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -14,8 +14,15 @@ import { PackageResolver } from '../utils/packageResolver.js';
 
 const CreateD365FileArgsSchema = z.object({
   objectType: z
-    .enum(['class', 'table', 'enum', 'form', 'query', 'view', 'data-entity', 'report',
-           'menu-item-display', 'menu-item-action', 'menu-item-output'])
+    .enum([
+      'class', 'table', 'enum', 'form', 'query', 'view', 'data-entity', 'report',
+      'edt', 'edt-extension',
+      'table-extension', 'form-extension', 'data-entity-extension', 'enum-extension',
+      'menu-item-display', 'menu-item-action', 'menu-item-output',
+      'menu-item-display-extension', 'menu-item-action-extension', 'menu-item-output-extension',
+      'menu', 'menu-extension',
+      'security-privilege', 'security-duty', 'security-role',
+    ])
     .describe('Type of D365FO object to create'),
   objectName: z
     .string()
@@ -1012,10 +1019,38 @@ ${defaultParamGroupXml}
         return this.generateAxDataEntityXml(objectName, properties);
       case 'report':
         return this.generateAxReportXml(objectName, properties);
+      case 'edt':
+        return this.generateAxEdtXml(objectName, properties);
+      case 'table-extension':
+        return this.generateAxTableExtensionXml(objectName);
+      case 'form-extension':
+        return this.generateAxFormExtensionXml(objectName);
+      case 'edt-extension':
+        return this.generateAxSimpleExtensionXml('AxEdtExtension', objectName);
+      case 'enum-extension':
+        return this.generateAxSimpleExtensionXml('AxEnumExtension', objectName);
+      case 'data-entity-extension':
+        return this.generateAxSimpleExtensionXml('AxDataEntityViewExtension', objectName);
       case 'menu-item-display':
       case 'menu-item-action':
       case 'menu-item-output':
         return this.generateAxMenuItemXml(objectType, objectName, properties);
+      case 'menu-item-display-extension':
+        return this.generateAxSimpleExtensionXml('AxMenuItemDisplayExtension', objectName);
+      case 'menu-item-action-extension':
+        return this.generateAxSimpleExtensionXml('AxMenuItemActionExtension', objectName);
+      case 'menu-item-output-extension':
+        return this.generateAxSimpleExtensionXml('AxMenuItemOutputExtension', objectName);
+      case 'menu':
+        return this.generateAxMenuXml(objectName, properties);
+      case 'menu-extension':
+        return this.generateAxMenuExtensionXml(objectName);
+      case 'security-privilege':
+        return this.generateAxSecurityPrivilegeXml(objectName, properties);
+      case 'security-duty':
+        return this.generateAxSecurityDutyXml(objectName, properties);
+      case 'security-role':
+        return this.generateAxSecurityRoleXml(objectName, properties);
       default:
         throw new Error(`Unsupported object type: ${objectType}`);
     }
@@ -1721,6 +1756,154 @@ ${defaultParamGroupXml}
   }
 
   /**
+   * Generate AxEdt XML (Extended Data Type).
+   * Default i:type is AxEdtString; override via properties.edtType.
+   */
+  static generateAxEdtXml(name: string, properties?: Record<string, any>): string {
+    const edtType = properties?.edtType || 'AxEdtString';
+    const label = properties?.label || '@TODO:LabelId';
+    const extends_ = properties?.extends ? `\n\t<Extends>${properties.extends}</Extends>` : '';
+    const stringSize = edtType === 'AxEdtString'
+      ? `\n\t<StringSize>${properties?.stringSize ?? 30}</StringSize>` : '';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns=""
+\ti:type="${edtType}">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>${extends_}
+\t<ArrayElements />
+\t<Relations />
+\t<TableReferences />${stringSize}
+</AxEdt>`;
+  }
+
+  /**
+   * Generate a minimal extension XML for AxEdtExtension, AxEnumExtension,
+   * AxDataEntityViewExtension, AxMenuItemDisplayExtension, AxMenuItemActionExtension,
+   * AxMenuItemOutputExtension.
+   * Name convention: BaseObjectName.ExtensionName  (e.g. CustTable.MyExtension)
+   */
+  static generateAxSimpleExtensionXml(rootElement: string, name: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<${rootElement} xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<PropertyModifications />
+</${rootElement}>`;
+  }
+
+  /**
+   * Generate AxTableExtension XML.
+   * Name convention: TableName.ExtensionName
+   */
+  static generateAxTableExtensionXml(name: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxTableExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<FieldGroupExtensions />
+\t<FieldGroups />
+\t<FieldModifications />
+\t<Fields />
+\t<FullTextIndexes />
+\t<Indexes />
+\t<Mappings />
+\t<PropertyModifications />
+\t<RelationExtensions />
+\t<RelationModifications />
+\t<Relations />
+</AxTableExtension>`;
+  }
+
+  /**
+   * Generate AxFormExtension XML.
+   * Name convention: FormName.ExtensionName
+   */
+  static generateAxFormExtensionXml(name: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>${name}</Name>
+\t<ControlModifications />
+\t<Controls />
+\t<DataSourceModifications />
+\t<DataSourceReferences />
+\t<DataSources />
+\t<Parts />
+\t<PropertyModifications />
+</AxFormExtension>`;
+  }
+
+  /**
+   * Generate AxSecurityPrivilege XML.
+   */
+  static generateAxSecurityPrivilegeXml(name: string, properties?: Record<string, any>): string {
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<DataEntityPermissions />
+\t<DirectAccessPermissions />
+\t<EntryPoints />
+\t<FormControlOverrides />
+</AxSecurityPrivilege>`;
+  }
+
+  /**
+   * Generate AxSecurityDuty XML.
+   */
+  static generateAxSecurityDutyXml(name: string, properties?: Record<string, any>): string {
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<Privileges />
+</AxSecurityDuty>`;
+  }
+
+  /**
+   * Generate AxSecurityRole XML.
+   */
+  static generateAxSecurityRoleXml(name: string, properties?: Record<string, any>): string {
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<DirectAccessPermissions />
+\t<Duties />
+\t<Privileges />
+\t<SubRoles />
+</AxSecurityRole>`;
+  }
+
+  /**
+   * Generate AxMenu XML.
+   */
+  static generateAxMenuXml(name: string, properties?: Record<string, any>): string {
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxMenu xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<Elements />
+</AxMenu>`;
+  }
+
+  /**
+   * Generate AxMenuExtension XML.
+   * Name convention: MenuName.ExtensionName
+   */
+  static generateAxMenuExtensionXml(name: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxMenuExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+\t<Name>${name}</Name>
+\t<Customizations />
+\t<Elements />
+\t<MenuElementModifications />
+\t<PropertyModifications />
+</AxMenuExtension>`;
+  }
+
+  /**
    * Generate AxMenuItemDisplay / AxMenuItemAction / AxMenuItemOutput XML.
    *
    * AOT folder mapping:
@@ -1790,6 +1973,17 @@ export class ProjectFileManager {
       'menu-item-display': 'Menu Items Display',
       'menu-item-action': 'Menu Items Action',
       'menu-item-output': 'Menu Items Output',
+      'menu-item-display-extension': 'Menu Item Display Extensions',
+      'menu-item-action-extension': 'Menu Item Action Extensions',
+      'menu-item-output-extension': 'Menu Item Output Extensions',
+      edt: 'Extended Data Types',
+      'edt-extension': 'EDT Extensions',
+      'enum-extension': 'Enum Extensions',
+      menu: 'Menus',
+      'menu-extension': 'Menu Extensions',
+      'security-privilege': 'Security Privileges',
+      'security-duty': 'Security Duties',
+      'security-role': 'Security Roles',
     };
     return folderMap[objectType] || 'Classes';
   }
@@ -1814,6 +2008,17 @@ export class ProjectFileManager {
       'menu-item-display': 'AxMenuItemDisplay',
       'menu-item-action': 'AxMenuItemAction',
       'menu-item-output': 'AxMenuItemOutput',
+      'menu-item-display-extension': 'AxMenuItemDisplayExtension',
+      'menu-item-action-extension': 'AxMenuItemActionExtension',
+      'menu-item-output-extension': 'AxMenuItemOutputExtension',
+      edt: 'AxEdt',
+      'edt-extension': 'AxEdtExtension',
+      'enum-extension': 'AxEnumExtension',
+      menu: 'AxMenu',
+      'menu-extension': 'AxMenuExtension',
+      'security-privilege': 'AxSecurityPrivilege',
+      'security-duty': 'AxSecurityDuty',
+      'security-role': 'AxSecurityRole',
     };
     return prefixMap[objectType] || 'AxClass';
   }
@@ -2175,13 +2380,27 @@ export async function handleCreateD365File(
       table: 'AxTable',
       enum: 'AxEnum',
       form: 'AxForm',
-      'menu-item-display': 'AxMenuItemDisplay',
-      'menu-item-action': 'AxMenuItemAction',
-      'menu-item-output': 'AxMenuItemOutput',
       query: 'AxQuery',
       view: 'AxView',
       'data-entity': 'AxDataEntityView',
       report: 'AxReport',
+      edt: 'AxEdt',
+      'edt-extension': 'AxEdtExtension',
+      'table-extension': 'AxTableExtension',
+      'form-extension': 'AxFormExtension',
+      'data-entity-extension': 'AxDataEntityViewExtension',
+      'enum-extension': 'AxEnumExtension',
+      'menu-item-display': 'AxMenuItemDisplay',
+      'menu-item-action': 'AxMenuItemAction',
+      'menu-item-output': 'AxMenuItemOutput',
+      'menu-item-display-extension': 'AxMenuItemDisplayExtension',
+      'menu-item-action-extension': 'AxMenuItemActionExtension',
+      'menu-item-output-extension': 'AxMenuItemOutputExtension',
+      menu: 'AxMenu',
+      'menu-extension': 'AxMenuExtension',
+      'security-privilege': 'AxSecurityPrivilege',
+      'security-duty': 'AxSecurityDuty',
+      'security-role': 'AxSecurityRole',
     };
 
     const objectFolder = objectFolderMap[args.objectType];

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -11,7 +11,15 @@ import { getConfigManager } from '../utils/configManager.js';
 
 const GenerateD365XmlArgsSchema = z.object({
   objectType: z
-    .enum(['class', 'table', 'enum', 'form', 'query', 'view', 'data-entity', 'report'])
+    .enum([
+      'class', 'table', 'enum', 'form', 'query', 'view', 'data-entity', 'report',
+      'edt', 'edt-extension',
+      'table-extension', 'form-extension', 'data-entity-extension', 'enum-extension',
+      'menu-item-display', 'menu-item-action', 'menu-item-output',
+      'menu-item-display-extension', 'menu-item-action-extension', 'menu-item-output-extension',
+      'menu', 'menu-extension',
+      'security-privilege', 'security-duty', 'security-role',
+    ])
     .describe('Type of D365FO object'),
   objectName: z
     .string()
@@ -768,9 +776,177 @@ ${defaultParamGroupXml}
         return this.generateAxDataEntityXml(objectName, properties);
       case 'report':
         return this.generateAxReportXml(objectName, properties);
+      case 'edt':
+        return this.generateAxEdtXml(objectName, properties);
+      case 'table-extension':
+        return this.generateAxTableExtensionXml(objectName);
+      case 'form-extension':
+        return this.generateAxFormExtensionXml(objectName);
+      case 'edt-extension':
+        return this.generateAxSimpleExtensionXml('AxEdtExtension', objectName);
+      case 'enum-extension':
+        return this.generateAxSimpleExtensionXml('AxEnumExtension', objectName);
+      case 'data-entity-extension':
+        return this.generateAxSimpleExtensionXml('AxDataEntityViewExtension', objectName);
+      case 'menu-item-display':
+      case 'menu-item-action':
+      case 'menu-item-output':
+        return this.generateAxMenuItemXml(objectType, objectName, properties);
+      case 'menu-item-display-extension':
+        return this.generateAxSimpleExtensionXml('AxMenuItemDisplayExtension', objectName);
+      case 'menu-item-action-extension':
+        return this.generateAxSimpleExtensionXml('AxMenuItemActionExtension', objectName);
+      case 'menu-item-output-extension':
+        return this.generateAxSimpleExtensionXml('AxMenuItemOutputExtension', objectName);
+      case 'menu':
+        return this.generateAxMenuXml(objectName, properties);
+      case 'menu-extension':
+        return this.generateAxMenuExtensionXml(objectName);
+      case 'security-privilege':
+        return this.generateAxSecurityPrivilegeXml(objectName, properties);
+      case 'security-duty':
+        return this.generateAxSecurityDutyXml(objectName, properties);
+      case 'security-role':
+        return this.generateAxSecurityRoleXml(objectName, properties);
       default:
         throw new Error(`Unsupported object type: ${objectType}`);
     }
+  }
+
+  static generateAxEdtXml(name: string, properties?: Record<string, any>): string {
+    const edtType = properties?.edtType || 'AxEdtString';
+    const label = properties?.label || '@TODO:LabelId';
+    const extends_ = properties?.extends ? `\n\t<Extends>${properties.extends}</Extends>` : '';
+    const stringSize = edtType === 'AxEdtString'
+      ? `\n\t<StringSize>${properties?.stringSize ?? 30}</StringSize>` : '';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns=""
+\ti:type="${edtType}">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>${extends_}
+\t<ArrayElements />
+\t<Relations />
+\t<TableReferences />${stringSize}
+</AxEdt>`;
+  }
+
+  static generateAxSimpleExtensionXml(rootElement: string, name: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<${rootElement} xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<PropertyModifications />
+</${rootElement}>`;
+  }
+
+  static generateAxTableExtensionXml(name: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxTableExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<FieldGroupExtensions />
+\t<FieldGroups />
+\t<FieldModifications />
+\t<Fields />
+\t<FullTextIndexes />
+\t<Indexes />
+\t<Mappings />
+\t<PropertyModifications />
+\t<RelationExtensions />
+\t<RelationModifications />
+\t<Relations />
+</AxTableExtension>`;
+  }
+
+  static generateAxFormExtensionXml(name: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>${name}</Name>
+\t<ControlModifications />
+\t<Controls />
+\t<DataSourceModifications />
+\t<DataSourceReferences />
+\t<DataSources />
+\t<Parts />
+\t<PropertyModifications />
+</AxFormExtension>`;
+  }
+
+  static generateAxMenuItemXml(
+    itemType: string,
+    name: string,
+    properties?: Record<string, any>
+  ): string {
+    const elemName = itemType === 'menu-item-action' ? 'AxMenuItemAction'
+      : itemType === 'menu-item-output' ? 'AxMenuItemOutput'
+      : 'AxMenuItemDisplay';
+    const objType = itemType === 'menu-item-action' ? 'Class'
+      : itemType === 'menu-item-output' ? 'Report'
+      : 'Form';
+    const targetObject = properties?.targetObject || properties?.object || name;
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<${elemName} xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<Object>${targetObject}</Object>
+\t<ObjectType>${objType}</ObjectType>
+</${elemName}>`;
+  }
+
+  static generateAxMenuXml(name: string, properties?: Record<string, any>): string {
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxMenu xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<Elements />
+</AxMenu>`;
+  }
+
+  static generateAxMenuExtensionXml(name: string): string {
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxMenuExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+\t<Name>${name}</Name>
+\t<Customizations />
+\t<Elements />
+\t<MenuElementModifications />
+\t<PropertyModifications />
+</AxMenuExtension>`;
+  }
+
+  static generateAxSecurityPrivilegeXml(name: string, properties?: Record<string, any>): string {
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<DataEntityPermissions />
+\t<DirectAccessPermissions />
+\t<EntryPoints />
+\t<FormControlOverrides />
+</AxSecurityPrivilege>`;
+  }
+
+  static generateAxSecurityDutyXml(name: string, properties?: Record<string, any>): string {
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<Privileges />
+</AxSecurityDuty>`;
+  }
+
+  static generateAxSecurityRoleXml(name: string, properties?: Record<string, any>): string {
+    const label = properties?.label || '@TODO:LabelId';
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${label}</Label>
+\t<DirectAccessPermissions />
+\t<Duties />
+\t<Privileges />
+\t<SubRoles />
+</AxSecurityRole>`;
   }
 }
 
@@ -810,6 +986,23 @@ export async function handleGenerateD365Xml(
       view: 'AxView',
       'data-entity': 'AxDataEntityView',
       report: 'AxReport',
+      edt: 'AxEdt',
+      'edt-extension': 'AxEdtExtension',
+      'table-extension': 'AxTableExtension',
+      'form-extension': 'AxFormExtension',
+      'data-entity-extension': 'AxDataEntityViewExtension',
+      'enum-extension': 'AxEnumExtension',
+      'menu-item-display': 'AxMenuItemDisplay',
+      'menu-item-action': 'AxMenuItemAction',
+      'menu-item-output': 'AxMenuItemOutput',
+      'menu-item-display-extension': 'AxMenuItemDisplayExtension',
+      'menu-item-action-extension': 'AxMenuItemActionExtension',
+      'menu-item-output-extension': 'AxMenuItemOutputExtension',
+      menu: 'AxMenu',
+      'menu-extension': 'AxMenuExtension',
+      'security-privilege': 'AxSecurityPrivilege',
+      'security-duty': 'AxSecurityDuty',
+      'security-role': 'AxSecurityRole',
     };
 
     const objectFolder = objectFolderMap[args.objectType];

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -14,7 +14,15 @@ import { getConfigManager } from '../utils/configManager.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 
 const ModifyD365FileArgsSchema = z.object({
-  objectType: z.enum(['class', 'table', 'form', 'enum', 'query', 'view', 'edt', 'data-entity', 'report', 'table-extension', 'class-extension', 'form-extension', 'enum-extension']).describe('Type of D365FO object'),
+  objectType: z.enum([
+    'class', 'table', 'form', 'enum', 'query', 'view', 'edt', 'data-entity', 'report',
+    'table-extension', 'class-extension', 'form-extension', 'enum-extension', 'edt-extension',
+    'data-entity-extension',
+    'menu-item-display', 'menu-item-action', 'menu-item-output',
+    'menu-item-display-extension', 'menu-item-action-extension', 'menu-item-output-extension',
+    'menu', 'menu-extension',
+    'security-privilege', 'security-duty', 'security-role',
+  ]).describe('Type of D365FO object'),
   objectName: z.string().describe('Name of the object to modify'),
   operation: z.enum(['add-method', 'add-field', 'modify-field', 'rename-field', 'replace-all-fields', 'modify-property', 'remove-method', 'remove-field']).describe('Operation to perform'),
   
@@ -282,9 +290,22 @@ export async function findD365FileOnDisk(
     'data-entity': 'AxDataEntityView',
     report: 'AxReport',
     'table-extension': 'AxTableExtension',
-    'class-extension': 'AxClassExtension',
+    'class-extension': 'AxClass',
     'form-extension': 'AxFormExtension',
     'enum-extension': 'AxEnumExtension',
+    'edt-extension': 'AxEdtExtension',
+    'data-entity-extension': 'AxDataEntityViewExtension',
+    'menu-item-display': 'AxMenuItemDisplay',
+    'menu-item-action': 'AxMenuItemAction',
+    'menu-item-output': 'AxMenuItemOutput',
+    'menu-item-display-extension': 'AxMenuItemDisplayExtension',
+    'menu-item-action-extension': 'AxMenuItemActionExtension',
+    'menu-item-output-extension': 'AxMenuItemOutputExtension',
+    menu: 'AxMenu',
+    'menu-extension': 'AxMenuExtension',
+    'security-privilege': 'AxSecurityPrivilege',
+    'security-duty': 'AxSecurityDuty',
+    'security-role': 'AxSecurityRole',
   };
 
   const objectFolder = folderMap[objectType];


### PR DESCRIPTION
Extends create_d365fo_file, generate_d365fo_xml and modify_d365fo_file with full AOT folder mapping for all common D365FO object types.

New types added:
  edt, edt-extension             → AxEdt / AxEdtExtension
  table-extension                → AxTableExtension
  form-extension                 → AxFormExtension
  data-entity-extension          → AxDataEntityViewExtension
  enum-extension                 → AxEnumExtension
  menu, menu-extension           → AxMenu / AxMenuExtension
  menu-item-*-extension          → AxMenuItemDisplay/Action/OutputExtension
  security-privilege/duty/role   → AxSecurityPrivilege/Duty/Role

Also fixes modifyD365File: class-extension now correctly maps to AxClass (CoC extensions are AxClass files, not a separate AxClassExtension folder).