### PR TITLE
fix: make bridgeValidateAfterWrite fire-and-forget to prevent server …

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -3861,24 +3861,24 @@ export async function handleCreateD365File(
       `[create_d365fo_file] ✅ Written: ${normalizedFullPath}  (${fileSizeKb} KB)`
     );
 
-    // Post-write validation via C# bridge (best-effort — non-fatal if bridge unavailable)
+    // Post-write validation via C# bridge (best-effort, non-fatal, fire-and-forget).
+    // Not awaited: the validation goes through the sequential bridge stdin/stdout
+    // pipe and can take 60s+, which would block all subsequent MCP calls.
+    // See: https://github.com/dynamics365ninja/d365fo-mcp-server/issues/407
     let bridgeValidation = '';
-    try {
-      const validationMsg = await bridgeValidateAfterWrite(
-        context?.bridge,
-        args.objectType,
-        finalObjectName,
-      );
+    bridgeValidateAfterWrite(
+      context?.bridge,
+      args.objectType,
+      finalObjectName,
+    ).then(validationMsg => {
       if (validationMsg) {
-        bridgeValidation = `\n${validationMsg}\n`;
         console.error(`[create_d365fo_file] Bridge validation: ${validationMsg}`);
       }
-    } catch (e) {
+    }).catch(e => {
       console.error(`[create_d365fo_file] Bridge validation skipped: ${e}`);
-    }
+    });
 
     // Auto-invalidate Redis cache so subsequent reads return fresh data
-    // (bridgeValidateAfterWrite already refreshed the C# bridge DiskProvider)
     if (context?.cache) {
       try {
         await invalidateCache(context.cache, finalObjectName, args.objectType, [finalObjectName]);

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -849,19 +849,24 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
 
     console.error(`[modify_d365fo_file] ✅ Bridge ${operation}: ${bridgeResult.message}`);
 
-    // Post-write validation (best-effort)
+    // Post-write validation (best-effort, fire-and-forget).
+    // Not awaited: the validation goes through the sequential bridge stdin/stdout
+    // pipe and can take 60s+, which would block all subsequent MCP calls.
+    // See: https://github.com/dynamics365ninja/d365fo-mcp-server/issues/407
     let bridgeValidation = '';
-    try {
-      const validationMsg = await bridgeValidateAfterWrite(
-        context.bridge,
-        objectType,
-        objectName,
-      );
-      if (validationMsg) bridgeValidation = `\n${validationMsg}`;
-    } catch (_e) { /* skip */ }
+    bridgeValidateAfterWrite(
+      context.bridge,
+      objectType,
+      objectName,
+    ).then(validationMsg => {
+      if (validationMsg) {
+        console.error(`[modify_d365fo_file] Bridge validation: ${validationMsg}`);
+      }
+    }).catch(e => {
+      console.error(`[modify_d365fo_file] Bridge validation skipped: ${e}`);
+    });
 
     // Auto-invalidate Redis cache so subsequent reads return fresh data
-    // (bridgeValidateAfterWrite already refreshed the C# bridge DiskProvider)
     try {
       await invalidateCache(context.cache, objectName, objectType, [objectName]);
     } catch { /* Redis not available — non-fatal */ }


### PR DESCRIPTION
…hang (#407)

bridgeValidateAfterWrite() awaited two sequential bridge calls (refresh + validate) each with 60s timeouts, blocking the response path. Since the .NET bridge processes requests sequentially via stdin/stdout, this starved all subsequent MCP calls, causing the server to hang permanently.

The validation is documented as best-effort and non-fatal, so it is now fire-and-forget (.then/.catch instead of await). The HTTP response returns immediately after the file is written. Validation results are logged to stderr asynchronously.

Fixes #407