### PR TITLE
feat: enforce reuse-before-creating and additive-diff rules in system…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,6 +73,12 @@ PowerShell / any terminal command **WILL HANG** in VS 2022 / VS 2026 MCP integra
 
    Pass the BASE object name to `create_d365fo_file` and let the tool inject the token — don't hand-build the infix.
 
+### Reuse & diff safety
+
+10. **Reuse before creating** — `prepare_change` lists existing CoC wrappers and event handlers. If an extension or handler class in the custom model already owns the target, add the new method there. Never create a parallel feature-named class (`<Target>_<Feature>_Extension`, `<Form>_<Feature>_EH`) unless the user explicitly asks for a separate class. The suffix comes from `EXTENSION_NAMING_STYLE` / existing artifacts — never from feature, ticket, or customer names; if it cannot be derived, ask.
+11. **The post-write diff must be additive or narrowly targeted** — verify via `review_workspace_changes` (or re-read with `get_*_info`) that no unrelated XML nodes (`<DataSources>`, `<Controls>`, methods, pattern metadata) disappeared. If they did, the edit failed: `undo_last_modification`.
+12. **An example form named by the user is a pattern contract** — keep its pattern family and required scaffolding (datasources, ActionPane/Tab/grid/QuickFilter); missing pattern elements are a failed generation even if the XML is well-formed.
+
 ## Full Instructions
 
 The complete X++ rules, query grammar, CoC authoring rules, and workflow details are delivered via the MCP prompt `xpp_system_instructions`. If that prompt is not loaded, request it or consult [src/prompts/systemInstructions.ts](../src/prompts/systemInstructions.ts) directly.

--- a/CLAUDE.template.md
+++ b/CLAUDE.template.md
@@ -59,6 +59,8 @@ Call `get_workspace_info()` before doing anything with D365FO objects.
 6. Never use hardcoded strings in Info/warning/error — use `@Model:Label`
 7. Call `search_labels()` before `create_label()` — reuse existing labels
 8. Extension naming depends on `EXTENSION_NAMING_STYLE` (check `get_workspace_info`). Default `prefix` → class `{Target}{Prefix}_Extension`, element `{Target}.{Prefix}Extension`; `model-name` → class `{Target}_{ModelName}_Extension`, element `{Target}.{ModelName}`. Pass the BASE name to `create_d365fo_file` and let the tool apply the token — don't hand-build the infix.
+9. Reuse before creating: if an extension/handler class for the target already exists in the custom model (`prepare_change` lists them), add the method there — never create a parallel feature-named class unless the user explicitly asks; never invent suffixes from feature/ticket/customer names
+10. After writes, check the diff is additive (`review_workspace_changes` or re-read via `get_*_info`) — unrelated nodes disappearing = failed edit → `undo_last_modification`
 
 ## Terminal Note
 

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -78,7 +78,7 @@ You are an AI assistant with access to D365FO MCP tools, assisting with Dynamics
 2. Generate → \`resolve_references(code)\` + \`validate_xpp(code)\` — fix errors in the same turn
 3. \`create_d365fo_file(..., groundingToken=...)\`
 
-**New forms:** never hand-write form XML — follow Decision Tree #3 (cloning preserves patterns/sub-patterns; FP001-FP005/FP007 violations BLOCK the write).
+**New forms:** never hand-write form XML — follow Decision Tree #3 (cloning preserves patterns/sub-patterns; FP001-FP005/FP007 violations BLOCK the write). A user-named example form is a pattern contract, not inspiration: keep its pattern family and required scaffolding (datasources, ActionPane/Tab/grid/QuickFilter) unless the user explicitly asks for a different pattern.
 
 ## Hard Rules
 
@@ -87,12 +87,17 @@ You are an AI assistant with access to D365FO MCP tools, assisting with Dynamics
 - **Never infer the target model from search results.** Model names in results are the SOURCE model of that object. All writes go to the configured model from \`.mcp.json\`.
 - **Never switch projects autonomously.** If a different model seems needed, ASK the user first.
 
+### Reuse before creating
+- \`prepare_change\` returns existing CoC wrappers and event handlers — if an extension or handler class in the custom model already owns the target object, add the new method THERE. Never create a parallel feature-named class (\`<Target>_<Feature>_Extension\`, \`<Form>_<Feature>_EH\`) unless the user explicitly asks for a separate class.
+- **The artifact suffix is not the feature name.** It comes from \`EXTENSION_NAMING_STYLE\` (see \`get_workspace_info\`) and existing related artifacts. Never invent a suffix from feature names, tickets, customer names, or labels — if none can be derived, ASK.
+
 ### Writes apply immediately (no preview)
 \`modify_d365fo_file\` and \`create_d365fo_file\` write to disk the moment they are called — VS 2022 Copilot Chat has no Keep/Undo UI. Therefore:
 1. Describe the exact change in chat (object, operation, before→after) and wait for explicit confirmation.
 2. Call the tool ONCE. \`isError=true\` → the change did NOT apply: fix the cause, retry. Success → it is done; do not wait for further approval.
 3. Revert with \`undo_last_modification\` (or pass \`createBackup=true\`).
 4. Before multi-file tasks, suggest a feature branch (\`git switch -c mcp/<task>\`) — propose, never create branches autonomously.
+5. **The resulting diff must be additive or narrowly targeted.** After a write, verify via \`review_workspace_changes\` (or re-read with \`get_*_info\`) that no unrelated XML nodes — \`<DataSources>\`, \`<Controls>\`, methods, pattern metadata — disappeared. If they did, the edit failed: \`undo_last_modification\` and retry with a targeted operation.
 
 ### D365FO files: MCP tools ONLY
 - ⛔ **NEVER** use \`create_file\`, \`edit_file\`, \`apply_patch\`, \`replace_string_in_file\`, \`str_replace_editor\`, or any built-in file-write tool on .xml/.xpp files — not even as a fallback. They bypass IMetadataProvider and corrupt VS 2022's in-memory model. If \`modify_d365fo_file\` errors, STOP and report the error verbatim.

--- a/src/tools/xppKnowledge.ts
+++ b/src/tools/xppKnowledge.ts
@@ -407,6 +407,8 @@ final class SalesFormLetter_MyModel_Extension
       'DataEventHandler signature: static void handler(Common _sender, DataEventArgs _e)',
       'Validating events: cast _e to ValidateEventArgs, call _e.parmValidateResult(false) to fail',
       'NEVER use SubscribesTo + delegateStr for standard table data events — use DataEventHandler',
+      'REUSE BEFORE CREATING: call find_event_handlers first — if a handler class for the target already exists in the custom model, add the new handler method there instead of creating a parallel class',
+      'Both _EH and _EventHandler handler-class naming styles exist — follow the style already used in the model; never introduce a feature-named handler class (<Form>_<Feature>_EH) unless the user explicitly asks for a separate class',
     ],
     examples: [
       {
@@ -701,6 +703,8 @@ MyDocumentId newId = numSeq.num();
       'New controls: add via modify_d365fo_file(operation="add-control", parentControl="TabGeneral") — the control type is checked against the parent container\'s sub-pattern',
       'Data sources: add via modify_d365fo_file(operation="add-data-source")',
       'NEVER use PowerShell or read_file to inspect form XML — use get_form_info',
+      'A user-provided example form is a PATTERN CONTRACT: read it with get_form_info, keep the same pattern family, and verify the generated form keeps the required scaffolding (datasources, design pattern/version, ActionPane/Body/Tab/FastTab/grid/QuickFilter) — missing pattern elements are a failed generation even if the XML is well-formed',
+      'Edits must be additive: never drop unrelated <Controls>, <DataSources>, <DataSourceModifications>, methods, or pattern metadata — use targeted modify_d365fo_file operations and verify the diff with review_workspace_changes afterwards',
     ],
     related: ['coc', 'event-handlers', 'formrun-lifecycle'],
   },
@@ -1917,6 +1921,8 @@ select salesTable where salesTable.ShippingDateRequested == cutoffDate;`,
       'Wrappers can read/call protected members of the augmented class (PU9+); cannot reach private',
       'Pre-processing: call business logic before next. Post-processing: call next first, then business logic. Wrap: call next inside the logic',
       'Use get_method_signature tool to get exact parameter types before writing the wrapper',
+      'REUSE BEFORE CREATING: if a CoC extension class for the target already exists in the custom model (prepare_change / find_coc_extensions lists them), add the wrapper there — never create a parallel feature-named class (<Target>_<Feature>_Extension) unless the user explicitly requests separation',
+      'The class suffix comes from EXTENSION_NAMING_STYLE and existing related artifacts — never from feature names, tickets, or customer names; if it cannot be derived, ask the user',
     ],
     examples: [
       {


### PR DESCRIPTION
… instructions

- xppKnowledge: add rules for CoC and event-handler reuse (never create parallel feature-named classes when one already exists in the custom model)
- xppKnowledge: add form pattern contract rule (user-named form is a pattern contract; keep datasources/ActionPane/grid/QuickFilter scaffolding)
- xppKnowledge: add additive-diff rule for form edits (never drop unrelated Controls/DataSources/methods; verify with review_workspace_changes)
- systemInstructions: clarify form example = pattern contract, not inspiration
- systemInstructions: add reuse-before-creating section under Hard Rules
- systemInstructions: add additive-diff verification step to write workflow
- copilot-instructions.md / CLAUDE.template.md: sync matching rules