### PR TITLE
refactor: make D365FO_DEV_ENVIRONMENT_TYPE the canonical external set…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,8 @@ MCP_SERVER_MODE=full          # full (default) | read-only | write-only
 
 # Dev environment detection: auto (default), traditional, ude (Power Platform Tools)
 # 'auto' detects UDE when XPP config files exist in %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\
-DEV_ENVIRONMENT_TYPE=auto
+D365FO_DEV_ENVIRONMENT_TYPE=auto
+# Legacy name (still honored as a fallback if the prefixed one is unset): DEV_ENVIRONMENT_TYPE=auto
 
 # --- Traditional (AOSService VM) ---
 
@@ -122,7 +123,6 @@ EXTENSION_PREFIX=ISV_
 # D365FO_PROJECT_PATH=K:\repos\MySolution\MyProject\MyProject.rnrproj
 # D365FO_SOLUTION_PATH=K:\repos\MySolution\MySolution.sln
 # D365FO_SOLUTIONS_PATH=K:\repos\MySolution\projects
-# D365FO_DEV_ENVIRONMENT_TYPE=auto
 # D365FO_CUSTOM_PACKAGES_PATH=C:\CustomXppCode                # UDE: ModelStoreFolder
 # D365FO_MICROSOFT_PACKAGES_PATH=C:\Users\...\PackagesLocalDirectory  # UDE: FrameworkDirectory
 # D365FO_BRIDGE_LOG_FILE=C:\Temp\d365fo-bridge.log

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -39,7 +39,7 @@ EXTRACT_MODE=custom
 In UDE environments, custom models are **auto-detected** from the custom packages path (`ModelStoreFolder` in your XPP config file). You do not need to set `CUSTOM_MODELS`:
 
 ```env
-DEV_ENVIRONMENT_TYPE=ude
+D365FO_DEV_ENVIRONMENT_TYPE=ude
 XPP_CONFIG_NAME=MyConfig    # name from %LOCALAPPDATA%\Microsoft\Dynamics365\XppConfig\
 EXTENSION_PREFIX=ISV_
 ```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -221,7 +221,7 @@ copy .env.example .env
 Edit `.env`:
 
 ```env
-DEV_ENVIRONMENT_TYPE=auto
+D365FO_DEV_ENVIRONMENT_TYPE=auto
 PACKAGES_PATH=K:/AosService/PackagesLocalDirectory
 CUSTOM_MODELS=YourPackageName
 ```

--- a/instances/.env.template
+++ b/instances/.env.template
@@ -22,14 +22,15 @@ METADATA_PATH=./metadata
 # D365 ENVIRONMENT
 # =============================================================================
 # Development environment type: auto, traditional, ude
-DEV_ENVIRONMENT_TYPE=ude
+# (legacy name DEV_ENVIRONMENT_TYPE still honored as a fallback)
+D365FO_DEV_ENVIRONMENT_TYPE=ude
 
 # --- UDE (Unified Developer Experience) ---
 # XPP config name (from %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\)
 # Tip: run  npm run select-config  to list available configs
 XPP_CONFIG_NAME=
 
-# --- Traditional (only if DEV_ENVIRONMENT_TYPE=traditional) ---
+# --- Traditional (only if D365FO_DEV_ENVIRONMENT_TYPE=traditional) ---
 # D365FO_PACKAGE_PATH=C:\AOSService\PackagesLocalDirectory
 # CUSTOM_MODELS=MyModel1,MyModel2
 

--- a/instances/.env.template
+++ b/instances/.env.template
@@ -40,6 +40,14 @@ XPP_CONFIG_NAME=
 # ISV prefix for code gen and naming validation (e.g. ASP, CTSO, WHS)
 EXTENSION_PREFIX=
 
+# Optional suffix appended to new object names (e.g. MyTableZZ with EXTENSION_SUFFIX=ZZ)
+# Most projects use only a prefix — leave unset unless your naming convention requires a suffix.
+# EXTENSION_SUFFIX=
+
+# Extension naming style: prefix (default, embeds EXTENSION_PREFIX) or model-name (embeds the model name)
+# Use model-name when your model name is long/customer-specific but your prefix is a short abbreviation.
+# EXTENSION_NAMING_STYLE=prefix
+
 # Model name for code generation tools
 D365FO_MODEL_NAME=
 
@@ -49,6 +57,40 @@ D365FO_MODEL_NAME=
 INCLUDE_LABELS=true
 LABEL_LANGUAGES=en-US
 EXTRACT_MODE=all
+
+# Label sort order: "alphabetical" (default) or "append" (new labels added at end of file)
+# LABEL_SORT_ORDER=alphabetical
+
+# Compute usage statistics during build (slow for large databases)
+# COMPUTE_STATS=false
+
+# =============================================================================
+# AZURE BLOB STORAGE (optional — only if this instance pulls its DB from blob)
+# =============================================================================
+# Local instances normally build their own DB, so these stay unset. Set them
+# only if you download a prebuilt DB instead of running extract + build locally.
+# AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=youraccount;AccountKey=yourkey;EndpointSuffix=core.windows.net
+# BLOB_CONTAINER_NAME=xpp-databases
+# BLOB_DATABASE_NAME=xpp-metadata.db
+
+# =============================================================================
+# D365FO CONTEXT (optional — normally passed via .mcp.json, not .env)
+# =============================================================================
+# These D365FO_* variables are usually set in the server's .mcp.json "env" block
+# so Visual Studio passes them to the subprocess. Listed here for reference /
+# manual CLI runs. UDE instances get their context from XPP_CONFIG_NAME above.
+# D365FO_WORKSPACE_PATH=K:\AOSService\PackagesLocalDirectory\YourPackage\YourModel
+# D365FO_PROJECT_PATH=K:\repos\MySolution\MyProject\MyProject.rnrproj
+# D365FO_SOLUTION_PATH=K:\repos\MySolution\MySolution.sln
+# D365FO_SOLUTIONS_PATH=K:\repos\MySolution\projects
+# D365FO_DEV_ENVIRONMENT_TYPE=auto
+# D365FO_CUSTOM_PACKAGES_PATH=C:\CustomXppCode                # UDE: ModelStoreFolder
+# D365FO_MICROSOFT_PACKAGES_PATH=C:\Users\...\PackagesLocalDirectory  # UDE: FrameworkDirectory
+# D365FO_BRIDGE_LOG_FILE=C:\Temp\d365fo-bridge.log
+#
+# Bridge timeouts (milliseconds). Raise on large installations or slow VMs.
+# BRIDGE_READY_TIMEOUT_MS=30000   # wait for the C# bridge to become ready (default 30000)
+# BRIDGE_CALL_TIMEOUT_MS=60000    # per-call timeout for a single bridge request (default 60000)
 
 # =============================================================================
 # SERVER OPTIONS

--- a/instances/rebuild-instance.ps1
+++ b/instances/rebuild-instance.ps1
@@ -76,7 +76,7 @@ function Show-MissingSettings([System.IO.DirectoryInfo]$inst) {
 # versioned file (e.g. "myenv-dev___10.0.2345.153") and rewrite the .env so
 # run-instance can later detect UDE upgrades with a plain file-exists check.
 function Normalize-XppConfigName([string]$envFile) {
-    $envType = Get-EnvValue $envFile 'DEV_ENVIRONMENT_TYPE'
+    $envType = Get-DevEnvType $envFile
     if ($envType -eq 'traditional') { return }
 
     $configName = Get-EnvValue $envFile 'XPP_CONFIG_NAME'
@@ -113,6 +113,44 @@ function Get-EnvValue([string]$envFile, [string]$key) {
     return $null
 }
 
+# ── Helper: read the dev-environment-type setting ───────────────────────────
+# Canonical name is the D365FO_-prefixed form; the plain name is a legacy
+# fallback so un-migrated instances keep behaving correctly during rebuild.
+function Get-DevEnvType([string]$envFile) {
+    $v = Get-EnvValue $envFile 'D365FO_DEV_ENVIRONMENT_TYPE'
+    if (-not $v) { $v = Get-EnvValue $envFile 'DEV_ENVIRONMENT_TYPE' }
+    return $v
+}
+
+# ── Helper: migrate the dev-env-type setting to its canonical prefixed name ──
+# The public setting was renamed DEV_ENVIRONMENT_TYPE -> D365FO_DEV_ENVIRONMENT_TYPE
+# (matching the D365FO_PACKAGE_PATH convention). If an instance .env still uses
+# only the old plain name, offer to rename it in place. Fires only on a genuine
+# migration case (prefixed missing AND plain present), so instances that omit
+# the setting entirely are never nagged. Declining is safe — the plain name is
+# still read as a legacy fallback by both these scripts and the server.
+function Migrate-DevEnvTypeName([string]$envFile) {
+    $prefixed = Get-EnvValue $envFile 'D365FO_DEV_ENVIRONMENT_TYPE'
+    $plain    = Get-EnvValue $envFile 'DEV_ENVIRONMENT_TYPE'
+    if ($prefixed -or (-not $plain)) { return }
+
+    Write-Host ''
+    Write-Host 'NOTE: the dev-environment-type setting has been renamed.' -ForegroundColor Yellow
+    Write-Host '  Old: DEV_ENVIRONMENT_TYPE' -ForegroundColor Yellow
+    Write-Host "  New: D365FO_DEV_ENVIRONMENT_TYPE  (current value: $plain)" -ForegroundColor Yellow
+    Write-Host ''
+    $answer = Read-Host 'Rename it in this .env now? [Y/n]'
+    if ($answer -eq 'n') {
+        Write-Host '  Left unchanged (the old name still works as a legacy fallback).' -ForegroundColor DarkGray
+        return
+    }
+
+    $content = Get-Content $envFile -Raw
+    $content = $content -replace '(?m)^(\s*)DEV_ENVIRONMENT_TYPE(\s*=)', '${1}D365FO_DEV_ENVIRONMENT_TYPE${2}'
+    Set-Content -Path $envFile -Value $content -NoNewline
+    Write-Host '  Renamed DEV_ENVIRONMENT_TYPE -> D365FO_DEV_ENVIRONMENT_TYPE' -ForegroundColor Cyan
+}
+
 # ── Helper: rebuild a single instance ───────────────────────────────────────
 function Rebuild-SingleInstance([System.IO.DirectoryInfo]$inst) {
     $envFile = Join-Path $inst.FullName '.env'
@@ -124,6 +162,7 @@ function Rebuild-SingleInstance([System.IO.DirectoryInfo]$inst) {
     Write-Host "Config: $envFile" -ForegroundColor DarkGray
     Write-Host ('=' * 60) -ForegroundColor DarkGray
 
+    Migrate-DevEnvTypeName $envFile
     Normalize-XppConfigName $envFile
 
     Write-Host ''

--- a/instances/run-instance.ps1
+++ b/instances/run-instance.ps1
@@ -63,12 +63,21 @@ function Get-EnvValue([string]$envFile, [string]$key) {
     return $null
 }
 
+# ── Helper: read the dev-environment-type setting ───────────────────────────
+# Canonical name is the D365FO_-prefixed form; the plain name is a legacy
+# fallback (see rebuild-instance.ps1 for the one-time rename nudge).
+function Get-DevEnvType([string]$envFile) {
+    $v = Get-EnvValue $envFile 'D365FO_DEV_ENVIRONMENT_TYPE'
+    if (-not $v) { $v = Get-EnvValue $envFile 'DEV_ENVIRONMENT_TYPE' }
+    return $v
+}
+
 # ── Run ─────────────────────────────────────────────────────────────────────
 $envFile = Join-Path $selected.FullName '.env'
 $env:ENV_FILE = $envFile
 
 # ── Warn if XPP_CONFIG_NAME no longer resolves ──────────────────────────────
-$envType = Get-EnvValue $envFile 'DEV_ENVIRONMENT_TYPE'
+$envType = Get-DevEnvType $envFile
 $configName = Get-EnvValue $envFile 'XPP_CONFIG_NAME'
 if ($configName -and ($envType -ne 'traditional')) {
     # Rebuild normalises XPP_CONFIG_NAME to the full versioned filename, so a

--- a/src/utils/loadEnv.ts
+++ b/src/utils/loadEnv.ts
@@ -53,4 +53,15 @@ export function loadEnv(callerImportMetaUrl: string): void {
       process.env[key] = resolve(envDir, val);
     }
   }
+
+  // Bridge external setting names to the internal variable the code reads.
+  // The public/canonical setting is the D365FO_-prefixed name (same convention
+  // as D365FO_PACKAGE_PATH), but internally every consumer reads the plain
+  // DEV_ENVIRONMENT_TYPE. Copy the prefixed value into the plain name so a
+  // single normalization point serves all consumers — no read-site changes.
+  // Prefixed wins when both are set; a lone plain entry (loaded natively by
+  // dotenv) is tolerated as silent legacy so existing installs keep working.
+  if (process.env.D365FO_DEV_ENVIRONMENT_TYPE) {
+    process.env.DEV_ENVIRONMENT_TYPE = process.env.D365FO_DEV_ENVIRONMENT_TYPE;
+  }
 }

--- a/tests/utils/loadEnv.test.ts
+++ b/tests/utils/loadEnv.test.ts
@@ -27,7 +27,14 @@ import { loadEnv } from '../../src/utils/loadEnv.js';
 const mockConfig = vi.mocked(dotenv.config);
 
 // ── Env-var isolation ────────────────────────────────────────────────────────
-const TRACKED_VARS = ['ENV_FILE', 'DB_PATH', 'LABELS_DB_PATH', 'METADATA_PATH'] as const;
+const TRACKED_VARS = [
+  'ENV_FILE',
+  'DB_PATH',
+  'LABELS_DB_PATH',
+  'METADATA_PATH',
+  'DEV_ENVIRONMENT_TYPE',
+  'D365FO_DEV_ENVIRONMENT_TYPE',
+] as const;
 let savedEnv: Partial<Record<string, string>> = {};
 
 beforeEach(() => {
@@ -199,5 +206,51 @@ describe('relative path resolution', () => {
     expect(process.env.DB_PATH).toBeUndefined();
     expect(process.env.LABELS_DB_PATH).toBeUndefined();
     expect(process.env.METADATA_PATH).toBeUndefined();
+  });
+});
+
+// ── Dev-environment-type alias (external prefixed → internal plain) ───────────
+// The public/canonical setting is D365FO_DEV_ENVIRONMENT_TYPE, but the code
+// reads the plain DEV_ENVIRONMENT_TYPE. loadEnv bridges the two: prefixed wins,
+// a lone plain entry is tolerated as silent legacy.
+describe('dev-environment-type alias', () => {
+  it('copies the prefixed value into the plain name when only prefixed is set', () => {
+    mockConfig.mockImplementation(() => {
+      process.env.D365FO_DEV_ENVIRONMENT_TYPE = 'ude';
+      return { parsed: {} } as any;
+    });
+
+    loadEnv(FAKE_CALLER_URL);
+
+    expect(process.env.DEV_ENVIRONMENT_TYPE).toBe('ude');
+  });
+
+  it('lets the prefixed value win when both names are set', () => {
+    mockConfig.mockImplementation(() => {
+      process.env.DEV_ENVIRONMENT_TYPE = 'traditional';
+      process.env.D365FO_DEV_ENVIRONMENT_TYPE = 'ude';
+      return { parsed: {} } as any;
+    });
+
+    loadEnv(FAKE_CALLER_URL);
+
+    expect(process.env.DEV_ENVIRONMENT_TYPE).toBe('ude');
+  });
+
+  it('preserves a lone plain entry (legacy fallback) when prefixed is unset', () => {
+    mockConfig.mockImplementation(() => {
+      process.env.DEV_ENVIRONMENT_TYPE = 'traditional';
+      return { parsed: {} } as any;
+    });
+
+    loadEnv(FAKE_CALLER_URL);
+
+    expect(process.env.DEV_ENVIRONMENT_TYPE).toBe('traditional');
+  });
+
+  it('leaves the plain name unset when neither is provided', () => {
+    loadEnv(FAKE_CALLER_URL);
+
+    expect(process.env.DEV_ENVIRONMENT_TYPE).toBeUndefined();
   });
 });


### PR DESCRIPTION
…ting

The dev environment type was exposed under two names: the older plain DEV_ENVIRONMENT_TYPE and the D365FO_-prefixed form added later for the .mcp.json env{} block. Standardize the public setting on the prefixed name (matching the D365FO_PACKAGE_PATH convention) while keeping the plain name internally so no read sites change.

- loadEnv: bridge prefixed -> plain in one place (prefixed wins; a lone plain entry is tolerated as silent legacy). Covers all Node entry points.
- PowerShell: run/rebuild read both (prefixed ?? plain); rebuild offers a one-time in-place rename of the old plain name on confirm.
- Flip .env.example, instances/.env.template, and docs to the prefixed name; keep plain documented as a legacy fallback.
- loadEnv tests: prefixed wins, prefixed-only resolves, lone plain preserved, neither -> unset.