### PR TITLE
fix: add @emnapi/core+runtime 1.11.2 to lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -334,6 +334,29 @@
         "node": ">= 20.12.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",


### PR DESCRIPTION
## Problem

The `d365fo-mcp-app-deploy` pipeline (`npm ci` on ubuntu-latest / Node 24) fails:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Missing: @emnapi/core@1.11.2 from lock file
npm error Missing: @emnapi/runtime@1.11.2 from lock file
```

## Root cause

Not the wasm binding itself — that's already pinned (`@rolldown/binding-wasm32-wasi@1.1.3`, whose manifest hard-pins emnapi to `1.11.1`). The drift comes from its transitive `@napi-rs/wasm-runtime`, which declares emnapi as **peer dependencies** with a floating range:

```
peerDependencies:
  @emnapi/core:    ^1.7.1
  @emnapi/runtime: ^1.7.1
```

When `@emnapi/*@1.11.2` was published, the CI resolver picked it as the top-level peer, but the lock only had emnapi `1.11.1` nested under the wasm binding — hence "missing from lock file".

## Fix

Add the missing top-level `@emnapi/core@1.11.2` and `@emnapi/runtime@1.11.2` nodes (integrity verified against the registry). Purely additive — 23 lines, 0 deletions, no `package.json` change. `npm ci` passes locally.

## Follow-up (durable fix)

This is the same class of bandaid as #626 / #627 and **will recur** when `@emnapi/1.11.3` ships. A permanent fix pins the floating peer via `overrides` (`@emnapi/core`/`@emnapi/runtime`), but that restructures the lock and must be regenerated on Linux (the optional wasm chain gets pruned on macOS). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)