### PR TITLE
fix: prevent 'activation failed' in hybrid mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -650,6 +650,27 @@ async function main() {
       });
     });
 
+    // Early /mcp route — returns 503 while services are loading so MCP clients
+    // (VS 2022, VS Code Copilot) get a proper JSON-RPC error instead of a 404
+    // during Azure cold start. Once initializeServices() finishes, the real
+    // transport route replaces this via Express's route stack.
+    app.post('/mcp', (_req, res) => {
+      if (serverState.isReady) {
+        // Should not happen — real transport route takes over. But just in case:
+        res.status(503).json({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Server is starting, please retry in a few seconds' },
+          id: (_req.body as any)?.id ?? null,
+        });
+        return;
+      }
+      res.status(503).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: `Server is starting: ${serverState.statusMessage}` },
+        id: (_req.body as any)?.id ?? null,
+      });
+    });
+
     // Bind port immediately — Azure requires the port to be open within ~230 s
     const host = process.env.HOST || '0.0.0.0';
     await new Promise<void>(resolve => app.listen(PORT, host, () => {

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -25,8 +25,11 @@ export interface McpContext {
 }
 
 export interface McpConfig {
+  /** Top-level context — preferred location (avoids VS 2022 treating it as an MCP server). */
+  context?: McpContext;
   servers: {
     [key: string]: any;
+    /** @deprecated Put context at top level instead. Kept for backward compatibility. */
     context?: McpContext;
   };
 }
@@ -599,7 +602,9 @@ class ConfigManager {
    * Merges .mcp.json config with runtime context (runtime takes priority)
    */
   getContext(): McpContext | null {
-    const fileContext = this.config?.servers.context || null;
+    // Prefer top-level context (doesn't clash with VS 2022 server discovery).
+    // Fall back to servers.context for backward compatibility.
+    const fileContext = this.config?.context || this.config?.servers?.context || null;
     // Per-request context (AsyncLocalStorage) takes priority over the shared
     // runtimeContext singleton — this prevents workspace paths from bleeding
     // between concurrent HTTP requests from different users.


### PR DESCRIPTION
Two issues causing MCP activation failures:

1. context key inside servers{}  VS 2022/VS 2026 interprets every key under 'servers' as an MCP server definition. 'context' has no command/url so it fails to activate. Fix: configManager now reads context from both top-level and servers.context (backward compat). Users should move context to top level.

2. Azure cold-start 404  the /mcp route was only registered after initializeServices() completed (DB load). During cold start, POST /mcp returned Express 404, causing the MCP client to report 'activation of the server failed'. Fix: register an early /mcp route that returns JSON-RPC 503 during startup so the client can distinguish 'starting' from 'not found' and retry.