### PR TITLE
fix: address MCP server feedback across labels/d365fo_file/strategy t…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,30 @@ async function initializeBridge(targetContext: import('./types/context.js').XppS
         referencePackagesPath = msPath;
       }
     } else {
-      packagesPath = configMgr.getPackagePath() ?? undefined;
+      // Traditional: the MS PackagesLocalDirectory is the canonical metadata root.
+      const pldPath = configMgr.getPackagePath() ?? undefined;
+      // A custom metadata root — e.g. a repo checkout configured via
+      // context.customPackagesPath / D365FO_CUSTOM_PACKAGES_PATH — may hold the
+      // model being edited. If it differs from the PLD, make it the PRIMARY
+      // provider and keep the PLD as the reference provider so BOTH custom and
+      // Microsoft-shipped objects resolve. Without this, modify/create via the
+      // bridge can't find objects whose metadata lives outside the PLD (the
+      // bridge resolves objects by its configured roots, not per-call paths).
+      const customPath = await configMgr.getCustomPackagesPath();
+      const { existsSync } = await import('fs');
+      const { join, resolve } = await import('path');
+      const samePath = (a?: string, b?: string) =>
+        !!a && !!b && resolve(a).toLowerCase() === resolve(b).toLowerCase();
+      if (customPath && existsSync(customPath) && !samePath(customPath, pldPath)) {
+        packagesPath = customPath;
+        if (pldPath) {
+          referencePackagesPath = pldPath;
+          const candidate = join(pldPath, 'bin');
+          if (existsSync(candidate)) binPath = candidate;
+        }
+      } else {
+        packagesPath = pldPath;
+      }
     }
 
     // Pass xref connection details for UDE environments

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -3354,6 +3354,26 @@ export class XppSymbolIndex {
   }
 
   /**
+   * Get the physical .label.txt file path for each language of a label file.
+   * Used by labels(action="info", labelFileId=…) so callers get the on-disk
+   * location per language instead of having to shell out to find it.
+   */
+  getLabelFilePaths(
+    labelFileId: string,
+    model?: string,
+  ): Array<{ language: string; filePath: string; model: string }> {
+    const params: any[] = [labelFileId];
+    let sql = `
+      SELECT DISTINCT language, file_path AS filePath, model
+      FROM labels
+      WHERE label_file_id = ? AND file_path IS NOT NULL AND file_path != ''
+    `;
+    if (model) { sql += ` AND model = ?`; params.push(model); }
+    sql += ` ORDER BY language`;
+    return this.labelsDb.prepare(sql).all(...params) as any[];
+  }
+
+  /**
    * Remove all labels for the given models (used during incremental rebuild)
    */
   clearLabelsForModels(models: string[]): void {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -561,7 +561,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               },
               packagePath: {
                 type: 'string',
-                description: 'Base package path (default: K:\\AosService\\PackagesLocalDirectory)'
+                description: 'Base package path (default: K:\\AosService\\PackagesLocalDirectory). Also used by [modify] to locate objects whose metadata lives outside the default PackagesLocalDirectory (e.g. a repo checkout). Note: bridge-backed modify operations resolve objects via the C# bridge\'s startup roots — if the model is outside them, set context.customPackagesPath / D365FO_CUSTOM_PACKAGES_PATH instead, or pass an explicit filePath.'
               },
               sourceCode: {
                 type: 'string',
@@ -875,7 +875,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
           description:
             'Unified label operations — read and write. Choose an `action`:\n' +
             '• search → full-text query across indexed label files (read). Always run before action=create.\n' +
-            '• info → all language translations for a labelId, OR list available label files when labelId is omitted (read).\n' +
+            '• info → all language translations for a labelId, OR list available label files when labelId is omitted. Pass labelFileId (without labelId) to get that label file plus the physical .label.txt path per language (read).\n' +
             '• create → add a new label to an AxLabelFile, write into every language .label.txt, create XML descriptors if missing (write). Label IDs describe MEANING — never add a model prefix.\n' +
             '• rename → rename a label ID across .label.txt + X++ + XML metadata + SQLite index. Use dryRun=true first (write).',
           inputSchema: {
@@ -893,7 +893,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               },
               labelFileId: {
                 type: 'string',
-                description: '[search|info|create|rename] AxLabelFile ID (e.g. ContosoExt, SYS).',
+                description: '[search|info|create|rename] AxLabelFile ID (e.g. ContosoExt, SYS). For action=info with no labelId, returns the physical .label.txt path per language.',
               },
               language: {
                 type: 'string',
@@ -1195,11 +1195,11 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             },
             scenario: {
               type: 'string',
-              enum: ['data-validation', 'field-defaulting', 'business-logic-change',
+              enum: ['data-validation', 'field-defaulting', 'field-change-reaction', 'business-logic-change',
                      'outbound-integration', 'inbound-data', 'ui-modification',
                      'document-output', 'number-sequence', 'security-access',
                      'batch-processing', 'custom'],
-              description: '[strategy] Scenario category (auto-detected from goal if omitted).',
+              description: '[strategy] Scenario category (auto-detected from goal if omitted). field-defaulting = set defaults on NEW records (initValue); field-change-reaction = react when a user/code CHANGES a field (modifiedField).',
             },
             handlerType: {
               type: 'string',

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -3830,14 +3830,54 @@ export async function handleCreateD365File(
 
     if (fileExisted) {
       if (!args.overwrite) {
+        // Surface what's already on disk so the caller doesn't have to read the
+        // file in chunks just to discover its contents. Previously this branch
+        // returned only "already exists", forcing repeated read_file calls.
+        let existingContent = '';
+        try {
+          existingContent = await fs.readFile(normalizedFullPath, 'utf-8');
+        } catch { /* unreadable — fall through with no summary */ }
+
+        let existingSummary = '';
+        let inlineContent = '';
+        if (existingContent) {
+          const methodNames = [...existingContent.matchAll(/<Method>\s*<Name>([^<]+)<\/Name>/g)].map(m => m[1]);
+          const fieldNames = [...existingContent.matchAll(/<AxTableField[A-Za-z]*>\s*<Name>([^<]+)<\/Name>/g)].map(m => m[1]);
+          const summaryParts: string[] = [];
+          if (methodNames.length) {
+            summaryParts.push(`${methodNames.length} method(s): ${methodNames.slice(0, 30).join(', ')}${methodNames.length > 30 ? ', …' : ''}`);
+          }
+          if (fieldNames.length) {
+            summaryParts.push(`${fieldNames.length} field(s): ${fieldNames.slice(0, 30).join(', ')}${fieldNames.length > 30 ? ', …' : ''}`);
+          }
+          const sizeKb = (Buffer.byteLength(existingContent, 'utf-8') / 1024).toFixed(1);
+          existingSummary = `\n\n📄 Existing file (${sizeKb} KB):` +
+            (summaryParts.length ? `\n  ${summaryParts.join('\n  ')}` : ' (no methods/fields detected)');
+
+          // Inline the full content when small enough to be useful in one shot;
+          // otherwise point at the targeted readers rather than dumping a huge file.
+          const INLINE_LIMIT = 8000;
+          inlineContent = existingContent.length <= INLINE_LIMIT
+            ? `\n\n----- BEGIN ${path.basename(normalizedFullPath)} -----\n${existingContent}\n----- END -----`
+            : `\n\n(File is ${sizeKb} KB — too large to inline. Use get_method / get_object_info to read specific members.)`;
+        }
+
+        // When the requested objectName was normalized to a different on-disk name,
+        // say so explicitly — the file that "already exists" can otherwise look
+        // unrelated to what the caller asked for (e.g. "Foo_Extension" → "FooAc_Extension").
+        const nameNote = finalObjectName !== args.objectName
+          ? `\n\nℹ️ Note: objectName "${args.objectName}" was normalized to "${finalObjectName}" ` +
+            `(active naming style/prefix), so this is the file that matches your request.`
+          : '';
+
         return {
           content: [
             {
               type: 'text',
-              text: `⚠️ File already exists: ${normalizedFullPath}\n\nOptions:\n` +
+              text: `⚠️ File already exists: ${normalizedFullPath}${nameNote}${existingSummary}\n\nOptions:\n` +
                 `  1. Pass overwrite=true together with xmlContent to replace the file.\n` +
                 `  2. Use d365fo_file(action="modify") to make targeted changes (rename-field, replace-all-fields, modify-property, …).\n` +
-                `  3. Choose a different objectName.`,
+                `  3. Choose a different objectName.${inlineContent}`,
             },
           ],
           isError: true,

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -432,6 +432,40 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       };
     }
 
+    // Guard against silently scaffolding a brand-new label file at the WRONG path.
+    // When the label file is missing AND we're about to create it, verify the model
+    // directory actually exists at the resolved location. If it doesn't, the package
+    // path/name almost certainly points to the default PackagesLocalDirectory while the
+    // model's metadata lives somewhere else (e.g. a repo checkout) — creating the file
+    // here would "succeed" but write to a location D365FO never reads. Fail loudly with
+    // guidance instead of producing a phantom label file.
+    if (labelFileMissing && createLabelFileIfMissing) {
+      let modelDirExists = false;
+      try {
+        await fs.access(modelDir);
+        modelDirExists = true;
+      } catch { /* missing */ }
+      if (!modelDirExists) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                `❌ Cannot create label file "${labelFileId}" — the model directory does not exist at the resolved path:\n` +
+                `    ${modelDir}\n\n` +
+                `Resolved package: "${resolvedPackageName}"  |  packages root: "${resolvedPackagePath}"\n\n` +
+                `This usually means the model's metadata lives somewhere other than the default ` +
+                `PackagesLocalDirectory (e.g. a repo checkout). Re-run with the correct location, for example:\n` +
+                `  labels(action="create", labelId="${labelId}", labelFileId="${labelFileId}", model="${model}",\n` +
+                `         packageName="<ActualPackageFolder>", packagePath="<root that contains it>", createLabelFileIfMissing=true)\n\n` +
+                `Nothing was written.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
     let existingLanguages: string[];
 
     if (requestedLanguages.length > 0) {
@@ -597,6 +631,8 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       const skipLines = [
         `⚠️ Label "${labelId}" already exists in all languages:\n` +
         skipped.map(s => `  - ${s}`).join('\n') +
+        `\n\nLocation: ${labelResourcesDir}` +
+        `\nPackage : ${resolvedPackageName} @ ${resolvedPackagePath}` +
         '\n\nNo label text changes were made.',
       ];
       if (addedToProject.length > 0) {
@@ -618,6 +654,8 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       '',
       `Label ID   : ${labelId}`,
       `Label File : ${labelFileId}  (model: ${model})`,
+      `Package    : ${resolvedPackageName} @ ${resolvedPackagePath}`,
+      `Location   : ${labelResourcesDir}`,
       '',
       'Written to languages:',
       ...written.map(l => `  ✔ ${l}  → ${translationMap.get(l)?.text ?? enUsText}`),

--- a/src/tools/extensionStrategyAdvisor.ts
+++ b/src/tools/extensionStrategyAdvisor.ts
@@ -13,6 +13,7 @@ import type { XppServerContext } from '../types/context.js';
 const scenarioTypes = [
   'data-validation',
   'field-defaulting',
+  'field-change-reaction',
   'business-logic-change',
   'outbound-integration',
   'inbound-data',
@@ -120,6 +121,47 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
     antiPatterns: [
       { wrong: 'Overriding insert()', why: 'insert() is for persistence — defaults belong in initValue()' },
       { wrong: 'Form init()', why: 'Form init runs once at form open, not per new record' },
+    ],
+  },
+
+  // ── Reacting to a user/field value change ─────────────────────────────
+  {
+    id: 'field-change-reaction',
+    scenarios: ['field-change-reaction'],
+    goalKeywords: [
+      'when the user changes', 'when a user changes', 'when user changes', 'user changes',
+      'react to', 'react when', 'respond when', 'on field change', 'field is changed',
+      'field changes', 'changes a field', 'when a field', 'recalculate when', 'update when',
+      'modifiedfield', 'modified field', 'onmodifiedfield', 'cascade', 'depends on',
+      'clear when', 'reset when',
+    ],
+    mechanism: 'CoC on table.modifiedField() (or form data source modifiedField / onModifiedField event)',
+    reasoning:
+      'modifiedField() fires every time a field value changes on an EXISTING or new record — including ' +
+      'edits made by the user in the UI and changes made in X++. It is the correct entry point for ' +
+      'reacting to a value change (recalculating dependent fields, clearing related values, cascading ' +
+      'defaults). Do NOT use initValue() for this — initValue() runs ONCE when the record is first ' +
+      'created and never fires again when the user later edits a field.',
+    risks: [
+      'modifiedField receives a FieldId — switch on fieldNum(Table, Field) so the logic only runs for the field you care about',
+      'When using CoC, call next() first so the kernel applies its own modifiedField logic before yours',
+      'modifiedField runs per keystroke-commit on the form — keep the logic cheap and avoid heavy queries',
+      'It does NOT fire for set-based data updates (update_recordset / DMF import) — add table-level logic if those paths matter',
+    ],
+    alternatives: [
+      { mechanism: 'CoC on table.modifiedField()', when: 'The reaction must apply everywhere the field changes (UI, X++, services)' },
+      { mechanism: 'Form data source field modified() / onModified event', when: 'The reaction is UI-specific and should NOT apply to service/entity writes' },
+      { mechanism: 'CoC on table.modifiedFieldValue()', when: 'You also need the previous value to decide what to do' },
+    ],
+    nextSteps: [
+      'analyze_extension_points("TableName") — confirm modifiedField is CoC-eligible and see existing extensions',
+      'get_method(include="signature", "TableName", "modifiedField", includeCocTemplate: true) — get the CoC skeleton',
+      'find_coc_extensions("TableName", "modifiedField") — check for existing wrappers',
+    ],
+    antiPatterns: [
+      { wrong: 'CoC on initValue()', why: 'initValue fires only at record creation — it will NOT run when the user later changes the field' },
+      { wrong: 'Overriding the field on the form only', why: 'Misses X++ and service writes — table-level modifiedField is safer unless the reaction is purely cosmetic' },
+      { wrong: 'validateField for side effects', why: 'validateField is for accept/reject decisions, not for mutating other fields' },
     ],
   },
 
@@ -383,6 +425,7 @@ function detectScenario(goal: string): typeof scenarioTypes[number] | undefined 
   const scenarioKeywordMap: { scenario: typeof scenarioTypes[number]; keywords: string[] }[] = [
     { scenario: 'data-validation', keywords: ['validat', 'check', 'verify', 'must be', 'cannot be', 'not allowed', 'mandatory', 'required field', 'constraint'] },
     { scenario: 'field-defaulting', keywords: ['default', 'init value', 'auto-fill', 'prefill', 'auto-populate', 'initvalue'] },
+    { scenario: 'field-change-reaction', keywords: ['when the user changes', 'when user changes', 'user changes', 'react to', 'react when', 'field is changed', 'field changes', 'changes a field', 'recalculate when', 'modifiedfield', 'modified field', 'on field change', 'cascade', 'clear when', 'reset when'] },
     { scenario: 'outbound-integration', keywords: ['send to', 'notify external', 'push to', 'outbound', 'power automate', 'service bus', 'webhook', 'event grid', 'publish event'] },
     { scenario: 'inbound-data', keywords: ['import', 'inbound', 'data entity', 'odata', 'dmf', 'dixf', 'data migration', 'bulk load', 'rest api'] },
     { scenario: 'ui-modification', keywords: ['form', 'add field', 'add button', 'add tab', 'hide control', 'lookup', 'display method', 'dialog', 'action pane'] },
@@ -508,7 +551,8 @@ function formatNoMatch(goal: string, objectName?: string): string {
   out += `\n**General guidance:**\n\n`;
   out += `| Goal | Mechanism |\n|------|----------|\n`;
   out += `| Validate data | Table event (onValidatedWrite) or CoC on validateWrite() |\n`;
-  out += `| Default field values | Table event (onInitValue) or CoC on initValue() |\n`;
+  out += `| Default field values (on new record) | Table event (onInitValue) or CoC on initValue() |\n`;
+  out += `| React when a user changes a field | CoC on modifiedField() (NOT initValue) |\n`;
   out += `| Modify business logic | Chain of Command (CoC) |\n`;
   out += `| Send notification to external system | Business Event |\n`;
   out += `| Receive/import external data | Data Entity (OData/DMF) |\n`;

--- a/src/tools/getLabelInfo.ts
+++ b/src/tools/getLabelInfo.ts
@@ -31,14 +31,25 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
 
     // ── Mode A: no labelId → list available AxLabelFile IDs ─────────────────
     if (!labelId) {
-      const files = symbolIndex.getLabelFileIds(model);
+      let files = symbolIndex.getLabelFileIds(model);
+
+      // When a specific labelFileId is requested, narrow the listing to it and
+      // additionally surface the physical .label.txt path for each language so
+      // the caller never has to shell out to locate the file on disk.
+      if (labelFileId) {
+        files = files.filter(f => f.labelFileId.toLowerCase() === labelFileId.toLowerCase());
+      }
+
       if (files.length === 0) {
         return {
           content: [
             {
               type: 'text',
               text:
-                `No label files found${model ? ` for model "${model}"` : ''}.\n` +
+                `No label files found` +
+                (labelFileId ? ` matching labelFileId "${labelFileId}"` : '') +
+                (model ? ` for model "${model}"` : '') +
+                `.\n` +
                 `Make sure labels are indexed (run build-database with INCLUDE_LABELS=true).`,
             },
           ],
@@ -46,13 +57,32 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
       }
 
       const lines: string[] = [
-        `Available AxLabelFile IDs${model ? ` in model "${model}"` : ''}:`,
+        labelFileId
+          ? `Label file "${labelFileId}"${model ? ` in model "${model}"` : ''}:`
+          : `Available AxLabelFile IDs${model ? ` in model "${model}"` : ''}:`,
         '',
       ];
       for (const f of files) {
         lines.push(`  LabelFileId : ${f.labelFileId}`);
         lines.push(`  Model       : ${f.model}`);
         lines.push(`  Languages   : ${f.languages}`);
+
+        // Physical file paths per language (only when a specific file was asked for,
+        // so the generic "list everything" view stays compact).
+        if (labelFileId) {
+          const paths = symbolIndex.getLabelFilePaths(f.labelFileId, model);
+          if (paths.length > 0) {
+            lines.push(`  Files       :`);
+            for (const p of paths) {
+              lines.push(`    [${p.language.padEnd(6)}] ${p.filePath}`);
+            }
+          } else {
+            lines.push(
+              `  Files       : (no physical path indexed — label rows may predate path tracking; ` +
+              `re-run build-database with INCLUDE_LABELS=true to populate file paths)`,
+            );
+          }
+        }
         lines.push('');
       }
       lines.push(

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -357,6 +357,14 @@ const ModifyD365FileArgsSchema = z.object({
   createBackup: z.boolean().optional().default(false).describe('Create a .bak backup of the file before modifying it (default: false). Changes can also be reverted with undo_last_modification (git checkout) without a backup. Set true when the file is not under source control.'),
   modelName: z.string().optional().describe('Model name (auto-detected if not provided). Pass this if the file was just created and is not yet indexed.'),
   packageName: z.string().optional().describe('Package name. Auto-resolved if omitted.'),
+  packagePath: z.string().optional().describe(
+    'Root packages path to search when the object lives outside the default PackagesLocalDirectory ' +
+    '(e.g. a repo metadata checkout like "K:\\\\repos\\\\…\\\\metadata"). Used to locate the file for ' +
+    'backup and the direct-XML fallback. NOTE: bridge-backed operations (add-method, add-field, etc.) ' +
+    'resolve objects via the C# bridge, which is configured with fixed roots at startup — if the model ' +
+    'is not under the bridge\'s roots, set context.customPackagesPath / D365FO_CUSTOM_PACKAGES_PATH so ' +
+    'the bridge picks it up, or pass an explicit filePath.'
+  ),
   workspacePath: z.string().optional().describe('Path to workspace for finding file'),
   filePath: z.string().optional().describe(
     'Absolute path to the XML file. Use this when the object was just created and the path is already known ' +
@@ -509,15 +517,18 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     }
 
     // 1. Find the file
-    const filePath = await findD365File(symbolIndex, objectType, objectName, modelName, workspacePath, explicitFilePath);
+    const filePath = await findD365File(symbolIndex, objectType, objectName, modelName, workspacePath, explicitFilePath, args.packagePath);
 
     if (!filePath) {
       throw new Error(
         `File not found for ${objectType} "${objectName}".\n\n` +
         `Retry options (do NOT use PowerShell — this tool can handle it):\n` +
         `  1. Pass modelName="<YourModel>" — triggers filesystem lookup by path.\n` +
-        `  2. Pass filePath="K:\\\\AosService\\\\PackagesLocalDirectory\\\\<pkg>\\\\<model>\\\\${objectName}.xml" — bypasses all lookup.\n` +
-        `  3. If the object was just created, re-run d365fo_file(action="create") first and use the returned path as filePath.`
+        `  2. Pass packagePath="<root that contains the model>" if the metadata lives outside the default PackagesLocalDirectory (e.g. a repo checkout).\n` +
+        `  3. Pass filePath="K:\\\\AosService\\\\PackagesLocalDirectory\\\\<pkg>\\\\<model>\\\\${objectName}.xml" — bypasses all lookup.\n` +
+        `  4. If the object was just created, re-run d365fo_file(action="create") first and use the returned path as filePath.\n\n` +
+        `If the file exists but bridge operations still fail to resolve the object, the C# bridge's metadata roots ` +
+        `(fixed at startup) likely don't include this model — set context.customPackagesPath / D365FO_CUSTOM_PACKAGES_PATH and restart the server.`
       );
     }
 
@@ -1090,7 +1101,8 @@ async function findD365File(
   objectName: string,
   modelName?: string,
   _workspacePath?: string,
-  explicitFilePath?: string
+  explicitFilePath?: string,
+  packagePath?: string,
 ): Promise<string | null> {
   // Explicit path bypasses all lookup — use when caller knows the exact location
   // (e.g. the path was returned by create_d365fo_file).
@@ -1177,7 +1189,7 @@ async function findD365File(
 
   // Filesystem fallback: handles newly created files not yet in the symbol index,
   // and all types not covered by the symbol DB (edt, report, extensions, security, menu …).
-  return findD365FileOnDisk(objectType, objectName, modelName);
+  return findD365FileOnDisk(objectType, objectName, modelName, packagePath);
 }
 
 /**
@@ -1188,7 +1200,8 @@ async function findD365File(
 export async function findD365FileOnDisk(
   objectType: string,
   objectName: string,
-  modelName?: string
+  modelName?: string,
+  explicitPackagePath?: string,
 ): Promise<string | null> {
   const folderMap: Record<string, string> = {
     class: 'AxClass',
@@ -1253,6 +1266,29 @@ export async function findD365FileOnDisk(
   // Try this before the MS PLD so we find repo-tracked objects first.
   const customWritePath = await configManager.getCustomPackagesPath();
 
+  // Candidate 0: caller-supplied packagePath. Highest priority — the caller knows
+  // the model lives outside the default PackagesLocalDirectory (e.g. a repo checkout).
+  // Try both the package==model layout and a PackageResolver scan rooted here so a
+  // package!=model layout (e.g. package "ACAUTOCONT" / model "AC AUTOCONT") still resolves.
+  if (explicitPackagePath) {
+    const directPath = path.join(explicitPackagePath, resolvedModel, resolvedModel, objectFolder, `${objectName}.xml`);
+    try {
+      await fs.access(directPath);
+      console.error(`[modifyD365File] Found via explicit packagePath: ${directPath}`);
+      return directPath;
+    } catch { /* try resolver scan below */ }
+    try {
+      const resolver = new PackageResolver([explicitPackagePath]);
+      const resolved = await resolver.resolve(resolvedModel);
+      if (resolved) {
+        const resolvedPath = path.join(resolved.rootPath, resolved.packageName, resolvedModel, objectFolder, `${objectName}.xml`);
+        await fs.access(resolvedPath);
+        console.error(`[modifyD365File] Found via explicit packagePath (PackageResolver): ${resolvedPath}`);
+        return resolvedPath;
+      }
+    } catch { /* not found under explicit packagePath; fall through */ }
+  }
+
   // Candidate 1: custom write root, package == model (most common for custom models)
   if (customWritePath) {
     const customCandidatePath = path.join(
@@ -1293,7 +1329,7 @@ export async function findD365FileOnDisk(
   try {
     const envType = await configManager.getDevEnvironmentType();
     const msPath = envType === 'ude' ? await configManager.getMicrosoftPackagesPath() : null;
-    const roots = [customWritePath, msPath, configPackagePath].filter(Boolean) as string[];
+    const roots = [explicitPackagePath, customWritePath, msPath, configPackagePath].filter(Boolean) as string[];
     const resolver = new PackageResolver(roots);
     const resolved = await resolver.resolve(resolvedModel);
     if (resolved) {

--- a/tests/tools/extensionStrategyAdvisor.test.ts
+++ b/tests/tools/extensionStrategyAdvisor.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Extension Strategy Advisor Tests
+ * Focus: the field-change-reaction scenario must recommend modifiedField(),
+ * NOT initValue(), when the goal is "react when a user changes a field".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extensionStrategyAdvisorTool } from '../../src/tools/extensionStrategyAdvisor';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const ctx = {} as XppServerContext;
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'extension_info', arguments: args },
+});
+
+describe('extension_info strategy — field-change-reaction', () => {
+  it('recommends modifiedField (not initValue) when reacting to a user field change', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req({ goal: 'recalculate the total when the user changes the quantity field', objectName: 'LedgerJournalTrans' }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('field-change-reaction');
+    expect(text).toMatch(/modifiedField/);
+    // The recommended mechanism must not be initValue-based defaulting.
+    expect(text).not.toMatch(/Recommended:.*initValue/);
+  });
+
+  it('explicit scenario=field-change-reaction routes to modifiedField', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req({ goal: 'do something', scenario: 'field-change-reaction' }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/modifiedField/);
+  });
+
+  it('still recommends initValue for genuine new-record defaulting', async () => {
+    const result = await extensionStrategyAdvisorTool(
+      req({ goal: 'set a default value for the warehouse field on new records' }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('field-defaulting');
+    expect(text).toMatch(/initValue/);
+  });
+});

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -93,6 +93,7 @@ const buildContext = (overrides: Partial<XppServerContext> = {}): XppServerConte
     searchLabels: vi.fn(() => []),
     getLabelById: vi.fn(() => undefined),
     getLabelFileIds: vi.fn(() => []),
+    getLabelFilePaths: vi.fn(() => []),
     getCustomModels: vi.fn(() => ['MyModel']),
     insertOrUpdateLabel: vi.fn(),
     searchSymbols: vi.fn(() => []),
@@ -187,6 +188,31 @@ describe('get_label_info', () => {
     expect(text).toContain('SYS');
   });
 
+  it('returns physical file paths per language when labelFileId is given without labelId', async () => {
+    (ctx.symbolIndex.getLabelFileIds as any).mockReturnValue([
+      { labelFileId: 'MyModel', model: 'MyModel', languages: 'en-US,cs' },
+      { labelFileId: 'SYS', model: 'ApplicationSuite', languages: 'en-US' },
+    ]);
+    (ctx.symbolIndex.getLabelFilePaths as any).mockReturnValue([
+      { language: 'en-US', filePath: 'K:\\repos\\meta\\MyModel\\MyModel\\AxLabelFile\\LabelResources\\en-US\\MyModel.en-US.label.txt', model: 'MyModel' },
+      { language: 'cs', filePath: 'K:\\repos\\meta\\MyModel\\MyModel\\AxLabelFile\\LabelResources\\cs\\MyModel.cs.label.txt', model: 'MyModel' },
+    ]);
+
+    const result = await getLabelInfoTool(
+      req('get_label_info', { labelFileId: 'MyModel' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(ctx.symbolIndex.getLabelFilePaths as any).toHaveBeenCalledWith('MyModel', undefined);
+    const text = result.content[0].text;
+    // Narrowed to the requested file only — SYS must not appear.
+    expect(text).not.toContain('SYS');
+    expect(text).toContain('en-US');
+    expect(text).toContain('MyModel.en-US.label.txt');
+    expect(text).toContain('MyModel.cs.label.txt');
+  });
+
   it('returns no-files message when no label files exist', async () => {
     (ctx.symbolIndex.getLabelFileIds as any).mockReturnValue([]);
     const result = await getLabelInfoTool(req('get_label_info', {}), ctx);
@@ -263,6 +289,57 @@ describe('create_label', () => {
     // Result is success (file write is mocked) or at minimum not a Zod validation error
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text).toMatch(/created|success|MyNewFeature/i);
+  });
+
+  it('reports the resolved package + physical location in the success output', async () => {
+    (ctx.symbolIndex.getLabelById as any).mockReturnValue([]);
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'TransparencyTest',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        createLabelFileIfMissing: true,
+        updateIndex: false,
+        translations: [{ language: 'en-US', text: 'Transparency test' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Package');
+    expect(text).toContain('Location');
+    // The resolved packages root must be surfaced so the caller can see WHERE it wrote.
+    expect(text).toContain('PackagesLocalDirectory');
+  });
+
+  it('fails loudly instead of scaffolding a label file when the model directory does not exist', async () => {
+    const fsMock = await import('fs');
+    (fsMock.promises.writeFile as any).mockClear();
+    // No language folders discovered (label file missing) …
+    (fsMock.promises.readdir as any).mockImplementation(async () => []);
+    // … and the model directory itself does not exist at the resolved path.
+    (fsMock.promises.access as any).mockImplementation(async () => { throw new Error('ENOENT'); });
+
+    (ctx.symbolIndex.getLabelById as any).mockReturnValue([]);
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'PhantomLabel',
+        labelFileId: 'MyModel',
+        model: 'MyModel',
+        createLabelFileIfMissing: true,
+        updateIndex: false,
+        translations: [{ language: 'en-US', text: 'Should not be written' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/model directory does not exist|Nothing was written/i);
+    // No .label.txt should have been written.
+    expect((fsMock.promises.writeFile as any)).not.toHaveBeenCalled();
   });
 
   it('adds label file descriptors to VS project', async () => {


### PR DESCRIPTION
…ools

Six independent fixes from a usage-feedback report:

- labels(create): guard against silently scaffolding a label file at the wrong path — verify the model dir exists before creating, and always surface the resolved package + physical location in the output.
- d365fo_file(create): "already exists" now returns a method/field summary plus the file content inline (<=8 KB) instead of an opaque warning, and reports objectName normalization (Foo_Extension -> FooAc_Extension).
- d365fo_file(modify): traditional-mode bridge now uses the custom packages root as primary provider (PLD as reference) so objects in a repo metadata checkout resolve; modify also accepts packagePath for file location.
- labels(info, labelFileId): returns the physical .label.txt path per language via new symbolIndex.getLabelFilePaths().
- extension_info(strategy): new field-change-reaction scenario recommends modifiedField() instead of initValue() for user-field-change use cases.

Adds tests for the label-info paths, the create guard/transparency, and the new strategy scenario. Full suite: 922 passing.