### PR TITLE
fix(labels): preserve original line endings when writing .label.txt

### DIFF
--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -20,6 +20,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { getConfigManager } from '../utils/configManager.js';
 import { PackageResolver } from '../utils/packageResolver.js';
+import { detectEol } from '../utils/eolUtils.js';
 import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
 
 // UTF-8 BOM (Byte Order Mark)
@@ -114,15 +115,6 @@ const CreateLabelArgsSchema = z.object({
 });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-/** Detect the dominant line ending in a file. Defaults to CRLF for new/empty
- *  files — D365FO label files are Windows-native and TFVC tracks them as CRLF.
- *  Preserving the original EOL avoids VCS diffs that look like every line changed. */
-function detectEol(content: string): '\r\n' | '\n' {
-  if (content.includes('\r\n')) return '\r\n';
-  if (content.includes('\n')) return '\n';
-  return '\r\n';
-}
 
 /** Parse a .label.txt file into an ordered map: labelId → { text, comment } */
 function parseLabelMap(content: string): Map<string, { text: string; comment?: string }> {

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -115,6 +115,15 @@ const CreateLabelArgsSchema = z.object({
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+/** Detect the dominant line ending in a file. Defaults to CRLF for new/empty
+ *  files — D365FO label files are Windows-native and TFVC tracks them as CRLF.
+ *  Preserving the original EOL avoids VCS diffs that look like every line changed. */
+function detectEol(content: string): '\r\n' | '\n' {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\n')) return '\n';
+  return '\r\n';
+}
+
 /** Parse a .label.txt file into an ordered map: labelId → { text, comment } */
 function parseLabelMap(content: string): Map<string, { text: string; comment?: string }> {
   const map = new Map<string, { text: string; comment?: string }>();
@@ -148,8 +157,13 @@ function parseLabelMap(content: string): Map<string, { text: string; comment?: s
 
 /** Render a label map back to .label.txt content with UTF-8 BOM.
  *  When `sort` is true (default), entries are sorted alphabetically by label ID.
- *  When `sort` is false, entries are written in insertion order (existing + appended). */
-function serializeLabelMap(map: Map<string, { text: string; comment?: string }>, sort = true): string {
+ *  When `sort` is false, entries are written in insertion order (existing + appended).
+ *  `eol` should be the line ending detected from the existing file (defaults to CRLF for new files). */
+function serializeLabelMap(
+  map: Map<string, { text: string; comment?: string }>,
+  sort = true,
+  eol: '\r\n' | '\n' = '\r\n',
+): string {
   const entries = sort
     ? [...map.entries()].sort(([a], [b]) => a.localeCompare(b, 'en', { sensitivity: 'base' }))
     : [...map.entries()];
@@ -159,7 +173,7 @@ function serializeLabelMap(map: Map<string, { text: string; comment?: string }>,
     if (comment) lines.push(` ;${comment}`);
   }
   // End with a newline, prepend UTF-8 BOM for D365FO compatibility
-  return UTF8_BOM + lines.join('\n') + '\n';
+  return UTF8_BOM + lines.join(eol) + eol;
 }
 
 /** Write file with UTF-8 BOM signature */
@@ -390,6 +404,8 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
         // File doesn't exist yet — start empty
       }
 
+      // Preserve the existing file's line endings so VCS diffs only show the new label.
+      const eol = detectEol(content);
       const labelMap = parseLabelMap(content);
 
       // Duplicate check
@@ -405,8 +421,8 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       // Ensure the directory exists
       await fs.mkdir(langDir, { recursive: true });
 
-      // Write updated file with UTF-8 BOM
-      const newContent = serializeLabelMap(labelMap, shouldSort);
+      // Write updated file with UTF-8 BOM, preserving the original EOL style
+      const newContent = serializeLabelMap(labelMap, shouldSort, eol);
       await writeFileWithBom(txtPath, newContent);
       written.push(lang);
 

--- a/src/tools/renameLabel.ts
+++ b/src/tools/renameLabel.ts
@@ -19,6 +19,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { getConfigManager } from '../utils/configManager.js';
 import { PackageResolver } from '../utils/packageResolver.js';
+import { detectEol } from '../utils/eolUtils.js';
 
 // UTF-8 BOM
 const UTF8_BOM = '\uFEFF';
@@ -88,9 +89,7 @@ function escapeRegex(s: string): string {
 function renameLabelInTxt(content: string, oldId: string, newId: string): string | null {
   // Preserve the original line-ending style — D365FO .label.txt files are CRLF
   // in TFVC/Git, and silently rewriting them as LF makes every line look modified.
-  const eol: '\r\n' | '\n' = content.includes('\r\n')
-    ? '\r\n'
-    : (content.includes('\n') ? '\n' : '\r\n');
+  const eol = detectEol(content);
   const lines = stripBom(content).replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
   let found = false;
   const out: string[] = [];

--- a/src/tools/renameLabel.ts
+++ b/src/tools/renameLabel.ts
@@ -86,6 +86,11 @@ function escapeRegex(s: string): string {
  * Returns the new file content, or null if the label was not found.
  */
 function renameLabelInTxt(content: string, oldId: string, newId: string): string | null {
+  // Preserve the original line-ending style — D365FO .label.txt files are CRLF
+  // in TFVC/Git, and silently rewriting them as LF makes every line look modified.
+  const eol: '\r\n' | '\n' = content.includes('\r\n')
+    ? '\r\n'
+    : (content.includes('\n') ? '\n' : '\r\n');
   const lines = stripBom(content).replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
   let found = false;
   const out: string[] = [];
@@ -104,7 +109,7 @@ function renameLabelInTxt(content: string, oldId: string, newId: string): string
   }
 
   if (!found) return null;
-  return UTF8_BOM + out.join('\n');
+  return UTF8_BOM + out.join(eol);
 }
 
 /**

--- a/src/utils/eolUtils.ts
+++ b/src/utils/eolUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * EOL (line ending) detection utilities for file-writing operations.
+ *
+ * D365FO .label.txt files are Windows-native CRLF by convention (TFVC and Git
+ * both track them as CRLF). Tools that read-normalize-write must preserve the
+ * original line ending so VCS diffs only highlight the intentional changes.
+ */
+
+/**
+ * Detect the dominant line ending in a file's content.
+ *
+ * Strategy: first-CRLF-wins — any CRLF in the file is treated as evidence that
+ * the whole file is CRLF (the realistic D365FO failure mode is "tool stripped CRs
+ * from a CRLF file", not a genuinely mixed-EOL file we need to majority-vote on).
+ * Falls back to LF only when line endings are present but none are CRLF.
+ * Defaults to CRLF for brand-new or empty files to match D365FO conventions.
+ */
+export function detectEol(content: string): '\r\n' | '\n' {
+  if (content.includes('\r\n')) return '\r\n';
+  if (content.includes('\n')) return '\n';
+  return '\r\n';
+}

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -879,4 +879,41 @@ describe('rename_label', () => {
     const bareLfMatches = labelWrite!.content.match(/(?<!\r)\n/g);
     expect(bareLfMatches).toBeNull();
   });
+
+  it('preserves LF line endings when renaming inside a LF .label.txt', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: Array<{ path: string; content: string }> = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (p: string, content: string) => {
+      writeCalls.push({ path: p, content });
+    });
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    // LF source file — e.g. a repo checked out on Linux or with core.autocrlf=false.
+    (fsMock.promises.readFile as any).mockResolvedValue(
+      '\uFEFFAppleLabel=Apple text\nOldFeatureName=Some text\nZebraLabel=Zebra text\n',
+    );
+
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'OldFeatureName' }),
+    ]);
+
+    const result = await renameLabelTool(
+      req('rename_label', {
+        oldLabelId: 'OldFeatureName',
+        newLabelId: 'NewFeatureName',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+      }),
+      ctx,
+    );
+    if (result.isError) throw new Error(`rename_label failed: ${result.content[0].text}`);
+    expect(result.isError).toBeFalsy();
+    const labelWrite = writeCalls.find(c => c.path.endsWith('.label.txt'));
+    expect(labelWrite).toBeDefined();
+    // Renamed line must keep LF — tool must not upgrade a LF file to CRLF.
+    expect(labelWrite!.content).toContain('NewFeatureName=Some text\n');
+    expect(labelWrite!.content).toContain('AppleLabel=Apple text\n');
+    // No CRLF sequences must be present — file must stay pure LF.
+    expect(labelWrite!.content).not.toContain('\r\n');
+  });
 });

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -694,6 +694,97 @@ describe('create_label', () => {
       else process.env.LABEL_SORT_ORDER = origEnv;
     }
   });
+
+  it('preserves CRLF line endings when the original file uses CRLF', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: string[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (_p: string, content: string) => {
+      writeCalls.push(content);
+    });
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    // Existing file uses CRLF (Windows / TFVC default for D365FO label files)
+    (fsMock.promises.readFile as any).mockResolvedValueOnce(
+      '﻿AppleLabel=Apple text\r\nZebraLabel=Zebra text\r\n',
+    );
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'MiddleLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        translations: [{ language: 'en-US', text: 'Middle text' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const labelWrite = writeCalls.find(c => c.includes('MiddleLabel='));
+    expect(labelWrite).toBeDefined();
+    // The written file MUST keep CRLF — switching to LF makes every line look modified in VCS diffs.
+    expect(labelWrite).toContain('\r\n');
+    expect(labelWrite).toContain('AppleLabel=Apple text\r\n');
+    expect(labelWrite).toContain('MiddleLabel=Middle text\r\n');
+    // And it must not introduce bare LF (i.e. every LF should be preceded by CR)
+    const bareLfMatches = labelWrite!.match(/(?<!\r)\n/g);
+    expect(bareLfMatches).toBeNull();
+  });
+
+  it('preserves LF line endings when the original file uses LF', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: string[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (_p: string, content: string) => {
+      writeCalls.push(content);
+    });
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    (fsMock.promises.readFile as any).mockResolvedValueOnce(
+      '﻿AppleLabel=Apple text\nZebraLabel=Zebra text\n',
+    );
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'MiddleLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        translations: [{ language: 'en-US', text: 'Middle text' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const labelWrite = writeCalls.find(c => c.includes('MiddleLabel='));
+    expect(labelWrite).toBeDefined();
+    expect(labelWrite).not.toContain('\r\n');
+    expect(labelWrite).toContain('MiddleLabel=Middle text\n');
+  });
+
+  it('defaults to CRLF for a brand-new label file (no existing content)', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: Array<{ path: string; content: string }> = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (p: string, content: string) => {
+      writeCalls.push({ path: p, content });
+    });
+    // No existing language folders — triggers the createLabelFileIfMissing path
+    (fsMock.promises.readdir as any).mockResolvedValueOnce([]);
+    // readFile is never called when the file is brand-new; if it is, return empty
+    (fsMock.promises.readFile as any).mockResolvedValue('');
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'BrandNew',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        createLabelFileIfMissing: true,
+        updateIndex: false,
+        translations: [{ language: 'en-US', text: 'Brand new label' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const labelWrite = writeCalls.find(c => c.content.includes('BrandNew='));
+    expect(labelWrite).toBeDefined();
+    // New D365FO label files default to CRLF (Windows-native, matches TFVC defaults)
+    expect(labelWrite!.content).toContain('BrandNew=Brand new label\r\n');
+  });
 });
 
 // ─── rename_label ────────────────────────────────────────────────────────────
@@ -746,5 +837,46 @@ describe('rename_label', () => {
   it('returns error when required fields are missing', async () => {
     const result = await renameLabelTool(req('rename_label', { oldLabelId: 'Foo' }), ctx);
     expect(result.isError).toBe(true);
+  });
+
+  it('preserves CRLF line endings when renaming inside a CRLF .label.txt', async () => {
+    const fsMock = await import('fs');
+    const writeCalls: Array<{ path: string; content: string }> = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (p: string, content: string) => {
+      writeCalls.push({ path: p, content });
+    });
+    // First readdir call returns the language list; later collectFiles calls fall
+    // back to the default [] mock so the subsequent .xpp/.xml scan finds nothing.
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    // CRLF source file with the label to rename plus a couple of siblings.
+    // The rename tool reads the file three times (existence check, duplicate
+    // check, and the actual rewrite), so use mockResolvedValue.
+    (fsMock.promises.readFile as any).mockResolvedValue(
+      '﻿AppleLabel=Apple text\r\nOldFeatureName=Some text\r\nZebraLabel=Zebra text\r\n',
+    );
+
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'OldFeatureName' }),
+    ]);
+
+    const result = await renameLabelTool(
+      req('rename_label', {
+        oldLabelId: 'OldFeatureName',
+        newLabelId: 'NewFeatureName',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+      }),
+      ctx,
+    );
+    if (result.isError) throw new Error(`rename_label failed: ${result.content[0].text}`);
+    expect(result.isError).toBeFalsy();
+    const labelWrite = writeCalls.find(c => c.path.endsWith('.label.txt'));
+    expect(labelWrite).toBeDefined();
+    // Renamed line must use CRLF, and surrounding lines must not be silently downgraded to LF
+    expect(labelWrite!.content).toContain('NewFeatureName=Some text\r\n');
+    expect(labelWrite!.content).toContain('AppleLabel=Apple text\r\n');
+    const bareLfMatches = labelWrite!.content.match(/(?<!\r)\n/g);
+    expect(bareLfMatches).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

  `create_label` and `rename_label` were silently rewriting `.label.txt` files with LF line endings even when the
  original file used CRLF. Because D365FO `.label.txt` files are CRLF in TFVC/Git by convention, the result was a diff
  where **every existing line looked modified** — making code review on label changes effectively useless.

  ### Root cause

  Both tools read the file, normalized CRLF/CR → LF for parsing, and then serialized back using bare `\n`:

  - `src/tools/createLabel.ts` — `parseLabelMap` collapsed to LF, `serializeLabelMap` emitted `lines.join('\n')`.
  - `src/tools/renameLabel.ts` — `renameLabelInTxt` did the same `lines.join('\n')` after normalization.

  The parser normalizing is fine (it only consumes content); the bug was the writer not preserving what was there.

  ### Fix

  Detect the line ending from the file as read, thread it through the serializer, and write it back unchanged. Detection
   treats any CRLF in the file as evidence that the file is CRLF (first CRLF wins); falls back to LF only if there are
  line endings but none of them are CRLF; defaults to **CRLF** for a brand-new/empty file. CRLF-biased on purpose —
  D365FO `.label.txt` files are Windows-native CRLF by convention, and the realistic failure mode this fixes is "tool
  stripped CRs from a CRLF file," not a mixed-EOL file we need to majority-vote on.

  ```ts
  function detectEol(content: string): '\r\n' | '\n' {
    if (content.includes('\r\n')) return '\r\n';
    if (content.includes('\n')) return '\n';
    return '\r\n';
  }
  ```

  `serializeLabelMap` now takes an `eol` parameter (default `'\r\n'`); the call site passes `detectEol(content)` from
  the file just read. `renameLabel.ts` gets the same treatment inline inside `renameLabelInTxt`.

  `replaceReferences` (used for `.xpp` / `.xml` reference rewrites) was already safe — it's a literal `String.replace`
  and never touches line endings.

  ## Changes

  - `src/tools/createLabel.ts` — added `detectEol()`, `serializeLabelMap(map, sort, eol)`, EOL threaded through the
  write loop.
  - `src/tools/renameLabel.ts` — EOL detection inside `renameLabelInTxt`.
  - `tests/tools/labels.test.ts` — 4 new regression tests.
