### PR TITLE
fix: table/table-extension EDT field resolution loses enum name and mistypes *DateTime EDTs

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -23,7 +23,7 @@ import { gateOnReferenceErrors } from './resolveReferences.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 import { buildAxSecurityPrivilegeXml } from './securityPrivilegeXml.js';
 import { buildAxDataEntityXml } from './dataEntityXml.js';
-import { resolveEdtBaseType, heuristicEdtBaseType, isEnumName, bridgeEdtBaseType } from './generateSmartTable.js';
+import { resolveEdtBaseType, resolveEdtEnumType, heuristicEdtBaseType, isEnumName, bridgeEdtBaseType } from './generateSmartTable.js';
 import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
 import { buildAxMapXml } from './mapXml.js';
 
@@ -4085,7 +4085,19 @@ export async function handleCreateD365File(
               const resolved = (await bridgeEdtBaseType(context.bridge, edt))
                 ?? (db ? resolveEdtBaseType(edt, db) : undefined)
                 ?? heuristicEdtBaseType(edt);
-              if (resolved) f.type = resolved;
+              if (resolved) {
+                f.type = resolved;
+                // An EDT whose OWN base type is Enum (e.g. "Posted" extends "NoYes") only
+                // gets the literal string "Enum" back from the resolvers above — without
+                // the actual enum name, the bridge cannot emit a valid AxTableFieldEnum and
+                // silently falls back to AxTableFieldString. Look up the underlying enum
+                // name so the field is created correctly instead of building "successfully"
+                // as a mistyped string field.
+                if (resolved === 'Enum' && !f.enumType && db) {
+                  const enumType = resolveEdtEnumType(edt, db);
+                  if (enumType) f.enumType = enumType;
+                }
+              }
             }
           }
         }

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -1150,6 +1150,43 @@ export function resolveEdtBaseType(edtName: string, db: any, depth = 0): string 
 }
 
 /**
+ * Resolve the underlying ENUM NAME for an EDT whose own base type is Enum (e.g. "Posted"
+ * extends the "NoYes" enum, "SalesStatus" extends its own enum). Mirrors the chain-walk in
+ * resolveEdtBaseType() but returns the enum name instead of the literal string "Enum".
+ *
+ * Needed because resolveEdtBaseType() alone can only tell the caller "this field's type is
+ * Enum" — without also knowing WHICH enum, the bridge cannot emit a valid AxTableFieldEnum
+ * (it has no EnumType to write) and silently falls back to AxTableFieldString. This was
+ * discovered live: a table field created with only `{ name, edt: "Posted" }` (no explicit
+ * enumType) resolved `type: 'Enum'` via resolveEdtBaseType() but the created field came back
+ * as plain AxTableFieldString with ExtendedDataType=Posted — a valid-looking but semantically
+ * wrong field (the compiler accepts a String-typed field pointed at an Enum-based EDT via
+ * ExtendedDataType, so this doesn't even fail the build; it just isn't what was asked for).
+ *
+ * Returns undefined when the EDT isn't enum-backed (or isn't indexed).
+ */
+export function resolveEdtEnumType(edtName: string, db: any, depth = 0): string | undefined {
+  if (depth > 8) return undefined; // guard against circular chains
+
+  try {
+    const row = db.prepare(
+      `SELECT extends, enum_type FROM edt_metadata WHERE edt_name = ? LIMIT 1`
+    ).get(edtName) as { extends: string | null; enum_type: string | null } | undefined;
+
+    if (!row) return undefined;
+    // Enum-based EDT: extends is null but enum_type is set (e.g. Posted → NoYes)
+    if (row.enum_type && !row.extends) return row.enum_type;
+    if (!row.extends) return undefined; // root EDT of a non-enum primitive
+    if (row.extends === 'Enum') return undefined; // extends the bare primitive, no named enum
+
+    // Follow the chain to the parent EDT (e.g. a custom EDT extending "Posted")
+    return resolveEdtEnumType(row.extends, db, depth + 1);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Heuristic base type from an EDT/field name when the EDT is not in the index
  * (e.g. a standard EDT whose edt_metadata wasn't loaded, or a same-session EDT).
  * Mirrors SmartXmlBuilder.getAxTableFieldType's name heuristics but returns the
@@ -1160,7 +1197,14 @@ export function resolveEdtBaseType(edtName: string, db: any, depth = 0): string 
 export function heuristicEdtBaseType(edtName: string): string | undefined {
   const e = edtName.toLowerCase();
   if (e === 'recid' || e.endsWith('recid') || e.includes('refrecid')) return 'Int64';
-  if (e.includes('utcdatetime') || (e.includes('datetime') && !e.includes('transdate'))) return 'UtcDateTime';
+  // Any "...DateTime" name (TransDateTime, CreatedDateTime, ModifiedDateTime, UtcDateTime,
+  // ...) is UtcDateTime-based. The previous `&& !e.includes('transdate')` guard was meant
+  // to protect something else but instead excluded the single most common case: a name
+  // containing BOTH "datetime" and "transdate" (e.g. "TransDateTime" itself, since
+  // "transdatetime" contains "transdate" as a substring) fell through this branch entirely
+  // AND the next Date branch (which excludes names containing "time"), so it resolved to
+  // undefined and the caller defaulted the field to plain AxTableFieldString.
+  if (e.includes('datetime')) return 'UtcDateTime';
   if (e.includes('date') && !e.includes('time') && !e.includes('update')) return 'Date';
   if (e.includes('amount') || e.includes('price') || e.includes('qty') || e.includes('quantity')
       || e.includes('percent') || e.includes('rate') || e === 'real' || e.endsWith('mst')) return 'Real';

--- a/tests/tools/edt-resolution.test.ts
+++ b/tests/tools/edt-resolution.test.ts
@@ -5,6 +5,7 @@ import {
   isInfrastructureField,
   heuristicEdtBaseType,
   resolveEdtBaseType,
+  resolveEdtEnumType,
   isEnumName,
 } from '../../src/tools/generateSmartTable';
 
@@ -135,6 +136,17 @@ describe('heuristicEdtBaseType (fallback when EDT not indexed)', () => {
     expect(heuristicEdtBaseType('CreatedDateTime')).toBe('UtcDateTime');
   });
 
+  it('maps TransDateTime to UtcDateTime (regression: substring-exclusion bug)', () => {
+    // Found live while implementing the eval-loop "sales credit review + audit" scenario:
+    // a table field created with only `{ name: "PostedAt", edt: "TransDateTime" }` came
+    // back as plain AxTableFieldString instead of AxTableFieldUtcDateTime. Root cause: the
+    // old check was `e.includes('datetime') && !e.includes('transdate')` — but
+    // "transdatetime".includes('transdate') is true, so the exclusion fired on the exact
+    // name it should have matched, and the field silently defaulted to String.
+    expect(heuristicEdtBaseType('TransDateTime')).toBe('UtcDateTime');
+    expect(heuristicEdtBaseType('ModifiedDateTime')).toBe('UtcDateTime');
+  });
+
   it('returns undefined for names with no recognizable base type', () => {
     expect(heuristicEdtBaseType('ContosoRentEquipmentId')).toBeUndefined();
     expect(heuristicEdtBaseType('Name')).toBeUndefined();
@@ -181,6 +193,51 @@ describe('resolveEdtBaseType (indexed EDT, root-EDT ambiguity)', () => {
 
   it('returns undefined for an EDT missing from the index', () => {
     expect(resolveEdtBaseType('ContosoCustomId', edtMetaDb({}))).toBeUndefined();
+  });
+});
+
+describe('resolveEdtEnumType (recover the enum name behind an Enum-based EDT)', () => {
+  function edtMetaDb(rows: Record<string, { extends?: string | null; enum_type?: string | null }>) {
+    return {
+      prepare(_sql: string) {
+        return {
+          get(arg: string) {
+            const key = Object.keys(rows).find(k => k.toLowerCase() === String(arg).toLowerCase());
+            if (!key) return undefined;
+            const r = rows[key];
+            return { extends: r.extends ?? null, enum_type: r.enum_type ?? null };
+          },
+        };
+      },
+    };
+  }
+
+  it('resolves the underlying enum name for a directly enum-backed EDT', () => {
+    // Regression: resolveEdtBaseType('Posted', db) correctly returns the literal string
+    // "Enum", but createD365File's field-type resolution had no way to learn WHICH enum
+    // (NoYes) — so a field created with only `{ name, edt: "Posted" }` got `type: 'Enum'`
+    // with no `enumType`, and the bridge silently emitted AxTableFieldString instead of
+    // AxTableFieldEnum. This helper closes that gap.
+    const db = edtMetaDb({ Posted: { enum_type: 'NoYes' } });
+    expect(resolveEdtEnumType('Posted', db)).toBe('NoYes');
+  });
+
+  it('follows the EDT chain to find the enum on an indirectly enum-backed EDT', () => {
+    const db = edtMetaDb({
+      Posted: { enum_type: 'NoYes' },
+      MyPostedFlag: { extends: 'Posted' },
+    });
+    expect(resolveEdtEnumType('MyPostedFlag', db)).toBe('NoYes');
+  });
+
+  it('returns undefined for a non-enum EDT', () => {
+    const db = edtMetaDb({ TransDate: {}, MyAmount: { extends: 'Real' } });
+    expect(resolveEdtEnumType('TransDate', db)).toBeUndefined();
+    expect(resolveEdtEnumType('MyAmount', db)).toBeUndefined();
+  });
+
+  it('returns undefined for an EDT missing from the index', () => {
+    expect(resolveEdtEnumType('ContosoCustomId', edtMetaDb({}))).toBeUndefined();
   });
 });
 

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -563,6 +563,99 @@ describe('create_d365fo_file', () => {
     expect(sentParams.fields[0].edt).toBe('ContosoRentDailyRate');
   });
 
+  it('table create resolves BOTH type and enumType for a field whose EDT is itself Enum-backed', async () => {
+    // Regression (eval scenario 2 — sales credit review + audit): the field-type resolution
+    // added for the test above handles Real/Date/Int64 EDTs, but an EDT whose OWN base type is
+    // Enum (e.g. the standard "Posted" EDT, which extends the "NoYes" enum) only got as far as
+    // `type: 'Enum'` — nothing populated `enumType`, so the bridge could not emit a valid
+    // AxTableFieldEnum and silently fell back to AxTableFieldString. Reproduced live: a table
+    // field `{ name: "Posted", edt: "Posted" }` (no explicit enumType) was written as
+    // i:type="AxTableFieldString" with ExtendedDataType=Posted — no build error, just silently
+    // the wrong storage kind.
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml',
+      api: 'IMetaTableProvider.Create',
+    }));
+    const ctx = buildContext();
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, createObject, validateObject: vi.fn(async () => null) };
+    // Distinguish the two DIFFERENT queries this path issues against the same fake db:
+    // isEnumName() probes the `symbols` table (is "Posted" itself an enum name? no — it's
+    // an EDT), while resolveEdtBaseType()/resolveEdtEnumType() probe `edt_metadata` (what
+    // does the "Posted" EDT extend? the "NoYes" enum). A mock that didn't discriminate by
+    // SQL text would make isEnumName() false-positive on the edt_metadata row and short
+    // -circuit before the code under test ever runs.
+    (ctx.symbolIndex.db as any).prepare = vi.fn((sql: string) => ({
+      get: (arg: string) => {
+        if (/FROM symbols/.test(sql)) return undefined; // isEnumName: "Posted" is not itself an enum
+        if (String(arg).toLowerCase() === 'posted') {
+          return { extends: null, enum_type: 'NoYes', string_size: null };
+        }
+        return undefined;
+      },
+    }));
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'table',
+        objectName: 'MyTable',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: {
+          fields: [
+            { name: 'Posted', edt: 'Posted' }, // no explicit type/enumType — must be resolved
+          ],
+        },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(createObject).toHaveBeenCalledTimes(1);
+    const sentParams = createObject.mock.calls[0][0];
+    expect(sentParams.fields[0].type).toBe('Enum');
+    expect(sentParams.fields[0].enumType).toBe('NoYes');
+  });
+
+  it('table create resolves a "...DateTime"-named EDT to UtcDateTime, not String', async () => {
+    // Regression (eval scenario 2): heuristicEdtBaseType('TransDateTime') used to return
+    // undefined (see edt-resolution.test.ts for the root cause), so with no index entry
+    // for the EDT either, a field `{ name: "PostedAt", edt: "TransDateTime" }` fell all the
+    // way through to the bridge's AxTableFieldString default instead of AxTableFieldUtcDateTime.
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml',
+      api: 'IMetaTableProvider.Create',
+    }));
+    const ctx = buildContext();
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, createObject, validateObject: vi.fn(async () => null) };
+    // No index entry for TransDateTime — forces the heuristic fallback.
+    (ctx.symbolIndex.db as any).stmt.get.mockReturnValue(undefined);
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'table',
+        objectName: 'MyTable',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: {
+          fields: [
+            { name: 'PostedAt', edt: 'TransDateTime' },
+          ],
+        },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    const sentParams = createObject.mock.calls[0][0];
+    expect(sentParams.fields[0].type).toBe('UtcDateTime');
+  });
+
   it('table create normalizes properties.indexes (indexName/indexFields -> name/fields)', async () => {
     // Regression (eval scenario 1 — Equipment Rental): the only index shape documented
     // anywhere in the tool (modify operation="add-index") is { indexName, indexFields:


### PR DESCRIPTION
## Summary
- `d365fo_file(create, objectType="table"|"table-extension")`'s EDT-only field-type resolution (added in #632) resolves an Enum-backed EDT (e.g. the standard `Posted` EDT, which extends `NoYes`) to `type: 'Enum'` but never captures **which** enum — the bridge can't emit a valid `AxTableFieldEnum` without an `EnumType`, so it silently falls back to `AxTableFieldString`.
- `heuristicEdtBaseType()`'s datetime check (`e.includes('datetime') && !e.includes('transdate')`) excludes the single most common case: any name containing **both** substrings — i.e. `TransDateTime` itself — falls through to `undefined` and defaults to `AxTableFieldString` instead of `AxTableFieldUtcDateTime`.

## Evidence
Reproduced live implementing the eval-loop "sales credit review + audit" scenario (`docs/USAGE_EXAMPLES.md` #2) against a throwaway `fm-mcp` sandbox:
- `FmMcpSalesPostingAuditLog` created with `{ name: "Posted", edt: "Posted" }` and `{ name: "PostedAt", edt: "TransDateTime" }` (no explicit `type`/`enumType`, per the tool's own documented "EDT auto-resolved when omitted" usage) — both fields came back as `AxTableFieldString` instead of `AxTableFieldEnum` (`EnumType=NoYes`) and `AxTableFieldUtcDateTime`.
- Confirmed via direct execution of the compiled resolver functions against the live symbol index: `resolveEdtBaseType('Posted', db)` returns the literal string `'Enum'` with no way for the caller to learn the enum name, and `heuristicEdtBaseType('TransDateTime')` returns `undefined`.

## Fix
- `generateSmartTable.ts`: new `resolveEdtEnumType()`, mirroring `resolveEdtBaseType()`'s chain-walk but returning the underlying enum name. Simplified the datetime heuristic to `e.includes('datetime')`.
- `createD365File.ts`: when the resolved field type is `'Enum'` and the caller didn't supply `enumType`, look it up via `resolveEdtEnumType()` before handing the field to the bridge.

## Before / after (live sandbox)
| Field | Before | After |
|---|---|---|
| `Posted` (edt: `Posted`) | `AxTableFieldString`, `ExtendedDataType=Posted` | `AxTableFieldEnum`, `ExtendedDataType=Posted` |
| `PostedAt` (edt: `TransDateTime`) | `AxTableFieldString` | `AxTableFieldUtcDateTime` |

## Test plan
- [x] New regression tests: `tests/tools/edt-resolution.test.ts` (`resolveEdtEnumType` describe block + `TransDateTime`/`ModifiedDateTime` heuristic case) and `tests/tools/file-ops.test.ts` (two new `create_d365fo_file` end-to-end cases).
- [x] Full suite: `npm test` — 98 files / 1478 tests passed, no regressions.
- [x] `npm run build` (tsc) — clean.

Evidence run: eval-loop implementer session, scenario 2 ("Extending standard posting: sales credit review + audit"), `fm-mcp` sandbox model. Not a duplicate of #630-635 (those covered EDT `BaseType`/`edtType` key mismatch, enum-extension dropped values, table create dropping index name/fields, incremental re-index losing EDT/EnumType, `add-control`, and menu submenu knowledge — this is a distinct residual gap in the same field-resolution code path #632 introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)