### PR TITLE
feat(create_label): add `languages` param to scope label file writes

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -767,12 +767,17 @@ Show me the X++ snippet for label BatchGroup
 
 ### create_label
 
-Adds a new label to every language `.label.txt` file in a model. Inserts the entry
-alphabetically (as required by the D365FO label file format), creates the AxLabelFile XML
-descriptors if the model doesn't have any yet, and updates the MCP index so the new label
-is immediately searchable.
+Adds a new label to every language `.label.txt` file in a model (or only the locales given in
+`languages`). Inserts the entry alphabetically (as required by the D365FO label file format),
+creates the AxLabelFile XML descriptors if the model doesn't have any yet, and updates the MCP
+index so the new label is immediately searchable.
 
 > **Always call `search_labels` first** to verify the label doesn't already exist.
+
+> **Note — `LabelResources/` is shared across the whole model.** By default the label is written
+> to *every* locale folder present in the model, even folders that exist only because a sibling
+> label file (e.g. a multi-language report) ships them. For a customization that needs just one
+> language, pass `languages: ["en-US"]` to avoid creating empty placeholder files for the others.
 
 **Parameters:**
 - `labelId` — new label ID, e.g. `MyNewField` (required)
@@ -780,6 +785,8 @@ is immediately searchable.
 - `model` — model name, e.g. `MyModel` (required)
 - `translations` — array of `{ language, text }` objects (required); provide all supported
   languages
+- `languages` — restrict which locale `.label.txt` files are written/created, e.g. `["en-US"]`.
+  When omitted/empty, writes to every language folder already present in the model (default)
 - `defaultComment` — developer comment added to each translation
 - `packageName` — package name for label file location; auto-resolved from model if omitted
 - `packagePath` — override base path (default: auto-detected from environment)

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -141,7 +141,7 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 |------|-------------|---------------|
 | **search_labels** | Full-text search across all AxLabelFile labels | "Find a label for 'customer account'" |
 | **get_label_info** | All translations for a label ID, or list label files | "Show all translations of MyFeature in MyModel" |
-| **create_label** | Add a new label to all language files in a model | "Create label MyNewField in MyModel" |
+| **create_label** | Add a new label to all language files in a model (or only the locales listed in `languages`) | "Create label MyNewField in MyModel" |
 | **rename_label** | Rename a label ID in .label.txt, X++ source and XML metadata | "Rename label OldName to NewName in MyModel" |
 
 ---

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -385,13 +385,22 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
     if (requestedLanguages.length > 0) {
       // Explicit scope: write ONLY to the requested locales, creating folders as needed.
       // Prevents the label from leaking into locales owned by sibling label files.
-      const discoveredSet = new Set(discoveredLanguages.map(l => l.toLowerCase()));
+      //
+      // Use a case-insensitive map from lowercase → actual on-disk name so that
+      // callers passing BCP-47 standard casing (en-US) match Linux-unzipped
+      // directories stored in lowercase (en-us). Without this, the write path
+      // would build LabelResources/en-US/... next to an existing en-us/ folder,
+      // creating a duplicate locale tree on case-sensitive filesystems.
+      const discoveredMap = new Map(discoveredLanguages.map(l => [l.toLowerCase(), l]));
       for (const lang of requestedLanguages) {
-        if (!discoveredSet.has(lang.toLowerCase())) {
+        if (!discoveredMap.has(lang.toLowerCase())) {
           await createLangDirectory(lang);
+          discoveredMap.set(lang.toLowerCase(), lang);
         }
       }
-      existingLanguages = [...requestedLanguages];
+      // Resolve each requested locale to its actual on-disk name; fall back to the
+      // caller-provided value for newly-created folders (not yet on disk).
+      existingLanguages = requestedLanguages.map(l => discoveredMap.get(l.toLowerCase()) ?? l);
     } else if (labelFileMissing) {
       // No explicit scope and nothing exists yet — seed the folders from the translations.
       existingLanguages = [];

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -62,6 +62,18 @@ const CreateLabelArgsSchema = z.object({
       'Label text for each language. At minimum provide en-US. ' +
         'For languages without a translation the en-US text is used as fallback.',
     ),
+  languages: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Restrict which language .label.txt files are written/created. ' +
+        'When provided, the label is created ONLY for these locales (e.g. ["en-US"] for an ' +
+        'English-only customization), creating the folders if needed. This avoids leaking the ' +
+        'label into locales that exist only because OTHER label files in the same model ship ' +
+        'them (LabelResources is shared across the whole model). ' +
+        'When omitted or empty, the label is written to every language folder already present ' +
+        'in the model (default behavior).',
+    ),
   description: z
     .string()
     .optional()
@@ -318,10 +330,16 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
     }
     const enUsText = translationMap.get('en-US')?.text ?? translations[0].text;
 
-    // 2. Discover existing language folders
-    let existingLanguages: string[] = [];
+    // 2. Discover the language folders that already exist in the model.
+    //    NOTE: LabelResources/ is shared by EVERY label file in the model, so this lists
+    //    locales owned by sibling label files too. The `languages` arg scopes the writes.
+    const requestedLanguages = (args.languages ?? [])
+      .map(l => l.trim())
+      .filter(Boolean);
+
+    let discoveredLanguages: string[] = [];
     try {
-      existingLanguages = await fs.readdir(labelResourcesDir);
+      discoveredLanguages = await fs.readdir(labelResourcesDir);
     } catch {
       // LabelResources dir does not exist yet
     }
@@ -342,33 +360,49 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       }
     };
 
-    // 3. If no existing languages, decide whether to create
-    if (existingLanguages.length === 0) {
-      if (!createLabelFileIfMissing) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text:
-                `AxLabelFile "${labelFileId}" not found in model "${model}" ` +
-                `(expected path: ${labelResourcesDir}).\n\n` +
-                `Set createLabelFileIfMissing=true to create the label file from scratch, ` +
-                `or use create_d365fo_file to scaffold the label file first.`,
-            },
-          ],
-          isError: true,
-        };
-      }
+    // 3. Determine the target language set and create any missing folders.
+    //    A brand-new label file (no locales at all anywhere in the model) is still guarded
+    //    by createLabelFileIfMissing regardless of which mode we're in.
+    const labelFileMissing = discoveredLanguages.length === 0;
+    if (labelFileMissing && !createLabelFileIfMissing) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `AxLabelFile "${labelFileId}" not found in model "${model}" ` +
+              `(expected path: ${labelResourcesDir}).\n\n` +
+              `Set createLabelFileIfMissing=true to create the label file from scratch, ` +
+              `or use create_d365fo_file to scaffold the label file first.`,
+          },
+        ],
+        isError: true,
+      };
+    }
 
-      // Create the LabelResources directory structure
+    let existingLanguages: string[];
+
+    if (requestedLanguages.length > 0) {
+      // Explicit scope: write ONLY to the requested locales, creating folders as needed.
+      // Prevents the label from leaking into locales owned by sibling label files.
+      const discoveredSet = new Set(discoveredLanguages.map(l => l.toLowerCase()));
+      for (const lang of requestedLanguages) {
+        if (!discoveredSet.has(lang.toLowerCase())) {
+          await createLangDirectory(lang);
+        }
+      }
+      existingLanguages = [...requestedLanguages];
+    } else if (labelFileMissing) {
+      // No explicit scope and nothing exists yet — seed the folders from the translations.
+      existingLanguages = [];
       for (const [lang] of translationMap) {
         await createLangDirectory(lang);
         existingLanguages.push(lang);
       }
     } else {
-      // Label file already has some languages.
-      // Always create directories for languages in translationMap that don't exist yet.
-      // createLabelFileIfMissing only guards the "no languages at all" case above.
+      // No explicit scope — default behavior: write to every language folder that already
+      // exists in the model, plus any new languages supplied via translations.
+      existingLanguages = [...discoveredLanguages];
       const existingSet = new Set(existingLanguages.map(l => l.toLowerCase()));
       for (const [lang] of translationMap) {
         if (!existingSet.has(lang.toLowerCase())) {
@@ -564,7 +598,8 @@ export const createLabelToolDefinition = {
   name: 'create_label',
   description:
     'Add a new label to an existing AxLabelFile in a custom D365FO model. ' +
-    'Writes the label into every language .label.txt file that exists in the model, ' +
+    'Writes the label into every language .label.txt file that exists in the model ' +
+    '(or only the locales listed in `languages`), ' +
     'inserts in alphabetical order, and updates the MCP index. ' +
     'Always call search_labels first to check if a suitable label already exists.',
   inputSchema: {
@@ -594,6 +629,14 @@ export const createLabelToolDefinition = {
           },
           required: ['language', 'text'],
         },
+      },
+      languages: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Restrict which language .label.txt files are written/created (e.g. ["en-US"] for an ' +
+          'English-only customization). When omitted or empty, the label is written to every ' +
+          'language folder already present in the model (default).',
       },
       defaultComment: {
         type: 'string',

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -3,7 +3,7 @@
  * Covers: search_labels, get_label_info, create_label, rename_label
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { searchLabelsTool } from '../../src/tools/searchLabels';
 import { getLabelInfoTool } from '../../src/tools/getLabelInfo';
 import { createLabelTool } from '../../src/tools/createLabel';
@@ -227,6 +227,18 @@ describe('create_label', () => {
   let ctx: XppServerContext;
 
   beforeEach(() => { ctx = buildContext(); });
+
+  // Tests below override the shared fs mocks (some with persistent mockResolvedValue).
+  // Restore them to the factory defaults after each test so state never leaks into the
+  // rename_label suite that follows.
+  afterEach(async () => {
+    const fsMock = await import('fs');
+    (fsMock.promises.readFile as any).mockImplementation(async () => '; Label file\nMyExistingLabel=Existing label text\n');
+    (fsMock.promises.writeFile as any).mockImplementation(async () => {});
+    (fsMock.promises.mkdir as any).mockImplementation(async () => {});
+    (fsMock.promises.access as any).mockImplementation(async () => {});
+    (fsMock.promises.readdir as any).mockImplementation(async () => []);
+  });
 
   it('creates label with multiple translations', async () => {
     // Simulate label not existing yet
@@ -454,6 +466,102 @@ describe('create_label', () => {
   it('returns error when required fields are missing', async () => {
     const result = await createLabelTool(req('create_label', { labelId: 'Foo' }), ctx);
     expect(result.isError).toBe(true);
+  });
+
+  it('writes to every existing model language when `languages` is omitted (default fan-out)', async () => {
+    const fsMock = await import('fs');
+    const writes: { path: string; content: string }[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (p: string, content: string) => {
+      writes.push({ path: p, content });
+    });
+    // LabelResources is shared across the model: lt / nb-NO exist only because sibling
+    // label files ship them, but the default behavior still writes to all of them.
+    (fsMock.promises.readdir as any).mockResolvedValue(['en-US', 'fi', 'lt', 'nb-NO']);
+    (fsMock.promises.readFile as any).mockResolvedValue('﻿');
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'NewFeatureLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        addToProject: false,
+        translations: [{ language: 'en-US', text: 'New feature' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(writes.some(w => w.path.endsWith('MyModel.en-US.label.txt'))).toBe(true);
+    expect(writes.some(w => w.path.endsWith('MyModel.fi.label.txt'))).toBe(true);
+    expect(writes.some(w => w.path.endsWith('MyModel.lt.label.txt'))).toBe(true);
+    expect(writes.some(w => w.path.endsWith('MyModel.nb-NO.label.txt'))).toBe(true);
+  });
+
+  it('writes ONLY the requested locales when `languages` is provided', async () => {
+    const fsMock = await import('fs');
+    const writes: { path: string; content: string }[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (p: string, content: string) => {
+      writes.push({ path: p, content });
+    });
+    // Model has 4 locale folders, but this customization only needs en-US.
+    (fsMock.promises.readdir as any).mockResolvedValue(['en-US', 'fi', 'lt', 'nb-NO']);
+    (fsMock.promises.readFile as any).mockResolvedValue('﻿');
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'NewFeatureLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        addToProject: false,
+        languages: ['en-US'],
+        translations: [{ language: 'en-US', text: 'New feature' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    // en-US written; fi / lt / nb-NO must NOT be touched (no stray placeholder files)
+    expect(writes.some(w => w.path.endsWith('MyModel.en-US.label.txt'))).toBe(true);
+    expect(writes.some(w => w.path.endsWith('MyModel.fi.label.txt'))).toBe(false);
+    expect(writes.some(w => w.path.endsWith('MyModel.lt.label.txt'))).toBe(false);
+    expect(writes.some(w => w.path.endsWith('MyModel.nb-NO.label.txt'))).toBe(false);
+    // and no orphaned XML descriptors for the unrequested locales
+    expect(writes.some(w => w.path.endsWith('MyModel_lt.xml'))).toBe(false);
+    expect(writes.some(w => w.path.endsWith('MyModel_nb-NO.xml'))).toBe(false);
+  });
+
+  it('creates a missing locale folder when requested via `languages`', async () => {
+    const fsMock = await import('fs');
+    const writes: { path: string; content: string }[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (p: string, content: string) => {
+      writes.push({ path: p, content });
+    });
+    // Model currently only has en-US; caller explicitly wants en-US + sv (new locale).
+    (fsMock.promises.readdir as any).mockResolvedValue(['en-US']);
+    (fsMock.promises.readFile as any).mockResolvedValue('﻿');
+    // descriptor / new-file existence checks should report "missing" so they get created
+    (fsMock.promises.access as any).mockRejectedValue(new Error('ENOENT'));
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'NewFeatureLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        addToProject: false,
+        languages: ['en-US', 'sv'],
+        translations: [
+          { language: 'en-US', text: 'New feature' },
+          { language: 'sv', text: 'Ny funktion' },
+        ],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(writes.some(w => w.path.endsWith('MyModel.en-US.label.txt'))).toBe(true);
+    expect(writes.some(w => w.path.endsWith('MyModel.sv.label.txt'))).toBe(true);
+    // fi / lt / nb-NO never requested and not present — must not appear
+    expect(writes.some(w => w.path.endsWith('MyModel.fi.label.txt'))).toBe(false);
   });
 
   it('defaults description to VS project name when no comment is provided', async () => {

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -564,6 +564,45 @@ describe('create_label', () => {
     expect(writes.some(w => w.path.endsWith('MyModel.fi.label.txt'))).toBe(false);
   });
 
+  it('resolves to on-disk casing when `languages` locale differs in case (Linux unzip)', async () => {
+    // Scenario: MS packages were unzipped on Linux — locale directories are lowercase (en-us, de).
+    // The caller passes standard BCP-47 values (en-US, de).
+    // The tool must write to the existing on-disk paths, NOT create new en-US/ de/ sibling folders.
+    const fsMock = await import('fs');
+    const writes: { path: string; content: string }[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (p: string, content: string) => {
+      writes.push({ path: p, content });
+    });
+    // On-disk the folders are lowercase (Linux unzip behaviour)
+    (fsMock.promises.readdir as any).mockResolvedValue(['en-us', 'de']);
+    (fsMock.promises.readFile as any).mockResolvedValue('\uFEFF');
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'CaseMismatchLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        addToProject: false,
+        // Caller uses standard BCP-47 casing
+        languages: ['en-US', 'de'],
+        translations: [
+          { language: 'en-US', text: 'Case test' },
+          { language: 'de', text: 'Groß-Klein-Test' },
+        ],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+
+    // Must write into the existing lowercase directory names, not create new mixed-case ones
+    expect(writes.some(w => /[/\\]en-us[/\\]/.test(w.path))).toBe(true);
+    expect(writes.some(w => /[/\\]de[/\\]/.test(w.path))).toBe(true);
+
+    // Must NOT create a second en-US/ folder alongside en-us/
+    expect(writes.some(w => /[/\\]en-US[/\\]/.test(w.path))).toBe(false);
+  });
+
   it('defaults description to VS project name when no comment is provided', async () => {
     const fsMock = await import('fs');
     const writeCalls: string[] = [];


### PR DESCRIPTION
Add an optional `languages` array parameter to the create_label tool. When provided, the label is written only to those locales instead of every language folder present in the model. This prevents labels from leaking into locales that exist only because sibling label files in the same model ship them (LabelResources/ is shared across the whole model). For example report might be translated to 20 languages, but user only need 1 language for operating D365.

When omitted or empty, the existing behavior is preserved: the label is written to every language folder already present in the model.