### PR TITLE
fix: strip &#xD; CR entities from CDATA blocks in modifyD365File

### DIFF
--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -39,7 +39,9 @@ export function rewrapXmlTagAsCdata(tag: string, xml: string): string {
         .replace(/&gt;/g, '>')
         .replace(/&amp;/g, '&')
         .replace(/&apos;/g, "'")
-        .replace(/&quot;/g, '"');
+        .replace(/&quot;/g, '"')
+        // xml2js Builder escapes \r as &#xD; — strip it to normalise to LF-only line endings
+        .replace(/&#xD;/g, '');
       // Normalise: strip leading/trailing newlines
       const content = decoded.replace(/^\n+/, '').replace(/\n+$/, '');
       // D365FO convention: <![CDATA[\n...content...\n\n]]>


### PR DESCRIPTION
xml2js Builder escapes \r (carriage return) as &#xD; during XML serialization. rewrapXmlTagAsCdata() decoded standard XML entities but missed &#xD;, causing it to appear as literal text inside <Declaration> and <Source> CDATA blocks.

Fix: add .replace(/&#xD;/g, '') to normalize line endings to LF.