### PR TITLE
fix: reduce agent friction from first-session failures

### DIFF
--- a/src/metadata/formPatternMiner.ts
+++ b/src/metadata/formPatternMiner.ts
@@ -107,12 +107,22 @@ function asArray<T>(value: T | T[] | undefined | null): T[] {
   return [value];
 }
 
-/** 'AxFormGridControl' → 'Grid', 'AxFormActionPaneControl' → 'ActionPane', 'AxFormControl' → '' */
+/**
+ * Extension control type names that end in 'Control' and must NOT have the suffix stripped,
+ * because they are identified by that full name via FormControlExtension.Name in the validator.
+ */
+const EXTENSION_CONTROL_NAMES = new Set(['QuickFilterControl', 'SegmentedEntryControl']);
+
+/**
+ * 'AxFormGridControl' → 'Grid', 'AxFormActionPaneControl' → 'ActionPane', 'AxFormControl' → ''
+ * Exception: extension controls like 'QuickFilterControl' keep their full suffix so they
+ * match FormControlExtension.Name lookups used by the form pattern validator.
+ */
 export function normalizeControlType(axType: string | undefined): string {
   if (!axType) return '';
   let t = axType;
   if (t.startsWith('AxForm')) t = t.slice('AxForm'.length);
-  if (t.endsWith('Control')) t = t.slice(0, -'Control'.length);
+  if (t.endsWith('Control') && !EXTENSION_CONTROL_NAMES.has(t)) t = t.slice(0, -'Control'.length);
   return t;
 }
 

--- a/src/tools/findReferences.ts
+++ b/src/tools/findReferences.ts
@@ -11,7 +11,9 @@ import { buildObjectTypeMismatchMessage, detectObjectTypeInDb } from '../utils/m
 import { tryBridgeReferences } from '../bridge/bridgeAdapter.js';
 
 const FindReferencesArgsSchema = z.object({
-  targetName: z.string().describe('Name of the target. For a precise, type-scoped method where-used, qualify it as "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable") or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name matches that name on every type.'),
+  // Accept "name" as an alias for "targetName" — agents frequently confuse the two.
+  targetName: z.string().optional().describe('Name of the target. For a precise, type-scoped method where-used, qualify it as "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable") or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name matches that name on every type.'),
+  name: z.string().optional().describe('Alias for targetName.'),
   targetType: z.enum(['method', 'class', 'table', 'field', 'enum', 'all']).optional().describe('Type of the target to search for'),
   ownerName: z.string().optional().describe('Declaring table/class/form that owns the method, when targetName is just the bare method name. Used to scope the where-used to a single type (matches Visual Studio xref).'),
   scope: z.enum(['all', 'workspace', 'standard', 'custom']).optional().default('all').describe('Search scope'),
@@ -19,7 +21,7 @@ const FindReferencesArgsSchema = z.object({
   // Default OFF: code-context snippets roughly quadruple the token cost of this tool.
   // Agents typically only need file:line:type — turn context on explicitly when you need snippets.
   includeContext: z.boolean().optional().default(false).describe('Include code context around reference (opt-in to reduce token usage)'),
-});
+}).refine(a => a.targetName || a.name, { message: "must have required property 'targetName'" });
 
 /**
  * Map a symbol-index `type` value to its DYNAMICSXREFDB container segment.
@@ -83,7 +85,8 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
   try {
     const args = FindReferencesArgsSchema.parse(request.params.arguments);
     const { symbolIndex } = context;
-    const { targetName, targetType, scope, limit, includeContext, ownerName } = args;
+    const { targetType, scope, limit, includeContext, ownerName } = args;
+    const targetName = (args.targetName ?? args.name)!; // accept "name" alias
 
     // --- Parse the target shape ----------------------------------------------
     // Accept three forms:

--- a/src/tools/getObjectInfo.ts
+++ b/src/tools/getObjectInfo.ts
@@ -29,12 +29,14 @@ const GetObjectInfoArgsSchema = z.object({
     'both are accepted; the base object name is extracted automatically.',
   ),
   name: z.string().min(1).describe('Exact object name (use search/search(queries=[...]) first if unsure).'),
+  // Top-level class shortcuts — accepted directly so callers don't need to nest them in options.
+  methodOffset: z.number().optional().describe('[class] Pagination offset for methods. Classes with >15 methods are paged; pass multiples of 15 to get the next page.'),
+  compact: z.boolean().optional().describe('[class] true = signatures only (default), false = include full method source bodies.'),
   options: z.record(z.string(), z.any()).optional().describe(
-    'Optional type-specific flags forwarded to the reader, e.g. ' +
-    '{ "compact": false } for class, { "includeRdl": true } for report, ' +
-    '{ "searchControl": "AccountNum" } for form, { "filter": "Path" } for macro. ' +
-    'For classes: { "members": "names" } returns a fast IntelliSense-style member ' +
-    'name list (optional "prefix" to filter) instead of full metadata.',
+    'Optional type-specific flags forwarded to the reader. ' +
+    'Class: { "compact": false } for full source, { "methodOffset": 15 } for next method page, ' +
+    '{ "members": "names" } for fast member-name list (add "prefix" to filter). ' +
+    'Report: { "includeRdl": true }. Form: { "searchControl": "AccountNum" }. Macro: { "filter": "Path" }.',
   ),
 });
 
@@ -47,7 +49,11 @@ export async function getObjectInfoTool(request: CallToolRequest, context: XppSe
     };
   }
 
-  const { objectType, name, options } = parsed.data;
+  const { objectType, name, methodOffset, compact, options: rawOptions } = parsed.data;
+  // Merge top-level class shortcuts into options so dispatch.buildArgs sees them.
+  const options: Record<string, any> = { ...rawOptions };
+  if (methodOffset !== undefined) options.methodOffset = methodOffset;
+  if (compact !== undefined) options.compact = compact;
 
   // Folded code_completion: a fast member-name list for classes.
   // get_object_info(objectType="class", name, options:{ members:"names", prefix? })

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -78,7 +78,7 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
       };
     }
 
-    // 2. Find the method in database
+    // 2. Find the method in database (advisory — delegates and SubscribesTo handlers may be absent)
     const methodStmt = rdb.prepare(`
       SELECT name, signature, parent_name, file_path
       FROM symbols
@@ -89,10 +89,6 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
     `);
 
     const methodRow = methodStmt.get(methodName, className);
-
-    if (!methodRow) {
-      throw new Error(`Method "${methodName}" not found in ${classRow.type} "${className}".`);
-    }
 
     // 3. C# bridge (IMetadataProvider — live source, always current)
     // Bridge returns full source → parse signature locally + detect obsolete.
@@ -118,6 +114,23 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
       output += `\`\`\`xpp\n${sigText}\n\`\`\`\n`;
       output += `\n> ⚠️ CoC template not available without full method source. Start the C# bridge for full functionality.\n`;
       return { content: [{ type: 'text', text: output }] };
+    }
+
+    // Method not in SQLite and not reachable via bridge/XML.
+    // Delegates and SubscribesTo handlers are commonly absent from the index.
+    if (!methodRow) {
+      return {
+        content: [{
+          type: 'text',
+          text: `❌ Method **${className}.${methodName}** not found.\n\n` +
+            `The method is not in the symbol index and could not be retrieved via bridge or XML.\n` +
+            `This is common for:\n` +
+            `- **Delegate methods** (declared with the \`delegate\` keyword)\n` +
+            `- **Event handler subscriptions** (\`[SubscribesTo]\` handlers in extension classes)\n\n` +
+            `Use \`get_object_info(objectType="class", name="${className}")\` to see all indexed methods.`,
+        }],
+        isError: true,
+      };
     }
 
     return {

--- a/src/utils/toolProgressMessage.ts
+++ b/src/utils/toolProgressMessage.ts
@@ -42,7 +42,44 @@ export function buildProgressMessage(toolName: string, args: Record<string, any>
       }
     case 'd365fo_file':
       switch (a.action) {
-        case 'modify':   return `✏️ ${a.operation ?? 'Modifying'} on ${a.objectType ?? 'object'} ${a.objectName ?? ''}`;
+        case 'modify': {
+          const op = a.operation ?? 'modify';
+          const obj = `${a.objectType ?? 'object'} ${a.objectName ?? ''}`;
+          switch (op) {
+            case 'add-index':
+            case 'remove-index': {
+              const fields = Array.isArray(a.indexFields)
+                ? a.indexFields.map((f: any) => f.fieldName ?? f).join(', ')
+                : '';
+              return `✏️ ${op} "${a.indexName ?? ''}"${fields ? ` [${fields}]` : ''} on ${obj}`;
+            }
+            case 'add-relation':
+            case 'remove-relation': {
+              const constraints = Array.isArray(a.relationConstraints)
+                ? a.relationConstraints.map((c: any) => `${c.fieldName ?? c.field} → ${c.relatedFieldName ?? c.relatedField}`).join(', ')
+                : '';
+              return `✏️ ${op} "${a.relationName ?? ''}"${a.relatedTable ? ` → ${a.relatedTable}` : ''}${constraints ? ` [${constraints}]` : ''} on ${obj}`;
+            }
+            case 'modify-property':
+              return `✏️ ${op} ${a.propertyPath ?? ''}${a.propertyValue !== undefined ? ` = ${String(a.propertyValue).slice(0, 40)}` : ''} on ${obj}`;
+            case 'add-method':
+            case 'remove-method':
+            case 'add-table-method':
+            case 'add-display-method':
+              return `✏️ ${op} "${a.methodName ?? ''}" on ${obj}`;
+            case 'add-field':
+            case 'modify-field':
+            case 'rename-field':
+            case 'remove-field':
+              return `✏️ ${op} "${a.fieldName ?? ''}"${a.fieldNewName ? ` → "${a.fieldNewName}"` : ''} on ${obj}`;
+            case 'add-enum-value':
+            case 'modify-enum-value':
+            case 'remove-enum-value':
+              return `✏️ ${op} "${a.enumValueName ?? ''}" on ${obj}`;
+            default:
+              return `✏️ ${op} on ${obj}`;
+          }
+        }
         case 'generate': return `🔧 Generating XML for ${a.objectType ?? 'object'} ${a.objectName ?? ''}`;
         default:         return `📁 Creating ${a.objectType ?? 'object'} ${a.objectName ?? ''}`;
       }

--- a/tests/metadata/formPatternMiner.test.ts
+++ b/tests/metadata/formPatternMiner.test.ts
@@ -68,6 +68,13 @@ describe('normalizeControlType', () => {
     expect(normalizeControlType('AxFormControl')).toBe('');
     expect(normalizeControlType(undefined)).toBe('');
   });
+
+  it('preserves Control suffix for extension control types', () => {
+    // QuickFilterControl is an extension control — its full name must be preserved
+    // so it matches FormControlExtension.Name lookups in the validator.
+    expect(normalizeControlType('AxFormQuickFilterControl')).toBe('QuickFilterControl');
+    expect(normalizeControlType('AxFormSegmentedEntryControl')).toBe('SegmentedEntryControl');
+  });
 });
 
 // ─── walkFormDesign on SimpleList template ───────────────────────────────────


### PR DESCRIPTION
- formPatternMiner: preserve 'Control' suffix for extension control types (QuickFilterControl, SegmentedEntryControl) so i:type="AxFormQuickFilterControl" normalizes correctly and passes the form pattern validator instead of producing 'QuickFilter' which the validator rejected as FP003

- methodSignature: remove SQLite hard-gate before bridge/XML fallback so delegate methods and [SubscribesTo] handlers not indexed in SQLite are still resolved via C# bridge or XML, with a descriptive error if all fail

- getObjectInfo: accept methodOffset and compact as top-level arguments (not only nested in options) so agents don't silently lose pagination state; improve options description to prominently document methodOffset

- findReferences: accept 'name' as alias for 'targetName' so agents that pass the wrong parameter name get results instead of a validation error

- toolProgressMessage: add operation-specific detail to d365fo_file modify log (index name+fields, relation name+table+constraints, property path+value, method name, field name) replacing generic 'add-index on table X' messages