### PR TITLE
docs: unify MCP server name to d365fo-mcp-tools across all documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ This workspace contains D365FO code. **Always use the specialized MCP tools** �
 >
 > **Case 1 — tool call FAILS (MCP server not connected):**
 > - STOP immediately. Tell the user:
->   > ⚠️ **MCP server is not connected.** The d365fo-mcp-server must be running for safe D365FO development.
+>   > ⚠️ **MCP server is not connected.** The d365fo-mcp-tools must be running for safe D365FO development.
 >   > Without it I cannot read the symbol database, detect the correct model name, or safely create/modify files.
 >   >
 >   > Options:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npm run dev                      # Server at http://localhost:3000
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "http://localhost:3000/mcp/"
     },
     "context": {
@@ -88,7 +88,12 @@ Copy-Item -Path ".github" -Destination "C:\Path\To\YourSolution\" -Recurse
 
 ---
 
-## What Copilot can do — 41 X++ tools
+## What Copilot can do — 42 X++ tools
+
+### Workspace & Diagnostics
+| Ask Copilot | Tool used |
+|-------------|-----------|
+| `Is the MCP server connected and which model am I working in?` | `get_workspace_info` |
 
 ### Search & Discovery
 | Ask Copilot | Tool used |
@@ -170,7 +175,7 @@ Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.m
 |------|---------|
 | [docs/SETUP.md](docs/SETUP.md) | Installation, configuration, Azure deployment |
 | [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md) | `.mcp.json` reference — workspace paths, UDE, project settings |
-| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 41 tools with parameters and example prompts |
+| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 42 tools with parameters and example prompts |
 | [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md) | Practical examples: search, CoC, SysOperation, security |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Technical architecture, dual-database design |
 | [docs/CUSTOM_EXTENSIONS.md](docs/CUSTOM_EXTENSIONS.md) | ISV / custom model configuration |

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -12,7 +12,7 @@ Place this file in the root of your Visual Studio solution (next to the `.sln` f
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "https://your-server.azurewebsites.net/mcp/"
     },
     "context": {
@@ -43,13 +43,12 @@ The server will also:
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "https://your-server.azurewebsites.net/mcp/"
     },
     "context": {
       "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName",
-      "projectPath": "K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj",
-      "solutionPath": "K:\\VSProjects\\MySolution"
+      "projectPath": "K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj"
     }
   }
 }
@@ -63,7 +62,7 @@ roots — one for your custom code and one for Microsoft standard packages:
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "https://your-server.azurewebsites.net/mcp/"
     },
     "context": {
@@ -190,8 +189,7 @@ GitHub Copilot connects to both servers at the same time and selects the right o
       "command": "node",
       "args": ["K:\\d365fo-mcp-server\\dist\\index.js", "--stdio"],
       "env": {
-        "MCP_SERVER_MODE": "write-only",
-        "DB_PATH": "K:\\d365fo-mcp-server\\data\\xpp-metadata.db"
+        "MCP_SERVER_MODE": "write-only"
       }
     },
     "context": {

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -90,7 +90,7 @@ No local server, no local database.
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "https://your-server.azurewebsites.net/mcp/"
     },
     "context": {
@@ -224,7 +224,7 @@ The server runs at `http://localhost:8080`. Verify with `http://localhost:8080/h
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "http://localhost:8080/mcp/"
     },
     "context": {
@@ -256,7 +256,7 @@ automatically. In most cases you do not need to set any paths manually.
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "https://your-server.azurewebsites.net/mcp/"
     },
     "context": {
@@ -272,7 +272,7 @@ automatically. In most cases you do not need to set any paths manually.
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "https://your-server.azurewebsites.net/mcp/"
     },
     "context": {

--- a/docs/WORKSPACE_DETECTION.md
+++ b/docs/WORKSPACE_DETECTION.md
@@ -57,7 +57,7 @@ Minimal override example:
 ```json
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "http://localhost:8080/mcp/"
     },
     "context": {


### PR DESCRIPTION
Replaces inconsistent server names (d365fo-code-intelligence, d365fo-mcp-server) with the canonical d365fo-mcp-tools name in all .mcp.json config examples. Also adds get_workspace_info as the 42nd tool to README.