### PR TITLE
fix(codegen): correct NumberSeqFormHandler class name in number-sequence template

### DIFF
--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -948,14 +948,14 @@ public class ${name}DimensionController
 function numberSeqHandlerTemplate(name: string): string {
   return `/// <summary>
 /// Integrates number sequence auto-generation into the ${name} form.
-/// This class handles the NumberSequenceFormHandler setup in the form.
+/// This class handles the NumberSeqFormHandler setup in the form.
 /// Add init() call to form init(), and numSeqFormHandler reference to classDeclaration.
 /// </summary>
 // ── Step 1: Form classDeclaration ───────────────────────────────────────
 // [Form]
 // public class ${name}Form extends FormRun
 // {
-//     NumberSequenceFormHandler numSeqFormHandler;
+//     NumberSeqFormHandler numSeqFormHandler;
 // }
 
 // ── Step 2: Form init() ─────────────────────────────────────────────────
@@ -963,8 +963,8 @@ function numberSeqHandlerTemplate(name: string): string {
 // {
 //     super();
 //     // Hook number sequence handler to the ${name}Id field
-//     numSeqFormHandler = NumberSequenceFormHandler::newForm(
-//         ${name}Parameters::numRef${name}Id().NumberSequence,  // number sequence reference
+//     numSeqFormHandler = NumberSeqFormHandler::newForm(
+//         ${name}Parameters::numRef${name}Id().NumberSequenceId,  // number sequence reference (RefRecId)
 //         element,                                              // FormRun
 //         tableNum(${name}),                                    // table
 //         fieldNum(${name}, ${name}Id));                        // field to fill


### PR DESCRIPTION
## Problem

The `numberSeqHandlerTemplate` in `src/tools/codeGen.ts` — the form auto-numbering pattern the MCP hands to agents — contained two incorrect X++ references:

1. **`NumberSequenceFormHandler`** (3 occurrences) — this class does not exist. The correct name is **`NumberSeqFormHandler`**. The section header right above the template already used the correct name, so this was an internal inconsistency.
2. **`.NumberSequence`** — should be **`.NumberSequenceId`** (the `RefRecId` field). The rest of the knowledge base (`xppKnowledge.ts:621`) actively warns against `.NumberSequence`.

Because the template is copied verbatim by agents, both errors produced X++ that does not compile.

## Fix

Corrected all occurrences in the template. No behavior change beyond the emitted comment text; `xppKnowledge.ts` and `d365foErrorHelp.ts` already had the correct names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)