### PR TITLE
fix(search-labels): route underscore/special-char queries to LIKE fal…

### DIFF
--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -2668,9 +2668,17 @@ export class XppSymbolIndex {
       return this.searchLabelsLike(query, opts);
     }
 
-    // Sanitize query for FTS5 (escape special chars)
+    // Sanitize query for FTS5 (strip chars that would cause a syntax error)
     const ftsQuery = query.replace(/['"*()]/g, ' ').trim();
-    if (!ftsQuery) return [];
+    // Route to LIKE when FTS5 would silently return 0 results:
+    // • '_' and '%' — word separators in the unicode61 tokenizer (also LIKE wildcards);
+    //   literal underscore/percent searches must go through LIKE with proper escaping.
+    // • Any query whose alphanumeric content disappears after sanitization (e.g. '-',
+    //   '.', '@', ':', '@SYS:') produces zero FTS5 tokens and no exception to trigger
+    //   the catch-based fallback below.
+    if (/[_%]/.test(query) || !/[a-zA-Z0-9]/.test(ftsQuery)) {
+      return this.searchLabelsLike(query, opts);
+    }
 
     // Cache statement keyed by which optional filters are active (4 variants)
     const stmtKey = `searchLabels_${model ? 'model' : 'nomodel'}_${labelFileId ? 'lfid' : 'nolfid'}`;
@@ -2710,7 +2718,10 @@ export class XppSymbolIndex {
     opts: { language?: string; model?: string; labelFileId?: string; limit?: number } = {},
   ): any[] {
     const { language = 'en-US', model, labelFileId, limit = 30 } = opts;
-    const pattern = `%${query}%`;
+    // Escape LIKE special characters so the query is treated as a literal substring.
+    // '\' is the escape character declared in the SQL ESCAPE clause below.
+    const escaped = query.replace(/[\\%_]/g, '\\$&');
+    const pattern = `%${escaped}%`;
 
     const stmtKey = `searchLabelsLike_${model ? 'model' : 'nomodel'}_${labelFileId ? 'lfid' : 'nolfid'}`;
     let stmt = this.labelsStmtCache.get(stmtKey);
@@ -2718,7 +2729,7 @@ export class XppSymbolIndex {
       let sql = `
         SELECT label_id, label_file_id, model, language, text, comment, file_path, 0 as rank
         FROM labels
-        WHERE (text LIKE ? OR label_id LIKE ?)
+        WHERE (text LIKE ? ESCAPE '\\' OR label_id LIKE ? ESCAPE '\\')
           AND LOWER(language) = LOWER(?)`;
       if (model)       sql += `\n          AND model = ?`;
       if (labelFileId) sql += `\n          AND label_file_id = ?`;

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -26,8 +26,12 @@ vi.mock('fs/promises', () => ({
   }),
   writeFile: vi.fn(async () => {}),
   mkdir: vi.fn(async () => {}),
-  access: vi.fn(async () => {}),
-  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  // Drive/root paths exist; individual files do not (prevents false "file already exists" errors).
+  access: vi.fn(async (p: string) => {
+    if (/^[A-Za-z]:[\\\/]?$/.test(p) || p === '/') return; // drive root or fs root
+    throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+  }),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false, size: 1024 })),
   readdir: vi.fn(async () => []),
 }));
 
@@ -403,6 +407,25 @@ describe('verify_d365fo_project', () => {
 // ─── create_d365fo_file ──────────────────────────────────────────────────────
 
 describe('create_d365fo_file', () => {
+  beforeEach(async () => {
+    // Reset access mock: verify_d365fo_project tests override it; restore the
+    // default that makes drive roots accessible but individual files absent.
+    const fsMod = await import('fs/promises');
+    (fsMod.access as any).mockImplementation(async (p: string) => {
+      if (/^[A-Za-z]:[\\\/]?$/.test(p) || p === '/') return;
+      throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+    });
+    (fsMod.readFile as any).mockImplementation(async (p: string) => {
+      if (p.endsWith('.rnrproj')) {
+        return `<Project><ItemGroup><Content Include="AxClass\\ExistingClass.xml" /></ItemGroup></Project>`;
+      }
+      if (p.endsWith('.xml')) {
+        return `<?xml version="1.0"?><AxClass><Name>ExistingClass</Name></AxClass>`;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+  });
+
   it('creates a class file and reports success', async () => {
     const result = await handleCreateD365File(
       req('create_d365fo_file', {
@@ -437,7 +460,7 @@ describe('create_d365fo_file', () => {
       }),
     );
     // Non-Windows: creation fails (needs Windows) and is correctly reported as isError.
-    expect((result as any).isError).toBe(process.platform !== 'win32');
+    expect(!!(result as any).isError).toBe(process.platform !== 'win32');
   });
 
   it('auto-converts bare extension name to dot-notation (Case C fix)', async () => {
@@ -539,7 +562,7 @@ describe('create_d365fo_file', () => {
       }),
     );
     // Non-Windows: creation fails (needs Windows) and is correctly reported as isError.
-    expect((result as any).isError).toBe(process.platform !== 'win32');
+    expect(!!(result as any).isError).toBe(process.platform !== 'win32');
   });
 
   it('returns error when objectType is missing', async () => {


### PR DESCRIPTION
…lback

FTS5 unicode61 tokenizer treats '_' and other non-alphanumeric chars as word separators, so they are never stored as tokens. Queries containing only such characters produced 0 results silently (no exception fired, so the catch-based LIKE fallback was never triggered).

Two fixes in searchLabels():
1. Pre-check: if query contains '_' or '%' (LIKE wildcards), or if the sanitized ftsQuery contains no alphanumeric chars (e.g. '-', '.', '@', ':'), route directly to searchLabelsLike() before touching FTS5.
2. In searchLabelsLike(): escape '\\', '%' and '_' in the query before building the LIKE pattern, and declare ESCAPE '\\' in SQL so they are matched literally instead of as wildcards.