### PR TITLE
fix(write-path): route custom model writes to D365FO_CUSTOM_PACKAGES_PATH

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -3689,20 +3689,20 @@ export async function handleCreateD365File(
     let basePath: string;
     let resolvedPackageName: string;
 
+    // Resolve the custom write root (D365FO_CUSTOM_PACKAGES_PATH).
+    // Applies in both UDE and traditional mode — it always points to the repo
+    // working tree where custom model XML lives, regardless of dev env type.
+    const customWritePath = await configManager.getCustomPackagesPath();
+
     if (args.packageName) {
       // Explicit packageName always wins, regardless of environment type
       resolvedPackageName = args.packageName;
-      if (envType === 'ude') {
-        const customPath = await configManager.getCustomPackagesPath();
-        basePath = customPath || args.packagePath || configPackagePath || fallbackPackagePath();
-      } else {
-        basePath = args.packagePath || configPackagePath || fallbackPackagePath();
-      }
+      // Custom write root beats the MS PLD for explicit packageName calls too.
+      basePath = args.packagePath || customWritePath || configPackagePath || fallbackPackagePath();
     } else if (envType === 'ude') {
-      // UDE mode: auto-resolve package name via descriptor scan
-      const customPath = await configManager.getCustomPackagesPath();
+      // UDE mode: auto-resolve package name via descriptor scan across both roots
       const msPath = await configManager.getMicrosoftPackagesPath();
-      const roots = [customPath, msPath].filter(Boolean) as string[];
+      const roots = [customWritePath, msPath].filter(Boolean) as string[];
 
       const resolver = new PackageResolver(roots);
       const resolved = await resolver.resolve(actualModelName);
@@ -3713,19 +3713,22 @@ export async function handleCreateD365File(
       } else {
         // Fallback: assume package == model (common case)
         resolvedPackageName = actualModelName;
-        basePath = customPath || args.packagePath || configPackagePath || fallbackPackagePath();
+        basePath = customWritePath || args.packagePath || configPackagePath || fallbackPackagePath();
       }
     } else {
-      // Traditional mode without explicit packageName: assume package == model
+      // Traditional mode: assume package == model.
+      // Prefer the custom write root over D365FO_PACKAGE_PATH so custom model
+      // XML lands in the repo working tree rather than the MS PackagesLocalDirectory.
       resolvedPackageName = actualModelName;
       basePath =
         args.packagePath ||
+        customWritePath ||
         configPackagePath ||
         fallbackPackagePath();
     }
 
     console.error(
-      `[create_d365fo_file] Environment: ${envType}, Package: ${resolvedPackageName}, Model: ${actualModelName}`,
+      `[create_d365fo_file] Environment: ${envType}, Package: ${resolvedPackageName}, Model: ${actualModelName}, BasePath: ${basePath}`,
     );
 
     const modelPath = path.join(

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1249,7 +1249,29 @@ export async function findD365FileOnDisk(
   const configPackagePath =
     configManager.getPackagePath() || fallbackPackagePath();
 
-  // Traditional mode: package name == model name (most common case)
+  // Resolve the custom write root (D365FO_CUSTOM_PACKAGES_PATH).
+  // Try this before the MS PLD so we find repo-tracked objects first.
+  const customWritePath = await configManager.getCustomPackagesPath();
+
+  // Candidate 1: custom write root, package == model (most common for custom models)
+  if (customWritePath) {
+    const customCandidatePath = path.join(
+      customWritePath,
+      resolvedModel,
+      resolvedModel,
+      objectFolder,
+      `${objectName}.xml`
+    );
+    try {
+      await fs.access(customCandidatePath);
+      console.error(`[modifyD365File] Found via custom packages path: ${customCandidatePath}`);
+      return customCandidatePath;
+    } catch {
+      // Not at custom path; continue
+    }
+  }
+
+  // Candidate 2: MS PLD / configured packagePath, package == model (traditional fallback)
   const candidatePath = path.join(
     configPackagePath,
     resolvedModel,
@@ -1263,37 +1285,35 @@ export async function findD365FileOnDisk(
     console.error(`[modifyD365File] Found via filesystem fallback: ${candidatePath}`);
     return candidatePath;
   } catch {
-    // Not at the default package==model path; try UDE layout
+    // Not at the default package==model path; try PackageResolver (UDE or custom layout)
   }
 
-  // UDE mode: package name may differ from model name — use PackageResolver
+  // Candidate 3: PackageResolver scan — handles package != model layouts in both UDE
+  // and traditional setups with a custom root
   try {
     const envType = await configManager.getDevEnvironmentType();
-    if (envType === 'ude') {
-      const customPath = await configManager.getCustomPackagesPath();
-      const msPath = await configManager.getMicrosoftPackagesPath();
-      const roots = [customPath, msPath].filter(Boolean) as string[];
-      const resolver = new PackageResolver(roots);
-      const resolved = await resolver.resolve(resolvedModel);
-      if (resolved) {
-        const udePath = path.join(
-          resolved.rootPath,
-          resolved.packageName,
-          resolvedModel,
-          objectFolder,
-          `${objectName}.xml`
-        );
-        try {
-          await fs.access(udePath);
-          console.error(`[modifyD365File] Found via UDE filesystem fallback: ${udePath}`);
-          return udePath;
-        } catch {
-          // Not found at UDE path either
-        }
+    const msPath = envType === 'ude' ? await configManager.getMicrosoftPackagesPath() : null;
+    const roots = [customWritePath, msPath, configPackagePath].filter(Boolean) as string[];
+    const resolver = new PackageResolver(roots);
+    const resolved = await resolver.resolve(resolvedModel);
+    if (resolved) {
+      const resolvedPath = path.join(
+        resolved.rootPath,
+        resolved.packageName,
+        resolvedModel,
+        objectFolder,
+        `${objectName}.xml`
+      );
+      try {
+        await fs.access(resolvedPath);
+        console.error(`[modifyD365File] Found via PackageResolver: ${resolvedPath}`);
+        return resolvedPath;
+      } catch {
+        // Not found at resolved path either
       }
     }
   } catch {
-    // UDE resolution failed — skip silently
+    // PackageResolver failed — skip silently
   }
 
   return null;

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -317,8 +317,12 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           }
         }
 
-        const { modelName, modelSource, isModelSourceAutoDetected, projectPath, projectSource, packagePath, packageSource } =
-          await configManager.getWorkspaceInfoDiagnostics();
+        const {
+          modelName, modelSource, isModelSourceAutoDetected,
+          projectPath, projectSource,
+          packagePath, packageSource,
+          customPackagesPath, customPackagesSource,
+        } = await configManager.getWorkspaceInfoDiagnostics();
         const envType = await configManager.getDevEnvironmentType();
         const frameworkDirectory = await configManager.getMicrosoftPackagesPath();
 
@@ -353,12 +357,22 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           ? !isCustomModel(modelName) && !isPlaceholder && isAutoDetectedSource
           : false;
 
+        // Determine the effective custom write root for display and freshness check.
+        // Precedence: D365FO_CUSTOM_PACKAGES_PATH > D365FO_PACKAGE_PATH (read-only MS root).
+        const effectiveWritePath = customPackagesPath ?? packagePath;
+        const effectiveWriteSource = customPackagesPath ? customPackagesSource : packageSource;
+
+        // The MS framework path shown in diagnostics: prefer the explicit
+        // D365FO_MICROSOFT_PACKAGES_PATH; fall back to the bridge frameworkDirectory;
+        // in a single-root traditional setup neither is set so omit the line.
+        const msFrameworkPath = frameworkDirectory ?? (!customPackagesPath ? null : packagePath);
+
         const lines: string[] = [
           `## D365FO Workspace Configuration`,
           ``,
           `Model name      : ${modelName ?? '(not configured)'}  (source: ${modelSource})`,
-          `Package path    : ${packagePath ?? '(not configured)'}  (custom metadata, source: ${packageSource})`,
-          `Framework dir   : ${frameworkDirectory ?? '(not applicable — single-root setup)'}  (Microsoft metadata, read-only)`,
+          `Custom write path: ${effectiveWritePath ?? '(not configured)'}  (custom metadata, source: ${effectiveWriteSource})`,
+          `Framework dir   : ${msFrameworkPath ?? '(not applicable — single-root setup)'}  (Microsoft metadata, read-only)`,
           `Project path    : ${projectPath ?? '(not detected)'}  (source: ${projectSource})`,
           `Env type        : ${envType}`,
           ``,
@@ -479,8 +493,8 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         // -----------------------------------------------------------------------
         try {
           const lastIndexedAt = context.symbolIndex.getLastIndexedAt?.() ?? null;
-          const modelMetadataDir = packagePath && modelName
-            ? nodePath.join(packagePath, modelName)
+          const modelMetadataDir = effectiveWritePath && modelName
+            ? nodePath.join(effectiveWritePath, modelName)
             : null;
           const staleness = checkIndexStaleness(lastIndexedAt, modelMetadataDir);
           lines.push('', ...staleness.lines);

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -916,6 +916,8 @@ class ConfigManager {
     projectSource: string;
     packagePath: string | null;
     packageSource: string;
+    customPackagesPath: string | null;
+    customPackagesSource: string;
   }> {
     // Ensure config is loaded and auto-detection has had a chance to run
     await this.ensureLoaded();
@@ -961,13 +963,23 @@ class ConfigManager {
       projectSource = 'auto-detected from .rnrproj';
     }
 
-    // Package path
+    // Package path (MS framework / standard packages — read-only reference root)
     const packagePath = this.getPackagePath();
     let packageSource = '(not configured)';
 
     const context = this.getContext();
+    const fileContext = this.config?.context || this.config?.servers?.context || null;
+
     if (context?.packagePath) {
-      packageSource = '.mcp.json';
+      // getContext() merges env vars with higher priority than .mcp.json.
+      // Report the actual source so diagnostics don't mislead the developer.
+      if (process.env.D365FO_PACKAGE_PATH?.trim()) {
+        packageSource = 'D365FO_PACKAGE_PATH env var';
+      } else if (fileContext?.packagePath) {
+        packageSource = '.mcp.json';
+      } else {
+        packageSource = 'env var';
+      }
     } else if (context?.workspacePath && /PackagesLocalDirectory/i.test(context.workspacePath)) {
       packageSource = 'workspacePath';
     } else if (this.autoDetectedProject?.packagePath) {
@@ -976,8 +988,28 @@ class ConfigManager {
       packageSource = 'well-known path probe';
     }
 
+    // Custom write path (D365FO_CUSTOM_PACKAGES_PATH / customPackagesPath in context)
+    // — this is the repo working tree where custom model XML is written and tracked by git.
+    const customPackagesPath = await this.getCustomPackagesPath();
+    let customPackagesSource = '(not configured)';
+
+    if (customPackagesPath) {
+      if (process.env.D365FO_CUSTOM_PACKAGES_PATH?.trim()) {
+        customPackagesSource = 'D365FO_CUSTOM_PACKAGES_PATH env var';
+      } else if (fileContext?.customPackagesPath) {
+        customPackagesSource = '.mcp.json';
+      } else {
+        customPackagesSource = 'XPP config auto-detection';
+      }
+    }
+
     const isModelSourceAutoDetected = modelSource.includes('auto-detected');
-    return { modelName, modelSource, isModelSourceAutoDetected, projectPath, projectSource, packagePath, packageSource };
+    return {
+      modelName, modelSource, isModelSourceAutoDetected,
+      projectPath, projectSource,
+      packagePath, packageSource,
+      customPackagesPath, customPackagesSource,
+    };
   }
 
   /**

--- a/tests/utils/configManager.test.ts
+++ b/tests/utils/configManager.test.ts
@@ -417,3 +417,66 @@ describe('isStaticallyConfigured', () => {
     delete process.env.D365FO_MODEL_NAME;
   });
 });
+
+// ─── getWorkspaceInfoDiagnostics — provenance labels ─────────────────────────
+
+describe('getWorkspaceInfoDiagnostics provenance', () => {
+  beforeEach(() => {
+    vi.stubEnv('DEV_ENVIRONMENT_TYPE', '');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('labels packageSource as env var when D365FO_PACKAGE_PATH is set', async () => {
+    process.env.D365FO_PACKAGE_PATH = 'K:\\AosService\\PackagesLocalDirectory';
+    const mgr = makeManager({});
+    (mgr as any).xppConfigLoaded = true;
+    (mgr as any).xppConfig = null;
+
+    const diag = await mgr.getWorkspaceInfoDiagnostics();
+    expect(diag.packageSource).toBe('D365FO_PACKAGE_PATH env var');
+    delete process.env.D365FO_PACKAGE_PATH;
+  });
+
+  it('labels packageSource as .mcp.json when packagePath comes from file config only', async () => {
+    const mgr = makeManager({ packagePath: 'K:\\AosService\\PackagesLocalDirectory' });
+    (mgr as any).xppConfigLoaded = true;
+    (mgr as any).xppConfig = null;
+
+    const diag = await mgr.getWorkspaceInfoDiagnostics();
+    expect(diag.packageSource).toBe('.mcp.json');
+  });
+
+  it('returns customPackagesPath and its source from env var', async () => {
+    process.env.D365FO_CUSTOM_PACKAGES_PATH = 'C:\\repos\\MyProject\\src\\Metadata';
+    const mgr = makeManager({});
+    (mgr as any).xppConfigLoaded = true;
+    (mgr as any).xppConfig = null;
+
+    const diag = await mgr.getWorkspaceInfoDiagnostics();
+    expect(diag.customPackagesPath).toBe('C:\\repos\\MyProject\\src\\Metadata');
+    expect(diag.customPackagesSource).toBe('D365FO_CUSTOM_PACKAGES_PATH env var');
+    delete process.env.D365FO_CUSTOM_PACKAGES_PATH;
+  });
+
+  it('returns customPackagesPath and its source from .mcp.json', async () => {
+    const mgr = makeManager({ customPackagesPath: 'C:\\repos\\MyProject\\src\\Metadata' });
+    (mgr as any).xppConfigLoaded = true;
+    (mgr as any).xppConfig = null;
+
+    const diag = await mgr.getWorkspaceInfoDiagnostics();
+    expect(diag.customPackagesPath).toBe('C:\\repos\\MyProject\\src\\Metadata');
+    expect(diag.customPackagesSource).toBe('.mcp.json');
+  });
+
+  it('returns null customPackagesPath when neither env var nor config is set', async () => {
+    const mgr = makeManager({});
+    (mgr as any).xppConfigLoaded = true;
+    (mgr as any).xppConfig = null;
+
+    const diag = await mgr.getWorkspaceInfoDiagnostics();
+    expect(diag.customPackagesPath).toBeNull();
+    expect(diag.customPackagesSource).toBe('(not configured)');
+  });
+});


### PR DESCRIPTION
Previously, d365fo_file create/modify targeted D365FO_PACKAGE_PATH (the Microsoft PackagesLocalDirectory) for custom models in traditional mode and as a fallback in UDE mode, so new XML never reached the repo working tree.

The commit `bb8ccda` fixed the **bridge initialization** in `index.ts` — but didn't fix the **file write path** in `createD365File.ts`. So the bridge correctly used the custom path for reading/resolving objects, but `create` was still computing `basePath` separately and could end up using the MS PLD.

**The timeline:**

1. **Before `bb8ccda`** — everything was broken: bridge pointed to MS PLD, writes went to MS PLD. I could write files correctly because I were probably using an older setup without the split paths.

2. **I changed my `.env`** — added `D365FO_CUSTOM_PACKAGES_PATH` (separating the two paths). This is when it broke for me. Before that change, `D365FO_PACKAGE_PATH` and the custom path were the same directory (or the custom path wasn't set), so writes accidentally landed in the right place.

3. **`bb8ccda`** fixed the bridge/read side — resolving model objects worked again.

4. **this fix ** — closes the remaining gap: the write side (`create`/`modify`) now also checks `customWritePath` before falling back to `configPackagePath`.



Changes:
- createD365File: resolve customWritePath upfront; prefer it over configPackagePath in all three branches (explicit packageName, UDE, and traditional), not just inside the UDE else-if.
- modifyD365File / findD365FileOnDisk: check the custom write root first, then the MS PLD, then PackageResolver — eliminates the need to fall into UDE-specific code for custom models on traditional setups.
- configManager.getWorkspaceInfoDiagnostics: add customPackagesPath / customPackagesSource to the return; fix packageSource provenance label (was ".mcp.json" even when value came from D365FO_PACKAGE_PATH env var).
- toolHandler / get_workspace_info: rename "Package path (custom metadata)" to "Custom write path"; use effectiveWritePath (custom > MS PLD) for the index-freshness check; fix "Framework dir" to show the MS packages path separately from the write root.
- Tests: 5 new provenance-label assertions in configManager.test.ts.

Before:
In UDE the MCP reported wrong custom path and wrote new files to MS packageslocaldirectory and not to custom model directory as it should in UDE configuration.

Both fixes are confirmed working in my specific configuration only:
get_workspace_info now correctly shows Custom write path: \path\src\Metadata with provenance D365FO_CUSTOM_PACKAGES_PATH env var, and the MS PackagesLocalDirectory as read-only Framework dir.
d365fo_file create writes to ...\src\Metadata\model\model\AxClass\... — the repo working tree — not PackagesLocalDirectory.

