### PR TITLE
add EXTENSION_NAMING_STYLE to decouple prefix from extension token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,15 @@ EXTENSION_PREFIX=ISV_
 # Most projects use only a prefix — leave unset unless your naming convention requires a suffix.
 # EXTENSION_SUFFIX=
 
+# Extension naming style — how extension elements/classes are named:
+#   prefix     (default): embed the EXTENSION_PREFIX infix, per MS prefix guideline
+#                         (e.g. CustTable.CrExtension, CustTableCr_Extension)
+#   model-name          : embed the MODEL NAME, matching the Visual Studio default
+#                         (e.g. CustTable.ContosoRobotics, CustTable_ContosoRobotics_Extension).
+#                         EXTENSION_PREFIX still applies to new objects and extension fields/methods.
+# Use model-name when your model name is long/customer-specific but your prefix is a short abbreviation.
+# EXTENSION_NAMING_STYLE=prefix
+
 # Extraction scope: all (standard + custom) | standard | custom
 # EXTRACT_MODE=all
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ PowerShell / any terminal command **WILL HANG** in VS 2022 / VS 2026 MCP integra
 5. Never use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
 6. Never use hardcoded strings in Info/warning/error — use `@Model:Label`
 7. Call `search_labels()` before `create_label()` — reuse existing labels
-8. Extension class naming: `[ExtensionOf(...)] final class {Target}{Prefix}_Extension`
+8. Extension naming depends on `EXTENSION_NAMING_STYLE` (check `get_workspace_info`). Default `prefix` → class `{Target}{Prefix}_Extension`, element `{Target}.{Prefix}Extension`; `model-name` → class `{Target}_{ModelName}_Extension`, element `{Target}.{ModelName}`. Pass the BASE name to `create_d365fo_file` and let the tool apply the token — don't hand-build the infix.
 
 ## Full Instructions
 

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -72,6 +72,27 @@ Takes 1–2 hours (standard Microsoft models are large). Only needed when Micros
 
 ---
 
+## Extension Naming Style
+
+When code-gen tools name an **extension element** (table/form/view/etc. extension) or an **extension class** (CoC / augmentation), the token that distinguishes your extension from others is controlled by `EXTENSION_NAMING_STYLE`:
+
+```env
+EXTENSION_PREFIX=CR
+EXTENSION_NAMING_STYLE=prefix        # default — or "model-name"
+```
+
+| Style | Element extension | Extension class |
+|-------|-------------------|-----------------|
+| `prefix` (default) | `CustTable.CrExtension` | `CustTableCr_Extension` |
+| `model-name` | `CustTable.ContosoRobotics` | `CustTable_ContosoRobotics_Extension` |
+
+- **`prefix`** embeds the `EXTENSION_PREFIX` infix (Microsoft's prefix-based naming guideline).
+- **`model-name`** embeds the **model name**, matching the Visual Studio developer-tools default (which uses the model name because it is already guaranteed unique). Use this when your model name is long/customer-specific (e.g. `ContosoRobotics`) but your prefix is a short abbreviation (e.g. `CR`) — the prefix still applies to **new** objects (`CRMyTable`) and to fields/methods added inside extensions (`CRApprovingWorker`); only the extension element/class token switches to the model name.
+
+Run `get_workspace_info` to see the active style and worked examples of exactly what the tools will emit.
+
+---
+
 ## Searching Custom Extensions
 
 Use `search_extensions` to search only within your custom/ISV models:

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -9,7 +9,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { Parser, Builder } from 'xml2js';
 import { getConfigManager, fallbackPackagePath } from '../utils/configManager.js';
-import { registerCustomModel, resolveObjectPrefix, applyObjectPrefix, getObjectSuffix, applyObjectSuffix } from '../utils/modelClassifier.js';
+import { registerCustomModel, resolveObjectPrefix, applyObjectPrefix, getObjectSuffix, applyObjectSuffix, getExtensionNamingStyle } from '../utils/modelClassifier.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
@@ -3506,15 +3506,20 @@ export async function handleCreateD365File(
 
     // Apply extension prefix to object name
     const objectPrefix = resolveObjectPrefix(actualModelName);
+    const namingStyle = getExtensionNamingStyle();
 
     // If EXTENSION_PREFIX differs from modelName, the AI may have embedded the modelName
     // in the extension name. Strip it so applyObjectPrefix injects the correct prefix only.
+    // NOTE: this stripping only makes sense for the prefix-infix style. Under the
+    // model-name style the model name IS the desired token, so the stripping below is
+    // skipped and applyObjectPrefix (given actualModelName) normalises the name instead.
     let effectiveObjectName = args.objectName;
 
     // Case A: dot-notation extension elements (table/form/EDT/enum extensions)
     // e.g. "CustTable.MyModelExtension" with modelName="MyModel" → "CustTable.Extension"
     // applyObjectPrefix then produces "CustTable.MyExtension"
     if (
+      namingStyle !== 'model-name' &&
       args.objectName.includes('.') &&
       args.objectName.toLowerCase().endsWith('extension') &&
       actualModelName &&
@@ -3536,6 +3541,7 @@ export async function handleCreateD365File(
     // e.g. "SalesFormLetterContoso_Extension" with modelName="ContosoExt" → "SalesFormLetter_Extension"
     // applyObjectPrefix then produces "SalesFormLetterContoso_Extension"
     if (
+      namingStyle !== 'model-name' &&
       args.objectName.endsWith('_Extension') &&
       actualModelName &&
       objectPrefix.toLowerCase() !== actualModelName.toLowerCase()
@@ -3568,9 +3574,20 @@ export async function handleCreateD365File(
       );
     }
 
-    let finalObjectName = applyObjectPrefix(effectiveObjectName, objectPrefix);
+    // Pass actualModelName so the model-name naming style can use it as the extension
+    // token. For the default prefix style (or non-extension objects) it is ignored.
+    let finalObjectName = applyObjectPrefix(effectiveObjectName, objectPrefix, actualModelName);
+    // Trailing suffix (EXTENSION_SUFFIX) applies to NEW objects only — never to
+    // extension elements/classes. (For the prefix style applyObjectSuffix already
+    // skips _Extension and dot-notation "…Extension" names; this guard additionally
+    // covers the model-name style's "Base.ModelName" form, which has no "Extension"
+    // word and would otherwise wrongly receive the suffix.)
+    const isExtensionObjectType =
+      args.objectType === 'class-extension' || DOT_NOTATION_EXTENSION_TYPES.has(args.objectType);
     const objectSuffix = getObjectSuffix();
-    finalObjectName = applyObjectSuffix(finalObjectName, objectSuffix);
+    if (!isExtensionObjectType) {
+      finalObjectName = applyObjectSuffix(finalObjectName, objectSuffix);
+    }
     if (finalObjectName !== args.objectName) {
       console.error(`[create_d365fo_file] Applied naming: ${args.objectName} → ${finalObjectName}`);
     }

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -46,7 +46,7 @@ import { securityCoverageInfoTool } from './securityCoverageInfo.js';
 import { analyzeExtensionPointsTool } from './analyzeExtensionPoints.js';
 import { validateObjectNamingTool } from './validateObjectNaming.js';
 import { verifyD365ProjectTool } from './verifyD365Project.js';
-import { resolveObjectPrefix, isCustomModel, getObjectSuffix } from '../utils/modelClassifier.js';
+import { resolveObjectPrefix, isCustomModel, getObjectSuffix, getExtensionNamingStyle, deriveExtensionInfix } from '../utils/modelClassifier.js';
 import { getStdioSessionInfo } from '../utils/stdioSessionInfo.js';
 import { updateSymbolIndexTool } from './updateSymbolIndex.js';
 import { buildProjectTool } from './buildProject.js';
@@ -469,6 +469,33 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
             : `ℹ️  EXTENSION_SUFFIX is not set. No suffix will be applied. This is normal — most projects use prefixes only.`,
           ``,
         ];
+
+        // ── Extension naming style ────────────────────────────────────────────
+        // The prefix doubles as the extension infix UNLESS EXTENSION_NAMING_STYLE
+        // is set to "model-name", in which case extension elements/classes embed the
+        // MODEL NAME (Visual Studio default). The tool ALWAYS normalises the extension
+        // token to whatever this style dictates — so pass the BASE object name and let
+        // the tool name it; do not hand-build the infix yourself.
+        const extNamingStyle = getExtensionNamingStyle();
+        const extInfix = deriveExtensionInfix(effectivePrefix);
+        const sampleClassExt = extNamingStyle === 'model-name' && modelName
+          ? `CustTable_${modelName}_Extension`
+          : `CustTable${extInfix}_Extension`;
+        const sampleElemExt = extNamingStyle === 'model-name' && modelName
+          ? `CustTable.${modelName}`
+          : `CustTable.${extInfix}Extension`;
+        lines.push(
+          `## Extension Naming`,
+          ``,
+          `EXTENSION_NAMING_STYLE: ${process.env.EXTENSION_NAMING_STYLE?.trim() || '(not set → "prefix")'}`,
+          extNamingStyle === 'model-name'
+            ? `✅ model-name style — extension token is the MODEL NAME (Visual Studio default).`
+            : `ℹ️  prefix style (default) — extension token is the EXTENSION_PREFIX infix.`,
+          `  • Extension class  → ${sampleClassExt}`,
+          `  • Element extension → ${sampleElemExt}`,
+          `  ⚠️  Pass the BASE object name (e.g. "CustTable") to create_d365fo_file and let the tool apply the token — any infix you embed will be normalised to the above.`,
+          ``,
+        );
 
         if (isPlaceholder) {
           // Only scan .rnrproj files when model name looks like a placeholder — avoids

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -60,6 +60,28 @@ export function getObjectSuffix(): string {
 }
 
 /**
+ * Resolve the extension-naming style from the environment.
+ *
+ *  - 'prefix' (default): extension elements and extension classes embed the
+ *    EXTENSION_PREFIX as an infix, per Microsoft's prefix-based guideline
+ *    (e.g. CustTable.CrExtension, CustTableCr_Extension).
+ *
+ *  - 'model-name': extension elements and extension classes embed the MODEL NAME,
+ *    matching the Visual Studio developer-tools default
+ *    (e.g. CustTable.ContosoRobotics, CustTable_ContosoRobotics_Extension).
+ *    EXTENSION_PREFIX still applies to NEW objects and to fields/methods added
+ *    inside extensions — only the extension element/class token changes.
+ *
+ * Configured via EXTENSION_NAMING_STYLE. Any value other than 'model-name'
+ * (including unset) resolves to 'prefix' so existing setups are unchanged.
+ */
+export function getExtensionNamingStyle(): 'prefix' | 'model-name' {
+  return process.env.EXTENSION_NAMING_STYLE?.trim().toLowerCase() === 'model-name'
+    ? 'model-name'
+    : 'prefix';
+}
+
+/**
  * Apply a configurable suffix to a NEW model element name.
  * The suffix is appended at the end of the object name.
  *
@@ -167,8 +189,15 @@ export function deriveExtensionInfix(resolvedPrefix: string): string {
  *
  * Case-insensitive check prevents double-prefixing.
  */
-export function applyObjectPrefix(objectName: string, prefix: string): string {
+export function applyObjectPrefix(objectName: string, prefix: string, modelName?: string): string {
   if (!prefix) return objectName;
+
+  // When the model-name style is active AND a model name is supplied, extension
+  // elements/classes embed the model name instead of the prefix infix (VS default).
+  // Only the extension branches (dot-notation + _Extension) diverge — regular
+  // objects still use the prefix, so callers that create new objects (and don't
+  // pass a model name) are completely unaffected.
+  const useModelName = !!modelName && getExtensionNamingStyle() === 'model-name';
 
   // Extension infix form — PascalCase without underscore (e.g. "XY" → "Xy" when env had "XY_")
   const extensionInfix = deriveExtensionInfix(prefix);
@@ -199,6 +228,13 @@ export function applyObjectPrefix(objectName: string, prefix: string): string {
     const basePart = objectName.slice(0, dotIdx);
     const suffixPart = objectName.slice(dotIdx + 1);
 
+    // model-name style: VS default → BaseElement.ModelName
+    // (no prefix infix, no "Extension" word). Replaces whatever token follows the
+    // dot so a re-run is idempotent (BaseElement.ModelName → BaseElement.ModelName).
+    if (useModelName) {
+      return `${basePart}.${modelName}`;
+    }
+
     if (suffixPart.toLowerCase().endsWith('extension')) {
       // Always return the correctly-cased suffix — never preserve the original casing.
       // Without this, "VendTrans.CTSOExtension" with EXTENSION_PREFIX=CTSO_ would not be
@@ -218,6 +254,21 @@ export function applyObjectPrefix(objectName: string, prefix: string): string {
   // IMPORTANT: objectName MUST be the BASE class name + "_Extension" WITHOUT any prefix infix.
   if (objectName.endsWith('_Extension')) {
     const baseName = objectName.slice(0, -'_Extension'.length);
+
+    // model-name style: VS default → Base_ModelName_Extension.
+    // Strip any trailing model-name token (with or without separating underscore)
+    // so re-running is idempotent and never produces Base_ModelName_ModelName_Extension.
+    if (useModelName) {
+      let cleanBase = baseName.replace(/_+$/, '');
+      const lowerModel = modelName!.toLowerCase();
+      if (cleanBase.toLowerCase().endsWith('_' + lowerModel)) {
+        cleanBase = cleanBase.slice(0, cleanBase.length - lowerModel.length - 1);
+      } else if (cleanBase.toLowerCase().endsWith(lowerModel)) {
+        cleanBase = cleanBase.slice(0, cleanBase.length - lowerModel.length);
+      }
+      cleanBase = cleanBase.replace(/_+$/, '');
+      return `${cleanBase}_${modelName}_Extension`;
+    }
 
     // Check if the extension infix is already present at the end (case-insensitive)
     if (baseName.toLowerCase().endsWith(extensionInfix.toLowerCase())) {

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -65,6 +65,7 @@ vi.mock('../../src/utils/modelClassifier', () => ({
   applyObjectPrefix: vi.fn((name: string) => name),
   getObjectSuffix: vi.fn(() => ''),
   applyObjectSuffix: vi.fn((name: string) => name),
+  getExtensionNamingStyle: vi.fn(() => 'prefix'),
   isCustomModel: vi.fn(() => true),
   isStandardModel: vi.fn(() => false),
 }));

--- a/tests/utils/applyObjectPrefix.test.ts
+++ b/tests/utils/applyObjectPrefix.test.ts
@@ -18,12 +18,18 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { applyObjectPrefix } from '../../src/utils/modelClassifier';
 
 const originalPrefix = process.env.EXTENSION_PREFIX;
+const originalStyle = process.env.EXTENSION_NAMING_STYLE;
 
 afterEach(() => {
   if (originalPrefix === undefined) {
     delete process.env.EXTENSION_PREFIX;
   } else {
     process.env.EXTENSION_PREFIX = originalPrefix;
+  }
+  if (originalStyle === undefined) {
+    delete process.env.EXTENSION_NAMING_STYLE;
+  } else {
+    process.env.EXTENSION_NAMING_STYLE = originalStyle;
   }
 });
 
@@ -150,5 +156,72 @@ describe('applyObjectPrefix — NORMAL CASE (regular objects)', () => {
   it('returns unchanged when prefix is empty', () => {
     delete process.env.EXTENSION_PREFIX;
     expect(applyObjectPrefix('MyTable', '')).toBe('MyTable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EXTENSION_NAMING_STYLE=model-name — extension token is the MODEL NAME (VS default)
+// ---------------------------------------------------------------------------
+describe('applyObjectPrefix — model-name style (EXTENSION_NAMING_STYLE=model-name)', () => {
+  // Short prefix that differs from the long model name — the scenario this style exists for.
+  const setup = () => {
+    process.env.EXTENSION_PREFIX = 'CR';
+    process.env.EXTENSION_NAMING_STYLE = 'model-name';
+  };
+
+  it('class extension uses model name: Base_Extension → Base_ModelName_Extension', () => {
+    setup();
+    expect(applyObjectPrefix('CustTable_Extension', 'CR', 'ContosoRobotics'))
+      .toBe('CustTable_ContosoRobotics_Extension');
+  });
+
+  it('class extension is idempotent (no double model name)', () => {
+    setup();
+    expect(applyObjectPrefix('CustTable_ContosoRobotics_Extension', 'CR', 'ContosoRobotics'))
+      .toBe('CustTable_ContosoRobotics_Extension');
+  });
+
+  it('class extension strips a stray prefix infix and uses the model name', () => {
+    setup();
+    // double underscore left by upstream model-name stripping must collapse cleanly
+    expect(applyObjectPrefix('CustTable__Extension', 'CR', 'ContosoRobotics'))
+      .toBe('CustTable_ContosoRobotics_Extension');
+  });
+
+  it('element extension uses model name with no "Extension" word: Base.Extension → Base.ModelName', () => {
+    setup();
+    expect(applyObjectPrefix('CustTable.Extension', 'CR', 'ContosoRobotics'))
+      .toBe('CustTable.ContosoRobotics');
+  });
+
+  it('element extension is idempotent (Base.ModelName → Base.ModelName)', () => {
+    setup();
+    expect(applyObjectPrefix('CustTable.ContosoRobotics', 'CR', 'ContosoRobotics'))
+      .toBe('CustTable.ContosoRobotics');
+  });
+
+  it('element extension replaces a foreign/prefix token with the model name', () => {
+    setup();
+    expect(applyObjectPrefix('CustTable.CrExtension', 'CR', 'ContosoRobotics'))
+      .toBe('CustTable.ContosoRobotics');
+  });
+
+  it('NEW objects still use the short prefix (model name is ignored for non-extensions)', () => {
+    setup();
+    expect(applyObjectPrefix('MyTable', 'CR', 'ContosoRobotics')).toBe('CRMyTable');
+  });
+
+  it('falls back to prefix-infix behavior when no model name is passed', () => {
+    setup();
+    expect(applyObjectPrefix('CustTable_Extension', 'CR')).toBe('CustTableCR_Extension');
+  });
+
+  it('prefix style is unaffected even when a model name is passed', () => {
+    process.env.EXTENSION_PREFIX = 'CR';
+    delete process.env.EXTENSION_NAMING_STYLE; // default = prefix
+    expect(applyObjectPrefix('CustTable_Extension', 'CR', 'ContosoRobotics'))
+      .toBe('CustTableCR_Extension');
+    expect(applyObjectPrefix('CustTable.Extension', 'CR', 'ContosoRobotics'))
+      .toBe('CustTable.CRExtension');
   });
 });


### PR DESCRIPTION
## Summary

  Adds an opt-in `EXTENSION_NAMING_STYLE` setting that **decouples the short `EXTENSION_PREFIX` from the token used to
  name extension elements/classes.**

  Until now the extension infix was always derived from `EXTENSION_PREFIX`, which implicitly assumed the prefix equals
  the model name. Projects that use a long, model-specific name (e.g. `ContosoRobotics`) but a short prefix abbreviation
   (e.g. `CR`) could not produce the Visual Studio developer-tools default extension names. This is the same mismatch
  behind #430.

  ## Behavior

  `EXTENSION_NAMING_STYLE` (env var):

  | Style | Element extension | Extension class |
  |-------|-------------------|-----------------|
  | `prefix` *(default, unchanged)* | `CustTable.CrExtension` | `CustTableCr_Extension` |
  | `model-name` | `CustTable.ContosoRobotics` | `CustTable_ContosoRobotics_Extension` |

  - **`prefix`** — Microsoft's prefix-based naming guideline (embeds the `EXTENSION_PREFIX` infix).
  - **`model-name`** — the Visual Studio default (embeds the **model name**, which is already guaranteed unique).
  `EXTENSION_PREFIX` still applies to **new** objects (`CRMyTable`) and to fields/methods added inside extensions
  (`CRApprovingWorker`); only the extension element/class token switches to the model name.

  > [!NOTE]
  > The default (`prefix`) path is **byte-identical** to current behavior. Existing setups are unaffected — this is
  purely additive and opt-in.

  ## Changes

  - **`src/utils/modelClassifier.ts`** — new `getExtensionNamingStyle()`; `applyObjectPrefix` gains an optional
  `modelName` argument with idempotent model-name branches for dot-notation (`Base.ModelName`) and `_Extension`
  (`Base_ModelName_Extension`) names.
  - **`src/tools/createD365File.ts`** — threads the model name into `applyObjectPrefix`; the model-name-stripping cases
  are now guarded to the `prefix` style; `EXTENSION_SUFFIX` is no longer applied to extension object types (the
  `Base.ModelName` form has no `Extension` word and would otherwise be wrongly suffixed).
  - **`src/tools/toolHandler.ts`** — `get_workspace_info` now reports the active style with worked examples and
  instructs the agent to pass the **base** object name (and not hand-build the infix).
  - **Docs** — `.env.example`, `docs/CUSTOM_EXTENSIONS.md`, `.github/copilot-instructions.md`.
  - **Tests** — model-name-style coverage added to `tests/utils/applyObjectPrefix.test.ts` (incl. idempotency /
  no-double-token guards); mock updated in `tests/tools/file-ops.test.ts`.

  ## Testing

  - `npm run build` — clean
  - `npm test` — **477 passing** (23 files), including the new model-name cases.

  ## Related

  Realigns extension naming with the intent of #430 (model name as the extension token), but only when
  `EXTENSION_NAMING_STYLE=model-name` is set.