### PR TITLE
Fix/build project tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,8 +40,7 @@ LOG_LEVEL=debug               # error | warn | info | debug
 # =============================================================================
 # Standard single-VM setup. All tools are available.
 # ------------------------------------------------------------------
-
-MCP_SERVER_MODE=full
+MCP_SERVER_MODE=full          # full (default) | read-only | write-only
 
 # Dev environment detection: auto (default), traditional, ude (Power Platform Tools)
 # 'auto' detects UDE when XPP config files exist in %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\

--- a/tests/tools/buildProject.test.ts
+++ b/tests/tools/buildProject.test.ts
@@ -58,13 +58,14 @@ vi.mock('../../src/utils/operationLocks.js', () => ({
   forceReleaseLock: vi.fn().mockResolvedValue(undefined),
 }));
 
+import path from 'path';
 import { buildProjectTool } from '../../src/tools/buildProject';
 
 const PROJECT_PATH = 'C:\\MyProject\\MyProject.rnrproj';
 const MODEL_NAME = 'MyModel';
 const RNRPROJ_XML = `<Project><Model>${MODEL_NAME}</Model></Project>`;
 const PKG = 'C:\\AOSService\\PackagesLocalDirectory';
-const XPPC = `${PKG}\\bin\\xppc.exe`;
+const XPPC = path.join(PKG, 'bin', 'xppc.exe');
 
 function makeFakeChild(pid = 12345) {
   const child: any = {
@@ -263,7 +264,7 @@ describe('build_d365fo_project', () => {
   it('passes -metadata and -compilermetadata args to xppc.exe', async () => {
     const CUSTOM = 'C:\\Repos\\MyCode\\Metadata';
     const MSFT = 'C:\\AOSService\\PackagesLocalDirectory';
-    const xppc = `${MSFT}\\bin\\xppc.exe`;
+    const xppc = path.join(MSFT, 'bin', 'xppc.exe');
 
     cfgGetCustomPackagesPath.mockResolvedValue(CUSTOM);
     cfgGetMicrosoftPackagesPath.mockResolvedValue(MSFT);


### PR DESCRIPTION
This pull request updates how file paths are constructed in the test suite to improve cross-platform compatibility. Instead of hardcoding Windows-style paths, it now uses Node's `path.join` to generate file paths, ensuring tests work consistently across different operating systems.

**Test improvements for path handling:**

* Updated the construction of the `xppc.exe` path in `tests/tools/buildProject.test.ts` to use `path.join` instead of string concatenation, improving cross-platform compatibility.
* Modified the test for passing arguments to `xppc.exe` to also use `path.join` for path construction, ensuring consistency and reliability in tests.