### PR TITLE
Audit follow-up: isError consistency, central error net, docs sync

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -117,7 +117,7 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 |------|------------|-------------|
 | **generate_d365fo_xml** | Anywhere (cloud + local) | Returns XML content — Copilot then creates the file |
 | **create_d365fo_file** | Local Windows VM only | Creates the physical file and adds it to the VS project |
-| **modify_d365fo_file** | Local Windows VM only | Safely edits an existing file with automatic backup |
+| **modify_d365fo_file** | Local Windows VM only | Edits an existing file in place (applies immediately; optional `.bak` backup) |
 | **verify_d365fo_project** | Local Windows VM only | Reads `.rnrproj` on K:\ to verify objects exist on disk and are referenced in the project file |
 
 ### Security & Extensions (10 tools)
@@ -596,12 +596,16 @@ Use this when the MCP server is hosted in Azure and does not have local file sys
 
 ### modify_d365fo_file
 
-Edits an existing D365FO XML file safely:
+Edits an existing D365FO XML file:
 
-1. Creates a backup (`.bak`) before touching anything
-2. Makes the change (add/edit/remove a method or field)
-3. Validates that the XML is still well-formed
-4. Rolls back from the backup if anything goes wrong
+1. Makes the change (add/edit/remove a method or field) via IMetadataProvider
+2. Validates that the XML is still well-formed
+3. Optionally writes a `.bak` first when `createBackup=true` (default: `false`)
+
+> ⚠️ **Applies immediately — there is no dry-run/preview mode.** The change is written
+> to disk the moment the tool is called. Describe the intended change in chat and let the
+> user confirm *before* calling. To revert, use `undo_last_modification` (git checkout) or
+> pass `createBackup=true` to keep a `.bak` copy. Failures are returned with `isError=true`.
 
 Supports `packageName` parameter for when the package name differs from the model name.
 In UDE environments this is auto-resolved; in traditional environments it defaults to

--- a/docs/proposals/bridge-resilience.md
+++ b/docs/proposals/bridge-resilience.md
@@ -1,0 +1,96 @@
+# Proposal: Bridge resilience (retry + health-check)
+
+> Status: **Draft — needs validation on a Windows D365FO VM.**
+> The C# bridge (`D365MetadataBridge.exe`) only runs on Windows, so the changes below
+> cannot be verified in the Linux CI/dev container. This document specifies the design and
+> a test plan so it can be implemented and validated against a real bridge.
+
+## Why
+
+`src/bridge/bridgeClient.ts` spawns the bridge as a child process and talks to it over a
+**single, sequential** stdin/stdout JSON-RPC pipe. Today:
+
+- A single call timeout (`BRIDGE_CALL_TIMEOUT_MS`, now configurable) rejects the promise,
+  but there is **no retry** — a transient hiccup (GC pause, slow first metadata load) fails
+  the whole tool call.
+- There is **no health-check**: if the child process dies or wedges, subsequent calls keep
+  timing out one by one until something restarts it.
+- There is **no detection of a stale pipe** (e.g. process alive but not responding).
+
+This is the main remaining robustness gap from the audit. It is intentionally *not* shipped
+blind because incorrect retry logic on a stateful, sequential pipe can duplicate **write**
+operations (create/modify) — which must never happen.
+
+## Design
+
+### 1. Classify operations: retryable vs. non-retryable
+
+Retries are safe **only for idempotent reads**. Writes (create/modify/label/index) must
+**never** be auto-retried on timeout, because the operation may have already applied on the
+bridge side before the timeout fired.
+
+```ts
+// bridgeAdapter already separates tryBridge* (reads) from bridge* (writes).
+// Add an explicit allow-list of retryable methods (reads only).
+const RETRYABLE_METHODS = new Set([
+  'getClass', 'getTable', 'getForm', 'getEnum', 'getEdt', 'getQuery', 'getView',
+  'getReport', 'getDataEntity', 'getMethodSource', 'getMethodSignature', 'getMenuItem',
+  'completion', 'findExtensionClasses', 'findEventSubscribers', 'apiUsageCallers',
+]);
+```
+
+### 2. Bounded retry with backoff (reads only)
+
+In the `call()` path, when a read method times out or the pipe errors:
+
+- retry up to `BRIDGE_MAX_RETRIES` (default 2) with exponential backoff (250ms, 500ms),
+  jittered;
+- before each retry, run the health-check (below) and restart the child if it is dead;
+- never retry a method not in `RETRYABLE_METHODS`.
+
+```ts
+const BRIDGE_MAX_RETRIES = envInt('BRIDGE_MAX_RETRIES', 2);
+```
+
+### 3. Health-check / liveness
+
+Add a lightweight `ping` method to the C# bridge (`RequestDispatcher.cs`) that returns
+`{ ok: true }` without touching `IMetadataProvider`. The client:
+
+- pings before a retry and on a configurable idle interval (`BRIDGE_HEALTHCHECK_MS`,
+  default 0 = disabled);
+- if the child has exited (`child.exitCode !== null`) or ping times out, tears down the
+  pipe and respawns via the existing spawn path, then replays only the **current read**.
+
+### 4. Restart safety
+
+- Serialize restart behind the existing sequential-call lock so a restart cannot interleave
+  with an in-flight write.
+- Cap restarts (e.g. 3 within 60s) to avoid crash loops; after the cap, surface a clear
+  `isError` result telling the user to check the bridge log (`D365FO_BRIDGE_LOG_FILE`).
+
+## New env vars (document in `.env.example`)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `BRIDGE_MAX_RETRIES` | `2` | Max retries for **read** calls on timeout/pipe error |
+| `BRIDGE_HEALTHCHECK_MS` | `0` | Idle ping interval (0 = disabled) |
+| `BRIDGE_MAX_RESTARTS` | `3` | Max child respawns per 60s before giving up |
+
+## Test plan (on Windows VM)
+
+1. **Read retry:** kill the bridge mid-`getTable`; expect one transparent restart + retry,
+   correct result, single log line.
+2. **Write never retried:** force a timeout during `create`/`modify`; expect immediate
+   `isError` with a message, **no second write** (verify the AOT object was created exactly
+   once / the modification applied once).
+3. **Crash loop guard:** make the bridge exit on startup; expect ≤3 respawns then a clear
+   `isError`.
+4. **Health-check idle:** set `BRIDGE_HEALTHCHECK_MS=5000`, idle 30s, then call — expect the
+   pipe still healthy (or transparently restarted) with no user-visible failure.
+5. **Regression:** existing `tests/bridge/*` and `bridge-e2e.ts` stay green.
+
+## Out of scope
+
+- A true `dryRun` preview for `modify_d365fo_file` (would need a preview mode in the C#
+  `IMetadataProvider` write path). Tracked separately.

--- a/src/tools/dbSync.ts
+++ b/src/tools/dbSync.ts
@@ -334,7 +334,8 @@ export const dbSyncTool = async (params: any, _context: any) => {
           ` (${elapsedSec}s)` +
           `\n\n${scopeDesc}` +
           `\n\n${output || '(no output)'}`
-      }]
+      }],
+      isError: hasErrors,
     };
   } catch (error: any) {
     console.error('Error syncing DB:', error);

--- a/src/tools/edtInfo.ts
+++ b/src/tools/edtInfo.ts
@@ -77,7 +77,7 @@ function getEdtHierarchy(db: any, edtName: string, modelName?: string) {
   }
 
   if (chain.length === 0) {
-    return { content: [{ type: 'text', text: `EDT not found in edt_metadata: ${edtName}\n\nRun extract-metadata to index EDT metadata.` }] };
+    return { content: [{ type: 'text', text: `EDT not found in edt_metadata: ${edtName}\n\nRun extract-metadata to index EDT metadata.` }], isError: true };
   }
 
   // Direct children (EDTs that extend this one)

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -1453,7 +1453,7 @@ export async function handleGenerateD365Xml(
         '  1. Pass modelName explicitly in the tool call arguments\n' +
         '  2. Add modelName to .mcp.json context: { "context": { "modelName": "YourModel" } }\n' +
         '  3. Add workspacePath ending with the package/model name: { "context": { "workspacePath": "K:\\\\...\\\\YourModel" } }';
-      return { content: [{ type: 'text', text: errorMsg }] };
+      return { content: [{ type: 'text', text: errorMsg }], isError: true };
     }
 
     console.error(

--- a/src/tools/getLabelInfo.ts
+++ b/src/tools/getLabelInfo.ts
@@ -77,6 +77,7 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
               `💡 Try search_labels to find labels by text, or omit labelId to list available label files.`,
           },
         ],
+        isError: true,
       };
     }
 

--- a/src/tools/renameLabel.ts
+++ b/src/tools/renameLabel.ts
@@ -165,6 +165,7 @@ export async function renameLabelTool(request: CallToolRequest, context: XppServ
     if (oldLabelId === newLabelId) {
       return {
         content: [{ type: 'text', text: `⚠️ Old and new label IDs are identical ("${oldLabelId}"). Nothing to do.` }],
+        isError: true,
       };
     }
 

--- a/src/tools/securityArtifactInfo.ts
+++ b/src/tools/securityArtifactInfo.ts
@@ -59,6 +59,7 @@ function getPrivilegeInfo(db: any, name: string, _includeChain: boolean) {
   if (!symbol) {
     return {
       content: [{ type: 'text', text: `Security privilege not found: ${name}\n\nTip: Run extract-metadata and build-database to index security objects.` }],
+      isError: true,
     };
   }
 
@@ -101,6 +102,7 @@ function getDutyInfo(db: any, name: string, includeChain: boolean) {
   if (!symbol) {
     return {
       content: [{ type: 'text', text: `Security duty not found: ${name}` }],
+      isError: true,
     };
   }
 
@@ -166,6 +168,7 @@ function getRoleInfo(db: any, name: string, includeChain: boolean) {
   if (!symbol) {
     return {
       content: [{ type: 'text', text: `Security role not found: ${name}` }],
+      isError: true,
     };
   }
 

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -207,7 +207,9 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
     }
 
     const finishMetrics = recordToolStart(toolName);
-    const result = await (async () => {
+    let result: any;
+    try {
+    result = await (async () => {
       // Build the progress description for this tool call.
       const args = request.params.arguments as Record<string, any> | undefined;
       const progressMsg = buildProgressMessage(toolName, args);
@@ -623,6 +625,20 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         };
     } })();
     })();
+    } catch (err) {
+      // Central safety net: convert ANY thrown error (incl. zod validation,
+      // bridge failures, unexpected exceptions) into a proper tool result with
+      // isError:true so the agent SEES the failure and can react/retry, instead
+      // of it surfacing as an opaque JSON-RPC protocol error. Individual tools
+      // may still return their own richer isError messages; this only catches
+      // what escapes them.
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[toolHandler] ❌ ${toolName} threw: ${message}`);
+      result = {
+        content: [{ type: 'text', text: `❌ ${toolName} failed: ${message}` }],
+        isError: true,
+      };
+    }
 
     const capped = capToolResponse(toolName, result);
     // Record metrics: detect empty result (no content or first text item is empty)

--- a/src/tools/undoLastModification.ts
+++ b/src/tools/undoLastModification.ts
@@ -97,6 +97,7 @@ export const undoLastModificationTool = async (params: any, context: XppServerCo
     if (!fs.existsSync(absolutePath)) {
       return {
         content: [{ type: 'text', text: 'File not found and not tracked by git: ' + absolutePath }],
+        isError: true,
       };
     }
 


### PR DESCRIPTION
This pull request focuses on improving error handling and documentation for several tools in the codebase, particularly making error states explicit and easier for Copilot and users to detect and handle. It also introduces a new proposal for enhancing the robustness of the bridge client with retries and health checks. The most important changes are grouped below:

**Error Handling Improvements:**

* Added `isError: true` to tool responses when an error or not-found condition occurs across multiple tools, ensuring that failures are clearly signaled to Copilot and users. This affects tools such as `getEdtHierarchy`, `handleGenerateD365Xml`, `getLabelInfoTool`, `renameLabelTool`, `getPrivilegeInfo`, `getDutyInfo`, `getRoleInfo`, and `undoLastModificationTool` (`src/tools/edtInfo.ts`, `src/tools/generateD365Xml.ts`, `src/tools/getLabelInfo.ts`, `src/tools/renameLabel.ts`, `src/tools/securityArtifactInfo.ts`, `src/tools/undoLastModification.ts`). [[1]](diffhunk://#diff-9a86afa9a79724a3f4d006c38e820766663f9d27385bf0b9ec76335295aa86f1L80-R80) [[2]](diffhunk://#diff-e1e7fce542c2fc43bba3dd26014907a89b50f9294dc4967e3e8b7354eecdff2bL1456-R1456) [[3]](diffhunk://#diff-c4890eb92105c289f2bd693f8557191255041e4ed02f3928da5c9ed287502c94R80) [[4]](diffhunk://#diff-76257de6934897f1fcd9d6bf66dabe78b01e2315189bfe5d84def17fae143cd5R168) [[5]](diffhunk://#diff-88bc91fe5e28ea9c90d83d3f73c2ffcc031d2681e0abbca5d5960930186774beR62) [[6]](diffhunk://#diff-88bc91fe5e28ea9c90d83d3f73c2ffcc031d2681e0abbca5d5960930186774beR105) [[7]](diffhunk://#diff-88bc91fe5e28ea9c90d83d3f73c2ffcc031d2681e0abbca5d5960930186774beR171) [[8]](diffhunk://#diff-db9584eaefe357d4fdd64f4194a067f0e0db8afbf38c4a105cc009df10d4f389R100)
* Updated the central tool handler to wrap all tool calls in a try/catch block, converting any uncaught exceptions into a proper tool result with `isError: true`. This ensures that unexpected errors are surfaced in a consistent, agent-friendly way instead of as protocol errors (`src/tools/toolHandler.ts`). [[1]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dL210-R212) [[2]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dR628-R641)
* Added `isError` to the result of the `dbSyncTool` when errors are detected (`src/tools/dbSync.ts`).

**Documentation and Behavior Clarification:**

* Updated documentation for the `modify_d365fo_file` tool to clarify that changes are applied immediately, backup creation is optional (controlled by a parameter), and there is no dry-run mode. The docs now warn users to confirm intent before making changes and describe how to revert (`docs/MCP_TOOLS.md`). [[1]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L120-R120) [[2]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L599-R608)

**Robustness Proposal:**

* Added a new proposal document outlining a plan to add retry and health-check logic to the bridge client, including classifying operations as retryable or not, implementing bounded retries with backoff, health-check pings, restart safety, and new environment variables. This document also includes a test plan and explicitly states out-of-scope items (`docs/proposals/bridge-resilience.md`).