### PR TITLE
docs: add Claude Code CLI support (CLAUDE.md, setup guide, alwaysLoad)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,9 @@
 # D365 Finance & Operations X++ Development
 
-<!-- Copy this file to your D365FO solution parent folder alongside .mcp.json.
-     Claude Code reads CLAUDE.md automatically from the working directory upward.
+<!-- Copy this file to the parent folder that contains all your D365FO solution folders
+     (the same folder where .github\copilot-instructions.md lives for Copilot users).
+     Claude Code reads CLAUDE.md automatically from the working directory upward,
+     so one copy here covers every solution underneath — no per-solution copies needed.
 
      Full rules are delivered via the MCP `xpp_system_instructions` prompt.
      This file provides only the minimum static context needed when the MCP server
@@ -51,7 +53,7 @@ Call `get_workspace_info()` before doing anything with D365FO objects.
 5. Never use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
 6. Never use hardcoded strings in Info/warning/error — use `@Model:Label`
 7. Call `search_labels()` before `create_label()` — reuse existing labels
-8. Extension naming depends on `EXTENSION_NAMING_STYLE` (check `get_workspace_info`). Default `prefix` → class `{Target}{Prefix}_Extension`, element `{Target}.{Prefix}Extension`; `model-name` → class `{Target}_{ModelName}_Extension`. Pass the BASE name to `create_d365fo_file`.
+8. Extension naming depends on `EXTENSION_NAMING_STYLE` (check `get_workspace_info`). Default `prefix` → class `{Target}{Prefix}_Extension`, element `{Target}.{Prefix}Extension`; `model-name` → class `{Target}_{ModelName}_Extension`, element `{Target}.{ModelName}`. Pass the BASE name to `create_d365fo_file` and let the tool apply the token — don't hand-build the infix.
 
 ## Terminal Note
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# D365 Finance & Operations X++ Development
+
+<!-- Copy this file to your D365FO solution parent folder alongside .mcp.json.
+     Claude Code reads CLAUDE.md automatically from the working directory upward.
+
+     Full rules are delivered via the MCP `xpp_system_instructions` prompt.
+     This file provides only the minimum static context needed when the MCP server
+     is not yet connected or the prompt hasn't been loaded. -->
+
+## MCP Tool Priority
+
+For D365FO and X++ work, **always use `d365fo-mcp-tools`** — never semantic code intelligence tools or built-in file/search tools.
+
+| File / task | Required tool |
+|-------------|--------------|
+| .xpp, .xml, .rnrproj, .label.txt | `d365fo-mcp-tools` only |
+| X++ symbol lookup (class/table/method/enum/EDT) | `d365fo-mcp-tools` only (`search`, `get_class_info`, `get_table_info`, …) |
+| .cs, .json, .yml, .md, .config | Built-in tools OK |
+| General codebase search (non-D365FO) | Other connected tools OK |
+
+> Semantic code intelligence tools (codebase indexers, symbol search servers, etc.) index general source code — they do **not** index D365FO metadata. Using them for X++ symbol lookup returns wrong or empty results.
+
+## Mandatory First Check
+
+Call `get_workspace_info()` before doing anything with D365FO objects.
+
+| Response | Action |
+|----------|--------|
+| Call fails | STOP. MCP server not connected. Ask user to start it. |
+| `⛔ CONFIGURATION PROBLEM` | STOP. Relay message. Wait for user. |
+| `✅ Configuration looks valid` | Note model name. Proceed. |
+
+## Core Tool Mapping
+
+| Action | Tool |
+|--------|------|
+| Create D365FO object | `create_d365fo_file` (never built-in file tools) |
+| Edit existing object | Describe change + confirm in chat, then `modify_d365fo_file` (applies immediately) |
+| Search objects | `search()` / `batch_search()` |
+| Read class/table/form | `get_class_info` / `get_table_info` / `get_form_info` |
+| Method signature (for CoC) | `get_method_signature` |
+| Build/BP/Sync | `build_d365fo_project` / `run_bp_check` / `trigger_db_sync` |
+| Error diagnosis | `get_d365fo_error_help(errorText)` |
+
+## Key Rules (condensed)
+
+1. Model name comes from `.mcp.json` — never infer from search results
+2. `modify_d365fo_file`/`create_d365fo_file` APPLY IMMEDIATELY (no dry-run) — describe the change and confirm in chat first; revert with `undo_last_modification` (or pass `createBackup=true`)
+3. Never run `build_d365fo_project()` automatically — only on explicit user request
+4. Never copy default parameter values into CoC wrapper signatures
+5. Never use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
+6. Never use hardcoded strings in Info/warning/error — use `@Model:Label`
+7. Call `search_labels()` before `create_label()` — reuse existing labels
+8. Extension naming depends on `EXTENSION_NAMING_STYLE` (check `get_workspace_info`). Default `prefix` → class `{Target}{Prefix}_Extension`, element `{Target}.{Prefix}Extension`; `model-name` → class `{Target}_{ModelName}_Extension`. Pass the BASE name to `create_d365fo_file`.
+
+## Terminal Note
+
+Terminal commands work normally in Claude Code CLI. They will hang only when an AI is connected via VS 2022's MCP integration (which Claude Code CLI is not).
+
+## Full Instructions
+
+Complete X++ rules, query grammar, CoC authoring rules, and workflow details are delivered via the MCP prompt `xpp_system_instructions`. If that prompt is not loaded, request it or consult `src/prompts/systemInstructions.ts` directly.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Claude Code uses a different config format from Copilot — `"mcpServers"` key, 
 claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https://your-server.azurewebsites.net/mcp/","alwaysLoad":true}'
 
 # Local stdio
-claude mcp add-json --scope user d365fo-mcp-tools '{"type":"stdio","command":"node","args":["K:\\d365fo-mcp-server\\dist\\index.js"],"env":{"DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata.db","LABELS_DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db","D365FO_WORKSPACE_PATH":"K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"},"alwaysLoad":true}'
+claude mcp add-json --scope user d365fo-mcp-tools '{"type":"stdio","command":"node","args":["K:\\d365fo-mcp-server\\dist\\index.js"],"env":{"DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata.db","LABELS_DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db","D365FO_SOLUTIONS_PATH":"K:\\repos\\MySolution\\projects","D365FO_WORKSPACE_PATH":"K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"},"alwaysLoad":true}'
 ```
 
 > `alwaysLoad: true` loads the d365fo tool list at session start, preventing Claude from routing X++ lookups to other connected code intelligence tools or built-in search.

--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@
 
 ## Why this exists
 
-GitHub Copilot excels at C#, Python, and JavaScript — languages with rich public training data. X++ is different. Your D365FO codebase is private, highly customized, and deeply interconnected: thousands of CoC extensions layered over standard Microsoft code, ISV packages adding their own tables and classes, custom EDTs that drive field validation across dozens of forms. Copilot has never seen any of it.
+AI coding assistants excel at C#, Python, and JavaScript — languages with rich public training data. X++ is different. Your D365FO codebase is private, highly customized, and deeply interconnected: thousands of CoC extensions layered over standard Microsoft code, ISV packages adding their own tables and classes, custom EDTs that drive field validation across dozens of forms. No AI has seen any of it.
 
-The result is AI that confidently generates code that doesn't compile: wrong method signatures, missing parameters, fields that don't exist on the table, CoC chains broken because Copilot didn't know an extension already wrapped the method.
+The result is AI that confidently generates code that doesn't compile: wrong method signatures, missing parameters, fields that don't exist on the table, CoC chains broken because the AI didn't know an extension already wrapped the method.
 
-This MCP server solves that by pre-indexing your entire D365FO installation — hundreds of thousands of symbols across standard and custom models — and exposing it to Copilot as 54 specialized tools. Before generating any X++ code, Copilot can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
+This MCP server solves that by pre-indexing your entire D365FO installation — hundreds of thousands of symbols across standard and custom models — and exposing it as 54 specialized tools. Works with **GitHub Copilot** and **Claude Code CLI**. Before generating any X++ code, the AI can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
 
 ![Solution Architecture](docs/img/solution-architecture-diagram.png)
 
 | Without this server | With this server |
 |---------------------|-----------------|
-| Copilot guesses method signatures → compile errors | Exact signatures pulled from your actual codebase |
+| AI guesses method signatures → compile errors | Exact signatures pulled from your actual codebase |
 | "Does CustTable.validateWrite() have any CoC wrappers?" requires manual AOT search | `find_coc_extensions` answers in < 50 ms |
-| ISV and custom model extensions invisible to Copilot | All models fully indexed and searchable |
+| ISV and custom model extensions invisible to AI | All models fully indexed and searchable |
 | Security hierarchy takes hours to trace manually | `get_security_coverage_for_object` traces Role → Duty → Privilege → Entry Point instantly |
-| Copilot generates hardcoded strings instead of label references | `search_labels` finds the right `@SYS`/`@MODULE` label key immediately |
+| AI generates hardcoded strings instead of label references | `search_labels` finds the right `@SYS`/`@MODULE` label key immediately |
 | "Which tables reference CustTable?" requires digging through AOT relations | `get_table_relations` returns every FK relation and cardinality in one call |
 | EDT base types and field lengths are a constant lookup | `get_edt_details` returns the full EDT definition including extends chain |
-| Copilot doesn't know which SysOperation framework class to extend | `search_classes` with a description filter surfaces the right base class |
+| AI doesn't know which SysOperation framework class to extend | `search_classes` with a description filter surfaces the right base class |
 | New CoC extension may silently duplicate an existing one | `find_coc_extensions` reveals all existing wrappers before you write a line |
 | Menu item to form mapping requires navigating the AOT manually | `get_menu_item_details` resolves the full path from menu item to form to data source |
 
@@ -117,6 +117,34 @@ Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
 
 ---
 
+## Connect to Claude Code CLI
+
+Claude Code uses a different config format from Copilot — `"mcpServers"` key, explicit `"type"` field, and `"alwaysLoad": true` to prevent tool deferral.
+
+**1.** Install Claude Code CLI: `npm install -g @anthropic-ai/claude-code`
+
+**2.** Register the server (writes to `~/.claude.json`):
+
+```powershell
+# Azure-hosted
+claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https://your-server.azurewebsites.net/mcp/","alwaysLoad":true}'
+
+# Local stdio
+claude mcp add-json --scope user d365fo-mcp-tools '{"type":"stdio","command":"node","args":["K:\\d365fo-mcp-server\\dist\\index.js"],"env":{"DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata.db","LABELS_DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db","D365FO_WORKSPACE_PATH":"K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"},"alwaysLoad":true}'
+```
+
+> `alwaysLoad: true` loads the d365fo tool list at session start, preventing Claude from routing X++ lookups to other connected code intelligence tools or built-in search.
+
+**3.** Copy `CLAUDE.md` to the parent folder of your D365FO solutions:
+
+```powershell
+Copy-Item -Path "K:\d365fo-mcp-server\CLAUDE.md" -Destination "C:\source\repos\"
+```
+
+> **Full Claude Code setup guide (all scenarios, project-scoped `.mcp.json`, troubleshooting):** [docs/CLAUDE_CODE_SETUP.md](docs/CLAUDE_CODE_SETUP.md)
+
+---
+
 ## Azure Deployment
 
 Host on Azure App Service so the whole team shares one instance — nobody needs the server running locally.
@@ -155,3 +183,4 @@ Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.m
 | [docs/PIPELINES.md](docs/PIPELINES.md) | Automated metadata extraction and deployment via Azure DevOps |
 | [docs/TESTING.md](docs/TESTING.md) | Running tests, test structure, mock guidelines, coverage |
 | [docs/SQLITE_DEPENDENCY.md](docs/SQLITE_DEPENDENCY.md) | SQLite vs C# Bridge — which tools use which data source |
+| [docs/CLAUDE_CODE_SETUP.md](docs/CLAUDE_CODE_SETUP.md) | Connecting Claude Code CLI — `.mcp.json` + `CLAUDE.md` setup |

--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -1,0 +1,175 @@
+# Claude Code CLI Setup
+
+Connect the D365 F&O MCP Server to Claude Code CLI in 4 steps.
+
+> **Already deployed by your team on Azure?** Skip to [Step 2](#step-2--register-the-mcp-server).
+
+---
+
+## Step 1 — Build the server
+
+Same prerequisites and build steps as the Copilot guide — no VS 2022 required.
+
+| Requirement | Where to get it |
+|------------|----------------|
+| Node.js 24.x LTS | [nodejs.org](https://nodejs.org) |
+| Claude Code CLI | `npm install -g @anthropic-ai/claude-code` |
+| Python 3.x | Needed by `node-gyp` for native SQLite |
+| .NET Framework 4.8 Developer Pack | Required for the C# bridge (file create/modify on D365FO VMs) |
+
+```powershell
+git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
+cd K:\d365fo-mcp-server
+npm install
+
+# Build the C# bridge (required for file create/modify on Windows VMs)
+cd bridge\D365MetadataBridge
+dotnet build -c Release
+cd ..\..
+
+copy .env.example .env
+# Edit .env — set PACKAGES_PATH, CUSTOM_MODELS, LABEL_LANGUAGES
+
+npm run extract-metadata
+npm run build-database
+npm run build
+```
+
+> **Already on Azure?** Skip `extract-metadata` and `build-database` — the index lives in Azure. You only need `npm install` + bridge build + `npm run build`.
+
+---
+
+## Step 2 — Register the MCP server
+
+Claude Code stores MCP server config in `~/.claude.json` (not in `.mcp.json` like Copilot). Use `claude mcp add-json` to register the server. The `alwaysLoad` flag is critical — without it, Claude Code defers d365fo tools and may route X++ lookups to other connected code intelligence tools or built-in search instead.
+
+### Scenario A: Azure-hosted server (most teams)
+
+```powershell
+claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https://your-server.azurewebsites.net/mcp/","alwaysLoad":true}'
+```
+
+### Scenario D: Local stdio (single developer)
+
+```powershell
+claude mcp add-json --scope user d365fo-mcp-tools '{"type":"stdio","command":"node","args":["K:\\d365fo-mcp-server\\dist\\index.js"],"env":{"DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata.db","LABELS_DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db","D365FO_SOLUTIONS_PATH":"K:\\repos\\MySolution\\projects","D365FO_WORKSPACE_PATH":"K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"},"alwaysLoad":true}'
+```
+
+> In PowerShell single-quoted strings, `"` does **not** need escaping. Double backslashes `\\` are still required — that is JSON path escaping, not shell escaping.
+
+### Scenario B: Hybrid — Azure search + local writes
+
+Run both commands:
+
+```powershell
+claude mcp add-json --scope user d365fo-azure '{"type":"http","url":"https://your-server.azurewebsites.net/mcp/","alwaysLoad":true}'
+
+claude mcp add-json --scope user d365fo-local '{"type":"stdio","command":"node","args":["K:\\d365fo-mcp-server\\dist\\index.js"],"env":{"MCP_SERVER_MODE":"write-only","D365FO_SOLUTIONS_PATH":"K:\\repos\\MySolution\\projects","D365FO_WORKSPACE_PATH":"K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"},"alwaysLoad":true}'
+```
+
+### Alternative: project-scoped `.mcp.json`
+
+To share the config with your team via version control, create `.mcp.json` in your D365FO solution root. Claude Code uses the **`"mcpServers"`** key (not `"servers"` like GitHub Copilot):
+
+```json
+{
+  "mcpServers": {
+    "d365fo-mcp-tools": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["K:\\d365fo-mcp-server\\dist\\index.js"],
+      "env": {
+        "DB_PATH": "K:\\d365fo-mcp-server\\data\\xpp-metadata.db",
+        "LABELS_DB_PATH": "K:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db",
+        "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects",
+        "D365FO_WORKSPACE_PATH": "K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"
+      },
+      "alwaysLoad": true
+    }
+  }
+}
+```
+
+For HTTP (Azure) in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "d365fo-mcp-tools": {
+      "type": "http",
+      "url": "https://your-server.azurewebsites.net/mcp/",
+      "alwaysLoad": true
+    }
+  }
+}
+```
+
+> Claude Code prompts for approval before using project-scoped servers. Accept once; Claude Code remembers.
+
+### Why `alwaysLoad: true`?
+
+Claude Code's Tool Search feature defers MCP tool schemas to save context. When tools are deferred, Claude picks whichever tool it finds first during a search step — which may be another connected code intelligence tool or a built-in search tool instead of `d365fo-mcp-tools`. Setting `alwaysLoad: true` loads the d365fo tool list into context at session start, guaranteeing Claude sees them before making any tool choice. Without it, Claude may route D365FO metadata queries to other connected code intelligence tools and get wrong or empty results. Combined with `CLAUDE.md` (Step 3), this eliminates the wrong-tool problem entirely.
+
+---
+
+## Step 3 — Place `CLAUDE.md`
+
+Copy `CLAUDE.md` from the repo root to the parent folder of your D365FO solutions. Claude Code reads it automatically from the working directory upward, so one copy covers all solutions underneath.
+
+```powershell
+# Example: place in the parent of all your D365FO solution folders
+Copy-Item -Path "K:\d365fo-mcp-server\CLAUDE.md" -Destination "C:\source\repos\"
+```
+
+`CLAUDE.md` reinforces the tool priority in plain language — telling Claude to use `d365fo-mcp-tools` for all X++ work regardless of what other tools are connected. `alwaysLoad` handles it technically; `CLAUDE.md` handles it instructionally.
+
+---
+
+## Step 4 — Verify
+
+Run in any terminal:
+
+```powershell
+claude mcp list
+```
+
+You should see `d365fo-mcp-tools` listed as connected. Then start a Claude Code session from your D365FO solution folder and ask:
+
+```
+What tables contain the "CustAccount" field?
+```
+
+Claude should call the `search` tool from `d365fo-mcp-tools`. If it routes to another tool instead, check:
+1. `CLAUDE.md` is present in the working directory or a parent
+2. `alwaysLoad: true` is set in the server config (`claude mcp get d365fo-mcp-tools` to inspect)
+
+For file operations, try:
+
+```
+Create a new class called TestHelper with a static method hello() that returns "Hello"
+```
+
+If a file appears on disk, the C# bridge is working.
+
+---
+
+## Claude Code vs GitHub Copilot
+
+| Feature | GitHub Copilot (VS 2022) | Claude Code CLI |
+|---------|--------------------------|-----------------|
+| Instruction file | `.github\copilot-instructions.md` | `CLAUDE.md` |
+| Agent mode toggle | Required (VS 2022 Agent Mode) | Always agentic — no toggle needed |
+| Terminal commands | Hang in VS 2022 MCP context | Work normally |
+| Config file location | `%USERPROFILE%\.mcp.json` or next to `.sln` | `~/.claude.json` (via `claude mcp add`) or `.mcp.json` in project root |
+| Config root key | `"servers"` | `"mcpServers"` |
+| Server type field | Not required | Explicit `"type"` recommended |
+| Always-load tools | Not available | `"alwaysLoad": true` — prevents tool deferral |
+
+---
+
+## See Also
+
+- [QUICK_START.md](QUICK_START.md) — Full Copilot scenario guide (Scenarios A–F); env var reference applies to Claude Code too
+- [MCP_CONFIG.md](MCP_CONFIG.md) — Complete env var reference for D365FO workspace paths
+- [MCP_TOOLS.md](MCP_TOOLS.md) — All 54 tools with parameters and example prompts
+- [BRIDGE.md](BRIDGE.md) — C# Metadata Bridge (required for file create/modify on Windows VMs)

--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -49,7 +49,7 @@ Claude Code stores MCP server config in `~/.claude.json` (not in `.mcp.json` lik
 claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https://your-server.azurewebsites.net/mcp/","alwaysLoad":true}'
 ```
 
-### Scenario D: Local stdio (single developer)
+### Scenario B: Local stdio (single developer)
 
 ```powershell
 claude mcp add-json --scope user d365fo-mcp-tools '{"type":"stdio","command":"node","args":["K:\\d365fo-mcp-server\\dist\\index.js"],"env":{"DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata.db","LABELS_DB_PATH":"K:\\d365fo-mcp-server\\data\\xpp-metadata-labels.db","D365FO_SOLUTIONS_PATH":"K:\\repos\\MySolution\\projects","D365FO_WORKSPACE_PATH":"K:\\AosService\\PackagesLocalDirectory\\YourPackageName\\YourModelName"},"alwaysLoad":true}'
@@ -57,7 +57,7 @@ claude mcp add-json --scope user d365fo-mcp-tools '{"type":"stdio","command":"no
 
 > In PowerShell single-quoted strings, `"` does **not** need escaping. Double backslashes `\\` are still required — that is JSON path escaping, not shell escaping.
 
-### Scenario B: Hybrid — Azure search + local writes
+### Scenario C: Hybrid — Azure search + local writes
 
 Run both commands:
 
@@ -157,10 +157,10 @@ If a file appears on disk, the C# bridge is working.
 
 | Feature | GitHub Copilot (VS 2022) | Claude Code CLI |
 |---------|--------------------------|-----------------|
-| Instruction file | `.github\copilot-instructions.md` | `CLAUDE.md` |
+| Instruction file | `.github\copilot-instructions.md` (in solutions parent folder — one copy covers all solutions) | `CLAUDE.md` (same location — solutions parent folder) |
 | Agent mode toggle | Required (VS 2022 Agent Mode) | Always agentic — no toggle needed |
 | Terminal commands | Hang in VS 2022 MCP context | Work normally |
-| Config file location | `%USERPROFILE%\.mcp.json` or next to `.sln` | `~/.claude.json` (via `claude mcp add`) or `.mcp.json` in project root |
+| Config file location | `%USERPROFILE%\.mcp.json` (user-scoped, covers all projects) | `~/.claude.json` (via `claude mcp add`) or `.mcp.json` in project root |
 | Config root key | `"servers"` | `"mcpServers"` |
 | Server type field | Not required | Explicit `"type"` recommended |
 | Always-load tools | Not available | `"alwaysLoad": true` — prevents tool deferral |

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -53,6 +53,8 @@ npm run build
 
 ---
 
+> **Using Claude Code CLI instead of GitHub Copilot?** See [CLAUDE_CODE_SETUP.md](CLAUDE_CODE_SETUP.md) — different config format (`"mcpServers"` key, `alwaysLoad: true`) and `CLAUDE.md` placement.
+
 ## Step 3 — Connect Copilot
 
 ### 3a. Enable MCP in GitHub and Visual Studio
@@ -383,3 +385,4 @@ After starting, check the server log for:
 | Architecture overview | [ARCHITECTURE.md](ARCHITECTURE.md) |
 | ISV / custom model configuration | [CUSTOM_EXTENSIONS.md](CUSTOM_EXTENSIONS.md) |
 | Azure DevOps pipelines | [PIPELINES.md](PIPELINES.md) |
+| **Claude Code CLI setup** | [CLAUDE_CODE_SETUP.md](CLAUDE_CODE_SETUP.md) |

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -1,11 +1,11 @@
 ﻿/**
  * System Instructions Prompt for X++ Development
- * Optimized for GitHub Copilot in Visual Studio 2022 / 2026
+ * Optimized for MCP-capable AI clients (GitHub Copilot, Claude Code) in Visual Studio 2022 / 2026
  * Based on Microsoft's official guidelines for custom instructions
  *
  * NOTE: This file is the MCP prompt source of truth for AI system instructions.
- * The static GitHub Copilot instruction layer (.github/copilot-instructions.md)
- * mirrors these rules. If you update rules here, sync them there too.
+ * The static instruction layers (.github/copilot-instructions.md, CLAUDE.md)
+ * mirror these rules. If you update rules here, sync them there too.
  */
 
 /**
@@ -14,7 +14,7 @@
 export function getSystemInstructionsPromptDefinition() {
   return {
     name: 'xpp_system_instructions',
-    description: 'System instructions for GitHub Copilot when working with D365 Finance & Operations X++ development',
+    description: 'System instructions for AI assistants (GitHub Copilot, Claude Code) when working with D365 Finance & Operations X++ development',
     arguments: [],
   };
 }
@@ -31,7 +31,7 @@ export function handleSystemInstructionsPrompt() {
           type: 'text',
           text: `# X++ Development System Instructions
 
-You are GitHub Copilot assisting with Dynamics 365 Finance & Operations (D365FO) X++ development in Visual Studio 2022 / 2026.
+You are an AI assistant with access to D365FO MCP tools, assisting with Dynamics 365 Finance & Operations (D365FO) X++ development in Visual Studio 2022 / 2026.
 
 ## Core Principle
 


### PR DESCRIPTION
## Summary

  - Add `CLAUDE.md` — Claude Code's equivalent of `.github/copilot-instructions.md`. Includes an MCP tool priority table
  that explicitly routes all X++ and D365FO object lookups to `d365fo-mcp-tools`, overriding any other semantic code
  intelligence tool the developer may have connected (e.g. codebase indexers, symbol search servers).
  - Add `docs/CLAUDE_CODE_SETUP.md` — full setup guide covering MCP registration via `claude mcp add-json`, the correct
  `"mcpServers"` key format (differs from Copilot's `"servers"`), explicit `"type"` field, and `"alwaysLoad": true`
  which prevents Claude's Tool Search from deferring d365fo tools at session start.
  - Update `README.md` — client-agnostic language in "Why this exists", new "Connect to Claude Code CLI" section with
  correct config snippets.
  - Update `docs/QUICK_START.md` — pointer to Claude Code setup right before the Copilot-specific Step 3.
  - Update `src/prompts/systemInstructions.ts` — remove "You are GitHub Copilot" from the MCP prompt; make it
  client-agnostic.

  ## Why

  The server works with Claude Code CLI, but without `CLAUDE.md` and `alwaysLoad: true`, Claude has no guidance on which
  tool to use for X++ lookups. Developers commonly have other semantic code intelligence MCP servers connected
  (codebase indexers, symbol search, etc.) — without explicit priority rules, Claude may route D365FO metadata queries
  to those tools instead, returning wrong or empty results. This PR adds the missing wiring for Claude Code users
  without changing any Copilot behaviour.

  ## Test plan

  - [X] `claude mcp list` shows `d365fo-mcp-tools`
  - [X] Ask "What tables contain CustAccount?" → `search` tool fires from `d365fo-mcp-tools`
  - [X] Request MCP prompt `xpp_system_instructions` → no longer says "GitHub Copilot"
  - [X] Existing Copilot setup unaffected — all Copilot docs and `.github/copilot-instructions.md` unchanged