### PR TITLE
Fix/478 enum xml format

### DIFF
--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -651,7 +651,8 @@ namespace D365MetadataBridge.Protocol
                                 ?? request.GetIntParam("value")
                                 ?? throw new ArgumentException("Missing: enumValue");
                             return _writeService!.AddEnumValue(enumName, valueName, value,
-                                request.GetStringParam("label"));
+                                request.GetStringParam("label"),
+                                request.GetStringParam("countryRegionCodes"));
                         });
 
                     case "modifyenumvalue":
@@ -984,7 +985,7 @@ namespace D365MetadataBridge.Protocol
                                         int.TryParse(ev?.ToString(), out enumVal);
                                     writeResult = _writeService.AddEnumValue(objectName,
                                         S("enumValueName") ?? S("valueName") ?? throw new ArgumentException("Missing: enumValueName"),
-                                        enumVal, S("label"));
+                                        enumVal, S("label"), S("countryRegionCodes"));
                                 }
                                 break;
 

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -563,6 +563,7 @@ namespace D365MetadataBridge.Services
                 {
                     var axVal = new AxEnumValue { Name = v.Name, Value = v.Value };
                     if (!string.IsNullOrEmpty(v.Label)) axVal.Label = v.Label;
+                    if (!string.IsNullOrEmpty(v.CountryRegionCodes)) axVal.CountryRegionCodes = v.CountryRegionCodes;
                     axEnum.AddEnumValue(axVal);
                 }
             }
@@ -967,6 +968,7 @@ namespace D365MetadataBridge.Services
                 {
                     var axVal = new AxEnumValue { Name = v.Name, Value = v.Value };
                     if (!string.IsNullOrEmpty(v.Label)) axVal.Label = v.Label;
+                    if (!string.IsNullOrEmpty(v.CountryRegionCodes)) axVal.CountryRegionCodes = v.CountryRegionCodes;
                     axExt.EnumValues.Add(axVal);
                 }
             }
@@ -1972,7 +1974,7 @@ namespace D365MetadataBridge.Services
         // ========================
 
         /// <summary>Adds a value to an enum.</summary>
-        public object AddEnumValue(string enumName, string valueName, int value, string? label)
+        public object AddEnumValue(string enumName, string valueName, int value, string? label, string? countryRegionCodes = null)
         {
             var axEnum = _provider.Enums.Read(enumName)
                 ?? throw new ArgumentException($"Enum '{enumName}' not found");
@@ -1980,6 +1982,7 @@ namespace D365MetadataBridge.Services
 
             var axVal = new AxEnumValue { Name = valueName, Value = value };
             if (!string.IsNullOrEmpty(label)) axVal.Label = label;
+            if (!string.IsNullOrEmpty(countryRegionCodes)) axVal.CountryRegionCodes = countryRegionCodes;
             axEnum.AddEnumValue(axVal);
 
             ((IMetaEnumProvider)_provider.Enums).Update(axEnum, msi);
@@ -3436,5 +3439,8 @@ namespace D365MetadataBridge.Services
 
         [System.Text.Json.Serialization.JsonPropertyName("label")]
         public string? Label { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("countryRegionCodes")]
+        public string? CountryRegionCodes { get; set; }
     }
 }

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -1433,10 +1433,11 @@ export async function bridgeAddEnumValue(
   valueName: string,
   value: number,
   label?: string,
+  countryRegionCodes?: string,
 ): Promise<{ success: boolean; message: string } | null> {
   if (!bridge?.isReady || !bridge.metadataAvailable) return null;
   try {
-    const result = await bridge.addEnumValue(enumName, valueName, value, label);
+    const result = await bridge.addEnumValue(enumName, valueName, value, label, countryRegionCodes);
     return {
       success: result.success,
       message: result.success

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -584,8 +584,8 @@ export class BridgeClient extends EventEmitter {
   }
 
   /** Add a value to an enum */
-  async addEnumValue(enumName: string, valueName: string, value: number, label?: string): Promise<BridgeWriteResult> {
-    return this.call<BridgeWriteResult>('addEnumValue', { objectName: enumName, enumValueName: valueName, enumValue: value, label });
+  async addEnumValue(enumName: string, valueName: string, value: number, label?: string, countryRegionCodes?: string): Promise<BridgeWriteResult> {
+    return this.call<BridgeWriteResult>('addEnumValue', { objectName: enumName, enumValueName: valueName, enumValue: value, label, countryRegionCodes });
   }
 
   /** Modify an existing enum value's properties */

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -840,13 +840,15 @@ EXAMPLES:
                   'Additional properties for the object being created. Supported keys by objectType:\n' +
                   '• class:           extends, implements, isFinal, isAbstract\n' +
                   '• table:           label, tableGroup, tableType, titleField1, titleField2, fields[]\n' +
-                  '• enum:            label, isExtensible, enumValues[{name,value?,label?,helpText?}]\n' +
+                  '• enum:            label, useEnumValue, configurationKey, isExtensible, enumValues[{name,value?,label?,helpText?}]\n' +
+                  '• enum-extension:  enumValues[{name,label?,value?,countryRegionCodes?}]\n' +
                   '• table-extension: fields[{name,edt?,enumType?,label?,mandatory?,fieldType?}] — fieldType defaults to AxTableFieldString; use AxTableFieldEnum for enum-based fields (also set enumType)\n' +
                   '• edt:             label, extends, edtType, stringSize\n' +
                   '• form:            caption, formTemplate, dataSource\n' +
                   '• security-privilege: label, targetObject (menu item ObjectName), objectType (MenuItemDisplay|MenuItemAction|MenuItemOutput, default: MenuItemDisplay), accessLevel (view=Read only | maintain=Read+Update+Create+Delete, default: view)\n' +
                   '• menu-item-*:     label, object, objectType\n' +
                   'Example enum: properties={"label":"@ContosoExt:Status","enumValues":[{"name":"Open","label":"@ContosoExt:Open"},{"name":"Closed","label":"@ContosoExt:Closed"}]}\n' +
+                  'Example enum-extension: properties={"enumValues":[{"name":"MyValue","label":"@MyModel:MyValue","countryRegionCodes":"CZ"}]}\n' +
                   'Example table-extension (string EDT field): properties={"fields":[{"name":"ContosoField","edt":"CustAccount","label":"@Contoso:Customer"}]}\n' +
                   'Example table-extension (enum field): properties={"fields":[{"name":"ContosoStatus","enumType":"NoYes","fieldType":"AxTableFieldEnum","label":"@Contoso:Status"}]}'
               },
@@ -915,7 +917,7 @@ EXAMPLES:
                 description: `Additional properties depending on objectType:
 - class/form/query/view: extends, implements, label
 - table: label, tableGroup, fields[]
-- enum: label, isExtensible, enumValues[{name,value?,label?,helpText?}]
+- enum: label, useEnumValue, configurationKey, isExtensible, enumValues[{name,value?,label?,helpText?}]
 - table-extension: fields[{name,edt?,enumType?,label?,mandatory?,fieldType?}] — fieldType defaults to AxTableFieldString; use AxTableFieldEnum for enum-based fields (also set enumType)
 - report (ALL REQUIRED for correct XML):
     dpClassName   {string}  Data Provider class name (e.g. "ContosoInventByZoneDP")

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -701,12 +701,22 @@ ${fieldsXml}\t<FullTextIndexes />
   ): string {
     const label = properties?.label || enumName;
     const useEnumValue = properties?.useEnumValue ? 'Yes' : 'No';
-
+    const configKeyXml = properties?.configurationKey
+      ? `\t<ConfigurationKey>${properties.configurationKey}</ConfigurationKey>\n`
+      : '';
 
     // Build <EnumValues> block from properties.enumValues array
     // Each entry: { name: string; value?: number; label?: string; helpText?: string }
     const enumValueSpecs: Array<{ name: string; value?: number; label?: string; helpText?: string }> =
       Array.isArray(properties?.enumValues) ? properties.enumValues : [];
+
+    // D365FO hard limit: max 251 elements (0–250). Warn early — compiler rejects beyond this.
+    if (enumValueSpecs.length > 251) {
+      throw new Error(
+        `Enum '${enumName}' has ${enumValueSpecs.length} values but D365FO supports a maximum of 251 (0–250). ` +
+        `Consider redesigning as a class hierarchy or splitting into multiple enums.`
+      );
+    }
 
     let enumValuesXml: string;
     if (enumValueSpecs.length === 0) {
@@ -731,10 +741,11 @@ ${fieldsXml}\t<FullTextIndexes />
     // IsExtensible goes after EnumValues; value is lowercase true/false
     const isExtensibleXml = properties?.isExtensible ? '\t<IsExtensible>true</IsExtensible>\n' : '';
 
+    // Element order matches real D365FO: Name → ConfigurationKey → Label → UseEnumValue → EnumValues → IsExtensible
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${enumName}</Name>
-\t<Label>${label}</Label>
+${configKeyXml}\t<Label>${label}</Label>
 \t<UseEnumValue>${useEnumValue}</UseEnumValue>
 ${enumValuesXml}${isExtensibleXml}</AxEnum>
 `;
@@ -1428,7 +1439,7 @@ ${defaultParamGroupXml}
       case 'edt-extension':
         return this.generateAxSimpleExtensionXml('AxEdtExtension', objectName);
       case 'enum-extension':
-        return this.generateAxSimpleExtensionXml('AxEnumExtension', objectName);
+        return this.generateAxEnumExtensionXml(objectName, properties);
       case 'data-entity-extension':
         return this.generateAxSimpleExtensionXml('AxDataEntityViewExtension', objectName);
       case 'menu-item-display':
@@ -1495,6 +1506,47 @@ ${defaultParamGroupXml}
    *  5. <AxReportDesign> has xmlns="" and i:type="AxReportPrecisionDesign" attributes
    *     (VS Designer won't show Designs sub-nodes without these)
    */
+
+  /**
+   * Sanitize AxEnum XML — fixes common AI-generator mistakes that cause VS2022 to
+   * silently ignore enum values or refuse to open the file:
+   *
+   *  1. <Values>…</Values>  →  <EnumValues>…</EnumValues>
+   *     AI models frequently map the JSON `enumValues` array to a plain <Values> wrapper;
+   *     D365FO deserializer requires <EnumValues>.
+   *
+   *  2. <AxEnum> without xmlns:i="http://www.w3.org/2001/XMLSchema-instance"
+   *     The attribute is required for the i:type resolution inside the file.
+   *
+   *  3. More than 251 <AxEnumValue> elements — D365FO compiler hard limit.
+   */
+  static sanitizeEnumXml(xml: string): string {
+    // 1. Rename <Values> container to <EnumValues>
+    if (/<Values>/.test(xml) && !/<EnumValues>/.test(xml)) {
+      xml = xml.replace(/<Values>/g, '<EnumValues>').replace(/<\/Values>/g, '</EnumValues>');
+      console.error('[sanitizeEnumXml] Renamed <Values> → <EnumValues>');
+    }
+
+    // 2. Add xmlns:i to <AxEnum> root if missing
+    if (!xml.includes('xmlns:i=')) {
+      xml = xml.replace(
+        /(<AxEnum)(\s|>)/,
+        '$1 xmlns:i="http://www.w3.org/2001/XMLSchema-instance"$2'
+      );
+      console.error('[sanitizeEnumXml] Added xmlns:i to <AxEnum>');
+    }
+
+    // 3. Validate max 251 enum values (D365FO compiler hard limit, MS Learn confirmed)
+    const valueCount = (xml.match(/<AxEnumValue>/g) ?? []).length;
+    if (valueCount > 251) {
+      console.error(
+        `[sanitizeEnumXml] ⚠️ WARNING: ${valueCount} enum values detected — D365FO supports max 251 (0–250). ` +
+        `The compiler will reject this file. Consider splitting into multiple enums or using a class hierarchy.`
+      );
+    }
+
+    return xml;
+  }
 
   /**
    * Sanitize AxTable XML to ensure correct D365FO field element format.
@@ -2279,7 +2331,7 @@ ${defaultParamGroupXml}
   }
 
   /**
-   * Generate a minimal extension XML for AxEdtExtension, AxEnumExtension,
+   * Generate a minimal extension XML for AxEdtExtension,
    * AxDataEntityViewExtension, AxMenuItemDisplayExtension, AxMenuItemActionExtension,
    * AxMenuItemOutputExtension.
    * Name convention: BaseObjectName.ExtensionName  (e.g. CustTable.MyExtension)
@@ -2290,6 +2342,45 @@ ${defaultParamGroupXml}
 \t<Name>${name}</Name>
 \t<PropertyModifications />
 </${rootElement}>`;
+  }
+
+  /**
+   * Generate AxEnumExtension XML.
+   * Name convention: BaseEnumName.PrefixExtension
+   *
+   * Supported properties:
+   *   enumValues: Array<{ name, label?, value?, countryRegionCodes?, helpText? }>
+   */
+  static generateAxEnumExtensionXml(name: string, properties?: Record<string, any>): string {
+    // Build <EnumValues> block
+    const enumValueSpecs: Array<{
+      name: string; label?: string; value?: number; countryRegionCodes?: string; helpText?: string;
+    }> = Array.isArray(properties?.enumValues) ? properties.enumValues : [];
+
+    let enumValuesXml: string;
+    if (enumValueSpecs.length === 0) {
+      enumValuesXml = '\t<EnumValues />';
+    } else {
+      enumValuesXml = '\t<EnumValues>';
+      for (const v of enumValueSpecs) {
+        enumValuesXml += `\n\t\t<AxEnumValue>`;
+        enumValuesXml += `\n\t\t\t<Name>${v.name}</Name>`;
+        if (v.countryRegionCodes) enumValuesXml += `\n\t\t\t<CountryRegionCodes>${v.countryRegionCodes}</CountryRegionCodes>`;
+        if (v.label) enumValuesXml += `\n\t\t\t<Label>${v.label}</Label>`;
+        if (v.helpText) enumValuesXml += `\n\t\t\t<HelpText>${v.helpText}</HelpText>`;
+        if (v.value !== undefined && v.value !== 0) enumValuesXml += `\n\t\t\t<Value>${v.value}</Value>`;
+        enumValuesXml += `\n\t\t</AxEnumValue>`;
+      }
+      enumValuesXml += '\n\t</EnumValues>';
+    }
+
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxEnumExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+${enumValuesXml}
+\t<PropertyModifications />
+\t<ValueModifications />
+</AxEnumExtension>`;
   }
 
   /**
@@ -3712,10 +3803,12 @@ export async function handleCreateD365File(
           if (props.methods) bridgeParams.methods = props.methods as { name: string; source?: string }[];
         }
 
-        // For enums: pass values from properties
+        // For enums: pass values from properties.
+        // Accept both `enumValues` (documented in tool description) and `values` (legacy).
         if (args.objectType === 'enum' && args.properties) {
           const props = args.properties as Record<string, unknown>;
-          if (props.values) bridgeParams.values = props.values as Record<string, unknown>[];
+          const enumVals = (props.enumValues ?? props.values) as Record<string, unknown>[] | undefined;
+          if (enumVals) bridgeParams.values = enumVals;
         }
 
         // For views: pass fields from properties
@@ -3856,6 +3949,12 @@ export async function handleCreateD365File(
     // Sanitize query XML — ensures xmlns="" and i:type="AxQuerySimple" on root element.
     if (args.objectType === 'query') {
       xmlContent = XmlTemplateGenerator.sanitizeQueryXml(xmlContent);
+    }
+
+    // Sanitize enum XML — fixes <Values> → <EnumValues> and adds xmlns:i if missing.
+    // Applies to both template-generated and caller-provided xmlContent.
+    if (args.objectType === 'enum') {
+      xmlContent = XmlTemplateGenerator.sanitizeEnumXml(xmlContent);
     }
 
     // Safety net: ensure every pair of adjacent </Method>…<Method> is separated by

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -376,11 +376,23 @@ ${titleField1Xml}${titleField2Xml}\t<DeleteActions />
     properties?: Record<string, any>
   ): string {
     const label = properties?.label || enumName;
+    const useEnumValue = properties?.useEnumValue ? 'Yes' : 'No';
+    const configKeyXml = properties?.configurationKey
+      ? `\t<ConfigurationKey>${properties.configurationKey}</ConfigurationKey>\n`
+      : '';
 
     // Build <EnumValues> block from properties.enumValues array
     // Each entry: { name: string; value?: number; label?: string; helpText?: string }
     const enumValueSpecs: Array<{ name: string; value?: number; label?: string; helpText?: string }> =
       Array.isArray(properties?.enumValues) ? properties.enumValues : [];
+
+    // D365FO hard limit: max 251 elements (0–250). Warn early — compiler rejects beyond this.
+    if (enumValueSpecs.length > 251) {
+      throw new Error(
+        `Enum '${enumName}' has ${enumValueSpecs.length} values but D365FO supports a maximum of 251 (0–250). ` +
+        `Consider redesigning as a class hierarchy or splitting into multiple enums.`
+      );
+    }
 
     let enumValuesXml: string;
     if (enumValueSpecs.length === 0) {
@@ -405,10 +417,12 @@ ${titleField1Xml}${titleField2Xml}\t<DeleteActions />
     // IsExtensible goes after EnumValues; value is lowercase true/false
     const isExtensibleXml = properties?.isExtensible ? '\t<IsExtensible>true</IsExtensible>\n' : '';
 
+    // Element order matches real D365FO: Name → ConfigurationKey → Label → UseEnumValue → EnumValues → IsExtensible
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${enumName}</Name>
-\t<Label>${label}</Label>
+${configKeyXml}\t<Label>${label}</Label>
+\t<UseEnumValue>${useEnumValue}</UseEnumValue>
 ${enumValuesXml}${isExtensibleXml}</AxEnum>
 `;
   }
@@ -1032,7 +1046,7 @@ ${defaultParamGroupXml}
       case 'edt-extension':
         return this.generateAxSimpleExtensionXml('AxEdtExtension', objectName);
       case 'enum-extension':
-        return this.generateAxSimpleExtensionXml('AxEnumExtension', objectName);
+        return this.generateAxEnumExtensionXml(objectName, properties);
       case 'data-entity-extension':
         return this.generateAxSimpleExtensionXml('AxDataEntityViewExtension', objectName);
       case 'menu-item-display':
@@ -1097,6 +1111,44 @@ ${defaultParamGroupXml}
 \t<Name>${name}</Name>
 \t<PropertyModifications />
 </${rootElement}>`;
+  }
+
+  /**
+   * Generate AxEnumExtension XML.
+   * Name convention: BaseEnumName.PrefixExtension
+   *
+   * Supported properties:
+   *   enumValues: Array<{ name, label?, value?, countryRegionCodes?, helpText? }>
+   */
+  static generateAxEnumExtensionXml(name: string, properties?: Record<string, any>): string {
+    const enumValueSpecs: Array<{
+      name: string; label?: string; value?: number; countryRegionCodes?: string; helpText?: string;
+    }> = Array.isArray(properties?.enumValues) ? properties.enumValues : [];
+
+    let enumValuesXml: string;
+    if (enumValueSpecs.length === 0) {
+      enumValuesXml = '\t<EnumValues />';
+    } else {
+      enumValuesXml = '\t<EnumValues>';
+      for (const v of enumValueSpecs) {
+        enumValuesXml += `\n\t\t<AxEnumValue>`;
+        enumValuesXml += `\n\t\t\t<Name>${v.name}</Name>`;
+        if (v.countryRegionCodes) enumValuesXml += `\n\t\t\t<CountryRegionCodes>${v.countryRegionCodes}</CountryRegionCodes>`;
+        if (v.label) enumValuesXml += `\n\t\t\t<Label>${v.label}</Label>`;
+        if (v.helpText) enumValuesXml += `\n\t\t\t<HelpText>${v.helpText}</HelpText>`;
+        if (v.value !== undefined && v.value !== 0) enumValuesXml += `\n\t\t\t<Value>${v.value}</Value>`;
+        enumValuesXml += `\n\t\t</AxEnumValue>`;
+      }
+      enumValuesXml += '\n\t</EnumValues>';
+    }
+
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxEnumExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+${enumValuesXml}
+\t<PropertyModifications />
+\t<ValueModifications />
+</AxEnumExtension>`;
   }
 
   static generateAxTableExtensionXml(name: string, properties?: Record<string, any>): string {

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -167,6 +167,10 @@ const ModifyD365FileArgsSchema = z.object({
     'If omitted for add-enum-value, the next available value is assigned automatically. ' +
     'Use with modify-enum-value to change the integer value (rare — may break existing data).'
   ),
+  enumValueCountryRegionCodes: z.string().optional().describe(
+    'ISO country/region codes for the enum value, comma-separated (e.g. "CZ", "CZ,SK"). ' +
+    'Used with add-enum-value to restrict the value to specific locales.'
+  ),
 
   // For add-display-method
   displayMethodReturnEdt: z.string().optional().describe(
@@ -773,6 +777,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             (args as any).enumValueName,
             (args as any).enumValue ?? 0,
             (args as any).enumValueLabel,
+            (args as any).enumValueCountryRegionCodes,
           );
         }
         break;


### PR DESCRIPTION
This pull request enhances enum and enum extension handling for D365FO in both the backend bridge and the TypeScript codebase. It adds support for the `countryRegionCodes` property on enum values, improves XML generation and validation for enums and enum extensions, and updates the API and documentation to reflect these capabilities.

**Enum and Enum Extension Enhancements**

* Added support for the `countryRegionCodes` property on enum values throughout the bridge service, write parameters, and XML generation. This allows specifying country/region restrictions for enum values. [[1]](diffhunk://#diff-3cb1b6bedcb703a25e89e2c11fee1fd5468af2744f624acf46fb9a3e72438ac7L654-R655) [[2]](diffhunk://#diff-3cb1b6bedcb703a25e89e2c11fee1fd5468af2744f624acf46fb9a3e72438ac7L987-R988) [[3]](diffhunk://#diff-3fd1f04ed33511727876f7ab347e4756201950d3300e0a27cf6ae9b6a92adaabR566) [[4]](diffhunk://#diff-3fd1f04ed33511727876f7ab347e4756201950d3300e0a27cf6ae9b6a92adaabR971) [[5]](diffhunk://#diff-3fd1f04ed33511727876f7ab347e4756201950d3300e0a27cf6ae9b6a92adaabL1975-R1985) [[6]](diffhunk://#diff-3fd1f04ed33511727876f7ab347e4756201950d3300e0a27cf6ae9b6a92adaabR3442-R3444) [[7]](diffhunk://#diff-2d87341e788d301b6529d7f06d77e8125bd8b59cd2c44343025d23de3a1a6d6dR1436-R1440) [[8]](diffhunk://#diff-7f9d5c070985e04783df404c600adf5319e0aa2193693f9095c226c4d1b6f8a0L587-R588)

* The TypeScript API and bridge client now accept and forward the `countryRegionCodes` property when adding enum values. [[1]](diffhunk://#diff-2d87341e788d301b6529d7f06d77e8125bd8b59cd2c44343025d23de3a1a6d6dR1436-R1440) [[2]](diffhunk://#diff-7f9d5c070985e04783df404c600adf5319e0aa2193693f9095c226c4d1b6f8a0L587-R588)

**XML Generation and Validation Improvements**

* The enum and enum extension XML generators now support the `countryRegionCodes` field, ensure proper D365FO element order, and enforce the 251-value limit with early error messages. [[1]](diffhunk://#diff-e1e7fce542c2fc43bba3dd26014907a89b50f9294dc4967e3e8b7354eecdff2bR379-R396) [[2]](diffhunk://#diff-e1e7fce542c2fc43bba3dd26014907a89b50f9294dc4967e3e8b7354eecdff2bR420-R425) [[3]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL704-R720) [[4]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR744-R748) [[5]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL1431-R1442) [[6]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR1510-R1550) [[7]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL2282-R2334) [[8]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR2347-R2385)

* Added a dedicated `generateAxEnumExtensionXml` method for correct enum extension XML output, including all supported enum value properties. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR2347-R2385) [[2]](diffhunk://#diff-e1e7fce542c2fc43bba3dd26014907a89b50f9294dc4967e3e8b7354eecdff2bL1035-R1049)

* Introduced `sanitizeEnumXml` to automatically fix common AI-generated mistakes in enum XML (e.g., renaming `<Values>` to `<EnumValues>`, adding required namespaces, and warning about value limits). [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR1510-R1550) [[2]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR3954-R3959)

**API and Documentation Updates**

* The server and tool documentation now describe the new `countryRegionCodes` property and provide updated examples for enum and enum extension creation. (F50795c5L584R584, [src/server/mcpServer.tsL918-R920](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L918-R920))

* The enum creation handler now accepts both `enumValues` and legacy `values` arrays for backward compatibility.

These changes make enum value handling more robust and aligned with D365FO requirements, and provide clearer validation and usage for extension scenarios.

#478 