### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -701,7 +701,13 @@ export class XppSymbolIndex {
       // PERFORMANCE: Also select only essential columns in fallback
       const fallbackCacheKey = types?.length ? `fallback_typed_${types.join('_')}` : 'fallback_all';
       let fallbackSql = `SELECT s.id, s.name, s.type, s.parent_name, s.signature, s.file_path, s.model, s.description FROM symbols s WHERE s.name LIKE ?`;
-      const fallbackParams: any[] = [`%${query.replace(/[%_]/g, '\\$&')}%`];
+      const escapeLikePattern = (value: string): string => {
+        // First escape backslashes, then escape SQL LIKE wildcards % and _
+        return value
+          .replace(/\\/g, '\\\\')
+          .replace(/[%_]/g, '\\$&');
+      };
+      const fallbackParams: any[] = [`%${escapeLikePattern(query)}%`];
       if (types && types.length > 0) {
         fallbackSql += ` AND s.type IN (${types.map(() => '?').join(',')})`;  
         fallbackParams.push(...types);


### PR DESCRIPTION
Potential fix for [https://github.com/dynamics365ninja/d365fo-mcp-server/security/code-scanning/9](https://github.com/dynamics365ninja/d365fo-mcp-server/security/code-scanning/9)

In general, when escaping user input for SQL `LIKE` patterns using a backslash escape, you must first escape existing backslashes, then escape all occurrences of `%` and `_`. That ensures that no combination of user-supplied backslashes and wildcards can alter how the pattern is interpreted.

In this code, the best targeted fix is to replace the single `replace(/[%_]/g, '\\$&')` call with a small helper that (a) escapes `\` as `\\`, and then (b) escapes `%` and `_` as `\%` and `\_`. We should implement this without changing semantics elsewhere: keep using parameter placeholders and the same `LIKE` expression, only improving the construction of the parameter string. Concretely, inside `searchSymbols`, introduce a small local function (or inline expression) that does two chained `.replace` operations: first `s.replace(/\\/g, '\\\\')` to double backslashes, then `.replace(/[%_]/g, '\\$&')` to prefix `%` and `_` with a backslash. Then use that function when building `fallbackParams[0]`, wrapping the escaped string with `%...%` as before. No new imports are needed, and all changes stay inside `src/metadata/symbolIndex.ts` and within the shown method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
