### PR TITLE
refactor: update server mode handling and improve diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,6 @@ PORT=8080
 
 # Log level: error, warn, info, debug
 LOG_LEVEL=debug
-# DEBUG_LOGGING=true
 
 # Server mode for hybrid deployments (default: full)
 # - full       → all tools (local development, single-server setup)

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -67,6 +67,27 @@ Key points:
 - No `context` block needed — model name is resolved from `.rnrproj` automatically.
 - `MCP_SERVER_MODE` defaults to `full` — omit it unless you need `read-only` or `write-only`.
 
+#### Enabling diagnostics
+
+Add `DEBUG_LOGGING` and `LOG_FILE` to the `env` block to capture a full session trace:
+
+```json
+"env": {
+  "DB_PATH": "C:\\path\\to\\data\\xpp-metadata.db",
+  "LABELS_DB_PATH": "C:\\path\\to\\data\\xpp-metadata-labels.db",
+  "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects",
+  "DEBUG_LOGGING": "true",
+  "LOG_FILE": "C:\\Temp\\d365fo-mcp.log"
+}
+```
+
+The log file collects all output including JSON-RPC messages and is useful when the VS 2022
+Output window is too noisy or truncated. Open it with any text editor or watch live with:
+
+```powershell
+Get-Content "C:\Temp\d365fo-mcp.log" -Encoding UTF8 -Wait
+```
+
 ### HTTP (Azure-hosted or `npm run dev`)
 
 The server listens on a TCP port. Used for Azure deployments and for local `npm run dev` sessions.
@@ -153,7 +174,8 @@ files from `%LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\` and detects the pat
 | `D365FO_SOLUTIONS_PATH` | Recommended | Folder containing D365FO `.rnrproj` files. Server scans it at startup for model auto-detection and lists all found projects in `get_workspace_info`. Required for project switching by name (`projectName` parameter). |
 | `MCP_SERVER_MODE` | No | `full` (default), `read-only`, or `write-only`. Only needed in hybrid setups. |
 | `MCP_FORCE_HTTP` | No | Set to `true` to prevent stdio mode even when stdin is piped (rare). |
-| `DEBUG_LOGGING` | No | Set to `true` to dump workspace-related HTTP headers to stderr (HTTP transport only). |
+| `DEBUG_LOGGING` | No | Set to `true` to enable verbose raw JSON-RPC trace on stderr. Every message VS 2022 sends to the server (`[VS→MCP]`) and every reply the server sends back (`[MCP→VS]`) is printed with a relative timestamp. Useful for diagnosing handshake failures or unexpected tool responses. Works in both stdio and HTTP mode. |
+| `LOG_FILE` | No | Absolute path to a log file (e.g. `C:\\Temp\\d365fo-mcp.log`). All stderr output — including JSON-RPC trace when `DEBUG_LOGGING=true` — is **tee'd** to this file in addition to the normal stderr stream. The file is opened in append mode at process startup, so multiple sessions accumulate in one file. A banner line with the timestamp and PID is written at the start of each session. Useful on Windows where the VS 2022 Output window truncates long lines and does not persist across sessions. |
 
 ### When do you need the optional properties?
 
@@ -237,8 +259,8 @@ this by running two servers simultaneously:
 
 | Instance | Runs on | `MCP_SERVER_MODE` | Tools |
 |----------|---------|-------------------|-------|
-| `d365fo-azure` | Azure App Service | `read-only` | 38 search & analysis tools |
-| `d365fo-local` | Windows VM (stdio) | `write-only` | `create_d365fo_file`, `modify_d365fo_file`, `create_label`, `rename_label` |
+| `d365fo-azure` | Azure App Service | `read-only` | 36 search & analysis tools |
+| `d365fo-local` | Windows VM (stdio) | `write-only` | `create_d365fo_file`, `modify_d365fo_file`, `create_label`, `rename_label`, `verify_d365fo_project`, `get_workspace_info` |
 
 GitHub Copilot connects to both servers at the same time and selects the right one automatically.
 
@@ -283,26 +305,28 @@ When the server starts, it logs the detected mode and tool count:
 **Write-only mode (local companion):**
 ```
 🔧 Server mode: write-only (from env: write-only)
-🎯 Registered 4 X++ MCP tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label)
-[MCP Server] Tool list filtered for write-only mode: 4 tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label)
+🎯 Registered 6 X++ MCP tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label, verify_d365fo_project, get_workspace_info)
+[MCP Server] Tool list filtered for write-only mode: 6 tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label, verify_d365fo_project, get_workspace_info)
 ```
 
 **Read-only mode (Azure server):**
 ```
 🔧 Server mode: read-only (from env: read-only)
-🎯 Registered 38 X++ MCP tools (all except write tools)
-[MCP Server] Tool list filtered for read-only mode: 38 tools (write tools excluded)
+🎯 Registered 36 X++ MCP tools (all except local tools)
+[MCP Server] Tool list filtered for read-only mode: 36 tools (local tools excluded)
 ```
 
 **Full mode (local development):**
 ```
 🔧 Server mode: full (from env: not set, defaulting to full)
-🎯 Registered 42 X++ MCP tools (8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 5 file-ops + 3 pattern-analysis + 9 security-extensions)
+🎯 Registered 42 X++ MCP tools (1 workspace-config + 8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 4 file-ops + 3 pattern-analysis + 9 security-extensions)
 [MCP Server] Tool list in full mode: 42 tools (no filtering)
 ```
 
-> **Note:** The local server in `write-only` mode still needs access to the metadata database
-> (for path resolution and model detection), but it doesn't need Redis or Azure Blob Storage.
+> **Note:** The local server in `write-only` mode skips database download and the symbol
+> index entirely — it only needs `.mcp.json` for path resolution. Redis and Azure Blob Storage
+> are not required. `get_workspace_info` and `verify_d365fo_project` are included in
+> `write-only` mode because they read local K:\ filesystem paths not accessible from Azure.
 
 ### Azure App Service settings for read-only mode
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -10,6 +10,11 @@ just ask in plain English.
 
 ### Workspace Configuration (1 tool)
 
+> ⚠️ **Local-only** — excluded from `read-only` (Azure) mode; available in `full` and `write-only` modes.
+> Reports server config loaded from `.mcp.json`, detected D365FO projects from `D365FO_SOLUTIONS_PATH`,
+> and stdio session info (MCP client name, roots). On Azure this would return irrelevant cloud-server
+> state rather than your developer workspace — use the local companion for this tool.
+
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|
 | **get_workspace_info** | Verify model name, package path, project path — ⚠️ call this FIRST | "Check my workspace configuration" |
@@ -63,15 +68,21 @@ just ask in plain English.
 | **get_form_patterns** | Analyze datasource/control patterns for forms | "Find forms using CustTable" |
 | **generate_code** | Generate X++ boilerplate (class, batch job, CoC, etc.) | "Generate a batch job class for order processing" |
 
-### File Operations (3 tools)
+### File Operations — LOCAL_TOOLS (4 tools)
+
+> The following tools access the **local Windows VM filesystem** (K:\ drive paths in
+> `PackagesLocalDirectory` or `.rnrproj` project files) and are therefore excluded from
+> the Azure `read-only` deployment. In the hybrid setup they run on the local companion
+> (`MCP_SERVER_MODE=write-only`). They also skip the DB loading wait — no symbol database needed.
 
 | Tool | Works where | What it does |
 |------|------------|-------------|
 | **generate_d365fo_xml** | Anywhere (cloud + local) | Returns XML content — Copilot then creates the file |
 | **create_d365fo_file** | Local Windows VM only | Creates the physical file and adds it to the VS project |
 | **modify_d365fo_file** | Local Windows VM only | Safely edits an existing file with automatic backup |
+| **verify_d365fo_project** | Local Windows VM only | Reads `.rnrproj` on K:\ to verify objects exist on disk and are referenced in the project file |
 
-### Security & Extensions (10 tools)
+### Security & Extensions (9 tools)
 
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|
@@ -84,7 +95,6 @@ just ask in plain English.
 | **get_data_entity_info** | Data entity category, OData name, data sources, keys | "Show me CustCustomerV3Entity details" |
 | **analyze_extension_points** | CoC-eligible methods, delegates, events — what can be extended | "What can I extend on SalesLine?" |
 | **validate_object_naming** | Validate proposed extension/object names against D365FO conventions | "Is SalesTableExtension a valid extension class name?" |
-| **verify_d365fo_project** | Verify objects exist on disk and are referenced in the .rnrproj file | "Check that all created files are in place" |
 
 ### Label Management (4 tools)
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build-fts": "node --max-old-space-size=6144 --import tsx/esm scripts/build-fts.ts",
     "index-metadata": "tsx scripts/extract-metadata.ts && node --max-old-space-size=6144 --import tsx/esm scripts/build-database.ts",
     "blob-manager": "tsx scripts/azure-blob-manager.ts",
-    "select-config": "powershell -ExecutionPolicy Bypass -File scripts/select-xpp-config.ps1"
+    "select-config": "powershell -ExecutionPolicy Bypass -File scripts/select-xpp-config.ps1",
+    "test-stdio": "tsx scripts/test-stdio.ts"
   },
   "keywords": [
     "mcp",

--- a/scripts/test-stdio.ts
+++ b/scripts/test-stdio.ts
@@ -1,0 +1,197 @@
+/**
+ * End-to-end stdio transport test.
+ *
+ * Spawns the MCP server as a subprocess (write-only mode, no DB needed),
+ * performs the full MCP handshake, injects a fake workspace root and then
+ * calls get_workspace_info to verify project/workspace detection.
+ *
+ * Usage:
+ *   npx tsx scripts/test-stdio.ts
+ *   npx tsx scripts/test-stdio.ts --path "K:\repos\ASL\src\d365fo\projects\AslCore\AslCore.rnrproj"
+ *   npx tsx scripts/test-stdio.ts --workspace "K:\repos\ASL\src\d365fo\projects"
+ *
+ * Options:
+ *   --path        Path to a .rnrproj file OR a workspace folder.
+ *                 When a .rnrproj file is given, the script automatically uses
+ *                 the solution folder (two levels up) as the root — which is
+ *                 exactly what VS 2022 sends via roots/list.
+ *   --workspace   Alias for --path (workspace folder or .rnrproj file).
+ *   --switch      After first get_workspace_info, send roots/list_changed with
+ *                 a second path to test solution-switch detection.
+ *                 Accepts a .rnrproj file or a workspace folder.
+ *                 e.g. --switch "K:\repos\ASL\src\d365fo\projects\AslFinCZ\..."
+ */
+
+import { Client }               from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { ListRootsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { fileURLToPath }         from 'url';
+import { dirname, resolve, extname } from 'path';
+
+// ── CLI args ──────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+function getArg(name: string): string | null {
+  const idx = args.indexOf(name);
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : null;
+}
+
+/**
+ * VS 2022 sends workspace roots in roots/list as FOLDER paths, not .rnrproj files.
+ *
+ * When the user passes a .rnrproj path for convenience, we return the immediate
+ * parent directory (the project folder).  This gives the most specific folder
+ * that still contains the relevant project, regardless of nesting depth:
+ *
+ *   build/Solutions/AslCore/AslCore.rnrproj        → build/Solutions/AslCore/
+ *   projects/AslCore - FM/AslCore - FM/AslCore.rnrproj → projects/AslCore - FM/AslCore - FM/
+ *
+ * Note: VS 2022 may send the solution folder (one level higher) for multi-project
+ * solutions.  The server handles that case via name-match detection and git branch
+ * heuristics.  For test purposes the project folder is always unambiguous.
+ */
+function resolveToFolder(p: string): string {
+  if (extname(p).toLowerCase() !== '.rnrproj') return p;
+  // Return immediate parent — the project folder containing the .rnrproj
+  return resolve(p, '..');
+}
+
+const testPath      = getArg('--path') ?? getArg('--workspace');
+const switchPath    = getArg('--switch');
+
+// Default: use D365FO_SOLUTIONS_PATH from env or a generic fallback
+const primaryRoot: string = resolveToFolder(
+  testPath ??
+  process.env.D365FO_SOLUTIONS_PATH ??
+  'K:\\repos\\ASL\\src\\d365fo\\projects'
+);
+
+// Convert Windows path → file:// URI so it matches what VS 2022 sends
+function toFileUri(p: string): string {
+  // already a URI?
+  if (p.startsWith('file://')) return p;
+  return 'file:///' + p.replace(/\\/g, '/');
+}
+
+// ── Current roots state (shared between transport and test logic) ─────────────
+let currentRoots: string[] = [primaryRoot];
+
+// ── Server entry point ────────────────────────────────────────────────────────
+const __dir     = dirname(fileURLToPath(import.meta.url));
+const serverJs  = resolve(__dir, '../dist/index.js');
+const serverEnv = {
+  // Inherit everything so DB_PATH etc. from the real .env are picked up
+  ...process.env as Record<string, string>,
+  // write-only: fast startup, no 1.5 GB DB load needed
+  MCP_SERVER_MODE: 'write-only',
+  // Keep debug output readable
+  DEBUG_LOGGING: 'false',
+};
+
+console.log('─'.repeat(70));
+console.log('🧪 D365FO MCP stdio transport test');
+console.log(`   Server  : ${serverJs}`);
+console.log(`   Root(s) : ${currentRoots.join(', ')}`);
+if (switchPath) console.log(`   Switch  : ${switchPath}`);
+console.log('─'.repeat(70));
+
+// ── Transport + Client ────────────────────────────────────────────────────────
+const transport = new StdioClientTransport({
+  command: 'node',
+  args:    [serverJs],
+  env:     serverEnv,
+  stderr:  'pipe',   // capture server stderr for display
+});
+
+// Forward server stderr to our stderr so we can see what the server logs
+transport.stderr?.on('data', (chunk: Buffer) => {
+  process.stderr.write(chunk);
+});
+
+const client = new Client(
+  { name: 'test-stdio-client', version: '1.0.0' },
+  {
+    capabilities: {
+      roots: { listChanged: true },   // tell server we support solution-switching
+    },
+  }
+);
+
+// The server sends roots/list as a REQUEST to the client right after initialized.
+// We must respond with the current roots — same as VS 2022 does.
+client.setRequestHandler(ListRootsRequestSchema, async () => ({
+  roots: currentRoots.map(p => ({ uri: toFileUri(p), name: p })),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function printSection(title: string, text: string): void {
+  console.log('\n' + '═'.repeat(70));
+  console.log(`  ${title}`);
+  console.log('═'.repeat(70));
+  // Highlight key lines
+  text.split('\n').forEach(line => {
+    if (line.startsWith('✅') || line.startsWith('⛔') || line.startsWith('⚠️') ||
+        line.includes('Model name') || line.includes('Project path') ||
+        line.includes('Workspace') || line.includes('Client name') ||
+        line.includes('Roots (last') || line.includes('roots/list_changed') ||
+        line.startsWith('▶')) {
+      console.log('\x1b[33m' + line + '\x1b[0m');   // yellow highlight
+    } else {
+      console.log(line);
+    }
+  });
+}
+
+async function callGetWorkspaceInfo(): Promise<string> {
+  const result = await client.callTool({ name: 'get_workspace_info', arguments: {} });
+  const text = (result.content as Array<{ type: string; text: string }>)
+    .filter(c => c.type === 'text')
+    .map(c => c.text)
+    .join('\n');
+  return text;
+}
+
+// Give the server ~300 ms after connection so roots/list exchange settles
+function wait(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+try {
+  process.stdout.write('⏳ Connecting…\n');
+  await client.connect(transport);
+  console.log('✅ Connected (MCP handshake complete)');
+
+  // Wait for the server's InitializedNotification handler to fire and
+  // the roots/list exchange to complete before calling any tool.
+  await wait(500);
+
+  // ── First call ────────────────────────────────────────────────────────────
+  process.stdout.write('⏳ Calling get_workspace_info…\n');
+  const info1 = await callGetWorkspaceInfo();
+  printSection('get_workspace_info — initial state', info1);
+
+  // ── Solution switch simulation ────────────────────────────────────────────
+  if (switchPath) {
+    const switchFolder = resolveToFolder(switchPath);
+    console.log(`\n🔄 Simulating solution switch → ${switchFolder}`);
+    currentRoots = [switchFolder];
+
+    // Send the notification VS 2022 sends when user opens a different solution
+    await client.sendRootsListChanged();
+    console.log('   roots/list_changed notification sent');
+
+    // Wait for server to re-request roots/list and re-run detection
+    await wait(1500);
+
+    process.stdout.write('⏳ Calling get_workspace_info after switch…\n');
+    const info2 = await callGetWorkspaceInfo();
+    printSection('get_workspace_info — after solution switch', info2);
+  }
+
+  console.log('\n✅ Test complete.\n');
+  await client.close();
+  process.exit(0);
+} catch (err) {
+  console.error('\n❌ Test failed:', err);
+  process.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,14 +31,45 @@ import { WorkspaceScanner } from './workspace/workspaceScanner.js';
 import { HybridSearch } from './workspace/hybridSearch.js';
 import { initializeDatabase } from './database/download.js';
 import { initializeConfig, getConfigManager } from './utils/configManager.js';
-import { SERVER_MODE, WRITE_TOOLS } from './server/serverMode.js';
+import { SERVER_MODE, LOCAL_TOOLS } from './server/serverMode.js';
+import { setInitializeParams } from './utils/stdioSessionInfo.js';
 import * as fs from 'fs/promises';
+import * as fsSync from 'node:fs';
+import { Transform } from 'node:stream';
 
 // Filter verbose debug progress messages unless DEBUG_LOGGING is enabled.
 // Only suppress messages that are KNOWN debug output (tool-handler progress)
 // and do NOT contain any error/warning indicators.
 const originalConsoleError = console.error;
 const DEBUG_LOGGING = process.env.DEBUG_LOGGING === 'true';
+
+// ─── Optional file-based logging ──────────────────────────────────────────────
+// Set LOG_FILE env var to an absolute path to get a copy of all stderr output
+// written to a file. Useful when the IDE doesn't expose MCP subprocess stderr
+// (e.g. VS 2022 Output window only shows Copilot extension logs, not ours).
+//
+// In .mcp.json:  "LOG_FILE": "C:\\Temp\\d365fo-mcp.log"
+// Tail in PS:    Get-Content C:\Temp\d365fo-mcp.log -Wait -Tail 50
+// ─────────────────────────────────────────────────────────────────────────────
+const LOG_FILE = process.env.LOG_FILE;
+let _logStream: fsSync.WriteStream | undefined;
+if (LOG_FILE) {
+  try {
+    _logStream = fsSync.createWriteStream(LOG_FILE, { flags: 'a', encoding: 'utf8' });
+    const banner = `\n${'─'.repeat(72)}\n[d365fo-mcp] Started at ${new Date().toISOString()}  pid=${process.pid}\n${'─'.repeat(72)}\n`;
+    _logStream.write(banner);
+    // Tee: intercept process.stderr so every write also goes to the log file
+    const origStderrWrite = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = function (chunk: any, ...rest: any[]) {
+      _logStream!.write(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+      return origStderrWrite(chunk, ...rest);
+    };
+  } catch (e) {
+    // Don't crash if log file can't be opened — just disable file logging
+    process.stderr.write(`[d365fo-mcp] ⚠️ Cannot open LOG_FILE=${LOG_FILE}: ${e}\n`);
+    _logStream = undefined;
+  }
+}
 console.error = (...args: any[]) => {
   if (DEBUG_LOGGING) {
     originalConsoleError(...args);
@@ -106,9 +137,10 @@ async function initializeServices() {
   console.log(`🔧 Server mode: ${SERVER_MODE} (from env: ${process.env.MCP_SERVER_MODE || 'not set, defaulting to full'})`);
 
   // -----------------------------------------------------------------------
-  // write-only mode: skip all database/symbol work — file-operation tools
-  // (create_d365fo_file, modify_d365fo_file, create_label) only need the
-  // config manager for path resolution, not the 1.5 GB symbol database.
+  // write-only mode: skip all database/symbol work — LOCAL_TOOLS
+  // (create_d365fo_file, modify_d365fo_file, create_label, verify_d365fo_project,
+  //  get_workspace_info etc.) only need the config manager for path resolution,
+  //  not the 1.5 GB symbol database.
   // -----------------------------------------------------------------------
   if (SERVER_MODE === 'write-only') {
     console.log('✏️  Mode: write-only (local file-operations companion)');
@@ -117,12 +149,14 @@ async function initializeServices() {
     console.log('⚙️  Loading .mcp.json configuration...');
     const config = await initializeConfig();
     if (config?.servers.context) {
-      console.log('✅ Configuration loaded from .mcp.json');
+      console.log('✅ Configuration loaded from .mcp.json (servers.context)');
       if (config.servers.context.workspacePath) {
         console.log(`   Workspace path: ${config.servers.context.workspacePath}`);
       }
+    } else if (config) {
+      console.log('ℹ️  .mcp.json found (VS/Copilot registry format) — paths from process.env');
     } else {
-      console.log('ℹ️  No .mcp.json configuration found, using defaults');
+      console.log('ℹ️  No .mcp.json found — using environment variables / defaults');
     }
 
     const cache = new RedisCacheService();
@@ -152,16 +186,20 @@ async function initializeServices() {
     // Load .mcp.json configuration
     console.log('⚙️  Loading .mcp.json configuration...');
     const config = await initializeConfig();
-    if (config && config.servers.context) {
-      console.log('✅ Configuration loaded from .mcp.json');
+    if (config?.servers.context) {
+      console.log('✅ Configuration loaded from .mcp.json (servers.context)');
       if (config.servers.context.workspacePath) {
         console.log(`   Workspace path: ${config.servers.context.workspacePath}`);
       }
       if (config.servers.context.packagePath) {
         console.log(`   Package path: ${config.servers.context.packagePath}`);
       }
+    } else if (config) {
+      // Home .mcp.json found but uses VS/Copilot server-registry format (servers.<name>).
+      // D365FO paths are supplied via process.env (D365FO_SOLUTIONS_PATH, DB_PATH, …).
+      console.log('ℹ️  .mcp.json found (VS/Copilot registry format) — paths from process.env');
     } else {
-      console.log('ℹ️  No .mcp.json configuration found, using defaults');
+      console.log('ℹ️  No .mcp.json found — using environment variables / defaults');
     }
 
     // Initialize cache service
@@ -324,6 +362,85 @@ async function initializeServices() {
 }
 
 async function main() {
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Phase-1 diagnostic interceptors (stdio-only helpers)
+  // Defined here so _phase1Start and diagTs are never allocated in HTTP mode.
+  // Each incoming/outgoing newline-delimited JSON-RPC message is logged to
+  // stderr so you can see exactly what VS 2022 sends.
+  // ─────────────────────────────────────────────────────────────────────────────
+  const _phase1Start = Date.now();
+  function diagTs(): string {
+    return `+${Date.now() - _phase1Start}ms`;
+  }
+
+  /** Wraps process.stdin — logs every incoming JSON-RPC message, passes data through unchanged. */
+  function createDiagnosticStdin(): Transform {
+    let buf = Buffer.alloc(0);
+    const t = new Transform({
+      transform(chunk: Buffer, _enc, cb) {
+        buf = Buffer.concat([buf, chunk]);
+        // MCP stdio transport uses newline-delimited JSON: each message is one
+        // JSON object terminated by \n (with optional \r before \n).
+        let newlineIdx: number;
+        while ((newlineIdx = buf.indexOf(0x0a)) !== -1) {
+          const line = buf.slice(0, newlineIdx).toString('utf8').replace(/\r$/, '');
+          buf = buf.slice(newlineIdx + 1);
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line);
+            // Always capture initialize params regardless of DEBUG_LOGGING flag
+            // so get_workspace_info can show them even in production stdio mode.
+            if (msg.method === 'initialize' && msg.params) {
+              setInitializeParams(msg.params);
+            }
+            if (DEBUG_LOGGING) {
+              const kind = msg.method != null ? `📨 ${msg.method}` : `✅ reply#${msg.id}`;
+              const payload = msg.params ?? msg.result ?? msg.error ?? {};
+              process.stderr.write(
+                `[VS→MCP ${diagTs()}] ${kind}  ${JSON.stringify(payload).slice(0, 900)}\n`
+              );
+            }
+          } catch { /* non-JSON line, skip */ }
+        }
+        cb(null, chunk); // pass data through unchanged
+      },
+    });
+    process.stdin.pipe(t);
+    return t;
+  }
+
+  /** Wraps process.stdout — logs every outgoing JSON-RPC message, passes data through unchanged. */
+  function createDiagnosticStdout(): Transform {
+    let buf = Buffer.alloc(0);
+    const t = new Transform({
+      transform(chunk: Buffer, _enc, cb) {
+        buf = Buffer.concat([buf, chunk]);
+        // MCP stdio transport uses newline-delimited JSON.
+        let newlineIdx: number;
+        while ((newlineIdx = buf.indexOf(0x0a)) !== -1) {
+          const line = buf.slice(0, newlineIdx).toString('utf8').replace(/\r$/, '');
+          buf = buf.slice(newlineIdx + 1);
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line);
+            const kind = msg.method != null ? `🔔 ${msg.method}` : `📤 reply#${msg.id}`;
+            let payload: unknown = msg.result ?? msg.params ?? msg.error ?? {};
+            // Avoid flooding log with the full tools/list payload
+            if (msg.id != null && Array.isArray((payload as any)?.tools)) {
+              payload = { tools_count: (payload as any).tools.length, first: (payload as any).tools[0]?.name };
+            }
+            process.stderr.write(
+              `[MCP→VS ${diagTs()}] ${kind}  ${JSON.stringify(payload).slice(0, 500)}\n`
+            );
+          } catch { /* non-JSON line, skip */ }
+        }
+        cb(null, chunk); // pass data through unchanged
+      },
+    });
+    t.pipe(process.stdout);
+    return t;
+  }
+
   // CRITICAL: In STDIO mode, redirect all console.log to stderr
   // GitHub Copilot reads stdout for MCP protocol only!
   if (isStdioMode) {
@@ -349,7 +466,16 @@ async function main() {
     // Eagerly scan D365FO_SOLUTIONS_PATH so allDetectedProjects is populated before
     // VS 2022 sends roots/list (usually within 1–2 s of startup).
     getConfigManager().initEagerScan();
-    process.stderr.write(`[stdio] Seeding workspace: ${initialWorkspace}\n`);
+    process.stderr.write(`[stdio ${diagTs()}] Seeding workspace: ${initialWorkspace}\n`);
+    if (DEBUG_LOGGING) {
+      process.stderr.write(
+        `[phase1 diag] ────────────────────────────────────────────────────────\n` +
+        `[phase1 diag] DEBUG_LOGGING=true → raw JSON-RPC trace ENABLED\n` +
+        `[phase1 diag]  [VS→MCP ...] = messages FROM Visual Studio TO this server\n` +
+        `[phase1 diag]  [MCP→VS ...] = messages FROM this server TO Visual Studio\n` +
+        `[phase1 diag] ────────────────────────────────────────────────────────\n`
+      );
+    }
     getConfigManager().setRuntimeContext({ workspacePath: initialWorkspace });
 
     // STDIO mode: connect transport BEFORE the heavy database open so the MCP
@@ -397,15 +523,26 @@ async function main() {
     const mcpServer = createXppMcpServer(stubContext);
 
     // Step 2: connect transport — handshake completes here
-    const transport = new StdioServerTransport();
+    // Always wrap stdin with the session-sniffer Transform so we can capture
+    // the `initialize` request params (clientInfo, capabilities) for
+    // get_workspace_info diagnostics — even when DEBUG_LOGGING is false.
+    // stdout is only intercepted when DEBUG_LOGGING=true (it's noisy).
+    const diagStdin  = createDiagnosticStdin();
+    const diagStdout = DEBUG_LOGGING ? createDiagnosticStdout() : process.stdout;
+    const transport = new StdioServerTransport(
+      diagStdin  as unknown as typeof process.stdin,
+      diagStdout as unknown as typeof process.stdout,
+    );
     await mcpServer.connect(transport);
-    console.log('✅ Stdio transport connected (DB loading in background)');
+    console.log(`✅ Stdio transport connected ${diagTs()} (DB loading in background)`);
 
     // Step 3: yield the event loop so `initialized` + roots/list can be processed
     // BEFORE the synchronous new Database() call blocks the event loop.
     await new Promise<void>(resolve => setImmediate(resolve));
+    process.stderr.write(`[stdio ${diagTs()}] setImmediate fired — roots/list exchange should be done\n`);
 
     // Step 4: load real database in the background
+    const dbLoadStart = Date.now();
     initializeServices().then(({ symbolIndex, parser, cache, workspaceScanner, hybridSearch, termRelationshipGraph }) => {
       // Step 5: patch the context references used by tool handlers
       stubContext.symbolIndex       = symbolIndex;
@@ -420,7 +557,7 @@ async function main() {
       serverState.statusMessage = 'Ready';
       // Resolve dbReady AFTER context is patched — tools can now run with real index.
       resolveDbReady();
-      console.log('✅ Database loaded — all tools fully operational');
+      console.log(`✅ Database loaded in ${Date.now() - dbLoadStart} ms (${diagTs()} from process start) — all tools fully operational`);
     }).catch(err => {
       rejectDbReady(err);
       console.error('❌ Background initialization failed:', err);
@@ -428,12 +565,12 @@ async function main() {
 
     // Log tool count immediately (transport is already connected)
     const totalTools = 42;
-    const writeToolCount = WRITE_TOOLS.size;
-    const toolCount = SERVER_MODE === 'write-only' ? writeToolCount :
-                     SERVER_MODE === 'read-only' ? totalTools - writeToolCount : totalTools;
-    const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(WRITE_TOOLS).join(', ')})` :
-                    SERVER_MODE === 'read-only' ? '(all except write tools)' :
-                    '(8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 5 file-ops + 3 pattern-analysis + 9 security-extensions)';
+    const localToolCount = LOCAL_TOOLS.size;
+    const toolCount = SERVER_MODE === 'write-only' ? localToolCount :
+                     SERVER_MODE === 'read-only' ? totalTools - localToolCount : totalTools;
+    const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(LOCAL_TOOLS).join(', ')})` :
+                    SERVER_MODE === 'read-only' ? '(all except local tools)' :
+                    '(1 workspace-config + 8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 4 file-ops + 3 pattern-analysis + 9 security-extensions)';
     console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
@@ -548,8 +685,8 @@ async function main() {
         .map(cat => ({
           ...cat,
           tools: cat.tools.filter(t => {
-            if (SERVER_MODE === 'read-only') return !WRITE_TOOLS.has(t.name);
-            if (SERVER_MODE === 'write-only') return WRITE_TOOLS.has(t.name);
+            if (SERVER_MODE === 'read-only') return !LOCAL_TOOLS.has(t.name);
+            if (SERVER_MODE === 'write-only') return LOCAL_TOOLS.has(t.name);
             return true;
           }),
         }))

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -15,11 +15,12 @@ import { registerClassResource } from '../resources/classResource.js';
 import { registerWorkspaceResources } from '../resources/workspaceResource.js';
 import { registerCodeReviewPrompt } from '../prompts/codeReview.js';
 import type { XppServerContext } from '../types/context.js';
-import { SERVER_MODE, WRITE_TOOLS } from './serverMode.js';
+import { SERVER_MODE, LOCAL_TOOLS } from './serverMode.js';
 import { getConfigManager } from '../utils/configManager.js';
+import { setLastRoots, recordRootsListChanged } from '../utils/stdioSessionInfo.js';
 
 export type { XppServerContext };
-export { SERVER_MODE, WRITE_TOOLS } from './serverMode.js';
+export { SERVER_MODE, LOCAL_TOOLS, WRITE_TOOLS } from './serverMode.js';
 export type { ServerMode } from './serverMode.js';
 
 /**
@@ -46,11 +47,21 @@ function fileUriToPath(uri: string): string | null {
  * even when VS 2022 sends multiple roots (open project folders).
  */
 function applyRootsToConfig(roots: Array<{ uri: string }>): void {
-  if (!roots?.length) return;
+  if (!roots?.length) {
+    // VS 2022 sends empty roots/list when closing a solution (transition state).
+    // Log this so it's visible in diagnostics, but keep the current detection
+    // result — the next roots/list_changed will bring the new solution path.
+    process.stderr.write('[mcpServer] roots/list received (0 root(s)) — solution closing or no workspace open\n');
+    setLastRoots([]);
+    return;
+  }
 
   // Log all received roots for diagnostics
   process.stderr.write(`[mcpServer] roots/list received (${roots.length} root(s)):\n`);
   roots.forEach((r, i) => process.stderr.write(`  [${i}] ${r.uri}\n`));
+
+  // Persist URIs in the stdio session singleton so get_workspace_info can display them.
+  setLastRoots(roots.map(r => r.uri));
 
   // Convert all URIs to local paths
   const paths = roots
@@ -60,7 +71,19 @@ function applyRootsToConfig(roots: Array<{ uri: string }>): void {
   if (paths.length === 0) return;
 
   // Pass all paths; configManager will pick the most specific unambiguous one.
-  getConfigManager().setRuntimeContextFromRoots(paths).catch(err => {
+  // After detection completes, log what solution/project was resolved so it's
+  // easy to verify in the log that the correct project was picked.
+  getConfigManager().setRuntimeContextFromRoots(paths).then(() => {
+    const { modelName, source, projectPath, solutionPath, workspacePath } =
+      getConfigManager().getDetectionSummary();
+    process.stderr.write(
+      `[mcpServer] ✅ Project detection result:\n` +
+      `   Model name  : ${modelName ?? '(unknown)'} (source: ${source})\n` +
+      `   Project path: ${projectPath  ?? '(not set)'}\n` +
+      `   Solution    : ${solutionPath ?? '(not set)'}\n` +
+      `   Workspace   : ${workspacePath ?? '(not set)'}\n`
+    );
+  }).catch(err => {
     process.stderr.write(`[mcpServer] setRuntimeContextFromRoots error: ${err}\n`);
   });
 }
@@ -87,19 +110,27 @@ export function createXppMcpServer(context: XppServerContext): Server {
   // up-to-date on `notifications/roots/list_changed`.
   // -----------------------------------------------------------------------
   server.setNotificationHandler(InitializedNotificationSchema, async () => {
+    process.stderr.write(
+      `[mcpServer ${new Date().toISOString().slice(11, 23)}] ⚡ 'initialized' notification received — requesting roots/list\n`
+    );
     try {
       const result = await server.request(
         { method: 'roots/list', params: {} },
         ListRootsResultSchema
       );
       applyRootsToConfig(result.roots ?? []);
-    } catch {
+    } catch (e) {
       // Client doesn't support roots/list — workspace already seeded from
       // process.cwd() or env vars in index.ts stdio startup.
+      process.stderr.write(`[mcpServer] ⚠️  roots/list not supported by client: ${e}\n`);
     }
   });
 
   server.setNotificationHandler(RootsListChangedNotificationSchema, async () => {
+    recordRootsListChanged();
+    process.stderr.write(
+      `[mcpServer ${new Date().toISOString().slice(11, 23)}] 🔄 'roots/list_changed' notification — re-requesting roots/list\n`
+    );
     try {
       const result = await server.request(
         { method: 'roots/list', params: {} },
@@ -2104,11 +2135,11 @@ Examples:
 
     // Apply server mode filter
     if (SERVER_MODE === 'read-only') {
-      allTools.tools = allTools.tools.filter(t => !WRITE_TOOLS.has(t.name));
-      console.error(`[MCP Server] Tool list filtered for read-only mode: ${allTools.tools.length} tools (write tools excluded)`);
+      allTools.tools = allTools.tools.filter(t => !LOCAL_TOOLS.has(t.name));
+      console.error(`[MCP Server] Tool list filtered for read-only mode: ${allTools.tools.length} tools (local tools excluded)`);
     } else if (SERVER_MODE === 'write-only') {
-      allTools.tools = allTools.tools.filter(t => WRITE_TOOLS.has(t.name));
-      console.error(`[MCP Server] Tool list filtered for write-only mode: ${allTools.tools.length} tools (${Array.from(WRITE_TOOLS).join(', ')})`);
+      allTools.tools = allTools.tools.filter(t => LOCAL_TOOLS.has(t.name));
+      console.error(`[MCP Server] Tool list filtered for write-only mode: ${allTools.tools.length} tools (${Array.from(LOCAL_TOOLS).join(', ')})`);
     } else {
       console.error(`[MCP Server] Tool list in full mode: ${allTools.tools.length} tools (no filtering)`);
     }

--- a/src/server/serverMode.ts
+++ b/src/server/serverMode.ts
@@ -10,22 +10,49 @@
  */
 
 /**
- * Tools that require local Windows VM file system access (K:\ drive).
- * - Excluded in 'read-only' mode (Azure deployment)
- * - The only tools exposed in 'write-only' mode (local companion)
+ * Tools that require local Windows VM filesystem access (K:\ drive) or read
+ * local server state not available from Azure (e.g. in-memory config, .mcp.json).
+ *
+ * These tools have three properties in common:
+ *  1. They access local paths (K:\PackagesLocalDirectory, K:\VSProjects, .mcp.json)
+ *     that are NOT reachable from an Azure-hosted instance.
+ *  2. They do NOT need the symbol database — they skip the dbReady await.
+ *  3. They are the tools available in 'write-only' (local companion) mode.
+ *
+ * - Excluded in 'read-only' mode (Azure deployment can't access local K:\ paths)
+ * - The only tools exposed in 'write-only' mode (lightweight local companion)
+ *
+ * Members:
+ *  create_d365fo_file   — writes XML to K:\PackagesLocalDirectory
+ *  modify_d365fo_file   — edits XML on K:\PackagesLocalDirectory
+ *  create_label         — writes to K:\PackagesLocalDirectory label files
+ *  rename_label         — rewrites label files + all source references on K:\
+ *  verify_d365fo_project — reads .rnrproj from K:\VSProjects
+ *  get_workspace_info   — scans .rnrproj via D365FO_SOLUTIONS_PATH (K:\); reads
+ *                         .mcp.json + in-memory config/stdio session state;
+ *                         on Azure would return irrelevant server info, not dev
+ *                         workspace info — so it's excluded from read-only mode
  */
-export const WRITE_TOOLS = new Set([
+export const LOCAL_TOOLS = new Set([
   'create_d365fo_file',
   'modify_d365fo_file',
   'create_label',
   'rename_label',
+  'verify_d365fo_project',
+  'get_workspace_info',
 ]);
+
+/**
+ * @deprecated Use LOCAL_TOOLS — kept temporarily so any external import doesn't break.
+ * Will be removed in the next major release.
+ */
+export const WRITE_TOOLS = LOCAL_TOOLS;
 
 /**
  * Server mode, resolved once at startup from MCP_SERVER_MODE env var.
  * - 'full'       (default) – all tools registered (local development)
- * - 'read-only'  – WRITE_TOOLS excluded   (Azure App Service deployment)
- * - 'write-only' – only WRITE_TOOLS exposed (lightweight local companion)
+ * - 'read-only'  – LOCAL_TOOLS excluded   (Azure App Service deployment)
+ * - 'write-only' – only LOCAL_TOOLS exposed (lightweight local companion)
  */
 export type ServerMode = 'full' | 'read-only' | 'write-only';
 

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -157,23 +157,6 @@ export class CustomHttpTransport implements Transport {
           getConfigManager().setRuntimeContext({ workspacePath });
         }
 
-        // DEBUG: dump workspace-related headers + _meta when DEBUG_LOGGING=true
-        // Run once per request so VS 2022 / Copilot exact header keys can be identified.
-        if (process.env.DEBUG_LOGGING === 'true') {
-          const debugPayload = {
-            headers: Object.fromEntries(
-              Object.entries(req.headers).filter(([k]) =>
-                k.includes('workspace') || k.includes('copilot') ||
-                k.includes('vscode') || k.includes('root') ||
-                k.includes('origin') || k.includes('referer')
-              )
-            ),
-            resolvedWorkspacePath: workspacePath,
-            meta: (request as any).params?._meta,
-          };
-          process.stderr.write(`[VS22-Headers] ${JSON.stringify(debugPayload, null, 2)}\n`);
-        }
-
         if (!request.jsonrpc || !request.method) {
           res.status(400).json({
             jsonrpc: '2.0',

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -2545,20 +2545,11 @@ export class ProjectFileManager {
     projectPath: string,
     objectType: string,
     objectName: string,
-    absoluteXmlPath: string
+    _absoluteXmlPath: string  // kept for API compatibility
   ): Promise<boolean> {
-    console.error(
-      `[ProjectFileManager] Adding to project: ${projectPath}, type: ${objectType}, name: ${objectName}`
-    );
-    console.error(`[ProjectFileManager] Absolute XML path: ${absoluteXmlPath}`);
-
     // Read project file
     const projectXml = await fs.readFile(projectPath, 'utf-8');
     const project = await this.parser.parseStringPromise(projectXml);
-
-    console.error(
-      `[ProjectFileManager] Parsed project, ItemGroup count: ${Array.isArray(project.Project.ItemGroup) ? project.Project.ItemGroup.length : 'single'}`
-    );
 
     // Ensure project structure exists
     if (!project.Project) {
@@ -3067,10 +3058,7 @@ export async function handleCreateD365File(
 
     // Ensure directory exists (create if needed)
     const directory = path.dirname(normalizedFullPath);
-    console.error(
-      `[create_d365fo_file] Ensuring directory exists: ${directory}`
-    );
-    
+
     // Check if this looks like a Windows path on non-Windows system
     if (process.platform !== 'win32' && /^[A-Z]:\\/.test(normalizedFullPath)) {
       throw new Error(
@@ -3112,7 +3100,6 @@ export async function handleCreateD365File(
 
     try {
       await fs.mkdir(directory, { recursive: true });
-      console.error(`[create_d365fo_file] Directory ready: ${directory}`);
     } catch (mkdirError) {
       console.error(
         `[create_d365fo_file] Failed to create directory:`,
@@ -3238,9 +3225,6 @@ export async function handleCreateD365File(
       const utf8BOM = Buffer.from([0xEF, 0xBB, 0xBF]);
       const xmlBuffer = Buffer.concat([utf8BOM, Buffer.from(xmlContent, 'utf-8')]);
       await fs.writeFile(normalizedFullPath, xmlBuffer);
-      console.error(
-        `[create_d365fo_file] File written successfully with UTF-8 BOM: ${normalizedFullPath}`
-      );
     } catch (writeError) {
       console.error(`[create_d365fo_file] Failed to write file:`, writeError);
       
@@ -3261,17 +3245,14 @@ export async function handleCreateD365File(
 
     // Verify file was written
     const stats = await fs.stat(normalizedFullPath);
+    const fileSizeKb = (stats.size / 1024).toFixed(1);
     console.error(
-      `[create_d365fo_file] File written: ${normalizedFullPath}, size: ${stats.size} bytes`
+      `[create_d365fo_file] ✅ Written: ${normalizedFullPath}  (${fileSizeKb} KB)`
     );
 
     // Add to Visual Studio project if requested
     let projectMessage = '';
     if (args.addToProject) {
-      console.error(
-        `[create_d365fo_file] addToProject requested, solutionPath: ${solutionPathToUse}, projectPath: ${projectPathToUse}`
-      );
-
       // Try to find project file if not explicitly specified
       // Use projectPathToUse which includes values from .mcp.json config
       let projectPath = projectPathToUse;
@@ -3308,9 +3289,6 @@ export async function handleCreateD365File(
 
       if (projectPath) {
         try {
-          console.error(
-            `[create_d365fo_file] Adding to project: ${projectPath}`
-          );
           // Validate project file exists
           await fs.access(projectPath);
 
@@ -3318,10 +3296,6 @@ export async function handleCreateD365File(
           // The full path must point to the exact XML location in PackagesLocalDirectory
           // Ensure Windows path format with backslashes
           const absoluteXmlPath = normalizedFullPath;
-
-          console.error(
-            `[create_d365fo_file] Absolute XML path: ${absoluteXmlPath}`
-          );
 
           // Add to project
           const projectManager = new ProjectFileManager();

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -2,7 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { XppServerContext } from '../types/context.js';
 import { getConfigManager } from '../utils/configManager.js';
-import { SERVER_MODE, WRITE_TOOLS } from '../server/serverMode.js';
+import { SERVER_MODE, LOCAL_TOOLS } from '../server/serverMode.js';
 import { searchTool } from './search.js';
 import { batchSearchTool } from './batchSearch.js';
 import { classInfoTool } from './classInfo.js';
@@ -45,6 +45,7 @@ import { analyzeExtensionPointsTool } from './analyzeExtensionPoints.js';
 import { validateObjectNamingTool } from './validateObjectNaming.js';
 import { verifyD365ProjectTool } from './verifyD365Project.js';
 import { resolveObjectPrefix } from '../utils/modelClassifier.js';
+import { getStdioSessionInfo } from '../utils/stdioSessionInfo.js';
 
 /**
  * Extract workspace path from GitHub Copilot _meta and apply it to ConfigManager.
@@ -149,9 +150,10 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
     // patched into the context. Awaiting it here ensures every tool call uses
     // the real index — tools that arrive during DB loading will block (showing
     // a spinner in the IDE) rather than silently returning empty results.
-    // Write-only tools (create_d365fo_file etc.) don't need the DB, so they
-    // skip the wait and execute immediately.
-    if (context.dbReady && !WRITE_TOOLS.has(toolName)) {
+    // LOCAL_TOOLS (create_d365fo_file, verify_d365fo_project, get_workspace_info
+    // etc.) access the local filesystem or in-memory config — no DB needed,
+    // so they skip the wait and execute immediately.
+    if (context.dbReady && !LOCAL_TOOLS.has(toolName)) {
       const t0 = Date.now();
       await context.dbReady;
       const elapsed = Date.now() - t0;
@@ -160,14 +162,14 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       }
     }
 
-    // Enforce server mode: block write tools in read-only mode, block read tools in write-only mode
-    if (SERVER_MODE === 'read-only' && WRITE_TOOLS.has(toolName)) {
+    // Enforce server mode: block local tools in read-only (Azure) mode, block search/analysis tools in write-only mode
+    if (SERVER_MODE === 'read-only' && LOCAL_TOOLS.has(toolName)) {
       return {
-        content: [{ type: 'text', text: `⚠️ Tool '${toolName}' requires local Windows VM file system access and is not available in read-only mode.\n\nThis MCP server is running in read-only mode (Azure deployment).\nTo use file operations, configure a local MCP server with MCP_SERVER_MODE=write-only in your .mcp.json.\n\nSee: https://github.com/dynamics365ninja/d365fo-mcp-server/blob/main/docs/MCP_CONFIG.md` }],
+        content: [{ type: 'text', text: `⚠️ Tool '${toolName}' requires local Windows VM filesystem access and is not available in read-only mode.\n\nThis MCP server is running in read-only mode (Azure deployment).\nTo use file operations and workspace diagnostics, configure a local MCP server with MCP_SERVER_MODE=write-only in your .mcp.json.\n\nSee: https://github.com/dynamics365ninja/d365fo-mcp-server/blob/main/docs/MCP_CONFIG.md` }],
         isError: true,
       };
     }
-    if (SERVER_MODE === 'write-only' && !WRITE_TOOLS.has(toolName)) {
+    if (SERVER_MODE === 'write-only' && !LOCAL_TOOLS.has(toolName)) {
       return {
         content: [{ type: 'text', text: `⚠️ Tool '${toolName}' is not available in write-only mode.\n\nThis local MCP server only handles file operations. Search and analysis tools are provided by the Azure MCP server.` }],
         isError: true,
@@ -388,6 +390,46 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           }
           lines.push(``);
           lines.push(`To switch project: call get_workspace_info with projectName = "<ModelName>"`);
+        }
+
+        // -----------------------------------------------------------------------
+        // Stdio session info — what VS 2022 sent during the MCP handshake
+        // Populated by the stdin sniffer in index.ts (always active in stdio mode).
+        // -----------------------------------------------------------------------
+        const sio = getStdioSessionInfo();
+        lines.push(``);
+        lines.push(`## Stdio Session Info`);
+        lines.push(``);
+        if (!sio.initializedAt) {
+          lines.push(`_Not in stdio mode (or initialize not yet received)._`);
+        } else {
+          lines.push(`Client name     : ${sio.clientName    ?? '(not sent)'}`);
+          lines.push(`Client version  : ${sio.clientVersion ?? '(not sent)'}`);
+          lines.push(`MCP protocol    : ${sio.protocolVersion ?? '(not sent)'}`);
+          lines.push(`Roots listChanged cap: ${sio.supportsRootsListChanged ? 'yes ✅' : 'no ❌'}`);
+          lines.push(`Initialize at   : ${sio.initializedAt}`);
+          lines.push(``);
+          if (sio.lastRoots.length === 0) {
+            lines.push(`Roots (last roots/list): _none received yet_`);
+          } else {
+            lines.push(`Roots (last roots/list) @ ${sio.rootsLastAt}:`);
+            sio.lastRoots.forEach((u, i) => lines.push(`  [${i}] ${u}`));
+          }
+          lines.push(``);
+          if (sio.rootsListChangedCount === 0) {
+            lines.push(`roots/list_changed events: 0 (VS 2022 has NOT changed solution since startup)`);
+            if (sio.supportsRootsListChanged) {
+              lines.push(`  ℹ️  Client declared roots.listChanged=true — it WILL send this notification`);
+              lines.push(`     when you open/switch a solution. Switch now and call get_workspace_info again.`);
+            } else {
+              lines.push(`  ⚠️  Client did NOT declare roots.listChanged capability — automatic`);
+              lines.push(`     solution-switch detection may not be available.`);
+            }
+          } else {
+            lines.push(`roots/list_changed events: ${sio.rootsListChangedCount} ✅`);
+            lines.push(`Last change at  : ${sio.rootsListChangedLastAt}`);
+            lines.push(`✅ VS 2022 IS sending roots/list_changed — solution switching IS detectable.`);
+          }
         }
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -96,8 +96,19 @@ class ConfigManager {
         const all = await scanAllD365Projects(solutionsRoot);
         if (all.length > 0) {
           this.allDetectedProjects = all;
-          console.error(`[ConfigManager] 🔍 Eager scan complete: ${all.length} project(s) found`);
-          all.forEach(p => console.error(`   - ${p.modelName}: ${p.projectPath}`));
+          // Compact summary: group by model, then list counts + first project path per model
+          const byModel = new Map<string, string[]>();
+          for (const p of all) {
+            const list = byModel.get(p.modelName) ?? [];
+            if (p.projectPath) list.push(p.projectPath);
+            byModel.set(p.modelName, list);
+          }
+          console.error(
+            `[ConfigManager] 🔍 Eager scan complete: ${all.length} project(s) across ${byModel.size} model(s)`
+          );
+          for (const [model, paths] of byModel) {
+            console.error(`   ${model}: ${paths.length} project(s)  (first: ${paths[0]})`);
+          }
         } else {
           console.error(`[ConfigManager] 🔍 Eager scan: no projects found under ${solutionsRoot}`);
         }
@@ -194,19 +205,27 @@ class ConfigManager {
     // matchProjectForWorkspace() which is called from setRuntimeContextFromRoots().
     const solutionsRoot = process.env.D365FO_SOLUTIONS_PATH;
     if (solutionsRoot) {
-      const all = await scanAllD365Projects(solutionsRoot);
-      if (all.length > 0) {
-        this.allDetectedProjects = all;
-        console.error(`[ConfigManager] Found ${all.length} project(s) under D365FO_SOLUTIONS_PATH:`);
-        all.forEach(p => console.error(`   - ${p.modelName}: ${p.projectPath}`));
-        // Re-check staleness: time has passed since the initial check above.
-        const isNowStale = generation !== undefined && generation < this.detectionGeneration;
-        // Use first found as primary if workspace detection yielded nothing and scan is current.
-        if (!this.autoDetectedProject && !isNowStale) {
-          this.autoDetectedProject = all[0];
-          registerCustomModel(all[0].modelName);
-          console.error(`[ConfigManager] ✅ Using first found project as primary: ${all[0].modelName}`);
+      // Skip re-scan if initEagerScan() already populated the list (avoids duplicate log output).
+      const needsScan = this.allDetectedProjects.length === 0;
+      if (needsScan) {
+        const all = await scanAllD365Projects(solutionsRoot);
+        if (all.length > 0) {
+          this.allDetectedProjects = all;
+          const byModel = new Map<string, number>();
+          for (const p of all) byModel.set(p.modelName, (byModel.get(p.modelName) ?? 0) + 1);
+          console.error(
+            `[ConfigManager] Found ${all.length} project(s) across ${byModel.size} model(s) under D365FO_SOLUTIONS_PATH`
+          );
         }
+      }
+      const all = this.allDetectedProjects;
+      // Re-check staleness: time has passed since the initial check above.
+      const isNowStale = generation !== undefined && generation < this.detectionGeneration;
+      // Use first found as primary if workspace detection yielded nothing and scan is current.
+      if (all.length > 0 && !this.autoDetectedProject && !isNowStale) {
+        this.autoDetectedProject = all[0];
+        registerCustomModel(all[0].modelName);
+        console.error(`[ConfigManager] ✅ Using first found project as primary: ${all[0].modelName}`);
       }
     }
   }
@@ -288,8 +307,12 @@ class ConfigManager {
 
     // Await the eager D365FO_SOLUTIONS_PATH scan so allDetectedProjects is populated
     // before we try matchProjectForWorkspace (otherwise it always returns null).
+    // Cap at 5 s — consistent with the timeout used in getAutoDetectedProject().
     if (this.allDetectedProjectsReady) {
-      await this.allDetectedProjectsReady;
+      await Promise.race([
+        this.allDetectedProjectsReady,
+        new Promise<void>(resolve => setTimeout(resolve, 5_000)),
+      ]);
     }
 
     // Priority 1: exact / unambiguous path match
@@ -431,6 +454,20 @@ class ConfigManager {
     }
 
     if (children.length > 1) {
+      // Priority C: D365FO convention — the "primary" project in a solution folder
+      // usually has the SAME NAME as the solution folder itself.
+      // e.g. VS 2022 sends root "AslCore - FeatureManagement/" which contains
+      // AslAuditReports - FeatureManagement/, AslCore - FeatureManagement/, …
+      // → prefer the project whose own folder name matches the workspace base name.
+      const wpBase = path.basename(workspacePath).toLowerCase();
+      const nameMatch = children.find(p => {
+        const projectFolderName = path.basename(path.dirname(p.projectPath!)).toLowerCase();
+        return projectFolderName === wpBase;
+      });
+      if (nameMatch) {
+        console.error(`[ConfigManager] ⚡ Solution-name match (${children.length} candidates): ${nameMatch.modelName}`);
+        return nameMatch;
+      }
       console.error(`[ConfigManager] Workspace is ancestor of ${children.length} projects — ambiguous, not switching`);
     }
 
@@ -606,7 +643,10 @@ class ConfigManager {
       ];
       for (const candidate of wellKnownCandidates) {
         if (existsSync(candidate)) {
-          console.error(`[ConfigManager] ✅ Auto-probed packagePath: ${candidate}`);
+          if (!(this as any)._packagePathLoggedOnce) {
+            console.error(`[ConfigManager] ✅ Auto-probed packagePath: ${candidate}`);
+            (this as any)._packagePathLoggedOnce = true;
+          }
           return candidate;
         }
       }
@@ -735,17 +775,26 @@ class ConfigManager {
   }> {
     // Ensure config is loaded and auto-detection has had a chance to run
     await this.ensureLoaded();
+
+    // If the D365FO_SOLUTIONS_PATH eager scan is still running, wait for it
+    // first — that scan populates allDetectedProjects which setRuntimeContextFromRoots
+    // needs to do a path-match.  Cap at 5 s so we never block Copilot past its timeout.
+    if (this.allDetectedProjectsReady) {
+      await Promise.race([
+        this.allDetectedProjectsReady,
+        new Promise<void>(resolve => setTimeout(resolve, 5_000)),
+      ]);
+    }
+
     if (!this.autoDetectionAttempted) {
       const ctx = this.config?.servers.context;
       await this.autoDetectProject(this.runtimeContext.workspacePath || ctx?.workspacePath);
     } else if (!this.autoDetectedProject && this.detectionInProgress) {
       // autoDetectionAttempted was set immediately when background scan started,
-      // but the scan hasn't finished yet — wait up to 12 s for the result.
-      // This fixes "null on first call" when VS 2022 makes a tool call before
-      // the D365FO_SOLUTIONS_PATH scan or BFS completes.
+      // but the scan hasn't finished yet — wait up to 5 s for the result.
       await Promise.race([
         this.detectionInProgress,
-        new Promise<void>(resolve => setTimeout(resolve, 12_000)),
+        new Promise<void>(resolve => setTimeout(resolve, 5_000)),
       ]);
       this.detectionInProgress = null;
     }
@@ -886,6 +935,32 @@ class ConfigManager {
     }
 
     return this.autoDetectedProject?.solutionPath || null;
+  }
+
+  /**
+   * Returns a snapshot of the currently detected project for diagnostic logging.
+   * All fields are resolved synchronously from the in-memory state — no async I/O.
+   */
+  getDetectionSummary(): {
+    modelName: string | null;
+    source: string;
+    projectPath: string | null;
+    solutionPath: string | null;
+    workspacePath: string | null;
+  } {
+    const { modelName, source } = this.getModelNameWithSource();
+    return {
+      modelName,
+      source,
+      projectPath:  this.runtimeContext.projectPath  ??
+                    this.autoDetectedProject?.projectPath  ??
+                    this.config?.servers.context?.projectPath  ?? null,
+      solutionPath: this.runtimeContext.solutionPath ??
+                    this.autoDetectedProject?.solutionPath ??
+                    this.config?.servers.context?.solutionPath ?? null,
+      workspacePath: this.runtimeContext.workspacePath ??
+                     this.config?.servers.context?.workspacePath ?? null,
+    };
   }
 
   /**

--- a/src/utils/stdioSessionInfo.ts
+++ b/src/utils/stdioSessionInfo.ts
@@ -1,0 +1,76 @@
+/**
+ * Singleton that stores information captured from the stdio MCP handshake.
+ *
+ * Written by:
+ *  - index.ts createDiagnosticStdin() — parses the raw `initialize` JSON-RPC
+ *    request (first message on stdin) and stores clientInfo + capabilities.
+ *  - mcpServer.ts applyRootsToConfig() — stores last roots/list result.
+ *  - mcpServer.ts RootsListChangedNotificationSchema handler — increments
+ *    rootsListChangedCount each time VS 2022 reports a workspace change.
+ *
+ * Read by get_workspace_info so devs can verify what VS 2022 is sending
+ * without having to grep log files.
+ */
+
+export interface StdioSessionInfo {
+  /** e.g. "Microsoft Visual Studio" */
+  clientName:    string | null;
+  /** e.g. "17.12.35527.113" */
+  clientVersion: string | null;
+  /** e.g. "2025-06-18" */
+  protocolVersion: string | null;
+  /** true when client declared roots.listChanged capability */
+  supportsRootsListChanged: boolean;
+  /** ISO timestamp of the initialize message */
+  initializedAt: string | null;
+  /** URIs from the most recent roots/list response */
+  lastRoots: string[];
+  /** ISO timestamp of the most recent roots/list fetch */
+  rootsLastAt: string | null;
+  /** How many times roots/list_changed notification arrived (0 = never) */
+  rootsListChangedCount: number;
+  /** ISO timestamp of the most recent roots/list_changed notification */
+  rootsListChangedLastAt: string | null;
+}
+
+const _info: StdioSessionInfo = {
+  clientName:    null,
+  clientVersion: null,
+  protocolVersion: null,
+  supportsRootsListChanged: false,
+  initializedAt: null,
+  lastRoots: [],
+  rootsLastAt: null,
+  rootsListChangedCount: 0,
+  rootsListChangedLastAt: null,
+};
+
+/** Returns a live reference — callers should treat it as read-only. */
+export function getStdioSessionInfo(): Readonly<StdioSessionInfo> {
+  return _info;
+}
+
+/** Called once when the raw `initialize` request is parsed from stdin. */
+export function setInitializeParams(params: {
+  protocolVersion?: string;
+  clientInfo?: { name?: string; version?: string };
+  capabilities?: { roots?: { listChanged?: boolean } };
+}): void {
+  _info.protocolVersion          = params.protocolVersion ?? null;
+  _info.clientName               = params.clientInfo?.name    ?? null;
+  _info.clientVersion            = params.clientInfo?.version ?? null;
+  _info.supportsRootsListChanged = params.capabilities?.roots?.listChanged === true;
+  _info.initializedAt            = new Date().toISOString();
+}
+
+/** Called by applyRootsToConfig after each roots/list fetch. */
+export function setLastRoots(uris: string[]): void {
+  _info.lastRoots    = uris;
+  _info.rootsLastAt  = new Date().toISOString();
+}
+
+/** Called by the RootsListChangedNotificationSchema handler. */
+export function recordRootsListChanged(): void {
+  _info.rootsListChangedCount++;
+  _info.rootsListChangedLastAt = new Date().toISOString();
+}

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -109,8 +109,22 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
     console.error(`[WorkspaceDetector] Found ${projectFiles.length} .rnrproj file(s):`);
     projectFiles.forEach(p => console.error(`   - ${p}`));
 
-    // Use the first project found (most common case: single project in workspace)
-    const primaryProject = projectFiles[0];
+    // D365FO convention: in a multi-project solution folder the "primary" project
+    // usually has the SAME NAME as the solution folder (workspace base name).
+    // e.g. workspace "AslCore - FeatureManagement/" → prefer the .rnrproj whose
+    // own folder is also named "AslCore - FeatureManagement".
+    // Falls back to the first file found (alphabetically) when no name match.
+    let primaryProject = projectFiles[0];
+    if (projectFiles.length > 1) {
+      const wpBase = path.basename(workspacePath).toLowerCase();
+      const nameMatch = projectFiles.find(
+        p => path.basename(path.dirname(p)).toLowerCase() === wpBase,
+      );
+      if (nameMatch) {
+        primaryProject = nameMatch;
+        console.error(`[WorkspaceDetector] Solution-name match → ${path.basename(nameMatch)}`);
+      }
+    }
     const modelName = await extractModelNameFromProject(primaryProject);
 
     if (!modelName) {


### PR DESCRIPTION
This pull request makes several improvements to documentation, adds a new test script, and enhances the server's logging and configuration handling. The most significant changes are the introduction of file-based logging, updates to tool lists and server mode documentation, and the addition of a script for end-to-end stdio transport testing. These updates clarify the hybrid deployment setup, improve diagnostics, and ensure the toolset and configuration are accurately described.

**Diagnostics & Logging Improvements**
* Added support for file-based logging via the `LOG_FILE` environment variable. All stderr output (including JSON-RPC traces when `DEBUG_LOGGING=true`) is tee'd to the specified log file, with a session banner and PID, improving traceability especially in environments where IDE output is truncated. (`src/index.ts`, `docs/MCP_CONFIG.md`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L34-R72) [[2]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcL156-R178)
* Updated documentation to clarify the purpose and usage of `DEBUG_LOGGING` and `LOG_FILE`, including sample configuration and PowerShell commands for live log monitoring. (`docs/MCP_CONFIG.md`) [[1]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcR70-R90) [[2]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcL156-R178)

**Toolset & Server Mode Documentation**
* Revised tool lists and descriptions to accurately reflect which tools are available in each server mode (`full`, `read-only`, `write-only`), including new local-only tools like `verify_d365fo_project` and `get_workspace_info`. (`docs/MCP_TOOLS.md`, `docs/MCP_CONFIG.md`) [[1]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95R13-R17) [[2]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L66-R85) [[3]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcL240-R263) [[4]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcL286-R329)
* Updated server mode startup logs to show the correct tool counts and clarify which tools are included/excluded in each mode. (`docs/MCP_CONFIG.md`)

**Testing & Development Utilities**
* Added a new script `scripts/test-stdio.ts` and corresponding npm command `test-stdio` for end-to-end stdio transport testing. This script simulates VS 2022 workspace root handling and verifies project detection, including solution-switch scenarios. (`scripts/test-stdio.ts`, `package.json`) [[1]](diffhunk://#diff-a1649fe812d69c0c3420529459929ff3e11c56c216e7ef4bae6e2db30ae0d680R1-R197) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R19)

**Configuration Handling**
* Improved `.mcp.json` configuration loading messages to distinguish between full context configs and VS/Copilot registry formats, clarifying where workspace and package paths are sourced. (`src/index.ts`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L120-R159) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L155-R202)

**Minor Updates**
* Cleaned up `.env.example` by removing a commented-out `DEBUG_LOGGING` line. (`.env.example`)

These changes collectively enhance the developer experience by improving diagnostics, clarifying tool availability, and providing robust testing utilities.