### PR TITLE
docs: documentation audit and corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,15 @@ Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.m
 | File | Contents |
 |------|---------|
 | [docs/QUICK_START.md](docs/QUICK_START.md) | **Start here** — 5 steps to get running, all `.mcp.json` parameters, logging |
-| [docs/SETUP.md](docs/SETUP.md) | Detailed installation, configuration, all deployment scenarios |
-| [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md) | `.mcp.json` reference — workspace paths, UDE, project settings |
+| [docs/SETUP.md](docs/SETUP.md) | Detailed installation, configuration, all deployment scenarios A–F |
+| [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md) | `.mcp.json` reference — workspace paths, UDE, project settings, all env vars |
 | [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 54 tools with parameters and example prompts |
 | [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md) | Practical examples: search, CoC, SysOperation, security |
+| [docs/CUSTOM_EXTENSIONS.md](docs/CUSTOM_EXTENSIONS.md) | ISV / custom model configuration and multi-model extraction |
+| [docs/WORKSPACE_DETECTION.md](docs/WORKSPACE_DETECTION.md) | How the server auto-detects your D365FO project, model, and package path |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Technical architecture, dual-database design, cache invalidation |
 | [docs/BRIDGE.md](docs/BRIDGE.md) | C# Metadata Bridge reference — mandatory on Windows VMs for all write operations |
-| [docs/CUSTOM_EXTENSIONS.md](docs/CUSTOM_EXTENSIONS.md) | ISV / custom model configuration |
-| [docs/PIPELINES.md](docs/PIPELINES.md) | Automated metadata extraction via Azure DevOps |
+| [docs/SETUP_AZURE.md](docs/SETUP_AZURE.md) | Deploy the server to Azure App Service (admin/DevOps guide) |
+| [docs/PIPELINES.md](docs/PIPELINES.md) | Automated metadata extraction and deployment via Azure DevOps |
+| [docs/TESTING.md](docs/TESTING.md) | Running tests, test structure, mock guidelines, coverage |
+| [docs/SQLITE_DEPENDENCY.md](docs/SQLITE_DEPENDENCY.md) | SQLite vs C# Bridge — which tools use which data source |

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -1,10 +1,19 @@
 # Custom X++ Extensions Guide
 
-This guide explains how to extract and index custom X++ extensions/ISV models.
+This guide explains how to configure, extract, and index your custom X++ models and ISV packages alongside the standard Microsoft D365FO models.
+
+## What this covers
+
+- How to tell the server which models are "yours" (vs. standard Microsoft models)
+- How to extract only custom models (fast, a few minutes) vs. everything (slow, 1–2 h)
+- How the `search_extensions` tool filters to your code only
+- Multi-instance setups where each client has its own custom models
+
+---
 
 ## Configuration
 
-### Traditional
+### Traditional (PackagesLocalDirectory)
 
 Add to your `.env` file:
 
@@ -12,65 +21,103 @@ Add to your `.env` file:
 # Standard D365 packages path
 PACKAGES_PATH=C:\AOSService\PackagesLocalDirectory
 
-# Custom models to extract (comma-separated)
+# Your custom models (comma-separated package/model names)
 CUSTOM_MODELS=ISV_CustomModule1,ISV_CustomModule2,CompanyExtensions
 
-# Optional: Extension prefix for filtering
+# ISV prefix — used by search_extensions for prefix filtering and by code-gen tools
+# for naming validation (e.g. class names must start with this prefix)
 EXTENSION_PREFIX=ISV_
 
-# Extraction mode: 'all' (standard + custom), 'standard', or 'custom'
-EXTRACT_MODE=all
+# Extraction mode: 'custom' (your models only), 'standard', or 'all'
+EXTRACT_MODE=custom
 ```
 
-**Note**: Custom models are defined in `CUSTOM_MODELS` environment variable. All other models are automatically considered Microsoft standard models. This approach automatically adapts to new D365 versions without maintaining a static list.
+**How custom model detection works:** Everything listed in `CUSTOM_MODELS` is treated as your code. All other models are automatically classified as Microsoft standard. The server never requires you to maintain a static list of Microsoft model names — the list auto-adapts to new D365FO versions.
 
-### UDE (Unified Developer Experience)
+### UDE (Unified Developer Experience / Power Platform Tools)
 
-In UDE environments, custom models are **auto-detected** from the custom packages path (`ModelStoreFolder` in your XPP config). You do not need to set `CUSTOM_MODELS` — everything under the custom root is treated as custom, everything under the Microsoft root is standard.
+In UDE environments, custom models are **auto-detected** from the custom packages path (`ModelStoreFolder` in your XPP config file). You do not need to set `CUSTOM_MODELS`:
 
-## Extract Custom Extensions Only
+```env
+DEV_ENVIRONMENT_TYPE=ude
+XPP_CONFIG_NAME=MyConfig    # name from %LOCALAPPDATA%\Microsoft\Dynamics365\XppConfig\
+EXTENSION_PREFIX=ISV_
+```
 
-To extract only your custom extension models:
+Every model under `ModelStoreFolder` is automatically treated as custom; everything under `FrameworkDirectory` is Microsoft standard. Run `npm run select-config` to list available XPP configs.
 
-```bash
-# Set environment variables
+---
+
+## Extraction
+
+### Custom models only (recommended for day-to-day updates)
+
+```powershell
 $env:EXTRACT_MODE="custom"
-$env:CUSTOM_MODELS="ISV_Module1,ISV_Module2"
-$env:EXTENSION_PREFIX="ISV_"
-
-# Run extraction
 npm run extract-metadata
-
-# Build database
 npm run build-database
 ```
 
-## Extract Everything
+Takes a few minutes. Use after every code change or sprint.
 
-To extract both standard models and custom extensions:
+### Everything (first-time setup or after D365FO upgrade)
 
-```bash
+```powershell
 $env:EXTRACT_MODE="all"
-$env:CUSTOM_MODELS="ISV_Module1,ISV_Module2"
-
 npm run extract-metadata
 npm run build-database
 ```
 
-## Search Custom Extensions
+Takes 1–2 hours (standard Microsoft models are large). Only needed when Microsoft standard model content changes.
 
-Use the `search_extensions` tool to search only within custom/ISV models:
+---
+
+## Searching Custom Extensions
+
+Use `search_extensions` to search only within your custom/ISV models:
 
 ```
 search_extensions(query="Cust", prefix="ISV_")
 ```
 
-Results are filtered to non-Microsoft models and grouped by model name.
+Results are restricted to non-Microsoft models and grouped by model name. The `prefix` parameter further narrows results to objects whose names start with the given ISV prefix.
+
+You can also use the main `search` tool and filter by model:
+
+```
+search(query="CustTable extension", objectType="table-extension")
+```
+
+---
+
+## Multi-Model Packages
+
+A single D365FO package can contain multiple models (e.g. package `CompanyExtensions` may have models `CompanyCore` and `CompanyReporting`). List all model names — not just the package name — in `CUSTOM_MODELS`:
+
+```env
+CUSTOM_MODELS=CompanyCore,CompanyReporting
+```
+
+The server uses the two-level workspace path (`PackagesLocalDirectory\PackageName\ModelName`) to resolve files to the correct subfolder.
+
+---
+
+## Multiple Clients / Instances
+
+If you work on several D365FO environments (different clients, different ISV prefixes), use the multi-instance scripts in `instances/`:
+
+```powershell
+.\instances\add-instance.ps1    # creates instances\clientA\ with its own .env
+```
+
+Each instance has its own `CUSTOM_MODELS`, `EXTENSION_PREFIX`, and database. See [Scenario F in SETUP.md](SETUP.md#scenario-f-multiple-instances--one-machine-multiple-d365fo-environments).
+
+---
 
 ## Benefits
 
-1. **Separate Indexing**: Index custom extensions separately from standard models
-2. **Faster Search**: Search only in your custom code
-3. **Model Grouping**: Results grouped by custom model
-4. **Prefix Filtering**: Filter by ISV/partner prefix
-5. **Version Control**: Track only your custom models in source control
+1. **Fast incremental updates** — rebuild only custom models after a sprint, not the entire 350-model Microsoft index
+2. **Focused search** — `search_extensions` returns only your code, not noise from standard models
+3. **Correct naming validation** — `EXTENSION_PREFIX` prevents code-gen tools from generating objects without the required ISV prefix
+4. **Automatic classification** — no static Microsoft model list to maintain across D365FO version upgrades
+5. **Multi-instance isolation** — each client environment has its own index, no cross-contamination

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -974,6 +974,8 @@ Create a SalesReport copying fields from SalesInvoice report
 
 ---
 
+### verify_d365fo_project
+
 Verifies that D365FO objects exist on disk at the correct AOT path and are referenced in the Visual Studio project file. Use this instead of PowerShell after `create_d365fo_file` to confirm that files were created and registered correctly.
 
 **Parameters:**

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -132,15 +132,9 @@ Start the server: `cd K:\d365fo-mcp-server && npm run dev`
 
 ---
 
-#### Scenario E: Multiple instances (one machine, multiple clients)
+#### Scenario D: Local stdio — zero-config (single developer)
 
-Running several D365FO environments from a single installation?
-Use the `instances\add-instance.ps1` / `instances\rebuild-instance.ps1` / `instances\run-instance.ps1` scripts — each
-instance gets its own `.env`, own database, and own port. Point a per-solution `.mcp.json`
-at the correct port for seamless per-project Copilot context.
-See [Scenario F in SETUP.md](SETUP.md#scenario-f-multiple-instances--one-machine-multiple-d365fo-environments) for the full walkthrough.
-
-No HTTP server — Copilot spawns the process directly via stdin/stdout.
+No HTTP server — Copilot spawns the process directly. Requires a pre-built database.
 
 ```json
 {
@@ -149,7 +143,8 @@ No HTTP server — Copilot spawns the process directly via stdin/stdout.
       "command": "node",
       "args": ["K:\\d365fo-mcp-server\\dist\\index.js"],
       "env": {
-        "MCP_SERVER_MODE": "full",
+        "DB_PATH": "K:\\d365fo-mcp-server\\data\\xpp-metadata.db",
+        "LABELS_DB_PATH": "K:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db",
         "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects",
         "D365FO_WORKSPACE_PATH": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"
       }
@@ -157,6 +152,18 @@ No HTTP server — Copilot spawns the process directly via stdin/stdout.
   }
 }
 ```
+
+> **UDE?** Replace `D365FO_WORKSPACE_PATH` with `D365FO_MODEL_NAME` + `D365FO_DEV_ENVIRONMENT_TYPE=ude`. See [Scenario D in SETUP.md](SETUP.md#scenario-d-ude-unified-developer-experience).
+
+---
+
+#### Scenario F: Multiple instances (one machine, multiple clients)
+
+Running several D365FO environments from a single installation?
+Use the `instances\add-instance.ps1` / `instances\rebuild-instance.ps1` / `instances\run-instance.ps1` scripts — each
+instance gets its own `.env`, own database, and own port. Point a per-solution `.mcp.json`
+at the correct port for seamless per-project Copilot context.
+See [Scenario F in SETUP.md](SETUP.md#scenario-f-multiple-instances--one-machine-multiple-d365fo-environments) for the full walkthrough.
 
 ---
 

--- a/docs/SETUP_AZURE.md
+++ b/docs/SETUP_AZURE.md
@@ -189,13 +189,14 @@ Confirm the tool count matches `read-only` mode (all tools except `create_d365fo
 
 ## Azure DevOps Pipelines
 
-Three ready-to-use pipelines are in `.azure-pipelines/`:
+Four ready-to-use pipelines are in `.azure-pipelines/`:
 
 | Pipeline | When to use | Duration |
 |----------|-------------|----------|
-| `d365fo-mcp-data-build-custom.yml` | After any change to your custom models | ~5–15 min |
-| `d365fo-mcp-data-build-standard.yml` | After a D365FO version upgrade or hotfix | ~30–45 min |
-| `d365fo-mcp-data-platform-upgrade.yml` | Full rebuild: standard + custom + database | ~1.5–2 h |
+| `d365fo-mcp-app-deploy.yml` | After any change to server code (auto-triggers on push to `main`) | ~5 min |
+| `d365fo-mcp-data-extract-and-build-custom.yml` | After any change to your custom models | ~15–30 min |
+| `d365fo-mcp-data-extract-and-build-platform.yml` | After a D365FO version upgrade or hotfix | ~60–120 min |
+| `d365fo-mcp-data-platform-upgrade.yml` | Full rebuild: standard + custom + labels | ~90–120 min |
 
 ### Required Variable Group
 
@@ -211,7 +212,7 @@ Create a variable group named **`xpp-mcp-server-config`** in Azure DevOps Librar
 
 ### Uploading Standard Packages
 
-The `d365fo-mcp-data-build-standard.yml` pipeline needs the raw `PackagesLocalDirectory` from your D365FO VM as a zip in the `packages` container.
+The `d365fo-mcp-data-extract-and-build-platform.yml` pipeline needs the raw `PackagesLocalDirectory` from your D365FO VM as a zip in the `packages` container.
 
 On your D365FO VM, compress `K:\AosService\PackagesLocalDirectory` and upload the resulting zip as `PackagesLocalDirectory.zip` to the `packages` container using **Azure Storage Explorer**.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,6 +5,9 @@ This project uses [Vitest](https://vitest.dev/) as the testing framework.
 ## Running Tests
 
 ```bash
+# Run all tests once
+npm test -- --run
+
 # Run all tests in watch mode
 npm test
 
@@ -13,7 +16,12 @@ npm test -- --coverage
 
 # Run a specific test file
 npm test tests/tools/discovery.test.ts
+
+# Run integration tests (requires built dist/)
+npm run test:integration
 ```
+
+> **Integration tests** (`vitest.integration.config.ts`) exercise tool handler routing end-to-end with a real in-memory SQLite DB. Run them after `npm run build` to catch wiring issues not covered by unit tests.
 
 ## Test Structure
 


### PR DESCRIPTION
- README: add 4 missing docs to documentation table (WORKSPACE_DETECTION, TESTING, SETUP_AZURE, SQLITE_DEPENDENCY)
- QUICK_START: add missing Scenario D (local stdio / UDE), rename multi-instance from Scenario E to F (matches SETUP.md), add D365FO_SOLUTIONS_PATH and DB_PATH to Scenario D .mcp.json example
- SETUP_AZURE: fix Azure DevOps pipeline names and count (3->4), correct durations to match PIPELINES.md
- MCP_TOOLS: add missing ### verify_d365fo_project heading
- TESTING: document test:integration script and vitest.integration.config.ts
- CUSTOM_EXTENSIONS: rewrite with multi-model packages, UDE auto-detection, multi-instance guidance, and EXTENSION_PREFIX explanation