### PR TITLE
add multi-instance support with centralized loadEnv and management scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ lerna-debug.log*
 .env.local
 .env.*.local
 
+# Multi-instance data (per-machine, contains .env files, databases, metadata)
+instances/*/
+
 # Database files
 *.db
 *.db-shm

--- a/add-instance.ps1
+++ b/add-instance.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+    Create a new MCP server instance.
+.DESCRIPTION
+    Prompts for instance name and port, creates the folder structure,
+    and copies the .env template. Opens the .env for editing when done.
+#>
+param(
+    [string]$InstanceName,
+    [int]$Port
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = $PSScriptRoot
+$instancesDir = Join-Path $repoRoot 'instances'
+$templateFile = Join-Path $instancesDir '.env.template'
+
+if (-not (Test-Path $templateFile)) {
+    Write-Host "Template not found: $templateFile" -ForegroundColor Red
+    exit 1
+}
+
+# ── Discover existing instances ─────────────────────────────────────────────
+$existing = @(Get-ChildItem -Path $instancesDir -Directory -ErrorAction SilentlyContinue |
+    Where-Object { Test-Path (Join-Path $_.FullName '.env') } |
+    Sort-Object Name)
+
+# ── Helper: read PORT from an .env file ─────────────────────────────────────
+function Get-EnvPort([string]$envFile) {
+    $line = Select-String -Path $envFile -Pattern '^\s*PORT\s*=' -List | Select-Object -First 1
+    if ($line) { return ($line.Line -replace '^\s*PORT\s*=\s*', '').Trim() }
+    return $null
+}
+
+# ── Show existing instances ─────────────────────────────────────────────────
+if ($existing.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'Existing instances:' -ForegroundColor Cyan
+    Write-Host ''
+    foreach ($inst in $existing) {
+        $p = Get-EnvPort (Join-Path $inst.FullName '.env')
+        Write-Host "  - $($inst.Name)  " -NoNewline -ForegroundColor White
+        Write-Host "(port $p)" -ForegroundColor DarkGray
+    }
+    Write-Host ''
+}
+
+# ── Prompt for name ─────────────────────────────────────────────────────────
+if (-not $InstanceName) {
+    $InstanceName = Read-Host 'Instance name (e.g. alpha, projectX, client-prod)'
+    $InstanceName = $InstanceName.Trim()
+}
+if (-not $InstanceName) {
+    Write-Host 'No name provided.' -ForegroundColor Red
+    exit 1
+}
+
+$instanceDir = Join-Path $instancesDir $InstanceName
+if (Test-Path (Join-Path $instanceDir '.env')) {
+    Write-Host "Instance '$InstanceName' already exists." -ForegroundColor Red
+    exit 1
+}
+
+# ── Prompt for port ─────────────────────────────────────────────────────────
+# Suggest next available port based on existing instances
+$usedPorts = @($existing | ForEach-Object {
+    $p = Get-EnvPort (Join-Path $_.FullName '.env')
+    if ($p -and $p -ne '?') { [int]$p }
+})
+$suggestedPort = 3001
+if ($usedPorts.Count -gt 0) {
+    $suggestedPort = ($usedPorts | Measure-Object -Maximum).Maximum + 1
+}
+
+if (-not $Port) {
+    $input = Read-Host "Port [$suggestedPort]"
+    $input = $input.Trim()
+    if ($input) { $Port = [int]$input } else { $Port = $suggestedPort }
+}
+
+if ($usedPorts -contains $Port) {
+    Write-Host "WARNING: Port $Port is already used by another instance." -ForegroundColor Yellow
+    $confirm = Read-Host 'Continue anyway? [y/N]'
+    if ($confirm -ne 'y') { exit 0 }
+}
+
+# ── Create instance ─────────────────────────────────────────────────────────
+Write-Host ''
+Write-Host "Creating instance: $InstanceName" -ForegroundColor Green
+Write-Host "  Directory: $instanceDir" -ForegroundColor DarkGray
+Write-Host "  Port:      $Port" -ForegroundColor DarkGray
+
+New-Item -Path (Join-Path $instanceDir 'data') -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path $instanceDir 'metadata') -ItemType Directory -Force | Out-Null
+
+# Copy template with placeholders replaced
+$content = Get-Content $templateFile -Raw
+$content = $content -replace '__PORT__', $Port
+Set-Content -Path (Join-Path $instanceDir '.env') -Value $content -NoNewline
+
+Write-Host ''
+Write-Host 'Instance created.' -ForegroundColor Green
+Write-Host ''
+Write-Host 'Next steps:' -ForegroundColor Cyan
+Write-Host '  1. Edit the .env file - set XPP_CONFIG_NAME, EXTENSION_PREFIX, D365FO_MODEL_NAME'
+Write-Host ('  2. Rebuild:  .\rebuild-instance.ps1 ' + $InstanceName)
+Write-Host ('  3. Run:      .\run-instance.ps1 ' + $InstanceName)
+Write-Host ''
+
+# Offer to open .env for editing
+$open = Read-Host 'Open .env for editing now? [Y/n]'
+if ($open -ne 'n') {
+    $envPath = Join-Path $instanceDir '.env'
+    # Try VS Code first, fall back to notepad
+    $vscode = Get-Command code -ErrorAction SilentlyContinue
+    if ($vscode) {
+        & code $envPath
+    } else {
+        Start-Process notepad $envPath
+    }
+}

--- a/instances/.env.template
+++ b/instances/.env.template
@@ -1,0 +1,58 @@
+# =============================================================================
+# X++ MCP Server - Instance Configuration
+# =============================================================================
+# This file was created by add-instance.cmd. Edit the values below for your
+# D365FO environment, then run:  rebuild-instance.cmd <instance-name>
+#
+# Paths DB_PATH, LABELS_DB_PATH, and METADATA_PATH are pre-filled to point
+# at this instance's subfolder. You generally don't need to change them.
+# =============================================================================
+
+# Server port — each instance must use a unique port
+PORT=__PORT__
+
+# =============================================================================
+# INSTANCE-SPECIFIC PATHS (relative to this .env file's directory)
+# =============================================================================
+DB_PATH=./data/xpp-metadata.db
+LABELS_DB_PATH=./data/xpp-metadata-labels.db
+METADATA_PATH=./metadata
+
+# =============================================================================
+# D365 ENVIRONMENT
+# =============================================================================
+# Development environment type: auto, traditional, ude
+DEV_ENVIRONMENT_TYPE=ude
+
+# --- UDE (Unified Developer Experience) ---
+# XPP config name (from %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\)
+# Tip: run  npm run select-config  to list available configs
+XPP_CONFIG_NAME=
+
+# --- Traditional (only if DEV_ENVIRONMENT_TYPE=traditional) ---
+# D365FO_PACKAGE_PATH=C:\AOSService\PackagesLocalDirectory
+# CUSTOM_MODELS=MyModel1,MyModel2
+
+# =============================================================================
+# CUSTOM EXTENSIONS
+# =============================================================================
+# ISV prefix for code gen and naming validation (e.g. ASP, CTSO, WHS)
+EXTENSION_PREFIX=
+
+# Model name for code generation tools
+D365FO_MODEL_NAME=
+
+# =============================================================================
+# DATABASE BUILD OPTIONS
+# =============================================================================
+INCLUDE_LABELS=true
+LABEL_LANGUAGES=en-US
+EXTRACT_MODE=all
+
+# =============================================================================
+# SERVER OPTIONS
+# =============================================================================
+NODE_ENV=development
+LOG_LEVEL=info
+MCP_SERVER_MODE=full
+REDIS_ENABLED=false

--- a/rebuild-instance.ps1
+++ b/rebuild-instance.ps1
@@ -1,0 +1,204 @@
+<#
+.SYNOPSIS
+    Rebuild databases for one or all MCP server instances.
+.DESCRIPTION
+    Lists available instances and lets you pick which one to rebuild,
+    with an "All instances" option at the end.
+    You can also pass the instance name directly: .\rebuild-instance.ps1 alpha
+    Or rebuild everything:                        .\rebuild-instance.ps1 --all
+#>
+param(
+    [string]$InstanceName,
+    [switch]$All
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = $PSScriptRoot
+
+# ── Discover instances ──────────────────────────────────────────────────────
+$instancesDir = Join-Path $repoRoot 'instances'
+$instances = @(Get-ChildItem -Path $instancesDir -Directory -ErrorAction SilentlyContinue |
+    Where-Object { Test-Path (Join-Path $_.FullName '.env') } |
+    Sort-Object Name)
+
+if ($instances.Count -eq 0) {
+    Write-Host 'No instances found. Run .\add-instance.ps1 to create one.' -ForegroundColor Yellow
+    exit 1
+}
+
+# ── Helper: read PORT from an .env file ─────────────────────────────────────
+function Get-EnvPort([string]$envFile) {
+    $line = Select-String -Path $envFile -Pattern '^\s*PORT\s*=' -List | Select-Object -First 1
+    if ($line) { return ($line.Line -replace '^\s*PORT\s*=\s*', '').Trim() }
+    return '?'
+}
+
+# ── Helper: extract variable names from a .env file ─────────────────────────
+function Get-EnvVarNames([string]$envFile) {
+    $names = @()
+    foreach ($line in (Get-Content $envFile)) {
+        # Match uncommented KEY=value lines (skip comments and blank lines)
+        if ($line -match '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=') {
+            $names += $Matches[1]
+        }
+    }
+    return $names
+}
+
+# ── Helper: check instance .env for missing settings from .env.example ──────
+# Returns $true if missing settings were found.
+function Show-MissingSettings([System.IO.DirectoryInfo]$inst) {
+    $exampleFile = Join-Path $repoRoot '.env.example'
+    if (-not (Test-Path $exampleFile)) { return $false }
+
+    $envFile = Join-Path $inst.FullName '.env'
+    $exampleVars = Get-EnvVarNames $exampleFile
+    $instanceVars = Get-EnvVarNames $envFile
+
+    $missing = @($exampleVars | Where-Object { $_ -notin $instanceVars })
+    if ($missing.Count -eq 0) { return $false }
+
+    Write-Host ''
+    Write-Host "  New settings in .env.example not in $($inst.Name)/.env:" -ForegroundColor Yellow
+    foreach ($var in $missing) {
+        # Show the line from .env.example for context
+        $line = Select-String -Path $exampleFile -Pattern "^\s*$var\s*=" -List | Select-Object -First 1
+        $val = if ($line) { ($line.Line -replace "^\s*$var\s*=\s*", '').Trim() } else { '' }
+        Write-Host "    $var=$val" -ForegroundColor DarkYellow
+    }
+    return $true
+}
+
+# ── Helper: rebuild a single instance ───────────────────────────────────────
+function Rebuild-SingleInstance([System.IO.DirectoryInfo]$inst) {
+    $envFile = Join-Path $inst.FullName '.env'
+    $env:ENV_FILE = $envFile
+
+    Write-Host ''
+    Write-Host ('=' * 60) -ForegroundColor DarkGray
+    Write-Host "Rebuilding: $($inst.Name)" -ForegroundColor Green
+    Write-Host "Config: $envFile" -ForegroundColor DarkGray
+    Write-Host ('=' * 60) -ForegroundColor DarkGray
+
+    Write-Host ''
+    Write-Host '[1/2] Extracting metadata...' -ForegroundColor Cyan
+    & npx tsx (Join-Path $repoRoot 'scripts\extract-metadata.ts')
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Metadata extraction failed for $($inst.Name)" -ForegroundColor Red
+        return $false
+    }
+
+    Write-Host ''
+    Write-Host '[2/2] Building database...' -ForegroundColor Cyan
+    & node --max-old-space-size=6144 --import tsx/esm (Join-Path $repoRoot 'scripts\build-database.ts')
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Database build failed for $($inst.Name)" -ForegroundColor Red
+        return $false
+    }
+
+    Write-Host ''
+    Write-Host "Done: $($inst.Name)" -ForegroundColor Green
+    return $true
+}
+
+# ── Select instance(s) ─────────────────────────────────────────────────────
+$toRebuild = @()
+
+if ($All) {
+    $toRebuild = $instances
+} elseif ($InstanceName) {
+    $selected = $instances | Where-Object { $_.Name -eq $InstanceName }
+    if (-not $selected) {
+        Write-Host "Instance '$InstanceName' not found." -ForegroundColor Red
+        exit 1
+    }
+    $toRebuild = @($selected)
+} else {
+    Write-Host ''
+    Write-Host 'Available instances:' -ForegroundColor Cyan
+    Write-Host ''
+    for ($i = 0; $i -lt $instances.Count; $i++) {
+        $port = Get-EnvPort (Join-Path $instances[$i].FullName '.env')
+        Write-Host "  $($i + 1). $($instances[$i].Name)  " -NoNewline -ForegroundColor White
+        Write-Host "(port $port)" -ForegroundColor DarkGray
+    }
+    $allIndex = $instances.Count + 1
+    Write-Host ''
+    Write-Host "  $allIndex. All instances" -ForegroundColor Yellow
+    Write-Host ''
+    $choice = Read-Host 'Select instance [number]'
+    $index = [int]$choice - 1
+
+    if ($index -eq ($allIndex - 1)) {
+        $toRebuild = $instances
+    } elseif ($index -lt 0 -or $index -ge $instances.Count) {
+        Write-Host 'Invalid selection.' -ForegroundColor Red
+        exit 1
+    } else {
+        $toRebuild = @($instances[$index])
+    }
+}
+
+# ── Optionally update code first ────────────────────────────────────────────
+Write-Host ''
+$pullAnswer = Read-Host 'Pull latest code from Git? [Y/n]'
+if ($pullAnswer -ne 'n') {
+    Write-Host ''
+    Write-Host '[Git] Pulling latest...' -ForegroundColor DarkGray
+    & git pull
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host 'ERROR: git pull failed' -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host '[npm] Installing dependencies...' -ForegroundColor DarkGray
+    & npm install
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host 'ERROR: npm install failed' -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host '[tsc] Building TypeScript...' -ForegroundColor DarkGray
+    & npm run build
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host 'ERROR: TypeScript build failed' -ForegroundColor Red
+        exit 1
+    }
+} else {
+    Write-Host 'Skipping code update.' -ForegroundColor DarkGray
+}
+
+# ── Check for new settings ──────────────────────────────────────────────────
+$hasNewSettings = $false
+foreach ($inst in $toRebuild) {
+    if (Show-MissingSettings $inst) { $hasNewSettings = $true }
+}
+if ($hasNewSettings) {
+    Write-Host 'Update your .env files with the new settings before continuing.' -ForegroundColor Yellow
+    Write-Host 'The rebuild will wait until you are done.' -ForegroundColor Yellow
+    Write-Host ''
+    $answer = Read-Host 'Continue with rebuild? [y/N]'
+    if ($answer -ne 'y') {
+        Write-Host 'Aborted.' -ForegroundColor DarkGray
+        exit 0
+    }
+}
+
+# ── Rebuild ─────────────────────────────────────────────────────────────────
+$failed = @()
+foreach ($inst in $toRebuild) {
+    $ok = Rebuild-SingleInstance $inst
+    if (-not $ok) { $failed += $inst.Name }
+}
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+if ($toRebuild.Count -gt 1) {
+    Write-Host ''
+    Write-Host ('=' * 60) -ForegroundColor DarkGray
+    if ($failed.Count -eq 0) {
+        Write-Host "All $($toRebuild.Count) instances rebuilt successfully." -ForegroundColor Green
+    } else {
+        Write-Host "Completed with errors. Failed: $($failed -join ', ')" -ForegroundColor Red
+    }
+    Write-Host ('=' * 60) -ForegroundColor DarkGray
+}

--- a/run-instance.ps1
+++ b/run-instance.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+    Start an MCP server instance.
+.DESCRIPTION
+    Lists available instances and lets you pick which one to run.
+    You can also pass the instance name directly: .\run-instance.ps1 alpha
+#>
+param(
+    [string]$InstanceName
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = $PSScriptRoot
+
+# ── Discover instances ──────────────────────────────────────────────────────
+$instancesDir = Join-Path $repoRoot 'instances'
+$instances = @(Get-ChildItem -Path $instancesDir -Directory -ErrorAction SilentlyContinue |
+    Where-Object { Test-Path (Join-Path $_.FullName '.env') } |
+    Sort-Object Name)
+
+if ($instances.Count -eq 0) {
+    Write-Host 'No instances found. Run .\add-instance.ps1 to create one.' -ForegroundColor Yellow
+    exit 1
+}
+
+# ── Helper: read PORT from an .env file ─────────────────────────────────────
+function Get-EnvPort([string]$envFile) {
+    $line = Select-String -Path $envFile -Pattern '^\s*PORT\s*=' -List | Select-Object -First 1
+    if ($line) { return ($line.Line -replace '^\s*PORT\s*=\s*', '').Trim() }
+    return '?'
+}
+
+# ── Select instance ─────────────────────────────────────────────────────────
+if ($InstanceName) {
+    $selected = $instances | Where-Object { $_.Name -eq $InstanceName }
+    if (-not $selected) {
+        Write-Host "Instance '$InstanceName' not found." -ForegroundColor Red
+        exit 1
+    }
+} else {
+    Write-Host ''
+    Write-Host 'Available instances:' -ForegroundColor Cyan
+    Write-Host ''
+    for ($i = 0; $i -lt $instances.Count; $i++) {
+        $port = Get-EnvPort (Join-Path $instances[$i].FullName '.env')
+        Write-Host "  $($i + 1). $($instances[$i].Name)  " -NoNewline -ForegroundColor White
+        Write-Host "(port $port)" -ForegroundColor DarkGray
+    }
+    Write-Host ''
+    $choice = Read-Host 'Select instance [number]'
+    $index = [int]$choice - 1
+    if ($index -lt 0 -or $index -ge $instances.Count) {
+        Write-Host 'Invalid selection.' -ForegroundColor Red
+        exit 1
+    }
+    $selected = $instances[$index]
+}
+
+# ── Run ─────────────────────────────────────────────────────────────────────
+$envFile = Join-Path $selected.FullName '.env'
+$env:ENV_FILE = $envFile
+
+Write-Host ''
+Write-Host "Starting instance: $($selected.Name)" -ForegroundColor Green
+Write-Host "Config: $envFile" -ForegroundColor DarkGray
+Write-Host ''
+
+node (Join-Path $repoRoot 'dist\index.js')

--- a/scripts/azure-blob-manager.ts
+++ b/scripts/azure-blob-manager.ts
@@ -5,7 +5,8 @@
 
 console.log('📦 Loading azure-blob-manager.ts...');
 
-import 'dotenv/config';
+import { loadEnv } from '../src/utils/loadEnv.js';
+loadEnv(import.meta.url);
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { BlobServiceClient, ContainerClient } from '@azure/storage-blob';

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -3,7 +3,8 @@
  * Builds SQLite database from extracted metadata
  */
 
-import dotenv from 'dotenv';
+import { loadEnv } from '../src/utils/loadEnv.js';
+loadEnv(import.meta.url);
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';
@@ -12,10 +13,6 @@ import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// Support ENV_FILE override for multi-instance setups
-// set ENV_FILE=.env.alpha && npm run build-database
-dotenv.config({ path: process.env.ENV_FILE ? path.resolve(process.env.ENV_FILE) : undefined });
 
 import { isCustomModel, isStandardModel, getCustomModels } from '../src/utils/modelClassifier.js';
 import { indexAllLabels } from '../src/metadata/labelParser.js';

--- a/scripts/build-fts.ts
+++ b/scripts/build-fts.ts
@@ -22,7 +22,8 @@
  *           Upload final xpp-metadata.db to Blob Storage
  */
 
-import dotenv from 'dotenv';
+import { loadEnv } from '../src/utils/loadEnv.js';
+loadEnv(import.meta.url);
 import * as fsSync from 'fs';
 import { XppSymbolIndex } from '../src/metadata/symbolIndex.js';
 import { indexAllLabels } from '../src/metadata/labelParser.js';
@@ -32,10 +33,6 @@ import * as path from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// Support ENV_FILE override for multi-instance setups
-// set ENV_FILE=.env.alpha && npm run build-fts
-dotenv.config({ path: process.env.ENV_FILE ? path.resolve(process.env.ENV_FILE) : undefined });
 
 const OUTPUT_DB     = process.env.DB_PATH       || './data/xpp-metadata.db';
 const OUTPUT_LABELS_DB = process.env.LABELS_DB_PATH || './data/xpp-metadata-labels.db';

--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -3,7 +3,8 @@
  * Extracts X++ metadata from D365 F&O PackagesLocalDirectory
  */
 
-import dotenv from 'dotenv';
+import { loadEnv } from '../src/utils/loadEnv.js';
+loadEnv(import.meta.url);
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';
@@ -14,10 +15,6 @@ import { XppConfigProvider } from '../src/utils/xppConfigProvider.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// Support ENV_FILE override for multi-instance setups
-// set ENV_FILE=.env.alpha && npm run extract-metadata
-dotenv.config({ path: process.env.ENV_FILE ? path.resolve(process.env.ENV_FILE) : undefined });
 
 const PACKAGES_PATH = process.env.PACKAGES_PATH || 'C:\\AOSService\\PackagesLocalDirectory';
 const OUTPUT_PATH = process.env.METADATA_PATH || './extracted-metadata';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,31 +3,12 @@
  * Main entry point
  */
 
-// Load .env from the directory that contains this source file (src/ or dist/).
-// Using an explicit path makes dotenv work regardless of the process working
-// directory — critical when the server is started from K:\ or any other location.
-//
-// ENV_FILE support: set the ENV_FILE environment variable to point to an
-// instance-specific .env file, enabling multiple server instances to share a
-// single source/dist folder while each using its own configuration.
-//   set ENV_FILE=.env.alpha && node dist/index.js   ← instance 1
-//   set ENV_FILE=.env.beta  && node dist/index.js   ← instance 2
-import dotenv from 'dotenv';
+// Load .env — supports ENV_FILE env var for multi-instance setups.
+// See src/utils/loadEnv.ts for details.
+import { loadEnv } from './utils/loadEnv.js';
+loadEnv(import.meta.url);
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
-{
-  const __d = dirname(fileURLToPath(import.meta.url));
-  // src/index.ts  → ../  = repo root   ✓
-  // dist/index.js → ../  = repo root   ✓
-  const envPath = process.env.ENV_FILE
-    ? resolve(process.env.ENV_FILE)
-    : resolve(__d, '../.env');
-  const result = dotenv.config({ path: envPath });
-  if (result.error && !process.env.ENV_FILE) {
-    // Fallback: let dotenv try process.cwd() the normal way
-    dotenv.config();
-  }
-}
 import express from 'express';
 import compression from 'compression';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';

--- a/src/utils/loadEnv.ts
+++ b/src/utils/loadEnv.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared dotenv loader with ENV_FILE support.
+ *
+ * Allows running multiple server instances (or build scripts) from a single
+ * source folder by pointing each instance at its own .env file:
+ *
+ *   ENV_FILE=.env.alpha node dist/index.js
+ *   ENV_FILE=.env.beta  npm run build-database
+ *
+ * When ENV_FILE is not set, falls back to the repo-root .env file.
+ *
+ * Relative paths in DB_PATH, LABELS_DB_PATH, and METADATA_PATH are resolved
+ * relative to the .env file's directory, so instance .env files can use
+ * portable paths like ./data/xpp-metadata.db that survive folder renames.
+ */
+
+import dotenv from 'dotenv';
+import { dirname, isAbsolute, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+/** Env vars whose relative paths should resolve from the .env file directory. */
+const PATH_VARS = ['DB_PATH', 'LABELS_DB_PATH', 'METADATA_PATH'] as const;
+
+/**
+ * Load environment variables from a .env file.
+ *
+ * @param callerImportMetaUrl - pass `import.meta.url` from the calling module
+ *   so the default .env path resolves relative to the repo root regardless of
+ *   the process working directory.
+ */
+export function loadEnv(callerImportMetaUrl: string): void {
+  const callerDir = dirname(fileURLToPath(callerImportMetaUrl));
+
+  const envPath = process.env.ENV_FILE
+    ? resolve(process.env.ENV_FILE)
+    : resolve(callerDir, '../.env');
+
+  const result = dotenv.config({ path: envPath });
+  if (result.error) {
+    // Fallback: let dotenv try process.cwd() the normal way
+    dotenv.config();
+  }
+
+  // Resolve relative paths in key variables relative to the .env file's
+  // directory, not process.cwd(). This makes instance .env files portable.
+  const envDir = dirname(envPath);
+  for (const key of PATH_VARS) {
+    const val = process.env[key];
+    if (val && !isAbsolute(val)) {
+      process.env[key] = resolve(envDir, val);
+    }
+  }
+}

--- a/src/utils/metadataResolver.ts
+++ b/src/utils/metadataResolver.ts
@@ -17,14 +17,17 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { getConfigManager, fallbackPackagePath } from './configManager.js';
 
-// Resolve path relative to this file, not to process.cwd()
+// Resolve path relative to this file, not to process.cwd().
+// METADATA_PATH env var allows multi-instance setups to point at different folders.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // METADATA_PATH env var allows each server instance to point to its own extracted-metadata
 // folder when running multiple instances from a single source directory.
 const EXTRACTED_METADATA_BASE = process.env.METADATA_PATH
   ? path.resolve(process.env.METADATA_PATH)
   : path.resolve(__dirname, '../../extracted-metadata');
-const METADATA_BASE = path.resolve(__dirname, '../../metadata');
+const METADATA_BASE = process.env.METADATA_PATH
+  ? path.resolve(process.env.METADATA_PATH)
+  : path.resolve(__dirname, '../../metadata');
 
 export type ExtractedObjectType = 'classes' | 'enums' | 'edts' | 'tables' | 'views';
 


### PR DESCRIPTION
Centralize dotenv loading in src/utils/loadEnv.ts with ENV_FILE support and relative path resolution. Add PowerShell scripts for interactive instance management (add/run/rebuild). Make metadataResolver.ts respect METADATA_PATH env var for runtime metadata lookups.