### PR TITLE
fix(modify): advertise all modify-operation params and align handler …

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -704,6 +704,18 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                 type: 'string',
                 description: '[modify] Field label (for add-field and modify-field)'
               },
+              fieldHelpText: {
+                type: 'string',
+                description: '[modify:modify-field] Field help text.'
+              },
+              fieldEnumType: {
+                type: 'string',
+                description: '[modify:modify-field] Enum name to set on an enum-typed field.'
+              },
+              fieldStringSize: {
+                type: 'string',
+                description: '[modify:modify-field] String size to set on a string-typed field.'
+              },
               fields: {
                 type: 'array',
                 description:
@@ -768,6 +780,10 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                   '[modify:add-control] Control type: String (default), Integer, Real, CheckBox (NoYes/boolean), ComboBox (enums), ' +
                   'Date, DateTime, Int64, Group, Button, CommandButton, MenuFunctionButton.'
               },
+              controlLabel: {
+                type: 'string',
+                description: '[modify:add-control] Optional label for the new control.'
+              },
               positionType: {
                 type: 'string',
                 description: '[modify:add-control] Optional: AfterItem | BeforeItem. Omit to append at the end of the parent.'
@@ -776,10 +792,162 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                 type: 'string',
                 description: '[modify:add-control] Name of the sibling control to position after (used with positionType=AfterItem).'
               },
+              baseFormName: {
+                type: 'string',
+                description: '[modify:add-control] Base form name for auto-resolving parentControl when the extension name does not contain it (e.g. objectName="SalesOrder.MyExt" → "SalesOrder"). Pass only when auto-detection fails.'
+              },
+              // ── action=modify: add-table-method / add-display-method ─────────
+              tableMethodType: {
+                type: 'string',
+                enum: ['find', 'exist', 'findByRecId', 'validateWrite', 'validateDelete', 'initValue'],
+                description:
+                  '[modify:add-table-method] Standard table method to auto-generate (method name is implied). ' +
+                  'find/exist also need tableKeyField. Omit and pass methodName+sourceCode for a custom method instead.'
+              },
+              tableKeyField: {
+                type: 'string',
+                description: '[modify:add-table-method] Primary key field for find/exist generation (e.g. "ItemId", "SalesId").'
+              },
+              displayMethodReturnEdt: {
+                type: 'string',
+                description: '[modify:add-display-method] EDT/type the display method returns (e.g. "Name", "AmountMST"). With methodName, auto-generates a display-method stub. Omit and pass sourceCode for a custom body.'
+              },
+              // ── action=modify: add-index / remove-index ─────────────────────
+              indexName: {
+                type: 'string',
+                description: '[modify:add-index/remove-index] Index name.'
+              },
+              indexFields: {
+                type: 'array',
+                description: '[modify:add-index] Fields that make up the index (required for add-index).',
+                items: {
+                  type: 'object',
+                  properties: {
+                    fieldName: { type: 'string', description: 'Field name.' },
+                    direction: { type: 'string', enum: ['Asc', 'Desc'], description: 'Sort direction (optional).' },
+                  },
+                  required: ['fieldName'],
+                },
+              },
+              indexAllowDuplicates: {
+                type: 'boolean',
+                description: '[modify:add-index] Allow duplicates (default: false = unique).'
+              },
+              indexAlternateKey: {
+                type: 'boolean',
+                description: '[modify:add-index] Mark the index as an alternate key.'
+              },
+              indexEnabled: {
+                type: 'boolean',
+                description: '[modify:add-index] Whether the index is enabled (default: true).'
+              },
+              // ── action=modify: add-relation / remove-relation ───────────────
+              relationName: {
+                type: 'string',
+                description: '[modify:add-relation/remove-relation] Relation name.'
+              },
+              relatedTable: {
+                type: 'string',
+                description: '[modify:add-relation] Related (foreign key) table name.'
+              },
+              relationConstraints: {
+                type: 'array',
+                description: '[modify:add-relation] Field constraints (field = relatedField pairs).',
+                items: {
+                  type: 'object',
+                  properties: {
+                    fieldName: { type: 'string', description: 'Local field name.' },
+                    relatedFieldName: { type: 'string', description: 'Field name in the related table.' },
+                  },
+                  required: ['fieldName', 'relatedFieldName'],
+                },
+              },
+              relationCardinality: {
+                type: 'string',
+                description: '[modify:add-relation] Local-side cardinality: ZeroMore | ZeroOne | ExactlyOne (default: ZeroMore).'
+              },
+              relatedTableCardinality: {
+                type: 'string',
+                description: '[modify:add-relation] Related-side cardinality: ZeroMore | ZeroOne | ExactlyOne (default: ExactlyOne).'
+              },
+              relationshipType: {
+                type: 'string',
+                description: '[modify:add-relation] Association | Composition | Aggregation | Link | Specialization (default: Association).'
+              },
+              // ── action=modify: field groups ─────────────────────────────────
+              fieldGroupName: {
+                type: 'string',
+                description: '[modify:add-field-group/remove-field-group/add-field-to-field-group] Field group name.'
+              },
+              fieldGroupFields: {
+                type: 'array',
+                description: '[modify:add-field-group] Initial field names (may be empty — add later with add-field-to-field-group).',
+                items: { type: 'string' },
+              },
+              fieldGroupLabel: {
+                type: 'string',
+                description: '[modify:add-field-group] Field group label (optional).'
+              },
+              extendBaseFieldGroup: {
+                type: 'boolean',
+                description: '[modify:add-field-to-field-group] table-extension only: true extends an existing base-table field group (<FieldGroupExtensions>); false/omitted adds to a new group defined in the extension.'
+              },
+              // ── action=modify: add-data-source (form-extension) ─────────────
+              dataSourceName: {
+                type: 'string',
+                description: '[modify:add-data-source] Data source reference name (e.g. "MyTable_1").'
+              },
+              dataSourceTable: {
+                type: 'string',
+                description: '[modify:add-data-source] Base table for the data source (e.g. "MyTable").'
+              },
+              joinSource: {
+                type: 'string',
+                description: '[modify:add-data-source] Optional existing data source on the form to join the new one to.'
+              },
+              linkType: {
+                type: 'string',
+                description: '[modify:add-data-source] Optional join/link type when joinSource is set: InnerJoin | OuterJoin | ExistJoin | NotExistJoin | Delayed | Active | Passive.'
+              },
+              // ── action=modify: enum values ──────────────────────────────────
+              enumValueName: {
+                type: 'string',
+                description: '[modify:add-enum-value/modify-enum-value/remove-enum-value] Enum value name (e.g. "Approved").'
+              },
+              enumValueLabel: {
+                type: 'string',
+                description: '[modify:add-enum-value/modify-enum-value] Label reference (e.g. "@MyModel:Approved").'
+              },
+              enumValueHelpText: {
+                type: 'string',
+                description: '[modify:add-enum-value] Help-text reference (optional).'
+              },
+              enumValueInt: {
+                type: 'number',
+                description: '[modify:add-enum-value] Explicit integer value; if omitted the next available value is assigned. With modify-enum-value, changes the integer (rare).'
+              },
+              enumValueCountryRegionCodes: {
+                type: 'string',
+                description: '[modify:add-enum-value] ISO country/region codes, comma-separated (e.g. "CZ,SK").'
+              },
+              // ── action=modify: add-menu-item-to-menu ────────────────────────
+              menuItemToAdd: {
+                type: 'string',
+                description: '[modify:add-menu-item-to-menu] Name of the menu item to add (e.g. "MyCustomForm").'
+              },
+              menuItemToAddType: {
+                type: 'string',
+                enum: ['display', 'action', 'output'],
+                description: '[modify:add-menu-item-to-menu] Menu item kind: display (form), action (class), output (report). Default: display.'
+              },
               createBackup: {
                 type: 'boolean',
                 description: '[modify] Create backup before modification (default: false)',
                 default: false
+              },
+              filePath: {
+                type: 'string',
+                description: '[modify] Absolute path to the XML file — bypasses symbol-DB lookup. Use when the object was just created and the path is known.'
               },
               workspacePath: {
                 type: 'string',

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -275,6 +275,9 @@ const ModifyD365FileArgsSchema = z.object({
     'Use CheckBox for NoYes/boolean fields. Use ComboBox for enum fields. ' +
     'If omitted the tool auto-picks based on the EDT base type if controlDataField is provided.'
   ),
+  controlLabel: z.string().optional().describe(
+    'Optional label for the new control (add-control). Becomes the control <Label>.'
+  ),
   positionType: z.string().optional().describe(
     'Optional positioning: AfterItem | BeforeItem. Omit to append at the end of the parent.'
   ),
@@ -330,6 +333,9 @@ const ModifyD365FileArgsSchema = z.object({
   ),
   fieldMandatory: z.boolean().optional().describe('Is field mandatory'),
   fieldLabel: z.string().optional().describe('Field label'),
+  fieldHelpText: z.string().optional().describe('Field help text (modify-field).'),
+  fieldEnumType: z.string().optional().describe('Enum name to set on the field (modify-field, for enum-typed fields).'),
+  fieldStringSize: z.string().optional().describe('String size to set on the field (modify-field, for string-typed fields).'),
   fields: z.array(z.object({
     name: z.string(),
     edt: z.string().optional(),
@@ -379,6 +385,12 @@ const ModifyD365FileArgsSchema = z.object({
   // For add-data-source (form-extension)
   dataSourceName: z.string().optional().describe('Data source reference name for add-data-source (e.g. "MyTable_1").'),
   dataSourceTable: z.string().optional().describe('Base table name for add-data-source (e.g. "MyTable").'),
+  joinSource: z.string().optional().describe(
+    'Optional name of an existing data source on the form to join the new data source to (add-data-source).'
+  ),
+  linkType: z.string().optional().describe(
+    'Optional join/link type when joinSource is set (add-data-source): InnerJoin | OuterJoin | ExistJoin | NotExistJoin | Delayed | Active | Passive.'
+  ),
 
   // For modify-property
   propertyPath: z.string().optional().describe(
@@ -784,13 +796,15 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'modify-field': {
         if (args.fieldName) {
+          // Read the documented field-* params (the advertised surface). The bridge
+          // expects bare prop keys (label/edt/mandatory/…), so map onto those here.
           const fieldProps: Record<string, string> = {};
-          if ((args as any).label) fieldProps.label = (args as any).label;
-          if ((args as any).helpText) fieldProps.helpText = (args as any).helpText;
-          if ((args as any).mandatory !== undefined) fieldProps.mandatory = String((args as any).mandatory);
-          if ((args as any).edt) fieldProps.edt = (args as any).edt;
-          if ((args as any).enumType) fieldProps.enumType = (args as any).enumType;
-          if ((args as any).stringSize) fieldProps.stringSize = String((args as any).stringSize);
+          if ((args as any).fieldLabel) fieldProps.label = (args as any).fieldLabel;
+          if ((args as any).fieldHelpText) fieldProps.helpText = (args as any).fieldHelpText;
+          if ((args as any).fieldMandatory !== undefined) fieldProps.mandatory = String((args as any).fieldMandatory);
+          if ((args as any).fieldType) fieldProps.edt = (args as any).fieldType;
+          if ((args as any).fieldEnumType) fieldProps.enumType = (args as any).fieldEnumType;
+          if ((args as any).fieldStringSize) fieldProps.stringSize = String((args as any).fieldStringSize);
           bridgeResult = await bridgeModifyField(
             context.bridge,
             objectName,
@@ -883,7 +897,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             objectName,
             (args as any).fieldGroupName,
             (args as any).fieldGroupLabel,
-            (args as any).fields,
+            (args as any).fieldGroupFields,
           );
         }
         break;
@@ -1003,7 +1017,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             context.bridge,
             objectName,
             (args as any).enumValueName,
-            (args as any).enumValue ?? 0,
+            (args as any).enumValueInt ?? 0,
             (args as any).enumValueLabel,
             (args as any).enumValueCountryRegionCodes,
           );
@@ -1014,7 +1028,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         if ((args as any).enumValueName) {
           const evProps: Record<string, string> = {};
           if ((args as any).enumValueLabel) evProps.label = (args as any).enumValueLabel;
-          if ((args as any).enumValue !== undefined) evProps.value = String((args as any).enumValue);
+          if ((args as any).enumValueInt !== undefined) evProps.value = String((args as any).enumValueInt);
           bridgeResult = await bridgeModifyEnumValue(
             context.bridge,
             objectName,
@@ -1044,7 +1058,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             (args as any).controlType ?? 'String',
             (args as any).controlDataSource,
             (args as any).controlDataField,
-            (args as any).label,
+            (args as any).controlLabel,
           );
         }
         break;

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -72,6 +72,40 @@ describe('tool inventory contract', () => {
     }
   });
 
+  it('advertises modify-operation params in the d365fo_file inputSchema', () => {
+    // Regression guard: the advertised inputSchema is the only param surface the
+    // model sees. If an operation's params are handled in modifyD365File.ts but not
+    // exposed here, the model cannot pass them and the op fails with "returned null".
+    const requiredModifyParams = [
+      // add-table-method / add-display-method
+      'tableMethodType', 'tableKeyField', 'displayMethodReturnEdt',
+      // add-index / remove-index
+      'indexName', 'indexFields', 'indexAllowDuplicates', 'indexAlternateKey',
+      // add-relation
+      'relationName', 'relatedTable', 'relationConstraints',
+      // field groups
+      'fieldGroupName', 'fieldGroupFields', 'extendBaseFieldGroup',
+      // add-data-source
+      'dataSourceName', 'dataSourceTable', 'joinSource', 'linkType',
+      // modify-field extras
+      'fieldHelpText', 'fieldEnumType', 'fieldStringSize',
+      // add-control label
+      'controlLabel',
+      // enum values
+      'enumValueName', 'enumValueLabel', 'enumValueInt', 'enumValueCountryRegionCodes',
+      // add-menu-item-to-menu
+      'menuItemToAdd', 'menuItemToAddType',
+      // aliases / lookup
+      'methodCode', 'sourceCode', 'baseFormName', 'filePath',
+    ];
+    for (const param of requiredModifyParams) {
+      expect(
+        new RegExp(`\\b${param}:\\s*\\{`).test(mcpServerSource),
+        `d365fo_file inputSchema is missing advertised modify param '${param}'`,
+      ).toBe(true);
+    }
+  });
+
   it('includes critical diagnostics and SDLC tools in both inventories', () => {
     const criticalTools = [
       'get_workspace_info',


### PR DESCRIPTION
…arg names

The advertised d365fo_file inputSchema is the only param surface the model sees. It exposed only sourceCode/methodCode plus the field/control params, so any operation whose params were handled in modifyD365File.ts but never advertised could not receive them — the model literally could not pass tableMethodType, indexName, relationName, fieldGroupName, dataSourceName, enumValue*, menuItemToAdd, etc. It fell back to cramming everything into sourceCode/methodCode (e.g. methodCode="dataSourceName=...;dataSourceTable=...") and the op failed with "returned null — required parameters may be missing".

Audited every arg the modify switch reads against the Zod schema and the advertised schema, and closed every gap:

Advertised in the inputSchema (now reachable by the model):
- add-table-method: tableMethodType, tableKeyField
- add-display-method: displayMethodReturnEdt
- add-index/remove-index: indexName, indexFields, indexAllowDuplicates, indexAlternateKey, indexEnabled
- add-relation: relationName, relatedTable, relationConstraints, relationCardinality, relatedTableCardinality, relationshipType
- field groups: fieldGroupName, fieldGroupFields, fieldGroupLabel, extendBaseFieldGroup
- add-data-source: dataSourceName, dataSourceTable, joinSource, linkType
- enum values: enumValueName, enumValueLabel, enumValueHelpText, enumValueInt, enumValueCountryRegionCodes
- add-menu-item-to-menu: menuItemToAdd, menuItemToAddType
- add-control: baseFormName, controlLabel
- modify-field: fieldHelpText, fieldEnumType, fieldStringSize
- modify lookup-bypass: filePath

Handler arg-name mismatches fixed (ops were silently broken):
- enum value: read enumValueInt, not enumValue
- modify-field: read documented fieldLabel/fieldType/fieldMandatory/ fieldHelpText/fieldEnumType/fieldStringSize, not bare label/edt/mandatory/...
- add-field-group: pass fieldGroupFields (string[]), not fields (object[])
- add-control: read controlLabel, not label
- add-index: read indexAllowDuplicates/indexAlternateKey, not allowDuplicates/ alternateKey

Adds a tool-inventory regression test asserting these params stay advertised.