### PR TITLE
fix(audit): repair integration test tier, security_info errors, stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
-[![Tests](https://img.shields.io/badge/tests-850%2B-brightgreen.svg)](docs/TESTING.md)
+[![Tests](https://img.shields.io/badge/tests-1100%2B-brightgreen.svg)](docs/TESTING.md)
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-The project uses [Vitest](https://vitest.dev/). 850+ tests run without a live D365FO environment — all external dependencies (SQLite, filesystem, bridge, cache) are mocked.
+The project uses [Vitest](https://vitest.dev/). 1100+ tests run without a live D365FO environment — all external dependencies (SQLite, filesystem, bridge, cache) are mocked.
 
 ## Running tests
 
@@ -9,7 +9,7 @@ npm test -- --run                       # all tests once
 npm test                                # watch mode
 npm test -- --coverage                  # with coverage → coverage/
 npm test tests/tools/discovery.test.ts  # single file
-npm run test:integration                # tool routing end-to-end (requires npm run build)
+npm run test:integration                # tool routing end-to-end via the real dispatcher
 npx tsx tests/bridge-e2e.ts             # manual bridge E2E (Windows D365FO VM only)
 ```
 

--- a/src/tools/securityInfo.ts
+++ b/src/tools/securityInfo.ts
@@ -10,7 +10,6 @@
  */
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
-import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { securityArtifactInfoTool } from './securityArtifactInfo.js';
 import { securityCoverageInfoTool } from './securityCoverageInfo.js';
@@ -18,33 +17,34 @@ import { securityCoverageInfoTool } from './securityCoverageInfo.js';
 export const SECURITY_MODES = ['artifact', 'coverage'] as const;
 export type SecurityMode = (typeof SECURITY_MODES)[number];
 
-const SecurityInfoArgsSchema = z
-  .object({
-    mode: z.enum(SECURITY_MODES).describe(
-      'artifact → details + hierarchy of a named privilege/duty/role; ' +
-      'coverage → which roles/duties/privileges grant access to a given object.',
-    ),
-  })
-  .passthrough();
-
 function subRequest(name: string, args: Record<string, unknown>): CallToolRequest {
   return { method: 'tools/call', params: { name, arguments: args } };
 }
 
-export async function securityInfoTool(request: CallToolRequest, context: XppServerContext) {
-  const parsed = SecurityInfoArgsSchema.safeParse(request.params.arguments ?? {});
-  if (!parsed.success) {
-    return {
-      content: [{ type: 'text', text: `❌ security_info: invalid arguments — ${parsed.error.message}` }],
-      isError: true,
-    };
-  }
+function err(text: string) {
+  return { content: [{ type: 'text' as const, text }], isError: true };
+}
 
-  const { mode, ...rest } = parsed.data;
-  if (mode === 'coverage') {
-    return securityCoverageInfoTool(subRequest('get_security_coverage_for_object', rest), context);
+export async function securityInfoTool(request: CallToolRequest, context: XppServerContext) {
+  const a = (request.params.arguments ?? {}) as Record<string, any>;
+  const mode = a.mode as string | undefined;
+  const { mode: _mode, ...rest } = a;
+
+  switch (mode) {
+    case 'artifact':
+      // Validate per-mode required params here so the agent gets a guided
+      // message instead of the underlying handler's raw ZodError.
+      if (!a.name) return err('security_info(mode="artifact") requires `name` (the privilege/duty/role name).');
+      if (!a.artifactType) return err('security_info(mode="artifact") requires `artifactType` (privilege, duty, or role).');
+      return securityArtifactInfoTool(subRequest('get_security_artifact_info', rest), context);
+
+    case 'coverage':
+      if (!a.objectName) return err('security_info(mode="coverage") requires `objectName` (the form/table/class/menu-item name).');
+      return securityCoverageInfoTool(subRequest('get_security_coverage_for_object', rest), context);
+
+    default:
+      return err(`security_info: unknown mode "${mode ?? '(missing)'}". Use one of: ${SECURITY_MODES.join(', ')}.`);
   }
-  return securityArtifactInfoTool(subRequest('get_security_artifact_info', rest), context);
 }
 
 // Tool registration (name, description, inputSchema) lives inline in

--- a/src/tools/undoLastModification.ts
+++ b/src/tools/undoLastModification.ts
@@ -150,11 +150,11 @@ async function cleanupIndexAfterUndo(
 
   try {
     // 1. Remove stale symbols from SQLite
-    const { deletedCount } = symbolIndex.removeSymbolsByFile(filePath);
+    const { deletedCount } = symbolIndex?.removeSymbolsByFile?.(filePath) ?? { deletedCount: 0 };
     console.error(`[undo] Removed ${deletedCount} stale symbol(s) for ${path.basename(filePath)}`);
 
     // 2. Remove stale labels (label .txt files have the same path pattern)
-    const labelCount = symbolIndex.removeLabelsByFile(filePath);
+    const labelCount = symbolIndex?.removeLabelsByFile?.(filePath) ?? 0;
     if (labelCount > 0) {
       console.error(`[undo] Removed ${labelCount} stale label(s) for ${path.basename(filePath)}`);
     }

--- a/tests/dispatch.integration.test.ts
+++ b/tests/dispatch.integration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tool-routing integration test — exercises the REAL central dispatcher
+ * (`registerToolHandler`) end to end, not the individual tool handlers in
+ * isolation. This is the suite `npm run test:integration` runs.
+ *
+ * Unlike the unit tests (which call each tool function directly with mocked
+ * dependencies), this drives a request through the same code path the live
+ * MCP server uses: server-mode gating → dbReady wait → dedup/in-flight →
+ * progress + logging channels → the `switch (toolName)` router → response
+ * capping → metrics. A regression in any of those layers shows up here.
+ *
+ * `get_knowledge` is used as the probe because it is pure (request-only, no
+ * SQLite/bridge/filesystem) and is NOT excluded from dedup, so the dedup
+ * layer can be asserted too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { registerToolHandler } from '../src/tools/toolHandler';
+import type { XppServerContext } from '../src/types/context';
+
+type CallHandler = (request: any, extra: any) => Promise<any>;
+
+/**
+ * Minimal stand-in for the MCP `Server`. registerToolHandler only registers a
+ * single request handler (for CallToolRequestSchema) and calls
+ * sendLoggingMessage() best-effort, so that is all we need to capture.
+ */
+function buildFakeServer(): { server: any; getCallHandler: () => CallHandler } {
+  let callHandler: CallHandler | undefined;
+  const server = {
+    setRequestHandler(schema: unknown, handler: CallHandler) {
+      if (schema === CallToolRequestSchema) callHandler = handler;
+    },
+    // best-effort logging channel — handler wraps this in try/catch
+    async sendLoggingMessage() {},
+  };
+  return {
+    server,
+    getCallHandler: () => {
+      if (!callHandler) throw new Error('CallTool handler was not registered');
+      return callHandler;
+    },
+  };
+}
+
+const ctx: XppServerContext = { symbolIndex: {} } as unknown as XppServerContext;
+
+// No progressToken → the handler skips the notifications/progress channel.
+const extra = { _meta: {} };
+
+function call(handler: CallHandler, name: string, args: Record<string, unknown>) {
+  return handler({ method: 'tools/call', params: { name, arguments: args } }, extra);
+}
+
+describe('tool routing — central dispatcher (integration)', () => {
+  it('routes a real tool through the dispatcher and returns content', async () => {
+    const { server, getCallHandler } = buildFakeServer();
+    registerToolHandler(server, ctx);
+
+    const res: any = await call(getCallHandler(), 'get_knowledge', { kind: 'knowledge', topic: 'coc' });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content?.[0]?.text).toBeTruthy();
+    expect(typeof res.content[0].text).toBe('string');
+  });
+
+  it('returns a friendly isError for an unknown tool name', async () => {
+    const { server, getCallHandler } = buildFakeServer();
+    registerToolHandler(server, ctx);
+
+    const res: any = await call(getCallHandler(), 'no_such_tool', {});
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Unknown tool');
+  });
+
+  it('serves an identical repeat call from the dedup cache', async () => {
+    const { server, getCallHandler } = buildFakeServer();
+    registerToolHandler(server, ctx);
+    const h = getCallHandler();
+
+    // Unique topic so the dedup key cannot collide with the other cases.
+    const args = { kind: 'knowledge', topic: 'integration-dedup-probe' };
+    const first: any = await call(h, 'get_knowledge', args);
+    const second: any = await call(h, 'get_knowledge', args);
+
+    expect(first.content[0].text).toBeTruthy();
+    // The second identical call is short-circuited and annotated by the dispatcher.
+    expect(second.content.map((c: any) => c.text).join('\n')).toContain('Duplicate call');
+  });
+});

--- a/tests/tools/mergedDispatchers.test.ts
+++ b/tests/tools/mergedDispatchers.test.ts
@@ -2,7 +2,8 @@
  * Merged dispatcher tests — verify the consolidated tools route to the correct
  * underlying handler and remap their discriminator/params correctly.
  *
- * Covers: extension_info, validate_code, generate_object, object_patterns.
+ * Covers: extension_info, validate_code, generate_object, object_patterns,
+ * analyze_code, security_info.
  * The underlying handlers are mocked so these tests assert ONLY the dispatcher's
  * own routing + argument-remapping logic (the handlers have their own tests).
  */
@@ -27,8 +28,13 @@ vi.mock('../../src/tools/analyzePatterns', () => ({ analyzeCodePatternsTool: vi.
 vi.mock('../../src/tools/suggestImplementation', () => ({ suggestMethodImplementationTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'impl' }] })) }));
 vi.mock('../../src/tools/analyzeCompleteness', () => ({ analyzeClassCompletenessTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'complete' }] })) }));
 vi.mock('../../src/tools/apiUsagePatterns', () => ({ getApiUsagePatternsTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'api' }] })) }));
+vi.mock('../../src/tools/securityArtifactInfo', () => ({ securityArtifactInfoTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'artifact' }] })) }));
+vi.mock('../../src/tools/securityCoverageInfo', () => ({ securityCoverageInfoTool: vi.fn((_r: any) => ({ content: [{ type: 'text', text: 'coverage' }] })) }));
 
 import { extensionInfoTool } from '../../src/tools/extensionInfo';
+import { securityInfoTool } from '../../src/tools/securityInfo';
+import { securityArtifactInfoTool } from '../../src/tools/securityArtifactInfo';
+import { securityCoverageInfoTool } from '../../src/tools/securityCoverageInfo';
 import { analyzeCodeTool } from '../../src/tools/analyzeCode';
 import { getApiUsagePatternsTool } from '../../src/tools/apiUsagePatterns';
 import { validateCodeTool } from '../../src/tools/validateCode';
@@ -246,5 +252,59 @@ describe('analyze_code dispatcher', () => {
   it('does not override an explicit apiName', async () => {
     await analyzeCodeTool(req('analyze_code', { mode: 'api-usage', apiName: 'NumberSeq', className: 'X' }), ctx);
     expect(argsOf(getApiUsagePatternsTool).apiName).toBe('NumberSeq');
+  });
+});
+
+// ── security_info ─────────────────────────────────────────────────────────────
+describe('security_info dispatcher', () => {
+  it('mode=artifact → securityArtifactInfo with mode stripped, params passed through', async () => {
+    await securityInfoTool(
+      req('security_info', { mode: 'artifact', name: 'VendPaymTermsMaintain', artifactType: 'duty', includeChain: true }),
+      ctx,
+    );
+    expect(securityArtifactInfoTool).toHaveBeenCalledOnce();
+    expect(securityCoverageInfoTool).not.toHaveBeenCalled();
+    const fwd = argsOf(securityArtifactInfoTool);
+    expect(fwd).toEqual({ name: 'VendPaymTermsMaintain', artifactType: 'duty', includeChain: true });
+    expect(fwd.mode).toBeUndefined();
+  });
+
+  it('mode=coverage → securityCoverageInfo with objectName/objectType passed through', async () => {
+    await securityInfoTool(
+      req('security_info', { mode: 'coverage', objectName: 'VendPaymTerms', objectType: 'form' }),
+      ctx,
+    );
+    expect(securityCoverageInfoTool).toHaveBeenCalledOnce();
+    expect(securityArtifactInfoTool).not.toHaveBeenCalled();
+    expect(argsOf(securityCoverageInfoTool)).toEqual({ objectName: 'VendPaymTerms', objectType: 'form' });
+  });
+
+  it('missing name on artifact → friendly error, no handler call', async () => {
+    const r: any = await securityInfoTool(req('security_info', { mode: 'artifact', artifactType: 'role' }), ctx);
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/requires `name`/);
+    expect(securityArtifactInfoTool).not.toHaveBeenCalled();
+  });
+
+  it('missing artifactType on artifact → friendly error', async () => {
+    const r: any = await securityInfoTool(req('security_info', { mode: 'artifact', name: 'X' }), ctx);
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/requires `artifactType`/);
+    expect(securityArtifactInfoTool).not.toHaveBeenCalled();
+  });
+
+  it('missing objectName on coverage → friendly error', async () => {
+    const r: any = await securityInfoTool(req('security_info', { mode: 'coverage' }), ctx);
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/requires `objectName`/);
+    expect(securityCoverageInfoTool).not.toHaveBeenCalled();
+  });
+
+  it('unknown/missing mode → friendly error listing valid modes', async () => {
+    const r: any = await securityInfoTool(req('security_info', { name: 'X', artifactType: 'role' }), ctx);
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/unknown mode/);
+    expect(r.content[0].text).toMatch(/artifact, coverage/);
+    expect(securityArtifactInfoTool).not.toHaveBeenCalled();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,14 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     setupFiles: ['./tests/setup.ts'],
+    // Integration tests (*.integration.test.ts) are run separately via
+    // vitest.integration.config.ts (npm run test:integration) — keep them out
+    // of the default unit run so the two tiers stay distinct.
+    exclude: [...configDefaults.exclude, '**/*.integration.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Findings from a functionality audit of the 26 MCP tools, plus their fixes. All changes are small, well-scoped and fully covered.

## What was wrong

**1. `test:integration` was a dead command**
The integration config's include pattern (`tests/**/*.integration.{test,spec}.ts`) matched **zero files**, so `npm run test:integration` exited 1 (`No test files found`). CI doesn't invoke it, so the pipeline wasn't broken — but the documented command was misleading.
→ Added a real end-to-end routing test ([`tests/dispatch.integration.test.ts`](tests/dispatch.integration.test.ts)) that drives a request through the **live `registerToolHandler` dispatcher** (the `switch` router, dedup/in-flight coalescing, the central error-net, response capping, progress/logging channels). Uses `get_knowledge` as the probe because it's pure (no SQLite/bridge/fs) and not dedup-excluded. Also excluded `*.integration.test.ts` from the unit run so the two tiers stay distinct.

**2. `security_info` — only consolidated dispatcher with no test, and raw ZodErrors**
The underlying handlers use `.parse()`, so a missing `name`/`artifactType`/`objectName` surfaced as a raw ZodError instead of the guided per-mode message every other dispatcher returns.
→ Gave `security_info` `extension_info`-style friendly errors and added a 6-case dispatcher suite to [`mergedDispatchers.test.ts`](tests/tools/mergedDispatchers.test.ts) (param passthrough for artifact/coverage + every error path). Param shapes were verified correct — no latent routing bug, this just adds the missing regression net.

**3. `undo_last_modification` — unguarded index call**
`symbolIndex.removeSymbolsByFile(...)` threw a `TypeError` when the context had no index (caught as "non-fatal", but noisy).
→ Guarded with `symbolIndex?.removeSymbolsByFile?.() ?? …`.

**4. Stale docs**
Test count badge/blurb `850+` → `1100+` (actual: 1104). Corrected the `test:integration` description (runs via tsx, no build needed).

## Verification
- `tsc --noEmit` — clean
- Unit suite — **1104/1104** pass (68 files, +6 new)
- Integration suite — **3/3** pass

## Note
Two items I initially flagged turned out to be **already correct** in the docs, so they were left untouched: the "25 modify operations" count (enum has exactly 25 unique values) and "18 AOT object types" for create (an intentional subset, not the full 30-value shared enum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)