### PR TITLE
fix: correct extension class prefix naming and remove internal brand …

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,7 +106,7 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 8. **ALWAYS** pass `methods=["find","exist"]` to `generate_smart_table()` when user requests those methods — never add them via `modify_d365fo_file` afterwards
 9. **NEVER** include model prefix in `name` param of `generate_smart_table`/`generate_smart_form` — prefix is applied automatically (causes double-prefix)
 10. **NEVER** use `get_enum_info()` for EDTs — use `get_edt_info()` instead
-11. **NEVER** infer the target model from search results or object names — the `model` field in search/get_table_info results is the SOURCE model of that existing object, NOT where you should create new objects. The target model for ALL create/modify operations is ALWAYS from `.mcp.json` (projectPath/modelName). Example of WRONG reasoning: task involves a report → search returns objects from "AslReports" → ❌ DO NOT use "AslReports". Use the configured model.
+11. **NEVER** infer the target model from search results or object names — the `model` field in search/get_table_info results is the SOURCE model of that existing object, NOT where you should create new objects. The target model for ALL create/modify operations is ALWAYS from `.mcp.json` (projectPath/modelName). Example of WRONG reasoning: task involves a report → search returns objects from "ContosoReports" → ❌ DO NOT use "ContosoReports". Use the configured model.
 12. **NEVER** create AxReport XML with `create_file` or PowerShell — ALWAYS use `create_d365fo_file(objectType="report", xmlContent=<full XML>, addToProject=true)`. SSRS reports require UTF-8 BOM and correct AOT path which only `create_d365fo_file` guarantees.
 13. **ALWAYS** put class member variable declarations **inside** the class `{ }` body in `sourceCode` — they become `<Declaration>` in the AxClass XML. Variables placed **outside** the `{}` are NOT part of the declaration and will be lost.
 14. **NEVER** use `today()` — it is deprecated (BPUpgradeCodeToday). Use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())` instead, everywhere: default parameter values, date comparisons, queries.
@@ -167,9 +167,9 @@ public void myMethod() { ... }
 
 ### ⚠️ NEVER bypass create_d365fo_file to "work around" prefix handling
 
-The `create_d365fo_file` tool derives the object name prefix from the `modelName` parameter — it is NOT hardcoded to any value (not "Asl", not anything else). If modelName is "MyModel", the prefix is "MyModel".
-- Pass the base name WITHOUT prefix: `objectName="InventoryByZones"`, `modelName="MyModel"` → tool creates `MyModelInventoryByZones`
-- Double-prefix is prevented automatically: `objectName="MyModelInventoryByZones"` + `modelName="MyModel"` → tool detects prefix already present → uses name as-is
+The `create_d365fo_file` tool derives the object name prefix from the `modelName` parameter — it is NOT hardcoded to any value (not "Contoso", not anything else). If modelName is "ContosoExt", the prefix is "ContosoExt".
+- Pass the base name WITHOUT prefix: `objectName="InventoryByZones"`, `modelName="ContosoExt"` → tool creates `ContosoExtInventoryByZones`
+- Double-prefix is prevented automatically: `objectName="ContosoExtInventoryByZones"` + `modelName="ContosoExt"` → tool detects prefix already present → uses name as-is
 - ❌ NEVER write XML files directly with `create_file` or PowerShell because you think the prefix logic is wrong
 - ❌ NEVER edit .rnrproj manually — `create_d365fo_file` with `addToProject=true` handles it
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -283,7 +283,7 @@ with `search(query, type: 'report')`.
 **Examples:**
 ```
 Show me the dataset fields of the InventValue report
-What does the AslInventByZone report look like — datasets and design?
+What does the ContosoInventByZone report look like — datasets and design?
 Find reports related to fixed assets
 ```
 
@@ -382,7 +382,7 @@ from descriptor XML files. In traditional environments, it defaults to the model
 Create a class MyHelper and add it to my project
 Create a table extension for InventTable in my model
 Create a class in the CustomExtensions package, Contoso Utilities model
-Create the SSRS report XML for AslMyReport in my model
+Create the SSRS report XML for ContosoMyReport in my model
 ```
 
 ---
@@ -708,9 +708,9 @@ Verifies that D365FO objects exist on disk at the correct AOT path and are refer
 ```json
 {
   "objects": [
-    { "objectType": "table",            "objectName": "AslInventByZoneTmp" },
-    { "objectType": "report",           "objectName": "AslInventByZone" },
-    { "objectType": "menu-item-action", "objectName": "AslInventByZone" }
+    { "objectType": "table",            "objectName": "ContosoInventByZoneTmp" },
+    { "objectType": "report",           "objectName": "ContosoInventByZone" },
+    { "objectType": "menu-item-action", "objectName": "ContosoInventByZone" }
   ],
   "projectPath": "K:\\AosService\\PackagesLocalDirectory\\fm-mcp\\fm-mcp\\fm-mcp.rnrproj"
 }
@@ -722,9 +722,9 @@ Verifies that D365FO objects exist on disk at the correct AOT path and are refer
 
 | Object | Type | Disk | Project |
 |--------|------|------|---------|
-| AslInventByZoneTmp | table | ✅ `K:\...\AxTable\AslInventByZoneTmp.xml` | ✅ |
-| AslInventByZone | report | ✅ ... | ✅ |
-| AslInventByZone | menu-item-action | ❌ Missing — expected: `K:\...\AxMenuItemAction\AslInventByZone.xml` | ✅ |
+| ContosoInventByZoneTmp | table | ✅ `K:\...\AxTable\ContosoInventByZoneTmp.xml` | ✅ |
+| ContosoInventByZone | report | ✅ ... | ✅ |
+| ContosoInventByZone | menu-item-action | ❌ Missing — expected: `K:\...\AxMenuItemAction\ContosoInventByZone.xml` | ✅ |
 
 ### Summary
 - Checked: 3   On disk ✅: 2   Missing from disk ❌: 1

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -26,8 +26,9 @@ after the base call completes, and create the file in my project.
 2. `analyze_extension_points` — shows CoC-eligible methods, `final` blocks, and delegate hooks on `SalesFormLetter`
 3. `get_method_signature` — returns the exact return type and parameters to match
 4. `generate_code` with `pattern: coc-extension` — produces the complete extension class
-5. `create_d365fo_file` — writes the XML to `MyPackage\MyModel\AxClass\` and adds it to the `.rnrproj`
-6. `verify_d365fo_project` — confirms the file is on disk and in the project
+5. `validate_object_naming` — confirms the generated class name (e.g. `SalesFormLetterContoso_Extension`) follows D365FO naming conventions and has no collision in the symbol index
+6. `create_d365fo_file` — writes the XML to the model's `AxClass\` folder and adds it to the `.rnrproj`
+7. `verify_d365fo_project` — confirms the file is on disk and in the project
 
 **Why this matters:** Calling `find_coc_extensions` first prevents creating a duplicate wrapper
 that would shadow an existing ISV extension and cause a build conflict.
@@ -36,7 +37,7 @@ that would shadow an existing ISV extension and cause a build conflict.
 
 ## Scenario 2 — Design and Build a Complete SysOperation Batch Job
 
-**Goal:** Create a full batch job from scratch, following the exact patterns already used in the codebase.
+**Goal:** Create a full batch job from scratch, following the exact patterns already used in the codebase — including correct labels and EDT types.
 
 **Prompt:**
 ```
@@ -44,23 +45,28 @@ I need to create a SysOperation batch job that recalculates vendor payment terms
 for all active vendors. The job should:
 - Run nightly as a recurring batch
 - Report progress and write errors to the infolog
-- Follow the same patterns as existing batch jobs in my MyPackage model
+- Use labelled parameters in the DataContract dialog
+- Follow the same patterns as existing batch jobs in the codebase
 
-Analyse the existing patterns first, then generate the DataContract,
-Controller, and Service classes, and create all three files in my project.
+Analyse the existing patterns first, look up the right EDT types for the
+parameters, resolve labels, then generate the DataContract, Controller,
+and Service classes, and create all three files in my project.
 ```
 
 **Tools Copilot chains:**
-1. `search` — finds existing batch jobs in `MyPackage` to analyse patterns
-2. `get_class_info` — reads the DataContract, Controller, and Service signatures of a representative existing job
-3. `batch_search` — fetches `SysOperationServiceController`, `SysOperationDataContractBase`, and `LedgerParameters` in parallel
-4. `generate_code` with `pattern: sysoperation` — generates all three classes following the discovered patterns
-5. `create_d365fo_file` × 3 — writes each class file and registers it in the project
-6. `verify_d365fo_project` — confirms all three objects are correctly placed
+1. `analyze_code_patterns` — finds existing SysOperation batch jobs in the codebase and extracts the common structure (DataContract, Controller, Service pattern)
+2. `get_method_signature` + `batch_search` — retrieves signatures of `SysOperationServiceController`, `SysOperationDataContractBase`, and `BatchHeader` in parallel
+3. `search_labels` + `get_label_info` — checks whether labels for dialog captions (e.g. "Vendor", "Payment terms") already exist in the model's label file
+4. `get_class_info` — reads the full class definition of a representative existing batch job to confirm the exact method signatures and attribute usage
+5. `generate_code` with `pattern: sysoperation` — produces all three classes (DataContract, Controller, Service) following the discovered patterns
+6. `create_label` — creates any missing labels for the DataContract parameter captions in all supported languages
+7. `get_edt_info` — looks up the correct base EDT for each DataContract parameter (e.g. `VendAccount`, `PaymTermId`) to ensure proper validation and lookup behaviour
+8. `create_d365fo_file` × 3 — writes the DataContract, Controller, and Service XML files and registers each in the project
+9. `verify_d365fo_project` — confirms all three objects are on disk and correctly included in the `.rnrproj`
 
-**Why this matters:** Analysing real patterns before generating ensures the new job uses
-the same error-handling, progress-reporting, and ttsbegin/ttscommit structure
-as everything else in the codebase — not a generic template.
+**Why this matters:** Fetching EDT types before generating ensures each DataContract
+parameter has the correct base type, so the dialog renders the right lookup and
+the compiler validates assignments — not just a plain `str` or `int`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
       "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -132,7 +131,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
       "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -2376,7 +2374,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2784,7 +2781,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3519,7 +3515,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4250,7 +4245,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4351,7 +4345,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4427,7 +4420,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -4580,7 +4572,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -92,10 +92,10 @@ Use this guide to select the correct tool:
 - **DO NOT ask user** \u2014 and **DO NOT** use Get-ChildItem, dir, ls, find or any shell command to search for project files. The MCP server resolves paths automatically from .mcp.json.
 
 **⚠️ CRITICAL \u2014 Never infer the target model from search results or object names:**
-- The symbol database contains objects from ALL models (Microsoft + ISV + custom). Search results will include objects from models like AslReports, AslCore, ApplicationSuite, etc.
+- The symbol database contains objects from ALL models (Microsoft + ISV + custom). Search results will include objects from models like ContosoReports, ContosoCore, ApplicationSuite, etc.
 - The model name returned in search/get_table_info/get_class_info results is the SOURCE model of that object \u2014 it is NOT the model where you should create new objects.
 - The target model for ALL file creation (create_d365fo_file, create_label, modify_d365fo_file) is ALWAYS the one from .mcp.json (modelName/projectPath), regardless of what the task is about or what model names appear in search results.
-- Example of WRONG reasoning: task involves a report → search returns objects from "AslReports" → ❌ DO NOT use "AslReports" as the model. Use the configured model from .mcp.json.
+- Example of WRONG reasoning: task involves a report → search returns objects from "ContosoReports" → ❌ DO NOT use "ContosoReports" as the model. Use the configured model from .mcp.json.
 
 ### 2. Method Signatures
 **Before creating Chain of Command extensions:**

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -374,7 +374,7 @@ EXAMPLES:
                 description: 'Code pattern to generate.',
               },
               name: { type: 'string', description: 'Name for the generated element. For extensions: base element name.' },
-              modelName: { type: 'string', description: 'Model/solution prefix (auto-detected from EXTENSION_PREFIX env var if omitted).' },
+              modelName: { type: 'string', description: 'Actual model name from .mcp.json (auto-detected from EXTENSION_PREFIX env var if omitted). NEVER use generic placeholders like "MyModel".' },
               menuItemType: {
                 type: 'string',
                 enum: ['display', 'action', 'output'],
@@ -580,11 +580,11 @@ EXAMPLES:
               },
               objectName: {
                 type: 'string',
-                description: 'Base name WITHOUT model prefix (e.g., "InventoryByZones", "ProcessOrdersBatch"). The tool auto-prepends the prefix derived from modelName: modelName="MyModel" → prefix="MyModel" → final="MyModelInventoryByZones". The prefix is NOT hardcoded — it always comes from modelName. Double-prefix prevention: if you already include the prefix ("MyModelMyTable" + modelName="MyModel"), tool detects it and uses name as-is. NEVER bypass this tool to work around prefix handling.'
+                description: 'Base name WITHOUT model prefix (e.g., "InventoryByZones", "ProcessOrdersBatch"). The tool auto-prepends the prefix derived from modelName or EXTENSION_PREFIX env var. Double-prefix prevention: if you already include the prefix, the tool detects it and uses name as-is. EXTENSION_PREFIX always has priority over modelName for prefix resolution. FOR EXTENSION CLASSES (ending with "_Extension"): pass only the BASE class name + "_Extension" without ANY prefix infix — e.g. "SalesFormLetter_Extension" NOT "SalesFormLetterFmMcp_Extension". The tool injects the correct prefix infix automatically: "SalesFormLetterContoso_Extension". NEVER bypass this tool to work around prefix handling.'
               },
               modelName: {
                 type: 'string',
-                description: 'Model name from .mcp.json — this also determines the object name prefix. Pass the exact model name configured in .mcp.json (e.g., "MyModel"). DO NOT use model names from search results — those are source models of existing objects, not your target model.'
+                description: 'Actual model name from .mcp.json (e.g., "FmMcp", "WHSExt", "ContosoExt") — determines the object naming prefix. ALWAYS read this from .mcp.json or workspace context. NEVER guess or use generic placeholders like "MyModel" or "MyPackage". DO NOT use model names from search results — those are source models of existing objects, not your target model.'
               },
               packageName: {
                 type: 'string',
@@ -664,8 +664,8 @@ EXAMPLES:
 - class/form/query/view: extends, implements, label
 - table: label, tableGroup, fields[]
 - report (ALL REQUIRED for correct XML):
-    dpClassName   {string}  Data Provider class name (e.g. "AslInventByZoneDP")
-    tmpTableName  {string}  TempDB table name        (e.g. "AslInventByZoneTmp")
+    dpClassName   {string}  Data Provider class name (e.g. "ContosoInventByZoneDP")
+    tmpTableName  {string}  TempDB table name        (e.g. "ContosoInventByZoneTmp")
     datasetName   {string}  Dataset name — defaults to tmpTableName if omitted
     designName    {string}  Design name              (default: "Report")
     caption       {string}  Design caption label ref (e.g. "@MyModel:MyLabel")
@@ -1137,14 +1137,14 @@ Use WHEN:
 
 Examples:
 - get_report_info("InventValue") → datasets, fields, design structure of InventValue report
-- get_report_info("AslInventByZone") → datasets + RDL summary
-- get_report_info("AslInventByZone", includeRdl=true) → full embedded RDL XML`,
+- get_report_info("ContosoInventByZone") → datasets + RDL summary
+- get_report_info("ContosoInventByZone", includeRdl=true) → full embedded RDL XML`,
           inputSchema: {
             type: 'object',
             properties: {
               reportName: {
                 type: 'string',
-                description: 'Name of the AxReport object (e.g. "InventValue", "AslInventByZone")',
+                description: 'Name of the AxReport object (e.g. "InventValue", "ContosoInventByZone")',
               },
               modelName: {
                 type: 'string',
@@ -1193,11 +1193,11 @@ Examples:
               },
               model: {
                 type: 'string',
-                description: 'Restrict to a specific model (e.g. MyModel, ApplicationPlatform)',
+                description: 'Restrict to a specific model (e.g. ContosoExt, ApplicationPlatform)',
               },
               labelFileId: {
                 type: 'string',
-                description: 'Restrict to a specific label file ID (e.g. MyModel, SYS)',
+                description: 'Restrict to a specific label file ID (e.g. ContosoExt, SYS)',
               },
               limit: {
                 type: 'number',
@@ -1235,11 +1235,11 @@ Examples:
               },
               labelFileId: {
                 type: 'string',
-                description: 'Label file ID (e.g. MyModel, SYS)',
+                description: 'Label file ID (e.g. ContosoExt, SYS)',
               },
               model: {
                 type: 'string',
-                description: 'Model to filter by (e.g. MyModel)',
+                description: 'Model to filter by (e.g. ContosoExt)',
               },
             },
             required: [],
@@ -1272,11 +1272,11 @@ Examples:
               },
               labelFileId: {
                 type: 'string',
-                description: 'Label file ID (e.g. MyModel)',
+                description: 'Label file ID (e.g. ContosoExt)',
               },
               model: {
                 type: 'string',
-                description: 'Model name that owns the label file (e.g. MyModel)',
+                description: 'Model name that owns the label file (e.g. ContosoExt)',
               },
               packageName: {
                 type: 'string',
@@ -1343,11 +1343,11 @@ Examples:
               },
               labelFileId: {
                 type: 'string',
-                description: 'Label file ID that owns the label (e.g. MyModel, MyPackage)',
+                description: 'Label file ID that owns the label (e.g. ContosoExt, SYS)',
               },
               model: {
                 type: 'string',
-                description: 'Model name that owns the label file (e.g. MyModel)',
+                description: 'Model name that owns the label file (e.g. ContosoExt)',
               },
               packageName: {
                 type: 'string',

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -19,8 +19,9 @@ const CodeGenArgsSchema = z.object({
     'For XML patterns (security-privilege, menu-item): the name for the generated XML object.'
   ),
   modelName: z.string().optional().describe(
-    'Model/solution prefix used to derive the naming infix when EXTENSION_PREFIX is not set (e.g. "MyModel"). ' +
-    'Required for extension patterns when EXTENSION_PREFIX is not configured.'
+    'Actual model name from .mcp.json — used to derive the naming infix when EXTENSION_PREFIX env var is not set (e.g. "FmMcp", "WHSExt", "ContosoExt"). ' +
+    'Required for extension patterns when EXTENSION_PREFIX is not configured. ' +
+    'NEVER pass generic placeholders like "MyModel" — always use the real model name from .mcp.json.'
   ),
   menuItemType: z.enum(['display', 'action', 'output']).optional()
     .describe('For menu-item pattern: type of menu item (display=form, action=class, output=report)'),

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -789,7 +789,7 @@ public class ${queryName} extends QueryRun
    *   contractParams - Array of { name, dataType?, label?, defaultValue? } → contract class parameters (DataMember)
    *   rdlContent    - Full RDL XML string to embed (auto-generated from fields when omitted)
    *
-   * AOT structure generated (mirrors real D365FO reports like AslReports_CashOrder_CZ):
+   * AOT structure generated (mirrors real D365FO reports like ContosoReports_CashOrder_CZ):
    *   <AxReport xmlns="Microsoft.Dynamics.AX.Metadata.V2">
    *     <DataMethods />
    *     <DataSets>
@@ -2796,7 +2796,29 @@ export async function handleCreateD365File(
 
     // Apply extension prefix to object name
     const objectPrefix = resolveObjectPrefix(actualModelName);
-    const finalObjectName = applyObjectPrefix(args.objectName, objectPrefix);
+
+    // For extension classes (objectName ends with "_Extension"):
+    // If EXTENSION_PREFIX differs from modelName, the AI may have already embedded the
+    // modelName as infix (e.g. "SalesFormLetterFmMcp_Extension" with modelName="FmMcp").
+    // Strip the modelName infix so applyObjectPrefix can inject the correct EXTENSION_PREFIX
+    // instead of stacking both → "SalesFormLetterFmMcpContoso_Extension" (wrong).
+    let effectiveObjectName = args.objectName;
+    if (
+      args.objectName.endsWith('_Extension') &&
+      actualModelName &&
+      objectPrefix.toLowerCase() !== actualModelName.toLowerCase()
+    ) {
+      const baseName = args.objectName.slice(0, -'_Extension'.length);
+      if (baseName.toLowerCase().endsWith(actualModelName.toLowerCase())) {
+        effectiveObjectName = baseName.slice(0, -actualModelName.length) + '_Extension';
+        console.error(
+          `[create_d365fo_file] Stripped model name infix "${actualModelName}" from extension class: ` +
+          `${args.objectName} → ${effectiveObjectName}`
+        );
+      }
+    }
+
+    const finalObjectName = applyObjectPrefix(effectiveObjectName, objectPrefix);
     if (finalObjectName !== args.objectName) {
       console.error(`[create_d365fo_file] Applied prefix "${objectPrefix}": ${args.objectName} → ${finalObjectName}`);
     }

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -41,10 +41,10 @@ const CreateLabelArgsSchema = z.object({
     ),
   labelFileId: z
     .string()
-    .describe('Label file ID to add the label to (e.g. MyModel). Must exist in the model.'),
+    .describe('Label file ID to add the label to (e.g. ContosoExt). Must exist in the model.'),
   model: z
     .string()
-    .describe('Model name that owns the label file (e.g. MyModel, MyExtensions)'),
+    .describe('Model name that owns the label file (e.g. ContosoExt, ApplicationSuite)'),
   packageName: z
     .string()
     .optional()
@@ -383,11 +383,11 @@ export const createLabelToolDefinition = {
       },
       labelFileId: {
         type: 'string',
-        description: 'Label file ID that the label belongs to (e.g. MyModel)',
+        description: 'Label file ID that the label belongs to (e.g. ContosoExt)',
       },
       model: {
         type: 'string',
-        description: 'Model name (e.g. MyModel, MyExtensions)',
+        description: 'Model name (e.g. ContosoExt, ApplicationSuite)',
       },
       translations: {
         type: 'array',

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -502,7 +502,7 @@ ${titleField1Xml}${titleField2Xml}\t<DeleteActions />
    *   contractParams - Array of { name, dataType?, label?, defaultValue? } → contract class parameters (DataMember)
    *   rdlContent    - Full RDL XML string to embed (auto-generated from fields when omitted)
    *
-   * AOT structure generated (mirrors real D365FO reports like AslReports_CashOrder_CZ):
+   * AOT structure generated (mirrors real D365FO reports like ContosoReports_CashOrder_CZ):
    *   <AxReport xmlns="Microsoft.Dynamics.AX.Metadata.V2">
    *     <DataMethods />
    *     <DataSets>

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -311,7 +311,7 @@ export async function handleGenerateSmartForm(
     console.log(`[generateSmartForm] Non-Windows environment — returning XML as text (no file write)`);
     const noModelNote = resolvedModel
       ? ''
-      : `\n> ⚠️  No model resolved — XML generated without prefix. Pass \`modelName\` (e.g. \`"MyModel"\`) for correct object naming.`;
+      : `\n> ⚠️  No model resolved — XML generated without prefix. Pass \`modelName\` with the actual model name from .mcp.json (e.g. \`"FmMcp"\`) for correct object naming.`;
     const nextStep = [
       ``,
       `**✅ MANDATORY NEXT STEP — immediately call \`create_d365fo_file\` with the XML below:**`,

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -602,7 +602,7 @@ export async function handleGenerateSmartTable(
   if (isNonWindows) {
     const noModelNote = resolvedModel
       ? ''
-      : `\n> ⚠️  No model resolved — XML generated without prefix. Pass \`modelName\` (e.g. \`"MyModel"\`) for correct object naming.\n> 🚨 **IMPORTANT**: Do NOT add a prefix to the \`name\` parameter when calling this tool — the tool applies the prefix automatically from \`modelName\`. If you pass e.g. \`name="MyAccountTable"\`, the result will be double-prefixed as \`"MyMyAccountTable"\`.`;
+      : `\n> ⚠️  No model resolved — XML generated without prefix. Pass \`modelName\` with the actual model name from .mcp.json (e.g. \`"FmMcp"\`) for correct object naming.\n> 🚨 **IMPORTANT**: Do NOT add a prefix to the \`name\` parameter when calling this tool — the tool applies the prefix automatically from \`modelName\`. Passing a name that already includes the prefix will result in double-prefixing.`;
     const nextStep = [
       ``,
       `**✅ MANDATORY NEXT STEP — immediately call \`create_d365fo_file\` with the XML below:**`,

--- a/src/tools/getLabelInfo.ts
+++ b/src/tools/getLabelInfo.ts
@@ -19,8 +19,8 @@ const GetLabelInfoArgsSchema = z.object({
   labelFileId: z
     .string()
     .optional()
-    .describe('Label file ID (e.g. MyModel, SYS, ApplicationPlatform)'),
-  model: z.string().optional().describe('Model to filter by (e.g. MyModel)'),
+    .describe('Label file ID (e.g. ContosoExt, SYS, ApplicationPlatform)'),
+  model: z.string().optional().describe('Model to filter by (e.g. ContosoExt)'),
 });
 
 export async function getLabelInfoTool(request: CallToolRequest, context: XppServerContext) {
@@ -141,11 +141,11 @@ export const getLabelInfoToolDefinition = {
       },
       labelFileId: {
         type: 'string',
-        description: 'Label file ID (e.g. MyModel, SYS)',
+        description: 'Label file ID (e.g. ContosoExt, SYS)',
       },
       model: {
         type: 'string',
-        description: 'Model to filter by (e.g. MyModel)',
+        description: 'Model to filter by (e.g. ContosoExt)',
       },
     },
     required: [],

--- a/src/tools/renameLabel.ts
+++ b/src/tools/renameLabel.ts
@@ -35,10 +35,10 @@ const RenameLabelArgsSchema = z.object({
     .describe('New label ID, e.g. MyRenamedField'),
   labelFileId: z
     .string()
-    .describe('Label file ID that owns the label (e.g. MyModel, AslCore)'),
+    .describe('Label file ID that owns the label (e.g. ContosoExt, ContosoCore)'),
   model: z
     .string()
-    .describe('Model name that owns the label file (e.g. MyModel)'),
+    .describe('Model name that owns the label file (e.g. ContosoExt)'),
   packageName: z
     .string()
     .optional()

--- a/src/tools/searchLabels.ts
+++ b/src/tools/searchLabels.ts
@@ -27,11 +27,11 @@ const SearchLabelsArgsSchema = z.object({
   model: z
     .string()
     .optional()
-    .describe('Restrict results to a specific model (e.g. MyModel, ApplicationPlatform)'),
+    .describe('Restrict results to a specific model (e.g. ContosoExt, ApplicationPlatform)'),
   labelFileId: z
     .string()
     .optional()
-    .describe('Restrict results to a specific label file ID (e.g. MyModel, SYS)'),
+    .describe('Restrict results to a specific label file ID (e.g. ContosoExt, SYS)'),
   limit: z.number().optional().default(30).describe('Maximum number of results (default 30)'),
 });
 
@@ -124,11 +124,11 @@ export const searchLabelsToolDefinition = {
       },
       model: {
         type: 'string',
-        description: 'Restrict to a specific model (e.g. MyModel)',
+        description: 'Restrict to a specific model (e.g. ContosoExt)',
       },
       labelFileId: {
         type: 'string',
-        description: 'Restrict to a specific label file ID (e.g. MyModel, SYS)',
+        description: 'Restrict to a specific label file ID (e.g. ContosoExt, SYS)',
       },
       limit: {
         type: 'number',

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -56,19 +56,29 @@ export function getExtensionPrefix(): string {
  * Microsoft naming guidelines (https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/naming-guidelines-extensions):
  *  - New model elements  → prefix concatenated directly: {Prefix}{ObjectName}  (e.g. WHSMyTable)
  *  - Extension elements  → {BaseElement}.{Prefix}Extension                     (e.g. HCMWorker.WHSExtension)
- *  - Extension classes   → {BaseElement}{Prefix}_Extension                     (e.g. ContactPersonWHS_Extension)
+ *  - Extension classes   → {BaseElement}{Prefix}_Extension                     (e.g. SalesFormLetterContoso_Extension)
  *  - Fields in extensions→ {Prefix}{FieldName}                                 (e.g. WHSApprovingWorker)
  *
- * Priority:
+ * Priority (EXTENSION_PREFIX has higher priority than modelName):
  * 1. EXTENSION_PREFIX env var (trailing '_' stripped — the underscore is NOT part of the prefix)
- * 2. modelName as fallback
+ * 2. modelName as fallback (only if EXTENSION_PREFIX is not set)
  *
  * Returns empty string when both are empty.
  */
 export function resolveObjectPrefix(modelName: string): string {
   const envPrefix = process.env.EXTENSION_PREFIX?.trim();
-  const raw = (envPrefix || modelName).replace(/_+$/, ''); // strip trailing underscores
-  return raw;
+  
+  // EXTENSION_PREFIX has absolute priority — even if modelName is provided
+  if (envPrefix) {
+    return envPrefix.replace(/_+$/, ''); // strip trailing underscores
+  }
+  
+  // Fallback to modelName only if EXTENSION_PREFIX is not set
+  if (modelName) {
+    return modelName.replace(/_+$/, '');
+  }
+  
+  return '';
 }
 
 /**
@@ -76,13 +86,48 @@ export function resolveObjectPrefix(modelName: string): string {
  * Per MS guidelines, the prefix is concatenated directly (no separator):
  *   WHSMyTable, MyPrefixMyClass, ContosoMyForm
  *
+ * SPECIAL CASE: For extension classes ending with "_Extension",
+ * the prefix goes BEFORE "_Extension" as a suffix:
+ *   SalesFormLetterContoso_Extension (not ContosoSalesFormLetter_Extension)
+ *
+ * CRITICAL for extension classes: If EXTENSION_PREFIX is set in .env,
+ * it should be used EXCLUSIVELY - never combined with modelName prefix.
+ * The function receives the ALREADY RESOLVED prefix (from resolveObjectPrefix),
+ * so it strips any existing suffix-prefix and replaces it with the current one.
+ *
  * Case-insensitive check prevents double-prefixing.
  */
 export function applyObjectPrefix(objectName: string, prefix: string): string {
   if (!prefix) return objectName;
-  // Capitalize first letter of prefix (e.g. "whs" → "Whs", "WHS" stays "WHS")
+  
+  // Capitalize first letter of prefix (e.g. "whs" → "Whs", "WHS" stays "WHS", "contoso" → "Contoso")
   const normalizedPrefix = prefix.charAt(0).toUpperCase() + prefix.slice(1);
-  if (objectName.toLowerCase().startsWith(normalizedPrefix.toLowerCase())) return objectName;
+  
+  // SPECIAL CASE: Extension classes — prefix goes as SUFFIX before "_Extension"
+  // Example: SalesFormLetter + Contoso → SalesFormLetterContoso_Extension
+  //
+  // IMPORTANT: objectName MUST be the BASE class name + "_Extension" WITHOUT any prefix infix.
+  // E.g. "SalesFormLetter_Extension", NOT "SalesFormLetterFmMcp_Extension".
+  // Callers (e.g. createD365File) are responsible for stripping any stale model-name infix
+  // before calling this function when EXTENSION_PREFIX differs from modelName.
+  if (objectName.endsWith('_Extension')) {
+    const baseName = objectName.slice(0, -'_Extension'.length);
+    
+    // Check if the target prefix is already present at the end (case-insensitive)
+    if (baseName.toLowerCase().endsWith(normalizedPrefix.toLowerCase())) {
+      return objectName; // Already has the correct prefix, return as-is
+    }
+    
+    // Inject the correct prefix before "_Extension"
+    return `${baseName}${normalizedPrefix}_Extension`;
+  }
+  
+  // NORMAL CASE: Regular objects — prefix at the START
+  // Check if already prefixed (case-insensitive)
+  if (objectName.toLowerCase().startsWith(normalizedPrefix.toLowerCase())) {
+    return objectName;
+  }
+  
   // Capitalize first letter of objectName part so result is PascalCase
   const normalizedName = objectName.charAt(0).toUpperCase() + objectName.slice(1);
   return `${normalizedPrefix}${normalizedName}`;


### PR DESCRIPTION
This pull request updates all documentation, instructions, and code comments to consistently use "Contoso" and "ContosoExt" as the model name and prefix examples, replacing previous generic or placeholder names like "Asl", "MyModel", and "MyPackage". It also clarifies the correct usage of model names and prefixes in code generation tools, ensuring that only the actual model name from `.mcp.json` is used for file creation and naming, and never inferred from search results or object names. These changes improve clarity and prevent confusion for developers using MCP tools.

**Model naming and prefix handling improvements:**

* All documentation and instructions now use "Contoso" and "ContosoExt" as the canonical model name and prefix examples, replacing "Asl", "MyModel", and "MyPackage" throughout (`.github/copilot-instructions.md`, `docs/MCP_TOOLS.md`, `src/prompts/systemInstructions.ts`, `src/server/mcpServer.ts`, `src/tools/codeGen.ts`, `src/tools/createD365File.ts`). [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L109-R109) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L170-R172) [[3]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L286-R286) [[4]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L385-R385) [[5]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L711-R713) [[6]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L725-R727) [[7]](diffhunk://#diff-387d5c2d72b4e3605e85cd319fbd67da69445b6838b3c1ffed5a2488824f6c64L95-R98) [[8]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L377-R377) [[9]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L583-R587) [[10]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L667-R668) [[11]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1140-R1147) [[12]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1196-R1200) [[13]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1238-R1242) [[14]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1275-R1279) [[15]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1346-R1350) [[16]](diffhunk://#diff-1ec3a3763a74dd20695979559c5d6542ae541285b1430df57aa7a6acaba99404L22-R24) [[17]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL792-R792)
* Clarified that the model name for file creation and naming must always come from `.mcp.json` or workspace context, and never from search results or object names. Generic placeholders like "MyModel" are explicitly discouraged and replaced with real model names in examples. [[1]](diffhunk://#diff-387d5c2d72b4e3605e85cd319fbd67da69445b6838b3c1ffed5a2488824f6c64L95-R98) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L377-R377) [[3]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L583-R587) [[4]](diffhunk://#diff-1ec3a3763a74dd20695979559c5d6542ae541285b1430df57aa7a6acaba99404L22-R24)
* Updated code generation tool descriptions to explain that the prefix is derived from the actual model name or the `EXTENSION_PREFIX` environment variable, and that double-prefix prevention logic is handled automatically. Special instructions are given for extension class naming. [[1]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L583-R587) [[2]](diffhunk://#diff-1ec3a3763a74dd20695979559c5d6542ae541285b1430df57aa7a6acaba99404L22-R24)
* All sample object names, report names, and label file IDs in documentation and code comments now use "Contoso" and "ContosoExt" for consistency and clarity. [[1]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L286-R286) [[2]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L385-R385) [[3]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L711-R713) [[4]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L725-R727) [[5]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L667-R668) [[6]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1140-R1147) [[7]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1196-R1200) [[8]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1238-R1242) [[9]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1275-R1279) [[10]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1346-R1350) [[11]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL792-R792)
* Improved scenario and usage examples in documentation to reinforce correct model name and prefix handling, and to clarify the importance of analyzing the codebase for naming conventions and object creation. [[1]](diffhunk://#diff-7c912a00313e262356400d83024c714e162d759b92e2604f5fa88cf231302547L29-R31) [[2]](diffhunk://#diff-7c912a00313e262356400d83024c714e162d759b92e2604f5fa88cf231302547L39-R69)