### PR TITLE
fix: scaffold/clone residue cleanup + tool-contract & validator fixes

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -572,7 +572,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                 description:
                   'Additional properties by objectType:\n' +
                   '• class: extends, implements, isFinal, isAbstract\n' +
-                  '• table: label, tableGroup, tableType, titleField1/2, fields[]\n' +
+                  '• table: label, tableGroup, tableType, titleField1/2, fields[{name,type?|edt?|fieldType?,enumType?,label?,mandatory?}] — enum fields need enumType (+ optionally fieldType:"AxTableFieldEnum")\n' +
                   '• enum: label, useEnumValue, configurationKey, isExtensible, enumValues[{name,value?,label?,helpText?}]\n' +
                   '• enum-extension: enumValues[{name,label?,value?,countryRegionCodes?}]\n' +
                   '• table-extension: fields[{name,edt?,enumType?,label?,mandatory?,fieldType?}] — enum fields need fieldType:"AxTableFieldEnum" + enumType\n' +
@@ -1194,7 +1194,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               domain: {
                 type: 'string',
                 enum: ['table', 'form'],
-                description: 'table = table field/index/relation patterns; form = form-pattern toolkit (set action).',
+                description: 'table = table field/index/relation patterns; form = form-pattern toolkit (set action). Optional — inferred from the other params (action/pattern/xml/formName → form; tableGroup → table). Alias: patternType.',
               },
               // ── domain=table ───────────────────────────────────────────────
               tableGroup: {
@@ -1274,7 +1274,10 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                 description: '[form/validate] Explicit path to an AxForm XML file (e.g. a freshly created form not yet indexed).',
               },
             },
-            required: ['domain'],
+            // domain is optional: objectPatternsTool infers it from the other
+            // params (and accepts the `patternType` alias). Marking it required
+            // here made clients pre-reject otherwise-valid calls.
+            required: [],
           },
         },
         {
@@ -1658,7 +1661,10 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               description: '[error] Optional error code (e.g. SYS10028, CSUV1, BPUpgradeCodeToday)',
             },
           },
-          required: ['kind'],
+          // kind is optional: getKnowledgeTool infers it from topic (→ knowledge)
+          // or errorText (→ error). Marking it required made clients pre-reject
+          // calls that passed only `topic`.
+          required: [],
         },
       },
       {

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -627,8 +627,12 @@ ${methodsXml}\t</SourceCode>
     // Build <Fields> block from properties.fields array (TableFieldSpec[]).
     // Copilot may pass field definitions via properties.fields or via sourceCode JSON —
     // both paths merge into properties before calling here (see generate()).
-    const fieldSpecs: Array<{ name: string; edt?: string; type?: string; mandatory?: boolean; label?: string }> =
-      Array.isArray(properties?.fields) ? properties.fields : [];
+    // Field-spec keys are unified with the table-extension path (generateAxTableExtensionXml):
+    // accept an explicit AxTableField* i:type (fieldType), a primitive base type (type),
+    // or infer AxTableFieldEnum from enumType — and always emit <EnumType> for enum fields.
+    const fieldSpecs: Array<{
+      name: string; edt?: string; type?: string; fieldType?: string; enumType?: string; mandatory?: boolean; label?: string;
+    }> = Array.isArray(properties?.fields) ? properties.fields : [];
 
     let fieldsXml: string;
     if (fieldSpecs.length === 0) {
@@ -636,14 +640,17 @@ ${methodsXml}\t</SourceCode>
     } else {
       fieldsXml = '\t<Fields>\n';
       for (const f of fieldSpecs) {
-        // Determine i:type: use explicit type if provided, otherwise derive from EDT name heuristics.
-        // NEVER default to AxTableFieldString blindly when an EDT is present — EDT base type matters!
-        const iType = fieldTypeToAxType(f.type || 'String', f.edt);
+        // Determine i:type: explicit AxTableField* wins; otherwise derive from the
+        // primitive type / enumType / EDT name heuristics. NEVER default to
+        // AxTableFieldString blindly when an EDT or enumType is present.
+        const iType = f.fieldType
+          ?? fieldTypeToAxType(f.type || (f.enumType ? 'Enum' : 'String'), f.edt);
         fieldsXml += `\t\t<AxTableField xmlns=""\n\t\t\ti:type="${iType}">\n`;
         fieldsXml += `\t\t\t<Name>${f.name}</Name>\n`;
         if (f.edt)       fieldsXml += `\t\t\t<ExtendedDataType>${f.edt}</ExtendedDataType>\n`;
-        if (f.mandatory) fieldsXml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
         if (f.label)     fieldsXml += `\t\t\t<Label>${f.label}</Label>\n`;
+        if (f.mandatory) fieldsXml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
+        if (f.enumType)  fieldsXml += `\t\t\t<EnumType>${f.enumType}</EnumType>\n`;
         fieldsXml += `\t\t</AxTableField>\n`;
       }
       fieldsXml += '\t</Fields>\n';

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -359,6 +359,7 @@ export async function handleGenerateSmartForm(
     const cloneResult = cloneFormXml(sourceXml, {
       targetFormName: finalName,
       tableMapping,
+      caption: caption || label,
       getTableFields: (table: string) => {
         const rows = fieldStmt.all(table) as Array<{ name: string }>;
         return rows.length > 0 ? rows.map((r) => r.name) : null; // unknown table → keep fields
@@ -373,11 +374,25 @@ export async function handleGenerateSmartForm(
     if (cloneResult.strippedMethods.length > 0) {
       noteLines.push(`   Methods stripped (re-add what you need via d365fo_file(action="modify") add-method): ${cloneResult.strippedMethods.join(', ')}`);
     }
+    if (cloneResult.clearedSourceCodeMirror) {
+      noteLines.push(`   SourceCode datasource/control method mirror cleared (stale field/control method holders)`);
+    }
+    if (cloneResult.resetClassDeclaration) {
+      noteLines.push(`   classDeclaration body reset to empty (source member vars/macros dropped with the methods)`);
+    }
+    if (cloneResult.removedIndexes.length > 0) {
+      noteLines.push(`   Default datasource index dropped (source-table index): ${cloneResult.removedIndexes.map(i => `${i.dataSource}.${i.index}`).join(', ')}`);
+    }
     if (cloneResult.droppedFields.length > 0) {
       noteLines.push(`   ⚠️ Fields dropped (missing on target table): ${cloneResult.droppedFields.map(d => `${d.dataSource}.${d.field}`).join(', ')}`);
     }
     if (cloneResult.removedControls.length > 0) {
       noteLines.push(`   ⚠️ Controls removed (bound to dropped fields): ${cloneResult.removedControls.join(', ')}`);
+    }
+    for (const rq of cloneResult.repointedQuickFilters) {
+      noteLines.push(rq.to
+        ? `   QuickFilter default column repointed: ${rq.from} → ${rq.to}`
+        : `   ⚠️ QuickFilter default column "${rq.from}" was removed and no surviving column was found — set defaultColumnName manually`);
     }
     cloneNotes = `\n${noteLines.join('\n')}`;
   } else {

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -46,11 +46,53 @@ const LabelsArgsSchema = z
   })
   .passthrough();
 
+/**
+ * Common near-misses agents reach for, mapped to the canonical action. Keeps the
+ * advertised enum tight while still accepting obvious synonyms at runtime (for
+ * clients that don't enforce the JSON-schema enum before dispatch).
+ */
+const ACTION_ALIASES: Record<string, LabelAction> = {
+  list: 'info', 'list-files': 'info', 'list-label-files': 'info', get: 'info', 'get-info': 'info',
+  find: 'search', query: 'search', lookup: 'search',
+  add: 'create', 'create-label': 'create', 'new': 'create',
+  'rename-label': 'rename',
+};
+
+/** Action values that mean "create the label *file*", which is d365fo_file's job. */
+const LABEL_FILE_ACTIONS = new Set(['create-label-file', 'create-file', 'create-labelfile', 'new-label-file']);
+
 export async function labelsTool(request: CallToolRequest, context: XppServerContext) {
-  const parsed = LabelsArgsSchema.safeParse(request.params.arguments ?? {});
+  const rawArgs = { ...(request.params.arguments ?? {}) } as Record<string, any>;
+  const rawAction = typeof rawArgs.action === 'string' ? rawArgs.action.trim().toLowerCase() : rawArgs.action;
+
+  if (typeof rawAction === 'string') {
+    if (LABEL_FILE_ACTIONS.has(rawAction)) {
+      return {
+        content: [{
+          type: 'text',
+          text:
+            `❌ labels: "${rawArgs.action}" is not a labels action — creating a label *file* is done with ` +
+            `d365fo_file(action="create", objectType="label-file", ...). The labels tool only manages individual ` +
+            `labels: ${LABEL_ACTIONS.join(', ')}.`,
+        }],
+        isError: true,
+      };
+    }
+    if (!LABEL_ACTIONS.includes(rawAction as LabelAction) && ACTION_ALIASES[rawAction]) {
+      rawArgs.action = ACTION_ALIASES[rawAction];
+    }
+  }
+
+  const parsed = LabelsArgsSchema.safeParse(rawArgs);
   if (!parsed.success) {
     return {
-      content: [{ type: 'text', text: `❌ labels: invalid arguments — ${parsed.error.message}` }],
+      content: [{
+        type: 'text',
+        text:
+          `❌ labels: invalid arguments — action must be one of: ${LABEL_ACTIONS.join(', ')} ` +
+          `(got "${rawArgs.action ?? ''}"). search=find labels, info=translations/list files, ` +
+          `create=add a label, rename=rename a label ID.`,
+      }],
       isError: true,
     };
   }
@@ -59,7 +101,7 @@ export async function labelsTool(request: CallToolRequest, context: XppServerCon
   const dispatch = LABEL_DISPATCH[action as LabelAction];
   if (!dispatch) {
     return {
-      content: [{ type: 'text', text: `❌ labels: unsupported action "${action}".` }],
+      content: [{ type: 'text', text: `❌ labels: unsupported action "${action}". Valid actions: ${LABEL_ACTIONS.join(', ')}.` }],
       isError: true,
     };
   }

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -604,7 +604,11 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // 1a. Path containment guard — every write target must live under a configured
     //     <PackagesLocalDirectory>/<Package>/<Model>/Ax<Type>/<File>.xml layout.
     //     Refuses path traversal via explicit filePath or JSON sourcePath (security-critical).
-    const containment = await assertWritePathAllowed(filePath, modelName);
+    //     A caller-supplied packagePath (metadata outside PLD, e.g. a repo checkout) is
+    //     honored as an allowed root — findD365File already resolves against it, so the
+    //     containment list must include it too or valid writes get wrongly rejected.
+    const extraRoots = args.packagePath ? [args.packagePath] : undefined;
+    const containment = await assertWritePathAllowed(filePath, modelName, { extraRoots });
     if (!containment.ok) {
       throw new Error(containment.reason || 'Path containment check failed');
     }
@@ -639,7 +643,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         const data = JSON.parse(fileContent);
         if (data.sourcePath) {
           // Re-validate the indirect path: sourcePath also comes from user-influenced data.
-          const srcContainment = await assertWritePathAllowed(data.sourcePath, modelName);
+          const srcContainment = await assertWritePathAllowed(data.sourcePath, modelName, { extraRoots });
           if (!srcContainment.ok) {
             throw new Error(`sourcePath rejected: ${srcContainment.reason}`);
           }

--- a/src/tools/objectPatterns.ts
+++ b/src/tools/objectPatterns.ts
@@ -22,7 +22,9 @@ function err(text: string) {
 
 export async function objectPatternsTool(request: CallToolRequest, context: XppServerContext) {
   const a = (request.params.arguments ?? {}) as Record<string, any>;
-  let domain = a.domain as string | undefined;
+  // Accept `patternType` / `type` as aliases for the `domain` discriminator —
+  // agents frequently reach for these names.
+  let domain = (a.domain ?? a.patternType ?? a.type) as string | undefined;
 
   // Infer the discriminator from form/table-specific params when omitted.
   if (domain !== 'table' && domain !== 'form') {
@@ -54,7 +56,11 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
     return formPatternTool(formRequest, context);
   }
 
-  return err(`object_patterns: unknown domain "${a.domain}". Use "table" (table field/index/relation patterns) or "form" (form-pattern toolkit; pass action=analyze|spec|validate).`);
+  return err(
+    `object_patterns: could not determine domain (got domain/patternType="${a.domain ?? a.patternType ?? a.type ?? ''}"). ` +
+    `Pass domain="table" (table field/index/relation patterns) or domain="form" (form-pattern toolkit; with action=analyze|spec|validate). ` +
+    `Domain is also inferred from action/pattern/xml/formName (→ form) or tableGroup (→ table).`,
+  );
 }
 
 // Tool registration (name, description, inputSchema) lives inline in

--- a/src/utils/formCloner.ts
+++ b/src/utils/formCloner.ts
@@ -21,6 +21,8 @@ export interface CloneFormOptions {
   getTableFields?: (table: string) => string[] | null;
   /** Strip form/datasource methods except classDeclaration (default true) */
   stripMethods?: boolean;
+  /** New Design caption (label ref or text). Replaces the source form's caption. */
+  caption?: string;
 }
 
 export interface CloneFormResult {
@@ -30,6 +32,14 @@ export interface CloneFormResult {
   droppedFields: Array<{ dataSource: string; field: string }>;
   removedControls: string[];
   strippedMethods: string[];
+  /** True when the <SourceCode> datasource/control method mirror was emptied. */
+  clearedSourceCodeMirror: boolean;
+  /** True when the classDeclaration body (member vars/macros) was reset to empty. */
+  resetClassDeclaration: boolean;
+  /** Default datasource indexes dropped from re-bound datasources. */
+  removedIndexes: Array<{ dataSource: string; index: string }>;
+  /** QuickFilter defaultColumnName references repointed/cleared after column removal. */
+  repointedQuickFilters: Array<{ from: string; to: string }>;
 }
 
 interface ElementBlock {
@@ -103,6 +113,39 @@ function firstElementValue(content: string, tagName: string): string | undefined
   return m?.[1];
 }
 
+/** Value of a FormControlExtension ExtensionProperty by property name. */
+function extPropValue(content: string, propName: string): string | undefined {
+  for (const p of findElementBlocks(content, 'AxFormControlExtensionProperty')) {
+    if (firstElementValue(p.content, 'Name') === propName) {
+      return p.content.match(/<Value>([^<]*)<\/Value>/)?.[1];
+    }
+  }
+  return undefined;
+}
+
+/** Depth-first search for an AxFormControl with a given <Name> under <Design>. */
+function findControlByName(xml: string, name: string): ElementBlock | undefined {
+  const designStart = xml.indexOf('<Design>');
+  const stack = [...findElementBlocks(xml, 'AxFormControl', designStart === -1 ? 0 : designStart)];
+  while (stack.length) {
+    const blk = stack.pop()!;
+    if (firstElementValue(blk.content, 'Name') === name) return blk;
+    for (const child of findElementBlocks(blk.content, 'AxFormControl', blk.content.indexOf('>') + 1)) {
+      stack.push({ start: blk.start + child.start, end: blk.start + child.end, content: child.content });
+    }
+  }
+  return undefined;
+}
+
+/** First direct child AxFormControl <Name> not in the removed set. */
+function firstRemainingChildName(containerContent: string, removed: Set<string>): string | undefined {
+  for (const child of findElementBlocks(containerContent, 'AxFormControl', containerContent.indexOf('>') + 1)) {
+    const n = firstElementValue(child.content, 'Name');
+    if (n && !removed.has(n.toLowerCase())) return n;
+  }
+  return undefined;
+}
+
 /** Remove a set of [start,end) ranges from a string (ranges must not overlap). */
 function removeRanges(xml: string, ranges: Array<{ start: number; end: number }>): string {
   let result = xml;
@@ -137,6 +180,7 @@ export function cloneFormXml(sourceXml: string, opt: CloneFormOptions): CloneFor
     tableMapping = {},
     getTableFields,
     stripMethods = true,
+    caption,
   } = opt;
 
   let xml = sourceXml;
@@ -147,6 +191,10 @@ export function cloneFormXml(sourceXml: string, opt: CloneFormOptions): CloneFor
     droppedFields: [],
     removedControls: [],
     strippedMethods: [],
+    clearedSourceCodeMirror: false,
+    resetClassDeclaration: false,
+    removedIndexes: [],
+    repointedQuickFilters: [],
   };
 
   // ── 1. Form rename ─────────────────────────────────────────────────────────
@@ -177,6 +225,51 @@ export function cloneFormXml(sourceXml: string, opt: CloneFormOptions): CloneFor
         }
       }
       xml = removeRanges(xml, removals);
+    }
+  }
+
+  // ── 2b. Empty the <SourceCode> datasource/control method mirror ────────────
+  // <SourceCode> carries a <DataSources>/<DataControls> mirror that exists only
+  // to host per-datasource, per-field and per-control method overrides. We strip
+  // those methods, so the mirror is dead weight — and it still names the SOURCE
+  // table's fields and the source form's controls, which the deserializer
+  // cross-checks against the (re-bound) real datasources and rejects. Reset both
+  // to the empty self-closing form every clean form uses.
+  for (const childTag of ['DataSources', 'DataControls']) {
+    const sc = findElementBlocks(xml, 'SourceCode')[0];
+    if (!sc) break;
+    const blk = findElementBlocks(xml, childTag, sc.start, sc.end)[0];
+    if (!blk || blk.content.endsWith('/>')) continue;
+    const xmlnsAttr = blk.content.match(/^<\w+\s+(xmlns="[^"]*")/)?.[1] ?? 'xmlns=""';
+    xml = xml.slice(0, blk.start) + `<${childTag} ${xmlnsAttr} />` + xml.slice(blk.end);
+    result.clearedSourceCodeMirror = true;
+  }
+
+  // ── 2c. Reset the classDeclaration body ────────────────────────────────────
+  // Member variables and macros (e.g. `boolean isDefaultPaymentChange;`,
+  // `#ISOCountryRegionCodes`) only existed to support the methods we just
+  // stripped. Keep the class header (attributes / extends / implements) but
+  // empty the body so the clone compiles. The form name was already retargeted.
+  {
+    const sc = findElementBlocks(xml, 'SourceCode')[0];
+    if (sc) {
+      for (const method of findElementBlocks(xml, 'Method', sc.start, sc.end)) {
+        if (firstElementValue(method.content, 'Name') !== 'classDeclaration') continue;
+        const cdata = method.content.match(/<Source>\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*<\/Source>/);
+        if (cdata) {
+          const body = cdata[1];
+          const open = body.indexOf('{');
+          const close = body.lastIndexOf('}');
+          if (open !== -1 && close > open && body.slice(open + 1, close).trim().length > 0) {
+            const header = body.slice(0, open).replace(/[ \t]+$/, '');
+            const newCdata = cdata[0].replace(cdata[1], `\n${header.trimStart()}\n{\n}\n`);
+            const newMethod = method.content.replace(cdata[0], newCdata);
+            xml = xml.slice(0, method.start) + newMethod + xml.slice(method.end);
+            result.resetClassDeclaration = true;
+          }
+        }
+        break;
+      }
     }
   }
 
@@ -213,6 +306,14 @@ export function cloneFormXml(sourceXml: string, opt: CloneFormOptions): CloneFor
       newBlock = newBlock.replace(`<Name>${dsName}</Name>`, `<Name>${targetTable}</Name>`);
       result.renamedDataSources.push({ from: dsName, to: targetTable });
     }
+
+    // The default-sort <Index> names an index on the SOURCE table that the
+    // target table almost certainly doesn't have — drop it (D365FO falls back
+    // to the table's primary index).
+    newBlock = newBlock.replace(/[ \t]*<Index(?:\s[^>]*)?>([^<]*)<\/Index>\r?\n?/g, (_m, idx) => {
+      result.removedIndexes.push({ dataSource: renameDs ? targetTable : dsName, index: idx });
+      return '';
+    });
 
     xml = xml.slice(0, ds.start) + newBlock + xml.slice(ds.end);
   }
@@ -285,6 +386,43 @@ export function cloneFormXml(sourceXml: string, opt: CloneFormOptions): CloneFor
         }
       }
       xml = removeRanges(xml, controlRemovals);
+
+      // Repoint QuickFilter defaultColumnName references that named a removed
+      // column — otherwise the QuickFilter points at a control that no longer
+      // exists. Best-effort: retarget to the first surviving column of the same
+      // grid (named by the sibling targetControlName property).
+      const removedSet = new Set(result.removedControls.map((c) => c.toLowerCase()));
+      for (const ext of [...findElementBlocks(xml, 'FormControlExtension')].sort((a, b) => b.start - a.start)) {
+        const defCol = extPropValue(ext.content, 'defaultColumnName');
+        if (!defCol || !removedSet.has(defCol.toLowerCase())) continue;
+        const gridName = extPropValue(ext.content, 'targetControlName');
+        const grid = gridName ? findControlByName(xml, gridName) : undefined;
+        const replacement = grid ? firstRemainingChildName(grid.content, removedSet) : undefined;
+        if (replacement) {
+          const newExt = ext.content.replace(
+            new RegExp(`(<Value>)${escapeRegExp(defCol)}(</Value>)`),
+            `$1${replacement}$2`,
+          );
+          xml = xml.slice(0, ext.start) + newExt + xml.slice(ext.end);
+        }
+        result.repointedQuickFilters.push({ from: defCol, to: replacement ?? '' });
+      }
+    }
+  }
+
+  // ── 5. Caption override ────────────────────────────────────────────────────
+  // The cloned Design keeps the SOURCE form's caption (e.g. @SYS23346 "Payment
+  // terms"). Replace it when the caller supplied a caption. Scoped to the region
+  // before <Controls> so we only touch the Design-level caption, not a tab page's.
+  if (caption) {
+    const designStart = xml.indexOf('<Design>');
+    const controlsStart = xml.indexOf('<Controls', designStart);
+    if (designStart !== -1 && controlsStart !== -1) {
+      const region = xml.slice(designStart, controlsStart);
+      const capRe = /(<Caption(?:\s[^>]*)?>)[^<]*(<\/Caption>)/;
+      if (capRe.test(region)) {
+        xml = xml.slice(0, designStart) + region.replace(capRe, `$1${caption}$2`) + xml.slice(controlsStart);
+      }
     }
   }
 

--- a/src/utils/pathContainment.ts
+++ b/src/utils/pathContainment.ts
@@ -65,7 +65,7 @@ function isUnder(child: string, parent: string): boolean {
  * Order: configured package path → UDE custom packages → UDE Microsoft packages → fallback.
  * Empty/undefined entries are skipped.
  */
-async function getAllowedRoots(): Promise<string[]> {
+async function getAllowedRoots(extraRoots?: (string | null | undefined)[]): Promise<string[]> {
   const cfg = getConfigManager();
   await cfg.ensureLoaded();
   const roots = new Set<string>();
@@ -74,6 +74,12 @@ async function getAllowedRoots(): Promise<string[]> {
   add(cfg.getPackagePath());
   try { add(await cfg.getCustomPackagesPath()); } catch { /* optional */ }
   try { add(await cfg.getMicrosoftPackagesPath()); } catch { /* optional */ }
+
+  // Caller-supplied roots (e.g. the `packagePath` tool param pointing at a repo
+  // checkout outside PackagesLocalDirectory). These are operator/agent-declared
+  // metadata roots and carry the same trust as a configured root; the canonical
+  // AOT-shape and model-hint checks below still apply to anything under them.
+  for (const r of extraRoots ?? []) add(r);
 
   // Fallback only if nothing was configured — prevents writing to unrelated drives
   // when config is silently missing (better to error out than guess).
@@ -93,6 +99,7 @@ async function getAllowedRoots(): Promise<string[]> {
 export async function assertWritePathAllowed(
   filePath: string,
   modelHint?: string,
+  opts?: { extraRoots?: (string | null | undefined)[] },
 ): Promise<PathContainmentResult> {
   if (!filePath || typeof filePath !== 'string') {
     return { ok: false, reason: 'filePath is empty' };
@@ -104,7 +111,7 @@ export async function assertWritePathAllowed(
   const canonical = normalise(filePath);
 
   // 1. Root containment
-  const roots = await getAllowedRoots();
+  const roots = await getAllowedRoots(opts?.extraRoots);
   const matchedRoot = roots.find(r => isUnder(canonical, r));
   if (!matchedRoot) {
     return {
@@ -157,8 +164,12 @@ export async function assertWritePathAllowed(
 }
 
 /** Throwing wrapper — convenient in tool handlers. */
-export async function ensureWritePathAllowed(filePath: string, modelHint?: string): Promise<string> {
-  const r = await assertWritePathAllowed(filePath, modelHint);
+export async function ensureWritePathAllowed(
+  filePath: string,
+  modelHint?: string,
+  opts?: { extraRoots?: (string | null | undefined)[] },
+): Promise<string> {
+  const r = await assertWritePathAllowed(filePath, modelHint, opts);
   if (!r.ok) throw new Error(`⛔ Path containment check failed: ${r.reason}`);
   return r.canonicalPath!;
 }

--- a/src/validation/formPatternValidator.ts
+++ b/src/validation/formPatternValidator.ts
@@ -64,6 +64,27 @@ interface FormFacts {
 
 const CONTAINER_TYPES = new Set(['Group', 'TabPage', 'Tab']);
 
+/**
+ * Composite platform controls whose internal child structure is managed by the
+ * platform, not by the form pattern. The financial DimensionEntryControl is the
+ * classic case: it nests its own Groups (one per dimension segment), which a
+ * pattern like FieldsFieldGroups would otherwise reject as "more than one level
+ * of group nesting". Faithful clones of real shipped forms (SalesTable etc.)
+ * legitimately contain these, so the validator treats them as opaque — accepted
+ * wherever input controls are allowed, and never descended into.
+ */
+const OPAQUE_CONTROL_TYPES = new Set([
+  'DimensionEntryControl',
+  'DimensionExpressionEntryControl',
+]);
+
+/** True for composite controls whose interior is not governed by form patterns. */
+function isOpaqueControl(node: FormControlNode): boolean {
+  if (OPAQUE_CONTROL_TYPES.has(node.type)) return true;
+  const hay = `${node.type} ${node.axType ?? ''}`.toLowerCase();
+  return /dimension(entry|expression)/.test(hay);
+}
+
 function nodePath(parentPath: string, node: FormControlNode): string {
   return `${parentPath}/${node.type}[${node.name}]`;
 }
@@ -206,7 +227,9 @@ function matchChildren(
     if (consumed[i]) continue;
     const child = actual[i];
     const allowedExtra =
-      extra === 'any' || (Array.isArray(extra) && (extra.includes('*') || extra.includes(child.type)));
+      extra === 'any'
+      || isOpaqueControl(child)
+      || (Array.isArray(extra) && (extra.includes('*') || extra.includes(child.type)));
     if (!allowedExtra) {
       violations.push({
         rule: 'FP004',
@@ -314,6 +337,10 @@ function validateSubPatternsDeep(
   violations: FormPatternViolation[],
 ): void {
   for (const node of nodes) {
+    // Opaque composite controls (DimensionEntryControl …) own their interior —
+    // do not validate or descend into their managed child structure.
+    if (isOpaqueControl(node)) continue;
+
     const path = nodePath(parentPath, node);
 
     if (node.pattern) {
@@ -370,6 +397,7 @@ function countContainers(nodes: FormControlNode[]): { total: number; patterned: 
   let total = 0;
   let patterned = 0;
   const visit = (node: FormControlNode): void => {
+    if (isOpaqueControl(node)) return; // managed interior — not pattern containers
     if (CONTAINER_TYPES.has(node.type)) {
       total++;
       if (node.pattern) patterned++;

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -353,6 +353,43 @@ describe('XmlTemplateGenerator security duty/role generators', () => {
   });
 });
 
+// ─── table create: enum field generation ─────────────────────────────────────
+
+describe('XmlTemplateGenerator.generateAxTableXml enum fields', () => {
+  it('emits AxTableFieldEnum + EnumType from enumType (extension-style field spec)', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('AslRentEquipment', {
+      fields: [{ name: 'EquipmentStatus', enumType: 'NoYes', label: '@Asl:Status' }],
+    });
+    expect(xml).toContain('i:type="AxTableFieldEnum"');
+    expect(xml).toContain('<EnumType>NoYes</EnumType>');
+    expect(xml).not.toContain('AxTableFieldString');
+  });
+
+  it('honors an explicit fieldType="AxTableFieldEnum"', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('AslRentEquipment', {
+      fields: [{ name: 'EquipmentStatus', fieldType: 'AxTableFieldEnum', enumType: 'NoYes' }],
+    });
+    expect(xml).toContain('i:type="AxTableFieldEnum"');
+    expect(xml).toContain('<EnumType>NoYes</EnumType>');
+  });
+
+  it('still maps the primitive type="Enum" spec to an enum field', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('AslRentEquipment', {
+      fields: [{ name: 'EquipmentStatus', type: 'Enum', enumType: 'NoYes' }],
+    });
+    expect(xml).toContain('i:type="AxTableFieldEnum"');
+    expect(xml).toContain('<EnumType>NoYes</EnumType>');
+  });
+
+  it('leaves plain string fields untouched', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('AslRentEquipment', {
+      fields: [{ name: 'EquipmentName', edt: 'Name' }],
+    });
+    expect(xml).toContain('i:type="AxTableFieldString"');
+    expect(xml).not.toContain('<EnumType>');
+  });
+});
+
 // ─── generate_smart_table ────────────────────────────────────────────────────
 
 describe('generate_smart_table', () => {

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -8,6 +8,7 @@ import { searchLabelsTool } from '../../src/tools/searchLabels';
 import { getLabelInfoTool } from '../../src/tools/getLabelInfo';
 import { createLabelTool } from '../../src/tools/createLabel';
 import { renameLabelTool } from '../../src/tools/renameLabel';
+import { labelsTool } from '../../src/tools/labels';
 import { isExtensionLabelFile } from '../../src/metadata/labelParser';
 import type { XppServerContext } from '../../src/types/context';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
@@ -1281,5 +1282,45 @@ describe('rename_label', () => {
     expect(labelWrite!.content).toContain('AppleLabel=Apple text\n');
     // No CRLF sequences must be present — file must stay pure LF.
     expect(labelWrite!.content).not.toContain('\r\n');
+  });
+});
+
+describe('labels dispatcher: action aliases + errors', () => {
+  let ctx: XppServerContext;
+  beforeEach(() => { ctx = buildContext(); });
+
+  it('redirects create-label-file to d365fo_file with a clear message', async () => {
+    const r: any = await labelsTool(
+      { method: 'tools/call', params: { name: 'labels', arguments: { action: 'create-label-file', model: 'MyModel' } } } as CallToolRequest,
+      ctx,
+    );
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('d365fo_file');
+  });
+
+  it('rejects an unknown action and lists the valid ones', async () => {
+    const r: any = await labelsTool(
+      { method: 'tools/call', params: { name: 'labels', arguments: { action: 'frobnicate' } } } as CallToolRequest,
+      ctx,
+    );
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('search, info, create, rename');
+  });
+
+  it('aliases action="list" to info (not rejected as invalid)', async () => {
+    // "list" is not a canonical action; the alias map rewrites it to "info" so
+    // safeParse succeeds and it dispatches instead of failing validation.
+    let r: any;
+    try {
+      r = await labelsTool(
+        { method: 'tools/call', params: { name: 'labels', arguments: { action: 'list', model: 'MyModel' } } } as CallToolRequest,
+        ctx,
+      );
+    } catch {
+      // A downstream sub-tool error is fine here — it means the alias was accepted
+      // and we got past argument validation, which is what this test asserts.
+      return;
+    }
+    expect(r.content?.[0]?.text ?? '').not.toContain('invalid arguments');
   });
 });

--- a/tests/tools/mergedDispatchers.test.ts
+++ b/tests/tools/mergedDispatchers.test.ts
@@ -192,6 +192,17 @@ describe('object_patterns dispatcher', () => {
     expect(formPatternTool).not.toHaveBeenCalled();
   });
 
+  it('accepts patternType as an alias for domain', async () => {
+    await objectPatternsTool(req('object_patterns', { patternType: 'table', tableGroup: 'Main' }), ctx);
+    expect(getTablePatternsTool).toHaveBeenCalledOnce();
+    expect(formPatternTool).not.toHaveBeenCalled();
+  });
+
+  it('accepts type as an alias for domain', async () => {
+    await objectPatternsTool(req('object_patterns', { type: 'form', action: 'analyze' }), ctx);
+    expect(formPatternTool).toHaveBeenCalledOnce();
+  });
+
   it('unknown/omitted domain with no signals → friendly error', async () => {
     const r: any = await objectPatternsTool(req('object_patterns', {}), ctx);
     expect(r.isError).toBe(true);

--- a/tests/utils/formCloner.test.ts
+++ b/tests/utils/formCloner.test.ts
@@ -146,6 +146,167 @@ describe('cloneFormXml', () => {
   });
 });
 
+// A PaymTerm-shaped source carrying every residue category that broke the
+// AslRentEquipment clone: a SourceCode datasource/control method mirror, member
+// vars + macros in classDeclaration, a default <Index>, a @SYS caption, and a
+// QuickFilter whose defaultColumnName points at a soon-to-be-dropped column.
+const paymTermLike = () => `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>PaymTerm</Name>
+\t<SourceCode>
+\t\t<Methods xmlns="">
+\t\t\t<Method>
+\t\t\t\t<Name>classDeclaration</Name>
+\t\t\t\t<Source><![CDATA[
+[Form]
+public class PaymTerm extends FormRun
+{
+    boolean isDefaultPaymentChange;
+    #ISOCountryRegionCodes
+}
+]]></Source>
+\t\t\t</Method>
+\t\t\t<Method>
+\t\t\t\t<Name>init</Name>
+\t\t\t\t<Source><![CDATA[
+public void init() { super(); }
+]]></Source>
+\t\t\t</Method>
+\t\t</Methods>
+\t\t<DataSources xmlns="">
+\t\t\t<DataSource>
+\t\t\t\t<Name>Payment</Name>
+\t\t\t\t<Fields>
+\t\t\t\t\t<Field><DataField>Cash</DataField></Field>
+\t\t\t\t\t<Field><DataField>PaymTermId</DataField></Field>
+\t\t\t\t</Fields>
+\t\t\t</DataSource>
+\t\t</DataSources>
+\t\t<DataControls xmlns="">
+\t\t\t<Control><Name>Administration_DefaultPaymTerm_PSN</Name></Control>
+\t\t</DataControls>
+\t\t<Members xmlns="" />
+\t</SourceCode>
+\t<DataSources>
+\t\t<AxFormDataSource xmlns="">
+\t\t\t<Name>Payment</Name>
+\t\t\t<Table>PaymTerm</Table>
+\t\t\t<Fields>
+\t\t\t\t<AxFormDataSourceField><DataField>Name</DataField></AxFormDataSourceField>
+\t\t\t\t<AxFormDataSourceField><DataField>PaymTermId</DataField></AxFormDataSourceField>
+\t\t\t\t<AxFormDataSourceField><DataField>Cash</DataField></AxFormDataSourceField>
+\t\t\t</Fields>
+\t\t\t<Index>TermIdx</Index>
+\t\t\t<ReferencedDataSources />
+\t\t\t<DataSourceLinks />
+\t\t\t<DerivedDataSources />
+\t\t</AxFormDataSource>
+\t</DataSources>
+\t<Design>
+\t\t<Caption xmlns="">@SYS23346</Caption>
+\t\t<DataSource xmlns="">Payment</DataSource>
+\t\t<Pattern xmlns="">SimpleList</Pattern>
+\t\t<PatternVersion xmlns="">1.1</PatternVersion>
+\t\t<Style xmlns="">SimpleList</Style>
+\t\t<Controls xmlns="">
+\t\t\t<AxFormControl xmlns="" i:type="AxFormGroupControl">
+\t\t\t\t<Name>CustomFilterGroup</Name>
+\t\t\t\t<Controls>
+\t\t\t\t\t<AxFormControl>
+\t\t\t\t\t\t<Name>QuickFilterControl</Name>
+\t\t\t\t\t\t<FormControlExtension>
+\t\t\t\t\t\t\t<Name>QuickFilterControl</Name>
+\t\t\t\t\t\t\t<ExtensionProperties>
+\t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
+\t\t\t\t\t\t\t\t\t<Name>targetControlName</Name>
+\t\t\t\t\t\t\t\t\t<Type>String</Type>
+\t\t\t\t\t\t\t\t\t<Value>PaymentGrid</Value>
+\t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
+\t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
+\t\t\t\t\t\t\t\t\t<Name>defaultColumnName</Name>
+\t\t\t\t\t\t\t\t\t<Type>String</Type>
+\t\t\t\t\t\t\t\t\t<Value>Grid_PaymTermId</Value>
+\t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
+\t\t\t\t\t\t\t</ExtensionProperties>
+\t\t\t\t\t\t</FormControlExtension>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t</Controls>
+\t\t\t</AxFormControl>
+\t\t\t<AxFormControl xmlns="" i:type="AxFormGridControl">
+\t\t\t\t<Name>PaymentGrid</Name>
+\t\t\t\t<Controls>
+\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormStringControl">
+\t\t\t\t\t\t<Name>Grid_Name</Name>
+\t\t\t\t\t\t<DataField>Name</DataField>
+\t\t\t\t\t\t<DataSource>Payment</DataSource>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormStringControl">
+\t\t\t\t\t\t<Name>Grid_PaymTermId</Name>
+\t\t\t\t\t\t<DataField>PaymTermId</DataField>
+\t\t\t\t\t\t<DataSource>Payment</DataSource>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormStringControl">
+\t\t\t\t\t\t<Name>Grid_Cash</Name>
+\t\t\t\t\t\t<DataField>Cash</DataField>
+\t\t\t\t\t\t<DataSource>Payment</DataSource>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t</Controls>
+\t\t\t\t<DataSource>Payment</DataSource>
+\t\t\t</AxFormControl>
+\t\t</Controls>
+\t</Design>
+\t<Parts />
+</AxForm>`;
+
+describe('cloneFormXml residue cleanup (PaymTerm → AslRentEquipment)', () => {
+  const clone = () =>
+    cloneFormXml(paymTermLike(), {
+      targetFormName: 'AslRentEquipment',
+      tableMapping: { PaymTerm: 'AslRentEquipment' },
+      caption: '@AslRent:Equipment',
+      getTableFields: (table) => (table.toLowerCase() === 'aslrentequipment' ? ['Name'] : null),
+    });
+
+  it('empties the SourceCode datasource/control method mirror', () => {
+    const r = clone();
+    expect(r.clearedSourceCodeMirror).toBe(true);
+    const sc = r.xml.slice(r.xml.indexOf('<SourceCode>'), r.xml.indexOf('</SourceCode>'));
+    expect(sc).toContain('<DataSources xmlns="" />');
+    expect(sc).toContain('<DataControls xmlns="" />');
+    // The stale field/control holders are gone.
+    expect(r.xml).not.toContain('Administration_DefaultPaymTerm_PSN');
+    expect(sc).not.toContain('<Field><DataField>Cash</DataField></Field>');
+  });
+
+  it('resets the classDeclaration body (drops member vars and macros)', () => {
+    const r = clone();
+    expect(r.resetClassDeclaration).toBe(true);
+    expect(r.xml).not.toContain('isDefaultPaymentChange');
+    expect(r.xml).not.toContain('#ISOCountryRegionCodes');
+    expect(r.xml).toContain('public class AslRentEquipment extends FormRun');
+  });
+
+  it('drops the source-table default <Index> from re-bound datasources', () => {
+    const r = clone();
+    expect(r.removedIndexes).toEqual([{ dataSource: 'Payment', index: 'TermIdx' }]);
+    expect(r.xml).not.toContain('<Index>TermIdx</Index>');
+  });
+
+  it('overrides the Design caption', () => {
+    const r = clone();
+    expect(r.xml).toContain('<Caption xmlns="">@AslRent:Equipment</Caption>');
+    expect(r.xml).not.toContain('@SYS23346');
+  });
+
+  it('repoints QuickFilter defaultColumnName off a removed column', () => {
+    const r = clone();
+    expect(r.removedControls).toEqual(expect.arrayContaining(['Grid_PaymTermId', 'Grid_Cash']));
+    expect(r.repointedQuickFilters).toEqual([{ from: 'Grid_PaymTermId', to: 'Grid_Name' }]);
+    expect(r.xml).toContain('<Value>Grid_Name</Value>');
+    expect(r.xml).not.toContain('<Value>Grid_PaymTermId</Value>');
+  });
+});
+
 describe('injectMethodStubs', () => {
   it('injects form + datasource stubs into template XML', () => {
     const stubs = methodStubsForPattern('DetailsMaster', 'CustTable');

--- a/tests/validation/formPatternValidator.test.ts
+++ b/tests/validation/formPatternValidator.test.ts
@@ -203,6 +203,33 @@ describe('validateFormTree rule units', () => {
     expect(rules(report, 'error')).toContain('FP004');
   });
 
+  it('opaque controls: nested Groups inside a DimensionEntryControl are NOT flagged in FieldsFieldGroups', () => {
+    // A faithful clone of a real form (e.g. SalesTable) nests Groups inside the
+    // financial DimensionEntryControl. The platform manages that interior, so the
+    // FieldsFieldGroups "one level of group nesting" rule must not apply to it.
+    const tabPage = node('TabPage', 'TabPageGeneral', {
+      pattern: 'FieldsFieldGroups',
+      children: [
+        node('String', 'AccountNum'),
+        node('DimensionEntryControl', 'LedgerDimension', {
+          children: [
+            node('Group', 'Segment1', { children: [node('String', 'Seg1Val')] }),
+            node('Group', 'Segment2', { children: [node('String', 'Seg2Val')] }),
+          ],
+        }),
+      ],
+    });
+    const design: FormDesignInfo = {
+      pattern: 'DetailsMaster',
+      patternVersion: '1.1',
+      style: 'DetailsFormMaster',
+      properties: {},
+      controls: [actionPane(), node('Tab', 'Tab', { properties: { Style: 'FastTabs' }, children: [tabPage] })],
+    };
+    const report = validateFormTree({ design, dataSourceCount: 1 });
+    expect(rules(report, 'error')).toEqual([]);
+  });
+
   it('FP006: FastTab page without sub-pattern warns (unspecified container)', () => {
     const design: FormDesignInfo = {
       pattern: 'DetailsMaster',


### PR DESCRIPTION
Opravy chybových stavů, na které jsme narazili při vytváření formuláře `AslRentEquipment` přes MCP nástroje.

## formCloner (`cloneFrom` scaffold)
Klonovač přebindoval datasource, ale nečistil rezidua zdrojového formuláře. Nově:
- **vyprázdní zrcadlo `<SourceCode>`** (`<DataSources>` field-holdery + `<DataControls>`) — stale field/control method holdery ukazovaly na zdrojovou tabulku a **lámaly deserializaci** formuláře
- **resetuje tělo `classDeclaration`** (členské proměnné/makra zdroje), hlavičku třídy (`extends`/`implements`) zachová
- **dropne default `<Index>`** z přebindovaných datasourců (index zdrojové tabulky)
- **přepíše Design `<Caption>`** z `caption`/`label`
- **repointuje QuickFilter `defaultColumnName`** z odstraněného sloupce na první přeživší

Druhý nezmapovaný datasource se záměrně nemaže (může být legitimní) — pouze se hlásí.

## createD365File
Field-spec při *create* tabulky teď přijímá `fieldType` + `enumType` (sjednoceno s extension cestou) a emituje `<EnumType>`, takže enum pole už nespadnou na `AxTableFieldString`.

## Kontrakty nástrojů
- `object_patterns` přijímá aliasy `patternType`/`type` a `domain` už není `required` (odvozuje se)
- `get_knowledge` — `kind` už není `required` (odvozuje se z `topic`/`errorText`)
- `labels` — normalizace aliasů akcí + přesná chyba s výčtem platných akcí

## Path guard
`assertWritePathAllowed` respektuje `packagePath` od volajícího jako povolený root → `modify add-index` nad metadaty mimo PLD už není mylně odmítnut.

## Validátor
`DimensionEntryControl` a podobné kompozitní controly jsou brány jako opaque (přijaty tam, kde jsou povolené input controly, a nerekurzuje se do nich) → věrné klony reálných formulářů projdou validací.

## Testy
988 zelených (+5 cloner cleanup, +4 enum, +2 object_patterns alias, +3 labels, +1 validator opaque-control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)