### PR TITLE
feat: add API key authentication for HTTP mode

### DIFF
--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -105,6 +105,24 @@ The server listens on a TCP port. Used for Azure deployments and for local `npm 
 }
 ```
 
+If the server has `API_KEY` authentication enabled, add a `headers` block:
+
+```json
+{
+  "servers": {
+    "d365fo-mcp-tools": {
+      "url": "https://your-server.azurewebsites.net/mcp/",
+      "headers": {
+        "X-Api-Key": "your-api-key-here"
+      }
+    },
+    "context": {
+      "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"
+    }
+  }
+}
+```
+
 Note: VS 2022 HTTP transport does **not** send workspace headers. Use `workspacePath` or
 `projectPath` in the `context` block, or switch to stdio.
 

--- a/docs/SETUP_AZURE.md
+++ b/docs/SETUP_AZURE.md
@@ -97,6 +97,12 @@ In the Azure Portal, go to the App Service → **Settings** → **Environment va
 | `SCM_DO_BUILD_DURING_DEPLOYMENT` | `false` | Pre-built `node_modules` are shipped in the deploy zip — Oryx must NOT run `npm ci` (no gcc/make on App Service Linux) |
 | `WEBSITE_NODE_DEFAULT_VERSION` | `~24` | |
 
+**Optional — Authentication (recommended for private projects):**
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| `API_KEY` | e.g. `my-secret-key-here` | When set, all `/mcp` requests must include `X-Api-Key` header. `/health` is always public. Generate a strong random key (e.g. `openssl rand -hex 32`). Leave empty to disable. |
+
 **Optional — Redis (recommended for teams):**
 
 | Setting | Value |

--- a/infrastructure/azuredeploy.json
+++ b/infrastructure/azuredeploy.json
@@ -55,6 +55,13 @@
       "metadata": {
         "description": "Comma-separated label languages to index. Each language adds ~125 MB. Examples: en-US,cs,de  or  en-US"
       }
+    },
+    "apiKey": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "API key for authenticating MCP requests. When set, clients must send X-Api-Key header. Leave empty to disable auth."
+      }
     }
   },
   "variables": {
@@ -190,6 +197,10 @@
             {
               "name": "WEBSITES_PORT",
               "value": "8080"
+            },
+            {
+              "name": "API_KEY",
+              "value": "[parameters('apiKey')]"
             }
           ]
         }

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -32,6 +32,10 @@ param storageSku string = 'Standard_LRS'
 @description('Comma-separated label languages to index. Each language adds ~125 MB. Examples: en-US,cs,de  or  en-US')
 param labelLanguages string = 'en-US,cs,sk,de'
 
+@description('API key for authenticating MCP requests. When set, clients must send X-Api-Key header. Leave empty to disable auth.')
+@secure()
+param apiKey string = ''
+
 var appServicePlanName = '${appName}-plan'
 var appServiceName = appName
 var storageAccountName = replace(appName, '-', '')
@@ -154,6 +158,10 @@ resource appService 'Microsoft.Web/sites@2023-01-01' = {
         {
           name: 'WEBSITES_PORT'
           value: '8080'
+        }
+        {
+          name: 'API_KEY'
+          value: apiKey
         }
       ]
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { HybridSearch } from './workspace/hybridSearch.js';
 import { initializeDatabase } from './database/download.js';
 import { initializeConfig, getConfigManager } from './utils/configManager.js';
 import { SERVER_MODE, LOCAL_TOOLS } from './server/serverMode.js';
+import { apiKeyAuth } from './middleware/apiKeyAuth.js';
 import { setInitializeParams } from './utils/stdioSessionInfo.js';
 import * as fs from 'fs/promises';
 import * as fsSync from 'node:fs';
@@ -632,6 +633,11 @@ async function main() {
     app.use(compression());
 
     app.use(express.json());
+
+    // API key authentication — enforced when API_KEY env var is set.
+    // Must be after express.json() but before route handlers.
+    // /health is excluded so Azure health probes still work unauthenticated.
+    app.use(apiKeyAuth);
 
     // Health check endpoint — dynamic: reflects serverState at request time
     app.get('/health', (_req, res) => {

--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -1,0 +1,80 @@
+import type { Request, Response, NextFunction } from 'express';
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * API Key authentication middleware for HTTP mode.
+ *
+ * When the `API_KEY` environment variable is set, every request (except
+ * unauthenticated paths like `/health`) must include a matching key in
+ * one of these locations (checked in order):
+ *
+ *   1. `X-Api-Key` header          — preferred for MCP clients
+ *   2. `Authorization: Bearer <key>` header — works with tools that only support Bearer
+ *
+ * If `API_KEY` is NOT set, the middleware is a pass-through (no-op) so
+ * existing deployments keep working without changes.
+ *
+ * Timing-safe comparison is used to prevent timing side-channel attacks.
+ */
+
+const API_KEY = process.env.API_KEY?.trim();
+
+/** Paths that never require authentication */
+const PUBLIC_PATHS = new Set(['/', '/health']);
+
+/**
+ * Constant-time string comparison.
+ * Returns false immediately only when lengths differ (which is already
+ * observable via response time in any string comparison).
+ */
+function safeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+}
+
+function extractApiKey(req: Request): string | null {
+  // 1. X-Api-Key header (preferred)
+  const xApiKey = req.headers['x-api-key'];
+  if (typeof xApiKey === 'string' && xApiKey.length > 0) {
+    return xApiKey;
+  }
+
+  // 2. Authorization: Bearer <key>
+  const authHeader = req.headers['authorization'];
+  if (typeof authHeader === 'string' && authHeader.toLowerCase().startsWith('bearer ')) {
+    const token = authHeader.slice(7).trim();
+    if (token.length > 0) return token;
+  }
+
+  return null;
+}
+
+/**
+ * Express middleware that enforces API key authentication.
+ * Mount BEFORE any route handlers.
+ */
+export function apiKeyAuth(req: Request, res: Response, next: NextFunction): void {
+  // No API_KEY configured → auth disabled, pass through
+  if (!API_KEY) {
+    next();
+    return;
+  }
+
+  // Public endpoints are always accessible (Azure health probes, etc.)
+  if (PUBLIC_PATHS.has(req.path)) {
+    next();
+    return;
+  }
+
+  const provided = extractApiKey(req);
+
+  if (!provided || !safeCompare(provided, API_KEY)) {
+    res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Missing or invalid API key. Provide it via X-Api-Key header or Authorization: Bearer <key>.',
+    });
+    return;
+  }
+
+  next();
+}


### PR DESCRIPTION
- New middleware (src/middleware/apiKeyAuth.ts) enforces X-Api-Key header when API_KEY env var is set; no-op when unset (backward compatible)
- Supports X-Api-Key header and Authorization: Bearer fallback
- Uses timing-safe comparison to prevent side-channel attacks
- /health endpoint excluded so Azure health probes still work
- Added API_KEY parameter to Bicep and ARM templates (@secure)
- Updated SETUP_AZURE.md and MCP_CONFIG.md with client configuration