### PR TITLE
feat: C# metadata bridge — Phase 1 integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,21 @@ coverage/
 # Internal planning docs
 docs/plans/
 
+# C# Bridge build artifacts
+bridge/D365MetadataBridge/bin/
+bridge/D365MetadataBridge/obj/
+
+# Bridge scratch/debug files
+bridge/inspect-*.ps1
+bridge/stderr*.log
+bridge/D365MetadataBridge/bridge-stderr.log
+
+# Visual Studio solution user files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
 # Misc
 .cache/
 deployment.zip

--- a/bridge/D365MetadataBridge/D365MetadataBridge.csproj
+++ b/bridge/D365MetadataBridge/D365MetadataBridge.csproj
@@ -1,0 +1,56 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <RootNamespace>D365MetadataBridge</RootNamespace>
+    <AssemblyName>D365MetadataBridge</AssemblyName>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <!--
+    D365FO bin directory — contains all Microsoft.Dynamics.*.dll assemblies.
+    Every D365FO development desktop has this directory available.
+
+    Traditional VM:  K:\AosService\PackagesLocalDirectory\bin
+    Cloud-hosted:    C:\AosService\PackagesLocalDirectory\bin
+    UDE (Unified Developer Experience): path from .mcp.json microsoftPackagesPath/bin
+
+    Override per-machine via:
+      dotnet build -p:D365BinPath="C:\path\to\bin"
+    or in a local Directory.Build.props (not committed to source control).
+  -->
+  <PropertyGroup>
+    <D365BinPath Condition="'$(D365BinPath)' == '' And Exists('K:\AosService\PackagesLocalDirectory\bin')">K:\AosService\PackagesLocalDirectory\bin</D365BinPath>
+    <D365BinPath Condition="'$(D365BinPath)' == '' And Exists('C:\AosService\PackagesLocalDirectory\bin')">C:\AosService\PackagesLocalDirectory\bin</D365BinPath>
+  </PropertyGroup>
+
+  <!-- NuGet packages -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!--
+    D365FO assemblies: auto-referenced from $(D365BinPath) via glob.
+    At runtime, Program.cs dynamically loads them via AppDomain.AssemblyResolve
+    from the - -packages-path argument, so Private=false (don't copy to output).
+  -->
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(D365BinPath)' != ''">
+    <Reference Include="$(D365BinPath)\Microsoft.Dynamics.*.dll">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="$(D365BinPath)\Microsoft.Dynamics.Framework.Tools.MetaModel.Core.dll">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/bridge/D365MetadataBridge/Models/Models.cs
+++ b/bridge/D365MetadataBridge/Models/Models.cs
@@ -1,0 +1,481 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace D365MetadataBridge.Models
+{
+    // ========================
+    // Table models
+    // ========================
+
+    public class TableInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("developerDocumentation")]
+        public string? DeveloperDocumentation { get; set; }
+
+        [JsonPropertyName("tableGroup")]
+        public string? TableGroup { get; set; }
+
+        [JsonPropertyName("tabletype")]
+        public string? TableType { get; set; }
+
+        [JsonPropertyName("cacheLookup")]
+        public string? CacheLookup { get; set; }
+
+        [JsonPropertyName("clusteredIndex")]
+        public string? ClusteredIndex { get; set; }
+
+        [JsonPropertyName("primaryIndex")]
+        public string? PrimaryIndex { get; set; }
+
+        [JsonPropertyName("saveDataPerCompany")]
+        public string? SaveDataPerCompany { get; set; }
+
+        [JsonPropertyName("extends")]
+        public string? Extends { get; set; }
+
+        [JsonPropertyName("supportInheritance")]
+        public string? SupportInheritance { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("fields")]
+        public List<FieldInfoModel> Fields { get; set; } = new List<FieldInfoModel>();
+
+        [JsonPropertyName("fieldGroups")]
+        public List<FieldGroupModel> FieldGroups { get; set; } = new List<FieldGroupModel>();
+
+        [JsonPropertyName("indexes")]
+        public List<IndexInfoModel> Indexes { get; set; } = new List<IndexInfoModel>();
+
+        [JsonPropertyName("relations")]
+        public List<RelationInfoModel> Relations { get; set; } = new List<RelationInfoModel>();
+
+        [JsonPropertyName("methods")]
+        public List<MethodInfoModel> Methods { get; set; } = new List<MethodInfoModel>();
+    }
+
+    public class FieldInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("fieldType")]
+        public string FieldType { get; set; } = "";
+
+        [JsonPropertyName("extendedDataType")]
+        public string? ExtendedDataType { get; set; }
+
+        [JsonPropertyName("enumType")]
+        public string? EnumType { get; set; }
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("helpText")]
+        public string? HelpText { get; set; }
+
+        [JsonPropertyName("mandatory")]
+        public bool Mandatory { get; set; }
+
+        [JsonPropertyName("allowEdit")]
+        public string? AllowEdit { get; set; }
+
+        [JsonPropertyName("stringSize")]
+        public int? StringSize { get; set; }
+    }
+
+    public class FieldGroupModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("fields")]
+        public List<string> Fields { get; set; } = new List<string>();
+    }
+
+    public class IndexInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("allowDuplicates")]
+        public bool AllowDuplicates { get; set; }
+
+        [JsonPropertyName("alternateKey")]
+        public bool AlternateKey { get; set; }
+
+        [JsonPropertyName("fields")]
+        public List<IndexFieldModel> Fields { get; set; } = new List<IndexFieldModel>();
+    }
+
+    public class IndexFieldModel
+    {
+        [JsonPropertyName("dataField")]
+        public string DataField { get; set; } = "";
+
+        [JsonPropertyName("includedColumn")]
+        public bool IncludedColumn { get; set; }
+    }
+
+    public class RelationInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("relatedTable")]
+        public string RelatedTable { get; set; } = "";
+
+        [JsonPropertyName("cardinality")]
+        public string? Cardinality { get; set; }
+
+        [JsonPropertyName("relatedTableCardinality")]
+        public string? RelatedTableCardinality { get; set; }
+
+        [JsonPropertyName("constraints")]
+        public List<RelationConstraintModel> Constraints { get; set; } = new List<RelationConstraintModel>();
+    }
+
+    public class RelationConstraintModel
+    {
+        [JsonPropertyName("field")]
+        public string? Field { get; set; }
+
+        [JsonPropertyName("relatedField")]
+        public string? RelatedField { get; set; }
+
+        [JsonPropertyName("value")]
+        public string? Value { get; set; }
+    }
+
+    // ========================
+    // Class models
+    // ========================
+
+    public class ClassInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("extends")]
+        public string? Extends { get; set; }
+
+        [JsonPropertyName("isAbstract")]
+        public bool IsAbstract { get; set; }
+
+        [JsonPropertyName("isFinal")]
+        public bool IsFinal { get; set; }
+
+        [JsonPropertyName("isStatic")]
+        public bool IsStatic { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("declaration")]
+        public string? Declaration { get; set; }
+
+        [JsonPropertyName("methods")]
+        public List<MethodInfoModel> Methods { get; set; } = new List<MethodInfoModel>();
+    }
+
+    public class MethodInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("source")]
+        public string? Source { get; set; }
+
+        [JsonPropertyName("isStatic")]
+        public bool IsStatic { get; set; }
+    }
+
+    // ========================
+    // Enum models
+    // ========================
+
+    public class EnumInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("helpText")]
+        public string? HelpText { get; set; }
+
+        [JsonPropertyName("isExtensible")]
+        public bool IsExtensible { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("values")]
+        public List<EnumValueModel> Values { get; set; } = new List<EnumValueModel>();
+    }
+
+    public class EnumValueModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("value")]
+        public int Value { get; set; }
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+    }
+
+    // ========================
+    // EDT models
+    // ========================
+
+    public class EdtInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("baseType")]
+        public string BaseType { get; set; } = "";
+
+        [JsonPropertyName("extends")]
+        public string? Extends { get; set; }
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("helpText")]
+        public string? HelpText { get; set; }
+
+        [JsonPropertyName("stringSize")]
+        public int? StringSize { get; set; }
+
+        [JsonPropertyName("referenceTable")]
+        public string? ReferenceTable { get; set; }
+
+        [JsonPropertyName("enumType")]
+        public string? EnumType { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+    }
+
+    // ========================
+    // Form models
+    // ========================
+
+    public class FormInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("formPattern")]
+        public string? FormPattern { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("dataSources")]
+        public List<FormDataSourceModel> DataSources { get; set; } = new List<FormDataSourceModel>();
+
+        [JsonPropertyName("controls")]
+        public List<FormControlModel> Controls { get; set; } = new List<FormControlModel>();
+
+        [JsonPropertyName("methods")]
+        public List<MethodInfoModel> Methods { get; set; } = new List<MethodInfoModel>();
+    }
+
+    public class FormDataSourceModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("table")]
+        public string Table { get; set; } = "";
+
+        [JsonPropertyName("joinSource")]
+        public string? JoinSource { get; set; }
+
+        [JsonPropertyName("linkType")]
+        public string? LinkType { get; set; }
+    }
+
+    public class FormControlModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("controlType")]
+        public string ControlType { get; set; } = "";
+
+        [JsonPropertyName("dataSource")]
+        public string? DataSource { get; set; }
+
+        [JsonPropertyName("dataField")]
+        public string? DataField { get; set; }
+
+        [JsonPropertyName("children")]
+        public List<FormControlModel>? Children { get; set; }
+    }
+
+    // ========================
+    // Query / View / DataEntity models
+    // ========================
+
+    public class QueryInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("dataSources")]
+        public List<QueryDataSourceModel> DataSources { get; set; } = new List<QueryDataSourceModel>();
+    }
+
+    public class QueryDataSourceModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("table")]
+        public string Table { get; set; } = "";
+
+        [JsonPropertyName("joinMode")]
+        public string? JoinMode { get; set; }
+
+        [JsonPropertyName("childDataSources")]
+        public List<QueryDataSourceModel>? ChildDataSources { get; set; }
+    }
+
+    public class ViewInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("query")]
+        public string? Query { get; set; }
+
+        [JsonPropertyName("fields")]
+        public List<FieldInfoModel> Fields { get; set; } = new List<FieldInfoModel>();
+    }
+
+    public class DataEntityInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("publicEntityName")]
+        public string? PublicEntityName { get; set; }
+
+        [JsonPropertyName("publicCollectionName")]
+        public string? PublicCollectionName { get; set; }
+
+        [JsonPropertyName("isPublic")]
+        public bool IsPublic { get; set; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("dataSources")]
+        public List<FormDataSourceModel> DataSources { get; set; } = new List<FormDataSourceModel>();
+
+        [JsonPropertyName("fields")]
+        public List<FieldInfoModel> Fields { get; set; } = new List<FieldInfoModel>();
+    }
+
+    public class ReportInfoModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("dataSets")]
+        public List<string> DataSets { get; set; } = new List<string>();
+    }
+
+    // ========================
+    // Cross-reference models
+    // ========================
+
+    public class ReferenceInfoModel
+    {
+        [JsonPropertyName("sourcePath")]
+        public string SourcePath { get; set; } = "";
+
+        [JsonPropertyName("sourceModule")]
+        public string? SourceModule { get; set; }
+
+        [JsonPropertyName("kind")]
+        public string? Kind { get; set; }
+
+        [JsonPropertyName("line")]
+        public int Line { get; set; }
+
+        [JsonPropertyName("column")]
+        public int Column { get; set; }
+    }
+
+    // ========================
+    // Search models
+    // ========================
+
+    public class SearchResultModel
+    {
+        [JsonPropertyName("results")]
+        public List<SearchItemModel> Results { get; set; } = new List<SearchItemModel>();
+
+        [JsonPropertyName("totalCount")]
+        public int TotalCount { get; set; }
+    }
+
+    public class SearchItemModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "";
+
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+    }
+
+    public class MethodSourceModel
+    {
+        [JsonPropertyName("className")]
+        public string ClassName { get; set; } = "";
+
+        [JsonPropertyName("methodName")]
+        public string MethodName { get; set; } = "";
+
+        [JsonPropertyName("source")]
+        public string? Source { get; set; }
+
+        [JsonPropertyName("found")]
+        public bool Found { get; set; }
+    }
+}

--- a/bridge/D365MetadataBridge/Program.cs
+++ b/bridge/D365MetadataBridge/Program.cs
@@ -1,0 +1,239 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+using D365MetadataBridge.Protocol;
+using D365MetadataBridge.Services;
+
+namespace D365MetadataBridge
+{
+    /// <summary>
+    /// D365 Finance &amp; Operations Metadata Bridge
+    /// 
+    /// Provides access to D365FO metadata via Microsoft's official Dev Tools APIs
+    /// (IMetadataProvider, ICrossReferenceProvider) over a stdin/stdout JSON protocol.
+    /// 
+    /// This bridge is spawned by the Node.js MCP server as a child process.
+    /// All JSON messages are newline-delimited on stdout.
+    /// All diagnostic/log messages go to stderr (never stdout).
+    /// </summary>
+    static class Program
+    {
+        private static string _packagesPath = @"K:\AosService\PackagesLocalDirectory";
+        private static string? _binPath = null; // Explicit bin path (UDE: microsoftPackagesPath/bin)
+        private static string _xrefServer = "localhost";
+        private static string _xrefDatabase = "DYNAMICSXREFDB";
+        private static readonly TextWriter Log = Console.Error;
+
+        static async Task<int> Main(string[] args)
+        {
+            // Parse command-line arguments
+            for (int i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "--packages-path" when i + 1 < args.Length:
+                        _packagesPath = args[++i];
+                        break;
+                    case "--bin-path" when i + 1 < args.Length:
+                        _binPath = args[++i];
+                        break;
+                    case "--xref-server" when i + 1 < args.Length:
+                        _xrefServer = args[++i];
+                        break;
+                    case "--xref-database" when i + 1 < args.Length:
+                        _xrefDatabase = args[++i];
+                        break;
+                    case "--help":
+                        PrintUsage();
+                        return 0;
+                }
+            }
+
+            // Setup assembly resolution for D365FO DLLs.
+            // Traditional: {packagesPath}/bin
+            // UDE: --bin-path points to microsoftPackagesPath/bin (MS framework DLLs)
+            //      while --packages-path points to the custom packages root for metadata.
+            var primaryBinPath = _binPath ?? Path.Combine(_packagesPath, "bin");
+            if (!Directory.Exists(primaryBinPath))
+            {
+                Log.WriteLine($"[FATAL] D365FO bin path not found: {primaryBinPath}");
+                return 1;
+            }
+
+            // In UDE mode both bin directories may contain needed DLLs
+            var fallbackBinPath = _binPath != null ? Path.Combine(_packagesPath, "bin") : null;
+            SetupAssemblyResolution(primaryBinPath, fallbackBinPath);
+            Log.WriteLine($"[INFO] Assembly resolution configured for: {primaryBinPath}");
+            if (fallbackBinPath != null && Directory.Exists(fallbackBinPath))
+                Log.WriteLine($"[INFO] Additional assembly search path: {fallbackBinPath}");
+
+            // Initialize services
+            MetadataReadService? metadataService = null;
+            CrossReferenceService? xrefService = null;
+
+            try
+            {
+                Log.WriteLine($"[INFO] Initializing MetadataProvider from: {_packagesPath}");
+                metadataService = new MetadataReadService(_packagesPath);
+                Log.WriteLine("[INFO] MetadataProvider initialized successfully");
+            }
+            catch (Exception ex)
+            {
+                Log.WriteLine($"[ERROR] Failed to initialize MetadataProvider: {ex.Message}");
+                Log.WriteLine($"[ERROR] Stack: {ex.StackTrace}");
+                // Continue — we'll report errors for metadata calls but xref might still work
+            }
+
+            try
+            {
+                Log.WriteLine($"[INFO] Initializing CrossReferenceProvider: {_xrefServer}\\{_xrefDatabase}");
+                xrefService = new CrossReferenceService(_xrefServer, _xrefDatabase);
+                Log.WriteLine("[INFO] CrossReferenceProvider initialized successfully");
+            }
+            catch (Exception ex)
+            {
+                Log.WriteLine($"[WARN] Failed to initialize CrossReferenceProvider: {ex.Message}");
+                // Non-fatal — cross-references are optional
+            }
+
+            // Create request dispatcher
+            var dispatcher = new RequestDispatcher(metadataService, xrefService);
+
+            // Send ready signal
+            var readyResponse = new BridgeResponse
+            {
+                Id = "ready",
+                Result = JsonSerializer.SerializeToElement(new
+                {
+                    version = "1.0.0",
+                    status = "ready",
+                    packagesPath = _packagesPath,
+                    metadataAvailable = metadataService != null,
+                    xrefAvailable = xrefService != null
+                })
+            };
+            await WriteResponse(readyResponse);
+
+            Log.WriteLine("[INFO] Bridge ready, entering stdin/stdout loop");
+
+            // Enter stdin/stdout loop
+            return await RunStdioLoop(dispatcher);
+        }
+
+        private static async Task<int> RunStdioLoop(RequestDispatcher dispatcher)
+        {
+            var reader = new StreamReader(Console.OpenStandardInput());
+
+            string? line;
+            while ((line = await reader.ReadLineAsync()) != null)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                BridgeResponse response;
+                try
+                {
+                    var request = JsonSerializer.Deserialize<BridgeRequest>(line, JsonOptions.Default);
+                    if (request == null || string.IsNullOrEmpty(request.Method))
+                    {
+                        response = BridgeResponse.CreateError("?", -32600, "Invalid request");
+                    }
+                    else
+                    {
+                        Log.WriteLine($"[DEBUG] → {request.Method} (id={request.Id})");
+                        response = await dispatcher.Dispatch(request);
+                        Log.WriteLine($"[DEBUG] ← {request.Method} OK (id={request.Id})");
+                    }
+                }
+                catch (JsonException ex)
+                {
+                    Log.WriteLine($"[ERROR] JSON parse error: {ex.Message}");
+                    response = BridgeResponse.CreateError("?", -32700, $"Parse error: {ex.Message}");
+                }
+                catch (Exception ex)
+                {
+                    Log.WriteLine($"[ERROR] Unhandled: {ex.Message}\n{ex.StackTrace}");
+                    response = BridgeResponse.CreateError("?", -32603, $"Internal error: {ex.Message}");
+                }
+
+                await WriteResponse(response);
+            }
+
+            Log.WriteLine("[INFO] stdin closed, bridge exiting");
+            return 0;
+        }
+
+        private static async Task WriteResponse(BridgeResponse response)
+        {
+            var json = JsonSerializer.Serialize(response, JsonOptions.Default);
+            var stdout = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+            await stdout.WriteLineAsync(json);
+            await stdout.FlushAsync();
+        }
+
+        private static void SetupAssemblyResolution(string primaryBinPath, string? fallbackBinPath = null)
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+            {
+                var assemblyName = new AssemblyName(args.Name);
+                var dllName = assemblyName.Name + ".dll";
+
+                // Search primary bin path first, then fallback (UDE: both MS + custom)
+                foreach (var searchPath in new[] { primaryBinPath, fallbackBinPath })
+                {
+                    if (searchPath == null || !Directory.Exists(searchPath)) continue;
+                    var dllPath = Path.Combine(searchPath, dllName);
+                    if (File.Exists(dllPath))
+                    {
+                        Log.WriteLine($"[ASSEMBLY] Resolving {assemblyName.Name} from {dllPath}");
+                        try
+                        {
+                            return Assembly.LoadFrom(dllPath);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.WriteLine($"[ASSEMBLY] Failed to load {dllPath}: {ex.Message}");
+                        }
+                    }
+                }
+                return null;
+            };
+        }
+
+        private static void PrintUsage()
+        {
+            Console.Error.WriteLine(@"
+D365 Metadata Bridge — stdin/stdout JSON protocol for D365FO metadata access
+
+Usage:
+  D365MetadataBridge.exe [options]
+
+Options:
+  --packages-path <path>   Path to PackagesLocalDirectory (default: K:\AosService\PackagesLocalDirectory)
+  --bin-path <path>        Explicit DLL directory (UDE: microsoftPackagesPath\bin). If omitted, uses {packages-path}\bin.
+  --xref-server <server>   SQL Server for cross-reference DB (default: localhost)
+  --xref-database <db>     Cross-reference database name (default: DYNAMICSXREFDB)
+  --help                   Show this help
+
+Protocol:
+  Send JSON requests as single lines to stdin:
+    {""id"":""1"",""method"":""ping"",""params"":{}}
+  
+  Receive JSON responses on stdout (one per line):
+    {""id"":""1"",""result"":""pong""}
+
+Methods:
+  ping                              Health check
+  readTable     {tableName}         Read table metadata (fields, indexes, relations)
+  readClass     {className}         Read class metadata (methods, declaration)
+  readEnum      {enumName}          Read enum metadata (values)
+  readEdt       {edtName}           Read EDT metadata (base type, properties)
+  readForm      {formName}          Read form metadata (datasources, controls)
+  searchObjects {type, query}       Search for objects by name pattern
+  findReferences {objectPath}       Find cross-references (requires DYNAMICSXREFDB)
+");
+        }
+    }
+}

--- a/bridge/D365MetadataBridge/Protocol/BridgeProtocol.cs
+++ b/bridge/D365MetadataBridge/Protocol/BridgeProtocol.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace D365MetadataBridge.Protocol
+{
+    /// <summary>
+    /// JSON-RPC style request from the Node.js MCP server
+    /// </summary>
+    public class BridgeRequest
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("method")]
+        public string Method { get; set; } = "";
+
+        [JsonPropertyName("params")]
+        public JsonElement? Params { get; set; }
+
+        /// <summary>
+        /// Helper to extract a string parameter from Params
+        /// </summary>
+        public string? GetStringParam(string name)
+        {
+            if (Params == null || Params.Value.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (Params.Value.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String)
+                return prop.GetString();
+
+            return null;
+        }
+
+        /// <summary>
+        /// Helper to extract an integer parameter from Params
+        /// </summary>
+        public int? GetIntParam(string name)
+        {
+            if (Params == null || Params.Value.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (Params.Value.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.Number)
+                return prop.GetInt32();
+
+            return null;
+        }
+
+        /// <summary>
+        /// Helper to extract a boolean parameter from Params
+        /// </summary>
+        public bool? GetBoolParam(string name)
+        {
+            if (Params == null || Params.Value.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (Params.Value.TryGetProperty(name, out var prop) &&
+                (prop.ValueKind == JsonValueKind.True || prop.ValueKind == JsonValueKind.False))
+                return prop.GetBoolean();
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// JSON-RPC style response sent to the Node.js MCP server
+    /// </summary>
+    public class BridgeResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("result")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public JsonElement? Result { get; set; }
+
+        [JsonPropertyName("error")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public BridgeError? Error { get; set; }
+
+        public static BridgeResponse CreateSuccess(string id, object result)
+        {
+            return new BridgeResponse
+            {
+                Id = id,
+                Result = JsonSerializer.SerializeToElement(result, JsonOptions.Default)
+            };
+        }
+
+        public static BridgeResponse CreateError(string id, int code, string message)
+        {
+            return new BridgeResponse
+            {
+                Id = id,
+                Error = new BridgeError { Code = code, Message = message }
+            };
+        }
+    }
+
+    /// <summary>
+    /// Error object in the response
+    /// </summary>
+    public class BridgeError
+    {
+        [JsonPropertyName("code")]
+        public int Code { get; set; }
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = "";
+    }
+
+    /// <summary>
+    /// Shared JSON serializer options
+    /// </summary>
+    public static class JsonOptions
+    {
+        public static readonly JsonSerializerOptions Default = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = false
+        };
+    }
+}

--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Threading.Tasks;
+using D365MetadataBridge.Services;
+
+namespace D365MetadataBridge.Protocol
+{
+    /// <summary>
+    /// Routes incoming requests to the appropriate service method.
+    /// </summary>
+    public class RequestDispatcher
+    {
+        private readonly MetadataReadService? _metadataService;
+        private readonly CrossReferenceService? _xrefService;
+
+        public RequestDispatcher(MetadataReadService? metadataService, CrossReferenceService? xrefService)
+        {
+            _metadataService = metadataService;
+            _xrefService = xrefService;
+        }
+
+        public Task<BridgeResponse> Dispatch(BridgeRequest request)
+        {
+            try
+            {
+                switch (request.Method.ToLowerInvariant())
+                {
+                    // === Health ===
+                    case "ping":
+                        return Task.FromResult(BridgeResponse.CreateSuccess(request.Id, "pong"));
+
+                    // === Metadata Read ===
+                    case "readtable":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("tableName")
+                                ?? throw new ArgumentException("Missing parameter: tableName");
+                            return _metadataService!.ReadTable(name);
+                        });
+
+                    case "readclass":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("className")
+                                ?? throw new ArgumentException("Missing parameter: className");
+                            return _metadataService!.ReadClass(name);
+                        });
+
+                    case "readenum":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("enumName")
+                                ?? throw new ArgumentException("Missing parameter: enumName");
+                            return _metadataService!.ReadEnum(name);
+                        });
+
+                    case "readedt":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("edtName")
+                                ?? throw new ArgumentException("Missing parameter: edtName");
+                            return _metadataService!.ReadEdt(name);
+                        });
+
+                    case "readform":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("formName")
+                                ?? throw new ArgumentException("Missing parameter: formName");
+                            return _metadataService!.ReadForm(name);
+                        });
+
+                    case "readquery":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("queryName")
+                                ?? throw new ArgumentException("Missing parameter: queryName");
+                            return _metadataService!.ReadQuery(name);
+                        });
+
+                    case "readview":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("viewName")
+                                ?? throw new ArgumentException("Missing parameter: viewName");
+                            return _metadataService!.ReadView(name);
+                        });
+
+                    case "readdataentity":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("entityName")
+                                ?? throw new ArgumentException("Missing parameter: entityName");
+                            return _metadataService!.ReadDataEntity(name);
+                        });
+
+                    case "readreport":
+                        return HandleMetadata(request, () =>
+                        {
+                            var name = request.GetStringParam("reportName")
+                                ?? throw new ArgumentException("Missing parameter: reportName");
+                            return _metadataService!.ReadReport(name);
+                        });
+
+                    case "getmethodsource":
+                        return HandleMetadata(request, () =>
+                        {
+                            var className = request.GetStringParam("className")
+                                ?? throw new ArgumentException("Missing parameter: className");
+                            var methodName = request.GetStringParam("methodName")
+                                ?? throw new ArgumentException("Missing parameter: methodName");
+                            return _metadataService!.GetMethodSource(className, methodName);
+                        });
+
+                    // === Search ===
+                    case "searchobjects":
+                        return HandleMetadata(request, () =>
+                        {
+                            var type = request.GetStringParam("type") ?? "all";
+                            var query = request.GetStringParam("query")
+                                ?? throw new ArgumentException("Missing parameter: query");
+                            var maxResults = request.GetIntParam("maxResults") ?? 50;
+                            return _metadataService!.SearchObjects(type, query, maxResults);
+                        });
+
+                    case "listobjects":
+                        return HandleMetadata(request, () =>
+                        {
+                            var type = request.GetStringParam("type")
+                                ?? throw new ArgumentException("Missing parameter: type");
+                            return _metadataService!.ListObjects(type);
+                        });
+
+                    // === Cross-References ===
+                    case "findreferences":
+                        return HandleXref(request, () =>
+                        {
+                            var objectPath = request.GetStringParam("objectPath")
+                                ?? request.GetStringParam("targetName")
+                                ?? throw new ArgumentException("Missing parameter: objectPath or targetName");
+                            return _xrefService!.FindReferences(objectPath);
+                        });
+
+                    case "getxrefschema":
+                        return HandleXref(request, () =>
+                        {
+                            return _xrefService!.GetSchemaInfo();
+                        });
+
+                    case "samplexrefrows":
+                        return HandleXref(request, () =>
+                        {
+                            var tableName = request.GetStringParam("tableName") ?? "References";
+                            return _xrefService!.SampleRows(tableName);
+                        });
+
+                    // === Info ===
+                    case "getinfo":
+                        return Task.FromResult(BridgeResponse.CreateSuccess(request.Id, new
+                        {
+                            version = "1.0.0",
+                            metadataAvailable = _metadataService != null,
+                            xrefAvailable = _xrefService != null,
+                            capabilities = new[]
+                            {
+                                "ping", "readTable", "readClass", "readEnum", "readEdt",
+                                "readForm", "readQuery", "readView", "readDataEntity",
+                                "readReport", "getMethodSource", "searchObjects",
+                                "listObjects", "findReferences", "getInfo"
+                            }
+                        }));
+
+                    default:
+                        return Task.FromResult(
+                            BridgeResponse.CreateError(request.Id, -32601, $"Unknown method: {request.Method}"));
+                }
+            }
+            catch (Exception ex)
+            {
+                return Task.FromResult(
+                    BridgeResponse.CreateError(request.Id, -32603, $"Dispatch error: {ex.Message}"));
+            }
+        }
+
+        private Task<BridgeResponse> HandleMetadata(BridgeRequest request, Func<object?> handler)
+        {
+            if (_metadataService == null)
+                return Task.FromResult(
+                    BridgeResponse.CreateError(request.Id, -32000, "Metadata service not available"));
+
+            try
+            {
+                var result = handler();
+                if (result == null)
+                    return Task.FromResult(
+                        BridgeResponse.CreateError(request.Id, -32001, "Object not found"));
+
+                return Task.FromResult(BridgeResponse.CreateSuccess(request.Id, result));
+            }
+            catch (ArgumentException ex)
+            {
+                return Task.FromResult(
+                    BridgeResponse.CreateError(request.Id, -32602, ex.Message));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ERROR] {request.Method}: {ex.Message}\n{ex.StackTrace}");
+                return Task.FromResult(
+                    BridgeResponse.CreateError(request.Id, -32603, $"Error in {request.Method}: {ex.Message}"));
+            }
+        }
+
+        private Task<BridgeResponse> HandleXref(BridgeRequest request, Func<object?> handler)
+        {
+            if (_xrefService == null)
+                return Task.FromResult(
+                    BridgeResponse.CreateError(request.Id, -32000,
+                        "Cross-reference service not available (DYNAMICSXREFDB not configured)"));
+
+            try
+            {
+                var result = handler();
+                return Task.FromResult(BridgeResponse.CreateSuccess(request.Id, result ?? new object()));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ERROR] {request.Method}: {ex.Message}\n{ex.StackTrace}");
+                return Task.FromResult(
+                    BridgeResponse.CreateError(request.Id, -32603, $"Error in {request.Method}: {ex.Message}"));
+            }
+        }
+    }
+}

--- a/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
+++ b/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using D365MetadataBridge.Models;
+
+namespace D365MetadataBridge.Services
+{
+    /// <summary>
+    /// Provides cross-reference queries using the DYNAMICSXREFDB SQL database.
+    /// This replaces the FTS5 text-search approach with real compiler-resolved references.
+    /// </summary>
+    public class CrossReferenceService
+    {
+        private readonly string _connectionString;
+
+        public CrossReferenceService(string server, string database)
+        {
+            _connectionString = $"Server={server};Database={database};Integrated Security=True;TrustServerCertificate=True;";
+
+            // Test the connection
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+                Console.Error.WriteLine($"[CrossRefService] Connected to {server}\\{database}");
+            }
+        }
+
+        /// <summary>
+        /// Find all references to a given object path.
+        /// Object paths follow the D365FO convention:
+        ///   /Tables/CustTable
+        ///   /Tables/CustTable/Fields/AccountNum
+        ///   /Classes/SalesFormLetter/Methods/run
+        /// </summary>
+        public object FindReferences(string objectPath)
+        {
+            var references = new List<ReferenceInfoModel>();
+
+            // Schema: Names(Id, Path, ProviderId, ModuleId), References(SourceId, TargetId, Kind, Line, Column)
+            // Modules(Id, Module), Providers(Id, Provider)
+            // Path format: /Classes/ClassName, /Tables/TableName, /Enums/EnumName, etc.
+            // If user passes plain name (e.g. "CustTable"), try common prefixes
+
+            var pathVariants = new List<string>();
+            if (objectPath.StartsWith("/"))
+            {
+                pathVariants.Add(objectPath);
+            }
+            else
+            {
+                // Try common AOT path prefixes
+                pathVariants.Add($"/Tables/{objectPath}");
+                pathVariants.Add($"/Classes/{objectPath}");
+                pathVariants.Add($"/Enums/{objectPath}");
+                pathVariants.Add($"/Views/{objectPath}");
+                pathVariants.Add($"/DataEntityViews/{objectPath}");
+                pathVariants.Add($"/Queries/{objectPath}");
+                pathVariants.Add($"/Forms/{objectPath}");
+            }
+
+            // Build parameterized IN clause
+            var paramNames = new List<string>();
+            for (int i = 0; i < pathVariants.Count; i++) paramNames.Add($"@P{i}");
+
+            const string queryTemplate = @"
+                SELECT TOP 500
+                    src.Path AS SourcePath,
+                    sm.Module AS SourceModule,
+                    r.Kind,
+                    r.Line,
+                    r.[Column]
+                FROM [References] r
+                INNER JOIN dbo.Names tgt ON tgt.Id = r.TargetId
+                INNER JOIN dbo.Names src ON src.Id = r.SourceId
+                LEFT  JOIN dbo.Modules sm ON sm.Id = src.ModuleId
+                WHERE tgt.Path IN ({0})
+                ORDER BY src.Path, r.Line";
+
+            var query = string.Format(queryTemplate, string.Join(",", paramNames));
+
+            try
+            {
+                using (var conn = new SqlConnection(_connectionString))
+                {
+                    conn.Open();
+                    using (var cmd = new SqlCommand(query, conn))
+                    {
+                        for (int i = 0; i < pathVariants.Count; i++)
+                            cmd.Parameters.AddWithValue($"@P{i}", pathVariants[i]);
+                        cmd.CommandTimeout = 30;
+
+                        using (var reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                references.Add(new ReferenceInfoModel
+                                {
+                                    SourcePath = reader.GetString(0),
+                                    SourceModule = reader.IsDBNull(1) ? null : reader.GetString(1),
+                                    Kind = reader.IsDBNull(2) ? null : reader.GetByte(2).ToString(),
+                                    Line = reader.IsDBNull(3) ? 0 : (int)reader.GetInt16(3),
+                                    Column = reader.IsDBNull(4) ? 0 : (int)reader.GetInt16(4),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            catch (SqlException ex)
+            {
+                Console.Error.WriteLine($"[CrossRefService] SQL error: {ex.Message}");
+                return FindReferencesViaApi(objectPath);
+            }
+
+            return new { objectPath, count = references.Count, references };
+        }
+
+        /// <summary>
+        /// Fallback: Use the MS XReference provider API directly.
+        /// This requires the Xlnt DLLs and a valid cross-reference database.
+        /// </summary>
+        private object FindReferencesViaApi(string objectPath)
+        {
+            try
+            {
+                // Try using the Xlnt XReference API
+                // This is wrapped in a separate method to avoid assembly loading issues
+                // if the Xlnt DLLs are not available
+                return FindReferencesViaXlntApi(objectPath);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[CrossRefService] XRef API also failed: {ex.Message}");
+                return new
+                {
+                    objectPath,
+                    count = 0,
+                    references = new List<ReferenceInfoModel>(),
+                    error = $"Cross-reference query failed. SQL error and XRef API unavailable: {ex.Message}"
+                };
+            }
+        }
+
+        private object FindReferencesViaXlntApi(string objectPath)
+        {
+            // Lazy-load the Xlnt assemblies to avoid TypeLoadException if DLLs are missing
+            // The actual implementation uses:
+            //   ICrossReferenceProvider xrefProvider = CrossReferenceProviderFactory
+            //       .CreateSqlCrossReferenceProvider(server, database);
+            //   var refs = xrefProvider.FindReferences("", objectPath, CrossReferenceKind.Any);
+
+            // For Phase 1, return a stub
+            return new
+            {
+                objectPath,
+                count = 0,
+                references = new List<ReferenceInfoModel>(),
+                note = "XRef API integration pending — use SQL direct query for now"
+            };
+        }
+
+        /// <summary>
+        /// Discover the actual schema of the DYNAMICSXREFDB for debugging.
+        /// </summary>
+        public object GetSchemaInfo()
+        {
+            var tables = new List<object>();
+
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+                // Get tables
+                var tableNames = new List<string>();
+                using (var cmd = new SqlCommand(
+                    "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' ORDER BY TABLE_NAME",
+                    conn))
+                {
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read()) tableNames.Add(reader.GetString(0));
+                    }
+                }
+
+                // Get columns for each table
+                foreach (var tbl in tableNames)
+                {
+                    var cols = new List<string>();
+                    using (var cmd = new SqlCommand(
+                        $"SELECT COLUMN_NAME + ' (' + DATA_TYPE + ')' FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = @T ORDER BY ORDINAL_POSITION",
+                        conn))
+                    {
+                        cmd.Parameters.AddWithValue("@T", tbl);
+                        using (var reader = cmd.ExecuteReader())
+                        {
+                            while (reader.Read()) cols.Add(reader.GetString(0));
+                        }
+                    }
+                    tables.Add(new { table = tbl, columns = cols });
+                }
+            }
+
+            return new { database = "DYNAMICSXREFDB", tables };
+        }
+
+        /// <summary>
+        /// Sample rows from a table for debugging.
+        /// </summary>
+        public object SampleRows(string tableName)
+        {
+            // Sanitize table name (only allow alphanumeric and underscore)
+            if (!System.Text.RegularExpressions.Regex.IsMatch(tableName, @"^[a-zA-Z_]\w*$"))
+                throw new ArgumentException("Invalid table name");
+
+            var rows = new List<Dictionary<string, object?>>();
+
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+                using (var cmd = new SqlCommand($"SELECT TOP 10 * FROM [{tableName}]", conn))
+                {
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            var row = new Dictionary<string, object?>();
+                            for (int i = 0; i < reader.FieldCount; i++)
+                            {
+                                row[reader.GetName(i)] = reader.IsDBNull(i) ? null : reader.GetValue(i)?.ToString();
+                            }
+                            rows.Add(row);
+                        }
+                    }
+                }
+            }
+
+            return new { tableName, count = rows.Count, rows };
+        }
+    }
+}

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -1,0 +1,416 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using D365MetadataBridge.Models;
+using Microsoft.Dynamics.AX.Metadata.MetaModel;
+using Microsoft.Dynamics.AX.Metadata.Providers;
+using Microsoft.Dynamics.AX.Metadata.Storage;
+
+namespace D365MetadataBridge.Services
+{
+    /// <summary>
+    /// Reads D365FO metadata using Microsoft's official IMetadataProvider API.
+    /// Uses CreateDiskProvider (standalone mode, no VS/instrumentation dependency).
+    /// </summary>
+    public class MetadataReadService
+    {
+        private readonly IMetadataProvider _provider;
+
+        public MetadataReadService(string packagesPath)
+        {
+            // Use DiskProvider (standalone mode) — avoids .NET Framework EventDescriptor dependency
+            var factory = new MetadataProviderFactory();
+            _provider = factory.CreateDiskProvider(packagesPath);
+            Console.Error.WriteLine($"[MetadataService] Initialized via DiskProvider: {packagesPath}");
+        }
+
+        // ========================
+        // TABLE
+        // ========================
+        public TableInfoModel? ReadTable(string tableName)
+        {
+            if (!_provider.Tables.Exists(tableName)) return null;
+            var table = _provider.Tables.Read(tableName);
+            if (table == null) return null;
+
+            var result = new TableInfoModel
+            {
+                Name = table.Name,
+                Label = Safe(() => table.Label),
+                DeveloperDocumentation = Safe(() => table.DeveloperDocumentation),
+                TableGroup = Safe(() => table.TableGroup.ToString()),
+                TableType = Safe(() => table.TableType.ToString()),
+                CacheLookup = Safe(() => table.CacheLookup.ToString()),
+                ClusteredIndex = Safe(() => table.ClusteredIndex),
+                PrimaryIndex = Safe(() => table.PrimaryIndex),
+                Extends = Safe(() => table.Extends),
+                SaveDataPerCompany = Safe(() => table.SaveDataPerCompany.ToString()),
+                SupportInheritance = Safe(() => table.SupportInheritance.ToString()),
+            };
+
+            try { var mi = _provider.Tables.GetModelInfo(tableName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
+
+            try { foreach (var f in table.Fields) result.Fields.Add(MapField(f)); } catch (Exception ex) { Warn("fields", tableName, ex); }
+            try { foreach (var g in table.FieldGroups) { var gm = new FieldGroupModel { Name = g.Name, Label = Safe(() => g.Label) }; try { foreach (var f in g.Fields) gm.Fields.Add(Safe(() => f.DataField) ?? f.Name); } catch { } result.FieldGroups.Add(gm); } } catch (Exception ex) { Warn("fieldGroups", tableName, ex); }
+            try { foreach (var i in table.Indexes) { var im = new IndexInfoModel { Name = i.Name, AllowDuplicates = IsYes(() => i.AllowDuplicates), AlternateKey = IsYes(() => i.AlternateKey) }; try { foreach (var f in i.Fields) im.Fields.Add(new IndexFieldModel { DataField = Safe(() => f.DataField) ?? f.Name, IncludedColumn = IsYes(() => f.IncludedColumn) }); } catch { } result.Indexes.Add(im); } } catch (Exception ex) { Warn("indexes", tableName, ex); }
+
+            try
+            {
+                foreach (var r in table.Relations)
+                {
+                    var rm = new RelationInfoModel
+                    {
+                        Name = r.Name,
+                        RelatedTable = Safe(() => r.RelatedTable) ?? "",
+                        Cardinality = Safe(() => r.Cardinality.ToString()),
+                        RelatedTableCardinality = Safe(() => r.RelatedTableCardinality.ToString()),
+                    };
+                    try
+                    {
+                        foreach (var c in r.Constraints)
+                        {
+                            var cm = new RelationConstraintModel();
+                            if (c is AxTableRelationConstraintField fc) { cm.Field = fc.Field; cm.RelatedField = fc.RelatedField; }
+                            else if (c is AxTableRelationConstraintFixed xc) { cm.Field = xc.Field; cm.Value = xc.Value.ToString(); }
+                            rm.Constraints.Add(cm);
+                        }
+                    }
+                    catch { }
+                    result.Relations.Add(rm);
+                }
+            }
+            catch (Exception ex) { Warn("relations", tableName, ex); }
+
+            try { if (table.Methods != null) foreach (var m in table.Methods) result.Methods.Add(new MethodInfoModel { Name = m.Name, Source = Safe(() => m.Source) }); } catch (Exception ex) { Warn("methods", tableName, ex); }
+
+            return result;
+        }
+
+        // ========================
+        // CLASS
+        // ========================
+        public ClassInfoModel? ReadClass(string className)
+        {
+            if (!_provider.Classes.Exists(className)) return null;
+            var cls = _provider.Classes.Read(className);
+            if (cls == null) return null;
+
+            var result = new ClassInfoModel
+            {
+                Name = cls.Name,
+                IsAbstract = cls.IsAbstract,
+                IsFinal = cls.IsFinal,
+                IsStatic = cls.IsStatic,
+                Extends = Safe(() => cls.Extends),
+                Declaration = Safe(() => cls.Declaration),
+            };
+
+            try { var mi = _provider.Classes.GetModelInfo(className); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
+
+            // Methods from cls.Methods (KeyedObjectCollection<AxMethod>) — the actual methods with source
+            // Note: cls.SourceCode.Methods is AxMethodPropertyCollection (empty for disk reads) — DON'T use it
+            try
+            {
+                if (cls.Methods != null)
+                {
+                    foreach (var method in cls.Methods)
+                    {
+                        result.Methods.Add(new MethodInfoModel
+                        {
+                            Name = method.Name,
+                            Source = Safe(() => method.Source),
+                        });
+                    }
+                }
+            }
+            catch (Exception ex) { Warn("methods", className, ex); }
+
+            return result;
+        }
+
+        // ========================
+        // METHOD SOURCE
+        // ========================
+        public MethodSourceModel GetMethodSource(string className, string methodName)
+        {
+            var result = new MethodSourceModel { ClassName = className, MethodName = methodName };
+
+            // Try class first
+            if (_provider.Classes.Exists(className))
+            {
+                var cls = _provider.Classes.Read(className);
+                if (cls != null)
+                {
+                    if (string.Equals(methodName, "classDeclaration", StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.Source = cls.Declaration;
+                        result.Found = result.Source != null;
+                        return result;
+                    }
+
+                    try
+                    {
+                        if (cls.Methods != null)
+                        {
+                            foreach (var method in cls.Methods)
+                            {
+                                if (string.Equals(method.Name, methodName, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    result.MethodName = method.Name;
+                                    result.Source = method.Source;
+                                    result.Found = true;
+                                    return result;
+                                }
+                            }
+                        }
+                    }
+                    catch { }
+                }
+            }
+
+            // Try table
+            if (_provider.Tables.Exists(className))
+            {
+                var table = _provider.Tables.Read(className);
+                if (table?.Methods != null)
+                {
+                    try
+                    {
+                        foreach (var method in table.Methods)
+                        {
+                            if (string.Equals(method.Name, methodName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                result.MethodName = method.Name;
+                                result.Source = method.Source;
+                                result.Found = true;
+                                return result;
+                            }
+                        }
+                    }
+                    catch { }
+                }
+            }
+
+            return result;
+        }
+
+        // ========================
+        // ENUM
+        // ========================
+        public EnumInfoModel? ReadEnum(string enumName)
+        {
+            if (!_provider.Enums.Exists(enumName)) return null;
+            var e = _provider.Enums.Read(enumName);
+            if (e == null) return null;
+
+            var result = new EnumInfoModel { Name = e.Name, Label = Safe(() => e.Label), HelpText = Safe(() => e.HelpText) };
+            try { result.IsExtensible = e.IsExtensible; } catch { }
+            try { var mi = _provider.Enums.GetModelInfo(enumName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
+
+            try
+            {
+                int idx = 0;
+                foreach (var v in e.EnumValues)
+                {
+                    result.Values.Add(new EnumValueModel { Name = v.Name, Value = SafeInt(() => v.Value, idx), Label = Safe(() => v.Label) });
+                    idx++;
+                }
+            }
+            catch (Exception ex) { Warn("values", enumName, ex); }
+
+            return result;
+        }
+
+        // ========================
+        // EDT
+        // ========================
+        public EdtInfoModel? ReadEdt(string edtName)
+        {
+            if (!_provider.Edts.Exists(edtName)) return null;
+            var edt = _provider.Edts.Read(edtName);
+            if (edt == null) return null;
+
+            var result = new EdtInfoModel
+            {
+                Name = edt.Name,
+                BaseType = edt.GetType().Name.Replace("AxEdt", ""),
+                Extends = Safe(() => edt.Extends),
+                Label = Safe(() => edt.Label),
+                HelpText = Safe(() => edt.HelpText),
+            };
+
+            try { var mi = _provider.Edts.GetModelInfo(edtName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
+            if (edt is AxEdtString s) result.StringSize = SafeInt(() => s.StringSize, 0);
+            if (edt is AxEdtEnum en) result.EnumType = Safe(() => en.EnumType);
+            try { result.ReferenceTable = Safe(() => ((dynamic)edt).ReferenceTable?.Table); } catch { }
+
+            return result;
+        }
+
+        // ========================
+        // FORM
+        // ========================
+        public FormInfoModel? ReadForm(string formName)
+        {
+            if (!_provider.Forms.Exists(formName)) return null;
+            var form = _provider.Forms.Read(formName);
+            if (form == null) return null;
+
+            var result = new FormInfoModel { Name = form.Name };
+            try { var mi = _provider.Forms.GetModelInfo(formName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
+
+            try { if (form.DataSources != null) foreach (var ds in form.DataSources) result.DataSources.Add(new FormDataSourceModel { Name = ds.Name, Table = Safe(() => ds.Table) ?? "", JoinSource = Safe(() => ds.JoinSource) }); } catch (Exception ex) { Warn("datasources", formName, ex); }
+            try { if (form.Design?.Controls != null) MapControls(form.Design.Controls, result.Controls, 0); } catch (Exception ex) { Warn("controls", formName, ex); }
+
+            return result;
+        }
+
+        private void MapControls(dynamic? controls, List<FormControlModel> target, int depth)
+        {
+            if (controls == null || depth > 15) return;
+            try
+            {
+                foreach (dynamic c in controls!)
+                {
+                    try
+                    {
+                        var cm = new FormControlModel { Name = Safe(() => (string)c.Name) ?? "", ControlType = ((object)c).GetType().Name.Replace("AxFormControl", "") };
+                        try { cm.DataSource = Safe(() => (string)c.DataSource); cm.DataField = Safe(() => (string)c.DataField); } catch { }
+                        try { if (c.Controls != null) { cm.Children = new List<FormControlModel>(); MapControls(c.Controls, cm.Children, depth + 1); if (cm.Children.Count == 0) cm.Children = null; } } catch { }
+                        target.Add(cm);
+                    }
+                    catch { }
+                }
+            }
+            catch { }
+        }
+
+        // ========================
+        // QUERY / VIEW / DATA ENTITY / REPORT
+        // ========================
+        public QueryInfoModel? ReadQuery(string queryName)
+        {
+            if (!_provider.Queries.Exists(queryName)) return null;
+            var q = _provider.Queries.Read(queryName);
+            if (q == null) return null;
+            var result = new QueryInfoModel { Name = q.Name };
+            try { var mi = _provider.Queries.GetModelInfo(queryName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
+            return result;
+        }
+
+        public ViewInfoModel? ReadView(string viewName)
+        {
+            if (!_provider.Views.Exists(viewName)) return null;
+            var v = _provider.Views.Read(viewName);
+            if (v == null) return null;
+            var result = new ViewInfoModel { Name = v.Name, Label = Safe(() => v.Label), Query = Safe(() => v.Query) };
+            try { var mi = _provider.Views.GetModelInfo(viewName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
+            try { if (v.Fields != null) foreach (var f in v.Fields) result.Fields.Add(new FieldInfoModel { Name = f.Name, FieldType = f.GetType().Name.Replace("AxViewField", "") }); } catch { }
+            return result;
+        }
+
+        public DataEntityInfoModel? ReadDataEntity(string entityName)
+        {
+            if (!_provider.DataEntityViews.Exists(entityName)) return null;
+            var e = _provider.DataEntityViews.Read(entityName);
+            if (e == null) return null;
+            var result = new DataEntityInfoModel { Name = e.Name, Label = Safe(() => e.Label), PublicEntityName = Safe(() => e.PublicEntityName), PublicCollectionName = Safe(() => e.PublicCollectionName), IsPublic = IsYes(() => e.IsPublic) };
+            try { var mi = _provider.DataEntityViews.GetModelInfo(entityName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
+            try { if (e.Fields != null) foreach (var f in e.Fields) result.Fields.Add(new FieldInfoModel { Name = f.Name, FieldType = f.GetType().Name }); } catch { }
+            return result;
+        }
+
+        public ReportInfoModel? ReadReport(string reportName)
+        {
+            try
+            {
+                if (!_provider.Reports.Exists(reportName)) return null;
+                var r = _provider.Reports.Read(reportName);
+                return r == null ? null : new ReportInfoModel { Name = r.Name };
+            }
+            catch { return null; }
+        }
+
+        // ========================
+        // SEARCH / LIST
+        // ========================
+        public SearchResultModel SearchObjects(string type, string query, int maxResults)
+        {
+            var result = new SearchResultModel();
+            void Search(string objType, IList<string> keys)
+            {
+                foreach (var n in keys)
+                {
+                    if (result.Results.Count >= maxResults) return;
+                    if (n.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0)
+                        result.Results.Add(new SearchItemModel { Name = n, Type = objType });
+                }
+            }
+
+            try
+            {
+                switch (type.ToLowerInvariant())
+                {
+                    case "table": Search("table", _provider.Tables.GetPrimaryKeys()); break;
+                    case "class": Search("class", _provider.Classes.GetPrimaryKeys()); break;
+                    case "enum": Search("enum", _provider.Enums.GetPrimaryKeys()); break;
+                    case "edt": Search("edt", _provider.Edts.GetPrimaryKeys()); break;
+                    case "form": Search("form", _provider.Forms.GetPrimaryKeys()); break;
+                    default:
+                        Search("table", _provider.Tables.GetPrimaryKeys());
+                        Search("class", _provider.Classes.GetPrimaryKeys());
+                        Search("enum", _provider.Enums.GetPrimaryKeys());
+                        Search("edt", _provider.Edts.GetPrimaryKeys());
+                        Search("form", _provider.Forms.GetPrimaryKeys());
+                        break;
+                }
+            }
+            catch (Exception ex) { Console.Error.WriteLine($"[WARN] Search error: {ex.Message}"); }
+
+            result.TotalCount = result.Results.Count;
+            return result;
+        }
+
+        public object ListObjects(string type)
+        {
+            IList<string> keys = type.ToLowerInvariant() switch
+            {
+                "table" => _provider.Tables.GetPrimaryKeys(),
+                "class" => _provider.Classes.GetPrimaryKeys(),
+                "enum" => _provider.Enums.GetPrimaryKeys(),
+                "edt" => _provider.Edts.GetPrimaryKeys(),
+                "form" => _provider.Forms.GetPrimaryKeys(),
+                "view" => _provider.Views.GetPrimaryKeys(),
+                "query" => _provider.Queries.GetPrimaryKeys(),
+                "dataentity" => _provider.DataEntityViews.GetPrimaryKeys(),
+                _ => new List<string>()
+            };
+            return new { type, count = keys.Count, names = keys };
+        }
+
+        // ========================
+        // HELPERS
+        // ========================
+        private static string? Safe(Func<string?> f) { try { return f(); } catch { return null; } }
+        private static bool IsYes(Func<object> f) { try { return f()?.ToString() == "Yes"; } catch { return false; } }
+        private static int SafeInt(Func<int> f, int d) { try { return f(); } catch { return d; } }
+        private static void Warn(string section, string obj, Exception ex) => Console.Error.WriteLine($"[WARN] Error reading {section} for {obj}: {ex.Message}");
+
+        private FieldInfoModel MapField(AxTableField field)
+        {
+            var m = new FieldInfoModel
+            {
+                Name = field.Name,
+                FieldType = field.GetType().Name.Replace("AxTableField", ""),
+                ExtendedDataType = Safe(() => field.ExtendedDataType),
+                Label = Safe(() => field.Label),
+                HelpText = Safe(() => field.HelpText),
+                Mandatory = IsYes(() => field.Mandatory),
+                AllowEdit = Safe(() => field.AllowEdit.ToString()),
+            };
+            if (field is AxTableFieldString s) m.StringSize = SafeInt(() => s.StringSize, 0);
+            if (field is AxTableFieldEnum en) m.EnumType = Safe(() => en.EnumType);
+            return m;
+        }
+    }
+}

--- a/d365fo-mcp-server.sln
+++ b/d365fo-mcp-server.sln
@@ -1,0 +1,29 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "bridge", "bridge", "{68BF4094-9419-05A7-776B-98D5B493D877}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D365MetadataBridge", "bridge\D365MetadataBridge\D365MetadataBridge.csproj", "{B7F15E56-837C-0C37-9776-5F800A887019}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B7F15E56-837C-0C37-9776-5F800A887019}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7F15E56-837C-0C37-9776-5F800A887019}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7F15E56-837C-0C37-9776-5F800A887019}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7F15E56-837C-0C37-9776-5F800A887019}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B7F15E56-837C-0C37-9776-5F800A887019} = {68BF4094-9419-05A7-776B-98D5B493D877}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {23F56E3B-8D32-415A-92A3-7956DD3F6C62}
+	EndGlobalSection
+EndGlobal

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -1,0 +1,644 @@
+# C# Metadata Bridge
+
+The C# Metadata Bridge connects the Node.js MCP server to Microsoft's official
+D365 Finance & Operations Dev Tools API (`IMetadataProvider`) and cross-reference
+database (`DYNAMICSXREFDB`) via a .NET Framework 4.8 child process.
+
+It provides **live, always-current** metadata access on Windows D365FO development
+VMs. On Azure/Linux deployments where D365FO is not installed, the bridge is
+simply absent and the server falls back to its pre-built SQLite index — there is
+zero behavioral change.
+
+---
+
+## Table of Contents
+
+- [Why a Bridge?](#why-a-bridge)
+- [Architecture](#architecture)
+- [Process Lifecycle](#process-lifecycle)
+- [Integration into Tool Handlers](#integration-into-tool-handlers)
+- [Request Flow — End to End](#request-flow--end-to-end)
+- [JSON-RPC Protocol](#json-rpc-protocol)
+- [C# Components](#c-components)
+- [TypeScript Components](#typescript-components)
+- [Supported Endpoints](#supported-endpoints)
+- [Data Source Comparison](#data-source-comparison)
+- [Deployment Scenarios](#deployment-scenarios)
+- [Configuration](#configuration)
+- [Building the Bridge](#building-the-bridge)
+- [Testing](#testing)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Why a Bridge?
+
+The existing MCP server uses a **pre-built SQLite database** containing 584,799+
+symbols extracted from D365FO metadata XML files. This works everywhere (Azure,
+Linux, CI/CD), but has limitations:
+
+| Limitation | Bridge Solution |
+|---|---|
+| Data is a point-in-time snapshot (stale after code changes) | Live API reads current runtime metadata |
+| XML parsing is fragile (ISV models may use non-standard structures) | Microsoft's own parser handles all edge cases |
+| Cross-references are approximated via FTS text search | Exact compiler cross-references from `DYNAMICSXREFDB` |
+| No access to computed/inherited properties | `IMetadataProvider` resolves full inheritance chains |
+
+The bridge is an **additive enhancement** — it does not replace any existing logic.
+
+---
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "Node.js Process"
+        MCP[MCP Server]
+        TH[Tool Handlers<br/>tableInfo, classInfo, ...]
+        BA[bridgeAdapter.ts<br/>tryBridge* functions]
+        BC[bridgeClient.ts<br/>BridgeClient class]
+        SI[(SQLite DB<br/>584K+ symbols)]
+        PARSER[XML Parser]
+    end
+
+    subgraph "C# Child Process (.NET 4.8)"
+        RD[RequestDispatcher]
+        MRS[MetadataReadService]
+        XRS[CrossReferenceService]
+        IMP[IMetadataProvider<br/>Microsoft Dev Tools API]
+        XREF[(DYNAMICSXREFDB<br/>SQL Server)]
+    end
+
+    MCP --> TH
+    TH -->|"1. try bridge"| BA
+    BA --> BC
+    BC -->|"stdin: JSON-RPC"| RD
+    RD --> MRS
+    RD --> XRS
+    MRS --> IMP
+    XRS --> XREF
+    RD -->|"stdout: JSON-RPC"| BC
+
+    TH -->|"2. fallback"| SI
+    TH -->|"2. fallback"| PARSER
+
+    style BA fill:#4CAF50,color:#fff
+    style BC fill:#4CAF50,color:#fff
+    style MRS fill:#0078D4,color:#fff
+    style XRS fill:#0078D4,color:#fff
+    style IMP fill:#68217A,color:#fff
+    style XREF fill:#DC382D,color:#fff
+```
+
+---
+
+## Process Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant Node as Node.js MCP Server
+    participant Bridge as D365MetadataBridge.exe
+
+    Note over Node: Server startup (stdio mode)
+    Node->>Node: Step 3b — async, non-blocking
+    Node->>Bridge: spawn(exe, --packages-path K:\AosService\...)
+    Bridge->>Bridge: Load Microsoft.Dynamics.*.dll
+    Bridge->>Bridge: Initialize IMetadataProvider
+    Bridge->>Bridge: Connect to DYNAMICSXREFDB (optional)
+    Bridge-->>Node: stdout: {"id":"ready","result":{"metadataAvailable":true,"xrefAvailable":true}}
+    Node->>Node: stubContext.bridge = client
+    Note over Node: Bridge ready — tool handlers can use it
+
+    loop Every tool call
+        Node->>Bridge: stdin: {"id":"42","method":"readTable","params":{"tableName":"CustTable"}}
+        Bridge->>Bridge: IMetadataProvider.Tables.Read("CustTable")
+        Bridge-->>Node: stdout: {"id":"42","result":{...fields, indexes, relations...}}
+    end
+
+    Note over Node: Server shutdown
+    Node->>Bridge: stdin.end()
+    Bridge->>Bridge: Graceful exit
+```
+
+**Startup is non-blocking.** The bridge is initialized inside `void (async () => { ... })()` in
+`src/index.ts` (Step 3b). The MCP server is fully operational immediately — the SQLite
+database loads in parallel (Step 4). When the bridge becomes ready, it is assigned to
+`stubContext.bridge` and tool handlers begin using it automatically.
+
+If the bridge fails to start (no D365FO installed, missing DLLs, wrong path), a one-line
+info message is logged and the server continues with SQLite-only mode.
+
+---
+
+## Integration into Tool Handlers
+
+Every read-only tool handler follows the same **try-first, fall-through** pattern:
+
+```typescript
+// Example: src/tools/tableInfo.ts
+
+import { tryBridgeTable } from '../bridge/bridgeAdapter.js';
+
+export async function tableInfoTool(request, context) {
+    const args = TableInfoArgsSchema.parse(request.params.arguments);
+
+    // ① Cache hit → return immediately (unchanged)
+    const cached = await cache.get(cacheKey);
+    if (cached) return formatCached(cached);
+
+    // ② Bridge attempt → returns result or null
+    const bridgeResult = await tryBridgeTable(context.bridge, args.tableName, args.methodOffset);
+    if (bridgeResult) return bridgeResult;
+
+    // ③ Existing SQLite + XML parser logic (completely unchanged)
+    const tableSymbol = symbolIndex.getSymbolByName(args.tableName, 'table');
+    const tableInfo = await parser.parseTableFile(tableSymbol.filePath, tableSymbol.model);
+    // ... format and return
+}
+```
+
+The `tryBridge*()` functions in `bridgeAdapter.ts` return `null` when:
+- `context.bridge` is `undefined` (bridge not connected)
+- `bridge.isReady` is `false` (process died or not yet initialized)
+- The bridge call threw an error (caught and logged, returns `null`)
+- The object was not found (bridge returned `null`)
+
+In all of these cases, the existing logic runs as if the bridge didn't exist.
+
+### Integrated Tool Handlers
+
+| Tool | Adapter Function | Bridge Data Source |
+|---|---|---|
+| `get_table_info` | `tryBridgeTable()` | `IMetadataProvider.Tables` |
+| `get_class_info` | `tryBridgeClass()` | `IMetadataProvider.Classes` |
+| `get_method_source` | `tryBridgeMethodSource()` | `IMetadataProvider.Classes` |
+| `get_form_info` | `tryBridgeForm()` | `IMetadataProvider.Forms` |
+| `get_enum_info` | `tryBridgeEnum()` | `IMetadataProvider.Enums` |
+| `get_edt_info` | `tryBridgeEdt()` | `IMetadataProvider.Edts` |
+| `find_references` | `tryBridgeReferences()` | `DYNAMICSXREFDB` |
+| `search` | `tryBridgeSearch()` | `IMetadataProvider` (multi-type) |
+
+### Tools NOT Using the Bridge (Phase 2 — future)
+
+These tools perform write operations or use specialized logic that doesn't benefit from the bridge:
+
+- `create_d365fo_file`, `modify_d365fo_file` — file write operations
+- `generate_smart_table`, `generate_smart_form`, `generate_smart_report` — code generation
+- `analyze_extension_points`, `recommend_extension_strategy` — analysis heuristics
+- `find_coc_extensions`, `find_event_handlers` — SQLite FTS pattern matching
+- `get_query_info`, `get_view_info`, `get_data_entity_info`, `get_report_info` — not yet wired
+
+---
+
+## Request Flow — End to End
+
+Here is what happens when an AI client calls `get_table_info("CustTable")`:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  1. IDE sends MCP tool call: get_table_info({tableName:"CustTable"})│
+└───────────────────────────────┬──────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  2. tableInfoTool() — check cache                                    │
+│     Cache miss → continue                                            │
+└───────────────────────────────┬──────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  3. tryBridgeTable(context.bridge, "CustTable")                      │
+│     ├─ bridge.isReady? ✅                                            │
+│     ├─ bridge.readTable("CustTable")                                 │
+│     │   ├─ JSON-RPC → stdin:  {"id":"1","method":"readTable",        │
+│     │   │                      "params":{"tableName":"CustTable"}}   │
+│     │   ├─ C#: IMetadataProvider.Tables.Read("CustTable")            │
+│     │   ├─ C#: Map fields, indexes, relations, methods → JSON        │
+│     │   └─ JSON-RPC ← stdout: {"id":"1","result":{...}}              │
+│     ├─ formatTable() → markdown with fields/indexes/relations        │
+│     └─ return { content: [{type:'text', text: markdown}] }           │
+│                                                                      │
+│  ✅ DONE — SQLite/parser code never executes                         │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+If the bridge is unavailable, step 3 returns `null` in ~0ms and the flow continues:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  3. tryBridgeTable(undefined, "CustTable")                           │
+│     └─ !bridge?.isReady → return null                                │
+└───────────────────────────────┬──────────────────────────────────────┘
+                                │
+                                ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│  4. symbolIndex.getSymbolByName("CustTable", "table")                │
+│     → SQLite query → {filePath, model}                               │
+│  5. parser.parseTableFile(filePath, model)                           │
+│     → Read XML, extract fields/indexes/relations/methods             │
+│  6. Format markdown, cache, return                                   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## JSON-RPC Protocol
+
+Communication between Node.js and the C# process uses **newline-delimited JSON-RPC**
+over stdin (requests) and stdout (responses). Stderr is reserved for diagnostics.
+
+### Request Format
+
+```json
+{
+  "id": "42",
+  "method": "readTable",
+  "params": {
+    "tableName": "CustTable"
+  }
+}
+```
+
+### Response Format (success)
+
+```json
+{
+  "id": "42",
+  "result": {
+    "name": "CustTable",
+    "label": "Customers",
+    "model": "ApplicationSuite",
+    "fields": [...],
+    "indexes": [...],
+    "relations": [...]
+  }
+}
+```
+
+### Response Format (error)
+
+```json
+{
+  "id": "42",
+  "error": {
+    "code": -32001,
+    "message": "Object not found"
+  }
+}
+```
+
+### Special Messages
+
+| Message | Direction | Purpose |
+|---|---|---|
+| `{"id":"ready","result":{...}}` | C# → Node | Sent once after initialization. Contains `metadataAvailable` and `xrefAvailable` flags. |
+| `{"id":"N","method":"ping"}` | Node → C# | Health check. Returns `"pong"`. |
+| `{"id":"N","method":"getInfo"}` | Node → C# | Returns version, capabilities, and status. |
+
+### Error Codes
+
+| Code | Meaning |
+|---|---|
+| `-32601` | Unknown method |
+| `-32602` | Invalid/missing parameters |
+| `-32000` | Service not available (metadata or xref) |
+| `-32001` | Object not found |
+| `-32603` | Internal error |
+
+---
+
+## C# Components
+
+Located in `bridge/D365MetadataBridge/`:
+
+```
+D365MetadataBridge/
+├── Program.cs                      Entry point — arg parsing, DLL loading, process loop
+├── D365MetadataBridge.csproj       .NET Framework 4.8 project
+├── Protocol/
+│   ├── BridgeProtocol.cs           Request/Response/Error JSON models
+│   └── RequestDispatcher.cs        Routes methods to service handlers
+├── Services/
+│   ├── MetadataReadService.cs      IMetadataProvider wrapper (tables, classes, enums, ...)
+│   └── CrossReferenceService.cs    DYNAMICSXREFDB SQL queries
+└── Models/
+    └── Models.cs                   C# POCOs matching TypeScript bridge types
+```
+
+### MetadataReadService
+
+Wraps `Microsoft.Dynamics.AX.Metadata.MetaModel.IMetadataProvider` with typed
+read methods:
+
+| Method | D365FO API Used | Returns |
+|---|---|---|
+| `ReadTable(name)` | `provider.Tables.Read(name)` | Fields, indexes, relations, methods |
+| `ReadClass(name)` | `provider.Classes.Read(name)` | Declaration, methods with source, inheritance |
+| `ReadEnum(name)` | `provider.Enums.Read(name)` | Values with labels and integer values |
+| `ReadEdt(name)` | `provider.Edts.Read(name)` | Base type, extends, constraints |
+| `ReadForm(name)` | `provider.Forms.Read(name)` | Data sources, control tree |
+| `ReadQuery(name)` | `provider.Queries.Read(name)` | Data sources, ranges, sorting |
+| `ReadView(name)` | `provider.Views.Read(name)` | Fields, data sources |
+| `ReadDataEntity(name)` | `provider.DataEntityViews.Read(name)` | Fields, keys, data sources |
+| `ReadReport(name)` | `provider.Reports.Read(name)` | Datasets, parameters, designs |
+| `GetMethodSource(class, method)` | `provider.Classes.Read(class)` | Full X++ source of one method |
+| `SearchObjects(type, query, max)` | Iterates `provider.*.GetPrimaryKeys()` | Matching object names |
+| `ListObjects(type)` | `provider.*.GetPrimaryKeys()` | All object names of a type |
+
+### CrossReferenceService
+
+Connects to `DYNAMICSXREFDB` on the local SQL Server (or a configured instance) and
+executes cross-reference queries:
+
+| Method | SQL Table | Returns |
+|---|---|---|
+| `FindReferences(path)` | `References`, `Names`, `Path` | All callers/references to an object |
+| `GetSchemaInfo()` | `INFORMATION_SCHEMA` | Available tables and columns |
+| `SampleRows(table)` | Any table | Sample data for debugging |
+
+### DLL Loading
+
+The bridge loads Microsoft assemblies at runtime from the D365FO packages directory:
+
+```
+{packagesPath}/bin/
+├── Microsoft.Dynamics.AX.Metadata.dll
+├── Microsoft.Dynamics.AX.Metadata.Core.dll
+├── Microsoft.Dynamics.AX.Metadata.Storage.dll
+├── Microsoft.Dynamics.ApplicationPlatform.Xti.Server.dll
+└── ... (additional dependencies resolved via AssemblyResolve)
+```
+
+`Program.cs` registers an `AppDomain.CurrentDomain.AssemblyResolve` handler to find
+these DLLs automatically. For UDE environments, a separate `--bin-path` argument
+points to the Microsoft framework bin directory.
+
+---
+
+## TypeScript Components
+
+Located in `src/bridge/`:
+
+```
+src/bridge/
+├── index.ts              Barrel exports for all bridge types and functions
+├── bridgeClient.ts       BridgeClient class — spawn, JSON-RPC, typed methods
+├── bridgeTypes.ts        ~35 TypeScript interfaces matching C# models
+└── bridgeAdapter.ts      8 tryBridge*() adapter functions for tool handlers
+```
+
+### BridgeClient (`bridgeClient.ts`)
+
+Singleton class managing the child process lifecycle:
+
+- **`initialize()`** — Spawns the `.exe`, waits for the `"ready"` JSON message (30s timeout)
+- **`call<T>(method, params)`** — Sends JSON-RPC request, returns typed promise (60s timeout)
+- **`dispose()`** — Gracefully shuts down the child process
+- **14 typed convenience methods** — `readTable()`, `readClass()`, `findReferences()`, etc.
+
+Properties:
+- `isReady` — Process is running and initialized
+- `metadataAvailable` — `IMetadataProvider` API loaded successfully
+- `xrefAvailable` — `DYNAMICSXREFDB` connection is active
+
+### Bridge Types (`bridgeTypes.ts`)
+
+TypeScript interfaces that mirror the C# model classes:
+
+```typescript
+interface BridgeTableInfo {
+  name: string;
+  label?: string;
+  model?: string;
+  tableGroup?: string;
+  fields: BridgeFieldInfo[];
+  indexes: BridgeIndexInfo[];
+  relations: BridgeRelationInfo[];
+  methods: BridgeMethodInfo[];
+  // ...
+}
+```
+
+### Bridge Adapter (`bridgeAdapter.ts`)
+
+Eight `tryBridge*()` functions, one per tool handler. Each:
+
+1. Checks `bridge?.isReady` (and `bridge.metadataAvailable` or `bridge.xrefAvailable`)
+2. Calls the appropriate bridge method
+3. Formats the response into markdown matching the tool's existing output style
+4. Returns a `ToolResult` object — or `null` to signal fallback
+
+```typescript
+export async function tryBridgeTable(
+  bridge: BridgeClient | undefined,
+  tableName: string,
+  methodOffset = 0,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return null;
+  try {
+    const t = await bridge.readTable(tableName);
+    if (!t) return null;
+    return { content: [{ type: 'text', text: formatTable(t, methodOffset) }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] readTable(${tableName}) failed: ${e}`);
+    return null;     // ← fallback to SQLite
+  }
+}
+```
+
+All bridge-sourced output includes a `_Source: C# bridge (IMetadataProvider)_` marker
+so the AI client can distinguish it from SQLite-sourced data.
+
+---
+
+## Supported Endpoints
+
+| Method | Parameters | Response Type | Source |
+|---|---|---|---|
+| `ping` | — | `"pong"` | Health |
+| `getInfo` | — | Version, capabilities, flags | Health |
+| `readTable` | `tableName` | `BridgeTableInfo` | IMetadataProvider |
+| `readClass` | `className` | `BridgeClassInfo` | IMetadataProvider |
+| `readEnum` | `enumName` | `BridgeEnumInfo` | IMetadataProvider |
+| `readEdt` | `edtName` | `BridgeEdtInfo` | IMetadataProvider |
+| `readForm` | `formName` | `BridgeFormInfo` | IMetadataProvider |
+| `readQuery` | `queryName` | `BridgeQueryInfo` | IMetadataProvider |
+| `readView` | `viewName` | `BridgeViewInfo` | IMetadataProvider |
+| `readDataEntity` | `entityName` | `BridgeDataEntityInfo` | IMetadataProvider |
+| `readReport` | `reportName` | `BridgeReportInfo` | IMetadataProvider |
+| `getMethodSource` | `className`, `methodName` | `BridgeMethodSource` | IMetadataProvider |
+| `searchObjects` | `query`, `type?`, `maxResults?` | `BridgeSearchResult` | IMetadataProvider |
+| `listObjects` | `type` | `BridgeListResult` | IMetadataProvider |
+| `findReferences` | `targetName` / `objectPath` | `BridgeReferenceResult` | DYNAMICSXREFDB |
+| `getXrefSchema` | — | Schema info | DYNAMICSXREFDB |
+| `sampleXrefRows` | `tableName?` | Sample data | DYNAMICSXREFDB |
+
+---
+
+## Data Source Comparison
+
+| Aspect | SQLite + XML Parser | C# Bridge |
+|---|---|---|
+| **Data freshness** | Snapshot at build time | Always live |
+| **Availability** | Everywhere (Azure, Linux, CI) | Windows with D365FO only |
+| **Startup time** | ~2s (load .db file) | ~5–15s (load MS DLLs + init provider) |
+| **Per-call latency** | ~1–5ms (SQLite) + ~10–50ms (XML parse) | ~20–100ms (IPC + API call) |
+| **Coverage** | 584K+ symbols across all standard models | Everything the runtime knows about |
+| **Cross-references** | Approximate (FTS text matching) | Exact (compiler XRef database) |
+| **Inherited properties** | Not resolved (flat XML only) | Fully resolved by the API |
+| **Custom/ISV models** | Only if pre-indexed | Automatically available if deployed |
+| **Output marker** | _(none)_ | `_Source: C# bridge (IMetadataProvider)_` |
+
+---
+
+## Deployment Scenarios
+
+### Scenario 1: Windows D365FO Dev VM (full bridge)
+
+```
+MCP Server (stdio) ─── D365MetadataBridge.exe ─── IMetadataProvider
+                                                └── DYNAMICSXREFDB
+```
+
+- Bridge auto-starts at server launch
+- All 8 tool handlers use bridge as primary source
+- SQLite serves as fallback (bridge process crash, specific object not found)
+
+### Scenario 2: Azure App Service / Linux (no bridge)
+
+```
+MCP Server (HTTP) ─── SQLite DB ─── XML parser
+```
+
+- Bridge is not started (no .exe, no D365FO DLLs)
+- `context.bridge` remains `undefined`
+- All `tryBridge*()` calls return `null` instantly (~0ms overhead)
+- Identical behavior to pre-bridge versions
+
+### Scenario 3: UDE (Unified Developer Experience)
+
+```
+MCP Server (stdio) ─── D365MetadataBridge.exe ─── IMetadataProvider
+                        (--bin-path points to              │
+                         microsoftPackagesPath/bin)         │
+                                                      (no DYNAMICSXREFDB)
+```
+
+- Bridge starts with separate `--bin-path` for Microsoft framework DLLs
+- `metadataAvailable: true`, `xrefAvailable: false`
+- Metadata tools use bridge; `find_references` falls back to SQLite FTS
+
+---
+
+## Configuration
+
+The bridge is configured automatically from the existing `.mcp.json` settings:
+
+```json
+{
+  "servers": {
+    "context": {
+      "modelName": "ContosoExt",
+      "packagePath": "K:\\AosService\\PackagesLocalDirectory",
+      "projectPath": "K:\\repos\\ContosoExt\\ContosoExt.rnrproj"
+    }
+  }
+}
+```
+
+- **`packagePath`** → passed as `--packages-path` to the bridge exe
+- **UDE detection** → if `devEnvironmentType === 'ude'`, `microsoftPackagesPath/bin`
+  is passed as `--bin-path`
+- **XRef database** → defaults to `localhost` / `DYNAMICSXREFDB`. Override with
+  environment variables or `BridgeClientOptions`.
+
+No additional configuration is needed. The bridge is opt-in by presence — if the
+`.exe` exists and D365FO DLLs are accessible, it starts automatically.
+
+---
+
+## Building the Bridge
+
+### Prerequisites
+
+- .NET Framework 4.8 Developer Pack (or Visual Studio 2022 with .NET desktop workload)
+- D365FO development VM (for the Microsoft.Dynamics.*.dll references)
+
+### Build
+
+```bash
+cd bridge/D365MetadataBridge
+dotnet build -c Release
+```
+
+The output is placed in `bridge/D365MetadataBridge/bin/Release/`.
+
+The `BridgeClient` auto-detects the exe location by searching:
+1. `options.bridgeExePath` (explicit override)
+2. `bridge/D365MetadataBridge/bin/Release/D365MetadataBridge.exe` (relative to repo)
+3. `bridge/D365MetadataBridge/bin/Debug/D365MetadataBridge.exe` (debug build)
+
+---
+
+## Testing
+
+### E2E Test (requires D365FO VM)
+
+```bash
+npx tsx tests/bridge-e2e.ts
+```
+
+This spawns the real bridge process, runs 12 integration tests against live metadata,
+and reports results. Covers: ping, readTable, readClass, getMethodSource, readEnum,
+readEdt, readForm, readQuery, readView, readDataEntity, searchObjects, and findReferences.
+
+### Unit Tests (no D365FO required)
+
+The existing vitest suite (231 tests) verifies that all tool handlers work correctly
+when the bridge is absent (`context.bridge = undefined`). The `tryBridge*()` calls
+return `null` and the SQLite/parser path executes as before.
+
+```bash
+npm test -- --run
+```
+
+---
+
+## Troubleshooting
+
+### Bridge doesn't start
+
+**Symptom:** `ℹ️  C# bridge not available: ...` in server logs.
+
+**Common causes:**
+- D365MetadataBridge.exe not built → run `dotnet build` in the bridge directory
+- `packagePath` in `.mcp.json` is incorrect → fix the path to PackagesLocalDirectory
+- Microsoft.Dynamics.*.dll not found → verify `{packagePath}/bin/` contains the DLLs
+- Running on Linux/macOS → bridge is Windows-only (expected behavior)
+
+### Bridge starts but metadata is unavailable
+
+**Symptom:** `metadataAvailable: false` in the ready message.
+
+**Common causes:**
+- D365FO is not deployed to PackagesLocalDirectory
+- DLL version mismatch (old bridge exe with newer D365FO update)
+- Assembly binding failure → check bridge stderr for `[ERROR]` messages
+
+### Bridge starts but XRef is unavailable
+
+**Symptom:** `xrefAvailable: false` in the ready message.
+
+**Common causes:**
+- SQL Server is not running on the VM
+- DYNAMICSXREFDB database does not exist (run full DB sync + XRef update in D365FO)
+- SQL authentication issues → bridge uses Windows Integrated Auth by default
+
+### Tool returns SQLite data despite bridge being connected
+
+**Symptom:** Output does not contain `_Source: C# bridge_` marker.
+
+**Common causes:**
+- The result was served from cache (cache hit occurs before bridge check)
+- The specific tool handler is not yet wired to the bridge (Phase 2 tools)
+- The bridge returned `null` for that object (not found in IMetadataProvider)

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -1,0 +1,395 @@
+/**
+ * Bridge Adapter — Converts C# bridge responses into the markdown format
+ * expected by MCP tool handlers.
+ *
+ * Each function returns a pre-formatted MCP tool result (content array)
+ * or null if the bridge couldn't provide the data.
+ *
+ * Usage pattern inside a tool handler:
+ *   const bridgeResult = await tryBridgeTable(context.bridge, tableName, methodOffset);
+ *   if (bridgeResult) return bridgeResult;
+ *   // ... fallback to SQLite/parser ...
+ */
+
+import type { BridgeClient } from './bridgeClient.js';
+import type {
+  BridgeTableInfo,
+  BridgeClassInfo,
+} from './bridgeTypes.js';
+
+/** Standard MCP tool response shape */
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// TABLE
+// ════════════════════════════════════════════════════════════════════════
+
+const TABLE_METHOD_PAGE_SIZE = 25;
+
+export async function tryBridgeTable(
+  bridge: BridgeClient | undefined,
+  tableName: string,
+  methodOffset = 0,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return null;
+  try {
+    const t = await bridge.readTable(tableName);
+    if (!t) return null;
+    return { content: [{ type: 'text', text: formatTable(t, methodOffset) }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] readTable(${tableName}) failed: ${e}`);
+    return null;
+  }
+}
+
+function formatTable(t: BridgeTableInfo, methodOffset: number): string {
+  let out = `# Table: ${t.name}\n\n`;
+  if (t.label) out += `**Label:** ${t.label}\n`;
+  if (t.tableGroup) out += `**Table Group:** ${t.tableGroup}\n`;
+  if (t.model) out += `**Model:** ${t.model}\n`;
+  if (t.extends) out += `**Extends:** ${t.extends}\n`;
+  if (t.cacheLookup) out += `**CacheLookup:** ${t.cacheLookup}\n`;
+  if (t.clusteredIndex) out += `**ClusteredIndex:** ${t.clusteredIndex}\n`;
+  if (t.primaryIndex) out += `**PrimaryIndex:** ${t.primaryIndex}\n`;
+  out += `_Source: C# bridge (IMetadataProvider)_\n\n`;
+
+  // Fields
+  out += `## Fields (${t.fields.length})\n\n`;
+  out += `_Field type is shown as explicit EDT when available._\n\n`;
+  for (const f of t.fields) {
+    const required = f.mandatory ? ' **(required)**' : '';
+    const label = f.label ? ` - ${f.label}` : '';
+    const typeInfo = f.extendedDataType
+      ? `EDT: ${f.extendedDataType} (base: ${f.fieldType})`
+      : `Type: ${f.fieldType}`;
+    out += `- **${f.name}**: ${typeInfo}${required}${label}\n`;
+  }
+
+  // Indexes
+  out += `\n## Indexes (${t.indexes.length})\n\n`;
+  for (const idx of t.indexes) {
+    const unique = !idx.allowDuplicates ? ' **(unique)**' : '';
+    const fieldNames = idx.fields.map((f: any) => typeof f === 'string' ? f : f.dataField ?? f.name).join(', ');
+    out += `- **${idx.name}**: [${fieldNames}]${unique}\n`;
+  }
+
+  // Relations
+  out += `\n## Relations (${t.relations.length})\n\n`;
+  for (const rel of t.relations) {
+    out += `- **${rel.name}** → ${rel.relatedTable}\n`;
+    for (const c of rel.constraints) {
+      if (c.field && c.relatedField) {
+        out += `  - ${c.field} = ${c.relatedField}\n`;
+      } else if (c.field && c.value) {
+        out += `  - ${c.field} = (fixed: ${c.value})\n`;
+      }
+    }
+  }
+
+  // Methods (paginated)
+  if (t.methods.length > 0) {
+    const visible = t.methods.slice(methodOffset, methodOffset + TABLE_METHOD_PAGE_SIZE);
+    const total = t.methods.length;
+    const hasMore = methodOffset + TABLE_METHOD_PAGE_SIZE < total;
+
+    out += `\n## Methods (${total} total`;
+    if (total > TABLE_METHOD_PAGE_SIZE) {
+      out += `, showing ${methodOffset + 1}–${Math.min(methodOffset + TABLE_METHOD_PAGE_SIZE, total)}`;
+    }
+    out += `)\n\n`;
+
+    for (const m of visible) {
+      out += `### ${m.name}\n\n`;
+      if (m.source) {
+        const preview = m.source.substring(0, 500);
+        out += `\`\`\`xpp\n${preview}${m.source.length > 500 ? '\n// ...' : ''}\n\`\`\`\n\n`;
+      }
+    }
+
+    if (hasMore) {
+      out += `> ⚠️ **${total - methodOffset - TABLE_METHOD_PAGE_SIZE} more methods.** Call again with \`methodOffset: ${methodOffset + TABLE_METHOD_PAGE_SIZE}\`.\n\n`;
+    }
+  }
+
+  return out;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// CLASS
+// ════════════════════════════════════════════════════════════════════════
+
+const CLASS_METHOD_PAGE_SIZE = 15;
+
+export async function tryBridgeClass(
+  bridge: BridgeClient | undefined,
+  className: string,
+  compact: boolean,
+  methodOffset = 0,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return null;
+  try {
+    const cls = await bridge.readClass(className);
+    if (!cls) return null;
+    return { content: [{ type: 'text', text: formatClass(cls, compact, methodOffset) }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] readClass(${className}) failed: ${e}`);
+    return null;
+  }
+}
+
+function formatClass(cls: BridgeClassInfo, compact: boolean, methodOffset: number): string {
+  const modifiers: string[] = [];
+  if (cls.isFinal) modifiers.push('final');
+  if (cls.isAbstract) modifiers.push('abstract');
+  const modStr = modifiers.length > 0 ? ` (${modifiers.join(', ')})` : '';
+
+  let out = `# Class: ${cls.name}${modStr}\n\n`;
+  if (cls.extends) out += `**Extends:** ${cls.extends}\n`;
+  if (cls.model) out += `**Model:** ${cls.model}\n`;
+  out += `**Abstract:** ${cls.isAbstract ? 'Yes' : 'No'}\n`;
+  out += `**Final:** ${cls.isFinal ? 'Yes' : 'No'}\n`;
+  out += `_Source: C# bridge (IMetadataProvider)_\n\n`;
+
+  if (!compact && cls.declaration) {
+    out += `## Declaration\n\`\`\`xpp\n${cls.declaration}\n\`\`\`\n\n`;
+  }
+
+  const total = cls.methods.length;
+  const visible = cls.methods.slice(methodOffset, methodOffset + CLASS_METHOD_PAGE_SIZE);
+  const hasMore = methodOffset + CLASS_METHOD_PAGE_SIZE < total;
+
+  out += `## Methods (${total} total`;
+  if (total > CLASS_METHOD_PAGE_SIZE) {
+    out += `, showing ${methodOffset + 1}–${Math.min(methodOffset + CLASS_METHOD_PAGE_SIZE, total)}`;
+  }
+  out += `)\n\n`;
+
+  for (const m of visible) {
+    if (compact) {
+      // Signature-only: extract first line of source for signature
+      const sig = m.source ? m.source.split('\n')[0].trim() : m.name;
+      out += `- \`${sig}\`\n`;
+    } else {
+      out += `### ${m.name}\n\n`;
+      if (m.source) {
+        const preview = m.source.substring(0, 500);
+        out += `\`\`\`xpp\n${preview}${m.source.length > 500 ? '\n// ... (use get_method_source for full body)' : ''}\n\`\`\`\n\n`;
+      }
+    }
+  }
+
+  if (hasMore) {
+    out += `> ⚠️ **${total - methodOffset - CLASS_METHOD_PAGE_SIZE} more methods.** Call again with \`methodOffset: ${methodOffset + CLASS_METHOD_PAGE_SIZE}\`.\n\n`;
+  }
+
+  return out;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// METHOD SOURCE
+// ════════════════════════════════════════════════════════════════════════
+
+export async function tryBridgeMethodSource(
+  bridge: BridgeClient | undefined,
+  className: string,
+  methodName: string,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return null;
+  try {
+    const ms = await bridge.getMethodSource(className, methodName);
+    if (!ms.found || !ms.source) return null;
+    const text =
+      `# ${ms.className}.${ms.methodName}\n\n` +
+      `_Source: C# bridge (IMetadataProvider)_\n\n` +
+      `\`\`\`xpp\n${ms.source}\n\`\`\``;
+    return { content: [{ type: 'text', text }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] getMethodSource(${className}, ${methodName}) failed: ${e}`);
+    return null;
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// ENUM
+// ════════════════════════════════════════════════════════════════════════
+
+export async function tryBridgeEnum(
+  bridge: BridgeClient | undefined,
+  enumName: string,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return null;
+  try {
+    const en = await bridge.readEnum(enumName);
+    if (!en) return null;
+
+    let out = `# Enum: ${en.name}\n\n`;
+    if (en.label) out += `**Label:** ${en.label}\n`;
+    if (en.model) out += `**Model:** ${en.model}\n`;
+    out += `**Extensible:** ${en.isExtensible ? 'Yes' : 'No'}\n`;
+    out += `_Source: C# bridge (IMetadataProvider)_\n\n`;
+
+    out += `## Values (${en.values.length})\n\n`;
+    for (const v of en.values) {
+      const lbl = v.label ? ` - ${v.label}` : '';
+      out += `- **${v.name}** = ${v.value}${lbl}\n`;
+    }
+
+    return { content: [{ type: 'text', text: out }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] readEnum(${enumName}) failed: ${e}`);
+    return null;
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// EDT
+// ════════════════════════════════════════════════════════════════════════
+
+export async function tryBridgeEdt(
+  bridge: BridgeClient | undefined,
+  edtName: string,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return null;
+  try {
+    const edt = await bridge.readEdt(edtName);
+    if (!edt) return null;
+
+    let out = `# EDT: ${edt.name}\n\n`;
+    if (edt.baseType) out += `**Base Type:** ${edt.baseType}\n`;
+    if (edt.extends) out += `**Extends:** ${edt.extends}\n`;
+    if (edt.label) out += `**Label:** ${edt.label}\n`;
+    if (edt.helpText) out += `**Help Text:** ${edt.helpText}\n`;
+    if (edt.stringSize) out += `**String Size:** ${edt.stringSize}\n`;
+    if (edt.enumType) out += `**Enum Type:** ${edt.enumType}\n`;
+    if (edt.referenceTable) out += `**Reference Table:** ${edt.referenceTable}\n`;
+    if (edt.model) out += `**Model:** ${edt.model}\n`;
+    out += `_Source: C# bridge (IMetadataProvider)_\n`;
+
+    return { content: [{ type: 'text', text: out }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] readEdt(${edtName}) failed: ${e}`);
+    return null;
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// FORM
+// ════════════════════════════════════════════════════════════════════════
+
+export async function tryBridgeForm(
+  bridge: BridgeClient | undefined,
+  formName: string,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return null;
+  try {
+    const form = await bridge.readForm(formName);
+    if (!form) return null;
+
+    let out = `# Form: ${form.name}\n\n`;
+    if (form.model) out += `**Model:** ${form.model}\n`;
+    out += `_Source: C# bridge (IMetadataProvider)_\n\n`;
+
+    out += `## Data Sources (${form.dataSources.length})\n\n`;
+    for (const ds of form.dataSources) {
+      const join = ds.joinSource ? ` (join: ${ds.joinSource})` : '';
+      out += `- **${ds.name}** → ${ds.table}${join}\n`;
+    }
+
+    out += `\n## Controls (${form.controls.length} top-level)\n\n`;
+    formatControlTree(form.controls, out, 0);
+    // formatControlTree appends to a local — rebuild via helper
+    out += buildControlTree(form.controls, 0);
+
+    return { content: [{ type: 'text', text: out }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] readForm(${formName}) failed: ${e}`);
+    return null;
+  }
+}
+
+function buildControlTree(controls: Array<{ name: string; controlType: string; dataSource?: string; dataField?: string; children?: any[] }>, depth: number): string {
+  if (!controls || depth > 10) return '';
+  let out = '';
+  const indent = '  '.repeat(depth);
+  for (const c of controls) {
+    const binding = c.dataSource && c.dataField ? ` [${c.dataSource}.${c.dataField}]` : '';
+    out += `${indent}- **${c.name}** (${c.controlType})${binding}\n`;
+    if (c.children?.length) {
+      out += buildControlTree(c.children, depth + 1);
+    }
+  }
+  return out;
+}
+
+function formatControlTree(_controls: any[], _out: string, _depth: number): void {
+  // no-op — buildControlTree handles this
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// FIND REFERENCES
+// ════════════════════════════════════════════════════════════════════════
+
+export async function tryBridgeReferences(
+  bridge: BridgeClient | undefined,
+  targetName: string,
+  limit = 50,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.xrefAvailable) return null;
+  try {
+    const refs = await bridge.findReferences(targetName);
+    if (!refs || refs.count === 0) return null;
+
+    let out = `# References to \`${targetName}\`\n\n`;
+    out += `**Total:** ${refs.count} reference(s) found\n`;
+    out += `_Source: C# bridge (DYNAMICSXREFDB)_\n\n`;
+
+    const visible = refs.references.slice(0, limit);
+    for (const r of visible) {
+      const module = r.sourceModule ? ` [${r.sourceModule}]` : '';
+      const loc = r.line > 0 ? `:${r.line}` : '';
+      out += `- **${r.sourcePath}**${loc}${module}\n`;
+    }
+
+    if (refs.count > limit) {
+      out += `\n> ⚠️ Showing first ${limit} of ${refs.count} references.\n`;
+    }
+
+    return { content: [{ type: 'text', text: out }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] findReferences(${targetName}) failed: ${e}`);
+    return null;
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// SEARCH
+// ════════════════════════════════════════════════════════════════════════
+
+export async function tryBridgeSearch(
+  bridge: BridgeClient | undefined,
+  query: string,
+  objectType?: string,
+  maxResults = 50,
+): Promise<ToolResult | null> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return null;
+  try {
+    const sr = await bridge.searchObjects(query, objectType);
+    if (!sr || sr.results.length === 0) return null;
+
+    let out = `# Search: "${query}"${objectType ? ` (type: ${objectType})` : ''}\n\n`;
+    out += `**Results:** ${sr.results.length}\n`;
+    out += `_Source: C# bridge (IMetadataProvider)_\n\n`;
+
+    for (const r of sr.results.slice(0, maxResults)) {
+      out += `- **${r.name}** (${r.type})\n`;
+    }
+
+    return { content: [{ type: 'text', text: out }] };
+  } catch (e) {
+    console.error(`[BridgeAdapter] searchObjects(${query}) failed: ${e}`);
+    return null;
+  }
+}

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -1,0 +1,444 @@
+/**
+ * BridgeClient — Manages the C# D365MetadataBridge child process.
+ *
+ * Protocol: newline-delimited JSON-RPC over stdin/stdout.
+ * Stderr: diagnostics/logging (forwarded to console.error).
+ *
+ * Lifecycle:
+ *   1. `initialize()` — spawns the .exe, waits for "ready" JSON
+ *   2. `call(method, params)` — sends a request, returns promise of response
+ *   3. `dispose()` — kills the child process
+ *
+ * The client is designed to be a singleton field on XppServerContext.
+ * It is only initialized when running on a Windows VM with D365FO installed.
+ */
+
+import { ChildProcess, spawn } from 'child_process';
+import { EventEmitter } from 'events';
+import * as path from 'path';
+import * as fs from 'fs';
+import { fileURLToPath } from 'url';
+import type {
+  BridgeResponse,
+  BridgeReadyPayload,
+  BridgeInfoPayload,
+  BridgeTableInfo,
+  BridgeClassInfo,
+  BridgeEnumInfo,
+  BridgeEdtInfo,
+  BridgeFormInfo,
+  BridgeQueryInfo,
+  BridgeViewInfo,
+  BridgeDataEntityInfo,
+  BridgeReportInfo,
+  BridgeReferenceResult,
+  BridgeSearchResult,
+  BridgeMethodSource,
+  BridgeListResult,
+} from './bridgeTypes.js';
+
+// Re-export types for convenience
+export type { BridgeReadyPayload, BridgeInfoPayload } from './bridgeTypes.js';
+export * from './bridgeTypes.js';
+
+const BRIDGE_EXE_NAME = 'D365MetadataBridge.exe';
+const READY_TIMEOUT_MS = 30_000;   // 30s for metadata provider init
+const CALL_TIMEOUT_MS = 60_000;    // 60s per call (large searches can take time)
+
+export interface BridgeClientOptions {
+  /** Path to the D365MetadataBridge.exe (auto-detected if omitted) */
+  bridgeExePath?: string;
+  /** K:\AosService\PackagesLocalDirectory */
+  packagesPath: string;
+  /**
+   * Explicit path to the D365FO bin directory containing Microsoft.Dynamics.*.dll.
+   * Traditional: omit — defaults to {packagesPath}/bin.
+   * UDE: set to microsoftPackagesPath/bin (the FrameworkDirectory bin folder).
+   */
+  binPath?: string;
+  /** SQL Server instance for cross-references (default: localhost) */
+  xrefServer?: string;
+  /** XRef database name (default: DYNAMICSXREFDB) */
+  xrefDatabase?: string;
+  /** Timeout for the ready signal in ms */
+  readyTimeoutMs?: number;
+  /** Timeout for each RPC call in ms */
+  callTimeoutMs?: number;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class BridgeClient extends EventEmitter {
+  private process: ChildProcess | null = null;
+  private buffer = '';
+  private requestId = 0;
+  private pending = new Map<string, PendingRequest>();
+  private readyPayload: BridgeReadyPayload | null = null;
+  private _isReady = false;
+  private _disposed = false;
+
+  public readonly options: BridgeClientOptions;
+
+  constructor(options: BridgeClientOptions) {
+    super();
+    this.options = options;
+  }
+
+  /** Whether the bridge process is running and the metadata provider initialized */
+  get isReady(): boolean { return this._isReady && !this._disposed; }
+
+  /** Whether the MS metadata API is available (set after ready) */
+  get metadataAvailable(): boolean { return this.readyPayload?.metadataAvailable ?? false; }
+
+  /** Whether the cross-reference DB is available (set after ready) */
+  get xrefAvailable(): boolean { return this.readyPayload?.xrefAvailable ?? false; }
+
+  /** The ready payload from the bridge process */
+  get ready(): BridgeReadyPayload | null { return this.readyPayload; }
+
+  // ========================================
+  // Lifecycle
+  // ========================================
+
+  /**
+   * Spawn the C# bridge process and wait for the "ready" message.
+   * Resolves with the BridgeReadyPayload on success.
+   * Rejects if the process fails to start or doesn't send ready in time.
+   */
+  async initialize(): Promise<BridgeReadyPayload> {
+    if (this._disposed) throw new Error('BridgeClient has been disposed');
+    if (this._isReady) return this.readyPayload!;
+
+    const exePath = this.resolveBridgeExe();
+    const args = [
+      '--packages-path', this.options.packagesPath,
+    ];
+    if (this.options.binPath) {
+      args.push('--bin-path', this.options.binPath);
+    }
+    if (this.options.xrefServer) {
+      args.push('--xref-server', this.options.xrefServer);
+    }
+    if (this.options.xrefDatabase) {
+      args.push('--xref-database', this.options.xrefDatabase);
+    }
+
+    console.error(`[BridgeClient] Spawning: ${exePath} ${args.join(' ')}`);
+
+    return new Promise<BridgeReadyPayload>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.dispose();
+        reject(new Error(`Bridge process did not become ready within ${this.options.readyTimeoutMs ?? READY_TIMEOUT_MS}ms`));
+      }, this.options.readyTimeoutMs ?? READY_TIMEOUT_MS);
+
+      try {
+        this.process = spawn(exePath, args, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
+        });
+      } catch (err) {
+        clearTimeout(timeout);
+        reject(new Error(`Failed to spawn bridge: ${err}`));
+        return;
+      }
+
+      // Handle stdout — newline-delimited JSON
+      this.process.stdout!.on('data', (chunk: Buffer) => {
+        this.buffer += chunk.toString('utf8');
+        let newlineIdx: number;
+        while ((newlineIdx = this.buffer.indexOf('\n')) !== -1) {
+          const line = this.buffer.substring(0, newlineIdx).trim();
+          this.buffer = this.buffer.substring(newlineIdx + 1);
+          if (!line) continue;
+
+          try {
+            const msg: BridgeResponse = JSON.parse(line);
+
+            // Handle the initial "ready" message
+            if (msg.id === 'ready' && msg.result) {
+              clearTimeout(timeout);
+              this.readyPayload = msg.result as BridgeReadyPayload;
+              this._isReady = true;
+              console.error(`[BridgeClient] Ready: metadata=${this.readyPayload.metadataAvailable}, xref=${this.readyPayload.xrefAvailable}`);
+              this.emit('ready', this.readyPayload);
+              resolve(this.readyPayload);
+              return;
+            }
+
+            // Handle RPC responses
+            const pending = this.pending.get(msg.id);
+            if (pending) {
+              this.pending.delete(msg.id);
+              clearTimeout(pending.timer);
+              if (msg.error) {
+                pending.reject(new Error(`Bridge error [${msg.error.code}]: ${msg.error.message}`));
+              } else {
+                pending.resolve(msg.result);
+              }
+            }
+          } catch (parseErr) {
+            console.error(`[BridgeClient] Failed to parse line: ${line.substring(0, 200)}`);
+          }
+        }
+      });
+
+      // Forward stderr for diagnostics
+      this.process.stderr!.on('data', (chunk: Buffer) => {
+        const text = chunk.toString('utf8').trim();
+        if (text) {
+          // Only log non-trivial messages
+          for (const line of text.split('\n')) {
+            if (line.includes('[ERROR]') || line.includes('[WARN]')) {
+              console.error(`[Bridge] ${line.trim()}`);
+            }
+          }
+        }
+      });
+
+      this.process.on('error', (err) => {
+        clearTimeout(timeout);
+        this._isReady = false;
+        console.error(`[BridgeClient] Process error: ${err.message}`);
+        this.rejectAllPending(new Error(`Bridge process error: ${err.message}`));
+        reject(err);
+      });
+
+      this.process.on('exit', (code, signal) => {
+        this._isReady = false;
+        console.error(`[BridgeClient] Process exited: code=${code}, signal=${signal}`);
+        this.rejectAllPending(new Error(`Bridge process exited unexpectedly: code=${code}`));
+      });
+    });
+  }
+
+  /**
+   * Send a JSON-RPC call to the bridge and return the result.
+   * Rejects if bridge is not ready, the call times out, or the bridge returns an error.
+   */
+  async call<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    if (!this._isReady || this._disposed || !this.process?.stdin?.writable) {
+      throw new Error('Bridge is not ready');
+    }
+
+    const id = String(++this.requestId);
+    const request = JSON.stringify({ id, method, params }) + '\n';
+
+    return new Promise<T>((resolve, reject) => {
+      const timeoutMs = this.options.callTimeoutMs ?? CALL_TIMEOUT_MS;
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Bridge call '${method}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      });
+
+      this.process!.stdin!.write(request, 'utf8', (err) => {
+        if (err) {
+          this.pending.delete(id);
+          clearTimeout(timer);
+          reject(new Error(`Failed to write to bridge stdin: ${err.message}`));
+        }
+      });
+    });
+  }
+
+  /** Gracefully shut down the bridge process */
+  dispose(): void {
+    if (this._disposed) return;
+    this._disposed = true;
+    this._isReady = false;
+
+    this.rejectAllPending(new Error('BridgeClient disposed'));
+
+    if (this.process) {
+      try {
+        this.process.stdin?.end();
+        // Give it a moment to exit gracefully
+        setTimeout(() => {
+          if (this.process && !this.process.killed) {
+            this.process.kill('SIGTERM');
+          }
+        }, 2000);
+      } catch { /* ignore */ }
+      this.process = null;
+    }
+  }
+
+  // ========================================
+  // Typed convenience methods
+  // ========================================
+
+  async ping(): Promise<string> {
+    return this.call<string>('ping');
+  }
+
+  async readTable(tableName: string): Promise<BridgeTableInfo | null> {
+    return this.call<BridgeTableInfo | null>('readTable', { tableName });
+  }
+
+  async readClass(className: string): Promise<BridgeClassInfo | null> {
+    return this.call<BridgeClassInfo | null>('readClass', { className });
+  }
+
+  async readEnum(enumName: string): Promise<BridgeEnumInfo | null> {
+    return this.call<BridgeEnumInfo | null>('readEnum', { enumName });
+  }
+
+  async readEdt(edtName: string): Promise<BridgeEdtInfo | null> {
+    return this.call<BridgeEdtInfo | null>('readEdt', { edtName });
+  }
+
+  async readForm(formName: string): Promise<BridgeFormInfo | null> {
+    return this.call<BridgeFormInfo | null>('readForm', { formName });
+  }
+
+  async readQuery(queryName: string): Promise<BridgeQueryInfo | null> {
+    return this.call<BridgeQueryInfo | null>('readQuery', { queryName });
+  }
+
+  async readView(viewName: string): Promise<BridgeViewInfo | null> {
+    return this.call<BridgeViewInfo | null>('readView', { viewName });
+  }
+
+  async readDataEntity(entityName: string): Promise<BridgeDataEntityInfo | null> {
+    return this.call<BridgeDataEntityInfo | null>('readDataEntity', { entityName });
+  }
+
+  async readReport(reportName: string): Promise<BridgeReportInfo | null> {
+    return this.call<BridgeReportInfo | null>('readReport', { reportName });
+  }
+
+  async getMethodSource(className: string, methodName: string): Promise<BridgeMethodSource> {
+    return this.call<BridgeMethodSource>('getMethodSource', { className, methodName });
+  }
+
+  async searchObjects(query: string, objectType?: string): Promise<BridgeSearchResult> {
+    const params: Record<string, unknown> = { query };
+    if (objectType) params.objectType = objectType;
+    return this.call<BridgeSearchResult>('searchObjects', params);
+  }
+
+  async listObjects(type: string): Promise<BridgeListResult> {
+    return this.call<BridgeListResult>('listObjects', { type });
+  }
+
+  async findReferences(targetName: string, targetType?: string): Promise<BridgeReferenceResult> {
+    const params: Record<string, unknown> = { targetName };
+    if (targetType) params.targetType = targetType;
+    return this.call<BridgeReferenceResult>('findReferences', params);
+  }
+
+  async getInfo(): Promise<BridgeInfoPayload> {
+    return this.call<BridgeInfoPayload>('getInfo');
+  }
+
+  // ========================================
+  // Private helpers
+  // ========================================
+
+  private resolveBridgeExe(): string {
+    // 1. Explicit path from options
+    if (this.options.bridgeExePath) {
+      if (!fs.existsSync(this.options.bridgeExePath)) {
+        throw new Error(`Bridge exe not found at: ${this.options.bridgeExePath}`);
+      }
+      return this.options.bridgeExePath;
+    }
+
+    // 2. Look relative to this module's location (project root/bridge/D365MetadataBridge/bin/Release/)
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const candidates = [
+      // Development: built in-tree
+      path.resolve(__dirname, '../../bridge/D365MetadataBridge/bin/Release', BRIDGE_EXE_NAME),
+      // Production: alongside the server
+      path.resolve(__dirname, '../bridge', BRIDGE_EXE_NAME),
+      // Same directory
+      path.resolve(__dirname, BRIDGE_EXE_NAME),
+    ];
+
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw new Error(
+      `Bridge executable not found. Searched:\n${candidates.map(c => `  - ${c}`).join('\n')}\n` +
+      `Build it with: cd bridge/D365MetadataBridge && dotnet build -c Release`
+    );
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const [_id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+// ========================================
+// Factory function — detects D365FO presence
+// ========================================
+
+/**
+ * Attempt to create and initialize a BridgeClient.
+ * Returns null if D365FO is not installed or the bridge exe is missing.
+ *
+ * This is a non-throwing factory — safe to call during server startup.
+ */
+export async function createBridgeClient(options: {
+  packagesPath?: string;
+  binPath?: string;
+  bridgeExePath?: string;
+  xrefServer?: string;
+  xrefDatabase?: string;
+}): Promise<BridgeClient | null> {
+  // Auto-detect packagesPath if not provided
+  const packagesPath = options.packagesPath ?? detectPackagesPath();
+  if (!packagesPath) {
+    console.error('[BridgeClient] No packagesPath detected — bridge disabled');
+    return null;
+  }
+
+  // Check if bridge exe exists before trying to spawn
+  const client = new BridgeClient({
+    ...options,
+    packagesPath,
+  });
+
+  try {
+    await client.initialize();
+    return client;
+  } catch (err) {
+    console.error(`[BridgeClient] Initialization failed: ${err}`);
+    client.dispose();
+    return null;
+  }
+}
+
+function detectPackagesPath(): string | null {
+  const candidates = [
+    'K:\\AosService\\PackagesLocalDirectory',
+    'C:\\AosService\\PackagesLocalDirectory',
+    'J:\\AosService\\PackagesLocalDirectory',
+    process.env.PackagesPath ?? '',
+  ].filter(Boolean);
+
+  for (const p of candidates) {
+    // Traditional: bin is directly under packagesPath
+    if (fs.existsSync(path.join(p, 'bin', 'Microsoft.Dynamics.AX.Metadata.dll'))) {
+      return p;
+    }
+  }
+  return null;
+}

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -1,0 +1,309 @@
+/**
+ * TypeScript interfaces matching the C# bridge Models.
+ * These are the JSON shapes returned by the D365MetadataBridge process.
+ */
+
+// ===========================
+// Protocol types
+// ===========================
+
+export interface BridgeRequest {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface BridgeResponse<T = unknown> {
+  id: string;
+  result?: T;
+  error?: BridgeError;
+}
+
+export interface BridgeError {
+  code: number;
+  message: string;
+}
+
+export interface BridgeReadyPayload {
+  version: string;
+  status: 'ready';
+  packagesPath: string;
+  metadataAvailable: boolean;
+  xrefAvailable: boolean;
+}
+
+export interface BridgeInfoPayload {
+  version: string;
+  metadataAvailable: boolean;
+  xrefAvailable: boolean;
+  capabilities: string[];
+}
+
+// ===========================
+// Metadata types — Tables
+// ===========================
+
+export interface BridgeTableInfo {
+  name: string;
+  label?: string;
+  developerDocumentation?: string;
+  tableGroup?: string;
+  tabletype?: string;
+  cacheLookup?: string;
+  clusteredIndex?: string;
+  primaryIndex?: string;
+  saveDataPerCompany?: string;
+  extends?: string;
+  supportInheritance?: string;
+  model?: string;
+  fields: BridgeFieldInfo[];
+  indexes: BridgeIndexInfo[];
+  relations: BridgeRelationInfo[];
+  methods: BridgeMethodInfo[];
+}
+
+export interface BridgeFieldInfo {
+  name: string;
+  fieldType: string;
+  extendedDataType?: string;
+  label?: string;
+  helpText?: string;
+  mandatory: boolean;
+  allowEdit?: string;
+  stringSize?: number;
+  enumType?: string;
+}
+
+export interface BridgeIndexInfo {
+  name: string;
+  allowDuplicates: boolean;
+  fields: string[];
+}
+
+export interface BridgeRelationInfo {
+  name: string;
+  relatedTable: string;
+  cardinality?: string;
+  relatedTableCardinality?: string;
+  constraints: BridgeRelationConstraint[];
+}
+
+export interface BridgeRelationConstraint {
+  field?: string;
+  relatedField?: string;
+  value?: string;
+}
+
+// ===========================
+// Metadata types — Classes
+// ===========================
+
+export interface BridgeClassInfo {
+  name: string;
+  extends?: string;
+  isAbstract: boolean;
+  isFinal: boolean;
+  isStatic: boolean;
+  model?: string;
+  declaration?: string;
+  methods: BridgeMethodInfo[];
+}
+
+export interface BridgeMethodInfo {
+  name: string;
+  returnType?: string;
+  source?: string;
+  isStatic?: boolean;
+  visibility?: string;
+}
+
+// ===========================
+// Metadata types — Enums
+// ===========================
+
+export interface BridgeEnumInfo {
+  name: string;
+  label?: string;
+  helpText?: string;
+  isExtensible: boolean;
+  model?: string;
+  values: BridgeEnumValueInfo[];
+}
+
+export interface BridgeEnumValueInfo {
+  name: string;
+  value: number;
+  label?: string;
+}
+
+// ===========================
+// Metadata types — EDTs
+// ===========================
+
+export interface BridgeEdtInfo {
+  name: string;
+  baseType?: string;
+  extends?: string;
+  label?: string;
+  helpText?: string;
+  stringSize?: number;
+  enumType?: string;
+  referenceTable?: string;
+  model?: string;
+}
+
+// ===========================
+// Metadata types — Forms
+// ===========================
+
+export interface BridgeFormInfo {
+  name: string;
+  model?: string;
+  dataSources: BridgeFormDataSource[];
+  controls: BridgeFormControl[];
+}
+
+export interface BridgeFormDataSource {
+  name: string;
+  table: string;
+  joinSource?: string;
+}
+
+export interface BridgeFormControl {
+  name: string;
+  controlType: string;
+  dataSource?: string;
+  dataField?: string;
+  children?: BridgeFormControl[];
+}
+
+// ===========================
+// Metadata types — Queries
+// ===========================
+
+export interface BridgeQueryInfo {
+  name: string;
+  model?: string;
+  dataSources: BridgeQueryDataSource[];
+}
+
+export interface BridgeQueryDataSource {
+  name: string;
+  table: string;
+  joinMode?: string;
+  children?: BridgeQueryDataSource[];
+}
+
+// ===========================
+// Metadata types — Views
+// ===========================
+
+export interface BridgeViewInfo {
+  name: string;
+  label?: string;
+  model?: string;
+  query?: string;
+  fields: BridgeViewField[];
+}
+
+export interface BridgeViewField {
+  name: string;
+  fieldType: string;
+  mandatory: boolean;
+}
+
+// ===========================
+// Metadata types — Data Entities
+// ===========================
+
+export interface BridgeDataEntityInfo {
+  name: string;
+  label?: string;
+  publicEntityName?: string;
+  publicCollectionName?: string;
+  isPublic: boolean;
+  model?: string;
+  dataSources: BridgeDataEntityDataSource[];
+  keys: BridgeDataEntityKey[];
+  fieldMappings: BridgeDataEntityFieldMapping[];
+}
+
+export interface BridgeDataEntityDataSource {
+  name: string;
+  table: string;
+}
+
+export interface BridgeDataEntityKey {
+  name: string;
+  fields: string[];
+}
+
+export interface BridgeDataEntityFieldMapping {
+  fieldName: string;
+  dataSource?: string;
+  dataField?: string;
+}
+
+// ===========================
+// Metadata types — Reports
+// ===========================
+
+export interface BridgeReportInfo {
+  name: string;
+  model?: string;
+  dataSets: string[];
+  designs: string[];
+}
+
+// ===========================
+// Cross-reference types
+// ===========================
+
+export interface BridgeReferenceResult {
+  objectPath: string;
+  count: number;
+  references: BridgeReferenceInfo[];
+}
+
+export interface BridgeReferenceInfo {
+  sourcePath: string;
+  sourceModule?: string;
+  kind?: string;
+  line: number;
+  column: number;
+}
+
+// ===========================
+// Search types
+// ===========================
+
+export interface BridgeSearchResult {
+  results: BridgeSearchItem[];
+}
+
+export interface BridgeSearchItem {
+  name: string;
+  type: string;
+  model?: string;
+}
+
+// ===========================
+// Method source types
+// ===========================
+
+export interface BridgeMethodSource {
+  className: string;
+  methodName: string;
+  found: boolean;
+  source?: string;
+}
+
+// ===========================
+// List objects types
+// ===========================
+
+export interface BridgeListResult {
+  type: string;
+  count: number;
+  names: string[];
+}

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Bridge module — C# D365MetadataBridge integration.
+ *
+ * Provides access to Microsoft's official Dev Tools API (IMetadataProvider)
+ * and cross-reference database (DYNAMICSXREFDB) via a child process.
+ *
+ * Usage:
+ *   import { BridgeClient, createBridgeClient } from './bridge/index.js';
+ *
+ *   // In server startup:
+ *   const bridge = await createBridgeClient({ packagesPath: 'K:\\AosService\\PackagesLocalDirectory' });
+ *   if (bridge) {
+ *     const table = await bridge.readTable('CustTable');
+ *     const refs = await bridge.findReferences('CustTable');
+ *   }
+ */
+
+export { BridgeClient, createBridgeClient } from './bridgeClient.js';
+export type { BridgeClientOptions, BridgeReadyPayload, BridgeInfoPayload } from './bridgeClient.js';
+export * from './bridgeTypes.js';
+export {
+  tryBridgeTable,
+  tryBridgeClass,
+  tryBridgeMethodSource,
+  tryBridgeEnum,
+  tryBridgeEdt,
+  tryBridgeForm,
+  tryBridgeReferences,
+  tryBridgeSearch,
+} from './bridgeAdapter.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -546,6 +546,40 @@ async function main() {
     await new Promise<void>(resolve => setImmediate(resolve));
     process.stderr.write(`[stdio ${diagTs()}] setImmediate fired — roots/list exchange should be done\n`);
 
+    // Step 3b: Initialize C# bridge in parallel with DB load (non-blocking)
+    // The bridge provides live metadata from Microsoft's IMetadataProvider API
+    // and cross-reference queries — only available on Windows VMs with D365FO.
+    void (async () => {
+      try {
+        const { createBridgeClient } = await import('./bridge/bridgeClient.js');
+        const configMgr = getConfigManager();
+        const packagesPath = configMgr.getPackagePath() ?? undefined;
+        // UDE mode: MS framework DLLs live under microsoftPackagesPath,
+        // not under the main packagesPath.
+        const devEnvType = await configMgr.getDevEnvironmentType();
+        let binPath: string | undefined;
+        if (devEnvType === 'ude') {
+          const msPath = await configMgr.getMicrosoftPackagesPath();
+          if (msPath) {
+            const { existsSync } = await import('fs');
+            const { join } = await import('path');
+            const candidate = join(msPath, 'bin');
+            if (existsSync(candidate)) binPath = candidate;
+          }
+        }
+        const bridge = await createBridgeClient({
+          packagesPath,
+          binPath,
+        });
+        if (bridge) {
+          stubContext.bridge = bridge;
+          console.log(`✅ C# bridge connected (${devEnvType}): metadata=${bridge.metadataAvailable}, xref=${bridge.xrefAvailable}`);
+        }
+      } catch (err) {
+        console.log(`ℹ️  C# bridge not available: ${err}`);
+      }
+    })();
+
     // Step 4: load real database in the background
     const dbLoadStart = Date.now();
     initializeServices().then(({ symbolIndex, parser, cache, workspaceScanner, hybridSearch, termRelationshipGraph }) => {

--- a/src/tools/classInfo.ts
+++ b/src/tools/classInfo.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { validateWorkspacePath } from '../workspace/workspaceUtils.js';
 import { buildObjectTypeMismatchMessage } from '../utils/metadataResolver.js';
+import { tryBridgeClass } from '../bridge/bridgeAdapter.js';
 
 const METHOD_PAGE_SIZE = 15;
 
@@ -82,6 +83,10 @@ export async function classInfoTool(request: CallToolRequest, context: XppServer
         content: [{ type: 'text', text }],
       };
     }
+
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata)
+    const bridgeResult = await tryBridgeClass(context.bridge, args.className, args.compact !== false, args.methodOffset ?? 0);
+    if (bridgeResult) return bridgeResult;
 
     // Query database and parse
     const classSymbol = symbolIndex.getSymbolByName(args.className, 'class');

--- a/src/tools/edtInfo.ts
+++ b/src/tools/edtInfo.ts
@@ -9,6 +9,7 @@ import type { XppServerContext } from '../types/context.js';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
 import { readEdtRawXml } from '../utils/metadataResolver.js';
+import { tryBridgeEdt } from '../bridge/bridgeAdapter.js';
 
 const GetEdtInfoArgsSchema = z.object({
   edtName: z.string().describe('Name of the Extended Data Type (EDT)'),
@@ -50,6 +51,10 @@ export async function getEdtInfoTool(request: CallToolRequest, context: XppServe
     if (args.mode === 'hierarchy') {
       return getEdtHierarchy(symbolIndex.db, edtName, modelName);
     }
+
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata, standard mode only)
+    const bridgeResult = await tryBridgeEdt(context.bridge, edtName);
+    if (bridgeResult) return bridgeResult;
 
     // ── Step 1: query edt_metadata (rich columns, always present in DB) ──────
     let edtDbRow: any;

--- a/src/tools/enumInfo.ts
+++ b/src/tools/enumInfo.ts
@@ -10,6 +10,7 @@ import type { XppServerContext } from '../types/context.js';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
 import { readEnumRawXml, buildXmlNotAvailableMessage } from '../utils/metadataResolver.js';
+import { tryBridgeEnum } from '../bridge/bridgeAdapter.js';
 
 const GetEnumInfoArgsSchema = z.object({
   enumName: z.string().describe('Name of the enum'),
@@ -43,6 +44,10 @@ export async function getEnumInfoTool(request: CallToolRequest, context: XppServ
       modelName, 
       includeLabels
     } = args;
+
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata)
+    const bridgeResult = await tryBridgeEnum(context.bridge, enumName);
+    if (bridgeResult) return bridgeResult;
 
     // 1. Find enum in index
     let stmt;

--- a/src/tools/findReferences.ts
+++ b/src/tools/findReferences.ts
@@ -8,6 +8,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { buildObjectTypeMismatchMessage } from '../utils/metadataResolver.js';
+import { tryBridgeReferences } from '../bridge/bridgeAdapter.js';
 
 const FindReferencesArgsSchema = z.object({
   targetName: z.string().describe('Name of the target (class name, method name, field name, etc.)'),
@@ -38,6 +39,10 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
     if (cachedResult) {
       return cachedResult;
     }
+
+    // Try C# bridge first (DYNAMICSXREFDB — live cross-references)
+    const bridgeResult = await tryBridgeReferences(context.bridge, targetName, limit);
+    if (bridgeResult) return bridgeResult;
 
     // --- Parse dotted notation (e.g. "SalesLineCopy.copy()" or "SalesLineCopy.copy") ---
     // Extract parent object name so we can cross-check its actual type in the DB

--- a/src/tools/formInfo.ts
+++ b/src/tools/formInfo.ts
@@ -12,6 +12,7 @@ import { parseStringPromise } from 'xml2js';
 import { resolveDbPathLocally } from '../utils/metadataResolver.js';
 import { findD365FileOnDisk } from './modifyD365File.js';
 import { getConfigManager } from '../utils/configManager.js';
+import { tryBridgeForm } from '../bridge/bridgeAdapter.js';
 import path from 'path';
 
 const GetFormInfoArgsSchema = z.object({
@@ -100,6 +101,10 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
       }
       return await parseAndFormatForm(formName, 'Unknown', xmlContent, includeControls, includeDataSources, includeMethods, searchControl);
     }
+
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata)
+    const bridgeResult = await tryBridgeForm(context.bridge, formName);
+    if (bridgeResult) return bridgeResult;
 
     // 1. Find the form (with workspace support)
     let formRow: any = null;

--- a/src/tools/getMethodSource.ts
+++ b/src/tools/getMethodSource.ts
@@ -9,6 +9,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { readMethodMetadata } from '../utils/metadataResolver.js';
+import { tryBridgeMethodSource } from '../bridge/bridgeAdapter.js';
 
 const GetMethodSourceArgsSchema = z.object({
   className: z.string().describe('Name of the class containing the method'),
@@ -20,6 +21,10 @@ export async function getMethodSourceTool(request: CallToolRequest, context: Xpp
     const args = GetMethodSourceArgsSchema.parse(request.params.arguments);
     const { symbolIndex } = context;
     const { className, methodName } = args;
+
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata)
+    const bridgeResult = await tryBridgeMethodSource(context.bridge, className, methodName);
+    if (bridgeResult) return bridgeResult;
 
     // 1. Look up the symbol row to get model + source
     const row = symbolIndex.db.prepare(`

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -17,6 +17,7 @@ import {
   generateSearchSuggestions,
   formatSuggestions
 } from '../utils/suggestionEngine.js';
+import { tryBridgeSearch } from '../bridge/bridgeAdapter.js';
 
 const SearchArgsSchema = z.object({
   query: z.string().describe('Search query (class name, method name, etc.)'),
@@ -41,6 +42,10 @@ export async function searchTool(request: CallToolRequest, context: XppServerCon
     if (args.includeWorkspace && args.workspacePath) {
       return await performHybridSearch(args, context);
     }
+
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata)
+    const bridgeResult = await tryBridgeSearch(context.bridge, args.query, args.type === 'all' ? undefined : args.type, args.limit);
+    if (bridgeResult) return bridgeResult;
 
     // Standard external metadata search
     return await performExternalSearch(args, symbolIndex, cache);

--- a/src/tools/tableInfo.ts
+++ b/src/tools/tableInfo.ts
@@ -8,6 +8,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { findD365FileOnDisk } from './modifyD365File.js';
+import { tryBridgeTable } from '../bridge/bridgeAdapter.js';
 
 const METHOD_PAGE_SIZE = 25;
 
@@ -46,6 +47,10 @@ export async function tableInfoTool(request: CallToolRequest, context: XppServer
         ],
       };
     }
+
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata)
+    const bridgeResult = await tryBridgeTable(context.bridge, args.tableName, args.methodOffset);
+    if (bridgeResult) return bridgeResult;
 
     // Query database and parse
     const tableSymbol = symbolIndex.getSymbolByName(args.tableName, 'table');

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -8,6 +8,7 @@ import type { RedisCacheService } from '../cache/redisCache.js';
 import type { WorkspaceScanner } from '../workspace/workspaceScanner.js';
 import type { HybridSearch } from '../workspace/hybridSearch.js';
 import type { TermRelationshipGraph } from '../utils/suggestionEngine.js';
+import type { BridgeClient } from '../bridge/bridgeClient.js';
 
 /**
  * Editor context from IDE (VS2022, VS2026)
@@ -38,6 +39,13 @@ export interface XppServerContext {
   hybridSearch: HybridSearch;
   termRelationshipGraph: TermRelationshipGraph;
   editorContext?: EditorContext;
+  /**
+   * C# bridge to Microsoft's Dev Tools API (IMetadataProvider + DYNAMICSXREFDB).
+   * Available only on Windows VMs with D365FO installed.
+   * When present, tools can use it for live metadata reads and cross-references
+   * instead of the SQLite symbol index.
+   */
+  bridge?: BridgeClient;
   /**
    * Resolves when the real symbol database has been loaded.
    * Present only in stdio mode when the stub pattern is active.

--- a/tests/bridge-e2e.ts
+++ b/tests/bridge-e2e.ts
@@ -1,0 +1,108 @@
+/**
+ * Quick end-to-end test for the C# bridge from Node.js.
+ * Run with: npx tsx tests/bridge-e2e.ts
+ */
+
+import { BridgeClient } from '../src/bridge/bridgeClient.js';
+
+async function main() {
+  console.log('=== Bridge E2E Test ===\n');
+
+  const client = new BridgeClient({
+    packagesPath: 'K:\\AosService\\PackagesLocalDirectory',
+  });
+
+  try {
+    console.log('1. Initializing bridge...');
+    const ready = await client.initialize();
+    console.log(`   ✅ Ready: metadata=${ready.metadataAvailable}, xref=${ready.xrefAvailable}, version=${ready.version}`);
+
+    console.log('\n2. Ping...');
+    const pong = await client.ping();
+    console.log(`   ✅ ${pong}`);
+
+    console.log('\n3. Read table CustTable...');
+    const table = await client.readTable('CustTable');
+    if (table) {
+      console.log(`   ✅ ${table.name}: ${table.fields.length} fields, ${table.indexes.length} indexes, ${table.relations.length} relations`);
+      console.log(`   Label: ${table.label}, Model: ${table.model}, TableGroup: ${table.tableGroup}`);
+      console.log(`   First 3 fields: ${table.fields.slice(0, 3).map(f => `${f.name}(${f.extendedDataType || f.fieldType})`).join(', ')}`);
+    } else {
+      console.log('   ❌ CustTable not found');
+    }
+
+    console.log('\n4. Read class SalesFormLetter...');
+    const cls = await client.readClass('SalesFormLetter');
+    if (cls) {
+      console.log(`   ✅ ${cls.name}: ${cls.methods.length} methods, extends=${cls.extends}, abstract=${cls.isAbstract}`);
+      console.log(`   First 5 methods: ${cls.methods.slice(0, 5).map(m => m.name).join(', ')}`);
+    } else {
+      console.log('   ❌ SalesFormLetter not found');
+    }
+
+    console.log('\n5. Get method source CustTable.find...');
+    const method = await client.getMethodSource('CustTable', 'find');
+    if (method.found) {
+      console.log(`   ✅ Found: ${method.source?.substring(0, 150)}...`);
+    } else {
+      console.log('   ❌ CustTable.find not found');
+    }
+
+    console.log('\n6. Read enum SalesStatus...');
+    const en = await client.readEnum('SalesStatus');
+    if (en) {
+      console.log(`   ✅ ${en.name}: ${en.values.length} values, extensible=${en.isExtensible}`);
+      console.log(`   Values: ${en.values.map(v => `${v.name}=${v.value}`).join(', ')}`);
+    } else {
+      console.log('   ❌ SalesStatus not found');
+    }
+
+    console.log('\n7. Read EDT CustAccount...');
+    const edt = await client.readEdt('CustAccount');
+    if (edt) {
+      console.log(`   ✅ ${edt.name}: baseType=${edt.baseType}, extends=${edt.extends}, size=${edt.stringSize}`);
+    } else {
+      console.log('   ❌ CustAccount not found');
+    }
+
+    console.log('\n8. Search "SalesInvoice" classes...');
+    const search = await client.searchObjects('SalesInvoice', 'class');
+    console.log(`   ✅ Found ${search.results.length} results`);
+    search.results.slice(0, 5).forEach(r => console.log(`   - ${r.name} (${r.type})`));
+
+    console.log('\n9. Find references to CustTable...');
+    const refs = await client.findReferences('CustTable');
+    console.log(`   ✅ ${refs.count} references found`);
+    refs.references.slice(0, 5).forEach(r => console.log(`   - ${r.sourcePath} (module: ${r.sourceModule}, line: ${r.line})`));
+
+    console.log('\n10. Read form CustTable...');
+    const form = await client.readForm('CustTable');
+    if (form) {
+      console.log(`   ✅ ${form.name}: ${form.dataSources.length} datasources, ${form.controls.length} top controls`);
+    } else {
+      console.log('   ❌ CustTable form not found');
+    }
+
+    console.log('\n11. Read data entity CustCustomerV3Entity...');
+    const entity = await client.readDataEntity('CustCustomerV3Entity');
+    if (entity) {
+      console.log(`   ✅ ${entity.name}: public=${entity.isPublic}, collection=${entity.publicCollectionName}`);
+      console.log(`   DataSources: ${entity.dataSources.map(ds => ds.name).join(', ')}`);
+    } else {
+      console.log('   ❌ CustCustomerV3Entity not found');
+    }
+
+    console.log('\n12. List all tables (count)...');
+    const list = await client.listObjects('table');
+    console.log(`   ✅ ${list.count} tables in the system`);
+
+    console.log('\n=== ALL TESTS PASSED ===');
+  } catch (err) {
+    console.error('\n❌ Test failed:', err);
+    process.exitCode = 1;
+  } finally {
+    client.dispose();
+  }
+}
+
+main();


### PR DESCRIPTION
Add a .NET Framework 4.8 child process (D365MetadataBridge.exe) that provides live metadata from Microsoft's IMetadataProvider API and cross-reference queries from DYNAMICSXREFDB via stdin/stdout JSON-RPC.

C# bridge components:
- Program.cs: entry point, DLL loading, stdio loop
- MetadataReadService: IMetadataProvider wrapper (tables, classes, enums, EDTs, forms, queries, views, data entities, reports, search)
- CrossReferenceService: DYNAMICSXREFDB SQL queries
- Protocol: BridgeRequest/Response, RequestDispatcher (16 endpoints)
- Models: C# POCOs matching TypeScript bridge types

TypeScript bridge integration:
- bridgeClient.ts: BridgeClient class — spawn, JSON-RPC, 14 typed methods
- bridgeTypes.ts: ~35 interfaces matching C# models
- bridgeAdapter.ts: 8 tryBridge*() adapter functions for tool handlers
- index.ts (barrel): re-exports all bridge types and functions

Tool handler integration (try-first, fall-through pattern):
- get_table_info, get_class_info, get_method_source, get_form_info, get_enum_info, get_edt_info, find_references, search
- Each checks bridge first; returns null to fall back to SQLite/parser

Infrastructure:
- .gitignore: bridge build artifacts, VS solution user files
- context.ts: bridge?: BridgeClient on XppServerContext
- index.ts: Step 3b non-blocking bridge init in stdio mode
- d365fo-mcp-server.sln: VS solution with bridge project
- docs/BRIDGE.md: comprehensive documentation (~640 lines)
- tests/bridge-e2e.ts: 12 E2E integration tests

Zero breaking changes — bridge is additive. When absent (Azure/Linux), all tryBridge*() calls return null in ~0ms and existing logic runs.

TypeScript: 0 errors | Tests: 231 passed (12 files)