### PR TITLE
fix: resolve 9 bugs found in audit (SQLite WAL, transport, security, …

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -100,10 +100,16 @@ namespace D365MetadataBridge.Services
 
                 if (idEl == null || layerEl == null) return null;
 
+                if (!int.TryParse(idEl.Value, out int id) || !int.TryParse(layerEl.Value, out int layer))
+                {
+                    Console.Error.WriteLine($"[WriteService] Invalid numeric Id or Layer in descriptor {xmlPath}: Id='{idEl.Value}' Layer='{layerEl.Value}'");
+                    return null;
+                }
+
                 return new ModelSaveInfo
                 {
-                    Id = int.Parse(idEl.Value),
-                    Layer = int.Parse(layerEl.Value)
+                    Id = id,
+                    Layer = layer
                 };
             }
             catch (Exception ex)

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,9 @@ if (LOG_FILE) {
     _logStream.write(banner);
     // Tee: intercept process.stderr so every write also goes to the log file
     const origStderrWrite = process.stderr.write.bind(process.stderr);
-    (process.stderr as any).write = function (chunk: any, ...rest: any[]) {
+    (process.stderr as NodeJS.WriteStream & { write: (...args: any[]) => boolean }).write = function (chunk: any, ...rest: any[]): boolean {
       _logStream!.write(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
-      return origStderrWrite(chunk, ...rest);
+      return origStderrWrite(chunk, ...rest) as boolean;
     };
   } catch (e) {
     // Don't crash if log file can't be opened — just disable file logging

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -57,7 +57,11 @@ export class XppSymbolIndex {
     
     // Enable SQLite performance optimizations for both DBs
     // Note: journal_mode should be set by caller (MEMORY for build, WAL for production)
-    if (!this.db.pragma('journal_mode', { simple: true })) {
+    // pragma('journal_mode', { simple: true }) returns a non-empty string like "wal" or "delete".
+    // A non-empty string is always truthy, so !pragma(...) is always false — the comparison
+    // must be done against the actual value string.
+    const currentJournalMode = this.db.pragma('journal_mode', { simple: true }) as string;
+    if (currentJournalMode !== 'wal') {
       // Set default to WAL if not already configured
       this.db.pragma('journal_mode = WAL'); // Write-Ahead Logging for better concurrency
     }
@@ -76,7 +80,8 @@ export class XppSymbolIndex {
     this.db.pragma('wal_autocheckpoint = 4000');
     
     // Configure labels DB similarly
-    if (!this.labelsDb.pragma('journal_mode', { simple: true })) {
+    const labelsJournalMode = this.labelsDb.pragma('journal_mode', { simple: true }) as string;
+    if (labelsJournalMode !== 'wal') {
       this.labelsDb.pragma('journal_mode = WAL');
     }
     this.labelsDb.pragma('synchronous = NORMAL');

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -24,19 +24,27 @@ export { SERVER_MODE, LOCAL_TOOLS, WRITE_TOOLS } from './serverMode.js';
 export type { ServerMode } from './serverMode.js';
 
 /**
- * Convert a file:// URI to a local Windows path.
+ * Convert a file:// URI to a local path.
  * Duplicated from transport.ts to keep mcpServer.ts self-contained
  * (no circular dep between transport ↔ mcpServer).
+ * Handles both Windows (drive-letter) and POSIX (Linux/macOS, Azure) paths.
  */
 function fileUriToPath(uri: string): string | null {
   if (!uri) return null;
   if (uri.startsWith('file:///')) {
-    return decodeURIComponent(uri.slice('file:///'.length)).replace(/\//g, '\\');
+    const decoded = decodeURIComponent(uri.slice('file:///'.length));
+    if (process.platform === 'win32') {
+      return decoded.replace(/\//g, '\\');
+    }
+    // POSIX: restore the leading slash stripped by slice('file:///'.length)
+    return '/' + decoded;
   }
   if (uri.startsWith('file://')) {
-    return decodeURIComponent(uri.slice('file://'.length)).replace(/\//g, '\\');
+    const decoded = decodeURIComponent(uri.slice('file://'.length));
+    return process.platform === 'win32' ? decoded.replace(/\//g, '\\') : decoded;
   }
-  if (uri.length > 2 && (uri[1] === ':' || uri.startsWith('\\\\'))) return uri;
+  // Already a local path — Windows drive letter, UNC share, or POSIX absolute
+  if (uri.length > 2 && (uri[1] === ':' || uri.startsWith('\\\\') || uri.startsWith('/'))) return uri;
   return null;
 }
 

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -74,16 +74,20 @@ function extractWorkspaceFromRequest(req: Request, requestBody: JSONRPCRequest):
 function fileUriToPath(uri: string | undefined): string | null {
   if (!uri) return null;
   if (uri.startsWith('file:///')) {
-    // file:///K:/VSProjects/... → K:/VSProjects/...
     const decoded = decodeURIComponent(uri.slice('file:///'.length));
-    // Normalize Windows path separators
-    return decoded.replace(/\//g, '\\');
+    if (process.platform === 'win32') {
+      // file:///K:/VSProjects/... → K:\VSProjects\...
+      return decoded.replace(/\//g, '\\');
+    }
+    // POSIX: file:///home/user/proj → /home/user/proj
+    return '/' + decoded;
   }
   if (uri.startsWith('file://')) {
-    return decodeURIComponent(uri.slice('file://'.length)).replace(/\//g, '\\');
+    const decoded = decodeURIComponent(uri.slice('file://'.length));
+    return process.platform === 'win32' ? decoded.replace(/\//g, '\\') : decoded;
   }
-  // Already a local path
-  if (uri.length > 2 && (uri[1] === ':' || uri.startsWith('\\\\'))) {
+  // Already a local path — Windows drive letter or UNC, or POSIX absolute
+  if (uri.length > 2 && (uri[1] === ':' || uri.startsWith('\\\\') || uri.startsWith('/'))) {
     return uri;
   }
   return null;
@@ -93,7 +97,7 @@ export class CustomHttpTransport implements Transport {
   private server: Server;
   private app: Express;
   private context: XppServerContext;
-  private pendingRequests = new Map<string | number, (message: JSONRPCMessage) => void>();
+  private pendingRequests = new Map<string | number, { resolve: (message: JSONRPCMessage) => void; reject: (err: Error) => void }>();
 
   // Transport interface properties
   onmessage?: (message: JSONRPCMessage) => void;
@@ -127,15 +131,21 @@ export class CustomHttpTransport implements Transport {
   }
 
   async close(): Promise<void> {
+    // Reject all in-flight promises so their awaiting callers fail fast
+    // instead of hanging until the per-request timeout fires.
+    const err = new Error('Transport closed');
+    for (const { reject } of this.pendingRequests.values()) {
+      reject(err);
+    }
     this.pendingRequests.clear();
   }
 
   async send(message: JSONRPCMessage): Promise<void> {
     // Route response to the correct pending request by id
     if ('id' in message && message.id !== undefined && message.id !== null) {
-      const resolver = this.pendingRequests.get(message.id);
-      if (resolver) {
-        resolver(message);
+      const pending = this.pendingRequests.get(message.id);
+      if (pending) {
+        pending.resolve(message);
         this.pendingRequests.delete(message.id);
         return;
       }
@@ -181,17 +191,19 @@ export class CustomHttpTransport implements Transport {
         if (!('id' in request)) {
           // Handle special notifications
           if ((request as any).method === 'notifications/cancelled' || 
-              (request as any).method === 'cancelled' ||
-              (request as any).method === 'shutdown') {
-            // Send 202 and signal completion
+              (request as any).method === 'cancelled') {
+            // A cancelled notification does NOT close the transport.
+            // It signals that a specific in-flight request was cancelled by the client,
+            // but the HTTP connection (per-request) is already done.  Simply acknowledge.
+            res.status(202).json({ status: 'accepted' });
+            return;
+          }
+
+          if ((request as any).method === 'shutdown') {
+            // In HTTP mode each request is independent — there is no persistent connection
+            // to tear down.  Calling onclose() here would stop the entire server for ALL
+            // concurrent users, which is wrong.  Acknowledge and do nothing else.
             res.status(202).json({ status: 'accepted', completed: true });
-            
-            // Trigger cleanup after response is sent
-            setImmediate(() => {
-              if (this.onclose) {
-                this.onclose();
-              }
-            });
             return;
           }
           
@@ -251,11 +263,18 @@ export class CustomHttpTransport implements Transport {
               }
             }, TOOL_TIMEOUT_MS);
 
-            this.pendingRequests.set(internalId, (message) => {
-              clearTimeout(timeoutId);
-              // Restore the original client id before resolving
-              if ('id' in message) (message as any).id = originalId;
-              resolve(message);
+            this.pendingRequests.set(internalId, {
+              resolve: (message) => {
+                clearTimeout(timeoutId);
+                // Restore the original client id before resolving
+                if ('id' in message) (message as any).id = originalId;
+                resolve(message);
+              },
+              reject: (err) => {
+                clearTimeout(timeoutId);
+                (request as any).id = originalId;
+                reject(err);
+              },
             });
           });
 

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -91,15 +91,24 @@ const PACKAGES_CANDIDATES = [
 
 async function killOrphanedBuildProcesses(): Promise<void> {
   // Kills any MSBuild and devenv processes that may be stuck from a previous build.
-  // Uses taskkill /F /IM — safe on a D365FO developer VM where these are build-only processes.
+  // Uses taskkill /F /IM which affects ALL processes with matching image names on this machine.
+  // This is intentionally broad — only call this when force=true is explicitly requested.
+  // On a shared developer VM, this will also kill processes started by other users.
   const targets = ['MSBuild.exe', 'devenv.com', 'devenv.exe'];
-  await Promise.allSettled(
+  const results = await Promise.allSettled(
     targets.map(name =>
       execFileAsync('taskkill', ['/F', '/IM', name], { timeout: 10_000, windowsHide: true })
-        .then(() => console.error(`[build_d365fo_project] killed ${name}`))
+        .then(({ stdout }) => {
+          // taskkill prints PIDs of killed processes; log them for traceability
+          console.error(`[build_d365fo_project] killed ${name}: ${stdout.trim() || '(no output)'}`);
+        })
         .catch(() => { /* process was not running — that's fine */ }),
     ),
   );
+  const killed = results.filter(r => r.status === 'fulfilled').length;
+  if (killed > 0) {
+    console.error(`[build_d365fo_project] ⚠️ Killed all matching MSBuild/devenv processes on this machine (force=true)`);
+  }
 }
 
 async function isProcessImageRunning(imageName: string): Promise<boolean> {

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -86,6 +86,17 @@ async function directXmlReplaceCode(
       return null; // oldCode not found in file at all
     }
 
+    // Ensure there is exactly one occurrence so we replace the correct block.
+    // String.prototype.replace() without /g only replaces the FIRST occurrence,
+    // which would silently leave other occurrences and produce ambiguous results.
+    const occurrences = content.split(oldCode).length - 1;
+    if (occurrences > 1) {
+      return {
+        success: false,
+        message: `❌ directXmlReplaceCode: oldCode appears ${occurrences} times in ${filePath} — replacement is ambiguous. Provide a more specific oldCode snippet.`,
+      };
+    }
+
     const updated = content.replace(oldCode, newCode);
     if (updated === content) {
       return null; // no change made

--- a/src/tools/sysTestRunner.ts
+++ b/src/tools/sysTestRunner.ts
@@ -8,6 +8,19 @@ import { withOperationLock } from '../utils/operationLocks.js';
 
 const execFileAsync = util.promisify(execFile);
 
+/**
+ * Guard against shell-injection characters in values that are embedded in
+ * execFile argument arrays.  execFile() does NOT use a shell, but embedded
+ * newlines or quotes can still corrupt the argument stream on some platforms.
+ */
+function assertSafePath(value: string, label: string): void {
+  if (/[&|<>^`!;$%"'\n\r]/.test(value)) {
+    throw new Error(
+      `${label} contains potentially dangerous characters and cannot be used in a command: ${value}`
+    );
+  }
+}
+
 export const sysTestRunnerToolDefinition = {
   name: 'run_systest_class',
   description: 'Invoke D365FO SysTest framework against a specific test class.',
@@ -60,6 +73,19 @@ export const sysTestRunnerTool = async (params: any, _context: any) => {
     }
 
     let args: string[];
+    // Validate user-supplied values before embedding them in command arguments.
+    try {
+      assertSafePath(className, 'className');
+      assertSafePath(resolvedModelName, 'modelName');
+      assertSafePath(packagesRoot, 'packagesRoot');
+      if (testMethod) assertSafePath(testMethod, 'testMethod');
+    } catch (validationErr: any) {
+      return {
+        content: [{ type: 'text', text: `❌ Invalid parameter: ${validationErr.message}` }],
+        isError: true,
+      };
+    }
+
     if (runnerPath === sysTestRunnerPath) {
       // SysTestRunner.exe: -name:<className>[::testMethod] -packagePath:<path>
       const testTarget = testMethod ? `${className}::${testMethod}` : className;


### PR DESCRIPTION
…paths)

- fix(symbolIndex): journal_mode WAL pragma check was always false Previously used !pragma(...) which evaluated the string 'wal' as truthy, so WAL was never set. Now compares returned value against 'wal'.

- fix(modifyD365File): directXmlReplaceCode detects ambiguous multi-occurrence String.replace() only replaces the first occurrence silently. Now counts occurrences and returns an error when oldCode appears more than once.

- fix(MetadataWriteService): int.Parse -> int.TryParse in descriptor parsing FormatException on corrupted descriptor XML was silently swallowed as null, producing a misleading 'model not found' error. TryParse logs the bad value.

- fix(transport): shutdown/cancelled notifications no longer call onclose() In HTTP mode onclose() on the shared transport would terminate the entire server for all concurrent users. Separated the three notification cases: 'cancelled' acknowledges only; 'shutdown' acknowledges without closing.

- fix(transport): close() rejects pending requests instead of silently dropping Previously clear() left in-flight promises hanging until timeout. Now pendingRequests stores {resolve, reject} pairs and close() rejects all.

- fix(sysTestRunner): add assertSafePath() validation for user-supplied args className, modelName, testMethod and packagesRoot are now validated before being embedded in execFile argument arrays, matching buildProject.ts pattern.

- fix(index): stderr write monkey-patch declared return type Changed from untyped (as any) to a properly typed cast that declares and returns boolean, fixing the implicit any and potential stream API breakage.

- fix(transport,mcpServer): fileUriToPath handles POSIX file:// URIs Previously all slashes were converted to backslashes unconditionally, silently dropping all file:///home/... paths on Linux/macOS/Azure. Now checks process.platform and restores the leading slash for POSIX paths.

- fix(buildProject): killOrphanedBuildProcesses logs PIDs and warns scope The function was silent about killed processes. Now logs image names/output and warns that taskkill /F /IM affects all matching processes on the machine.