### PR TITLE
feat: enhance documentation and configuration for Copilot integration…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -97,7 +97,7 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 | Request | MCP Tools |
 |---------|-----------|
 | Fix bug / review | `get_class_info` → `suggest_method_implementation` → `find_references` |
-| Refactor / improve | `get_class_info` → `analyze_class_completeness` → `analyze_code_patterns` |
+| Refactor / improve | See **Refactoring Workflow** section below |
 | Find best practice | `analyze_code_patterns` → `get_api_usage_patterns` |
 | Optimize query | `get_table_info` → `analyze_code_patterns` |
 | Where is X used? | `find_references(targetName)` |
@@ -210,6 +210,47 @@ The `create_d365fo_file` tool derives the object name prefix from the `modelName
 - Double-prefix is prevented automatically: `objectName="ContosoExtInventoryByZones"` + `modelName="ContosoExt"` → tool detects prefix already present → uses name as-is
 - ❌ NEVER write XML files directly with `create_file` or PowerShell because you think the prefix logic is wrong
 - ❌ NEVER edit .rnrproj manually — `create_d365fo_file` with `addToProject=true` handles it
+
+---
+
+## Refactoring Workflow
+
+When the user asks to **refactor**, **improve**, **clean up**, **optimize**, or **review** an existing class or method — NEVER use `read_file`, `get_file`, `code_search`, or `edit_file`. Use only MCP tools.
+
+```
+1. Read class structure:   get_class_info("ClassName")
+                           → returns all method signatures, inheritance, model
+                           → compact=true (default) — signatures only, fast
+                           → compact=false — only if you need to read bodies
+
+2. Find completeness gaps: analyze_class_completeness("ClassName")
+                           → reports missing standard methods (find, exist, etc.)
+                           → flags methods that should be static, etc.
+
+3. Find real patterns:     analyze_code_patterns("scenario")
+                           → e.g. "validation", "query pattern", "error handling"
+                           → shows how standard D365FO code solves the same problem
+
+4. Read specific bodies:   get_method_signature("ClassName", "methodName")
+                           → use for EACH method you intend to change
+                           → NEVER guess the body from the signature
+
+5. Find usages:            find_references("ClassName")  or  find_references("methodName")
+                           → verify that renaming/changing a method won't break callers
+                           → call BEFORE removing or renaming anything
+
+6. Apply changes:          modify_d365fo_file(objectType="class", objectName="ClassName",
+                             operation="add-method" / "remove-method", sourceCode="...")
+                           ❌ NEVER use edit_file, apply_patch, replace_string_in_file
+```
+
+**Rules for refactoring:**
+- ALWAYS read the full class first with `get_class_info` — never assume you know the current structure
+- ALWAYS call `get_method_signature` for every method you plan to change — don't edit blindly
+- ALWAYS call `find_references` before renaming a public method — it may be called from other classes/forms
+- NEVER delete a method without checking `find_references` first
+- Labels: if you rename or add `Info()`/`warning()`/`error()` messages, use `search_labels()` + `create_label()`
+- Doc comments: every changed public/protected method MUST have a meaningful `/// <summary>`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ npm run dev                      # Server at http://localhost:3000
 **4.** Copy the Copilot instruction files so Copilot knows the D365FO workflow rules:
 
 ```powershell
-Copy-Item -Path ".github" -Destination "C:\Path\To\YourSolution\" -Recurse
+# Place .github in a parent folder shared by all your D365FO solutions, e.g.:
+Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
 ```
+
+> **Tip:** Visual Studio 2022 searches for `.github\copilot-instructions.md` upward from the solution folder, so one copy in a common parent directory covers all solutions underneath — no need to copy it into every solution separately.
 
 > **Full config options** (UDE paths, explicit projectPath, solutionPath): [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -48,17 +48,23 @@ If you are responsible for deploying the server infrastructure to Azure, see [SE
 
 ## Step 2 — Place copilot-instructions.md
 
-Copy the file `.github/copilot-instructions.md` from this repository into the root of your
-D365FO solution workspace (same folder as your `.sln` file):
+Copy the `.github` folder from this repository into a **common parent directory** that contains
+all your D365FO solutions. Visual Studio 2022 automatically searches upward from the solution
+folder, so one copy covers every solution underneath — no need to repeat it per solution.
 
 ```
-K:\VSProjects\MySolution\
-├── .mcp.json                      ← config file (created in Step 3)
+C:\source\repos\                   ← parent folder (common ancestor of all solutions)
 ├── .github\
-│   └── copilot-instructions.md   ← copy here from this repo
-├── MySolution.sln
-└── MyProject\
-    └── MyProject.rnrproj
+│   └── copilot-instructions.md   ← copy here once — applies to all solutions below
+├── MySolution1\
+│   └── MySolution1.sln
+└── MySolution2\
+    └── MySolution2.sln
+```
+
+```powershell
+# Example — adjust the destination to match your actual parent folder
+Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
 ```
 
 GitHub Copilot automatically picks up `copilot-instructions.md` and uses it to give
@@ -326,8 +332,13 @@ want to maintain per-solution files.
 - Confirm Visual Studio version is 17.14 or later
 - Confirm *Editor Preview Features* are enabled at https://github.com/settings/copilot/features
 - Confirm Copilot Chat is in **Agent Mode** (not Ask or Edit)
-- Confirm `.mcp.json` is in the solution root (same folder as the `.sln` file)
+- Confirm `.mcp.json` is in the solution root or user home directory (`%USERPROFILE%\.mcp.json`)
 - Restart Visual Studio after creating or editing `.mcp.json`
+
+### Copilot ignores MCP tools and uses built-in file search instead
+- Confirm `.github\copilot-instructions.md` exists somewhere in the directory tree above your solution
+- Visual Studio 2022 searches upward from the solution folder — place it in a common parent (e.g. `C:\source\repos\.github\`) to cover all solutions at once
+- Confirm Visual Studio version supports custom instructions (17.11 or later)
 
 ### File created in wrong D365FO model
 Use the two-level `workspacePath` format: `PackagesLocalDirectory\YourPackageName\YourModelName`.

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -273,9 +273,6 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         const packagePath = configManager.getPackagePath() ?? null;
         const projectPath = await configManager.getProjectPath() ?? null;
         const envType = await configManager.getDevEnvironmentType();
-        // getRawAutoDetectedModelName() returns what was found in .rnrproj regardless of config.
-        // autoDetectProject() was already executed above (triggered by getProjectPath()), so this is free.
-        const rawDetectedModel = await configManager.getRawAutoDetectedModelName();
 
         // Prefix diagnostics
         const extensionPrefixEnv = process.env.EXTENSION_PREFIX?.trim() || null;
@@ -307,6 +304,9 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         ];
 
         if (isPlaceholder) {
+          // Only scan .rnrproj files when model name looks like a placeholder — avoids
+          // misleading "no .rnrproj files found" warnings when config is fully set up.
+          const rawDetectedModel = await configManager.getRawAutoDetectedModelName();
           const detectedHint = rawDetectedModel
             ? `> ✅ Auto-detected from .rnrproj: **${rawDetectedModel}**\n` +
               `> Update your .mcp.json: set \`modelName\` to \`"${rawDetectedModel}"\``

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -172,21 +172,37 @@ class ConfigManager {
   }
 
   /**
-   * Find .mcp.json file in current or parent directories, then user home directory
+   * Find .mcp.json file.
    * Priority:
-   * 1. Current directory and up to 5 parent directories (project-specific config)
-   * 2. User home directory (global config)
-   * 3. Current directory (fallback)
+   * 1. MCP_CONFIG_PATH env var (explicit override)
+   * 2. User home directory — single canonical config location (~/.mcp.json)
+   * 3. Current directory and up to 5 parent directories (project-specific override, rare)
+   * 4. Current directory fallback (file may not exist yet)
    */
   private findConfigFile(): string {
-    // Step 0: Explicit override via MCP_CONFIG_PATH env var
+    // Step 1: Explicit override via MCP_CONFIG_PATH env var
     const envConfigPath = process.env.MCP_CONFIG_PATH;
     if (envConfigPath && existsSync(envConfigPath)) {
       console.error(`[ConfigManager] Using MCP_CONFIG_PATH: ${envConfigPath}`);
       return envConfigPath;
     }
 
-    // Step 1: Search in current directory and parent directories
+    // Step 2: User home directory — primary location, use os.homedir() which is reliable
+    // even when USERPROFILE / HOME env vars are not set in the server process.
+    const homeDir = os.homedir();
+    if (homeDir) {
+      const homeConfigPath = path.join(homeDir, '.mcp.json');
+      try {
+        if (existsSync(homeConfigPath)) {
+          console.error(`[ConfigManager] Using config from home directory: ${homeConfigPath}`);
+          return homeConfigPath;
+        }
+      } catch {
+        // Continue searching
+      }
+    }
+
+    // Step 3: Search in current directory and parent directories (project-specific override)
     let currentDir = process.cwd();
     const maxDepth = 5;
     let depth = 0;
@@ -195,6 +211,7 @@ class ConfigManager {
       const configPath = path.join(currentDir, '.mcp.json');
       try {
         if (existsSync(configPath)) {
+          console.error(`[ConfigManager] Using project config: ${configPath}`);
           return configPath;
         }
       } catch {
@@ -209,22 +226,7 @@ class ConfigManager {
       depth++;
     }
 
-    // Step 2: User home directory — use os.homedir() which is reliable
-    // even when USERPROFILE / HOME env vars are not set in the server process.
-    const homeDir = os.homedir();
-    if (homeDir) {
-      const homeConfigPath = path.join(homeDir, '.mcp.json');
-      try {
-        if (existsSync(homeConfigPath)) {
-          console.error(`[ConfigManager] Using global config from home directory: ${homeConfigPath}`);
-          return homeConfigPath;
-        }
-      } catch {
-        // Continue to fallback
-      }
-    }
-
-    // Step 3: Fallback to current directory (file may not exist yet)
+    // Step 4: Fallback to current directory (file may not exist yet)
     return path.join(process.cwd(), '.mcp.json');
   }
 


### PR DESCRIPTION
This pull request improves the setup and configuration experience for D365FO Copilot workflows, clarifies documentation around `.github` and `.mcp.json` placement, and updates the config file search logic to prioritize user home directory. The changes make it easier to manage Copilot instructions across multiple solutions and ensure consistent detection of configuration files.

**Documentation improvements for `.github` and `.mcp.json` placement:**

* Updated `README.md`, `docs/SETUP.md`, and `.github/copilot-instructions.md` to recommend placing the `.github` folder in a common parent directory shared by all D365FO solutions, so Visual Studio can automatically find Copilot instructions without needing multiple copies. Added clear examples and tips for setup. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R89) [[2]](diffhunk://#diff-22495e73839073b1b84e771b0b9097a8820e466365fd27b123f7fe7edeeb3047L51-R67) [[3]](diffhunk://#diff-22495e73839073b1b84e771b0b9097a8820e466365fd27b123f7fe7edeeb3047L329-R342)
* Clarified that `.mcp.json` can be placed in either the solution root or the user home directory (`%USERPROFILE%\.mcp.json`), and updated troubleshooting steps accordingly.

**Copilot workflow and refactoring guidance:**

* Added a new "Refactoring Workflow" section to `.github/copilot-instructions.md`, detailing step-by-step MCP tool usage for refactoring, improving, or reviewing classes/methods, and emphasizing not to use file-based tools for these tasks. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L100-R100) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R216-R256)

**Configuration file search logic enhancements:**

* Refactored `ConfigManager` in `src/utils/configManager.ts` to prioritize the MCP config file search order: first by `MCP_CONFIG_PATH` env var, then by user home directory, then by current/parent directories, and finally by current directory fallback. Added logging for which config file is used. [[1]](diffhunk://#diff-efab9f0a41413dc6c071355523d35ffa774870598b1fe96f0f56c3f102614c89L175-R205) [[2]](diffhunk://#diff-efab9f0a41413dc6c071355523d35ffa774870598b1fe96f0f56c3f102614c89R214) [[3]](diffhunk://#diff-efab9f0a41413dc6c071355523d35ffa774870598b1fe96f0f56c3f102614c89L212-R229)

**Tool handler logic update:**

* Changed `registerToolHandler` in `src/tools/toolHandler.ts` so `.rnrproj` files are only scanned for model name detection if the model name is a placeholder, reducing unnecessary warnings when config is already set up. [[1]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dL276-L278) [[2]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dR307-R309)