### PR TITLE
feat: bulk labels, clone pattern-mismatch pre-check, generic-word EDT…

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1046,7 +1046,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             'Unified label operations — read and write. Choose an `action`:\n' +
             '• search → full-text query across indexed label files (read). Always run before action=create.\n' +
             '• info → all language translations for a labelId, OR list available label files when labelId is omitted. Pass labelFileId (without labelId) to get that label file plus the physical .label.txt path per language (read).\n' +
-            '• create → add a new label to an AxLabelFile, write into every language .label.txt, create XML descriptors if missing (write). Label IDs describe MEANING — never add a model prefix. Target the model\'s ORIGINAL label file, never a label file extension (…_Extension…). Fails if the label already exists.\n' +
+            '• create → add a new label to an AxLabelFile, write into every language .label.txt, create XML descriptors if missing (write). Label IDs describe MEANING — never add a model prefix. Target the model\'s ORIGINAL label file, never a label file extension (…_Extension…). Fails if the label already exists. For many labels at once pass labels:[{labelId, translations}, …] with the shared labelFileId/model at the top level — they are created in one call and reported together.\n' +
             '• update → overwrite the text of an EXISTING label (e.g. fix a wrong/duplicate translation in cs/de). Same args as create; provide the corrected translations[] (write).\n' +
             '• rename → rename a label ID across .label.txt + X++ + XML metadata + SQLite index. Use dryRun=true first (write).',
           inputSchema: {
@@ -1085,9 +1085,35 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                 description: '[info] Exact label ID. Omit for action=info to list available label files for the model.',
               },
               // ── action=create ──────────────────────────────────────────────
+              labels: {
+                type: 'array',
+                description:
+                  '[create] OPTIONAL bulk mode — create several labels in one call. Each entry is { labelId, translations[], description?, defaultComment? }. ' +
+                  'Shared fields (labelFileId, model, languages, paths…) stay at the top level. When present, top-level labelId/translations are ignored. ' +
+                  'Each label is created via the normal single-label path and results are aggregated into one report (a failed entry does not abort the batch).',
+                items: {
+                  type: 'object',
+                  properties: {
+                    labelId: { type: 'string', description: 'Label ID for this entry — alphanumeric, no model prefix.' },
+                    translations: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          language: { type: 'string', description: 'Locale code, e.g. en-US, cs, de, sk' },
+                          text: { type: 'string', description: 'Label text' },
+                          comment: { type: 'string', description: 'Developer comment (optional)' },
+                        },
+                        required: ['language', 'text'],
+                      },
+                    },
+                  },
+                  required: ['labelId', 'translations'],
+                },
+              },
               translations: {
                 type: 'array',
-                description: '[create] REQUIRED. Translations for each language. Provide at least en-US.',
+                description: '[create] REQUIRED for single-label create (omit when using labels[]). Translations for each language. Provide at least en-US.',
                 items: {
                   type: 'object',
                   properties: {

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -279,9 +279,88 @@ function normalizeCreateLabelArgs(raw: unknown): Record<string, unknown> {
   return args;
 }
 
+// ── Bulk fan-out ──────────────────────────────────────────────────────────────
+
+/**
+ * Pull a `labels: [...]` array off the raw args, if present and non-empty.
+ * Bulk callers pass shared fields (labelFileId, model, paths…) at the top level
+ * and one entry per label ({ labelId, translations, … }). Returns null for the
+ * ordinary single-label shape so the normal path runs unchanged.
+ */
+export function extractBulkLabels(raw: unknown): Array<Record<string, unknown>> | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const arr = (raw as Record<string, unknown>).labels;
+  if (!Array.isArray(arr) || arr.length === 0) return null;
+  return arr.filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object');
+}
+
+/** The single-label create signature, injectable so the fan-out is testable. */
+export type SingleLabelRunner = (
+  request: CallToolRequest,
+  context: XppServerContext,
+) => Promise<any>;
+
+/**
+ * Create many labels in one call. Each entry is merged over the shared top-level
+ * fields and routed through the single-label path (which keeps validation, file
+ * creation and indexing identical), then results are aggregated into one report.
+ * Continues past per-label failures so one bad entry doesn't abort the batch.
+ */
+export async function createLabelsBulk(
+  entries: Array<Record<string, unknown>>,
+  raw: Record<string, unknown>,
+  context: XppServerContext,
+  runSingle: SingleLabelRunner = createLabelTool,
+): Promise<{ content: Array<{ type: 'text'; text: string }>; isError: boolean }> {
+  // Shared fields = everything except the per-entry array and any top-level
+  // labelId/translations (each entry owns those).
+  const shared: Record<string, unknown> = { ...raw };
+  delete shared.labels;
+  delete shared.labelId;
+  delete shared.translations;
+
+  const lines: string[] = [];
+  let created = 0;
+  let failed = 0;
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const mergedArgs = { ...shared, ...entry };
+    const labelId = typeof entry.labelId === 'string' ? entry.labelId : `(entry ${i + 1})`;
+    const subRequest: CallToolRequest = {
+      method: 'tools/call',
+      params: { name: 'create_label', arguments: mergedArgs },
+    };
+    // Recurses into the single-label path: mergedArgs carries no `labels` array,
+    // so extractBulkLabels returns null and the normal handler runs.
+    const res = await runSingle(subRequest, context);
+    const text = res?.content?.[0]?.text ?? '(no output)';
+    if (res?.isError) {
+      failed++;
+      lines.push(`🔴 ${labelId}: ${text.split('\n')[0]}`);
+    } else {
+      created++;
+      lines.push(`🟢 ${labelId}: ${text.split('\n')[0]}`);
+    }
+  }
+
+  const header =
+    `${failed === 0 ? '✅' : '⚠️'} labels(action="create", labels=[…]): ` +
+    `${created} created, ${failed} failed (of ${entries.length}).`;
+  return {
+    content: [{ type: 'text', text: [header, '', ...lines].join('\n') }],
+    isError: failed > 0,
+  };
+}
+
 // ── Tool implementation ───────────────────────────────────────────────────────
 
 export async function createLabelTool(request: CallToolRequest, context: XppServerContext) {
+  // Bulk shape: a `labels` array fans out to one single-label create per entry.
+  const bulk = extractBulkLabels(request.params.arguments);
+  if (bulk) {
+    return createLabelsBulk(bulk, request.params.arguments as Record<string, unknown>, context);
+  }
   try {
     const parsed = CreateLabelArgsSchema.safeParse(
       normalizeCreateLabelArgs(request.params.arguments),

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -107,6 +107,37 @@ export const generateSmartFormTool: Tool = {
   },
 };
 
+/**
+ * Pre-write check for cloneFrom: cloning copies the reference form's control
+ * hierarchy and sub-patterns verbatim. If the caller asked for a different
+ * pattern than the reference declares, the result will likely violate the
+ * requested pattern (e.g. SimpleListDetails forbids a Tab the source carried)
+ * and be rejected by the form-pattern validator. Returns a warning line when the
+ * cloned form's declared <Pattern> differs from the requested pattern, or null
+ * when they match / either can't be determined.
+ */
+export function cloneFromPatternMismatchWarning(
+  requestedPattern: string | undefined,
+  clonedXml: string,
+  sourceFormName: string,
+): string | null {
+  if (!requestedPattern) return null;
+  const intended = resolvePattern(requestedPattern);
+  const clonedPattern = clonedXml.match(/<Pattern xmlns="">([^<]+)<\/Pattern>/)?.[1];
+  if (!intended || !clonedPattern) return null;
+  if (intended.xmlName.toLowerCase() === clonedPattern.toLowerCase()) return null;
+
+  const ref = intended.referenceForms?.[0];
+  return (
+    `🛑 PATTERN MISMATCH — you requested "${intended.xmlName}" but "${sourceFormName}" is a "${clonedPattern}" form. ` +
+    `Cloning copies that structure verbatim, so the result may violate "${intended.xmlName}" ` +
+    `(controls/sub-patterns the target pattern disallows) and be rejected by the form-pattern validator.` +
+    (ref
+      ? ` Clone a "${intended.xmlName}" reference instead, e.g. cloneFrom="${ref}".`
+      : ` Clone a reference form that already uses "${intended.xmlName}".`)
+  );
+}
+
 export async function handleGenerateSmartForm(
   args: GenerateSmartFormArgs,
   symbolIndex: XppSymbolIndex
@@ -408,6 +439,9 @@ export async function handleGenerateSmartForm(
         ? `   QuickFilter default column repointed: ${rq.from} → ${rq.to}`
         : `   ⚠️ QuickFilter default column "${rq.from}" was removed and no surviving column was found — set defaultColumnName manually`);
     }
+    // Pattern-compatibility pre-check (see cloneFromPatternMismatchWarning).
+    const mismatch = cloneFromPatternMismatchWarning(formPattern, xml, cloneResult.sourceFormName);
+    if (mismatch) noteLines.push(`   ${mismatch}`);
     cloneNotes = `\n${noteLines.join('\n')}`;
   } else {
     xml = FormPatternTemplates.build(normalizedPattern, {

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -1053,6 +1053,27 @@ export function isInfrastructureField(fieldName: string): boolean {
   return INFRA.has(fieldName.toLowerCase());
 }
 
+/**
+ * Single common field words that, on their own, don't pin down a domain EDT.
+ * A fuzzy EDT that merely prepends a domain prefix to one of these
+ * (e.g. "Status" → "CovStatus", "Type" → "LedgerPostingType") scores high on
+ * containment but is the wrong concept, so for these names we accept only an
+ * exact EDT match and otherwise fall through to the name heuristic / string
+ * default. Multi-word field names like "RentEquipmentId" are specific enough
+ * that a prefixed EDT ("ContosoRentEquipmentId") is a genuinely good match.
+ */
+const GENERIC_FIELD_WORDS = new Set([
+  'status', 'type', 'category', 'group', 'code', 'class', 'state', 'kind',
+  'level', 'priority', 'value', 'key', 'order', 'sequence', 'version',
+  'mode', 'role', 'reason', 'method', 'action', 'source', 'target', 'color',
+  'size', 'unit', 'parent', 'child', 'owner', 'number', 'line',
+]);
+
+/** True when a field name is a single generic word (see GENERIC_FIELD_WORDS). */
+function isGenericFieldWord(fieldName: string): boolean {
+  return GENERIC_FIELD_WORDS.has(fieldName.toLowerCase());
+}
+
 /** Confidence (0–1) that an EDT name matches a field name, by containment. */
 function edtNameConfidence(field: string, edt: string): number {
   const f = field.toLowerCase();
@@ -1075,6 +1096,11 @@ export function resolveBestEdt(fieldName: string, db: any): string {
     ).get(fieldName) as { edt_name: string } | undefined;
     if (exact) return exact.edt_name;
 
+    // Generic single-word fields don't accept fuzzy matches — a prefixed EDT
+    // (CovStatus for "Status") is a different concept. Only their exact match
+    // above counts; otherwise fall through to the heuristic / string default.
+    const acceptFuzzy = !isGenericFieldWord(fieldName);
+
     const candidates = db.prepare(
       `SELECT edt_name FROM edt_metadata WHERE edt_name LIKE ? COLLATE NOCASE ORDER BY LENGTH(edt_name) ASC LIMIT 30`
     ).all(`%${fieldName}%`) as Array<{ edt_name: string }>;
@@ -1084,12 +1110,12 @@ export function resolveBestEdt(fieldName: string, db: any): string {
       const conf = edtNameConfidence(fieldName, c.edt_name);
       if (conf > bestConf) { bestConf = conf; best = c.edt_name; }
     }
-    if (best && bestConf >= 0.8) return best;
+    if (acceptFuzzy && best && bestConf >= 0.8) return best;
 
     const heuristic = suggestEdtFromFieldName(fieldName);
     if (validateEdtExists(heuristic, db)) return heuristic;
 
-    if (best && bestConf >= 0.6) return best;
+    if (acceptFuzzy && best && bestConf >= 0.6) return best;
   } catch {
     /* DB unavailable — fall back to the pure heuristic below */
   }

--- a/tests/tools/clonePatternMismatch.test.ts
+++ b/tests/tools/clonePatternMismatch.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { cloneFromPatternMismatchWarning } from '../../src/tools/generateSmartForm';
+
+/** Minimal AxForm shell carrying a Design-level <Pattern>. */
+function formXmlWithPattern(pattern: string): string {
+  return `<?xml version="1.0"?><AxForm><Design><Pattern xmlns="">${pattern}</Pattern></Design></AxForm>`;
+}
+
+describe('cloneFromPatternMismatchWarning', () => {
+  it('warns when the cloned reference declares a different pattern than requested', () => {
+    const warn = cloneFromPatternMismatchWarning(
+      'SimpleListDetails',
+      formXmlWithPattern('SimpleList'),
+      'CustGroup',
+    );
+    expect(warn).not.toBeNull();
+    expect(warn).toContain('PATTERN MISMATCH');
+    expect(warn).toContain('SimpleListDetails');
+    expect(warn).toContain('SimpleList');
+    expect(warn).toContain('CustGroup');
+    // Points the caller at a same-pattern reference form to clone instead.
+    expect(warn).toMatch(/cloneFrom="\w+"/);
+  });
+
+  it('returns null when the cloned pattern matches the requested one', () => {
+    expect(
+      cloneFromPatternMismatchWarning(
+        'SimpleListDetails',
+        formXmlWithPattern('SimpleListDetails'),
+        'ProjCategory',
+      ),
+    ).toBeNull();
+  });
+
+  it('is case-insensitive on the pattern name', () => {
+    expect(
+      cloneFromPatternMismatchWarning('simplelist', formXmlWithPattern('SimpleList'), 'CustGroup'),
+    ).toBeNull();
+  });
+
+  it('returns null when no pattern was requested', () => {
+    expect(
+      cloneFromPatternMismatchWarning(undefined, formXmlWithPattern('SimpleList'), 'CustGroup'),
+    ).toBeNull();
+  });
+
+  it('returns null when the cloned XML carries no Design pattern', () => {
+    expect(
+      cloneFromPatternMismatchWarning('SimpleListDetails', '<AxForm><Design/></AxForm>', 'X'),
+    ).toBeNull();
+  });
+});

--- a/tests/tools/createLabel-bulk.test.ts
+++ b/tests/tools/createLabel-bulk.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import {
+  extractBulkLabels,
+  createLabelsBulk,
+  type SingleLabelRunner,
+} from '../../src/tools/createLabel';
+
+describe('extractBulkLabels', () => {
+  it('returns the entries for the bulk shape', () => {
+    const entries = extractBulkLabels({ labels: [{ labelId: 'A' }, { labelId: 'B' }] });
+    expect(entries).toHaveLength(2);
+  });
+
+  it('returns null for the single-label shape', () => {
+    expect(extractBulkLabels({ labelId: 'A', translations: [] })).toBeNull();
+  });
+
+  it('returns null for an empty array and drops non-object entries', () => {
+    expect(extractBulkLabels({ labels: [] })).toBeNull();
+    expect(extractBulkLabels({ labels: [{ labelId: 'A' }, null, 'x'] })).toHaveLength(1);
+  });
+});
+
+describe('createLabelsBulk fan-out', () => {
+  /** Capture what each single-label call received and return a canned result. */
+  function recordingRunner(failOn: Set<string> = new Set()): {
+    runner: SingleLabelRunner;
+    calls: Array<Record<string, unknown>>;
+  } {
+    const calls: Array<Record<string, unknown>> = [];
+    const runner: SingleLabelRunner = async (req: CallToolRequest) => {
+      const args = req.params.arguments as Record<string, unknown>;
+      calls.push(args);
+      const id = String(args.labelId);
+      return failOn.has(id)
+        ? { content: [{ type: 'text', text: `❌ ${id} already exists` }], isError: true }
+        : { content: [{ type: 'text', text: `✅ created ${id}` }], isError: false };
+    };
+    return { runner, calls };
+  }
+
+  it('merges shared top-level fields into every entry and routes one call each', async () => {
+    const { runner, calls } = recordingRunner();
+    const raw = {
+      labelFileId: 'ContosoExt',
+      model: 'ContosoExt',
+      languages: ['en-US'],
+      labels: [
+        { labelId: 'EquipmentName', translations: [{ language: 'en-US', text: 'Equipment name' }] },
+        { labelId: 'DailyRate', translations: [{ language: 'en-US', text: 'Daily rate' }] },
+      ],
+    };
+
+    const res = await createLabelsBulk(extractBulkLabels(raw)!, raw, {} as any, runner);
+
+    expect(calls).toHaveLength(2);
+    // Shared fields propagate; the per-entry array itself does not leak through.
+    expect(calls[0]).toMatchObject({ labelFileId: 'ContosoExt', model: 'ContosoExt', labelId: 'EquipmentName' });
+    expect(calls[0].labels).toBeUndefined();
+    expect(calls[1]).toMatchObject({ labelId: 'DailyRate', languages: ['en-US'] });
+    expect(res.isError).toBe(false);
+    expect(res.content[0].text).toContain('2 created, 0 failed');
+  });
+
+  it('continues past a failed entry and reports it as an error overall', async () => {
+    const { runner } = recordingRunner(new Set(['DupId']));
+    const raw = {
+      labelFileId: 'ContosoExt',
+      labels: [
+        { labelId: 'GoodId', translations: [{ language: 'en-US', text: 'ok' }] },
+        { labelId: 'DupId', translations: [{ language: 'en-US', text: 'dup' }] },
+        { labelId: 'AlsoGood', translations: [{ language: 'en-US', text: 'ok2' }] },
+      ],
+    };
+
+    const res = await createLabelsBulk(extractBulkLabels(raw)!, raw, {} as any, runner);
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('2 created, 1 failed');
+    expect(res.content[0].text).toContain('🔴 DupId');
+    expect(res.content[0].text).toContain('🟢 AlsoGood');
+  });
+
+  it('lets a per-entry field override a shared default', async () => {
+    const { runner, calls } = recordingRunner();
+    const raw = {
+      labelFileId: 'ContosoExt',
+      description: 'shared desc',
+      labels: [{ labelId: 'A', translations: [], description: 'per-entry desc' }],
+    };
+
+    await createLabelsBulk(extractBulkLabels(raw)!, raw, {} as any, runner);
+    expect(calls[0].description).toBe('per-entry desc');
+  });
+});

--- a/tests/tools/edt-resolution.test.ts
+++ b/tests/tools/edt-resolution.test.ts
@@ -72,6 +72,27 @@ describe('resolveBestEdt (DB-aware)', () => {
     const db = fakeDb([]);
     expect(resolveBestEdt('Category', db)).toBe('String255');
   });
+
+  it('does NOT grab a domain-prefixed EDT for a generic field word', () => {
+    // "CovStatus" contains "Status" (conf ≥ 0.8) but is an unrelated concept —
+    // a generic "Status" field must not inherit it. Regression for the fuzzy
+    // containment edge that real (noisy) indexes hit but minimal fakes missed.
+    expect(resolveBestEdt('Status', fakeDb(['CovStatus']))).toBe('String255');
+    expect(resolveBestEdt('Type', fakeDb(['LedgerPostingType']))).toBe('String255');
+    expect(resolveBestEdt('Group', fakeDb(['CustGroupId', 'VendGroup']))).toBe('String255');
+  });
+
+  it('still prefers a prefixed EDT for a SPECIFIC multi-word field', () => {
+    // The generic-word guard must not regress the model-prefixed match: a
+    // specific field is unambiguous enough that a prefixed EDT is correct.
+    expect(resolveBestEdt('RentEquipmentId', fakeDb(['ContosoRentEquipmentId', 'CovStatus'])))
+      .toBe('ContosoRentEquipmentId');
+  });
+
+  it('still returns an exact EDT match for a generic word when one exists', () => {
+    // The guard only blocks FUZZY matches; an exact same-name EDT is honored.
+    expect(resolveBestEdt('Category', fakeDb(['Category', 'ProjCategoryId']))).toBe('Category');
+  });
 });
 
 describe('isInfrastructureField', () => {


### PR DESCRIPTION
… guard

Three root-cause fixes in the MCP server surface that produced first-pass failures during scaffolding:

- labels(create): accept a bulk `labels:[{labelId, translations}, …]` array with shared top-level fields. Each entry fans out through the normal single-label path (validation/write/index unchanged) and results aggregate into one report; a failed entry no longer aborts the batch.

- generate_smart_form(cloneFrom): pre-write PATTERN MISMATCH warning when the cloned reference declares a different pattern than the requested formPattern, so callers aren't surprised by FP00x from the post-write validator (e.g. SimpleListDetails cloned from a Tab-carrying source). Extracted as a pure, tested cloneFromPatternMismatchWarning().

- resolveBestEdt: generic single-word fields (Status, Type, Category, …) no longer grab a domain-prefixed fuzzy EDT (Status→CovStatus). They accept only an exact match and otherwise fall through to the heuristic / String default. Regression-tested against a realistic noisy EDT index.

Tests: +15 across edt-resolution, createLabel-bulk, clonePatternMismatch. tsc clean; 640 tools/validation/golden tests pass.