### PR TITLE
fix(modify): reject XML/CDATA markup in X++ method source

### DIFF
--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -72,6 +72,50 @@ export function decodeXmlEntitiesFromXppSource(source: string): string {
 }
 
 /**
+ * Reject an X++ source payload that smuggles XML/CDATA structure.
+ *
+ * Method source written through the bridge is handed verbatim to the D365FO SDK
+ * serializer, which wraps it in `<![CDATA[ … ]]>` and emits the surrounding
+ * `<Method>…</Method>` markup itself. If the caller's source already contains
+ * the CDATA terminator `]]>` or closing metadata tags, the serializer writes
+ * them inside the CDATA block unchanged — producing structurally invalid XML:
+ * a premature/doubled `]]>` and a stray `<Method>` that drops the enclosing
+ * `</Method>` (exactly the corruption D365FO refuses to deserialize). The
+ * direct-XML replace fallback has the same exposure: a literal string replace
+ * that injects `]]>` into an existing CDATA block corrupts it too.
+ *
+ * This always means the AI passed a slice of the .xml file where clean X++ was
+ * expected. Reject it here — before it reaches disk — with an actionable
+ * message, rather than silently escaping and hiding the mistake.
+ *
+ * X++ legitimately uses `<`/`>` (generics, comparisons, doc comments), so we
+ * only flag the CDATA terminator and the specific opening/closing metadata
+ * tokens, never bare angle brackets.
+ */
+export function assertCleanXppSource(source: string | undefined, paramName: string): void {
+  if (!source) return;
+
+  if (source.includes(']]>')) {
+    throw new Error(
+      `⛔ ${paramName} contains the CDATA terminator "]]>" — that is XML, not clean X++ source.\n\n` +
+      `Method source is wrapped in <![CDATA[ … ]]> by the metadata serializer, so a "]]>" inside it ` +
+      `breaks the CDATA block and yields invalid XML (doubled "]]>" plus a dropped </Method>), which ` +
+      `D365FO refuses to load.\n\n` +
+      `Pass ONLY the X++ code — no <Source>, <![CDATA[, ]]> or </Method> markup. The tool adds the wrapping itself.`
+    );
+  }
+
+  const structuralTag = source.match(/<\/(?:Source|Methods?)>|<Method>|<!\[CDATA\[/);
+  if (structuralTag) {
+    throw new Error(
+      `⛔ ${paramName} contains the XML metadata token "${structuralTag[0]}" — that is XML, not clean X++ source.\n\n` +
+      `You pasted a slice of the .xml file. Pass ONLY the X++ code — the tool emits the ` +
+      `<Method>, <Source> and <![CDATA[ … ]]> wrapping itself.`
+    );
+  }
+}
+
+/**
  * Direct XML file-level replace-code fallback.
  * Used when the C# bridge fails or returns null for replace-code on forms/form-extensions
  * (e.g. control override methods that the SDK doesn't expose via the Methods API).
@@ -412,6 +456,15 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       `d365fo_file(action="modify", objectType="${args.objectType}", objectName="${args.objectName}", operation="${args.operation}")`,
     );
     if (referenceError) return referenceError;
+
+    // CDATA-corruption guard: any X++ payload that will be CDATA-wrapped by the
+    // serializer (add-method's source) or spliced into an existing CDATA block
+    // (replace-code's newCode) must be clean X++ — never a slice of .xml markup.
+    // A "]]>" or stray <Method>/<Source> in the payload otherwise survives into
+    // the file and produces the invalid doubled-"]]>" / dropped-</Method> shape.
+    assertCleanXppSource(args.sourceCode, 'sourceCode');
+    assertCleanXppSource((args as any).methodCode, 'methodCode');
+    assertCleanXppSource(args.newCode, 'newCode');
 
     const { symbolIndex } = context;
     const {

--- a/tests/tools/xpp-source-guard.test.ts
+++ b/tests/tools/xpp-source-guard.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Regression tests — CDATA-corruption guard (assertCleanXppSource)
+ *
+ * Reproduces the observed corruption where a method's `<Source>` payload that
+ * already contained XML/CDATA markup (a "]]>" terminator and/or a stray
+ * <Method> tag) survived into the file, yielding invalid XML:
+ *
+ *     …    }
+ *     ]]>]]></Source>           ← doubled "]]>"
+ *           <Method>             ← previous </Method> dropped
+ *
+ * Method source is CDATA-wrapped by the D365FO serializer, so such a payload is
+ * always a slice of .xml the AI pasted where clean X++ was expected. The guard
+ * must reject it BEFORE any bridge write — never reaching disk.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool, assertCleanXppSource } from '../../src/tools/modifyD365File';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// ─── Bridge mock — assert these are NEVER called for a poisoned payload ───────
+
+const { mockBridgeAddMethod, mockBridgeReplaceCode } = vi.hoisted(() => ({
+  mockBridgeAddMethod: vi.fn(async () => ({ success: true, message: '✅ added' })),
+  mockBridgeReplaceCode: vi.fn(async () => ({ success: true, message: '✅ replaced' })),
+}));
+
+vi.mock('../../src/bridge/index', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/index')>();
+  return {
+    ...actual,
+    bridgeAddMethod: mockBridgeAddMethod,
+    bridgeReplaceCode: mockBridgeReplaceCode,
+    bridgeValidateAfterWrite: vi.fn(async () => null),
+  };
+});
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (p.endsWith('.xml')) return CLASS_XML;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const CLASS_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>MyClass</Name>
+  <SourceCode>
+    <Declaration><![CDATA[class MyClass {}]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>modifiedField</Name>
+        <Source><![CDATA[public void modifiedField(FieldId _id)
+{
+    super(_id);
+}]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>`;
+
+const FILE_PATH = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxClass\\MyClass.xml';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'modify_d365fo_file', arguments: args },
+});
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare: vi.fn(() => stmt) },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: {} as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    bridge: { isReady: true, metadataAvailable: true } as any,
+  };
+};
+
+// ─── Unit-level guard ────────────────────────────────────────────────────────
+
+describe('assertCleanXppSource', () => {
+  it('rejects a payload containing the CDATA terminator "]]>"', () => {
+    expect(() => assertCleanXppSource('void m()\n{\n}\n]]></Source>', 'sourceCode'))
+      .toThrow(/CDATA terminator|\]\]>/);
+  });
+
+  it('rejects a payload containing a stray <Method> tag', () => {
+    expect(() => assertCleanXppSource('void m() {}\n<Method>\n<Name>foo</Name>', 'sourceCode'))
+      .toThrow(/metadata token|<Method>/);
+  });
+
+  it('rejects a payload containing <![CDATA[', () => {
+    expect(() => assertCleanXppSource('<Source><![CDATA[void m(){}', 'sourceCode'))
+      .toThrow(/metadata token|CDATA/);
+  });
+
+  it('accepts clean X++ that uses < and > (generics, comparisons, doc comments)', () => {
+    const clean =
+      `/// <summary>\n/// Does work.\n/// </summary>\n` +
+      `public void run()\n{\n    List<str> items = new List(Types::String);\n    if (a < b && b > c) { info("ok"); }\n}`;
+    expect(() => assertCleanXppSource(clean, 'sourceCode')).not.toThrow();
+  });
+
+  it('accepts undefined / empty source', () => {
+    expect(() => assertCleanXppSource(undefined, 'sourceCode')).not.toThrow();
+    expect(() => assertCleanXppSource('', 'sourceCode')).not.toThrow();
+  });
+});
+
+// ─── Tool-level: poisoned payload must not reach the bridge ───────────────────
+
+describe('modify_d365fo_file CDATA-corruption guard (regression)', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    mockBridgeAddMethod.mockClear();
+    mockBridgeReplaceCode.mockClear();
+  });
+
+  it('add-method: rejects sourceCode with "]]>" before any bridge write', async () => {
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'class',
+        objectName: 'MyClass',
+        operation: 'add-method',
+        methodName: 'AC_defaultTaxItemGroupFromAsset',
+        sourceCode: 'public void AC_defaultTaxItemGroupFromAsset()\n{\n}\n]]></Source>\n</Method>',
+        filePath: FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/\]\]>|CDATA/);
+    expect(mockBridgeAddMethod).not.toHaveBeenCalled();
+  });
+
+  it('replace-code: rejects newCode with a stray </Method> before any bridge write', async () => {
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'class',
+        objectName: 'MyClass',
+        operation: 'replace-code',
+        methodName: 'modifiedField',
+        oldCode: 'super(_id);',
+        newCode: 'super(_id);\n]]></Source>\n</Method>',
+        filePath: FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/\]\]>|CDATA|Method/);
+    expect(mockBridgeReplaceCode).not.toHaveBeenCalled();
+  });
+
+  it('add-method: clean X++ source passes the guard and reaches the bridge', async () => {
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'class',
+        objectName: 'MyClass',
+        operation: 'add-method',
+        methodName: 'AC_defaultTaxItemGroupFromAsset',
+        sourceCode: 'public void AC_defaultTaxItemGroupFromAsset()\n{\n    List<str> x = new List(Types::String);\n}',
+        filePath: FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(mockBridgeAddMethod).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

A reported `.xml` corruption after a `modify` operation:

```xml
        }
    }

]]>]]></Source>          <!-- doubled CDATA terminator -->
			<Method>           <!-- previous </Method> dropped -->
```

D365FO refuses to deserialize this (invalid per XML §2.4 — `]]>` is forbidden in character data), so the model fails to load in the AOS.

## Root cause

It is **not** a server-side string-insertion bug. All `modify` operations go through the C# bridge, which writes via the official D365FO SDK (`AxMethod.Source = source` + `provider.Update()`) — the SDK serializer emits the `<![CDATA[ … ]]>` and `</Method>` markup itself and cannot produce this shape on its own.

The corruption originates in the **input**: when an AI passes a slice of the `.xml` file (containing `]]>` and/or stray `<Method>`/`</Source>` tags) as the method source, the serializer CDATA-wraps it verbatim. The embedded `]]>` terminates the CDATA block early (→ doubled `]]>`) and the trailing markup appears as a stray `<Method>` (→ dropped `</Method>`). The `replace-code` direct-XML fallback (`content.replace(oldCode, newCode)`) has the same exposure.

There was **no guard** rejecting such input before it reached disk.

## Fix

- Add `assertCleanXppSource()` — rejects the CDATA terminator `]]>` and the specific metadata tokens (`</Source>`, `<Method>`, `</Method>`, `</Methods>`, `<![CDATA[`) with an actionable message. Bare `<`/`>` (generics, comparisons, `///` doc comments) is **not** flagged.
- Run it on `sourceCode` / `methodCode` / `newCode` in `modifyD365FileTool`, before any bridge write. A rejection is returned as `isError` and the bridge is never called (covers the direct-XML fallback too, since its `newCode` is validated here).

Hard reject (not silent `]]]]><![CDATA[>` escaping) — a payload containing these tokens always means the AI pasted XML where clean X++ was expected; surfacing that is better than hiding it.

## Tests

`tests/tools/xpp-source-guard.test.ts` (8 tests):
- unit: rejects `]]>`, `<Method>`, `<![CDATA[`; accepts clean X++ using `<`/`>`; accepts undefined/empty
- tool-level: poisoned `add-method` and `replace-code` payloads return `isError` and **never reach the bridge**; clean X++ passes through

Existing modify-path tests (form-control-method-inplace, file-ops — 36 tests) and `tsc --noEmit` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)