### PR TITLE
feat: make objectName optional and derive from filePath in modifyD365 FileTool

### DIFF
--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -180,7 +180,7 @@ const ModifyD365FileArgsSchema = z.object({
     'menu', 'menu-extension',
     'security-privilege', 'security-duty', 'security-role',
   ]).describe('Type of D365FO object'),
-  objectName: z.string().describe('Name of the object to modify'),
+  objectName: z.string().optional().describe('Name of the object to modify'),
   operation: z.enum([
     'add-method', 'remove-method', 'replace-code',
     'add-field', 'modify-field', 'rename-field', 'replace-all-fields', 'remove-field',
@@ -450,6 +450,23 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
   try {
     const args = ModifyD365FileArgsSchema.parse(request.params.arguments);
 
+    // objectName is optional when filePath is given — derive it from the file
+    // basename using path.win32.basename (handles Windows backslash paths on
+    // all platforms — path.posix.basename treats '\\' as a regular character).
+    if (!args.objectName) {
+      if (args.filePath) {
+        (args as any).objectName = path.win32.basename(args.filePath, '.xml');
+      } else {
+        return {
+          content: [{
+            type: 'text',
+            text: "\u274c Provide 'objectName' \u2014 or 'filePath', from which the object name is derived.",
+          }],
+          isError: true,
+        };
+      }
+    }
+
     // Grounding enforcement: modifying an extension changes the behaviour of an
     // existing base object — when GROUNDING_ENFORCE=true the model must prove
     // (via prepare_change) that it inspected the real object first.
@@ -484,13 +501,15 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     const { symbolIndex } = context;
     const {
       objectType,
-      objectName,
       operation,
       createBackup,
       modelName,
       workspacePath,
       filePath: explicitFilePath,
     } = args;
+    // objectName guaranteed non-null by the derivation block above.
+    // Declared as `let` so it can be corrected from the resolved file basename below.
+    let objectName = args.objectName!;
 
     // ── Auto-resolve parentControl for add-control on form-extension ─────────
     // When `parentControl` is a fuzzy / lowercase string (e.g. "general"), look
@@ -669,6 +688,17 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       await createFileBackup(actualFilePath);
     }
 
+    // 3b. Derive the authoritative object name from the resolved file path.
+    //     The caller may pass objectName="RentEquipment" while the file on disk
+    //     is AslRentEquipment.xml (auto-prefixed at create time). The C# bridge
+    //     resolves objects by name — if the name doesn't match the file it will
+    //     always return null. Use path.win32.basename so Windows backslash paths
+    //     are handled correctly on all platforms (posix treats '\\' as a char).
+    const fileBaseName = path.win32.basename(actualFilePath, '.xml');
+    if (fileBaseName && fileBaseName !== objectName) {
+      objectName = fileBaseName;
+    }
+
     // ── Bridge-only modify via IMetadataProvider.Update() ────────────────────
     // ALL modify operations go through the C# bridge. The bridge reads, modifies,
     // and writes via the official D365FO metadata API — no xml2js needed.
@@ -845,11 +875,16 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'add-index': {
         if ((args as any).indexName) {
+          // indexFields is documented as [{fieldName, direction?}] but the bridge
+          // expects a flat string[]. Map objects to their fieldName strings here.
+          const indexFieldNames: string[] | undefined = Array.isArray((args as any).indexFields)
+            ? (args as any).indexFields.map((f: any) => (typeof f === 'string' ? f : f?.fieldName)).filter(Boolean)
+            : undefined;
           bridgeResult = await bridgeAddIndex(
             context.bridge,
             objectName,
             (args as any).indexName,
-            (args as any).indexFields,
+            indexFieldNames,
             (args as any).indexAllowDuplicates,
             (args as any).indexAlternateKey,
           );
@@ -868,12 +903,20 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'add-relation': {
         if ((args as any).relationName && (args as any).relatedTable) {
+          // relationConstraints is documented as [{fieldName, relatedFieldName}] but
+          // the bridge's WriteRelationConstraint deserializes {field, relatedField}.
+          const constraints = Array.isArray((args as any).relationConstraints)
+            ? (args as any).relationConstraints.map((c: any) => ({
+                field: c.fieldName ?? c.field,
+                relatedField: c.relatedFieldName ?? c.relatedField,
+              }))
+            : (args as any).relationConstraints;
           bridgeResult = await bridgeAddRelation(
             context.bridge,
             objectName,
             (args as any).relationName,
             (args as any).relatedTable,
-            (args as any).relationConstraints,
+            constraints,
           );
         }
         break;

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -673,4 +673,117 @@ describe('modify_d365fo_file', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/bridge is not available/i);
   });
+
+  it('add-index maps indexFields objects to a flat field-name string[] for the bridge', async () => {
+    // Regression: indexFields is documented as [{fieldName, direction?}] but the bridge
+    // expects a flat string[]. Without mapping, C# receives [{fieldName:…}] deserialized
+    // as List<string> with null entries — silently creates an index with no fields.
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addIndex = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = {
+      isReady: true,
+      metadataAvailable: true,
+      addIndex,
+      validateObject: vi.fn(async () => null),
+    };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentEquipmentTable',
+        operation: 'add-index',
+        indexName: 'EquipmentIdx',
+        indexFields: [{ fieldName: 'AslRentEquipmentId' }],
+        indexAllowDuplicates: false,
+        indexAlternateKey: true,
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(addIndex).toHaveBeenCalledTimes(1);
+    const [tableName, indexName, fields, allowDuplicates, alternateKey] = addIndex.mock.calls[0];
+    expect(tableName).toBe('AslRentEquipmentTable');
+    expect(indexName).toBe('EquipmentIdx');
+    // The critical assertion: a flat array of strings, not [{ fieldName }] objects.
+    expect(fields).toEqual(['AslRentEquipmentId']);
+    expect(allowDuplicates).toBe(false);
+    expect(alternateKey).toBe(true);
+  });
+
+  it('add-relation maps relationConstraints {fieldName,relatedFieldName} to {field,relatedField}', async () => {
+    // Regression: relationConstraints is documented as [{fieldName, relatedFieldName}] but the
+    // C# WriteRelationConstraint deserializes {field, relatedField}. Without remapping, C# sees
+    // null keys and silently writes a relation with empty constraints.
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addRelation = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = {
+      isReady: true,
+      metadataAvailable: true,
+      addRelation,
+      validateObject: vi.fn(async () => null),
+    };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentEquipmentTable',
+        operation: 'add-relation',
+        relationName: 'AslRentCategory',
+        relatedTable: 'AslRentCategoryTable',
+        relationConstraints: [{ fieldName: 'CategoryId', relatedFieldName: 'CategoryId' }],
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(addRelation).toHaveBeenCalledTimes(1);
+    const [, , , constraints] = addRelation.mock.calls[0];
+    expect(constraints).toEqual([{ field: 'CategoryId', relatedField: 'CategoryId' }]);
+  });
+
+  it('derives objectName from filePath when objectName is omitted', async () => {
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>AslRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const addIndex = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addIndex, validateObject: vi.fn(async () => null) };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        // objectName intentionally omitted — must be derived from filePath basename
+        operation: 'add-index',
+        indexName: 'EquipmentIdx',
+        indexFields: [{ fieldName: 'AslRentEquipmentId' }],
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\AslRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(addIndex).toHaveBeenCalledTimes(1);
+    expect(addIndex.mock.calls[0][0]).toBe('AslRentEquipmentTable');
+  });
+
+  it('errors clearly when both objectName and filePath are omitted', async () => {
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', { objectType: 'table', operation: 'add-index', indexName: 'X', indexFields: [{ fieldName: 'Y' }] }),
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/objectName|filePath/);
+  });
 });


### PR DESCRIPTION
This pull request improves the robustness and usability of the `modifyD365FileTool` by making the `objectName` parameter optional (when `filePath` is provided), ensuring correct mapping of arguments for bridge operations, and adding regression tests to prevent subtle bugs when interacting with the C# bridge. The changes focus on better parameter handling, argument normalization, and comprehensive test coverage.

**Parameter handling and normalization:**

* Made `objectName` in `ModifyD365FileArgsSchema` optional and added logic to derive it from the `filePath` if not provided, ensuring error feedback if both are missing. (`src/tools/modifyD365File.ts`) [[1]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637L183-R183) [[2]](diffhunk://#diff-bb53d7ad3a6b2e887b732ae67da918d064467658d05851a9527b3d7d00a5c637R453-R469)
* After resolving the actual file path, the authoritative `objectName` is derived from the file basename, guaranteeing consistency with the file system and bridge expectations. (`src/tools/modifyD365File.ts`)

**Bridge argument mapping fixes:**

* For the `add-index` operation, mapped `indexFields` from an array of objects to a flat array of field name strings, matching the bridge's expected input and preventing silent failures. (`src/tools/modifyD365File.ts`)
* For the `add-relation` operation, remapped `relationConstraints` from `{fieldName, relatedFieldName}` to `{field, relatedField}` as required by the C# bridge, preventing null keys and empty constraints. (`src/tools/modifyD365File.ts`)

**Test coverage improvements:**

* Added regression tests to verify correct mapping of `indexFields` and `relationConstraints`, derivation of `objectName` from `filePath`, and proper error handling when both are omitted. (`tests/tools/file-ops.test.ts`)