### PR TITLE
feat(tools): uncap get_method_source response size

### DIFF
--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -118,6 +118,8 @@ const TOOL_CAP_SIZES: Record<string, number | 'uncapped'> = {
   create_d365fo_file:               'uncapped',
   generate_d365fo_xml:              'uncapped',
   get_report_info:                  'uncapped',
+  // Method source must never be truncated — partial code is useless
+  get_method_source:                'uncapped',
   // New tools with longer output
   get_security_artifact_info:       8000,
   get_security_coverage_for_object: 8000,


### PR DESCRIPTION
The default 5000-char cap truncated long method bodies mid-code, making the returned source unusable. Method source must always be returned in full — partial code is actively harmful for analysis and code generation.

Added get_method_source to TOOL_CAP_SIZES with 'uncapped' to bypass the global truncation applied by capToolResponse().