### PR TITLE
fix: log diagnostic details when C# bridge fails to connect (#400)

### DIFF
--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -690,9 +690,15 @@ export async function createBridgeClient(options: {
   // Auto-detect packagesPath if not provided
   const packagesPath = options.packagesPath ?? detectPackagesPath();
   if (!packagesPath) {
-    console.error('[BridgeClient] No packagesPath detected — bridge disabled');
+    console.error(
+      '[BridgeClient] No packagesPath detected — bridge disabled.\n' +
+      '  Set "packagePath" in .mcp.json context, or ensure PackagesLocalDirectory exists.\n' +
+      '  Checked: options.packagesPath=' + (options.packagesPath ?? 'undefined') + ', env.PackagesPath=' + (process.env.PackagesPath ?? 'undefined')
+    );
     return null;
   }
+
+  console.error(`[BridgeClient] packagesPath=${packagesPath}, binPath=${options.binPath ?? 'auto'}`);
 
   // Check if bridge exe exists before trying to spawn
   const client = new BridgeClient({

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,6 +368,8 @@ async function initializeBridge(targetContext: import('./types/context.js').XppS
     const xrefServer = await configMgr.getXrefDbServer() ?? undefined;
     const xrefDatabase = await configMgr.getXrefDbName() ?? undefined;
 
+    console.log(`[Bridge] Attempting connection: packagesPath=${packagesPath ?? 'not set'}, binPath=${binPath ?? 'auto'}, devEnvType=${devEnvType}`);
+
     const bridge = await createBridgeClient({
       packagesPath,
       binPath,
@@ -378,6 +380,14 @@ async function initializeBridge(targetContext: import('./types/context.js').XppS
     if (bridge) {
       targetContext.bridge = bridge;
       console.log(`✅ C# bridge connected (${devEnvType}): metadata=${bridge.metadataAvailable}, xref=${bridge.xrefAvailable}`);
+    } else {
+      console.log(
+        `⚠️  C# bridge not available — createBridgeClient returned null.\n` +
+        `   packagesPath: ${packagesPath ?? '(not detected — check .mcp.json context.packagePath or PackagesLocalDirectory)'}\n` +
+        `   devEnvType: ${devEnvType}\n` +
+        `   Check stderr / bridge log for details. Ensure the bridge exe is built:\n` +
+        `     cd bridge/D365MetadataBridge && dotnet build -c Release`
+      );
     }
   } catch (err) {
     console.log(`ℹ️  C# bridge not available: ${err}`);


### PR DESCRIPTION
When createBridgeClient() returns null the server previously logged nothing, making it impossible for users to diagnose why the bridge was unavailable.

Changes:
- initializeBridge: log resolved packagesPath/binPath/devEnvType before attempting connection; log actionable warning when bridge returns null
- createBridgeClient: log detailed context when packagesPath detection fails and log resolved paths before spawning the bridge process

Closes #400