### PR TITLE
Regenerate runtime metadata after xppc build so new classes deploy without VS

### DIFF
--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -8,6 +8,7 @@ import crypto from 'crypto';
 import { getConfigManager } from '../utils/configManager.js';
 import { forceReleaseLock } from '../utils/operationLocks.js';
 import { lookupErrorFix } from './d365foErrorHelp.js';
+import { generateRuntimeMetadata } from './generateMetadata.js';
 
 const execFileAsync = util.promisify(execFile);
 
@@ -569,6 +570,26 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
         await writeBuildState(errState, customPackagesPath).catch(() => {});
       });
       return;
+    }
+
+    // All models built — regenerate .md runtime metadata manifests from XML source.
+    // xppc produces the compiled .netmodule but does NOT update the binary .md
+    // manifests that the AOS uses to resolve class names at runtime. Without this
+    // step, newly added classes are invisible to D365 after deployment even though
+    // the assembly compiled successfully.
+    const metaResult = await generateRuntimeMetadata(
+      microsoftPackagesPath,
+      customPackagesPath,
+      liveState.targetModel,
+    );
+    if (metaResult.skipped) {
+      await buildLog('WARN', `Runtime metadata regeneration skipped: ${metaResult.message}`);
+    } else if (metaResult.success) {
+      await buildLog('INFO', `Runtime metadata regenerated: ${metaResult.message}`);
+      await appendFile(state.logFile, `\n✅ Runtime metadata (.md) regenerated for ${liveState.targetModel}\n`, 'utf-8').catch(() => {});
+    } else {
+      await buildLog('WARN', `Runtime metadata regeneration failed (build still succeeded): ${metaResult.message}`);
+      await appendFile(state.logFile, `\n⚠️ Runtime metadata (.md) regeneration failed — VS build required for deployment of new classes:\n${metaResult.message}\n`, 'utf-8').catch(() => {});
     }
 
     // All models built — finalise as succeeded

--- a/src/tools/generateMetadata.ts
+++ b/src/tools/generateMetadata.ts
@@ -1,0 +1,275 @@
+/**
+ * generateMetadata.ts
+ *
+ * Regenerates D365FO runtime metadata manifests (.md files) from XML source
+ * after an xppc compile, without requiring a full VS build.
+ *
+ * Background: xppc.exe compiles X++ source into .netmodule files but does NOT
+ * update the binary .md manifests that the AOS uses to resolve class names at
+ * runtime. VS BuildTask does this as a post-compile step using the
+ * MetadataProviderFactory + RuntimeMetadataWriter APIs from
+ * Microsoft.Dynamics.AX.Metadata.Storage.dll.
+ *
+ * This module replicates that step by:
+ *  1. Compiling a small .NET Framework 4.x helper (GenerateMetadata.exe) on
+ *     first use, referencing the DLLs from the D365FO framework directory.
+ *  2. Running the compiled helper after each successful xppc build.
+ *
+ * The helper exe is cached in the framework `bin` directory (so .NET resolves
+ * the referenced Dynamics DLLs via the application base) under a name that
+ * embeds a short hash of its C# source. It therefore survives MCP server
+ * restarts and is recompiled automatically both when D365FO is upgraded (new
+ * framework directory) and when the helper source below changes (new hash).
+ */
+
+import { execFile } from 'child_process';
+import util from 'util';
+import path from 'path';
+import crypto from 'crypto';
+import { access, writeFile, unlink, cp } from 'fs/promises';
+
+const execFileAsync = util.promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// C# source for the helper — compiled on first use
+// ---------------------------------------------------------------------------
+
+const CS_SOURCE = `
+using System;
+using System.IO;
+using Microsoft.Dynamics.AX.Metadata.Storage;
+using Microsoft.Dynamics.AX.Metadata.Storage.Runtime;
+
+class GenerateMetadata
+{
+    static int Main(string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("Usage: GenerateMetadata.exe <metadataDir> <modelName> <outputDir>");
+            return 1;
+        }
+
+        string metadataDir = args[0];
+        string modelName   = args[1];
+        string outputDir   = args[2];
+
+        try
+        {
+            var factory  = new MetadataProviderFactory();
+            var provider = factory.CreateDiskProvider(metadataDir);
+            var version  = new Version(1, 0, 0, 0);
+            RuntimeMetadataWriter.WriteAll(provider, modelName, outputDir, version, false, null);
+            Console.WriteLine("OK: runtime metadata written for " + modelName);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("GenerateMetadata error: " + ex.Message);
+            for (var inner = ex.InnerException; inner != null; inner = inner.InnerException)
+                Console.Error.WriteLine("  -> " + inner.Message);
+            return 1;
+        }
+    }
+}
+`.trim();
+
+// Short hash of the helper source. Embedded in the cached exe name so that any
+// edit to CS_SOURCE produces a new file name and the stale exe is never reused
+// (editing the C# without this would silently keep running the old binary).
+const HELPER_VERSION = crypto.createHash('sha256').update(CS_SOURCE).digest('hex').slice(0, 8);
+
+// ---------------------------------------------------------------------------
+// csc.exe locations (.NET Framework 4.x, built into Windows)
+// ---------------------------------------------------------------------------
+
+const CSC_CANDIDATES = [
+  'C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319\\csc.exe',
+  'C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\csc.exe',
+];
+
+async function findCscExe(): Promise<string | null> {
+  for (const c of CSC_CANDIDATES) {
+    try { await access(c); return c; } catch { /* next */ }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Compile helper (once per framework version)
+// ---------------------------------------------------------------------------
+
+function exeCachePath(frameworkBinDir: string): string {
+  // Place the exe in the framework bin directory itself so .NET finds the
+  // referenced Dynamics DLLs via the application base directory at runtime.
+  // The source-hash suffix forces a rebuild whenever CS_SOURCE changes.
+  return path.join(frameworkBinDir, `D365McpGenerateMetadata.${HELPER_VERSION}.exe`);
+}
+
+async function compileHelper(
+  cscExe: string,
+  frameworkBinDir: string,
+  exePath: string,
+): Promise<void> {
+  const csFile = exePath.replace(/\.exe$/, '.cs');
+
+  await writeFile(csFile, CS_SOURCE, 'utf-8');
+
+  const refs = [
+    'Microsoft.Dynamics.AX.Metadata.Core.dll',
+    'Microsoft.Dynamics.AX.Metadata.dll',
+    'Microsoft.Dynamics.AX.Metadata.Storage.dll',
+  ].map(dll => `/reference:${path.join(frameworkBinDir, dll)}`);
+
+  try {
+    await execFileAsync(cscExe, [
+      '/nologo',
+      `/out:${exePath}`,
+      '/target:exe',
+      '/platform:x64',
+      ...refs,
+      csFile,
+    ], { timeout: 30_000 });
+  } finally {
+    await unlink(csFile).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Compiler-metadata sync
+//
+// xppc reads the X++ source from the -metadata root (the source repo) but
+// writes the compiled model's X++ compiler metadata (the XppMetadata tree:
+// class signatures, RunOn, visibility, method parameters, ...) to the
+// -compilermetadata root (the framework PackagesLocalDirectory). The two roots
+// differ in an MCP-only build.
+//
+// RuntimeMetadataWriter's disk provider reads BOTH source and compiler metadata
+// relative to a single root. Reading from the source root, it finds source for
+// a newly added class but no co-located compiler metadata, so it reports
+// IsCompilerMetadataSet = false and throws "Compiler metadata not set before
+// serialization to runtime format".
+//
+// Fix: after the compile, overlay the freshly written XppMetadata from the
+// -compilermetadata root onto the source metadata root so every source class
+// has its compiler metadata alongside it. Overlay (not mirror) — orphan
+// compiler metadata with no matching source is harmless because the provider
+// enumerates classes from the source XML.
+// ---------------------------------------------------------------------------
+
+async function syncCompilerMetadata(
+  compilerMetadataRoot: string,
+  metadataRoot: string,
+  modelName: string,
+): Promise<string> {
+  const src  = path.join(compilerMetadataRoot, modelName, 'XppMetadata');
+  const dest = path.join(metadataRoot, modelName, 'XppMetadata');
+
+  // Same root (e.g. CHE where -metadata == -compilermetadata) — nothing to do.
+  if (path.resolve(src).toLowerCase() === path.resolve(dest).toLowerCase()) {
+    return 'compiler metadata already co-located with source';
+  }
+
+  try {
+    await access(src);
+  } catch {
+    return `no compiler metadata to sync (not found at ${src})`;
+  }
+
+  await cp(src, dest, { recursive: true, force: true });
+  return `compiler metadata synced from ${src}`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface GenerateMetadataResult {
+  skipped: boolean;
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Regenerate the .md runtime metadata manifests for `modelName` from its XML
+ * source. Called after a successful xppc build.
+ *
+ * @param microsoftPackagesPath  Framework directory (FrameworkDirectory / PackagesLocalDirectory for CHE)
+ * @param customPackagesPath     Model store root — the directory that contains the model folder
+ * @param modelName              Model to regenerate manifests for
+ */
+export async function generateRuntimeMetadata(
+  microsoftPackagesPath: string,
+  customPackagesPath: string,
+  modelName: string,
+): Promise<GenerateMetadataResult> {
+  const frameworkBinDir = path.join(microsoftPackagesPath, 'bin');
+  const outputDir       = path.join(customPackagesPath, modelName, 'bin');
+
+  // Verify at least one of the required DLLs exists before attempting anything
+  const storageDll = path.join(frameworkBinDir, 'Microsoft.Dynamics.AX.Metadata.Storage.dll');
+  try {
+    await access(storageDll);
+  } catch {
+    return {
+      skipped: true,
+      success: false,
+      message: `Skipped metadata regeneration — Microsoft.Dynamics.AX.Metadata.Storage.dll not found at ${frameworkBinDir}`,
+    };
+  }
+
+  const cscExe = await findCscExe();
+  if (!cscExe) {
+    return {
+      skipped: true,
+      success: false,
+      message: 'Skipped metadata regeneration — csc.exe not found (expected at C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319\\csc.exe)',
+    };
+  }
+
+  const exePath = exeCachePath(frameworkBinDir);
+
+  // Compile helper if not yet cached for this framework version
+  try {
+    await access(exePath);
+  } catch {
+    try {
+      await compileHelper(cscExe, frameworkBinDir, exePath);
+    } catch (compileErr: any) {
+      return {
+        skipped: false,
+        success: false,
+        message: `Failed to compile GenerateMetadata helper: ${compileErr.message}`,
+      };
+    }
+  }
+
+  // Co-locate the freshly compiled compiler metadata with the source before the
+  // runtime writer reads it (see syncCompilerMetadata for why this is required
+  // for newly added classes in an MCP-only build).
+  let syncMessage: string;
+  try {
+    syncMessage = await syncCompilerMetadata(microsoftPackagesPath, customPackagesPath, modelName);
+  } catch (syncErr: any) {
+    return {
+      skipped: false,
+      success: false,
+      message: `Failed to sync compiler metadata: ${syncErr.message}`,
+    };
+  }
+
+  // Run the helper
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      exePath,
+      [customPackagesPath, modelName, outputDir],
+      { timeout: 60_000 },
+    );
+    const output = [stdout, stderr].filter(Boolean).join('\n').trim();
+    const message = [syncMessage, output].filter(Boolean).join(' | ') || 'Runtime metadata regenerated';
+    return { skipped: false, success: true, message };
+  } catch (runErr: any) {
+    const output = [runErr.stdout, runErr.stderr, runErr.message].filter(Boolean).join('\n');
+    return { skipped: false, success: false, message: `GenerateMetadata.exe failed: ${output}` };
+  }
+}

--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -68,8 +68,11 @@ export const runBpCheckTool = async (params: any, _context: any) => {
 
     // metadataPath: where X++ source XML lives (custom model metadata)
     const metadataPath = customPackagesPath || packagesRoot;
-    // packagesRootPath: where compiled binaries live (framework packages)
-    const packagesRootPath = microsoftPackagesPath || packagesRoot;
+    // packagesRootPath (-compilerMetadata): where compiled binaries live.
+    // Must be the CUSTOM model packages path, not the framework dir —
+    // compiled artifacts are written to the custom path, so xppbp must
+    // look there or it emits CompilerMetadataMissing for newly-added classes.
+    const packagesRootPath = customPackagesPath || packagesRoot;
 
     /**
      * xppbp.exe CLI flag styles observed across versions:


### PR DESCRIPTION
Summary
An MCP-only xppc build produces the compiled .netmodule but does not update the binary .md runtime manifests the AOS uses to resolve class names — so newly added classes were invisible after deployment or deployable package until a full Visual Studio build was run manually.

xppc.exe compiles X++ to .netmodule but does not regenerate the .md manifests; in a normal build that step is performed by the Visual Studio MSBuild BuildTask, which isn't available in a headless/MCP build. Rather than reimplement manifest generation, this change invokes the same Microsoft API the BuildTask uses — RuntimeMetadataWriter.WriteAll in Microsoft.Dynamics.AX.Metadata.Storage.dll — directly, so the output matches what VS would produce.

Changes
generateMetadata.ts — after a successful compile, runs a cached .NET helper (RuntimeMetadataWriter.WriteAll) to rebuild the .md manifests from XML source.

xppc writes a compiled class's X++ compiler metadata to the -compilermetadata root, while the writer reads it relative to the -metadata (source) root; for a newly added class these differ, so the writer threw "Compiler metadata not set before serialization to runtime format." Fixed by overlaying the freshly written XppMetadata from the compiler-metadata root onto the source root before generation (overlay, not mirror — orphan metadata with no source is inert). 

The helper exe is cached under a name hashed from its C# source, so it rebuilds automatically when the helper source or framework version changes.

buildProject.ts — invokes runtime-metadata regeneration after the build queue completes; a regeneration failure is logged but does not fail the build.

runBpCheck.ts — points -compilerMetadata at the custom packages path so xppbp finds compiler metadata for newly added classes instead of reporting CompilerMetadataMissing.

Testing
Verified end-to-end on a live D365FO 10.0.2527 UDE environment, reproducing the original failure first and confirming the fix resolves it.

Original symptom

Added a brand-new X++ class (never built in Visual Studio) to a custom model.

Ran an MCP-only full build — xppc reported Errors: 0, Warnings: 0 — and deployed to the target environment.

The change was not actually delivered: the new class was absent from the running AOS despite the clean build and deploy.
Cause: the binary .md runtime manifests (which the AOS uses to resolve class names) were out of sync — xppc produces the .netmodule but never updates them. 

Added a component (generateMetadata.ts) to regenerate the .md files from XML source after each build, replicating the VS BuildTask post-compile step. (xppc alone does not do this, and the VS BuildTask that does is not usable headlessly — hence calling the underlying Microsoft API directly.)

Secondary failure surfaced by that component

With .md regeneration in place, RuntimeMetadataWriter.WriteAll then threw "Compiler metadata not set before serialization to runtime format" for the new class.

Root cause: xppc writes a new class's compiler metadata (XppMetadata\…\<Class>.xml) to the -compilermetadata root, while the writer reads it relative to the -metadata (source) root. The new class had source but no co-located compiler metadata → IsCompilerMetadataSet = false.

Fix: overlay the freshly written XppMetadata from the compiler-metadata root onto the source root before regeneration.

Fix verification (isolated)

Copied the missing XppMetadata entry into the source root and re-ran the helper → succeeded; the regenerated *_AxClass.md grew to include the new class. Diagnostics showed Already set: 48, Fixed: 0 — all classes carry compiler metadata.

Fix verification (real build path)

Removed the class, added a different new class with a unique marker, and ran a clean MCP-only full build through build_d365fo_project (patched server loaded).

Build reported ✅ Runtime metadata (.md) regenerated; the overlay sync ran automatically, the new class appeared in the regenerated *_AxClass.md, and the removed class was correctly absent.

Deployment confirmation

Deployed to UDE with no Visual Studio build and ran the new class — its marker output appeared in the AOS, confirming the class is fully resolvable at runtime from an MCP-only build.

Overlay-vs-mirror check

Confirmed orphan compiler metadata (an XppMetadata entry with no matching source class) is inert — the disk provider enumerates classes from source XML, so leftover entries never appear in the manifest. This is why the sync overlays rather than wiping the destination first.

Additional fix — runBpCheck.ts (related, independently useful)
BP check no longer emits CompilerMetadataMissing for newly-added classes once -compilerMetadata points at the custom packages path. Same underlying theme as the main fix (compiler metadata for new classes living under the custom path rather than the framework path), but it affects the BP-check tool rather than the build/metadata-regeneration path.

Scope / not covered
- This change addresses the runtime .md metadata manifests for AOT elements (the cause of new classes being invisible after an MCP-only build). Label compilation and SSRS report deployment are separate build pipelines that this change does not modify and were not verified here. Whether MCP-only builds correctly deliver new labels and new reports without a VS build is a known follow-up for me to test separately at a later time. 
- CHE was not used for testing
- Only Class objects were used in the testing, but should not be limited to. 