### PR TITLE
fix(extensions): add-control fallback for form-extensions + table-extension field create

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -47,8 +47,8 @@ namespace D365MetadataBridge.Services
         /// identity — the small ordinal Id AND the SequenceId. This matters because the
         /// model descriptor's &lt;Id&gt; element is actually the SequenceId (a large number);
         /// parsing it into ModelSaveInfo.Id while leaving SequenceId=0 makes
-        /// IMetadataProvider.Create() throw NullReferenceException. (Verified: fm-mcp manifest
-        /// Id=116 SequenceId=896000930 creates fine; descriptor-derived Id=896000930
+        /// IMetadataProvider.Create() throw NullReferenceException. (Verified: a custom model's
+        /// manifest Id=116 SequenceId=896000930 creates fine; descriptor-derived Id=896000930
         /// SequenceId=0 NREs.) The descriptor scan stays as a fallback for models the
         /// manifest does not enumerate (e.g. not yet built/registered).
         /// Caches results for repeated calls.

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -228,6 +228,36 @@ function fieldTypeToAxType(fieldType: string, edtName?: string): string {
 }
 
 /**
+ * Normalize the flexible field specs accepted by the tool / XML generators
+ * (`{ name, edt?, type?, fieldType?, enumType?, mandatory?, label? }`) into the
+ * key shape the C# bridge's WriteFieldParam expects
+ * (`{ name, fieldType, extendedDataType, enumType, mandatory, label }`).
+ *
+ * Without this, fields handed to the bridge as `{ edt, type }` silently lose their
+ * EDT and base type — the bridge sees FieldType="" and creates a bare String field
+ * with no ExtendedDataType. `fieldType` may arrive either as a base-type keyword
+ * ("Integer") or as a full i:type ("AxTableFieldInt"); the latter is stripped back
+ * to the keyword the bridge's CreateTableField switch understands.
+ */
+export function normalizeFieldSpecsForBridge(
+  fields: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  return fields.map((f) => {
+    let fieldType = f.type ?? f.fieldType;
+    if (typeof fieldType === 'string') fieldType = fieldType.replace(/^AxTableField/, '');
+    const out: Record<string, unknown> = { name: f.name };
+    if (fieldType != null && fieldType !== '') out.fieldType = fieldType;
+    if (f.edt != null) out.extendedDataType = f.edt;
+    else if (f.extendedDataType != null) out.extendedDataType = f.extendedDataType;
+    if (f.enumType != null) out.enumType = f.enumType;
+    if (f.mandatory != null) out.mandatory = f.mandatory;
+    if (f.label != null) out.label = f.label;
+    if (f.stringSize != null) out.stringSize = f.stringSize;
+    return out;
+  });
+}
+
+/**
  * XML Templates for different D365FO object types
  */
 export class XmlTemplateGenerator {
@@ -3915,10 +3945,14 @@ export async function handleCreateD365File(
           bridgeParams.methods = parsed.methods;
         }
 
-        // For tables: pass fields, fieldGroups, indexes, relations from properties
-        if (args.objectType === 'table' && args.properties) {
+        // For tables AND table-extensions: pass fields, fieldGroups, indexes, relations
+        // from properties. (Previously only 'table' was handled, so a table-extension's
+        // properties.fields were silently dropped and the file got an empty <Fields />.)
+        // Field specs are normalized to the bridge's WriteFieldParam key shape so that
+        // `{ edt, type }` keys are not lost — otherwise every field becomes a bare String.
+        if ((args.objectType === 'table' || args.objectType === 'table-extension') && args.properties) {
           const props = args.properties as Record<string, unknown>;
-          if (props.fields) bridgeParams.fields = props.fields as Record<string, unknown>[];
+          if (props.fields) bridgeParams.fields = normalizeFieldSpecsForBridge(props.fields as Record<string, unknown>[]);
           if (props.fieldGroups) bridgeParams.fieldGroups = props.fieldGroups as Record<string, unknown>[];
           if (props.indexes) bridgeParams.indexes = props.indexes as Record<string, unknown>[];
           if (props.relations) bridgeParams.relations = props.relations as Record<string, unknown>[];

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -347,29 +347,37 @@ async function directXmlAddMenuItemToMenu(
 }
 
 /**
- * controlType (as passed to add-control) → the AxForm*Control element emitted
- * inside a form-extension's <FormControlExtension> wrapper. Mirrors the bridge's
- * CreateFormControl type map and the field→control resolution in fieldControlTypes.
- * Unknown types fall back to a plain String control, which is always valid.
+ * controlType (as passed to add-control) → the form control element emitted inside
+ * a form-extension's <FormControl>, together with its <Type> value. Verified against
+ * shipped standard form extensions (e.g. InventItemSampling.AdvancedQualityManagement).
+ * NOTE: an integer control is `AxFormIntegerControl` (Type=Integer) — NOT
+ * `AxFormIntControl`. Unknown types fall back to String, which is always valid.
  */
-const CONTROL_TYPE_TO_ELEMENT: Record<string, string> = {
-  string: 'AxFormStringControl',
-  integer: 'AxFormIntControl',
-  int: 'AxFormIntControl',
-  int64: 'AxFormInt64Control',
-  real: 'AxFormRealControl',
-  date: 'AxFormDateControl',
-  datetime: 'AxFormDateTimeControl',
-  utcdatetime: 'AxFormDateTimeControl',
-  time: 'AxFormTimeControl',
-  guid: 'AxFormGuidControl',
-  checkbox: 'AxFormCheckBoxControl',
-  combobox: 'AxFormComboBoxControl',
-  button: 'AxFormButtonControl',
-  commandbutton: 'AxFormCommandButtonControl',
-  menufunctionbutton: 'AxFormMenuFunctionButtonControl',
-  group: 'AxFormGroupControl',
+const CONTROL_TYPE_TO_FORM_CONTROL: Record<string, { iType: string; typeValue: string }> = {
+  string:      { iType: 'AxFormStringControl',   typeValue: 'String' },
+  integer:     { iType: 'AxFormIntegerControl',  typeValue: 'Integer' },
+  int:         { iType: 'AxFormIntegerControl',  typeValue: 'Integer' },
+  int64:       { iType: 'AxFormInt64Control',    typeValue: 'Int64' },
+  real:        { iType: 'AxFormRealControl',     typeValue: 'Real' },
+  date:        { iType: 'AxFormDateControl',     typeValue: 'Date' },
+  datetime:    { iType: 'AxFormDateTimeControl', typeValue: 'DateTime' },
+  utcdatetime: { iType: 'AxFormDateTimeControl', typeValue: 'DateTime' },
+  time:        { iType: 'AxFormTimeControl',     typeValue: 'Time' },
+  guid:        { iType: 'AxFormGuidControl',     typeValue: 'Guid' },
+  checkbox:    { iType: 'AxFormCheckBoxControl', typeValue: 'CheckBox' },
+  combobox:    { iType: 'AxFormComboBoxControl', typeValue: 'ComboBox' },
+  button:      { iType: 'AxFormButtonControl',   typeValue: 'Button' },
+  group:       { iType: 'AxFormGroupControl',    typeValue: 'Group' },
 };
+const DEFAULT_FORM_CONTROL = { iType: 'AxFormStringControl', typeValue: 'String' };
+
+/** Random 9-char lowercase-alphanumeric suffix, matching the SDK's
+ *  `FormExtensionControl<rand>` wrapper-name convention (e.g. "fh5riowy1"). */
+function formExtensionControlName(): string {
+  let s = '';
+  while (s.length < 9) s += Math.random().toString(36).slice(2);
+  return `FormExtensionControl${s.slice(0, 9)}`;
+}
 
 /**
  * Direct XML fallback for add-control on a form-extension.
@@ -378,8 +386,10 @@ const CONTROL_TYPE_TO_ELEMENT: Record<string, string> = {
  * which can NEVER find a form EXTENSION (named "BaseForm.Suffix") — it always
  * reports 'Form "<ext>" not found'. add-control on a form-extension therefore has
  * no working bridge path at all (independent of metadata-root freshness). This
- * writes the AxFormControlExtension element straight into the extension's
- * <Controls> collection, matching the shape the D365FO SDK serializes. It edits
+ * writes an <AxFormExtensionControl> element straight into the extension's
+ * <Controls> collection, in the exact shape the D365FO SDK serializes (verified
+ * against shipped standard extensions): an empty-namespace <FormControl i:type="…">
+ * wrapped by <AxFormExtensionControl xmlns=""> with a <Parent> reference. It edits
  * the file on disk, so it is unaffected by what the bridge has loaded.
  */
 async function directXmlAddControl(
@@ -395,7 +405,7 @@ async function directXmlAddControl(
     const rawContent = await fs.readFile(filePath, 'utf-8');
     const content = rawContent.replace(/^﻿/, '').replace(/\r\n/g, '\n');
 
-    // Idempotency: a control extension with this Name already present → skip.
+    // Idempotency: a control with this Name already present → skip.
     // (controlName is a D365 identifier, so a literal substring match is safe.)
     if (content.includes(`<Name>${controlName}</Name>`)) {
       return {
@@ -404,26 +414,28 @@ async function directXmlAddControl(
       };
     }
 
-    const element = CONTROL_TYPE_TO_ELEMENT[(controlType || 'String').toLowerCase()] ?? 'AxFormStringControl';
-    const ns = 'Microsoft.Dynamics.AX.Metadata.V6';
+    const { iType, typeValue } = CONTROL_TYPE_TO_FORM_CONTROL[(controlType || 'String').toLowerCase()] ?? DEFAULT_FORM_CONTROL;
 
-    // Inner control properties, in the order shipped extensions serialize them:
-    // Name → DataField → DataSource → Label.
-    const inner = [`\t\t\t\t\t<d4p1:Name>${controlName}</d4p1:Name>`];
-    if (dataField) inner.push(`\t\t\t\t\t<d4p1:DataField>${dataField}</d4p1:DataField>`);
-    if (dataSource) inner.push(`\t\t\t\t\t<d4p1:DataSource>${dataSource}</d4p1:DataSource>`);
-    if (label) inner.push(`\t\t\t\t\t<d4p1:Label>${label}</d4p1:Label>`);
+    // Inner <FormControl> children, in the order shipped extensions serialize them:
+    // Name → Type → FormControlExtension(nil) → DataField → DataSource → Label → [Items].
+    const inner = [
+      `\t\t\t\t<Name>${controlName}</Name>`,
+      `\t\t\t\t<Type>${typeValue}</Type>`,
+      `\t\t\t\t<FormControlExtension i:nil="true" />`,
+    ];
+    if (dataField) inner.push(`\t\t\t\t<DataField>${dataField}</DataField>`);
+    if (dataSource) inner.push(`\t\t\t\t<DataSource>${dataSource}</DataSource>`);
+    if (label) inner.push(`\t\t\t\t<Label>${label}</Label>`);
+    if (typeValue === 'ComboBox') inner.push(`\t\t\t\t<Items />`);
 
     const newElement =
-      `\t\t<AxFormControlExtension>\n` +
-      `\t\t\t<Name>${controlName}</Name>\n` +
-      `\t\t\t<ParentControlName>${parentControl}</ParentControlName>\n` +
-      `\t\t\t<FormControlExtension>\n` +
-      `\t\t\t\t<${element} xmlns:d4p1="${ns}">\n` +
+      `\t\t<AxFormExtensionControl xmlns="">\n` +
+      `\t\t\t<Name>${formExtensionControlName()}</Name>\n` +
+      `\t\t\t<FormControl xmlns="" i:type="${iType}">\n` +
       inner.join('\n') + '\n' +
-      `\t\t\t\t</${element}>\n` +
-      `\t\t\t</FormControlExtension>\n` +
-      `\t\t</AxFormControlExtension>`;
+      `\t\t\t</FormControl>\n` +
+      `\t\t\t<Parent>${parentControl}</Parent>\n` +
+      `\t\t</AxFormExtensionControl>`;
 
     let updated: string;
     if (content.includes('<Controls />')) {
@@ -437,10 +449,10 @@ async function directXmlAddControl(
     if (updated === content) return null;
 
     await fs.writeFile(filePath, normalizeD365Xml(updated), 'utf-8');
-    console.error(`[modify_d365fo_file] ✅ directXmlAddControl: added '${controlName}' (${element}) to ${filePath}`);
+    console.error(`[modify_d365fo_file] ✅ directXmlAddControl: added '${controlName}' (${iType}) to ${filePath}`);
     return {
       success: true,
-      message: `✅ Control '${controlName}' (${element}) added to '${parentControl}' via direct XML fallback. File: ${filePath}`,
+      message: `✅ Control '${controlName}' (${iType}) added to '${parentControl}' via direct XML fallback. File: ${filePath}`,
     };
   } catch (err) {
     console.error(`[modify_d365fo_file] directXmlAddControl failed: ${err}`);

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -347,6 +347,108 @@ async function directXmlAddMenuItemToMenu(
 }
 
 /**
+ * controlType (as passed to add-control) → the AxForm*Control element emitted
+ * inside a form-extension's <FormControlExtension> wrapper. Mirrors the bridge's
+ * CreateFormControl type map and the field→control resolution in fieldControlTypes.
+ * Unknown types fall back to a plain String control, which is always valid.
+ */
+const CONTROL_TYPE_TO_ELEMENT: Record<string, string> = {
+  string: 'AxFormStringControl',
+  integer: 'AxFormIntControl',
+  int: 'AxFormIntControl',
+  int64: 'AxFormInt64Control',
+  real: 'AxFormRealControl',
+  date: 'AxFormDateControl',
+  datetime: 'AxFormDateTimeControl',
+  utcdatetime: 'AxFormDateTimeControl',
+  time: 'AxFormTimeControl',
+  guid: 'AxFormGuidControl',
+  checkbox: 'AxFormCheckBoxControl',
+  combobox: 'AxFormComboBoxControl',
+  button: 'AxFormButtonControl',
+  commandbutton: 'AxFormCommandButtonControl',
+  menufunctionbutton: 'AxFormMenuFunctionButtonControl',
+  group: 'AxFormGroupControl',
+};
+
+/**
+ * Direct XML fallback for add-control on a form-extension.
+ *
+ * The C# bridge's AddControl resolves its target via _provider.Forms.Read(name),
+ * which can NEVER find a form EXTENSION (named "BaseForm.Suffix") — it always
+ * reports 'Form "<ext>" not found'. add-control on a form-extension therefore has
+ * no working bridge path at all (independent of metadata-root freshness). This
+ * writes the AxFormControlExtension element straight into the extension's
+ * <Controls> collection, matching the shape the D365FO SDK serializes. It edits
+ * the file on disk, so it is unaffected by what the bridge has loaded.
+ */
+async function directXmlAddControl(
+  filePath: string,
+  controlName: string,
+  parentControl: string,
+  controlType: string,
+  dataSource?: string,
+  dataField?: string,
+  label?: string,
+): Promise<{ success: boolean; message: string } | null> {
+  try {
+    const rawContent = await fs.readFile(filePath, 'utf-8');
+    const content = rawContent.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+    // Idempotency: a control extension with this Name already present → skip.
+    // (controlName is a D365 identifier, so a literal substring match is safe.)
+    if (content.includes(`<Name>${controlName}</Name>`)) {
+      return {
+        success: true,
+        message: `✅ Control '${controlName}' already present in ${filePath} — skipped (idempotent).`,
+      };
+    }
+
+    const element = CONTROL_TYPE_TO_ELEMENT[(controlType || 'String').toLowerCase()] ?? 'AxFormStringControl';
+    const ns = 'Microsoft.Dynamics.AX.Metadata.V6';
+
+    // Inner control properties, in the order shipped extensions serialize them:
+    // Name → DataField → DataSource → Label.
+    const inner = [`\t\t\t\t\t<d4p1:Name>${controlName}</d4p1:Name>`];
+    if (dataField) inner.push(`\t\t\t\t\t<d4p1:DataField>${dataField}</d4p1:DataField>`);
+    if (dataSource) inner.push(`\t\t\t\t\t<d4p1:DataSource>${dataSource}</d4p1:DataSource>`);
+    if (label) inner.push(`\t\t\t\t\t<d4p1:Label>${label}</d4p1:Label>`);
+
+    const newElement =
+      `\t\t<AxFormControlExtension>\n` +
+      `\t\t\t<Name>${controlName}</Name>\n` +
+      `\t\t\t<ParentControlName>${parentControl}</ParentControlName>\n` +
+      `\t\t\t<FormControlExtension>\n` +
+      `\t\t\t\t<${element} xmlns:d4p1="${ns}">\n` +
+      inner.join('\n') + '\n' +
+      `\t\t\t\t</${element}>\n` +
+      `\t\t\t</FormControlExtension>\n` +
+      `\t\t</AxFormControlExtension>`;
+
+    let updated: string;
+    if (content.includes('<Controls />')) {
+      updated = content.replace('<Controls />', `<Controls>\n${newElement}\n\t</Controls>`);
+    } else if (content.includes('</Controls>')) {
+      updated = content.replace('</Controls>', `${newElement}\n\t</Controls>`);
+    } else {
+      return null; // no <Controls> collection — not a form-extension shape we recognise
+    }
+
+    if (updated === content) return null;
+
+    await fs.writeFile(filePath, normalizeD365Xml(updated), 'utf-8');
+    console.error(`[modify_d365fo_file] ✅ directXmlAddControl: added '${controlName}' (${element}) to ${filePath}`);
+    return {
+      success: true,
+      message: `✅ Control '${controlName}' (${element}) added to '${parentControl}' via direct XML fallback. File: ${filePath}`,
+    };
+  } catch (err) {
+    console.error(`[modify_d365fo_file] directXmlAddControl failed: ${err}`);
+    return null;
+  }
+}
+
+/**
  * Heuristic: does a bridge failure message indicate the C# provider could not
  * resolve the target object (vs. a genuine operation error like "index already
  * exists")? An unresolved object is the one failure worth a refresh+retry,
@@ -1443,6 +1545,22 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             (args as any).controlDataField,
             (args as any).controlLabel,
           );
+          // Fallback: the bridge's AddControl resolves its target via _provider.Forms,
+          // which can never find a form EXTENSION (named "Base.Suffix") — it always
+          // reports 'Form "<ext>" not found', regardless of metadata-root freshness.
+          // For form extensions, write the control element straight into the XML.
+          if (objectType === 'form-extension' && (!bridgeResult || !bridgeResult.success)) {
+            const xmlFallbackResult = await directXmlAddControl(
+              actualFilePath,
+              (args as any).controlName,
+              (args as any).parentControl,
+              (args as any).controlType ?? 'String',
+              (args as any).controlDataSource,
+              (args as any).controlDataField,
+              (args as any).controlLabel,
+            );
+            if (xmlFallbackResult) bridgeResult = xmlFallbackResult;
+          }
         }
         break;
       }

--- a/src/utils/fieldControlTypes.ts
+++ b/src/utils/fieldControlTypes.ts
@@ -30,7 +30,7 @@ export const DEFAULT_CONTROL: ControlTypeInfo = {
 const TABLE_FIELD_TO_CONTROL: Record<string, ControlTypeInfo> = {
   AxTableFieldString: { iType: 'AxFormStringControl', typeValue: 'String' },
   AxTableFieldMemo: { iType: 'AxFormStringControl', typeValue: 'String' },
-  AxTableFieldInt: { iType: 'AxFormIntControl', typeValue: 'Integer' },
+  AxTableFieldInt: { iType: 'AxFormIntegerControl', typeValue: 'Integer' },
   AxTableFieldInt64: { iType: 'AxFormInt64Control', typeValue: 'Int64' },
   AxTableFieldReal: { iType: 'AxFormRealControl', typeValue: 'Real' },
   AxTableFieldDate: { iType: 'AxFormDateControl', typeValue: 'Date' },

--- a/tests/tools/edt-resolution.test.ts
+++ b/tests/tools/edt-resolution.test.ts
@@ -199,10 +199,10 @@ describe('isEnumName (enum vs EDT detection)', () => {
   it('detects an indexed enum name', () => {
     // Regression for friction #2: an enum-backed field was created as
     // AxTableFieldString + EDT instead of AxTableFieldEnum.
-    expect(isEnumName('AslRentEquipmentStatus', enumDb(['AslRentEquipmentStatus']))).toBe(true);
+    expect(isEnumName('ContosoRentEquipmentStatus', enumDb(['ContosoRentEquipmentStatus']))).toBe(true);
   });
   it('returns false for a name that is not an indexed enum', () => {
-    expect(isEnumName('CustAccount', enumDb(['AslRentEquipmentStatus']))).toBe(false);
+    expect(isEnumName('CustAccount', enumDb(['ContosoRentEquipmentStatus']))).toBe(false);
   });
 });
 

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -352,7 +352,7 @@ describe('verify_d365fo_project', () => {
     const result = await verifyD365ProjectTool(
       req('verify_d365fo_project', {
         objects: [{ objectType: 'class', objectName: 'MyHelper' }],
-        modelName: 'MyModel',
+        modelName: 'Contoso',
         packageName: 'MyPackage',
         projectPath: 'K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj',
       }),
@@ -373,7 +373,7 @@ describe('verify_d365fo_project', () => {
     const result = await verifyD365ProjectTool(
       req('verify_d365fo_project', {
         objects: [{ objectType: 'class', objectName: 'MissingClass' }],
-        modelName: 'MyModel',
+        modelName: 'Contoso',
         packageName: 'MyPackage',
         projectPath: 'K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj',
       }),
@@ -403,7 +403,7 @@ describe('verify_d365fo_project', () => {
           { objectType: 'table', objectName: 'MyTable' },
           { objectType: 'enum', objectName: 'MyEnum' },
         ],
-        modelName: 'MyModel',
+        modelName: 'Contoso',
         packageName: 'MyPackage',
         projectPath: 'K:\\VSProjects\\MySolution\\MyProject\\MyProject.rnrproj',
       }),
@@ -451,8 +451,8 @@ describe('create_d365fo_file', () => {
       req('create_d365fo_file', {
         objectType: 'class',
         objectName: 'MyNewClass',
-        modelName: 'FmMcp',
-        packageName: 'FmMcp',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
         packagePath: 'K:\\PackagesLocalDirectory',
         addToProject: false,
       }),
@@ -467,14 +467,54 @@ describe('create_d365fo_file', () => {
       req('create_d365fo_file', {
         objectType: 'table-extension',
         objectName: 'CustTable.MY_Extension',
-        modelName: 'FmMcp',
-        packageName: 'FmMcp',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
         packagePath: 'K:\\PackagesLocalDirectory',
         addToProject: false,
       }),
     );
     // fs is fully mocked — writes succeed on all platforms.
     expect((result as any).isError).toBeFalsy();
+  });
+
+  it('table-extension create passes properties.fields to the bridge (normalized to WriteFieldParam keys)', async () => {
+    // Regression: the bridge create path only forwarded fields for objectType==='table',
+    // so a table-extension's properties.fields were dropped and the file got an empty
+    // <Fields />. Fields must be forwarded AND normalized ({ edt, type } → { extendedDataType, fieldType }).
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTableExtension\\CustTable.MyExt.xml',
+      api: 'IMetaTableExtensionProvider.Create',
+    }));
+    const ctx = buildContext();
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, createObject, validateObject: vi.fn(async () => null) };
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'table-extension',
+        objectName: 'CustTable.MyExt',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: {
+          fields: [
+            { name: 'LookAheadMonths', edt: 'BudgetNumberOfPeriods', type: 'Integer' },
+            { name: 'LookBackMonths', edt: 'BudgetNumberOfPeriods', type: 'Integer' },
+          ],
+        },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(createObject).toHaveBeenCalledTimes(1);
+    const sentParams = createObject.mock.calls[0][0];
+    expect(sentParams.objectType).toBe('table-extension');
+    expect(sentParams.fields).toEqual([
+      { name: 'LookAheadMonths', fieldType: 'Integer', extendedDataType: 'BudgetNumberOfPeriods' },
+      { name: 'LookBackMonths', fieldType: 'Integer', extendedDataType: 'BudgetNumberOfPeriods' },
+    ]);
   });
 
   it('auto-converts bare extension name to dot-notation (Case C fix)', async () => {
@@ -485,18 +525,18 @@ describe('create_d365fo_file', () => {
       req('create_d365fo_file', {
         objectType: 'table-extension',
         objectName: 'PurchTable',
-        modelName: 'FmMcp',
-        packageName: 'FmMcp',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
         packagePath: 'K:\\PackagesLocalDirectory',
         addToProject: false,
       }),
     );
     // fs is fully mocked — writes succeed on all platforms.
     // We inspect the path embedded in the message: it must use dot-notation
-    // (PurchTable.<something>Extension.xml) and NOT a flat prefix (FmMcpPurchTable.xml).
+    // (PurchTable.<something>Extension.xml) and NOT a flat prefix (MyModelPurchTable.xml).
     const text: string = result.content[0].text;
     expect(text).toMatch(/PurchTable[.][^/\\]*[Ee]xtension/);
-    expect(text).not.toMatch(/FmMcpPurchTable|[A-Za-z]+PurchTable\.xml/);
+    expect(text).not.toMatch(/MyModelPurchTable|[A-Za-z]+PurchTable\.xml/);
   });
 
   it('auto-converts bare class-extension name to _Extension form (Case D fix)', async () => {
@@ -512,8 +552,8 @@ describe('create_d365fo_file', () => {
       req('create_d365fo_file', {
         objectType: 'class-extension',
         objectName: 'SalesFormLetter',
-        modelName: 'FmMcp',
-        packageName: 'FmMcp',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
         packagePath: 'K:\\PackagesLocalDirectory',
         addToProject: false,
       }),
@@ -567,8 +607,8 @@ describe('create_d365fo_file', () => {
       req('create_d365fo_file', {
         objectType: 'class',
         objectName: 'MyHybridClass',
-        modelName: 'FmMcp',
-        packageName: 'FmMcp',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
         packagePath: 'K:\\PackagesLocalDirectory',
         xmlContent: xml,
         addToProject: false,
@@ -580,13 +620,13 @@ describe('create_d365fo_file', () => {
 
   it('returns error when objectType is missing', async () => {
     await expect(
-      handleCreateD365File(req('create_d365fo_file', { objectName: 'Foo', modelName: 'MyModel' })),
+      handleCreateD365File(req('create_d365fo_file', { objectName: 'Foo', modelName: 'Contoso' })),
     ).rejects.toThrow();
   });
 
   it('returns error when objectName is missing', async () => {
     await expect(
-      handleCreateD365File(req('create_d365fo_file', { objectType: 'class', modelName: 'MyModel' })),
+      handleCreateD365File(req('create_d365fo_file', { objectType: 'class', modelName: 'Contoso' })),
     ).rejects.toThrow();
   });
 });
@@ -935,7 +975,7 @@ describe('modify_d365fo_file', () => {
           operation: 'add-index',
           indexName: 'ContosoRentEquipmentIdx',
           indexFields: [{ fieldName: 'ContosoRentEquipmentId' }],
-          modelName: 'MyModel',
+          modelName: 'Contoso',
         }),
         ctx,
       );
@@ -1258,14 +1298,20 @@ describe('modify_d365fo_file', () => {
     );
     expect(written).toBeDefined();
     const writtenContent: string = written[1];
-    expect(writtenContent).toContain('<AxFormControlExtension>');
-    expect(writtenContent).toContain('<ParentControlName>DetailsPropertiesFastTabPage</ParentControlName>');
-    expect(writtenContent).toContain('AxFormStringControl');
+    // Must match the SDK-serialized shape: <AxFormExtensionControl xmlns=""> wrapping
+    // an empty-namespace <FormControl i:type="…"> with a <Parent> reference.
+    expect(writtenContent).toContain('<AxFormExtensionControl xmlns="">');
+    expect(writtenContent).toContain('<FormControl xmlns="" i:type="AxFormStringControl">');
+    expect(writtenContent).toContain('<Type>String</Type>');
+    expect(writtenContent).toContain('<Parent>DetailsPropertiesFastTabPage</Parent>');
     expect(writtenContent).toContain('ContosoPaymentReference');
-    expect(writtenContent).toContain('<d4p1:DataSource>ContosoRentRule</d4p1:DataSource>');
+    expect(writtenContent).toContain('<DataSource>ContosoRentRule</DataSource>');
+    // Must NOT use the malformed AxFormControlExtension/ParentControlName shape.
+    expect(writtenContent).not.toContain('<AxFormControlExtension>');
+    expect(writtenContent).not.toContain('ParentControlName');
   });
 
-  it('add-control maps controlType to the matching AxForm*Control element (Integer → AxFormIntControl)', async () => {
+  it('add-control maps controlType to the matching AxForm*Control element (Integer → AxFormIntegerControl)', async () => {
     const fsMod = await import('fs/promises');
     const extXml =
       `<?xml version="1.0" encoding="utf-8"?>\n` +
@@ -1296,7 +1342,8 @@ describe('modify_d365fo_file', () => {
       String(c[0]).includes('SomeForm.MyExt.xml'),
     );
     expect(written).toBeDefined();
-    expect(written[1]).toContain('AxFormIntControl');
+    expect(written[1]).toContain('<FormControl xmlns="" i:type="AxFormIntegerControl">');
+    expect(written[1]).toContain('<Type>Integer</Type>');
   });
 
   it('replace-code "oldCode not found" error includes a tip to use get_object_info or add-method', async () => {

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -1003,22 +1003,22 @@ describe('modify_d365fo_file', () => {
     // skipped and only the actual methods are added.
     const fsMod = await import('fs/promises');
     (fsMod.readFile as any).mockResolvedValueOnce(
-      `<?xml version="1.0"?><AxClass><Name>AslRentAgreementTable_Extension</Name></AxClass>`,
+      `<?xml version="1.0"?><AxClass><Name>ContosoRentAgreementTable_Extension</Name></AxClass>`,
     );
     const addMethod = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
     (ctx as any).bridge = { isReady: true, metadataAvailable: true, addMethod, refreshProvider: vi.fn(), validateObject: vi.fn(async () => null) };
 
-    const classDecl = `[ExtensionOf(tableStr(AslRentAgreementTable))]\nfinal class AslRentAgreementTable_Extension\n{\n}`;
+    const classDecl = `[ExtensionOf(tableStr(ContosoRentAgreementTable))]\nfinal class ContosoRentAgreementTable_Extension\n{\n}`;
     const method1  = `public void validateStatus()\n{\n    // TODO\n}`;
     const method2  = `public void computeTotals()\n{\n    // TODO\n}`;
 
     const result = await modifyD365FileTool(
       req('modify_d365fo_file', {
         objectType: 'table',
-        objectName: 'AslRentAgreementTable_Extension',
+        objectName: 'ContosoRentAgreementTable_Extension',
         operation: 'add-method',
         sourceCode: `${classDecl}\n\n${method1}\n\n${method2}`,
-        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxClass\\AslRentAgreementTable_Extension.xml',
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxClass\\ContosoRentAgreementTable_Extension.xml',
       }),
       ctx,
     );
@@ -1211,6 +1211,92 @@ describe('modify_d365fo_file', () => {
     expect(writtenContent).toContain('AxMenuFunctionItem');
     expect(writtenContent).toContain('<MenuItemName>ContosoRentEquipmentTable</MenuItemName>');
     expect(writtenContent).toContain('<MenuItemType>Display</MenuItemType>');
+  });
+
+  it('add-control on a form-extension falls back to XML when the bridge fails (extension never resolves as a form)', async () => {
+    // Root cause: the C# bridge's AddControl reads _provider.Forms.Read(name), which
+    // can never resolve a form EXTENSION ("Base.Suffix") — it always reports
+    // 'Form "<ext>" not found'. The XML fallback must write the control element.
+    const fsMod = await import('fs/promises');
+    const extXml =
+      `<?xml version="1.0" encoding="utf-8"?>\n` +
+      `<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">\n` +
+      `\t<Name>ContosoRentConfiguration.MyExt</Name>\n` +
+      `\t<ControlModifications />\n` +
+      `\t<Controls />\n` +
+      `\t<DataSourceModifications />\n` +
+      `\t<PropertyModifications />\n` +
+      `</AxFormExtension>`;
+    (fsMod.readFile as any).mockResolvedValue(extXml);
+
+    const addControl = vi.fn(async () => {
+      throw new Error("Form 'ContosoRentConfiguration.MyExt' not found");
+    });
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addControl, refreshProvider: vi.fn() };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form-extension',
+        objectName: 'ContosoRentConfiguration.MyExt',
+        operation: 'add-control',
+        controlName: 'ContosoPaymentReference',
+        parentControl: 'DetailsPropertiesFastTabPage',
+        controlType: 'String',
+        controlDataSource: 'ContosoRentRule',
+        controlDataField: 'ContosoPaymentReference',
+        controlLabel: '@ContosoLabels:PaymentReference',
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxFormExtension\\ContosoRentConfiguration.MyExt.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    // Bridge was attempted first (and failed), XML fallback wrote the file.
+    expect(addControl).toHaveBeenCalledTimes(1);
+    const written = (fsMod.writeFile as any).mock.calls.find((c: any[]) =>
+      String(c[0]).includes('ContosoRentConfiguration.MyExt.xml'),
+    );
+    expect(written).toBeDefined();
+    const writtenContent: string = written[1];
+    expect(writtenContent).toContain('<AxFormControlExtension>');
+    expect(writtenContent).toContain('<ParentControlName>DetailsPropertiesFastTabPage</ParentControlName>');
+    expect(writtenContent).toContain('AxFormStringControl');
+    expect(writtenContent).toContain('ContosoPaymentReference');
+    expect(writtenContent).toContain('<d4p1:DataSource>ContosoRentRule</d4p1:DataSource>');
+  });
+
+  it('add-control maps controlType to the matching AxForm*Control element (Integer → AxFormIntControl)', async () => {
+    const fsMod = await import('fs/promises');
+    const extXml =
+      `<?xml version="1.0" encoding="utf-8"?>\n` +
+      `<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">\n` +
+      `\t<Name>SomeForm.MyExt</Name>\n` +
+      `\t<Controls />\n` +
+      `</AxFormExtension>`;
+    (fsMod.readFile as any).mockResolvedValue(extXml);
+
+    const addControl = vi.fn(async () => ({ success: false }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addControl, refreshProvider: vi.fn() };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form-extension',
+        objectName: 'SomeForm.MyExt',
+        operation: 'add-control',
+        controlName: 'MyCount',
+        parentControl: 'TabGeneral',
+        controlType: 'Integer',
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxFormExtension\\SomeForm.MyExt.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const written = (fsMod.writeFile as any).mock.calls.find((c: any[]) =>
+      String(c[0]).includes('SomeForm.MyExt.xml'),
+    );
+    expect(written).toBeDefined();
+    expect(written[1]).toContain('AxFormIntControl');
   });
 
   it('replace-code "oldCode not found" error includes a tip to use get_object_info or add-method', async () => {

--- a/tests/utils/fieldControlTypes.test.ts
+++ b/tests/utils/fieldControlTypes.test.ts
@@ -15,7 +15,7 @@ describe('controlForTableField', () => {
     expect(controlForTableField('AxTableFieldString')).toEqual({ iType: 'AxFormStringControl', typeValue: 'String' });
     expect(controlForTableField('AxTableFieldReal')).toEqual({ iType: 'AxFormRealControl', typeValue: 'Real' });
     expect(controlForTableField('AxTableFieldDate')).toEqual({ iType: 'AxFormDateControl', typeValue: 'Date' });
-    expect(controlForTableField('AxTableFieldInt')).toEqual({ iType: 'AxFormIntControl', typeValue: 'Integer' });
+    expect(controlForTableField('AxTableFieldInt')).toEqual({ iType: 'AxFormIntegerControl', typeValue: 'Integer' });
     expect(controlForTableField('AxTableFieldInt64')).toEqual({ iType: 'AxFormInt64Control', typeValue: 'Int64' });
     expect(controlForTableField('AxTableFieldUtcDateTime')).toEqual({ iType: 'AxFormDateTimeControl', typeValue: 'DateTime' });
   });


### PR DESCRIPTION
## Summary

Fixes three bugs hit when working with table/form extensions through `d365fo_file`, plus a related form-generator fix, **plus hardening that prevents the same class of failure from recurring.**

### Bug #1 — `create` drops `properties.fields` for `table-extension`
The bridge-first create path forwarded `fields/fieldGroups/indexes/relations` **only when `objectType === 'table'`**, so a table-extension's `properties.fields` were silently dropped and the file got an empty `<Fields />`. Extended the branch to `table-extension` and added `normalizeFieldSpecsForBridge` — field specs use `{ name, edt, type }`, but the bridge's `WriteFieldParam` deserializes `{ name, fieldType, extendedDataType, … }`, so the raw keys had to be remapped or the EDT/base type was lost.

### Bug #2 — `add-control` generated the wrong XML shape for form-extensions
The first version of the `directXmlAddControl` fallback emitted a malformed shape (`<AxFormControlExtension>` / `<ParentControlName>` / d4p1-prefixed `AxFormIntControl`) copied from a customer file that was itself invalid. Verified against the shipped reference `InventItemSampling.AdvancedQualityManagement.xml`, the correct shape is `<AxFormExtensionControl xmlns="">` wrapping an empty-namespace `<FormControl i:type="…">` (Name → Type → FormControlExtension nil → DataField → DataSource → Label) with a `<Parent>` reference. Integer control = **`AxFormIntegerControl`** + `<Type>Integer</Type>` (not `AxFormIntControl` — confirmed: 84 occurrences vs 0 in shipped packages).

### Bug #3 — `add-control` failed for form-extensions created in the same session
Resolved by the fallback above. The real cause was not "metadata roots fixed at startup" (the bridge's `RefreshProvider` rescans disk) but that the bridge's `AddControl` resolves via `_provider.Forms.Read(name)`, which can never find a form **extension** (`Base.Suffix`). The TS fallback writes the control straight into the XML.

### Related — form generator emitted the same wrong integer element
`src/utils/fieldControlTypes.ts` mapped integer fields to the non-existent `AxFormIntControl`. Corrected to `AxFormIntegerControl`.

## Hardening (prevents the same failure pattern recurring)
These come from analyzing the original session that produced the malformed file — the failures chained: dropped fields → add-control unavailable → hand-written wrong XML → deserialize failure → a long PowerShell `Get-ChildItem`/`Select-String` expedition to reverse-engineer the right shape.

1. **Actionable not-found guidance.** `get_object_info` / `batch_get_info` now append, on any reader "not found", the correct next steps (`search`/`batch_search`, `update_symbol_index`, check `D365FO_CUSTOM_PACKAGES_PATH`) and **explicitly forbid filesystem scanning**. The bare "not found" message was the guidance vacuum that nudged agents into raw disk grep.
2. **Form-extension control-shape gate.** `create` with hand-written `xmlContent` for a form-extension is validated for the deserializer-rejecting shapes and **blocked with the correct template** (when `FORM_PATTERN_ENFORCE` is on) — no more silently-broken files.
3. **Advisory X++ select linter.** `add-method` / `replace-code` surface a likely "WHERE after join" mistake up front (non-blocking) instead of letting it become a build error hunted by hand.

## Changes
- `src/tools/modifyD365File.ts` — `directXmlAddControl` (correct shape) + advisory X++ select lint
- `src/tools/createD365File.ts` — forward + normalize fields for `table-extension`; form-extension shape gate
- `src/tools/{getObjectInfo,batchGetInfo,objectInfoRegistry}.ts`, `src/utils/metadataResolver.ts` — not-found guidance
- `src/utils/{fieldControlTypes,formExtensionShapeValidator,xppSelectLint}.ts`
- Tests across `tests/tools/*` and `tests/utils/*`

## Testing
- `npx tsc --noEmit` — clean
- `npx vitest run` — **1128 passed (71 files)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)