### PR TITLE
fix: reduce agent friction (batch 3) — 8 first-attempt failures

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1493,13 +1493,15 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
       },
       {
         name: 'verify_d365fo_project',
-        description: 'Verify that D365FO objects exist on disk at the correct AOT path and are referenced in the .rnrproj project file. Use instead of PowerShell to check d365fo_file(action="create") results.',
+        description:
+          'Verify that D365FO objects exist on disk at the correct AOT path and are referenced in the .rnrproj project file. Use instead of PowerShell to check d365fo_file(action="create") results. ' +
+          'Omit `objects` to verify the ENTIRE project: every object referenced in the .rnrproj is checked on disk (requires projectPath, or an auto-detected/configured project).',
         inputSchema: {
           type: 'object',
           properties: {
             objects: {
               type: 'array',
-              description: 'List of objects to verify',
+              description: 'List of objects to verify. OPTIONAL — omit to verify every object referenced in the project (.rnrproj).',
               items: {
                 type: 'object',
                 properties: {
@@ -1528,19 +1530,20 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             packageName: { type: 'string', description: 'Package name. Auto-resolved from model name if omitted.' },
             packagePath: { type: 'string', description: 'Base package path (default: K:\\AosService\\PackagesLocalDirectory)' },
           },
-          required: ['objects'],
         },
       },
       // ── SDLC & Build Tools ────────────────────────────────────────────────────
       {
         name: 'update_symbol_index',
-        description: 'Index a newly generated or modified D365FO XML file immediately so references to it work without restarting the server. Call this after d365fo_file(action="create") to make the new object instantly searchable.',
+        description:
+          'Index a newly generated or modified D365FO XML file immediately so references to it work without restarting the server. ' +
+          'Call this after d365fo_file(action="create") — pass the created file\'s `filePath` — to make the new object instantly searchable AND, for new AxEnum/AxEdt files, resolvable by scaffolding (so enum fields become AxTableFieldEnum and EDT fields get the correct base type). ' +
+          'Call WITHOUT `filePath` for a lightweight refresh: it refreshes the C# bridge provider and drops workspace caches so objects created via the bridge this session become resolvable (does NOT fully index them into the symbol DB).',
         inputSchema: {
           type: 'object',
           properties: {
-            filePath: { type: 'string', description: 'Absolute path to the modified or created XML file (e.g. K:\\\\AosService\\\\PackagesLocalDirectory\\\\MyModel\\\\MyModel\\\\AxClass\\\\MyClass.xml)' },
+            filePath: { type: 'string', description: 'Absolute path to the modified or created XML file (e.g. K:\\\\AosService\\\\PackagesLocalDirectory\\\\MyModel\\\\MyModel\\\\AxClass\\\\MyClass.xml). Omit to run a lightweight bridge/workspace refresh instead of indexing a specific file.' },
           },
-          required: ['filePath'],
         },
       },
       {

--- a/src/tools/createLabel.ts
+++ b/src/tools/createLabel.ts
@@ -371,6 +371,20 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       const issues = parsed.error.issues
         .map(i => `${i.path.join('.') || '(root)'}: ${i.message}`)
         .join('; ');
+      // Common first-attempt mistake: passing the label *file* shape
+      // (labelFileId + a top-level `language`) instead of the label shape
+      // (labelId + translations[]). Call it out explicitly.
+      const raw = (request.params.arguments ?? {}) as Record<string, unknown>;
+      const wrongShape =
+        (raw.language !== undefined || raw.labelFileId !== undefined) &&
+        raw.labelId === undefined &&
+        raw.translations === undefined &&
+        raw.text === undefined && raw.value === undefined && raw.label === undefined;
+      const shapeHint = wrongShape
+        ? `\n\n⚠️ It looks like you passed \`language\`/\`labelFileId\` but no \`labelId\` or \`translations\`. ` +
+          `\`language\` is NOT a top-level create param — put each language inside \`translations\`. ` +
+          `\`labelFileId\` is the file that HOLDS the label; \`labelId\` is the label itself (both are required).`
+        : '';
       return {
         content: [{
           type: 'text',
@@ -378,7 +392,8 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
             `❌ labels(action="create"/"update"): invalid arguments — ${issues}.\n` +
             `Required: labelId, labelFileId, model, translations:[{language, text}]. Example:\n` +
             `  labels(action="create", labelId="EquipmentName", labelFileId="ContosoExt", model="ContosoExt", ` +
-            `translations=[{language:"en-US", text:"Equipment name"}])`,
+            `translations=[{language:"en-US", text:"Equipment name"}])` +
+            shapeHint,
         }],
         isError: true,
       };

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -347,6 +347,10 @@ export async function handleGenerateSmartForm(
   // Lines datasource (header+lines patterns): add a second datasource bound to
   // the lines table, with its own typed field controls and field list.
   let linesTableResolved = linesTable || linesDataSource;
+  // The effective lines datasource name (may differ from the corrected table name when
+  // an explicit, distinct linesDataSource is supplied). Hoisted so the method-stub
+  // injection below references the same name as the datasource we actually emit.
+  let linesDsNameResolved: string | undefined;
   // Note about an auto-corrected lines table name — threaded into the output via cloneNotes.
   let linesTableNote = '';
   if (linesTableResolved) {
@@ -420,14 +424,41 @@ export async function handleGenerateSmartForm(
       /* index unavailable — skip validation and proceed */
     }
 
-    const linesDsNameResolved = linesDataSource || linesTableResolved;
-    dataSources.push({
-      name: linesDsNameResolved,
-      table: linesTableResolved,
-      allowEdit: true,
-      allowCreate: true,
-      allowDelete: true,
-    });
+    // Datasource name: by D365FO convention it equals the (corrected) table name.
+    // Honor an explicit linesDataSource ONLY when it is a genuinely distinct name —
+    // not just the wrong pluralized guess (e.g. "AslRentAgreementLines") that the
+    // table auto-correction above already resolved to "AslRentAgreementLine".
+    // Otherwise the form ends up with a datasource named after a non-existent table.
+    // Local const captures the (possibly auto-corrected) table name so TS keeps the
+    // non-undefined narrowing through the reassignments above.
+    const linesTbl: string = linesTableResolved;
+    const explicitDsIsStalePlural =
+      !!linesDataSource &&
+      linesDataSource.toLowerCase() !== linesTbl.toLowerCase() &&
+      (linesDataSource.replace(/s$/i, '').toLowerCase() === linesTbl.toLowerCase() ||
+        linesDataSource.toLowerCase() === `${linesTbl.toLowerCase()}s`);
+    const dsName = linesDataSource && !explicitDsIsStalePlural ? linesDataSource : linesTbl;
+    linesDsNameResolved = dsName;
+
+    // Guard against a duplicate datasource: skip when one already targets the same
+    // table or already uses the same name (prevents the stale "…Lines" + correct
+    // "…Line" double-datasource the form scaffolder previously produced).
+    const isDuplicateDs = dataSources.some(
+      ds =>
+        ds.table.toLowerCase() === linesTbl.toLowerCase() ||
+        ds.name.toLowerCase() === dsName.toLowerCase(),
+    );
+    if (!isDuplicateDs) {
+      dataSources.push({
+        name: dsName,
+        table: linesTbl,
+        allowEdit: true,
+        allowCreate: true,
+        allowDelete: true,
+      });
+    } else {
+      console.log(`[generateSmartForm] Skipped duplicate lines datasource for table "${linesTbl}"`);
+    }
     try {
       const db = symbolIndex.getReadDb();
       linesFields = collectGridFields(db, linesTableResolved);
@@ -443,9 +474,11 @@ export async function handleGenerateSmartForm(
     console.warn(`[generateSmartForm] No datasource configured, form will be empty`);
   }
 
-  // Determine package path
+  // Determine package path — prefer the bridge's custom packages root (where bridge-backed
+  // writes actually land) so the reported/fallback path matches the real write location.
   const configManager = getConfigManager();
-  const packagePath = configManager.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
+  const customPackagesRoot = await configManager.getCustomPackagesPath();
+  const packagePath = customPackagesRoot || configManager.getPackagePath() || 'K:\\AosService\\PackagesLocalDirectory';
 
   // Resolve project/solution path — fall back to configManager (from .mcp.json / auto-detection)
   let resolvedProjectPath = projectPath;
@@ -718,7 +751,7 @@ export async function handleGenerateSmartForm(
     const patternInXml = xml.match(/<Pattern xmlns="">([^<]+)<\/Pattern>/)?.[1] ?? normalizedPattern;
     const stubDsName =
       xml.match(/<AxFormDataSource[^>]*>\s*<Name>([^<]+)<\/Name>/)?.[1] ?? primaryDs?.name ?? '';
-    const stubLinesDsName = linesTableResolved ? (linesDataSource || linesTableResolved) : undefined;
+    const stubLinesDsName = linesTableResolved ? (linesDsNameResolved || linesTableResolved) : undefined;
     const stubResult = injectMethodStubs(
       xml,
       methodStubsForPattern(patternInXml, stubDsName, stubLinesDsName),

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -398,14 +398,26 @@ export async function handleGenerateSmartTable(
   {
     const db = symbolIndex.getReadDb();
     for (const f of fields) {
+      // The resolved "EDT" may actually be an enum (e.g. a custom RentStatus enum
+      // or a field that resolveBestEdt echoed back as a same-session custom type).
+      // An enum-backed field must be AxTableFieldEnum + EnumType, not String + EDT.
+      if (f.edt && !f.enumType && isEnumName(f.edt, db)) {
+        f.enumType = f.edt;
+        f.type = 'Enum';
+        f.edt = undefined;
+        continue;
+      }
       if (f.edt && !f.type) {
-        f.type = resolveEdtBaseType(f.edt, db);
+        // Prefer the indexed base type; when the EDT isn't indexed (same-session or
+        // an OOB EDT whose metadata wasn't loaded) fall back to a name heuristic so
+        // the bridge gets an explicit type instead of defaulting Real/Date EDTs to String.
+        f.type = resolveEdtBaseType(f.edt, db) ?? heuristicEdtBaseType(f.edt);
       }
       // Validate EDT exists in the symbol index
       if (f.edt) {
         const edtExists = validateEdtExists(f.edt, db);
         if (!edtExists) {
-          edtWarnings.push(`⚠️ Field "${f.name}": EDT "${f.edt}" not found in indexed metadata — will cause build error 'EdtDoesNotExist'. Change to an existing EDT.`);
+          edtWarnings.push(`⚠️ Field "${f.name}": "${f.edt}" not found in indexed metadata as an EDT or enum — if it is a same-session custom type, call update_symbol_index on its file first, then regenerate. Otherwise this will cause a build error.`);
         }
       }
     }
@@ -476,7 +488,12 @@ export async function handleGenerateSmartTable(
   // and may miss packagePath from config if ensureLoaded() was not yet called.
   const configManager = getConfigManager();
   await configManager.ensureLoaded();
-  const resolvedPackagePath = argPackagePath || configManager.getPackagePath();
+  // Prefer the bridge's custom packages root (where bridge-backed writes actually land,
+  // e.g. a repo metadata checkout like K:\repos\…\metadata) so the exists-guard, the
+  // fallback write target, and the reported path all match the real write location.
+  // Falls back to the standard PackagesLocalDirectory for traditional environments.
+  const customPackagesRoot = await configManager.getCustomPackagesPath();
+  const resolvedPackagePath = argPackagePath || customPackagesRoot || configManager.getPackagePath();
   // getPackagePath() already probes C:\ and K:\ well-known locations before returning null,
   // so reaching here with null means neither location exists on this machine.
   if (!resolvedPackagePath && process.platform === 'win32') {
@@ -759,6 +776,7 @@ export async function handleGenerateSmartTable(
         name: f.name,
         fieldType: f.type || undefined,
         edt: f.edt || undefined,
+        enumType: f.enumType || undefined,
         mandatory: f.mandatory || false,
         label: f.label || undefined,
       })),
@@ -1010,6 +1028,42 @@ function resolveEdtBaseType(edtName: string, db: any, depth = 0): string | undef
     return resolveEdtBaseType(row.extends, db, depth + 1);
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * Heuristic base type from an EDT/field name when the EDT is not in the index
+ * (e.g. a standard EDT whose edt_metadata wasn't loaded, or a same-session EDT).
+ * Mirrors SmartXmlBuilder.getAxTableFieldType's name heuristics but returns the
+ * primitive base type so it can be passed explicitly to the C# bridge (which
+ * otherwise defaults unknown EDTs to AxTableFieldString).
+ * Returns undefined for genuinely unrecognizable names (caller keeps EDT-as-string).
+ */
+export function heuristicEdtBaseType(edtName: string): string | undefined {
+  const e = edtName.toLowerCase();
+  if (e === 'recid' || e.endsWith('recid') || e.includes('refrecid')) return 'Int64';
+  if (e.includes('utcdatetime') || (e.includes('datetime') && !e.includes('transdate'))) return 'UtcDateTime';
+  if (e.includes('date') && !e.includes('time') && !e.includes('update')) return 'Date';
+  if (e.includes('amount') || e.includes('price') || e.includes('qty') || e.includes('quantity')
+      || e.includes('percent') || e.includes('rate') || e === 'real' || e.endsWith('mst')) return 'Real';
+  if ((e.endsWith('int') || e.includes('count') || e.includes('level'))
+      && !e.includes('account') && !e.includes('name')) return 'Integer';
+  return undefined;
+}
+
+/**
+ * Check whether a name refers to an indexed ENUM (not an EDT). Used to emit
+ * AxTableFieldEnum + EnumType instead of AxTableFieldString + ExtendedDataType
+ * for fields whose "EDT" is actually a base enum (e.g. a custom RentStatus enum).
+ */
+export function isEnumName(name: string, db: any): boolean {
+  try {
+    const row = db.prepare(
+      `SELECT 1 FROM symbols WHERE name = ? COLLATE NOCASE AND type IN ('enum', 'enum-extension') LIMIT 1`
+    ).get(name);
+    return !!row;
+  } catch {
+    return false;
   }
 }
 

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -167,6 +167,47 @@ export function countTopLevelMethodBodies(source: string): number {
   return count;
 }
 
+/** Split a source string containing one or more top-level X++ methods into the
+ *  individual method sources (each including any leading doc comments / attributes
+ *  and its full body). Mirrors countTopLevelMethodBodies' brace/comment/string
+ *  handling. Used to let add-method accept several methods in one call and add them
+ *  one <Method> at a time. */
+export function splitTopLevelMethodBodies(source: string): string[] {
+  const s = source;
+  const methods: string[] = [];
+  let depth = 0;
+  let methodStart = -1;
+  let i = 0;
+  while (i < s.length) {
+    const ch = s[i];
+    // Start a method slice at the first significant char (incl. leading /// doc
+    // comments and [Attribute] blocks) after the previous method closed.
+    if (methodStart === -1 && !/\s/.test(ch)) methodStart = i;
+
+    const two = s.slice(i, i + 2);
+    if (two === '//') { const nl = s.indexOf('\n', i); i = nl === -1 ? s.length : nl; continue; }
+    if (two === '/*') { const end = s.indexOf('*/', i + 2); i = end === -1 ? s.length : end + 2; continue; }
+    if (ch === '"') { i++; while (i < s.length && s[i] !== '"') { if (s[i] === '\\') i++; i++; } i++; continue; }
+
+    if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      if (depth > 0) depth--;
+      if (depth === 0 && methodStart !== -1) {
+        methods.push(s.slice(methodStart, i + 1).trim());
+        methodStart = -1;
+      }
+    }
+    i++;
+  }
+  // Trailing brace-less content (e.g. an interface/abstract method declaration).
+  if (methodStart !== -1) {
+    const tail = s.slice(methodStart).trim();
+    if (tail) methods.push(tail);
+  }
+  return methods.filter(Boolean);
+}
+
 /**
  * Reject an add-method payload that contains more than one method. Each add-method
  * call emits a single <Method>; passing two methods drops the second outside the
@@ -704,10 +745,16 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // method-adding operations — replace-code's newCode is a snippet, not a method.
     if (['add-method', 'add-display-method', 'add-table-method'].includes(args.operation)) {
       const methodSrc = args.sourceCode ?? (args as any).methodCode;
-      assertSingleMethodSource(methodSrc);
+      // add-method may carry several methods — they are split and added one <Method>
+      // at a time below. add-display-method / add-table-method generate a single
+      // method, so multiple bodies there are still a mistake.
+      if (args.operation !== 'add-method') {
+        assertSingleMethodSource(methodSrc);
+      }
       // Derive methodName from the source signature when omitted — the full method
       // source already contains the name (e.g. "public static X find(...)" → "find").
-      if (!args.methodName) {
+      // Skip derivation when the payload holds multiple methods (handled per-method).
+      if (!args.methodName && countTopLevelMethodBodies(methodSrc ?? '') <= 1) {
         const derived = extractMethodNameFromSource(methodSrc);
         if (derived) {
           args.methodName = derived;
@@ -948,14 +995,45 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       case 'add-method': {
         // sourceCode and methodCode are aliases; sourceCode wins when both are set.
         const methodSource = args.sourceCode ?? (args as any).methodCode;
-        if (args.methodName && methodSource) {
-          bridgeResult = await bridgeAddMethod(
-            context.bridge,
-            objectType,
-            objectName,
-            args.methodName,
-            methodSource,
-          );
+        if (methodSource) {
+          // A single call may carry several methods — split and add each as its own
+          // <Method> so callers don't have to issue one tool call per method.
+          const bodies = countTopLevelMethodBodies(methodSource) > 1
+            ? splitTopLevelMethodBodies(methodSource)
+            : [methodSource];
+
+          if (bodies.length > 1) {
+            const added: string[] = [];
+            let lastResult: { success: boolean; message: string } | null = null;
+            for (const body of bodies) {
+              const mName = extractMethodNameFromSource(body);
+              if (!mName) {
+                throw new Error(
+                  `⛔ add-method: could not derive a method name from one of the ${bodies.length} method bodies. ` +
+                  `Ensure each method has a complete signature (e.g. "public void foo()").`,
+                );
+              }
+              lastResult = await bridgeAddMethod(context.bridge, objectType, objectName, mName, body);
+              if (!lastResult) {
+                throw new Error(
+                  `Bridge add-method failed for '${mName}' (${added.length} of ${bodies.length} method(s) added successfully: ${added.join(', ') || 'none'}).`,
+                );
+              }
+              added.push(mName);
+            }
+            // Summarize as a single result for the downstream success message.
+            bridgeResult = lastResult
+              ? { ...lastResult, message: `Added ${added.length} methods: ${added.join(', ')}` }
+              : null;
+          } else if (args.methodName) {
+            bridgeResult = await bridgeAddMethod(
+              context.bridge,
+              objectType,
+              objectName,
+              args.methodName,
+              methodSource,
+            );
+          }
         }
         break;
       }

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -85,6 +85,37 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
   const { filePath } = params;
   try {
     const { symbolIndex } = context;
+
+    // ── REFRESH MODE: no filePath ───────────────────────────────────────────
+    // Pick up objects created this session that the caller can't point a file at
+    // (e.g. bridge createObject results) by refreshing the C# bridge provider and
+    // dropping workspace caches. Lighter than a full reindex; per-object SQLite
+    // indexing still needs an explicit filePath.
+    if (!filePath || (typeof filePath === 'string' && filePath.trim().length === 0)) {
+      context.workspaceScanner?.invalidate?.();
+      let bridgeNote = 'Bridge provider not available (skipped).';
+      try {
+        const refreshResult = await bridgeRefreshProvider(context.bridge);
+        if (refreshResult) {
+          bridgeNote = `Bridge provider refreshed in ${refreshResult.elapsedMs}ms — newly created objects are now resolvable by bridge-backed operations.`;
+        }
+      } catch (e: any) {
+        bridgeNote = `Bridge refresh skipped: ${e?.message ?? e}`;
+      }
+      symbolIndex.touchLastIndexed?.();
+      return {
+        content: [{
+          type: 'text',
+          text:
+            `🔄 **Index refresh** (no filePath supplied).\n\n` +
+            `${bridgeNote}\n` +
+            `Workspace scan cache invalidated.\n\n` +
+            `ℹ️ To fully index a specific new object into the searchable symbol DB (so scaffolding ` +
+            `resolves its EDTs/enums and references work), call this tool again with \`filePath\` ` +
+            `pointing at the created \`.xml\` (e.g. the new AxEnum/AxEdt/AxTable file).`,
+        }],
+      };
+    }
     // A file just changed on disk — drop the workspace scan cache so the
     // context pipeline (recently-edited / active object) reflects it at once.
     context.workspaceScanner?.invalidate?.();
@@ -282,14 +313,43 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
       const result = await parser.parseEdtFile(filePath, model);
       if (result.success && result.data) {
         const edtData = result.data as any;
+        const edtName = edtData.name ?? objectName;
         symbolIndex.addSymbol({
-          name: edtData.name ?? objectName,
+          name: edtName,
           type: 'edt',
           signature: edtData.extends ?? undefined,
           filePath,
           model,
         });
         insertedCount++;
+        // Also populate edt_metadata so scaffolding (resolveEdtBaseType / resolveBestEdt)
+        // can resolve this EDT's base type and relation. The single-file indexer
+        // previously skipped this table, so a same-session EDT never resolved its base
+        // type and its fields defaulted to AxTableFieldString.
+        try {
+          symbolIndex.db
+            .prepare(`DELETE FROM edt_metadata WHERE edt_name = ? AND model = ?`)
+            .run(edtName, model);
+          symbolIndex.db.prepare(`
+            INSERT OR REPLACE INTO edt_metadata (
+              edt_name, extends, enum_type, reference_table, relation_type,
+              string_size, database_string_size, display_length, label, model
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `).run(
+            edtName,
+            edtData.extends ?? null,
+            edtData.enumType ?? null,
+            edtData.referenceTable ?? null,
+            edtData.relationType ?? null,
+            edtData.stringSize ?? null,
+            edtData.databaseStringSize ?? null,
+            edtData.displayLength ?? null,
+            edtData.label ?? null,
+            model,
+          );
+        } catch (e) {
+          console.error(`[update_symbol_index] edt_metadata upsert skipped for ${edtName}: ${e}`);
+        }
       } else {
         tx();
       }

--- a/src/tools/verifyD365Project.ts
+++ b/src/tools/verifyD365Project.ts
@@ -51,6 +51,12 @@ const objectFolderMap: Record<string, string> = {
   'security-role':                'AxSecurityRole',
 };
 
+// Reverse of objectFolderMap: AOT folder name (lowercased) → object type. Used to
+// derive objects from a project's Content Includes in verify-all mode.
+const folderToObjectType: Record<string, string> = Object.fromEntries(
+  Object.entries(objectFolderMap).map(([type, folder]) => [folder.toLowerCase(), type])
+);
+
 const VerifyD365ProjectArgsSchema = z.object({
   objects: z
     .array(
@@ -59,7 +65,8 @@ const VerifyD365ProjectArgsSchema = z.object({
         objectName: z.string().describe('Name of the object'),
       })
     )
-    .describe('List of objects to verify'),
+    .optional()
+    .describe('List of objects to verify. Omit to verify every object referenced in the project.'),
   projectPath: z
     .string()
     .optional()
@@ -111,6 +118,10 @@ export async function verifyD365ProjectTool(
     const configPackagePath = configManager.getPackagePath();
     const envType = await configManager.getDevEnvironmentType();
     const configModelName = configManager.getModelName();
+    // Resolve a project path from args or config — needed for the project-reference
+    // check, for model-name derivation, and (in verify-all mode) to enumerate objects.
+    const resolvedProjectPath =
+      args.projectPath || (await configManager.getProjectPath()) || undefined;
 
     // Derive model name — priority:
     //   1) Explicit args.modelName
@@ -119,12 +130,12 @@ export async function verifyD365ProjectTool(
     let actualModelName: string =
       args.modelName ||
       configModelName ||
-      (args.projectPath ? path.basename(args.projectPath, path.extname(args.projectPath)) : '') ||
+      (resolvedProjectPath ? path.basename(resolvedProjectPath, path.extname(resolvedProjectPath)) : '') ||
       'UnknownModel';
     const modelDetectedFrom =
       args.modelName          ? 'argument'    :
       configModelName         ? 'mcp.json'    :
-      args.projectPath        ? 'projectPath' :
+      resolvedProjectPath     ? 'projectPath' :
                                 'none';
 
     let basePath: string;
@@ -159,11 +170,53 @@ export async function verifyD365ProjectTool(
     // ── Load project includes (optional) ─────────────────────────────────────
     let projectIncludes: Set<string> | null = null;
     let projectLoadError: string | null = null;
-    if (args.projectPath) {
+    if (resolvedProjectPath) {
       try {
-        projectIncludes = await readProjectIncludes(args.projectPath);
+        projectIncludes = await readProjectIncludes(resolvedProjectPath);
       } catch (e: any) {
         projectLoadError = e.message;
+      }
+    }
+
+    // ── Resolve the object list ──────────────────────────────────────────────
+    // verify-all mode: when no objects are supplied, derive them from the project's
+    // Content Includes (e.g. "AxClass\MyClass" → { class, MyClass }).
+    type VerifyObject = { objectType: (typeof OBJECT_TYPES)[number]; objectName: string };
+    const objectsToVerify: VerifyObject[] = args.objects ? [...args.objects] : [];
+    if (objectsToVerify.length === 0) {
+      if (!projectIncludes) {
+        return {
+          content: [{
+            type: 'text',
+            text:
+              '❌ No `objects` supplied and no project could be read to verify them all.\n\n' +
+              'Either pass `objects` explicitly, or provide `projectPath` (or configure projectPath ' +
+              'in .mcp.json / auto-detect) so every object referenced in the .rnrproj can be checked.' +
+              (projectLoadError ? `\n\n⚠️ Project read error: ${projectLoadError}` : ''),
+          }],
+          isError: true,
+        };
+      }
+      for (const inc of projectIncludes) {
+        const sep = inc.includes('\\') ? '\\' : '/';
+        const parts = inc.split(sep);
+        if (parts.length < 2) continue;
+        const folder = parts[0];
+        const name = parts[parts.length - 1].replace(/\.xml$/i, '');
+        const objType = folderToObjectType[folder.toLowerCase()];
+        if (objType && name) {
+          objectsToVerify.push({ objectType: objType as (typeof OBJECT_TYPES)[number], objectName: name });
+        }
+      }
+      if (objectsToVerify.length === 0) {
+        return {
+          content: [{
+            type: 'text',
+            text:
+              `ℹ️ The project at \`${resolvedProjectPath}\` has no recognizable object references to verify ` +
+              `(no Content Includes mapped to a known AOT folder).`,
+          }],
+        };
       }
     }
 
@@ -180,7 +233,7 @@ export async function verifyD365ProjectTool(
 
     const results: ObjectResult[] = [];
 
-    for (const obj of args.objects) {
+    for (const obj of objectsToVerify) {
       const axFolder = objectFolderMap[obj.objectType] ?? 'AxClass';
       const filePath = path.join(basePath, resolvedPackageName, actualModelName, axFolder, `${obj.objectName}.xml`);
 

--- a/src/utils/smartXmlBuilder.ts
+++ b/src/utils/smartXmlBuilder.ts
@@ -15,6 +15,9 @@ export interface TableFieldSpec {
   type?: string;
   mandatory?: boolean;
   label?: string;
+  /** Enum name for enum-backed fields (AxTableFieldEnum). When set, the field emits
+   *  <EnumType> instead of <ExtendedDataType>. */
+  enumType?: string;
 }
 
 export interface TableIndexSpec {
@@ -402,14 +405,17 @@ export class SmartXmlBuilder {
    * NOT typed element names like <AxTableFieldString>.
    */
   private buildTableField(field: TableFieldSpec): string {
-    const { name, edt, type, mandatory, label } = field;
+    const { name, edt, type, mandatory, label, enumType } = field;
 
-    const iType = this.getAxTableFieldType(edt, type);
+    // Enum-backed fields use AxTableFieldEnum + <EnumType>, never <ExtendedDataType>.
+    const iType = enumType ? 'AxTableFieldEnum' : this.getAxTableFieldType(edt, type);
 
     // D365FO field format: <AxTableField xmlns="" i:type="AxTableFieldString">
     let xml = `\t\t<AxTableField xmlns=""\n\t\t\t\ti:type="${iType}">\n`;
     xml += `\t\t\t<Name>${name}</Name>\n`;
-    if (edt) {
+    if (enumType) {
+      xml += `\t\t\t<EnumType>${enumType}</EnumType>\n`;
+    } else if (edt) {
       xml += `\t\t\t<ExtendedDataType>${edt}</ExtendedDataType>\n`;
     }
     if (mandatory) {

--- a/tests/tools/edt-resolution.test.ts
+++ b/tests/tools/edt-resolution.test.ts
@@ -3,6 +3,8 @@ import {
   resolveBestEdt,
   suggestEdtFromFieldName,
   isInfrastructureField,
+  heuristicEdtBaseType,
+  isEnumName,
 } from '../../src/tools/generateSmartTable';
 
 /**
@@ -112,6 +114,51 @@ describe('resolveBestEdt (DB-aware)', () => {
     const db = fakeDb([]);
     expect(resolveBestEdt('Status', db)).toBe('String255');
     expect(resolveBestEdt('Category', db)).toBe('String255');
+  });
+});
+
+describe('heuristicEdtBaseType (fallback when EDT not indexed)', () => {
+  it('resolves Real/Date/Int64 from standard EDT names', () => {
+    // Regression for friction #3: Qty/TransDate/RecId fell to AxTableFieldString on
+    // the bridge path because their base type was undefined when not indexed.
+    expect(heuristicEdtBaseType('Qty')).toBe('Real');
+    expect(heuristicEdtBaseType('AmountMST')).toBe('Real');
+    expect(heuristicEdtBaseType('DailyRate')).toBe('Real');
+    expect(heuristicEdtBaseType('TransDate')).toBe('Date');
+    expect(heuristicEdtBaseType('AcquiredDate')).toBe('Date');
+    expect(heuristicEdtBaseType('RecId')).toBe('Int64');
+    expect(heuristicEdtBaseType('SomeRefRecId')).toBe('Int64');
+  });
+
+  it('maps datetime names to UtcDateTime', () => {
+    expect(heuristicEdtBaseType('CreatedDateTime')).toBe('UtcDateTime');
+  });
+
+  it('returns undefined for names with no recognizable base type', () => {
+    expect(heuristicEdtBaseType('ContosoRentEquipmentId')).toBeUndefined();
+    expect(heuristicEdtBaseType('Name')).toBeUndefined();
+  });
+});
+
+describe('isEnumName (enum vs EDT detection)', () => {
+  function enumDb(enums: string[]) {
+    return {
+      prepare(_sql: string) {
+        return {
+          get(arg: string) {
+            return enums.some(e => e.toLowerCase() === String(arg).toLowerCase()) ? { 1: 1 } : undefined;
+          },
+        };
+      },
+    };
+  }
+  it('detects an indexed enum name', () => {
+    // Regression for friction #2: an enum-backed field was created as
+    // AxTableFieldString + EDT instead of AxTableFieldEnum.
+    expect(isEnumName('AslRentEquipmentStatus', enumDb(['AslRentEquipmentStatus']))).toBe(true);
+  });
+  it('returns false for a name that is not an indexed enum', () => {
+    expect(isEnumName('CustAccount', enumDb(['AslRentEquipmentStatus']))).toBe(false);
   });
 });
 

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -9,7 +9,7 @@ import { validateObjectNamingTool } from '../../src/tools/validateObjectNaming';
 import { getExtensionNamingStyle } from '../../src/utils/modelClassifier';
 import { verifyD365ProjectTool } from '../../src/tools/verifyD365Project';
 import { handleCreateD365File } from '../../src/tools/createD365File';
-import { modifyD365FileTool, countTopLevelMethodBodies, isUnresolvedObjectError, extractMethodNameFromSource } from '../../src/tools/modifyD365File';
+import { modifyD365FileTool, countTopLevelMethodBodies, splitTopLevelMethodBodies, isUnresolvedObjectError, extractMethodNameFromSource } from '../../src/tools/modifyD365File';
 import type { XppServerContext } from '../../src/types/context';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
@@ -398,9 +398,12 @@ describe('verify_d365fo_project', () => {
     expect(result.content[0].text).toContain('MyEnum');
   });
 
-  it('returns error when objects array is missing', async () => {
+  it('verify-all mode: missing objects derives them from the project or asks for one', async () => {
     const result = await verifyD365ProjectTool(req('verify_d365fo_project', {}), buildContext());
-    expect((result as any).isError).toBe(true);
+    const text = result.content[0].text as string;
+    // Objects are now optional: it either verifies every object referenced in a
+    // resolvable project, or returns clear guidance — never a raw schema parse error.
+    expect(text).toMatch(/Verification Results|no `objects`|no recognizable object/i);
   });
 });
 
@@ -835,7 +838,7 @@ describe('modify_d365fo_file', () => {
     expect(result.content[0].text).toMatch(/objectName|filePath/);
   });
 
-  it('rejects add-method whose sourceCode contains two methods', async () => {
+  it('add-method accepts multiple methods (no single-method rejection)', async () => {
     const twoMethods =
       `public int lastLineNum()\n{\n    return 0;\n}\n\n` +
       `public AmountCur calcLineAmount()\n{\n    return this.Qty * this.Price;\n}`;
@@ -850,8 +853,24 @@ describe('modify_d365fo_file', () => {
       }),
       ctx,
     );
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/exactly ONE method|2 method bodies/i);
+    // Multiple methods are now split and added one at a time — the old single-method
+    // guard no longer fires (this env has no bridge, so it fails later at the bridge).
+    expect(result.content[0].text).not.toMatch(/exactly ONE method|method bodies were detected/i);
+  });
+
+  it('splitTopLevelMethodBodies splits multiple methods, preserving each body and doc comments', () => {
+    const src =
+      `/// <summary>first</summary>\npublic int lastLineNum()\n{\n    if (x) { y(); }\n    return 0;\n}\n\n` +
+      `public AmountCur calcLineAmount()\n{\n    return this.Qty * this.Price;\n}`;
+    const parts = splitTopLevelMethodBodies(src);
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toContain('lastLineNum');
+    expect(parts[0]).toContain('first');           // leading doc comment retained
+    expect(parts[0]).toContain('if (x) { y(); }');  // nested block kept with method 1
+    expect(parts[1]).toContain('calcLineAmount');
+    expect(parts[1]).not.toContain('lastLineNum');
+    // A single method round-trips unchanged.
+    expect(splitTopLevelMethodBodies(`public void run()\n{\n    a();\n}`)).toHaveLength(1);
   });
 
   it('countTopLevelMethodBodies counts methods, ignoring nested blocks/comments/strings', () => {


### PR DESCRIPTION
Addresses 8 first-session friction points reported from a live scaffolding run:

1. update_symbol_index: filePath now optional. No-arg call runs a lightweight bridge-provider + workspace refresh instead of hard-erroring on a missing required param. 2/3. Scaffolded fields got the wrong base type when their EDT/enum wasn't yet
   indexed (enum→AxTableFieldString+EDT; Qty/TransDate→String):
   - generate_smart_table now detects indexed enums (AxTableFieldEnum+EnumType, no ExtendedDataType) and falls back to a name heuristic for the base type so the C# bridge no longer defaults Real/Date/Int64 EDTs to String.
   - update_symbol_index now populates edt_metadata for AxEdt files so a same-session EDT resolves its base type after per-file indexing.
   - enumType wired through the bridge field mapping and the XML builder.
4. add-method: accepts multiple methods in one call (split + add each as its own <Method>) instead of rejecting with "expects exactly ONE method".
5. generate_smart_form: lines datasource name now tracks the auto-corrected table name and is de-duplicated, fixing the stale "…Lines" + correct "…Line" double-datasource.
6. generate_smart_table/form resolve the packages root from the bridge's custom packages path so the exists-guard, fallback write, and reported path match where files actually land.
7. verify_d365fo_project: objects now optional — omit to verify every object referenced in the .rnrproj (verify-all mode).
8. labels(action="create"): clearer error that calls out the common labelFileId/language-vs-labelId/translations mistake.

Tests: +5 (splitTopLevelMethodBodies, heuristicEdtBaseType, isEnumName, verify-all mode, multi-method add). Full suite 1080 passing.