### PR TITLE
Fix/stdio crash and object patterns friction

### DIFF
--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -425,7 +425,7 @@ namespace D365MetadataBridge.Protocol
                                 default:
                                     throw new ArgumentException($"createObject not supported for '{objectType}' via bridge — use XML fallback");
                             }
-                        });
+                        }, true);
 
                     case "createsmarttable":
                         return HandleWrite(request, () =>
@@ -445,7 +445,7 @@ namespace D365MetadataBridge.Protocol
                                 request.GetParam<System.Collections.Generic.List<WriteRelationParam>>("relations"),
                                 request.GetParam<System.Collections.Generic.List<WriteMethodParam>>("methods"),
                                 request.GetDictParam("extraProperties"));
-                        });
+                        }, true);
 
                     case "addmethod":
                         return HandleWrite(request, () =>
@@ -787,7 +787,7 @@ namespace D365MetadataBridge.Protocol
             }
         }
 
-        private Task<BridgeResponse> HandleWrite(BridgeRequest request, Func<object?> handler)
+        private Task<BridgeResponse> HandleWrite(BridgeRequest request, Func<object?> handler, bool refreshAfterSuccess = false)
         {
             if (_writeService == null)
                 return Task.FromResult(
@@ -799,6 +799,14 @@ namespace D365MetadataBridge.Protocol
                 if (result == null)
                     return Task.FromResult(
                         BridgeResponse.CreateError(request.Id, -32001, "Write operation returned null"));
+
+                // Refresh the provider after create operations so subsequent reads (e.g. get_object_info)
+                // see the correct metadata (TableGroup, fields, etc.) rather than a stale cache state.
+                if (refreshAfterSuccess && _metadataService != null)
+                {
+                    try { _metadataService.RefreshProvider(); }
+                    catch (Exception ex) { Console.Error.WriteLine($"[WARN] Auto-refresh after {request.Method} failed: {ex.Message}"); }
+                }
 
                 return Task.FromResult(BridgeResponse.CreateSuccess(request.Id, result));
             }
@@ -815,7 +823,7 @@ namespace D365MetadataBridge.Protocol
                 // to the MCP client) so it doesn't surface as an alarming warning. The
                 // error response is still returned so the caller falls back to XML.
                 if (IsRecoverableWrite(request.Method))
-                    Console.Error.WriteLine($"[INFO] {request.Method} failed (recoverable — caller falls back to XML generation): {ex.Message}");
+                    Console.Error.WriteLine($"[INFO] {request.Method} failed (recoverable — caller falls back to XML generation): {ex.Message}\n{ex.StackTrace}");
                 else
                     Console.Error.WriteLine($"[ERROR] {request.Method}: {ex.Message}\n{ex.StackTrace}");
                 return Task.FromResult(

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -41,7 +41,16 @@ namespace D365MetadataBridge.Services
         // ========================
 
         /// <summary>
-        /// Resolves a model name to ModelSaveInfo by reading model descriptor XML files.
+        /// Resolves a model name to ModelSaveInfo.
+        ///
+        /// PREFERRED: the provider's model manifest, which gives the model's real runtime
+        /// identity — the small ordinal Id AND the SequenceId. This matters because the
+        /// model descriptor's &lt;Id&gt; element is actually the SequenceId (a large number);
+        /// parsing it into ModelSaveInfo.Id while leaving SequenceId=0 makes
+        /// IMetadataProvider.Create() throw NullReferenceException. (Verified: fm-mcp manifest
+        /// Id=116 SequenceId=896000930 creates fine; descriptor-derived Id=896000930
+        /// SequenceId=0 NREs.) The descriptor scan stays as a fallback for models the
+        /// manifest does not enumerate (e.g. not yet built/registered).
         /// Caches results for repeated calls.
         /// </summary>
         public ModelSaveInfo? ResolveModelSaveInfo(string modelName)
@@ -49,6 +58,13 @@ namespace D365MetadataBridge.Services
             if (_modelCache.TryGetValue(modelName, out var cached))
                 return cached;
 
+            // Preferred: authoritative identity from the runtime model manifest.
+            var fromManifest = ResolveModelSaveInfoFromManifest(modelName);
+            if (fromManifest != null) { _modelCache[modelName] = fromManifest; return fromManifest; }
+
+            // Fallback: descriptor scan. Note the Id/SequenceId caveat above — this path
+            // can yield a ModelSaveInfo the create API rejects, but it is the best we can do
+            // when the model is absent from the manifest.
             // Scan {packagesPath}/{*}/Descriptor/{modelName}.xml
             // First try the direct path (most models: package name = model name)
             var directPath = Path.Combine(_packagesPath, modelName, "Descriptor", modelName + ".xml");
@@ -78,6 +94,30 @@ namespace D365MetadataBridge.Services
                 Console.Error.WriteLine($"[WriteService] Error scanning model descriptors: {ex.Message}");
             }
 
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves ModelSaveInfo from the provider's model manifest by model name, capturing
+        /// the real runtime Id + SequenceId (see ResolveModelSaveInfo remarks). Returns null
+        /// when the model is not enumerated by the manifest.
+        /// </summary>
+        private ModelSaveInfo? ResolveModelSaveInfoFromManifest(string modelName)
+        {
+            try
+            {
+                var manifest = _provider.ModelManifest;
+                if (manifest == null) return null;
+                foreach (var mi in manifest.ListModelInfos())
+                {
+                    if (string.Equals(mi.Name, modelName, StringComparison.OrdinalIgnoreCase))
+                        return new ModelSaveInfo { Id = mi.Id, Layer = mi.Layer, Name = mi.Name, SequenceId = mi.SequenceId };
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[WriteService] Manifest model lookup failed for '{modelName}': {ex.Message}");
+            }
             return null;
         }
 

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -259,6 +259,20 @@ export class BridgeClient extends EventEmitter {
       // cannot corrupt the state of its successor.
       const child = this.process;
 
+      // Guard the child's stdio streams against unhandled 'error' events. When the
+      // bridge process dies mid-write (e.g. a crash during createSmartTable), Node
+      // can emit EPIPE/ECONNRESET on stdin/stdout/stderr. A stream that emits
+      // 'error' with no listener throws as an uncaughtException and would take the
+      // whole MCP server down ("crashes on the first request"). Recovery is driven
+      // by the 'error'/'exit' handlers on the child below; here we just absorb the
+      // stream-level noise so it never becomes fatal.
+      const onStreamError = (where: string) => (err: Error) => {
+        console.error(`[BridgeClient] ${where} stream error: ${err.message}`);
+      };
+      child.stdin?.on('error', onStreamError('stdin'));
+      child.stdout?.on('error', onStreamError('stdout'));
+      child.stderr?.on('error', onStreamError('stderr'));
+
       // Handle stdout — newline-delimited JSON
       child.stdout!.on('data', (chunk: Buffer) => {
         if (this.process !== child) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,28 @@ console.error = (...args: any[]) => {
   }
 };
 
+// ─── Global safety net ────────────────────────────────────────────────────────
+// An unhandled promise rejection terminates the Node process by default
+// (Node ≥15, --unhandled-rejections=throw). In stdio mode that kills the MCP
+// subprocess and the client must restart it — observed as "the server crashes
+// on the first request and has to be restarted" when a background task (e.g.
+// the async DB load) rejects before any tool call awaits it. Log and keep the
+// server alive instead of dying. (stderr is already tee'd to LOG_FILE above.)
+process.on('unhandledRejection', (reason) => {
+  const msg = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+  process.stderr.write(`[d365fo-mcp] ⚠️ Unhandled promise rejection (server staying up): ${msg}\n`);
+});
+
+// Same protection for SYNCHRONOUS uncaught exceptions — a throw that escapes a
+// timer/stream/event callback (not an awaited promise) would otherwise stop the
+// process outright. For a stdio server that means the MCP client must respawn
+// the subprocess after the very first failing request. Log the full stack so the
+// root cause is diagnosable, then keep serving. (Genuinely fatal startup errors
+// are still surfaced via main().catch → process.exit below.)
+process.on('uncaughtException', (err) => {
+  process.stderr.write(`[d365fo-mcp] ⚠️ Uncaught exception (server staying up): ${err?.stack ?? err}\n`);
+});
+
 const PORT = parseInt(process.env.PORT || '8080');
 // Derive server root from this file's location so paths are absolute
 // regardless of process.cwd() — critical when VS Code launches this as stdio subprocess.
@@ -511,6 +533,12 @@ async function main() {
       resolveDbReady = res;
       rejectDbReady  = rej;
     });
+    // Floor handler: if the background DB load fails before any tool call awaits
+    // dbReady (e.g. the first request is a LOCAL tool, which skips the wait in
+    // toolHandler), the rejection would otherwise float and crash the stdio
+    // process. Attaching a catch here marks it handled; tool handlers that do
+    // await context.dbReady still receive and surface the rejection themselves.
+    dbReadyPromise.catch(() => { /* handled — never let it float */ });
 
     const stubContext: import('./types/context.js').XppServerContext = {
       symbolIndex: stubIndex,

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -1235,7 +1235,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               domain: {
                 type: 'string',
                 enum: ['table', 'form'],
-                description: 'table = table field/index/relation patterns; form = form-pattern toolkit (set action). Optional — inferred from the other params (action/pattern/xml/formName → form; tableGroup → table). Alias: patternType.',
+                description: 'table = table field/index/relation patterns; form = form-pattern toolkit (set action). Optional — inferred from the other params (action/pattern/xml/formName → form; tableGroup → table). ⚠️ This is NOT a free-form "pattern type": a concept like "number-sequence"/"SysOperation" belongs to get_knowledge, not here.',
               },
               // ── domain=table ───────────────────────────────────────────────
               tableGroup: {

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -704,7 +704,7 @@ export async function handleGenerateSmartForm(
       caption: caption || label || finalName,
       gridFields,
       fieldTypes,
-      linesDsName: linesTableResolved ? (linesDataSource || linesTableResolved) : undefined,
+      linesDsName: linesDsNameResolved ?? (linesTableResolved || undefined),
       linesDsTable: linesTableResolved || undefined,
       linesFields,
       linesFieldTypes,

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -341,9 +341,15 @@ export async function handleGenerateSmartTable(
     const hintDb = symbolIndex.getReadDb();
 
     for (const hint of hintFields) {
-      // Check if field already exists
-      if (fields.find(f => f.name === hint)) {
-        continue;
+      // Duplicate field name in hint list (e.g. agent passed the EDT name twice: "AmountMST, AmountMST"
+      // instead of distinct field names like "DailyRate, LineAmount"). Preserve both by suffixing the
+      // second occurrence rather than silently dropping it — the caller wanted two separate fields.
+      let fieldName = hint;
+      if (fields.find(f => f.name === fieldName)) {
+        let suffix = 2;
+        while (fields.find(f => f.name === `${hint}${suffix}`)) suffix++;
+        fieldName = `${hint}${suffix}`;
+        console.warn(`[generateSmartTable] Duplicate hint "${hint}" → renamed to "${fieldName}"`);
       }
 
       const edt = resolveBestEdt(hint, hintDb);
@@ -359,7 +365,7 @@ export async function handleGenerateSmartTable(
         hintLower === 'num' ||
         hintLower === 'code';
       fields.push({
-        name: hint,
+        name: fieldName,
         edt,
         mandatory: isMandatory,
       });
@@ -408,10 +414,16 @@ export async function handleGenerateSmartTable(
         continue;
       }
       if (f.edt && !f.type) {
-        // Prefer the indexed base type; when the EDT isn't indexed (same-session or
-        // an OOB EDT whose metadata wasn't loaded) fall back to a name heuristic so
-        // the bridge gets an explicit type instead of defaulting Real/Date EDTs to String.
-        f.type = resolveEdtBaseType(f.edt, db) ?? heuristicEdtBaseType(f.edt);
+        // Authoritative base type from the C# bridge (live IMetadataProvider) when
+        // available. The symbol index stores extends=null for ROOT Date/Real/Int64
+        // EDTs (e.g. TransDate→Date, Qty→Real), so resolveEdtBaseType wrongly
+        // defaulted them to String — the #1 source of "scaffold made my date/amount
+        // field a string". The bridge reads the real AxEdt element type and resolves
+        // it correctly. Fall back to the index + name heuristic only when the bridge
+        // is unavailable (Azure/Linux) or doesn't know the EDT.
+        f.type = await bridgeEdtBaseType(bridge, f.edt)
+              ?? resolveEdtBaseType(f.edt, db)
+              ?? heuristicEdtBaseType(f.edt);
       }
       // Validate EDT exists in the symbol index
       if (f.edt) {
@@ -991,15 +1003,43 @@ export async function handleGenerateSmartTable(
 }
 
 /**
+ * Resolve an EDT's primitive base type via the C# bridge (live IMetadataProvider).
+ *
+ * The bridge reads the real AxEdt element type (AxEdtDate/AxEdtReal/AxEdtInt64/…),
+ * so it correctly distinguishes a ROOT Date/Real EDT from a String one — which the
+ * symbol index CANNOT, because it stores extends=null for root EDTs regardless of
+ * their primitive. Returns a token compatible with resolveEdtBaseType
+ * (String/Integer/Real/Date/Int64/Guid/…), or undefined when the bridge is
+ * unavailable, doesn't know the EDT, or reports it as Enum (enum-backed EDTs are
+ * handled separately via the enumType path, so we must not emit a bare "Enum" here).
+ */
+async function bridgeEdtBaseType(bridge: BridgeClient | undefined, edtName: string): Promise<string | undefined> {
+  if (!bridge?.isReady) return undefined;
+  try {
+    const info = await bridge.readEdt(edtName);
+    const bt = (info as any)?.baseType;
+    if (typeof bt !== 'string' || bt.length === 0 || bt === 'Enum') return undefined;
+    return bt;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Resolve the primitive base type for a D365FO EDT by walking the edt_metadata chain.
  * The `extends` column in edt_metadata stores either a primitive type name
  * (String, Real, Int64, Date, UtcDateTime, Enum, Container, Guid, Integer) or
  * another EDT name. We follow the chain until we reach a primitive type.
  *
+ * ⚠️ Index limitation: ROOT EDTs that extend a primitive store extends=null, so this
+ * cannot tell a Date/Real root EDT from a String one and defaults such cases to
+ * String. Prefer bridgeEdtBaseType() when a bridge is available; this is the
+ * offline (Azure/Linux) fallback.
+ *
  * Returns a base type string compatible with fieldTypeToAxType(), e.g.:
  *   "Qty" → "Real", "TransDate" → "Date", "ItemId" → "String"
  */
-function resolveEdtBaseType(edtName: string, db: any, depth = 0): string | undefined {
+export function resolveEdtBaseType(edtName: string, db: any, depth = 0): string | undefined {
   // D365FO primitive types − these map directly to AxTableField types
   const PRIMITIVES = new Set([
     'String', 'Integer', 'Int64', 'Real', 'Date', 'UtcDateTime', 'DateTime',
@@ -1012,8 +1052,8 @@ function resolveEdtBaseType(edtName: string, db: any, depth = 0): string | undef
 
   try {
     const row = db.prepare(
-      `SELECT extends, enum_type FROM edt_metadata WHERE edt_name = ? LIMIT 1`
-    ).get(edtName) as { extends: string | null; enum_type: string | null } | undefined;
+      `SELECT extends, enum_type, string_size FROM edt_metadata WHERE edt_name = ? LIMIT 1`
+    ).get(edtName) as { extends: string | null; enum_type: string | null; string_size: string | number | null } | undefined;
 
     // EDT not found in the index (e.g. a custom EDT not yet indexed, or a standard OOB EDT
     // whose index wasn't loaded). Return undefined so callers fall back to EDT-name heuristics
@@ -1021,7 +1061,14 @@ function resolveEdtBaseType(edtName: string, db: any, depth = 0): string | undef
     if (!row) return undefined;
     // Enum-based EDT: extends is null but enum_type is set (e.g. SalesStatus, PurchStatus)
     if (row.enum_type && !row.extends) return 'Enum';
-    if (!row.extends) return 'String';
+    if (!row.extends) {
+      // ROOT EDT: the index does NOT record the primitive (AxEdtDate/Real/Int64/String all
+      // store extends=null). A real string EDT carries a string_size; without one we genuinely
+      // CANNOT tell String from Date/Real/Int64 — so return undefined and let the caller's
+      // name heuristic (or the bridge) decide, instead of mislabeling e.g. TransDate/Qty as
+      // String. This is the #1 "scaffold turned my date/amount field into a string" bug.
+      return row.string_size != null ? 'String' : undefined;
+    }
     if (PRIMITIVES.has(row.extends)) return row.extends;
 
     // Follow chain to the parent EDT

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1008,6 +1008,16 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             for (const body of bodies) {
               const mName = extractMethodNameFromSource(body);
               if (!mName) {
+                // A body without a derivable method name is typically a class/extension declaration
+                // (e.g. "[ExtensionOf(tableStr(T))] final class T_Extension { }"). Such blocks are
+                // NOT methods and do not belong in add-method — skip and continue.
+                // The regex handles: optional attribute block(s) → optional modifiers (final/abstract/
+                // public/static/…) → class or interface keyword.
+                const trimmed = body.trim();
+                if (/^\s*(?:\[[^\]]*\]\s*)*(?:(?:public|private|protected|final|abstract|static|internal|sealed)\s+)*(?:class|interface)\b/i.test(trimmed)) {
+                  console.warn(`[add-method] Skipping class/interface declaration block (not a method): ${trimmed.slice(0, 80)}...`);
+                  continue;
+                }
                 throw new Error(
                   `⛔ add-method: could not derive a method name from one of the ${bodies.length} method bodies. ` +
                   `Ensure each method has a complete signature (e.g. "public void foo()").`,

--- a/src/tools/objectPatterns.ts
+++ b/src/tools/objectPatterns.ts
@@ -15,6 +15,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { XppServerContext } from '../types/context.js';
 import { getTablePatternsTool } from './getTablePatterns.js';
 import { formPatternTool } from './formPattern.js';
+import { resolvePatternExact } from '../knowledge/formPatterns/index.js';
 
 function err(text: string) {
   return { content: [{ type: 'text' as const, text }], isError: true };
@@ -24,7 +25,23 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
   const a = (request.params.arguments ?? {}) as Record<string, any>;
   // Accept `patternType` / `type` / `objectType` as aliases for the `domain`
   // discriminator — agents frequently reach for these names.
-  let domain = (a.domain ?? a.patternType ?? a.type ?? a.objectType) as string | undefined;
+  const aliasRaw = a.domain ?? a.patternType ?? a.type ?? a.objectType;
+  let domain = aliasRaw as string | undefined;
+
+  // A recognized FORM PATTERN NAME (e.g. "SimpleList", "DetailsMaster") passed
+  // via patternType/type/objectType is not a domain — agents conflate "which
+  // pattern" with the table/form discriminator. Route it to the form toolkit and
+  // spec out that pattern. resolvePatternExact only matches real id/xmlName/alias
+  // (exact, case-insensitive), so concept nouns like "number-sequence" still fall
+  // through to the get_knowledge redirect below.
+  let inferredPattern: string | undefined;
+  if (domain !== 'table' && domain !== 'form' && typeof aliasRaw === 'string') {
+    const spec = resolvePatternExact(aliasRaw);
+    if (spec) {
+      inferredPattern = spec.xmlName;
+      domain = 'form';
+    }
+  }
 
   // Infer the discriminator from form/table-specific params when omitted.
   if (domain !== 'table' && domain !== 'form') {
@@ -43,15 +60,19 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
 
   if (domain === 'form') {
     // formPatternTool requires `action`; infer it when omitted.
+    const pattern = a.pattern ?? inferredPattern;
     let action = a.action as string | undefined;
     if (!action) {
-      if (a.pattern !== undefined) action = 'spec';
+      if (pattern !== undefined) action = 'spec';
       else if (a.xml !== undefined || a.formName !== undefined || a.filePath !== undefined) action = 'validate';
       else action = 'analyze';
     }
     const formRequest: CallToolRequest = {
       ...request,
-      params: { ...request.params, arguments: { ...a, domain, action } },
+      params: {
+        ...request.params,
+        arguments: { ...a, domain, action, ...(pattern !== undefined ? { pattern } : {}) },
+      },
     };
     return formPatternTool(formRequest, context);
   }

--- a/src/utils/formPatternTemplates.ts
+++ b/src/utils/formPatternTemplates.ts
@@ -785,7 +785,7 @@ ${gridPanelFieldControls}\t\t\t\t\t\t\t\t</Controls>
       dsName = formName,
       dsTable = dsName,
       caption,
-      linesDsName = `${dsName}Lines`,
+      linesDsName = `${dsName.replace(/Table$/i, '')}Line`,
       linesDsTable = linesDsName,
       gridFields = [],
       linesFields = [],

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -433,6 +433,28 @@ describe('generate_smart_table', () => {
     );
     expect(result?.content[0].text).toMatch(/<Indexes>|UniqueIndex|Idx/i);
   });
+
+  it('preserves both fields when the same hint name appears twice (dedup regression #2)', async () => {
+    // Agent passed the EDT name twice ("AmountMST, AmountMST") instead of distinct
+    // field names. The second occurrence must be renamed AmountMST2, not dropped.
+    const result = await handleGenerateSmartTable(
+      {
+        name: 'RentalLine',
+        modelName: 'MyModel',
+        fieldsHint: 'AgreementId, AmountMST, AmountMST',
+      },
+      ctx.symbolIndex,
+    );
+    expect(result?.isError).toBeFalsy();
+    const xml = result?.content[0].text ?? '';
+    // Both amount fields present under different names
+    expect(xml).toContain('AmountMST');
+    expect(xml).toContain('AmountMST2');
+    // Not silently collapsed to a single AmountMST
+    const count = (xml.match(/AmountMST(?!2)/g) ?? []).length;
+    expect(count).toBeGreaterThanOrEqual(1); // original present
+    expect(xml).toContain('AmountMST2');     // duplicate renamed
+  });
 });
 
 // ─── generate_smart_form ─────────────────────────────────────────────────────

--- a/tests/tools/edt-resolution.test.ts
+++ b/tests/tools/edt-resolution.test.ts
@@ -4,6 +4,7 @@ import {
   suggestEdtFromFieldName,
   isInfrastructureField,
   heuristicEdtBaseType,
+  resolveEdtBaseType,
   isEnumName,
 } from '../../src/tools/generateSmartTable';
 
@@ -137,6 +138,49 @@ describe('heuristicEdtBaseType (fallback when EDT not indexed)', () => {
   it('returns undefined for names with no recognizable base type', () => {
     expect(heuristicEdtBaseType('ContosoRentEquipmentId')).toBeUndefined();
     expect(heuristicEdtBaseType('Name')).toBeUndefined();
+  });
+});
+
+describe('resolveEdtBaseType (indexed EDT, root-EDT ambiguity)', () => {
+  // Fake edt_metadata over a {name: {extends, enum_type, string_size}} map.
+  function edtMetaDb(rows: Record<string, { extends?: string | null; enum_type?: string | null; string_size?: string | number | null }>) {
+    return {
+      prepare(_sql: string) {
+        return {
+          get(arg: string) {
+            const key = Object.keys(rows).find(k => k.toLowerCase() === String(arg).toLowerCase());
+            if (!key) return undefined;
+            const r = rows[key];
+            return { extends: r.extends ?? null, enum_type: r.enum_type ?? null, string_size: r.string_size ?? null };
+          },
+        };
+      },
+    };
+  }
+
+  it('does NOT mislabel a root Date/Real EDT as String (string_size is null → undefined)', () => {
+    // The #1 bug: TransDate/Qty are indexed with extends=null and no string_size.
+    // Returning "String" here shadowed heuristicEdtBaseType; we must return undefined
+    // so the caller's heuristic (or the bridge) resolves the real primitive.
+    const db = edtMetaDb({ TransDate: {}, RealBase: {}, Qty: { extends: 'RealBase' } });
+    expect(resolveEdtBaseType('TransDate', db)).toBeUndefined();
+    expect(resolveEdtBaseType('Qty', db)).toBeUndefined(); // chains through RealBase → ambiguous root
+  });
+
+  it('still resolves a genuine String EDT (root with a string_size)', () => {
+    const db = edtMetaDb({ Name: { string_size: 60 }, Num: { string_size: 20 } });
+    expect(resolveEdtBaseType('Name', db)).toBe('String');
+    expect(resolveEdtBaseType('Num', db)).toBe('String');
+  });
+
+  it('resolves enum-backed and primitive-extending EDTs', () => {
+    const db = edtMetaDb({ SalesStatus: { enum_type: 'SalesStatus' }, MyAmount: { extends: 'Real' } });
+    expect(resolveEdtBaseType('SalesStatus', db)).toBe('Enum');
+    expect(resolveEdtBaseType('MyAmount', db)).toBe('Real');
+  });
+
+  it('returns undefined for an EDT missing from the index', () => {
+    expect(resolveEdtBaseType('ContosoCustomId', edtMetaDb({}))).toBeUndefined();
   });
 });
 

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -979,6 +979,41 @@ describe('modify_d365fo_file', () => {
     expect(source).not.toContain('&lt;');
   });
 
+  it('add-method skips class/extension declaration block and adds the real methods', async () => {
+    // Regression #4: agent passes classDeclaration + multiple method bodies in one sourceCode.
+    // The class declaration block has no method signature ("final class Foo_Extension {}") so
+    // extractMethodNameFromSource returns null for it. Previously this threw; now it is silently
+    // skipped and only the actual methods are added.
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxClass><Name>AslRentAgreementTable_Extension</Name></AxClass>`,
+    );
+    const addMethod = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addMethod, refreshProvider: vi.fn(), validateObject: vi.fn(async () => null) };
+
+    const classDecl = `[ExtensionOf(tableStr(AslRentAgreementTable))]\nfinal class AslRentAgreementTable_Extension\n{\n}`;
+    const method1  = `public void validateStatus()\n{\n    // TODO\n}`;
+    const method2  = `public void computeTotals()\n{\n    // TODO\n}`;
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'AslRentAgreementTable_Extension',
+        operation: 'add-method',
+        sourceCode: `${classDecl}\n\n${method1}\n\n${method2}`,
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxClass\\AslRentAgreementTable_Extension.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    // Class declaration block is skipped; only the 2 real methods are added.
+    expect(addMethod).toHaveBeenCalledTimes(2);
+    const names = addMethod.mock.calls.map((c: any[]) => c[2]);
+    expect(names).toContain('validateStatus');
+    expect(names).toContain('computeTotals');
+  });
+
   it('replace-code returns bridge-required error when oldCode is not found (no bridge)', async () => {
     const fsMod = await import('fs/promises');
     (fsMod.readFile as any).mockResolvedValueOnce(

--- a/tests/tools/mergedDispatchers.test.ts
+++ b/tests/tools/mergedDispatchers.test.ts
@@ -209,6 +209,26 @@ describe('object_patterns dispatcher', () => {
     expect(formPatternTool).toHaveBeenCalledOnce();
   });
 
+  it('a real form-pattern NAME in patternType → form + action=spec + pattern', async () => {
+    await objectPatternsTool(req('object_patterns', { patternType: 'SimpleList' }), ctx);
+    expect(formPatternTool).toHaveBeenCalledOnce();
+    expect(getTablePatternsTool).not.toHaveBeenCalled();
+    expect(argsOf(formPatternTool)).toMatchObject({ domain: 'form', action: 'spec', pattern: 'SimpleList' });
+  });
+
+  it('a real form-pattern NAME in objectType (canonicalised) → form spec', async () => {
+    await objectPatternsTool(req('object_patterns', { objectType: 'detailsmaster' }), ctx);
+    expect(argsOf(formPatternTool)).toMatchObject({ domain: 'form', action: 'spec', pattern: 'DetailsMaster' });
+  });
+
+  it('a concept noun (number-sequence) in patternType → friendly error, no handler, redirects to get_knowledge', async () => {
+    const r: any = await objectPatternsTool(req('object_patterns', { patternType: 'number-sequence' }), ctx);
+    expect(r.isError).toBe(true);
+    expect(formPatternTool).not.toHaveBeenCalled();
+    expect(getTablePatternsTool).not.toHaveBeenCalled();
+    expect(r.content[0].text).toContain('get_knowledge');
+  });
+
   it('unknown/omitted domain with no signals → friendly error', async () => {
     const r: any = await objectPatternsTool(req('object_patterns', {}), ctx);
     expect(r.isError).toBe(true);

--- a/tests/utils/formPatternTemplates.test.ts
+++ b/tests/utils/formPatternTemplates.test.ts
@@ -543,12 +543,17 @@ describe('Form pattern edge cases', () => {
     expect(hasNamedControl(xml, 'Tab')).toBe(true);
   });
 
-  it('DetailsTransaction uses default linesDsName when not provided', () => {
-    const xml = FormPatternTemplates.buildDetailsTransaction({
+  it('DetailsTransaction uses D365FO-correct default linesDsName when not provided', () => {
+    // SalesTable → SalesLine, Order → OrderLine  (strips Table suffix, adds singular Line)
+    const xmlTable = FormPatternTemplates.buildDetailsTransaction({
+      formName: 'SalesForm', dsName: 'SalesTable', dsTable: 'SalesTable',
+    });
+    expect(xmlTable).toContain('<Name>SalesLine</Name>');
+
+    const xmlNoSuffix = FormPatternTemplates.buildDetailsTransaction({
       formName: 'OrderForm', dsName: 'Order', dsTable: 'OrderTable',
     });
-    // Default: dsName + "Lines"
-    expect(xml).toContain('<Name>OrderLines</Name>');
+    expect(xmlNoSuffix).toContain('<Name>OrderLine</Name>');
   });
 
   it('caption is optional and omitted correctly', () => {


### PR DESCRIPTION
## Fix stdio crash, object_patterns honeypot, and 6 scaffold first-attempt friction points

Batch of targeted fixes discovered during a real Equipment Rental module scaffold
session. No refactoring beyond what each bug required. **1089 tests passing.**

### Crashes & reliability
Node ≥15 terminates the process on an unhandled promise rejection. In stdio mode this
killed the MCP subprocess — observed as *"the server crashes on the first request and
has to be restarted"* — when the async DB load rejected before any local tool awaited
`dbReadyPromise`.
- Global `unhandledRejection` + `uncaughtException` handlers that log and keep serving
- Floor `.catch()` on `dbReadyPromise` so a background failure never floats
- `'error'` listeners on the bridge child's stdin/stdout/stderr (an unlistened stream
  error throws as a fatal `uncaughtException` — e.g. EPIPE when the bridge dies mid-write)

### `object_patterns` routing (#0)
The `domain` schema advertised `Alias: patternType`, leading agents to pass concept
nouns like `"number-sequence"` / `"SysOperation"` to a handler that couldn't use them.
- Removed the alias; added an explicit ⚠️ note that this is **not** a free-form type field
- `resolvePatternExact()` pre-check: a real form-pattern NAME (e.g. `"SimpleList"`,
  `"DetailsMaster"`) passed via `patternType`/`type`/`objectType` now routes to
  `domain=form`, `action=spec`. Concept nouns still redirect to `get_knowledge`.

### Bridge `ModelSaveInfo` NRE — every create silently fell back to XML (#0)
`createObject` / `createSmartTable` were NRE-ing inside `IMetadataProvider.Create()` and
silently falling back to XML generation. Root cause: the model descriptor's `<Id>` is
actually the **SequenceId** (large number, e.g. `896000930`), not the small
`ModelSaveInfo.Id` (e.g. `116`). `ParseModelDescriptor` put it in `.Id` and left
`SequenceId = 0`, so the SDK couldn't map it to a loaded model.
- `ResolveModelSaveInfo()` now reads the runtime **model manifest** first (correct
  Id + SequenceId + Layer); descriptor scan stays as fallback
- Stack traces added to recoverable-write `[INFO]` logs so silent fallbacks are diagnosable

### EDT base type (#1) — Date/Real fields scaffolded as String
`resolveEdtBaseType()` returned `'String'` for root EDTs (`extends = null`), shadowing the
name heuristic — `TransDate` (→ Date) and `Qty` (→ Real) became `AxTableFieldString`.
- Returns `undefined` for root EDTs with no `string_size` (genuinely ambiguous)
- New `bridgeEdtBaseType()` asks the C# bridge for the real primitive type
- Resolution chain: **bridge → index → name heuristic**

### Scaffold friction (#2–#5)
- **#2 `fieldsHint` dedup** — a repeated hint name (`"AmountMST, AmountMST"`) was silently
  dropped; now auto-suffixed (`AmountMST2`) so both fields survive.
- **#3 DetailsTransaction `linesDsName`** — default was `${dsName}Lines` (never correct in
  D365FO); now `${dsName without Table}Line` (`SalesTable → SalesLine`). `generateSmartForm`
  passes the stale-plural–corrected `linesDsNameResolved` to the template.
- **#4 `add-method` + `classDeclaration`** — a class/extension declaration block in a
  multi-body `sourceCode` (`[ExtensionOf(...)] final class Foo_Extension {}`) made name
  derivation throw. It's now skipped (not a method); the real methods in the same call
  are still added.
- **#5 bridge stale cache** — after `createSmartTable`/`createObject`, `get_object_info`
  reported `TableGroup: Miscellaneous` (stale provider). Both creates now call
  `RefreshProvider()` on success.

### Tests
- `edt-resolution.test.ts` — 4 cases for root-EDT ambiguity
- `mergedDispatchers.test.ts` — form-pattern-name routing + concept-noun redirect
- `file-ops.test.ts` — `add-method` skips class block, adds 2 methods
- `code-generation.test.ts` — `fieldsHint` dedup keeps both fields
- `formPatternTemplates.test.ts` — `SalesTable → SalesLine` default

### Reviewer notes
- **Bridge rebuild required** for the C# changes (#0 NRE fix, #5 cache refresh, stack traces)
- **MCP server restart required** after the rebuild — the model manifest is cached at bridge spawn
- **#5 has no unit test** — the C# auto-refresh requires end-to-end verification with a running bridge