### PR TITLE
feat(multi-instance): detect and handle UDE upgrades

### DIFF
--- a/instances/rebuild-instance.ps1
+++ b/instances/rebuild-instance.ps1
@@ -69,6 +69,48 @@ function Show-MissingSettings([System.IO.DirectoryInfo]$inst) {
     return $true
 }
 
+# ── Helper: normalise XPP_CONFIG_NAME to the full versioned filename ────────
+# If the .env has a short name (e.g. "myenv-dev"), resolve it to the current
+# versioned file (e.g. "myenv-dev___10.0.2345.153") and rewrite the .env so
+# run-instance can later detect UDE upgrades with a plain file-exists check.
+function Normalize-XppConfigName([string]$envFile) {
+    $envType = Get-EnvValue $envFile 'DEV_ENVIRONMENT_TYPE'
+    if ($envType -eq 'traditional') { return }
+
+    $configName = Get-EnvValue $envFile 'XPP_CONFIG_NAME'
+    if (-not $configName) { return }
+    # Already a full versioned name
+    if ($configName -match '^(.+)___(.+)$') { return }
+
+    $configDir = Join-Path $env:LOCALAPPDATA 'Microsoft\Dynamics365\XPPConfig'
+    if (-not (Test-Path $configDir)) { return }
+
+    $match = @(Get-ChildItem -Path $configDir -Filter '*.json' -File |
+        Where-Object { $_.Name -match "^$([regex]::Escape($configName))___(.+)\.json$" } |
+        Sort-Object LastWriteTime -Descending)
+    if ($match.Count -eq 0) {
+        Write-Host ''
+        Write-Host "WARNING: XPP_CONFIG_NAME '$configName' does not match any config in $configDir" -ForegroundColor Yellow
+        Write-Host '  Leaving .env unchanged; rebuild will likely fail.' -ForegroundColor Yellow
+        return
+    }
+
+    $full = $match[0].BaseName
+    $content = Get-Content $envFile -Raw
+    $content = $content -replace '(?m)^XPP_CONFIG_NAME=.*$', "XPP_CONFIG_NAME=$full"
+    Set-Content -Path $envFile -Value $content -NoNewline
+
+    Write-Host ''
+    Write-Host "Expanded XPP_CONFIG_NAME: $configName -> $full" -ForegroundColor Cyan
+}
+
+# ── Helper: read a value from an .env file ─────────────────────────────────
+function Get-EnvValue([string]$envFile, [string]$key) {
+    $line = Select-String -Path $envFile -Pattern "^\s*$key\s*=" -List | Select-Object -First 1
+    if ($line) { return ($line.Line -replace "^\s*$key\s*=\s*", '').Trim() }
+    return $null
+}
+
 # ── Helper: rebuild a single instance ───────────────────────────────────────
 function Rebuild-SingleInstance([System.IO.DirectoryInfo]$inst) {
     $envFile = Join-Path $inst.FullName '.env'
@@ -79,6 +121,8 @@ function Rebuild-SingleInstance([System.IO.DirectoryInfo]$inst) {
     Write-Host "Rebuilding: $($inst.Name)" -ForegroundColor Green
     Write-Host "Config: $envFile" -ForegroundColor DarkGray
     Write-Host ('=' * 60) -ForegroundColor DarkGray
+
+    Normalize-XppConfigName $envFile
 
     Write-Host ''
     Write-Host '[1/2] Extracting metadata...' -ForegroundColor Cyan

--- a/instances/run-instance.ps1
+++ b/instances/run-instance.ps1
@@ -56,9 +56,41 @@ if ($InstanceName) {
     $selected = $instances[$index]
 }
 
+# ── Helper: read a value from an .env file ─────────────────────────────────
+function Get-EnvValue([string]$envFile, [string]$key) {
+    $line = Select-String -Path $envFile -Pattern "^\s*$key\s*=" -List | Select-Object -First 1
+    if ($line) { return ($line.Line -replace "^\s*$key\s*=\s*", '').Trim() }
+    return $null
+}
+
 # ── Run ─────────────────────────────────────────────────────────────────────
 $envFile = Join-Path $selected.FullName '.env'
 $env:ENV_FILE = $envFile
+
+# ── Warn if XPP_CONFIG_NAME no longer resolves ──────────────────────────────
+$envType = Get-EnvValue $envFile 'DEV_ENVIRONMENT_TYPE'
+$configName = Get-EnvValue $envFile 'XPP_CONFIG_NAME'
+if ($configName -and ($envType -ne 'traditional')) {
+    # Rebuild normalises XPP_CONFIG_NAME to the full versioned filename, so a
+    # plain file-exists check is enough: if the pinned file is gone, the UDE
+    # was upgraded and the DB is stale.
+    $configDir = Join-Path $env:LOCALAPPDATA 'Microsoft\Dynamics365\XPPConfig'
+    $configPath = Join-Path $configDir "$configName.json"
+    if (-not (Test-Path $configPath)) {
+        Write-Host ''
+        Write-Host 'WARNING: XPP_CONFIG_NAME does not match any file in' -ForegroundColor Yellow
+        Write-Host "  $configDir" -ForegroundColor Yellow
+        Write-Host "  Current value: $configName" -ForegroundColor Yellow
+        Write-Host '  The UDE may have been upgraded since this instance was configured.' -ForegroundColor Yellow
+        Write-Host "  Fix with:  .\instances\upgrade-instance.ps1 $($selected.Name)" -ForegroundColor Yellow
+        Write-Host ''
+        $answer = Read-Host 'Continue anyway? [y/N]'
+        if ($answer -ne 'y') {
+            Write-Host 'Aborted.' -ForegroundColor DarkGray
+            exit 0
+        }
+    }
+}
 
 Write-Host ''
 Write-Host "Starting instance: $($selected.Name)" -ForegroundColor Green

--- a/instances/upgrade-instance.ps1
+++ b/instances/upgrade-instance.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+    Repoint an MCP server instance at a new XPP config and rebuild its databases.
+.DESCRIPTION
+    Use this after upgrading the UDE version for an environment (Microsoft drops
+    a new XPPConfig file with a new FrameworkDirectory). Pick the instance, pick
+    the new config, and this will update the instance's .env and trigger a rebuild.
+
+    You can pass the instance name directly: .\instances\upgrade-instance.ps1 myinstance
+#>
+param(
+    [string]$InstanceName
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$instancesDir = Join-Path $repoRoot 'instances'
+
+# ── Discover instances ──────────────────────────────────────────────────────
+$instances = @(Get-ChildItem -Path $instancesDir -Directory -ErrorAction SilentlyContinue |
+    Where-Object { Test-Path (Join-Path $_.FullName '.env') } |
+    Sort-Object Name)
+
+if ($instances.Count -eq 0) {
+    Write-Host 'No instances found. Run .\instances\add-instance.ps1 to create one.' -ForegroundColor Yellow
+    exit 1
+}
+
+# ── Helper: read a value from an .env file ──────────────────────────────────
+function Get-EnvValue([string]$envFile, [string]$key) {
+    $line = Select-String -Path $envFile -Pattern "^\s*$key\s*=" -List | Select-Object -First 1
+    if ($line) { return ($line.Line -replace "^\s*$key\s*=\s*", '').Trim() }
+    return $null
+}
+
+# ── Select instance ─────────────────────────────────────────────────────────
+if ($InstanceName) {
+    $selected = $instances | Where-Object { $_.Name -eq $InstanceName }
+    if (-not $selected) {
+        Write-Host "Instance '$InstanceName' not found." -ForegroundColor Red
+        exit 1
+    }
+} else {
+    Write-Host ''
+    Write-Host 'Available instances:' -ForegroundColor Cyan
+    Write-Host ''
+    for ($i = 0; $i -lt $instances.Count; $i++) {
+        $envFile = Join-Path $instances[$i].FullName '.env'
+        $port = Get-EnvValue $envFile 'PORT'
+        $cfg = Get-EnvValue $envFile 'XPP_CONFIG_NAME'
+        Write-Host "  $($i + 1). $($instances[$i].Name)  " -NoNewline -ForegroundColor White
+        Write-Host "(port $port)" -NoNewline -ForegroundColor DarkGray
+        if ($cfg) { Write-Host "  [$cfg]" -ForegroundColor DarkGray } else { Write-Host '' }
+    }
+    Write-Host ''
+    $choice = Read-Host 'Select instance [number]'
+    $index = [int]$choice - 1
+    if ($index -lt 0 -or $index -ge $instances.Count) {
+        Write-Host 'Invalid selection.' -ForegroundColor Red
+        exit 1
+    }
+    $selected = $instances[$index]
+}
+
+$instanceEnv = Join-Path $selected.FullName '.env'
+$currentConfig = Get-EnvValue $instanceEnv 'XPP_CONFIG_NAME'
+
+Write-Host ''
+Write-Host "Instance: $($selected.Name)" -ForegroundColor Green
+if ($currentConfig) {
+    Write-Host "Current XPP_CONFIG_NAME: $currentConfig" -ForegroundColor DarkGray
+} else {
+    Write-Host 'Current XPP_CONFIG_NAME: (not set)' -ForegroundColor DarkGray
+}
+
+# ── List available XPP configs ──────────────────────────────────────────────
+$configDir = Join-Path $env:LOCALAPPDATA 'Microsoft\Dynamics365\XPPConfig'
+if (-not (Test-Path $configDir)) {
+    Write-Host ''
+    Write-Host "No XPP config directory found at: $configDir" -ForegroundColor Yellow
+    Write-Host 'This directory is created by Power Platform Tools in VS2022.' -ForegroundColor Gray
+    exit 1
+}
+
+$configs = @(Get-ChildItem -Path $configDir -Filter '*.json' -File |
+    Where-Object { $_.Name -match '^(.+)___(.+)\.json$' } |
+    Sort-Object LastWriteTime -Descending)
+
+if ($configs.Count -eq 0) {
+    Write-Host "No XPP config files found in: $configDir" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'Available XPP Configs' -ForegroundColor Cyan
+Write-Host '=====================' -ForegroundColor Cyan
+Write-Host ''
+
+for ($i = 0; $i -lt $configs.Count; $i++) {
+    $file = $configs[$i]
+    $match = [regex]::Match($file.Name, '^(.+)___(.+)\.json$')
+    $name = $match.Groups[1].Value
+    $version = $match.Groups[2].Value
+
+    $json = Get-Content $file.FullName -Raw | ConvertFrom-Json
+    $customPath = $json.ModelStoreFolder
+    $msPath = $json.FrameworkDirectory
+
+    $suffix = ''
+    if ($i -eq 0) { $suffix += ' (newest)' }
+    if ($currentConfig -and ($file.BaseName -eq $currentConfig -or $name -eq $currentConfig)) {
+        $suffix += ' (current)'
+    }
+
+    Write-Host "  [$($i + 1)] " -NoNewline -ForegroundColor White
+    Write-Host "$name" -NoNewline -ForegroundColor Green
+    Write-Host "  v$version$suffix" -ForegroundColor Gray
+    Write-Host "      Custom:    $customPath" -ForegroundColor DarkGray
+    Write-Host "      Microsoft: $msPath" -ForegroundColor DarkGray
+    Write-Host ''
+}
+
+$selection = Read-Host "Select config (1-$($configs.Count)), or Enter for newest"
+if ([string]::IsNullOrWhiteSpace($selection)) {
+    $selectedCfg = $configs[0]
+} else {
+    $idx = [int]$selection - 1
+    if ($idx -lt 0 -or $idx -ge $configs.Count) {
+        Write-Host 'Invalid selection.' -ForegroundColor Red
+        exit 1
+    }
+    $selectedCfg = $configs[$idx]
+}
+
+$newConfigName = $selectedCfg.BaseName  # filename without .json
+
+Write-Host ''
+Write-Host 'Change summary:' -ForegroundColor Cyan
+if ($currentConfig) {
+    Write-Host "  was: $currentConfig" -ForegroundColor DarkYellow
+} else {
+    Write-Host '  was: (not set)' -ForegroundColor DarkYellow
+}
+Write-Host "  now: $newConfigName" -ForegroundColor Green
+
+if ($currentConfig -eq $newConfigName) {
+    Write-Host ''
+    Write-Host 'XPP_CONFIG_NAME is unchanged.' -ForegroundColor Yellow
+    $answer = Read-Host 'Rebuild anyway? [y/N]'
+    if ($answer -ne 'y') {
+        Write-Host 'Aborted.' -ForegroundColor DarkGray
+        exit 0
+    }
+} else {
+    Write-Host ''
+    $answer = Read-Host 'Write this to the instance .env and rebuild? [Y/n]'
+    if ($answer -eq 'n') {
+        Write-Host 'Aborted.' -ForegroundColor DarkGray
+        exit 0
+    }
+}
+
+# ── Update the instance .env ────────────────────────────────────────────────
+if ($currentConfig -ne $newConfigName) {
+    $content = Get-Content $instanceEnv -Raw
+    if ($content -match '(?m)^XPP_CONFIG_NAME=.*$') {
+        $content = $content -replace '(?m)^XPP_CONFIG_NAME=.*$', "XPP_CONFIG_NAME=$newConfigName"
+    } elseif ($content -match '(?m)^#\s*XPP_CONFIG_NAME=') {
+        $content = $content -replace '(?m)^#\s*XPP_CONFIG_NAME=.*$', "XPP_CONFIG_NAME=$newConfigName"
+    } else {
+        $content = $content.TrimEnd() + "`nXPP_CONFIG_NAME=$newConfigName`n"
+    }
+    Set-Content -Path $instanceEnv -Value $content -NoNewline
+    Write-Host ''
+    Write-Host "Updated: $instanceEnv" -ForegroundColor Cyan
+    Write-Host "  XPP_CONFIG_NAME=$newConfigName" -ForegroundColor DarkGray
+}
+
+# ── Hand off to rebuild-instance.ps1 ────────────────────────────────────────
+Write-Host ''
+Write-Host 'Starting rebuild...' -ForegroundColor Cyan
+& (Join-Path $PSScriptRoot 'rebuild-instance.ps1') $selected.Name
+exit $LASTEXITCODE


### PR DESCRIPTION
 ## Summary

  Builds on PR #445. When Microsoft ships a new UDE version, a new
  `XPPConfig` file is dropped with an updated `FrameworkDirectory`, which
  silently invalidates previously-indexed metadata for that instance.
  This change detects the situation at startup and provides a guided
  upgrade path.

  - **`instances/upgrade-instance.ps1`** (new): pick an instance, pick a
    new XPPConfig from `%LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig`,
    rewrite `XPP_CONFIG_NAME` in the instance `.env`, then hand off to
    `rebuild-instance.ps1`.
  - **`instances/rebuild-instance.ps1`**: normalises `XPP_CONFIG_NAME` to
    the full versioned filename (e.g. `myenv-dev___10.0.2345.153`) so a
    later existence check is unambiguous. Skipped for traditional envs.
  - **`instances/run-instance.ps1`**: warns if the pinned
    `XPP_CONFIG_NAME` no longer resolves to a real file (UDE was
    upgraded since this instance was configured) and points the user at
    `upgrade-instance.ps1`.

  ## Test plan

  - [ ] Run `instances/run-instance.ps1` on an instance whose
    `XPP_CONFIG_NAME` references an existing config — starts normally,
    no warning.
  - [ ] Manually edit an instance `.env` so `XPP_CONFIG_NAME` points to
    a non-existent file — `run-instance.ps1` warns and offers to abort.
  - [ ] Run `instances/upgrade-instance.ps1 <instance>` — lists configs,
    marks current/newest, rewrites `.env`, kicks off rebuild.
  - [ ] Run `instances/rebuild-instance.ps1` on an instance with a
    short-name `XPP_CONFIG_NAME` (`myenv-dev`) — value is rewritten to
    the versioned form before rebuild proceeds.
  - [ ] Traditional environment (`DEV_ENVIRONMENT_TYPE=traditional`) —
    normalisation is skipped and `run-instance.ps1` does not warn.