### PR TITLE
perf: optimize LLM instructions for token efficiency

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,461 +1,51 @@
 # D365 Finance & Operations X++ Development
 
-<!-- Mirrors rules from xpp_system_instructions MCP prompt (src/prompts/systemInstructions.ts). Keep in sync. -->
+<!-- Thin pointer — full rules are delivered via the MCP `xpp_system_instructions` prompt.
+     This file provides only the minimum static context needed when the MCP server
+     is not yet connected or the prompt hasn't been loaded. -->
 
-This workspace contains D365FO code. **Always use the specialized MCP tools** — backed by a pre-indexed symbol database with hundreds of thousands of D365FO objects. Built-in file/search tools do not understand X++ syntax or AOT structure.
+## Quick Start
 
----
+This workspace contains a D365FO MCP server. **Always use the specialized MCP tools** for D365FO objects (.xml/.xpp/.rnrproj/.label.txt). Built-in file/search tools are fine for .cs, .json, .yml, .md, .config files.
 
-## 🚨 TERMINAL PROHIBITION
+## Mandatory First Check
 
-**PowerShell / any terminal command WILL HANG in this workspace.** This applies in VS Code, VS 2022, VS 2026.
-
-- **NEVER** run `run_in_terminal`, Developer PowerShell, or any shell command
-- **NEVER** use terminal as fallback when an MCP tool fails — STOP and report the error
-- If a tool parameter "seems missing" — re-read the schema; it IS present
-
-## 🔓 WHEN MCP IS OPTIONAL
-
-MCP rules apply **only to D365FO objects** (`.xml`/`.xpp`, AOT objects, labels, `.rnrproj`).
-
-**Use built-in tools freely for:** `*.cs`, `*.json`, `*.yml`, `*.md`, `*.config`, `*.csproj`, `*.sln`, plain text, or when user says "skip MCP" / "manual mode".
-
-- **`.rnrproj`** = D365FO project → managed by MCP (`addToProject=true`). NEVER edit directly.
-- **`.csproj`** = C# project → use built-in tools.
-
-## � HOW READS ARE RESOLVED (read-path policy)
-
-Info tools (`get_class_info`, `get_table_info`, `get_form_info`, `get_view_info`, `get_query_info`, `get_report_info`, `get_table_extension_info`, `find_coc_extensions`, `analyze_extension_points`) resolve data in this order:
-
-1. **C# bridge** — live `IMetadataProvider` from the running D365FO instance. Authoritative when available.
-2. **SQLite symbol index** — pre-built mirror. Used when the bridge is offline (Azure, write-only mode, build agents).
-3. **Filesystem parse** — last resort for objects created in the current session and not yet indexed. Scanner has a 3 s budget, 30 s result cache, and can be disabled in production with `D365FO_DISABLE_FS_FALLBACK=true`.
-
-You never need to pick the source manually — just call the tool. If you see `⚠️ Served from symbol index` or `⚠️ Not yet in bridge metadata`, the bridge was unavailable and the tool already fell back.
-
-## 🛡️ WRITE-PATH SAFETY
-
-All write operations (`modify_d365fo_file`, `create_d365fo_file`) only accept paths that live under a configured `PackagesLocalDirectory/<Package>/<Model>/Ax<Type>/<Name>.xml`. Arbitrary paths are rejected.
-
----
-
-## �🔌 MANDATORY FIRST CHECK
-
-**Call `get_workspace_info()` before doing anything.**
+Call `get_workspace_info()` before doing anything with D365FO objects.
 
 | Response | Action |
 |----------|--------|
-| Call fails | STOP. Tell user MCP server is not connected. Offer: start server (A) or continue with built-in tools (B). Wait for answer. |
-| "not available in read-only mode" | Azure mode. Ask user for model name explicitly. Do NOT infer from search results. |
+| Call fails | STOP. MCP server not connected. Ask user to start it. |
 | `⛔ CONFIGURATION PROBLEM` | STOP. Relay message. Wait for user. |
-| `✅ Configuration looks valid` | Note model name. Use it for all create/modify calls. Proceed. |
+| `✅ Configuration looks valid` | Note model name. Proceed. |
 
-If you encounter `MyModel`/`MyPackage` placeholder mid-task — STOP and notify user.
+## Terminal Prohibition
 
-## ✏️ EDITING D365FO FILES
+PowerShell / any terminal command **WILL HANG** in VS 2022 / VS 2026 MCP integration. Never use `run_in_terminal` or generate scripts as fallback when an MCP tool fails — STOP and report the error.
+
+## Core Tool Mapping
 
 | Action | Tool |
 |--------|------|
-| Edit existing objects | `modify_d365fo_file()` — methods, fields, indexes, relations, field-groups, controls, properties |
-| Create new objects | `create_d365fo_file()` |
-| Search | `search()`, `batch_search()` |
-| Read objects | `get_class_info()`, `get_table_info()`, `get_form_info()`, `get_report_info()` |
-| Verify project | `verify_d365fo_project()` |
-| Build/BP/Sync/Test | `build_d365fo_project()`, `run_bp_check()`, `trigger_db_sync()`, `run_systest_class()` |
-
-**NEVER use** `replace_string_in_file`, `edit_file`, `create_file`, `read_file`, `grep_search`, `code_search` on D365FO `.xml`/`.xpp` files.
-
-**`overwrite=true` on `create_d365fo_file`** — ONLY for full XML replacement. NEVER for incremental changes (add-field, add-field-group, etc.) → use `modify_d365fo_file`.
-
-**`dryRun=true` — MANDATORY for every `modify_d365fo_file` call.** Visual Studio 2022 does NOT show Keep/Undo buttons for MCP edits, so the diff must be reviewed in chat before disk is touched.
-
-Required sequence for every modification:
-1. Call `modify_d365fo_file` with `dryRun=true` → show the returned diff to the user.
-2. Wait for explicit confirmation ("apply", "ok", "yes", etc.).
-3. Re-call the SAME operation with `dryRun=false`.
-
-Skip the dry-run only when the user has explicitly said "skip dryRun" / "apply directly" for the current task. Batched operations (multiple `modify_d365fo_file` calls in sequence) require dry-run for EACH call — never apply a chain of edits without per-step confirmation.
-
-## 🌿 VS 2022 Review Workflow (Git checkpointing)
-
-VS 2022 has no inline accept/reject UI for agent edits. Use Git as the review layer:
-
-1. **Before starting a task** — ensure clean tree, then create a checkpoint branch:
-   `git switch -c mcp/<short-task-name>` (or at minimum `git commit -am "checkpoint"` on current branch).
-2. **During the task** — every `modify_d365fo_file` runs with `dryRun=true` first (see above).
-3. **After the task** — review via VS 2022 → *View → Git Changes* (per-file diff, per-hunk Stage/Unstage/Discard).
-4. **Accept** = commit + merge into main. **Reject** = `git restore <file>` or `git branch -D mcp/<task>`.
-
-If the user is on `main` (or another protected branch) and asks for a non-trivial change, suggest creating a feature branch first. Do NOT create branches autonomously — propose and wait.
-
-### ⛔ Escalating-workarounds anti-pattern — STOP at step 0
-
-If `modify_d365fo_file` is the correct tool but you feel tempted to try something else, you are wrong. STOP.
-```
-WRONG SPIRAL (each step is MORE wrong):
- Step 1: "I'll use replace_string_in_file to patch the XML"
- Step 2: "replace failed — I'll try a different approach"
- Step 3: "I'll read the file with PowerShell first, then overwrite"
- Step 4: "Terminal returns no output — I'll add Write-Output"
- Step 5: "I'll use create_d365fo_file with overwrite=true"
-
-CORRECT (always, immediately):
- modify_d365fo_file(operation="add-field-group" | "add-field" | "add-method" | …)
-```
-If `modify_d365fo_file` itself errors — STOP and report to user. Do NOT try PowerShell.
-
-### `modify_d365fo_file` — full operation inventory
-
-| Category | Operations |
-|----------|------------|
-| Methods | `add-method`, `remove-method`, `replace-code` |
-| Fields | `add-field`, `modify-field`, `rename-field`, `replace-all-fields`, `remove-field` |
-| Indexes | `add-index`, `remove-index` |
-| Relations | `add-relation`, `remove-relation` |
-| Field groups | `add-field-group`, `remove-field-group`, `add-field-to-field-group` |
-| Table-ext | `add-field-modification` (override base-table field label/mandatory) |
-| Form-ext | `add-control`, `add-data-source` |
-| Any object | `modify-property` |
-
-### modify-property examples
-```
-TableGroup/TableType/CacheLookup/Label/Extends → modify_d365fo_file(operation="modify-property", propertyPath="...", propertyValue="...")
-```
-Works for tables, table-extensions, EDTs, classes, and all object types.
-
-### Table-extension property paths (via `modify-property`, objectType="table-extension")
-
-`Label`, `HelpText`, `TableGroup`, `CacheLookup`, `TitleField1`, `TitleField2`, `ClusteredIndex`, `PrimaryIndex`, `SaveDataPerCompany`, `TableType`, `SystemTable`, `ModifiedDateTime`, `CreatedDateTime`, `ModifiedBy`, `CreatedBy`, `CountryRegionCodes`
-
-### rename-field / replace-all-fields
-
-```
-Rename one field   → rename-field   fieldName="OldName"  fieldNewName="NewName"
-                     (auto-fixes index DataField refs and TitleField1/2)
-                     Repair-only: pass OLD corrupted name → only index refs fixed
-
-Rewrite ALL fields → replace-all-fields  fields=[{name,edt?,type?,mandatory?,label?}, ...]
-                     (use when field names contain spaces or are otherwise corrupted)
-```
-
-### TableGroup vs TableType
-- **TableGroup** = business role: `Miscellaneous`|`Main`|`Transaction`|`Parameter`|`Group`|`WorksheetHeader`|`WorksheetLine`|`Reference`|`Framework`
-- **TableType** = storage: `RegularTable`(default)|`TempDB`|`InMemory`
-- ⛔ NEVER pass `tableGroup="TempDB"`. Use `tableType="TempDB"`, `tableGroup="Main"`.
-
-## ⚡ TOKEN BUDGET
-
-- `get_class_info` defaults to `compact=true` (signatures only). Max 2 calls per turn.
-- Use `get_method_source(class, method)` for full bodies.
-- `search_extensions` — max once per turn.
-
-## 📣 TRANSPARENCY
-
-VS 2022 shows only "ran tool_name" — no output. **Always** write 1 sentence before each tool call and summarize the result in 1–3 lines after.
-
----
-
-## Quick Reference — Request → Tool
-
-| Request | Tools |
-|---------|-------|
-| Fix bug / review | `get_class_info` → `get_method_source` → `modify_d365fo_file` |
-| Where is X used? | `find_references(targetName)` |
-| What can I extend? | `analyze_extension_points(objectName)` |
-| Which extension mechanism? | `recommend_extension_strategy(goal)` |
-| CoC extensions of X? | `find_coc_extensions(className)` |
-| Event handlers for X? | `find_event_handlers(targetName)` |
-| Security coverage? | `get_security_coverage_for_object(objectName)` |
-| Create SSRS report | `generate_smart_report(name, fieldsHint, ...)` |
-| Create CoC extension | See CoC workflow below |
-| Diagnose X++ error | `get_d365fo_error_help(errorText)` |
-| X++ knowledge/patterns | `get_xpp_knowledge(topic)` → `analyze_code_patterns(scenario)` |
-| Create table/form | `generate_smart_table()` / `generate_smart_form()` |
-| Best practices / BP check | `run_bp_check()` — NEVER manually review code with `get_method_source` |
-| Build project | `build_d365fo_project()` |
-| Sync database | `trigger_db_sync()` |
-| Run tests | `run_systest_class()` |
-
----
-
-## Non-Negotiable Rules
-
-1. **NEVER** use built-in file/edit tools (`create_file`, `replace_string_in_file`, `read_file`, `grep_search`…) on `.xml`/`.xpp`/`.label.txt`/`.rnrproj` files — use the matching D365FO MCP tool
-2. **NEVER** guess method signatures — call `get_method_signature` before CoC
-3. **NEVER** call `create_d365fo_file` without `projectPath` or `solutionPath`
-4. **ALWAYS** search labels with `search_labels()` first; create via `create_label()`
-5. **ALWAYS** pass `fieldsHint` for tables, `primaryKeyFields` for composite PKs
-6. **ALWAYS** pass `methods=["find","exist"]` to `generate_smart_table()` when needed — don't add after
-7. **NEVER** include model prefix in `name` of `generate_smart_*` — auto-applied. Pass base name without prefix: `objectName="InventByZones"` + `modelName="ContosoExt"` → `ContosoExtInventByZones`.
-8. **NEVER** use `get_enum_info()` for EDTs — use `get_edt_info()`
-9. **NEVER** infer target model from search results — always use model from `.mcp.json`
-10. Security types: `security-privilege` → `AxSecurityPrivilege`, `security-duty` → `AxSecurityDuty`, `security-role` → `AxSecurityRole` — NEVER mix
-11. Class member variables go **inside** class `{ }` in `sourceCode` — outside = lost
-12. **NEVER** use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
-13. **NEVER** call functions in `WHERE` clauses — assign to variable first
-14. **NEVER** use hardcoded strings in `Info()`/`warning()`/`error()` — use `@Model:Label`
-15. **NEVER** nest `while select` loops — use `join` or pre-load to `Map`/temp table
-16. **ALWAYS** call `create_label()` before referencing new labels in code. **Exception:** when adding a field to a table/table-extension with an EDT that already has a label defined, do **NOT** set a label on the field — the field inherits the label from the EDT automatically. Only set `label` on a field when deliberately overriding the EDT's label.
-17. **ALWAYS** write meaningful `/// <summary>` on public/protected classes and methods
-18. **NEVER** call `[SysObsolete]` methods — read the attribute for the replacement
-19. **NEVER** switch project autonomously via `get_workspace_info(projectName=...)` — ask user
-20. **ALWAYS** call `get_d365fo_error_help()` for D365FO errors — don't guess fixes
-21. CoC class extension: `create_d365fo_file(objectType="class-extension", objectName="{Target}{Prefix}_Extension")`
-22. **CoC wrappers: NEVER copy default parameter values from the base method into the extension signature.** `public void salute(str message = "Hi")` → wrapper signature must be `public void salute(str message)` (no `= "Hi"`). See "Chain of Command (CoC) Authoring Rules" section.
-23. **CoC wrappers must call `next` unconditionally** at first-level statement scope (not in `if`/`while`/`for`, not after `return`). PU21+: `next` is permitted inside `try`/`catch`/`finally`. Exception: `[Replaceable]`-attributed methods may break the chain.
-24. **NEVER make instance fields `public`** — use `parmFoo` accessors. Default visibility is `protected`; keep it.
-25. **NEVER use `doInsert` / `doUpdate` / `doDelete` for normal business logic** — they bypass overridden table methods, framework validation, and event handlers. Reserved for data-fix / migration only.
-26. Standard data events use `[DataEventHandler]` — NOT `[SubscribesTo + delegateStr]`. `delegateStr` is for custom delegates only.
-27. SDLC tools (`run_bp_check`, `build_d365fo_project`, `trigger_db_sync`, `run_systest_class`) auto-detect params from `.mcp.json`. If they error about missing binaries, fix `.mcp.json`.
-28. `review_workspace_changes` = git diff code review only. NOT for verifying modify/create success.
-29. `get_form_info` works for ALL forms (standard + custom). If ⚠️ warning, retry with `filePath=`.
-30. **NEVER run `build_d365fo_project()` automatically.** Builds block the user. After completing changes, say *"Changes applied. Run a build when you're ready to validate."* Only build on explicit request ("build", "compile", "check errors"). If the build reports X++ errors, fix them via `modify_d365fo_file` and rebuild until clean.
-31. **"Check best practices" / "BP check" → ALWAYS call `run_bp_check()`**. NEVER manually iterate `get_method_source` to review code for BP compliance — the BP checker is authoritative.
-32. **X++ syntax authority — Microsoft Learn.** When uncertain about X++ syntax, language constructs, framework APIs, or platform behavior, the **only** authoritative source is the Microsoft Learn `dynamics365/fin-ops-core/dev-itpro` documentation tree. Do NOT guess and do NOT rely on AX 2012 / older training data. Reference (or fetch via `fetch_webpage` if a tool is available):
-    - `select` statement, joins, ranges, field lists, `firstOnly`, `forUpdate`, `pessimisticLock`, `crossCompany`: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement>
-    - General developer landing page (entry point to all X++ topics): <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-tools/developer-home-page>
-    - X++ language reference root: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-language-reference>
-    - Chain of Command / method wrapping: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/method-wrapping-coc>
-    Combine Learn (syntax authority) with MCP tools (real metadata: table/field/method names from THIS environment). Learn for "how is `while select` written"; MCP for "does field `BalanceMST` exist on `CustTable`".
-
-### X++ Database Query Rules (`select` / `while select`)
-
-Follow the `select` statement contract from Microsoft Learn (link above). Key non-negotiables for generated code:
-
-**Statement order (grammar-enforced):**
-```
-select [FindOption…] [FieldList from] tableBuffer [index…] [order by / group by] [where …] [join … [where …]]
-```
-- `FindOption` keywords (`crossCompany`, `firstOnly`, `forUpdate`, `forceNestedLoop`, `forceSelectOrder`, `forcePlaceholders`, `pessimisticLock`, `optimisticLock`, `repeatableRead`, `validTimeState`, `noFetch`, `reverse`, `firstFast`) go **between `select` and the table buffer / field list** — never after the buffer, never on a joined buffer (with the documented exception of `forUpdate` which can target a specific buffer in a join).
-- `order by` / `group by` / `where` must appear **after the LAST `join` clause**, not between two joins. Multiple `group by` clauses are allowed but only one of them can table-qualify a field.
-
-**Buffer placement of FindOptions (the gotcha the user reported):**
-- **`crossCompany` belongs on the OUTER select (first/driving buffer).** It is a query-level option, not a per-table option. Putting it on a joined buffer is wrong even when "the joined buffer is the one we need data from across companies".
-  ```xpp
-  // ✅ CORRECT
-  select crossCompany custTable
-      join custInvoiceJour
-      where custInvoiceJour.OrderAccount == custTable.AccountNum;
-
-  // ❌ WRONG — crossCompany on the joined buffer
-  select custTable
-      join crossCompany custInvoiceJour
-      where …;
-  ```
-- Optional company filter: `select crossCompany : myContainer custTable …` where `myContainer` is `container` or expression of type container (e.g. `(['dat'] + ['dmo'])`). Without the colon-list, all authorized companies are scanned.
-
-**`in` operator — what it accepts (the second user-reported gotcha):**
-- Grammar: `where Expression in List` where `List` = "an array of values" — i.e. an X++ **`container`**.
-- Works with **any primitive type** that fits in a container: `str`, `int`, `int64`, `real`, `enum`, `boolean`, `date`, `utcDateTime`, `RecId`. **NOT enum-only.** The user's report ("works only on enum") is incorrect — but the practical pattern in MS code most often uses enum containers, which is probably why it appeared that way.
-- Does NOT accept: a `Set`, `List` (the X++ collection class), `Map`, table buffer, or another `select` subquery.
-- Build the container with `[v1, v2, v3]` literal or by concatenation `(c1 + c2)`. Empty container = no rows match (do not pass an empty container expecting "all rows").
-- Only ONE `in` clause per `where` (grammar: `WhereClause = where Expression InClause` — single `InClause`). For multiple set filters, AND them: `where a in c1 && b in c2`.
-- Example:
-  ```xpp
-  container postingTypes = [LedgerPostingType::PurchStdProfit, LedgerPostingType::PurchStdLoss];
-  container accounts = ['1000', '2000', '3000'];
-  select sum(CostAmountAdjustment) from inventSettlement
-      where inventSettlement.OperationsPosting in postingTypes
-        && inventSettlement.LedgerAccount in accounts;
-  ```
-- ❌ NEVER do `inventSettlement.OperationsPosting == LedgerPostingType::A || inventSettlement.OperationsPosting == LedgerPostingType::B || …` — refactor to `in container`.
-
-**Other Learn-confirmed rules:**
-- **Field list before table** when you don't need the full row: `select FieldA, FieldB from myTable where …` — never `select * from` style.
-- **`firstOnly`** when you expect at most one row. Cannot be combined with the `next` statement (Learn explicit warning).
-- **`forUpdate`** required before any `.update()` / `.delete()` inside the same transaction; pair with `ttsbegin`/`ttscommit`.
-- **`exists join` / `notExists join`** instead of nested `while select` for filter-only joins.
-- **`outer join`** — there is only LEFT outer; **no RIGHT outer, no `left` keyword**. Default values fill non-matching rows (0 for int, "" for str, etc.) — check explicitly with the joined buffer's `RecId` if you need to distinguish "no match" from "real zero".
-- **Join criteria use `where`, not `on`.** X++ has no `on` keyword.
-- **`index hint`** requires `myTable.allowIndexHint(true)` to be called BEFORE the select — otherwise the hint is silently ignored. Only use when you have measured a regression — never speculative.
-- **`index` (without `hint`)** = sort-only request, always honored.
-- **Aggregates** (`sum`, `avg`, `count`, `minof`, `maxof`):
-  - `sum` / `avg` / `count` work only on integer/real fields (Learn explicit).
-  - When `sum` would return null (no matching rows), X++ returns NO row — guard with `if (buffer)` after the select.
-  - Non-aggregated fields in the select list must be in `group by`.
-- **`forceLiterals`** is forbidden — SQL injection risk (Learn explicit warning). Use `forcePlaceholders` (default for non-join selects) or omit.
-- **No function calls in `where`** — assign to a local variable first (rule 13). Same applies to `joins`/`order by`/`group by`.
-- **No nested `while select`** — use `join` or pre-load to `Map`/temp table (rule 15).
-- **`crossCompany`** must be explicit when querying across DataAreaId; default is current company only. See buffer-placement rule above.
-- **`validTimeState(dateFrom, dateTo)`** for date-effective tables (tables with `ValidTimeStateFieldType ≠ None`). Don't query date-effective tables without it unless you specifically want all historical rows.
-- **`RecordInsertList` / `insert_recordset` / `update_recordset` / `delete_from`** for set-based operations — prefer over row-by-row loops for performance.
-- **`doInsert` / `doUpdate` / `doDelete`** = bypass overridden `insert`/`update`/`delete` table methods, framework code (validate, find, init), and event handlers. **Reserved for data-fix / migration scenarios only** — never for normal business logic.
-- **SQL injection mitigation** — when building dynamic queries from user input, use `executeQueryWithParameters` API, never string concatenation into the `where` clause. `forceLiterals` is the equivalent SQL-injection trap on `select` statements.
-- **SQL timeout** — interactive sessions: 30 min, batch/services/OData: 3 h. To override, call `queryTimeout` API. Long-running queries should catch `Exception::Timeout` and either retry or surface a meaningful error.
-
-If a query construct is requested that you have not verified against Learn in this session, STOP and either fetch the Learn page or tell the user you need to verify before generating code.
-
-### Chain of Command (CoC) Authoring Rules
-
-Verified against [method-wrapping-coc](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/method-wrapping-coc).
-
-**🚨 NEVER copy default parameter values into the wrapper signature.** This is the user-reported gotcha. The signature in the extension class must repeat parameter types and names but NEVER the `= defaultValue` part — even if the base method declares them.
-
-```xpp
-// Base method
-class Person
-{
-    public void salute(str message = "Hi") { … }
-}
-
-// ✅ CORRECT — wrapper omits the default value
-[ExtensionOf(classStr(Person))]
-final class APerson_Extension
-{
-    public void salute(str message)        // no  "= 'Hi'" here
-    {
-        next salute(message);
-    }
-}
-
-// ❌ WRONG — copying the default breaks the contract / will not compile
-public void salute(str message = "Hi")     // ← forbidden
-```
-
-**Other CoC non-negotiables:**
-
-- **Wrapper must always call `next`** — except on `[Replaceable]` methods, where the chain may be conditionally broken.
-- **`next` must be at the first-level statement scope** — NOT inside `if`, `while`, `for`, `do-while`, NOT after a `return`, NOT inside a logical expression. Platform Update 21+: `next` is permitted inside `try`/`catch`/`finally`.
-- **Signature otherwise matches base exactly** — same return type, same parameter types and order, same `static` modifier if applicable. Use `get_method_signature` to retrieve the exact base contract before authoring.
-- **Static method wrapping** — must repeat the `static` keyword on the wrapper. Forms are excluded from static wrapping (no class semantics for forms).
-- **Cannot wrap constructors.** New methods on an extension class without parameters become the extension's own constructor (must be `public`, no args).
-- **Extension class shape:** `[ExtensionOf(classStr|tableStr|formStr|formDataSourceStr|formDataFieldStr|formControlStr(...))] final class <Target>_<Suffix>` — class must be `final`, name should end with `_Extension` (or descriptive suffix). One extension class per nested form concept (data source, field, control).
-- **`[Hookable(false)]`** on a base method blocks CoC and pre/post handlers entirely — cannot wrap.
-- **`[Wrappable(false)]`** blocks wrapping (still allows pre/post handlers). `final` methods need explicit `[Wrappable(true)]` to be wrappable.
-- **Form-nested wrapping:** use `formdatasourcestr`, `formdatafieldstr`, `formControlStr`. Cannot add NEW methods via CoC on these — only wrap methods that already exist in the base concept (e.g. `init`, `validateWrite`, `clicked`, …). To add brand-new logic, call into a public/protected method on the original control.
-- **Visibility:** wrappers run with the access of the extension class but can read/call **protected** members of the augmented class (since Platform Update 9). They cannot reach `private` members.
-
-### X++ Class & Method Rules
-
-Verified against [xpp-classes-methods](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-classes-methods).
-
-- **Class default access = `public`.** Removing `public` does not make a class non-public. Use `internal` to limit to the same model, `final` to prevent extension via inheritance, `abstract` for base-only types.
-- **Instance fields default = `protected`.** **NEVER make instance fields `public`** — expose via accessor methods (`parmFoo` convention) or `[DataMember]` for serialization. Public fields tightly couple consumers to internal layout.
-- **Constructor pattern:** one `new()` per class (compiler generates an empty default if absent). Convention: `new()` is `protected`, exposed via a `public static construct()` factory. `init()` does specialized post-construction setup.
-- **Method modifier order in the header:** `[edit | display] [public | protected | private | internal] [static | abstract | final]`. `static final` is permitted; mixing `abstract` with `final`/`static` is not.
-- **Override visibility rule:** an override must be at least as accessible as the base method. `public` → `public` only; `protected` → `public` or `protected`; `private` → not overridable.
-- **Optional parameters** must come after all required parameters. Callers **cannot skip** an optional parameter to reach a later one — all preceding parameters must be supplied. Use `prmIsDefault(_x)` inside a `parmX(_x = x)` accessor to detect "was this passed".
-- **All parameters are pass-by-value.** Mutating a parameter inside the method does NOT affect the caller's variable. To return modified state, return it explicitly or use a wrapper class.
-- **`this` rules:**
-  - Required (or qualified) for instance method calls.
-  - Cannot qualify class-declaration member variables (write the bare name).
-  - Cannot be used in a static method.
-  - Cannot qualify static methods (use `ClassName::method()`).
-- **Extension methods (separate from CoC, target = Class / Table / View / Map):**
-  - Extension class must be `static` (not `final`), name ends with `_Extension`.
-  - Every extension method is `public static`.
-  - First parameter is the target type — caller does NOT pass it; the runtime supplies the receiver.
-- **Constants over macros.** Use `public const str FOO = 'bar';` at class scope (cross-referenced, scoped, IntelliSense-aware) instead of `#define.FOO('bar')`. Reference via `ClassName::FOO` (or unqualified inside the same class).
-- **`var` keyword** for type-inferred locals when the type is obvious from the right-hand side (`var sum = decimal + amount;`). Skip `var` when the type is non-obvious — readability beats brevity.
-- **Declare-anywhere is encouraged** — declare close to first use, prefer the smallest scope. The compiler rejects shadowing of an outer-scope variable with the same name.
-
-### X++ Statement & Type Rules
-
-Verified against [xpp-conditional](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-conditional) and [xpp-variables-data-types](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-variables-data-types).
-
-- **`switch` `break` is required.** Implicit fall-through compiles but is misleading. To match multiple values to one branch use the **comma-list** syntax: `case 13, 17, 21: …; break;` — never the empty-fall-through chain.
-- **Ternary `cond ? a : b`** — both branches must have the same type (no implicit widening of `int` ↔ `real`).
-- **X++ has NO database null.** Each primitive has a "null-equivalent" sentinel: `int 0`, `real 0.0`, `str ""`, `date 1900-01-01`, `utcDateTime` with date-part `1900-01-01`, `enum` element with value `0`. In SQL `where` clauses these compare as false; in plain expressions they compare as ordinary values. Do not write `if (myDate == null)` — write `if (!myDate)` or `if (myDate == dateNull())`.
-- **Casting:** prefer `as` (returns `null` on type mismatch) and `is` (boolean test) over hard down-casts. Down-casts on object-typed expressions throw `InvalidCastException`. Late binding exists for `Object` and `FormRun` only — accept the runtime cost and lack of compile-time checks if you use it.
-- **`using` blocks** for `IDisposable` resources (StreamReader, FileIOPermission, etc.). Equivalent to `try` + `finally { x.Dispose(); }`; using `using` is shorter and exception-safe.
-- **Embedded function declarations** (local functions inside a method) can read variables declared earlier in the enclosing method but cannot leak their own variables out. Prefer them over private helper methods only when the helper truly does not belong to the class API.
-
-### AxClass sourceCode Format
-
-Class member variables go **inside** the class braces; methods stay at top level of the `sourceCode` string:
-
-```xpp
-public class MyClass extends MyBase
-{
-    int counter;
-}
-
-public void myMethod() { ... }
-```
-
-### generate_smart_table/form — Two Success Cases
-
-- **Azure/Linux** (response says "Azure/Linux"): tool returns XML → call `create_d365fo_file(xmlContent=..., addToProject=true)`
-- **Windows** (response says "DO NOT call create_d365fo_file"): file already written → STOP
-
----
-
-## Refactoring Workflow
-
-```
-1. get_class_info("Class")           → signatures (compact=true default)
-2. analyze_class_completeness("Class") → missing standard methods
-3. get_method_source("Class","method") → full body of methods to change
-4. find_references("method")          → verify no callers break
-5. modify_d365fo_file(dryRun=true)    → preview diff
-6. modify_d365fo_file(dryRun=false)   → apply after user confirms
-```
-
-- NEVER delete a method without `find_references` first
-- NEVER guess method bodies from signatures — read source
-
-## CoC Extension Workflow
-
-```
-1. analyze_extension_points("Target")
-2. get_method_signature("Target", "method", includeCocTemplate: true)
-3. create_d365fo_file(objectType="class-extension", objectName="Target_Extension", ...)
-4. modify_d365fo_file(operation="add-method", sourceCode="<CoC skeleton>")
-```
-
-## Table Extension Workflow
-
-```
-1. get_table_extension_info("Table")  → existing extensions
-2. create_d365fo_file(objectType="table-extension", objectName="Table.PrefixExt", addToProject=true)
-3. modify_d365fo_file(operation="add-field" | "add-index" | "add-field-group" | ...)
-```
-
-## Form Extension Workflow
-
-```
-1. get_form_info("Form", searchControl="TabName")  → exact control names
-2. create_d365fo_file(objectType="form-extension", objectName="Form.MyExt", addToProject=true)
-3. modify_d365fo_file(operation="add-control", parentControl="Tab", controlDataField="Field", ...)
-```
-
-## Event Handler Workflow
-
-```
-1. find_event_handlers("Table")       → existing handlers
-2. create_d365fo_file(objectType="class", objectName="TableEventHandler", ...)
-3. Standard events:  [DataEventHandler(tableStr(T), DataEventType::Inserted)]
-   Custom delegates: [SubscribesTo(tableStr(T), delegateStr(T, myDelegate))]
-```
-
-## SSRS Report Workflow
-
-**Preferred:** `generate_smart_report(name, fieldsHint, caption, contractParams)` — generates all 5 objects.
-
-**Manual order:** TmpTable → Contract → DP class → Controller → Report (via `create_d365fo_file(objectType="report", xmlContent=...)`)
-
----
-
-## Labels
-
-1. `search_labels(query)` — always search first
-2. `create_label(labelId, labelFileId, model, translations, createLabelFileIfMissing: true)` — creates label + project entry
-3. `rename_label(oldLabelId, newLabelId, ...)` — renames across files
-
-- Label IDs describe meaning, NOT model: ✅ `CustomerName` ❌ `MyModelCustomerName`
-- Pass `createLabelFileIfMissing: true` on first use in a model
-
-## Available `generate_code` Patterns
-
-`batch-job`, `sysoperation`, `table-extension`, `class-extension`, `event-handler`, `security-privilege`, `menu-item`, `data-entity`, `ssrs-report-full`, `lookup-form`, `form-handler`, `form-datasource-extension`, `form-control-extension`, `map-extension`, `dialog-box`, `dimension-controller`, `number-seq-handler`, `display-menu-controller`, `data-entity-staging`, `service-class-ais`, `business-event`, `custom-telemetry`, `feature-class`, `composite-entity`, `custom-service`, `er-custom-function`
-
-## Available `generate_smart_form` Patterns
-
-`SimpleList`, `SimpleListDetails`, `DetailsMaster`, `DetailsTransaction`, `Dialog`, `TableOfContents`, `Lookup`, `ListPage`, `Workspace`
-
-## File Paths
-
-AOT: `C:\AOSService\PackagesLocalDirectory\{Model}\{Model}\Ax{Type}\{Name}.xml`
-
-Always provide `projectPath` in `create_d365fo_file` — auto-extracts model from `.rnrproj`.
+| Create D365FO object | `create_d365fo_file` (never `create_file`) |
+| Edit existing object | `modify_d365fo_file` with `dryRun=true` first |
+| Search objects | `search()` / `batch_search()` |
+| Read class/table/form | `get_class_info` / `get_table_info` / `get_form_info` |
+| Method signature (for CoC) | `get_method_signature` |
+| Build/BP/Sync | `build_d365fo_project` / `run_bp_check` / `trigger_db_sync` |
+| Error diagnosis | `get_d365fo_error_help(errorText)` |
+
+## Key Rules (condensed)
+
+1. Model name comes from `.mcp.json` — never infer from search results
+2. `dryRun=true` is mandatory for every `modify_d365fo_file` — VS 2022 has no undo UI
+3. Never run `build_d365fo_project()` automatically — only on explicit user request
+4. Never copy default parameter values into CoC wrapper signatures
+5. Never use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
+6. Never use hardcoded strings in Info/warning/error — use `@Model:Label`
+7. Call `search_labels()` before `create_label()` — reuse existing labels
+8. Extension class naming: `[ExtensionOf(...)] final class {Target}{Prefix}_Extension`
+
+## Full Instructions
+
+The complete X++ rules, query grammar, CoC authoring rules, and workflow details are delivered via the MCP prompt `xpp_system_instructions`. If that prompt is not loaded, request it or consult `src/prompts/systemInstructions.ts` directly.
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -398,8 +398,8 @@ plain-language explanation plus a corrective action — no symbol-index access n
 it works in both Azure read-only and local modes.
 
 **When to call:** Whenever the compiler Output window, Error List, or runtime infolog shows
-an unfamiliar error. Rule 22 in `copilot-instructions.md` mandates calling this tool
-**before guessing a fix.**
+an unfamiliar error. The system instructions mandate calling this tool **before guessing
+a fix** (see `xpp_system_instructions` MCP prompt / `src/prompts/systemInstructions.ts`).
 
 **Parameters:**
 | Parameter | Required | Description |

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -169,7 +169,8 @@ See [Scenario F in SETUP.md](SETUP.md#scenario-f-multiple-instances--one-machine
 
 ## Step 4 — Place copilot-instructions.md
 
-Copy the instruction file so Copilot knows D365FO workflow rules:
+Copy the bootstrap instruction file so Copilot has minimal D365FO context even before
+the MCP server connects:
 
 ```powershell
 # Place .github in a parent folder shared by all D365FO solutions:
@@ -178,6 +179,11 @@ Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
 
 VS 2022 searches for `.github\copilot-instructions.md` upward from the `.sln` folder —
 one copy in a common parent covers all solutions underneath.
+
+> **Note:** This file is intentionally small (~50 lines). The complete X++ rules, query
+> grammar, and workflow details are delivered at runtime via the MCP prompt
+> `xpp_system_instructions`. The bootstrap file only ensures correct tool routing if the
+> MCP server hasn't connected yet.
 
 ---
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -75,8 +75,10 @@ C:\source\repos\                   ← parent folder (common ancestor of all sol
 Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
 ```
 
-GitHub Copilot automatically picks up `copilot-instructions.md` and uses it to give
-the AI the right D365FO context for every conversation.
+GitHub Copilot automatically picks up `copilot-instructions.md` as a bootstrap layer.
+It contains minimal rules (tool mapping, key constraints, terminal prohibition) that apply
+before the MCP server connects. The full X++ development instructions are delivered at
+runtime via the MCP prompt `xpp_system_instructions` (defined in `src/prompts/systemInstructions.ts`).
 
 ---
 

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -37,12 +37,17 @@ You are GitHub Copilot assisting with Dynamics 365 Finance & Operations (D365FO)
 
 **Before generating ANY X++ code, ALWAYS query the MCP tools to get accurate, real-time metadata from the user's environment.**
 
-Your training data may be outdated. D365FO has 584,799+ objects in a pre-indexed database. MCP tools provide:
-- ✅ Real-time metadata from user's actual environment
-- ✅ Fast queries (<10ms cached, <100ms uncached)
-- ✅ Accurate method signatures, field names, and patterns
-- ✅ Understanding of X++ semantics (inheritance, EDT, relations)
-- ✅ Compiler-resolved cross-references via DYNAMICSXREFDB (on Windows D365FO VMs) — enriched reference types, method-level CoC detail, event handler classification
+## Decision Tree (evaluate FIRST for every request)
+
+1. **Creating D365FO object?** → \\`create_d365fo_file\\` (never \\`create_file\\`)
+2. **Modifying existing object?** → \\`modify_d365fo_file\\` with \\`dryRun=true\\` first
+3. **Generating X++ code?** → \\`analyze_code_patterns\\` + \\`search\\` → then generate
+4. **Mentions D365FO object?** → Use MCP tools to verify it exists
+5. **Need field/method/API info?** → \\`get_class_info\\`, \\`get_table_info\\`, \\`get_method_signature\\`
+6. **X++ syntax uncertain?** → Consult Microsoft Learn links below
+7. **Error diagnosis?** → \\`get_d365fo_error_help(errorText)\\`
+
+Your training data may be outdated. D365FO has 584,799+ objects in a pre-indexed database. MCP tools provide real-time metadata, accurate signatures, and fast queries (<10ms cached).
 
 ## Tool Selection Guide
 
@@ -143,105 +148,43 @@ Skip the dry-run only when the user has explicitly said "skip dryRun" / "apply d
 5. **NEVER run \`build_d365fo_project()\` automatically.** Builds take a long time and block the user. After completing changes, tell the user the changes are done and they can build manually when ready. Only run \`build_d365fo_project()\` when the user explicitly requests it ("build", "compile", "check errors"). If after a requested build there are X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
 
 ### 4. Semantic vs. Prefix Search
-**Understand the difference:**
-- **Semantic (by concept):** "methods related to totals" → Use \`search("total", type="method")\`
-- **Prefix (exact start):** "methods starting with calc" → Use \`code_completion(className, prefix="calc")\`
-- ❌ NEVER use \`code_completion\` without \`className\` parameter - will fail validation
+- **Semantic (by concept):** \\`search("total", type="method")\\`
+- **Prefix (exact start):** \\`code_completion(className="SalesTable", prefix="calc")\\`
+- \\`code_completion\\` requires \\`className\\` — will fail without it
 
-### 5. Forbidden Built-in Tools
-**For D365FO objects (.xml, .xpp), NEVER use:**
-- ❌ \`code_search\` - hangs 5+ minutes → Use \`search\`
-- ❌ \`file_search\` - can't parse XML → Use \`search\` or \`get_class_info\`
-- ❌ \`read_file\` - objects not in files → Use \`get_class_info\`/\`get_table_info\`
-- ❌ \`get_file\` - can't read AOT → Use specific MCP tools
-- ❌ \`create_file\` - wrong location/structure → Use \`create_d365fo_file\`
-- ❌ \`edit_file\` / \`apply_patch\` - corrupts XML → Use \`modify_d365fo_file\`
+### 5. For D365FO Objects — Use MCP Tools Only
+For .xml/.xpp files, use MCP tools instead of built-in tools:
+- \\`search\\` instead of \\`code_search\\`/\\`file_search\\` (avoids 350+ model folder scan)
+- \\`get_class_info\\`/\\`get_table_info\\` instead of \\`read_file\\`
+- \\`create_d365fo_file\\` instead of \\`create_file\\`
+- \\`modify_d365fo_file\\` instead of \\`edit_file\\`/\\`apply_patch\\`
 
-**Why:** D365FO metadata is in SQL database, not workspace files. Built-in tools scan 350+ models causing hangs. MCP tools use indexed queries (<100ms).
+### 6. Terminal/Scripts Prohibition
+PowerShell and Python scripts hang indefinitely in VS 2022 MCP integration. When \\`modify_d365fo_file\\` errors:
+1. Report the exact error to the user
+2. Suggest the correct MCP operation
+3. If no MCP tool exists, tell user to do it manually in VS AOT
 
-### 6. NEVER Use Scripts as Fallback — and NEVER Read-then-Write
-**When an MCP tool is unavailable or returns an error, NEVER:**
-- ❌ Write or run PowerShell scripts (.ps1) to modify D365FO XML files — they hang indefinitely in VS 2022
-- ❌ Write or run Python scripts to patch XML — same issue, no result
-- ❌ Use \`run_in_terminal\`, \`execute_command\`, or any shell execution to write files
-- ❌ Generate \`Set-Content\`, \`Out-File\`, \`[System.IO.File]::WriteAllText\` or similar file-write commands
-
-**Critical anti-pattern — NEVER do this:**
-\`\`\`
-// ❌ WRONG — read_file succeeds (file exists on disk), but there is no write_file tool in VS 2022
-read_file(path)          // reads XML for "context"
-→ manually construct XML edit in memory
-→ generate PowerShell Set-Content script to write it back
-→ script hangs forever, no output, infinite spinner
-\`\`\`
-This pattern looks reasonable but **always fails** in VS 2022 because \`read_file\` exists but \`write_file\`/\`edit_file\` do not. The only way to write D365FO XML is \`modify_d365fo_file\`.
-
-**Instead, when a tool cannot complete the operation:**
-1. Report the exact error to the user (e.g. "Field group X already exists")
-2. Suggest the correct MCP tool to use next (e.g. \`add-field-to-field-group\`)
-3. **Skip the step entirely** — never attempt a workaround via scripts or shell commands
-4. If no MCP tool exists for the operation, tell the user to perform it manually in Visual Studio AOT
-
-**Why:** Visual Studio 2022 MCP integration does not allow interactive terminal sessions. Any spawned PowerShell/Python process will hang waiting for stdin or permissions, causing an infinite spinner with no output.
-
-## Workflow Examples
+## Workflow Examples (condensed)
 
 ### Creating a New Class
-\`\`\`
-User: "Create a helper class for financial dimensions"
-
-Correct Workflow:
-1. analyze_code_patterns("financial dimensions") → Learn common patterns
-2. search("dimension", type="class") → Find existing classes
-3. get_api_usage_patterns("DimensionAttributeValueSet") → How to use API
-4. create_d365fo_file(
-     objectType="class",
-     objectName="MyDimHelper",
-     modelName="auto-detected-from-workspace",
-     addToProject=true
-   ) → Creates file in PackagesLocalDirectory
-5. generate_code(pattern="class", name="MyDimHelper") → Generate with patterns
-
-❌ Wrong: Using create_file or generating code without consulting tools
-\`\`\`
+1. \\`analyze_code_patterns("financial dimensions")\\` → patterns
+2. \\`search("dimension", type="class")\\` → existing implementations
+3. \\`create_d365fo_file(objectType="class", objectName="MyDimHelper", addToProject=true)\\`
 
 ### Creating Chain of Command Extension
-\`\`\`
-User: "Extend CustTable.validateWrite"
+1. \\`get_method_signature("CustTable", "validateWrite")\\` → exact signature
+2. \\`find_coc_extensions("CustTable")\\` → check existing wrappers
+3. \\`create_d365fo_file(objectType="class-extension", objectName="CustTableMY_Extension")\\`
+4. \\`modify_d365fo_file(operation="add-method", sourceCode="<CoC wrapper>", dryRun=true)\\`
 
-Correct Workflow:
-1. get_class_info("CustTable") → Understand class structure
-2. get_method_signature("CustTable", "validateWrite") → Get exact signature
-   Returns: "public boolean validateWrite(boolean _insertMode)"
-3. suggest_method_implementation("CustTable", "validateWrite") → See examples
-4. generate_code(pattern="table-extension", name="CustTable") → Create CoC extension skeleton
-
-❌ Wrong: Guessing method signature or generating without looking it up
-\`\`\`
-
-### Finding Methods by Concept
-\`\`\`
-User: "What methods on SalesTable calculate totals?"
-
-Correct Workflow:
-1. search("total OR sum OR amount", type="method") → Semantic search
-2. Filter results to SalesTable
-3. get_method_signature for specific methods user wants
-
-❌ Wrong: Using code_completion(className="SalesTable") - that's for prefix search
-\`\`\`
+### Finding Methods
+- Semantic (concept): \\`search("total", type="method")\\`
+- Prefix (exact start): \\`code_completion(className="SalesTable", prefix="calc")\\`
 
 ### Querying a Table
-\`\`\`
-User: "Query customers with balance > 1000"
-
-Correct Workflow:
-1. get_table_info("CustTable") → Get field names and indexes
-2. search("balance", type="field") → Find exact field name
-3. Generate optimized X++ query with correct field names
-
-❌ Wrong: Guessing field names like "Balance", "BalanceRemaining", etc.
-\`\`\`
+1. \\`get_table_info("CustTable")\\` → verify field names
+2. Generate X++ query with confirmed field names
 
 ## Code Generation Best Practices
 
@@ -269,33 +212,16 @@ When generating X++ code after gathering context:
 - Infolog for user messages
 - Validation patterns before database operations
 
-## When to Use General Knowledge
+## When to Use General Knowledge vs MCP Tools
 
-You may use general knowledge for:
-- X++ syntax (if, while, for, select statements) — **only if certain**; otherwise consult Microsoft Learn (see below)
-- Standard framework patterns (RunBase, SysOperation)
-- Best practices and design patterns
-- Visual Studio IDE usage
+- **General knowledge OK for:** X++ syntax (if certain), standard framework patterns, best practices, VS IDE usage
+- **ALWAYS use MCP tools for:** object names, signatures, field names, creating files, discovering patterns, code generation
+- **When uncertain about syntax:** consult Microsoft Learn (\\`dynamics365/fin-ops-core/dev-itpro\\`) — not AX 2012 training data
 
-**But ALWAYS use MCP tools for:**
-- ANY code generation (classes, methods, logic)
-- Object names, signatures, field names
-- Creating D365FO files
-- Discovering patterns and implementations
-- Method/API usage
-
-## Authoritative X++ Syntax Source — Microsoft Learn
-
-When uncertain about X++ syntax, language constructs, framework APIs, or platform behavior, the **only** authoritative source is the Microsoft Learn \`dynamics365/fin-ops-core/dev-itpro\` documentation tree. Do NOT guess and do NOT rely on AX 2012 / older training data.
-
-Key references (fetch via \`fetch_webpage\` if available, otherwise tell the user you need to verify):
-- \`select\` statement, joins, ranges, field lists, \`firstOnly\`, \`forUpdate\`, \`pessimisticLock\`, \`crossCompany\`: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement>
-- General developer landing page: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-tools/developer-home-page>
-- X++ language reference root: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-language-reference>
-
-Division of authority:
-- **Microsoft Learn** = HOW the syntax is written (e.g. "how is \`while select\` constructed").
-- **MCP tools** = WHAT exists in this environment (e.g. "does field \`BalanceMST\` exist on \`CustTable\`").
+Key Learn references:
+- \\`select\\` statement: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement>
+- X++ language reference: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-language-reference>
+- CoC / method wrapping: <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/method-wrapping-coc>
 
 ### X++ Database Query Rules (\`select\` / \`while select\`)
 
@@ -306,7 +232,8 @@ Follow the \`select\` statement contract from Microsoft Learn (link above). Non-
 select [FindOption…] [FieldList from] tableBuffer [index…] [order by / group by] [where …] [join … [where …]]
 \`\`\`
 - \`FindOption\` keywords (\`crossCompany\`, \`firstOnly\`, \`forUpdate\`, \`forceNestedLoop\`, \`forceSelectOrder\`, \`forcePlaceholders\`, \`pessimisticLock\`, \`optimisticLock\`, \`repeatableRead\`, \`validTimeState\`, \`noFetch\`, \`reverse\`, \`firstFast\`) go **between \`select\` and the table buffer / field list**.
-- \`order by\` / \`group by\` / \`where\` must appear **after the LAST \`join\` clause**, not between two joins.
+- Each table buffer (including joined buffers) gets its own \`where\` clause immediately after it.
+- \`order by\` / \`group by\` apply to the driving buffer and appear after the full join chain.
 
 **Buffer placement of FindOptions — common mistakes:**
 - **\`crossCompany\` belongs on the OUTER select (first/driving buffer).** It is a query-level option, not a per-table option. Putting it on a joined buffer is wrong even when "the joined buffer is the one we need data from across companies".
@@ -327,8 +254,8 @@ select [FindOption…] [FieldList from] tableBuffer [index…] [order by / group
 - Works with **any primitive type** that fits in a container: \`str\`, \`int\`, \`int64\`, \`real\`, \`enum\`, \`boolean\`, \`date\`, \`utcDateTime\`, \`RecId\`. **NOT enum-only.** Practical MS code most often uses enum containers, which can give the false impression of an enum-only restriction.
 - Does NOT accept: a \`Set\`, X++ \`List\` collection class, \`Map\`, table buffer, or another \`select\` subquery.
 - Build the container with \`[v1, v2, v3]\` literal or by concatenation \`(c1 + c2)\`. Empty container = no rows match.
-- Only ONE \`in\` clause per \`where\` — for multiple set filters, AND them: \`where a in c1 && b in c2\`.
-- ❌ NEVER do long chains of \`field == X || field == Y || field == Z\` — refactor to \`in container\`.
+- Multiple \`in\` expressions can be combined with \`&&\`: \`where a in c1 && b in c2\`.
+- Refactor long \`field == X || field == Y || field == Z\` chains into \`field in container\`.
 
 **Other Learn-confirmed rules:**
 - **Field list before table** when you don't need the full row.
@@ -410,6 +337,106 @@ Verified against [xpp-conditional](https://learn.microsoft.com/en-us/dynamics365
 - **\`using\` blocks** for \`IDisposable\` — equivalent to \`try\`/\`finally { Dispose() }\`, exception-safe.
 - **Embedded local functions** read enclosing variables but cannot leak their own. Use only when the helper does not belong to the class API.
 
+### SysDa Framework (fluent query API)
+
+SysDa is the modern X++ query API — a fluent, object-oriented alternative to \`select\` statements. Use when building queries dynamically or when query logic depends on runtime conditions.
+
+**Core classes:**
+- \`SysDaQueryObject\` — root query builder. Set table buffer via constructor.
+- \`SysDaSearchObject\` / \`SysDaSearchStatement\` — execute the query and populate buffers.
+- \`SysDaFindObject\` / \`SysDaFindStatement\` — like \`firstOnly\` equivalent.
+- \`SysDaUpdateObject\` / \`SysDaUpdateStatement\` — set-based update.
+- \`SysDaInsertObject\` / \`SysDaInsertStatement\` — set-based insert from query.
+- \`SysDaDeleteObject\` / \`SysDaDeleteStatement\` — set-based delete.
+
+**Building a query:**
+\`\`\`xpp
+CustTable custTable;
+var qe = new SysDaQueryObject(custTable);
+qe.whereClause(new SysDaEqualsExpression(
+    new SysDaFieldExpression(custTable, fieldStr(CustTable, AccountNum)),
+    new SysDaValueExpression('US-001')
+));
+var so = new SysDaSearchStatement();
+while (so.nextRecord(qe))
+{
+    info(custTable.AccountNum);
+}
+\`\`\`
+
+**Joins:** \`qe.joinClause(SysDaJoinKind::InnerJoin, joinQe)\` — supports Inner, Outer, Exists, NotExists.
+
+**When to use SysDa vs \`select\`:**
+- **\`select\`/\`while select\`** — preferred for static, known-at-compile-time queries (cleaner, faster to read, compile-time field validation).
+- **SysDa** — preferred when: (a) query shape depends on runtime conditions (optional joins/filters), (b) building framework/reusable query logic, (c) dynamically selecting fields or aggregates.
+
+### Query Object Model (AOT Query at runtime)
+
+The \`Query\`/\`QueryRun\` classes execute AOT-defined or runtime-built queries:
+
+**Key classes:**
+- \`Query\` — defines structure (data sources, ranges, sorting, joins).
+- \`QueryBuildDataSource\` — one table in the query; add via \`query.addDataSource(tableNum(T))\`.
+- \`QueryBuildRange\` — filter: \`qbds.addRange(fieldNum(T, Field)).value(queryValue('X'))\`.
+- \`QueryRun\` — executes the query and iterates results.
+
+**Typical pattern:**
+\`\`\`xpp
+Query query = new Query();
+QueryBuildDataSource qbds = query.addDataSource(tableNum(CustTable));
+qbds.addRange(fieldNum(CustTable, CustGroup)).value(queryValue('10'));
+qbds.addSortField(fieldNum(CustTable, AccountNum));
+QueryRun qr = new QueryRun(query);
+while (qr.next())
+{
+    CustTable ct = qr.get(tableNum(CustTable));
+    info(ct.AccountNum);
+}
+\`\`\`
+
+**When to use Query vs \`select\`:**
+- **AOT Query objects** — forms/reports bind to them; reusable across multiple consumers.
+- **Runtime Query** — when user can dynamically modify filters (SysQueryForm integration), or when using \`SysQueryRun\` for batch dialog filtering.
+- **\`select\`** — for inline data access where no dynamic filter UI is needed.
+
+**Key APIs:**
+- \`SysQuery::findOrCreateRange(qbds, fieldNum)\` — idempotent range addition.
+- \`QueryBuildDataSource::addDataSource()\` — nested join (child data source).
+- \`qbds.joinMode(JoinMode::ExistsJoin)\` — set join type at runtime.
+- \`query.allowCrossCompany(true)\` + \`query.addCompanyRange('dat')\` — cross-company at Query level.
+
+### FormRun Lifecycle & Form Development
+
+Forms in D365FO follow a strict initialization lifecycle. Key methods execute in this order:
+
+**Initialization sequence:**
+1. \`form.init()\` — form structure loaded, data sources NOT yet active
+2. \`FormDataSource.init()\` — each data source initializes (link types resolved)
+3. \`form.run()\` — form becomes visible
+4. \`FormDataSource.executeQuery()\` — initial data load
+
+**Common extension points (via CoC or event handlers):**
+- \`FormDataSource.init()\` — add ranges, modify query before first execution
+- \`FormDataSource.executeQuery()\` — modify query dynamically on each refresh
+- \`FormDataSource.active()\` — fires when cursor moves to a new record (update dependent data sources or UI)
+- \`FormDataSource.validateWrite()\` — custom validation before save
+- \`FormDataSource.write()\` — post-save logic
+- \`FormControl.clicked()\` / \`modified()\` — button/field interaction handlers
+
+**Form interaction patterns:**
+- \`FormDataSource.research(retainPosition: true)\` — refresh grid keeping cursor position.
+- \`element.args()\` — access caller context (menu item, record, enum parameter).
+- \`FormDataSource.queryBuildDataSource()\` — access underlying QueryBuildDataSource for runtime range manipulation.
+- \`FormDataSource.filter(fieldNum, value)\` / \`removeFilter(fieldNum)\` — programmatic quick-filter.
+- \`element.design().controlName(formControlStr(MyForm, MyControl))\` — access control by name at runtime.
+- \`FormLetterServiceController\` — base for document posting forms (invoices, packing slips).
+
+**Rules for form extensions:**
+- Use \`get_form_info(formName, searchControl="...")\` to find exact control names before adding controls.
+- Add data sources via \`modify_d365fo_file(operation="add-data-source")\`.
+- Add controls via \`modify_d365fo_file(operation="add-control", parentControl="...")\`.
+- NEVER guess control names — they differ from field names and are often prefixed.
+
 ## Performance Notes
 
 - First query: ~50-100ms (database)
@@ -423,19 +450,7 @@ If tool returns no results:
 2. Try type='all' to broaden search
 3. Check for typos (D365FO names are case-sensitive)
 4. Inform user if object might not exist
-5. Suggest checking AOT in Visual Studio
 
-## Decision Tree
-
-Before responding to ANY request, ask:
-
-1. **Creating D365FO object?** → Use \`create_d365fo_file\` immediately
-2. **Generating ANY X++ code?** → Use \`analyze_code_patterns\` + \`search\` first
-3. **Mentions D365FO object?** → Use MCP tools to verify it exists
-4. **About fields/methods/APIs?** → Use \`code_completion\`, \`get_class_info\`, or \`get_table_info\`
-5. **X++ syntax or concept?** → Can use general knowledge (but prefer tools when unsure)
-
-**When in doubt, USE THE TOOLS.** They're fast and prevent errors.
 
 ---
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -184,24 +184,7 @@ export function createXppMcpServer(context: XppServerContext): Server {
       tools: [
         {
           name: 'search',
-          description: `🔍 Search 584,799+ pre-indexed D365FO objects by exact name (e.g., "CustTable", "SalesFormLetter") or keywords (e.g., "dimension helper", "validation table"). Returns basic info: name, type, model.
-
-Use WHEN:
-- You don't know the exact object name
-- Exploring what exists in standard D365FO
-- Quick discovery before detailed analysis with get_class_info() or get_table_info()
-
-Use get_class_info() or get_table_info() INSTEAD when:
-- You already know the exact name AND need full source code/methods
-- You need complete structure (all methods with implementations)
-
-Use batch_search() INSTEAD when:
-- You need to search for multiple objects at once → 3x faster
-
-Examples:
-- "CustTable" → finds CustTable table
-- "sales helper" → finds SalesHelper, SalesFormLetterHelper, etc.
-- "dimension" with type="class" → finds all classes with "dimension" in name`,
+          description: 'Search pre-indexed D365FO objects by name or keywords. Returns name, type, model. Use batch_search for multiple queries. Use get_class_info/get_table_info when you already know the exact name and need full details.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -233,22 +216,7 @@ Examples:
         },
         {
           name: 'batch_search',
-          description: `Execute multiple X++ symbol searches in parallel within a single request.
-
-This tool enables efficient exploration by running independent searches concurrently,
-reducing HTTP round-trip overhead and total execution time.
-
-Use cases:
-- Exploring multiple related concepts simultaneously (e.g., "dimension", "helper", "validation")
-- Comparing different search queries at once
-- Reducing workflow time for exploratory searches
-
-Performance:
-- 3 sequential searches: ~150ms (3 HTTP requests)
-- 3 parallel searches: ~50ms (1 HTTP request) → 3x faster
-
-Workspace-aware: Each query can optionally include workspace files by specifying
-workspacePath and includeWorkspace parameters.`,
+          description: 'Execute multiple symbol searches in parallel (max 10). 3x faster than sequential search calls. Supports deduplication and cross-referencing across results.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -331,27 +299,7 @@ workspacePath and includeWorkspace parameters.`,
         },
         {
           name: 'search_extensions',
-          description: `🔍 Search ONLY custom/ISV code, filtering out 500,000+ Microsoft standard objects. Essential for finding YOUR modifications vs. Microsoft's standard code.
-
-Filters to models tagged as:
-- Custom (your company's modifications)
-- ISV (third-party vendor extensions)  
-- VAR (partner extensions)
-
-Use WHEN:
-- Finding "what did WE change?"
-- Identifying custom extensions for a standard object (e.g., "CustTable")
-- Avoiding confusion between Microsoft standard code and your modifications
-- You only want to see custom/ISV classes, not the 500K+ Microsoft objects
-
-⚠️ READ-ONLY REFERENCE TOOL: Results show WHERE existing objects live. The model names in results are SOURCE models of those existing objects. They are NOT suggestions for where to create new objects.
-❌ NEVER use a model name from search_extensions results as the target for create_d365fo_file, create_label, or modify_d365fo_file.
-✅ The target model for ALL create/modify operations is ALWAYS from .mcp.json (modelName/projectPath).
-
-Examples:
-- "CustTable" → finds only YourCompany_CustTable_Extension (NOT Microsoft's CustTable)
-- "sales" with prefix="Contoso" → finds ContosoSalesHelper, ContosoSalesValidator
-- "dimension" → finds only YOUR custom dimension classes`,
+          description: 'Search only custom/ISV objects, filtering out Microsoft standard code. Model names in results are SOURCE models — never use them as target for create/modify operations.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -364,31 +312,7 @@ Examples:
         },
         {
           name: 'get_class_info',
-          description: `📊 Get COMPLETE class definition with ALL methods, full source code, inheritance chain, and attributes. Returns the ENTIRE class as if you opened the file in Visual Studio.
-
-Returns:
-- All methods with FULL signatures AND source code implementations
-- Inheritance (extends, implements interfaces)
-- Class attributes ([ExtensionOf], [SysObsolete], etc.)
-- All private/protected/public/static methods
-- Class-level properties
-
-Use WHEN:
-- You need to see method implementations (not just names)
-- Understanding class architecture before extending it
-- Creating Chain of Command (CoC) extensions (combine with get_method_signature())
-- Analyzing how a specific class works internally
-
-Use code_completion() INSTEAD when:
-- You only need method/field NAMES (IntelliSense-like)
-- You don't need source code implementations
-
-Use search() FIRST when:
-- You don't know the exact class name yet
-
-Examples:
-- get_class_info("SalesFormLetter") → returns full class with 50+ methods and complete source
-- get_class_info("CustTable") → returns table with fields + methods like validateWrite(), insert()`,
+          description: 'Get class definition: methods (signatures or full source), inheritance, attributes. Default compact=true returns signatures only. Use get_method_source for specific method bodies. Use code_completion for name-only listing.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -403,33 +327,7 @@ Examples:
         },
         {
           name: 'get_table_info',
-          description: `📊 PRIMARY TOOL for ALL table queries! Get complete table schema with all fields, indexes, relations, AND table methods.
-
-⭐ USE THIS for ANY question about table methods, fields, or structure!
-
-Returns:
-- All table METHODS with signatures and source code (calcAmount, validateWrite, etc.)
-- All fields with explicit EDT marker when present (format: EDT: <Name> (base: <Type>)), otherwise base type (format: Type: <Type>)
-- Indexes: primary key, unique indexes, clustered indexes
-- Relations: foreign keys to other tables with cardinality
-- Table properties: caching strategy, TableGroup, SaveDataPerCompany, etc.
-
-Use WHEN (includes all table-related queries):
-- ✅ "What methods are on SalesTable?" → get_table_info("SalesTable")
-- ✅ "Methods related to totals on SalesTable" → get_table_info("SalesTable")
-- ✅ "Show me calc methods on CustTable" → get_table_info("CustTable")
-- ✅ Understanding table structure before writing X++ queries
-- ✅ Creating table extensions with new fields
-- ✅ Understanding data relationships (foreign keys, navigation)
-- ✅ Before writing data migration or integration scripts
-- ✅ Analyzing table methods and validation logic
-
-DO NOT USE code_completion() for tables - it doesn't work!
-
-Examples:
-- get_table_info("SalesTable") → ALL methods (calcAmount, validateWrite, etc.) + fields + relations
-- get_table_info("CustTable") → 100+ fields, methods, relations to DirParty/LogisticsPostalAddress
-- get_table_info("InventTable") → product master fields, methods, relations to EcoResProduct`,
+          description: 'Get complete table schema: fields (with EDT info), indexes, relations, methods, and properties. Primary tool for any table-related query. Do NOT use code_completion for tables.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -441,35 +339,7 @@ Examples:
         },
         {
           name: 'code_completion',
-          description: `⚡ Get IntelliSense-like method and field name completions for CLASSES only. Faster than get_class_info() when you only need member names, not implementations.
-
-⚠️ CLASSES ONLY - For TABLES use get_table_info() instead!
-
-Returns:
-- Method names with basic signatures (parameters, return types)
-- Field names with types
-- Filtered by prefix if specified (e.g., "calc*" finds calcAmount, calcDiscount)
-
-Use WHEN:
-- Working with X++ CLASSES (not tables)
-- Writing code and need to see available methods quickly
-- You want to filter by prefix for faster discovery
-- You don't need to see method source code
-
-DO NOT USE for TABLES:
-- ❌ code_completion("SalesTable") → Use get_table_info("SalesTable") instead
-- ❌ code_completion("CustTable") → Use get_table_info("CustTable") instead
-- ❌ For ANY table, always use get_table_info()
-
-Use get_class_info() INSTEAD when:
-- You need to see method SOURCE CODE implementations
-- You need to understand HOW methods work internally
-- Creating Chain of Command extensions (need full method body)
-
-Examples (CLASSES only):
-- code_completion("SalesFormLetter") → lists methods/fields of the CLASS
-- code_completion("NumberSeq", prefix="get") → getNum, getVoucher, etc.
-- code_completion("DimensionHelper", prefix="validate") → validation methods`,
+          description: 'IntelliSense-like member name completions for CLASSES only. Returns method/field names with basic signatures. Faster than get_class_info when you only need names. For tables, use get_table_info instead.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -483,46 +353,7 @@ Examples (CLASSES only):
         },
         {
           name: 'generate_code',
-          description: `🎯 GENERATE X++ CODE - Call this FIRST when user asks to CREATE/BUILD D365FO objects!
-
-WHEN TO USE (keywords):
-- "create" / "build" / "implement" / "add new" / "generate" / "make"
-- "batch job" = batch-job, "helper class" = helper class, "runnable" = runnable class
-- ANY request to create NEW D365FO class, batch job, form handler, data entity
-- "SysOperation" / "DataContract" / "event handler" / "security privilege" / "menu item"
-
-WORKFLOW (ALWAYS follow):
-1. Call analyze_code_patterns("description") → learn from existing code patterns
-2. Call generate_code(pattern, name) → get X++ source code template
-3. Call create_d365fo_file(objectType="class", objectName=name, sourceCode=<from step 2>, addToProject=true)
-
-PATTERNS (X++ code):
-- "batch-job" → Batch job (extends RunBaseBatch) with dialog, pack/unpack, contract class
-- "class" → Standard helper/utility class
-- "runnable" → Runnable class with main() method
-- "form-handler" → Form event handler (datasource/control event subscribers)
-- "data-entity" → Data entity with staging table
-- "table-extension" → Table extension [ExtensionOf(tableStr(TableName))]
-- "sysoperation" → Full SysOperation: DataContract + Controller + Service (3 classes)
-  Controller uses new() override with parmClassName/parmMethodName (standard D365FO pattern)
-  Optional: serviceMethod param to name the Service method (default: "process")
-- "event-handler" → Class with [SubscribesTo] handlers for table/class events
-
-PATTERNS (XML output — use for AOT XML files):
-- "security-privilege" → AxSecurityPrivilege XML (generates View + Maintain privilege pair)
-- "menu-item" → AxMenuItemDisplay/Action/Output XML
-
-EXAMPLES:
-- "Create SysOperation for processing orders"
-  → generate_code(pattern="sysoperation", name="ProcessOrders")
-- "Create SysOperation for processing orders with custom method name"
-  → generate_code(pattern="sysoperation", name="ProcessOrders", serviceMethod="processOrders")
-- "Create event handler for CustTable"
-  → generate_code(pattern="event-handler", name="CustTable")
-- "Create security privilege for CustTable form"
-  → generate_code(pattern="security-privilege", name="CustTable", targetObject="CustTable")
-- "Create menu item for CustTable form"
-  → generate_code(pattern="menu-item", name="CustTable", menuItemType="display", targetObject="CustTable")`,
+          description: 'Generate X++ code from patterns. Call analyze_code_patterns first, then generate_code, then create_d365fo_file. Patterns: batch-job, sysoperation, class, runnable, event-handler, table-extension, class-extension, form-handler, form-datasource-extension, form-control-extension, security-privilege, menu-item, ssrs-report-full, lookup-form, dialog-box, dimension-controller, number-seq-handler, data-entity, data-entity-staging, service-class-ais, business-event, custom-telemetry, feature-class, composite-entity, custom-service, er-custom-function, map-extension, display-menu-controller.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -581,26 +412,7 @@ EXAMPLES:
         },
         {
           name: 'analyze_code_patterns',
-          description: `🧠 Analyze YOUR actual codebase to find most common classes, methods, and dependencies used in a scenario. Essential for creating code based on REAL D365FO patterns, not generic examples.
-
-Searches YOUR codebase and returns:
-- Most frequently used classes for the scenario
-- Common method patterns and naming conventions
-- Typical dependencies and imports
-- Real-world implementation examples
-
-⚠️ CALL THIS FIRST before generating new code to learn from existing patterns.
-
-Use WHEN:
-- Before creating new classes → see how similar classes are structured
-- Before implementing business logic → find similar implementations  
-- Learning D365FO conventions in your organization
-- Understanding how others solved similar problems
-
-Examples:
-- analyze_code_patterns("ledger journal creation") → finds LedgerJournalEngine, journal posting classes
-- analyze_code_patterns("sales order validation") → finds SalesTable validation patterns
-- analyze_code_patterns("dimension", classPattern="Helper") → finds dimension helper classes`,
+          description: 'Analyze the codebase to find common classes, methods, and dependencies for a scenario. Call BEFORE generate_code to learn from existing real patterns.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -613,24 +425,7 @@ Examples:
         },
         {
           name: 'suggest_method_implementation',
-          description: `🧠 Find REAL implementation examples of similar methods in YOUR codebase. Shows how others implemented the same/similar method, not generic templates.
-
-Searches YOUR codebase and returns:
-- Real method implementations with similar name/purpose
-- Common patterns for method signature (parameters, return type)
-- Typical method body structure and logic flow
-- Dependencies and classes commonly used together
-
-Use WHEN:
-- Implementing a standard D365FO method (validateWrite, insert, update, etc.)
-- You know the method name but not how to implement it
-- Want to see real examples from your codebase
-- Creating Chain of Command extensions based on existing patterns
-
-Examples:
-- suggest_method_implementation("CustTable", "validateWrite") → shows how others validate customer data
-- suggest_method_implementation("SalesTable", "insert") → shows common insert() patterns
-- suggest_method_implementation("MyHelper", "calculate") → finds similar calculation methods`,
+          description: 'Find real implementation examples of similar methods in the codebase. Shows how others implemented the same/similar method with actual code.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -655,23 +450,7 @@ Examples:
         },
         {
           name: 'analyze_class_completeness',
-          description: `🧠 Analyze a class and suggest missing methods by comparing with similar classes. Helps ensure your class follows common D365FO patterns and conventions.
-
-Analyzes YOUR codebase and returns:
-- Methods that similar classes have but your class is missing
-- Common method patterns in the same class category
-- Suggestions for standard methods (validateWrite, find, exist, etc.)
-- Completeness score based on similar classes
-
-Use WHEN:
-- After creating a new class → check if you're missing important methods
-- Reviewing existing class → ensure it follows patterns
-- Before code review → identify gaps
-- Learning what methods a class typically needs
-
-Examples:
-- analyze_class_completeness("MyCustomerHelper") → suggests missing find(), exist(), validate()
-- analyze_class_completeness("MySalesProcessor") → compares with other processor classes`,
+          description: 'Analyze a class and suggest missing methods by comparing with similar classes in the codebase. Identifies gaps like missing find(), exist(), validate() methods.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -682,25 +461,7 @@ Examples:
         },
         {
           name: 'get_api_usage_patterns',
-          description: `🧠 Shows how a specific API/class is ACTUALLY used in YOUR codebase. Returns real initialization patterns and method call sequences, not documentation.
-
-Searches YOUR codebase and returns:
-- Common initialization patterns (how to create instances)
-- Typical method call sequences (what methods are called together and in what order)
-- Required setup/configuration before using the API
-- Common parameters and return value usage
-- Real usage examples from your code
-
-Use WHEN:
-- First time using a complex D365FO API/class
-- Need to understand correct initialization sequence
-- Want to see real examples instead of reading documentation
-- Understanding how others use a specific class
-
-Examples:
-- get_api_usage_patterns("LedgerJournalEngine") → shows initialization + posting sequence
-- get_api_usage_patterns("NumberSeq") → shows how to generate number sequences  
-- get_api_usage_patterns("DimensionAttributeValueSet") → dimension creation patterns`,
+          description: 'Show how a specific API/class is actually used in the codebase: initialization sequences, method call patterns, and common parameters.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -712,83 +473,14 @@ Examples:
         },
         {
           name: 'create_d365fo_file',
-          description: `🔥 CREATE D365FO FILE - REPLACES BUILT-IN create_file FOR ALL D365FO OBJECTS!
+          description: `Create D365FO AOT object file (.xml) in the correct PackagesLocalDirectory location with proper XML structure and UTF-8 BOM. Auto-adds to VS project (.rnrproj).
 
-🚨 WARNING: BUILT-IN create_file WILL CORRUPT D365FO METADATA! NEVER USE IT FOR .xml FILES!
+Object types: class, table, enum, form, query, view, data-entity, report, edt, security-privilege, security-duty, security-role, menu-item-display/action/output, menu, table/class/form/enum/edt/data-entity-extension, menu-item-*-extension, menu-extension, business-event, tile, kpi.
 
-WHEN TO USE (MUST use for ANY D365FO object creation):
-- User asks to CREATE, BUILD, IMPLEMENT, GENERATE new class, table, enum, form, query, view, data entity, or SSRS report
-- Keywords: "create", "build", "implement", "add new", "generate", "make"
-- "batch job" = batch-job class, "helper class" = helper class, "runnable" = runnable class, "report" = objectType="report"
-- ANY request to create a new D365FO object
+For extensions: objectName="BaseObject.PrefixExtension" (e.g. "CustTable.ContosoExtension").
+Model name auto-detected from .mcp.json. Object name prefix auto-applied from EXTENSION_PREFIX.
 
-WHY NOT create_file:
-❌ create_file → Wrong XML structure, no UTF-8 BOM, doesn't add to VS project, breaks AOT
-✅ create_d365fo_file → Correct AOT location, UTF-8 BOM, auto-adds to .rnrproj, validates structure
-
-WHAT IT DOES:
-- Creates physical XML file in correct AOT location (K:\\AosService\\PackagesLocalDirectory\\{Model}\\{Model}\\AxClass\\{Name}.xml)
-- Automatically adds file to Visual Studio project (.rnrproj) if addToProject=true
-- Auto-detects correct model name from workspace .rnrproj file
-- Generates proper XML structure with UTF-8 BOM encoding
-
-REQUIRED PARAMETERS:
-- objectType: NEW objects → class, table, enum, form, query, view, data-entity, report, edt
-             SECURITY    → security-privilege (AxSecurityPrivilege)
-                           security-duty      (AxSecurityDuty)       ← NOT the same as privilege!
-                           security-role      (AxSecurityRole)
-             MENU ITEMS  → menu-item-display, menu-item-action, menu-item-output, menu
-             EXTENSIONS  → table-extension, form-extension, enum-extension, edt-extension,
-                           data-entity-extension, menu-item-display-extension,
-                           menu-item-action-extension, menu-item-output-extension, menu-extension
-  ⚠️ SECURITY RULE: ALWAYS use the matching type — duty ≠ privilege ≠ role:
-     security-privilege → AxSecurityPrivilege folder
-     security-duty      → AxSecurityDuty folder
-     security-role      → AxSecurityRole folder
-  ⚠️ EXTENSION RULE: Extending an EXISTING standard object? ALWAYS use the -extension variant:
-     "table-extension" → AxTableExtension folder, objectName = "BaseTable.PrefixExtension"
-     "form-extension"  → AxFormExtension folder,  objectName = "BaseForm.PrefixExtension"
-     NEVER use objectType="table" to create a table extension — wrong folder, broken AOT!
-- objectName: Name of the new object (e.g., "ProcessOpenOrdersBatch" for batch job)
-  For extensions: "BaseElement.PrefixExtension" (e.g., "CustTable.ContosoExtension")
-- modelName: Any value (auto-corrected from .rnrproj)
-- addToProject: true (to automatically add to VS project)
-
-IF A FILE WAS CREATED WITH WRONG objectType (e.g. "table" instead of "table-extension"):
-❌ NEVER use PowerShell Move-Item / Rename-Item / Copy-Item to fix it
-✅ Call create_d365fo_file again with the CORRECT objectType and overwrite=true
-
-WORKFLOW:
-1. generate_code(pattern="batch-job", name="MyBatch") → Get X++ code
-2. create_d365fo_file(objectType="class", objectName="MyBatch", sourceCode=<step 1>, addToProject=true)
-
-AXCLASS sourceCode FORMAT — CRITICAL:
-The sourceCode string for a class MUST follow this exact layout:
-  • Class header (attributes + class keyword + extends/implements) WITH member variable
-    declarations INSIDE the outer { } — this block becomes <Declaration>
-  • Method bodies follow AFTER the closing } of the class header — each becomes a <Method>
-
-Example (correct):
-  [DataContractAttribute]
-  public class MyClass extends MyBase
-  {
-      int globalPackageNumber;
-      Qty totalExportedQty;
-  }
-  public int globalPackageNumber(int _v = globalPackageNumber)
-  {
-      globalPackageNumber = _v;
-      return globalPackageNumber;
-  }
-
-Common mistakes:
-  ❌ Putting member variables OUTSIDE the class { } (they will be lost in <Declaration>)
-  ❌ Omitting the class { } block entirely (all content treated as one method)
-  ❌ Putting member variables inside a method body
-
-EXAMPLES:
-- "Create batch job for processing orders" → create_d365fo_file(objectType="class", objectName="ProcessOrdersBatch", addToProject=true)
-- "Create helper class for sales calculations" → create_d365fo_file(objectType="class", objectName="SalesCalculationHelper", addToProject=true)`,
+SourceCode format for classes: class declaration with member vars inside { }, methods after closing }.`,
           inputSchema: {
             type: 'object',
             properties: {
@@ -935,26 +627,7 @@ EXAMPLES:
         },
         {
           name: 'find_references',
-          description: `🔍 Find ALL references (where-used analysis) to a class, method, field, table, or enum across entire D365FO codebase. Essential for impact analysis before making changes.
-
-Searches 584,799+ objects and returns:
-- All classes/methods that reference the target
-- File locations and line numbers
-- Context of how it's used (method calls, instantiation, etc.)
-- Dependencies and impact scope
-
-Use WHEN:
-- Before modifying/deleting a class, method, or field → understand impact
-- Finding all places that use a specific API
-- Understanding dependencies and coupling
-- Impact analysis for refactoring
-- "Who calls this method?"
-
-Examples:
-- find_references("DimensionAttributeValueSet") → finds all classes using dimensions
-- find_references("validateWrite", targetType="method") → finds all validateWrite() calls
-- find_references("CustTable.AccountNum", targetType="field") → finds all uses of AccountNum field
-- find_references("SalesStatus", targetType="enum") → finds all SalesStatus enum usage`,
+          description: 'Find all references (where-used) to a class, method, field, table, or enum across the entire codebase. Essential for impact analysis before refactoring.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1237,30 +910,7 @@ Examples:
         },
         {
           name: 'get_method_signature',
-          description: `⚙️ Get EXACT method signature including parameters, return type, and modifiers. CRITICAL for creating Chain of Command (CoC) extensions - incorrect signatures cause compilation errors.
-
-Returns:
-- Complete method signature with modifiers (public, protected, private, static, final)
-- All parameters with types and default values
-- Return type
-- Method attributes ([Hookable], [Replaceable], etc.)
-
-MANDATORY WORKFLOW for CoC extensions:
-1. get_method_signature(className, methodName) → get EXACT signature
-2. Copy signature EXACTLY (parameters, types, modifiers must match)
-3. Create extension with [ExtensionOf(classStr(...))] attribute
-4. Implement with next keyword for CoC pattern
-
-Use WHEN:
-- Creating Chain of Command extensions (REQUIRED)
-- Before overriding/extending methods
-- Need exact parameter types and default values
-- Verifying method accessibility (public/protected/private)
-
-Examples:
-- get_method_signature("CustTable", "validateWrite") → returns: public boolean validateWrite(boolean _insertMode = false)
-- get_method_signature("SalesTable", "insert") → returns: public void insert()
-- get_method_signature("NumberSeq", "num") → returns: public static NumberSeqCode num()`,
+          description: 'Get exact method signature (modifiers, return type, parameters, attributes). REQUIRED before creating CoC extensions — incorrect signatures cause compilation errors.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1278,25 +928,7 @@ Examples:
         },
         {
           name: 'get_method_source',
-          description: `📄 Get the full X++ source code of a specific method. Use this when you need to understand the complete implementation — business logic, conditions, loops, error handling — not just the signature.
-
-⚠️ ONLY call this for methods you have already confirmed exist via \`get_class_info\`. Never guess or infer a method name from D365FO conventions (e.g. parm*, find, exist) — the method may not be defined in this class. If unsure, call \`get_class_info\` first and pick the method name from the returned list.
-
-Returns:
-- Complete method body as X++ code
-- Method signature
-- Model name
-
-Use WHEN:
-- Analysing what a method actually does (not just its signature)
-- Understanding business logic before writing an extension
-- Reviewing validation rules, posting logic, or workflow steps
-- Comparing implementations across classes
-
-Examples:
-- get_method_source("SalesTable", "validateWrite") → full validation logic
-- get_method_source("CustTable", "insert") → complete insert implementation
-- get_method_source("InventUpd_Reservation", "updateReservation") → full reservation logic`,
+          description: 'Get the full X++ source code of a specific method. Only call for methods confirmed to exist via get_class_info — never guess method names.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1314,37 +946,7 @@ Examples:
         },
         {
           name: 'get_form_info',
-          description: `📋 Get complete D365FO form structure including datasources, control hierarchy (buttons, grids, tabs, groups), methods, and form architecture. Essential for form customization and extensions.
-
-Returns:
-- Datasources with fields, methods, and data source configuration
-- Control tree: ButtonGroups, Grids, Tabs, TabPages, Groups, Fields
-- Form methods (init, run, close, datasource methods)
-- Control properties (Visible, Enabled, Mandatory, etc.)
-- Event handlers and overrides
-
-Use WHEN:
-- Customizing forms with extensions
-- Understanding form structure before modifications
-- Finding control names for code extensions
-- Analyzing datasource relationships
-- Creating form event handlers
-
-⚡ FAST CONTROL LOOKUP — use searchControl parameter:
-  get_form_info("SalesTable", searchControl="General") returns only controls whose
-  name contains "General", with path, parent name, and children.
-  ❌ NEVER use PowerShell Get-Content or grep to find tab names in form XML.
-  ✅ ALWAYS use searchControl instead — this tool CAN read ALL D365FO forms.
-
-⚠️ If you receive a "could not be read from disk" warning, the response will include
-  a ready-to-use retry command with filePath= already filled in.
-  ❌ NEVER fall back to PowerShell when this happens — just retry with filePath.
-
-Examples:
-- get_form_info("SalesTable") → full structure with datasources, grids, tab hierarchy
-- get_form_info("CustTable", searchControl="General") → find the General tab exact name
-- get_form_info("PurchTable", searchControl="LineView") → find the LineView grid name
-- get_form_info("MyForm", filePath="K:\\\\AOSService\\\\...\\\\AxForm\\\\MyForm.xml") → bypass DB lookup`,
+          description: 'Get form structure: datasources, control hierarchy, methods, properties. Use searchControl parameter for fast control name lookup (e.g. searchControl="General" to find tab names). Retry with filePath if disk-read warning occurs.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1382,27 +984,7 @@ Examples:
         },
         {
           name: 'get_query_info',
-          description: `📊 Get complete D365FO query structure including datasources, joins, ranges, field lists, sorting, and grouping. Essential for understanding and extending queries used by forms, reports, and data entities.
-
-Returns:
-- All datasources in the query hierarchy
-- Joins between datasources (inner, outer, exists, notexists) with relations
-- Ranges (WHERE clause filters) with field, value, enabled status
-- Field lists (SELECT clause)
-- Sorting and grouping configuration
-- Query methods and dynamic behavior
-
-Use WHEN:
-- Understanding query logic before modification
-- Creating query extensions to add datasources/ranges
-- Analyzing report or form data sources
-- Debugging query performance issues
-- Understanding data relationships in queries
-
-Examples:
-- get_query_info("CustTransOpenQuery") → open customer transactions query with date/status ranges
-- get_query_info("InventTransQuery") → inventory transactions with item/site joins
-- get_query_info("LedgerJournalTransQuery") → journal lines query structure`,
+          description: 'Get query structure: datasources, joins, ranges, field lists, sorting. Essential for understanding queries used by forms, reports, and data entities.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1425,27 +1007,7 @@ Examples:
         },
         {
           name: 'get_view_info',
-          description: `📊 Get complete D365FO view or data entity structure including mapped fields, data sources, computed columns, relations, methods, and view architecture. Essential for data entity development and OData integration.
-
-Returns:
-- All fields with data source mappings
-- Computed columns (unmapped fields with methods)
-- Underlying tables and relations
-- View methods and business logic
-- Data entity properties (Public, IsPublic, DataManagementEnabled)
-- Staging table configuration (for data entities)
-
-Use WHEN:
-- Developing data entities for integration
-- Understanding OData API structure
-- Creating view extensions with new fields
-- Analyzing data entity business logic
-- Understanding DMF (Data Management Framework) entities
-
-Examples:
-- get_view_info("GeneralJournalAccountEntryView") → ledger entry view with dimension fields
-- get_view_info("CustCustomerV3Entity") → customer OData entity with party/address mappings
-- get_view_info("SalesOrderHeaderV2Entity") → sales order integration entity`,
+          description: 'Get view or data entity structure: mapped fields, data sources, computed columns, relations, OData/DMF configuration. Use get_data_entity_info for OData-specific metadata.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1468,27 +1030,7 @@ Examples:
         },
         {
           name: 'get_enum_info',
-          description: `🔢 Get complete D365FO enum (enumeration) definition including all enum values, integer values, labels, and properties. Essential for understanding enum options and creating enum extensions.
-
-Returns:
-- All enum values with their names
-- Integer value for each enum element
-- Labels/descriptions for each value
-- Enum properties (UseEnumValue, ConfigurationKey, etc.)
-- Style configuration (for display)
-
-Use WHEN:
-- Understanding available enum values for a field
-- Creating enum extensions with new values
-- Writing code that checks enum values
-- Understanding enum integer values for database queries
-- Documenting enum options
-
-Examples:
-- get_enum_info("SalesStatus") → None=0, Backorder=1, Delivered=2, Invoiced=3, Canceled=4
-- get_enum_info("NoYes") → No=0, Yes=1 (most common boolean enum)
-- get_enum_info("CustAccountType") → Customer=0, Vendor=1, Employee=2, etc.
-- get_enum_info("BOMType") → BOM types for production orders`,
+          description: 'Get enum definition: all values with names, integer values, and labels. Use for understanding available options before writing code or extending enums.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1502,27 +1044,7 @@ Examples:
         },
         {
           name: 'get_edt_info',
-          description: `📊 Get complete Extended Data Type (EDT) definition including base type, labels, reference table, and EDT properties. EDT names are UNIQUE ACROSS ALL MODELS.
-
-Returns:
-- Core EDT properties (Extends, EnumType, ReferenceTable, StringSize, DisplayLength, etc.)
-- Label/help/configuration metadata
-- Additional raw EDT properties when present
-
-Use WHEN:
-- You need to inspect an EDT before using it on table fields
-- You need reference table / relation metadata from AxEdt
-- You need to validate EDT inheritance (Extends) and display constraints
-
-FALLBACK Strategy (if EDT not found with modelName):
-- EDT names are globally unique, so omit modelName and retry
-- Call get_edt_info(edtName="MyEdt") without modelName → will search ALL models
-- If first call fails with a specific modelName, ALWAYS retry without modelName
-
-Examples:
-- get_edt_info("WhsInboundShipmentOrderMessageRecId") → finds EDT regardless of model
-- If model-specific lookup fails, retry: get_edt_info("WhsInboundShipmentOrderMessageRecId") (no modelName)
-- get_edt_info("CustAccount") → Customer account number EDT`,
+          description: 'Get EDT definition: base type, extends, reference table, labels, string size. EDT names are globally unique — omit modelName if lookup fails. Use mode="hierarchy" for ancestor chain and field usages.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1546,27 +1068,7 @@ Examples:
         },
         {
           name: 'get_report_info',
-          description: `📄 Read AxReport XML structure directly — datasets, fields, designs, RDL summary.
-
-Use this INSTEAD of PowerShell Get-Content when studying an existing SSRS report.
-Returns structured info without running any shell commands.
-
-Returns:
-- DataSets: name, DataSourceType, Query string, all AxReportDataSetField entries (Name/Alias/DataType/Caption)
-- Designs: name, Caption, linked DataSet, Style, whether RDL is embedded
-- RDL summary (element counts: Tablix, groups, parameters, language) — use includeRdl=true for full RDL
-- DataMethods presence, EmbeddedImages count
-
-Use WHEN:
-- Studying an existing report before creating a similar one
-- Checking what fields/aliases a DataSet exposes
-- Verifying report structure after create_d365fo_file
-- Understanding RDL design without opening Report Designer
-
-Examples:
-- get_report_info("InventValue") → datasets, fields, design structure of InventValue report
-- get_report_info("ContosoInventByZone") → datasets + RDL summary
-- get_report_info("ContosoInventByZone", includeRdl=true) → full embedded RDL XML`,
+          description: 'Read AxReport XML: datasets, fields, designs, RDL summary. Use includeRdl=true for full RDL content. Use instead of PowerShell when studying existing SSRS reports.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1594,20 +1096,7 @@ Examples:
         },
         {
           name: 'search_labels',
-          description: `🏷️ Full-text search across indexed D365FO AxLabelFile labels. Search by text, label ID or comment to find existing labels before creating new ones.
-
-Returns matching label IDs, their translated text, developer comment and the X++ reference syntax (@LabelFileId:LabelId).
-
-Use WHEN:
-- Looking for an existing label to reuse (always do this BEFORE create_label!)
-- Finding the correct reference syntax for a label
-- Discovering what labels exist in a custom model
-- Searching for labels by keyword (e.g. "customer", "batch", "error")
-
-Examples:
-- search_labels("batch group") → finds MyFeature, BatchGroup, etc.
-- search_labels("MyFeature", model="MyModel") → labels in custom MyModel model
-- search_labels("feature", language="cs") → Czech translations`,
+          description: 'Full-text search across indexed D365FO label files. Search by text, label ID, or comment. Returns label IDs, translations, and @LabelFileId:LabelId reference syntax. ALWAYS search before create_label.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1637,23 +1126,7 @@ Examples:
         },
         {
           name: 'get_label_info',
-          description: `🏷️ Get all language translations for a D365FO label ID, or list available AxLabelFile IDs in a model.
-
-Returns:
-- All translations (en-US, cs, de, sk, and other indexed languages)
-- Developer comment
-- X++ reference syntax: @LabelFileId:LabelId
-- Ready-to-use code snippets for X++ and metadata XML
-
-Use WHEN:
-- Verifying that a label has translations in all required languages
-- Getting the correct @LabelFileId:LabelId reference to use in code
-- Listing which label files exist in a custom model (omit labelId)
-
-Examples:
-- get_label_info("MyFeature", model="MyModel") → all translations
-- get_label_info(model="MyModel") → list label files in MyModel
-- get_label_info("BatchGroup") → all languages for BatchGroup`,
+          description: 'Get all language translations for a label ID, or list available label files in a model. Returns translations, developer comment, and @LabelFileId:LabelId reference syntax.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1675,25 +1148,7 @@ Examples:
         },
         {
           name: 'create_label',
-          description: `🏷️ Add a new label to an existing AxLabelFile in a custom D365FO model.
-
-Writes the label into EVERY language .label.txt file that exists in the model, creates XML descriptors if missing, and updates the MCP label index.
-
-By default labels are inserted alphabetically. Set sortLabels=false (or LABEL_SORT_ORDER=append in env) to append new labels at the end preserving existing file order.
-
-⚠️ ALWAYS call search_labels first to check if a suitable label already exists!
-
-Process:
-1. Reads each existing .label.txt file for the model
-2. Checks for duplicate label ID
-3. Inserts the new label (alphabetically or appended, based on sortLabels)
-4. Writes the updated file back to disk
-5. Updates the SQLite label index
-
-Examples:
-- create_label("MyNewField", "MyModel", "MyModel", [{language:"en-US", text:"My new field"}, {language:"cs", text:"Moje nové pole"}])
-- create_label with createLabelFileIfMissing=true → creates AxLabelFile structure from scratch
-- create_label with sortLabels=false → appends the new label at the end of each .label.txt file`,
+          description: 'Add a new label to an existing AxLabelFile. Writes into every language .label.txt, creates XML descriptors if missing, updates SQLite index. ALWAYS call search_labels first. Label IDs describe meaning — never add model prefix.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1775,19 +1230,7 @@ Examples:
         },
         {
           name: 'rename_label',
-          description: `🏷️ Rename a D365FO label ID everywhere it is used.
-
-Renames the label in ALL of the following places:
-1. Every .label.txt file in the model (the label entry itself)
-2. Every X++ source file (.xpp) that references @LabelFileId:OldId
-3. Every XML metadata file that references @LabelFileId:OldId (Label, HelpText, Caption, etc.)
-4. Updates the MCP SQLite label index
-
-⚠️ Run with dryRun=true first to preview the impact before committing!
-
-Examples:
-- rename_label(oldLabelId="OldName", newLabelId="NewName", labelFileId="MyModel", model="MyModel", dryRun=true)
-- rename_label(oldLabelId="OldName", newLabelId="NewName", labelFileId="MyModel", model="MyModel")`,
+          description: `Rename a D365FO label ID across all .label.txt files, X++ sources, and XML metadata in the model. Also updates the SQLite label index. Use dryRun=true first to preview impact.`,
           inputSchema: {
             type: 'object',
             properties: {
@@ -1834,13 +1277,7 @@ Examples:
         },
         {
           name: 'get_table_patterns',
-          description: `📊 Analyze common field types, index patterns, and relation structures for D365FO tables.
-
-Helps understand table design patterns before creating new tables. Use tableGroup to analyze patterns in standard table groups (Main, Transaction, Parameter, etc.) or similarTo to find tables with similar structure.
-
-Examples:
-- get_table_patterns(tableGroup="Transaction") → Analyze common fields/indexes in transaction tables
-- get_table_patterns(similarTo="CustTable") → Find tables with similar structure to CustTable`,
+          description: 'Analyze common field types, index patterns, and relation structures for D365FO tables. Filter by tableGroup (Main, Transaction, etc.) or find tables similar to a given table.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1863,14 +1300,7 @@ Examples:
         },
         {
           name: 'get_form_patterns',
-          description: `📋 Analyze common datasource configurations, control hierarchies, and D365FO form patterns.
-
-Helps understand form design patterns before creating new forms. Use formPattern to analyze D365FO standard patterns, dataSource to find forms using a specific table, or similarTo for specific form analysis.
-
-Examples:
-- get_form_patterns(formPattern="SimpleList") → Analyze SimpleList pattern forms
-- get_form_patterns(dataSource="CustTable") → Find all forms using CustTable
-- get_form_patterns(similarTo="CustTableListPage") → Find forms similar to CustTableListPage`,
+          description: 'Analyze common datasource configurations, control hierarchies, and D365FO form patterns. Filter by formPattern, dataSource table name, or similarTo form.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1897,16 +1327,7 @@ Examples:
         },
         {
           name: 'suggest_edt',
-          description: `🔍 Suggest Extended Data Types (EDT) for a field name using fuzzy matching and pattern analysis.
-
-Analyzes indexed EDT metadata to recommend appropriate Extended Data Types based on field name patterns and optional context. Returns confidence-ranked suggestions with EDT properties (base type, enum, reference table, label).
-
-Use BEFORE creating table fields to ensure you reuse existing EDTs instead of primitive types.
-
-Examples:
-- suggest_edt(fieldName="CustomerAccount") → Suggests CustAccount EDT
-- suggest_edt(fieldName="OrderAmount", context="sales order") → Suggests AmountCur, SalesAmountCur, etc.
-- suggest_edt(fieldName="TransDate") → Suggests TransDate EDT`,
+          description: 'Suggest Extended Data Types (EDT) for a field name using fuzzy matching. Returns confidence-ranked suggestions with EDT properties. Use BEFORE creating table fields to reuse existing EDTs.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -1929,20 +1350,7 @@ Examples:
         },
         {
           name: 'generate_smart_table',
-          description: `🎨 AI-driven table generation with intelligent field/index/relation suggestions.
-
-Generates AxTable XML using pattern analysis from indexed metadata. Supports multiple strategies:
-1. Copy structure from existing table (copyFrom parameter)
-2. Analyze table group patterns and generate common fields (tableGroup + generateCommonFields)
-3. Use field hints and suggest EDTs (fieldsHint parameter)
-4. Combine all strategies for comprehensive generation
-
-Returns complete XML ready for create_d365fo_file or manual save.
-
-Examples:
-- generate_smart_table(name="MyOrderTable", tableGroup="Transaction", generateCommonFields=true)
-- generate_smart_table(name="MyTable", copyFrom="CustTable")
-- generate_smart_table(name="MyTable", fieldsHint="RecId, Name, Amount")`,
+          description: 'AI-driven table generation with intelligent field/index/relation suggestions from pattern analysis. Strategies: copyFrom existing table, tableGroup + generateCommonFields, or fieldsHint with auto-suggested EDTs. Returns complete XML for create_d365fo_file.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -2009,20 +1417,7 @@ Examples:
         },
         {
           name: 'generate_smart_form',
-          description: `🎨 AI-driven form generation with intelligent datasource/control suggestions.
-
-Generates AxForm XML using pattern analysis from indexed metadata. Supports multiple strategies:
-1. Copy structure from existing form (copyFrom parameter)
-2. Auto-generate datasource and grid from table (dataSource + generateControls)
-3. Analyze form pattern and apply structure (formPattern parameter)
-4. Combine strategies for comprehensive generation
-
-Returns complete XML ready for create_d365fo_file or manual save.
-
-Examples:
-- generate_smart_form(name="MyOrderForm", dataSource="MyOrderTable", generateControls=true)
-- generate_smart_form(name="MyForm", copyFrom="CustTableListPage")
-- generate_smart_form(name="MyForm", formPattern="SimpleList", dataSource="MyTable")`,
+          description: 'AI-driven form generation with intelligent datasource/control suggestions from pattern analysis. Strategies: copyFrom existing form, dataSource + generateControls, or formPattern application. Returns complete XML for create_d365fo_file.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -2072,31 +1467,7 @@ Examples:
         },
         {
           name: 'generate_smart_report',
-          description: `🎨 AI-driven SSRS report generation — creates up to 5 D365FO objects in one call.
-
-Generates:
-1. TmpTable (TempDB) — report data storage
-2. Contract class (DataContractAttribute) — dialog parameters
-3. DP class (SrsReportDataProviderBase) — data processing
-4. Controller class (SrsReportRunController) — menu item entry point (optional)
-5. AxReport XML + RDL design — dataset + tablix bound to DP/TmpTable
-
-Strategies:
-- fieldsHint: comma-separated field names → auto-suggest EDTs, build TmpTable + report fields
-- fields: structured field specs with explicit EDTs and .NET data types
-- contractParams: dialog parameters → Contract class with parm methods
-- copyFrom: copy field structure from existing report's TmpTable
-- designStyle: SimpleList (default) or GroupedWithTotals
-
-⛔ NEVER call generate_smart_report without fieldsHint, fields, or copyFrom — no fields = no XML.
-⛔ NEVER add model prefix to the name parameter — prefix is applied automatically.
-⛔ On Azure/Linux: call create_d365fo_file for EACH returned object block, in order.
-⛔ On Windows: DO NOT call create_d365fo_file — files are written directly.
-
-Examples:
-- generate_smart_report(name="InventByZones", fieldsHint="ItemId, ItemName, Qty, Zone", caption="Inventory by Zones")
-- generate_smart_report(name="CustBalance", fieldsHint="CustAccount, Name, Balance", contractParams=[{name:"FromDate",type:"TransDate"},{name:"ToDate",type:"TransDate"}])
-- generate_smart_report(name="SalesReport", copyFrom="SalesInvoice")`,
+          description: `AI-driven SSRS report generation — creates up to 5 objects (TmpTable, Contract, DP, Controller, AxReport+RDL) in one call. Use fieldsHint or fields for field specs, contractParams for dialog parameters. Never add model prefix to name — auto-applied. On Azure/Linux: call create_d365fo_file for each returned object. On Windows: files are written directly.`,
           inputSchema: {
             type: 'object',
             properties: {
@@ -2175,18 +1546,7 @@ Examples:
       // ── New tools: security, menu items, extensions ──────────────────────────────
       {
         name: 'get_security_artifact_info',
-        description: `Get detailed info for a D365FO security privilege, duty, or role.
-Walks the full hierarchy: Role → Duties → Privileges → Entry Points.
-
-Use for:
-- Auditing what a role or duty grants access to
-- Finding which roles cover a specific privilege
-- Understanding the entry-point/access-level details of a privilege
-
-Examples:
-  { name: "CustTableFullControl", artifactType: "privilege" }
-  { name: "CustTableMaintain", artifactType: "duty", includeChain: true }
-  { name: "AccountsReceivableClerk", artifactType: "role" }`,
+        description: 'Get detailed info for a D365FO security privilege, duty, or role. Walks full hierarchy: Role → Duties → Privileges → Entry Points.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2203,13 +1563,7 @@ Examples:
       },
       {
         name: 'get_menu_item_info',
-        description: `Get details for a D365FO menu item including target object and full security chain.
-
-Shows the privilege → duty → role chain that grants access to this menu item.
-
-Examples:
-  { name: "CustTable", itemType: "display" }
-  { name: "LedgerJournalTable", itemType: "any" }`,
+        description: 'Get details for a D365FO menu item including target object and full security chain (privilege → duty → role).',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2226,19 +1580,7 @@ Examples:
       },
       {
         name: 'find_coc_extensions',
-        description: `Find all Chain of Command (CoC) extensions for a D365FO class or table method.
-
-Also shows event handler subscriptions (SubscribesTo) for the target class/table.
-
-Use this before writing a CoC extension to:
-1. Check if the method is already wrapped
-2. Understand which models extend this class
-3. Find potential conflicts
-
-Examples:
-  { className: "SalesFormLetter" }
-  { className: "SalesLine", methodName: "validateWrite" }
-  { className: "CustTable", includeEventHandlers: true }`,
+        description: 'Find all Chain of Command (CoC) extensions and event handler subscriptions for a D365FO class or table. Use before writing a CoC extension to check for conflicts.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2255,13 +1597,7 @@ Examples:
       },
       {
         name: 'get_table_extension_info',
-        description: `Get all extensions for a D365FO table and show the effective merged schema.
-
-Lists every extension across all models that add fields, indexes, or methods to the table.
-
-Examples:
-  { tableName: "CustTable" }
-  { tableName: "SalesLine", includeEffectiveSchema: true }`,
+        description: 'Get all extensions for a D365FO table across all models and show the effective merged schema (base + extension fields/indexes/methods).',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2277,14 +1613,7 @@ Examples:
       },
       {
         name: 'get_data_entity_info',
-        description: `Get D365FO-specific metadata for a data entity (AxDataEntityView).
-
-Shows OData settings, DMF configuration, staging table, data sources, and keys.
-Use instead of get_view_info when working with entities for OData/DMF integrations.
-
-Examples:
-  { entityName: "CustCustomerV3Entity" }
-  { entityName: "SalesOrderHeaderV2Entity" }`,
+        description: 'Get D365FO data entity metadata: OData settings, DMF configuration, staging table, data sources, and keys. Use instead of get_view_info for OData/DMF work.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2295,15 +1624,7 @@ Examples:
       },
       {
         name: 'find_event_handlers',
-        description: `Find all event handler subscriptions for a D365FO class or table.
-
-Searches for static SubscribesTo handlers and delegate += subscriptions.
-Use before adding event handlers to check for duplicates.
-
-Examples:
-  { targetTable: "CustTable" }
-  { targetClass: "SalesFormLetter", eventName: "onPostRun" }
-  { targetTable: "SalesLine", eventName: "onValidatedWrite" }`,
+        description: 'Find all event handler subscriptions (SubscribesTo, delegate +=) for a D365FO class or table. Use before adding event handlers to check for duplicates.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2321,14 +1642,7 @@ Examples:
       },
       {
         name: 'get_security_coverage_for_object',
-        description: `Show what security privileges, duties, and roles cover a D365FO object.
-
-Traces the reverse chain: object → menu items → privileges → duties → roles.
-
-Examples:
-  { objectName: "CustTable" }
-  { objectName: "LedgerJournalTable", objectType: "form" }
-  { objectName: "CustTableListPage", objectType: "menu-item" }`,
+        description: 'Show what security privileges, duties, and roles cover a D365FO object. Traces reverse chain: object → menu items → privileges → duties → roles.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2345,19 +1659,7 @@ Examples:
       },
       {
         name: 'analyze_extension_points',
-        description: `Analyze available extension points for a D365FO class, table, or form.
-
-For classes: CoC-eligible methods, replaceable methods, delegates, and blocked methods.
-For tables: 8 standard table events + custom delegates.
-For forms: data sources and form methods.
-Shows which extension points are already used by existing extensions.
-
-Use this before writing any extension.
-
-Examples:
-  { objectName: "SalesLine", objectType: "table" }
-  { objectName: "SalesFormLetter", objectType: "class" }
-  { objectName: "CustTable", showExistingExtensions: true }`,
+        description: 'Analyze available extension points for a D365FO class, table, or form. Shows CoC-eligible methods, replaceable methods, delegates, blocked methods, and which points are already extended.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2379,20 +1681,7 @@ Examples:
       },
       {
         name: 'recommend_extension_strategy',
-        description: `Recommends the best D365FO extensibility mechanism for a given scenario.
-
-Prevents common design mistakes — e.g. using CoC where a Business Event or delegate is appropriate,
-or using a Business Event for inbound data where a Data Entity is correct.
-
-Returns: recommended mechanism, reasoning, risks/caveats, alternatives, anti-patterns, and next MCP tool calls.
-
-Use BEFORE writing any extension code to ensure the right approach.
-
-Examples:
-  { goal: "validate that SalesLine quantity is positive", objectName: "SalesLine" }
-  { goal: "send order confirmation to external ERP" }
-  { goal: "add custom field to CustTable form", objectName: "CustTable" }
-  { goal: "import vendor data from CSV", scenario: "inbound-data" }`,
+        description: 'Recommends the best D365FO extensibility mechanism for a given scenario (CoC, event handler, business event, data entity, etc.). Prevents common design mistakes. Returns recommendation, reasoning, risks, alternatives, and next MCP tool calls.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2418,24 +1707,7 @@ Examples:
       },
       {
         name: 'validate_object_naming',
-        description: `Validate a proposed D365FO object name against naming conventions.
-
-Checks:
-1. Extension naming rules: {Base}{Prefix}_Extension (class) or {Base}.{Prefix}Extension (AOT)
-2. Prefix requirements: custom objects must use ISV/model prefix — two valid patterns:
-   - Direct prefix:    MYVendPaymTermsMaintain    (prefix concatenated directly)
-   - Prefix separator: MY_VendPaymTermsMaintain   (prefix + underscore + name — also valid)
-   Underscore at any other position is an error.
-3. Type-specific rules: privilege → View/Maintain suffix, data entity → Entity suffix
-4. Conflict detection: exact match + similar names against the symbol index
-
-Auto-detects the model prefix from EXTENSION_PREFIX env var (same as get_workspace_info).
-Pass modelPrefix explicitly to override.
-
-Examples:
-  { proposedName: "VendTableMY_Extension", objectType: "class-extension", baseObjectName: "VendTable", modelPrefix: "MY" }
-  { proposedName: "CustTable.MyExtension", objectType: "table-extension", baseObjectName: "CustTable", modelPrefix: "My" }
-  { proposedName: "MY_VendPaymTermsMaintain", objectType: "security-privilege", modelPrefix: "MY" }`,
+        description: 'Validate a proposed D365FO object name against naming conventions: extension naming, ISV prefix, type-specific suffixes, and conflict detection against the symbol index.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -2461,28 +1733,7 @@ Examples:
       },
       {
         name: 'get_workspace_info',
-        description: `🔌 ALWAYS call this FIRST at the start of every D365FO session to verify the workspace configuration.
-
-Returns the configured model name, package path (custom metadata root), framework directory (Microsoft metadata root, populated only on UDE / Power Platform Tools setups), project path, environment type, EXTENSION_PREFIX value, and effective object prefix.
-
-On UDE there are two metadata roots: custom code lives under the package path, Microsoft standard code under the framework dir. Only the package path is writable — never create or modify files under the framework dir.
-
-Explicitly flags whether the model name is a placeholder (MyModel, MyPackage, etc.) — if so, STOP and inform the user before doing anything else.
-Also warns when EXTENSION_PREFIX is not set in the server environment (prefix will fall back to model name, which may be wrong for models with hyphens like "fm-mcp").
-
-When the configured modelName IS a placeholder, this tool auto-detects the real model name
-from the .rnrproj file and shows it as a concrete fix suggestion, so the user knows exactly
-what value to put in .mcp.json.
-
-**Solution switching (VS 2022):** When the user opens a different D365FO solution or says
-"switch to <ProjectName>", call get_workspace_info with projectName (preferred) or projectPath.
-  - projectName: just the model name, e.g. "ContosoEDS" — server resolves the path automatically.
-  - projectPath: full path to the .rnrproj file (fallback when name is ambiguous).
-The server switches context immediately without restart.
-If D365FO_SOLUTIONS_PATH is configured, the output lists all available projects.
-
-Use this instead of get_label_info or search to detect the correct model — those tools return
-SOURCE models of existing objects, not the TARGET model for new objects.`,
+        description: `ALWAYS call FIRST at session start. Returns model name, package path, framework directory, project path, environment type, and EXTENSION_PREFIX. Flags placeholder model names and missing prefix. Use projectName/projectPath params for solution switching. This is the authoritative source for target model — not search results.`,
         inputSchema: {
           type: 'object',
           properties: {
@@ -2500,14 +1751,7 @@ SOURCE models of existing objects, not the TARGET model for new objects.`,
       },
       {
         name: 'verify_d365fo_project',
-        description: `Verify that D365FO objects exist on disk at the correct AOT path and are referenced in the Visual Studio project (.rnrproj) file.
-
-Use this INSTEAD OF PowerShell to check whether create_d365fo_file placed files correctly.
-Reports ✅/❌ for each object on both disk presence and project inclusion.
-
-Examples:
-  { objects: [{ objectType: "table", objectName: "MyTable" }, { objectType: "class", objectName: "MyClass" }], projectPath: "K:\\\\AosService\\\\PackagesLocalDirectory\\\\MyPkg\\\\MyModel\\\\MyModel.rnrproj" }
-  { objects: [{ objectType: "menu-item-action", objectName: "MyMenuItem" }], modelName: "MyModel" }`,
+        description: 'Verify that D365FO objects exist on disk at the correct AOT path and are referenced in the .rnrproj project file. Use instead of PowerShell to check create_d365fo_file results.',
         inputSchema: {
           type: 'object',
           properties: {


### PR DESCRIPTION
- Compress all 54 tool descriptions in mcpServer.ts (remove emoji, examples, verbose blocks)
- Restructure systemInstructions.ts: decision tree first, fix factual errors (where/in clause), merge duplicate sections
- Add SysDa, Query object model, and FormRun lifecycle coverage to system instructions
- Reduce copilot-instructions.md from ~460 lines to ~50 line thin pointer (full rules via MCP prompt)
- Update docs (SETUP.md, QUICK_START.md, MCP_TOOLS.md) to reflect new instruction architecture