### PR TITLE
feat(#366): add sortLabels parameter and LABEL_SORT_ORDER env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,9 @@ INCLUDE_LABELS=true
 # Languages to index — limiting this significantly reduces DB size
 LABEL_LANGUAGES=en-US,cs,sk,de
 
+# Label sort order: "alphabetical" (default) or "append" (new labels added at end of file)
+# LABEL_SORT_ORDER=alphabetical
+
 # ISV/extension prefix used to identify custom objects
 EXTENSION_PREFIX=ISV_
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -236,6 +236,9 @@ All available parameters in one block with comments:
         // "DEBUG_LOGGING": "true",               // verbose JSON-RPC trace
         // "LOG_FILE": "C:\\Temp\\d365fo-mcp.log" // tee all output to file
 
+        // ── Label options ───────────────────────────────────────────
+        // "LABEL_SORT_ORDER": "append"            // "alphabetical" (default) or "append"
+
         // ── HTTP port (only for npm run dev, not stdio) ─────────────
         // "PORT": "8080"
       }
@@ -301,6 +304,7 @@ All available parameters in one block with comments:
 | `bridgeLogFile` | — | optional | optional | optional |
 | `DEBUG_LOGGING` | — | optional | optional | optional |
 | `LOG_FILE` | — | optional | optional | optional |
+| `LABEL_SORT_ORDER` | — | optional | optional | optional |
 
 ---
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1634,20 +1634,23 @@ Examples:
           name: 'create_label',
           description: `🏷️ Add a new label to an existing AxLabelFile in a custom D365FO model.
 
-Writes the label into EVERY language .label.txt file that exists in the model (inserts alphabetically), creates XML descriptors if missing, and updates the MCP label index.
+Writes the label into EVERY language .label.txt file that exists in the model, creates XML descriptors if missing, and updates the MCP label index.
+
+By default labels are inserted alphabetically. Set sortLabels=false (or LABEL_SORT_ORDER=append in env) to append new labels at the end preserving existing file order.
 
 ⚠️ ALWAYS call search_labels first to check if a suitable label already exists!
 
 Process:
 1. Reads each existing .label.txt file for the model
 2. Checks for duplicate label ID
-3. Inserts the new label in alphabetical position
+3. Inserts the new label (alphabetically or appended, based on sortLabels)
 4. Writes the updated file back to disk
 5. Updates the SQLite label index
 
 Examples:
 - create_label("MyNewField", "MyModel", "MyModel", [{language:"en-US", text:"My new field"}, {language:"cs", text:"Moje nové pole"}])
-- create_label with createLabelFileIfMissing=true → creates AxLabelFile structure from scratch`,
+- create_label with createLabelFileIfMissing=true → creates AxLabelFile structure from scratch
+- create_label with sortLabels=false → appends the new label at the end of each .label.txt file`,
           inputSchema: {
             type: 'object',
             properties: {
@@ -1715,6 +1718,13 @@ Examples:
               updateIndex: {
                 type: 'boolean',
                 description: 'Update MCP label index after writing (default: true)',
+              },
+              sortLabels: {
+                type: 'boolean',
+                description:
+                  'Sort labels alphabetically when writing .label.txt files (default: true). ' +
+                  'Set to false to append new labels at the end preserving existing file order. ' +
+                  'Defaults to LABEL_SORT_ORDER env var ("alphabetical" = true, "append" = false).',
               },
             },
             required: ['labelId', 'labelFileId', 'model', 'translations'],

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -103,6 +103,14 @@ const CreateLabelArgsSchema = z.object({
     .optional()
     .default(true)
     .describe('Update the MCP label index after writing files (default: true)'),
+  sortLabels: z
+    .boolean()
+    .optional()
+    .describe(
+      'Sort labels alphabetically when writing .label.txt files. ' +
+        'When false, new labels are appended at the end preserving existing file order. ' +
+        'Defaults to the LABEL_SORT_ORDER env var ("alphabetical" = true, "append" = false), or true if not set.',
+    ),
 });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -138,11 +146,15 @@ function parseLabelMap(content: string): Map<string, { text: string; comment?: s
   return map;
 }
 
-/** Render a label map back to .label.txt content (alphabetically sorted) with UTF-8 BOM */
-function serializeLabelMap(map: Map<string, { text: string; comment?: string }>): string {
-  const sorted = [...map.entries()].sort(([a], [b]) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
+/** Render a label map back to .label.txt content with UTF-8 BOM.
+ *  When `sort` is true (default), entries are sorted alphabetically by label ID.
+ *  When `sort` is false, entries are written in insertion order (existing + appended). */
+function serializeLabelMap(map: Map<string, { text: string; comment?: string }>, sort = true): string {
+  const entries = sort
+    ? [...map.entries()].sort(([a], [b]) => a.localeCompare(b, 'en', { sensitivity: 'base' }))
+    : [...map.entries()];
   const lines: string[] = [];
-  for (const [id, { text, comment }] of sorted) {
+  for (const [id, { text, comment }] of entries) {
     lines.push(`${id}=${text}`);
     if (comment) lines.push(` ;${comment}`);
   }
@@ -194,6 +206,10 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       createLabelFileIfMissing,
       updateIndex,
     } = args;
+
+    // Resolve sortLabels: explicit param → LABEL_SORT_ORDER env → true (alphabetical)
+    const envSortOrder = process.env.LABEL_SORT_ORDER?.toLowerCase();
+    const shouldSort = args.sortLabels ?? (envSortOrder === 'append' ? false : true);
 
     // Description fallback: explicit description → VS project name → labelFileId
     // Model name is not useful here — it's typically identical to labelFileId.
@@ -390,7 +406,7 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       await fs.mkdir(langDir, { recursive: true });
 
       // Write updated file with UTF-8 BOM
-      const newContent = serializeLabelMap(labelMap);
+      const newContent = serializeLabelMap(labelMap, shouldSort);
       await writeFileWithBom(txtPath, newContent);
       written.push(lang);
 

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -560,6 +560,141 @@ describe('create_label', () => {
     expect(labelWrite).toContain(' ;Explicit comment');
     expect(labelWrite).not.toContain('Should be overridden');
   });
+
+  it('appends new label at end when sortLabels=false', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: string[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (_p: string, content: string) => {
+      writeCalls.push(content);
+    });
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    // Existing file has labels in non-alphabetical order: Zebra before Apple
+    (fsMock.promises.readFile as any).mockResolvedValueOnce('\uFEFFZebraLabel=Zebra text\nAppleLabel=Apple text\n');
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'MiddleLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        sortLabels: false,
+        translations: [{ language: 'en-US', text: 'Middle text' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const labelWrite = writeCalls.find(c => c.includes('MiddleLabel='));
+    expect(labelWrite).toBeDefined();
+    // With sortLabels=false, original order preserved: Zebra, Apple, then Middle appended
+    const lines = labelWrite!.split('\n').filter(l => l.includes('='));
+    expect(lines[0]).toContain('ZebraLabel=');
+    expect(lines[1]).toContain('AppleLabel=');
+    expect(lines[2]).toContain('MiddleLabel=');
+  });
+
+  it('sorts alphabetically by default (sortLabels not specified)', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: string[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (_p: string, content: string) => {
+      writeCalls.push(content);
+    });
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    // Existing file has labels in non-alphabetical order
+    (fsMock.promises.readFile as any).mockResolvedValueOnce('\uFEFFZebraLabel=Zebra text\nAppleLabel=Apple text\n');
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'MiddleLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        translations: [{ language: 'en-US', text: 'Middle text' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const labelWrite = writeCalls.find(c => c.includes('MiddleLabel='));
+    expect(labelWrite).toBeDefined();
+    // Default: alphabetically sorted
+    const lines = labelWrite!.split('\n').filter(l => l.includes('='));
+    expect(lines[0]).toContain('AppleLabel=');
+    expect(lines[1]).toContain('MiddleLabel=');
+    expect(lines[2]).toContain('ZebraLabel=');
+  });
+
+  it('respects LABEL_SORT_ORDER=append env var when sortLabels not specified', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: string[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (_p: string, content: string) => {
+      writeCalls.push(content);
+    });
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    (fsMock.promises.readFile as any).mockResolvedValueOnce('\uFEFFZebraLabel=Zebra text\nAppleLabel=Apple text\n');
+
+    // Set env var
+    const origEnv = process.env.LABEL_SORT_ORDER;
+    process.env.LABEL_SORT_ORDER = 'append';
+    try {
+      const result = await createLabelTool(
+        req('create_label', {
+          labelId: 'MiddleLabel',
+          labelFileId: 'MyModel',
+          model: 'MyModel',
+          updateIndex: false,
+          translations: [{ language: 'en-US', text: 'Middle text' }],
+        }),
+        ctx,
+      );
+      expect(result.isError).toBeFalsy();
+      const labelWrite = writeCalls.find(c => c.includes('MiddleLabel='));
+      expect(labelWrite).toBeDefined();
+      // Env says append: Zebra, Apple, Middle (not sorted)
+      const lines = labelWrite!.split('\n').filter(l => l.includes('='));
+      expect(lines[0]).toContain('ZebraLabel=');
+      expect(lines[1]).toContain('AppleLabel=');
+      expect(lines[2]).toContain('MiddleLabel=');
+    } finally {
+      if (origEnv === undefined) delete process.env.LABEL_SORT_ORDER;
+      else process.env.LABEL_SORT_ORDER = origEnv;
+    }
+  });
+
+  it('sortLabels=true overrides LABEL_SORT_ORDER=append env var', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: string[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (_p: string, content: string) => {
+      writeCalls.push(content);
+    });
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    (fsMock.promises.readFile as any).mockResolvedValueOnce('\uFEFFZebraLabel=Zebra text\nAppleLabel=Apple text\n');
+
+    const origEnv = process.env.LABEL_SORT_ORDER;
+    process.env.LABEL_SORT_ORDER = 'append';
+    try {
+      const result = await createLabelTool(
+        req('create_label', {
+          labelId: 'MiddleLabel',
+          labelFileId: 'MyModel',
+          model: 'MyModel',
+          updateIndex: false,
+          sortLabels: true,
+          translations: [{ language: 'en-US', text: 'Middle text' }],
+        }),
+        ctx,
+      );
+      expect(result.isError).toBeFalsy();
+      const labelWrite = writeCalls.find(c => c.includes('MiddleLabel='));
+      expect(labelWrite).toBeDefined();
+      // Explicit sortLabels=true wins: alphabetical
+      const lines = labelWrite!.split('\n').filter(l => l.includes('='));
+      expect(lines[0]).toContain('AppleLabel=');
+      expect(lines[1]).toContain('MiddleLabel=');
+      expect(lines[2]).toContain('ZebraLabel=');
+    } finally {
+      if (origEnv === undefined) delete process.env.LABEL_SORT_ORDER;
+      else process.env.LABEL_SORT_ORDER = origEnv;
+    }
+  });
 });
 
 // ─── rename_label ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Add optional sortLabels parameter to create_label tool and LABEL_SORT_ORDER environment variable to control label ordering.

- sortLabels=false appends new labels at end of file (preserves order)
- sortLabels=true sorts alphabetically (existing default behavior)
- LABEL_SORT_ORDER=append env var sets default to append mode
- Explicit sortLabels parameter overrides env var
- Updated mcpServer.ts tool schema, .env.example, QUICK_START.md
- Added 4 tests covering all combinations

Closes #366