### PR TITLE
fix: AI guardrails for obsolete methods, stale index, and hallucinate…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -199,7 +199,8 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 > `run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, and `run_systest_class` call the real D365FO CLI binaries (xppbp.exe, MSBuild, SyncEngine.exe).
 > - All parameters are **optional** — model name and packagePath are auto-detected from `.mcp.json`.
 > - If `run_bp_check` returns an error about a missing binary, it means `packagePath` in `.mcp.json` is wrong — fix the config, do NOT switch to PowerShell or `review_workspace_changes`.
-> - `review_workspace_changes` is for **git diff code review only** — it is NOT a substitute for BP check.
+> - `review_workspace_changes` is for **git diff code review only** — NOT a substitute for BP check, and NOT for verifying that `modify_d365fo_file` succeeded.
+> - After `modify_d365fo_file` or `create_d365fo_file`, always call `update_symbol_index(filePath)` first, then `get_class_info` or `get_method_source` to confirm the change landed. Never use `review_workspace_changes` as a verification step.
 
 > ### ⚠️ CRITICAL — `get_form_info` WORKS for ALL D365FO forms
 >
@@ -244,6 +245,10 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 19. **ALWAYS** write meaningful `/// <summary>` doc comments on every public/protected class and method — the text must describe what the code does, not just echo the name. `/// MyClass class.` or `/// run.` is NEVER acceptable (BPXmlDocNoDocumentationComments).
 20. **NEVER** pass `tableGroup="TempDB"` or `tableGroup="InMemory"` to `generate_smart_table` — `TempDB`/`InMemory` are **TableType** values, not **TableGroup** values. For a TempDB table use `tableType="TempDB"` and keep `tableGroup="Main"` (or another valid group). Valid `TableGroup` values (system enum TableGroup, source: MSDN): `Miscellaneous` (default for new tables) | `Main` | `Transaction` | `Parameter` | `Group` | `WorksheetHeader` | `WorksheetLine` | `Reference` | `Framework`.
 21. **NEVER** use PowerShell / `run_in_terminal` to run BP checks, builds, or DB sync — ALWAYS use `run_bp_check()`, `build_d365fo_project()`, `trigger_db_sync()`, `run_systest_class()`. All parameters (model, packagePath, projectPath) are **optional** and auto-detected from `.mcp.json`. If one of these tools returns an error about a missing binary or path, inform the user to fix `.mcp.json` — do NOT fall back to PowerShell. Do NOT use `review_workspace_changes` as a substitute for `run_bp_check` — they serve different purposes.
+22. **NEVER** call a method or API marked with `[SysObsolete]` (or `[Obsolete]` in C# interop). The attribute message almost always names the replacement — read it and use that replacement instead. If you encounter an obsolete symbol while reading existing code with `get_method_source` or in `analyze_code_patterns` output, verify the replacement before generating any call to it. Common examples:
+    - `today()` → `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
+    - `SysQuery::findOrCreateRange()` → `SysQuery::findOrCreateRange()` still valid but many helpers around it changed — check the attribute
+    - When `get_method_source` or `search` returns a method body containing `[SysObsolete(...)]` on it, do NOT generate calls to that method. Use the replacement stated in the attribute string.
 
 ### AxClass sourceCode Format — Member Variables in Declaration
 
@@ -327,6 +332,9 @@ When the user asks to **refactor**, **improve**, **clean up**, **optimize**, or 
                            → use for EACH method you intend to change
                            → returns the FULL source code (not just the signature)
                            → NEVER guess the body from the signature
+                           → ⚠️ ONLY call for methods you already saw listed in step 1.
+                              NEVER infer names from D365FO conventions (parm*, find, exist, …)
+                              — the method may not exist on this class.
 
 5. Find usages:            find_references("ClassName")  or  find_references("methodName")
                            → verify that renaming/changing a method won't break callers
@@ -609,7 +617,7 @@ c) Save to disk:                     create_d365fo_file(objectType="report", obj
 ### SDLC & Build Tools
 | Tool | Use for |
 |------|---------|
-| `update_symbol_index(filePath)` | Index a newly generated XML file immediately so that references to it work without restarting. |
+| `update_symbol_index(filePath)` | **Call after every `modify_d365fo_file` AND `create_d365fo_file`** so that `get_class_info`, `get_method_source`, and `search` return fresh results. Without this, the index is stale and lookups for newly-added methods will return ❌ not found. |
 | `build_d365fo_project(projectPath)` | Run MSBuild compilation locally to capture errors. |
 | `trigger_db_sync(modelName, tableName?)` | Run a database sync for the current model. |
 | `run_bp_check(projectPath, targetFilter?)` | Run Microsoft Best Practices (xppbp.exe) analysis. |
@@ -618,7 +626,7 @@ c) Save to disk:                     create_d365fo_file(objectType="report", obj
 ### Code Review & Source Control
 | Tool | Use for |
 |------|---------|
-| `review_workspace_changes(directoryPath)` | Analyzes uncommitted X++ changes locally and fetches a git diff to perform AI-based D365 Code Review. |
+| `review_workspace_changes(directoryPath)` | **Code review only** (git diff → BP check). ❌ NOT for verifying that a `modify_d365fo_file` call succeeded — use `update_symbol_index` + `get_class_info` for that. If the diff is truncated, do NOT use built-in tools to read more — they are forbidden on .xml/.xpp. |
 | `undo_last_modification(filePath)` | Safely checkout HEAD or delete specifically created untracked files when a code implementation was incorrectly generated. |
 
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1156,6 +1156,8 @@ Examples:
           name: 'get_method_source',
           description: `📄 Get the full X++ source code of a specific method. Use this when you need to understand the complete implementation — business logic, conditions, loops, error handling — not just the signature.
 
+⚠️ ONLY call this for methods you have already confirmed exist via \`get_class_info\`. Never guess or infer a method name from D365FO conventions (e.g. parm*, find, exist) — the method may not be defined in this class. If unsure, call \`get_class_info\` first and pick the method name from the returned list.
+
 Returns:
 - Complete method body as X++ code
 - Method signature
@@ -2418,7 +2420,7 @@ Examples:
       // ── Code Review & Source Control ─────────────────────────────────────────
       {
         name: 'review_workspace_changes',
-        description: 'Analyze uncommitted X++ changes in a local git repository (git diff HEAD) and perform an AI-based D365FO code review. Checks for BP violations, missing labels, CoC patterns, and other best practices.',
+        description: 'Analyze uncommitted X++ changes in a local git repository (git diff HEAD) and perform an AI-based D365FO code review. Checks for BP violations, missing labels, CoC patterns, and other best practices.\n\n⚠️ This tool is for CODE REVIEW ONLY — NOT for verifying that a modify_d365fo_file or create_d365fo_file call succeeded. For post-edit verification use verify_d365fo_project (disk + .rnrproj) and get_class_info / get_method_source after update_symbol_index.\n\n⚠️ The diff output may be large. If it appears truncated, do NOT use built-in file-reading tools (read_file, grep_search, get_file) to supplement it — those tools are forbidden on .xml/.xpp files. Instead, accept the visible portion and proceed or ask the user to narrow the scope.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/tools/getMethodSource.ts
+++ b/src/tools/getMethodSource.ts
@@ -32,10 +32,44 @@ export async function getMethodSourceTool(request: CallToolRequest, context: Xpp
     `).get(className, methodName) as { source: string | null; signature: string | null; model: string; file_path: string } | undefined;
 
     if (!row) {
+      // Find similarly-named methods on the same class to help the caller self-correct
+      const candidates = symbolIndex.db.prepare(`
+        SELECT name, signature
+        FROM symbols
+        WHERE type = 'method'
+          AND parent_name = ?
+          AND name LIKE ?
+        ORDER BY name
+        LIMIT 10
+      `).all(className, `%${methodName.replace(/^parm/i, '')}%`) as Array<{ name: string; signature: string | null }>;
+
+      let hint = '';
+      if (candidates.length > 0) {
+        hint = '\n\n**Similar methods on this class:**\n' +
+          candidates.map(c => `- \`${c.signature || c.name}\``).join('\n');
+      } else {
+        // Broader fallback: list parm* methods if the caller was looking for a parm method
+        if (/^parm/i.test(methodName)) {
+          const parmMethods = symbolIndex.db.prepare(`
+            SELECT name, signature
+            FROM symbols
+            WHERE type = 'method'
+              AND parent_name = ?
+              AND name LIKE 'parm%'
+            ORDER BY name
+            LIMIT 15
+          `).all(className) as Array<{ name: string; signature: string | null }>;
+          if (parmMethods.length > 0) {
+            hint = '\n\n**Available parm* methods on this class:**\n' +
+              parmMethods.map(c => `- \`${c.signature || c.name}\``).join('\n');
+          }
+        }
+      }
+
       return {
         content: [{
           type: 'text',
-          text: `❌ Method **${className}.${methodName}** not found in the index.\n\nMake sure the class name and method name are correct. Use \`search\` or \`get_class_info\` to discover available methods.`,
+          text: `❌ Method **${className}.${methodName}** not found in the index.${hint}\n\nUse \`get_class_info\` to see all available methods.`,
         }],
         isError: true,
       };
@@ -58,11 +92,19 @@ export async function getMethodSourceTool(request: CallToolRequest, context: Xpp
       };
     }
 
+    // Detect [SysObsolete] / [Obsolete] on the method itself
+    const obsoleteMatch = source.match(/\[\s*SysObsolete\s*\(\s*['"]([^'"]*)['"]/i)
+      ?? source.match(/\[\s*Obsolete\s*\(\s*['"]([^'"]*)['"]/i);
+    const obsoleteWarning = obsoleteMatch
+      ? `\n\n> ⚠️ **This method is marked obsolete.** Do NOT generate calls to it.\n> Replacement hint from the attribute: _"${obsoleteMatch[1]}"_\n> Read the hint above and use the stated replacement instead.`
+      : '';
+
     const output = [
       `## ${className}.${methodName}`,
       '',
       row.signature ? `**Signature:** \`${row.signature}\`` : '',
       `**Model:** ${row.model}`,
+      obsoleteWarning,
       '',
       '```xpp',
       source,

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -103,23 +103,31 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
 
     if (extractedMethod) {
       const jsonSignature = buildSignatureFromExtractedMethod(extractedMethod);
-      const result = formatOutput(className, methodName, jsonSignature, classRow.model, includeCoc);
+      const obsoleteWarning = detectObsolete(extractedMethod.source ?? '');
+      const result = formatOutput(className, methodName, jsonSignature, classRow.model, includeCoc, obsoleteWarning);
       await cache.setClassInfo(cacheKey, result);
       return result;
     }
 
     // 3b. SECONDARY: XML file (only works when running on D365FO VM with correct paths)
     let methodSignature: MethodSignature | null = null;
+    let xmlSource = '';
     try {
       const xmlContent = await fs.readFile(classRow.file_path, 'utf-8');
       const xmlObj = await parseStringPromise(xmlContent);
       methodSignature = extractMethodSignature(xmlObj, methodName);
+      // Grab raw source for obsolete detection
+      const axClass = xmlObj?.AxClass;
+      const methods = axClass?.Methods?.[0]?.Method ?? [];
+      const mNode = methods.find((m: any) => m.Name?.[0] === methodName);
+      xmlSource = mNode?.Source?.[0] ?? '';
     } catch {
       // File not accessible (build-agent path) — fall through to DB fallback
     }
 
     if (methodSignature) {
-      const result = formatOutput(className, methodName, methodSignature, classRow.model, includeCoc);
+      const obsoleteWarning = detectObsolete(xmlSource);
+      const result = formatOutput(className, methodName, methodSignature, classRow.model, includeCoc, obsoleteWarning);
       await cache.setClassInfo(cacheKey, result);
       return result;
     }
@@ -429,16 +437,31 @@ function buildFallbackSignature(methodRow: any): MethodSignature {
 /**
  * Format output
  */
+/**
+ * Detect [SysObsolete] or [Obsolete] attribute in X++ source and return a warning string.
+ * Returns an empty string when no obsolete marker is found.
+ */
+function detectObsolete(source: string): string {
+  const m = source.match(/\[\s*SysObsolete\s*\(\s*['"]([^'"]*)['"]|\[\s*Obsolete\s*\(\s*['"]([^'"]*)['"]/i);
+  if (!m) return '';
+  const msg = m[1] ?? m[2] ?? '';
+  return `\n> ⚠️ **This method is marked obsolete. Do NOT generate calls to it.**${
+    msg ? `\n> Replacement hint: _"${msg}"_` : ''
+  }\n> Use the stated replacement instead.`;
+}
+
 function formatOutput(
   className: string,
   methodName: string,
   signature: MethodSignature,
   modelName: string,
-  includeCocTemplate: boolean = false
+  includeCocTemplate: boolean = false,
+  obsoleteWarning: string = ''
 ): any {
   let output = `# Method: \`${className}.${methodName}\`\n`;
-  output += `**Model:** ${modelName}  **Returns:** ${signature.returnType}  **Modifiers:** ${signature.modifiers.join(', ') || 'none'}\n\n`;
-  output += `\`\`\`xpp\n${signature.signature}\n\`\`\`\n`;
+  output += `**Model:** ${modelName}  **Returns:** ${signature.returnType}  **Modifiers:** ${signature.modifiers.join(', ') || 'none'}\n`;
+  if (obsoleteWarning) output += obsoleteWarning + '\n';
+  output += `\n\`\`\`xpp\n${signature.signature}\n\`\`\`\n`;
 
   if (signature.parameters.length > 0) {
     output += `\n**Parameters:** ${signature.parameters.map(p => `${p.type} ${p.name}${p.defaultValue ? ` = ${p.defaultValue}` : ''}`).join(', ')}\n`;


### PR DESCRIPTION
…d method names

- get_method_source: when method not found, return similar/parm* methods from DB so AI can self-correct without extra get_class_info round-trip
- get_method_source: detect [SysObsolete]/[Obsolete] in returned source and emit a blocking warning with the replacement hint from the attribute string
- get_method_signature: same obsolete detection across all three resolution paths (JSON metadata, XML file, DB fallback); warning shown before CoC template
- mcpServer.ts: update_symbol_index description now explicitly says 'call after modify_d365fo_file AND create_d365fo_file'
- mcpServer.ts: review_workspace_changes description warns it is NOT for post-edit verification and forbids built-in tools on truncated diffs
- mcpServer.ts: get_method_source description warns to only call for methods confirmed via get_class_info first
- copilot-instructions.md: refactoring workflow step 4 warns against inferring parm*/find/exist method names that may not exist on the class
- copilot-instructions.md: SDLC box adds post-edit verification rule (update_symbol_index -> get_class_info, never review_workspace_changes)
- copilot-instructions.md: tools table - update_symbol_index marked as mandatory after every modify/create; review_workspace_changes marked NOT for verification
- copilot-instructions.md: rule 22 - never call [SysObsolete] methods; read attribute message for replacement