### PR TITLE
feat: implement real SDLC tools (run_bp_check, build, dbsync, systest…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -189,6 +189,17 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
   | PowerShell `run_in_terminal` or scripts to edit files | **FORBIDDEN. ALWAYS USE MCP TOOLS INSTEAD! PowerShell hangs in this workspace.** |
 | PowerShell `ls`, `Test-Path`, `Get-Item` to check D365FO files | `verify_d365fo_project()` |
 | PowerShell `Get-Content` / `Select-String` to find tab/control names in form XML | `get_form_info(formName, searchControl="General")` |
+| PowerShell / `run_in_terminal` to run BP check (xppbp.exe) | `run_bp_check()` — auto-detects model and packagePath from .mcp.json |
+| PowerShell / `run_in_terminal` to compile/build the project | `build_d365fo_project()` — auto-detects projectPath from .mcp.json |
+| PowerShell / `run_in_terminal` to run DB sync (SyncEngine.exe) | `trigger_db_sync()` |
+| PowerShell / `run_in_terminal` to run unit tests | `run_systest_class()` |
+
+> ### ⚠️ SDLC Tools — NEVER fall back to PowerShell or review_workspace_changes
+>
+> `run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, and `run_systest_class` call the real D365FO CLI binaries (xppbp.exe, MSBuild, SyncEngine.exe).
+> - All parameters are **optional** — model name and packagePath are auto-detected from `.mcp.json`.
+> - If `run_bp_check` returns an error about a missing binary, it means `packagePath` in `.mcp.json` is wrong — fix the config, do NOT switch to PowerShell or `review_workspace_changes`.
+> - `review_workspace_changes` is for **git diff code review only** — it is NOT a substitute for BP check.
 
 > ### ⚠️ CRITICAL — `get_form_info` WORKS for ALL D365FO forms
 >
@@ -232,6 +243,7 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 18. **ALWAYS** call `create_label()` for every new label ID before referencing it in code — uncreated labels cause BPErrorUnknownLabel at build time.
 19. **ALWAYS** write meaningful `/// <summary>` doc comments on every public/protected class and method — the text must describe what the code does, not just echo the name. `/// MyClass class.` or `/// run.` is NEVER acceptable (BPXmlDocNoDocumentationComments).
 20. **NEVER** pass `tableGroup="TempDB"` or `tableGroup="InMemory"` to `generate_smart_table` — `TempDB`/`InMemory` are **TableType** values, not **TableGroup** values. For a TempDB table use `tableType="TempDB"` and keep `tableGroup="Main"` (or another valid group). Valid `TableGroup` values (system enum TableGroup, source: MSDN): `Miscellaneous` (default for new tables) | `Main` | `Transaction` | `Parameter` | `Group` | `WorksheetHeader` | `WorksheetLine` | `Reference` | `Framework`.
+21. **NEVER** use PowerShell / `run_in_terminal` to run BP checks, builds, or DB sync — ALWAYS use `run_bp_check()`, `build_d365fo_project()`, `trigger_db_sync()`, `run_systest_class()`. All parameters (model, packagePath, projectPath) are **optional** and auto-detected from `.mcp.json`. If one of these tools returns an error about a missing binary or path, inform the user to fix `.mcp.json` — do NOT fall back to PowerShell. Do NOT use `review_workspace_changes` as a substitute for `run_bp_check` — they serve different purposes.
 
 ### AxClass sourceCode Format — Member Variables in Declaration
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -2369,9 +2369,9 @@ Examples:
         inputSchema: {
           type: 'object',
           properties: {
-            projectPath: { type: 'string', description: 'Absolute path to the .rnrproj file (e.g. K:\\\\repos\\\\MySolution\\\\MyProject\\\\MyProject.rnrproj)' },
+            projectPath: { type: 'string', description: 'Absolute path to the .rnrproj file (e.g. K:\\\\repos\\\\MySolution\\\\MyProject\\\\MyProject.rnrproj). Auto-detected from .mcp.json if omitted.' },
           },
-          required: ['projectPath'],
+          required: [],
         },
       },
       {
@@ -2382,6 +2382,7 @@ Examples:
           properties: {
             modelName: { type: 'string', description: 'The name of the model to sync (e.g. "ContosoExtensions")' },
             tableName: { type: 'string', description: 'Optional: sync only this specific table instead of the whole model' },
+            packagePath: { type: 'string', description: 'PackagesLocalDirectory root path. Auto-detected from .mcp.json if omitted.' },
           },
           required: ['modelName'],
         },
@@ -2392,20 +2393,24 @@ Examples:
         inputSchema: {
           type: 'object',
           properties: {
-            projectPath: { type: 'string', description: 'Absolute path to the .rnrproj file to analyze' },
+            projectPath: { type: 'string', description: 'Absolute path to the .rnrproj file to analyze. Auto-detected from .mcp.json if omitted.' },
             targetFilter: { type: 'string', description: 'Optional: filter results to a specific class, table, or object name' },
+            modelName: { type: 'string', description: 'Model name to check. Auto-detected from .mcp.json if omitted.' },
+            packagePath: { type: 'string', description: 'PackagesLocalDirectory root path. Auto-detected from .mcp.json if omitted.' },
           },
-          required: ['projectPath'],
+          required: [],
         },
       },
       {
         name: 'run_systest_class',
-        description: 'Execute a D365FO unit test class using SysTestRunner.exe. Returns pass/fail results for each test method.',
+        description: 'Execute a D365FO unit test class using SysTestRunner.exe or xppbp.exe. Returns pass/fail results for each test method.',
         inputSchema: {
           type: 'object',
           properties: {
             className: { type: 'string', description: 'The name of the SysTest class to run (e.g. "MyModuleTest")' },
             modelName: { type: 'string', description: 'The model containing the test class. Auto-detected from .mcp.json if omitted.' },
+            packagePath: { type: 'string', description: 'PackagesLocalDirectory root path. Auto-detected from .mcp.json if omitted.' },
+            testMethod: { type: 'string', description: 'Optional: run only this specific test method within the class (e.g. "testValidation").' },
           },
           required: ['className'],
         },

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -1,30 +1,79 @@
 import { z } from 'zod';
 import { exec } from 'child_process';
 import util from 'util';
+import { access } from 'fs/promises';
+import { getConfigManager } from '../utils/configManager.js';
 
 const execAsync = util.promisify(exec);
+
+// Known MSBuild locations on D365FO development VMs (in order of preference)
+const MSBUILD_CANDIDATES = [
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe',
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe',
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe',
+  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe',
+  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe',
+  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe',
+];
 
 export const buildProjectToolDefinition = {
   name: 'build_d365fo_project',
   description: 'Triggers a local MSBuild process on the .rnrproj to catch compiler errors.',
   parameters: z.object({
-    projectPath: z.string().describe('The absolute path to the .rnrproj file')
+    projectPath: z.string().optional().describe('The absolute path to the .rnrproj file. Auto-detected from .mcp.json if omitted.')
   })
 };
 
 export const buildProjectTool = async (params: any, _context: any) => {
-  const { projectPath } = params;
   try {
-    console.error('Starting MSBuild for ' + projectPath);
-    const buildCommand = 'echo Mock build for ' + projectPath + ' completed successfully.';
-    const { stdout } = await execAsync(buildCommand);
+    const configManager = getConfigManager();
+    await configManager.ensureLoaded();
+
+    const resolvedProjectPath = params.projectPath || await configManager.getProjectPath();
+    if (!resolvedProjectPath) {
+      return {
+        content: [{ type: 'text', text: '❌ Cannot determine project path.\n\nProvide projectPath parameter or set it in .mcp.json.' }],
+        isError: true
+      };
+    }
+
+    // Try to locate MSBuild
+    let msbuildExe: string | null = null;
+    for (const candidate of MSBUILD_CANDIDATES) {
+      try {
+        await access(candidate);
+        msbuildExe = candidate;
+        break;
+      } catch { /* not found, try next */ }
+    }
+
+    // Fall back to msbuild from PATH
+    if (!msbuildExe) {
+      msbuildExe = 'msbuild';
+    }
+
+    const buildCommand = `"${msbuildExe}" "${resolvedProjectPath}" /p:Configuration=Debug /p:Platform=AnyCPU /m /v:minimal /nologo`;
+    console.error(`[build_d365fo_project] Running: ${buildCommand}`);
+
+    const { stdout, stderr } = await execAsync(buildCommand, {
+      maxBuffer: 20 * 1024 * 1024,
+      timeout: 600_000 // 10 minutes
+    });
+
+    const output = [stdout, stderr].filter(Boolean).join('\n').trim();
+    const hasErrors = /\b(error|Error)\s+(CS|AX|X\+\+|MSB)\d+|Build FAILED/i.test(output);
+    const hasWarnings = /\b(warning)\s+(CS|AX|X\+\+|MSB|BP)\d+/i.test(output);
+
+    const status = hasErrors ? '❌ Build FAILED' : hasWarnings ? '⚠️ Build succeeded with warnings' : '✅ Build succeeded';
+
     return {
-      content: [{ type: 'text', text: 'OK Build finished.\n\nstdout:\n' + stdout }]
+      content: [{ type: 'text', text: `${status}\n\nProject: ${resolvedProjectPath}\n\n${output || '(no output)'}` }]
     };
   } catch (error: any) {
     console.error('Error building project:', error);
+    const output = [error.stdout, error.stderr, error.message].filter(Boolean).join('\n');
     return {
-      content: [{ type: 'text', text: 'Error Build Failed:\n' + error.stdout + '\n' + error.stderr + '\n' + error.message }],
+      content: [{ type: 'text', text: '❌ Build failed:\n\n' + output }],
       isError: true
     };
   }

--- a/src/tools/dbSync.ts
+++ b/src/tools/dbSync.ts
@@ -1,32 +1,81 @@
 import { z } from 'zod';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import util from 'util';
+import path from 'path';
+import fs from 'fs/promises';
+import { getConfigManager } from '../utils/configManager.js';
 
-const execAsync = util.promisify(exec);
+const execFileAsync = util.promisify(execFile);
 
 export const dbSyncToolDefinition = {
   name: 'trigger_db_sync',
   description: 'Triggers a database sync for a specific model or table to validate schema integrity.',
   parameters: z.object({
     modelName: z.string().describe('The name of the model to sync'),
-    tableName: z.string().optional().describe('An optional specific table to sync')
+    tableName: z.string().optional().describe('An optional specific table to sync'),
+    packagePath: z.string().optional().describe('PackagesLocalDirectory root. Auto-detected if omitted.')
   })
 };
 
 export const dbSyncTool = async (params: any, _context: any) => {
   const { modelName, tableName } = params;
   try {
-    console.error('Starting DB Sync for model: ' + modelName + (tableName ? ' table: ' + tableName : ''));
-    const target = tableName ? '-table ' + tableName : '-model ' + modelName;
-    const mockedCommand = 'echo DB Sync Mock for ' + target + ' completed.';
-    const { stdout } = await execAsync(mockedCommand);
+    const configManager = getConfigManager();
+    await configManager.ensureLoaded();
+
+    const packagesRoot = params.packagePath
+      || configManager.getPackagePath()
+      || 'K:\\AosService\\PackagesLocalDirectory';
+
+    // SyncEngine.exe location
+    const syncEnginePath = path.join(packagesRoot, 'Bin', 'SyncEngine.exe');
+    try {
+      await fs.access(syncEnginePath);
+    } catch {
+      return {
+        content: [{ type: 'text', text: `❌ SyncEngine.exe not found at: ${syncEnginePath}\n\nMake sure PackagesLocalDirectory is correctly configured in .mcp.json (packagePath).` }],
+        isError: true
+      };
+    }
+
+    // SyncEngine.exe -connect=... -metadatabinaries=... -syncmode=...
+    // For D365FO local dev: SyncEngine.exe -syncmode=fullall -connect=<connection> -metadatabinaries=<binpath>
+    const binPath = path.join(packagesRoot, modelName, 'bin');
+    const connectionString = 'Data Source=localhost;Initial Catalog=AxDB;Integrated Security=True';
+
+    const args: string[] = [
+      `-syncmode=${tableName ? 'onlysyncselectedtables' : 'fullall'}`,
+      `-connect=${connectionString}`,
+      `-metadatabinaries=${binPath}`
+    ];
+    if (tableName) {
+      args.push(`-tables=${tableName}`);
+    }
+
+    console.error(`[trigger_db_sync] Running: "${syncEnginePath}" ${args.join(' ')}`);
+
+    const { stdout, stderr } = await execFileAsync(syncEnginePath, args, {
+      maxBuffer: 20 * 1024 * 1024,
+      timeout: 600_000 // 10 minutes
+    });
+
+    const output = [stdout, stderr].filter(Boolean).join('\n').trim();
+    const hasErrors = /error|failed|exception/i.test(output);
+
     return {
-      content: [{ type: 'text', text: 'OK DB Sync finished.\n\nstdout:\n' + stdout }]
+      content: [{
+        type: 'text',
+        text: (hasErrors ? '❌ DB Sync failed' : '✅ DB Sync completed') +
+          `\n\nModel: ${modelName}` +
+          (tableName ? `\nTable: ${tableName}` : '') +
+          `\n\n${output || '(no output)'}`
+      }]
     };
   } catch (error: any) {
     console.error('Error syncing DB:', error);
+    const output = [error.stdout, error.stderr, error.message].filter(Boolean).join('\n');
     return {
-      content: [{ type: 'text', text: 'Error DB Sync Failed:\n' + error.stdout + '\n' + error.message }],
+      content: [{ type: 'text', text: '❌ DB Sync failed:\n\n' + output }],
       isError: true
     };
   }

--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -1,32 +1,94 @@
 import { z } from 'zod';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import util from 'util';
+import path from 'path';
+import fs from 'fs/promises';
+import { getConfigManager } from '../utils/configManager.js';
 
-const execAsync = util.promisify(exec);
+const execFileAsync = util.promisify(execFile);
 
 export const runBpCheckToolDefinition = {
   name: 'run_bp_check',
   description: 'Runs xppbp.exe against the project to enforce Microsoft Best Practices.',
   parameters: z.object({
-    projectPath: z.string().describe('The absolute path to the .rnrproj file to check.'),
-    targetFilter: z.string().optional().describe('Optional: filter results to a specific class, table, or object name')
+    projectPath: z.string().optional().describe('The absolute path to the .rnrproj file to check. Auto-detected from .mcp.json if omitted.'),
+    targetFilter: z.string().optional().describe('Optional: filter results to a specific class, table, or object name'),
+    modelName: z.string().optional().describe('Model name to check. Auto-detected from .mcp.json if omitted.'),
+    packagePath: z.string().optional().describe('PackagesLocalDirectory root. Auto-detected if omitted.')
   })
 };
 
 export const runBpCheckTool = async (params: any, _context: any) => {
-  const { projectPath, targetFilter } = params;
+  const { targetFilter } = params;
   try {
-    console.error('Starting BP Check for ' + projectPath);
-    const filterNote = targetFilter ? ' (filter: ' + targetFilter + ')' : '';
-    const checkCommand = 'echo Mock BP check passed for ' + projectPath + filterNote + '.';
-    const { stdout } = await execAsync(checkCommand);
+    const configManager = getConfigManager();
+    await configManager.ensureLoaded();
+
+    // Resolve package path
+    const packagesRoot = params.packagePath
+      || configManager.getPackagePath()
+      || 'K:\\AosService\\PackagesLocalDirectory';
+
+    // Resolve model name
+    const modelName = params.modelName || configManager.getModelName();
+    if (!modelName) {
+      return {
+        content: [{ type: 'text', text: '❌ Cannot determine model name.\n\nProvide modelName parameter or set it in .mcp.json.' }],
+        isError: true
+      };
+    }
+
+    // Resolve project path (optional for xppbp, but useful for package resolution)
+    const resolvedProjectPath = params.projectPath || await configManager.getProjectPath();
+
+    // Locate xppbp.exe
+    const xppbpPath = path.join(packagesRoot, 'Bin', 'xppbp.exe');
+    try {
+      await fs.access(xppbpPath);
+    } catch {
+      return {
+        content: [{ type: 'text', text: `❌ xppbp.exe not found at: ${xppbpPath}\n\nMake sure PackagesLocalDirectory is correctly configured in .mcp.json (packagePath).` }],
+        isError: true
+      };
+    }
+
+    // Build xppbp.exe arguments
+    // xppbp.exe -packagesroot:<root> -model:<model> [-filter:<object>] [-vsproj:<path>]
+    const args: string[] = [
+      `-packagesroot:${packagesRoot}`,
+      `-model:${modelName}`
+    ];
+    if (targetFilter) {
+      args.push(`-filter:${targetFilter}`);
+    }
+    if (resolvedProjectPath) {
+      args.push(`-vsproj:${resolvedProjectPath}`);
+    }
+
+    console.error(`[run_bp_check] Running: "${xppbpPath}" ${args.join(' ')}`);
+
+    const { stdout, stderr } = await execFileAsync(xppbpPath, args, {
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 300_000 // 5 minutes
+    });
+
+    const output = [stdout, stderr].filter(Boolean).join('\n').trim();
+    const hasErrors = /error|BPError|BPCheck/i.test(output);
+
     return {
-      content: [{ type: 'text', text: 'OK BP Check finished.\n\nstdout:\n' + stdout }]
+      content: [{
+        type: 'text',
+        text: (hasErrors ? '⚠️ BP Check completed with issues' : '✅ BP Check passed') +
+          `\n\nModel: ${modelName}` +
+          (targetFilter ? `\nFilter: ${targetFilter}` : '') +
+          `\n\n${output || '(no output)'}` 
+      }]
     };
   } catch (error: any) {
     console.error('Error running BP Check:', error);
+    const output = [error.stdout, error.stderr, error.message].filter(Boolean).join('\n');
     return {
-      content: [{ type: 'text', text: 'Error BP Check Failed:\n' + error.stdout + '\n' + error.message }],
+      content: [{ type: 'text', text: '❌ BP Check failed:\n\n' + output }],
       isError: true
     };
   }

--- a/src/tools/sysTestRunner.ts
+++ b/src/tools/sysTestRunner.ts
@@ -1,31 +1,109 @@
 import { z } from 'zod';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import util from 'util';
+import path from 'path';
+import fs from 'fs/promises';
+import { getConfigManager } from '../utils/configManager.js';
 
-const execAsync = util.promisify(exec);
+const execFileAsync = util.promisify(execFile);
 
 export const sysTestRunnerToolDefinition = {
   name: 'run_systest_class',
   description: 'Invoke D365FO SysTest framework against a specific test class.',
   parameters: z.object({
     className: z.string().describe('The name of the SysTest class to run'),
-    modelName: z.string().optional().describe('The model containing the test class. Auto-detected from .mcp.json if omitted.')
+    modelName: z.string().optional().describe('The model containing the test class. Auto-detected from .mcp.json if omitted.'),
+    packagePath: z.string().optional().describe('PackagesLocalDirectory root. Auto-detected if omitted.'),
+    testMethod: z.string().optional().describe('Optional: run only this specific test method within the class.')
   })
 };
 
 export const sysTestRunnerTool = async (params: any, _context: any) => {
-  const { className, modelName } = params;
+  const { className, testMethod } = params;
   try {
-    console.error('Starting SysTestRunner for class: ' + className + (modelName ? ' in model: ' + modelName : ''));
-    const runCommand = 'echo Mock SysTestRunner for ' + className + ' passed.';
-    const { stdout } = await execAsync(runCommand);
+    const configManager = getConfigManager();
+    await configManager.ensureLoaded();
+
+    const resolvedModelName = params.modelName || configManager.getModelName();
+    if (!resolvedModelName) {
+      return {
+        content: [{ type: 'text', text: '❌ Cannot determine model name.\n\nProvide modelName parameter or set it in .mcp.json.' }],
+        isError: true
+      };
+    }
+
+    const packagesRoot = params.packagePath
+      || configManager.getPackagePath()
+      || 'K:\\AosService\\PackagesLocalDirectory';
+
+    // xppbp.exe can also run SysTest classes via -runtest flag
+    // Alternatively use SysTestRunner.exe if available
+    const xppbpPath = path.join(packagesRoot, 'Bin', 'xppbp.exe');
+    const sysTestRunnerPath = path.join(packagesRoot, 'Bin', 'SysTestRunner.exe');
+
+    // Prefer SysTestRunner.exe, fall back to xppbp.exe
+    let runnerPath: string;
+    try {
+      await fs.access(sysTestRunnerPath);
+      runnerPath = sysTestRunnerPath;
+    } catch {
+      try {
+        await fs.access(xppbpPath);
+        runnerPath = xppbpPath;
+      } catch {
+        return {
+          content: [{ type: 'text', text: `❌ Neither SysTestRunner.exe nor xppbp.exe found in:\n${path.join(packagesRoot, 'Bin')}\n\nMake sure PackagesLocalDirectory is correctly configured.` }],
+          isError: true
+        };
+      }
+    }
+
+    let args: string[];
+    if (runnerPath === sysTestRunnerPath) {
+      // SysTestRunner.exe: -name:<className>[::testMethod] -packagePath:<path>
+      const testTarget = testMethod ? `${className}::${testMethod}` : className;
+      args = [
+        `-name:${testTarget}`,
+        `-packagePath:${packagesRoot}`,
+        `-model:${resolvedModelName}`
+      ];
+    } else {
+      // xppbp.exe: -packagesroot:<root> -model:<model> -runtest:<class>
+      args = [
+        `-packagesroot:${packagesRoot}`,
+        `-model:${resolvedModelName}`,
+        `-runtest:${className}`
+      ];
+      if (testMethod) args.push(`-testmethod:${testMethod}`);
+    }
+
+    console.error(`[run_systest_class] Running: "${runnerPath}" ${args.join(' ')}`);
+
+    const { stdout, stderr } = await execFileAsync(runnerPath, args, {
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 300_000 // 5 minutes
+    });
+
+    const output = [stdout, stderr].filter(Boolean).join('\n').trim();
+    const hasFailed = /failed|error|exception/i.test(output);
+    const passed = /passed|success/i.test(output);
+
+    const status = hasFailed ? '❌ Tests FAILED' : passed ? '✅ Tests passed' : '⚠️ Tests completed (check output)';
+
     return {
-      content: [{ type: 'text', text: 'OK Test finished.\n\nstdout:\n' + stdout }]
+      content: [{
+        type: 'text',
+        text: `${status}\n\nClass: ${className}` +
+          (testMethod ? `::${testMethod}` : '') +
+          `\nModel: ${resolvedModelName}` +
+          `\n\n${output || '(no output)'}`
+      }]
     };
   } catch (error: any) {
     console.error('Error running test:', error);
+    const output = [error.stdout, error.stderr, error.message].filter(Boolean).join('\n');
     return {
-      content: [{ type: 'text', text: 'Error Test Failed:\n' + error.stdout + '\n' + error.message }],
+      content: [{ type: 'text', text: '❌ Tests failed:\n\n' + output }],
       isError: true
     };
   }

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -1,32 +1,202 @@
 import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
+import { XppMetadataParser } from '../metadata/xmlParser.js';
+import type { XppServerContext } from '../types/context.js';
+import type { XppSymbol } from '../metadata/types.js';
 
 export const updateSymbolIndexToolDefinition = {
   name: 'update_symbol_index',
-  description: 'Validates and index specifically modified or created file.',
+  description: 'Index a newly generated or modified D365FO XML file immediately so references to it work without restarting the server.',
   parameters: z.object({
-    filePath: z.string().describe('The absolute path to the modified XML file')
+    filePath: z.string().describe('The absolute path to the modified or created XML file')
   })
 };
 
-export const updateSymbolIndexTool = async (params: any, _context: any) => {
+/** Map AOT folder names to symbol types */
+const AOT_FOLDER_TYPE_MAP: Record<string, XppSymbol['type']> = {
+  'axclass': 'class',
+  'axtable': 'table',
+  'axtableextension': 'table-extension',
+  'axform': 'form',
+  'axformextension': 'form-extension',
+  'axenum': 'enum',
+  'axenumsextension': 'enum-extension',
+  'axedt': 'edt',
+  'axedtsextension': 'edt-extension',
+  'axquery': 'query',
+  'axview': 'view',
+  'axreport': 'report',
+  'axsecurityprivilege': 'security-privilege',
+  'axsecurityduty': 'security-duty',
+  'axsecurityrole': 'security-role',
+  'axmenuitemaction': 'menu-item-action',
+  'axmenuitemdisplay': 'menu-item-display',
+  'axmenuitemoutput': 'menu-item-output',
+};
+
+/**
+ * Extract model name from AOT file path.
+ * Pattern: {packagesRoot}\{package}\{model}\Ax{Type}\{Name}.xml
+ * or:      {packagesRoot}\{model}\{model}\Ax{Type}\{Name}.xml
+ */
+function extractModelFromPath(filePath: string): string | null {
+  const parts = filePath.replace(/\//g, '\\').split('\\');
+  // Find the AOT folder index (e.g. AxClass, AxTable)
+  const aotIdx = parts.findIndex(p => p.toLowerCase() in AOT_FOLDER_TYPE_MAP);
+  if (aotIdx >= 2) {
+    return parts[aotIdx - 1]; // folder immediately before the AOT folder = model name
+  }
+  return null;
+}
+
+export const updateSymbolIndexTool = async (params: any, context: XppServerContext) => {
   const { filePath } = params;
   try {
     if (!fs.existsSync(filePath)) {
       return {
-        content: [{ type: 'text', text: 'Warning: File not found at ' + filePath }]
+        content: [{ type: 'text', text: `⚠️ File not found at ${filePath}` }]
       };
     }
-    console.error('Updating SQLite index for file: ' + filePath);
-    const sym = path.parse(filePath).name;
+
+    const { symbolIndex } = context;
+    const parser = new XppMetadataParser();
+    const objectName = path.parse(filePath).name;
+    const parts = filePath.replace(/\//g, '\\').split('\\');
+    const aotFolder = parts.find((p: string) => p.toLowerCase() in AOT_FOLDER_TYPE_MAP) ?? '';
+    const objectType: XppSymbol['type'] = AOT_FOLDER_TYPE_MAP[aotFolder.toLowerCase()] ?? 'class';
+    const model = extractModelFromPath(filePath) ?? 'Unknown';
+
+    console.error(`[update_symbol_index] Re-indexing ${objectType} "${objectName}" (model: ${model})`);
+
+    // 1. Remove all existing symbols for this file so stale entries don't linger
+    const deleted = symbolIndex.db
+      .prepare(`DELETE FROM symbols WHERE file_path = ?`)
+      .run(filePath);
+    const deletedCount = deleted.changes;
+
+    // 2. Re-parse the XML and insert fresh symbols
+    let insertedCount = 0;
+    const tx = symbolIndex.db.transaction(() => {
+      // Minimal fallback for types not handled individually below
+      symbolIndex.addSymbol({
+        name: objectName,
+        type: objectType,
+        filePath,
+        model,
+      });
+      insertedCount++;
+    });
+
+    // For classes and tables, parse XML to get methods/fields too
+    if (objectType === 'class') {
+      const result = await parser.parseClassFile(filePath, model);
+      if (result.success && result.data) {
+        const classData = result.data;
+        const insert = symbolIndex.db.transaction(() => {
+          symbolIndex.addSymbol({
+            name: classData.name,
+            type: 'class',
+            signature: classData.extends ? `extends ${classData.extends}` : undefined,
+            filePath,
+            model,
+            description: classData.documentation,
+            extendsClass: classData.extends,
+            implementsInterfaces: classData.implements?.join(', '),
+          });
+          insertedCount++;
+          for (const method of classData.methods ?? []) {
+            const params = method.parameters?.map((p: any) => `${p.type} ${p.name}`).join(', ') ?? '';
+            symbolIndex.addSymbol({
+              name: method.name,
+              type: 'method',
+              parentName: classData.name,
+              signature: `${method.returnType} ${method.name}(${params})`,
+              filePath,
+              model,
+              source: method.source,
+            });
+            insertedCount++;
+          }
+        });
+        insert();
+      } else {
+        // Fallback: just index the object name
+        tx();
+      }
+    } else if (objectType === 'table') {
+      const result = await parser.parseTableFile(filePath, model);
+      if (result.success && result.data) {
+        const tableData = result.data;
+        const insert = symbolIndex.db.transaction(() => {
+          symbolIndex.addSymbol({
+            name: tableData.name,
+            type: 'table',
+            filePath,
+            model,
+          });
+          insertedCount++;
+          for (const field of tableData.fields ?? []) {
+            symbolIndex.addSymbol({
+              name: field.name,
+              type: 'field',
+              parentName: tableData.name,
+              signature: field.type,
+              filePath,
+              model,
+            });
+            insertedCount++;
+          }
+        });
+        insert();
+      } else {
+        tx();
+      }
+    } else if (objectType === 'edt') {
+      const result = await parser.parseEdtFile(filePath, model);
+      if (result.success && result.data) {
+        const edtData = result.data as any;
+        symbolIndex.addSymbol({
+          name: edtData.name ?? objectName,
+          type: 'edt',
+          signature: edtData.extends ?? undefined,
+          filePath,
+          model,
+        });
+        insertedCount++;
+      } else {
+        tx();
+      }
+    } else if (objectType === 'form' || objectType === 'form-extension') {
+      const result = await parser.parseFormFile(filePath, model);
+      if (result.success && result.data) {
+        const formData = result.data as any;
+        symbolIndex.addSymbol({
+          name: formData.name ?? objectName,
+          type: objectType,
+          filePath,
+          model,
+        });
+        insertedCount++;
+      } else {
+        tx();
+      }
+    } else {
+      tx();
+    }
+
     return {
-      content: [{ type: 'text', text: 'Successfully indexed ' + sym + ' into SQLite cache.' }]
+      content: [{
+        type: 'text',
+        text: `✅ Symbol index updated for **${objectName}** (${objectType}, model: ${model}).\n\n` +
+          `Removed: ${deletedCount} stale entr${deletedCount === 1 ? 'y' : 'ies'}\n` +
+          `Inserted: ${insertedCount} symbol${insertedCount !== 1 ? 's' : ''}`
+      }]
     };
   } catch (error: any) {
     console.error('Error updating symbol index:', error);
     return {
-      content: [{ type: 'text', text: 'Error updating symbol index: ' + error.message }],
+      content: [{ type: 'text', text: `❌ Error updating symbol index: ${error.message}` }],
       isError: true
     };
   }


### PR DESCRIPTION
This pull request significantly improves the D365FO MCP toolchain by enabling automatic detection of parameters from `.mcp.json`, enforcing best practices in documentation and instructions, and replacing PowerShell-based operations with direct CLI binary invocations. The changes enhance reliability, reduce manual configuration, and provide clearer error handling and output for build, BP check, database sync, and unit test operations.

**MCP Tool Automation and Reliability**

* All MCP tools (`run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, `run_systest_class`) now auto-detect parameters (model, packagePath, projectPath) from `.mcp.json` if omitted, reducing manual input and configuration errors. [[1]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L2372-R2374) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R2385) [[3]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L2395-R2413)
* Each tool directly invokes the relevant D365FO CLI binaries (e.g., `xppbp.exe`, `MSBuild.exe`, `SyncEngine.exe`, `SysTestRunner.exe`) with robust error handling, clear output summaries, and fallback logic for binary location. [[1]](diffhunk://#diff-a241a053ffe514ec38deed6e56f90e21e79faf9743509e6bec7f92b9f975225cR4-R76) [[2]](diffhunk://#diff-3468384829fccd93e289f81dc6feb006835a35b7b5f25c946a43468e7d491fb1L2-R78) [[3]](diffhunk://#diff-eca9a19782a6f842ce9260a7087e0f4059ea6c334673c42c19e597f8e2c3149aL2-R91) [[4]](diffhunk://#diff-45165ddc36cd4d53e4ed2ee86a62d906d936cbdb137057cdc55cc12fbc167c52L2-R106)

**Best Practice Enforcement and Documentation**

* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R192-R202): Expanded instructions to strictly forbid PowerShell or `run_in_terminal` for BP checks, builds, DB sync, and unit tests. All operations must use MCP tools, and fallback to PowerShell or `review_workspace_changes` is explicitly prohibited. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R192-R202) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R246)
* Clarified that MCP tools serve different purposes and that errors relating to missing binaries or paths must be resolved by fixing `.mcp.json`, not by switching tools. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R192-R202) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R246)

**Tool Definitions and Input Schema Improvements**

* Tool definitions and input schemas updated to reflect optional parameters and auto-detection, improving API usability and reducing required fields for common operations. [[1]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L2372-R2374) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R2385) [[3]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L2395-R2413)

**Error Handling and Output**

* All tools now provide clear, actionable error messages when binaries are missing or parameters cannot be resolved, guiding users to fix `.mcp.json` instead of falling back to unsupported methods. [[1]](diffhunk://#diff-a241a053ffe514ec38deed6e56f90e21e79faf9743509e6bec7f92b9f975225cR4-R76) [[2]](diffhunk://#diff-3468384829fccd93e289f81dc6feb006835a35b7b5f25c946a43468e7d491fb1L2-R78) [[3]](diffhunk://#diff-eca9a19782a6f842ce9260a7087e0f4059ea6c334673c42c19e597f8e2c3149aL2-R91) [[4]](diffhunk://#diff-45165ddc36cd4d53e4ed2ee86a62d906d936cbdb137057cdc55cc12fbc167c52L2-R106)

**Codebase Modernization**

* Replaced PowerShell-based mock commands with direct binary invocations using `execFile`, improved buffer and timeout handling, and added logic to locate binaries in common VM paths or fallback to system PATH. [[1]](diffhunk://#diff-a241a053ffe514ec38deed6e56f90e21e79faf9743509e6bec7f92b9f975225cR4-R76) [[2]](diffhunk://#diff-3468384829fccd93e289f81dc6feb006835a35b7b5f25c946a43468e7d491fb1L2-R78) [[3]](diffhunk://#diff-eca9a19782a6f842ce9260a7087e0f4059ea6c334673c42c19e597f8e2c3149aL2-R91) [[4]](diffhunk://#diff-45165ddc36cd4d53e4ed2ee86a62d906d936cbdb137057cdc55cc12fbc167c52L2-R106)

These changes collectively make the MCP toolchain more robust, user-friendly, and aligned with D365FO development best practices.