### PR TITLE
treat commented-out keys as present in missing-settings check

### DIFF
--- a/instances/rebuild-instance.ps1
+++ b/instances/rebuild-instance.ps1
@@ -34,11 +34,13 @@ function Get-EnvPort([string]$envFile) {
 }
 
 # ── Helper: extract variable names from a .env file ─────────────────────────
+# Treats commented-out lines (e.g. "# KEY=value") as present-but-disabled so
+# that the missing-settings check doesn't flag vars the user has intentionally
+# left commented in their instance .env.
 function Get-EnvVarNames([string]$envFile) {
     $names = @()
     foreach ($line in (Get-Content $envFile)) {
-        # Match uncommented KEY=value lines (skip comments and blank lines)
-        if ($line -match '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=') {
+        if ($line -match '^\s*#?\s*([A-Za-z_][A-Za-z0-9_]*)\s*=') {
             $names += $Matches[1]
         }
     }


### PR DESCRIPTION
  ## Summary

  Fixes a false-positive in `instances/rebuild-instance.ps1`'s "missing settings" check: optional settings that ship
  **commented-out** in `.env.example` were being reported as missing from every instance.

  ## Background

  When rebuilding a multi-instance setup, `rebuild-instance.ps1` compares each instance's `.env` against the repo's
  `.env.example` and warns about keys present in the example but absent from the instance. The helper that extracts key
  names, `Get-EnvVarNames`, only matched **uncommented** `KEY=value` lines:

  ```powershell
  if ($line -match '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=') { ... }
  ```
  So any key that .env.example intentionally leaves commented (e.g. # EXTENSION_SUFFIX=, # EXTENSION_NAMING_STYLE=) was
  treated as nonexistent — and then flagged as "new setting missing from your instance," even though leaving it
  commented is the intended default. That's noise for every optional, off-by-default setting.

  Change

  Allow an optional leading # in the key regex so a commented # KEY= counts as present-but-disabled:

  - if ($line -match '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=') {
  + if ($line -match '^\s*#?\s*([A-Za-z_][A-Za-z0-9_]*)\s*=') {

  The missing-settings warning now fires only for keys that are genuinely absent from an instance .env.

> **Note:** The match is applied symmetrically to both files being compared (`.env.example` and the instance `.env`),
  which is the desired behavior: a key the instance has stubbed out as a comment is also correctly treated as "known,"
  not missing.