### PR TITLE
fix: add fallback instructions and prevent duplicate field groups in …

### DIFF
--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -127,6 +127,31 @@ Use this guide to select the correct tool:
 
 **Why:** D365FO metadata is in SQL database, not workspace files. Built-in tools scan 350+ models causing hangs. MCP tools use indexed queries (<100ms).
 
+### 6. NEVER Use Scripts as Fallback — and NEVER Read-then-Write
+**When an MCP tool is unavailable or returns an error, NEVER:**
+- ❌ Write or run PowerShell scripts (.ps1) to modify D365FO XML files — they hang indefinitely in VS 2022
+- ❌ Write or run Python scripts to patch XML — same issue, no result
+- ❌ Use \`run_in_terminal\`, \`execute_command\`, or any shell execution to write files
+- ❌ Generate \`Set-Content\`, \`Out-File\`, \`[System.IO.File]::WriteAllText\` or similar file-write commands
+
+**Critical anti-pattern — NEVER do this:**
+\`\`\`
+// ❌ WRONG — read_file succeeds (file exists on disk), but there is no write_file tool in VS 2022
+read_file(path)          // reads XML for "context"
+→ manually construct XML edit in memory
+→ generate PowerShell Set-Content script to write it back
+→ script hangs forever, no output, infinite spinner
+\`\`\`
+This pattern looks reasonable but **always fails** in VS 2022 because \`read_file\` exists but \`write_file\`/\`edit_file\` do not. The only way to write D365FO XML is \`modify_d365fo_file\`.
+
+**Instead, when a tool cannot complete the operation:**
+1. Report the exact error to the user (e.g. "Field group X already exists")
+2. Suggest the correct MCP tool to use next (e.g. \`add-field-to-field-group\`)
+3. **Skip the step entirely** — never attempt a workaround via scripts or shell commands
+4. If no MCP tool exists for the operation, tell the user to perform it manually in Visual Studio AOT
+
+**Why:** Visual Studio 2022 MCP integration does not allow interactive terminal sessions. Any spawned PowerShell/Python process will hang waiting for stdin or permissions, causing an infinite spinner with no output.
+
 ## Workflow Examples
 
 ### Creating a New Class

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -2049,6 +2049,14 @@ async function addFieldGroup(xmlObj: any, objectType: string, args: any): Promis
 
   const container = ensureArrayContainer(root, 'FieldGroups', 'AxTableFieldGroup');
 
+  // Check for duplicate — field group with this name already exists
+  const existing = container.AxTableFieldGroup.find(
+    (fg: any) => (Array.isArray(fg.Name) ? fg.Name[0] : fg.Name) === fieldGroupName
+  );
+  if (existing) {
+    throw new Error(`Field group "${fieldGroupName}" already exists in this ${objectType}. Use add-field-to-field-group to add fields to it.`);
+  }
+
   const fgFieldNodes = ((fieldGroupFields || []) as string[]).map((f: string) => ({ DataField: [f] }));
 
   const newFg: any = {


### PR DESCRIPTION
This pull request adds important safeguards and error handling to prevent problematic file modification patterns in D365FO development, and improves user guidance when MCP tools are unavailable or encounter errors.

Guidance and anti-pattern prevention:

* Updated `src/prompts/systemInstructions.ts` to explicitly prohibit using scripts (PowerShell, Python) or shell commands as fallback methods for modifying D365FO XML files. It explains why these approaches always fail in Visual Studio 2022 and outlines the correct error reporting and user guidance steps when MCP tools cannot complete an operation.

Error handling for duplicate field groups:

* Added a check in `src/tools/modifyD365File.ts` to prevent creating a duplicate field group. If a field group with the same name already exists, the tool now throws a clear error and suggests using `add-field-to-field-group` instead.