### PR TITLE
fix: parse .label.txt paths cross-platform in update_symbol_index

### DIFF
--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -73,7 +73,8 @@ function normalizeLocale(locale: string): string {
 }
 
 function parseLabelFileName(filePath: string): { labelFileId: string; language: string } | null {
-  const baseName = path.basename(filePath);
+  const parts = filePath.split(/[\\/]/);
+  const baseName = parts[parts.length - 1] ?? '';
   const withoutSuffix = baseName.replace(/\.label\.txt$/i, '');
   const dotIdx = withoutSuffix.lastIndexOf('.');
   if (dotIdx < 0) return null;
@@ -92,7 +93,9 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
   const { filePath } = params;
   try {
     const { symbolIndex, cache } = context;
-    const objectName = path.parse(filePath).name;
+    const pathParts = filePath.split(/[\\/]/);
+    const fileName = pathParts[pathParts.length - 1] ?? filePath;
+    const objectName = fileName.replace(/\.[^.]+$/, '');
     const parts = filePath.replace(/\//g, '\\').split('\\');
     const aotFolder = parts.find((p: string) => p.toLowerCase() in AOT_FOLDER_TYPE_MAP) ?? '';
     const objectType: XppSymbol['type'] = AOT_FOLDER_TYPE_MAP[aotFolder.toLowerCase()] ?? 'class';


### PR DESCRIPTION
This pull request improves the way file paths are handled when parsing label file names and extracting object names in `src/tools/updateSymbolIndex.ts`. The main focus is to make the code more robust and platform-independent by consistently splitting paths using both forward and backward slashes.

**Path handling improvements:**

* Updated the `parseLabelFileName` function to split `filePath` using both forward and backward slashes, ensuring that the base file name is correctly extracted regardless of the operating system.
* Modified the logic for extracting `objectName` in `updateSymbolIndexTool` to use the file name portion of the path (split by both slashes) and strip the file extension, making the process more reliable across different platforms.