### PR TITLE
Implement health check for app service and update metadata path

### DIFF
--- a/.azure-pipelines/d365fo-mcp-app-deploy.yml
+++ b/.azure-pipelines/d365fo-mcp-app-deploy.yml
@@ -17,13 +17,6 @@ trigger:
       - 'tsconfig.json'
       - '.azure-pipelines/d365fo-mcp-app-deploy.yml'
 
-# Allow manual run from Azure DevOps UI (Queue build button)
-parameters:
-  - name: forceRedeploy
-    displayName: 'Force redeploy (even without code changes)'
-    type: boolean
-    default: false
-
 pool:
   vmImage: 'ubuntu-latest'
 
@@ -81,24 +74,6 @@ stages:
               archiveType: zip
               archiveFile: '$(Build.ArtifactStagingDirectory)/app.zip'
               replaceExistingArchive: true
-              exclude: |
-                .git/**
-                .azure-pipelines/**
-                scripts/**
-                tests/**
-                test-data/**
-                coverage/**
-                src/**
-                docs/**
-                infrastructure/**
-                data/**
-                metadata/**
-                database/**
-                *.md
-                tsconfig.json
-                vitest.config.ts
-                .env*
-                .mcp.json*
 
           - task: PublishBuildArtifacts@1
             displayName: 'Publish artifact'
@@ -145,3 +120,26 @@ stages:
                     deployToSlotOrASE: false
                     enableCustomDeployment: true
                     DeploymentType: zipDeploy
+
+                # Poll /health until the app responds 200 or timeout (10 min).
+                # In read-only mode the app downloads the SQLite metadata DB from
+                # Azure Blob Storage (300–600 MB) before opening the HTTP port —
+                # this typically takes 2–5 minutes on a cold start.
+                - script: |
+                    HEALTH_URL="https://$(AZURE_APP_SERVICE_NAME).azurewebsites.net/health"
+                    echo "Waiting 30 s for App Service restart before polling..."
+                    sleep 30
+                    echo "Polling $HEALTH_URL (max 10 min, every 15 s)..."
+                    for i in $(seq 1 40); do
+                      STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL")
+                      echo "Attempt $i/40: HTTP $STATUS"
+                      if [ "$STATUS" = "200" ]; then
+                        echo "✅ Health check passed."
+                        exit 0
+                      fi
+                      sleep 15
+                    done
+                    echo "❌ Health check FAILED — app did not respond with HTTP 200 within 10 minutes."
+                    echo "   Check App Service logs: az webapp log tail --name $(AZURE_APP_SERVICE_NAME) --resource-group <rg>"
+                    exit 1
+                  displayName: 'Health check — verify /health returns 200 (10 min timeout)'

--- a/.azure-pipelines/d365fo-mcp-data-extract-and-build-custom.yml
+++ b/.azure-pipelines/d365fo-mcp-data-extract-and-build-custom.yml
@@ -40,7 +40,7 @@ variables:
   - name: LABELS_DB_PATH
     value: './database/xpp-metadata-labels.db'
   - name: PACKAGES_PATH
-    value: '$(Build.SourcesDirectory)/Metadata'
+    value: '$(Build.SourcesDirectory)/your/path/to/metadata' // Path to the metadata files from the Git repository
   - name: MCP_SERVER_PATH
     value: '$(Pipeline.Workspace)/mcp-server'
 

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -32,9 +32,9 @@ param storageSku string = 'Standard_LRS'
 @description('Comma-separated label languages to index. Each language adds ~125 MB. Examples: en-US,cs,de  or  en-US')
 param labelLanguages string = 'en-US,cs,sk,de'
 
-var appServicePlanName = 'asp-${appName}'
-var appServiceName = 'app-${appName}-${uniqueString(resourceGroup().id)}'
-var storageAccountName = 'st${replace(appName, '-', '')}${uniqueString(resourceGroup().id)}'
+var appServicePlanName = '${appName}-plan'
+var appServiceName = appName
+var storageAccountName = replace(appName, '-', '')
 // B-tier uses 'Basic', P-tier uses 'PremiumV3'
 var appServiceTier = startsWith(appServiceSku, 'B') ? 'Basic' : 'PremiumV3'
 
@@ -92,17 +92,6 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2023-01-01' = {
   }
 }
 
-// Application Insights
-resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
-  name: 'appi-${appName}'
-  location: location
-  kind: 'web'
-  properties: {
-    Application_Type: 'web'
-    Request_Source: 'rest'
-  }
-}
-
 // App Service (Web App)
 resource appService 'Microsoft.Web/sites@2023-01-01' = {
   name: appServiceName
@@ -156,7 +145,7 @@ resource appService 'Microsoft.Web/sites@2023-01-01' = {
         }
         {
           name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
-          value: 'true'
+          value: 'false'
         }
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
@@ -184,4 +173,3 @@ output mcpEndpoint string = 'https://${appService.properties.defaultHostName}/mc
 output storageAccountName string = storageAccount.name
 output metadataContainerName string = metadataContainer.name
 output packagesContainerName string = packagesContainer.name
-output appInsightsInstrumentationKey string = appInsights.properties.InstrumentationKey


### PR DESCRIPTION
This pull request makes several updates to the Azure deployment pipeline and infrastructure configuration for the MCP app. Key changes include improvements to health checks after deployment, simplification of archive steps, and modifications to infrastructure naming and build behavior. The most important changes are grouped below by theme.

**Azure Pipeline Improvements:**

* Added a post-deployment health check script to poll the `/health` endpoint, ensuring the app responds with HTTP 200 within 10 minutes. This helps verify successful startup, especially after cold starts.
* Removed the manual redeploy parameter from the pipeline, simplifying the process and reducing confusion in the Azure DevOps UI.
* Simplified the archive step by removing the list of excluded files and directories, making artifact creation more straightforward.

**Infrastructure Configuration Updates:**

* Changed naming conventions for Azure resources in `main.bicep` to use simpler and more predictable names (e.g., `appServicePlanName`, `appServiceName`, and `storageAccountName`).
* Disabled build during deployment by setting `SCM_DO_BUILD_DURING_DEPLOYMENT` to `false`, which can improve deployment reliability and speed.
* Removed Application Insights resource and its output from the infrastructure template, streamlining resource provisioning. [[1]](diffhunk://#diff-9f47a3690f2243e268bf2be862538eb3943f51543bf8e0fd2891b66ba1f73c85L95-L105) [[2]](diffhunk://#diff-9f47a3690f2243e268bf2be862538eb3943f51543bf8e0fd2891b66ba1f73c85L187)

**Pipeline Variable Update:**

* Updated the `PACKAGES_PATH` variable in the data extract pipeline to clarify the path to metadata files from the Git repository.