### PR TITLE
feat(forms): type-aware controls, lines datasource, and start pattern…

### DIFF
--- a/bridge/D365MetadataBridge/Program.cs
+++ b/bridge/D365MetadataBridge/Program.cs
@@ -190,6 +190,16 @@ namespace D365MetadataBridge
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Services.CrossReferenceService? InitCrossReferenceService()
         {
+            // Cross-references require the DYNAMICSXREFDB SQL database. This is an
+            // OPTIONAL capability — metadata read/write works fully without it. When
+            // no xref database is configured, skip silently instead of attempting a
+            // doomed SQL connection that otherwise logs an alarming [WARN] on every
+            // startup (the TS side forwards [WARN]/[ERROR] to the MCP client).
+            if (string.IsNullOrWhiteSpace(_xrefDatabase))
+            {
+                Log.WriteLine("[INFO] Cross-reference DB not configured — xref features disabled (metadata operations unaffected)");
+                return null;
+            }
             try
             {
                 Log.WriteLine($"[INFO] Initializing CrossReferenceProvider: {_xrefServer}\\{_xrefDatabase}");
@@ -199,7 +209,10 @@ namespace D365MetadataBridge
             }
             catch (Exception ex)
             {
-                Log.WriteLine($"[WARN] Failed to initialize CrossReferenceProvider: {ex.Message}");
+                // Optional capability — a SQL connection failure is not a server error.
+                // Log at [INFO] so it is not surfaced as a client-facing warning; the
+                // ready payload already reports xrefAvailable=false for callers that care.
+                Log.WriteLine($"[INFO] Cross-reference DB unavailable — xref features disabled ({ex.Message})");
                 return null;
             }
         }

--- a/bridge/D365MetadataBridge/Protocol/BridgeProtocol.cs
+++ b/bridge/D365MetadataBridge/Protocol/BridgeProtocol.cs
@@ -94,7 +94,23 @@ namespace D365MetadataBridge.Protocol
             var dict = new Dictionary<string, string>();
             foreach (var kv in prop.EnumerateObject())
             {
-                dict[kv.Name] = kv.Value.GetString() ?? kv.Value.GetRawText();
+                // GetString() THROWS on any kind other than String/Null — it does not
+                // return null for booleans/numbers/arrays. The old `GetString() ?? …`
+                // therefore crashed the whole request with "requires an element of type
+                // 'String', but the target element has type 'True'/'Array'" whenever a
+                // caller put a non-string value in the map. Coerce by kind instead.
+                switch (kv.Value.ValueKind)
+                {
+                    case JsonValueKind.String:
+                        dict[kv.Name] = kv.Value.GetString() ?? string.Empty;
+                        break;
+                    case JsonValueKind.Null:
+                        break; // omit null-valued properties
+                    default:
+                        // bool/number/array/object → raw JSON token ("true", "42", "[…]")
+                        dict[kv.Name] = kv.Value.GetRawText();
+                        break;
+                }
             }
             return dict;
         }

--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -809,11 +809,27 @@ namespace D365MetadataBridge.Protocol
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"[ERROR] {request.Method}: {ex.Message}\n{ex.StackTrace}");
+                // createObject / createSmartTable always have a TS-side XML-generation
+                // fallback, so a failure here is a recoverable fast-path miss, not a
+                // server error. Log it at [INFO] (the TS side does not forward [INFO]
+                // to the MCP client) so it doesn't surface as an alarming warning. The
+                // error response is still returned so the caller falls back to XML.
+                if (IsRecoverableWrite(request.Method))
+                    Console.Error.WriteLine($"[INFO] {request.Method} failed (recoverable — caller falls back to XML generation): {ex.Message}");
+                else
+                    Console.Error.WriteLine($"[ERROR] {request.Method}: {ex.Message}\n{ex.StackTrace}");
                 return Task.FromResult(
                     BridgeResponse.CreateError(request.Id, -32603, $"Error in {request.Method}: {ex.Message}"));
             }
         }
+
+        /// <summary>
+        /// Write methods that have a guaranteed caller-side fallback (TS XML generation),
+        /// so a bridge failure is recoverable and should not be logged as a hard error.
+        /// </summary>
+        private static bool IsRecoverableWrite(string method) =>
+            string.Equals(method, "createObject", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(method, "createSmartTable", StringComparison.OrdinalIgnoreCase);
 
         private Task<BridgeResponse> HandleXref(BridgeRequest request, Func<object?> handler)
         {

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -45,7 +45,7 @@ namespace D365MetadataBridge.Services
             _referencePackagesPath = referencePackagesPath;
             // Use DiskProvider (standalone mode) — avoids .NET Framework EventDescriptor dependency
             var factory = new MetadataProviderFactory();
-            _provider = factory.CreateDiskProvider(packagesPath);
+            _provider = CreatePrimaryProvider(factory, packagesPath, referencePackagesPath);
             Console.Error.WriteLine($"[MetadataService] Initialized via DiskProvider: {packagesPath}");
 
             if (referencePackagesPath != null)
@@ -60,6 +60,42 @@ namespace D365MetadataBridge.Services
                     Console.Error.WriteLine($"[WARN] Failed to initialize reference DiskProvider at '{referencePackagesPath}': {ex.Message}");
                 }
             }
+        }
+
+        /// <summary>
+        /// Builds the primary DiskProvider. When a reference (standard/Microsoft) packages
+        /// path is configured, the provider spans BOTH roots so that WRITE operations can
+        /// resolve a STANDARD base object — e.g. creating an extension of a standard enum.
+        /// A single-root provider over only the custom path cannot, which made
+        /// createObject(enum-extension of a standard base) throw "The given key was not
+        /// present in the dictionary".
+        ///
+        /// Defensive: if the multi-root configuration is unavailable on this platform the
+        /// method falls back to the single-path provider, so the working read path is never
+        /// regressed (worst case = prior behaviour).
+        /// </summary>
+        private static IMetadataProvider CreatePrimaryProvider(MetadataProviderFactory factory, string primaryPath, string? referencePath)
+        {
+            if (!string.IsNullOrEmpty(referencePath) && System.IO.Directory.Exists(referencePath))
+            {
+                try
+                {
+                    var config = new Microsoft.Dynamics.AX.Metadata.Storage.DiskProvider.DiskProviderConfiguration
+                    {
+                        MetadataPath = primaryPath,
+                        IncludeStatic = true,
+                    };
+                    config.AddMetadataPath(referencePath!);
+                    var combined = factory.CreateDiskProvider(config);
+                    Console.Error.WriteLine($"[MetadataService] DiskProvider spans 2 roots (writes can resolve standard bases): {primaryPath} + {referencePath}");
+                    return combined;
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"[WARN] Combined DiskProvider failed ({ex.Message}) — using single-path provider: {primaryPath}");
+                }
+            }
+            return factory.CreateDiskProvider(primaryPath);
         }
 
         /// <summary>
@@ -89,7 +125,7 @@ namespace D365MetadataBridge.Services
         {
             var sw = System.Diagnostics.Stopwatch.StartNew();
             var factory = new MetadataProviderFactory();
-            _provider = factory.CreateDiskProvider(_packagesPath);
+            _provider = CreatePrimaryProvider(factory, _packagesPath, _referencePackagesPath);
             OnProviderRefreshed?.Invoke(_provider);
             sw.Stop();
             Console.Error.WriteLine($"[MetadataService] Provider refreshed in {sw.ElapsedMilliseconds}ms");
@@ -139,12 +175,46 @@ namespace D365MetadataBridge.Services
                         if (!_provider.Queries.Exists(objectName)) return new { valid = false, reason = $"Query '{objectName}' not found by IMetadataProvider after refresh" };
                         return new { valid = true, objectType, objectName };
 
+                    case "view":
+                        if (!_provider.Views.Exists(objectName)) return new { valid = false, reason = $"View '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
                     case "report":
                         if (!_provider.Reports.Exists(objectName)) return new { valid = false, reason = $"Report '{objectName}' not found by IMetadataProvider after refresh" };
                         return new { valid = true, objectType, objectName };
 
+                    case "menu":
+                        if (!_provider.Menus.Exists(objectName)) return new { valid = false, reason = $"Menu '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
+                    case "menu-item-display":
+                        if (!_provider.MenuItemDisplays.Exists(objectName)) return new { valid = false, reason = $"MenuItemDisplay '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
+                    case "menu-item-action":
+                        if (!_provider.MenuItemActions.Exists(objectName)) return new { valid = false, reason = $"MenuItemAction '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
+                    case "menu-item-output":
+                        if (!_provider.MenuItemOutputs.Exists(objectName)) return new { valid = false, reason = $"MenuItemOutput '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
+                    case "security-privilege":
+                        if (!_provider.SecurityPrivileges.Exists(objectName)) return new { valid = false, reason = $"SecurityPrivilege '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
+                    case "security-duty":
+                        if (!_provider.SecurityDuties.Exists(objectName)) return new { valid = false, reason = $"SecurityDuty '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
+                    case "security-role":
+                        if (!_provider.SecurityRoles.Exists(objectName)) return new { valid = false, reason = $"SecurityRole '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
                     default:
-                        return new { valid = false, reason = $"Unsupported objectType for validation: {objectType}" };
+                        // Types the bridge can't read back yet (label, resource, tile, kpi, …):
+                        // not an error — the file was already written. Caller logs this at debug.
+                        return new { valid = false, reason = $"validation-unsupported: {objectType}" };
                 }
             }
             catch (Exception ex)

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -106,10 +106,15 @@ namespace D365MetadataBridge.Services
                     return null;
                 }
 
+                // Name is REQUIRED for Create: the SDK routes a brand-new object to its
+                // model folder via ModelSaveInfo.Name. Leaving it null is why createObject
+                // threw NullReferenceException while modify (Update) — which already knows
+                // the existing object's location — worked fine.
                 return new ModelSaveInfo
                 {
                     Id = id,
-                    Layer = layer
+                    Layer = layer,
+                    Name = targetModelName
                 };
             }
             catch (Exception ex)
@@ -622,7 +627,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         public object CreateQuery(string name, string modelName, Dictionary<string, string>? properties)
         {
-            var msi = ResolveModelSaveInfo(modelName);
+            var msi = ResolveModelSaveInfo(modelName)
+                ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
 
             // AxQuery is abstract. Use reflection to try AxQuerySimple first.
             // If that fails, fall back by creating a dynamic instance.
@@ -668,7 +674,8 @@ namespace D365MetadataBridge.Services
             List<WriteFieldParam>? fields,
             Dictionary<string, string>? properties)
         {
-            var msi = ResolveModelSaveInfo(modelName);
+            var msi = ResolveModelSaveInfo(modelName)
+                ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axView = new AxView { Name = name };
 
             if (properties != null)
@@ -697,7 +704,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         public object CreateMenuItemAction(string name, string modelName, Dictionary<string, string>? properties)
         {
-            var msi = ResolveModelSaveInfo(modelName);
+            var msi = ResolveModelSaveInfo(modelName)
+                ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axMI = new AxMenuItemAction { Name = name };
 
             if (properties != null)
@@ -719,7 +727,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         public object CreateMenuItemDisplay(string name, string modelName, Dictionary<string, string>? properties)
         {
-            var msi = ResolveModelSaveInfo(modelName);
+            var msi = ResolveModelSaveInfo(modelName)
+                ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axMI = new AxMenuItemDisplay { Name = name };
 
             if (properties != null)
@@ -741,7 +750,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         public object CreateMenuItemOutput(string name, string modelName, Dictionary<string, string>? properties)
         {
-            var msi = ResolveModelSaveInfo(modelName);
+            var msi = ResolveModelSaveInfo(modelName)
+                ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axMI = new AxMenuItemOutput { Name = name };
 
             if (properties != null)
@@ -763,7 +773,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         public object CreateSecurityPrivilege(string name, string modelName, Dictionary<string, string>? properties)
         {
-            var msi = ResolveModelSaveInfo(modelName);
+            var msi = ResolveModelSaveInfo(modelName)
+                ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axObj = new AxSecurityPrivilege { Name = name };
 
             if (properties != null)
@@ -785,7 +796,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         public object CreateSecurityDuty(string name, string modelName, Dictionary<string, string>? properties)
         {
-            var msi = ResolveModelSaveInfo(modelName);
+            var msi = ResolveModelSaveInfo(modelName)
+                ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axObj = new AxSecurityDuty { Name = name };
 
             if (properties != null)
@@ -807,7 +819,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         public object CreateSecurityRole(string name, string modelName, Dictionary<string, string>? properties)
         {
-            var msi = ResolveModelSaveInfo(modelName);
+            var msi = ResolveModelSaveInfo(modelName)
+                ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axObj = new AxSecurityRole { Name = name };
 
             if (properties != null)
@@ -1060,6 +1073,28 @@ namespace D365MetadataBridge.Services
         /// Adds or replaces a method on a class or table.
         /// Read → add/replace method → Update.
         /// </summary>
+        /// <summary>Finds a form data source by name (case-insensitive); null if absent.</summary>
+        private static object? FindFormDataSource(dynamic axForm, string dsName)
+        {
+            foreach (var ds in axForm.DataSources)
+            {
+                if (string.Equals((string)((dynamic)ds).Name, dsName, StringComparison.OrdinalIgnoreCase))
+                    return (object)ds;
+            }
+            return null;
+        }
+
+        /// <summary>Finds a field on a form data source by name (case-insensitive); null if absent.</summary>
+        private static object? FindDsField(dynamic dataSource, string fieldName)
+        {
+            foreach (var f in dataSource.Fields)
+            {
+                if (string.Equals((string)((dynamic)f).Name, fieldName, StringComparison.OrdinalIgnoreCase))
+                    return (object)f;
+            }
+            return null;
+        }
+
         public object AddMethod(string objectType, string objectName, string methodName, string source)
         {
             switch (objectType.ToLowerInvariant())
@@ -1106,6 +1141,39 @@ namespace D365MetadataBridge.Services
                     var axForm = _provider.Forms.Read(objectName)
                         ?? throw new ArgumentException($"Form '{objectName}' not found");
                     var msi = GetModelSaveInfoForObject(_provider.Forms, objectName);
+                    var formProvider = _provider.Forms as IMetaFormProvider
+                        ?? throw new InvalidOperationException("IMetaFormProvider not available");
+
+                    // Route a dotted methodName to a data-source (or data-source-field)
+                    // override when the first segment is an actual data source on the form:
+                    //   "DataSource.method"       → override on the form data source
+                    //   "DataSource.Field.method" → override on a data-source field
+                    // Without this the method is added as a FORM-CLASS method, where e.g.
+                    // a data source initValue()'s super() binds to FormRun.initValue and fails
+                    // to compile. Control overrides ("Button.clicked" — first segment is NOT a
+                    // data source) fall through to the form-class path below unchanged.
+                    var dotParts = methodName.Split('.');
+                    if (dotParts.Length is 2 or 3)
+                    {
+                        dynamic? ds = FindFormDataSource(axForm, dotParts[0]);
+                        if (ds != null)
+                        {
+                            var leaf = dotParts[dotParts.Length - 1];
+                            var dsMethod = new AxMethod { Name = leaf, Source = source };
+                            if (dotParts.Length == 2)
+                            {
+                                ds.AddMethod(dsMethod);
+                            }
+                            else
+                            {
+                                dynamic field = FindDsField(ds, dotParts[1])
+                                    ?? throw new ArgumentException($"Field '{dotParts[1]}' not found on data source '{dotParts[0]}' of form '{objectName}'");
+                                field.AddMethod(dsMethod);
+                            }
+                            formProvider.Update(axForm, msi);
+                            return new { success = true, operation = "add-method", objectType, objectName, methodName, api = "IMetaFormProvider.Update (data source override)" };
+                        }
+                    }
 
                     if (!TryUpdateMethodSourceInPlace(axForm, methodName, source))
                     {
@@ -1113,8 +1181,6 @@ namespace D365MetadataBridge.Services
                         axForm.AddMethod(axMethod);
                     }
 
-                    var formProvider = _provider.Forms as IMetaFormProvider
-                        ?? throw new InvalidOperationException("IMetaFormProvider not available");
                     formProvider.Update(axForm, msi);
 
                     return new { success = true, operation = "add-method", objectType, objectName, methodName, api = "IMetaFormProvider.Update" };
@@ -2123,58 +2189,39 @@ namespace D365MetadataBridge.Services
                 ?? throw new ArgumentException($"Menu '{menuName}' not found");
             var msi = GetModelSaveInfoForObject(_provider.Menus, menuName);
 
-            // Use dynamic dispatch — AxMenu.MenuItems hierarchy varies by SDK version.
-            // Menu element items are NOT the standalone AxMenuItemDisplay/Action/Output types;
-            // they are AxMenuElementMenuItem* types (or similar).
-            dynamic dynMenu = axMenu;
-
             var itemType = (menuItemType ?? "display").ToLowerInvariant();
-            var assembly = typeof(AxClass).Assembly;
 
-            // Discover the correct element type for menu item references
-            string[] candidateTypeNames = itemType switch
+            // Idempotency: menu Elements is a KeyedObjectCollection keyed by Name. Adding a
+            // duplicate fails inside the SDK and surfaces as an opaque NullReferenceException,
+            // so skip when the item is already on the menu (it is then already correct).
+            if (axMenu.Elements != null)
             {
-                "display" => new[] {
-                    "Microsoft.Dynamics.AX.Metadata.MetaModel.AxMenuElementMenuItemDisplay",
-                    "Microsoft.Dynamics.AX.Metadata.MetaModel.AxMenuItemDisplayReference" },
-                "action" => new[] {
-                    "Microsoft.Dynamics.AX.Metadata.MetaModel.AxMenuElementMenuItemAction",
-                    "Microsoft.Dynamics.AX.Metadata.MetaModel.AxMenuItemActionReference" },
-                "output" => new[] {
-                    "Microsoft.Dynamics.AX.Metadata.MetaModel.AxMenuElementMenuItemOutput",
-                    "Microsoft.Dynamics.AX.Metadata.MetaModel.AxMenuItemOutputReference" },
-                _ => throw new ArgumentException($"Unsupported menu item type: '{menuItemType}'. Use 'display', 'action', or 'output'."),
-            };
-
-            Type? elementType = null;
-            foreach (var name in candidateTypeNames)
-            {
-                elementType = assembly.GetType(name);
-                if (elementType != null) break;
-            }
-
-            // Last resort: iterate MenuItems to find element base type, then find subclass for our item type
-            if (elementType == null)
-            {
-                // Try to get the collection's generic argument as the base type
-                dynamic menuItems = dynMenu.MenuItems;
-                var collType = ((object)menuItems).GetType();
-                if (collType.IsGenericType)
+                foreach (var existing in axMenu.Elements)
                 {
-                    var baseElemType = collType.GetGenericArguments()[0];
-                    // Find a subclass whose name contains "display"/"action"/"output"
-                    elementType = assembly.GetTypes()
-                        .FirstOrDefault(t => baseElemType.IsAssignableFrom(t) && !t.IsAbstract
-                            && t.Name.IndexOf(itemType, StringComparison.OrdinalIgnoreCase) >= 0);
+                    if (string.Equals((string)((dynamic)existing).Name, menuItemName, StringComparison.OrdinalIgnoreCase))
+                        return new { success = true, operation = "add-menu-item-to-menu", objectName = menuName, menuItemName, menuItemType = itemType, skipped = true, reason = $"menu item '{menuItemName}' already on menu '{menuName}'", api = "IMetaMenuProvider.Update" };
                 }
             }
 
-            if (elementType == null)
-                throw new InvalidOperationException($"Cannot determine menu element type for '{itemType}' — use xmlContent fallback");
-
-            dynamic menuItem = Activator.CreateInstance(elementType)!;
-            menuItem.Name = menuItemName;
-            dynMenu.MenuItems.Add(menuItem);
+            // AxMenu holds AxMenuElement children in `Elements` (added via AddElement) — NOT
+            // a `MenuItems` collection. A menu-item reference is an AxMenuElementMenuItem whose
+            // MenuItemType (Display/Action/Output) discriminates the referenced item kind.
+            // NOTE: MenuItemType lives in the Core assembly (Microsoft.Dynamics.AX.Metadata.Core),
+            // a DIFFERENT assembly than AxMenuElementMenuItem — reference both directly rather
+            // than via typeof(AxClass).Assembly.GetType(), which only sees the one assembly.
+            var element = new AxMenuElementMenuItem
+            {
+                Name = menuItemName,
+                MenuItemName = menuItemName,
+                MenuItemType = itemType switch
+                {
+                    "display" => Microsoft.Dynamics.AX.Metadata.Core.MetaModel.MenuItemType.Display,
+                    "action" => Microsoft.Dynamics.AX.Metadata.Core.MetaModel.MenuItemType.Action,
+                    "output" => Microsoft.Dynamics.AX.Metadata.Core.MetaModel.MenuItemType.Output,
+                    _ => throw new ArgumentException($"Unsupported menu item type: '{menuItemType}'. Use 'display', 'action', or 'output'."),
+                },
+            };
+            axMenu.AddElement(element);
 
             ((IMetaMenuProvider)_provider.Menus).Update(axMenu, msi);
             return new { success = true, operation = "add-menu-item-to-menu", objectName = menuName, menuItemName, menuItemType = itemType, api = "IMetaMenuProvider.Update" };
@@ -2222,13 +2269,32 @@ namespace D365MetadataBridge.Services
                         ?? throw new ArgumentException($"Form '{objectName}' not found");
                     var msi = GetModelSaveInfoForObject(_provider.Forms, objectName);
 
-                    // AxFormDataSource hierarchy is abstract — find concrete type via reflection
-                    // (same pattern as CreateFormControl for abstract AxFormControl types)
+                    // Idempotency: don't append a duplicate. If a data source with the same
+                    // NAME already exists, skip (it may be a template stub already bound to the
+                    // right table). If a DIFFERENT-named data source already binds the same
+                    // TABLE, skip too — adding a second binding to the same table is almost
+                    // always an accident (a stub the caller meant to replace, not duplicate).
+                    foreach (var existing in axForm.DataSources)
+                    {
+                        dynamic dyn = existing;
+                        if (string.Equals((string)dyn.Name, dsName, StringComparison.OrdinalIgnoreCase))
+                            return new { success = true, operation = "add-data-source", objectType, objectName, dsName, table, skipped = true, reason = $"data source '{dsName}' already exists", api = "IMetaFormProvider.Update" };
+                        if (string.Equals((string)dyn.Table, table, StringComparison.OrdinalIgnoreCase))
+                            return new { success = true, operation = "add-data-source", objectType, objectName, dsName, table, skipped = true, reason = $"data source '{(string)dyn.Name}' already binds table '{table}'", api = "IMetaFormProvider.Update" };
+                    }
+
+                    // AxFormDataSource hierarchy is abstract. A top-level form data source
+                    // MUST be an AxFormDataSourceRoot — picking the first concrete
+                    // AxFormDataSourceConcrete subtype can yield AxFormDataSourceReferenced
+                    // (used for nested/referenced sources), which AxForm.AddDataSource then
+                    // fails to cast to AxFormDataSourceRoot. Resolve the Root type explicitly.
                     var assembly = typeof(AxClass).Assembly;
-                    var dsType = assembly.GetTypes()
-                        .FirstOrDefault(t => typeof(AxFormDataSourceConcrete).IsAssignableFrom(t) && !t.IsAbstract)
+                    var dsType = assembly.GetType("Microsoft.Dynamics.AX.Metadata.MetaModel.AxFormDataSourceRoot")
+                        ?? assembly.GetTypes().FirstOrDefault(t =>
+                               typeof(AxFormDataSourceConcrete).IsAssignableFrom(t) && !t.IsAbstract
+                               && t.Name == "AxFormDataSourceRoot")
                         ?? throw new InvalidOperationException(
-                            "No concrete AxFormDataSource type found in metadata assembly — use xmlContent fallback");
+                            "AxFormDataSourceRoot type not found in metadata assembly — use xmlContent fallback");
                     dynamic ds = Activator.CreateInstance(dsType)!;
                     ds.Name = dsName;
                     ds.Table = table;
@@ -3247,7 +3313,7 @@ namespace D365MetadataBridge.Services
                 {
                     foreach (ModelInfo mi in modelInfos)
                     {
-                        return new ModelSaveInfo { Id = mi.Id, Layer = mi.Layer };
+                        return new ModelSaveInfo { Id = mi.Id, Layer = mi.Layer, Name = mi.Name, SequenceId = mi.SequenceId };
                     }
                 }
             }
@@ -3257,7 +3323,7 @@ namespace D365MetadataBridge.Services
             ModelInfo? foundMi = TryGetModelInfoFromProviders(objectName);
             if (foundMi != null)
             {
-                return new ModelSaveInfo { Id = foundMi.Id, Layer = foundMi.Layer };
+                return new ModelSaveInfo { Id = foundMi.Id, Layer = foundMi.Layer, Name = foundMi.Name, SequenceId = foundMi.SequenceId };
             }
 
             // Strategy 3: infer model from on-disk file path
@@ -3265,6 +3331,8 @@ namespace D365MetadataBridge.Services
             //   We scan common AOT folders for the object name.
             string[] aotFolders = { "AxClass", "AxTable", "AxForm", "AxEnum", "AxEdt",
                                     "AxQuery", "AxView", "AxDataEntityView", "AxReport",
+                                    "AxMenu", "AxMenuItemDisplay", "AxMenuItemAction", "AxMenuItemOutput",
+                                    "AxSecurityPrivilege", "AxSecurityDuty", "AxSecurityRole",
                                     "AxTableExtension", "AxFormExtension", "AxClassExtension",
                                     "AxEnumExtension" };
             try

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -13,6 +13,7 @@
 
 import type { BridgeClient } from './bridgeClient.js';
 import * as debouncedRefresh from './debouncedRefresh.js';
+import { debugLog } from '../utils/logger.js';
 import type {
   BridgeTableInfo,
   BridgeClassInfo,
@@ -895,6 +896,12 @@ export async function bridgeValidateAfterWrite(
       if (result.valueCount != null && result.valueCount > 0) parts.push(`${result.valueCount} values`);
       return parts.join(' | ');
     } else {
+      // The bridge can't read back this object type yet — not an error (the file was
+      // already written). Skip silently rather than emitting a misleading warning.
+      if (typeof result.reason === 'string' && result.reason.startsWith('validation-unsupported')) {
+        debugLog(`[BridgeAdapter] validateAfterWrite: ${result.reason} (${objectName}) — skipped`);
+        return null;
+      }
       return `⚠️ **IMetadataProvider could not read back \`${objectName}\`**: ${result.reason ?? 'unknown error'}`;
     }
   } catch (e) {
@@ -1020,7 +1027,9 @@ export async function bridgeCreateObject(
       return { success: false, message: `Bridge createObject returned success=false` };
     }
   } catch (e) {
-    console.error(`[BridgeAdapter] createObject(${params.objectType}, ${params.objectName}) failed: ${e}`);
+    // Recoverable: the caller falls back to XML generation on null. Log at debug
+    // so an expected fast-path miss doesn't surface as a client-facing error.
+    debugLog(`[BridgeAdapter] createObject(${params.objectType}, ${params.objectName}) failed — falling back to XML generation: ${e}`);
     return null; // Signal to caller: fall back to XML generation
   }
 }
@@ -1058,7 +1067,9 @@ export async function bridgeCreateSmartTable(
       return null;
     }
   } catch (e) {
-    console.error(`[BridgeAdapter] createSmartTable(${params.objectName}) failed: ${e}`);
+    // Recoverable: the caller falls back to SmartXmlBuilder on null. Log at debug
+    // so an expected fast-path miss doesn't surface as a client-facing error.
+    debugLog(`[BridgeAdapter] createSmartTable(${params.objectName}) failed — falling back to SmartXmlBuilder: ${e}`);
     return null; // Signal to caller: fall back to SmartXmlBuilder
   }
 }
@@ -1086,7 +1097,7 @@ export async function bridgeAddMethod(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addMethod(${objectType}, ${objectName}, ${methodName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1141,7 +1152,7 @@ export async function bridgeSetProperty(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] setProperty(${objectType}, ${objectName}, ${propertyPath}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1169,7 +1180,7 @@ export async function bridgeReplaceCode(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] replaceCode(${objectType}, ${objectName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1195,7 +1206,7 @@ export async function bridgeRemoveMethod(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] removeMethod(${objectType}, ${objectName}, ${methodName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1221,7 +1232,7 @@ export async function bridgeAddIndex(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addIndex(${tableName}, ${indexName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1244,7 +1255,7 @@ export async function bridgeRemoveIndex(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] removeIndex(${tableName}, ${indexName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1269,7 +1280,7 @@ export async function bridgeAddRelation(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addRelation(${tableName}, ${relationName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1292,7 +1303,7 @@ export async function bridgeRemoveRelation(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] removeRelation(${tableName}, ${relationName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1317,7 +1328,7 @@ export async function bridgeAddFieldGroup(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addFieldGroup(${tableName}, ${groupName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1340,7 +1351,7 @@ export async function bridgeRemoveFieldGroup(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] removeFieldGroup(${tableName}, ${groupName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1364,7 +1375,7 @@ export async function bridgeAddFieldToFieldGroup(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addFieldToFieldGroup(${tableName}, ${groupName}, ${fieldName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1484,7 +1495,7 @@ export async function bridgeAddEnumValue(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addEnumValue(${enumName}, ${valueName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1508,7 +1519,7 @@ export async function bridgeModifyEnumValue(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] modifyEnumValue(${enumName}, ${valueName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1531,7 +1542,7 @@ export async function bridgeRemoveEnumValue(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] removeEnumValue(${enumName}, ${valueName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1559,7 +1570,7 @@ export async function bridgeAddControl(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addControl(${formName}, ${controlName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1586,7 +1597,7 @@ export async function bridgeAddDataSource(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addDataSource(${objectType}, ${objectName}, ${dsName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1649,7 +1660,7 @@ export async function bridgeAddFieldModification(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addFieldModification(${extensionName}, ${fieldName}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 
@@ -1678,7 +1689,7 @@ export async function bridgeAddMenuItemToMenu(
     };
   } catch (e) {
     console.error(`[BridgeAdapter] addMenuItemToMenu(${menuName}, ${menuItemToAdd}) failed: ${e}`);
-    return null;
+    return { success: false, message: String(e) };
   }
 }
 

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -289,7 +289,16 @@ export class BridgeClient extends EventEmitter {
               this.pending.delete(msg.id);
               clearTimeout(pending.timer);
               if (msg.error) {
-                pending.reject(new Error(`Bridge error [${msg.error.code}]: ${msg.error.message}`));
+                // A read "object not found" (-32001 from the metadata read path) is a
+                // normal negative result, not an error — resolve null so read methods
+                // (typed T | null) return cleanly and callers don't log it as a failure.
+                // The write path's -32001 ("Write operation returned null") keeps a
+                // distinct message and still rejects.
+                if (msg.error.code === -32001 && /not found/i.test(msg.error.message ?? '')) {
+                  pending.resolve(null);
+                } else {
+                  pending.reject(new Error(`Bridge error [${msg.error.code}]: ${msg.error.message}`));
+                }
               } else {
                 pending.resolve(msg.result);
               }
@@ -329,9 +338,12 @@ export class BridgeClient extends EventEmitter {
 
       child.on('exit', (code, signal) => {
         if (this.process !== child) return;
+        clearTimeout(timeout);
         this._isReady = false;
         console.error(`[BridgeClient] Process exited: code=${code}, signal=${signal}`);
-        this.rejectAllPending(new Error(`Bridge process exited unexpectedly: code=${code}`));
+        const exitErr = new Error(`Bridge process exited before becoming ready: code=${code}, signal=${signal}`);
+        this.rejectAllPending(exitErr);
+        reject(exitErr);
       });
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,18 +66,20 @@ console.error = (...args: any[]) => {
     return;
   }
   const firstArg = String(args[0]);
-  // Suppress only verbose debug progress from known tool handler prefixes,
-  // but NEVER suppress if the message contains error/warning indicators.
-  const isToolDebugMessage =
-    (firstArg.includes('[create_d365fo_file]') ||
-     firstArg.includes('[generate_d365fo_xml]') ||
-     firstArg.includes('[ProjectFileManager]')) &&
-    !firstArg.includes('Failed') &&
-    !firstArg.includes('Error') &&
-    !firstArg.includes('error') &&
-    !firstArg.includes('❌') &&
-    !firstArg.includes('⚠️');
-  if (!isToolDebugMessage) {
+  // Suppress verbose operational debug messages from any tool/component prefix
+  // (pattern: message starts with "[module_name]"), but NEVER suppress if the
+  // message contains error/warning indicators — those must always reach the client.
+  const hasErrorIndicator =
+    firstArg.includes('Failed') ||
+    firstArg.includes('failed') ||
+    firstArg.includes('Error') ||
+    firstArg.includes('error') ||
+    firstArg.includes('❌') ||
+    firstArg.includes('⚠️') ||
+    firstArg.includes('[WARN]') ||
+    firstArg.includes('[ERROR]');
+  const isModuleDebugMessage = /^\[[\w\- ]+\]/.test(firstArg) && !hasErrorIndicator;
+  if (!isModuleDebugMessage) {
     originalConsoleError(...args);
   }
 };
@@ -399,24 +401,19 @@ async function initializeBridge(targetContext: import('./types/context.js').XppS
 
 async function main() {
   // ─────────────────────────────────────────────────────────────────────────────
-  // Phase-1 diagnostic interceptors (stdio-only helpers)
-  // Defined here so _phase1Start and diagTs are never allocated in HTTP mode.
-  // Each incoming/outgoing newline-delimited JSON-RPC message is logged to
-  // stderr so you can see exactly what VS 2022 sends.
+  // Stdin sniffer: capture the `initialize` request params for get_workspace_info.
   // ─────────────────────────────────────────────────────────────────────────────
-  const _phase1Start = Date.now();
-  function diagTs(): string {
-    return `+${Date.now() - _phase1Start}ms`;
-  }
-
-  /** Wraps process.stdin — logs every incoming JSON-RPC message, passes data through unchanged. */
-  function createDiagnosticStdin(): Transform {
+  /**
+   * Wraps process.stdin to capture the `initialize` request params (clientInfo,
+   * capabilities, roots) so get_workspace_info can surface them. Passes every
+   * byte through unchanged — this feeds a real tool, it is not a diagnostic trace.
+   */
+  function createInitializeParamsSniffer(): Transform {
     let buf = Buffer.alloc(0);
     const t = new Transform({
       transform(chunk: Buffer, _enc, cb) {
         buf = Buffer.concat([buf, chunk]);
-        // MCP stdio transport uses newline-delimited JSON: each message is one
-        // JSON object terminated by \n (with optional \r before \n).
+        // MCP stdio transport uses newline-delimited JSON: one object per line.
         let newlineIdx: number;
         while ((newlineIdx = buf.indexOf(0x0a)) !== -1) {
           const line = buf.slice(0, newlineIdx).toString('utf8').replace(/\r$/, '');
@@ -424,17 +421,8 @@ async function main() {
           if (!line.trim()) continue;
           try {
             const msg = JSON.parse(line);
-            // Always capture initialize params regardless of DEBUG_LOGGING flag
-            // so get_workspace_info can show them even in production stdio mode.
             if (msg.method === 'initialize' && msg.params) {
               setInitializeParams(msg.params);
-            }
-            if (DEBUG_LOGGING) {
-              const kind = msg.method != null ? `📨 ${msg.method}` : `✅ reply#${msg.id}`;
-              const payload = msg.params ?? msg.result ?? msg.error ?? {};
-              process.stderr.write(
-                `[VS→MCP ${diagTs()}] ${kind}  ${JSON.stringify(payload).slice(0, 900)}\n`
-              );
             }
           } catch { /* non-JSON line, skip */ }
         }
@@ -445,43 +433,24 @@ async function main() {
     return t;
   }
 
-  /** Wraps process.stdout — logs every outgoing JSON-RPC message, passes data through unchanged. */
-  function createDiagnosticStdout(): Transform {
-    let buf = Buffer.alloc(0);
-    const t = new Transform({
-      transform(chunk: Buffer, _enc, cb) {
-        buf = Buffer.concat([buf, chunk]);
-        // MCP stdio transport uses newline-delimited JSON.
-        let newlineIdx: number;
-        while ((newlineIdx = buf.indexOf(0x0a)) !== -1) {
-          const line = buf.slice(0, newlineIdx).toString('utf8').replace(/\r$/, '');
-          buf = buf.slice(newlineIdx + 1);
-          if (!line.trim()) continue;
-          try {
-            const msg = JSON.parse(line);
-            const kind = msg.method != null ? `🔔 ${msg.method}` : `📤 reply#${msg.id}`;
-            let payload: unknown = msg.result ?? msg.params ?? msg.error ?? {};
-            // Avoid flooding log with the full tools/list payload
-            if (msg.id != null && Array.isArray((payload as any)?.tools)) {
-              payload = { tools_count: (payload as any).tools.length, first: (payload as any).tools[0]?.name };
-            }
-            process.stderr.write(
-              `[MCP→VS ${diagTs()}] ${kind}  ${JSON.stringify(payload).slice(0, 500)}\n`
-            );
-          } catch { /* non-JSON line, skip */ }
-        }
-        cb(null, chunk); // pass data through unchanged
-      },
-    });
-    t.pipe(process.stdout);
-    return t;
-  }
-
-  // CRITICAL: In STDIO mode, redirect all console.log to stderr
+  // CRITICAL: In STDIO mode, redirect all console.log/info/warn to stderr.
   // GitHub Copilot reads stdout for MCP protocol only!
+  // Suppress verbose operational messages unless DEBUG_LOGGING=true — every
+  // stderr line appears as "[warning] [server stderr]" in the MCP client UI,
+  // which is confusing when it's just normal startup/metrics output.
   if (isStdioMode) {
-    console.log = (...args: any[]) => process.stderr.write(args.join(' ') + '\n');
-    console.info = (...args: any[]) => process.stderr.write(args.join(' ') + '\n');
+    const stderrWrite = (...args: any[]) => {
+      if (DEBUG_LOGGING) { process.stderr.write(args.join(' ') + '\n'); return; }
+      const msg = args.join(' ');
+      // Only forward genuine errors/warnings; suppress operational info.
+      if (msg.includes('❌') || msg.includes('⚠️') ||
+          msg.includes('Error') || msg.includes('error') ||
+          msg.includes('Failed') || msg.includes('failed')) {
+        process.stderr.write(msg + '\n');
+      }
+    };
+    console.log = stderrWrite;
+    console.info = stderrWrite;
     console.warn = (...args: any[]) => process.stderr.write('[WARN] ' + args.join(' ') + '\n');
   } else {
     // HTTP mode (Azure App Service): redirect console.warn to stdout so Azure
@@ -506,16 +475,6 @@ async function main() {
     // Eagerly scan D365FO_SOLUTIONS_PATH so allDetectedProjects is populated before
     // VS 2022 sends roots/list (usually within 1–2 s of startup).
     getConfigManager().initEagerScan();
-    process.stderr.write(`[stdio ${diagTs()}] Seeding workspace: ${initialWorkspace}\n`);
-    if (DEBUG_LOGGING) {
-      process.stderr.write(
-        `[phase1 diag] ────────────────────────────────────────────────────────\n` +
-        `[phase1 diag] DEBUG_LOGGING=true → raw JSON-RPC trace ENABLED\n` +
-        `[phase1 diag]  [VS→MCP ...] = messages FROM Visual Studio TO this server\n` +
-        `[phase1 diag]  [MCP→VS ...] = messages FROM this server TO Visual Studio\n` +
-        `[phase1 diag] ────────────────────────────────────────────────────────\n`
-      );
-    }
     getConfigManager().setRuntimeContext({ workspacePath: initialWorkspace });
 
     // STDIO mode: connect transport BEFORE the heavy database open so the MCP
@@ -557,23 +516,18 @@ async function main() {
     const mcpServer = createXppMcpServer(stubContext);
 
     // Step 2: connect transport — handshake completes here
-    // Always wrap stdin with the session-sniffer Transform so we can capture
-    // the `initialize` request params (clientInfo, capabilities) for
-    // get_workspace_info diagnostics — even when DEBUG_LOGGING is false.
-    // stdout is only intercepted when DEBUG_LOGGING=true (it's noisy).
-    const diagStdin  = createDiagnosticStdin();
-    const diagStdout = DEBUG_LOGGING ? createDiagnosticStdout() : process.stdout;
+    // Always wrap stdin with the initialize-params sniffer so we can capture the
+    // `initialize` request params (clientInfo, capabilities) for get_workspace_info.
     const transport = new StdioServerTransport(
-      diagStdin  as unknown as typeof process.stdin,
-      diagStdout as unknown as typeof process.stdout,
+      createInitializeParamsSniffer() as unknown as typeof process.stdin,
+      process.stdout,
     );
     await mcpServer.connect(transport);
-    console.log(`✅ Stdio transport connected ${diagTs()} (DB loading in background)`);
+    console.log('✅ Stdio transport connected (DB loading in background)');
 
     // Step 3: yield the event loop so `initialized` + roots/list can be processed
     // BEFORE the synchronous new Database() call blocks the event loop.
     await new Promise<void>(resolve => setImmediate(resolve));
-    process.stderr.write(`[stdio ${diagTs()}] setImmediate fired — roots/list exchange should be done\n`);
 
     // Step 3b: Initialize C# bridge in parallel with DB load (non-blocking)
     // The bridge provides live metadata from Microsoft's IMetadataProvider API
@@ -593,7 +547,7 @@ async function main() {
       serverState.statusMessage = 'Ready';
       // Resolve dbReady AFTER context is patched — tools can now run with real index.
       resolveDbReady();
-      console.log(`✅ Database loaded in ${Date.now() - dbLoadStart} ms (${diagTs()} from process start) — all tools fully operational`);
+      console.log(`✅ Database loaded in ${Date.now() - dbLoadStart} ms — all tools fully operational`);
 
       // The in-memory stub symbol index is also unreachable once swapped.
       try { stubIndex.close(); } catch { /* ignore */ }

--- a/src/knowledge/formPatterns/catalog/subPatterns/fields.ts
+++ b/src/knowledge/formPatterns/catalog/subPatterns/fields.ts
@@ -11,7 +11,7 @@ export const fieldsFieldGroups: SubPatternSpec = {
   id: 'FieldsFieldGroups',
   xmlName: 'FieldsFieldGroups',
   displayName: 'Fields and Field Groups',
-  versions: ['1.1', '1.0'],
+  versions: ['1.2', '1.1', '1.0'],
   appliesToControlTypes: ['Group', 'TabPage'],
   purpose:
     'Responsive column layout for containers that contain only fields and one level of field groups. ' +

--- a/src/knowledge/formPatterns/catalog/topLevel/detailsTransaction.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/detailsTransaction.ts
@@ -6,6 +6,20 @@
 import type { FormPatternSpec, NodeSpec } from '../../types.js';
 import { actionPane, filterGroup } from './common.js';
 
+/**
+ * Read-only navigation list (left SidePanel grid of header records). Required by
+ * the platform's DetailsTransaction pattern from v1.4 onward; kept `optional`
+ * here so faithful clones of older header+lines forms don't false-fail.
+ */
+const navigationListPanel: NodeSpec = {
+  id: 'NavigationList',
+  controlTypes: ['Group'],
+  occurrence: 'optional',
+  nameHint: 'NavigationList',
+  properties: { Style: 'SidePanel' },
+  extraChildren: 'any',
+};
+
 const headerLinesTabs: NodeSpec = {
   id: 'HeaderLinesTabs',
   controlTypes: ['Tab'],
@@ -46,11 +60,16 @@ export const detailsTransaction: FormPatternSpec = {
   referenceForms: ['SalesTable', 'PurchTable', 'ProjInvoiceJournal'],
   designProperties: { Style: 'DetailsFormTransaction' },
   requiresDataSource: 'headerLines',
-  root: [actionPane('required'), filterGroup('optional'), headerLinesTabs],
+  root: [actionPane('required'), navigationListPanel, filterGroup('optional'), headerLinesTabs],
   extraRootChildren: 'none',
   lifecycleGuidance: [
-    'Link the lines datasource to the header datasource (JoinSource + Active link type).',
+    'Link the lines datasource to the header datasource (JoinSource + Delayed/Active link type).',
     'Override the lines datasource initValue() to default line fields from the header.',
     'Override the header datasource active() to refresh totals/line state.',
+  ],
+  notes: [
+    'From v1.4 the platform pattern requires a Navigation List (left SidePanel grid ' +
+      'of header records); the generator emits one. The catalog keeps it optional so ' +
+      'clones of older v1.x forms without one are not rejected.',
   ],
 };

--- a/src/knowledge/formPatterns/catalog/topLevel/listPage.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/listPage.ts
@@ -10,7 +10,9 @@ export const listPage: FormPatternSpec = {
   id: 'ListPage',
   xmlName: 'ListPage',
   displayName: 'List Page',
-  versions: ['1.1', '1.0'],
+  // 'UX7 1.0' is the installed-platform version (mined from 179 shipped ListPages);
+  // the legacy 1.1/1.0 remain for back-compat with older metadata.
+  versions: ['UX7 1.0', '1.1', '1.0'],
   purpose:
     'Read-optimized grid entry point for browsing records and acting on them, typically with ' +
     'FactBoxes in the Parts node and a corresponding Details form.',

--- a/src/knowledge/formPatterns/catalog/topLevel/simpleListDetails.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/simpleListDetails.ts
@@ -6,25 +6,35 @@
 import type { FormPatternSpec, NodeSpec } from '../../types.js';
 import { actionPane } from './common.js';
 
+// Left nav list: a Group with Style=SidePanel. NOTE: SidePanel is a *Style*, not
+// a <Pattern> — the platform has no "SidePanel" sub-pattern (mining confirmed),
+// so this container carries no sub-pattern.
 const navigationListPanel: NodeSpec = {
   id: 'NavigationList',
   controlTypes: ['Group'],
   occurrence: 'required',
   nameHint: 'GridContainer',
   properties: { Style: 'SidePanel' },
-  requiresSubPattern: true,
-  allowedSubPatterns: ['SidePanel'],
   extraChildren: 'any',
 };
 
-const detailsPanel: NodeSpec = {
-  id: 'DetailsPanel',
-  controlTypes: ['Group', 'Tab'],
-  occurrence: 'required',
-  nameHint: 'DetailsGroup',
-  requiresSubPattern: true,
-  // Details content commonly follows a fields layout or contains a Tab
+// Always-visible header fields above the detail tabs (FieldsFieldGroups group).
+const detailsHeader: NodeSpec = {
+  id: 'DetailsHeader',
+  controlTypes: ['Group'],
+  occurrence: 'optional',
+  nameHint: 'DetailsHeader',
   allowedSubPatterns: ['FieldsFieldGroups', 'TabularFields', 'ToolbarAndFields'],
+  extraChildren: 'any',
+};
+
+// The detail FastTabs ("Details Tabs"). Optional in the catalog so clones of
+// older layouts (Tab nested in a Group) are not rejected; the generator emits it.
+const detailsTabs: NodeSpec = {
+  id: 'DetailsTabs',
+  controlTypes: ['Tab', 'Group'],
+  occurrence: 'optional',
+  nameHint: 'Tab',
   extraChildren: 'any',
 };
 
@@ -50,7 +60,7 @@ export const simpleListDetailsListGrid: FormPatternSpec = {
   referenceForms: ['PaymTerm', 'CustPaymModeTable', 'BankGroup'],
   designProperties: { Style: 'SimpleListDetails' },
   requiresDataSource: 'one',
-  root: [actionPane('required'), navigationListPanel, detailsPanel],
+  root: [actionPane('required'), navigationListPanel, detailsHeader, detailsTabs],
   extraRootChildren: 'none',
   lifecycleGuidance: [
     'Override the datasource active() to refresh dependent detail content when selection changes.',
@@ -87,7 +97,8 @@ export const simpleListDetailsTree: FormPatternSpec = {
       properties: { Style: 'SidePanel' },
       extraChildren: 'any',
     },
-    detailsPanel,
+    detailsHeader,
+    detailsTabs,
   ],
   extraRootChildren: 'none',
 };

--- a/src/knowledge/formPatterns/catalog/topLevel/tableOfContents.ts
+++ b/src/knowledge/formPatterns/catalog/topLevel/tableOfContents.ts
@@ -28,7 +28,11 @@ export const tableOfContents: FormPatternSpec = {
       id: 'TOCTabs',
       controlTypes: ['Tab'],
       occurrence: 'required',
-      properties: { Style: 'TOCList' },
+      // The top-level TOC navigation Tab uses Style=VerticalTabs (NOT the invalid
+      // 'TOCList', which makes xppc abort deserialization and suppress pattern
+      // validation for the whole build). Each TOC section is an unpatterned
+      // TabPage holding a TOCTitleContainer heading + a nested FastTabs tab.
+      properties: { Style: 'VerticalTabs' },
       children: [
         {
           id: 'TOCSection',

--- a/src/knowledge/formPatterns/methodStubs.ts
+++ b/src/knowledge/formPatterns/methodStubs.ts
@@ -87,19 +87,38 @@ const DS_VALIDATE_WRITE: MethodStub = {
         }`,
 };
 
+/** Lines datasource initValue that defaults the foreign key from the header record. */
+const LINES_INIT_VALUE = (headerDsName: string): MethodStub => ({
+  name: 'initValue',
+  source: `        public void initValue()
+        {
+            super();
+
+            // TODO: default line fields from the header record, e.g.:
+            // this.cursor().HeaderRecId = ${headerDsName || 'Header'}.RecId;
+        }`,
+});
+
 // ── Per-pattern selection ────────────────────────────────────────────────────
 
 export interface PatternMethodStubs {
   formMethods: MethodStub[];
   /** Stubs for the PRIMARY datasource */
   dataSourceMethods: MethodStub[];
+  /** Stubs for the LINES datasource (header+lines patterns) */
+  linesDataSourceMethods?: MethodStub[];
 }
 
 /**
  * Lifecycle stubs appropriate for a pattern. `dsName` is the primary
- * datasource name (used inside stub bodies for examples).
+ * datasource name; `linesDsName` (optional) the lines datasource for
+ * header+lines patterns (used to default line fields from the header).
  */
-export function methodStubsForPattern(patternName: string, dsName: string): PatternMethodStubs {
+export function methodStubsForPattern(
+  patternName: string,
+  dsName: string,
+  linesDsName?: string,
+): PatternMethodStubs {
   const spec = resolvePattern(patternName);
   const id = spec?.id ?? 'SimpleList';
 
@@ -124,7 +143,12 @@ export function methodStubsForPattern(patternName: string, dsName: string): Patt
     case 'DetailsTransaction':
       return {
         formMethods: [FORM_INIT],
-        dataSourceMethods: [DS_ACTIVE, DS_INIT_VALUE, DS_VALIDATE_WRITE],
+        // Header datasource drives selection + save-time validation.
+        dataSourceMethods: [DS_ACTIVE, DS_VALIDATE_WRITE],
+        // Lines datasource defaults new-line fields from the header.
+        linesDataSourceMethods: linesDsName
+          ? [LINES_INIT_VALUE(dsName), DS_VALIDATE_WRITE]
+          : undefined,
       };
     case 'SimpleListDetails':
       return {
@@ -169,9 +193,29 @@ export function injectMethodStubs(
   xml: string,
   stubs: PatternMethodStubs,
   dsName: string,
+  linesDsName?: string,
 ): { xml: string; injected: string[] } {
   let result = xml;
   const injected: string[] = [];
+
+  // Insert a <Methods> block right after a datasource's <Name>. Returns the
+  // updated XML (or the original when the datasource/methods aren't found).
+  const injectDsMethods = (src: string, targetDs: string, methods: MethodStub[]): string => {
+    if (methods.length === 0 || !targetDs) return src;
+    // Search from the real <DataSources> region so a same-named SourceCode method
+    // can't be mistaken for the datasource's <Name>.
+    const dsRegion = src.indexOf('<AxFormDataSource');
+    const nameTag = `<Name>${targetDs}</Name>`;
+    const nameIdx = src.indexOf(nameTag, dsRegion === -1 ? 0 : dsRegion);
+    if (nameIdx === -1) return src;
+    const insertAt = nameIdx + nameTag.length;
+    const block =
+      `\n\t\t\t<Methods>\n` +
+      methods.map((s) => methodXml(s, '\t\t\t\t')).join('') +
+      `\t\t\t</Methods>`;
+    injected.push(...methods.map((s) => `${targetDs}.${s.name}`));
+    return src.slice(0, insertAt) + block + src.slice(insertAt);
+  };
 
   if (stubs.formMethods.length > 0) {
     // classDeclaration method block ends at the first </Method> after its <Name>
@@ -187,20 +231,9 @@ export function injectMethodStubs(
     }
   }
 
-  if (stubs.dataSourceMethods.length > 0 && dsName) {
-    // Primary datasource: first <AxFormDataSource …><Name>dsName</Name>
-    const dsOpen = result.indexOf('<AxFormDataSource');
-    const nameTag = `<Name>${dsName}</Name>`;
-    const nameIdx = dsOpen === -1 ? -1 : result.indexOf(nameTag, dsOpen);
-    if (nameIdx !== -1) {
-      const insertAt = nameIdx + nameTag.length;
-      const methodsBlock =
-        `\n\t\t\t<Methods>\n` +
-        stubs.dataSourceMethods.map((s) => methodXml(s, '\t\t\t\t')).join('') +
-        `\t\t\t</Methods>`;
-      result = result.slice(0, insertAt) + methodsBlock + result.slice(insertAt);
-      injected.push(...stubs.dataSourceMethods.map((s) => `${dsName}.${s.name}`));
-    }
+  result = injectDsMethods(result, dsName, stubs.dataSourceMethods);
+  if (stubs.linesDataSourceMethods && linesDsName) {
+    result = injectDsMethods(result, linesDsName, stubs.linesDataSourceMethods);
   }
 
   return { xml: result, injected };

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -18,6 +18,8 @@ import type { XppServerContext } from '../types/context.js';
 import { SERVER_MODE, LOCAL_TOOLS, ALWAYS_TOOLS } from './serverMode.js';
 import { TOOL_ANNOTATIONS } from './toolAnnotations.js';
 import { getConfigManager } from '../utils/configManager.js';
+
+const DEBUG_LOGGING = process.env.DEBUG_LOGGING === 'true';
 import { setLastRoots, recordRootsListChanged } from '../utils/stdioSessionInfo.js';
 import { OBJECT_INFO_TYPES, BATCH_INFO_TYPES } from '../tools/objectInfoRegistry.js';
 
@@ -59,16 +61,19 @@ function fileUriToPath(uri: string): string | null {
 function applyRootsToConfig(roots: Array<{ uri: string }>): void {
   if (!roots?.length) {
     // VS 2022 sends empty roots/list when closing a solution (transition state).
-    // Log this so it's visible in diagnostics, but keep the current detection
-    // result — the next roots/list_changed will bring the new solution path.
-    process.stderr.write('[mcpServer] roots/list received (0 root(s)) — solution closing or no workspace open\n');
+    // Keep the current detection result — the next roots/list_changed will update it.
+    if (DEBUG_LOGGING) {
+      process.stderr.write('[mcpServer] roots/list received (0 root(s)) — solution closing or no workspace open\n');
+    }
     setLastRoots([]);
     return;
   }
 
   // Log all received roots for diagnostics
-  process.stderr.write(`[mcpServer] roots/list received (${roots.length} root(s)):\n`);
-  roots.forEach((r, i) => process.stderr.write(`  [${i}] ${r.uri}\n`));
+  if (DEBUG_LOGGING) {
+    process.stderr.write(`[mcpServer] roots/list received (${roots.length} root(s)):\n`);
+    roots.forEach((r, i) => process.stderr.write(`  [${i}] ${r.uri}\n`));
+  }
 
   // Persist URIs in the stdio session singleton so get_workspace_info can display them.
   setLastRoots(roots.map(r => r.uri));
@@ -84,17 +89,19 @@ function applyRootsToConfig(roots: Array<{ uri: string }>): void {
   // After detection completes, log what solution/project was resolved so it's
   // easy to verify in the log that the correct project was picked.
   getConfigManager().setRuntimeContextFromRoots(paths).then(() => {
-    const { modelName, source, projectPath, solutionPath, workspacePath } =
-      getConfigManager().getDetectionSummary();
-    process.stderr.write(
-      `[mcpServer] ✅ Project detection result:\n` +
-      `   Model name  : ${modelName ?? '(unknown)'} (source: ${source})\n` +
-      `   Project path: ${projectPath  ?? '(not set)'}\n` +
-      `   Solution    : ${solutionPath ?? '(not set)'}\n` +
-      `   Workspace   : ${workspacePath ?? '(not set)'}\n`
-    );
+    if (DEBUG_LOGGING) {
+      const { modelName, source, projectPath, solutionPath, workspacePath } =
+        getConfigManager().getDetectionSummary();
+      process.stderr.write(
+        `[mcpServer] ✅ Project detection result:\n` +
+        `   Model name  : ${modelName ?? '(unknown)'} (source: ${source})\n` +
+        `   Project path: ${projectPath  ?? '(not set)'}\n` +
+        `   Solution    : ${solutionPath ?? '(not set)'}\n` +
+        `   Workspace   : ${workspacePath ?? '(not set)'}\n`
+      );
+    }
   }).catch(err => {
-    process.stderr.write(`[mcpServer] setRuntimeContextFromRoots error: ${err}\n`);
+    process.stderr.write(`[mcpServer] ⚠️ setRuntimeContextFromRoots error: ${err}\n`);
   });
 }
 
@@ -121,14 +128,18 @@ export function createXppMcpServer(context: XppServerContext): Server {
   // up-to-date on `notifications/roots/list_changed`.
   // -----------------------------------------------------------------------
   server.setNotificationHandler(InitializedNotificationSchema, async () => {
-    process.stderr.write(
-      `[mcpServer ${new Date().toISOString().slice(11, 23)}] ⚡ 'initialized' notification received — requesting roots/list\n`
-    );
+    if (DEBUG_LOGGING) {
+      process.stderr.write(
+        `[mcpServer ${new Date().toISOString().slice(11, 23)}] ⚡ 'initialized' notification received — requesting roots/list\n`
+      );
+    }
     // Only stdio clients (VS Code, VS 2022) advertise the roots capability.
     // HTTP / Azure clients do not — skipping the call avoids a -32001 timeout
     // that would otherwise be logged as a spurious warning in Azure Monitor.
     if (!server.getClientCapabilities()?.roots) {
-      process.stderr.write(`[mcpServer] ℹ️  Client has no roots capability — skipping roots/list\n`);
+      if (DEBUG_LOGGING) {
+        process.stderr.write(`[mcpServer] ℹ️  Client has no roots capability — skipping roots/list\n`);
+      }
       return;
     }
     // HTTP transports (Azure App Service, MCP_FORCE_HTTP) are request-response only —
@@ -136,15 +147,16 @@ export function createXppMcpServer(context: XppServerContext): Server {
     // declares `roots` capability, calling roots/list would always time out (-32001).
     const isHttpMode = !!process.env.WEBSITES_PORT || process.env.MCP_FORCE_HTTP === 'true';
     if (isHttpMode) {
-      process.stderr.write(`[mcpServer] ℹ️  HTTP mode — skipping roots/list (transport is request-response only)\n`);
+      if (DEBUG_LOGGING) {
+        process.stderr.write(`[mcpServer] ℹ️  HTTP mode — skipping roots/list (transport is request-response only)\n`);
+      }
       return;
     }
-    // Instanced mode: .mcp.json / env vars already provide both model name and
-    // workspace path — the workspace is fully known and immutable per instance.
-    // Skipping the call avoids a -32001 timeout when mcp-remote is the transport
-    // (hard-coded 60 s timeout, server-initiated requests cannot complete over HTTP).
+    // Instanced mode
     if (await getConfigManager().isStaticallyConfigured()) {
-      process.stderr.write(`[mcpServer] ℹ️  Static config complete — skipping roots/list (instanced mode)\n`);
+      if (DEBUG_LOGGING) {
+        process.stderr.write(`[mcpServer] ℹ️  Static config complete — skipping roots/list (instanced mode)\n`);
+      }
       return;
     }
     try {
@@ -162,9 +174,11 @@ export function createXppMcpServer(context: XppServerContext): Server {
 
   server.setNotificationHandler(RootsListChangedNotificationSchema, async () => {
     recordRootsListChanged();
-    process.stderr.write(
-      `[mcpServer ${new Date().toISOString().slice(11, 23)}] 🔄 'roots/list_changed' notification — re-requesting roots/list\n`
-    );
+    if (DEBUG_LOGGING) {
+      process.stderr.write(
+        `[mcpServer ${new Date().toISOString().slice(11, 23)}] 🔄 'roots/list_changed' notification — re-requesting roots/list\n`
+      );
+    }
     const isHttpMode = !!process.env.WEBSITES_PORT || process.env.MCP_FORCE_HTTP === 'true';
     if (!server.getClientCapabilities()?.roots || isHttpMode) {
       return;
@@ -172,7 +186,9 @@ export function createXppMcpServer(context: XppServerContext): Server {
     // Instanced mode: workspace is immutable per server instance — the
     // notification is irrelevant and the request would time out over mcp-remote.
     if (await getConfigManager().isStaticallyConfigured()) {
-      process.stderr.write(`[mcpServer] ℹ️  Static config complete — skipping roots/list on change (instanced mode)\n`);
+      if (DEBUG_LOGGING) {
+        process.stderr.write(`[mcpServer] ℹ️  Static config complete — skipping roots/list on change (instanced mode)\n`);
+      }
       return;
     }
     try {
@@ -463,7 +479,7 @@ export function createXppMcpServer(context: XppServerContext): Server {
               generateController: { type: 'boolean', description: '[scaffold:report] Generate Controller class (default: true).' },
               designStyle: { type: 'string', description: '[scaffold:report] RDL design pattern: "SimpleList" (default) or "GroupedWithTotals".' },
               copyFrom: { type: 'string', description: '[scaffold:table|form|report] Copy structure from existing object (table fields/indexes/relations; form datasources — prefer cloneFrom; report field structure).' },
-              fieldsHint: { type: 'string', description: '[scaffold:table|report] Comma-separated field names (e.g. "RecId, Name, Amount"). EDTs auto-suggested.' },
+              fieldsHint: { type: 'string', description: '[scaffold:table|report] Comma-separated field names (e.g. "RecId, Name, Amount"). EDTs auto-suggested from the indexed metadata. ⚠️ Custom EDTs/enums created in the SAME SESSION are not yet indexed — call update_symbol_index first, then scaffold, so the new EDTs are found and used. Without this step those fields will default to String255.' },
             },
             required: ['mode'],
           },
@@ -1054,8 +1070,8 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             properties: {
               action: {
                 type: 'string',
-                enum: ['search', 'info', 'create', 'update', 'rename', 'list-files'],
-                description: 'Label operation to perform. "list-files" is an alias of "info" (lists label files).',
+                enum: ['search', 'info', 'create', 'update', 'rename', 'list', 'list-files'],
+                description: 'Label operation to perform. "list"/"list-files" are aliases of "info" (lists label files).',
               },
               // ── shared filters ─────────────────────────────────────────────
               model: {

--- a/src/tools/analyzeCode.ts
+++ b/src/tools/analyzeCode.ts
@@ -49,6 +49,18 @@ export async function analyzeCodeTool(request: CallToolRequest, context: XppServ
   }
 
   const { mode, ...rest } = parsed.data;
+
+  // api-usage expects `apiName`, but the "API" is frequently a class (e.g.
+  // NumberSeqFormHandler), so agents reach for className/class/api. Map them so the
+  // first call succeeds instead of failing "apiName required".
+  if (mode === 'api-usage') {
+    const r = rest as Record<string, unknown>;
+    if (r.apiName === undefined) {
+      const alt = r.className ?? r.class ?? r.api;
+      if (typeof alt === 'string') r.apiName = alt;
+    }
+  }
+
   const dispatch = ANALYZE_DISPATCH[mode as AnalyzeMode];
   if (!dispatch) {
     return {

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -13,7 +13,7 @@ import { registerCustomModel, resolveObjectPrefix, applyObjectPrefix, getObjectS
 import { PackageResolver } from '../utils/packageResolver.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
-import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject } from '../bridge/index.js';
+import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject, bridgeRefreshProvider } from '../bridge/index.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
 import { gateOnFormPatternErrors } from './validateFormPattern.js';
 import { FormPatternTemplates } from '../utils/formPatternTemplates.js';
@@ -3908,12 +3908,27 @@ export async function handleCreateD365File(
     // (report, data-entity, tile, kpi, business-event, etc.).
     if (!args.xmlContent && context?.bridge && actualModelName && canBridgeCreate(args.objectType)) {
       try {
+        // The bridge's `properties` is a flat string map (C# Dictionary<string,string>).
+        // Keep only SCALAR values and stringify them. Structured collections
+        // (fields/fieldGroups/indexes/relations/values/enumValues/methods) are
+        // arrays/objects passed via their own bridge params below — if they leak into
+        // `properties` the C# GetDictParam calls GetString() on a JSON array/boolean and
+        // the whole create throws ("requires an element of type 'String', but the target
+        // element has type 'Array'/'True'").
+        const scalarProperties: Record<string, string> | undefined = args.properties
+          ? Object.fromEntries(
+              Object.entries(args.properties as Record<string, unknown>)
+                .filter(([, v]) => v != null && (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean'))
+                .map(([k, v]) => [k, String(v)]),
+            )
+          : undefined;
+
         // Prepare parameters for the bridge
         const bridgeParams: Parameters<typeof bridgeCreateObject>[1] = {
           objectType: args.objectType,
           objectName: finalObjectName,
           modelName: actualModelName,
-          properties: (args.properties as Record<string, string>) ?? undefined,
+          properties: scalarProperties && Object.keys(scalarProperties).length > 0 ? scalarProperties : undefined,
         };
 
         // For classes: parse sourceCode into declaration + methods
@@ -3995,6 +4010,10 @@ export async function handleCreateD365File(
             }
           }
 
+          // Eagerly refresh the bridge provider so the new object is immediately
+          // resolvable by subsequent modify calls in the same session.
+          try { await bridgeRefreshProvider(context.bridge); } catch { /* best-effort */ }
+
           return {
             content: [
               {
@@ -4027,21 +4046,33 @@ export async function handleCreateD365File(
     // When xmlContent or sourceCode contains `class MyClass` but finalObjectName is `MyPrefixMyClass`,
     // the file would be named MyPrefixMyClass.xml but contain `class MyClass` — inconsistency!
     if (finalObjectName !== args.objectName && (args.xmlContent || args.sourceCode)) {
-      // Pattern to match: `class OriginalName` or `public class OriginalName`
+      const orig = args.objectName;
+      const final = finalObjectName;
+      // Escape for use in RegExp (handles dots in extension names like "Foo.Extension")
+      const escapedOrig = orig.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+      // 1. `class OriginalName` / `public class OriginalName` etc.
       const classPattern = new RegExp(
-        `\\b(public\\s+|private\\s+|protected\\s+|internal\\s+|final\\s+)?class\\s+${args.objectName}\\b`,
-        'g'
+        `\\b(public\\s+|private\\s+|protected\\s+|internal\\s+|final\\s+)?class\\s+${escapedOrig}\\b`,
+        'g',
       );
-      const replacedContent = xmlContent.replace(classPattern, (match) => {
-        return match.replace(args.objectName, finalObjectName);
-      });
-      
-      if (replacedContent !== xmlContent) {
+      let replaced = xmlContent.replace(classPattern, (match) => match.replace(orig, final));
+
+      // 2. classnum(OriginalName) — X++ intrinsic that refers to the class by name.
+      //    Callers often write classnum(OriginalName) in the source code before prefixing.
+      const classnumPattern = new RegExp(`\\bclassnum\\(\\s*${escapedOrig}\\s*\\)`, 'gi');
+      replaced = replaced.replace(classnumPattern, (m) => m.replace(new RegExp(escapedOrig, 'i'), final));
+
+      // 3. classStr(OriginalName) — used in [ExtensionOf(classStr(...))] and SysOperation attributes.
+      const classStrPattern = new RegExp(`\\bclassStr\\(\\s*${escapedOrig}\\s*\\)`, 'gi');
+      replaced = replaced.replace(classStrPattern, (m) => m.replace(new RegExp(escapedOrig, 'i'), final));
+
+      if (replaced !== xmlContent) {
         console.error(
           `[create_d365fo_file] ✅ Fixed class name inconsistency: ` +
-          `replaced \`class ${args.objectName}\` with \`class ${finalObjectName}\` in XML content`
+          `replaced \`${orig}\` with \`${final}\` in XML content (class decl, classnum, classStr)`,
         );
-        xmlContent = replacedContent;
+        xmlContent = replaced;
       }
     }
 
@@ -4142,6 +4173,10 @@ export async function handleCreateD365File(
     console.error(
       `[create_d365fo_file] ✅ Written: ${normalizedFullPath}  (${fileSizeKb} KB)`
     );
+
+    // Eagerly refresh the bridge provider so the new object is immediately
+    // resolvable by subsequent modify calls in the same session.
+    try { await bridgeRefreshProvider(context?.bridge); } catch { /* best-effort */ }
 
     // Post-write validation via C# bridge (best-effort, non-fatal, fire-and-forget).
     // Not awaited: the validation goes through the sequential bridge stdin/stdout

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -20,12 +20,15 @@ import { resolvePattern } from '../knowledge/formPatterns/index.js';
 import { cloneFormXml } from '../utils/formCloner.js';
 import { methodStubsForPattern, injectMethodStubs } from '../knowledge/formPatterns/methodStubs.js';
 import { findBaseFormXml } from './modifyD365File.js';
+import { getFieldControlMap, type FieldControlMap } from '../utils/fieldControlTypes.js';
 
 interface GenerateSmartFormArgs {
   name: string;
   label?: string;
   caption?: string;
   dataSource?: string;
+  linesTable?: string;
+  linesDataSource?: string;
   formPattern?: string;
   copyFrom?: string;
   cloneFrom?: string;
@@ -58,6 +61,16 @@ export const generateSmartFormTool: Tool = {
       dataSource: {
         type: 'string',
         description: 'Optional: Table name for primary datasource. Tool will auto-generate grid with fields.',
+      },
+      linesTable: {
+        type: 'string',
+        description: 'Optional: Lines table name for header+lines patterns (DetailsTransaction). ' +
+          'Creates a second datasource joined to the header (JoinSource + LinkType=Delayed), ' +
+          'populates the lines grid with typed field controls, and the field list on the datasource.',
+      },
+      linesDataSource: {
+        type: 'string',
+        description: 'Optional: explicit lines datasource name (defaults to the lines table name).',
       },
       formPattern: {
         type: 'string',
@@ -147,6 +160,8 @@ export async function handleGenerateSmartForm(
     label,
     caption,
     dataSource,
+    linesTable,
+    linesDataSource,
     formPattern,
     copyFrom,
     cloneFrom,
@@ -240,30 +255,39 @@ export async function handleGenerateSmartForm(
   // Strategy 3: Generate controls for datasource fields
   // Also collects gridFields for pattern templates regardless of generateControls flag
   let gridFields: string[] = [];
+  // Field → control-type maps so generated controls get the right type
+  // (enum→ComboBox, date→Date, …) instead of defaulting every field to String.
+  let fieldTypes: FieldControlMap | undefined;
+  let linesFields: string[] = [];
+  let linesFieldTypes: FieldControlMap | undefined;
+
+  // Resolve the table fields (minus system fields), capped for a sensible grid width.
+  const collectGridFields = (db: any, table: string): string[] => {
+    const dbFields = db.prepare(`
+      SELECT name FROM symbols
+      WHERE type = 'field' AND parent_name = ? COLLATE NOCASE
+      ORDER BY name
+    `).all(table) as Array<{ name: string }>;
+    return dbFields
+      .map((f) => f.name)
+      .filter((n) => !['RecId', 'RecVersion', 'DataAreaId', 'Partition'].includes(n))
+      .slice(0, 8);
+  };
+
   if (dataSource && dataSources.length > 0) {
     try {
       const db = symbolIndex.getReadDb();
+      gridFields = collectGridFields(db, dataSource);
+      fieldTypes = getFieldControlMap(db, dataSource);
 
-      // Query fields directly from symbols DB
-      const dbFields = db.prepare(`
-        SELECT name FROM symbols
-        WHERE type = 'field' AND parent_name = ?
-        ORDER BY name
-      `).all(dataSource) as Array<{ name: string }>;
-
-      if (dbFields.length > 0) {
-        // Collect field names excluding system fields for grid display
-        gridFields = dbFields
-          .map((f: { name: string }) => f.name)
-          .filter((n: string) => !['RecId', 'RecVersion', 'DataAreaId', 'Partition'].includes(n))
-          .slice(0, 8); // Cap at 8 columns — reasonable for most patterns
-
+      if (gridFields.length > 0) {
         if (generateControls) {
           // Legacy path: also build explicit controls for backward compat
           const gridControl = builder.buildGridControl(
             `${dataSource}Grid`,
             dataSource,
-            gridFields
+            gridFields,
+            fieldTypes,
           );
           controls.push(gridControl);
           console.log(`[generateSmartForm] Generated grid with ${gridFields.length} fields`);
@@ -273,6 +297,100 @@ export async function handleGenerateSmartForm(
       }
     } catch (error) {
       console.warn(`[generateSmartForm] Failed to generate controls:`, error);
+    }
+  }
+
+  // Lines datasource (header+lines patterns): add a second datasource bound to
+  // the lines table, with its own typed field controls and field list.
+  let linesTableResolved = linesTable || linesDataSource;
+  // Note about an auto-corrected lines table name — threaded into the output via cloneNotes.
+  let linesTableNote = '';
+  if (linesTableResolved) {
+    // Validate the lines table exists in the index. The lines-table name is a
+    // frequent source of error: the model guesses it from the header table by
+    // appending "Lines" (e.g. header "AslRentAgreementTable" → "AslRentAgreementTableLines"),
+    // but the real table is usually "<headerBase>Line" ("AslRentAgreementLine").
+    // Generate structured candidates from both the given name and the header
+    // table, auto-correct to the first that actually exists, and only hard-fail
+    // when none resolves.
+    try {
+      const db = symbolIndex.getReadDb();
+      const exists = db.prepare(
+        `SELECT name FROM symbols WHERE type = 'table' AND name = ? COLLATE NOCASE LIMIT 1`,
+      );
+      const direct = exists.get(linesTableResolved) as { name: string } | undefined;
+      if (!direct) {
+        // Build an ordered, de-duplicated candidate list.
+        const candidates: string[] = [];
+        const add = (n?: string | null) => {
+          const v = (n ?? '').trim();
+          if (v && !candidates.some(c => c.toLowerCase() === v.toLowerCase())) candidates.push(v);
+        };
+        const ln = linesTableResolved;
+        add(ln.replace(/s$/i, ''));               // strip trailing plural "s"
+        add(ln.replace(/Lines$/i, 'Line'));       // …Lines → …Line
+        add(ln.replace(/Table(Lines?)$/i, 'Line')); // …Table(Line|Lines) → …Line
+        add(ln.replace(/Table(Lines?)$/i, '$1'));   // …TableLines → …Lines
+        if (dataSource) {
+          const base = dataSource.replace(/Table$/i, ''); // header base, e.g. AslRentAgreement
+          add(`${base}Line`);
+          add(`${base}Lines`);
+          add(`${base}TransLine`);
+          add(`${base}Trans`);
+        }
+
+        let matched: string | undefined;
+        for (const cand of candidates) {
+          const hit = exists.get(cand) as { name: string } | undefined;
+          if (hit) { matched = hit.name; break; }
+        }
+
+        if (matched) {
+          // Auto-correct to the verified table and record a visible note.
+          linesTableNote =
+            `\n   🔍 linesTable "${linesTableResolved}" not found — auto-corrected to "${matched}" (verified in the index).`;
+          console.log(`[generateSmartForm] linesTable "${linesTableResolved}" → "${matched}" (auto-corrected)`);
+          linesTableResolved = matched;
+        } else {
+          // Nothing matched — fail with the best fuzzy suggestion we can find.
+          const stem = linesTableResolved.replace(/s$/i, '');
+          const alt = db.prepare(
+            `SELECT name FROM symbols WHERE type = 'table' AND name LIKE ? COLLATE NOCASE ORDER BY LENGTH(name) ASC LIMIT 1`,
+          ).get(`${stem}%`) as { name: string } | undefined;
+          const suggestion = alt && alt.name.toLowerCase() !== linesTableResolved.toLowerCase()
+            ? `\n\nDid you mean \`linesTable="${alt.name}"\`?`
+            : '';
+          return {
+            content: [{
+              type: 'text',
+              text:
+                `❌ Lines table "${linesTableResolved}" not found in the symbol index.` +
+                suggestion +
+                `\n\nIf the table was just created in this session, call \`update_symbol_index\` first, then retry.`,
+            }],
+            isError: true,
+          };
+        }
+      }
+    } catch {
+      /* index unavailable — skip validation and proceed */
+    }
+
+    const linesDsNameResolved = linesDataSource || linesTableResolved;
+    dataSources.push({
+      name: linesDsNameResolved,
+      table: linesTableResolved,
+      allowEdit: true,
+      allowCreate: true,
+      allowDelete: true,
+    });
+    try {
+      const db = symbolIndex.getReadDb();
+      linesFields = collectGridFields(db, linesTableResolved);
+      linesFieldTypes = getFieldControlMap(db, linesTableResolved);
+      console.log(`[generateSmartForm] Lines datasource ${linesDsNameResolved} with ${linesFields.length} fields`);
+    } catch (error) {
+      console.warn(`[generateSmartForm] Failed to collect lines fields:`, error);
     }
   }
 
@@ -365,7 +483,7 @@ export async function handleGenerateSmartForm(
     : builder.defaultFormPattern();
   const primaryDs = dataSources[0];
   let xml: string;
-  let cloneNotes = '';
+  let cloneNotes = linesTableNote;
 
   if (cloneFrom) {
     const sourceXml = await findBaseFormXml(cloneFrom, symbolIndex);
@@ -388,6 +506,50 @@ export async function handleGenerateSmartForm(
     const fieldStmt = db.prepare(`
       SELECT name FROM symbols WHERE type = 'field' AND parent_name = ? COLLATE NOCASE
     `);
+    // ── PRE-CLONE FIELD-OVERLAP CHECK ──────────────────────────────────────
+    // Before cloning, verify the source and target tables are structurally
+    // related (≥ 30 % shared fields per mapped pair). If the overlap is too
+    // low, cloning will strip most controls and produce a useless form.
+    // Fail-fast here rather than returning a gutted result.
+    if (tableMapping && Object.keys(tableMapping).length > 0) {
+      const poorOverlap: string[] = [];
+      for (const [srcTable, tgtTable] of Object.entries(tableMapping as Record<string, string>)) {
+        if (!tgtTable || srcTable.toLowerCase() === tgtTable.toLowerCase()) continue;
+        const srcFields = fieldStmt.all(srcTable) as Array<{ name: string }>;
+        const tgtFields = fieldStmt.all(tgtTable) as Array<{ name: string }>;
+        // Unknown table in index → field list is unavailable; skip check for that pair.
+        if (srcFields.length < 3 || tgtFields.length === 0) continue;
+        const tgtFieldSet = new Set(tgtFields.map((f) => f.name.toLowerCase()));
+        const shared = srcFields.filter((f) => tgtFieldSet.has(f.name.toLowerCase()));
+        const ratio = shared.length / srcFields.length;
+        if (ratio < 0.3) {
+          poorOverlap.push(
+            `${srcTable} → ${tgtTable}: ${shared.length}/${srcFields.length} fields shared (${Math.round(ratio * 100)} %)`,
+          );
+        }
+      }
+      if (poorOverlap.length > 0) {
+        const targetList = Object.values(tableMapping as Record<string, string>).filter(Boolean).join(', ');
+        return {
+          content: [{
+            type: 'text',
+            text:
+              `❌ PRE-CLONE CHECK — Poor field overlap between source and target tables:\n` +
+              poorOverlap.map((s) => `  • ${s}`).join('\n') +
+              `\n\nCloning "${cloneFrom}" would strip most of its controls ` +
+              `(source and target tables are structurally unrelated).\n\n` +
+              `**✅ Recommended fix — scaffold from a pattern template (fast, no cloning needed):**\n` +
+              `\`\`\`\ngenerate_object(mode="scaffold", objectType="form",\n  name="${name}",\n  formPattern="${formPattern ?? 'SimpleList'}",\n  dataSource="${targetList}"\n)\n\`\`\`\n\n` +
+              `**Alternative — find a structurally similar reference form first:**\n` +
+              `\`object_patterns(domain="form", action="analyze", recommend={ "dataSource": "${targetList}", "pattern": "${formPattern ?? 'auto'}" })\`\n` +
+              `Then re-run with the suggested \`cloneFrom\` value.`,
+          }],
+          isError: true,
+        };
+      }
+    }
+    // ── end pre-clone field-overlap check ─────────────────────────────────
+
     const cloneResult = cloneFormXml(sourceXml, {
       targetFormName: finalName,
       tableMapping,
@@ -420,16 +582,30 @@ export async function handleGenerateSmartForm(
     }
     // Poor-match guard: if a re-bound datasource lost most of its fields, the
     // reference form's table is structurally unrelated to the target — the clone
-    // is likely unusable. Flag it loudly so the caller picks a closer reference
-    // or scaffolds from a template instead of silently shipping a gutted form.
+    // is likely unusable. Return an error immediately so the caller is forced to
+    // pick a structurally similar reference form or scaffold from a template.
+    // (Previously this only emitted a warning note and still returned the gutted
+    // XML, which the model then tried to use — always resulting in manual rewrite.)
     const poorMatches = cloneResult.fieldStats.filter(s => s.total >= 3 && s.dropped / s.total >= 0.6);
     if (poorMatches.length > 0) {
-      noteLines.push(
-        `   🛑 POOR CLONE MATCH — ${poorMatches.map(s => `${s.dataSource}: ${s.dropped}/${s.total} fields dropped`).join('; ')}. ` +
-        `The reference form "${cloneResult.sourceFormName}" is bound to a table unrelated to your target, so most controls were stripped. ` +
-        `Pick a reference form over a structurally similar table (object_patterns(domain="form", action="analyze", recommend={...}) suggests one), ` +
-        `or scaffold from a template: generate_object(mode="scaffold", objectType="form", formPattern="...", dataSource="...").`,
-      );
+      const matchSummary = poorMatches.map(s => `${s.dataSource}: ${s.dropped}/${s.total} fields dropped`).join('; ');
+      const tableList = Object.values(tableMapping ?? {}).filter(Boolean).join(', ') || 'your target table';
+      return {
+        content: [{
+          type: 'text',
+          text:
+            `❌ POOR CLONE MATCH — ${matchSummary}.\n\n` +
+            `"${cloneResult.sourceFormName}" is bound to a table structurally unrelated to ${tableList}, ` +
+            `so cloning would strip ${poorMatches.reduce((a, s) => a + s.dropped, 0)} of ${poorMatches.reduce((a, s) => a + s.total, 0)} controls and produce an unusable form.\n\n` +
+            `**Fix — choose one:**\n` +
+            `1. Find a structurally similar reference form first:\n` +
+            `   \`object_patterns(domain="form", action="analyze", recommend={ "dataSource": "${tableList}", "pattern": "${formPattern ?? 'auto'}" })\`\n` +
+            `   Then re-run with the suggested \`cloneFrom\` value.\n\n` +
+            `2. Scaffold from a pattern template (no cloning needed):\n` +
+            `   \`generate_object(mode="scaffold", objectType="form", name="${name}", formPattern="${formPattern ?? 'SimpleList'}", dataSource="${tableList}")\``,
+        }],
+        isError: true,
+      };
     }
     if (cloneResult.removedControls.length > 0) {
       noteLines.push(`   ⚠️ Controls removed (bound to dropped fields): ${cloneResult.removedControls.join(', ')}`);
@@ -450,6 +626,11 @@ export async function handleGenerateSmartForm(
       dsTable: primaryDs?.table,
       caption: caption || label || finalName,
       gridFields,
+      fieldTypes,
+      linesDsName: linesTableResolved ? (linesDataSource || linesTableResolved) : undefined,
+      linesDsTable: linesTableResolved || undefined,
+      linesFields,
+      linesFieldTypes,
     });
 
     // Align the Design-level PatternVersion with the version this environment uses
@@ -493,7 +674,13 @@ export async function handleGenerateSmartForm(
     const patternInXml = xml.match(/<Pattern xmlns="">([^<]+)<\/Pattern>/)?.[1] ?? normalizedPattern;
     const stubDsName =
       xml.match(/<AxFormDataSource[^>]*>\s*<Name>([^<]+)<\/Name>/)?.[1] ?? primaryDs?.name ?? '';
-    const stubResult = injectMethodStubs(xml, methodStubsForPattern(patternInXml, stubDsName), stubDsName);
+    const stubLinesDsName = linesTableResolved ? (linesDataSource || linesTableResolved) : undefined;
+    const stubResult = injectMethodStubs(
+      xml,
+      methodStubsForPattern(patternInXml, stubDsName, stubLinesDsName),
+      stubDsName,
+      stubLinesDsName,
+    );
     xml = stubResult.xml;
     if (stubResult.injected.length > 0) {
       cloneNotes += `\n   Method stubs injected: ${stubResult.injected.join(', ')}`;
@@ -673,7 +860,7 @@ export async function handleGenerateSmartForm(
           cloneNotes,
           projectMessage,
           ``,
-          `⛔ DO NOT call \`d365fo_file(action="create")\` — the file is already written to disk.`,
+          `⛔ DO NOT call \`d365fo_file(action="create")\` — the file is already written to disk at the path above. Calling d365fo_file would create a DUPLICATE at a different path which causes build conflicts.`,
           `⛔ DO NOT call \`generate\` again — task is COMPLETE.`,
           ``,
           `Next steps for the user:`,

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -105,7 +105,10 @@ export const generateSmartTableTool: Tool = {
           '"platnost do" or "ValidTo" or "to date" → "ValidTo", ' +
           '"active" or "active flag" → "Active", ' +
           '"customer" or "customer account" → "CustAccount". ' +
-          'Example call: fieldsHint="AccountNum, Name, Description, ValidFrom, ValidTo"',
+          'Example call: fieldsHint="AccountNum, Name, Description, ValidFrom, ValidTo". ' +
+          '⚠️ EDT auto-suggestion is index-based: custom EDTs/enums created in the SAME SESSION are not yet in the ' +
+          'index and those fields will fall back to String255. Call update_symbol_index BEFORE scaffolding to ensure ' +
+          'the new custom EDTs are resolved correctly.',
       },
       primaryKeyFields: {
         type: 'array',
@@ -833,7 +836,7 @@ export async function handleGenerateSmartTable(
               edtWarningBlock,
               projectMessage,
               ``,
-              `⛔ DO NOT call \`d365fo_file(action="create")\` — the file is already written to disk.`,
+              `⛔ DO NOT call \`d365fo_file(action="create")\` — the file is already written to disk at the path above. Calling d365fo_file would create a DUPLICATE at a different path which causes build conflicts.`,
               `⛔ DO NOT call \`generate\` again — task is COMPLETE.`,
               ``,
               `Next steps for the user:`,
@@ -956,7 +959,7 @@ export async function handleGenerateSmartTable(
           edtWarningBlock,
           projectMessage,
           ``,
-          `⛔ DO NOT call \`d365fo_file(action="create")\` — the file is already written to disk.`,
+          `⛔ DO NOT call \`d365fo_file(action="create")\` — the file is already written to disk at the path above. Calling d365fo_file would create a DUPLICATE at a different path which causes build conflicts.`,
           `⛔ DO NOT call \`generate\` again — task is COMPLETE.`,
           ``,
           `Next steps for the user:`,

--- a/src/tools/getFormPatternSpec.ts
+++ b/src/tools/getFormPatternSpec.ts
@@ -265,6 +265,37 @@ export async function getFormPatternSpecTool(
     ...FORM_PATTERN_CATALOG.patterns.map((p) => p.xmlName),
     ...FORM_PATTERN_CATALOG.subPatterns.map((p) => p.xmlName),
   ];
+
+  // Detect common knowledge topics that look like pattern names so the model
+  // gets an actionable redirect instead of a generic unknown-pattern list.
+  const KNOWLEDGE_TOPIC_REDIRECTS: Record<string, string> = {
+    'number-sequence':   'number-sequences',
+    'number-sequences':  'number-sequences',
+    'numbersequence':    'number-sequences',
+    'security':          'security',
+    'security-access':   'security',
+    'coc':               'coc-authoring',
+    'coc-authoring':     'coc-authoring',
+    'sysoperation':      'sysoperation',
+    'data-entity':       'data-entities',
+    'data-entities':     'data-entities',
+    'workflow':          'workflow',
+    'select-statement':  'select-statement',
+  };
+  const knowledgeTopic = KNOWLEDGE_TOPIC_REDIRECTS[name.toLowerCase()];
+  if (knowledgeTopic) {
+    return {
+      isError: true,
+      content: [{
+        type: 'text',
+        text:
+          `❌ "${name}" is not a form pattern — it is a knowledge topic.\n\n` +
+          `Use get_knowledge instead:\n` +
+          `  get_knowledge(kind="knowledge", topic="${knowledgeTopic}")`,
+      }],
+    };
+  }
+
   return {
     isError: true,
     content: [{

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -115,6 +115,19 @@ export async function labelsTool(request: CallToolRequest, context: XppServerCon
   // can't accidentally clobber text via action="create".
   if (action === 'update') (rest as Record<string, unknown>).overwriteExisting = true;
 
+  // Param near-misses for search: the handler expects `query`, but agents commonly
+  // reach for searchText/text/q. Map them so the first call succeeds.
+  if (action === 'search') {
+    const r = rest as Record<string, unknown>;
+    if (r.query === undefined) {
+      const alt = r.searchText ?? r.text ?? r.q;
+      if (typeof alt === 'string') {
+        r.query = alt;
+        delete r.searchText; delete r.text; delete r.q;
+      }
+    }
+  }
+
   const subRequest: CallToolRequest = {
     method: 'tools/call',
     params: { name: dispatch.toolName, arguments: rest },

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs/promises';
 import path from 'path';
 import { parseStringPromise } from 'xml2js';
 import { getConfigManager, fallbackPackagePath, extractModelFromFilePath } from '../utils/configManager.js';
-import { isStandardModel } from '../utils/modelClassifier.js';
+import { isStandardModel, resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { resolveDbPathLocally } from '../utils/metadataResolver.js';
 import { assertWritePathAllowed } from '../utils/pathContainment.js';
@@ -25,6 +25,7 @@ import {
   bridgeAddEnumValue, bridgeModifyEnumValue, bridgeRemoveEnumValue,
   bridgeAddControl, bridgeAddDataSource,
   bridgeAddFieldModification, bridgeAddMenuItemToMenu,
+  bridgeRefreshProvider,
 } from '../bridge/index.js';
 import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
@@ -115,6 +116,91 @@ export function assertCleanXppSource(source: string | undefined, paramName: stri
   }
 }
 
+/** Strip X++ line/block/doc comments and string literals so their braces/parens
+ *  don't skew structural scans. Returns a same-ish-length cleaned string. */
+function stripXppCommentsAndStrings(s: string): string {
+  let out = '';
+  let i = 0;
+  while (i < s.length) {
+    const two = s.slice(i, i + 2);
+    if (two === '//') {                       // line comment (incl. /// doc comments)
+      const nl = s.indexOf('\n', i);
+      i = nl === -1 ? s.length : nl;
+      continue;
+    }
+    if (two === '/*') {                        // block comment
+      const end = s.indexOf('*/', i + 2);
+      i = end === -1 ? s.length : end + 2;
+      continue;
+    }
+    if (s[i] === '"') {                         // string literal
+      i++;
+      while (i < s.length && s[i] !== '"') { if (s[i] === '\\') i++; i++; }
+      i++;
+      out += '""';
+      continue;
+    }
+    out += s[i];
+    i++;
+  }
+  return out;
+}
+
+/** Count top-level X++ method bodies: a `{` opened at brace-depth 0 immediately
+ *  after a `)` (a method signature). Nested blocks (if/for/switch) are inside the
+ *  body (depth > 0) and a class wrapper opens after an identifier, so neither is
+ *  miscounted. */
+export function countTopLevelMethodBodies(source: string): number {
+  const cleaned = stripXppCommentsAndStrings(source);
+  let depth = 0;
+  let count = 0;
+  let prevSignificant = '';
+  for (const ch of cleaned) {
+    if (ch === '{') {
+      if (depth === 0 && prevSignificant === ')') count++;
+      depth++;
+    } else if (ch === '}') {
+      if (depth > 0) depth--;
+    }
+    if (!/\s/.test(ch)) prevSignificant = ch;
+  }
+  return count;
+}
+
+/**
+ * Reject an add-method payload that contains more than one method. Each add-method
+ * call emits a single <Method>; passing two methods drops the second outside the
+ * class scope and yields invalid X++ ("Unexpected token 'public' specified outside
+ * the scope of any class or model element"). Splitting into separate calls is the fix.
+ */
+export function assertSingleMethodSource(source: string | undefined): void {
+  if (!source) return;
+  const count = countTopLevelMethodBodies(source);
+  if (count > 1) {
+    throw new Error(
+      `⛔ add-method expects exactly ONE method, but ${count} method bodies were detected in the source.\n\n` +
+      `Each add-method call adds a single <Method> element. Passing multiple methods puts all but ` +
+      `the first OUTSIDE the class scope, producing invalid X++ ("Unexpected token 'public' specified ` +
+      `outside the scope of any class or model element").\n\n` +
+      `Add each method with its own add-method call — one method per call.`
+    );
+  }
+}
+
+/**
+ * Derive the method name from a full X++ method source: the identifier immediately
+ * before the first '(' of the signature, after stripping comments, strings and
+ * attribute blocks (e.g. [ExtensionOf(...)]). Lets add-method callers omit methodName
+ * when they already pass the complete source (e.g. "public static X find(...)").
+ * Returns null when no signature can be found.
+ */
+export function extractMethodNameFromSource(source: string | undefined): string | null {
+  if (!source) return null;
+  const cleaned = stripXppCommentsAndStrings(source).replace(/\[[^\]]*\]/g, ' ');
+  const m = cleaned.match(/\b([A-Za-z_]\w*)\s*\(/);
+  return m ? m[1] : null;
+}
+
 /**
  * Direct XML file-level replace-code fallback.
  * Used when the C# bridge fails or returns null for replace-code on forms/form-extensions
@@ -170,6 +256,59 @@ async function directXmlReplaceCode(
   }
 }
 
+/**
+ * Heuristic: does a bridge failure message indicate the C# provider could not
+ * resolve the target object (vs. a genuine operation error like "index already
+ * exists")? An unresolved object is the one failure worth a refresh+retry,
+ * because an object created this session may not be in the provider's
+ * startup-fixed metadata roots yet.
+ */
+export function isUnresolvedObjectError(message: string | undefined): boolean {
+  if (!message) return false;
+  // Content/operation failures that merely contain "not found" are NOT object
+  // resolution and must not trigger the refresh+retry or the "could not resolve"
+  // guidance: replace-code's "oldCode not found in <obj>.<method>", a missing
+  // method/field/index, etc. The object was resolved — only the snippet/member wasn't.
+  if (/\b(oldcode|new ?code|code|snippet|method|field|index|relation|element)\b[^.]*\bnot found/i.test(message)) {
+    return false;
+  }
+  // Genuine object-resolution failures: a quoted object name "'X' not found",
+  // or the explicit resolve/model phrases the bridge emits.
+  return /'[^']+'\s+not found|could not resolve|does not exist|not in (the )?(metadata )?model|cannot determine model/i.test(message);
+}
+
+/**
+ * Build the actionable "object could not be resolved" error for a modify
+ * operation. When `bridgeReported` is supplied it is included verbatim so the
+ * caller sees exactly what the C# bridge said rather than a generic guess.
+ */
+function unresolvedObjectError(
+  operation: string,
+  objectType: string,
+  objectName: string,
+  actualFilePath?: string,
+  bridgeReported?: string,
+): string {
+  return (
+    `Bridge operation '${operation}' could not resolve ${objectType} '${objectName}'.\n` +
+    (bridgeReported ? `Bridge reported: ${bridgeReported}\n` : '') +
+    `Most likely cause: the C# metadata bridge could not find '${objectName}' in its metadata model.\n` +
+    `This is typical right after creating an object in the same session — the bridge's metadata ` +
+    `roots are fixed at startup, so a file written this session may not be in its model.\n` +
+    `Auto-refresh was already attempted once and still failed.\n\n` +
+    `Reliable fallback (works for tables, forms, classes created this session):\n` +
+    `  Read ${objectName}.xml with get_object_info, add the ${operation.replace('add-', '')} ` +
+    `element directly to the XML, then re-write the whole file:\n` +
+    `  d365fo_file(action="create", overwrite=true, xmlContent="<complete updated XML>")\n\n` +
+    `Alternative — try in order:\n` +
+    `  1. update_symbol_index({ filePath: "<path to ${objectName}.xml>" })\n` +
+    `  2. Check D365FO_CUSTOM_PACKAGES_PATH points to the correct metadata folder.\n` +
+    `  3. Confirm ${objectName}.xml actually exists on disk.\n` +
+    (actualFilePath ? `Resolved file path: ${actualFilePath}\n` : '') +
+    `If none of these apply, the object may simply not exist or its name may be misspelled.`
+  );
+}
+
 const ModifyD365FileArgsSchema = z.object({
   objectType: z.enum([
     'class', 'table', 'form', 'enum', 'query', 'view', 'edt', 'data-entity', 'report',
@@ -180,7 +319,11 @@ const ModifyD365FileArgsSchema = z.object({
     'menu', 'menu-extension',
     'security-privilege', 'security-duty', 'security-role',
   ]).describe('Type of D365FO object'),
-  objectName: z.string().describe('Name of the object to modify'),
+  objectName: z.string().optional().describe(
+    'Name of the object to modify. Optional when filePath is provided — it is then ' +
+    'derived from the file basename (the bridge resolves objects by name, which the ' +
+    'file path already determines).'
+  ),
   operation: z.enum([
     'add-method', 'remove-method', 'replace-code',
     'add-field', 'modify-field', 'rename-field', 'replace-all-fields', 'remove-field',
@@ -450,6 +593,32 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
   try {
     const args = ModifyD365FileArgsSchema.parse(request.params.arguments);
 
+    // Decode XML entities in X++ payloads. An AI that copied entity-encoded code (an
+    // SSRS <Text> block, or escaped doc comments like "/// &lt;summary&gt;") sends
+    // &lt;/&gt;/&amp;/&quot;/&apos;; the serializer would otherwise write them literally
+    // into the source. No-op for clean X++ — literal <, >, && and " are not entities.
+    if (args.sourceCode) args.sourceCode = decodeXmlEntitiesFromXppSource(args.sourceCode);
+    if ((args as any).methodCode) (args as any).methodCode = decodeXmlEntitiesFromXppSource((args as any).methodCode);
+    if (args.newCode) args.newCode = decodeXmlEntitiesFromXppSource(args.newCode);
+    if (args.oldCode) args.oldCode = decodeXmlEntitiesFromXppSource(args.oldCode);
+
+    // objectName is optional when filePath is given — derive it from the file
+    // basename so callers don't have to pass the name redundantly (the bridge
+    // resolves objects by name, which an explicit filePath already determines).
+    if (!args.objectName) {
+      if (args.filePath) {
+        args.objectName = path.basename(args.filePath, '.xml');
+      } else {
+        return {
+          content: [{
+            type: 'text',
+            text: "❌ Provide 'objectName' — or 'filePath', from which the object name is derived.",
+          }],
+          isError: true,
+        };
+      }
+    }
+
     // Grounding enforcement: modifying an extension changes the behaviour of an
     // existing base object — when GROUNDING_ENFORCE=true the model must prove
     // (via prepare_change) that it inspected the real object first.
@@ -481,16 +650,34 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     assertCleanXppSource((args as any).methodCode, 'methodCode');
     assertCleanXppSource(args.newCode, 'newCode');
 
+    // add-method emits exactly one <Method>; reject a payload carrying multiple
+    // methods (the extras would land outside the class → invalid X++). Only for the
+    // method-adding operations — replace-code's newCode is a snippet, not a method.
+    if (['add-method', 'add-display-method', 'add-table-method'].includes(args.operation)) {
+      const methodSrc = args.sourceCode ?? (args as any).methodCode;
+      assertSingleMethodSource(methodSrc);
+      // Derive methodName from the source signature when omitted — the full method
+      // source already contains the name (e.g. "public static X find(...)" → "find").
+      if (!args.methodName) {
+        const derived = extractMethodNameFromSource(methodSrc);
+        if (derived) {
+          args.methodName = derived;
+          console.error(`[modify_d365fo_file] methodName omitted — derived '${derived}' from the source signature`);
+        }
+      }
+    }
+
     const { symbolIndex } = context;
-    const {
+    let {
       objectType,
-      objectName,
       operation,
       createBackup,
       modelName,
       workspacePath,
       filePath: explicitFilePath,
     } = args;
+    // Non-null: guaranteed set above (derived from filePath when omitted).
+    let objectName = args.objectName!;
 
     // ── Auto-resolve parentControl for add-control on form-extension ─────────
     // When `parentControl` is a fuzzy / lowercase string (e.g. "general"), look
@@ -669,6 +856,21 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       await createFileBackup(actualFilePath);
     }
 
+    // 3b. Derive the authoritative object name from the resolved file path.
+    //     The caller may pass objectName="RentEquipment" while the file on disk
+    //     is AslRentEquipment.xml (auto-prefixed at create time).  The C# bridge
+    //     resolves objects by name from its metadata model — if the name doesn't
+    //     match the file it will always return null, regardless of refreshes.
+    //     We use the XML filename (without extension) as the ground truth.
+    const fileBaseName = path.basename(actualFilePath, '.xml');
+    const bridgeObjectName = fileBaseName !== objectName ? fileBaseName : objectName;
+    if (bridgeObjectName !== objectName) {
+      console.error(
+        `[modify_d365fo_file] ℹ️  objectName "${objectName}" → resolved to "${bridgeObjectName}" from file basename`,
+      );
+      objectName = bridgeObjectName;
+    }
+
     // ── Bridge-only modify via IMetadataProvider.Update() ────────────────────
     // ALL modify operations go through the C# bridge. The bridge reads, modifies,
     // and writes via the official D365FO metadata API — no xml2js needed.
@@ -684,6 +886,12 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     }
 
     let bridgeResult: { success: boolean; message: string } | null = null;
+    let _bridgeRetried = false;
+    // Retry loop: on the first null result with all required params present,
+    // refresh the bridge provider (picks up objects created this session) and
+    // re-run the operation once. Max 1 auto-refresh retry (_bridgeRetried guard).
+    _bridgeRetry: do {
+      bridgeResult = null;
 
     switch (operation) {
       case 'add-method': {
@@ -741,6 +949,12 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             `\n\n> 🔧 Table method \`${gen.methodName}\` generated from ` +
             `tableMethodType="${(args as any).tableMethodType}".` +
             (gen.note ? `\n> ${gen.note}` : '');
+        }
+        // When caller supplies custom source (methodCode/sourceCode) + tableMethodType
+        // but omits methodName, the method name equals the tableMethodType value
+        // (find / exist / findByRecId / validateWrite / validateDelete / initValue).
+        if (!methodName && (args as any).tableMethodType && methodSource) {
+          methodName = (args as any).tableMethodType as string;
         }
         if (methodName && methodSource) {
           bridgeResult = await bridgeAddMethod(
@@ -845,11 +1059,19 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'add-index': {
         if ((args as any).indexName) {
+          // indexFields is documented (Zod + MCP schema) as [{ fieldName, direction? }],
+          // but the bridge's addIndex expects a flat string[] of field names. Map the
+          // objects to their fieldName here — passing the objects straight through makes
+          // the C# side deserialize [{fieldName:…}] into List<string>, which throws and
+          // surfaces as a null bridge result (misreported as "could not resolve table").
+          const indexFieldNames: string[] | undefined = Array.isArray((args as any).indexFields)
+            ? (args as any).indexFields.map((f: any) => (typeof f === 'string' ? f : f?.fieldName)).filter(Boolean)
+            : undefined;
           bridgeResult = await bridgeAddIndex(
             context.bridge,
             objectName,
             (args as any).indexName,
-            (args as any).indexFields,
+            indexFieldNames,
             (args as any).indexAllowDuplicates,
             (args as any).indexAlternateKey,
           );
@@ -868,12 +1090,24 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'add-relation': {
         if ((args as any).relationName && (args as any).relatedTable) {
+          // relationConstraints is documented as [{ fieldName, relatedFieldName }], but the
+          // bridge/C# WriteRelationConstraint deserializes the JSON keys { field, relatedField }.
+          // Without this remap the keys don't match: C# sees no `field`/`relatedField`, leaves
+          // both null, and silently writes a relation with EMPTY constraints (no hard error —
+          // the corruption only surfaces at compile time). Map the field names explicitly.
+          const constraints: Array<{ field?: string; relatedField?: string }> | undefined =
+            Array.isArray((args as any).relationConstraints)
+              ? (args as any).relationConstraints.map((c: any) => ({
+                  field: c?.field ?? c?.fieldName,
+                  relatedField: c?.relatedField ?? c?.relatedFieldName,
+                }))
+              : undefined;
           bridgeResult = await bridgeAddRelation(
             context.bridge,
             objectName,
             (args as any).relationName,
             (args as any).relatedTable,
-            (args as any).relationConstraints,
+            constraints,
           );
         }
         break;
@@ -1139,6 +1373,20 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         (args as any)[p] !== undefined || (aliases[p] ?? []).some(a => (args as any)[a] !== undefined);
       const missing = required.filter(p => !isProvided(p));
 
+      // Auto-refresh retry: all required params are present but bridge returned
+      // null — the object was likely written this session and isn't in the
+      // bridge's metadata model yet (roots are fixed at startup). Refresh once
+      // and re-run the operation. Afterwards the normal error path takes over.
+      if (missing.length === 0 && !_bridgeRetried && context.bridge) {
+        console.error(
+          `[modify_d365fo_file] ⚠️ '${operation}' on '${objectName}' returned null — ` +
+          `refreshing bridge provider and retrying once`,
+        );
+        try { await bridgeRefreshProvider(context.bridge); } catch { /* best-effort */ }
+        _bridgeRetried = true;
+        continue _bridgeRetry;
+      }
+
       // Two distinct causes produce a null bridge result; pick the message that
       // matches reality instead of always blaming missing parameters.
       if (missing.length > 0) {
@@ -1151,29 +1399,43 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         );
       }
 
-      // All required params were supplied, yet the bridge returned null. The
-      // cause is object resolution: the C# bridge could not find '${objectName}'
-      // in its metadata model. This is common right after creating the object —
-      // the bridge resolves objects through fixed roots configured at startup
-      // and does not see files written since, so a just-created object is not
-      // yet in its model.
-      throw new Error(
-        `Bridge operation '${operation}' returned null even though all required parameters ` +
-        `(${required.join(', ') || 'none'}) were provided.\n` +
-        `Most likely cause: the C# metadata bridge could not resolve ${objectType} '${objectName}'.\n` +
-        `This is typical right after creating an object — the bridge's metadata roots are fixed at ` +
-        `startup, so an object written this session may not be in its model yet.\n` +
-        `Try, in order:\n` +
-        `  1. Refresh the bridge's view of the new object: update_symbol_index({ filePath: "<path to ${objectName}.xml>" }).\n` +
-        `  2. Ensure the model is under the bridge's roots — set context.customPackagesPath / ` +
-        `D365FO_CUSTOM_PACKAGES_PATH to the metadata folder, or pass an explicit filePath to this call.\n` +
-        `  3. Confirm ${objectName}.xml actually exists on disk under those roots.\n` +
-        (actualFilePath ? `Resolved file path: ${actualFilePath}\n` : '') +
-        `If none of these apply, the object may simply not exist or its name may be misspelled.`
-      );
+      // All required params were supplied, yet the bridge returned null (it never
+      // attempted the op — e.g. provider not ready). Surface the actionable
+      // same-session resolution guidance.
+      throw new Error(unresolvedObjectError(operation, objectType, objectName, actualFilePath));
     }
-    if (!bridgeResult.success) {
-      throw new Error(`Bridge operation '${operation}' failed: ${bridgeResult.message}`);
+
+    // Bridge executed but reported failure. A resolution failure (object created
+    // this session, not yet in the provider's fixed-root model) gets the same
+    // one-shot refresh+retry the null path gets; any other failure falls through
+    // to the real-message throw below — no longer masked as a generic guess.
+    if (
+      !bridgeResult.success &&
+      !_bridgeRetried &&
+      context.bridge &&
+      isUnresolvedObjectError(bridgeResult.message)
+    ) {
+      console.error(
+        `[modify_d365fo_file] ⚠️ '${operation}' on '${objectName}' failed (${bridgeResult.message}) — ` +
+        `refreshing bridge provider and retrying once`,
+      );
+      try { await bridgeRefreshProvider(context.bridge); } catch { /* best-effort */ }
+      _bridgeRetried = true;
+      continue _bridgeRetry;
+    }
+    break _bridgeRetry;
+    } while (true); // end of retry loop
+
+    if (!bridgeResult!.success) {
+      // Surface the real bridge error. For an object-resolution failure keep the
+      // actionable same-session fallback guidance, now including exactly what the
+      // bridge reported instead of a generic "could not resolve" guess.
+      if (isUnresolvedObjectError(bridgeResult!.message)) {
+        throw new Error(
+          unresolvedObjectError(operation, objectType, objectName, actualFilePath, bridgeResult!.message),
+        );
+      }
+      throw new Error(`Bridge operation '${operation}' failed: ${bridgeResult!.message}`);
     }
 
     console.error(`[modify_d365fo_file] ✅ Bridge ${operation}: ${bridgeResult.message}`);
@@ -1279,6 +1541,36 @@ async function findD365File(
     return explicitFilePath;
   }
 
+  // Resolve by the given name first; if that misses, retry once with the model
+  // prefix applied. create_d365fo_file auto-prefixes new object names (e.g.
+  // "RentEquipmentTable" → "AslRentEquipmentTable"), so a modify call with the bare
+  // name would otherwise fail to locate the file. The bridge object name is then
+  // re-derived from the resolved file's basename, so the prefixed name flows through.
+  const direct = await resolveD365FileByName(symbolIndex, objectType, objectName, modelName, packagePath);
+  if (direct) return direct;
+
+  const prefix = resolveObjectPrefix(modelName || getConfigManager().getModelName() || '');
+  if (prefix && !objectType.endsWith('-extension')) {
+    const prefixed = applyObjectPrefix(objectName, prefix);
+    if (prefixed && prefixed.toLowerCase() !== objectName.toLowerCase()) {
+      const viaPrefixed = await resolveD365FileByName(symbolIndex, objectType, prefixed, modelName, packagePath);
+      if (viaPrefixed) {
+        console.error(`[modifyD365File] '${objectName}' not found — resolved via prefixed name '${prefixed}'`);
+        return viaPrefixed;
+      }
+    }
+  }
+  return null;
+}
+
+/** Resolve a D365FO file by an exact object name (symbol DB, then filesystem). */
+async function resolveD365FileByName(
+  symbolIndex: any,
+  objectType: string,
+  objectName: string,
+  modelName?: string,
+  packagePath?: string,
+): Promise<string | null> {
   // Symbol DB only indexes a subset of types — for the rest go straight to filesystem.
   const dbTypeMap: Record<string, string> = {
     class: 'class',
@@ -1750,13 +2042,31 @@ function bufferVarName(tableName: string): string {
  * find/exist signatures use the correct parameter type. The field's `signature`
  * column stores its EDT name. Returns null when the field is not indexed.
  */
+/** Metadata base-type keywords (the stripped i:type, e.g. AxTableFieldString → "String").
+ *  These are NOT valid X++ parameter types — a field's signature in the index stores
+ *  the base type, not its EDT, so a resolved value matching one of these must be
+ *  discarded in favour of the field name (D365 fields are conventionally named after
+ *  their EDT, e.g. field ItemId uses EDT ItemId). */
+const METADATA_BASE_TYPE_KEYWORDS = new Set([
+  'string', 'integer', 'int', 'int64', 'real', 'date', 'time', 'datetime',
+  'utcdatetime', 'guid', 'container', 'enum', 'boolean', 'memo',
+]);
+
+function isMetadataBaseTypeKeyword(t: string): boolean {
+  return METADATA_BASE_TYPE_KEYWORDS.has(t.trim().toLowerCase());
+}
+
 function resolveFieldEdt(tableName: string, fieldName: string, db: any): string | null {
   try {
     const row = db.prepare(
       `SELECT signature FROM symbols WHERE type = 'field' AND parent_name = ? COLLATE NOCASE AND name = ? COLLATE NOCASE LIMIT 1`
     ).get(tableName, fieldName) as { signature: string | null } | undefined;
     const sig = row?.signature?.trim();
-    return sig ? sig : null;
+    // The index stores the field's BASE TYPE (e.g. "String"), not its EDT. A base-type
+    // keyword is not a usable X++ parameter type, so treat it as unresolved — the caller
+    // then falls back to the field name, which is conventionally the EDT.
+    if (!sig || isMetadataBaseTypeKeyword(sig)) return null;
+    return sig;
   } catch {
     return null;
   }

--- a/src/tools/objectPatterns.ts
+++ b/src/tools/objectPatterns.ts
@@ -22,9 +22,9 @@ function err(text: string) {
 
 export async function objectPatternsTool(request: CallToolRequest, context: XppServerContext) {
   const a = (request.params.arguments ?? {}) as Record<string, any>;
-  // Accept `patternType` / `type` as aliases for the `domain` discriminator —
-  // agents frequently reach for these names.
-  let domain = (a.domain ?? a.patternType ?? a.type) as string | undefined;
+  // Accept `patternType` / `type` / `objectType` as aliases for the `domain`
+  // discriminator — agents frequently reach for these names.
+  let domain = (a.domain ?? a.patternType ?? a.type ?? a.objectType) as string | undefined;
 
   // Infer the discriminator from form/table-specific params when omitted.
   if (domain !== 'table' && domain !== 'form') {
@@ -56,10 +56,14 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
     return formPatternTool(formRequest, context);
   }
 
+  const got = a.domain ?? a.patternType ?? a.type ?? a.objectType ?? '';
   return err(
-    `object_patterns: could not determine domain (got domain/patternType="${a.domain ?? a.patternType ?? a.type ?? ''}"). ` +
-    `Pass domain="table" (table field/index/relation patterns) or domain="form" (form-pattern toolkit; with action=analyze|spec|validate). ` +
-    `Domain is also inferred from action/pattern/xml/formName (→ form) or tableGroup (→ table).`,
+    `object_patterns: could not determine domain (got domain/objectType="${got}"). ` +
+    `This tool only covers table and form patterns — pass domain="table" (table field/index/relation patterns) ` +
+    `or domain="form" (form-pattern toolkit; with action=analyze|spec|validate). ` +
+    `Domain is also inferred from action/pattern/xml/formName (→ form) or tableGroup (→ table).\n\n` +
+    `If you were after a feature/concept (e.g. "number-sequence", SysOperation, RunBase, data events), ` +
+    `that is a knowledge topic — use get_knowledge(topic="${typeof got === 'string' && got ? got : '<topic>'}") instead.`,
   );
 }
 

--- a/src/tools/prepare.ts
+++ b/src/tools/prepare.ts
@@ -36,8 +36,13 @@ function subRequest(name: string, args: Record<string, unknown>): CallToolReques
 export async function prepareTool(request: CallToolRequest, context: XppServerContext) {
   const parsed = PrepareArgsSchema.safeParse(request.params.arguments ?? {});
   if (!parsed.success) {
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+    const modeArg = args['mode'];
+    const modeMsg = modeArg === undefined
+      ? `❌ prepare: missing required parameter "mode".\n\nUsage:\n  prepare(mode="change", objectName="...", methodName="...")  — extend/modify an existing object\n  prepare(mode="create", objectName="...", objectType="...")   — plan a new object`
+      : `❌ prepare: invalid mode "${modeArg}". Valid values: "change", "create".\n\n  prepare(mode="change", objectName="...", methodName="...")  — extend/modify an existing object\n  prepare(mode="create", objectName="...", objectType="...")   — plan a new object`;
     return {
-      content: [{ type: 'text', text: `❌ prepare: invalid arguments — ${parsed.error.message}` }],
+      content: [{ type: 'text', text: modeMsg }],
       isError: true,
     };
   }

--- a/src/tools/xppKnowledge.ts
+++ b/src/tools/xppKnowledge.ts
@@ -613,26 +613,69 @@ class MyReportDP extends SRSReportDataProviderBase
       'Number sequences generate unique, configurable identifiers for master data and transactions. ' +
       'They support scope (shared, company, legal entity) and format segments.',
     rules: [
-      'Define in NumberSequenceModuleXxx class (e.g. NumberSequenceModuleCustPaym)',
-      'loadModule() method: register each number sequence reference with its EDT, label, and scope',
-      'Use NumberSeqFormHandler on forms for auto-number behavior',
-      'Continuous sequences: no gaps allowed — performance impact, use only when legally required',
-      'Non-continuous (default): allows gaps — faster, use for internal IDs',
-      'Call NumberSeq::newGetNum() to fetch next number at runtime',
-      'Scope: DataArea (per-company), Global (cross-company), OperatingUnit',
-      'Format: {Company}-{NumberSequence:#######} — configurable in Number sequences form',
+      'Module class EXTENDS NumberSeqApplicationModule — exact name. ❌ NOT "NumberSequenceApplicationModule" (that class does not exist).',
+      'It is a subclass (extends), so override loadModule() and call super() at the top. ❌ NOT next() — next() is ONLY for [ExtensionOf] CoC classes, never for an extends subclass.',
+      'loadModule() registers each reference with NumberSeqDatatype::construct(), then parmDatatypeId(extendedTypeNum(MyEdt)) + parmWizardIsContinuous/parmWizardIsManual/parmWizardIsChangeDownAllowed/… , then this.create(datatype). ❌ Do NOT assign fields on a NumberSeqReference/NumberSequenceReference buffer (DataTypeId, WizardContinuous, AllowManual… are parm*() methods on NumberSeqDatatype, NOT table fields) and there is NO this.addModuleEntry().',
+      'Override numberSeqModule() to return your NumberSeqModule enum value.',
+      'A new module class is NOT auto-loaded: extend the NumberSeqModule enum and register the module via an event handler on NumberSeqGlobal (or CoC) so loadModule() runs.',
+      'Form auto-numbering: NumberSeqFormHandler::newForm(<ParametersTable>::numRef<Id>().NumberSequenceId, element, <datasource>, fieldNum(<Table>, <Id>)). First arg is a RefRecId via the .NumberSequenceId field. ❌ NOT .NumberSequence and ❌ NOT a string code.',
+      'Runtime fetch: NumberSeqReference::findReference(extendedTypeNum(MyId)) → NumberSeq::newGetNum(ref) → .num(); call .abort() to release on rollback.',
+      'Continuous (no gaps): perf cost — only when legally required. Non-continuous (default) allows gaps, faster for internal IDs.',
+      'Scope: DataArea (per-company), Global (cross-company), OperatingUnit.',
+      'Verify exact parm*() names against the SDK with get_object_info(objectType="class", name="NumberSeqDatatype") before relying on them.',
     ],
     examples: [
       {
-        label: 'Fetching next number',
+        label: 'Module class — register the reference in loadModule() (correct API)',
+        code: `public class NumberSeqModuleAslRent extends NumberSeqApplicationModule
+{
+    protected void loadModule()
+    {
+        NumberSeqDatatype datatype = NumberSeqDatatype::construct();
+        datatype.parmDatatypeId(extendedTypeNum(AslRentEquipmentId));
+        datatype.parmReferenceHelp(literalStr("Equipment ID"));
+        datatype.parmWizardIsContinuous(false);
+        datatype.parmWizardIsManual(NoYes::No);
+        datatype.parmWizardIsChangeDownAllowed(NoYes::Yes);
+        datatype.parmWizardIsChangeUpAllowed(NoYes::Yes);
+        datatype.parmWizardHighest(0);
+        datatype.parmSortField(1);
+        datatype.addParameterType(NumberSeqParameterType::DataArea, true, false);
+        this.create(datatype);            // NOT a NumberSeqReference field assignment
+    }
+
+    public NumberSeqModule numberSeqModule()
+    {
+        return NumberSeqModule::AslRent;  // your NumberSeqModule enum value
+    }
+}`,
+      },
+      {
+        label: 'Form auto-numbering handler',
+        code: `NumberSeqFormHandler numberSeqFormHandler;   // form member
+
+public NumberSeqFormHandler numberSeqFormHandler()
+{
+    if (!numberSeqFormHandler)
+    {
+        numberSeqFormHandler = NumberSeqFormHandler::newForm(
+            AslRentParameters::numRefAslRentEquipmentId().NumberSequenceId, // RefRecId, not a string
+            element,
+            AslRentEquipmentTable_ds,
+            fieldNum(AslRentEquipmentTable, AslRentEquipmentId));
+    }
+    return numberSeqFormHandler;
+}`,
+      },
+      {
+        label: 'Fetching next number at runtime',
         code: `NumberSequenceReference numSeqRef =
-    NumberSeqReference::findReference(
-        extendedTypeNum(MyDocumentId));
+    NumberSeqReference::findReference(extendedTypeNum(AslRentEquipmentId));
 
 NumberSeq numSeq = NumberSeq::newGetNum(numSeqRef);
-MyDocumentId newId = numSeq.num();
+AslRentEquipmentId newId = numSeq.num();
 
-// If insert fails, release the number:
+// If the insert is rolled back, release the number:
 // numSeq.abort();`,
       },
     ],

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -11,6 +11,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { autoDetectD365Project, detectD365Project, scanAllD365Projects, extractModelNameFromProject, detectGitBranch, isMicrosoftDemoModel, type D365ProjectInfo } from './workspaceDetector.js';
 import { registerCustomModel, getCustomModels } from './modelClassifier.js';
 import { XppConfigProvider, type XppEnvironmentConfig } from './xppConfigProvider.js';
+import { debugLog } from './logger.js';
 
 export interface McpContext {
   workspacePath?: string;
@@ -105,27 +106,29 @@ class ConfigManager {
     const solutionsRoot = process.env.D365FO_SOLUTIONS_PATH;
     if (!solutionsRoot || this.allDetectedProjectsReady) return;
 
-    console.error(`[ConfigManager] 🔍 Eager project scan starting: ${solutionsRoot}`);
+    debugLog(`[ConfigManager] 🔍 Eager project scan starting: ${solutionsRoot}`);
     this.allDetectedProjectsReady = (async () => {
       try {
         const all = await scanAllD365Projects(solutionsRoot);
         if (all.length > 0) {
           this.allDetectedProjects = all;
-          // Compact summary: group by model, then list counts + first project path per model
+          // Compact summary: group by model, then list counts + first project path per model.
+          // Operational/info only — gated behind DEBUG_LOGGING so it doesn't surface as
+          // dozens of "[server stderr]" warnings in the MCP client on every startup.
           const byModel = new Map<string, string[]>();
           for (const p of all) {
             const list = byModel.get(p.modelName) ?? [];
             if (p.projectPath) list.push(p.projectPath);
             byModel.set(p.modelName, list);
           }
-          console.error(
+          debugLog(
             `[ConfigManager] 🔍 Eager scan complete: ${all.length} project(s) across ${byModel.size} model(s)`
           );
           for (const [model, paths] of byModel) {
-            console.error(`   ${model}: ${paths.length} project(s)  (first: ${paths[0]})`);
+            debugLog(`   ${model}: ${paths.length} project(s)  (first: ${paths[0]})`);
           }
         } else {
-          console.error(`[ConfigManager] 🔍 Eager scan: no projects found under ${solutionsRoot}`);
+          debugLog(`[ConfigManager] 🔍 Eager scan: no projects found under ${solutionsRoot}`);
         }
       } catch (err) {
         console.error(`[ConfigManager] 🔍 Eager scan failed:`, err);
@@ -200,7 +203,11 @@ class ConfigManager {
     // discard this (now stale) result so we never overwrite a more recent correct answer.
     const isStale = generation !== undefined && generation < this.detectionGeneration;
     if (isStale) {
-      console.error(`[ConfigManager] ⚠️ Stale workspace detection (gen ${generation} < current ${this.detectionGeneration}) — skipping project assignment`);
+      // Benign race-guard: a newer detection (e.g. roots/list arriving after the
+      // initial workspace seed) superseded this one, so we discard the stale result.
+      // Expected during normal startup — gated behind DEBUG_LOGGING so it doesn't
+      // surface as a client-facing warning.
+      debugLog(`[ConfigManager] ⚠️ Stale workspace detection (gen ${generation} < current ${this.detectionGeneration}) — skipping project assignment`);
       // Do NOT return early: D365FO_SOLUTIONS_PATH scan below must still run so
       // that allDetectedProjects is populated for future matchProjectForWorkspace calls.
     } else if (detectedProject) {

--- a/src/utils/fieldControlTypes.ts
+++ b/src/utils/fieldControlTypes.ts
@@ -1,0 +1,108 @@
+/**
+ * Field type → form control type resolution.
+ *
+ * The indexed `symbols` table stores a uniform "String" signature for every
+ * field, so it cannot tell an enum from a date from a real. To emit the correct
+ * AxForm control for each field (ComboBox for enums, Date for dates, …) we read
+ * the field's real `i:type` straight from the table's AOT XML — which every
+ * indexed field row points at via its `file_path`.
+ *
+ * Mapping is driven by the field's AxTableField i:type (reliable, present on
+ * every field) rather than the EDT name, so it works for custom EDTs too.
+ */
+
+import fs from 'fs';
+
+export interface ControlTypeInfo {
+  /** AxForm control i:type attribute, e.g. 'AxFormComboBoxControl' */
+  iType: string;
+  /** <Type> element value, e.g. 'ComboBox' */
+  typeValue: string;
+}
+
+/** Fallback when the field type is unknown — a plain string control is always valid. */
+export const DEFAULT_CONTROL: ControlTypeInfo = {
+  iType: 'AxFormStringControl',
+  typeValue: 'String',
+};
+
+/** AxTableField i:type → AxForm control (enums handled separately in {@link controlForTableField}). */
+const TABLE_FIELD_TO_CONTROL: Record<string, ControlTypeInfo> = {
+  AxTableFieldString: { iType: 'AxFormStringControl', typeValue: 'String' },
+  AxTableFieldMemo: { iType: 'AxFormStringControl', typeValue: 'String' },
+  AxTableFieldInt: { iType: 'AxFormIntControl', typeValue: 'Integer' },
+  AxTableFieldInt64: { iType: 'AxFormInt64Control', typeValue: 'Int64' },
+  AxTableFieldReal: { iType: 'AxFormRealControl', typeValue: 'Real' },
+  AxTableFieldDate: { iType: 'AxFormDateControl', typeValue: 'Date' },
+  AxTableFieldUtcDateTime: { iType: 'AxFormDateTimeControl', typeValue: 'DateTime' },
+  AxTableFieldTime: { iType: 'AxFormTimeControl', typeValue: 'Time' },
+  AxTableFieldGuid: { iType: 'AxFormGuidControl', typeValue: 'Guid' },
+};
+
+/**
+ * Resolve the form control for a table field, given its AxTableField i:type and
+ * (for enums) the bound enum name. NoYes enums become a CheckBox; every other
+ * enum a ComboBox — matching how shipped forms render them.
+ */
+export function controlForTableField(tableFieldIType: string, enumType?: string): ControlTypeInfo {
+  if (tableFieldIType === 'AxTableFieldEnum') {
+    if (enumType && enumType.trim().toLowerCase() === 'noyes') {
+      return { iType: 'AxFormCheckBoxControl', typeValue: 'CheckBox' };
+    }
+    return { iType: 'AxFormComboBoxControl', typeValue: 'ComboBox' };
+  }
+  return TABLE_FIELD_TO_CONTROL[tableFieldIType] ?? DEFAULT_CONTROL;
+}
+
+/** field name (lower-cased) → resolved control type */
+export type FieldControlMap = Map<string, ControlTypeInfo>;
+
+/**
+ * Parse a table's AOT XML into a field→control-type map. Returns an empty map on
+ * any failure (missing file, parse issue) — callers fall back to String controls.
+ */
+export function parseTableFieldControls(tableXml: string): FieldControlMap {
+  const map: FieldControlMap = new Map();
+  // Each <AxTableField … i:type="AxTableFieldXxx"> … </AxTableField> block.
+  // [^>]* spans the (possibly multi-line) opening tag up to its '>'.
+  const fieldRe = /<AxTableField\b[^>]*?i:type="(AxTableField\w+)"[^>]*>([\s\S]*?)<\/AxTableField>/g;
+  let m: RegExpExecArray | null;
+  while ((m = fieldRe.exec(tableXml)) !== null) {
+    const iType = m[1];
+    const body = m[2];
+    const name = body.match(/<Name>([^<]+)<\/Name>/)?.[1]?.trim();
+    if (!name) continue;
+    const enumType = body.match(/<EnumType>([^<]+)<\/EnumType>/)?.[1]?.trim();
+    map.set(name.toLowerCase(), controlForTableField(iType, enumType));
+  }
+  return map;
+}
+
+/**
+ * Build a field→control-type map for a table by locating its AOT XML through the
+ * symbol index (any field row of the table carries the table's `file_path`).
+ *
+ * @param db   read-only better-sqlite3 handle (symbolIndex.getReadDb())
+ * @param table table name
+ */
+export function getFieldControlMap(db: any, table: string): FieldControlMap {
+  try {
+    const row = db
+      .prepare(
+        `SELECT file_path FROM symbols
+         WHERE type = 'field' AND parent_name = ? COLLATE NOCASE
+           AND file_path IS NOT NULL AND file_path != ''
+         LIMIT 1`,
+      )
+      .get(table) as { file_path?: string } | undefined;
+    if (!row?.file_path || !fs.existsSync(row.file_path)) return new Map();
+    return parseTableFieldControls(fs.readFileSync(row.file_path, 'utf-8'));
+  } catch {
+    return new Map();
+  }
+}
+
+/** Control type for a single field from a (possibly undefined) map, defaulting to String. */
+export function controlForField(field: string, types?: FieldControlMap): ControlTypeInfo {
+  return types?.get(field.toLowerCase()) ?? DEFAULT_CONTROL;
+}

--- a/src/utils/formPatternTemplates.ts
+++ b/src/utils/formPatternTemplates.ts
@@ -14,6 +14,8 @@
  *   Lookup            → SysLanguageLookup.xml (ApplicationPlatform)
  */
 
+import { type FieldControlMap, controlForField } from './fieldControlTypes.js';
+
 export interface FormTemplateOptions {
   /** Form name (also used for classDeclaration) */
   formName: string;
@@ -31,6 +33,16 @@ export interface FormTemplateOptions {
   linesDsName?: string;
   /** Lines datasource table name for DetailsTransaction */
   linesDsTable?: string;
+  /** Field names to show in the lines grid (DetailsTransaction) */
+  linesFields?: string[];
+  /**
+   * Field → control-type map for the primary table. When provided, field
+   * controls render with the correct type (ComboBox for enums, Date for dates,
+   * …) instead of defaulting every field to a string control.
+   */
+  fieldTypes?: FieldControlMap;
+  /** Field → control-type map for the lines table (DetailsTransaction). */
+  linesFieldTypes?: FieldControlMap;
 }
 
 /** Supported top-level D365FO form patterns */
@@ -46,6 +58,35 @@ export type FormPattern =
   | 'Workspace';
 
 export class FormPatternTemplates {
+
+  /**
+   * Render a single field input control with the correct control type.
+   *
+   * `indent` is the tab string for the opening `<AxFormControl>` line; child
+   * elements are emitted one tab deeper and the `i:type` attribute two tabs
+   * deeper, matching the surrounding AOT layout. The control type is resolved
+   * from `types` (enum→ComboBox, date→Date, …); unknown fields fall back to a
+   * string control.
+   */
+  static fieldControl(
+    field: string,
+    dsName: string,
+    indent: string,
+    namePrefix = '',
+    types?: FieldControlMap,
+  ): string {
+    const ctl = controlForField(field, types);
+    return (
+      `${indent}<AxFormControl xmlns=""\n` +
+      `${indent}\t\ti:type="${ctl.iType}">\n` +
+      `${indent}\t<Name>${namePrefix}${field}</Name>\n` +
+      `${indent}\t<Type>${ctl.typeValue}</Type>\n` +
+      `${indent}\t<FormControlExtension\n${indent}\t\ti:nil="true" />\n` +
+      `${indent}\t<DataField>${field}</DataField>\n` +
+      `${indent}\t<DataSource>${dsName}</DataSource>\n` +
+      `${indent}</AxFormControl>\n`
+    );
+  }
 
   // ---------------------------------------------------------------------------
   // SimpleList  (v1.1)
@@ -63,14 +104,7 @@ export class FormPatternTemplates {
     const defaultCol = gridFields.length > 0 ? `Grid_${gridFields[0]}` : `Grid_${dsName}`;
 
     const fieldControls = gridFields.map(f =>
-      `\t\t\t\t\t<AxFormControl xmlns=""\n` +
-      `\t\t\t\t\t\t\ti:type="AxFormStringControl">\n` +
-      `\t\t\t\t\t\t<Name>Grid_${f}</Name>\n` +
-      `\t\t\t\t\t\t<Type>String</Type>\n` +
-      `\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\ti:nil="true" />\n` +
-      `\t\t\t\t\t\t<DataField>${f}</DataField>\n` +
-      `\t\t\t\t\t\t<DataSource>${dsName}</DataSource>\n` +
-      `\t\t\t\t\t</AxFormControl>\n`
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t', 'Grid_', opt.fieldTypes)
     ).join('');
 
     const dsFields = gridFields.length > 0
@@ -223,25 +257,18 @@ ${fieldControls}\t\t\t\t</Controls>
     const defaultCol = gridFields.length > 0 ? `Grid_${gridFields[0]}` : `Grid_${dsName}`;
 
     const listFieldControls = gridFields.slice(0, 3).map(f =>
-      `\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n` +
-      `\t\t\t\t\t\t\t\t\t\ti:type="AxFormStringControl">\n` +
-      `\t\t\t\t\t\t\t\t\t<Name>Grid_${f}</Name>\n` +
-      `\t\t\t\t\t\t\t\t\t<Type>String</Type>\n` +
-      `\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
-      `\t\t\t\t\t\t\t\t\t<DataField>${f}</DataField>\n` +
-      `\t\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>\n` +
-      `\t\t\t\t\t\t\t\t</AxFormControl>\n`
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t', 'Grid_', opt.fieldTypes)
     ).join('');
 
     const detailFieldControls = gridFields.map(f =>
-      `\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormStringControl">\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<Name>Overview_${f}</Name>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<Type>String</Type>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<DataField>${f}</DataField>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>\n` +
-      `\t\t\t\t\t\t\t\t\t\t</AxFormControl>\n`
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t\t\t', 'Overview_', opt.fieldTypes)
+    ).join('');
+
+    // FastTab page fields: the Tab's FieldsFieldGroups page must hold real
+    // controls — an empty group does not qualify as a "Details Tab Page" and
+    // xppc rejects the Tab as missing that required child.
+    const tabFieldControls = gridFields.map(f =>
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t\t', 'Tab_', opt.fieldTypes)
     ).join('');
 
     return `<?xml version="1.0" encoding="utf-8"?>
@@ -309,14 +336,14 @@ ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormGroupControl">
 \t\t\t\t<Name>GridContainer</Name>
-\t\t\t\t<Pattern>SidePanel</Pattern>
-\t\t\t\t<PatternVersion>1.0</PatternVersion>
+\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
 \t\t\t\t<Type>Group</Type>
 \t\t\t\t<FormControlExtension
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
 \t\t\t\t\t<AxFormControl>
 \t\t\t\t\t\t<Name>QuickFilterControl</Name>
+\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t<FormControlExtension>
 \t\t\t\t\t\t\t<Name>QuickFilterControl</Name>
 \t\t\t\t\t\t\t<ExtensionComponents />
@@ -341,78 +368,80 @@ ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\ti:type="AxFormGridControl">
 \t\t\t\t\t\t<Name>Grid</Name>
+\t\t\t\t\t\t<AllowEdit>No</AllowEdit>
 \t\t\t\t\t\t<Type>Grid</Type>
+\t\t\t\t\t\t<WidthMode>SizeToContent</WidthMode>
 \t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t<Controls>
 ${listFieldControls}\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<AlternateRowShading>No</AlternateRowShading>
 \t\t\t\t\t\t<DataSource>${dsName}</DataSource>
 \t\t\t\t\t\t<GridLinesStyle>Vertical</GridLinesStyle>
+\t\t\t\t\t\t<MultiSelect>No</MultiSelect>
+\t\t\t\t\t\t<ShowRowLabels>No</ShowRowLabels>
 \t\t\t\t\t\t<Style>List</Style>
 \t\t\t\t\t</AxFormControl>
 \t\t\t\t</Controls>
+\t\t\t\t<FrameType>None</FrameType>
 \t\t\t\t<Style>SidePanel</Style>
 \t\t\t</AxFormControl>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t<Name>DetailsGroup</Name>
+\t\t\t\t<Name>DetailsHeader</Name>
+\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
+\t\t\t\t<PatternVersion>1.1</PatternVersion>
 \t\t\t\t<Type>Group</Type>
+\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t<FormControlExtension
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
 \t\t\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\t\t\ti:type="AxFormTabControl">
-\t\t\t\t\t\t<Name>Tab</Name>
-\t\t\t\t\t\t<Type>Tab</Type>
+\t\t\t\t\t\t\ti:type="AxFormGroupControl">
+\t\t\t\t\t\t<Name>Overview</Name>
+\t\t\t\t\t\t<Type>Group</Type>
+\t\t\t\t\t\t<DataGroup>Overview</DataGroup>
+\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t<Controls>
+${detailFieldControls}\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<FrameType>None</FrameType>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t</Controls>
+\t\t\t\t<ColumnsMode>Fill</ColumnsMode>
+\t\t\t\t<FrameType>None</FrameType>
+\t\t\t</AxFormControl>
+\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\ti:type="AxFormTabControl">
+\t\t\t\t<Name>Tab</Name>
+\t\t\t\t<Type>Tab</Type>
+\t\t\t\t<FormControlExtension
+\t\t\t\t\ti:nil="true" />
+\t\t\t\t<Controls>
+\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t<Name>TabPageGeneral</Name>
+\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
+\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t<Type>TabPage</Type>
 \t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t<Controls>
 \t\t\t\t\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
-\t\t\t\t\t\t\t\t<Name>TabPageOverview</Name>
-\t\t\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
-\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
-\t\t\t\t\t\t\t\t<Type>TabPage</Type>
-\t\t\t\t\t\t\t\t<Caption>Overview</Caption>
+\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
+\t\t\t\t\t\t\t\t<Name>GeneralGroup</Name>
+\t\t\t\t\t\t\t\t<Type>Group</Type>
 \t\t\t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t\t\t<Controls>
-\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t\t\t\t\t\t\t<Name>OverviewGroup</Name>
-\t\t\t\t\t\t\t\t\t\t<Type>Group</Type>
-\t\t\t\t\t\t\t\t\t\t<DataGroup>Overview</DataGroup>
-\t\t\t\t\t\t\t\t\t\t<FormControlExtension
-\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
-\t\t\t\t\t\t\t\t\t\t<Controls>
-${detailFieldControls}\t\t\t\t\t\t\t\t\t\t</Controls>
-\t\t\t\t\t\t\t\t\t</AxFormControl>
-\t\t\t\t\t\t\t\t</Controls>
-\t\t\t\t\t\t\t</AxFormControl>
-\t\t\t\t\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
-\t\t\t\t\t\t\t\t<Name>TabPageGeneral</Name>
-\t\t\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
-\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
-\t\t\t\t\t\t\t\t<Type>TabPage</Type>
-\t\t\t\t\t\t\t\t<Caption>General</Caption>
-\t\t\t\t\t\t\t\t<FormControlExtension
-\t\t\t\t\t\t\t\t\ti:nil="true" />
-\t\t\t\t\t\t\t\t<Controls>
-\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t\t\t\t\t\t\t<Name>GeneralGroup</Name>
-\t\t\t\t\t\t\t\t\t\t<Type>Group</Type>
-\t\t\t\t\t\t\t\t\t\t<DataGroup>General</DataGroup>
-\t\t\t\t\t\t\t\t\t\t<FormControlExtension
-\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
-\t\t\t\t\t\t\t\t\t\t<Controls />
-\t\t\t\t\t\t\t\t\t</AxFormControl>
-\t\t\t\t\t\t\t\t</Controls>
+${tabFieldControls}\t\t\t\t\t\t\t\t</Controls>
 \t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<ColumnsMode>Fill</ColumnsMode>
+\t\t\t\t\t\t<Caption>General</Caption>
 \t\t\t\t\t</AxFormControl>
 \t\t\t\t</Controls>
+\t\t\t\t<Style>FastTabs</Style>
 \t\t\t</AxFormControl>
 \t\t</Controls>
 \t</Design>
@@ -436,15 +465,41 @@ ${detailFieldControls}\t\t\t\t\t\t\t\t\t\t</Controls>
       : '';
 
     const overviewFieldControls = gridFields.map(f =>
-      `\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormStringControl">\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<Name>Overview_${f}</Name>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<Type>String</Type>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<DataField>${f}</DataField>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>\n` +
-      `\t\t\t\t\t\t\t\t\t\t</AxFormControl>\n`
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t\t\t', 'Overview_', opt.fieldTypes)
     ).join('');
+
+    // DetailsMaster 1.4 keeps a left NavigationList (SidePanel) whose grid must be
+    // a List-style grid carrying the identifying columns.
+    const navListFieldControls = gridFields.slice(0, 3).map(f =>
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t', 'NavList_', opt.fieldTypes)
+    ).join('');
+
+    const generalFieldControls = gridFields.map(f =>
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t\t\t\t\t', 'General_', opt.fieldTypes)
+    ).join('');
+
+    const gridPanelFieldControls = gridFields.slice(0, 5).map(f =>
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t', 'GridPanel_', opt.fieldTypes)
+    ).join('');
+
+    // DetailsMaster 1.4 wraps the detail view in a single "Panel Tab" page whose
+    // header is a DetailTitleContainer group carrying a TitleField bound to the
+    // record's identifying field.
+    const titleField = gridFields[0];
+    const detailTitleXml = titleField
+      ? `\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n` +
+        `\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormStringControl">\n` +
+        `\t\t\t\t\t\t\t\t\t\t<Name>TitleField</Name>\n` +
+        `\t\t\t\t\t\t\t\t\t\t<Skip>Yes</Skip>\n` +
+        `\t\t\t\t\t\t\t\t\t\t<Type>String</Type>\n` +
+        `\t\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>\n` +
+        `\t\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
+        `\t\t\t\t\t\t\t\t\t\t<DataField>${titleField}</DataField>\n` +
+        `\t\t\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>\n` +
+        `\t\t\t\t\t\t\t\t\t\t<ShowLabel>No</ShowLabel>\n` +
+        `\t\t\t\t\t\t\t\t\t\t<Style>TitleField</Style>\n` +
+        `\t\t\t\t\t\t\t\t\t</AxFormControl>\n`
+      : '';
 
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
@@ -480,7 +535,7 @@ public class ${formName} extends FormRun
 \t<Design>
 ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t<Pattern xmlns="">DetailsMaster</Pattern>
-\t\t<PatternVersion xmlns="">1.1</PatternVersion>
+\t\t<PatternVersion xmlns="">1.4</PatternVersion>
 \t\t<Style xmlns="">DetailsFormMaster</Style>
 \t\t<TitleDataSource xmlns="">${dsName}</TitleDataSource>
 \t\t<Controls xmlns="">
@@ -510,16 +565,16 @@ ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t\t</AxFormControl>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t<Name>NavigationFilterGroup</Name>
-\t\t\t\t<Pattern>CustomAndQuickFilters</Pattern>
-\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t<Name>NavigationList</Name>
+\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
 \t\t\t\t<Type>Group</Type>
-\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t<Visible>No</Visible>
 \t\t\t\t<FormControlExtension
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
 \t\t\t\t\t<AxFormControl>
 \t\t\t\t\t\t<Name>QuickFilterControl</Name>
+\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t<FormControlExtension>
 \t\t\t\t\t\t\t<Name>QuickFilterControl</Name>
 \t\t\t\t\t\t\t<ExtensionComponents />
@@ -527,79 +582,189 @@ ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
 \t\t\t\t\t\t\t\t\t<Name>targetControlName</Name>
 \t\t\t\t\t\t\t\t\t<Type>String</Type>
-\t\t\t\t\t\t\t\t\t<Value>Grid</Value>
+\t\t\t\t\t\t\t\t\t<Value>NavigationGrid</Value>
 \t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
 \t\t\t\t\t\t\t</ExtensionProperties>
 \t\t\t\t\t\t</FormControlExtension>
 \t\t\t\t\t</AxFormControl>
+\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\ti:type="AxFormGridControl">
+\t\t\t\t\t\t<Name>NavigationGrid</Name>
+\t\t\t\t\t\t<AllowEdit>No</AllowEdit>
+\t\t\t\t\t\t<Type>Grid</Type>
+\t\t\t\t\t\t<WidthMode>SizeToContent</WidthMode>
+\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t<Controls>
+${navListFieldControls}\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<DataSource>${dsName}</DataSource>
+\t\t\t\t\t\t<MultiSelect>No</MultiSelect>
+\t\t\t\t\t\t<ShowRowLabels>No</ShowRowLabels>
+\t\t\t\t\t\t<Style>List</Style>
+\t\t\t\t\t</AxFormControl>
 \t\t\t\t</Controls>
-\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>
 \t\t\t\t<FrameType>None</FrameType>
-\t\t\t\t<Style>CustomFilter</Style>
-\t\t\t\t<ViewEditMode>Edit</ViewEditMode>
-\t\t\t</AxFormControl>
-\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t<Name>HeaderGroup</Name>
-\t\t\t\t<Type>Group</Type>
-\t\t\t\t<FormControlExtension
-\t\t\t\t\ti:nil="true" />
-\t\t\t\t<Controls />
-\t\t\t\t<DataSource>${dsName}</DataSource>
-\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t<Style>SidePanel</Style>
 \t\t\t</AxFormControl>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormTabControl">
 \t\t\t\t<Name>Tab</Name>
+\t\t\t\t<AlignControl>No</AlignControl>
+\t\t\t\t<AutoDeclaration>Yes</AutoDeclaration>
 \t\t\t\t<Type>Tab</Type>
 \t\t\t\t<FormControlExtension
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
 \t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\ti:type="AxFormTabPageControl">
-\t\t\t\t\t\t<Name>TabPageOverview</Name>
-\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
-\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t<Name>FormTabPageDetail</Name>
 \t\t\t\t\t\t<Type>TabPage</Type>
-\t\t\t\t\t\t<Caption>Overview</Caption>
 \t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t<Controls>
 \t\t\t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t\t\t\t\t<Name>OverviewGroup</Name>
+\t\t\t\t\t\t\t\t<Name>DetailHeaderGroup</Name>
 \t\t\t\t\t\t\t\t<Type>Group</Type>
-\t\t\t\t\t\t\t\t<DataGroup>Overview</DataGroup>
+\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t\t\t<Controls>
-${overviewFieldControls}\t\t\t\t\t\t\t\t</Controls>
+${detailTitleXml}\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>
+\t\t\t\t\t\t\t\t<FrameType>None</FrameType>
+\t\t\t\t\t\t\t\t<Style>DetailTitleContainer</Style>
+\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\ti:type="AxFormTabControl">
+\t\t\t\t\t\t\t\t<Name>DetailTab</Name>
+\t\t\t\t\t\t\t\t<AutoDeclaration>Yes</AutoDeclaration>
+\t\t\t\t\t\t\t\t<Type>Tab</Type>
+\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t<Name>TabPageOverview</Name>
+\t\t\t\t\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
+\t\t\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
+\t\t\t\t\t\t\t\t\t\t\t\t<Name>OverviewGroup</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t<Type>Group</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+${overviewFieldControls}\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t<DataGroup>Overview</DataGroup>
+\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t<ColumnsMode>Fill</ColumnsMode>
+\t\t\t\t\t\t\t\t\t\t<Caption>Overview</Caption>
+\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t<Name>TabPageGeneral</Name>
+\t\t\t\t\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
+\t\t\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
+\t\t\t\t\t\t\t\t\t\t\t\t<Name>GeneralGroup</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t<Type>Group</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+${generalFieldControls}\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t<ColumnsMode>Fill</ColumnsMode>
+\t\t\t\t\t\t\t\t\t\t<Caption>General</Caption>
+\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t<Style>FastTabs</Style>
 \t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<PanelStyle>Details</PanelStyle>
+\t\t\t\t\t\t<Style>DetailsFormDetails</Style>
 \t\t\t\t\t</AxFormControl>
 \t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\ti:type="AxFormTabPageControl">
-\t\t\t\t\t\t<Name>TabPageGeneral</Name>
-\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
-\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t<Name>FormTabPageGrid</Name>
 \t\t\t\t\t\t<Type>TabPage</Type>
-\t\t\t\t\t\t<Caption>General</Caption>
 \t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t<Controls>
 \t\t\t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t\t\t\t\t<Name>GeneralGroup</Name>
+\t\t\t\t\t\t\t\t<Name>GridFilterGroup</Name>
+\t\t\t\t\t\t\t\t<Pattern>CustomAndQuickFilters</Pattern>
+\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
 \t\t\t\t\t\t\t\t<Type>Group</Type>
-\t\t\t\t\t\t\t\t<DataGroup>General</DataGroup>
+\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\t\t\ti:nil="true" />
-\t\t\t\t\t\t\t\t<Controls />
+\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t<AxFormControl>
+\t\t\t\t\t\t\t\t\t\t<Name>GridQuickFilter</Name>
+\t\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t\t\t\t\t\t\t<FormControlExtension>
+\t\t\t\t\t\t\t\t\t\t\t<Name>QuickFilterControl</Name>
+\t\t\t\t\t\t\t\t\t\t\t<ExtensionComponents />
+\t\t\t\t\t\t\t\t\t\t\t<ExtensionProperties>
+\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>targetControlName</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>String</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<Value>OverviewGrid</Value>
+\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
+\t\t\t\t\t\t\t\t\t\t\t</ExtensionProperties>
+\t\t\t\t\t\t\t\t\t\t</FormControlExtension>
+\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>
+\t\t\t\t\t\t\t\t<FrameType>None</FrameType>
+\t\t\t\t\t\t\t\t<Style>CustomFilter</Style>
+\t\t\t\t\t\t\t\t<ViewEditMode>Edit</ViewEditMode>
+\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\ti:type="AxFormGridControl">
+\t\t\t\t\t\t\t\t<Name>OverviewGrid</Name>
+\t\t\t\t\t\t\t\t<AllowEdit>Yes</AllowEdit>
+\t\t\t\t\t\t\t\t<Type>Grid</Type>
+\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t<Controls>
+${gridPanelFieldControls}\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>
+\t\t\t\t\t\t\t\t<DefaultAction>OverviewGridDefaultAction</DefaultAction>
+\t\t\t\t\t\t\t\t<MultiSelect>No</MultiSelect>
+\t\t\t\t\t\t\t\t<ShowRowLabels>No</ShowRowLabels>
+\t\t\t\t\t\t\t\t<Style>Tabular</Style>
+\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\ti:type="AxFormCommandButtonControl">
+\t\t\t\t\t\t\t\t<Name>OverviewGridDefaultAction</Name>
+\t\t\t\t\t\t\t\t<Type>CommandButton</Type>
+\t\t\t\t\t\t\t\t<Visible>No</Visible>
+\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t<Command>DetailsView</Command>
 \t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<PanelStyle>Grid</PanelStyle>
+\t\t\t\t\t\t<Style>DetailsFormGrid</Style>
 \t\t\t\t\t</AxFormControl>
 \t\t\t\t</Controls>
-\t\t\t\t<Style>FastTabs</Style>
+\t\t\t\t<AlignChild>No</AlignChild>
+\t\t\t\t<DataSource>${dsName}</DataSource>
+\t\t\t\t<ShowTabs>No</ShowTabs>
 \t\t\t</AxFormControl>
 \t\t</Controls>
 \t</Design>
@@ -623,21 +788,57 @@ ${overviewFieldControls}\t\t\t\t\t\t\t\t</Controls>
       linesDsName = `${dsName}Lines`,
       linesDsTable = linesDsName,
       gridFields = [],
+      linesFields = [],
     } = opt;
     const captionXml = caption
       ? `\t\t<Caption xmlns="">${caption}</Caption>\n`
       : '';
 
-    const headerFieldControls = gridFields.map(f =>
-      `\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormStringControl">\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t\t<Name>Header_${f}</Name>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t\t<Type>String</Type>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t\t<DataField>${f}</DataField>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>\n` +
-      `\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>\n`
+    // Read-only navigation list: up to 3 identifying header fields.
+    const navListColumns = gridFields.slice(0, 3).map(f =>
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t', 'Nav_', opt.fieldTypes)
     ).join('');
+
+    const headerFieldControls = gridFields.map(f =>
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t\t', 'Header_', opt.fieldTypes)
+    ).join('');
+
+    const linesColumns = linesFields.map(f =>
+      FormPatternTemplates.fieldControl(f, linesDsName, '\t\t\t\t\t\t\t\t\t', 'Line_', opt.linesFieldTypes)
+    ).join('');
+
+    // LineViewTab's third page: a line-details fast-tab showing the selected
+    // line's fields (distinct control names from the lines grid columns).
+    const lineDetailControls = linesFields.map(f =>
+      FormPatternTemplates.fieldControl(f, linesDsName, '\t\t\t\t\t\t\t\t\t\t', 'LineDtl_', opt.linesFieldTypes)
+    ).join('');
+
+    // The Grid panel (alternate "list" view) of the MainTab needs its own grid
+    // columns — distinct names from the nav list / header to avoid collisions.
+    const gridPanelColumns = gridFields.slice(0, 5).map(f =>
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t', 'GridPanel_', opt.fieldTypes)
+    ).join('');
+
+    // The DetailsTab pairs a header-only panel (HeaderView) with the combined
+    // header+lines panel (LineView); its fields need distinct control names.
+    const headerViewFieldControls = gridFields.map(f =>
+      FormPatternTemplates.fieldControl(f, dsName, '\t\t\t\t\t\t\t\t\t\t', 'HView_', opt.fieldTypes)
+    ).join('');
+
+    const dsFieldList = (fields: string[]): string =>
+      fields.length > 0
+        ? `\t\t\t<Fields>\n` +
+          fields.map(f =>
+            `\t\t\t\t<AxFormDataSourceField>\n\t\t\t\t\t<DataField>${f}</DataField>\n\t\t\t\t</AxFormDataSourceField>\n`,
+          ).join('') +
+          `\t\t\t</Fields>\n`
+        : `\t\t\t<Fields />\n`;
+    const headerDsFields = dsFieldList(gridFields);
+    const linesDsFields = dsFieldList(linesFields);
+
+    // DetailsTransaction v1.4 carries the title in a DetailTitleContainer header
+    // (HeaderInfo) bound to the record's identifying field.
+    const titleField = gridFields[0];
 
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
@@ -663,8 +864,7 @@ public class ${formName} extends FormRun
 \t\t<AxFormDataSource xmlns="">
 \t\t\t<Name>${dsName}</Name>
 \t\t\t<Table>${dsTable}</Table>
-\t\t\t<Fields />
-\t\t\t<ReferencedDataSources />
+${headerDsFields}\t\t\t<ReferencedDataSources />
 \t\t\t<InsertIfEmpty>No</InsertIfEmpty>
 \t\t\t<DataSourceLinks />
 \t\t\t<DerivedDataSources />
@@ -672,22 +872,18 @@ public class ${formName} extends FormRun
 \t\t<AxFormDataSource xmlns="">
 \t\t\t<Name>${linesDsName}</Name>
 \t\t\t<Table>${linesDsTable}</Table>
-\t\t\t<Fields />
-\t\t\t<ReferencedDataSources />
+${linesDsFields}\t\t\t<ReferencedDataSources />
+\t\t\t<JoinSource>${dsName}</JoinSource>
+\t\t\t<LinkType>Delayed</LinkType>
 \t\t\t<InsertIfEmpty>No</InsertIfEmpty>
-\t\t\t<DataSourceLinks>
-\t\t\t\t<AxFormDataSourceLink>
-\t\t\t\t\t<LinkType>Active</LinkType>
-\t\t\t\t\t<Table>${dsName}</Table>
-\t\t\t\t</AxFormDataSourceLink>
-\t\t\t</DataSourceLinks>
+\t\t\t<DataSourceLinks />
 \t\t\t<DerivedDataSources />
 \t\t</AxFormDataSource>
 \t</DataSources>
 \t<Design>
 ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t<Pattern xmlns="">DetailsTransaction</Pattern>
-\t\t<PatternVersion xmlns="">1.1</PatternVersion>
+\t\t<PatternVersion xmlns="">1.4</PatternVersion>
 \t\t<Style xmlns="">DetailsFormTransaction</Style>
 \t\t<TitleDataSource xmlns="">${dsName}</TitleDataSource>
 \t\t<Controls xmlns="">
@@ -717,16 +913,16 @@ ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t\t</AxFormControl>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t<Name>NavigationFilterGroup</Name>
-\t\t\t\t<Pattern>CustomAndQuickFilters</Pattern>
-\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t<Name>NavigationList</Name>
+\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
 \t\t\t\t<Type>Group</Type>
-\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t<Visible>No</Visible>
 \t\t\t\t<FormControlExtension
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
 \t\t\t\t\t<AxFormControl>
-\t\t\t\t\t\t<Name>QuickFilterControl</Name>
+\t\t\t\t\t\t<Name>NavigationListFilter</Name>
+\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t<FormControlExtension>
 \t\t\t\t\t\t\t<Name>QuickFilterControl</Name>
 \t\t\t\t\t\t\t<ExtensionComponents />
@@ -734,88 +930,358 @@ ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
 \t\t\t\t\t\t\t\t\t<Name>targetControlName</Name>
 \t\t\t\t\t\t\t\t\t<Type>String</Type>
-\t\t\t\t\t\t\t\t\t<Value>Grid</Value>
+\t\t\t\t\t\t\t\t\t<Value>NavigationListGrid</Value>
 \t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
 \t\t\t\t\t\t\t</ExtensionProperties>
 \t\t\t\t\t\t</FormControlExtension>
 \t\t\t\t\t</AxFormControl>
+\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\ti:type="AxFormGridControl">
+\t\t\t\t\t\t<Name>NavigationListGrid</Name>
+\t\t\t\t\t\t<AllowEdit>No</AllowEdit>
+\t\t\t\t\t\t<Type>Grid</Type>
+\t\t\t\t\t\t<WidthMode>SizeToContent</WidthMode>
+\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t<Controls>
+${navListColumns}\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<DataSource>${dsName}</DataSource>
+\t\t\t\t\t\t<MultiSelect>No</MultiSelect>
+\t\t\t\t\t\t<ShowRowLabels>No</ShowRowLabels>
+\t\t\t\t\t\t<Style>List</Style>
+\t\t\t\t\t</AxFormControl>
 \t\t\t\t</Controls>
-\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>
 \t\t\t\t<FrameType>None</FrameType>
-\t\t\t\t<Style>CustomFilter</Style>
-\t\t\t\t<ViewEditMode>Edit</ViewEditMode>
+\t\t\t\t<Style>SidePanel</Style>
 \t\t\t</AxFormControl>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormTabControl">
-\t\t\t\t<Name>Tab</Name>
+\t\t\t\t<Name>MainTab</Name>
+\t\t\t\t<AlignControl>No</AlignControl>
 \t\t\t\t<Type>Tab</Type>
 \t\t\t\t<FormControlExtension
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
 \t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\ti:type="AxFormTabPageControl">
-\t\t\t\t\t\t<Name>TabPageHeader</Name>
-\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
-\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t<Name>TabPageDetails</Name>
+\t\t\t\t\t\t<AutoDeclaration>Yes</AutoDeclaration>
+\t\t\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
 \t\t\t\t\t\t<Type>TabPage</Type>
-\t\t\t\t\t\t<Caption>Header</Caption>
+\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t<Controls>
 \t\t\t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t\t\t\t\t<Name>HeaderGeneralGroup</Name>
+\t\t\t\t\t\t\t\t<Name>HeaderInfo</Name>
 \t\t\t\t\t\t\t\t<Type>Group</Type>
-\t\t\t\t\t\t\t\t<Caption>General</Caption>
-\t\t\t\t\t\t\t\t<DataGroup>Overview</DataGroup>
+\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t\t\t<Controls>
-${headerFieldControls}\t\t\t\t\t\t\t\t</Controls>
+${titleField ? `\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormStringControl">
+\t\t\t\t\t\t\t\t\t\t<Name>HeaderTitle</Name>
+\t\t\t\t\t\t\t\t\t\t<Skip>Yes</Skip>
+\t\t\t\t\t\t\t\t\t\t<Type>String</Type>
+\t\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t<DataField>${titleField}</DataField>
+\t\t\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>
+\t\t\t\t\t\t\t\t\t\t<ShowLabel>No</ShowLabel>
+\t\t\t\t\t\t\t\t\t\t<Style>TitleField</Style>
+\t\t\t\t\t\t\t\t\t</AxFormControl>\n` : ''}\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>
+\t\t\t\t\t\t\t\t<FrameType>None</FrameType>
+\t\t\t\t\t\t\t\t<Style>DetailTitleContainer</Style>
 \t\t\t\t\t\t\t</AxFormControl>
-\t\t\t\t\t\t</Controls>
-\t\t\t\t\t</AxFormControl>
-\t\t\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
-\t\t\t\t\t\t<Name>TabPageLines</Name>
-\t\t\t\t\t\t<Type>TabPage</Type>
-\t\t\t\t\t\t<Caption>Lines</Caption>
-\t\t\t\t\t\t<FormControlExtension
-\t\t\t\t\t\t\ti:nil="true" />
-\t\t\t\t\t\t<Controls>
 \t\t\t\t\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\t\t\t\t\ti:type="AxFormActionPaneTabControl">
-\t\t\t\t\t\t\t\t<Name>LinesActionPane</Name>
-\t\t\t\t\t\t\t\t<Type>ActionPaneTab</Type>
+\t\t\t\t\t\t\t\t\ti:type="AxFormTabControl">
+\t\t\t\t\t\t\t\t<Name>DetailsTab</Name>
+\t\t\t\t\t\t\t\t<Type>Tab</Type>
 \t\t\t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t\t\t<Controls>
 \t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormButtonGroupControl">
-\t\t\t\t\t\t\t\t\t\t<Name>LinesButtonGroup</Name>
-\t\t\t\t\t\t\t\t\t\t<Type>ButtonGroup</Type>
+\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t<Name>LineView</Name>
+\t\t\t\t\t\t\t\t\t\t<AutoDeclaration>Yes</AutoDeclaration>
+\t\t\t\t\t\t\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
+\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
-\t\t\t\t\t\t\t\t\t\t<Controls />
-\t\t\t\t\t\t\t\t\t\t<ArrangeMethod>Vertical</ArrangeMethod>
+\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabControl">
+\t\t\t\t\t\t\t\t\t\t\t\t<Name>LineViewTab</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t<AutoDeclaration>Yes</AutoDeclaration>
+\t\t\t\t\t\t\t\t\t\t\t\t<Type>Tab</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LineViewHeader</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>HeaderGeneralGroup</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>Group</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+${headerFieldControls}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<ColumnsMode>Fill</ColumnsMode>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Caption>Header</Caption>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FastTabExpanded>No</FastTabExpanded>
+\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LineViewLines</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormActionPaneControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LinesActionPaneStrip</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>ActionPane</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormActionPaneTabControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LinesActionTab</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>ActionPaneTab</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormButtonGroupControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LinesStripButtonGroup</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>ButtonGroup</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AlignChild>No</AlignChild>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AlignChildren>No</AlignChildren>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<ArrangeMethod>Vertical</ArrangeMethod>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<DataSource>${linesDsName}</DataSource>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Style>Strip</Style>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGridControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LinesGrid</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>Grid</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+${linesColumns}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<DataSource>${linesDsName}</DataSource>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Style>Tabular</Style>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<VisibleRows>5</VisibleRows>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<VisibleRowsMode>Fixed</VisibleRowsMode>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Caption>Lines</Caption>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FastTabExpanded>Always</FastTabExpanded>
+\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LineViewLineDetails</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LineDetailsTab</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AutoDeclaration>Yes</AutoDeclaration>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>Tab</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>TabLineGeneral</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>LineDetailsGroup</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>Group</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+${lineDetailControls}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<ColumnsMode>Fill</ColumnsMode>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Caption>General</Caption>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AlignChild>No</AlignChild>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Style>Tabs</Style>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Caption>Line details</Caption>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<DataSource>${linesDsName}</DataSource>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FastTabExpanded>No</FastTabExpanded>
+\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t<AlignChild>No</AlignChild>
+\t\t\t\t\t\t\t\t\t\t\t\t<Style>FastTabs</Style>
+\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t<PanelStyle>DetailsLine</PanelStyle>
+\t\t\t\t\t\t\t\t\t\t<Style>DetailsFormDetails</Style>
+\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t<Name>HeaderView</Name>
+\t\t\t\t\t\t\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
+\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabControl">
+\t\t\t\t\t\t\t\t\t\t\t\t<Name>HeaderDetailsTab</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t<AutoDeclaration>Yes</AutoDeclaration>
+\t\t\t\t\t\t\t\t\t\t\t\t<Type>Tab</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>TabHeaderGeneral</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>HeaderViewGroup</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>Group</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Controls>
+${headerViewFieldControls}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<ColumnsMode>Fill</ColumnsMode>
+\t\t\t\t\t\t\t\t\t\t\t\t\t\t<Caption>General</Caption>
+\t\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t\t\t<AlignChild>No</AlignChild>
+\t\t\t\t\t\t\t\t\t\t\t\t<Style>FastTabs</Style>
+\t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t\t\t<PanelStyle>DetailsHeader</PanelStyle>
+\t\t\t\t\t\t\t\t\t\t<Style>DetailsFormDetails</Style>
 \t\t\t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t<AlignChild>No</AlignChild>
+\t\t\t\t\t\t\t\t<ShowTabs>No</ShowTabs>
+\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<PanelStyle>Details</PanelStyle>
+\t\t\t\t\t\t<Style>DetailsFormDetails</Style>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\ti:type="AxFormTabPageControl">
+\t\t\t\t\t\t<Name>TabPageGrid</Name>
+\t\t\t\t\t\t<Type>TabPage</Type>
+\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
+\t\t\t\t\t\t\t\t<Name>GridFilterGroup</Name>
+\t\t\t\t\t\t\t\t<Pattern>CustomAndQuickFilters</Pattern>
+\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>
+\t\t\t\t\t\t\t\t<Type>Group</Type>
+\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t<Controls>
+\t\t\t\t\t\t\t\t\t<AxFormControl>
+\t\t\t\t\t\t\t\t\t\t<Name>GridQuickFilter</Name>
+\t\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
+\t\t\t\t\t\t\t\t\t\t<FormControlExtension>
+\t\t\t\t\t\t\t\t\t\t\t<Name>QuickFilterControl</Name>
+\t\t\t\t\t\t\t\t\t\t\t<ExtensionComponents />
+\t\t\t\t\t\t\t\t\t\t\t<ExtensionProperties>
+\t\t\t\t\t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<Name>targetControlName</Name>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<Type>String</Type>
+\t\t\t\t\t\t\t\t\t\t\t\t\t<Value>OverviewGrid</Value>
+\t\t\t\t\t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
+\t\t\t\t\t\t\t\t\t\t\t</ExtensionProperties>
+\t\t\t\t\t\t\t\t\t\t</FormControlExtension>
+\t\t\t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>
+\t\t\t\t\t\t\t\t<FrameType>None</FrameType>
+\t\t\t\t\t\t\t\t<Style>CustomFilter</Style>
+\t\t\t\t\t\t\t\t<ViewEditMode>Edit</ViewEditMode>
 \t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\t\t\ti:type="AxFormGridControl">
-\t\t\t\t\t\t\t\t<Name>LinesGrid</Name>
+\t\t\t\t\t\t\t\t<Name>OverviewGrid</Name>
+\t\t\t\t\t\t\t\t<AllowEdit>Yes</AllowEdit>
 \t\t\t\t\t\t\t\t<Type>Grid</Type>
 \t\t\t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\t\t\ti:nil="true" />
-\t\t\t\t\t\t\t\t<Controls />
-\t\t\t\t\t\t\t\t<DataSource>${linesDsName}</DataSource>
-\t\t\t\t\t\t\t\t<DataGroup>Overview</DataGroup>
+\t\t\t\t\t\t\t\t<Controls>
+${gridPanelColumns}\t\t\t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>
+\t\t\t\t\t\t\t\t<DefaultAction>OverviewGridDefaultAction</DefaultAction>
+\t\t\t\t\t\t\t\t<MultiSelect>No</MultiSelect>
+\t\t\t\t\t\t\t\t<ShowRowLabels>No</ShowRowLabels>
 \t\t\t\t\t\t\t\t<Style>Tabular</Style>
 \t\t\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t\t\t<AxFormControl xmlns=""
+\t\t\t\t\t\t\t\t\ti:type="AxFormCommandButtonControl">
+\t\t\t\t\t\t\t\t<Name>OverviewGridDefaultAction</Name>
+\t\t\t\t\t\t\t\t<Type>CommandButton</Type>
+\t\t\t\t\t\t\t\t<Visible>No</Visible>
+\t\t\t\t\t\t\t\t<FormControlExtension
+\t\t\t\t\t\t\t\t\ti:nil="true" />
+\t\t\t\t\t\t\t\t<Command>DetailsView</Command>
+\t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<PanelStyle>Grid</PanelStyle>
+\t\t\t\t\t\t<Style>DetailsFormGrid</Style>
 \t\t\t\t\t</AxFormControl>
 \t\t\t\t</Controls>
-\t\t\t\t<Style>FastTabs</Style>
+\t\t\t\t<AlignChild>No</AlignChild>
+\t\t\t\t<ArrangeMethod>Vertical</ArrangeMethod>
+\t\t\t\t<ShowTabs>No</ShowTabs>
 \t\t\t</AxFormControl>
 \t\t</Controls>
 \t</Design>
@@ -894,6 +1360,14 @@ ${headerFieldControls}\t\t\t\t\t\t\t\t</Controls>
       ? ''
       : `\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>\n\t\t\t\t<PatternVersion>1.1</PatternVersion>\n`;
 
+    // The 'Dialog - Basic' pattern requires the body to fill the dialog. D365
+    // serializes a control's properties in two alphabetical groups split by
+    // <Controls>: HeightMode/WidthMode belong to the BEFORE group (HeightMode
+    // before Pattern, WidthMode after Type), ColumnsMode to the AFTER group.
+    const dialogBodyLayout = sections.length > 0
+      ? ''
+      : `\t\t\t\t<ColumnsMode>Fill</ColumnsMode>\n`;
+
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
 \t<Name>${formName}</Name>
@@ -923,17 +1397,20 @@ ${captionXml}\t\t<Frame xmlns="">Dialog</Frame>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormGroupControl">
 \t\t\t\t<Name>DialogBody</Name>
+\t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
 ${dialogBodyPattern}\t\t\t\t<Type>Group</Type>
+\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t<FormControlExtension
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
 ${bodyContent}\t\t\t\t</Controls>
-\t\t\t\t<Style>DialogContent</Style>
+${dialogBodyLayout}\t\t\t\t<Style>DialogContent</Style>
 \t\t\t</AxFormControl>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormButtonGroupControl">
 \t\t\t\t<Name>ButtonGroup</Name>
 \t\t\t\t<Type>ButtonGroup</Type>
+\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t<FormControlExtension
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
@@ -954,6 +1431,7 @@ ${bodyContent}\t\t\t\t</Controls>
 \t\t\t\t\t\t<Command>Cancel</Command>
 \t\t\t\t\t</AxFormControl>
 \t\t\t\t</Controls>
+\t\t\t\t<ArrangeMethod>HorizontalRight</ArrangeMethod>
 \t\t\t\t<Style>DialogCommitContainer</Style>
 \t\t\t</AxFormControl>
 \t\t</Controls>
@@ -970,7 +1448,7 @@ ${bodyContent}\t\t\t\t</Controls>
   // Structure: Tab control (TOC navigation) → TabPages (FieldsFieldGroups each)
   // ---------------------------------------------------------------------------
   static buildTableOfContents(opt: FormTemplateOptions): string {
-    const { formName, dsName, dsTable, caption, sections = [] } = opt;
+    const { formName, dsName, dsTable, caption, sections = [], gridFields = [] } = opt;
     const captionXml = caption
       ? `\t\t<Caption xmlns="">${caption}</Caption>\n`
       : '';
@@ -982,17 +1460,72 @@ ${bodyContent}\t\t\t\t</Controls>
           { name: 'TabPageSetup',    caption: 'Setup' },
         ];
 
+    // TableOfContents = a single TOC navigation Tab whose every page carries a
+    // TOCTitleContainer group (heading) plus a nested FastTabs tab holding the
+    // FieldsFieldGroups content. The section TabPage itself is unpatterned.
+    const sectionFields = (s: { name: string }): string =>
+      (dsName ? gridFields : []).map(f =>
+        FormPatternTemplates.fieldControl(f, dsName!, '\t\t\t\t\t\t\t\t\t\t', `${s.name}_`, opt.fieldTypes),
+      ).join('');
+
     const tabPageControls = effectiveSections.map(s =>
       `\t\t\t\t<AxFormControl xmlns=""\n` +
       `\t\t\t\t\t\ti:type="AxFormTabPageControl">\n` +
       `\t\t\t\t\t<Name>${s.name}</Name>\n` +
-      `\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>\n` +
-      `\t\t\t\t\t<PatternVersion>1.1</PatternVersion>\n` +
       `\t\t\t\t\t<Type>TabPage</Type>\n` +
-      `\t\t\t\t\t<Caption>${s.caption}</Caption>\n` +
-      `\t\t\t\t\t<FrameType>None</FrameType>\n` +
       `\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\ti:nil="true" />\n` +
-      `\t\t\t\t\t<Controls />\n` +
+      `\t\t\t\t\t<Controls>\n` +
+      // TOC heading
+      `\t\t\t\t\t\t<AxFormControl xmlns=""\n\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">\n` +
+      `\t\t\t\t\t\t\t<Name>${s.name}Title</Name>\n` +
+      `\t\t\t\t\t\t\t<Skip>Yes</Skip>\n` +
+      `\t\t\t\t\t\t\t<Type>Group</Type>\n` +
+      `\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>\n` +
+      `\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\ti:nil="true" />\n` +
+      `\t\t\t\t\t\t\t<Controls>\n` +
+      `\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n\t\t\t\t\t\t\t\t\t\ti:type="AxFormStaticTextControl">\n` +
+      `\t\t\t\t\t\t\t\t\t<Name>${s.name}Instruction</Name>\n` +
+      `\t\t\t\t\t\t\t\t\t<Skip>Yes</Skip>\n` +
+      `\t\t\t\t\t\t\t\t\t<Type>StaticText</Type>\n` +
+      `\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>\n` +
+      `\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
+      `\t\t\t\t\t\t\t\t\t<Style>MainInstruction</Style>\n` +
+      `\t\t\t\t\t\t\t\t\t<Text>${s.caption}</Text>\n` +
+      `\t\t\t\t\t\t\t\t</AxFormControl>\n` +
+      `\t\t\t\t\t\t\t</Controls>\n` +
+      `\t\t\t\t\t\t\t<AllowUserSetup>No</AllowUserSetup>\n` +
+      `\t\t\t\t\t\t\t<FrameType>None</FrameType>\n` +
+      `\t\t\t\t\t\t\t<Style>TOCTitleContainer</Style>\n` +
+      `\t\t\t\t\t\t</AxFormControl>\n` +
+      // nested FastTabs content tab
+      `\t\t\t\t\t\t<AxFormControl xmlns=""\n\t\t\t\t\t\t\t\ti:type="AxFormTabControl">\n` +
+      `\t\t\t\t\t\t\t<Name>${s.name}FastTab</Name>\n` +
+      `\t\t\t\t\t\t\t<Type>Tab</Type>\n` +
+      `\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\ti:nil="true" />\n` +
+      `\t\t\t\t\t\t\t<Controls>\n` +
+      `\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n\t\t\t\t\t\t\t\t\t\ti:type="AxFormTabPageControl">\n` +
+      `\t\t\t\t\t\t\t\t\t<Name>${s.name}Page</Name>\n` +
+      `\t\t\t\t\t\t\t\t\t<Pattern>FieldsFieldGroups</Pattern>\n` +
+      `\t\t\t\t\t\t\t\t\t<PatternVersion>1.1</PatternVersion>\n` +
+      `\t\t\t\t\t\t\t\t\t<Type>TabPage</Type>\n` +
+      `\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
+      `\t\t\t\t\t\t\t\t\t<Controls>\n` +
+      `\t\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n\t\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">\n` +
+      `\t\t\t\t\t\t\t\t\t\t\t<Name>${s.name}Group</Name>\n` +
+      `\t\t\t\t\t\t\t\t\t\t\t<Type>Group</Type>\n` +
+      `\t\t\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
+      `\t\t\t\t\t\t\t\t\t\t\t<Controls>\n` +
+      sectionFields(s) +
+      `\t\t\t\t\t\t\t\t\t\t\t</Controls>\n` +
+      `\t\t\t\t\t\t\t\t\t\t</AxFormControl>\n` +
+      `\t\t\t\t\t\t\t\t\t</Controls>\n` +
+      `\t\t\t\t\t\t\t\t\t<ColumnsMode>Fill</ColumnsMode>\n` +
+      `\t\t\t\t\t\t\t\t\t<Caption>${s.caption}</Caption>\n` +
+      `\t\t\t\t\t\t\t\t</AxFormControl>\n` +
+      `\t\t\t\t\t\t\t</Controls>\n` +
+      `\t\t\t\t\t\t\t<Style>FastTabs</Style>\n` +
+      `\t\t\t\t\t\t</AxFormControl>\n` +
+      `\t\t\t\t\t</Controls>\n` +
       `\t\t\t\t</AxFormControl>\n`
     ).join('');
 
@@ -1038,14 +1571,6 @@ ${captionXml}${dsOnDesign}\t\t<Pattern xmlns="">TableOfContents</Pattern>
 \t\t<Style xmlns="">TableOfContents</Style>
 \t\t<Controls xmlns="">
 \t\t\t<AxFormControl xmlns=""
-\t\t\t\t\ti:type="AxFormActionPaneControl">
-\t\t\t\t<Name>ActionPane</Name>
-\t\t\t\t<Type>ActionPane</Type>
-\t\t\t\t<FormControlExtension
-\t\t\t\t\ti:nil="true" />
-\t\t\t\t<Controls />
-\t\t\t</AxFormControl>
-\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormTabControl">
 \t\t\t\t<Name>Tab</Name>
 \t\t\t\t<Type>Tab</Type>
@@ -1053,7 +1578,7 @@ ${captionXml}${dsOnDesign}\t\t<Pattern xmlns="">TableOfContents</Pattern>
 \t\t\t\t\ti:nil="true" />
 \t\t\t\t<Controls>
 ${tabPageControls}\t\t\t\t</Controls>
-\t\t\t\t<Style>TOCList</Style>
+\t\t\t\t<Style>VerticalTabs</Style>
 \t\t\t</AxFormControl>
 \t\t</Controls>
 \t</Design>
@@ -1073,7 +1598,6 @@ ${tabPageControls}\t\t\t\t</Controls>
     const captionXml = caption
       ? `\t\t<Caption xmlns="">${caption}</Caption>\n`
       : '';
-    const defaultCol = gridFields.length > 0 ? `Grid_${gridFields[0]}` : `Grid_${dsName}`;
 
     const fieldControls = gridFields.map(f =>
       `\t\t\t\t\t<AxFormControl xmlns=""\n` +
@@ -1117,53 +1641,21 @@ public class ${formName} extends FormRun
 \t\t</AxFormDataSource>
 \t</DataSources>
 \t<Design>
-${captionXml}\t\t<Pattern xmlns="">Lookup</Pattern>
-\t\t<PatternVersion xmlns="">1.2</PatternVersion>
+${captionXml}\t\t<Frame xmlns="">Border</Frame>
+\t\t<HeightMode xmlns="">SizeToContent</HeightMode>
+\t\t<Pattern xmlns="">LookupGridOnly</Pattern>
+\t\t<PatternVersion xmlns="">1.1</PatternVersion>
 \t\t<Style xmlns="">Lookup</Style>
+\t\t<WidthMode xmlns="">SizeToAvailable</WidthMode>
+\t\t<WindowType xmlns="">Popup</WindowType>
 \t\t<Controls xmlns="">
-\t\t\t<AxFormControl xmlns=""
-\t\t\t\t\ti:type="AxFormGroupControl">
-\t\t\t\t<Name>CustomFilterGroup</Name>
-\t\t\t\t<Pattern>CustomAndQuickFilters</Pattern>
-\t\t\t\t<PatternVersion>1.1</PatternVersion>
-\t\t\t\t<Type>Group</Type>
-\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
-\t\t\t\t<FormControlExtension
-\t\t\t\t\ti:nil="true" />
-\t\t\t\t<Controls>
-\t\t\t\t\t<AxFormControl>
-\t\t\t\t\t\t<Name>QuickFilterControl</Name>
-\t\t\t\t\t\t<FormControlExtension>
-\t\t\t\t\t\t\t<Name>QuickFilterControl</Name>
-\t\t\t\t\t\t\t<ExtensionComponents />
-\t\t\t\t\t\t\t<ExtensionProperties>
-\t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
-\t\t\t\t\t\t\t\t\t<Name>targetControlName</Name>
-\t\t\t\t\t\t\t\t\t<Type>String</Type>
-\t\t\t\t\t\t\t\t\t<Value>Grid</Value>
-\t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
-\t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
-\t\t\t\t\t\t\t\t\t<Name>defaultColumnName</Name>
-\t\t\t\t\t\t\t\t\t<Type>String</Type>
-\t\t\t\t\t\t\t\t\t<Value>${defaultCol}</Value>
-\t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
-\t\t\t\t\t\t\t\t<AxFormControlExtensionProperty>
-\t\t\t\t\t\t\t\t\t<Name>placeholderText</Name>
-\t\t\t\t\t\t\t\t\t<Type>String</Type>
-\t\t\t\t\t\t\t\t</AxFormControlExtensionProperty>
-\t\t\t\t\t\t\t</ExtensionProperties>
-\t\t\t\t\t\t</FormControlExtension>
-\t\t\t\t\t</AxFormControl>
-\t\t\t\t</Controls>
-\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>
-\t\t\t\t<FrameType>None</FrameType>
-\t\t\t\t<Style>CustomFilter</Style>
-\t\t\t</AxFormControl>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormGridControl">
 \t\t\t\t<Name>Grid</Name>
+\t\t\t\t<AllowEdit>No</AllowEdit>
 \t\t\t\t<ElementPosition>1431655764</ElementPosition>
 \t\t\t\t<FilterExpression>%1</FilterExpression>
+\t\t\t\t<HeightMode>SizeToContent</HeightMode>
 \t\t\t\t<Type>Grid</Type>
 \t\t\t\t<VerticalSpacing>-1</VerticalSpacing>
 \t\t\t\t<FormControlExtension
@@ -1244,7 +1736,7 @@ public class ${formName} extends FormRun
 \t<Design>
 ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t<Pattern xmlns="">ListPage</Pattern>
-\t\t<PatternVersion xmlns="">1.1</PatternVersion>
+\t\t<PatternVersion xmlns="">UX7 1.0</PatternVersion>
 \t\t<Style xmlns="">ListPage</Style>
 \t\t<TitleDataSource xmlns="">${dsName}</TitleDataSource>
 \t\t<Controls xmlns="">
@@ -1330,6 +1822,7 @@ ${captionXml}\t\t<DataSource xmlns="">${dsName}</DataSource>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormGridControl">
 \t\t\t\t<Name>Grid</Name>
+\t\t\t\t<AllowEdit>No</AllowEdit>
 \t\t\t\t<ElementPosition>1431655764</ElementPosition>
 \t\t\t\t<FilterExpression>%1</FilterExpression>
 \t\t\t\t<Type>Grid</Type>
@@ -1371,7 +1864,6 @@ ${fieldControls}\t\t\t\t</Controls>
       `\t\t\t\t\t<AxFormControl xmlns=""\n` +
       `\t\t\t\t\t\t\ti:type="AxFormTabPageControl">\n` +
       `\t\t\t\t\t\t<Name>${sec.name}Section</Name>\n` +
-      `\t\t\t\t\t\t<Caption>${sec.caption}</Caption>\n` +
       `\t\t\t\t\t\t<ElementPosition>${536870912 * (idx + 2)}</ElementPosition>\n` +
       `\t\t\t\t\t\t<Type>TabPage</Type>\n` +
       `\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\ti:nil="true" />\n` +
@@ -1403,6 +1895,7 @@ ${fieldControls}\t\t\t\t</Controls>
       `\t\t\t\t\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>\n` +
       `\t\t\t\t\t\t\t\t<FrameType>None</FrameType>\n` +
       `\t\t\t\t\t\t\t\t<Style>CustomFilter</Style>\n` +
+      `\t\t\t\t\t\t\t\t<ViewEditMode>Edit</ViewEditMode>\n` +
       `\t\t\t\t\t\t\t</AxFormControl>\n` +
       `\t\t\t\t\t\t\t<AxFormControl xmlns=""\n` +
       `\t\t\t\t\t\t\t\t\ti:type="AxFormGridControl">\n` +
@@ -1416,7 +1909,9 @@ ${fieldControls}\t\t\t\t</Controls>
       `\t\t\t\t\t\t\t\t<Style>Tabular</Style>\n` +
       `\t\t\t\t\t\t\t</AxFormControl>\n` +
       `\t\t\t\t\t\t</Controls>\n` +
+      `\t\t\t\t\t\t<FastTabExpanded>Yes</FastTabExpanded>\n` +
       `\t\t\t\t\t\t<FrameType>None</FrameType>\n` +
+      `\t\t\t\t\t\t<Caption>${sec.caption}</Caption>\n` +
       `\t\t\t\t\t</AxFormControl>\n`
     ).join('');
 
@@ -1455,9 +1950,12 @@ public class ${formName} extends FormRun
 \t\t</AxFormDataSource>
 \t</DataSources>
 \t<Design>
-${captionXml}\t\t<Pattern xmlns="">Workspace</Pattern>
-\t\t<PatternVersion xmlns="">1.0</PatternVersion>
+${captionXml}\t\t<Pattern xmlns="">WorkspaceOperational</Pattern>
+\t\t<PatternVersion xmlns="">1.1</PatternVersion>
+\t\t<ShowDeleteButton xmlns="">No</ShowDeleteButton>
+\t\t<ShowNewButton xmlns="">No</ShowNewButton>
 \t\t<Style xmlns="">Workspace</Style>
+\t\t<ViewEditMode xmlns="">View</ViewEditMode>
 \t\t<Controls xmlns="">
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormActionPaneControl">
@@ -1494,7 +1992,9 @@ ${captionXml}\t\t<Pattern xmlns="">Workspace</Pattern>
 \t\t\t<AxFormControl xmlns=""
 \t\t\t\t\ti:type="AxFormTabControl">
 \t\t\t\t<Name>PanoramaBody</Name>
+\t\t\t\t<AutoDeclaration>Yes</AutoDeclaration>
 \t\t\t\t<ElementPosition>268435455</ElementPosition>
+\t\t\t\t<ExtendedStyle>tab_simpleFastTab</ExtendedStyle>
 \t\t\t\t<Type>Tab</Type>
 \t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t<HeightMode>SizeToAvailable</HeightMode>
@@ -1504,7 +2004,6 @@ ${captionXml}\t\t<Pattern xmlns="">Workspace</Pattern>
 \t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\ti:type="AxFormTabPageControl">
 \t\t\t\t\t\t<Name>SummarySection</Name>
-\t\t\t\t\t\t<Caption>Summary</Caption>
 \t\t\t\t\t\t<ElementPosition>536870911</ElementPosition>
 \t\t\t\t\t\t<Type>TabPage</Type>
 \t\t\t\t\t\t<FormControlExtension
@@ -1513,8 +2012,6 @@ ${captionXml}\t\t<Pattern xmlns="">Workspace</Pattern>
 \t\t\t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
 \t\t\t\t\t\t\t\t<Name>TileSection</Name>
-\t\t\t\t\t\t\t\t<Pattern>Workspace_SummaryNumbers_UnboundFields</Pattern>
-\t\t\t\t\t\t\t\t<PatternVersion>1.0</PatternVersion>
 \t\t\t\t\t\t\t\t<Type>Group</Type>
 \t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>
 \t\t\t\t\t\t\t\t<FormControlExtension
@@ -1525,7 +2022,6 @@ ${captionXml}\t\t<Pattern xmlns="">Workspace</Pattern>
 \t\t\t\t\t\t\t\t</Controls>
 \t\t\t\t\t\t\t\t<ArrangeMethod>HorizontalLeft</ArrangeMethod>
 \t\t\t\t\t\t\t\t<FrameType>None</FrameType>
-\t\t\t\t\t\t\t\t<Style>TileSection</Style>
 \t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t\t<AxFormControl xmlns=""
 \t\t\t\t\t\t\t\t\ti:type="AxFormGroupControl">
@@ -1541,12 +2037,14 @@ ${captionXml}\t\t<Pattern xmlns="">Workspace</Pattern>
 \t\t\t\t\t\t\t\t<FrameType>None</FrameType>
 \t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t</Controls>
+\t\t\t\t\t\t<FastTabExpanded>Yes</FastTabExpanded>
 \t\t\t\t\t\t<FrameType>None</FrameType>
+\t\t\t\t\t\t<Caption>Summary</Caption>
 \t\t\t\t\t</AxFormControl>
 ${listSections}\t\t\t\t</Controls>
 \t\t\t\t<AlignChild>No</AlignChild>
-\t\t\t\t<ShowTabs>No</ShowTabs>
-\t\t\t\t<Style>Panorama</Style>
+\t\t\t\t<ShowTabs>Yes</ShowTabs>
+\t\t\t\t<Style>FastTabs</Style>
 \t\t\t</AxFormControl>
 \t\t</Controls>
 \t</Design>

--- a/src/utils/loadEnv.ts
+++ b/src/utils/loadEnv.ts
@@ -35,13 +35,17 @@ export function loadEnv(callerImportMetaUrl: string): void {
     ? resolve(process.env.ENV_FILE)
     : resolve(callerDir, '../.env');
 
-  const result = dotenv.config({ path: envPath });
+  // quiet: true suppresses dotenv v17's stdout "◇ injected env" logging.
+  // That log uses console.log which at module-load time (before the MCP stdio
+  // redirects are set up) writes directly to process.stdout, corrupting the
+  // MCP JSON-RPC channel in stdio mode.
+  const result = dotenv.config({ path: envPath, quiet: true });
   if (result.error && !process.env.ENV_FILE) {
     // Fallback: let dotenv try process.cwd() the normal way.
     // Only fall back when ENV_FILE was not explicitly set — if the user pointed
     // at a specific file that is missing, we surface the error rather than
     // silently loading a different config.
-    dotenv.config();
+    dotenv.config({ quiet: true });
   }
 
   // Resolve relative paths in key variables relative to the .env file's

--- a/src/utils/smartXmlBuilder.ts
+++ b/src/utils/smartXmlBuilder.ts
@@ -7,6 +7,7 @@
 import { FormPatternTemplates, FormPattern } from './formPatternTemplates.js';
 import { ensureXppDocComment } from './xppDocGen.js';
 import { decodeXmlEntitiesFromXppSource } from '../tools/modifyD365File.js';
+import { type FieldControlMap, controlForField } from './fieldControlTypes.js';
 
 export interface TableFieldSpec {
   name: string;
@@ -42,6 +43,10 @@ export interface FormControlSpec {
   type: 'Grid' | 'Group' | 'String' | 'Int64' | 'Real' | 'Date' | 'DateTime' | 'Button' | 'ActionPane';
   properties?: Record<string, string>;
   children?: FormControlSpec[];
+  /** Explicit AxForm control i:type override (e.g. 'AxFormComboBoxControl' for an enum field). */
+  iType?: string;
+  /** Explicit <Type> value override paired with {@link iType} (e.g. 'ComboBox'). */
+  typeValue?: string;
 }
 
 /**
@@ -560,7 +565,11 @@ export class SmartXmlBuilder {
       Button:     { iType: 'AxFormButtonControl',     typeValue: 'Button' },
       ActionPane: { iType: 'AxFormActionPaneControl', typeValue: 'ActionPane' },
     };
-    const mapped = typeMap[type] ?? { iType: 'AxFormStringControl', typeValue: 'String' };
+    // An explicit per-control override (set by buildGridControl for typed fields)
+    // wins over the coarse FormControlSpec.type mapping.
+    const mapped = control.iType && control.typeValue
+      ? { iType: control.iType, typeValue: control.typeValue }
+      : typeMap[type] ?? { iType: 'AxFormStringControl', typeValue: 'String' };
 
     // All AxFormControl nodes need xmlns="" to override the AxForm default namespace
     let xml = `${indent}<AxFormControl xmlns=""\n${indent}\ti:type="${mapped.iType}">\n`;
@@ -616,17 +625,24 @@ export class SmartXmlBuilder {
   /**
    * Generate form grid control with fields
    */
-  buildGridControl(name: string, dataSource: string, fields: string[]): FormControlSpec {
-    const gridChildren: FormControlSpec[] = fields.map(field => ({
-      // Prefix with dataSource to avoid name collisions when multiple grids exist
-      name: `${dataSource}_${field}`,
-      type: 'String',
-      properties: {
-        // DataField MUST come before DataSource — matches real D365FO AOT XML element order
-        DataField: field,
-        DataSource: dataSource,
-      },
-    }));
+  buildGridControl(name: string, dataSource: string, fields: string[], fieldTypes?: FieldControlMap): FormControlSpec {
+    const gridChildren: FormControlSpec[] = fields.map(field => {
+      // Resolve the correct control type per field (enum→ComboBox, date→Date, …);
+      // unknown fields fall back to a string control.
+      const ctl = controlForField(field, fieldTypes);
+      return {
+        // Prefix with dataSource to avoid name collisions when multiple grids exist
+        name: `${dataSource}_${field}`,
+        type: 'String' as const,
+        iType: ctl.iType,
+        typeValue: ctl.typeValue,
+        properties: {
+          // DataField MUST come before DataSource — matches real D365FO AOT XML element order
+          DataField: field,
+          DataSource: dataSource,
+        },
+      };
+    });
 
     return {
       name,

--- a/src/utils/stdioSessionInfo.ts
+++ b/src/utils/stdioSessionInfo.ts
@@ -2,8 +2,8 @@
  * Singleton that stores information captured from the stdio MCP handshake.
  *
  * Written by:
- *  - index.ts createDiagnosticStdin() — parses the raw `initialize` JSON-RPC
- *    request (first message on stdin) and stores clientInfo + capabilities.
+ *  - index.ts createInitializeParamsSniffer() — parses the raw `initialize`
+ *    JSON-RPC request (first message on stdin) and stores clientInfo + capabilities.
  *  - mcpServer.ts applyRootsToConfig() — stores last roots/list result.
  *  - mcpServer.ts RootsListChangedNotificationSchema handler — increments
  *    rootsListChangedCount each time VS 2022 reports a workspace change.

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs/promises';
 import { existsSync } from 'fs';
 import * as path from 'path';
+import { debugLog } from './logger.js';
 
 export interface D365ProjectInfo {
   /** Path to the .rnrproj file. May be undefined when model was detected from PackagesLocalDirectory path. */
@@ -117,18 +118,18 @@ export async function extractModelNameFromProject(projectPath: string): Promise<
  */
 export async function detectD365Project(workspacePath: string, maxDepth: number = 5): Promise<D365ProjectInfo | null> {
   try {
-    console.error(`[WorkspaceDetector] Searching for .rnrproj files in: ${workspacePath}`);
+    debugLog(`[WorkspaceDetector] Searching for .rnrproj files in: ${workspacePath}`);
 
     // Find all .rnrproj files in workspace
     const projectFiles = await findProjectFiles(workspacePath, maxDepth);
 
     if (projectFiles.length === 0) {
-      console.error('[WorkspaceDetector] No .rnrproj files found in workspace');
+      debugLog('[WorkspaceDetector] No .rnrproj files found in workspace');
       return null;
     }
 
-    console.error(`[WorkspaceDetector] Found ${projectFiles.length} .rnrproj file(s):`);
-    projectFiles.forEach(p => console.error(`   - ${p}`));
+    debugLog(`[WorkspaceDetector] Found ${projectFiles.length} .rnrproj file(s):`);
+    projectFiles.forEach(p => debugLog(`   - ${p}`));
 
     // D365FO convention: in a multi-project solution folder the "primary" project
     // usually has the SAME NAME as the solution folder (workspace base name).
@@ -143,7 +144,7 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
       );
       if (nameMatch) {
         primaryProject = nameMatch;
-        console.error(`[WorkspaceDetector] Solution-name match → ${path.basename(nameMatch)}`);
+        debugLog(`[WorkspaceDetector] Solution-name match → ${path.basename(nameMatch)}`);
       }
     }
 
@@ -152,12 +153,12 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
     // (e.g. FleetManagement — the VS new-project wizard default).
     const modelName = await extractModelNameFromProject(primaryProject);
     if (modelName && isMicrosoftDemoModel(modelName) && projectFiles.length > 1) {
-      console.error(`[WorkspaceDetector] Primary .rnrproj has MS demo model "${modelName}" — looking for better candidate`);
+      debugLog(`[WorkspaceDetector] Primary .rnrproj has MS demo model "${modelName}" — looking for better candidate`);
       for (const pf of projectFiles) {
         if (pf === primaryProject) continue;
         const altModel = await extractModelNameFromProject(pf);
         if (altModel && !isMicrosoftDemoModel(altModel)) {
-          console.error(`[WorkspaceDetector] Skipping demo model "${modelName}", using "${altModel}" from ${path.basename(pf)}`);
+          debugLog(`[WorkspaceDetector] Skipping demo model "${modelName}", using "${altModel}" from ${path.basename(pf)}`);
           primaryProject = pf;
           break;
         }
@@ -178,10 +179,10 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
       solutionPath,
     };
 
-    console.error('[WorkspaceDetector] ✅ Detected D365FO project:');
-    console.error(`   Project: ${result.projectPath}`);
-    console.error(`   Model: ${result.modelName}`);
-    console.error(`   Solution: ${result.solutionPath}`);
+    debugLog('[WorkspaceDetector] ✅ Detected D365FO project:');
+    debugLog(`   Project: ${result.projectPath}`);
+    debugLog(`   Model: ${result.modelName}`);
+    debugLog(`   Solution: ${result.solutionPath}`);
 
     return result;
   } catch (error) {
@@ -203,7 +204,7 @@ export async function autoDetectD365Project(
 ): Promise<D365ProjectInfo | null> {
   // Priority 1: Explicit workspace path
   if (explicitWorkspacePath) {
-    console.error(`[WorkspaceDetector] Using explicit workspace path: ${explicitWorkspacePath}`);
+    debugLog(`[WorkspaceDetector] Using explicit workspace path: ${explicitWorkspacePath}`);
     const result = await detectD365Project(explicitWorkspacePath);
     if (result) return result;
   }
@@ -214,9 +215,9 @@ export async function autoDetectD365Project(
   const cwd = process.cwd();
   const cwdIsNodeProject = existsSync(path.join(cwd, 'package.json'));
   if (cwdIsNodeProject) {
-    console.error(`[WorkspaceDetector] Skipping cwd (Node.js project): ${cwd}`);
+    debugLog(`[WorkspaceDetector] Skipping cwd (Node.js project): ${cwd}`);
   } else {
-    console.error(`[WorkspaceDetector] Trying current working directory: ${cwd}`);
+    debugLog(`[WorkspaceDetector] Trying current working directory: ${cwd}`);
     const cwdResult = await detectD365Project(cwd);
     if (cwdResult) return cwdResult;
   }
@@ -224,7 +225,7 @@ export async function autoDetectD365Project(
   // Priority 3: Explicit env vars
   const envWorkspace = process.env.WORKSPACE_PATH;
   if (envWorkspace) {
-    console.error(`[WorkspaceDetector] Trying WORKSPACE_PATH env var: ${envWorkspace}`);
+    debugLog(`[WorkspaceDetector] Trying WORKSPACE_PATH env var: ${envWorkspace}`);
     const envResult = await detectD365Project(envWorkspace);
     if (envResult) return envResult;
   }
@@ -234,7 +235,7 @@ export async function autoDetectD365Project(
   // All found projects are also returned via scanAllD365Projects() for listing in get_workspace_info.
   const solutionsRoot = process.env.D365FO_SOLUTIONS_PATH;
   if (solutionsRoot) {
-    console.error(`[WorkspaceDetector] Scanning D365FO_SOLUTIONS_PATH: ${solutionsRoot}`);
+    debugLog(`[WorkspaceDetector] Scanning D365FO_SOLUTIONS_PATH: ${solutionsRoot}`);
     const result = await detectD365Project(solutionsRoot, 6);
     if (result) return result;
   }
@@ -265,7 +266,7 @@ export async function autoDetectD365Project(
         const files = await findProjectFiles(searchRoot);
         if (files.length > 0) {
           const loggedSearchRoot = sanitizePathForLog(searchRoot);
-          console.error(`[WorkspaceDetector] Found ${files.length} .rnrproj file(s) in ${loggedSearchRoot}`);
+          debugLog(`[WorkspaceDetector] Found ${files.length} .rnrproj file(s) in ${loggedSearchRoot}`);
           const projectPath = files[0]; // take first (most likely the user's project)
           const modelName = await extractModelNameFromProject(projectPath);
           if (modelName) {
@@ -273,8 +274,8 @@ export async function autoDetectD365Project(
             const packagePath = explicitWorkspacePath
               ? path.normalize(explicitWorkspacePath).match(/^(.+[\\\/]PackagesLocalDirectory)(?:[\\\/]|$)/i)?.[1] || null
               : null;
-            console.error(`[WorkspaceDetector] ✅ Found project via well-known path: ${projectPath}`);
-            console.error(`[WorkspaceDetector]    ModelName: ${modelName}`);
+            debugLog(`[WorkspaceDetector] ✅ Found project via well-known path: ${projectPath}`);
+            debugLog(`[WorkspaceDetector]    ModelName: ${modelName}`);
             return {
               modelName,
               projectPath,
@@ -313,9 +314,9 @@ export async function autoDetectD365Project(
     if (match) {
       const packagePath = match[1];
       const modelName = match[2];
-      console.error(`[WorkspaceDetector] ✅ Extracted model name from PackagesLocalDirectory path: ${modelName}`);
-      console.error(`[WorkspaceDetector]    Package path: ${packagePath}`);
-      console.error(`[WorkspaceDetector]    Note: projectPath unknown — addToProject=true requires projectPath in .mcp.json`);
+      debugLog(`[WorkspaceDetector] ✅ Extracted model name from PackagesLocalDirectory path: ${modelName}`);
+      debugLog(`[WorkspaceDetector]    Package path: ${packagePath}`);
+      debugLog(`[WorkspaceDetector]    Note: projectPath unknown — addToProject=true requires projectPath in .mcp.json`);
       return {
         modelName,
         packagePath,

--- a/src/validation/formPatternValidator.ts
+++ b/src/validation/formPatternValidator.ts
@@ -191,12 +191,27 @@ function matchChildren(
 
     if (indices.length === 0) {
       if (spec.occurrence === 'required' || spec.occurrence === 'oneOrMore') {
+        const basefix = `Add a ${spec.controlTypes[0]} control${spec.nameHint ? ` (conventionally named ${spec.nameHint})` : ''} under ${parentPath}.`;
+        const qfSnippet = spec.controlTypes[0] === 'QuickFilterControl'
+          ? '\nQuickFilterControl requires a specific XML structure (NO i:type attribute, NOT <ExtensionName>):\n' +
+            '<AxFormControl>\n' +
+            '  <Name>QuickFilterControl</Name>\n' +
+            '  <FormControlExtension>\n' +
+            '    <Name>QuickFilterControl</Name>\n' +
+            '    <ExtensionComponents />\n' +
+            '    <ExtensionProperties>\n' +
+            '      <AxFormControlExtensionProperty><Name>targetControlName</Name><Type>String</Type><Value>Grid</Value></AxFormControlExtensionProperty>\n' +
+            '      <AxFormControlExtensionProperty><Name>defaultColumnName</Name><Type>String</Type><Value>ColumnName</Value></AxFormControlExtensionProperty>\n' +
+            '    </ExtensionProperties>\n' +
+            '  </FormControlExtension>\n' +
+            '</AxFormControl>'
+          : '';
         violations.push({
           rule: 'FP003',
           severity: 'error',
           path: parentPath,
           excerpt: `${patternLabel}: required ${spec.controlTypes.join('/')} ("${spec.id}") is missing`,
-          fix: `Add a ${spec.controlTypes[0]} control${spec.nameHint ? ` (conventionally named ${spec.nameHint})` : ''} under ${parentPath}.`,
+          fix: basefix + qfSnippet,
         });
       }
       continue;

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -9,7 +9,7 @@ import { validateObjectNamingTool } from '../../src/tools/validateObjectNaming';
 import { getExtensionNamingStyle } from '../../src/utils/modelClassifier';
 import { verifyD365ProjectTool } from '../../src/tools/verifyD365Project';
 import { handleCreateD365File } from '../../src/tools/createD365File';
-import { modifyD365FileTool } from '../../src/tools/modifyD365File';
+import { modifyD365FileTool, countTopLevelMethodBodies, isUnresolvedObjectError, extractMethodNameFromSource } from '../../src/tools/modifyD365File';
 import type { XppServerContext } from '../../src/types/context';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
@@ -647,6 +647,317 @@ describe('modify_d365fo_file', () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/bridge is not available/i);
+  });
+
+  it('add-index maps indexFields objects to a flat field-name string[] for the bridge', async () => {
+    // Regression: indexFields is documented as [{ fieldName, direction? }], but the
+    // bridge's addIndex expects string[]. Passing the objects straight through made
+    // the C# side fail to deserialize [{fieldName:…}] into List<string>, surfacing as
+    // a null bridge result misreported as "could not resolve table".
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addIndex = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = {
+      isReady: true,
+      metadataAvailable: true,
+      addIndex,
+      // bridgeValidateAfterWrite is fire-and-forget; provide a no-op surface.
+      validateObject: vi.fn(async () => null),
+    };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentEquipmentTable',
+        operation: 'add-index',
+        indexName: 'EquipmentIdx',
+        indexFields: [{ fieldName: 'AslRentEquipmentId' }],
+        indexAllowDuplicates: false,
+        indexAlternateKey: true,
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(addIndex).toHaveBeenCalledTimes(1);
+    const [tableName, indexName, fields, allowDuplicates, alternateKey] = addIndex.mock.calls[0];
+    expect(tableName).toBe('AslRentEquipmentTable');
+    expect(indexName).toBe('EquipmentIdx');
+    // The critical assertion: a flat array of strings, not [{ fieldName }] objects.
+    expect(fields).toEqual(['AslRentEquipmentId']);
+    expect(allowDuplicates).toBe(false);
+    expect(alternateKey).toBe(true);
+  });
+
+  it('add-relation maps relationConstraints {fieldName,relatedFieldName} to {field,relatedField}', async () => {
+    // Regression: relationConstraints is documented as [{ fieldName, relatedFieldName }] but the
+    // C# WriteRelationConstraint deserializes { field, relatedField }. Without remapping, C# sees
+    // null keys and silently writes a relation with empty constraints (no error, corruption at
+    // compile time).
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addRelation = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = {
+      isReady: true,
+      metadataAvailable: true,
+      addRelation,
+      validateObject: vi.fn(async () => null),
+    };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentEquipmentTable',
+        operation: 'add-relation',
+        relationName: 'AslRentCategory',
+        relatedTable: 'AslRentCategoryTable',
+        relationConstraints: [{ fieldName: 'CategoryId', relatedFieldName: 'CategoryId' }],
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(addRelation).toHaveBeenCalledTimes(1);
+    const [, , , constraints] = addRelation.mock.calls[0];
+    expect(constraints).toEqual([{ field: 'CategoryId', relatedField: 'CategoryId' }]);
+  });
+
+  it('surfaces the real bridge error (not a generic "could not resolve") on a non-resolution failure', async () => {
+    // Regression for the masking bug: adapter catch used to swallow the C# error and
+    // return null, which the tool reported as "could not resolve table". Now the real
+    // message must come through.
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addIndex = vi.fn(async () => {
+      throw new Error("Bridge error [BadRequest]: index 'EquipmentIdx' already exists");
+    });
+    const refreshProvider = vi.fn(async () => ({ refreshed: true, elapsedMs: 1 }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addIndex, refreshProvider };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentEquipmentTable',
+        operation: 'add-index',
+        indexName: 'EquipmentIdx',
+        indexFields: [{ fieldName: 'AslRentEquipmentId' }],
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/already exists/i);
+    // A non-resolution failure must NOT trigger the refresh+retry, and must NOT be
+    // dressed up as "could not resolve".
+    expect(result.content[0].text).not.toMatch(/could not resolve/i);
+    expect(addIndex).toHaveBeenCalledTimes(1);
+    expect(refreshProvider).not.toHaveBeenCalled();
+  });
+
+  it('refresh-retries once on an object-resolution failure, then surfaces guidance + bridge message', async () => {
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValue(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addIndex = vi.fn(async () => {
+      throw new Error("Bridge error [NotFound]: Table 'AslRentEquipmentTable' not found");
+    });
+    const refreshProvider = vi.fn(async () => ({ refreshed: true, elapsedMs: 1 }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addIndex, refreshProvider };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentEquipmentTable',
+        operation: 'add-index',
+        indexName: 'EquipmentIdx',
+        indexFields: [{ fieldName: 'AslRentEquipmentId' }],
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    // Resolution failure: retried exactly once (2 attempts), refresh attempted.
+    expect(addIndex).toHaveBeenCalledTimes(2);
+    expect(refreshProvider).toHaveBeenCalledTimes(1);
+    // Keeps the actionable same-session guidance AND shows what the bridge reported.
+    expect(result.content[0].text).toMatch(/could not resolve/i);
+    expect(result.content[0].text).toMatch(/Bridge reported:/);
+    expect(result.content[0].text).toMatch(/not found/i);
+  });
+
+  it('derives objectName from filePath when objectName is omitted', async () => {
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addIndex = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addIndex, refreshProvider: vi.fn() };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        // objectName intentionally omitted — must be derived from filePath basename
+        operation: 'add-index',
+        indexName: 'EquipmentIdx',
+        indexFields: [{ fieldName: 'AslRentEquipmentId' }],
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(addIndex).toHaveBeenCalledTimes(1);
+    expect(addIndex.mock.calls[0][0]).toBe('AslRentEquipmentTable');
+  });
+
+  it('errors clearly when both objectName and filePath are omitted', async () => {
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', { objectType: 'table', operation: 'add-index', indexName: 'X', indexFields: [{ fieldName: 'Y' }] }),
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/objectName|filePath/);
+  });
+
+  it('rejects add-method whose sourceCode contains two methods', async () => {
+    const twoMethods =
+      `public int lastLineNum()\n{\n    return 0;\n}\n\n` +
+      `public AmountCur calcLineAmount()\n{\n    return this.Qty * this.Price;\n}`;
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentAgreementLine',
+        operation: 'add-method',
+        methodName: 'lastLineNum',
+        sourceCode: twoMethods,
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentAgreementLine.xml',
+      }),
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/exactly ONE method|2 method bodies/i);
+  });
+
+  it('countTopLevelMethodBodies counts methods, ignoring nested blocks/comments/strings', () => {
+    const oneWithNesting =
+      `public void run()\n{\n    if (this.x) { this.y(); }\n    while (a) { b(); }\n    str s = "a) { fake";\n}`;
+    expect(countTopLevelMethodBodies(oneWithNesting)).toBe(1);
+    // A CoC skeleton wraps the method in a class, so the method body is at depth 1,
+    // not top-level → counts 0. That's intended: class-wrapped methods are validly
+    // scoped, so the guard (reject > 1) never fires on them — it targets only BARE
+    // multi-method payloads, which are what land outside the class scope.
+    const cocSkeleton =
+      `[ExtensionOf(classStr(NumberSeqApplicationModule))]\nfinal class Foo_Extension\n{\n    public void loadModule()\n    {\n        next loadModule();\n    }\n}`;
+    expect(countTopLevelMethodBodies(cocSkeleton)).toBe(0);
+    const two =
+      `public int a()\n{\n    return 0;\n}\npublic int b()\n{\n    return 1;\n}`;
+    expect(countTopLevelMethodBodies(two)).toBe(2);
+  });
+
+  it('resolves an unprefixed objectName via the model prefix (RentEquipmentTable → AslRentEquipmentTable)', async () => {
+    const fsMod = await import('fs/promises');
+    const mc = await import('../../src/utils/modelClassifier');
+    const origResolve = vi.mocked(mc.resolveObjectPrefix).getMockImplementation();
+    const origApply = vi.mocked(mc.applyObjectPrefix).getMockImplementation();
+    vi.mocked(mc.resolveObjectPrefix).mockReturnValue('Asl');
+    vi.mocked(mc.applyObjectPrefix).mockImplementation((n: string) =>
+      n.toLowerCase().startsWith('asl') ? n : `Asl${n}`);
+    // Only the PREFIXED file exists on disk; the bare name does not.
+    (fsMod.access as any).mockImplementation(async (p: string) => {
+      if (/AslRentEquipmentTable\.xml$/i.test(p)) return;
+      if (/^[A-Za-z]:[\\/]?$/.test(p) || p === '/') return;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    (fsMod.readFile as any).mockResolvedValue(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addIndex = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addIndex, refreshProvider: vi.fn() };
+
+    try {
+      const result = await modifyD365FileTool(
+        req('modify_d365fo_file', {
+          objectType: 'table',
+          objectName: 'RentEquipmentTable', // no Asl prefix — must be auto-resolved
+          operation: 'add-index',
+          indexName: 'AslRentEquipmentIdx',
+          indexFields: [{ fieldName: 'AslRentEquipmentId' }],
+          modelName: 'MyModel',
+        }),
+        ctx,
+      );
+      expect(result.isError).toBeFalsy();
+      // The bridge gets the prefixed name, derived from the resolved file basename.
+      expect(addIndex.mock.calls[0][0]).toBe('AslRentEquipmentTable');
+    } finally {
+      if (origResolve) vi.mocked(mc.resolveObjectPrefix).mockImplementation(origResolve);
+      if (origApply) vi.mocked(mc.applyObjectPrefix).mockImplementation(origApply);
+    }
+  });
+
+  it('isUnresolvedObjectError distinguishes object resolution from content/member misses', () => {
+    // Genuine object-resolution failures (retry-worthy)
+    expect(isUnresolvedObjectError("Table 'AslRentEquipmentTable' not found")).toBe(true);
+    expect(isUnresolvedObjectError("Form 'AslX' not found")).toBe(true);
+    expect(isUnresolvedObjectError("Cannot determine model for existing object 'AslRentModule'")).toBe(true);
+    expect(isUnresolvedObjectError('could not resolve table')).toBe(true);
+    // Content / member misses (NOT object resolution — must not trigger retry/guidance)
+    expect(isUnresolvedObjectError('Error in replaceCode: oldCode not found in AslRentEquipmentTable.classDeclaration')).toBe(false);
+    expect(isUnresolvedObjectError("Index 'EquipmentIdx' not found on table 'AslRentEquipmentTable'")).toBe(false);
+    expect(isUnresolvedObjectError('index already exists')).toBe(false);
+    expect(isUnresolvedObjectError(undefined)).toBe(false);
+  });
+
+  it('extractMethodNameFromSource reads the name from the signature', () => {
+    expect(extractMethodNameFromSource('public static AslRentParameters find(boolean _f = false)\n{\n}')).toBe('find');
+    expect(extractMethodNameFromSource('/// <summary>x</summary>\npublic void run()\n{\n}')).toBe('run');
+    expect(extractMethodNameFromSource('[ExtensionOf(classStr(Foo))]\nfinal class B\n{\n  public void loadModule() {}\n}')).toBe('loadModule');
+    expect(extractMethodNameFromSource(undefined)).toBeNull();
+  });
+
+  it('add-method derives methodName from the source signature and decodes XML entities', async () => {
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>AslRentParameters</Name></AxTable>`,
+    );
+    const addMethod = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addMethod, refreshProvider: vi.fn(), validateObject: vi.fn(async () => null) };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentParameters',
+        operation: 'add-method',
+        // methodName omitted on purpose; entity-escaped doc comment
+        methodCode: '/// &lt;summary&gt;Finds the params.&lt;/summary&gt;\npublic static AslRentParameters find(boolean _forUpdate = false)\n{\n    AslRentParameters p;\n    return p;\n}',
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentParameters.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(addMethod).toHaveBeenCalledTimes(1);
+    const [, , methodName, source] = addMethod.mock.calls[0];
+    expect(methodName).toBe('find');                 // derived from signature
+    expect(source).toContain('/// <summary>');       // entities decoded
+    expect(source).not.toContain('&lt;');
   });
 
   it('replace-code returns bridge-required error when oldCode is not found (no bridge)', async () => {

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -1377,4 +1377,13 @@ describe('labels dispatcher: action aliases + errors', () => {
     }
     expect(r.content?.[0]?.text ?? '').not.toContain('invalid arguments');
   });
+
+  it('aliases search param searchText → query (does not fail as missing query)', async () => {
+    const r: any = await labelsTool(
+      { method: 'tools/call', params: { name: 'labels', arguments: { action: 'search', searchText: 'customer' } } } as CallToolRequest,
+      ctx,
+    );
+    // searchText is mapped to query, so the search runs instead of failing validation.
+    expect(r.content?.[0]?.text ?? '').not.toMatch(/expected string, received undefined|missing|required/i);
+  });
 });

--- a/tests/tools/mergedDispatchers.test.ts
+++ b/tests/tools/mergedDispatchers.test.ts
@@ -23,8 +23,14 @@ vi.mock('../../src/tools/codeGen', () => ({ codeGenTool: vi.fn((_r: any) => ({ c
 vi.mock('../../src/tools/generateSmart', () => ({ generateSmartTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'scaffold' }] })) }));
 vi.mock('../../src/tools/getTablePatterns', () => ({ getTablePatternsTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'table' }] })) }));
 vi.mock('../../src/tools/formPattern', () => ({ formPatternTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'form' }] })) }));
+vi.mock('../../src/tools/analyzePatterns', () => ({ analyzeCodePatternsTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'patterns' }] })) }));
+vi.mock('../../src/tools/suggestImplementation', () => ({ suggestMethodImplementationTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'impl' }] })) }));
+vi.mock('../../src/tools/analyzeCompleteness', () => ({ analyzeClassCompletenessTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'complete' }] })) }));
+vi.mock('../../src/tools/apiUsagePatterns', () => ({ getApiUsagePatternsTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'api' }] })) }));
 
 import { extensionInfoTool } from '../../src/tools/extensionInfo';
+import { analyzeCodeTool } from '../../src/tools/analyzeCode';
+import { getApiUsagePatternsTool } from '../../src/tools/apiUsagePatterns';
 import { validateCodeTool } from '../../src/tools/validateCode';
 import { generateObjectTool } from '../../src/tools/generateObject';
 import { objectPatternsTool } from '../../src/tools/objectPatterns';
@@ -206,5 +212,19 @@ describe('object_patterns dispatcher', () => {
   it('unknown/omitted domain with no signals → friendly error', async () => {
     const r: any = await objectPatternsTool(req('object_patterns', {}), ctx);
     expect(r.isError).toBe(true);
+  });
+});
+
+// ── analyze_code ──────────────────────────────────────────────────────────────
+describe('analyze_code dispatcher', () => {
+  it('routes api-usage and maps className → apiName', async () => {
+    await analyzeCodeTool(req('analyze_code', { mode: 'api-usage', className: 'NumberSeqFormHandler' }), ctx);
+    expect(getApiUsagePatternsTool).toHaveBeenCalledOnce();
+    expect(argsOf(getApiUsagePatternsTool).apiName).toBe('NumberSeqFormHandler');
+  });
+
+  it('does not override an explicit apiName', async () => {
+    await analyzeCodeTool(req('analyze_code', { mode: 'api-usage', apiName: 'NumberSeq', className: 'X' }), ctx);
+    expect(argsOf(getApiUsagePatternsTool).apiName).toBe('NumberSeq');
   });
 });

--- a/tests/tools/table-method-generator.test.ts
+++ b/tests/tools/table-method-generator.test.ts
@@ -35,6 +35,18 @@ describe('generateTableMethodSource', () => {
     expect(note).toMatch(/Could not resolve the EDT/i);
   });
 
+  it('ignores a base-type signature ("String") and uses the field name, not an invalid X++ type', () => {
+    // The symbol index stores a field's BASE TYPE in signature (e.g. "String"), not its
+    // EDT. "String" is not a valid X++ parameter type — the generator must fall back to
+    // the field name (conventionally the EDT) rather than emit `find(String _id)`.
+    const { source, note } = generateTableMethodSource(
+      'AslRentEquipmentTable', 'find', 'AslRentEquipmentId', fakeDb('String'),
+    );
+    expect(source).toContain('find(AslRentEquipmentId _aslRentEquipmentId,');
+    expect(source).not.toMatch(/find\(String /);
+    expect(note).toMatch(/Could not resolve the EDT/i);
+  });
+
   it('generates an exist method returning boolean', () => {
     const { methodName, source } = generateTableMethodSource(
       'MyTable', 'exist', 'ItemId', fakeDb('ItemId'),

--- a/tests/utils/fieldControlTypes.test.ts
+++ b/tests/utils/fieldControlTypes.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for field type → form control type resolution.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  controlForTableField,
+  controlForField,
+  parseTableFieldControls,
+  DEFAULT_CONTROL,
+} from '../../src/utils/fieldControlTypes';
+
+describe('controlForTableField', () => {
+  it('maps base scalar field types to their form controls', () => {
+    expect(controlForTableField('AxTableFieldString')).toEqual({ iType: 'AxFormStringControl', typeValue: 'String' });
+    expect(controlForTableField('AxTableFieldReal')).toEqual({ iType: 'AxFormRealControl', typeValue: 'Real' });
+    expect(controlForTableField('AxTableFieldDate')).toEqual({ iType: 'AxFormDateControl', typeValue: 'Date' });
+    expect(controlForTableField('AxTableFieldInt')).toEqual({ iType: 'AxFormIntControl', typeValue: 'Integer' });
+    expect(controlForTableField('AxTableFieldInt64')).toEqual({ iType: 'AxFormInt64Control', typeValue: 'Int64' });
+    expect(controlForTableField('AxTableFieldUtcDateTime')).toEqual({ iType: 'AxFormDateTimeControl', typeValue: 'DateTime' });
+  });
+
+  it('maps a non-NoYes enum to a ComboBox', () => {
+    expect(controlForTableField('AxTableFieldEnum', 'SalesStatus')).toEqual({
+      iType: 'AxFormComboBoxControl',
+      typeValue: 'ComboBox',
+    });
+  });
+
+  it('maps a NoYes enum to a CheckBox', () => {
+    expect(controlForTableField('AxTableFieldEnum', 'NoYes')).toEqual({
+      iType: 'AxFormCheckBoxControl',
+      typeValue: 'CheckBox',
+    });
+  });
+
+  it('falls back to a string control for unknown field types', () => {
+    expect(controlForTableField('AxTableFieldSomethingNew')).toEqual(DEFAULT_CONTROL);
+  });
+});
+
+describe('parseTableFieldControls', () => {
+  const tableXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>DemoTable</Name>
+  <Fields>
+    <AxTableField xmlns=""
+        i:type="AxTableFieldString">
+      <Name>AccountNum</Name>
+    </AxTableField>
+    <AxTableField xmlns=""
+        i:type="AxTableFieldEnum">
+      <Name>Status</Name>
+      <EnumType>SalesStatus</EnumType>
+    </AxTableField>
+    <AxTableField xmlns=""
+        i:type="AxTableFieldEnum">
+      <Name>Blocked</Name>
+      <EnumType>NoYes</EnumType>
+    </AxTableField>
+    <AxTableField xmlns=""
+        i:type="AxTableFieldReal">
+      <Name>Amount</Name>
+    </AxTableField>
+    <AxTableField xmlns=""
+        i:type="AxTableFieldDate">
+      <Name>DueDate</Name>
+    </AxTableField>
+  </Fields>
+</AxTable>`;
+
+  const map = parseTableFieldControls(tableXml);
+
+  it('parses every field with its correct control type (case-insensitive key)', () => {
+    expect(map.get('accountnum')).toEqual({ iType: 'AxFormStringControl', typeValue: 'String' });
+    expect(map.get('status')).toEqual({ iType: 'AxFormComboBoxControl', typeValue: 'ComboBox' });
+    expect(map.get('blocked')).toEqual({ iType: 'AxFormCheckBoxControl', typeValue: 'CheckBox' });
+    expect(map.get('amount')).toEqual({ iType: 'AxFormRealControl', typeValue: 'Real' });
+    expect(map.get('duedate')).toEqual({ iType: 'AxFormDateControl', typeValue: 'Date' });
+  });
+
+  it('returns an empty map for non-table content', () => {
+    expect(parseTableFieldControls('<not-a-table/>').size).toBe(0);
+  });
+});
+
+describe('controlForField', () => {
+  const map = new Map([['status', { iType: 'AxFormComboBoxControl', typeValue: 'ComboBox' }]]);
+
+  it('resolves a mapped field', () => {
+    expect(controlForField('Status', map).typeValue).toBe('ComboBox');
+  });
+
+  it('defaults to a string control when the field or map is absent', () => {
+    expect(controlForField('Unknown', map)).toEqual(DEFAULT_CONTROL);
+    expect(controlForField('Status', undefined)).toEqual(DEFAULT_CONTROL);
+  });
+});

--- a/tests/utils/formPatternTemplates.test.ts
+++ b/tests/utils/formPatternTemplates.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { FormPatternTemplates } from '../../src/utils/formPatternTemplates';
+import { validateFormPatternXml } from '../../src/validation/formPatternValidator';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -118,31 +119,38 @@ describe('SimpleListDetails pattern', () => {
     expect(xml).toContain('AxFormActionPaneControl');
   });
 
-  it('has GridContainer with SidePanel pattern', () => {
+  it('has GridContainer as a SidePanel (Style, not a Pattern)', () => {
     expect(hasNamedControl(xml, 'GridContainer')).toBe(true);
-    expect(xml).toContain('<Pattern>SidePanel</Pattern>');
+    // SidePanel is a Style on the nav-list container, NOT a <Pattern> — the
+    // platform has no "SidePanel" sub-pattern (mining confirmed).
+    expect(xml).toContain('<Style>SidePanel</Style>');
+    expect(xml).not.toContain('<Pattern>SidePanel</Pattern>');
   });
 
   it('has QuickFilter inside GridContainer', () => {
     expect(hasNamedControl(xml, 'QuickFilterControl')).toBe(true);
   });
 
-  it('has Grid with List style', () => {
+  it('has a read-only List-style nav grid', () => {
     expect(hasNamedControl(xml, 'Grid')).toBe(true);
     expect(xml).toContain('<Style>List</Style>');
+    expect(xml).toContain('<AllowEdit>No</AllowEdit>');
   });
 
-  it('has DetailsGroup with Tab', () => {
-    expect(hasNamedControl(xml, 'DetailsGroup')).toBe(true);
+  it('has a DetailsHeader (FieldsFieldGroups) and a Details Tabs control', () => {
+    expect(hasNamedControl(xml, 'DetailsHeader')).toBe(true);
     expect(hasNamedControl(xml, 'Tab')).toBe(true);
   });
 
-  it('has Overview and General tab pages', () => {
-    expect(hasNamedControl(xml, 'TabPageOverview')).toBe(true);
+  it('sets ColumnsMode=Fill on FieldsFieldGroups containers', () => {
+    expect(xml).toContain('<ColumnsMode>Fill</ColumnsMode>');
+  });
+
+  it('has the General details tab page', () => {
     expect(hasNamedControl(xml, 'TabPageGeneral')).toBe(true);
   });
 
-  it('places detail fields in overview group', () => {
+  it('places detail fields in the details header overview group', () => {
     expect(hasNamedControl(xml, 'Overview_Field1')).toBe(true);
   });
 });
@@ -155,7 +163,7 @@ describe('DetailsMaster pattern', () => {
   it('generates valid XML with correct pattern', () => {
     expect(xml).toContain('<AxForm');
     expect(hasDesignProperty(xml, 'Pattern', 'DetailsMaster')).toBe(true);
-    expect(hasDesignProperty(xml, 'PatternVersion', '1.1')).toBe(true);
+    expect(hasDesignProperty(xml, 'PatternVersion', '1.4')).toBe(true);
     expect(hasDesignProperty(xml, 'Style', 'DetailsFormMaster')).toBe(true);
   });
 
@@ -176,17 +184,28 @@ describe('DetailsMaster pattern', () => {
     expect(xml).toContain('AxFormActionPaneControl');
   });
 
-  it('has NavigationFilterGroup with QuickFilter', () => {
-    expect(hasNamedControl(xml, 'NavigationFilterGroup')).toBe(true);
-    expect(xml).toContain('<Pattern>CustomAndQuickFilters</Pattern>');
+  it('has NavigationList (SidePanel) with QuickFilter and a List grid', () => {
+    // DetailsMaster 1.4 keeps a hidden NavigationList side panel (not a bare filter).
+    expect(hasNamedControl(xml, 'NavigationList')).toBe(true);
     expect(hasNamedControl(xml, 'QuickFilterControl')).toBe(true);
+    expect(xml).toContain('<Style>SidePanel</Style>');
   });
 
-  it('has HeaderGroup', () => {
-    expect(hasNamedControl(xml, 'HeaderGroup')).toBe(true);
+  it('has a Details Panel (DetailHeaderGroup + DetailTab) under the Panel Tab', () => {
+    // v1.4 wraps the detail view in FormTabPageDetail (PanelStyle=Details).
+    expect(hasNamedControl(xml, 'FormTabPageDetail')).toBe(true);
+    expect(hasNamedControl(xml, 'DetailHeaderGroup')).toBe(true);
+    expect(hasNamedControl(xml, 'DetailTab')).toBe(true);
+    expect(xml).toContain('<PanelStyle>Details</PanelStyle>');
   });
 
-  it('has Tab with FastTabs style', () => {
+  it('has a Grid Panel with a default action', () => {
+    expect(hasNamedControl(xml, 'FormTabPageGrid')).toBe(true);
+    expect(xml).toContain('<PanelStyle>Grid</PanelStyle>');
+    expect(xml).toContain('<DefaultAction>OverviewGridDefaultAction</DefaultAction>');
+  });
+
+  it('has Tab with FastTabs style on the inner detail tab', () => {
     expect(hasNamedControl(xml, 'Tab')).toBe(true);
     expect(xml).toContain('<Style>FastTabs</Style>');
   });
@@ -201,14 +220,12 @@ describe('DetailsMaster pattern', () => {
     expect(hasNamedControl(xml, 'Overview_Field2')).toBe(true);
   });
 
-  it('generates correct control hierarchy order: ActionPane → Filter → Header → Tab', () => {
+  it('generates correct control hierarchy order: ActionPane → NavigationList → Tab', () => {
     const actionPaneIdx = xml.indexOf('<Name>ActionPane</Name>');
-    const filterIdx = xml.indexOf('<Name>NavigationFilterGroup</Name>');
-    const headerIdx = xml.indexOf('<Name>HeaderGroup</Name>');
+    const navListIdx = xml.indexOf('<Name>NavigationList</Name>');
     const tabIdx = xml.indexOf('<Name>Tab</Name>');
-    expect(actionPaneIdx).toBeLessThan(filterIdx);
-    expect(filterIdx).toBeLessThan(headerIdx);
-    expect(headerIdx).toBeLessThan(tabIdx);
+    expect(actionPaneIdx).toBeLessThan(navListIdx);
+    expect(navListIdx).toBeLessThan(tabIdx);
   });
 });
 
@@ -225,7 +242,8 @@ describe('DetailsTransaction pattern', () => {
   it('generates valid XML with correct pattern', () => {
     expect(xml).toContain('<AxForm');
     expect(hasDesignProperty(xml, 'Pattern', 'DetailsTransaction')).toBe(true);
-    expect(hasDesignProperty(xml, 'PatternVersion', '1.1')).toBe(true);
+    // v1.4 is the only DetailsTransaction version shipped by the platform.
+    expect(hasDesignProperty(xml, 'PatternVersion', '1.4')).toBe(true);
     expect(hasDesignProperty(xml, 'Style', 'DetailsFormTransaction')).toBe(true);
   });
 
@@ -244,8 +262,9 @@ describe('DetailsTransaction pattern', () => {
     expect(matches!.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('uses Active LinkType for lines datasource (not InnerJoin)', () => {
-    expect(xml).toContain('<LinkType>Active</LinkType>');
+  it('links lines datasource to the header via JoinSource + Delayed link', () => {
+    expect(xml).toContain('<JoinSource>TestDS</JoinSource>');
+    expect(xml).toContain('<LinkType>Delayed</LinkType>');
     expect(xml).not.toContain('<LinkType>InnerJoin</LinkType>');
   });
 
@@ -260,19 +279,38 @@ describe('DetailsTransaction pattern', () => {
     expect(hasNamedControl(xml, 'ActionPane')).toBe(true);
   });
 
-  it('has NavigationFilterGroup with QuickFilter', () => {
-    expect(hasNamedControl(xml, 'NavigationFilterGroup')).toBe(true);
+  it('has a Navigation List (read-only header grid) required by v1.4', () => {
+    expect(hasNamedControl(xml, 'NavigationList')).toBe(true);
+    expect(hasNamedControl(xml, 'NavigationListGrid')).toBe(true);
     expect(hasNamedControl(xml, 'QuickFilterControl')).toBe(true);
+    // The nav list grid is a SidePanel, read-only, List-style grid bound to the header.
+    expect(xml).toContain('<Style>SidePanel</Style>');
+    expect(xml).toContain('<AllowEdit>No</AllowEdit>');
   });
 
-  it('has Tab with FastTabs style', () => {
-    expect(hasNamedControl(xml, 'Tab')).toBe(true);
+  it('Navigation List grid is bound to the header datasource', () => {
+    const gridIdx = xml.indexOf('<Name>NavigationListGrid</Name>');
+    expect(gridIdx).toBeGreaterThan(-1);
+    expect(xml.indexOf('<DataSource>TestDS</DataSource>', gridIdx)).toBeGreaterThan(-1);
+  });
+
+  it('has the v1.4 nested panel tabs (MainTab + DetailsTab) with FastTabs leaves', () => {
+    expect(hasNamedControl(xml, 'MainTab')).toBe(true);
+    expect(hasNamedControl(xml, 'DetailsTab')).toBe(true);
+    expect(hasNamedControl(xml, 'LineViewTab')).toBe(true);
     expect(xml).toContain('<Style>FastTabs</Style>');
   });
 
-  it('has Header and Lines tab pages', () => {
-    expect(hasNamedControl(xml, 'TabPageHeader')).toBe(true);
-    expect(hasNamedControl(xml, 'TabPageLines')).toBe(true);
+  it('pairs Details and Grid panels under MainTab', () => {
+    expect(hasNamedControl(xml, 'TabPageDetails')).toBe(true);
+    expect(hasNamedControl(xml, 'TabPageGrid')).toBe(true);
+    expect(xml).toContain('<PanelStyle>Details</PanelStyle>');
+    expect(xml).toContain('<PanelStyle>Grid</PanelStyle>');
+  });
+
+  it('has Line View header and lines pages', () => {
+    expect(hasNamedControl(xml, 'LineViewHeader')).toBe(true);
+    expect(hasNamedControl(xml, 'LineViewLines')).toBe(true);
   });
 
   it('has LinesGrid bound to lines datasource', () => {
@@ -280,12 +318,13 @@ describe('DetailsTransaction pattern', () => {
     expect(xml).toContain(`<DataSource>TestLines</DataSource>`);
   });
 
-  it('has LinesActionPane for line-level actions', () => {
-    expect(hasNamedControl(xml, 'LinesActionPane')).toBe(true);
+  it('carries a DetailTitleContainer header (HeaderInfo)', () => {
+    expect(hasNamedControl(xml, 'HeaderInfo')).toBe(true);
+    expect(xml).toContain('<Style>DetailTitleContainer</Style>');
   });
 
   it('HeaderGeneralGroup does not have redundant Pattern attribute', () => {
-    // The group inside TabPageHeader should not have its own Pattern=FieldsFieldGroups
+    // The group inside LineViewHeader should not have its own Pattern=FieldsFieldGroups
     const headerGroupIdx = xml.indexOf('<Name>HeaderGeneralGroup</Name>');
     expect(headerGroupIdx).toBeGreaterThan(-1);
     // Check the ~200 chars after HeaderGeneralGroup name — should have Type but not Pattern
@@ -368,9 +407,15 @@ describe('TableOfContents pattern', () => {
     expect(hasDesignProperty(xml, 'PatternVersion', '1.1')).toBe(true);
   });
 
-  it('has ActionPane control', () => {
-    expect(hasNamedControl(xml, 'ActionPane')).toBe(true);
-    expect(xml).toContain('AxFormActionPaneControl');
+  it('has no ActionPane — the TableOfContents pattern forbids one in Design', () => {
+    expect(hasNamedControl(xml, 'ActionPane')).toBe(false);
+    expect(xml).not.toContain('AxFormActionPaneControl');
+  });
+
+  it('wraps each section in a TOCTitleContainer + nested FastTab', () => {
+    expect(xml).toContain('<Style>TOCTitleContainer</Style>');
+    expect(xml).toContain('<Style>VerticalTabs</Style>');
+    expect(hasNamedControl(xml, 'TabPageGeneralFastTab')).toBe(true);
   });
 
   it('has DataSource on Design when dsName is provided', () => {
@@ -381,9 +426,11 @@ describe('TableOfContents pattern', () => {
     expect(xml).toContain('<InsertIfEmpty>No</InsertIfEmpty>');
   });
 
-  it('has Tab with TOCList style', () => {
+  it('has a TOC navigation Tab with no invalid TabStyle', () => {
+    // 'TOCList' is not a valid FormTabStyle enum — it makes xppc abort
+    // deserialization, which suppresses pattern validation for the whole build.
     expect(hasNamedControl(xml, 'Tab')).toBe(true);
-    expect(xml).toContain('<Style>TOCList</Style>');
+    expect(xml).not.toContain('<Style>TOCList</Style>');
   });
 
   it('generates tab pages from sections', () => {
@@ -424,14 +471,15 @@ describe('Lookup pattern', () => {
   const xml = FormPatternTemplates.buildLookup(defaultOpts);
 
   it('generates valid XML with correct pattern', () => {
-    expect(hasDesignProperty(xml, 'Pattern', 'Lookup')).toBe(true);
-    expect(hasDesignProperty(xml, 'PatternVersion', '1.2')).toBe(true);
+    // The installed platform exposes the grid-only lookup as 'LookupGridOnly' 1.1.
+    expect(hasDesignProperty(xml, 'Pattern', 'LookupGridOnly')).toBe(true);
+    expect(hasDesignProperty(xml, 'PatternVersion', '1.1')).toBe(true);
     expect(hasDesignProperty(xml, 'Style', 'Lookup')).toBe(true);
   });
 
-  it('has CustomFilterGroup with QuickFilter', () => {
-    expect(hasNamedControl(xml, 'CustomFilterGroup')).toBe(true);
-    expect(hasNamedControl(xml, 'QuickFilterControl')).toBe(true);
+  it('is grid-only — no filter group allowed by LookupGridOnly', () => {
+    expect(hasNamedControl(xml, 'CustomFilterGroup')).toBe(false);
+    expect(hasDesignProperty(xml, 'HeightMode', 'SizeToContent')).toBe(true);
   });
 
   it('has Grid with fields', () => {
@@ -447,7 +495,7 @@ describe('ListPage pattern', () => {
 
   it('generates valid XML with correct pattern', () => {
     expect(hasDesignProperty(xml, 'Pattern', 'ListPage')).toBe(true);
-    expect(hasDesignProperty(xml, 'PatternVersion', '1.1')).toBe(true);
+    expect(hasDesignProperty(xml, 'PatternVersion', 'UX7 1.0')).toBe(true);
     expect(hasDesignProperty(xml, 'Style', 'ListPage')).toBe(true);
   });
 
@@ -527,4 +575,62 @@ describe('Form pattern edge cases', () => {
       expect(xml).toContain('</AxForm>');
     }
   });
+});
+
+// ─── Control-type correctness ────────────────────────────────────────────────
+
+describe('typed field controls', () => {
+  const fieldTypes = new Map([
+    ['status', { iType: 'AxFormComboBoxControl', typeValue: 'ComboBox' }],
+    ['amount', { iType: 'AxFormRealControl', typeValue: 'Real' }],
+    ['name', { iType: 'AxFormStringControl', typeValue: 'String' }],
+  ]);
+  const opts = { ...defaultOpts, gridFields: ['Name', 'Status', 'Amount'], fieldTypes };
+
+  it('SimpleList renders the correct control type per field', () => {
+    const xml = FormPatternTemplates.buildSimpleList(opts);
+    expect(xml).toContain('i:type="AxFormComboBoxControl"');
+    expect(xml).toContain('<Type>ComboBox</Type>');
+    expect(xml).toContain('i:type="AxFormRealControl"');
+  });
+
+  it('defaults to string controls when no type map is given', () => {
+    const xml = FormPatternTemplates.buildSimpleList({ ...defaultOpts });
+    expect(xml).toContain('i:type="AxFormStringControl"');
+    expect(xml).not.toContain('AxFormComboBoxControl');
+  });
+
+  it('DetailsTransaction renders typed line-grid columns', () => {
+    const xml = FormPatternTemplates.buildDetailsTransaction({
+      ...opts,
+      linesDsName: 'Lines',
+      linesDsTable: 'LineT',
+      linesFields: ['Qty'],
+      linesFieldTypes: new Map([['qty', { iType: 'AxFormRealControl', typeValue: 'Real' }]]),
+    });
+    expect(xml).toContain('<Name>Line_Qty</Name>');
+    const idx = xml.indexOf('<Name>Line_Qty</Name>');
+    expect(xml.slice(idx - 120, idx)).toContain('AxFormRealControl');
+  });
+});
+
+// ─── Generated forms conform to their own pattern (no validator errors) ───────
+
+describe('generated forms pass the pattern validator', () => {
+  const cases: Array<[string, string]> = [
+    ['SimpleList', FormPatternTemplates.buildSimpleList(defaultOpts)],
+    ['SimpleListDetails', FormPatternTemplates.buildSimpleListDetails(defaultOpts)],
+    ['DetailsMaster', FormPatternTemplates.buildDetailsMaster(defaultOpts)],
+    ['DetailsTransaction', FormPatternTemplates.buildDetailsTransaction({
+      ...defaultOpts, linesDsName: 'Lines', linesDsTable: 'LineT', linesFields: ['Field1'],
+    })],
+  ];
+
+  for (const [name, xml] of cases) {
+    it(`${name} produces no pattern errors`, async () => {
+      const report = await validateFormPatternXml(xml);
+      const errors = report.violations.filter((v) => v.severity === 'error');
+      expect(errors, JSON.stringify(errors, null, 2)).toHaveLength(0);
+    });
+  }
 });

--- a/tests/utils/loadEnv.test.ts
+++ b/tests/utils/loadEnv.test.ts
@@ -76,7 +76,7 @@ describe('env file path resolution', () => {
     loadEnv(FAKE_CALLER_URL);
 
     expect(mockConfig).toHaveBeenCalledTimes(1);
-    expect(mockConfig).toHaveBeenCalledWith({ path: REPO_ROOT_ENV });
+    expect(mockConfig).toHaveBeenCalledWith({ path: REPO_ROOT_ENV, quiet: true });
   });
 
   it('uses ENV_FILE when set to an absolute path', () => {
@@ -86,6 +86,7 @@ describe('env file path resolution', () => {
     expect(mockConfig).toHaveBeenCalledTimes(1);
     expect(mockConfig).toHaveBeenCalledWith({
       path: path.resolve('/some/instances/alpha/.env'),
+      quiet: true,
     });
   });
 
@@ -95,6 +96,7 @@ describe('env file path resolution', () => {
 
     expect(mockConfig).toHaveBeenCalledWith({
       path: path.resolve('instances/alpha/.env'),
+      quiet: true,
     });
   });
 });
@@ -108,8 +110,8 @@ describe('fallback behaviour', () => {
 
     // First call: explicit path; second call: no args (process.cwd() fallback)
     expect(mockConfig).toHaveBeenCalledTimes(2);
-    expect(mockConfig).toHaveBeenNthCalledWith(1, { path: REPO_ROOT_ENV });
-    expect(mockConfig).toHaveBeenNthCalledWith(2);
+    expect(mockConfig).toHaveBeenNthCalledWith(1, { path: REPO_ROOT_ENV, quiet: true });
+    expect(mockConfig).toHaveBeenNthCalledWith(2, { quiet: true });
   });
 
   it('does NOT fall back when ENV_FILE is set but the file is missing', () => {


### PR DESCRIPTION
## Summary
Reconciles the form-pattern catalog to the installed xppc engine and substantially
hardens the C# metadata bridge plus the create/modify tooling around it. Most of the
bridge work was surfaced by a real object-generation workflow (tables, EDTs, enums,
forms, menus, security) that previously failed or emitted misleading noise.

## Form patterns
- All 9 form patterns reconciled to the installed xppc engine (canonical property
  ordering + per-pattern fixes).
- Type-aware controls (enum→ComboBox, date→Date, …), a lines data source for
  header+lines patterns, business-logic method stubs.
- Pre-clone field-overlap check — cloning structurally unrelated tables fails fast
  instead of producing a gutted form.

## Bridge — object creation (C#)
- **Set `ModelSaveInfo.Name`** — root cause of the universal `createObject`
  `NullReferenceException`. Create routes a new object to its model folder via `Name`;
  Update already knew the location (which is why modify worked while create NRE'd).
- `AxMenu` uses `Elements`/`AddElement` + `AxMenuElementMenuItem`; `MenuItemType`
  resolved from the Core assembly.
- `add-data-source` instantiates `AxFormDataSourceRoot` explicitly and is **idempotent**.
- Write provider **spans custom + reference roots** so an extension *of a standard base*
  resolves the base ("given key was not present in the dictionary").
- Read-back validation for menu / menu-item / security / view; `ResolveModelSaveInfo`
  null-guards on the remaining create methods.
- Stop leaking array/non-string properties into the create dict; `GetDictParam` coerces
  non-string JSON instead of throwing.
- `AxMenu` uses `Elements`/`AddElement` + `AxMenuElementMenuItem` for `add-menu-item-to-menu`
  (`MenuItemType` from the Core assembly); the op is **idempotent** (skips a duplicate
  element, which otherwise surfaced as an opaque NRE).

## Bridge & modify — correctness + ergonomics (TS)
- Remap array-of-object modify params (`indexFields`, `relationConstraints`) to the
  bridge's key shape; **surface the real bridge error** instead of masking failures as a
  null "could not resolve". Refresh+retry now fires only on genuine object-resolution
  failures (not content misses like replace-code "oldCode not found").
- Route form `add-method` `"DataSource[.Field].method"` to the data-source override section.
- Reject `add-method` payloads carrying more than one method.
- `find`/`exist` no longer emit a base-type (`String`) parameter — fall back to the field name.
- Resolve an unprefixed `objectName` via the model prefix; `objectName` optional when
  `filePath` is given; smarter lines-table auto-correction.
- Derive `methodName` from the method source signature when omitted; **wire up XML-entity
  decoding** (`&lt;`/`&gt;`/`&amp;`/…) of X++ payloads so escaped source is written as real X++.

## Noise & logging
- Read "object not found" (`-32001`) treated as `null`, not an error.
- Recoverable `createObject`/`createSmartTable` misses logged at debug, not `[ERROR]`.
- Removed the Phase-1 JSON-RPC diagnostic trace; workspace-detection logs gated behind
  `DEBUG_LOGGING`; optional cross-reference SQL connection skipped when unconfigured.

## First-call ergonomics & knowledge
- `labels`: `action="list"`; `searchText`/`text`/`q` aliases for `query`.
- `object_patterns`: `objectType` domain alias + redirect knowledge topics to `get_knowledge`.
- `analyze_code(api-usage)`: `className`/`class` aliases for `apiName`.
- Corrected the **number-sequences** knowledge (NumberSeqApplicationModule + `super()`,
  `NumberSeqDatatype::construct()` + `this.create()`; flagged the AX2012 anti-patterns).

## Activation
- **TS changes** take effect on MCP **server restart**.
- **C# bridge changes** require a **bridge rebuild + restart** (`dotnet build bridge/D365MetadataBridge/D365MetadataBridge.csproj -c Release`).

## Testing
Full suite green — 1048 tests. C# compiles clean against SDK 7.0.7858.27 (metadata APIs verified via reflection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)