### PR TITLE
fix: bridge EDT create silently drops requested base type (BaseType/edtType key mismatch)

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -4043,6 +4043,18 @@ export async function handleCreateD365File(
           if (props.fields) bridgeParams.fields = props.fields as Record<string, unknown>[];
         }
 
+        // For EDTs: translate the tool's documented `edtType` property to the bridge's
+        // expected `BaseType` key. C# CreateEdt() does `properties.TryGetValue("BaseType", ...)`
+        // — a literal, case-SENSITIVE dictionary lookup — so sending `edtType` (as documented
+        // in the tool schema and as suggest_edt/prepare recommend) never matched, silently
+        // defaulting every bridge-created EDT to AxEdtString regardless of the requested type
+        // (Real, Int, Date, Enum, ...). Confirmed via a live create of an EDT with
+        // edtType:"Real", extends:"AmountCur" — the written XML came back i:type="AxEdtString".
+        if (args.objectType === 'edt' && bridgeParams.properties && 'edtType' in bridgeParams.properties) {
+          const { edtType, ...rest } = bridgeParams.properties;
+          bridgeParams.properties = { ...rest, BaseType: edtType };
+        }
+
         const bridgeResult = await bridgeCreateObject(context.bridge, bridgeParams);
         if (bridgeResult?.success && bridgeResult.filePath) {
           console.error(`[create_d365fo_file] ✅ Created via C# bridge: ${bridgeResult.filePath}`);

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -519,6 +519,42 @@ describe('create_d365fo_file', () => {
     ]);
   });
 
+  it('edt create translates properties.edtType to the bridge\'s BaseType key', async () => {
+    // Regression (eval scenario 1 — Equipment Rental): C# CreateEdt() picks the concrete
+    // AxEdt subclass via `properties.TryGetValue("BaseType", ...)` — a literal, case-sensitive
+    // dictionary lookup. The tool's documented/schema property name is `edtType` (see
+    // suggest_edt / prepare / d365fo_file docs), so it never matched and every bridge-created
+    // EDT silently defaulted to AxEdtString no matter what type was requested. Verified live:
+    // edtType:"Real" + extends:"AmountCur" wrote i:type="AxEdtString" to disk.
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxEdt\\MyDailyRate.xml',
+      api: 'IMetaEdtProvider.Create',
+    }));
+    const ctx = buildContext();
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, createObject, validateObject: vi.fn(async () => null) };
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'edt',
+        objectName: 'DailyRate',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: { label: '@Contoso:DailyRate', extends: 'AmountCur', edtType: 'Real' },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(createObject).toHaveBeenCalledTimes(1);
+    const sentParams = createObject.mock.calls[0][0];
+    expect(sentParams.properties.BaseType).toBe('Real');
+    expect(sentParams.properties.edtType).toBeUndefined();
+    expect(sentParams.properties.Extends ?? sentParams.properties.extends).toBe('AmountCur');
+  });
+
   it('blocks form-extension create when xmlContent uses the malformed control shape', async () => {
     // Guard: the deserializer-rejecting shape an AI tends to hand-write
     // (AxFormControlExtension / ParentControlName / FormControlExtension-wrapping / AxFormIntControl)


### PR DESCRIPTION
## Summary
- `d365fo_file(action="create", objectType="edt")` goes through the C# bridge's `IMetaEdtProvider.Create()`, which selects the concrete `AxEdt*` subclass via `properties.TryGetValue("BaseType", ...)` — a literal, case-sensitive dictionary lookup.
- The TS write path (`src/tools/createD365File.ts`) never sent a `BaseType` key: it forwarded the tool's documented `edtType` property (`Real`/`Int`/`Date`/`Enum`/...) verbatim as a scalar property, so the C# lookup always missed and every bridge-created EDT silently defaulted to `AxEdtString`, no matter what type was requested.
- Fix: translate `edtType` → `BaseType` in the bridge properties payload right before calling `createObject`, matching the existing per-`objectType` special-case blocks already used for `table`/`enum`/`view` a few lines below in the same function.

## Evidence this is a genuine tool defect (not a model/prompt error)
Found live while re-running the eval-loop "Equipment Rental" greenfield scenario (`docs/USAGE_EXAMPLES.md` scenario 1) against a throwaway `fm-mcp` sandbox model:

```
d365fo_file(action="create", objectType="edt", objectName="RentDailyRate",
  properties={"label": "@fm-mcp:RentDailyRate", "extends": "AmountCur", "edtType": "Real"})
```
reported success, but the written XML was:
```xml
<AxEdt ... i:type="AxEdtString">
  <Name>FmMcpRentDailyRate</Name>
  <Extends>AmountCur</Extends>
  ...
```
i.e. a `Real`-typed EDT (extending the `Real`-based `AmountCur`) was silently written as a `String` EDT. This is the same class of bug already documented in `docs/USAGE_EXAMPLES.md` scenario 2 for `edtType="Enum"` (`AxEdtEnum` → `AxEdtString`), but the root cause is broader: it is not enum-specific, it is *every* non-default `edtType` value, because the bridge never received the key it was looking for at all.

`extends`/`label` were unaffected because `SetAxEdtProperty` (the per-key setter) does a case-insensitive `ToLowerInvariant()` switch and correctly matched `extends`/`label`/`stringSize` — only the base-type-selection lookup at construction time uses the case-sensitive, unaliased `"BaseType"` key.

## Fix
`src/tools/createD365File.ts`: after building `bridgeParams`, for `objectType === 'edt'`, rename `edtType` → `BaseType` in `bridgeParams.properties`.

## Test plan
- [x] New regression test in `tests/tools/file-ops.test.ts` asserting the bridge receives `properties.BaseType === 'Real'` (not `edtType`) for `edtType: "Real"`, reproducing the exact Real/AmountCur case from the live run.
- [x] Full suite: `npm test` — 98 files / 1465 tests passed.
- [x] `npm run build` (tsc) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)