### PR TITLE
fix: separate TableType and TableGroup; add labelId no-prefix rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,42 @@ This workspace contains D365FO code. **Always use the specialized MCP tools** �
 > Label/HelpText → modify-property  propertyPath="Label" propertyValue="@MyModel:MyLabel"
 > ```
 >
+> **⚠️ TableGroup vs TableType — CRITICAL DISTINCTION:**
+> ```
+> TableGroup  = business role of the table (system enum TableGroup, source: MSDN).
+>   Valid values and meanings:
+>     Miscellaneous   — DEFAULT for new tables; does not fit any other category (e.g. TableExpImpDef)
+>     Main            — principal master table for a central business object, static base data
+>                       (e.g. CustTable, VendTable)
+>     Transaction     — transaction/journal data, typically not edited directly
+>                       (e.g. CustTrans, VendTrans)
+>     Parameter       — setup/parameter data for a Main table, usually 1 record per company
+>                       (e.g. CustParameters, VendParameters)
+>     Group           — categorisation for a Main table, one-to-many: Group → Main
+>                       (e.g. CustGroup, VendGroup)
+>     WorksheetHeader — worksheet header that categorises WorksheetLine rows
+>                       one-to-many: WorksheetHeader → WorksheetLine (e.g. SalesTable)
+>     WorksheetLine   — lines to be validated and turned into transactions;
+>                       may be deleted without affecting system stability (e.g. SalesLine)
+>     Reference       — shared reference/lookup data across modules
+>     Framework       — internal Microsoft framework/infrastructure tables
+>   ⛔ NEVER use "TempDB" or "InMemory" as a TableGroup value — those are TableType values!
+>
+> TableType   = storage type of the table (source: MSDN).
+>   Valid values: RegularTable (default, omit from XML) | TempDB | InMemory
+>     RegularTable — DEFAULT. Permanent table stored in the main database. Omit from XML entirely.
+>     TempDB       — Temporary table in SQL Server TempDB. Dropped when no longer used by the current
+>                    method. Joins and set operations are EFFICIENT. Use for SSRS report tmp tables
+>                    and session-scoped data.
+>     InMemory     — Temporary ISAM file on the AOS/client tier. SQL Server has no connection to it.
+>                    Joins and set operations are usually INEFFICIENT. Equivalent to the old
+>                    "Temporary" property from AX 2009.
+>
+> For a new TempDB table:
+>   generate_smart_table(tableType="TempDB", tableGroup="Main", ...)   ← CORRECT
+>   generate_smart_table(tableGroup="TempDB", ...)                     ← ❌ WRONG
+> ```
+>
 > **Table-extension properties (objectType="table-extension") — stored in `<PropertyModifications>`, NEVER use PowerShell:**
 > ```
 > Label             → modify-property  objectType="table-extension"  propertyPath="Label"             propertyValue="@MyModel:MyLabel"
@@ -194,6 +230,7 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 17. **NEVER** nest `while select` inside another `while select` — use `join` in a single select, or pre-load into `Map`/temp table. Nested data-access loops trigger BPCheckNestedLoopinCode.
 18. **ALWAYS** call `create_label()` for every new label ID before referencing it in code — uncreated labels cause BPErrorUnknownLabel at build time.
 19. **ALWAYS** write meaningful `/// <summary>` doc comments on every public/protected class and method — the text must describe what the code does, not just echo the name. `/// MyClass class.` or `/// run.` is NEVER acceptable (BPXmlDocNoDocumentationComments).
+20. **NEVER** pass `tableGroup="TempDB"` or `tableGroup="InMemory"` to `generate_smart_table` — `TempDB`/`InMemory` are **TableType** values, not **TableGroup** values. For a TempDB table use `tableType="TempDB"` and keep `tableGroup="Main"` (or another valid group). Valid `TableGroup` values (system enum TableGroup, source: MSDN): `Miscellaneous` (default for new tables) | `Main` | `Transaction` | `Parameter` | `Group` | `WorksheetHeader` | `WorksheetLine` | `Reference` | `Framework`.
 
 ### AxClass sourceCode Format — Member Variables in Declaration
 
@@ -551,6 +588,12 @@ c) Save to disk:                     create_d365fo_file(objectType="report", obj
 | `get_label_info(labelId?, model?)` | Get translations, list label files |
 | `create_label(labelId, labelFileId, model, translations[])` | Create new label |
 | `rename_label(oldLabelId, newLabelId, labelFileId, model)` | Rename label ID in .label.txt, X++ source, and XML metadata |
+
+> **Label ID naming — NO prefix!**
+> Label IDs describe the **meaning of the text**, not the owning object or model.
+> ✅ CORRECT: `CustomerName`, `InvoiceDate`, `ErrorAmountNegative`, `FieldAccountNum`
+> ❌ WRONG (prefixed like an object): `AslCoreCustomerName`, `ContosoExtInvoiceDate`
+> The label *file* (e.g. `@AslCore:CustomerName`) already identifies the owning model — the ID itself needs no prefix.
 
 > **Label file creation:** When calling `create_label` for the first time in a model (label file does not exist yet), **always** pass `createLabelFileIfMissing: true`. Without it the tool returns an error. Pass translations for all required languages (e.g. `en-US`, `cs`, `de`) — the tool creates the directory structure and XML descriptors for each language automatically. If you provide a translation for a language that does not yet have a folder (e.g. cs), set `createLabelFileIfMissing: true` so the folder and descriptor are created.
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1570,7 +1570,11 @@ Examples:
             properties: {
               labelId: {
                 type: 'string',
-                description: 'Unique label identifier (alphanumeric), e.g. MyNewField',
+                description:
+                  'Unique label identifier (alphanumeric). ' +
+                  '⛔ NEVER add a model/object prefix — label IDs describe meaning, not ownership. ' +
+                  'Good: "CustomerName", "InvoiceDate", "ErrorAmountNegative". ' +
+                  'Bad (prefixed): "AslCoreCustomerName", "ContosoExtInvoiceDate".',
               },
               labelFileId: {
                 type: 'string',
@@ -1800,7 +1804,28 @@ Examples:
               },
               tableGroup: {
                 type: 'string',
-                description: 'Table group (Main, Transaction, Parameter, etc.)',
+                description:
+                  'Table group (business role). Defined by the system enum TableGroup (source: MSDN). ' +
+                  'Valid values: ' +
+                  '"Miscellaneous" = DEFAULT for new tables (e.g. TableExpImpDef); ' +
+                  '"Main" = master table for a central business object (e.g. CustTable, VendTable); ' +
+                  '"Transaction" = transaction data, not edited directly (e.g. CustTrans, VendTrans); ' +
+                  '"Parameter" = setup data for a Main table, one record/company (e.g. CustParameters); ' +
+                  '"Group" = categorisation for a Main table, one-to-many with Main (e.g. CustGroup); ' +
+                  '"WorksheetHeader" = worksheet header, one-to-many with WorksheetLine (e.g. SalesTable); ' +
+                  '"WorksheetLine" = lines to validate → transactions, may be deleted safely (e.g. SalesLine); ' +
+                  '"Reference" = shared reference/lookup data; ' +
+                  '"Framework" = internal Microsoft framework tables. ' +
+                  '⛔ NEVER pass "TempDB" or "InMemory" here — use tableType instead.',
+              },
+              tableType: {
+                type: 'string',
+                description:
+                  'Table storage type (TableType property, source: MSDN). Valid values: ' +
+                  '"Regular"/"RegularTable" = DEFAULT, permanent — omit for regular tables; ' +
+                  '"TempDB" = temporary table in SQL TempDB, dropped after use, joins are EFFICIENT; ' +
+                  '"InMemory" = temporary ISAM file on AOS tier, joins are INEFFICIENT (= old AX2009 Temporary). ' +
+                  '⛔ NEVER pass this value as tableGroup.',
               },
               copyFrom: {
                 type: 'string',

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -37,7 +37,11 @@ const CreateLabelArgsSchema = z.object({
     .string()
     .regex(/^[A-Za-z][A-Za-z0-9_]*$/, 'Label ID must be alphanumeric (no spaces)')
     .describe(
-      'Label identifier — must be unique within the label file, e.g. MyNewField or MyFeature',
+      'Label identifier — must be unique within the label file. ' +
+      '⛔ NEVER add a model/object prefix to label IDs. ' +
+      'Label IDs describe the meaning of the text, NOT the owning object. ' +
+      'Good examples: "CustomerName", "InvoiceDate", "ErrorAmountNegative". ' +
+      'Bad examples (with prefix): "AslCoreCustomerName", "ContosoExtInvoiceDate".',
     ),
   labelFileId: z
     .string()

--- a/src/tools/generateSmartReport.ts
+++ b/src/tools/generateSmartReport.ts
@@ -486,22 +486,17 @@ export async function handleGenerateSmartReport(
   const tmpTableXml = builder.buildTableXml({
     name: tmpTableName,
     label: `${reportCaption} (temp)`,
-    tableGroup: 'Framework',
+    tableGroup: 'Main',
+    tableType: 'TempDB',
     fields: tableFields,
     indexes: [builder.buildPrimaryKeyIndex(tmpTableName, [tableFields[0]?.name || 'RecId'])],
   });
-  // Inject TempDB table type — SmartXmlBuilder doesn't have a tableType param,
-  // so we insert it right after <TableGroup>
-  const tmpTableXmlFinal = tmpTableXml.replace(
-    '</AxTable>',
-    '\t<TableType>TempDB</TableType>\n</AxTable>'
-  );
 
   generatedObjects.push({
     objectType: 'table',
     objectName: tmpTableName,
     aotFolder: 'AxTable',
-    content: tmpTableXmlFinal,
+    content: tmpTableXml,
   });
   log(`Generated TmpTable: ${tmpTableName} (${tableFields.length} fields)`);
 
@@ -514,7 +509,8 @@ export async function handleGenerateSmartReport(
     const dsTblXml = builder.buildTableXml({
       name: ds.tmpTableName,
       label: `${reportCaption} - ${ds.name} (temp)`,
-      tableGroup: 'Framework',
+      tableGroup: 'Main',
+      tableType: 'TempDB',
       fields: ds.tableFields,
       indexes: [builder.buildPrimaryKeyIndex(ds.tmpTableName, [ds.tableFields[0]?.name || 'RecId'])],
     });
@@ -522,7 +518,7 @@ export async function handleGenerateSmartReport(
       objectType: 'table',
       objectName: ds.tmpTableName,
       aotFolder: 'AxTable',
-      content: dsTblXml.replace('</AxTable>', '\t<TableType>TempDB</TableType>\n</AxTable>'),
+      content: dsTblXml,
     });
     log(`Generated extra TmpTable: ${ds.tmpTableName} (${ds.tableFields.length} fields)`);
   }

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -17,6 +17,15 @@ interface GenerateSmartTableArgs {
   name: string;
   label?: string;
   tableGroup?: string;
+  /**
+   * Table storage type. Defined by the TableType property (source: MSDN).
+   *   Regular / RegularTable — DEFAULT. Permanent table stored in the main database.
+   *   TempDB                 — Temporary table in SQL Server TempDB. Dropped when no longer used
+   *                            by the current method. Joins/set operations are efficient.
+   *   InMemory               — Temporary ISAM file on AOS/client tier. SQL Server has no connection.
+   *                            Joins/set operations are usually INEFFICIENT. Same as old AX 2009 "Temporary".
+   */
+  tableType?: string;
   copyFrom?: string;
   fieldsHint?: string;
   primaryKeyFields?: string[];
@@ -49,7 +58,31 @@ export const generateSmartTableTool: Tool = {
       },
       tableGroup: {
         type: 'string',
-        description: 'Table group (e.g., "Main", "Parameter", "Group", "Transaction")',
+        description:
+          'Table group (business role). Defined by the system enum TableGroup (source: MSDN). ' +
+          'Valid values: ' +
+          '"Miscellaneous" = DEFAULT for new tables, does not fit other categories (e.g. TableExpImpDef); ' +
+          '"Main" = principal/master table for a central business object, static base data (e.g. CustTable, VendTable); ' +
+          '"Transaction" = transaction data, usually not edited directly (e.g. CustTrans, VendTrans); ' +
+          '"Parameter" = setup/parameter data for a Main table, typically one record per company (e.g. CustParameters); ' +
+          '"Group" = categorisation for a Main table, one-to-many with Main (e.g. CustGroup, VendGroup); ' +
+          '"WorksheetHeader" = worksheet header that categorises WorksheetLine rows (e.g. SalesTable); ' +
+          '"WorksheetLine" = lines to be validated and turned into transactions, may be deleted safely (e.g. SalesLine); ' +
+          '"Reference" = shared reference/lookup data across modules; ' +
+          '"Framework" = internal Microsoft framework/infrastructure tables. ' +
+          '⛔ NEVER pass "TempDB" or "InMemory" here — those are TableType values, NOT TableGroup values. ' +
+          'For temporary tables use tableType="TempDB" and keep tableGroup as "Main" (typical choice for Tmp tables).',
+      },
+      tableType: {
+        type: 'string',
+        description:
+          'Table storage type (TableType property, source: MSDN). Valid values: ' +
+          '"Regular" / "RegularTable" = DEFAULT, permanent table in main database — omit for regular tables; ' +
+          '"TempDB" = temporary table in SQL Server TempDB, dropped when no longer used by current method, ' +
+          'joins and set operations are EFFICIENT — use for SSRS report tmp tables and session-scoped data; ' +
+          '"InMemory" = temporary ISAM file on AOS/client tier, SQL Server has no connection to it, ' +
+          'joins and set operations are usually INEFFICIENT — equivalent to old AX 2009 "Temporary" property. ' +
+          '⛔ NEVER pass this value as tableGroup — they are completely separate properties.',
       },
       copyFrom: {
         type: 'string',
@@ -126,6 +159,7 @@ export async function handleGenerateSmartTable(
     name,
     label,
     tableGroup = 'Main',
+    tableType,
     copyFrom,
     fieldsHint,
     primaryKeyFields,
@@ -137,8 +171,49 @@ export async function handleGenerateSmartTable(
     methods: requestedMethods,
   } = args;
 
-  console.log(`[generateSmartTable] Generating table: ${name}, tableGroup=${tableGroup}, copyFrom=${copyFrom}`);
+  // Guard: 'TempDB' and 'InMemory' are NOT valid TableGroup values.
+  if (tableGroup === 'TempDB' || tableGroup === 'InMemory') {
+    return {
+      content: [{
+        type: 'text',
+        text: [
+          `❌ **Invalid parameter: tableGroup="${tableGroup}"**`,
+          ``,
+          `'${tableGroup}' is a **TableType** value, NOT a **TableGroup** value.`,
+          `These are two completely different D365FO table properties:`,
+          ``,
+          `| Property | Purpose | Valid values |`,
+          `|----------|---------|--------------|`,
+          `| **TableType** | Storage type | RegularTable, TempDB, InMemory |`,
+          `| **TableGroup** | Business role | Miscellaneous (default), Main, Transaction, Parameter, Group, WorksheetHeader, WorksheetLine, Reference, Framework |`,
+          ``,
+          `TableGroup meanings (source: MSDN / system enum TableGroup):`,
+          `  Miscellaneous   — DEFAULT for new tables; does not fit any other category`,
+          `  Main            — master/base object table, static data (e.g. CustTable, VendTable)`,
+          `  Transaction     — transaction data, not edited directly (e.g. CustTrans, VendTrans)`,
+          `  Parameter       — setup data for a Main table, usually one record/company (e.g. CustParameters)`,
+          `  Group           — categorisation for a Main table, one-to-many with Main (e.g. CustGroup)`,
+          `  WorksheetHeader — worksheet header, one-to-many with WorksheetLine (e.g. SalesTable)`,
+          `  WorksheetLine   — lines to validate → transactions, may be deleted safely (e.g. SalesLine)`,
+          `  Reference       — shared reference/lookup data across modules`,
+          `  Framework       — internal Microsoft framework/infrastructure tables`,
+          ``,
+          `🔄 **Call generate_smart_table again** with the corrected parameters:`,
+          `\`\`\``,
+          `generate_smart_table(`,
+          `  name="${name}",`,
+          `  tableType="${tableGroup}",       ← move here`,
+          `  tableGroup="Main",               ← use a valid TableGroup value`,
+          `  fieldsHint="...",`,
+          `)`,
+          `\`\`\``,
+        ].join('\n'),
+      }],
+      isError: true,
+    };
+  }
 
+  console.log(`[generateSmartTable] Generating table: ${name}, tableGroup=${tableGroup}, tableType=${tableType ?? 'Regular'}, copyFrom=${copyFrom}`);
   const builder = new SmartXmlBuilder();
   let fields: TableFieldSpec[] = [];
   let indexes: TableIndexSpec[] = [];
@@ -590,6 +665,7 @@ export async function handleGenerateSmartTable(
     name: finalName,
     label: label || finalName,
     tableGroup,
+    tableType,
     fields,
     indexes,
     relations,

--- a/src/utils/smartXmlBuilder.ts
+++ b/src/utils/smartXmlBuilder.ts
@@ -53,12 +53,24 @@ export class SmartXmlBuilder {
     name: string;
     label?: string;
     tableGroup?: string;
+    /**
+     * Table storage type. Defined by the TableType property (source: MSDN).
+     *   Regular / RegularTable — DEFAULT. Permanent table stored in the main database. Omit from XML (it is the default).
+     *   TempDB                 — Temporary table in SQL Server's TempDB database. Dropped when no longer used
+     *                            by the current method. Joins and set operations are efficient.
+     *   InMemory               — Temporary ISAM file on the AOS/client tier; SQL Server has no connection to it.
+     *                            Joins and set operations are usually INEFFICIENT. Equivalent to the old
+     *                            "Temporary" property from AX 2009.
+     * ⚠️ NEVER pass 'TempDB' or 'InMemory' as the `tableGroup` parameter —
+     *    those are NOT valid TableGroup values. Use `tableType` instead.
+     */
+    tableType?: string;
     fields: TableFieldSpec[];
     indexes?: TableIndexSpec[];
     relations?: TableRelationSpec[];
     methods?: Array<{ name: string; source: string }>;
   }): string {
-    const { name, label, tableGroup, fields, indexes, relations, methods } = spec;
+    const { name, label, tableGroup, tableType, fields, indexes, relations, methods } = spec;
 
     let xml = `<?xml version="1.0" encoding="utf-8"?>\n`;
     xml += `<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">\n`;
@@ -83,26 +95,63 @@ export class SmartXmlBuilder {
       xml += `\t<Label>${this.escapeXml(label)}</Label>\n`;
     }
 
-    // BP rule: CacheLookup — set based on TableGroup to avoid BP warning "CacheLookup should be set"
-    const effectiveTableGroup = tableGroup || 'Main';
-    const cacheLookupMap: Record<string, string> = {
-      Parameter:    'Found',
-      Group:        'Found',
-      Main:         'Found',
-      Transaction:  'None',
-      WorksheetHeader: 'None',
-      WorksheetLine:   'None',
-      Miscellaneous:   'NotInTTS',
-      Framework:       'Found',
-    };
-    const cacheLookup = cacheLookupMap[effectiveTableGroup] || 'Found';
-    xml += `\t<CacheLookup>${cacheLookup}</CacheLookup>\n`;
+    // Normalise tableType — 'RegularTable' is the default and is omitted from XML.
+    const normalizedTableType = tableType && tableType.toLowerCase() !== 'regulartable' ? tableType : '';
+    const isTempTable = normalizedTableType === 'TempDB' || normalizedTableType === 'InMemory';
 
-    // BP rule: SaveDataPerCompany — Yes by default (most tables are company-specific)
-    // Parameter and Group tables are always per-company; shared tables need explicit No
-    xml += `\t<SaveDataPerCompany>Yes</SaveDataPerCompany>\n`;
+    // Guard: 'TempDB' and 'InMemory' are NOT valid TableGroup values — they belong to TableType.
+    if (tableGroup === 'TempDB' || tableGroup === 'InMemory') {
+      throw new Error(
+        `❌ Invalid TableGroup value "${tableGroup}". ` +
+        `'TempDB' and 'InMemory' are values for the TableType property, NOT for TableGroup. ` +
+        `Valid TableGroup values: Main | Transaction | Parameter | Group | Reference | ` +
+        `Miscellaneous | WorksheetHeader | WorksheetLine | Framework. ` +
+        `To create a temporary table pass tableType="${tableGroup}" and keep tableGroup empty or set it to 'Main'.`
+      );
+    }
+
+    // Valid TableGroup values — system enum TableGroup (source: MSDN / D365FO AOT):
+    //   Miscellaneous   — DEFAULT for new tables; does not fit any other category (e.g. TableExpImpDef)
+    //   Main            — principal master table for a central business object (static base data)
+    //   Transaction     — transaction/journal data, typically not edited directly
+    //   Parameter       — setup/parameter data for a Main table (usually 1 record per company)
+    //   Group           — categorisation for a Main table (one-to-many: Group → Main)
+    //   WorksheetHeader — worksheet header rows; one-to-many with WorksheetLine
+    //   WorksheetLine   — lines to validate → transactions; may be deleted without affecting stability
+    //   Reference       — shared reference/lookup data across modules
+    //   Framework       — internal Microsoft framework / infrastructure tables
+    // For TempDB/InMemory tables the group is typically 'Main' (matches real D365FO Tmp tables).
+    const effectiveTableGroup = tableGroup || 'Main';
+
+    // BP rule: CacheLookup — set based on TableGroup to avoid BP warning "CacheLookup should be set".
+    // TempDB tables reside in SQL TempDB and are session-scoped → CacheLookup=None (never cache).
+    // InMemory tables are ISAM files on AOS tier, not in SQL Server → CacheLookup=None.
+    if (isTempTable) {
+      xml += `\t<CacheLookup>None</CacheLookup>\n`;
+    } else {
+      const cacheLookupMap: Record<string, string> = {
+        Parameter:       'Found',
+        Group:           'Found',
+        Main:            'Found',
+        Transaction:     'None',
+        WorksheetHeader: 'None',
+        WorksheetLine:   'None',
+        Miscellaneous:   'NotInTTS',
+        Framework:       'Found',
+      };
+      const cacheLookup = cacheLookupMap[effectiveTableGroup] || 'Found';
+      xml += `\t<CacheLookup>${cacheLookup}</CacheLookup>\n`;
+    }
+
+    // BP rule: SaveDataPerCompany — TempDB/InMemory tables are session-scoped, not company-scoped.
+    xml += `\t<SaveDataPerCompany>${isTempTable ? 'No' : 'Yes'}</SaveDataPerCompany>\n`;
 
     xml += `\t<TableGroup>${effectiveTableGroup}</TableGroup>\n`;
+
+    // Inject TableType element for non-regular tables (TempDB / InMemory).
+    if (normalizedTableType) {
+      xml += `\t<TableType>${normalizedTableType}</TableType>\n`;
+    }
 
     // TitleField1/TitleField2: first two non-RecId fields
     const titleCandidates = fields.filter(f => f.name !== 'RecId').slice(0, 2);


### PR DESCRIPTION
This pull request makes major improvements to how D365FO table properties are handled and documented, especially clarifying the distinction between `TableGroup` (business role) and `TableType` (storage type). It enforces correct usage of these properties in both code and documentation, prevents common mistakes (such as passing `TempDB` or `InMemory` as a `TableGroup`), and updates label naming conventions to avoid unnecessary prefixes. The changes also update tool schemas, error handling, and generated XML to align with these best practices.

**Key changes:**

### TableGroup vs TableType distinction and enforcement

* Added extensive documentation and code comments throughout `.github/copilot-instructions.md`, tool schemas, and code to clarify the difference between `TableGroup` (business role) and `TableType` (storage type), including valid values and examples. Explicitly warns never to use `TempDB` or `InMemory` as a `TableGroup`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R70-R105) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R233) [[3]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dL52-R85) [[4]](diffhunk://#diff-f23cfecf8e136c0308088563e28c9676330ea33729bb3fdecbbe3d2903fe71fcL86-R131)
* Added a guard and error message in `handleGenerateSmartTable` and in `SmartXmlBuilder` to prevent using `TempDB`/`InMemory` as `TableGroup`, with clear guidance on how to correct the parameters. [[1]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dL140-R216) [[2]](diffhunk://#diff-f23cfecf8e136c0308088563e28c9676330ea33729bb3fdecbbe3d2903fe71fcL86-R131)

### Tool and schema updates

* Added a `tableType` parameter to `generateSmartTable` and `generateSmartReport` tools, with detailed descriptions and validation in both the code and the OpenAPI schemas. [[1]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR20-R28) [[2]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dL52-R85) [[3]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR162) [[4]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR668) [[5]](diffhunk://#diff-49db3e44f343bfeea2653dd2d7b5c42b13de02c963d3971f4327ccbf3a553a11L489-R499) [[6]](diffhunk://#diff-49db3e44f343bfeea2653dd2d7b5c42b13de02c963d3971f4327ccbf3a553a11L517-R521) [[7]](diffhunk://#diff-f23cfecf8e136c0308088563e28c9676330ea33729bb3fdecbbe3d2903fe71fcR56-R73)
* Updated all relevant code paths to use the new `tableType` parameter and to generate correct XML for temporary tables, removing previous hacks that injected `<TableType>` manually. [[1]](diffhunk://#diff-49db3e44f343bfeea2653dd2d7b5c42b13de02c963d3971f4327ccbf3a553a11L489-R499) [[2]](diffhunk://#diff-49db3e44f343bfeea2653dd2d7b5c42b13de02c963d3971f4327ccbf3a553a11L517-R521) [[3]](diffhunk://#diff-f23cfecf8e136c0308088563e28c9676330ea33729bb3fdecbbe3d2903fe71fcL86-R131) [[4]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR668)

### Label naming conventions

* Updated documentation and schemas to clarify that label IDs should describe meaning only, never include model/object prefixes, and provided good/bad examples. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R592-R597) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1573-R1577) [[3]](diffhunk://#diff-aa454b1d0537c6f49eb8a25e1de4ae9698545a51ee1073c729ffdd54c87011faL40-R44)

---

These changes will help prevent common mistakes in D365FO table creation, improve code clarity, and ensure generated artifacts and documentation are consistent and correct.