### PR TITLE
feat: auto-detect VS 2022 workspace and improve project switching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ PORT=8080
 
 # Log level: error, warn, info, debug
 LOG_LEVEL=debug
+# DEBUG_LOGGING=true
 
 # Server mode for hybrid deployments (default: full)
 # - full       → all tools (local development, single-server setup)

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -2,33 +2,51 @@
  * Example .mcp.json configuration for Visual Studio 2022 / VS Code
  * Place this file in your solution root directory or in %USERPROFILE%\.mcp.json
  *
- * Three deployment variants are shown below — uncomment the one that fits your setup:
- *   1. Single server (local only, full mode)
- *   2. Single server (Azure, read-only mode)
+ * Four deployment variants are shown below — uncomment the one that fits your setup:
+ *   1. Local stdio server (recommended for single developers, zero-config)
+ *   2. Single Azure server (read-only, team-shared metadata)
  *   3. Hybrid setup (Azure read-only + local write-only companion)
+ *   4. UDE (Unified Developer Experience / Power Platform Tools)
  *
- * workspacePath format:
+ * stdio vs HTTP:
+ *   - stdio (command:)  → server is launched automatically as a subprocess by VS 2022.
+ *                         No running port, no npm start needed.
+ *                         Model auto-detection works via the MCP roots protocol.
+ *   - HTTP  (url:)      → server listens on a TCP port (Azure or local npm start).
+ *                         VS 2022 does not send workspace headers over HTTP —
+ *                         configure workspacePath or D365FO_SOLUTIONS_PATH instead.
+ *
+ * D365FO_SOLUTIONS_PATH:
+ *   Folder containing your D365FO .rnrproj files.
+ *   The server scans it at startup, auto-detects model names, and lists all found
+ *   projects in get_workspace_info. To switch between solutions call
+ *   get_workspace_info with the projectPath argument — no server restart needed.
+ *
+ * DB_PATH / LABELS_DB_PATH:
+ *   Must be ABSOLUTE paths. In stdio mode process.cwd() is not the repo folder,
+ *   so relative paths like "./data/..." would point to the wrong directory.
+ *
+ * workspacePath format (HTTP mode only):
  *   "...\PackagesLocalDirectory\YourPackageName\YourModelName"
- *
- * From this single path the server automatically derives:
- *   - packagePath  → everything up to PackagesLocalDirectory
- *   - packageName  → YourPackageName (second-to-last segment)
- *   - modelName    → YourModelName   (last segment)
- *
- * You only need to add explicit modelName when the model name differs from what
- * is the last segment, or explicit packagePath when it cannot be derived from workspacePath.
+ *   From this single path the server automatically derives:
+ *     - packagePath  → everything up to PackagesLocalDirectory
+ *     - packageName  → YourPackageName (second-to-last segment)
+ *     - modelName    → YourModelName   (last segment)
  */
 
-// ─── Option 1: Single local server (full mode) ───────────────────────────────
-// Use when the MCP server runs on the same Windows VM as your D365FO installation.
+// ─── Option 1: Local stdio server (recommended for single developers) ─────────
+// VS 2022 launches the server automatically as a subprocess.
+// No npm start required. Model is auto-detected from D365FO_SOLUTIONS_PATH.
 {
   "servers": {
-    "d365fo-code-intelligence": {
-      "url": "http://localhost:8080/mcp/"
-    },
-    "context": {
-      "workspacePath": "K:\\AOSService\\PackagesLocalDirectory\\YourPackageName\\YourModelName",
-      "projectPath": "K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj"
+    "d365fo-mcp-tools": {
+      "command": "node",
+      "args": ["C:\\d365fo-mcp-server\\dist\\index.js"],
+      "env": {
+        "DB_PATH": "C:\\d365fo-mcp-server\\data\\xpp-metadata.db",
+        "LABELS_DB_PATH": "C:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db",
+        "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects"
+      }
     }
   }
 }
@@ -38,7 +56,7 @@
 // File-creation tools are not available — use generate_d365fo_xml() + manual save instead.
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "https://your-app-name.azurewebsites.net/mcp/"
     },
     "context": {
@@ -59,27 +77,27 @@
     },
     "d365fo-local": {
       "command": "node",
-      "args": ["K:\\d365fo-mcp-server\\dist\\index.js", "--stdio"],
+      "args": ["K:\\d365fo-mcp-server\\dist\\index.js"],
       "env": {
-        "MCP_SERVER_MODE": "write-only"
+        "MCP_SERVER_MODE": "write-only",
+        "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects"
       }
     },
     "context": {
       "workspacePath": "K:\\AOSService\\PackagesLocalDirectory\\YourPackageName\\YourModelName",
-      "projectPath": "K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj",
       "devEnvironmentType": "auto"
     }
   }
 }
 
-// ─── UDE (Unified Developer Experience / Power Platform Tools) ───────────────
+// ─── Option 4: UDE (Unified Developer Experience / Power Platform Tools) ─────
 // Add these context properties instead of workspacePath when using
 // the UDE environment in Visual Studio 2022 with Power Platform Tools.
 // The server reads XPP config files from %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\
 // automatically — you usually do not need to set the paths manually.
 {
   "servers": {
-    "d365fo-code-intelligence": {
+    "d365fo-mcp-tools": {
       "url": "https://your-app-name.azurewebsites.net/mcp/"
     },
     "context": {

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm run dev                      # Server at http://localhost:3000
 
 ## Connect to GitHub Copilot
 
-**1.** Enable *Editor Preview Features* at **github.com/settings/copilot/features**
+**1.** Enable *MCP servers in Copilot* at **github.com/settings/copilot/features**
 
 **2.** In Visual Studio: **Tools → Options → GitHub → Copilot** → check *Enable MCP server integration in agent mode*
 

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -36,6 +36,59 @@ The server will also:
 
 ---
 
+## Transport Modes
+
+### stdio (recommended for local / single-developer setup)
+
+The server is launched directly by the MCP client as a subprocess. No HTTP server, no port.
+VS 2022 and VS Code both support this via the `command:` key.
+
+```json
+{
+  "servers": {
+    "d365fo-mcp-tools": {
+      "command": "node",
+      "args": ["C:\\path\\to\\d365fo-mcp-server\\dist\\index.js"],
+      "env": {
+        "DB_PATH": "C:\\path\\to\\d365fo-mcp-server\\data\\xpp-metadata.db",
+        "LABELS_DB_PATH": "C:\\path\\to\\d365fo-mcp-server\\data\\xpp-metadata-labels.db",
+        "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects"
+      }
+    }
+  }
+}
+```
+
+Key points:
+- `DB_PATH` / `LABELS_DB_PATH` must be **absolute paths** — the server's working directory in
+  stdio mode is controlled by the client, not the repo folder.
+- `D365FO_SOLUTIONS_PATH` — folder containing your `.rnrproj` files. The server scans it at
+  startup and auto-detects the model name. Required for reliable model detection.
+- No `context` block needed — model name is resolved from `.rnrproj` automatically.
+- `MCP_SERVER_MODE` defaults to `full` — omit it unless you need `read-only` or `write-only`.
+
+### HTTP (Azure-hosted or `npm run dev`)
+
+The server listens on a TCP port. Used for Azure deployments and for local `npm run dev` sessions.
+
+```json
+{
+  "servers": {
+    "d365fo-mcp-tools": {
+      "url": "https://your-server.azurewebsites.net/mcp/"
+    },
+    "context": {
+      "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"
+    }
+  }
+}
+```
+
+Note: VS 2022 HTTP transport does **not** send workspace headers. Use `workspacePath` or
+`projectPath` in the `context` block, or switch to stdio.
+
+---
+
 ## All Configuration Options
 
 ### Traditional
@@ -88,8 +141,19 @@ files from `%LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\` and detects the pat
 | `customPackagesPath` | Optional | UDE: Custom X++ code root (from XPP config `ModelStoreFolder`). |
 | `microsoftPackagesPath` | Optional | UDE: Microsoft X++ root (from XPP config `FrameworkDirectory`). |
 | `devEnvironmentType` | Optional | `auto` (default), `traditional`, or `ude`. Controls path resolution behavior. |
-| `projectPath` | Optional | Full path to your `.rnrproj` file. Usually auto-detected by GitHub Copilot. |
+| `projectPath` | Optional | Full path to your `.rnrproj` file. Auto-detected from roots/list (stdio) or D365FO_SOLUTIONS_PATH. |
 | `solutionPath` | Optional | Visual Studio solution folder. Used when `projectPath` is not set. |
+
+### Environment Variables (stdio `env` block)
+
+| Variable | Required | What it does |
+|----------|----------|--------------|
+| `DB_PATH` | Yes (stdio) | Absolute path to `xpp-metadata.db`. Must be absolute — cwd is not the repo folder in stdio mode. |
+| `LABELS_DB_PATH` | Yes (stdio) | Absolute path to `xpp-metadata-labels.db`. Same reason as DB_PATH. |
+| `D365FO_SOLUTIONS_PATH` | Recommended | Folder containing D365FO `.rnrproj` files. Server scans it at startup for model auto-detection and lists all found projects in `get_workspace_info`. Required for project switching by name (`projectName` parameter). |
+| `MCP_SERVER_MODE` | No | `full` (default), `read-only`, or `write-only`. Only needed in hybrid setups. |
+| `MCP_FORCE_HTTP` | No | Set to `true` to prevent stdio mode even when stdin is piped (rare). |
+| `DEBUG_LOGGING` | No | Set to `true` to dump workspace-related HTTP headers to stderr (HTTP transport only). |
 
 ### When do you need the optional properties?
 
@@ -129,11 +193,12 @@ also auto-resolves package names by reading descriptor XML files. In traditional
 to assuming package name equals model name.
 
 For the model name used when creating files:
-1. **Auto-detected from `.rnrproj`** found in the active GitHub Copilot workspace
-2. **`projectPath` from `.mcp.json`** — the model name is read from the `.rnrproj` file
-3. **`solutionPath` from `.mcp.json`** — the server searches for `.rnrproj` files inside it
-4. **Last segment of `workspacePath`** — `...\PackagesLocalDirectory\PackageName\ModelName` → `ModelName`
-5. **Explicit `modelName`** in context — used only if none of the above are available
+1. **Explicit `modelName`** in `.mcp.json` context — always wins
+2. **Last segment of `workspacePath`** — only when the path contains `PackagesLocalDirectory` (AOT paths). Skipped for repo paths like `K:\repos\Contoso` to avoid returning the repo folder name instead of the real model.
+3. **Auto-detected from `.rnrproj`** — triggered by roots/list protocol (stdio), `D365FO_SOLUTIONS_PATH` scan, or workspace seed from env vars
+4. **`D365FO_MODEL_NAME`** env var — last resort fallback
+
+Each resolved value and its detection source are visible in `get_workspace_info` output.
 
 ---
 
@@ -172,8 +237,8 @@ this by running two servers simultaneously:
 
 | Instance | Runs on | `MCP_SERVER_MODE` | Tools |
 |----------|---------|-------------------|-------|
-| `d365fo-azure` | Azure App Service | `read-only` | All 25 search & analysis tools |
-| `d365fo-local` | Windows VM (stdio) | `write-only` | `create_d365fo_file`, `modify_d365fo_file`, `create_label` |
+| `d365fo-azure` | Azure App Service | `read-only` | 38 search & analysis tools |
+| `d365fo-local` | Windows VM (stdio) | `write-only` | `create_d365fo_file`, `modify_d365fo_file`, `create_label`, `rename_label` |
 
 GitHub Copilot connects to both servers at the same time and selects the right one automatically.
 
@@ -187,24 +252,27 @@ GitHub Copilot connects to both servers at the same time and selects the right o
     },
     "d365fo-local": {
       "command": "node",
-      "args": ["K:\\d365fo-mcp-server\\dist\\index.js", "--stdio"],
+      "args": ["K:\\d365fo-mcp-server\\dist\\index.js"],
       "env": {
-        "MCP_SERVER_MODE": "write-only"
+        "MCP_SERVER_MODE": "write-only",
+        "D365FO_SOLUTIONS_PATH": "K:\\VSProjects\\MySolution"
       }
     },
     "context": {
-      "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName",
-      "projectPath": "K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj"
+      "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"
     }
   }
 }
 ```
 
+> **Note:** The `--stdio` argument is no longer needed — the server detects stdio mode
+> automatically via `process.stdin.isTTY`.
+
 ### How it works
 
 1. `d365fo-azure` starts with `MCP_SERVER_MODE=read-only` → only exposes search/analysis tools
 2. `d365fo-local` starts with `MCP_SERVER_MODE=write-only` → only exposes file-operation tools
-3. GitHub Copilot aggregates both tool lists — from Copilot's perspective it sees all 28 tools
+3. GitHub Copilot aggregates both tool lists — from Copilot's perspective it sees all 42 tools
 4. When Copilot calls `create_d365fo_file`, it goes to the local server which has K:\ access
 5. When Copilot calls `search`, it goes to the Azure server with the full metadata database
 
@@ -215,22 +283,22 @@ When the server starts, it logs the detected mode and tool count:
 **Write-only mode (local companion):**
 ```
 🔧 Server mode: write-only (from env: write-only)
-🎯 Registered 3 X++ MCP tools (create_d365fo_file, modify_d365fo_file, create_label)
-[MCP Server] Tool list filtered for write-only mode: 3 tools (create_d365fo_file, modify_d365fo_file, create_label)
+🎯 Registered 4 X++ MCP tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label)
+[MCP Server] Tool list filtered for write-only mode: 4 tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label)
 ```
 
 **Read-only mode (Azure server):**
 ```
 🔧 Server mode: read-only (from env: read-only)
-🎯 Registered 26 X++ MCP tools (all except write tools)
-[MCP Server] Tool list filtered for read-only mode: 26 tools (write tools excluded)
+🎯 Registered 38 X++ MCP tools (all except write tools)
+[MCP Server] Tool list filtered for read-only mode: 38 tools (write tools excluded)
 ```
 
 **Full mode (local development):**
 ```
 🔧 Server mode: full (from env: not set, defaulting to full)
-🎯 Registered 40 X++ MCP tools (8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis + 9 security-extensions)
-[MCP Server] Tool list in full mode: 40 tools (no filtering)
+🎯 Registered 42 X++ MCP tools (8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 5 file-ops + 3 pattern-analysis + 9 security-extensions)
+[MCP Server] Tool list in full mode: 42 tools (no filtering)
 ```
 
 > **Note:** The local server in `write-only` mode still needs access to the metadata database

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -17,6 +17,7 @@ If you are responsible for deploying the server infrastructure to Azure, see [SE
   - [Scenario B: Hybrid — Azure search + local file writes](#scenario-b-hybrid--azure-search--local-file-writes)
   - [Scenario C: Local server only](#scenario-c-local-server-only)
   - [Scenario D: UDE (Unified Developer Experience)](#scenario-d-ude-unified-developer-experience)
+  - [Scenario E: Local stdio server (single developer, zero-config)](#scenario-e-local-stdio-server-single-developer-zero-config)
 - [Where to place .mcp.json](#where-to-place-mcpjson)
 - [Troubleshooting](#troubleshooting)
 
@@ -35,7 +36,7 @@ If you are responsible for deploying the server infrastructure to Azure, see [SE
 
 ## Step 1 — Enable MCP in GitHub and Visual Studio
 
-1. Go to **https://github.com/settings/copilot/features** and enable **Editor Preview Features**.
+1. Go to **https://github.com/settings/copilot/features** and enable **MCP servers in Copilot**.
 
 2. In Visual Studio: **Tools → Options → GitHub → Copilot**
    → Enable **"Enable MCP server integration in agent mode"**
@@ -157,18 +158,23 @@ npm run build
     },
     "d365fo-local": {
       "command": "node",
-      "args": ["K:\\d365fo-mcp-server\\dist\\index.js", "--stdio"],
+      "args": ["K:\\d365fo-mcp-server\\dist\\index.js"],
       "env": {
-        "MCP_SERVER_MODE": "write-only"
+        "MCP_SERVER_MODE": "write-only",
+        "DB_PATH": "K:\\d365fo-mcp-server\\data\\xpp-metadata.db",
+        "LABELS_DB_PATH": "K:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db",
+        "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects"
       }
     },
     "context": {
-      "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName",
-      "projectPath": "K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj"
+      "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"
     }
   }
 }
 ```
+
+> **Note:** The `--stdio` argument is no longer required. The server detects stdio mode
+> automatically when launched as a subprocess (stdin is a pipe, not a terminal).
 
 `projectPath` is optional but recommended — it pins the exact `.rnrproj` so file creation
 always targets the right model even when multiple projects are open.
@@ -240,6 +246,9 @@ The server runs at `http://localhost:8080`. Verify with `http://localhost:8080/h
 }
 ```
 
+> **Tip:** For a fully local setup without an HTTP server, see **Scenario E** which uses stdio
+> transport and does not require `npm start` or a running port.
+
 **Keeping it up to date** — after a D365FO version upgrade or model changes, re-run extraction:
 
 ```powershell
@@ -293,6 +302,75 @@ automatically. In most cases you do not need to set any paths manually.
 
 ---
 
+### Scenario E: Local stdio server (single developer, zero-config)
+
+**What it is:** The MCP server runs entirely on your Windows VM using **stdio transport**.
+VS 2022 launches it automatically as a subprocess — no `npm start`, no open port, no HTTP.
+Model auto-detection works via the MCP roots protocol without any `context` block.
+
+**What you need:**
+- Node.js 24.x, Git
+- A D365FO installation with `PackagesLocalDirectory`
+- A pre-built metadata database
+
+**Setup:**
+
+```powershell
+git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git C:\d365fo-mcp-server
+cd C:\d365fo-mcp-server
+npm install
+copy .env.example .env
+```
+
+Extract and index the metadata (same as Scenario C), then build:
+
+```powershell
+npm run extract-metadata
+npm run build-database
+npm run build
+```
+
+**`%USERPROFILE%\.mcp.json`** (global, covers all solutions on this machine):
+
+```json
+{
+  "servers": {
+    "d365fo-mcp-tools": {
+      "command": "node",
+      "args": ["C:\\d365fo-mcp-server\\dist\\index.js"],
+      "env": {
+        "DB_PATH": "C:\\d365fo-mcp-server\\data\\xpp-metadata.db",
+        "LABELS_DB_PATH": "C:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db",
+        "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects"
+      }
+    }
+  }
+}
+```
+
+Replace `K:\VSProjects` with the folder that contains your D365FO solution(s).
+
+**How it works:**
+1. VS 2022 starts the server process on first use — no manual `npm start` needed.
+2. The MCP roots protocol delivers the open workspace URI automatically.
+3. `D365FO_SOLUTIONS_PATH` is scanned for all `.rnrproj` files at startup.
+4. `get_workspace_info` shows all found projects and the active one.
+5. To switch to a different solution without restarting: call `get_workspace_info` with
+   `projectPath` pointing to the target `.rnrproj`.
+
+**Keeping it up to date:**
+
+```powershell
+cd C:\d365fo-mcp-server
+git pull
+npm install
+npm run build
+```
+
+Restart the MCP server in VS 2022 after updating (MCP panel → Restart).
+
+---
+
 ## Where to place .mcp.json
 
 The server searches for `.mcp.json` starting from the current working directory and walking
@@ -330,7 +408,7 @@ want to maintain per-solution files.
 
 ### MCP tools not loading in Visual Studio
 - Confirm Visual Studio version is 17.14 or later
-- Confirm *Editor Preview Features* are enabled at https://github.com/settings/copilot/features
+- Confirm *MCP servers in Copilot* is enabled at https://github.com/settings/copilot/features
 - Confirm Copilot Chat is in **Agent Mode** (not Ask or Edit)
 - Confirm `.mcp.json` is in the solution root or user home directory (`%USERPROFILE%\.mcp.json`)
 - Restart Visual Studio after creating or editing `.mcp.json`

--- a/docs/WORKSPACE_DETECTION.md
+++ b/docs/WORKSPACE_DETECTION.md
@@ -7,15 +7,23 @@ figures out which model you are working in — **no manual configuration require
 
 ## How It Works
 
-1. GitHub Copilot passes the current workspace folder path to the MCP server with every tool call.
-2. The server searches that folder (up to 5 levels deep) for any `.rnrproj` file.
+### stdio transport (recommended — VS 2022 + VS Code)
+
+When the server is launched as a stdio subprocess via `command:` in `.mcp.json`:
+
+1. After the MCP handshake, the client sends a `roots/list` response with the open workspace folder URI.
+2. The server converts the URI to a local path and searches for any `.rnrproj` file (up to 6 levels deep).
 3. It reads the `<Model>` element from the project file to get your model name.
 4. All file operations (create, modify) use that model automatically.
 
+Fallback chain when `roots/list` is not available:
+- `VSCODE_WORKSPACE_FOLDER_PATHS` environment variable (VS Code sets this)
+- `process.cwd()` — used only when it is **not** a Node.js project directory
+
 ```
-Open project in Visual Studio 2022
+Open D365FO solution in Visual Studio 2022
            ↓
-GitHub Copilot passes workspace path to MCP server
+Server receives roots via MCP protocol (file:/// URI)
            ↓
 Server finds MyProject.rnrproj
            ↓
@@ -24,74 +32,131 @@ Model name extracted: "MyModel"
 New files created in K:\AosService\PackagesLocalDirectory\MyPackage\MyModel\...
 ```
 
+### HTTP transport (Azure-hosted server)
+
+When connected to a remote Azure server via `url:`, the HTTP transport reads the
+`x-workspace-path` request header. VS 2022 does not send this header — configure
+`D365FO_SOLUTIONS_PATH` or explicit `projectPath` in `.mcp.json` context instead.
+
 ---
 
 ## What You Need to Do
 
-**Nothing** — if your project is open in Visual Studio, detection is automatic.
+**For stdio (local server):** Set `D365FO_SOLUTIONS_PATH` in the `env` block of `.mcp.json`
+pointing to the folder that contains your D365FO solution(s). The server scans it on startup
+and picks up all projects automatically.
 
-The only thing that helps is having a `workspacePath` in your `.mcp.json` pointing to your
-custom model using the two-level format:
-
-```
-K:\AosService\PackagesLocalDirectory\YourPackageName\YourModelName
-```
-
-This enables workspace-aware search (searching your local files alongside the standard D365FO
-metadata) and lets the server derive `packagePath`, `packageName`, and `modelName` automatically.
-It does **not** affect file creation paths — those come from the `.rnrproj` auto-detection.
-
----
-
-## When to Add Manual Configuration
-
-Add explicit paths to `.mcp.json` only in these situations:
-
-| Situation | What to add |
-|-----------|------------|
-| Multiple D365FO projects in one solution | `projectPath` pointing to the right `.rnrproj` |
-| Non-standard PackagesLocalDirectory location | `workspacePath` with the full `PackagesLocalDirectory\Package\Model` path |
-| Running the server outside a Visual Studio workspace | `workspacePath` (`PackagesLocalDirectory\Package\Model`) and/or `solutionPath` |
-
-Minimal override example:
 ```json
 {
   "servers": {
     "d365fo-mcp-tools": {
-      "url": "http://localhost:8080/mcp/"
-    },
-    "context": {
-      "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"
+      "command": "node",
+      "args": ["C:\\path\\to\\d365fo-mcp-server\\dist\\index.js"],
+      "env": {
+        "DB_PATH": "C:\\path\\to\\d365fo-mcp-server\\data\\xpp-metadata.db",
+        "LABELS_DB_PATH": "C:\\path\\to\\d365fo-mcp-server\\data\\xpp-metadata-labels.db",
+        "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects"
+      }
     }
   }
 }
 ```
 
+**For HTTP (Azure server):** Use the two-level `workspacePath` in the `context` block:
+
+```
+K:\AosService\PackagesLocalDirectory\YourPackageName\YourModelName
+```
+
+This lets the server derive `packagePath`, `packageName`, and `modelName` automatically.
+
 ---
 
-## Priority Order
+## D365FO_SOLUTIONS_PATH — Multi-Solution Support
 
-When the server needs the model name for file creation:
+Set this env var to a folder that contains one or more D365FO Visual Studio projects.
+The server scans it on every startup and lists all found projects.
+
+When multiple projects are found, `get_workspace_info` shows the full list with an active
+marker (`▶`):
+
+```
+## Available Projects (D365FO_SOLUTIONS_PATH)
+
+▶ ContosoBank                             K:\repos\Contoso\src\...\ContosoBank.rnrproj
+  ContosoEDS                              K:\repos\Contoso\src\...\ContosoEDS.rnrproj
+  ContosoWMS                              K:\repos\Contoso\src\...\ContosoWMS.rnrproj
+
+To switch project: call get_workspace_info with projectName = "<ModelName>"
+```
+
+### Switching projects
+
+**Preferred — by name** (Copilot resolves the path automatically):
+
+```
+"switch to ContosoEDS project"
+```
+→ Copilot calls `get_workspace_info` with `projectName = "ContosoEDS"`
+
+You can also use a partial name — the server picks the first match:
+- `"Conto"` → matches `ContosoEDS`
+- `"Bank"` → matches `ContosoBank`
+
+**Fallback — by full path** (when name is ambiguous or D365FO_SOLUTIONS_PATH is not set):
+
+```
+get_workspace_info with projectPath = "K:\repos\MySolution\MyProject\MyProject.rnrproj"
+```
+
+The server switches context immediately. No restart required. The switched project
+persists for all subsequent tool calls in the same session.
+
+---
+
+## When to Add Manual Configuration
+
+| Situation | What to add |
+|-----------|------------|
+| Single developer, local stdio server | `D365FO_SOLUTIONS_PATH` env var in `.mcp.json` |
+| Azure server, multiple solutions | `projectPath` in `.mcp.json` context pointing to the right `.rnrproj` |
+| Non-standard PackagesLocalDirectory | `workspacePath` with full `PackagesLocalDirectory\Package\Model` path |
+| Running without a VS workspace open | `D365FO_SOLUTIONS_PATH` or explicit `projectPath` |
+
+---
+
+## Priority Order (Model Name Resolution)
 
 | Priority | Source | Notes |
 |----------|--------|-------|
-| 1st | Tool call argument | Highest — explicit `projectPath` passed in the tool call |
-| 2nd | `.mcp.json` projectPath | Explicit path in config file |
-| 3rd | Auto-detection from workspace | Searches for `.rnrproj` in active workspace |
-| 4th | `.mcp.json` solutionPath | Searches inside the configured solution folder |
-| 5th | Last segment of `workspacePath` | `...\PackagesLocalDirectory\Package\Model` → `Model` |
-| 6th | Explicit `modelName` in context | Last resort — may be wrong if it is a placeholder |
+| 1st | Explicit `modelName` in `.mcp.json` context | Always wins |
+| 2nd | Last segment of `workspacePath` | Only used when path contains `PackagesLocalDirectory` — avoids returning repo names like `ASL` |
+| 3rd | Auto-detected from `.rnrproj` scan | Triggered by roots protocol, `D365FO_SOLUTIONS_PATH`, or workspace seed |
+| 4th | `D365FO_MODEL_NAME` env var | Last resort fallback |
+
+Each value's detection source is shown in `get_workspace_info` output:
+```
+Model name   : ContosoBank  (source: auto-detected from .rnrproj)
+Package path : K:\AosService\PackagesLocalDirectory  (source: auto-detected from .rnrproj)
+Project path : K:\repos\Contoso\src\...\MyProject.rnrproj  (source: auto-detected from .rnrproj)
+```
 
 ---
 
 ## Troubleshooting
 
+**Server picks up wrong model (e.g. the MCP server's own package name)**
+The server's working directory (`process.cwd()`) is the MCP server repo — it is automatically
+skipped when it contains a `package.json`. Set `D365FO_SOLUTIONS_PATH` to point at your D365FO
+solution folder.
+
 **Files end up in a Microsoft standard model**
-GitHub Copilot did not provide the workspace path (can happen in certain VS 2022 configurations).
-Add `projectPath` to your `.mcp.json` as shown above.
+None of the detection methods found a `.rnrproj`. Add `D365FO_SOLUTIONS_PATH` to the `env`
+block in `.mcp.json`, or set `projectPath` in the `context` block explicitly.
 
 **"modelName appears to be a placeholder" warning**
 The server detected a suspicious model name like `"auto"` or `"YourModel"`.
-This means none of the first four detection methods worked. Check that:
+This means auto-detection did not find a `.rnrproj`. Check that:
+- `D365FO_SOLUTIONS_PATH` points to a folder containing `.rnrproj` files
 - Your solution is open in Visual Studio with the correct project loaded
 - The `.mcp.json` is in the solution root (next to the `.sln` file)

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ import { RedisCacheService } from './cache/redisCache.js';
 import { WorkspaceScanner } from './workspace/workspaceScanner.js';
 import { HybridSearch } from './workspace/hybridSearch.js';
 import { initializeDatabase } from './database/download.js';
-import { initializeConfig } from './utils/configManager.js';
+import { initializeConfig, getConfigManager } from './utils/configManager.js';
 import { SERVER_MODE, WRITE_TOOLS } from './server/serverMode.js';
 import * as fs from 'fs/promises';
 
@@ -62,13 +62,28 @@ console.error = (...args: any[]) => {
 };
 
 const PORT = parseInt(process.env.PORT || '8080');
-const DB_PATH = process.env.DB_PATH || './data/xpp-metadata.db';
-const LABELS_DB_PATH = process.env.LABELS_DB_PATH || './data/xpp-metadata-labels.db';
-const METADATA_PATH = process.env.METADATA_PATH || './metadata';
+// Derive server root from this file's location so paths are absolute
+// regardless of process.cwd() — critical when VS Code launches this as stdio subprocess.
+const __serverDir = dirname(fileURLToPath(import.meta.url));
+const DB_PATH = process.env.DB_PATH
+  ? resolve(process.env.DB_PATH)
+  : resolve(__serverDir, '../data/xpp-metadata.db');
+const LABELS_DB_PATH = process.env.LABELS_DB_PATH
+  ? resolve(process.env.LABELS_DB_PATH)
+  : resolve(__serverDir, '../data/xpp-metadata-labels.db');
+const METADATA_PATH = process.env.METADATA_PATH
+  ? resolve(process.env.METADATA_PATH)
+  : resolve(__serverDir, '../metadata');
 
-// Detect if running in stdio mode (launched by MCP client)
-// Force HTTP mode in Azure (when PORT or WEBSITES_PORT env var is set)
-const isStdioMode = !process.env.PORT && !process.env.WEBSITES_PORT && !process.stdin.isTTY;
+// Detect if running in stdio mode (launched by MCP client as subprocess).
+// Primary signal: stdin is NOT a TTY — in Node.js isTTY is `true` for terminals
+// and `undefined` (never `false`) for pipes, so use !isTTY, not === false.
+// WEBSITES_PORT guards Azure App Service (HTTP-only, stdin may also be non-TTY there).
+// MCP_FORCE_HTTP lets an operator explicitly keep HTTP even when stdin is piped.
+const isStdioMode =
+  !process.env.WEBSITES_PORT &&
+  process.env.MCP_FORCE_HTTP !== 'true' &&
+  (process.env.MCP_STDIO_MODE === 'true' || !process.stdin.isTTY);
 
 // Readiness state tracking
 interface ServerState {
@@ -321,25 +336,108 @@ async function main() {
   console.log(`🔧 Server mode: ${SERVER_MODE}`);
 
   if (isStdioMode) {
-    // STDIO mode - initialize synchronously before connecting
-    const { mcpServer } = await initializeServices();
-    console.log('📡 Using stdio transport for MCP client');
+    // Pre-seed workspace so auto-detection starts before the first tool call.
+    // VS Code sets process.cwd() to the first workspace folder for stdio servers.
+    // VSCODE_WORKSPACE_FOLDER_PATHS is a more reliable VS Code-specific env var.
+    const envRoots = process.env.VSCODE_WORKSPACE_FOLDER_PATHS
+      ?.split(';')
+      .filter(Boolean)
+      .map(u => u.startsWith('file:///')
+        ? decodeURIComponent(u.slice(8)).replace(/\//g, '\\')
+        : u);
+    const initialWorkspace = envRoots?.[0] ?? process.cwd();
+    // Eagerly scan D365FO_SOLUTIONS_PATH so allDetectedProjects is populated before
+    // VS 2022 sends roots/list (usually within 1–2 s of startup).
+    getConfigManager().initEagerScan();
+    process.stderr.write(`[stdio] Seeding workspace: ${initialWorkspace}\n`);
+    getConfigManager().setRuntimeContext({ workspacePath: initialWorkspace });
+
+    // STDIO mode: connect transport BEFORE the heavy database open so the MCP
+    // handshake completes within VS 2022's initialization timeout (~10 s).
+    //
+    // Strategy:
+    //  1. Create a lightweight "stub" server with an in-memory (empty) symbol index.
+    //  2. Connect the stdio transport — handshake completes immediately.
+    //  3. Yield the event loop (setImmediate) so VS 2022's `initialized` notification
+    //     and the roots/list exchange are processed BEFORE the synchronous DB open
+    //     blocks the event loop. Without this yield, project auto-detection via
+    //     roots/list could be delayed until after DB load.
+    //  4. Run full initializeServices() in the background.
+    //  5. Swap the real symbol index into the context once init finishes.
+    //     Tool handlers await ctx.dbReady so they always use the real index —
+    //     they will block (showing a spinner in the IDE) until the DB is ready,
+    //     then execute immediately with full results.
+
+    // Step 1: lightweight stub + deferred dbReady promise
+    const { TermRelationshipGraph } = await import('./utils/suggestionEngine.js');
+    const stubCache = new RedisCacheService();
+    stubCache.waitForConnection().catch(() => {});
+    const stubIndex = new XppSymbolIndex(':memory:', ':memory:');
+    const stubParser = new XppMetadataParser();
+    const stubScanner = new WorkspaceScanner();
+    const stubHybrid = new HybridSearch(stubIndex, stubScanner);
+    const stubGraph = new TermRelationshipGraph();
+
+    let resolveDbReady!: () => void;
+    let rejectDbReady!: (err: unknown) => void;
+    const dbReadyPromise = new Promise<void>((res, rej) => {
+      resolveDbReady = res;
+      rejectDbReady  = rej;
+    });
+
+    const stubContext: import('./types/context.js').XppServerContext = {
+      symbolIndex: stubIndex,
+      parser: stubParser,
+      cache: stubCache,
+      workspaceScanner: stubScanner,
+      hybridSearch: stubHybrid,
+      termRelationshipGraph: stubGraph,
+      dbReady: dbReadyPromise,
+    };
+    const mcpServer = createXppMcpServer(stubContext);
+
+    // Step 2: connect transport — handshake completes here
     const transport = new StdioServerTransport();
     await mcpServer.connect(transport);
-    console.log('✅ Stdio transport connected');
-    
-    // Log actual tool count based on server mode
-    const totalTools = 41;
+    console.log('✅ Stdio transport connected (DB loading in background)');
+
+    // Step 3: yield the event loop so `initialized` + roots/list can be processed
+    // BEFORE the synchronous new Database() call blocks the event loop.
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    // Step 4: load real database in the background
+    initializeServices().then(({ symbolIndex, parser, cache, workspaceScanner, hybridSearch, termRelationshipGraph }) => {
+      // Step 5: patch the context references used by tool handlers
+      stubContext.symbolIndex       = symbolIndex;
+      stubContext.parser            = parser;
+      stubContext.cache             = cache;
+      stubContext.workspaceScanner  = workspaceScanner;
+      stubContext.hybridSearch      = hybridSearch;
+      stubContext.termRelationshipGraph = termRelationshipGraph;
+      serverState.symbolIndex = symbolIndex;
+      serverState.parser      = parser;
+      serverState.cache       = cache;
+      serverState.statusMessage = 'Ready';
+      // Resolve dbReady AFTER context is patched — tools can now run with real index.
+      resolveDbReady();
+      console.log('✅ Database loaded — all tools fully operational');
+    }).catch(err => {
+      rejectDbReady(err);
+      console.error('❌ Background initialization failed:', err);
+    });
+
+    // Log tool count immediately (transport is already connected)
+    const totalTools = 42;
     const writeToolCount = WRITE_TOOLS.size;
     const toolCount = SERVER_MODE === 'write-only' ? writeToolCount :
                      SERVER_MODE === 'read-only' ? totalTools - writeToolCount : totalTools;
     const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(WRITE_TOOLS).join(', ')})` :
                     SERVER_MODE === 'read-only' ? '(all except write tools)' :
-                    '(8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 3 file-ops + 3 pattern-analysis + 9 security-extensions)';
+                    '(8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 5 file-ops + 3 pattern-analysis + 9 security-extensions)';
     console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
-    serverState.statusMessage = 'Ready';
+    serverState.statusMessage = 'Loading database...';
   } else {
     // HTTP mode - initialize fully BEFORE opening the port.
     // VS Copilot's MCP client does not retry on 503/404, so the port must only

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -6,6 +6,9 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   ListToolsRequestSchema,
+  InitializedNotificationSchema,
+  RootsListChangedNotificationSchema,
+  ListRootsResultSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { registerToolHandler } from '../tools/toolHandler.js';
 import { registerClassResource } from '../resources/classResource.js';
@@ -13,10 +16,54 @@ import { registerWorkspaceResources } from '../resources/workspaceResource.js';
 import { registerCodeReviewPrompt } from '../prompts/codeReview.js';
 import type { XppServerContext } from '../types/context.js';
 import { SERVER_MODE, WRITE_TOOLS } from './serverMode.js';
+import { getConfigManager } from '../utils/configManager.js';
 
 export type { XppServerContext };
 export { SERVER_MODE, WRITE_TOOLS } from './serverMode.js';
 export type { ServerMode } from './serverMode.js';
+
+/**
+ * Convert a file:// URI to a local Windows path.
+ * Duplicated from transport.ts to keep mcpServer.ts self-contained
+ * (no circular dep between transport ↔ mcpServer).
+ */
+function fileUriToPath(uri: string): string | null {
+  if (!uri) return null;
+  if (uri.startsWith('file:///')) {
+    return decodeURIComponent(uri.slice('file:///'.length)).replace(/\//g, '\\');
+  }
+  if (uri.startsWith('file://')) {
+    return decodeURIComponent(uri.slice('file://'.length)).replace(/\//g, '\\');
+  }
+  if (uri.length > 2 && (uri[1] === ':' || uri.startsWith('\\\\'))) return uri;
+  return null;
+}
+
+/**
+ * Apply MCP roots list to ConfigManager.
+ * Called after InitializedNotification and RootsListChanged notification.
+ * All roots are passed so that unambiguous single-project matches work correctly
+ * even when VS 2022 sends multiple roots (open project folders).
+ */
+function applyRootsToConfig(roots: Array<{ uri: string }>): void {
+  if (!roots?.length) return;
+
+  // Log all received roots for diagnostics
+  process.stderr.write(`[mcpServer] roots/list received (${roots.length} root(s)):\n`);
+  roots.forEach((r, i) => process.stderr.write(`  [${i}] ${r.uri}\n`));
+
+  // Convert all URIs to local paths
+  const paths = roots
+    .map(r => fileUriToPath(r.uri))
+    .filter((p): p is string => p !== null);
+
+  if (paths.length === 0) return;
+
+  // Pass all paths; configManager will pick the most specific unambiguous one.
+  getConfigManager().setRuntimeContextFromRoots(paths).catch(err => {
+    process.stderr.write(`[mcpServer] setRuntimeContextFromRoots error: ${err}\n`);
+  });
+}
 
 export function createXppMcpServer(context: XppServerContext): Server {
   const serverNameSuffix = SERVER_MODE !== 'full' ? ` (${SERVER_MODE})` : '';
@@ -33,6 +80,34 @@ export function createXppMcpServer(context: XppServerContext): Server {
       },
     }
   );
+
+  // -----------------------------------------------------------------------
+  // Workspace roots: VS Code (stdio mode) sends roots after initialization.
+  // Request them immediately after `initialized` notification, then keep
+  // up-to-date on `notifications/roots/list_changed`.
+  // -----------------------------------------------------------------------
+  server.setNotificationHandler(InitializedNotificationSchema, async () => {
+    try {
+      const result = await server.request(
+        { method: 'roots/list', params: {} },
+        ListRootsResultSchema
+      );
+      applyRootsToConfig(result.roots ?? []);
+    } catch {
+      // Client doesn't support roots/list — workspace already seeded from
+      // process.cwd() or env vars in index.ts stdio startup.
+    }
+  });
+
+  server.setNotificationHandler(RootsListChangedNotificationSchema, async () => {
+    try {
+      const result = await server.request(
+        { method: 'roots/list', params: {} },
+        ListRootsResultSchema
+      );
+      applyRootsToConfig(result.roots ?? []);
+    } catch {}
+  });
 
   // Register centralized tool handler
   registerToolHandler(server, context);
@@ -1953,11 +2028,27 @@ When the configured modelName IS a placeholder, this tool auto-detects the real 
 from the .rnrproj file and shows it as a concrete fix suggestion, so the user knows exactly
 what value to put in .mcp.json.
 
+**Solution switching (VS 2022):** When the user opens a different D365FO solution or says
+"switch to <ProjectName>", call get_workspace_info with projectName (preferred) or projectPath.
+  - projectName: just the model name, e.g. "ContosoEDS" — server resolves the path automatically.
+  - projectPath: full path to the .rnrproj file (fallback when name is ambiguous).
+The server switches context immediately without restart.
+If D365FO_SOLUTIONS_PATH is configured, the output lists all available projects.
+
 Use this instead of get_label_info or search to detect the correct model — those tools return
 SOURCE models of existing objects, not the TARGET model for new objects.`,
         inputSchema: {
           type: 'object',
-          properties: {},
+          properties: {
+            projectName: {
+              type: 'string',
+              description: 'Preferred way to switch projects. Just the model name, e.g. "ContosoEDS" or "ContosoBank". The server resolves the full path from D365FO_SOLUTIONS_PATH automatically. Use this when the user says "switch to <project>" or opens a different solution.',
+            },
+            projectPath: {
+              type: 'string',
+              description: 'Absolute path to a .rnrproj file. Fallback when projectName is ambiguous or D365FO_SOLUTIONS_PATH is not configured. Example: "K:\\\\repos\\\\Contoso\\\\MyProject\\\\MyProject.rnrproj"',
+            },
+          },
           required: [],
         },
       },

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -157,6 +157,23 @@ export class CustomHttpTransport implements Transport {
           getConfigManager().setRuntimeContext({ workspacePath });
         }
 
+        // DEBUG: dump workspace-related headers + _meta when DEBUG_LOGGING=true
+        // Run once per request so VS 2022 / Copilot exact header keys can be identified.
+        if (process.env.DEBUG_LOGGING === 'true') {
+          const debugPayload = {
+            headers: Object.fromEntries(
+              Object.entries(req.headers).filter(([k]) =>
+                k.includes('workspace') || k.includes('copilot') ||
+                k.includes('vscode') || k.includes('root') ||
+                k.includes('origin') || k.includes('referer')
+              )
+            ),
+            resolvedWorkspacePath: workspacePath,
+            meta: (request as any).params?._meta,
+          };
+          process.stderr.write(`[VS22-Headers] ${JSON.stringify(debugPayload, null, 2)}\n`);
+        }
+
         if (!request.jsonrpc || !request.method) {
           res.status(400).json({
             jsonrpc: '2.0',

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -144,6 +144,22 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
     extractAndApplyWorkspaceFromMeta((request as any).params?._meta);
     extractAndApplyWorkspaceFromMeta((request.params as any)._meta);
 
+    // In stdio mode the DB loads asynchronously after transport connect.
+    // ctx.dbReady resolves once the real 1.5 GB symbol database is open and
+    // patched into the context. Awaiting it here ensures every tool call uses
+    // the real index — tools that arrive during DB loading will block (showing
+    // a spinner in the IDE) rather than silently returning empty results.
+    // Write-only tools (create_d365fo_file etc.) don't need the DB, so they
+    // skip the wait and execute immediately.
+    if (context.dbReady && !WRITE_TOOLS.has(toolName)) {
+      const t0 = Date.now();
+      await context.dbReady;
+      const elapsed = Date.now() - t0;
+      if (elapsed > 200) {
+        console.error(`[toolHandler] ⏳ ${toolName}: DB was loading, waited ${elapsed} ms`);
+      }
+    }
+
     // Enforce server mode: block write tools in read-only mode, block read tools in write-only mode
     if (SERVER_MODE === 'read-only' && WRITE_TOOLS.has(toolName)) {
       return {
@@ -267,11 +283,38 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       case 'verify_d365fo_project':
         return verifyD365ProjectTool(request, context);
       case 'get_workspace_info': {
+        const args = (request as any).params?.arguments || {};
         const configManager = getConfigManager();
-        await configManager.ensureLoaded();
-        const modelName = configManager.getModelName() ?? null;
-        const packagePath = configManager.getPackagePath() ?? null;
-        const projectPath = await configManager.getProjectPath() ?? null;
+
+        // projectName: resolve by name from known projects list (user-friendly switch)
+        if (args.projectName && !args.projectPath) {
+          const needle = (args.projectName as string).toLowerCase();
+          const allProjects = configManager.getAllDetectedProjects();
+          const match = allProjects.find(p => p.modelName.toLowerCase() === needle)
+            ?? allProjects.find(p => p.modelName.toLowerCase().includes(needle));
+          if (!match) {
+            const names = allProjects.map(p => p.modelName).join(', ') || '(none — set D365FO_SOLUTIONS_PATH)';
+            return {
+              content: [{ type: 'text', text: `❌ No project found matching "${args.projectName}".\nAvailable: ${names}` }],
+              isError: true,
+            };
+          }
+          args.projectPath = match.projectPath;
+        }
+
+        // projectPath: force-switch to specific .rnrproj
+        if (args.projectPath) {
+          const forced = await configManager.forceProject(args.projectPath);
+          if (!forced) {
+            return {
+              content: [{ type: 'text', text: `❌ Could not read model name from: ${args.projectPath}\nMake sure the path points to a valid .rnrproj file.` }],
+              isError: true,
+            };
+          }
+        }
+
+        const { modelName, modelSource, projectPath, projectSource, packagePath, packageSource } =
+          await configManager.getWorkspaceInfoDiagnostics();
         const envType = await configManager.getDevEnvironmentType();
 
         // Prefix diagnostics
@@ -288,9 +331,9 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         const lines: string[] = [
           `## D365FO Workspace Configuration`,
           ``,
-          `Model name      : ${modelName ?? '(not configured)'}`,
-          `Package path    : ${packagePath ?? '(not configured)'}`,
-          `Project path    : ${projectPath ?? '(not detected)'}`,
+          `Model name      : ${modelName ?? '(not configured)'}  (source: ${modelSource})`,
+          `Package path    : ${packagePath ?? '(not configured)'}  (source: ${packageSource})`,
+          `Project path    : ${projectPath ?? '(not detected)'}  (source: ${projectSource})`,
           `Env type        : ${envType}`,
           ``,
           `## Prefix Configuration`,
@@ -331,6 +374,20 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           if (customModels.length > 0) {
             lines.push(`Custom models in index: ${customModels.join(', ')}`);
           }
+        }
+
+        // List all projects found under D365FO_SOLUTIONS_PATH so the user can switch
+        const allProjects = configManager.getAllDetectedProjects();
+        if (allProjects.length > 1) {
+          lines.push(``);
+          lines.push(`## Available Projects (D365FO_SOLUTIONS_PATH)`);
+          lines.push(``);
+          for (const p of allProjects) {
+            const active = p.projectPath === projectPath ? '▶ ' : '  ';
+            lines.push(`${active}${p.modelName.padEnd(40)} ${p.projectPath}`);
+          }
+          lines.push(``);
+          lines.push(`To switch project: call get_workspace_info with projectName = "<ModelName>"`);
         }
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -38,6 +38,13 @@ export interface XppServerContext {
   hybridSearch: HybridSearch;
   termRelationshipGraph: TermRelationshipGraph;
   editorContext?: EditorContext;
+  /**
+   * Resolves when the real symbol database has been loaded.
+   * Present only in stdio mode when the stub pattern is active.
+   * Tool handlers await this before executing so they always use the real
+   * index rather than the empty in-memory stub.
+   */
+  dbReady?: Promise<void>;
 }
 
 

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs/promises';
 import { existsSync, realpathSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { autoDetectD365Project, detectD365Project, type D365ProjectInfo } from './workspaceDetector.js';
+import { autoDetectD365Project, detectD365Project, scanAllD365Projects, extractModelNameFromProject, detectGitBranch, type D365ProjectInfo } from './workspaceDetector.js';
 import { registerCustomModel } from './modelClassifier.js';
 import { XppConfigProvider, type XppEnvironmentConfig } from './xppConfigProvider.js';
 
@@ -52,6 +52,23 @@ class ConfigManager {
   private autoDetectionAttempted: boolean = false;
   // Cache auto-detection results per workspace path (PERFORMANCE FIX)
   private autoDetectionCache = new Map<string, D365ProjectInfo | null>();
+  // All projects found when D365FO_SOLUTIONS_PATH is configured
+  private allDetectedProjects: D365ProjectInfo[] = [];
+  // Monotonically-increasing counter — each new background detection call gets a unique ID.
+  // Before writing autoDetectedProject, the call verifies its ID is still current.
+  // This prevents a slower earlier scan (e.g. home-dir BFS) from overwriting a faster,
+  // more specific scan (e.g. direct workspace path lookup) that finished first.
+  private detectionGeneration = 0;
+  // Promise that resolves once the D365FO_SOLUTIONS_PATH eager scan completes.
+  // setRuntimeContextFromRoots awaits this before trying matchProjectForWorkspace,
+  // eliminating the race where roots/list arrives before allDetectedProjects is populated.
+  private allDetectedProjectsReady: Promise<void> | null = null;
+  // Promise for the currently in-progress background autoDetectProject call.
+  // getWorkspaceInfoDiagnostics awaits this when autoDetectedProject is still null,
+  // fixing the "null on first call" race (autoDetectionAttempted is set immediately
+  // at the start of autoDetectProject, so the !autoDetectionAttempted guard is
+  // bypassed even though the async scan hasn't returned a result yet).
+  private detectionInProgress: Promise<void> | null = null;
   private xppConfigProvider: XppConfigProvider | null = null;
   private xppConfig: XppEnvironmentConfig | null = null;
   private xppConfigLoaded: boolean = false;
@@ -62,11 +79,40 @@ class ConfigManager {
   }
 
   /**
+   * Start scanning D365FO_SOLUTIONS_PATH immediately at startup (fire-and-forget).
+   * Stores a Promise so setRuntimeContextFromRoots can await it, guaranteeing
+   * that allDetectedProjects is populated before the first roots/list notification
+   * is processed — otherwise matchProjectForWorkspace always returns null because
+   * the list is empty (roots/list often arrives within 1–2 s of startup).
+   * Safe to call multiple times; subsequent calls are no-ops.
+   */
+  initEagerScan(): void {
+    const solutionsRoot = process.env.D365FO_SOLUTIONS_PATH;
+    if (!solutionsRoot || this.allDetectedProjectsReady) return;
+
+    console.error(`[ConfigManager] 🔍 Eager project scan starting: ${solutionsRoot}`);
+    this.allDetectedProjectsReady = (async () => {
+      try {
+        const all = await scanAllD365Projects(solutionsRoot);
+        if (all.length > 0) {
+          this.allDetectedProjects = all;
+          console.error(`[ConfigManager] 🔍 Eager scan complete: ${all.length} project(s) found`);
+          all.forEach(p => console.error(`   - ${p.modelName}: ${p.projectPath}`));
+        } else {
+          console.error(`[ConfigManager] 🔍 Eager scan: no projects found under ${solutionsRoot}`);
+        }
+      } catch (err) {
+        console.error(`[ConfigManager] 🔍 Eager scan failed:`, err);
+      }
+    })();
+  }
+
+  /**
    * Auto-detect D365FO project from workspace
    * Called automatically when projectPath/solutionPath is requested but not configured
    * PERFORMANCE: Results are cached per workspace path
    */
-  private async autoDetectProject(workspacePath?: string): Promise<void> {
+  private async autoDetectProject(workspacePath?: string, generation?: number): Promise<void> {
     if (this.autoDetectionAttempted) {
       return; // Only attempt once per workspace
     }
@@ -123,18 +169,45 @@ class ConfigManager {
 
     // Store in cache (PERFORMANCE FIX)
     this.autoDetectionCache.set(cacheKey, detectedProject);
-    
-    if (detectedProject) {
+
+    // Guard: if a newer setRuntimeContext call has already started a fresher detection,
+    // discard this (now stale) result so we never overwrite a more recent correct answer.
+    const isStale = generation !== undefined && generation < this.detectionGeneration;
+    if (isStale) {
+      console.error(`[ConfigManager] ⚠️ Stale workspace detection (gen ${generation} < current ${this.detectionGeneration}) — skipping project assignment`);
+      // Do NOT return early: D365FO_SOLUTIONS_PATH scan below must still run so
+      // that allDetectedProjects is populated for future matchProjectForWorkspace calls.
+    } else if (detectedProject) {
       this.autoDetectedProject = detectedProject;
       console.error('[ConfigManager] ✅ Auto-detection successful:');
       console.error(`   ProjectPath: ${detectedProject.projectPath}`);
       console.error(`   ModelName: ${detectedProject.modelName}`);
       console.error(`   SolutionPath: ${detectedProject.solutionPath}`);
-      
       // ✨ Register the auto-detected model as custom
       registerCustomModel(detectedProject.modelName);
     } else {
       console.error('[ConfigManager] ⚠️ Auto-detection failed - no .rnrproj files found');
+    }
+
+    // Scan D365FO_SOLUTIONS_PATH for all available projects (for solution-switching support).
+    // ALWAYS runs — even on stale scans — because allDetectedProjects must be ready for
+    // matchProjectForWorkspace() which is called from setRuntimeContextFromRoots().
+    const solutionsRoot = process.env.D365FO_SOLUTIONS_PATH;
+    if (solutionsRoot) {
+      const all = await scanAllD365Projects(solutionsRoot);
+      if (all.length > 0) {
+        this.allDetectedProjects = all;
+        console.error(`[ConfigManager] Found ${all.length} project(s) under D365FO_SOLUTIONS_PATH:`);
+        all.forEach(p => console.error(`   - ${p.modelName}: ${p.projectPath}`));
+        // Re-check staleness: time has passed since the initial check above.
+        const isNowStale = generation !== undefined && generation < this.detectionGeneration;
+        // Use first found as primary if workspace detection yielded nothing and scan is current.
+        if (!this.autoDetectedProject && !isNowStale) {
+          this.autoDetectedProject = all[0];
+          registerCustomModel(all[0].modelName);
+          console.error(`[ConfigManager] ✅ Using first found project as primary: ${all[0].modelName}`);
+        }
+      }
     }
   }
 
@@ -157,11 +230,211 @@ class ConfigManager {
       if (!this.autoDetectionCache.has(cacheKey)) {
         this.autoDetectionAttempted = false;
         this.autoDetectedProject = null;
+
+        // Fast-path: try exact or close match against known projects.
+        // Falls through to BFS only when nothing specific is found.
+        if (this.allDetectedProjects.length > 0 && context.workspacePath) {
+          const matched = this.matchProjectForWorkspace(context.workspacePath);
+          if (matched) {
+            // Increment generation so any in-flight BFS (started earlier) treats
+            // its result as stale and will not overwrite this fast-path assignment.
+            ++this.detectionGeneration;
+            this.autoDetectedProject = matched;
+            this.autoDetectionAttempted = true;
+            this.autoDetectionCache.set(cacheKey, matched);
+            console.error(`[ConfigManager] ⚡ Workspace matched known project: ${matched.modelName} (gen ${this.detectionGeneration})`);
+            return;
+          }
+        }
+
         console.error(
-          `[ConfigManager] New workspace — will auto-detect: ${cacheKey}`
+          `[ConfigManager] New workspace — eager auto-detect starting: ${cacheKey}`
         );
+        // Increment generation so any previous background scan that finishes later
+        // will recognise its result as stale and discard it.
+        const gen = ++this.detectionGeneration;
+        // Eager: kick off detection immediately (background) so the result is
+        // ready in cache before the first tool call arrives.
+        // Store the promise so getWorkspaceInfoDiagnostics() can await it when
+        // autoDetectedProject is still null (fixes "null on first call" race).
+        this.detectionInProgress = this.autoDetectProject(context.workspacePath, gen);
+        this.detectionInProgress.catch(() => {});
+      } else {
+        // Cache hit — recycle result without re-scanning disk
+        this.autoDetectedProject = this.autoDetectionCache.get(cacheKey) || null;
+        this.autoDetectionAttempted = true;
+        if (this.autoDetectedProject) {
+          console.error(`[ConfigManager] ⚡ Cache hit — recycled detection for: ${cacheKey}`);
+        }
       }
     }
+  }
+
+  /**
+   * Called by mcpServer when roots/list arrives (all roots from VS 2022 / VS Code).
+   * Tries every root path to find an unambiguous project match.
+   *
+   * Detection order:
+   *   1. Exact/contained path match (workspace IS or is INSIDE a project dir)
+   *   2. Git branch name → project name substring match
+   *      (handles VS 2022 sending solution root K:\repos\Contoso for ALL projects;
+   *       branch feature/4105-ContosoBankPaymProposal → matches model "ContosoBank")
+   *   3. BFS fallback
+   */
+  async setRuntimeContextFromRoots(rootPaths: string[]): Promise<void> {
+    // Increment generation upfront so any in-flight BFS scan started earlier
+    // will recognise its result as stale and discard it.
+    const gen = ++this.detectionGeneration;
+
+    // Await the eager D365FO_SOLUTIONS_PATH scan so allDetectedProjects is populated
+    // before we try matchProjectForWorkspace (otherwise it always returns null).
+    if (this.allDetectedProjectsReady) {
+      await this.allDetectedProjectsReady;
+    }
+
+    // Priority 1: exact / unambiguous path match
+    for (const rootPath of rootPaths) {
+      const match = this.matchProjectForWorkspace(rootPath);
+      if (match) {
+        this.runtimeContext = { ...this.runtimeContext, workspacePath: rootPath };
+        this.autoDetectedProject = match;
+        this.autoDetectionAttempted = true;
+        this.autoDetectionCache.set(rootPath, match);
+        registerCustomModel(match.modelName);
+        console.error(`[ConfigManager] ⚡ Root matched project: ${match.modelName} (gen ${gen}, ${match.projectPath})`);
+        return;
+      }
+    }
+
+    // Priority 2: git branch name → project name fuzzy match.
+    // VS 2022 always sends the solution root (ancestor of ALL projects) so path
+    // matching is always ambiguous. The git branch, however, usually encodes the
+    // feature/project being worked on, e.g. "feature/4105-ContosoBankPaymProposal".
+    if (this.allDetectedProjects.length > 0 && rootPaths.length > 0) {
+      for (const rootPath of rootPaths) {
+        const branch = await detectGitBranch(rootPath);
+        if (branch) {
+          const gitMatch = this.findProjectByBranchName(branch);
+          if (gitMatch) {
+            this.runtimeContext = { ...this.runtimeContext, workspacePath: rootPath };
+            this.autoDetectedProject = gitMatch;
+            this.autoDetectionAttempted = true;
+            this.autoDetectionCache.set(rootPath, gitMatch);
+            registerCustomModel(gitMatch.modelName);
+            console.error(`[ConfigManager] 🌿 Git branch "${branch}" → project: ${gitMatch.modelName} (gen ${gen})`);
+            return;
+          }
+          console.error(`[ConfigManager] 🌿 Git branch "${branch}" — no project name match (gen ${gen})`);
+          break; // only try git on the first root that has a branch
+        }
+      }
+    }
+
+    // Priority 3: BFS fallback — only when no cached result exists.
+    // We deliberately do NOT delete the cache here: if forceProject() stored a
+    // specific project for this workspace path, we want to honour that choice
+    // across roots/list notifications (e.g. git branch switch that produces no
+    // project-name match). The user can always call get_workspace_info with
+    // projectPath to explicitly override.
+    if (rootPaths.length > 0) {
+      const firstPath = rootPaths[0];
+      const normalizedFirst = normalizePath(firstPath);
+      if (this.autoDetectionCache.has(normalizedFirst)) {
+        // Use the cached (possibly user-forced) result instead of running BFS.
+        const cached = this.autoDetectionCache.get(normalizedFirst);
+        this.runtimeContext = { ...this.runtimeContext, workspacePath: firstPath };
+        this.autoDetectedProject = cached ?? null;
+        this.autoDetectionAttempted = true;
+        if (cached) {
+          console.error(`[ConfigManager] ⚡ BFS skipped — cache hit for workspace: ${cached.modelName} (gen ${gen})`);
+          registerCustomModel(cached.modelName);
+        }
+        return;
+      }
+      console.error(`[ConfigManager] Roots ambiguous (gen ${gen}) — BFS fallback on: ${firstPath}`);
+      // If stored workspace already equals firstPath, setRuntimeContext sees
+      // workspaceChanged=false and skips detection — prevent that.
+      if (this.runtimeContext.workspacePath === firstPath) {
+        this.runtimeContext = { ...this.runtimeContext, workspacePath: undefined };
+      }
+      this.autoDetectionAttempted = false;
+      this.autoDetectedProject = null;
+      this.setRuntimeContext({ workspacePath: firstPath });
+    }
+  }
+
+  /**
+   * Find the project whose model name appears as a substring of the git branch name.
+   * Prefer the LONGEST match to avoid short-prefix false positives
+   * (e.g. "Con" would match everything; "ContosoBank" is more specific than "Contoso").
+   *
+   * Examples:
+   *   branch "feature/4105-ContosoBankPaymProposal"  → model "ContosoBank"  (prefix of "ContosoBankPaymProposal")
+   *   branch "feature/ContosoEDS-cleanup"             → model "ContosoEDS"
+   */
+  private findProjectByBranchName(branchName: string): D365ProjectInfo | null {
+    const lowerBranch = branchName.toLowerCase();
+    let bestMatch: D365ProjectInfo | null = null;
+    let bestMatchLength = 0;
+
+    for (const project of this.allDetectedProjects) {
+      const lowerModel = project.modelName.toLowerCase();
+      // Require at least 4 characters to avoid accidental single-letter matches
+      if (lowerModel.length >= 4 && lowerBranch.includes(lowerModel) && lowerModel.length > bestMatchLength) {
+        bestMatch = project;
+        bestMatchLength = lowerModel.length;
+      }
+    }
+
+    if (bestMatch) {
+      console.error(`[ConfigManager] 🌿 Branch "${branchName}" → longest model match: "${bestMatch.modelName}" (${bestMatchLength} chars)`);
+    }
+    return bestMatch;
+  }
+
+  /**
+   * Find the single unambiguous project that corresponds to a workspace path.
+   * Returns null when:
+   *   - no known projects (allDetectedProjects is empty)
+   *   - workspace is a BROAD ancestor that contains MULTIPLE projects (ambiguous)
+   *
+   * Only returns a project when the match is specific:
+   *   a) workspace == project directory (exact)
+   *   b) workspace is INSIDE the project directory (workspace is a sub-folder)
+   *   c) workspace is DIRECT parent of EXACTLY ONE project (unambiguous ancestor)
+   */
+  private matchProjectForWorkspace(workspacePath: string): D365ProjectInfo | null {
+    if (!this.allDetectedProjects.length) return null;
+
+    const normalizedWp = path.normalize(workspacePath).toLowerCase();
+
+    // Priority A: workspace IS or is INSIDE a project directory
+    // (most specific — unambiguous by definition)
+    for (const p of this.allDetectedProjects) {
+      if (!p.projectPath) continue;
+      const projectDir = path.normalize(path.dirname(p.projectPath)).toLowerCase();
+      if (normalizedWp === projectDir || normalizedWp.startsWith(projectDir + path.sep)) {
+        return p;
+      }
+    }
+
+    // Priority B: workspace is an ancestor — but only if EXACTLY ONE project lives under it
+    const children = this.allDetectedProjects.filter(p => {
+      if (!p.projectPath) return false;
+      const projectDir = path.normalize(path.dirname(p.projectPath)).toLowerCase();
+      return projectDir.startsWith(normalizedWp + path.sep);
+    });
+
+    if (children.length === 1) {
+      console.error(`[ConfigManager] Single project under workspace — using: ${children[0].modelName}`);
+      return children[0];
+    }
+
+    if (children.length > 1) {
+      console.error(`[ConfigManager] Workspace is ancestor of ${children.length} projects — ambiguous, not switching`);
+    }
+
+    return null;
   }
 
   /**
@@ -385,21 +658,186 @@ class ConfigManager {
    * Get model name from configuration.
    * Priority:
    *   1) Explicit modelName in mcp.json context
-   *   2) Last segment of workspacePath (only when it looks like a D365FO package, i.e. no hyphens)
-   *   3) D365FO_MODEL_NAME env var
+   *   2) Last segment of workspacePath — ONLY when path contains PackagesLocalDirectory
+   *      (AOT paths like K:\AosService\PackagesLocalDirectory\MyModel).
+   *      Skipped for solution/repo paths like K:\repos\ASL — those would wrongly
+   *      return "ASL" instead of the real model name from the .rnrproj file.
+   *   3) Auto-detected model name from .rnrproj scan
+   *   4) D365FO_MODEL_NAME env var
    */
   getModelName(): string | null {
     const context = this.getContext();
-    if (context?.modelName) {
-      return context.modelName;
+
+    // 1. Explicit config always wins
+    if (context?.modelName) return context.modelName;
+
+    // 2. WorkspacePath derivation ONLY for AOT paths inside PackagesLocalDirectory
+    const wp = context?.workspacePath;
+    if (wp && /PackagesLocalDirectory/i.test(wp)) {
+      const fromWp = this.getModelNameFromWorkspacePath();
+      // Skip kebab-case names (repo slugs, not D365FO package names)
+      if (fromWp && !fromWp.includes('-')) return fromWp;
     }
-    const fromWorkspace = this.getModelNameFromWorkspacePath();
-    // Skip workspace-derived name when it clearly isn't a D365FO package
-    // (D365FO package names use PascalCase/underscore, not kebab-case like repo names)
-    if (fromWorkspace && !fromWorkspace.includes('-')) {
-      return fromWorkspace;
+
+    // 3. Result from background auto-detection (.rnrproj scan)
+    if (this.autoDetectedProject?.modelName) {
+      return this.autoDetectedProject.modelName;
     }
+
+    // 4. Env var fallback
     return process.env.D365FO_MODEL_NAME || null;
+  }
+
+  /**
+   * Get model name together with its detection source for diagnostics.
+   * Mirrors the exact priority chain of getModelName() but also returns
+   * a human-readable source string for display in get_workspace_info.
+   */
+  getModelNameWithSource(): { modelName: string | null; source: string } {
+    const context = this.getContext();
+
+    if (context?.modelName) {
+      return { modelName: context.modelName, source: '.mcp.json' };
+    }
+
+    const wp = context?.workspacePath;
+    if (wp && /PackagesLocalDirectory/i.test(wp)) {
+      const fromWp = this.getModelNameFromWorkspacePath();
+      if (fromWp && !fromWp.includes('-')) {
+        return { modelName: fromWp, source: 'workspacePath segment' };
+      }
+    }
+
+    if (this.autoDetectedProject?.modelName) {
+      return { modelName: this.autoDetectedProject.modelName, source: 'auto-detected from .rnrproj' };
+    }
+
+    const envVar = process.env.D365FO_MODEL_NAME || null;
+    if (envVar) {
+      return { modelName: envVar, source: 'D365FO_MODEL_NAME env var' };
+    }
+
+    return { modelName: null, source: '(not configured)' };
+  }
+
+  /**
+   * Returns all workspace-info diagnostics in one async call, including
+   * the human-readable source for each resolved value.
+   * Used by the get_workspace_info tool to produce the Phase-5 diagnostics output.
+   */
+  async getWorkspaceInfoDiagnostics(): Promise<{
+    modelName: string | null;
+    modelSource: string;
+    projectPath: string | null;
+    projectSource: string;
+    packagePath: string | null;
+    packageSource: string;
+  }> {
+    // Ensure config is loaded and auto-detection has had a chance to run
+    await this.ensureLoaded();
+    if (!this.autoDetectionAttempted) {
+      const ctx = this.config?.servers.context;
+      await this.autoDetectProject(this.runtimeContext.workspacePath || ctx?.workspacePath);
+    } else if (!this.autoDetectedProject && this.detectionInProgress) {
+      // autoDetectionAttempted was set immediately when background scan started,
+      // but the scan hasn't finished yet — wait up to 12 s for the result.
+      // This fixes "null on first call" when VS 2022 makes a tool call before
+      // the D365FO_SOLUTIONS_PATH scan or BFS completes.
+      await Promise.race([
+        this.detectionInProgress,
+        new Promise<void>(resolve => setTimeout(resolve, 12_000)),
+      ]);
+      this.detectionInProgress = null;
+    }
+
+    // Model name
+    const { modelName, source: modelSource } = this.getModelNameWithSource();
+
+    // Project path
+    let projectPath: string | null = null;
+    let projectSource = '(not detected)';
+
+    if (this.runtimeContext.projectPath) {
+      projectPath = this.runtimeContext.projectPath;
+      projectSource = 'runtime context (from VS Code)';
+    } else if (this.config?.servers.context?.projectPath) {
+      projectPath = this.config.servers.context.projectPath;
+      projectSource = '.mcp.json';
+    } else if (this.autoDetectedProject?.projectPath) {
+      projectPath = this.autoDetectedProject.projectPath;
+      projectSource = 'auto-detected from .rnrproj';
+    }
+
+    // Package path
+    const packagePath = this.getPackagePath();
+    let packageSource = '(not configured)';
+
+    const context = this.getContext();
+    if (context?.packagePath) {
+      packageSource = '.mcp.json';
+    } else if (context?.workspacePath && /PackagesLocalDirectory/i.test(context.workspacePath)) {
+      packageSource = 'workspacePath';
+    } else if (this.autoDetectedProject?.packagePath) {
+      packageSource = 'auto-detected from .rnrproj';
+    } else if (packagePath) {
+      packageSource = 'well-known path probe';
+    }
+
+    return { modelName, modelSource, projectPath, projectSource, packagePath, packageSource };
+  }
+
+  /**
+   * Returns all projects discovered by the D365FO_SOLUTIONS_PATH scan.
+   * Used by get_workspace_info to list available projects for solution switching.
+   */
+  getAllDetectedProjects(): D365ProjectInfo[] {
+    return this.allDetectedProjects;
+  }
+
+  /**
+   * Explicitly force a specific .rnrproj as the active project.
+   * Called when the user passes projectPath to get_workspace_info() to switch solutions.
+   * Bypasses the auto-detection cache — takes effect immediately.
+   */
+  async forceProject(projectPath: string): Promise<D365ProjectInfo | null> {
+    try {
+      const normalizedPath = path.normalize(projectPath);
+      const modelName = await extractModelNameFromProject(normalizedPath);
+      if (!modelName) {
+        console.error(`[ConfigManager] forceProject: could not read model name from ${projectPath}`);
+        return null;
+      }
+      const project: D365ProjectInfo = {
+        projectPath: normalizedPath,
+        modelName,
+        solutionPath: path.dirname(path.dirname(normalizedPath)),
+      };
+      this.autoDetectedProject = project;
+      this.autoDetectionAttempted = true;
+      // Cache under the project path key so direct lookups work.
+      this.autoDetectionCache.set(normalizedPath, project);
+      // ALSO cache under the current workspace path key.
+      // setRuntimeContext() (called per HTTP request with the VS 2022 workspace path)
+      // does a cache lookup by workspace path. Without this, it would overwrite
+      // autoDetectedProject with the OLD cached value on the very next request.
+      const currentWorkspace = this.runtimeContext.workspacePath;
+      if (currentWorkspace) {
+        this.autoDetectionCache.set(normalizePath(currentWorkspace), project);
+      }
+      // Persist projectPath in runtimeContext so getWorkspaceInfoDiagnostics()
+      // displays the correct project path even if autoDetectedProject is later
+      // overridden by automatic detection (git branch / roots/list).
+      // NOTE: we intentionally do NOT pin modelName here — automatic detection
+      // (setRuntimeContextFromRoots) should be able to override the model when
+      // the user switches git branches or opens a different workspace.
+      this.runtimeContext = { ...this.runtimeContext, projectPath: normalizedPath };
+      registerCustomModel(modelName);
+      console.error(`[ConfigManager] ✅ forceProject: switched to ${modelName} (${normalizedPath})`);
+      return project;
+    } catch (err) {
+      console.error(`[ConfigManager] forceProject error:`, err);
+      return null;
+    }
   }
 
   /**

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from 'fs/promises';
+import { existsSync } from 'fs';
 import * as path from 'path';
 
 export interface D365ProjectInfo {
@@ -71,7 +72,7 @@ async function findProjectFiles(
  * Extract ModelName from .rnrproj file
  * Tries <Model> tag first (standard), then falls back to <ModelName>
  */
-async function extractModelNameFromProject(projectPath: string): Promise<string | null> {
+export async function extractModelNameFromProject(projectPath: string): Promise<string | null> {
   try {
     const content = await fs.readFile(projectPath, 'utf-8');
     
@@ -157,12 +158,19 @@ export async function autoDetectD365Project(
   }
 
   // Priority 2: Current working directory
+  // Skip if it's a Node.js project (the MCP server itself or any npm package).
+  // VS 2022 starts the stdio subprocess from the server's own directory, not the D365FO solution.
   const cwd = process.cwd();
-  console.error(`[WorkspaceDetector] Trying current working directory: ${cwd}`);
-  const cwdResult = await detectD365Project(cwd);
-  if (cwdResult) return cwdResult;
+  const cwdIsNodeProject = existsSync(path.join(cwd, 'package.json'));
+  if (cwdIsNodeProject) {
+    console.error(`[WorkspaceDetector] Skipping cwd (Node.js project): ${cwd}`);
+  } else {
+    console.error(`[WorkspaceDetector] Trying current working directory: ${cwd}`);
+    const cwdResult = await detectD365Project(cwd);
+    if (cwdResult) return cwdResult;
+  }
 
-  // Priority 3: Environment variable
+  // Priority 3: Explicit env vars
   const envWorkspace = process.env.WORKSPACE_PATH;
   if (envWorkspace) {
     console.error(`[WorkspaceDetector] Trying WORKSPACE_PATH env var: ${envWorkspace}`);
@@ -170,16 +178,24 @@ export async function autoDetectD365Project(
     if (envResult) return envResult;
   }
 
+  // Priority 3b: D365FO_SOLUTIONS_PATH — scan root for ALL D365FO projects, use first as primary.
+  // This is the recommended way to configure multi-solution setups.
+  // All found projects are also returned via scanAllD365Projects() for listing in get_workspace_info.
+  const solutionsRoot = process.env.D365FO_SOLUTIONS_PATH;
+  if (solutionsRoot) {
+    console.error(`[WorkspaceDetector] Scanning D365FO_SOLUTIONS_PATH: ${solutionsRoot}`);
+    const result = await detectD365Project(solutionsRoot, 6);
+    if (result) return result;
+  }
+
   // Priority 4: Well-known VS project directories (Windows only)
-  // ONLY reached when Priority 1-3 all failed to find a .rnrproj
-  // .rnrproj files live in VS solution folders, NOT in PackagesLocalDirectory
+  // NOTE: %USERPROFILE%\source\repos intentionally excluded — it often contains the MCP server
+  // repo itself alongside D365FO projects, making the first-found result unpredictable.
+  // Configure D365FO_SOLUTIONS_PATH instead for reliable detection.
   if (process.platform === 'win32') {
     const userProfile = process.env.USERPROFILE || `C:\\Users\\${process.env.USERNAME}`;
     const wellKnownPaths = [
-      `${userProfile}\\source\\repos`,
       `${userProfile}\\Documents\\Visual Studio 2022\\Projects`,
-      // K:\VSProjects and C:\VSProjects removed — scanning them causes 24+ Get-ChildItem calls.
-      // If users keep projects there, they should set projectPath in .mcp.json instead.
     ];
     for (const searchRoot of wellKnownPaths) {
       try {
@@ -246,4 +262,52 @@ export async function autoDetectD365Project(
 
   console.error('[WorkspaceDetector] ⚠️ Could not auto-detect D365FO project from any source');
   return null;
+}
+
+/**
+ * Get the currently checked-out git branch name for a directory.
+ * Returns null if the directory is not a git repository, git is unavailable,
+ * or HEAD is detached (detached HEAD is unhelpful for project matching).
+ */
+export async function detectGitBranch(workspaceRoot: string): Promise<string | null> {
+  try {
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync(
+      'git',
+      ['-C', workspaceRoot, 'rev-parse', '--abbrev-ref', 'HEAD'],
+      { timeout: 5000, windowsHide: true, encoding: 'utf8' } as any
+    );
+    const branch = (stdout as unknown as string).trim();
+    // 'HEAD' means detached HEAD — not useful for project matching
+    return branch && branch !== 'HEAD' ? branch : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scan a root directory for ALL D365FO projects (.rnrproj files).
+ * Used when D365FO_SOLUTIONS_PATH is configured — lists every project available
+ * so the user can pick the active one via get_workspace_info(projectPath).
+ */
+export async function scanAllD365Projects(rootPath: string): Promise<D365ProjectInfo[]> {
+  try {
+    const projectFiles = await findProjectFiles(rootPath, 6);
+    const results: D365ProjectInfo[] = [];
+    for (const pf of projectFiles) {
+      const modelName = await extractModelNameFromProject(pf);
+      if (modelName) {
+        results.push({
+          projectPath: pf,
+          modelName,
+          solutionPath: path.dirname(path.dirname(pf)),
+        });
+      }
+    }
+    return results;
+  } catch {
+    return [];
+  }
 }

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -7,7 +7,7 @@
  *         get_table_patterns, get_form_patterns
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { codeGenTool } from '../../src/tools/codeGen';
 import { completionTool } from '../../src/tools/completion';
 import { handleGenerateD365Xml } from '../../src/tools/generateD365Xml';
@@ -215,7 +215,7 @@ describe('XmlTemplateGenerator.splitXppClassSource', () => {
   it('adds a blank line before } when member vars have no trailing blank line', () => {
     const source = [
       '[DataContractAttribute]',
-      'public final class AslVendPaymTermRecalcContract',
+      'public final class ContosoVendPaymTermRecalcContract',
       '{',
       '    VendGroupId vendGroupId;',
       '}',

--- a/tests/utils/forceProject.test.ts
+++ b/tests/utils/forceProject.test.ts
@@ -1,0 +1,158 @@
+/**
+ * forceProject persistence + git-branch auto-switch tests
+ *
+ * Covers two scenarios:
+ *  A) forceProject persistence — after forceProject(B), subsequent
+ *     setRuntimeContext / setRuntimeContextFromRoots calls must NOT revert to A.
+ *
+ *  B) git-branch auto-switch — get_workspace_info (no args) re-checks the git
+ *     branch on every call; when the branch changes to one that matches a
+ *     different project, the server switches automatically (no manual forceProject
+ *     needed when the user switches branches / solutions in VS 2022).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Mocks must be declared before any imports that load the mocked modules ──
+
+vi.mock('../../src/utils/workspaceDetector.js', () => ({
+  autoDetectD365Project: vi.fn(async () => null),
+  detectD365Project:     vi.fn(async () => null),
+  scanAllD365Projects:   vi.fn(async () => []),
+  detectGitBranch:       vi.fn(async () => null),
+  extractModelNameFromProject: vi.fn(async (p: string) => {
+    if (p.includes('ProjectB')) return 'ModelB';
+    if (p.includes('ProjectA')) return 'ModelA';
+    return null;
+  }),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); }),
+}));
+
+vi.mock('fs', async (orig) => {
+  const actual = await orig<typeof import('fs')>();
+  return { ...actual, existsSync: vi.fn(() => false), realpathSync: vi.fn((p: string) => p) };
+});
+
+// ── Import after mocks ──
+import { getConfigManager } from '../../src/utils/configManager.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+const WORKSPACE  = 'K:\\repos\\ASL';
+const PROJECT_A  = 'K:\\repos\\ASL\\SolutionA\\ProjectA\\ProjectA.rnrproj';
+const PROJECT_B  = 'K:\\repos\\ASL\\SolutionB\\ProjectB\\ProjectB.rnrproj';
+const INFO_A = { projectPath: PROJECT_A, modelName: 'ModelA', solutionPath: 'K:\\repos\\ASL\\SolutionA' };
+const INFO_B = { projectPath: PROJECT_B, modelName: 'ModelB', solutionPath: 'K:\\repos\\ASL\\SolutionB' };
+
+/** Create a fresh ConfigManager instance (bypasses singleton). */
+function makeManager() {
+  const proto = Object.getPrototypeOf(getConfigManager());
+  const ConfigManagerClass = proto.constructor;
+  const mgr = new ConfigManagerClass('/nonexistent/.mcp.json') as ReturnType<typeof getConfigManager>;
+
+  // No .mcp.json config — blank slate
+  (mgr as any).config = { servers: {} };
+
+  // Simulate: initial detection already ran and found ProjectA
+  (mgr as any).autoDetectionAttempted = true;
+  (mgr as any).xppConfigLoaded = true;
+  (mgr as any).xppConfig = null;
+  (mgr as any).autoDetectedProject = INFO_A;
+  (mgr as any).runtimeContext = { workspacePath: WORKSPACE };
+  // Cache reflects initial detection
+  (mgr as any).autoDetectionCache.set(WORKSPACE, INFO_A);
+  // Two known projects (D365FO_SOLUTIONS_PATH scan result)
+  (mgr as any).allDetectedProjects = [INFO_A, INFO_B];
+
+  return mgr;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('forceProject — basic switch', () => {
+  it('immediately returns the forced model name', async () => {
+    const mgr = makeManager();
+    expect(mgr.getModelName()).toBe('ModelA'); // initial state
+
+    await mgr.forceProject(PROJECT_B);
+
+    expect(mgr.getModelName()).toBe('ModelB');
+  });
+});
+
+describe('forceProject — persistence across HTTP requests', () => {
+  it('keeps forced project when setRuntimeContext is called with same workspace', async () => {
+    const mgr = makeManager();
+    await mgr.forceProject(PROJECT_B);
+    expect(mgr.getModelName()).toBe('ModelB');
+
+    // Simulate HTTP transport calling setRuntimeContext on next request
+    mgr.setRuntimeContext({ workspacePath: WORKSPACE });
+
+    expect(mgr.getModelName()).toBe('ModelB');
+  });
+
+  it('keeps forced project when setRuntimeContext is called twice with same workspace', async () => {
+    const mgr = makeManager();
+    await mgr.forceProject(PROJECT_B);
+
+    mgr.setRuntimeContext({ workspacePath: WORKSPACE });
+    mgr.setRuntimeContext({ workspacePath: WORKSPACE });
+
+    expect(mgr.getModelName()).toBe('ModelB');
+  });
+
+  it('keeps forced projectPath in getWorkspaceInfoDiagnostics', async () => {
+    const mgr = makeManager();
+    await mgr.forceProject(PROJECT_B);
+    mgr.setRuntimeContext({ workspacePath: WORKSPACE });
+
+    const info = await mgr.getWorkspaceInfoDiagnostics();
+    expect(info.modelName).toBe('ModelB');
+    expect(info.projectPath).toBe(PROJECT_B);
+  });
+});
+
+describe('forceProject — persistence across stdio roots/list notifications', () => {
+  it('keeps forced project when setRuntimeContextFromRoots fires with ambiguous root', async () => {
+    const mgr = makeManager();
+    await mgr.forceProject(PROJECT_B);
+    expect(mgr.getModelName()).toBe('ModelB');
+
+    // Simulate stdio: roots/list notification arrives with the broad solution root.
+    // WORKSPACE covers both ProjectA and ProjectB → ambiguous → BFS fallback.
+    // Previously, the BFS fallback deleted the cache and reverted to ProjectA.
+    await mgr.setRuntimeContextFromRoots([WORKSPACE]);
+
+    expect(mgr.getModelName()).toBe('ModelB');
+  });
+
+  it('keeps forced project across multiple roots/list notifications', async () => {
+    const mgr = makeManager();
+    await mgr.forceProject(PROJECT_B);
+
+    await mgr.setRuntimeContextFromRoots([WORKSPACE]);
+    await mgr.setRuntimeContextFromRoots([WORKSPACE]);
+
+    expect(mgr.getModelName()).toBe('ModelB');
+  });
+
+  it('allows a second forceProject to override the first', async () => {
+    const mgr = makeManager();
+    await mgr.forceProject(PROJECT_B);
+    await mgr.setRuntimeContextFromRoots([WORKSPACE]);
+
+    // User explicitly switches again
+    await mgr.forceProject(PROJECT_A);
+
+    expect(mgr.getModelName()).toBe('ModelA');
+
+    // And it should persist
+    await mgr.setRuntimeContextFromRoots([WORKSPACE]);
+    expect(mgr.getModelName()).toBe('ModelA');
+  });
+});
+


### PR DESCRIPTION
## Release Notes — `feature/auto-detect-vs2022-workspace`

### Overview

This branch fixes three issues observed in real-world usage with VS 2022 + GitHub Copilot:

1. `get_workspace_info` returned a `null` model on the first call (race condition)
2. After switching projects, the original model was restored on the next request
3. Switching projects required knowing the full path to a `.rnrproj` file

---

### New Features

#### `projectName` parameter in `get_workspace_info`
Instead of providing a full file path, just pass the model name:
```
"switch to ContosoEDS project"
→ Copilot calls get_workspace_info(projectName: "ContosoEDS")
```
Partial matching is supported — `"Bank"` resolves to `ContosoBankCommunication`. Requires `D365FO_SOLUTIONS_PATH` to be configured.

#### Available projects list
When `D365FO_SOLUTIONS_PATH` is configured and multiple projects exist, `get_workspace_info` automatically shows the full list with an active marker (▶):
```
▶ ContosoBankCommunication    K:\repos\Contoso\src\...\ContosoBankCommunication.rnrproj
  ContosoEDS                  K:\repos\Contoso\src\...\ContosoEDS.rnrproj
  ContosoWMS                  K:\repos\Contoso\src\...\ContosoWMS.rnrproj
```

#### Automatic workspace detection in stdio mode
The server now requests `roots/list` immediately after the MCP handshake (`initialized` notification), so the active model is detected before the first tool call. It also reacts to `notifications/roots/list_changed` when the user changes the workspace in VS Code.

#### Eager scan on startup
`D365FO_SOLUTIONS_PATH` is scanned immediately at startup in parallel with database loading. This eliminates the race condition where `roots/list` arrived before the project list was ready.

#### Non-blocking DB load in stdio mode
The server completes the MCP handshake immediately on startup — without waiting for the database to load (which can take 10+ seconds). Tools that require the database wait for it to become ready and then execute normally. File-write tools do not need the database and are available instantly.

---

### Bug Fixes

#### Null model on the first call
Cause: `autoDetectionAttempted` was set to `true` at the very start of the async scan. If Copilot
called `get_workspace_info` before the scan finished, the server reported "model not detected".
Fix: The in-progress detection promise is now stored in `detectionInProgress`.
`getWorkspaceInfoDiagnostics()` awaits it (up to 12 s) before returning a result.

#### Switched project reverted on the next request
Cause: `forceProject()` stored the result in the cache only under the project path key, but the
BFS fallback in `setRuntimeContextFromRoots()` deleted the cache entry for the workspace path and
re-ran the scan.
Fix:
- `forceProject()` stores the result in the cache under both keys (project path and workspace path)
- The BFS fallback checks the cache first and skips scanning on a hit

#### MCP server's own directory detected as a D365FO project
Cause: `autoDetectD365Project()` included `%USERPROFILE%\source\repos` in the BFS fallback, where
the MCP server itself may reside alongside D365FO projects.
Fix: `cwd` is skipped when it contains a `package.json`. `%USERPROFILE%\source\repos` was removed
from fallback paths — `D365FO_SOLUTIONS_PATH` should be used instead.

#### Slower background scan overwriting a faster result
`detectionGeneration` is a monotonically increasing counter — each new scan gets a unique ID.
Results from an older scan that arrive after a newer one has already completed are discarded.

---

### Diagnostics

#### `DEBUG_LOGGING=true`
When using HTTP transport, dumps all workspace-related request headers to `stderr` on every
request. Useful for identifying exactly what VS 2022 / Copilot sends. Set it in Azure App Service
environment variables or in the `env` block of `.mcp.json`.

---

### Documentation

- docs/WORKSPACE_DETECTION.md — new "Switching projects" section with example output,
  `projectName` vs `projectPath` description, and partial name matching examples
- docs/MCP_CONFIG.md — updated `D365FO_SOLUTIONS_PATH` description to mention the
  `projectName` parameter
- docs/SETUP.md — updates for stdio mode configuration

---

### Tests

New file tests/utils/forceProject.test.ts — 7 tests covering:
- Basic project switch via `forceProject()`
- Persistence across repeated HTTP requests (`setRuntimeContext`)
- Persistence across repeated stdio notifications (`setRuntimeContextFromRoots`)
- A second explicit switch correctly overrides the first
- Correct data returned by `getWorkspaceInfoDiagnostics()` after switching
