### PR TITLE
fix: suggest the exact package root in path-guard error for repo-chec…

### DIFF
--- a/src/utils/pathContainment.ts
+++ b/src/utils/pathContainment.ts
@@ -127,6 +127,20 @@ export async function assertWritePathAllowed(
   const roots = await getAllowedRoots(opts?.extraRoots);
   const matchedRoot = roots.find(r => isUnder(canonical, r));
   if (!matchedRoot) {
+    // When the path still has the canonical <…>/<Package>/<Model>/Ax<Type>/<File>
+    // shape, the would-be package root is everything above <Package>. Surfacing
+    // the exact value turns a generic "configure a root" into a copy-paste fix —
+    // this is the common repo-checkout case (metadata outside PackagesLocalDirectory).
+    const segs = canonical.split('/').filter(Boolean);
+    const axIdx = segs.findIndex(s => /^Ax[A-Z]/.test(s));
+    const derivedRoot =
+      axIdx >= 3 && axIdx === segs.length - 2 ? segs.slice(0, axIdx - 2).join('/') : '';
+    const suggestion = derivedRoot
+      ? `    This object's package root looks like: ${derivedRoot}\n` +
+        `    → per call:   packagePath="${derivedRoot}"\n` +
+        `    → persistent: set context.customPackagesPath / D365FO_CUSTOM_PACKAGES_PATH to it (and restart).\n`
+      : `    Set context.customPackagesPath / D365FO_CUSTOM_PACKAGES_PATH (and restart), ` +
+        `or pass packagePath="<root that contains the model>".\n`;
     return {
       ok: false,
       reason:
@@ -137,9 +151,9 @@ export async function assertWritePathAllowed(
         `  resolved path: ${canonical}\n` +
         `  allowed roots:\n` +
         (roots.length ? roots.map(r => `    - ${r}`).join('\n') : '    (none configured)') + '\n' +
-        `  → The file resolved under none of these roots. This usually means its model is not on an\n` +
-        `    allowed root: set context.customPackagesPath / D365FO_CUSTOM_PACKAGES_PATH (and restart),\n` +
-        `    or pass packagePath="<root that contains the model>". It is NOT a path-separator issue.`,
+        `  → The file resolved under none of these roots (its model is not on an allowed root):\n` +
+        suggestion +
+        `    It is NOT a path-separator issue.`,
     };
   }
 

--- a/tests/utils/pathContainmentBroadening.test.ts
+++ b/tests/utils/pathContainmentBroadening.test.ts
@@ -31,4 +31,14 @@ describe('pathContainment — PLD-base broadening', () => {
     expect(r.ok).toBe(false);
     expect(r.reason).toContain('NOT a path-separator issue');
   });
+
+  it('suggests the exact package root for a repo-checkout layout', async () => {
+    // The real reported case: metadata lives in a Git checkout, not under PLD.
+    const r = await assertWritePathAllowed(
+      'K:\\repos\\ASL\\src\\d365fo\\metadata\\fm-mcp\\fm-mcp\\AxTable\\AslRentEquipment.xml',
+      'fm-mcp',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('packagePath="K:/repos/ASL/src/d365fo/metadata"');
+  });
 });


### PR DESCRIPTION
…kout layouts

When a write target is rejected but still has the canonical <…>/<Package>/<Model>/Ax<Type>/<File> shape, derive the would-be package root (everything above <Package>) and print it as a copy-paste packagePath / customPackagesPath value. Turns the generic "configure a root" hint into an exact fix for the common case where metadata lives in a Git checkout outside PackagesLocalDirectory.