### PR TITLE
feat(cli): professional, capability-aware startup output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { initializeConfig, getConfigManager } from './utils/configManager.js';
 import { SERVER_MODE, LOCAL_TOOLS } from './server/serverMode.js';
 import { apiKeyAuth } from './middleware/apiKeyAuth.js';
 import { setInitializeParams } from './utils/stdioSessionInfo.js';
+import { box, kv, sectionTitle, statusLine, spread, c, glyph, sanitize, supportsUnicode, log, shortPath, startupWarnings } from './utils/terminalUi.js';
 import * as fs from 'fs/promises';
 import * as fsSync from 'node:fs';
 import { Transform } from 'node:stream';
@@ -146,9 +147,6 @@ const serverState: ServerState = {
 };
 
 async function initializeServices() {
-  console.log('🚀 Starting X++ MCP Code Completion Server...');
-  console.log(`🔧 Server mode: ${SERVER_MODE} (from env: ${process.env.MCP_SERVER_MODE || 'not set, defaulting to full'})`);
-
   // -----------------------------------------------------------------------
   // write-only mode: skip all database/symbol work — LOCAL_TOOLS
   // (create_d365fo_file, modify_d365fo_file, labels, verify_d365fo_project,
@@ -156,20 +154,19 @@ async function initializeServices() {
   //  not the 1.5 GB symbol database.
   // -----------------------------------------------------------------------
   if (SERVER_MODE === 'write-only') {
-    console.log('✏️  Mode: write-only (local file-operations companion)');
-    console.log('⏭️  Skipping database download and symbol index — not needed in write-only mode');
+    log.info('Mode: write-only (local file-operations companion)');
+    log.detail('skipping database download and symbol index — not needed here');
 
-    console.log('⚙️  Loading .mcp.json configuration...');
     const config = await initializeConfig();
     if (config?.servers?.context) {
-      console.log('✅ Configuration loaded from .mcp.json (servers.context)');
+      log.ok('Configuration loaded from .mcp.json (servers.context)');
       if (config.servers.context.workspacePath) {
-        console.log(`   Workspace path: ${config.servers.context.workspacePath}`);
+        log.detail(`workspace: ${config.servers.context.workspacePath}`);
       }
     } else if (config) {
-      console.log('ℹ️  .mcp.json found (VS/Copilot registry format) — paths from process.env');
+      log.info('Configuration from environment (.mcp.json uses VS/Copilot registry format)');
     } else {
-      console.log('ℹ️  No .mcp.json found — using environment variables / defaults');
+      log.info('Configuration from environment variables');
     }
 
     const symbolIndex = new XppSymbolIndex(':memory:', ':memory:');
@@ -182,7 +179,7 @@ async function initializeServices() {
 
     const context: import('./types/context.js').XppServerContext = { symbolIndex, parser, workspaceScanner, hybridSearch };
     const mcpServer = createXppMcpServer(context);
-    console.log('✅ MCP Server initialized (write-only mode)');
+    log.ok('MCP Server initialized (write-only mode)');
     return { mcpServer, symbolIndex, parser, workspaceScanner, hybridSearch, context };
   }
 
@@ -190,23 +187,24 @@ async function initializeServices() {
   // full / read-only mode: full initialization with database
   // -----------------------------------------------------------------------
   try {
-    // Load .mcp.json configuration
-    console.log('⚙️  Loading .mcp.json configuration...');
+    // Resolve configuration source — report the outcome in a single line rather
+    // than a "loading…" step followed by a result (the load is instant, and an
+    // absent .mcp.json is a normal case, not a warning).
     const config = await initializeConfig();
     if (config?.servers?.context) {
-      console.log('✅ Configuration loaded from .mcp.json (servers.context)');
+      log.ok('Configuration loaded from .mcp.json (servers.context)');
       if (config.servers.context.workspacePath) {
-        console.log(`   Workspace path: ${config.servers.context.workspacePath}`);
+        log.detail(`workspace: ${config.servers.context.workspacePath}`);
       }
       if (config.servers.context.packagePath) {
-        console.log(`   Package path: ${config.servers.context.packagePath}`);
+        log.detail(`packages:  ${config.servers.context.packagePath}`);
       }
     } else if (config) {
       // Home .mcp.json found but uses VS/Copilot server-registry format (servers.<name>).
       // D365FO paths are supplied via process.env (D365FO_SOLUTIONS_PATH, DB_PATH, …).
-      console.log('ℹ️  .mcp.json found (VS/Copilot registry format) — paths from process.env');
+      log.info('Configuration from environment (.mcp.json uses VS/Copilot registry format)');
     } else {
-      console.log('ℹ️  No .mcp.json found — using environment variables / defaults');
+      log.info('Configuration from environment variables');
     }
 
     // Download database from blob storage if configured (only if remote is newer than local)
@@ -215,23 +213,25 @@ async function initializeServices() {
         serverState.statusMessage = 'Checking database version...';
         await initializeDatabase();
       } catch (error) {
-        console.error('⚠️  Failed to download database from blob storage:', error);
-        console.log('   Will attempt to use existing local database...');
-        
+        console.error(statusLine('warn', 'Failed to download database from blob storage:'), error);
+        log.detail('will attempt to use existing local database' + glyph.ellipsis);
+
         // If download failed, check if local database exists and is valid
         try {
           await fs.access(DB_PATH);
-          console.log('   ℹ️  Local database file exists, will attempt to use it');
+          log.detail('local database file exists, will attempt to use it');
         } catch {
-          console.log('   ⚠️  No local database available - server will start with empty index');
+          log.warn('No local database available — server will start with empty index');
         }
       }
     }
 
-    // Initialize symbol index and parser
-    console.log(`📚 Loading metadata from: ${DB_PATH}`);
-    console.log(`📚 Labels database: ${LABELS_DB_PATH}`);
+    // Initialize symbol index and parser (DB path is shown in the startup header).
+    // The open + count is synchronous and can block for a while on a large DB,
+    // so announce it first — otherwise the output looks frozen during the load.
+    log.step('Loading symbols' + glyph.ellipsis);
     serverState.statusMessage = 'Loading metadata database...';
+    const dbLoadStart = Date.now();
 
     // Yield event loop so any pending MCP protocol messages (initialize exchange,
     // roots/list, first tool call) can be queued before new Database() blocks.
@@ -246,88 +246,79 @@ async function initializeServices() {
       symbolIndex = new XppSymbolIndex(DB_PATH, LABELS_DB_PATH);
       symbolCount = symbolIndex.getSymbolCount();
     } catch (error: any) {
-      console.error('❌ Failed to open database:', error);
-      
+      console.error(statusLine('err', 'Failed to open database:'), error);
+
       // If database is corrupted, delete it and create new empty one
       if (error.code === 'SQLITE_CORRUPT' || error.message?.includes('malformed')) {
-        console.log('   🧹 Database is corrupted, removing and creating fresh database...');
+        log.warn('Database is corrupted — removing and creating a fresh one' + glyph.ellipsis);
         try {
           await fs.unlink(DB_PATH);
-          console.log('   ✅ Corrupted database removed');
+          log.detail('corrupted database removed');
         } catch (unlinkError) {
-          console.error('   ⚠️  Failed to remove corrupted database:', unlinkError);
+          console.error(statusLine('warn', 'Failed to remove corrupted database:'), unlinkError);
         }
-        
+
         // Try again with fresh database
         symbolIndex = new XppSymbolIndex(DB_PATH, LABELS_DB_PATH);
         symbolCount = symbolIndex.getSymbolCount();
-        console.log('   ⚠️  Symbol index is now empty. To restore, run:');
-        console.log('       npm run index-metadata');
+        log.warn('Symbol index is now empty. To restore, run: npm run index-metadata');
       } else {
         throw error;
       }
     }
-    
+
     const parser = new XppMetadataParser();
-    
+
     // Check if database needs indexing
     if (symbolCount === 0) {
-      console.log('⚠️  No symbols found in database. Run indexing first:');
-      console.log('   npm run index-metadata');
-      console.log('   or set METADATA_PATH and the server will index on startup');
-      
+      log.warn('No symbols found in database — run `npm run index-metadata` first');
+      log.detail('or set METADATA_PATH and the server will index on startup');
+
       // If metadata path exists, index it
       try {
         await fs.access(METADATA_PATH);
-        console.log(`📖 Indexing metadata from: ${METADATA_PATH}`);
+        log.step(`Indexing metadata from ${METADATA_PATH}` + glyph.ellipsis);
         serverState.statusMessage = 'Indexing metadata...';
         const modelNamesStr = process.env.CUSTOM_MODELS || 'CustomModel';
         const modelNames = modelNamesStr.split(',').map(m => m.trim()).filter(Boolean);
-        console.log(`📦 Using model names: ${modelNames.join(', ')}`);
-        
+        log.detail(`model names: ${modelNames.join(', ')}`);
+
         for (const modelName of modelNames) {
-          console.log(`   Indexing ${modelName}...`);
+          log.detail(`indexing ${modelName}` + glyph.ellipsis);
           await symbolIndex.indexMetadataDirectory(METADATA_PATH, modelName);
         }
-        
-        console.log(`✅ Indexed ${symbolIndex.getSymbolCount()} symbols from ${modelNames.length} model(s)`);
-      } catch (error) {
-        console.log('⚠️  Metadata path not accessible, starting with empty index');
+
+        log.ok(`Indexed ${symbolIndex.getSymbolCount().toLocaleString('en-US')} symbols from ${modelNames.length} model(s)`);
+      } catch {
+        log.warn('Metadata path not accessible — starting with empty index');
       }
     } else {
-      console.log(`✅ Loaded ${symbolCount} symbols from database`);
-      const breakdown = symbolIndex.getSymbolCountByType();
-      console.log('   📊 Symbol types: ' + 
-        `${breakdown.class || 0} classes, ` +
-        `${breakdown.table || 0} tables, ` +
-        `${breakdown.form || 0} forms, ` +
-        `${breakdown.query || 0} queries, ` +
-        `${breakdown.view || 0} views`);
+      const b = symbolIndex.getSymbolCountByType();
+      const n = (x: number) => (x || 0).toLocaleString('en-US');
+      log.ok(`Loaded ${symbolCount.toLocaleString('en-US')} symbols in ${((Date.now() - dbLoadStart) / 1000).toFixed(1)}s`);
+      log.detail(`${n(b.class)} classes ${glyph.dot} ${n(b.table)} tables ${glyph.dot} ${n(b.form)} forms ${glyph.dot} ${n(b.query)} queries ${glyph.dot} ${n(b.view)} views`);
     }
 
     serverState.symbolIndex = symbolIndex;
     serverState.parser = parser;
 
     // Initialize workspace scanner and hybrid search
-    console.log('🔍 Initializing workspace scanner...');
     const workspaceScanner = new WorkspaceScanner();
     const hybridSearch = new HybridSearch(symbolIndex, workspaceScanner);
-    console.log('✅ Workspace-aware search enabled');
 
     // Create MCP server with full context
     serverState.statusMessage = 'Initializing MCP server...';
-    const context: import('./types/context.js').XppServerContext = { 
-      symbolIndex, 
-      parser, 
-      workspaceScanner, 
+    const context: import('./types/context.js').XppServerContext = {
+      symbolIndex,
+      parser,
+      workspaceScanner,
       hybridSearch,
     };
     const mcpServer = createXppMcpServer(context);
-    console.log('✅ MCP Server initialized with workspace support');
 
     return { mcpServer, symbolIndex, parser, workspaceScanner, hybridSearch, context };
   } catch (error) {
-    console.error('❌ Initialization error:', error);
+    console.error(statusLine('err', 'Initialization error:'), error);
     serverState.statusMessage = `Initialization failed: ${error}`;
     throw error;
   }
@@ -338,7 +329,13 @@ async function initializeServices() {
  * Shared by stdio and HTTP startup paths.
  * Attaches bridge to the given context object on success.
  */
-async function initializeBridge(targetContext: import('./types/context.js').XppServerContext): Promise<void> {
+interface BridgeStatus {
+  ok: boolean;
+  summary: string;
+  detail?: string;
+}
+
+async function initializeBridge(targetContext: import('./types/context.js').XppServerContext): Promise<BridgeStatus> {
   try {
     const { createBridgeClient } = await import('./bridge/bridgeClient.js');
     const configMgr = getConfigManager();
@@ -400,8 +397,6 @@ async function initializeBridge(targetContext: import('./types/context.js').XppS
     const xrefServer = await configMgr.getXrefDbServer() ?? undefined;
     const xrefDatabase = await configMgr.getXrefDbName() ?? undefined;
 
-    console.log(`[Bridge] Attempting connection: packagesPath=${packagesPath ?? 'not set'}, referencePackagesPath=${referencePackagesPath ?? 'none'}, binPath=${binPath ?? 'auto'}, devEnvType=${devEnvType}`);
-
     const bridge = await createBridgeClient({
       packagesPath,
       referencePackagesPath,
@@ -412,18 +407,16 @@ async function initializeBridge(targetContext: import('./types/context.js').XppS
     });
     if (bridge) {
       targetContext.bridge = bridge;
-      console.log(`✅ C# bridge connected (${devEnvType}): metadata=${bridge.metadataAvailable}, xref=${bridge.xrefAvailable}`);
-    } else {
-      console.log(
-        `⚠️  C# bridge not available — createBridgeClient returned null.\n` +
-        `   packagesPath: ${packagesPath ?? '(not detected — check .mcp.json context.packagePath or PackagesLocalDirectory)'}\n` +
-        `   devEnvType: ${devEnvType}\n` +
-        `   Check stderr / bridge log for details. Ensure the bridge exe is built:\n` +
-        `     cd bridge/D365MetadataBridge && dotnet build -c Release`
-      );
+      const cap = `metadata ${bridge.metadataAvailable ? 'yes' : 'no'} ${glyph.dot} xref ${bridge.xrefAvailable ? 'yes' : 'no'}`;
+      return { ok: true, summary: `C# bridge connected (${devEnvType}) ${glyph.dot} ${cap}` };
     }
+    return {
+      ok: false,
+      summary: `C# bridge unavailable (${devEnvType}) — live metadata off, using the symbol index`,
+      detail: `packages: ${packagesPath ?? '(not detected — check .mcp.json context.packagePath or PackagesLocalDirectory)'}`,
+    };
   } catch (err) {
-    console.log(`ℹ️  C# bridge not available: ${err}`);
+    return { ok: false, summary: `C# bridge unavailable: ${err}` };
   }
 }
 
@@ -481,13 +474,27 @@ async function main() {
     console.info = stderrWrite;
     console.warn = (...args: any[]) => process.stderr.write('[WARN] ' + args.join(' ') + '\n');
   } else {
-    // HTTP mode (Azure App Service): redirect console.warn to stdout so Azure
-    // Log Stream shows red ONLY for console.error (real errors), not warnings.
+    // HTTP mode (e.g. `npm run dev` in PowerShell, or Azure App Service).
+    // Sanitise at the stream level so the classic Windows console (cp852) shows
+    // clean ASCII glyphs instead of mojibake, while modern terminals (Windows
+    // Terminal, VS Code) keep the emoji. Wrapping process.stdout/stderr.write —
+    // rather than the console.* methods — keeps the error-detection filter above
+    // working on the original (emoji-bearing) text, and catches direct
+    // process.stderr.write calls too. No-op when Unicode is supported.
+    // Safe in HTTP mode: the MCP protocol travels over HTTP sockets, not stdout.
+    if (!supportsUnicode) {
+      const wrapWrite = (stream: NodeJS.WriteStream) => {
+        const orig = stream.write.bind(stream) as (...a: any[]) => boolean;
+        (stream as any).write = (chunk: any, ...rest: any[]): boolean =>
+          typeof chunk === 'string' ? orig(sanitize(chunk), ...rest) : orig(chunk, ...rest);
+      };
+      wrapWrite(process.stdout);
+      wrapWrite(process.stderr);
+    }
+    // Redirect console.warn to stdout so Azure Log Stream shows red ONLY for
+    // console.error (real errors), not warnings.
     console.warn = (...args: any[]) => process.stdout.write('[WARN] ' + args.join(' ') + '\n');
   }
-
-  console.log(`📡 Mode: ${isStdioMode ? 'STDIO' : 'HTTP'}`);
-  console.log(`🔧 Server mode: ${SERVER_MODE}`);
 
   if (isStdioMode) {
     // Pre-seed workspace so auto-detection starts before the first tool call.
@@ -557,7 +564,7 @@ async function main() {
       process.stdout,
     );
     await mcpServer.connect(transport);
-    console.log('✅ Stdio transport connected (DB loading in background)');
+    log.ok('Stdio transport connected (DB loading in background)');
 
     // Step 3: yield the event loop so `initialized` + roots/list can be processed
     // BEFORE the synchronous new Database() call blocks the event loop.
@@ -566,7 +573,7 @@ async function main() {
     // Step 3b: Initialize C# bridge in parallel with DB load (non-blocking)
     // The bridge provides live metadata from Microsoft's IMetadataProvider API
     // and cross-reference queries — only available on Windows VMs with D365FO.
-    void initializeBridge(stubContext);
+    void initializeBridge(stubContext).then(s => (s.ok ? log.ok(s.summary) : log.warn(s.summary)));
 
     // Step 4: load real database in the background
     const dbLoadStart = Date.now();
@@ -581,13 +588,13 @@ async function main() {
       serverState.statusMessage = 'Ready';
       // Resolve dbReady AFTER context is patched — tools can now run with real index.
       resolveDbReady();
-      console.log(`✅ Database loaded in ${Date.now() - dbLoadStart} ms — all tools fully operational`);
+      log.ok(`Database loaded in ${Date.now() - dbLoadStart} ms — all tools fully operational`);
 
       // The in-memory stub symbol index is also unreachable once swapped.
       try { stubIndex.close(); } catch { /* ignore */ }
     }).catch(err => {
       rejectDbReady(err);
-      console.error('❌ Background initialization failed:', err);
+      console.error(statusLine('err', 'Background initialization failed:'), err);
     });
 
     // Log tool count immediately (transport is already connected)
@@ -598,7 +605,7 @@ async function main() {
     const toolDesc = SERVER_MODE === 'write-only' ? `(${Array.from(LOCAL_TOOLS).join(', ')})` :
                     SERVER_MODE === 'read-only' ? '(all except local tools)' :
                     '(2 discovery + 1 labels + 3 object-info + 2 intelligent + 2 smart-gen + 1 file-ops + 1 pattern-analysis + 5 security-ext + 5 sdlc-build + 2 code-review + 2 code-quality)';
-    console.log(`🎯 Registered ${toolCount} X++ MCP tools ${toolDesc}`);
+    log.ok(`Registered ${toolCount} X++ MCP tools ${toolDesc}`);
     serverState.isReady = true;
     serverState.isHealthy = true;
     serverState.statusMessage = 'Loading database...';
@@ -607,7 +614,25 @@ async function main() {
     // the process during the (potentially long) database initialisation phase.
     // The health endpoint returns 503 while the server is starting and 200 once
     // fully ready.  MCP routes are registered dynamically after initializeServices().
-    console.log('📡 Using HTTP transport for standalone server');
+    // Branded banner first — connection details are known immediately, before
+    // the (potentially long) database load. Symbol counts are intentionally NOT
+    // shown here; they appear once during the load (`✓ Loaded … symbols`).
+    const host = process.env.HOST || '0.0.0.0';
+    const W = 50;
+    console.log('');
+    for (const line of box([
+      spread(c.bold('D365 F&O MCP Server'), c.dim('v1.0.0'), W),
+      c.gray('X++ Code Intelligence'),
+    ], W)) {
+      console.log(line);
+    }
+    console.log('');
+    console.log(kv('Mode', `HTTP ${c.dim(glyph.dot)} ${SERVER_MODE}`));
+    console.log(kv('Endpoint', c.cyan(`http://${host}:${PORT}/mcp`)));
+    console.log(kv('Health', c.cyan(`http://localhost:${PORT}/health`)));
+    console.log(kv('Runtime', `Node ${process.version} ${c.dim(glyph.dot)} pid ${process.pid}`));
+    console.log(kv('Database', c.dim(shortPath(DB_PATH))));
+    console.log('');
 
     // Create Express app
     const app = express();
@@ -658,30 +683,33 @@ async function main() {
     });
 
     // Bind port immediately — Azure requires the port to be open within ~230 s
-    const host = process.env.HOST || '0.0.0.0';
-    await new Promise<void>(resolve => app.listen(PORT, host, () => {
-      console.log(`🔌 HTTP server bound to ${host}:${PORT} — waiting for initialisation...`);
-      resolve();
-    }));
+    await new Promise<void>(resolve => app.listen(PORT, host, () => resolve()));
 
     // Initialise services in the background; register MCP routes once ready
-    initializeServices().then(({ mcpServer, symbolIndex, parser, workspaceScanner, hybridSearch, context }) => {
+    initializeServices().then(async ({ mcpServer, symbolIndex, parser, workspaceScanner, hybridSearch, context }) => {
       // Register MCP transport (Express supports dynamic route registration)
       createStreamableHttpTransport(mcpServer, app, { symbolIndex, parser, workspaceScanner, hybridSearch });
-
-      // Initialize C# bridge (non-blocking) — also needed for HTTP mode on Windows/UDE
-      if (context) void initializeBridge(context);
 
       serverState.isReady = true;
       serverState.isHealthy = true;
       serverState.statusMessage = 'Ready';
 
       console.log('');
-      console.log('✅ Server is READY!');
-      console.log(`✅ D365 F&O MCP Server listening on ${host}:${PORT}`);
-      console.log(`📡 MCP endpoint: http://${host}:${PORT}/mcp`);
-      console.log(`🏥 Health check: http://localhost:${PORT}/health`);
-      console.log(`🔧 Server mode: ${SERVER_MODE}`);
+      console.log(statusLine('ok', c.green(`Ready in ${process.uptime().toFixed(1)}s`)));
+
+      // C# bridge — await its connection (bounded) so its status prints here, in
+      // order, instead of trailing after the tool list. A slow/hung bridge must
+      // never block startup, so cap the wait; it keeps connecting in the
+      // background afterwards and attaches to the context once ready.
+      if (context) {
+        const status = await Promise.race<BridgeStatus>([
+          initializeBridge(context),
+          new Promise<BridgeStatus>(r => setTimeout(
+            () => r({ ok: true, summary: 'C# bridge still connecting in the background' + glyph.ellipsis }), 6000)),
+        ]);
+        if (status.ok) log.ok(status.summary); else log.warn(status.summary);
+        if (status.detail) log.detail(status.detail);
+      }
       console.log('');
 
       const toolCatalog = [
@@ -729,7 +757,7 @@ async function main() {
           { name: 'review_workspace_changes',     desc: 'AI-based D365FO code review on uncommitted X++ changes (git diff)' },
           { name: 'undo_last_modification',       desc: 'Safely revert last file change: checkout HEAD or delete untracked file' },
         ]},
-        { icon: '✅', category: 'Code Quality & Grounding', tools: [
+        { icon: '🧪', category: 'Code Quality & Grounding', tools: [
           { name: 'validate_code',                     desc: 'mode=syntax (offline BP validator, SEL/COC/BP/TTS/XML) | references (semantic symbol resolver vs index)' },
           { name: 'prepare',                      desc: 'Single-call context aggregator + grounding token: mode=change|create' },
         ]},
@@ -748,16 +776,31 @@ async function main() {
 
       const totalTools = filteredCatalog.reduce((sum, cat) => sum + cat.tools.length, 0);
 
-      console.log(`🎯 Available tools (${totalTools} total):`);
+      // Align tool names into a column (cap so long names don't push descriptions off-screen).
+      const nameW = Math.min(
+        26,
+        Math.max(...filteredCatalog.flatMap(cat => cat.tools.map(t => t.name.length))) + 2,
+      );
+
+      console.log(sectionTitle(`Tools (${totalTools})`));
+      console.log('');
       for (const cat of filteredCatalog) {
-        console.log(`   ${cat.icon} ${cat.category} (${cat.tools.length}):`);
+        console.log(`  ${cat.icon} ${c.bold(c.cyan(cat.category))} ${c.dim(`(${cat.tools.length})`)}`);
         for (const t of cat.tools) {
-          console.log(`   - ${t.name.padEnd(28)} ${t.desc}`);
+          console.log(`    ${t.name.padEnd(nameW)}${c.dim(t.desc)}`);
         }
         console.log('');
       }
+
+      // End-of-startup recap — surfaces any warnings the long tool list scrolled
+      // past, so the operator sees them without scrolling back up.
+      if (startupWarnings.length > 0) {
+        console.log(statusLine('warn', c.yellow(`${startupWarnings.length} warning${startupWarnings.length > 1 ? 's' : ''} during startup:`)));
+        for (const w of startupWarnings) log.detail(w);
+        console.log('');
+      }
     }).catch((err) => {
-      console.error('❌ Initialisation failed:', err);
+      console.error(statusLine('err', 'Initialisation failed:'), err);
       serverState.isHealthy = false;
       serverState.statusMessage = `Initialisation failed: ${err}`;
     });
@@ -765,6 +808,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error('❌ Fatal error:', error);
+  console.error(statusLine('err', 'Fatal error:'), error);
   process.exit(1);
 });

--- a/src/utils/terminalUi.ts
+++ b/src/utils/terminalUi.ts
@@ -1,0 +1,215 @@
+/**
+ * terminalUi — capability-aware console formatting for the dev/HTTP startup banner.
+ *
+ * Two Windows-specific problems this solves:
+ *   1. Mojibake icons. Node writes UTF-8 bytes to stdout; the classic Windows
+ *      PowerShell 5.1 / conhost window interprets them in the OEM code page
+ *      (cp852 on Czech locale), so emoji render as garbage. We detect terminals
+ *      that genuinely render Unicode (Windows Terminal, VS Code, ConEmu, *nix)
+ *      and fall back to ASCII glyphs everywhere else.
+ *   2. Colour noise. ANSI is honoured on Win10+ TTYs but must be disabled for
+ *      pipes, NO_COLOR, and dumb terminals.
+ *
+ * Everything degrades gracefully: on a legacy terminal you still get clean,
+ * aligned, readable output — just with [OK]/[!]/-> instead of ✓/⚠/›.
+ */
+
+import { relative, isAbsolute, sep } from 'path';
+
+const isWin = process.platform === 'win32';
+
+/**
+ * Whether the terminal reliably renders Unicode (box-drawing + emoji).
+ * On Windows only modern hosts qualify; the default PowerShell/conhost window
+ * does not, so we stay on ASCII there. Honour FORCE_UNICODE=1/0 as an override.
+ */
+export const supportsUnicode: boolean = (() => {
+  if (process.env.FORCE_UNICODE === '1') return true;
+  if (process.env.FORCE_UNICODE === '0') return false;
+  if (!isWin) return process.env.TERM !== 'linux';
+  return (
+    Boolean(process.env.WT_SESSION) ||              // Windows Terminal
+    process.env.TERM_PROGRAM === 'vscode' ||        // VS Code integrated terminal
+    Boolean(process.env.ConEmuTask) ||              // ConEmu / Cmder
+    process.env.TERM === 'xterm-256color' ||        // explicit xterm
+    process.env.WSLENV !== undefined                // WSL interop
+  );
+})();
+
+/**
+ * Whether to emit ANSI colour codes. Disabled for non-TTY (pipes/redirects),
+ * NO_COLOR, and dumb terminals; FORCE_COLOR=1 forces it on.
+ */
+export const supportsColor: boolean = (() => {
+  if (process.env.FORCE_COLOR && process.env.FORCE_COLOR !== '0') return true;
+  if ('NO_COLOR' in process.env) return false;
+  if (process.env.TERM === 'dumb') return false;
+  return Boolean(process.stdout.isTTY);
+})();
+
+// ─── Colour helpers ──────────────────────────────────────────────────────────
+const wrap = (open: number, close: number) => (s: string): string =>
+  supportsColor ? `\x1b[${open}m${s}\x1b[${close}m` : s;
+
+export const c = {
+  bold: wrap(1, 22),
+  dim: wrap(2, 22),
+  red: wrap(31, 39),
+  green: wrap(32, 39),
+  yellow: wrap(33, 39),
+  blue: wrap(34, 39),
+  magenta: wrap(35, 39),
+  cyan: wrap(36, 39),
+  gray: wrap(90, 39),
+};
+
+// ─── Glyphs (Unicode with ASCII fallback) ────────────────────────────────────
+const U = supportsUnicode;
+export const glyph = {
+  tl: U ? '╭' : '+',
+  tr: U ? '╮' : '+',
+  bl: U ? '╰' : '+',
+  br: U ? '╯' : '+',
+  h: U ? '─' : '-',
+  v: U ? '│' : '|',
+  dot: U ? '·' : '-',
+  ok: U ? '✓' : 'OK',
+  warn: U ? '▲' : '!',
+  err: U ? '✗' : 'x',
+  info: U ? 'ℹ' : 'i',
+  arrow: U ? '›' : '>',
+  bullet: U ? '•' : '*',
+  ellipsis: U ? '…' : '...',
+};
+
+// ─── Emoji → ASCII sanitiser ─────────────────────────────────────────────────
+// Maps the semantic emoji used in startup logs to short ASCII tags, then strips
+// any remaining decorative emoji + variation selectors. No-op when Unicode is
+// supported, so modern terminals keep the emoji.
+// Semantic emoji → short ASCII tag. The trailing space (if any) is preserved so
+// "✅ Loaded" becomes "[OK] Loaded".
+const EMOJI_TAGS: Array<[RegExp, string]> = [
+  [/✅|✔️?/g, '[OK]'],
+  [/❌/g, '[X]'],
+  [/⚠️?/g, '[!]'],
+  [/ℹ️?/g, '[i]'],
+  [/⏭️?/g, '[skip]'],
+];
+// Decorative emoji / pictographs (+ variation selector & ZWJ) together with the
+// spaces that immediately follow them — so stripping "🚀 Starting" yields
+// "Starting" and "  🔍 Search" yields "  Search", preserving real indentation.
+const EMOJI_STRIP = /(?:[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0F}\u{200D}\u{2190}-\u{21FF}\u{2300}-\u{23FF}])+ */gu;
+
+// "Fancy" punctuation that also mojibakes on legacy code pages (cp852/cp1250).
+// These appear throughout existing log strings (em-dashes, middots, ellipses…),
+// so transliterate them to plain ASCII rather than leave garbage bytes.
+const PUNCT_MAP: Array<[RegExp, string]> = [
+  [/[—–‒―]/g, '-'],   // — – ‒ ― dashes
+  [/…/g, '...'],                      // … ellipsis
+  [/[·•]/g, '-'],                // · • separators/bullets
+  [/[‘’‛]/g, "'"],          // ' ' curly single quotes
+  [/[“”‟]/g, '"'],          // " " curly double quotes
+  [/[‹›]/g, '>'],                // ‹ › angle quotes
+  [/→/g, '->'],                        // → arrow
+  [/×/g, 'x'],                         // × multiplication sign
+  [/ /g, ' '],                         // non-breaking space
+];
+
+/** Replace/strip emoji & fancy punctuation so legacy code pages don't show mojibake. No-op on Unicode terminals. */
+export function sanitize(text: string): string {
+  if (supportsUnicode) return text;
+  let out = text;
+  for (const [re, tag] of EMOJI_TAGS) out = out.replace(re, tag);
+  out = out.replace(EMOJI_STRIP, '');
+  for (const [re, rep] of PUNCT_MAP) out = out.replace(re, rep);
+  return out;
+}
+
+// ─── Layout helpers ──────────────────────────────────────────────────────────
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+/** Visible length of a string, ignoring ANSI colour codes. */
+export function visibleLen(s: string): number {
+  return s.replace(ANSI_RE, '').length;
+}
+
+/** Pad `s` (accounting for ANSI codes) with spaces to `width` on the right. */
+function padEndVisible(s: string, width: number): string {
+  const pad = width - visibleLen(s);
+  return pad > 0 ? s + ' '.repeat(pad) : s;
+}
+
+/**
+ * Draw a rounded box around the given rows. Each row is a pre-styled string;
+ * width is derived from the widest visible row (min `minWidth`), capped sensibly.
+ */
+export function box(rows: string[], minWidth = 48): string[] {
+  const inner = Math.max(minWidth, ...rows.map(visibleLen));
+  const top = c.gray(glyph.tl + glyph.h.repeat(inner + 2) + glyph.tr);
+  const bottom = c.gray(glyph.bl + glyph.h.repeat(inner + 2) + glyph.br);
+  const body = rows.map(
+    (r) => c.gray(glyph.v) + ' ' + padEndVisible(r, inner) + ' ' + c.gray(glyph.v),
+  );
+  return [top, ...body, bottom];
+}
+
+/** Build a left/right justified line of total visible `width`. */
+export function spread(left: string, right: string, width: number): string {
+  const gap = Math.max(1, width - visibleLen(left) - visibleLen(right));
+  return left + ' '.repeat(gap) + right;
+}
+
+/** A `label  value` row with the label dimmed and padded to `labelWidth`. */
+export function kv(label: string, value: string, labelWidth = 9): string {
+  return '  ' + c.dim(padEndVisible(label, labelWidth)) + value;
+}
+
+/** A section header (uppercased, accented). */
+export function sectionTitle(title: string): string {
+  return '  ' + c.bold(c.cyan(title.toUpperCase()));
+}
+
+/** A status line such as "✓ Ready in 3.2s". `kind` picks the glyph + colour. */
+export function statusLine(kind: 'step' | 'ok' | 'warn' | 'err' | 'info', msg: string): string {
+  const map = {
+    step: [glyph.arrow, c.cyan] as const,
+    ok: [glyph.ok, c.green] as const,
+    warn: [glyph.warn, c.yellow] as const,
+    err: [glyph.err, c.red] as const,
+    info: [glyph.info, c.gray] as const,
+  };
+  const [g, paint] = map[kind];
+  return '  ' + paint(g) + ' ' + msg;
+}
+
+/**
+ * Warnings emitted during startup are collected here so a compact summary can be
+ * printed at the end (so an individual warning doesn't get lost in the scroll).
+ */
+export const startupWarnings: string[] = [];
+
+/**
+ * Convenience status loggers for the startup sequence. They resolve console.*
+ * lazily at call time, so the stdio/HTTP overrides installed in main() apply.
+ *  - step/ok/info → stdout (operational; suppressed in stdio mode)
+ *  - warn/err     → stderr (kept visible to MCP clients in stdio mode)
+ *  - detail       → dimmed, indented sub-line under the preceding status
+ * warn also records the message in startupWarnings for the end-of-startup recap.
+ */
+export const log = {
+  step: (msg: string): void => console.log(statusLine('step', msg)),
+  ok: (msg: string): void => console.log(statusLine('ok', msg)),
+  info: (msg: string): void => console.log(statusLine('info', msg)),
+  warn: (msg: string): void => { startupWarnings.push(msg); console.error(statusLine('warn', msg)); },
+  err: (msg: string): void => console.error(statusLine('err', msg)),
+  detail: (msg: string): void => console.log('      ' + c.dim(msg)),
+};
+
+/**
+ * Render a path relative to `cwd` (prefixed with "./") when it lives under it,
+ * otherwise return the absolute path unchanged. Keeps long startup paths short.
+ */
+export function shortPath(p: string, cwd = process.cwd()): string {
+  const rel = relative(cwd, p);
+  return rel && !rel.startsWith('..') && !isAbsolute(rel) ? '.' + sep + rel : p;
+}


### PR DESCRIPTION
## Why

Customers running `npm run dev` in PowerShell saw a noisy startup log with **mojibake icons** — Node writes UTF-8 bytes to stdout, but the classic Windows PowerShell 5.1 / conhost window interprets them in the OEM code page (cp852 on Czech locale), so emoji rendered as garbage. The output was also verbose and redundant.

## What

A clean, branded, **capability-aware** startup experience that degrades gracefully on legacy terminals.

### New `src/utils/terminalUi.ts`
- Detects **Unicode** support (Windows Terminal / VS Code / ConEmu / WSL / *nix → emoji + box-drawing; classic conhost → ASCII) and **colour** support (TTY, honours `NO_COLOR` / `FORCE_COLOR`). Overridable via `FORCE_UNICODE`.
- Falls back to ASCII glyphs (`[OK]` / `!` / `->` instead of `✓` / `▲` / `›`) and transliterates fancy punctuation (`—` `·` `…`) so cp852 never shows garbage.
- Sanitising happens at the `process.stdout/stderr.write` level, so the existing error-detection filter still sees the original (emoji-bearing) text, and the MCP stdio protocol is untouched (HTTP mode talks over sockets, not stdout).
- Helpers: `box`, `kv`, `sectionTitle`, `statusLine`, `spread`, `shortPath`, and `log.*` status loggers.

### Reworked startup output (HTTP / dev mode)
- **Banner-first**: branded box + `Mode` / `Endpoint` / `Health` / `Runtime` / `Database` header printed immediately (values known at start), then concise progress steps, then `Ready`.
- Single-line config resolution (no "loading… → not found" two-liner; absent `.mcp.json` reframed as a neutral `ℹ Configuration from environment variables`).
- Symbol DB path moved into the header, **shortened** relative to cwd (`.\data\xpp-metadata.db`).
- Removed redundant / internal-only step lines.
- **Load duration** on the symbol-load line (`✓ Loaded 1,158,319 symbols in 0.4s`).
- **C# bridge** status printed as one ordered line right after `Ready` (bounded 6 s wait so a slow/hung bridge never blocks startup; it keeps connecting in the background).
- **End-of-startup warning recap** so warnings aren't lost behind the long tool list.

### Example (Unicode terminal)
```
╭────────────────────────────────────────────────────╮
│ D365 F&O MCP Server                         v1.0.0 │
│ X++ Code Intelligence                              │
╰────────────────────────────────────────────────────╯

  Mode     HTTP · full
  Endpoint http://0.0.0.0:8080/mcp
  Health   http://localhost:8080/health
  Runtime  Node v24.13.0 · pid 4032
  Database .\data\xpp-metadata.db

  ℹ Configuration from environment variables
  › Loading symbols…
  ✓ Loaded 1,158,319 symbols in 0.4s
      58,503 classes · 18,150 tables · 9,232 forms · 4,898 queries · 8,745 views

  ✓ Ready in 3.5s
  ✓ C# bridge connected (traditional) · metadata yes · xref no

  TOOLS (26)
  …
```

On the classic PowerShell console the same renders in pure ASCII (`+--+` box, `[OK]`, `>`), no mojibake.

## Testing
- `tsc --noEmit` clean.
- Booted the server in HTTP mode and verified output in both Unicode (`FORCE_UNICODE=1`) and ASCII (`FORCE_UNICODE=0`) modes, plus an empty-DB scenario to confirm the warning recap renders.
- Stdio mode behaviour unchanged (operational logs still suppressed; warnings/errors still forwarded to MCP clients).

🤖 Generated with [Claude Code](https://claude.com/claude-code)