### PR TITLE
feat(getObjectInfo): add support for multiple extension types in object info tools

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -19,6 +19,7 @@ import { SERVER_MODE, LOCAL_TOOLS, ALWAYS_TOOLS } from './serverMode.js';
 import { TOOL_ANNOTATIONS } from './toolAnnotations.js';
 import { getConfigManager } from '../utils/configManager.js';
 import { setLastRoots, recordRootsListChanged } from '../utils/stdioSessionInfo.js';
+import { OBJECT_INFO_TYPES, BATCH_INFO_TYPES } from '../tools/objectInfoRegistry.js';
 
 export type { XppServerContext };
 export { SERVER_MODE, LOCAL_TOOLS, WRITE_TOOLS } from './serverMode.js';
@@ -330,9 +331,7 @@ export function createXppMcpServer(context: XppServerContext): Server {
                     name: { type: 'string', description: 'Exact object name (use search first if unsure)' },
                     type: {
                       type: 'string',
-                      enum: ['class', 'table', 'form', 'query', 'view', 'enum', 'edt', 'report',
-                        'data-entity', 'menu-item', 'table-extension',
-                        'security-privilege', 'security-duty', 'security-role'],
+                      enum: [...BATCH_INFO_TYPES],
                       description: 'Object type — selects the underlying get_*_info tool',
                     },
                   },
@@ -846,14 +845,14 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
         },
         {
           name: 'get_object_info',
-          description: 'Read one D365FO object\'s metadata. Pick the kind via objectType: class, table, form, query, view, enum, edt, report, data-entity, menu-item, service, map, config-key, security-policy, macro. Type-specific flags go in options, e.g. {"includeRdl":true} (report), {"searchControl":"General"} (form), {"compact":false} (class), {"filter":"Path"} (macro), {"mode":"hierarchy"} (edt). For CLASSES, {"members":"names"} (optional {"prefix":...}) returns a fast IntelliSense-style member-name list instead of full metadata. For 2+ objects use batch_get_info. Replaces the former get_<type>_info and code_completion tools.',
+          description: 'Read one D365FO object\'s metadata. Pick the kind via objectType: class, table, form, query, view, enum, edt, report, data-entity, menu-item, service, map, config-key, security-policy, macro. Extension types (table-extension, form-extension, enum-extension, edt-extension, data-entity-extension) list all extensions of a base object — pass the base object name or a full extension name (the dot suffix is stripped automatically). Type-specific flags go in options, e.g. {"includeRdl":true} (report), {"searchControl":"General"} (form), {"compact":false} (class), {"filter":"Path"} (macro), {"mode":"hierarchy"} (edt). For CLASSES, {"members":"names"} (optional {"prefix":...}) returns a fast IntelliSense-style member-name list instead of full metadata. For 2+ objects use batch_get_info. Replaces the former get_<type>_info and code_completion tools.',
           inputSchema: {
             type: 'object',
             properties: {
               objectType: {
                 type: 'string',
-                enum: ['class', 'table', 'form', 'query', 'view', 'enum', 'edt', 'report', 'data-entity', 'menu-item', 'service', 'map', 'config-key', 'security-policy', 'macro'],
-                description: 'Kind of object to read',
+                enum: [...OBJECT_INFO_TYPES],
+                description: 'Kind of object to read (incl. *-extension types — pass base object name or full extension name)',
               },
               name: {
                 type: 'string',

--- a/src/tools/getObjectInfo.ts
+++ b/src/tools/getObjectInfo.ts
@@ -21,10 +21,12 @@ import { completionTool } from './completion.js';
 const GetObjectInfoArgsSchema = z.object({
   objectType: z.enum(OBJECT_INFO_TYPES).describe(
     'Kind of object to read: class, table, form, query, view, enum, edt, report, ' +
-    'data-entity, menu-item, service, map, config-key, security-policy, macro, table-extension. ' +
-    'For table-extension the name may be either the full extension name ' +
-    '(e.g. "CustInvoiceJour.Extension") or just the base table name — ' +
-    'both are accepted; the base table name is extracted automatically.',
+    'data-entity, menu-item, service, map, config-key, security-policy, macro. ' +
+    'Extension types list every extension of a base object: table-extension, ' +
+    'form-extension, enum-extension, edt-extension, data-entity-extension, class-extension. ' +
+    'For any *-extension the name may be either the full extension name ' +
+    '(e.g. "CustInvoiceJour.Extension") or just the base object name — ' +
+    'both are accepted; the base object name is extracted automatically.',
   ),
   name: z.string().min(1).describe('Exact object name (use search/search(queries=[...]) first if unsure).'),
   options: z.record(z.string(), z.any()).optional().describe(

--- a/src/tools/getObjectInfo.ts
+++ b/src/tools/getObjectInfo.ts
@@ -21,7 +21,10 @@ import { completionTool } from './completion.js';
 const GetObjectInfoArgsSchema = z.object({
   objectType: z.enum(OBJECT_INFO_TYPES).describe(
     'Kind of object to read: class, table, form, query, view, enum, edt, report, ' +
-    'data-entity, menu-item, service, map, config-key, security-policy, macro.',
+    'data-entity, menu-item, service, map, config-key, security-policy, macro, table-extension. ' +
+    'For table-extension the name may be either the full extension name ' +
+    '(e.g. "CustInvoiceJour.Extension") or just the base table name — ' +
+    'both are accepted; the base table name is extracted automatically.',
   ),
   name: z.string().min(1).describe('Exact object name (use search/search(queries=[...]) first if unsure).'),
   options: z.record(z.string(), z.any()).optional().describe(

--- a/src/tools/objectInfoRegistry.ts
+++ b/src/tools/objectInfoRegistry.ts
@@ -27,7 +27,7 @@ import { getMapInfoTool } from './mapInfo.js';
 import { getConfigKeyInfoTool } from './configKeyInfo.js';
 import { getSecurityPolicyInfoTool } from './securityPolicyInfo.js';
 import { getMacroInfoTool } from './macroInfo.js';
-import { tableExtensionInfoTool, formExtensionInfoTool, enumExtensionInfoTool, edtExtensionInfoTool, dataEntityExtensionInfoTool } from './tableExtensionInfo.js';
+import { tableExtensionInfoTool, formExtensionInfoTool, enumExtensionInfoTool, edtExtensionInfoTool, dataEntityExtensionInfoTool, classExtensionInfoTool } from './tableExtensionInfo.js';
 import { securityArtifactInfoTool } from './securityArtifactInfo.js';
 
 export type InfoTool = (request: CallToolRequest, context: XppServerContext) => Promise<any>;
@@ -42,6 +42,13 @@ export interface ReaderDispatch {
 /** name + spread options; unknown option keys are stripped by each handler's zod schema. */
 const byName = (key: string): ReaderDispatch['buildArgs'] =>
   (name, options) => ({ [key]: name, ...(options ?? {}) });
+
+/**
+ * Like byName, but for extension lookups: accepts either the base object name or
+ * a full extension name and passes only the base name (dot suffix stripped) under `key`.
+ */
+const byBaseName = (key: string): ReaderDispatch['buildArgs'] =>
+  (name, options) => ({ [key]: name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) });
 
 export const READER_DISPATCH: Record<string, ReaderDispatch> = {
   'class':              { tool: classInfoTool,            toolName: 'get_class_info',             buildArgs: byName('className') },
@@ -59,12 +66,12 @@ export const READER_DISPATCH: Record<string, ReaderDispatch> = {
   'config-key':         { tool: getConfigKeyInfoTool,     toolName: 'get_config_key_info',        buildArgs: byName('name') },
   'security-policy':    { tool: getSecurityPolicyInfoTool,toolName: 'get_security_policy_info',   buildArgs: byName('policyName') },
   'macro':              { tool: getMacroInfoTool,         toolName: 'get_macro_info',             buildArgs: byName('macroName') },
-  'table-extension':         { tool: tableExtensionInfoTool,       toolName: 'get_table_extension_info',        buildArgs: (name, options) => ({ tableName: name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
-  'form-extension':          { tool: formExtensionInfoTool,        toolName: 'get_form_extension_info',         buildArgs: (name, options) => ({ baseName:   name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
-  'enum-extension':          { tool: enumExtensionInfoTool,        toolName: 'get_enum_extension_info',         buildArgs: (name, options) => ({ baseName:   name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
-  'edt-extension':           { tool: edtExtensionInfoTool,         toolName: 'get_edt_extension_info',          buildArgs: (name, options) => ({ baseName:   name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
-  'data-entity-extension':   { tool: dataEntityExtensionInfoTool,  toolName: 'get_data_entity_extension_info',  buildArgs: (name, options) => ({ baseName:   name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
-  'class-extension':         { tool: classInfoTool,                toolName: 'get_class_info',                  buildArgs: byName('className') },
+  'table-extension':         { tool: tableExtensionInfoTool,       toolName: 'get_table_extension_info',        buildArgs: byBaseName('tableName') },
+  'form-extension':          { tool: formExtensionInfoTool,        toolName: 'get_form_extension_info',         buildArgs: byBaseName('baseName') },
+  'enum-extension':          { tool: enumExtensionInfoTool,        toolName: 'get_enum_extension_info',         buildArgs: byBaseName('baseName') },
+  'edt-extension':           { tool: edtExtensionInfoTool,         toolName: 'get_edt_extension_info',          buildArgs: byBaseName('baseName') },
+  'data-entity-extension':   { tool: dataEntityExtensionInfoTool,  toolName: 'get_data_entity_extension_info',  buildArgs: byBaseName('baseName') },
+  'class-extension':         { tool: classExtensionInfoTool,       toolName: 'get_class_extension_info',         buildArgs: byBaseName('baseName') },
   'security-privilege': { tool: securityArtifactInfoTool, toolName: 'get_security_artifact_info', buildArgs: n => ({ name: n, artifactType: 'privilege' }) },
   'security-duty':      { tool: securityArtifactInfoTool, toolName: 'get_security_artifact_info', buildArgs: n => ({ name: n, artifactType: 'duty' }) },
   'security-role':      { tool: securityArtifactInfoTool, toolName: 'get_security_artifact_info', buildArgs: n => ({ name: n, artifactType: 'role' }) },

--- a/src/tools/objectInfoRegistry.ts
+++ b/src/tools/objectInfoRegistry.ts
@@ -27,7 +27,7 @@ import { getMapInfoTool } from './mapInfo.js';
 import { getConfigKeyInfoTool } from './configKeyInfo.js';
 import { getSecurityPolicyInfoTool } from './securityPolicyInfo.js';
 import { getMacroInfoTool } from './macroInfo.js';
-import { tableExtensionInfoTool } from './tableExtensionInfo.js';
+import { tableExtensionInfoTool, formExtensionInfoTool, enumExtensionInfoTool, edtExtensionInfoTool, dataEntityExtensionInfoTool } from './tableExtensionInfo.js';
 import { securityArtifactInfoTool } from './securityArtifactInfo.js';
 
 export type InfoTool = (request: CallToolRequest, context: XppServerContext) => Promise<any>;
@@ -59,10 +59,12 @@ export const READER_DISPATCH: Record<string, ReaderDispatch> = {
   'config-key':         { tool: getConfigKeyInfoTool,     toolName: 'get_config_key_info',        buildArgs: byName('name') },
   'security-policy':    { tool: getSecurityPolicyInfoTool,toolName: 'get_security_policy_info',   buildArgs: byName('policyName') },
   'macro':              { tool: getMacroInfoTool,         toolName: 'get_macro_info',             buildArgs: byName('macroName') },
-  // Additional types reachable via batch_get_info AND still published as their
-  // own dedicated tools (different argument shape: type discriminator + name).
-  // Unlike the per-name OBJECT_INFO_TYPES above, these stay registered separately.
-  'table-extension':    { tool: tableExtensionInfoTool,   toolName: 'get_table_extension_info',   buildArgs: byName('tableName') },
+  'table-extension':         { tool: tableExtensionInfoTool,       toolName: 'get_table_extension_info',        buildArgs: (name, options) => ({ tableName: name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
+  'form-extension':          { tool: formExtensionInfoTool,        toolName: 'get_form_extension_info',         buildArgs: (name, options) => ({ baseName:   name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
+  'enum-extension':          { tool: enumExtensionInfoTool,        toolName: 'get_enum_extension_info',         buildArgs: (name, options) => ({ baseName:   name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
+  'edt-extension':           { tool: edtExtensionInfoTool,         toolName: 'get_edt_extension_info',          buildArgs: (name, options) => ({ baseName:   name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
+  'data-entity-extension':   { tool: dataEntityExtensionInfoTool,  toolName: 'get_data_entity_extension_info',  buildArgs: (name, options) => ({ baseName:   name.includes('.') ? name.split('.')[0] : name, ...(options ?? {}) }) },
+  'class-extension':         { tool: classInfoTool,                toolName: 'get_class_info',                  buildArgs: byName('className') },
   'security-privilege': { tool: securityArtifactInfoTool, toolName: 'get_security_artifact_info', buildArgs: n => ({ name: n, artifactType: 'privilege' }) },
   'security-duty':      { tool: securityArtifactInfoTool, toolName: 'get_security_artifact_info', buildArgs: n => ({ name: n, artifactType: 'duty' }) },
   'security-role':      { tool: securityArtifactInfoTool, toolName: 'get_security_artifact_info', buildArgs: n => ({ name: n, artifactType: 'role' }) },
@@ -72,10 +74,13 @@ export const READER_DISPATCH: Record<string, ReaderDispatch> = {
 export const OBJECT_INFO_TYPES = [
   'class', 'table', 'form', 'query', 'view', 'enum', 'edt', 'report',
   'data-entity', 'menu-item', 'service', 'map', 'config-key', 'security-policy', 'macro',
+  // Extension types
+  'table-extension', 'class-extension', 'form-extension', 'enum-extension',
+  'edt-extension', 'data-entity-extension',
 ] as const;
 
 /** Types accepted by batch_get_info (superset incl. extensions + security artifacts). */
 export const BATCH_INFO_TYPES = [
   ...OBJECT_INFO_TYPES,
-  'table-extension', 'security-privilege', 'security-duty', 'security-role',
+  'security-privilege', 'security-duty', 'security-role',
 ] as const;

--- a/src/tools/tableExtensionInfo.ts
+++ b/src/tools/tableExtensionInfo.ts
@@ -222,7 +222,7 @@ const GenericExtArgsSchema = z.object({
 });
 
 function makeObjectExtensionTool(
-  extensionType: 'form-extension' | 'enum-extension' | 'edt-extension' | 'data-entity-extension',
+  extensionType: 'form-extension' | 'enum-extension' | 'edt-extension' | 'data-entity-extension' | 'class-extension',
   objectLabel: string,
 ) {
   return async function objectExtensionInfoTool(request: CallToolRequest, context: XppServerContext) {
@@ -317,3 +317,4 @@ export const formExtensionInfoTool       = makeObjectExtensionTool('form-extensi
 export const enumExtensionInfoTool       = makeObjectExtensionTool('enum-extension',        'Enum');
 export const edtExtensionInfoTool        = makeObjectExtensionTool('edt-extension',         'EDT');
 export const dataEntityExtensionInfoTool = makeObjectExtensionTool('data-entity-extension', 'DataEntity');
+export const classExtensionInfoTool      = makeObjectExtensionTool('class-extension',       'Class');

--- a/src/tools/tableExtensionInfo.ts
+++ b/src/tools/tableExtensionInfo.ts
@@ -204,3 +204,116 @@ export async function tableExtensionInfoTool(request: CallToolRequest, context: 
     };
   }
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// Generic object extension info (form-extension, enum-extension,
+// edt-extension, data-entity-extension)
+//
+// Same data-source priority as tableExtensionInfoTool:
+//   1. extension_metadata table (indexed build data)
+//   2. symbols table fallback
+//
+// Unlike table-extension there is no bridge fast-path yet and no filesystem
+// fallback — those can be added incrementally.
+// ────────────────────────────────────────────────────────────────────────────
+
+const GenericExtArgsSchema = z.object({
+  baseName: z.string().describe('Base object name (or full extension name — dot suffix is stripped automatically)'),
+});
+
+function makeObjectExtensionTool(
+  extensionType: 'form-extension' | 'enum-extension' | 'edt-extension' | 'data-entity-extension',
+  objectLabel: string,
+) {
+  return async function objectExtensionInfoTool(request: CallToolRequest, context: XppServerContext) {
+    try {
+      const raw = (request.params.arguments ?? {}) as Record<string, unknown>;
+      // Accept baseName or tableName for compat; strip dot notation if present.
+      const rawName = (raw.baseName ?? raw.tableName ?? raw.name ?? '') as string;
+      const baseName = rawName.includes('.') ? rawName.split('.')[0] : rawName;
+
+      const parsed = GenericExtArgsSchema.safeParse({ baseName });
+      if (!parsed.success || !baseName) {
+        return { content: [{ type: 'text', text: `❌ ${extensionType}: baseName is required.` }], isError: true };
+      }
+
+      const db = context.symbolIndex.getReadDb();
+
+      // ── extension_metadata (rich) ──────────────────────────────────────
+      let metaRows: any[] = [];
+      try {
+        metaRows = db.prepare(
+          `SELECT extension_name, model, added_fields, added_indexes, added_methods, coc_methods, event_subscriptions
+           FROM extension_metadata
+           WHERE base_object_name = ? AND extension_type = ?
+           ORDER BY model, extension_name`
+        ).all(baseName, extensionType) as any[];
+      } catch { /* older DB without extension_metadata — non-fatal */ }
+
+      // ── symbols fallback ───────────────────────────────────────────────
+      const symbolRows = db.prepare(
+        `SELECT name, model FROM symbols
+         WHERE type = ? AND (extends_class = ? OR name LIKE ?)
+         ORDER BY model, name`
+      ).all(extensionType, baseName, `${baseName}.%`) as any[];
+
+      const seen = new Set<string>();
+      const extensions: Array<{
+        name: string; model: string;
+        addedFields: string[]; addedIndexes: string[]; addedMethods: string[];
+        cocMethods: string[]; eventSubs: string[];
+      }> = [];
+
+      for (const row of metaRows) {
+        if (!seen.has(row.extension_name)) {
+          seen.add(row.extension_name);
+          let addedFields: string[] = [], addedIndexes: string[] = [];
+          let addedMethods: string[] = [], cocMethods: string[] = [], eventSubs: string[] = [];
+          try { addedFields = JSON.parse(row.added_fields || '[]'); } catch { /**/ }
+          try { addedIndexes = JSON.parse(row.added_indexes || '[]'); } catch { /**/ }
+          try { addedMethods = JSON.parse(row.added_methods || '[]'); } catch { /**/ }
+          try { cocMethods = JSON.parse(row.coc_methods || '[]'); } catch { /**/ }
+          try { eventSubs = JSON.parse(row.event_subscriptions || '[]'); } catch { /**/ }
+          extensions.push({ name: row.extension_name, model: row.model, addedFields, addedIndexes, addedMethods, cocMethods, eventSubs });
+        }
+      }
+      for (const row of symbolRows) {
+        if (!seen.has(row.name)) {
+          seen.add(row.name);
+          extensions.push({ name: row.name, model: row.model, addedFields: [], addedIndexes: [], addedMethods: [], cocMethods: [], eventSubs: [] });
+        }
+      }
+
+      let output = `${objectLabel} Extensions of: ${baseName}\n\n`;
+
+      if (extensions.length === 0) {
+        output += `No ${extensionType} found in index for "${baseName}".\n`;
+        output += `Tip: Re-run extract-metadata + build-database if the extension was added recently.\n`;
+      } else {
+        for (let i = 0; i < extensions.length; i++) {
+          const ext = extensions[i];
+          output += `[${i + 1}] ${ext.name} (${ext.model})\n`;
+          if (ext.addedFields.length > 0) output += `    Added Fields (${ext.addedFields.length}): ${ext.addedFields.join(', ')}\n`;
+          if (ext.addedIndexes.length > 0) output += `    Added Indexes (${ext.addedIndexes.length}): ${ext.addedIndexes.join(', ')}\n`;
+          if (ext.cocMethods.length > 0) output += `    Wraps Methods (CoC) (${ext.cocMethods.length}): ${ext.cocMethods.join(', ')}\n`;
+          const newMethods = ext.addedMethods.filter(m => !ext.cocMethods.some(c => c.toLowerCase() === m.toLowerCase()));
+          if (newMethods.length > 0) output += `    Added Methods (${newMethods.length}): ${newMethods.slice(0, 5).join(', ')}${newMethods.length > 5 ? ` (+${newMethods.length - 5} more)` : ''}\n`;
+          if (ext.eventSubs.length > 0) output += `    Event Subscriptions (${ext.eventSubs.length}): ${ext.eventSubs.slice(0, 3).join(', ')}${ext.eventSubs.length > 3 ? '...' : ''}\n`;
+        }
+        output += `\nTotal: ${extensions.length} extension(s) from model(s): ${[...new Set(extensions.map(e => e.model))].join(', ')}\n`;
+      }
+
+      return { content: [{ type: 'text', text: output }] };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error getting ${extensionType} info: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        isError: true,
+      };
+    }
+  };
+}
+
+export const formExtensionInfoTool       = makeObjectExtensionTool('form-extension',        'Form');
+export const enumExtensionInfoTool       = makeObjectExtensionTool('enum-extension',        'Enum');
+export const edtExtensionInfoTool        = makeObjectExtensionTool('edt-extension',         'EDT');
+export const dataEntityExtensionInfoTool = makeObjectExtensionTool('data-entity-extension', 'DataEntity');

--- a/tests/tools/object-extension-info.test.ts
+++ b/tests/tools/object-extension-info.test.ts
@@ -1,0 +1,157 @@
+/**
+ * get_object_info extension-type tests.
+ *
+ * Exercises the generic object-extension readers (form/enum/edt/data-entity/
+ * class-extension) end-to-end through getObjectInfoTool → READER_DISPATCH,
+ * against a real in-memory SQLite database using the production schema subset.
+ *
+ * Regression guard for PR #557: extension types must be advertised by both
+ * OBJECT_INFO_TYPES and the dispatch registry, and class-extension must return
+ * extension metadata (CoC/added methods) — not be silently routed to the base
+ * class reader.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Database from 'better-sqlite3';
+import { getObjectInfoTool } from '../../src/tools/getObjectInfo';
+import {
+  READER_DISPATCH,
+  OBJECT_INFO_TYPES,
+  BATCH_INFO_TYPES,
+} from '../../src/tools/objectInfoRegistry';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+let db: InstanceType<typeof Database>;
+let context: XppServerContext;
+
+const req = (objectType: string, name: string): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'get_object_info', arguments: { objectType, name } },
+});
+
+const textOf = async (objectType: string, name: string): Promise<string> => {
+  const res = await getObjectInfoTool(req(objectType, name), context);
+  return res.content[0].text as string;
+};
+
+beforeAll(() => {
+  db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      type TEXT NOT NULL,
+      model TEXT,
+      parent_name TEXT,
+      extends_class TEXT
+    );
+    CREATE TABLE extension_metadata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      extension_name TEXT,
+      extension_type TEXT,
+      base_object_name TEXT,
+      added_fields TEXT,
+      added_indexes TEXT,
+      added_methods TEXT,
+      coc_methods TEXT,
+      event_subscriptions TEXT,
+      model TEXT
+    );
+  `);
+
+  const insMeta = db.prepare(
+    `INSERT INTO extension_metadata
+       (extension_name, extension_type, base_object_name, added_fields, added_indexes,
+        added_methods, coc_methods, event_subscriptions, model)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  // form-extension with a CoC method + event subscription
+  insMeta.run('CustTable.ContosoForm_Extension', 'form-extension', 'CustTable',
+    null, null, null, '["init"]', '["onInitialized"]', 'Contoso');
+  // enum-extension
+  insMeta.run('NoYes.Contoso_Extension', 'enum-extension', 'NoYes',
+    null, null, null, null, null, 'Contoso');
+  // edt-extension
+  insMeta.run('AccountNum.Contoso_Extension', 'edt-extension', 'AccountNum',
+    null, null, null, null, null, 'Contoso');
+  // data-entity-extension
+  insMeta.run('CustomerEntity.Contoso_Extension', 'data-entity-extension', 'CustomerEntity',
+    null, null, null, null, null, 'Contoso');
+  // class-extension — the regression-critical one (CoC wrap + new method)
+  insMeta.run('SalesFormLetterContoso_Extension', 'class-extension', 'SalesFormLetter',
+    null, null, '["postJournal","helper"]', '["postJournal"]', null, 'Contoso');
+
+  // symbols-only fallback (no extension_metadata row) for a form extension
+  db.prepare(
+    'INSERT INTO symbols (name, type, model, extends_class) VALUES (?, ?, ?, ?)',
+  ).run('VendTable.Legacy_Extension', 'form-extension', 'LegacyModel', 'VendTable');
+
+  context = {
+    symbolIndex: {
+      getReadDb: () => db,
+    } as any,
+  } as XppServerContext;
+});
+
+afterAll(() => db.close());
+
+describe('get_object_info — extension types are registered', () => {
+  it('OBJECT_INFO_TYPES contains every extension type', () => {
+    for (const t of [
+      'table-extension', 'form-extension', 'enum-extension',
+      'edt-extension', 'data-entity-extension', 'class-extension',
+    ]) {
+      expect(OBJECT_INFO_TYPES).toContain(t);
+      expect(BATCH_INFO_TYPES).toContain(t);
+      expect(READER_DISPATCH[t]).toBeDefined();
+    }
+  });
+});
+
+describe('get_object_info — generic object-extension readers', () => {
+  it('returns a form extension from extension_metadata', async () => {
+    const text = await textOf('form-extension', 'CustTable');
+    expect(text).toContain('Form Extensions of: CustTable');
+    expect(text).toContain('CustTable.ContosoForm_Extension');
+    expect(text).toContain('Wraps Methods (CoC) (1): init');
+    expect(text).toContain('Event Subscriptions (1): onInitialized');
+  });
+
+  it('accepts a full extension name and strips the dot suffix to the base name', async () => {
+    const text = await textOf('form-extension', 'CustTable.AnythingHere');
+    expect(text).toContain('Form Extensions of: CustTable');
+    expect(text).toContain('CustTable.ContosoForm_Extension');
+  });
+
+  it('reads enum / edt / data-entity extensions with the right label', async () => {
+    expect(await textOf('enum-extension', 'NoYes')).toContain('Enum Extensions of: NoYes');
+    expect(await textOf('edt-extension', 'AccountNum')).toContain('EDT Extensions of: AccountNum');
+    expect(await textOf('data-entity-extension', 'CustomerEntity'))
+      .toContain('DataEntity Extensions of: CustomerEntity');
+  });
+
+  it('class-extension returns extension metadata (CoC + new methods), not base class info', async () => {
+    const text = await textOf('class-extension', 'SalesFormLetter');
+    expect(text).toContain('Class Extensions of: SalesFormLetter');
+    expect(text).toContain('SalesFormLetterContoso_Extension');
+    // CoC wrap surfaced
+    expect(text).toContain('Wraps Methods (CoC) (1): postJournal');
+    // "helper" is a genuinely new method (not a CoC wrap) → listed under Added Methods
+    expect(text).toContain('Added Methods (1): helper');
+    // must NOT have fallen through to the base-class reader
+    expect(text).not.toContain('# Class:');
+    expect(text).not.toContain('not found');
+  });
+
+  it('falls back to the symbols table when extension_metadata has no row', async () => {
+    const text = await textOf('form-extension', 'VendTable');
+    expect(text).toContain('VendTable.Legacy_Extension');
+    expect(text).toContain('LegacyModel');
+  });
+
+  it('reports an empty result cleanly for an unknown base object', async () => {
+    const text = await textOf('enum-extension', 'DoesNotExist');
+    expect(text).toContain('No enum-extension found in index for "DoesNotExist"');
+  });
+});


### PR DESCRIPTION
This pull request adds comprehensive support for retrieving information about various object extension types (such as form, enum, EDT, and data entity extensions) in addition to existing table extension support. It introduces a generic mechanism for handling these extension types, updates the object info registry to recognize and dispatch requests for them, and improves argument handling for extension lookups.

**Extension support and registry updates:**

* Added generic support for retrieving info about `form-extension`, `enum-extension`, `edt-extension`, and `data-entity-extension` objects, using a new shared implementation (`makeObjectExtensionTool`) in `tableExtensionInfo.ts`. This implementation queries both the `extension_metadata` and `symbols` tables, and generates rich output for each extension type.
* Updated the object info registry in `objectInfoRegistry.ts` to register the new extension info tools and to dispatch requests for these types. Also improved the argument handling for extension types to accept either the full extension name or just the base object name, automatically extracting the base name as needed. [[1]](diffhunk://#diff-b0a81254f3d1c30531a8b99fa8a7cf77f2fb08f5f01b77ce9a375c8ac5cabe4dL30-R30) [[2]](diffhunk://#diff-b0a81254f3d1c30531a8b99fa8a7cf77f2fb08f5f01b77ce9a375c8ac5cabe4dL62-R67)

**Schema and type list changes:**

* Expanded the `OBJECT_INFO_TYPES` array to include all new extension types, ensuring they are recognized as valid object types throughout the system.
* Updated the argument schema and description for extension types in `getObjectInfo.ts` to clarify that both the full extension name and base object name are accepted for lookups.