### PR TITLE
fix: SEL005 where-clause scanner state leak over-flags unrelated code

### DIFF
--- a/src/tools/validateXpp.ts
+++ b/src/tools/validateXpp.ts
@@ -230,23 +230,42 @@ function checkFunctionInWhere(code: string): ValidationViolation[] {
   const violations: ValidationViolation[] = [];
   // Scan masked text so function-like tokens inside strings/comments aren't flagged.
   const lines = maskStringsAndComments(code).split('\n');
+  // `inWhere` tracks whether we are still inside an open where-clause carried
+  // over from a previous line (a where clause that wraps onto multiple lines).
+  // It MUST be closed at the clause's actual boundary — the statement
+  // terminator `;` or a block-open `{` — otherwise every function call in the
+  // rest of the file (including unrelated later methods) gets misattributed
+  // to "inside where clause". See regression test for the exact failure mode.
   let inWhere = false;
   lines.forEach((rawLine, i) => {
     const line = rawLine.trimStart();
     if (line.startsWith('//') || line.startsWith('*')) return;
-    // Rough state: entering where means the line contains "where" keyword
-    if (/\bwhere\b/i.test(rawLine)) inWhere = true;
-    if (inWhere && /{/.test(rawLine)) inWhere = false;
-    if (!inWhere) return;
+
+    // Determine where scanning should start on this line: right after the
+    // `where` keyword if one starts a new clause here, or from the top of
+    // the line if we're still inside a clause opened on an earlier line.
+    let scanStart = 0;
+    if (!inWhere) {
+      const whereMatch = /\bwhere\b/i.exec(rawLine);
+      if (!whereMatch) return;
+      inWhere = true;
+      scanStart = whereMatch.index + whereMatch[0].length;
+    }
+
+    // The clause ends at the first statement terminator or block-open at/after
+    // scanStart — only scan up to (not past) that point on this line.
+    const rest = rawLine.slice(scanStart);
+    const endMatch = /[;{]/.exec(rest);
+    const scanSegment = endMatch ? rest.slice(0, endMatch.index) : rest;
 
     // Find function calls (word followed by '(') that are not intrinsics
     const callPattern = /\b([a-zA-Z_]\w*)\s*\(/g;
     let m: RegExpExecArray | null;
-    while ((m = callPattern.exec(rawLine)) !== null) {
+    while ((m = callPattern.exec(scanSegment)) !== null) {
       const fnName = m[1].toLowerCase();
       if (INTRINSIC_FUNCTIONS.has(fnName)) continue;
       // Skip common X++ keywords
-      if (['if', 'while', 'for', 'switch', 'catch', 'str', 'int', 'new'].includes(fnName)) continue;
+      if (['if', 'while', 'for', 'switch', 'catch', 'str', 'int', 'new', 'where'].includes(fnName)) continue;
       violations.push({
         rule: 'SEL005',
         severity: 'warning',
@@ -258,6 +277,8 @@ function checkFunctionInWhere(code: string): ValidationViolation[] {
       });
       break; // one violation per line is enough
     }
+
+    if (endMatch) inWhere = false;
   });
   return violations;
 }

--- a/tests/tools/validate-xpp.test.ts
+++ b/tests/tools/validate-xpp.test.ts
@@ -70,6 +70,81 @@ describe('SEL rules', () => {
     const result = await validateXppTool(req({ code, codeType: 'xpp' }));
     expect(getText(result)).toContain('SEL004');
   });
+
+  it('SEL005: flags a genuine function call inside a where clause', async () => {
+    const code = `
+      void run()
+      {
+          CustTable custTable;
+          select firstOnly custTable where custTable.AccountNum == someFunc(1);
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).toContain('SEL005');
+  });
+
+  it('SEL005: does NOT flag statements after the where-clause terminates on the same line', async () => {
+    // Regression (eval L4-vendor-cert-compliance): `select count(x) from t where ...).RecId;`
+    // followed by an unrelated info() call was misattributed as "inside where clause" —
+    // the scanner never closed the where-clause state because it only reset on `{`,
+    // never on the statement-terminating `;`.
+    const code = `
+      class TestSelectCountValidator
+      {
+          public void run()
+          {
+              CustTable custTable;
+              int c;
+
+              c = (select count(RecId) from custTable
+                  where custTable.AccountNum != '').RecId;
+
+              info(strFmt("%1", c));
+          }
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('SEL005');
+  });
+
+  it('SEL005: does NOT bleed into unrelated later methods in the same class', async () => {
+    // Even more pathological form of the same bug: a where-clause on an early
+    // line left `inWhere` stuck true for the rest of the file, so a completely
+    // unrelated method DECLARATION several lines later ("run2(") was flagged.
+    const code = `
+      class TestSelectCountValidator2
+      {
+          public void run()
+          {
+              CustTable custTable;
+              int c;
+
+              c = (select count(RecId) from custTable
+                  where custTable.AccountNum != '').RecId;
+          }
+
+          public void run2()
+          {
+              info(strFmt("%1", 1));
+          }
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('SEL005');
+  });
+
+  it('SEL005: does not flag an aggregate function in the select list before "where" on the same line', async () => {
+    const code = `
+      void run()
+      {
+          CustTable custTable;
+          int c;
+          c = (select count(RecId) from custTable where custTable.AccountNum != '').RecId;
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('SEL005');
+  });
 });
 
 // ─── COC rules ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `validate_code(mode="syntax")`'s SEL005 rule ("function call inside where clause") tracked being "inside a where clause" with a boolean that only reset on a line containing `{`. A normal select/where statement terminates with `;`, not `{`, so the very first `where` keyword in a file left the scanner permanently "inside a where clause" for every following line.
- Confirmed with a minimal, VM-free repro: a `select count(RecId) from t where ...).RecId;` followed by a plain `info(strFmt(...))` on the *next statement* got the `info()` call flagged as "inside where clause" — and in a more pathological case, an unrelated method declaration (`public void run2()`) several lines later in the same class was flagged too.
- Root cause: `checkFunctionInWhere` in `src/tools/validateXpp.ts` scanned the *entire* rest of the line/file once `where` was seen, with no notion of where the clause actually ends.
- Fix: only start scanning after the `where` keyword's position (so a `count(...)` in the select list before `where` on the same line is out of scope), and close the state at the first `;` or `{` at/after that point — scanning only the segment up to the terminator.

## Evidence
Hit while running the agent eval loop (`docs/AGENT_EVAL_LOOP.md`) against the `fm-mcp` sandbox implementing the "vendor certificate compliance" scenario from `docs/USAGE_EXAMPLES.md` (scenario 3) — a SysOperation service class doing set-based `update_recordset` updates plus `select count(...)` progress counters and `info()` calls got false-positive SEL005 warnings that would have sent the agent chasing a non-issue.

Classification: `VALIDATOR_GAP` (a gate producing a false positive on correct code).

## Before / after
- Before: `validate_code(mode="syntax")` on the repro code returned `SEL005` warnings on lines with no where clause at all.
- After: 0 SEL005 warnings on the same code; a genuine function call in a where clause (`where custTable.AccountNum == someFunc(1)`) is still correctly flagged.

## Test plan
- [x] Added 4 regression tests to `tests/tools/validate-xpp.test.ts`: genuine in-where flag still fires; same-line terminator no longer bleeds into the next statement; state no longer bleeds into an unrelated later method; aggregate in the select-list before `where` on the same line is not flagged.
- [x] `npm test` — 1482/1482 passing, 98 files, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)