### PR TITLE
fix: merged dispatcher param-shape mismatches in get_method and get_knowledge

### DIFF
--- a/src/tools/getKnowledge.ts
+++ b/src/tools/getKnowledge.ts
@@ -45,7 +45,16 @@ export async function getKnowledgeTool(request: CallToolRequest) {
   if (kind === 'error') {
     return d365foErrorHelpTool(subRequest('get_d365fo_error_help', rest));
   }
-  return xppKnowledgeTool(subRequest('get_xpp_knowledge', rest));
+
+  // The underlying xppKnowledge handler expects `topic`. Models commonly guess
+  // `query`/`q`/`search` instead — remap those to `topic` so the call doesn't
+  // fail with a misleading "expected string, received undefined" zod error.
+  const knowledgeArgs = { ...rest } as Record<string, unknown>;
+  if (knowledgeArgs.topic == null) {
+    const alias = knowledgeArgs.query ?? knowledgeArgs.q ?? knowledgeArgs.search;
+    if (alias != null) knowledgeArgs.topic = alias;
+  }
+  return xppKnowledgeTool(subRequest('get_xpp_knowledge', knowledgeArgs));
 }
 
 // Tool registration (name, description, inputSchema) lives inline in

--- a/src/tools/getMethod.ts
+++ b/src/tools/getMethod.ts
@@ -66,9 +66,25 @@ export async function getMethodTool(request: CallToolRequest, context: XppServer
   // both: signature first (cheap context), then full source.
   const sig = await getMethodSignatureTool(subRequest('get_method_signature', rest), context);
   const src = await getMethodSourceTool(subRequest('get_method_source', rest), context);
+  const sigOk = Boolean(sig && !sig.isError);
+  const srcOk = Boolean(src && !src.isError);
+
+  // Source is the authoritative payload. Some members (e.g. classDeclaration)
+  // have a valid source but no parseable signature, so the signature path emits
+  // a misleading "method not found" error. When the source succeeded, only keep
+  // the parts that actually succeeded — never surface a signature-only failure.
+  const parts = [
+    ...(sigOk ? sig!.content : []),
+    ...(srcOk ? src!.content : []),
+  ];
+  if (parts.length > 0) {
+    return { content: parts, isError: false };
+  }
+
+  // Both failed — return the source error (its "not found" hint is more useful).
   return {
-    content: [...(sig?.content ?? []), ...(src?.content ?? [])],
-    isError: Boolean(sig?.isError || src?.isError),
+    content: [...(src?.content ?? sig?.content ?? [])],
+    isError: true,
   };
 }
 

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -116,6 +116,22 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
       return { content: [{ type: 'text', text: output }] };
     }
 
+    // classDeclaration is the class header pseudo-member — it has no
+    // parenthesised signature, so the signature path can never parse it even
+    // though its source is retrievable. Give an accurate pointer instead of the
+    // misleading "delegate / SubscribesTo" not-found message below.
+    if (methodName.toLowerCase() === 'classdeclaration') {
+      return {
+        content: [{
+          type: 'text',
+          text: `ℹ️ \`${className}.classDeclaration\` is the class header, not a method — it has no signature.\n\n` +
+            `Use \`get_method(className="${className}", methodName="classDeclaration", include="source")\` to read the declaration source, ` +
+            `or \`get_object_info(objectType="class", name="${className}")\` for the class overview.`,
+        }],
+        isError: true,
+      };
+    }
+
     // Method not in SQLite and not reachable via bridge/XML.
     // Delegates and SubscribesTo handlers are commonly absent from the index.
     if (!methodRow) {

--- a/tests/tools/getKnowledge.test.ts
+++ b/tests/tools/getKnowledge.test.ts
@@ -42,4 +42,22 @@ describe('get_knowledge kind inference', () => {
     await getKnowledgeTool(req({}));
     expect(xppKnowledgeTool).toHaveBeenCalledOnce();
   });
+
+  it('remaps query → topic for the knowledge handler', async () => {
+    await getKnowledgeTool(req({ query: 'X++ static variable lifetime' }));
+    expect(xppKnowledgeTool).toHaveBeenCalledOnce();
+    expect((xppKnowledgeTool as any).mock.calls[0][0].params.arguments).toMatchObject({
+      topic: 'X++ static variable lifetime',
+    });
+  });
+
+  it('remaps q / search aliases to topic too', async () => {
+    await getKnowledgeTool(req({ search: 'number sequences' }));
+    expect((xppKnowledgeTool as any).mock.calls[0][0].params.arguments).toMatchObject({ topic: 'number sequences' });
+  });
+
+  it('does not override an explicit topic with query', async () => {
+    await getKnowledgeTool(req({ topic: 'CoC', query: 'ignored' }));
+    expect((xppKnowledgeTool as any).mock.calls[0][0].params.arguments.topic).toBe('CoC');
+  });
 });

--- a/tests/tools/getMethod.test.ts
+++ b/tests/tools/getMethod.test.ts
@@ -1,0 +1,86 @@
+/**
+ * get_method dispatcher tests — routing by `include` and the "both" merge rule.
+ *
+ * The two underlying handlers are mocked so these tests assert ONLY the
+ * dispatcher's own routing + result-merging logic. The key regression here:
+ * when a member (e.g. classDeclaration) has no parseable signature, the
+ * signature handler returns isError, but the source handler succeeds — the
+ * merged "both" result must NOT surface that false-negative.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+vi.mock('../../src/tools/methodSignature', () => ({
+  getMethodSignatureTool: vi.fn(),
+}));
+vi.mock('../../src/tools/getMethodSource', () => ({
+  getMethodSourceTool: vi.fn(),
+}));
+
+import { getMethodTool } from '../../src/tools/getMethod';
+import { getMethodSignatureTool } from '../../src/tools/methodSignature';
+import { getMethodSourceTool } from '../../src/tools/getMethodSource';
+
+const sigMock = getMethodSignatureTool as any;
+const srcMock = getMethodSourceTool as any;
+
+const ctx: any = { symbolIndex: {} };
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'get_method', arguments: args },
+});
+const ok = (text: string) => ({ content: [{ type: 'text', text }] });
+const err = (text: string) => ({ content: [{ type: 'text', text }], isError: true });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('get_method dispatcher', () => {
+  it('include=signature → only the signature handler', async () => {
+    sigMock.mockResolvedValue(ok('sig'));
+    await getMethodTool(req({ className: 'C', methodName: 'm', include: 'signature' }), ctx);
+    expect(getMethodSignatureTool).toHaveBeenCalledOnce();
+    expect(getMethodSourceTool).not.toHaveBeenCalled();
+  });
+
+  it('include=source → only the source handler', async () => {
+    srcMock.mockResolvedValue(ok('src'));
+    await getMethodTool(req({ className: 'C', methodName: 'm', include: 'source' }), ctx);
+    expect(getMethodSourceTool).toHaveBeenCalledOnce();
+    expect(getMethodSignatureTool).not.toHaveBeenCalled();
+  });
+
+  it('missing className → friendly error, no handler call', async () => {
+    const r: any = await getMethodTool(req({ methodName: 'm' }), ctx);
+    expect(r.isError).toBe(true);
+    expect(getMethodSignatureTool).not.toHaveBeenCalled();
+    expect(getMethodSourceTool).not.toHaveBeenCalled();
+  });
+
+  it('both: concatenates when both succeed', async () => {
+    sigMock.mockResolvedValue(ok('SIG'));
+    srcMock.mockResolvedValue(ok('SRC'));
+    const r: any = await getMethodTool(req({ className: 'C', methodName: 'm' }), ctx);
+    expect(r.isError).toBe(false);
+    expect(r.content.map((c: any) => c.text)).toEqual(['SIG', 'SRC']);
+  });
+
+  it('both: source success suppresses a signature-only failure (classDeclaration case)', async () => {
+    sigMock.mockResolvedValue(err('❌ not found / Delegate methods'));
+    srcMock.mockResolvedValue(ok('## C.classDeclaration\n_Source: C# bridge_'));
+    const r: any = await getMethodTool(req({ className: 'C', methodName: 'classDeclaration' }), ctx);
+    expect(r.isError).toBe(false);
+    expect(r.content).toHaveLength(1);
+    expect(r.content[0].text).toContain('classDeclaration');
+    expect(r.content[0].text).not.toContain('Delegate methods');
+  });
+
+  it('both: when both fail, returns the source error', async () => {
+    sigMock.mockResolvedValue(err('sig error'));
+    srcMock.mockResolvedValue(err('src not found — use get_object_info'));
+    const r: any = await getMethodTool(req({ className: 'C', methodName: 'nope' }), ctx);
+    expect(r.isError).toBe(true);
+    expect(r.content).toHaveLength(1);
+    expect(r.content[0].text).toContain('get_object_info');
+  });
+});


### PR DESCRIPTION
## Problem

Two consolidated (merged) tools failed to translate input/output shape into what their sub-handlers expect, producing misleading errors:

### 1. `get_method` on `classDeclaration` — "not found" *and* the source at once
Default `include: "both"` runs both sub-handlers and concatenates their output. For `classDeclaration` (the class-header pseudo-member, which has no parenthesised signature):
- `get_method_signature` → `parseMethodSignature` can't find a `name(` line, so the bridge result is discarded → emits the misleading `❌ not found / Delegate methods / [SubscribesTo]` message.
- `get_method_source` → returns the raw bridge source fine.

Result: a contradictory blob (false-negative warning + valid source) with `isError: true`.

### 2. `get_knowledge { "query": ... }` — zod error on `topic`
The underlying `xppKnowledge` schema requires `topic`. `get_knowledge` passes `query` straight through, so zod throws `expected string, received undefined` at path `topic`. The field is named `topic`, with no alias for the common `query` guess.

## Fix

- **`get_method.ts`** — in `"both"`, merge only the parts that actually succeeded. When the source path succeeds, a signature-only failure is no longer surfaced and `isError` is `false`; when both fail, return the source error (its `get_object_info` hint is more useful).
- **`methodSignature.ts`** — direct `include: "signature"` on `classDeclaration` now returns an accurate "this is the class header, has no signature — use `include="source"`" message instead of the delegate/SubscribesTo hint.
- **`getKnowledge.ts`** — remap `query` / `q` / `search` → `topic` before forwarding (only when `topic` is absent; explicit `topic` wins).

## Tests
- New `tests/tools/getMethod.test.ts` (6 cases, incl. the source-success-suppresses-signature-failure regression).
- Extended `tests/tools/getKnowledge.test.ts` for the `query/search → topic` alias and explicit-`topic` precedence.
- `tsc` build clean; affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)