### PR TITLE
fix: auto-convert bare extension name to dot-notation (Case C)

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -3458,6 +3458,24 @@ export async function handleCreateD365File(
       }
     }
 
+    // Case C: dot-notation extension types provided without a dot (bare base name)
+    // e.g. objectType="table-extension", objectName="PurchTable"
+    // → effectiveObjectName="PurchTable.Extension" so applyObjectPrefix SPECIAL CASE A
+    // produces the correct "PurchTable.ContosoExtension" instead of falling into NORMAL CASE
+    // and producing the wrong "ContosoPurchTable".
+    const DOT_NOTATION_EXTENSION_TYPES = new Set([
+      'table-extension', 'form-extension', 'enum-extension', 'edt-extension',
+      'data-entity-extension', 'menu-item-display-extension', 'menu-item-action-extension',
+      'menu-item-output-extension', 'menu-extension',
+    ]);
+    if (DOT_NOTATION_EXTENSION_TYPES.has(args.objectType) && !effectiveObjectName.includes('.')) {
+      effectiveObjectName = `${effectiveObjectName}.Extension`;
+      console.error(
+        `[create_d365fo_file] Bare extension name auto-converted to dot-notation: ` +
+        `${args.objectName} → ${effectiveObjectName}`
+      );
+    }
+
     let finalObjectName = applyObjectPrefix(effectiveObjectName, objectPrefix);
     const objectSuffix = getObjectSuffix();
     finalObjectName = applyObjectSuffix(finalObjectName, objectSuffix);

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -345,6 +345,29 @@ describe('create_d365fo_file', () => {
     expect((result as any).isError).toBeFalsy();
   });
 
+  it('auto-converts bare extension name to dot-notation (Case C fix)', async () => {
+    // Bug: objectType="table-extension", objectName="PurchTable" (no dot) used to
+    // fall into NORMAL CASE of applyObjectPrefix and produce "ContosoPurchTable".
+    // Fix: Case C should append ".Extension" so applyObjectPrefix handles it correctly.
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'table-extension',
+        objectName: 'PurchTable',
+        modelName: 'FmMcp',
+        packageName: 'FmMcp',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+      }),
+    );
+    // On macOS the function throws "Cannot create on non-Windows" before writing, which
+    // is caught by the outer catch and returned as content text (no isError flag).
+    // We inspect the path embedded in the message: it must use dot-notation
+    // (PurchTable.<something>Extension.xml) and NOT a flat prefix (FmMcpPurchTable.xml).
+    const text: string = result.content[0].text;
+    expect(text).toMatch(/PurchTable[.][^/\\]*[Ee]xtension/);
+    expect(text).not.toMatch(/FmMcpPurchTable|[A-Za-z]+PurchTable\.xml/);
+  });
+
   it('creates a class from custom xmlContent (hybrid scenario)', async () => {
     const xml = `<?xml version="1.0"?><AxClass><Name>MyHybridClass</Name></AxClass>`;
     const result = await handleCreateD365File(


### PR DESCRIPTION
When objectType is a dot-notation extension type (table-extension, form-extension, enum-extension, edt-extension, data-entity-extension, menu-item-*-extension, menu-extension) and objectName has no dot, applyObjectPrefix fell into NORMAL CASE and produced a wrong flat- prefixed name (e.g. ContosoPurchTable instead of PurchTable.ContosoExtension).

Fix: add Case C before applyObjectPrefix that appends '.Extension' to bare names, letting SPECIAL CASE A in applyObjectPrefix handle them correctly per MS naming guidelines.

Fixes #430