### PR TITLE
feat: enhance metadata handling by resolving assembly version conflic…

### DIFF
--- a/bridge/D365MetadataBridge/D365MetadataBridge.csproj
+++ b/bridge/D365MetadataBridge/D365MetadataBridge.csproj
@@ -8,6 +8,13 @@
     <RootNamespace>D365MetadataBridge</RootNamespace>
     <AssemblyName>D365MetadataBridge</AssemblyName>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- Resolve transitive assembly version conflicts in D365FO bin (e.g. SCDP 7.0.0 vs 7.0.4) -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <!-- MSB3277: version conflict between Microsoft-shipped SCDP.dll (7.0.0) and
+         SCDPBundling.dll (depends on 7.0.4) in PackagesLocalDirectory\bin.
+         We don't control these DLLs and the bridge doesn't use SCDP at all — safe to suppress. -->
+    <MSBuildWarningsAsMessages>MSB3277</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
   <!--

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -295,7 +295,7 @@ namespace D365MetadataBridge.Services
             if (q == null) return null;
             var result = new QueryInfoModel { Name = q.Name };
             try { var mi = _provider.Queries.GetModelInfo(queryName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
-            try { if (q.DataSources != null) foreach (dynamic ds in q.DataSources) result.DataSources.Add(MapQueryDataSource(ds)); } catch (Exception ex) { Warn("dataSources", queryName, ex); }
+            try { dynamic dq = q; if (dq.DataSources != null) foreach (dynamic ds in dq.DataSources) result.DataSources.Add(MapQueryDataSource(ds)); } catch (Exception ex) { Warn("dataSources", queryName, ex); }
             return result;
         }
 
@@ -318,7 +318,7 @@ namespace D365MetadataBridge.Services
             var result = new DataEntityInfoModel { Name = e.Name, Label = Safe(() => e.Label), PublicEntityName = Safe(() => e.PublicEntityName), PublicCollectionName = Safe(() => e.PublicCollectionName), IsPublic = IsYes(() => e.IsPublic) };
             try { var mi = _provider.DataEntityViews.GetModelInfo(entityName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
             try { if (e.Fields != null) foreach (var f in e.Fields) result.Fields.Add(new FieldInfoModel { Name = f.Name, FieldType = f.GetType().Name }); } catch { }
-            try { if (e.DataSources != null) foreach (dynamic ds in e.DataSources) result.DataSources.Add(new FormDataSourceModel { Name = Safe(() => (string)ds.Name) ?? "", Table = Safe(() => (string)ds.Table) ?? "" }); } catch (Exception ex) { Warn("dataSources", entityName, ex); }
+            try { dynamic de = e; if (de.DataSources != null) foreach (dynamic ds in de.DataSources) result.DataSources.Add(new FormDataSourceModel { Name = Safe(() => (string)ds.Name) ?? "", Table = Safe(() => (string)ds.Table) ?? "" }); } catch (Exception ex) { Warn("dataSources", entityName, ex); }
             return result;
         }
 


### PR DESCRIPTION
This pull request focuses on improving compatibility and robustness in the `D365MetadataBridge` project. The main updates include resolving assembly version conflicts at the project level and making minor defensive coding adjustments to dynamic property access in the metadata reading service.

Project configuration improvements:

* Updated `D365MetadataBridge.csproj` to automatically generate binding redirects and suppress MSB3277 warnings, addressing version conflicts between transitive dependencies (e.g., different versions of `SCDP.dll`) that are outside our control. This ensures smoother builds and runtime behavior when multiple versions are present.

Code robustness enhancements:

* Updated dynamic property access in `MetadataReadService.cs` by assigning the dynamic objects (`q` and `e`) to new variables (`dq` and `de`) before accessing their `DataSources` properties. This change makes the code more resilient to dynamic type issues and clarifies intent. [[1]](diffhunk://#diff-52e0bd83a3724da461b2ba62bed716098850bbbd7cf444a3207c1e15e9bc58abL298-R298) [[2]](diffhunk://#diff-52e0bd83a3724da461b2ba62bed716098850bbbd7cf444a3207c1e15e9bc58abL321-R321)