### PR TITLE
fix: table/table-extension create silently mistypes EDT-based fields and drops index name/fields

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -23,6 +23,7 @@ import { gateOnReferenceErrors } from './resolveReferences.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 import { buildAxSecurityPrivilegeXml } from './securityPrivilegeXml.js';
 import { buildAxDataEntityXml } from './dataEntityXml.js';
+import { resolveEdtBaseType, heuristicEdtBaseType, isEnumName, bridgeEdtBaseType } from './generateSmartTable.js';
 import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
 import { buildAxMapXml } from './mapXml.js';
 
@@ -262,6 +263,42 @@ export function normalizeFieldSpecsForBridge(
     if (f.mandatory != null) out.mandatory = f.mandatory;
     if (f.label != null) out.label = f.label;
     if (f.stringSize != null) out.stringSize = f.stringSize;
+    return out;
+  });
+}
+
+/**
+ * Normalize the flexible index specs accepted by the tool into the key shape the
+ * C# bridge's WriteIndexParam actually deserializes: `{ name, fields: string[],
+ * alternateKey?, allowDuplicates? }`.
+ *
+ * CRITICAL: the ONLY index shape documented anywhere in the tool's schema is the
+ * `modify(operation="add-index")` one — `{ indexName, indexFields: [{ fieldName }] }`
+ * — and `modifyD365File.ts` correctly translates those keys before calling the
+ * bridge. But `d365fo_file(action="create", objectType="table"|"table-extension",
+ * properties.indexes=[...])` forwarded `properties.indexes` to the bridge
+ * UNTRANSLATED. WriteIndexParam has no `indexName`/`indexFields` properties, so
+ * System.Text.Json silently ignores both unrecognized keys — the create call still
+ * reports success, but the written index has an empty Name and an empty Fields
+ * list, which xppc rejects at build time ("the name of the '1st' index is not
+ * valid"). Accept both the bridge's native `{name, fields}` shape and the
+ * documented `{indexName, indexFields}` shape so create behaves the same as modify.
+ */
+export function normalizeIndexSpecsForBridge(
+  indexes: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  return indexes.map((idx) => {
+    const name = idx.name ?? idx.indexName;
+    const rawFields = (idx.fields ?? idx.indexFields) as unknown[] | undefined;
+    const fields = Array.isArray(rawFields)
+      ? rawFields
+          .map((f) => (typeof f === 'string' ? f : (f as Record<string, unknown> | null)?.fieldName))
+          .filter((f): f is string => typeof f === 'string' && f.length > 0)
+      : undefined;
+    const out: Record<string, unknown> = { name };
+    if (fields && fields.length > 0) out.fields = fields;
+    if (idx.alternateKey != null) out.alternateKey = idx.alternateKey;
+    if (idx.allowDuplicates != null) out.allowDuplicates = idx.allowDuplicates;
     return out;
   });
 }
@@ -4019,13 +4056,40 @@ export async function handleCreateD365File(
           const props = args.properties as Record<string, unknown>;
           if (props.fields) bridgeParams.fields = normalizeFieldSpecsForBridge(props.fields as Record<string, unknown>[]);
           if (props.fieldGroups) bridgeParams.fieldGroups = props.fieldGroups as Record<string, unknown>[];
-          if (props.indexes) bridgeParams.indexes = props.indexes as Record<string, unknown>[];
+          if (props.indexes) bridgeParams.indexes = normalizeIndexSpecsForBridge(props.indexes as Record<string, unknown>[]);
           if (props.relations) bridgeParams.relations = props.relations as Record<string, unknown>[];
           if (props.methods) {
             bridgeParams.methods = (props.methods as { name: string; source?: string }[]).map(m => ({
               ...m,
               source: m.source !== undefined ? reindentXppSource(m.source) : m.source,
             }));
+          }
+
+          // Resolve each field's base type from its EDT when the caller only gave
+          // `edt` (the documented usage — the tool schema says "EDT auto-resolved
+          // when omitted"). Without this, C# CreateTableField() defaults ANY field
+          // whose `type` is unset to AxTableFieldString regardless of the EDT's real
+          // base type — a Real-based EDT (e.g. a rate/amount) or a Date-based EDT
+          // silently becomes a string field. `generateSmartTable`/`generate_object`
+          // already resolve this; the plain d365fo_file(create, table/table-extension)
+          // path never did. Mirrors that resolution: bridge (authoritative) → indexed
+          // edt_metadata chain → name heuristic.
+          if (bridgeParams.fields && bridgeParams.fields.length > 0) {
+            const db = context.symbolIndex?.getReadDb?.();
+            for (const f of bridgeParams.fields as Record<string, unknown>[]) {
+              const edt = f.edt as string | undefined;
+              if (!edt || f.type) continue;
+              if (db && !f.enumType && isEnumName(edt, db)) {
+                f.enumType = edt;
+                f.type = 'Enum';
+                delete f.edt;
+                continue;
+              }
+              const resolved = (await bridgeEdtBaseType(context.bridge, edt))
+                ?? (db ? resolveEdtBaseType(edt, db) : undefined)
+                ?? heuristicEdtBaseType(edt);
+              if (resolved) f.type = resolved;
+            }
           }
         }
 

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -1084,7 +1084,7 @@ export async function handleGenerateSmartTable(
  * unavailable, doesn't know the EDT, or reports it as Enum (enum-backed EDTs are
  * handled separately via the enumType path, so we must not emit a bare "Enum" here).
  */
-async function bridgeEdtBaseType(bridge: BridgeClient | undefined, edtName: string): Promise<string | undefined> {
+export async function bridgeEdtBaseType(bridge: BridgeClient | undefined, edtName: string): Promise<string | undefined> {
   if (!bridge?.isReady) return undefined;
   try {
     const info = await bridge.readEdt(edtName);

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -519,6 +519,89 @@ describe('create_d365fo_file', () => {
     ]);
   });
 
+  it('table create resolves a field\'s base type from its EDT when only `edt` is given', async () => {
+    // Regression (eval scenario 1 — Equipment Rental): d365fo_file(create, objectType="table")
+    // never resolved a field's base type from its EDT — only generateSmartTable/generate_object
+    // did. C# CreateTableField() defaults any field whose `type` is unset to AxTableFieldString,
+    // so a Real-based EDT (e.g. a daily-rate EDT extending AmountCur) or a Date-based EDT
+    // silently became a string field. Reproduced live: a table field `{ name: "DailyRate", edt:
+    // "AC_RentDailyRate" }` (EDT extends AmountCur, a Real EDT) was written as
+    // i:type="AxTableFieldString" — no build error, just silently wrong, until later X++ against
+    // the field (e.g. Qty * DailyRate) fails to compile.
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml',
+      api: 'IMetaTableProvider.Create',
+    }));
+    const ctx = buildContext();
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, createObject, validateObject: vi.fn(async () => null) };
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'table',
+        objectName: 'MyTable',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: {
+          fields: [
+            { name: 'DailyRate', edt: 'ContosoRentDailyRate' }, // no explicit type — must be resolved
+          ],
+        },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(createObject).toHaveBeenCalledTimes(1);
+    const sentParams = createObject.mock.calls[0][0];
+    // No index/bridge EDT info available in this unit test — falls back to the name heuristic,
+    // which recognizes "...Rate" as Real. The point under test is that `type` is populated
+    // AT ALL from the edt, not left undefined (which the bridge treats as "String").
+    expect(sentParams.fields[0].type).toBe('Real');
+    expect(sentParams.fields[0].edt).toBe('ContosoRentDailyRate');
+  });
+
+  it('table create normalizes properties.indexes (indexName/indexFields -> name/fields)', async () => {
+    // Regression (eval scenario 1 — Equipment Rental): the only index shape documented
+    // anywhere in the tool (modify operation="add-index") is { indexName, indexFields:
+    // [{fieldName}] } — and modifyD365File.ts correctly translates those keys before calling
+    // the bridge. But d365fo_file(create, objectType="table", properties.indexes=[...]) forwarded
+    // properties.indexes UNTRANSLATED. WriteIndexParam has no indexName/indexFields properties,
+    // so System.Text.Json silently drops both — create still reports success, but the written
+    // index has an empty Name and empty Fields, which xppc rejects at build time ("the name of
+    // the '1st' index is not valid"). Reproduced live against a real table create.
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml',
+      api: 'IMetaTableProvider.Create',
+    }));
+    const ctx = buildContext();
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, createObject, validateObject: vi.fn(async () => null) };
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'table',
+        objectName: 'MyTable',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: {
+          fields: [{ name: 'MyId', edt: 'RefRecId', type: 'Int64' }],
+          indexes: [{ indexName: 'MyIdIdx', alternateKey: true, indexFields: [{ fieldName: 'MyId' }] }],
+        },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(createObject).toHaveBeenCalledTimes(1);
+    const sentParams = createObject.mock.calls[0][0];
+    expect(sentParams.indexes).toEqual([{ name: 'MyIdIdx', fields: ['MyId'], alternateKey: true }]);
+  });
+
   it('blocks form-extension create when xmlContent uses the malformed control shape', async () => {
     // Guard: the deserializer-rejecting shape an AI tends to hand-write
     // (AxFormControlExtension / ParentControlName / FormControlExtension-wrapping / AxFormIntControl)


### PR DESCRIPTION
## Summary
Two related gaps in the same code path — `d365fo_file(action="create", objectType="table"|"table-extension")`:

**1. Field base-type resolution never wired into the plain create path.**
`generateSmartTable`/`generate_object` already resolve a field's base type from its EDT (bridge `readEdt` → indexed `edt_metadata` chain → name heuristic) before handing fields to the bridge, because C# `CreateTableField()` defaults ANY field whose `type` is unset to `AxTableFieldString`. The plain `d365fo_file(create)` path with `properties.fields=[{name, edt}]` — the documented "EDT auto-resolved when omitted" usage — skipped this step entirely, so any non-string EDT (Real, Date, Int64, ...) silently became a string field, with no error at table-create time.

**2. `properties.indexes` forwarded to the bridge completely untranslated.**
The only index shape documented anywhere in the tool is the `modify(operation="add-index")` one — `{ indexName, indexFields: [{fieldName}] }` — and `modifyD365File.ts` correctly maps those to the bridge's `WriteIndexParam` keys (`name`, `fields: string[]`). The create path had no equivalent mapping, so following the only documented index shape produced an index with an empty `Name` and empty `Fields` (`System.Text.Json` silently drops unrecognized keys) — the write reports success, and the next build fails with `"the name of the '1st' index is not valid"`.

## Evidence this is a genuine tool defect (not a model/prompt error)
Both reproduced live while implementing the eval-loop "Equipment Rental" greenfield scenario (`docs/USAGE_EXAMPLES.md` #1) against a throwaway `fm-mcp` sandbox model:

- Created `FmMcpRentEquipment` with a field `{ name: "DailyRate", edt: "FmMcpRentDailyRate" }` (`FmMcpRentDailyRate` extends `AmountCur`, a `Real` EDT). The write reported success; the produced XML had `i:type="AxTableFieldString"` on `DailyRate` (and `AcquiredDate`, edt `TransDate`) instead of `AxTableFieldReal`/`AxTableFieldDate`.
- Same create call's `properties.indexes = [{ indexName: "RentEquipmentIdIdx", alternateKey: true, indexFields: [{fieldName: "RentEquipmentId"}] }]` wrote `<AxTableIndex><AlternateKey>Yes</AlternateKey><Fields /></AxTableIndex>` — no `<Name>` element, no fields — and the very next `build_d365fo_project` failed with:
  ```
  MetadataProvider Error: Table dynamics://Table/FmMcpRentEquipment: On table 'FmMcpRentEquipment', the name of the '1st' index is not valid.
  ```

## Fix
- `src/tools/createD365File.ts`: after `normalizeFieldSpecsForBridge`, resolve each field's base type from its `edt` using the same priority order already used elsewhere (`bridgeEdtBaseType` → `resolveEdtBaseType` (index) → `heuristicEdtBaseType` (name heuristic)), skipping fields that already have an explicit `type`. Enum-backed "EDTs" (a bare enum name passed as `edt`) are correctly redirected to `enumType`/`AxTableFieldEnum` via the existing `isEnumName` helper.
- `src/tools/generateSmartTable.ts`: exported the previously-private `bridgeEdtBaseType` helper so it can be reused.
- `src/tools/createD365File.ts`: added `normalizeIndexSpecsForBridge()`, mirroring `normalizeFieldSpecsForBridge()`, accepting both the bridge-native `{name, fields}` shape and the documented `{indexName, indexFields}` shape.

## Test plan
- [x] New regression tests in `tests/tools/file-ops.test.ts`:
  - `table create resolves a field's base type from its EDT when only \`edt\` is given` — asserts `sentParams.fields[0].type === 'Real'` for a `...Rate` EDT with no explicit `type`.
  - `table create normalizes properties.indexes (indexName/indexFields -> name/fields)` — asserts `sentParams.indexes` comes out as `[{name, fields, alternateKey}]`.
- [x] Full suite: `npm test` — 98 files / 1466 tests passed.
- [x] `npm run build` (tsc) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)