### PR TITLE
fix(find-references): scope method where-used to the declaring type

### DIFF
--- a/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
+++ b/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
@@ -83,10 +83,33 @@ namespace D365MetadataBridge.Services
         {
             var references = new List<ReferenceInfoModel>();
 
+            // Container segments that can own methods/fields, used to expand a
+            // member-qualified ("Owner.member") input across object types.
+            string[] memberContainers = { "Tables", "Classes", "Forms", "Views", "DataEntityViews", "Queries", "Maps" };
+
             var pathVariants = new List<string>();
+            bool memberQualified = false;
             if (objectPath.StartsWith("/"))
             {
+                // Explicit AOT path — use exactly as given (e.g. /Tables/SalesTable/Methods/initFromX).
                 pathVariants.Add(objectPath);
+                memberQualified = objectPath.Contains("/Methods/") || objectPath.Contains("/Fields/");
+            }
+            else if (objectPath.Contains("."))
+            {
+                // Member-qualified bare input ("Owner.member"): scope to a single
+                // method/field on its declaring type. We don't know whether Owner is
+                // a Table/Class/… so expand method+field variants across containers;
+                // only the path that actually exists will match.
+                memberQualified = true;
+                var dot = objectPath.LastIndexOf('.');
+                var owner = objectPath.Substring(0, dot);
+                var member = objectPath.Substring(dot + 1);
+                foreach (var c in memberContainers)
+                {
+                    pathVariants.Add($"/{c}/{owner}/Methods/{member}");
+                    pathVariants.Add($"/{c}/{owner}/Fields/{member}");
+                }
             }
             else
             {
@@ -100,11 +123,16 @@ namespace D365MetadataBridge.Services
                 pathVariants.Add($"/Forms/{objectPath}");
             }
 
-            // Also add sub-paths (methods, fields) so we catch method-level references
+            // Also add sub-paths (methods, fields) so we catch method-level references.
+            // A member-qualified target already points at an exact leaf path, so adding
+            // "/%" children would wrongly pull in unrelated nested references — skip it.
             var extraPaths = new List<string>();
-            foreach (var p in pathVariants)
+            if (!memberQualified)
             {
-                extraPaths.Add(p + "/%"); // LIKE pattern for children
+                foreach (var p in pathVariants)
+                {
+                    extraPaths.Add(p + "/%"); // LIKE pattern for children
+                }
             }
 
             // Build parameterized query with IN + LIKE

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -421,25 +421,53 @@ function countControls(controls: BridgeFormControl[]): number {
 // FIND REFERENCES
 // ════════════════════════════════════════════════════════════════════════
 
+/**
+ * Outcome of a bridge where-used lookup. The caller must distinguish a clean
+ * empty result (authoritative "no references") from an error or an unavailable
+ * bridge — in the latter cases falling back to the name-only FTS scan is right,
+ * but for a clean empty it must NOT (that would re-introduce the over-reporting).
+ */
+export type BridgeReferencesOutcome =
+  | { status: 'ok'; result: ToolResult }
+  | { status: 'empty' }
+  | { status: 'error' }
+  | { status: 'unavailable' };
+
 export async function tryBridgeReferences(
   bridge: BridgeClient | undefined,
   target: string | string[],
   limit = 50,
   displayName?: string,
-): Promise<ToolResult | null> {
-  if (!bridge?.isReady || !bridge.xrefAvailable) return null;
+): Promise<BridgeReferencesOutcome> {
+  if (!bridge?.isReady || !bridge.xrefAvailable) return { status: 'unavailable' };
   // Accept several candidate paths (e.g. one per container type when an owner
   // name collides across Tables/Classes) — query each and merge. Each source
   // reference targets a distinct path, so there are no cross-candidate dupes.
   const targets = Array.isArray(target) ? target : [target];
   const label = displayName ?? targets[0];
-  try {
-    const merged: BridgeReferenceInfo[] = [];
-    for (const t of targets) {
+
+  // Query each candidate independently: a failing one — a thrown RPC error or an
+  // in-band SQL error from the C# bridge (resolves with `error` set, count 0) —
+  // must not abort the others, and must be remembered so we never report a
+  // transient failure as an authoritative "0 references".
+  const merged: BridgeReferenceInfo[] = [];
+  let errored = false;
+  for (const t of targets) {
+    try {
       const r = await bridge.findReferences(t);
+      if (r?.error) errored = true;
       if (r?.references?.length) merged.push(...r.references);
+    } catch (e) {
+      errored = true;
+      console.error(`[BridgeAdapter] findReferences(${t}) failed: ${e}`);
     }
-    if (merged.length === 0) return null;
+  }
+
+  // No rows: "empty" is authoritative only when nothing went wrong; otherwise
+  // signal "error" so the caller falls back instead of trusting the 0.
+  if (merged.length === 0) return errored ? { status: 'error' } : { status: 'empty' };
+
+  {
     const refs = { count: merged.length, references: merged };
 
     let out = `# References to \`${label}\`\n\n`;
@@ -496,10 +524,7 @@ export async function tryBridgeReferences(
       out += `\n> ⚠️ Showing first ${limit} of ${refs.count} references.\n`;
     }
 
-    return { content: [{ type: 'text', text: out }] };
-  } catch (e) {
-    console.error(`[BridgeAdapter] findReferences(${label}) failed: ${e}`);
-    return null;
+    return { status: 'ok', result: { content: [{ type: 'text', text: out }] } };
   }
 }
 

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -34,6 +34,7 @@ import type {
   BridgeEventSubscriberResult,
   BridgeSmartTableResult,
   BridgeApiUsageCallersResult,
+  BridgeReferenceInfo,
 } from './bridgeTypes.js';
 
 /** Standard MCP tool response shape */
@@ -422,15 +423,26 @@ function countControls(controls: BridgeFormControl[]): number {
 
 export async function tryBridgeReferences(
   bridge: BridgeClient | undefined,
-  targetName: string,
+  target: string | string[],
   limit = 50,
+  displayName?: string,
 ): Promise<ToolResult | null> {
   if (!bridge?.isReady || !bridge.xrefAvailable) return null;
+  // Accept several candidate paths (e.g. one per container type when an owner
+  // name collides across Tables/Classes) — query each and merge. Each source
+  // reference targets a distinct path, so there are no cross-candidate dupes.
+  const targets = Array.isArray(target) ? target : [target];
+  const label = displayName ?? targets[0];
   try {
-    const refs = await bridge.findReferences(targetName);
-    if (!refs || refs.count === 0) return null;
+    const merged: BridgeReferenceInfo[] = [];
+    for (const t of targets) {
+      const r = await bridge.findReferences(t);
+      if (r?.references?.length) merged.push(...r.references);
+    }
+    if (merged.length === 0) return null;
+    const refs = { count: merged.length, references: merged };
 
-    let out = `# References to \`${targetName}\`\n\n`;
+    let out = `# References to \`${label}\`\n\n`;
     out += `**Total:** ${refs.count} reference(s) found\n`;
     out += `_Source: C# bridge (DYNAMICSXREFDB)_\n\n`;
 
@@ -486,7 +498,7 @@ export async function tryBridgeReferences(
 
     return { content: [{ type: 'text', text: out }] };
   } catch (e) {
-    console.error(`[BridgeAdapter] findReferences(${targetName}) failed: ${e}`);
+    console.error(`[BridgeAdapter] findReferences(${label}) failed: ${e}`);
     return null;
   }
 }

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -335,6 +335,8 @@ export interface BridgeReferenceResult {
   objectPath: string;
   count: number;
   references: BridgeReferenceInfo[];
+  /** Set by the C# bridge when the xref query failed in-band (e.g. SQL error) — count is 0 but this is NOT an authoritative "no references". */
+  error?: string;
 }
 
 export interface BridgeReferenceInfo {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -791,19 +791,23 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
         },
         {
           name: 'find_references',
-          description: 'Find all references (where-used) to a class, method, field, table, or enum across the entire codebase. Essential for impact analysis before refactoring.',
+          description: 'Find all references (where-used) to a class, method, field, table, or enum. Essential for impact analysis before refactoring. For a method, SCOPE it to its declaring type — pass "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable"), set ownerName alongside a bare method name, or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name (no owner) matches that name on every type and over-reports.',
           inputSchema: {
             type: 'object',
             properties: {
               targetName: {
                 type: 'string',
-                description: 'Name of the target (class name, method name, field name, etc.)'
+                description: 'Target name. Method where-used: qualify as "Owner.method" or pass an AOT path "/Tables/<Table>/Methods/<method>" for a result scoped to one declaring type (matches Visual Studio xref). A bare method name is name-only and over-reports.'
               },
               targetType: {
                 type: 'string',
                 enum: ['class', 'method', 'field', 'table', 'enum', 'edt', 'form', 'query', 'view', 'report', 'all'],
                 description: 'Type of the target to search for',
                 default: 'all'
+              },
+              ownerName: {
+                type: 'string',
+                description: 'Declaring table/class/form that owns the method, when targetName is the bare method name. Scopes the where-used to that single type.'
               },
               limit: {
                 type: 'number',

--- a/src/tools/findReferences.ts
+++ b/src/tools/findReferences.ts
@@ -23,8 +23,9 @@ const FindReferencesArgsSchema = z.object({
 
 /**
  * Map a symbol-index `type` value to its DYNAMICSXREFDB container segment.
- * Only types that can own methods are listed — these are the containers the
- * xref path "/<Container>/<Owner>/Methods/<method>" is built from.
+ * Only types that can own methods/fields are listed — these are the containers
+ * the xref path "/<Container>/<Owner>/<Methods|Fields>/<member>" is built from.
+ * Enums are intentionally absent: their values are not methods or fields here.
  */
 const TYPE_TO_XREF_CONTAINER: Record<string, string> = {
   table: 'Tables',
@@ -33,7 +34,6 @@ const TYPE_TO_XREF_CONTAINER: Record<string, string> = {
   query: 'Queries',
   view: 'Views',
   map: 'Maps',
-  enum: 'Enums',
   'data-entity': 'DataEntityViews',
 };
 
@@ -52,16 +52,17 @@ function resolveXrefContainers(db: any, ownerName: string): string[] {
 }
 
 /**
- * Authoritative "no references" result for a method-scoped lookup when the xref
- * bridge is available and returned nothing. We deliberately do NOT fall back to
- * the name-only FTS scan here — that scan pools callers of every same-named
- * method across all types, which is exactly the wrong answer for where-used.
+ * Authoritative "no references" result for a member-scoped lookup when the xref
+ * bridge is available and cleanly returned nothing. We deliberately do NOT fall
+ * back to the name-only FTS scan here — that scan pools callers of every
+ * same-named member across all types, which is exactly the wrong answer for
+ * where-used. (Reached only on a clean empty, never on a bridge error.)
  */
 function buildScopedEmptyResult(displayName: string, bridgeTargets: string[]): { content: Array<{ type: 'text'; text: string }> } {
   let out = `# References to \`${displayName}\`\n\n`;
   out += `**Total References Found:** 0\n`;
   out += `_Source: C# bridge (DYNAMICSXREFDB) — scoped to the declaring type_\n\n`;
-  out += `No callers found for this specific method.\n\n`;
+  out += `No callers found for this specific member.\n\n`;
   out += `Resolved xref path(s):\n`;
   for (const t of bridgeTargets) out += `- \`${t}\`\n`;
   out += `\n**If you expected results:** verify the owner type and method name, `;
@@ -105,36 +106,45 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
       owner ?? ((targetType === 'class' || targetType === 'method') ? memberName : null);
 
     const wantsMethod = !targetType || targetType === 'method' || targetType === 'all';
+    // Which AOT child segments to scope an "Owner.member" target to. A method
+    // lookup hits "/Methods/", a field lookup "/Fields/"; the default ("all" /
+    // unset) covers both, since we don't know whether the member is a method or
+    // field. Building only "/Methods/" (the original bug) made a field-qualified
+    // target return an authoritative — and wrong — "no callers".
+    const memberSegments: string[] = [];
+    if (wantsMethod) memberSegments.push('Methods');
+    if (!targetType || targetType === 'field' || targetType === 'all') memberSegments.push('Fields');
 
     // --- Build the bridge target(s) ------------------------------------------
-    // The DYNAMICSXREFDB bridge scopes a method to its declaring type ONLY when
-    // given a method-qualified path. A bare method name matches no object there
+    // The DYNAMICSXREFDB bridge scopes a member to its declaring type ONLY when
+    // given a member-qualified path. A bare member name matches no object there
     // and silently returns 0 — so when an owner is known we resolve its container
-    // type and build "/<Container>/<Owner>/Methods/<method>" before querying.
+    // type and build "/<Container>/<Owner>/<Methods|Fields>/<member>" before querying.
     let bridgeTargets: string[] = [cleanTargetName];
-    let methodScoped = false;
+    let memberScoped = false;
     if (isAotPath) {
-      methodScoped = cleanTargetName.includes('/Methods/');
-    } else if (owner && wantsMethod) {
+      memberScoped = cleanTargetName.includes('/Methods/') || cleanTargetName.includes('/Fields/');
+    } else if (owner && memberSegments.length > 0) {
       const containers = resolveXrefContainers(symbolIndex.getReadDb(), owner);
       bridgeTargets = containers.length > 0
-        ? containers.map(c => `/${c}/${owner}/Methods/${memberName}`)
+        ? containers.flatMap(c => memberSegments.map(seg => `/${c}/${owner}/${seg}/${memberName}`))
         // Owner not indexed — hand the qualified name to the bridge, which (when
-        // built with method-variant expansion) resolves it across container types.
+        // built with member-variant expansion) resolves it across container types.
         : [`${owner}.${memberName}`];
-      methodScoped = true;
+      memberScoped = true;
     }
 
     // Try C# bridge first (DYNAMICSXREFDB — live cross-references)
-    const bridgeResult = await tryBridgeReferences(context.bridge, bridgeTargets, limit, targetName);
-    if (bridgeResult) return bridgeResult;
+    const bridgeOutcome = await tryBridgeReferences(context.bridge, bridgeTargets, limit, targetName);
+    if (bridgeOutcome.status === 'ok') return bridgeOutcome.result;
 
-    // For a method-scoped lookup the xref bridge is authoritative: if it is
-    // available and returned nothing, report the empty scoped result rather than
-    // dropping to the name-only FTS scan below (which pools callers of every
-    // same-named method across all types — the original "25 references" bug).
-    const bridgeXrefUp = !!(context.bridge?.isReady && context.bridge?.xrefAvailable);
-    if (methodScoped && bridgeXrefUp) {
+    // For a member-scoped lookup the xref bridge is authoritative — but ONLY when
+    // it cleanly returned no rows ('empty'). On 'error' (RPC/SQL failure) or
+    // 'unavailable' we deliberately fall through to the FTS heuristic rather than
+    // report a confident "0 references" we can't actually stand behind. Reporting
+    // the empty scoped result here is what avoids the name-only FTS scan pooling
+    // callers of every same-named member across all types (the "25 references" bug).
+    if (memberScoped && bridgeOutcome.status === 'empty') {
       return buildScopedEmptyResult(targetName, bridgeTargets);
     }
 

--- a/src/tools/findReferences.ts
+++ b/src/tools/findReferences.ts
@@ -7,18 +7,67 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { buildObjectTypeMismatchMessage } from '../utils/metadataResolver.js';
+import { buildObjectTypeMismatchMessage, detectObjectTypeInDb } from '../utils/metadataResolver.js';
 import { tryBridgeReferences } from '../bridge/bridgeAdapter.js';
 
 const FindReferencesArgsSchema = z.object({
-  targetName: z.string().describe('Name of the target (class name, method name, field name, etc.)'),
+  targetName: z.string().describe('Name of the target. For a precise, type-scoped method where-used, qualify it as "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable") or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name matches that name on every type.'),
   targetType: z.enum(['method', 'class', 'table', 'field', 'enum', 'all']).optional().describe('Type of the target to search for'),
+  ownerName: z.string().optional().describe('Declaring table/class/form that owns the method, when targetName is just the bare method name. Used to scope the where-used to a single type (matches Visual Studio xref).'),
   scope: z.enum(['all', 'workspace', 'standard', 'custom']).optional().default('all').describe('Search scope'),
   limit: z.number().optional().default(50).describe('Maximum results to return'),
   // Default OFF: code-context snippets roughly quadruple the token cost of this tool.
   // Agents typically only need file:line:type — turn context on explicitly when you need snippets.
   includeContext: z.boolean().optional().default(false).describe('Include code context around reference (opt-in to reduce token usage)'),
 });
+
+/**
+ * Map a symbol-index `type` value to its DYNAMICSXREFDB container segment.
+ * Only types that can own methods are listed — these are the containers the
+ * xref path "/<Container>/<Owner>/Methods/<method>" is built from.
+ */
+const TYPE_TO_XREF_CONTAINER: Record<string, string> = {
+  table: 'Tables',
+  class: 'Classes',
+  form: 'Forms',
+  query: 'Queries',
+  view: 'Views',
+  map: 'Maps',
+  enum: 'Enums',
+  'data-entity': 'DataEntityViews',
+};
+
+/**
+ * Resolve which xref containers an owner name exists as (Tables/Classes/…).
+ * Usually one; returns several only when a name collides across object types.
+ */
+function resolveXrefContainers(db: any, ownerName: string): string[] {
+  const types = detectObjectTypeInDb(db, ownerName);
+  const containers = new Set<string>();
+  for (const { type } of types) {
+    const container = TYPE_TO_XREF_CONTAINER[type];
+    if (container) containers.add(container);
+  }
+  return [...containers];
+}
+
+/**
+ * Authoritative "no references" result for a method-scoped lookup when the xref
+ * bridge is available and returned nothing. We deliberately do NOT fall back to
+ * the name-only FTS scan here — that scan pools callers of every same-named
+ * method across all types, which is exactly the wrong answer for where-used.
+ */
+function buildScopedEmptyResult(displayName: string, bridgeTargets: string[]): { content: Array<{ type: 'text'; text: string }> } {
+  let out = `# References to \`${displayName}\`\n\n`;
+  out += `**Total References Found:** 0\n`;
+  out += `_Source: C# bridge (DYNAMICSXREFDB) — scoped to the declaring type_\n\n`;
+  out += `No callers found for this specific method.\n\n`;
+  out += `Resolved xref path(s):\n`;
+  for (const t of bridgeTargets) out += `- \`${t}\`\n`;
+  out += `\n**If you expected results:** verify the owner type and method name, `;
+  out += `or pass an explicit AOT path as \`targetName\` (e.g. \`/Classes/MyClass/Methods/myMethod\`).\n`;
+  return { content: [{ type: 'text', text: out }] };
+}
 
 interface Reference {
   file: string;
@@ -33,55 +82,98 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
   try {
     const args = FindReferencesArgsSchema.parse(request.params.arguments);
     const { symbolIndex } = context;
-    const { targetName, targetType, scope, limit, includeContext } = args;
+    const { targetName, targetType, scope, limit, includeContext, ownerName } = args;
 
-    // Try C# bridge first (DYNAMICSXREFDB — live cross-references)
-    const bridgeResult = await tryBridgeReferences(context.bridge, targetName, limit);
-    if (bridgeResult) return bridgeResult;
-
-    // --- Parse dotted notation (e.g. "SalesLineCopy.copy()" or "SalesLineCopy.copy") ---
-    // Extract parent object name so we can cross-check its actual type in the DB
-    let parentObjectName: string | null = null;
+    // --- Parse the target shape ----------------------------------------------
+    // Accept three forms:
+    //   1. AOT path        "/Tables/SalesTable/Methods/initFromSalesQuotationTable"
+    //   2. Owner-qualified "SalesTable.initFromSalesQuotationTable" (or ownerName + bare method)
+    //   3. Bare name       "initFromSalesQuotationTable" / "CustTable"
     const cleanTargetName = targetName.replace(/\(.*$/, '').trim(); // strip trailing parens
-    if (cleanTargetName.includes('.')) {
-      const parts = cleanTargetName.split('.');
-      parentObjectName = parts[0].trim() || null;
-    } else if (targetType === 'class' || targetType === 'method') {
-      // Also check the bare name itself when caller explicitly expects a class
-      parentObjectName = cleanTargetName;
+    const isAotPath = cleanTargetName.startsWith('/');
+
+    let owner: string | null = ownerName?.trim() || null;
+    let memberName = cleanTargetName;
+    if (!isAotPath && cleanTargetName.includes('.')) {
+      const dot = cleanTargetName.lastIndexOf('.');
+      owner = owner ?? (cleanTargetName.slice(0, dot).trim() || null);
+      memberName = cleanTargetName.slice(dot + 1).trim();
     }
 
-    // Build search patterns
+    // parentObjectName powers the cross-type ("you used a form name as a class") hint
+    const parentObjectName: string | null =
+      owner ?? ((targetType === 'class' || targetType === 'method') ? memberName : null);
+
+    const wantsMethod = !targetType || targetType === 'method' || targetType === 'all';
+
+    // --- Build the bridge target(s) ------------------------------------------
+    // The DYNAMICSXREFDB bridge scopes a method to its declaring type ONLY when
+    // given a method-qualified path. A bare method name matches no object there
+    // and silently returns 0 — so when an owner is known we resolve its container
+    // type and build "/<Container>/<Owner>/Methods/<method>" before querying.
+    let bridgeTargets: string[] = [cleanTargetName];
+    let methodScoped = false;
+    if (isAotPath) {
+      methodScoped = cleanTargetName.includes('/Methods/');
+    } else if (owner && wantsMethod) {
+      const containers = resolveXrefContainers(symbolIndex.getReadDb(), owner);
+      bridgeTargets = containers.length > 0
+        ? containers.map(c => `/${c}/${owner}/Methods/${memberName}`)
+        // Owner not indexed — hand the qualified name to the bridge, which (when
+        // built with method-variant expansion) resolves it across container types.
+        : [`${owner}.${memberName}`];
+      methodScoped = true;
+    }
+
+    // Try C# bridge first (DYNAMICSXREFDB — live cross-references)
+    const bridgeResult = await tryBridgeReferences(context.bridge, bridgeTargets, limit, targetName);
+    if (bridgeResult) return bridgeResult;
+
+    // For a method-scoped lookup the xref bridge is authoritative: if it is
+    // available and returned nothing, report the empty scoped result rather than
+    // dropping to the name-only FTS scan below (which pools callers of every
+    // same-named method across all types — the original "25 references" bug).
+    const bridgeXrefUp = !!(context.bridge?.isReady && context.bridge?.xrefAvailable);
+    if (methodScoped && bridgeXrefUp) {
+      return buildScopedEmptyResult(targetName, bridgeTargets);
+    }
+
+    // Build search patterns (FTS fallback — only reached when the xref bridge is
+    // unavailable). This is a name-based heuristic and cannot scope a method to
+    // its declaring type; match on the bare member name.
+    const ftsName = isAotPath
+      ? (cleanTargetName.split('/').pop() || cleanTargetName)
+      : memberName;
     const references: Reference[] = [];
     let totalReferences = 0;
 
     // 1. Search for method calls
     if (!targetType || targetType === 'method' || targetType === 'all') {
-      const methodRefs = findMethodReferences(symbolIndex, targetName, scope, limit);
+      const methodRefs = findMethodReferences(symbolIndex, ftsName, scope, limit);
       references.push(...methodRefs);
     }
 
     // 2. Search for class references (extends, implements, instantiations)
     if (!targetType || targetType === 'class' || targetType === 'all') {
-      const classRefs = findClassReferences(symbolIndex, targetName, scope, limit);
+      const classRefs = findClassReferences(symbolIndex, ftsName, scope, limit);
       references.push(...classRefs);
     }
 
     // 3. Search for table references (select statements, table buffers)
     if (!targetType || targetType === 'table' || targetType === 'all') {
-      const tableRefs = findTableReferences(symbolIndex, targetName, scope, limit);
+      const tableRefs = findTableReferences(symbolIndex, ftsName, scope, limit);
       references.push(...tableRefs);
     }
 
     // 4. Search for field references
     if (!targetType || targetType === 'field' || targetType === 'all') {
-      const fieldRefs = findFieldReferences(symbolIndex, targetName, scope, limit);
+      const fieldRefs = findFieldReferences(symbolIndex, ftsName, scope, limit);
       references.push(...fieldRefs);
     }
 
     // 5. Search for enum references
     if (!targetType || targetType === 'enum' || targetType === 'all') {
-      const enumRefs = findEnumReferences(symbolIndex, targetName, scope, limit);
+      const enumRefs = findEnumReferences(symbolIndex, ftsName, scope, limit);
       references.push(...enumRefs);
     }
 
@@ -99,7 +191,12 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
     if (targetType) {
       output += `**Target Type:** ${targetType}\n`;
     }
-    output += `**Scope:** ${scope}\n\n`;
+    output += `**Scope:** ${scope}\n`;
+    output += `_Source: name-based index scan (xref bridge unavailable) — heuristic; not scoped to a declaring type._\n`;
+    if (wantsMethod && !owner && !isAotPath) {
+      output += `> ℹ️ This counts every method named \`${ftsName}\` regardless of owner. For a type-scoped where-used, pass \`ownerName\` or qualify as \`Owner.${ftsName}\`.\n`;
+    }
+    output += `\n`;
 
     // Cross-type check: detect when the caller used a form/table/view name as if it were a class
     const typeMismatchSection = parentObjectName

--- a/tests/tools/discovery.test.ts
+++ b/tests/tools/discovery.test.ts
@@ -243,4 +243,80 @@ describe('find_references', () => {
     const result = await findReferencesTool(req('find_references', {}), ctx);
     expect(result.isError).toBe(true);
   });
+
+  // ─── method scoping (the SalesTable.initFromSalesQuotationTable bug) ────────
+
+  const stubDbType = (c: XppServerContext, type: string) => {
+    (c.symbolIndex.db as any).prepare = vi.fn(() => ({
+      all: vi.fn(() => [{ type, model: 'ApplicationSuite' }]),
+      get: vi.fn(() => undefined),
+    }));
+  };
+
+  const makeXrefBridge = (refs: any[]) => ({
+    isReady: true,
+    metadataAvailable: true,
+    xrefAvailable: true,
+    findReferences: vi.fn(async (path: string) => ({ objectPath: path, count: refs.length, references: refs })),
+  });
+
+  it('scopes "Owner.method" to the declaring type via the xref bridge', async () => {
+    stubDbType(ctx, 'table'); // SalesTable resolves to a Table container
+    const bridge = makeXrefBridge([
+      { sourcePath: '/Classes/Foo/Methods/bar', sourceModule: 'App', line: 10, column: 1, referenceType: 'call', callerClass: 'Foo', callerMethod: 'bar' },
+    ]);
+    ctx.bridge = bridge as any;
+
+    const result = await findReferencesTool(
+      req('find_references', { targetName: 'SalesTable.initFromSalesQuotationTable', targetType: 'method' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(bridge.findReferences).toHaveBeenCalledWith('/Tables/SalesTable/Methods/initFromSalesQuotationTable');
+    expect(result.content[0].text).toMatch(/DYNAMICSXREFDB/);
+  });
+
+  it('accepts ownerName to scope a bare method name', async () => {
+    stubDbType(ctx, 'class');
+    const bridge = makeXrefBridge([
+      { sourcePath: '/Classes/Caller/Methods/run', line: 5, column: 1, referenceType: 'call', callerClass: 'Caller', callerMethod: 'run' },
+    ]);
+    ctx.bridge = bridge as any;
+
+    const result = await findReferencesTool(
+      req('find_references', { targetName: 'run', ownerName: 'SalesFormLetter', targetType: 'method' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(bridge.findReferences).toHaveBeenCalledWith('/Classes/SalesFormLetter/Methods/run');
+  });
+
+  it('reports an authoritative empty scoped result instead of pooling via FTS', async () => {
+    stubDbType(ctx, 'table');
+    const bridge = makeXrefBridge([]); // bridge up, but no callers for THIS method
+    ctx.bridge = bridge as any;
+
+    const result = await findReferencesTool(
+      req('find_references', { targetName: 'SalesTable.someUnusedMethod', targetType: 'method' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/scoped to the declaring type/i);
+    expect(result.content[0].text).toMatch(/0/);
+  });
+
+  it('flags the name-only heuristic when a bare method name is used without the bridge', async () => {
+    // No bridge configured → FTS fallback path
+    const result = await findReferencesTool(
+      req('find_references', { targetName: 'initFromSalesQuotationTable', targetType: 'method' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/heuristic|name-based/i);
+    expect(result.content[0].text).toMatch(/ownerName|qualify/i);
+  });
 });

--- a/tests/tools/discovery.test.ts
+++ b/tests/tools/discovery.test.ts
@@ -319,4 +319,80 @@ describe('find_references', () => {
     expect(result.content[0].text).toMatch(/heuristic|name-based/i);
     expect(result.content[0].text).toMatch(/ownerName|qualify/i);
   });
+
+  it('falls back to the heuristic (not an authoritative empty) when the xref bridge errors', async () => {
+    stubDbType(ctx, 'table');
+    // Bridge is up but the lookup throws (RPC/SQL failure) — must NOT be reported
+    // as a confident "0 references scoped to the declaring type".
+    ctx.bridge = {
+      isReady: true,
+      metadataAvailable: true,
+      xrefAvailable: true,
+      findReferences: vi.fn(async () => { throw new Error('SQL connection lost'); }),
+    } as any;
+
+    const result = await findReferencesTool(
+      req('find_references', { targetName: 'SalesTable.initFromSalesQuotationTable', targetType: 'method' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).not.toMatch(/scoped to the declaring type/i);
+    expect(result.content[0].text).toMatch(/heuristic|name-based/i);
+  });
+
+  it('treats an in-band bridge error result as a failure, not an authoritative empty', async () => {
+    stubDbType(ctx, 'table');
+    // C# bridge resolves with count 0 but an `error` field set (e.g. SQL error).
+    ctx.bridge = {
+      isReady: true,
+      metadataAvailable: true,
+      xrefAvailable: true,
+      findReferences: vi.fn(async (path: string) => ({ objectPath: path, count: 0, references: [], error: 'SQL timeout' })),
+    } as any;
+
+    const result = await findReferencesTool(
+      req('find_references', { targetName: 'SalesTable.initFromSalesQuotationTable', targetType: 'method' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).not.toMatch(/scoped to the declaring type/i);
+    expect(result.content[0].text).toMatch(/heuristic|name-based/i);
+  });
+
+  it('scopes a field-qualified target to "/Fields/" on the declaring type', async () => {
+    stubDbType(ctx, 'table');
+    const bridge = makeXrefBridge([
+      { sourcePath: '/Classes/Foo/Methods/bar', line: 3, column: 1, referenceType: 'field-access', callerClass: 'Foo', callerMethod: 'bar' },
+    ]);
+    ctx.bridge = bridge as any;
+
+    const result = await findReferencesTool(
+      req('find_references', { targetName: 'CustTable.AccountNum', targetType: 'field' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(bridge.findReferences).toHaveBeenCalledWith('/Tables/CustTable/Fields/AccountNum');
+  });
+
+  it('builds both Methods and Fields variants for a member-qualified target with the default type', async () => {
+    stubDbType(ctx, 'table');
+    const bridge = makeXrefBridge([
+      { sourcePath: '/Classes/Foo/Methods/bar', line: 3, column: 1, referenceType: 'field-access', callerClass: 'Foo', callerMethod: 'bar' },
+    ]);
+    ctx.bridge = bridge as any;
+
+    // No targetType → don't yet know if AccountNum is a method or a field; both
+    // path variants must be queried so a field-qualified target still resolves.
+    const result = await findReferencesTool(
+      req('find_references', { targetName: 'CustTable.AccountNum' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(bridge.findReferences).toHaveBeenCalledWith('/Tables/CustTable/Methods/AccountNum');
+    expect(bridge.findReferences).toHaveBeenCalledWith('/Tables/CustTable/Fields/AccountNum');
+  });
 });


### PR DESCRIPTION
## Issue
`find_references` for a method returned callers of *every* same-named method across all types (e.g. 25 for `initFromSalesQuotationTable`) instead of only the one declared on the target type (7, matching Visual Studio's xref).

The DYNAMICSXREFDB bridge can scope to a single type, but only when handed a method-qualified path. A bare method name matched no object there, returned 0, and the tool silently fell back to a name-only FTS scan that pools all same-named methods.

## Fix
- **`findReferences`**: accept `Owner.method`, a new `ownerName` param, or a raw AOT path; resolve the owner's container type from the index and query the bridge with `/<Container>/<Owner>/Methods/<method>`. When the xref bridge is available but the scoped lookup is empty, report that authoritatively instead of pooling via FTS. The FTS fallback (bridge-down only) is labelled heuristic and nudges toward owner scoping.
- **`bridgeAdapter.tryBridgeReferences`**: accept multiple candidate paths (owner name colliding across containers) plus a display label; merge results.
- **`CrossReferenceService.FindReferences`** (C# bridge): expand a member-qualified bare input (`Owner.member`) into method + field path variants across container types, and skip the `/%` child expansion for exact leaf paths.
- **`mcpServer`**: document the qualified-target shapes on the tool description + `ownerName`.
