### PR TITLE
fix: Microsoft package labels excluded from FTS search due to en-us case mismatch

### DIFF
--- a/src/metadata/labelParser.ts
+++ b/src/metadata/labelParser.ts
@@ -175,7 +175,9 @@ export async function discoverLabelFiles(
 
       results.push({
         labelFileId,
-        language: locale,  // Use actual locale from filesystem (may be en-us or en-US)
+        // Normalize locale to BCP-47 canonical form (e.g. 'en-us' → 'en-US', 'es-mx' → 'es-MX')
+        // Microsoft packages on Linux use lowercase directory names; custom packages use mixed-case.
+        language: locale.split('-').map((part, i) => i === 0 ? part.toLowerCase() : part.toUpperCase()).join('-'),
         filePath: path.join(localeDir, file),
       });
     }

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -423,18 +423,19 @@ export class XppSymbolIndex {
     `);
 
     // Only index en-US rows to keep FTS compact (~5x smaller on typical installs)
+    // Case-insensitive: Microsoft packages store language as 'en-us' from Linux directory names
     this.labelsDb.exec(`
-      CREATE TRIGGER IF NOT EXISTS labels_ai AFTER INSERT ON labels WHEN new.language = 'en-US' BEGIN
+      CREATE TRIGGER IF NOT EXISTS labels_ai AFTER INSERT ON labels WHEN LOWER(new.language) = 'en-us' BEGIN
         INSERT INTO labels_fts(rowid, label_id, text, comment)
         VALUES (new.id, new.label_id, new.text, new.comment);
       END;
 
-      CREATE TRIGGER IF NOT EXISTS labels_ad AFTER DELETE ON labels WHEN old.language = 'en-US' BEGIN
+      CREATE TRIGGER IF NOT EXISTS labels_ad AFTER DELETE ON labels WHEN LOWER(old.language) = 'en-us' BEGIN
         INSERT INTO labels_fts(labels_fts, rowid, label_id, text, comment)
         VALUES ('delete', old.id, old.label_id, old.text, old.comment);
       END;
 
-      CREATE TRIGGER IF NOT EXISTS labels_au AFTER UPDATE ON labels WHEN old.language = 'en-US' OR new.language = 'en-US' BEGIN
+      CREATE TRIGGER IF NOT EXISTS labels_au AFTER UPDATE ON labels WHEN LOWER(old.language) = 'en-us' OR LOWER(new.language) = 'en-us' BEGIN
         INSERT INTO labels_fts(labels_fts, rowid, label_id, text, comment)
         VALUES ('delete', old.id, old.label_id, old.text, old.comment);
         INSERT INTO labels_fts(rowid, label_id, text, comment)
@@ -2603,10 +2604,11 @@ export class XppSymbolIndex {
   rebuildLabelsFts(): void {
     // Clear existing FTS index
     this.labelsDb.exec(`INSERT INTO labels_fts(labels_fts) VALUES('delete-all')`);
-    // Re-populate with en-US rows only
+    // Re-populate with en-US rows only (case-insensitive: Microsoft packages store
+    // locale as 'en-us' from Linux-unzipped directory names, custom packages use 'en-US')
     this.labelsDb.exec(`
       INSERT INTO labels_fts(rowid, label_id, text, comment)
-      SELECT id, label_id, text, comment FROM labels WHERE language = 'en-US'
+      SELECT id, label_id, text, comment FROM labels WHERE LOWER(language) = 'en-us'
     `);
   }
 
@@ -2717,7 +2719,7 @@ export class XppSymbolIndex {
         SELECT label_id, label_file_id, model, language, text, comment, file_path, 0 as rank
         FROM labels
         WHERE (text LIKE ? OR label_id LIKE ?)
-          AND language = ?`;
+          AND LOWER(language) = LOWER(?)`;
       if (model)       sql += `\n          AND model = ?`;
       if (labelFileId) sql += `\n          AND label_file_id = ?`;
       sql += `\n        LIMIT ?`;


### PR DESCRIPTION
## Root cause

Label files under Microsoft packages store their locale folder as lowercase `en-us`. Custom packages use `en-US`. Hard-coded language comparisons excluded one set, dropping ~114,583 Microsoft package labels silently from the FTS index.

## Changes

- **`labelParser.ts`** — normalize locale to BCP-47 canonical form on parse (`en-us` → `en-US`)
- **`symbolIndex.ts`** — wrap all `language =` comparisons in `LOWER()` in the FTS rebuild query, `searchLabelsLike`, and the three live triggers (`labels_ai`, `labels_au`, `labels_ad`)

## Verification

- FTS index row count: **257,640 → 372,223** (+114,583 previously missing Microsoft labels)
- `search_labels(query="vendor confirmation history")` now returns results from Microsoft Foundation model labels that were previously missing entirely
