### PR TITLE
fix(labels): sort label IDs with case-insensitive ordinal collation

### DIFF
--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -159,6 +159,17 @@ function parseLabelMap(content: string): Map<string, { text: string; comment?: s
   return map;
 }
 
+/** Case-insensitive ordinal comparison of two label IDs.
+ *  Matches Visual Studio's ordering of .label.txt entries, where `_` (0x5F) sorts
+ *  AFTER all letters. A locale-aware comparer (e.g. localeCompare) instead sorts `_`
+ *  BEFORE letters, which shuffles `word_`-prefixed IDs on every write and produces
+ *  spurious git diffs. Equivalent to .NET's StringComparer.OrdinalIgnoreCase. */
+function compareLabelIdsOrdinalCI(a: string, b: string): number {
+  const ua = a.toUpperCase();
+  const ub = b.toUpperCase();
+  return ua < ub ? -1 : ua > ub ? 1 : 0;
+}
+
 /** Render a label map back to .label.txt content with UTF-8 BOM.
  *  When `sort` is true (default), entries are sorted alphabetically by label ID.
  *  When `sort` is false, entries are written in insertion order (existing + appended).
@@ -169,7 +180,7 @@ function serializeLabelMap(
   eol: '\r\n' | '\n' = '\r\n',
 ): string {
   const entries = sort
-    ? [...map.entries()].sort(([a], [b]) => a.localeCompare(b, 'en', { sensitivity: 'base' }))
+    ? [...map.entries()].sort(([a], [b]) => compareLabelIdsOrdinalCI(a, b))
     : [...map.entries()];
   const lines: string[] = [];
   for (const [id, { text, comment }] of entries) {

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -768,6 +768,50 @@ describe('create_label', () => {
     expect(lines[2]).toContain('ZebraLabel=');
   });
 
+  it('orders underscore after letters (case-insensitive ordinal, matching Visual Studio)', async () => {
+    // Regression for the create_label sort-collation bug: a locale-aware comparer
+    // (localeCompare 'en', sensitivity 'base') sorts '_' BEFORE letters, but Visual
+    // Studio uses case-insensitive ordinal where '_' (0x5F) sorts AFTER A–Z. The
+    // disagreement shuffles `word_`-prefixed IDs on every write → spurious git churn.
+    // Empirically proven order in VS: Gx, px, _x (underscore last).
+    const fsMock = await import('fs');
+    const writeCalls: string[] = [];
+    (fsMock.promises.writeFile as any).mockImplementation(async (_p: string, content: string) => {
+      writeCalls.push(content);
+    });
+    (fsMock.promises.readdir as any).mockResolvedValueOnce(['en-US']);
+    // Existing file holds the three probe labels in scrambled order.
+    (fsMock.promises.readFile as any).mockResolvedValueOnce(
+      '﻿Zmvnsorttest_x=underscore\nZmvnsorttestGx=upper G\nZmvnsorttestpx=lower p\n',
+    );
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'ZmvnsorttestAx',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        updateIndex: false,
+        addToProject: false,
+        translations: [{ language: 'en-US', text: 'added' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const labelWrite = writeCalls.find(c => c.includes('ZmvnsorttestGx='));
+    expect(labelWrite).toBeDefined();
+    const ids = labelWrite!
+      .split('\n')
+      .filter(l => l.includes('='))
+      .map(l => l.split('=')[0].replace('﻿', ''));
+    // Case-insensitive ordinal: Ax, Gx, px (G<P), then _x LAST ('_'=0x5F > letters).
+    expect(ids).toEqual([
+      'ZmvnsorttestAx',
+      'ZmvnsorttestGx',
+      'Zmvnsorttestpx',
+      'Zmvnsorttest_x',
+    ]);
+  });
+
   it('respects LABEL_SORT_ORDER=append env var when sortLabels not specified', async () => {
     const fsMock = await import('fs');
     const writeCalls: string[] = [];


### PR DESCRIPTION
## Issue

`create_label` (with `sortLabels=true`, the default) sorted `.label.txt` entries using `localeCompare('en', { sensitivity: 'base' })` — a linguistic comparer where `_` (underscore) sorts **before** letters. Visual Studio orders label entries with case-insensitive **ordinal**, where `_` (0x5F) sorts **after** A–Z.

The two collations disagree only on `word_`-prefixed IDs (e.g. `Dispatch_Instructions` vs `Dispatched`), so the tool reshuffled exactly those entries on every write — producing large symmetric insert/delete git diffs unrelated to the label being added. This bug has been present since the tool was first introduced.

## Fix

Replace the comparer with `compareLabelIdsOrdinalCI` (uppercase-then-ordinal, the JS equivalent of .NET `StringComparer.OrdinalIgnoreCase`) so the tool's ordering matches Visual Studio and writes are diff-stable.