### PR TITLE
fix(bridge): make menu items, security & other object types searchable

### DIFF
--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -120,7 +120,12 @@ namespace D365MetadataBridge.Protocol
                     case "searchobjects":
                         return HandleMetadata(request, () =>
                         {
-                            var type = request.GetStringParam("type") ?? "all";
+                            // The TS bridge client sends the type filter under "objectType";
+                            // accept both keys so the filter is honored either way (and never
+                            // silently downgraded to an unfiltered "all" search).
+                            var type = request.GetStringParam("type")
+                                ?? request.GetStringParam("objectType")
+                                ?? "all";
                             var query = request.GetStringParam("query")
                                 ?? throw new ArgumentException("Missing parameter: query");
                             var maxResults = request.GetIntParam("maxResults") ?? 50;

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -1165,6 +1165,7 @@ namespace D365MetadataBridge.Services
 
             void Search(string objType, IList<string> keys)
             {
+                if (keys == null) return;
                 foreach (var n in keys)
                 {
                     if (result.Results.Count >= maxResults) return;
@@ -1173,23 +1174,84 @@ namespace D365MetadataBridge.Services
                 }
             }
 
+            // Materialize primary keys from a provider collection.
+            // IMPORTANT: these are accessed STRONGLY-TYPED through the public
+            // Microsoft.Dynamics.AX.Metadata.Providers.IMetadataProvider interface — NOT via
+            // `dynamic`. The concrete provider (DiskMetadataProvider) is an internal type, and
+            // the DLR cannot bind to public members of an internal type from this assembly:
+            // `dynamic dyn = prov; dyn.MenuItemDisplays` throws RuntimeBinderException
+            // ("'object' does not contain a definition for 'MenuItemDisplays'") and silently
+            // yields nothing — which is exactly how menu items/security stayed invisible.
+            // Interface access binds at compile time and works. Keys are enumerated (not cast
+            // to IList<string>) so a lazy IEnumerable<string> return is handled safely too.
+            List<string> Keys(string label, Func<IEnumerable<string>> getter)
+            {
+                var list = new List<string>();
+                try
+                {
+                    var raw = getter();
+                    if (raw != null)
+                        foreach (var k in raw) list.Add(k);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[WARN] Search: could not list '{label}': {ex.GetType().Name}: {ex.Message}");
+                }
+                return list;
+            }
+
             void SearchProvider(IMetadataProvider prov)
             {
                 try
                 {
                     switch (type.ToLowerInvariant())
                     {
-                        case "table": Search("table", prov.Tables.GetPrimaryKeys()); break;
-                        case "class": Search("class", prov.Classes.GetPrimaryKeys()); break;
-                        case "enum": Search("enum", prov.Enums.GetPrimaryKeys()); break;
-                        case "edt": Search("edt", prov.Edts.GetPrimaryKeys()); break;
-                        case "form": Search("form", prov.Forms.GetPrimaryKeys()); break;
+                        case "table": Search("table", Keys("table", () => prov.Tables.GetPrimaryKeys())); break;
+                        case "class": Search("class", Keys("class", () => prov.Classes.GetPrimaryKeys())); break;
+                        case "enum": Search("enum", Keys("enum", () => prov.Enums.GetPrimaryKeys())); break;
+                        case "edt": Search("edt", Keys("edt", () => prov.Edts.GetPrimaryKeys())); break;
+                        case "form": Search("form", Keys("form", () => prov.Forms.GetPrimaryKeys())); break;
+                        case "query": Search("query", Keys("query", () => prov.Queries.GetPrimaryKeys())); break;
+                        case "view": Search("view", Keys("view", () => prov.Views.GetPrimaryKeys())); break;
+                        case "data-entity":
+                        case "dataentity": Search("data-entity", Keys("data-entity", () => prov.DataEntityViews.GetPrimaryKeys())); break;
+
+                        case "menu-item-display": Search("menu-item-display", Keys("menu-item-display", () => prov.MenuItemDisplays.GetPrimaryKeys())); break;
+                        case "menu-item-action": Search("menu-item-action", Keys("menu-item-action", () => prov.MenuItemActions.GetPrimaryKeys())); break;
+                        case "menu-item-output": Search("menu-item-output", Keys("menu-item-output", () => prov.MenuItemOutputs.GetPrimaryKeys())); break;
+
+                        case "security-privilege": Search("security-privilege", Keys("security-privilege", () => prov.SecurityPrivileges.GetPrimaryKeys())); break;
+                        case "security-duty": Search("security-duty", Keys("security-duty", () => prov.SecurityDuties.GetPrimaryKeys())); break;
+                        case "security-role": Search("security-role", Keys("security-role", () => prov.SecurityRoles.GetPrimaryKeys())); break;
+
+                        case "table-extension": Search("table-extension", Keys("table-extension", () => prov.TableExtensions.GetPrimaryKeys())); break;
+                        // IMetadataProvider has no ClassExtensions collection — CoC/augmentation
+                        // classes live in the regular Classes collection (named *_Extension). The
+                        // bridge can't filter them out here, so return nothing and let the caller
+                        // fall back to the SQLite index, which indexes class-extension explicitly.
+                        case "class-extension": break;
+                        case "form-extension": Search("form-extension", Keys("form-extension", () => prov.FormExtensions.GetPrimaryKeys())); break;
+                        case "enum-extension": Search("enum-extension", Keys("enum-extension", () => prov.EnumExtensions.GetPrimaryKeys())); break;
+                        case "edt-extension": Search("edt-extension", Keys("edt-extension", () => prov.EdtExtensions.GetPrimaryKeys())); break;
+                        case "data-entity-extension": Search("data-entity-extension", Keys("data-entity-extension", () => prov.DataEntityViewExtensions.GetPrimaryKeys())); break;
+
                         default:
-                            Search("table", prov.Tables.GetPrimaryKeys());
-                            Search("class", prov.Classes.GetPrimaryKeys());
-                            Search("enum", prov.Enums.GetPrimaryKeys());
-                            Search("edt", prov.Edts.GetPrimaryKeys());
-                            Search("form", prov.Forms.GetPrimaryKeys());
+                            // "all" (or any unrecognized filter): enumerate every object kind so
+                            // nothing — menu items included — is silently invisible to search.
+                            Search("table", Keys("table", () => prov.Tables.GetPrimaryKeys()));
+                            Search("class", Keys("class", () => prov.Classes.GetPrimaryKeys()));
+                            Search("enum", Keys("enum", () => prov.Enums.GetPrimaryKeys()));
+                            Search("edt", Keys("edt", () => prov.Edts.GetPrimaryKeys()));
+                            Search("form", Keys("form", () => prov.Forms.GetPrimaryKeys()));
+                            Search("query", Keys("query", () => prov.Queries.GetPrimaryKeys()));
+                            Search("view", Keys("view", () => prov.Views.GetPrimaryKeys()));
+                            Search("data-entity", Keys("data-entity", () => prov.DataEntityViews.GetPrimaryKeys()));
+                            Search("menu-item-display", Keys("menu-item-display", () => prov.MenuItemDisplays.GetPrimaryKeys()));
+                            Search("menu-item-action", Keys("menu-item-action", () => prov.MenuItemActions.GetPrimaryKeys()));
+                            Search("menu-item-output", Keys("menu-item-output", () => prov.MenuItemOutputs.GetPrimaryKeys()));
+                            Search("security-privilege", Keys("security-privilege", () => prov.SecurityPrivileges.GetPrimaryKeys()));
+                            Search("security-duty", Keys("security-duty", () => prov.SecurityDuties.GetPrimaryKeys()));
+                            Search("security-role", Keys("security-role", () => prov.SecurityRoles.GetPrimaryKeys()));
                             break;
                     }
                 }

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -1229,7 +1229,9 @@ namespace D365MetadataBridge.Services
                         // classes live in the regular Classes collection (named *_Extension). The
                         // bridge can't filter them out here, so return nothing and let the caller
                         // fall back to the SQLite index, which indexes class-extension explicitly.
-                        case "class-extension": break;
+                        case "class-extension":
+                            Console.Error.WriteLine("[DEBUG] Search: class-extension requested — no IMetadataProvider collection; falling back to SQLite index");
+                            break;
                         case "form-extension": Search("form-extension", Keys("form-extension", () => prov.FormExtensions.GetPrimaryKeys())); break;
                         case "enum-extension": Search("enum-extension", Keys("enum-extension", () => prov.EnumExtensions.GetPrimaryKeys())); break;
                         case "edt-extension": Search("edt-extension", Keys("edt-extension", () => prov.EdtExtensions.GetPrimaryKeys())); break;
@@ -1278,20 +1280,21 @@ namespace D365MetadataBridge.Services
         {
             try
             {
-                dynamic providerDynamic = _provider;
-                dynamic privileges = providerDynamic.SecurityPrivileges;
+                // Access collections via IMetadataProvider interface (compile-time binding).
+                // Avoids RuntimeBinderException when DiskMetadataProvider (internal type)
+                // is accessed through dynamic from another assembly.
+                var privileges = _provider.SecurityPrivileges;
                 dynamic? axObj = privileges.Read(name);
                 // Fallback to reference provider (UDE: Microsoft packages)
                 if (axObj == null && _referenceProvider != null)
                 {
-                    dynamic refProv = _referenceProvider!;
-                    privileges = refProv.SecurityPrivileges;
+                    privileges = _referenceProvider!.SecurityPrivileges;
                     axObj = privileges.Read(name);
                 }
                 if (axObj == null) return null;
 
                 string? model = null;
-                try { var mi = privileges.GetModelInfo(name); if (mi?.Count > 0) model = ((IEnumerable<dynamic>)mi).First().Name; } catch { }
+                try { var mi = privileges.GetModelInfo(name); if (mi?.Count > 0) model = mi.First().Name; } catch { }
 
                 var entryPoints = new List<object>();
                 try
@@ -1312,17 +1315,17 @@ namespace D365MetadataBridge.Services
                 var parentDuties = new List<object>();
                 try
                 {
-                    foreach (var dutyName in providerDynamic.SecurityDuties.GetPrimaryKeys())
+                    foreach (var dutyName in _provider.SecurityDuties.GetPrimaryKeys())
                     {
                         try
                         {
-                            dynamic duty = providerDynamic.SecurityDuties.Read((string)dutyName);
+                            dynamic duty = _provider.SecurityDuties.Read(dutyName);
                             if (duty?.Privileges == null) continue;
                             foreach (var p in duty.Privileges)
                             {
                                 if ((string)p.Name == name)
                                 {
-                                    parentDuties.Add(new { name = (string)dutyName });
+                                    parentDuties.Add(new { name = dutyName });
                                     break;
                                 }
                             }
@@ -1358,20 +1361,21 @@ namespace D365MetadataBridge.Services
         {
             try
             {
-                dynamic providerDynamic = _provider;
-                dynamic duties = providerDynamic.SecurityDuties;
+                // Access collections via IMetadataProvider interface (compile-time binding).
+                // Avoids RuntimeBinderException when DiskMetadataProvider (internal type)
+                // is accessed through dynamic from another assembly.
+                var duties = _provider.SecurityDuties;
                 dynamic? axObj = duties.Read(name);
                 // Fallback to reference provider (UDE: Microsoft packages)
                 if (axObj == null && _referenceProvider != null)
                 {
-                    dynamic refProv = _referenceProvider!;
-                    duties = refProv.SecurityDuties;
+                    duties = _referenceProvider!.SecurityDuties;
                     axObj = duties.Read(name);
                 }
                 if (axObj == null) return null;
 
                 string? model = null;
-                try { var mi = duties.GetModelInfo(name); if (mi?.Count > 0) model = ((IEnumerable<dynamic>)mi).First().Name; } catch { }
+                try { var mi = duties.GetModelInfo(name); if (mi?.Count > 0) model = mi.First().Name; } catch { }
 
                 var childPrivileges = new List<object>();
                 try
@@ -1397,17 +1401,17 @@ namespace D365MetadataBridge.Services
                 var parentRoles = new List<object>();
                 try
                 {
-                    foreach (var roleName in providerDynamic.SecurityRoles.GetPrimaryKeys())
+                    foreach (var roleName in _provider.SecurityRoles.GetPrimaryKeys())
                     {
                         try
                         {
-                            dynamic role = providerDynamic.SecurityRoles.Read((string)roleName);
+                            dynamic role = _provider.SecurityRoles.Read(roleName);
                             if (role?.Duties == null) continue;
                             foreach (var d in role.Duties)
                             {
                                 if ((string)d.Name == name)
                                 {
-                                    parentRoles.Add(new { name = (string)roleName });
+                                    parentRoles.Add(new { name = roleName });
                                     break;
                                 }
                             }
@@ -1444,20 +1448,21 @@ namespace D365MetadataBridge.Services
         {
             try
             {
-                dynamic providerDynamic = _provider;
-                dynamic roles = providerDynamic.SecurityRoles;
+                // Access collections via IMetadataProvider interface (compile-time binding).
+                // Avoids RuntimeBinderException when DiskMetadataProvider (internal type)
+                // is accessed through dynamic from another assembly.
+                var roles = _provider.SecurityRoles;
                 dynamic? axObj = roles.Read(name);
                 // Fallback to reference provider (UDE: Microsoft packages)
                 if (axObj == null && _referenceProvider != null)
                 {
-                    dynamic refProv = _referenceProvider!;
-                    roles = refProv.SecurityRoles;
+                    roles = _referenceProvider!.SecurityRoles;
                     axObj = roles.Read(name);
                 }
                 if (axObj == null) return null;
 
                 string? model = null;
-                try { var mi = roles.GetModelInfo(name); if (mi?.Count > 0) model = ((IEnumerable<dynamic>)mi).First().Name; } catch { }
+                try { var mi = roles.GetModelInfo(name); if (mi?.Count > 0) model = mi.First().Name; } catch { }
 
                 var childDuties = new List<object>();
                 try
@@ -1532,25 +1537,34 @@ namespace D365MetadataBridge.Services
                 // Try primary provider first, then reference provider (UDE fallback)
                 foreach (var prov in new[] { _provider, _referenceProvider }.Where(p => p != null))
                 {
-                    dynamic providerDynamic = prov!;
-
                     foreach (var tryType in tryTypes)
                     {
                         try
                         {
-                            dynamic items = tryType switch
+                            // Access collections via IMetadataProvider interface (compile-time binding).
+                            // Avoids RuntimeBinderException when DiskMetadataProvider (internal type)
+                            // is accessed through dynamic from another assembly.
+                            dynamic? axObj = tryType switch
                             {
-                                "display" => providerDynamic.MenuItemDisplays,
-                                "action" => providerDynamic.MenuItemActions,
-                                "output" => providerDynamic.MenuItemOutputs,
+                                "display" => (object?)prov!.MenuItemDisplays.Read(name),
+                                "action"  => (object?)prov!.MenuItemActions.Read(name),
+                                "output"  => (object?)prov!.MenuItemOutputs.Read(name),
                                 _ => throw new InvalidOperationException()
                             };
-
-                            dynamic axObj = items.Read(name);
                             if (axObj == null) continue;
 
                             string? model = null;
-                            try { var mi = items.GetModelInfo(name); if (mi?.Count > 0) model = ((IEnumerable<dynamic>)mi).First().Name; } catch { }
+                            try
+                            {
+                                var rawMi = tryType switch
+                                {
+                                    "display" => (object?)prov!.MenuItemDisplays.GetModelInfo(name),
+                                    "action"  => (object?)prov!.MenuItemActions.GetModelInfo(name),
+                                    _         => (object?)prov!.MenuItemOutputs.GetModelInfo(name),
+                                };
+                                if (rawMi != null) { dynamic dmi = rawMi; if (dmi.Count > 0) model = (string?)dmi.First().Name; }
+                            }
+                            catch { }
 
                             return new
                             {

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -503,7 +503,7 @@ export async function tryBridgeSearch(
 ): Promise<ToolResult | null> {
   if (!bridge?.isReady || !bridge.metadataAvailable) return null;
   try {
-    const sr = await bridge.searchObjects(query, objectType);
+    const sr = await bridge.searchObjects(query, objectType, maxResults);
     if (!sr || sr.results.length === 0) return null;
 
     let out = `# Search: "${query}"${objectType ? ` (type: ${objectType})` : ''}\n\n`;

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -382,9 +382,10 @@ export class BridgeClient extends EventEmitter {
     return this.call<BridgeMethodSource>('getMethodSource', { className, methodName });
   }
 
-  async searchObjects(query: string, objectType?: string): Promise<BridgeSearchResult> {
+  async searchObjects(query: string, objectType?: string, maxResults?: number): Promise<BridgeSearchResult> {
     const params: Record<string, unknown> = { query };
     if (objectType) params.objectType = objectType;
+    if (maxResults != null) params.maxResults = maxResults;
     return this.call<BridgeSearchResult>('searchObjects', params);
   }
 

--- a/tests/tools/bridge-search.test.ts
+++ b/tests/tools/bridge-search.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for tryBridgeSearch — verifies that the new object types introduced in
+ * PR #511 (menu items, security artifacts, query, view, data-entity, extensions)
+ * are correctly routed, formatted and passed through with the right maxResults.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { tryBridgeSearch } from '../../src/bridge/bridgeAdapter';
+import type { BridgeClient } from '../../src/bridge/bridgeClient';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeBridge(results: { name: string; type: string }[] = []): BridgeClient {
+  return {
+    isReady: true,
+    metadataAvailable: true,
+    searchObjects: vi.fn(async () => ({
+      results,
+      totalCount: results.length,
+    })),
+  } as unknown as BridgeClient;
+}
+
+// ─── basic routing ────────────────────────────────────────────────────────────
+
+describe('tryBridgeSearch — basic', () => {
+  it('returns null when bridge is not ready', async () => {
+    const bridge = { isReady: false, metadataAvailable: true } as unknown as BridgeClient;
+    expect(await tryBridgeSearch(bridge, 'ProjPosted')).toBeNull();
+  });
+
+  it('returns null when bridge has no metadata', async () => {
+    const bridge = { isReady: true, metadataAvailable: false } as unknown as BridgeClient;
+    expect(await tryBridgeSearch(bridge, 'ProjPosted')).toBeNull();
+  });
+
+  it('returns null when bridge returns empty results', async () => {
+    const bridge = makeBridge([]);
+    expect(await tryBridgeSearch(bridge, 'ProjPosted')).toBeNull();
+  });
+
+  it('includes result count and source annotation', async () => {
+    const bridge = makeBridge([{ name: 'ProjPostingTrans', type: 'table' }]);
+    const result = await tryBridgeSearch(bridge, 'ProjPosting');
+    expect(result).not.toBeNull();
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('Results:');
+    expect(text).toContain('C# bridge');
+  });
+});
+
+// ─── menu item types (PR #511 additions) ──────────────────────────────────────
+
+describe('tryBridgeSearch — menu item types', () => {
+  it('searches for menu-item-display and shows type in output', async () => {
+    const bridge = makeBridge([
+      { name: 'ProjPostedProjectTransactions', type: 'menu-item-display' },
+    ]);
+    const result = await tryBridgeSearch(bridge, 'ProjPosted', 'menu-item-display', 20);
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('ProjPostedProjectTransactions');
+    expect(text).toContain('menu-item-display');
+    // Confirms the type filter is shown in the header
+    expect(text).toContain('type: menu-item-display');
+    // Confirms searchObjects was called with the right objectType
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'ProjPosted',
+      'menu-item-display',
+      20,
+    );
+  });
+
+  it('searches for menu-item-action', async () => {
+    const bridge = makeBridge([{ name: 'ProjCreate', type: 'menu-item-action' }]);
+    const result = await tryBridgeSearch(bridge, 'ProjCreate', 'menu-item-action', 10);
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('menu-item-action');
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'ProjCreate',
+      'menu-item-action',
+      10,
+    );
+  });
+
+  it('searches for menu-item-output', async () => {
+    const bridge = makeBridge([{ name: 'ProjInvoice', type: 'menu-item-output' }]);
+    const result = await tryBridgeSearch(bridge, 'ProjInvoice', 'menu-item-output', 10);
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'ProjInvoice',
+      'menu-item-output',
+      10,
+    );
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('menu-item-output');
+  });
+});
+
+// ─── security artifact types (PR #511 additions) ─────────────────────────────
+
+describe('tryBridgeSearch — security artifact types', () => {
+  it('searches for security-privilege', async () => {
+    const bridge = makeBridge([{ name: 'SalesSalesOrderMaintain', type: 'security-privilege' }]);
+    const result = await tryBridgeSearch(bridge, 'SalesSales', 'security-privilege', 20);
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('SalesSalesOrderMaintain');
+    expect(text).toContain('security-privilege');
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'SalesSales',
+      'security-privilege',
+      20,
+    );
+  });
+
+  it('searches for security-duty', async () => {
+    const bridge = makeBridge([{ name: 'SalesOrderMaintain', type: 'security-duty' }]);
+    const result = await tryBridgeSearch(bridge, 'SalesOrder', 'security-duty', 10);
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'SalesOrder',
+      'security-duty',
+      10,
+    );
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('security-duty');
+  });
+
+  it('searches for security-role', async () => {
+    const bridge = makeBridge([{ name: 'SalesManager', type: 'security-role' }]);
+    const result = await tryBridgeSearch(bridge, 'Sales', 'security-role', 10);
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'Sales',
+      'security-role',
+      10,
+    );
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('SalesManager');
+  });
+});
+
+// ─── maxResults passthrough (PR #511 fix) ────────────────────────────────────
+
+describe('tryBridgeSearch — maxResults passthrough', () => {
+  it('passes custom maxResults to bridge.searchObjects', async () => {
+    const bridge = makeBridge([{ name: 'SalesTable', type: 'table' }]);
+    await tryBridgeSearch(bridge, 'Sales', 'table', 75);
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'Sales',
+      'table',
+      75,
+    );
+  });
+
+  it('uses default maxResults of 50 when not specified', async () => {
+    const bridge = makeBridge([{ name: 'SalesTable', type: 'table' }]);
+    await tryBridgeSearch(bridge, 'Sales');
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'Sales',
+      undefined,
+      50,
+    );
+  });
+
+  it('omits objectType param when searching all types', async () => {
+    const bridge = makeBridge([{ name: 'CustTable', type: 'table' }]);
+    // undefined objectType means "all" — should be passed as undefined, not "all"
+    await tryBridgeSearch(bridge, 'Cust', undefined, 20);
+    expect((bridge.searchObjects as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      'Cust',
+      undefined,
+      20,
+    );
+  });
+});
+
+// ─── mixed result types ───────────────────────────────────────────────────────
+
+describe('tryBridgeSearch — mixed results', () => {
+  it('renders all result types in output when searching all', async () => {
+    const bridge = makeBridge([
+      { name: 'ProjPostedProjectTransactions', type: 'menu-item-display' },
+      { name: 'ProjPostedEnum', type: 'enum' },
+      { name: 'ProjPostedPrivilege', type: 'security-privilege' },
+    ]);
+    const result = await tryBridgeSearch(bridge, 'ProjPosted', undefined, 50);
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('ProjPostedProjectTransactions');
+    expect(text).toContain('menu-item-display');
+    expect(text).toContain('ProjPostedEnum');
+    expect(text).toContain('ProjPostedPrivilege');
+    expect(text).toContain('security-privilege');
+  });
+});


### PR DESCRIPTION
## Summary

  Bridge search (`searchObjects`) silently ignored most object types. A search for a display menu item like
  `ProjPostedProjectTransactions` returned **only** the similarly-named enum — the menu item itself was invisible. Three
  layered defects caused this:

  1. **Type filter dropped at the JSON-RPC boundary** — the TS client sent the filter as `objectType`, but the C#
  dispatcher read `type`, so it always defaulted to `"all"`. Explicitly asking for `menu-item-display` still searched
  everything.
  2. **Coverage gap in `SearchObjects`** — it only enumerated `table`/`class`/`enum`/`edt`/`form`. Menu items, security
  objects, queries, views, data entities and extensions were never searched.
  3. **`dynamic` binding failure** (found during testing) — accessing the new collections via `dynamic` threw
  `RuntimeBinderException: 'object' does not contain a definition for 'MenuItemDisplays'`, because the concrete provider
  (`DiskMetadataProvider`) is `internal` and the DLR can't bind its public members from another assembly.

  Because the bridge short-circuits the SQLite fallback whenever it returns ≥1 result, a partial hit (the enum) also
  masked menu items that the SQLite index *does* contain.

  ## Changes

  - **`RequestDispatcher.cs`** — `searchObjects` accepts both `type` and `objectType`, so the filter is honored.
  - **`MetadataReadService.SearchObjects`** — now covers menu items, security (privilege/duty/role), query, view,
  data-entity and extensions, in both the typed cases and the `"all"` default. Collections are accessed
  **strongly-typed** through `IMetadataProvider` (not `dynamic`). `class-extension` is a no-op (no provider collection —
  CoC classes live in `Classes`) and falls back to the SQLite index, which indexes it explicitly.
  - **`bridgeClient.ts` / `bridgeAdapter.ts`** — the tool's `limit` is passed through to the bridge as `maxResults`
  (previously dropped, capping every search at 50).