### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete string escaping or encoding

### DIFF
--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -19,7 +19,38 @@ function escapeCmdArg(arg: string): string {
   }
   // Characters that can change cmd.exe parsing semantics
   const needsQuoting = /[\s&|<>^"]/u.test(arg);
-  let escaped = arg.replace(/"/g, '\\"');
+  // Escape double quotes and handle backslashes preceding them in a cmd.exe-compatible way.
+  // Inside a quoted argument, each run of N backslashes followed by a quote should become
+  // 2N backslashes followed by two quotes, so that the called program receives the intented characters.
+  let escaped = '';
+  for (let i = 0; i < arg.length; ) {
+    const ch = arg[i];
+    if (ch === '\\') {
+      // Count run of backslashes
+      let j = i;
+      while (j < arg.length && arg[j] === '\\') {
+        j++;
+      }
+      const numBackslashes = j - i;
+      const nextChar = arg[j];
+      if (nextChar === '"') {
+        // Double the backslashes, then escape the quote by doubling it
+        escaped += '\\'.repeat(numBackslashes * 2) + '""';
+        i = j + 1;
+      } else {
+        // No following quote: keep backslashes as-is
+        escaped += '\\'.repeat(numBackslashes);
+        i = j;
+      }
+    } else if (ch === '"') {
+      // Bare quote: escape by doubling
+      escaped += '""';
+      i++;
+    } else {
+      escaped += ch;
+      i++;
+    }
+  }
   return needsQuoting ? `"${escaped}"` : escaped;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/dynamics365ninja/d365fo-mcp-server/security/code-scanning/16](https://github.com/dynamics365ninja/d365fo-mcp-server/security/code-scanning/16)

General approach: avoid implementing custom partial escaping logic and instead rely on a well-understood, battle-tested quoting/escaping routine for Windows command lines. In Node/TypeScript, the `shell-quote` package does not handle Windows cmd.exe semantics, but `node:child_process` already offers safer APIs when passing arguments as an array instead of a composed command line string. However, the presence of this helper implies the code is composing a `cmd.exe` command line string elsewhere, so we should implement a correct cmd.exe-compatible quoting routine that handles both double quotes and backslashes in the way `cmd.exe` expects.

Best specific fix: replace the simplistic `escapeCmdArg` implementation with one that:

1. Wraps arguments in double quotes when needed (as now).
2. Escapes embedded double quotes by doubling them (`"` → `""`), which is how `cmd.exe` expects literal double quotes inside a quoted string.
3. Handles backslashes in front of double quotes correctly by doubling the backslashes before each embedded quote, so that the program receives the intended characters.
4. Leaves other backslashes alone when not directly preceding a double quote (they don’t need escaping for cmd itself).

This avoids the current incorrect use of `\"`, which is not the conventional way to represent a literal quote in cmd arguments and does not address the interaction with backslashes. We can implement this in-place inside `escapeCmdArg` in `src/tools/buildProject.ts`, without modifying any imports and without altering callers or functionality besides making argument escaping more correct/robust.

Concretely, modify lines 20–23:

- Keep the `needsQuoting` regex.
- Replace `let escaped = arg.replace(/"/g, '\\"');` with a small loop that walks the string and, for each run of backslashes followed by a double quote, doubles the backslashes and the quote, so `\+"` → `\\+""`. This matches typical Windows argument-quoting practice and satisfies CodeQL’s concern about unescaped backslashes in front of meta-characters.

No new imports are required; the logic only uses basic string operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
