### PR TITLE
feat: implement get_method_source tool to retrieve full X++ method so…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,7 +76,8 @@ This workspace contains D365FO code. **Always use the specialized MCP tools** �
 > **Pattern:**
 > ```
 > 1. get_class_info("MyClass")                       analyze (compact=true by default)
-> 2. get_method_signature(class, method)             only if you need a body
+> 2. get_method_source(class, method)               to read the full body
+>    get_method_signature(class, method)            only if you need exact signature for CoC
 > 3. modify_d365fo_file()                            apply
 >    NOT: replace_string_in_file                       FORBIDDEN
 >    NOT: PowerShell script                            FORBIDDEN
@@ -85,7 +86,7 @@ This workspace contains D365FO code. **Always use the specialized MCP tools** �
 > ## ⚡ TOKEN BUDGET — READ BEFORE EVERY CALL
 >
 > - `get_class_info` returns **signatures only** by default (`compact=true`) — do NOT pass `compact=false` unless you need to read a body
-> - **NEVER call `get_class_info` more than 2× per turn** — use `get_method_signature(class, method)` for individual method bodies
+> - **NEVER call `get_class_info` more than 2× per turn** — use `get_method_source(class, method)` for individual method bodies (full source); use `get_method_signature(class, method)` only when you need the exact signature for CoC
 > - `search_extensions` can return large results — use at most once per turn
 
 ---
@@ -231,8 +232,9 @@ When the user asks to **refactor**, **improve**, **clean up**, **optimize**, or 
                            → e.g. "validation", "query pattern", "error handling"
                            → shows how standard D365FO code solves the same problem
 
-4. Read specific bodies:   get_method_signature("ClassName", "methodName")
+4. Read specific bodies:   get_method_source("ClassName", "methodName")
                            → use for EACH method you intend to change
+                           → returns the FULL source code (not just the signature)
                            → NEVER guess the body from the signature
 
 5. Find usages:            find_references("ClassName")  or  find_references("methodName")
@@ -433,7 +435,8 @@ c) Save to disk:                     create_d365fo_file(objectType="report", obj
 | `get_view_info(viewName)` | View / data entity structure |
 | `get_data_entity_info(entityName)` | Data entity: category, OData settings, datasources, keys, field mappings |
 | `get_report_info(reportName)` | **Read AxReport structure** — datasets, fields, designs, RDL summary. Use INSTEAD of PowerShell Get-Content |
-| `get_method_signature(className, methodName, includeCocTemplate?)` | **Preferred way to get a full method body** — required before CoC. Pass `includeCocTemplate: true` only when writing a CoC extension |
+| `get_method_source(className, methodName)` | **Full X++ source code** — use when you need to understand what the method does (complete business logic, conditions, loops) |
+| `get_method_signature(className, methodName, includeCocTemplate?)` | **Exact signature** — required before CoC. Pass `includeCocTemplate: true` only when writing a CoC extension |
 | `find_references(targetName, targetType?)` | Where-used analysis |
 
 ### Security & Extensions

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -32,7 +32,7 @@ just ask in plain English.
 | **get_edt_info** | Extended Data Type definition: base type, labels, properties | "Show me EDT properties for CustAccount" |
 | **code_completion** | List methods/fields on a class or table | "What methods start with 'calc' on SalesTable?" |
 
-### Advanced Object Info (6 tools)
+### Advanced Object Info (7 tools)
 
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|
@@ -41,6 +41,7 @@ just ask in plain English.
 | **get_view_info** | View/data entity: fields, relations, methods | "Show me GeneralJournalAccountEntryView" |
 | **get_report_info** | AxReport structure: datasets, fields, designs, RDL summary | "Show me the dataset fields of InventValue report" |
 | **get_method_signature** | Exact signature for CoC extensions | "Get signature of CustTable.validateWrite()" |
+| **get_method_source** | Full X++ source code of a method | "Show me the full implementation of SalesTable.validateWrite()" |
 | **find_references** | Where is this class/method/field used? | "Where is DimensionAttributeValueSet used?" |
 
 ### Intelligent Code Generation (4 tools)
@@ -227,6 +228,24 @@ wrong signature always causes a compilation error.
 ```
 Get the signature of SalesTable.validateWrite()
 What parameters does InventTable.initFromTable() take?
+```
+
+---
+
+### get_method_source
+
+Returns the complete X++ source code of a method — the full implementation including all
+conditions, loops, transaction handling, and error logic. Use this when the signature alone is
+not enough and you need to understand what the method actually does.
+
+The database stores the full body alongside the snippet, so no file I/O is needed at query time.
+Falls back to the extracted JSON metadata when the database was built before this feature was added.
+
+**Examples:**
+```
+Show me the full implementation of SalesTable.validateWrite()
+What does InventUpd_Reservation.updateReservation() actually do?
+Show me the posting logic in SalesInvoiceJournalPost.run()
 ```
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -564,13 +564,13 @@ async function main() {
     });
 
     // Log tool count immediately (transport is already connected)
-    const totalTools = 42;
+    const totalTools = 43;
     const localToolCount = LOCAL_TOOLS.size;
     const toolCount = SERVER_MODE === 'write-only' ? localToolCount :
                      SERVER_MODE === 'read-only' ? totalTools - localToolCount : totalTools;
     const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(LOCAL_TOOLS).join(', ')})` :
                     SERVER_MODE === 'read-only' ? '(all except local tools)' :
-                    '(1 workspace-config + 8 discovery + 4 labels + 6 object-info + 4 intelligent + 3 smart-generation + 4 file-ops + 3 pattern-analysis + 9 security-extensions)';
+                    '(1 workspace-config + 8 discovery + 4 labels + 7 object-info + 4 intelligent + 3 smart-generation + 4 file-ops + 3 pattern-analysis + 9 security-extensions)';
     console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
@@ -644,6 +644,7 @@ async function main() {
           { name: 'get_view_info',                desc: 'View/data entity fields, relations, computed columns' },
           { name: 'get_report_info',              desc: 'AxReport datasets, fields, designs and RDL summary' },
           { name: 'get_method_signature',         desc: 'Exact method signature (required before CoC extensions)' },
+          { name: 'get_method_source',            desc: 'Full X++ source code of a method (complete business logic)' },
           { name: 'find_references',              desc: 'Where-used analysis across the entire codebase' },
         ]},
         { icon: '🧠', category: 'Intelligent Code Generation', tools: [

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -149,6 +149,7 @@ export class XppSymbolIndex {
         description TEXT,
         tags TEXT,
         source_snippet TEXT,
+        source TEXT,
         complexity INTEGER,
         used_types TEXT,
         method_calls TEXT,
@@ -176,6 +177,7 @@ export class XppSymbolIndex {
         ['description', 'TEXT'],
         ['tags', 'TEXT'],
         ['source_snippet', 'TEXT'],
+        ['source', 'TEXT'],
         ['complexity', 'INTEGER'],
         ['used_types', 'TEXT'],
         ['method_calls', 'TEXT'],
@@ -509,11 +511,11 @@ export class XppSymbolIndex {
       stmt = this.db.prepare(`
         INSERT OR REPLACE INTO symbols (
           name, type, parent_name, signature, file_path, model, package_name,
-          description, tags, source_snippet, complexity, used_types, method_calls,
+          description, tags, source_snippet, source, complexity, used_types, method_calls,
           inline_comments, extends_class, implements_interfaces, usage_example,
           usage_frequency, pattern_type, typical_usages, called_by_count, related_methods, api_patterns
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
       this.stmtCache.set('addSymbol', stmt);
     }
@@ -529,6 +531,7 @@ export class XppSymbolIndex {
       symbol.description || null,
       symbol.tags || null,
       symbol.sourceSnippet || null,
+      symbol.source || null,
       symbol.complexity || null,
       symbol.usedTypes || null,
       symbol.methodCalls || null,
@@ -1167,6 +1170,7 @@ export class XppSymbolIndex {
               description: method.documentation,
               tags: method.tags?.join(', '),
               sourceSnippet: method.sourceSnippet,
+              source: method.source,
               complexity: method.complexity,
               usedTypes: method.usedTypes?.join(', '),
               methodCalls: method.methodCalls?.join(', '),

--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -140,6 +140,7 @@ export interface XppSymbol {
   description?: string;         // Human-readable description
   tags?: string;                // Comma-separated tags (stored as TEXT in SQLite)
   sourceSnippet?: string;       // First 10 lines for preview
+  source?: string;              // Full method source code
   complexity?: number;          // Complexity score (0-100)
   usedTypes?: string;           // Comma-separated types used
   methodCalls?: string;         // Comma-separated method calls

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1107,6 +1107,40 @@ Examples:
           },
         },
         {
+          name: 'get_method_source',
+          description: `📄 Get the full X++ source code of a specific method. Use this when you need to understand the complete implementation — business logic, conditions, loops, error handling — not just the signature.
+
+Returns:
+- Complete method body as X++ code
+- Method signature
+- Model name
+
+Use WHEN:
+- Analysing what a method actually does (not just its signature)
+- Understanding business logic before writing an extension
+- Reviewing validation rules, posting logic, or workflow steps
+- Comparing implementations across classes
+
+Examples:
+- get_method_source("SalesTable", "validateWrite") → full validation logic
+- get_method_source("CustTable", "insert") → complete insert implementation
+- get_method_source("InventUpd_Reservation", "updateReservation") → full reservation logic`,
+          inputSchema: {
+            type: 'object',
+            properties: {
+              className: {
+                type: 'string',
+                description: 'Name of the class containing the method',
+              },
+              methodName: {
+                type: 'string',
+                description: 'Name of the method to retrieve source code for',
+              },
+            },
+            required: ['className', 'methodName'],
+          },
+        },
+        {
           name: 'get_form_info',
           description: `📋 Get complete D365FO form structure including datasources, control hierarchy (buttons, grids, tabs, groups), methods, and form architecture. Essential for form customization and extensions.
 

--- a/src/tools/getMethodSource.ts
+++ b/src/tools/getMethodSource.ts
@@ -1,0 +1,81 @@
+/**
+ * Get Method Source Tool
+ * Returns the full X++ source code of a method stored in the symbols database.
+ * Falls back to reading the extracted JSON metadata file when the DB row predates
+ * the source column (built before this feature was added).
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+import { readMethodMetadata } from '../utils/metadataResolver.js';
+
+const GetMethodSourceArgsSchema = z.object({
+  className: z.string().describe('Name of the class containing the method'),
+  methodName: z.string().describe('Name of the method'),
+});
+
+export async function getMethodSourceTool(request: CallToolRequest, context: XppServerContext) {
+  try {
+    const args = GetMethodSourceArgsSchema.parse(request.params.arguments);
+    const { symbolIndex } = context;
+    const { className, methodName } = args;
+
+    // 1. Look up the symbol row to get model + source
+    const row = symbolIndex.db.prepare(`
+      SELECT source, signature, model, file_path
+      FROM symbols
+      WHERE type = 'method'
+        AND parent_name = ?
+        AND name = ?
+      LIMIT 1
+    `).get(className, methodName) as { source: string | null; signature: string | null; model: string; file_path: string } | undefined;
+
+    if (!row) {
+      return {
+        content: [{
+          type: 'text',
+          text: `❌ Method **${className}.${methodName}** not found in the index.\n\nMake sure the class name and method name are correct. Use \`search\` or \`get_class_info\` to discover available methods.`,
+        }],
+        isError: true,
+      };
+    }
+
+    let source = row.source ?? null;
+
+    // 2. Fallback: DB built before source column was added → read from JSON
+    if (!source) {
+      const extracted = await readMethodMetadata(row.model, className, methodName);
+      source = extracted?.source ?? null;
+    }
+
+    if (!source) {
+      return {
+        content: [{
+          type: 'text',
+          text: `⚠️ Source code for **${className}.${methodName}** is not available.\n\nThe database may have been built before source storage was enabled. Re-run \`build-database\` to populate source code.`,
+        }],
+      };
+    }
+
+    const output = [
+      `## ${className}.${methodName}`,
+      '',
+      row.signature ? `**Signature:** \`${row.signature}\`` : '',
+      `**Model:** ${row.model}`,
+      '',
+      '```xpp',
+      source,
+      '```',
+    ].filter(line => line !== undefined).join('\n');
+
+    return {
+      content: [{ type: 'text', text: output }],
+    };
+  } catch (err) {
+    return {
+      content: [{ type: 'text', text: `❌ Error: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -19,6 +19,7 @@ import { handleCreateD365File } from './createD365File.js';
 import { findReferencesTool } from './findReferences.js';
 import { modifyD365FileTool } from './modifyD365File.js';
 import { getMethodSignatureTool } from './methodSignature.js';
+import { getMethodSourceTool } from './getMethodSource.js';
 import { getFormInfoTool } from './formInfo.js';
 import { getQueryInfoTool } from './queryInfo.js';
 import { getViewInfoTool } from './viewInfo.js';
@@ -209,6 +210,8 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         return modifyD365FileTool(request, context);
       case 'get_method_signature':
         return getMethodSignatureTool(request, context);
+      case 'get_method_source':
+        return getMethodSourceTool(request, context);
       case 'get_form_info':
         return getFormInfoTool(request, context);
       case 'get_query_info':


### PR DESCRIPTION
This pull request introduces a new MCP tool, `get_method_source`, which provides the full X++ source code for a method. The changes span documentation, tool registration, database schema, and implementation, making it easier for developers to analyze and understand business logic in D365FO code. The tool complements the existing `get_method_signature` by offering complete method bodies, with fallback support for older databases.

**New tool: Full method source retrieval**

* Added `get_method_source` tool: Returns the complete X++ source code for a method, including business logic, conditions, and loops. Registered in the server and tool handler, and documented in both user and developer guides. [[1]](diffhunk://#diff-5543ec34c4b55208628f7614f652c2486b7e70dbb70fde6e2e61b53f01ccd42bR1-R81) [[2]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dR22) [[3]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dR213-R214) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R647) [[5]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R1109-R1142) [[6]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95R44) [[7]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95R235-R252) [[8]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L567-R573)

**Database schema and metadata enhancements**

* Extended `XppSymbolIndex` and `XppSymbol` types to store and retrieve the full method source (`source` column), updating all relevant insert and query logic. [[1]](diffhunk://#diff-24d47911da9fe8bf9c3832e1a6e81b78a28d43dac7d0236e8b9655d43c4fcc3fR152) [[2]](diffhunk://#diff-24d47911da9fe8bf9c3832e1a6e81b78a28d43dac7d0236e8b9655d43c4fcc3fR180) [[3]](diffhunk://#diff-24d47911da9fe8bf9c3832e1a6e81b78a28d43dac7d0236e8b9655d43c4fcc3fL512-R518) [[4]](diffhunk://#diff-24d47911da9fe8bf9c3832e1a6e81b78a28d43dac7d0236e8b9655d43c4fcc3fR534) [[5]](diffhunk://#diff-24d47911da9fe8bf9c3832e1a6e81b78a28d43dac7d0236e8b9655d43c4fcc3fR1173) [[6]](diffhunk://#diff-69846ae5af5732bf5624f1558ee9eb4803b8b5342f9f821f335639e4d206b03aR143)

**Documentation updates**

* Updated `.github/copilot-instructions.md` and `docs/MCP_TOOLS.md` to clarify the distinction between `get_method_source` (full body) and `get_method_signature` (exact signature), including usage patterns, token budget guidance, and example prompts. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L79-R80) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L88-R89) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L234-R237) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L436-R439) [[5]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L35-R35)

**Tool count and category adjustments**

* Increased the registered tool count and updated the "Advanced Object Info" category to reflect the addition of `get_method_source`.

**User experience improvements**

* Provided detailed error handling and fallback logic in the new tool to ensure users receive helpful messages when source code is unavailable or the database is outdated.