### PR TITLE
Refactor Azure deployment configurations and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,28 +33,6 @@ MCP_SERVER_MODE=full
 DB_PATH=./data/xpp-metadata.db
 
 # =============================================================================
-# D365 FINANCE & OPERATIONS CONNECTION (Required for metadata extraction)
-# =============================================================================
-# Where to find this: Azure Portal > Azure Active Directory > App registrations
-# Create a new app registration for your D365 F&O environment
-
-# Tenant ID - Find in: Azure Portal > Azure Active Directory > Overview
-D365_TENANT_ID=your-tenant-id-here
-
-# Client (Application) ID - Find in: Your app registration > Overview
-D365_CLIENT_ID=your-client-id-here
-
-# Client Secret - Find in: Your app registration > Certificates & secrets > New client secret
-D365_CLIENT_SECRET=your-client-secret-here
-
-# D365 F&O Environment URL - Your D365 environment base URL
-# Example: https://mycompany.operations.dynamics.com
-D365_RESOURCE_URL=https://your-environment.operations.dynamics.com
-
-# OData API Endpoint - Usually {D365_RESOURCE_URL}/data
-ODATA_ENDPOINT=https://your-environment.operations.dynamics.com/data
-
-# =============================================================================
 # METADATA EXTRACTION
 # =============================================================================
 # Development environment type: auto (default), traditional, ude (Power Platform Tools)
@@ -178,9 +156,3 @@ RATE_LIMIT_AUTH_MAX_REQUESTS=5
 
 # Blob name/path for the database file
 # BLOB_DATABASE_NAME=xpp-metadata.db
-
-# =============================================================================
-# APPLICATION INSIGHTS (Optional - For production monitoring)
-# =============================================================================
-# Find in: Azure Portal > Application Insights > Overview
-# APPINSIGHTS_INSTRUMENTATIONKEY=your-instrumentation-key-here

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,9 @@ jobs:
   build:
     name: Build Application
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -61,6 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      id-token: write   # required for OIDC login
+      contents: read
     
     steps:
       - name: Download deployment artifact
@@ -71,7 +76,9 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to Azure App Service
         uses: azure/webapps-deploy@v3

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -34,6 +34,9 @@ jobs:
   deploy-infrastructure:
     name: Deploy Bicep to Azure
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for OIDC login
+      contents: read
 
     env:
       # Prefer manual input; fall back to repository secret for automated runs.
@@ -57,7 +60,9 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Create parameters file
         run: |

--- a/docs/SETUP_AZURE.md
+++ b/docs/SETUP_AZURE.md
@@ -90,7 +90,7 @@ In the Azure Portal, go to the App Service → **Settings** → **Environment va
 | `LABEL_LANGUAGES` | e.g. `en-US,cs,de` | Comma-separated; each language adds ~125 MB |
 | `MCP_SERVER_MODE` | `read-only` | Hides file-creation tools; use local companion for writes |
 | `NODE_ENV` | `production` | |
-| `SCM_DO_BUILD_DURING_DEPLOYMENT` | `true` | Oryx runs `npm ci` on deploy |
+| `SCM_DO_BUILD_DURING_DEPLOYMENT` | `false` | Pre-built `node_modules` are shipped in the deploy zip — Oryx must NOT run `npm ci` (no gcc/make on App Service Linux) |
 | `WEBSITE_NODE_DEFAULT_VERSION` | `~24` | |
 
 **Optional — Redis (recommended for teams):**
@@ -122,14 +122,17 @@ For a **manual one-time deploy** (from your Windows machine):
    cd d365fo-mcp-server
    npm install
    npm run build
-   # Do NOT include node_modules — Oryx rebuilds them on App Service for Linux
-   Compress-Archive -Path dist, package.json, package-lock.json, startup.sh `
+   # Include node_modules — must be compiled for Linux (native better-sqlite3 addon)
+   # If building on Windows, use WSL2 or a Linux Docker container for npm install
+   Compress-Archive -Path dist, node_modules, package.json, package-lock.json, startup.sh `
      -DestinationPath deploy.zip
    ```
 
 2. Upload via the Portal: Web App → **Deployment Center** → **Deploy** → upload `deploy.zip`.
 
-> The `better-sqlite3` addon is a native module. Including Windows-compiled `node_modules` breaks the server on Linux. With `SCM_DO_BUILD_DURING_DEPLOYMENT=true`, Oryx runs `npm ci` after unpacking and compiles for Linux.
+> **Important:** `better-sqlite3` is a native module that must be compiled for Linux. `node_modules` built on Windows will crash the server.
+> Use the **Azure DevOps pipeline** (recommended) — it builds on `ubuntu-latest`, which shares the same glibc as App Service Linux, so the compiled binaries are compatible.
+> `SCM_DO_BUILD_DURING_DEPLOYMENT` is set to `false` because App Service Linux has no gcc/make to rebuild native addons.
 
 ---
 


### PR DESCRIPTION
This pull request updates deployment workflows and documentation to improve Azure compatibility and clarify environment setup. The main changes are the migration to OIDC authentication for Azure login, adjustments to build and deployment artifacts to support native modules, and improved documentation for production deployments.

**CI/CD Workflow Improvements:**

* Migrated Azure login in `.github/workflows/deploy.yml` and `.github/workflows/infrastructure.yml` from using `AZURE_CREDENTIALS` to OIDC-based authentication with `client-id`, `tenant-id`, and `subscription-id` inputs. Updated job permissions to include `id-token: write` and `contents: read` for secure OIDC login. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R66-R68) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L74-R81) [[3]](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40R37-R39) [[4]](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40L60-R65)
* Added `contents: read` permissions to the build job in `.github/workflows/deploy.yml` for improved security and compliance.

**Documentation and Deployment Artifact Updates:**

* Updated `docs/SETUP_AZURE.md` to clarify that `SCM_DO_BUILD_DURING_DEPLOYMENT` should be set to `false` and that pre-built `node_modules` (compiled for Linux) must be included in the deployment zip. Provided guidance for building native modules on Linux and explained why App Service Linux cannot rebuild them. [[1]](diffhunk://#diff-dab4e16984a3c7559ce090b78baeba3b59a8a917240ace8eae03889a370088a8L93-R93) [[2]](diffhunk://#diff-dab4e16984a3c7559ce090b78baeba3b59a8a917240ace8eae03889a370088a8L125-R135)

**Environment Configuration Cleanup:**

* Removed D365 Finance & Operations and Application Insights configuration sections from `.env.example` to streamline and clarify required environment variables. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL35-L56) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL181-L186)