### PR TITLE
knowledge: document AxMenuElementSubMenu for nested submenus (was undocumented)

### DIFF
--- a/src/tools/xppKnowledge.ts
+++ b/src/tools/xppKnowledge.ts
@@ -2330,6 +2330,54 @@ finally
     ],
     related: ['set-based', 'select-statement', 'performance'],
   },
+
+  // ── Menus & submenu nesting ────────────────────────────────────────────────
+  {
+    id: 'menu-navigation',
+    title: 'Menus, Menu Items & Submenu Nesting',
+    keywords: ['menu', 'submenu', 'sub-menu', 'navigation', 'axmenu', 'axmenuelement', 'menu item', 'nesting', 'inquiries and reports'],
+    summary:
+      'An AxMenu is a flat <Elements> collection of AxMenuElement entries. A menu ITEM reference ' +
+      '(display/action/output) is an AxMenuElementMenuItem. A NESTED SUBMENU (another AxMenu shown ' +
+      'as a folder inside this one, e.g. "Inquiries and reports") is a DIFFERENT element type — ' +
+      'AxMenuElementSubMenu — with its own field name, not a menu-item reference.',
+    rules: [
+      'Menu-item reference: <AxMenuElement i:type="AxMenuElementMenuItem"><Name>X</Name><MenuItemName>X</MenuItemName></AxMenuElement>',
+      'Submenu reference (nesting another AxMenu inside this one): <AxMenuElement i:type="AxMenuElementSubMenu"><Name>X</Name><SubMenu>X</SubMenu></AxMenuElement> — ' +
+        'the field is <SubMenu>, NOT <MenuName> and NOT <MenuItemName>. Verified against the real ' +
+        'Microsoft.Dynamics.AX.Metadata.dll type names: AxMenuElementMenuItem, AxMenuElementSubMenu, ' +
+        'AxMenuElementSeparator, AxMenuElementTile, AxMenuElementMenuReference (a different, legacy concept — not the one you want for a plain submenu).',
+      '❌ There is no tool operation to add a submenu automatically: add-menu-item-to-menu\'s menuItemToAddType only accepts "display"/"action"/"output" (menu ITEMS). To nest a submenu you must hand-author the <AxMenuElementSubMenu> element into the parent menu\'s XML (d365fo_file create/modify with overwrite) — this is a genuine, current tool gap, not a workaround to avoid.',
+      'A submenu is itself just a normal AxMenu object (create it with d365fo_file(action="create", objectType="menu")) — build its own items first, THEN add the AxMenuElementSubMenu reference to it from the parent menu.',
+      'This applies both to brand-new standalone menus AND to menu-extensions (AxMenuExtension) nesting into a standard menu (e.g. under "Inquiries and reports") — neither path has a dedicated add-submenu tool operation.',
+      'Always verify with build_d365fo_project after hand-authoring: a wrong element type name (e.g. the plausible-looking but nonexistent "AxMenuElementMenu"/"MenuName") is NOT caught by xppc itself — it only surfaces when the separate GenerateMetadata runtime-metadata step tries to deserialize the file ("cannot be deserialized as AxMenu ... no knowledge of any type that maps to this name").',
+    ],
+    examples: [
+      {
+        label: 'Parent menu with two items and one nested submenu',
+        code: `<AxMenu xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+  <Name>MyModule</Name>
+  <Label>@MyModel:MyModule</Label>
+  <Elements>
+    <AxMenuElement xmlns="" i:type="AxMenuElementMenuItem">
+      <Name>MyEquipment</Name>
+      <MenuItemName>MyEquipment</MenuItemName>
+    </AxMenuElement>
+    <AxMenuElement xmlns="" i:type="AxMenuElementMenuItem">
+      <Name>MyAgreement</Name>
+      <MenuItemName>MyAgreement</MenuItemName>
+    </AxMenuElement>
+    <!-- Nested submenu: MySetup is itself a separate AxMenu object -->
+    <AxMenuElement xmlns="" i:type="AxMenuElementSubMenu">
+      <Name>MySetup</Name>
+      <SubMenu>MySetup</SubMenu>
+    </AxMenuElement>
+  </Elements>
+</AxMenu>`,
+      },
+    ],
+    related: ['security', 'form-patterns'],
+  },
 ];
 
 // ─── Search Logic ───────────────────────────────────────────────────────────

--- a/tests/tools/xpp-knowledge.test.ts
+++ b/tests/tools/xpp-knowledge.test.ts
@@ -64,6 +64,21 @@ describe('get_xpp_knowledge', () => {
     expect(text).not.toContain('❌ No matching');
   });
 
+  it('documents AxMenuElementSubMenu (not AxMenuElementMenu) for "submenu" topic', async () => {
+    // Regression (eval scenario 1 — Equipment Rental): hand-authoring a nested submenu into a
+    // brand-new AxMenu (no tool operation exists for this — add-menu-item-to-menu only accepts
+    // display/action/output) is easy to get wrong. A plausible-looking
+    // <AxMenuElementMenu>/<MenuName> guess is NOT a real type — xppc itself doesn't catch it, only
+    // the separate GenerateMetadata step fails to deserialize it. Verified live against
+    // Microsoft.Dynamics.AX.Metadata.dll: the real type is AxMenuElementSubMenu with a <SubMenu>
+    // field. This was previously undocumented anywhere in the knowledge base.
+    const result = await xppKnowledgeTool(req({ topic: 'submenu' }));
+    const text = getText(result);
+    expect(text).toContain('AxMenuElementSubMenu');
+    expect(text).toContain('SubMenu');
+    expect(text).not.toContain('❌ No matching');
+  });
+
   it('returns detailed format with code examples', async () => {
     const result = await xppKnowledgeTool(req({ topic: 'transactions', format: 'detailed' }));
     const text = getText(result);


### PR DESCRIPTION
## Summary
Nesting a submenu into an `AxMenu` (e.g. a "Setup" folder inside a module menu, or the standard "Inquiries and reports" submenu) has no dedicated tool operation — `add-menu-item-to-menu`'s `menuItemToAddType` only accepts `"display"`/`"action"`/`"output"` (menu **items**, not sub-**menus**). This gap is already informally noted in `docs/USAGE_EXAMPLES.md` across three prior eval runs, but the knowledge base itself had **zero** entries about menus at all, and nothing documented the correct hand-authored XML shape for a plain (non-extension) menu's submenu element.

## Evidence this is a genuine knowledge gap (not a model/prompt error)
Confirmed the gap firsthand while implementing the eval-loop "Equipment Rental" scenario (`docs/USAGE_EXAMPLES.md` #1). With no tool operation and no knowledge-base guidance available, I guessed a plausible-looking shape:
```xml
<AxMenuElement i:type="AxMenuElementMenu"><Name>X</Name><MenuName>X</MenuName></AxMenuElement>
```
This is **not a real type**. `xppc` itself did not catch it (0 errors) — the mistake only surfaced when the separate `GenerateMetadata` runtime-metadata step failed to deserialize the file:
```
cannot be deserialized as 'AxMenu' ... no knowledge of any type that maps to the name ':AxMenuElementMenu'
```
Root-caused the real type by grepping readable type-name strings directly out of `Microsoft.Dynamics.AX.Metadata.dll` (`grep -a -o "AxMenuElement[A-Za-z]*"`): the real type is **`AxMenuElementSubMenu`**, and its field is **`<SubMenu>`**, not `<MenuName>`.

## Fix
Adds a new `'menu-navigation'` knowledge base entry (`src/tools/xppKnowledge.ts`, queryable via `get_xpp_knowledge`) documenting:
- The `AxMenuElementMenuItem` vs `AxMenuElementSubMenu` distinction.
- The correct `<SubMenu>` field name.
- That this applies to both plain menus and menu-extensions.
- That `xppc` alone won't catch a wrong element name (only `GenerateMetadata` will) — so hand-authored submenu XML must be verified with a full `build_d365fo_project`, not just a compile.

This is a pure knowledge-base data addition — no write-path/validator code changed, so no C# bridge changes were needed (the underlying tool gap — no `add-submenu` operation — is a feature request, not a bug in existing code, and is out of scope for this fix).

## Test plan
- [x] New regression test in `tests/tools/xpp-knowledge.test.ts`: the `"submenu"` topic surfaces `AxMenuElementSubMenu`/`SubMenu`.
- [x] Full suite: `npm test` — 98 files / 1465 tests passed.
- [x] `npm run build` (tsc) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)