### PR TITLE
fix: stop emitting <IsFinal> and <IsAbstract> in class XML (#539)

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -539,10 +539,6 @@ export class XmlTemplateGenerator {
     const implementsAttr = properties?.implements
       ? `\t<Implements>${properties.implements}</Implements>\n`
       : '';
-    const isFinalAttr = properties?.isFinal ? `\t<IsFinal>Yes</IsFinal>\n` : '';
-    const isAbstractAttr = properties?.isAbstract
-      ? `\t<IsAbstract>Yes</IsAbstract>\n`
-      : '';
 
     // D365FO convention: method source is always indented by 4 spaces inside <Source>.
     // This matches what VS writes and what the compiler/Designer expect to see.
@@ -562,7 +558,7 @@ export class XmlTemplateGenerator {
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${className}</Name>
-${extendsAttr}${implementsAttr}${isFinalAttr}${isAbstractAttr}\t<SourceCode>
+${extendsAttr}${implementsAttr}\t<SourceCode>
 \t\t<Declaration><![CDATA[
 ${ensureBlankLineBeforeClosingBrace(ensureXppDocComment(declaration))}
 ]]></Declaration>
@@ -589,7 +585,7 @@ ${methodsXml}\t</SourceCode>
     const defaultSource = sourceCode ||
       `[ExtensionOf(classStr(${baseClass}))]\nfinal class ${extensionName}\n{\n    // ⚠️  ALWAYS call next <methodName>() — verify exact signature with:\n    //     get_method_signature("${baseClass}", "methodName")\n    //\n    // Template for wrapping a method:\n    //   public ReturnType methodName(ParamType _param)\n    //   {\n    //       ReturnType result = next methodName(_param);\n    //       return result;\n    //   }\n}`;
 
-    return XmlTemplateGenerator.generateAxClassXml(extensionName, defaultSource, { isFinal: true, ...properties });
+    return XmlTemplateGenerator.generateAxClassXml(extensionName, defaultSource, { ...properties });
   }
 
   /**
@@ -2700,7 +2696,7 @@ public final class ${contractName} extends BusinessEventsContract
     }
 }`;
 
-    return XmlTemplateGenerator.generateAxClassXml(name, source, { label, helpText, isFinal: true });
+    return XmlTemplateGenerator.generateAxClassXml(name, source, { label, helpText });
   }
 
   /**

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -274,10 +274,6 @@ class XmlTemplateGenerator {
     const implementsAttr = properties?.implements
       ? `\t<Implements>${properties.implements}</Implements>\n`
       : '';
-    const isFinalAttr = properties?.isFinal ? `\t<IsFinal>Yes</IsFinal>\n` : '';
-    const isAbstractAttr = properties?.isAbstract
-      ? `\t<IsAbstract>Yes</IsAbstract>\n`
-      : '';
 
     // D365FO convention: method source is always indented by 4 spaces inside <Source>.
     const indentMethodSource = (src: string): string =>
@@ -296,7 +292,7 @@ class XmlTemplateGenerator {
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${className}</Name>
-${extendsAttr}${implementsAttr}${isFinalAttr}${isAbstractAttr}\t<SourceCode>
+${extendsAttr}${implementsAttr}\t<SourceCode>
 \t\t<Declaration><![CDATA[
 ${ensureBlankLineBeforeClosingBrace(ensureXppDocComment(declaration))}
 ]]></Declaration>


### PR DESCRIPTION
Microsoft source class XMLs (~66 500 files) never emit these elements; they only appear in compiler output under XppMetadata. The final/abstract modifiers in the X++ <Declaration> are sufficient.

- Drop isFinalAttr/isAbstractAttr emission from XmlTemplateGenerator in both src/tools/createD365File.ts and src/tools/generateD365Xml.ts.
- Stop forcing isFinal: true in generateAxClassExtensionXml (CoC) and the BusinessEvent contract helper.
- <Extends> is intentionally retained — it is a valid source-XML element.
- xmlParser.ts and bridgeAdapter.ts continue to read these tags for backward compatibility with existing XMLs that contain them.

Closes #539