### PR TITLE
Fix analysis-without-write workflow gap and harden write tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,11 @@ EXTENSION_PREFIX=ISV_
 # D365FO_CUSTOM_PACKAGES_PATH=C:\CustomXppCode                # UDE: ModelStoreFolder
 # D365FO_MICROSOFT_PACKAGES_PATH=C:\Users\...\PackagesLocalDirectory  # UDE: FrameworkDirectory
 # D365FO_BRIDGE_LOG_FILE=C:\Temp\d365fo-bridge.log
+#
+# Bridge timeouts (milliseconds). Raise these on large installations or slow VMs
+# where metadata-provider init or big searches exceed the defaults.
+# BRIDGE_READY_TIMEOUT_MS=30000   # time to wait for the C# bridge to become ready (default 30000)
+# BRIDGE_CALL_TIMEOUT_MS=60000    # per-call timeout for a single bridge request (default 60000)
 
 # =============================================================================
 # MODE: HYBRID  (local write-only companion for an Azure-hosted read-only instance)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,7 @@ PowerShell / any terminal command **WILL HANG** in VS 2022 / VS 2026 MCP integra
 | Action | Tool |
 |--------|------|
 | Create D365FO object | `create_d365fo_file` (never `create_file`) |
-| Edit existing object | `modify_d365fo_file` with `dryRun=true` first |
+| Edit existing object | describe change + confirm in chat, then `modify_d365fo_file` (applies immediately) |
 | Search objects | `search()` / `batch_search()` |
 | Read class/table/form | `get_class_info` / `get_table_info` / `get_form_info` |
 | Method signature (for CoC) | `get_method_signature` |
@@ -37,7 +37,7 @@ PowerShell / any terminal command **WILL HANG** in VS 2022 / VS 2026 MCP integra
 ## Key Rules (condensed)
 
 1. Model name comes from `.mcp.json` — never infer from search results
-2. `dryRun=true` is mandatory for every `modify_d365fo_file` — VS 2022 has no undo UI
+2. `modify_d365fo_file`/`create_d365fo_file` APPLY IMMEDIATELY (no dry-run) — describe the change and confirm in chat first; revert with `undo_last_modification` (or pass `createBackup=true`)
 3. Never run `build_d365fo_project()` automatically — only on explicit user request
 4. Never copy default parameter values into CoC wrapper signatures
 5. Never use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -76,9 +76,16 @@ Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
 ```
 
 GitHub Copilot automatically picks up `copilot-instructions.md` as a bootstrap layer.
-It contains minimal rules (tool mapping, key constraints, terminal prohibition) that apply
-before the MCP server connects. The full X++ development instructions are delivered at
-runtime via the MCP prompt `xpp_system_instructions` (defined in `src/prompts/systemInstructions.ts`).
+It contains the rules the agent relies on **without any extra action** — tool mapping, key
+constraints, the terminal prohibition, and the confirm-before-write workflow (create/modify
+apply immediately, there is no dry-run). **This step is not optional:** it is the only channel
+that delivers the workflow rules to the agent automatically.
+
+A fuller version of these instructions is also exposed as the MCP prompt `xpp_system_instructions`
+(defined in `src/prompts/systemInstructions.ts`). ⚠️ MCP prompts are **opt-in** — they are NOT
+injected automatically; the user must explicitly invoke the prompt in the client (e.g. pick
+`xpp_system_instructions` from the MCP prompt picker in chat). Do not rely on it being present by
+default — keep `copilot-instructions.md` in place so the critical rules are always loaded.
 
 ---
 

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -61,8 +61,18 @@ export type { BridgeReadyPayload, BridgeInfoPayload } from './bridgeTypes.js';
 export * from './bridgeTypes.js';
 
 const BRIDGE_EXE_NAME = 'D365MetadataBridge.exe';
-const READY_TIMEOUT_MS = 30_000;   // 30s for metadata provider init
-const CALL_TIMEOUT_MS = 60_000;    // 60s per call (large searches can take time)
+
+/** Parse a positive-integer env var with a fallback (ignores invalid/non-positive values). */
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+// Configurable via env so large installations / slow VMs can raise the limits.
+const READY_TIMEOUT_MS = envInt('BRIDGE_READY_TIMEOUT_MS', 30_000); // 30s for metadata provider init
+const CALL_TIMEOUT_MS = envInt('BRIDGE_CALL_TIMEOUT_MS', 60_000);   // 60s per call (large searches can take time)
 
 export interface BridgeClientOptions {
   /** Path to the D365MetadataBridge.exe (auto-detected if omitted) */

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -40,7 +40,7 @@ You are GitHub Copilot assisting with Dynamics 365 Finance & Operations (D365FO)
 ## Decision Tree (evaluate FIRST for every request)
 
 1. **Creating D365FO object?** → \`create_d365fo_file\` (never \`create_file\`)
-2. **Modifying existing object?** → \`modify_d365fo_file\` with \`dryRun=true\` first
+2. **Modifying existing object?** → describe the change + confirm in chat, then \`modify_d365fo_file\` (applies immediately, no preview)
 3. **Generating X++ code?** → \`analyze_code_patterns\` + \`search\` → then generate
 4. **Mentions D365FO object?** → Use MCP tools to verify it exists
 5. **Need field/method/API info?** → \`get_class_info\`, \`get_table_info\`, \`get_method_signature\`
@@ -121,15 +121,15 @@ Use this guide to select the correct tool:
 - Example of WRONG reasoning: task involves a report → search returns objects from "ContosoReports" → ❌ DO NOT use "ContosoReports" as the model. Use the configured model from .mcp.json.
 - **NEVER switch projects autonomously.** The MCP server auto-detects the correct project from the VS 2022 workspace. Do NOT call get_workspace_info(projectName=...) because you think the task belongs to a different model \u2014 the user decides which solution to open; you work within it. If you believe a different model is needed, ASK the user first.
 
-### 1b. dryRun Review Workflow (VS 2022 has no Keep/Undo UI)
-**\`dryRun=true\` is MANDATORY for every \`modify_d365fo_file\` call.** VS 2022's GitHub Copilot Chat does not display per-edit Keep/Undo buttons, so the diff must be reviewed in chat before disk is touched.
+### 1b. Confirm-before-write Review Workflow (VS 2022 has no Keep/Undo UI)
+**\`modify_d365fo_file\` and \`create_d365fo_file\` APPLY IMMEDIATELY — there is no dry-run/preview mode.** The moment the tool is called the change is written to disk via IMetadataProvider. VS 2022's GitHub Copilot Chat does not display per-edit Keep/Undo buttons, so review must happen in chat *before* the call.
 
 Required sequence for every modification:
-1. Call \`modify_d365fo_file\` with \`dryRun=true\` → present the returned diff to the user.
+1. **Describe the exact change in chat** (target object, operation, the X++/property before→after) and ask the user to confirm.
 2. Wait for explicit confirmation ("apply", "ok", "yes", etc.).
-3. Re-call the SAME operation with \`dryRun=false\`.
+3. Call \`modify_d365fo_file\` ONCE to apply. Revert with \`undo_last_modification\` if needed (or pass \`createBackup=true\` to keep a .bak copy).
 
-Skip the dry-run only when the user has explicitly said "skip dryRun" / "apply directly" for the current task. Batched operations (multiple \`modify_d365fo_file\` calls in a row) require dry-run for EACH call — never apply a chain of edits without per-step confirmation.
+After the call, read the response: \`isError=true\` means the change did NOT apply — fix the cause and retry. A success response means the file is already written; do not wait for further confirmation to "apply" — it is done. For batched edits, confirm the whole set up front, then apply each call in sequence.
 
 **Git checkpointing (recommended):** Before non-trivial multi-file tasks, suggest the user create a feature branch (\`git switch -c mcp/<task-name>\`) so changes can be reviewed/discarded via VS 2022 → *View → Git Changes*. Do NOT create branches autonomously — propose and wait for the user.
 
@@ -176,7 +176,7 @@ PowerShell and Python scripts hang indefinitely in VS 2022 MCP integration. When
 1. \`get_method_signature("CustTable", "validateWrite")\` → exact signature
 2. \`find_coc_extensions("CustTable")\` → check existing wrappers
 3. \`create_d365fo_file(objectType="class-extension", objectName="CustTableMY_Extension")\`
-4. \`modify_d365fo_file(operation="add-method", sourceCode="<CoC wrapper>", dryRun=true)\`
+4. Confirm the wrapper in chat, then \`modify_d365fo_file(operation="add-method", sourceCode="<CoC wrapper>")\` (applies immediately)
 
 ### Finding Methods
 - Semantic (concept): \`search("total", type="method")\`

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -489,6 +489,10 @@ export function createXppMcpServer(context: XppServerContext): Server {
           name: 'create_d365fo_file',
           description: `Create D365FO AOT object file (.xml) in the correct PackagesLocalDirectory location with proper XML structure and UTF-8 BOM. Auto-adds to VS project (.rnrproj).
 
+⚠️ THIS IS THE WRITE/COMPLETION STEP. Analysis tools (analyze_code_patterns, search, get_class_info/get_table_info, generate_code/generate_smart_*) only PREPARE the design — they do NOT create anything on disk. Once the design is known, you MUST CALL create_d365fo_file to actually write the file. Do NOT stop after analysis or after presenting generated code: the task is incomplete until this tool has run and returned success (isError=false).
+
+On error this tool returns isError=true with a message (e.g. file already exists, Microsoft model blocked). Read it and fix/retry — never treat a ⚠️/❌ response as success.
+
 Object types: class, table, enum, form, query, view, data-entity, report, edt, security-privilege, security-duty, security-role, menu-item-display/action/output, menu, table/class/form/enum/edt/data-entity-extension, menu-item-*-extension, menu-extension, business-event, tile, kpi.
 
 For extensions: objectName="BaseObject.PrefixExtension" (e.g. "CustTable.ContosoExtension").
@@ -666,7 +670,7 @@ SourceCode format for classes: class declaration with member vars inside { }, me
         },
         {
           name: 'modify_d365fo_file',
-          description: '⚠️ WINDOWS ONLY: Safely modifies an existing D365FO XML file (class, table, enum, form, query, view). Supports adding/removing/modifying methods and fields, modifying properties. Validates XML after modification. IMPORTANT: This tool MUST run locally on Windows D365FO VM - it CANNOT work through Azure HTTP proxy (Linux).',
+          description: '⚠️ WINDOWS ONLY: Safely modifies an existing D365FO XML file (class, table, enum, form, query, view). Supports adding/removing/modifying methods and fields, modifying properties. Validates XML after modification. IMPORTANT: This tool MUST run locally on Windows D365FO VM - it CANNOT work through Azure HTTP proxy (Linux).\n\n⚠️ APPLIES IMMEDIATELY — there is NO dry-run/preview mode. The moment this tool is called it writes the change to disk via IMetadataProvider.Update(). Therefore: BEFORE calling, describe the exact change you intend to make in chat and let the user confirm; only then call this tool to apply it. To revert, use undo_last_modification (git checkout), or pass createBackup=true to also keep a .bak copy. On success the response reports the applied operation. On error the response has isError=true with a message — read it and fix/retry; never treat a ⚠️/❌ response as success.',
           inputSchema: {
             type: 'object',
             properties: {

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -3406,7 +3406,7 @@ export async function handleCreateD365File(
         '  3. Add workspacePath ending with the package/model name: { "context": { "workspacePath": "C:\\\\AosService\\\\PackagesLocalDirectory\\\\YourModel" } }\n' +
         '  4. Add projectPath or solutionPath to .mcp.json so the model is auto-extracted from .rnrproj';
       console.error(`[create_d365fo_file] ${errorMsg}`);
-      return { content: [{ type: 'text', text: errorMsg }] };
+      return { content: [{ type: 'text', text: errorMsg }], isError: true };
     }
 
     // ⚠️ CRITICAL WARNING: If no project/solution path available anywhere
@@ -3467,7 +3467,8 @@ export async function handleCreateD365File(
               type: 'text',
               text: errorMsg
             }
-          ]
+          ],
+          isError: true,
         };
       }
     }
@@ -3784,6 +3785,7 @@ export async function handleCreateD365File(
                 `  3. Choose a different objectName.`,
             },
           ],
+          isError: true,
         };
       }
     }
@@ -4172,6 +4174,7 @@ export async function handleCreateD365File(
           text: `❌ Error creating D365FO file:\n\n${error instanceof Error ? error.message : 'Unknown error'}`,
         },
       ],
+      isError: true,
     };
   }
 }

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -348,7 +348,7 @@ const ModifyD365FileArgsSchema = z.object({
   propertyValue: z.string().optional().describe('New property value'),
   
   // Options
-  createBackup: z.boolean().optional().default(false).describe('Create backup before modification (default: false)'),
+  createBackup: z.boolean().optional().default(false).describe('Create a .bak backup of the file before modifying it (default: false). Changes can also be reverted with undo_last_modification (git checkout) without a backup. Set true when the file is not under source control.'),
   modelName: z.string().optional().describe('Model name (auto-detected if not provided). Pass this if the file was just created and is not yet indexed.'),
   packageName: z.string().optional().describe('Package name. Auto-resolved if omitted.'),
   workspacePath: z.string().optional().describe('Path to workspace for finding file'),
@@ -413,6 +413,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               `**Candidates** (${resolution.multiple.length}):\n${candidateList}\n\n` +
               `Re-call \`add-control\` with the exact \`parentControl\` name from the list above.`,
           }],
+          isError: true,
         };
       }
 

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -328,8 +328,15 @@ describe('create_d365fo_file', () => {
         addToProject: false,
       }),
     );
-    expect((result as any).isError).toBeFalsy();
-    expect(result.content[0].text).toMatch(/created|success|MyNewClass/i);
+    if (process.platform === 'win32') {
+      expect((result as any).isError).toBeFalsy();
+      expect(result.content[0].text).toMatch(/created|success|MyNewClass/i);
+    } else {
+      // Non-Windows: creation legitimately fails (requires a Windows D365FO VM) and is
+      // now correctly reported as isError rather than masked as a success message.
+      expect((result as any).isError).toBe(true);
+      expect(result.content[0].text).toMatch(/non-Windows|Windows/i);
+    }
   });
 
   it('creates a table-extension file', async () => {
@@ -343,7 +350,8 @@ describe('create_d365fo_file', () => {
         addToProject: false,
       }),
     );
-    expect((result as any).isError).toBeFalsy();
+    // Non-Windows: creation fails (needs Windows) and is correctly reported as isError.
+    expect((result as any).isError).toBe(process.platform !== 'win32');
   });
 
   it('auto-converts bare extension name to dot-notation (Case C fix)', async () => {
@@ -382,7 +390,8 @@ describe('create_d365fo_file', () => {
         addToProject: false,
       }),
     );
-    expect((result as any).isError).toBeFalsy();
+    // Non-Windows: creation fails (needs Windows) and is correctly reported as isError.
+    expect((result as any).isError).toBe(process.platform !== 'win32');
   });
 
   it('returns error when objectType is missing', async () => {


### PR DESCRIPTION
This pull request introduces several important changes to the D365FO MCP extension, focusing on improving the reliability and clarity of file modification workflows, error handling, and user guidance. The most significant updates are the removal of the "dry-run" workflow for file modifications (changes now apply immediately), clearer documentation and instructions for users and Copilot, improved error reporting for file operations, and enhanced configurability for bridge timeouts.

**Key changes:**

### Workflow and User Guidance

* Removed the "dry-run" (preview) mode for `modify_d365fo_file` and `create_d365fo_file`. Changes now apply immediately; users are required to describe and confirm changes in chat before applying them. Documentation and Copilot instructions have been updated to reflect this new confirm-before-write workflow. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L30-R30) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L40-R40) [[3]](diffhunk://#diff-387d5c2d72b4e3605e85cd319fbd67da69445b6838b3c1ffed5a2488824f6c64L43-R43) [[4]](diffhunk://#diff-387d5c2d72b4e3605e85cd319fbd67da69445b6838b3c1ffed5a2488824f6c64L124-R132) [[5]](diffhunk://#diff-387d5c2d72b4e3605e85cd319fbd67da69445b6838b3c1ffed5a2488824f6c64L179-R179) [[6]](diffhunk://#diff-22495e73839073b1b84e771b0b9097a8820e466365fd27b123f7fe7edeeb3047L79-R88)
* Updated tool descriptions and system instructions to emphasize that file creation/modification tools write changes to disk immediately and provide guidance on reverting changes using `undo_last_modification` or backups. [[1]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2R492-R495) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L669-R673) [[3]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637L351-R351)

### Error Handling and Reporting

* All file creation and modification tools now consistently set `isError: true` on failure, including environment/platform errors (e.g., running on non-Windows), improving reliability of error detection in clients and tests. [[1]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL3409-R3409) [[2]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcL3470-R3471) [[3]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR3788) [[4]](diffhunk://#diff-5cfaa5c86b51d3f6684c4d3296214652c1843d410794d439050d4a2ddf7d60dcR4177) [[5]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637R416) [[6]](diffhunk://#diff-20a5e0ec53122d70eaf2f8a22417c189cb16c738f90e4f203d3e110db9d02f85R331-R339) [[7]](diffhunk://#diff-20a5e0ec53122d70eaf2f8a22417c189cb16c738f90e4f203d3e110db9d02f85L346-R354) [[8]](diffhunk://#diff-20a5e0ec53122d70eaf2f8a22417c189cb16c738f90e4f203d3e110db9d02f85L385-R394)

### Bridge Client Configurability

* Added environment variable overrides for bridge timeouts (`BRIDGE_READY_TIMEOUT_MS`, `BRIDGE_CALL_TIMEOUT_MS`) to support large installations or slow VMs, with documentation in `.env.example` and implementation in `bridgeClient.ts`. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR129-R133) [[2]](diffhunk://#diff-7f9d5c070985e04783df404c600adf5319e0aa2193693f9095c226c4d1b6f8a0L64-R75)

### Documentation Improvements

* Clarified the role of `copilot-instructions.md` as the authoritative source for workflow rules, and explained the opt-in nature of MCP prompts in `systemInstructions.ts`.

These changes ensure that file operations are more predictable, errors are surfaced clearly, and users and Copilot are aligned on the correct workflow for safe and auditable D365FO development.