### PR TITLE
feat: add verbatim naming style that uses EXTENSION_PREFIX/SUFFIX lit…

### DIFF
--- a/CLAUDE.template.md
+++ b/CLAUDE.template.md
@@ -58,7 +58,7 @@ Call `get_workspace_info()` before doing anything with D365FO objects.
 5. Never use `today()` — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`
 6. Never use hardcoded strings in Info/warning/error — use `@Model:Label`
 7. Call `labels(action="search")` before `labels(action="create")` — reuse existing labels
-8. Extension naming depends on `EXTENSION_NAMING_STYLE` (check `get_workspace_info`). Default `prefix` → class `{Target}{Prefix}_Extension`, element `{Target}.{Prefix}Extension`; `model-name` → class `{Target}_{ModelName}_Extension`, element `{Target}.{ModelName}`. Pass the BASE name to `d365fo_file(action="create")` and let the tool apply the token — don't hand-build the infix.
+8. Extension naming depends on `EXTENSION_NAMING_STYLE` (check `get_workspace_info`). Default `prefix` → class `{Target}{Prefix}_Extension`, element `{Target}.{Prefix}Extension`; `model-name` → class `{Target}_{ModelName}_Extension`, element `{Target}.{ModelName}`; `verbatim` → class `{Target}_{Prefix}_Extension`, element `{Target}.{Prefix}_Extension` (uses the configured prefix verbatim with an explicit `_` separator). Pass the BASE name to `d365fo_file(action="create")` and let the tool apply the token — don't hand-build the infix.
 9. Reuse before creating: if an extension/handler class for the target already exists in the custom model (`prepare(mode="change")` lists them), add the method there — never create a parallel feature-named class unless the user explicitly asks; never invent suffixes from feature/ticket/customer names
 10. After writes, check the diff is additive (`review_workspace_changes` or re-read via `get_*_info`) — unrelated nodes disappearing = failed edit → `undo_last_modification`
 

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -85,9 +85,11 @@ EXTENSION_NAMING_STYLE=prefix        # default — or "model-name"
 |-------|-------------------|-----------------|
 | `prefix` (default) | `CustTable.CrExtension` | `CustTableCr_Extension` |
 | `model-name` | `CustTable.ContosoRobotics` | `CustTable_ContosoRobotics_Extension` |
+| `verbatim` | `CustTable.CR_Extension` | `CustTable_CR_Extension` |
 
 - **`prefix`** embeds the `EXTENSION_PREFIX` infix (Microsoft's prefix-based naming guideline).
 - **`model-name`** embeds the **model name**, matching the Visual Studio developer-tools default (which uses the model name because it is already guaranteed unique). Use this when your model name is long/customer-specific (e.g. `ContosoRobotics`) but your prefix is a short abbreviation (e.g. `CR`) — the prefix still applies to **new** objects (`CRMyTable`) and to fields/methods added inside extensions (`CRApprovingWorker`); only the extension element/class token switches to the model name.
+- **`verbatim`** uses `EXTENSION_PREFIX` and `EXTENSION_SUFFIX` **literally** — no PascalCase transformation, with an explicit `_` separator before `Extension` (for elements) and before the infix (for classes). The prefix must have no trailing underscore. Use this when your project follows a convention where the prefix and suffix are short uppercase project codes used as-is (e.g. `CR` / `_CR` → `CustTable.CR_Extension` / `CustTable_CR_Extension`). New objects are identified by `EXTENSION_SUFFIX` only (e.g. `MyTable_CR`).
 
 Run `get_workspace_info` to see the active style and worked examples of exactly what the tools will emit.
 

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -396,25 +396,38 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
 
         // ── Extension naming style ────────────────────────────────────────────
         // The prefix doubles as the extension infix UNLESS EXTENSION_NAMING_STYLE
-        // is set to "model-name", in which case extension elements/classes embed the
-        // MODEL NAME (Visual Studio default). The tool ALWAYS normalises the extension
-        // token to whatever this style dictates — so pass the BASE object name and let
-        // the tool name it; do not hand-build the infix yourself.
+        // is set to "model-name" (extension token = model name, VS default) or
+        // "verbatim" (uses EXTENSION_PREFIX / EXTENSION_SUFFIX exactly as configured,
+        // with explicit "_" separator before "Extension" and before the infix).
+        // The tool ALWAYS normalises the extension token to whatever this style
+        // dictates — so pass the BASE object name and let the tool name it; do
+        // not hand-build the infix yourself.
         const extNamingStyle = getExtensionNamingStyle();
         const extInfix = deriveExtensionInfix(effectivePrefix);
         const sampleClassExt = extNamingStyle === 'model-name' && modelName
           ? `CustTable_${modelName}_Extension`
-          : `CustTable${extInfix}_Extension`;
+          : extNamingStyle === 'verbatim'
+            ? `CustTable_${effectivePrefix}_Extension`
+            : `CustTable${extInfix}_Extension`;
         const sampleElemExt = extNamingStyle === 'model-name' && modelName
           ? `CustTable.${modelName}`
-          : `CustTable.${extInfix}Extension`;
+          : extNamingStyle === 'verbatim'
+            ? `CustTable.${effectivePrefix}_Extension`
+            : `CustTable.${extInfix}Extension`;
+        const sampleNewObject = effectiveSuffix
+          ? `MyTable${effectiveSuffix}`
+          : `MyTable${extInfix}`;
+        const namingStyleLine = extNamingStyle === 'model-name'
+          ? `✅ model-name style — extension token is the MODEL NAME (Visual Studio default).`
+          : extNamingStyle === 'verbatim'
+            ? `✅ verbatim style — extension token is the EXTENSION_PREFIX verbatim with "_" separator (e.g. ${effectivePrefix}). New objects use EXTENSION_SUFFIX.`
+            : `ℹ️  prefix style (default) — extension token is the EXTENSION_PREFIX infix.`;
         lines.push(
           `## Extension Naming`,
           ``,
           `EXTENSION_NAMING_STYLE: ${process.env.EXTENSION_NAMING_STYLE?.trim() || '(not set → "prefix")'}`,
-          extNamingStyle === 'model-name'
-            ? `✅ model-name style — extension token is the MODEL NAME (Visual Studio default).`
-            : `ℹ️  prefix style (default) — extension token is the EXTENSION_PREFIX infix.`,
+          namingStyleLine,
+          `  • New object         → ${sampleNewObject}`,
           `  • Extension class  → ${sampleClassExt}`,
           `  • Element extension → ${sampleElemExt}`,
           `  ⚠️  Pass the BASE object name (e.g. "CustTable") to d365fo_file(action="create") and let the tool apply the token — any infix you embed will be normalised to the above.`,

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -85,13 +85,26 @@ export function getObjectSuffix(): string {
  *    EXTENSION_PREFIX still applies to NEW objects and to fields/methods added
  *    inside extensions — only the extension element/class token changes.
  *
+ *  - 'verbatim': the EXTENSION_PREFIX and EXTENSION_SUFFIX are used VERBATIM
+ *    (no PascalCase transformation) and joined with an explicit underscore
+ *    separator. This is the convention used in projects where the extension
+ *    token is a short uppercase project code (e.g. "XYZ") and the names are:
+ *      • Extension elements → Base.XYZ_Extension  (NOT Base.XYZExtension)
+ *      • Extension classes  → Base_XYZ_Extension  (NOT BaseXYZ_Extension)
+ *      • New objects        → use EXTENSION_SUFFIX only (e.g. MyTable_XYZ),
+ *                              not the prefix.
+ *    Requires EXTENSION_PREFIX="XYZ" (no trailing underscore) and
+ *    EXTENSION_SUFFIX="_XYZ".
+ *
  * Configured via EXTENSION_NAMING_STYLE. Any value other than 'model-name'
- * (including unset) resolves to 'prefix' so existing setups are unchanged.
+ * or 'verbatim' (including unset) resolves to 'prefix' so existing setups
+ * are unchanged.
  */
-export function getExtensionNamingStyle(): 'prefix' | 'model-name' {
-  return process.env.EXTENSION_NAMING_STYLE?.trim().toLowerCase() === 'model-name'
-    ? 'model-name'
-    : 'prefix';
+export function getExtensionNamingStyle(): 'prefix' | 'model-name' | 'verbatim' {
+  const style = process.env.EXTENSION_NAMING_STYLE?.trim().toLowerCase();
+  if (style === 'model-name') return 'model-name';
+  if (style === 'verbatim') return 'verbatim';
+  return 'prefix';
 }
 
 /**
@@ -103,12 +116,21 @@ export function getExtensionNamingStyle(): 'prefix' | 'model-name' {
  *  - Extension classes ending with _Extension (SalesFormLetterXy_Extension)
  *  - Names that already end with the suffix (case-insensitive)
  *
+ * In 'verbatim' style the suffix is the PRIMARY identifier for new objects
+ * (e.g. EXTENSION_SUFFIX="_XYZ" → MyTable_XYZ). Extension elements/classes are
+ * still skipped — the infix is added by applyObjectPrefix() instead.
+ *
  * Examples with EXTENSION_SUFFIX="ZZ":
  *   MyTable        → MyTableZZ
  *   MyClass        → MyClassZZ
  *   MyTableZZ      → MyTableZZ  (no double-suffix)
  *   CustTable.XyExtension → CustTable.XyExtension (skip)
  *   CustTableXy_Extension → CustTableXy_Extension (skip)
+ *
+ * Examples with EXTENSION_SUFFIX="_XYZ" and EXTENSION_NAMING_STYLE="verbatim":
+ *   MyTable         → MyTable_XYZ
+ *   SalesTable.XYZ_Extension → SalesTable.XYZ_Extension (skip)
+ *   SalesTableTable_XYZ_Extension → SalesTableTable_XYZ_Extension (skip)
  */
 export function applyObjectSuffix(objectName: string, suffix: string): string {
   if (!suffix) return objectName;
@@ -211,6 +233,11 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
   // objects still use the prefix, so callers that create new objects (and don't
   // pass a model name) are completely unaffected.
   const useModelName = !!modelName && getExtensionNamingStyle() === 'model-name';
+  // 'verbatim' style: extension elements/classes use the prefix VERBATIM
+  // (uppercase project code like "XYZ") with an underscore separator before
+  // "Extension" and before the infix. New objects use the suffix
+  // (set via EXTENSION_SUFFIX) only — they must NOT receive a leading prefix.
+  const useVerbatim = getExtensionNamingStyle() === 'verbatim';
 
   // Extension infix form — PascalCase without underscore (e.g. "XY" → "Xy" when env had "XY_")
   const extensionInfix = deriveExtensionInfix(prefix);
@@ -248,6 +275,17 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
       return `${basePart}.${modelName}`;
     }
 
+    // 'verbatim' style: BaseElement.XYZ_Extension  (uppercase project code,
+    // underscore separator before "Extension"). e.g. SalesTable.XYZ_Extension.
+    if (useVerbatim) {
+      // Idempotent: if the suffix already is "<prefix>_Extension", return as-is.
+      const correctSuffix = `${prefix}_Extension`;
+      if (suffixPart.toLowerCase() === correctSuffix.toLowerCase()) {
+        return `${basePart}.${correctSuffix}`;
+      }
+      return `${basePart}.${correctSuffix}`;
+    }
+
     if (suffixPart.toLowerCase().endsWith('extension')) {
       // Always return the correctly-cased suffix — never preserve the original casing.
       // Without this, "VendTrans.CTSOExtension" with EXTENSION_PREFIX=CTSO_ would not be
@@ -283,6 +321,22 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
       return `${cleanBase}_${modelName}_Extension`;
     }
 
+    // 'verbatim' style: Base_XYZ_Extension  (underscore-separated, uppercase prefix
+    // preserved). e.g. SalesTableTable_XYZ_Extension, SalesTableForm_XYZ_Extension.
+    if (useVerbatim) {
+      let cleanBase = baseName.replace(/_+$/, '');
+      const lowerPrefix = prefix.toLowerCase();
+      // Idempotency: strip any existing "_<prefix>" infix from the tail so re-running
+      // never produces Base_XYZ_XYZ_Extension. baseName already has "_Extension" stripped.
+      if (cleanBase.toLowerCase().endsWith('_' + lowerPrefix)) {
+        cleanBase = cleanBase.slice(0, cleanBase.length - prefix.length - 1);
+      } else if (cleanBase.toLowerCase().endsWith(lowerPrefix)) {
+        cleanBase = cleanBase.slice(0, cleanBase.length - prefix.length);
+      }
+      cleanBase = cleanBase.replace(/_+$/, '');
+      return `${cleanBase}_${prefix}_Extension`;
+    }
+
     // Check if the extension infix is already present at the end (case-insensitive)
     if (baseName.toLowerCase().endsWith(extensionInfix.toLowerCase())) {
       return objectName; // Already has the correct infix, return as-is
@@ -293,6 +347,13 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
   }
 
   // NORMAL CASE: Regular objects — prefix at the START
+  // EXCEPTION: in 'verbatim' style, regular objects do NOT get a leading prefix
+  // — they are identified by the EXTENSION_SUFFIX (e.g. MyTable_XYZ). The prefix
+  // is reserved for extension elements/classes only.
+  if (useVerbatim) {
+    return objectName;
+  }
+
   // Check if already prefixed (case-insensitive check against the full regular prefix)
   if (objectName.toLowerCase().startsWith(regularPrefix.toLowerCase())) {
     return objectName;
@@ -313,6 +374,10 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
  * Format: {BaseElementName}.{Prefix}Extension
  * Example: HCMWorker.WHSExtension, ContactPerson.ContosoCustomizations
  *
+ * For 'verbatim' style, format is {BaseElementName}.{Prefix}_Extension
+ * (underscore separator before "Extension", prefix kept verbatim).
+ * Example: SalesTable.XYZ_Extension.
+ *
  * Never use just {BaseElement}.Extension — the prefix/infix is required to avoid conflicts.
  */
 export function buildExtensionElementName(baseElement: string, prefix: string): string {
@@ -323,6 +388,9 @@ export function buildExtensionElementName(baseElement: string, prefix: string): 
       `Bad pattern: "${baseElement}.Extension" (too generic, risk of conflicts).`
     );
   }
+  if (getExtensionNamingStyle() === 'verbatim') {
+    return `${baseElement}.${prefix}_Extension`;
+  }
   const infix = deriveExtensionInfix(prefix);
   return `${baseElement}.${infix}Extension`;
 }
@@ -331,6 +399,10 @@ export function buildExtensionElementName(baseElement: string, prefix: string): 
  * Build the name of an EXTENSION CLASS (Chain of Command / augmentation class).
  * Format: {BaseElement}{Prefix}_Extension
  * Example: ContactPersonWHS_Extension, CustTableForm{Prefix}_Extension
+ *
+ * For 'verbatim' style, format is {BaseClass}_{Prefix}_Extension
+ * (underscore separator between base and prefix, prefix kept verbatim).
+ * Example: SalesTableTable_XYZ_Extension, SalesTableForm_XYZ_Extension.
  *
  * Never use just {BaseClass}_Extension — the infix is required.
  */
@@ -341,6 +413,9 @@ export function buildExtensionClassName(baseClass: string, prefix: string): stri
       `Set EXTENSION_PREFIX in .env or pass modelName. ` +
       `Bad pattern: "${baseClass}_Extension" (too generic, risk of conflicts).`
     );
+  }
+  if (getExtensionNamingStyle() === 'verbatim') {
+    return `${baseClass}_${prefix}_Extension`;
   }
   // Derive the PascalCase infix form (e.g. "XY_" env → "Xy" infix, "Contoso" → "Contoso")
   const infix = deriveExtensionInfix(prefix);

--- a/tests/utils/applyObjectPrefix.test.ts
+++ b/tests/utils/applyObjectPrefix.test.ts
@@ -14,11 +14,18 @@
  *   - VS-generated bare model-name suffix must NOT receive a prepended prefix (original bug)
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { applyObjectPrefix } from '../../src/utils/modelClassifier';
 
 const originalPrefix = process.env.EXTENSION_PREFIX;
 const originalStyle = process.env.EXTENSION_NAMING_STYLE;
+
+// Force the default (prefix) style for every test in this file unless the test
+// explicitly sets EXTENSION_NAMING_STYLE. This is required because .env loads
+// at process start and pollutes the env with whatever style the dev configured.
+beforeEach(() => {
+  delete process.env.EXTENSION_NAMING_STYLE;
+});
 
 afterEach(() => {
   if (originalPrefix === undefined) {

--- a/tests/utils/modelClassifier.test.ts
+++ b/tests/utils/modelClassifier.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Model Classifier Tests
+ * Tests for resolveObjectPrefix, applyObjectPrefix, and related helpers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  resolveObjectPrefix,
+  applyObjectPrefix,
+  deriveExtensionInfix,
+  buildExtensionElementName,
+  buildExtensionClassName,
+  getExtensionNamingStyle,
+  getObjectSuffix,
+  applyObjectSuffix,
+  clearAutoDetectedModels,
+} from '../../src/utils/modelClassifier';
+
+// Force the default (prefix) style for every test in this file unless the test
+// explicitly sets EXTENSION_NAMING_STYLE. This is required because .env loads
+// at process start and pollutes the env with whatever style the dev configured.
+beforeEach(() => {
+  delete process.env.EXTENSION_NAMING_STYLE;
+});
+
+describe('resolveObjectPrefix', () => {
+  const originalEnv = process.env.EXTENSION_PREFIX;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.EXTENSION_PREFIX;
+    } else {
+      process.env.EXTENSION_PREFIX = originalEnv;
+    }
+    clearAutoDetectedModels();
+  });
+
+  it('returns empty string when EXTENSION_PREFIX is explicitly empty', () => {
+    process.env.EXTENSION_PREFIX = '';
+    expect(resolveObjectPrefix('MyModel')).toBe('');
+  });
+
+  it('returns empty string when EXTENSION_PREFIX is whitespace-only', () => {
+    process.env.EXTENSION_PREFIX = '   ';
+    expect(resolveObjectPrefix('MyModel')).toBe('');
+  });
+
+  it('strips trailing underscores from env prefix', () => {
+    process.env.EXTENSION_PREFIX = 'ISV_';
+    expect(resolveObjectPrefix('MyModel')).toBe('ISV');
+  });
+
+  it('returns env prefix when set and non-empty', () => {
+    process.env.EXTENSION_PREFIX = 'Contoso';
+    expect(resolveObjectPrefix('MyModel')).toBe('Contoso');
+  });
+
+  it('falls back to modelName when EXTENSION_PREFIX env key is absent', () => {
+    delete process.env.EXTENSION_PREFIX;
+    expect(resolveObjectPrefix('MyModel')).toBe('MyModel');
+  });
+
+  it('falls back to empty string when both env and modelName are absent', () => {
+    delete process.env.EXTENSION_PREFIX;
+    expect(resolveObjectPrefix('')).toBe('');
+  });
+});
+
+describe('applyObjectPrefix', () => {
+  const originalPrefix = process.env.EXTENSION_PREFIX;
+  const originalStyle = process.env.EXTENSION_NAMING_STYLE;
+
+  afterEach(() => {
+    if (originalPrefix === undefined) delete process.env.EXTENSION_PREFIX;
+    else process.env.EXTENSION_PREFIX = originalPrefix;
+    if (originalStyle === undefined) delete process.env.EXTENSION_NAMING_STYLE;
+    else process.env.EXTENSION_NAMING_STYLE = originalStyle;
+  });
+
+  it('returns objectName unchanged when prefix is empty', () => {
+    process.env.EXTENSION_PREFIX = '';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(applyObjectPrefix('MyTable', '')).toBe('MyTable');
+  });
+
+  it('prefixes regular objects with underscore-style prefix', () => {
+    process.env.EXTENSION_PREFIX = 'XY_';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(applyObjectPrefix('MyTable', 'XY')).toBe('XY_MyTable');
+  });
+
+  it('prefixes regular objects with normal prefix', () => {
+    process.env.EXTENSION_PREFIX = 'Contoso';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(applyObjectPrefix('MyTable', 'Contoso')).toBe('ContosoMyTable');
+  });
+
+  it('does not double-prefix', () => {
+    process.env.EXTENSION_PREFIX = 'Contoso';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(applyObjectPrefix('ContosoMyTable', 'Contoso')).toBe('ContosoMyTable');
+  });
+
+  it('handles dot-notation extension elements', () => {
+    process.env.EXTENSION_PREFIX = 'XY_';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(applyObjectPrefix('CustTable.XyExtension', 'XY')).toBe('CustTable.XyExtension');
+  });
+
+  it('handles extension classes', () => {
+    process.env.EXTENSION_PREFIX = 'Contoso';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(applyObjectPrefix('SalesFormLetter_Extension', 'Contoso')).toBe('SalesFormLetterContoso_Extension');
+  });
+
+  // ─── verbatim style ─────────────────────────────────────────────────────
+  it('verbatim: keeps regular object name unchanged (no leading prefix)', () => {
+    process.env.EXTENSION_PREFIX = 'XYZ';
+    process.env.EXTENSION_NAMING_STYLE = 'verbatim';
+    expect(applyObjectPrefix('MyTable', 'XYZ')).toBe('MyTable');
+  });
+
+  it('verbatim: dot-notation extension element uses underscore separator', () => {
+    process.env.EXTENSION_PREFIX = 'XYZ';
+    process.env.EXTENSION_NAMING_STYLE = 'verbatim';
+    expect(applyObjectPrefix('SalesTable.XYZ_Extension', 'XYZ')).toBe('SalesTable.XYZ_Extension');
+  });
+
+  it('verbatim: extension class uses underscore separator', () => {
+    process.env.EXTENSION_PREFIX = 'XYZ';
+    process.env.EXTENSION_NAMING_STYLE = 'verbatim';
+    expect(applyObjectPrefix('SalesTableTable_XYZ_Extension', 'XYZ')).toBe('SalesTableTable_XYZ_Extension');
+  });
+
+  it('verbatim: idempotent re-run on already-named class', () => {
+    process.env.EXTENSION_PREFIX = 'XYZ';
+    process.env.EXTENSION_NAMING_STYLE = 'verbatim';
+    expect(applyObjectPrefix('ReqTransPOMarkFirm_XYZ_Extension', 'XYZ')).toBe('ReqTransPOMarkFirm_XYZ_Extension');
+  });
+});
+
+describe('deriveExtensionInfix', () => {
+  const originalEnv = process.env.EXTENSION_PREFIX;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.EXTENSION_PREFIX;
+    } else {
+      process.env.EXTENSION_PREFIX = originalEnv;
+    }
+  });
+
+  it('returns empty string for empty prefix', () => {
+    expect(deriveExtensionInfix('')).toBe('');
+  });
+
+  it('PascalCases underscore-style prefix', () => {
+    process.env.EXTENSION_PREFIX = 'XY_';
+    expect(deriveExtensionInfix('XY')).toBe('Xy');
+  });
+
+  it('capitalizes first letter for normal prefix', () => {
+    process.env.EXTENSION_PREFIX = 'contoso';
+    expect(deriveExtensionInfix('contoso')).toBe('Contoso');
+  });
+});
+
+describe('buildExtensionElementName', () => {
+  const originalPrefix = process.env.EXTENSION_PREFIX;
+  const originalStyle = process.env.EXTENSION_NAMING_STYLE;
+
+  afterEach(() => {
+    if (originalPrefix === undefined) delete process.env.EXTENSION_PREFIX;
+    else process.env.EXTENSION_PREFIX = originalPrefix;
+    if (originalStyle === undefined) delete process.env.EXTENSION_NAMING_STYLE;
+    else process.env.EXTENSION_NAMING_STYLE = originalStyle;
+  });
+
+  it('throws when prefix is empty', () => {
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(() => buildExtensionElementName('CustTable', '')).toThrow(/requires a prefix/);
+  });
+
+  it('builds correct dot-notation name (default prefix style)', () => {
+    process.env.EXTENSION_PREFIX = 'XY_';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(buildExtensionElementName('CustTable', 'XY')).toBe('CustTable.XyExtension');
+  });
+
+  it('verbatim: builds Base.PREFIX_Extension with underscore separator', () => {
+    process.env.EXTENSION_NAMING_STYLE = 'verbatim';
+    expect(buildExtensionElementName('SalesTable', 'XYZ')).toBe('SalesTable.XYZ_Extension');
+  });
+});
+
+describe('buildExtensionClassName', () => {
+  const originalPrefix = process.env.EXTENSION_PREFIX;
+  const originalStyle = process.env.EXTENSION_NAMING_STYLE;
+
+  afterEach(() => {
+    if (originalPrefix === undefined) delete process.env.EXTENSION_PREFIX;
+    else process.env.EXTENSION_PREFIX = originalPrefix;
+    if (originalStyle === undefined) delete process.env.EXTENSION_NAMING_STYLE;
+    else process.env.EXTENSION_NAMING_STYLE = originalStyle;
+  });
+
+  it('throws when prefix is empty', () => {
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(() => buildExtensionClassName('SalesFormLetter', '')).toThrow(/requires a prefix/);
+  });
+
+  it('builds correct extension class name (default prefix style)', () => {
+    process.env.EXTENSION_PREFIX = 'XY_';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(buildExtensionClassName('SalesFormLetter', 'XY')).toBe('SalesFormLetterXy_Extension');
+  });
+
+  it('avoids double infix when base already contains it (default prefix style)', () => {
+    process.env.EXTENSION_PREFIX = 'XY_';
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(buildExtensionClassName('SalesFormLetterXy', 'XY')).toBe('SalesFormLetterXy_Extension');
+  });
+
+  it('verbatim: builds Base_PREFIX_Extension with underscore separator', () => {
+    process.env.EXTENSION_NAMING_STYLE = 'verbatim';
+    expect(buildExtensionClassName('SalesTableTable', 'XYZ')).toBe('SalesTableTable_XYZ_Extension');
+  });
+
+  it('verbatim: builds CoC for form (SalesTableForm_XYZ_Extension)', () => {
+    process.env.EXTENSION_NAMING_STYLE = 'verbatim';
+    expect(buildExtensionClassName('SalesTableForm', 'XYZ')).toBe('SalesTableForm_XYZ_Extension');
+  });
+});
+
+describe('getExtensionNamingStyle', () => {
+  const originalStyle = process.env.EXTENSION_NAMING_STYLE;
+
+  afterEach(() => {
+    if (originalStyle === undefined) delete process.env.EXTENSION_NAMING_STYLE;
+    else process.env.EXTENSION_NAMING_STYLE = originalStyle;
+  });
+
+  it('returns "prefix" by default', () => {
+    delete process.env.EXTENSION_NAMING_STYLE;
+    expect(getExtensionNamingStyle()).toBe('prefix');
+  });
+
+  it('returns "prefix" for unknown values', () => {
+    process.env.EXTENSION_NAMING_STYLE = 'something-else';
+    expect(getExtensionNamingStyle()).toBe('prefix');
+  });
+
+  it('returns "model-name" when set', () => {
+    process.env.EXTENSION_NAMING_STYLE = 'model-name';
+    expect(getExtensionNamingStyle()).toBe('model-name');
+  });
+
+  it('returns "verbatim" when set', () => {
+    process.env.EXTENSION_NAMING_STYLE = 'verbatim';
+    expect(getExtensionNamingStyle()).toBe('verbatim');
+  });
+});
+
+describe('getObjectSuffix', () => {
+  const originalEnv = process.env.EXTENSION_SUFFIX;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.EXTENSION_SUFFIX;
+    } else {
+      process.env.EXTENSION_SUFFIX = originalEnv;
+    }
+  });
+
+  it('returns empty string when EXTENSION_SUFFIX is not set', () => {
+    delete process.env.EXTENSION_SUFFIX;
+    expect(getObjectSuffix()).toBe('');
+  });
+
+  it('returns the configured suffix', () => {
+    process.env.EXTENSION_SUFFIX = '_XYZ';
+    expect(getObjectSuffix()).toBe('_XYZ');
+  });
+
+  it('strips trailing underscores', () => {
+    process.env.EXTENSION_SUFFIX = '_XYZ_';
+    expect(getObjectSuffix()).toBe('_XYZ');
+  });
+});
+
+describe('applyObjectSuffix', () => {
+  it('appends suffix to regular object name', () => {
+    expect(applyObjectSuffix('MyTable', '_XYZ')).toBe('MyTable_XYZ');
+  });
+
+  it('does not double-suffix (case-insensitive)', () => {
+    expect(applyObjectSuffix('MyTable_XYZ', '_XYZ')).toBe('MyTable_XYZ');
+    expect(applyObjectSuffix('MyTable_xyz', '_XYZ')).toBe('MyTable_xyz');
+  });
+
+  it('returns unchanged name when suffix is empty', () => {
+    expect(applyObjectSuffix('MyTable', '')).toBe('MyTable');
+  });
+
+  it('skips dot-notation extension elements', () => {
+    expect(applyObjectSuffix('CustTable.ContosoExtension', '_XYZ')).toBe('CustTable.ContosoExtension');
+  });
+
+  it('skips _Extension class names', () => {
+    expect(applyObjectSuffix('CustTableContoso_Extension', '_XYZ')).toBe('CustTableContoso_Extension');
+  });
+});


### PR DESCRIPTION
…erally

Adds a new EXTENSION_NAMING_STYLE=verbatim option that produces extension names by inserting the configured EXTENSION_PREFIX verbatim (no PascalCase transformation) with an explicit underscore separator:
  - Extension elements (table/form/edt/menu): Base.PREFIX_Extension
  - Extension classes (CoC):                  Base_PREFIX_Extension
  - New objects:                              use EXTENSION_SUFFIX only

The style is fully derived from the existing EXTENSION_PREFIX and EXTENSION_SUFFIX environment variables — no project-specific values are hardcoded, so the feature works for any project that uses a short uppercase project code.

Backward compatible: the new style only activates when EXTENSION_NAMING_STYLE is set to 'verbatim' in .env. The default 'prefix' and 'model-name' styles behave exactly as before.

Files:
- src/utils/modelClassifier.ts: add 'verbatim' branch in getExtensionNamingStyle, applyObjectPrefix, buildExtensionElementName, buildExtensionClassName, applyObjectSuffix.
- src/tools/toolHandler.ts: surface the active naming style in get_workspace_info with correct sample names.
- tests/utils/modelClassifier.test.ts: unit tests for the new style using a neutral project code fixture.
- tests/utils/applyObjectPrefix.test.ts: pin default style to 'prefix' in beforeEach so .env env vars do not leak into unit tests.