### PR TITLE
fix: skip roots/list when server is statically configured (instanced mode)

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -137,6 +137,15 @@ export function createXppMcpServer(context: XppServerContext): Server {
       process.stderr.write(`[mcpServer] ℹ️  HTTP mode — skipping roots/list (transport is request-response only)\n`);
       return;
     }
+    // Instanced mode: if .mcp.json / env vars already provide both a model name and
+    // a path, the workspace is fully known — no need to ask the client for its open
+    // folders. Skipping the call avoids a -32001 timeout when mcp-remote is the
+    // transport (it has a hard-coded 60 s timeout and cannot complete a
+    // server-initiated request over HTTP).
+    if (await getConfigManager().isStaticallyConfigured()) {
+      process.stderr.write(`[mcpServer] ℹ️  Static config complete — skipping roots/list (instanced mode)\n`);
+      return;
+    }
     try {
       const result = await server.request(
         { method: 'roots/list', params: {} },
@@ -157,6 +166,10 @@ export function createXppMcpServer(context: XppServerContext): Server {
     );
     const isHttpMode = !!process.env.WEBSITES_PORT || process.env.MCP_FORCE_HTTP === 'true';
     if (!server.getClientCapabilities()?.roots || isHttpMode) {
+      return;
+    }
+    if (await getConfigManager().isStaticallyConfigured()) {
+      process.stderr.write(`[mcpServer] ℹ️  Static config complete — skipping roots/list on change (instanced mode)\n`);
       return;
     }
     try {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -137,11 +137,10 @@ export function createXppMcpServer(context: XppServerContext): Server {
       process.stderr.write(`[mcpServer] ℹ️  HTTP mode — skipping roots/list (transport is request-response only)\n`);
       return;
     }
-    // Instanced mode: if .mcp.json / env vars already provide both a model name and
-    // a path, the workspace is fully known — no need to ask the client for its open
-    // folders. Skipping the call avoids a -32001 timeout when mcp-remote is the
-    // transport (it has a hard-coded 60 s timeout and cannot complete a
-    // server-initiated request over HTTP).
+    // Instanced mode: .mcp.json / env vars already provide both model name and
+    // workspace path — the workspace is fully known and immutable per instance.
+    // Skipping the call avoids a -32001 timeout when mcp-remote is the transport
+    // (hard-coded 60 s timeout, server-initiated requests cannot complete over HTTP).
     if (await getConfigManager().isStaticallyConfigured()) {
       process.stderr.write(`[mcpServer] ℹ️  Static config complete — skipping roots/list (instanced mode)\n`);
       return;
@@ -168,6 +167,8 @@ export function createXppMcpServer(context: XppServerContext): Server {
     if (!server.getClientCapabilities()?.roots || isHttpMode) {
       return;
     }
+    // Instanced mode: workspace is immutable per server instance — the
+    // notification is irrelevant and the request would time out over mcp-remote.
     if (await getConfigManager().isStaticallyConfigured()) {
       process.stderr.write(`[mcpServer] ℹ️  Static config complete — skipping roots/list on change (instanced mode)\n`);
       return;

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -659,6 +659,44 @@ class ConfigManager {
   }
 
   /**
+   * Returns true when the static configuration (`.mcp.json` + `D365FO_*` env vars)
+   * already provides enough workspace context to work without calling `roots/list`.
+   *
+   * In instanced mode every project has its own dedicated server instance whose
+   * config file contains both a model name and at least one path. Calling
+   * `roots/list` in this situation is unnecessary and causes a -32001 timeout when
+   * `mcp-remote` is the transport (it has a hard-coded 60 s request timeout and
+   * cannot complete a server-initiated request over HTTP).
+   *
+   * Awaits `ensureLoaded()` so it is safe to call before the first tool invocation.
+   */
+  async isStaticallyConfigured(): Promise<boolean> {
+    await this.ensureLoaded();
+
+    const fileContext = this.config?.context || this.config?.servers?.context;
+
+    const hasModelName = !!(
+      fileContext?.modelName ||
+      process.env.D365FO_MODEL_NAME
+    );
+
+    const hasPath = !!(
+      fileContext?.workspacePath       ||
+      fileContext?.packagePath         ||
+      fileContext?.customPackagesPath  ||
+      fileContext?.projectPath         ||
+      fileContext?.solutionPath        ||
+      process.env.D365FO_WORKSPACE_PATH          ||
+      process.env.D365FO_PACKAGE_PATH            ||
+      process.env.D365FO_CUSTOM_PACKAGES_PATH    ||
+      process.env.D365FO_PROJECT_PATH            ||
+      process.env.D365FO_SOLUTION_PATH
+    );
+
+    return hasModelName && hasPath;
+  }
+
+  /**
    * Get workspace path from configuration
    * Returns the base PackagesLocalDirectory path if workspacePath contains it
    */

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -663,36 +663,25 @@ class ConfigManager {
    * already provides enough workspace context to work without calling `roots/list`.
    *
    * In instanced mode every project has its own dedicated server instance whose
-   * config file contains both a model name and at least one path. Calling
-   * `roots/list` in this situation is unnecessary and causes a -32001 timeout when
-   * `mcp-remote` is the transport (it has a hard-coded 60 s request timeout and
-   * cannot complete a server-initiated request over HTTP).
+   * config contains both a model name and at least one path. Calling `roots/list`
+   * is then unnecessary and causes a -32001 timeout when `mcp-remote` is the
+   * transport (it has a hard-coded 60 s request timeout and cannot complete a
+   * server-initiated request over HTTP). In instanced mode the workspace is also
+   * immutable per instance, so `roots_list_changed` notifications are irrelevant.
    *
    * Awaits `ensureLoaded()` so it is safe to call before the first tool invocation.
    */
   async isStaticallyConfigured(): Promise<boolean> {
     await this.ensureLoaded();
-
-    const fileContext = this.config?.context || this.config?.servers?.context;
-
-    const hasModelName = !!(
-      fileContext?.modelName ||
-      process.env.D365FO_MODEL_NAME
-    );
-
+    const ctx = this.getContext();
+    const hasModelName = !!ctx?.modelName;
     const hasPath = !!(
-      fileContext?.workspacePath       ||
-      fileContext?.packagePath         ||
-      fileContext?.customPackagesPath  ||
-      fileContext?.projectPath         ||
-      fileContext?.solutionPath        ||
-      process.env.D365FO_WORKSPACE_PATH          ||
-      process.env.D365FO_PACKAGE_PATH            ||
-      process.env.D365FO_CUSTOM_PACKAGES_PATH    ||
-      process.env.D365FO_PROJECT_PATH            ||
-      process.env.D365FO_SOLUTION_PATH
+      ctx?.workspacePath ||
+      ctx?.packagePath   ||
+      ctx?.customPackagesPath ||
+      ctx?.projectPath   ||
+      ctx?.solutionPath
     );
-
     return hasModelName && hasPath;
   }
 

--- a/tests/utils/configManager.test.ts
+++ b/tests/utils/configManager.test.ts
@@ -350,3 +350,70 @@ describe('extractModelFromFilePath', () => {
     expect(extractModelFromFilePath('')).toBeNull();
   });
 });
+
+// ─── isStaticallyConfigured ───────────────────────────────────────────────────
+
+describe('isStaticallyConfigured', () => {
+  it('returns true when modelName + workspacePath provided in file config', async () => {
+    const mgr = makeManager({ modelName: 'TestModel', workspacePath: 'K:\\AosService\\PackagesLocalDirectory' });
+    expect(await mgr.isStaticallyConfigured()).toBe(true);
+  });
+
+  it('returns true when modelName + packagePath provided in file config', async () => {
+    const mgr = makeManager({ modelName: 'TestModel', packagePath: 'K:\\AosService\\PackagesLocalDirectory' });
+    expect(await mgr.isStaticallyConfigured()).toBe(true);
+  });
+
+  it('returns true when modelName + projectPath provided in file config', async () => {
+    const mgr = makeManager({ modelName: 'TestModel', projectPath: 'K:\\Projects\\TestModel.rnrproj' });
+    expect(await mgr.isStaticallyConfigured()).toBe(true);
+  });
+
+  it('returns true when modelName + solutionPath provided in file config', async () => {
+    const mgr = makeManager({ modelName: 'TestModel', solutionPath: 'K:\\Projects\\TestModel.sln' });
+    expect(await mgr.isStaticallyConfigured()).toBe(true);
+  });
+
+  it('returns true when modelName + customPackagesPath provided in file config', async () => {
+    const mgr = makeManager({ modelName: 'TestModel', customPackagesPath: 'K:\\AosService\\PackagesLocalDirectory' });
+    expect(await mgr.isStaticallyConfigured()).toBe(true);
+  });
+
+  it('returns false when modelName is present but no path', async () => {
+    const mgr = makeManager({ modelName: 'TestModel' });
+    expect(await mgr.isStaticallyConfigured()).toBe(false);
+  });
+
+  it('returns false when path is present but no modelName', async () => {
+    const mgr = makeManager({ workspacePath: 'K:\\AosService\\PackagesLocalDirectory' });
+    expect(await mgr.isStaticallyConfigured()).toBe(false);
+  });
+
+  it('returns false when config is empty', async () => {
+    const mgr = makeManager({});
+    expect(await mgr.isStaticallyConfigured()).toBe(false);
+  });
+
+  it('returns true when both provided via env vars', async () => {
+    process.env.D365FO_MODEL_NAME = 'TestModel';
+    process.env.D365FO_WORKSPACE_PATH = 'K:\\AosService\\PackagesLocalDirectory';
+    const mgr = makeManager({});
+    expect(await mgr.isStaticallyConfigured()).toBe(true);
+    delete process.env.D365FO_MODEL_NAME;
+    delete process.env.D365FO_WORKSPACE_PATH;
+  });
+
+  it('returns true when modelName from env var, path from file config', async () => {
+    process.env.D365FO_MODEL_NAME = 'TestModel';
+    const mgr = makeManager({ workspacePath: 'K:\\AosService\\PackagesLocalDirectory' });
+    expect(await mgr.isStaticallyConfigured()).toBe(true);
+    delete process.env.D365FO_MODEL_NAME;
+  });
+
+  it('returns false when only D365FO_MODEL_NAME env var is set', async () => {
+    process.env.D365FO_MODEL_NAME = 'TestModel';
+    const mgr = makeManager({});
+    expect(await mgr.isStaticallyConfigured()).toBe(false);
+    delete process.env.D365FO_MODEL_NAME;
+  });
+});


### PR DESCRIPTION
In instanced mode the .mcp.json / D365FO_* env vars already provide both a model name and a workspace path, so calling roots/list is unnecessary. With mcp-remote as transport the call causes a -32001 timeout (60 s hard limit, server-initiated requests cannot complete over HTTP).

- Add ConfigManager.isStaticallyConfigured() that checks config + env vars
- Guard the initial roots/list fetch and the change-handler with the new check
- Log a clear message when skipping so the reason is visible in stderr