### PR TITLE
Feature/grounded reliability phase2

### DIFF
--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -570,6 +570,17 @@ export class XppSymbolIndex {
       CREATE INDEX IF NOT EXISTS idx_mit_model ON menu_item_targets(model);
     `);
 
+    // ── Index Metadata (key-value) ───────────────────────────────────────────
+    // Small bookkeeping table: e.g. last_indexed_at drives the staleness
+    // detector in get_workspace_info.
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS _index_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+
     // ── Property Statistics ──────────────────────────────────────────────────
     // Distribution of metadata property values across STANDARD models, mined
     // during build-database. Drives data-driven BP property rules in
@@ -1208,6 +1219,8 @@ export class XppSymbolIndex {
       this.createFTSTriggers();
       console.log(`   ✅ Indexed ${models.length} model(s) in ${duration}s (FTS rebuilt in ${ftsDuration}s)`);
     }
+
+    this.touchLastIndexed();
   }
 
   /**
@@ -1906,6 +1919,31 @@ export class XppSymbolIndex {
       } catch (error) {
         console.error(`      ⚠️  Skipped ${extensionType} ${file}: ${error instanceof Error ? error.message : error}`);
       }
+    }
+  }
+
+  // ─── Index freshness bookkeeping ────────────────────────────────────────────
+
+  /** Record "the index was (re)built/updated now" — drives staleness detection. */
+  touchLastIndexed(): void {
+    try {
+      this.db.prepare(
+        `INSERT OR REPLACE INTO _index_meta (key, value) VALUES ('last_indexed_at', ?)`,
+      ).run(new Date().toISOString());
+    } catch {
+      // Bookkeeping is best-effort
+    }
+  }
+
+  /** ISO timestamp of the last full or incremental index update, or null. */
+  getLastIndexedAt(): string | null {
+    try {
+      const row = this.getReadDb().prepare(
+        `SELECT value FROM _index_meta WHERE key = 'last_indexed_at'`,
+      ).get() as { value: string } | undefined;
+      return row?.value ?? null;
+    } catch {
+      return null;
     }
   }
 

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -8,6 +8,7 @@ import os from 'os';
 import crypto from 'crypto';
 import { getConfigManager } from '../utils/configManager.js';
 import { forceReleaseLock } from '../utils/operationLocks.js';
+import { lookupErrorFix } from './d365foErrorHelp.js';
 
 const execFileAsync = util.promisify(execFile);
 
@@ -49,6 +50,107 @@ const XPPC_COMPILE_ERROR_RE = /^Compile Error:/m;
 
 // When xppc reports stale symbols from a previous incremental build, a full build is needed
 const XPPC_STALE_SYMBOL_RE = /has not been successfully compiled since it was last changed|Do a Full Build/i;
+
+// ---------------------------------------------------------------------------
+// Structured compiler diagnostics
+// xppc -log lines have the form (observed in standalone/UDE mode):
+//   Compile Error: Class Method dynamics://MyModel/MyClass/myMethod: [(28,27),(28,28)]: ';' expected.
+// i.e.  <severity>: <element kind> dynamics://<model>/<object>[/<member>]: [(line,col)[,(line,col)]]: <message>
+// ---------------------------------------------------------------------------
+
+export interface XppcDiagnostic {
+  severity: 'error' | 'warning';
+  /** Element kind as reported by xppc, e.g. "Class Method", "Table Field" */
+  kind?: string;
+  model?: string;
+  object?: string;
+  member?: string;
+  line?: number;
+  column?: number;
+  message: string;
+}
+
+const XPPC_DIAG_LINE_RE =
+  /^(Compile Fatal Error|Compile Error|Compile Warning|Generation Warning|Best Practice Warning):\s*(?:(.*?)\s+)?dynamics:\/\/([^/\s:]+)\/([^/\s:]+)(?:\/([^\s:]+))?\s*:?\s*\[\((\d+),(\d+)\)(?:,\(\d+,\d+\))?\]\s*:\s*(.*)$/;
+
+/** Parse xppc log content into structured diagnostics. */
+export function parseXppcDiagnostics(logContent: string): XppcDiagnostic[] {
+  const diagnostics: XppcDiagnostic[] = [];
+  for (const rawLine of logContent.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const m = XPPC_DIAG_LINE_RE.exec(line);
+    if (m) {
+      diagnostics.push({
+        severity: m[1].includes('Error') ? 'error' : 'warning',
+        kind: m[2] || undefined,
+        model: m[3],
+        object: m[4],
+        member: m[5] || undefined,
+        line: Number(m[6]),
+        column: Number(m[7]),
+        message: m[8].trim(),
+      });
+      continue;
+    }
+    // Fallback: severity prefix without the dynamics:// location part
+    const simple = /^(Compile Fatal Error|Compile Error|Compile Warning|Generation Warning):\s*(.+)$/.exec(line);
+    if (simple) {
+      diagnostics.push({
+        severity: simple[1].includes('Error') ? 'error' : 'warning',
+        message: simple[2].trim(),
+      });
+    }
+  }
+  return diagnostics;
+}
+
+/**
+ * Render diagnostics as a numbered, machine-actionable block. Errors come
+ * first; duplicate messages are collapsed; the first few distinct errors are
+ * enriched with a fix hint from the get_d365fo_error_help knowledge base so
+ * the model can correct everything in one round.
+ */
+export function formatStructuredDiagnostics(diagnostics: XppcDiagnostic[], maxItems = 25): string {
+  if (diagnostics.length === 0) return '';
+  const errors = diagnostics.filter(d => d.severity === 'error');
+  const warnings = diagnostics.filter(d => d.severity === 'warning');
+  const ordered = [...errors, ...warnings];
+
+  const seen = new Set<string>();
+  const lines: string[] = [
+    `📋 Structured diagnostics: ${errors.length} error(s), ${warnings.length} warning(s)`,
+    '',
+  ];
+  let shown = 0;
+  let enriched = 0;
+  for (const d of ordered) {
+    const key = `${d.object ?? ''}|${d.member ?? ''}|${d.line ?? ''}|${d.message}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (shown >= maxItems) {
+      lines.push(`… and ${ordered.length - shown} more (see raw log below).`);
+      break;
+    }
+    shown++;
+    const location = d.object
+      ? `${d.object}${d.member ? `.${d.member}` : ''}${d.line ? ` (line ${d.line}, col ${d.column})` : ''}`
+      : '(no location)';
+    lines.push(`${shown}. ${d.severity === 'error' ? '🔴' : '🟡'} ${location}: ${d.message}`);
+    // Enrich the first few distinct errors with a known fix
+    if (d.severity === 'error' && enriched < 3) {
+      const help = lookupErrorFix(d.message);
+      if (help) {
+        enriched++;
+        lines.push(`   💡 ${help.title}: ${help.fix[0]}`);
+      }
+    }
+  }
+  if (errors.length > 0) {
+    lines.push('');
+    lines.push('Fix the errors with modify_d365fo_file (use the object/line references above), then rebuild.');
+  }
+  return lines.join('\n');
+}
 
 // ---------------------------------------------------------------------------
 // Build job state
@@ -132,6 +234,15 @@ async function readLogTail(logFile: string, lines = 60): Promise<string> {
     return all.slice(-lines).join('\n').trim();
   } catch {
     return '(log not yet available)';
+  }
+}
+
+// Read the entire log without truncation — used for diagnostics parsing only.
+async function readWholeLog(logFile: string): Promise<string> {
+  try {
+    return await readFile(logFile, 'utf-8');
+  } catch {
+    return '';
   }
 }
 
@@ -688,14 +799,20 @@ export const buildProjectTool = async (params: any, _context: any) => {
         const relevantResult = succeeded
           ? allResults[allResults.length - 1]
           : allResults.find(r => r.status === 'failed');
+        const relevantLogFile = relevantResult?.logFile ?? existingState.logFile;
         const logContent = succeeded
-          ? await readLogTail(relevantResult?.logFile ?? existingState.logFile)
-          : await readFullLog(relevantResult?.logFile ?? existingState.logFile);
+          ? await readLogTail(relevantLogFile)
+          : await readFullLog(relevantLogFile);
+        const structured = succeeded
+          ? ''
+          : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(relevantLogFile)));
 
         return {
           content: [{
             type: 'text',
-            text: `${statusIcon} — ${allResults.length} models, ${totalDuration}s total\n\n${modelLines}\n\n--- Log (${relevantResult?.modelName ?? targetModel}) ---\n${logContent}`,
+            text: `${statusIcon} — ${allResults.length} models, ${totalDuration}s total\n\n${modelLines}\n\n` +
+              (structured ? `${structured}\n\n` : '') +
+              `--- Log (${relevantResult?.modelName ?? targetModel}) ---\n${logContent}`,
           }],
           ...(succeeded ? {} : { isError: true }),
         };
@@ -710,11 +827,16 @@ export const buildProjectTool = async (params: any, _context: any) => {
       const duration      = existingState.endTime
         ? Math.round((new Date(existingState.endTime).getTime() - new Date(existingState.startTime).getTime()) / 1000)
         : '?';
+      const structured    = succeeded
+        ? ''
+        : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(existingState.logFile)));
 
       return {
         content: [{
           type: 'text',
-          text: `${statusIcon} (${existingState.tool}, ${buildMode}, ${duration}s)\n\nModel: ${targetModel}\n\n${logContent || '(no output)'}`,
+          text: `${statusIcon} (${existingState.tool}, ${buildMode}, ${duration}s)\n\nModel: ${targetModel}\n\n` +
+            (structured ? `${structured}\n\n--- Raw log ---\n` : '') +
+            `${logContent || '(no output)'}`,
         }],
         ...((!succeeded) ? { isError: true } : {}),
       };

--- a/src/tools/d365foErrorHelp.ts
+++ b/src/tools/d365foErrorHelp.ts
@@ -380,6 +380,20 @@ function formatEntry(entry: ErrorEntry, context?: string): string {
 
 // ─── Tool Handler ────────────────────────────────────────────────────────────
 
+/**
+ * Programmatic lookup against ERROR_DB — used by build_d365fo_project to
+ * enrich structured compiler diagnostics with a fix hint without an extra
+ * tool round-trip. Returns the best match or undefined.
+ */
+export function lookupErrorFix(errorText: string): { title: string; fix: string[] } | undefined {
+  const scored = ERROR_DB
+    .map(entry => ({ entry, score: scoreError(entry, errorText, undefined) }))
+    .filter(s => s.score > 0)
+    .sort((a, b) => b.score - a.score);
+  if (scored.length === 0) return undefined;
+  return { title: scored[0].entry.title, fix: scored[0].entry.fix };
+}
+
 export function d365foErrorHelpTool(request: CallToolRequest) {
   try {
     const args = D365foErrorHelpArgsSchema.parse(request.params.arguments);

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -62,7 +62,11 @@ import { validateXppTool } from './validateXpp.js';
 import { resolveReferencesTool } from './resolveReferences.js';
 import { prepareChangeTool } from './prepareChange.js';
 import { prepareCreateTool } from './prepareCreate.js';
-import { recordToolStart, startMetricsLogging } from '../utils/toolMetrics.js';
+import { recordToolStart, startMetricsLogging, recordCallSequence } from '../utils/toolMetrics.js';
+import {
+  DEDUP_EXCLUDED_TOOLS, DEDUP_TTL_MS,
+  dedupKey, getDedupedResult, storeDedupResult, appendNote,
+} from '../utils/callDedup.js';
 import { buildProgressMessage } from '../utils/toolProgressMessage.js';
 
 /**
@@ -144,6 +148,7 @@ function getCapForTool(toolName: string): number | 'uncapped' {
   return TOOL_CAP_SIZES[toolName] ?? TOOL_CAP_SIZES['default'];
 }
 
+
 function capToolResponse(toolName: string, result: any): any {
   const cap = getCapForTool(toolName);
   if (cap === 'uncapped' || !result?.content) return result;
@@ -208,6 +213,21 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         content: [{ type: 'text', text: `⚠️ Tool '${toolName}' is not available in write-only mode.\n\nThis local MCP server only handles file operations. Search and analysis tools are provided by the Azure MCP server.` }],
         isError: true,
       };
+    }
+
+    // ── Loop detection + duplicate-call dedup ────────────────────────────────
+    const callKey = dedupKey(toolName, request.params.arguments);
+    const occurrences = recordCallSequence(toolName, callKey);
+    if (!DEDUP_EXCLUDED_TOOLS.has(toolName)) {
+      const cached = getDedupedResult(callKey);
+      if (cached !== undefined) {
+        console.error(`[toolHandler] ♻️  ${toolName}: identical call within ${DEDUP_TTL_MS / 1000}s — served from dedup cache`);
+        return appendNote(
+          cached,
+          `> ♻️ Duplicate call — this exact ${toolName} call was answered moments ago; ` +
+          `the result above is identical. Use the data you already have instead of re-querying.`,
+        );
+      }
     }
 
     const finishMetrics = recordToolStart(toolName);
@@ -655,11 +675,25 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       };
     }
 
-    const capped = capToolResponse(toolName, result);
+    let capped = capToolResponse(toolName, result);
     // Record metrics: detect empty result (no content or first text item is empty)
     const firstText = capped?.content?.[0]?.text;
     const isEmpty = !firstText || firstText.trim().length === 0 || firstText === 'No results returned';
     finishMetrics(isEmpty);
+
+    if (!DEDUP_EXCLUDED_TOOLS.has(toolName)) {
+      storeDedupResult(callKey, capped);
+      // Loop hint: 3+ identical calls in the recent window means the model is
+      // cycling (cache misses only happen when calls are >60 s apart).
+      if (occurrences >= 3) {
+        capped = appendNote(
+          capped,
+          `> ⚠️ Loop detected: this is occurrence #${occurrences} of the exact same ${toolName} call. ` +
+          `The answer does not change between calls. If you are missing information, ` +
+          `use a DIFFERENT tool or different parameters (see suggestions above), or ask the user.`,
+        );
+      }
+    }
     return capped;
   });
 }

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -67,6 +67,8 @@ import {
   DEDUP_EXCLUDED_TOOLS, DEDUP_TTL_MS,
   dedupKey, getDedupedResult, storeDedupResult, appendNote,
 } from '../utils/callDedup.js';
+import { checkIndexStaleness } from '../utils/indexStaleness.js';
+import * as nodePath from 'path';
 import { buildProgressMessage } from '../utils/toolProgressMessage.js';
 
 /**
@@ -604,6 +606,21 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           }
           lines.push(``);
           lines.push(`To switch project: call get_workspace_info with projectName = "<ModelName>"`);
+        }
+
+        // -----------------------------------------------------------------------
+        // Index freshness — compare workspace mtimes vs last_indexed_at so the
+        // model (and user) know whether symbol lookups reflect current code.
+        // -----------------------------------------------------------------------
+        try {
+          const lastIndexedAt = context.symbolIndex.getLastIndexedAt?.() ?? null;
+          const modelMetadataDir = packagePath && modelName
+            ? nodePath.join(packagePath, modelName)
+            : null;
+          const staleness = checkIndexStaleness(lastIndexedAt, modelMetadataDir);
+          lines.push('', ...staleness.lines);
+        } catch {
+          // Freshness reporting is best-effort — never break get_workspace_info
         }
 
         // -----------------------------------------------------------------------

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -118,6 +118,8 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
         await bridgeRefreshProvider(context.bridge);
       } catch { /* bridge not available */ }
 
+      symbolIndex.touchLastIndexed?.();
+
       const parts_cleaned: string[] = [];
       if (deletedCount > 0) parts_cleaned.push(`${deletedCount} symbol(s)`);
       if (labelCount > 0) parts_cleaned.push(`${labelCount} label(s)`);
@@ -175,6 +177,7 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
       }
 
       await invalidateCache(cache, labelFileId, 'label', [labelFileId]);
+      symbolIndex.touchLastIndexed?.();
 
       return {
         content: [{
@@ -319,6 +322,7 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
 
     // ── Invalidate Redis cache for the re-indexed object ────────────────────
     await invalidateCache(cache, objectName, objectType, [objectName]);
+    symbolIndex.touchLastIndexed?.();
 
     return {
       content: [{

--- a/src/utils/callDedup.ts
+++ b/src/utils/callDedup.ts
@@ -1,0 +1,74 @@
+/**
+ * Duplicate-call dedup cache (agentic-loop mitigation).
+ *
+ * A model stuck in a loop re-issues the same read call with identical
+ * arguments. Read tools are served from a short-TTL cache on repeat — the
+ * model gets the identical answer instantly (with a note) instead of
+ * re-running DB/bridge queries. Stateful tools are excluded: repeated
+ * identical calls are legitimate there (build polling, write retries after
+ * fixes, git state checks).
+ */
+
+export const DEDUP_TTL_MS = 60_000;
+export const DEDUP_MAX_ENTRIES = 200;
+
+/** Tools whose repeated identical calls are legitimate — never dedup, never loop-hint. */
+export const DEDUP_EXCLUDED_TOOLS = new Set([
+  'create_d365fo_file', 'modify_d365fo_file', 'generate_d365fo_xml',
+  'create_label', 'rename_label', 'undo_last_modification',
+  'update_symbol_index', 'build_d365fo_project', 'trigger_db_sync',
+  'run_bp_check', 'run_systest_class', 'review_workspace_changes',
+  'verify_d365fo_project', 'get_workspace_info',
+  'prepare_change', 'prepare_create', // issue fresh grounding tokens
+]);
+
+interface DedupEntry {
+  result: unknown;
+  at: number;
+}
+
+const dedupCache = new Map<string, DedupEntry>();
+
+export function dedupKey(toolName: string, args: unknown): string {
+  try {
+    return `${toolName}|${JSON.stringify(args ?? {})}`;
+  } catch {
+    return `${toolName}|<unserializable>`;
+  }
+}
+
+export function getDedupedResult(key: string): any | undefined {
+  const entry = dedupCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.at > DEDUP_TTL_MS) {
+    dedupCache.delete(key);
+    return undefined;
+  }
+  return entry.result;
+}
+
+export function storeDedupResult(key: string, result: any): void {
+  if (result?.isError) return; // never cache failures — retries must re-execute
+  if (dedupCache.size >= DEDUP_MAX_ENTRIES) {
+    // Drop the oldest entry (Map preserves insertion order)
+    const oldest = dedupCache.keys().next().value;
+    if (oldest !== undefined) dedupCache.delete(oldest);
+  }
+  dedupCache.set(key, { result, at: Date.now() });
+}
+
+/** Test/maintenance helper. */
+export function clearDedupCache(): void {
+  dedupCache.clear();
+}
+
+/** Append a note to the first text item of a result (shallow clone). */
+export function appendNote(result: any, note: string): any {
+  if (!result?.content?.length) return result;
+  const content = result.content.map((item: any, i: number) =>
+    i === 0 && item.type === 'text' && typeof item.text === 'string'
+      ? { ...item, text: `${item.text}\n\n${note}` }
+      : item,
+  );
+  return { ...result, content };
+}

--- a/src/utils/indexStaleness.ts
+++ b/src/utils/indexStaleness.ts
@@ -1,0 +1,139 @@
+/**
+ * Index staleness detection.
+ *
+ * The symbol index is the single source of truth for grounding — but only
+ * while it reflects the current workspace. This module compares the newest
+ * XML mtime in the active model's metadata folder with the index's
+ * last_indexed_at bookkeeping timestamp and produces a warning when the
+ * workspace has changed since the last (re)index.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Hard cap on stat'ed files so the scan stays fast on huge models. */
+const MAX_SCANNED_FILES = 5000;
+
+/** Files newer than the index by less than this are tolerated (clock skew, in-flight writes). */
+const TOLERANCE_MS = 60_000;
+
+export interface MtimeScanResult {
+  /** Epoch ms of the newest .xml/.label.txt file found */
+  newestMtime: number;
+  newestFile: string;
+  scannedFiles: number;
+  /** True when the scan stopped at MAX_SCANNED_FILES */
+  truncated: boolean;
+}
+
+/**
+ * Recursively find the newest metadata file mtime under rootDir.
+ * Returns null when the directory does not exist or contains no metadata files.
+ */
+export function findNewestMetadataMtime(rootDir: string): MtimeScanResult | null {
+  let newestMtime = 0;
+  let newestFile = '';
+  let scannedFiles = 0;
+  let truncated = false;
+
+  const walk = (dir: string): void => {
+    if (truncated) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (truncated) return;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Skip build output and VCS noise
+        const lower = entry.name.toLowerCase();
+        if (lower === 'bin' || lower === '.git' || lower === 'xppmetadata') continue;
+        walk(full);
+      } else if (/\.(xml|label\.txt)$/i.test(entry.name)) {
+        scannedFiles++;
+        if (scannedFiles > MAX_SCANNED_FILES) {
+          truncated = true;
+          return;
+        }
+        try {
+          const mtime = fs.statSync(full).mtimeMs;
+          if (mtime > newestMtime) {
+            newestMtime = mtime;
+            newestFile = full;
+          }
+        } catch { /* file vanished mid-scan */ }
+      }
+    }
+  };
+
+  try {
+    if (!fs.existsSync(rootDir) || !fs.statSync(rootDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  walk(rootDir);
+  if (scannedFiles === 0) return null;
+  return { newestMtime, newestFile, scannedFiles, truncated };
+}
+
+export interface StalenessReport {
+  status: 'fresh' | 'stale' | 'unknown';
+  lines: string[];
+}
+
+/**
+ * Compare workspace mtimes against the index timestamp and render a report
+ * section for get_workspace_info.
+ */
+export function checkIndexStaleness(
+  lastIndexedAt: string | null,
+  modelMetadataDir: string | null,
+): StalenessReport {
+  const lines: string[] = ['## Index Freshness', ''];
+
+  if (!lastIndexedAt) {
+    lines.push(
+      'ℹ️  Index has no freshness timestamp yet (built before this feature or never built).',
+      '   It will be recorded on the next build-database run or update_symbol_index call.',
+    );
+    return { status: 'unknown', lines };
+  }
+
+  const indexedAtMs = Date.parse(lastIndexedAt);
+  const ageHours = Math.round((Date.now() - indexedAtMs) / 3_600_000);
+  lines.push(`Last indexed   : ${lastIndexedAt} (${ageHours} h ago)`);
+
+  if (!modelMetadataDir) {
+    lines.push('ℹ️  Model metadata folder not resolved — cannot compare workspace mtimes.');
+    return { status: 'unknown', lines };
+  }
+
+  const scan = findNewestMetadataMtime(modelMetadataDir);
+  if (!scan) {
+    lines.push(`ℹ️  No metadata files found under ${modelMetadataDir} — nothing to compare.`);
+    return { status: 'unknown', lines };
+  }
+
+  lines.push(
+    `Newest file    : ${path.basename(scan.newestFile)} (${new Date(scan.newestMtime).toISOString()})` +
+    (scan.truncated ? ` — scanned first ${MAX_SCANNED_FILES} files` : ` — ${scan.scannedFiles} files scanned`),
+  );
+
+  if (scan.newestMtime > indexedAtMs + TOLERANCE_MS) {
+    lines.push(
+      '',
+      '⚠️  **INDEX IS STALE** — the workspace contains files newer than the last index update.',
+      `   Newest change: ${scan.newestFile}`,
+      '   Symbol lookups may return outdated signatures/fields for recently edited objects.',
+      `   Fix: call \`update_symbol_index(filePath="${scan.newestFile.replace(/\\/g, '\\\\')}")\` for the changed file(s),`,
+      '   or run `npm run build-database` (EXTRACT_MODE=custom) for a full custom-model refresh.',
+    );
+    return { status: 'stale', lines };
+  }
+
+  lines.push('✅ Index is up to date with the workspace.');
+  return { status: 'fresh', lines };
+}

--- a/src/utils/toolMetrics.ts
+++ b/src/utils/toolMetrics.ts
@@ -10,26 +10,71 @@ interface ToolStats {
   calls: number;
   totalLatencyMs: number;
   emptyResults: number;
+  /** Calls with identical tool+args repeated within the recent-call window */
+  duplicateCalls: number;
 }
 
 const stats = new Map<string, ToolStats>();
 
 let logIntervalHandle: ReturnType<typeof setInterval> | null = null;
 
+function getStats(toolName: string): ToolStats {
+  let s = stats.get(toolName);
+  if (!s) {
+    s = { calls: 0, totalLatencyMs: 0, emptyResults: 0, duplicateCalls: 0 };
+    stats.set(toolName, s);
+  }
+  return s;
+}
+
 /** Call before dispatching a tool. Returns a finish() callback. */
 export function recordToolStart(toolName: string): (isEmpty: boolean) => void {
   const t0 = Date.now();
   return (isEmpty: boolean) => {
     const elapsed = Date.now() - t0;
-    let s = stats.get(toolName);
-    if (!s) {
-      s = { calls: 0, totalLatencyMs: 0, emptyResults: 0 };
-      stats.set(toolName, s);
-    }
+    const s = getStats(toolName);
     s.calls++;
     s.totalLatencyMs += elapsed;
     if (isEmpty) s.emptyResults++;
   };
+}
+
+// ─── Call-sequence tracking (agentic-loop detection) ─────────────────────────
+// Keeps a ring buffer of the most recent tool calls (tool + args hash).
+// A model stuck in a loop re-issues the same call with the same arguments —
+// recordCallSequence returns how many times this exact call appeared in the
+// recent window so the handler can inject a corrective hint into the response.
+
+const SEQUENCE_WINDOW = 15;
+const SEQUENCE_BUFFER_MAX = 30;
+
+interface SequenceEntry {
+  tool: string;
+  argsKey: string;
+  at: number;
+}
+
+const recentCalls: SequenceEntry[] = [];
+
+/**
+ * Record a call in the sequence buffer and return the number of occurrences
+ * of this exact tool+args combination within the recent window (including
+ * the call just recorded). 1 = first occurrence, 3+ = likely loop.
+ */
+export function recordCallSequence(toolName: string, argsKey: string): number {
+  recentCalls.push({ tool: toolName, argsKey, at: Date.now() });
+  if (recentCalls.length > SEQUENCE_BUFFER_MAX) {
+    recentCalls.splice(0, recentCalls.length - SEQUENCE_BUFFER_MAX);
+  }
+  const window = recentCalls.slice(-SEQUENCE_WINDOW);
+  const occurrences = window.filter(e => e.tool === toolName && e.argsKey === argsKey).length;
+  if (occurrences > 1) getStats(toolName).duplicateCalls++;
+  return occurrences;
+}
+
+/** Test/maintenance helper — clears the sequence buffer. */
+export function resetCallSequence(): void {
+  recentCalls.length = 0;
 }
 
 /** Returns a snapshot of current metrics sorted by call count descending. */
@@ -38,6 +83,7 @@ export function getMetricsSnapshot(): Array<{
   calls: number;
   avgLatencyMs: number;
   emptyRatio: number;
+  duplicateCalls: number;
 }> {
   return Array.from(stats.entries())
     .map(([tool, s]) => ({
@@ -45,6 +91,7 @@ export function getMetricsSnapshot(): Array<{
       calls: s.calls,
       avgLatencyMs: s.calls > 0 ? Math.round(s.totalLatencyMs / s.calls) : 0,
       emptyRatio: s.calls > 0 ? Math.round((s.emptyResults / s.calls) * 100) / 100 : 0,
+      duplicateCalls: s.duplicateCalls,
     }))
     .sort((a, b) => b.calls - a.calls);
 }

--- a/tests/golden/quality-gate.test.ts
+++ b/tests/golden/quality-gate.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Golden quality-gate tests (plan pillar 7).
+ *
+ * Locks the offline quality chain end-to-end:
+ *   resolve_references (semantic grounding) → validate_xpp (BP rules)
+ *
+ * Two directions are asserted:
+ *   1. Realistic, correct artifacts MUST pass both gates cleanly — the gates
+ *      must never block legitimate code (false positives break the workflow).
+ *   2. Hallucinated / BP-violating variants MUST be rejected — regressions in
+ *      any rule or in the resolver surface here immediately.
+ *
+ * generate_code templates are additionally locked against validate_xpp so the
+ * "/// Foo class." class of template regressions (fixed in fbc2f76) cannot
+ * return.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Database from 'better-sqlite3';
+import { resolveXppReferences, type ResolverDeps } from '../../src/tools/resolveReferences';
+import { validateXppTool } from '../../src/tools/validateXpp';
+import { codeGenTool } from '../../src/tools/codeGen';
+
+// ─── Index fixture (production schema subset, realistic standard objects) ────
+
+let db: InstanceType<typeof Database>;
+let deps: ResolverDeps;
+
+const LABELS: Record<string, string[]> = {
+  Contoso: ['BlockedCustomer', 'ImportParameters'],
+  SYS: ['SYS12345'],
+};
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL, type TEXT NOT NULL, parent_name TEXT,
+      signature TEXT, extends_class TEXT
+    );
+    CREATE TABLE extension_metadata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      extension_name TEXT, extension_type TEXT, base_object_name TEXT,
+      added_fields TEXT, added_methods TEXT, coc_methods TEXT
+    );
+    CREATE TABLE menu_item_targets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      menu_item_name TEXT NOT NULL, menu_item_type TEXT
+    );
+  `);
+  const sym = db.prepare(
+    'INSERT INTO symbols (name, type, parent_name, signature, extends_class) VALUES (?, ?, ?, ?, ?)',
+  );
+  // Standard tables
+  sym.run('CustTable', 'table', null, null, null);
+  sym.run('AccountNum', 'field', 'CustTable', 'CustAccount', null);
+  sym.run('Blocked', 'field', 'CustTable', 'CustVendorBlocked', null);
+  sym.run('CreditMax', 'field', 'CustTable', 'AmountMST', null);
+  sym.run('validateWrite', 'method', 'CustTable', 'public boolean validateWrite()', null);
+  sym.run('find', 'method', 'CustTable',
+    'public static CustTable find(CustAccount _custAccount, boolean _forUpdate = false)', null);
+  sym.run('SalesTable', 'table', null, null, null);
+  sym.run('SalesId', 'field', 'SalesTable', 'SalesIdBase', null);
+  sym.run('CustAccount', 'field', 'SalesTable', 'CustAccount', null);
+  // Standard enums (incl. platform event enums used in handler attributes)
+  sym.run('CustVendorBlocked', 'enum', null, null, null);
+  sym.run('NoYes', 'enum', null, null, null);
+  sym.run('DataEventType', 'enum', null, null, null);
+  // EDTs
+  sym.run('CustAccount', 'edt', null, 'AccountNum', null);
+  sym.run('AmountMST', 'edt', null, 'AmountMSTBase', null);
+
+  deps = {
+    db,
+    getLabelById: (labelId: string, labelFileId?: string) => {
+      const hit = (f: string) => (LABELS[f] ?? []).includes(labelId) ? [{ labelId, labelFileId: f }] : [];
+      return labelFileId ? hit(labelFileId) : Object.keys(LABELS).flatMap(hit);
+    },
+    getLabelFileIds: () => Object.keys(LABELS).map(labelFileId => ({ labelFileId })),
+  };
+});
+
+afterAll(() => db.close());
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const resolveErrors = (code: string) =>
+  resolveXppReferences(code, deps).violations.filter(v => v.severity === 'error');
+
+const validate = async (code: string, codeType: 'xpp' | 'xml-table' = 'xpp') => {
+  const result = await validateXppTool({
+    params: { name: 'validate_xpp', arguments: { code, codeType } },
+  });
+  return { text: result.content?.[0]?.text ?? '', isError: !!result.isError };
+};
+
+const generate = async (args: Record<string, unknown>): Promise<string> => {
+  const result = await codeGenTool({
+    method: 'tools/call',
+    params: { name: 'generate_code', arguments: args },
+  } as any);
+  const text = result.content?.[0]?.text ?? '';
+  const fence = /```(?:xpp|x\+\+|xml)?\r?\n([\s\S]*?)```/.exec(text);
+  return fence ? fence[1] : text;
+};
+
+// ─── Golden: correct artifacts pass the full gate ────────────────────────────
+
+describe('golden — correct artifacts pass both gates', () => {
+  const COC_WRAPPER = `
+/// <summary>
+/// Blocks writing customers that exceed the Contoso credit policy.
+/// </summary>
+[ExtensionOf(tableStr(CustTable))]
+final class CustTableContoso_Extension
+{
+    /// <summary>
+    /// Validates the customer record against the Contoso credit policy before write.
+    /// </summary>
+    /// <returns>true when the record passes validation; otherwise, false.</returns>
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        CustTable custTable;
+
+        if (custTable.Blocked == CustVendorBlocked::All)
+        {
+            ret = checkFailed("@Contoso:BlockedCustomer");
+        }
+        return ret;
+    }
+}`;
+
+  it('CoC table-method wrapper resolves and validates cleanly', async () => {
+    expect(resolveErrors(COC_WRAPPER)).toEqual([]);
+    const v = await validate(COC_WRAPPER);
+    expect(v.isError).toBe(false);
+  });
+
+  const EVENT_HANDLER = `
+/// <summary>
+/// Reacts to customer inserts for the Contoso integration feed.
+/// </summary>
+final class ContosoCustTableEventHandler
+{
+    /// <summary>
+    /// Publishes the inserted customer to the Contoso integration feed.
+    /// </summary>
+    /// <param name = "_sender">The customer record that was inserted.</param>
+    /// <param name = "_e">The data event arguments.</param>
+    [DataEventHandler(tableStr(CustTable), DataEventType::Inserted)]
+    public static void custTable_onInserted(Common _sender, DataEventArgs _e)
+    {
+        CustTable custTable = _sender as CustTable;
+        if (custTable.AccountNum)
+        {
+            // integration publish intentionally omitted in the golden fixture
+        }
+    }
+}`;
+
+  it('data event handler resolves and validates cleanly', async () => {
+    expect(resolveErrors(EVENT_HANDLER)).toEqual([]);
+    const v = await validate(EVENT_HANDLER);
+    expect(v.isError).toBe(false);
+  });
+
+  const TABLE_XML = `
+<AxTable>
+  <Name>ContosoImportParameters</Name>
+  <Label>@Contoso:ImportParameters</Label>
+  <TableGroup>Parameter</TableGroup>
+  <ClusteredIndex>KeyIdx</ClusteredIndex>
+  <Fields>
+    <AxTableField>
+      <Name>Key</Name>
+      <ExtendedDataType>ParametersKey</ExtendedDataType>
+    </AxTableField>
+  </Fields>
+  <Indexes>
+    <AxTableIndex>
+      <Name>KeyIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+    </AxTableIndex>
+  </Indexes>
+</AxTable>`;
+
+  it('complete table XML passes all XML property rules', async () => {
+    const v = await validate(TABLE_XML, 'xml-table');
+    expect(v.isError).toBe(false);
+    expect(v.text).not.toMatch(/XML00[1-5]/);
+  });
+});
+
+// ─── Golden: hallucinated / BP-violating variants are rejected ───────────────
+
+describe('golden — hallucinated and BP-violating artifacts are rejected', () => {
+  it('rejects a wrapper touching a non-existent field', () => {
+    const errors = resolveErrors(`
+      CustTable custTable;
+      custTable.LoyaltyTier = 5;`);
+    expect(errors.map(e => e.kind)).toContain('unknown-field');
+  });
+
+  it('rejects a call to a non-existent static method', () => {
+    const errors = resolveErrors('CustTable::findByLoyalty("gold");');
+    expect(errors.map(e => e.kind)).toContain('unknown-static-member');
+  });
+
+  it('rejects a call with wrong arity against the indexed signature', () => {
+    const errors = resolveErrors('CustTable::find("c1", true, 42);');
+    expect(errors.map(e => e.kind)).toContain('arity-mismatch');
+  });
+
+  it('rejects an extension of a misspelled table', () => {
+    const errors = resolveErrors('[ExtensionOf(tableStr(CusTable))]');
+    expect(errors.map(e => e.kind)).toContain('unknown-intrinsic-target');
+  });
+
+  it('rejects a label that does not exist in a known label file', () => {
+    const errors = resolveErrors('info("@Contoso:NoSuchLabel");');
+    expect(errors.map(e => e.kind)).toContain('unknown-label');
+  });
+
+  it('flags today() and hardcoded strings in the BP gate', async () => {
+    const v = await validate(`
+      void run()
+      {
+          if (systemDateGet() > today())
+          {
+              error("Date is in the past");
+          }
+      }`);
+    expect(v.text).toContain('SEL001');
+    expect(v.text).toContain('BP001');
+  });
+
+  it('flags a bare table XML missing Label, TableGroup and AlternateKey', async () => {
+    const v = await validate(`
+<AxTable>
+  <Name>ContosoBare</Name>
+  <Fields>
+    <AxTableField><Name>Value</Name></AxTableField>
+  </Fields>
+</AxTable>`, 'xml-table');
+    expect(v.isError).toBe(true);
+    expect(v.text).toContain('XML001');
+    expect(v.text).toContain('XML002');
+    expect(v.text).toContain('XML003');
+    expect(v.text).toContain('XML004');
+  });
+});
+
+// ─── Golden: generate_code templates stay BP-clean ───────────────────────────
+
+describe('golden — generate_code templates pass validate_xpp', () => {
+  const NEW_OBJECT_PATTERNS = ['class', 'runnable', 'batch-job', 'sysoperation'];
+
+  for (const pattern of NEW_OBJECT_PATTERNS) {
+    it(`template "${pattern}" generates BP-clean code`, async () => {
+      const code = await generate({ pattern, name: 'ContosoGoldenProbe', modelName: 'Contoso' });
+      expect(code.trim().length).toBeGreaterThan(0);
+      const v = await validate(code);
+      // No errors, and specifically no generic doc-comment regression (BP003)
+      expect(v.isError).toBe(false);
+      expect(v.text).not.toContain('BP003');
+    });
+  }
+
+  it('template "class-extension" generates BP-clean CoC skeleton', async () => {
+    const code = await generate({
+      pattern: 'class-extension',
+      name: 'SalesFormLetter',
+      modelName: 'Contoso',
+    });
+    expect(code).toContain('[ExtensionOf(');
+    const v = await validate(code);
+    expect(v.isError).toBe(false);
+    expect(v.text).not.toContain('BP003');
+    expect(v.text).not.toContain('COC002'); // must be final
+    expect(v.text).not.toContain('COC003'); // must end _Extension
+  });
+});

--- a/tests/tools/xppcDiagnostics.test.ts
+++ b/tests/tools/xppcDiagnostics.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Structured xppc diagnostics tests — parser + formatter.
+ * Line format grounded in the observed xppc -log output:
+ *   Compile Error: Class Method dynamics://MyModel/MyClass/myMethod: [(28,27),(28,28)]: ';' expected.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseXppcDiagnostics, formatStructuredDiagnostics } from '../../src/tools/buildProject';
+
+describe('parseXppcDiagnostics', () => {
+  it('parses the canonical class-method error line', () => {
+    const diags = parseXppcDiagnostics(
+      "Compile Error: Class Method dynamics://MyModel/MyClass/myMethod: [(28,27),(28,28)]: ';' expected.",
+    );
+    expect(diags).toHaveLength(1);
+    expect(diags[0]).toMatchObject({
+      severity: 'error',
+      kind: 'Class Method',
+      model: 'MyModel',
+      object: 'MyClass',
+      member: 'myMethod',
+      line: 28,
+      column: 27,
+      message: "';' expected.",
+    });
+  });
+
+  it('parses object-level diagnostics without a member', () => {
+    const diags = parseXppcDiagnostics(
+      'Compile Error: Table dynamics://MyModel/MyTable: [(1,1),(1,2)]: Unknown field reference.',
+    );
+    expect(diags[0]).toMatchObject({
+      object: 'MyTable',
+      member: undefined,
+      line: 1,
+      message: 'Unknown field reference.',
+    });
+  });
+
+  it('classifies warnings', () => {
+    const diags = parseXppcDiagnostics(
+      'Compile Warning: Class Method dynamics://MyModel/MyClass/run: [(5,1),(5,2)]: Unused variable x.',
+    );
+    expect(diags[0].severity).toBe('warning');
+  });
+
+  it('falls back to message-only diagnostics for unstructured error lines', () => {
+    const diags = parseXppcDiagnostics(
+      'Compile Fatal Error: The metadata path could not be resolved.',
+    );
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe('error');
+    expect(diags[0].object).toBeUndefined();
+    expect(diags[0].message).toBe('The metadata path could not be resolved.');
+  });
+
+  it('ignores non-diagnostic log noise', () => {
+    const diags = parseXppcDiagnostics(
+      'Loading metadata...\nCompiling module MyModel\nDone in 42s\n',
+    );
+    expect(diags).toEqual([]);
+  });
+
+  it('parses a multi-line log with mixed severities', () => {
+    const log = [
+      'Loading metadata...',
+      "Compile Error: Class Method dynamics://M/ClassA/m1: [(10,5),(10,6)]: ';' expected.",
+      'Compile Warning: Class Method dynamics://M/ClassA/m2: [(20,1),(20,2)]: Unused variable.',
+      "Compile Error: Class Method dynamics://M/ClassB/m3: [(30,2),(30,3)]: Unbalanced TTS level.",
+    ].join('\n');
+    const diags = parseXppcDiagnostics(log);
+    expect(diags).toHaveLength(3);
+    expect(diags.filter(d => d.severity === 'error')).toHaveLength(2);
+  });
+});
+
+describe('formatStructuredDiagnostics', () => {
+  it('returns empty string for no diagnostics', () => {
+    expect(formatStructuredDiagnostics([])).toBe('');
+  });
+
+  it('orders errors before warnings and includes locations', () => {
+    const text = formatStructuredDiagnostics(parseXppcDiagnostics([
+      'Compile Warning: Class Method dynamics://M/ClassA/m2: [(20,1),(20,2)]: Unused variable.',
+      "Compile Error: Class Method dynamics://M/ClassA/m1: [(10,5),(10,6)]: ';' expected.",
+    ].join('\n')));
+    expect(text).toContain('1 error(s), 1 warning(s)');
+    const errIdx = text.indexOf('ClassA.m1');
+    const warnIdx = text.indexOf('ClassA.m2');
+    expect(errIdx).toBeGreaterThan(-1);
+    expect(warnIdx).toBeGreaterThan(errIdx);
+    expect(text).toContain('(line 10, col 5)');
+    expect(text).toContain('modify_d365fo_file');
+  });
+
+  it('enriches known errors with a fix hint from the error knowledge base', () => {
+    const text = formatStructuredDiagnostics(parseXppcDiagnostics(
+      'Compile Error: Class Method dynamics://M/ClassB/m3: [(30,2),(30,3)]: Unbalanced TTS level on exit.',
+    ));
+    expect(text).toContain('💡');
+    expect(text).toMatch(/TTS/i);
+  });
+
+  it('collapses duplicate diagnostics', () => {
+    const line = "Compile Error: Class Method dynamics://M/ClassA/m1: [(10,5),(10,6)]: ';' expected.";
+    const text = formatStructuredDiagnostics(parseXppcDiagnostics(`${line}\n${line}\n${line}`));
+    expect(text.match(/ClassA\.m1/g)).toHaveLength(1);
+  });
+});

--- a/tests/utils/callDedup.test.ts
+++ b/tests/utils/callDedup.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Dedup cache + call-sequence loop detection tests.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  dedupKey, getDedupedResult, storeDedupResult, clearDedupCache,
+  appendNote, DEDUP_EXCLUDED_TOOLS, DEDUP_TTL_MS,
+} from '../../src/utils/callDedup';
+import { recordCallSequence, resetCallSequence, getMetricsSnapshot } from '../../src/utils/toolMetrics';
+
+beforeEach(() => {
+  clearDedupCache();
+  resetCallSequence();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('dedup cache', () => {
+  it('returns the stored result for an identical key within the TTL', () => {
+    const key = dedupKey('search', { query: 'CustTable' });
+    const result = { content: [{ type: 'text', text: 'hit' }] };
+    storeDedupResult(key, result);
+    expect(getDedupedResult(key)).toBe(result);
+  });
+
+  it('treats different args as different keys', () => {
+    storeDedupResult(dedupKey('search', { query: 'A' }), { content: [{ type: 'text', text: 'A' }] });
+    expect(getDedupedResult(dedupKey('search', { query: 'B' }))).toBeUndefined();
+  });
+
+  it('expires entries after the TTL', () => {
+    vi.useFakeTimers();
+    const key = dedupKey('search', { query: 'CustTable' });
+    storeDedupResult(key, { content: [{ type: 'text', text: 'hit' }] });
+    vi.advanceTimersByTime(DEDUP_TTL_MS + 1);
+    expect(getDedupedResult(key)).toBeUndefined();
+  });
+
+  it('never caches error results', () => {
+    const key = dedupKey('search', { query: 'X' });
+    storeDedupResult(key, { isError: true, content: [{ type: 'text', text: 'fail' }] });
+    expect(getDedupedResult(key)).toBeUndefined();
+  });
+
+  it('excludes stateful tools from dedup', () => {
+    for (const tool of ['build_d365fo_project', 'modify_d365fo_file', 'prepare_change', 'get_workspace_info']) {
+      expect(DEDUP_EXCLUDED_TOOLS.has(tool)).toBe(true);
+    }
+    expect(DEDUP_EXCLUDED_TOOLS.has('search')).toBe(false);
+    expect(DEDUP_EXCLUDED_TOOLS.has('get_table_info')).toBe(false);
+  });
+});
+
+describe('appendNote', () => {
+  it('appends to the first text item only', () => {
+    const result = appendNote(
+      { content: [{ type: 'text', text: 'body' }, { type: 'text', text: 'second' }] },
+      '> note',
+    );
+    expect(result.content[0].text).toBe('body\n\n> note');
+    expect(result.content[1].text).toBe('second');
+  });
+
+  it('returns the input unchanged when there is no content', () => {
+    const r = { content: [] };
+    expect(appendNote(r, 'x')).toBe(r);
+  });
+});
+
+describe('recordCallSequence (loop detection)', () => {
+  it('counts identical calls within the window', () => {
+    expect(recordCallSequence('search', 'k1')).toBe(1);
+    expect(recordCallSequence('search', 'k1')).toBe(2);
+    expect(recordCallSequence('search', 'k1')).toBe(3);
+  });
+
+  it('does not mix different tools or args', () => {
+    recordCallSequence('search', 'k1');
+    expect(recordCallSequence('get_table_info', 'k1')).toBe(1);
+    expect(recordCallSequence('search', 'k2')).toBe(1);
+  });
+
+  it('forgets calls that fall outside the window', () => {
+    recordCallSequence('search', 'k1');
+    for (let i = 0; i < 15; i++) recordCallSequence('other', `fill-${i}`);
+    expect(recordCallSequence('search', 'k1')).toBe(1);
+  });
+
+  it('tracks duplicates in the metrics snapshot', () => {
+    recordCallSequence('search', 'dup');
+    recordCallSequence('search', 'dup');
+    const snap = getMetricsSnapshot().find(s => s.tool === 'search');
+    expect(snap?.duplicateCalls).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/utils/indexStaleness.test.ts
+++ b/tests/utils/indexStaleness.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Index staleness detection tests.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { findNewestMetadataMtime, checkIndexStaleness } from '../../src/utils/indexStaleness';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'staleness-test-'));
+  fs.mkdirSync(path.join(tmpDir, 'MyModel', 'AxClass'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'MyModel', 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, 'MyModel', 'AxClass', 'ContosoHelper.xml'), '<AxClass/>');
+  fs.writeFileSync(path.join(tmpDir, 'MyModel', 'bin', 'ignored.xml'), '<x/>'); // bin is skipped
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('findNewestMetadataMtime', () => {
+  it('finds the newest xml file and skips bin folders', () => {
+    const result = findNewestMetadataMtime(path.join(tmpDir, 'MyModel'));
+    expect(result).not.toBeNull();
+    expect(result!.newestFile).toContain('ContosoHelper.xml');
+    expect(result!.scannedFiles).toBe(1); // bin/ignored.xml not counted
+  });
+
+  it('returns null for a missing directory', () => {
+    expect(findNewestMetadataMtime(path.join(tmpDir, 'DoesNotExist'))).toBeNull();
+  });
+
+  it('returns null for a directory without metadata files', () => {
+    const empty = path.join(tmpDir, 'Empty');
+    fs.mkdirSync(empty, { recursive: true });
+    expect(findNewestMetadataMtime(empty)).toBeNull();
+  });
+});
+
+describe('checkIndexStaleness', () => {
+  it('reports unknown when no timestamp exists', () => {
+    const report = checkIndexStaleness(null, path.join(tmpDir, 'MyModel'));
+    expect(report.status).toBe('unknown');
+    expect(report.lines.join('\n')).toContain('no freshness timestamp');
+  });
+
+  it('reports stale when workspace files are newer than the index', () => {
+    const oldIndex = new Date(Date.now() - 24 * 3_600_000).toISOString();
+    const report = checkIndexStaleness(oldIndex, path.join(tmpDir, 'MyModel'));
+    expect(report.status).toBe('stale');
+    const text = report.lines.join('\n');
+    expect(text).toContain('INDEX IS STALE');
+    expect(text).toContain('update_symbol_index');
+  });
+
+  it('reports fresh when the index is newer than all files', () => {
+    const futureIndex = new Date(Date.now() + 3_600_000).toISOString();
+    const report = checkIndexStaleness(futureIndex, path.join(tmpDir, 'MyModel'));
+    expect(report.status).toBe('fresh');
+    expect(report.lines.join('\n')).toContain('up to date');
+  });
+
+  it('reports unknown when the model dir cannot be resolved', () => {
+    const report = checkIndexStaleness(new Date().toISOString(), null);
+    expect(report.status).toBe('unknown');
+  });
+});
+
+describe('symbolIndex last_indexed_at bookkeeping', () => {
+  it('touchLastIndexed/getLastIndexedAt round-trips an ISO timestamp', () => {
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    try {
+      expect(index.getLastIndexedAt()).toBeNull();
+      index.touchLastIndexed();
+      const ts = index.getLastIndexedAt();
+      expect(ts).toBeTruthy();
+      expect(Number.isNaN(Date.parse(ts!))).toBe(false);
+    } finally {
+      index.close();
+    }
+  });
+});


### PR DESCRIPTION
This pull request introduces several improvements focused on reliability, feedback, and agentic-loop mitigation in the build and tool infrastructure. The most significant changes are the addition of structured diagnostics for compiler errors, a duplicate-call deduplication mechanism to prevent agentic loops, and index staleness tracking for improved workspace freshness reporting.

**Structured Compiler Diagnostics and Enrichment:**

- Added parsing of `xppc` compiler logs into structured diagnostics with severity, location, and message fields, enabling more actionable and machine-readable error reporting (`parseXppcDiagnostics`, `formatStructuredDiagnostics`). The first few errors are now enriched with fix hints from the error knowledge base, helping users and models resolve issues faster. (F4fab749L51R51, [[1]](diffhunk://#diff-a241a053ffe514ec38deed6e56f90e21e79faf9743509e6bec7f92b9f975225cR802-R815) [[2]](diffhunk://#diff-a241a053ffe514ec38deed6e56f90e21e79faf9743509e6bec7f92b9f975225cR830-R839) [[3]](diffhunk://#diff-bf3230351c14cf2877ad74b7d270d90cfc4815cfb55a97ecab2f93bb481a43eeR383-R396)

**Agentic-Loop Mitigation and Deduplication:**

- Introduced a duplicate-call deduplication cache (`callDedup.ts`) for read-only tools to prevent repeated identical calls from being re-executed. If a duplicate is detected within a short TTL, the cached result is returned with an explanatory note; after multiple repeats, a loop warning is appended. Stateful tools are excluded from deduplication. [[1]](diffhunk://#diff-426c3c1fbb3c9475a8591280f3b381a2e0b237424a5fef8f5e6e6408503694beR1-R74) [[2]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dL65-R71) [[3]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dR220-R234) [[4]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dL658-R713)

**Index Staleness Tracking and Reporting:**

- Added a small `_index_meta` table and methods (`touchLastIndexed`, `getLastIndexedAt`) to track when the symbol index was last updated. This timestamp is now refreshed on index updates and compared to workspace file mtimes to detect and report staleness in `get_workspace_info`. [[1]](diffhunk://#diff-24d47911da9fe8bf9c3832e1a6e81b78a28d43dac7d0236e8b9655d43c4fcc3fR573-R583) [[2]](diffhunk://#diff-24d47911da9fe8bf9c3832e1a6e81b78a28d43dac7d0236e8b9655d43c4fcc3fR1222-R1223) [[3]](diffhunk://#diff-24d47911da9fe8bf9c3832e1a6e81b78a28d43dac7d0236e8b9655d43c4fcc3fR1925-R1949) [[4]](diffhunk://#diff-1b30a5f352b92fa6a326dc70fdd4939ad8b038fd43aec1a95705163856b5df58R121-R122) [[5]](diffhunk://#diff-1b30a5f352b92fa6a326dc70fdd4939ad8b038fd43aec1a95705163856b5df58R180) [[6]](diffhunk://#diff-1b30a5f352b92fa6a326dc70fdd4939ad8b038fd43aec1a95705163856b5df58R325) [[7]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dR611-R625)

**Supporting Refactors and Utilities:**

- Added helper functions for reading entire log files for diagnostics, and made minor imports/utility adjustments to support the above features. [[1]](diffhunk://#diff-a241a053ffe514ec38deed6e56f90e21e79faf9743509e6bec7f92b9f975225cR240-R248) [[2]](diffhunk://#diff-a241a053ffe514ec38deed6e56f90e21e79faf9743509e6bec7f92b9f975225cR11) [[3]](diffhunk://#diff-763f25445de51dc873332f8d06ed210c9f9321d82c2b7a5ff5be7202d1d6620dR153)

These changes together improve the developer and model experience by providing clearer error feedback, reducing unnecessary tool invocations, and ensuring that workspace state is reliably reported.