### PR TITLE
fix: skip roots/list for HTTP clients, prefer custom over demo models…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,158 +1,89 @@
 # =============================================================================
-# X++ MCP Server - Development Configuration
+# X++ MCP Server — Configuration
 # =============================================================================
-# Copy this file to .env and update with your actual values
-# For production deployment, use Azure App Service configuration
+# Copy this file to .env and fill in the relevant section for your deployment:
+#
+#   local  → single VM with D365FO; MCP_SERVER_MODE=full (default)
+#   hybrid → Azure read-only + local write-only companion
+#   azure  → Azure-hosted read-only instance; MCP_SERVER_MODE=read-only
+#
+# =============================================================================
+# GENERAL — required in all modes
+# =============================================================================
+
+# Runtime environment
+NODE_ENV=development          # development | staging | production
+PORT=8080                     # HTTP listen port
+LOG_LEVEL=debug               # error | warn | info | debug
 
 # =============================================================================
-# SERVER CONFIGURATION
+# MODE: LOCAL  (MCP_SERVER_MODE=full)
 # =============================================================================
-# Environment: development, staging, production
-NODE_ENV=development
+# Standard single-VM setup. All tools are available.
+# ------------------------------------------------------------------
 
-# Server port (default: 8080)
-PORT=8080
-
-# Log level: error, warn, info, debug
-LOG_LEVEL=debug
-
-# Server mode for hybrid deployments (default: full)
-# - full       → all tools (local development, single-server setup)
-# - read-only  → search/analysis tools only; excludes create_d365fo_file, modify_d365fo_file, create_label
-#                Use this for the Azure-hosted instance in a hybrid setup
-# - write-only → only file-operation tools; intended as a lightweight local companion
-#                Use this for the local Windows VM instance in a hybrid setup
 MCP_SERVER_MODE=full
 
-# =============================================================================
-# DATABASE CONFIGURATION
-# =============================================================================
-# Path to SQLite database with indexed X++ metadata
-# For development: Use local path like ./data/xpp-metadata.db
-# For production: /tmp/xpp-metadata.db (ephemeral) or persistent storage
-DB_PATH=./data/xpp-metadata.db
-
-# =============================================================================
-# METADATA EXTRACTION
-# =============================================================================
-# Development environment type: auto (default), traditional, ude (Power Platform Tools)
-# When 'auto': detects UDE if XPP config files exist in %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\
+# Dev environment detection: auto (default), traditional, ude (Power Platform Tools)
+# 'auto' detects UDE when XPP config files exist in %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\
 DEV_ENVIRONMENT_TYPE=auto
 
-# --- Traditional ---
-# Path to D365 PackagesLocalDirectory on your development VM (traditional only)
-# Not used for UDE — paths are auto-detected from XPP config files instead
-# Default location: C:\AOSService\PackagesLocalDirectory
+# --- Traditional (AOSService VM) ---
+
+# Root folder of all D365FO packages
 PACKAGES_PATH=C:\AOSService\PackagesLocalDirectory
 
-# Comma-separated list of custom model names (traditional only)
-# Not needed for UDE — custom models are auto-detected from the custom packages path
-# Find in: Visual Studio > Dynamics 365 > Model Management > View models
-# Example: CUSTOM_MODELS=CustomModel1,CustomModel2,ApplicationSuite
+# Comma-separated custom model names (UDE auto-detects these; only needed for traditional)
+# Find in VS → Dynamics 365 → Model Management → View models
 CUSTOM_MODELS=YourCustomModel1,YourCustomModel2
 
-# --- UDE (Unified Developer Experience) ---
-# XPP config name to use (from %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\)
-# Leave empty to auto-select newest config
-# Example: contoso-dev-env1___10.0.2428.63
-# Tip: run  npm run select-config  to pick from available XPP configs interactively
-# XPP_CONFIG_NAME=
+# --- UDE (Unified Developer Experience / Power Platform Tools) ---
 
-# =============================================================================
-# DATABASE BUILD OPTIONS
-# =============================================================================
-# Index AxLabelFile labels during database build (default: true)
-# Set to false to skip label indexing (faster build, but search_labels/get_label_info/create_label won't work)
+# XPP config name from %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\
+# Leave empty to use the newest config automatically.
+# Run  npm run select-config  to pick interactively.
+# XPP_CONFIG_NAME=contoso-dev-env1___10.0.2428.63
+
+# --- Database & extraction ---
+
+# SQLite database with indexed X++ metadata
+DB_PATH=./data/xpp-metadata.db
+
+# Output folder for extracted XML metadata
+METADATA_PATH=./extracted-metadata
+
+# Index label files during DB build; disable to speed up build (search_labels won't work)
 INCLUDE_LABELS=true
 
-# Languages to index from AxLabelFile (comma-separated)
-# Reduces database size significantly by indexing only required languages
-# Default: en-US,cs,sk,de (4 languages, ~500 MB labels database)
-# Full set would be 70+ languages (~8 GB labels database)
-# Examples:
-#   LABEL_LANGUAGES=en-US,cs,sk,de  (Central Europe, ~500 MB)
-#   LABEL_LANGUAGES=en-US,es,fr,de  (Western Europe, ~500 MB)
-#   LABEL_LANGUAGES=en-US           (English only, ~125 MB)
-#   LABEL_LANGUAGES=all             (All 70+ languages, ~8 GB)
+# Languages to index — limiting this significantly reduces DB size
 LABEL_LANGUAGES=en-US,cs,sk,de
 
-# Path where extracted XML metadata will be stored
-METADATA_PATH=./metadata
+# ISV/extension prefix used to identify custom objects
+EXTENSION_PREFIX=ISV_
 
-# =============================================================================
-# CUSTOM EXTENSIONS CONFIGURATION (For ISV solutions)
-# =============================================================================
-# Prefix for identifying custom extensions
-# EXTENSION_PREFIX=ISV_
-
-# Extract mode: 'all' (standard + custom), 'standard' (only standard models), 'custom' (only custom models)
+# Extraction scope: all (standard + custom) | standard | custom
 # EXTRACT_MODE=all
 
-# Compute usage statistics during database build (slow for large databases)
+# Compute usage statistics during build (slow for large databases)
 # COMPUTE_STATS=false
 
-# =============================================================================
-# REDIS CACHE (Optional - Improves performance)
-# =============================================================================
-# Enable/disable Redis caching (set to 'true' to enable)
-REDIS_ENABLED=false
+# --- Azure Blob Storage — source of the indexed DB ---
 
-# Redis connection URL
-# For local development: redis://localhost:6379
-# For Azure: Use Azure Cache for Redis connection string
-# REDIS_URL=redis://localhost:6379
-
-# Cluster mode - REQUIRED for Azure Managed Redis (Enterprise / cluster tier)
-# Set to 'true' if you get 'MOVED' errors in the logs.
-# Azure Managed Redis always runs as a cluster; classic Azure Cache for Redis does not.
-# REDIS_CLUSTER_MODE=false
-
-# Cache TTL in seconds (default: 3600 = 1 hour)
-# CACHE_TTL=3600
-
-# Redis password (if required)
-# REDIS_PASSWORD=your-redis-password
-
-# =============================================================================
-# RATE LIMITING
-# =============================================================================
-# Time window in milliseconds (default: 900000 = 15 minutes)
-RATE_LIMIT_WINDOW_MS=900000
-
-# Maximum requests per window per IP (default: 100)
-RATE_LIMIT_MAX_REQUESTS=100
-
-# Strict limit for expensive operations (default: 20)
-RATE_LIMIT_STRICT_MAX_REQUESTS=20
-
-# Limit for authentication attempts (default: 5)
-RATE_LIMIT_AUTH_MAX_REQUESTS=5
-
-# =============================================================================
-# MEMORY OPTIMIZATION & SEARCH SUGGESTIONS
-# =============================================================================
-# Enable intelligent "Did you mean?" search suggestions
-# When enabled, builds a term relationship graph for better suggestions
-# Requires ~800MB-1.5GB heap memory depending on symbol count
-# 
-# Recommended settings:
-# - Development: true (full features)
-# - Azure Pipeline/CI: false (minimize memory)
-# - Production: false or true (enable only if >2GB RAM available)
-# - Docker: false (use smaller memory limits)
-#
-# Default: true in development, false otherwise
-# ENABLE_SEARCH_SUGGESTIONS=true
-
-# =============================================================================
-# AZURE BLOB STORAGE (Optional - For cloud deployment)
-# =============================================================================
-# Azure Storage connection string
-# Find in: Azure Portal > Storage Account > Access keys
+# Find connection string in: Azure Portal → Storage Account → Access keys
 # AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=youraccount;AccountKey=yourkey;EndpointSuffix=core.windows.net
-
-# Blob container name for metadata storage
 # BLOB_CONTAINER_NAME=xpp-databases
-
-# Blob name/path for the database file
 # BLOB_DATABASE_NAME=xpp-metadata.db
+
+# =============================================================================
+# MODE: HYBRID  (local write-only companion for an Azure-hosted read-only instance)
+# =============================================================================
+# The Azure read-only instance runs entirely in the cloud — configure it via
+# Azure App Service settings, not via .env.
+# This section covers only the local write-only companion on the Windows VM.
+# ------------------------------------------------------------------
+
+MCP_SERVER_MODE=write-only
+CUSTOM_MODELS=YourCustomModel1,YourCustomModel2
+INCLUDE_LABELS=true
+LABEL_LANGUAGES=en-US,cs,sk,de
+EXTENSION_PREFIX=ISV_

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,25 @@ This workspace contains D365FO code. **Always use the specialized MCP tools** �
 > Label/HelpText → modify-property  propertyPath="Label" propertyValue="@MyModel:MyLabel"
 > ```
 >
+> **Table-extension properties (objectType="table-extension") — stored in `<PropertyModifications>`, NEVER use PowerShell:**
+> ```
+> Label             → modify-property  objectType="table-extension"  propertyPath="Label"             propertyValue="@MyModel:MyLabel"
+> HelpText          → modify-property  objectType="table-extension"  propertyPath="HelpText"           propertyValue="@MyModel:MyHelpText"
+> TableGroup        → modify-property  objectType="table-extension"  propertyPath="TableGroup"         propertyValue="Group"
+> CacheLookup       → modify-property  objectType="table-extension"  propertyPath="CacheLookup"        propertyValue="Found"
+> TitleField1/2     → modify-property  objectType="table-extension"  propertyPath="TitleField1"        propertyValue="ItemId"
+> ClusteredIndex    → modify-property  objectType="table-extension"  propertyPath="ClusteredIndex"     propertyValue="MyIdx"
+> PrimaryIndex      → modify-property  objectType="table-extension"  propertyPath="PrimaryIndex"       propertyValue="MyIdx"
+> SaveDataPerCompany→ modify-property  objectType="table-extension"  propertyPath="SaveDataPerCompany" propertyValue="No"
+> TableType         → modify-property  objectType="table-extension"  propertyPath="TableType"          propertyValue="TempDB"
+> SystemTable       → modify-property  objectType="table-extension"  propertyPath="SystemTable"        propertyValue="Yes"
+> ModifiedDateTime  → modify-property  objectType="table-extension"  propertyPath="ModifiedDateTime"   propertyValue="Yes"
+> CreatedDateTime   → modify-property  objectType="table-extension"  propertyPath="CreatedDateTime"    propertyValue="Yes"
+> ModifiedBy        → modify-property  objectType="table-extension"  propertyPath="ModifiedBy"         propertyValue="Yes"
+> CreatedBy         → modify-property  objectType="table-extension"  propertyPath="CreatedBy"          propertyValue="Yes"
+> CountryRegionCode → modify-property  objectType="table-extension"  propertyPath="CountryRegionCodes" propertyValue="CZ,SK"
+> ```
+>
 > **Field rename / bulk field rewrite — NEVER use PowerShell for these:**
 > ```
 > Rename one field   → rename-field        fieldName="OldName"  fieldNewName="NewName"
@@ -121,7 +140,6 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 | Create SSRS report | See **SSRS Report Workflow** section below |
 | Create CoC extension | See **CoC / Extension Workflows** section below |
 | What is the exact tab/group/control name in form X? | `get_form_info(formName, searchControl="General")` |
-
 ## Critical Rules
 
 ### Forbidden built-in tools on D365FO files
@@ -134,6 +152,21 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 | `create_file` for D365FO objects | `create_d365fo_file()` |
 | PowerShell `ls`, `Test-Path`, `Get-Item` to check D365FO files | `verify_d365fo_project()` |
 | PowerShell `Get-Content` / `Select-String` to find tab/control names in form XML | `get_form_info(formName, searchControl="General")` |
+
+> ### ⚠️ CRITICAL — `get_form_info` WORKS for ALL D365FO forms
+>
+> `get_form_info` can read BOTH standard Microsoft forms (CustTable, SalesTable, …) **and** custom model forms.
+>
+> **NEVER say or assume "form metadata is not available through MCP".**
+>
+> If `get_form_info` returns a ⚠️ warning saying the file could not be read from disk, the response
+> already contains a ready-to-use retry command with `filePath=` filled in. Copy it and retry — DO NOT fall back to PowerShell.
+>
+> ```
+> ✅ CORRECT:  get_form_info(formName="CustTable", searchControl="General")
+> ✅ RETRY:    get_form_info(formName="CustTable", filePath="K:\\AOSService\\...\\AxForm\\CustTable.xml", searchControl="General")
+> ❌ FORBIDDEN: PowerShell Get-Content / read_file on form XML
+> ```
 
 ### Non-Negotiable Rules
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -113,6 +113,13 @@ export function createXppMcpServer(context: XppServerContext): Server {
     process.stderr.write(
       `[mcpServer ${new Date().toISOString().slice(11, 23)}] ⚡ 'initialized' notification received — requesting roots/list\n`
     );
+    // Only stdio clients (VS Code, VS 2022) advertise the roots capability.
+    // HTTP / Azure clients do not — skipping the call avoids a -32001 timeout
+    // that would otherwise be logged as a spurious warning in Azure Monitor.
+    if (!server.getClientCapabilities()?.roots) {
+      process.stderr.write(`[mcpServer] ℹ️  Client has no roots capability — skipping roots/list\n`);
+      return;
+    }
     try {
       const result = await server.request(
         { method: 'roots/list', params: {} },
@@ -120,9 +127,9 @@ export function createXppMcpServer(context: XppServerContext): Server {
       );
       applyRootsToConfig(result.roots ?? []);
     } catch (e) {
-      // Client doesn't support roots/list — workspace already seeded from
-      // process.cwd() or env vars in index.ts stdio startup.
-      process.stderr.write(`[mcpServer] ⚠️  roots/list not supported by client: ${e}\n`);
+      // Unlikely now that we checked capabilities first, but still guard
+      // against network errors or other unexpected failures.
+      process.stderr.write(`[mcpServer] ⚠️  roots/list failed: ${e}\n`);
     }
   });
 
@@ -131,6 +138,9 @@ export function createXppMcpServer(context: XppServerContext): Server {
     process.stderr.write(
       `[mcpServer ${new Date().toISOString().slice(11, 23)}] 🔄 'roots/list_changed' notification — re-requesting roots/list\n`
     );
+    if (!server.getClientCapabilities()?.roots) {
+      return;
+    }
     try {
       const result = await server.request(
         { method: 'roots/list', params: {} },
@@ -906,9 +916,25 @@ Examples:
                 type: 'string',
                 description: 'Method name (required for add-method, remove-method)'
               },
+              sourceCode: {
+                type: 'string',
+                description:
+                  '[add-method] PREFERRED parameter — pass the FULL X++ method source: ' +
+                  'access modifiers + return type + method name + parameters + body + optional attributes. ' +
+                  'Example: "public void myMethod(str _param)\\n{\\n    next myMethod(_param);\\n}". ' +
+                  'The tool detects that the first real code line contains an access modifier and the method ' +
+                  'name followed by "(" and stores the source as-is without adding an extra signature. ' +
+                  'Alias of methodCode \u2014 use this when passing a complete CoC skeleton or any full method.'
+              },
               methodCode: {
                 type: 'string',
-                description: 'X++ code for the method body (required for add-method)'
+                description:
+                  '[add-method] X++ source for the method. Accepts either the FULL method source ' +
+                  '(access modifiers + return type + name + params + body) or just the body. ' +
+                  'When a full source is supplied the signature is preserved as-is. ' +
+                  'When only a body is supplied the signature is assembled from methodModifiers, ' +
+                  'methodReturnType, methodName, and methodParameters. ' +
+                  'Alias: sourceCode (preferred \u2014 pass sourceCode instead for clarity).'
               },
               methodModifiers: {
                 type: 'string',
@@ -988,17 +1014,28 @@ Examples:
               propertyPath: {
                 type: 'string',
                 description:
-                  'Top-level property name to set on the object root. ' +
-                  'Table properties: TableGroup (Group/Parameter/Main/…), TitleField1, TitleField2, ' +
-                  'TableType (TempDB / InMemory / RegularTable), CacheLookup, ClusteredIndex, ' +
-                  'PrimaryIndex, SaveDataPerCompany (Yes/No), Label, HelpText, Extends. ' +
-                  'EDT properties: Extends, StringSize, Label, HelpText, ReferenceTable, ReferenceField. ' +
-                  'Class properties: Extends, Abstract (true/false), Final (true/false), Label. ' +
-                  'Use dot notation only for truly nested XML nodes (rare). ' +
-                  'Examples: propertyPath="TableGroup" propertyValue="Group" | ' +
+                  'Property name to set on the object.\n\n' +
+                  'For **AxTable** (objectType="table"): direct child XML element — ' +
+                  'TableGroup (Group/Parameter/Main/WorksheetHeader/WorksheetLine/Miscellaneous/Framework), ' +
+                  'TitleField1, TitleField2, TableType (TempDB/InMemory/RegularTable), CacheLookup, ' +
+                  'ClusteredIndex, PrimaryIndex, SaveDataPerCompany (Yes/No), Label, HelpText, Extends, SystemTable (Yes/No).\n\n' +
+                  'For **AxTableExtension** (objectType="table-extension"): properties are stored in ' +
+                  '<PropertyModifications>/<AxPropertyModification> — NOT as direct elements. ' +
+                  'Supported names: Label, HelpText, TableGroup, CacheLookup, TitleField1, TitleField2, ' +
+                  'ClusteredIndex, PrimaryIndex, SaveDataPerCompany, TableType, SystemTable, ' +
+                  'ModifiedDateTime (Yes/No), CreatedDateTime (Yes/No), ModifiedBy (Yes/No), CreatedBy (Yes/No), ' +
+                  'CountryRegionCodes (comma-separated ISO codes, e.g. "CZ,SK").\n\n' +
+                  'For **AxEdt** (objectType="edt"): Extends, StringSize, Label, HelpText, ReferenceTable, ReferenceField.\n\n' +
+                  'For **AxClass** (objectType="class"): Extends, Abstract (true/false), Final (true/false), Label.\n\n' +
+                  'Examples: ' +
+                  'propertyPath="Label" propertyValue="@MyModel:MyLabel" | ' +
+                  'propertyPath="HelpText" propertyValue="@MyModel:MyHelpText" | ' +
+                  'propertyPath="TableGroup" propertyValue="Group" | ' +
                   'propertyPath="TitleField1" propertyValue="ItemId" | ' +
                   'propertyPath="TableType" propertyValue="TempDB" | ' +
-                  'propertyPath="Extends" propertyValue="WHSZoneId" (on an EDT)'
+                  'propertyPath="ModifiedDateTime" propertyValue="Yes" (table-extension) | ' +
+                  'propertyPath="CountryRegionCodes" propertyValue="CZ,SK" (table-extension) | ' +
+                  'propertyPath="Extends" propertyValue="WHSZoneId" (EDT)'
               },
               propertyValue: {
                 type: 'string',
@@ -1162,12 +1199,17 @@ Use WHEN:
   get_form_info("SalesTable", searchControl="General") returns only controls whose
   name contains "General", with path, parent name, and children.
   ❌ NEVER use PowerShell Get-Content or grep to find tab names in form XML.
-  ✅ ALWAYS use searchControl instead.
+  ✅ ALWAYS use searchControl instead — this tool CAN read ALL D365FO forms.
+
+⚠️ If you receive a "could not be read from disk" warning, the response will include
+  a ready-to-use retry command with filePath= already filled in.
+  ❌ NEVER fall back to PowerShell when this happens — just retry with filePath.
 
 Examples:
 - get_form_info("SalesTable") → full structure with datasources, grids, tab hierarchy
 - get_form_info("CustTable", searchControl="General") → find the General tab exact name
-- get_form_info("PurchTable", searchControl="LineView") → find the LineView grid name`,
+- get_form_info("PurchTable", searchControl="LineView") → find the LineView grid name
+- get_form_info("MyForm", filePath="K:\\\\AOSService\\\\...\\\\AxForm\\\\MyForm.xml") → bypass DB lookup`,
           inputSchema: {
             type: 'object',
             properties: {
@@ -1175,12 +1217,20 @@ Examples:
                 type: 'string',
                 description: 'Name of the form (e.g., SalesTable, CustTable, InventTable)'
               },
+              filePath: {
+                type: 'string',
+                description:
+                  'Absolute path to the form XML file. Use this when get_form_info returned a ' +
+                  '"could not be read from disk" warning \u2014 the warning includes the exact path to pass here. ' +
+                  'Bypasses the DB path lookup entirely. ' +
+                  'Example: "K:\\\\AOSService\\\\PackagesLocalDirectory\\\\AslCore\\\\AslCore\\\\AxForm\\\\MyForm.xml"',
+              },
               searchControl: {
                 type: 'string',
                 description: 'Case-insensitive substring to search for in control names. ' +
                   'Returns matching controls with path, parent name, and children. ' +
                   'Use this to find exact tab/group names for form extensions. ' +
-                  'NEVER use PowerShell to search form XML — use this instead.',
+                  'NEVER use PowerShell to search form XML \u2014 use this instead.',
               },
               includeWorkspace: {
                 type: 'boolean',

--- a/src/tools/formInfo.ts
+++ b/src/tools/formInfo.ts
@@ -9,12 +9,20 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
-import { buildXmlNotAvailableMessage, resolveDbPathLocally } from '../utils/metadataResolver.js';
+import { resolveDbPathLocally } from '../utils/metadataResolver.js';
 import { findD365FileOnDisk } from './modifyD365File.js';
+import { getConfigManager } from '../utils/configManager.js';
+import path from 'path';
 
 const GetFormInfoArgsSchema = z.object({
   formName: z.string().describe('Name of the form'),
   modelName: z.string().optional().describe('Model name (auto-detected if not provided)'),
+  filePath: z.string().optional().describe(
+    'Absolute path to the form XML file on disk. ' +
+    'Use this when get_form_info previously returned a "could not be read from disk" warning with a guessed path. ' +
+    'Bypasses the DB path lookup entirely. ' +
+    'Example: filePath="K:\\AOSService\\PackagesLocalDirectory\\AslCore\\AslCore\\AxForm\\MyForm.xml"'
+  ),
   includeControls: z.boolean().optional().default(true).describe('Include control hierarchy'),
   includeDataSources: z.boolean().optional().default(true).describe('Include datasource information'),
   includeMethods: z.boolean().optional().default(true).describe('Include form methods'),
@@ -64,7 +72,8 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
     const { symbolIndex, hybridSearch } = context;
     const { 
       formName, 
-      modelName, 
+      modelName,
+      filePath: explicitFilePath,
       includeControls, 
       includeDataSources, 
       includeMethods,
@@ -72,6 +81,25 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
       workspacePath,
       searchControl,
     } = args;
+
+    // 0. If an explicit filePath is provided, skip the DB lookup entirely.
+    // This is the retry path when Strategy A–D failed and the caller supplies the path directly.
+    if (explicitFilePath) {
+      let xmlContent: string | null = null;
+      try {
+        xmlContent = await fs.readFile(explicitFilePath, 'utf-8');
+      } catch (e) {
+        return {
+          content: [{ type: 'text', text:
+            `❌ get_form_info: cannot read form XML at explicit filePath="${explicitFilePath}": ` +
+            `${e instanceof Error ? e.message : String(e)}\n\n` +
+            `Check the path is correct and accessible. DO NOT use PowerShell — fix the filePath parameter.`,
+          }],
+          isError: true,
+        };
+      }
+      return await parseAndFormatForm(formName, 'Unknown', xmlContent, includeControls, includeDataSources, includeMethods, searchControl);
+    }
 
     // 1. Find the form (with workspace support)
     let formRow: any = null;
@@ -121,8 +149,10 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
       throw new Error(`Form "${formName}" not found. Make sure it's indexed or provide workspacePath for local forms.`);
     }
 
-    // 2. Read the form XML
-    // file_path may point to: (a) actual XML on disk, or (b) JSON metadata with sourcePath
+    // 2. Read the form XML — four strategies, most specific to most generic
+    //
+    // Strategy A: read the DB-stored path directly (works for absolute Windows paths from
+    //             a locally indexed DB, e.g. K:\AOSService\PackagesLocalDirectory\...\AxForm\SalesTable.xml)
     let xmlContent: string | null = null;
     try {
       const fileContent = await fs.readFile(formRow.file_path, 'utf-8');
@@ -141,12 +171,26 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
         xmlContent = fileContent;
       }
     } catch {
-      // file_path not accessible
+      // file_path not accessible — try fallbacks below
     }
 
-    // Fallback: DB path is from build agent (e.g. /home/vsts/work/...) — try local disk
+    // Strategy B: DB stores a RELATIVE path (e.g. "AslCore/AslCore/AxForm/MyForm.xml").
+    // Join it with the configured packages path to get the absolute path on this machine.
+    if (!xmlContent && !path.isAbsolute(formRow.file_path)) {
+      const cm = getConfigManager();
+      await cm.ensureLoaded();
+      const pkgPath = cm.getPackagePath() || 'K:\\AOSService\\PackagesLocalDirectory';
+      const absolutePath = path.join(pkgPath, formRow.file_path);
+      try {
+        xmlContent = await fs.readFile(absolutePath, 'utf-8');
+      } catch {
+        // Not accessible at this packages path
+      }
+    }
+
+    // Strategy C: build-agent path (e.g. /home/vsts/work/.../PackagesLocalDirectory/...) —
+    // remap to local PackagesLocalDirectory.
     if (!xmlContent) {
-      // Strategy 1: remap build-agent path to local PackagesLocalDirectory (works for any model)
       const remappedPath = await resolveDbPathLocally(formRow.file_path);
       if (remappedPath) {
         try {
@@ -157,8 +201,10 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
       }
     }
 
+    // Strategy D: scan the configured packages directory for the form XML using the model
+    // name from the DB row (handles cases where Strategy B fails because the configured
+    // packages path differs from the default, or UDE layout is used).
     if (!xmlContent) {
-      // Strategy 2: filesystem lookup via configured model path (works for custom models)
       const diskPath = await findD365FileOnDisk('form', formName, formRow.model);
       if (diskPath) {
         try {
@@ -170,53 +216,32 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
     }
 
     if (!xmlContent) {
+      // Build a list of paths we tried so the human/AI can diagnose and retry
+      const cm = getConfigManager();
+      await cm.ensureLoaded();
+      const pkgPath = cm.getPackagePath() || 'K:\\AOSService\\PackagesLocalDirectory';
+      const guessedAbsPath = path.isAbsolute(formRow.file_path)
+        ? formRow.file_path
+        : path.join(pkgPath, formRow.file_path);
+
       return {
-        content: [{ type: 'text', text: buildXmlNotAvailableMessage('form', formName, formRow.file_path) }],
-        isError: true,
+        content: [{
+          type: 'text',
+          text:
+            `⚠️ get_form_info: form XML for "${formName}" (model: ${formRow.model}) could not be read from disk.\n\n` +
+            `**DO NOT use PowerShell or read_file to work around this — retry get_form_info with the filePath parameter instead.**\n\n` +
+            `Tried path (from DB): \`${formRow.file_path}\`\n` +
+            `Guessed absolute path: \`${guessedAbsPath}\`\n\n` +
+            `✅ **Retry with explicit filePath:**\n` +
+            `  get_form_info(formName="${formName}", filePath="${guessedAbsPath}")\n\n` +
+            `If the path above is wrong, locate the form at:\n` +
+            `  \`{packagePath}\\${formRow.model}\\${formRow.model}\\AxForm\\${formName}.xml\`\n` +
+            `and pass it via the filePath parameter.`,
+        }],
       };
     }
 
-    const xmlObj = await parseStringPromise(xmlContent);
-
-    // 3. Extract form info
-    const formInfo: FormInfo = {
-      name: formName,
-      model: formRow.model,
-      design: [],
-      dataSources: [],
-      methods: [],
-    };
-
-    const axForm = xmlObj.AxForm;
-    if (!axForm) {
-      throw new Error('Invalid AxForm XML structure');
-    }
-
-    // Extract data sources
-    if (includeDataSources && axForm.DataSources) {
-      formInfo.dataSources = extractDataSources(axForm.DataSources[0]);
-    }
-
-    // Extract design (controls)
-    if (includeControls && axForm.Design) {
-      formInfo.design = extractControls(axForm.Design[0]);
-    }
-
-    // Extract methods (form methods are under SourceCode > Methods, not top-level)
-    if (includeMethods && axForm.SourceCode && axForm.SourceCode[0] && axForm.SourceCode[0].Methods) {
-      formInfo.methods = extractMethods(axForm.SourceCode[0].Methods[0]);
-    }
-
-    // 4. If searchControl provided, return search results instead of full output
-    if (searchControl) {
-      const matches = searchControlsInHierarchy(formInfo.design, searchControl);
-      return {
-        content: [{ type: 'text', text: formatControlSearchResults(formInfo.name, formInfo.model, matches, searchControl) }],
-      };
-    }
-
-    // 5. Format output
-    return formatFormOutput(formInfo, includeControls, includeDataSources, includeMethods);
+    return await parseAndFormatForm(formName, formRow.model, xmlContent, includeControls, includeDataSources, includeMethods, searchControl);
 
   } catch (error) {
     return {
@@ -229,6 +254,56 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
       isError: true,
     };
   }
+}
+
+// ── Shared XML parse + format helper ────────────────────────────────────────
+
+/**
+ * Parse form XML and return the formatted tool response.
+ * Shared by both the normal DB-lookup path and the explicit filePath bypass.
+ */
+async function parseAndFormatForm(
+  formName: string,
+  modelName: string,
+  xmlContent: string,
+  includeControls: boolean,
+  includeDataSources: boolean,
+  includeMethods: boolean,
+  searchControl?: string,
+) {
+  const xmlObj = await parseStringPromise(xmlContent);
+
+  const formInfo: FormInfo = {
+    name: formName,
+    model: modelName,
+    design: [],
+    dataSources: [],
+    methods: [],
+  };
+
+  const axForm = xmlObj.AxForm;
+  if (!axForm) {
+    throw new Error('Invalid AxForm XML structure');
+  }
+
+  if (includeDataSources && axForm.DataSources) {
+    formInfo.dataSources = extractDataSources(axForm.DataSources[0]);
+  }
+  if (includeControls && axForm.Design) {
+    formInfo.design = extractControls(axForm.Design[0]);
+  }
+  if (includeMethods && axForm.SourceCode && axForm.SourceCode[0] && axForm.SourceCode[0].Methods) {
+    formInfo.methods = extractMethods(axForm.SourceCode[0].Methods[0]);
+  }
+
+  if (searchControl) {
+    const matches = searchControlsInHierarchy(formInfo.design, searchControl);
+    return {
+      content: [{ type: 'text', text: formatControlSearchResults(formInfo.name, formInfo.model, matches, searchControl) }],
+    };
+  }
+
+  return formatFormOutput(formInfo, includeControls, includeDataSources, includeMethods);
 }
 
 // ── Control search helpers ───────────────────────────────────────────────────

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -130,10 +130,22 @@ const ModifyD365FileArgsSchema = z.object({
   
   // For add-method
   methodName: z.string().optional().describe('Name of method to add/remove'),
-  methodCode: z.string().optional().describe('X++ code for the method body'),
+  methodCode: z.string().optional().describe(
+    'X++ code for the method — either the FULL source (access modifiers + return type + name + params + body) ' +
+    'or just the method body. When the full source is provided (first real code line contains an access ' +
+    'modifier and the method name followed by "("), it is used as-is. When only a body is provided, ' +
+    'the signature is assembled from methodModifiers, methodReturnType, methodName, and methodParameters. ' +
+    'Alias: sourceCode (preferred when passing a complete CoC skeleton or full method source).'
+  ),
+  sourceCode: z.string().optional().describe(
+    'Alias for methodCode — pass the FULL X++ method source including access modifiers, return type, ' +
+    'method name, parameters, attributes (e.g. [ExtensionOf(...)]), and body. ' +
+    'This is the preferred parameter when passing a complete CoC skeleton. ' +
+    'Either methodCode or sourceCode may be used; sourceCode takes precedence if both are supplied.'
+  ),
   methodModifiers: z.string().optional().describe('Method modifiers (e.g., "public static")'),
   methodReturnType: z.string().optional().describe('Return type of method'),
-  methodParameters: z.string().optional().describe('Method parameters (e.g., "str _param1, int _param2")'),
+  methodParameters: z.string().optional().describe('Method parameters (e.g., "str _param1, int _param2")'),  
   
   // For add-field / modify-field (tables)
   fieldName: z.string().optional().describe('Name of field to add/remove/modify/rename'),
@@ -199,13 +211,21 @@ const ModifyD365FileArgsSchema = z.object({
 
   // For modify-property
   propertyPath: z.string().optional().describe(
-    'Top-level property name to set. For tables: TableGroup, TitleField1, TitleField2, TableType (TempDB/RegularTable/InMemory), ' +
-    'CacheLookup, ClusteredIndex, PrimaryIndex, SaveDataPerCompany, Label, HelpText, Extends. ' +
+    'Property name to set. ' +
+    'For tables (AxTable): TableGroup, TitleField1, TitleField2, TableType (TempDB/RegularTable/InMemory), ' +
+    'CacheLookup, ClusteredIndex, PrimaryIndex, SaveDataPerCompany, Label, HelpText, Extends, SystemTable. ' +
+    'For table-extensions (AxTableExtension): properties are stored inside <PropertyModifications> as ' +
+    '<AxPropertyModification> entries. Supported: Label, HelpText, TableGroup, CacheLookup, TitleField1, TitleField2, ' +
+    'ClusteredIndex, PrimaryIndex, SaveDataPerCompany, TableType, SystemTable, ' +
+    'ModifiedDateTime (Yes/No), CreatedDateTime (Yes/No), ModifiedBy (Yes/No), CreatedBy (Yes/No), ' +
+    'CountryRegionCodes (comma-separated, e.g. "CZ,SK"). ' +
     'For EDTs: Extends, StringSize, Label, HelpText, ReferenceTable, ReferenceField. ' +
     'For classes: Extends, Abstract, Final, Label. ' +
     'For nested properties use dot notation, e.g. "Fields.AxTableField.Name" (rare). ' +
     'Examples: propertyPath="TableGroup" propertyValue="Group"; propertyPath="TitleField1" propertyValue="ItemId"; ' +
-    'propertyPath="TableType" propertyValue="TempDB"; propertyPath="Extends" propertyValue="WHSZoneId"'
+    'propertyPath="TableType" propertyValue="TempDB"; propertyPath="Extends" propertyValue="WHSZoneId"; ' +
+    'propertyPath="ModifiedDateTime" propertyValue="Yes" (table-extension); ' +
+    'propertyPath="CountryRegionCodes" propertyValue="CZ,SK" (table-extension)'
   ),
   propertyValue: z.string().optional().describe('New property value'),
   
@@ -744,10 +764,35 @@ function inferDefaultMethodBody(methodName: string, returnType: string, params: 
 }
 
 /**
- * Add method to class/table/form
+ * Determines whether `code` starts with a complete X++ method signature rather than
+ * just a method body.
+ *
+ * A complete signature has its first real code line (skipping blank lines, doc-comment
+ * lines, and attribute lines starting with `[`) containing BOTH:
+ *   - an X++ access/type modifier keyword (public, protected, private, static, …)
+ *   - the method name immediately followed by `(`
+ *
+ * This is more reliable than a bare `includes('(')` check, which would also match any
+ * function call inside the method body (e.g. `myHelper.compute(value)`) and cause the
+ * signature to be omitted from the stored XML.
  */
+function hasMethodSignatureLine(code: string, methodName: string): boolean {
+  const MODIFIER_RE = /\b(public|protected|private|static|final|abstract|virtual|override|server|client|display|edit)\b/;
+  for (const line of code.split('\n')) {
+    const t = line.trim();
+    // Skip blank lines, comments (// /// /* *), and attribute lines [...]
+    if (!t || t.startsWith('//') || t.startsWith('/*') || t.startsWith('*') || t.startsWith('[')) continue;
+    // First real code line: must contain an access modifier AND methodName followed by '('
+    return MODIFIER_RE.test(t) && t.includes(`${methodName}(`);
+  }
+  return false;
+}
+
 async function addMethod(xmlObj: any, objectType: string, args: any): Promise<boolean> {
-  const { methodName, methodCode, methodModifiers, methodReturnType, methodParameters } = args;
+  // sourceCode is the canonical parameter name used in copilot instructions;
+  // methodCode is the legacy name — accept either, with sourceCode taking precedence.
+  const effectiveMethodCode: string | undefined = args.sourceCode ?? args.methodCode;
+  const { methodName, methodModifiers, methodReturnType, methodParameters } = args;
 
   if (!methodName) {
     throw new Error('methodName is required for add-method operation');
@@ -767,7 +812,7 @@ async function addMethod(xmlObj: any, objectType: string, args: any): Promise<bo
     if (!root.SourceCode || typeof root.SourceCode[0] !== 'object') {
       root.SourceCode = [{}];
     }
-    root.SourceCode[0].Declaration = [ensureXppDocComment(decodeXmlEntitiesFromXppSource(methodCode || ''))];
+    root.SourceCode[0].Declaration = [ensureXppDocComment(decodeXmlEntitiesFromXppSource(effectiveMethodCode || ''))];
     return true;
   }
 
@@ -800,15 +845,19 @@ async function addMethod(xmlObj: any, objectType: string, args: any): Promise<bo
     methodsNode[0].Method = [methodsNode[0].Method];
   }
 
-  // Build full method source — if methodCode already contains the signature use it directly,
-  // otherwise assemble from methodModifiers / methodReturnType / methodParameters.
+  // Build full method source — if the effective code already contains the signature use it
+  // directly, otherwise assemble from methodModifiers / methodReturnType / methodParameters.
   // Decode any XML entities first: AI models may copy entity-encoded text from SSRS report
-  // <Text> blocks (e.g. &lt;summary&gt;) and pass it as methodCode. Those entities must be
-  // decoded to proper characters so the CDATA section is not corrupted.
-  const decodedMethodCode = methodCode ? decodeXmlEntitiesFromXppSource(methodCode) : undefined;
+  // <Text> blocks (e.g. &lt;summary&gt;) and pass it as the code argument. Those entities
+  // must be decoded to proper characters so the CDATA section is not corrupted.
+  const decodedMethodCode = effectiveMethodCode ? decodeXmlEntitiesFromXppSource(effectiveMethodCode) : undefined;
   let fullSource: string;
-  if (decodedMethodCode && decodedMethodCode.includes('(')) {
-    // Caller passed a complete method (signature + body)
+  if (decodedMethodCode && hasMethodSignatureLine(decodedMethodCode, methodName)) {
+    // Caller passed a complete method (signature + body) — use as-is.
+    // hasMethodSignatureLine checks that the first real code line (skipping comments/attributes)
+    // contains both an access modifier keyword AND the method name followed by '('.
+    // This is more reliable than a bare includes('(') check, which would also match function
+    // calls inside the body (e.g. myHelper.compute(value)) and silently omit the signature.
     fullSource = decodedMethodCode;
   } else {
     const modifiers  = methodModifiers  || 'public';
@@ -1318,6 +1367,64 @@ async function modifyProperty(xmlObj: any, objectType: string, args: any): Promi
 
   if (propertyValue === undefined) {
     throw new Error('propertyValue is required for modify-property operation');
+  }
+
+  // ── table-extension: properties live inside <PropertyModifications> ───────────────────────────
+  // AxTableExtension does NOT expose top-level property elements like AxTable does.
+  // Instead all table-level overrides are stored as:
+  //   <PropertyModifications>
+  //     <AxPropertyModification>
+  //       <Name>Label</Name>
+  //       <Value>@MyModel:MyLabel</Value>
+  //     </AxPropertyModification>
+  //   </PropertyModifications>
+  //
+  // Supported property names (case-sensitive, matching AOT XML exactly):
+  //   Label, HelpText, TableGroup, CacheLookup, TitleField1, TitleField2,
+  //   ClusteredIndex, PrimaryIndex, SaveDataPerCompany, TableType, SystemTable,
+  //   ModifiedDateTime, CreatedDateTime, ModifiedBy, CreatedBy, CountryRegionCodes
+  if (objectType === 'table-extension') {
+    const rootKey = getRootKey(objectType); // 'AxTableExtension'
+    const root = xmlObj[rootKey];
+    if (!root) {
+      throw new Error(`Invalid XML structure: root element <${rootKey}> not found`);
+    }
+
+    // Ensure <PropertyModifications> container exists.
+    // xml2js parses <PropertyModifications /> as [''] — must treat as empty.
+    const rawPM = root.PropertyModifications;
+    const pmEmpty =
+      !rawPM ||
+      rawPM === '' ||
+      (Array.isArray(rawPM) && (rawPM.length === 0 || rawPM[0] === '' || rawPM[0] == null));
+    if (pmEmpty) {
+      root.PropertyModifications = [{ AxPropertyModification: [] }];
+    }
+    const pmContainer = Array.isArray(root.PropertyModifications)
+      ? root.PropertyModifications[0]
+      : root.PropertyModifications;
+
+    if (!pmContainer.AxPropertyModification) {
+      pmContainer.AxPropertyModification = [];
+    } else if (!Array.isArray(pmContainer.AxPropertyModification)) {
+      // Single existing entry parsed as object, not 1-element array
+      pmContainer.AxPropertyModification = [pmContainer.AxPropertyModification];
+    }
+
+    // Update existing entry or append a new one
+    const existing = (pmContainer.AxPropertyModification as any[]).find(
+      (m: any) => m.Name && m.Name[0] === propertyPath
+    );
+    if (existing) {
+      existing.Value = [propertyValue];
+    } else {
+      pmContainer.AxPropertyModification.push({
+        Name: [propertyPath],
+        Value: [propertyValue],
+      });
+    }
+
+    return true;
   }
 
   // Special case: changing the base type of an EDT (i:type XML attribute on the root element).

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -330,8 +330,20 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           'mymodel', 'mypackage', 'model', 'package', 'modelname', 'packagename',
           'yourmodel', 'yourpackage', 'custommodel', 'custompackage',
           'testmodel', 'testpackage', 'samplemodel', 'samplepackage',
+          // Microsoft tutorial / demo models — these are shipped as sample code with D365FO
+          // and should never be the target model for a new custom project.
+          // If auto-detection lands on one of these it almost always means the developer
+          // forgot to change the default model in the VS new-project wizard.
+          'fleetmanagement', 'fleetmanagementextension',
+          'fleetmanagementunittests', 'tutorial',
         ]);
         const isPlaceholder = !modelName || PLACEHOLDER_NAMES.has(modelName.toLowerCase());
+        // Also flag when auto-detection found a Microsoft standard model name
+        // that isn't in the PLACEHOLDER_NAMES set but is not a custom model.
+        const { isCustomModel } = await import('../utils/modelClassifier.js');
+        const isStandardMsModel = modelName
+          ? !isCustomModel(modelName) && !isPlaceholder
+          : false;
 
         const lines: string[] = [
           `## D365FO Workspace Configuration`,
@@ -372,6 +384,32 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
             `> 3. The projectPath points to a valid .rnrproj file`,
             `>`,
             `> Do you want to fix the configuration first, or continue with built-in tools (limited functionality)?`,
+          );
+        } else if (isStandardMsModel) {
+          // Model was auto-detected from a .rnrproj whose <Model> tag points to a Microsoft
+          // standard model. This almost always means the developer created a new VS project
+          // and forgot to change the default model name in the project wizard (D365FO VS
+          // extension defaults to "FleetManagement" in new-project dialogs).
+          const allProj = configManager.getAllDetectedProjects();
+          const customCandidates = allProj.filter(p => isCustomModel(p.modelName));
+          const hint = customCandidates.length > 0
+            ? `Available custom models: ${customCandidates.map(p => p.modelName).join(', ')}\n` +
+              `Switch with: get_workspace_info(projectName="<model>")`
+            : `No custom models found under D365FO_SOLUTIONS_PATH. Check your project configuration.`;
+          lines.push(
+            `⛔ CONFIGURATION PROBLEM — model name "${modelName}" is a Microsoft standard/demo model, not a custom model.`,
+            ``,
+            `**YOU MUST STOP** and tell the user:`,
+            `> The auto-detected model "${modelName}" is a Microsoft standard model.`,
+            `> This usually happens when a new VS project was created and the default model`,
+            `> in the project wizard ("FleetManagement") was not changed to the correct custom model.`,
+            `>`,
+            `> How to fix:`,
+            `> 1. In Visual Studio, open the .rnrproj file and change <Model>FleetManagement</Model>`,
+            `>    to the correct model name (e.g. <Model>AslCore</Model>).`,
+            `> 2. OR explicitly switch to a known project:`,
+            `>    ${hint}`,
+            `> 3. OR add the correct modelName to .mcp.json.`,
           );
         } else {
           lines.push(`✅ Configuration looks valid. Proceed with D365FO operations using model "${modelName}".`);

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs/promises';
 import { existsSync, realpathSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { autoDetectD365Project, detectD365Project, scanAllD365Projects, extractModelNameFromProject, detectGitBranch, type D365ProjectInfo } from './workspaceDetector.js';
+import { autoDetectD365Project, detectD365Project, scanAllD365Projects, extractModelNameFromProject, detectGitBranch, isMicrosoftDemoModel, type D365ProjectInfo } from './workspaceDetector.js';
 import { registerCustomModel } from './modelClassifier.js';
 import { XppConfigProvider, type XppEnvironmentConfig } from './xppConfigProvider.js';
 
@@ -222,10 +222,21 @@ class ConfigManager {
       // Re-check staleness: time has passed since the initial check above.
       const isNowStale = generation !== undefined && generation < this.detectionGeneration;
       // Use first found as primary if workspace detection yielded nothing and scan is current.
+      // Skip Microsoft demo/tutorial model names (e.g. FleetManagement) — these appear when
+      // a developer creates a new VS project and leaves the default model name unchanged.
+      // Prefer the first custom (non-demo) model; only fall back to demo models when that
+      // is ALL that was found (unusual, but possible in purely tutorial repos).
       if (all.length > 0 && !this.autoDetectedProject && !isNowStale) {
-        this.autoDetectedProject = all[0];
-        registerCustomModel(all[0].modelName);
-        console.error(`[ConfigManager] ✅ Using first found project as primary: ${all[0].modelName}`);
+        const primary = all.find(p => !isMicrosoftDemoModel(p.modelName)) ?? all[0];
+        if (isMicrosoftDemoModel(primary.modelName)) {
+          console.error(
+            `[ConfigManager] ⚠️ All detected projects are Microsoft demo models — using "${primary.modelName}" as fallback.`,
+            `This usually means the VS project wizard default model was not changed.`,
+          );
+        }
+        this.autoDetectedProject = primary;
+        registerCustomModel(primary.modelName);
+        console.error(`[ConfigManager] ✅ Using first found project as primary: ${primary.modelName}`);
       }
     }
   }

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -19,6 +19,27 @@ export interface D365ProjectInfo {
 }
 
 /**
+ * Microsoft tutorial / demo model names that ship with D365FO.
+ * A new VS project's <Model> tag defaults to "FleetManagement" when the developer
+ * forgets to change it in the project wizard. These model names must never be
+ * auto-selected as the target custom model for create/modify operations.
+ */
+const MICROSOFT_DEMO_MODELS = new Set([
+  'fleetmanagement',
+  'fleetmanagementextension',
+  'fleetmanagementunittests',
+  'tutorial',
+]);
+
+/**
+ * Returns true when the model name is a well-known Microsoft tutorial/demo model
+ * that should never be auto-selected as a custom project target.
+ */
+export function isMicrosoftDemoModel(modelName: string): boolean {
+  return MICROSOFT_DEMO_MODELS.has(modelName.toLowerCase());
+}
+
+/**
  * Find all .rnrproj files in a directory (recursive search)
  * Limited to reasonable depth to avoid performance issues
  */
@@ -125,7 +146,23 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
         console.error(`[WorkspaceDetector] Solution-name match → ${path.basename(nameMatch)}`);
       }
     }
+
+    // Read ALL candidate model names in parallel so we can prefer non-demo models
+    // when the initially selected primaryProject has a Microsoft demo model name
+    // (e.g. FleetManagement — the VS new-project wizard default).
     const modelName = await extractModelNameFromProject(primaryProject);
+    if (modelName && isMicrosoftDemoModel(modelName) && projectFiles.length > 1) {
+      console.error(`[WorkspaceDetector] Primary .rnrproj has MS demo model "${modelName}" — looking for better candidate`);
+      for (const pf of projectFiles) {
+        if (pf === primaryProject) continue;
+        const altModel = await extractModelNameFromProject(pf);
+        if (altModel && !isMicrosoftDemoModel(altModel)) {
+          console.error(`[WorkspaceDetector] Skipping demo model "${modelName}", using "${altModel}" from ${path.basename(pf)}`);
+          primaryProject = pf;
+          break;
+        }
+      }
+    }
 
     if (!modelName) {
       console.error('[WorkspaceDetector] Could not extract ModelName from .rnrproj');


### PR DESCRIPTION
This pull request introduces several important improvements to the MCP server and its documentation, focusing on clarifying environment configuration, enhancing documentation for D365FO property modifications and form metadata access, and improving robustness in server-client interactions. The changes make deployment modes easier to understand, expand tool support for table extensions, and ensure that form metadata can always be retrieved without falling back to PowerShell.

Configuration and deployment clarity:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL2-R89): Reorganized and clarified environment variable sections for local, hybrid, and Azure deployment modes. Added explicit instructions and grouped settings for easier setup and maintenance.

Documentation and tool guidance enhancements:

* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R70-R88): Added explicit instructions for modifying table-extension properties using `modify-property` and clarified that these should never use PowerShell. Expanded the list of supported properties and provided examples for each.
* `.github/copilot-instructions.md`, `src/server/mcpServer.ts`: Emphasized that `get_form_info` works for all D365FO forms (standard and custom), and clarified retry behavior with `filePath` when encountering read errors. Updated documentation and schema to prevent incorrect fallback to PowerShell. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R156-R170) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1165-R1233)
* [`src/server/mcpServer.ts`](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L991-R1038): Expanded the `propertyPath` documentation for `modify-property` to distinguish between table and table-extension properties, listing all supported names and usage examples.

Server robustness and client capability checks:

* [`src/server/mcpServer.ts`](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R116-R132): Improved handling of client capabilities by checking for roots support before requesting roots/list, preventing unnecessary warnings and timeouts in Azure deployments. [[1]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R116-R132) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R141-R143)

Method addition parameter clarity:

* [`src/server/mcpServer.ts`](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R919-R937): Clarified the preferred use of `sourceCode` for adding methods, distinguishing between full method source and method body, and documenting aliasing and behavior.