### PR TITLE
fix: yield event loop before synchronous DB open to prevent first-req…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,10 +210,16 @@ async function initializeServices() {
     console.log(`📚 Loading metadata from: ${DB_PATH}`);
     console.log(`📚 Labels database: ${LABELS_DB_PATH}`);
     serverState.statusMessage = 'Loading metadata database...';
-    
+
+    // Yield event loop so any pending MCP protocol messages (initialize exchange,
+    // roots/list, first tool call) can be queued before new Database() blocks.
+    // better-sqlite3 open is synchronous — a 1.5 GB file can stall the loop for
+    // several seconds, causing the first client request to time out and cancel.
+    await new Promise<void>(r => setImmediate(r));
+
     let symbolIndex: XppSymbolIndex;
     let symbolCount = 0;
-    
+
     try {
       symbolIndex = new XppSymbolIndex(DB_PATH, LABELS_DB_PATH);
       symbolCount = symbolIndex.getSymbolCount();


### PR DESCRIPTION
…uest cancel

better-sqlite3 new Database() is synchronous. For the 1.5 GB symbol index this can block the Node.js event loop for 3-15 seconds. During this window the StdioServerTransport cannot read stdin, so any tool call that arrives before the DB opens gets no response within the MCP client timeout. The client then sends notifications/cancelled, closes stdin, and the server exits — producing the "canceled on first request, restart required" symptom.

Added a setImmediate yield just before new XppSymbolIndex() so pending stdin messages (initialize exchange, roots/list, first tool call) are queued and processed before the blocking open begins. The dbReady promise then resolves normally and the tool executes with the real index.