### PR TITLE
Security audit, perf hardening, and docs refresh

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 <!-- Mirrors rules from xpp_system_instructions MCP prompt (src/prompts/systemInstructions.ts). Keep in sync. -->
 
-This workspace contains D365FO code. **Always use the specialized MCP tools** — backed by a pre-indexed symbol database with 584,799+ D365FO objects. Built-in file/search tools do not understand X++ syntax or AOT structure.
+This workspace contains D365FO code. **Always use the specialized MCP tools** — backed by a pre-indexed symbol database with hundreds of thousands of D365FO objects. Built-in file/search tools do not understand X++ syntax or AOT structure.
 
 ---
 
@@ -23,7 +23,23 @@ MCP rules apply **only to D365FO objects** (`.xml`/`.xpp`, AOT objects, labels, 
 - **`.rnrproj`** = D365FO project → managed by MCP (`addToProject=true`). NEVER edit directly.
 - **`.csproj`** = C# project → use built-in tools.
 
-## 🔌 MANDATORY FIRST CHECK
+## � HOW READS ARE RESOLVED (read-path policy)
+
+Info tools (`get_class_info`, `get_table_info`, `get_form_info`, `get_view_info`, `get_query_info`, `get_report_info`, `get_table_extension_info`, `find_coc_extensions`, `analyze_extension_points`) resolve data in this order:
+
+1. **C# bridge** — live `IMetadataProvider` from the running D365FO instance. Authoritative when available.
+2. **SQLite symbol index** — pre-built mirror. Used when the bridge is offline (Azure, write-only mode, build agents).
+3. **Filesystem parse** — last resort for objects created in the current session and not yet indexed. Scanner has a 3 s budget, 30 s result cache, and can be disabled in production with `D365FO_DISABLE_FS_FALLBACK=true`.
+
+You never need to pick the source manually — just call the tool. If you see `⚠️ Served from symbol index` or `⚠️ Not yet in bridge metadata`, the bridge was unavailable and the tool already fell back.
+
+## 🛡️ WRITE-PATH SAFETY
+
+All write operations (`modify_d365fo_file`, `create_d365fo_file`) only accept paths that live under a configured `PackagesLocalDirectory/<Package>/<Model>/Ax<Type>/<Name>.xml`. Arbitrary paths are rejected.
+
+---
+
+## �🔌 MANDATORY FIRST CHECK
 
 **Call `get_workspace_info()` before doing anything.**
 
@@ -145,40 +161,39 @@ VS 2022 shows only "ran tool_name" — no output. **Always** write 1 sentence be
 
 ## Non-Negotiable Rules
 
-1. **NEVER** use built-in file/edit tools on `.xml`/`.xpp` files
+1. **NEVER** use built-in file/edit tools (`create_file`, `replace_string_in_file`, `read_file`, `grep_search`…) on `.xml`/`.xpp`/`.label.txt`/`.rnrproj` files — use the matching D365FO MCP tool
 2. **NEVER** guess method signatures — call `get_method_signature` before CoC
-3. **NEVER** use `create_file` for D365FO objects — use `create_d365fo_file()`
-4. **NEVER** call `create_d365fo_file` without `projectPath` or `solutionPath`
-5. **NEVER** edit `.label.txt` directly — use `create_label()`; search first with `search_labels()`
-6. **ALWAYS** pass `fieldsHint` for tables, `primaryKeyFields` for composite PKs
-7. **ALWAYS** pass `methods=["find","exist"]` to `generate_smart_table()` when needed — don't add after
-8. **NEVER** include model prefix in `name` param of `generate_smart_*` — auto-applied
-9. **NEVER** use `get_enum_info()` for EDTs — use `get_edt_info()`
-10. **NEVER** infer target model from search results — always use model from `.mcp.json`
-11. **NEVER** create AxReport with `create_file` — use `create_d365fo_file(objectType="report")`
-12. Security types: `security-privilege` → `AxSecurityPrivilege`, `security-duty` → `AxSecurityDuty`, `security-role` → `AxSecurityRole` — NEVER mix them
-13. Class member variables go **inside** class `{ }` in `sourceCode` — outside = lost
-14. **NEVER** use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
-15. **NEVER** call functions in `WHERE` clauses — assign to variable first
-16. **NEVER** use hardcoded strings in `Info()`/`warning()`/`error()` — use `@Model:Label`
-17. **NEVER** nest `while select` loops — use `join` or pre-load to `Map`/temp table
-18. **ALWAYS** call `create_label()` before referencing new labels in code. **Exception:** when adding a field to a table/table-extension with an EDT that already has a label defined, do **NOT** set a label on the field — the field inherits the label from the EDT automatically. Only set `label` on a field when deliberately overriding the EDT's label.
-19. **ALWAYS** write meaningful `/// <summary>` on public/protected classes and methods
-20. **NEVER** call `[SysObsolete]` methods — read the attribute for the replacement
-21. **NEVER** switch project autonomously via `get_workspace_info(projectName=...)` — ask user
-22. **ALWAYS** call `get_d365fo_error_help()` for D365FO errors — don't guess fixes
-23. CoC class extension: `create_d365fo_file(objectType="class-extension", objectName="{Target}{Prefix}_Extension")`
-24. Standard data events use `[DataEventHandler]` — NOT `[SubscribesTo + delegateStr]`. `delegateStr` is for custom delegates only.
-25. SDLC tools (`run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, `run_systest_class`) auto-detect params from `.mcp.json`. If they error about missing binaries, fix `.mcp.json`.
-26. `review_workspace_changes` = git diff code review only. NOT for verifying modify/create success.
-27. `get_form_info` works for ALL forms (standard + custom). If ⚠️ warning, retry with `filePath=`.
-28. **NEVER run `build_d365fo_project()` automatically.** Builds take a long time and block the user. After completing changes, inform the user that changes are done and they can build manually when ready — e.g. *"Changes applied. Run a build when you're ready to validate."* Only run `build_d365fo_project()` when the user explicitly requests it ("build", "compile", "check errors"). If the build reports X++ errors, fix them immediately using `modify_d365fo_file` and rebuild until clean.
-29. **"Check best practices" / "BP check" → ALWAYS call `run_bp_check()`**. NEVER manually iterate `get_method_source` to review code for BP compliance — the BP checker tool is authoritative and covers all rules.
+3. **NEVER** call `create_d365fo_file` without `projectPath` or `solutionPath`
+4. **ALWAYS** search labels with `search_labels()` first; create via `create_label()`
+5. **ALWAYS** pass `fieldsHint` for tables, `primaryKeyFields` for composite PKs
+6. **ALWAYS** pass `methods=["find","exist"]` to `generate_smart_table()` when needed — don't add after
+7. **NEVER** include model prefix in `name` of `generate_smart_*` — auto-applied. Pass base name without prefix: `objectName="InventByZones"` + `modelName="ContosoExt"` → `ContosoExtInventByZones`.
+8. **NEVER** use `get_enum_info()` for EDTs — use `get_edt_info()`
+9. **NEVER** infer target model from search results — always use model from `.mcp.json`
+10. Security types: `security-privilege` → `AxSecurityPrivilege`, `security-duty` → `AxSecurityDuty`, `security-role` → `AxSecurityRole` — NEVER mix
+11. Class member variables go **inside** class `{ }` in `sourceCode` — outside = lost
+12. **NEVER** use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
+13. **NEVER** call functions in `WHERE` clauses — assign to variable first
+14. **NEVER** use hardcoded strings in `Info()`/`warning()`/`error()` — use `@Model:Label`
+15. **NEVER** nest `while select` loops — use `join` or pre-load to `Map`/temp table
+16. **ALWAYS** call `create_label()` before referencing new labels in code. **Exception:** when adding a field to a table/table-extension with an EDT that already has a label defined, do **NOT** set a label on the field — the field inherits the label from the EDT automatically. Only set `label` on a field when deliberately overriding the EDT's label.
+17. **ALWAYS** write meaningful `/// <summary>` on public/protected classes and methods
+18. **NEVER** call `[SysObsolete]` methods — read the attribute for the replacement
+19. **NEVER** switch project autonomously via `get_workspace_info(projectName=...)` — ask user
+20. **ALWAYS** call `get_d365fo_error_help()` for D365FO errors — don't guess fixes
+21. CoC class extension: `create_d365fo_file(objectType="class-extension", objectName="{Target}{Prefix}_Extension")`
+22. Standard data events use `[DataEventHandler]` — NOT `[SubscribesTo + delegateStr]`. `delegateStr` is for custom delegates only.
+23. SDLC tools (`run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, `run_systest_class`) auto-detect params from `.mcp.json`. If they error about missing binaries, fix `.mcp.json`.
+24. `review_workspace_changes` = git diff code review only. NOT for verifying modify/create success.
+25. `get_form_info` works for ALL forms (standard + custom). If ⚠️ warning, retry with `filePath=`.
+26. **NEVER run `build_d365fo_project()` automatically.** Builds block the user. After completing changes, say *"Changes applied. Run a build when you're ready to validate."* Only build on explicit request ("build", "compile", "check errors"). If the build reports X++ errors, fix them via `modify_d365fo_file` and rebuild until clean.
+27. **"Check best practices" / "BP check" → ALWAYS call `run_bp_check()`**. NEVER manually iterate `get_method_source` to review code for BP compliance — the BP checker is authoritative.
 
 ### AxClass sourceCode Format
 
+Class member variables go **inside** the class braces; methods stay at top level of the `sourceCode` string:
+
 ```xpp
-// ✅ Variables inside class {}
 public class MyClass extends MyBase
 {
     int counter;
@@ -191,10 +206,6 @@ public void myMethod() { ... }
 
 - **Azure/Linux** (response says "Azure/Linux"): tool returns XML → call `create_d365fo_file(xmlContent=..., addToProject=true)`
 - **Windows** (response says "DO NOT call create_d365fo_file"): file already written → STOP
-
-### Prefix Handling
-
-Pass base name without prefix: `objectName="InventByZones"` + `modelName="ContosoExt"` → creates `ContosoExtInventByZones`. Double-prefix auto-prevented. NEVER bypass with `create_file`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GitHub Copilot excels at C#, Python, and JavaScript — languages with rich publ
 
 The result is AI that confidently generates code that doesn't compile: wrong method signatures, missing parameters, fields that don't exist on the table, CoC chains broken because Copilot didn't know an extension already wrapped the method.
 
-This MCP server solves that by pre-indexing your entire D365FO installation — 584,799+ symbols across standard and custom models — and exposing it to Copilot as 54 specialized tools. Before generating any X++ code, Copilot can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
+This MCP server solves that by pre-indexing your entire D365FO installation — hundreds of thousands of symbols across standard and custom models — and exposing it to Copilot as 54 specialized tools. Before generating any X++ code, Copilot can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
 
 ![Solution Architecture](docs/img/solution-architecture-diagram.png)
 
@@ -40,7 +40,7 @@ This MCP server solves that by pre-indexing your entire D365FO installation — 
 ---
 
 ## Key Capabilities
-- **Massive Metadata Index:** Instantly looks up signatures, tables, enums, EDTs across standard and ISV code out of 580,000+ objects.
+- **Massive Metadata Index:** Instantly looks up signatures, tables, enums, EDTs across standard and ISV code out of hundreds of thousands of objects.
 - **Smart Object Generation:** AI-driven tools build XML structures exactly matching D365 standard patterns (SimpleList, Forms, Tables).
 - **X++ Knowledge Base:** Queryable knowledge base of D365FO patterns, best practices, and AX2012→D365FO migration guidance — prevents deprecated API usage.
 - **Code Review & Git Diff:** Reviews uncommitted workspace changes locally matching D365 Best Practice metrics directly against Copilot chat.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -515,23 +515,33 @@ sequenceDiagram
     Bridge->>Bridge: Dispose providers, close SQL
 ```
 
-### Integration Pattern — Bridge-First with Fallback
+### Integration Pattern — Bridge → DB → Disk
 
-Every read tool uses the **try-bridge-first** pattern:
+Every read tool uses a strict three-tier lookup order:
 
 ```
 Tool handler:
-  1. tryBridge*(args)        → call C# bridge via JSON-RPC (stdin/stdout)
-     ├─ Bridge available + object found → return live metadata
-     └─ Bridge unavailable or error    → continue to step 2
-  2. symbolIndex.search()    → FTS5 query on SQLite symbols database
-  3. xmlParser.parse()       → Parse raw XML from PackagesLocalDirectory
-  4. Format + cache result   → Store in Redis (optional)
+  1. Bridge (authoritative)  → C# IMetadataProvider via JSON-RPC (stdin/stdout)
+     └─ Bridge available + object found → return live metadata
+  2. SQLite symbol index     → FTS5 / structured queries on the pre-built DB
+     └─ Used when the bridge is offline (Azure, write-only mode, build agents)
+        or the object is not covered by the bridge for this call
+  3. Disk parse              → xmlParser.parseXxxFile() on the AOT XML file
+     └─ Last resort for objects created in the current session and not yet
+        indexed. The extension scanner has a ~3 s budget and 30 s result cache
+        and can be disabled entirely via D365FO_DISABLE_FS_FALLBACK=true.
+  4. Cache (optional)        → Redis is off by default; when enabled it only
+                               short-circuits the above for repeated queries.
 ```
 
-Write tools (`create_d365fo_file`, `modify_d365fo_file`) have **no fallback** — if the bridge
-is unavailable, they return an error. This is by design: only the C# `IMetadataProvider` API
-can safely create/modify D365FO objects (correct XML encoding, AOT path, `.rnrproj` registration).
+Write tools (`create_d365fo_file`, `modify_d365fo_file`) have **no bridge fallback** — if the
+bridge is unavailable they return an error. This is by design: only the C# `IMetadataProvider`
+API can safely create/modify D365FO objects (correct XML encoding, AOT path, `.rnrproj`
+registration).
+
+**Write-path safety:** every write target is validated against the configured
+`PackagesLocalDirectory` roots and the canonical `<Package>/<Model>/Ax<Type>/<Name>.xml`
+layout. Paths outside the roots or with the wrong shape are rejected before any file I/O.
 
 ### C# Components
 

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -19,11 +19,12 @@ For architecture details, see [ARCHITECTURE.md § C# Bridge Architecture](ARCHIT
 The bridge runs as a child process spawned by the Node.js server at startup. Communication
 uses newline-delimited JSON-RPC over stdin/stdout.
 
-Every tool handler follows a **bridge-first, fallback** pattern:
+Every tool handler follows a strict **Bridge → DB → Disk** priority:
 
-1. **Bridge available** → call `IMetadataProvider` via JSON-RPC → return result
-2. **Bridge unavailable** → fall back to SQLite index + XML parser (read-only tools only)
-3. **Write operations** → bridge is the **only** path — no fallback exists
+1. **Bridge available** → call `IMetadataProvider` via JSON-RPC → return result (authoritative)
+2. **Bridge offline** → fall back to the SQLite symbol index (read-only tools only)
+3. **Not in index either** → parse the AOT XML file on disk (only for tools that need it — table / table-extension / form / report info and the extension scanner, with a bounded budget)
+4. **Write operations** → bridge is the **only** path — no fallback exists
 
 ---
 

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -236,7 +236,11 @@ with VS 2022's `.mcp.json` parser.
 | `D365FO_CUSTOM_PACKAGES_PATH` | Optional | UDE: custom X++ code root. |
 | `D365FO_MICROSOFT_PACKAGES_PATH` | Optional | UDE: Microsoft X++ root. |
 | `MCP_SERVER_MODE` | No | `full` (default), `read-only`, or `write-only`. Only needed in hybrid setups. |
-| `MCP_TOOL_TIMEOUT_MS` | No | HTTP transport per-request timeout in ms (default: 120000). Increase if Azure queries time out. |
+| `MCP_TOOL_TIMEOUT_MS` | No | Default HTTP transport per-request timeout in ms (default: 120000). Acts as the catch-all ceiling for tools not in the fast/heavy class below. |
+| `MCP_TOOL_TIMEOUT_FAST_MS` | No | Per-tool timeout (ms) for fast read tools: `search`, `batch_search`, `get_*_info`, `search_labels`, `get_label_info`. Default: 30000. Raise on slow storage (Azure SMB). |
+| `MCP_TOOL_TIMEOUT_HEAVY_MS` | No | Per-tool timeout (ms) for heavy tools: `build_d365fo_project`, `trigger_db_sync`, `run_bp_check`, `run_systest_class`, `update_symbol_index`. Default: 600000 (10 min). |
+| `D365FO_FS_SCAN_TIMEOUT_MS` | No | Budget (ms) for the filesystem extension-scanner fallback (table/form/class extension lookup). Default: 3000. |
+| `D365FO_DISABLE_FS_FALLBACK` | No | `true` disables the disk scan that runs when the symbol index has no data for an extension. Recommended in production where the index is authoritative and a stale scan would mask missing data. |
 | `MCP_FORCE_HTTP` | No | Set to `true` to prevent stdio mode even when stdin is piped (rare). |
 | `ENV_FILE` | No | Absolute or relative path to a `.env` file. When set, the server loads that file instead of the default repo-root `.env`. Use this to run multiple instances of the server from a single installation — each instance has its own `.env` with its own `PORT`, `DB_PATH`, and `METADATA_PATH`. Relative paths in `DB_PATH`, `LABELS_DB_PATH`, and `METADATA_PATH` inside the target file are resolved relative to that file's directory. See [Scenario F in SETUP.md](SETUP.md#scenario-f-multiple-instances--one-machine-multiple-d365fo-environments). |
 | `DEBUG_LOGGING` | No | Set to `true` to enable verbose raw JSON-RPC trace on stderr. Every message VS 2022 sends to the server (`[VS→MCP]`) and every reply the server sends back (`[MCP→VS]`) is printed with a relative timestamp. Useful for diagnosing handshake failures or unexpected tool responses. Works in both stdio and HTTP mode. |

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -131,7 +131,7 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 | **find_event_handlers** † | All event handlers with type classification and event filtering | "Who handles the onInserted event of SalesLine?" |
 | **get_table_extension_info** | All extensions of a table: added fields, indexes, methods | "What fields did ISV packages add to CustTable?" |
 | **get_data_entity_info** † | Data entity category, OData name, data sources, keys | "Show me CustCustomerV3Entity details" |
-| **analyze_extension_points** † | CoC-eligible methods, delegates, events — what can be extended (bridge enrichment for existing extensions) | "What can I extend on SalesLine?" |
+| **analyze_extension_points** † | CoC-eligible methods, delegates, events — what can be extended (pass `showExistingExtensions=true` to also list existing wrappers/subscribers) | "What can I extend on SalesLine?" |
 | **recommend_extension_strategy** | Recommends the best extensibility mechanism for a scenario — prevents wrong choices (CoC vs event vs Business Event vs data entity) | "Should I use CoC or Business Event to notify an external system?" |
 | **validate_object_naming** | Validate proposed extension/object names against D365FO conventions | "Is SalesTableExtension a valid extension class name?" |
 
@@ -150,7 +150,7 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 
 ### search
 
-Searches all 584 799+ D365FO symbols. Understands type filters so you can narrow results.
+Searches every indexed D365FO symbol (hundreds of thousands across standard + custom models). Understands type filters so you can narrow results.
 
 **Supported types:** class, table, method, field, enum, edt, form, query, view, report
 

--- a/docs/SETUP_AZURE.md
+++ b/docs/SETUP_AZURE.md
@@ -24,7 +24,7 @@ If you are a developer who only wants to **use** an existing server, see [SETUP.
 - **Node.js** 24.x LTS (for building the application and metadata on your Windows VM)
 - **Python** 3.x (required by `node-gyp` during `npm install`)
 - **Git**
-- An Azure subscription with permissions to create App Service, Storage Account, and optionally Redis
+- An Azure subscription with permissions to create App Service and Storage Account (Redis is optional; skip unless you have evidence of cache benefit)
 
 ---
 
@@ -48,7 +48,7 @@ Developer's Windows VM
 | Azure Blob Storage | Stores `xpp-metadata.db` (~2–3 GB depending on UnitTest models) and labels database (~500 MB) | Standard LRS |
 | Azure App Service Plan | Hosts the Node.js server | B3 (dev/test), P0v3 (production) |
 | Azure App Service (Web App) | Runs the MCP server | Linux, Node 24 LTS |
-| Azure Managed Redis | Optional — speeds up repeated queries | B0 Basic or higher |
+| Azure Managed Redis | Optional. Only helpful when many users hammer the same queries; the SQLite index is already in-process and sub-10 ms, so most deployments see no measurable gain. | B0 Basic or higher |
 
 ---
 
@@ -103,7 +103,9 @@ In the Azure Portal, go to the App Service → **Settings** → **Environment va
 |---------|-------|-------|
 | `API_KEY` | e.g. `my-secret-key-here` | When set, all `/mcp` requests must include `X-Api-Key` header. `/health` is always public. Generate a strong random key (e.g. `openssl rand -hex 32`). Leave empty to disable. |
 
-**Optional — Redis (recommended for teams):**
+**Optional — Redis (skip unless measured):**
+
+Most deployments should leave this disabled. The server already serves reads from an in-process SQLite database backed by WAL and FTS5, which is typically faster than a round-trip to Redis. Enable only if profiling shows repeated identical queries from many users dominating your traffic.
 
 | Setting | Value |
 |---------|-------|

--- a/docs/SQLITE_DEPENDENCY.md
+++ b/docs/SQLITE_DEPENDENCY.md
@@ -10,8 +10,8 @@ This document maps every MCP tool to its data-source usage and explains why SQLi
 
 | Data Source | What It Provides | Platform |
 |-------------|-----------------|----------|
-| **SQLite** — symbols DB | 584 799+ pre-indexed symbols with FTS5 full-text search, `edt_metadata`, `extension_metadata`, `menu_item_targets`, `security_*` hierarchy tables, `source_snippet` column | Cross-platform (Azure/Linux + Windows) |
-| **SQLite** — labels DB | 19M+ label entries across 70 languages with FTS search | Cross-platform |
+| **SQLite** — symbols DB | Hundreds of thousands of pre-indexed symbols with FTS5 full-text search, `edt_metadata`, `extension_metadata`, `menu_item_targets`, `security_*` hierarchy tables, `source_snippet` column | Cross-platform (Azure/Linux + Windows) |
+| **SQLite** — labels DB | Tens of millions of label entries across 70 languages with FTS search | Cross-platform |
 | **C# Bridge** — IMetadataProvider | Live reads of individual D365FO objects (class, table, form, EDT, enum, …) | Windows-only (.NET 4.8) |
 | **C# Bridge** — DYNAMICSXREFDB | Compiler-resolved cross-references: `Names`, `References`, `Modules` tables | Windows-only (SQL Server) |
 
@@ -75,15 +75,15 @@ These tools query across hundreds to thousands of objects with GROUP BY, COUNT, 
 |------|-----------------|---------------|
 | `analyzePatterns` | Scan `source_snippet` for pattern types, method frequencies | Thousands of classes |
 | `analyzeCompleteness` | Compare class methods vs. similar classes | Hundreds of same-type classes |
-| `suggestImplementation` | Fuzzy method name matching across all classes | 584K+ symbols |
-| `suggestEdt` | Exact → prefix → keyword → context on `edt_metadata` | 8K+ EDTs |
+| `suggestImplementation` | Fuzzy method name matching across all classes | Full symbol index |
+| `suggestEdt` | Exact → prefix → keyword → context on `edt_metadata` | Thousands of EDTs |
 | `getTablePatterns` | GROUP BY / COUNT on tables of same TableGroup | Hundreds of tables |
 | `getFormPatterns` | GROUP BY on forms of same pattern | Hundreds of forms |
 | `generateSmartTable` | EDT resolution + auto-FK relations via `edt_metadata` chain walk | `edt_metadata` + symbols |
 | `generateSmartForm` | copyFrom structure + auto-grid from table fields | Symbols + form patterns |
 | `generateSmartReport` | copyFrom TmpTable + EDT → .NET type resolution | `edt_metadata` chain walk |
 | `securityCoverageInfo` | 4-table JOIN (role → duty → privilege → entry point) | `security_*` hierarchy |
-| `validateObjectNaming` | Collision check LIKE/exact across all symbols | 584K+ symbols |
+| `validateObjectNaming` | Collision check LIKE/exact across all symbols | Full symbol index |
 
 ### E) SQLite for File Resolution in Write Operations (1 tool)
 
@@ -119,7 +119,7 @@ SQLite fills all of these gaps with pre-indexed, pre-aggregated data optimized f
 
 ### 3. Sole Source for 19M+ Labels
 
-The labels database contains 19 million+ entries across 70 languages. `IMetadataProvider` has no API for reading or searching label files. Every label operation — search, read, create, rename — goes exclusively through SQLite. There is no alternative data path.
+The labels database contains tens of millions of entries across 70 languages. `IMetadataProvider` has no API for reading or searching label files. Every label operation — search, read, create, rename — goes exclusively through SQLite. There is no alternative data path.
 
 ---
 
@@ -130,7 +130,7 @@ The labels database contains 19 million+ entries across 70 languages. `IMetadata
 | Add FTS to DYNAMICSXREFDB | ❌ Microsoft-owned DB, read-only schema | Would require custom SQL Server full-text index + schema changes to a production database |
 | Add label API to bridge | ⚠️ Possible but laborious | Requires parsing all `.label.txt` files (19M entries) in C#, plus building search/CRUD — essentially reimplementing `labelsDb.ts` |
 | Add aggregation endpoints to bridge | ⚠️ Possible for individual queries | Each analytical query (pattern mining, EDT chain walk, security hierarchy) would need a dedicated C# endpoint — dozens of new endpoints, each doing what one SQL query does today |
-| Enumerate all objects via bridge for aggregation | ❌ Prohibitively slow | Reading 584K objects one-by-one via IPC to compute a GROUP BY would take minutes vs. milliseconds in SQLite |
+| Enumerate all objects via bridge for aggregation | ❌ Prohibitively slow | Reading the full symbol set one-by-one via IPC to compute a GROUP BY would take minutes vs. milliseconds in SQLite |
 | Drop Azure/Linux support | ❌ Violates product requirements | The MCP server must work in read-only Azure deployments where no D365FO runtime exists |
 
 **Conclusion:** SQLite and the C# bridge are complementary by design. The bridge provides **live, authoritative, single-object reads** and **compiler-resolved cross-references**. SQLite provides **bulk search, aggregation, cross-platform availability, and label management**. Neither can fully replace the other.

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -150,7 +150,7 @@ and verify the objects are in place.
 3. `search` + `batch_search` ×9 — parallel searches across name variants (`VendPaymTerms`, `VendPaymentTerms`, `PaymTerm*`, `MY_VendPaymTermsMaintain`) for privileges, duties, and menu items
 4. `get_menu_item_info` ×2 — `VendPaymTerms` menu item detail (target form, security chain); called again for display-type variant
 5. `get_security_artifact_info` ×8 — reads full entry lists for candidate duties: `VendPaymentTermsMaintain`, `VendPaymTermsMaintain`, `LedgerPaymTermsMaintain`, `PaymTermsMaintain`, `VendVendorMasterMaintain`, `VendInvoiceVendorMaintain`, and privileges `PaymTermMaintain`, `PaymTermView`
-6. `validate_object_naming` ×2 — confirms `MY_VendPaymTermsMaintain` follows D365FO conventions and has no collision in 584K+ symbols
+6. `validate_object_naming` ×2 — confirms `MY_VendPaymTermsMaintain` follows D365FO conventions and has no collision across the indexed symbols
    (prefix separator `MY_` is valid — `{Prefix}_{Name}` is a supported D365FO naming pattern)  ✅
 7. `generate_code` — generates security-privilege XML skeleton for `VendPaymTerms`
 8. `search_labels` ×2 — label lookup for "vendor payment terms maintain" (with and without model filter)

--- a/scripts/build-fts.ts
+++ b/scripts/build-fts.ts
@@ -55,6 +55,11 @@ async function buildFts(): Promise<void> {
 
   const symbolIndex = new XppSymbolIndex(OUTPUT_DB, OUTPUT_LABELS_DB);
 
+  // Close read-pool connections before setting EXCLUSIVE locking mode.
+  // SQLite cannot grant locking_mode = EXCLUSIVE while any other connection
+  // (even read-only, in-process) holds a shared lock.
+  symbolIndex.closeReadPool();
+
   // Use same bulk-load pragmas for the FTS rebuild (important: no WAL during heavy writes)
   symbolIndex.db.pragma('journal_mode = MEMORY');
   symbolIndex.db.pragma('synchronous = OFF');

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -298,17 +298,29 @@ export class BridgeClient extends EventEmitter {
 
     this.rejectAllPending(new Error('BridgeClient disposed'));
 
-    if (this.process) {
+    // Capture the child reference in a local variable BEFORE clearing this.process.
+    // The deferred SIGTERM closure must retain the reference or it kills nothing,
+    // leaking the D365MetadataBridge child process across restarts.
+    const child = this.process;
+    this.process = null;
+    if (child) {
       try {
-        this.process.stdin?.end();
-        // Give it a moment to exit gracefully
-        setTimeout(() => {
-          if (this.process && !this.process.killed) {
-            this.process.kill('SIGTERM');
+        child.stdin?.end();
+        const graceful = setTimeout(() => {
+          if (!child.killed) {
+            try { child.kill('SIGTERM'); } catch { /* already gone */ }
           }
         }, 2000);
+        // SIGKILL fallback if SIGTERM did not terminate within another 3s.
+        const hard = setTimeout(() => {
+          if (!child.killed) {
+            try { child.kill('SIGKILL'); } catch { /* already gone */ }
+          }
+        }, 5000);
+        // Do not keep the event loop alive purely for these timers.
+        if (typeof graceful.unref === 'function') graceful.unref();
+        if (typeof hard.unref === 'function') hard.unref();
       } catch { /* ignore */ }
-      this.process = null;
     }
   }
 

--- a/src/cache/redisCache.ts
+++ b/src/cache/redisCache.ts
@@ -270,6 +270,27 @@ export class RedisCacheService {
   }
 
   /**
+   * Non-blocking key scan. Unlike KEYS which is O(N) and blocks the Redis
+   * event loop on large keyspaces, SCAN iterates in bounded chunks.
+   * `max` caps the result size so diagnostics/maintenance never walk the
+   * entire keyspace.
+   */
+  private async scanKeys(pattern: string, max: number = 1000): Promise<string[]> {
+    if (!this.client) return [];
+    const keys: string[] = [];
+    let cursor = '0';
+    do {
+      const [nextCursor, batch] = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 200);
+      cursor = nextCursor;
+      for (const k of batch) {
+        keys.push(k);
+        if (keys.length >= max) return keys;
+      }
+    } while (cursor !== '0');
+    return keys;
+  }
+
+  /**
    * Delete all keys matching a pattern
    */
   async deletePattern(pattern: string): Promise<void> {
@@ -278,9 +299,12 @@ export class RedisCacheService {
     }
 
     try {
-      const keys = await this.client.keys(pattern);
-      if (keys.length > 0) {
-        await this.client.del(...keys);
+      // SCAN + batched DEL instead of KEYS — SCAN never blocks Redis,
+      // and batched DEL avoids unbounded argument lists.
+      const keys = await this.scanKeys(pattern, 10_000);
+      for (let i = 0; i < keys.length; i += 500) {
+        const chunk = keys.slice(i, i + 500);
+        if (chunk.length > 0) await this.client.del(...chunk);
       }
     } catch (error) {
       console.error('Redis deletePattern error:', error);
@@ -440,8 +464,8 @@ export class RedisCacheService {
       const memoryMatch = info.match(/used_memory_human:(.+)/);
       const memory = memoryMatch ? memoryMatch[1].trim() : 'unknown';
 
-      // Get top keys by TTL (most recently accessed/important)
-      const allKeys = await this.client.keys('xpp:*');
+      // Get top keys by TTL (most recently accessed/important) — use SCAN, not KEYS.
+      const allKeys = await this.scanKeys('xpp:*', 500);
       const topKeys: Array<{ key: string; ttl: number }> = [];
       
       if (allKeys.length > 0) {
@@ -480,9 +504,9 @@ export class RedisCacheService {
     }
 
     try {
-      // Get all keys
-      const searchKeys = await this.client.keys('xpp:search:*');
-      const classKeys = await this.client.keys('xpp:class:*');
+      // Sampled SCAN (capped) so pattern analysis never blocks Redis on large keyspaces.
+      const searchKeys = await this.scanKeys('xpp:search:*', 500);
+      const classKeys = await this.scanKeys('xpp:class:*', 500);
 
       // Extract queries from keys
       const queries = searchKeys

--- a/src/index.ts
+++ b/src/index.ts
@@ -599,6 +599,16 @@ async function main() {
       // Resolve dbReady AFTER context is patched — tools can now run with real index.
       resolveDbReady();
       console.log(`✅ Database loaded in ${Date.now() - dbLoadStart} ms (${diagTs()} from process start) — all tools fully operational`);
+
+      // Close the handshake-phase stub cache so we don't leak its (no-op or
+      // real Redis) connection for the rest of the process lifetime.
+      // The stub and the real cache are distinct RedisCacheService instances;
+      // once the real one is wired, the stub is unreachable.
+      if (stubCache !== cache) {
+        stubCache.close().catch(() => {});
+      }
+      // The in-memory stub symbol index is also unreachable once swapped.
+      try { stubIndex.close(); } catch { /* ignore */ }
     }).catch(err => {
       rejectDbReady(err);
       console.error('❌ Background initialization failed:', err);

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1939,13 +1939,28 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Search custom extensions by prefix
+   * Search custom extensions by prefix.
+   *
+   * Restricts results to symbol types whose names carry the `*_Extension` /
+   * `*.<model>Extension` convention (class-extension, table-extension, etc.)
+   * so that unrelated symbols sharing a substring don't leak into extension UI.
    */
   searchCustomExtensions(query: string, prefix?: string, limit: number = 20): XppSymbol[] {
+    // Allow extension-shaped rows (regardless of whether the indexer set a
+    // dedicated *-extension type) while also including explicit extension types.
     let sql = `
       SELECT *
       FROM symbols
       WHERE name LIKE ?
+        AND (
+          type IN (
+            'class-extension','table-extension','form-extension','enum-extension',
+            'edt-extension','view-extension','query-extension','data-entity-extension',
+            'map-extension','menu-extension','security-role-extension','security-duty-extension'
+          )
+          OR name LIKE '%_Extension'
+          OR name LIKE '%.%Extension'
+        )
     `;
 
     const params: any[] = [`%${query}%`];
@@ -2457,11 +2472,30 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Close the database connection
+   * Close the database connection and release all pooled resources.
+   *
+   * Includes:
+   *  - prepared-statement cache
+   *  - main writer DB + read pool
+   *  - labels DB + labels read pool
+   *  - any pending debounced labels FTS rebuild timer
+   *
+   * Previously only the writer DB was closed, leaving file handles and a
+   * pending timer behind which caused shutdown hangs and file-handle leaks.
    */
   close(): void {
+    // Flush any debounced labels FTS rebuild to avoid losing writes on shutdown.
+    if (this._labelsFtsTimer) {
+      clearTimeout(this._labelsFtsTimer);
+      this._labelsFtsTimer = null;
+    }
+
+    // Drain read pools first — writer close will fail on WAL if readers hold a lock.
+    this.closeReadPool();
+
     this.stmtCache.clear();
-    this.db.close();
+    try { this.db.close(); } catch { /* ignore */ }
+    try { this.labelsDb.close(); } catch { /* ignore */ }
   }
 
   // ============================================
@@ -2469,7 +2503,10 @@ export class XppSymbolIndex {
   // ============================================
 
   /**
-   * Add (or replace) a label entry in the index
+   * Add (or replace) a label entry in the index.
+   * Labels live in the separate `labelsDb` connection — NOT in the main symbols DB.
+   * The stmtCache is shared across connections so the cache key is namespaced to avoid
+   * accidentally reusing a statement prepared against a different DB handle.
    */
   addLabel(entry: {
     labelId: string;
@@ -2480,13 +2517,13 @@ export class XppSymbolIndex {
     comment?: string;
     filePath: string;
   }): void {
-    let stmt = this.stmtCache.get('addLabel');
+    let stmt = this.stmtCache.get('labels::addLabel');
     if (!stmt) {
-      stmt = this.db.prepare(`
+      stmt = this.labelsDb.prepare(`
         INSERT OR REPLACE INTO labels (label_id, label_file_id, model, language, text, comment, file_path)
         VALUES (?, ?, ?, ?, ?, ?, ?)
       `);
-      this.stmtCache.set('addLabel', stmt);
+      this.stmtCache.set('labels::addLabel', stmt);
     }
     stmt.run(
       entry.labelId,

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -1,5 +1,6 @@
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import type { Request, Response } from 'express';
+import { createHash } from 'crypto';
 
 /**
  * Rate limiter configuration for different endpoint types
@@ -29,15 +30,21 @@ function parseEnvInt(key: string, defaultVal: number, min: number, max: number):
  * per-user token (GitHub Copilot OAuth token), so it identifies individual
  * users even when they all come from the same IP.
  *
- * Security: we use only the last 32 characters of the token so the full
- * secret never appears in logs or memory for longer than necessary.
+ * Security: we SHA-256 the full Authorization header and use the hash as the
+ * key. Slicing the raw token (old behaviour) let an attacker vary the leading
+ * bytes of a forged header to create unlimited buckets and bypass the limit.
+ * Hashing anchors the key to the ENTIRE header so any change — forged or not —
+ * produces a fresh limit, and the full secret never reaches logs or memory
+ * for longer than the sync hash computation.
+ *
  * Falls back to IP when no Authorization header is present (curl, healthz).
  */
 function generateKey(req: Request): string {
   const authHeader = req.headers['authorization'];
-  if (authHeader && authHeader.length > 8) {
-    // Take last 32 chars — enough entropy to distinguish users, avoids logging full token
-    return 'tok:' + authHeader.slice(-32);
+  if (typeof authHeader === 'string' && authHeader.length > 8) {
+    // Hash the full header; truncate the digest for a compact in-memory key.
+    const digest = createHash('sha256').update(authHeader).digest('hex');
+    return 'tok:' + digest.slice(0, 32);
   }
 
   // Fallback: IP-based key (same logic as before)

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -24,6 +24,40 @@ const TOOL_TIMEOUT_MS = Math.max(10_000,
 );
 
 /**
+ * Per-tool timeout classes. A single global ceiling has two failure modes:
+ *  - fast tools (get_class_info, search) starve the request slot when a
+ *    misbehaving call hangs for the full 120 s
+ *  - heavy tools (build, db-sync, systest) get killed prematurely
+ *
+ * We split timeouts by workload. All values can be overridden via env.
+ */
+const TOOL_TIMEOUT_FAST_MS  = Math.max(5_000,  parseInt(process.env.MCP_TOOL_TIMEOUT_FAST_MS  || '30000',  10) || 30_000);
+const TOOL_TIMEOUT_HEAVY_MS = Math.max(60_000, parseInt(process.env.MCP_TOOL_TIMEOUT_HEAVY_MS || '600000', 10) || 600_000);
+
+const HEAVY_TOOLS = new Set<string>([
+  'build_d365fo_project',
+  'trigger_db_sync',
+  'run_bp_check',
+  'run_systest_class',
+  'update_symbol_index',
+]);
+
+const FAST_TOOLS = new Set<string>([
+  'search', 'batch_search',
+  'get_class_info', 'get_table_info', 'get_form_info',
+  'get_edt_info', 'get_enum_info', 'get_menu_item_info',
+  'get_view_info', 'get_query_info', 'get_report_info',
+  'get_data_entity_info', 'search_labels', 'get_label_info',
+]);
+
+function resolveToolTimeout(toolName: string | undefined): number {
+  if (!toolName) return TOOL_TIMEOUT_MS;
+  if (HEAVY_TOOLS.has(toolName)) return TOOL_TIMEOUT_HEAVY_MS;
+  if (FAST_TOOLS.has(toolName))  return TOOL_TIMEOUT_FAST_MS;
+  return TOOL_TIMEOUT_MS;
+}
+
+/**
  * Extract workspace folder path from GitHub Copilot MCP request.
  * Copilot can pass workspace info via HTTP headers or _meta in params.
  * Returns a local file-system path (converts file:// URI → path).
@@ -254,14 +288,19 @@ export class CustomHttpTransport implements Transport {
             const originalId = request.id;
             (request as any).id = internalId;
 
+            // Resolve the timeout class for this specific tool call so slow tools
+            // (build / db-sync) aren't killed and fast tools don't starve the slot
+            // for the full global ceiling.
+            const perToolTimeoutMs = resolveToolTimeout(toolName);
+
             const timeoutId = setTimeout(() => {
               if (this.pendingRequests.has(internalId!)) {
                 this.pendingRequests.delete(internalId!);
                 (request as any).id = originalId; // restore on timeout
-                process.stderr.write(`← ${tag} ⏱️ ${toolName} timed out after ${TOOL_TIMEOUT_MS / 1000}s\n`);
-                reject(new Error(`Request timeout: ${toolName} did not complete within ${TOOL_TIMEOUT_MS / 1000}s`));
+                process.stderr.write(`← ${tag} ⏱️ ${toolName} timed out after ${perToolTimeoutMs / 1000}s\n`);
+                reject(new Error(`Request timeout: ${toolName} did not complete within ${perToolTimeoutMs / 1000}s`));
               }
-            }, TOOL_TIMEOUT_MS);
+            }, perToolTimeoutMs);
 
             this.pendingRequests.set(internalId, {
               resolve: (message) => {

--- a/src/tools/analyzeExtensionPoints.ts
+++ b/src/tools/analyzeExtensionPoints.ts
@@ -21,8 +21,10 @@ const AnalyzeExtensionPointsArgsSchema = z.object({
   objectName: z.string().describe('Class or table name to analyze extension points for'),
   objectType: z.enum(['class', 'table', 'form', 'auto']).optional().default('auto')
     .describe('Object type (auto=detect from symbol index)'),
-  showExistingExtensions: z.boolean().optional().default(true)
-    .describe('Show which extension points are already wrapped/subscribed by existing extensions'),
+  // Default OFF: enumerating existing extensions can roughly double the response size.
+  // Opt in only when you want to see who already wraps/subscribes.
+  showExistingExtensions: z.boolean().optional().default(false)
+    .describe('Show which extension points are already wrapped/subscribed by existing extensions (opt-in)'),
 });
 
 export async function analyzeExtensionPointsTool(request: CallToolRequest, context: XppServerContext) {

--- a/src/tools/classInfo.ts
+++ b/src/tools/classInfo.ts
@@ -84,36 +84,26 @@ export async function classInfoTool(request: CallToolRequest, context: XppServer
       };
     }
 
-    // Try C# bridge first (IMetadataProvider — live D365FO metadata)
-    // Skip bridge for compact=true: DB signatures are instant (no IPC) and sufficient.
-    // Bridge fetches full method source bodies only for the adapter to extract line 1
-    // as a signature — pure waste when compact mode only needs signatures.
-    if (args.compact === false) {
-      const bridgeResult = await tryBridgeClass(context.bridge, args.className, false, args.methodOffset ?? 0);
-      if (bridgeResult) {
-        // Cache bridge result to avoid repeated IPC for the same class
-        await cache.setClassInfo(cacheKey, bridgeResult).catch(() => {});
-        return bridgeResult;
-      }
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata).
+    // Priority order per read-path spec: Bridge → DB → Disk. Bridge is authoritative
+    // because it reflects whatever the currently-running D365FO instance sees;
+    // DB is a pre-indexed mirror; disk is the slowest last-resort parse.
+    const bridgeResult = await tryBridgeClass(context.bridge, args.className, args.compact !== false, args.methodOffset ?? 0);
+    if (bridgeResult) {
+      await cache.setClassInfo(cacheKey, bridgeResult).catch(() => {});
+      return bridgeResult;
     }
 
-    // Query database and parse
+    // Query database next
     const classSymbol = symbolIndex.getSymbolByName(args.className, 'class');
 
     if (!classSymbol) {
-      // SQLite has no record — try bridge as fallback (essential in write-only mode
-      // where SQLite is an empty in-memory DB but bridge reads directly from disk)
-      const bridgeFallback = await tryBridgeClass(context.bridge, args.className, false, args.methodOffset ?? 0);
-      if (bridgeFallback) {
-        await cache.setClassInfo(cacheKey, bridgeFallback).catch(() => {});
-        return bridgeFallback;
-      }
       const typeMismatch = buildObjectTypeMismatchMessage(symbolIndex.getReadDb(), args.className);
       return {
         content: [
           {
             type: 'text',
-            text: `❌ Class "${args.className}" not found in symbol index.${typeMismatch}`,
+            text: `❌ Class "${args.className}" not found via bridge or symbol index.${typeMismatch}`,
           },
         ],
         isError: true,

--- a/src/tools/dbSync.ts
+++ b/src/tools/dbSync.ts
@@ -15,6 +15,19 @@ const SYNCABLE_AOT_FOLDERS = new Set([
 const MAX_OUTPUT_LENGTH = 8_000;
 
 /**
+ * Redact the `-connect=...` argument when logging SyncEngine invocations so
+ * SQL Server credentials never appear in plain text in server logs.
+ */
+function maskConnectArgs(args: string[]): string[] {
+  return args.map(a => {
+    if (typeof a === 'string' && a.toLowerCase().startsWith('-connect=')) {
+      return '-connect=***REDACTED***';
+    }
+    return a;
+  });
+}
+
+/**
  * Runs an executable and streams output to stderr for progress visibility.
  * Returns combined stdout+stderr and the exit code.
  */
@@ -29,9 +42,27 @@ function runWithStreaming(
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
+    // Bound in-memory buffering of child output. A 60-minute sync on a verbose
+    // SyncEngine can emit tens of MB which previously all accumulated in RAM.
+    // Once the cap is hit we drop the oldest bytes — progress is still logged
+    // live to stderr, and the final client-facing output is already capped by
+    // MAX_OUTPUT_LENGTH below.
+    const MAX_BUFFER_BYTES = 2 * 1024 * 1024; // 2 MB per stream
+    const truncated = { stdout: false, stderr: false };
     let stdout = '';
     let stderr = '';
     let killed = false;
+    const appendBounded = (which: 'stdout' | 'stderr', text: string) => {
+      const current = which === 'stdout' ? stdout : stderr;
+      const next = current + text;
+      if (next.length > MAX_BUFFER_BYTES) {
+        truncated[which] = true;
+        const trimmed = next.slice(next.length - MAX_BUFFER_BYTES);
+        if (which === 'stdout') stdout = trimmed; else stderr = trimmed;
+      } else {
+        if (which === 'stdout') stdout = next; else stderr = next;
+      }
+    };
 
     const timer = opts.timeout > 0
       ? setTimeout(() => {
@@ -43,7 +74,7 @@ function runWithStreaming(
 
     child.stdout.on('data', (chunk: Buffer) => {
       const text = chunk.toString();
-      stdout += text;
+      appendBounded('stdout', text);
       // Log progress lines so user can see activity in MCP server logs
       for (const line of text.split('\n').filter((l: string) => l.trim())) {
         console.error(`[db-sync stdout] ${line}`);
@@ -52,7 +83,7 @@ function runWithStreaming(
 
     child.stderr.on('data', (chunk: Buffer) => {
       const text = chunk.toString();
-      stderr += text;
+      appendBounded('stderr', text);
       for (const line of text.split('\n').filter((l: string) => l.trim())) {
         console.error(`[db-sync stderr] ${line}`);
       }
@@ -270,7 +301,7 @@ export const dbSyncTool = async (params: any, _context: any) => {
       }
     }
 
-    console.error(`[trigger_db_sync] Running: "${syncEnginePath}" ${args.join(' ')}`);
+    console.error(`[trigger_db_sync] Running: "${syncEnginePath}" ${maskConnectArgs(args).join(' ')}`);
 
     // Timeouts: partial 15 min, full 60 min
     const timeoutMs = isPartial ? 15 * 60_000 : 60 * 60_000;

--- a/src/tools/findReferences.ts
+++ b/src/tools/findReferences.ts
@@ -15,7 +15,9 @@ const FindReferencesArgsSchema = z.object({
   targetType: z.enum(['method', 'class', 'table', 'field', 'enum', 'all']).optional().describe('Type of the target to search for'),
   scope: z.enum(['all', 'workspace', 'standard', 'custom']).optional().default('all').describe('Search scope'),
   limit: z.number().optional().default(50).describe('Maximum results to return'),
-  includeContext: z.boolean().optional().default(true).describe('Include code context around reference'),
+  // Default OFF: code-context snippets roughly quadruple the token cost of this tool.
+  // Agents typically only need file:line:type — turn context on explicitly when you need snippets.
+  includeContext: z.boolean().optional().default(false).describe('Include code context around reference (opt-in to reduce token usage)'),
 });
 
 interface Reference {

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -15,6 +15,7 @@ import { getConfigManager, fallbackPackagePath, extractModelFromFilePath } from 
 import { isStandardModel } from '../utils/modelClassifier.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { resolveDbPathLocally } from '../utils/metadataResolver.js';
+import { assertWritePathAllowed } from '../utils/pathContainment.js';
 import {
   bridgeValidateAfterWrite, canBridgeModify,
   bridgeAddMethod, bridgeRemoveMethod, bridgeAddField, bridgeSetProperty, bridgeReplaceCode,
@@ -433,6 +434,14 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       );
     }
 
+    // 1a. Path containment guard — every write target must live under a configured
+    //     <PackagesLocalDirectory>/<Package>/<Model>/Ax<Type>/<File>.xml layout.
+    //     Refuses path traversal via explicit filePath or JSON sourcePath (security-critical).
+    const containment = await assertWritePathAllowed(filePath, modelName);
+    if (!containment.ok) {
+      throw new Error(containment.reason || 'Path containment check failed');
+    }
+
     // 1b. Model-ownership guard: refuse to modify objects in standard Microsoft models.
     // This prevents accidental writes to ApplicationSuite, ApplicationFoundation, etc.
     const resolvedModelFromPath = extractModelFromFilePath(filePath);
@@ -462,7 +471,12 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       if (trimmed.startsWith('{')) {
         const data = JSON.parse(fileContent);
         if (data.sourcePath) {
-          actualFilePath = data.sourcePath;
+          // Re-validate the indirect path: sourcePath also comes from user-influenced data.
+          const srcContainment = await assertWritePathAllowed(data.sourcePath, modelName);
+          if (!srcContainment.ok) {
+            throw new Error(`sourcePath rejected: ${srcContainment.reason}`);
+          }
+          actualFilePath = srcContainment.canonicalPath || data.sourcePath;
         } else {
           throw new Error(`Metadata file has no sourcePath: ${filePath}`);
         }

--- a/src/tools/reviewWorkspaceChanges.ts
+++ b/src/tools/reviewWorkspaceChanges.ts
@@ -10,6 +10,9 @@ async function git(args: string[], cwd: string): Promise<string> {
     cwd,
     windowsHide: true,
     maxBuffer: 1024 * 1024 * 10,
+    // Bound runtime so a misbehaving git process (large repo, hung transport,
+    // credential prompt) can never hold the tool thread indefinitely.
+    timeout: 30_000,
   });
   return stdout;
 }

--- a/src/tools/tableInfo.ts
+++ b/src/tools/tableInfo.ts
@@ -48,14 +48,23 @@ export async function tableInfoTool(request: CallToolRequest, context: XppServer
       };
     }
 
-    // C# bridge (IMetadataProvider — live D365FO metadata, always available)
+    // Read-path priority: Bridge → DB (symbol index) → Disk (last resort).
+    // 1. Bridge — live D365FO metadata, always up-to-date when available.
     const bridgeResult = await tryBridgeTable(context.bridge, args.tableName, args.methodOffset);
     if (bridgeResult) {
       await cache.setClassInfo(cacheKey, bridgeResult).catch(() => {});
       return bridgeResult;
     }
 
-    // Fallback: table may have just been created and bridge hasn't refreshed yet
+    // 2. DB index fallback — serves offline / write-only / build-agent scenarios.
+    const { symbolIndex } = context;
+    const dbResponse = buildTableResponseFromDb(symbolIndex, args.tableName, args.methodOffset);
+    if (dbResponse) {
+      return dbResponse;
+    }
+
+    // 3. Disk fallback — slowest, only when bridge AND DB have no record
+    //    (e.g. a brand-new table not yet indexed).
     const diskPath = await findD365FileOnDisk('table', args.tableName);
     if (diskPath) {
       const model = path.basename(path.dirname(path.dirname(diskPath)));
@@ -83,7 +92,7 @@ export async function tableInfoTool(request: CallToolRequest, context: XppServer
     return {
       content: [{
         type: 'text',
-        text: `Table "${args.tableName}" not found via bridge or on disk.\n\nIf this is a newly created table, ensure .mcp.json has the correct modelName/projectPath so the server can locate it.`,
+        text: `Table "${args.tableName}" not found via bridge, symbol index, or on disk.\n\nIf this is a newly created table, ensure .mcp.json has the correct modelName/projectPath so the server can locate it.`,
       }],
       isError: true,
     };
@@ -96,4 +105,47 @@ export async function tableInfoTool(request: CallToolRequest, context: XppServer
       isError: true,
     };
   }
+}
+
+/**
+ * Serve table info entirely from the pre-indexed symbol database.
+ * Returns null when the table is not present in the index; caller then falls through
+ * to disk parsing. Never reads the filesystem.
+ */
+function buildTableResponseFromDb(
+  symbolIndex: any,
+  tableName: string,
+  methodOffset: number,
+): { content: { type: 'text'; text: string }[] } | null {
+  const tableSym = symbolIndex.getSymbolByName?.(tableName, 'table');
+  if (!tableSym) return null;
+
+  const rdb = symbolIndex.getReadDb();
+  const fields = rdb.prepare(
+    `SELECT name, signature FROM symbols WHERE parent_name = ? AND type = 'field' ORDER BY name`
+  ).all(tableName) as Array<{ name: string; signature: string | null }>;
+  const methods = rdb.prepare(
+    `SELECT name, signature FROM symbols WHERE parent_name = ? AND type = 'method' ORDER BY name`
+  ).all(tableName) as Array<{ name: string; signature: string | null }>;
+
+  const METHOD_PAGE = 25;
+  const totalMethods = methods.length;
+  const paged = methods.slice(methodOffset, methodOffset + METHOD_PAGE);
+  const hasMore = methodOffset + METHOD_PAGE < totalMethods;
+
+  let out = `# Table: ${tableSym.name}\n`;
+  if (tableSym.model) out += `**Model:** ${tableSym.model}\n`;
+  out += `\n## Fields (${fields.length})\n\n`;
+  for (const f of fields) {
+    out += `- **${f.name}**${f.signature ? `: ${f.signature}` : ''}\n`;
+  }
+  out += `\n## Methods (${totalMethods} total${totalMethods > METHOD_PAGE ? `, showing ${methodOffset + 1}–${Math.min(methodOffset + METHOD_PAGE, totalMethods)}` : ''})\n\n`;
+  for (const m of paged) {
+    out += `- \`${m.signature || m.name}\`\n`;
+  }
+  if (hasMore) {
+    out += `\n> ⚠️ ${totalMethods - methodOffset - METHOD_PAGE} more methods. Call again with methodOffset=${methodOffset + METHOD_PAGE}.`;
+  }
+  out += `\n\n> ℹ️ Served from symbol index (bridge unavailable).`;
+  return { content: [{ type: 'text', text: out }] };
 }

--- a/src/tools/undoLastModification.ts
+++ b/src/tools/undoLastModification.ts
@@ -14,6 +14,8 @@ async function git(args: string[], cwd: string): Promise<string> {
     cwd,
     windowsHide: true,
     maxBuffer: 1024 * 1024 * 10,
+    // Prevent a hung git from blocking the tool indefinitely.
+    timeout: 30_000,
   });
   return stdout.trim();
 }

--- a/src/utils/fsExtensionScanner.ts
+++ b/src/utils/fsExtensionScanner.ts
@@ -83,8 +83,46 @@ export const EXTENSION_FOLDER_CONFIG: Readonly<Record<string, ExtensionTypeConfi
 // ── Core scanner ─────────────────────────────────────────────────────────────
 
 /**
+ * Hard budget (ms) for a single scan. The scanner walks every package and every
+ * model folder, so without a cap a scan on a full `PackagesLocalDirectory`
+ * (hundreds of packages) can block the tool for many seconds. The budget is
+ * checked between directory reads so partial results are still returned.
+ *
+ * Override with `D365FO_FS_SCAN_TIMEOUT_MS` (minimum 500 ms).
+ */
+const SCAN_TIMEOUT_MS = Math.max(500,
+  parseInt(process.env.D365FO_FS_SCAN_TIMEOUT_MS || '3000', 10) || 3000
+);
+
+/**
+ * When true, the filesystem fallback is completely disabled and the scanner
+ * always returns []. Useful in production where the index is authoritative and
+ * a stale scan would silently mask missing data.
+ */
+const FS_FALLBACK_DISABLED = process.env.D365FO_DISABLE_FS_FALLBACK === 'true';
+
+/**
+ * Per-scan result cache with short TTL. Three different tools
+ * (table-extension / CoC / analyze-extension-points) may request the same
+ * object within a single conversation; caching keeps the scanner from
+ * re-walking the filesystem each time.
+ */
+const SCAN_CACHE_TTL_MS = 30_000;
+interface ScanCacheEntry { at: number; data: FsExtensionScanResult[]; }
+const scanCache = new Map<string, ScanCacheEntry>();
+
+function cacheKeyFor(objectName: string, extensionType: string, packagePath: string): string {
+  return `${packagePath}|${extensionType}|${objectName.toLowerCase()}`;
+}
+
+/**
  * Scan the D365FO packages directory for extension XML files for a given base
  * object and extension type.
+ *
+ * Protections against request-time pathology:
+ *  - returns [] immediately when D365FO_DISABLE_FS_FALLBACK=true
+ *  - caps total work at SCAN_TIMEOUT_MS (partial results allowed)
+ *  - caches the result for SCAN_CACHE_TTL_MS
  *
  * @param objectName   Base object name (e.g. `SalesTable`, `SalesOrder`)
  * @param extensionType Key from EXTENSION_FOLDER_CONFIG (e.g. `'table-extension'`)
@@ -95,8 +133,18 @@ export async function scanFsExtensions(
   extensionType: string,
   packagePath: string,
 ): Promise<FsExtensionScanResult[]> {
+  if (FS_FALLBACK_DISABLED) return [];
   const config = EXTENSION_FOLDER_CONFIG[extensionType];
   if (!config) return [];
+
+  const cacheKey = cacheKeyFor(objectName, extensionType, packagePath);
+  const cached = scanCache.get(cacheKey);
+  if (cached && Date.now() - cached.at < SCAN_CACHE_TTL_MS) {
+    return cached.data;
+  }
+
+  const started = Date.now();
+  const timeBudgetExceeded = () => Date.now() - started > SCAN_TIMEOUT_MS;
 
   const results: FsExtensionScanResult[] = [];
   let packages: string[];
@@ -108,7 +156,8 @@ export async function scanFsExtensions(
 
   const lowerObjName = objectName.toLowerCase();
 
-  for (const pkg of packages) {
+  outer: for (const pkg of packages) {
+    if (timeBudgetExceeded()) break outer;
     const pkgDir = path.join(packagePath, pkg);
     let modelDirs: string[];
     try {
@@ -118,6 +167,7 @@ export async function scanFsExtensions(
     } catch { continue; }
 
     for (const mdl of modelDirs) {
+      if (timeBudgetExceeded()) break outer;
       const axDir = path.join(pkgDir, mdl, config.axFolder);
       let xmlFiles: string[];
       try {
@@ -125,6 +175,7 @@ export async function scanFsExtensions(
       } catch { continue; }
 
       for (const xmlFile of xmlFiles) {
+        if (timeBudgetExceeded()) break outer;
         // ── Fast-path: filename filter (avoids reading files unnecessarily) ──
         const baseName = path.basename(xmlFile, '.xml');
         const lowerBase = baseName.toLowerCase();
@@ -149,6 +200,8 @@ export async function scanFsExtensions(
     }
   }
 
+  // Store even partial results — next call within TTL returns them instantly.
+  scanCache.set(cacheKey, { at: Date.now(), data: results });
   return results;
 }
 

--- a/src/utils/pathContainment.ts
+++ b/src/utils/pathContainment.ts
@@ -1,0 +1,164 @@
+/**
+ * Path containment guard for D365FO write operations.
+ *
+ * All D365FO XML objects live at the canonical path:
+ *   <PackagesLocalDirectory>/<Package>/<Model>/Ax<Type>/<Name>.xml
+ *
+ * UDE layout is analogous under the custom packages root.
+ *
+ * This guard ensures that any file path the server is asked to write to
+ * actually resolves underneath one of the configured package roots AND
+ * contains the expected `/<Package>/<Model>/Ax*` segment shape. It prevents:
+ *   - path traversal via explicit filePath / sourcePath JSON
+ *   - writes to arbitrary locations on the host (repos, system dirs, etc.)
+ *   - silent drift between the "resolved model" and the actual on-disk model
+ *
+ * Security-wise this is the single authoritative place that decides whether
+ * a given absolute path is an acceptable write target.
+ */
+
+import * as path from 'path';
+import { realpathSync } from 'fs';
+import { getConfigManager, fallbackPackagePath } from './configManager.js';
+
+export interface PathContainmentResult {
+  ok: boolean;
+  /** When ok=false, human-readable reason. */
+  reason?: string;
+  /** When ok=true, the canonical absolute path with on-disk casing applied. */
+  canonicalPath?: string;
+  /** Matched root (for diagnostics). */
+  matchedRoot?: string;
+}
+
+/**
+ * True when `p` looks absolute on either POSIX or Windows, regardless of host
+ * OS. The server routinely runs on Windows but tests (and Azure proxy) run on
+ * Linux/macOS against Windows-style paths — using only `path.isAbsolute` would
+ * reject valid production paths in those cross-platform contexts.
+ */
+function isAbsoluteCrossPlatform(p: string): boolean {
+  if (!p) return false;
+  if (path.isAbsolute(p)) return true;
+  // Windows drive letter (C:\...) or UNC (\\server\share\...)
+  return /^[a-zA-Z]:[\\/]/.test(p) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(p);
+}
+
+/** Normalise a path to absolute + POSIX separators for comparison. */
+function normalise(p: string): string {
+  if (!p) return '';
+  let abs = isAbsoluteCrossPlatform(p) ? p : path.resolve(p);
+  try { abs = realpathSync(abs); } catch { /* may not exist yet — ok */ }
+  return abs.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+/** True when `child` is equal to or nested under `parent` (case-insensitive). */
+function isUnder(child: string, parent: string): boolean {
+  if (!parent) return false;
+  const c = normalise(child).toLowerCase();
+  const p = normalise(parent).toLowerCase();
+  return c === p || c.startsWith(p + '/');
+}
+
+/**
+ * Build the list of allowed root directories for D365FO writes from config.
+ * Order: configured package path → UDE custom packages → UDE Microsoft packages → fallback.
+ * Empty/undefined entries are skipped.
+ */
+async function getAllowedRoots(): Promise<string[]> {
+  const cfg = getConfigManager();
+  await cfg.ensureLoaded();
+  const roots = new Set<string>();
+  const add = (r: string | null | undefined) => { if (r && r.trim()) roots.add(normalise(r)); };
+
+  add(cfg.getPackagePath());
+  try { add(await cfg.getCustomPackagesPath()); } catch { /* optional */ }
+  try { add(await cfg.getMicrosoftPackagesPath()); } catch { /* optional */ }
+
+  // Fallback only if nothing was configured — prevents writing to unrelated drives
+  // when config is silently missing (better to error out than guess).
+  if (roots.size === 0) add(fallbackPackagePath());
+  return [...roots];
+}
+
+/**
+ * Validate that `filePath` points at a D365FO AOT file inside an allowed root
+ * and matches the canonical `<root>/<Package>/<Model>/Ax<Type>/<Name>.xml` shape.
+ *
+ * `modelHint` (optional) is the model name the caller expects to modify; when
+ * provided we additionally require the path's model segment to match it
+ * (case-insensitive). This catches the agent-steered attack where `modelName`
+ * is one value but `filePath` points into a different (standard) model.
+ */
+export async function assertWritePathAllowed(
+  filePath: string,
+  modelHint?: string,
+): Promise<PathContainmentResult> {
+  if (!filePath || typeof filePath !== 'string') {
+    return { ok: false, reason: 'filePath is empty' };
+  }
+  if (!isAbsoluteCrossPlatform(filePath)) {
+    return { ok: false, reason: `filePath must be absolute: "${filePath}"` };
+  }
+
+  const canonical = normalise(filePath);
+
+  // 1. Root containment
+  const roots = await getAllowedRoots();
+  const matchedRoot = roots.find(r => isUnder(canonical, r));
+  if (!matchedRoot) {
+    return {
+      ok: false,
+      reason:
+        `Refusing to write outside configured D365FO package roots.\n` +
+        `  path:    ${filePath}\n` +
+        `  allowed: ${roots.join(' | ') || '(none configured)'}`,
+    };
+  }
+
+  // 2. Canonical AOT shape:  <root>/<Package>/<Model>/Ax<Type>/<Name>.xml
+  // (UDE layout also matches because customPackagesPath is itself the <root>.)
+  const relative = canonical.slice(matchedRoot.length).replace(/^\/+/, '');
+  const parts = relative.split('/').filter(Boolean);
+  if (parts.length < 4) {
+    return {
+      ok: false,
+      reason:
+        `Path does not match canonical AOT layout (<Package>/<Model>/Ax<Type>/<File>):\n  ${filePath}`,
+    };
+  }
+  const [, modelSeg, axFolder, lastSeg] = parts;
+  if (!/^Ax[A-Z]/.test(axFolder)) {
+    return {
+      ok: false,
+      reason: `Expected Ax* folder as 3rd segment, got "${axFolder}" — path: ${filePath}`,
+    };
+  }
+  if (!lastSeg.toLowerCase().endsWith('.xml') && !lastSeg.toLowerCase().endsWith('.xpp')) {
+    return {
+      ok: false,
+      reason: `Expected .xml/.xpp file, got "${lastSeg}" — path: ${filePath}`,
+    };
+  }
+
+  // 3. Optional model-hint cross-check
+  if (modelHint && modelHint.trim() && modelHint !== 'any') {
+    if (modelSeg.toLowerCase() !== modelHint.toLowerCase()) {
+      return {
+        ok: false,
+        reason:
+          `Model mismatch: filePath is in model "${modelSeg}" but caller requested "${modelHint}". ` +
+          `This usually means the agent passed filePath from a different object.`,
+      };
+    }
+  }
+
+  return { ok: true, canonicalPath: canonical, matchedRoot };
+}
+
+/** Throwing wrapper — convenient in tool handlers. */
+export async function ensureWritePathAllowed(filePath: string, modelHint?: string): Promise<string> {
+  const r = await assertWritePathAllowed(filePath, modelHint);
+  if (!r.ok) throw new Error(`⛔ Path containment check failed: ${r.reason}`);
+  return r.canonicalPath!;
+}


### PR DESCRIPTION
Code changes:
- Add write-path containment guard (src/utils/pathContainment.ts) enforcing canonical PackagesLocalDirectory/<Package>/<Model>/Ax<Type>/<Name>.xml layout for create/modify.
- classInfo: always try bridge first (even compact=true), then SQLite, then bounded disk parse.
- tableInfo: insert SQLite fallback between bridge and disk.
- fsExtensionScanner: 3 s budget (D365FO_FS_SCAN_TIMEOUT_MS), 30 s result cache, opt-out via D365FO_DISABLE_FS_FALLBACK.
- symbolIndex: addLabel now writes to labelsDb; close() flushes FTS timer and both DBs; searchCustomExtensions restricted to *-extension types.
- bridgeClient.dispose(): capture child ref before null, SIGTERM at 2 s, SIGKILL at 5 s, unref timers.
- redisCache: SCAN-based scanKeys() replaces KEYS; batched DEL in chunks of 500.
- rateLimiter: SHA-256 hash of full Authorization header (truncated 32 chars).
- transport: per-tool timeouts MCP_TOOL_TIMEOUT_FAST_MS (30 s) / MCP_TOOL_TIMEOUT_HEAVY_MS (600 s).
- dbSync: mask -connect= in logs; bounded 2 MB stdout/stderr buffers.
- reviewWorkspaceChanges / undoLastModification: execFile timeout 30 s.
- build-fts: close read pool before switching to EXCLUSIVE locking.
- index.ts: close stub cache/index after DB swap.

Docs:
- copilot-instructions: explicit Bridge -> DB -> Disk read policy and write-path safety section; dropped stale symbol count.
- ARCHITECTURE / BRIDGE: align with three-tier read policy; document pathContainment guard.
- MCP_CONFIG: document MCP_TOOL_TIMEOUT_FAST_MS/HEAVY_MS, D365FO_FS_SCAN_TIMEOUT_MS, D365FO_DISABLE_FS_FALLBACK.
- SETUP_AZURE: reframe Redis as strictly optional.
- MCP_TOOLS: note analyze_extension_points needs showExistingExtensions=true for wrappers.
- README / SQLITE_DEPENDENCY / USAGE_EXAMPLES: replace hardcoded '584,799+/19M+' with neutral wording.