### PR TITLE
fix: package path resolution (#374) and standard model write protection (#369)

### DIFF
--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -701,10 +701,10 @@ export async function createBridgeClient(options: {
 
 function detectPackagesPath(): string | null {
   const candidates = [
-    'K:\\AosService\\PackagesLocalDirectory',
+    process.env.PackagesPath ?? '',
     'C:\\AosService\\PackagesLocalDirectory',
     'J:\\AosService\\PackagesLocalDirectory',
-    process.env.PackagesPath ?? '',
+    'K:\\AosService\\PackagesLocalDirectory',
   ].filter(Boolean);
 
   for (const p of candidates) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -554,6 +554,7 @@ async function main() {
       try {
         const { createBridgeClient } = await import('./bridge/bridgeClient.js');
         const configMgr = getConfigManager();
+        await configMgr.ensureLoaded();
         const packagesPath = configMgr.getPackagePath() ?? undefined;
         // UDE mode: MS framework DLLs live under microsoftPackagesPath,
         // not under the main packagesPath.

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { Parser, Builder } from 'xml2js';
-import { getConfigManager } from '../utils/configManager.js';
+import { getConfigManager, fallbackPackagePath } from '../utils/configManager.js';
 import { registerCustomModel, resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
@@ -69,7 +69,7 @@ const CreateD365FileArgsSchema = z.object({
   packagePath: z
     .string()
     .optional()
-    .describe('Base package path (default: K:\\AosService\\PackagesLocalDirectory)'),
+    .describe('Base package path (default: auto-detected from .mcp.json or well-known locations: C:\\, J:\\, K:\\AosService\\PackagesLocalDirectory)'),
   sourceCode: z
     .string()
     .optional()
@@ -3380,9 +3380,9 @@ export async function handleCreateD365File(
       resolvedPackageName = args.packageName;
       if (envType === 'ude') {
         const customPath = await configManager.getCustomPackagesPath();
-        basePath = customPath || args.packagePath || configPackagePath || 'K:\\AosService\\PackagesLocalDirectory';
+        basePath = customPath || args.packagePath || configPackagePath || fallbackPackagePath();
       } else {
-        basePath = args.packagePath || configPackagePath || 'K:\\AosService\\PackagesLocalDirectory';
+        basePath = args.packagePath || configPackagePath || fallbackPackagePath();
       }
     } else if (envType === 'ude') {
       // UDE mode: auto-resolve package name via descriptor scan
@@ -3399,7 +3399,7 @@ export async function handleCreateD365File(
       } else {
         // Fallback: assume package == model (common case)
         resolvedPackageName = actualModelName;
-        basePath = customPath || args.packagePath || configPackagePath || 'K:\\AosService\\PackagesLocalDirectory';
+        basePath = customPath || args.packagePath || configPackagePath || fallbackPackagePath();
       }
     } else {
       // Traditional mode without explicit packageName: assume package == model
@@ -3407,7 +3407,7 @@ export async function handleCreateD365File(
       basePath =
         args.packagePath ||
         configPackagePath ||
-        'K:\\AosService\\PackagesLocalDirectory';
+        fallbackPackagePath();
     }
 
     console.error(

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -11,7 +11,8 @@ import * as fs from 'fs/promises';
 
 import path from 'path';
 import { parseStringPromise } from 'xml2js';
-import { getConfigManager } from '../utils/configManager.js';
+import { getConfigManager, fallbackPackagePath, extractModelFromFilePath } from '../utils/configManager.js';
+import { isStandardModel } from '../utils/modelClassifier.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { resolveDbPathLocally } from '../utils/metadataResolver.js';
 import {
@@ -369,6 +370,27 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         `  2. Pass filePath="K:\\\\AosService\\\\PackagesLocalDirectory\\\\<pkg>\\\\<model>\\\\${objectName}.xml" — bypasses all lookup.\n` +
         `  3. If the object was just created, re-run create_d365fo_file first and use the returned path as filePath.`
       );
+    }
+
+    // 1b. Model-ownership guard: refuse to modify objects in standard Microsoft models.
+    // This prevents accidental writes to ApplicationSuite, ApplicationFoundation, etc.
+    const resolvedModelFromPath = extractModelFromFilePath(filePath);
+    if (resolvedModelFromPath && isStandardModel(resolvedModelFromPath)) {
+      const configManager = getConfigManager();
+      const configuredModel = modelName || configManager.getModelName();
+      // Only block if the resolved model differs from the user's explicitly configured model.
+      // If user explicitly set modelName=ApplicationSuite, they know what they're doing.
+      if (!modelName || modelName !== resolvedModelFromPath) {
+        throw new Error(
+          `⛔ Refusing to modify "${objectName}" — the resolved file belongs to standard Microsoft model "${resolvedModelFromPath}".\n\n` +
+          `Your configured model is "${configuredModel || '(not set)'}".\n` +
+          `Modifying standard objects is not permitted — it can corrupt the base application.\n\n` +
+          `To extend a standard object, create an extension instead:\n` +
+          `  • Table: create_d365fo_file(objectType="table-extension", objectName="${objectName}.${configuredModel || 'YourModel'}Extension")\n` +
+          `  • Class: create_d365fo_file(objectType="class-extension", objectName="${objectName}_Extension")\n` +
+          `  • Form:  create_d365fo_file(objectType="form-extension", objectName="${objectName}.${configuredModel || 'YourModel'}Extension")`
+        );
+      }
     }
 
     // 2. Resolve actual XML file path (DB may store JSON metadata with sourcePath)
@@ -839,15 +861,31 @@ async function findD365File(
       const row = stmt.get(symbolType, objectName, modelName);
       dbResult = row ? row.file_path : null;
     } else {
-      const stmt = rdb.prepare(`
-        SELECT file_path
-        FROM symbols
-        WHERE type = ? AND name = ?
-        ORDER BY model
-        LIMIT 1
-      `);
-      const row = stmt.get(symbolType, objectName);
-      dbResult = row ? row.file_path : null;
+      // No modelName specified — prefer the user's configured model to avoid
+      // accidentally resolving to a standard Microsoft model (issue #369).
+      const configuredModel = getConfigManager().getModelName();
+      if (configuredModel) {
+        const stmtPref = rdb.prepare(`
+          SELECT file_path
+          FROM symbols
+          WHERE type = ? AND name = ? AND model = ?
+          LIMIT 1
+        `);
+        const prefRow = stmtPref.get(symbolType, objectName, configuredModel);
+        dbResult = prefRow ? prefRow.file_path : null;
+      }
+      if (!dbResult) {
+        // Fallback: any model (still guarded by the standard-model check after findD365File)
+        const stmt = rdb.prepare(`
+          SELECT file_path
+          FROM symbols
+          WHERE type = ? AND name = ?
+          ORDER BY model
+          LIMIT 1
+        `);
+        const row = stmt.get(symbolType, objectName);
+        dbResult = row ? row.file_path : null;
+      }
     }
 
     // Only trust the DB path when it is an absolute path that actually exists on disk.
@@ -940,7 +978,7 @@ export async function findD365FileOnDisk(
   }
 
   const configPackagePath =
-    configManager.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
+    configManager.getPackagePath() || fallbackPackagePath();
 
   // Traditional mode: package name == model name (most common case)
   const candidatePath = path.join(
@@ -1120,7 +1158,7 @@ async function findBaseFormXml(baseFormName: string, symbolIndex: any): Promise<
     if (!path.isAbsolute(dbFilePath)) {
       const cm = getConfigManager();
       await cm.ensureLoaded();
-      const pkgPath = cm.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
+      const pkgPath = cm.getPackagePath() || fallbackPackagePath();
       const abs = await tryRead(path.join(pkgPath, dbFilePath));
       if (abs) return abs;
     }

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -682,6 +682,7 @@ class ConfigManager {
     if (process.platform === 'win32') {
       const wellKnownCandidates = [
         'C:\\AosService\\PackagesLocalDirectory',
+        'J:\\AosService\\PackagesLocalDirectory',
         'K:\\AosService\\PackagesLocalDirectory',
       ];
       for (const candidate of wellKnownCandidates) {
@@ -1115,4 +1116,32 @@ export async function initializeConfig(
 ): Promise<McpConfig | null> {
   const manager = getConfigManager(configPath);
   return await manager.load();
+}
+
+/**
+ * Fallback package path when configManager.getPackagePath() returns null.
+ * This only happens when no config is loaded AND none of the well-known
+ * candidate paths (C:, J:, K:) exist on the filesystem.
+ * The value is a safe sentinel — callers will get a clear 'file not found'
+ * rather than silently defaulting to a specific drive letter.
+ */
+const FALLBACK_PACKAGE_PATH = 'C:\\AosService\\PackagesLocalDirectory';
+
+export function fallbackPackagePath(): string {
+  return FALLBACK_PACKAGE_PATH;
+}
+
+/**
+ * Extract the package name from a D365FO file path.
+ * Standard AOT layout: .../PackagesLocalDirectory/{Package}/{Model}/Ax{Type}/{Name}.xml
+ * Returns the package name (first segment after PackagesLocalDirectory), or null.
+ * The package name is what isStandardModel() checks against (e.g. ApplicationSuite).
+ */
+export function extractModelFromFilePath(filePath: string): string | null {
+  const normalised = filePath.replace(/\\/g, '/');
+  const match = normalised.match(/PackagesLocalDirectory\/([^/]+)\/[^/]+\/Ax[^/]+\//i);
+  if (match) {
+    return match[1]; // package name (first segment, e.g. ApplicationSuite)
+  }
+  return null;
 }

--- a/src/utils/metadataResolver.ts
+++ b/src/utils/metadataResolver.ts
@@ -15,7 +15,7 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { getConfigManager } from './configManager.js';
+import { getConfigManager, fallbackPackagePath } from './configManager.js';
 
 // Resolve path relative to this file, not to process.cwd()
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -262,7 +262,7 @@ export async function resolveDbPathLocally(dbFilePath: string): Promise<string |
   const configManager = getConfigManager();
   await configManager.ensureLoaded();
   const localPackagePath =
-    configManager.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
+    configManager.getPackagePath() || fallbackPackagePath();
 
   // Convert forward slashes back to the OS separator
   const localPath = path.join(localPackagePath, ...relativePart.split('/'));

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -42,6 +42,8 @@ vi.mock('../../src/utils/configManager', () => ({
     getCustomPackagesPath: vi.fn(async () => null),
     getMicrosoftPackagesPath: vi.fn(async () => null),
   })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
 }));
 
 vi.mock('../../src/utils/packageResolver', () => ({
@@ -62,6 +64,7 @@ vi.mock('../../src/utils/modelClassifier', () => ({
   resolveObjectPrefix: vi.fn(() => ''),
   applyObjectPrefix: vi.fn((name: string) => name),
   isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
 }));
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/tests/utils/configManager.test.ts
+++ b/tests/utils/configManager.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getConfigManager } from '../../src/utils/configManager';
+import { getConfigManager, fallbackPackagePath, extractModelFromFilePath } from '../../src/utils/configManager';
 
 // Prevent real file I/O during unit tests
 vi.mock('fs/promises', () => ({
@@ -274,5 +274,44 @@ describe('kebab-case path rejection', () => {
     // Hyphen in name → skip, fall back to env or null
     delete process.env.D365FO_MODEL_NAME;
     expect(mgr.getModelName()).toBeNull();
+  });
+});
+
+// ─── fallbackPackagePath ─────────────────────────────────────────────────────
+
+describe('fallbackPackagePath', () => {
+  it('returns a valid C: path string', () => {
+    const result = fallbackPackagePath();
+    expect(result).toBe('C:\\AosService\\PackagesLocalDirectory');
+  });
+});
+
+// ─── extractModelFromFilePath (issue #369) ───────────────────────────────────
+
+describe('extractModelFromFilePath', () => {
+  it('extracts package name from standard AOT path', () => {
+    expect(extractModelFromFilePath(
+      'K:\\AosService\\PackagesLocalDirectory\\ApplicationSuite\\Foundation\\AxTable\\CustTable.xml'
+    )).toBe('ApplicationSuite');
+  });
+
+  it('extracts package name when package == model', () => {
+    expect(extractModelFromFilePath(
+      'K:\\AosService\\PackagesLocalDirectory\\ContosoExt\\ContosoExt\\AxClass\\MyClass.xml'
+    )).toBe('ContosoExt');
+  });
+
+  it('handles forward slashes', () => {
+    expect(extractModelFromFilePath(
+      'K:/AosService/PackagesLocalDirectory/AppSuite/Foundation/AxForm/CustTable.xml'
+    )).toBe('AppSuite');
+  });
+
+  it('returns null for non-AOT paths', () => {
+    expect(extractModelFromFilePath('/home/vsts/work/1/s/foo.xml')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractModelFromFilePath('')).toBeNull();
   });
 });


### PR DESCRIPTION
#374 - Package path not correct:
- index.ts: await configMgr.ensureLoaded() before bridge initialization (config was null, causing getPackagePath() to skip explicit packagePath)
- configManager.ts: add J:\ to well-known probe candidates (C, J, K)
- bridgeClient.ts: reorder detectPackagesPath() — env var first, then C/J/K
- Remove all hardcoded 'K:\AosService\PackagesLocalDirectory' fallbacks from createD365File.ts, modifyD365File.ts, metadataResolver.ts — replaced with fallbackPackagePath() that returns C: as safe sentinel
- extractModelFromFilePath() utility for path → package name resolution

#369 - Unauthorized Modifications to Standard Objects:
- modifyD365File.ts: add model-ownership guard after findD365File() — refuses to write to standard Microsoft models (ApplicationSuite, etc.) with actionable error message suggesting extension patterns instead
- findD365File(): prefer user's configured model in DB query when no modelName is specified, preventing alphabetical-first resolution from returning standard model paths (defense-in-depth)

Tests: 6 new tests (fallbackPackagePath, extractModelFromFilePath),
       mock updates for file-ops.test.ts — 260/260 passing