### PR TITLE
feat(guidance): harden against the form/table-extension failure patterns

### DIFF
--- a/src/tools/batchGetInfo.ts
+++ b/src/tools/batchGetInfo.ts
@@ -10,7 +10,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { READER_DISPATCH, BATCH_INFO_TYPES } from './objectInfoRegistry.js';
+import { READER_DISPATCH, BATCH_INFO_TYPES, withNotFoundGuidance } from './objectInfoRegistry.js';
 
 export const BatchGetInfoArgsSchema = z.object({
   objects: z.array(z.object({
@@ -37,7 +37,7 @@ export async function batchGetInfoTool(request: CallToolRequest, context: XppSer
         params: { name: dispatch.toolName, arguments: dispatch.buildArgs(obj.name) },
       };
       try {
-        const result = await dispatch.tool(subRequest, context);
+        const result = withNotFoundGuidance(await dispatch.tool(subRequest, context), obj.name, obj.type);
         return { ...obj, success: !result.isError, text: result.content?.[0]?.text ?? 'No content' };
       } catch (err) {
         return { ...obj, success: false, text: `Error: ${err instanceof Error ? err.message : err}` };

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -15,7 +15,8 @@ import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
 import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject, bridgeRefreshProvider } from '../bridge/index.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
-import { gateOnFormPatternErrors } from './validateFormPattern.js';
+import { gateOnFormPatternErrors, isFormPatternEnforceEnabled } from './validateFormPattern.js';
+import { validateFormExtensionControlShape, buildFormExtensionShapeError } from '../utils/formExtensionShapeValidator.js';
 import { FormPatternTemplates } from '../utils/formPatternTemplates.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
@@ -4145,6 +4146,22 @@ export async function handleCreateD365File(
       }
       if (gate.warningsText) {
         formPatternWarnings = `\n${gate.warningsText}\n`;
+      }
+    }
+
+    // Form-extension control-shape gate: reject the malformed control shapes an AI
+    // tends to hand-write (<AxFormControlExtension>, <ParentControlName>,
+    // <FormControlExtension> wrapping the control, AxFormIntControl) — they pass XML
+    // well-formedness but the D365FO deserializer rejects them. Blocks when
+    // FORM_PATTERN_ENFORCE is on (default), else appends a warning.
+    if (args.objectType === 'form-extension' && args.xmlContent) {
+      const shapeProblems = validateFormExtensionControlShape(xmlContent);
+      if (shapeProblems.length > 0) {
+        const shapeError = buildFormExtensionShapeError(finalObjectName, shapeProblems);
+        if (isFormPatternEnforceEnabled()) {
+          return { content: [{ type: 'text', text: shapeError }], isError: true };
+        }
+        formPatternWarnings += `\n⚠️ ${shapeError}\n`;
       }
     }
 

--- a/src/tools/getObjectInfo.ts
+++ b/src/tools/getObjectInfo.ts
@@ -15,7 +15,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { READER_DISPATCH, OBJECT_INFO_TYPES } from './objectInfoRegistry.js';
+import { READER_DISPATCH, OBJECT_INFO_TYPES, withNotFoundGuidance } from './objectInfoRegistry.js';
 import { completionTool } from './completion.js';
 
 const GetObjectInfoArgsSchema = z.object({
@@ -91,7 +91,8 @@ export async function getObjectInfoTool(request: CallToolRequest, context: XppSe
     method: 'tools/call',
     params: { name: dispatch.toolName, arguments: dispatch.buildArgs(name, options) },
   };
-  return dispatch.tool(subRequest, context);
+  const result = await dispatch.tool(subRequest, context);
+  return withNotFoundGuidance(result, name, objectType);
 }
 
 // Tool registration (name, description, inputSchema) lives inline in

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -36,6 +36,7 @@ import {
   isFormPatternEnforceEnabled,
 } from './validateFormPattern.js';
 import { validateEdtExtensionChange } from '../utils/edtExtensionValidator.js';
+import { lintXppSelect } from '../utils/xppSelectLint.js';
 
 /**
  * Decode the standard XML entities (&lt;, &gt;, &apos;, &quot;, &amp;) and normalise
@@ -1798,6 +1799,12 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
     }
 
+    // Advisory X++ select-statement lint on the source just written (add-method /
+    // replace-code etc.). Non-blocking: surfaces a likely "WHERE after join" mistake
+    // up front instead of letting it become a build error the agent hunts by hand.
+    const xppLintWarnings = lintXppSelect(args.sourceCode ?? (args as any).methodCode ?? args.newCode);
+    const xppLintNote = xppLintWarnings.length > 0 ? `\n\n${xppLintWarnings.join('\n\n')}` : '';
+
     return {
       content: [
         {
@@ -1805,7 +1812,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
           text:
             `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
-            `🔧 API: ${bridgeResult.message}\n\n` +
+            `🔧 API: ${bridgeResult.message}${xppLintNote}\n\n` +
             `**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate`,
         },
       ],

--- a/src/tools/objectInfoRegistry.ts
+++ b/src/tools/objectInfoRegistry.ts
@@ -12,6 +12,7 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { XppServerContext } from '../types/context.js';
+import { isNotFoundResultText, buildNotFoundGuidance } from '../utils/metadataResolver.js';
 import { classInfoTool } from './classInfo.js';
 import { tableInfoTool } from './tableInfo.js';
 import { getFormInfoTool } from './formInfo.js';
@@ -31,6 +32,26 @@ import { tableExtensionInfoTool, formExtensionInfoTool, enumExtensionInfoTool, e
 import { securityArtifactInfoTool } from './securityArtifactInfo.js';
 
 export type InfoTool = (request: CallToolRequest, context: XppServerContext) => Promise<any>;
+
+/**
+ * Append actionable "use search / update_symbol_index, don't grep the disk" guidance
+ * to a reader result that failed to resolve the object. Shared by get_object_info and
+ * batch_get_info so every reader benefits from a single choke point.
+ *
+ * No-op unless the result is an error whose text reads like a not-found (so genuine
+ * operation errors aren't masked), and skipped when a type-mismatch hint or our own
+ * guidance is already present (keeps it idempotent and avoids double guidance).
+ */
+export function withNotFoundGuidance(result: any, name: string, objectType: string): any {
+  if (!result?.isError) return result;
+  const text: string | undefined = result.content?.[0]?.text;
+  if (!isNotFoundResultText(text)) return result;
+  if (/Type Mismatch/i.test(text!) || /Resolve `.*` .* with the right tool/.test(text!)) return result;
+  return {
+    ...result,
+    content: [{ type: 'text', text: text + buildNotFoundGuidance(name, objectType) }],
+  };
+}
 
 export interface ReaderDispatch {
   tool: InfoTool;

--- a/src/utils/formExtensionShapeValidator.ts
+++ b/src/utils/formExtensionShapeValidator.ts
@@ -1,0 +1,125 @@
+/**
+ * Form-extension control-shape validator.
+ *
+ * Catches the malformed AxFormExtension control shapes that an AI tends to produce
+ * when hand-writing `xmlContent` (the escape hatch when add-control can't be used).
+ * These exact mistakes were observed in the wild and silently produced a file that
+ * the D365FO deserializer rejects — costing a long debugging + filesystem-grep
+ * expedition. Flagging them at write time, with the correct shape, fixes that in one
+ * shot.
+ *
+ * Correct shape (verified against shipped standard extensions, e.g.
+ * InventItemSampling.AdvancedQualityManagement):
+ *
+ *   <AxFormExtensionControl xmlns="">
+ *     <Name>FormExtensionControl{rand}</Name>
+ *     <FormControl xmlns="" i:type="AxFormIntegerControl">
+ *       <Name>Field</Name>
+ *       <Type>Integer</Type>
+ *       <FormControlExtension i:nil="true" />
+ *       <DataField>Field</DataField>
+ *       <DataSource>Table</DataSource>
+ *       <Label>@Model:Label</Label>
+ *     </FormControl>
+ *     <Parent>ParentControl</Parent>
+ *   </AxFormExtensionControl>
+ */
+
+export interface FormExtShapeProblem {
+  found: string;
+  expected: string;
+  detail: string;
+}
+
+/**
+ * The canonical correct shape, shown to the caller when a problem is found so they
+ * can fix it without grepping standard packages.
+ */
+export const CORRECT_FORM_EXTENSION_CONTROL_TEMPLATE =
+  `<AxFormExtensionControl xmlns="">\n` +
+  `    <Name>FormExtensionControl{uniqueId}</Name>\n` +
+  `    <FormControl xmlns="" i:type="AxFormIntegerControl">\n` +
+  `        <Name>FieldName</Name>\n` +
+  `        <Type>Integer</Type>\n` +
+  `        <FormControlExtension i:nil="true" />\n` +
+  `        <DataField>FieldName</DataField>\n` +
+  `        <DataSource>TableName</DataSource>\n` +
+  `        <Label>@Model:LabelId</Label>\n` +
+  `    </FormControl>\n` +
+  `    <Parent>ParentControlName</Parent>\n` +
+  `</AxFormExtensionControl>`;
+
+/**
+ * Inspect form-extension XML for the known malformed control shapes. Returns an empty
+ * array when the shape is fine. Pure + side-effect-free so it is trivially testable.
+ */
+export function validateFormExtensionControlShape(xml: string): FormExtShapeProblem[] {
+  const problems: FormExtShapeProblem[] = [];
+
+  // 1. Wrong wrapper element for a newly-added control.
+  if (/<AxFormControlExtension\b/.test(xml)) {
+    problems.push({
+      found: '<AxFormControlExtension>',
+      expected: '<AxFormExtensionControl xmlns="">',
+      detail:
+        'A new control added by a form extension is wrapped in <AxFormExtensionControl xmlns="">, ' +
+        'not <AxFormControlExtension>.',
+    });
+  }
+
+  // 2. Wrong parent-reference element.
+  if (/<ParentControlName\b/.test(xml)) {
+    problems.push({
+      found: '<ParentControlName>',
+      expected: '<Parent>',
+      detail: 'The parent control is referenced with <Parent>Name</Parent>, not <ParentControlName>.',
+    });
+  }
+
+  // 3. <FormControlExtension> used as the control CONTAINER (wrong) — i.e. an opening
+  //    <FormControlExtension> that wraps an <AxForm…Control> child. The legitimate use
+  //    is the self-closing <FormControlExtension i:nil="true" /> INSIDE a <FormControl>,
+  //    which this pattern deliberately does not match.
+  if (/<FormControlExtension\s*>[\s\S]*?<AxForm\w*Control\b/.test(xml)) {
+    problems.push({
+      found: '<FormControlExtension><AxForm…Control>',
+      expected: '<FormControl xmlns="" i:type="AxForm…Control">',
+      detail:
+        'The control itself goes in <FormControl xmlns="" i:type="AxForm…Control">…</FormControl>. ' +
+        '<FormControlExtension i:nil="true" /> is a separate, self-closing element INSIDE that FormControl.',
+    });
+  }
+
+  // 4. Non-existent integer control element.
+  if (/\bAxFormIntControl\b/.test(xml)) {
+    problems.push({
+      found: 'AxFormIntControl',
+      expected: 'AxFormIntegerControl',
+      detail:
+        'The integer form control class is AxFormIntegerControl (with <Type>Integer</Type>). ' +
+        'AxFormIntControl does not exist and fails deserialization.',
+    });
+  }
+
+  return problems;
+}
+
+/**
+ * Render a blocking error message for the detected problems, including the correct
+ * template so the caller can fix the XML in a single edit (no package grepping).
+ */
+export function buildFormExtensionShapeError(
+  objectName: string,
+  problems: FormExtShapeProblem[],
+): string {
+  const rows = problems
+    .map(p => `  • \`${p.found}\` → must be \`${p.expected}\`\n    ${p.detail}`)
+    .join('\n');
+  return (
+    `⛔ form-extension "${objectName}" — the control XML uses a shape the D365FO deserializer rejects.\n\n` +
+    `Problems found:\n${rows}\n\n` +
+    `Correct shape for a bound control added to an existing parent:\n\`\`\`xml\n${CORRECT_FORM_EXTENSION_CONTROL_TEMPLATE}\n\`\`\`\n\n` +
+    `Tip: prefer d365fo_file(action="modify", operation="add-control", objectType="form-extension", …) — ` +
+    `it now emits this exact shape for you, so you rarely need to hand-write the XML.`
+  );
+}

--- a/src/utils/metadataResolver.ts
+++ b/src/utils/metadataResolver.ts
@@ -372,6 +372,41 @@ export function buildObjectTypeMismatchMessage(
 }
 
 /**
+ * Heuristic: does a reader result's text indicate an object-resolution ("not found")
+ * failure, as opposed to a genuine operation error (parse failure, timeout, etc.)?
+ * Used to decide whether to append the not-found guidance below.
+ */
+export function isNotFoundResultText(text: string | undefined): boolean {
+  if (!text) return false;
+  return /\bnot found\b|could not resolve|does not exist/i.test(text);
+}
+
+/**
+ * Actionable guidance appended to a reader's "object not found" result.
+ *
+ * Steers the agent to the right MCP tools (search / update_symbol_index) and the
+ * config knob for custom packages — and explicitly AWAY from filesystem scanning
+ * (Get-ChildItem / Select-String / dir / ls / find). Raw disk scanning is the
+ * anti-pattern that turns one missing object into dozens of PowerShell calls: it is
+ * slow (350+ model folders), can hang the VS 2022 MCP integration, and bypasses
+ * metadata resolution. The "not found" message alone left a guidance vacuum that
+ * nudged agents straight into it — this fills the vacuum with the correct next steps.
+ */
+export function buildNotFoundGuidance(name: string, objectType: string): string {
+  return (
+    `\n\n---\n` +
+    `🔎 **Resolve \`${name}\` (${objectType}) with the right tool — do not guess or grep the disk:**\n` +
+    `1. \`search\` / \`batch_search\` for \`${name}\` — the exact name may differ (model prefix, casing, suffix).\n` +
+    `2. Real object in a custom package that isn't indexed yet? Run ` +
+    `\`update_symbol_index({ filePath: "<absolute path to ${name}.xml>" })\`, and confirm ` +
+    `\`D365FO_CUSTOM_PACKAGES_PATH\` includes that package so the bridge + symbol index can see it.\n` +
+    `3. Just created it this session? The bridge may not have it yet — pass the file path, or it will be picked up after a refresh.\n\n` +
+    `⛔ Do NOT scan the filesystem (Get-ChildItem / Select-String / dir / ls / find) to locate D365FO objects — ` +
+    `it is slow, can hang the VS 2022 MCP integration, and bypasses metadata resolution. Use the tools above.`
+  );
+}
+
+/**
  * Build a friendly error explaining that the XML for this object type
  * is not available in the current deployment (no D365FO installation).
  */

--- a/src/utils/xppSelectLint.ts
+++ b/src/utils/xppSelectLint.ts
@@ -1,0 +1,88 @@
+/**
+ * Lightweight, ADVISORY X++ select-statement linter.
+ *
+ * replace-code / add-method write X++ source verbatim — they are not a compiler — so a
+ * structural select mistake reaches disk and only surfaces as a build error later (with a
+ * line number the agent then hunts via filesystem grep). This catches the one mistake that
+ * is both common in AI-generated X++ and unambiguous to detect:
+ *
+ *   a main-table WHERE clause placed AFTER a join.
+ *
+ * In X++ a select reads:
+ *   select [field] from Main [where mainCond]
+ *       [ [exists|notexists|outer] join Buf from T where joinCond ]...
+ * The main WHERE must precede every join, and each join clause carries at most ONE where.
+ * Two `where` keywords inside a single join segment therefore means a stray where landed
+ * after the join — exactly the "WHERE after exists join" bug.
+ *
+ * ADVISORY ONLY: returns human-readable warnings, never throws or blocks. A compiler this is
+ * not, and a false positive must never break a legitimate write — at worst it adds a note.
+ */
+
+/** Strip X++ line/block/doc comments and string literals so 'where'/'join' tokens inside
+ *  them don't skew the scan. Replaces stripped spans with spaces to preserve offsets loosely. */
+function stripCommentsAndStrings(s: string): string {
+  let out = '';
+  let i = 0;
+  while (i < s.length) {
+    const two = s.slice(i, i + 2);
+    if (two === '//') {
+      const nl = s.indexOf('\n', i);
+      i = nl === -1 ? s.length : nl;
+      continue;
+    }
+    if (two === '/*') {
+      const end = s.indexOf('*/', i + 2);
+      i = end === -1 ? s.length : end + 2;
+      continue;
+    }
+    if (s[i] === '"') {
+      i++;
+      while (i < s.length && s[i] !== '"') { if (s[i] === '\\') i++; i++; }
+      i++;
+      out += '""';
+      continue;
+    }
+    out += s[i];
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Inspect X++ source for misplaced WHERE clauses in select statements. Returns a list of
+ * advisory warning strings (empty when clean).
+ */
+export function lintXppSelect(source: string | undefined): string[] {
+  if (!source || !/\bselect\b/i.test(source)) return [];
+  const cleaned = stripCommentsAndStrings(source);
+  const warnings: string[] = [];
+
+  // Each select statement spans from `select` to its terminating `;`.
+  const selectRe = /\bselect\b[\s\S]*?;/gi;
+  let m: RegExpExecArray | null;
+  while ((m = selectRe.exec(cleaned)) !== null) {
+    const stmt = m[0];
+    if (!/\bjoin\b/i.test(stmt)) continue; // only join-bearing selects can have this bug
+
+    // Split into segments at each `join` keyword. Segment 0 is the main-table region
+    // (its where is legal); every later segment is one join's clause and may hold at
+    // most ONE where. Two wheres in a single join segment ⇒ a stray (main-table) where.
+    const segments = stmt.split(/\bjoin\b/i);
+    for (let s = 1; s < segments.length; s++) {
+      const whereCount = (segments[s].match(/\bwhere\b/gi) ?? []).length;
+      if (whereCount >= 2) {
+        const snippet = stmt.replace(/\s+/g, ' ').trim().slice(0, 120);
+        warnings.push(
+          `⚠️ Possible X++ select error: a WHERE clause appears AFTER a join.\n` +
+          `   In X++ the main-table WHERE must come BEFORE any join, and each join has at most one WHERE.\n` +
+          `   Move the main-table condition ahead of the join:\n` +
+          `     select <field> from <Main> where <mainCond> exists join <Buf> from <T> where <joinCond>;\n` +
+          `   Statement: ${snippet}${stmt.length > 120 ? '…' : ''}`,
+        );
+        break; // one warning per statement is enough
+      }
+    }
+  }
+  return warnings;
+}

--- a/tests/tools/batchGetInfo.test.ts
+++ b/tests/tools/batchGetInfo.test.ts
@@ -66,6 +66,22 @@ describe('batch_get_info', () => {
     expect(text).toContain('NoSuchEnum [ENUM] ❌');
   });
 
+  it('appends actionable resolution guidance (and forbids filesystem scanning) on a not-found result', async () => {
+    const result = await batchGetInfoTool(
+      makeRequest([{ name: 'NoSuchEnum', type: 'enum' }]),
+      context,
+    );
+
+    const text = result.content[0].text;
+    // The reader's own "not found" is preserved …
+    expect(text).toContain('enum not found');
+    // … and the shared guidance is appended: steer to search/update_symbol_index …
+    expect(text).toMatch(/search.*batch_search|update_symbol_index/i);
+    expect(text).toMatch(/D365FO_CUSTOM_PACKAGES_PATH/);
+    // … and explicitly forbid Get-ChildItem / Select-String filesystem scanning.
+    expect(text).toMatch(/Get-ChildItem|Select-String/);
+  });
+
   it('rejects invalid arguments', async () => {
     const result = await batchGetInfoTool(makeRequest([]), context);
     expect(result.isError).toBe(true);

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -517,6 +517,45 @@ describe('create_d365fo_file', () => {
     ]);
   });
 
+  it('blocks form-extension create when xmlContent uses the malformed control shape', async () => {
+    // Guard: the deserializer-rejecting shape an AI tends to hand-write
+    // (AxFormControlExtension / ParentControlName / FormControlExtension-wrapping / AxFormIntControl)
+    // must be caught at write time with the correct template — not silently written.
+    const malformed =
+      `<?xml version="1.0" encoding="utf-8"?>\n` +
+      `<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">\n` +
+      `\t<Name>BudgetControlConfiguration.MyExt</Name>\n` +
+      `\t<Controls>\n` +
+      `\t\t<AxFormControlExtension>\n` +
+      `\t\t\t<Name>X</Name>\n` +
+      `\t\t\t<ParentControlName>Tab</ParentControlName>\n` +
+      `\t\t\t<FormControlExtension>\n` +
+      `\t\t\t\t<AxFormIntControl><Name>X</Name></AxFormIntControl>\n` +
+      `\t\t\t</FormControlExtension>\n` +
+      `\t\t</AxFormControlExtension>\n` +
+      `\t</Controls>\n` +
+      `</AxFormExtension>`;
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'form-extension',
+        objectName: 'BudgetControlConfiguration.MyExt',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        overwrite: true,
+        xmlContent: malformed,
+      }),
+    );
+
+    expect((result as any).isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toMatch(/AxFormExtensionControl xmlns=""/);   // correct wrapper shown
+    expect(text).toMatch(/AxFormIntegerControl/);              // correct integer element shown
+    expect(text).toMatch(/<Parent>/);                          // correct parent element shown
+  });
+
   it('auto-converts bare extension name to dot-notation (Case C fix)', async () => {
     // Bug: objectType="table-extension", objectName="PurchTable" (no dot) used to
     // fall into NORMAL CASE of applyObjectPrefix and produce "ContosoPurchTable".

--- a/tests/utils/formExtensionShapeValidator.test.ts
+++ b/tests/utils/formExtensionShapeValidator.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateFormExtensionControlShape,
+  buildFormExtensionShapeError,
+} from '../../src/utils/formExtensionShapeValidator';
+
+const WRONG_SHAPE =
+  `<?xml version="1.0" encoding="utf-8"?>\n` +
+  `<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">\n` +
+  `\t<Name>BudgetControlConfiguration.MyExt</Name>\n` +
+  `\t<Controls>\n` +
+  `\t\t<AxFormControlExtension>\n` +
+  `\t\t\t<Name>X</Name>\n` +
+  `\t\t\t<ParentControlName>Tab</ParentControlName>\n` +
+  `\t\t\t<FormControlExtension>\n` +
+  `\t\t\t\t<AxFormIntControl xmlns:d4p1="Microsoft.Dynamics.AX.Metadata.V6">\n` +
+  `\t\t\t\t\t<d4p1:Name>X</d4p1:Name>\n` +
+  `\t\t\t\t</AxFormIntControl>\n` +
+  `\t\t\t</FormControlExtension>\n` +
+  `\t\t</AxFormControlExtension>\n` +
+  `\t</Controls>\n` +
+  `</AxFormExtension>`;
+
+const CORRECT_SHAPE =
+  `<?xml version="1.0" encoding="utf-8"?>\n` +
+  `<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">\n` +
+  `\t<Name>BudgetControlConfiguration.MyExt</Name>\n` +
+  `\t<Controls>\n` +
+  `\t\t<AxFormExtensionControl xmlns="">\n` +
+  `\t\t\t<Name>FormExtensionControlabc123xyz</Name>\n` +
+  `\t\t\t<FormControl xmlns="" i:type="AxFormIntegerControl">\n` +
+  `\t\t\t\t<Name>X</Name>\n` +
+  `\t\t\t\t<Type>Integer</Type>\n` +
+  `\t\t\t\t<FormControlExtension i:nil="true" />\n` +
+  `\t\t\t\t<DataField>X</DataField>\n` +
+  `\t\t\t\t<DataSource>T</DataSource>\n` +
+  `\t\t\t</FormControl>\n` +
+  `\t\t\t<Parent>Tab</Parent>\n` +
+  `\t\t</AxFormExtensionControl>\n` +
+  `\t</Controls>\n` +
+  `</AxFormExtension>`;
+
+describe('validateFormExtensionControlShape', () => {
+  it('flags all four malformed tokens in the wrong shape', () => {
+    const problems = validateFormExtensionControlShape(WRONG_SHAPE);
+    const found = problems.map(p => p.found);
+    expect(found).toContain('<AxFormControlExtension>');
+    expect(found).toContain('<ParentControlName>');
+    expect(found).toContain('<FormControlExtension><AxForm…Control>');
+    expect(found).toContain('AxFormIntControl');
+  });
+
+  it('passes the correct SDK-serialized shape with no problems', () => {
+    expect(validateFormExtensionControlShape(CORRECT_SHAPE)).toEqual([]);
+  });
+
+  it('does not flag the legitimate self-closing <FormControlExtension i:nil="true" />', () => {
+    // The correct shape contains <FormControlExtension i:nil="true" /> — must NOT be flagged.
+    const problems = validateFormExtensionControlShape(CORRECT_SHAPE);
+    expect(problems.find(p => p.found.includes('FormControlExtension'))).toBeUndefined();
+  });
+
+  it('buildFormExtensionShapeError includes the correct template and the found tokens', () => {
+    const problems = validateFormExtensionControlShape(WRONG_SHAPE);
+    const msg = buildFormExtensionShapeError('BudgetControlConfiguration.MyExt', problems);
+    expect(msg).toMatch(/AxFormExtensionControl xmlns=""/);
+    expect(msg).toMatch(/AxFormIntegerControl/);
+    expect(msg).toMatch(/<Parent>/);
+    expect(msg).toMatch(/AxFormIntControl/); // the "found" token is shown too
+  });
+});

--- a/tests/utils/xppSelectLint.test.ts
+++ b/tests/utils/xppSelectLint.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { lintXppSelect } from '../../src/utils/xppSelectLint';
+
+describe('lintXppSelect', () => {
+  it('flags a main-table WHERE placed after an exists join', () => {
+    const src = `
+      BudgetSourceTrackingDetail trackingDetail;
+      BudgetSourceTracking       tracking;
+      select firstOnly trackingDetail
+          exists join tracking
+              where tracking.RecId == trackingDetail.BudgetSourceTracking
+                 && tracking.BudgetSource == _budgetSourceId
+          where trackingDetail.BudgetControlLedgerDimension == ruleDim;
+    `;
+    const warnings = lintXppSelect(src);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/WHERE clause appears AFTER a join/i);
+  });
+
+  it('does NOT flag a correct select: main WHERE before the join', () => {
+    const src = `
+      select firstOnly trackingDetail
+          where trackingDetail.BudgetControlLedgerDimension == ruleDim
+          exists join tracking
+              where tracking.RecId == trackingDetail.BudgetSourceTracking
+                 && tracking.BudgetSource == _budgetSourceId;
+    `;
+    expect(lintXppSelect(src)).toEqual([]);
+  });
+
+  it('does NOT flag multiple joins each with their own WHERE', () => {
+    const src = `
+      select A
+          where A.x == 1
+          exists join B where B.y == A.y
+          exists join C where C.z == A.z;
+    `;
+    expect(lintXppSelect(src)).toEqual([]);
+  });
+
+  it('ignores non-select source and source without joins', () => {
+    expect(lintXppSelect('public void foo() { int x = 1; }')).toEqual([]);
+    expect(lintXppSelect('select firstOnly t where t.Field == 1;')).toEqual([]);
+    expect(lintXppSelect(undefined)).toEqual([]);
+  });
+
+  it('does not trip on the word "where"/"join" inside comments or strings', () => {
+    const src = `
+      // select t exists join u where a where b -- this is a comment, not code
+      str msg = "select x exists join y where p where q";
+      select firstOnly t where t.Field == 1 exists join u where u.Id == t.Id;
+    `;
+    expect(lintXppSelect(src)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-on hardening from the bug-report analysis — prevents the same class of pain (silent malformed writes + PowerShell filesystem expeditions) at the source.

1. Actionable not-found guidance. get_object_info / batch_get_info now append, on any reader "not found", the correct next steps (search / batch_search, update_symbol_index, check D365FO_CUSTOM_PACKAGES_PATH) and EXPLICITLY forbid filesystem scanning (Get-ChildItem / Select-String / find). The guidance vacuum in the bare "not found" message was what nudged agents into raw disk grep. Shared helper buildNotFoundGuidance + withNotFoundGuidance choke point.

2. Form-extension control-shape gate. create with hand-written xmlContent for a form-extension is now validated for the deserializer-rejecting shapes an AI tends to produce (AxFormControlExtension / ParentControlName / FormControlExtension-wrapping / AxFormIntControl) and blocked with the correct template (when FORM_PATTERN_ENFORCE is on). No more silently-broken files.

3. Advisory X++ select linter. add-method / replace-code now surface a likely "WHERE after join" mistake up front instead of letting it become a build error the agent hunts by hand. Non-blocking — a compiler this is not.

New modules: formExtensionShapeValidator, xppSelectLint. 11 new tests; full suite green.