### PR TITLE
Fix/configured model custom classification

### DIFF
--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -441,10 +441,17 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           'fleetmanagementunittests', 'tutorial',
         ]);
         const isPlaceholder = !modelName || PLACEHOLDER_NAMES.has(modelName.toLowerCase());
+        // The "Microsoft standard model" warning only makes sense for an AUTO-DETECTED
+        // model: its whole premise is that a .rnrproj scan landed on a standard/demo
+        // model because the developer forgot to change the VS new-project wizard default.
+        // An explicitly configured model (D365FO_MODEL_NAME env var or a modelName key
+        // in .mcp.json) was named deliberately, so second-guessing it produces false
+        // positives — e.g. a model whose ISV prefix is only an abbreviation of its name.
+        const isAutoDetectedSource = modelSource.includes('auto-detected');
         // Also flag when auto-detection found a Microsoft standard model name
         // that isn't in the PLACEHOLDER_NAMES set but is not a custom model.
         const isStandardMsModel = modelName
-          ? !isCustomModel(modelName) && !isPlaceholder
+          ? !isCustomModel(modelName) && !isPlaceholder && isAutoDetectedSource
           : false;
 
         const lines: string[] = [

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -418,7 +418,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           }
         }
 
-        const { modelName, modelSource, projectPath, projectSource, packagePath, packageSource } =
+        const { modelName, modelSource, isModelSourceAutoDetected, projectPath, projectSource, packagePath, packageSource } =
           await configManager.getWorkspaceInfoDiagnostics();
         const envType = await configManager.getDevEnvironmentType();
         const frameworkDirectory = await configManager.getMicrosoftPackagesPath();
@@ -447,7 +447,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         // An explicitly configured model (D365FO_MODEL_NAME env var or a modelName key
         // in .mcp.json) was named deliberately, so second-guessing it produces false
         // positives — e.g. a model whose ISV prefix is only an abbreviation of its name.
-        const isAutoDetectedSource = modelSource.includes('auto-detected');
+        const isAutoDetectedSource = isModelSourceAutoDetected;
         // Also flag when auto-detection found a Microsoft standard model name
         // that isn't in the PLACEHOLDER_NAMES set but is not a custom model.
         const isStandardMsModel = modelName

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { autoDetectD365Project, detectD365Project, scanAllD365Projects, extractModelNameFromProject, detectGitBranch, isMicrosoftDemoModel, type D365ProjectInfo } from './workspaceDetector.js';
-import { registerCustomModel } from './modelClassifier.js';
+import { registerCustomModel, getCustomModels } from './modelClassifier.js';
 import { XppConfigProvider, type XppEnvironmentConfig } from './xppConfigProvider.js';
 
 export interface McpContext {
@@ -53,6 +53,9 @@ class ConfigManager {
   private config: McpConfig | null = null;
   private configPath: string;
   private runtimeContext: Partial<McpContext> = {};
+  // Guards the one-time registration of explicitly-configured custom models
+  // (the resolved target model + any CUSTOM_MODELS entries) performed in ensureLoaded().
+  private configuredModelsRegistered = false;
   /**
    * Per-request context storage — isolates each HTTP request's workspace path
    * from concurrent requests. Populated via runWithRequestContext() in transport.ts.
@@ -595,6 +598,30 @@ class ConfigManager {
    */
   async ensureLoaded(): Promise<void> {
     await this.load();
+
+    // Register the explicitly-configured custom models exactly once. The target
+    // model resolved from configuration (D365FO_MODEL_NAME env var or a modelName
+    // key in .mcp.json) is custom by definition, as are any CUSTOM_MODELS entries.
+    // Registering them here makes isCustomModel() deterministic regardless of call
+    // ordering — without it, a long model name whose ISV prefix is only an
+    // abbreviation (e.g. prefix "CR" for "ContosoRobotics") is misclassified as a
+    // Microsoft standard model until some later operation happens to register it.
+    if (!this.configuredModelsRegistered) {
+      this.configuredModelsRegistered = true;
+
+      const configuredModel = this.getContext()?.modelName?.trim();
+      if (configuredModel) {
+        registerCustomModel(configuredModel);
+      }
+
+      // CUSTOM_MODELS literals (wildcard patterns are matched directly by
+      // isCustomModel, so they don't need to be registered as exact names).
+      for (const entry of getCustomModels()) {
+        if (!entry.includes('*')) {
+          registerCustomModel(entry);
+        }
+      }
+    }
   }
 
   /**
@@ -841,7 +868,24 @@ class ConfigManager {
     const context = this.getContext();
 
     if (context?.modelName) {
-      return { modelName: context.modelName, source: '.mcp.json' };
+      // getContext() merges three sources with precedence runtime > env var > file.
+      // Report the one that actually produced the value, so the diagnostics don't
+      // send the developer looking in .mcp.json for a value that came from the
+      // D365FO_MODEL_NAME environment variable.
+      const fileContext = this.config?.context || this.config?.servers?.context || null;
+      const requestModel = this.requestContextStorage.getStore()?.modelName;
+      const runtimeModel = requestModel ?? this.runtimeContext.modelName;
+      const envModel = process.env.D365FO_MODEL_NAME?.trim() || undefined;
+
+      let source = '.mcp.json';
+      if (runtimeModel) {
+        source = 'runtime context (from VS / VS Code)';
+      } else if (envModel) {
+        source = 'D365FO_MODEL_NAME env var';
+      } else if (fileContext?.modelName) {
+        source = '.mcp.json';
+      }
+      return { modelName: context.modelName, source };
     }
 
     const wp = context?.workspacePath;

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -900,11 +900,6 @@ class ConfigManager {
       return { modelName: this.autoDetectedProject.modelName, source: 'auto-detected from .rnrproj' };
     }
 
-    const envVar = process.env.D365FO_MODEL_NAME || null;
-    if (envVar) {
-      return { modelName: envVar, source: 'D365FO_MODEL_NAME env var' };
-    }
-
     return { modelName: null, source: '(not configured)' };
   }
 
@@ -916,6 +911,7 @@ class ConfigManager {
   async getWorkspaceInfoDiagnostics(): Promise<{
     modelName: string | null;
     modelSource: string;
+    isModelSourceAutoDetected: boolean;
     projectPath: string | null;
     projectSource: string;
     packagePath: string | null;
@@ -980,7 +976,8 @@ class ConfigManager {
       packageSource = 'well-known path probe';
     }
 
-    return { modelName, modelSource, projectPath, projectSource, packagePath, packageSource };
+    const isModelSourceAutoDetected = modelSource.includes('auto-detected');
+    return { modelName, modelSource, isModelSourceAutoDetected, projectPath, projectSource, packagePath, packageSource };
   }
 
   /**

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -51,6 +51,19 @@ export function getExtensionPrefix(): string {
 }
 
 /**
+ * Get the explicitly configured target model name from the environment.
+ *
+ * D365FO_MODEL_NAME is the model the server was told to write into. It is set
+ * deliberately by the developer (e.g. per server instance), so the model it
+ * names is custom by definition — see isCustomModel().
+ *
+ * Returns empty string when not configured.
+ */
+export function getConfiguredModelName(): string {
+  return process.env.D365FO_MODEL_NAME?.trim() || '';
+}
+
+/**
  * Get configurable object suffix from environment.
  * Returns the raw EXTENSION_SUFFIX value (trailing underscores stripped).
  * Empty string when not configured.
@@ -370,16 +383,26 @@ export function isCustomModel(modelName: string): boolean {
   if (isAutoDetectedCustomModel(modelName)) {
     return true;
   }
-  
+
+  // Priority 2: The explicitly configured target model (D365FO_MODEL_NAME) is
+  // custom by definition — it was named deliberately as the write target.
+  // This check is independent of the ISV prefix, which is frequently an
+  // abbreviation of the model name (e.g. prefix "CR" for model "ContosoRobotics")
+  // and therefore fails the literal startsWith() heuristic in Priority 4 below.
+  const configuredModel = getConfiguredModelName();
+  if (configuredModel && configuredModel.toLowerCase() === modelName.toLowerCase()) {
+    return true;
+  }
+
   const customModels = getCustomModels();
   const extensionPrefix = getExtensionPrefix();
-  
-  // Priority 2: Check if model matches any pattern in custom models list
+
+  // Priority 3: Check if model matches any pattern in custom models list
   const isInCustomList = customModels.some(pattern => matchesPattern(pattern, modelName));
-  
-  // Priority 3: Check if model starts with extension prefix
+
+  // Priority 4: Check if model starts with extension prefix
   const hasExtensionPrefix = !!(extensionPrefix && modelName.startsWith(extensionPrefix));
-  
+
   return isInCustomList || hasExtensionPrefix;
 }
 

--- a/tests/utils/isCustomModel.test.ts
+++ b/tests/utils/isCustomModel.test.ts
@@ -1,0 +1,104 @@
+/**
+ * isCustomModel tests — explicitly-configured target model classification.
+ *
+ * Regression for the false "Microsoft standard model" warning: a model whose
+ * ISV prefix is only an abbreviation of its name (e.g. prefix "CR" for model
+ * "ContosoRobotics") fails the literal startsWith() heuristic, so before the fix
+ * it was misclassified as a standard model until something registered it at runtime.
+ *
+ * The configured target model (D365FO_MODEL_NAME) is now custom by definition,
+ * independent of the prefix — while genuinely unrelated models stay standard.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { isCustomModel, clearAutoDetectedModels } from '../../src/utils/modelClassifier';
+
+const originalPrefix = process.env.EXTENSION_PREFIX;
+const originalModelName = process.env.D365FO_MODEL_NAME;
+const originalCustomModels = process.env.CUSTOM_MODELS;
+
+function restore(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  restore('EXTENSION_PREFIX', originalPrefix);
+  restore('D365FO_MODEL_NAME', originalModelName);
+  restore('CUSTOM_MODELS', originalCustomModels);
+  clearAutoDetectedModels();
+});
+
+describe('isCustomModel — explicitly configured target model', () => {
+  it('REGRESSION: configured model with an abbreviation prefix is custom', () => {
+    // Prefix "CR" is NOT a literal start of "ContosoRobotics" (2nd char is "o", not "R"),
+    // so the startsWith() heuristic fails — the configured-model check must catch it.
+    process.env.EXTENSION_PREFIX = 'CR';
+    process.env.D365FO_MODEL_NAME = 'ContosoRobotics';
+    delete process.env.CUSTOM_MODELS;
+    clearAutoDetectedModels();
+
+    expect(isCustomModel('ContosoRobotics')).toBe(true);
+  });
+
+  it('configured-model match is case-insensitive', () => {
+    process.env.D365FO_MODEL_NAME = 'ContosoRobotics';
+    delete process.env.EXTENSION_PREFIX;
+    delete process.env.CUSTOM_MODELS;
+    clearAutoDetectedModels();
+
+    expect(isCustomModel('contosorobotics')).toBe(true);
+  });
+
+  it('is scoped to the configured model — an unrelated model stays standard', () => {
+    // Proves the fix does not blanket-classify everything as custom.
+    process.env.EXTENSION_PREFIX = 'CR';
+    process.env.D365FO_MODEL_NAME = 'ContosoRobotics';
+    delete process.env.CUSTOM_MODELS;
+    clearAutoDetectedModels();
+
+    expect(isCustomModel('GeneralLedger')).toBe(false);
+  });
+
+  it('with no configuration at all, an arbitrary Microsoft model is standard', () => {
+    delete process.env.EXTENSION_PREFIX;
+    delete process.env.D365FO_MODEL_NAME;
+    delete process.env.CUSTOM_MODELS;
+    clearAutoDetectedModels();
+
+    expect(isCustomModel('ApplicationSuite')).toBe(false);
+  });
+});
+
+describe('isCustomModel — existing signals still hold', () => {
+  it('CUSTOM_MODELS entry is custom', () => {
+    delete process.env.EXTENSION_PREFIX;
+    delete process.env.D365FO_MODEL_NAME;
+    process.env.CUSTOM_MODELS = 'ContosoRoboticsIsvExt,SomeOtherModel';
+    clearAutoDetectedModels();
+
+    expect(isCustomModel('ContosoRoboticsIsvExt')).toBe(true);
+  });
+
+  it('CUSTOM_MODELS wildcard pattern is custom', () => {
+    delete process.env.EXTENSION_PREFIX;
+    delete process.env.D365FO_MODEL_NAME;
+    process.env.CUSTOM_MODELS = 'ContosoRobotics*';
+    clearAutoDetectedModels();
+
+    expect(isCustomModel('ContosoRoboticsTest')).toBe(true);
+  });
+
+  it('literal prefix match still classifies as custom', () => {
+    // When the prefix genuinely IS the start of the model name.
+    process.env.EXTENSION_PREFIX = 'WHS';
+    delete process.env.D365FO_MODEL_NAME;
+    delete process.env.CUSTOM_MODELS;
+    clearAutoDetectedModels();
+
+    expect(isCustomModel('WHSCustomExtensions')).toBe(true);
+  });
+});

--- a/tests/utils/isCustomModel.test.ts
+++ b/tests/utils/isCustomModel.test.ts
@@ -10,7 +10,7 @@
  * independent of the prefix — while genuinely unrelated models stay standard.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { isCustomModel, clearAutoDetectedModels } from '../../src/utils/modelClassifier';
 
 const originalPrefix = process.env.EXTENSION_PREFIX;
@@ -24,6 +24,10 @@ function restore(key: string, value: string | undefined): void {
     process.env[key] = value;
   }
 }
+
+beforeEach(() => {
+  clearAutoDetectedModels();
+});
 
 afterEach(() => {
   restore('EXTENSION_PREFIX', originalPrefix);


### PR DESCRIPTION
  ## Fix: false "Microsoft standard model" warning for configured models

  ### Problem

  `get_workspace_info` intermittently emitted a `⛔ CONFIGURATION PROBLEM — model is a
  Microsoft standard model` warning (a `YOU MUST STOP` directive) for a model that was
  explicitly configured via `D365FO_MODEL_NAME`.

  It happened whenever the ISV prefix is an **abbreviation** of the model name rather than
  a literal leading substring — e.g. prefix `CR` for model `ContosoRobotics`.
  `isCustomModel()` classified a model as custom only via:

  1. runtime registration, or
  2. a `CUSTOM_MODELS` list match, or
  3. `modelName.startsWith(EXTENSION_PREFIX)` — which fails for abbreviation prefixes.

  On a **cold server** none of these held, so the configured model was misclassified as
  standard until some later operation (e.g. `create_d365fo_file`) happened to register it —
  hence the intermittency. As a side issue, the diagnostics always labeled the model source
  as `.mcp.json` even when it came from the `D365FO_MODEL_NAME` env var, sending developers
  to the wrong file.

  ### Fix

  - **`isCustomModel`** — the explicitly-configured target model (`D365FO_MODEL_NAME`) is now
    custom by definition, independent of the prefix. Deterministic; no call-ordering dependency.
  - **`configManager.ensureLoaded`** — registers the config-resolved model and any
    `CUSTOM_MODELS` literals as custom once at load (also covers a `modelName` key in `.mcp.json`).
  - **`getModelNameWithSource`** — reports the real origin (`D365FO_MODEL_NAME env var` vs
    `.mcp.json` vs runtime) instead of always claiming `.mcp.json`.
  - **`get_workspace_info`** — the standard-model warning is now gated to **auto-detected**
    sources only, so it can never fire for an explicitly-configured model.