### PR TITLE
fix: close read pool before EXCLUSIVE mode in build script

### DIFF
--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -45,6 +45,10 @@ async function buildDatabase() {
 
   // Optimize for bulk loading: use MEMORY journal during build
   console.log('⚡ Setting bulk load optimizations (MEMORY journal)...');
+  // Close read-pool connections first: SQLite cannot grant locking_mode = EXCLUSIVE
+  // while any other connection (even read-only, even in-process) holds a shared lock.
+  // The pool is only needed for concurrent production reads, not for build scripts.
+  symbolIndex.closeReadPool();
   symbolIndex.db.pragma('journal_mode = MEMORY'); // Fastest for bulk inserts
   symbolIndex.db.pragma('synchronous = OFF');     // Maximum speed (safe for build process)
   symbolIndex.db.pragma('locking_mode = EXCLUSIVE'); // No concurrent access needed during build

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -134,6 +134,24 @@ export class XppSymbolIndex {
   }
 
   /**
+   * Close and drain all read-pool connections.
+   * Must be called before setting locking_mode = EXCLUSIVE on the writer
+   * connection (e.g. in build scripts) — SQLite cannot grant EXCLUSIVE while
+   * any other connection (even read-only, even in-process) holds a shared lock.
+   */
+  closeReadPool(): void {
+    for (const conn of this.readPool) {
+      try { conn.close(); } catch { /* ignore */ }
+    }
+    this.readPool = [];
+    for (const conn of this.labelsReadPool) {
+      try { conn.close(); } catch { /* ignore */ }
+    }
+    this.labelsReadPool = [];
+    this.readPoolRR = 0;
+  }
+
+  /**
    * Get (or lazily prepare) a statement on a specific connection.
    * Uses the per-connection WeakMap cache so statements are never shared
    * across connections.


### PR DESCRIPTION
XppSymbolIndex constructor opens 3 read-only pool connections at startup. SQLite cannot grant locking_mode = EXCLUSIVE while any other connection (even in-process, read-only) holds a shared lock — resulting in SQLITE_BUSY at build-database.ts:48 during Azure Pipeline runs.

Fix: expose closeReadPool() which closes all readPool and labelsReadPool connections and resets the round-robin counter. build-database.ts calls it immediately before the bulk-load pragma block so the writer connection can successfully acquire EXCLUSIVE locking mode.