### PR TITLE
feat: update SDLC & Build Tools section with new testing tool and adj…

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -70,7 +70,7 @@ just ask in plain English.
 | **get_form_patterns** | Analyze datasource/control patterns for forms | "Find forms using CustTable" |
 | **generate_code** | Generate X++ boilerplate (class, batch job, CoC, etc.) | "Generate a batch job class for order processing" |
 
-### SDLC & Build Tools — LOCAL_TOOLS (5 tools - NEW)
+### SDLC & Build Tools — LOCAL_TOOLS (6 tools - NEW)
 
 The following tools empower Copilot to trigger X++ compilation, testing, and db syncing:
 
@@ -80,10 +80,7 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 | **build_d365fo_project** | Triggers an MSBuild process on the project to catch compiler errors | "Build my project and show me the errors" |
 | **trigger_db_sync** | Runs a database sync for the given table or the whole model | "Sync the database to reflect my table changes" |
 | **run_bp_check** | Runs the best practice linter on the code | "Run best practice checks on my latest changes" |
-| **run_systest** | Runs unit tests using SysTestRunner | "Run the unit tests in my project" |
-
-| **undo_last_modification** | Undoes the last uncommitted modification or file creation via git | "Undo the changes I just made to CustTable.xml" |
-
+| **run_systest_class** | Invokes D365FO SysTest framework against a specific test class | "Run the unit tests in MyTestClass" |
 | **undo_last_modification** | Undoes the last uncommitted modification or file creation via git | "Undo the changes I just made to CustTable.xml" |
 
 ### File Operations — LOCAL_TOOLS (4 tools)


### PR DESCRIPTION
This pull request updates the documentation for the SDLC & Build Tools section in `docs/MCP_TOOLS.md` to reflect a change in the available tools and clarify their descriptions. The most important changes are:

**Toolset updates and corrections:**

* Updated the tool count from 5 to 6 in the "SDLC & Build Tools — LOCAL_TOOLS" section to accurately reflect the number of tools available.
* Replaced the `run_systest` tool (which ran unit tests using `SysTestRunner`) with a more specific `run_systest_class` tool that invokes the D365FO SysTest framework against a specific test class, and updated its description and example usage accordingly.
* Fixed the formatting and placement of the `undo_last_modification` tool entry for consistency and clarity.