### PR TITLE
fix(build-output): prevent truncation of compiler errors in build output

### DIFF
--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -253,9 +253,16 @@ async function readWholeLog(logFile: string): Promise<string> {
 //   2. Include a context window around each such line.
 //   3. Always include the last TAIL_LINES of the log (build summary).
 //   4. Fall back to head+tail only when no diagnostics are found.
+//
+// The number of diagnostic windows is capped at MAX_DIAGS so a build with
+// hundreds of scattered errors cannot blow up the (now uncapped) response —
+// the goal is to optimise the signal, not to dump the whole log. The first
+// MAX_DIAGS diagnostics (in log order, i.e. earliest/most actionable) are
+// shown; the structured diagnostics section above already summarises counts.
 async function readFullLog(logFile: string, maxLines = 300): Promise<string> {
-  const CONTEXT = 3;   // lines before/after each diagnostic
+  const CONTEXT = 3;     // lines before/after each diagnostic
   const TAIL_LINES = 30; // always-included trailing lines
+  const MAX_DIAGS = 30;  // cap on diagnostic windows to bound response size
 
   try {
     const content = await readFile(logFile, 'utf-8');
@@ -269,8 +276,11 @@ async function readFullLog(logFile: string, maxLines = 300): Promise<string> {
     }
 
     if (diagIndices.length > 0) {
+      const totalDiags = diagIndices.length;
+      const shownDiags = diagIndices.slice(0, MAX_DIAGS);
+
       const included = new Set<number>();
-      for (const idx of diagIndices) {
+      for (const idx of shownDiags) {
         for (let i = Math.max(0, idx - CONTEXT); i <= Math.min(all.length - 1, idx + CONTEXT); i++) {
           included.add(i);
         }
@@ -280,9 +290,10 @@ async function readFullLog(logFile: string, maxLines = 300): Promise<string> {
       }
 
       const sorted = [...included].sort((a, b) => a - b);
-      const out: string[] = [
-        `[Phase table omitted — ${diagIndices.length} diagnostic line(s) with context shown below]\n`,
-      ];
+      const header = totalDiags > shownDiags.length
+        ? `[Phase table omitted — first ${shownDiags.length} of ${totalDiags} diagnostic line(s) with context shown below]\n`
+        : `[Phase table omitted — ${totalDiags} diagnostic line(s) with context shown below]\n`;
+      const out: string[] = [header];
       let prev = -1;
       for (const i of sorted) {
         if (prev !== -1 && i > prev + 1) {

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -246,13 +246,55 @@ async function readWholeLog(logFile: string): Promise<string> {
   }
 }
 
-// Return up to maxLines of a log file, showing head+tail when truncated.
-// Used when reporting a failed build so the full diagnostic context is visible.
+// Return a log excerpt for a failed build that always includes diagnostic lines.
+// When the log is large (e.g. long phase timing tables before the error section),
+// the naive head+tail approach can miss error lines. Instead we:
+//   1. Find every line matching a compiler diagnostic prefix.
+//   2. Include a context window around each such line.
+//   3. Always include the last TAIL_LINES of the log (build summary).
+//   4. Fall back to head+tail only when no diagnostics are found.
 async function readFullLog(logFile: string, maxLines = 300): Promise<string> {
+  const CONTEXT = 3;   // lines before/after each diagnostic
+  const TAIL_LINES = 30; // always-included trailing lines
+
   try {
     const content = await readFile(logFile, 'utf-8');
     const all = content.split(/\r?\n/);
     if (all.length <= maxLines) return content.trim();
+
+    const DIAG_RE = /^(Compile Fatal Error|Compile Error|Compile Warning|Generation Warning|Best Practice Warning):/;
+    const diagIndices: number[] = [];
+    for (let i = 0; i < all.length; i++) {
+      if (DIAG_RE.test(all[i].trim())) diagIndices.push(i);
+    }
+
+    if (diagIndices.length > 0) {
+      const included = new Set<number>();
+      for (const idx of diagIndices) {
+        for (let i = Math.max(0, idx - CONTEXT); i <= Math.min(all.length - 1, idx + CONTEXT); i++) {
+          included.add(i);
+        }
+      }
+      for (let i = Math.max(0, all.length - TAIL_LINES); i < all.length; i++) {
+        included.add(i);
+      }
+
+      const sorted = [...included].sort((a, b) => a - b);
+      const out: string[] = [
+        `[Phase table omitted — ${diagIndices.length} diagnostic line(s) with context shown below]\n`,
+      ];
+      let prev = -1;
+      for (const i of sorted) {
+        if (prev !== -1 && i > prev + 1) {
+          out.push(`... (${i - prev - 1} lines omitted) ...`);
+        }
+        out.push(all[i]);
+        prev = i;
+      }
+      return out.join('\n').trim();
+    }
+
+    // No diagnostic lines found — fall back to head+tail.
     const half = Math.floor(maxLines / 2);
     return (
       `[First ${half} lines]\n` +

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -96,6 +96,10 @@ const TOOL_CAP_SIZES: Record<string, number | 'uncapped'> = {
   get_object_info:                  'uncapped',
   // Method source must never be truncated — partial code is useless
   get_method:                       'uncapped',
+  // Build output must never be truncated — compiler errors appear at the end of
+  // long phase-timing logs and would be lost. The structured diagnostics section
+  // already caps at 25 items; readFullLog now focuses on diagnostic lines only.
+  build_d365fo_project:             'uncapped',
   // New tools with longer output
   security_info:                    8000,
   // extensibility merges the former table-extension/extension-point/strategy/


### PR DESCRIPTION
Two layered truncations were silently hiding xppc.exe errors:

1. toolHandler.ts: build_d365fo_project was not listed in TOOL_CAP_SIZES, so it fell through to the 5000-char default cap. Added it as 'uncapped' — the structured diagnostics section already caps at 25 items, so the raw log section is the only remaining growth vector.

2. buildProject.ts readFullLog(): the old head+tail strategy (first 150 + last 150 lines) would bury error lines inside the omitted middle when xppc's phase timing table filled the first half of the log. Replaced with a diagnostic-focused reader that:
   - Finds every Compile Error / Fatal / Warning line in the full log
   - Includes 3 lines of context around each diagnostic
   - Always includes the last 30 lines (build summary)
   - Falls back to head+tail only when no diagnostics are found

Together these ensure compiler errors are always visible in the MCP response regardless of how long the phase timing table is.