### PR TITLE
Fix/modify tool param aliases and method gen

### DIFF
--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -968,9 +968,6 @@ const BRIDGE_MODIFY_TYPES = new Set([
   'form', 'query', 'view',
   'class-extension', 'table-extension', 'form-extension', 'enum-extension',
   'menu-item-action', 'menu-item-display', 'menu-item-output',
-  // 'menu' is the only object type add-menu-item-to-menu targets — the C# bridge
-  // (RequestDispatcher → MetadataWriteService.AddMenuItemToMenu) loads the AxMenu
-  // by name and updates it. Without this the operation is rejected before dispatch.
   'menu',
 ]);
 

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -968,6 +968,10 @@ const BRIDGE_MODIFY_TYPES = new Set([
   'form', 'query', 'view',
   'class-extension', 'table-extension', 'form-extension', 'enum-extension',
   'menu-item-action', 'menu-item-display', 'menu-item-output',
+  // 'menu' is the only object type add-menu-item-to-menu targets — the C# bridge
+  // (RequestDispatcher → MetadataWriteService.AddMenuItemToMenu) loads the AxMenu
+  // by name and updates it. Without this the operation is rejected before dispatch.
+  'menu',
 ]);
 
 /**

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -579,6 +579,8 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                   '• edt: label, extends, edtType, stringSize\n' +
                   '• form: caption, formTemplate, dataSource\n' +
                   '• security-privilege: label, targetObject, objectType (MenuItemDisplay|Action|Output), accessLevel (view|maintain)\n' +
+                  '• security-duty: label, privileges[] (privilege names — array or comma-separated)\n' +
+                  '• security-role: label, duties[] (duty names), privileges[] (privilege names)\n' +
                   '• menu-item-*: label, object, objectType\n' +
                   'Example: properties={"fields":[{"name":"ContosoStatus","enumType":"NoYes","fieldType":"AxTableFieldEnum","label":"@Contoso:Status"}]}'
               },
@@ -1127,7 +1129,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               },
               createLabelFileIfMissing: {
                 type: 'boolean',
-                description: '[create] Create AxLabelFile structure if missing (default: false).',
+                description: '[create] Create the AxLabelFile structure if missing (default: true). A wrong-path guard still fails loudly when the model directory is not found, so no phantom file is produced. Set false to fail fast instead.',
               },
               sortLabels: {
                 type: 'boolean',

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -2622,30 +2622,58 @@ ${relationsXml}
   }
 
   /**
+   * Normalize a name list that may arrive as an array or a comma/semicolon/
+   * newline-separated string (models pass either). Returns trimmed, non-empty names.
+   */
+  static normalizeNameList(value: any): string[] {
+    if (!value) return [];
+    const arr = Array.isArray(value) ? value : String(value).split(/[,;\n]+/);
+    return arr.map((s: any) => String(s).trim()).filter((s: string) => s.length > 0);
+  }
+
+  /**
+   * Render a security reference container: a self-closing tag when empty, or the
+   * wrapped child references (e.g. <AxSecurityRolePermissionSet><Name>…</Name></…>).
+   */
+  private static securityRefContainer(container: string, childTag: string, names: string[]): string {
+    if (names.length === 0) return `\t<${container} />`;
+    const children = names
+      .map(n => `\t\t<${childTag}>\n\t\t\t<Name>${n}</Name>\n\t\t</${childTag}>`)
+      .join('\n');
+    return `\t<${container}>\n${children}\n\t</${container}>`;
+  }
+
+  /**
    * Generate AxSecurityDuty XML.
+   * properties.privileges – privilege names to reference (array or comma-separated).
    */
   static generateAxSecurityDutyXml(name: string, properties?: Record<string, any>): string {
     const label = properties?.label || '@TODO:LabelId';
+    const privileges = this.normalizeNameList(properties?.privileges);
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
 \t<Label>${label}</Label>
-\t<Privileges />
+${this.securityRefContainer('Privileges', 'AxSecurityRolePermissionSet', privileges)}
 </AxSecurityDuty>`;
   }
 
   /**
    * Generate AxSecurityRole XML.
+   * properties.duties     – duty names to reference (array or comma-separated).
+   * properties.privileges – privilege names to reference directly on the role.
    */
   static generateAxSecurityRoleXml(name: string, properties?: Record<string, any>): string {
     const label = properties?.label || '@TODO:LabelId';
+    const duties = this.normalizeNameList(properties?.duties);
+    const privileges = this.normalizeNameList(properties?.privileges);
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
 \t<Label>${label}</Label>
 \t<DirectAccessPermissions />
-\t<Duties />
-\t<Privileges />
+${this.securityRefContainer('Duties', 'AxSecurityRoleDutyPermission', duties)}
+${this.securityRefContainer('Privileges', 'AxSecurityRolePermissionSet', privileges)}
 \t<SubRoles />
 </AxSecurityRole>`;
   }

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -107,10 +107,11 @@ const CreateLabelArgsSchema = z.object({
   createLabelFileIfMissing: z
     .boolean()
     .optional()
-    .default(false)
+    .default(true)
     .describe(
-      'If true and the AxLabelFile does not exist yet, create it with the provided translations. ' +
-        'Set to false (default) to fail fast when the label file is missing.',
+      'If true (default) and the AxLabelFile does not exist yet, create it with the provided ' +
+        'translations. A wrong-path guard still fails loudly when the model directory is not found, ' +
+        'so this never produces a phantom label file. Set to false to fail fast instead of creating.',
     ),
   allowExtensionLabelFile: z
     .boolean()

--- a/src/tools/formPattern.ts
+++ b/src/tools/formPattern.ts
@@ -53,8 +53,6 @@ export async function formPatternTool(request: CallToolRequest, context: XppServ
     return getFormPatternSpecTool(subRequest('get_form_pattern_spec', rest), context);
   }
 
-  // analyze: full pattern advisor — supports recommend / formPattern / dataSource / similarTo
-  // (the advertised analyze surface). getFormPatternsTool reads (request, context).
   return getFormPatternsTool(subRequest('get_form_patterns', rest), context);
 }
 

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -388,6 +388,26 @@ export async function handleGenerateSmartForm(
       caption: caption || label || finalName,
       gridFields,
     });
+
+    // Template PatternVersions are hardcoded (e.g. 1.1) and can lag behind the
+    // target environment, which then rejects the form in BP with a
+    // BPFrameworkFatalException ("unknown PatternVersion"). Align the Design-level
+    // PatternVersion with the version this environment actually uses for the
+    // pattern (mined from real forms). Sub-pattern versions are left untouched.
+    const designPattern = xml.match(/<Pattern xmlns="">([^<]+)<\/Pattern>/)?.[1];
+    if (designPattern) {
+      const envVersion = resolveEnvPatternVersion(symbolIndex.getReadDb(), designPattern);
+      if (envVersion) {
+        const current = xml.match(/<PatternVersion xmlns="">([^<]*)<\/PatternVersion>/)?.[1];
+        if (current && current !== envVersion) {
+          xml = xml.replace(
+            /(<PatternVersion xmlns="">)[^<]*(<\/PatternVersion>)/,
+            `$1${envVersion}$2`,
+          );
+          cloneNotes += `\n   PatternVersion aligned to this environment: ${current} → ${envVersion}`;
+        }
+      }
+    }
   }
 
   // Optional lifecycle method stubs (pattern-appropriate, with TODO markers)
@@ -429,6 +449,35 @@ export async function handleGenerateSmartForm(
       `\n   ⚠️ Pattern validation found ${patternErrors.length} error(s) in the cloned XML ` +
       `(d365fo_file(action="create") will block them while FORM_PATTERN_ENFORCE=true):\n` +
       errorList.split('\n').map(l => `      ${l}`).join('\n');
+  }
+
+  // Datasource table existence check: a datasource bound to a table that does not
+  // exist (e.g. a wrongly pluralized "…Lines" instead of "…Line") produces a form
+  // that cannot build. Warn — with the closest existing table name — rather than
+  // emitting a silently-broken form.
+  try {
+    const db = symbolIndex.getReadDb();
+    const tableExists = db.prepare(
+      `SELECT 1 FROM symbols WHERE type = 'table' AND name = ? COLLATE NOCASE LIMIT 1`,
+    );
+    const seenTables = new Set<string>();
+    for (const m of xml.matchAll(/<Table>([^<]+)<\/Table>/g)) {
+      const table = m[1].trim();
+      if (!table || seenTables.has(table.toLowerCase())) continue;
+      seenTables.add(table.toLowerCase());
+      if (tableExists.get(table)) continue;
+      // Suggest the closest real table: try the de-pluralized stem as a prefix.
+      const stem = table.replace(/s$/i, '');
+      const alt = db.prepare(
+        `SELECT name FROM symbols WHERE type = 'table' AND name LIKE ? COLLATE NOCASE ORDER BY LENGTH(name) ASC LIMIT 1`,
+      ).get(`${stem}%`) as { name: string } | undefined;
+      cloneNotes +=
+        `\n   ⚠️ Datasource table "${table}" not found in the index` +
+        (alt && alt.name.toLowerCase() !== table.toLowerCase() ? ` — did you mean "${alt.name}"?` : '') +
+        ` The form will not build until that table exists or the datasource is re-pointed.`;
+    }
+  } catch {
+    /* index unavailable — skip the existence check */
   }
 
   // On non-Windows (Azure/Linux) — return XML as text, no file write possible.
@@ -560,6 +609,28 @@ export async function handleGenerateSmartForm(
       },
     ],
   };
+}
+
+/**
+ * Resolve the PatternVersion this environment actually uses for a Design-level
+ * form pattern, from mined form_patterns data (the most common version among real
+ * forms). Returns null when no mined data is available (older index) so the caller
+ * keeps the template default. Exported for testing.
+ */
+export function resolveEnvPatternVersion(db: any, patternXmlName: string): string | null {
+  try {
+    const row = db.prepare(`
+      SELECT pattern_version, COUNT(*) AS n
+      FROM form_patterns
+      WHERE node_path = 'Design' AND pattern = ? AND pattern_version IS NOT NULL AND pattern_version != ''
+      GROUP BY pattern_version
+      ORDER BY n DESC
+      LIMIT 1
+    `).get(patternXmlName) as { pattern_version: string } | undefined;
+    return row?.pattern_version ?? null;
+  } catch {
+    return null; // index predates form_patterns mining — keep the template version
+  }
 }
 
 // extractModelFromProject and findProjectInSolution moved to ../utils/projectUtils.ts

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -389,11 +389,8 @@ export async function handleGenerateSmartForm(
       gridFields,
     });
 
-    // Template PatternVersions are hardcoded (e.g. 1.1) and can lag behind the
-    // target environment, which then rejects the form in BP with a
-    // BPFrameworkFatalException ("unknown PatternVersion"). Align the Design-level
-    // PatternVersion with the version this environment actually uses for the
-    // pattern (mined from real forms). Sub-pattern versions are left untouched.
+    // Align the Design-level PatternVersion with the version this environment uses
+    // for the pattern; template defaults can lag and be rejected by BP.
     const designPattern = xml.match(/<Pattern xmlns="">([^<]+)<\/Pattern>/)?.[1];
     if (designPattern) {
       const envVersion = resolveEnvPatternVersion(symbolIndex.getReadDb(), designPattern);
@@ -451,10 +448,8 @@ export async function handleGenerateSmartForm(
       errorList.split('\n').map(l => `      ${l}`).join('\n');
   }
 
-  // Datasource table existence check: a datasource bound to a table that does not
-  // exist (e.g. a wrongly pluralized "…Lines" instead of "…Line") produces a form
-  // that cannot build. Warn — with the closest existing table name — rather than
-  // emitting a silently-broken form.
+  // Warn when a datasource is bound to a table that does not exist in the index,
+  // suggesting the closest real table name.
   try {
     const db = symbolIndex.getReadDb();
     const tableExists = db.prepare(
@@ -466,7 +461,6 @@ export async function handleGenerateSmartForm(
       if (!table || seenTables.has(table.toLowerCase())) continue;
       seenTables.add(table.toLowerCase());
       if (tableExists.get(table)) continue;
-      // Suggest the closest real table: try the de-pluralized stem as a prefix.
       const stem = table.replace(/s$/i, '');
       const alt = db.prepare(
         `SELECT name FROM symbols WHERE type = 'table' AND name LIKE ? COLLATE NOCASE ORDER BY LENGTH(name) ASC LIMIT 1`,
@@ -612,10 +606,8 @@ export async function handleGenerateSmartForm(
 }
 
 /**
- * Resolve the PatternVersion this environment actually uses for a Design-level
- * form pattern, from mined form_patterns data (the most common version among real
- * forms). Returns null when no mined data is available (older index) so the caller
- * keeps the template default. Exported for testing.
+ * The most common Design-level PatternVersion this environment uses for a form
+ * pattern, from mined form_patterns data. Returns null when no mined data exists.
  */
 export function resolveEnvPatternVersion(db: any, patternXmlName: string): string | null {
   try {
@@ -629,7 +621,7 @@ export function resolveEnvPatternVersion(db: any, patternXmlName: string): strin
     `).get(patternXmlName) as { pattern_version: string } | undefined;
     return row?.pattern_version ?? null;
   } catch {
-    return null; // index predates form_patterns mining — keep the template version
+    return null;
   }
 }
 

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -267,9 +267,7 @@ export async function handleGenerateSmartTable(
   }
 
   // Strategy 2: Generate common fields based on table group patterns.
-  // Skip when the caller provided explicit fieldsHint — they have stated exactly
-  // which fields the table needs, so mining "commonly co-occurring" fields only
-  // injects unrelated infrastructure (e.g. MCRHoldCode) they then have to remove.
+  // Skipped when explicit fieldsHint is given (the caller stated the fields).
   if (generateCommonFields && !copyFrom && !fieldsHint) {
     console.log(`[generateSmartTable] Analyzing patterns for table group: ${tableGroup}`);
     try {
@@ -311,9 +309,7 @@ export async function handleGenerateSmartTable(
           }
         }
 
-        // Add fields appearing in 30%+ of sample tables, excluding cross-cutting
-        // infrastructure fields that pollute most standard tables but rarely belong
-        // on a fresh custom table (the user did not ask for them).
+        // Add fields appearing in 30%+ of sample tables, excluding infrastructure fields.
         const threshold = Math.max(1, Math.floor(sampleTables.length * 0.3));
         const commonFields = Array.from(fieldFrequency.entries())
           .filter(([key, data]) => data.count >= threshold && !isInfrastructureField(key.split(':')[0]))
@@ -347,7 +343,6 @@ export async function handleGenerateSmartTable(
         continue;
       }
 
-      // Prefer a real EDT from the indexed environment over a generic name guess.
       const edt = resolveBestEdt(hint, hintDb);
       const hintLower = hint.toLowerCase();
       // Mark as mandatory only when the field name IS an identifier (ends with 'Id',
@@ -1046,11 +1041,7 @@ function validateEdtExists(edtName: string, db: any): boolean {
 /**
  * Suggest EDT based on field name heuristics
  */
-/**
- * Cross-cutting infrastructure fields that appear on a large share of standard
- * tables (module framework hooks, audit columns, etc.) but should never be
- * auto-injected onto a fresh custom table from frequency mining.
- */
+/** Framework/audit fields that should never be auto-injected from frequency mining. */
 export function isInfrastructureField(fieldName: string): boolean {
   const INFRA = new Set([
     'mcrholdcode', 'mcrholduserid', 'mcrholddatetime',
@@ -1062,11 +1053,7 @@ export function isInfrastructureField(fieldName: string): boolean {
   return INFRA.has(fieldName.toLowerCase());
 }
 
-/**
- * Confidence that an EDT name corresponds to a field name, by containment.
- * 1.0 = identical; high when one fully contains the other (e.g. field
- * "RentEquipmentId" ⊂ EDT "AslRentEquipmentId" — a model-prefixed custom EDT).
- */
+/** Confidence (0–1) that an EDT name matches a field name, by containment. */
 function edtNameConfidence(field: string, edt: string): number {
   const f = field.toLowerCase();
   const e = edt.toLowerCase();
@@ -1077,13 +1064,9 @@ function edtNameConfidence(field: string, edt: string): number {
 }
 
 /**
- * Resolve the best EDT for a field name, preferring REAL EDTs from the indexed
- * environment over generic name heuristics. This is what makes the scaffold pick
- * a project's own EDT (e.g. AslRentEquipmentId) instead of a generic guess
- * (RefRecId) that is the wrong base type.
- *
- * Order: exact EDT-name match → strong fuzzy match (≥0.8) → name heuristic that
- * actually exists in this environment → weaker fuzzy match (≥0.6) → raw heuristic.
+ * Resolve the best EDT for a field name, preferring real indexed EDTs over name
+ * heuristics. Order: exact EDT-name match → strong fuzzy match (≥0.8) → heuristic
+ * that exists in this environment → weaker fuzzy match (≥0.6) → raw heuristic.
  */
 export function resolveBestEdt(fieldName: string, db: any): string {
   try {
@@ -1129,9 +1112,7 @@ export function suggestEdtFromFieldName(fieldName: string): string {
   if (nameLower.includes('rate')) return 'AmountMST';
   if (nameLower.includes('quantity') || nameLower.includes('qty')) return 'Qty';
   if (nameLower.includes('price')) return 'PriceUnit';
-  // ValidFrom / ValidTo — D365FO datetime effectivity pattern (UtcDateTime EDTs).
-  // Only the bare effectivity names map to the *DateTime EDTs; any other field
-  // whose name ends in "date" is a calendar Date → TransDate.
+  // Only the bare effectivity names map to the *DateTime EDTs; other "*date" → TransDate.
   if (nameLower === 'validfrom') return 'ValidFromDateTime';
   if (nameLower === 'validto') return 'ValidToDateTime';
   if (nameLower.includes('datetime') || nameLower.includes('time')) return 'TransDateTime';
@@ -1143,11 +1124,9 @@ export function suggestEdtFromFieldName(fieldName: string): string {
   if (nameLower.includes('percent') || nameLower.includes('pct')) return 'Percent';
   if (nameLower.includes('enabled') || nameLower.includes('active') || nameLower.includes('flag')) return 'NoYesId';
 
-  // NOTE: deliberately NO blanket "*id → RefRecId" or "status → NoYesId" rule.
-  // RefRecId (int64) is the wrong base type for the common string business key
-  // (e.g. RentEquipmentId), and "status" is usually a domain enum, not a boolean.
-  // Such fields fall through to a string default unless a real EDT matches via
-  // resolveBestEdt — far less wrong than forcing the field to the wrong type.
+  // No blanket "*id → RefRecId" / "status → NoYesId" rule: those force the wrong
+  // base type. Such fields fall through to the string default unless resolveBestEdt
+  // matches a real EDT.
 
   // Default to string
   return 'String255';

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -266,8 +266,11 @@ export async function handleGenerateSmartTable(
     }
   }
 
-  // Strategy 2: Generate common fields based on table group patterns
-  if (generateCommonFields && !copyFrom) {
+  // Strategy 2: Generate common fields based on table group patterns.
+  // Skip when the caller provided explicit fieldsHint — they have stated exactly
+  // which fields the table needs, so mining "commonly co-occurring" fields only
+  // injects unrelated infrastructure (e.g. MCRHoldCode) they then have to remove.
+  if (generateCommonFields && !copyFrom && !fieldsHint) {
     console.log(`[generateSmartTable] Analyzing patterns for table group: ${tableGroup}`);
     try {
       const db = symbolIndex.getReadDb();
@@ -308,10 +311,12 @@ export async function handleGenerateSmartTable(
           }
         }
 
-        // Add fields appearing in 30%+ of sample tables
+        // Add fields appearing in 30%+ of sample tables, excluding cross-cutting
+        // infrastructure fields that pollute most standard tables but rarely belong
+        // on a fresh custom table (the user did not ask for them).
         const threshold = Math.max(1, Math.floor(sampleTables.length * 0.3));
         const commonFields = Array.from(fieldFrequency.entries())
-          .filter(([, data]) => data.count >= threshold)
+          .filter(([key, data]) => data.count >= threshold && !isInfrastructureField(key.split(':')[0]))
           .sort((a, b) => b[1].count - a[1].count)
           .slice(0, 10);
 
@@ -334,15 +339,16 @@ export async function handleGenerateSmartTable(
   if (fieldsHint && !copyFrom) {
     console.log(`[generateSmartTable] Parsing field hints: ${fieldsHint}`);
     const hintFields = fieldsHint.split(',').map(s => s.trim()).filter(s => s.length > 0);
-    
+    const hintDb = symbolIndex.getReadDb();
+
     for (const hint of hintFields) {
       // Check if field already exists
       if (fields.find(f => f.name === hint)) {
         continue;
       }
 
-      // Try to suggest EDT based on name
-      const edt = suggestEdtFromFieldName(hint);
+      // Prefer a real EDT from the indexed environment over a generic name guess.
+      const edt = resolveBestEdt(hint, hintDb);
       const hintLower = hint.toLowerCase();
       // Mark as mandatory only when the field name IS an identifier (ends with 'Id',
       // equals 'RecId', or exactly 'AccountNum'/'CustAccount' patterns).
@@ -1040,7 +1046,74 @@ function validateEdtExists(edtName: string, db: any): boolean {
 /**
  * Suggest EDT based on field name heuristics
  */
-function suggestEdtFromFieldName(fieldName: string): string {
+/**
+ * Cross-cutting infrastructure fields that appear on a large share of standard
+ * tables (module framework hooks, audit columns, etc.) but should never be
+ * auto-injected onto a fresh custom table from frequency mining.
+ */
+export function isInfrastructureField(fieldName: string): boolean {
+  const INFRA = new Set([
+    'mcrholdcode', 'mcrholduserid', 'mcrholddatetime',
+    'sortorder', 'displayorder',
+    'createdby', 'createddatetime', 'modifiedby', 'modifieddatetime',
+    'createdtransactionid', 'modifiedtransactionid',
+    'recid', 'recversion', 'dataareaid', 'partition', 'tableid', 'instancerelationtype',
+  ]);
+  return INFRA.has(fieldName.toLowerCase());
+}
+
+/**
+ * Confidence that an EDT name corresponds to a field name, by containment.
+ * 1.0 = identical; high when one fully contains the other (e.g. field
+ * "RentEquipmentId" ⊂ EDT "AslRentEquipmentId" — a model-prefixed custom EDT).
+ */
+function edtNameConfidence(field: string, edt: string): number {
+  const f = field.toLowerCase();
+  const e = edt.toLowerCase();
+  if (f === e) return 1.0;
+  if (e.includes(f)) return 0.9 - (e.length - f.length) * 0.01;
+  if (f.includes(e)) return 0.8 - (f.length - e.length) * 0.01;
+  return 0;
+}
+
+/**
+ * Resolve the best EDT for a field name, preferring REAL EDTs from the indexed
+ * environment over generic name heuristics. This is what makes the scaffold pick
+ * a project's own EDT (e.g. AslRentEquipmentId) instead of a generic guess
+ * (RefRecId) that is the wrong base type.
+ *
+ * Order: exact EDT-name match → strong fuzzy match (≥0.8) → name heuristic that
+ * actually exists in this environment → weaker fuzzy match (≥0.6) → raw heuristic.
+ */
+export function resolveBestEdt(fieldName: string, db: any): string {
+  try {
+    const exact = db.prepare(
+      `SELECT edt_name FROM edt_metadata WHERE edt_name = ? COLLATE NOCASE LIMIT 1`
+    ).get(fieldName) as { edt_name: string } | undefined;
+    if (exact) return exact.edt_name;
+
+    const candidates = db.prepare(
+      `SELECT edt_name FROM edt_metadata WHERE edt_name LIKE ? COLLATE NOCASE ORDER BY LENGTH(edt_name) ASC LIMIT 30`
+    ).all(`%${fieldName}%`) as Array<{ edt_name: string }>;
+    let best = '';
+    let bestConf = 0;
+    for (const c of candidates) {
+      const conf = edtNameConfidence(fieldName, c.edt_name);
+      if (conf > bestConf) { bestConf = conf; best = c.edt_name; }
+    }
+    if (best && bestConf >= 0.8) return best;
+
+    const heuristic = suggestEdtFromFieldName(fieldName);
+    if (validateEdtExists(heuristic, db)) return heuristic;
+
+    if (best && bestConf >= 0.6) return best;
+  } catch {
+    /* DB unavailable — fall back to the pure heuristic below */
+  }
+  return suggestEdtFromFieldName(fieldName);
+}
+
+export function suggestEdtFromFieldName(fieldName: string): string {
   const nameLower = fieldName.toLowerCase();
 
   // Common patterns
@@ -1053,23 +1126,28 @@ function suggestEdtFromFieldName(fieldName: string): string {
   if (nameLower === 'description') return 'Description';
   if (nameLower.includes('description') || nameLower === 'desc') return 'Description';
   if (nameLower.includes('amount')) return 'AmountMST';
+  if (nameLower.includes('rate')) return 'AmountMST';
   if (nameLower.includes('quantity') || nameLower.includes('qty')) return 'Qty';
   if (nameLower.includes('price')) return 'PriceUnit';
-  // ValidFrom / ValidTo — D365FO date effectivity pattern
-  if (nameLower === 'validfrom' || nameLower === 'fromdate' || nameLower === 'datefrom' || nameLower === 'platnostod') return 'ValidFromDateTime';
-  if (nameLower === 'validto' || nameLower === 'todate' || nameLower === 'dateto' || nameLower === 'platnostdo') return 'ValidToDateTime';
-  if (nameLower.includes('validfrom') || nameLower.includes('fromdate')) return 'ValidFromDateTime';
-  if (nameLower.includes('validto') || nameLower.includes('todate')) return 'ValidToDateTime';
+  // ValidFrom / ValidTo — D365FO datetime effectivity pattern (UtcDateTime EDTs).
+  // Only the bare effectivity names map to the *DateTime EDTs; any other field
+  // whose name ends in "date" is a calendar Date → TransDate.
+  if (nameLower === 'validfrom') return 'ValidFromDateTime';
+  if (nameLower === 'validto') return 'ValidToDateTime';
+  if (nameLower.includes('datetime') || nameLower.includes('time')) return 'TransDateTime';
   if (nameLower.includes('date')) return 'TransDate';
-  if (nameLower.includes('time') || nameLower.includes('datetime')) return 'TransDateTime';
   if (nameLower.includes('account')) return 'LedgerAccount';
   if (nameLower.includes('customer') || nameLower.includes('cust')) return 'CustAccount';
   if (nameLower.includes('vendor') || nameLower.includes('vend')) return 'VendAccount';
   if (nameLower.includes('item')) return 'ItemId';
   if (nameLower.includes('percent') || nameLower.includes('pct')) return 'Percent';
-  if (nameLower.includes('status')) return 'NoYesId';
   if (nameLower.includes('enabled') || nameLower.includes('active') || nameLower.includes('flag')) return 'NoYesId';
-  if (nameLower.includes('id') && !nameLower.includes('recid')) return 'RefRecId';
+
+  // NOTE: deliberately NO blanket "*id → RefRecId" or "status → NoYesId" rule.
+  // RefRecId (int64) is the wrong base type for the common string business key
+  // (e.g. RentEquipmentId), and "status" is usually a domain enum, not a boolean.
+  // Such fields fall through to a string default unless a real EDT matches via
+  // resolveBestEdt — far less wrong than forcing the field to the wrong type.
 
   // Default to string
   return 'String255';

--- a/src/tools/getKnowledge.ts
+++ b/src/tools/getKnowledge.ts
@@ -19,8 +19,6 @@ export type KnowledgeKind = (typeof KNOWLEDGE_KINDS)[number];
 
 const GetKnowledgeArgsSchema = z
   .object({
-    // kind is the discriminator but optional — models routinely omit it and pass
-    // only topic/errorText. We infer it below rather than rejecting the call.
     kind: z.enum(KNOWLEDGE_KINDS).optional().describe(
       'knowledge → look up an X++ topic/rule; error → diagnose a compiler/runtime error message. ' +
       'Optional — inferred from errorText (→ error) or topic (→ knowledge) when omitted.',
@@ -42,8 +40,6 @@ export async function getKnowledgeTool(request: CallToolRequest) {
   }
 
   const { kind: explicitKind, ...rest } = parsed.data;
-  // Infer the discriminator when omitted: errorText/errorCode imply error
-  // diagnosis; anything else (topic, or a bare list-all call) is a knowledge lookup.
   const kind: KnowledgeKind =
     explicitKind ?? ((rest as any).errorText || (rest as any).errorCode ? 'error' : 'knowledge');
   if (kind === 'error') {

--- a/src/tools/getKnowledge.ts
+++ b/src/tools/getKnowledge.ts
@@ -19,8 +19,11 @@ export type KnowledgeKind = (typeof KNOWLEDGE_KINDS)[number];
 
 const GetKnowledgeArgsSchema = z
   .object({
-    kind: z.enum(KNOWLEDGE_KINDS).describe(
-      'knowledge → look up an X++ topic/rule; error → diagnose a compiler/runtime error message.',
+    // kind is the discriminator but optional — models routinely omit it and pass
+    // only topic/errorText. We infer it below rather than rejecting the call.
+    kind: z.enum(KNOWLEDGE_KINDS).optional().describe(
+      'knowledge → look up an X++ topic/rule; error → diagnose a compiler/runtime error message. ' +
+      'Optional — inferred from errorText (→ error) or topic (→ knowledge) when omitted.',
     ),
   })
   .passthrough();
@@ -38,7 +41,11 @@ export async function getKnowledgeTool(request: CallToolRequest) {
     };
   }
 
-  const { kind, ...rest } = parsed.data;
+  const { kind: explicitKind, ...rest } = parsed.data;
+  // Infer the discriminator when omitted: errorText/errorCode imply error
+  // diagnosis; anything else (topic, or a bare list-all call) is a knowledge lookup.
+  const kind: KnowledgeKind =
+    explicitKind ?? ((rest as any).errorText || (rest as any).errorCode ? 'error' : 'knowledge');
   if (kind === 'error') {
     return d365foErrorHelpTool(subRequest('get_d365fo_error_help', rest));
   }

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -497,7 +497,6 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // up the base form XML, walk the control tree, and resolve to the exact name.
     // This makes add-control seamless — no prior get_object_info(form) call required.
     let addControlNote = '';
-    // Note surfaced when add-table-method / add-display-method generates the source.
     let generationNote = '';
     if (operation === 'add-control' && objectType === 'form-extension' && args.parentControl) {
       const resolution = await resolveParentControl(
@@ -684,9 +683,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
 
     switch (operation) {
       case 'add-method': {
-        // sourceCode and methodCode are documented aliases; sourceCode wins when both
-        // are supplied. Accept either so callers passing the methodCode alias are not
-        // silently dropped into the "returned null" path.
+        // sourceCode and methodCode are aliases; sourceCode wins when both are set.
         const methodSource = args.sourceCode ?? (args as any).methodCode;
         if (args.methodName && methodSource) {
           bridgeResult = await bridgeAddMethod(
@@ -700,8 +697,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         break;
       }
       case 'add-display-method': {
-        // Accept explicit source (sourceCode/methodCode alias) verbatim; otherwise
-        // generate a display-method stub from displayMethodReturnEdt + methodName.
+        // Explicit source wins; otherwise generate a stub from displayMethodReturnEdt.
         let methodSource = args.sourceCode ?? (args as any).methodCode;
         const methodName = args.methodName;
         if (!methodSource && methodName && (args as any).displayMethodReturnEdt) {
@@ -725,8 +721,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         break;
       }
       case 'add-table-method': {
-        // Accept explicit source (sourceCode/methodCode alias) verbatim; otherwise
-        // generate a standard table method from tableMethodType (+ tableKeyField).
+        // Explicit source wins; otherwise generate from tableMethodType.
         let methodSource = args.sourceCode ?? (args as any).methodCode;
         let methodName = args.methodName;
         if (!methodSource && (args as any).tableMethodType) {
@@ -796,8 +791,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'modify-field': {
         if (args.fieldName) {
-          // Read the documented field-* params (the advertised surface). The bridge
-          // expects bare prop keys (label/edt/mandatory/…), so map onto those here.
+          // Map the field-* params onto the bare prop keys the bridge expects.
           const fieldProps: Record<string, string> = {};
           if ((args as any).fieldLabel) fieldProps.label = (args as any).fieldLabel;
           if ((args as any).fieldHelpText) fieldProps.helpText = (args as any).fieldHelpText;
@@ -1133,8 +1127,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         'modify-property': ['propertyPath', 'propertyValue'],
       };
       const required = paramHints[operation] ?? [];
-      // Some params have documented aliases — treat any alias as satisfying the requirement
-      // so the diagnostic doesn't report a param "MISSING" when its alias was supplied.
+      // Treat a supplied alias as satisfying the requirement.
       const aliases: Record<string, string[]> = {
         sourceCode: ['methodCode'],
       };

--- a/src/tools/objectPatterns.ts
+++ b/src/tools/objectPatterns.ts
@@ -24,8 +24,7 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
   const a = (request.params.arguments ?? {}) as Record<string, any>;
   let domain = a.domain as string | undefined;
 
-  // Infer the discriminator when omitted — models routinely pass only a
-  // form/table-specific param (e.g. pattern, action, recommend, tableGroup).
+  // Infer the discriminator from form/table-specific params when omitted.
   if (domain !== 'table' && domain !== 'form') {
     const formSignals = ['action', 'pattern', 'recommend', 'formPattern', 'similarTo', 'dataSource', 'xml', 'formName'];
     const tableSignals = ['tableGroup'];
@@ -41,8 +40,7 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
   }
 
   if (domain === 'form') {
-    // formPatternTool requires `action`. Infer it when omitted from the params
-    // present: pattern → spec; xml/formName/filePath → validate; otherwise analyze.
+    // formPatternTool requires `action`; infer it when omitted.
     let action = a.action as string | undefined;
     if (!action) {
       if (a.pattern !== undefined) action = 'spec';

--- a/src/tools/objectPatterns.ts
+++ b/src/tools/objectPatterns.ts
@@ -22,16 +22,41 @@ function err(text: string) {
 
 export async function objectPatternsTool(request: CallToolRequest, context: XppServerContext) {
   const a = (request.params.arguments ?? {}) as Record<string, any>;
-  const domain = a.domain as string | undefined;
+  let domain = a.domain as string | undefined;
 
-  switch (domain) {
-    case 'table':
-      return getTablePatternsTool(request, context);
-    case 'form':
-      return formPatternTool(request, context);
-    default:
-      return err(`object_patterns: unknown domain "${domain}". Use "table" (table field/index/relation patterns) or "form" (form-pattern toolkit; pass action=analyze|spec|validate).`);
+  // Infer the discriminator when omitted — models routinely pass only a
+  // form/table-specific param (e.g. pattern, action, recommend, tableGroup).
+  if (domain !== 'table' && domain !== 'form') {
+    const formSignals = ['action', 'pattern', 'recommend', 'formPattern', 'similarTo', 'dataSource', 'xml', 'formName'];
+    const tableSignals = ['tableGroup'];
+    if (formSignals.some(k => a[k] !== undefined)) {
+      domain = 'form';
+    } else if (tableSignals.some(k => a[k] !== undefined)) {
+      domain = 'table';
+    }
   }
+
+  if (domain === 'table') {
+    return getTablePatternsTool(request, context);
+  }
+
+  if (domain === 'form') {
+    // formPatternTool requires `action`. Infer it when omitted from the params
+    // present: pattern → spec; xml/formName/filePath → validate; otherwise analyze.
+    let action = a.action as string | undefined;
+    if (!action) {
+      if (a.pattern !== undefined) action = 'spec';
+      else if (a.xml !== undefined || a.formName !== undefined || a.filePath !== undefined) action = 'validate';
+      else action = 'analyze';
+    }
+    const formRequest: CallToolRequest = {
+      ...request,
+      params: { ...request.params, arguments: { ...a, domain, action } },
+    };
+    return formPatternTool(formRequest, context);
+  }
+
+  return err(`object_patterns: unknown domain "${a.domain}". Use "table" (table field/index/relation patterns) or "form" (form-pattern toolkit; pass action=analyze|spec|validate).`);
 }
 
 // Tool registration (name, description, inputSchema) lives inline in

--- a/tests/bridge/canBridgeModify.test.ts
+++ b/tests/bridge/canBridgeModify.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { canBridgeModify } from '../../src/bridge/bridgeAdapter';
+
+describe('canBridgeModify', () => {
+  it('accepts add-menu-item-to-menu on a menu (the only type it targets)', () => {
+    // Regression: 'menu' was missing from BRIDGE_MODIFY_TYPES, so the op was
+    // rejected before dispatch even though the C# bridge implements it.
+    expect(canBridgeModify('menu', 'add-menu-item-to-menu')).toBe(true);
+    expect(canBridgeModify('Menu', 'add-menu-item-to-menu')).toBe(true);
+  });
+
+  it('accepts the common type/operation combinations', () => {
+    expect(canBridgeModify('table', 'add-index')).toBe(true);
+    expect(canBridgeModify('table', 'add-relation')).toBe(true);
+    expect(canBridgeModify('form', 'add-method')).toBe(true);
+    expect(canBridgeModify('form-extension', 'add-data-source')).toBe(true);
+    expect(canBridgeModify('enum', 'add-enum-value')).toBe(true);
+  });
+
+  it('rejects unknown object types and operations', () => {
+    expect(canBridgeModify('bogus-type', 'add-method')).toBe(false);
+    expect(canBridgeModify('table', 'bogus-operation')).toBe(false);
+  });
+});

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -317,6 +317,42 @@ describe('XmlTemplateGenerator.splitXppClassSource', () => {
   });
 });
 
+// ─── XmlTemplateGenerator security generators ───────────────────────────────
+
+describe('XmlTemplateGenerator security duty/role generators', () => {
+  it('emits privilege references on a duty from properties.privileges', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityDutyXml('MyDuty', {
+      label: '@My:Duty',
+      privileges: ['MyView', 'MyMaintain'],
+    });
+    expect(xml).toContain('<AxSecurityRolePermissionSet>\n\t\t\t<Name>MyView</Name>');
+    expect(xml).toContain('<Name>MyMaintain</Name>');
+    expect(xml).not.toContain('<Privileges />');
+  });
+
+  it('accepts a comma-separated privilege string', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityDutyXml('MyDuty', {
+      privileges: 'MyView, MyMaintain',
+    });
+    expect(xml).toContain('<Name>MyView</Name>');
+    expect(xml).toContain('<Name>MyMaintain</Name>');
+  });
+
+  it('keeps an empty self-closing Privileges when none are given', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityDutyXml('MyDuty', {});
+    expect(xml).toContain('<Privileges />');
+  });
+
+  it('emits duty references on a role from properties.duties', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityRoleXml('MyRole', {
+      duties: ['MyDuty1', 'MyDuty2'],
+    });
+    expect(xml).toContain('<AxSecurityRoleDutyPermission>\n\t\t\t<Name>MyDuty1</Name>');
+    expect(xml).toContain('<Name>MyDuty2</Name>');
+    expect(xml).not.toContain('<Duties />');
+  });
+});
+
 // ─── generate_smart_table ────────────────────────────────────────────────────
 
 describe('generate_smart_table', () => {

--- a/tests/tools/edt-resolution.test.ts
+++ b/tests/tools/edt-resolution.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveBestEdt,
+  suggestEdtFromFieldName,
+  isInfrastructureField,
+} from '../../src/tools/generateSmartTable';
+
+/**
+ * Fake read-db over a fixed list of EDT names. Handles the three query shapes
+ * resolveBestEdt / validateEdtExists use: exact "= ?", "LIKE ?", and the
+ * "SELECT 1 FROM edt_metadata" existence probe.
+ */
+function fakeDb(edts: string[]) {
+  return {
+    prepare(sql: string) {
+      return {
+        get(arg: string) {
+          if (/= \?/.test(sql)) {
+            const hit = edts.find(e => e.toLowerCase() === String(arg).toLowerCase());
+            if (/SELECT 1/.test(sql)) return hit ? { 1: 1 } : undefined;
+            return hit ? { edt_name: hit } : undefined;
+          }
+          return undefined;
+        },
+        all(arg: string) {
+          const needle = String(arg).replace(/%/g, '').toLowerCase();
+          return edts.filter(e => e.toLowerCase().includes(needle)).map(e => ({ edt_name: e }));
+        },
+      };
+    },
+  };
+}
+
+describe('suggestEdtFromFieldName (heuristic)', () => {
+  it('maps a *date field to TransDate, not a non-existent *DateTime EDT', () => {
+    expect(suggestEdtFromFieldName('FromDate')).toBe('TransDate');
+    expect(suggestEdtFromFieldName('ToDate')).toBe('TransDate');
+  });
+
+  it('keeps the bare ValidFrom/ValidTo effectivity datetimes', () => {
+    expect(suggestEdtFromFieldName('ValidFrom')).toBe('ValidFromDateTime');
+    expect(suggestEdtFromFieldName('ValidTo')).toBe('ValidToDateTime');
+  });
+
+  it('maps rate to an amount EDT', () => {
+    expect(suggestEdtFromFieldName('DailyRate')).toBe('AmountMST');
+  });
+
+  it('does NOT force *Id to RefRecId or status to NoYesId', () => {
+    expect(suggestEdtFromFieldName('RentEquipmentId')).toBe('String255');
+    expect(suggestEdtFromFieldName('Status')).toBe('String255');
+  });
+});
+
+describe('resolveBestEdt (DB-aware)', () => {
+  it('prefers a real model-prefixed EDT over a generic guess', () => {
+    const db = fakeDb(['AslRentEquipmentId', 'RefRecId']);
+    expect(resolveBestEdt('RentEquipmentId', db)).toBe('AslRentEquipmentId');
+  });
+
+  it('returns an exact EDT match when one exists', () => {
+    const db = fakeDb(['AslRentEquipmentId']);
+    expect(resolveBestEdt('AslRentEquipmentId', db)).toBe('AslRentEquipmentId');
+  });
+
+  it('uses the heuristic when it resolves to an existing EDT', () => {
+    const db = fakeDb(['AmountMST']);
+    expect(resolveBestEdt('DailyRate', db)).toBe('AmountMST');
+  });
+
+  it('falls back to the string default when nothing matches', () => {
+    const db = fakeDb([]);
+    expect(resolveBestEdt('Category', db)).toBe('String255');
+  });
+});
+
+describe('isInfrastructureField', () => {
+  it('flags cross-cutting framework/audit fields', () => {
+    expect(isInfrastructureField('MCRHoldCode')).toBe(true);
+    expect(isInfrastructureField('modifiedDateTime')).toBe(true);
+  });
+
+  it('does not flag ordinary business fields', () => {
+    expect(isInfrastructureField('Name')).toBe(false);
+    expect(isInfrastructureField('DailyRate')).toBe(false);
+  });
+});

--- a/tests/tools/form-pattern-version.test.ts
+++ b/tests/tools/form-pattern-version.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEnvPatternVersion } from '../../src/tools/generateSmartForm';
+
+describe('resolveEnvPatternVersion', () => {
+  it('returns the most-common Design PatternVersion mined for the pattern', () => {
+    const db = {
+      prepare: () => ({ get: () => ({ pattern_version: '1.4', n: 12 }) }),
+    };
+    expect(resolveEnvPatternVersion(db, 'SimpleListDetails')).toBe('1.4');
+  });
+
+  it('returns null when no mined version exists for the pattern', () => {
+    const db = { prepare: () => ({ get: () => undefined }) };
+    expect(resolveEnvPatternVersion(db, 'SimpleList')).toBeNull();
+  });
+
+  it('returns null (keeps template default) when the form_patterns table is absent', () => {
+    const db = {
+      prepare: () => {
+        throw new Error('no such table: form_patterns');
+      },
+    };
+    expect(resolveEnvPatternVersion(db, 'ListPage')).toBeNull();
+  });
+});

--- a/tests/tools/getKnowledge.test.ts
+++ b/tests/tools/getKnowledge.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+vi.mock('../../src/tools/xppKnowledge', () => ({
+  xppKnowledgeTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'knowledge' }] })),
+}));
+vi.mock('../../src/tools/d365foErrorHelp', () => ({
+  d365foErrorHelpTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'error' }] })),
+}));
+
+import { getKnowledgeTool } from '../../src/tools/getKnowledge';
+import { xppKnowledgeTool } from '../../src/tools/xppKnowledge';
+import { d365foErrorHelpTool } from '../../src/tools/d365foErrorHelp';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'get_knowledge', arguments: args },
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('get_knowledge kind inference', () => {
+  it('routes explicit kind=error to the error-help handler', async () => {
+    await getKnowledgeTool(req({ kind: 'error', errorText: 'SYS10028' }));
+    expect(d365foErrorHelpTool).toHaveBeenCalledOnce();
+    expect(xppKnowledgeTool).not.toHaveBeenCalled();
+  });
+
+  it('infers kind=knowledge from a bare topic', async () => {
+    await getKnowledgeTool(req({ topic: 'select-statement' }));
+    expect(xppKnowledgeTool).toHaveBeenCalledOnce();
+    expect(d365foErrorHelpTool).not.toHaveBeenCalled();
+  });
+
+  it('infers kind=error from errorText when kind omitted', async () => {
+    await getKnowledgeTool(req({ errorText: 'BPFrameworkFatalException' }));
+    expect(d365foErrorHelpTool).toHaveBeenCalledOnce();
+    expect(xppKnowledgeTool).not.toHaveBeenCalled();
+  });
+
+  it('defaults to knowledge for a bare list-all call', async () => {
+    await getKnowledgeTool(req({}));
+    expect(xppKnowledgeTool).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/tools/mergedDispatchers.test.ts
+++ b/tests/tools/mergedDispatchers.test.ts
@@ -168,7 +168,31 @@ describe('object_patterns dispatcher', () => {
     expect(getTablePatternsTool).not.toHaveBeenCalled();
   });
 
-  it('unknown/omitted domain → friendly error', async () => {
+  it('infers domain=form + action=spec from a bare pattern arg', async () => {
+    await objectPatternsTool(req('object_patterns', { pattern: 'SimpleList' }), ctx);
+    expect(formPatternTool).toHaveBeenCalledOnce();
+    expect(getTablePatternsTool).not.toHaveBeenCalled();
+    expect(argsOf(formPatternTool)).toMatchObject({ domain: 'form', action: 'spec', pattern: 'SimpleList' });
+  });
+
+  it('infers domain=form + action=analyze from recommend', async () => {
+    await objectPatternsTool(req('object_patterns', { recommend: { entityKind: 'master' } }), ctx);
+    expect(formPatternTool).toHaveBeenCalledOnce();
+    expect(argsOf(formPatternTool)).toMatchObject({ domain: 'form', action: 'analyze' });
+  });
+
+  it('infers domain=form + action=validate from xml', async () => {
+    await objectPatternsTool(req('object_patterns', { xml: '<AxForm/>' }), ctx);
+    expect(argsOf(formPatternTool)).toMatchObject({ domain: 'form', action: 'validate' });
+  });
+
+  it('infers domain=table from tableGroup when domain omitted', async () => {
+    await objectPatternsTool(req('object_patterns', { tableGroup: 'Main' }), ctx);
+    expect(getTablePatternsTool).toHaveBeenCalledOnce();
+    expect(formPatternTool).not.toHaveBeenCalled();
+  });
+
+  it('unknown/omitted domain with no signals → friendly error', async () => {
     const r: any = await objectPatternsTool(req('object_patterns', {}), ctx);
     expect(r.isError).toBe(true);
   });


### PR DESCRIPTION
This pull request introduces several enhancements and improvements across the codebase, focusing on smarter field and EDT inference, better handling of security model XML generation, improved tool ergonomics, and more robust pattern/version alignment. The changes aim to make code generation more accurate, user-friendly, and aligned with real-world D365FO environments.

**Smart field and EDT inference improvements:**

- Improved EDT inference in `generateSmartTable` by introducing `resolveBestEdt`, which prefers real indexed EDTs over heuristics and uses fuzzy matching, resulting in more accurate field type suggestions. Infrastructure/audit fields are now excluded from auto-injection during field mining. [[1]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dL1043-R1099) [[2]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dL311-R315) [[3]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR338-R346) [[4]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dR1112-R1129)
- The common field mining step now skips infrastructure fields and only runs when explicit `fieldsHint` is not provided. [[1]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dL269-R271) [[2]](diffhunk://#diff-93a7a8364dd530121f32622d8fb593d854a826b2a3d39d39cd5216c66ef9ed0dL311-R315)

**Security model and XML generation enhancements:**

- Added new helpers to normalize name lists and render security reference containers in XML, supporting both arrays and comma-separated strings for privileges and duties. Enhanced XML generation for security duty and role to include referenced privileges and duties.
- Updated documentation and schema to reflect support for `security-duty` and `security-role` with their properties.

**Form and pattern generation improvements:**

- The smart form generator now aligns the design-level `PatternVersion` in generated XML with the most common version found in the environment, reducing build errors due to version mismatches. [[1]](diffhunk://#diff-1da8edd24f06b72404b7f9eba9d919c188d640a88449feffc65fadc4dbb3f4c4R391-R407) [[2]](diffhunk://#diff-1da8edd24f06b72404b7f9eba9d919c188d640a88449feffc65fadc4dbb3f4c4R608-R627)
- Added a warning when a datasource table referenced in a generated form does not exist, suggesting the closest matching table name.

**Tool ergonomics and schema updates:**

- The `createLabelFileIfMissing` option now defaults to `true` and has improved documentation, preventing accidental phantom label files. [[1]](diffhunk://#diff-aa454b1d0537c6f49eb8a25e1de4ae9698545a51ee1073c729ffdd54c87011faL110-R114) [[2]](diffhunk://#diff-1b7b3c9a6b332fb0216d5bcd2bdd37b7e48702f8e0309d9c4466728f72a56ee2L1130-R1132)
- The knowledge tool's `kind` parameter is now optional and inferred from context if omitted, improving usability. [[1]](diffhunk://#diff-e426737527155a2f28150d896364010d33b5d238e11ae6ae333aa20ce73d21e1L22-R24) [[2]](diffhunk://#diff-e426737527155a2f28150d896364010d33b5d238e11ae6ae333aa20ce73d21e1L41-R44)

**Minor and miscellaneous changes:**

- Added `'menu'` to the set of bridge modify types.
- Clarified comments and handling for method source code aliases in the modify tool. [[1]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637L500) [[2]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637L687-R686) [[3]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637L703-R700) [[4]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637L728-R724)
- Removed outdated comments in the form pattern tool.

These changes collectively improve code generation accuracy, developer experience, and alignment with D365FO best practices.