### PR TITLE
fix: improve formatting of AxTableField XML elements for better reada…

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -561,7 +561,7 @@ ${methodsXml}\t</SourceCode>
         // Determine i:type: use explicit type if provided, otherwise derive from EDT name heuristics.
         // NEVER default to AxTableFieldString blindly when an EDT is present — EDT base type matters!
         const iType = fieldTypeToAxType(f.type || 'String', f.edt);
-        fieldsXml += `\t\t<AxTableField xmlns="" i:type="${iType}">\n`;
+        fieldsXml += `\t\t<AxTableField xmlns=""\n\t\t\ti:type="${iType}">\n`;
         fieldsXml += `\t\t\t<Name>${f.name}</Name>\n`;
         if (f.edt)       fieldsXml += `\t\t\t<ExtendedDataType>${f.edt}</ExtendedDataType>\n`;
         if (f.mandatory) fieldsXml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
@@ -1419,7 +1419,8 @@ ${defaultParamGroupXml}
    * Sanitize AxTable XML to ensure correct D365FO field element format.
    *
    * D365FO requires fields as:
-   *   <AxTableField xmlns="" i:type="AxTableFieldString"> ... </AxTableField>
+   *   <AxTableField xmlns=""
+   *     i:type="AxTableFieldString"> ... </AxTableField>
    *
    * AI generators often emit the shorter form:
    *   <AxTableFieldString> ... </AxTableFieldString>
@@ -1439,7 +1440,7 @@ ${defaultParamGroupXml}
       const openRe = new RegExp(`<${ft}(\\s[^>]*)?>`, 'g');
       xml = xml.replace(openRe, (_match, attrs: string | undefined) => {
         const extra = attrs ? attrs : '';
-        return `<AxTableField xmlns="" i:type="${ft}"${extra}>`;
+        return `<AxTableField xmlns=""\n\t\t\ti:type="${ft}"${extra}>`;
       });
       // Closing tag
       xml = xml.replace(new RegExp(`<\\/${ft}>`, 'g'), '</AxTableField>');


### PR DESCRIPTION
This pull request updates the XML formatting for `AxTableField` elements in the `src/tools/createD365File.ts` file to improve compatibility with D365FO requirements. The changes ensure that the `i:type` attribute is placed on a new line and indented, matching the expected format and clarifying the code for future maintenance.

XML formatting improvements:

* Updated the XML generation in `fieldsXml` so that the `i:type` attribute for `AxTableField` elements is placed on a new indented line, ensuring compliance with D365FO standards.
* Modified documentation and XML sanitization logic to reflect the new formatting, both in code comments and in the XML replacement logic. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL1422-R1423) [[2]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL1442-R1443)