### PR TITLE
fix: bridge JIT crash — defer D365FO type resolution until after Asse…

### DIFF
--- a/bridge/D365MetadataBridge/Program.cs
+++ b/bridge/D365MetadataBridge/Program.cs
@@ -1,10 +1,10 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using D365MetadataBridge.Protocol;
-using D365MetadataBridge.Services;
 
 namespace D365MetadataBridge
 {
@@ -17,6 +17,15 @@ namespace D365MetadataBridge
     /// This bridge is spawned by the Node.js MCP server as a child process.
     /// All JSON messages are newline-delimited on stdout.
     /// All diagnostic/log messages go to stderr (never stdout).
+    /// 
+    /// IMPORTANT: Main() must NOT reference any D365FO-dependent types
+    /// (MetadataReadService, MetadataWriteService, CrossReferenceService) even as
+    /// local variables.  The CLR JIT-compiles the entire async state machine for
+    /// Main before the first instruction executes — which means it tries to load
+    /// Microsoft.Dynamics.AX.Metadata.dll before SetupAssemblyResolution has been
+    /// called.  All D365FO-dependent code lives in RunBridge(), which is marked
+    /// [MethodImpl(NoInlining)] so the JIT defers its compilation until after
+    /// the AssemblyResolve handler is registered.
     /// </summary>
     static class Program
     {
@@ -28,7 +37,7 @@ namespace D365MetadataBridge
 
         static async Task<int> Main(string[] args)
         {
-            // Parse command-line arguments
+            // Parse command-line arguments — NO D365FO type references allowed here!
             for (int i = 0; i < args.Length; i++)
             {
                 switch (args[i])
@@ -51,7 +60,7 @@ namespace D365MetadataBridge
                 }
             }
 
-            // Setup assembly resolution for D365FO DLLs.
+            // Setup assembly resolution for D365FO DLLs BEFORE any D365FO type is touched.
             // Traditional: {packagesPath}/bin
             // UDE: --bin-path points to microsoftPackagesPath/bin (MS framework DLLs)
             //      while --packages-path points to the custom packages root for metadata.
@@ -69,42 +78,29 @@ namespace D365MetadataBridge
             if (fallbackBinPath != null && Directory.Exists(fallbackBinPath))
                 Log.WriteLine($"[INFO] Additional assembly search path: {fallbackBinPath}");
 
-            // Initialize services
-            MetadataReadService? metadataService = null;
-            CrossReferenceService? xrefService = null;
+            // Delegate to RunBridge — a separate method whose JIT compilation is
+            // deferred (NoInlining) until AFTER AssemblyResolve is registered.
+            return await RunBridge();
+        }
 
-            try
-            {
-                Log.WriteLine($"[INFO] Initializing MetadataProvider from: {_packagesPath}");
-                metadataService = new MetadataReadService(_packagesPath);
-                Log.WriteLine("[INFO] MetadataProvider initialized successfully");
-            }
-            catch (Exception ex)
-            {
-                Log.WriteLine($"[ERROR] Failed to initialize MetadataProvider: {ex.Message}");
-                Log.WriteLine($"[ERROR] Stack: {ex.StackTrace}");
-                // Continue — we'll report errors for metadata calls but xref might still work
-            }
-
-            try
-            {
-                Log.WriteLine($"[INFO] Initializing CrossReferenceProvider: {_xrefServer}\\{_xrefDatabase}");
-                xrefService = new CrossReferenceService(_xrefServer, _xrefDatabase);
-                Log.WriteLine("[INFO] CrossReferenceProvider initialized successfully");
-            }
-            catch (Exception ex)
-            {
-                Log.WriteLine($"[WARN] Failed to initialize CrossReferenceProvider: {ex.Message}");
-                // Non-fatal — cross-references are optional
-            }
+        /// <summary>
+        /// All D365FO-dependent code lives here so the JIT doesn't try to resolve
+        /// Microsoft.Dynamics.AX.Metadata types during Main's state machine compilation.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task<int> RunBridge()
+        {
+            // Late-import: Services namespace references D365FO assemblies
+            var metadataService = InitMetadataService();
+            var xrefService = InitCrossReferenceService();
 
             // Create write service (shares the same provider as read service)
-            MetadataWriteService? writeService = null;
+            Services.MetadataWriteService? writeService = null;
             if (metadataService != null)
             {
                 try
                 {
-                    writeService = new MetadataWriteService(metadataService.Provider, _packagesPath);
+                    writeService = new Services.MetadataWriteService(metadataService.Provider, _packagesPath);
                     // Keep write service provider in sync when read service refreshes
                     metadataService.OnProviderRefreshed = (newProvider) => writeService.UpdateProvider(newProvider);
                     Log.WriteLine("[INFO] MetadataWriteService initialized");
@@ -137,6 +133,41 @@ namespace D365MetadataBridge
 
             // Enter stdin/stdout loop
             return await RunStdioLoop(dispatcher);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Services.MetadataReadService? InitMetadataService()
+        {
+            try
+            {
+                Log.WriteLine($"[INFO] Initializing MetadataProvider from: {_packagesPath}");
+                var svc = new Services.MetadataReadService(_packagesPath);
+                Log.WriteLine("[INFO] MetadataProvider initialized successfully");
+                return svc;
+            }
+            catch (Exception ex)
+            {
+                Log.WriteLine($"[ERROR] Failed to initialize MetadataProvider: {ex.Message}");
+                Log.WriteLine($"[ERROR] Stack: {ex.StackTrace}");
+                return null;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Services.CrossReferenceService? InitCrossReferenceService()
+        {
+            try
+            {
+                Log.WriteLine($"[INFO] Initializing CrossReferenceProvider: {_xrefServer}\\{_xrefDatabase}");
+                var svc = new Services.CrossReferenceService(_xrefServer, _xrefDatabase);
+                Log.WriteLine("[INFO] CrossReferenceProvider initialized successfully");
+                return svc;
+            }
+            catch (Exception ex)
+            {
+                Log.WriteLine($"[WARN] Failed to initialize CrossReferenceProvider: {ex.Message}");
+                return null;
+            }
         }
 
         private static async Task<int> RunStdioLoop(RequestDispatcher dispatcher)


### PR DESCRIPTION
…mblyResolve

Problem: D365MetadataBridge.exe crashed on startup with:
  FileNotFoundException: Could not load 'Microsoft.Dynamics.AX.Metadata'
  at Program.<Main>d__5.MoveNext()

Root cause: The async state machine for Main() declared local variables of types MetadataReadService, CrossReferenceService, MetadataWriteService — all of which depend on Microsoft.Dynamics.AX.Metadata.dll. When the CLR JIT- compiled the state machine, it tried to resolve these types BEFORE SetupAssemblyResolution() was called (the handler that redirects assembly loading to K:\AosService\PackagesLocalDirectory\bin\).

Fix: Split Main() into two methods:
  - Main() — args parsing + SetupAssemblyResolution (NO D365FO type refs)
  - RunBridge() — all D365FO-dependent code ([MethodImpl(NoInlining)])

The NoInlining attribute ensures the JIT defers compilation of RunBridge() until it is actually called — by which time AssemblyResolve is registered and can resolve Microsoft.Dynamics.AX.Metadata.dll from the bin directory.

Also extracted InitMetadataService() and InitCrossReferenceService() as separate NoInlining methods for the same reason.

Removed 'using D365MetadataBridge.Services' from top-level — Services types are now referenced via qualified names (Services.MetadataReadService etc.) to make the dependency boundary explicit.

This also fixes the VS 2022 Copilot 'server shut down unexpectedly' error that occurred when the bridge crash propagated to the Node.js MCP server.