### PR TITLE
fix: skip field label when EDT has label; never auto-build - ask user to build manually

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -162,7 +162,7 @@ VS 2022 shows only "ran tool_name" — no output. **Always** write 1 sentence be
 15. **NEVER** call functions in `WHERE` clauses — assign to variable first
 16. **NEVER** use hardcoded strings in `Info()`/`warning()`/`error()` — use `@Model:Label`
 17. **NEVER** nest `while select` loops — use `join` or pre-load to `Map`/temp table
-18. **ALWAYS** call `create_label()` before referencing new labels in code
+18. **ALWAYS** call `create_label()` before referencing new labels in code. **Exception:** when adding a field to a table/table-extension with an EDT that already has a label defined, do **NOT** set a label on the field — the field inherits the label from the EDT automatically. Only set `label` on a field when deliberately overriding the EDT's label.
 19. **ALWAYS** write meaningful `/// <summary>` on public/protected classes and methods
 20. **NEVER** call `[SysObsolete]` methods — read the attribute for the replacement
 21. **NEVER** switch project autonomously via `get_workspace_info(projectName=...)` — ask user
@@ -172,7 +172,7 @@ VS 2022 shows only "ran tool_name" — no output. **Always** write 1 sentence be
 25. SDLC tools (`run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, `run_systest_class`) auto-detect params from `.mcp.json`. If they error about missing binaries, fix `.mcp.json`.
 26. `review_workspace_changes` = git diff code review only. NOT for verifying modify/create success.
 27. `get_form_info` works for ALL forms (standard + custom). If ⚠️ warning, retry with `filePath=`.
-28. **After completing a larger series of changes** (multiple objects, structural metadata changes, or several `create_d365fo_file` / `modify_d365fo_file` calls), **run `build_d365fo_project()`**. Do **not** run a build after every small in-method edit; prefer building after broader changes or when the user explicitly asks for validation. If the build reports X++ errors, fix them immediately using `modify_d365fo_file` and rebuild until clean.
+28. **NEVER run `build_d365fo_project()` automatically.** Builds take a long time and block the user. After completing changes, inform the user that changes are done and they can build manually when ready — e.g. *"Changes applied. Run a build when you're ready to validate."* Only run `build_d365fo_project()` when the user explicitly requests it ("build", "compile", "check errors"). If the build reports X++ errors, fix them immediately using `modify_d365fo_file` and rebuild until clean.
 29. **"Check best practices" / "BP check" → ALWAYS call `run_bp_check()`**. NEVER manually iterate `get_method_source` to review code for BP compliance — the BP checker tool is authoritative and covers all rules.
 
 ### AxClass sourceCode Format

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -128,7 +128,7 @@ Use this guide to select the correct tool:
 2. \`search(...)\` - find similar implementations
 3. \`get_class_info(...)\` or \`get_table_info(...)\` - understand dependencies
 4. \`generate_code(...)\` or \`create_d365fo_file(...)\` - create with correct patterns
-5. **After completing a larger series of changes** (multiple objects, structural metadata changes, or several \`create_d365fo_file\` / \`modify_d365fo_file\` calls), **run \`build_d365fo_project()\`**. Do **not** run a build after every small in-method edit; prefer building after broader changes or when the user explicitly asks for validation. If the build reports X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
+5. **NEVER run \`build_d365fo_project()\` automatically.** Builds take a long time and block the user. After completing changes, tell the user the changes are done and they can build manually when ready. Only run \`build_d365fo_project()\` when the user explicitly requests it ("build", "compile", "check errors"). If after a requested build there are X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
 
 ### 4. Semantic vs. Prefix Search
 **Understand the difference:**


### PR DESCRIPTION
This pull request updates coding standards and system instructions to clarify when and how to use labels on fields and when to run project builds. The key changes focus on preventing unnecessary builds and ensuring correct label usage, reducing confusion and improving performance.

**Build process guidance:**
* Updated instructions to **never run `build_d365fo_project()` automatically**; users are now told to run builds manually when ready, and builds should only be triggered on explicit user request. This avoids blocking the user with long-running builds and clarifies error handling after builds. (.github/copilot-instructions.md [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L175-R175) src/prompts/systemInstructions.ts [[2]](diffhunk://#diff-387d5c2d72b4e3605e85cd319fbd67da69445b6838b3c1ffed5a2488824f6c64L131-R131)

**Label usage clarification:**
* Added an exception to the rule about calling `create_label()` before referencing new labels: when adding a field to a table or table-extension with an EDT that already has a label, do **not** set a label on the field unless deliberately overriding the EDT's label. (.github/copilot-instructions.md [.github/copilot-instructions.mdL165-R165](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L165-R165))