### PR TITLE
test(loadEnv): derive Windows drive letter from cwd

### DIFF
--- a/tests/utils/loadEnv.test.ts
+++ b/tests/utils/loadEnv.test.ts
@@ -60,10 +60,13 @@ afterEach(() => {
 
 // Simulate a caller at /repo/src/index.ts → callerDir = /repo/src
 // Default envPath resolves to /repo/src/../.env = /repo/.env
-// On Windows, file URLs require a drive letter — use C:/repo to keep the
-// path.resolve('/repo/...') expectations consistent (same drive root).
+// On Windows, file URLs require a drive letter, and path.resolve('/repo/...')
+// resolves against the *current working directory's* drive — which is not
+// necessarily C:. Derive the drive from process.cwd() so the URL-based path
+// and the path.resolve(...) expectations always share the same drive root.
+const WIN_DRIVE = process.cwd().slice(0, 1);
 const FAKE_CALLER_URL = process.platform === 'win32'
-  ? 'file:///C:/repo/src/index.ts'
+  ? `file:///${WIN_DRIVE}:/repo/src/index.ts`
   : 'file:///repo/src/index.ts';
 const REPO_ROOT_ENV = path.resolve('/repo/.env');
 


### PR DESCRIPTION
The loadEnv test hardcoded C: in the fake caller URL, but path.resolve('/repo/...') on Windows resolves against the current working directory's drive. Running from another drive (e.g. K:) caused a C: vs K: mismatch and 5 failing tests. Derive the drive from process.cwd() so expectations match regardless of drive.