### PR TITLE
feat(cli): interactive management CLI (setup, doctor, start, update, index, instance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ Pick your path:
 
 Full walkthrough with all scenarios: **[docs/QUICK_START.md](docs/QUICK_START.md)**
 
+### Interactive setup (recommended)
+
+After cloning and `npm install`, the management CLI walks you through everything else — scenario selection, C# bridge build, `.env` configuration, index build — and prints the `.mcp.json` block to paste:
+
+```powershell
+git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
+cd K:\d365fo-mcp-server
+npm install
+npm run setup        # first-time setup wizard
+npm run doctor       # health check — verifies Node, build, index, bridge
+```
+
+Day-to-day management runs through the same CLI (`npx d365fo-mcp` or `npm run cli --`): `start`, `update`, `index`, and `instance add/list/run/rebuild/upgrade` for multi-instance setups. Every command works non-interactively with arguments, or asks with predefined choices when run bare.
+
+### Manual setup
+
 ```powershell
 # Local / hybrid install (on the D365FO VM)
 git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -4,6 +4,8 @@ Everything a **developer** needs to connect GitHub Copilot (VS 2022 ≥ 17.14 / 
 
 > Fast path: [QUICK_START.md](QUICK_START.md) · Azure deployment (admins): [SETUP_AZURE.md](SETUP_AZURE.md) · Claude Code: [CLAUDE_CODE_SETUP.md](CLAUDE_CODE_SETUP.md)
 
+> **Prefer a guided setup?** After `git clone` + `npm install`, run `npm run setup` — the interactive management CLI walks through the scenario choice below, builds the bridge and the index, and prints the `.mcp.json` block. `npm run doctor` verifies an existing installation. Day-to-day: `npx d365fo-mcp start|update|index|instance …` (each command also runs non-interactively with arguments). The PowerShell scripts referenced below keep working as before.
+
 ---
 
 ## Choosing a scenario
@@ -183,6 +185,8 @@ One machine, several D365FO clients — each instance gets its own `.env`, datab
 .\instances\rebuild-instance.ps1 clientA   # extract + build index for the instance (--all for all)
 .\instances\run-instance.ps1 clientA       # start on its port
 ```
+
+Or the CLI equivalents: `npx d365fo-mcp instance add|rebuild|run|upgrade [name]` (interactive when the name is omitted; `instance upgrade` repoints an instance after a UDE version upgrade).
 
 Point a per-solution `.mcp.json` at the right port:
 

--- a/instances/run-instance.ps1
+++ b/instances/run-instance.ps1
@@ -106,7 +106,8 @@ Write-Host "Starting instance: $($selected.Name)" -ForegroundColor Green
 Write-Host "Config: $envFile" -ForegroundColor DarkGray
 Write-Host ''
 
-node (Join-Path $repoRoot 'dist\index.js')  if ($LASTEXITCODE -ne 0) {
+node (Join-Path $repoRoot 'dist\index.js')
+if ($LASTEXITCODE -ne 0) {
     Write-Host "ERROR: Server exited with code $LASTEXITCODE" -ForegroundColor Red
     exit $LASTEXITCODE
-  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",
+        "@clack/prompts": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.27.0",
         "@types/compression": "^1.8.1",
         "better-sqlite3": "^12.9.0",
+        "commander": "^15.0.0",
         "compression": "^1.8.1",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -68,6 +70,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
       "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -129,6 +132,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
       "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -299,27 +303,32 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
+    "node_modules/@clack/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
+    "node_modules/@clack/prompts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
+      "integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@clack/core": "1.4.2",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1012,9 +1021,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1032,9 +1038,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,9 +1055,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1072,9 +1072,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,9 +1089,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1112,9 +1106,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1420,6 +1411,7 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -1894,6 +1886,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/component-emitter": {
@@ -2409,6 +2410,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
@@ -2424,6 +2440,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -2765,6 +2790,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3168,9 +3194,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3192,9 +3215,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3216,9 +3236,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3240,9 +3257,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3670,6 +3684,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4186,6 +4201,12 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4419,6 +4440,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -4525,6 +4547,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4603,6 +4626,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -4767,6 +4791,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",
+  "bin": {
+    "d365fo-mcp": "dist/cli/index.js"
+  },
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "cli": "tsx src/cli/index.ts",
+    "setup": "tsx src/cli/index.ts setup",
+    "doctor": "tsx src/cli/index.ts doctor",
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest",
@@ -37,9 +43,11 @@
   "license": "MIT",
   "dependencies": {
     "@azure/storage-blob": "^12.31.0",
+    "@clack/prompts": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.27.0",
     "@types/compression": "^1.8.1",
     "better-sqlite3": "^12.9.0",
+    "commander": "^15.0.0",
     "compression": "^1.8.1",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,0 +1,148 @@
+/**
+ * `d365fo-mcp doctor` — environment and installation health check.
+ *
+ * Verifies everything SETUP.md lists as a prerequisite and prints a fix for
+ * each failed check. Exit code 1 when a hard failure is found (something that
+ * prevents the server from working at all), 0 otherwise.
+ */
+import * as fs from 'node:fs';
+import { resolve } from 'node:path';
+import { p } from '../ui.js';
+import { isWindows, paths, repoRoot } from '../context.js';
+import { readEnvValue } from '../envFile.js';
+import { listInstances } from '../instances.js';
+import { isXppConfigStale, listXppConfigs, xppConfigDir } from '../xppConfig.js';
+
+type Severity = 'ok' | 'warn' | 'fail' | 'info';
+
+interface CheckResult {
+  severity: Severity;
+  message: string;
+  fix?: string;
+}
+
+const REQUIRED_NODE_MAJOR = 24;
+/** Below this size the index is almost certainly incomplete (SETUP.md troubleshooting). */
+const MIN_HEALTHY_DB_BYTES = 100 * 1024 * 1024;
+
+function report(r: CheckResult): void {
+  const line = r.fix ? `${r.message}\n   fix: ${r.fix}` : r.message;
+  if (r.severity === 'ok') p.log.success(line);
+  else if (r.severity === 'warn') p.log.warn(line);
+  else if (r.severity === 'fail') p.log.error(line);
+  else p.log.info(line);
+}
+
+function checkDb(envFile: string | null, defaultDb: string, label: string): CheckResult {
+  const configured = envFile ? readEnvValue(envFile, 'DB_PATH') : null;
+  const base = envFile ? resolve(envFile, '..') : repoRoot;
+  const dbPath = configured ? resolve(base, configured) : defaultDb;
+  if (!fs.existsSync(dbPath)) {
+    return {
+      severity: 'warn',
+      message: `${label}: database not found (${dbPath})`,
+      fix: 'd365fo-mcp index — not needed for hybrid/azure-client setups',
+    };
+  }
+  const size = fs.statSync(dbPath).size;
+  const mb = (size / 1024 / 1024).toFixed(0);
+  if (size < MIN_HEALTHY_DB_BYTES) {
+    return {
+      severity: 'warn',
+      message: `${label}: database is only ${mb} MB — index looks incomplete`,
+      fix: 'd365fo-mcp index',
+    };
+  }
+  return { severity: 'ok', message: `${label}: database OK (${mb} MB)` };
+}
+
+async function probeHealth(port: number, label: string): Promise<CheckResult> {
+  try {
+    const res = await fetch(`http://localhost:${port}/health`, { signal: AbortSignal.timeout(1500) });
+    const body = (await res.json()) as { status?: string; symbols?: number };
+    if (res.ok) {
+      return { severity: 'ok', message: `${label}: running on port ${port} (${body.symbols?.toLocaleString('en-US') ?? '?'} symbols)` };
+    }
+    return { severity: 'info', message: `${label}: starting on port ${port} (${body.status ?? res.status})` };
+  } catch {
+    return { severity: 'info', message: `${label}: not running on port ${port} (fine unless you expect an HTTP server)` };
+  }
+}
+
+export async function doctorCommand(): Promise<void> {
+  p.intro('d365fo-mcp doctor');
+  let failures = 0;
+  const emit = (r: CheckResult) => {
+    if (r.severity === 'fail') failures++;
+    report(r);
+  };
+
+  // Runtime
+  const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
+  emit(nodeMajor >= REQUIRED_NODE_MAJOR
+    ? { severity: 'ok', message: `Node.js ${process.versions.node}` }
+    : { severity: 'fail', message: `Node.js ${process.versions.node} — ${REQUIRED_NODE_MAJOR}.x required (package.json engines)`, fix: 'install Node 24 LTS' });
+
+  // Install + build
+  emit(fs.existsSync(resolve(repoRoot, 'node_modules'))
+    ? { severity: 'ok', message: 'Dependencies installed (node_modules)' }
+    : { severity: 'fail', message: 'node_modules missing', fix: 'npm install' });
+  emit(fs.existsSync(paths.distEntry)
+    ? { severity: 'ok', message: 'Server built (dist/index.js)' }
+    : { severity: 'fail', message: 'dist/index.js missing — server not built', fix: 'npm run build' });
+
+  // Configuration
+  emit(fs.existsSync(paths.rootEnv)
+    ? { severity: 'ok', message: 'Root .env present' }
+    : { severity: 'info', message: 'No root .env — fine when config comes from .mcp.json env or instances/', fix: 'd365fo-mcp setup' });
+
+  // Database (root)
+  emit(checkDb(fs.existsSync(paths.rootEnv) ? paths.rootEnv : null, paths.defaultDb, 'Root'));
+
+  // C# bridge — the only write path; Windows-only.
+  if (isWindows) {
+    emit(fs.existsSync(paths.bridgeExe)
+      ? { severity: 'ok', message: 'C# bridge built (D365MetadataBridge.exe)' }
+      : { severity: 'warn', message: 'C# bridge not built — server runs read-only', fix: 'cd bridge\\D365MetadataBridge && dotnet build -c Release' });
+    const dir = xppConfigDir();
+    const configs = listXppConfigs();
+    if (dir && fs.existsSync(dir)) {
+      emit({ severity: 'ok', message: `UDE: ${configs.length} XPP config(s) in ${dir}` });
+    } else {
+      emit({ severity: 'info', message: 'No UDE XPPConfig directory — traditional VM or UDE tools not installed' });
+    }
+  } else {
+    emit({ severity: 'info', message: `C# bridge skipped (Windows-only) — platform is ${process.platform}` });
+  }
+
+  // Instances
+  const instances = listInstances();
+  if (instances.length > 0) {
+    p.log.step(`Instances (${instances.length})`);
+    for (const inst of instances) {
+      emit(checkDb(inst.envFile, resolve(inst.dir, 'data', 'xpp-metadata.db'), `Instance '${inst.name}'`));
+      if (isWindows && isXppConfigStale(inst.envFile)) {
+        emit({
+          severity: 'warn',
+          message: `Instance '${inst.name}': XPP_CONFIG_NAME no longer resolves — UDE upgraded since configuration`,
+          fix: `d365fo-mcp instance upgrade ${inst.name}`,
+        });
+      }
+    }
+  }
+
+  // Live servers
+  const rootPortRaw = readEnvValue(paths.rootEnv, 'PORT');
+  const rootPort = rootPortRaw && /^\d+$/.test(rootPortRaw) ? parseInt(rootPortRaw, 10) : 8080;
+  emit(await probeHealth(rootPort, 'Server'));
+  for (const inst of instances) {
+    if (inst.port !== null) emit(await probeHealth(inst.port, `Instance '${inst.name}'`));
+  }
+
+  if (failures > 0) {
+    p.outro(`${failures} problem(s) found — apply the fixes above and re-run.`);
+    process.exitCode = 1;
+  } else {
+    p.outro('No blocking problems found.');
+  }
+}

--- a/src/cli/commands/indexCmd.ts
+++ b/src/cli/commands/indexCmd.ts
@@ -1,0 +1,103 @@
+/**
+ * `d365fo-mcp index [instance] [--all]` — rebuild the metadata index
+ * (extract-metadata + build-database), the TS counterpart of
+ * instances/rebuild-instance.ps1 minus the git-pull step (that lives in
+ * `d365fo-mcp update`).
+ */
+import * as fs from 'node:fs';
+import { isWindows, paths } from '../context.js';
+import { missingVars } from '../envFile.js';
+import { runNode } from '../exec.js';
+import { listInstances } from '../instances.js';
+import { instanceTarget, pickTarget, rootTarget, Target } from '../target.js';
+import { askConfirm, askSelect, p } from '../ui.js';
+import { normalizeXppConfigName } from '../xppConfig.js';
+
+/** Warn about vars added to .env.example since this .env was created. */
+function warnMissingSettings(envFile: string | null, label: string): boolean {
+  if (!envFile || !fs.existsSync(envFile) || !fs.existsSync(paths.envExample)) return false;
+  const missing = missingVars(
+    fs.readFileSync(paths.envExample, 'utf8'),
+    fs.readFileSync(envFile, 'utf8'),
+  );
+  if (missing.length === 0) return false;
+  p.log.warn(`New settings in .env.example not present in ${label}:\n` +
+    missing.map(m => `   ${m.name}=${m.value}`).join('\n'));
+  return true;
+}
+
+/** Run extract + build-database for one target. Returns true on success. */
+export async function rebuildIndex(target: Target): Promise<boolean> {
+  const env = target.envFile ? { ENV_FILE: target.envFile } : undefined;
+
+  if (isWindows && target.envFile) {
+    const expanded = normalizeXppConfigName(target.envFile);
+    if (expanded) p.log.info(`Expanded XPP_CONFIG_NAME: ${expanded.from} → ${expanded.to}`);
+  }
+
+  p.log.step(`[1/2] Extracting metadata (${target.label})…`);
+  if (await runNode(['--import', 'tsx/esm', paths.extractScript], { env }) !== 0) {
+    p.log.error(`Metadata extraction failed for ${target.label}`);
+    return false;
+  }
+
+  p.log.step(`[2/2] Building database (${target.label})…`);
+  if (await runNode(['--max-old-space-size=6144', '--import', 'tsx/esm', paths.buildDbScript], { env }) !== 0) {
+    p.log.error(`Database build failed for ${target.label}`);
+    return false;
+  }
+
+  p.log.success(`Index rebuilt: ${target.label}`);
+  return true;
+}
+
+export async function indexCommand(instanceName: string | undefined, opts: { all?: boolean; yes?: boolean }): Promise<void> {
+  p.intro('d365fo-mcp index');
+
+  let targets: Target[];
+  if (opts.all) {
+    const instances = listInstances();
+    if (instances.length === 0) {
+      p.log.error('--all: no instances found under instances/.');
+      process.exitCode = 1;
+      return;
+    }
+    targets = instances.map(instanceTarget);
+  } else if (!instanceName && opts.yes) {
+    // Fully non-interactive: no name + --yes targets the root server.
+    targets = [rootTarget()];
+  } else if (!instanceName && listInstances().length > 0) {
+    // Interactive: offer "all instances" like rebuild-instance.ps1 does.
+    const choice = await askSelect('Rebuild which index?', [
+      { value: '__pick__', label: 'Choose a single target…' },
+      { value: '__all__', label: 'All instances' },
+    ]);
+    targets = choice === '__all__'
+      ? listInstances().map(instanceTarget)
+      : [await pickTarget(undefined, 'Which target?')];
+  } else {
+    targets = [await pickTarget(instanceName, 'Which target?')];
+  }
+
+  const hasNewSettings = targets
+    .map(t => warnMissingSettings(t.envFile, `${t.label} .env`))
+    .some(Boolean);
+  if (hasNewSettings && !opts.yes) {
+    if (!await askConfirm('Some .env files are missing new settings (see above). Continue anyway?', false)) {
+      p.cancel('Aborted — update the .env files first.');
+      return;
+    }
+  }
+
+  const failed: string[] = [];
+  for (const target of targets) {
+    if (!await rebuildIndex(target)) failed.push(target.name);
+  }
+
+  if (failed.length > 0) {
+    p.outro(`Completed with errors. Failed: ${failed.join(', ')}`);
+    process.exitCode = 1;
+  } else {
+    p.outro(targets.length > 1 ? `All ${targets.length} indexes rebuilt.` : 'Done.');
+  }
+}

--- a/src/cli/commands/instance.ts
+++ b/src/cli/commands/instance.ts
@@ -1,0 +1,166 @@
+/**
+ * `d365fo-mcp instance <add|list|run|rebuild|upgrade>` — multi-instance
+ * management, the TS counterpart of instances/*.ps1 (Scenario F in SETUP.md).
+ * run/rebuild are thin aliases of `start`/`index` with an instance argument.
+ */
+import * as fs from 'node:fs';
+import { resolve } from 'node:path';
+import { readEnvValue, writeEnvValue } from '../envFile.js';
+import { createInstance, getInstance, listInstances, suggestPort } from '../instances.js';
+import { instanceTarget } from '../target.js';
+import { askConfirm, askSelect, askText, p } from '../ui.js';
+import { listXppConfigs, XppConfig, xppConfigDir } from '../xppConfig.js';
+import { rebuildIndex } from './indexCmd.js';
+
+function printInstances(): void {
+  const instances = listInstances();
+  if (instances.length === 0) {
+    p.log.info('No instances yet — create one with: d365fo-mcp instance add');
+    return;
+  }
+  const lines = instances.map(i => {
+    const dbPath = resolve(i.dir, readEnvValue(i.envFile, 'DB_PATH') ?? './data/xpp-metadata.db');
+    const db = fs.existsSync(dbPath) ? `${(fs.statSync(dbPath).size / 1024 / 1024).toFixed(0)} MB` : 'no index';
+    const cfg = readEnvValue(i.envFile, 'XPP_CONFIG_NAME');
+    return `${i.name.padEnd(20)} port ${String(i.port ?? '?').padEnd(6)} db ${db.padEnd(10)}${cfg ? ` [${cfg}]` : ''}`;
+  });
+  p.note(lines.join('\n'), `Instances (${instances.length})`);
+}
+
+export async function instanceListCommand(): Promise<void> {
+  p.intro('d365fo-mcp instance list');
+  printInstances();
+  p.outro('');
+}
+
+export async function instanceAddCommand(name: string | undefined, portArg: string | undefined): Promise<void> {
+  p.intro('d365fo-mcp instance add');
+  const instances = listInstances();
+  if (instances.length > 0) printInstances();
+
+  const instanceName = name ?? await askText({
+    message: 'Instance name',
+    placeholder: 'e.g. alpha, projectX, client-prod',
+    required: true,
+  });
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(instanceName)) {
+    p.log.error(`'${instanceName}' is not a valid instance name (letters, digits, . _ - only).`);
+    process.exitCode = 1;
+    return;
+  }
+  if (getInstance(instanceName)) {
+    p.log.error(`Instance '${instanceName}' already exists.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const suggested = suggestPort(instances);
+  const port = portArg ? parseInt(portArg, 10) : parseInt(await askText({
+    message: 'Port',
+    initialValue: String(suggested),
+    required: true,
+  }), 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    p.log.error(`Invalid port: ${portArg ?? port}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (instances.some(i => i.port === port)) {
+    if (!await askConfirm(`Port ${port} is already used by another instance. Continue anyway?`, false)) {
+      p.cancel('Aborted.');
+      return;
+    }
+  }
+
+  const inst = createInstance(instanceName, port);
+  p.log.success(`Instance created: ${inst.dir}`);
+  p.note(
+    `1. Edit ${inst.envFile}\n` +
+    '   — set XPP_CONFIG_NAME (or run: d365fo-mcp instance upgrade ' + instanceName + '),\n' +
+    '     EXTENSION_PREFIX and D365FO_MODEL_NAME\n' +
+    `2. Build the index:  d365fo-mcp instance rebuild ${instanceName}\n` +
+    `3. Start it:         d365fo-mcp instance run ${instanceName}`,
+    'Next steps',
+  );
+  p.outro('');
+}
+
+/** Interactive XPP config picker; returns null when none are available. */
+async function pickXppConfig(currentConfig: string | null): Promise<XppConfig | null> {
+  const configs = listXppConfigs();
+  if (configs.length === 0) {
+    const dir = xppConfigDir();
+    p.log.error(`No XPP config files found${dir ? ` in ${dir}` : ''}.\n` +
+      '   This directory is created by Power Platform Tools in VS2022 (Windows only).');
+    return null;
+  }
+  const fullName = await askSelect(
+    'Select the XPP config',
+    configs.map((cfg, i) => ({
+      value: cfg.fullName,
+      label: `${cfg.name}  v${cfg.version}${i === 0 ? ' (newest)' : ''}${cfg.fullName === currentConfig || cfg.name === currentConfig ? ' (current)' : ''}`,
+      hint: cfg.modelStoreFolder,
+    })),
+    configs[0].fullName,
+  );
+  return configs.find(cfg => cfg.fullName === fullName)!;
+}
+
+export async function instanceUpgradeCommand(name: string | undefined): Promise<void> {
+  p.intro('d365fo-mcp instance upgrade');
+  const instances = listInstances();
+  if (instances.length === 0) {
+    p.log.error('No instances found. Create one with: d365fo-mcp instance add');
+    process.exitCode = 1;
+    return;
+  }
+
+  let inst = name ? getInstance(name) : undefined;
+  if (name && !inst) {
+    p.log.error(`Instance '${name}' not found.`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!inst) {
+    const picked = await askSelect(
+      'Which instance do you want to repoint?',
+      instances.map(i => ({
+        value: i.name,
+        label: i.name,
+        hint: `port ${i.port ?? '?'}${readEnvValue(i.envFile, 'XPP_CONFIG_NAME') ? ` · ${readEnvValue(i.envFile, 'XPP_CONFIG_NAME')}` : ''}`,
+      })),
+    );
+    inst = getInstance(picked)!;
+  }
+
+  const currentConfig = readEnvValue(inst.envFile, 'XPP_CONFIG_NAME');
+  p.log.info(`Current XPP_CONFIG_NAME: ${currentConfig ?? '(not set)'}`);
+
+  const selected = await pickXppConfig(currentConfig);
+  if (!selected) {
+    process.exitCode = 1;
+    return;
+  }
+
+  if (currentConfig === selected.fullName) {
+    p.log.warn('XPP_CONFIG_NAME is unchanged.');
+    if (!await askConfirm('Rebuild anyway?', false)) {
+      p.cancel('Aborted.');
+      return;
+    }
+  } else {
+    p.log.info(`was: ${currentConfig ?? '(not set)'}\n   now: ${selected.fullName}`);
+    if (!await askConfirm('Write this to the instance .env and rebuild?')) {
+      p.cancel('Aborted.');
+      return;
+    }
+    writeEnvValue(inst.envFile, 'XPP_CONFIG_NAME', selected.fullName);
+    p.log.success(`Updated ${inst.envFile}`);
+  }
+
+  if (!await rebuildIndex(instanceTarget(inst))) {
+    process.exitCode = 1;
+    return;
+  }
+  p.outro('Upgrade complete.');
+}

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,0 +1,239 @@
+/**
+ * `d365fo-mcp setup` — first-time setup wizard.
+ *
+ * Walks through the deployment scenarios documented in docs/SETUP.md
+ * (A azure client · B hybrid · C local HTTP · D UDE · E local stdio ·
+ * F multi-instance), runs the install/build/index steps for the chosen one,
+ * and prints the .mcp.json block to paste into the MCP client config.
+ */
+import * as fs from 'node:fs';
+import { resolve } from 'node:path';
+import { isWindows, paths, repoRoot } from '../context.js';
+import { readEnvValue, writeEnvValue } from '../envFile.js';
+import { runExe, runShell } from '../exec.js';
+import { rootTarget } from '../target.js';
+import { askConfirm, askSelect, askText, p } from '../ui.js';
+import { listXppConfigs } from '../xppConfig.js';
+import { rebuildIndex } from './indexCmd.js';
+import { instanceAddCommand } from './instance.js';
+
+type Scenario = 'azure' | 'hybrid' | 'local-http' | 'ude' | 'local-stdio' | 'multi';
+
+const distEntryWin = () => resolve(repoRoot, 'dist', 'index.js');
+
+function mcpJsonNote(servers: Record<string, unknown>, title = '.mcp.json'): void {
+  p.note(JSON.stringify({ servers }, null, 2), title);
+}
+
+function placementNote(): void {
+  p.note(
+    'Place the block above in:\n' +
+    '  %USERPROFILE%\\.mcp.json          — all solutions (recommended)\n' +
+    '  next to the .sln                 — that solution only\n\n' +
+    'Also copy .github\\copilot-instructions.md into a parent of your\n' +
+    'solution folders (mandatory for Copilot — see docs/SETUP.md).\n' +
+    'Restart Visual Studio after editing .mcp.json.',
+    'Where it goes',
+  );
+}
+
+/** npm install + npm run build, skipping steps that are already done. */
+async function ensureInstalledAndBuilt(): Promise<boolean> {
+  if (!fs.existsSync(resolve(repoRoot, 'node_modules'))) {
+    p.log.step('Installing dependencies (npm install)…');
+    if (await runShell('npm install') !== 0) { p.log.error('npm install failed.'); return false; }
+  } else {
+    p.log.success('Dependencies already installed.');
+  }
+  if (!fs.existsSync(paths.distEntry) || await askConfirm('dist/ already exists — rebuild TypeScript anyway?', false)) {
+    p.log.step('Building TypeScript (npm run build)…');
+    if (await runShell('npm run build') !== 0) { p.log.error('Build failed.'); return false; }
+  }
+  return true;
+}
+
+/** Build the C# bridge — the only write path; Windows D365FO VMs only. */
+async function maybeBuildBridge(scenario: Scenario): Promise<boolean> {
+  if (!isWindows) {
+    p.log.info('C# bridge skipped — it only builds on Windows D365FO VMs (writes stay unavailable here).');
+    return true;
+  }
+  if (fs.existsSync(paths.bridgeExe) && !await askConfirm('C# bridge already built — rebuild it?', false)) {
+    return true;
+  }
+  if (!await askConfirm('Build the C# bridge? (required for creating/modifying files)')) {
+    p.log.warn('Skipped — the server will run read-only until you build it.');
+    return true;
+  }
+  const args = ['build', '-c', 'Release'];
+  if (scenario === 'ude') {
+    const binPath = await askText({
+      message: 'UDE: path to the FrameworkDirectory\\bin folder (Enter to let MSBuild auto-detect)',
+      placeholder: 'C:\\Users\\...\\PackagesLocalDirectory\\bin',
+    });
+    if (binPath) args.push(`-p:D365BinPath=${binPath}`);
+  }
+  p.log.step('Building C# bridge (dotnet build -c Release)…');
+  if (await runExe('dotnet', args, { cwd: paths.bridgeDir }) !== 0) {
+    p.log.error('Bridge build failed — check .NET Framework 4.8 Dev Pack and the NuGet feed (docs/SETUP.md).');
+    return false;
+  }
+  p.log.success('C# bridge built.');
+  return true;
+}
+
+/** Create/complete the root .env interactively. Returns the configured port. */
+async function configureRootEnv(scenario: Scenario): Promise<number> {
+  if (!fs.existsSync(paths.rootEnv)) {
+    fs.copyFileSync(paths.envExample, paths.rootEnv);
+    p.log.success('Created .env from .env.example');
+  } else {
+    p.log.info('.env already exists — the wizard only overwrites the keys you answer below.');
+  }
+
+  const envType = scenario === 'ude' ? 'ude' : await askSelect('Development environment type', [
+    { value: 'auto', label: 'auto', hint: 'detect UDE when XPP configs exist (default)' },
+    { value: 'traditional', label: 'traditional', hint: 'classic AOSService VM' },
+    { value: 'ude', label: 'ude', hint: 'Unified Developer Experience / Power Platform Tools' },
+  ], 'auto');
+  writeEnvValue(paths.rootEnv, 'D365FO_DEV_ENVIRONMENT_TYPE', envType);
+
+  if (envType === 'traditional') {
+    writeEnvValue(paths.rootEnv, 'D365FO_PACKAGE_PATH', await askText({
+      message: 'Packages root (PackagesLocalDirectory)',
+      initialValue: readEnvValue(paths.rootEnv, 'D365FO_PACKAGE_PATH') ?? 'C:\\AOSService\\PackagesLocalDirectory',
+      required: true,
+    }));
+    writeEnvValue(paths.rootEnv, 'CUSTOM_MODELS', await askText({
+      message: 'Custom model names (comma-separated; VS → Dynamics 365 → Model Management)',
+      initialValue: readEnvValue(paths.rootEnv, 'CUSTOM_MODELS') ?? '',
+      required: true,
+    }));
+  } else {
+    // UDE/auto: pin an XPP config when any exist; otherwise the server
+    // auto-detects the newest one at runtime.
+    const configs = listXppConfigs();
+    if (configs.length > 0) {
+      const pick = await askSelect('XPP config to pin (from %LOCALAPPDATA%\\...\\XPPConfig)', [
+        { value: '', label: '(auto — always use the newest)' },
+        ...configs.map((cfg, i) => ({ value: cfg.fullName, label: `${cfg.name}  v${cfg.version}${i === 0 ? ' (newest)' : ''}`, hint: cfg.modelStoreFolder })),
+      ], '');
+      if (pick) writeEnvValue(paths.rootEnv, 'XPP_CONFIG_NAME', pick);
+    }
+  }
+
+  const prefix = await askText({
+    message: 'Extension prefix for your custom objects (e.g. ASP, CTSO)',
+    initialValue: readEnvValue(paths.rootEnv, 'EXTENSION_PREFIX') ?? '',
+    required: true,
+  });
+  writeEnvValue(paths.rootEnv, 'EXTENSION_PREFIX', prefix);
+
+  let port = 8080;
+  if (scenario === 'local-http') {
+    port = parseInt(await askText({
+      message: 'HTTP port',
+      initialValue: readEnvValue(paths.rootEnv, 'PORT') ?? '8080',
+      required: true,
+    }), 10);
+    writeEnvValue(paths.rootEnv, 'PORT', String(port));
+  }
+  p.log.success('.env updated.');
+  return port;
+}
+
+async function maybeBuildIndex(): Promise<boolean> {
+  if (!await askConfirm('Build the metadata index now? (custom models: minutes; EXTRACT_MODE=all: 1–2 h)')) {
+    p.log.warn('Skipped — run `d365fo-mcp index` before first use.');
+    return true;
+  }
+  return rebuildIndex(rootTarget());
+}
+
+export async function setupCommand(): Promise<void> {
+  p.intro('d365fo-mcp setup — first-time setup');
+
+  const scenario = await askSelect<Scenario>('How will this developer machine use the MCP server? (docs/SETUP.md)', [
+    { value: 'local-stdio', label: 'E — Local stdio ★', hint: 'single developer on a D365FO VM; VS launches the server' },
+    { value: 'hybrid', label: 'B — Hybrid ★', hint: 'Azure serves the shared index; local companion handles writes' },
+    { value: 'local-http', label: 'C — Local HTTP', hint: 'several clients on this machine share one server on a port' },
+    { value: 'ude', label: 'D — UDE', hint: 'Unified Developer Experience / Power Platform Tools' },
+    { value: 'multi', label: 'F — Multi-instance', hint: 'several D365FO clients on one machine, one instance each' },
+    { value: 'azure', label: 'A — Azure client', hint: 'read-only connection to a team server; no local install' },
+  ]);
+
+  // ── A: nothing to install ─────────────────────────────────────────────────
+  if (scenario === 'azure') {
+    const url = await askText({ message: 'Azure server URL', placeholder: 'https://your-server.azurewebsites.net/mcp/', required: true });
+    mcpJsonNote({ 'd365fo-mcp-tools': { url } });
+    placementNote();
+    p.outro('Done. For real development (writes on your VM) re-run setup and pick Scenario B.');
+    return;
+  }
+
+  // ── Everything else needs the local clone installed and built ────────────
+  if (!await ensureInstalledAndBuilt()) { process.exitCode = 1; return; }
+  if (!await maybeBuildBridge(scenario)) { process.exitCode = 1; return; }
+
+  if (scenario === 'hybrid') {
+    const url = await askText({ message: 'Azure server URL', placeholder: 'https://your-server.azurewebsites.net/mcp/', required: true });
+    const solutionsPath = await askText({ message: 'Folder scanned for .rnrproj solutions (D365FO_SOLUTIONS_PATH)', placeholder: 'K:\\repos\\MySolution\\projects', required: true });
+    const workspacePath = await askText({ message: 'Two-level workspace path …\\PackagesLocalDirectory\\<Package>\\<Model> (D365FO_WORKSPACE_PATH)', placeholder: 'K:\\AosService\\PackagesLocalDirectory\\YourPackage\\YourModel', required: true });
+    mcpJsonNote({
+      'd365fo-azure': { url },
+      'd365fo-local': {
+        command: 'node',
+        args: [distEntryWin()],
+        env: { MCP_SERVER_MODE: 'write-only', D365FO_SOLUTIONS_PATH: solutionsPath, D365FO_WORKSPACE_PATH: workspacePath },
+      },
+    });
+    placementNote();
+    p.outro('Hybrid setup complete — no local index needed (Azure serves the search).');
+    return;
+  }
+
+  if (scenario === 'multi') {
+    p.log.info('Each D365FO client gets its own instance (own .env, database and port).');
+    await instanceAddCommand(undefined, undefined);
+    return;
+  }
+
+  // ── C / D / E: local index setups ─────────────────────────────────────────
+  const port = await configureRootEnv(scenario);
+  if (!await maybeBuildIndex()) { process.exitCode = 1; return; }
+
+  if (scenario === 'local-http') {
+    mcpJsonNote({ 'd365fo-mcp-tools': { url: `http://localhost:${port}/mcp/` } });
+    placementNote();
+    p.outro('Done. Start the server with: d365fo-mcp start');
+    return;
+  }
+
+  if (scenario === 'ude') {
+    const modelName = await askText({ message: 'Model name for code generation (D365FO_MODEL_NAME)', required: true });
+    mcpJsonNote({
+      'd365fo-mcp-tools': {
+        command: 'node',
+        args: [distEntryWin()],
+        env: { D365FO_MODEL_NAME: modelName, D365FO_DEV_ENVIRONMENT_TYPE: 'ude' },
+      },
+    });
+    placementNote();
+    p.outro('Done. VS spawns the server automatically — no manual start needed.');
+    return;
+  }
+
+  // E — local stdio
+  const solutionsPath = await askText({
+    message: 'Folder scanned for .rnrproj solutions (D365FO_SOLUTIONS_PATH; Enter to skip)',
+    placeholder: 'K:\\repos\\MySolution\\projects',
+  });
+  const env: Record<string, string> = {
+    DB_PATH: paths.defaultDb,
+    LABELS_DB_PATH: paths.defaultLabelsDb,
+  };
+  if (solutionsPath) env.D365FO_SOLUTIONS_PATH = solutionsPath;
+  mcpJsonNote({ 'd365fo-mcp-tools': { command: 'node', args: [distEntryWin()], env } });
+  placementNote();
+  p.outro('Done. VS spawns the server automatically — no manual start needed.');
+}

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -1,0 +1,55 @@
+/**
+ * `d365fo-mcp start [instance]` — run the server in the foreground,
+ * the TS counterpart of instances/run-instance.ps1. Started from a terminal
+ * the server picks HTTP mode by itself (stdin is a TTY); stdio mode is what
+ * IDE clients use when they spawn dist/index.js directly.
+ */
+import * as fs from 'node:fs';
+import { isWindows, paths } from '../context.js';
+import { readEnvValue } from '../envFile.js';
+import { runNode, runShell } from '../exec.js';
+import { pickTarget } from '../target.js';
+import { askConfirm, p } from '../ui.js';
+import { isXppConfigStale, xppConfigDir } from '../xppConfig.js';
+
+export async function startCommand(instanceName: string | undefined): Promise<void> {
+  p.intro('d365fo-mcp start');
+  const target = await pickTarget(instanceName, 'Which server do you want to start?');
+
+  if (!fs.existsSync(paths.distEntry)) {
+    p.log.warn('dist/index.js not found — the server has not been built yet.');
+    if (!await askConfirm('Build it now (npm run build)?')) {
+      p.cancel('Aborted.');
+      return;
+    }
+    if (await runShell('npm run build') !== 0) {
+      p.log.error('Build failed.');
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  // UDE staleness guard: a pinned XPP config that no longer exists means the
+  // environment was upgraded and this database indexes the old version.
+  if (isWindows && target.envFile && isXppConfigStale(target.envFile)) {
+    const configName = readEnvValue(target.envFile, 'XPP_CONFIG_NAME');
+    p.log.warn(`XPP_CONFIG_NAME '${configName}' does not match any file in ${xppConfigDir()}.\n` +
+      `   The UDE may have been upgraded since ${target.label} was configured.\n` +
+      `   Fix with: d365fo-mcp instance upgrade ${target.name}`);
+    if (!await askConfirm('Continue anyway?', false)) {
+      p.cancel('Aborted.');
+      return;
+    }
+  }
+
+  const port = target.port ?? (target.envFile ? readEnvValue(target.envFile, 'PORT') : null) ?? 8080;
+  p.log.step(`Starting ${target.label} — expected endpoint http://localhost:${port}/mcp (Ctrl+C stops it)`);
+
+  const code = await runNode([paths.distEntry], {
+    env: target.envFile ? { ENV_FILE: target.envFile } : undefined,
+  });
+  if (code !== 0) {
+    p.log.error(`Server exited with code ${code}`);
+    process.exitCode = code;
+  }
+}

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,0 +1,58 @@
+/**
+ * `d365fo-mcp update [--yes]` — pull the latest code, reinstall dependencies,
+ * rebuild TypeScript, and optionally rebuild the C# bridge and the metadata
+ * index (the "Update" flow SETUP.md documents as git pull && npm install &&
+ * npm run build).
+ */
+import * as fs from 'node:fs';
+import { isWindows, paths } from '../context.js';
+import { runExe, runShell } from '../exec.js';
+import { listInstances } from '../instances.js';
+import { instanceTarget, rootTarget } from '../target.js';
+import { askConfirm, p } from '../ui.js';
+import { rebuildIndex } from './indexCmd.js';
+
+export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
+  p.intro('d365fo-mcp update');
+
+  const steps: [string, () => Promise<number>][] = [
+    ['git pull', () => runExe('git', ['pull'])],
+    ['npm install', () => runShell('npm install')],
+    ['npm run build', () => runShell('npm run build')],
+  ];
+  for (const [label, run] of steps) {
+    p.log.step(label);
+    if (await run() !== 0) {
+      p.log.error(`${label} failed — fix the error above and re-run.`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  // Rebuild the bridge only where it was built before: a missing exe means
+  // this install never needed writes (or is not a D365FO VM at all).
+  if (isWindows && fs.existsSync(paths.bridgeExe)) {
+    const rebuild = opts.yes || await askConfirm('Rebuild the C# bridge (recommended after a D365FO version upgrade)?');
+    if (rebuild) {
+      if (await runExe('dotnet', ['build', '-c', 'Release'], { cwd: paths.bridgeDir }) !== 0) {
+        p.log.error('Bridge build failed — writes may use the previous bridge binary.');
+        process.exitCode = 1;
+        return;
+      }
+      p.log.success('C# bridge rebuilt.');
+    }
+  }
+
+  if (!opts.yes && await askConfirm('Rebuild the metadata index too? (takes minutes to hours)', false)) {
+    const instances = listInstances();
+    const targets = instances.length > 0 ? instances.map(instanceTarget) : [rootTarget()];
+    for (const target of targets) {
+      if (!await rebuildIndex(target)) {
+        process.exitCode = 1;
+        return;
+      }
+    }
+  }
+
+  p.outro('Update complete.');
+}

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,0 +1,30 @@
+/**
+ * CLI context — repo-root resolution shared by all commands.
+ *
+ * The CLI runs either from src/cli (tsx during development) or dist/cli
+ * (built). Both are exactly two levels below the repo root, so resolve
+ * relative to this file rather than process.cwd() — developers invoke the
+ * CLI from arbitrary directories.
+ */
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __cliDir = dirname(fileURLToPath(import.meta.url));
+
+export const repoRoot = resolve(__cliDir, '../..');
+
+export const paths = {
+  rootEnv: resolve(repoRoot, '.env'),
+  envExample: resolve(repoRoot, '.env.example'),
+  instancesDir: resolve(repoRoot, 'instances'),
+  instanceTemplate: resolve(repoRoot, 'instances', '.env.template'),
+  distEntry: resolve(repoRoot, 'dist', 'index.js'),
+  defaultDb: resolve(repoRoot, 'data', 'xpp-metadata.db'),
+  defaultLabelsDb: resolve(repoRoot, 'data', 'xpp-metadata-labels.db'),
+  bridgeDir: resolve(repoRoot, 'bridge', 'D365MetadataBridge'),
+  bridgeExe: resolve(repoRoot, 'bridge', 'D365MetadataBridge', 'bin', 'Release', 'D365MetadataBridge.exe'),
+  extractScript: resolve(repoRoot, 'scripts', 'extract-metadata.ts'),
+  buildDbScript: resolve(repoRoot, 'scripts', 'build-database.ts'),
+} as const;
+
+export const isWindows = process.platform === 'win32';

--- a/src/cli/envFile.ts
+++ b/src/cli/envFile.ts
@@ -1,0 +1,84 @@
+/**
+ * .env file helpers — read/update individual keys while preserving the rest
+ * of the file byte-for-byte (comments, ordering, blank lines).
+ *
+ * Mirrors the semantics of the PowerShell management scripts
+ * (instances/*.ps1, scripts/select-xpp-config.ps1) so both entry points stay
+ * interchangeable: an active line wins over a commented one, setting a key
+ * first replaces the active line, then un-comments a commented line, and
+ * finally appends.
+ */
+import * as fs from 'node:fs';
+
+/** First active (non-commented) value of `key`, or null. */
+export function getValue(content: string, key: string): string | null {
+  const re = new RegExp(`^\\s*${escapeRe(key)}\\s*=(.*)$`, 'm');
+  const m = content.match(re);
+  return m ? m[1].trim() : null;
+}
+
+/** Replace the active line, else un-comment a commented one, else append. */
+export function setValue(content: string, key: string, value: string): string {
+  // Replacer function, not a replacement string — values containing `$&`
+  // or `$'` must land in the file literally.
+  const line = () => `${key}=${value}`;
+  const active = new RegExp(`^\\s*${escapeRe(key)}\\s*=.*$`, 'm');
+  if (active.test(content)) {
+    return content.replace(active, line);
+  }
+  const commented = new RegExp(`^#\\s*${escapeRe(key)}\\s*=.*$`, 'm');
+  if (commented.test(content)) {
+    return content.replace(commented, line);
+  }
+  return content.replace(/\s*$/, '') + `\n${key}=${value}\n`;
+}
+
+/**
+ * All variable names present in the file. Commented-out assignments
+ * ("# KEY=value") count as present-but-disabled so the missing-settings
+ * check doesn't nag about vars a user intentionally left commented.
+ */
+export function varNames(content: string): string[] {
+  const names: string[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    const m = line.match(/^\s*#?\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+    if (m) names.push(m[1]);
+  }
+  return names;
+}
+
+/** Vars in `exampleContent` that are absent from `envContent`, with example values. */
+export function missingVars(exampleContent: string, envContent: string): { name: string; value: string }[] {
+  const have = new Set(varNames(envContent));
+  const missing: { name: string; value: string }[] = [];
+  for (const name of varNames(exampleContent)) {
+    if (have.has(name)) continue;
+    have.add(name); // report each var once
+    missing.push({ name, value: getValue(exampleContent, name) ?? '' });
+  }
+  return missing;
+}
+
+// ── File-backed wrappers ─────────────────────────────────────────────────────
+
+export function readEnvValue(envFile: string, key: string): string | null {
+  if (!fs.existsSync(envFile)) return null;
+  return getValue(fs.readFileSync(envFile, 'utf8'), key);
+}
+
+export function writeEnvValue(envFile: string, key: string, value: string): void {
+  const content = fs.existsSync(envFile) ? fs.readFileSync(envFile, 'utf8') : '';
+  fs.writeFileSync(envFile, setValue(content, key, value));
+}
+
+/**
+ * Dev-environment type with the legacy fallback name, matching
+ * run-instance.ps1 / rebuild-instance.ps1 and the server itself.
+ */
+export function readDevEnvType(envFile: string): string | null {
+  return readEnvValue(envFile, 'D365FO_DEV_ENVIRONMENT_TYPE') ?? readEnvValue(envFile, 'DEV_ENVIRONMENT_TYPE');
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/cli/exec.ts
+++ b/src/cli/exec.ts
@@ -1,0 +1,56 @@
+/**
+ * Subprocess helpers for the management CLI.
+ *
+ * Two flavours, chosen to avoid Windows quoting pitfalls:
+ *  - runShell: constant command strings (npm install, git pull, …) through the
+ *    platform shell — npm/npx are .cmd shims on Windows and cannot be spawned
+ *    directly (EINVAL since the Node 18 shell hardening).
+ *  - runNode / runExe: real executables (node itself, dotnet.exe) with an args
+ *    array and no shell, so paths with spaces need no quoting.
+ *
+ * All flavours stream output to the terminal (stdio: inherit) — extraction and
+ * database builds run for minutes and their progress must stay visible.
+ */
+import { spawn } from 'node:child_process';
+import { repoRoot } from './context.js';
+
+export interface RunOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+function spawnAndWait(cmd: string, args: string[], opts: RunOptions, shell: boolean): Promise<number> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd ?? repoRoot,
+      env: { ...process.env, ...opts.env },
+      stdio: 'inherit',
+      shell,
+    });
+    child.on('error', reject);
+    child.on('close', code => resolvePromise(code ?? 1));
+  });
+}
+
+/** Run a constant command line (e.g. 'npm install') through the shell. */
+export function runShell(command: string, opts: RunOptions = {}): Promise<number> {
+  return spawnAndWait(command, [], opts, true);
+}
+
+/** Run the current Node binary with the given args (no shell). */
+export function runNode(args: string[], opts: RunOptions = {}): Promise<number> {
+  return spawnAndWait(process.execPath, args, opts, false);
+}
+
+/** Run a real executable (dotnet, git) with an args array (no shell). */
+export function runExe(cmd: string, args: string[], opts: RunOptions = {}): Promise<number> {
+  return spawnAndWait(cmd, args, opts, false);
+}
+
+/** Throwing variant — use for steps where a failure must abort the flow. */
+export async function mustSucceed(promise: Promise<number>, what: string): Promise<void> {
+  const code = await promise;
+  if (code !== 0) {
+    throw new Error(`${what} failed with exit code ${code}`);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * d365fo-mcp — interactive management CLI for the D365 F&O MCP Server.
+ *
+ * Every operation is a plain subcommand (scriptable, CI-friendly); running
+ * with no arguments opens an interactive menu, and any missing argument is
+ * asked for with predefined choices. The instances/*.ps1 scripts remain as a
+ * PowerShell fallback for the same flows.
+ *
+ *   d365fo-mcp                  interactive menu
+ *   d365fo-mcp setup            first-time setup wizard (scenarios A–F)
+ *   d365fo-mcp doctor           environment & installation health check
+ *   d365fo-mcp start [name]     run the root server or an instance
+ *   d365fo-mcp update [--yes]   git pull + npm install + build (+ bridge/index)
+ *   d365fo-mcp index [name]     rebuild the metadata index (--all: all instances)
+ *   d365fo-mcp instance …       add | list | run | rebuild | upgrade
+ */
+import { Command } from 'commander';
+import { doctorCommand } from './commands/doctor.js';
+import { indexCommand } from './commands/indexCmd.js';
+import { instanceAddCommand, instanceListCommand, instanceUpgradeCommand } from './commands/instance.js';
+import { setupCommand } from './commands/setup.js';
+import { startCommand } from './commands/start.js';
+import { updateCommand } from './commands/update.js';
+import { askSelect, p } from './ui.js';
+import { listInstances } from './instances.js';
+
+const program = new Command();
+
+program
+  .name('d365fo-mcp')
+  .description('Manage the D365 F&O MCP Server: setup, updates, instances, index builds')
+  .version('1.0.0');
+
+program.command('setup')
+  .description('First-time setup wizard (deployment scenarios A–F from docs/SETUP.md)')
+  .action(setupCommand);
+
+program.command('doctor')
+  .description('Check the environment and installation; prints a fix for every problem')
+  .action(doctorCommand);
+
+program.command('start')
+  .argument('[instance]', "instance name, or 'root' for the repo-level .env")
+  .description('Start the server in the foreground (HTTP mode)')
+  .action(startCommand);
+
+program.command('update')
+  .option('-y, --yes', 'non-interactive: accept defaults, skip the reindex question')
+  .description('Update the installation: git pull + npm install + build (+ bridge, index)')
+  .action(updateCommand);
+
+program.command('index')
+  .argument('[instance]', "instance name, or 'root' for the repo-level .env")
+  .option('--all', 'rebuild every instance')
+  .option('-y, --yes', 'non-interactive: skip confirmation questions')
+  .description('Rebuild the metadata index (extract + build database)')
+  .action(indexCommand);
+
+const instance = program.command('instance').description('Manage multi-instance setups (Scenario F)');
+instance.command('add')
+  .argument('[name]', 'instance name')
+  .argument('[port]', 'HTTP port')
+  .description('Create a new instance (folder + .env from the template)')
+  .action(instanceAddCommand);
+instance.command('list')
+  .description('List instances with port, index size and pinned XPP config')
+  .action(instanceListCommand);
+instance.command('run')
+  .argument('[name]', 'instance name')
+  .description('Start an instance (alias of: d365fo-mcp start <name>)')
+  .action(startCommand);
+instance.command('rebuild')
+  .argument('[name]', 'instance name')
+  .option('--all', 'rebuild every instance')
+  .description('Rebuild the index of an instance (alias of: d365fo-mcp index <name>)')
+  .action((name: string | undefined, opts: { all?: boolean }) => indexCommand(name, opts));
+instance.command('upgrade')
+  .argument('[name]', 'instance name')
+  .description('Repoint an instance at a new XPP config after a UDE upgrade, then rebuild')
+  .action(instanceUpgradeCommand);
+
+/** No arguments → interactive menu over the same commands. */
+async function mainMenu(): Promise<void> {
+  p.intro('d365fo-mcp — D365 F&O MCP Server management');
+  const hasInstances = listInstances().length > 0;
+  const action = await askSelect('What do you want to do?', [
+    { value: 'setup', label: 'Setup', hint: 'first-time setup wizard' },
+    { value: 'doctor', label: 'Doctor', hint: 'check environment & installation' },
+    { value: 'start', label: 'Start server', hint: hasInstances ? 'root or an instance' : 'root server' },
+    { value: 'update', label: 'Update', hint: 'git pull + install + build' },
+    { value: 'index', label: 'Rebuild index', hint: 'extract metadata + build database' },
+    { value: 'instance-add', label: 'Add instance', hint: 'new multi-instance environment' },
+    ...(hasInstances ? [
+      { value: 'instance-list', label: 'List instances' },
+      { value: 'instance-upgrade', label: 'Upgrade instance', hint: 'repoint at a new XPP config' },
+    ] : []),
+  ]);
+  switch (action) {
+    case 'setup': return setupCommand();
+    case 'doctor': return doctorCommand();
+    case 'start': return startCommand(undefined);
+    case 'update': return updateCommand({});
+    case 'index': return indexCommand(undefined, {});
+    case 'instance-add': return instanceAddCommand(undefined, undefined);
+    case 'instance-list': return instanceListCommand();
+    case 'instance-upgrade': return instanceUpgradeCommand(undefined);
+  }
+}
+
+async function main(): Promise<void> {
+  if (process.argv.length <= 2) {
+    await mainMenu();
+    return;
+  }
+  await program.parseAsync(process.argv);
+}
+
+main().catch((err: unknown) => {
+  p.log.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/cli/instances.ts
+++ b/src/cli/instances.ts
@@ -1,0 +1,64 @@
+/**
+ * Multi-instance helpers — TypeScript counterpart of instances/*.ps1.
+ * An instance is any directory under instances/ containing a .env file.
+ */
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+import { paths } from './context.js';
+import { readEnvValue } from './envFile.js';
+
+export interface Instance {
+  name: string;
+  dir: string;
+  envFile: string;
+  port: number | null;
+}
+
+export function listInstances(): Instance[] {
+  if (!fs.existsSync(paths.instancesDir)) return [];
+  return fs.readdirSync(paths.instancesDir, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => {
+      const dir = join(paths.instancesDir, e.name);
+      const envFile = join(dir, '.env');
+      return { name: e.name, dir, envFile };
+    })
+    .filter(i => fs.existsSync(i.envFile))
+    .map(i => {
+      const raw = readEnvValue(i.envFile, 'PORT');
+      const port = raw && /^\d+$/.test(raw) ? parseInt(raw, 10) : null;
+      return { ...i, port };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function getInstance(name: string): Instance | undefined {
+  return listInstances().find(i => i.name === name);
+}
+
+/** Next free port: max of existing instance ports + 1, or 3001. */
+export function suggestPort(instances: Instance[]): number {
+  const used = instances.map(i => i.port).filter((p): p is number => p !== null);
+  return used.length > 0 ? Math.max(...used) + 1 : 3001;
+}
+
+/**
+ * Create instances/<name>/{.env,data,metadata} from the .env.template
+ * (with __PORT__ substituted). Throws when the instance already exists
+ * or the template is missing.
+ */
+export function createInstance(name: string, port: number): Instance {
+  if (!fs.existsSync(paths.instanceTemplate)) {
+    throw new Error(`Template not found: ${paths.instanceTemplate}`);
+  }
+  const dir = join(paths.instancesDir, name);
+  const envFile = join(dir, '.env');
+  if (fs.existsSync(envFile)) {
+    throw new Error(`Instance '${name}' already exists.`);
+  }
+  fs.mkdirSync(join(dir, 'data'), { recursive: true });
+  fs.mkdirSync(join(dir, 'metadata'), { recursive: true });
+  const content = fs.readFileSync(paths.instanceTemplate, 'utf8').replaceAll('__PORT__', String(port));
+  fs.writeFileSync(envFile, content);
+  return { name, dir, envFile, port };
+}

--- a/src/cli/target.ts
+++ b/src/cli/target.ts
@@ -1,0 +1,50 @@
+/**
+ * Target selection — commands like start/index operate either on the root
+ * server (repo .env) or on one instance under instances/. Resolves a
+ * positional instance name, or asks interactively when instances exist.
+ */
+import * as fs from 'node:fs';
+import { paths, repoRoot } from './context.js';
+import { Instance, listInstances } from './instances.js';
+import { askSelect } from './ui.js';
+
+export interface Target {
+  /** 'root' or the instance name */
+  name: string;
+  label: string;
+  /** null → root default config (loadEnv falls back to repo .env) */
+  envFile: string | null;
+  port: number | null;
+  instance?: Instance;
+}
+
+export function rootTarget(): Target {
+  return { name: 'root', label: 'root server (.env)', envFile: fs.existsSync(paths.rootEnv) ? paths.rootEnv : null, port: null };
+}
+
+export function instanceTarget(inst: Instance): Target {
+  return { name: inst.name, label: `instance '${inst.name}'`, envFile: inst.envFile, port: inst.port, instance: inst };
+}
+
+/**
+ * Resolve the target: explicit name → that instance ('root' selects the root
+ * server); no name and no instances → root; otherwise ask.
+ */
+export async function pickTarget(instanceName: string | undefined, message: string): Promise<Target> {
+  const instances = listInstances();
+  if (instanceName) {
+    if (instanceName === 'root') return rootTarget();
+    const inst = instances.find(i => i.name === instanceName);
+    if (!inst) {
+      throw new Error(`Instance '${instanceName}' not found. Available: ${instances.map(i => i.name).join(', ') || '(none)'}`);
+    }
+    return instanceTarget(inst);
+  }
+  if (instances.length === 0) return rootTarget();
+
+  const choice = await askSelect(message, [
+    { value: 'root', label: 'root server', hint: repoRoot },
+    ...instances.map(i => ({ value: i.name, label: i.name, hint: i.port !== null ? `port ${i.port}` : undefined })),
+  ]);
+  return choice === 'root' ? rootTarget() : instanceTarget(instances.find(i => i.name === choice)!);
+}

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -1,0 +1,36 @@
+/**
+ * Prompt helpers — thin wrapper over @clack/prompts with uniform
+ * cancel handling (Ctrl+C / Esc exits the CLI cleanly instead of
+ * returning a cancel symbol every caller must check).
+ */
+import * as p from '@clack/prompts';
+import type { Option } from '@clack/prompts';
+
+export { p };
+
+/** Unwrap a clack result; exit gracefully when the user cancelled. */
+export function ensure<T>(value: T | symbol): T {
+  if (p.isCancel(value)) {
+    p.cancel('Cancelled.');
+    process.exit(0);
+  }
+  return value as T;
+}
+
+export async function askText(opts: { message: string; placeholder?: string; initialValue?: string; required?: boolean }): Promise<string> {
+  const v = ensure(await p.text({
+    message: opts.message,
+    placeholder: opts.placeholder,
+    initialValue: opts.initialValue,
+    validate: opts.required ? (s?: string) => (s?.trim() ? undefined : 'Required') : undefined,
+  }));
+  return (v ?? '').trim();
+}
+
+export async function askConfirm(message: string, initialValue = true): Promise<boolean> {
+  return ensure(await p.confirm({ message, initialValue }));
+}
+
+export async function askSelect<T extends string>(message: string, options: Option<T>[], initialValue?: T): Promise<T> {
+  return ensure(await p.select<T>({ message, options, initialValue }));
+}

--- a/src/cli/xppConfig.ts
+++ b/src/cli/xppConfig.ts
@@ -1,0 +1,96 @@
+/**
+ * XPP config discovery (UDE / Power Platform Tools) — TypeScript counterpart
+ * of scripts/select-xpp-config.ps1 and the helpers in instances/*.ps1.
+ *
+ * Configs live in %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig as
+ * "<name>___<version>.json"; Windows-only by nature — callers on other
+ * platforms get an empty list.
+ */
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+import { getValue, readDevEnvType, readEnvValue, setValue } from './envFile.js';
+
+export interface XppConfig {
+  /** Filename without .json, e.g. "contoso-dev___10.0.2428.63" */
+  fullName: string;
+  /** Environment name before the ___ separator */
+  name: string;
+  version: string;
+  file: string;
+  mtimeMs: number;
+  modelStoreFolder?: string;
+  frameworkDirectory?: string;
+}
+
+export function xppConfigDir(): string | null {
+  const localAppData = process.env.LOCALAPPDATA;
+  if (!localAppData) return null;
+  return join(localAppData, 'Microsoft', 'Dynamics365', 'XPPConfig');
+}
+
+/** All versioned configs, newest first. Empty when the directory is absent. */
+export function listXppConfigs(): XppConfig[] {
+  const dir = xppConfigDir();
+  if (!dir || !fs.existsSync(dir)) return [];
+  const configs: XppConfig[] = [];
+  for (const entry of fs.readdirSync(dir)) {
+    const m = entry.match(/^(.+)___(.+)\.json$/);
+    if (!m) continue;
+    const file = join(dir, entry);
+    let modelStoreFolder: string | undefined;
+    let frameworkDirectory: string | undefined;
+    try {
+      const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+      modelStoreFolder = json.ModelStoreFolder;
+      frameworkDirectory = json.FrameworkDirectory;
+    } catch { /* unreadable config — still list it */ }
+    configs.push({
+      fullName: entry.replace(/\.json$/, ''),
+      name: m[1],
+      version: m[2],
+      file,
+      mtimeMs: fs.statSync(file).mtimeMs,
+      modelStoreFolder,
+      frameworkDirectory,
+    });
+  }
+  return configs.sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+/**
+ * Expand a short XPP_CONFIG_NAME (e.g. "myenv-dev") in an .env file to the
+ * newest full versioned name ("myenv-dev___10.0.2345.153") so a later
+ * staleness check is a plain file-exists test. No-op for traditional
+ * environments, full names, or when nothing matches.
+ * Returns the expansion that happened, or null.
+ */
+export function normalizeXppConfigName(envFile: string): { from: string; to: string } | null {
+  if (readDevEnvType(envFile) === 'traditional') return null;
+  const current = readEnvValue(envFile, 'XPP_CONFIG_NAME');
+  if (!current || /___/.test(current)) return null;
+
+  const match = listXppConfigs().filter(c => c.name === current);
+  if (match.length === 0) return null;
+
+  const full = match[0].fullName;
+  const content = fs.readFileSync(envFile, 'utf8');
+  fs.writeFileSync(envFile, setValue(content, 'XPP_CONFIG_NAME', full));
+  return { from: current, to: full };
+}
+
+/**
+ * True when the pinned XPP_CONFIG_NAME no longer resolves to a file —
+ * i.e. the UDE was upgraded since the instance was configured and its
+ * database is stale. Only meaningful after normalizeXppConfigName.
+ */
+export function isXppConfigStale(envFile: string): boolean {
+  if (readDevEnvType(envFile) === 'traditional') return false;
+  const configName = readEnvValue(envFile, 'XPP_CONFIG_NAME');
+  if (!configName) return false;
+  const dir = xppConfigDir();
+  if (!dir || !fs.existsSync(dir)) return false;
+  return !fs.existsSync(join(dir, `${configName}.json`));
+}
+
+// Re-export for callers that work on content strings in tests.
+export { getValue as _getValue };

--- a/tests/utils/cliEnvFile.test.ts
+++ b/tests/utils/cliEnvFile.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the CLI .env helpers — they must mirror the semantics of the
+ * PowerShell management scripts (active line wins, set replaces → uncomments
+ * → appends, commented vars count as present for the missing-settings diff).
+ */
+import { describe, expect, it } from 'vitest';
+import { getValue, missingVars, setValue, varNames } from '../../src/cli/envFile.js';
+
+describe('cli envFile helpers', () => {
+  describe('getValue', () => {
+    it('reads an active assignment and trims the value', () => {
+      expect(getValue('PORT= 8080 \nDB_PATH=./db\n', 'PORT')).toBe('8080');
+    });
+
+    it('ignores commented assignments', () => {
+      expect(getValue('# PORT=8080\n', 'PORT')).toBeNull();
+    });
+
+    it('does not match keys that only share a prefix', () => {
+      expect(getValue('DB_PATH_EXTRA=x\n', 'DB_PATH')).toBeNull();
+    });
+
+    it('returns empty string for an empty assignment', () => {
+      expect(getValue('XPP_CONFIG_NAME=\n', 'XPP_CONFIG_NAME')).toBe('');
+    });
+  });
+
+  describe('setValue', () => {
+    it('replaces an existing active line in place', () => {
+      const out = setValue('A=1\nPORT=8080\nB=2\n', 'PORT', '3001');
+      expect(out).toBe('A=1\nPORT=3001\nB=2\n');
+    });
+
+    it('un-comments a commented line when no active line exists', () => {
+      const out = setValue('# XPP_CONFIG_NAME=old\nB=2\n', 'XPP_CONFIG_NAME', 'env___10.0.1');
+      expect(out).toBe('XPP_CONFIG_NAME=env___10.0.1\nB=2\n');
+    });
+
+    it('prefers the active line over a commented one', () => {
+      const out = setValue('# PORT=1\nPORT=2\n', 'PORT', '3');
+      expect(out).toContain('# PORT=1');
+      expect(out).toContain('PORT=3');
+      expect(out).not.toContain('PORT=2');
+    });
+
+    it('appends with a trailing newline when the key is absent', () => {
+      expect(setValue('A=1', 'NEW', 'x')).toBe('A=1\nNEW=x\n');
+      expect(setValue('A=1\n\n', 'NEW', 'x')).toBe('A=1\nNEW=x\n');
+    });
+
+    it('treats regex metacharacters in values literally', () => {
+      const out = setValue('P=$old\n', 'P', 'C:\\a$b');
+      expect(out).toBe('P=C:\\a$b\n');
+    });
+
+    it("does not expand replacement-string sequences like $& or $'", () => {
+      expect(setValue('SECRET=x\n', 'SECRET', "a$&b$'c")).toBe("SECRET=a$&b$'c\n");
+    });
+  });
+
+  describe('varNames / missingVars', () => {
+    it('counts commented assignments as present', () => {
+      expect(varNames('A=1\n# B=2\n  # C = 3\nnot a var\n')).toEqual(['A', 'B', 'C']);
+    });
+
+    it('reports example vars absent from the env, with active example values', () => {
+      const example = 'A=1\nB=two\nC=3\n';
+      const env = 'A=changed\n# B=disabled\n';
+      expect(missingVars(example, env)).toEqual([{ name: 'C', value: '3' }]);
+    });
+
+    it('shows an empty value for example vars that are only commented', () => {
+      expect(missingVars('# C=3\n', '')).toEqual([{ name: 'C', value: '' }]);
+    });
+
+    it('reports each missing var only once, with the active value', () => {
+      const example = '# D=x\nD=y\n';
+      expect(missingVars(example, '')).toEqual([{ name: 'D', value: 'y' }]);
+    });
+  });
+});

--- a/tests/utils/cliInstances.test.ts
+++ b/tests/utils/cliInstances.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { suggestPort } from '../../src/cli/instances.js';
+
+const inst = (name: string, port: number | null) =>
+  ({ name, dir: `/x/${name}`, envFile: `/x/${name}/.env`, port });
+
+describe('cli suggestPort', () => {
+  it('defaults to 3001 with no instances', () => {
+    expect(suggestPort([])).toBe(3001);
+  });
+
+  it('suggests max used port + 1', () => {
+    expect(suggestPort([inst('a', 3001), inst('b', 3005), inst('c', 3002)])).toBe(3006);
+  });
+
+  it('ignores instances without a parseable port', () => {
+    expect(suggestPort([inst('a', null)])).toBe(3001);
+  });
+});


### PR DESCRIPTION
## What

New `d365fo-mcp` management CLI so developers handle first-time setup, updates, index rebuilds and multi-instance management from one interactive tool instead of stitching together npm scripts, PowerShell scripts and SETUP.md.

Every operation is a plain subcommand (scriptable, CI-friendly); missing arguments are asked for interactively with predefined choices (`@clack/prompts` + `commander`). Running bare `d365fo-mcp` opens a menu.

| Command | Purpose |
|---------|---------|
| `setup` | First-time wizard over the SETUP.md scenarios A–F: install, C# bridge build, `.env` configuration with an XPP-config picker, index build, prints the `.mcp.json` block to paste |
| `doctor` | Environment/installation health check with a fix per finding — Node version, build, DB presence/size, bridge exe, stale UDE configs, live `/health` probes; exit 1 on blocking problems |
| `start [name]` | Run the root server or an instance in the foreground (with UDE staleness guard) |
| `update [--yes]` | `git pull` + `npm install` + build, optional bridge rebuild and reindex |
| `index [name\|--all]` | Rebuild the metadata index; warns about `.env` keys missing vs `.env.example`, normalizes `XPP_CONFIG_NAME` |
| `instance add/list/run/rebuild/upgrade` | TS port of `instances/*.ps1`, incl. repointing an instance after a UDE upgrade |

Entry points: `npx d365fo-mcp` (bin → `dist/cli/index.js`), `npm run setup`, `npm run doctor`, `npm run cli --`.

The PowerShell scripts keep working as a fallback; this PR also fixes a broken line break in `instances/run-instance.ps1` that disabled its exit-code handling (separate commit).

## Docs

README Quick Start gained an "Interactive setup (recommended)" section; docs/SETUP.md points to the CLI next to the scenario choice and the multi-instance section.

## Testing

- 17 new unit tests for the `.env` helpers (replace → uncomment → append semantics, missing-settings diff) and port suggestion
- Full unit suite green: 98 files, 1464 tests
- Smoke-tested: `--help`, `doctor` (exit codes), non-interactive `instance add` + `list`, built `dist/cli` runs standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)