### PR TITLE
fix: method in-place edit, stale build lock, form control override

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,7 +172,7 @@ VS 2022 shows only "ran tool_name" — no output. **Always** write 1 sentence be
 25. SDLC tools (`run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, `run_systest_class`) auto-detect params from `.mcp.json`. If they error about missing binaries, fix `.mcp.json`.
 26. `review_workspace_changes` = git diff code review only. NOT for verifying modify/create success.
 27. `get_form_info` works for ALL forms (standard + custom). If ⚠️ warning, retry with `filePath=`.
-28. **After completing a series of changes** (multiple `create_d365fo_file` / `modify_d365fo_file` calls), **automatically run `build_d365fo_project()`**. If the build reports X++ errors, fix them immediately using `modify_d365fo_file` and rebuild until clean.
+28. **After completing a larger series of changes** (multiple objects, structural metadata changes, or several `create_d365fo_file` / `modify_d365fo_file` calls), **run `build_d365fo_project()`**. Do **not** run a build after every small in-method edit; prefer building after broader changes or when the user explicitly asks for validation. If the build reports X++ errors, fix them immediately using `modify_d365fo_file` and rebuild until clean.
 29. **"Check best practices" / "BP check" → ALWAYS call `run_bp_check()`**. NEVER manually iterate `get_method_source` to review code for BP compliance — the BP checker tool is authoritative and covers all rules.
 
 ### AxClass sourceCode Format

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -2483,12 +2483,30 @@ namespace D365MetadataBridge.Services
             // Try top-level Methods first (AxClass, AxTable, AxTableExtension, etc.)
             if (TryUpdateSourceInCollection(axObject, "Methods", methodName, newSource)) return true;
 
+            string? controlNameFilter = null;
+            string effectiveMethodName = methodName;
+            if (!string.IsNullOrWhiteSpace(methodName) && methodName.Contains('.'))
+            {
+                var dotIdx = methodName.IndexOf('.');
+                controlNameFilter = methodName.Substring(0, dotIdx);
+                effectiveMethodName = methodName.Substring(dotIdx + 1);
+            }
+
             // For forms: SourceCode.Methods (form-level methods like init, run)
             try
             {
                 dynamic dyn = axObject;
                 dynamic sourceCode = dyn.SourceCode;
-                if (sourceCode != null && TryUpdateSourceInCollection(sourceCode, "Methods", methodName, newSource)) return true;
+                if (sourceCode != null)
+                {
+                    if (TryUpdateSourceInCollection(sourceCode, "Methods", methodName, newSource)) return true;
+
+                    if (controlNameFilter != null)
+                    {
+                        var combinedName = $"{controlNameFilter}_{effectiveMethodName}";
+                        if (TryUpdateSourceInCollection(sourceCode, "Methods", combinedName, newSource)) return true;
+                    }
+                }
             }
             catch { }
 
@@ -2497,9 +2515,56 @@ namespace D365MetadataBridge.Services
             {
                 dynamic dyn = axObject;
                 dynamic sourceCode = dyn.SourceCode;
-                if (sourceCode != null && TryUpdateSourceInCollection(sourceCode, "DataControls", methodName, newSource)) return true;
+                if (sourceCode != null && TryUpdateSourceInFormDataControls(sourceCode, controlNameFilter, effectiveMethodName, methodName, newSource)) return true;
             }
             catch { }
+
+            return false;
+        }
+
+        private bool TryUpdateSourceInFormDataControls(dynamic sourceCode, string? controlNameFilter, string effectiveMethodName, string originalMethodName, string newSource)
+        {
+            try
+            {
+                foreach (dynamic ctrl in sourceCode.DataControls)
+                {
+                    string ctrlName = (string)ctrl.Name;
+                    bool controlMatches = controlNameFilter == null ||
+                        string.Equals(ctrlName, controlNameFilter, StringComparison.OrdinalIgnoreCase);
+
+                    if (!controlMatches) continue;
+
+                    try
+                    {
+                        foreach (dynamic m in ctrl.Methods)
+                        {
+                            string mName = (string)m.Name;
+                            if (string.Equals(mName, effectiveMethodName, StringComparison.OrdinalIgnoreCase) ||
+                                string.Equals(mName, originalMethodName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                m.Source = newSource;
+                                return true;
+                            }
+                        }
+                    }
+                    catch { }
+
+                    try
+                    {
+                        string? directSrc = (string?)ctrl.Source;
+                        if (directSrc != null && controlNameFilter != null)
+                        {
+                            ctrl.Source = newSource;
+                            return true;
+                        }
+                    }
+                    catch { }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[WriteService] TryUpdateSourceInFormDataControls({originalMethodName}) failed: {ex.Message}");
+            }
 
             return false;
         }

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -128,7 +128,7 @@ Use this guide to select the correct tool:
 2. \`search(...)\` - find similar implementations
 3. \`get_class_info(...)\` or \`get_table_info(...)\` - understand dependencies
 4. \`generate_code(...)\` or \`create_d365fo_file(...)\` - create with correct patterns
-5. **After completing a series of changes** (multiple \`create_d365fo_file\` / \`modify_d365fo_file\` calls), **automatically run \`build_d365fo_project()\`**. If the build reports X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
+5. **After completing a larger series of changes** (multiple objects, structural metadata changes, or several \`create_d365fo_file\` / \`modify_d365fo_file\` calls), **run \`build_d365fo_project()\`**. Do **not** run a build after every small in-method edit; prefer building after broader changes or when the user explicitly asks for validation. If the build reports X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
 
 ### 4. Semantic vs. Prefix Search
 **Understand the difference:**

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -999,9 +999,9 @@ Examples:
                 ],
                 description:
                   'Type of modification to perform.\n' +
-                  'add-method: add a new method (or CoC method) to a class/table/form.\n' +
+                  'add-method: add a new method (or CoC method) to a class/table/form, or update an existing method in place when the same name already exists so its position is preserved.\n' +
                   'remove-method: remove a method by name.\n' +
-                  'replace-code: surgical in-place replacement — pass oldCode (exact snippet to find) + newCode (replacement text). ' +
+                  'replace-code: surgical in-place replacement — pass oldCode (exact snippet to find) + newCode (replacement text). This is also the preferred way to replace an entire existing method when you already know the old source. ' +
                   'For form control override methods use methodName="ControlName.methodName" (e.g. "PostButton.clicked").\n' +
                   'add-field: add a field to a table or table-extension.\n' +
                   'modify-field: change EDT/mandatory/label of an existing field.\n' +

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -102,6 +102,29 @@ async function killOrphanedBuildProcesses(): Promise<void> {
   );
 }
 
+async function isProcessImageRunning(imageName: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync('tasklist', [
+      '/FI', `IMAGENAME eq ${imageName}`,
+      '/FO', 'CSV',
+      '/NH',
+    ], { timeout: 10_000, windowsHide: true });
+
+    return stdout.toLowerCase().includes(`"${imageName.toLowerCase()}"`);
+  } catch {
+    return false;
+  }
+}
+
+async function getRunningBuildProcesses(): Promise<string[]> {
+  const targets = ['MSBuild.exe', 'devenv.com', 'devenv.exe'];
+  const states = await Promise.all(targets.map(async name => ({
+    name,
+    running: await isProcessImageRunning(name),
+  })));
+  return states.filter(state => state.running).map(state => state.name);
+}
+
 async function resolvePackagesPath(): Promise<string | null> {
   try {
     const configManager = getConfigManager();
@@ -236,16 +259,25 @@ export const buildProjectTool = async (params: any, _context: any) => {
         isOperationLockHeld(devenvLockKey),
       ]);
       if (mainLocked || devenvLocked) {
-        const which = mainLocked ? 'MSBuild' : 'devenv.com fallback';
-        await buildLog('WARN', `Build already in progress (${which} lock held) for: ${resolvedProjectPath} — rejecting new request`);
-        return {
-          content: [{
-            type: 'text',
-            text: `⚠️ A build is already in progress (${which}) for this project.\n\n` +
-              'Wait for it to finish, or call `build_d365fo_project` with `force: true` to kill the stuck build and start fresh.',
-          }],
-          isError: true,
-        };
+        const runningProcesses = await getRunningBuildProcesses();
+
+        if (runningProcesses.length === 0) {
+          await buildLog('WARN', `Detected stale build lock with no active build processes for: ${resolvedProjectPath} — clearing locks`);
+          await forceReleaseLock(buildLockKey);
+          await forceReleaseLock(devenvLockKey);
+        } else {
+          const which = mainLocked ? 'MSBuild' : 'devenv.com fallback';
+          await buildLog('WARN', `Build already in progress (${which} lock held, active processes: ${runningProcesses.join(', ')}) for: ${resolvedProjectPath} — rejecting new request`);
+          return {
+            content: [{
+              type: 'text',
+              text: `⚠️ A build is already in progress (${which}) for this project.\n\n` +
+                `Active processes: ${runningProcesses.join(', ')}\n\n` +
+                'Wait for it to finish, or call `build_d365fo_project` with `force: true` to kill the stuck build and start fresh.',
+            }],
+            isError: true,
+          };
+        }
       }
     }
 

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -700,7 +700,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             `    methodName="PostButton.clicked",\n` +
             `    oldCode="ttsbegin;",\n` +
             `    newCode="")\n\n` +
-            `If you want to replace an entire method, use remove-method + add-method instead.`
+            `If you want to replace an entire existing method, pass the full old method source as oldCode and the full new method source as newCode so the edit stays in place. Use remove-method + add-method only when you intentionally want a remove/add operation.`
           );
         }
         
@@ -1355,7 +1355,7 @@ export const modifyD365FileToolDefinition = {
   description:
     '✏️ Edit existing D365FO XML files (AxClass, AxTable, AxTableExtension, AxForm, AxFormExtension, etc.). ' +
     'Supports atomic operations:\n' +
-    '• Methods: add-method, remove-method (table, form, class, table-extension, class-extension)\n' +
+    '• Methods: add-method, remove-method (table, form, class, table-extension, class-extension). add-method updates an existing method in place when the name already exists, preserving method order.\n' +
     '• Fields: add-field, modify-field, rename-field, replace-all-fields, remove-field (table, table-extension)\n' +
     '• Indexes: add-index, remove-index (table, table-extension)\n' +
     '• Relations: add-relation, remove-relation (table, table-extension)\n' +

--- a/tests/tools/form-control-method-inplace.test.ts
+++ b/tests/tools/form-control-method-inplace.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Regression tests — Form control method in-place editing
+ *
+ * Verifies that `modify_d365fo_file` with operation `add-method` on a form and
+ * a control-qualified method name (`ControlName.methodName` format) routes to
+ * `bridgeAddMethod` exactly once — without first calling `bridgeRemoveMethod`.
+ *
+ * Before the fix in MetadataWriteService.cs (TryUpdateSourceInFormDataControls),
+ * `TryUpdateMethodSourceInPlace` failed to find control override methods inside
+ * SourceCode.DataControls, so the bridge returned success=false.  The AI then
+ * fell back to the documented workaround of remove-method + add-method, which
+ * always appends the method at the end of the file (breaking method order).
+ *
+ * This TS layer test asserts the correct single-call pattern from the tool up.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool } from '../../src/tools/modifyD365File';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// ─── Hoist bridge mock functions so they can be referenced inside vi.mock ────
+
+const { mockBridgeAddMethod, mockBridgeRemoveMethod } = vi.hoisted(() => ({
+  mockBridgeAddMethod: vi.fn(async () => ({
+    success: true,
+    message: '✅ Method PostButton.clicked updated in place via IMetadataProvider',
+  })),
+  mockBridgeRemoveMethod: vi.fn(async () => ({
+    success: true,
+    message: '✅ Method removed',
+  })),
+}));
+
+// Keep canBridgeModify real so form+add-method is correctly accepted.
+// Replace only the functions under test.
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return {
+    ...actual,
+    bridgeAddMethod: mockBridgeAddMethod,
+    bridgeRemoveMethod: mockBridgeRemoveMethod,
+    bridgeValidateAfterWrite: vi.fn(async () => null),
+  };
+});
+
+// ─── Module mocks (same pattern as file-ops.test.ts) ─────────────────────────
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (p.endsWith('.xml')) return FORM_XML_WITH_CONTROL_METHOD;
+    if (p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (m: string) => ({
+      packageName: m,
+      modelName: m,
+      rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({
+      packageName: p,
+      modelName: m,
+      rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/** Minimal form XML with an existing PostButton.clicked control override. */
+const FORM_XML_WITH_CONTROL_METHOD = `<?xml version="1.0" encoding="utf-8"?>
+<AxForm>
+  <Name>VendInvoiceApprovalJournal</Name>
+  <SourceCode>
+    <Methods />
+    <DataControls>
+      <DataControl>
+        <Name>PostButton</Name>
+        <Methods>
+          <Method>
+            <Name>clicked</Name>
+            <Source><![CDATA[public void clicked()
+{
+    super();
+}]]></Source>
+          </Method>
+        </Methods>
+      </DataControl>
+    </DataControls>
+  </SourceCode>
+</AxForm>`;
+
+const FORM_FILE_PATH =
+  'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxForm\\VendInvoiceApprovalJournal.xml';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const req = (name: string, args: Record<string, unknown> = {}): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name, arguments: args },
+});
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare: vi.fn(() => stmt) },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {}),
+      generateSearchKey: vi.fn((q: string) => `k:${q}`),
+    } as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    /** Bridge present and ready — required or the tool returns early with isError */
+    bridge: {
+      isReady: true,
+      metadataAvailable: true,
+    } as any,
+  };
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('form control method in-place editing (regression)', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    mockBridgeAddMethod.mockClear();
+    mockBridgeRemoveMethod.mockClear();
+  });
+
+  it('calls bridgeAddMethod exactly once with the control-qualified method name', async () => {
+    const newSource = `public void clicked()\n{\n    super();\n    info("posted");\n}`;
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form',
+        objectName: 'VendInvoiceApprovalJournal',
+        operation: 'add-method',
+        methodName: 'PostButton.clicked',
+        sourceCode: newSource,
+        filePath: FORM_FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(mockBridgeAddMethod).toHaveBeenCalledTimes(1);
+    expect(mockBridgeAddMethod).toHaveBeenCalledWith(
+      ctx.bridge,
+      'form',
+      'VendInvoiceApprovalJournal',
+      'PostButton.clicked',
+      newSource,
+    );
+  });
+
+  it('does NOT call bridgeRemoveMethod (anti-regression: no remove+add workaround)', async () => {
+    const newSource = `public void clicked()\n{\n    super();\n    info("done");\n}`;
+
+    await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form',
+        objectName: 'VendInvoiceApprovalJournal',
+        operation: 'add-method',
+        methodName: 'PostButton.clicked',
+        sourceCode: newSource,
+        filePath: FORM_FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(mockBridgeRemoveMethod).not.toHaveBeenCalled();
+  });
+
+  it('returns a success response that mentions the object name', async () => {
+    const newSource = `public void clicked()\n{\n    super();\n}`;
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form',
+        objectName: 'VendInvoiceApprovalJournal',
+        operation: 'add-method',
+        methodName: 'PostButton.clicked',
+        sourceCode: newSource,
+        filePath: FORM_FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('VendInvoiceApprovalJournal');
+  });
+
+  it('handles a top-level form method (no control prefix) the same way', async () => {
+    const newSource = `void init()\n{\n    super();\n}`;
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form',
+        objectName: 'VendInvoiceApprovalJournal',
+        operation: 'add-method',
+        methodName: 'init',
+        sourceCode: newSource,
+        filePath: FORM_FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(mockBridgeAddMethod).toHaveBeenCalledTimes(1);
+    expect(mockBridgeAddMethod).toHaveBeenCalledWith(
+      ctx.bridge,
+      'form',
+      'VendInvoiceApprovalJournal',
+      'init',
+      newSource,
+    );
+    expect(mockBridgeRemoveMethod).not.toHaveBeenCalled();
+  });
+
+  it('returns isError when bridge is absent', async () => {
+    ctx.bridge = undefined;
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form',
+        objectName: 'VendInvoiceApprovalJournal',
+        operation: 'add-method',
+        methodName: 'PostButton.clicked',
+        sourceCode: `public void clicked()\n{\n    super();\n}`,
+        filePath: FORM_FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/bridge is not available/i);
+  });
+});


### PR DESCRIPTION
- systemInstructions + copilot-instructions: build only after larger series of changes, not after every small in-method edit
- modifyD365File.ts: document add-method in-place semantics; improve replace-code error guidance (oldCode/newCode instead of remove+add)
- mcpServer.ts: update operation descriptions for add-method / replace-code
- buildProject.ts: detect stale build lock using tasklist; auto-clear when no MSBuild/devenv process is running
- MetadataWriteService.cs: fix TryUpdateMethodSourceInPlace to handle control override methods (ControlName.methodName) via new helper TryUpdateSourceInFormDataControls; add combinedName fallback
- tests: add regression test for form control method in-place editing (form-control-method-inplace.test.ts, 5 tests, all passing)