### PR TITLE
Feature/grounded reliability phase1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**57 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
+**58 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
@@ -20,7 +20,7 @@ AI coding assistants excel at C#, Python, and JavaScript — languages with rich
 
 The result is AI that confidently generates code that doesn't compile: wrong method signatures, missing parameters, fields that don't exist on the table, CoC chains broken because the AI didn't know an extension already wrapped the method.
 
-This MCP server solves that by pre-indexing your entire D365FO installation — hundreds of thousands of symbols across standard and custom models — and exposing it as 57 specialized tools. Works with **GitHub Copilot** and **Claude Code CLI**. Before generating any X++ code, the AI can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
+This MCP server solves that by pre-indexing your entire D365FO installation — hundreds of thousands of symbols across standard and custom models — and exposing it as 58 specialized tools. Works with **GitHub Copilot** and **Claude Code CLI**. Before generating any X++ code, the AI can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
 
 ![Solution Architecture](docs/img/solution-architecture-diagram.png)
 
@@ -173,7 +173,7 @@ Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.m
 | [docs/QUICK_START.md](docs/QUICK_START.md) | **Start here** — 5 steps to get running, all `.mcp.json` parameters, logging |
 | [docs/SETUP.md](docs/SETUP.md) | Detailed installation, configuration, all deployment scenarios A–F |
 | [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md) | `.mcp.json` reference — workspace paths, UDE, project settings, all env vars |
-| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 57 tools with parameters and example prompts |
+| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 58 tools with parameters and example prompts |
 | [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md) | Practical examples: search, CoC, SysOperation, security |
 | [docs/CUSTOM_EXTENSIONS.md](docs/CUSTOM_EXTENSIONS.md) | ISV / custom model configuration and multi-model extraction |
 | [docs/WORKSPACE_DETECTION.md](docs/WORKSPACE_DETECTION.md) | How the server auto-detects your D365FO project, model, and package path |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-﻿# D365 F&O MCP Server
+# D365 F&O MCP Server
 
 <div align="center">
 
-**56 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
+**57 AI tools that know every X++ class, table, method, and EDT in your D365FO codebase**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
@@ -20,7 +20,7 @@ AI coding assistants excel at C#, Python, and JavaScript — languages with rich
 
 The result is AI that confidently generates code that doesn't compile: wrong method signatures, missing parameters, fields that don't exist on the table, CoC chains broken because the AI didn't know an extension already wrapped the method.
 
-This MCP server solves that by pre-indexing your entire D365FO installation — hundreds of thousands of symbols across standard and custom models — and exposing it as 56 specialized tools. Works with **GitHub Copilot** and **Claude Code CLI**. Before generating any X++ code, the AI can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
+This MCP server solves that by pre-indexing your entire D365FO installation — hundreds of thousands of symbols across standard and custom models — and exposing it as 57 specialized tools. Works with **GitHub Copilot** and **Claude Code CLI**. Before generating any X++ code, the AI can look up exact method signatures, check what CoC extensions already exist, trace security hierarchies, find label translations, and understand the full shape of your data model. The result is code that compiles on the first try and integrates correctly with your existing customizations.
 
 ![Solution Architecture](docs/img/solution-architecture-diagram.png)
 
@@ -173,7 +173,7 @@ Setup guide: [docs/SETUP.md](docs/SETUP.md) · CI/CD pipeline: [docs/PIPELINES.m
 | [docs/QUICK_START.md](docs/QUICK_START.md) | **Start here** — 5 steps to get running, all `.mcp.json` parameters, logging |
 | [docs/SETUP.md](docs/SETUP.md) | Detailed installation, configuration, all deployment scenarios A–F |
 | [docs/MCP_CONFIG.md](docs/MCP_CONFIG.md) | `.mcp.json` reference — workspace paths, UDE, project settings, all env vars |
-| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 56 tools with parameters and example prompts |
+| [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) | All 57 tools with parameters and example prompts |
 | [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md) | Practical examples: search, CoC, SysOperation, security |
 | [docs/CUSTOM_EXTENSIONS.md](docs/CUSTOM_EXTENSIONS.md) | ISV / custom model configuration and multi-model extraction |
 | [docs/WORKSPACE_DETECTION.md](docs/WORKSPACE_DETECTION.md) | How the server auto-detects your D365FO project, model, and package path |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ graph TB
     subgraph "MCP Server Components"
         HTTP[HTTP Transport Layer\n Express + Rate Limiting]
         PROTO[MCP Protocol Handler\n JSON-RPC 2.0]
-        TOOLS[Tool Handlers\n 57 MCP Tools]
+        TOOLS[Tool Handlers\n 58 MCP Tools]
         DB[(Symbols Database\n FTS5, 584K+ symbols)]
         LDB[(Labels Database\n FTS5, 19M+ labels, 70 languages)]
         CACHE[Redis Cache\n Optional]
@@ -102,7 +102,7 @@ sequenceDiagram
     alt Initialize
         MCP-->>IDE: Server Capabilities
     else Tools List
-        MCP-->>IDE: 57 Tool Definitions
+        MCP-->>IDE: 58 Tool Definitions
     else Tool Call
         MCP->>Handler: Route to Handler
         Handler->>Tool: Execute Tool
@@ -804,7 +804,7 @@ graph LR
     subgraph "MCP Protocol Methods"
         INIT[initialize\n Server Capabilities]
         NOTIFY[notifications/initialized\n Handshake Complete]
-        TOOLS_LIST[tools/list\n 57 Available Tools]
+        TOOLS_LIST[tools/list\n 58 Available Tools]
         TOOLS_CALL[tools/call\n Execute Tool]
         RES_LIST[resources/list\n Empty]
         RES_TMPL[resources/templates/list\n Empty]
@@ -813,7 +813,7 @@ graph LR
     end
 
     INIT -.-> CAPS[Capabilities: tools, resources, prompts]
-    TOOLS_LIST -.-> TOOL_DEFS["56 tools: search, batch_search, search_extensions, get_class_info, get_table_info, code_completion, get_method_signature, get_method_source, find_references, get_form_info, get_query_info, get_view_info, get_enum_info, get_edt_info, get_report_info, generate_code, analyze_code_patterns, suggest_method_implementation, analyze_class_completeness, get_api_usage_patterns, get_xpp_knowledge, get_d365fo_error_help, validate_xpp, resolve_references, prepare_change, generate_d365fo_xml, create_d365fo_file, modify_d365fo_file, search_labels, get_label_info, create_label, rename_label, get_table_patterns, get_form_patterns, generate_smart_table, generate_smart_form, generate_smart_report, suggest_edt, get_security_artifact_info, get_security_coverage_for_object, get_menu_item_info, find_coc_extensions, find_event_handlers, get_table_extension_info, get_data_entity_info, analyze_extension_points, recommend_extension_strategy, validate_object_naming, get_workspace_info, verify_d365fo_project, update_symbol_index, build_d365fo_project, trigger_db_sync, run_bp_check, run_systest_class, review_workspace_changes, undo_last_modification"]
+    TOOLS_LIST -.-> TOOL_DEFS["56 tools: search, batch_search, search_extensions, get_class_info, get_table_info, code_completion, get_method_signature, get_method_source, find_references, get_form_info, get_query_info, get_view_info, get_enum_info, get_edt_info, get_report_info, generate_code, analyze_code_patterns, suggest_method_implementation, analyze_class_completeness, get_api_usage_patterns, get_xpp_knowledge, get_d365fo_error_help, validate_xpp, resolve_references, prepare_change, prepare_create, generate_d365fo_xml, create_d365fo_file, modify_d365fo_file, search_labels, get_label_info, create_label, rename_label, get_table_patterns, get_form_patterns, generate_smart_table, generate_smart_form, generate_smart_report, suggest_edt, get_security_artifact_info, get_security_coverage_for_object, get_menu_item_info, find_coc_extensions, find_event_handlers, get_table_extension_info, get_data_entity_info, analyze_extension_points, recommend_extension_strategy, validate_object_naming, get_workspace_info, verify_d365fo_project, update_symbol_index, build_d365fo_project, trigger_db_sync, run_bp_check, run_systest_class, review_workspace_changes, undo_last_modification"]
     TOOLS_CALL -.-> EXEC[Tool Execution: search DB, parse XML, return results]
     style INIT fill:#4CAF50,color:#fff
     style TOOLS_CALL fill:#2196F3,color:#fff

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ graph TB
     subgraph "MCP Server Components"
         HTTP[HTTP Transport Layer\n Express + Rate Limiting]
         PROTO[MCP Protocol Handler\n JSON-RPC 2.0]
-        TOOLS[Tool Handlers\n 56 MCP Tools]
+        TOOLS[Tool Handlers\n 57 MCP Tools]
         DB[(Symbols Database\n FTS5, 584K+ symbols)]
         LDB[(Labels Database\n FTS5, 19M+ labels, 70 languages)]
         CACHE[Redis Cache\n Optional]
@@ -102,7 +102,7 @@ sequenceDiagram
     alt Initialize
         MCP-->>IDE: Server Capabilities
     else Tools List
-        MCP-->>IDE: 56 Tool Definitions
+        MCP-->>IDE: 57 Tool Definitions
     else Tool Call
         MCP->>Handler: Route to Handler
         Handler->>Tool: Execute Tool
@@ -804,7 +804,7 @@ graph LR
     subgraph "MCP Protocol Methods"
         INIT[initialize\n Server Capabilities]
         NOTIFY[notifications/initialized\n Handshake Complete]
-        TOOLS_LIST[tools/list\n 56 Available Tools]
+        TOOLS_LIST[tools/list\n 57 Available Tools]
         TOOLS_CALL[tools/call\n Execute Tool]
         RES_LIST[resources/list\n Empty]
         RES_TMPL[resources/templates/list\n Empty]
@@ -813,7 +813,7 @@ graph LR
     end
 
     INIT -.-> CAPS[Capabilities: tools, resources, prompts]
-    TOOLS_LIST -.-> TOOL_DEFS["56 tools: search, batch_search, search_extensions, get_class_info, get_table_info, code_completion, get_method_signature, get_method_source, find_references, get_form_info, get_query_info, get_view_info, get_enum_info, get_edt_info, get_report_info, generate_code, analyze_code_patterns, suggest_method_implementation, analyze_class_completeness, get_api_usage_patterns, get_xpp_knowledge, get_d365fo_error_help, validate_xpp, prepare_change, generate_d365fo_xml, create_d365fo_file, modify_d365fo_file, search_labels, get_label_info, create_label, rename_label, get_table_patterns, get_form_patterns, generate_smart_table, generate_smart_form, generate_smart_report, suggest_edt, get_security_artifact_info, get_security_coverage_for_object, get_menu_item_info, find_coc_extensions, find_event_handlers, get_table_extension_info, get_data_entity_info, analyze_extension_points, recommend_extension_strategy, validate_object_naming, get_workspace_info, verify_d365fo_project, update_symbol_index, build_d365fo_project, trigger_db_sync, run_bp_check, run_systest_class, review_workspace_changes, undo_last_modification"]
+    TOOLS_LIST -.-> TOOL_DEFS["56 tools: search, batch_search, search_extensions, get_class_info, get_table_info, code_completion, get_method_signature, get_method_source, find_references, get_form_info, get_query_info, get_view_info, get_enum_info, get_edt_info, get_report_info, generate_code, analyze_code_patterns, suggest_method_implementation, analyze_class_completeness, get_api_usage_patterns, get_xpp_knowledge, get_d365fo_error_help, validate_xpp, resolve_references, prepare_change, generate_d365fo_xml, create_d365fo_file, modify_d365fo_file, search_labels, get_label_info, create_label, rename_label, get_table_patterns, get_form_patterns, generate_smart_table, generate_smart_form, generate_smart_report, suggest_edt, get_security_artifact_info, get_security_coverage_for_object, get_menu_item_info, find_coc_extensions, find_event_handlers, get_table_extension_info, get_data_entity_info, analyze_extension_points, recommend_extension_strategy, validate_object_naming, get_workspace_info, verify_d365fo_project, update_symbol_index, build_d365fo_project, trigger_db_sync, run_bp_check, run_systest_class, review_workspace_changes, undo_last_modification"]
     TOOLS_CALL -.-> EXEC[Tool Execution: search DB, parse XML, return results]
     style INIT fill:#4CAF50,color:#fff
     style TOOLS_CALL fill:#2196F3,color:#fff

--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -171,5 +171,5 @@ If a file appears on disk, the C# bridge is working.
 
 - [QUICK_START.md](QUICK_START.md) — Full Copilot scenario guide (Scenarios A–F); env var reference applies to Claude Code too
 - [MCP_CONFIG.md](MCP_CONFIG.md) — Complete env var reference for D365FO workspace paths
-- [MCP_TOOLS.md](MCP_TOOLS.md) — All 56 tools with parameters and example prompts
+- [MCP_TOOLS.md](MCP_TOOLS.md) — All 57 tools with parameters and example prompts
 - [BRIDGE.md](BRIDGE.md) — C# Metadata Bridge (required for file create/modify on Windows VMs)

--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -171,5 +171,5 @@ If a file appears on disk, the C# bridge is working.
 
 - [QUICK_START.md](QUICK_START.md) — Full Copilot scenario guide (Scenarios A–F); env var reference applies to Claude Code too
 - [MCP_CONFIG.md](MCP_CONFIG.md) — Complete env var reference for D365FO workspace paths
-- [MCP_TOOLS.md](MCP_TOOLS.md) — All 57 tools with parameters and example prompts
+- [MCP_TOOLS.md](MCP_TOOLS.md) — All 58 tools with parameters and example prompts
 - [BRIDGE.md](BRIDGE.md) — C# Metadata Bridge (required for file create/modify on Windows VMs)

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -361,7 +361,7 @@ GitHub Copilot connects to both servers at the same time and selects the right o
 
 1. `d365fo-azure` starts with `MCP_SERVER_MODE=read-only` → only exposes search/analysis tools
 2. `d365fo-local` starts with `MCP_SERVER_MODE=write-only` → only exposes file-operation tools
-3. GitHub Copilot aggregates both tool lists — from Copilot's perspective it sees all 56 tools
+3. GitHub Copilot aggregates both tool lists — from Copilot's perspective it sees All 57 tools
 4. When Copilot calls `create_d365fo_file`, it goes to the local server which has K:\ access
 5. When Copilot calls `search`, it goes to the Azure server with the full metadata database
 
@@ -386,8 +386,8 @@ When the server starts, it logs the detected mode and tool count:
 **Full mode (local development):**
 ```
 🔧 Server mode: full (from env: not set, defaulting to full)
-🎯 Registered 56 X++ MCP tools (full mode)
-[MCP Server] Tool list in full mode: 56 tools (no filtering)
+🎯 Registered 57 X++ MCP tools (full mode)
+[MCP Server] Tool list in full mode: 57 tools (no filtering)
 ```
 
 > **Note:** The local server in `write-only` mode skips database download and the symbol

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -361,7 +361,7 @@ GitHub Copilot connects to both servers at the same time and selects the right o
 
 1. `d365fo-azure` starts with `MCP_SERVER_MODE=read-only` → only exposes search/analysis tools
 2. `d365fo-local` starts with `MCP_SERVER_MODE=write-only` → only exposes file-operation tools
-3. GitHub Copilot aggregates both tool lists — from Copilot's perspective it sees All 57 tools
+3. GitHub Copilot aggregates both tool lists — from Copilot's perspective it sees All 58 tools
 4. When Copilot calls `create_d365fo_file`, it goes to the local server which has K:\ access
 5. When Copilot calls `search`, it goes to the Azure server with the full metadata database
 
@@ -386,8 +386,8 @@ When the server starts, it logs the detected mode and tool count:
 **Full mode (local development):**
 ```
 🔧 Server mode: full (from env: not set, defaulting to full)
-🎯 Registered 57 X++ MCP tools (full mode)
-[MCP Server] Tool list in full mode: 57 tools (no filtering)
+🎯 Registered 58 X++ MCP tools (full mode)
+[MCP Server] Tool list in full mode: 58 tools (no filtering)
 ```
 
 > **Note:** The local server in `write-only` mode skips database download and the symbol

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,7 +1,7 @@
 # All Available Tools
 
 When you ask GitHub Copilot a question about D365FO code, it automatically calls one of these
-56 tools to look up the answer or generate code. You do not need to name the tools yourself —
+57 tools to look up the answer or generate code. You do not need to name the tools yourself —
 just ask in plain English.
 
 > **C# Metadata Bridge (Windows D365FO VMs only):** On a Windows VM with D365FO installed,
@@ -144,14 +144,19 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 | **create_label** | Add a new label to all language files in a model (or only the locales listed in `languages`) | "Create label MyNewField in MyModel" |
 | **rename_label** | Rename a label ID in .label.txt, X++ source and XML metadata | "Rename label OldName to NewName in MyModel" |
 
-### Code Quality & Grounding (2 tools)
+### Code Quality & Grounding (3 tools)
 
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|
 | **validate_xpp** | Offline X++/XML BP validator — <50 ms, all-platform, no xppbp.exe needed. Returns `{rule, severity, line, excerpt, fix}[]`. Call after generating code, before write operations. | "Validate this generated class for BP issues" |
+| **resolve_references** | Semantic reference resolver — verifies every type, table field, method (incl. arity), enum, label and intrinsic target (`tableStr`, `fieldStr`, …) in generated X++ against the indexed codebase. Catches hallucinated symbols before the compiler does. | "Check that this generated code only references real symbols" |
 | **prepare_change** | Single-round context aggregator for extension work. Returns method signature, existing CoC wrappers, eligibility, strategy, naming validation, and a grounding token in one parallel call. | "Prepare context for extending CustTable.validateWrite" |
 
-> **Grounding enforcement:** `prepare_change` issues a SHA-256 provenance token (30-min TTL). When `GROUNDING_ENFORCE=true` is set in `.env`, extension patterns in `generate_code` and extension objectTypes in `create_d365fo_file` require a valid token — ensuring generated code is grounded in your actual codebase, not AI training data.
+> **Grounding enforcement:** `prepare_change` issues a SHA-256 provenance token (30-min TTL) **bound to the object it was issued for**. When `GROUNDING_ENFORCE=true` is set in `.env`:
+> - extension patterns in `generate_code` and extension objectTypes in `create_d365fo_file` / `modify_d365fo_file` require a valid token for the target object, and
+> - X++ source passed to `create_d365fo_file` / `modify_d365fo_file` is run through `resolve_references` — the write is rejected while any identifier cannot be proven against the index.
+>
+> This ensures generated code is grounded in your actual codebase, not AI training data.
 
 ---
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,7 +1,7 @@
 # All Available Tools
 
 When you ask GitHub Copilot a question about D365FO code, it automatically calls one of these
-57 tools to look up the answer or generate code. You do not need to name the tools yourself —
+58 tools to look up the answer or generate code. You do not need to name the tools yourself —
 just ask in plain English.
 
 > **C# Metadata Bridge (Windows D365FO VMs only):** On a Windows VM with D365FO installed,
@@ -144,13 +144,14 @@ The following tools empower Copilot to trigger X++ compilation, testing, and db 
 | **create_label** | Add a new label to all language files in a model (or only the locales listed in `languages`) | "Create label MyNewField in MyModel" |
 | **rename_label** | Rename a label ID in .label.txt, X++ source and XML metadata | "Rename label OldName to NewName in MyModel" |
 
-### Code Quality & Grounding (3 tools)
+### Code Quality & Grounding (4 tools)
 
 | Tool | What it does | Example prompt |
 |------|-------------|---------------|
-| **validate_xpp** | Offline X++/XML BP validator — <50 ms, all-platform, no xppbp.exe needed. Returns `{rule, severity, line, excerpt, fix}[]`. Call after generating code, before write operations. | "Validate this generated class for BP issues" |
+| **validate_xpp** | Offline X++/XML BP validator — <50 ms, all-platform, no xppbp.exe needed. Returns `{rule, severity, line, excerpt, fix}[]` incl. data-driven property rules (XML002–XML005) mined from your standard models. Call after generating code, before write operations. | "Validate this generated class for BP issues" |
 | **resolve_references** | Semantic reference resolver — verifies every type, table field, method (incl. arity), enum, label and intrinsic target (`tableStr`, `fieldStr`, …) in generated X++ against the indexed codebase. Catches hallucinated symbols before the compiler does. | "Check that this generated code only references real symbols" |
 | **prepare_change** | Single-round context aggregator for extension work. Returns method signature, existing CoC wrappers, eligibility, strategy, naming validation, and a grounding token in one parallel call. | "Prepare context for extending CustTable.validateWrite" |
+| **prepare_create** | Single-round context aggregator for NEW objects. Returns collision check, naming with the auto-applied prefix, similar objects to copy patterns from, EDT suggestions for planned fields, reusable labels, mined property defaults, and a grounding token. | "Prepare context for a new Contoso import parameters table" |
 
 > **Grounding enforcement:** `prepare_change` issues a SHA-256 provenance token (30-min TTL) **bound to the object it was issued for**. When `GROUNDING_ENFORCE=true` is set in `.env`:
 > - extension patterns in `generate_code` and extension objectTypes in `create_d365fo_file` / `modify_d365fo_file` require a valid token for the target object, and

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -229,7 +229,7 @@ All available parameters in one block with comments:
       "args": ["K:\\d365fo-mcp-server\\dist\\index.js"],
       "env": {
         // ── Server mode ──────────────────────────────────────────────
-        // "full"       — all 56 tools (default for local)
+        // "full"       — All 57 tools (default for local)
         // "read-only"  — search/analysis tools only (Azure deployment)
         // "write-only" — file operations only (local companion in hybrid)
         "MCP_SERVER_MODE": "write-only",
@@ -376,7 +376,7 @@ After starting, check the server log for:
 
 | Topic | Documentation |
 |-------|--------------|
-| All 56 tools with parameters | [MCP_TOOLS.md](MCP_TOOLS.md) |
+| All 57 tools with parameters | [MCP_TOOLS.md](MCP_TOOLS.md) |
 | Practical usage examples (CoC, reports, security) | [USAGE_EXAMPLES.md](USAGE_EXAMPLES.md) |
 | Complete `.mcp.json` reference (all properties) | [MCP_CONFIG.md](MCP_CONFIG.md) |
 | Server deployment to Azure | [SETUP.md](SETUP.md) / [SETUP_AZURE.md](SETUP_AZURE.md) |

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -229,7 +229,7 @@ All available parameters in one block with comments:
       "args": ["K:\\d365fo-mcp-server\\dist\\index.js"],
       "env": {
         // ── Server mode ──────────────────────────────────────────────
-        // "full"       — All 57 tools (default for local)
+        // "full"       — All 58 tools (default for local)
         // "read-only"  — search/analysis tools only (Azure deployment)
         // "write-only" — file operations only (local companion in hybrid)
         "MCP_SERVER_MODE": "write-only",
@@ -376,7 +376,7 @@ After starting, check the server log for:
 
 | Topic | Documentation |
 |-------|--------------|
-| All 57 tools with parameters | [MCP_TOOLS.md](MCP_TOOLS.md) |
+| All 58 tools with parameters | [MCP_TOOLS.md](MCP_TOOLS.md) |
 | Practical usage examples (CoC, reports, security) | [USAGE_EXAMPLES.md](USAGE_EXAMPLES.md) |
 | Complete `.mcp.json` reference (all properties) | [MCP_CONFIG.md](MCP_CONFIG.md) |
 | Server deployment to Azure | [SETUP.md](SETUP.md) / [SETUP_AZURE.md](SETUP_AZURE.md) |

--- a/docs/proposals/next-level-grounding-plan.md
+++ b/docs/proposals/next-level-grounding-plan.md
@@ -1,0 +1,198 @@
+# Next-Level Plan — 100% Grounded, Compilable, BP-Clean Output
+
+> Ground truth: tento plán vychází výhradně ze stávající codebase (`src/`, `bridge/`,
+> `docs/`, schéma v `src/metadata/symbolIndex.ts`) a z dat, která server indexuje
+> (symbols DB 584k+ symbolů, labels DB, DYNAMICSXREFDB přes bridge). Žádné předpoklady
+> z trénovacích dat.
+
+## Co už platí (ověřeno v kódu)
+
+| Schopnost | Kde |
+|-----------|-----|
+| Symbol index: `signature`, `source`, `used_types`, `method_calls`, `extends_class`, FTS5 | `src/metadata/symbolIndex.ts:259-367` |
+| Doménové tabulky: `table_relations`, `form_datasources`, `edt_metadata`, `security_*`, `menu_item_targets`, `extension_metadata` | `src/metadata/symbolIndex.ts:450-575` |
+| Bridge read/write + xref: `readtable…readreport`, `findreferences`, `findextensionclasses`, `createobject`, `addmethod`, `setproperty`, `validateobject` (read-back přes IMetadataProvider) | `bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs` |
+| Offline BP validátor — 13 regex pravidel (SEL/COC/BP/XML) | `src/tools/validateXpp.ts` |
+| Single-round agregátor pro extension práci + grounding token (SHA-256, 30 min TTL) | `src/tools/prepareChange.ts`, `src/utils/provenanceStore.ts` |
+| Skutečný kompilátor a BP: MSBuild + `xppbp.exe` na vyžádání | `src/tools/buildProject.ts`, `src/tools/runBpCheck.ts` |
+| Metriky nástrojů: calls, latency, emptyResults (in-memory) | `src/utils/toolMetrics.ts` |
+| Systémové instrukce: 349 řádků po zeštíhlení | `src/prompts/systemInstructions.ts` |
+
+## Zjištěné mezery (root causes)
+
+1. **Nic neověřuje, že identifikátory ve vygenerovaném kódu existují.** `validate_xpp`
+   kontroluje styl (regex), ne sémantiku. Model může vygenerovat `CustTable.MyFakeField`
+   a žádná brána to nechytí dřív než MSBuild. Grep potvrzuje: žádný resolver referencí
+   proti symbols DB neexistuje.
+2. **Grounding enforcement je děravý.** `enforceGrounding()` volá jen `generate_code`
+   (`src/tools/codeGen.ts:1860`). `create_d365fo_file` ani `modify_d365fo_file` token
+   nevyžadují — commit message fbc2f76 tvrdí opak. Zápis bez důkazu o groundingu je
+   stále možný.
+3. **Vlastnosti (properties) objektů nemají datově řízenou validaci.** XML001 je jediné
+   property pravidlo a je hardcodované. Šablony v `smartXmlBuilder`/`generateD365Xml`
+   nastavují properties podle kódu šablon, ne podle toho, co reálně dělá Microsoft
+   v indexovaných standardních modelech, a nic je nekonfrontuje s xppbp pravidly
+   před zápisem.
+4. **Kompilace není součástí smyčky jako levná brána.** `build_d365fo_project` vrací
+   surový log; chybí model-scoped rychlá cesta se strukturovanými diagnostikami
+   `{file, line, error, fix}` které model zpracuje v jednom kroku.
+5. **`prepare_change` pokrývá jen rozšiřování existujících objektů.** Pro tvorbu nových
+   objektů (tabulka, forma, třída) musí model skládat kontext z 4–6 samostatných volání
+   (search → naming → labels → EDT → patterns) — přesně ty redundantní loopy, které chceme
+   eliminovat.
+6. **Čerstvost indexu se nehlídá.** Když uživatel změní X++ ve VS, index je stale a server
+   to nikde nesignalizuje — odpovědi pak nejsou „aktuální platforma".
+7. **Loopy nejsou měřitelné.** `toolMetrics` počítá volání a empty results, ale nevidí
+   sekvence (opakovaná identická volání, ping-pong mezi search→info→search).
+
+---
+
+## Pilíře
+
+### Pilíř 1 — Sémantický resolver referencí (`resolve_references`) — anti-halucinační brána č. 1
+
+**Nový soubor:** `src/tools/resolveReferences.ts`
+
+Z vygenerovaného X++/XML vytáhne všechny externí reference a každou ověří proti
+jedinému místu pravdy:
+
+| Co se extrahuje | Proti čemu se ověřuje |
+|----------------|----------------------|
+| Typy (deklarace, `new`, statická volání `Foo::bar()`) | `symbols WHERE name=? AND type IN ('class','table','interface',…)` |
+| `table.field` přístupy | `symbols WHERE parent_name=? AND type='field'` (existující index `idx_parent_type_name`) |
+| Volání metod + arita | `signature` ze `symbols` (stejná query jako `prepareChange.fetchMethodSignature`) |
+| Enum hodnoty `Enum::Value` | `symbols WHERE parent_name=? AND type='enum_value'` |
+| Label reference `@SYS…`, `@Model:Key` | labels DB |
+| EDT v deklaracích polí | `edt_metadata` |
+
+Výstup: `{unknownSymbols[], wrongArity[], missingFields[], missingLabels[]}` — strojově
+čitelný, oprava v témže tahu. Bridge-first kde běží (`resolveobjectinfo` už existuje),
+SQLite fallback všude. Vše < 200 ms, žádná kompilace.
+
+**Zapojení fail-closed:** `create_d365fo_file` a `modify_d365fo_file` interně zavolají
+resolver před zápisem; při `GROUNDING_ENFORCE=true` neznámý symbol = zápis odmítnut
+s přesným seznamem co ověřit. Tím se „100% z codebase" stává vynutitelnou vlastností,
+ne prosbou v promptu.
+
+### Pilíř 2 — Uzavření grounding enforcementu
+
+1. `enforceGrounding()` přidat do `create_d365fo_file` (extension varianty) a
+   `modify_d365fo_file` — dorovnat kód s tím, co tvrdí commit fbc2f76 a docs.
+2. Token vázat na `objectName` (dnes je jen globální hash s TTL — `provenanceStore.ts`):
+   token vystavený pro `CustTable` nesmí projít při zápisu do `SalesTable`.
+3. **Nový agregátor `prepare_create`** (`src/tools/prepareCreate.ts`) — zrcadlo
+   `prepare_change` pro nové objekty. Jedno volání paralelně vrátí: kolizi jmen
+   (search), validaci namingu (`validateObjectNaming`), vhodné EDT (`suggestEdt`),
+   existující labely (`searchLabels`), doporučený pattern (`getTablePatterns`/
+   `getFormPatterns`) a grounding token. Eliminuje 4–6 kol na 1.
+
+### Pilíř 3 — Datově řízený property/BP engine (properties 100% dle BP)
+
+**Princip: pravidla se těží z indexovaných dat, ne píší z hlavy.**
+
+1. **`property_stats` tabulka** v symbols DB, plněná při `build-database` ze stejných
+   extrahovaných XML, která už parsuje `enhancedParser`/`xmlParser`: pro každý typ uzlu
+   (AxTable, AxTableField*, AxTableIndex, AxFormControl…) a property uložit distribuci
+   hodnot napříč standardními Microsoft modely. Příklad: 98 % AxTable má `Label`,
+   100 % primárních indexů `AllowDuplicates=No` → z toho plynou pravidla.
+2. **`validate_xpp` rozšířit o property vrstvu řízenou daty:** místo dalších hardcoded
+   XML pravidel číst `property_stats` + povinné properties odvozené z toho, co
+   `xppbp.exe` reálně reportuje (mapování BP error kódů, které už parsuje
+   `runBpCheck.ts`). Chybějící/odchylná property → violation s návrhem hodnoty
+   převzaté ze statistiky standardu.
+3. **Generátory čerpají defaulty ze stejné tabulky:** `smartXmlBuilder`,
+   `generate_smart_table/form/report` nastaví properties podle většinové hodnoty
+   standardu pro daný pattern, ne podle literálů v šabloně. Šablona se tak nemůže
+   rozjet s aktuální verzí platformy — při reindexu nové PU se defaulty samy aktualizují.
+4. **Post-write verifikace uvnitř nástroje:** po každém `createobject`/`addfield`/…
+   bridge automaticky zavolá `validateobject` (read-back přes IMetadataProvider) a
+   výsledek vrátí v té samé odpovědi. Žádné extra agentí kolo — nástroj sám potvrdí,
+   že metadata API soubor přečte.
+
+### Pilíř 4 — Kompilace jako strukturovaná brána (`compile_check`)
+
+**Soubor:** rozšíření `src/tools/buildProject.ts` (sdílená infrastruktura), nový tool
+`compile_check`.
+
+1. Model-scoped build (jen model z `.mcp.json`, ne celá solution) — nejlevnější běh
+   skutečného xppc, jediného arbitra kompilovatelnosti.
+2. Výstup parsovat na `{file, line, column, code, message}[]` místo surového logu;
+   každou chybu obohatit o fix z `d365foErrorHelp` (už existuje) — model opraví vše
+   v jednom tahu.
+3. Cache posledního úspěšného buildu per model (hash souborů) → „již ověřeno, beze změn"
+   odpověď za ms.
+4. Zůstává on-demand (pravidlo č. 3 v CLAUDE.template.md se nemění) — ale když uživatel
+   řekne „ověř", je to jedno kolo, ne čtení 5 MB logu.
+
+Invariantní řetěz kvality (každý krok levnější filtr před dražším):
+```
+resolve_references (<200 ms, index)  →  validate_xpp (<50 ms, pravidla+property_stats)
+→  bridge validateobject (read-back)  →  compile_check (xppc, on-demand)
+→  run_bp_check (xppbp, on-demand potvrzení)
+```
+
+### Pilíř 5 — Minimalizace agentic loops
+
+1. **Dedup identických volání:** v `toolHandler` krátká (60 s) response cache klíčovaná
+   `tool+args` — opakované identické volání vrátí cached výsledek s poznámkou
+   „duplicate call", místo aby model čekal na DB/bridge znovu.
+2. **Sekvenční telemetrie:** rozšířit `toolMetrics.ts` o záznam posledních N volání
+   per session (nástroj + hash argumentů). Detekce smyček (3× stejné volání, ping-pong
+   A→B→A) → do odpovědi vložit nápovědu „už ses ptal, odpověď byla X / použij
+   prepare_change". Snapshoty persistovat do `data/` pro vyhodnocení.
+3. **Response contract:** každý read tool vrací sekci `nextAction` (jediný doporučený
+   další krok) — vzor už používá `prepare_change` (`:335`); sjednotit napříč nástroji.
+4. **Batch read:** `batch_search` existuje; doplnit `batch_get_info` (N objektů jedním
+   voláním, interně paralelně jako `prepareChange`).
+5. **Instrukce pod 200 řádků:** `systemInstructions.ts` (349) dál zeštíhlit — vše, co je
+   pravidlo o kódu, patří do `get_xpp_knowledge`; v promptu zůstane jen rozhodovací
+   strom „jaký nástroj kdy" + tvrdé zákazy. Krátké a přesné = účel instrukcí.
+
+### Pilíř 6 — Čerstvost indexu (index = aktuální platforma)
+
+1. **Staleness detektor:** při `get_workspace_info` (povinný první krok dle
+   CLAUDE.template.md) porovnat max(mtime) sledovaných modelů s timestampem posledního
+   indexu (metadata tabulka v DB). Stale → varování + doporučení `update_symbol_index`.
+2. **Auto-reindex změněných souborů:** `debouncedRefresh` v `src/bridge/` už debounced
+   mechanismus má — napojit na file-watcher workspace modelu (jen `D365FO_WORKSPACE_PATH`,
+   ne celé PackagesLocalDirectory), aby lokální editace ve VS byly v indexu do sekund.
+3. **Stáří indexu v odpovědích:** read tooly připojí `indexAge` když index > 24 h starý,
+   aby model i uživatel viděli, z jak čerstvé pravdy se odpovídá.
+
+### Pilíř 7 — Měřitelná spolehlivost (eval harness)
+
+1. **Golden scénáře** v `tests/golden/`: reálné zadání → očekávaný výstup, který musí
+   projít celou bránou (resolve_references čistý, validate_xpp čistý, na Windows CI
+   i compile_check + xppbp). Pokrýt všechny generátory: CoC, event handler, tabulka,
+   forma, report, security artefakt, label.
+2. **CI gate:** každá změna šablon/generátorů musí projít golden testy — regrese typu
+   „`/// ${name} class`" (chyba nalezená v Pillar 2 minulého plánu) se už nemůže vrátit.
+3. **KPI z telemetrie:** průměrný počet tool-volání na dokončený úkol, podíl zápisů
+   odmítnutých groundingem, podíl výstupů prošlých kompilací napoprvé. Cíl: ≥ 95 %
+   kompilace napoprvé, ≤ 3 tool volání na extension úkol.
+
+---
+
+## Pořadí implementace
+
+| Fáze | Změna | Proč v tomto pořadí |
+|------|-------|--------------------|
+| 1 | Pilíř 2.1+2.2 — utěsnit enforcement (create/modify + token vázaný na objekt) | Nejmenší diff, zavírá známou díru vs. dokumentace |
+| 2 | Pilíř 1 — `resolve_references` + zapojení do write nástrojů | Největší dopad na halucinace; staví jen na existujícím indexu |
+| 3 | Pilíř 3.1+3.2 — `property_stats` při build-database + datová pravidla ve `validate_xpp` | Vyžaduje rebuild DB, proto dřív než generátory |
+| 4 | Pilíř 3.3+3.4 — generátory čtou property defaulty; auto `validateobject` po zápisu | Závisí na fázi 3 |
+| 5 | Pilíř 2.3 — `prepare_create` | Zrcadlí hotový `prepare_change` |
+| 6 | Pilíř 4 — `compile_check` se strukturovanými diagnostikami | Nezávislé, Windows-only část |
+| 7 | Pilíř 5 — dedup, sekvenční telemetrie, response contract, batch_get_info | Průřezové, bezpečné po stabilizaci bran |
+| 8 | Pilíř 6 — staleness + auto-reindex | Nezávislé |
+| 9 | Pilíř 7 — golden testy + CI gate + KPI | Zamyká vše předchozí proti regresím |
+
+Každá fáze je samostatně mergovatelná s testy (vzor: čtyři fáze commitu fbc2f76).
+
+## Cílový invariant (po implementaci)
+
+Žádný zápis X++ ani XML neprojde, dokud každý referencovaný symbol, pole, enum,
+label a EDT není doložen v indexu/bridge (fail-closed), property neodpovídají
+statistice standardní platformy a kód neprošel offline pravidly. Kompilátor a xppbp
+pak jen potvrzují, co levné brány už zaručily — a model k tomu potřebuje 1 přípravné
+volání, 1 generaci a 1 zápis.

--- a/src/index.ts
+++ b/src/index.ts
@@ -615,13 +615,13 @@ async function main() {
     });
 
     // Log tool count immediately (transport is already connected)
-    const totalTools = 57;
+    const totalTools = 58;
     const localToolCount = LOCAL_TOOLS.size;
     const toolCount = SERVER_MODE === 'write-only' ? localToolCount :
                      SERVER_MODE === 'read-only' ? totalTools - localToolCount : totalTools;
     const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(LOCAL_TOOLS).join(', ')})` :
                     SERVER_MODE === 'read-only' ? '(all except local tools)' :
-                    '(8 discovery + 7 object-info + 6 intelligent + 4 smart-gen + 3 pattern-analysis + 10 security-ext + 4 file-ops + 7 sdlc-build + 4 labels + 3 code-quality)';
+                    '(8 discovery + 7 object-info + 6 intelligent + 4 smart-gen + 3 pattern-analysis + 10 security-ext + 4 file-ops + 7 sdlc-build + 4 labels + 4 code-quality)';
     console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
@@ -787,6 +787,7 @@ async function main() {
           { name: 'validate_xpp',                 desc: 'Offline BP validator: 13 rules (SEL/COC/BP/XML), <50 ms, no Windows required' },
           { name: 'resolve_references',           desc: 'Semantic resolver: every type/field/method/label in generated code proven against the index' },
           { name: 'prepare_change',               desc: 'Single-call context aggregator: signature + CoC wrappers + grounding token' },
+          { name: 'prepare_create',               desc: 'Single-call aggregator for NEW objects: collisions + naming + EDTs + labels + token' },
         ]},
       ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -615,13 +615,13 @@ async function main() {
     });
 
     // Log tool count immediately (transport is already connected)
-    const totalTools = 56;
+    const totalTools = 57;
     const localToolCount = LOCAL_TOOLS.size;
     const toolCount = SERVER_MODE === 'write-only' ? localToolCount :
                      SERVER_MODE === 'read-only' ? totalTools - localToolCount : totalTools;
     const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(LOCAL_TOOLS).join(', ')})` :
                     SERVER_MODE === 'read-only' ? '(all except local tools)' :
-                    '(8 discovery + 7 object-info + 6 intelligent + 4 smart-gen + 3 pattern-analysis + 10 security-ext + 4 file-ops + 7 sdlc-build + 4 labels + 2 code-quality)';
+                    '(8 discovery + 7 object-info + 6 intelligent + 4 smart-gen + 3 pattern-analysis + 10 security-ext + 4 file-ops + 7 sdlc-build + 4 labels + 3 code-quality)';
     console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
@@ -785,6 +785,7 @@ async function main() {
         ]},
         { icon: '✅', category: 'Code Quality & Grounding', tools: [
           { name: 'validate_xpp',                 desc: 'Offline BP validator: 13 rules (SEL/COC/BP/XML), <50 ms, no Windows required' },
+          { name: 'resolve_references',           desc: 'Semantic resolver: every type/field/method/label in generated code proven against the index' },
           { name: 'prepare_change',               desc: 'Single-call context aggregator: signature + CoC wrappers + grounding token' },
         ]},
       ];

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -7,6 +7,7 @@ import Database from 'better-sqlite3';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { XppSymbol } from './types.js';
+import { isStandardModel } from '../utils/modelClassifier.js';
 
 /**
  * Detect if running in CI environment
@@ -567,6 +568,25 @@ export class XppSymbolIndex {
       CREATE INDEX IF NOT EXISTS idx_mit_name ON menu_item_targets(menu_item_name);
       CREATE INDEX IF NOT EXISTS idx_mit_target ON menu_item_targets(target_object);
       CREATE INDEX IF NOT EXISTS idx_mit_model ON menu_item_targets(model);
+    `);
+
+    // ── Property Statistics ──────────────────────────────────────────────────
+    // Distribution of metadata property values across STANDARD models, mined
+    // during build-database. Drives data-driven BP property rules in
+    // validate_xpp: "what does Microsoft actually set on this node type"
+    // instead of hardcoded rule tables. Presence is encoded as the special
+    // values '(present)' / '(absent)'.
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS property_stats (
+        node_type TEXT NOT NULL,
+        property TEXT NOT NULL,
+        value TEXT NOT NULL,
+        model TEXT NOT NULL,
+        count INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (node_type, property, value, model)
+      );
+      CREATE INDEX IF NOT EXISTS idx_ps_node_prop ON property_stats(node_type, property);
     `);
 
     // ── Extension Metadata ───────────────────────────────────────────────────
@@ -1352,6 +1372,9 @@ export class XppSymbolIndex {
           model,
         });
 
+        // Mine property distribution for data-driven BP rules (standard models only)
+        this.recordTablePropertyStats(tableData, model);
+
         // Add field symbols
         if (tableData.fields && Array.isArray(tableData.fields)) {
           for (const field of tableData.fields) {
@@ -1886,6 +1909,89 @@ export class XppSymbolIndex {
     }
   }
 
+  // ─── Property statistics (data-driven BP rules) ────────────────────────────
+
+  /**
+   * Record one observation of a metadata property value.
+   * Presence checks use the special values '(present)' / '(absent)'.
+   */
+  recordPropertyStat(nodeType: string, property: string, value: string, model: string): void {
+    let stmt = this.stmtCache.get('recordPropertyStat');
+    if (!stmt) {
+      stmt = this.db.prepare(`
+        INSERT INTO property_stats (node_type, property, value, model, count)
+        VALUES (?, ?, ?, ?, 1)
+        ON CONFLICT(node_type, property, value, model) DO UPDATE SET count = count + 1
+      `);
+      this.stmtCache.set('recordPropertyStat', stmt);
+    }
+    stmt.run(nodeType, property, value, model);
+  }
+
+  /**
+   * Ratio of '(present)' observations for a property across all mined models.
+   * Returns total=0 when no statistics exist (validate_xpp falls back to
+   * static defaults in that case).
+   */
+  getPropertyPresenceRatio(nodeType: string, property: string): { present: number; total: number; ratio: number } {
+    const rows = this.getReadDb().prepare(
+      `SELECT value, SUM(count) AS c FROM property_stats
+       WHERE node_type = ? AND property = ? GROUP BY value`,
+    ).all(nodeType, property) as Array<{ value: string; c: number }>;
+    let present = 0;
+    let total = 0;
+    for (const row of rows) {
+      total += row.c;
+      if (row.value === '(present)') present += row.c;
+    }
+    return { present, total, ratio: total > 0 ? present / total : 0 };
+  }
+
+  /** Most common values for a property, ordered by observation count. */
+  getPropertyValueDistribution(
+    nodeType: string,
+    property: string,
+    limit = 10,
+  ): Array<{ value: string; count: number }> {
+    return this.getReadDb().prepare(
+      `SELECT value, SUM(count) AS count FROM property_stats
+       WHERE node_type = ? AND property = ? AND value NOT IN ('(present)', '(absent)')
+       GROUP BY value ORDER BY count DESC LIMIT ?`,
+    ).all(nodeType, property, limit) as Array<{ value: string; count: number }>;
+  }
+
+  /**
+   * Mine property statistics from one parsed table JSON. Only standard
+   * (Microsoft) models are mined — the stats answer "what does the standard
+   * platform do", not "what did our customizations do".
+   */
+  private recordTablePropertyStats(tableData: any, model: string): void {
+    if (!isStandardModel(model)) return;
+    const presence = (v: unknown) => (v ? '(present)' : '(absent)');
+    try {
+      // xmlParser defaults label to the table name — same value means no real label
+      const hasLabel = !!tableData.label && tableData.label !== tableData.name;
+      this.recordPropertyStat('AxTable', 'Label', presence(hasLabel), model);
+      this.recordPropertyStat('AxTable', 'TableGroup', tableData.tableGroup || '(absent)', model);
+      this.recordPropertyStat('AxTable', 'PrimaryIndex', presence(tableData.primaryIndex), model);
+      this.recordPropertyStat('AxTable', 'ClusteredIndex', presence(tableData.clusteredIndex), model);
+      const indexes = Array.isArray(tableData.indexes) ? tableData.indexes : [];
+      this.recordPropertyStat(
+        'AxTable', 'AlternateKeyIndex',
+        presence(indexes.some((i: any) => i?.unique)), model,
+      );
+      const fields = Array.isArray(tableData.fields) ? tableData.fields : [];
+      for (const field of fields) {
+        this.recordPropertyStat(
+          'AxTableField', 'ExtendedDataType',
+          presence(field?.extendedDataType || field?.enumType), model,
+        );
+      }
+    } catch {
+      // Statistics are best-effort — never fail the indexing pass
+    }
+  }
+
   /**
    * Get class methods for autocomplete
    */
@@ -2348,6 +2454,7 @@ export class XppSymbolIndex {
     this.db.exec('DELETE FROM security_role_duties');
     this.db.exec('DELETE FROM menu_item_targets');
     this.db.exec('DELETE FROM extension_metadata');
+    this.db.exec('DELETE FROM property_stats');
     this.vacuum();
   }
 
@@ -2376,6 +2483,7 @@ export class XppSymbolIndex {
       this.db.prepare(`DELETE FROM security_role_duties WHERE model IN (${placeholders})`).run(...modelNames);
       this.db.prepare(`DELETE FROM menu_item_targets WHERE model IN (${placeholders})`).run(...modelNames);
       this.db.prepare(`DELETE FROM extension_metadata WHERE model IN (${placeholders})`).run(...modelNames);
+      this.db.prepare(`DELETE FROM property_stats WHERE model IN (${placeholders})`).run(...modelNames);
     });
     deleteAll();
 

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -140,10 +140,15 @@ After the call, read the response: \`isError=true\` means the change did NOT app
 3. Incorrect signatures cause compilation errors
 
 ### 3. Code Generation Workflow
-**For ANY code generation request:**
-1. \`analyze_code_patterns(scenario)\` - learn from real codebase
-2. \`search(...)\` - find similar implementations
-3. \`get_class_info(...)\` or \`get_table_info(...)\` - understand dependencies
+**Extension work (CoC, event handler, table/form extension) — 3 calls total:**
+1. \`prepare_change(goal, objectName, methodName?)\` — ONE call returns signature, existing CoC wrappers, eligibility, strategy + \`groundingToken\`
+2. Generate the code, then \`resolve_references(code)\` + \`validate_xpp(code)\` — fix any errors in the same turn
+3. \`create_d365fo_file\`/\`modify_d365fo_file\` with \`groundingToken\`
+
+**New objects:**
+1. \`analyze_code_patterns(scenario)\` / \`search(...)\` - learn from real codebase
+2. \`get_class_info(...)\` or \`get_table_info(...)\` - understand dependencies
+3. Generate, then \`resolve_references(code)\` — every type/field/method/label must be proven by the index
 4. \`generate_code(...)\` or \`create_d365fo_file(...)\` - create with correct patterns
 5. **NEVER run \`build_d365fo_project()\` automatically.** Builds take a long time and block the user. After completing changes, tell the user the changes are done and they can build manually when ready. Only run \`build_d365fo_project()\` when the user explicitly requests it ("build", "compile", "check errors"). If after a requested build there are X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
 
@@ -175,10 +180,10 @@ PowerShell and Python scripts hang indefinitely in VS 2022 MCP integration. When
 3. \`create_d365fo_file(objectType="class", objectName="MyDimHelper", addToProject=true)\`
 
 ### Creating Chain of Command Extension
-1. \`get_method_signature("CustTable", "validateWrite")\` → exact signature
-2. \`find_coc_extensions("CustTable")\` → check existing wrappers
-3. \`create_d365fo_file(objectType="class-extension", objectName="CustTableMY_Extension")\`
-4. Confirm the wrapper in chat, then \`modify_d365fo_file(operation="add-method", sourceCode="<CoC wrapper>")\` (applies immediately)
+1. \`prepare_change(goal="...", objectName="CustTable", methodName="validateWrite")\` → signature + existing wrappers + \`groundingToken\` (replaces get_method_signature + find_coc_extensions)
+2. Generate wrapper → \`resolve_references(code)\` → fix errors
+3. \`create_d365fo_file(objectType="class-extension", objectName="CustTableMY_Extension", groundingToken=...)\`
+4. Confirm the wrapper in chat, then \`modify_d365fo_file(operation="add-method", sourceCode="<CoC wrapper>", groundingToken=...)\` (applies immediately)
 
 ### Finding Methods
 - Semantic (concept): \`search("total", type="method")\`

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -145,11 +145,10 @@ After the call, read the response: \`isError=true\` means the change did NOT app
 2. Generate the code, then \`resolve_references(code)\` + \`validate_xpp(code)\` — fix any errors in the same turn
 3. \`create_d365fo_file\`/\`modify_d365fo_file\` with \`groundingToken\`
 
-**New objects:**
-1. \`analyze_code_patterns(scenario)\` / \`search(...)\` - learn from real codebase
-2. \`get_class_info(...)\` or \`get_table_info(...)\` - understand dependencies
-3. Generate, then \`resolve_references(code)\` — every type/field/method/label must be proven by the index
-4. \`generate_code(...)\` or \`create_d365fo_file(...)\` - create with correct patterns
+**New objects — 3 calls total:**
+1. \`prepare_create(goal, objectName, objectType, fieldsHint?)\` — ONE call returns collision check, naming, similar objects, EDT suggestions, reusable labels, property defaults + \`groundingToken\`
+2. Generate the object, then \`resolve_references(code)\` + \`validate_xpp(code)\` — fix any errors in the same turn
+3. \`create_d365fo_file(..., groundingToken=...)\`
 5. **NEVER run \`build_d365fo_project()\` automatically.** Builds take a long time and block the user. After completing changes, tell the user the changes are done and they can build manually when ready. Only run \`build_d365fo_project()\` when the user explicitly requests it ("build", "compile", "check errors"). If after a requested build there are X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
 
 ### 4. Semantic vs. Prefix Search

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -591,6 +591,13 @@ SourceCode format for classes: class declaration with member vars inside { }, me
                   '\u274c NEVER use PowerShell/create_file to overwrite D365FO objects \u2014 always use overwrite=true here.',
                 default: false,
               },
+              groundingToken: {
+                type: 'string',
+                description:
+                  'Provenance token returned by prepare_change. Proves the change was grounded in the indexed codebase. ' +
+                  'Required for *-extension objectTypes when GROUNDING_ENFORCE=true on the server. ' +
+                  'The token is object-bound: it only authorizes writes to the object it was issued for.',
+              },
             },
             required: ['objectType', 'objectName'],
           },
@@ -921,6 +928,13 @@ SourceCode format for classes: class declaration with member vars inside { }, me
               workspacePath: {
                 type: 'string',
                 description: 'Path to workspace for finding file'
+              },
+              groundingToken: {
+                type: 'string',
+                description:
+                  'Provenance token returned by prepare_change. Proves the change was grounded in the indexed codebase. ' +
+                  'Required for *-extension objectTypes when GROUNDING_ENFORCE=true on the server. ' +
+                  'The token is object-bound: it only authorizes writes to the object it was issued for.',
               },
             },
             required: ['objectType', 'objectName', 'operation'],

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -2094,6 +2094,44 @@ SourceCode format for classes: class declaration with member vars inside { }, me
           required: ['goal', 'objectName'],
         },
       },
+      {
+        name: 'prepare_create',
+        description:
+          'Single-round context aggregator for creating NEW D365FO objects (mirror of prepare_change). ' +
+          'Returns in ONE call: name collision check, naming validation with the auto-applied prefix, ' +
+          'similar existing objects to copy patterns from, EDT suggestions for planned fields, ' +
+          'reusable labels, mined property defaults (standard-model statistics), and a grounding token. ' +
+          'Replaces the search → validate_object_naming → suggest_edt → search_labels sequence with one call. ' +
+          'Call BEFORE generating any new object.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            goal: {
+              type: 'string',
+              description: 'One-sentence description of what the new object is for. Example: "Parameter table for the Contoso import feature."',
+            },
+            objectName: {
+              type: 'string',
+              description: 'Proposed BASE name WITHOUT model prefix (same value you would pass to create_d365fo_file). Example: "ImportParameters".',
+            },
+            objectType: {
+              type: 'string',
+              enum: [
+                'class', 'table', 'form', 'enum', 'edt', 'query', 'view',
+                'data-entity', 'report', 'menu-item-display', 'menu-item-action',
+                'menu-item-output', 'security-privilege', 'security-duty', 'security-role',
+              ],
+              description: 'Type of the new D365FO object.',
+            },
+            fieldsHint: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'For tables/views: planned field names — each gets EDT suggestions from the index.',
+            },
+          },
+          required: ['goal', 'objectName', 'objectType'],
+        },
+      },
     ],
     };
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -2008,7 +2008,9 @@ SourceCode format for classes: class declaration with member vars inside { }, me
           '[ExtensionOf] class not final (COC002), class not ending _Extension (COC003), ' +
           'CoC default param values (COC001), hardcoded strings in info/warning/error (BP001), ' +
           'doInsert/doUpdate/doDelete misuse (BP002), generic doc-comments (BP003), ' +
-          'missing AlternateKey on table XML (XML001).',
+          'missing AlternateKey on table XML (XML001). ' +
+          'Plus data-driven property rules mined from standard models (XML002 Label, ' +
+          'XML003 TableGroup, XML004 field EDT, XML005 ClusteredIndex).',
         inputSchema: {
           type: 'object',
           properties: {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -2031,6 +2031,31 @@ SourceCode format for classes: class declaration with member vars inside { }, me
         },
       },
       {
+        name: 'resolve_references',
+        description:
+          'Semantic reference resolver (<200 ms, index-only) — verifies that every type, ' +
+          'table field, method (incl. arity), enum, label and intrinsic target (tableStr, ' +
+          'fieldStr, classStr, …) in generated X++ code EXISTS in the indexed codebase. ' +
+          'Catches hallucinated symbols BEFORE the compiler does. ' +
+          'Call AFTER generating code and BEFORE create_d365fo_file / modify_d365fo_file. ' +
+          'Returns structured violations {kind, severity, line, identifier, detail} — fix errors in the same turn. ' +
+          'When GROUNDING_ENFORCE=true, write tools run this check internally and reject code with errors.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            code: {
+              type: 'string',
+              description: 'X++ source code to resolve. Paste the full generated method/class text.',
+            },
+            context: {
+              type: 'string',
+              description: 'Optional: owning class/table name, used in diagnostic messages.',
+            },
+          },
+          required: ['code'],
+        },
+      },
+      {
         name: 'prepare_change',
         description:
           'Single-round context aggregator for D365FO extension work. ' +

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -1860,6 +1860,7 @@ export async function codeGenTool(request: CallToolRequest) {
       const groundingError = enforceGrounding(
         args.groundingToken,
         `generate_code(pattern="${args.pattern}", name="${args.name}")`,
+        args.name,
       );
       if (groundingError) return groundingError;
 

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -14,6 +14,7 @@ import { PackageResolver } from '../utils/packageResolver.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
 import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject } from '../bridge/index.js';
+import { enforceGrounding } from '../utils/provenanceStore.js';
 import { invalidateCache } from './updateSymbolIndex.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 
@@ -108,6 +109,13 @@ const CreateD365FileArgsSchema = z.object({
     .describe(
       'Allow overwriting an existing file. Use together with xmlContent when you need to completely ' +
       'rewrite an object (e.g. table with corrupted field names). Default: false (returns error if file already exists).'
+    ),
+  groundingToken: z
+    .string()
+    .optional()
+    .describe(
+      'Provenance token returned by prepare_change. Proves the change was grounded in the indexed codebase. ' +
+      'Required for *-extension objectTypes when GROUNDING_ENFORCE=true on the server.'
     ),
 });
 
@@ -3313,6 +3321,18 @@ export async function handleCreateD365File(
   },
 ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
   const args = CreateD365FileArgsSchema.parse(request.params.arguments);
+
+  // Grounding enforcement: extension objects modify the behaviour of existing
+  // code, so when GROUNDING_ENFORCE=true the model must prove (via prepare_change)
+  // that it inspected the real object before writing the extension.
+  if (args.objectType.endsWith('-extension')) {
+    const groundingError = enforceGrounding(
+      args.groundingToken,
+      `create_d365fo_file(objectType="${args.objectType}", objectName="${args.objectName}")`,
+      args.objectName,
+    );
+    if (groundingError) return groundingError;
+  }
 
   try {
     // Step 1: Try to find and parse .rnrproj to get actual ModelName

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -15,6 +15,7 @@ import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
 import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject } from '../bridge/index.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
+import { gateOnReferenceErrors } from './resolveReferences.js';
 import { invalidateCache } from './updateSymbolIndex.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 
@@ -3318,6 +3319,7 @@ export async function handleCreateD365File(
   context?: {
     bridge?: import('../bridge/bridgeClient.js').BridgeClient;
     cache?: import('../cache/redisCache.js').RedisCacheService;
+    symbolIndex?: import('../metadata/symbolIndex.js').XppSymbolIndex;
   },
 ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
   const args = CreateD365FileArgsSchema.parse(request.params.arguments);
@@ -3333,6 +3335,15 @@ export async function handleCreateD365File(
     );
     if (groundingError) return groundingError;
   }
+
+  // Semantic reference gate: when GROUNDING_ENFORCE=true, every identifier in the
+  // X++ source must be proven against the symbol index before it reaches disk.
+  const referenceError = gateOnReferenceErrors(
+    args.sourceCode,
+    context?.symbolIndex,
+    `create_d365fo_file(objectType="${args.objectType}", objectName="${args.objectName}")`,
+  );
+  if (referenceError) return referenceError;
 
   try {
     // Step 1: Try to find and parse .rnrproj to get actual ModelName

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -29,6 +29,7 @@ import {
 import { invalidateCache } from './updateSymbolIndex.js';
 import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
+import { enforceGrounding } from '../utils/provenanceStore.js';
 
 /**
  * Decode the standard XML entities (&lt;, &gt;, &apos;, &quot;, &amp;) and normalise
@@ -367,11 +368,28 @@ const ModifyD365FileArgsSchema = z.object({
   solutionPath: z.string().optional().describe(
     'Path to VS solution directory. Used to find .rnrproj when projectPath is not given.'
   ),
+  groundingToken: z.string().optional().describe(
+    'Provenance token returned by prepare_change. Proves the change was grounded in the indexed codebase. ' +
+    'Required for *-extension objectTypes when GROUNDING_ENFORCE=true on the server.'
+  ),
 });
 
 export async function modifyD365FileTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = ModifyD365FileArgsSchema.parse(request.params.arguments);
+
+    // Grounding enforcement: modifying an extension changes the behaviour of an
+    // existing base object — when GROUNDING_ENFORCE=true the model must prove
+    // (via prepare_change) that it inspected the real object first.
+    if (args.objectType.endsWith('-extension')) {
+      const groundingError = enforceGrounding(
+        args.groundingToken,
+        `modify_d365fo_file(objectType="${args.objectType}", objectName="${args.objectName}", operation="${args.operation}")`,
+        args.objectName,
+      );
+      if (groundingError) return groundingError;
+    }
+
     const { symbolIndex } = context;
     const {
       objectType,

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -30,6 +30,7 @@ import { invalidateCache } from './updateSymbolIndex.js';
 import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
+import { gateOnReferenceErrors } from './resolveReferences.js';
 
 /**
  * Decode the standard XML entities (&lt;, &gt;, &apos;, &quot;, &amp;) and normalise
@@ -389,6 +390,16 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       );
       if (groundingError) return groundingError;
     }
+
+    // Semantic reference gate: when GROUNDING_ENFORCE=true, every identifier in
+    // X++ source about to be written must be proven against the symbol index.
+    const xppToWrite = args.sourceCode ?? args.methodCode ?? args.newCode;
+    const referenceError = gateOnReferenceErrors(
+      xppToWrite,
+      context.symbolIndex,
+      `modify_d365fo_file(objectType="${args.objectType}", objectName="${args.objectName}", operation="${args.operation}")`,
+    );
+    if (referenceError) return referenceError;
 
     const { symbolIndex } = context;
     const {

--- a/src/tools/prepareChange.ts
+++ b/src/tools/prepareChange.ts
@@ -279,6 +279,7 @@ export async function prepareChangeTool(request: any, context: XppServerContext)
     objectName,
     methodName,
     objectType: resolvedType,
+    proposedName,
     methodSignature: sigText ?? undefined,
     cocExtensions: cocText,
     extensionEligibility: eligText,
@@ -333,10 +334,11 @@ export async function prepareChangeTool(request: any, context: XppServerContext)
   lines.push(
     process.env.GROUNDING_ENFORCE === 'true'
       ? '⚠️  **GROUNDING_ENFORCE=true** — pass `groundingToken` to `generate_code` ' +
-        '(extension patterns) and `create_d365fo_file` (extension objectTypes). ' +
+        '(extension patterns), `create_d365fo_file` and `modify_d365fo_file` (extension objectTypes). ' +
+        `The token is bound to \`${objectName}\` — it does not authorize writes to other objects. ` +
         'Token expires in 30 minutes.'
-      : 'ℹ️  Pass `groundingToken` to `generate_code` or `create_d365fo_file` to confirm ' +
-        'this context was used. Set `GROUNDING_ENFORCE=true` to require it.',
+      : 'ℹ️  Pass `groundingToken` to `generate_code`, `create_d365fo_file` or `modify_d365fo_file` ' +
+        'to confirm this context was used. Set `GROUNDING_ENFORCE=true` to require it.',
   );
 
   return {

--- a/src/tools/prepareCreate.ts
+++ b/src/tools/prepareCreate.ts
@@ -1,0 +1,272 @@
+/**
+ * prepare_create — single-round context aggregator for NEW D365FO objects.
+ *
+ * Mirror of prepare_change for object creation: one call replaces the
+ * search → validate_object_naming → suggest_edt → search_labels → patterns
+ * sequence (4–6 agentic rounds) with a single parallel query bundle:
+ *   - name collision check (exact + prefix variants) against the symbol index
+ *   - naming validation incl. the prefix the write tool will actually apply
+ *   - similar existing objects to copy patterns from
+ *   - EDT suggestions for planned table fields (edt_metadata + symbols)
+ *   - reusable existing labels matching the object name
+ *   - mined property defaults from property_stats (what standard models set)
+ *   - grounding token (object-bound, 30-min TTL)
+ */
+
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+import { createProvenanceToken } from '../utils/provenanceStore.js';
+import { getConfigManager } from '../utils/configManager.js';
+import { resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+
+export const prepareCreateArgsSchema = z.object({
+  goal: z.string().describe(
+    'One-sentence description of what the new object is for. ' +
+    'Example: "Parameter table for the Contoso import feature."',
+  ),
+  objectName: z.string().describe(
+    'Proposed BASE name of the new object WITHOUT model prefix ' +
+    '(the same value you would pass to create_d365fo_file). Example: "ImportParameters".',
+  ),
+  objectType: z.enum([
+    'class', 'table', 'form', 'enum', 'edt', 'query', 'view',
+    'data-entity', 'report', 'menu-item-display', 'menu-item-action',
+    'menu-item-output', 'security-privilege', 'security-duty', 'security-role',
+  ]).describe('Type of the new D365FO object.'),
+  fieldsHint: z.array(z.string()).optional().describe(
+    'For tables/views: planned field names (e.g. ["CustAccount", "ImportDate", "Qty"]). ' +
+    'Each gets EDT suggestions from the index.',
+  ),
+});
+
+// ── Lookups (all index-only, run in parallel) ────────────────────────────────
+
+/** Exact + prefixed collision check. */
+function checkCollisions(
+  finalName: string,
+  baseName: string,
+  context: XppServerContext,
+): string {
+  try {
+    const db = context.symbolIndex.getReadDb();
+    const rows = db.prepare(
+      `SELECT DISTINCT name, type, model FROM symbols
+       WHERE name IN (?, ?) COLLATE NOCASE
+          AND parent_name IS NULL
+       LIMIT 10`,
+    ).all(finalName, baseName) as Array<{ name: string; type: string; model: string }>;
+    if (rows.length > 0) {
+      return rows
+        .map(r => `⚠️  "${r.name}" already exists as ${r.type} in model "${r.model}" — pick a different name or extend it instead.`)
+        .join('\n');
+    }
+    return `✅ No collision — neither "${finalName}" nor "${baseName}" exists in the index.`;
+  } catch {
+    return '(collision check unavailable — index not ready)';
+  }
+}
+
+/** Naming validation incl. the prefix create_d365fo_file will apply. */
+function validateNaming(baseName: string, finalName: string, modelName: string | undefined): string {
+  const issues: string[] = [];
+  if (finalName.length > 81) {
+    issues.push(`❌ Final name "${finalName}" exceeds the 81-char AOT limit (${finalName.length}).`);
+  }
+  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(baseName)) {
+    issues.push('❌ Name may contain only letters, digits and underscores, and must not start with a digit.');
+  }
+  if (!/^[A-Z]/.test(baseName)) {
+    issues.push('❌ Name must start with an uppercase letter (PascalCase).');
+  }
+  const lines = [
+    `Base name   : ${baseName}`,
+    `Final name  : ${finalName}${finalName !== baseName ? ' _(prefix auto-applied by create_d365fo_file)_' : ''}`,
+    `Model       : ${modelName ?? '(not configured — set modelName or .mcp.json)'}`,
+  ];
+  if (issues.length > 0) lines.push(...issues);
+  else lines.push('✅ Naming looks valid.');
+  return lines.join('\n');
+}
+
+/** Similar existing objects worth copying patterns from. */
+function findSimilarObjects(
+  baseName: string,
+  objectType: string,
+  context: XppServerContext,
+): string {
+  try {
+    const db = context.symbolIndex.getReadDb();
+    // Split CamelCase into tokens and search for the most specific ones
+    const tokens = baseName.split(/(?=[A-Z])/).filter(t => t.length >= 4);
+    const needle = tokens.length > 0 ? tokens[tokens.length - 1] : baseName;
+    const rows = db.prepare(
+      `SELECT name, model FROM symbols
+       WHERE type = ? AND name LIKE ? AND parent_name IS NULL
+       ORDER BY LENGTH(name) LIMIT 5`,
+    ).all(objectType, `%${needle}%`) as Array<{ name: string; model: string }>;
+    if (rows.length > 0) {
+      return rows.map(r => `  ${r.name} (${r.model})`).join('\n') +
+        `\n_Use get_${objectType === 'table' ? 'table' : 'class'}_info or copyFrom in generate_smart_* to reuse their structure._`;
+    }
+  } catch {
+    // ignore
+  }
+  return '(no similar objects found — greenfield)';
+}
+
+/** EDT suggestions for planned table fields. */
+function suggestEdtsForFields(
+  fieldsHint: string[],
+  context: XppServerContext,
+): string {
+  const lines: string[] = [];
+  try {
+    const db = context.symbolIndex.getReadDb();
+    const stmt = db.prepare(
+      `SELECT name, signature FROM symbols
+       WHERE type = 'edt' AND name LIKE ? ORDER BY LENGTH(name) LIMIT 3`,
+    );
+    for (const field of fieldsHint.slice(0, 10)) {
+      const tokens = field.split(/(?=[A-Z])/).filter(t => t.length >= 3);
+      const needle = tokens.length > 0 ? tokens[tokens.length - 1] : field;
+      const rows = stmt.all(`%${needle}%`) as Array<{ name: string; signature: string | null }>;
+      lines.push(
+        rows.length > 0
+          ? `  ${field} → ${rows.map(r => r.name + (r.signature ? ` (extends ${r.signature})` : '')).join(', ')}`
+          : `  ${field} → (no EDT match — use suggest_edt("${field}") or base it on a primitive + label)`,
+      );
+    }
+  } catch {
+    return '(EDT lookup unavailable)';
+  }
+  return lines.join('\n');
+}
+
+/** Existing labels that could be reused for the new object. */
+function findReusableLabels(baseName: string, context: XppServerContext): string {
+  try {
+    const words = baseName.replace(/([A-Z])/g, ' $1').trim();
+    const rows = context.symbolIndex.searchLabels(words, { language: 'en-us', limit: 5 });
+    if (rows.length > 0) {
+      return rows
+        .map(r => `  @${r.labelFileId}:${r.labelId} = "${r.text}" (${r.model})`)
+        .join('\n') + '\n_Reuse instead of creating duplicates (rule: search_labels before create_label)._';
+    }
+  } catch {
+    // ignore
+  }
+  return '(no matching labels — create new ones via create_label)';
+}
+
+/** Mined property defaults for the object type (tables only for now). */
+function minedPropertyDefaults(objectType: string, context: XppServerContext): string {
+  if (objectType !== 'table') return '';
+  try {
+    const idx = context.symbolIndex as unknown as {
+      getPropertyPresenceRatio(n: string, p: string): { present: number; total: number; ratio: number };
+      getPropertyValueDistribution(n: string, p: string, l?: number): Array<{ value: string; count: number }>;
+    };
+    if (typeof idx.getPropertyPresenceRatio !== 'function') return '';
+    const lines: string[] = [];
+    for (const prop of ['Label', 'TableGroup', 'PrimaryIndex', 'ClusteredIndex', 'AlternateKeyIndex']) {
+      const r = idx.getPropertyPresenceRatio('AxTable', prop);
+      if (r.total === 0) continue;
+      lines.push(`  ${prop}: set by ${Math.round(r.ratio * 100)}% of standard tables${r.ratio >= 0.8 ? ' → REQUIRED' : ''}`);
+    }
+    const dist = idx.getPropertyValueDistribution('AxTable', 'TableGroup', 4);
+    if (dist.length > 0) {
+      const total = dist.reduce((s, d) => s + d.count, 0);
+      lines.push(`  TableGroup values: ${dist.map(d => `${d.value} (${Math.round((d.count / total) * 100)}%)`).join(', ')}`);
+    }
+    if (lines.length > 0) {
+      return lines.join('\n');
+    }
+  } catch {
+    // ignore
+  }
+  return '(no mined statistics — run build-database to mine standard models)';
+}
+
+// ── Tool handler ──────────────────────────────────────────────────────────────
+
+export async function prepareCreateTool(request: any, context: XppServerContext): Promise<any> {
+  const raw = request?.params?.arguments ?? request;
+  const parsed = prepareCreateArgsSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: `❌ Invalid parameters: ${parsed.error.message}` }],
+    };
+  }
+
+  const { goal, objectName, objectType, fieldsHint } = parsed.data;
+  const modelName = getConfigManager().getModelName() ?? undefined;
+  const prefix = resolveObjectPrefix(modelName ?? '');
+  const finalName = prefix ? applyObjectPrefix(objectName, prefix) : objectName;
+
+  // All lookups are synchronous index queries — run them in one tick.
+  const [collisions, naming, similar, edts, labels, propertyDefaults] = [
+    checkCollisions(finalName, objectName, context),
+    validateNaming(objectName, finalName, modelName),
+    findSimilarObjects(objectName, objectType, context),
+    fieldsHint && fieldsHint.length > 0 ? suggestEdtsForFields(fieldsHint, context) : '',
+    findReusableLabels(objectName, context),
+    minedPropertyDefaults(objectType, context),
+  ];
+
+  const token = createProvenanceToken({
+    goal,
+    objectName,
+    objectType,
+    proposedName: finalName,
+  });
+
+  const lines: string[] = [
+    `# prepare_create — ${objectType} \`${finalName}\``,
+    '',
+    `**Goal:** ${goal}`,
+    '',
+    '### Collision check _(symbol index)_',
+    collisions,
+    '',
+    '### Naming',
+    naming,
+    '',
+    '### Similar existing objects _(copy patterns from these)_',
+    similar,
+    '',
+  ];
+  if (edts) {
+    lines.push('### EDT suggestions for planned fields _(edt index)_', edts, '');
+  }
+  lines.push('### Reusable labels _(labels index)_', labels, '');
+  if (propertyDefaults) {
+    lines.push('### Property defaults _(mined from standard models)_', propertyDefaults, '');
+  }
+  lines.push('---');
+  lines.push(`**Grounding token:** \`${token}\``);
+  lines.push('');
+  lines.push(
+    'Next: generate the object, run `resolve_references` + `validate_xpp` on the result, ' +
+    `then call \`create_d365fo_file(objectType="${objectType}", objectName="${objectName}", groundingToken=...)\`. ` +
+    'The token is bound to this object and expires in 30 minutes.',
+  );
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
+  };
+}
+
+export const prepareCreateToolDefinition = {
+  name: 'prepare_create',
+  description:
+    'Single-round context aggregator for creating NEW D365FO objects (mirror of prepare_change). ' +
+    'Returns in ONE call: name collision check, naming validation with the auto-applied prefix, ' +
+    'similar existing objects to copy patterns from, EDT suggestions for planned fields, ' +
+    'reusable labels, mined property defaults (standard-model statistics), and a grounding token. ' +
+    'Replaces the search → validate_object_naming → suggest_edt → search_labels sequence with one call. ' +
+    'Call BEFORE generating any new object.',
+  inputSchema: prepareCreateArgsSchema,
+};

--- a/src/tools/resolveReferences.ts
+++ b/src/tools/resolveReferences.ts
@@ -1,0 +1,879 @@
+/**
+ * resolve_references — semantic reference resolver for generated X++ code.
+ *
+ * Anti-hallucination gate: extracts every external identifier from an X++
+ * snippet and verifies it against the indexed codebase (symbols DB, labels DB,
+ * extension_metadata, menu_item_targets). Nothing is assumed from training
+ * data — a reference is either proven by the index or reported.
+ *
+ * Verified reference kinds:
+ *   - Intrinsic functions: classStr/tableStr/fieldStr/enumStr/extendedTypeStr/
+ *     formStr/queryStr/methodStr/menuItem*Str(...) — args are compile-time
+ *     checked by the real X++ compiler, so they must exist in the index
+ *   - Static member access  Type::member  (incl. arity check from signature)
+ *   - Variable declarations TypeName varName — type must exist
+ *   - Bound buffer access   buffer.Field / buffer.method() when the variable
+ *     was declared in the snippet with a table/view type from the index
+ *   - Label references      "@File:Id" and legacy "@SYS12345"
+ *
+ * Severity model (conservative — false blocks are worse than misses):
+ *   error   — intrinsic target missing, static type/method missing,
+ *             field missing on a confidently-bound table, arity mismatch,
+ *             modern label id missing in a known label file
+ *   warning — unknown declared type (kernel classes are not in metadata XML),
+ *             instance method missing, legacy label not found,
+ *             label file unknown (may be created later in the same task)
+ */
+
+import { z } from 'zod';
+import type { XppServerContext } from '../types/context.js';
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+
+export const resolveReferencesArgsSchema = z.object({
+  code: z.string().describe(
+    'X++ source code to resolve. Paste the full generated method/class text.'
+  ),
+  context: z.string().optional().describe(
+    'Optional: owning class/table name, used in diagnostic messages.'
+  ),
+});
+
+export const resolveReferencesToolDefinition = {
+  name: 'resolve_references',
+  description:
+    'Semantic reference resolver (<200 ms, index-only) — verifies that every type, ' +
+    'table field, method (incl. arity), enum, label and intrinsic target (tableStr, ' +
+    'fieldStr, classStr, …) in generated X++ code EXISTS in the indexed codebase. ' +
+    'Catches hallucinated symbols BEFORE the compiler does. ' +
+    'Call AFTER generating code and BEFORE create_d365fo_file / modify_d365fo_file. ' +
+    'Returns {kind, severity, line, identifier, detail}[] — fix errors in the same turn. ' +
+    'When GROUNDING_ENFORCE=true, write tools run this check internally and reject code with errors.',
+  inputSchema: resolveReferencesArgsSchema,
+};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface ReferenceViolation {
+  kind:
+    | 'unknown-type'
+    | 'unknown-static-member'
+    | 'unknown-method'
+    | 'unknown-field'
+    | 'unknown-label'
+    | 'unknown-intrinsic-target'
+    | 'arity-mismatch';
+  severity: 'error' | 'warning';
+  line: number;
+  identifier: string;
+  detail: string;
+}
+
+export interface ResolveResult {
+  violations: ReferenceViolation[];
+  /** Count of references that were positively verified against the index */
+  verifiedCount: number;
+}
+
+/** Minimal DB surface the resolver needs — satisfied by better-sqlite3. */
+export interface ResolverDeps {
+  db: {
+    prepare(sql: string): {
+      get(...params: unknown[]): unknown;
+      all(...params: unknown[]): unknown[];
+    };
+  };
+  getLabelById(
+    labelId: string,
+    labelFileId?: string,
+  ): Array<{ labelId: string; labelFileId: string }>;
+  getLabelFileIds(): Array<{ labelFileId: string }>;
+}
+
+// ── X++ language tables ───────────────────────────────────────────────────────
+
+const XPP_KEYWORDS = new Set([
+  'abstract', 'anytype', 'as', 'asc', 'at', 'avg', 'break', 'breakpoint', 'by',
+  'byref', 'case', 'catch', 'changecompany', 'class', 'client', 'const', 'container',
+  'continue', 'count', 'crosscompany', 'default', 'delegate', 'delete_from', 'desc',
+  'display', 'div', 'do', 'edit', 'element', 'else', 'eventhandler', 'exists',
+  'extends', 'false', 'final', 'finally', 'firstfast', 'firstonly', 'firstonly10',
+  'firstonly100', 'firstonly1000', 'flush', 'for', 'forceliterals', 'forcenestedloop',
+  'forceplaceholders', 'forceselectorder', 'forupdate', 'from', 'generateonly',
+  'group', 'if', 'implements', 'index', 'insert_recordset', 'interface', 'internal',
+  'is', 'join', 'like', 'maxof', 'minof', 'mod', 'new', 'next', 'nofetch',
+  'notexists', 'null', 'optimisticlock', 'order', 'outer', 'pause', 'pessimisticlock',
+  'print', 'private', 'protected', 'public', 'readonly', 'repeatableread', 'retry',
+  'return', 'reverse', 'select', 'server', 'setting', 'static', 'sum', 'super',
+  'switch', 'tablelock', 'this', 'throw', 'true', 'try', 'ttsabort', 'ttsbegin',
+  'ttscommit', 'update_recordset', 'using', 'validtimestate', 'void', 'where',
+  'while', 'window',
+]);
+
+const XPP_BUILTIN_TYPES = new Set([
+  'int', 'int64', 'real', 'str', 'boolean', 'date', 'utcdatetime', 'timeofday',
+  'anytype', 'container', 'guid', 'void', 'var',
+]);
+
+/**
+ * Kernel (binary) classes are NOT present in PackagesLocalDirectory metadata
+ * XML, so the index cannot prove them. Common ones are allow-listed; unknown
+ * declared types degrade to warnings precisely because this list is not
+ * exhaustive.
+ */
+const KERNEL_TYPES = new Set([
+  'object', 'xrecord', 'common', 'xsession', 'xinfo', 'xglobal', 'xapplication',
+  'xversion', 'args', 'classfactory',
+  // Forms
+  'formrun', 'formdatasource', 'formdataobject', 'formcontrol', 'formdesign',
+  'formstringcontrol', 'formbuttoncontrol', 'formcheckboxcontrol',
+  'formcomboboxcontrol', 'formdatecontrol', 'formdatetimecontrol',
+  'formintcontrol', 'formint64control', 'formrealcontrol', 'formgridcontrol',
+  'formgroupcontrol', 'formtabcontrol', 'formtabpagecontrol',
+  'formreferencegroupcontrol', 'formfunctionbuttoncontrol',
+  'formcommandbuttoncontrol', 'formmenubuttoncontrol', 'formactionpanecontrol',
+  'formactionpanetabcontrol', 'formbuttongroupcontrol', 'formstaticcontrol',
+  'formwindowcontrol', 'formtreecontrol', 'formlistcontrol',
+  // Query framework
+  'query', 'queryrun', 'querybuilddatasource', 'querybuildrange',
+  'querybuildlink', 'querybuildfieldlist', 'queryfilter', 'queryhavingfilter',
+  // Collections
+  'map', 'set', 'list', 'array', 'struct', 'listenumerator', 'listiterator',
+  'mapenumerator', 'setenumerator', 'recordinsertlist', 'recordsortedlist',
+  'recordlinklist',
+  // Reflection
+  'dicttable', 'dictfield', 'dictclass', 'dictenum', 'dicttype', 'dictindex',
+  'dictrelation', 'dictview', 'treenode',
+  // IO / misc
+  'textbuffer', 'binary', 'xmldocument', 'xmlelement', 'xmlnode', 'xmlnodelist',
+  'xmlattribute', 'xmlreader', 'xmlwriter', 'textio', 'commaio', 'asciiio',
+  'connection', 'userconnection', 'statement', 'resultset', 'sqlsystem',
+  'sqldatadictionary', 'sqlstatementexecutepermission', 'executepermission',
+  'fileiopermission', 'runaspermission', 'datetimeutil', 'timezone', 'random',
+  'runbase', 'image', 'clrinterop', 'clrobject', 'thread', 'webrequest',
+  'webresponse', 'gc', 'session', 'infolog', 'debug', 'global',
+  // Kernel enums (not in metadata XML)
+  'types', 'tablescope', 'utcdatetimeorder', 'dateorder', 'dateday',
+  'datemonth', 'dateyear', 'statementtype', 'concurrencymodel', 'isolationlevel',
+]);
+
+/** Methods available on every table buffer via the kernel xRecord/Common base. */
+const TABLE_BUILTIN_METHODS = new Set([
+  'insert', 'doinsert', 'update', 'doupdate', 'delete', 'dodelete', 'write',
+  'validatewrite', 'validatedelete', 'validatefield', 'validatefieldvalue',
+  'initvalue', 'modifiedfield', 'modifiedfieldvalue', 'clear', 'selectforupdate',
+  'selectlocked', 'reread', 'checkrecord', 'skipdatamethods', 'skipdatabaselog',
+  'skipevents', 'skipdeleteactions', 'skipdeletemethod', 'skipaosvalidation',
+  'merge', 'data', 'orig', 'postload', 'caption', 'helpfield', 'tooltipfield',
+  'tooltiprecord', 'defaultfield', 'defaultrow', 'settmp', 'settmpdata',
+  'istmp', 'wasvalidated', 'recordlevelsecurity', 'cansubmittoworkflow',
+  'tablename', 'fieldbuffercount', 'dispose', 'getfieldvalue', 'setfieldvalue',
+  'existsalready', 'renameprimarykey', 'aosvalidatedelete', 'aosvalidateinsert',
+  'aosvalidateread', 'aosvalidateupdate', 'joinchildren', 'rowcount', 'queryrun',
+]);
+
+/** System fields present on every table (kernel-managed, not in metadata XML). */
+const TABLE_SYSTEM_FIELDS = new Set([
+  'recid', 'tableid', 'dataareaid', 'recversion', 'partition',
+  'createddatetime', 'createdby', 'modifieddatetime', 'modifiedby',
+  'createdtransactionid', 'modifiedtransactionid',
+]);
+
+/** Methods available on every class instance via the kernel Object base. */
+const OBJECT_BUILTIN_METHODS = new Set([
+  'new', 'finalize', 'tostring', 'handle', 'notify', 'wait', 'objectonserver',
+  'usagecount', 'owner', 'gettimeouttimerhandle', 'cancurrenttimeout',
+  'setrefcountzero', 'equal',
+]);
+
+const TABLE_LIKE_TYPES = new Set(['table', 'view', 'map', 'data-entity', 'table-extension']);
+
+// Intrinsic function → expected symbol types of the FIRST argument.
+// null = any indexed symbol type counts (e.g. identifierStr).
+const INTRINSIC_TARGET_TYPES: Record<string, string[] | null> = {
+  classstr: ['class', 'class-extension'],
+  classnum: ['class', 'class-extension'],
+  tablestr: ['table', 'view', 'map', 'data-entity', 'table-extension'],
+  tablenum: ['table', 'view', 'map', 'data-entity'],
+  fieldstr: ['table', 'view', 'map', 'data-entity'],
+  fieldnum: ['table', 'view', 'map', 'data-entity'],
+  enumstr: ['enum'],
+  enumnum: ['enum'],
+  enumcnt: ['enum'],
+  extendedtypestr: ['edt'],
+  extendedtypenum: ['edt'],
+  formstr: ['form'],
+  querystr: ['query'],
+  viewstr: ['view'],
+  mapstr: ['map'],
+  methodstr: ['class', 'table', 'form', 'class-extension'],
+  staticmethodstr: ['class', 'class-extension'],
+  dataentitydatasourcestr: ['data-entity'],
+  tablefieldgroupstr: ['table', 'table-extension'],
+  menuitemdisplaystr: null,
+  menuitemactionstr: null,
+  menuitemoutputstr: null,
+  tilestr: null,
+  resourcestr: null,
+};
+
+// ── Code preprocessing ───────────────────────────────────────────────────────
+
+interface CleanedCode {
+  /** Code with comments and string literals blanked (length-preserving). */
+  cleaned: string;
+  /** String literals with their offsets (for label extraction). */
+  strings: Array<{ value: string; index: number }>;
+}
+
+/** Blank comments and string literals while preserving offsets/line numbers. */
+function cleanCode(code: string): CleanedCode {
+  const strings: Array<{ value: string; index: number }> = [];
+  const chars = code.split('');
+  const n = chars.length;
+  let i = 0;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to; k++) if (chars[k] !== '\n') chars[k] = ' ';
+  };
+  while (i < n) {
+    const c = code[i];
+    const next = code[i + 1];
+    if (c === '/' && next === '/') {
+      let j = i;
+      while (j < n && code[j] !== '\n') j++;
+      blank(i, j);
+      i = j;
+    } else if (c === '/' && next === '*') {
+      let j = code.indexOf('*/', i + 2);
+      j = j === -1 ? n : j + 2;
+      blank(i, j);
+      i = j;
+    } else if (c === '"' || c === "'") {
+      const quote = c;
+      let j = i + 1;
+      let value = '';
+      while (j < n) {
+        if (code[j] === '\\' && j + 1 < n) { value += code[j] + code[j + 1]; j += 2; continue; }
+        if (code[j] === quote) break;
+        value += code[j];
+        j++;
+      }
+      strings.push({ value, index: i + 1 });
+      blank(i + 1, Math.min(j, n));
+      i = Math.min(j + 1, n);
+    } else {
+      i++;
+    }
+  }
+  return { cleaned: chars.join(''), strings };
+}
+
+function lineOf(code: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < code.length; i++) {
+    if (code[i] === '\n') line++;
+  }
+  return line;
+}
+
+// ── Index lookups ─────────────────────────────────────────────────────────────
+
+function symbolTypes(deps: ResolverDeps, name: string): string[] {
+  try {
+    const rows = deps.db
+      .prepare('SELECT DISTINCT type FROM symbols WHERE name = ? COLLATE NOCASE LIMIT 10')
+      .all(name) as Array<{ type: string }>;
+    return rows.map(r => r.type);
+  } catch {
+    return [];
+  }
+}
+
+function menuItemExists(deps: ResolverDeps, name: string): boolean {
+  try {
+    const row = deps.db
+      .prepare('SELECT 1 AS x FROM menu_item_targets WHERE menu_item_name = ? COLLATE NOCASE LIMIT 1')
+      .get(name);
+    return row !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+interface MethodRow { signature: string | null }
+
+/** Look up a method on an object, walking the extends_class chain (classes). */
+function findMethod(
+  deps: ResolverDeps,
+  ownerName: string,
+  methodName: string,
+  depth = 0,
+): MethodRow | undefined {
+  if (depth > 10) return undefined;
+  try {
+    const row = deps.db.prepare(
+      `SELECT signature FROM symbols
+       WHERE parent_name = ? COLLATE NOCASE AND name = ? COLLATE NOCASE AND type = 'method'
+       LIMIT 1`,
+    ).get(ownerName, methodName) as MethodRow | undefined;
+    if (row) return row;
+    // Extension-added methods (CoC wrappers, augmentation classes)
+    const extRows = deps.db.prepare(
+      `SELECT added_methods, coc_methods FROM extension_metadata
+       WHERE base_object_name = ? COLLATE NOCASE`,
+    ).all(ownerName) as Array<{ added_methods: string | null; coc_methods: string | null }>;
+    const target = methodName.toLowerCase();
+    for (const ext of extRows) {
+      for (const col of [ext.added_methods, ext.coc_methods]) {
+        if (!col) continue;
+        try {
+          const names = JSON.parse(col) as unknown[];
+          if (names.some(m =>
+            (typeof m === 'string' ? m : (m as { name?: string })?.name ?? '')
+              .toLowerCase() === target,
+          )) {
+            return { signature: null };
+          }
+        } catch { /* malformed JSON — skip */ }
+      }
+    }
+    // Walk inheritance chain
+    const parent = deps.db.prepare(
+      `SELECT extends_class FROM symbols
+       WHERE name = ? COLLATE NOCASE AND type IN ('class','table') AND extends_class IS NOT NULL
+       LIMIT 1`,
+    ).get(ownerName) as { extends_class: string | null } | undefined;
+    if (parent?.extends_class && parent.extends_class.toLowerCase() !== ownerName.toLowerCase()) {
+      return findMethod(deps, parent.extends_class, methodName, depth + 1);
+    }
+  } catch { /* DB error — treat as not found */ }
+  return undefined;
+}
+
+/** Check a field on a table: indexed fields, system fields, extension fields. */
+function fieldExists(deps: ResolverDeps, tableName: string, fieldName: string): boolean {
+  if (TABLE_SYSTEM_FIELDS.has(fieldName.toLowerCase())) return true;
+  try {
+    const row = deps.db.prepare(
+      `SELECT 1 AS x FROM symbols
+       WHERE parent_name = ? COLLATE NOCASE AND name = ? COLLATE NOCASE AND type = 'field'
+       LIMIT 1`,
+    ).get(tableName, fieldName);
+    if (row !== undefined) return true;
+    const extRows = deps.db.prepare(
+      `SELECT added_fields FROM extension_metadata
+       WHERE base_object_name = ? COLLATE NOCASE AND extension_type = 'table-extension'`,
+    ).all(tableName) as Array<{ added_fields: string | null }>;
+    const target = fieldName.toLowerCase();
+    for (const ext of extRows) {
+      if (!ext.added_fields) continue;
+      try {
+        const names = JSON.parse(ext.added_fields) as unknown[];
+        if (names.some(f =>
+          (typeof f === 'string' ? f : (f as { name?: string })?.name ?? '')
+            .toLowerCase() === target,
+        )) {
+          return true;
+        }
+      } catch { /* malformed JSON — skip */ }
+    }
+  } catch { /* DB error — treat as not found */ }
+  return false;
+}
+
+// ── Signature arity ───────────────────────────────────────────────────────────
+
+interface Arity { min: number; max: number }
+
+/** Parse "ReturnType name(Type a, Type b = x)" → {min, max}. */
+function parseSignatureArity(signature: string): Arity | undefined {
+  const open = signature.indexOf('(');
+  const close = signature.lastIndexOf(')');
+  if (open === -1 || close === -1 || close < open) return undefined;
+  const inner = signature.slice(open + 1, close).trim();
+  if (inner === '') return { min: 0, max: 0 };
+  const params = splitTopLevel(inner);
+  const optional = params.filter(p => p.includes('=')).length;
+  return { min: params.length - optional, max: params.length };
+}
+
+/** Split on top-level commas (ignores commas inside (), [], <>). */
+function splitTopLevel(text: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of text) {
+    if (ch === '(' || ch === '[' || ch === '<') depth++;
+    else if (ch === ')' || ch === ']' || ch === '>') depth = Math.max(0, depth - 1);
+    if (ch === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim() !== '') parts.push(current);
+  return parts;
+}
+
+/** Extract the balanced argument list starting at the '(' at `openIdx`. */
+function extractCallArgs(code: string, openIdx: number): string | undefined {
+  let depth = 0;
+  for (let i = openIdx; i < code.length; i++) {
+    if (code[i] === '(') depth++;
+    else if (code[i] === ')') {
+      depth--;
+      if (depth === 0) return code.slice(openIdx + 1, i);
+    }
+  }
+  return undefined;
+}
+
+function countCallArgs(argsText: string): number {
+  if (argsText.trim() === '') return 0;
+  return splitTopLevel(argsText).length;
+}
+
+// ── Local declaration collection ─────────────────────────────────────────────
+
+interface LocalScope {
+  /** Identifiers declared inside the snippet (class names, vars, params). */
+  declaredNames: Set<string>;
+  /** varName(lower) → declared TypeName */
+  bindings: Map<string, string>;
+}
+
+const DECL_STOPWORDS = new Set([
+  ...XPP_KEYWORDS,
+  'next', // CoC: `next methodName(...)`
+]);
+
+function collectLocals(cleaned: string): LocalScope {
+  const declaredNames = new Set<string>();
+  const bindings = new Map<string, string>();
+
+  // Class / interface declarations inside the snippet
+  for (const m of cleaned.matchAll(/\b(?:class|interface)\s+([A-Za-z_]\w*)/g)) {
+    declaredNames.add(m[1].toLowerCase());
+  }
+
+  // `Type var;`, `Type var = ...`, `Type var, var2;` — statement-leading position
+  const declRe = /(^|[;{}\n])\s*([A-Za-z_]\w*)\s+([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*(?=[=;,)])/g;
+  for (const m of cleaned.matchAll(declRe)) {
+    const typeName = m[2];
+    if (DECL_STOPWORDS.has(typeName.toLowerCase())) continue;
+    for (const varName of m[3].split(',').map(v => v.trim())) {
+      if (!varName || XPP_KEYWORDS.has(varName.toLowerCase())) continue;
+      declaredNames.add(varName.toLowerCase());
+      bindings.set(varName.toLowerCase(), typeName);
+    }
+  }
+
+  // Method parameters: `(Type _a, Type _b = default)`
+  for (const m of cleaned.matchAll(/\(([^()]*)\)/g)) {
+    for (const param of splitTopLevel(m[1])) {
+      const pm = param.trim().match(/^([A-Za-z_]\w*)\s+([A-Za-z_]\w*)/);
+      if (!pm) continue;
+      if (XPP_KEYWORDS.has(pm[1].toLowerCase())) continue;
+      declaredNames.add(pm[2].toLowerCase());
+      bindings.set(pm[2].toLowerCase(), pm[1]);
+    }
+  }
+
+  return { declaredNames, bindings };
+}
+
+// ── Main resolver ─────────────────────────────────────────────────────────────
+
+export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveResult {
+  const violations: ReferenceViolation[] = [];
+  let verifiedCount = 0;
+  const { cleaned, strings } = cleanCode(code);
+  const locals = collectLocals(cleaned);
+
+  const typeExistsCache = new Map<string, string[]>();
+  const lookupTypes = (name: string): string[] => {
+    const key = name.toLowerCase();
+    let types = typeExistsCache.get(key);
+    if (types === undefined) {
+      types = symbolTypes(deps, name);
+      typeExistsCache.set(key, types);
+    }
+    return types;
+  };
+
+  const isKnownType = (name: string): boolean => {
+    const lower = name.toLowerCase();
+    return XPP_BUILTIN_TYPES.has(lower)
+      || KERNEL_TYPES.has(lower)
+      || locals.declaredNames.has(lower)
+      || lookupTypes(name).length > 0;
+  };
+
+  // ── 1. Label references (from original string literals) ────────────────────
+  for (const s of strings) {
+    const modern = s.value.match(/^@([A-Za-z][A-Za-z0-9_]*):([A-Za-z0-9_]+)$/);
+    const legacy = s.value.match(/^@([A-Z]{2,4}\d+)$/);
+    if (modern) {
+      const [, fileId, labelId] = modern;
+      if (deps.getLabelById(labelId, fileId).length > 0) {
+        verifiedCount++;
+      } else {
+        // Distinguish: known label file with missing id (error) vs unknown file (warning)
+        const fileKnown = labelFileExists(deps, fileId);
+        violations.push({
+          kind: 'unknown-label',
+          severity: fileKnown ? 'error' : 'warning',
+          line: lineOf(code, s.index),
+          identifier: `@${fileId}:${labelId}`,
+          detail: fileKnown
+            ? `Label id "${labelId}" not found in label file "${fileId}". Use search_labels to find the right id or create_label to add it.`
+            : `Label file "${fileId}" not found in the index. If it is new, create the label first (create_label), then re-run.`,
+        });
+      }
+    } else if (legacy) {
+      if (deps.getLabelById(legacy[1]).length > 0) {
+        verifiedCount++;
+      } else {
+        violations.push({
+          kind: 'unknown-label',
+          severity: 'warning',
+          line: lineOf(code, s.index),
+          identifier: `@${legacy[1]}`,
+          detail: `Legacy label "@${legacy[1]}" not found in the labels index. Verify with get_label_info.`,
+        });
+      }
+    }
+  }
+
+  // ── 2. Intrinsic functions ──────────────────────────────────────────────────
+  const intrinsicRe = /\b([A-Za-z]+[Ss]tr|tableNum|classNum|enumNum|enumCnt|fieldNum|extendedTypeNum)\s*\(\s*([A-Za-z_]\w*)\s*(?:,\s*([A-Za-z_]\w*)\s*)?\)/g;
+  for (const m of cleaned.matchAll(intrinsicRe)) {
+    const fn = m[1].toLowerCase();
+    const expected = INTRINSIC_TARGET_TYPES[fn];
+    if (expected === undefined) continue; // not an intrinsic we know (e.g. subStr)
+    const target = m[2];
+    const member = m[3];
+    const line = lineOf(cleaned, m.index ?? 0);
+
+    if (locals.declaredNames.has(target.toLowerCase())) { verifiedCount++; continue; }
+
+    const types = lookupTypes(target);
+    const targetOk = expected === null
+      ? (types.length > 0 || menuItemExists(deps, target))
+      : types.some(t => expected.includes(t));
+    if (!targetOk) {
+      violations.push({
+        kind: 'unknown-intrinsic-target',
+        severity: 'error',
+        line,
+        identifier: `${m[1]}(${target}${member ? `, ${member}` : ''})`,
+        detail: expected === null
+          ? `"${target}" not found in the index (checked symbols and menu items).`
+          : `"${target}" is not a known ${expected.join('/')} in the index. Use search() to find the correct name.`,
+      });
+      continue;
+    }
+
+    // Second argument: fieldStr(T, F) / methodStr(C, m) / tableFieldGroupStr(T, G)
+    if (member) {
+      if (fn === 'fieldstr' || fn === 'fieldnum') {
+        if (fieldExists(deps, target, member)) {
+          verifiedCount++;
+        } else {
+          violations.push({
+            kind: 'unknown-field',
+            severity: 'error',
+            line,
+            identifier: `${target}.${member}`,
+            detail: `Field "${member}" not found on ${target} (checked fields, system fields, table extensions). Use get_table_info("${target}").`,
+          });
+        }
+      } else if (fn === 'methodstr' || fn === 'staticmethodstr') {
+        if (findMethod(deps, target, member)) {
+          verifiedCount++;
+        } else {
+          violations.push({
+            kind: 'unknown-method',
+            severity: 'error',
+            line,
+            identifier: `${target}.${member}`,
+            detail: `Method "${member}" not found on ${target} (checked inheritance chain and extensions). Use get_class_info("${target}").`,
+          });
+        }
+      } else {
+        verifiedCount++;
+      }
+    } else {
+      verifiedCount++;
+    }
+  }
+
+  // ── 3. Static member access Type::member ────────────────────────────────────
+  const staticRe = /\b([A-Za-z_]\w*)\s*::\s*([A-Za-z_]\w*)/g;
+  for (const m of cleaned.matchAll(staticRe)) {
+    const typeName = m[1];
+    const member = m[2];
+    const line = lineOf(cleaned, m.index ?? 0);
+    const lower = typeName.toLowerCase();
+
+    if (locals.declaredNames.has(lower)) continue;
+    if (KERNEL_TYPES.has(lower)) { verifiedCount++; continue; } // no metadata for kernel statics
+
+    const types = lookupTypes(typeName);
+    if (types.length === 0) {
+      violations.push({
+        kind: 'unknown-type',
+        severity: 'error',
+        line,
+        identifier: `${typeName}::${member}`,
+        detail: `"${typeName}" not found in the index. Use search("${typeName}") to find the correct name.`,
+      });
+      continue;
+    }
+    if (types.includes('enum')) {
+      // Enum values are not indexed as symbols — the enum itself is proven.
+      verifiedCount++;
+      continue;
+    }
+
+    const method = findMethod(deps, typeName, member);
+    if (!method) {
+      violations.push({
+        kind: 'unknown-static-member',
+        severity: 'error',
+        line,
+        identifier: `${typeName}::${member}`,
+        detail: `Static method "${member}" not found on ${typeName} (checked inheritance chain and extensions). Use get_class_info("${typeName}") or get_method_signature.`,
+      });
+      continue;
+    }
+    verifiedCount++;
+
+    // Arity check when the call site and the signature are both parseable
+    if (method.signature) {
+      const arity = parseSignatureArity(method.signature);
+      const callOpen = cleaned.indexOf('(', (m.index ?? 0) + m[0].length);
+      const between = callOpen === -1
+        ? ''
+        : cleaned.slice((m.index ?? 0) + m[0].length, callOpen);
+      if (arity && callOpen !== -1 && between.trim() === '') {
+        const argsText = extractCallArgs(cleaned, callOpen);
+        if (argsText !== undefined) {
+          const n = countCallArgs(argsText);
+          if (n < arity.min || n > arity.max) {
+            violations.push({
+              kind: 'arity-mismatch',
+              severity: 'error',
+              line,
+              identifier: `${typeName}::${member}`,
+              detail: `Call passes ${n} argument(s), but the indexed signature expects ${
+                arity.min === arity.max ? arity.min : `${arity.min}–${arity.max}`
+              }: ${method.signature.trim()}`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // ── 4. Declared types ───────────────────────────────────────────────────────
+  const reportedTypes = new Set<string>();
+  for (const [, typeName] of locals.bindings) {
+    const lower = typeName.toLowerCase();
+    if (reportedTypes.has(lower)) continue;
+    reportedTypes.add(lower);
+    if (isKnownType(typeName)) {
+      verifiedCount++;
+    } else {
+      violations.push({
+        kind: 'unknown-type',
+        severity: 'warning',
+        line: 0,
+        identifier: typeName,
+        detail: `Declared type "${typeName}" not found in the index. ` +
+          `If it is a kernel class this is a false positive; otherwise use search("${typeName}").`,
+      });
+    }
+  }
+
+  // ── 5. Bound buffer member access var.Field / var.method() ────────────────
+  for (const [varLower, typeName] of locals.bindings) {
+    const types = lookupTypes(typeName);
+    const isTableLike = types.some(t => TABLE_LIKE_TYPES.has(t));
+    const isClass = !isTableLike && types.includes('class');
+    if (!isTableLike && !isClass) continue;
+
+    const memberRe = new RegExp(String.raw`\b${varLower}\s*\.\s*([A-Za-z_]\w*)\s*(\()?`, 'gi');
+    const checkedMembers = new Set<string>();
+    for (const m of cleaned.matchAll(memberRe)) {
+      const member = m[1];
+      const isCall = m[2] === '(';
+      const key = `${member.toLowerCase()}:${isCall}`;
+      if (checkedMembers.has(key)) continue;
+      checkedMembers.add(key);
+      const line = lineOf(cleaned, m.index ?? 0);
+
+      if (isCall) {
+        const builtin = isTableLike
+          ? TABLE_BUILTIN_METHODS.has(member.toLowerCase())
+          : OBJECT_BUILTIN_METHODS.has(member.toLowerCase());
+        if (builtin || findMethod(deps, typeName, member)) {
+          verifiedCount++;
+        } else {
+          violations.push({
+            kind: 'unknown-method',
+            severity: 'warning',
+            line,
+            identifier: `${typeName}.${member}()`,
+            detail: `Method "${member}" not found on ${typeName} (checked builtins, inheritance, extensions). Verify with get_${isTableLike ? 'table' : 'class'}_info("${typeName}").`,
+          });
+        }
+      } else if (isTableLike) {
+        if (fieldExists(deps, typeName, member)) {
+          verifiedCount++;
+        } else {
+          violations.push({
+            kind: 'unknown-field',
+            severity: 'error',
+            line,
+            identifier: `${typeName}.${member}`,
+            detail: `Field "${member}" not found on ${typeName} (checked fields, system fields, table extensions). Use get_table_info("${typeName}").`,
+          });
+        }
+      }
+    }
+  }
+
+  return { violations, verifiedCount };
+}
+
+/** True when the label file id is present in the labels index. */
+function labelFileExists(deps: ResolverDeps, fileId: string): boolean {
+  try {
+    const target = fileId.toLowerCase();
+    return deps.getLabelFileIds().some(f => f.labelFileId.toLowerCase() === target);
+  } catch {
+    return false;
+  }
+}
+
+// ── Fail-closed gate for write tools ─────────────────────────────────────────
+
+/**
+ * When GROUNDING_ENFORCE=true, run the resolver over X++ source about to be
+ * written and reject the write if any ERROR-severity violation is found.
+ * Returns null when the gate passes (disabled, no code, or clean).
+ */
+export function gateOnReferenceErrors(
+  code: string | undefined,
+  symbolIndex: {
+    getReadDb(): ResolverDeps['db'];
+    getLabelById: ResolverDeps['getLabelById'];
+    getLabelFileIds: ResolverDeps['getLabelFileIds'];
+  } | undefined,
+  operationDescription: string,
+): { isError: true; content: [{ type: 'text'; text: string }] } | null {
+  if (process.env.GROUNDING_ENFORCE !== 'true') return null;
+  if (!code || !symbolIndex) return null;
+  let result: ResolveResult;
+  try {
+    result = resolveXppReferences(code, {
+      db: symbolIndex.getReadDb(),
+      getLabelById: symbolIndex.getLabelById.bind(symbolIndex),
+      getLabelFileIds: symbolIndex.getLabelFileIds.bind(symbolIndex),
+    });
+  } catch {
+    return null; // resolver failure must never block writes
+  }
+  const errors = result.violations.filter(v => v.severity === 'error');
+  if (errors.length === 0) return null;
+  const list = errors
+    .map(v => `  • [${v.kind}] line ${v.line}: \`${v.identifier}\` — ${v.detail}`)
+    .join('\n');
+  return {
+    isError: true,
+    content: [{
+      type: 'text',
+      text:
+        `❌ Unresolved references in ${operationDescription} (GROUNDING_ENFORCE=true).\n\n` +
+        `The following identifiers could NOT be proven against the indexed codebase:\n\n` +
+        `${list}\n\n` +
+        `Fix the identifiers (use the suggested lookup tools), then retry. ` +
+        `Run \`resolve_references\` on the corrected code to confirm it is clean.`,
+    }],
+  };
+}
+
+// ── MCP tool handler ──────────────────────────────────────────────────────────
+
+export async function resolveReferencesTool(
+  request: { params: { arguments?: unknown } },
+  context: XppServerContext,
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const parsed = resolveReferencesArgsSchema.safeParse(request.params.arguments ?? {});
+  if (!parsed.success) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: `❌ resolve_references: invalid arguments — ${parsed.error.message}` }],
+    };
+  }
+  const { code, context: objContext } = parsed.data;
+
+  let result: ResolveResult;
+  try {
+    result = resolveXppReferences(code, {
+      db: context.symbolIndex.getReadDb(),
+      getLabelById: context.symbolIndex.getLabelById.bind(context.symbolIndex),
+      getLabelFileIds: context.symbolIndex.getLabelFileIds.bind(context.symbolIndex),
+    });
+  } catch (error) {
+    return {
+      isError: true,
+      content: [{
+        type: 'text',
+        text: `❌ resolve_references failed: ${error instanceof Error ? error.message : String(error)}`,
+      }],
+    };
+  }
+
+  const errors = result.violations.filter(v => v.severity === 'error');
+  const warnings = result.violations.filter(v => v.severity === 'warning');
+  const suffix = objContext ? ` in ${objContext}` : '';
+
+  if (result.violations.length === 0) {
+    return {
+      content: [{
+        type: 'text',
+        text:
+          `✅ resolve_references: all ${result.verifiedCount} reference(s) verified against the index${suffix}.\n` +
+          `No hallucinated symbols detected. Safe to proceed with the write operation.`,
+      }],
+    };
+  }
+
+  const lines: string[] = [
+    `${errors.length > 0 ? '❌' : '⚠️'} resolve_references: ` +
+    `${errors.length} error(s), ${warnings.length} warning(s)${suffix} — ` +
+    `${result.verifiedCount} reference(s) verified OK.`,
+    '',
+  ];
+  for (const v of result.violations) {
+    lines.push(
+      `${v.severity === 'error' ? '❌' : '⚠️'} **${v.kind}**` +
+      `${v.line > 0 ? ` (line ${v.line})` : ''}: \`${v.identifier}\``,
+    );
+    lines.push(`   ${v.detail}`);
+    lines.push('');
+  }
+  if (errors.length > 0) {
+    lines.push('**Fix all errors before writing** — these identifiers do not exist in the indexed codebase.');
+  } else {
+    lines.push('Warnings are informational (kernel classes and new labels are not indexable). Review, then proceed.');
+  }
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
+    ...(errors.length > 0 ? { isError: true } : {}),
+  };
+}

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -59,6 +59,7 @@ import { undoLastModificationTool } from './undoLastModification.js';
 import { xppKnowledgeTool } from './xppKnowledge.js';
 import { d365foErrorHelpTool } from './d365foErrorHelp.js';
 import { validateXppTool } from './validateXpp.js';
+import { resolveReferencesTool } from './resolveReferences.js';
 import { prepareChangeTool } from './prepareChange.js';
 import { recordToolStart, startMetricsLogging } from '../utils/toolMetrics.js';
 import { buildProgressMessage } from '../utils/toolProgressMessage.js';
@@ -392,6 +393,8 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         return xppKnowledgeTool(request);
       case 'validate_xpp':
         return validateXppTool(request);
+      case 'resolve_references':
+        return resolveReferencesTool(request, context);
       case 'prepare_change':
         return prepareChangeTool(request, context);
       case 'get_workspace_info': {

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -61,6 +61,7 @@ import { d365foErrorHelpTool } from './d365foErrorHelp.js';
 import { validateXppTool } from './validateXpp.js';
 import { resolveReferencesTool } from './resolveReferences.js';
 import { prepareChangeTool } from './prepareChange.js';
+import { prepareCreateTool } from './prepareCreate.js';
 import { recordToolStart, startMetricsLogging } from '../utils/toolMetrics.js';
 import { buildProgressMessage } from '../utils/toolProgressMessage.js';
 
@@ -397,6 +398,8 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         return resolveReferencesTool(request, context);
       case 'prepare_change':
         return prepareChangeTool(request, context);
+      case 'prepare_create':
+        return prepareCreateTool(request, context);
       case 'get_workspace_info': {
         const args = (request as any).params?.arguments || {};
 

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -392,7 +392,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       case 'get_xpp_knowledge':
         return xppKnowledgeTool(request);
       case 'validate_xpp':
-        return validateXppTool(request);
+        return validateXppTool(request, context);
       case 'resolve_references':
         return resolveReferencesTool(request, context);
       case 'prepare_change':

--- a/src/tools/validateXpp.ts
+++ b/src/tools/validateXpp.ts
@@ -18,6 +18,13 @@
  *   BP002   doInsert/doUpdate/doDelete outside explicit migration comment
  *   BP003   Generic doc-comment (/// Foo class. / /// methodName.)
  *   XML001  AxTable XML missing an index with <AlternateKey>Yes</AlternateKey>
+ *
+ * Data-driven property rules (thresholds mined from STANDARD models into the
+ * property_stats table during build-database; static defaults when no stats):
+ *   XML002  AxTable missing <Label>
+ *   XML003  AxTable missing <TableGroup> (suggests the most common standard values)
+ *   XML004  AxTableField without <ExtendedDataType>/<EnumType>
+ *   XML005  AxTable missing <ClusteredIndex> (only when standard usage ≥ threshold)
  */
 
 import { z } from 'zod';
@@ -46,7 +53,9 @@ export const validateXppToolDefinition = {
     'Rules: today() deprecated, forceLiterals banned, crossCompany placement, ' +
     'nested while-select, function in where, CoC/ExtensionOf correctness, ' +
     'hardcoded strings, doInsert/doUpdate/doDelete misuse, generic doc-comments, ' +
-    'missing AlternateKey on table XML.',
+    'missing AlternateKey on table XML. ' +
+    'Plus data-driven property rules (XML002-XML005: Label, TableGroup, field EDT, ClusteredIndex) ' +
+    'with thresholds mined from your standard models during build-database.',
   inputSchema: validateXppArgsSchema,
 };
 
@@ -432,6 +441,133 @@ function checkMissingAlternateKey(code: string): ValidationViolation[] {
   return violations;
 }
 
+// ── Data-driven property rules (XML002–XML005) ──────────────────────────────
+
+/**
+ * Provider of mined property statistics — implemented by XppSymbolIndex.
+ * When unavailable (offline use, stats not built), the rules fall back to
+ * STATIC_PROPERTY_DEFAULTS.
+ */
+export interface PropertyStatsProvider {
+  getPropertyPresenceRatio(nodeType: string, property: string): { present: number; total: number; ratio: number };
+  getPropertyValueDistribution(nodeType: string, property: string, limit?: number): Array<{ value: string; count: number }>;
+}
+
+/** A property rule fires when the standard platform sets it at least this often. */
+const PROPERTY_RULE_THRESHOLD = 0.8;
+
+/** Behaviour when no mined statistics are available. */
+const STATIC_PROPERTY_DEFAULTS: Record<string, boolean> = {
+  'AxTable.Label': true,
+  'AxTable.TableGroup': true,
+  'AxTableField.ExtendedDataType': true,
+  'AxTable.ClusteredIndex': false, // only enforced when stats prove standard usage
+};
+
+/** Decide whether a property rule applies + build its evidence string. */
+function propertyRuleApplies(
+  stats: PropertyStatsProvider | undefined,
+  nodeType: string,
+  property: string,
+): { applies: boolean; evidence: string } {
+  if (stats) {
+    try {
+      const r = stats.getPropertyPresenceRatio(nodeType, property);
+      if (r.total > 0) {
+        return {
+          applies: r.ratio >= PROPERTY_RULE_THRESHOLD,
+          evidence: `${Math.round(r.ratio * 100)}% of ${r.total.toLocaleString('en-US')} standard ${nodeType} nodes set this property`,
+        };
+      }
+    } catch { /* stats unavailable — fall through to defaults */ }
+  }
+  return {
+    applies: STATIC_PROPERTY_DEFAULTS[`${nodeType}.${property}`] ?? false,
+    evidence: 'static default (no mined statistics available — run build-database to mine standard models)',
+  };
+}
+
+/** Extract the table-level header segment (before <Fields>) of an AxTable XML. */
+function tableHeaderSegment(code: string): string {
+  const fieldsIdx = code.search(/<Fields\b/i);
+  return fieldsIdx === -1 ? code : code.slice(0, fieldsIdx);
+}
+
+/** XML002/XML003/XML005 — table-level property presence. */
+function checkTableProperties(code: string, stats?: PropertyStatsProvider): ValidationViolation[] {
+  const violations: ValidationViolation[] = [];
+  if (!/<AxTable[\s>]/i.test(code)) return violations;
+  const header = tableHeaderSegment(code);
+
+  const label = propertyRuleApplies(stats, 'AxTable', 'Label');
+  if (label.applies && !/<Label>[^<]+<\/Label>/i.test(header)) {
+    violations.push({
+      rule: 'XML002',
+      severity: 'error',
+      excerpt: '<AxTable> — missing <Label>',
+      fix: `Add <Label>@YourModel:TableLabel</Label> to the table header (create the label first via create_label). Evidence: ${label.evidence}.`,
+    });
+  }
+
+  const tableGroup = propertyRuleApplies(stats, 'AxTable', 'TableGroup');
+  if (tableGroup.applies && !/<TableGroup>[^<]+<\/TableGroup>/i.test(header)) {
+    let suggestion = 'Main (master data), Transaction (postings), Parameter (settings), Group (groupings)';
+    if (stats) {
+      try {
+        const dist = stats.getPropertyValueDistribution('AxTable', 'TableGroup', 4);
+        if (dist.length > 0) {
+          const total = dist.reduce((s, d) => s + d.count, 0);
+          suggestion = dist
+            .map(d => `${d.value} (${Math.round((d.count / total) * 100)}%)`)
+            .join(', ');
+        }
+      } catch { /* keep static suggestion */ }
+    }
+    violations.push({
+      rule: 'XML003',
+      severity: 'error',
+      excerpt: '<AxTable> — missing <TableGroup>',
+      fix: `Add <TableGroup> to the table header. Most common standard values: ${suggestion}. Evidence: ${tableGroup.evidence}.`,
+    });
+  }
+
+  const clustered = propertyRuleApplies(stats, 'AxTable', 'ClusteredIndex');
+  if (clustered.applies && !/<ClusteredIndex>[^<]+<\/ClusteredIndex>/i.test(header)) {
+    violations.push({
+      rule: 'XML005',
+      severity: 'warning',
+      excerpt: '<AxTable> — missing <ClusteredIndex>',
+      fix: `Set <ClusteredIndex> to the primary index name for predictable physical ordering. Evidence: ${clustered.evidence}.`,
+    });
+  }
+
+  return violations;
+}
+
+/** XML004 — every AxTableField should carry an EDT (or EnumType for enums). */
+function checkFieldEdt(code: string, stats?: PropertyStatsProvider): ValidationViolation[] {
+  const violations: ValidationViolation[] = [];
+  if (!/<AxTableField[\s>]/i.test(code)) return violations;
+  const rule = propertyRuleApplies(stats, 'AxTableField', 'ExtendedDataType');
+  if (!rule.applies) return violations;
+
+  const fieldBlocks = code.split(/<AxTableField[\s>]/i).slice(1);
+  for (const block of fieldBlocks) {
+    const body = block.split(/<\/AxTableField>/i)[0] ?? block;
+    if (/<ExtendedDataType>[^<]+<\/ExtendedDataType>/i.test(body)) continue;
+    if (/<EnumType>[^<]+<\/EnumType>/i.test(body)) continue;
+    const name = /<Name>([^<]+)<\/Name>/i.exec(body)?.[1] ?? '(unnamed)';
+    violations.push({
+      rule: 'XML004',
+      severity: 'warning',
+      excerpt: `<AxTableField> ${name} — no <ExtendedDataType> or <EnumType>`,
+      fix: `Base field "${name}" on an EDT (use suggest_edt to find one) or an enum. ` +
+        `Primitive-typed fields lose label, help text, and length governance. Evidence: ${rule.evidence}.`,
+    });
+  }
+  return violations;
+}
+
 // ── Runner ────────────────────────────────────────────────────────────────────
 
 const XPP_RULES = [
@@ -452,9 +588,15 @@ const XML_RULES = [
   checkMissingAlternateKey,
 ];
 
+const XML_PROPERTY_RULES = [
+  checkTableProperties,
+  checkFieldEdt,
+];
+
 function runRules(
   code: string,
   codeType: 'xpp' | 'xml-table' | 'xml-any',
+  stats?: PropertyStatsProvider,
 ): ValidationViolation[] {
   const violations: ValidationViolation[] = [];
   if (codeType === 'xpp') {
@@ -465,9 +607,15 @@ function runRules(
     for (const rule of [...XPP_RULES, ...XML_RULES]) {
       violations.push(...rule(code));
     }
+    for (const rule of XML_PROPERTY_RULES) {
+      violations.push(...rule(code, stats));
+    }
   } else {
     for (const rule of XML_RULES) {
       violations.push(...rule(code));
+    }
+    for (const rule of XML_PROPERTY_RULES) {
+      violations.push(...rule(code, stats));
     }
   }
   return violations;
@@ -475,7 +623,10 @@ function runRules(
 
 // ── Tool handler ──────────────────────────────────────────────────────────────
 
-export async function validateXppTool(request: any): Promise<any> {
+export async function validateXppTool(
+  request: any,
+  serverContext?: { symbolIndex?: PropertyStatsProvider },
+): Promise<any> {
   const raw = request?.params?.arguments ?? request;
   const parsed = validateXppArgsSchema.safeParse(raw);
   if (!parsed.success) {
@@ -486,7 +637,10 @@ export async function validateXppTool(request: any): Promise<any> {
   }
 
   const { code, codeType = 'xpp', context } = parsed.data;
-  const violations = runRules(code, codeType);
+  const stats = typeof serverContext?.symbolIndex?.getPropertyPresenceRatio === 'function'
+    ? serverContext.symbolIndex
+    : undefined;
+  const violations = runRules(code, codeType, stats);
 
   const errors = violations.filter(v => v.severity === 'error');
   const warnings = violations.filter(v => v.severity === 'warning');
@@ -496,7 +650,8 @@ export async function validateXppTool(request: any): Promise<any> {
       content: [{
         type: 'text',
         text: `✅ validate_xpp: no violations found${context ? ` in ${context}` : ''}.\n` +
-          `Checked ${XPP_RULES.length + (codeType !== 'xpp' ? XML_RULES.length : 0)} rules.`,
+          `Checked ${XPP_RULES.length + (codeType !== 'xpp' ? XML_RULES.length + XML_PROPERTY_RULES.length : 0)} rule groups` +
+          `${codeType !== 'xpp' && stats ? ' (property rules driven by mined standard-model statistics)' : ''}.`,
       }],
     };
   }

--- a/src/utils/provenanceStore.ts
+++ b/src/utils/provenanceStore.ts
@@ -19,6 +19,8 @@ export interface ProvenanceContext {
   objectName: string;
   methodName?: string;
   objectType?: string;
+  /** Proposed name of the new extension object, when supplied to prepare_change */
+  proposedName?: string;
   /** Condensed facts gathered by prepare_change */
   methodSignature?: string;
   cocExtensions?: string;
@@ -75,20 +77,64 @@ export function isValidToken(token: string): boolean {
 }
 
 /**
+ * Check that a token was issued for the object actually being written.
+ *
+ * A token issued for `CustTable` is accepted for targets that embed that name
+ * (`CustTable.ContosoExtension`, `CustTableContoso_Extension`, …) and for the
+ * proposedName recorded by prepare_change. Names shorter than 4 chars are
+ * compared exactly to avoid trivial substring matches.
+ */
+export function tokenMatchesTarget(
+  bundle: ProvenanceBundle,
+  targetObjectName: string,
+): boolean {
+  const target = targetObjectName.trim().toLowerCase();
+  if (!target) return true;
+  const candidates = [bundle.context.objectName, bundle.context.proposedName]
+    .filter((c): c is string => !!c)
+    .map(c => c.trim().toLowerCase());
+  return candidates.some(c => {
+    if (c === target) return true;
+    if (c.length < 4 || target.length < 4) return false;
+    return target.includes(c) || c.includes(target);
+  });
+}
+
+/**
  * Enforce grounding for extension write operations.
  *
- * Returns an error result if:
- *   - GROUNDING_ENFORCE=true is set in the environment, AND
- *   - no valid grounding token was provided.
+ * Returns an error result if GROUNDING_ENFORCE=true is set in the environment AND:
+ *   - no valid grounding token was provided, OR
+ *   - the token was issued for a different object than `targetObjectName`.
  *
  * Returns null when enforcement passes (either disabled or token is valid).
  */
 export function enforceGrounding(
   groundingToken: string | undefined,
   operationDescription: string,
+  targetObjectName?: string,
 ): { isError: true; content: [{ type: 'text'; text: string }] } | null {
   if (process.env.GROUNDING_ENFORCE !== 'true') return null;
-  if (groundingToken && isValidToken(groundingToken)) return null;
+  if (groundingToken && isValidToken(groundingToken)) {
+    if (!targetObjectName) return null;
+    const bundle = getProvenanceBundle(groundingToken)!;
+    if (tokenMatchesTarget(bundle, targetObjectName)) return null;
+    return {
+      isError: true,
+      content: [{
+        type: 'text',
+        text:
+          `❌ Grounding token mismatch for ${operationDescription} (GROUNDING_ENFORCE=true).\n\n` +
+          `The provided token was issued for object \`${bundle.context.objectName}\`` +
+          (bundle.context.proposedName ? ` (proposed: \`${bundle.context.proposedName}\`)` : '') +
+          `, but this call targets \`${targetObjectName}\`.\n\n` +
+          `**Required workflow:**\n` +
+          `1. Call \`prepare_change(goal="...", objectName="${targetObjectName}")\` for THIS object.\n` +
+          `2. Pass the returned \`groundingToken\` to this tool.\n\n` +
+          `Tokens are object-bound — one token cannot authorize writes to a different object.`,
+      }],
+    };
+  }
   const reason = groundingToken
     ? 'the provided groundingToken has expired or is invalid'
     : 'no groundingToken was provided';

--- a/tests/tools/grounding-enforcement.test.ts
+++ b/tests/tools/grounding-enforcement.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Fail-closed grounding enforcement in write tools.
+ *
+ * When GROUNDING_ENFORCE=true, extension objectTypes in create_d365fo_file and
+ * modify_d365fo_file must reject calls without a valid (object-bound) token
+ * BEFORE touching the file system.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { handleCreateD365File } from '../../src/tools/createD365File';
+import { modifyD365FileTool } from '../../src/tools/modifyD365File';
+import { createProvenanceToken } from '../../src/utils/provenanceStore';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { XppServerContext } from '../../src/types/context';
+
+const ORIGINAL_ENFORCE = process.env.GROUNDING_ENFORCE;
+
+afterEach(() => {
+  if (ORIGINAL_ENFORCE === undefined) delete process.env.GROUNDING_ENFORCE;
+  else process.env.GROUNDING_ENFORCE = ORIGINAL_ENFORCE;
+});
+
+const createReq = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'create_d365fo_file', arguments: args },
+});
+
+const modifyReq = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'modify_d365fo_file', arguments: args },
+});
+
+// Enforcement runs before any context access — a stub is sufficient.
+const stubContext = {} as XppServerContext;
+
+describe('create_d365fo_file grounding enforcement', () => {
+  it('rejects extension objectType without a token when GROUNDING_ENFORCE=true', async () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const result = await handleCreateD365File(createReq({
+      objectType: 'class-extension',
+      objectName: 'CustTable.ContosoExtension',
+    }));
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Grounding required');
+    expect(result.content[0].text).toContain('prepare_change');
+  });
+
+  it('rejects a token issued for a different object', async () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const token = createProvenanceToken({ goal: 'test', objectName: 'SalesTable' });
+    const result = await handleCreateD365File(createReq({
+      objectType: 'table-extension',
+      objectName: 'CustTable.ContosoExtension',
+      groundingToken: token,
+    }));
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('token mismatch');
+  });
+
+  it('does not block non-extension objectTypes', async () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const result = await handleCreateD365File(createReq({
+      objectType: 'class',
+      objectName: 'ContosoHelper',
+      packagePath: 'Z:\\nonexistent\\path',
+    }));
+    // May fail later for other reasons (no model/path), but never for grounding.
+    expect(result.content[0].text ?? '').not.toContain('Grounding required');
+  });
+});
+
+describe('modify_d365fo_file grounding enforcement', () => {
+  it('rejects extension objectType without a token when GROUNDING_ENFORCE=true', async () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const result = await modifyD365FileTool(modifyReq({
+      objectType: 'form-extension',
+      objectName: 'SalesTable.ContosoExtension',
+      operation: 'add-control',
+      controlName: 'MyControl',
+      parentControl: 'TabGeneral',
+    }), stubContext);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Grounding required');
+  });
+
+  it('accepts a valid object-bound token (passes enforcement gate)', async () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const token = createProvenanceToken({ goal: 'test', objectName: 'SalesTable' });
+    const result = await modifyD365FileTool(modifyReq({
+      objectType: 'table-extension',
+      objectName: 'SalesTable.ContosoExtension',
+      operation: 'add-field',
+      fieldName: 'ContosoField',
+      groundingToken: token,
+      filePath: 'Z:\\nonexistent\\SalesTable.ContosoExtension.xml',
+    }), stubContext);
+    // Fails later (file does not exist), but NOT at the grounding gate.
+    expect(result.content[0].text ?? '').not.toContain('Grounding required');
+    expect(result.content[0].text ?? '').not.toContain('token mismatch');
+  });
+});

--- a/tests/tools/prepare-create.test.ts
+++ b/tests/tools/prepare-create.test.ts
@@ -1,0 +1,140 @@
+/**
+ * prepare_create tool tests — single-round aggregator for new objects.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { prepareCreateTool } from '../../src/tools/prepareCreate';
+import { getProvenanceBundle } from '../../src/utils/provenanceStore';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const req = (args: Record<string, unknown> = {}): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'prepare_create', arguments: args },
+});
+
+const getText = (result: any): string => result.content?.[0]?.text ?? '';
+
+/** In-memory stub over the queries prepare_create issues. */
+const buildContext = (opts: {
+  existingNames?: Array<{ name: string; type: string; model: string }>;
+  edts?: Array<{ name: string; signature: string | null }>;
+  labels?: Array<{ labelId: string; labelFileId: string; model: string; text: string }>;
+  stats?: boolean;
+} = {}): XppServerContext => {
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      all: vi.fn((..._params: unknown[]) => {
+        if (sql.includes("type = 'edt'")) return opts.edts ?? [];
+        if (sql.includes('name IN (?, ?)')) return opts.existingNames ?? [];
+        return [];
+      }),
+      get: vi.fn(() => undefined),
+      run: vi.fn(),
+    })),
+  };
+  const symbolIndex: any = {
+    getReadDb: () => db,
+    searchLabels: vi.fn(() => opts.labels ?? []),
+  };
+  if (opts.stats) {
+    symbolIndex.getPropertyPresenceRatio = vi.fn(() => ({ present: 950, total: 1000, ratio: 0.95 }));
+    symbolIndex.getPropertyValueDistribution = vi.fn(() => [
+      { value: 'Main', count: 600 },
+      { value: 'Transaction', count: 400 },
+    ]);
+  }
+  return { symbolIndex } as unknown as XppServerContext;
+};
+
+beforeEach(() => {
+  delete process.env.EXTENSION_PREFIX;
+});
+
+describe('prepare_create input validation', () => {
+  it('rejects missing objectType', async () => {
+    const result = await prepareCreateTool(
+      req({ goal: 'x', objectName: 'ImportParameters' }),
+      buildContext(),
+    );
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe('prepare_create aggregation', () => {
+  it('returns all sections and a valid object-bound grounding token', async () => {
+    const result = await prepareCreateTool(
+      req({ goal: 'Import parameters table', objectName: 'ImportParameters', objectType: 'table' }),
+      buildContext(),
+    );
+    const text = getText(result);
+    expect(result.isError).toBeFalsy();
+    expect(text).toContain('Collision check');
+    expect(text).toContain('Naming');
+    expect(text).toContain('Reusable labels');
+    expect(text).toContain('Grounding token');
+
+    const token = /\*\*Grounding token:\*\* `([0-9a-f]{32})`/.exec(text)?.[1];
+    expect(token).toBeTruthy();
+    const bundle = getProvenanceBundle(token!);
+    expect(bundle?.context.objectName).toBe('ImportParameters');
+    expect(bundle?.context.objectType).toBe('table');
+  });
+
+  it('reports collisions found in the index', async () => {
+    const result = await prepareCreateTool(
+      req({ goal: 'x', objectName: 'CustTable', objectType: 'table' }),
+      buildContext({ existingNames: [{ name: 'CustTable', type: 'table', model: 'ApplicationSuite' }] }),
+    );
+    expect(getText(result)).toContain('already exists as table');
+  });
+
+  it('applies EXTENSION_PREFIX to the final name', async () => {
+    process.env.EXTENSION_PREFIX = 'Contoso';
+    const result = await prepareCreateTool(
+      req({ goal: 'x', objectName: 'ImportParameters', objectType: 'table' }),
+      buildContext(),
+    );
+    expect(getText(result)).toContain('ContosoImportParameters');
+  });
+
+  it('suggests EDTs for fieldsHint', async () => {
+    const result = await prepareCreateTool(
+      req({
+        goal: 'x', objectName: 'ImportParameters', objectType: 'table',
+        fieldsHint: ['CustAccount'],
+      }),
+      buildContext({ edts: [{ name: 'CustAccount', signature: 'AccountNum' }] }),
+    );
+    const text = getText(result);
+    expect(text).toContain('EDT suggestions');
+    expect(text).toContain('CustAccount → CustAccount (extends AccountNum)');
+  });
+
+  it('lists reusable labels from the labels index', async () => {
+    const result = await prepareCreateTool(
+      req({ goal: 'x', objectName: 'ImportParameters', objectType: 'table' }),
+      buildContext({ labels: [{ labelId: 'ImportParams', labelFileId: 'Contoso', model: 'ContosoModel', text: 'Import parameters' }] }),
+    );
+    expect(getText(result)).toContain('@Contoso:ImportParams');
+  });
+
+  it('includes mined property defaults for tables when stats exist', async () => {
+    const result = await prepareCreateTool(
+      req({ goal: 'x', objectName: 'ImportParameters', objectType: 'table' }),
+      buildContext({ stats: true }),
+    );
+    const text = getText(result);
+    expect(text).toContain('Property defaults');
+    expect(text).toContain('95% of standard tables');
+    expect(text).toContain('Main (60%)');
+  });
+
+  it('flags invalid names', async () => {
+    const result = await prepareCreateTool(
+      req({ goal: 'x', objectName: 'importParameters', objectType: 'class' }),
+      buildContext(),
+    );
+    expect(getText(result)).toContain('must start with an uppercase letter');
+  });
+});

--- a/tests/tools/resolve-references.test.ts
+++ b/tests/tools/resolve-references.test.ts
@@ -1,0 +1,360 @@
+/**
+ * resolve_references tests — semantic reference resolution against a real
+ * in-memory SQLite database using the production schema subset.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  resolveXppReferences,
+  gateOnReferenceErrors,
+  resolveReferencesTool,
+  type ResolverDeps,
+} from '../../src/tools/resolveReferences';
+
+const ORIGINAL_ENFORCE = process.env.GROUNDING_ENFORCE;
+
+let db: InstanceType<typeof Database>;
+let deps: ResolverDeps;
+
+const LABELS: Record<string, string[]> = {
+  // labelFileId → known label ids
+  SYS: ['SYS12345'],
+  Contoso: ['MyLabel'],
+};
+
+function makeDeps(database: InstanceType<typeof Database>): ResolverDeps {
+  return {
+    db: database,
+    getLabelById: (labelId: string, labelFileId?: string) => {
+      const hit = (fileId: string) =>
+        (LABELS[fileId] ?? []).includes(labelId) ? [{ labelId, labelFileId: fileId }] : [];
+      if (labelFileId) return hit(labelFileId);
+      return Object.keys(LABELS).flatMap(hit);
+    },
+    getLabelFileIds: () => Object.keys(LABELS).map(labelFileId => ({ labelFileId })),
+  };
+}
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      parent_name TEXT,
+      signature TEXT,
+      extends_class TEXT
+    );
+    CREATE TABLE extension_metadata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      extension_name TEXT,
+      extension_type TEXT,
+      base_object_name TEXT,
+      added_fields TEXT,
+      added_methods TEXT,
+      coc_methods TEXT
+    );
+    CREATE TABLE menu_item_targets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      menu_item_name TEXT NOT NULL,
+      menu_item_type TEXT
+    );
+  `);
+
+  const sym = db.prepare(
+    'INSERT INTO symbols (name, type, parent_name, signature, extends_class) VALUES (?, ?, ?, ?, ?)',
+  );
+  // Tables + fields + methods
+  sym.run('CustTable', 'table', null, null, null);
+  sym.run('AccountNum', 'field', 'CustTable', 'CustAccount', null);
+  sym.run('CustGroup', 'field', 'CustTable', 'CustGroupId', null);
+  sym.run('Blocked', 'field', 'CustTable', 'CustVendorBlocked', null);
+  sym.run('validateWrite', 'method', 'CustTable', 'public boolean validateWrite()', null);
+  sym.run('find', 'method', 'CustTable',
+    'public static CustTable find(CustAccount _custAccount, boolean _forUpdate = false)', null);
+  sym.run('SalesTable', 'table', null, null, null);
+  sym.run('SalesId', 'field', 'SalesTable', 'SalesIdBase', null);
+  // Classes with inheritance
+  sym.run('SalesFormLetter', 'class', null, null, 'RunBaseBatch');
+  sym.run('run', 'method', 'SalesFormLetter', 'public void run()', null);
+  sym.run('ContosoBase', 'class', null, null, null);
+  sym.run('doStuff', 'method', 'ContosoBase', 'public int doStuff(int _a, str _b = "")', null);
+  sym.run('ContosoChild', 'class', null, null, 'ContosoBase');
+  // Enum / EDT / form / query
+  sym.run('NoYes', 'enum', null, null, null);
+  sym.run('CustAccount', 'edt', null, 'AccountNum', null);
+  sym.run('CustTableListPage', 'form', null, null, null);
+  sym.run('CustTableSRS', 'query', null, null, null);
+
+  db.prepare(
+    `INSERT INTO extension_metadata
+       (extension_name, extension_type, base_object_name, added_fields, added_methods, coc_methods)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run('CustTable.ContosoExtension', 'table-extension', 'CustTable', '["ContosoTier"]', null, null);
+  db.prepare(
+    `INSERT INTO extension_metadata
+       (extension_name, extension_type, base_object_name, added_fields, added_methods, coc_methods)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run('SalesFormLetterContoso_Extension', 'class-extension', 'SalesFormLetter',
+    null, null, '[{"name":"postJournal"}]');
+
+  db.prepare('INSERT INTO menu_item_targets (menu_item_name, menu_item_type) VALUES (?, ?)')
+    .run('CustTableListPage', 'display');
+
+  deps = makeDeps(db);
+});
+
+afterAll(() => db.close());
+
+afterEach(() => {
+  if (ORIGINAL_ENFORCE === undefined) delete process.env.GROUNDING_ENFORCE;
+  else process.env.GROUNDING_ENFORCE = ORIGINAL_ENFORCE;
+});
+
+const errorsOf = (code: string) =>
+  resolveXppReferences(code, deps).violations.filter(v => v.severity === 'error');
+const warningsOf = (code: string) =>
+  resolveXppReferences(code, deps).violations.filter(v => v.severity === 'warning');
+
+// ─── Clean code ──────────────────────────────────────────────────────────────
+
+describe('resolveXppReferences — clean code', () => {
+  it('verifies a realistic CoC wrapper with zero violations', () => {
+    const code = `
+[ExtensionOf(tableStr(CustTable))]
+final class CustTableContoso_Extension
+{
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        CustTable custTable;
+
+        if (custTable.AccountNum && custTable.Blocked == NoYes::Yes)
+        {
+            ret = checkFailed("@Contoso:MyLabel");
+        }
+        return ret;
+    }
+}`;
+    const result = resolveXppReferences(code, deps);
+    expect(result.violations).toEqual([]);
+    expect(result.verifiedCount).toBeGreaterThan(3);
+  });
+
+  it('accepts system fields, extension fields and builtin table methods', () => {
+    const code = `
+CustTable custTable;
+custTable.ContosoTier = 1;
+if (custTable.RecId)
+{
+    custTable.doUpdate();
+}`;
+    expect(resolveXppReferences(code, deps).violations).toEqual([]);
+  });
+
+  it('accepts kernel classes without metadata', () => {
+    const code = `
+Map valueMap = new Map(Types::String, Types::String);
+Query query = new Query();
+QueryBuildDataSource qbds;
+`;
+    // Types:: is a kernel enum — must not be flagged
+    expect(errorsOf(code)).toEqual([]);
+  });
+
+  it('verifies static call through the inheritance chain', () => {
+    expect(errorsOf('ContosoChild::doStuff(1);')).toEqual([]);
+  });
+
+  it('verifies a CoC method recorded in extension_metadata', () => {
+    expect(errorsOf('methodStr(SalesFormLetter, postJournal)')).toEqual([]);
+  });
+
+  it('verifies menu item intrinsics against menu_item_targets', () => {
+    expect(errorsOf('menuItemDisplayStr(CustTableListPage)')).toEqual([]);
+  });
+});
+
+// ─── Hallucinated symbols ────────────────────────────────────────────────────
+
+describe('resolveXppReferences — hallucination detection', () => {
+  it('flags an unknown table in tableStr()', () => {
+    const errors = errorsOf('[ExtensionOf(tableStr(CustTabel))]');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('unknown-intrinsic-target');
+    expect(errors[0].identifier).toContain('CustTabel');
+  });
+
+  it('flags an unknown field in fieldStr()', () => {
+    const errors = errorsOf('fieldStr(CustTable, CreditLimit)');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('unknown-field');
+  });
+
+  it('flags a fake field on a bound buffer', () => {
+    const errors = errorsOf('CustTable custTable;\ncustTable.FakeField = 1;');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('unknown-field');
+    expect(errors[0].identifier).toBe('CustTable.FakeField');
+  });
+
+  it('flags an unknown static method', () => {
+    const errors = errorsOf('CustTable::findByFoo("x");');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('unknown-static-member');
+  });
+
+  it('flags a completely unknown type in static access', () => {
+    const errors = errorsOf('ContosoFakeHelper::run();');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('unknown-type');
+  });
+
+  it('reports an unknown declared type as warning (kernel classes are unindexable)', () => {
+    const warnings = warningsOf('ContosoMissingType helper;');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].kind).toBe('unknown-type');
+  });
+
+  it('flags an unknown instance method as warning', () => {
+    const warnings = warningsOf('CustTable custTable;\ncustTable.fakeMethod();');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].kind).toBe('unknown-method');
+  });
+});
+
+// ─── Arity ───────────────────────────────────────────────────────────────────
+
+describe('resolveXppReferences — arity checks', () => {
+  it('accepts calls within the signature arity range', () => {
+    expect(errorsOf('CustTable::find("c1");')).toEqual([]);
+    expect(errorsOf('CustTable::find("c1", true);')).toEqual([]);
+  });
+
+  it('flags too few arguments', () => {
+    const errors = errorsOf('CustTable::find();');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('arity-mismatch');
+  });
+
+  it('flags too many arguments', () => {
+    const errors = errorsOf('CustTable::find("c1", true, 42);');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('arity-mismatch');
+  });
+});
+
+// ─── Labels ──────────────────────────────────────────────────────────────────
+
+describe('resolveXppReferences — labels', () => {
+  it('verifies existing modern and legacy labels', () => {
+    expect(resolveXppReferences('info("@Contoso:MyLabel");\ninfo("@SYS12345");', deps).violations)
+      .toEqual([]);
+  });
+
+  it('flags a missing id in a KNOWN label file as error', () => {
+    const errors = errorsOf('info("@Contoso:DoesNotExist");');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('unknown-label');
+  });
+
+  it('flags an unknown label file as warning (may be created later)', () => {
+    const warnings = warningsOf('info("@BrandNewFile:SomeLabel");');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].kind).toBe('unknown-label');
+  });
+
+  it('flags a missing legacy label as warning', () => {
+    const warnings = warningsOf('info("@SYS99999");');
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+// ─── Comments and strings are ignored ───────────────────────────────────────
+
+describe('resolveXppReferences — preprocessing', () => {
+  it('ignores identifiers inside comments and plain strings', () => {
+    const code = `
+// FakeTable::method() in a comment
+/* CustTable.NothingHere */
+str s = "FakeClass::run()";
+`;
+    expect(resolveXppReferences(code, deps).violations).toEqual([]);
+  });
+});
+
+// ─── Fail-closed gate ────────────────────────────────────────────────────────
+
+describe('gateOnReferenceErrors', () => {
+  const stubIndex = {
+    getReadDb: () => db as unknown as ResolverDeps['db'],
+    getLabelById: deps?.getLabelById ?? ((id: string, f?: string) => makeDeps(db).getLabelById(id, f)),
+    getLabelFileIds: () => Object.keys(LABELS).map(labelFileId => ({ labelFileId })),
+  };
+
+  it('returns null when enforcement is disabled', () => {
+    delete process.env.GROUNDING_ENFORCE;
+    expect(gateOnReferenceErrors('CustTable::findByFoo();', stubIndex, 'op')).toBeNull();
+  });
+
+  it('rejects code with error-severity violations when enforced', () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const result = gateOnReferenceErrors(
+      'CustTable custTable;\ncustTable.FakeField = 1;',
+      stubIndex,
+      'create_d365fo_file(...)',
+    );
+    expect(result?.isError).toBe(true);
+    expect(result?.content[0].text).toContain('FakeField');
+    expect(result?.content[0].text).toContain('resolve_references');
+  });
+
+  it('passes warning-only code when enforced', () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    expect(gateOnReferenceErrors('ContosoMissingType helper;', stubIndex, 'op')).toBeNull();
+  });
+
+  it('never blocks when no symbolIndex is available', () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    expect(gateOnReferenceErrors('Fake::stuff();', undefined, 'op')).toBeNull();
+  });
+});
+
+// ─── MCP tool handler ────────────────────────────────────────────────────────
+
+describe('resolveReferencesTool', () => {
+  const context = {
+    symbolIndex: {
+      getReadDb: () => db,
+      getLabelById: (id: string, f?: string) => makeDeps(db).getLabelById(id, f),
+      getLabelFileIds: () => Object.keys(LABELS).map(labelFileId => ({ labelFileId })),
+    },
+  } as any;
+
+  it('returns success summary for clean code', async () => {
+    const result = await resolveReferencesTool(
+      { params: { arguments: { code: 'CustTable::find("c1");' } } },
+      context,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('✅');
+    expect(result.content[0].text).toContain('verified');
+  });
+
+  it('returns isError with structured violations for hallucinated code', async () => {
+    const result = await resolveReferencesTool(
+      { params: { arguments: { code: 'CustTable::fakeStatic();', context: 'MyClass' } } },
+      context,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('unknown-static-member');
+    expect(result.content[0].text).toContain('MyClass');
+  });
+
+  it('rejects missing code argument', async () => {
+    const result = await resolveReferencesTool({ params: { arguments: {} } }, context);
+    expect(result.isError).toBe(true);
+  });
+});

--- a/tests/tools/validate-xpp.test.ts
+++ b/tests/tools/validate-xpp.test.ts
@@ -173,3 +173,112 @@ describe('XML rules', () => {
     expect(getText(result)).not.toContain('XML001');
   });
 });
+
+// ─── Data-driven property rules (XML002–XML005) ──────────────────────────────
+
+const COMPLETE_TABLE_XML = `
+<AxTable>
+  <Name>ContosoTable</Name>
+  <Label>@Contoso:ContosoTable</Label>
+  <TableGroup>Main</TableGroup>
+  <ClusteredIndex>ContosoIdx</ClusteredIndex>
+  <Fields>
+    <AxTableField>
+      <Name>ContosoId</Name>
+      <ExtendedDataType>CustAccount</ExtendedDataType>
+    </AxTableField>
+  </Fields>
+  <Indexes>
+    <AxTableIndex>
+      <Name>ContosoIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+    </AxTableIndex>
+  </Indexes>
+</AxTable>`;
+
+const BARE_TABLE_XML = `
+<AxTable>
+  <Name>ContosoTable</Name>
+  <Fields>
+    <AxTableField>
+      <Name>ContosoId</Name>
+    </AxTableField>
+  </Fields>
+  <Indexes>
+    <AxTableIndex>
+      <Name>ContosoIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+    </AxTableIndex>
+  </Indexes>
+</AxTable>`;
+
+/** Stats provider stub with configurable ratios. */
+const statsProvider = (ratios: Record<string, number>, totals = 1000) => ({
+  getPropertyPresenceRatio: (nodeType: string, property: string) => {
+    const ratio = ratios[`${nodeType}.${property}`];
+    return ratio === undefined
+      ? { present: 0, total: 0, ratio: 0 }
+      : { present: Math.round(ratio * totals), total: totals, ratio };
+  },
+  getPropertyValueDistribution: () => [
+    { value: 'Main', count: 600 },
+    { value: 'Transaction', count: 400 },
+  ],
+});
+
+describe('XML property rules — static defaults (no stats)', () => {
+  it('flags missing Label, TableGroup and field EDT on a bare table', async () => {
+    const result = await validateXppTool(req({ code: BARE_TABLE_XML, codeType: 'xml-table' }));
+    const text = getText(result);
+    expect(text).toContain('XML002');
+    expect(text).toContain('XML003');
+    expect(text).toContain('XML004');
+    expect(text).not.toContain('XML005'); // static default off without stats
+  });
+
+  it('passes a complete table XML', async () => {
+    const result = await validateXppTool(req({ code: COMPLETE_TABLE_XML, codeType: 'xml-table' }));
+    const text = getText(result);
+    for (const rule of ['XML002', 'XML003', 'XML004', 'XML005']) {
+      expect(text).not.toContain(rule);
+    }
+  });
+});
+
+describe('XML property rules — mined statistics', () => {
+  it('includes mined evidence and value distribution in violations', async () => {
+    const context = {
+      symbolIndex: statsProvider({
+        'AxTable.Label': 0.97,
+        'AxTable.TableGroup': 0.95,
+        'AxTableField.ExtendedDataType': 0.92,
+      }),
+    } as any;
+    const result = await validateXppTool(req({ code: BARE_TABLE_XML, codeType: 'xml-table' }), context);
+    const text = getText(result);
+    expect(text).toContain('97% of 1,000 standard AxTable nodes');
+    expect(text).toContain('Main (60%)');
+  });
+
+  it('disables a rule when standard usage is below the threshold', async () => {
+    const context = {
+      symbolIndex: statsProvider({
+        'AxTable.Label': 0.3, // standard models rarely set it → rule off
+        'AxTable.TableGroup': 0.95,
+        'AxTableField.ExtendedDataType': 0.92,
+      }),
+    } as any;
+    const result = await validateXppTool(req({ code: BARE_TABLE_XML, codeType: 'xml-table' }), context);
+    const text = getText(result);
+    expect(text).not.toContain('XML002');
+    expect(text).toContain('XML003');
+  });
+
+  it('enables XML005 only when stats prove standard usage', async () => {
+    const context = {
+      symbolIndex: statsProvider({ 'AxTable.ClusteredIndex': 0.9 }),
+    } as any;
+    const result = await validateXppTool(req({ code: BARE_TABLE_XML, codeType: 'xml-table' }), context);
+    expect(getText(result)).toContain('XML005');
+  });
+});

--- a/tests/utils/propertyStats.test.ts
+++ b/tests/utils/propertyStats.test.ts
@@ -1,0 +1,66 @@
+/**
+ * property_stats tests — mined property distributions in the symbol index.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+let index: XppSymbolIndex;
+
+beforeAll(() => {
+  index = new XppSymbolIndex(':memory:', ':memory:');
+});
+
+afterAll(() => {
+  index.close();
+});
+
+describe('recordPropertyStat / getPropertyPresenceRatio', () => {
+  it('aggregates presence observations into a ratio', () => {
+    for (let i = 0; i < 9; i++) index.recordPropertyStat('AxTable', 'Label', '(present)', 'ApplicationSuite');
+    index.recordPropertyStat('AxTable', 'Label', '(absent)', 'ApplicationSuite');
+
+    const r = index.getPropertyPresenceRatio('AxTable', 'Label');
+    expect(r.total).toBe(10);
+    expect(r.present).toBe(9);
+    expect(r.ratio).toBeCloseTo(0.9);
+  });
+
+  it('returns total=0 when no statistics exist', () => {
+    const r = index.getPropertyPresenceRatio('AxForm', 'NeverMined');
+    expect(r.total).toBe(0);
+    expect(r.ratio).toBe(0);
+  });
+
+  it('aggregates across models', () => {
+    index.recordPropertyStat('AxView', 'Label', '(present)', 'ApplicationSuite');
+    index.recordPropertyStat('AxView', 'Label', '(present)', 'ApplicationPlatform');
+    const r = index.getPropertyPresenceRatio('AxView', 'Label');
+    expect(r.total).toBe(2);
+    expect(r.present).toBe(2);
+  });
+});
+
+describe('getPropertyValueDistribution', () => {
+  it('returns values ordered by count, excluding presence markers', () => {
+    for (let i = 0; i < 5; i++) index.recordPropertyStat('AxTable', 'TableGroup', 'Main', 'ApplicationSuite');
+    for (let i = 0; i < 3; i++) index.recordPropertyStat('AxTable', 'TableGroup', 'Transaction', 'ApplicationSuite');
+    index.recordPropertyStat('AxTable', 'TableGroup', 'Parameter', 'ApplicationSuite');
+    index.recordPropertyStat('AxTable', 'TableGroup', '(absent)', 'ApplicationSuite');
+
+    const dist = index.getPropertyValueDistribution('AxTable', 'TableGroup');
+    expect(dist[0]).toEqual({ value: 'Main', count: 5 });
+    expect(dist[1]).toEqual({ value: 'Transaction', count: 3 });
+    expect(dist.map(d => d.value)).not.toContain('(absent)');
+  });
+});
+
+describe('clearModels removes property stats for the cleared model', () => {
+  it('deletes per-model rows', () => {
+    index.recordPropertyStat('AxQuery', 'Title', '(present)', 'ContosoModel');
+    index.recordPropertyStat('AxQuery', 'Title', '(present)', 'ApplicationSuite');
+    index.clearModels(['ContosoModel']);
+    const r = index.getPropertyPresenceRatio('AxQuery', 'Title');
+    expect(r.total).toBe(1);
+  });
+});

--- a/tests/utils/provenanceStore.test.ts
+++ b/tests/utils/provenanceStore.test.ts
@@ -1,0 +1,135 @@
+/**
+ * provenanceStore tests — grounding tokens, TTL, object binding, enforcement.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createProvenanceToken,
+  getProvenanceBundle,
+  isValidToken,
+  tokenMatchesTarget,
+  enforceGrounding,
+} from '../../src/utils/provenanceStore';
+
+const ORIGINAL_ENFORCE = process.env.GROUNDING_ENFORCE;
+
+afterEach(() => {
+  if (ORIGINAL_ENFORCE === undefined) delete process.env.GROUNDING_ENFORCE;
+  else process.env.GROUNDING_ENFORCE = ORIGINAL_ENFORCE;
+  vi.useRealTimers();
+});
+
+// ─── Token lifecycle ─────────────────────────────────────────────────────────
+
+describe('createProvenanceToken / isValidToken', () => {
+  it('creates a 32-char hex token that validates', () => {
+    const token = createProvenanceToken({ goal: 'test', objectName: 'CustTable' });
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+    expect(isValidToken(token)).toBe(true);
+  });
+
+  it('stores the full context in the bundle', () => {
+    const token = createProvenanceToken({
+      goal: 'test',
+      objectName: 'CustTable',
+      methodName: 'validateWrite',
+      proposedName: 'CustTableContoso_Extension',
+    });
+    const bundle = getProvenanceBundle(token);
+    expect(bundle?.context.objectName).toBe('CustTable');
+    expect(bundle?.context.proposedName).toBe('CustTableContoso_Extension');
+  });
+
+  it('rejects an unknown token', () => {
+    expect(isValidToken('deadbeefdeadbeefdeadbeefdeadbeef')).toBe(false);
+  });
+
+  it('expires tokens after 30 minutes', () => {
+    vi.useFakeTimers();
+    const token = createProvenanceToken({ goal: 'test', objectName: 'CustTable' });
+    expect(isValidToken(token)).toBe(true);
+    vi.advanceTimersByTime(31 * 60 * 1000);
+    expect(isValidToken(token)).toBe(false);
+  });
+});
+
+// ─── Object binding ──────────────────────────────────────────────────────────
+
+describe('tokenMatchesTarget', () => {
+  const bundleFor = (objectName: string, proposedName?: string) => {
+    const token = createProvenanceToken({ goal: 'test', objectName, proposedName });
+    return getProvenanceBundle(token)!;
+  };
+
+  it('matches exact object name (case-insensitive)', () => {
+    expect(tokenMatchesTarget(bundleFor('CustTable'), 'custtable')).toBe(true);
+  });
+
+  it('matches extension element name embedding the base object', () => {
+    expect(tokenMatchesTarget(bundleFor('CustTable'), 'CustTable.ContosoExtension')).toBe(true);
+  });
+
+  it('matches extension class name embedding the base object', () => {
+    expect(tokenMatchesTarget(bundleFor('SalesFormLetter'), 'SalesFormLetterContoso_Extension')).toBe(true);
+  });
+
+  it('matches the proposedName recorded by prepare_change', () => {
+    expect(tokenMatchesTarget(
+      bundleFor('CustTable', 'ContosoCustHelper'),
+      'ContosoCustHelper',
+    )).toBe(true);
+  });
+
+  it('rejects a different object', () => {
+    expect(tokenMatchesTarget(bundleFor('CustTable'), 'SalesTable.ContosoExtension')).toBe(false);
+  });
+
+  it('does not substring-match very short names', () => {
+    expect(tokenMatchesTarget(bundleFor('Tax'), 'TaxWithholdContoso_Extension')).toBe(false);
+    expect(tokenMatchesTarget(bundleFor('Tax'), 'Tax')).toBe(true);
+  });
+});
+
+// ─── Enforcement ─────────────────────────────────────────────────────────────
+
+describe('enforceGrounding', () => {
+  it('passes when GROUNDING_ENFORCE is not set', () => {
+    delete process.env.GROUNDING_ENFORCE;
+    expect(enforceGrounding(undefined, 'op')).toBeNull();
+  });
+
+  it('fails closed without a token when GROUNDING_ENFORCE=true', () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const result = enforceGrounding(undefined, 'create_d365fo_file(...)');
+    expect(result?.isError).toBe(true);
+    expect(result?.content[0].text).toContain('prepare_change');
+  });
+
+  it('fails with an invalid token', () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const result = enforceGrounding('deadbeefdeadbeefdeadbeefdeadbeef', 'op');
+    expect(result?.isError).toBe(true);
+    expect(result?.content[0].text).toContain('expired or is invalid');
+  });
+
+  it('passes with a valid token and matching target', () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const token = createProvenanceToken({ goal: 'test', objectName: 'CustTable' });
+    expect(enforceGrounding(token, 'op', 'CustTable.ContosoExtension')).toBeNull();
+  });
+
+  it('rejects a valid token used on a different object', () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const token = createProvenanceToken({ goal: 'test', objectName: 'CustTable' });
+    const result = enforceGrounding(token, 'op', 'SalesTable.ContosoExtension');
+    expect(result?.isError).toBe(true);
+    expect(result?.content[0].text).toContain('token mismatch');
+    expect(result?.content[0].text).toContain('SalesTable.ContosoExtension');
+  });
+
+  it('passes with a valid token when no target is supplied (backward compatible)', () => {
+    process.env.GROUNDING_ENFORCE = 'true';
+    const token = createProvenanceToken({ goal: 'test', objectName: 'CustTable' });
+    expect(enforceGrounding(token, 'op')).toBeNull();
+  });
+});

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -29,8 +29,8 @@ describe('tool inventory contract', () => {
   });
 
   it('exposes the expected total tool count', () => {
-    expect(mcpServerToolNames).toHaveLength(56);
-    expect(startupCatalogToolNames).toHaveLength(56);
+    expect(mcpServerToolNames).toHaveLength(57);
+    expect(startupCatalogToolNames).toHaveLength(57);
   });
 
   it('keeps local-only tool set aligned with the published tool inventory', () => {
@@ -40,7 +40,7 @@ describe('tool inventory contract', () => {
     }
 
     expect(LOCAL_TOOLS.size).toBe(25);
-    expect(mcpServerToolNames.filter(name => !LOCAL_TOOLS.has(name))).toHaveLength(31);
+    expect(mcpServerToolNames.filter(name => !LOCAL_TOOLS.has(name))).toHaveLength(32);
   });
 
   it('includes critical diagnostics and SDLC tools in both inventories', () => {

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -29,8 +29,8 @@ describe('tool inventory contract', () => {
   });
 
   it('exposes the expected total tool count', () => {
-    expect(mcpServerToolNames).toHaveLength(57);
-    expect(startupCatalogToolNames).toHaveLength(57);
+    expect(mcpServerToolNames).toHaveLength(58);
+    expect(startupCatalogToolNames).toHaveLength(58);
   });
 
   it('keeps local-only tool set aligned with the published tool inventory', () => {
@@ -40,7 +40,7 @@ describe('tool inventory contract', () => {
     }
 
     expect(LOCAL_TOOLS.size).toBe(25);
-    expect(mcpServerToolNames.filter(name => !LOCAL_TOOLS.has(name))).toHaveLength(32);
+    expect(mcpServerToolNames.filter(name => !LOCAL_TOOLS.has(name))).toHaveLength(33);
   });
 
   it('includes critical diagnostics and SDLC tools in both inventories', () => {


### PR DESCRIPTION
This pull request updates documentation to reflect the addition of two new MCP tools, increasing the total from 56 to 58. All references to the tool count and related descriptions have been updated for accuracy, and the documentation for the new tools and grounding enforcement has been enhanced.

**Documentation updates for tool count:**

* Updated all references in `README.md`, `docs/ARCHITECTURE.md`, `docs/CLAUDE_CODE_SETUP.md`, `docs/MCP_CONFIG.md`, `docs/QUICK_START.md`, and `docs/MCP_TOOLS.md` to state "58 tools" instead of "56 tools". [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L176-R176) [[4]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L39-R39) [[5]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L105-R105) [[6]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L807-R807) [[7]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L816-R816) [[8]](diffhunk://#diff-002f25c9a2350182a5993f371dfb533b2092c2c18bd96ad4f8635fc6a9c66bc5L174-R174) [[9]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcL364-R364) [[10]](diffhunk://#diff-86c24f6779432fd3c1a00d3f2e7efcfd7191abd4718d3c6c7cecb68aed3268dcL389-R390) [[11]](diffhunk://#diff-5d13ebe4a737c499916206e19a9f303a853f7e82beb707ba89d45e15c2a69a95L4-R4) [[12]](diffhunk://#diff-62e91d3086c96fcc1f472738d7bc30a4eef33361af2bfeba2f43668428d717bfL232-R232) [[13]](diffhunk://#diff-62e91d3086c96fcc1f472738d7bc30a4eef33361af2bfeba2f43668428d717bfL379-R379)

**Tool documentation enhancements:**

* Added documentation for two new tools: `resolve_references` (semantic reference resolver) and `prepare_create` (context aggregator for new objects) in `docs/MCP_TOOLS.md`.
* Expanded description of `validate_xpp` to include new data-driven property rules and clarified its usage.

**Grounding enforcement improvements:**

* Enhanced the grounding enforcement documentation to explain that provenance tokens are now bound to the object they were issued for and that source code validation is enforced before write operations.