### PR TITLE
fix: loadEnv tests failing on Windows due to POSIX-only file URL

### DIFF
--- a/tests/utils/loadEnv.test.ts
+++ b/tests/utils/loadEnv.test.ts
@@ -53,7 +53,11 @@ afterEach(() => {
 
 // Simulate a caller at /repo/src/index.ts → callerDir = /repo/src
 // Default envPath resolves to /repo/src/../.env = /repo/.env
-const FAKE_CALLER_URL = 'file:///repo/src/index.ts';
+// On Windows, file URLs require a drive letter — use C:/repo to keep the
+// path.resolve('/repo/...') expectations consistent (same drive root).
+const FAKE_CALLER_URL = process.platform === 'win32'
+  ? 'file:///C:/repo/src/index.ts'
+  : 'file:///repo/src/index.ts';
 const REPO_ROOT_ENV = path.resolve('/repo/.env');
 
 // ── Env file path resolution ─────────────────────────────────────────────────


### PR DESCRIPTION
This pull request updates the test setup in `loadEnv.test.ts` to improve cross-platform compatibility, specifically for Windows environments. The main change ensures that file URLs in tests include a drive letter when running on Windows, aligning with how file paths are resolved on that platform.

Test environment compatibility:

* Updated the `FAKE_CALLER_URL` constant in `tests/utils/loadEnv.test.ts` to use a Windows-style file URL with a drive letter when the tests are run on Windows, ensuring consistent path resolution across platforms.