### PR TITLE
ci: opt into Node.js 24 for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint-and-build:
     name: Lint & Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
 env:
   AZURE_WEBAPP_NAME: d365fo-mcp-server  # Replace with your app name
   NODE_VERSION: '24.x'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   create-release:
     name: Create GitHub Release


### PR DESCRIPTION
Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to ci.yml, deploy.yml and release.yml to suppress Node.js 20 deprecation warnings. infrastructure.yml was already updated in previous commit.