### PR TITLE
fix(docs): rename root CLAUDE.md template to CLAUDE.template.md

### DIFF
--- a/CLAUDE.template.md
+++ b/CLAUDE.template.md
@@ -1,9 +1,11 @@
 # D365 Finance & Operations X++ Development
 
-<!-- Copy this file to the parent folder that contains all your D365FO solution folders
-     (the same folder where .github\copilot-instructions.md lives for Copilot users).
-     Claude Code reads CLAUDE.md automatically from the working directory upward,
-     so one copy here covers every solution underneath — no per-solution copies needed.
+<!-- TEMPLATE — this file is NOT auto-loaded from the d365fo-mcp-server repo root.
+     Copy it to the parent folder that contains all your D365FO solution folders
+     (the same folder where .github\copilot-instructions.md lives for Copilot users)
+     and SAVE IT AS `CLAUDE.md` there. Claude Code reads CLAUDE.md automatically from
+     the working directory upward, so one copy covers every solution underneath —
+     no per-solution copies needed.
 
      Full rules are delivered via the MCP `xpp_system_instructions` prompt.
      This file provides only the minimum static context needed when the MCP server

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ claude mcp add-json --scope user d365fo-mcp-tools '{"type":"stdio","command":"no
 
 > `alwaysLoad: true` loads the d365fo tool list at session start, preventing Claude from routing X++ lookups to other connected code intelligence tools or built-in search.
 
-**3.** Copy `CLAUDE.md` to the parent folder of your D365FO solutions:
+**3.** Copy `CLAUDE.template.md` to the parent folder of your D365FO solutions, renaming it to `CLAUDE.md`:
 
 ```powershell
-Copy-Item -Path "K:\d365fo-mcp-server\CLAUDE.md" -Destination "C:\source\repos\"
+Copy-Item -Path "K:\d365fo-mcp-server\CLAUDE.template.md" -Destination "C:\source\repos\CLAUDE.md"
 ```
 
 > **Full Claude Code setup guide (all scenarios, project-scoped `.mcp.json`, troubleshooting):** [docs/CLAUDE_CODE_SETUP.md](docs/CLAUDE_CODE_SETUP.md)

--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -114,11 +114,11 @@ Claude Code's Tool Search feature defers MCP tool schemas to save context. When 
 
 ## Step 3 — Place `CLAUDE.md`
 
-Copy `CLAUDE.md` from the repo root to the parent folder of your D365FO solutions. Claude Code reads it automatically from the working directory upward, so one copy covers all solutions underneath.
+Copy `CLAUDE.template.md` from the repo root to the parent folder of your D365FO solutions, renaming it to `CLAUDE.md`. Claude Code reads it automatically from the working directory upward, so one copy covers all solutions underneath.
 
 ```powershell
-# Example: place in the parent of all your D365FO solution folders
-Copy-Item -Path "K:\d365fo-mcp-server\CLAUDE.md" -Destination "C:\source\repos\"
+# Example: place in the parent of all your D365FO solution folders, renamed to CLAUDE.md
+Copy-Item -Path "K:\d365fo-mcp-server\CLAUDE.template.md" -Destination "C:\source\repos\CLAUDE.md"
 ```
 
 `CLAUDE.md` reinforces the tool priority in plain language — telling Claude to use `d365fo-mcp-tools` for all X++ work regardless of what other tools are connected. `alwaysLoad` handles it technically; `CLAUDE.md` handles it instructionally.


### PR DESCRIPTION
## Issue

The repo-root `CLAUDE.md` added in #513 is a **distributable template** for working inside D365FO *projects* — its own header says to copy it to the parent folder of your D365FO solutions, and it instructs the agent to route X++ work through the `d365fo-mcp-tools` MCP server.

But `CLAUDE.md` is the one filename Claude Code reserves for a contributor's own repo-development instructions, auto-loaded from the working directory upward. Tracking it at the repo root causes two problems:

1. **It confiscates the contributor's memory slot.** Any contributor who keeps a `CLAUDE.md` with knowledge about developing this server can no longer have one — the tracked file collides with theirs. On pull, git aborts rather than overwrite an untracked `CLAUDE.md` (`"untracked working tree files would be overwritten by merge ... Aborting"`), blocking the pull and risking loss of that accumulated knowledge if resolved carelessly.
2. **Its content misdirects.** Because it is auto-loaded as instructions for *this* repo, anyone editing the server's TypeScript source is told to use the MCP tools for `.xml` / `.label.txt` / symbol lookups — wrong and misleading.

## Fix

- Rename the template `CLAUDE.md` → `CLAUDE.template.md`. Only the exact filename `CLAUDE.md` auto-loads, so the template becomes inert and the root slot is freed.
- Update the copy steps in `README.md` and `docs/CLAUDE_CODE_SETUP.md` to source `CLAUDE.template.md` and save it **as** `CLAUDE.md` at the destination.
- Clarify the in-file header to state it is a template and must be saved as `CLAUDE.md` where it is deployed.

The template body is unchanged.
