### PR TITLE
fix: get_object_info(enum) reports every value as 0 for UseEnumValue=No enums

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -500,12 +500,24 @@ namespace D365MetadataBridge.Services
             try { result.IsExtensible = e.IsExtensible; } catch { }
             try { var mi = prov.Enums.GetModelInfo(enumName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
 
+            // UseEnumValue=No (the required setting for extensible enums, and the common
+            // case for plain enums too) means values are position-based: the compiler
+            // assigns 0,1,2,... by declaration order and the <Value> element is omitted
+            // from the XML entirely. AxEnumValue.Value then deserializes to its int
+            // default (0) for every member — that's not an exception, so a
+            // SafeInt(..., idx) exception-based fallback never triggers, and every value
+            // incorrectly reports as 0 instead of its real positional ordinal. Only trust
+            // v.Value when UseEnumValue=Yes; otherwise use the declaration-order index,
+            // which is what actually gets compiled.
+            bool usesEnumValue = IsYes(() => ((dynamic)e).UseEnumValue);
+
             try
             {
                 int idx = 0;
                 foreach (var v in e.EnumValues)
                 {
-                    result.Values.Add(new EnumValueModel { Name = v.Name, Value = SafeInt(() => v.Value, idx), Label = Safe(() => v.Label) });
+                    int value = usesEnumValue ? SafeInt(() => v.Value, idx) : idx;
+                    result.Values.Add(new EnumValueModel { Name = v.Name, Value = value, Label = Safe(() => v.Label) });
                     idx++;
                 }
             }


### PR DESCRIPTION
## Summary
- `MetadataReadService.ReadEnum()` used an exception-based fallback (`SafeInt(() => v.Value, idx)`) to derive each enum member's value, assuming the AX metadata API throws when `<Value>` is absent. It doesn't — it returns the int default `0` — so every member of every `UseEnumValue=No` enum (the required setting for ALL extensible enums, and this server's own default for plain enums too) reported value `0` through `get_object_info(objectType="enum")`, even though the real compiled values are correctly positional (0, 1, 2, ...).
- Fix: read `e.UseEnumValue` (via the existing `IsYes()` dynamic-property helper) and use the declaration-order index directly when `UseEnumValue=No`; only trust `v.Value` when `UseEnumValue=Yes`.

## Evidence
Reproduced live during the eval-loop "customer priority-tier discounts" scenario (`docs/USAGE_EXAMPLES.md` #4) against a throwaway `fm-mcp` sandbox model. Created enum `CustPriorityTier` with explicit `properties.enumValues` values `0/1/2/3` and `isExtensible:true` (which correctly forces `UseEnumValue=No` per existing, deliberate logic in `generateD365Xml.ts`/`createD365File.ts` — verified the written XML has no `<Value>` elements, as intended). But:

```
get_object_info(objectType="enum", name="FmMcpCustPriorityTier")
  Standard = 0
  Silver   = 0
  Gold     = 0
  Platinum = 0
```

This is the same class of confusion the scenario-3 doc already warns about (an enum with no explicit values silently duplicating value 0) — except here the values are NOT actually duplicated (the compiler assigns them positionally at compile time, confirmed by successful build), the read-side *report* is simply wrong, and it could send an agent chasing a phantom duplicate-value bug.

## Fix
`bridge/D365MetadataBridge/Services/MetadataReadService.cs`: `ReadEnum()` now branches on `UseEnumValue` before trusting `AxEnumValue.Value`.

## Test plan
- No C# unit test project exists in this repo for the bridge (same constraint as PR #634's note); verified with `dotnet build` on `bridge/D365MetadataBridge` — 0 errors, 0 warnings.
- Live VM reproduction as described above (before/after not independently re-verifiable without redeploying the bridge binary to the VM this session, but the code path and root cause are unambiguous from the AX metadata API semantics and the existing `IsYes()` pattern used elsewhere in this file).

Evidence run: eval-loop implementer session, scenario 4 ("Cross-stack enhancement: customer priority-tier discounts"), `fm-mcp` sandbox model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)