### PR TITLE
fix(bridge): fix modify operations on custom objects and form DataCon…

### DIFF
--- a/bridge/D365MetadataBridge/Program.cs
+++ b/bridge/D365MetadataBridge/Program.cs
@@ -33,6 +33,7 @@ namespace D365MetadataBridge
         private static string? _binPath = null; // Explicit bin path (UDE: microsoftPackagesPath/bin)
         private static string _xrefServer = "localhost";
         private static string _xrefDatabase = "DYNAMICSXREFDB";
+        private static string? _logFile = null;
         private static readonly TextWriter Log = Console.Error;
 
         static async Task<int> Main(string[] args)
@@ -54,9 +55,35 @@ namespace D365MetadataBridge
                     case "--xref-database" when i + 1 < args.Length:
                         _xrefDatabase = args[++i];
                         break;
+                    case "--log-file" when i + 1 < args.Length:
+                        _logFile = args[++i];
+                        break;
                     case "--help":
                         PrintUsage();
                         return 0;
+                }
+            }
+
+            // Setup file-based logging (tee stderr → file) BEFORE anything else runs.
+            // Configured via --log-file <path> or bridgeLogFile in .mcp.json.
+            if (_logFile != null)
+            {
+                try
+                {
+                    var logDir = Path.GetDirectoryName(_logFile);
+                    if (!string.IsNullOrEmpty(logDir) && !Directory.Exists(logDir))
+                        Directory.CreateDirectory(logDir);
+
+                    var fileWriter = new StreamWriter(_logFile, append: true) { AutoFlush = true };
+                    var teeWriter = new TeeTextWriter(Console.Error, fileWriter);
+                    Console.SetError(teeWriter);
+                    Console.Error.WriteLine($"\n{new string('─', 72)}");
+                    Console.Error.WriteLine($"[Bridge] Log started at {DateTime.Now:O}  pid={System.Diagnostics.Process.GetCurrentProcess().Id}");
+                    Console.Error.WriteLine(new string('─', 72));
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[WARN] Cannot open log file {_logFile}: {ex.Message}");
                 }
             }
 
@@ -250,6 +277,58 @@ namespace D365MetadataBridge
             };
         }
 
+        /// <summary>
+        /// TextWriter that writes to two underlying writers simultaneously (tee).
+        /// Used to mirror Console.Error to both the original stderr pipe AND a log file.
+        /// </summary>
+        private sealed class TeeTextWriter : TextWriter
+        {
+            private readonly TextWriter _primary;
+            private readonly TextWriter _secondary;
+
+            public TeeTextWriter(TextWriter primary, TextWriter secondary)
+            {
+                _primary = primary;
+                _secondary = secondary;
+            }
+
+            public override System.Text.Encoding Encoding => _primary.Encoding;
+
+            public override void Write(char value)
+            {
+                _primary.Write(value);
+                _secondary.Write(value);
+            }
+
+            public override void Write(string? value)
+            {
+                _primary.Write(value);
+                _secondary.Write(value);
+            }
+
+            public override void WriteLine(string? value)
+            {
+                _primary.WriteLine(value);
+                _secondary.WriteLine(value);
+            }
+
+            public override void Flush()
+            {
+                _primary.Flush();
+                _secondary.Flush();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _secondary.Flush();
+                    _secondary.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+        }
+
         private static void PrintUsage()
         {
             Console.Error.WriteLine(@"
@@ -263,6 +342,7 @@ Options:
   --bin-path <path>        Explicit DLL directory (UDE: microsoftPackagesPath\bin). If omitted, uses {packages-path}\bin.
   --xref-server <server>   SQL Server for cross-reference DB (default: localhost)
   --xref-database <db>     Cross-reference database name (default: DYNAMICSXREFDB)
+  --log-file <path>        Write all diagnostic logs to this file (append mode)
   --help                   Show this help
 
 Protocol:

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -1142,6 +1142,51 @@ namespace D365MetadataBridge.Services
 
                     return new { success = true, operation = "add-method", objectType, objectName, methodName, api = "IMetaViewProvider.Update" };
                 }
+                case "form-extension":
+                {
+                    var axExt = _provider.FormExtensions.Read(objectName)
+                        ?? throw new ArgumentException($"Form extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.FormExtensions, objectName);
+
+                    RemoveMethodIfExists(axExt, methodName);
+
+                    var axMethod = new AxMethod { Name = methodName, Source = source };
+                    ((dynamic)axExt).Methods.Add(axMethod);
+
+                    ((IMetaFormExtensionProvider)_provider.FormExtensions).Update(axExt, msi);
+
+                    return new { success = true, operation = "add-method", objectType, objectName, methodName, api = "IMetaFormExtensionProvider.Update" };
+                }
+                case "class-extension":
+                {
+                    var axClass = _provider.Classes.Read(objectName)
+                        ?? throw new ArgumentException($"Class extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.Classes, objectName);
+
+                    RemoveMethodIfExists(axClass, methodName);
+
+                    var axMethod = new AxMethod { Name = methodName, Source = source };
+                    axClass.AddMethod(axMethod);
+
+                    ((IMetaClassProvider)_provider.Classes).Update(axClass, msi);
+
+                    return new { success = true, operation = "add-method", objectType, objectName, methodName, api = "IMetaClassProvider.Update" };
+                }
+                case "table-extension":
+                {
+                    var axExt = _provider.TableExtensions.Read(objectName)
+                        ?? throw new ArgumentException($"Table extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.TableExtensions, objectName);
+
+                    RemoveMethodIfExists(axExt, methodName);
+
+                    var axMethod = new AxMethod { Name = methodName, Source = source };
+                    ((dynamic)axExt).Methods.Add(axMethod);
+
+                    ((IMetaTableExtensionProvider)_provider.TableExtensions).Update(axExt, msi);
+
+                    return new { success = true, operation = "add-method", objectType, objectName, methodName, api = "IMetaTableExtensionProvider.Update" };
+                }
                 default:
                     throw new ArgumentException($"add-method not supported for objectType '{objectType}' via bridge (use XML fallback)");
             }
@@ -1305,6 +1350,43 @@ namespace D365MetadataBridge.Services
                     var obj = _provider.Forms.Read(objectName)
                         ?? throw new ArgumentException($"Form '{objectName}' not found");
                     var msi = GetModelSaveInfoForObject(_provider.Forms, objectName);
+
+                    // Diagnostic: log available SourceCode collections for debugging
+                    try
+                    {
+                        dynamic dForm = obj;
+                        int scMethodCount = 0, scDataControlCount = 0, scDataSourceCount = 0;
+                        var dcNames = new System.Collections.Generic.List<string>();
+                        try { foreach (var _ in dForm.SourceCode.Methods) scMethodCount++; } catch { }
+                        try
+                        {
+                            foreach (dynamic dc in dForm.SourceCode.DataControls)
+                            {
+                                scDataControlCount++;
+                                try
+                                {
+                                    string dcName = (string)dc.Name;
+                                    int methodCount = 0;
+                                    var methodNames = new System.Collections.Generic.List<string>();
+                                    try { foreach (dynamic m in dc.Methods) { methodCount++; try { methodNames.Add((string)m.Name); } catch { } } } catch { }
+                                    dcNames.Add($"{dcName}({string.Join(",", methodNames)})");
+                                }
+                                catch { dcNames.Add("?"); }
+                            }
+                        }
+                        catch { }
+                        try { foreach (var _ in dForm.SourceCode.DataSources) scDataSourceCount++; } catch { }
+                        Console.Error.WriteLine($"[WriteService] ReplaceCode form '{objectName}': " +
+                            $"SourceCode.Methods={scMethodCount}, DataControls={scDataControlCount}, DataSources={scDataSourceCount}, " +
+                            $"methodName='{methodName}', oldCode length={oldCode.Length}");
+                        if (dcNames.Count > 0)
+                            Console.Error.WriteLine($"[WriteService] ReplaceCode form '{objectName}': DataControls detail: [{string.Join(", ", dcNames)}]");
+                    }
+                    catch (Exception diagEx)
+                    {
+                        Console.Error.WriteLine($"[WriteService] ReplaceCode form '{objectName}': diagnostic failed: {diagEx.Message}");
+                    }
+
                     var replaced = ReplaceInMethods(obj, methodName, oldCode, newCode);
                     if (!replaced)
                         throw new InvalidOperationException($"oldCode not found in {objectName}" + (methodName != null ? $".{methodName}" : ""));
@@ -1331,6 +1413,39 @@ namespace D365MetadataBridge.Services
                     if (!replaced)
                         throw new InvalidOperationException($"oldCode not found in {objectName}" + (methodName != null ? $".{methodName}" : ""));
                     ((IMetaViewProvider)_provider.Views).Update(obj, msi);
+                    return new { success = true, operation = "replace-code", objectType, objectName, methodName, api = "Update" };
+                }
+                case "form-extension":
+                {
+                    var obj = _provider.FormExtensions.Read(objectName)
+                        ?? throw new ArgumentException($"Form extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.FormExtensions, objectName);
+                    var replaced = ReplaceInMethods(obj, methodName, oldCode, newCode);
+                    if (!replaced)
+                        throw new InvalidOperationException($"oldCode not found in {objectName}" + (methodName != null ? $".{methodName}" : ""));
+                    ((IMetaFormExtensionProvider)_provider.FormExtensions).Update(obj, msi);
+                    return new { success = true, operation = "replace-code", objectType, objectName, methodName, api = "Update" };
+                }
+                case "class-extension":
+                {
+                    var obj = _provider.Classes.Read(objectName)
+                        ?? throw new ArgumentException($"Class extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.Classes, objectName);
+                    var replaced = ReplaceInMethods(obj, methodName, oldCode, newCode);
+                    if (!replaced)
+                        throw new InvalidOperationException($"oldCode not found in {objectName}" + (methodName != null ? $".{methodName}" : ""));
+                    ((IMetaClassProvider)_provider.Classes).Update(obj, msi);
+                    return new { success = true, operation = "replace-code", objectType, objectName, methodName, api = "Update" };
+                }
+                case "table-extension":
+                {
+                    var obj = _provider.TableExtensions.Read(objectName)
+                        ?? throw new ArgumentException($"Table extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.TableExtensions, objectName);
+                    var replaced = ReplaceInMethods(obj, methodName, oldCode, newCode);
+                    if (!replaced)
+                        throw new InvalidOperationException($"oldCode not found in {objectName}" + (methodName != null ? $".{methodName}" : ""));
+                    ((IMetaTableExtensionProvider)_provider.TableExtensions).Update(obj, msi);
                     return new { success = true, operation = "replace-code", objectType, objectName, methodName, api = "Update" };
                 }
                 default:
@@ -1399,6 +1514,36 @@ namespace D365MetadataBridge.Services
                         throw new InvalidOperationException($"Method '{methodName}' not found on view '{objectName}'");
                     ((IMetaViewProvider)_provider.Views).Update(obj, msi);
                     return new { success = true, operation = "remove-method", objectType, objectName, methodName, api = "IMetaViewProvider.Update" };
+                }
+                case "form-extension":
+                {
+                    var obj = _provider.FormExtensions.Read(objectName)
+                        ?? throw new ArgumentException($"Form extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.FormExtensions, objectName);
+                    if (!RemoveMethodByName(obj, methodName))
+                        throw new InvalidOperationException($"Method '{methodName}' not found on form extension '{objectName}'");
+                    ((IMetaFormExtensionProvider)_provider.FormExtensions).Update(obj, msi);
+                    return new { success = true, operation = "remove-method", objectType, objectName, methodName, api = "IMetaFormExtensionProvider.Update" };
+                }
+                case "class-extension":
+                {
+                    var obj = _provider.Classes.Read(objectName)
+                        ?? throw new ArgumentException($"Class extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.Classes, objectName);
+                    if (!RemoveMethodByName(obj, methodName))
+                        throw new InvalidOperationException($"Method '{methodName}' not found on class extension '{objectName}'");
+                    ((IMetaClassProvider)_provider.Classes).Update(obj, msi);
+                    return new { success = true, operation = "remove-method", objectType, objectName, methodName, api = "IMetaClassProvider.Update" };
+                }
+                case "table-extension":
+                {
+                    var obj = _provider.TableExtensions.Read(objectName)
+                        ?? throw new ArgumentException($"Table extension '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.TableExtensions, objectName);
+                    if (!RemoveMethodByName(obj, methodName))
+                        throw new InvalidOperationException($"Method '{methodName}' not found on table extension '{objectName}'");
+                    ((IMetaTableExtensionProvider)_provider.TableExtensions).Update(obj, msi);
+                    return new { success = true, operation = "remove-method", objectType, objectName, methodName, api = "IMetaTableExtensionProvider.Update" };
                 }
                 default:
                     throw new ArgumentException($"remove-method not supported for objectType '{objectType}' via bridge");
@@ -2221,18 +2366,81 @@ namespace D365MetadataBridge.Services
         /// <summary>
         /// Removes a method by name from an AxClass or AxTable (both have a Methods collection).
         /// Uses dynamic because the Methods property is not on a shared interface.
+        /// For forms/form-extensions, also checks SourceCode.Methods and SourceCode.DataControls.
         /// </summary>
         private void RemoveMethodIfExists(object axObject, string methodName)
         {
+            // Try top-level Methods first (AxClass, AxTable, AxTableExtension, etc.)
+            if (TryRemoveFromCollection(axObject, "Methods", methodName)) return;
+
+            // For forms: SourceCode.Methods (form-level methods like init, run)
             try
             {
-                // Both AxClass and AxTable expose Methods as a KeyedObjectCollection<AxMethod>
                 dynamic dyn = axObject;
-                var methods = dyn.Methods;
-                AxMethod? toRemove = null;
-                foreach (AxMethod m in methods)
+                dynamic sourceCode = dyn.SourceCode;
+                if (sourceCode != null && TryRemoveFromCollection(sourceCode, "Methods", methodName)) return;
+            }
+            catch { }
+
+            // For forms: SourceCode.DataControls (control override methods)
+            try
+            {
+                dynamic dyn = axObject;
+                dynamic sourceCode = dyn.SourceCode;
+                if (sourceCode != null && TryRemoveFromCollection(sourceCode, "DataControls", methodName)) return;
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Removes a method by name, returning true if found and removed.
+        /// For forms/form-extensions, also checks SourceCode.Methods and SourceCode.DataControls.
+        /// </summary>
+        private bool RemoveMethodByName(object axObject, string methodName)
+        {
+            // Try top-level Methods first (AxClass, AxTable, etc.)
+            if (TryRemoveFromCollection(axObject, "Methods", methodName)) return true;
+
+            // For forms: SourceCode.Methods
+            try
+            {
+                dynamic dyn = axObject;
+                dynamic sourceCode = dyn.SourceCode;
+                if (sourceCode != null && TryRemoveFromCollection(sourceCode, "Methods", methodName)) return true;
+            }
+            catch { }
+
+            // For forms: SourceCode.DataControls
+            try
+            {
+                dynamic dyn = axObject;
+                dynamic sourceCode = dyn.SourceCode;
+                if (sourceCode != null && TryRemoveFromCollection(sourceCode, "DataControls", methodName)) return true;
+            }
+            catch { }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to remove a method by Name from a named collection on the given object.
+        /// Returns true if found and removed. Catches silently if the collection doesn't exist.
+        /// </summary>
+        private bool TryRemoveFromCollection(object parentObj, string collectionName, string methodName)
+        {
+            try
+            {
+                var prop = parentObj.GetType().GetProperty(collectionName);
+                if (prop == null) return false;
+                dynamic collection = prop.GetValue(parentObj);
+                if (collection == null) return false;
+
+                // Find the method to remove
+                dynamic? toRemove = null;
+                foreach (dynamic m in collection)
                 {
-                    if (string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase))
+                    string mName = (string)m.Name;
+                    if (string.Equals(mName, methodName, StringComparison.OrdinalIgnoreCase))
                     {
                         toRemove = m;
                         break;
@@ -2240,40 +2448,16 @@ namespace D365MetadataBridge.Services
                 }
                 if (toRemove != null)
                 {
-                    // KeyedObjectCollection has Remove(T) or RemoveAt
-                    methods.Remove(toRemove);
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"[WriteService] RemoveMethodIfExists failed: {ex.Message}");
-            }
-        }
-
-        /// <summary>
-        /// Removes a method by name, returning true if found and removed.
-        /// Unlike RemoveMethodIfExists, this throws-friendly variant returns a boolean.
-        /// </summary>
-        private bool RemoveMethodByName(object axObject, string methodName)
-        {
-            try
-            {
-                dynamic dyn = axObject;
-                var methods = dyn.Methods;
-                AxMethod? toRemove = null;
-                foreach (AxMethod m in methods)
-                {
-                    if (string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase))
-                    { toRemove = m; break; }
-                }
-                if (toRemove != null)
-                {
-                    methods.Remove(toRemove);
+                    collection.Remove(toRemove);
                     return true;
                 }
                 return false;
             }
-            catch { return false; }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[WriteService] TryRemoveFromCollection({collectionName}, {methodName}) failed: {ex.Message}");
+                return false;
+            }
         }
 
         /// <summary>Sets a property on an existing table field.</summary>
@@ -2415,8 +2599,20 @@ namespace D365MetadataBridge.Services
                 dynamic dyn = axObject;
                 bool replaced = false;
 
-                // Check declaration first (for classDeclaration scope)
-                if (methodName == null || methodName.Equals("classDeclaration", StringComparison.OrdinalIgnoreCase))
+                // Parse "ControlName.methodName" syntax for scoping to a specific form control override.
+                // E.g. methodName="PostButton.clicked" → controlNameFilter="PostButton", effectiveMethodName="clicked"
+                string? controlNameFilter = null;
+                string? effectiveMethodName = methodName;
+                if (methodName != null && methodName.Contains('.'))
+                {
+                    var dotIdx = methodName.IndexOf('.');
+                    controlNameFilter = methodName.Substring(0, dotIdx);
+                    effectiveMethodName = methodName.Substring(dotIdx + 1);
+                }
+
+                // Check declaration first (for classDeclaration scope, only when not targeting a control)
+                if (controlNameFilter == null &&
+                    (methodName == null || methodName.Equals("classDeclaration", StringComparison.OrdinalIgnoreCase)))
                 {
                     try
                     {
@@ -2430,17 +2626,145 @@ namespace D365MetadataBridge.Services
                     catch { /* some objects may not have Declaration */ }
                 }
 
-                // Check methods
-                foreach (AxMethod m in dyn.Methods)
+                // Check top-level methods (skip entirely when scoped to a specific control)
+                if (controlNameFilter == null)
                 {
-                    if (methodName != null && !string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    if (m.Source != null && m.Source.Contains(oldCode))
+                    // Standard objects: dyn.Methods (AxClass, AxTable, AxQuery, AxView, extensions)
+                    try
                     {
-                        m.Source = m.Source.Replace(oldCode, newCode);
-                        replaced = true;
+                        foreach (AxMethod m in dyn.Methods)
+                        {
+                            if (effectiveMethodName != null && !string.Equals(m.Name, effectiveMethodName, StringComparison.OrdinalIgnoreCase))
+                                continue;
+
+                            if (m.Source != null && m.Source.Contains(oldCode))
+                            {
+                                m.Source = m.Source.Replace(oldCode, newCode);
+                                replaced = true;
+                            }
+                        }
                     }
+                    catch { /* object may not have a top-level Methods collection */ }
+
+                    // Forms store methods under SourceCode.Methods (not top-level Methods)
+                    try
+                    {
+                        foreach (dynamic m in dyn.SourceCode.Methods)
+                        {
+                            string mName = (string)m.Name;
+                            if (effectiveMethodName != null && !string.Equals(mName, effectiveMethodName, StringComparison.OrdinalIgnoreCase))
+                                continue;
+
+                            string? src = (string?)m.Source;
+                            if (src != null && src.Contains(oldCode))
+                            {
+                                m.Source = src.Replace(oldCode, newCode);
+                                replaced = true;
+                            }
+                        }
+                    }
+                    catch { /* object may not have SourceCode.Methods (non-form objects) */ }
+                }
+
+                // Control override methods in forms are stored under SourceCode.DataControls.
+                // Each DataControl item is a CONTROL object (Name = control name, e.g. "PostButton")
+                // which contains a Methods collection (each with Name = method name, e.g. "clicked", and Source).
+                // SDK structure:  SourceCode.DataControls → [ { Name: "PostButton", Methods: [{ Name: "clicked", Source: "..." }] } ]
+                try
+                {
+                    foreach (dynamic ctrl in dyn.SourceCode.DataControls)
+                    {
+                        try
+                        {
+                            string ctrlName = (string)ctrl.Name;
+                            bool controlMatches = controlNameFilter == null ||
+                                string.Equals(ctrlName, controlNameFilter, StringComparison.OrdinalIgnoreCase);
+
+                            if (!controlMatches) continue;
+
+                            // Iterate methods inside this control
+                            try
+                            {
+                                foreach (dynamic m in ctrl.Methods)
+                                {
+                                    try
+                                    {
+                                        string mName = (string)m.Name;
+                                        bool methodMatches = effectiveMethodName == null ||
+                                            string.Equals(mName, effectiveMethodName, StringComparison.OrdinalIgnoreCase);
+
+                                        if (methodMatches)
+                                        {
+                                            string? src = (string?)m.Source;
+                                            if (src != null && src.Contains(oldCode))
+                                            {
+                                                m.Source = src.Replace(oldCode, newCode);
+                                                replaced = true;
+                                                Console.Error.WriteLine($"[WriteService] ReplaceInMethods: replaced in DataControl '{ctrlName}'.'{mName}'");
+                                            }
+                                        }
+                                    }
+                                    catch { }
+                                }
+                            }
+                            catch { /* control may not have Methods */ }
+
+                            // Fallback: some SDK versions may expose Source directly on the DataControl item
+                            // (for cases where control name IS the method name, e.g. flat override list)
+                            if (!replaced)
+                            {
+                                try
+                                {
+                                    string? directSrc = (string?)ctrl.Source;
+                                    if (directSrc != null && directSrc.Contains(oldCode))
+                                    {
+                                        ctrl.Source = directSrc.Replace(oldCode, newCode);
+                                        replaced = true;
+                                        Console.Error.WriteLine($"[WriteService] ReplaceInMethods: replaced via direct Source on DataControl '{ctrlName}'");
+                                    }
+                                }
+                                catch { }
+                            }
+                        }
+                        catch { }
+                    }
+                }
+                catch { /* object may not have SourceCode.DataControls (non-form objects) */ }
+
+                // Also try Design.Controls hierarchy — some SDK versions may expose methods on control objects
+                try { replaced |= ReplaceInControls(dyn.Design, controlNameFilter, effectiveMethodName, oldCode, newCode); } catch { }
+                try { replaced |= ReplaceInControls(dyn, controlNameFilter, effectiveMethodName, oldCode, newCode); } catch { }
+
+                // Last resort: if still not found and we have a combined methodName, try the full
+                // "ControlName.methodName" as a single method name in SourceCode.Methods (some forms)
+                if (!replaced && controlNameFilter != null && effectiveMethodName != null)
+                {
+                    try
+                    {
+                        foreach (dynamic m in dyn.SourceCode.Methods)
+                        {
+                            string mName = (string)m.Name;
+                            string combinedUnderscore = $"{controlNameFilter}_{effectiveMethodName}";
+                            if (string.Equals(mName, combinedUnderscore, StringComparison.OrdinalIgnoreCase)
+                             || string.Equals(mName, methodName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                string? src = (string?)m.Source;
+                                if (src != null && src.Contains(oldCode))
+                                {
+                                    m.Source = src.Replace(oldCode, newCode);
+                                    replaced = true;
+                                }
+                            }
+                        }
+                    }
+                    catch { }
+                }
+
+                // Absolute last resort: scan ALL reachable Source properties for oldCode (no method name filter)
+                // This handles edge cases where the SDK stores the code in an unexpected location.
+                if (!replaced)
+                {
+                    replaced = ReplaceCodeInXmlFallback(dyn, oldCode, newCode);
                 }
 
                 return replaced;
@@ -2452,19 +2776,208 @@ namespace D365MetadataBridge.Services
             }
         }
 
+        /// <summary>
+        /// Recursively searches all Controls in a form or form-extension object for override methods
+        /// matching the given filter constraints, and replaces oldCode with newCode in their Source.
+        /// Supports "ControlName.methodName" scoping via controlNameFilter + methodNameFilter.
+        /// Safe to call on non-form objects — if they have no Controls collection, returns false silently.
+        /// </summary>
+        private bool ReplaceInControls(dynamic parent, string? controlNameFilter, string? methodNameFilter,
+            string oldCode, string newCode)
+        {
+            bool replaced = false;
+            try
+            {
+                foreach (dynamic control in parent.Controls)
+                {
+                    try
+                    {
+                        string controlName = (string)control.Name;
+                        bool controlMatches = controlNameFilter == null ||
+                            string.Equals(controlName, controlNameFilter, StringComparison.OrdinalIgnoreCase);
+
+                        if (controlMatches)
+                        {
+                            // Try multiple property names for override methods:
+                            // - OverrideMethods (some SDK versions)
+                            // - Methods (other SDK versions / form controls)
+                            replaced |= ReplaceInMethodCollection(control, "OverrideMethods", methodNameFilter, oldCode, newCode);
+                            replaced |= ReplaceInMethodCollection(control, "Methods", methodNameFilter, oldCode, newCode);
+                        }
+
+                        // Recurse into nested controls regardless — a matching control may be nested in a group
+                        replaced |= ReplaceInControls(control, controlNameFilter, methodNameFilter, oldCode, newCode);
+                    }
+                    catch { }
+                }
+            }
+            catch { /* object has no Controls collection; silently skip */ }
+            return replaced;
+        }
+
+        /// <summary>
+        /// Iterates a named method collection on a dynamic object and replaces oldCode with newCode.
+        /// Returns true if at least one replacement was made. Silently returns false if the collection
+        /// doesn't exist on the object.
+        /// </summary>
+        private bool ReplaceInMethodCollection(dynamic obj, string collectionName, string? methodNameFilter,
+            string oldCode, string newCode)
+        {
+            bool replaced = false;
+            try
+            {
+                var prop = ((object)obj).GetType().GetProperty(collectionName);
+                if (prop == null) return false;
+                dynamic? collection = prop.GetValue(obj);
+                if (collection == null) return false;
+
+                foreach (dynamic m in collection)
+                {
+                    try
+                    {
+                        if (methodNameFilter != null &&
+                            !string.Equals((string)m.Name, methodNameFilter, StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        string? src = (string?)m.Source;
+                        if (src != null && src.Contains(oldCode))
+                        {
+                            m.Source = src.Replace(oldCode, newCode);
+                            replaced = true;
+                        }
+                    }
+                    catch { }
+                }
+            }
+            catch { }
+            return replaced;
+        }
+
+        /// <summary>
+        /// Absolute last-resort fallback: enumerate all iterable collections exposed by SourceCode
+        /// (Methods, DataSources, DataControls, Members) and any nested items looking for Source
+        /// properties that contain oldCode. Replaces globally. Used when structured access fails.
+        /// For DataControls, also iterates into each control's Methods sub-collection.
+        /// </summary>
+        private bool ReplaceCodeInXmlFallback(dynamic axObject, string oldCode, string newCode)
+        {
+            bool replaced = false;
+            try
+            {
+                // Try all known sub-collections on SourceCode
+                dynamic? sourceCode = null;
+                try { sourceCode = axObject.SourceCode; } catch { return false; }
+                if (sourceCode == null) return false;
+
+                string[] collectionNames = { "Methods", "DataSources", "Members" };
+                foreach (var colName in collectionNames)
+                {
+                    try
+                    {
+                        var prop = ((object)sourceCode).GetType().GetProperty(colName);
+                        if (prop == null) continue;
+                        dynamic? collection = prop.GetValue(sourceCode);
+                        if (collection == null) continue;
+
+                        foreach (dynamic item in collection)
+                        {
+                            try
+                            {
+                                string? src = null;
+                                try { src = (string?)item.Source; } catch { }
+                                if (src != null && src.Contains(oldCode))
+                                {
+                                    item.Source = src.Replace(oldCode, newCode);
+                                    replaced = true;
+                                    Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced in SourceCode.{colName} item '{(string?)item.Name ?? "?"}'");
+                                }
+                            }
+                            catch { }
+                        }
+                    }
+                    catch { }
+                }
+
+                // DataControls are special: each item is a control with nested Methods
+                try
+                {
+                    var dcProp = ((object)sourceCode).GetType().GetProperty("DataControls");
+                    if (dcProp != null)
+                    {
+                        dynamic? dcCollection = dcProp.GetValue(sourceCode);
+                        if (dcCollection != null)
+                        {
+                            foreach (dynamic ctrl in dcCollection)
+                            {
+                                try
+                                {
+                                    string ctrlName = "?";
+                                    try { ctrlName = (string)ctrl.Name; } catch { }
+
+                                    // Try methods inside control
+                                    try
+                                    {
+                                        foreach (dynamic m in ctrl.Methods)
+                                        {
+                                            try
+                                            {
+                                                string? src = (string?)m.Source;
+                                                if (src != null && src.Contains(oldCode))
+                                                {
+                                                    m.Source = src.Replace(oldCode, newCode);
+                                                    replaced = true;
+                                                    Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced in DataControls.{ctrlName}.{(string?)m.Name ?? "?"}");
+                                                }
+                                            }
+                                            catch { }
+                                        }
+                                    }
+                                    catch { }
+
+                                    // Also try direct Source on control object (flat override lists)
+                                    try
+                                    {
+                                        string? src = (string?)ctrl.Source;
+                                        if (src != null && src.Contains(oldCode))
+                                        {
+                                            ctrl.Source = src.Replace(oldCode, newCode);
+                                            replaced = true;
+                                            Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced direct Source on DataControl '{ctrlName}'");
+                                        }
+                                    }
+                                    catch { }
+                                }
+                                catch { }
+                            }
+                        }
+                    }
+                }
+                catch { }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback failed: {ex.Message}");
+            }
+            return replaced;
+        }
+
         // ========================
         // HELPERS: Model Info Resolution for Existing Objects
         // ========================
 
         /// <summary>
         /// Gets ModelSaveInfo for an existing object by asking the provider for its model info.
+        /// The generic IReadOnlySingleKeyedMetadataProvider does NOT expose GetModelInfo —
+        /// it lives on concrete provider interfaces (IMetaClassProvider, IMetaTableProvider, etc.).
+        /// We try dynamic dispatch first, then fall back to concrete provider properties,
+        /// and finally try to infer from the on-disk file path.
         /// </summary>
         private ModelSaveInfo GetModelSaveInfoForObject<T>(IReadOnlySingleKeyedMetadataProvider<T> collection, string objectName)
             where T : class
         {
+            // Strategy 1: dynamic dispatch on the collection object (works if runtime type exposes GetModelInfo)
             try
             {
-                // GetModelInfo returns ModelInfoCollection which is IEnumerable<ModelInfo>
                 dynamic dynCollection = collection;
                 var modelInfos = dynCollection.GetModelInfo(objectName);
                 if (modelInfos != null)
@@ -2475,12 +2988,70 @@ namespace D365MetadataBridge.Services
                     }
                 }
             }
+            catch { /* GetModelInfo not found on this interface — continue to fallback */ }
+
+            // Strategy 2: try all concrete provider properties that have GetModelInfo
+            ModelInfo? foundMi = TryGetModelInfoFromProviders(objectName);
+            if (foundMi != null)
+            {
+                return new ModelSaveInfo { Id = foundMi.Id, Layer = foundMi.Layer };
+            }
+
+            // Strategy 3: infer model from on-disk file path
+            //   Files live at {packagesPath}/{ModelName}/{ModelName}/Ax{Type}/{Name}.xml
+            //   We scan common AOT folders for the object name.
+            string[] aotFolders = { "AxClass", "AxTable", "AxForm", "AxEnum", "AxEdt",
+                                    "AxQuery", "AxView", "AxDataEntityView", "AxReport",
+                                    "AxTableExtension", "AxFormExtension", "AxClassExtension",
+                                    "AxEnumExtension" };
+            try
+            {
+                foreach (var packageDir in Directory.GetDirectories(_packagesPath))
+                {
+                    var packageName = Path.GetFileName(packageDir);
+                    foreach (var aotFolder in aotFolders)
+                    {
+                        var filePath = Path.Combine(packageDir, packageName, aotFolder, objectName + ".xml");
+                        if (File.Exists(filePath))
+                        {
+                            // Found the file — resolve model from this package name
+                            var msi = ResolveModelSaveInfo(packageName);
+                            if (msi != null)
+                            {
+                                Console.Error.WriteLine($"[WriteService] GetModelSaveInfoForObject: resolved '{objectName}' via file path → model '{packageName}'");
+                                return msi;
+                            }
+                        }
+                    }
+                }
+            }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"[WriteService] GetModelSaveInfoForObject failed for {objectName}: {ex.Message}");
+                Console.Error.WriteLine($"[WriteService] GetModelSaveInfoForObject file scan failed for {objectName}: {ex.Message}");
             }
 
             throw new InvalidOperationException($"Cannot determine model for existing object '{objectName}'");
+        }
+
+        /// <summary>
+        /// Tries GetModelInfo on all known concrete provider properties.
+        /// Returns the first ModelInfo found, or null.
+        /// </summary>
+        private ModelInfo? TryGetModelInfoFromProviders(string objectName)
+        {
+            // Each provider property (Classes, Tables, etc.) has GetModelInfo on its concrete type
+            try { var mi = _provider.Classes.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.Tables.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.Forms.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.Enums.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.Edts.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.Queries.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.Views.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.FormExtensions.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.TableExtensions.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.EnumExtensions.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            try { var mi = _provider.Reports.GetModelInfo(objectName); if (mi?.Count > 0) return mi.First(); } catch { }
+            return null;
         }
 
         // ========================

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -88,6 +88,29 @@ Output window is too noisy or truncated. Open it with any text editor or watch l
 Get-Content "C:\Temp\d365fo-mcp.log" -Encoding UTF8 -Wait
 ```
 
+#### C# bridge diagnostics
+
+The C# bridge (`D365MetadataBridge.exe`) has its own diagnostic output (`[WriteService]` messages)
+that is normally filtered — only `[ERROR]` and `[WARN]` lines reach the TS server. To capture
+**all** bridge diagnostics (including `replace-code` tracing, form control traversal, etc.),
+add `bridgeLogFile` to the `context` block:
+
+```json
+"context": {
+  "workspacePath": "K:\\AosService\\PackagesLocalDirectory\\YourPackage\\YourModel",
+  "bridgeLogFile": "C:\\Temp\\d365fo-bridge.log"
+}
+```
+
+When set, `bridgeLogFile` does two things:
+1. The bridge process tees all its stderr to the log file (append mode)
+2. The TS server forwards **all** bridge stderr lines (not just errors/warnings)
+
+Watch live:
+```powershell
+Get-Content "C:\Temp\d365fo-bridge.log" -Encoding UTF8 -Wait -Tail 50
+```
+
 ### HTTP (Azure-hosted or `npm run dev`)
 
 The server listens on a TCP port. Used for Azure deployments and for local `npm run dev` sessions.
@@ -182,6 +205,7 @@ files from `%LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\` and detects the pat
 | `devEnvironmentType` | Optional | `auto` (default), `traditional`, or `ude`. Controls path resolution behavior. |
 | `projectPath` | Optional | Full path to your `.rnrproj` file. Auto-detected from roots/list (stdio) or D365FO_SOLUTIONS_PATH. |
 | `solutionPath` | Optional | Visual Studio solution folder. Used when `projectPath` is not set. |
+| `bridgeLogFile` | Optional | Absolute path to a C# bridge log file (e.g. `C:\Temp\d365fo-bridge.log`). When set, the bridge tees all diagnostic output to this file in append mode, and the TS server forwards all bridge stderr lines (not just `[ERROR]`/`[WARN]`). Useful for debugging `modify_d365fo_file` issues (replace-code, form control traversal, etc.). |
 
 ### Environment Variables (stdio `env` block)
 

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -929,7 +929,7 @@ const BRIDGE_MODIFY_OPS = new Set([
 const BRIDGE_MODIFY_TYPES = new Set([
   'class', 'table', 'enum', 'edt',
   'form', 'query', 'view',
-  'table-extension', 'form-extension', 'enum-extension',
+  'class-extension', 'table-extension', 'form-extension', 'enum-extension',
   'menu-item-action', 'menu-item-display', 'menu-item-output',
 ]);
 

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -83,6 +83,8 @@ export interface BridgeClientOptions {
   readyTimeoutMs?: number;
   /** Timeout for each RPC call in ms */
   callTimeoutMs?: number;
+  /** Path to a log file for bridge diagnostics (append mode) */
+  logFile?: string;
 }
 
 interface PendingRequest {
@@ -144,6 +146,9 @@ export class BridgeClient extends EventEmitter {
     }
     if (this.options.xrefDatabase) {
       args.push('--xref-database', this.options.xrefDatabase);
+    }
+    if (this.options.logFile) {
+      args.push('--log-file', this.options.logFile);
     }
 
     console.error(`[BridgeClient] Spawning: ${exePath} ${args.join(' ')}`);
@@ -209,10 +214,15 @@ export class BridgeClient extends EventEmitter {
       this.process.stderr!.on('data', (chunk: Buffer) => {
         const text = chunk.toString('utf8').trim();
         if (text) {
-          // Only log non-trivial messages
           for (const line of text.split('\n')) {
-            if (line.includes('[ERROR]') || line.includes('[WARN]')) {
-              console.error(`[Bridge] ${line.trim()}`);
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            // When log file is configured, forward ALL bridge stderr lines
+            // (diagnostics are captured in the file; surface them on TS side too).
+            // Otherwise only forward errors and warnings to avoid noise.
+            if (this.options.logFile ||
+                trimmed.includes('[ERROR]') || trimmed.includes('[WARN]')) {
+              console.error(`[Bridge] ${trimmed}`);
             }
           }
         }
@@ -675,6 +685,7 @@ export async function createBridgeClient(options: {
   bridgeExePath?: string;
   xrefServer?: string;
   xrefDatabase?: string;
+  logFile?: string;
 }): Promise<BridgeClient | null> {
   // Auto-detect packagesPath if not provided
   const packagesPath = options.packagesPath ?? detectPackagesPath();
@@ -703,6 +714,7 @@ function detectPackagesPath(): string | null {
   const candidates = [
     process.env.PackagesPath ?? '',
     'C:\\AosService\\PackagesLocalDirectory',
+    'C:\\AOSService\\PackagesLocalDirectory',
     'J:\\AosService\\PackagesLocalDirectory',
     'K:\\AosService\\PackagesLocalDirectory',
   ].filter(Boolean);

--- a/src/index.ts
+++ b/src/index.ts
@@ -572,6 +572,7 @@ async function main() {
         const bridge = await createBridgeClient({
           packagesPath,
           binPath,
+          logFile: configMgr.getContext()?.bridgeLogFile ?? undefined,
         });
         if (bridge) {
           stubContext.bridge = bridge;

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -968,7 +968,8 @@ Examples:
                   'Type of modification to perform.\n' +
                   'add-method: add a new method (or CoC method) to a class/table/form.\n' +
                   'remove-method: remove a method by name.\n' +
-                  'replace-code: surgical in-place replacement (oldCode → newCode) inside a method body or class declaration.\n' +
+                  'replace-code: surgical in-place replacement — pass oldCode (exact snippet to find) + newCode (replacement text). ' +
+                  'For form control override methods use methodName="ControlName.methodName" (e.g. "PostButton.clicked").\n' +
                   'add-field: add a field to a table or table-extension.\n' +
                   'modify-field: change EDT/mandatory/label of an existing field.\n' +
                   'rename-field: rename a field (also fixes index DataField refs and TitleField1/2 automatically).\n' +
@@ -1021,6 +1022,21 @@ Examples:
               methodParameters: {
                 type: 'string',
                 description: 'Method parameters (e.g., "str _param1, int _param2")'
+              },
+              oldCode: {
+                type: 'string',
+                description:
+                  '[replace-code] REQUIRED. Exact existing X++ code snippet to find and replace. ' +
+                  'Must match the source text exactly (leading/trailing whitespace is trimmed). ' +
+                  'If methodName is also provided, the search is scoped to that method only. ' +
+                  'For form control override methods, use methodName="ControlName.methodName" (e.g. "PostButton.clicked").'
+              },
+              newCode: {
+                type: 'string',
+                description:
+                  '[replace-code] REQUIRED. Replacement X++ code snippet. ' +
+                  'Replaces the first occurrence of oldCode. ' +
+                  'Pass empty string "" to delete the matched oldCode snippet.'
               },
               fieldName: {
                 type: 'string',

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -63,6 +63,49 @@ export function decodeXmlEntitiesFromXppSource(source: string): string {
   return decodeStandardXmlEntities(source);
 }
 
+/**
+ * Direct XML file-level replace-code fallback.
+ * Used when the C# bridge fails or returns null for replace-code on forms/form-extensions
+ * (e.g. control override methods that the SDK doesn't expose via the Methods API).
+ *
+ * Reads the XML file, performs a simple string replacement inside <Source> CDATA blocks,
+ * and writes the file back. This is a last-resort fallback — the bridge is always preferred.
+ */
+async function directXmlReplaceCode(
+  filePath: string,
+  oldCode: string,
+  newCode: string,
+): Promise<{ success: boolean; message: string } | null> {
+  try {
+    // Read as Buffer to detect and preserve UTF-8 BOM (D365FO XML files use BOM)
+    const buf = await fs.readFile(filePath);
+    const hasBom = buf.length >= 3 && buf[0] === 0xEF && buf[1] === 0xBB && buf[2] === 0xBF;
+    const content = buf.toString('utf-8');
+
+    if (!content.includes(oldCode)) {
+      return null; // oldCode not found in file at all
+    }
+
+    const updated = content.replace(oldCode, newCode);
+    if (updated === content) {
+      return null; // no change made
+    }
+
+    // Preserve BOM if it was present: Node's utf-8 encoding strips BOM on read
+    // but '\uFEFF' prefix restores it on write.
+    const bomPrefix = hasBom && !updated.startsWith('\uFEFF') ? '\uFEFF' : '';
+    await fs.writeFile(filePath, bomPrefix + updated, 'utf-8');
+    console.error(`[modify_d365fo_file] ✅ directXmlReplaceCode fallback: replaced in ${filePath}`);
+    return {
+      success: true,
+      message: `✅ Code replaced via direct XML fallback (bridge was unavailable). File: ${filePath}`,
+    };
+  } catch (err) {
+    console.error(`[modify_d365fo_file] directXmlReplaceCode failed: ${err}`);
+    return null;
+  }
+}
+
 const ModifyD365FileArgsSchema = z.object({
   objectType: z.enum([
     'class', 'table', 'form', 'enum', 'query', 'view', 'edt', 'data-entity', 'report',
@@ -86,7 +129,12 @@ const ModifyD365FileArgsSchema = z.object({
     'add-control',
     'add-enum-value', 'modify-enum-value', 'remove-enum-value',
     'add-display-method', 'add-table-method', 'add-menu-item-to-menu',
-  ]).describe('Operation to perform'),
+  ]).describe(
+    'Operation to perform. ' +
+    'replace-code REQUIRES parameters: oldCode (exact code to find) + newCode (replacement). ' +
+    'add-method REQUIRES: methodName + sourceCode. ' +
+    'For form control override methods with replace-code, use methodName="ControlName.methodName" (e.g. "PostButton.clicked").'
+  ),
 
   // For add-enum-value / modify-enum-value / remove-enum-value
   enumValueName: z.string().optional().describe(
@@ -183,15 +231,17 @@ const ModifyD365FileArgsSchema = z.object({
     'This is the preferred parameter when passing a complete CoC skeleton. ' +
     'Either methodCode or sourceCode may be used; sourceCode takes precedence if both are supplied.'
   ),
-  // For replace-code
+  // For replace-code (REQUIRED for operation="replace-code" — do NOT use sourceCode for this)
   oldCode: z.string().optional().describe(
-    'Exact existing X++ code snippet to find and replace. Used with operation="replace-code". ' +
+    'REQUIRED for replace-code. Exact existing X++ code snippet to find and replace. ' +
     'Must match the source text exactly (leading/trailing whitespace is trimmed for matching). ' +
-    'If methodName is also provided the search is scoped to that method\'s Source block only.'
+    'If methodName is also provided the search is scoped to that method\'s Source block only. ' +
+    'For form control override methods, use methodName="ControlName.methodName" (e.g. "PostButton.clicked").'
   ),
   newCode: z.string().optional().describe(
-    'Replacement X++ code snippet. Used with operation="replace-code". ' +
-    'Replaces the first occurrence of oldCode in the target source block.'
+    'REQUIRED for replace-code. Replacement X++ code snippet. ' +
+    'Replaces the first occurrence of oldCode in the target source block. ' +
+    'Pass empty string "" to delete the matched oldCode snippet.'
   ),
   methodModifiers: z.string().optional().describe('Method modifiers (e.g., "public static")'),
   methodReturnType: z.string().optional().describe('Return type of method'),
@@ -619,14 +669,56 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         break;
       }
       case 'replace-code': {
-        if (args.oldCode && args.newCode) {
+        // Auto-detect common mistake: agent sends sourceCode/methodCode instead of oldCode/newCode
+        const hasOldNew = args.oldCode && args.newCode !== undefined;
+        const sentSourceCode = args.sourceCode || (args as any).methodCode;
+        
+        if (!hasOldNew && sentSourceCode) {
+          throw new Error(
+            `⛔ replace-code requires 'oldCode' and 'newCode' — NOT 'sourceCode'/'methodCode'.\n\n` +
+            `You sent sourceCode/methodCode but replace-code needs:\n` +
+            `  • oldCode = the exact existing snippet to find\n` +
+            `  • newCode = the replacement snippet\n\n` +
+            `Example:\n` +
+            `  modify_d365fo_file(objectType="form", objectName="MyForm",\n` +
+            `    operation="replace-code",\n` +
+            `    methodName="PostButton.clicked",\n` +
+            `    oldCode="ttsbegin;",\n` +
+            `    newCode="")\n\n` +
+            `If you want to replace an entire method, use remove-method + add-method instead.`
+          );
+        }
+        
+        if (hasOldNew) {
+          // Try bridge first
           bridgeResult = await bridgeReplaceCode(
             context.bridge,
             objectType,
             objectName,
             args.methodName,
-            args.oldCode,
-            args.newCode,
+            args.oldCode!,
+            args.newCode!,
+          );
+
+          // Fallback: if bridge returns null (unsupported type or not connected)
+          // or success=false (SDK couldn't find the code — e.g. form control override),
+          // do direct string replacement in the XML file.
+          // This handles form control override methods which the SDK may not expose.
+          if (!bridgeResult || !bridgeResult.success) {
+            const xmlFallbackResult = await directXmlReplaceCode(
+              actualFilePath, args.oldCode!, args.newCode!
+            );
+            if (xmlFallbackResult) {
+              bridgeResult = xmlFallbackResult;
+            }
+          }
+        } else {
+          throw new Error(
+            `replace-code requires both 'oldCode' and 'newCode' parameters.\n` +
+            `  oldCode: ${args.oldCode ? 'provided' : '⛔ MISSING'}\n` +
+            `  newCode: ${args.newCode !== undefined ? 'provided' : '⛔ MISSING'}\n` +
+            `Note: 'sourceCode' is NOT an alias for replace-code — you must use 'oldCode' and 'newCode'.\n` +
+            `For form control override methods, use methodName="ControlName.methodName" (e.g. "PostButton.clicked").`
           );
         }
         break;
@@ -724,9 +816,31 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     }
 
     if (!bridgeResult) {
+      const paramHints: Record<string, string[]> = {
+        'add-method': ['methodName', 'sourceCode'],
+        'remove-method': ['methodName'],
+        'replace-code': ['oldCode', 'newCode'],
+        'add-field': ['fieldName', 'fieldType'],
+        'modify-field': ['fieldName'],
+        'rename-field': ['fieldName', 'fieldNewName'],
+        'add-index': ['indexName'],
+        'remove-index': ['indexName'],
+        'add-relation': ['relationName', 'relatedTable'],
+        'remove-relation': ['relationName'],
+        'add-field-group': ['fieldGroupName'],
+        'remove-field-group': ['fieldGroupName'],
+        'add-field-to-field-group': ['fieldGroupName', 'fieldName'],
+        'add-control': ['controlName', 'parentControl'],
+        'add-data-source': ['dataSourceName', 'dataSourceTable'],
+        'modify-property': ['propertyPath', 'propertyValue'],
+      };
+      const required = paramHints[operation] ?? [];
+      const missingList = required.filter(p => !(args as any)[p]).map(p => `  ⛔ ${p}: MISSING`);
+      const providedList = required.filter(p => (args as any)[p]).map(p => `  ✅ ${p}: provided`);
       throw new Error(
         `Bridge operation '${operation}' returned null — required parameters may be missing.\n` +
-        `Check that all required arguments for '${operation}' are provided.`
+        `Required parameters for '${operation}':\n${[...providedList, ...missingList].join('\n')}\n` +
+        `Provided args: ${Object.keys(args).filter(k => (args as any)[k] !== undefined).join(', ')}`
       );
     }
     if (!bridgeResult.success) {

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -21,6 +21,7 @@ export interface McpContext {
   projectPath?: string;
   solutionPath?: string;
   devEnvironmentType?: 'auto' | 'traditional' | 'ude';
+  bridgeLogFile?: string;           // Path to bridge diagnostic log file (append mode)
 }
 
 export interface McpConfig {


### PR DESCRIPTION
…trol methods

Root causes fixed:
- GetModelSaveInfoForObject used dynamic dispatch on IReadOnlySingleKeyedMetadataProvider which does NOT expose GetModelInfo  all modify ops (replaceCode, addMethod, removeMethod) failed on custom objects (AC_*) with 'object does not contain a definition for GetModelInfo'. Added 3-tier fallback: dynamic dispatch -> concrete provider properties -> file path scan.

- ReplaceInMethods treated SourceCode.DataControls items as flat methods with .Source, but SDK exposes them as control objects (Name=controlName) with nested .Methods collection. Rewrote DataControls traversal to iterate ctrl.Methods for each control.

- ReplaceCodeInXmlFallback had the same DataControls bug  separated from generic loop, now iterates ctrl -> ctrl.Methods -> m.Source.

Other changes:
- Added form-extension/class-extension/table-extension cases to ReplaceCode, AddMethod, RemoveMethod switches in MetadataWriteService.cs
- Added class-extension to BRIDGE_MODIFY_TYPES in bridgeAdapter.ts
- Added oldCode/newCode parameters to manual JSON Schema in mcpServer.ts (fixes agent infinite loop where it couldn't see these params)
- Added directXmlReplaceCode TS fallback with BOM preservation for when bridge fails
- Added --log-file CLI arg to C# bridge with TeeTextWriter (stderr -> file)
- Added bridgeLogFile to McpContext interface, passed through bridgeClient -> bridge spawn
- bridgeClient forwards ALL bridge stderr lines when logFile is configured
- Improved diagnostic logging: form case now dumps DataControls with nested method names
- Enhanced error messages with per-operation parameter hints
- Rewrote RemoveMethodByName/RemoveMethodIfExists with TryRemoveFromCollection helper
- Added C:\\AOSService path candidate to detectPackagesPath
- Updated MCP_CONFIG.md with bridgeLogFile documentation