### PR TITLE
fix(bp-check): fix run_bp_check for UDE environments

### DIFF
--- a/bridge/D365MetadataBridge/Program.cs
+++ b/bridge/D365MetadataBridge/Program.cs
@@ -29,11 +29,11 @@ namespace D365MetadataBridge
     /// </summary>
     static class Program
     {
-        private static string _packagesPath = @"K:\AosService\PackagesLocalDirectory";
+        private static string _packagesPath = string.Empty;
         private static string? _referencePackagesPath = null; // UDE: Microsoft FrameworkDirectory packages path
-        private static string? _binPath = null; // Explicit bin path (UDE: microsoftPackagesPath/bin)
+        private static string? _binPath = null;               // Explicit bin path (UDE: microsoftPackagesPath/bin)
         private static string _xrefServer = "localhost";
-        private static string _xrefDatabase = "DYNAMICSXREFDB";
+        private static string _xrefDatabase = string.Empty;
         private static string? _logFile = null;
         private static readonly TextWriter Log = Console.Error;
 

--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -48,17 +48,8 @@ export const runBpCheckTool = async (params: any, _context: any) => {
       };
     }
 
-    // Resolve project path — required by most xppbp.exe versions
+    // Resolve project path — optional in UDE environments where xppbp no longer requires -vsproj
     const resolvedProjectPath = params.projectPath || await configManager.getProjectPath();
-    if (!resolvedProjectPath) {
-      return {
-        content: [{
-          type: 'text',
-          text: '❌ Cannot determine project path.\n\nProvide projectPath parameter or set it in .mcp.json:\n```json\n{ "servers": { "context": { "projectPath": "C:\\\\path\\\\to\\\\MyProject.rnrproj" } } }\n```'
-        }],
-        isError: true
-      };
-    }
 
     // In UDE the custom packages path (ModelStoreFolder) is the metadata root,
     // while the framework packages path (FrameworkDirectory) is the binaries root.
@@ -117,7 +108,7 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     // --- First attempt: modern -metadata: flag ---
     const args = buildArgs('-metadata:');
     const { combined, lastStdout, lastStderr } = await withOperationLock(
-      `bp:${resolvedProjectPath}`,
+      `bp:${modelName}`,
       async () => {
         console.error(`[run_bp_check] Attempt 1: "${xppbpPath}" ${args.join(' ')}`);
         try {
@@ -174,7 +165,8 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     return {
       content: [{
         type: 'text',
-        text: `${summary}\n\nModel: ${modelName}\nProject: ${resolvedProjectPath}` +
+        text: `${summary}\n\nModel: ${modelName}` +
+          (resolvedProjectPath ? `\nProject: ${resolvedProjectPath}` : '') +
           (targetFilter ? `\nFilter: ${targetFilter}` : '') +
           `\n\n${details}`
       }]

--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -3,14 +3,13 @@ import { execFile } from 'child_process';
 import util from 'util';
 import path from 'path';
 import fs from 'fs/promises';
-import os from 'os';
 import { getConfigManager } from '../utils/configManager.js';
 import { withOperationLock } from '../utils/operationLocks.js';
 
 const execFileAsync = util.promisify(execFile);
 
 // Keyword that xppbp.exe prints when it doesn't recognise the arguments
-const HELP_TEXT_PATTERN = /^usage:|BPCheck Tool|^xppbp\.exe|unrecognized|missing required/im;
+const HELP_TEXT_PATTERN = /^usage:|BPCheck Tool|^xppbp\.exe|unrecognized|missing required|X\+\+ Best Practice Options/im;
 
 export const runBpCheckToolDefinition = {
   name: 'run_bp_check',
@@ -40,11 +39,6 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     const configManager = getConfigManager();
     await configManager.ensureLoaded();
 
-    // Resolve package path
-    const packagesRoot = params.packagePath
-      || configManager.getPackagePath()
-      || 'K:\\AosService\\PackagesLocalDirectory';
-
     // Resolve model name
     const modelName = params.modelName || configManager.getModelName();
     if (!modelName) {
@@ -66,33 +60,52 @@ export const runBpCheckTool = async (params: any, _context: any) => {
       };
     }
 
-    // Locate xppbp.exe
+    // In UDE the custom packages path (ModelStoreFolder) is the metadata root,
+    // while the framework packages path (FrameworkDirectory) is the binaries root.
+    // For traditional environments both roles are served by packagesRoot.
+    const microsoftPackagesPath = await configManager.getMicrosoftPackagesPath();
+    const customPackagesPath = await configManager.getCustomPackagesPath();
+
+    // Explicit override from params takes priority; otherwise derive from XPP config
+    // so the version is never hardcoded — it comes from XPP_CONFIG_NAME in the instance .env.
+    const packagesRoot = params.packagePath
+      || microsoftPackagesPath
+      || configManager.getPackagePath()
+      || 'K:\\AosService\\PackagesLocalDirectory';
+
+    // Locate xppbp.exe — always in the Microsoft/framework packages Bin, not the custom model folder.
     const xppbpPath = path.join(packagesRoot, 'Bin', 'xppbp.exe');
     try {
       await fs.access(xppbpPath);
     } catch {
       return {
-        content: [{ type: 'text', text: `❌ xppbp.exe not found at: ${xppbpPath}\n\nMake sure PackagesLocalDirectory is correctly configured in .mcp.json (packagePath).` }],
+        content: [{ type: 'text', text: `❌ xppbp.exe not found at: ${xppbpPath}\n\nMake sure XPP_CONFIG_NAME is set correctly in your instance .env so the FrameworkDirectory is resolved automatically.` }],
         isError: true
       };
     }
 
-    // Temp XML log file — xppbp writes structured results here
-    const logFile = path.join(os.tmpdir(), `xppbp_${Date.now()}.xml`);
+    // metadataPath: where X++ source XML lives (custom model metadata)
+    const metadataPath = customPackagesPath || packagesRoot;
+    // packagesRootPath: where compiled binaries live (framework packages)
+    const packagesRootPath = microsoftPackagesPath || packagesRoot;
 
     /**
      * Build the args array for one invocation attempt.
-     * D365FO 10.0.20+ uses  -metadata:<path>  (preferred).
-     * Older builds used      -packagesroot:<path>.
-     * We try the modern flag first and fall back on the legacy flag when
-     * the output looks like the xppbp help/usage text.
+     * Required flags (modern xppbp.exe):
+     *   -metadata:<path>     — custom model metadata root (ModelStoreFolder in UDE)
+     *   -module:<name>       — package/module name (same as model for single-model packages)
+     *   -model:<name>        — model name
+     *   -packagesRoot:<path> — framework binaries root (FrameworkDirectory in UDE)
+     *   -all                 — check all element types
+     * Note: -car: generates an Excel (.xlsx) file, not XML — we rely on stdout instead.
      */
-    const buildArgs = (metadataFlag: '-metadata:' | '-packagesroot:'): string[] => {
+    const buildArgs = (metadataFlag: string): string[] => {
       const a: string[] = [
-        `${metadataFlag}${packagesRoot}`,
+        `${metadataFlag}${metadataPath}`,
+        `-module:${modelName}`,
         `-model:${modelName}`,
-        `-vsproj:${resolvedProjectPath}`,
-        `-xmlLog:${logFile}`
+        `-packagesRoot:${packagesRootPath}`,
+        `-all`,
       ];
       if (targetFilter) a.push(`-filter:${targetFilter}`);
       return a;
@@ -116,7 +129,7 @@ export const runBpCheckTool = async (params: any, _context: any) => {
 
         let localCombined = [stdout, stderr].filter(Boolean).join('\n').trim();
 
-        // --- Fallback: legacy -packagesroot: flag ---
+        // --- Fallback: legacy -packagesroot: flag (older xppbp without -metadata) ---
         if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
           const fallbackArgs = buildArgs('-packagesroot:');
           console.error(`[run_bp_check] Attempt 2 (legacy flag): "${xppbpPath}" ${fallbackArgs.join(' ')}`);
@@ -147,15 +160,9 @@ export const runBpCheckTool = async (params: any, _context: any) => {
       };
     }
 
-    // --- Read XML log file if xppbp wrote one ---
-    let logContent = '';
-    try {
-      logContent = await fs.readFile(logFile, 'utf-8');
-      await fs.unlink(logFile).catch(() => { /* best-effort cleanup */ });
-    } catch {
-      // xppbp didn't write a log file — fall back to stdout/stderr
-      logContent = combined;
-    }
+    // Use stdout/stderr directly — xppbp prints violations as plain text.
+    // (-car: generates an Excel file which is not human-readable as text.)
+    const logContent = combined;
 
     // Detect violations in XML log or plain text output
     const hasErrors = /BPError|<Diagnostic|severity="error"/i.test(logContent)


### PR DESCRIPTION
- Add 'X++ Best Practice Options' to help-text detection pattern so xppbp output is no longer misread as a successful pass
- Replace non-existent -vsproj: and -xmlLog: flags with correct ones: -module:, -all (required), drop -car: (generates Excel, not XML)
- In UDE, resolve xppbp.exe from microsoftPackagesPath (FrameworkDirectory from XPP_CONFIG_NAME) instead of customPackagesPath, so no version path is hardcoded in source or instance .env
- Separate -metadata: (ModelStoreFolder / custom code) from -packagesRoot: (FrameworkDirectory / MS binaries) for correct UDE invocation
- Remove hardcoded user-specific default paths from Program.cs bridge