### PR TITLE
fix(modifyD365File): use cross-platform absolute path check; ban repl…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,7 @@ PowerShell / any terminal command **WILL HANG** in VS 2022 / VS 2026 MCP integra
 
 1. Model name comes from `.mcp.json` — never infer from search results
 2. `modify_d365fo_file`/`create_d365fo_file` APPLY IMMEDIATELY (no dry-run) — describe the change and confirm in chat first; revert with `undo_last_modification` (or pass `createBackup=true`)
+2a. **NEVER** use `replace_string_in_file`, `edit_file`, `apply_patch`, or any built-in file-write tool on `.xml`/`.xpp` files — **not even as a fallback** when `modify_d365fo_file` fails. These bypass IMetadataProvider and corrupt VS 2022's in-memory model. If `modify_d365fo_file` errors, STOP and report the error verbatim.
 3. Never run `build_d365fo_project()` automatically — only on explicit user request
 4. Never copy default parameter values into CoC wrapper signatures
 5. Never use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -157,7 +157,9 @@ For .xml/.xpp files, use MCP tools instead of built-in tools:
 - \`search\` instead of \`code_search\`/\`file_search\` (avoids 350+ model folder scan)
 - \`get_class_info\`/\`get_table_info\` instead of \`read_file\`
 - \`create_d365fo_file\` instead of \`create_file\`
-- \`modify_d365fo_file\` instead of \`edit_file\`/\`apply_patch\`
+- \`modify_d365fo_file\` instead of \`edit_file\`/\`apply_patch\`/\`replace_string_in_file\`/\`str_replace_editor\`
+
+⛔ **NEVER** use \`replace_string_in_file\`, \`edit_file\`, \`apply_patch\`, \`str_replace_editor\`, or any built-in file-write tool on .xml or .xpp files — even as a fallback when \`modify_d365fo_file\` fails. These tools do not understand D365FO XML structure, bypass IMetadataProvider, and corrupt VS 2022's in-memory model. **If \`modify_d365fo_file\` returns an error, STOP and report the error verbatim. Do NOT attempt a workaround.**
 
 ### 6. Terminal/Scripts Prohibition
 PowerShell and Python scripts hang indefinitely in VS 2022 MCP integration. When \`modify_d365fo_file\` errors:

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1060,7 +1060,13 @@ async function findD365File(
     // which are never accessible at runtime.  Relative paths (e.g. "ContosoExt/ContosoExt/AxClass/Foo.xml")
     // also come from this source and cannot be used directly.
     // Fall through to findD365FileOnDisk which builds the correct absolute path from config.
-    if (dbResult && path.isAbsolute(dbResult)) {
+    //
+    // Use cross-platform absolute detection so that Windows-style drive paths (C:\...)
+    // are recognised as absolute even when the server runs on Linux/macOS (path.isAbsolute
+    // returns false for Windows paths on POSIX hosts, causing spurious fallback loops).
+    const isAbsoluteXPlat = (p: string) =>
+      path.isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p) || /^\\\\/.test(p);
+    if (dbResult && isAbsoluteXPlat(dbResult)) {
       try {
         await import('fs').then(m => m.promises.access(dbResult!));
         return dbResult;


### PR DESCRIPTION
…ace_string_in_file fallback

Two changes:

1. modifyD365File.ts – findD365File used path.isAbsolute(dbResult) which returns false for Windows-style drive paths (C:\...) when the process runs on Linux/macOS. The DB can store such paths (indexed on a Windows VM, read back on a Linux CI runner or Azure proxy). Added isAbsoluteXPlat() inline helper that additionally matches /^[a-zA-Z]:[\\/]/ and /^\\\\/ so those paths are correctly recognised as absolute and not silently dropped to the filesystem fallback.

2. systemInstructions.ts + .github/copilot-instructions.md – explicitly forbid replace_string_in_file / str_replace_editor / edit_file / apply_patch as fallbacks on .xml/.xpp files. Previously only edit_file/apply_patch were listed; replace_string_in_file was missing, which allowed the AI to reason: 'The MCP tool has a slash-format path comparison issue. I'\''ll edit the XML directly via replace_string_in_file' – a silent corruption path. Now rule 2a in copilot-instructions.md calls this out by name with STOP semantics.