### PR TITLE
fix: prevent duplicate methods and normalise doc comment indentation

### DIFF
--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -873,7 +873,17 @@ async function addMethod(xmlObj: any, objectType: string, args: any): Promise<bo
     Source: [ensureXppDocComment(fullSource)],
   };
 
-  methodsNode[0].Method.push(newMethod);
+  // Replace existing method with same name instead of pushing a duplicate.
+  // X++ does not support method overloading/overriding at the XML level — two
+  // <Method> nodes with the same <Name> cause serialisation/compiler errors.
+  const existingIdx = methodsNode[0].Method.findIndex(
+    (m: any) => m.Name && m.Name[0] === methodName
+  );
+  if (existingIdx !== -1) {
+    methodsNode[0].Method[existingIdx] = newMethod;
+  } else {
+    methodsNode[0].Method.push(newMethod);
+  }
 
   return true;
 }

--- a/src/utils/xppDocGen.ts
+++ b/src/utils/xppDocGen.ts
@@ -303,8 +303,9 @@ export function ensureXppDocComment(source: string): string {
   // Already documented?
   const firstNonEmpty = lines.find(l => l.trim().length > 0);
   if (firstNonEmpty?.trim().startsWith('///')) {
-    // Remove blank lines between /// doc-comment block and the next code line
-    return stripDocCommentGap(cleanSource);
+    // Remove blank lines between /// doc-comment block and the next code line,
+    // then normalise the /// block indentation to match the method signature.
+    return normalizeDocBlockIndent(stripDocCommentGap(cleanSource));
   }
 
   // Collect attribute lines before the signature (needed for class inference)
@@ -355,6 +356,40 @@ export function ensureXppDocComment(source: string): string {
   }
 
   return doc.join('\n') + '\n' + cleanSource;
+}
+
+/**
+ * Re-indent the leading /// doc-comment block so its indentation matches the
+ * first non-/// non-blank line (the attribute or method signature).
+ *
+ * An AI model may generate the /// block at column 0 while the signature is
+ * indented (or vice-versa).  This function normalises the mismatch so the
+ * first /// line always aligns with the rest of the method source.
+ */
+function normalizeDocBlockIndent(source: string): string {
+  const lines = source.split('\n');
+
+  // Detect the indentation of the first non-/// non-blank line (signature / attribute)
+  let sigIndent = '';
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t || t.startsWith('///')) continue;
+    sigIndent = line.match(/^(\s*)/)?.[1] ?? '';
+    break;
+  }
+
+  // Re-indent every leading /// line to use sigIndent
+  const result: string[] = [];
+  let inLeadingDocBlock = true;
+  for (const line of lines) {
+    if (inLeadingDocBlock && line.trim().startsWith('///')) {
+      result.push(sigIndent + line.trim());
+    } else {
+      inLeadingDocBlock = false;
+      result.push(line);
+    }
+  }
+  return result.join('\n');
 }
 
 /**


### PR DESCRIPTION
- addMethod now replaces an existing <Method> node with the same name instead of appending a second one; X++ has no overloading at the XML level so duplicate nodes cause compiler/deserialisation errors
- ensureXppDocComment now re-aligns a pre-existing /// doc block to match the indentation of the method signature line, fixing the case where AI-generated comments land at column 0 while the signature is indented (or vice-versa)