### PR TITLE
fix: change PACKAGE_PATH to D365FO_PACKAGE_PATH in metadata extractor

### DIFF
--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -16,7 +16,7 @@ import { XppConfigProvider } from '../src/utils/xppConfigProvider.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const PACKAGES_PATH = process.env.PACKAGES_PATH || 'C:\\AOSService\\PackagesLocalDirectory';
+const PACKAGES_PATH = process.env.D365FO_PACKAGE_PATH || 'C:\\AOSService\\PackagesLocalDirectory';
 const OUTPUT_PATH = process.env.METADATA_PATH || './extracted-metadata';
 const CUSTOM_MODELS_PATH = process.env.CUSTOM_MODELS_PATH; // Optional: separate path for custom extensions
 


### PR DESCRIPTION
Fixed not updated package path parameter in the scripts\extract-metadata.ts script.