### PR TITLE
perf(schema): token budget test + trim d365fo_file ListTools payload

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -575,11 +575,11 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
               },
               packagePath: {
                 type: 'string',
-                description: 'Base package path (default: K:\\AosService\\PackagesLocalDirectory). Also used by [modify] to locate objects whose metadata lives outside the default PackagesLocalDirectory (e.g. a repo checkout). Note: bridge-backed modify operations resolve objects via the C# bridge\'s startup roots — if the model is outside them, set context.customPackagesPath / D365FO_CUSTOM_PACKAGES_PATH instead, or pass an explicit filePath.'
+                description: 'Base package path (default: K:\\AosService\\PackagesLocalDirectory). [modify] also uses it to locate objects outside the default dir (e.g. a repo checkout); if the model is outside the bridge startup roots, set D365FO_CUSTOM_PACKAGES_PATH or pass filePath instead.'
               },
               sourceCode: {
                 type: 'string',
-                description: `X++ source code for the object.\n\nFOR CLASSES — the content is split into <Declaration> and <Methods> automatically:\n  • <Declaration> = class keyword line + ALL member variable declarations inside the outer { }\n  • <Methods>     = each method defined AFTER the closing } of the class header\n\nExample for a class with member variables and a method:\n  public class MyClass\n  {\n      int globalPackageNumber;\n      Qty totalExportedQty;\n  }\n  public void myMethod()\n  {\n      // body\n  }\n\nCRITICAL: member variables MUST be inside the class { } block — NOT after it.`
+                description: 'X++ source for the object. FOR CLASSES the content is auto-split: <Declaration> = the class line + ALL member variables inside the outer { }; <Methods> = each method AFTER the closing }. CRITICAL: member variables MUST sit inside the class { }, methods after it — never the reverse.'
               },
               properties: {
                 type: 'object',
@@ -595,8 +595,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                   '• security-privilege: label, targetObject, objectType (MenuItemDisplay|Action|Output), accessLevel (view|maintain), dataEntity (data entity name → emits DataEntityPermissions grant for OData access)\n' +
                   '• security-duty: label, privileges[] (privilege names — array or comma-separated)\n' +
                   '• security-role: label, duties[] (duty names), privileges[] (privilege names)\n' +
-                  '• menu-item-*: label, object, objectType\n' +
-                  'Example: properties={"fields":[{"name":"ContosoStatus","enumType":"NoYes","fieldType":"AxTableFieldEnum","label":"@Contoso:Status"}]}'
+                  '• menu-item-*: label, object, objectType'
               },
               addToProject: {
                 type: 'boolean',

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -23,10 +23,11 @@ import { createXppMcpServer } from '../../src/server/mcpServer';
 // the human-readable log line, never for assertions.
 const CHARS_PER_TOKEN = 4;
 
-// Ceilings in characters of serialized JSON. Current actuals (2026-06):
-//   total ≈ 70,706 · d365fo_file ≈ 19,106. Headroom is small on purpose.
-const TOTAL_BUDGET = 75_000;
-const LARGEST_TOOL_BUDGET = 20_000; // d365fo_file is the outlier (~27% of total)
+// Ceilings in characters of serialized JSON. Current actuals (2026-06, after
+// the A+B description trim): total ≈ 70,103 · d365fo_file ≈ 18,503. Headroom is
+// small on purpose so creep is caught early.
+const TOTAL_BUDGET = 72_000;
+const LARGEST_TOOL_BUDGET = 19_000; // d365fo_file is the outlier (~26% of total)
 
 async function getTools(): Promise<Array<{ name: string }>> {
   const ctx: any = { symbolIndex: {}, parser: {} };

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tool-schema token budget — a regression ratchet on the cost of the ListTools
+ * payload, which is sent to the model on (at least) every new session and is
+ * the server's largest fixed token cost.
+ *
+ * Rationale: the 26 tool schemas are verbose on purpose (the descriptions encode
+ * hard-won D365FO patterns that prevent failed/retried calls), so the goal is
+ * NOT to minimise blindly — it is to make the size *visible and bounded* so it
+ * cannot creep upward unnoticed. Lower these ceilings whenever the schema is
+ * trimmed; raise them only deliberately (e.g. a new tool), the same way
+ * toolInventory.test.ts guards the tool *count*.
+ *
+ * Measured against the REAL serialized payload (not the source), because that
+ * is what the client bills. We pull the registered `tools/list` handler off the
+ * constructed server rather than standing up a transport — the handler ignores
+ * its request/extra args, so a direct call returns the exact wire payload.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createXppMcpServer } from '../../src/server/mcpServer';
+
+// ~4 chars/token is the usual rough conversion for English+JSON; only used for
+// the human-readable log line, never for assertions.
+const CHARS_PER_TOKEN = 4;
+
+// Ceilings in characters of serialized JSON. Current actuals (2026-06):
+//   total ≈ 70,706 · d365fo_file ≈ 19,106. Headroom is small on purpose.
+const TOTAL_BUDGET = 75_000;
+const LARGEST_TOOL_BUDGET = 20_000; // d365fo_file is the outlier (~27% of total)
+
+async function getTools(): Promise<Array<{ name: string }>> {
+  const ctx: any = { symbolIndex: {}, parser: {} };
+  const server: any = createXppMcpServer(ctx);
+  const handler = server._requestHandlers?.get('tools/list');
+  if (!handler) throw new Error('tools/list handler not registered on the server');
+  const res = await handler({ method: 'tools/list' }, {});
+  return res.tools;
+}
+
+describe('tool schema token budget', () => {
+  it('total ListTools payload stays within the token budget', async () => {
+    const tools = await getTools();
+    const chars = JSON.stringify(tools).length;
+    // eslint-disable-next-line no-console
+    console.error(
+      `[tool-budget] ${tools.length} tools · ${chars} chars ≈ ${Math.round(chars / CHARS_PER_TOKEN)} tokens ` +
+      `(budget ${TOTAL_BUDGET} chars)`,
+    );
+    expect(tools.length).toBe(26);
+    expect(chars).toBeLessThan(TOTAL_BUDGET);
+  });
+
+  it('no single tool dominates the payload beyond its cap', async () => {
+    const tools = await getTools();
+    const sizes = tools
+      .map(t => ({ name: t.name, chars: JSON.stringify(t).length }))
+      .sort((a, b) => b.chars - a.chars);
+    // eslint-disable-next-line no-console
+    console.error('[tool-budget] top 5: ' + sizes.slice(0, 5).map(s => `${s.name}=${s.chars}`).join(', '));
+
+    const largest = sizes[0];
+    expect(
+      largest.chars,
+      `largest tool schema '${largest.name}' (${largest.chars} chars) exceeds the per-tool cap`,
+    ).toBeLessThan(LARGEST_TOOL_BUDGET);
+  });
+});


### PR DESCRIPTION
Token-efficiency work split out of #601 (which is now merged). Two changes, both focused on the `ListTools` payload — the server's largest fixed per-session token cost.

## 1. Token-budget regression test
[`tests/utils/toolSchemaBudget.test.ts`](tests/utils/toolSchemaBudget.test.ts) measures the **real serialized `ListTools` payload** (what the client bills) and fails if it grows past a ceiling. Pulls the registered `tools/list` handler off a constructed server, so it tracks the exact wire payload — no transport needed.

Current actuals: **26 tools · 70,187 chars ≈ 17,500 tokens**; `d365fo_file` alone is 18,587 chars (~26%). Ceilings: 72,000 total / 19,000 per-tool. Lower as the schema is trimmed; raise only deliberately — the same ratchet idea `toolInventory.test.ts` uses for the tool *count*.

## 2. Trim `d365fo_file` descriptions (A+B)
Descriptions only — **no param keys removed**, so the callable surface and the `toolInventory` contract are unchanged:
- `sourceCode`: replace the 8-line class example with the same rule stated tersely
- `properties`: drop the redundant trailing `Example` (shape is already shown on the table / table-extension lines)
- `packagePath`: condense the bridge-startup-roots caveat to a one-line pointer

## Honest note on impact
The gain is deliberately small (~600 chars off `d365fo_file`). Most of the schema is **irreducible param-shape signature** the model must see to call the tool correctly, not removable prose — the gross byte count overstated the trimmable surface. Deeper restructuring (moving per-operation modify docs into the `prepare(mode=change)` response) was **deferred**: medium accuracy risk, and prompt caching already amortizes the per-session cost. The real deliverable here is the budget test — from now on the cost is measured and cannot creep up silently.

## Verification
- `tsc --noEmit` clean
- Full suite **1114/1114** pass (incl. the new budget test and the `toolInventory` contract confirming no param keys were dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)