### PR TITLE
Feature/form pattern mining fixes

### DIFF
--- a/src/knowledge/formPatterns/catalog/subPatterns/fields.ts
+++ b/src/knowledge/formPatterns/catalog/subPatterns/fields.ts
@@ -65,8 +65,8 @@ export const fillText: SubPatternSpec = {
 
 export const horizontalFieldsButtonGroup: SubPatternSpec = {
   id: 'HorizontalFieldsButtonGroup',
-  xmlName: 'HorizontalFieldsButtonGroup',
-  xmlAliases: ['HorizontalFieldsAndButtonGroup', 'FieldsAndButtonGroup'],
+  xmlName: 'HorizontalFieldsButtonsGroup',
+  xmlAliases: ['HorizontalFieldsButtonGroup', 'HorizontalFieldsAndButtonGroup', 'FieldsAndButtonGroup'],
   displayName: 'Horizontal Fields and Button Group',
   versions: ['1.0'],
   appliesToControlTypes: ['Group'],
@@ -74,7 +74,6 @@ export const horizontalFieldsButtonGroup: SubPatternSpec = {
   referenceForms: ['SalesTable (GroupHeaderAddressHeaderOverview)'],
   root: [],
   extraRootChildren: 'any',
-  notes: ['xmlName to be confirmed by mining.'],
 };
 
 export const imagePreview: SubPatternSpec = {
@@ -98,4 +97,88 @@ export const fieldsSubPatterns: SubPatternSpec[] = [
   fillText,
   horizontalFieldsButtonGroup,
   imagePreview,
+];
+
+// ── Additional mined sub-patterns ─────────────────────────────────────────────
+
+/** Sentinel for containers with no standard sub-pattern. Suppresses FP001. */
+export const customSubPattern: SubPatternSpec = {
+  id: 'Custom',
+  xmlName: 'Custom',
+  displayName: 'Custom (no standard sub-pattern)',
+  versions: [],
+  appliesToControlTypes: ['Group', 'TabPage', '*'],
+  purpose: 'Container that does not follow a Microsoft-defined sub-pattern.',
+  root: [],
+  extraRootChildren: 'any',
+};
+
+export const businessCardThreeFields: SubPatternSpec = {
+  id: 'BusinessCardThreeFields',
+  xmlName: 'BusinessCardThreeFields',
+  displayName: 'Business Card - Three Fields',
+  versions: ['1.0'],
+  appliesToControlTypes: ['Group', 'TabPage'],
+  purpose: 'Compact card layout displaying three identifying fields for a record.',
+  referenceForms: [],
+  root: [],
+  extraRootChildren: 'any',
+};
+
+export const businessCardStatus: SubPatternSpec = {
+  id: 'BusinessCardStatus',
+  xmlName: 'BusinessCardStatus',
+  displayName: 'Business Card - Status',
+  versions: ['1.0'],
+  appliesToControlTypes: ['Group', 'TabPage'],
+  purpose: 'Card layout highlighting a status indicator alongside identifying fields.',
+  referenceForms: [],
+  root: [],
+  extraRootChildren: 'any',
+};
+
+export const businessCardIndicator: SubPatternSpec = {
+  id: 'BusinessCardIndicator',
+  xmlName: 'BusinessCardIndicator',
+  displayName: 'Business Card - Indicator',
+  versions: ['1.0'],
+  appliesToControlTypes: ['Group', 'TabPage'],
+  purpose: 'Card layout with a graphical indicator (e.g. traffic light) alongside fields.',
+  referenceForms: [],
+  root: [],
+  extraRootChildren: 'any',
+};
+
+export const tabPageTabularFields: SubPatternSpec = {
+  id: 'TabPageTabularFields',
+  xmlName: 'TabPageTabularFields',
+  displayName: 'Tab Page - Tabular Fields',
+  versions: ['1.0'],
+  appliesToControlTypes: ['TabPage'],
+  purpose: 'Tab page containing a structured tabular layout of fields (similar to TabularFields but scoped to a tab page).',
+  referenceForms: [],
+  root: [],
+  extraRootChildren: 'any',
+};
+
+export const entityHeader: SubPatternSpec = {
+  id: 'EntityHeader',
+  xmlName: 'EntityHeader',
+  displayName: 'Entity Header',
+  versions: ['1.0'],
+  appliesToControlTypes: ['Group', 'TabPage'],
+  purpose: 'Header area of an entity form showing key identifying fields above the FastTabs.',
+  referenceForms: [],
+  root: [],
+  extraRootChildren: 'any',
+};
+
+export const allFieldsSubPatterns: SubPatternSpec[] = [
+  ...fieldsSubPatterns,
+  customSubPattern,
+  businessCardThreeFields,
+  businessCardStatus,
+  businessCardIndicator,
+  tabPageTabularFields,
+  entityHeader,
 ];

--- a/src/knowledge/formPatterns/catalog/subPatterns/toolbar.ts
+++ b/src/knowledge/formPatterns/catalog/subPatterns/toolbar.ts
@@ -9,7 +9,8 @@ import type { SubPatternSpec } from '../../types.js';
 
 export const toolbarAndList: SubPatternSpec = {
   id: 'ToolbarAndList',
-  xmlName: 'ToolbarAndList',
+  xmlName: 'ToolbarList',
+  xmlAliases: ['ToolbarAndList'],
   displayName: 'Toolbar and List',
   versions: ['1.1', '1.0'],
   appliesToControlTypes: ['Group', 'TabPage'],
@@ -33,7 +34,8 @@ export const toolbarAndList: SubPatternSpec = {
 
 export const toolbarAndFields: SubPatternSpec = {
   id: 'ToolbarAndFields',
-  xmlName: 'ToolbarAndFields',
+  xmlName: 'ToolbarFields',
+  xmlAliases: ['ToolbarAndFields'],
   displayName: 'Toolbar and Fields',
   versions: ['1.1', '1.0'],
   appliesToControlTypes: ['Group', 'TabPage'],
@@ -65,8 +67,8 @@ export const nestedSimpleListDetails: SubPatternSpec = {
 
 export const toolbarAndListDouble: SubPatternSpec = {
   id: 'ToolbarAndListDouble',
-  xmlName: 'ToolbarAndListDouble',
-  xmlAliases: ['ToolbarAndList2', 'ToolbarAndListsDouble'],
+  xmlName: 'ToolbarListDouble',
+  xmlAliases: ['ToolbarAndListDouble', 'ToolbarAndList2', 'ToolbarAndListsDouble'],
   displayName: 'Toolbar and List - Double',
   versions: ['1.0'],
   appliesToControlTypes: ['Group', 'TabPage'],
@@ -78,7 +80,6 @@ export const toolbarAndListDouble: SubPatternSpec = {
     { id: 'SecondList', controlTypes: ['Grid'], occurrence: 'required', extraChildren: 'any' },
   ],
   extraRootChildren: 'any',
-  notes: ['xmlName to be confirmed by mining.'],
 };
 
 export const listPanel: SubPatternSpec = {

--- a/src/knowledge/formPatterns/catalog/topLevel/detailsMaster.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/detailsMaster.ts
@@ -28,7 +28,7 @@ export const detailsMaster: FormPatternSpec = {
   id: 'DetailsMaster',
   xmlName: 'DetailsMaster',
   displayName: 'Details Master',
-  versions: ['1.1', '1.0'],
+  versions: ['1.4', '1.3', '1.1', '1.0'],
   purpose:
     'Displays the details of a complex master entity on FastTabs, with a grid view and a details view ' +
     '(e.g. customers, vendors, products).',
@@ -69,7 +69,7 @@ export const detailsMasterTabs: FormPatternSpec = {
   xmlName: 'DetailsMasterTabs',
   variantOf: 'DetailsMaster',
   displayName: 'Details Master w/ Standard Tabs',
-  versions: ['1.0'],
+  versions: ['1.4', '1.0'],
   purpose:
     'Details Master variant for forms with a large number of FastTabs (>15) grouped into ' +
     'categories using standard tabs.',

--- a/src/knowledge/formPatterns/catalog/topLevel/detailsTransaction.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/detailsTransaction.ts
@@ -30,7 +30,7 @@ export const detailsTransaction: FormPatternSpec = {
   id: 'DetailsTransaction',
   xmlName: 'DetailsTransaction',
   displayName: 'Details Transaction',
-  versions: ['1.1', '1.0'],
+  versions: ['1.4', '1.1', '1.0'],
   purpose:
     'Displays the details of a complex transaction entity and its lines — an order header plus ' +
     'order lines (e.g. sales orders, purchase orders).',

--- a/src/knowledge/formPatterns/catalog/topLevel/dialog.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/dialog.ts
@@ -158,7 +158,7 @@ export const dialogDoubleTabs: FormPatternSpec = {
   xmlName: 'DialogDoubleTabs',
   variantOf: 'Dialog',
   displayName: 'Dialog w/ Double Tabs',
-  versions: ['1.2', '1.1', '1.0'],
+  versions: ['1.3', '1.2', '1.1', '1.0'],
   purpose: 'Modal dialog with two independent tab controls — typically a header group of tabs and a details group.',
   whenToUse: ['Dialog content that requires two separate tab groups at the same level'],
   whenNotToUse: ['Single tab group → Dialog w/ Tabs or Dialog w/ FastTabs'],

--- a/src/knowledge/formPatterns/catalog/topLevel/dialog.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/dialog.ts
@@ -66,7 +66,7 @@ export const dropDialog: FormPatternSpec = {
   xmlName: 'DropDialog',
   variantOf: 'Dialog',
   displayName: 'Drop Dialog',
-  versions: ['1.1', '1.0'],
+  versions: ['1.2', '1.1', '1.0'],
   purpose:
     'Lightweight dialog dropped from a button to gather a small set of inputs (<5 fields) ' +
     'that provide context for an action.',
@@ -84,6 +84,116 @@ export const dropDialog: FormPatternSpec = {
       extraChildren: 'any',
     },
     commitButtons,
+  ],
+  extraRootChildren: 'none',
+};
+
+export const dialogFastTabs: FormPatternSpec = {
+  id: 'DialogFastTabs',
+  xmlName: 'DialogFastTabs',
+  variantOf: 'Dialog',
+  displayName: 'Dialog w/ FastTabs',
+  versions: ['1.2', '1.1', '1.0'],
+  purpose: 'Modal dialog whose content is organized into FastTabs — for dialogs with many fields grouped by topic.',
+  whenToUse: ['Dialog with >5 fields that benefit from FastTab grouping'],
+  whenNotToUse: ['Few flat fields → Dialog - Basic', 'Standard tabs → Dialog w/ Tabs'],
+  referenceForms: [],
+  designProperties: { Style: 'Dialog' },
+  requiresDataSource: 'none',
+  root: [
+    {
+      id: 'FastTabBody',
+      controlTypes: ['Tab'],
+      occurrence: 'required',
+      properties: { Style: 'FastTabs' },
+      extraChildren: 'any',
+    },
+    commitButtons,
+  ],
+  extraRootChildren: 'none',
+};
+
+export const dialogTabs: FormPatternSpec = {
+  id: 'DialogTabs',
+  xmlName: 'DialogTabs',
+  variantOf: 'Dialog',
+  displayName: 'Dialog w/ Tabs',
+  versions: ['1.3', '1.2', '1.1', '1.0'],
+  purpose: 'Modal dialog whose content is organized into standard tabs.',
+  whenToUse: ['Dialog that requires tabbed navigation with standard (non-collapsible) tabs'],
+  whenNotToUse: ['Use FastTabs for most dialogs'],
+  referenceForms: [],
+  designProperties: { Style: 'Dialog' },
+  requiresDataSource: 'none',
+  root: [
+    {
+      id: 'TabBody',
+      controlTypes: ['Tab'],
+      occurrence: 'required',
+      extraChildren: 'any',
+    },
+    commitButtons,
+  ],
+  extraRootChildren: 'none',
+};
+
+export const dialogReadOnly: FormPatternSpec = {
+  id: 'DialogReadOnly',
+  xmlName: 'DialogReadOnly',
+  variantOf: 'Dialog',
+  displayName: 'Dialog - Read Only',
+  versions: ['1.2', '1.1', '1.0'],
+  purpose: 'Read-only modal dialog that presents information without allowing edits — no commit button required.',
+  whenToUse: ['Displaying a summary or details that require user acknowledgment only'],
+  whenNotToUse: ['User needs to enter data → Dialog - Basic'],
+  referenceForms: [],
+  designProperties: { Style: 'Dialog' },
+  requiresDataSource: 'none',
+  root: [dialogBody],
+  extraRootChildren: 'none',
+};
+
+export const dialogDoubleTabs: FormPatternSpec = {
+  id: 'DialogDoubleTabs',
+  xmlName: 'DialogDoubleTabs',
+  variantOf: 'Dialog',
+  displayName: 'Dialog w/ Double Tabs',
+  versions: ['1.2', '1.1', '1.0'],
+  purpose: 'Modal dialog with two independent tab controls — typically a header group of tabs and a details group.',
+  whenToUse: ['Dialog content that requires two separate tab groups at the same level'],
+  whenNotToUse: ['Single tab group → Dialog w/ Tabs or Dialog w/ FastTabs'],
+  referenceForms: [],
+  designProperties: { Style: 'Dialog' },
+  requiresDataSource: 'none',
+  root: [
+    { id: 'FirstTabGroup', controlTypes: ['Tab'], occurrence: 'required', extraChildren: 'any' },
+    { id: 'SecondTabGroup', controlTypes: ['Tab'], occurrence: 'required', extraChildren: 'any' },
+    commitButtons,
+  ],
+  extraRootChildren: 'none',
+};
+
+export const dropDialogReadOnly: FormPatternSpec = {
+  id: 'DropDialogReadOnly',
+  xmlName: 'DropDialogReadOnly',
+  variantOf: 'Dialog',
+  displayName: 'Drop Dialog - Read Only',
+  versions: ['1.2', '1.1', '1.0'],
+  purpose: 'Read-only drop dialog anchored to a button — shows summary info without allowing edits.',
+  whenToUse: ['Read-only preview/summary dropped from a button'],
+  whenNotToUse: ['User needs to enter data → Drop Dialog'],
+  referenceForms: [],
+  designProperties: { Style: 'DropDialog' },
+  requiresDataSource: 'none',
+  root: [
+    {
+      id: 'DialogBody',
+      controlTypes: ['Group'],
+      occurrence: 'required',
+      requiresSubPattern: true,
+      allowedSubPatterns: ['FieldsFieldGroups', 'TabularFields'],
+      extraChildren: 'any',
+    },
   ],
   extraRootChildren: 'none',
 };

--- a/src/knowledge/formPatterns/catalog/topLevel/factBox.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/factBox.ts
@@ -36,7 +36,7 @@ export const factBoxCard: FormPatternSpec = {
   xmlName: 'FormPartFactboxCard',
   xmlAliases: ['FactBoxCard', 'FormPartFactBoxCard'],
   displayName: 'Form Part FactBox Card',
-  versions: ['1.1', '1.0'],
+  versions: ['UX7 1.0', '1.1', '1.0'],
   purpose: 'FactBox showing a set of related fields for a single record (card style).',
   whenToUse: ['A handful of related fields (e.g. customer statistics) beside a parent form'],
   referenceForms: ['CustStatisticsStatistics'],

--- a/src/knowledge/formPatterns/catalog/topLevel/listPage.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/listPage.ts
@@ -10,7 +10,7 @@ export const listPage: FormPatternSpec = {
   id: 'ListPage',
   xmlName: 'ListPage',
   displayName: 'List Page',
-  versions: ['1.1', '1.0'],
+  versions: ['UX7 1.0', '1.1', '1.0'],
   purpose:
     'Read-optimized grid entry point for browsing records and acting on them, typically with ' +
     'FactBoxes in the Parts node and a corresponding Details form.',

--- a/src/knowledge/formPatterns/catalog/topLevel/lookup.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/lookup.ts
@@ -34,3 +34,68 @@ export const lookupBasic: FormPatternSpec = {
     'Use SysTableLookup/selectMode patterns to return the picked value.',
   ],
 };
+
+export const lookupGridOnly: FormPatternSpec = {
+  id: 'LookupGridOnly',
+  xmlName: 'LookupGridOnly',
+  variantOf: 'Lookup',
+  displayName: 'Lookup - Grid Only',
+  versions: ['1.2', '1.1', '1.0'],
+  purpose: 'Simplified lookup with only a grid (no filter bar or extra buttons) — the most common lookup variant.',
+  whenToUse: ['Auto-lookup replacement where no filter bar is needed'],
+  whenNotToUse: ['Filter bar needed → Lookup - Basic'],
+  referenceForms: [],
+  designProperties: { Style: 'Lookup' },
+  requiresDataSource: 'one',
+  root: [mainGrid('required')],
+  extraRootChildren: 'any',
+};
+
+export const lookupTab: FormPatternSpec = {
+  id: 'LookupTab',
+  xmlName: 'LookupTab',
+  variantOf: 'Lookup',
+  displayName: 'Lookup w/ Tabs',
+  versions: ['1.2', '1.1', '1.0'],
+  purpose: 'Lookup with multiple tab pages offering alternative views (e.g. grid view + tree view) for picking a value.',
+  whenToUse: ['Lookup that offers multiple selection modes or views in tabs'],
+  whenNotToUse: ['Single grid view → Lookup - Grid Only'],
+  referenceForms: [],
+  designProperties: { Style: 'Lookup' },
+  requiresDataSource: 'one',
+  root: [
+    filterGroup('optional'),
+    {
+      id: 'LookupTabs',
+      controlTypes: ['Tab'],
+      occurrence: 'required',
+      extraChildren: 'any',
+    },
+  ],
+  extraRootChildren: 'any',
+};
+
+export const lookupPreview: FormPatternSpec = {
+  id: 'LookupPreview',
+  xmlName: 'LookupPreview',
+  variantOf: 'Lookup',
+  displayName: 'Lookup w/ Preview',
+  versions: ['1.2', '1.1', '1.0'],
+  purpose: 'Lookup with a grid on the left and a preview/details pane on the right for the selected record.',
+  whenToUse: ['Lookup where users need to see record details before confirming their selection'],
+  whenNotToUse: ['No preview needed → Lookup - Grid Only'],
+  referenceForms: [],
+  designProperties: { Style: 'Lookup' },
+  requiresDataSource: 'one',
+  root: [
+    filterGroup('optional'),
+    mainGrid('required'),
+    {
+      id: 'PreviewGroup',
+      controlTypes: ['Group'],
+      occurrence: 'required',
+      extraChildren: 'any',
+    },
+  ],
+  extraRootChildren: 'any',
+};

--- a/src/knowledge/formPatterns/catalog/topLevel/simpleDetails.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/simpleDetails.ts
@@ -7,8 +7,8 @@ import type { FormPatternSpec } from '../../types.js';
 
 export const simpleDetailsToolbarFields: FormPatternSpec = {
   id: 'SimpleDetails',
-  xmlName: 'SimpleDetails',
-  xmlAliases: ['SimpleDetailsToolbarFields', 'SimpleDetailsWToolbar'],
+  xmlName: 'SimpleDetails-ToolbarFields',
+  xmlAliases: ['SimpleDetails', 'SimpleDetailsToolbarFields', 'SimpleDetailsWToolbar'],
   displayName: 'Simple Details w/ Toolbar and Fields',
   versions: ['1.1', '1.0'],
   purpose: 'Shows fields for a single base record with an optional toolbar — the default Simple Details variant.',
@@ -43,8 +43,123 @@ export const simpleDetailsToolbarFields: FormPatternSpec = {
   ],
   notes: [
     'Variants (FastTabs / Standard Tabs / Panorama) share the Simple Details class; ' +
-      'the variant is the body container style. Exact xmlNames to be confirmed by mining.',
+      'the variant is the body container style. Mining confirmed: newer forms serialize as ' +
+      'SimpleDetails-FastTabsContainer or SimpleDetails-StandardTabsContainer.',
   ],
 };
 
-export const simpleDetailsPatterns: FormPatternSpec[] = [simpleDetailsToolbarFields];
+export const simpleDetailsFastTabs: FormPatternSpec = {
+  id: 'SimpleDetailsFastTabs',
+  xmlName: 'SimpleDetails-FastTabsContainer',
+  variantOf: 'SimpleDetails',
+  displayName: 'Simple Details w/ FastTabs',
+  versions: ['1.4', '1.1', '1.0'],
+  purpose: 'Shows fields for a single record organized into FastTabs — the most common multi-tab Simple Details variant.',
+  whenToUse: [
+    'Form focused on ONE record with fields grouped into FastTabs (5-15+ fields)',
+    'No grid/list navigation, just a collapsible tab layout',
+  ],
+  whenNotToUse: [
+    'Flat field set without grouping → Simple Details w/ Toolbar and Fields',
+    'Standard (non-collapsible) tabs → Simple Details w/ Standard Tabs',
+  ],
+  referenceForms: ['ProjCategory', 'InventModelGroup'],
+  requiresDataSource: 'one',
+  root: [
+    {
+      id: 'Toolbar',
+      controlTypes: ['ActionPane', 'ActionPaneTab'],
+      occurrence: 'optional',
+      extraChildren: 'any',
+    },
+    {
+      id: 'FastTabs',
+      controlTypes: ['Tab'],
+      occurrence: 'required',
+      properties: { Style: 'FastTabs' },
+      extraChildren: 'any',
+    },
+  ],
+  extraRootChildren: 'any',
+};
+
+export const simpleDetailsStandardTabs: FormPatternSpec = {
+  id: 'SimpleDetailsStandardTabs',
+  xmlName: 'SimpleDetails-StandardTabsContainer',
+  variantOf: 'SimpleDetails',
+  displayName: 'Simple Details w/ Standard Tabs',
+  versions: ['1.5', '1.1', '1.0'],
+  purpose: 'Shows fields for a single record organized into standard (non-collapsible) tab pages.',
+  whenToUse: [
+    'Form focused on ONE record where fields are best shown in standard tabs',
+    'When FastTabs visual style is not appropriate',
+  ],
+  whenNotToUse: [
+    'FastTabs preferred for most modern forms',
+  ],
+  referenceForms: [],
+  requiresDataSource: 'one',
+  root: [
+    {
+      id: 'Toolbar',
+      controlTypes: ['ActionPane', 'ActionPaneTab'],
+      occurrence: 'optional',
+      extraChildren: 'any',
+    },
+    {
+      id: 'StandardTabs',
+      controlTypes: ['Tab'],
+      occurrence: 'required',
+      extraChildren: 'any',
+    },
+  ],
+  extraRootChildren: 'any',
+};
+
+export const simpleDetailsPanorama: FormPatternSpec = {
+  id: 'SimpleDetailsPanorama',
+  xmlName: 'SimpleDetails-Panorama',
+  variantOf: 'SimpleDetails',
+  displayName: 'Simple Details w/ Panorama',
+  versions: ['1.1', '1.0'],
+  purpose: 'Simple Details variant with a panorama-style horizontal scroll layout inside the details body.',
+  whenToUse: ['Single-record form with a panorama layout (rare — workspace-style UX for a detail form)'],
+  whenNotToUse: ['Standard detail forms — prefer FastTabs or Toolbar/Fields variants'],
+  referenceForms: [],
+  requiresDataSource: 'one',
+  root: [
+    {
+      id: 'PanoramaBody',
+      controlTypes: ['Tab'],
+      occurrence: 'required',
+      properties: { Style: 'Panorama' },
+      extraChildren: 'any',
+    },
+  ],
+  extraRootChildren: 'any',
+};
+
+export const simpleDetailsPatterns: FormPatternSpec[] = [
+  simpleDetailsToolbarFields,
+  simpleDetailsFastTabs,
+  simpleDetailsStandardTabs,
+  simpleDetailsPanorama,
+];
+
+/**
+ * Sentinel entry for forms marked as Custom — no standard pattern is enforced.
+ * Prevents FP001 false-positives; not a prescriptive recommendation.
+ */
+export const customPattern: FormPatternSpec = {
+  id: 'Custom',
+  xmlName: 'Custom',
+  displayName: 'Custom (no standard pattern)',
+  versions: [],
+  purpose: 'Indicates the form does not follow a Microsoft-defined pattern. Not for use in new development.',
+  whenToUse: [],
+  whenNotToUse: ['Any new form — select the appropriate Microsoft-defined pattern instead.'],
+  referenceForms: [],
+  root: [],
+  extraRootChildren: 'any',
+  notes: ['Treated as unstructured — the pattern validator does not enforce structure for Custom forms.'],
+};

--- a/src/knowledge/formPatterns/catalog/topLevel/simpleDetails.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/simpleDetails.ts
@@ -10,7 +10,7 @@ export const simpleDetailsToolbarFields: FormPatternSpec = {
   xmlName: 'SimpleDetails-ToolbarFields',
   xmlAliases: ['SimpleDetails', 'SimpleDetailsToolbarFields', 'SimpleDetailsWToolbar'],
   displayName: 'Simple Details w/ Toolbar and Fields',
-  versions: ['1.1', '1.0'],
+  versions: ['1.3', '1.1', '1.0'],
   purpose: 'Shows fields for a single base record with an optional toolbar — the default Simple Details variant.',
   whenToUse: [
     'Form focused on ONE record (no grid/list navigation)',

--- a/src/knowledge/formPatterns/catalog/topLevel/simpleListDetails.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/simpleListDetails.ts
@@ -31,8 +31,9 @@ const detailsPanel: NodeSpec = {
 export const simpleListDetailsListGrid: FormPatternSpec = {
   id: 'SimpleListDetails',
   xmlName: 'SimpleListDetails',
+  xmlAliases: ['SimpleListDetails-Grid'],
   displayName: 'Simple List & Details - List Grid',
-  versions: ['1.3', '1.2', '1.1', '1.0'],
+  versions: ['1.4', '1.3', '1.2', '1.1', '1.0'],
   purpose:
     'Maintains data for entities of medium complexity: a left navigation list (2-3 fields) ' +
     'plus a right details panel. The default Simple List & Details variant.',
@@ -58,5 +59,40 @@ export const simpleListDetailsListGrid: FormPatternSpec = {
   notes: [
     'Tabular Grid and Tree variants share the SimpleListDetails xmlName in metadata — ' +
       'the variant is determined by the list panel content (tabular grid / tree control).',
+    'Mining confirmed: newer forms serialize as SimpleListDetails-Grid; both forms resolve to this entry.',
   ],
 };
+
+export const simpleListDetailsTree: FormPatternSpec = {
+  id: 'SimpleListDetailsTree',
+  xmlName: 'SimpleListDetails-Tree',
+  variantOf: 'SimpleListDetails',
+  displayName: 'Simple List & Details - Tree',
+  versions: ['1.3', '1.2', '1.1', '1.0'],
+  purpose:
+    'Simple List & Details variant where the left navigation panel contains a tree control ' +
+    'instead of a flat grid (for hierarchical entities).',
+  whenToUse: ['Hierarchical entity where records are organized in a tree (e.g. category hierarchies)'],
+  whenNotToUse: ['Flat entity list → Simple List & Details - List Grid'],
+  referenceForms: ['EcoResCategoryHierarchy'],
+  designProperties: { Style: 'SimpleListDetails' },
+  requiresDataSource: 'one',
+  root: [
+    actionPane('required'),
+    {
+      id: 'NavigationList',
+      controlTypes: ['Group'],
+      occurrence: 'required',
+      nameHint: 'TreeContainer',
+      properties: { Style: 'SidePanel' },
+      extraChildren: 'any',
+    },
+    detailsPanel,
+  ],
+  extraRootChildren: 'none',
+};
+
+export const simpleListDetailsPatterns: FormPatternSpec[] = [
+  simpleListDetailsListGrid,
+  simpleListDetailsTree,
+];

--- a/src/knowledge/formPatterns/catalog/topLevel/tableOfContents.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/tableOfContents.ts
@@ -55,3 +55,43 @@ export const tableOfContents: FormPatternSpec = {
     'Override form init() + datasource executeQuery() when sections load related tables.',
   ],
 };
+
+export const advancedSelection: FormPatternSpec = {
+  id: 'AdvancedSelection',
+  xmlName: 'AdvancedSelection',
+  displayName: 'Advanced Selection',
+  versions: ['1.1', '1.0'],
+  purpose:
+    'Multi-select dialog allowing users to choose from a list with optional filtering — the "Add" ' +
+    'dialog pattern used when selecting multiple records (e.g. adding items to a group).',
+  whenToUse: [
+    'Multi-select scenarios where users pick several records from a list before confirming',
+    '"Add/Remove" style selection dialogs',
+  ],
+  whenNotToUse: ['Single-value pick → Lookup patterns'],
+  referenceForms: [],
+  requiresDataSource: 'one',
+  root: [
+    {
+      id: 'FilterGroup',
+      controlTypes: ['Group'],
+      occurrence: 'optional',
+      requiresSubPattern: true,
+      allowedSubPatterns: ['CustomAndQuickFilters', 'CustomFilters'],
+      extraChildren: 'any',
+    },
+    {
+      id: 'SelectionGrid',
+      controlTypes: ['Grid'],
+      occurrence: 'required',
+      extraChildren: 'any',
+    },
+    {
+      id: 'CommitButtonGroup',
+      controlTypes: ['ButtonGroup'],
+      occurrence: 'required',
+      extraChildren: 'any',
+    },
+  ],
+  extraRootChildren: 'none',
+};

--- a/src/knowledge/formPatterns/catalog/topLevel/task.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/task.ts
@@ -10,7 +10,7 @@ export const taskSingle: FormPatternSpec = {
   xmlName: 'TaskSingle',
   xmlAliases: ['Task', 'SimpleTask'],
   displayName: 'Task Single (legacy)',
-  versions: ['1.1', '1.0'],
+  versions: ['1.2', '1.1', '1.0'],
   purpose: 'Legacy AX 2012-style entity form (Overview + General tabs). MIGRATION ONLY — do not use for new forms.',
   whenToUse: ['Migrating an AX 2012 form with Overview/General tabs and a single datasource'],
   whenNotToUse: ['Any NEW form — use Simple List, Simple List & Details, or Details Master instead'],
@@ -21,15 +21,15 @@ export const taskSingle: FormPatternSpec = {
     { id: 'TaskTabs', controlTypes: ['Tab'], occurrence: 'required', extraChildren: 'any' },
   ],
   extraRootChildren: 'any',
-  notes: ['Legacy pattern. xmlName to be confirmed by mining.'],
 };
 
 export const taskDouble: FormPatternSpec = {
   id: 'TaskDouble',
-  xmlName: 'TaskDouble',
+  xmlName: 'TaskParentChild',
+  xmlAliases: ['TaskDouble'],
   variantOf: 'TaskSingle',
-  displayName: 'Task Double (legacy)',
-  versions: ['1.1', '1.0'],
+  displayName: 'Task Double / Parent-Child (legacy)',
+  versions: ['1.2', '1.1', '1.0'],
   purpose: 'Legacy AX 2012-style transaction form (two stacked Overview/General sets, header + lines). MIGRATION ONLY.',
   whenToUse: ['Migrating an AX 2012 header+lines form that does not fit Details Transaction'],
   whenNotToUse: ['Any NEW form — use Details Transaction instead'],
@@ -41,7 +41,6 @@ export const taskDouble: FormPatternSpec = {
     { id: 'LowerTabs', controlTypes: ['Tab', 'Group'], occurrence: 'optional', extraChildren: 'any' },
   ],
   extraRootChildren: 'any',
-  notes: ['Legacy pattern. xmlName to be confirmed by mining.'],
 };
 
 export const taskPatterns: FormPatternSpec[] = [taskSingle, taskDouble];

--- a/src/knowledge/formPatterns/catalog/topLevel/wizard.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/wizard.ts
@@ -9,7 +9,7 @@ export const wizard: FormPatternSpec = {
   id: 'Wizard',
   xmlName: 'Wizard',
   displayName: 'Wizard',
-  versions: ['1.1', '1.0'],
+  versions: ['1.2', '1.1', '1.0'],
   purpose:
     'Displays a sequence of tab pages gathering information in a predetermined order, ' +
     'navigated with Back/Next/Finish buttons (backed by a SysWizard class).',

--- a/src/knowledge/formPatterns/catalog/topLevel/workspace.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/workspace.ts
@@ -13,8 +13,9 @@ import { actionPane } from './common.js';
 
 export const workspacePanorama: FormPatternSpec = {
   id: 'Workspace',
-  xmlName: 'Workspace',
-  displayName: 'Workspace (Panorama)',
+  xmlName: 'TabbedWorkspace',
+  xmlAliases: ['Workspace'],
+  displayName: 'Workspace (Tabbed Panorama)',
   versions: ['1.0'],
   purpose:
     'Activity overview page: a horizontally scrolling panorama with a tile/KPI summary section ' +
@@ -61,7 +62,7 @@ export const formPartSectionList: FormPatternSpec = {
   xmlName: 'FormPartSectionList',
   xmlAliases: ['SectionList', 'WorkspaceSectionList'],
   displayName: 'Form Part Section List',
-  versions: ['1.1', '1.0'],
+  versions: ['1.2', '1.1', '1.0'],
   purpose:
     'A list shown in a workspace section — modeled as a separate form and rendered in the ' +
     'workspace via a Form Part control.',
@@ -77,7 +78,37 @@ export const formPartSectionList: FormPatternSpec = {
     },
   ],
   extraRootChildren: 'any',
-  notes: ['xmlName to be confirmed by mining. Variant "Section List - Double" adds a secondary hidden list.'],
+  notes: ['Variant "Section List - Double" adds a secondary hidden list.'],
+};
+
+export const formPartSectionListDouble: FormPatternSpec = {
+  id: 'FormPartSectionListDouble',
+  xmlName: 'FormPartSectionListDouble',
+  xmlAliases: ['SectionListDouble', 'WorkspaceSectionListDouble'],
+  variantOf: 'FormPartSectionList',
+  displayName: 'Form Part Section List - Double',
+  versions: ['1.2', '1.1', '1.0'],
+  purpose:
+    'A workspace section list with two lists — the primary visible list and a secondary hidden ' +
+    'list that becomes visible on toggle (e.g. "My" vs "All" tasks).',
+  whenToUse: ['Work-queue section that offers two list views the user can switch between'],
+  referenceForms: [],
+  requiresDataSource: 'one',
+  root: [
+    {
+      id: 'PrimaryList',
+      controlTypes: ['Group', 'Grid'],
+      occurrence: 'required',
+      extraChildren: 'any',
+    },
+    {
+      id: 'SecondaryList',
+      controlTypes: ['Group', 'Grid'],
+      occurrence: 'optional',
+      extraChildren: 'any',
+    },
+  ],
+  extraRootChildren: 'any',
 };
 
 export const hubPartChart: FormPatternSpec = {
@@ -94,7 +125,22 @@ export const hubPartChart: FormPatternSpec = {
     { id: 'Chart', controlTypes: ['*'], occurrence: 'required' },
   ],
   extraRootChildren: 'any',
-  notes: ['xmlName to be confirmed by mining.'],
+};
+
+export const hubPartGrid: FormPatternSpec = {
+  id: 'HubPartGrid',
+  xmlName: 'HubPartGrid',
+  xmlAliases: ['SectionGrid', 'WorkspaceSectionGrid'],
+  displayName: 'Hub Part Grid',
+  versions: ['1.0'],
+  purpose: 'A grid shown in a workspace section via a Form Part control.',
+  whenToUse: ['Grid/list section of an Operational Workspace rendered as a Form Part'],
+  referenceForms: [],
+  requiresDataSource: 'one',
+  root: [
+    { id: 'Grid', controlTypes: ['Grid'], occurrence: 'required', extraChildren: 'any' },
+  ],
+  extraRootChildren: 'any',
 };
 
 export const workspaceOperational: FormPatternSpec = {
@@ -119,5 +165,4 @@ export const workspaceOperational: FormPatternSpec = {
     },
   ],
   extraRootChildren: 'any',
-  notes: ['xmlName/versions to be confirmed by mining (Phase 3 cross-check).'],
 };

--- a/src/knowledge/formPatterns/crossCheck.ts
+++ b/src/knowledge/formPatterns/crossCheck.ts
@@ -104,32 +104,32 @@ export function crossCheckPatternCatalog(db: ReadDbLike): CrossCheckReport | nul
 
 export function formatCrossCheckReport(report: CrossCheckReport): string {
   const lines: string[] = [];
-  lines.push(`🧭 Form pattern catalog cross-check (${report.minedFormCount} patterned forms mined):`);
+  lines.push(`Form pattern catalog cross-check (${report.minedFormCount} patterned forms mined):`);
 
   if (report.catalogGaps.length === 0 && report.subPatternGaps.length === 0 && report.versionDrift.length === 0) {
-    lines.push('   ✅ All mined patterns and versions are covered by the catalog.');
+    lines.push('   OK  All mined patterns and versions are covered by the catalog.');
   }
   if (report.catalogGaps.length > 0) {
-    lines.push(`   ⚠️ Patterns missing from the catalog (top ${Math.min(10, report.catalogGaps.length)}):`);
+    lines.push(`   [!] Patterns missing from the catalog (top ${Math.min(10, report.catalogGaps.length)}):`);
     for (const gap of report.catalogGaps.slice(0, 10)) {
       lines.push(`      - ${gap.pattern} (${gap.forms} forms)`);
     }
   }
   if (report.subPatternGaps.length > 0) {
-    lines.push(`   ⚠️ Sub-patterns missing from the catalog (top ${Math.min(10, report.subPatternGaps.length)}):`);
+    lines.push(`   [!] Sub-patterns missing from the catalog (top ${Math.min(10, report.subPatternGaps.length)}):`);
     for (const gap of report.subPatternGaps.slice(0, 10)) {
       lines.push(`      - ${gap.pattern} (${gap.containers} containers)`);
     }
   }
   if (report.versionDrift.length > 0) {
-    lines.push('   ⚠️ Version drift (mined version not in catalog — update versions[] after verifying):');
+    lines.push('   [!] Version drift (mined version not in catalog -- update versions[] after verifying):');
     for (const drift of report.versionDrift.slice(0, 10)) {
       lines.push(`      - ${drift.pattern} v${drift.version} (${drift.forms} forms)`);
     }
   }
   if (report.unusedCatalogEntries.length > 0) {
     lines.push(
-      `   ℹ️ Catalog entries with zero mined usage (possible xmlName mismatch or unused area): ` +
+      `   [i] Catalog entries with zero mined usage (possible xmlName mismatch or unused area): ` +
       report.unusedCatalogEntries.join(', '),
     );
   }

--- a/src/knowledge/formPatterns/index.ts
+++ b/src/knowledge/formPatterns/index.ts
@@ -13,21 +13,23 @@ import type {
 } from './types.js';
 
 import { simpleList } from './catalog/topLevel/simpleList.js';
-import { simpleListDetailsListGrid } from './catalog/topLevel/simpleListDetails.js';
+import { simpleListDetailsListGrid, simpleListDetailsTree } from './catalog/topLevel/simpleListDetails.js';
 import { detailsMaster, detailsMasterTabs } from './catalog/topLevel/detailsMaster.js';
 import { detailsTransaction } from './catalog/topLevel/detailsTransaction.js';
-import { dialogBasic, dropDialog } from './catalog/topLevel/dialog.js';
-import { tableOfContents } from './catalog/topLevel/tableOfContents.js';
-import { lookupBasic } from './catalog/topLevel/lookup.js';
+import { dialogBasic, dropDialog, dialogFastTabs, dialogTabs, dialogReadOnly, dialogDoubleTabs, dropDialogReadOnly } from './catalog/topLevel/dialog.js';
+import { tableOfContents, advancedSelection } from './catalog/topLevel/tableOfContents.js';
+import { lookupBasic, lookupGridOnly, lookupTab, lookupPreview } from './catalog/topLevel/lookup.js';
 import { listPage } from './catalog/topLevel/listPage.js';
 import {
   workspacePanorama,
   workspaceOperational,
   formPartSectionList,
+  formPartSectionListDouble,
   hubPartChart,
+  hubPartGrid,
 } from './catalog/topLevel/workspace.js';
 import { factBoxPatterns } from './catalog/topLevel/factBox.js';
-import { simpleDetailsPatterns } from './catalog/topLevel/simpleDetails.js';
+import { simpleDetailsPatterns, customPattern } from './catalog/topLevel/simpleDetails.js';
 import { taskPatterns } from './catalog/topLevel/task.js';
 import { wizard } from './catalog/topLevel/wizard.js';
 
@@ -43,20 +45,33 @@ export const FORM_PATTERN_CATALOG: FormPatternCatalog = {
   patterns: [
     simpleList,
     simpleListDetailsListGrid,
+    simpleListDetailsTree,
     detailsMaster,
     detailsMasterTabs,
     detailsTransaction,
     dialogBasic,
     dropDialog,
+    dialogFastTabs,
+    dialogTabs,
+    dialogReadOnly,
+    dialogDoubleTabs,
+    dropDialogReadOnly,
     tableOfContents,
+    advancedSelection,
     lookupBasic,
+    lookupGridOnly,
+    lookupTab,
+    lookupPreview,
     listPage,
     workspacePanorama,
     workspaceOperational,
     formPartSectionList,
+    formPartSectionListDouble,
     hubPartChart,
+    hubPartGrid,
     ...factBoxPatterns,
     ...simpleDetailsPatterns,
+    customPattern,
     ...taskPatterns,
     wizard,
   ],

--- a/src/knowledge/formPatterns/index.ts
+++ b/src/knowledge/formPatterns/index.ts
@@ -34,7 +34,7 @@ import { taskPatterns } from './catalog/topLevel/task.js';
 import { wizard } from './catalog/topLevel/wizard.js';
 
 import { customFilterSubPatterns } from './catalog/subPatterns/customFilters.js';
-import { fieldsSubPatterns } from './catalog/subPatterns/fields.js';
+import { allFieldsSubPatterns } from './catalog/subPatterns/fields.js';
 import { panelSubPatterns } from './catalog/subPatterns/panels.js';
 import { toolbarSubPatterns } from './catalog/subPatterns/toolbar.js';
 import { workspaceSectionSubPatterns } from './catalog/subPatterns/workspaceSections.js';
@@ -77,7 +77,7 @@ export const FORM_PATTERN_CATALOG: FormPatternCatalog = {
   ],
   subPatterns: [
     ...customFilterSubPatterns,
-    ...fieldsSubPatterns,
+    ...allFieldsSubPatterns,
     ...panelSubPatterns,
     ...toolbarSubPatterns,
     ...workspaceSectionSubPatterns,

--- a/src/metadata/labelParser.ts
+++ b/src/metadata/labelParser.ts
@@ -84,7 +84,6 @@ export function parseLabelFile(
  */
 export async function discoverLabelFiles(
   modelDir: string,  // e.g. K:\AosService\PackagesLocalDirectory\MyPackage\MyModel
-  verbose: boolean = false,
 ): Promise<Array<{ labelFileId: string; language: string; filePath: string }>> {
   const results: Array<{ labelFileId: string; language: string; filePath: string }> = [];
   
@@ -110,31 +109,7 @@ export async function discoverLabelFiles(
   let locales: string[];
   try {
     locales = await fs.readdir(axLabelDir);
-  } catch (err) {
-    if (verbose) {
-      // Check if parent AxLabelFile directory exists (try both cases)
-      const axLabelFileDirOriginal = path.join(modelDir, 'AxLabelFile');
-      const axLabelFileDirLower = path.join(modelDir, 'axlabelfile');
-      const axLabelExists = fsSync.existsSync(axLabelFileDirOriginal) || fsSync.existsSync(axLabelFileDirLower);
-      
-      if (!axLabelExists) {
-        console.log(`      ℹ️  No AxLabelFile/axlabelfile directory in ${modelDir}`);
-        
-        // Debug: show what directories actually exist
-        try {
-          const actualDirs = fsSync.readdirSync(modelDir).filter(n => {
-            const stat = fsSync.statSync(path.join(modelDir, n));
-            return stat.isDirectory();
-          }).slice(0, 5);
-          if (actualDirs.length > 0) {
-            console.log(`         Available dirs: ${actualDirs.join(', ')}`);
-          }
-        } catch { /* ignore */ }
-      } else {
-        const whichCase = fsSync.existsSync(axLabelFileDirOriginal) ? 'AxLabelFile' : 'axlabelfile';
-        console.log(`      ℹ️  Found ${whichCase} but no LabelResources subdirectory in ${modelDir}`);
-      }
-    }
+  } catch {
     return results; // No AxLabelFile folder
   }
 
@@ -198,9 +173,9 @@ export async function indexModelLabels(
   symbolIndex: XppSymbolIndex,
   modelDir: string,
   model: string,
-  opts?: { skipFtsRebuild?: boolean; verbose?: boolean },
+  opts?: { skipFtsRebuild?: boolean },
 ): Promise<number> {
-  const labelFiles = await discoverLabelFiles(modelDir, opts?.verbose);
+  const labelFiles = await discoverLabelFiles(modelDir);
   if (labelFiles.length === 0) return 0;
 
   const allEntries: Parameters<XppSymbolIndex['bulkAddLabels']>[0] = [];
@@ -254,7 +229,6 @@ export async function indexAllLabels(
     // junction points, which readdirSync reports as isSymbolicLink()=true
     // rather than isDirectory()=true.
     models = entries.filter(e => e.isDirectory() || e.isSymbolicLink()).map(e => e.name);
-    console.log(`   🔍 Found ${models.length} potential model folders in ${packagesPath}`);
   } catch {
     console.error(`[LabelParser] Cannot read packages path: ${packagesPath}`);
     return { totalLabels, modelsIndexed };
@@ -263,8 +237,6 @@ export async function indexAllLabels(
   let skippedByFilter = 0;
   let skippedMissingDir = 0;
   let skippedNoLabels = 0;
-  const verboseDebug = process.env.DEBUG_LABELS === 'true';
-  let processedModels = 0;
 
   for (const packageOrModel of models) {
     if (modelFilter && !modelFilter(packageOrModel)) {
@@ -314,36 +286,13 @@ export async function indexAllLabels(
 
     // Process each model directory found within this package
     for (const { modelDir, modelName } of modelDirs) {
-      processedModels++;
-      // Enable verbose for first 3 models or when DEBUG_LABELS=true
-      const enableVerbose = verboseDebug || processedModels <= 3;
-
-      if (enableVerbose && processedModels === 1) {
-        const isNested = modelDirs.length > 1 || modelName !== packageOrModel;
-        console.log(`   📁 Using ${isNested ? 'nested' : 'flat'} structure`);
-        // Show which case was detected
-        const axLabelOriginal = path.join(modelDir, 'AxLabelFile');
-        const axLabelLower = path.join(modelDir, 'axlabelfile');
-        if (fsSync.existsSync(axLabelOriginal)) {
-          console.log(`   📁 Case: Windows (AxLabelFile with capital letters)`);
-        } else if (fsSync.existsSync(axLabelLower)) {
-          console.log(`   📁 Case: Linux (axlabelfile lowercase) - using case-insensitive matching`);
-        }
-      }
-
       // Skip per-model FTS rebuild; do a single rebuild after all models are indexed
-      const count = await indexModelLabels(symbolIndex, modelDir, modelName, { skipFtsRebuild: true, verbose: enableVerbose });
+      const count = await indexModelLabels(symbolIndex, modelDir, modelName, { skipFtsRebuild: true });
       if (count > 0) {
         totalLabels += count;
         modelsIndexed++;
-        if (enableVerbose) {
-          console.log(`      ✓ ${modelName}: ${count} labels`);
-        }
       } else {
         skippedNoLabels++;
-        if (enableVerbose) {
-          console.log(`      ✗ ${modelName}: no labels found`);
-        }
       }
     }
   }


### PR DESCRIPTION
This pull request expands and refines the catalog of form and sub-pattern specifications, adding new variants, clarifying naming conventions, and updating version support for existing patterns. The changes improve the accuracy and completeness of the form pattern definitions, supporting better pattern recognition and validation.

**Key changes include:**

### New Pattern and Sub-pattern Additions

* Added multiple new dialog variants: `DialogFastTabs`, `DialogTabs`, `DialogReadOnly`, `DialogDoubleTabs`, and `DropDialogReadOnly`, each supporting different dialog layouts and use cases.
* Introduced new lookup variants: `LookupGridOnly`, `LookupTab`, and `LookupPreview`, covering grid-only, tabbed, and preview-enabled lookup scenarios.
* Added new Simple Details variants: `SimpleDetailsFastTabs`, `SimpleDetailsStandardTabs`, and `SimpleDetailsPanorama`, providing support for FastTabs, standard tabs, and panorama layouts.
* Introduced additional sub-patterns for fields: `customSubPattern`, `businessCardThreeFields`, `businessCardStatus`, `businessCardIndicator`, `tabPageTabularFields`, and `entityHeader` to cover more layout scenarios and non-standard containers.
* Added a sentinel `customPattern` for forms that do not follow a Microsoft-defined pattern, to suppress false positives in validation.

### Naming and Aliases Improvements

* Updated `xmlName` and `xmlAliases` for several patterns and sub-patterns to reflect actual serialization and support pattern mining:
  * Changed `horizontalFieldsButtonGroup` to use `HorizontalFieldsButtonsGroup` as `xmlName` and expanded `xmlAliases`.
  * Adjusted `toolbarAndList`, `toolbarAndFields`, and `toolbarAndListDouble` to use `ToolbarList`, `ToolbarFields`, and `ToolbarListDouble` as `xmlName`, with appropriate aliases. [[1]](diffhunk://#diff-8300ad8692d981714a52c68af9e882003afc6594ced1e018bb6be2c5c76e3b02L12-R13) [[2]](diffhunk://#diff-8300ad8692d981714a52c68af9e882003afc6594ced1e018bb6be2c5c76e3b02L36-R38) [[3]](diffhunk://#diff-8300ad8692d981714a52c68af9e882003afc6594ced1e018bb6be2c5c76e3b02L68-R71)
  * Updated `simpleDetailsToolbarFields` to use `SimpleDetails-ToolbarFields` as `xmlName` and added more aliases.
  * Added `xmlAliases` for `simpleListDetailsListGrid`.

### Version and Reference Updates

* Expanded the `versions` arrays for many patterns to reflect additional supported or discovered versions (e.g., `DetailsMaster`, `DetailsMasterTabs`, `DetailsTransaction`, `DropDialog`, `factBoxCard`, `listPage`, `simpleListDetailsListGrid`). [[1]](diffhunk://#diff-f26849628869a425857e69bc527c34c1b82552ec5d668c5ea031724537a12f4eL31-R31) [[2]](diffhunk://#diff-f26849628869a425857e69bc527c34c1b82552ec5d668c5ea031724537a12f4eL72-R72) [[3]](diffhunk://#diff-17b446970fc77f95b52c5c7e5ffe556baaa4ed476599cc5c7158b5cc0f0fca7eL33-R33) [[4]](diffhunk://#diff-6926b29e7f96a43c0433d54f8a04ccb34fed22f8f70264542e547ed85c0e7043L69-R69) [[5]](diffhunk://#diff-211cf274a534240386b95d23eb73b29ae8fa9168dff765d37b0bc59973b3f230L39-R39) [[6]](diffhunk://#diff-435fc6da22f4bb8047f9d527a39ce29ab9d7f1693afcecc61cdbca371420b8d6L13-R13) [[7]](diffhunk://#diff-e3acbce545acf730ea7844d0cab563ec8a968c8eabc29e8bbf6957f2d233aeabR34-R36)
* Updated notes and documentation to clarify when to use specific variants and to reflect mining confirmations for naming and structure.

These changes enhance the pattern catalog's flexibility, accuracy, and maintainability, supporting a wider range of real-world form designs.