### PR TITLE
Add extension strategy advisor tool and corresponding tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -308,6 +308,7 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 | How does X work? | `get_class_info` / `get_table_info` / `get_form_info` / `get_report_info` |
 | How to implement X? (pattern) | `get_xpp_knowledge("batch job")` → `analyze_code_patterns` |
 | What can I extend on X? | `analyze_extension_points(objectName)` |
+| Which extension mechanism to use? | `recommend_extension_strategy(goal, objectName?)` |
 | Who already extends method X via CoC? | `find_coc_extensions(className, methodName)` |
 | Who handles events for table X? | `find_event_handlers(targetTable)` |
 | What fields/methods did extensions add to table X? | `get_table_extension_info(tableName)` |
@@ -317,6 +318,12 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 | Create SSRS report | `generate_smart_report` or `generate_code(pattern="ssrs-report-full")` → See **SSRS Report Workflow** section below |
 | Create CoC extension | See **CoC / Extension Workflows** section below |
 | Create workspace form | `generate_smart_form(name, formPattern="Workspace")` |
+| Create business event | `generate_code(pattern="business-event", name="MyEvent")` → creates BusinessEventsBase + contract |
+| Create custom service | `generate_code(pattern="custom-service", name="MyService")` → Service + contracts + group |
+| Create feature toggle | `generate_code(pattern="feature-class", name="MyFeature")` → FeatureClassAttribute class |
+| Add telemetry | `generate_code(pattern="custom-telemetry", name="MyModule")` → Application Insights signals |
+| Create ER function | `generate_code(pattern="er-custom-function", name="MyFunctions")` → ER formula provider |
+| Create composite entity | `generate_code(pattern="composite-entity", name="MyOrder")` → header + line DMF entity |
 | Diagnose X++ error | `get_d365fo_error_help(errorText, errorCode?)` |
 | What is the exact tab/group/control name in form X? | `get_form_info(formName, searchControl="General")` |
 ## Critical Rules
@@ -398,7 +405,7 @@ For any D365FO request, **start with MCP tools — never** `code_search`, `grep_
 21. **NEVER** use PowerShell / `run_in_terminal` to run BP checks, builds, or DB sync — ALWAYS use `run_bp_check()`, `build_d365fo_project()`, `trigger_db_sync()`, `run_systest_class()`. All parameters (model, packagePath, projectPath) are **optional** and auto-detected from `.mcp.json`. If one of these tools returns an error about a missing binary or path, inform the user to fix `.mcp.json` — do NOT fall back to PowerShell. Do NOT use `review_workspace_changes` as a substitute for `run_bp_check` — they serve different purposes.
 22. **ALWAYS** call `get_d365fo_error_help(errorText, errorCode?)` when the user pastes a D365FO compiler or runtime error. Do NOT guess the fix — X++ error semantics often differ from C# and the tool provides verified step-by-step fixes.
 23. **When creating a CoC class extension file** use `create_d365fo_file(objectType="class-extension", objectName="{TargetClass}{Prefix}_Extension", ...)` — this generates the correct `[ExtensionOf(classStr(...))]` + `final class` skeleton in the AxClass XML.
-24. **Available `generate_code` patterns** include: `batch-job`, `sysoperation`, `table-extension`, `class-extension`, `event-handler`, `security-privilege`, `menu-item`, `data-entity`, `ssrs-report-full` (generates DataContract + DP + Controller), `lookup-form` (SysTableLookup static method), `form-handler` (`[ExtensionOf(formStr(...))]` — pass `name`=FormName), `form-datasource-extension` (`[ExtensionOf(formDataSourceStr(Form, DS))]` — pass `name`=FormName + `baseName`=DataSourceName), `form-control-extension` (`[ExtensionOf(formControlStr(Form, Control))]` — pass `name`=FormName + `baseName`=ControlName; use `get_form_info` to find the exact control name first), `map-extension` (`[ExtensionOf(mapStr(...))]`), `dialog-box`, `dimension-controller`, `number-seq-handler`, `display-menu-controller`, `data-entity-staging`, `service-class-ais`.
+24. **Available `generate_code` patterns** include: `batch-job`, `sysoperation`, `table-extension`, `class-extension`, `event-handler`, `security-privilege`, `menu-item`, `data-entity`, `ssrs-report-full` (generates DataContract + DP + Controller), `lookup-form` (SysTableLookup static method), `form-handler` (`[ExtensionOf(formStr(...))]` — pass `name`=FormName), `form-datasource-extension` (`[ExtensionOf(formDataSourceStr(Form, DS))]` — pass `name`=FormName + `baseName`=DataSourceName), `form-control-extension` (`[ExtensionOf(formControlStr(Form, Control))]` — pass `name`=FormName + `baseName`=ControlName; use `get_form_info` to find the exact control name first), `map-extension` (`[ExtensionOf(mapStr(...))]`), `dialog-box`, `dimension-controller`, `number-seq-handler`, `display-menu-controller`, `data-entity-staging`, `service-class-ais`, `business-event` (BusinessEventsBase subclass + contract — triggers for Power Automate / Service Bus), `custom-telemetry` (Application Insights custom event/metric emission via SysApplicationInsightsEventLogger), `feature-class` (FeatureClassAttribute class for Feature Management workspace), `composite-entity` (header + line composite data entity for DMF), `custom-service` (Service class + Service Group + request/response contracts), `er-custom-function` (ERExpressionCustomFunctionProvider for ER formula designer).
 25. **Available `generate_smart_form` patterns** include: `SimpleList`, `SimpleListDetails`, `DetailsMaster`, `DetailsTransaction`, `Dialog`, `TableOfContents`, `Lookup`, `ListPage`, `Workspace` (operational workspace with panorama sections and KPI tile area).
 26. **NEVER** call a method or API marked with `[SysObsolete]` (or `[Obsolete]` in C# interop). The attribute message almost always names the replacement — read it and use that replacement instead. If you encounter an obsolete symbol while reading existing code with `get_method_source` or in `analyze_code_patterns` output, verify the replacement before generating any call to it. Common examples:
     - `today()` → `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
@@ -743,6 +750,7 @@ c) Save to disk:                     create_d365fo_file(objectType="report", obj
 | Tool | Use for |
 |------|---------|
 | `analyze_extension_points(objectName, showExistingExtensions?)` | What CoC methods, delegates, and data events does an object expose? Start here before any extension work |
+| `recommend_extension_strategy(goal, objectName?, scenario?)` | Which extensibility mechanism is correct for a given scenario? Prevents wrong choices (CoC vs event vs Business Event vs data entity) |
 | `get_table_extension_info(tableName)` | All extensions of a table across all models: added fields, indexes, methods |
 | `find_coc_extensions(className, methodName?)` | Which extension classes use CoC to wrap a given class/method? |
 | `find_event_handlers(targetTable)` | All `[SubscribesTo]` event handler methods for a table or class |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**53 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
+**54 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
@@ -20,7 +20,7 @@ GitHub Copilot excels at C#, Python, and JavaScript — languages with rich publ
 
 The result is AI that confidently generates code that doesn't compile: wrong method signatures, missing parameters, fields that don't exist on the table, CoC chains broken because Copilot didn't know an extension already wrapped the method.
 
-This MCP server solves that by pre-indexing your entire D365FO installation — 584,799+ symbols across standard and custom models — and exposing it to Copilot as 53 specialized tools. Before generating any X++ code, Copilot can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
+This MCP server solves that by pre-indexing your entire D365FO installation — 584,799+ symbols across standard and custom models — and exposing it to Copilot as 54 specialized tools. Before generating any X++ code, Copilot can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
 
 ![Solution Architecture](docs/img/solution-architecture-diagram.png)
 
@@ -138,7 +138,7 @@ Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.m
 |------|---------|
 | [docs/SETUP.md](docs/SETUP.md) | Installation, configuration, Azure deployment |
 | [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md) | `.mcp.json` reference — workspace paths, UDE, project settings |
-| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 53 tools with parameters and example prompts |
+| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 54 tools with parameters and example prompts |
 | [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md) | Practical examples: search, CoC, SysOperation, security |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Technical architecture, dual-database design |
 | [docs/CUSTOM_EXTENSIONS.md](docs/CUSTOM_EXTENSIONS.md) | ISV / custom model configuration |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ graph TB
     subgraph "MCP Server Components"
         HTTP[HTTP Transport Layer - Express + Rate Limiting]
         PROTO[MCP Protocol Handler - JSON-RPC 2.0]
-        TOOLS[Tool Handlers - 53 MCP Tools]
+        TOOLS[Tool Handlers - 54 MCP Tools]
         DB[(Symbols Database - FTS5, 584K+ symbols)]
         LDB[(Labels Database - FTS5, 19M+ labels, 70 languages)]
         CACHE[Redis Cache - Optional]
@@ -82,7 +82,7 @@ sequenceDiagram
     alt Initialize
         MCP-->>IDE: Server Capabilities
     else Tools List
-        MCP-->>IDE: 53 Tool Definitions
+        MCP-->>IDE: 54 Tool Definitions
     else Tool Call
         MCP->>Handler: Route to Handler
         Handler->>Tool: Execute Tool
@@ -142,6 +142,7 @@ graph LR
             EVTHDL[findEventHandlers.ts - find_event_handlers]
             TBLEXT[tableExtensionInfo.ts - get_table_extension_info]
             EXTPTS[analyzeExtensionPoints.ts - analyze_extension_points]
+            EXTSTRAT[extensionStrategyAdvisor.ts - recommend_extension_strategy]
             SECART[securityArtifactInfo.ts - get_security_artifact_info]
             SECCOV[securityCoverageInfo.ts - get_security_coverage_for_object]
             MENU[menuItemInfo.ts - get_menu_item_info]
@@ -585,7 +586,7 @@ graph LR
     subgraph "MCP Protocol Methods"
         INIT[initialize - Server Capabilities]
         NOTIFY[notifications/initialized - Handshake Complete]
-        TOOLS_LIST[tools/list - 51 Available Tools]
+        TOOLS_LIST[tools/list - 54 Available Tools]
         TOOLS_CALL[tools/call - Execute Tool]
         RES_LIST[resources/list - Empty]
         RES_TMPL[resources/templates/list - Empty]
@@ -594,7 +595,7 @@ graph LR
     end
 
     INIT -.-> CAPS[Capabilities: tools, resources, prompts]
-    TOOLS_LIST -.-> TOOL_DEFS["52 tools: search, batch_search, search_extensions, get_class_info, get_table_info, code_completion, get_method_signature, get_method_source, find_references, get_form_info, get_query_info, get_view_info, get_enum_info, get_edt_info, get_report_info, generate_code, analyze_code_patterns, suggest_method_implementation, analyze_class_completeness, get_api_usage_patterns, get_xpp_knowledge, generate_d365fo_xml, create_d365fo_file, modify_d365fo_file, search_labels, get_label_info, create_label, rename_label, get_table_patterns, get_form_patterns, generate_smart_table, generate_smart_form, generate_smart_report, suggest_edt, get_security_artifact_info, get_security_coverage_for_object, get_menu_item_info, find_coc_extensions, find_event_handlers, get_table_extension_info, get_data_entity_info, analyze_extension_points, validate_object_naming, get_workspace_info, verify_d365fo_project"]
+    TOOLS_LIST -.-> TOOL_DEFS["54 tools: search, batch_search, search_extensions, get_class_info, get_table_info, code_completion, get_method_signature, get_method_source, find_references, get_form_info, get_query_info, get_view_info, get_enum_info, get_edt_info, get_report_info, generate_code, analyze_code_patterns, suggest_method_implementation, analyze_class_completeness, get_api_usage_patterns, get_xpp_knowledge, get_d365fo_error_help, generate_d365fo_xml, create_d365fo_file, modify_d365fo_file, search_labels, get_label_info, create_label, rename_label, get_table_patterns, get_form_patterns, generate_smart_table, generate_smart_form, generate_smart_report, suggest_edt, get_security_artifact_info, get_security_coverage_for_object, get_menu_item_info, find_coc_extensions, find_event_handlers, get_table_extension_info, get_data_entity_info, analyze_extension_points, recommend_extension_strategy, validate_object_naming, get_workspace_info, verify_d365fo_project, update_symbol_index, build_d365fo_project, trigger_db_sync, run_bp_check, run_systest_class, review_workspace_changes, undo_last_modification"]
     TOOLS_CALL -.-> EXEC[Tool Execution: search DB, parse XML, return results]
     style INIT fill:#4CAF50,color:#fff
     style TOOLS_CALL fill:#2196F3,color:#fff

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -294,7 +294,7 @@ GitHub Copilot connects to both servers at the same time and selects the right o
 
 1. `d365fo-azure` starts with `MCP_SERVER_MODE=read-only` → only exposes search/analysis tools
 2. `d365fo-local` starts with `MCP_SERVER_MODE=write-only` → only exposes file-operation tools
-3. GitHub Copilot aggregates both tool lists — from Copilot's perspective it sees all 53 tools
+3. GitHub Copilot aggregates both tool lists — from Copilot's perspective it sees all 54 tools
 4. When Copilot calls `create_d365fo_file`, it goes to the local server which has K:\ access
 5. When Copilot calls `search`, it goes to the Azure server with the full metadata database
 
@@ -305,22 +305,22 @@ When the server starts, it logs the detected mode and tool count:
 **Write-only mode (local companion):**
 ```
 🔧 Server mode: write-only (from env: write-only)
-🎯 Registered 6 X++ MCP tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label, verify_d365fo_project, get_workspace_info)
-[MCP Server] Tool list filtered for write-only mode: 6 tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label, verify_d365fo_project, get_workspace_info)
+🎯 Registered 13 X++ MCP tools (create_d365fo_file, modify_d365fo_file, create_label, rename_label, verify_d365fo_project, update_symbol_index, build_d365fo_project, trigger_db_sync, run_bp_check, run_systest_class, review_workspace_changes, undo_last_modification, get_workspace_info)
+[MCP Server] Tool list filtered for write-only mode: 13 tools
 ```
 
 **Read-only mode (Azure server):**
 ```
 🔧 Server mode: read-only (from env: read-only)
-🎯 Registered 38 X++ MCP tools (all except local tools)
-[MCP Server] Tool list filtered for read-only mode: 38 tools (local tools excluded)
+🎯 Registered 41 X++ MCP tools (all except local tools)
+[MCP Server] Tool list filtered for read-only mode: 41 tools (local tools excluded)
 ```
 
 **Full mode (local development):**
 ```
 🔧 Server mode: full (from env: not set, defaulting to full)
-🎯 Registered 53 X++ MCP tools (full mode)
-[MCP Server] Tool list in full mode: 53 tools (no filtering)
+🎯 Registered 54 X++ MCP tools (full mode)
+[MCP Server] Tool list in full mode: 54 tools (no filtering)
 ```
 
 > **Note:** The local server in `write-only` mode skips database download and the symbol

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,7 +1,7 @@
 # All Available Tools
 
 When you ask GitHub Copilot a question about D365FO code, it automatically calls one of these
-53 tools to look up the answer or generate code. You do not need to name the tools yourself —
+54 tools to look up the answer or generate code. You do not need to name the tools yourself —
 just ask in plain English.
 
 ---
@@ -44,7 +44,7 @@ just ask in plain English.
 | **get_method_source** | Full X++ source code of a method | "Show me the full implementation of SalesTable.validateWrite()" |
 | **find_references** | Where is this class/method/field used? | "Where is DimensionAttributeValueSet used?" |
 
-### Intelligent Code Generation (5 tools)
+### Intelligent Code Generation (6 tools)
 
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|
@@ -100,7 +100,7 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 | **modify_d365fo_file** | Local Windows VM only | Safely edits an existing file with automatic backup |
 | **verify_d365fo_project** | Local Windows VM only | Reads `.rnrproj` on K:\ to verify objects exist on disk and are referenced in the project file |
 
-### Security & Extensions (9 tools)
+### Security & Extensions (10 tools)
 
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|
@@ -112,6 +112,7 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 | **get_table_extension_info** | All extensions of a table: added fields, indexes, methods | "What fields did ISV packages add to CustTable?" |
 | **get_data_entity_info** | Data entity category, OData name, data sources, keys | "Show me CustCustomerV3Entity details" |
 | **analyze_extension_points** | CoC-eligible methods, delegates, events — what can be extended | "What can I extend on SalesLine?" |
+| **recommend_extension_strategy** | Recommends the best extensibility mechanism for a scenario — prevents wrong choices (CoC vs event vs Business Event vs data entity) | "Should I use CoC or Business Event to notify an external system?" |
 | **validate_object_naming** | Validate proposed extension/object names against D365FO conventions | "Is SalesTableExtension a valid extension class name?" |
 
 ### Label Management (4 tools)

--- a/src/index.ts
+++ b/src/index.ts
@@ -569,13 +569,13 @@ async function main() {
     });
 
     // Log tool count immediately (transport is already connected)
-    const totalTools = 51;
+    const totalTools = 54;
     const localToolCount = LOCAL_TOOLS.size;
     const toolCount = SERVER_MODE === 'write-only' ? localToolCount :
                      SERVER_MODE === 'read-only' ? totalTools - localToolCount : totalTools;
     const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(LOCAL_TOOLS).join(', ')})` :
                     SERVER_MODE === 'read-only' ? '(all except local tools)' :
-                    '(8 discovery + 4 labels + 7 object-info + 4 intelligent + 4 smart-gen + 3 file-ops + 3 pattern-analysis + 11 security-ext + 5 sdlc-build + 2 code-review)';
+                    '(8 discovery + 7 object-info + 6 intelligent + 4 smart-gen + 3 pattern-analysis + 10 security-ext + 4 file-ops + 7 sdlc-build + 4 labels + 1 workspace)';
     console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
@@ -695,6 +695,7 @@ async function main() {
           { name: 'get_table_extension_info',     desc: 'All extensions of a table: added fields, indexes, methods' },
           { name: 'get_data_entity_info',         desc: 'Data entity: category, OData settings, data sources, keys' },
           { name: 'analyze_extension_points',     desc: 'CoC-eligible methods, delegates, events — what can be extended?' },
+          { name: 'recommend_extension_strategy',  desc: 'Recommends the best extensibility mechanism for a given scenario' },
           { name: 'validate_object_naming',       desc: 'Validate proposed extensions and object names against D365FO conventions' },
           { name: 'get_workspace_info',           desc: 'Detected workspace paths, model name, project file, and server mode' },
           { name: 'verify_d365fo_project',        desc: 'Verify objects exist on disk and are referenced in the .rnrproj project file' },

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -80,12 +80,19 @@ Use this guide to select the correct tool:
 | "Learn patterns for X" | \`analyze_code_patterns(scenario)\` | Always first |
 | "How to implement method" | \`suggest_method_implementation(className, methodName)\` | After get_method_signature |
 | "Where is X used" | \`find_references(targetName, targetType?)\` | For refactoring |
+| "Which extension mechanism?" | \`recommend_extension_strategy(goal, objectName?)\` | Use BEFORE any extension work |
 | "Why does this error occur" | \`get_d365fo_error_help(errorText, errorCode?)\` | None |
 | "Explain this X++ error" | \`get_d365fo_error_help(errorText)\` | None |
 | "Create CoC class extension" | \`create_d365fo_file(objectType="class-extension", ...)\` | find_coc_extensions |
 | "Create SSRS report" | \`generate_code(pattern="ssrs-report-full", name)\` | analyze_code_patterns |
 | "Create lookup form/method" | \`generate_code(pattern="lookup-form", name)\` | None |
 | "Create workspace form" | \`generate_smart_form(name, formPattern="Workspace")\` | None |
+| "Create business event" | \`generate_code(pattern="business-event", name)\` | None |
+| "Create custom service" | \`generate_code(pattern="custom-service", name)\` | None |
+| "Create feature toggle" | \`generate_code(pattern="feature-class", name)\` | None |
+| "Add telemetry" | \`generate_code(pattern="custom-telemetry", name)\` | None |
+| "Create ER function" | \`generate_code(pattern="er-custom-function", name)\` | None |
+| "Create composite entity" | \`generate_code(pattern="composite-entity", name)\` | None |
 
 ## Critical Rules
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -2293,6 +2293,45 @@ Examples:
         },
       },
       {
+        name: 'recommend_extension_strategy',
+        description: `Recommends the best D365FO extensibility mechanism for a given scenario.
+
+Prevents common design mistakes — e.g. using CoC where a Business Event or delegate is appropriate,
+or using a Business Event for inbound data where a Data Entity is correct.
+
+Returns: recommended mechanism, reasoning, risks/caveats, alternatives, anti-patterns, and next MCP tool calls.
+
+Use BEFORE writing any extension code to ensure the right approach.
+
+Examples:
+  { goal: "validate that SalesLine quantity is positive", objectName: "SalesLine" }
+  { goal: "send order confirmation to external ERP" }
+  { goal: "add custom field to CustTable form", objectName: "CustTable" }
+  { goal: "import vendor data from CSV", scenario: "inbound-data" }`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            goal: {
+              type: 'string',
+              description: 'What you want to achieve — e.g. "validate that SalesLine quantity is positive"',
+            },
+            objectName: {
+              type: 'string',
+              description: 'Target D365FO object if known — e.g. "SalesTable", "CustTable"',
+            },
+            scenario: {
+              type: 'string',
+              enum: ['data-validation', 'field-defaulting', 'business-logic-change',
+                     'outbound-integration', 'inbound-data', 'ui-modification',
+                     'document-output', 'number-sequence', 'security-access',
+                     'batch-processing', 'custom'],
+              description: 'Scenario category (auto-detected from goal if omitted)',
+            },
+          },
+          required: ['goal'],
+        },
+      },
+      {
         name: 'validate_object_naming',
         description: `Validate a proposed D365FO object name against naming conventions.
 

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -15,7 +15,9 @@ const CodeGenArgsSchema = z.object({
            'ssrs-report-full', 'lookup-form',
            'dialog-box', 'dimension-controller', 'number-seq-handler',
            'display-menu-controller', 'data-entity-staging', 'service-class-ais',
-           'form-datasource-extension', 'form-control-extension', 'map-extension'])
+           'form-datasource-extension', 'form-control-extension', 'map-extension',
+           'business-event', 'custom-telemetry', 'feature-class',
+           'composite-entity', 'custom-service', 'er-custom-function'])
     .describe('Code pattern to generate'),
   name: z.string().describe(
     'For NEW objects (class, runnable, data-entity, batch-job, sysoperation): the object name WITHOUT prefix — prefix is auto-applied from EXTENSION_PREFIX env var or modelName. ' +
@@ -176,6 +178,12 @@ class ${name}Service extends SysOperationServiceBase
   'display-menu-controller': displayMenuControllerTemplate,
   'data-entity-staging': dataEntityStagingTemplate,
   'service-class-ais': serviceClassAisTemplate,
+  'business-event': businessEventTemplate,
+  'custom-telemetry': customTelemetryTemplate,
+  'feature-class': featureClassTemplate,
+  'composite-entity': compositeEntityTemplate,
+  'custom-service': customServiceTemplate,
+  'er-custom-function': erCustomFunctionTemplate,
 };
 
 // Templates for EXTENSION elements: (baseName = element being extended, prefix = model/ISV infix)
@@ -1249,6 +1257,519 @@ public class ${name}Contract
         return description;
     }
 }`;
+}
+
+// ── Business Event pattern (contract + event class) ──────────────────────
+function businessEventTemplate(name: string): string {
+  return `// ══════════════════════════════════════════════════════════════════
+// Business Event: ${name}
+// 2 classes: Contract (payload) + Event (trigger).
+// After deployment, appears in: System Admin > Set up > Business events > Catalog
+// ══════════════════════════════════════════════════════════════════
+
+// ── 1. Business Event Contract (payload definition) ─────────────────────
+/// <summary>
+/// Contract defining the payload for the ${name} business event.
+/// Properties here become the JSON schema available to Power Automate / Service Bus subscribers.
+/// </summary>
+[DataContractAttribute]
+public final class ${name}BusinessEventContract extends BusinessEventsContract
+{
+    private CustAccount custAccount;
+    private Name        custName;
+    private str         documentId;
+
+    /// <summary>
+    /// Creates a new contract from a source record.
+    /// </summary>
+    public static ${name}BusinessEventContract newFromRecord(/* SourceTable _record */)
+    {
+        ${name}BusinessEventContract contract = new ${name}BusinessEventContract();
+
+        // Map source record fields to contract properties
+        // contract.parmCustAccount(_record.CustAccount);
+        // contract.parmCustName(_record.custName());
+        // contract.parmDocumentId(_record.DocumentId);
+
+        return contract;
+    }
+
+    [DataMemberAttribute('CustAccount'),
+     BusinessEventsDataMemberAttribute('@AccountsReceivable:CustAccount')]
+    public CustAccount parmCustAccount(CustAccount _v = custAccount)
+    {
+        custAccount = _v;
+        return custAccount;
+    }
+
+    [DataMemberAttribute('CustName'),
+     BusinessEventsDataMemberAttribute('@SYS7399')]  // Customer name
+    public Name parmCustName(Name _v = custName)
+    {
+        custName = _v;
+        return custName;
+    }
+
+    [DataMemberAttribute('DocumentId'),
+     BusinessEventsDataMemberAttribute('@SYS3252')]
+    public str parmDocumentId(str _v = documentId)
+    {
+        documentId = _v;
+        return documentId;
+    }
+}
+
+// ── 2. Business Event class (trigger) ───────────────────────────────────
+/// <summary>
+/// Business event triggered when ${name} occurs.
+/// Activate in: System Admin > Set up > Business events > Catalog.
+/// </summary>
+[BusinessEventsAttribute('${name}BusinessEvent',
+    '@MyModel:${name}BusinessEventDescription',
+    ModuleAxapta::SalesOrder)]   // ← change to your module
+public final class ${name}BusinessEvent extends BusinessEventsBase
+{
+    private /* SourceTable */ Common sourceRecord;
+
+    /// <summary>
+    /// Constructs the business event from a source record.
+    /// </summary>
+    public static ${name}BusinessEvent newFromRecord(/* SourceTable */ Common _record)
+    {
+        ${name}BusinessEvent businessEvent = new ${name}BusinessEvent();
+        businessEvent.sourceRecord = _record;
+        return businessEvent;
+    }
+
+    /// <summary>
+    /// Builds the contract payload sent to subscribers.
+    /// </summary>
+    protected BusinessEventsContract buildContract()
+    {
+        return ${name}BusinessEventContract::newFromRecord(this.sourceRecord);
+    }
+
+    // ── How to trigger this event ────────────────────────────────────
+    // In your business logic (e.g. after posting, confirmation, etc.):
+    //
+    //   ${name}BusinessEvent businessEvent =
+    //       ${name}BusinessEvent::newFromRecord(myRecord);
+    //   businessEvent.send();   // ← sends to all activated endpoints
+}`;
+}
+
+// ── Custom Telemetry pattern ─────────────────────────────────────────────
+function customTelemetryTemplate(name: string): string {
+  return `/// <summary>
+/// Custom telemetry signal for ${name}.
+/// Emits events to Application Insights via the monitoring framework.
+/// </summary>
+/// <remarks>
+/// Prerequisites:
+///   1. Enable Monitoring and telemetry in Feature management
+///   2. Configure Application Insights connection string in LCS / Power Platform admin
+///   3. After deployment, signals appear in App Insights → customEvents / traces
+/// </remarks>
+public final class ${name}Telemetry
+{
+    /// <summary>
+    /// Emits a custom event to Application Insights with structured properties.
+    /// </summary>
+    public static void emitEvent(
+        str   _eventName,
+        str   _contextId = '',
+        str   _detail    = '')
+    {
+        SysApplicationInsightsEventLogger logger =
+            SysApplicationInsightsEventLogger::construct();
+
+        // Set custom properties (appear as customDimensions in KQL)
+        Map customProperties = new Map(Types::String, Types::String);
+        customProperties.insert('EventName',  _eventName);
+        customProperties.insert('ContextId',  _contextId);
+        customProperties.insert('Detail',     _detail);
+        customProperties.insert('UserId',     curUserId());
+        customProperties.insert('Company',    curExt());
+
+        logger.logCustomEvent('${name}', customProperties);
+    }
+
+    /// <summary>
+    /// Emits a custom metric (numeric measurement) to Application Insights.
+    /// </summary>
+    public static void emitMetric(
+        str   _metricName,
+        real  _value,
+        str   _dimension = '')
+    {
+        SysApplicationInsightsMetricLogger metricLogger =
+            SysApplicationInsightsMetricLogger::construct();
+
+        Map customDimensions = new Map(Types::String, Types::String);
+        customDimensions.insert('Dimension', _dimension);
+        customDimensions.insert('Company',   curExt());
+
+        metricLogger.logMetricValue(_metricName, _value, customDimensions);
+    }
+}
+
+// ── Usage examples ──────────────────────────────────────────────────────
+// After a batch job completes:
+//   ${name}Telemetry::emitEvent('BatchCompleted', batchId, strFmt('%1 records processed', count));
+//
+// Track processing duration:
+//   ${name}Telemetry::emitMetric('ProcessingDurationMs', durationMs, 'OrderImport');
+//
+// KQL query to find events in Application Insights:
+//   customEvents
+//   | where name == "${name}"
+//   | extend EventName = tostring(customDimensions.EventName)
+//   | where EventName == "BatchCompleted"
+//   | project timestamp, EventName, tostring(customDimensions.ContextId)`;
+}
+
+
+
+// ── Feature Class pattern ────────────────────────────────────────────────
+function featureClassTemplate(name: string): string {
+  return `/// <summary>
+/// Feature management class for ${name}.
+/// Registers in the Feature Management workspace automatically.
+/// Enable/disable at runtime without redeployment.
+/// </summary>
+[FeatureClassAttribute]
+public final class ${name}Feature
+{
+    private static ${name}Feature instance = new ${name}Feature();
+
+    /// <summary>
+    /// Display label shown in Feature Management workspace.
+    /// </summary>
+    public static str label()
+    {
+        return "@MyModel:${name}FeatureLabel";
+    }
+
+    /// <summary>
+    /// Detailed description shown when expanding the feature in the workspace.
+    /// </summary>
+    public static str description()
+    {
+        return "@MyModel:${name}FeatureDescription";
+    }
+
+    /// <summary>
+    /// Module this feature belongs to (shown as category in Feature Management).
+    /// </summary>
+    public static str module()
+    {
+        return "@MyModel:ModuleName";
+    }
+
+    /// <summary>
+    /// Whether this feature is enabled by default for new environments.
+    /// Return false for features that need explicit opt-in.
+    /// </summary>
+    public static boolean isEnabledByDefault()
+    {
+        return false;
+    }
+
+    // ── Usage in X++ code ───────────────────────────────────────────────
+    // Cache the check result — never call isFeatureEnabled in a loop:
+    //
+    //   boolean featureEnabled = FeatureStateProvider::isFeatureEnabled(
+    //       classStr(${name}Feature));
+    //
+    //   if (featureEnabled)
+    //   {
+    //       // New behavior
+    //   }
+    //   else
+    //   {
+    //       // Legacy behavior
+    //   }
+}`;
+}
+
+// ── Composite Entity pattern ─────────────────────────────────────────────
+function compositeEntityTemplate(name: string): string {
+  return `// ══════════════════════════════════════════════════════════════════
+// Composite Data Entity: ${name}
+// Combines header + line entities for hierarchical data import/export.
+//
+// Prerequisites:
+//   1. ${name}HeaderEntity  — AxDataEntityView for header table
+//   2. ${name}LineEntity    — AxDataEntityView for line table
+//   Then create the composite entity in the VS designer.
+// ══════════════════════════════════════════════════════════════════
+
+// ── Composite Entity XML (AxCompositeDataEntity - create via VS designer) ──
+// Key properties:
+//   <Name>${name}CompositeEntity</Name>
+//   <PublicEntityName>${name}Composite</PublicEntityName>
+//   <IsPublic>Yes</IsPublic>
+//   <RootDataEntity>${name}HeaderEntity</RootDataEntity>
+//
+//   Mapping:
+//     Header → ${name}HeaderEntity (root)
+//       └── Lines → ${name}LineEntity (child, linked by foreign key)
+
+// ── Header Entity class adjustments ─────────────────────────────────────
+/// <summary>
+/// Header entity for ${name} composite import.
+/// Ensure natural key is defined (NOT RecId) for DMF matching.
+/// </summary>
+// Key XML for ${name}HeaderEntity:
+//   <IsPublic>Yes</IsPublic>
+//   <PublicEntityName>${name}Header</PublicEntityName>
+//   <PublicCollectionName>${name}Headers</PublicCollectionName>
+//   <DataManagementEnabled>Yes</DataManagementEnabled>
+//   <EntityCategory>Document</EntityCategory>
+//   <PrimaryKey>EntityKey</PrimaryKey>   ← natural key (e.g. OrderId)
+
+// ── Line Entity class adjustments ───────────────────────────────────────
+/// <summary>
+/// Line entity for ${name} composite import.
+/// MUST have a relation to the header entity for composite linking.
+/// </summary>
+// Key XML for ${name}LineEntity:
+//   <IsPublic>Yes</IsPublic>
+//   <PublicEntityName>${name}Line</PublicEntityName>
+//   <PublicCollectionName>${name}Lines</PublicCollectionName>
+//   <DataManagementEnabled>Yes</DataManagementEnabled>
+//   <EntityCategory>Document</EntityCategory>
+//
+// Relation (in line entity datasource):
+//   <AxDataEntityViewRelation>
+//     <Name>${name}Header</Name>
+//     <Cardinality>ZeroMore</Cardinality>
+//     <RelatedDataEntity>${name}HeaderEntity</RelatedDataEntity>
+//     <RelatedDataEntityCardinality>ZeroOne</RelatedDataEntityCardinality>
+//     <RelatedDataEntityRole>Header</RelatedDataEntityRole>
+//     <Role>Lines</Role>
+//     <Constraints>
+//       <AxDataEntityViewRelationConstraint>
+//         <Name>OrderId</Name>
+//         <Field>OrderId</Field>
+//         <RelatedField>OrderId</RelatedField>
+//       </AxDataEntityViewRelationConstraint>
+//     </Constraints>
+//   </AxDataEntityViewRelation>
+
+// ── DMF import workflow ─────────────────────────────────────────────────
+// 1. Create a Data Project in Data Management workspace
+// 2. Add the composite entity (${name}CompositeEntity)
+// 3. Import file format: XML or JSON (composite entities do NOT support CSV)
+// 4. Header/Line records are imported together in correct order
+// 5. After import: check staging table for errors (DMFTransferStatus)`;
+}
+
+// ── Custom Service (Service Group + Operations) pattern ──────────────────
+function customServiceTemplate(name: string): string {
+  return `// ══════════════════════════════════════════════════════════════════
+// Custom Service: ${name}
+// Exposes custom X++ logic as a SOAP/JSON web service.
+// 3 objects: Service class + Service XML (AxService) + Service Group XML
+// ══════════════════════════════════════════════════════════════════
+
+// ── 1. Service Contract (request/response) ──────────────────────────────
+[DataContractAttribute]
+public final class ${name}ServiceRequest
+{
+    private str     recordId;
+    private str     operation;
+
+    [DataMemberAttribute('RecordId')]
+    public str parmRecordId(str _v = recordId)
+    {
+        recordId = _v;
+        return recordId;
+    }
+
+    [DataMemberAttribute('Operation')]
+    public str parmOperation(str _v = operation)
+    {
+        operation = _v;
+        return operation;
+    }
+}
+
+[DataContractAttribute]
+public final class ${name}ServiceResponse
+{
+    private boolean success;
+    private str     message;
+    private str     resultData;
+
+    [DataMemberAttribute('Success')]
+    public boolean parmSuccess(boolean _v = success)
+    {
+        success = _v;
+        return success;
+    }
+
+    [DataMemberAttribute('Message')]
+    public str parmMessage(str _v = message)
+    {
+        message = _v;
+        return message;
+    }
+
+    [DataMemberAttribute('ResultData')]
+    public str parmResultData(str _v = resultData)
+    {
+        resultData = _v;
+        return resultData;
+    }
+}
+
+// ── 2. Service class ────────────────────────────────────────────────────
+/// <summary>
+/// Custom service operations for ${name}.
+/// Each public method with [SysEntryPointAttribute] becomes a service operation.
+/// </summary>
+public class ${name}Service
+{
+    /// <summary>
+    /// Processes the request and returns a response.
+    /// </summary>
+    [SysEntryPointAttribute(true)]
+    public ${name}ServiceResponse processRequest(${name}ServiceRequest _request)
+    {
+        ${name}ServiceResponse response = new ${name}ServiceResponse();
+
+        try
+        {
+            str recordId  = _request.parmRecordId();
+            str operation = _request.parmOperation();
+
+            // TODO: Implement business logic based on operation
+            ttsbegin;
+
+            // Process...
+
+            ttscommit;
+
+            response.parmSuccess(true);
+            response.parmMessage('Operation completed successfully.');
+        }
+        catch (Exception::Error)
+        {
+            response.parmSuccess(false);
+            response.parmMessage(infologLine(infologLine()));
+        }
+
+        return response;
+    }
+
+    /// <summary>
+    /// Returns a health check / ping response.
+    /// </summary>
+    [SysEntryPointAttribute(false)]
+    public str ping()
+    {
+        return 'OK';
+    }
+}
+
+// ── 3. AOT objects (create via create_d365fo_file) ──────────────────────
+// a) AxService XML:
+//    <AxService>
+//      <Name>${name}Service</Name>
+//      <Class>${name}Service</Class>
+//      <Operations>
+//        <AxServiceOperation>
+//          <Name>processRequest</Name>
+//          <Enabled>Yes</Enabled>
+//        </AxServiceOperation>
+//        <AxServiceOperation>
+//          <Name>ping</Name>
+//          <Enabled>Yes</Enabled>
+//        </AxServiceOperation>
+//      </Operations>
+//    </AxService>
+//
+// b) AxServiceGroup XML:
+//    <AxServiceGroup>
+//      <Name>${name}ServiceGroup</Name>
+//      <AutoDeploy>Yes</AutoDeploy>
+//      <Services>
+//        <Name>${name}Service</Name>
+//      </Services>
+//    </AxServiceGroup>
+//
+// Endpoint URL after deploy:
+//   https://{env}.operations.dynamics.com/api/services/${name}ServiceGroup/${name}Service/processRequest`;
+}
+
+// ── ER Custom Function pattern ───────────────────────────────────────────
+function erCustomFunctionTemplate(name: string): string {
+  return `/// <summary>
+/// Electronic Reporting custom function provider for ${name}.
+/// Extends the ER formula designer with custom functions usable in ER configurations.
+/// </summary>
+/// <remarks>
+/// After deployment, the function appears in the ER formula designer
+/// under the "Functions" list and can be used in ER format/model mappings.
+///
+/// Registration: The class is auto-discovered via [ERExpressionCustomFunctionProvider].
+/// </remarks>
+[ERExpressionCustomFunctionProvider]
+public final class ${name}ERFunctions
+{
+    /// <summary>
+    /// Custom string formatting function usable from ER formula designer.
+    /// ER formula usage: ${name}.FormatValue(value, format)
+    /// </summary>
+    [ERExpressionCustomFunction('FormatValue',
+        '@MyModel:${name}FormatValueDescription')]
+    public static str formatValue(str _value, str _format)
+    {
+        // TODO: Implement custom formatting logic
+        if (_format == 'upper')
+        {
+            return strUpr(_value);
+        }
+        else if (_format == 'trim')
+        {
+            return strLTrim(strRTrim(_value));
+        }
+        return _value;
+    }
+
+    /// <summary>
+    /// Custom lookup function — retrieves a value from D365FO tables.
+    /// ER formula usage: ${name}.LookupDescription(id)
+    /// </summary>
+    [ERExpressionCustomFunction('LookupDescription',
+        '@MyModel:${name}LookupDescDescription')]
+    public static str lookupDescription(str _id)
+    {
+        // TODO: Replace with actual table lookup
+        // Example: return InventTable::find(_id).itemName();
+        return '';
+    }
+
+    /// <summary>
+    /// Custom validation function returning boolean.
+    /// ER formula usage: ${name}.IsValid(value)
+    /// </summary>
+    [ERExpressionCustomFunction('IsValid',
+        '@MyModel:${name}IsValidDescription')]
+    public static boolean isValid(str _value)
+    {
+        // TODO: Implement validation logic
+        return _value != '';
+    }
+}
+
+// ── Usage in ER formula designer ────────────────────────────────────────
+// After deployment:
+//   1. Open Organizational administration > Electronic reporting > Configurations
+//   2. In format/model mapping designer, open the formula editor
+//   3. Find ${name}.FormatValue in the functions list
+//   4. Apply: ${name}.FormatValue(model.CustomerName, "upper")`;
 }
 
 const EXTENSION_PATTERNS = new Set([

--- a/src/tools/extensionStrategyAdvisor.ts
+++ b/src/tools/extensionStrategyAdvisor.ts
@@ -1,0 +1,570 @@
+/**
+ * Extension Strategy Advisor Tool
+ * Recommends the correct D365FO extensibility mechanism for a given scenario,
+ * preventing common mistakes like using CoC where a Business Event is needed.
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+// ─── Schema ─────────────────────────────────────────────────────────────────
+
+const scenarioTypes = [
+  'data-validation',
+  'field-defaulting',
+  'business-logic-change',
+  'outbound-integration',
+  'inbound-data',
+  'ui-modification',
+  'document-output',
+  'number-sequence',
+  'security-access',
+  'batch-processing',
+  'custom',
+] as const;
+
+const ExtensionStrategyArgsSchema = z.object({
+  goal: z.string().describe(
+    'What you want to achieve — e.g. "validate that SalesLine quantity is positive", ' +
+    '"send order confirmation to external ERP", "add field to CustTable form"'
+  ),
+  objectName: z.string().optional().describe(
+    'Target D365FO object if known — e.g. "SalesTable", "CustTable", "SalesFormLetter"'
+  ),
+  scenario: z.enum(scenarioTypes).optional().describe(
+    'Scenario category (auto-detected from goal if omitted). One of: ' +
+    scenarioTypes.join(', ')
+  ),
+});
+
+export const extensionStrategyToolDefinition = {
+  name: 'recommend_extension_strategy',
+  description:
+    'Recommends the best D365FO extensibility mechanism for a given scenario. ' +
+    'Prevents common design mistakes (e.g. using CoC where a Business Event or delegate is appropriate). ' +
+    'Returns: recommended mechanism, reasoning, risks, alternatives, and next MCP tool calls. ' +
+    'Use BEFORE writing extension code to ensure the right approach.',
+  inputSchema: ExtensionStrategyArgsSchema,
+};
+
+// ─── Decision Rules ─────────────────────────────────────────────────────────
+
+interface StrategyRule {
+  /** Short pattern ID */
+  id: string;
+  /** Scenario categories this rule applies to */
+  scenarios: readonly string[];
+  /** Keywords in the goal text that trigger this rule */
+  goalKeywords: readonly string[];
+  /** Recommended mechanism */
+  mechanism: string;
+  /** Why this mechanism is correct */
+  reasoning: string;
+  /** Risks / caveats with this approach */
+  risks: readonly string[];
+  /** Alternative mechanisms and when to prefer them */
+  alternatives: readonly { mechanism: string; when: string }[];
+  /** Suggested MCP tool calls to proceed */
+  nextSteps: readonly string[];
+  /** Anti-patterns: common wrong choices for this scenario */
+  antiPatterns: readonly { wrong: string; why: string }[];
+}
+
+const STRATEGY_RULES: readonly StrategyRule[] = [
+  // ── Data validation ───────────────────────────────────────────────────
+  {
+    id: 'validate-table-data',
+    scenarios: ['data-validation'],
+    goalKeywords: ['validate', 'validation', 'check', 'verify', 'must be', 'cannot be',
+                   'not allowed', 'mandatory', 'required field', 'constraint'],
+    mechanism: 'Table Event Handler (onValidatedWrite / onValidatingWrite)',
+    reasoning:
+      'Table data events fire consistently for ALL data entry paths (forms, services, data entities, batch). ' +
+      'CoC on validateWrite() also works but couples you to the method signature. Events are loosely coupled.',
+    risks: [
+      'onValidatedWrite fires AFTER standard validation — your code sees the result but cannot prevent insert if standard already approved',
+      'onValidatingWrite fires BEFORE — use this to reject; set args.parmValidateResult(false)',
+      'Data entity imports may bypass form-level validation — table events are safer than form events',
+    ],
+    alternatives: [
+      { mechanism: 'CoC on table.validateWrite()', when: 'You need access to the full method context or must call next() conditionally' },
+      { mechanism: 'Form data source validateWrite()', when: 'Validation is UI-specific and should NOT apply to service/entity imports' },
+    ],
+    nextSteps: [
+      'analyze_extension_points("TableName") — check available events and existing extensions',
+      'find_event_handlers("TableName") — see if someone already handles the same event',
+      'generate_code(pattern="event-handler") — generate the handler skeleton',
+    ],
+    antiPatterns: [
+      { wrong: 'Business Event', why: 'Business Events are for outbound notifications, not validation logic' },
+      { wrong: 'Data Entity validateWrite', why: 'Only fires for DMF/OData — misses form and X++ code paths' },
+    ],
+  },
+
+  // ── Field defaulting / initialization ─────────────────────────────────
+  {
+    id: 'field-defaulting',
+    scenarios: ['field-defaulting'],
+    goalKeywords: ['default', 'initialize', 'init value', 'auto-fill', 'auto-populate',
+                   'set default', 'prefill', 'initValue'],
+    mechanism: 'Table Event Handler (onInitValue) or CoC on initValue()',
+    reasoning:
+      'initValue() is the standard entry point for field defaults on new records. ' +
+      'The event variant (onInitValue / onInitializedRecord) fires after the kernel sets defaults.',
+    risks: [
+      'initValue only fires for new records — not on copy or data import',
+      'If using CoC, always call next first so standard defaults are set before your logic',
+    ],
+    alternatives: [
+      { mechanism: 'CoC on table.initValue()', when: 'You need to conditionally skip default logic or set values that depend on other defaulted fields' },
+      { mechanism: 'Form data source initValue()', when: 'Default depends on form context (e.g. header record of a lines form)' },
+    ],
+    nextSteps: [
+      'analyze_extension_points("TableName") — check initValue availability',
+      'get_method_signature("TableName", "initValue", includeCocTemplate: true) — get CoC template',
+    ],
+    antiPatterns: [
+      { wrong: 'Overriding insert()', why: 'insert() is for persistence — defaults belong in initValue()' },
+      { wrong: 'Form init()', why: 'Form init runs once at form open, not per new record' },
+    ],
+  },
+
+  // ── Business logic modification ───────────────────────────────────────
+  {
+    id: 'business-logic-change',
+    scenarios: ['business-logic-change'],
+    goalKeywords: ['modify', 'change behavior', 'add logic', 'extend', 'override',
+                   'before posting', 'after posting', 'custom calculation', 'adjust',
+                   'intercept', 'hook into'],
+    mechanism: 'Chain of Command (CoC) on the target method',
+    reasoning:
+      'CoC wraps the original method. You call next() to execute the original and can add pre/post logic. ' +
+      'This is the PRIMARY extensibility mechanism in D365FO for modifying existing business logic.',
+    risks: [
+      'CoC runs in the same transaction as the original — errors in your code roll back the entire operation',
+      'Multiple CoC extensions on the same method run in undefined order unless you control model loading',
+      'Replacing the return value of next() changes behavior for ALL callers — ensure correctness',
+    ],
+    alternatives: [
+      { mechanism: 'Delegate / event handler', when: 'The class exposes a delegate at the exact extension point you need — prefer it over CoC for loose coupling' },
+      { mechanism: 'Pre/post event handler', when: 'You only need to observe or react, not modify the core logic' },
+      { mechanism: 'Replaceable method', when: 'Method is marked [Replaceable] — you can fully replace it (rare in standard app)' },
+    ],
+    nextSteps: [
+      'analyze_extension_points("ClassName") — see CoC-eligible methods and delegates',
+      'get_method_signature("ClassName", "methodName", includeCocTemplate: true) — get exact CoC skeleton',
+      'find_coc_extensions("ClassName", "methodName") — check for existing CoC wrappers',
+    ],
+    antiPatterns: [
+      { wrong: 'Copy-paste the entire class', why: 'Over-layering defeats the purpose of extensions and blocks upgrades' },
+      { wrong: 'Business Event for internal logic', why: 'Business Events are async notifications — they cannot modify transactions' },
+    ],
+  },
+
+  // ── Outbound integration ──────────────────────────────────────────────
+  {
+    id: 'outbound-integration',
+    scenarios: ['outbound-integration'],
+    goalKeywords: ['send to', 'notify', 'push', 'outbound', 'external system', 'integration',
+                   'power automate', 'service bus', 'webhook', 'event grid', 'publish',
+                   'trigger external', 'notify erp', 'sync to'],
+    mechanism: 'Business Event',
+    reasoning:
+      'Business Events are the D365FO-native mechanism for outbound notifications. ' +
+      'They integrate with Power Automate, Azure Service Bus, Event Grid, and HTTPS endpoints. ' +
+      'They are async, decoupled from the transaction, and support payload contracts.',
+    risks: [
+      'Business Events fire AFTER commit — if the receiving system fails, D365FO transaction is already committed',
+      'Payload must be a DataContract class — complex object graphs need flattening',
+      'Event delivery is at-least-once — the consumer must be idempotent',
+    ],
+    alternatives: [
+      { mechanism: 'Custom service (JSON/SOAP)', when: 'The external system must pull data on demand rather than react to events' },
+      { mechanism: 'Data entity + OData', when: 'Integration requires CRUD operations, not event-driven notifications' },
+      { mechanism: 'Dual-write', when: 'Real-time bidirectional sync with Dataverse is needed' },
+    ],
+    nextSteps: [
+      'get_xpp_knowledge("business events") — learn the pattern',
+      'generate_code(pattern="business-event", name="MyEvent") — generate skeleton',
+    ],
+    antiPatterns: [
+      { wrong: 'CoC calling HttpClient', why: 'Synchronous HTTP in a transaction blocks the user and risks timeout/rollback' },
+      { wrong: 'Data entity for event notification', why: 'Data entities are for CRUD — use Business Events for push notifications' },
+      { wrong: 'Writing to an integration table', why: 'Polling tables are fragile — Business Events provide guaranteed delivery with retry' },
+    ],
+  },
+
+  // ── Inbound data / external data transfer ─────────────────────────────
+  {
+    id: 'inbound-data',
+    scenarios: ['inbound-data'],
+    goalKeywords: ['import', 'inbound', 'receive', 'data entity', 'odata', 'dmf', 'dixf',
+                   'data migration', 'bulk load', 'external data', 'api endpoint',
+                   'rest api', 'soap service', 'pull data'],
+    mechanism: 'Data Entity (+ optional custom service)',
+    reasoning:
+      'Data entities are the standard D365FO interface for inbound data. ' +
+      'They support OData REST, DMF batch import, Dual-write, and recurring integrations. ' +
+      'Custom services (JSON/SOAP) complement entities for complex multi-step operations.',
+    risks: [
+      'Data entity validation differs from form validation — test both paths',
+      'DMF set-based operations may bypass row-level validateWrite — use entity-level validation',
+      'High-volume imports should use DMF recurring integration, not OData per-record calls',
+    ],
+    alternatives: [
+      { mechanism: 'Custom service class', when: 'The operation is complex (multi-table, conditional) and does not map to a single entity' },
+      { mechanism: 'Dual-write', when: 'Real-time bidirectional sync with Dataverse tables' },
+      { mechanism: 'Composite entity', when: 'Header + lines structure needs to be imported as a document' },
+    ],
+    nextSteps: [
+      'get_xpp_knowledge("data-management-framework") — learn DMF patterns',
+      'search("MyTable", "data-entity") — check if an entity already exists',
+      'generate_code(pattern="data-entity", name="MyEntity") — generate entity skeleton',
+    ],
+    antiPatterns: [
+      { wrong: 'Direct table insert via custom endpoint', why: 'Bypasses validation, number sequences, and event handlers' },
+      { wrong: 'Business Event for inbound', why: 'Business Events are outbound-only — they push FROM D365FO, not into it' },
+    ],
+  },
+
+  // ── UI modification ───────────────────────────────────────────────────
+  {
+    id: 'ui-modification',
+    scenarios: ['ui-modification'],
+    goalKeywords: ['form', 'ui', 'add field', 'add button', 'add tab', 'hide control',
+                   'visible', 'enable', 'disable', 'lookup', 'form extension',
+                   'display method', 'menu item', 'action pane', 'dialog'],
+    mechanism: 'Form Extension (+ form extension class for logic)',
+    reasoning:
+      'Form extensions modify the UI declaratively (add controls, change properties) without touching the base form. ' +
+      'For logic (button clicks, data source overrides), use extension classes with [ExtensionOf(formStr(...))].',
+    risks: [
+      'Control names in extensions must be unique across ALL extensions of the same form',
+      'Cannot remove or reorder existing controls — only add, hide (Visible=No), or move to different groups',
+      'Form extension classes see only public/protected form methods — private methods are inaccessible',
+    ],
+    alternatives: [
+      { mechanism: 'CoC on form method', when: 'Need to modify existing form logic (e.g. init, close, active record change)' },
+      { mechanism: 'Display/edit method on table extension', when: 'Computed field shown on multiple forms — put it on the table, not the form' },
+      { mechanism: 'New standalone form', when: 'The change is too large for an extension (new document type, new workspace)' },
+    ],
+    nextSteps: [
+      'get_form_info("FormName", searchControl="General") — find exact control names and hierarchy',
+      'analyze_extension_points("FormName") — check form extension points',
+      'create_d365fo_file(objectType="form-extension") — create the extension',
+    ],
+    antiPatterns: [
+      { wrong: 'Overlayering the base form', why: 'Overlayering is not supported in D365FO — use extensions only' },
+      { wrong: 'CoC to add controls', why: 'Controls should be added declaratively in form extension XML, not built in code' },
+    ],
+  },
+
+  // ── Document output / printing ────────────────────────────────────────
+  {
+    id: 'document-output',
+    scenarios: ['document-output'],
+    goalKeywords: ['report', 'print', 'ssrs', 'pdf', 'document', 'invoice', 'packing slip',
+                   'er', 'electronic reporting', 'output', 'format', 'template',
+                   'business document', 'label print', 'excel'],
+    mechanism: 'Electronic Reporting (ER) or SSRS Report Extension',
+    reasoning:
+      'ER is the strategic direction for business documents (invoices, statements). ' +
+      'It supports runtime-editable templates (Word, Excel, PDF) without developer deployment. ' +
+      'SSRS reports are still used for operational/internal reports with complex data processing.',
+    risks: [
+      'ER requires a configuration provider and Dataverse model-mapping — setup cost is higher than SSRS',
+      'SSRS report extensions can only add fields — they cannot remove standard fields from the design',
+      'If the standard report is ER-based, extend the ER configuration — not the SSRS report',
+    ],
+    alternatives: [
+      { mechanism: 'SSRS report (new)', when: 'Operational internal report with complex DP class logic' },
+      { mechanism: 'ER format extension', when: 'Modifying an existing ER-based document (invoice, statement)' },
+      { mechanism: 'Report DP extension', when: 'Adding fields to an existing SSRS temp table via table extension + DP CoC' },
+    ],
+    nextSteps: [
+      'get_report_info("ReportName") — inspect existing report structure',
+      'get_xpp_knowledge("ssrs-reports") — patterns for SSRS',
+      'generate_smart_report(name="MyReport") — generate full SSRS stack',
+    ],
+    antiPatterns: [
+      { wrong: 'Business Event for document delivery', why: 'Business Events send notifications, not formatted documents' },
+      { wrong: 'Custom SSRS to replace an ER document', why: 'If standard uses ER, extend the ER config — SSRS won\'t integrate with document routing' },
+    ],
+  },
+
+  // ── Number sequence ───────────────────────────────────────────────────
+  {
+    id: 'number-sequence',
+    scenarios: ['number-sequence'],
+    goalKeywords: ['number sequence', 'auto number', 'sequence', 'voucher', 'numbering',
+                   'document number', 'auto-increment'],
+    mechanism: 'Number Sequence framework (NumberSeqModule + EDT + parameter form)',
+    reasoning:
+      'D365FO number sequences are configured per legal entity/company. ' +
+      'They require: EDT with NumberSequenceGroup, NumberSeqModule subclass, parameter table reference, and loadModule() registration.',
+    risks: [
+      'Number sequence must be set up in each legal entity — missing setup causes runtime error',
+      'Continuous sequences block concurrent transactions — use non-continuous unless legally required',
+    ],
+    alternatives: [
+      { mechanism: 'Custom counter table', when: 'Simple auto-increment without legal entity scope or configurable format (rare — prefer the framework)' },
+    ],
+    nextSteps: [
+      'get_xpp_knowledge("number-sequences") — full pattern reference',
+      'generate_code(pattern="number-seq-handler") — generate skeleton',
+    ],
+    antiPatterns: [
+      { wrong: 'Identity column / RecId as business number', why: 'RecId is internal — users need formatted, gapless (or configurable) business numbers' },
+      { wrong: 'Max+1 from table', why: 'Race condition under concurrency — number sequence framework handles locking correctly' },
+    ],
+  },
+
+  // ── Security / access control ─────────────────────────────────────────
+  {
+    id: 'security-access',
+    scenarios: ['security-access'],
+    goalKeywords: ['security', 'privilege', 'duty', 'role', 'permission', 'access',
+                   'menu item', 'grant', 'restrict', 'authorize'],
+    mechanism: 'Security Privilege + Duty + Role (AOT objects)',
+    reasoning:
+      'D365FO security follows a strict hierarchy: Menu Item → Privilege → Duty → Role. ' +
+      'Custom features need at least a Privilege (grants access to an entry point) and typically a Duty (groups related privileges). ' +
+      'Roles are assigned to users.',
+    risks: [
+      'Privileges are per-entry-point (menu item, web content, service) — not per table or field directly',
+      'Table permissions inherit via menu item → privilege chain — broken chain = no access',
+      'Extensible enums for duty/privilege discovery: use get_security_coverage_for_object to verify the chain',
+    ],
+    alternatives: [
+      { mechanism: 'Security policy (XDS)', when: 'Row-level security is needed (e.g. filter CustTable by user\'s allowed customers)' },
+      { mechanism: 'Table permission framework override', when: 'Granting DML access without a menu item entry point (rare)' },
+    ],
+    nextSteps: [
+      'get_xpp_knowledge("security-privileges-duties") — security pattern reference',
+      'get_security_coverage_for_object("ObjectName") — check existing security chain',
+      'create_d365fo_file(objectType="security-privilege") — create privilege',
+    ],
+    antiPatterns: [
+      { wrong: 'Hardcoded hasPermission() checks', why: 'Use the declarative security model — privilege chain enforced by the kernel' },
+      { wrong: 'Global::infolog for access denied', why: 'Throw error with specific message; the security framework handles denial automatically for menu items' },
+    ],
+  },
+
+  // ── Batch processing ──────────────────────────────────────────────────
+  {
+    id: 'batch-processing',
+    scenarios: ['batch-processing'],
+    goalKeywords: ['batch', 'scheduled', 'background', 'recurring', 'async processing',
+                   'batch job', 'sysoperation', 'runbase'],
+    mechanism: 'SysOperation framework (preferred) or RunBaseBatch',
+    reasoning:
+      'SysOperation separates contract (parameters), controller (scheduling), and service (execution). ' +
+      'It supports reliable async processing via the batch framework with retries and alerts.',
+    risks: [
+      'RunBase is legacy but still functional — use SysOperation for new development',
+      'Batch tasks run under the batch service account unless "Run as user" is configured',
+      'SysOperation contracts must be [DataContract] with [DataMember] — plain class members are lost during serialization',
+    ],
+    alternatives: [
+      { mechanism: 'RunBaseBatch', when: 'Simple one-off jobs or extending existing RunBase-based processes' },
+      { mechanism: 'Business Event + external processor', when: 'Processing should happen outside D365FO (e.g. Azure Function)' },
+    ],
+    nextSteps: [
+      'get_xpp_knowledge("sysoperation") — SysOperation patterns',
+      'generate_code(pattern="sysoperation", name="MyProcess") — generate SysOperation skeleton',
+      'generate_code(pattern="batch-job", name="MyBatch") — generate RunBaseBatch skeleton',
+    ],
+    antiPatterns: [
+      { wrong: 'Thread.Sleep / while-polling in batch', why: 'Use batch recurrence and alerts — polling wastes AOS resources' },
+      { wrong: 'Synchronous long-running operation on form', why: 'Operations > 5s should be batch-scheduled, not blocking the UI' },
+    ],
+  },
+];
+
+// ─── Scenario Auto-Detection ────────────────────────────────────────────────
+
+function detectScenario(goal: string): typeof scenarioTypes[number] | undefined {
+  const lower = goal.toLowerCase();
+
+  const scenarioKeywordMap: { scenario: typeof scenarioTypes[number]; keywords: string[] }[] = [
+    { scenario: 'data-validation', keywords: ['validat', 'check', 'verify', 'must be', 'cannot be', 'not allowed', 'mandatory', 'required field', 'constraint'] },
+    { scenario: 'field-defaulting', keywords: ['default', 'init value', 'auto-fill', 'prefill', 'auto-populate', 'initvalue'] },
+    { scenario: 'outbound-integration', keywords: ['send to', 'notify external', 'push to', 'outbound', 'power automate', 'service bus', 'webhook', 'event grid', 'publish event'] },
+    { scenario: 'inbound-data', keywords: ['import', 'inbound', 'data entity', 'odata', 'dmf', 'dixf', 'data migration', 'bulk load', 'rest api'] },
+    { scenario: 'ui-modification', keywords: ['form', 'add field', 'add button', 'add tab', 'hide control', 'lookup', 'display method', 'dialog', 'action pane'] },
+    { scenario: 'document-output', keywords: ['report', 'print', 'ssrs', 'pdf', 'electronic reporting', 'er format', 'invoice print', 'packing slip', 'business document'] },
+    { scenario: 'number-sequence', keywords: ['number sequence', 'auto number', 'voucher numbering', 'document number'] },
+    { scenario: 'security-access', keywords: ['privilege', 'duty', 'role', 'security', 'access control', 'permission', 'authorize'] },
+    { scenario: 'batch-processing', keywords: ['batch job', 'scheduled', 'background process', 'recurring', 'sysoperation', 'runbase'] },
+    { scenario: 'business-logic-change', keywords: ['modify', 'change behavior', 'add logic', 'extend method', 'before posting', 'after posting', 'intercept', 'hook into', 'override'] },
+  ];
+
+  // Score each scenario by matching keywords
+  let best: { scenario: typeof scenarioTypes[number]; score: number } | undefined;
+  for (const entry of scenarioKeywordMap) {
+    let score = 0;
+    for (const kw of entry.keywords) {
+      if (lower.includes(kw)) score++;
+    }
+    if (score > 0 && (!best || score > best.score)) {
+      best = { scenario: entry.scenario, score };
+    }
+  }
+  return best?.scenario;
+}
+
+// ─── Rule Matching ──────────────────────────────────────────────────────────
+
+function findMatchingRules(goal: string, scenario?: string): StrategyRule[] {
+  const lower = goal.toLowerCase();
+
+  // 1) Filter by scenario if provided
+  let candidates = scenario
+    ? STRATEGY_RULES.filter(r => r.scenarios.includes(scenario))
+    : [...STRATEGY_RULES];
+
+  // 2) Score each rule by keyword match on the goal
+  const scored = candidates.map(rule => {
+    let score = 0;
+    for (const kw of rule.goalKeywords) {
+      if (lower.includes(kw.toLowerCase())) score++;
+    }
+    // Boost if scenario matches explicitly
+    if (scenario && rule.scenarios.includes(scenario)) score += 3;
+    return { rule, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+
+  // Return top match + any close alternatives (score > 0)
+  return scored.filter(s => s.score > 0).map(s => s.rule);
+}
+
+// ─── Formatting ─────────────────────────────────────────────────────────────
+
+function formatRecommendation(
+  goal: string,
+  resolvedScenario: string,
+  primary: StrategyRule,
+  alternatives: StrategyRule[],
+  objectName?: string,
+): string {
+  let out = `# Extension Strategy Recommendation\n\n`;
+  out += `**Goal:** ${goal}\n`;
+  if (objectName) out += `**Target object:** ${objectName}\n`;
+  out += `**Detected scenario:** ${resolvedScenario}\n\n`;
+
+  out += `## ✅ Recommended: ${primary.mechanism}\n\n`;
+  out += `**Why:** ${primary.reasoning}\n\n`;
+
+  if (primary.risks.length > 0) {
+    out += `### ⚠️ Risks & Caveats\n\n`;
+    for (const risk of primary.risks) {
+      out += `- ${risk}\n`;
+    }
+    out += '\n';
+  }
+
+  if (primary.alternatives.length > 0) {
+    out += `### 🔄 Alternatives\n\n`;
+    for (const alt of primary.alternatives) {
+      out += `- **${alt.mechanism}** — ${alt.when}\n`;
+    }
+    out += '\n';
+  }
+
+  if (primary.antiPatterns.length > 0) {
+    out += `### ❌ Anti-Patterns (Do NOT Use)\n\n`;
+    for (const ap of primary.antiPatterns) {
+      out += `- **${ap.wrong}** — ${ap.why}\n`;
+    }
+    out += '\n';
+  }
+
+  out += `### 🚀 Next Steps\n\n`;
+  for (const step of primary.nextSteps) {
+    const stepWithObject = objectName
+      ? step.replace(/"(ClassName|TableName|FormName|ObjectName|ReportName)"/g, `"${objectName}"`)
+      : step;
+    out += `1. \`${stepWithObject}\`\n`;
+  }
+  out += '\n';
+
+  // Show secondary matches as brief alternatives
+  if (alternatives.length > 0) {
+    out += `## Other Potentially Applicable Strategies\n\n`;
+    for (const alt of alternatives.slice(0, 2)) {
+      out += `- **${alt.mechanism}** (scenario: ${alt.scenarios.join(', ')})\n`;
+    }
+    out += '\n';
+  }
+
+  return out;
+}
+
+function formatNoMatch(goal: string, objectName?: string): string {
+  let out = `# Extension Strategy Recommendation\n\n`;
+  out += `**Goal:** ${goal}\n`;
+  if (objectName) out += `**Target object:** ${objectName}\n\n`;
+  out += `Could not auto-detect the best extensibility mechanism from the goal description.\n\n`;
+  out += `**Try specifying the \`scenario\` parameter explicitly.** Available scenarios:\n\n`;
+  for (const s of scenarioTypes) {
+    out += `- \`${s}\`\n`;
+  }
+  out += `\n**General guidance:**\n\n`;
+  out += `| Goal | Mechanism |\n|------|----------|\n`;
+  out += `| Validate data | Table event (onValidatedWrite) or CoC on validateWrite() |\n`;
+  out += `| Default field values | Table event (onInitValue) or CoC on initValue() |\n`;
+  out += `| Modify business logic | Chain of Command (CoC) |\n`;
+  out += `| Send notification to external system | Business Event |\n`;
+  out += `| Receive/import external data | Data Entity (OData/DMF) |\n`;
+  out += `| Add field/button to form | Form Extension |\n`;
+  out += `| Print document / report | ER configuration or SSRS report |\n`;
+  out += `| Auto-numbering | Number Sequence framework |\n`;
+  out += `| Control user access | Security Privilege → Duty → Role |\n`;
+  out += `| Background / scheduled processing | SysOperation framework |\n`;
+  return out;
+}
+
+// ─── Tool Handler ───────────────────────────────────────────────────────────
+
+export async function extensionStrategyAdvisorTool(
+  request: CallToolRequest,
+  _context: XppServerContext,
+) {
+  try {
+    const args = ExtensionStrategyArgsSchema.parse(request.params.arguments);
+    const { goal, objectName } = args;
+
+    // Resolve scenario: explicit > auto-detected
+    const resolvedScenario = args.scenario ?? detectScenario(goal) ?? 'custom';
+    const matchedRules = findMatchingRules(goal, resolvedScenario !== 'custom' ? resolvedScenario : undefined);
+
+    if (matchedRules.length === 0) {
+      return {
+        content: [{ type: 'text' as const, text: formatNoMatch(goal, objectName) }],
+        isError: false,
+      };
+    }
+
+    const primary = matchedRules[0];
+    const secondaryAlternatives = matchedRules.slice(1);
+
+    return {
+      content: [{
+        type: 'text' as const,
+        text: formatRecommendation(goal, resolvedScenario, primary, secondaryAlternatives, objectName),
+      }],
+      isError: false,
+    };
+  } catch (error) {
+    return {
+      content: [{
+        type: 'text' as const,
+        text: `Error in extension strategy advisor: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      }],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/securityArtifactInfo.ts
+++ b/src/tools/securityArtifactInfo.ts
@@ -13,7 +13,10 @@ const SecurityArtifactInfoArgsSchema = z.object({
   includeChain: z.boolean().optional().default(true).describe('Walk the full hierarchy (role→duties→privileges→entry points)'),
 });
 
-export async function securityArtifactInfoTool(request: CallToolRequest, context: XppServerContext) {
+export async function securityArtifactInfoTool(
+  request: CallToolRequest,
+  context: XppServerContext,
+): Promise<{ content: { type: string; text: string }[]; isError?: boolean }> {
   try {
     const args = SecurityArtifactInfoArgsSchema.parse(request.params.arguments);
     const db = context.symbolIndex.db;

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -54,6 +54,7 @@ import { dbSyncTool } from './dbSync.js';
 import { runBpCheckTool } from './runBpCheck.js';
 import { sysTestRunnerTool } from './sysTestRunner.js';
 import { reviewWorkspaceChangesTool } from './reviewWorkspaceChanges.js';
+import { extensionStrategyAdvisorTool } from './extensionStrategyAdvisor.js';
 import { undoLastModificationTool } from './undoLastModification.js';
 import { xppKnowledgeTool } from './xppKnowledge.js';
 import { d365foErrorHelpTool } from './d365foErrorHelp.js';
@@ -122,6 +123,7 @@ const TOOL_CAP_SIZES: Record<string, number | 'uncapped'> = {
   get_security_coverage_for_object: 8000,
   get_table_extension_info:         6000,
   analyze_extension_points:         6000,
+  recommend_extension_strategy:     6000,
   find_coc_extensions:              5000,
   find_event_handlers:              5000,
   get_data_entity_info:             5000,
@@ -357,6 +359,8 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         return securityCoverageInfoTool(request, context);
       case 'analyze_extension_points':
         return analyzeExtensionPointsTool(request, context);
+      case 'recommend_extension_strategy':
+        return extensionStrategyAdvisorTool(request, context);
       case 'validate_object_naming':
         return validateObjectNamingTool(request, context);
       case 'verify_d365fo_project':

--- a/src/tools/xppKnowledge.ts
+++ b/src/tools/xppKnowledge.ts
@@ -15,7 +15,9 @@ const XppKnowledgeArgsSchema = z.object({
   topic: z.string().describe(
     'Topic to query — e.g. "batch job", "ttsbegin", "RunBase vs SysOperation", ' +
     '"set-based operations", "CoC", "data entities", "number sequences", "security", ' +
-    '"temp tables", "today() deprecated", "query patterns", "form patterns"'
+    '"temp tables", "today() deprecated", "query patterns", "form patterns", ' +
+    '"inventory", "feature management", "dual-write", "DMF", "warehouse", ' +
+    '"trade agreements", "configuration keys", "Power Platform"'
   ),
   format: z.enum(['concise', 'detailed']).optional().default('concise').describe(
     'concise = quick reference (default), detailed = full explanation with code examples'
@@ -29,7 +31,8 @@ export const xppKnowledgeToolDefinition = {
     'Returns distilled, verified patterns with code examples. Use BEFORE generating code to avoid deprecated ' +
     'APIs and AX2012 anti-patterns. Topics: batch jobs, transactions, queries, CoC/extensions, security, ' +
     'data entities, temp tables, number sequences, form patterns, set-based operations, error handling, ' +
-    'SysOperation framework, and more.',
+    'SysOperation framework, inventory management, feature management, dual-write, DMF, ' +
+    'warehouse management, trade agreements, configuration keys, Power Platform integration, and more.',
   inputSchema: XppKnowledgeArgsSchema,
 };
 
@@ -1465,6 +1468,335 @@ if (SecurityRights::hasTableAccess(tableNum(MyCustomTable), AccessType::Read))
       'For existing reports, use get_report_info() — NEVER read report XML with PowerShell',
     ],
     related: ['temp-tables', 'sysoperation'],
+  },
+
+  // ── Inventory Management ────────────────────────────────────────────────
+  {
+    id: 'inventory-management',
+    title: 'Inventory Management (InventTrans, InventDim, On-hand)',
+    keywords: ['inventory', 'inventtrans', 'inventdim', 'inventsum', 'inventonhand', 'reservation',
+               'inventtransorigin', 'inventmov', 'inventupdate', 'on-hand', 'stock'],
+    summary:
+      'D365FO inventory uses InventTrans (transactions), InventDim (dimension combinations), and InventSum ' +
+      '(aggregated on-hand). The InventMovement class hierarchy handles business logic for creating/updating ' +
+      'inventory transactions. Reservations flow through InventUpDate_Reservation.',
+    rules: [
+      'InventTrans: one record per inventory lot/transaction; linked via InventTransOrigin to source docs',
+      'InventDim: stores inventory dimensions (Site, Warehouse, Location, Batch, Serial, etc.) — NEVER create duplicates, use InventDim::findOrCreate()',
+      'InventSum: aggregated on-hand per ItemId + InventDimId — do NOT update directly, it is maintained by the system',
+      'InventOnHand: use InventOnHand class (not direct InventSum queries) for accurate on-hand calculations',
+      'InventMovement: abstract class hierarchy for business rules on inventory transactions — each source doc type has its own subclass',
+      'InventUpdate: updates InventTrans status (e.g. InventUpDate_Physical for packing slip, InventUpDate_Financial for invoice)',
+      'Reservation: InventUpDate_Reservation handles soft/hard reservation; respects reservation hierarchy (Site > Warehouse > Location > Batch > Serial)',
+      'Dimensions: configuration keys control which dimensions are active — check InventDimSetup',
+      'Use InventDimCtrl_Frm* classes to control dimension field visibility on forms',
+      'For custom inventory dimensions: follow the extension pattern in Microsoft docs — add via model extension, NOT overlayering',
+    ],
+    examples: [
+      {
+        label: 'Query on-hand',
+        code: `// Query available on-hand for an item
+InventDim       inventDim;
+InventOnHand    inventOnHand;
+
+inventDim.InventSiteId      = 'Site1';
+inventDim.InventLocationId  = 'WH1';
+inventDim = InventDim::findOrCreate(inventDim);
+
+inventOnHand = InventOnHand::newItemDim(
+    InventTable::find('ItemId'),
+    inventDim,
+    InventDimParm::activeDimFlag(inventDim));
+
+Qty availPhysical = inventOnHand.availPhysical();`,
+      },
+      {
+        label: 'Find or create InventDim',
+        code: `// ALWAYS use findOrCreate — never insert raw InventDim records
+InventDim dim;
+dim.InventSiteId     = 'Site1';
+dim.InventLocationId = 'WH-MAIN';
+dim = InventDim::findOrCreate(dim);
+// dim.inventDimId is now set`,
+      },
+    ],
+    related: ['query-patterns', 'set-based'],
+  },
+
+  // ── Feature Management ──────────────────────────────────────────────────
+  {
+    id: 'feature-management',
+    title: 'Feature Management & Feature Flighting',
+    keywords: ['feature management', 'feature class', 'feature flighting', 'featurestateprovider',
+               'isfeatureenabled', 'feature toggle', 'feature attribute', 'featureclassattribute'],
+    summary:
+      'D365FO Feature Management allows enabling/disabling features at runtime without redeployment. ' +
+      'ISV/custom features register via FeatureClassAttribute and appear in the Feature Management workspace. ' +
+      'Code checks feature state via FeatureStateProvider::isFeatureEnabled() to branch logic.',
+    rules: [
+      'Register custom feature: create a class with [FeatureClassAttribute] — it auto-appears in Feature Management workspace',
+      'Feature class: implement static methods label(), description(), module(), isEnabledByDefault()',
+      'Check at runtime: FeatureStateProvider::isFeatureEnabled(classStr(MyFeature)) returns true/false',
+      'NEVER use FeatureStateProvider inside a tight loop — cache the result in a local variable',
+      'Feature states: Enabled, Disabled, EnabledByDefault (user can still disable)',
+      'Always provide a meaningful description — it shows in the workspace and helps admins decide',
+      'For ISV: features can have dependencies on other features via [FeatureDependsOnAttribute]',
+      'Use Feature Management for gradual rollout — don\'t use configuration keys for new features (CK are compile-time)',
+      'In unit tests, mock feature state via SysTestFeatureStateProvider',
+    ],
+    examples: [
+      {
+        label: 'Feature class definition',
+        code: `/// <summary>
+/// My custom feature that enables enhanced validation.
+/// </summary>
+[FeatureClassAttribute]
+public final class MyEnhancedValidationFeature
+{
+    private static MyEnhancedValidationFeature instance = new MyEnhancedValidationFeature();
+
+    public static str label()
+    {
+        return "@MyModel:EnhancedValidationLabel";
+    }
+
+    public static str description()
+    {
+        return "@MyModel:EnhancedValidationDesc";
+    }
+
+    public static str module()
+    {
+        return "@MyModel:ModuleName";
+    }
+
+    public static boolean isEnabledByDefault()
+    {
+        return false;
+    }
+}`,
+      },
+      {
+        label: 'Runtime feature check',
+        code: `// Branch logic based on feature state
+if (FeatureStateProvider::isFeatureEnabled(
+        classStr(MyEnhancedValidationFeature)))
+{
+    // New enhanced validation path
+    this.validateEnhanced();
+}
+else
+{
+    // Legacy validation path
+    this.validateLegacy();
+}`,
+      },
+    ],
+    related: ['sysextension', 'testing'],
+  },
+
+  // ── Dual-write ──────────────────────────────────────────────────────────
+  {
+    id: 'dual-write',
+    title: 'Dual-write Integration (Dataverse ↔ F&O)',
+    keywords: ['dual-write', 'dual write', 'dataverse', 'cds', 'common data service', 'virtual entity',
+               'integration', 'synchronization', 'dualwriteentity'],
+    summary:
+      'Dual-write provides near-real-time bidirectional synchronization between D365FO and Dataverse (Power Platform). ' +
+      'It uses table maps (column mappings) and can be extended with custom logic via plug-ins on both sides. ' +
+      'Virtual entities expose F&O data in Dataverse without data duplication.',
+    rules: [
+      'Dual-write operates on data entities — ensure entities are OData-enabled and public',
+      'Table maps define column-level mappings between F&O entity fields and Dataverse table columns',
+      'Initial sync: always run from the side with the most complete data set',
+      'Error handling: dual-write has a retry mechanism — failed records go to an error queue',
+      'Live sync: changes in one system propagate to the other in near-real-time (~seconds)',
+      'Virtual entities: NO data copy — F&O data accessed via OData at runtime in Dataverse; read-only by default',
+      'For custom entities: add DataManagementEnabled=Yes, IsPublic=Yes, PublicEntityName/CollectionName',
+      'NEVER put complex business logic in dual-write transform — keep transforms simple (field mapping, default value)',
+      'For custom pre/post processing: use business events + Power Automate instead of dual-write plug-ins',
+      'Handle company (DataAreaId) filtering carefully — dual-write respects legal entity context',
+      'Performance: avoid dual-write on high-volume transaction tables — use async integration (business events + Service Bus) instead',
+    ],
+    related: ['data-entities', 'alerts-business-events'],
+  },
+
+  // ── Data Management Framework ───────────────────────────────────────────
+  {
+    id: 'data-management-framework',
+    title: 'Data Management Framework (DMF / DIXF)',
+    keywords: ['dmf', 'dixf', 'data import', 'data export', 'staging', 'data entity', 'data management',
+               'composite entity', 'recurring integration', 'data package', 'data project'],
+    summary:
+      'DMF (Data Import/Export Framework, formerly DIXF) is the standard mechanism for bulk data import/export in D365FO. ' +
+      'It uses data entities with optional staging tables for transformation, validation, and error handling. ' +
+      'Supports: file-based import, recurring integrations (queue-based), data packages, and composite entities.',
+    rules: [
+      'Data entities MUST have DataManagementEnabled=Yes to appear in Data Management workspace',
+      'Staging table: auto-generated or custom — holds imported records before target table insertion',
+      'Entity categories: Parameter, Reference, Master, Document, Transaction — controls import order in data packages',
+      'Composite entities: group header + line entities for hierarchical import (e.g. Sales order with lines)',
+      'Recurring integrations: REST API endpoint for automated queue-based import/export with external systems',
+      'ALWAYS refresh entity list after deploying new/modified entities: Data Management > Framework Parameters > Refresh entity list',
+      'Configuration keys: if entity/table/field config key is disabled, those elements are excluded from DMF',
+      'validateWrite() and insert/update chain is called per-record during import — keep these performant',
+      'For high-volume: use set-based processing via entity.insertEntityDataSource() where possible',
+      'Error handling: staging records get DMFTransferStatus (NotStarted, Completed, Error) — use error log for troubleshooting',
+      'Data packages: ZIP files containing multiple entity CSVs — used for ALM and environment configuration migration',
+    ],
+    examples: [
+      {
+        label: 'Entity with staging table (key XML properties)',
+        code: `<!-- AxDataEntityView key properties for DMF -->
+<IsPublic>Yes</IsPublic>
+<PublicEntityName>MyCustomer</PublicEntityName>
+<PublicCollectionName>MyCustomers</PublicCollectionName>
+<DataManagementEnabled>Yes</DataManagementEnabled>
+<DataManagementStagingTable>MyCustomerStaging</DataManagementStagingTable>
+<EntityCategory>Master</EntityCategory>
+<PrimaryKey>EntityKey</PrimaryKey>`,
+      },
+      {
+        label: 'Recurring integration API call',
+        code: `// External system pushes data via REST API:
+// POST https://{env}.operations.dynamics.com/api/connector/enqueue/{DataProject}
+// Content-Type: application/json
+// Body: { "MessageId": "...", "Company": "USMF" }
+// + attach file as multipart form data
+//
+// External system pulls exported data via:
+// GET https://{env}.operations.dynamics.com/api/connector/dequeue/{DataProject}`,
+      },
+    ],
+    related: ['data-entities', 'set-based'],
+  },
+
+  // ── Warehouse Management ────────────────────────────────────────────────
+  {
+    id: 'warehouse-management',
+    title: 'Warehouse Management (WHS / WMS)',
+    keywords: ['warehouse', 'whs', 'wms', 'wave', 'work', 'location directive', 'whswork',
+               'whsworktable', 'whsworkline', 'whswavetemplate', 'pick', 'put', 'replenishment'],
+    summary:
+      'D365FO Warehouse Management (WHS) manages advanced warehouse operations: wave processing, ' +
+      'work creation, pick/put execution, location directives, and mobile device flows. ' +
+      'WHSWorkTable/WHSWorkLine are core tables. Extensions use CoC on wave/work processor classes.',
+    rules: [
+      'WHSWorkTable: header of warehouse work (pick, put, count, replenishment) — one per work order',
+      'WHSWorkLine: detail lines (specific pick/put actions with from/to locations)',
+      'Wave processing: WHSWaveTemplate defines steps (wave template) — allocate, create work, etc.',
+      'Location directives: WHSLocDirTable rules determine where to pick from and put to',
+      'Work templates: define the work action sequence (Pick → Put, Count, etc.)',
+      'Mobile device: WHSMobileAppFlow — flows are customizable via extensions',
+      'For custom wave steps: extend WHSWaveStepBase and register in wave template config',
+      'NEVER directly update WHSWorkTable.WorkStatus — use the WHSWorkExecute class hierarchy',
+      'Use WHSLocationProfile for zone/location type configuration',
+      'Performance: wave processing is batch-capable — always use batch for large volumes',
+      'For extensions: use CoC on WHSPostEngine* classes for custom post-processing logic',
+    ],
+    related: ['inventory-management', 'sysoperation'],
+  },
+
+  // ── Trade Agreements ────────────────────────────────────────────────────
+  {
+    id: 'trade-agreements',
+    title: 'Trade Agreements & Pricing (PriceDisc)',
+    keywords: ['trade agreement', 'pricing', 'pricedisc', 'price', 'discount', 'sales price',
+               'purchase price', 'line discount', 'multiline discount', 'total discount',
+               'pricediscadmtrans', 'priceDiscTable'],
+    summary:
+      'D365FO trade agreements define prices and discounts for sales/purchase. ' +
+      'The PriceDisc class evaluates active agreements based on date, quantity, unit, dimensions, and customer/vendor hierarchy. ' +
+      'Agreements are stored in PriceDiscAdmTrans (journal lines) and activated via posting to PriceDiscTable.',
+    rules: [
+      'Trade agreement types: Sales price, Purchase price, Line discount, Multiline discount, Total discount',
+      'PriceDisc.findPrice() / findDisc(): core methods for price/discount evaluation — use these, NOT direct table queries',
+      'Agreement evaluation order: specific (customer+item) → group (cust group+item) → all (all+item) → all+all',
+      'Date effectivity: agreements have FromDate/ToDate — always pass the correct transaction date',
+      'Quantity breaks: agreements can be quantity-tiered — PriceDisc considers the line quantity',
+      'Dimension matching: agreements can be dimension-specific (color, size, config, style)',
+      'Journal posting: PriceDiscAdmTrans → post (validate + transfer) → PriceDiscTable (active agreements)',
+      'For custom pricing: extend PriceDisc via CoC on findPriceAgreement() or use pricing events',
+      'NEVER hardcode prices in code — always use the trade agreement / pricing framework',
+      'Supplementary items: PriceDiscAdmTrans can define supplementary items that auto-add to sales lines',
+    ],
+    related: ['coc', 'query-patterns'],
+  },
+
+  // ── Configuration Keys ──────────────────────────────────────────────────
+  {
+    id: 'configuration-keys',
+    title: 'Configuration Keys (Compile-time Feature Toggle)',
+    keywords: ['configuration key', 'config key', 'license code', 'conditional compilation',
+               'configurationkeynum', 'isconfiguationkeyenabled', 'sysconfigkey'],
+    summary:
+      'Configuration keys in D365FO control compile-time visibility of tables, fields, menu items, ' +
+      'and security. Unlike Feature Management (runtime), config keys require recompilation when changed. ' +
+      'They are typically used for module licensing and major functional areas.',
+    rules: [
+      'Configuration keys are compile-time — changing them requires deployment/recompilation',
+      'For runtime toggles, prefer Feature Management over config keys (no recompilation needed)',
+      'Tables/fields with disabled config keys are excluded from the database schema',
+      'Data entities respect config keys — disabled fields are excluded from DMF and OData',
+      'Use isConfigurationKeyEnabled(configurationKeyNum(MyKey)) for runtime checks',
+      'License codes: control which config keys are available — tied to ISV licensing',
+      'Custom config keys: create AxConfigurationKey XML and assign to tables/fields/menu items',
+      'Parent-child hierarchy: disabling a parent key disables all child keys',
+      'ALWAYS test with your config keys disabled — ensure no compile errors in alternate configurations',
+      'After config key changes: refresh entity list in Data Management workspace',
+    ],
+    examples: [
+      {
+        label: 'Runtime config key check',
+        code: `// Check if a configuration key is enabled at runtime
+if (isConfigurationKeyEnabled(configurationKeyNum(WHSAdvanced)))
+{
+    // WHS advanced features are available
+    this.processAdvancedWHS();
+}
+else
+{
+    // Basic warehouse (WMS) path
+    this.processBasicWMS();
+}`,
+      },
+      {
+        label: 'AxConfigurationKey XML',
+        code: `<?xml version="1.0" encoding="utf-8"?>
+<AxConfigurationKey xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>MyModuleKey</Name>
+  <Label>@MyModel:ModuleLabel</Label>
+  <Enabled>Yes</Enabled>
+  <ParentKey>SysMaster</ParentKey>
+  <LicenseCode>MyModuleLicenseCode</LicenseCode>
+</AxConfigurationKey>`,
+      },
+    ],
+    related: ['feature-management', 'security-privileges-duties'],
+  },
+
+  // ── Power Platform Integration ──────────────────────────────────────────
+  {
+    id: 'power-platform-integration',
+    title: 'Power Platform Integration (Virtual Entities, Dataverse)',
+    keywords: ['power platform', 'power automate', 'power apps', 'virtual entity', 'dataverse',
+               'finance operations connector', 'odata', 'business event', 'flow'],
+    summary:
+      'D365FO integrates with Power Platform via: OData endpoints (data entities), Business Events (triggers for Power Automate), ' +
+      'Virtual Entities (Dataverse tables backed by F&O data), and the Finance and Operations connector in Power Automate.',
+    rules: [
+      'OData endpoint: data entities with IsPublic=Yes are auto-exposed at {env}/data/{CollectionName}',
+      'Business events: subscribe via Power Automate trigger "When a Business Event occurs" for real-time notifications',
+      'Virtual entities: F&O tables/entities visible in Dataverse WITHOUT data duplication — queries route to F&O at runtime',
+      'Virtual entity setup: enable in Dataverse admin, configure in Power Platform integration settings in F&O',
+      'Finance and Operations connector: Power Automate actions for CRUD on data entities, running business events, executing batch jobs',
+      'For custom triggers: create a custom business event class (extends BusinessEventsBase) → it auto-appears as a Power Automate trigger',
+      'Authentication: virtual entities and OData use Azure AD (Entra ID) authentication — configure app registrations properly',
+      'NEVER expose sensitive data via OData without proper security — configure security privileges on data entities',
+      'Rate limiting: OData has throttling limits — use batch operations ($batch) for bulk CRUD',
+      'For Canvas/Model-driven apps: use virtual entities for real-time F&O data, NOT dual-write (which is for bidirectional sync)',
+    ],
+    related: ['data-entities', 'alerts-business-events', 'dual-write'],
   },
 ];
 

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -134,6 +134,60 @@ describe('generate_code', () => {
     );
     expect(result.isError).toBe(true);
   });
+
+  it('generates a business-event template', async () => {
+    const result = await codeGenTool(
+      req('generate_code', { pattern: 'business-event', name: 'OrderConfirmed', modelName: 'MyModel' }),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toMatch(/BusinessEventsBase|BusinessEventsContract/);
+  });
+
+  it('generates a custom-telemetry template', async () => {
+    const result = await codeGenTool(
+      req('generate_code', { pattern: 'custom-telemetry', name: 'OrderProcessing', modelName: 'MyModel' }),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toMatch(/ApplicationInsights|logCustomEvent|emitEvent/);
+  });
+
+  it('generates a feature-class template', async () => {
+    const result = await codeGenTool(
+      req('generate_code', { pattern: 'feature-class', name: 'EnhancedValidation', modelName: 'MyModel' }),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toMatch(/FeatureClassAttribute|isEnabledByDefault/);
+  });
+
+  it('generates a composite-entity template', async () => {
+    const result = await codeGenTool(
+      req('generate_code', { pattern: 'composite-entity', name: 'SalesOrder', modelName: 'MyModel' }),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toMatch(/HeaderEntity|LineEntity|Composite/);
+  });
+
+  it('generates a custom-service template', async () => {
+    const result = await codeGenTool(
+      req('generate_code', { pattern: 'custom-service', name: 'Inventory', modelName: 'MyModel' }),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toMatch(/ServiceRequest|ServiceResponse|SysEntryPointAttribute|ServiceGroup/);
+  });
+
+  it('generates an er-custom-function template', async () => {
+    const result = await codeGenTool(
+      req('generate_code', { pattern: 'er-custom-function', name: 'CustomFormats', modelName: 'MyModel' }),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toMatch(/ERExpressionCustomFunction|FormatValue|formula designer/i);
+  });
 });
 
 // ─── code_completion ─────────────────────────────────────────────────────────

--- a/tests/tools/extensions-security.test.ts
+++ b/tests/tools/extensions-security.test.ts
@@ -2,7 +2,8 @@
  * Extensions & Security Tools Tests
  * Covers: find_coc_extensions, find_event_handlers, get_table_extension_info,
  *         get_security_artifact_info, get_security_coverage_for_object,
- *         analyze_extension_points, get_menu_item_info, get_data_entity_info
+ *         analyze_extension_points, get_menu_item_info, get_data_entity_info,
+ *         recommend_extension_strategy
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -14,6 +15,7 @@ import { securityCoverageInfoTool } from '../../src/tools/securityCoverageInfo';
 import { analyzeExtensionPointsTool } from '../../src/tools/analyzeExtensionPoints';
 import { menuItemInfoTool } from '../../src/tools/menuItemInfo';
 import { dataEntityInfoTool } from '../../src/tools/dataEntityInfo';
+import { extensionStrategyAdvisorTool } from '../../src/tools/extensionStrategyAdvisor';
 import type { XppServerContext } from '../../src/types/context';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
@@ -440,5 +442,164 @@ describe('get_data_entity_info', () => {
   it('returns error when entityName is missing', async () => {
     const result = await dataEntityInfoTool(req('get_data_entity_info', {}), buildContext());
     expect(result.isError).toBe(true);
+  });
+});
+
+// ─── recommend_extension_strategy ────────────────────────────────────────────
+
+describe('recommend_extension_strategy', () => {
+  it('recommends table event for data validation scenario', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'validate that SalesLine quantity is positive',
+        objectName: 'SalesLine',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('data-validation');
+    expect(text).toMatch(/Table Event|onValidat/i);
+    expect(text).toContain('SalesLine');
+  });
+
+  it('recommends Business Event for outbound integration', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'send order confirmation to external ERP via Power Automate',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Business Event');
+    expect(text).toContain('outbound-integration');
+  });
+
+  it('recommends Data Entity for inbound data', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'import vendor master data from CSV via DMF',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Data Entity');
+    expect(text).toContain('inbound-data');
+  });
+
+  it('recommends Form Extension for UI modification', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'add custom field to CustTable form',
+        objectName: 'CustTable',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Form Extension');
+    expect(text).toContain('CustTable');
+  });
+
+  it('recommends CoC for business logic modification', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'add logic before posting sales invoice',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Chain of Command');
+  });
+
+  it('recommends ER/SSRS for document output', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'customize invoice print layout with new fields',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toMatch(/Electronic Reporting|SSRS/);
+  });
+
+  it('uses explicit scenario parameter when provided', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'do something with numbers',
+        scenario: 'number-sequence',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Number Sequence');
+  });
+
+  it('returns anti-patterns to avoid', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'validate sales order amount is not negative',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Anti-Patterns');
+  });
+
+  it('returns next steps with MCP tool calls', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'add field to CustTable form',
+        objectName: 'CustTable',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Next Steps');
+    expect(text).toContain('CustTable');
+  });
+
+  it('shows fallback guidance when goal is ambiguous', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'do something completely unrelated to any known pattern xyz123',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('scenario');
+  });
+
+  it('recommends SysOperation for batch processing', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'create a scheduled batch job to recalculate inventory',
+        scenario: 'batch-processing',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('SysOperation');
+  });
+
+  it('recommends security hierarchy for access control', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req('recommend_extension_strategy', {
+        goal: 'grant users access to new custom form via security role',
+      }),
+      buildContext(),
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toMatch(/Privilege|Duty|Role/);
   });
 });

--- a/tests/tools/xpp-knowledge.test.ts
+++ b/tests/tools/xpp-knowledge.test.ts
@@ -136,4 +136,62 @@ describe('get_xpp_knowledge', () => {
     const text = getText(result);
     expect(text).toContain('Related topics');
   });
+
+  // ── New knowledge topics (P1) ──────────────────────────────────────────
+
+  it('handles inventory management query', async () => {
+    const result = await xppKnowledgeTool(req({ topic: 'inventory InventTrans' }));
+    const text = getText(result);
+    expect(text).toContain('InventTrans');
+    expect(text).toContain('InventDim');
+  });
+
+  it('handles feature management query', async () => {
+    const result = await xppKnowledgeTool(req({ topic: 'feature management toggle' }));
+    const text = getText(result);
+    expect(text).toContain('FeatureClassAttribute');
+    expect(text).toContain('isFeatureEnabled');
+  });
+
+  it('handles dual-write query', async () => {
+    const result = await xppKnowledgeTool(req({ topic: 'dual-write Dataverse' }));
+    const text = getText(result);
+    expect(text).toContain('Dataverse');
+    expect(text).toContain('dual-write');
+  });
+
+  it('handles DMF/DIXF query', async () => {
+    const result = await xppKnowledgeTool(req({ topic: 'DMF data import staging' }));
+    const text = getText(result);
+    expect(text).toContain('Data Management');
+    expect(text).toContain('staging');
+  });
+
+  it('handles warehouse management query', async () => {
+    const result = await xppKnowledgeTool(req({ topic: 'warehouse WHS wave' }));
+    const text = getText(result);
+    expect(text).toContain('Warehouse');
+    expect(text).toContain('WHSWork');
+  });
+
+  it('handles trade agreements query', async () => {
+    const result = await xppKnowledgeTool(req({ topic: 'trade agreement pricing' }));
+    const text = getText(result);
+    expect(text).toContain('PriceDisc');
+    expect(text).toContain('Trade');
+  });
+
+  it('handles configuration keys query', async () => {
+    const result = await xppKnowledgeTool(req({ topic: 'configuration key license' }));
+    const text = getText(result);
+    expect(text).toContain('Configuration');
+    expect(text).toContain('config key');
+  });
+
+  it('handles Power Platform integration query', async () => {
+    const result = await xppKnowledgeTool(req({ topic: 'Power Platform virtual entity' }));
+    const text = getText(result);
+    expect(text).toContain('Power Platform');
+    expect(text).toContain('virtual entit');
+  });
 });

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -29,8 +29,8 @@ describe('tool inventory contract', () => {
   });
 
   it('exposes the expected total tool count', () => {
-    expect(mcpServerToolNames).toHaveLength(53);
-    expect(startupCatalogToolNames).toHaveLength(53);
+    expect(mcpServerToolNames).toHaveLength(54);
+    expect(startupCatalogToolNames).toHaveLength(54);
   });
 
   it('keeps local-only tool set aligned with the published tool inventory', () => {
@@ -40,7 +40,7 @@ describe('tool inventory contract', () => {
     }
 
     expect(LOCAL_TOOLS.size).toBe(13);
-    expect(mcpServerToolNames.filter(name => !LOCAL_TOOLS.has(name))).toHaveLength(40);
+    expect(mcpServerToolNames.filter(name => !LOCAL_TOOLS.has(name))).toHaveLength(41);
   });
 
   it('includes critical diagnostics and SDLC tools in both inventories', () => {


### PR DESCRIPTION
This pull request adds a new tool, `recommend_extension_strategy`, to the MCP toolset and updates documentation throughout the project to reflect the increase from 53 to 54 available tools. The new tool helps users determine the correct D365FO extensibility mechanism for a given scenario, reducing mistakes when choosing between CoC, events, business events, and data entities. All references, examples, and tool lists in the documentation have been updated accordingly.

**Key changes:**

**New Tool Addition:**

* Introduced the `recommend_extension_strategy` tool, which recommends the appropriate extensibility mechanism for a given scenario in D365FO, and updated usage instructions and examples in `.github/copilot-instructions.md` and `docs/MCP_TOOLS.md`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R311) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R753) [[3]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95R115)

**Documentation and Tool Count Updates:**

* Increased the reported number of MCP tools from 53 to 54 in all relevant documentation, including `README.md`, `docs/ARCHITECTURE.md`, `docs/MCP_CONFIG.md`, and `docs/MCP_TOOLS.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L141-R141) [[4]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L38-R38) [[5]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L85-R85) [[6]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcL297-R297) [[7]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L4-R4)
* Updated architecture diagrams, tool lists, and protocol method descriptions to reflect the new tool and tool count. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R145) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L588-R589) [[3]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L597-R598) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L572-R578) [[5]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L47-R47) [[6]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L103-R103) [[7]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcL308-R323)

**Enhancements to Code Generation Patterns:**

* Expanded the list of supported `generate_code` patterns with new options such as `business-event`, `custom-telemetry`, `feature-class`, `composite-entity`, `custom-service`, and `er-custom-function` in `.github/copilot-instructions.md`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R321-R326) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L401-R408)

These changes improve the guidance and automation available to developers working with D365FO, ensuring more accurate extensibility decisions and up-to-date documentation across the project.