### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -244,21 +244,28 @@ export async function autoDetectD365Project(
   // repo itself alongside D365FO projects, making the first-found result unpredictable.
   // Configure D365FO_SOLUTIONS_PATH instead for reliable detection.
   if (process.platform === 'win32') {
-    const userProfile = process.env.USERPROFILE || `C:\\Users\\${process.env.USERNAME}`;
+    const userProfile = process.env.USERPROFILE || (process.env.USERNAME ? `C:\\Users\\${process.env.USERNAME}` : undefined);
     const wellKnownPaths = [
-      `${userProfile}\\Documents\\Visual Studio 2022\\Projects`,
+      userProfile ? `${userProfile}\\Documents\\Visual Studio 2022\\Projects` : undefined,
       // Common D365FO VM layouts — K: is the data drive in most LCS-provisioned VMs
       `K:\\VSProjects`,
       `K:\\Projects`,
       `K:\\repos`,
       `C:\\VSProjects`,
       `C:\\Projects`,
-    ];
+    ].filter((p): p is string => !!p);
+    const sanitizePathForLog = (p: string): string => {
+      if (userProfile && p.startsWith(userProfile)) {
+        return p.replace(userProfile, '<UserProfile>');
+      }
+      return p;
+    };
     for (const searchRoot of wellKnownPaths) {
       try {
         const files = await findProjectFiles(searchRoot);
         if (files.length > 0) {
-          console.error(`[WorkspaceDetector] Found ${files.length} .rnrproj file(s) in ${searchRoot}`);
+          const loggedSearchRoot = sanitizePathForLog(searchRoot);
+          console.error(`[WorkspaceDetector] Found ${files.length} .rnrproj file(s) in ${loggedSearchRoot}`);
           const projectPath = files[0]; // take first (most likely the user's project)
           const modelName = await extractModelNameFromProject(projectPath);
           if (modelName) {


### PR DESCRIPTION
Potential fix for [https://github.com/dynamics365ninja/d365fo-mcp-server/security/code-scanning/4](https://github.com/dynamics365ninja/d365fo-mcp-server/security/code-scanning/4)

In general, to fix clear-text logging of data derived from `process.env`, avoid logging the raw environment values or strings directly derived from them, or else sanitize/redact before logging. In this case, the problematic information is the user-specific portion of `searchRoot` that comes from `USERPROFILE`. We can preserve the diagnostic usefulness by either (a) omitting user-specific paths from logs altogether, or (b) replacing them with a generic marker like `<UserProfile>` before logging.

The minimal, behavior-preserving change is in `src/utils/workspaceDetector.ts` where we log `searchRoot`. We can add a small helper to “sanitize” paths before logging by stripping or redacting `userProfile` if present, and then use that sanitized value in the log message. This keeps all workspace-detection behavior intact; only the log message content changes. No changes are needed in `src/index.ts` because `console.error` should continue to accept and forward arguments; we simply ensure the upstream caller no longer passes environment-derived paths in clear text.

Concretely:
- In `src/utils/workspaceDetector.ts`, after computing `userProfile` and `wellKnownPaths`, define a local `sanitizePathForLog` function or inline logic that, if `userProfile` is set and `searchRoot` starts with it, replaces the user-profile prefix with a placeholder like `<UserProfile>`.
- Update the log line at `console.error(\`[WorkspaceDetector] Found ${files.length} .rnrproj file(s) in ${searchRoot}\`);` to instead log `sanitizePathForLog(searchRoot)` (or the inlined redacted value).
- This requires no new imports or external dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
