### PR TITLE
feat(get_workspace_info): expose UDE FrameworkDirectory

### DIFF
--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -208,8 +208,8 @@ with VS 2022's `.mcp.json` parser.
 | `workspacePath` | `D365FO_WORKSPACE_PATH` | Recommended | Path to your model: `...\PackagesLocalDirectory\PackageName\ModelName`. All three values are derived from it automatically. |
 | `packagePath` | `D365FO_PACKAGE_PATH` | Optional | Base PackagesLocalDirectory path. Auto-extracted from `workspacePath` — only needed when `workspacePath` is not set. |
 | `modelName` | `D365FO_MODEL_NAME` | Optional | Explicit model name override — only needed when it differs from the last `workspacePath` segment. |
-| `customPackagesPath` | `D365FO_CUSTOM_PACKAGES_PATH` | Optional | UDE: Custom X++ code root (from XPP config `ModelStoreFolder`). |
-| `microsoftPackagesPath` | `D365FO_MICROSOFT_PACKAGES_PATH` | Optional | UDE: Microsoft X++ root (from XPP config `FrameworkDirectory`). |
+| `customPackagesPath` | `D365FO_CUSTOM_PACKAGES_PATH` | Optional | UDE: Custom X++ code root (from XPP config `ModelStoreFolder`). Surfaced at runtime by `get_workspace_info` as `Package path`. |
+| `microsoftPackagesPath` | `D365FO_MICROSOFT_PACKAGES_PATH` | Optional | UDE: Microsoft X++ root (from XPP config `FrameworkDirectory`). Surfaced at runtime by `get_workspace_info` as `Framework dir`; read-only — never used as a target for file creation. |
 | `devEnvironmentType` | `D365FO_DEV_ENVIRONMENT_TYPE` | Optional | `auto` (default), `traditional`, or `ude`. Controls path resolution behavior. |
 | `projectPath` | `D365FO_PROJECT_PATH` | Optional | Full path to your `.rnrproj` file. Auto-detected from roots/list (stdio) or D365FO_SOLUTIONS_PATH. |
 | `solutionPath` | `D365FO_SOLUTION_PATH` | Optional | Visual Studio solution folder. Used when `projectPath` is not set. |

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1125,11 +1125,17 @@ auto-detected model name as a concrete fix suggestion.
 > stop and fix `.mcp.json` before creating any files — without the correct model name, new
 > objects will land in the wrong model.
 
+On UDE / Power Platform Tools environments, D365FO splits metadata into two roots: a writable
+custom root (`Package path`, from `ModelStoreFolder`) and a read-only Microsoft root
+(`Framework dir`, from `FrameworkDirectory`). Both are reported so callers can resolve symbols
+across either tree, but file creation must always target the package path.
+
 **Takes no parameters.**
 
 **Returns:**
 - Model name (from `.mcp.json`) and whether it is a placeholder
-- Package path and project path
+- Package path (custom metadata root) and project path
+- Framework directory (Microsoft metadata root) — UDE only; empty on classic VMs
 - Environment type (`ude`, `traditional`, or `azure`)
 - If placeholder: the real model name auto-detected from `.rnrproj` + exact fix instruction
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -2461,7 +2461,10 @@ Examples:
         name: 'get_workspace_info',
         description: `🔌 ALWAYS call this FIRST at the start of every D365FO session to verify the workspace configuration.
 
-Returns the configured model name, package path, project path, environment type, EXTENSION_PREFIX value, and effective object prefix.
+Returns the configured model name, package path (custom metadata root), framework directory (Microsoft metadata root, populated only on UDE / Power Platform Tools setups), project path, environment type, EXTENSION_PREFIX value, and effective object prefix.
+
+On UDE there are two metadata roots: custom code lives under the package path, Microsoft standard code under the framework dir. Only the package path is writable — never create or modify files under the framework dir.
+
 Explicitly flags whether the model name is a placeholder (MyModel, MyPackage, etc.) — if so, STOP and inform the user before doing anything else.
 Also warns when EXTENSION_PREFIX is not set in the server environment (prefix will fall back to model name, which may be wrong for models with hyphens like "fm-mcp").
 

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -417,6 +417,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         const { modelName, modelSource, projectPath, projectSource, packagePath, packageSource } =
           await configManager.getWorkspaceInfoDiagnostics();
         const envType = await configManager.getDevEnvironmentType();
+        const frameworkDirectory = await configManager.getMicrosoftPackagesPath();
 
         // Prefix diagnostics
         const extensionPrefixEnv = process.env.EXTENSION_PREFIX?.trim() || null;
@@ -446,7 +447,8 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           `## D365FO Workspace Configuration`,
           ``,
           `Model name      : ${modelName ?? '(not configured)'}  (source: ${modelSource})`,
-          `Package path    : ${packagePath ?? '(not configured)'}  (source: ${packageSource})`,
+          `Package path    : ${packagePath ?? '(not configured)'}  (custom metadata, source: ${packageSource})`,
+          `Framework dir   : ${frameworkDirectory ?? '(not applicable — single-root setup)'}  (Microsoft metadata, read-only)`,
           `Project path    : ${projectPath ?? '(not detected)'}  (source: ${projectSource})`,
           `Env type        : ${envType}`,
           ``,


### PR DESCRIPTION
  ## Summary

  `get_workspace_info` now reports the Microsoft `FrameworkDirectory` in addition to the custom package path, so
  callers on UDE / Power Platform Tools setups can see both metadata roots at a glance.

  On UDE there are two metadata roots:
  - **Package path** — custom code root (from XPP config `ModelStoreFolder`), writable.
  - **Framework dir** — Microsoft standard code root (from XPP config `FrameworkDirectory`), read-only.

  The value already existed on `configManager` (`getMicrosoftPackagesPath()`) and was used by the bridge / BP
  check, but was never surfaced to the LLM through the workspace diagnostics tool. As a result, callers had no
  visible signal that a second metadata tree existed, and no clear pairing between the two.

  ## Changes

  - **`src/tools/toolHandler.ts`** — read `getMicrosoftPackagesPath()` and add a `Framework dir` line to the
  workspace block. Annotate both lines with their role (`custom metadata` vs. `Microsoft metadata, read-only`) so
  the dual-root pairing is self-documenting. On classic single-root environments the line falls back to `(not
  applicable — single-root setup)` instead of `(not configured)`, so the LLM doesn't flag a non-UDE setup as
  misconfigured.
  - **`src/server/mcpServer.ts`** — extend the `get_workspace_info` tool description to mention both roots, and
  explicitly warn that file creation must always target the package path, never the framework dir.
  - **`docs/MCP_TOOLS.md`** — update the Returns block and add a short UDE dual-root paragraph under the
  placeholder warning.
  - **`docs/MCP_CONFIG.md`** — cross-reference: the `customPackagesPath` and `microsoftPackagesPath` rows now point
   to their runtime labels (`Package path` / `Framework dir`) in `get_workspace_info` output.

  ## Why this matters for the LLM caller

  Without the framework dir in the diagnostics output, an LLM working on a UDE box only saw the writable custom
  root and had no way to discover where Microsoft standard metadata lived for symbol resolution. With the dual-root
   annotations in place, the LLM can:

  - Identify both metadata trees from a single tool call.
  - Tell at a glance which root is writable.
  - Avoid mistakenly passing the framework dir as `packagePath` to `create_d365fo_file`.

  ## Example output (UDE)

  ```
  ## D365FO Workspace Configuration

  Model name      : ContosoExt  (source: .mcp.json)
  Package path    : C:\Users\...\Metadata  (custom metadata, source: .mcp.json)
  Framework dir   : C:\Users\...\PackagesLocalDirectory  (Microsoft metadata, read-only)
  Project path    : K:\repos\ContosoExt\ContosoExt.rnrproj  (source: auto-detected from .rnrproj)
  Env type        : ude
  ```

  ## Example output (classic VM)

  ```
  Package path    : K:\AosService\PackagesLocalDirectory  (custom metadata, source: workspacePath)
  Framework dir   : (not applicable — single-root setup)  (Microsoft metadata, read-only)
  ```

  ## Test plan

  - [ ] Call `get_workspace_info` on a UDE environment with `D365FO_MICROSOFT_PACKAGES_PATH` set — verify
  `Framework dir` shows the configured path.
  - [ ] Call `get_workspace_info` on a UDE environment relying on XPP config auto-detection — verify the value
  comes through from `FrameworkDirectory`.
  - [ ] Call `get_workspace_info` on a classic VM (single-root) — verify the line shows `(not applicable —
  single-root setup)` rather than `(not configured)`.
  - [ ] Verify the surrounding placeholder / standard-model warnings still fire correctly.