### PR TITLE
fix(run_bp_check): restructure correct UDE metadata path separation with legacy fallbacks and CHE

### DIFF
--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -45,13 +45,23 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     // In UDE the custom packages path (ModelStoreFolder) is the metadata root,
     // while the framework packages path (FrameworkDirectory) is the binaries root.
     // For traditional environments both roles are served by packagesRoot.
-    const microsoftPackagesPath = await configManager.getMicrosoftPackagesPath();
-    const customPackagesPath = await configManager.getCustomPackagesPath();
+    // Priority 1: XPP config (UDE) — authoritative source for all paths (same as build_d365fo_project)
+    let customPackagesPath: string | null = null;
+    let microsoftPackagesPath: string | null = null;
+    const xppConfig = await configManager.getActiveXppConfig();
+    if (xppConfig) {
+      customPackagesPath = xppConfig.customPackagesPath;
+      microsoftPackagesPath = xppConfig.microsoftPackagesPath;
+    }
 
-    // Explicit override from params takes priority; otherwise derive from XPP config
-    // so the version is never hardcoded — it comes from XPP_CONFIG_NAME in the instance .env.
+    // Priority 2: configManager explicit methods (.mcp.json overrides)
+    if (!customPackagesPath) customPackagesPath = await configManager.getCustomPackagesPath();
+    if (!microsoftPackagesPath) microsoftPackagesPath = await configManager.getMicrosoftPackagesPath();
+
+    // Priority 3: Fallback to general package path (CHE / non-UDE)
     const packagesRoot = params.packagePath
       || microsoftPackagesPath
+      || customPackagesPath
       || configManager.getPackagePath()
       || 'K:\\AosService\\PackagesLocalDirectory';
 
@@ -68,51 +78,60 @@ export const runBpCheckTool = async (params: any, _context: any) => {
 
     // metadataPath: where X++ source XML lives (custom model metadata)
     const metadataPath = customPackagesPath || packagesRoot;
-    // packagesRootPath (-compilerMetadata): where compiled binaries live.
-    // Must be the CUSTOM model packages path, not the framework dir —
-    // compiled artifacts are written to the custom path, so xppbp must
-    // look there or it emits CompilerMetadataMissing for newly-added classes.
-    const packagesRootPath = customPackagesPath || packagesRoot;
+    // compilerMetadataPath: where compiled binaries and framework metadata live.
+    // In UDE: the framework/Microsoft packages root
+    // In CHE: same as metadataPath (both roles in one PackagesLocalDirectory)
+    const compilerMetadataPath = microsoftPackagesPath || packagesRoot;
 
     /**
      * xppbp.exe CLI flag styles observed across versions:
      *
      *   Style A — colon separator (older):
-     *     -metadata:<path>  -module:<name>  -model:<name>  -packagesRoot:<path>  -all
+     *     -metadata:<path>  -module:<name>  -model:<name>  -compilerMetadata:<path>  -all
      *     -filter:<name>  (filter by element name)
      *
      *   Style B — equals separator (newer, 10.0.24+):
-     *     -metadata=<path>  -module=<name>  -model=<name>  -packagesRoot=<path>  -all
+     *     -metadata=<path>  -module=<name>  -model=<name>  -compilerMetadata=<path>  -all
      *     class:<Name>  (positional element-type filter, e.g. "class:MyClass")
      *
-     *   Style C — legacy packagesroot only (no -metadata flag):
-     *     -packagesroot:<path>  -module:<name>  -model:<name>  -all
+     *   Style C — fallback (when -compilerMetadata is not recognized):
+     *     -metadata:<path>  -packagesRoot:<path>  -module:<name>  -model:<name>  -all
      *
      * We try A → B → C in order, stopping at the first that doesn't return help text.
+     * In UDE, metadataPath and compilerMetadataPath are different directories.
+     * In CHE, they may be the same (both in PackagesLocalDirectory).
      */
 
-    // Style A — colon separator
-    const buildArgsColonStyle = (metadataFlag: string): string[] => {
+    // Style A — colon separator with -compilerMetadata
+    const buildArgsColonStyle = (metadataFlag: string, compilerMetadataFlag: string): string[] => {
       const a: string[] = [
         `${metadataFlag}${metadataPath}`,
         `-module:${modelName}`,
         `-model:${modelName}`,
-        `-packagesRoot:${packagesRootPath}`,
+        `${compilerMetadataFlag}${compilerMetadataPath}`,
         `-all`,
       ];
       if (targetFilter) a.push(`-filter:${targetFilter}`);
       return a;
     };
 
-    // Style B — equals separator (xppbp 10.0.24+: positional "<type>:<Name>" filter, no leading dash)
-    const buildArgsEqStyle = (): string[] => {
+    // Style B — equals separator with -compilerMetadata (xppbp 10.0.24+: positional "<type>:<Name>" filter, no leading dash)
+    const buildArgsEqStyle = (useCompilerMetadataEq: boolean): string[] => {
       const a: string[] = [
         `-metadata=${metadataPath}`,
         `-module=${modelName}`,
         `-model=${modelName}`,
-        `-packagesRoot=${packagesRootPath}`,
-        `-all`,
       ];
+
+      // Try the newer -compilerMetadata= flag first in Style B
+      if (useCompilerMetadataEq) {
+        a.push(`-compilerMetadata=${compilerMetadataPath}`);
+      } else {
+        a.push(`-packagesRoot=${compilerMetadataPath}`);
+      }
+
+      a.push(`-all`);
+
       // Positional element filter: "<type>:<Name>" — type comes from targetElementType
       // (defaults to 'class' when omitted for backwards compatibility).
       if (targetFilter) {
@@ -122,15 +141,28 @@ export const runBpCheckTool = async (params: any, _context: any) => {
       return a;
     };
 
+    // Style C — fallback when -compilerMetadata is not recognized
+    const buildArgsFallbackStyle = (): string[] => {
+      const a: string[] = [
+        `-metadata:${metadataPath}`,
+        `-packagesRoot:${compilerMetadataPath}`,
+        `-module:${modelName}`,
+        `-model:${modelName}`,
+        `-all`,
+      ];
+      if (targetFilter) a.push(`-filter:${targetFilter}`);
+      return a;
+    };
+
     let stdout = '';
     let stderr = '';
 
     const { combined, lastStdout, lastStderr } = await withOperationLock(
       `bp:${modelName}`,
       async () => {
-        // --- Attempt 1: colon style with -metadata: ---
-        const args1 = buildArgsColonStyle('-metadata:');
-        console.error(`[run_bp_check] Attempt 1 (-metadata: colon): "${xppbpPath}" ${args1.join(' ')}`);
+        // --- Attempt 1: colon style with -compilerMetadata: (UDE: separates custom and framework paths) ---
+        const args1 = buildArgsColonStyle('-metadata:', '-compilerMetadata:');
+        console.error(`[run_bp_check] Attempt 1 (-compilerMetadata: colon): "${xppbpPath}" ${args1.join(' ')}`);
         try {
           ({ stdout, stderr } = await tryXppbp(xppbpPath, args1));
         } catch (e: any) {
@@ -139,10 +171,10 @@ export const runBpCheckTool = async (params: any, _context: any) => {
         }
         let localCombined = [stdout, stderr].filter(Boolean).join('\n').trim();
 
-        // --- Attempt 2: equals style (-metadata=, -module=, ...) ---
+        // --- Attempt 2: equals style with -compilerMetadata= (xppbp 10.0.24+) ---
         if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
-          const args2 = buildArgsEqStyle();
-          console.error(`[run_bp_check] Attempt 2 (-metadata= equals): "${xppbpPath}" ${args2.join(' ')}`);
+          const args2 = buildArgsEqStyle(true);  // useCompilerMetadataEq = true
+          console.error(`[run_bp_check] Attempt 2 (-compilerMetadata= equals): "${xppbpPath}" ${args2.join(' ')}`);
           try {
             ({ stdout, stderr } = await tryXppbp(xppbpPath, args2));
           } catch (e: any) {
@@ -152,12 +184,25 @@ export const runBpCheckTool = async (params: any, _context: any) => {
           localCombined = [stdout, stderr].filter(Boolean).join('\n').trim();
         }
 
-        // --- Attempt 3: legacy -packagesroot: (no -metadata flag) ---
+        // --- Attempt 3: equals style with -packagesRoot= (fallback for older xppbp) ---
         if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
-          const args3 = buildArgsColonStyle('-packagesroot:');
-          console.error(`[run_bp_check] Attempt 3 (legacy -packagesroot:): "${xppbpPath}" ${args3.join(' ')}`);
+          const args3 = buildArgsEqStyle(false);  // useCompilerMetadataEq = false, falls back to -packagesRoot=
+          console.error(`[run_bp_check] Attempt 3 (-packagesRoot= equals fallback): "${xppbpPath}" ${args3.join(' ')}`);
           try {
             ({ stdout, stderr } = await tryXppbp(xppbpPath, args3));
+          } catch (e: any) {
+            stdout = e.stdout ?? '';
+            stderr = e.stderr ?? '';
+          }
+          localCombined = [stdout, stderr].filter(Boolean).join('\n').trim();
+        }
+
+        // --- Attempt 4: colon style with -packagesRoot: (oldest fallback) ---
+        if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
+          const args4 = buildArgsFallbackStyle();
+          console.error(`[run_bp_check] Attempt 4 (-packagesRoot: colon fallback): "${xppbpPath}" ${args4.join(' ')}`);
+          try {
+            ({ stdout, stderr } = await tryXppbp(xppbpPath, args4));
           } catch (e: any) {
             stdout = e.stdout ?? '';
             stderr = e.stderr ?? '';
@@ -177,7 +222,7 @@ export const runBpCheckTool = async (params: any, _context: any) => {
       return {
         content: [{
           type: 'text',
-          text: `❌ xppbp.exe returned its help text for all three flag-style attempts (-metadata:, -metadata=, -packagesroot:).\n\nThis usually means the installed xppbp.exe version uses an unrecognised CLI format.\n\nRaw output:\n\n${combined}`
+          text: `❌ xppbp.exe returned its help text for all four flag-style attempts (-compilerMetadata:, -compilerMetadata=, -packagesRoot= with equals, -packagesRoot: with colon).\n\nThis usually means the installed xppbp.exe version uses an unrecognised CLI format.\n\nRaw output:\n\n${combined}`
         }],
         isError: true
       };

--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -45,7 +45,15 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     // In UDE the custom packages path (ModelStoreFolder) is the metadata root,
     // while the framework packages path (FrameworkDirectory) is the binaries root.
     // For traditional environments both roles are served by packagesRoot.
-    // Priority 1: XPP config (UDE) — authoritative source for all paths (same as build_d365fo_project)
+    //
+    // Path resolution — intentionally mirrors build_d365fo_project:
+    //   Priority 1: XPP config file (UDE — authoritative when present).
+    //               Note: when an XPP config exists, any customPackagesPath /
+    //               microsoftPackagesPath values in .mcp.json are NOT consulted.
+    //               Use params.packagePath to override the final packagesRoot.
+    //   Priority 2: configManager methods (.mcp.json context overrides, then
+    //               XPP config auto-detection as a second chance for CHE).
+    //   Priority 3: Well-known PackagesLocalDirectory probe (CHE fallback).
     let customPackagesPath: string | null = null;
     let microsoftPackagesPath: string | null = null;
     const xppConfig = await configManager.getActiveXppConfig();
@@ -55,10 +63,25 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     }
 
     // Priority 2: configManager explicit methods (.mcp.json overrides)
-    if (!customPackagesPath) customPackagesPath = await configManager.getCustomPackagesPath();
+    if (!customPackagesPath)    customPackagesPath    = await configManager.getCustomPackagesPath();
     if (!microsoftPackagesPath) microsoftPackagesPath = await configManager.getMicrosoftPackagesPath();
 
-    // Priority 3: Fallback to general package path (CHE / non-UDE)
+    // Priority 3: probe well-known PackagesLocalDirectory locations (CHE)
+    if (!microsoftPackagesPath) {
+      for (const candidate of [
+        'C:\\AOSService\\PackagesLocalDirectory',
+        'K:\\AOSService\\PackagesLocalDirectory',
+        'J:\\AOSService\\PackagesLocalDirectory',
+        'I:\\AOSService\\PackagesLocalDirectory',
+      ]) {
+        try { await fs.access(candidate); microsoftPackagesPath = candidate; break; } catch { /* next */ }
+      }
+    }
+
+    // In CHE, custom and Microsoft packages share the same PackagesLocalDirectory
+    if (!customPackagesPath && microsoftPackagesPath) customPackagesPath = microsoftPackagesPath;
+
+    // Final packagesRoot: explicit param override → microsoft path → custom path → legacy env var → hardcoded default
     const packagesRoot = params.packagePath
       || microsoftPackagesPath
       || customPackagesPath
@@ -115,16 +138,16 @@ export const runBpCheckTool = async (params: any, _context: any) => {
       return a;
     };
 
-    // Style B — equals separator with -compilerMetadata (xppbp 10.0.24+: positional "<type>:<Name>" filter, no leading dash)
-    const buildArgsEqStyle = (useCompilerMetadataEq: boolean): string[] => {
+    // Style B — equals separator (xppbp 10.0.24+: positional "<type>:<Name>" filter, no leading dash)
+    const buildArgsEqStyle = ({ compilerMetadata }: { compilerMetadata: boolean }): string[] => {
       const a: string[] = [
         `-metadata=${metadataPath}`,
         `-module=${modelName}`,
         `-model=${modelName}`,
       ];
 
-      // Try the newer -compilerMetadata= flag first in Style B
-      if (useCompilerMetadataEq) {
+      // -compilerMetadata= is the newer flag; fall back to -packagesRoot= for older xppbp
+      if (compilerMetadata) {
         a.push(`-compilerMetadata=${compilerMetadataPath}`);
       } else {
         a.push(`-packagesRoot=${compilerMetadataPath}`);
@@ -173,7 +196,7 @@ export const runBpCheckTool = async (params: any, _context: any) => {
 
         // --- Attempt 2: equals style with -compilerMetadata= (xppbp 10.0.24+) ---
         if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
-          const args2 = buildArgsEqStyle(true);  // useCompilerMetadataEq = true
+          const args2 = buildArgsEqStyle({ compilerMetadata: true });
           console.error(`[run_bp_check] Attempt 2 (-compilerMetadata= equals): "${xppbpPath}" ${args2.join(' ')}`);
           try {
             ({ stdout, stderr } = await tryXppbp(xppbpPath, args2));
@@ -186,7 +209,7 @@ export const runBpCheckTool = async (params: any, _context: any) => {
 
         // --- Attempt 3: equals style with -packagesRoot= (fallback for older xppbp) ---
         if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
-          const args3 = buildArgsEqStyle(false);  // useCompilerMetadataEq = false, falls back to -packagesRoot=
+          const args3 = buildArgsEqStyle({ compilerMetadata: false });
           console.error(`[run_bp_check] Attempt 3 (-packagesRoot= equals fallback): "${xppbpPath}" ${args3.join(' ')}`);
           try {
             ({ stdout, stderr } = await tryXppbp(xppbpPath, args3));

--- a/tests/tools/runBpCheck.test.ts
+++ b/tests/tools/runBpCheck.test.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- hoisted mocks -----------------------------------------------------------
+const {
+  accessMock, execFileMock,
+  cfgEnsureLoaded, cfgGetModelName, cfgGetProjectPath, cfgGetPackagePath,
+  cfgGetCustomPackagesPath, cfgGetMicrosoftPackagesPath, cfgGetActiveXppConfig,
+} = vi.hoisted(() => {
+  const accessMock = vi.fn();
+  // execFile needs a callback-style API for util.promisify
+  const execFileMock: any = vi.fn((_file: string, _args: string[], _opts: any, cb: Function) => {
+    cb(null, { stdout: '✅ no violations', stderr: '' });
+  });
+  const cfgEnsureLoaded             = vi.fn();
+  const cfgGetModelName             = vi.fn().mockReturnValue('MyModel');
+  const cfgGetProjectPath           = vi.fn().mockResolvedValue(null);
+  const cfgGetPackagePath           = vi.fn().mockReturnValue(null);
+  const cfgGetCustomPackagesPath    = vi.fn().mockResolvedValue(null);
+  const cfgGetMicrosoftPackagesPath = vi.fn().mockResolvedValue(null);
+  const cfgGetActiveXppConfig       = vi.fn().mockResolvedValue(null);
+  return {
+    accessMock, execFileMock,
+    cfgEnsureLoaded, cfgGetModelName, cfgGetProjectPath, cfgGetPackagePath,
+    cfgGetCustomPackagesPath, cfgGetMicrosoftPackagesPath, cfgGetActiveXppConfig,
+  };
+});
+
+vi.mock('child_process', () => ({ execFile: execFileMock }));
+// runBpCheck.ts uses `import fs from 'fs/promises'` (default namespace import).
+// Vitest resolves the default import to the `default` property of the mock object.
+// Without it `fs` is undefined, all fs.access() calls throw TypeError, which is
+// silently swallowed by the CHE probe try/catch, and the path resolution silently
+// falls through to the hardcoded K:\AosService default.
+vi.mock('fs/promises', () => { const m = { access: accessMock }; return { ...m, default: m }; });
+vi.mock('../../src/utils/configManager.js', () => ({
+  getConfigManager: () => ({
+    ensureLoaded:             cfgEnsureLoaded,
+    getModelName:             cfgGetModelName,
+    getProjectPath:           cfgGetProjectPath,
+    getPackagePath:           cfgGetPackagePath,
+    getCustomPackagesPath:    cfgGetCustomPackagesPath,
+    getMicrosoftPackagesPath: cfgGetMicrosoftPackagesPath,
+    getActiveXppConfig:       cfgGetActiveXppConfig,
+  }),
+}));
+vi.mock('../../src/utils/operationLocks.js', () => ({
+  withOperationLock: (_key: string, fn: () => any) => fn(),
+}));
+
+import path from 'path';
+import { runBpCheckTool } from '../../src/tools/runBpCheck';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHE_PKG  = 'C:\\AOSService\\PackagesLocalDirectory';
+const UDE_CUSTOM = 'D:\\Metadata\\CustomPackages';
+const UDE_MS     = 'D:\\Metadata\\MicrosoftPackages';
+
+const CHE_XPPBP = path.join(CHE_PKG,  'Bin', 'xppbp.exe');
+const UDE_XPPBP = path.join(UDE_MS,   'Bin', 'xppbp.exe');
+
+/** Allow fs.access only for the listed paths; all others reject with ENOENT. */
+function allowPaths(paths: string[]) {
+  accessMock.mockImplementation(async (p: string) => {
+    const norm = (s: string) => s.replace(/\\/g, '/').toLowerCase();
+    if (paths.some(a => norm(a) === norm(p))) return;
+    throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+  });
+}
+
+/** Returns captured args from execFileMock call N (0-based). */
+function capturedArgs(callIndex = 0): string[] {
+  return execFileMock.mock.calls[callIndex]?.[1] ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('run_bp_check — path resolution', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    execFileMock.mockImplementation((_file: string, _args: string[], _opts: any, cb: Function) => {
+      cb(null, { stdout: '✅ no violations', stderr: '' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Environment A — CHE: single PackagesLocalDirectory (Priority 3 probe)
+  // -------------------------------------------------------------------------
+  describe('Environment A — CHE (single PackagesLocalDirectory)', () => {
+    it('resolves xppbp.exe from probed CHE path when no config is present', async () => {
+      allowPaths([CHE_PKG, CHE_XPPBP]);
+
+      const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      expect(result.isError).toBeFalsy();
+      expect(execFileMock).toHaveBeenCalled();
+      const [exe] = execFileMock.mock.calls[0];
+      expect(exe).toBe(CHE_XPPBP);
+    });
+
+    it('passes -metadata= and -packagesRoot= pointing to the same CHE root', async () => {
+      allowPaths([CHE_PKG, CHE_XPPBP]);
+
+      await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      // The first successful attempt may be colon or equals style; in either
+      // case both metadata and compiler-metadata paths must resolve to CHE_PKG.
+      const args = capturedArgs(0);
+      const metaArg  = args.find(a => a.includes('metadata'));
+      const compArg  = args.find(a => a.includes('packagesRoot') || a.includes('compilerMetadata'));
+      expect(metaArg).toContain(CHE_PKG);
+      expect(compArg).toContain(CHE_PKG);
+    });
+
+    it('probes K:\\AOSService\\PackagesLocalDirectory when C:\\ variant absent', async () => {
+      const K_PKG   = 'K:\\AOSService\\PackagesLocalDirectory';
+      const K_XPPBP = path.join(K_PKG, 'Bin', 'xppbp.exe');
+      allowPaths([K_PKG, K_XPPBP]);
+
+      const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      expect(result.isError).toBeFalsy();
+      const [exe] = execFileMock.mock.calls[0];
+      expect(exe).toBe(K_XPPBP);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Environment B — UDE: separate custom and Microsoft/framework paths
+  // -------------------------------------------------------------------------
+  describe('Environment B — UDE (XPP config with separate paths)', () => {
+    beforeEach(() => {
+      cfgGetActiveXppConfig.mockResolvedValue({
+        configName:           'uat',
+        version:              '10.0.39',
+        customPackagesPath:   UDE_CUSTOM,
+        microsoftPackagesPath: UDE_MS,
+        referencePackagesPaths: [],
+      });
+    });
+
+    it('resolves xppbp.exe from microsoftPackagesPath (framework root)', async () => {
+      allowPaths([UDE_CUSTOM, UDE_MS, UDE_XPPBP]);
+
+      const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      expect(result.isError).toBeFalsy();
+      const [exe] = execFileMock.mock.calls[0];
+      expect(exe).toBe(UDE_XPPBP);
+    });
+
+    it('passes -metadata= pointing to customPackagesPath', async () => {
+      allowPaths([UDE_CUSTOM, UDE_MS, UDE_XPPBP]);
+
+      await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      const args      = capturedArgs(0);
+      const metaArg   = args.find(a => /^-metadata[:=]/.test(a));
+      expect(metaArg).toContain(UDE_CUSTOM);
+    });
+
+    it('passes -compilerMetadata= / -packagesRoot= pointing to microsoftPackagesPath', async () => {
+      allowPaths([UDE_CUSTOM, UDE_MS, UDE_XPPBP]);
+
+      await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      const args    = capturedArgs(0);
+      const compArg = args.find(a => a.includes('compilerMetadata') || a.includes('packagesRoot'));
+      expect(compArg).toContain(UDE_MS);
+      // Must NOT point to the custom metadata dir
+      expect(compArg).not.toContain(UDE_CUSTOM);
+    });
+
+    it('does NOT consult configManager.getCustomPackagesPath when xppConfig is present', async () => {
+      allowPaths([UDE_CUSTOM, UDE_MS, UDE_XPPBP]);
+
+      await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      // Priority 1 (XPP config) took effect — Priority 2 path must not have been called
+      expect(cfgGetCustomPackagesPath).not.toHaveBeenCalled();
+      expect(cfgGetMicrosoftPackagesPath).not.toHaveBeenCalled();
+    });
+
+    it('falls back to configManager paths when xppConfig returns null', async () => {
+      cfgGetActiveXppConfig.mockResolvedValue(null);
+      cfgGetCustomPackagesPath.mockResolvedValue(UDE_CUSTOM);
+      cfgGetMicrosoftPackagesPath.mockResolvedValue(UDE_MS);
+      allowPaths([UDE_CUSTOM, UDE_MS, UDE_XPPBP]);
+
+      const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      expect(result.isError).toBeFalsy();
+      expect(cfgGetCustomPackagesPath).toHaveBeenCalled();
+      expect(cfgGetMicrosoftPackagesPath).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // params.packagePath override
+  // -------------------------------------------------------------------------
+  describe('params.packagePath explicit override', () => {
+    it('uses params.packagePath for xppbp.exe resolution regardless of config', async () => {
+      const OVERRIDE = 'E:\\CustomBinaries\\PackagesLocalDirectory';
+      const OVERRIDE_XPPBP = path.join(OVERRIDE, 'Bin', 'xppbp.exe');
+      allowPaths([OVERRIDE, OVERRIDE_XPPBP]);
+
+      const result = await runBpCheckTool({ modelName: 'MyModel', packagePath: OVERRIDE }, {});
+
+      expect(result.isError).toBeFalsy();
+      const [exe] = execFileMock.mock.calls[0];
+      expect(exe).toBe(OVERRIDE_XPPBP);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error paths
+  // -------------------------------------------------------------------------
+  describe('Error paths', () => {
+    it('returns error when model name cannot be determined', async () => {
+      cfgGetModelName.mockReturnValue(null);
+
+      const result = await runBpCheckTool({}, {});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Cannot determine model name');
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
+
+    it('returns error when xppbp.exe is not found at resolved path', async () => {
+      allowPaths([CHE_PKG]); // directory exists but xppbp.exe does not
+
+      const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('xppbp.exe not found');
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
+
+    it('returns error when no package path can be resolved at all', async () => {
+      // fs.access always rejects → no CHE probe candidate found, no xppbp.exe
+      accessMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+      const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI flag styles
+// ---------------------------------------------------------------------------
+describe('run_bp_check — CLI flag style fallback chain', () => {
+  const HELP_OUTPUT = 'X++ Best Practice Options:\n  -metadata:<path>\n';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    allowPaths([CHE_PKG, CHE_XPPBP]);
+  });
+
+  it('succeeds on Attempt 1 and does not try further attempts', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: '✅ no violations', stderr: '' });
+    });
+
+    await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to Attempt 2 when Attempt 1 returns help text', async () => {
+    let callCount = 0;
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      callCount++;
+      if (callCount === 1) cb(null, { stdout: HELP_OUTPUT, stderr: '' });
+      else                 cb(null, { stdout: '✅ passed', stderr: '' });
+    });
+
+    const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(result.isError).toBeFalsy();
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls through to Attempt 3 when Attempts 1+2 return help text', async () => {
+    let callCount = 0;
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      callCount++;
+      if (callCount <= 2) cb(null, { stdout: HELP_OUTPUT, stderr: '' });
+      else                cb(null, { stdout: '✅ passed', stderr: '' });
+    });
+
+    const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(result.isError).toBeFalsy();
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls through to Attempt 4 when Attempts 1–3 return help text', async () => {
+    let callCount = 0;
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      callCount++;
+      if (callCount <= 3) cb(null, { stdout: HELP_OUTPUT, stderr: '' });
+      else                cb(null, { stdout: '✅ passed', stderr: '' });
+    });
+
+    const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(result.isError).toBeFalsy();
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns error message listing all four attempts when all return help text', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: HELP_OUTPUT, stderr: '' });
+    });
+
+    const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('four flag-style attempts');
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('Attempt 1 uses -compilerMetadata: (colon) style', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: '✅', stderr: '' });
+    });
+
+    await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    const args = capturedArgs(0);
+    expect(args.some(a => /^-compilerMetadata:/.test(a))).toBe(true);
+    expect(args.some(a => /^-metadata:/.test(a))).toBe(true);
+  });
+
+  it('Attempt 2 uses -compilerMetadata= (equals) style', async () => {
+    let callCount = 0;
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      callCount++;
+      if (callCount === 1) cb(null, { stdout: HELP_OUTPUT, stderr: '' });
+      else                 cb(null, { stdout: '✅', stderr: '' });
+    });
+
+    await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    const args = capturedArgs(1);
+    expect(args.some(a => /^-compilerMetadata=/.test(a))).toBe(true);
+    expect(args.some(a => /^-metadata=/.test(a))).toBe(true);
+  });
+
+  it('Attempt 3 uses -packagesRoot= (equals) style', async () => {
+    let callCount = 0;
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      callCount++;
+      if (callCount <= 2) cb(null, { stdout: HELP_OUTPUT, stderr: '' });
+      else                cb(null, { stdout: '✅', stderr: '' });
+    });
+
+    await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    const args = capturedArgs(2);
+    expect(args.some(a => /^-packagesRoot=/.test(a))).toBe(true);
+    expect(args.some(a => /^-metadata=/.test(a))).toBe(true);
+  });
+
+  it('Attempt 4 uses -packagesRoot: (colon) style', async () => {
+    let callCount = 0;
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      callCount++;
+      if (callCount <= 3) cb(null, { stdout: HELP_OUTPUT, stderr: '' });
+      else                cb(null, { stdout: '✅', stderr: '' });
+    });
+
+    await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    const args = capturedArgs(3);
+    expect(args.some(a => /^-packagesRoot:/.test(a))).toBe(true);
+    expect(args.some(a => /^-metadata:/.test(a))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BP violation detection
+// ---------------------------------------------------------------------------
+describe('run_bp_check — violation detection', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    allowPaths([CHE_PKG, CHE_XPPBP]);
+  });
+
+  it('reports ✅ when output contains no violations', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: 'Errors: 0\nWarnings: 0', stderr: '' });
+    });
+
+    const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('✅ BP Check passed');
+  });
+
+  it('reports ⚠️ when output contains BPError', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: 'BPError: LocalVariableNotUsed\nErrors: 1', stderr: '' });
+    });
+
+    const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('⚠️ BP Check completed with issues');
+  });
+
+  it('reports ⚠️ when Warnings counter is non-zero', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: 'Warnings: 3', stderr: '' });
+    });
+
+    const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(result.content[0].text).toContain('⚠️');
+  });
+
+  it('includes filter name in output when targetFilter is supplied', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: '✅', stderr: '' });
+    });
+
+    const result = await runBpCheckTool({ modelName: 'MyModel', targetFilter: 'MyClass' }, {});
+
+    expect(result.content[0].text).toContain('Filter: MyClass');
+    const args = capturedArgs(0);
+    expect(args.some(a => a.includes('MyClass'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Inadvertently commit broke bp check in specific configuration. This fix would revert fix from last commit which tried to address the missing metadata for objects (wrong paths). Please consider either full rollback of the additional fix to bpcheck (runbpcheck.ts) or consider if this fixes the issue more properly:

Environment A (explicit configuration):
Has D365FO_PACKAGE_PATH explicitly set in .env
Both metadata paths resolve to the same single location
xppbp can find all needed metadata in one place
The previous fix (both paths → customPackagesPath) worked because there was effectively only one root anyway

Environment B (XPP config-based):
Has XPP_CONFIG_NAME set, which provides two separate paths but no D365FO_PACKAGE_PATH set.
Custom packages root ≠ Microsoft packages root
The old code didn't use getActiveXppConfig(), so it ignored the XPP config
Both paths fell back to misconfigured defaults
xppbp got null configuration error

The difference:
Environment A has a single consolidated path → single-path workaround worked
Environment B has two separate paths from XPP config → single-path workaround failed
This fix should handle both by:
Reading XPP config first (fixes Environment B)
Falling back to explicit paths (preserves Environment A)

Changes:
- Use getActiveXppConfig() like build_d365fo_project does (Priority 1: UDE)
- Fallback to explicit methods (Priority 2: .mcp.json overrides)
- Fallback to shared packagesRoot (Priority 3: CHE environments)
- Rename packagesRootPath → compilerMetadataPath for clarity
- Restore correct path: compilerMetadataPath = microsoftPackagesPath
- Add -compilerMetadata flag support (Style A colon, Style B equals)
- Add fallback attempt with -packagesRoot for older xppbp versions
- Add Style C fallback for complete backwards compatibility

Tested both Environment A and Environment B 

"The source for referenced module 'StandardModule' is missing from the model store. Please specify the -packagesRoot parameter to instead use binary metadata for referenced modules. " Which should be normal in UDE.
