### PR TITLE
chore: sync instance env template with .env.example settings

### DIFF
--- a/instances/.env.template
+++ b/instances/.env.template
@@ -39,6 +39,14 @@ XPP_CONFIG_NAME=
 # ISV prefix for code gen and naming validation (e.g. ASP, CTSO, WHS)
 EXTENSION_PREFIX=
 
+# Optional suffix appended to new object names (e.g. MyTableZZ with EXTENSION_SUFFIX=ZZ)
+# Most projects use only a prefix — leave unset unless your naming convention requires a suffix.
+# EXTENSION_SUFFIX=
+
+# Extension naming style: prefix (default, embeds EXTENSION_PREFIX) or model-name (embeds the model name)
+# Use model-name when your model name is long/customer-specific but your prefix is a short abbreviation.
+# EXTENSION_NAMING_STYLE=prefix
+
 # Model name for code generation tools
 D365FO_MODEL_NAME=
 
@@ -48,6 +56,40 @@ D365FO_MODEL_NAME=
 INCLUDE_LABELS=true
 LABEL_LANGUAGES=en-US
 EXTRACT_MODE=all
+
+# Label sort order: "alphabetical" (default) or "append" (new labels added at end of file)
+# LABEL_SORT_ORDER=alphabetical
+
+# Compute usage statistics during build (slow for large databases)
+# COMPUTE_STATS=false
+
+# =============================================================================
+# AZURE BLOB STORAGE (optional — only if this instance pulls its DB from blob)
+# =============================================================================
+# Local instances normally build their own DB, so these stay unset. Set them
+# only if you download a prebuilt DB instead of running extract + build locally.
+# AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=youraccount;AccountKey=yourkey;EndpointSuffix=core.windows.net
+# BLOB_CONTAINER_NAME=xpp-metadata
+# BLOB_DATABASE_NAME=databases/xpp-metadata-latest.db
+
+# =============================================================================
+# D365FO CONTEXT (optional — normally passed via .mcp.json, not .env)
+# =============================================================================
+# These D365FO_* variables are usually set in the server's .mcp.json "env" block
+# so Visual Studio passes them to the subprocess. Listed here for reference /
+# manual CLI runs. UDE instances get their context from XPP_CONFIG_NAME above.
+# D365FO_WORKSPACE_PATH=K:\AOSService\PackagesLocalDirectory\YourPackage\YourModel
+# D365FO_PROJECT_PATH=K:\repos\MySolution\MyProject\MyProject.rnrproj
+# D365FO_SOLUTION_PATH=K:\repos\MySolution\MySolution.sln
+# D365FO_SOLUTIONS_PATH=K:\repos\MySolution\projects
+# D365FO_DEV_ENVIRONMENT_TYPE=auto
+# D365FO_CUSTOM_PACKAGES_PATH=C:\CustomXppCode                # UDE: ModelStoreFolder
+# D365FO_MICROSOFT_PACKAGES_PATH=C:\Users\...\PackagesLocalDirectory  # UDE: FrameworkDirectory
+# D365FO_BRIDGE_LOG_FILE=C:\Temp\d365fo-bridge.log
+#
+# Bridge timeouts (milliseconds). Raise on large installations or slow VMs.
+# BRIDGE_READY_TIMEOUT_MS=30000   # wait for the C# bridge to become ready (default 30000)
+# BRIDGE_CALL_TIMEOUT_MS=60000    # per-call timeout for a single bridge request (default 60000)
 
 # =============================================================================
 # SERVER OPTIONS

--- a/instances/.env.template
+++ b/instances/.env.template
@@ -69,8 +69,8 @@ EXTRACT_MODE=all
 # Local instances normally build their own DB, so these stay unset. Set them
 # only if you download a prebuilt DB instead of running extract + build locally.
 # AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=youraccount;AccountKey=yourkey;EndpointSuffix=core.windows.net
-# BLOB_CONTAINER_NAME=xpp-metadata
-# BLOB_DATABASE_NAME=databases/xpp-metadata-latest.db
+# BLOB_CONTAINER_NAME=xpp-databases
+# BLOB_DATABASE_NAME=xpp-metadata.db
 
 # =============================================================================
 # D365FO CONTEXT (optional — normally passed via .mcp.json, not .env)


### PR DESCRIPTION
Add the env vars present in .env.example but missing from the instance template as commented-out entries, so rebuild-instance.ps1's missing- settings check (which treats commented lines as present) stops flagging them on freshly-created instances.

Adds: EXTENSION_NAMING_STYLE, EXTENSION_SUFFIX, LABEL_SORT_ORDER, COMPUTE_STATS, the Azure Blob block (AZURE_STORAGE_CONNECTION_STRING, BLOB_CONTAINER_NAME, BLOB_DATABASE_NAME), the D365FO context block (WORKSPACE/PROJECT/SOLUTION/SOLUTIONS paths, DEV_ENVIRONMENT_TYPE, CUSTOM/MICROSOFT packages paths, BRIDGE_LOG_FILE), and bridge timeouts.