### PR TITLE
feat(eval): Phase 0 scaffold for the agent eval loop

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,49 @@
+# Agent eval loop — Phase 0 scaffold
+
+Phase 0 of the self-improving agent eval loop. See the full design in
+[docs/AGENT_EVAL_LOOP.md](../docs/AGENT_EVAL_LOOP.md).
+
+**Goal of Phase 0:** run **one** use-case end-to-end *by hand* through the
+grounded path on a D365FO VM, score it against golden metadata, and write one
+corpus record — proving where the tools actually break before any automation.
+
+## Layout
+
+```
+eval/
+├── README.md                     ← this file
+├── cases/
+│   ├── schema.json               ← JSON Schema for a use-case spec
+│   └── L1-table-basic.json       ← the Phase 0 case
+├── goldens/
+│   └── L1-table-basic/
+│       └── README.md             ← how to capture the golden on the VM
+└── corpus/
+    ├── schema.json               ← JSON Schema for a run record
+    └── runs/                      ← one .json run record per run (git-ignored content TBD)
+```
+
+## Manual run checklist (Phase 0, on the VM)
+
+Run with the mcp-server in `full` mode + C# bridge, pointed at a **throwaway
+sandbox model** (never a real customisation model).
+
+1. **Isolate** — create/confirm an empty sandbox model for this run.
+2. **Implement (grounded only)** — drive the case `instruction` through the
+   tool path: `prepare` → query tools (`search`, `object_info`, …) →
+   `validate_code(mode="references")` → `generate_object` → write via
+   `d365fo_file(action=create)`. No hand-edited XML.
+3. **Static gate** — record `validate_code` references + syntax results.
+4. **Build** — `build_d365fo_project`; capture `errors[]` and `bpWarnings[]`.
+5. **Oracle** — normalise the produced metadata and diff against
+   `goldens/L1-table-basic/` (see that folder's README to capture the golden the
+   first time).
+6. **Score & record** — fill one record matching `corpus/schema.json` and drop
+   it in `corpus/runs/`.
+7. **Roll back** — undo the write / wipe the sandbox model.
+8. **Triage** — classify any failure per the rubric in the design doc (§9);
+   record the hypothesis, not a fix.
+
+The output of Phase 0 is **one corpus record + a verdict** on whether the case
+passed build / BP-clean / golden — and, if not, which rubric class it fell into.
+That verdict decides what Phase 1 automates first.

--- a/eval/cases/L1-table-basic.json
+++ b/eval/cases/L1-table-basic.json
@@ -1,0 +1,14 @@
+{
+  "id": "L1-table-basic",
+  "title": "Basic table with fields, a field group and an index",
+  "tier": 1,
+  "instruction": "Create a new table named XyzAgentNote in the sandbox model. Fields: NoteId (EDT-backed string, mandatory), Subject (string 100), NoteText (long text), CreatedDateTime (utcdatetime). Add a field group 'Overview' containing Subject and NoteText. Add a unique index 'NoteIdx' on NoteId. Set the table's TitleField1 to Subject. Use the standard string EDTs from the index rather than inventing new ones.",
+  "target_artifact_types": ["AxTable"],
+  "golden_path": "eval/goldens/L1-table-basic/",
+  "ignore": [
+    "Table/@Id",
+    "Table/Fields/AxTableField/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": ["table", "fields", "fieldgroup", "index", "deterministic"]
+}

--- a/eval/cases/schema.json
+++ b/eval/cases/schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/dynamics365ninja/d365fo-mcp-server/eval/cases/schema.json",
+  "title": "Agent eval use-case spec",
+  "description": "A single D365FO implementation use-case for the agent eval loop. See docs/AGENT_EVAL_LOOP.md section 8.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "title", "tier", "instruction", "target_artifact_types", "golden_path"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^L[0-4]-[a-z0-9-]+$",
+      "description": "Stable case id, e.g. L1-table-basic. Prefix is the complexity tier."
+    },
+    "title": { "type": "string", "description": "Human-readable one-line title." },
+    "tier": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4,
+      "description": "Complexity tier L0-L4. Must match the id prefix."
+    },
+    "instruction": {
+      "type": "string",
+      "description": "The natural-language task the agent must implement using only the grounded tool path."
+    },
+    "target_artifact_types": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" },
+      "description": "AOT object types the case is expected to produce, e.g. AxTable, AxClass, AxForm."
+    },
+    "golden_path": {
+      "type": "string",
+      "description": "Repo-relative path to the golden metadata folder for this case."
+    },
+    "systest": {
+      "type": "string",
+      "description": "Optional repo-relative path to a SysTest definition for runtime correctness."
+    },
+    "ignore": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Per-case normalisation exceptions: element paths legitimately allowed to vary in the golden diff."
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Free-form tags for clustering, e.g. table, coc, form, security."
+    }
+  }
+}

--- a/eval/corpus/schema.json
+++ b/eval/corpus/schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/dynamics365ninja/d365fo-mcp-server/eval/corpus/schema.json",
+  "title": "Agent eval run record",
+  "description": "One self-contained evidence record per (case_id, run_id). See docs/AGENT_EVAL_LOOP.md section 5.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["run_id", "case_id", "tier", "timestamp", "server_git_sha", "score", "classification"],
+  "properties": {
+    "run_id": { "type": "string", "description": "Unique run id, e.g. <iso8601>__<case_id>__<short-hash>." },
+    "case_id": { "type": "string" },
+    "tier": { "type": "integer", "minimum": 0, "maximum": 4 },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "server_git_sha": { "type": "string", "description": "mcp-server commit under test." },
+    "bridge_version": { "type": "string" },
+    "platform_build": { "type": "string", "description": "D365FO PU / platform version on the VM." },
+    "generated_artifacts": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "AOT paths the run produced."
+    },
+    "static_gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "references": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "passed": { "type": "boolean" },
+            "unresolved": { "type": "array", "items": { "type": "string" } }
+          },
+          "required": ["passed"]
+        },
+        "syntax": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "passed": { "type": "boolean" },
+            "violations": { "type": "array", "items": { "type": "object" } }
+          },
+          "required": ["passed"]
+        }
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["succeeded"],
+      "properties": {
+        "succeeded": { "type": "boolean" },
+        "errors": { "type": "array", "items": { "type": "object" } },
+        "bpWarnings": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "golden_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["matched"],
+      "properties": {
+        "matched": { "type": "boolean" },
+        "missing": { "type": "array", "items": { "type": "string" } },
+        "extra": { "type": "array", "items": { "type": "string" } },
+        "changed": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "systest": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ran": { "type": "boolean" },
+        "passed": { "type": ["boolean", "null"] },
+        "failures": { "type": "array", "items": { "type": "object" } }
+      },
+      "required": ["ran"]
+    },
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["build", "bp_clean", "golden_match"],
+      "properties": {
+        "build": { "type": "integer", "enum": [0, 1] },
+        "bp_clean": { "type": "integer", "enum": [0, 1] },
+        "golden_match": { "type": "integer", "enum": [0, 1] },
+        "systest": { "type": ["integer", "null"], "enum": [0, 1, null] },
+        "tier_weight": { "type": "integer" }
+      }
+    },
+    "classification": {
+      "type": "string",
+      "enum": ["PASS", "TOOL_DEFECT", "KNOWLEDGE_GAP", "VALIDATOR_GAP", "MODEL_ERROR", "ENV_FLAKE"],
+      "description": "Rubric class for the run outcome. See docs/AGENT_EVAL_LOOP.md section 9."
+    },
+    "root_cause_hypothesis": { "type": "string" },
+    "suggested_fix_area": { "type": "string" },
+    "evidence_refs": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/eval/goldens/L1-table-basic/README.md
+++ b/eval/goldens/L1-table-basic/README.md
@@ -1,0 +1,30 @@
+# Golden — L1-table-basic
+
+This folder holds the **golden metadata** for case
+[`L1-table-basic`](../../cases/L1-table-basic.json): the normalised, expected
+metadata the server *should* produce for that instruction.
+
+It is empty until the golden is captured and human-approved. A golden is a
+reviewed artifact, like a snapshot test — not auto-generated trust.
+
+## Capturing the golden (first time, on the VM)
+
+1. Implement the case once through the grounded path and **manually verify** the
+   result is correct: it compiles, is BP-clean, and the table shape matches the
+   instruction (fields, types, mandatory flags, field group `Overview`, unique
+   index `NoteIdx`, `TitleField1 = Subject`).
+2. Take the produced AOT metadata for `XyzAgentNote` and **normalise** it
+   (per docs/AGENT_EVAL_LOOP.md §6.2):
+   - strip volatile fields — `@Id`/GUIDs, timestamps, `ModelSaveInfo`/model
+     descriptor (the case `ignore` list pins the known ones);
+   - canonicalise element ordering and whitespace.
+3. Save the normalised result here as `XyzAgentNote.metadata.xml` (or `.json`
+   if a normalised JSON form is used) and **get it reviewed** before relying on
+   it.
+
+Once present, every run diffs its normalised output against this golden;
+`missing` / `extra` / `changed` deltas are recorded in the run's `golden_diff`.
+
+> Note: goldens can drift across platform updates. Each run records
+> `platform_build`; if the golden legitimately changes for a new PU, update it
+> in a reviewed PR alongside the reason.


### PR DESCRIPTION
## What

Repo-side scaffold for **Phase 0** of the self-improving agent eval loop
(design: [docs/AGENT_EVAL_LOOP.md](docs/AGENT_EVAL_LOOP.md), PR #614).

No automation — Phase 0 is **one use-case run end-to-end by hand** on the VM to
locate where the tools actually break before Phase 1 builds the harness.

## Contents

```
eval/
├── README.md                       manual run checklist for the VM
├── cases/
│   ├── schema.json                 JSON Schema for a use-case spec
│   └── L1-table-basic.json         the Phase 0 case (table + fields + group + index)
├── goldens/
│   └── L1-table-basic/README.md    how to capture & approve the golden
└── corpus/
    ├── schema.json                 JSON Schema for a run record
    └── runs/                        one record per run
```

- The L1 case is deliberately **deterministic** (table/fields/group/index) so the
  golden-metadata oracle has high signal.
- Both schemas are draft-07 and validate.

## Run it (Phase 0, on the VM)

Follow `eval/README.md`: isolate sandbox model → grounded implement → static gate
→ build → golden diff → score → record → roll back → triage. Output is one corpus
record + a verdict (build / BP-clean / golden) that decides what Phase 1 automates
first.

## Note

The actual end-to-end run needs the D365FO dev VM (full mode + bridge) and the
first golden capture, which a maintainer runs there — this PR is the repo-side
scaffolding only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)