### PR TITLE
fix(build): chain VsDevCmd.bat before MSBuild to resolve MSB4062 (#385)

### DIFF
--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
-import { execFile } from 'child_process';
+import { execFile, exec } from 'child_process';
 import util from 'util';
 import { access } from 'fs/promises';
 import { getConfigManager } from '../utils/configManager.js';
 import { withOperationLock } from '../utils/operationLocks.js';
 
 const execFileAsync = util.promisify(execFile);
+const execAsync = util.promisify(exec);
 
 // Known MSBuild locations on D365FO development VMs (in order of preference)
 const MSBUILD_CANDIDATES = [
@@ -16,6 +17,20 @@ const MSBUILD_CANDIDATES = [
   'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe',
   'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe',
 ];
+
+// VS Developer Command Prompt batch files — initialises the VS environment so that
+// D365FO MSBuild task assemblies (e.g. Microsoft.Dynamics.Framework.Tools.BuildTasks.17.0)
+// are discoverable by MSBuild (fixes MSB4062 / "could not load assembly" errors).
+const VS_DEV_CMD_CANDIDATES = [
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\Tools\\VsDevCmd.bat',
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\Common7\\Tools\\VsDevCmd.bat',
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\Common7\\Tools\\VsDevCmd.bat',
+  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\Common7\\Tools\\VsDevCmd.bat',
+  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\Common7\\Tools\\VsDevCmd.bat',
+  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\Common7\\Tools\\VsDevCmd.bat',
+];
+
+const D365_BUILD_TASKS_ASSEMBLY = 'Microsoft.Dynamics.Framework.Tools.BuildTasks';
 
 export const buildProjectToolDefinition = {
   name: 'build_d365fo_project',
@@ -53,6 +68,19 @@ export const buildProjectTool = async (params: any, _context: any) => {
       msbuildExe = 'msbuild';
     }
 
+    // Try to locate VsDevCmd.bat — when present we chain it before MSBuild so that the
+    // Visual Studio extension directories are on the probing path.  This prevents MSB4062
+    // ("could not load assembly Microsoft.Dynamics.Framework.Tools.BuildTasks") which
+    // occurs when MSBuild is invoked outside the VS Developer environment.
+    let vsDevCmdPath: string | null = null;
+    for (const candidate of VS_DEV_CMD_CANDIDATES) {
+      try {
+        await access(candidate);
+        vsDevCmdPath = candidate;
+        break;
+      } catch { /* not found, try next */ }
+    }
+
     const buildArgs = [
       resolvedProjectPath,
       '/p:Configuration=Debug',
@@ -61,20 +89,66 @@ export const buildProjectTool = async (params: any, _context: any) => {
       '/v:minimal',
       '/nologo',
     ];
-    console.error(`[build_d365fo_project] Running: ${msbuildExe} ${buildArgs.join(' ')}`);
 
-    const { stdout, stderr } = await withOperationLock(
-      `build:${resolvedProjectPath}`,
-      () => execFileAsync(msbuildExe, buildArgs, {
-        maxBuffer: 20 * 1024 * 1024,
-        timeout: 600_000, // 10 minutes
-        windowsHide: true,
-      }),
-    );
+    let stdout: string;
+    let stderr: string;
+
+    if (vsDevCmdPath) {
+      // Run MSBuild through the VS Developer Command Prompt environment.
+      // `call "VsDevCmd.bat"` initialises VS environment variables in-process so that
+      // D365FO MSBuild task assemblies are discoverable by the subsequent MSBuild call
+      // (Node.js exec() uses cmd.exe /C on Windows, so && chaining works correctly).
+      const msbuildToken = msbuildExe.includes(' ') ? `"${msbuildExe}"` : msbuildExe;
+      const argsToken = buildArgs.map(a => (a.includes(' ') ? `"${a}"` : a)).join(' ');
+      const fullCmd = `call "${vsDevCmdPath}" && ${msbuildToken} ${argsToken}`;
+      console.error(`[build_d365fo_project] Running via VsDevCmd: ${fullCmd}`);
+      ({ stdout, stderr } = await withOperationLock(
+        `build:${resolvedProjectPath}`,
+        () => execAsync(fullCmd, {
+          maxBuffer: 20 * 1024 * 1024,
+          timeout: 600_000, // 10 minutes
+        }),
+      ));
+    } else {
+      console.error(`[build_d365fo_project] Running: ${msbuildExe} ${buildArgs.join(' ')}`);
+      ({ stdout, stderr } = await withOperationLock(
+        `build:${resolvedProjectPath}`,
+        () => execFileAsync(msbuildExe!, buildArgs, {
+          maxBuffer: 20 * 1024 * 1024,
+          timeout: 600_000, // 10 minutes
+          windowsHide: true,
+        }),
+      ));
+    }
 
     const output = [stdout, stderr].filter(Boolean).join('\n').trim();
     const hasErrors = /\b(error|Error)\s+(CS|AX|X\+\+|MSB)\d+|Build FAILED/i.test(output);
     const hasWarnings = /\b(warning)\s+(CS|AX|X\+\+|MSB|BP)\d+/i.test(output);
+
+    // Detect the specific D365FO task-assembly load failure even when it is reported as a
+    // warning/info line rather than a hard error.
+    const hasBuildTasksError = output.includes(D365_BUILD_TASKS_ASSEMBLY) && output.includes('MSB4062');
+    if (hasBuildTasksError) {
+      return {
+        content: [{
+          type: 'text',
+          text: `❌ Build FAILED — D365FO MSBuild task assembly not found (MSB4062)\n\n` +
+            `Project: ${resolvedProjectPath}\n\n` +
+            `The assembly \`${D365_BUILD_TASKS_ASSEMBLY}\` could not be loaded.\n\n` +
+            `**Root cause:** MSBuild was invoked outside the Visual Studio Developer environment, ` +
+            `so the D365FO extension task DLLs are not on the assembly probing path.\n\n` +
+            `**How to fix:**\n` +
+            `1. Ensure the "Dynamics 365" Visual Studio extension is fully installed (repair if needed).\n` +
+            `2. Verify that \`VsDevCmd.bat\` exists in \`Common7\\Tools\` under your VS installation — ` +
+            `this tool automatically chains through it when found.\n` +
+            `3. If the extension is installed but the error persists, run MSBuild from a ` +
+            `**Developer Command Prompt for VS 2022** (Start menu) and confirm the build ` +
+            `succeeds there first.\n\n` +
+            `Raw output:\n${output}`
+        }],
+        isError: true
+      };
+    }
 
     const status = hasErrors ? '❌ Build FAILED' : hasWarnings ? '⚠️ Build succeeded with warnings' : '✅ Build succeeded';
 
@@ -83,9 +157,31 @@ export const buildProjectTool = async (params: any, _context: any) => {
     };
   } catch (error: any) {
     console.error('Error building project:', error);
-    const output = [error.stdout, error.stderr, error.message].filter(Boolean).join('\n');
+    const rawOutput = [error.stdout, error.stderr, error.message].filter(Boolean).join('\n');
+
+    // Surface a targeted hint when the process exits non-zero due to the D365FO task assembly issue.
+    if (rawOutput.includes(D365_BUILD_TASKS_ASSEMBLY) && rawOutput.includes('MSB4062')) {
+      return {
+        content: [{
+          type: 'text',
+          text: `❌ Build failed — D365FO MSBuild task assembly not found (MSB4062)\n\n` +
+            `The assembly \`${D365_BUILD_TASKS_ASSEMBLY}\` could not be loaded by MSBuild.\n\n` +
+            `**Root cause:** The D365FO Visual Studio extension task DLLs are not discoverable ` +
+            `when MSBuild is run outside a Developer Command Prompt environment.\n\n` +
+            `**How to fix:**\n` +
+            `1. Ensure the "Dynamics 365" Visual Studio extension is fully installed.\n` +
+            `2. Verify \`VsDevCmd.bat\` exists at \`Common7\\Tools\` inside your VS 2022 install ` +
+            `folder — this tool chains through it automatically when present.\n` +
+            `3. As a fallback, open a **Developer Command Prompt for VS 2022** and confirm ` +
+            `\`msbuild "${resolvedProjectPath}"\` succeeds there.\n\n` +
+            `Raw output:\n${rawOutput}`
+        }],
+        isError: true
+      };
+    }
+
     return {
-      content: [{ type: 'text', text: '❌ Build failed:\n\n' + output }],
+      content: [{ type: 'text', text: '❌ Build failed:\n\n' + rawOutput }],
       isError: true
     };
   }


### PR DESCRIPTION
The D365FO MSBuild task assembly (Microsoft.Dynamics.Framework.Tools.BuildTasks) is only discoverable when MSBuild runs inside a Visual Studio Developer environment. Invoking MSBuild directly outside that context causes MSB4062 / CopyReferencesTask load failures reported in #385.

Changes:
- Auto-detect VsDevCmd.bat across VS 2022/2019 Enterprise/Professional/Community
- When found, run  via cmd.exe so the VS extension directories are on the assembly probing path before MSBuild starts
- Add targeted MSB4062 error response with root-cause explanation and fix steps for cases where VsDevCmd.bat is missing or the D365 extension is not installed

Closes #385