### PR TITLE
fix: remove redundant custom models list from get_workspace_info output

### DIFF
--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -570,10 +570,6 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           );
         } else {
           lines.push(`✅ Configuration looks valid. Proceed with D365FO operations using model "${modelName}".`);
-          const customModels = context.symbolIndex.getCustomModels?.() ?? [];
-          if (customModels.length > 0) {
-            lines.push(`Custom models in index: ${customModels.join(', ')}`);
-          }
         }
 
         // List all projects found under D365FO_SOLUTIONS_PATH so the user can switch


### PR DESCRIPTION
The 'Custom models in index' line after the valid-config message was redundant — the same information is already present in the '## Available Projects' section below with more context (paths, active indicator). Removing it reduces token usage.