### PR TITLE
fix(security): prevent path traversal via workspacePath and filePath …

### DIFF
--- a/src/tools/formInfo.ts
+++ b/src/tools/formInfo.ts
@@ -14,6 +14,7 @@ import type { XppServerContext } from '../types/context.js';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
 import { tryBridgeForm } from '../bridge/bridgeAdapter.js';
+import { assertWritePathAllowed } from '../utils/pathContainment.js';
 
 const GetFormInfoArgsSchema = z.object({
   formName: z.string().describe('Name of the form'),
@@ -82,6 +83,18 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
     // 0. If an explicit filePath is provided, skip bridge entirely.
     // This is the retry path for newly-created forms not yet in bridge metadata.
     if (explicitFilePath) {
+      // Security: validate that the supplied path falls within a configured D365FO
+      // package root before reading any file content.  Without this check a
+      // prompt-injection attack could read arbitrary local files via this parameter.
+      const containment = await assertWritePathAllowed(explicitFilePath);
+      if (!containment.ok) {
+        return {
+          content: [{ type: 'text', text:
+            `❌ get_form_info: filePath rejected — ${containment.reason}`,
+          }],
+          isError: true,
+        };
+      }
       let xmlContent: string | null = null;
       try {
         xmlContent = await fs.readFile(explicitFilePath, 'utf-8');

--- a/src/tools/reportInfo.ts
+++ b/src/tools/reportInfo.ts
@@ -15,6 +15,7 @@ import type { XppServerContext } from '../types/context.js';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
 import { tryBridgeReport } from '../bridge/bridgeAdapter.js';
+import { assertWritePathAllowed } from '../utils/pathContainment.js';
 
 const GetReportInfoArgsSchema = z.object({
   reportName: z.string().describe('Name of the AxReport object (without .xml extension)'),
@@ -79,6 +80,16 @@ export async function getReportInfoTool(request: CallToolRequest, context: XppSe
 
     // 2. Explicit file path fallback for newly-created reports
     if (explicitFilePath) {
+      // Security: validate that the supplied path falls within a configured D365FO
+      // package root before reading any file content.  Without this check a
+      // prompt-injection attack could read arbitrary local files via this parameter.
+      const containment = await assertWritePathAllowed(explicitFilePath);
+      if (!containment.ok) {
+        return {
+          content: [{ type: 'text', text: `❌ get_report_info: filePath rejected — ${containment.reason}` }],
+          isError: true,
+        };
+      }
       let xmlContent: string | null = null;
       try {
         const raw = await fs.readFile(explicitFilePath, 'utf-8');
@@ -86,6 +97,14 @@ export async function getReportInfoTool(request: CallToolRequest, context: XppSe
         if (trimmed.startsWith('{')) {
           const meta = JSON.parse(raw);
           if (meta.sourcePath) {
+            // Validate indirect sourcePath as well before reading it.
+            const srcContainment = await assertWritePathAllowed(meta.sourcePath);
+            if (!srcContainment.ok) {
+              return {
+                content: [{ type: 'text', text: `❌ get_report_info: sourcePath rejected — ${srcContainment.reason}` }],
+                isError: true,
+              };
+            }
             try { xmlContent = await fs.readFile(meta.sourcePath, 'utf-8'); } catch { /* not accessible */ }
           }
         } else {

--- a/src/utils/pathContainment.ts
+++ b/src/utils/pathContainment.ts
@@ -162,3 +162,45 @@ export async function ensureWritePathAllowed(filePath: string, modelHint?: strin
   if (!r.ok) throw new Error(`⛔ Path containment check failed: ${r.reason}`);
   return r.canonicalPath!;
 }
+
+/**
+ * Validate that `dirPath` is a directory inside one of the configured D365FO
+ * package roots. Used as the read-side equivalent of `assertWritePathAllowed`
+ * for workspace-scanning operations (`workspacePath` tool parameter).
+ *
+ * Prevents path traversal and arbitrary directory reads: any absolute path that
+ * does NOT resolve under a configured package root is rejected outright.
+ */
+export async function assertReadRootAllowed(dirPath: string): Promise<PathContainmentResult> {
+  if (!dirPath || typeof dirPath !== 'string') {
+    return { ok: false, reason: 'dirPath is empty' };
+  }
+  if (!isAbsoluteCrossPlatform(dirPath)) {
+    return { ok: false, reason: `dirPath must be absolute: "${dirPath}"` };
+  }
+
+  const canonical = normalise(dirPath);
+  const roots = await getAllowedRoots();
+  const matchedRoot = roots.find(r => isUnder(canonical, r));
+  if (!matchedRoot) {
+    return {
+      ok: false,
+      reason:
+        `Refusing to scan outside configured D365FO package roots.\n` +
+        `  path:    ${dirPath}\n` +
+        `  allowed: ${roots.join(' | ') || '(none configured)'}`,
+    };
+  }
+
+  return { ok: true, canonicalPath: canonical, matchedRoot };
+}
+
+/**
+ * Check that a single file path (e.g. a glob result) still resolves under
+ * `rootDir` after symlink resolution. Call this on every file returned by
+ * a glob that was rooted at a validated workspace path — a symlink inside
+ * the workspace could otherwise redirect a read outside the allowed root.
+ */
+export function isFileUnderRoot(filePath: string, rootDir: string): boolean {
+  return isUnder(filePath, rootDir);
+}

--- a/src/workspace/workspaceScanner.ts
+++ b/src/workspace/workspaceScanner.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { glob } from 'glob';
 import { parseStringPromise } from 'xml2js';
+import { isFileUnderRoot } from '../utils/pathContainment.js';
 
 export interface WorkspaceFile {
   path: string;
@@ -69,6 +70,15 @@ export class WorkspaceScanner {
     });
 
     for (const filePath of xmlFiles) {
+      // Defense in depth: verify that each globbed file (after symlink
+      // resolution) still resolves under the validated workspace root.
+      // A symlink placed inside the workspace could otherwise redirect a read
+      // to an arbitrary location outside the allowed root.
+      if (!isFileUnderRoot(filePath, workspacePath)) {
+        console.warn(`[WorkspaceScanner] Skipping ${filePath} — resolves outside workspace root ${workspacePath}`);
+        continue;
+      }
+
       const stat = await fs.stat(filePath);
       const fileName = path.basename(filePath, '.xml');
       

--- a/src/workspace/workspaceUtils.ts
+++ b/src/workspace/workspaceUtils.ts
@@ -5,28 +5,40 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { assertReadRootAllowed } from '../utils/pathContainment.js';
 
 /**
  * Validate workspace path
- * Ensures path is safe and accessible
+ * Ensures path is safe and accessible, and that it is contained within the
+ * configured D365FO package roots.
+ *
+ * Security: the previous implementation only checked for the literal substring
+ * ".." — absolute paths such as "/etc" or "C:\Windows" bypassed it entirely.
+ * This version resolves the path to an absolute form and then verifies it falls
+ * under one of the operator-configured package roots before any fs operation.
  */
 export async function validateWorkspacePath(workspacePath: string): Promise<{
   valid: boolean;
   error?: string;
 }> {
   try {
-    // Check for path traversal attempts
-    const normalizedPath = path.normalize(workspacePath);
-    if (normalizedPath.includes('..')) {
+    // Resolve to absolute, eliminating any relative segments.
+    const resolved = path.resolve(workspacePath);
+
+    // Root-containment check: reject any path that does not resolve under a
+    // configured D365FO package root (replaces the old ".." substring test,
+    // which was bypassable with absolute paths such as "/etc" or "C:\Windows").
+    const containment = await assertReadRootAllowed(resolved);
+    if (!containment.ok) {
       return {
         valid: false,
-        error: 'Path traversal detected - workspace path cannot contain ".."',
+        error: containment.reason ?? 'workspacePath escapes configured workspace roots',
       };
     }
 
-    // Check if path exists
+    // Check if path exists and is a directory.
     try {
-      const stats = await fs.stat(workspacePath);
+      const stats = await fs.stat(resolved);
       if (!stats.isDirectory()) {
         return {
           valid: false,
@@ -36,21 +48,12 @@ export async function validateWorkspacePath(workspacePath: string): Promise<{
     } catch (error) {
       return {
         valid: false,
-        error: `Workspace path does not exist or is not accessible: ${workspacePath}`,
-      };
-    }
-
-    // Check if path is too deep (security limit)
-    const depth = workspacePath.split(path.sep).length;
-    if (depth > 20) {
-      return {
-        valid: false,
-        error: 'Workspace path is too deep (max 20 levels)',
+        error: `Workspace path does not exist or is not accessible: ${resolved}`,
       };
     }
 
     // Check if path contains too many files (prevent DoS)
-    const files = await fs.readdir(workspacePath);
+    const files = await fs.readdir(resolved);
     if (files.length > 50000) {
       return {
         valid: false,


### PR DESCRIPTION
…params (GHSA-pw7v-9v7h-6j22)

- validateWorkspacePath: replace '..' substring check with assertReadRootAllowed root-containment check; absolute paths outside configured D365FO package roots (e.g. /etc, C:\Windows, ~/.ssh) are now rejected
- workspaceScanner.scanWorkspace: add per-file isFileUnderRoot re-check after glob to close the symlink escape vector
- formInfo filePath param: gate fs.readFile behind assertWritePathAllowed
- reportInfo filePath + sourcePath params: same gate, covers JSON indirection
- pathContainment: add assertReadRootAllowed() and isFileUnderRoot() exports