### PR TITLE
fix(labels): guard create/rename against label file extensions

### DIFF
--- a/src/metadata/labelParser.ts
+++ b/src/metadata/labelParser.ts
@@ -28,6 +28,24 @@ export interface ParsedLabel {
 }
 
 /**
+ * True when a label file ID refers to a label file EXTENSION rather than an
+ * original (base) label file owned by the model.
+ *
+ * D365FO names label file extensions with an `_Extension` marker, optionally
+ * followed by a model prefix — e.g. `Base_Extension` or `Base_ExtensionContoso`.
+ * On disk the content file is `${labelFileId}.${locale}.label.txt`, so the
+ * `_Extension` marker is carried in the label file ID itself.
+ *
+ * New labels must always be created in the model's own ORIGINAL label file.
+ * An extension only extends a base label file owned by another model; adding
+ * brand-new labels there is almost always a mistake (and is what leads clients
+ * to wrongly prefix the label IDs).
+ */
+export function isExtensionLabelFile(labelFileId: string): boolean {
+  return /_Extension/i.test(labelFileId);
+}
+
+/**
  * Parse a single .label.txt file into ParsedLabel records.
  */
 export function parseLabelFile(

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -876,7 +876,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             'Unified label operations — read and write. Choose an `action`:\n' +
             '• search → full-text query across indexed label files (read). Always run before action=create.\n' +
             '• info → all language translations for a labelId, OR list available label files when labelId is omitted. Pass labelFileId (without labelId) to get that label file plus the physical .label.txt path per language (read).\n' +
-            '• create → add a new label to an AxLabelFile, write into every language .label.txt, create XML descriptors if missing (write). Label IDs describe MEANING — never add a model prefix.\n' +
+            '• create → add a new label to an AxLabelFile, write into every language .label.txt, create XML descriptors if missing (write). Label IDs describe MEANING — never add a model prefix. Target the model\'s ORIGINAL label file, never a label file extension (…_Extension…).\n' +
             '• rename → rename a label ID across .label.txt + X++ + XML metadata + SQLite index. Use dryRun=true first (write).',
           inputSchema: {
             type: 'object',
@@ -893,7 +893,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               },
               labelFileId: {
                 type: 'string',
-                description: '[search|info|create|rename] AxLabelFile ID (e.g. ContosoExt, SYS). For action=info with no labelId, returns the physical .label.txt path per language.',
+                description: '[search|info|create|rename] AxLabelFile ID (e.g. ContosoExt, SYS). For action=info with no labelId, returns the physical .label.txt path per language. For create/rename use the model\'s ORIGINAL label file, not an extension (…_Extension…).',
               },
               language: {
                 type: 'string',
@@ -997,6 +997,13 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               updateIndex: {
                 type: 'boolean',
                 description: '[create|rename] Update the MCP label index after writing (default: true).',
+              },
+              allowExtensionLabelFile: {
+                type: 'boolean',
+                description:
+                  '[create|rename] Allow operating on a label file EXTENSION (labelFileId carrying the "_Extension" marker). ' +
+                  'Default false: new labels belong in the model\'s ORIGINAL label file, never an extension. ' +
+                  'Leave false unless you genuinely intend to write to an extension.',
               },
             },
             required: ['action'],

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import { getConfigManager } from '../utils/configManager.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { detectEol } from '../utils/eolUtils.js';
+import { isExtensionLabelFile } from '../metadata/labelParser.js';
 import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
 
 // UTF-8 BOM (Byte Order Mark)
@@ -110,6 +111,16 @@ const CreateLabelArgsSchema = z.object({
     .describe(
       'If true and the AxLabelFile does not exist yet, create it with the provided translations. ' +
         'Set to false (default) to fail fast when the label file is missing.',
+    ),
+  allowExtensionLabelFile: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Escape hatch to allow writing into a label file EXTENSION (a labelFileId ' +
+        'carrying the "_Extension" marker). Off by default: new labels belong in the ' +
+        "model's own ORIGINAL label file, not in an extension. Only set true if you " +
+        'genuinely intend to add labels to an extension label file.',
     ),
   updateIndex: z
     .boolean()
@@ -276,6 +287,32 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       createLabelFileIfMissing,
       updateIndex,
     } = args;
+
+    // Guard: never create new labels in a label file EXTENSION (e.g. "Base_Extension").
+    // Extensions only extend a base label file owned by another model — new labels
+    // belong in the model's own ORIGINAL label file. Writing here is what makes clients
+    // wrongly prefix the label IDs. Opt out explicitly with allowExtensionLabelFile=true.
+    if (isExtensionLabelFile(labelFileId) && !args.allowExtensionLabelFile) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `❌ "${labelFileId}" is a label file EXTENSION, not an original label file.\n\n` +
+              `New labels must be created in the model's own (original) label file — ` +
+              `extensions (…_Extension…) only extend a base label file owned by another model, ` +
+              `and adding new labels there leads to wrongly prefixed label IDs.\n\n` +
+              `➡️  Use the model's original label file instead. List the candidates with:\n` +
+              `      labels(action="info", model="${model}")\n` +
+              `   then re-run with that original labelFileId, e.g.:\n` +
+              `      labels(action="create", labelId="${labelId}", labelFileId="<OriginalLabelFileId>", model="${model}", ...)\n\n` +
+              `If you really must add labels to this extension, pass allowExtensionLabelFile=true.\n` +
+              `Nothing was written.`,
+          },
+        ],
+        isError: true,
+      };
+    }
 
     // Resolve sortLabels: explicit param → LABEL_SORT_ORDER env → true (alphabetical)
     const envSortOrder = process.env.LABEL_SORT_ORDER?.toLowerCase();

--- a/src/tools/renameLabel.ts
+++ b/src/tools/renameLabel.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import { getConfigManager } from '../utils/configManager.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { detectEol } from '../utils/eolUtils.js';
+import { isExtensionLabelFile } from '../metadata/labelParser.js';
 
 // UTF-8 BOM
 const UTF8_BOM = '\uFEFF';
@@ -54,6 +55,15 @@ const RenameLabelArgsSchema = z.object({
     .describe(
       'Additional absolute directory paths to scan for X++ / XML references. ' +
       'The model package directory is always included automatically.',
+    ),
+  allowExtensionLabelFile: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Escape hatch to allow operating on a label file EXTENSION (a labelFileId ' +
+        'carrying the "_Extension" marker). Off by default: labels belong in the ' +
+        "model's own ORIGINAL label file, not in an extension.",
     ),
   dryRun: z
     .boolean()
@@ -165,6 +175,25 @@ export async function renameLabelTool(request: CallToolRequest, context: XppServ
     if (oldLabelId === newLabelId) {
       return {
         content: [{ type: 'text', text: `⚠️ Old and new label IDs are identical ("${oldLabelId}"). Nothing to do.` }],
+        isError: true,
+      };
+    }
+
+    // Guard: don't operate on a label file EXTENSION (e.g. "Base_Extension").
+    // Labels belong in the model's own ORIGINAL label file. Opt out with
+    // allowExtensionLabelFile=true.
+    if (isExtensionLabelFile(labelFileId) && !args.allowExtensionLabelFile) {
+      return {
+        content: [{
+          type: 'text',
+          text:
+            `❌ "${labelFileId}" is a label file EXTENSION, not an original label file.\n\n` +
+            `Labels belong in the model's own (original) label file — extensions (…_Extension…) ` +
+            `only extend a base label file owned by another model.\n\n` +
+            `➡️  List the model's label files with labels(action="info", model="${model}") ` +
+            `and re-run with the original labelFileId.\n\n` +
+            `If you really must operate on this extension, pass allowExtensionLabelFile=true.`,
+        }],
         isError: true,
       };
     }

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -8,6 +8,7 @@ import { searchLabelsTool } from '../../src/tools/searchLabels';
 import { getLabelInfoTool } from '../../src/tools/getLabelInfo';
 import { createLabelTool } from '../../src/tools/createLabel';
 import { renameLabelTool } from '../../src/tools/renameLabel';
+import { isExtensionLabelFile } from '../../src/metadata/labelParser';
 import type { XppServerContext } from '../../src/types/context';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
@@ -109,6 +110,22 @@ const buildContext = (overrides: Partial<XppServerContext> = {}): XppServerConte
   workspaceScanner: {} as any,
   hybridSearch: {} as any,
   ...overrides,
+});
+
+// ─── isExtensionLabelFile ─────────────────────────────────────────────────────
+
+describe('isExtensionLabelFile', () => {
+  it('flags label file IDs carrying the _Extension marker', () => {
+    expect(isExtensionLabelFile('BaseLabels_Extension')).toBe(true);
+    expect(isExtensionLabelFile('BaseLabels_ExtensionContoso')).toBe(true);
+    expect(isExtensionLabelFile('baselabels_extension')).toBe(true); // case-insensitive
+  });
+
+  it('does not flag original label file IDs', () => {
+    expect(isExtensionLabelFile('MyModel')).toBe(false);
+    expect(isExtensionLabelFile('ContosoExt')).toBe(false);
+    expect(isExtensionLabelFile('SYS')).toBe(false);
+  });
 });
 
 // ─── search_labels ───────────────────────────────────────────────────────────
@@ -543,6 +560,69 @@ describe('create_label', () => {
   it('returns error when required fields are missing', async () => {
     const result = await createLabelTool(req('create_label', { labelId: 'Foo' }), ctx);
     expect(result.isError).toBe(true);
+  });
+
+  it('refuses to write into a label file EXTENSION and writes nothing', async () => {
+    const fsMock = await import('fs');
+    (fsMock.promises.writeFile as any).mockClear();
+    (ctx.symbolIndex.getLabelById as any).mockReturnValue([]);
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'MyNewLabel',
+        labelFileId: 'BaseLabels_Extension',
+        model: 'MyModel',
+        createLabelFileIfMissing: true,
+        updateIndex: false,
+        translations: [{ language: 'en-US', text: 'My new label' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/extension/i);
+    expect(result.content[0].text).toMatch(/original label file/i);
+    // Nothing must be written to disk.
+    expect((fsMock.promises.writeFile as any)).not.toHaveBeenCalled();
+  });
+
+  it('also detects an extension with a trailing model prefix (…_Extension<prefix>)', async () => {
+    (ctx.symbolIndex.getLabelById as any).mockReturnValue([]);
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'MyNewLabel',
+        labelFileId: 'BaseLabels_ExtensionContoso',
+        model: 'MyModel',
+        createLabelFileIfMissing: true,
+        updateIndex: false,
+        translations: [{ language: 'en-US', text: 'My new label' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/extension/i);
+  });
+
+  it('allows writing into an extension when allowExtensionLabelFile=true', async () => {
+    (ctx.symbolIndex.getLabelById as any).mockReturnValue([]);
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    const result = await createLabelTool(
+      req('create_label', {
+        labelId: 'MyNewLabel',
+        labelFileId: 'BaseLabels_Extension',
+        model: 'MyModel',
+        allowExtensionLabelFile: true,
+        createLabelFileIfMissing: true,
+        updateIndex: false,
+        addToProject: false,
+        translations: [{ language: 'en-US', text: 'My new label' }],
+      }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
   });
 
   it('writes to every existing model language when `languages` is omitted (default fan-out)', async () => {
@@ -1105,6 +1185,24 @@ describe('rename_label', () => {
   it('returns error when required fields are missing', async () => {
     const result = await renameLabelTool(req('rename_label', { oldLabelId: 'Foo' }), ctx);
     expect(result.isError).toBe(true);
+  });
+
+  it('refuses to operate on a label file EXTENSION', async () => {
+    const fsMock = await import('fs');
+    (fsMock.promises.writeFile as any).mockClear();
+
+    const result = await renameLabelTool(
+      req('rename_label', {
+        oldLabelId: 'OldName',
+        newLabelId: 'NewName',
+        labelFileId: 'BaseLabels_Extension',
+        model: 'MyModel',
+      }),
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/extension/i);
+    expect((fsMock.promises.writeFile as any)).not.toHaveBeenCalled();
   });
 
   it('preserves CRLF line endings when renaming inside a CRLF .label.txt', async () => {


### PR DESCRIPTION
New labels must go into a model's ORIGINAL label file, never into a label file extension (labelFileId carrying the "_Extension" marker), which only extends a base label file owned by another model. Writing there was also what led clients to wrongly prefix label IDs.

- Add shared isExtensionLabelFile() helper in labelParser
- create/rename now refuse extension label files with guidance toward the model's original label file (opt out via allowExtensionLabelFile)
- Surface allowExtensionLabelFile + warnings in the MCP tool schema
- Tests for helper + create/rename guards (49/49 green)