### PR TITLE
fix: register get_xpp_knowledge in ListToolsRequestSchema

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -2440,6 +2440,34 @@ Examples:
           required: ['filePath'],
         },
       },
+      {
+        name: 'get_xpp_knowledge',
+        description:
+          'Queryable knowledge base of D365FO X++ patterns, best practices, and AX2012→D365FO migration guidance. ' +
+          'Returns distilled, verified patterns with code examples. Use BEFORE generating code to avoid deprecated ' +
+          'APIs and AX2012 anti-patterns. Topics: batch jobs, transactions, queries, CoC/extensions, security, ' +
+          'data entities, temp tables, number sequences, form patterns, set-based operations, error handling, ' +
+          'SysOperation framework, and more.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            topic: {
+              type: 'string',
+              description:
+                'Topic to query — e.g. "batch job", "ttsbegin", "RunBase vs SysOperation", ' +
+                '"set-based operations", "CoC", "data entities", "number sequences", "security", ' +
+                '"temp tables", "today() deprecated", "query patterns", "form patterns"',
+            },
+            format: {
+              type: 'string',
+              enum: ['concise', 'detailed'],
+              default: 'concise',
+              description: 'concise = quick reference (default), detailed = full explanation with code examples',
+            },
+          },
+          required: ['topic'],
+        },
+      },
     ],
     };
 


### PR DESCRIPTION
This pull request adds a new API endpoint to the `src/server/mcpServer.ts` file, expanding the server's capabilities with a specialized knowledge base for D365FO X++ patterns and migration guidance. This endpoint is designed to help developers avoid deprecated APIs and anti-patterns by providing distilled, verified information.

New API endpoint for X++ knowledge:

* Added `get_xpp_knowledge` endpoint to the `Examples:` array, enabling queries about D365FO X++ patterns, best practices, and AX2012→D365FO migration guidance, with options for concise or detailed responses.