### PR TITLE
docs: clarify stdio vs local HTTP memory/process trade-off

### DIFF
--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -38,12 +38,15 @@ One path, three derived values — plus automatic `.rnrproj` discovery:
 |---|---------------------------|------------------------------|
 | Config key | `command` + `args` + `env` | `url` |
 | Started by | the MCP client (VS / Claude), no port | you / Azure |
+| Process / memory | one process **per client** — each loads its own copy of the symbol index (~1.5 GB) | one shared process — index loaded **once** for all connected clients |
 | Workspace context | full (`env` block) | headers only — limited |
 | Auth | n/a | optional `headers: { "X-Api-Key": "..." }` |
 
 > stdio note: `DB_PATH`/`LABELS_DB_PATH` must be **absolute** — the working directory is controlled by the client, not the repo.
 >
 > HTTP note: `D365FO_WORKSPACE_PATH` cannot be passed (no subprocess). For reliable model targeting combine HTTP search with a stdio write-only companion ([hybrid](#hybrid-mode-summary)).
+>
+> Multiple clients note: if several clients (e.g. VS Code + the CLI) talk to the **same** code base at once, prefer one local HTTP instance ([Scenario C](SETUP.md#scenario-c--local-http)). stdio spawns a separate subprocess per client, so each one loads its own ~1.5 GB index; a single HTTP instance loads it once and serves them all.
 
 ---
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -124,7 +124,7 @@ npm start                  # verify: http://localhost:8080/health
 }
 ```
 
-> Prefer **Scenario E** (stdio) — no port, no `npm start`, VS launches the server itself.
+> Prefer **Scenario E** (stdio) when a single client drives the server — no port, no `npm start`, VS launches it for you. Choose local HTTP when **several clients share one code base** (e.g. VS Code + the CLI at the same time): stdio spawns one subprocess per client, each loading its own ~1.5 GB index, whereas a single HTTP instance loads the index once and serves them all.
 
 ## Scenario D — UDE (Unified Developer Experience)
 


### PR DESCRIPTION
stdio spawns one subprocess per client, each loading its own ~1.5 GB symbol index; a single local HTTP instance loads it once and serves all connected clients. Document this in the transports table and Scenario C so users running multiple clients (e.g. VS Code + CLI) against one code base pick the memory-efficient setup. Raised in #563.