### PR TITLE
Fix/stdio crash and object patterns friction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,18 @@ console.error = (...args: any[]) => {
   }
 };
 
+// ─── Global safety net ────────────────────────────────────────────────────────
+// An unhandled promise rejection terminates the Node process by default
+// (Node ≥15, --unhandled-rejections=throw). In stdio mode that kills the MCP
+// subprocess and the client must restart it — observed as "the server crashes
+// on the first request and has to be restarted" when a background task (e.g.
+// the async DB load) rejects before any tool call awaits it. Log and keep the
+// server alive instead of dying. (stderr is already tee'd to LOG_FILE above.)
+process.on('unhandledRejection', (reason) => {
+  const msg = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+  process.stderr.write(`[d365fo-mcp] ⚠️ Unhandled promise rejection (server staying up): ${msg}\n`);
+});
+
 const PORT = parseInt(process.env.PORT || '8080');
 // Derive server root from this file's location so paths are absolute
 // regardless of process.cwd() — critical when VS Code launches this as stdio subprocess.
@@ -511,6 +523,12 @@ async function main() {
       resolveDbReady = res;
       rejectDbReady  = rej;
     });
+    // Floor handler: if the background DB load fails before any tool call awaits
+    // dbReady (e.g. the first request is a LOCAL tool, which skips the wait in
+    // toolHandler), the rejection would otherwise float and crash the stdio
+    // process. Attaching a catch here marks it handled; tool handlers that do
+    // await context.dbReady still receive and surface the rejection themselves.
+    dbReadyPromise.catch(() => { /* handled — never let it float */ });
 
     const stubContext: import('./types/context.js').XppServerContext = {
       symbolIndex: stubIndex,

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,16 @@ process.on('unhandledRejection', (reason) => {
   process.stderr.write(`[d365fo-mcp] ⚠️ Unhandled promise rejection (server staying up): ${msg}\n`);
 });
 
+// Same protection for SYNCHRONOUS uncaught exceptions — a throw that escapes a
+// timer/stream/event callback (not an awaited promise) would otherwise stop the
+// process outright. For a stdio server that means the MCP client must respawn
+// the subprocess after the very first failing request. Log the full stack so the
+// root cause is diagnosable, then keep serving. (Genuinely fatal startup errors
+// are still surfaced via main().catch → process.exit below.)
+process.on('uncaughtException', (err) => {
+  process.stderr.write(`[d365fo-mcp] ⚠️ Uncaught exception (server staying up): ${err?.stack ?? err}\n`);
+});
+
 const PORT = parseInt(process.env.PORT || '8080');
 // Derive server root from this file's location so paths are absolute
 // regardless of process.cwd() — critical when VS Code launches this as stdio subprocess.

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1235,7 +1235,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               domain: {
                 type: 'string',
                 enum: ['table', 'form'],
-                description: 'table = table field/index/relation patterns; form = form-pattern toolkit (set action). Optional — inferred from the other params (action/pattern/xml/formName → form; tableGroup → table). Alias: patternType.',
+                description: 'table = table field/index/relation patterns; form = form-pattern toolkit (set action). Optional — inferred from the other params (action/pattern/xml/formName → form; tableGroup → table). ⚠️ This is NOT a free-form "pattern type": a concept like "number-sequence"/"SysOperation" belongs to get_knowledge, not here.',
               },
               // ── domain=table ───────────────────────────────────────────────
               tableGroup: {

--- a/src/tools/objectPatterns.ts
+++ b/src/tools/objectPatterns.ts
@@ -15,6 +15,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { XppServerContext } from '../types/context.js';
 import { getTablePatternsTool } from './getTablePatterns.js';
 import { formPatternTool } from './formPattern.js';
+import { resolvePatternExact } from '../knowledge/formPatterns/index.js';
 
 function err(text: string) {
   return { content: [{ type: 'text' as const, text }], isError: true };
@@ -24,7 +25,23 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
   const a = (request.params.arguments ?? {}) as Record<string, any>;
   // Accept `patternType` / `type` / `objectType` as aliases for the `domain`
   // discriminator — agents frequently reach for these names.
-  let domain = (a.domain ?? a.patternType ?? a.type ?? a.objectType) as string | undefined;
+  const aliasRaw = a.domain ?? a.patternType ?? a.type ?? a.objectType;
+  let domain = aliasRaw as string | undefined;
+
+  // A recognized FORM PATTERN NAME (e.g. "SimpleList", "DetailsMaster") passed
+  // via patternType/type/objectType is not a domain — agents conflate "which
+  // pattern" with the table/form discriminator. Route it to the form toolkit and
+  // spec out that pattern. resolvePatternExact only matches real id/xmlName/alias
+  // (exact, case-insensitive), so concept nouns like "number-sequence" still fall
+  // through to the get_knowledge redirect below.
+  let inferredPattern: string | undefined;
+  if (domain !== 'table' && domain !== 'form' && typeof aliasRaw === 'string') {
+    const spec = resolvePatternExact(aliasRaw);
+    if (spec) {
+      inferredPattern = spec.xmlName;
+      domain = 'form';
+    }
+  }
 
   // Infer the discriminator from form/table-specific params when omitted.
   if (domain !== 'table' && domain !== 'form') {
@@ -43,15 +60,19 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
 
   if (domain === 'form') {
     // formPatternTool requires `action`; infer it when omitted.
+    const pattern = a.pattern ?? inferredPattern;
     let action = a.action as string | undefined;
     if (!action) {
-      if (a.pattern !== undefined) action = 'spec';
+      if (pattern !== undefined) action = 'spec';
       else if (a.xml !== undefined || a.formName !== undefined || a.filePath !== undefined) action = 'validate';
       else action = 'analyze';
     }
     const formRequest: CallToolRequest = {
       ...request,
-      params: { ...request.params, arguments: { ...a, domain, action } },
+      params: {
+        ...request.params,
+        arguments: { ...a, domain, action, ...(pattern !== undefined ? { pattern } : {}) },
+      },
     };
     return formPatternTool(formRequest, context);
   }

--- a/tests/tools/mergedDispatchers.test.ts
+++ b/tests/tools/mergedDispatchers.test.ts
@@ -209,6 +209,26 @@ describe('object_patterns dispatcher', () => {
     expect(formPatternTool).toHaveBeenCalledOnce();
   });
 
+  it('a real form-pattern NAME in patternType → form + action=spec + pattern', async () => {
+    await objectPatternsTool(req('object_patterns', { patternType: 'SimpleList' }), ctx);
+    expect(formPatternTool).toHaveBeenCalledOnce();
+    expect(getTablePatternsTool).not.toHaveBeenCalled();
+    expect(argsOf(formPatternTool)).toMatchObject({ domain: 'form', action: 'spec', pattern: 'SimpleList' });
+  });
+
+  it('a real form-pattern NAME in objectType (canonicalised) → form spec', async () => {
+    await objectPatternsTool(req('object_patterns', { objectType: 'detailsmaster' }), ctx);
+    expect(argsOf(formPatternTool)).toMatchObject({ domain: 'form', action: 'spec', pattern: 'DetailsMaster' });
+  });
+
+  it('a concept noun (number-sequence) in patternType → friendly error, no handler, redirects to get_knowledge', async () => {
+    const r: any = await objectPatternsTool(req('object_patterns', { patternType: 'number-sequence' }), ctx);
+    expect(r.isError).toBe(true);
+    expect(formPatternTool).not.toHaveBeenCalled();
+    expect(getTablePatternsTool).not.toHaveBeenCalled();
+    expect(r.content[0].text).toContain('get_knowledge');
+  });
+
   it('unknown/omitted domain with no signals → friendly error', async () => {
     const r: any = await objectPatternsTool(req('object_patterns', {}), ctx);
     expect(r.isError).toBe(true);


### PR DESCRIPTION
This pull request improves error handling and input interpretation in the server, particularly for the `objectPatternsTool`. The most significant changes are the addition of global safety nets for unhandled errors, smarter routing of form pattern requests, and clearer documentation to prevent misuse of the `domain` parameter.

**Error handling improvements:**
* Added global handlers for `unhandledRejection` and `uncaughtException` in `src/index.ts` to log errors and keep the server running instead of crashing on unexpected errors. This prevents the stdio server from terminating and requiring a client restart.
* Ensured that the background database load promise (`dbReadyPromise`) always has a catch handler to prevent unhandled promise rejections from crashing the process.

**Input interpretation and routing:**
* Enhanced the `objectPatternsTool` in `src/tools/objectPatterns.ts` to recognize when a form pattern name (e.g., "SimpleList", "DetailsMaster") is supplied as `patternType`, `type`, or `objectType`. Such requests are now routed to the form pattern toolkit (`formPatternTool`) with the correct parameters, improving agent usability and making the tool more robust to common input patterns. [[1]](diffhunk://#diff-bf096af3092a1a47f7052c6c7c828e00349d902281486cbfaea43232852592e5R18) [[2]](diffhunk://#diff-bf096af3092a1a47f7052c6c7c828e00349d902281486cbfaea43232852592e5L27-R44) [[3]](diffhunk://#diff-bf096af3092a1a47f7052c6c7c828e00349d902281486cbfaea43232852592e5R63-R75)
* Added new tests in `tests/tools/mergedDispatchers.test.ts` to verify correct routing for form pattern names, canonicalization of pattern names, and friendly error handling for unsupported concepts like "number-sequence" (which are redirected to `get_knowledge`).

**Documentation and parameter clarification:**
* Updated the description for the `domain` parameter in `src/server/mcpServer.ts` to clarify that it is not a free-form pattern type and to direct unsupported concepts to the correct tool (`get_knowledge`).