### PR TITLE
Fix security-duty/role-extension gap + generate_object scaffold dedup bug

### DIFF
--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -114,25 +114,27 @@ Add an audit inquiry form + menu item under Accounts receivable > Inquiries, and
 duty extension so the AR clerk role sees it.
 ```
 
+The diagram below is the **actual tool chain from a recorded run** of this prompt (object names normalized to the generic `AslSalesPostingAuditLog` / `Asl` prefix used above). It hit **real environment friction on almost every layer**: `SalesFormLetter.run` turned out to already be CoC'd by Microsoft itself, a leftover audit table + phantom labels from an interrupted prior attempt had to be identified and ignored, a form-scaffold clone silently bound to the wrong table, a hand-authored form had a subtle XML nesting bug, and the CoC build needed an extra model reference. See the cost box for the measured numbers.
+
 ```mermaid
 flowchart TB
-    A["get_workspace_info"] --> B["extension_info mode=coc<br/>SalesFormLetter.run already wrapped?"]
-    B --> C["extension_info mode=points<br/>CoC-eligible methods + delegates"]
-    C --> D["prepare mode=change<br/>signature + grounding token"]
-    D --> E["labels action=search then action=create x7"]
-    E --> F["suggest_edt + d365fo_file action=create<br/>audit EDTs"]
-    F --> G["generate_object objectType=table<br/>SalesPostingAuditLog"]
-    G --> H["d365fo_file action=create table<br/>then action=modify CustTable extension"]
-    H --> I["get_object_info table SalesPostingAuditLog<br/>verify what was actually written"]
-    I --> J["analyze_code mode=api-usage<br/>how SalesFormLetter_Confirm is invoked"]
-    J --> K["validate_code mode=references then mode=syntax"]
-    K --> L["d365fo_file action=create<br/>CoC class"]
-    L --> M["object_patterns domain=form action=analyze<br/>SimpleList inquiry"]
-    M --> N["generate_object objectType=form cloneFrom + validate"]
-    N --> O["d365fo_file action=create<br/>form + display menu item"]
-    O --> P["security_info mode=coverage<br/>AR clerk reach to the inquiry"]
-    P --> Q["d365fo_file action=create<br/>privilege + duty extension"]
-    Q --> R["verify_d365fo_project"]
+    A["extension_info mode=coc<br/>SalesFormLetter.run — ALREADY wrapped by Foundation's own extension"] --> B["extension_info mode=coc/points<br/>SalesFormLetter_Confirm.run — clean, unwrapped target"]
+    B --> C["prepare mode=change<br/>SalesFormLetter_Confirm.run — grounding token"]
+    C --> D["suggest_edt x6 + get_object_info edt/enum<br/>resolve SysUserId / TransDateTime / DocumentStatus / NoYes"]
+    D --> E["labels action=create (Sat) x15<br/>en-US / cs / de"]
+    E --> F["d365fo_file create edt + table SalesPostingAuditLog (7 fields)<br/>then modify add-index SalesId+PostedAt"]
+    F --> G["prepare mode=change CustTable → create table-extension<br/>COLLISION: CustTable.AslExtension already exists from a prior scenario"]
+    G --> H["verify_d365fo_project<br/>confirms AslSalesFormLetterAuditLog + @fm-mcp labels are phantom leftovers (0 on disk) — ignored"]
+    H --> I["d365fo_file modify add-field x2 into the EXISTING CustTable.AslExtension"]
+    I --> J["validate_code syntax+references → d365fo_file create class-extension<br/>SalesFormLetter_Confirm_Extension (credit gate + audit insert)"]
+    J --> K["object_patterns analyze/spec SimpleList → generate_object scaffold cloneFrom=CustGroup<br/>FAILS silently: 0 datasources, bound to stale/wrong table even after re-indexing"]
+    K --> L["hand-authored AxForm XML from the pattern spec<br/>object_patterns validate → conforms"]
+    L --> M["d365fo_file create menu-item-display<br/>+ menu-extension AccountsReceivable → InquiriesAndReports (anchor read from real AxMenu XML)"]
+    M --> N["security_info artifact role/duty<br/>SalesOrderProgressInquire (already on AR clerk role) → d365fo_file create security-privilege"]
+    N --> O["hand-crafted AxSecurityDutyExtension XML<br/>(objectType not exposed by the tool) + manual .rnrproj entry"]
+    O --> P["build_d365fo_project x2 FAIL<br/>artifact-name mismatch, then malformed AxFormDataSource nesting found by diffing vs real CustGroup.xml"]
+    P --> Q["build_d365fo_project FAIL — Retail assembly required<br/>add Retail to Descriptor ModuleReferences"]
+    Q --> R["build_d365fo_project PASS — 0 errors<br/>verify_d365fo_project"]
 ```
 
 **What gets created**
@@ -155,6 +157,8 @@ flowchart TB
 > **Indicative cost & model**
 > Tool calls **~30–42** · New context **~70–110K** · Output **~18–28K** · Billed total (cached) **~140–230K**
 > **Model: Opus 4.8** (Sonnet 4.6 is viable if the posting logic is simple). Anything touching financial posting order and `next` semantics rewards the stronger reasoner.
+>
+> **Measured run** *(one recorded end-to-end run on the `fm-mcp` sandbox; non-token metrics only)* — **Claude Sonnet 5** as the agent. Tool calls **~110** (~90 MCP + ~20 host: Bash/Read/Write/Edit) · Objects **9, build-clean** (`xppc` 0 errors) · 4 builds (3 fail → pass) · 15 labels (en-US/cs/de). This run landed well above the estimate because the "safely changing Microsoft code" framing was true in the fullest sense: `SalesFormLetter.run` was **already** CoC-wrapped by Microsoft's own `SalesFormLetter_InvoiceAppSuite_Extension`, confirming the doc's #1 gotcha before a line was written — the fix was retargeting to the unwrapped `SalesFormLetter_Confirm.run`. A leftover table (`AslSalesFormLetterAuditLog`) and phantom `@fm-mcp:...` labels from an interrupted prior attempt showed up in `prepare`'s related-context hints; `verify_d365fo_project` confirmed 0 bytes on disk for both, so they were ignored and rebuilt clean under the real `Sat` label file. Three real tooling gaps: (1) `generate_object(scaffold, cloneFrom=CustGroup)` silently produced a 0-datasource form still bound to `CustGroup`'s own fields because the target table wasn't in the symbol index yet — re-indexing and retrying returned the identical cached (broken) result, so the form was hand-authored from the `SimpleList` pattern spec instead; (2) that hand-written XML had a `<Methods>` block nested directly inside `<AxFormDataSource>` (valid-looking, wrong location) which silently reset the datasource's `Table` binding to empty — found only by diffing byte-for-byte against a real Microsoft `CustGroup.xml`; (3) `d365fo_file`'s `objectType` enum has no `security-duty-extension`/`security-role-extension` even though `AxSecurityDutyExtension` is a real, common Microsoft object type — worked around by hand-crafting the XML (adding the new privilege to the existing `SalesOrderProgressInquire` duty already on the AR clerk role) and registering it in the `.rnrproj` by hand. The final build error — a missing `Retail` module reference — was a genuine one-line fix to the model's `Descriptor` once traced to `SalesFormLetter.run()` touching a Retail-namespace type. Token/credit cost not captured on this run.
 
 ---
 
@@ -173,25 +177,22 @@ VendCertComplianceReport grouped by CertType. Menu items for the form, the batch
 the report under Procurement > Inquiries. A maintenance privilege + role.
 ```
 
+The diagram below is the **actual tool chain from a recorded run** of this prompt (object names normalized to the generic `VendCompliance` model / `VendCert` prefix used above) — the **cleanest of the runs measured so far**: no environment surprises, single first-try build.
+
 ```mermaid
 flowchart TB
-    A["get_workspace_info"] --> B["object_patterns domain=table<br/>compliance/transaction pattern"]
-    B --> C["labels action=search then create x9 (3 langs)"]
-    C --> D["suggest_edt + d365fo_file action=create<br/>CertNumber EDT + 2 enums"]
-    D --> E["generate_object objectType=table<br/>VendCertificate + VendAccount relation"]
-    E --> F["d365fo_file action=create table"]
-    F --> G["object_patterns domain=form action=analyze<br/>SimpleListDetails"]
-    G --> H["generate_object objectType=form cloneFrom + validate + create"]
-    H --> I["analyze_code mode=patterns scope=extensions<br/>existing SysOperation in this model"]
-    I --> J["generate_object mode=pattern pattern=sysoperation"]
-    J --> K["get_object_info edt + enum<br/>contract parameter types"]
-    K --> L["validate_code references + syntax"]
-    L --> M["d365fo_file action=create x3<br/>Contract / Controller / Service"]
-    M --> N["generate_object objectType=report<br/>VendCertComplianceReport full stack"]
-    N --> O["d365fo_file action=create x5<br/>Tmp / Contract / DP / Controller / Report"]
-    O --> P["d365fo_file action=modify<br/>processReport() query body"]
-    P --> Q["d365fo_file action=create<br/>3 menu items + submenu"]
-    Q --> R["d365fo_file action=create<br/>privilege + role; verify_d365fo_project"]
+    A["get_knowledge<br/>compliance / batch / report conventions"] --> B["labels action=create<br/>22 label IDs x 3 langs"]
+    B --> C["d365fo_file action=create<br/>EDT VendCertNumber + enums VendCertType / VendCertStatus"]
+    C --> D["d365fo_file action=create table VendCertificate<br/>then modify x2: VendAccount relation + table methods"]
+    D --> E["generate_object objectType=form cloneFrom<br/>SimpleListDetails + object_patterns validate"]
+    E --> F["validate_code syntax + references"]
+    F --> G["d365fo_file action=create x3<br/>VendCertExpiryCheck Contract / Service / Controller (SysOperation)"]
+    G --> H["generate_object objectType=report scaffold<br/>VendCertComplianceReport full stack"]
+    H --> I["d365fo_file action=modify x2<br/>widen Tmp unique index: VendAccount → VendAccount+CertNumber"]
+    I --> J["d365fo_file action=modify<br/>DP: enum2str(CertType/Status) + processReport() query"]
+    J --> K["d365fo_file action=create x2<br/>display + action menu items"]
+    K --> L["d365fo_file action=create<br/>privilege VendCertMaintain + role VendComplianceOfficer"]
+    L --> M["build_d365fo_project (async, polled twice)<br/>PASS first-try — 0 errors, ~32s"]
 ```
 
 **What gets created**
@@ -215,6 +216,8 @@ flowchart TB
 > **Indicative cost & model**
 > Tool calls **~35–48** · New context **~80–120K** · Output **~22–32K** · Billed total (cached) **~150–260K**
 > **Model: Sonnet 4.6.** The report scaffold + SysOperation pattern are well-trodden; Sonnet handles them at a fraction of Opus cost. Upgrade only if the batch logic gets genuinely intricate.
+>
+> **Measured run** *(one recorded end-to-end run on the `fm-mcp` sandbox; non-token metrics only)* — **Opus 4.8** as the agent. Tool calls **~35** (~30 MCP + ~5 host) · Objects **18, build-clean** (`xppc` 0 errors) · **1 build, first-try pass** (~26 s compile) · 22 labels (en-US/cs/de). The **cleanest run so far** — no environment surprises, landed at the low end of the estimate. Two scaffold-quality touch-ups were needed and are worth knowing about: `generate_object(objectType=report)` mapped the source **enum fields (`CertType`/`Status`) as `String255`** in the TmpTable (so the DP converts with `enum2str`), and it put a **unique index on only the first field (`VendAccount`)** — widened to `VendAccount`+`CertNumber` so a vendor can hold multiple certificates. The DP's `processReport()` ships as a documented TODO stub, filled after reading the source table — exactly as the gotcha note above says. Token/credit cost not captured on this run.
 
 ---
 
@@ -232,19 +235,26 @@ price/discount calc that applies the tier percent. Security: a setup-maintenance
 privilege wired into the AR setup duty. Labels in en-US, cs, de.
 ```
 
+The diagram below is the **actual tool chain from a recorded run** of this prompt (object names normalized to the generic `CustLoyalty` model / `Cust` prefix used above). It is busier than an idealized plan because real metadata pushed back twice: a leftover enum from an interrupted prior attempt pointed at a non-existent label file, and the sales-discount CoC target turned out to be unbuildable in this environment. See the cost box for the measured numbers.
+
 ```mermaid
-flowchart LR
-    A["labels action=search then create x4"] --> B["d365fo_file action=create<br/>enum CustPriorityTier"]
-    B --> C["d365fo_file action=modify<br/>CustTable extension + field"]
-    C --> D["get_object_info form<br/>exact TabGeneral control name"]
-    D --> E["d365fo_file action=modify x2<br/>CustTable form + CustTableListPage"]
-    E --> F["generate_object objectType=table<br/>CustTierDiscount"]
-    F --> G["object_patterns domain=form action=analyze<br/>SimpleList + create + menu item"]
-    G --> H["extension_info mode=coc + mode=points<br/>sales price/disc method"]
-    H --> I["prepare mode=change + validate_code"]
-    I --> J["d365fo_file action=create<br/>CoC class"]
-    J --> K["security_info mode=coverage<br/>AR setup duty"]
-    K --> L["d365fo_file action=create<br/>privilege + duty extension; verify"]
+flowchart TB
+    A["Grep + Glob<br/>leftover AslCustPriorityTier enum from an interrupted prior run"] --> B["labels action=info + Bash<br/>dangling @fm-mcp: refs — real label file on disk is Sat"]
+    B --> C["labels action=create (Sat)<br/>d365fo_file action=create enum CustPriorityTier"]
+    C --> D["prepare table=CustTable mode=change<br/>d365fo_file action=create table-extension + field"]
+    D --> E["get_object_info form + Grep<br/>resolve exact TabGeneral control name"]
+    E --> F["prepare form CustTable + CustTableListPage<br/>d365fo_file modify/create form-extension x3"]
+    F --> G["search x3 + Glob + Bash x4<br/>CustTableListPage is CustTable in grid view, not a separate form"]
+    G --> H["suggest_edt + d365fo_file create/modify<br/>table CustTierDiscount + findByTier"]
+    H --> I["object_patterns analyze/validate + generate_object<br/>SimpleList form + menu item"]
+    I --> J["extension_info mode=strategy<br/>get_object_info/get_method x8 on SalesLineType / PriceDisc / TradeModuleType"]
+    J --> K["prepare class=PriceDisc + validate_code<br/>d365fo_file create class-extension PriceDisc_Extension"]
+    K --> L["d365fo_file action=create<br/>privilege + duty + role"]
+    L --> M["build_d365fo_project<br/>FAIL — PriceCur EDT unresolvable (missing PricingEngine assembly)"]
+    M --> N["Grep + Edit + Bash<br/>delete the unbuildable PriceDisc_Extension"]
+    N --> O["prepare table=SalesLine + get_object_info x3<br/>retarget to SalesLine.modifiedField (LinePercent)"]
+    O --> P["d365fo_file action=create<br/>class-extension SalesLine_Extension"]
+    P --> Q["build_d365fo_project x2<br/>fail → PASS — 0 errors"]
 ```
 
 **What gets created**
@@ -266,6 +276,8 @@ flowchart LR
 > **Indicative cost & model**
 > Tool calls **~22–32** · New context **~45–75K** · Output **~12–20K** · Billed total (cached) **~90–160K**
 > **Model: Sonnet 4.6** for the build, **Haiku 4.5** for the discovery/extension turns. The cheapest full-stack scenario here — a good first one to run when you're calibrating your own token numbers.
+>
+> **Measured run** *(one recorded end-to-end run on the `fm-mcp` sandbox; non-token metrics only)* — **Opus 4.8** as the agent. Tool calls **~85** (~60 MCP + ~25 host: read/glob/terminal/grep) · Objects **10, build-clean** (`xppc` 0 errors) · 2 builds (91 s fail → 32 s pass) · 3 env-driven retries. This run landed **~2.5× the estimate**, for two reasons worth calling out because they are exactly the "real metadata pushes back" cases these scenarios exist to surface: (1) a missing `PricingEngine` assembly made the `PriceCur` EDT unresolvable, so the sales-line CoC had to retarget from `PriceDisc.parmPrice` to `SalesLine.modifiedField`; (2) `CustTableListPage` is **not** a separate form in this environment — the list page is the `CustTable` form in grid view — so the two form extensions collapse to one. Token/credit cost was not captured on this run; use the indicative row above for budgeting.
 
 ---
 
@@ -283,21 +295,23 @@ management > Inquiries and a view-only security role InventAnalyticsViewer. Walk
 through InventSum/InventTrans structure first so the buckets are correct.
 ```
 
+The diagram below is the **actual tool chain from a recorded run** of this prompt (object names normalized to the generic `InventAnalytics` model / `InventAging` prefix used above). It hit the **most tooling friction of the five scenarios**, including a mid-run session-limit disconnect of the MCP server itself. See the cost box for the measured numbers.
+
 ```mermaid
 flowchart TB
-    A["get_workspace_info"] --> B["get_object_info table x2<br/>InventSum + InventTrans structure"]
-    B --> C["analyze_code mode=api-usage<br/>how aging/dating is computed in std code"]
-    C --> D["object_patterns domain=table<br/>view + computed-column patterns"]
-    D --> E["labels action=search then create x6"]
-    E --> F["generate_object + d365fo_file action=create<br/>InventAgingView (ranges + computed buckets)"]
-    F --> G["get_object_info view<br/>verify fields exposed"]
-    G --> H["d365fo_file action=create<br/>data entity InventAgingEntity (OData, public)"]
-    H --> I["generate_object objectType=report<br/>InventAgingReport full stack"]
-    I --> J["d365fo_file action=create x5<br/>Tmp / Contract / DP / Controller / Report"]
-    J --> K["d365fo_file action=modify<br/>processReport() bucket query"]
-    K --> L["d365fo_file action=create<br/>display + output menu items + submenu"]
-    L --> M["validate_object_naming + d365fo_file action=create<br/>view privilege + role"]
-    M --> N["verify_d365fo_project + build_d365fo_project"]
+    A["Read eval golden (query+view pattern)<br/>get_object_info class InventTrans x2"] --> B["labels action=create<br/>8 IDs x 3 langs"]
+    B --> C["d365fo_file action=create<br/>query InventAgingQuery + view InventAgingView"]
+    C --> D["d365fo_file action=create data entity InventAgingEntity<br/>+ Edit: staging table doesn't exist → DataManagementEnabled=No"]
+    D --> E["generate_object objectType=report scaffold<br/>InventAgingReport full stack"]
+    E --> F["validate_code references<br/>d365fo_file modify DP: bucket query over InventDim join"]
+    F --> G["session limit hit — MCP server disconnected<br/>~15 ToolSearch retries across several turns until tools re-registered"]
+    G --> H["d365fo_file modify DP<br/>finish processReport() + insertAgingRow helper"]
+    H --> I["generate_object objectType=form x2 — both FAIL<br/>'table not found': can't scaffold a form on a VIEW"]
+    I --> J["object_patterns validate<br/>SimpleList form XML authored by hand, then d365fo_file create via xmlContent"]
+    J --> K["d365fo_file action=create<br/>display menu item + privilege + role"]
+    K --> L["build_d365fo_project<br/>FAIL — scaffold emitted non-existent SysOperationMandatoryAttribute"]
+    L --> M["d365fo_file modify<br/>remove the attribute (generated validate() already enforces mandatory)"]
+    M --> N["build_d365fo_project (async, polled)<br/>PASS — 0 errors, ~15s"]
 ```
 
 **What gets created**
@@ -320,6 +334,8 @@ flowchart TB
 > **Indicative cost & model**
 > Tool calls **~28–40** · New context **~60–100K** · Output **~16–26K** · Billed total (cached) **~120–210K**
 > **Model: Sonnet 4.6.** Lots of metadata reading (cheap on Haiku if you split the discovery turns), modest generation. Bump to Opus only if the bucket SQL/computed-column logic gets hairy.
+>
+> **Measured run** *(one recorded end-to-end run on the `fm-mcp` sandbox; non-token metrics only)* — **Opus 4.8** as the agent. Tool calls **~40** (~32 MCP + ~8 host) · Objects **13, build-clean** (`xppc` 0 errors) · 2 builds (88 s fail → 15 s pass) · 8 labels. This scenario hit the **most tooling friction** of the five — four gaps worth flagging: (1) `generate_object(objectType=form)` **cannot target a view** (only tables), so the inquiry form's SimpleList XML was authored directly and validated offline; (2) `generate_object(objectType=data-entity)` enabled DMF staging pointing at a **non-existent staging table** — turned off to match "staging off" (OData/public stays on); (3) the SSRS scaffold emitted a **non-existent `SysOperationMandatoryAttribute`** for the mandatory contract param (the one build error) — removed, since the generated `validate()` already enforces mandatory; (4) the "view with computed buckets" framing isn't realistic — a view's computed columns are static SQL and cannot honor the report's runtime `AsOfDate`, so bucketing correctly lives in the report DP over `InventTrans`+`InventDim`. On the plus side, the data-entity `primaryTable`/`fields` drop bug is gone — the entity came out fully populated (public collection + `ViewMetadata` query). Token/credit cost not captured on this run.
 
 ---
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -550,7 +550,7 @@ export function createXppMcpServer(context: XppServerContext): Server {
         {
           name: 'd365fo_file',
           description: `Create, modify, or generate a D365FO AOT object. Choose an \`action\`:
-• create → write a NEW object file (.xml) into PackagesLocalDirectory (UTF-8 BOM, auto-added to .rnrproj). THIS IS THE WRITE STEP — the task is incomplete until it returns isError=false. Never treat a ⚠️/❌ response as success. Extensions: objectName="BaseObject.PrefixExtension". (Windows)
+• create → write a NEW object file (.xml) into PackagesLocalDirectory (UTF-8 BOM, auto-added to .rnrproj). THIS IS THE WRITE STEP — incomplete until isError=false; treat ⚠️/❌ as failure. Extensions: objectName="BaseObject.PrefixExtension". (Windows)
 • modify → edit an EXISTING object via IMetadataProvider (methods, fields, indexes, relations, controls, enum values, properties). APPLIES IMMEDIATELY, no dry-run — describe the change and get user confirmation BEFORE calling. Revert with undo_last_modification. Requires \`operation\`. (Windows)
 • generate → produce the XML as TEXT only, no file written (Azure/Linux fallback when create reports "requires file system access"). Save it yourself with UTF-8 BOM. ALWAYS try action=create first.
 
@@ -572,6 +572,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
                   'menu-item-action-extension', 'menu-item-output-extension', 'menu-extension',
                   'menu-item-display', 'menu-item-action', 'menu-item-output', 'menu',
                   'security-privilege', 'security-duty', 'security-role',
+                  'security-duty-extension', 'security-role-extension',
                   'business-event', 'tile', 'kpi', 'map',
                 ],
                 description:

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -62,6 +62,7 @@ const CreateD365FileArgsSchema = z.object({
       'menu-item-display-extension', 'menu-item-action-extension', 'menu-item-output-extension',
       'menu', 'menu-extension',
       'security-privilege', 'security-duty', 'security-role',
+      'security-duty-extension', 'security-role-extension',
       'business-event', 'tile', 'kpi', 'map',
     ])
     .describe('Type of D365FO object to create'),
@@ -1469,6 +1470,10 @@ ${defaultParamGroupXml}
         return this.generateAxSecurityDutyXml(objectName, properties);
       case 'security-role':
         return this.generateAxSecurityRoleXml(objectName, properties);
+      case 'security-duty-extension':
+        return this.generateAxSecurityDutyExtensionXml(objectName, properties);
+      case 'security-role-extension':
+        return this.generateAxSecurityRoleExtensionXml(objectName, properties);
       case 'business-event':
         return XmlTemplateGenerator.generateBusinessEventXml(objectName, properties);
       case 'tile':
@@ -2657,6 +2662,45 @@ ${this.securityRefContainer('Privileges', 'AxSecurityRolePermissionSet', privile
   }
 
   /**
+   * Generate AxSecurityDutyExtension XML — adds privileges to an EXISTING (often
+   * Microsoft-owned) duty without overlaying it. Real Microsoft object type, e.g.
+   * K:\...\ApplicationCommon\AxSecurityDutyExtension\BatchJobMaintain.ApplicationCommon.xml.
+   * Name convention: "<BaseDuty>.<PrefixOrModel>Extension" (same dot-notation as
+   * menu-extension / table-extension — see DOT_NOTATION_EXTENSION_TYPES).
+   * properties.privileges – privilege names to add to the base duty (array or comma-separated).
+   */
+  static generateAxSecurityDutyExtensionXml(name: string, properties?: Record<string, any>): string {
+    const privileges = this.normalizeNameList(properties?.privileges);
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDutyExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
+\t<PropertyModifications />
+</AxSecurityDutyExtension>`;
+  }
+
+  /**
+   * Generate AxSecurityRoleExtension XML — adds duties and/or privileges to an
+   * EXISTING (often Microsoft-owned) role without overlaying it. Real Microsoft
+   * object type, e.g. K:\...\ApplicationCommon\AxSecurityRoleExtension\SystemUser.ApplicationCommon.xml.
+   * Name convention: "<BaseRole>.<PrefixOrModel>Extension".
+   * properties.duties     – duty names to add to the base role (array or comma-separated).
+   * properties.privileges – privilege names to add directly to the base role.
+   */
+  static generateAxSecurityRoleExtensionXml(name: string, properties?: Record<string, any>): string {
+    const duties = this.normalizeNameList(properties?.duties);
+    const privileges = this.normalizeNameList(properties?.privileges);
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRoleExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<DirectAccessPermissions />
+${this.securityRefContainer('Duties', 'AxSecurityDutyReference', duties)}
+${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
+\t<PropertyModifications />
+</AxSecurityRoleExtension>`;
+  }
+
+  /**
    * Generate BusinessEventsContract class XML (AxClass) for a Business Event.
    * The class extends BusinessEventsBase and includes a companion contract class.
    */
@@ -2919,6 +2963,8 @@ export class ProjectFileManager {
       'security-privilege': 'Security Privileges',
       'security-duty': 'Security Duties',
       'security-role': 'Security Roles',
+      'security-duty-extension': 'Security Duties',
+      'security-role-extension': 'Security Roles',
       'business-event': 'Classes',
       'label-file': 'Label Files',
       tile: 'Tiles',
@@ -2960,6 +3006,8 @@ export class ProjectFileManager {
       'security-privilege': 'AxSecurityPrivilege',
       'security-duty': 'AxSecurityDuty',
       'security-role': 'AxSecurityRole',
+      'security-duty-extension': 'AxSecurityDutyExtension',
+      'security-role-extension': 'AxSecurityRoleExtension',
       'business-event': 'AxClass',
       'label-file': 'AxLabelFile',
       tile: 'AxTile',
@@ -3616,6 +3664,7 @@ export async function handleCreateD365File(
       'table-extension', 'form-extension', 'enum-extension', 'edt-extension',
       'data-entity-extension', 'menu-item-display-extension', 'menu-item-action-extension',
       'menu-item-output-extension', 'menu-extension',
+      'security-duty-extension', 'security-role-extension',
     ]);
     if (DOT_NOTATION_EXTENSION_TYPES.has(args.objectType) && !effectiveObjectName.includes('.')) {
       effectiveObjectName = `${effectiveObjectName}.Extension`;
@@ -3693,6 +3742,8 @@ export async function handleCreateD365File(
       'security-privilege': 'AxSecurityPrivilege',
       'security-duty': 'AxSecurityDuty',
       'security-role': 'AxSecurityRole',
+      'security-duty-extension': 'AxSecurityDutyExtension',
+      'security-role-extension': 'AxSecurityRoleExtension',
       'business-event': 'AxClass',
       'label-file': 'AxLabelFile',
       tile: 'AxTile',

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -25,7 +25,8 @@ const GenerateD365XmlArgsSchema = z.object({
       'menu-item-display', 'menu-item-action', 'menu-item-output',
       'menu-item-display-extension', 'menu-item-action-extension', 'menu-item-output-extension',
       'menu', 'menu-extension',
-      'security-privilege', 'security-duty', 'security-role', 'map',
+      'security-privilege', 'security-duty', 'security-role',
+      'security-duty-extension', 'security-role-extension', 'map',
     ])
     .describe('Type of D365FO object'),
   objectName: z
@@ -1066,6 +1067,10 @@ ${defaultParamGroupXml}
         return this.generateAxSecurityDutyXml(objectName, properties);
       case 'security-role':
         return this.generateAxSecurityRoleXml(objectName, properties);
+      case 'security-duty-extension':
+        return this.generateAxSecurityDutyExtensionXml(objectName, properties);
+      case 'security-role-extension':
+        return this.generateAxSecurityRoleExtensionXml(objectName, properties);
       default:
         throw new Error(`Unsupported object type: ${objectType}`);
     }
@@ -1408,6 +1413,52 @@ ${relationsXml}
 \t<SubRoles />
 </AxSecurityRole>`;
   }
+
+  /** Normalize a name list that may arrive as an array or a comma/semicolon/newline-separated string. */
+  private static normalizeNameList(value: any): string[] {
+    if (!value) return [];
+    const arr = Array.isArray(value) ? value : String(value).split(/[,;\n]+/);
+    return arr.map((s: any) => String(s).trim()).filter((s: string) => s.length > 0);
+  }
+
+  private static refContainer(container: string, childTag: string, names: string[]): string {
+    if (names.length === 0) return `\t<${container} />`;
+    const children = names
+      .map(n => `\t\t<${childTag}>\n\t\t\t<Name>${n}</Name>\n\t\t</${childTag}>`)
+      .join('\n');
+    return `\t<${container}>\n${children}\n\t</${container}>`;
+  }
+
+  /**
+   * Generate AxSecurityDutyExtension XML — adds privileges to an EXISTING duty
+   * without overlaying it. Name convention: "<BaseDuty>.<PrefixOrModel>Extension".
+   */
+  static generateAxSecurityDutyExtensionXml(name: string, properties?: Record<string, any>): string {
+    const privileges = this.normalizeNameList(properties?.privileges);
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDutyExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+${this.refContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
+\t<PropertyModifications />
+</AxSecurityDutyExtension>`;
+  }
+
+  /**
+   * Generate AxSecurityRoleExtension XML — adds duties/privileges to an EXISTING
+   * role without overlaying it. Name convention: "<BaseRole>.<PrefixOrModel>Extension".
+   */
+  static generateAxSecurityRoleExtensionXml(name: string, properties?: Record<string, any>): string {
+    const duties = this.normalizeNameList(properties?.duties);
+    const privileges = this.normalizeNameList(properties?.privileges);
+    return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRoleExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<DirectAccessPermissions />
+${this.refContainer('Duties', 'AxSecurityDutyReference', duties)}
+${this.refContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
+\t<PropertyModifications />
+</AxSecurityRoleExtension>`;
+  }
 }
 
 /**
@@ -1463,6 +1514,8 @@ export async function handleGenerateD365Xml(
       'security-privilege': 'AxSecurityPrivilege',
       'security-duty': 'AxSecurityDuty',
       'security-role': 'AxSecurityRole',
+      'security-duty-extension': 'AxSecurityDutyExtension',
+      'security-role-extension': 'AxSecurityRoleExtension',
       map: 'AxMap',
     };
 

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -152,6 +152,47 @@ export function cloneFromPatternMismatchWarning(
   );
 }
 
+/**
+ * Pre-clone table-mapping coverage check (pure — no DB/fs access).
+ *
+ * `getTableFields(table)` must return the field-name list for a table, or `null`
+ * when the table is unknown to the caller (e.g. not yet in the symbol index).
+ * Two independent failure classes, checked separately:
+ *   - unknownTargets: the MAPPED target table has no known fields at all — cloning
+ *     cannot verify overlap, and (per cloneFormXml's own "unknown table → keep
+ *     fields" fallback) would silently leave that datasource bound to the SOURCE
+ *     table's fields instead of failing. Always worth surfacing loudly.
+ *   - poorOverlap: both tables are known, but share too few fields (<30%) for the
+ *     clone to be structurally meaningful.
+ * Source tables with <3 known fields are skipped (too little signal either way).
+ */
+export function checkTableMappingCoverage(
+  tableMapping: Record<string, string>,
+  getTableFields: (table: string) => string[] | null,
+): { unknownTargets: string[]; poorOverlap: string[] } {
+  const unknownTargets: string[] = [];
+  const poorOverlap: string[] = [];
+  for (const [srcTable, tgtTable] of Object.entries(tableMapping)) {
+    if (!tgtTable || srcTable.toLowerCase() === tgtTable.toLowerCase()) continue;
+    const srcFields = getTableFields(srcTable);
+    const tgtFields = getTableFields(tgtTable);
+    if (!tgtFields || tgtFields.length === 0) {
+      unknownTargets.push(tgtTable);
+      continue;
+    }
+    if (!srcFields || srcFields.length < 3) continue;
+    const tgtFieldSet = new Set(tgtFields.map((f) => f.toLowerCase()));
+    const shared = srcFields.filter((f) => tgtFieldSet.has(f.toLowerCase()));
+    const ratio = shared.length / srcFields.length;
+    if (ratio < 0.3) {
+      poorOverlap.push(
+        `${srcTable} → ${tgtTable}: ${shared.length}/${srcFields.length} fields shared (${Math.round(ratio * 100)} %)`,
+      );
+    }
+  }
+  return { unknownTargets: [...new Set(unknownTargets)], poorOverlap };
+}
+
 export async function handleGenerateSmartForm(
   args: GenerateSmartFormArgs,
   symbolIndex: XppSymbolIndex
@@ -590,21 +631,37 @@ export async function handleGenerateSmartForm(
     // low, cloning will strip most controls and produce a useless form.
     // Fail-fast here rather than returning a gutted result.
     if (tableMapping && Object.keys(tableMapping).length > 0) {
-      const poorOverlap: string[] = [];
-      for (const [srcTable, tgtTable] of Object.entries(tableMapping as Record<string, string>)) {
-        if (!tgtTable || srcTable.toLowerCase() === tgtTable.toLowerCase()) continue;
-        const srcFields = fieldStmt.all(srcTable) as Array<{ name: string }>;
-        const tgtFields = fieldStmt.all(tgtTable) as Array<{ name: string }>;
-        // Unknown table in index → field list is unavailable; skip check for that pair.
-        if (srcFields.length < 3 || tgtFields.length === 0) continue;
-        const tgtFieldSet = new Set(tgtFields.map((f) => f.name.toLowerCase()));
-        const shared = srcFields.filter((f) => tgtFieldSet.has(f.name.toLowerCase()));
-        const ratio = shared.length / srcFields.length;
-        if (ratio < 0.3) {
-          poorOverlap.push(
-            `${srcTable} → ${tgtTable}: ${shared.length}/${srcFields.length} fields shared (${Math.round(ratio * 100)} %)`,
-          );
-        }
+      // Found live 2026-07-01 (usage-examples eval, scenario 2): cloneFrom="CustGroup"
+      // + tableMapping to a just-created table not yet in the symbol index silently
+      // produced a form with 0 datasources/controls, self-reported as success —
+      // getTableFields returning null/empty for an unknown table used to make
+      // cloneFormXml leave that datasource's fields untouched (still bound to the
+      // SOURCE table) instead of failing. checkTableMappingCoverage now catches this
+      // as `unknownTargets`, separate from the pre-existing `poorOverlap` check.
+      const { unknownTargets, poorOverlap } = checkTableMappingCoverage(
+        tableMapping as Record<string, string>,
+        (table: string) => {
+          const rows = fieldStmt.all(table) as Array<{ name: string }>;
+          return rows.length > 0 ? rows.map((r) => r.name) : null;
+        },
+      );
+      if (unknownTargets.length > 0) {
+        return {
+          content: [{
+            type: 'text',
+            text:
+              `❌ PRE-CLONE CHECK — target table${unknownTargets.length > 1 ? 's' : ''} not found in the symbol index: ` +
+              `${unknownTargets.join(', ')}.\n\n` +
+              `Cloning cannot verify field overlap against an unindexed table, and the clone would silently keep ` +
+              `"${cloneFrom}"'s OWN fields unmapped instead of failing — producing a form that looks bound to your ` +
+              `table but whose datasource/controls still reference the source table's fields.\n\n` +
+              `**Fix — choose one:**\n` +
+              `1. If ${unknownTargets.join(', ')} was just created this session, index it first, then retry:\n` +
+              `   \`update_symbol_index(filePath="<absolute path to ${unknownTargets[0]}.xml>")\`\n` +
+              `2. Check the table name for a typo with \`search("${unknownTargets[0]}", type="table")\`.`,
+          }],
+          isError: true,
+        };
       }
       if (poorOverlap.length > 0) {
         const targetList = Object.values(tableMapping as Record<string, string>).filter(Boolean).join(', ');

--- a/src/tools/prepareChange.ts
+++ b/src/tools/prepareChange.ts
@@ -42,7 +42,7 @@ export const prepareChangeArgsSchema = z.object({
   ),
   objectType: z.enum([
     'class', 'table', 'form', 'query', 'view', 'enum', 'edt',
-    'data-entity', 'map', 'report',
+    'data-entity', 'map', 'report', 'security-duty', 'security-role',
   ]).optional().describe(
     'D365FO object type. Auto-detected from the symbol index when omitted.',
   ),
@@ -184,6 +184,12 @@ function fetchStrategy(objectType: string | undefined): string {
     strategies.push('• Form datasource extension [ExtensionOf(formDataSourceStr(...))] — CoC on DS methods');
   } else if (objectType === 'map') {
     strategies.push('• Map extension class [ExtensionOf(mapStr(...))] — add/wrap map methods');
+  } else if (objectType === 'security-duty') {
+    strategies.push('• security-duty-extension (AxSecurityDutyExtension) — add privileges to this EXISTING duty without overlaying it');
+    strategies.push('• New standalone security-duty — only if this duty is not a fit for the new privilege at all');
+  } else if (objectType === 'security-role') {
+    strategies.push('• security-role-extension (AxSecurityRoleExtension) — add duties/privileges to this EXISTING role without overlaying it');
+    strategies.push('• New standalone security-role — only if this role is not a fit for the new duty at all');
   } else {
     strategies.push('• Extension class via [ExtensionOf] — check the object type for supported extension mechanisms');
   }

--- a/src/tools/verifyD365Project.ts
+++ b/src/tools/verifyD365Project.ts
@@ -21,6 +21,7 @@ const OBJECT_TYPES = [
   'menu-item-display-extension', 'menu-item-action-extension', 'menu-item-output-extension',
   'menu', 'menu-extension',
   'security-privilege', 'security-duty', 'security-role',
+  'security-duty-extension', 'security-role-extension',
 ] as const;
 
 const objectFolderMap: Record<string, string> = {
@@ -49,6 +50,8 @@ const objectFolderMap: Record<string, string> = {
   'security-privilege':           'AxSecurityPrivilege',
   'security-duty':                'AxSecurityDuty',
   'security-role':                'AxSecurityRole',
+  'security-duty-extension':      'AxSecurityDutyExtension',
+  'security-role-extension':      'AxSecurityRoleExtension',
 };
 
 // Reverse of objectFolderMap: AOT folder name (lowercased) → object type. Used to

--- a/src/utils/callDedup.ts
+++ b/src/utils/callDedup.ts
@@ -20,6 +20,17 @@ export const DEDUP_EXCLUDED_TOOLS = new Set([
   'run_bp_check', 'run_systest_class', 'review_workspace_changes',
   'verify_d365fo_project', 'get_workspace_info',
   'prepare', // issues fresh grounding tokens
+  // generate_object(mode="scaffold") writes the object file directly to disk in
+  // traditional/Windows mode (same write-tool semantics as d365fo_file) AND reads
+  // live, mutable state (the symbol index) via cloneFrom/tableMapping/fieldsHint.
+  // Caching it by input args alone is unsound: a legitimate retry after
+  // update_symbol_index() (or after fixing a copyFrom/cloneFrom table) served the
+  // IDENTICAL stale/broken result from the dedup cache instead of re-reading the
+  // now-current index — found live 2026-07-01 (usage-examples eval, scenario 2):
+  // cloneFrom="CustGroup" + tableMapping to a brand-new table not yet indexed
+  // silently produced a 0-datasource form, and re-running after indexing the
+  // table returned the exact same broken cached result.
+  'generate_object',
 ]);
 
 interface DedupEntry {

--- a/tests/bridge/canBridgeCreate.test.ts
+++ b/tests/bridge/canBridgeCreate.test.ts
@@ -14,6 +14,14 @@ describe('canBridgeCreate', () => {
     expect(canBridgeCreate('security-role')).toBe(false);
   });
 
+  it('excludes security-duty-extension/security-role-extension (same TOOL_DEFECT class)', () => {
+    // These are always written via the local XML generator (see
+    // XmlTemplateGenerator.generateAxSecurityDutyExtensionXml/RoleExtensionXml in
+    // createD365File.ts) — never routed through the bridge's flat properties map.
+    expect(canBridgeCreate('security-duty-extension')).toBe(false);
+    expect(canBridgeCreate('security-role-extension')).toBe(false);
+  });
+
   it('excludes query/view (TOOL_DEFECT)', () => {
     // Regression: the bridge accepted dataSource/query as scalar properties
     // and reported success, but produced an empty query/view that can select

--- a/tests/tools/clonePatternMismatch.test.ts
+++ b/tests/tools/clonePatternMismatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cloneFromPatternMismatchWarning } from '../../src/tools/generateSmartForm';
+import { cloneFromPatternMismatchWarning, checkTableMappingCoverage } from '../../src/tools/generateSmartForm';
 
 /** Minimal AxForm shell carrying a Design-level <Pattern>. */
 function formXmlWithPattern(pattern: string): string {
@@ -48,5 +48,76 @@ describe('cloneFromPatternMismatchWarning', () => {
     expect(
       cloneFromPatternMismatchWarning('SimpleListDetails', '<AxForm><Design/></AxForm>', 'X'),
     ).toBeNull();
+  });
+});
+
+// ─── checkTableMappingCoverage ────────────────────────────────────────────────
+// Regression coverage for the 2026-07-01 usage-examples eval finding (scenario 2):
+// cloneFrom="CustGroup" + tableMapping to a brand-new table not yet in the symbol
+// index silently produced a 0-datasource form (getTableFields returned null/empty
+// for the unknown target, which used to be treated the same as "skip the check").
+describe('checkTableMappingCoverage', () => {
+  const CUSTGROUP_FIELDS = ['CustGroup', 'Name', 'PaymTermId', 'ClearingPeriod', 'TaxGroupId'];
+
+  it('flags a target table with zero known fields as unknown (not a silent skip)', () => {
+    const result = checkTableMappingCoverage(
+      { CustGroup: 'AslSalesPostingAuditLog' },
+      (table) => (table === 'CustGroup' ? CUSTGROUP_FIELDS : []),
+    );
+    expect(result.unknownTargets).toEqual(['AslSalesPostingAuditLog']);
+    expect(result.poorOverlap).toEqual([]);
+  });
+
+  it('treats a null field lookup the same as empty (unknown target)', () => {
+    const result = checkTableMappingCoverage(
+      { CustGroup: 'BrandNewTable' },
+      (table) => (table === 'CustGroup' ? CUSTGROUP_FIELDS : null),
+    );
+    expect(result.unknownTargets).toEqual(['BrandNewTable']);
+  });
+
+  it('dedupes repeated unknown targets across multiple mapping pairs', () => {
+    const result = checkTableMappingCoverage(
+      { TableA: 'SharedUnknown', TableB: 'SharedUnknown' },
+      (table) => (table === 'SharedUnknown' ? [] : ['SomeField']),
+    );
+    expect(result.unknownTargets).toEqual(['SharedUnknown']);
+  });
+
+  it('flags poor overlap when both tables are known but barely share fields', () => {
+    const result = checkTableMappingCoverage(
+      { CustGroup: 'SalesLine' },
+      (table) => (table === 'CustGroup' ? CUSTGROUP_FIELDS : ['SalesId', 'ItemId', 'SalesQty', 'LineNum']),
+    );
+    expect(result.unknownTargets).toEqual([]);
+    expect(result.poorOverlap).toHaveLength(1);
+    expect(result.poorOverlap[0]).toContain('CustGroup → SalesLine');
+  });
+
+  it('passes clean when tables share enough fields', () => {
+    const result = checkTableMappingCoverage(
+      { CustGroup: 'VendGroup' },
+      (table) => (table === 'CustGroup' ? CUSTGROUP_FIELDS : [...CUSTGROUP_FIELDS, 'ExtraVendField']),
+    );
+    expect(result.unknownTargets).toEqual([]);
+    expect(result.poorOverlap).toEqual([]);
+  });
+
+  it('skips self-mapped and empty target entries', () => {
+    const result = checkTableMappingCoverage(
+      { CustGroup: 'CustGroup', VendGroup: '' },
+      () => [],
+    );
+    expect(result.unknownTargets).toEqual([]);
+    expect(result.poorOverlap).toEqual([]);
+  });
+
+  it('skips the overlap check when the source table itself is unknown/too small', () => {
+    const result = checkTableMappingCoverage(
+      { UnknownSource: 'AslSalesPostingAuditLog' },
+      (table) => (table === 'AslSalesPostingAuditLog' ? ['SalesId', 'PostingType'] : null),
+    );
+    expect(result.unknownTargets).toEqual([]);
+    expect(result.poorOverlap).toEqual([]);
   });
 });

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -293,6 +293,34 @@ describe('generate_d365fo_xml', () => {
     );
     expect(result.isError).toBe(true);
   });
+
+  it('generates security-duty-extension XML (Azure/Linux fallback for the create gap)', async () => {
+    const result = await handleGenerateD365Xml(
+      req('generate_d365fo_xml', {
+        objectType: 'security-duty-extension',
+        objectName: 'SalesOrderProgressInquire.MyExtension',
+        modelName: 'MyModel',
+        properties: { privileges: ['MyAuditLogView'] },
+      }),
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('<AxSecurityDutyExtension');
+    expect(result.content[0].text).toContain('<Name>MyAuditLogView</Name>');
+  });
+
+  it('generates security-role-extension XML (Azure/Linux fallback for the create gap)', async () => {
+    const result = await handleGenerateD365Xml(
+      req('generate_d365fo_xml', {
+        objectType: 'security-role-extension',
+        objectName: 'SystemUser.MyExtension',
+        modelName: 'MyModel',
+        properties: { duties: ['MyAuditInquireDuty'] },
+      }),
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('<AxSecurityRoleExtension');
+    expect(result.content[0].text).toContain('<Name>MyAuditInquireDuty</Name>');
+  });
 });
 
 // ─── XmlTemplateGenerator.generateAxDataEntityXml ───────────────────────────
@@ -568,6 +596,59 @@ describe('XmlTemplateGenerator security duty/role generators', () => {
     expect(xml).toContain('<AxSecurityRoleDutyPermission>\n\t\t\t<Name>MyDuty1</Name>');
     expect(xml).toContain('<Name>MyDuty2</Name>');
     expect(xml).not.toContain('<Duties />');
+  });
+});
+
+// ─── security-duty-extension / security-role-extension generators ───────────
+// AxSecurityDutyExtension/AxSecurityRoleExtension add privileges/duties to an
+// EXISTING (often Microsoft-owned) duty/role without overlaying it — confirmed
+// against real shipped objects, e.g.
+// ApplicationCommon\AxSecurityDutyExtension\BatchJobMaintain.ApplicationCommon.xml
+// and ApplicationCommon\AxSecurityRoleExtension\SystemUser.ApplicationCommon.xml.
+describe('XmlTemplateGenerator security duty/role EXTENSION generators', () => {
+  it('emits AxSecurityPrivilegeReference entries on a duty extension', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityDutyExtensionXml(
+      'SalesOrderProgressInquire.AslExtension',
+      { privileges: ['AslSalesPostingAuditLogView'] },
+    );
+    expect(xml).toContain('<AxSecurityDutyExtension');
+    expect(xml).toContain('<Name>SalesOrderProgressInquire.AslExtension</Name>');
+    expect(xml).toContain('<AxSecurityPrivilegeReference>\n\t\t\t<Name>AslSalesPostingAuditLogView</Name>');
+    expect(xml).toContain('<PropertyModifications />');
+    // No <Label> — duty extensions don't carry one (only the base duty does).
+    expect(xml).not.toContain('<Label>');
+  });
+
+  it('accepts a comma-separated privilege string on a duty extension', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityDutyExtensionXml('MyDuty.Extension', {
+      privileges: 'MyView, MyMaintain',
+    });
+    expect(xml).toContain('<Name>MyView</Name>');
+    expect(xml).toContain('<Name>MyMaintain</Name>');
+  });
+
+  it('keeps an empty self-closing Privileges when none are given on a duty extension', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityDutyExtensionXml('MyDuty.Extension', {});
+    expect(xml).toContain('<Privileges />');
+  });
+
+  it('emits duty + privilege references on a role extension', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityRoleExtensionXml(
+      'SystemUser.AslExtension',
+      { duties: ['MyDuty1'], privileges: ['MyPrivilege1'] },
+    );
+    expect(xml).toContain('<AxSecurityRoleExtension');
+    expect(xml).toContain('<Name>SystemUser.AslExtension</Name>');
+    expect(xml).toContain('<DirectAccessPermissions />');
+    expect(xml).toContain('<AxSecurityDutyReference>\n\t\t\t<Name>MyDuty1</Name>');
+    expect(xml).toContain('<AxSecurityPrivilegeReference>\n\t\t\t<Name>MyPrivilege1</Name>');
+    expect(xml).toContain('<PropertyModifications />');
+  });
+
+  it('keeps empty self-closing Duties/Privileges when none are given on a role extension', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityRoleExtensionXml('MyRole.Extension', {});
+    expect(xml).toContain('<Duties />');
+    expect(xml).toContain('<Privileges />');
   });
 });
 

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -580,6 +580,52 @@ describe('create_d365fo_file', () => {
     expect(text).not.toMatch(/MyModelPurchTable|[A-Za-z]+PurchTable\.xml/);
   });
 
+  it('supports security-duty-extension: dot-notation naming + AxSecurityDutyExtension folder + XML', async () => {
+    // Gap found live (2026-07-01 usage-examples eval, scenario 2): d365fo_file had no
+    // security-duty-extension/security-role-extension objectType even though
+    // AxSecurityDutyExtension/AxSecurityRoleExtension are real, common Microsoft AOT
+    // types (e.g. ApplicationCommon\AxSecurityDutyExtension\BatchJobMaintain...xml) used
+    // to add a privilege to an EXISTING duty without overlaying it. Verifies the bare
+    // base name ("SalesOrderProgressInquire") follows the same dot-notation path as
+    // menu-extension/table-extension, lands in the AxSecurityDutyExtension folder, and
+    // the written XML references the given privilege.
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'security-duty-extension',
+        objectName: 'SalesOrderProgressInquire',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: { privileges: ['ContosoSalesPostingAuditLogView'] },
+      }),
+    );
+    const text: string = result.content[0].text;
+    expect((result as any).isError).not.toBe(true);
+    expect(text).toMatch(/AxSecurityDutyExtension/);
+    expect(text).toMatch(/SalesOrderProgressInquire[.][^/\\]*[Ee]xtension/);
+    expect(text).not.toMatch(/[A-Za-z]+SalesOrderProgressInquire\.xml/);
+  });
+
+  it('supports security-role-extension: dot-notation naming + AxSecurityRoleExtension folder + XML', async () => {
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'security-role-extension',
+        objectName: 'SystemUser',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: { duties: ['ContosoAuditInquireDuty'] },
+      }),
+    );
+    const text: string = result.content[0].text;
+    expect((result as any).isError).not.toBe(true);
+    expect(text).toMatch(/AxSecurityRoleExtension/);
+    expect(text).toMatch(/SystemUser[.][^/\\]*[Ee]xtension/);
+    expect(text).not.toMatch(/[A-Za-z]+SystemUser\.xml/);
+  });
+
   it('auto-converts bare class-extension name to _Extension form (Case D fix)', async () => {
     // Bug: objectType="class-extension", objectName="SalesFormLetter" (no "_Extension"
     // suffix) used to have no dot and not end in "_Extension", so it fell into

--- a/tests/tools/projectFileManager.test.ts
+++ b/tests/tools/projectFileManager.test.ts
@@ -149,6 +149,8 @@ describe('ProjectFileManager', () => {
         ['security-privilege', 'AxSecurityPrivilege', 'Security Privileges'],
         ['security-duty', 'AxSecurityDuty', 'Security Duties'],
         ['security-role', 'AxSecurityRole', 'Security Roles'],
+        ['security-duty-extension', 'AxSecurityDutyExtension', 'Security Duties'],
+        ['security-role-extension', 'AxSecurityRoleExtension', 'Security Roles'],
         ['business-event', 'AxClass', 'Classes'],
         ['label-file', 'AxLabelFile', 'Label Files'],
         ['tile', 'AxTile', 'Tiles'],

--- a/tests/utils/callDedup.test.ts
+++ b/tests/utils/callDedup.test.ts
@@ -54,6 +54,15 @@ describe('dedup cache', () => {
     expect(DEDUP_EXCLUDED_TOOLS.has('search')).toBe(false);
     expect(DEDUP_EXCLUDED_TOOLS.has('get_table_info')).toBe(false);
   });
+
+  it('excludes generate_object from dedup (writes to disk + reads live symbol-index state)', () => {
+    // Regression (2026-07-01 usage-examples eval, scenario 2): generate_object(mode="scaffold",
+    // objectType="form", cloneFrom=...) writes the file directly to disk in traditional/Windows
+    // mode, and its cloneFrom/tableMapping resolution depends on the CURRENT symbol-index state.
+    // A retry after update_symbol_index() used to be served the stale/broken cached result
+    // instead of re-reading the now-current index.
+    expect(DEDUP_EXCLUDED_TOOLS.has('generate_object')).toBe(true);
+  });
 });
 
 describe('appendNote', () => {


### PR DESCRIPTION
## Summary
- Validated USAGE_EXAMPLES.md scenario 2 ("sales credit review + audit") end-to-end in the `fm-mcp` sandbox — build-clean, `xppc` 0 errors — and recorded the measured run + actual tool chain diagram.
- That run surfaced two real MCP-server tool gaps, fixed here:
  - `d365fo_file` (and its `generate` mirror) had no `security-duty-extension`/`security-role-extension` objectType, even though `AxSecurityDutyExtension`/`AxSecurityRoleExtension` are real, common Microsoft AOT types used to add a privilege/duty to an **existing** duty/role without overlaying it.
  - `generate_object(mode="scaffold", cloneFrom=...)` writes to disk (same write semantics as `d365fo_file`) but wasn't excluded from the duplicate-call dedup cache, so a legitimate retry after `update_symbol_index()` was served a stale/broken cached result. Root-caused and fixed the underlying scaffold bug too: an unindexed target table used to silently fall through and leave the clone bound to the *source* table's fields instead of failing loudly.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — 1428/1428 tests passing (15 new regression tests added)
- [x] Tool-schema token budget guard tests still pass (trimmed unrelated description text to make room)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5rzqEEnjAU9d95iuZg8g