### PR TITLE
test(table): guard mandatory field groups on table create

### DIFF
--- a/tests/utils/tableFieldGroups.test.ts
+++ b/tests/utils/tableFieldGroups.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression: creating a table must always emit the 5 standard mandatory
+ * D365FO field groups (AutoReport, AutoLookup, AutoIdentification, AutoSummary,
+ * AutoBrowse). The VS D365FO project system requires them, and BP rules require
+ * AutoReport to be non-empty and AutoIdentification to carry AutoPopulate=Yes.
+ *
+ * This guards the SmartXmlBuilder fallback path (Azure/Linux / bridge unavailable);
+ * the C# bridge path emits the same 5 groups in MetadataWriteService.CreateSmartTable.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SmartXmlBuilder } from '../../src/utils/smartXmlBuilder';
+
+const MANDATORY_FIELD_GROUPS = [
+  'AutoReport',
+  'AutoLookup',
+  'AutoIdentification',
+  'AutoSummary',
+  'AutoBrowse',
+] as const;
+
+/** Extract the inner XML of a named AxTableFieldGroup block. */
+function fieldGroupBlock(xml: string, name: string): string {
+  const marker = `<Name>${name}</Name>`;
+  const idx = xml.indexOf(marker);
+  if (idx === -1) return '';
+  return xml.slice(idx).split('</AxTableFieldGroup>')[0];
+}
+
+describe('table create emits mandatory field groups', () => {
+  const builder = new SmartXmlBuilder();
+  const xml = builder.buildTableXml({
+    name: 'VerifyTable',
+    fields: [
+      { name: 'AccountNum', edt: 'CustAccount', mandatory: true },
+      { name: 'Name', edt: 'Name' },
+      { name: 'Description', edt: 'Description' },
+    ],
+  });
+
+  it.each(MANDATORY_FIELD_GROUPS)('emits the %s field group', (name) => {
+    expect(xml).toContain(`<Name>${name}</Name>`);
+  });
+
+  it('emits exactly the 5 standard groups (no duplicates / omissions)', () => {
+    const count = (xml.match(/<AxTableFieldGroup>/g) ?? []).length;
+    expect(count).toBe(MANDATORY_FIELD_GROUPS.length);
+  });
+
+  it('AutoReport is populated — BP requires a non-empty group', () => {
+    const block = fieldGroupBlock(xml, 'AutoReport');
+    expect(block).toContain('<DataField>AccountNum</DataField>');
+  });
+
+  it('AutoIdentification carries AutoPopulate=Yes', () => {
+    const block = fieldGroupBlock(xml, 'AutoIdentification');
+    expect(block).toContain('<AutoPopulate>Yes</AutoPopulate>');
+  });
+
+  it('still emits all groups for a single-RecId table', () => {
+    const recIdOnly = builder.buildTableXml({
+      name: 'RecIdOnlyTable',
+      fields: [{ name: 'RecId', edt: 'RecId', mandatory: true }],
+    });
+    for (const name of MANDATORY_FIELD_GROUPS) {
+      expect(recIdOnly).toContain(`<Name>${name}</Name>`);
+    }
+  });
+});


### PR DESCRIPTION
## Co a proč

Ověřoval jsem, že se při vytváření tabulek generují **povinné field groups**. Generování funguje správně v obou cestách (C# bridge i `SmartXmlBuilder` fallback), ale toto chování **nebylo pokryté žádným testem** — existující `buildTableXml` testy ověřovaly jen `TableGroup`/`TableType`.

Tento PR přidává regresní test, aby budoucí změna v generátoru nerozbila povinné field groups nepozorovaně.

## Co test ověřuje

Pro vygenerované AxTable XML:
- emituje se všech 5 standardních field groups: `AutoReport`, `AutoLookup`, `AutoIdentification`, `AutoSummary`, `AutoBrowse`
- přesně 5 skupin (žádné duplicity ani vynechání)
- `AutoReport` je naplněn poli (BP: nesmí být prázdná)
- `AutoIdentification` nese `AutoPopulate=Yes`
- skupiny se emitují i pro tabulku s jediným polem `RecId`

Testuje se `SmartXmlBuilder` fallback cesta (Azure/Linux / bridge nedostupný); C# bridge (`MetadataWriteService.CreateSmartTable`) emituje stejných 5 skupin.

## Test

```
npx vitest run tests/utils/tableFieldGroups.test.ts
Tests  9 passed (9)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)