### PR TITLE
Fix/add menu item xml fallback

### DIFF
--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -987,29 +987,32 @@ function numberSeqHandlerTemplate(name: string): string {
 //     numSeqFormHandler.formMethodDataSourceDelete();
 // }
 
-// ── Step 4: NumberSeqApplicationModule extension (loadModule CoC) ────────
+// ── Step 4: NumberSeqApplicationModule subclass (the module class) ────────
 /// <summary>
-/// Extends NumberSeqApplicationModule to register the ${name}Id number sequence reference.
-/// Apply CoC on NumberSeqApplicationModule.loadModule() in your model.
+/// Subclass of NumberSeqApplicationModule that registers the ${name}Id number sequence.
+/// Add a NumberSeqModule enum value for ${name} and register this class via an event
+/// handler on NumberSeqGlobal.initModules() so loadModule() is called at startup.
 /// </summary>
-[ExtensionOf(classStr(NumberSeqApplicationModule${name}))]
-final class NumberSeqApplicationModule${name}_Extension
+public class NumberSeqModule${name} extends NumberSeqApplicationModule
 {
-    public void loadModule()
+    protected void loadModule()
     {
-        next loadModule();
+        NumberSeqDatatype datatype = NumberSeqDatatype::construct();
+        datatype.parmDatatypeId(extendedTypeNum(${name}Id));
+        datatype.parmReferenceHelp(literalStr("${name} identifier"));
+        datatype.parmWizardIsContinuous(false);
+        datatype.parmWizardIsManual(NoYes::No);
+        datatype.parmWizardIsChangeDownAllowed(NoYes::Yes);
+        datatype.parmWizardIsChangeUpAllowed(NoYes::Yes);
+        datatype.parmWizardHighest(0);
+        datatype.parmSortField(1);
+        datatype.addParameterType(NumberSeqParameterType::DataArea, true, false);
+        this.create(datatype);
+    }
 
-        // Add number sequence scope for ${name}Id
-        NumberSeqScopeFactory scopeFactory;
-        NumberSeqScope        scope = NumberSeqScopeFactory::createDataAreaScope();
-
-        NumberSeqReference numSeqRef;
-        numSeqRef.AllowManual         = NoYes::Yes;
-        numSeqRef.Continuous          = NoYes::No;
-        numSeqRef.DataTypeId          = extendedTypeNum(${name}Id);
-        numSeqRef.NumberSequenceModule = extendedTypeNum(${name}Id); // use your module enum
-
-        this.addModuleEntry(numSeqRef, scope, true, "${name} identifier");
+    public NumberSeqModule numberSeqModule()
+    {
+        return NumberSeqModule::${name};
     }
 }
 

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -981,7 +981,7 @@ export async function handleGenerateSmartTable(
  * Returns a base type string compatible with fieldTypeToAxType(), e.g.:
  *   "Qty" → "Real", "TransDate" → "Date", "ItemId" → "String"
  */
-function resolveEdtBaseType(edtName: string, db: any, depth = 0): string {
+function resolveEdtBaseType(edtName: string, db: any, depth = 0): string | undefined {
   // D365FO primitive types − these map directly to AxTableField types
   const PRIMITIVES = new Set([
     'String', 'Integer', 'Int64', 'Real', 'Date', 'UtcDateTime', 'DateTime',
@@ -997,7 +997,10 @@ function resolveEdtBaseType(edtName: string, db: any, depth = 0): string {
       `SELECT extends, enum_type FROM edt_metadata WHERE edt_name = ? LIMIT 1`
     ).get(edtName) as { extends: string | null; enum_type: string | null } | undefined;
 
-    if (!row) return 'String';
+    // EDT not found in the index (e.g. a custom EDT not yet indexed, or a standard OOB EDT
+    // whose index wasn't loaded). Return undefined so callers fall back to EDT-name heuristics
+    // in getAxTableFieldType() instead of blindly defaulting to AxTableFieldString.
+    if (!row) return undefined;
     // Enum-based EDT: extends is null but enum_type is set (e.g. SalesStatus, PurchStatus)
     if (row.enum_type && !row.extends) return 'Enum';
     if (!row.extends) return 'String';
@@ -1006,7 +1009,7 @@ function resolveEdtBaseType(edtName: string, db: any, depth = 0): string {
     // Follow chain to the parent EDT
     return resolveEdtBaseType(row.extends, db, depth + 1);
   } catch {
-    return 'String';
+    return undefined;
   }
 }
 
@@ -1116,6 +1119,13 @@ export function resolveBestEdt(fieldName: string, db: any): string {
     if (acceptFuzzy && best && bestConf >= 0.8) return best;
 
     const heuristic = suggestEdtFromFieldName(fieldName);
+    // If the heuristic only fell back to the generic String255, and the fieldName itself
+    // looks like a PascalCase custom EDT (starts uppercase, ≥5 chars, non-generic), return
+    // the fieldName directly — it's likely a custom EDT not yet in the index.
+    // The edtWarnings system will validate it later and warn if it truly doesn't exist.
+    if (heuristic === 'String255' && acceptFuzzy && /^[A-Z]/.test(fieldName) && fieldName.length >= 5) {
+      return fieldName;
+    }
     if (validateEdtExists(heuristic, db)) return heuristic;
 
     if (acceptFuzzy && best && bestConf >= 0.6) return best;

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -34,6 +34,7 @@ import { recordToolStart, startMetricsLogging, recordCallSequence } from '../uti
 import {
   DEDUP_EXCLUDED_TOOLS, DEDUP_TTL_MS,
   dedupKey, getDedupedResult, storeDedupResult, appendNote,
+  getInFlight, registerInFlight, clearInFlight,
 } from '../utils/callDedup.js';
 import { checkIndexStaleness } from '../utils/indexStaleness.js';
 import { buildContextSnapshot, renderContextSnapshotSection } from '../workspace/contextSnapshot.js';
@@ -190,7 +191,23 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
           `the result above is identical. Use the data you already have instead of re-querying.`,
         );
       }
+      // In-flight dedup: if the same call is already executing, coalesce onto it
+      // rather than starting a redundant parallel execution.
+      const inFlight = getInFlight(callKey);
+      if (inFlight) {
+        console.error(`[toolHandler] ⏳ ${toolName}: identical call already in-flight — coalescing`);
+        const inFlightResult = await inFlight;
+        return appendNote(
+          inFlightResult,
+          `> ♻️ Parallel duplicate — coalesced with a concurrent identical call.`,
+        );
+      }
     }
+
+    // Register this call as in-flight so concurrent duplicates can coalesce.
+    const inFlightHandle = !DEDUP_EXCLUDED_TOOLS.has(toolName)
+      ? registerInFlight(callKey)
+      : null;
 
     const finishMetrics = recordToolStart(toolName);
     let result: any;
@@ -591,6 +608,9 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
 
     if (!DEDUP_EXCLUDED_TOOLS.has(toolName)) {
       storeDedupResult(callKey, capped);
+      // Resolve the in-flight promise so any coalesced waiters get the result.
+      inFlightHandle?.resolve(capped);
+      clearInFlight(callKey);
       // Loop hint: 3+ identical calls in the recent window means the model is
       // cycling (cache misses only happen when calls are >60 s apart).
       if (occurrences >= 3) {

--- a/src/utils/callDedup.ts
+++ b/src/utils/callDedup.ts
@@ -62,6 +62,39 @@ export function clearDedupCache(): void {
   dedupCache.clear();
 }
 
+// ── In-flight dedup ──────────────────────────────────────────────────────────
+// When two identical calls arrive before the first one completes the cache has
+// nothing to serve yet. Track each in-progress call as a Promise so the second
+// call can coalesce onto the first rather than executing a redundant copy.
+
+interface InFlightEntry {
+  promise: Promise<any>;
+  resolve: (r: any) => void;
+  reject: (e: any) => void;
+}
+
+const inFlightCalls = new Map<string, InFlightEntry>();
+
+export function getInFlight(key: string): Promise<any> | undefined {
+  return inFlightCalls.get(key)?.promise;
+}
+
+export function registerInFlight(key: string): { resolve: (r: any) => void; reject: (e: any) => void } {
+  let resolve!: (r: any) => void;
+  let reject!: (e: any) => void;
+  const promise = new Promise<any>((res, rej) => { resolve = res; reject = rej; });
+  inFlightCalls.set(key, { promise, resolve, reject });
+  return { resolve, reject };
+}
+
+export function clearInFlight(key: string): void {
+  inFlightCalls.delete(key);
+}
+
+export function clearAllInFlight(): void {
+  inFlightCalls.clear();
+}
+
 /** Append a note to the first text item of a result (shallow clone). */
 export function appendNote(result: any, note: string): any {
   if (!result?.content?.length) return result;

--- a/tests/tools/edt-resolution.test.ts
+++ b/tests/tools/edt-resolution.test.ts
@@ -101,9 +101,9 @@ describe('resolveBestEdt (DB-aware)', () => {
     // The edtWarnings system in the caller validates it separately.
     const db = fakeDb([]); // empty index — custom EDT not indexed yet
     expect(resolveBestEdt('ContosoRentEquipmentId', db)).toBe('ContosoRentEquipmentId');
-    expect(resolveBestEdt('AslRentAgreementId', db)).toBe('AslRentAgreementId');
-    // Note: AslRentDailyRate still maps to AmountMST via the 'rate' heuristic — correct behavior.
-    expect(resolveBestEdt('AslRentDailyRate', db)).toBe('AmountMST');
+    expect(resolveBestEdt('ContosoRentAgreementId', db)).toBe('ContosoRentAgreementId');
+    // Note: ContosoRentDailyRate still maps to AmountMST via the 'rate' heuristic — correct behavior.
+    expect(resolveBestEdt('ContosoRentDailyRate', db)).toBe('AmountMST');
   });
 
   it('does NOT return the fieldName for generic single-word fields even if PascalCase', () => {

--- a/tests/tools/edt-resolution.test.ts
+++ b/tests/tools/edt-resolution.test.ts
@@ -93,6 +93,26 @@ describe('resolveBestEdt (DB-aware)', () => {
     // The guard only blocks FUZZY matches; an exact same-name EDT is honored.
     expect(resolveBestEdt('Category', fakeDb(['Category', 'ProjCategoryId']))).toBe('Category');
   });
+
+  it('returns the fieldName itself when it looks like a custom PascalCase EDT not in the index', () => {
+    // When a user passes a custom EDT name that was just created (not yet indexed),
+    // resolveBestEdt should trust the input rather than silently defaulting to String255.
+    // This only fires when no specific heuristic matches (e.g. a plain ID field).
+    // The edtWarnings system in the caller validates it separately.
+    const db = fakeDb([]); // empty index — custom EDT not indexed yet
+    expect(resolveBestEdt('ContosoRentEquipmentId', db)).toBe('ContosoRentEquipmentId');
+    expect(resolveBestEdt('AslRentAgreementId', db)).toBe('AslRentAgreementId');
+    // Note: AslRentDailyRate still maps to AmountMST via the 'rate' heuristic — correct behavior.
+    expect(resolveBestEdt('AslRentDailyRate', db)).toBe('AmountMST');
+  });
+
+  it('does NOT return the fieldName for generic single-word fields even if PascalCase', () => {
+    // Generic single-word fields (status, category, type…) must still fall through to
+    // String255 — they are not EDTs, just column names for which we cannot infer a type.
+    const db = fakeDb([]);
+    expect(resolveBestEdt('Status', db)).toBe('String255');
+    expect(resolveBestEdt('Category', db)).toBe('String255');
+  });
 });
 
 describe('isInfrastructureField', () => {

--- a/tests/utils/callDedup.test.ts
+++ b/tests/utils/callDedup.test.ts
@@ -6,11 +6,13 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import {
   dedupKey, getDedupedResult, storeDedupResult, clearDedupCache,
   appendNote, DEDUP_EXCLUDED_TOOLS, DEDUP_TTL_MS,
+  getInFlight, registerInFlight, clearInFlight, clearAllInFlight,
 } from '../../src/utils/callDedup';
 import { recordCallSequence, resetCallSequence, getMetricsSnapshot } from '../../src/utils/toolMetrics';
 
 beforeEach(() => {
   clearDedupCache();
+  clearAllInFlight();
   resetCallSequence();
 });
 
@@ -67,6 +69,51 @@ describe('appendNote', () => {
   it('returns the input unchanged when there is no content', () => {
     const r = { content: [] };
     expect(appendNote(r, 'x')).toBe(r);
+  });
+});
+
+describe('in-flight dedup', () => {
+  it('getInFlight returns undefined before registration', () => {
+    expect(getInFlight('k1')).toBeUndefined();
+  });
+
+  it('registerInFlight makes the promise available via getInFlight', () => {
+    registerInFlight('k1');
+    expect(getInFlight('k1')).toBeInstanceOf(Promise);
+  });
+
+  it('resolving the handle settles the promise', async () => {
+    const handle = registerInFlight('k1');
+    const result = { content: [{ type: 'text', text: 'done' }] };
+    handle.resolve(result);
+    await expect(getInFlight('k1')).resolves.toBe(result);
+  });
+
+  it('clearInFlight removes the entry', () => {
+    registerInFlight('k1');
+    clearInFlight('k1');
+    expect(getInFlight('k1')).toBeUndefined();
+  });
+
+  it('coalesces two parallel identical calls (integration)', async () => {
+    // Simulate two concurrent calls: both check in-flight, neither finds a
+    // cached result. The first registers; the second should coalesce onto it.
+    const key = dedupKey('object_patterns', { domain: 'form', action: 'analyze' });
+
+    // --- caller A: registers and will resolve after a tick ---
+    const handle = registerInFlight(key);
+    const result = { content: [{ type: 'text', text: 'patterns' }] };
+
+    // --- caller B: finds the in-flight promise ---
+    const inFlight = getInFlight(key);
+    expect(inFlight).toBeInstanceOf(Promise);
+
+    // Simulate A completing
+    handle.resolve(result);
+    clearInFlight(key);
+
+    // B should receive the same result
+    expect(await inFlight).toBe(result);
   });
 });
 


### PR DESCRIPTION
## Summary

- **`add-menu-item-to-menu` XML fallback**: when the bridge throws a NullRef
  (new menus are not in bridge's startup-fixed metadata roots), the tool now
  writes `<AxMenuFunctionItem>` directly to the XML file — same pattern as the
  existing `replace-code` XML fallback

- **`replace-code` error hint**: when `oldCode not found`, the error message
  now includes a 💡 tip suggesting `get_object_info` / `add-method` as
  alternatives

- **In-flight dedup**: coalesces parallel identical tool calls that arrive before
  the first one completes (post-execution cache had nothing to serve yet);
  implemented as a Promise-based map alongside the existing TTL cache

- **Scaffold table field types** (2 fixes):
  - `resolveBestEdt`: when the heuristic falls back to `String255`, return the
    fieldName itself if it looks like a PascalCase custom EDT not yet in the
    index (e.g. just created this session)
  - `resolveEdtBaseType`: return `undefined` instead of `'String'` for EDTs not
    found in the index, so `getAxTableFieldType` can fall through to its
    EDT-name heuristics (`AmountMST` → `AxTableFieldReal`, `TransDate` →
    `AxTableFieldDate`)

- **`number-seq-handler` pattern**: replaced the incorrect CoC `[ExtensionOf]`
  skeleton with the correct `extends NumberSeqApplicationModule` subclass using
  `NumberSeqDatatype::construct()` / `parm*()` / `this.create()` — aligned with
  `xppKnowledge`

## Test plan

- [ ] `add-menu-item-to-menu` on a menu created in the current session (not in
  bridge's startup index) → item appears in XML
- [ ] `replace-code` with a wrong `oldCode` → error includes the 💡 tip
- [ ] Two simultaneous identical read-tool calls → second call receives the
  coalesced result (note in response)
- [ ] `generate_object` scaffold table with a custom EDT in `fieldsHint` not yet
  indexed → field keeps the EDT name, not `String255`
- [ ] `generate_object` scaffold table with `AmountMST`/`TransDate` in
  `fieldsHint` → XML element is `AxTableFieldReal`/`AxTableFieldDate`
- [ ] `generate_object(mode="pattern", pattern="number-seq-handler", name="Foo")`
  → generates `public class NumberSeqModuleFoo extends NumberSeqApplicationModule`
  with correct API