### PR TITLE
fix: pin @rolldown/binding-wasm32-wasi to prevent lock drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
   "engines": {
     "node": ">=24.0.0"
   },
+  "overrides": {
+    "@rolldown/binding-wasm32-wasi": "1.1.3"
+  },
   "allowScripts": {
     "better-sqlite3@12.11.1": true,
     "esbuild@0.28.1": true


### PR DESCRIPTION
Follow-up to #626. Deploy still failed after merge because `rolldown` (transitive dep of vitest -> vite) publishes frequent patches, each re-pinning a different `@emnapi/core`/`@emnapi/runtime` version for its optional `wasm32-wasi` binding. This caused `npm ci` to intermittently fail with a lock-file mismatch even right after a fresh `npm install`.

Adds an `overrides` entry pinning `@rolldown/binding-wasm32-wasi` to the version already resolved in `package-lock.json`, so it stops floating on every install.