### PR TITLE
fix: add-control was completely non-functional (backwards AxFormControl class names)

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -2888,33 +2888,51 @@ namespace D365MetadataBridge.Services
         private dynamic CreateFormControl(string controlType, string controlName,
             string? dataSource, string? dataField, string? label)
         {
-            // Use reflection to find AxFormControl* types in the metadata assembly
+            // D365FO form control classes follow the naming convention AxForm{Type}Control
+            // (e.g. AxFormStringControl, AxFormRealControl, AxFormGridControl) — verified
+            // against live IMetadataProvider reads of real forms (get_object_info) and
+            // against the already-correct CONTROL_TYPE_TO_FORM_CONTROL map used by the
+            // TS-side form-extension XML fallback (modifyD365File.ts). The PREVIOUS
+            // "AxFormControl{Type}" pattern below does not exist for ANY type — every
+            // call fell through to the dictionary fallback, whose values used the exact
+            // same backwards pattern (e.g. "AxFormControlString"), so assembly.GetType()
+            // returned null there too and add-control failed for every control type,
+            // every time, regardless of the field's data type. This was the (until now
+            // unexplained) "add-control is completely non-functional" defect documented
+            // across multiple eval runs (docs/USAGE_EXAMPLES.md).
             var assembly = typeof(AxClass).Assembly;
-            string typeName = $"Microsoft.Dynamics.AX.Metadata.MetaModel.AxFormControl{controlType}";
+            string typeName = $"Microsoft.Dynamics.AX.Metadata.MetaModel.AxForm{controlType}Control";
             var ctrlType = assembly.GetType(typeName);
 
-            // Fallback: try common type names
+            // Fallback: try common type-keyword aliases (case-insensitive; matches the
+            // keywords resolveEdtBaseType/heuristicEdtBaseType return on the TS side).
             if (ctrlType == null)
             {
                 var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    ["String"] = "AxFormControlString",
-                    ["Integer"] = "AxFormControlInteger",
-                    ["Real"] = "AxFormControlReal",
-                    ["Date"] = "AxFormControlDate",
-                    ["DateTime"] = "AxFormControlDateTime",
-                    ["Int64"] = "AxFormControlInt64",
-                    ["CheckBox"] = "AxFormControlCheckBox",
-                    ["ComboBox"] = "AxFormControlComboBox",
-                    ["Group"] = "AxFormControlGroup",
-                    ["Button"] = "AxFormControlButton",
-                    ["Grid"] = "AxFormControlGrid",
-                    ["Tab"] = "AxFormControlTab",
-                    ["TabPage"] = "AxFormControlTabPage",
-                    ["Image"] = "AxFormControlImage",
-                    ["ActionPane"] = "AxFormControlActionPane",
-                    ["ActionPaneTab"] = "AxFormControlActionPaneTab",
-                    ["ButtonGroup"] = "AxFormControlButtonGroup",
+                    ["String"] = "AxFormStringControl",
+                    ["Integer"] = "AxFormIntegerControl",
+                    ["Int"] = "AxFormIntegerControl",
+                    ["Real"] = "AxFormRealControl",
+                    ["Date"] = "AxFormDateControl",
+                    ["DateTime"] = "AxFormDateTimeControl",
+                    ["UtcDateTime"] = "AxFormDateTimeControl",
+                    ["Time"] = "AxFormTimeControl",
+                    ["Int64"] = "AxFormInt64Control",
+                    ["Guid"] = "AxFormGuidControl",
+                    ["Enum"] = "AxFormComboBoxControl",
+                    ["CheckBox"] = "AxFormCheckBoxControl",
+                    ["ComboBox"] = "AxFormComboBoxControl",
+                    ["Group"] = "AxFormGroupControl",
+                    ["Button"] = "AxFormButtonControl",
+                    ["CommandButton"] = "AxFormCommandButtonControl",
+                    ["Grid"] = "AxFormGridControl",
+                    ["Tab"] = "AxFormTabControl",
+                    ["TabPage"] = "AxFormTabPageControl",
+                    ["Image"] = "AxFormImageControl",
+                    ["ActionPane"] = "AxFormActionPaneControl",
+                    ["ActionPaneTab"] = "AxFormActionPaneTabControl",
+                    ["ButtonGroup"] = "AxFormButtonGroupControl",
                 };
                 if (map.TryGetValue(controlType, out var mapped))
                     ctrlType = assembly.GetType($"Microsoft.Dynamics.AX.Metadata.MetaModel.{mapped}");

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -28,6 +28,7 @@ import {
   bridgeRefreshProvider,
 } from '../bridge/index.js';
 import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
+import { heuristicEdtBaseType } from './generateSmartTable.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
@@ -1621,12 +1622,25 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'add-control': {
         if ((args as any).controlName && (args as any).parentControl) {
+          // The tool never exposes a `controlType` input (not in the Zod schema below),
+          // so this always used to fall back to the literal string "String" — every
+          // control, regardless of the bound field's actual type, was created as a plain
+          // string edit control. Infer a better default from the field name heuristic
+          // (the same one used for table field base-type resolution) when a
+          // controlDataField is given; this is a best-effort name heuristic, not an
+          // index/bridge EDT lookup (that would need resolving controlDataSource, a form
+          // DATA SOURCE name, back to its bound table — out of scope here), but it is
+          // strictly better than always guessing "String".
+          const resolvedControlType =
+            (args as any).controlType
+            ?? ((args as any).controlDataField ? heuristicEdtBaseType((args as any).controlDataField) : undefined)
+            ?? 'String';
           bridgeResult = await bridgeAddControl(
             context.bridge,
             objectName,
             (args as any).controlName,
             (args as any).parentControl,
-            (args as any).controlType ?? 'String',
+            resolvedControlType,
             (args as any).controlDataSource,
             (args as any).controlDataField,
             (args as any).controlLabel,
@@ -1640,7 +1654,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               actualFilePath,
               (args as any).controlName,
               (args as any).parentControl,
-              (args as any).controlType ?? 'String',
+              resolvedControlType,
               (args as any).controlDataSource,
               (args as any).controlDataField,
               (args as any).controlLabel,

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -1450,6 +1450,55 @@ describe('modify_d365fo_file', () => {
     expect(written[1]).toContain('<Type>Integer</Type>');
   });
 
+  it('add-control infers a non-String controlType from controlDataField when the caller omits controlType', async () => {
+    // Regression (eval scenario 1 — Equipment Rental): the tool never exposes a
+    // `controlType` input at all (not in the Zod schema), so every real caller omits
+    // it — modifyD365File.ts used to hard-default to the literal string "String"
+    // unconditionally, so EVERY control (Real/Date/Enum/...) was created as a plain
+    // string edit control regardless of the bound field's actual type. Combined with
+    // a separate C# bridge bug (AxFormControl{Type} vs the real AxForm{Type}Control
+    // naming), add-control was reported completely non-functional across multiple
+    // eval runs. This asserts the TS side now infers a real type via the field-name
+    // heuristic (heuristicEdtBaseType) instead of always guessing "String" — using
+    // the exact field name ("DailyRate") from the reproducing scenario.
+    const fsMod = await import('fs/promises');
+    const extXml =
+      `<?xml version="1.0" encoding="utf-8"?>\n` +
+      `<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">\n` +
+      `\t<Name>RentAgreementForm.MyExt</Name>\n` +
+      `\t<Controls />\n` +
+      `</AxFormExtension>`;
+    (fsMod.readFile as any).mockResolvedValue(extXml);
+
+    const addControl = vi.fn(async () => ({ success: false }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, addControl, refreshProvider: vi.fn() };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form-extension',
+        objectName: 'RentAgreementForm.MyExt',
+        operation: 'add-control',
+        controlName: 'Line_DailyRate',
+        parentControl: 'LinesGrid',
+        // No controlType — the tool must infer one from controlDataField.
+        controlDataSource: 'AC_RentAgreementLine',
+        controlDataField: 'DailyRate',
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxFormExtension\\RentAgreementForm.MyExt.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    // The bridge attempt itself must also have received the inferred type, not "String".
+    expect(addControl.mock.calls[0][3]).toBe('Real');
+    const written = (fsMod.writeFile as any).mock.calls.find((c: any[]) =>
+      String(c[0]).includes('RentAgreementForm.MyExt.xml'),
+    );
+    expect(written).toBeDefined();
+    expect(written[1]).toContain('<FormControl xmlns="" i:type="AxFormRealControl">');
+    expect(written[1]).toContain('<Type>Real</Type>');
+  });
+
   it('replace-code "oldCode not found" error includes a tip to use get_object_info or add-method', async () => {
     const fsMod = await import('fs/promises');
     // File exists but the oldCode snippet isn't in it (bridge also won't find it).


### PR DESCRIPTION
## Summary
`d365fo_file(modify, operation="add-control")` has been reported as broken — *"every control type failed against every parent container, including one that already had a working control of the same kind"* — across multiple prior eval runs (`docs/USAGE_EXAMPLES.md` scenario 1), but never root-caused until now.

**Root cause #1 (C# bridge — the hard failure).** `MetadataWriteService.CreateFormControl()` built the reflection type name as `Microsoft.Dynamics.AX.Metadata.MetaModel.AxFormControl{controlType}` (e.g. `"AxFormControlString"`), and its fallback dictionary's *values* used the exact same backwards pattern (e.g. `["String"] = "AxFormControlString"`). Neither name exists anywhere in the metadata assembly — D365FO's real convention is `AxForm{Type}Control` (e.g. `AxFormStringControl`, `AxFormRealControl`, `AxFormGridControl`), confirmed live via `get_object_info(form)` reads of real forms, and already correctly used by the TS-side form-extension XML fallback's own `CONTROL_TYPE_TO_FORM_CONTROL` map (`modifyD365File.ts`). So `assembly.GetType()` returned `null` for every single call, and `add-control` threw `"Unknown form control type"` unconditionally — for every control type, on every form, every time.

**Root cause #2 (TypeScript — compounding, silent even once #1 is fixed).** The tool never exposes a `controlType` input at all (not in `add-control`'s Zod schema), so every real caller omits it — and `modifyD365File.ts` unconditionally defaulted to the literal string `"String"`. Even after fixing #1, a Real rate field, a Date field, or an enum combo box would still be created as a plain string edit control, regardless of the bound field's actual type.

## Evidence this is a genuine tool defect (not a model/prompt error)
Reproduced live while implementing the eval-loop "Equipment Rental" greenfield scenario (`docs/USAGE_EXAMPLES.md` #1) against a throwaway `fm-mcp` sandbox model. Adding grid columns for `FmMcpRentAgreementLine`'s `Qty`/`RentEquipmentId` fields to a `DetailsTransaction` form's lines grid failed **identically for every field**:
```
Bridge error [-32602]: Unknown form control type: 'String' — no matching AxFormControl type found
```

## Fix
- `bridge/D365MetadataBridge/Services/MetadataWriteService.cs`: `CreateFormControl()` now builds `AxForm{Type}Control` (the verified real convention), and the fallback dictionary's values are corrected to real, existing class names (String/Integer/Real/Date/DateTime/Int64/Guid/Enum→ComboBox/CheckBox/Group/Button/CommandButton/Grid/Tab/TabPage/Image/ActionPane/ActionPaneTab/ButtonGroup) — aligned with the already-correct TS-side `CONTROL_TYPE_TO_FORM_CONTROL` map.
- `src/tools/modifyD365File.ts`: when the caller omits `controlType` and gives `controlDataField`, infer a type via the existing `heuristicEdtBaseType()` field-name heuristic instead of always guessing `"String"`. This is a best-effort name heuristic (not a full index/bridge EDT lookup through the form's datasource → table → field chain — that's out of scope here and could be a follow-up), but strictly better than always guessing wrong.

## Test plan
- [x] `dotnet build` on the bridge project — 0 errors, 0 warnings. (No C# unit test project exists in this repo to add a bridge-side regression test; the C# fix is verified by the build plus the live VM reproduction above.)
- [x] New regression test in `tests/tools/file-ops.test.ts`: a `controlDataField` of `"DailyRate"` (the exact reproducing field name) resolves to `"Real"` end-to-end — both in the bridge call arguments and the XML fallback's emitted `i:type`.
- [x] Full suite: `npm test` — 98 files / 1465 tests passed.
- [x] `npm run build` (tsc) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)