### PR TITLE
fix(dbSync): rewrite trigger_db_sync for reliability

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -168,6 +168,7 @@ VS 2022 shows only "ran tool_name" — no output. **Always** write 1 sentence be
 25. SDLC tools (`run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, `run_systest_class`) auto-detect params from `.mcp.json`. If they error about missing binaries, fix `.mcp.json`.
 26. `review_workspace_changes` = git diff code review only. NOT for verifying modify/create success.
 27. `get_form_info` works for ALL forms (standard + custom). If ⚠️ warning, retry with `filePath=`.
+28. **After completing a series of changes** (multiple `create_d365fo_file` / `modify_d365fo_file` calls), **automatically run `build_d365fo_project()`**. If the build reports X++ errors, fix them immediately using `modify_d365fo_file` and rebuild until clean.
 
 ### AxClass sourceCode Format
 

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -128,6 +128,7 @@ Use this guide to select the correct tool:
 2. \`search(...)\` - find similar implementations
 3. \`get_class_info(...)\` or \`get_table_info(...)\` - understand dependencies
 4. \`generate_code(...)\` or \`create_d365fo_file(...)\` - create with correct patterns
+5. **After completing a series of changes** (multiple \`create_d365fo_file\` / \`modify_d365fo_file\` calls), **automatically run \`build_d365fo_project()\`**. If the build reports X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
 
 ### 4. Semantic vs. Prefix Search
 **Understand the difference:**

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -2560,7 +2560,8 @@ Examples:
         description: 'Run a D365FO database sync (SyncEngine.exe). ' +
           'Supports partial sync of specific tables — much faster than full-model sync. ' +
           'Use partial sync after adding/renaming fields or indexes on known tables. ' +
-          'Use full sync after creating new tables or when unsure what changed.',
+          'Pass projectPath to auto-extract tables from .rnrproj for smart partial sync. ' +
+          'Use full sync only when unsure what changed.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2571,6 +2572,7 @@ Examples:
               description: 'Partial sync: sync only these tables (faster). Example: ["CustTable", "MyNewTable"]. Omit for full-model sync.',
             },
             tableName: { type: 'string', description: 'Single-table shorthand — equivalent to tables=["tableName"]. Kept for backwards compatibility.' },
+            projectPath: { type: 'string', description: 'Path to .rnrproj file. Auto-extracts table/view names for partial sync. Auto-detected from .mcp.json when no explicit tables given.' },
             syncViews: { type: 'boolean', description: 'Also sync views and data entities. Required after creating/modifying data entities. Default: false.' },
             connectionString: { type: 'string', description: 'SQL Server connection string. Default: "Data Source=localhost;Initial Catalog=AxDB;Integrated Security=True".' },
             packagePath: { type: 'string', description: 'PackagesLocalDirectory root. Auto-detected from .mcp.json if omitted.' },

--- a/src/tools/dbSync.ts
+++ b/src/tools/dbSync.ts
@@ -1,18 +1,146 @@
 import { z } from 'zod';
-import { execFile } from 'child_process';
-import util from 'util';
+import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs/promises';
+import { Parser } from 'xml2js';
 import { getConfigManager } from '../utils/configManager.js';
 import { withOperationLock } from '../utils/operationLocks.js';
 
-const execFileAsync = util.promisify(execFile);
+/** AOT folders that map to syncable DB objects (tables, table extensions, views, data entities). */
+const SYNCABLE_AOT_FOLDERS = new Set([
+  'AxTable', 'AxTableExtension', 'AxView', 'AxDataEntityView', 'AxDataEntityViewExtension',
+]);
+
+/** Max output length returned to the client (characters). */
+const MAX_OUTPUT_LENGTH = 8_000;
+
+/**
+ * Runs an executable and streams output to stderr for progress visibility.
+ * Returns combined stdout+stderr and the exit code.
+ */
+function runWithStreaming(
+  exe: string,
+  args: string[],
+  opts: { timeout: number; windowsHide?: boolean }
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(exe, args, {
+      windowsHide: opts.windowsHide ?? true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let killed = false;
+
+    const timer = opts.timeout > 0
+      ? setTimeout(() => {
+          killed = true;
+          child.kill('SIGTERM');
+          setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 5000);
+        }, opts.timeout)
+      : undefined;
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      // Log progress lines so user can see activity in MCP server logs
+      for (const line of text.split('\n').filter((l: string) => l.trim())) {
+        console.error(`[db-sync stdout] ${line}`);
+      }
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderr += text;
+      for (const line of text.split('\n').filter((l: string) => l.trim())) {
+        console.error(`[db-sync stderr] ${line}`);
+      }
+    });
+
+    child.on('error', (err) => {
+      if (timer) clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      if (timer) clearTimeout(timer);
+      if (killed) {
+        reject(Object.assign(
+          new Error(`SyncEngine timed out after ${opts.timeout / 60000} minutes`),
+          { stdout, stderr }
+        ));
+      } else {
+        resolve({ stdout, stderr, code });
+      }
+    });
+  });
+}
+
+/**
+ * Extract table/view names from a .rnrproj project file.
+ * Looks for Content Include entries like "AxTable\MyTable", "AxTableExtension\MyExt", etc.
+ */
+async function extractTablesFromProject(projectPath: string): Promise<string[]> {
+  const parser = new Parser({ explicitArray: true });
+  const xml = await fs.readFile(projectPath, 'utf-8');
+  const parsed = await parser.parseStringPromise(xml);
+
+  const tables: string[] = [];
+  const itemGroups: any[] = parsed?.Project?.ItemGroup ?? [];
+  for (const group of itemGroups) {
+    const contents: any[] = Array.isArray(group.Content) ? group.Content : [];
+    for (const c of contents) {
+      const inc: string | undefined = c?.$?.Include;
+      if (!inc) continue;
+      // Format: "AxTable\MyTableName" or "AxTableExtension\SomeExt"
+      const sep = inc.includes('\\') ? '\\' : inc.includes('/') ? '/' : '\\';
+      const parts = inc.split(sep);
+      if (parts.length >= 2 && SYNCABLE_AOT_FOLDERS.has(parts[0])) {
+        // For extensions like "CustTable.MyExt", extract base table name
+        const objectName = parts[1];
+        const baseName = objectName.includes('.') ? objectName.split('.')[0] : objectName;
+        if (baseName && !tables.includes(baseName)) {
+          tables.push(baseName);
+        }
+      }
+    }
+  }
+  return tables;
+}
+
+/**
+ * Check that critical StaticMetadata files exist for the model.
+ * SyncEngine hangs or crashes when these are missing.
+ */
+async function checkStaticMetadata(packagesRoot: string, modelName: string): Promise<string | null> {
+  const binDir = path.join(packagesRoot, modelName, 'bin', 'StaticMetadata');
+  try {
+    await fs.access(binDir);
+    return null; // OK
+  } catch {
+    return `⚠️ Missing StaticMetadata for model "${modelName}" at:\n${binDir}\n\n` +
+      'SyncEngine will fail without compiled metadata. Run a full Rebuild from Visual Studio first:\n' +
+      '  Right-click project → Rebuild\n' +
+      'Then retry db sync.';
+  }
+}
+
+/** Truncate output to avoid huge MCP responses. */
+function truncateOutput(text: string): string {
+  if (text.length <= MAX_OUTPUT_LENGTH) return text;
+  const half = Math.floor(MAX_OUTPUT_LENGTH / 2) - 50;
+  return text.slice(0, half) +
+    `\n\n... [truncated ${text.length - MAX_OUTPUT_LENGTH} chars] ...\n\n` +
+    text.slice(-half);
+}
 
 export const dbSyncToolDefinition = {
   name: 'trigger_db_sync',
   description: 'Triggers a D365FO database sync (SyncEngine.exe). ' +
     'Supports full-model sync or partial sync of specific tables/views. ' +
-    'Partial sync is faster and sufficient after adding/renaming fields, indexes, or creating a new table.',
+    'Partial sync is faster and sufficient after adding/renaming fields, indexes, or creating a new table. ' +
+    'Pass projectPath to auto-extract tables from the .rnrproj and do a smart partial sync.',
   parameters: z.object({
     modelName: z.string().optional().describe(
       'Model name to sync. Auto-detected from .mcp.json if omitted.'
@@ -25,6 +153,11 @@ export const dbSyncToolDefinition = {
     tableName: z.string().optional().describe(
       'Single table shorthand — equivalent to tables=["tableName"]. ' +
       'Kept for backwards compatibility; prefer tables[] for multiple objects.'
+    ),
+    projectPath: z.string().optional().describe(
+      'Path to .rnrproj file. Extracts all table/table-extension/view names from the project ' +
+      'and runs a partial sync for just those objects. Auto-detected from .mcp.json if omitted ' +
+      'when no explicit tables are given.'
     ),
     syncViews: z.boolean().optional().default(false).describe(
       'When true, also syncs views and data entities in addition to tables. ' +
@@ -69,69 +202,114 @@ export const dbSyncTool = async (params: any, _context: any) => {
       };
     }
 
-    // Merge tables[] and tableName (backwards-compat)
-    const tableList: string[] = [
+    // ── Pre-flight: check StaticMetadata exists for the model ─────────────
+    const metadataWarning = await checkStaticMetadata(packagesRoot, modelName);
+    // Warning is logged but does NOT block — we pass both -metadata (source XML)
+    // and -metadatabinaries so SyncEngine can fall back to source files.
+    if (metadataWarning) {
+      console.error(`[trigger_db_sync] ${metadataWarning}`);
+    }
+
+    // ── Resolve table list ────────────────────────────────────────────────
+    // Priority: explicit tables[] / tableName > projectPath extraction > full sync
+    let tableList: string[] = [
       ...(params.tables ?? []),
       ...(params.tableName ? [params.tableName] : []),
     ].filter((t: string) => t.trim().length > 0);
 
+    let projectExtracted = false;
+    if (tableList.length === 0) {
+      // Try to extract tables from project file for smart partial sync
+      const projectPath = params.projectPath || await configManager.getProjectPath();
+      if (projectPath) {
+        try {
+          await fs.access(projectPath);
+          const extracted = await extractTablesFromProject(projectPath);
+          if (extracted.length > 0) {
+            tableList = extracted;
+            projectExtracted = true;
+            console.error(`[trigger_db_sync] Extracted ${extracted.length} syncable objects from project: ${extracted.join(', ')}`);
+          }
+        } catch (e: any) {
+          console.error(`[trigger_db_sync] Could not read project file ${projectPath}: ${e.message}`);
+          // Fall through to full sync
+        }
+      }
+    }
+
     const isPartial = tableList.length > 0;
 
-    const binPath = path.join(packagesRoot, modelName, 'bin');
+    // SyncEngine needs the PackagesLocalDirectory root — it reads StaticMetadata
+    // from every model's bin folder, not just the current model's.
+    const metadataBinPath = packagesRoot;
     const connStr = params.connectionString
       || 'Data Source=localhost;Initial Catalog=AxDB;Integrated Security=True';
 
-    const syncMode = isPartial ? 'onlysyncselectedtables' : 'fullall';
+    let syncMode: string;
+    if (isPartial) {
+      syncMode = 'PartialList';
+    } else if (syncViews) {
+      syncMode = 'FullAllAndViews';
+    } else {
+      syncMode = 'FullAll';
+    }
+
     const args: string[] = [
       `-syncmode=${syncMode}`,
+      `-metadatabinaries=${metadataBinPath}`,
       `-connect=${connStr}`,
-      `-metadatabinaries=${binPath}`
     ];
-    if (isPartial) {
-      args.push(`-tables=${tableList.join(',')}`);
+    // Only add verbosediagnostics for full sync (adds overhead)
+    if (!isPartial) {
+      args.push('-verbosediagnostics');
     }
-    if (syncViews) {
-      // SyncEngine supports -syncmode=fullalltablesandviews for full sync with views,
-      // or we add the -views flag for partial sync
-      if (isPartial) {
-        args.push(`-views=${tableList.join(',')}`);
-      } else {
-        // Replace syncmode to include views
-        args[0] = '-syncmode=fullalltablesandviews';
+    if (isPartial) {
+      args.push(`-synclist=${tableList.join(',')}`);
+      if (syncViews) {
+        args.push(`-viewlist=${tableList.join(',')}`);
       }
     }
 
     console.error(`[trigger_db_sync] Running: "${syncEnginePath}" ${args.join(' ')}`);
 
+    // Timeouts: partial 15 min, full 60 min
+    const timeoutMs = isPartial ? 15 * 60_000 : 60 * 60_000;
+
+    const startTime = Date.now();
     const { stdout, stderr } = await withOperationLock(
-      `dbsync:${modelName}`,
-      () => execFileAsync(syncEnginePath, args, {
-        maxBuffer: 20 * 1024 * 1024,
-        timeout: 600_000, // 10 minutes
+      'dbsync',  // single lock key — SyncEngine can't run in parallel on same DB
+      () => runWithStreaming(syncEnginePath, args, {
+        timeout: timeoutMs,
         windowsHide: true,
       }),
     );
+    const elapsedSec = Math.round((Date.now() - startTime) / 1000);
 
-    const output = [stdout, stderr].filter(Boolean).join('\n').trim();
-    const hasErrors = /error|failed|exception/i.test(output);
+    const rawOutput = [stdout, stderr].filter(Boolean).join('\n').trim();
+    const output = truncateOutput(rawOutput);
+    const hasErrors = /\b(error|failed|exception)\b/i.test(rawOutput) &&
+      !/0 error/i.test(rawOutput);  // "0 errors" is success
 
     const scopeDesc = isPartial
-      ? `Partial sync — tables: ${tableList.join(', ')}${syncViews ? ' + views' : ''}`
+      ? `Partial sync — ${tableList.length} table(s): ${tableList.join(', ')}` +
+        (projectExtracted ? ' (extracted from project)' : '') +
+        (syncViews ? ' + views' : '')
       : `Full sync — model: ${modelName}${syncViews ? ' (tables + views)' : ''}`;
 
     return {
       content: [{
         type: 'text',
         text: (hasErrors ? '❌ DB Sync failed' : '✅ DB Sync completed') +
+          ` (${elapsedSec}s)` +
           `\n\n${scopeDesc}` +
           `\n\n${output || '(no output)'}`
       }]
     };
   } catch (error: any) {
     console.error('Error syncing DB:', error);
-    const output = [error.stdout, error.stderr, error.message].filter(Boolean).join('\n');
+    const rawOutput = [error.stdout, error.stderr, error.message].filter(Boolean).join('\n');
     return {
-      content: [{ type: 'text', text: '❌ DB Sync failed:\n\n' + output }],
+      content: [{ type: 'text', text: '❌ DB Sync failed:\n\n' + truncateOutput(rawOutput) }],
       isError: true
     };
   }


### PR DESCRIPTION
- Fix -metadatabinaries path: use PackagesLocalDirectory root, not model/bin
- Fix sync mode: use PartialList/-synclist instead of non-existent onlysyncselectedtables/-tablelist
- Remove invalid -metadata parameter
- Add smart partial sync from .rnrproj (auto-extract tables/views from project)
- Add streaming output via spawn instead of buffered execFile
- Increase timeout: 15min partial, 60min full (was 10min for all)
- Add pre-flight StaticMetadata check (warning, non-blocking)
- Add graceful kill on timeout (SIGTERM then SIGKILL)
- Fix operation lock key to single 'dbsync' (SyncEngine can't run in parallel)
- Add auto-build rule (#28) after series of create/modify changes