### PR TITLE
docs: fix remaining 42→43 tool count and clarify DB size by UnitTest …

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**42 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
+**43 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
@@ -91,7 +91,7 @@ Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
 
 ---
 
-## What Copilot can do — 42 X++ tools
+## What Copilot can do — 43 X++ tools
 
 ### Workspace & Diagnostics
 | Ask Copilot | Tool used |
@@ -162,7 +162,7 @@ Host on Azure App Service so the whole team shares one instance — nobody needs
 | Resource | Configuration | Monthly cost |
 |----------|---------------|-------------|
 | App Service Basic B3 | 4 vCPU, 7 GB RAM | ~$52 |
-| Blob Storage | ~3.5 GB (symbols + labels) | ~$3 |
+| Blob Storage | ~2.5–3.5 GB (symbols + labels, without/with UnitTest models) | ~$3 |
 | Azure Managed Redis (optional) Basic B0 | 2 vCPU, 0.5 GB Cache | ~$27 |
 | **Total without Redis** | | **~$55 / month** |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -377,7 +377,7 @@ graph TB
 ## Database Schema
 
 **Dual-Database Architecture** for performance optimization:
-- **Symbols Database** (`xpp-metadata.db`, ~3 GB) — Fast symbol searches
+- **Symbols Database** (`xpp-metadata.db`, ~2 GB without UnitTest models / ~3 GB with) — Fast symbol searches
 - **Labels Database** (`xpp-metadata-labels.db`, ~500 MB for 4 languages, up to 8 GB for all 70 languages) — Isolated label storage
 
 ### Symbols Database
@@ -939,7 +939,7 @@ graph LR
 
 ### Current Capacity
 
-- **Storage:** ~3 GB symbols database + ~500 MB labels database (4 languages) = ~3.5 GB total
+- **Storage:** ~2–3 GB symbols database (without/with UnitTest models) + ~500 MB labels database (4 languages) = ~2.5–3.5 GB total
 - **Memory:** 1.75GB (P0v3) - ~800MB used
 - **Throughput:** 100 req/15min per IP
 - **Latency:** 

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -59,7 +59,7 @@ xpp-metadata/
 │       ├── YourModel2/
 │       └── ...
 └── database/
-    ├── xpp-metadata.db     # Compiled symbols database (~3 GB)
+    ├── xpp-metadata.db     # Compiled symbols database (~2 GB without UnitTest models, ~3 GB with)
     └── xpp-metadata-labels.db  # Compiled labels database (~500 MB for 4 languages)
 ```
 
@@ -440,7 +440,7 @@ env:
 
 **Storage Costs:**
 - Metadata: ~2-3 GB → ~$0.05/month
-- Database: ~3 GB → ~$0.06/month
+- Database: ~2–3 GB (without/with UnitTest models) → ~$0.04–0.06/month
 - PackagesLocalDirectory.zip: ~5-10 GB → ~$0.15/month
 - Total: ~$0.23/month
 
@@ -460,7 +460,7 @@ env:
 - ✅ Review execution times for anomalies
 
 #### Monthly
-- ✅ Verify database size (~3.5 GB total expected: ~3 GB symbols + ~500 MB labels)
+- ✅ Verify database size (~2.5–3.5 GB total: ~2–3 GB symbols (without/with UnitTest models) + ~500 MB labels)
 - ✅ Check blob storage usage
 - ✅ Review App Service metrics
 
@@ -516,7 +516,7 @@ env:
 1. Review CUSTOM_MODELS variable
 2. Remove unnecessary models
 3. Re-run extraction
-4. Expected size: ~3.5 GB total (~3 GB symbols + ~500 MB labels)
+4. Expected size: ~2.5–3.5 GB total (~2–3 GB symbols depending on whether UnitTest models are included + ~500 MB labels)
 ```
 
 ---

--- a/docs/SETUP_AZURE.md
+++ b/docs/SETUP_AZURE.md
@@ -45,7 +45,7 @@ Developer's Windows VM
 
 | Resource | Purpose | Minimum SKU |
 |----------|---------|------------|
-| Azure Blob Storage | Stores `xpp-metadata.db` (~3 GB) and labels database (~500 MB) | Standard LRS |
+| Azure Blob Storage | Stores `xpp-metadata.db` (~2–3 GB depending on UnitTest models) and labels database (~500 MB) | Standard LRS |
 | Azure App Service Plan | Hosts the Node.js server | B3 (dev/test), P0v3 (production) |
 | Azure App Service (Web App) | Runs the MCP server | Linux, Node 24 LTS |
 | Azure Managed Redis | Optional — speeds up repeated queries | B0 Basic or higher |


### PR DESCRIPTION
This pull request updates documentation to reflect more accurate storage requirements and tool counts, particularly clarifying the size of the symbols database depending on whether UnitTest models are included. It also updates the number of X++ tools from 42 to 43.

**Documentation updates for tool count:**
* Updated the number of X++ tools from 42 to 43 in the `README.md` to reflect the addition of a new tool. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R94)

**Clarifications and corrections to storage/database size:**
* Updated all documentation references to the `xpp-metadata.db` symbols database size to specify it is ~2 GB without UnitTest models and ~3 GB with, including in `README.md`, `docs/ARCHITECTURE.md`, `docs/PIPELINES.md`, and `docs/SETUP_AZURE.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L165-R165) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L380-R380) [[3]](diffhunk://#diff-23881559362acc36fac83e8cba022294cc1356bed7217223a454711abcc1d0d8L62-R62) [[4]](diffhunk://#diff-dab4e16984a3c7559ce090b78baeba3b59a8a917240ace8eae03889a370088a8L48-R48)
* Adjusted total storage size estimates throughout the documentation to reflect the new symbols database size range (2.5–3.5 GB total, depending on inclusion of UnitTest models). [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L942-R942) [[2]](diffhunk://#diff-23881559362acc36fac83e8cba022294cc1356bed7217223a454711abcc1d0d8L443-R443) [[3]](diffhunk://#diff-23881559362acc36fac83e8cba022294cc1356bed7217223a454711abcc1d0d8L463-R463) [[4]](diffhunk://#diff-23881559362acc36fac83e8cba022294cc1356bed7217223a454711abcc1d0d8L519-R519)