### PR TITLE
fix: form template gate, bridge-null diagnostic, knowledge tokenization

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -16,6 +16,7 @@ import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
 import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject } from '../bridge/index.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
 import { gateOnFormPatternErrors } from './validateFormPattern.js';
+import { FormPatternTemplates } from '../utils/formPatternTemplates.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 
@@ -764,59 +765,39 @@ ${enumValuesXml}${isExtensibleXml}</AxEnum>
   }
 
   /**
-   * Generate AxForm XML structure (based on real D365FO form structure)
+   * Generate AxForm XML for a new form from a pattern template.
+   *
+   * Delegates to the pattern-compliant {@link FormPatternTemplates} builders so
+   * the generated skeleton actually satisfies the form-pattern gate. The old
+   * inline skeleton declared a `<Pattern>` over empty `<Controls />`, which the
+   * gate rejected as FP003 (required Grid/ActionPane missing) for every pattern
+   * — and worse, defaulted to a `DetailsTransaction` pattern even when the
+   * caller asked for a `SimpleList` template, guaranteeing a mismatch block.
+   *
+   * Pattern resolution: callers may express the intent as either `pattern`
+   * (the design pattern) or `formTemplate` (the VS template name); both are
+   * fuzzy strings normalized to a canonical pattern. When neither is given we
+   * default to SimpleList — the most common shape for a new setup table.
    */
   static generateAxFormXml(
     formName: string,
     properties?: Record<string, any>
   ): string {
-    const caption = properties?.caption || `@${formName}`;
-    const formTemplate = properties?.formTemplate || 'DetailsPage';
-    const pattern = properties?.pattern || 'DetailsTransaction';
-    const dataSource = properties?.dataSource || '';
-    const interactionClass = properties?.interactionClass || '';
-    const style = properties?.style || 'DetailsFormTransaction';
+    const rawPattern = properties?.pattern || properties?.formTemplate;
+    const pattern = rawPattern
+      ? FormPatternTemplates.normalizePattern(String(rawPattern))
+      : 'SimpleList';
 
-    // Build class declaration for SourceCode
-    const extendsFrom = properties?.extends || 'FormRun';
-    const classDeclaration = properties?.classDeclaration || 
-      `[Form]\npublic class ${formName} extends ${extendsFrom}\n{\n}`;
-
-    // Build optional InteractionClass
-    const interactionClassXml = interactionClass
-      ? `\t<InteractionClass>${interactionClass}</InteractionClass>\n`
-      : '';
-
-    // Build DataSource reference for Design
-    const dataSourceXml = dataSource
-      ? `\t\t<DataSource xmlns="">${dataSource}</DataSource>\n`
-      : '';
-
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
-\t<Name>${formName}</Name>
-\t<SourceCode>
-\t\t<Methods xmlns="">
-\t\t\t<Method>
-\t\t\t\t<Name>classDeclaration</Name>
-\t\t\t\t<Source><![CDATA[
-${classDeclaration}
-
-]]></Source>
-\t\t\t</Method>
-\t\t</Methods>
-\t</SourceCode>
-\t<FormTemplate>${formTemplate}</FormTemplate>
-${interactionClassXml}\t<DataSources />
-\t<Design>
-\t\t<Caption xmlns="">${caption}</Caption>
-${dataSourceXml}\t\t<Pattern xmlns="">${pattern}</Pattern>
-\t\t<Style xmlns="">${style}</Style>
-\t\t<Controls xmlns="" />
-\t</Design>
-\t<Parts />
-</AxForm>
-`;
+    return FormPatternTemplates.build(pattern, {
+      formName,
+      dsName: properties?.dataSource || undefined,
+      dsTable: properties?.dataSourceTable || properties?.dataSource || undefined,
+      caption: properties?.caption,
+      gridFields: Array.isArray(properties?.gridFields) ? properties.gridFields : undefined,
+      linesDsName: properties?.linesDataSource,
+      linesDsTable: properties?.linesDataSourceTable || properties?.linesDataSource,
+      sections: Array.isArray(properties?.sections) ? properties.sections : undefined,
+    });
   }
 
   /**

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1137,12 +1137,39 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       };
       const isProvided = (p: string) =>
         (args as any)[p] !== undefined || (aliases[p] ?? []).some(a => (args as any)[a] !== undefined);
-      const missingList = required.filter(p => !isProvided(p)).map(p => `  ⛔ ${p}: MISSING`);
-      const providedList = required.filter(p => isProvided(p)).map(p => `  ✅ ${p}: provided`);
+      const missing = required.filter(p => !isProvided(p));
+
+      // Two distinct causes produce a null bridge result; pick the message that
+      // matches reality instead of always blaming missing parameters.
+      if (missing.length > 0) {
+        const missingList = missing.map(p => `  ⛔ ${p}: MISSING`);
+        const providedList = required.filter(isProvided).map(p => `  ✅ ${p}: provided`);
+        throw new Error(
+          `Bridge operation '${operation}' returned null — required parameters are missing.\n` +
+          `Required parameters for '${operation}':\n${[...providedList, ...missingList].join('\n')}\n` +
+          `Provided args: ${Object.keys(args).filter(k => (args as any)[k] !== undefined).join(', ')}`
+        );
+      }
+
+      // All required params were supplied, yet the bridge returned null. The
+      // cause is object resolution: the C# bridge could not find '${objectName}'
+      // in its metadata model. This is common right after creating the object —
+      // the bridge resolves objects through fixed roots configured at startup
+      // and does not see files written since, so a just-created object is not
+      // yet in its model.
       throw new Error(
-        `Bridge operation '${operation}' returned null — required parameters may be missing.\n` +
-        `Required parameters for '${operation}':\n${[...providedList, ...missingList].join('\n')}\n` +
-        `Provided args: ${Object.keys(args).filter(k => (args as any)[k] !== undefined).join(', ')}`
+        `Bridge operation '${operation}' returned null even though all required parameters ` +
+        `(${required.join(', ') || 'none'}) were provided.\n` +
+        `Most likely cause: the C# metadata bridge could not resolve ${objectType} '${objectName}'.\n` +
+        `This is typical right after creating an object — the bridge's metadata roots are fixed at ` +
+        `startup, so an object written this session may not be in its model yet.\n` +
+        `Try, in order:\n` +
+        `  1. Refresh the bridge's view of the new object: update_symbol_index({ filePath: "<path to ${objectName}.xml>" }).\n` +
+        `  2. Ensure the model is under the bridge's roots — set context.customPackagesPath / ` +
+        `D365FO_CUSTOM_PACKAGES_PATH to the metadata folder, or pass an explicit filePath to this call.\n` +
+        `  3. Confirm ${objectName}.xml actually exists on disk under those roots.\n` +
+        (actualFilePath ? `Resolved file path: ${actualFilePath}\n` : '') +
+        `If none of these apply, the object may simply not exist or its name may be misspelled.`
       );
     }
     if (!bridgeResult.success) {

--- a/src/tools/xppKnowledge.ts
+++ b/src/tools/xppKnowledge.ts
@@ -2147,16 +2147,51 @@ function scoreEntry(entry: KnowledgeEntry, queryTokens: string[]): number {
   return score;
 }
 
-function searchKnowledge(topic: string): KnowledgeEntry[] {
-  const tokens = topic
+/**
+ * Tokenize a topic query. Splits on whitespace/comma/semicolon/slash, then for
+ * every token that itself contains a hyphen or underscore ALSO emits the split
+ * sub-words. The original (joined) token is kept so entry-ID matches like
+ * `set-based` still hit `entry.id === token`, while hyphenated multi-word
+ * queries like `number-sequence` also match word-level keywords/titles (which
+ * store the words separated by spaces, e.g. keyword "number sequence").
+ */
+function tokenize(topic: string): string[] {
+  const base = topic
     .toLowerCase()
     .replace(/[^a-z0-9áčďéěíňóřšťúůýž_\-/\s]/g, '')
     .split(/[\s,;/]+/)
     .filter(t => t.length > 1);
 
+  const out = new Set<string>();
+  for (const tok of base) {
+    out.add(tok);
+    if (tok.includes('-') || tok.includes('_')) {
+      for (const part of tok.split(/[-_]+/).filter(p => p.length > 1)) {
+        out.add(part);
+      }
+    }
+  }
+  return [...out];
+}
+
+/**
+ * Minimum top score for a query to count as a confident match. A score below
+ * this means no title/keyword/ID hit landed — only incidental summary-substring
+ * overlap (1–2 pts) — so the results are surfaced as low-confidence suggestions
+ * rather than authoritative answers. Without this floor, `number-sequence`
+ * silently returned Electronic Reporting docs (the nearest substring hit).
+ */
+const CONFIDENT_SCORE = 3;
+
+function searchKnowledge(topic: string): { entries: KnowledgeEntry[]; topScore: number } {
+  const tokens = tokenize(topic);
+
   if (tokens.length === 0) {
     // Return all entries sorted alphabetically
-    return [...KNOWLEDGE_BASE].sort((a, b) => a.title.localeCompare(b.title));
+    return {
+      entries: [...KNOWLEDGE_BASE].sort((a, b) => a.title.localeCompare(b.title)),
+      topScore: 0,
+    };
   }
 
   const scored = KNOWLEDGE_BASE
@@ -2164,7 +2199,10 @@ function searchKnowledge(topic: string): KnowledgeEntry[] {
     .filter(item => item.score > 0)
     .sort((a, b) => b.score - a.score);
 
-  return scored.map(s => s.entry);
+  return {
+    entries: scored.map(s => s.entry),
+    topScore: scored.length > 0 ? scored[0].score : 0,
+  };
 }
 
 // ─── Formatters ─────────────────────────────────────────────────────────────
@@ -2263,7 +2301,7 @@ function formatDetailed(entries: KnowledgeEntry[]): string {
 export async function xppKnowledgeTool(request: CallToolRequest) {
   try {
     const args = XppKnowledgeArgsSchema.parse(request.params.arguments);
-    const entries = searchKnowledge(args.topic);
+    const { entries, topScore } = searchKnowledge(args.topic);
 
     // Empty topic → compact table of contents listing ALL entries
     const isListAll = args.topic.trim() === '';
@@ -2277,6 +2315,16 @@ export async function xppKnowledgeTool(request: CallToolRequest) {
       formatted = args.format === 'detailed'
         ? formatDetailed(entries)
         : formatConcise(entries);
+
+      // Low-confidence guard: when something matched but only weakly (incidental
+      // substring overlap, no title/keyword/ID hit), warn so the caller doesn't
+      // treat unrelated content as authoritative.
+      if (entries.length > 0 && topScore < CONFIDENT_SCORE) {
+        formatted =
+          `⚠️ No strong match for "${args.topic}" — showing the closest entries below, which may be ` +
+          `unrelated. Browse the full list with \`get_knowledge(kind="knowledge")\` and an empty topic, ` +
+          `or refine your query.\n\n${formatted}`;
+      }
     }
 
     return {

--- a/tests/golden/form-pattern-gate.test.ts
+++ b/tests/golden/form-pattern-gate.test.ts
@@ -168,6 +168,26 @@ describe('form pattern gate in create_d365fo_file', () => {
     expect(vi.mocked(fsMock.writeFile)).toHaveBeenCalled();
   });
 
+  it('generates a gate-passing form from a SimpleList template (no xmlContent)', async () => {
+    // Regression: requesting formTemplate="SimpleList" with no xmlContent used to
+    // emit an empty-controls skeleton declaring a DetailsTransaction pattern,
+    // which the gate blocked (FP003 missing ActionPane/Tab). The template path
+    // must now produce a pattern-compliant SimpleList that writes cleanly.
+    process.env.FORM_PATTERN_ENFORCE = 'true';
+    const result = await handleCreateD365File(createReq({
+      objectType: 'form',
+      objectName: 'RentEquipment',
+      properties: { formTemplate: 'SimpleList', dataSource: 'AslRentEquipment', caption: 'Rent Equipment' },
+      modelName: 'ContosoExt',
+      addToProject: false,
+    }));
+    expect(result.isError, JSON.stringify(result.content)).not.toBe(true);
+    expect(vi.mocked(fsMock.writeFile)).toHaveBeenCalled();
+    const written = String(vi.mocked(fsMock.writeFile).mock.calls.at(-1)?.[1] ?? '');
+    expect(written).toContain('<Pattern xmlns="">SimpleList</Pattern>');
+    expect(written).not.toContain('DetailsTransaction');
+  });
+
   it('never gates non-form objectTypes', async () => {
     process.env.FORM_PATTERN_ENFORCE = 'true';
     const result = await handleCreateD365File(createReq({

--- a/tests/tools/xpp-knowledge.test.ts
+++ b/tests/tools/xpp-knowledge.test.ts
@@ -113,6 +113,17 @@ describe('get_xpp_knowledge', () => {
     expect(text).toContain('NumberSeq');
   });
 
+  it('resolves a hyphenated multi-word topic to the right entry', async () => {
+    // Regression: "number-sequence" used to score 0 on the number-sequences
+    // entry (keyword/title store the words space-separated) and silently
+    // returned Electronic Reporting docs as the nearest substring hit.
+    const result = await xppKnowledgeTool(req({ topic: 'number-sequence' }));
+    const text = getText(result);
+    expect(text).toContain('Number Sequences');
+    expect(text).toContain('NumberSeq');
+    expect(text).not.toContain('⚠️ No strong match');
+  });
+
   it('returns error for missing topic parameter', async () => {
     const result = await xppKnowledgeTool(req({}));
     expect(result.isError).toBe(true);


### PR DESCRIPTION
Three fixes surfaced by an Equipment Rental authoring session:

- createD365File: generate forms via the pattern-compliant FormPatternTemplates builders instead of an inline skeleton that declared a <Pattern> over empty <Controls/> (rejected as FP003 for every pattern) and ignored formTemplate, defaulting to DetailsTransaction. formTemplate/pattern now normalize to a canonical pattern; "SimpleList" writes cleanly.

- modifyD365File: when the bridge returns null but all required params were provided, name the real cause (the C# bridge couldn't resolve the object — common right after create) with ordered remedies, instead of always blaming missing parameters.

- xppKnowledge: tokenize hyphen/underscore queries into sub-words (while keeping the joined token for ID matches) so "number-sequence" resolves to the number-sequences entry instead of Electronic Reporting; add a relevance floor that flags low-confidence matches.

Adds regression tests for the SimpleList template path and hyphenated knowledge topics. Full suite: 1000 passing.