### PR TITLE
fix(#391): resolve remaining UDE/bridge issues from feedback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,9 +174,10 @@ async function initializeServices() {
     serverState.parser = parser;
     serverState.cache = cache;
 
-    const mcpServer = createXppMcpServer({ symbolIndex, parser, cache, workspaceScanner, hybridSearch });
+    const context: import('./types/context.js').XppServerContext = { symbolIndex, parser, cache, workspaceScanner, hybridSearch };
+    const mcpServer = createXppMcpServer(context);
     console.log('✅ MCP Server initialized (write-only mode)');
-    return { mcpServer, symbolIndex, parser, cache, workspaceScanner, hybridSearch };
+    return { mcpServer, symbolIndex, parser, cache, workspaceScanner, hybridSearch, context };
   }
 
   // -----------------------------------------------------------------------
@@ -318,20 +319,68 @@ async function initializeServices() {
 
     // Create MCP server with full context
     serverState.statusMessage = 'Initializing MCP server...';
-    const mcpServer = createXppMcpServer({ 
+    const context: import('./types/context.js').XppServerContext = { 
       symbolIndex, 
       parser, 
       cache, 
       workspaceScanner, 
       hybridSearch,
-    });
+    };
+    const mcpServer = createXppMcpServer(context);
     console.log('✅ MCP Server initialized with workspace support');
 
-    return { mcpServer, symbolIndex, parser, cache, workspaceScanner, hybridSearch };
+    return { mcpServer, symbolIndex, parser, cache, workspaceScanner, hybridSearch, context };
   } catch (error) {
     console.error('❌ Initialization error:', error);
     serverState.statusMessage = `Initialization failed: ${error}`;
     throw error;
+  }
+}
+
+/**
+ * Initialize C# bridge (non-blocking).
+ * Shared by stdio and HTTP startup paths.
+ * Attaches bridge to the given context object on success.
+ */
+async function initializeBridge(targetContext: import('./types/context.js').XppServerContext): Promise<void> {
+  try {
+    const { createBridgeClient } = await import('./bridge/bridgeClient.js');
+    const configMgr = getConfigManager();
+    await configMgr.ensureLoaded();
+    // Call getDevEnvironmentType() BEFORE getPackagePath() — it triggers
+    // ensureXppConfig() which populates xppConfig.customPackagesPath.
+    // Without this ordering, getPackagePath() can't use the UDE custom path.
+    const devEnvType = await configMgr.getDevEnvironmentType();
+    const packagesPath = configMgr.getPackagePath() ?? undefined;
+
+    let binPath: string | undefined;
+    if (devEnvType === 'ude') {
+      const msPath = await configMgr.getMicrosoftPackagesPath();
+      if (msPath) {
+        const { existsSync } = await import('fs');
+        const { join } = await import('path');
+        const candidate = join(msPath, 'bin');
+        if (existsSync(candidate)) binPath = candidate;
+      }
+    }
+
+    // Pass xref connection details for UDE environments
+    const xrefServer = await configMgr.getXrefDbServer() ?? undefined;
+    const xrefDatabase = await configMgr.getXrefDbName() ?? undefined;
+
+    const bridge = await createBridgeClient({
+      packagesPath,
+      binPath,
+      xrefServer,
+      xrefDatabase,
+      logFile: configMgr.getContext()?.bridgeLogFile ?? undefined,
+    });
+    if (bridge) {
+      targetContext.bridge = bridge;
+      console.log(`✅ C# bridge connected (${devEnvType}): metadata=${bridge.metadataAvailable}, xref=${bridge.xrefAvailable}`);
+    }
+  } catch (err) {
+    console.log(`ℹ️  C# bridge not available: ${err}`);
   }
 }
 
@@ -519,38 +568,7 @@ async function main() {
     // Step 3b: Initialize C# bridge in parallel with DB load (non-blocking)
     // The bridge provides live metadata from Microsoft's IMetadataProvider API
     // and cross-reference queries — only available on Windows VMs with D365FO.
-    void (async () => {
-      try {
-        const { createBridgeClient } = await import('./bridge/bridgeClient.js');
-        const configMgr = getConfigManager();
-        await configMgr.ensureLoaded();
-        const packagesPath = configMgr.getPackagePath() ?? undefined;
-        // UDE mode: MS framework DLLs live under microsoftPackagesPath,
-        // not under the main packagesPath.
-        const devEnvType = await configMgr.getDevEnvironmentType();
-        let binPath: string | undefined;
-        if (devEnvType === 'ude') {
-          const msPath = await configMgr.getMicrosoftPackagesPath();
-          if (msPath) {
-            const { existsSync } = await import('fs');
-            const { join } = await import('path');
-            const candidate = join(msPath, 'bin');
-            if (existsSync(candidate)) binPath = candidate;
-          }
-        }
-        const bridge = await createBridgeClient({
-          packagesPath,
-          binPath,
-          logFile: configMgr.getContext()?.bridgeLogFile ?? undefined,
-        });
-        if (bridge) {
-          stubContext.bridge = bridge;
-          console.log(`✅ C# bridge connected (${devEnvType}): metadata=${bridge.metadataAvailable}, xref=${bridge.xrefAvailable}`);
-        }
-      } catch (err) {
-        console.log(`ℹ️  C# bridge not available: ${err}`);
-      }
-    })();
+    void initializeBridge(stubContext);
 
     // Step 4: load real database in the background
     const dbLoadStart = Date.now();
@@ -630,9 +648,12 @@ async function main() {
     }));
 
     // Initialise services in the background; register MCP routes once ready
-    initializeServices().then(({ mcpServer, symbolIndex, parser, cache, workspaceScanner, hybridSearch }) => {
+    initializeServices().then(({ mcpServer, symbolIndex, parser, cache, workspaceScanner, hybridSearch, context }) => {
       // Register MCP transport (Express supports dynamic route registration)
       createStreamableHttpTransport(mcpServer, app, { symbolIndex, parser, cache, workspaceScanner, hybridSearch });
+
+      // Initialize C# bridge (non-blocking) — also needed for HTTP mode on Windows/UDE
+      if (context) void initializeBridge(context);
 
       serverState.isReady = true;
       serverState.isHealthy = true;

--- a/src/tools/getMethodSource.ts
+++ b/src/tools/getMethodSource.ts
@@ -9,6 +9,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import type { XppMetadataParser } from '../metadata/xmlParser.js';
 import { tryBridgeMethodSource } from '../bridge/bridgeAdapter.js';
 
 const GetMethodSourceArgsSchema = z.object({
@@ -101,7 +102,7 @@ async function tryXmlMethodSource(
 
   try {
     const parseResult = await Promise.race([
-      parser.parseClassFile(classRow.file_path, classRow.model),
+      parseByObjectType(parser, classRow.file_path, classRow.model, classRow.type),
       new Promise<{ success: false; error: string }>(resolve =>
         setTimeout(() => resolve({ success: false, error: 'timeout' }), 3000)
       ),
@@ -129,5 +130,23 @@ async function tryXmlMethodSource(
   } catch (e) {
     console.error(`[getMethodSource] XML parse for ${className}.${methodName} failed: ${e}`);
     return null;
+  }
+}
+
+/**
+ * Dispatch to the correct parser based on object type.
+ * Tables, views, and data-entities have different XML structures than classes.
+ */
+function parseByObjectType(
+  parser: XppMetadataParser,
+  filePath: string,
+  modelName: string,
+  objectType?: string,
+): Promise<{ success: boolean; data?: any; error?: string }> {
+  switch (objectType) {
+    case 'table':       return parser.parseTableFile(filePath, modelName);
+    case 'view':
+    case 'data-entity': return parser.parseViewFile(filePath, modelName);
+    default:            return parser.parseClassFile(filePath, modelName);
   }
 }

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -112,7 +112,7 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
 
     // Fallback: parse XML file from disk (same pattern as classInfo.ts)
     const xmlSignature = await tryXmlMethodSignature(
-      parser, classRow.file_path, className, methodName, classRow.model, includeCoc, cache, cacheKey,
+      parser, classRow.file_path, className, methodName, classRow.model, includeCoc, cache, cacheKey, classRow.type,
     );
     if (xmlSignature) return xmlSignature;
 
@@ -198,11 +198,12 @@ async function tryXmlMethodSignature(
   includeCoc: boolean,
   cache: any,
   cacheKey: string,
+  objectType?: string,
 ): Promise<any | null> {
   if (!parser || !filePath) return null;
   try {
     const parseResult = await Promise.race([
-      parser.parseClassFile(filePath, modelName),
+      parseByObjectType(parser, filePath, modelName, objectType),
       new Promise<{ success: false; error: string }>(resolve =>
         setTimeout(() => resolve({ success: false, error: 'timeout' }), 3000)
       ),
@@ -224,6 +225,24 @@ async function tryXmlMethodSignature(
   } catch (e) {
     console.error(`[methodSignature] XML parse for ${className}.${methodName} failed: ${e}`);
     return null;
+  }
+}
+
+/**
+ * Dispatch to the correct parser based on object type.
+ * Tables, views, and data-entities have different XML structures than classes.
+ */
+function parseByObjectType(
+  parser: XppMetadataParser,
+  filePath: string,
+  modelName: string,
+  objectType?: string,
+): Promise<{ success: boolean; data?: any; error?: string }> {
+  switch (objectType) {
+    case 'table':       return parser.parseTableFile(filePath, modelName);
+    case 'view':
+    case 'data-entity': return parser.parseViewFile(filePath, modelName);
+    default:            return parser.parseClassFile(filePath, modelName);
   }
 }
 

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -676,6 +676,16 @@ class ConfigManager {
       return normalizePath(this.autoDetectedProject.packagePath);
     }
 
+    // UDE mode: prefer customPackagesPath from XPP config over well-known path probes.
+    // On UDE boxes, C:\AosService\PackagesLocalDirectory may exist but be empty.
+    if (this.xppConfig?.customPackagesPath && existsSync(this.xppConfig.customPackagesPath)) {
+      if (!(this as any)._packagePathLoggedOnce) {
+        console.error(`[ConfigManager] ✅ UDE customPackagesPath: ${this.xppConfig.customPackagesPath}`);
+        (this as any)._packagePathLoggedOnce = true;
+      }
+      return normalizePath(this.xppConfig.customPackagesPath);
+    }
+
     // Last resort (Windows only): probe well-known PackagesLocalDirectory locations.
     // Covers the two standard D365FO installation scenarios without requiring .mcp.json config:
     //   C:\AosService\PackagesLocalDirectory  → VHD / local developer machine
@@ -1078,6 +1088,22 @@ class ConfigManager {
     // Priority 2: XPP config auto-detection
     await this.ensureXppConfig();
     return this.xppConfig?.microsoftPackagesPath || null;
+  }
+
+  /**
+   * Get the cross-reference database server (UDE: CrossReferencesDbServerName).
+   */
+  async getXrefDbServer(): Promise<string | null> {
+    await this.ensureXppConfig();
+    return this.xppConfig?.xrefDbServer || null;
+  }
+
+  /**
+   * Get the cross-reference database name (UDE: CrossReferencesDatabaseName).
+   */
+  async getXrefDbName(): Promise<string | null> {
+    await this.ensureXppConfig();
+    return this.xppConfig?.xrefDbName || null;
   }
 
   private async ensureXppConfig(): Promise<void> {


### PR DESCRIPTION
- XML fallback parser dispatch: methodSignature.ts and getMethodSource.ts now dispatch to parseTableFile/parseViewFile based on object type instead of always calling parseClassFile (fixes table/view method lookups)

- Bridge init in HTTP mode: extracted shared initializeBridge() function, called from both stdio and HTTP startup paths (fixes silent bridge absence in npm run dev / HTTP deployments)

- UDE xref DB connection: configManager exposes getXrefDbServer() and getXrefDbName() from XPP config; initializeBridge passes them to createBridgeClient (fixes xref on UDE boxes)

- UDE-aware getPackagePath: prefers xppConfig.customPackagesPath over well-known path probes; getDevEnvironmentType called before getPackagePath to ensure XPP config is loaded (fixes empty PackagesLocalDirectory on UDE)