### PR TITLE
feat: enhance EDT type handling and extension infix derivation in cod…

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -30,6 +30,7 @@ If you are responsible for deploying the server infrastructure to Azure, see [SE
 | Visual Studio 2022 | 17.14 | Earlier versions do not support MCP |
 | GitHub Copilot extension | Latest | Requires an active Copilot subscription |
 | Node.js | 24.x LTS | Required for hybrid setup only |
+| Python | 3.x | Required for hybrid setup only — used by `node-gyp` to compile native SQLite addon |
 | Git | Any | Required for hybrid setup only |
 
 ---

--- a/docs/SETUP_AZURE.md
+++ b/docs/SETUP_AZURE.md
@@ -25,6 +25,7 @@ If you are a developer who only wants to **use** an existing server, see [SETUP.
 
 - **Azure CLI** installed and logged in (`az login`)
 - **Node.js** 24.x LTS (for building the application and metadata)
+- **Python** 3.x (required by `node-gyp` to compile the native SQLite addon during `npm install`)
 - **Git**
 - An Azure subscription with permissions to create App Service, Storage Account, and optionally Redis
 

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -5,7 +5,7 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import { resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
+import { resolveObjectPrefix, applyObjectPrefix, deriveExtensionInfix } from '../utils/modelClassifier.js';
 import { getConfigManager } from '../utils/configManager.js';
 
 const CodeGenArgsSchema = z.object({
@@ -427,6 +427,8 @@ export async function codeGenTool(request: CallToolRequest) {
     // Resolve prefix: EXTENSION_PREFIX env var (stripped of trailing '_') or modelName arg → mcp.json → empty
     const resolvedModelName = args.modelName || getConfigManager().getModelName() || '';
     const prefix = resolveObjectPrefix(resolvedModelName);
+    // Extension infix: PascalCase form without underscore (e.g. "XY" → "Xy" when env has "XY_")
+    const extensionInfix = deriveExtensionInfix(prefix);
 
     let code: string;
     let displayName: string;
@@ -476,7 +478,7 @@ export async function codeGenTool(request: CallToolRequest) {
           isError: true,
         };
       }
-      code = extTemplate(baseName, prefix);
+      code = extTemplate(baseName, extensionInfix);
       displayName = baseName;
 
       if (args.pattern === 'event-handler') {
@@ -486,10 +488,10 @@ export async function codeGenTool(request: CallToolRequest) {
       } else {
         const exampleClass =
           args.pattern === 'table-extension'
-            ? `${baseName}${prefix}_Extension`
-            : `${baseName}${prefix}Form_Extension`;
-        namingNote = prefix
-          ? `📌 **Naming (MS guidelines):** Generated class: \`${exampleClass}\`\n  Base element: \`${baseName}\`, Prefix infix: \`${prefix}\``
+            ? `${baseName}${extensionInfix}_Extension`
+            : `${baseName}${extensionInfix}Form_Extension`;
+        namingNote = extensionInfix
+          ? `📌 **Naming (MS guidelines):** Generated class: \`${exampleClass}\`\n  Base element: \`${baseName}\`, Prefix infix: \`${extensionInfix}\``
           : `⚠️ **No prefix resolved** — set \`EXTENSION_PREFIX\` env var or pass \`modelName\` argument.\n  Generated bare name without prefix infix (e.g. \`${baseName}_Extension\`) which is **not MS-compliant**.`;
       }
     } else {

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -2160,9 +2160,27 @@ ${defaultParamGroupXml}
   /**
    * Generate AxEdt XML (Extended Data Type).
    * Default i:type is AxEdtString; override via properties.edtType.
+   * Accepts either the full AxEdt* form or a plain base-type name
+   * (string → AxEdtString, integer/int → AxEdtInt, int64 → AxEdtInt64,
+   *  real → AxEdtReal, date → AxEdtDate, datetime/utcdatetime → AxEdtUtcDateTime,
+   *  enum → AxEdtEnum, guid → AxEdtGuid, container → AxEdtContainer).
    */
   static generateAxEdtXml(name: string, properties?: Record<string, any>): string {
-    const edtType = properties?.edtType || 'AxEdtString';
+    const edtTypeRaw = properties?.edtType || 'AxEdtString';
+    const edtTypeNormMap: Record<string, string> = {
+      string:      'AxEdtString',
+      integer:     'AxEdtInt',
+      int:         'AxEdtInt',
+      int64:       'AxEdtInt64',
+      real:        'AxEdtReal',
+      date:        'AxEdtDate',
+      datetime:    'AxEdtUtcDateTime',
+      utcdatetime: 'AxEdtUtcDateTime',
+      enum:        'AxEdtEnum',
+      guid:        'AxEdtGuid',
+      container:   'AxEdtContainer',
+    };
+    const edtType = edtTypeNormMap[edtTypeRaw.toLowerCase()] ?? edtTypeRaw;
     const label = properties?.label || '@TODO:LabelId';
     const extends_ = properties?.extends ? `\n\t<Extends>${properties.extends}</Extends>` : '';
     const stringSize = edtType === 'AxEdtString'

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -1061,7 +1061,21 @@ ${defaultParamGroupXml}
   }
 
   static generateAxEdtXml(name: string, properties?: Record<string, any>): string {
-    const edtType = properties?.edtType || 'AxEdtString';
+    const edtTypeRaw = properties?.edtType || 'AxEdtString';
+    const edtTypeNormMap: Record<string, string> = {
+      string:      'AxEdtString',
+      integer:     'AxEdtInt',
+      int:         'AxEdtInt',
+      int64:       'AxEdtInt64',
+      real:        'AxEdtReal',
+      date:        'AxEdtDate',
+      datetime:    'AxEdtUtcDateTime',
+      utcdatetime: 'AxEdtUtcDateTime',
+      enum:        'AxEdtEnum',
+      guid:        'AxEdtGuid',
+      container:   'AxEdtContainer',
+    };
+    const edtType = edtTypeNormMap[edtTypeRaw.toLowerCase()] ?? edtTypeRaw;
     const label = properties?.label || '@TODO:LabelId';
     const extends_ = properties?.extends ? `\n\t<Extends>${properties.extends}</Extends>` : '';
     const stringSize = edtType === 'AxEdtString'

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1181,6 +1181,40 @@ async function modifyProperty(xmlObj: any, objectType: string, args: any): Promi
     throw new Error('propertyValue is required for modify-property operation');
   }
 
+  // Special case: changing the base type of an EDT (i:type XML attribute on the root element).
+  // Accepted aliases: BaseType / i:type / edtType — all map to the same XML attribute.
+  const edtTypeAliases = new Set(['basetype', 'i:type', 'edttype']);
+  if (objectType === 'edt' && edtTypeAliases.has(propertyPath.toLowerCase())) {
+    const edtTypeNormMap: Record<string, string> = {
+      string:      'AxEdtString',
+      integer:     'AxEdtInt',
+      int:         'AxEdtInt',
+      int64:       'AxEdtInt64',
+      real:        'AxEdtReal',
+      date:        'AxEdtDate',
+      datetime:    'AxEdtUtcDateTime',
+      utcdatetime: 'AxEdtUtcDateTime',
+      enum:        'AxEdtEnum',
+      guid:        'AxEdtGuid',
+      container:   'AxEdtContainer',
+    };
+    const normalizedValue = edtTypeNormMap[propertyValue.toLowerCase()] ?? propertyValue;
+    const rootKey = getRootKey(objectType);
+    const root = xmlObj[rootKey];
+    if (!root) {
+      throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
+    }
+    if (!root['$']) {
+      root['$'] = {};
+    }
+    root['$']['i:type'] = normalizedValue;
+    // Also update StringSize presence: AxEdtString needs it, others should not have it
+    if (normalizedValue !== 'AxEdtString') {
+      delete root['StringSize'];
+    }
+    return true;
+  }
+
   // Parse property path (e.g., "Table1.Visible")
   const parts = propertyPath.split('.');
   

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -82,13 +82,39 @@ export function resolveObjectPrefix(modelName: string): string {
 }
 
 /**
+ * Derive the extension infix form from an already-resolved prefix.
+ *
+ * Extension elements (dot-notation and _Extension classes) embed the prefix
+ * as a PascalCase infix WITHOUT any underscore separator:
+ *   - Underscore-style EXTENSION_PREFIX "XY_"  → resolved prefix "XY"  → infix "Xy"
+ *   - Normal prefix "Contoso"                  → resolved prefix "Contoso" → infix "Contoso"
+ *   - All-caps prefix "WHS" with "WHS_" in env → infix "Whs"
+ *   - All-caps prefix "WHS" with "WHS" in env  → infix "WHS" (unchanged)
+ *
+ * Detection: if EXTENSION_PREFIX env var ends with '_', apply first-upper + rest-lower.
+ */
+export function deriveExtensionInfix(resolvedPrefix: string): string {
+  if (!resolvedPrefix) return '';
+  const rawEnvPrefix = process.env.EXTENSION_PREFIX?.trim() ?? '';
+  const envHasUnderscore = rawEnvPrefix.endsWith('_');
+  if (envHasUnderscore) {
+    // XY_ → Xy  (first char uppercase, remaining chars lowercase)
+    return resolvedPrefix.charAt(0).toUpperCase() + resolvedPrefix.slice(1).toLowerCase();
+  }
+  // Normal PascalCase — just capitalize first letter, keep the rest as-is
+  return resolvedPrefix.charAt(0).toUpperCase() + resolvedPrefix.slice(1);
+}
+
+/**
  * Apply prefix to a NEW model element name.
  * Per MS guidelines, the prefix is concatenated directly (no separator):
  *   WHSMyTable, MyPrefixMyClass, ContosoMyForm
  *
- * SPECIAL CASE: For extension classes ending with "_Extension",
- * the prefix goes BEFORE "_Extension" as a suffix:
- *   SalesFormLetterContoso_Extension (not ContosoSalesFormLetter_Extension)
+ * Underscore-style prefixes (EXTENSION_PREFIX="XY_") are handled specially:
+ *   - Regular objects (classes, tables, forms, …): prefix kept with underscore
+ *       XY_CustTable, XY_MyClass  (NOT XyCustTable)
+ *   - Extension elements (dot-notation or _Extension class infix): PascalCase, no underscore
+ *       CustTable.XyExtension, CustTableXy_Extension  (NOT CustTable.XY_Extension)
  *
  * CRITICAL for extension classes: If EXTENSION_PREFIX is set in .env,
  * it should be used EXCLUSIVELY - never combined with modelName prefix.
@@ -99,53 +125,64 @@ export function resolveObjectPrefix(modelName: string): string {
  */
 export function applyObjectPrefix(objectName: string, prefix: string): string {
   if (!prefix) return objectName;
-  
-  // Capitalize first letter of prefix (e.g. "whs" → "Whs", "WHS" stays "WHS", "contoso" → "Contoso")
-  const normalizedPrefix = prefix.charAt(0).toUpperCase() + prefix.slice(1);
-  
+
+  // Extension infix form — PascalCase without underscore (e.g. "XY" → "Xy" when env had "XY_")
+  const extensionInfix = deriveExtensionInfix(prefix);
+
+  // Regular object prefix — keep underscore for underscore-style prefixes
+  //   EXTENSION_PREFIX="XY_" → rawEnvPrefix="XY_" → regularPrefix="XY_" → XY_CustTable
+  //   EXTENSION_PREFIX="Contoso" → regularPrefix="Contoso" → ContosoCustTable
+  const rawEnvPrefix = process.env.EXTENSION_PREFIX?.trim() ?? '';
+  const envHasUnderscore = rawEnvPrefix.endsWith('_');
+  const regularPrefix = envHasUnderscore
+    ? rawEnvPrefix                                         // keep "XY_" as-is
+    : prefix.charAt(0).toUpperCase() + prefix.slice(1);   // normalize PascalCase
+
   // SPECIAL CASE A: Dot-notation extension elements — BaseElement.PrefixExtension
-  // For table/form/EDT/enum/menu-item extensions: "CustTable.MyExtension", "HCMWorker.ContosoExtension"
-  // The suffix after the dot is always {Prefix}Extension. Replace any stale prefix with the correct one.
-  // Example: "CustTable.MyModelExtension" + prefix "My" → "CustTable.MyExtension"
+  // For table/form/EDT/enum extensions: "CustTable.XyExtension", "HCMWorker.ContosoExtension"
+  // The suffix after the dot is always {ExtensionInfix}Extension.
   if (objectName.includes('.') && objectName.toLowerCase().endsWith('extension')) {
     const dotIdx = objectName.lastIndexOf('.');
     const basePart = objectName.slice(0, dotIdx);    // e.g., "CustTable"
     const suffixPart = objectName.slice(dotIdx + 1); // e.g., "MyModelExtension"
-    const correctSuffix = `${normalizedPrefix}Extension`;
+    const correctSuffix = `${extensionInfix}Extension`;
     if (suffixPart.toLowerCase() === correctSuffix.toLowerCase()) {
-      return objectName; // Already has the correct prefix suffix, return as-is
+      return objectName; // Already has the correct extension suffix, return as-is
     }
     return `${basePart}.${correctSuffix}`;
   }
 
-  // SPECIAL CASE B: Extension classes — prefix goes as SUFFIX before "_Extension"
-  // Example: SalesFormLetter + Contoso → SalesFormLetterContoso_Extension
+  // SPECIAL CASE B: Extension classes — extension infix goes BEFORE "_Extension"
+  // Example: SalesFormLetter + "Contoso"       → SalesFormLetterContoso_Extension
+  // Example: SalesFormLetter + "XY" (env "XY_") → SalesFormLetterXy_Extension
   //
   // IMPORTANT: objectName MUST be the BASE class name + "_Extension" WITHOUT any prefix infix.
-  // E.g. "SalesFormLetter_Extension", NOT "SalesFormLetterContoso_Extension".
-  // Callers (e.g. createD365File) are responsible for stripping any stale model-name infix
-  // before calling this function when EXTENSION_PREFIX differs from modelName.
   if (objectName.endsWith('_Extension')) {
     const baseName = objectName.slice(0, -'_Extension'.length);
-    
-    // Check if the target prefix is already present at the end (case-insensitive)
-    if (baseName.toLowerCase().endsWith(normalizedPrefix.toLowerCase())) {
-      return objectName; // Already has the correct prefix, return as-is
+
+    // Check if the extension infix is already present at the end (case-insensitive)
+    if (baseName.toLowerCase().endsWith(extensionInfix.toLowerCase())) {
+      return objectName; // Already has the correct infix, return as-is
     }
-    
-    // Inject the correct prefix before "_Extension"
-    return `${baseName}${normalizedPrefix}_Extension`;
+
+    // Inject the extension infix before "_Extension"
+    return `${baseName}${extensionInfix}_Extension`;
   }
-  
+
   // NORMAL CASE: Regular objects — prefix at the START
-  // Check if already prefixed (case-insensitive)
-  if (objectName.toLowerCase().startsWith(normalizedPrefix.toLowerCase())) {
+  // Check if already prefixed (case-insensitive check against the full regular prefix)
+  if (objectName.toLowerCase().startsWith(regularPrefix.toLowerCase())) {
     return objectName;
   }
-  
-  // Capitalize first letter of objectName part so result is PascalCase
+  // For underscore-style: also check against the clean prefix (without underscore)
+  // to avoid re-prefixing objects that were already prefixed without the underscore.
+  if (envHasUnderscore && objectName.toLowerCase().startsWith(prefix.toLowerCase())) {
+    return objectName;
+  }
+
+  // Capitalize first letter of objectName part so result is PascalCase after the prefix
   const normalizedName = objectName.charAt(0).toUpperCase() + objectName.slice(1);
-  return `${normalizedPrefix}${normalizedName}`;
+  return `${regularPrefix}${normalizedName}`;
 }
 
 /**
@@ -163,7 +200,8 @@ export function buildExtensionElementName(baseElement: string, prefix: string): 
       `Bad pattern: "${baseElement}.Extension" (too generic, risk of conflicts).`
     );
   }
-  return `${baseElement}.${prefix}Extension`;
+  const infix = deriveExtensionInfix(prefix);
+  return `${baseElement}.${infix}Extension`;
 }
 
 /**
@@ -181,9 +219,11 @@ export function buildExtensionClassName(baseClass: string, prefix: string): stri
       `Bad pattern: "${baseClass}_Extension" (too generic, risk of conflicts).`
     );
   }
-  // Avoid double infix if baseClass already contains the prefix
-  const infix = baseClass.toLowerCase().includes(prefix.toLowerCase()) ? '' : prefix;
-  return `${baseClass}${infix}_Extension`;
+  // Derive the PascalCase infix form (e.g. "XY_" env → "Xy" infix, "Contoso" → "Contoso")
+  const infix = deriveExtensionInfix(prefix);
+  // Avoid double infix if baseClass already contains the infix
+  const infixToAdd = baseClass.toLowerCase().includes(infix.toLowerCase()) ? '' : infix;
+  return `${baseClass}${infixToAdd}_Extension`;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces improvements and fixes to prefix handling and naming conventions for extension elements and classes, as well as enhancements to EDT type normalization in XML generation and modification. The main focus is to ensure compliance with Microsoft guidelines for extension naming, handle underscore-style prefixes correctly, and improve developer experience by accepting more flexible EDT type aliases.

Prefix and naming improvements for extensions:

* Added `deriveExtensionInfix` function in `modelClassifier.ts` to convert resolved prefixes (especially underscore-style like "XY_") into PascalCase infixes for extension elements and classes, ensuring proper naming per MS guidelines.
* Updated `applyObjectPrefix`, `buildExtensionElementName`, and `buildExtensionClassName` in `modelClassifier.ts` to use the new infix logic, preventing incorrect or duplicate prefixes and handling underscore-style prefixes correctly for extension elements and classes. [[1]](diffhunk://#diff-58cbf5391d000d2d93b2f9b75ce50c82a417b9b1515b58e4712b290e65727e51L103-R185) [[2]](diffhunk://#diff-58cbf5391d000d2d93b2f9b75ce50c82a417b9b1515b58e4712b290e65727e51L166-R204) [[3]](diffhunk://#diff-58cbf5391d000d2d93b2f9b75ce50c82a417b9b1515b58e4712b290e65727e51L184-R226)
* Refactored `codeGenTool` in `codeGen.ts` to use the new extension infix for template generation and naming notes, replacing previous direct prefix usage. [[1]](diffhunk://#diff-1ec3a3763a74dd20695979559c5d6542ae541285b1430df57aa7a6acaba99404L8-R8) [[2]](diffhunk://#diff-1ec3a3763a74dd20695979559c5d6542ae541285b1430df57aa7a6acaba99404R430-R431) [[3]](diffhunk://#diff-1ec3a3763a74dd20695979559c5d6542ae541285b1430df57aa7a6acaba99404L479-R481) [[4]](diffhunk://#diff-1ec3a3763a74dd20695979559c5d6542ae541285b1430df57aa7a6acaba99404L489-R494)

EDT type normalization improvements:

* Enhanced `generateAxEdtXml` in both `createD365File.ts` and `generateD365Xml.ts` to accept common aliases for EDT types (e.g., "string", "int", "datetime") and map them to the correct AxEdt* XML type, improving robustness and developer convenience. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR2163-R2183) [[2]](diffhunk://#diff-e1e7fce542c2fc43bba3dd26014907a89b50f9294dc4967e3e8b7354eecdff2bL1064-R1078)
* Improved `modifyProperty` in `modifyD365File.ts` to handle EDT type changes using flexible aliases, updating the XML root `i:type` attribute and handling `StringSize` presence based on the new type.

Documentation updates:

* Updated `SETUP.md` and `SETUP_AZURE.md` to clarify that Python 3.x is required for hybrid setups, specifically for compiling the native SQLite addon via `node-gyp`. [[1]](diffhunk://#diff-22495e73839073b1b84e771b0b9097a8820e466365fd27b123f7fe7edeeb3047R33) [[2]](diffhunk://#diff-dab4e16984a3c7559ce090b78baeba3b59a8a917240ace8eae03889a370088a8R28)