### PR TITLE
﻿feat(edt-extension): validate StringSize/DatabaseStringSize and IsEx…

### DIFF
--- a/bridge/D365MetadataBridge/Models/Models.cs
+++ b/bridge/D365MetadataBridge/Models/Models.cs
@@ -287,6 +287,10 @@ namespace D365MetadataBridge.Models
         [JsonPropertyName("relationType")]
         public string? RelationType { get; set; }
 
+        /// <summary>True when the EDT is marked IsExtensible = Yes — required for AxEdtExtension to apply.</summary>
+        [JsonPropertyName("isExtensible")]
+        public bool IsExtensible { get; set; }
+
         // AxEdtReal specific
         [JsonPropertyName("noOfDecimals")]
         public int? NoOfDecimals { get; set; }

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -151,6 +151,8 @@ export interface BridgeEdtInfo {
   enumType?: string;
   referenceTable?: string;
   model?: string;
+  /** True when the base EDT is marked IsExtensible = Yes — required for AxEdtExtension. */
+  isExtensible?: boolean;
   // Gap-fill properties
   formHelp?: string;
   configurationKey?: string;

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -497,11 +497,22 @@ export class XppSymbolIndex {
         reference_table TEXT,
         relation_type TEXT,
         string_size TEXT,
+        database_string_size TEXT,
         display_length TEXT,
         label TEXT,
         model TEXT NOT NULL
       );
     `);
+
+    // Migrate existing edt_metadata table: add database_string_size column when missing
+    {
+      const existingCols = new Set(
+        (this.db.pragma('table_info(edt_metadata)') as Array<{ name: string }>).map(r => r.name)
+      );
+      if (!existingCols.has('database_string_size')) {
+        this.db.exec(`ALTER TABLE edt_metadata ADD COLUMN database_string_size TEXT;`);
+      }
+    }
 
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_edt_metadata_name ON edt_metadata(edt_name);
@@ -1526,12 +1537,13 @@ export class XppSymbolIndex {
 
         // Add extended EDT metadata to new table — always insert when any property is present
         if (edtData.extends || edtData.enumType || edtData.referenceTable ||
-            edtData.stringSize || edtData.displayLength || edtData.label) {
+            edtData.stringSize || edtData.displayLength || edtData.label ||
+            edtData.databaseStringSize) {
           const stmt = this.db.prepare(`
             INSERT OR REPLACE INTO edt_metadata (
               edt_name, extends, enum_type, reference_table, relation_type,
-              string_size, display_length, label, model
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+              string_size, database_string_size, display_length, label, model
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           `);
           
           stmt.run(
@@ -1541,6 +1553,7 @@ export class XppSymbolIndex {
             edtData.referenceTable || null,
             edtData.relationType || null,
             edtData.stringSize || null,
+            edtData.databaseStringSize || null,
             edtData.displayLength || null,
             edtData.label || null,
             model

--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -762,6 +762,7 @@ export class XppMetadataParser {
         referenceTable: getValue('ReferenceTable'),
         relationType: getValue('RelationType'),
         stringSize: getValue('StringSize'),
+        databaseStringSize: getValue('DatabaseStringSize'),
         displayLength: getValue('DisplayLength'),
         label: getValue('Label'),
         helpText: getValue('HelpText'),
@@ -777,6 +778,7 @@ export class XppMetadataParser {
       // Extract additional properties
       const knownProperties = new Set([
         'Name', 'Extends', 'EnumType', 'ReferenceTable', 'RelationType', 'StringSize', 'DisplayLength',
+        'DatabaseStringSize',
         'Label', 'HelpText', 'FormHelp', 'ConfigurationKey', 'Alignment', 'DecimalSeparator',
         'SignDisplay', 'NoOfDecimals', 'ArrayElements', 'Relations', 'TableReferences'
       ]);

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -149,7 +149,7 @@ After the call, read the response: \`isError=true\` means the change did NOT app
 1. \`prepare_create(goal, objectName, objectType, fieldsHint?)\` — ONE call returns collision check, naming, similar objects, EDT suggestions, reusable labels, property defaults + \`groundingToken\`
 2. Generate the object, then \`resolve_references(code)\` + \`validate_xpp(code)\` — fix any errors in the same turn
 3. \`create_d365fo_file(..., groundingToken=...)\`
-5. **NEVER run \`build_d365fo_project()\` automatically.** Builds take a long time and block the user. After completing changes, tell the user the changes are done and they can build manually when ready. Only run \`build_d365fo_project()\` when the user explicitly requests it ("build", "compile", "check errors"). If after a requested build there are X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean.
+5. **NEVER run \`build_d365fo_project()\` automatically.** Builds take a long time and block the user. After completing changes, tell the user the changes are done and they can build manually when ready. Only run \`build_d365fo_project()\` when the user explicitly requests it ("build", "compile", "check errors"). If after a requested build there are X++ errors, fix them immediately using \`modify_d365fo_file\` and rebuild until clean. **Call \`build_d365fo_project()\` exactly ONCE per requested build — by default the tool blocks until completion and returns the final result, so do NOT poll with repeated calls.**
 
 ### 4. Semantic vs. Prefix Search
 - **Semantic (by concept):** \`search("total", type="method")\`
@@ -396,6 +396,15 @@ All generated X++ code MUST pass the D365FO Best Practice checker without warnin
   the table MUST have an explicit \`<AxTableRelation>\` for that field
 - The \`generate_smart_table\` tool auto-detects these from \`edt_metadata.reference_table\`
 - If adding fields manually via \`modify_d365fo_file\`, add a matching table relation too
+
+### EDT extensions — what you CAN and CANNOT change
+\`AxEdtExtension\` (and \`modify_d365fo_file\` with \`objectType="edt-extension"\`) can ONLY change a small set of properties on an EDT, and only when the base EDT is marked \`IsExtensible=Yes\`.
+- ✅ Always allowed on extensions (when \`IsExtensible=true\`): \`Label\`, \`HelpText\`, \`FormHelp\`, \`ConfigurationKey\`, \`HelpAlign\`, \`Alignment\`, \`NoOfDecimals\`, \`DecimalSeparator\`, \`SignDisplay\`.
+- ⛔ NEVER changeable via extension: \`Extends\` (re-parenting), \`StringSize\` / \`DisplayLength\` on a *derived* EDT (these inherit from the root EDT — the change has no runtime effect and is rejected by the validator).
+- To **widen StringSize** on a field whose EDT is derived (e.g. \`AccountNum\` → \`Num\`):
+  1. Create a new EDT that extends the existing one with the larger \`StringSize\`, OR
+  2. Use a **table extension** on the consuming field (\`modify_d365fo_file\` operation \`modify-field\` → \`stringSize=...\`) — but mind \`databaseStringSize\` so existing data isn't truncated.
+- The \`modify_d365fo_file\` validator refuses illegal EDT-extension property changes up-front; relay the message verbatim instead of trying to work around it.
 
 ### BPCheckNestedLoopinCode — Avoid nested data access loops
 - ❌ NEVER nest \`while select\` inside another \`while select\` — causes N+1 queries

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1839,7 +1839,8 @@ SourceCode format for classes: class declaration with member vars inside { }, me
         description:
           'Builds a D365FO model using the X++ compiler (xppc.exe). ' +
           'Compiles the ENTIRE MODEL — not just one project file. ' +
-          'Runs in the background: first call starts the build; call again to poll status and see output. ' +
+          'By default the tool BLOCKS until the build finishes and returns the final result, so call it ONCE per requested build (do NOT poll). ' +
+          'Set wait:false for legacy fire-and-forget mode where the tool returns immediately and the caller polls with follow-up calls. ' +
           'Use fullBuild:true when xppc reports "model element has not been successfully compiled since it was last changed" (stale symbol error). ' +
           'Use buildReferencedModels:true to also build custom/ISV dependencies first (reads <ModuleReferences> from the model descriptor; skips Microsoft standard models; topological order).',
         inputSchema: {
@@ -1864,6 +1865,14 @@ SourceCode format for classes: class declaration with member vars inside { }, me
             buildReferencedModels: {
               type: 'boolean',
               description: 'Also build all custom/ISV models this model depends on before building the target. Skips Microsoft standard models.',
+            },
+            wait: {
+              type: 'boolean',
+              description: 'When true (default) the tool blocks until the build finishes and returns the final result in a single call. The agent should make exactly one call per requested build. Set false for legacy fire-and-forget polling behaviour.',
+            },
+            waitTimeoutMs: {
+              type: 'number',
+              description: 'Maximum time (ms) to block when wait:true before returning a "still running" snapshot. Defaults to 30 minutes. The build itself continues in the background.',
             },
           },
           required: [],

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -596,9 +596,10 @@ export const buildProjectToolDefinition = {
   description: [
     'Builds a D365FO model using the X++ compiler (xppc.exe) and returns compiler errors.',
     'Compiles the entire model — equivalent to building the full model in Visual Studio.',
-    'Because compilation can take several minutes, the build runs in the background.',
-    'First call: starts the build and returns immediately.',
-    'Subsequent calls for the same model: return current status + latest log output.',
+    'By default the tool waits for the build to finish before returning, so call it ONCE per request',
+    '(do NOT poll — a single call returns the final success/failure result).',
+    'Set wait:false for fire-and-forget mode where the tool returns immediately after spawning the build',
+    'and subsequent calls report current status (legacy behaviour).',
     'Use force:true to kill a stuck build and restart.',
     'Use fullBuild:true to omit -incremental and recompile all elements — fixes "stale symbol" errors.',
     'Use buildReferencedModels:true to also build custom/ISV dependencies before the target model',
@@ -624,8 +625,125 @@ export const buildProjectToolDefinition = {
       '(from <ModuleReferences> in the model descriptor). ' +
       'Skips Microsoft standard models. Builds in topological dependency order.',
     ),
+    wait: z.boolean().optional().default(true).describe(
+      'When true (default), the tool BLOCKS until the build finishes and returns the final result in a single call. ' +
+      'Do not call again to poll — the agent should make exactly one tool call per requested build. ' +
+      'When false, the tool returns immediately after spawning xppc and the caller is responsible for polling ' +
+      'with a follow-up call (legacy fire-and-forget behaviour).',
+    ),
+    waitTimeoutMs: z.number().int().positive().optional().describe(
+      'Maximum time (ms) to block when wait:true before returning a "still running" snapshot. ' +
+      'Defaults to 30 minutes. The build itself continues in the background; subsequent calls will pick up the result.',
+    ),
   }),
 };
+
+// ---------------------------------------------------------------------------
+// Render the final result of a finished build (succeeded or failed) as the
+// MCP response payload. Shared between the "existing finished state" branch
+// and the wait-for-completion branch so both code paths produce identical
+// output. Caller is responsible for calling clearBuildState() afterwards
+// when appropriate.
+// ---------------------------------------------------------------------------
+
+async function renderFinishedBuildResult(
+  finalState: BuildJobState,
+  targetModel: string,
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const succeeded  = finalState.status === 'succeeded';
+  const isQueued   = !!(finalState.buildQueue && finalState.buildQueue.length > 1);
+  const allResults = finalState.queueResults ?? [];
+
+  if (isQueued) {
+    const totalDuration = allResults.reduce((sum, r) => sum + r.duration, 0);
+    const statusIcon    = succeeded ? '✅ Build complete' : '❌ Build failed';
+    const modelLines    = allResults
+      .map(r => `  ${r.status === 'succeeded' ? '✅' : '❌'} ${r.modelName}: ${r.duration}s`)
+      .join('\n');
+
+    const relevantResult = succeeded
+      ? allResults[allResults.length - 1]
+      : allResults.find(r => r.status === 'failed');
+    const relevantLogFile = relevantResult?.logFile ?? finalState.logFile;
+    const logContent = succeeded
+      ? await readLogTail(relevantLogFile)
+      : await readFullLog(relevantLogFile);
+    const structured = succeeded
+      ? ''
+      : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(relevantLogFile)));
+
+    return {
+      content: [{
+        type: 'text',
+        text: `${statusIcon} — ${allResults.length} models, ${totalDuration}s total\n\n${modelLines}\n\n` +
+          (structured ? `${structured}\n\n` : '') +
+          `--- Log (${relevantResult?.modelName ?? targetModel}) ---\n${logContent}`,
+      }],
+      ...(succeeded ? {} : { isError: true }),
+    };
+  }
+
+  const logTail       = await readLogTail(finalState.logFile);
+  const logContent    = succeeded ? logTail : await readFullLog(finalState.logFile);
+  const hasWarnings   = succeeded && /^(Generation Warning|Compile Warning):/m.test(logTail);
+  const statusIcon    = !succeeded ? '❌ Build FAILED' : hasWarnings ? '⚠️ Build succeeded with warnings' : '✅ Build succeeded';
+  const buildMode     = finalState.fullBuild ? 'full build (target), incremental (deps)' : 'incremental';
+  const duration      = finalState.endTime
+    ? Math.round((new Date(finalState.endTime).getTime() - new Date(finalState.startTime).getTime()) / 1000)
+    : '?';
+  const structured    = succeeded
+    ? ''
+    : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(finalState.logFile)));
+
+  return {
+    content: [{
+      type: 'text',
+      text: `${statusIcon} (${finalState.tool}, ${buildMode}, ${duration}s)\n\nModel: ${targetModel}\n\n` +
+        (structured ? `${structured}\n\n--- Raw log ---\n` : '') +
+        `${logContent || '(no output)'}`,
+    }],
+    ...((!succeeded) ? { isError: true } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Block until the build for `targetModel` reaches a non-running state, the
+// tracked process is no longer alive, or `timeoutMs` elapses. Returns the
+// final state when finished, or null when the timeout was hit.
+// ---------------------------------------------------------------------------
+
+async function waitForBuildCompletion(
+  targetModel: string,
+  customPackagesPath: string,
+  timeoutMs: number,
+): Promise<BuildJobState | null> {
+  const deadline = Date.now() + timeoutMs;
+  // Poll roughly every second; xppc builds typically take many seconds to
+  // many minutes, so a 1 s cadence is fine and keeps responsiveness high.
+  const pollIntervalMs = 1000;
+  let lastState: BuildJobState | null = null;
+  while (Date.now() < deadline) {
+    const state = await readBuildState(targetModel, customPackagesPath);
+    if (state) {
+      lastState = state;
+      if (state.status !== 'running') return state;
+      // Process disappeared without writing a final state — give the close
+      // handler up to ~2 s to settle, then return whatever we have so the
+      // caller can surface a sensible "exited unexpectedly" message.
+      if (state.pid && !isProcessAlive(state.pid)) {
+        for (let i = 0; i < 4; i++) {
+          await new Promise(r => setTimeout(r, 500));
+          const refreshed = await readBuildState(targetModel, customPackagesPath);
+          if (refreshed && refreshed.status !== 'running') return refreshed;
+        }
+        return state;
+      }
+    }
+    await new Promise(r => setTimeout(r, pollIntervalMs));
+  }
+  // Timed out — return null so the caller emits a "still running" snapshot.
+  return lastState && lastState.status !== 'running' ? lastState : null;
+}
 
 // ---------------------------------------------------------------------------
 // Tool handler
@@ -747,6 +865,33 @@ export const buildProjectTool = async (params: any, _context: any) => {
               .map(r => `${r.status === 'succeeded' ? '✅' : '❌'} ${r.modelName} (${r.duration}s)`)
               .join(', ')
           : '';
+        // When wait:true (default) and a build is already running for this
+        // model, attach to it and block until completion instead of returning
+        // a snapshot — this matches the "single call per build" contract.
+        const waitForFinish = params.wait !== false;
+        if (waitForFinish) {
+          const timeoutMs: number = (typeof params.waitTimeoutMs === 'number' && params.waitTimeoutMs > 0)
+            ? params.waitTimeoutMs
+            : 30 * 60 * 1000;
+          const finalState = await waitForBuildCompletion(targetModel, customPackagesPath, timeoutMs);
+          if (finalState && finalState.status !== 'running') {
+            await clearBuildState(targetModel, customPackagesPath);
+            return await renderFinishedBuildResult(finalState, targetModel);
+          }
+          // Timed out — emit a "still running" snapshot so the caller can choose
+          // to extend the wait window with another call.
+          const tailLog = await readLogTail(existingState.logFile);
+          return {
+            content: [{
+              type: 'text',
+              text:
+                `⏳ ${queueProgress} (PID: ${existingState.pid}, running ${elapsed}s; wait timeout reached)${completedLine}\n\n` +
+                `Build continues in background. Call again to collect the final result, ` +
+                `or pass waitTimeoutMs to extend the wait window.\n\n` +
+                `--- Latest log ---\n${tailLog}`,
+            }],
+          };
+        }
         return {
           content: [{
             type: 'text',
@@ -783,63 +928,7 @@ export const buildProjectTool = async (params: any, _context: any) => {
 
       // Build finished — return result and clear state
       await clearBuildState(targetModel, customPackagesPath);
-      const succeeded  = existingState.status === 'succeeded';
-      const isQueued   = !!(existingState.buildQueue && existingState.buildQueue.length > 1);
-      const allResults = existingState.queueResults ?? [];
-
-      if (isQueued) {
-        // Multi-model result
-        const totalDuration = allResults.reduce((sum, r) => sum + r.duration, 0);
-        const statusIcon    = succeeded ? '✅ Build complete' : '❌ Build failed';
-        const modelLines    = allResults
-          .map(r => `  ${r.status === 'succeeded' ? '✅' : '❌'} ${r.modelName}: ${r.duration}s`)
-          .join('\n');
-
-        // Show the full log of the model that failed (or the final target on success)
-        const relevantResult = succeeded
-          ? allResults[allResults.length - 1]
-          : allResults.find(r => r.status === 'failed');
-        const relevantLogFile = relevantResult?.logFile ?? existingState.logFile;
-        const logContent = succeeded
-          ? await readLogTail(relevantLogFile)
-          : await readFullLog(relevantLogFile);
-        const structured = succeeded
-          ? ''
-          : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(relevantLogFile)));
-
-        return {
-          content: [{
-            type: 'text',
-            text: `${statusIcon} — ${allResults.length} models, ${totalDuration}s total\n\n${modelLines}\n\n` +
-              (structured ? `${structured}\n\n` : '') +
-              `--- Log (${relevantResult?.modelName ?? targetModel}) ---\n${logContent}`,
-          }],
-          ...(succeeded ? {} : { isError: true }),
-        };
-      }
-
-      // Single-model result
-      const logContent    = succeeded ? logTail : await readFullLog(existingState.logFile);
-      const hasWarnings   = succeeded && /^(Generation Warning|Compile Warning):/m.test(logTail);
-      const statusIcon    = !succeeded ? '❌ Build FAILED' : hasWarnings ? '⚠️ Build succeeded with warnings' : '✅ Build succeeded';
-      // fullBuild only applies to the target — label reflects what actually ran on the target
-      const buildMode     = existingState.fullBuild ? 'full build (target), incremental (deps)' : 'incremental';
-      const duration      = existingState.endTime
-        ? Math.round((new Date(existingState.endTime).getTime() - new Date(existingState.startTime).getTime()) / 1000)
-        : '?';
-      const structured    = succeeded
-        ? ''
-        : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(existingState.logFile)));
-
-      return {
-        content: [{
-          type: 'text',
-          text: `${statusIcon} (${existingState.tool}, ${buildMode}, ${duration}s)\n\nModel: ${targetModel}\n\n` +
-            (structured ? `${structured}\n\n--- Raw log ---\n` : '') +
-            `${logContent || '(no output)'}`,
-        }],
-        ...((!succeeded) ? { isError: true } : {}),
-      };
+      return await renderFinishedBuildResult(existingState, targetModel);
       } // end else (buildModeChanged)
     }
 
@@ -926,7 +1015,7 @@ export const buildProjectTool = async (params: any, _context: any) => {
     const pid = await spawnXppcForState(ctx, initState);
 
     // ------------------------------------------------------------------
-    // Return "build started" message
+    // Return "build started" message OR wait for completion
     // ------------------------------------------------------------------
     // When deps are included: full build applies only to the target model
     const modeLabel = fullBuild
@@ -937,6 +1026,43 @@ export const buildProjectTool = async (params: any, _context: any) => {
         buildQueue.map((m, i) => `  ${i + 1}. ${m}${m === targetModel ? ' (target)' : ' (dependency)'}`).join('\n')
       : '';
 
+    // wait defaults to true — single call returns the final result. When the
+    // caller passes wait:false explicitly we keep the legacy fire-and-forget
+    // behaviour for compatibility with callers that intentionally poll.
+    const waitForFinish = params.wait !== false;
+
+    if (waitForFinish) {
+      const timeoutMs: number = (typeof params.waitTimeoutMs === 'number' && params.waitTimeoutMs > 0)
+        ? params.waitTimeoutMs
+        : 30 * 60 * 1000; // 30 minutes default — covers full builds with referenced models
+      const finalState = await waitForBuildCompletion(targetModel, customPackagesPath, timeoutMs);
+      if (finalState && finalState.status !== 'running') {
+        await clearBuildState(targetModel, customPackagesPath);
+        return await renderFinishedBuildResult(finalState, targetModel);
+      }
+      // Timed out — leave the build running so a follow-up call can collect it.
+      const elapsed = Math.round((Date.now() - new Date(initState.startTime).getTime()) / 1000);
+      const tailLog = await readLogTail(firstLogFile);
+      return {
+        content: [{
+          type: 'text',
+          text: [
+            `⏳ ${modeLabel} still running after ${elapsed}s (timeout reached, build continues in background)`,
+            ``,
+            `Target: ${targetModel}${queueDetail}`,
+            `Log:    ${firstLogFile}`,
+            ``,
+            `Call **build_d365fo_project** again to collect the final result. ` +
+            `Or pass waitTimeoutMs to extend the wait window in a single call.`,
+            ``,
+            `--- Latest log ---`,
+            tailLog,
+          ].join('\n'),
+        }],
+      };
+    }
+
+    // Legacy fire-and-forget mode: return immediately after spawning.
     return {
       content: [{
         type: 'text',

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -31,6 +31,7 @@ import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
+import { validateEdtExtensionChange } from '../utils/edtExtensionValidator.js';
 
 /**
  * Decode the standard XML entities (&lt;, &gt;, &apos;, &quot;, &amp;) and normalise
@@ -734,6 +735,27 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'modify-property': {
         if (args.propertyPath && args.propertyValue !== undefined) {
+          // ── Semantic guard for AxEdtExtension property changes ───────────────
+          // D365FO silently accepts illegal extension edits (e.g. widening
+          // StringSize on a derived EDT) but the change is ineffective at
+          // runtime and corrupts the metadata model. Block them here with a
+          // clear explanation of the proper alternative.
+          if (objectType === 'edt-extension') {
+            const guard = await validateEdtExtensionChange(
+              objectName,
+              args.propertyPath,
+              String(args.propertyValue),
+              symbolIndex.getReadDb(),
+              context.bridge,
+            );
+            if (!guard.ok) {
+              return {
+                content: [{ type: 'text', text: guard.message ?? 'EDT extension change rejected.' }],
+                isError: true,
+              };
+            }
+          }
+
           bridgeResult = await bridgeSetProperty(
             context.bridge,
             objectType,

--- a/src/utils/edtExtensionValidator.ts
+++ b/src/utils/edtExtensionValidator.ts
@@ -1,0 +1,422 @@
+/**
+ * EDT Extension Validator
+ *
+ * Enforces D365FO rules about what can and cannot be changed via an
+ * AxEdtExtension. The XPP compiler / runtime silently accepts some edits
+ * that the metadata system rejects — so we gate them up-front and explain
+ * the proper alternative.
+ *
+ * Key rules (verified against Microsoft docs and SDK behaviour):
+ *
+ *   1. **StringSize** can only be modified on a *root* string EDT (one that
+ *      does NOT have <Extends>). For derived EDTs, StringSize is inherited
+ *      and must be widened by either:
+ *        - deriving a new EDT from the inherited one with the larger size, or
+ *        - using a table extension to point the field at a wider EDT.
+ *
+ *   2. **DisplayLength** follows the same inheritance rule as StringSize.
+ *
+ *   3. **Extends** cannot be changed on an extension — that would mean
+ *      re-parenting the base EDT.
+ *
+ *   4. Most "annotation"-style properties (Label, HelpText, FormHelp,
+ *      ConfigurationKey, HelpAlign, Alignment, NoOfDecimals on real,
+ *      DecimalSeparator, SignDisplay) are always allowed on extensions
+ *      regardless of whether the base EDT carries them itself.
+ *
+ *   5. The base EDT must be marked IsExtensible = true. Microsoft EDTs
+ *      typically are; user-created EDTs default to false. We can only check
+ *      this when the bridge is connected.
+ */
+
+import type { BridgeClient } from '../bridge/bridgeClient.js';
+import type { BridgeEdtInfo } from '../bridge/bridgeTypes.js';
+
+export interface EdtBaseInfo {
+  edtName: string;
+  /** Parent EDT name (Extends), or null/undefined when this is a root EDT. */
+  extends?: string | null;
+  /** Current string size (raw string from edt_metadata) — root EDTs only. */
+  stringSize?: string | null;
+  /**
+   * Maximum size of the underlying SQL column (`<DatabaseStringSize>` in XML).
+   * `-1` means unlimited (memo). When set and > 0, `StringSize` must not exceed it.
+   * Inherited through the Extends chain when not specified locally.
+   */
+  databaseStringSize?: string | null;
+  /** From bridge, when available; null/undefined when SQLite-only lookup. */
+  isExtensible?: boolean | null;
+}
+
+export interface EdtExtensionValidationResult {
+  ok: boolean;
+  message?: string;
+}
+
+/** Properties that propagate from the root via inheritance and cannot be
+ * overridden via an EDT extension at intermediate levels. */
+const INHERITED_PROPERTIES = new Set(['stringsize', 'displaylength', 'databasestringsize']);
+
+/** Properties that should never be set via an extension at all. */
+const FORBIDDEN_EXT_PROPERTIES = new Set(['extends']);
+
+/**
+ * Parse an edt-extension objectName into its base EDT name.
+ *
+ * Convention: BaseEdtName.MyExtension or BaseEdtName_MyExtension.
+ * If no separator is found, the input is returned as-is (assumed already a base name).
+ */
+export function extractBaseEdtName(extensionObjectName: string): string {
+  if (!extensionObjectName) return extensionObjectName;
+  const dotIdx = extensionObjectName.indexOf('.');
+  if (dotIdx > 0) return extensionObjectName.substring(0, dotIdx);
+  // Underscore convention: only treat as separator when right side looks like
+  // an Extension token (case-insensitive) so we don't truncate normal EDT names.
+  const usMatch = extensionObjectName.match(/^([A-Za-z][A-Za-z0-9]*?)_[A-Za-z0-9]*Extension$/);
+  if (usMatch) return usMatch[1];
+  return extensionObjectName;
+}
+
+/**
+ * Look up the base EDT in the SQLite symbol index.
+ * Returns null when the EDT is not indexed.
+ *
+ * When the same edt_name exists in multiple models (e.g. a model layered on
+ * top of a Microsoft EDT), prefer the row that carries the most information
+ * — specifically a non-null `extends` and a non-null `string_size`.
+ * Otherwise we may falsely conclude that an EDT is a *root* (no Extends) and
+ * permit a forbidden StringSize change via extension.
+ */
+export function lookupBaseEdtFromIndex(db: any, baseEdtName: string): EdtBaseInfo | null {
+  if (!db || !baseEdtName) return null;
+  try {
+    const rows = db.prepare(`
+      SELECT edt_name, extends, string_size, database_string_size
+      FROM edt_metadata
+      WHERE edt_name = ?
+    `).all(baseEdtName) as Array<{
+      edt_name: string; extends: string | null;
+      string_size: string | null; database_string_size: string | null;
+    }>;
+
+    if (!rows || rows.length === 0) return null;
+
+    // Pick the most informative row: non-null `extends` wins; tiebreak on non-null `string_size`.
+    let pick = rows[0];
+    for (const r of rows) {
+      const pickHasExt = !!(pick.extends && pick.extends.trim().length > 0);
+      const rHasExt = !!(r.extends && r.extends.trim().length > 0);
+      if (rHasExt && !pickHasExt) { pick = r; continue; }
+      if (rHasExt === pickHasExt) {
+        const pickHasSize = !!(pick.string_size && pick.string_size.trim().length > 0);
+        const rHasSize = !!(r.string_size && r.string_size.trim().length > 0);
+        if (rHasSize && !pickHasSize) pick = r;
+      }
+    }
+
+    return {
+      edtName: pick.edt_name,
+      extends: pick.extends,
+      stringSize: pick.string_size,
+      databaseStringSize: pick.database_string_size,
+    };
+  } catch {
+    // Older DB schemas may lack `database_string_size`; fall back to a query without it.
+    try {
+      const rows = db.prepare(`
+        SELECT edt_name, extends, string_size
+        FROM edt_metadata
+        WHERE edt_name = ?
+      `).all(baseEdtName) as Array<{ edt_name: string; extends: string | null; string_size: string | null }>;
+      if (!rows || rows.length === 0) return null;
+      const pick = rows[0];
+      return {
+        edtName: pick.edt_name,
+        extends: pick.extends,
+        stringSize: pick.string_size,
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Resolve the *root* EDT in the inheritance chain starting at baseEdtName.
+ *
+ * Walks Extends pointers until we hit an EDT with no Extends. Returns the
+ * full chain so callers can show "MyAccountNum → AccountNum → Num" hints.
+ */
+export function resolveEdtChain(db: any, baseEdtName: string, maxDepth = 16): EdtBaseInfo[] {
+  const chain: EdtBaseInfo[] = [];
+  const visited = new Set<string>();
+  let current: string | null | undefined = baseEdtName;
+  while (current && !visited.has(current.toLowerCase()) && chain.length < maxDepth) {
+    visited.add(current.toLowerCase());
+    const info = lookupBaseEdtFromIndex(db, current);
+    if (!info) break;
+    chain.push(info);
+    current = info.extends;
+  }
+  return chain;
+}
+
+/**
+ * Resolve the effective `DatabaseStringSize` for an EDT.
+ *
+ * `<DatabaseStringSize>` is inherited through the Extends chain just like
+ * `<StringSize>`. We walk up until we find a non-null value; `-1` means the
+ * underlying SQL column is unlimited (memo / nvarchar(max)).
+ *
+ * Returns:
+ *   - a positive integer when the chain has an explicit size,
+ *   - `-1` when any level in the chain says "unlimited",
+ *   - `null` when nothing in the chain specifies it (caller should not block).
+ */
+export function resolveEffectiveDatabaseStringSize(
+  db: any,
+  baseEdtName: string,
+  maxDepth = 16,
+): number | null {
+  const chain = db ? resolveEdtChain(db, baseEdtName, maxDepth) : [];
+  for (const link of chain) {
+    const raw = link.databaseStringSize;
+    if (raw == null || String(raw).trim().length === 0) continue;
+    const n = parseInt(String(raw), 10);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+/**
+ * Try to enrich base info with IsExtensible from the live bridge metadata.
+ * Returns the same struct when bridge is unavailable or read fails.
+ */
+export async function enrichWithBridge(
+  base: EdtBaseInfo,
+  bridge: BridgeClient | undefined,
+): Promise<EdtBaseInfo> {
+  if (!bridge?.isReady || !bridge.metadataAvailable) return base;
+  try {
+    const live = (await bridge.readEdt(base.edtName)) as
+      (BridgeEdtInfo & { isExtensible?: boolean; databaseStringSize?: number }) | null;
+    if (!live) return base;
+    return {
+      ...base,
+      extends: live.extends ?? base.extends,
+      stringSize: live.stringSize != null ? String(live.stringSize) : base.stringSize,
+      databaseStringSize: typeof live.databaseStringSize === 'number'
+        ? String(live.databaseStringSize)
+        : base.databaseStringSize,
+      isExtensible: typeof live.isExtensible === 'boolean' ? live.isExtensible : base.isExtensible,
+    };
+  } catch {
+    return base;
+  }
+}
+
+/**
+ * Core validation: can `propertyPath` be set to `propertyValue` on an
+ * AxEdtExtension whose base EDT is `base`?
+ *
+ * `db` (optional) lets the validator walk the Extends chain to provide a
+ * more informative message ("StringSize is inherited from AccountNum (root)").
+ */
+export function validateEdtExtensionProperty(
+  base: EdtBaseInfo,
+  propertyPath: string,
+  propertyValue: string,
+  db?: any,
+): EdtExtensionValidationResult {
+  const propLower = (propertyPath || '').trim().toLowerCase();
+
+  // Hard refuse re-parenting via extension
+  if (FORBIDDEN_EXT_PROPERTIES.has(propLower)) {
+    return {
+      ok: false,
+      message:
+        `⛔ Cannot change property '${propertyPath}' on an EDT extension.\n` +
+        `Re-parenting (changing Extends) is not allowed via AxEdtExtension. ` +
+        `Create a new EDT with the desired parent instead.`,
+    };
+  }
+
+  // Inherited size properties: only allowed when base EDT is the root
+  if (INHERITED_PROPERTIES.has(propLower)) {
+    if (base.extends && base.extends.trim().length > 0) {
+      const chain = db ? resolveEdtChain(db, base.edtName) : [base];
+      const root = chain[chain.length - 1];
+      const chainStr = chain.length > 1
+        ? chain.map(c => c.edtName).join(' → ')
+        : `${base.edtName} → ${base.extends}`;
+      const rootSize = root?.stringSize ? ` (current ${propertyPath}: ${root.stringSize})` : '';
+      return {
+        ok: false,
+        message:
+          `⛔ Cannot modify '${propertyPath}' via AxEdtExtension on derived EDT '${base.edtName}'.\n\n` +
+          `'${propertyPath}' is **inherited** through the Extends chain:\n` +
+          `  ${chainStr}\n\n` +
+          `Only the root EDT '${root?.edtName ?? '?'}'${rootSize} controls ${propertyPath}, and you cannot ` +
+          `extend Microsoft's root EDTs to widen them. Use one of these approved patterns instead:\n\n` +
+          `  • **Create a new EDT** that extends '${base.edtName}' with the desired ${propertyPath}, ` +
+          `then point your field at the new EDT (table extension → modify-field → edt=NewEdt).\n` +
+          `  • **Use a table extension** on the consuming field to override the size locally ` +
+          `(modify-field with stringSize=...) — but watch databaseStringSize on existing data.\n\n` +
+          `(For details see the X++ extension framework rules: StringSize/DisplayLength are not ` +
+          `extension points on derived EDTs.)`,
+      };
+    }
+    // Root EDT: still must be IsExtensible (when we know)
+    if (base.isExtensible === false) {
+      return {
+        ok: false,
+        message:
+          `⛔ Cannot modify '${propertyPath}' on EDT '${base.edtName}' — base EDT is **not extensible** ` +
+          `(IsExtensible = false). Microsoft has marked this EDT as closed to extension.\n` +
+          `Create a new EDT extending '${base.edtName}' with the desired ${propertyPath} instead.`,
+      };
+    }
+    // Cannot verify IsExtensible (no bridge / EDT not in live metadata).
+    // Refuse rather than silently allow a change that may be a runtime no-op or
+    // get rejected at compile time. The model can still proceed via the safe
+    // alternative paths (create derived EDT or table-extension on the field).
+    if (base.isExtensible == null) {
+      return {
+        ok: false,
+        message:
+          `⛔ Cannot verify whether EDT '${base.edtName}' is marked **IsExtensible = true**.\n` +
+          `${propertyPath} can only be changed via AxEdtExtension when the base EDT explicitly opts in.\n\n` +
+          `Use one of these safe alternatives instead:\n` +
+          `  • **Create a new EDT** that extends '${base.edtName}' with the desired ${propertyPath}, ` +
+          `then point your field at the new EDT (table extension → modify-field → edt=NewEdt).\n` +
+          `  • **Use a table extension** on the consuming field to widen the size locally ` +
+          `(modify-field with stringSize=...) — but watch databaseStringSize on existing data.\n\n` +
+          `Re-run with a connected bridge to verify IsExtensible if you believe extension is permitted.`,
+      };
+    }
+    // Defensive: refuse shrinking string size, which would corrupt existing data
+    if (propLower === 'stringsize') {
+      const newSize = parseInt(String(propertyValue), 10);
+      const currentSize = base.stringSize ? parseInt(base.stringSize, 10) : NaN;
+      if (Number.isFinite(newSize) && Number.isFinite(currentSize) && newSize < currentSize) {
+        return {
+          ok: false,
+          message:
+            `⛔ Refusing to shrink StringSize on '${base.edtName}' from ${currentSize} to ${newSize}. ` +
+            `Decreasing StringSize via extension is unsupported and risks truncating existing column data.`,
+        };
+      }
+      // Enforce the metadata invariant `StringSize <= DatabaseStringSize` (when known).
+      // -1 means unlimited (memo / nvarchar(max)) and is always permissible.
+      const dbSize = resolveEffectiveDatabaseStringSize(db, base.edtName);
+      if (Number.isFinite(newSize) && dbSize != null && dbSize > 0 && newSize > dbSize) {
+        return {
+          ok: false,
+          message:
+            `⛔ Cannot widen StringSize on '${base.edtName}' to ${newSize}: it exceeds the ` +
+            `effective DatabaseStringSize (${dbSize}) inherited from the EDT chain.\n\n` +
+            `D365FO requires StringSize ≤ DatabaseStringSize so the SQL column can hold the value. ` +
+            `Widening StringSize alone is silently capped at the DB size and risks runtime truncation.\n\n` +
+            `Options:\n` +
+            `  • First widen DatabaseStringSize on the same root EDT (modify-property propertyPath=DatabaseStringSize) ` +
+            `to at least ${newSize} (or -1 for unlimited), then widen StringSize.\n` +
+            `  • Or create a derived EDT extending '${base.edtName}' (which is allowed to lower StringSize ` +
+            `but cannot exceed the inherited DatabaseStringSize) and base your field on it.`,
+        };
+      }
+    }
+    // Same invariant in the other direction: DatabaseStringSize must not be
+    // shrunk below the current StringSize, which would orphan existing data.
+    if (propLower === 'databasestringsize') {
+      const newDb = parseInt(String(propertyValue), 10);
+      const currentSize = base.stringSize ? parseInt(base.stringSize, 10) : NaN;
+      if (Number.isFinite(newDb) && newDb !== -1 && newDb > 0 &&
+          Number.isFinite(currentSize) && newDb < currentSize) {
+        return {
+          ok: false,
+          message:
+            `⛔ Cannot shrink DatabaseStringSize on '${base.edtName}' to ${newDb}: ` +
+            `it would fall below the current StringSize (${currentSize}). ` +
+            `D365FO requires StringSize ≤ DatabaseStringSize. ` +
+            `Lower StringSize first, or set DatabaseStringSize to -1 (unlimited).`,
+        };
+      }
+    }
+  }
+
+  // All other properties (Label, HelpText, FormHelp, ConfigurationKey, etc.)
+  // are allowed regardless of inheritance.
+  return { ok: true };
+}
+
+/**
+ * Convenience wrapper: looks up the base EDT, enriches via bridge when
+ * available, and runs validation. Use this from modify_d365fo_file.
+ *
+ * Returns `{ ok: true }` and lets the caller proceed if everything is fine.
+ * Returns `{ ok: false, message }` to be relayed back to the model verbatim.
+ */
+export async function validateEdtExtensionChange(
+  extensionObjectName: string,
+  propertyPath: string,
+  propertyValue: string,
+  db: any,
+  bridge: BridgeClient | undefined,
+): Promise<EdtExtensionValidationResult> {
+  const baseName = extractBaseEdtName(extensionObjectName);
+  let base = lookupBaseEdtFromIndex(db, baseName);
+  if (!base) {
+    // Fall back to bridge-only lookup
+    if (bridge?.isReady && bridge.metadataAvailable) {
+      try {
+        const live = (await bridge.readEdt(baseName)) as
+          (BridgeEdtInfo & { isExtensible?: boolean; databaseStringSize?: number }) | null;
+        if (live) {
+          base = {
+            edtName: live.name,
+            extends: live.extends ?? null,
+            stringSize: live.stringSize != null ? String(live.stringSize) : null,
+            databaseStringSize: typeof live.databaseStringSize === 'number'
+              ? String(live.databaseStringSize)
+              : null,
+            isExtensible: typeof live.isExtensible === 'boolean' ? live.isExtensible : null,
+          };
+        }
+      } catch {
+        /* ignore — fall through to "ok" so we don't block on a missing index */
+      }
+    }
+  } else {
+    base = await enrichWithBridge(base, bridge);
+  }
+
+  if (!base) {
+    // We genuinely don't know whether this EDT is a root or a derived type.
+    // For inherited size properties (StringSize/DisplayLength) and the
+    // forbidden Extends property, refuse rather than passing through — the
+    // bridge silently accepts illegal extension edits and the change becomes
+    // an ineffective metadata modification.
+    const propLower = (propertyPath || '').trim().toLowerCase();
+    if (INHERITED_PROPERTIES.has(propLower) || FORBIDDEN_EXT_PROPERTIES.has(propLower)) {
+      return {
+        ok: false,
+        message:
+          `⛔ Cannot modify '${propertyPath}' on EDT extension '${extensionObjectName}' — ` +
+          `base EDT '${baseName}' was not found in the symbol index or live metadata, ` +
+          `so the validator cannot confirm whether the change is allowed.\n\n` +
+          `${propertyPath} is **inheritance-controlled**: it can only be changed via AxEdtExtension on a ` +
+          `*root* EDT marked IsExtensible = true. To stay safe, use one of these patterns instead:\n` +
+          `  • **Create a new EDT** extending '${baseName}' with the desired ${propertyPath}, then ` +
+          `point your field at it (table extension → modify-field → edt=NewEdt).\n` +
+          `  • **Use a table extension** on the consuming field to override the size locally ` +
+          `(watch databaseStringSize on existing data).\n\n` +
+          `If you genuinely need to extend '${baseName}' directly, run update_symbol_index (and start ` +
+          `the C# bridge) so the validator can verify Extends/IsExtensible.`,
+      };
+    }
+    // Other properties (Label, HelpText, ...) are always safe — let through.
+    return { ok: true };
+  }
+
+  return validateEdtExtensionProperty(base, propertyPath, propertyValue, db);
+}

--- a/tests/tools/buildProject.test.ts
+++ b/tests/tools/buildProject.test.ts
@@ -120,7 +120,7 @@ describe('build_d365fo_project', () => {
     spawnMock.mockReturnValue(child);
     allowPaths([PROJECT_PATH, XPPC, PKG]);
 
-    const result = await buildProjectTool({ projectPath: PROJECT_PATH }, {});
+    const result = await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [exe, args] = spawnMock.mock.calls[0];
@@ -136,7 +136,7 @@ describe('build_d365fo_project', () => {
     spawnMock.mockReturnValue(child);
     allowPaths([PROJECT_PATH, XPPC, PKG]);
 
-    await buildProjectTool({ projectPath: PROJECT_PATH }, {});
+    await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
 
     // writeFile is called to persist build state JSON (last write has the real PID)
     const stateCall = writeFileMock.mock.calls.filter((c: any[]) => c[0].includes('d365build_state')).at(-1);
@@ -152,7 +152,7 @@ describe('build_d365fo_project', () => {
     spawnMock.mockReturnValue(child);
     allowPaths([PROJECT_PATH, XPPC, PKG]);
 
-    await buildProjectTool({ projectPath: PROJECT_PATH }, {});
+    await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
 
     expect(child.unref).toHaveBeenCalledTimes(1);
   });
@@ -211,7 +211,7 @@ describe('build_d365fo_project', () => {
       return origKill(pid, sig);
     });
 
-    const result = await buildProjectTool({ projectPath: PROJECT_PATH }, {});
+    const result = await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
 
     expect(result.content[0].text).toContain('Call again to refresh');
     expect(spawnMock).not.toHaveBeenCalled();
@@ -283,7 +283,7 @@ describe('build_d365fo_project', () => {
     spawnMock.mockReturnValue(child);
     allowPaths([PROJECT_PATH, xppc]);
 
-    await buildProjectTool({ projectPath: PROJECT_PATH }, {});
+    await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnMock.mock.calls[0];
@@ -311,7 +311,7 @@ describe('build_d365fo_project', () => {
     spawnMock.mockReturnValue(child);
     allowPaths([PROJECT_PATH, XPPC, PKG]);
 
-    const result = await buildProjectTool({ projectPath: PROJECT_PATH, force: true }, {});
+    const result = await buildProjectTool({ projectPath: PROJECT_PATH, force: true, wait: false }, {});
 
     // A new build was started
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -331,7 +331,7 @@ describe('build_d365fo_project', () => {
     allowPaths([XPPC, PKG]);
     cfgGetModelName.mockReturnValue(MODEL_NAME);
 
-    await buildProjectTool({ modelName: MODEL_NAME }, {});
+    await buildProjectTool({ modelName: MODEL_NAME, wait: false }, {});
     expect(closeCallback).toBeDefined();
 
     readFileMock.mockImplementation(async (p: string) => {
@@ -363,7 +363,7 @@ describe('build_d365fo_project', () => {
     allowPaths([XPPC, PKG]);
     cfgGetModelName.mockReturnValue(MODEL_NAME);
 
-    await buildProjectTool({ modelName: MODEL_NAME }, {});
+    await buildProjectTool({ modelName: MODEL_NAME, wait: false }, {});
     expect(closeCallback).toBeDefined();
 
     readFileMock.mockImplementation(async (p: string) => {
@@ -396,7 +396,7 @@ describe('build_d365fo_project', () => {
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     });
 
-    await buildProjectTool({ modelName: 'mymodel' }, {});
+    await buildProjectTool({ modelName: 'mymodel', wait: false }, {});
     const firstPath = readPaths[0];
     expect(firstPath).toBeDefined();
 
@@ -425,7 +425,7 @@ describe('build_d365fo_project', () => {
     });
     vi.spyOn(process, 'kill').mockReturnValue(true as any);
 
-    const result = await buildProjectTool({ modelName: 'MYMODEL' }, {});
+    const result = await buildProjectTool({ modelName: 'MYMODEL', wait: false }, {});
     const secondPath = readPaths2[0];
     expect(secondPath).toBeDefined();
     expect(result.content[0].text).toContain('Call again to refresh');
@@ -440,7 +440,7 @@ describe('build_d365fo_project', () => {
     allowPaths([XPPC, PKG]);
     cfgGetModelName.mockReturnValue(null);
 
-    const result = await buildProjectTool({ modelName: 'ExplicitModel' }, {});
+    const result = await buildProjectTool({ modelName: 'ExplicitModel', wait: false }, {});
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnMock.mock.calls[0];

--- a/tests/utils/edtExtensionValidator.test.ts
+++ b/tests/utils/edtExtensionValidator.test.ts
@@ -1,0 +1,324 @@
+/**
+ * EDT Extension Validator tests
+ *
+ * Covers the rules in src/utils/edtExtensionValidator.ts, with an emphasis
+ * on the StringSize / DatabaseStringSize invariants that D365FO enforces:
+ *   - StringSize / DisplayLength are inherited; only the root EDT may carry them.
+ *   - StringSize must not exceed the effective DatabaseStringSize (unless -1).
+ *   - DatabaseStringSize must not be lowered below the current StringSize.
+ *   - Extends can never be set via AxEdtExtension.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import {
+  extractBaseEdtName,
+  lookupBaseEdtFromIndex,
+  resolveEdtChain,
+  resolveEffectiveDatabaseStringSize,
+  validateEdtExtensionProperty,
+} from '../../src/utils/edtExtensionValidator';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE edt_metadata (
+      edt_name TEXT PRIMARY KEY,
+      model TEXT,
+      base_type TEXT,
+      extends TEXT,
+      string_size TEXT,
+      database_string_size TEXT
+    );
+  `);
+  return db;
+}
+
+function insertEdt(db: any, row: {
+  name: string;
+  extends?: string | null;
+  stringSize?: string | null;
+  dbSize?: string | null;
+  model?: string;
+}) {
+  db.prepare(`
+    INSERT OR REPLACE INTO edt_metadata
+      (edt_name, model, base_type, extends, string_size, database_string_size)
+    VALUES (?, ?, 'String', ?, ?, ?)
+  `).run(
+    row.name,
+    row.model ?? 'Test',
+    row.extends ?? null,
+    row.stringSize ?? null,
+    row.dbSize ?? null,
+  );
+}
+
+describe('extractBaseEdtName', () => {
+  it('splits on dot convention', () => {
+    expect(extractBaseEdtName('AccountNum.MyExt')).toBe('AccountNum');
+  });
+
+  it('splits on underscore Extension convention', () => {
+    expect(extractBaseEdtName('AccountNum_AslExtension')).toBe('AccountNum');
+  });
+
+  it('returns input unchanged when no separator', () => {
+    expect(extractBaseEdtName('MyEdt')).toBe('MyEdt');
+  });
+
+  it('does not split arbitrary underscores in EDT names', () => {
+    expect(extractBaseEdtName('Sales_Order')).toBe('Sales_Order');
+  });
+});
+
+describe('lookupBaseEdtFromIndex (DatabaseStringSize)', () => {
+  let db: any;
+  beforeEach(() => { db = makeDb(); });
+
+  it('reads database_string_size column when present', () => {
+    insertEdt(db, { name: 'Foo', stringSize: '20', dbSize: '60' });
+    const info = lookupBaseEdtFromIndex(db, 'Foo');
+    expect(info?.databaseStringSize).toBe('60');
+  });
+
+  it('preserves null database_string_size', () => {
+    insertEdt(db, { name: 'Foo', stringSize: '20' });
+    const info = lookupBaseEdtFromIndex(db, 'Foo');
+    expect(info?.databaseStringSize).toBeNull();
+  });
+
+  it('falls back gracefully on legacy schema without the new column', () => {
+    const legacy = new Database(':memory:');
+    legacy.exec(`
+      CREATE TABLE edt_metadata (
+        edt_name TEXT, model TEXT, extends TEXT, string_size TEXT
+      );
+      INSERT INTO edt_metadata VALUES ('Foo','Test',NULL,'10');
+    `);
+    const info = lookupBaseEdtFromIndex(legacy, 'Foo');
+    expect(info?.edtName).toBe('Foo');
+    expect(info?.stringSize).toBe('10');
+    expect(info?.databaseStringSize).toBeUndefined();
+  });
+});
+
+describe('resolveEffectiveDatabaseStringSize', () => {
+  let db: any;
+  beforeEach(() => {
+    db = makeDb();
+    // Chain: Leaf → Mid → Root
+    insertEdt(db, { name: 'Root', stringSize: '20', dbSize: '60' });
+    insertEdt(db, { name: 'Mid', extends: 'Root', stringSize: '15' });
+    insertEdt(db, { name: 'Leaf', extends: 'Mid' });
+  });
+
+  it('returns local DatabaseStringSize when defined', () => {
+    expect(resolveEffectiveDatabaseStringSize(db, 'Root')).toBe(60);
+  });
+
+  it('walks Extends chain to find inherited DatabaseStringSize', () => {
+    expect(resolveEffectiveDatabaseStringSize(db, 'Leaf')).toBe(60);
+  });
+
+  it('returns -1 when chain says unlimited (memo)', () => {
+    insertEdt(db, { name: 'BigText', dbSize: '-1' });
+    insertEdt(db, { name: 'BigDerived', extends: 'BigText' });
+    expect(resolveEffectiveDatabaseStringSize(db, 'BigDerived')).toBe(-1);
+  });
+
+  it('returns null when the chain has no DatabaseStringSize at all', () => {
+    insertEdt(db, { name: 'A', stringSize: '10' });
+    insertEdt(db, { name: 'B', extends: 'A' });
+    expect(resolveEffectiveDatabaseStringSize(db, 'B')).toBeNull();
+  });
+});
+
+describe('validateEdtExtensionProperty — Extends', () => {
+  it('refuses changing Extends via extension', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'Foo', extends: null, stringSize: '10' },
+      'Extends',
+      'OtherEdt',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/Extends/);
+  });
+});
+
+describe('validateEdtExtensionProperty — StringSize on derived EDT', () => {
+  it('refuses StringSize change when base has Extends', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'AccountNumDerived', extends: 'AccountNum', stringSize: '20' },
+      'StringSize',
+      '60',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/inherited/i);
+  });
+
+  it('also refuses DisplayLength on derived EDT', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'Foo', extends: 'Bar', stringSize: '10' },
+      'DisplayLength',
+      '40',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/inherited/i);
+  });
+});
+
+describe('validateEdtExtensionProperty — StringSize on root EDT (extensibility)', () => {
+  it('refuses when IsExtensible is explicitly false', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'RootEdt', extends: null, stringSize: '20', isExtensible: false },
+      'StringSize',
+      '60',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/not extensible|IsExtensible/i);
+  });
+
+  it('refuses (fail-closed) when IsExtensible is unknown', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'RootEdt', extends: null, stringSize: '20', isExtensible: null },
+      'StringSize',
+      '60',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/verify|IsExtensible/i);
+  });
+
+  it('allows when IsExtensible is true and size grows', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'RootEdt', extends: null, stringSize: '20', isExtensible: true, databaseStringSize: '60' },
+      'StringSize',
+      '40',
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('validateEdtExtensionProperty — StringSize ≤ DatabaseStringSize invariant', () => {
+  let db: any;
+  beforeEach(() => {
+    db = makeDb();
+    insertEdt(db, { name: 'NarrowDb', stringSize: '20', dbSize: '30' });
+    insertEdt(db, { name: 'Unlimited', stringSize: '20', dbSize: '-1' });
+    insertEdt(db, { name: 'NoDbSize', stringSize: '20' });
+  });
+
+  it('refuses StringSize > local DatabaseStringSize', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'NarrowDb', extends: null, stringSize: '20', databaseStringSize: '30', isExtensible: true },
+      'StringSize',
+      '60',
+      db,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/DatabaseStringSize/);
+    expect(r.message).toMatch(/30/);
+  });
+
+  it('allows StringSize = DatabaseStringSize', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'NarrowDb', extends: null, stringSize: '20', databaseStringSize: '30', isExtensible: true },
+      'StringSize',
+      '30',
+      db,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('allows any StringSize when DatabaseStringSize is -1 (unlimited)', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'Unlimited', extends: null, stringSize: '20', databaseStringSize: '-1', isExtensible: true },
+      'StringSize',
+      '4000',
+      db,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('allows StringSize change when DatabaseStringSize is unknown', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'NoDbSize', extends: null, stringSize: '20', databaseStringSize: null, isExtensible: true },
+      'StringSize',
+      '4000',
+      db,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses shrinking StringSize regardless of DatabaseStringSize', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'NarrowDb', extends: null, stringSize: '20', databaseStringSize: '30', isExtensible: true },
+      'StringSize',
+      '10',
+      db,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/shrink/i);
+  });
+});
+
+describe('validateEdtExtensionProperty — DatabaseStringSize on derived EDT', () => {
+  it('refuses DatabaseStringSize change when base has Extends', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'Derived', extends: 'Root', stringSize: '20' },
+      'DatabaseStringSize',
+      '60',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/inherited/i);
+  });
+});
+
+describe('validateEdtExtensionProperty — DatabaseStringSize ≥ StringSize invariant', () => {
+  it('refuses lowering DatabaseStringSize below current StringSize', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'RootEdt', extends: null, stringSize: '40', databaseStringSize: '60', isExtensible: true },
+      'DatabaseStringSize',
+      '20',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/StringSize/);
+  });
+
+  it('allows lowering DatabaseStringSize when still ≥ StringSize', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'RootEdt', extends: null, stringSize: '20', databaseStringSize: '60', isExtensible: true },
+      'DatabaseStringSize',
+      '40',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('allows setting DatabaseStringSize to -1 (unlimited)', () => {
+    const r = validateEdtExtensionProperty(
+      { edtName: 'RootEdt', extends: null, stringSize: '40', databaseStringSize: '60', isExtensible: true },
+      'DatabaseStringSize',
+      '-1',
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('resolveEdtChain', () => {
+  it('walks the chain root-ward and stops at root', () => {
+    const db = makeDb();
+    insertEdt(db, { name: 'Root', stringSize: '20', dbSize: '60' });
+    insertEdt(db, { name: 'Mid', extends: 'Root' });
+    insertEdt(db, { name: 'Leaf', extends: 'Mid' });
+    const chain = resolveEdtChain(db, 'Leaf');
+    expect(chain.map(c => c.edtName)).toEqual(['Leaf', 'Mid', 'Root']);
+  });
+
+  it('terminates on cycles defensively', () => {
+    const db = makeDb();
+    insertEdt(db, { name: 'A', extends: 'B' });
+    insertEdt(db, { name: 'B', extends: 'A' });
+    const chain = resolveEdtChain(db, 'A');
+    expect(chain.length).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
…tensible on AxEdtExtension

New src/utils/edtExtensionValidator.ts gates AxEdtExtension property changes against D365FO metadata rules:
- StringSize/DisplayLength/DatabaseStringSize are inherited; refuse changes on derived EDTs.
- StringSize must not exceed effective DatabaseStringSize (walks Extends chain; -1 = unlimited/memo).
- DatabaseStringSize must not be lowered below current StringSize.
- Extends can never be set via extension.
- Fail-closed when IsExtensible can't be verified.

Schema: edt_metadata gains a database_string_size column (with ALTER TABLE migration); xmlParser extracts DatabaseStringSize; bridge EdtInfoModel/BridgeEdtInfo expose IsExtensible.

Build tool: build_d365fo_project now blocks once and waits for completion (wait=true default, waitTimeoutMs=30min) instead of requiring repeated polling. System instructions and tool description updated.

Tests: +28 cases for the validator (root vs derived, -1 semantics, both invariant directions, cycle defence,
legacy-schema fallback). Existing build tests pinned to wait:false. Total: 694 tests passing.