### PR TITLE
add Azure deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ The database downloads from Azure Blob Storage automatically on startup.
 
 Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.md](docs/PIPELINES.md)
 
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fdynamics365ninja%2Fd365fo-mcp-server%2Frefs%2Fheads%2Fmain%2Finfrastructure%2Fazuredeploy.json)
+
 ---
 
 ## Documentation

--- a/docs/SETUP_AZURE.md
+++ b/docs/SETUP_AZURE.md
@@ -74,6 +74,10 @@ In the **Azure Portal**:
 5. Enable **System-assigned managed identity** on the Web App
    (Web App → Settings → Identity → System assigned → On)
 
+For a one-click deployment that also includes the app settings and startup command from step 2, use this Azure Deploy button (note: this will not include the optional Redis resource).
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fdynamics365ninja%2Fd365fo-mcp-server%2Frefs%2Fheads%2Fmain%2Finfrastructure%2Fazuredeploy.json)
+
 ---
 
 ## Step 2 — Configure App Settings

--- a/infrastructure/azuredeploy.json
+++ b/infrastructure/azuredeploy.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.40.2.10011",
+      "templateHash": "13972538043223312628"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for resources"
+      }
+    },
+    "appServiceSku": {
+      "type": "string",
+      "defaultValue": "B3",
+      "allowedValues": [
+        "B1",
+        "B2",
+        "B3",
+        "P0v3",
+        "P1v3",
+        "P2v3"
+      ],
+      "metadata": {
+        "description": "App Service Plan SKU — B3 recommended (4 vCPU / 7 GB RAM); B1/B2 for dev/test"
+      }
+    },
+    "nodeVersion": {
+      "type": "string",
+      "defaultValue": "24-lts",
+      "metadata": {
+        "description": "Node.js version"
+      }
+    },
+    "storageSku": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS"
+      ],
+      "metadata": {
+        "description": "Storage account SKU"
+      }
+    },
+    "labelLanguages": {
+      "type": "string",
+      "defaultValue": "en-US,cs,sk,de",
+      "metadata": {
+        "description": "Comma-separated label languages to index. Each language adds ~125 MB. Examples: en-US,cs,de  or  en-US"
+      }
+    }
+  },
+  "variables": {
+    "appName": "[resourceGroup().name]",
+    "appServicePlanName": "[format('{0}-plan', variables('appName'))]",
+    "appServiceName": "[variables('appName')]",
+    "storageAccountName": "[replace(variables('appName'), '-', '')]",
+    "appServiceTier": "[if(startsWith(parameters('appServiceSku'), 'B'), 'Basic', 'PremiumV3')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('storageSku')]"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot",
+        "allowBlobPublicAccess": false,
+        "minimumTlsVersion": "TLS1_2",
+        "supportsHttpsTrafficOnly": true
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices",
+      "apiVersion": "2023-01-01",
+      "name": "[format('{0}/{1}', variables('storageAccountName'), 'default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2023-01-01",
+      "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', 'xpp-metadata')]",
+      "properties": {
+        "publicAccess": "None"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('storageAccountName'), 'default')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2023-01-01",
+      "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', 'packages')]",
+      "properties": {
+        "publicAccess": "None"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('storageAccountName'), 'default')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2023-01-01",
+      "name": "[variables('appServicePlanName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('appServiceSku')]",
+        "tier": "[variables('appServiceTier')]",
+        "capacity": 1
+      },
+      "kind": "linux",
+      "properties": {
+        "reserved": true
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2023-01-01",
+      "name": "[variables('appServiceName')]",
+      "location": "[parameters('location')]",
+      "kind": "app,linux",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
+        "httpsOnly": true,
+        "siteConfig": {
+          "linuxFxVersion": "[format('NODE|{0}', parameters('nodeVersion'))]",
+          "alwaysOn": true,
+          "ftpsState": "Disabled",
+          "minTlsVersion": "1.2",
+          "http20Enabled": true,
+          "appCommandLine": "bash startup.sh",
+          "appSettings": [
+            {
+              "name": "NODE_ENV",
+              "value": "production"
+            },
+            {
+              "name": "MCP_SERVER_MODE",
+              "value": "read-only"
+            },
+            {
+              "name": "AZURE_STORAGE_CONNECTION_STRING",
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}', variables('storageAccountName'), listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2023-01-01').keys[0].value, environment().suffixes.storage)]"
+            },
+            {
+              "name": "BLOB_CONTAINER_NAME",
+              "value": "xpp-metadata"
+            },
+            {
+              "name": "BLOB_DATABASE_NAME",
+              "value": "database/xpp-metadata.db"
+            },
+            {
+              "name": "DB_PATH",
+              "value": "/tmp/xpp-metadata.db"
+            },
+            {
+              "name": "LABELS_DB_PATH",
+              "value": "/tmp/xpp-metadata-labels.db"
+            },
+            {
+              "name": "LABEL_LANGUAGES",
+              "value": "[parameters('labelLanguages')]"
+            },
+            {
+              "name": "SCM_DO_BUILD_DURING_DEPLOYMENT",
+              "value": "false"
+            },
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "~24"
+            },
+            {
+              "name": "WEBSITES_PORT",
+              "value": "8080"
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "appServiceUrl": {
+      "type": "string",
+      "value": "[format('https://{0}', reference(resourceId('Microsoft.Web/sites', variables('appServiceName')), '2023-01-01').defaultHostName)]"
+    },
+    "mcpEndpoint": {
+      "type": "string",
+      "value": "[format('https://{0}/mcp', reference(resourceId('Microsoft.Web/sites', variables('appServiceName')), '2023-01-01').defaultHostName)]"
+    },
+    "storageAccountName": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    },
+    "metadataContainerName": {
+      "type": "string",
+      "value": "xpp-metadata"
+    },
+    "packagesContainerName": {
+      "type": "string",
+      "value": "packages"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces automated Azure deployment support for the project. The key change is the addition of an ARM template (`azuredeploy.json`) that provisions all required Azure resources and configures the application for production use. Documentation has also been updated to provide a one-click "Deploy to Azure" experience.

**Azure deployment automation:**

* Added `infrastructure/azuredeploy.json` ARM template to automate deployment of Azure resources, including an App Service (Linux), Storage Account with secure containers, and all necessary app settings for the application to run in production mode. The template allows customization of region, SKU, Node.js version, and label languages.

**Documentation updates:**

* Updated `README.md` to include a "Deploy to Azure" button for one-click deployment using the new ARM template.
* Updated `docs/SETUP_AZURE.md` with instructions and a "Deploy to Azure" button for the new automated deployment option, clarifying that this approach includes all required app settings and startup configuration.