### PR TITLE
feat: enhance AxSecurityPrivilege XML generation with targetObject an…

### DIFF
--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -813,7 +813,7 @@ export class XppMetadataParser {
     name: string;
     label?: string;
     sourcePath: string;
-    entryPoints: Array<{ name: string; objectType: string; accessLevel: string }>;
+    entryPoints: Array<{ name: string; objectName: string; objectType: string; accessLevel: string }>;
   }>> {
     try {
       const content = await fs.readFile(filePath, 'utf-8');
@@ -842,7 +842,7 @@ export class XppMetadataParser {
         } else {
           accessLevel = String(rawAccess);
         }
-        return { name: ep.Name || '', objectType: ep.ObjectType || '', accessLevel };
+        return { name: ep.Name || '', objectName: ep.ObjectName || ep.Name || '', objectType: ep.ObjectType || '', accessLevel };
       }).filter((ep: any) => ep.name);
 
       return { success: true, data: { name, label, sourcePath: filePath, entryPoints } };

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -746,6 +746,7 @@ EXAMPLES:
                   '• table-extension: fields[{name,edt?,enumType?,label?,mandatory?,fieldType?}] — fieldType defaults to AxTableFieldString; use AxTableFieldEnum for enum-based fields (also set enumType)\n' +
                   '• edt:             label, extends, edtType, stringSize\n' +
                   '• form:            caption, formTemplate, dataSource\n' +
+                  '• security-privilege: label, targetObject (menu item ObjectName), objectType (MenuItemDisplay|MenuItemAction|MenuItemOutput, default: MenuItemDisplay), accessLevel (view=Read only | maintain=Read+Update+Create+Delete, default: view)\n' +
                   '• menu-item-*:     label, object, objectType\n' +
                   'Example enum: properties={"label":"@ContosoExt:Status","enumValues":[{"name":"Open","label":"@ContosoExt:Open"},{"name":"Closed","label":"@ContosoExt:Closed"}]}\n' +
                   'Example table-extension (string EDT field): properties={"fields":[{"name":"ContosoField","edt":"CustAccount","label":"@Contoso:Customer"}]}\n' +

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -352,43 +352,50 @@ public final class ${baseName}EventHandler
 function securityPrivilegeXmlTemplate(name: string, targetMenuItemName: string): string {
   const viewName = name.endsWith('View') ? name : `${name}View`;
   const maintainName = name.endsWith('Maintain') ? name : `${name}Maintain`;
-  return `<!-- ${viewName} (Read access) -->
-<?xml version="1.0" encoding="utf-8"?>
+  // File 1: ViewName.xml
+  const viewXml = `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>${viewName}</Name>
-  <Label>@TODO:LabelId_View</Label>
-  <EntryPoints>
-    <AxSecurityEntryPointReference>
-      <Name>${targetMenuItemName}</Name>
-      <ObjectType>MenuItemDisplay</ObjectType>
-      <Grant>Read</Grant>
-    </AxSecurityEntryPointReference>
-  </EntryPoints>
-</AxSecurityPrivilege>
-
-<!-- ${maintainName} (Update/Create/Delete access) -->
-<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>${maintainName}</Name>
-  <Label>@TODO:LabelId_Maintain</Label>
-  <EntryPoints>
-    <AxSecurityEntryPointReference>
-      <Name>${targetMenuItemName}</Name>
-      <ObjectType>MenuItemDisplay</ObjectType>
-      <Grant>Update</Grant>
-    </AxSecurityEntryPointReference>
-    <AxSecurityEntryPointReference>
-      <Name>${targetMenuItemName}</Name>
-      <ObjectType>MenuItemDisplay</ObjectType>
-      <Grant>Create</Grant>
-    </AxSecurityEntryPointReference>
-    <AxSecurityEntryPointReference>
-      <Name>${targetMenuItemName}</Name>
-      <ObjectType>MenuItemDisplay</ObjectType>
-      <Grant>Delete</Grant>
-    </AxSecurityEntryPointReference>
-  </EntryPoints>
+\t<Name>${viewName}</Name>
+\t<Label>@TODO:LabelId_View</Label>
+\t<DataEntityPermissions />
+\t<DirectAccessPermissions />
+\t<EntryPoints>
+\t\t<AxSecurityEntryPointReference>
+\t\t\t<Name>${targetMenuItemName}</Name>
+\t\t\t<Grant>
+\t\t\t\t<Read>Allow</Read>
+\t\t\t</Grant>
+\t\t\t<ObjectName>${targetMenuItemName}</ObjectName>
+\t\t\t<ObjectType>MenuItemDisplay</ObjectType>
+\t\t\t<Forms />
+\t\t</AxSecurityEntryPointReference>
+\t</EntryPoints>
+\t<FormControlOverrides />
 </AxSecurityPrivilege>`;
+  // File 2: MaintainName.xml
+  const maintainXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${maintainName}</Name>
+\t<Label>@TODO:LabelId_Maintain</Label>
+\t<DataEntityPermissions />
+\t<DirectAccessPermissions />
+\t<EntryPoints>
+\t\t<AxSecurityEntryPointReference>
+\t\t\t<Name>${targetMenuItemName}</Name>
+\t\t\t<Grant>
+\t\t\t\t<Read>Allow</Read>
+\t\t\t\t<Update>Allow</Update>
+\t\t\t\t<Create>Allow</Create>
+\t\t\t\t<Delete>Allow</Delete>
+\t\t\t</Grant>
+\t\t\t<ObjectName>${targetMenuItemName}</ObjectName>
+\t\t\t<ObjectType>MenuItemDisplay</ObjectType>
+\t\t\t<Forms />
+\t\t</AxSecurityEntryPointReference>
+\t</EntryPoints>
+\t<FormControlOverrides />
+</AxSecurityPrivilege>`;
+  return `<!-- FILE 1: ${viewName}.xml (Read access) -->\n${viewXml}\n\n<!-- FILE 2: ${maintainName}.xml (Update/Create/Delete access) -->\n${maintainXml}`;
 }
 
 // ── Menu item XML pattern ────────────────────────────────────────────────

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -2284,16 +2284,33 @@ ${fieldsXml}
 
   /**
    * Generate AxSecurityPrivilege XML.
+   * properties.targetObject  – ObjectName of the target menu item (optional)
+   * properties.objectType    – MenuItemDisplay | MenuItemAction | MenuItemOutput (default: MenuItemDisplay)
+   * properties.accessLevel   – 'view' | 'maintain' | 'read' (default: 'view' = Read only)
    */
   static generateAxSecurityPrivilegeXml(name: string, properties?: Record<string, any>): string {
     const label = properties?.label || '@TODO:LabelId';
+    const targetObject: string | undefined = properties?.targetObject;
+    const objType: string = properties?.objectType || 'MenuItemDisplay';
+
+    let entryPointsXml: string;
+    if (targetObject) {
+      const al = (properties?.accessLevel || 'view').toLowerCase();
+      const grantXml = al === 'maintain'
+        ? '\t\t\t\t<Read>Allow</Read>\n\t\t\t\t<Update>Allow</Update>\n\t\t\t\t<Create>Allow</Create>\n\t\t\t\t<Delete>Allow</Delete>'
+        : '\t\t\t\t<Read>Allow</Read>';
+      entryPointsXml = `\n\t\t<AxSecurityEntryPointReference>\n\t\t\t<Name>${targetObject}</Name>\n\t\t\t<Grant>\n${grantXml}\n\t\t\t</Grant>\n\t\t\t<ObjectName>${targetObject}</ObjectName>\n\t\t\t<ObjectType>${objType}</ObjectType>\n\t\t\t<Forms />\n\t\t</AxSecurityEntryPointReference>\n\t`;
+    } else {
+      entryPointsXml = '';
+    }
+
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
 \t<Label>${label}</Label>
 \t<DataEntityPermissions />
 \t<DirectAccessPermissions />
-\t<EntryPoints />
+\t<EntryPoints>${entryPointsXml}</EntryPoints>
 \t<FormControlOverrides />
 </AxSecurityPrivilege>`;
   }

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -1229,13 +1229,27 @@ ${fieldsXml}
 
   static generateAxSecurityPrivilegeXml(name: string, properties?: Record<string, any>): string {
     const label = properties?.label || '@TODO:LabelId';
+    const targetObject: string | undefined = properties?.targetObject;
+    const objType: string = properties?.objectType || 'MenuItemDisplay';
+
+    let entryPointsXml: string;
+    if (targetObject) {
+      const al = (properties?.accessLevel || 'view').toLowerCase();
+      const grantXml = al === 'maintain'
+        ? '\t\t\t\t<Read>Allow</Read>\n\t\t\t\t<Update>Allow</Update>\n\t\t\t\t<Create>Allow</Create>\n\t\t\t\t<Delete>Allow</Delete>'
+        : '\t\t\t\t<Read>Allow</Read>';
+      entryPointsXml = `\n\t\t<AxSecurityEntryPointReference>\n\t\t\t<Name>${targetObject}</Name>\n\t\t\t<Grant>\n${grantXml}\n\t\t\t</Grant>\n\t\t\t<ObjectName>${targetObject}</ObjectName>\n\t\t\t<ObjectType>${objType}</ObjectType>\n\t\t\t<Forms />\n\t\t</AxSecurityEntryPointReference>\n\t`;
+    } else {
+      entryPointsXml = '';
+    }
+
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
 \t<Label>${label}</Label>
 \t<DataEntityPermissions />
 \t<DirectAccessPermissions />
-\t<EntryPoints />
+\t<EntryPoints>${entryPointsXml}</EntryPoints>
 \t<FormControlOverrides />
 </AxSecurityPrivilege>`;
   }


### PR DESCRIPTION
This pull request introduces improvements to the handling, parsing, and generation of security privilege XML files for menu items in the Dynamics 365 codebase. The main focus is to enhance support for specifying entry points with additional metadata, and to provide clearer documentation and more flexible XML generation for security privileges.

Improvements to security privilege XML generation:

* Added support for specifying `targetObject`, `objectType`, and `accessLevel` when generating security privilege XML in both `generateAxSecurityPrivilegeXml` methods (`src/tools/createD365File.ts`, `src/tools/generateD365Xml.ts`). Entry points now include richer metadata and grant levels are determined based on the access level provided. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR2287-R2313) [[2]](diffhunk://#diff-e1e7fce542c2fc43bba3dd26014907a89b50f9294dc4967e3e8b7354eecdff2bR1232-R1252)
* Updated the XML template in `securityPrivilegeXmlTemplate` (`src/tools/codeGen.ts`) to generate two separate XML files for "View" and "Maintain" access levels, and to include `ObjectName` and detailed grant permissions in each entry point.

Enhancements to metadata parsing:

* Modified the `XppMetadataParser` class in `src/metadata/xmlParser.ts` to parse and return `objectName` for each entry point, improving the accuracy and richness of parsed metadata. [[1]](diffhunk://#diff-3dc98d4fde526517e6592305f0e0f289daeed7b18b8d66cb6b8c9e03fb3ae0c0L816-R816) [[2]](diffhunk://#diff-3dc98d4fde526517e6592305f0e0f289daeed7b18b8d66cb6b8c9e03fb3ae0c0L845-R845)

Documentation updates:

* Expanded the examples and documentation in `src/server/mcpServer.ts` to clarify the properties supported for security privileges, including `label`, `targetObject`, `objectType`, and `accessLevel`.