### PR TITLE
fix: incremental table re-index stores field base type instead of EDT/EnumType

### DIFF
--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -65,6 +65,7 @@ export interface XppFieldInfo {
   name: string;
   type: string;
   extendedDataType?: string;
+  enumType?: string;
   mandatory: boolean;
   label?: string;
 }

--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -237,6 +237,7 @@ export class XppMetadataParser {
         name: field.Name || 'unknown',
         type: xppType,
         extendedDataType: field.ExtendedDataType || undefined,
+        enumType: field.EnumType || undefined,
         mandatory: field.Mandatory === 'Yes' || field.Mandatory === 'true',
         label: field.Label || undefined,
       };

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -294,11 +294,22 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
           });
           insertedCount++;
           for (const field of tableData.fields ?? []) {
+            // Store the field's actual EDT/EnumType as its signature, not the bare
+            // i:type-derived base type (String/Real/Enum/...). Consumers such as
+            // modifyD365File.ts's resolveFieldEdt() (used by add-table-method to
+            // generate find()/exist() parameter types) read this column expecting
+            // an X++-usable type name. A base-type keyword is never a valid X++
+            // parameter type, so storing it here silently broke EDT resolution for
+            // every table indexed through this incremental (same-session) path —
+            // the caller's base-type-keyword guard then fell back to the bare field
+            // name, which is only coincidentally correct when the field name and
+            // its EDT are identical (never true once a model prefix is auto-applied
+            // to the EDT but not the field, e.g. field "ItemId" + EDT "Contoso_ItemId").
             symbolIndex.addSymbol({
               name: field.name,
               type: 'field',
               parentName: tableData.name,
-              signature: field.type,
+              signature: field.extendedDataType || field.enumType || field.type,
               filePath,
               model,
             });

--- a/tests/tools/updateSymbolIndex.test.ts
+++ b/tests/tools/updateSymbolIndex.test.ts
@@ -3,10 +3,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   existsSyncMock,
   readFileSyncMock,
+  readFilePromiseMock,
   bridgeRefreshProviderMock,
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   readFileSyncMock: vi.fn(),
+  readFilePromiseMock: vi.fn(),
   bridgeRefreshProviderMock: vi.fn(async () => undefined),
 }));
 
@@ -17,6 +19,13 @@ vi.mock('fs', () => ({
   },
   existsSync: existsSyncMock,
   readFileSync: readFileSyncMock,
+}));
+
+// xmlParser.ts (used by the table-reindexing path) reads files via fs/promises,
+// a separate module from the sync `fs` mocked above.
+vi.mock('fs/promises', () => ({
+  default: { readFile: readFilePromiseMock },
+  readFile: readFilePromiseMock,
 }));
 
 vi.mock('../../src/bridge/index.js', () => ({
@@ -98,5 +107,55 @@ describe('update_symbol_index label file reconciliation', () => {
     expect(context.symbolIndex.removeLabelsByFile).toHaveBeenCalledWith(filePath);
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text).toContain('3 label(s)');
+  });
+});
+
+describe('update_symbol_index table re-indexing preserves field EDT/EnumType', () => {
+  let context: XppServerContext;
+
+  beforeEach(() => {
+    context = createContext();
+    vi.clearAllMocks();
+  });
+
+  it('stores the field\'s ExtendedDataType/EnumType as its signature, not the bare base type', async () => {
+    // Regression (eval scenario 1 — Equipment Rental): the incremental table-reindex path stored
+    // `signature: field.type` (the i:type-derived base type, e.g. "String"/"Enum") instead of the
+    // field's actual EDT/EnumType. modifyD365File.ts's resolveFieldEdt() (used by
+    // add-table-method to generate find()/exist() parameter types) reads this column expecting an
+    // X++-usable type name; a base-type keyword is discarded by its own guard, which then falls
+    // back to the bare field name — wrong for every custom-prefixed model, where the field name
+    // (e.g. "MyId") and its EDT (e.g. "Contoso_MyId") are never identical. Reproduced live: right
+    // after creating a table + calling update_symbol_index on it, add-table-method(find) on that
+    // table emitted `public static MyTable find(RentEquipmentId _rentEquipmentId, ...)` — using
+    // the bare field name as a (non-existent) type — instead of the real EDT.
+    const filePath = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml';
+    existsSyncMock.mockReturnValue(true);
+    readFilePromiseMock.mockResolvedValue(`<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>MyTable</Name>
+  <Label>My table</Label>
+  <TableGroup>Main</TableGroup>
+  <Fields>
+    <AxTableField xmlns="" i:type="AxTableFieldString">
+      <Name>MyId</Name>
+      <ExtendedDataType>ContosoMyId</ExtendedDataType>
+    </AxTableField>
+    <AxTableField xmlns="" i:type="AxTableFieldEnum">
+      <Name>MyStatus</Name>
+      <EnumType>ContosoMyStatus</EnumType>
+    </AxTableField>
+  </Fields>
+</AxTable>`);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    const addSymbolCalls = (context.symbolIndex.addSymbol as any).mock.calls.map((c: any[]) => c[0]);
+    const myIdField = addSymbolCalls.find((s: any) => s.type === 'field' && s.name === 'MyId');
+    const myStatusField = addSymbolCalls.find((s: any) => s.type === 'field' && s.name === 'MyStatus');
+
+    expect(myIdField?.signature).toBe('ContosoMyId');
+    expect(myStatusField?.signature).toBe('ContosoMyStatus');
   });
 });


### PR DESCRIPTION
## Summary
`update_symbol_index(filePath=<AxTable>.xml)` re-indexes a table's fields via `xmlParser.ts`'s `parseTableFile()`, then stored `signature: field.type` per field — but `field.type` is the `i:type`-derived **base type** (String/Real/Enum/...), not the field's actual EDT or EnumType. `XppFieldInfo` separately carries `extendedDataType` (previously ignored here) and, until this change, had no `enumType` property at all (`AxTableFieldEnum`'s `<EnumType>` was never parsed at all).

`modifyD365File.ts`'s `resolveFieldEdt()` reads this `signature` column to build X++ parameter types for `add-table-method`'s generated `find()`/`exist()` methods, expecting an X++-usable type name. A base-type keyword is correctly discarded by its own guard (`isMetadataBaseTypeKeyword`) — but the fallback is the **bare field name**, which is only coincidentally a valid type when the field name and its EDT happen to be identical. That's never true once a model prefix is auto-applied to the EDT but not the field (the standard convention this whole toolset uses for custom/ISV models), so every table indexed through this incremental (same-session) path got broken `find()`/`exist()` signatures.

## Evidence this is a genuine tool defect (not a model/prompt error)
Reproduced live while implementing the eval-loop "Equipment Rental" greenfield scenario (`docs/USAGE_EXAMPLES.md` #1) against a throwaway `fm-mcp` sandbox model. Right after creating table `FmMcpRentEquipment` (field `RentEquipmentId`, EDT `FmMcpRentEquipmentId`) and calling `update_symbol_index` on it, `d365fo_file(modify, operation="add-table-method", tableMethodType="find")` generated:
```x++
public static FmMcpRentEquipment find(RentEquipmentId _rentEquipmentId, boolean _forUpdate = false)
```
using the bare field name `RentEquipmentId` as the parameter **type** — not a real type in this model at all — instead of `FmMcpRentEquipmentId`. The tool's own inline warning ("Could not resolve the EDT... defaulted to field name") flagged the symptom but not the root cause, and the generated method would fail to compile.

Note: this only affects the **live, same-session incremental indexer** (`update_symbol_index` → `xmlParser.ts`). The separate full extract-metadata/build-database pipeline already captures EDT/EnumType correctly — confirmed via `symbolIndex.ts`'s unrelated `recordTablePropertyStats`, which already reads `field.enumType` from that pipeline's JSON — so this bug was invisible for any already-indexed standard/custom object and only bit freshly-created, same-session tables (exactly the scenario this eval run exercises).

## Fix
- `src/metadata/types.ts`: add `XppFieldInfo.enumType`.
- `src/metadata/xmlParser.ts`: `parseFields()` now captures `<EnumType>`.
- `src/tools/updateSymbolIndex.ts`: field signature is now `field.extendedDataType || field.enumType || field.type` instead of the bare base type.

## Test plan
- [x] New regression test in `tests/tools/updateSymbolIndex.test.ts`: re-indexes a table with one EDT-backed field and one enum-backed field, asserts the stored `signature` is the EDT/EnumType, not the base type.
- [x] Full suite: `npm test` — 98 files / 1465 tests passed.
- [x] `npm run build` (tsc) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)