### PR TITLE
Fix/class extension bare name naming

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -192,6 +192,32 @@ Search for MyModel helper classes
 
 ---
 
+### code_completion
+
+Lists methods and fields available on a class or table, with optional name-prefix filtering.
+Use this for lightweight symbol look-up when you already know the object name and want to see
+what members are available — without fetching the full class definition.
+
+> ℹ️ For full class details including method source code, use **get_class_info**.
+> For full table schemas, use **get_table_info**.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `className` | Yes | Class or table name |
+| `prefix` | No | Method/field name prefix to filter results |
+| `includeWorkspace` | No | Also scan local workspace files (requires `workspacePath`) |
+| `workspacePath` | No | Path to local workspace root for scanning |
+
+**Examples:**
+```
+What methods start with 'calc' on SalesTable?
+List all methods on LedgerJournalEngine
+Show fields starting with 'Cust' on CustTable
+```
+
+---
+
 ### get_class_info
 
 Returns the complete class definition: every method with its full signature and source code,
@@ -458,6 +484,48 @@ your team's real patterns, not generic templates.
 Analyze patterns for ledger journal creation
 What are the common patterns for helper classes in my code?
 Show me patterns for financial dimension handling
+```
+
+---
+
+### suggest_method_implementation
+
+Finds real examples of how similar methods are implemented in your codebase and generates
+an X++ method skeleton based on method-name heuristics. Call this before writing a method
+from scratch to ground the implementation in proven patterns.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `className` | Yes | Class that will contain the method |
+| `methodName` | Yes | Name of the method to implement |
+| `returnType` | No | Return type of the method (default: `void`) |
+| `parameters` | No | Array of `{ name, type }` parameter objects |
+
+**Examples:**
+```
+How do others implement validateWrite() on a sales-related table?
+Show me similar implementations of calcDiscount() with return type AmountMST
+Generate a skeleton for processPayment() returning boolean
+```
+
+---
+
+### analyze_class_completeness
+
+Checks a class against similar classes in the codebase to identify standard methods it
+is missing. Useful for ensuring a new class is fully implemented before review.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `className` | Yes | Name of the class to analyze |
+
+**Examples:**
+```
+Is MyHelper class complete?
+What standard methods is MySalesService missing?
+Analyze completeness of ContosoInvoiceController
 ```
 
 ---
@@ -1015,6 +1083,105 @@ Verifies that D365FO objects exist on disk at the correct AOT path and are refer
 
 ---
 
+### build_d365fo_project
+
+Triggers an MSBuild / xppc.exe compilation of the D365FO model. Repeated calls poll the
+running job and return the latest log output — no need to re-invoke separately to check status.
+
+> ⚠️ **LOCAL_TOOLS only** — requires a local Windows VM with D365FO installed.
+> Never call this automatically — only on explicit user request.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `modelName` | No | Model name to build; auto-detected from `.mcp.json` if omitted |
+| `projectPath` | No | `.rnrproj` path (used only to extract model name if `modelName` omitted) |
+| `force` | No | Kill any stuck build process and restart (default: `false`) |
+
+**Examples:**
+```
+Build my project and show me the errors
+Build the ContosoRobotics model
+Force-restart the stuck build
+```
+
+---
+
+### trigger_db_sync
+
+Runs SyncEngine.exe to synchronize the D365FO database schema to match current metadata.
+Supports full-model sync or targeted partial sync for specific tables.
+
+> ⚠️ **LOCAL_TOOLS only** — requires a local Windows VM with D365FO installed.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `modelName` | No | Model name to sync; auto-detected from `.mcp.json` if omitted |
+| `tables` | No | Array of table names for partial sync |
+| `tableName` | No | Single table name shorthand (equivalent to `tables: [tableName]`) |
+| `projectPath` | No | `.rnrproj` path; used to extract syncable objects for smart partial sync |
+| `syncViews` | No | Also sync views and data entities (default: `false`) |
+| `connectionString` | No | SQL connection string override |
+| `packagePath` | No | `PackagesLocalDirectory` root override |
+
+**Examples:**
+```
+Sync the database to reflect my table changes
+Sync only MyCustomTable and MyOrderTable
+Sync the whole FmMcp model including views
+```
+
+---
+
+### run_bp_check
+
+Runs the Microsoft xppbp.exe best-practice linter against the model or a specific object.
+Returns a pass/warning/error summary and raw BP output.
+
+> ⚠️ **LOCAL_TOOLS only** — requires a local Windows VM with D365FO installed.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `modelName` | No | Model name to check; auto-detected from `.mcp.json` if omitted |
+| `projectPath` | No | `.rnrproj` path; auto-detected if omitted |
+| `targetFilter` | No | Filter to a specific class, table, or object name |
+| `packagePath` | No | `PackagesLocalDirectory` root override |
+
+**Examples:**
+```
+Run best practice checks on my latest changes
+Run BP check filtered to MyCustomClass
+Check the ContosoRobotics model for best practice violations
+```
+
+---
+
+### run_systest_class
+
+Invokes the D365FO SysTest framework against a specific test class (and optionally a single
+test method). Uses SysTestRunner.exe when available, falling back to xppbp.exe.
+
+> ⚠️ **LOCAL_TOOLS only** — requires a local Windows VM with D365FO installed.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `className` | Yes | SysTest class name to run |
+| `testMethod` | No | Specific test method within the class (runs all methods if omitted) |
+| `modelName` | No | Model containing the test class; auto-detected if omitted |
+| `packagePath` | No | `PackagesLocalDirectory` root override |
+
+**Examples:**
+```
+Run the unit tests in MyTestClass
+Run only the testValidateWrite method in MyTableTest
+Run all tests in ContosoSalesServiceTest
+```
+
+---
+
 ### update_symbol_index
 
 Re-indexes a D365FO XML file in the SQLite symbol database. Since `create_d365fo_file`
@@ -1143,6 +1310,231 @@ across either tree, but file creation must always target the package path.
 ```
 Check my D365FO workspace configuration
 What model am I working in?
+```
+
+---
+
+### get_security_artifact_info
+
+Returns full details for a security privilege, duty, or role including the complete
+hierarchy chain: role → duties → privileges → entry points (forms, tables, menu items).
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `name` | Yes | Name of the security artifact |
+| `artifactType` | Yes | `privilege`, `duty`, or `role` |
+| `includeChain` | No | Walk and display the full hierarchy (default: `true`) |
+
+**Examples:**
+```
+Show me everything in the CustTableFullControl privilege
+What duties does the TradeSalesClerk role include?
+List all entry points in the SalesOrderMaintain duty
+```
+
+---
+
+### get_security_coverage_for_object
+
+Finds which roles, duties, and privileges grant access to a given form, table, or menu item.
+Returns a per-menu-item breakdown with aggregate role counts.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `objectName` | Yes | Form, table, class, or menu item name |
+| `objectType` | No | `form`, `table`, `class`, `menu-item`, or `auto` (default: `auto`) |
+
+**Examples:**
+```
+What roles can access the CustTable form?
+Which security privileges cover SalesTable?
+Who has access to the VendPaymProposal form?
+```
+
+---
+
+### get_menu_item_info
+
+Returns menu item metadata (type, target object, label) and the full security chain from
+the menu item up through privilege → duty → role. Falls back to fuzzy suggestions when the
+exact name is not found.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `name` | Yes | Menu item name |
+| `itemType` | No | `display`, `action`, `output`, or `any` (default: `any`) |
+
+**Examples:**
+```
+What form does the CustTable menu item open?
+Show me the security chain for SalesTableListPage menu item
+What output menu items exist for SalesInvoice?
+```
+
+---
+
+### find_coc_extensions
+
+Finds all Chain of Command (CoC) extension classes that wrap methods on the specified class
+or table. Bridge-first: uses DYNAMICSXREFDB when available for compiler-resolved results;
+falls back to SQLite extension metadata and filesystem scan.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `className` | Yes | Base class or table name being extended |
+| `methodName` | No | Filter results to a specific wrapped method |
+| `includeEventHandlers` | No | Also list static event subscriptions for this class/table (default: `true`) |
+
+**Examples:**
+```
+Does CustTable.validateWrite have any CoC wrappers?
+Find all CoC extensions on SalesFormLetter
+Which classes extend SalesLine.insert()?
+```
+
+---
+
+### find_event_handlers
+
+Finds all event handler methods that subscribe to events on a class or table. Bridge-first:
+uses DYNAMICSXREFDB when available; falls back to FTS5 source-snippet search.
+Supports filtering by event name and handler type.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `targetClass` | One of | Class whose events to find handlers for |
+| `targetTable` | One of | Table whose events to find handlers for |
+| `eventName` | No | Filter to a specific event (e.g. `onInserted`, `onValidatedWrite`) |
+| `handlerType` | No | `static`, `delegate`, or `all` (default: `all`) |
+
+> At least one of `targetClass` or `targetTable` is required.
+
+**Examples:**
+```
+Who handles the onInserted event of SalesLine?
+Find all event handlers on CustTable
+Show only delegate handlers on InventTable
+```
+
+---
+
+### get_table_extension_info
+
+Lists all extension objects that extend a base table — added fields, indexes, methods, and
+event subscriptions — and optionally merges them with the base schema into an effective
+schema summary.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `tableName` | Yes | Base table name whose extensions should be found |
+| `includeEffectiveSchema` | No | Merge base + extension fields/indexes into a combined totals view (default: `true`) |
+
+**Examples:**
+```
+What fields did ISV packages add to CustTable?
+Show all extensions of InventTable with effective schema
+List everything added to SalesLine by any extension
+```
+
+---
+
+### get_data_entity_info
+
+Returns data entity metadata: category, OData public name, data sources, field mappings,
+primary key, and enabled integrations. Bridge-first, with SQLite fuzzy suggestions on miss.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `entityName` | Yes | Name of the data entity (AxDataEntityView object name) |
+
+**Examples:**
+```
+Show me CustCustomerV3Entity details
+What OData name does VendorV2Entity expose?
+What data sources does SalesOrderHeaderV2Entity use?
+```
+
+---
+
+### analyze_extension_points
+
+Analyzes an X++ class, table, or form and returns all available extension surfaces:
+CoC-eligible methods, delegates, standard events, and (optionally) existing wrappers and
+subscribers already present in the codebase.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `objectName` | Yes | Class, table, or form name to analyze |
+| `objectType` | No | `class`, `table`, `form`, or `auto` (default: `auto`) |
+| `showExistingExtensions` | No | Also list existing CoC wrappers and event subscribers (default: `false`) |
+
+**Examples:**
+```
+What can I extend on SalesLine?
+Show extension points for CustTable including existing extensions
+What delegates does SalesFormLetter expose?
+```
+
+---
+
+### recommend_extension_strategy
+
+Rule-based advisor that recommends the best D365FO extensibility mechanism for a described
+goal — preventing wrong choices such as CoC where a Business Event or data entity is more
+appropriate. Returns the recommended strategy, reasoning, risks, alternatives,
+anti-patterns to avoid, and suggested next MCP calls.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `goal` | Yes | Plain-English description of what you want to achieve |
+| `objectName` | No | Target D365FO object, if known |
+| `scenario` | No | One of: `data-validation`, `field-defaulting`, `business-logic-change`, `outbound-integration`, `inbound-data`, `ui-modification`, `document-output`, `number-sequence`, `security-access`, `batch-processing`, `custom`. Auto-detected from `goal` if omitted. |
+
+**Examples:**
+```
+Should I use CoC or Business Event to notify an external system?
+How should I default a field value when a new sales order is created?
+What is the best way to add a custom field to the vendor invoice form?
+```
+
+---
+
+### validate_object_naming
+
+Validates a proposed D365FO object name against naming conventions and detects conflicts
+in the symbol index. Supports both `prefix` and `model-name` extension naming styles
+(controlled by `EXTENSION_NAMING_STYLE`).
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `proposedName` | Yes | The full object name to validate |
+| `objectType` | Yes | Object type: `class`, `table`, `form`, `enum`, `edt`, `query`, `view`, `table-extension`, `class-extension`, `form-extension`, `enum-extension`, `edt-extension`, `menu-item`, `security-privilege`, `security-duty`, `security-role`, `data-entity` |
+| `baseObjectName` | Extension types | Name of the base object being extended (required for all `*-extension` types) |
+| `modelPrefix` | No | Expected ISV/model prefix (2-4 uppercase letters, e.g. `"CR"`, `"WHS"`). Auto-detected from the symbol index if omitted. |
+| `modelName` | No | Target model name. Relevant only when `EXTENSION_NAMING_STYLE=model-name`, where the extension token is the model name instead of the prefix infix (e.g. `CustTable_ContosoRobotics_Extension`). Auto-detected from the active workspace config if omitted. |
+
+**Extension naming styles:**
+
+| Style | Class extension | Element extension |
+|-------|----------------|------------------|
+| `prefix` (default) | `{Base}{Prefix}_Extension` | `{Base}.{Prefix}Extension` |
+| `model-name` | `{Base}_{ModelName}_Extension` | `{Base}.{ModelName}` |
+
+**Examples:**
+```
+Is SalesTableCR_Extension a valid extension class name for SalesTable?
+Validate CustTable.ContosoRoboticsExtension as a table-extension
+Validate CustTable_ContosoRobotics_Extension as class-extension with modelName="ContosoRobotics"
 ```
 
 ---

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -3574,6 +3574,28 @@ export async function handleCreateD365File(
       );
     }
 
+    // Case D: class extensions (CoC) provided as a bare base class name, i.e. WITHOUT
+    // the "_Extension" suffix.
+    // e.g. objectType="class-extension", objectName="SalesFormLetter"
+    // → effectiveObjectName="SalesFormLetter_Extension" so applyObjectPrefix's
+    //   extension-class branch produces the correct name for the active style:
+    //     prefix style     → SalesFormLetterCr_Extension
+    //     model-name style → SalesFormLetter_ContosoRobotics_Extension
+    //
+    // Without this, a bare base name has no dot and does not end in "_Extension", so it
+    // falls into applyObjectPrefix's NORMAL CASE and is treated as a brand-new object —
+    // wrongly producing "CrSalesFormLetter". This mirrors the dot-notation Case C above;
+    // class-extension was the only extension type missing bare-name normalisation
+    // (the EXTENSION_NAMING_STYLE work added the model-name branches but assumed the
+    // caller always supplies the "_Extension" form for CoC classes).
+    if (args.objectType === 'class-extension' && !effectiveObjectName.endsWith('_Extension')) {
+      effectiveObjectName = `${effectiveObjectName}_Extension`;
+      console.error(
+        `[create_d365fo_file] Bare class-extension name auto-converted to _Extension form: ` +
+        `${args.objectName} → ${effectiveObjectName}`
+      );
+    }
+
     // Pass actualModelName so the model-name naming style can use it as the extension
     // token. For the default prefix style (or non-extension objects) it is ignored.
     let finalObjectName = applyObjectPrefix(effectiveObjectName, objectPrefix, actualModelName);

--- a/src/tools/validateObjectNaming.ts
+++ b/src/tools/validateObjectNaming.ts
@@ -7,7 +7,8 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { getObjectSuffix } from '../utils/modelClassifier.js';
+import { getObjectSuffix, getExtensionNamingStyle } from '../utils/modelClassifier.js';
+import { getConfigManager } from '../utils/configManager.js';
 
 const ValidateObjectNamingArgsSchema = z.object({
   proposedName: z.string().describe('The proposed object name to validate'),
@@ -22,6 +23,8 @@ const ValidateObjectNamingArgsSchema = z.object({
     .describe('Required for extension types: name of the object being extended'),
   modelPrefix: z.string().optional()
     .describe('Expected ISV/model prefix (2-4 uppercase letters, e.g. "WHS", "CONT"). Auto-detected if omitted.'),
+  modelName: z.string().optional()
+    .describe('Target model name. Only relevant when EXTENSION_NAMING_STYLE=model-name, where the extension token is the model name (e.g. CustTable_ContosoRobotics_Extension). Auto-detected from the active workspace if omitted.'),
 });
 
 // Extension types that require base object name
@@ -64,6 +67,19 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
       }
     }
 
+    // ── Resolve extension-naming style and (for model-name style) the model name ──
+    // Under EXTENSION_NAMING_STYLE=model-name the extension token is the MODEL NAME
+    // (Visual Studio developer-tools default), not the prefix infix:
+    //   class extension   → {Base}_{ModelName}_Extension
+    //   element extension → {Base}.{ModelName}
+    // Explicit modelName arg wins; otherwise resolve from the active workspace config.
+    const namingStyle = getExtensionNamingStyle();
+    let modelName = args.modelName?.trim() || '';
+    if (!modelName && namingStyle === 'model-name') {
+      modelName = getConfigManager().getModelName() ?? '';
+    }
+    const useModelName = namingStyle === 'model-name' && !!modelName;
+
     // ══════════════════════════════════════════════════════════════════
     // RULE SET 1: Extension naming rules
     // ══════════════════════════════════════════════════════════════════
@@ -74,30 +90,63 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
         errors.push(`baseObjectName is required for extension types (${args.objectType}).`);
       } else {
         if (args.objectType === 'class-extension') {
-          // Class extensions: {Base}{Prefix}_Extension
-          const expectedPattern = `${baseObjectName}${prefix}_Extension`;
+          // Class extensions:
+          //   prefix style     → {Base}{Prefix}_Extension
+          //   model-name style → {Base}_{ModelName}_Extension
+          const expectedPattern = useModelName
+            ? `${baseObjectName}_${modelName}_Extension`
+            : `${baseObjectName}${prefix}_Extension`;
+          const expectedToken = useModelName ? modelName : prefix;
 
           if (!name.startsWith(baseObjectName)) {
             errors.push(`Class extension names must start with the base class name.\n  Expected format: ${expectedPattern}`);
-            if (prefix) suggestions.push(`Correct name: ${expectedPattern}`);
+            if (expectedToken) suggestions.push(`Correct name: ${expectedPattern}`);
           } else if (!name.endsWith('_Extension')) {
             errors.push(`Class extension names must end with '_Extension'.\n  Expected format: ${expectedPattern}`);
-            if (prefix) suggestions.push(`Correct name: ${expectedPattern}`);
+            if (expectedToken) suggestions.push(`Correct name: ${expectedPattern}`);
           } else {
-            // Has correct structure — check prefix is included
-            const middle = name.slice(baseObjectName.length, -'_Extension'.length);
-            if (prefix && middle !== prefix && !middle.includes(prefix)) {
-              warnings.push(`Extension name does not include model prefix "${prefix}".\n  Current: ${name}\n  Recommended: ${expectedPattern}`);
+            // Has correct structure — check the expected token is included.
+            // Strip a leading separator so "_ContosoRobotics" compares cleanly to the model name.
+            const middle = name.slice(baseObjectName.length, -'_Extension'.length).replace(/^_+/, '');
+            if (expectedToken &&
+                middle.toLowerCase() !== expectedToken.toLowerCase() &&
+                !middle.toLowerCase().includes(expectedToken.toLowerCase())) {
+              warnings.push(
+                useModelName
+                  ? `Extension name does not embed the model name "${modelName}" (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${name}\n  Recommended: ${expectedPattern}`
+                  : `Extension name does not include model prefix "${prefix}".\n  Current: ${name}\n  Recommended: ${expectedPattern}`
+              );
             }
           }
 
-          // AOT extension name suggestion
-          if (args.objectType === 'class-extension') {
-            suggestions.push(`AOT label for extension file: ${baseObjectName}.${prefix}Extension (if creating table-extension AOT object instead)`);
+          // AOT element-extension name suggestion (if an element extension is meant instead)
+          suggestions.push(
+            useModelName
+              ? `AOT name for an element extension instead: ${baseObjectName}.${modelName}`
+              : `AOT label for extension file: ${baseObjectName}.${prefix}Extension (if creating table-extension AOT object instead)`
+          );
+
+        } else if (useModelName) {
+          // AOT extensions (table/form/enum/edt), model-name style: {Base}.{ModelName}
+          // Visual Studio names these with the bare model name and NO "Extension" word.
+          const expectedPattern = `${baseObjectName}.${modelName}`;
+
+          if (!name.includes('.')) {
+            errors.push(`${args.objectType} names must use dot notation: {Base}.{ModelName}.\n  Expected: ${expectedPattern}`);
+            suggestions.push(`Correct name: ${expectedPattern}`);
+          } else {
+            const [basePart, extPart] = name.split('.', 2);
+
+            if (basePart !== baseObjectName) {
+              errors.push(`Extension base (before '.') must exactly match baseObjectName.\n  Expected: ${baseObjectName}.xxx\n  Got: ${basePart}.xxx`);
+            }
+            if (extPart.toLowerCase() !== modelName.toLowerCase()) {
+              warnings.push(`Extension token (after '.') should be the model name "${modelName}" (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${extPart}\n  Recommended: ${modelName}`);
+            }
           }
 
         } else {
-          // AOT extensions (table/form/enum/edt): {Base}.{Prefix}Extension
+          // AOT extensions (table/form/enum/edt), prefix style: {Base}.{Prefix}Extension
           const expectedPattern = `${baseObjectName}.${prefix}Extension`;
 
           if (!name.includes('.')) {
@@ -221,6 +270,14 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
     let output = `Validation: "${name}" as ${args.objectType}\n`;
     if (args.baseObjectName) output += `Base Object: ${args.baseObjectName}\n`;
     if (prefix) output += `Model Prefix: ${prefix}\n`;
+    if (isExtension) {
+      output += useModelName
+        ? `Extension Style: model-name (token = model name "${modelName}")\n`
+        : `Extension Style: prefix (token = model prefix infix)\n`;
+      if (namingStyle === 'model-name' && !modelName) {
+        output += `  ⚠ EXTENSION_NAMING_STYLE=model-name but no model name could be resolved — validated structure only. Pass modelName to validate the extension token.\n`;
+      }
+    }
     output += '\n';
 
     if (errors.length > 0) {

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -483,6 +483,40 @@ describe('create_d365fo_file', () => {
     expect(text).not.toMatch(/[\\/]SalesFormLetter\.xml/);
   });
 
+  it('Case D × model-name style: bare class-extension name produces Base_ModelName_Extension', async () => {
+    // Verify that Case D (append _Extension) + Case B (strip model-name infix) +
+    // applyObjectPrefix (model-name branch) all compose correctly when
+    // EXTENSION_NAMING_STYLE=model-name.
+    // Input:  objectType="class-extension", objectName="SalesFormLetter" (bare, no suffix)
+    // Expected output file: SalesFormLetter_ContosoRobotics_Extension.xml
+    //   1. Case D: "SalesFormLetter" → "SalesFormLetter_Extension"
+    //   2. applyObjectPrefix (model-name branch): injects model name →
+    //      "SalesFormLetter_ContosoRobotics_Extension"
+    // applyObjectPrefix is mocked to identity, so we can only confirm Case D fired
+    // (name ends with _Extension and is not the bare name). The configManager mock
+    // returns 'MyModel' as model name, so we verify the _Extension suffix is present.
+    vi.mocked(getExtensionNamingStyle).mockReturnValue('model-name');
+    try {
+      const result = await handleCreateD365File(
+        req('create_d365fo_file', {
+          objectType: 'class-extension',
+          objectName: 'SalesFormLetter',
+          modelName: 'ContosoRobotics',
+          packageName: 'ContosoRobotics',
+          packagePath: 'K:\\PackagesLocalDirectory',
+          addToProject: false,
+        }),
+      );
+      const text: string = result.content[0].text;
+      // Case D must have fired: _Extension suffix present
+      expect(text).toMatch(/SalesFormLetter_Extension\.xml/);
+      // Must NOT fall into the NORMAL CASE (prefix-prepend on bare name)
+      expect(text).not.toMatch(/[\\/]SalesFormLetter\.xml/);
+    } finally {
+      vi.mocked(getExtensionNamingStyle).mockReturnValue('prefix');
+    }
+  });
+
   it('creates a class from custom xmlContent (hybrid scenario)', async () => {
     const xml = `<?xml version="1.0"?><AxClass><Name>MyHybridClass</Name></AxClass>`;
     const result = await handleCreateD365File(

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -369,6 +369,34 @@ describe('create_d365fo_file', () => {
     expect(text).not.toMatch(/FmMcpPurchTable|[A-Za-z]+PurchTable\.xml/);
   });
 
+  it('auto-converts bare class-extension name to _Extension form (Case D fix)', async () => {
+    // Bug: objectType="class-extension", objectName="SalesFormLetter" (no "_Extension"
+    // suffix) used to have no dot and not end in "_Extension", so it fell into
+    // applyObjectPrefix's NORMAL CASE and was treated as a brand-new object — wrongly
+    // producing "<Prefix>SalesFormLetter" (e.g. "CrSalesFormLetter"). class-extension
+    // was the only extension type missing the bare-name normalisation that the
+    // dot-notation types got in Case C.
+    // Fix: Case D appends "_Extension" so applyObjectPrefix routes it through the
+    // extension-class branch.
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'class-extension',
+        objectName: 'SalesFormLetter',
+        modelName: 'FmMcp',
+        packageName: 'FmMcp',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+      }),
+    );
+    // applyObjectPrefix is mocked to identity here, so the message path reflects the
+    // effectiveObjectName transformation only: it must be "SalesFormLetter_Extension.xml"
+    // and NOT the bare "SalesFormLetter.xml" (which would prove Case D did not fire and
+    // the name would later be mangled by the real applyObjectPrefix NORMAL CASE).
+    const text: string = result.content[0].text;
+    expect(text).toMatch(/SalesFormLetter_Extension\.xml/);
+    expect(text).not.toMatch(/[\\/]SalesFormLetter\.xml/);
+  });
+
   it('creates a class from custom xmlContent (hybrid scenario)', async () => {
     const xml = `<?xml version="1.0"?><AxClass><Name>MyHybridClass</Name></AxClass>`;
     const result = await handleCreateD365File(

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -4,8 +4,9 @@
  *         validate_object_naming, verify_d365fo_project
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { validateObjectNamingTool } from '../../src/tools/validateObjectNaming';
+import { getExtensionNamingStyle } from '../../src/utils/modelClassifier';
 import { verifyD365ProjectTool } from '../../src/tools/verifyD365Project';
 import { handleCreateD365File } from '../../src/tools/createD365File';
 import { modifyD365FileTool } from '../../src/tools/modifyD365File';
@@ -224,6 +225,91 @@ describe('validate_object_naming', () => {
       );
       expect(result.isError).toBeFalsy();
     }
+  });
+});
+
+// ─── validate_object_naming — EXTENSION_NAMING_STYLE=model-name ───────────────
+// Under the model-name style the extension token is the MODEL NAME (VS default),
+// not the prefix infix. The validator must accept Base_ModelName_Extension /
+// Base.ModelName and must NOT demand the prefix infix or a "…Extension" element token.
+describe('validate_object_naming — model-name style', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    (ctx.symbolIndex.db as any).stmt.get.mockReturnValue(undefined);
+    (ctx.symbolIndex.db as any).stmt.all.mockReturnValue([]);
+    vi.mocked(getExtensionNamingStyle).mockReturnValue('model-name');
+  });
+
+  afterEach(() => {
+    vi.mocked(getExtensionNamingStyle).mockReturnValue('prefix');
+  });
+
+  it('accepts a model-name class extension without errors', async () => {
+    const result = await validateObjectNamingTool(
+      req('validate_object_naming', {
+        proposedName: 'CustTable_ContosoRobotics_Extension',
+        objectType: 'class-extension',
+        baseObjectName: 'CustTable',
+        modelName: 'ContosoRobotics',
+        modelPrefix: 'CR',
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    // The model-name token is correct → no prefix-infix warning, no errors.
+    expect(result.content[0].text).not.toMatch(/ERRORS \(\d/);
+    expect(result.content[0].text).not.toMatch(/does not include model prefix/);
+    expect(result.content[0].text).toMatch(/Extension Style: model-name/);
+  });
+
+  it('warns when a class extension uses the prefix infix instead of the model name', async () => {
+    const result = await validateObjectNamingTool(
+      req('validate_object_naming', {
+        proposedName: 'CustTableCR_Extension',
+        objectType: 'class-extension',
+        baseObjectName: 'CustTable',
+        modelName: 'ContosoRobotics',
+        modelPrefix: 'CR',
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/does not embed the model name "ContosoRobotics"/);
+    expect(result.content[0].text).toMatch(/CustTable_ContosoRobotics_Extension/);
+  });
+
+  it('accepts a model-name element extension (Base.ModelName, no "Extension" word)', async () => {
+    const result = await validateObjectNamingTool(
+      req('validate_object_naming', {
+        proposedName: 'CustTable.ContosoRobotics',
+        objectType: 'table-extension',
+        baseObjectName: 'CustTable',
+        modelName: 'ContosoRobotics',
+        modelPrefix: 'CR',
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).not.toMatch(/ERRORS \(\d/);
+    // Must NOT demand a "…Extension" suffix under model-name style.
+    expect(result.content[0].text).not.toMatch(/must end with 'Extension'/);
+  });
+
+  it('warns when an element extension uses the prefix token instead of the model name', async () => {
+    const result = await validateObjectNamingTool(
+      req('validate_object_naming', {
+        proposedName: 'CustTable.CRExtension',
+        objectType: 'table-extension',
+        baseObjectName: 'CustTable',
+        modelName: 'ContosoRobotics',
+        modelPrefix: 'CR',
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/should be the model name "ContosoRobotics"/);
   });
 });
 


### PR DESCRIPTION
  ## Summary

  Two model-name extension-naming gaps missed in #495.

  **1. `create_d365fo_file` — bare class-extension name mangled**

  A bare base name for `class-extension` (no `_Extension`) fell into the "new object" branch and got the prefix
  prepended, instead of becoming an extension class:

  **1. `create_d365fo_file` — bare class-extension name mangled**

  A bare base name for `class-extension` (no `_Extension`) fell into the "new object" branch and got the prefix
  prepended, instead of becoming an extension class:
  A bare base name for `class-extension` (no `_Extension`) fell into the "new object" branch and got the prefix
  prepended, instead of becoming an extension class:

  | input | before | after |
  |---|---|---|
  | `SalesFormLetter` | `CrSalesFormLetter.xml` | `SalesFormLetter_ContosoRobotics_Extension.xml` |

  `class-extension` was the only extension type missing the bare-name normalisation that dot-notation types already had
  (Case C). Added the equivalent Case D.

  **2. `validate_object_naming` — unaware of model-name style**

  Only validated prefix-infix forms, so it flagged correct model-name names and recommended the wrong ones
  (contradicting `create_d365fo_file`):

  - class extension → `{Base}_{ModelName}_Extension`
  - element extension → `{Base}.{ModelName}`

  Added a `modelName` param and style-aware validation.