### PR TITLE
Potential fix for code scanning alert no. 7: Double escaping or unescaping

### DIFF
--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -15,6 +15,25 @@ import { getConfigManager } from '../utils/configManager.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 
 /**
+ * Decode the standard XML entities (&lt;, &gt;, &apos;, &quot;, &amp;) and normalise
+ * line endings by stripping xml2js's &#xD; representation of carriage return.
+ *
+ * IMPORTANT: &amp; is decoded LAST so that sequences like `&amp;quot;` are first
+ * turned into `&quot;` and can then, if desired, be decoded to `"`, avoiding
+ * incorrect double-unescaping.
+ */
+function decodeStandardXmlEntities(source: string): string {
+  return source
+    // xml2js Builder escapes \r as &#xD; — strip it to normalise to LF-only line endings
+    .replace(/&#xD;/g, '')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&');
+}
+
+/**
  * Decode XML entities from X++ source code.
  *
  * X++ source should never contain entity-encoded characters — `/// <summary>`
@@ -27,13 +46,7 @@ import { PackageResolver } from '../utils/packageResolver.js';
  * contains proper characters before it is stored in the XML object.
  */
 export function decodeXmlEntitiesFromXppSource(source: string): string {
-  return source
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
-    .replace(/&apos;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&#xD;/g, '');
+  return decodeStandardXmlEntities(source);
 }
 
 /**
@@ -56,14 +69,7 @@ export function rewrapXmlTagAsCdata(tag: string, xml: string): string {
         return _match;
       }
       // Decode XML entities introduced by the xml2js Builder
-      const decoded = innerRaw
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&amp;/g, '&')
-        .replace(/&apos;/g, "'")
-        .replace(/&quot;/g, '"')
-        // xml2js Builder escapes \r as &#xD; — strip it to normalise to LF-only line endings
-        .replace(/&#xD;/g, '');
+      const decoded = decodeStandardXmlEntities(innerRaw);
       // Normalise: strip leading/trailing newlines
       const content = decoded.replace(/^\n+/, '').replace(/\n+$/, '');
       // D365FO convention: <![CDATA[\n...content...\n\n]]>


### PR DESCRIPTION
Potential fix for [https://github.com/dynamics365ninja/d365fo-mcp-server/security/code-scanning/7](https://github.com/dynamics365ninja/d365fo-mcp-server/security/code-scanning/7)

In general, to fix double unescaping issues with entity decoders, you centralize the decoding logic in one function and ensure that the escape character (`&` for XML/HTML entities) is decoded last. That way, any sequences like `&amp;quot;` are first turned into `&quot;` and then, if desired, further decoded, instead of collapsing directly into `"`. You also avoid duplicating manual replacement chains across the codebase so they cannot drift or be applied in inconsistent order.

Concretely for this file, the best, minimal‑behavior change is:

1. Introduce a small internal helper `decodeStandardXmlEntities(s: string): string` that:
   - Removes `&#xD;` (to match existing behavior).
   - Replaces `&lt;` and `&gt;`.
   - Replaces `&apos;` and `&quot;`.
   - Replaces `&amp;` **last**.
2. Change `decodeXmlEntitiesFromXppSource` to simply call this helper and return its result. This keeps its external behavior but fixes the decode order.
3. Change `rewrapXmlTagAsCdata` to use the same helper instead of duplicating replacement calls. This ensures both places decode identically and safely, and also addresses the same CodeQL concern if it flags that block.

All edits are within `src/tools/modifyD365File.ts`, near the existing decoding code, and require no new imports or external libraries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
