### PR TITLE
fix: enum-extension create silently drops properties.enumValues

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -4029,9 +4029,15 @@ export async function handleCreateD365File(
           }
         }
 
-        // For enums: pass values from properties.
+        // For enums AND enum-extensions: pass values from properties.
         // Accept both `enumValues` (documented in tool description) and `values` (legacy).
-        if (args.objectType === 'enum' && args.properties) {
+        // Regression: only 'enum' was handled here, so an enum-extension's properties.enumValues
+        // never reached bridgeParams.values — C# CreateEnumExtension() happily accepts a `values`
+        // list, but was always called with null, silently writing an empty <EnumValues />
+        // (write reported success; the dropped value surfaced two calls later as an unrelated
+        // "unresolved enum value" build error). Same class of bug as the table/table-extension
+        // fields gap fixed above.
+        if ((args.objectType === 'enum' || args.objectType === 'enum-extension') && args.properties) {
           const props = args.properties as Record<string, unknown>;
           const enumVals = (props.enumValues ?? props.values) as Record<string, unknown>[] | undefined;
           if (enumVals) bridgeParams.values = enumVals;

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -519,6 +519,41 @@ describe('create_d365fo_file', () => {
     ]);
   });
 
+  it('enum-extension create forwards properties.enumValues to the bridge as `values`', async () => {
+    // Regression (eval scenario 1 — Equipment Rental): only objectType==='enum' populated
+    // bridgeParams.values, so an enum-extension's properties.enumValues never reached the
+    // bridge. C# CreateEnumExtension(name, modelName, values, properties) happily accepts a
+    // values list, but was always invoked with null — the write reported success while
+    // <EnumValues /> came back empty on disk. Reproduced live: adding a "Rent" value to the
+    // standard NumberSeqModule enum via objectType="enum-extension" wrote an empty
+    // <EnumValues /> despite enumValues:[{name:"Rent"}] being passed.
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxEnumExtension\\NumberSeqModule.MyExt.xml',
+      api: 'IMetaEnumExtensionProvider.Create',
+    }));
+    const ctx = buildContext();
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, createObject, validateObject: vi.fn(async () => null) };
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'enum-extension',
+        objectName: 'NumberSeqModule',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: { enumValues: [{ name: 'Rent', label: '@Contoso:RentModule' }] },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(createObject).toHaveBeenCalledTimes(1);
+    const sentParams = createObject.mock.calls[0][0];
+    expect(sentParams.values).toEqual([{ name: 'Rent', label: '@Contoso:RentModule' }]);
+  });
+
   it('blocks form-extension create when xmlContent uses the malformed control shape', async () => {
     // Guard: the deserializer-rejecting shape an AI tends to hand-write
     // (AxFormControlExtension / ParentControlName / FormControlExtension-wrapping / AxFormIntControl)


### PR DESCRIPTION
## Summary
- `d365fo_file(action="create", objectType="enum-extension")` goes through the C# bridge's `IMetaEnumExtensionProvider.Create()` via `CreateEnumExtension(name, modelName, values, properties)`, which correctly populates `<EnumValues/>` when given a `values` list.
- The TS write path (`src/tools/createD365File.ts`) only forwarded `properties.enumValues` into `bridgeParams.values` when `objectType === 'enum'` — the `'enum-extension'` case fell through the check entirely, so `bridgeParams.values` was always `undefined` for extensions. The bridge call still reports success; it just writes a structurally valid, empty `<EnumValues />`.
- Fix: broaden the condition to also match `'enum-extension'`, mirroring the existing table vs. table-extension `fields` fix a few lines above in the same function (same defect class, previously already found and fixed for tables but not carried over to enums).

## Evidence this is a genuine tool defect (not a model/prompt error)
This is a re-confirmation of a defect already flagged (but not root-caused) in `docs/USAGE_EXAMPLES.md` scenario 1's gotchas ("`d365fo_file(create, objectType="enum-extension")` can silently drop the enum value being added"). Reproduced live while re-running that exact scenario against a throwaway `fm-mcp` sandbox model:

```
d365fo_file(action="create", objectType="enum-extension", objectName="NumberSeqModule",
  properties={"enumValues": [{"name": "Rent", "label": "@fm-mcp:RentModuleMenu"}]})
```
reported success, but the written XML was:
```xml
<AxEnumExtension ...>
  <Name>NumberSeqModule.FmMcpExtension</Name>
  <EnumValues />
  ...
```
Root cause traced to `src/tools/createD365File.ts`: the block that lifts `properties.enumValues` into `bridgeParams.values` gates on `args.objectType === 'enum'` only, so it never runs for `'enum-extension'`. The C# side (`MetadataWriteService.CreateEnumExtension`) was never the problem — it happily builds `AxEnumValue` entries from `values` when given a non-null list.

## Fix
`src/tools/createD365File.ts`: change the gate to `args.objectType === 'enum' || args.objectType === 'enum-extension'`.

## Test plan
- [x] New regression test in `tests/tools/file-ops.test.ts` asserting the bridge receives `sentParams.values` for an `enum-extension` create with `properties.enumValues` set.
- [x] Full suite: `npm test` — 98 files / 1465 tests passed.
- [x] `npm run build` (tsc) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)