### PR TITLE
fix: error-hint scoring false-positives on generic word overlap (TTS misdiagnosis)

### DIFF
--- a/src/tools/d365foErrorHelp.ts
+++ b/src/tools/d365foErrorHelp.ts
@@ -326,6 +326,24 @@ catch (Exception::CLRError)
 
 // ─── Scoring & Search ────────────────────────────────────────────────────────
 
+// Grammatical filler + pure-numeric tokens carry no diagnostic signal on their own
+// (e.g. "is", "not", "0"). Without filtering these out, the word-level partial-match
+// fallback below spuriously matches unrelated error text: a pattern like "tts is not 0"
+// splits into ["tts","is","not","0"], and completely unrelated text such as
+// "...Version=0.0.0.0... is required to compile this module" matches "is" and "0",
+// scoring higher than 0 and potentially outranking every genuinely relevant entry —
+// surfacing a confidently wrong diagnosis (e.g. "TTS Level Mismatch" for a missing
+// assembly reference error) instead of "no match found".
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'to', 'of', 'in', 'on', 'at', 'by', 'or', 'and', 'not', 'no', 'this',
+  'that', 'it', 'its', 'as', 'for', 'with', 'from',
+]);
+
+function isSignificantWord(word: string): boolean {
+  return word.length >= 3 && !STOPWORDS.has(word) && !/^\d+$/.test(word);
+}
+
 function scoreError(entry: ErrorEntry, errorText: string, errorCode?: string): number {
   const lowerText = errorText.toLowerCase();
   const lowerCode = (errorCode ?? '').toLowerCase();
@@ -334,10 +352,19 @@ function scoreError(entry: ErrorEntry, errorText: string, errorCode?: string): n
   for (const pattern of entry.patterns) {
     if (lowerCode && lowerCode.includes(pattern)) score += 20;
     if (lowerText.includes(pattern)) score += 10;
-    // partial match — individual words
-    const words = pattern.split(/\s+/);
+    // Partial match fallback — significant words only (stopwords/numbers/short
+    // tokens are excluded, see isSignificantWord). A SINGLE coincidental word
+    // overlap (e.g. "reference" appearing in both an unrelated compiler error
+    // and a pattern like "label reference") is still not enough signal on its
+    // own to credit a multi-word pattern — require at least 2 of its significant
+    // words to actually appear, so one shared generic term can't alone tip an
+    // unrelated entry into "matched".
+    const words = pattern.split(/\s+/).filter(isSignificantWord);
     const matchedWords = words.filter(w => lowerText.includes(w) || lowerCode.includes(w));
-    score += matchedWords.length * 2;
+    const meetsThreshold = words.length <= 1 ? matchedWords.length === 1 : matchedWords.length >= 2;
+    if (meetsThreshold) {
+      score += matchedWords.length * 2;
+    }
   }
   return score;
 }

--- a/tests/tools/d365foErrorHelp.test.ts
+++ b/tests/tools/d365foErrorHelp.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { d365foErrorHelpTool, lookupErrorFix } from '../../src/tools/d365foErrorHelp';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'get_knowledge', arguments: args },
+});
+
+function textOf(result: ReturnType<typeof d365foErrorHelpTool>): string {
+  const content = (result as any).content;
+  return content.map((c: any) => c.text).join('\n');
+}
+
+describe('d365foErrorHelp scoring — stopword false-positive regression', () => {
+  // Reproduces a live eval-loop finding (docs/USAGE_EXAMPLES.md scenario 4): a
+  // missing-model-reference compile error was misdiagnosed as "TTS Level Mismatch".
+  // Root cause: the word-level partial-match fallback in scoreError() counted ANY
+  // individual word overlap, including grammatical filler ("is", "not") and bare
+  // numbers ("0") — both of which appear in totally unrelated error text purely by
+  // coincidence (e.g. "Version=0.0.0.0" contains "0"; "...is required..." contains
+  // "is"). The "tts is not 0" pattern's word list ["tts","is","not","0"] therefore
+  // scored a hit against text that has nothing to do with transactions.
+  const missingReferenceError =
+    "A reference to 'Dynamics.AX.Directory, Version=0.0.0.0, Culture=neutral, " +
+    "PublicKeyToken=null' is required to compile this module.";
+
+  it('does not misdiagnose a missing-assembly-reference error as a TTS issue', () => {
+    const result = lookupErrorFix(missingReferenceError);
+    expect(result?.title).not.toBe('TTS Level Mismatch');
+  });
+
+  it('reports no match (rather than a confident wrong answer) for unrelated error text', () => {
+    // With stopwords/numbers excluded from the fallback, no entry in the DB has any
+    // real keyword overlap with this message, so the tool should say so honestly.
+    const response = d365foErrorHelpTool(req({ errorText: missingReferenceError }));
+    expect(textOf(response)).toContain('No matching error pattern found');
+  });
+
+  it('still correctly matches a genuine TTS error (no regression on real matches)', () => {
+    const result = lookupErrorFix('TTS level is not 0 after ttsbegin/ttscommit imbalance');
+    expect(result?.title).toBe('TTS Level Mismatch');
+  });
+
+  it('still matches via errorCode prefix for a genuine case', () => {
+    const response = d365foErrorHelpTool(
+      req({ errorText: 'unbalanced tts detected during insert', errorCode: 'ttsbegin' })
+    );
+    expect(textOf(response)).toContain('TTS Level Mismatch');
+  });
+});


### PR DESCRIPTION
## Summary
- `d365foErrorHelp.ts`'s `scoreError()` word-level partial-match fallback split each multi-word pattern into individual words and credited score for ANY word found anywhere in the error text, with no stopword/length/numeric filtering. Grammatical filler ("is", "not") and bare numbers ("0") coincidentally appear in unrelated error text (a version string, "is required to compile"), so patterns built around them scored false positives — surfacing a confidently wrong diagnosis instead of "no match found".
- This affects both `get_knowledge(kind="error")` directly and `build_d365fo_project`'s inline `fixHint` (both call into the same `scoreError`/`lookupErrorFix` path).

## Evidence
Reproduced live during the eval-loop "customer priority-tier discounts" scenario (`docs/USAGE_EXAMPLES.md` #4). A genuine compile error:

```
A reference to 'Dynamics.AX.Directory, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' is required to compile this module.
```

(a missing model `ModuleReference` — nothing to do with transactions) was diagnosed as **"TTS Level Mismatch"** by both `get_knowledge(kind="error")` and the inline build `fixHint`. Root cause: pattern `"tts is not 0"` → words `["tts","is","not","0"]`; `"is"` and `"0"` both coincidentally appear in the unrelated text, scoring 4 points with zero real relevance. Had I trusted that hint instead of recognizing the actual pattern (matching a known-good sibling model's `ModuleReferences`, confirmed via a real Kitting-package descriptor), remediation would have gone in a completely wrong direction.

A first pass (stopword + numeric + short-token filtering) closed that case but surfaced a second instance of the same root cause: the identical error text then false-matched **"Label Does Not Exist"** via the single shared word `"reference"` (pattern `"label reference"` — no real semantic overlap, just a coincidentally shared generic term).

## Fix
`src/tools/d365foErrorHelp.ts`:
1. `isSignificantWord()` excludes stopwords, pure-numeric tokens, and words under 3 characters from the word-level fallback.
2. A multi-word pattern now requires **at least 2** of its significant words to actually appear before crediting any fallback score — a single coincidental shared word is no longer enough to "match" a whole phrase. Single-significant-word patterns (`"ttsbegin"`, `"@sys"`) are unaffected.

## Test plan
New `tests/tools/d365foErrorHelp.test.ts` (no test file existed before for this tool's matching logic) — 4 tests:
- the exact reproducing error no longer matches "TTS Level Mismatch"
- that error now correctly reports "No matching error pattern found" end-to-end
- a genuine TTS error message still matches "TTS Level Mismatch" (no regression)
- errorCode-prefix matching still works

Full suite: `npm test` — 99 files / 1486 tests passed, no regressions. `npm run build` (tsc) — clean.

Evidence run: eval-loop implementer session, scenario 4 ("Cross-stack enhancement: customer priority-tier discounts"), `fm-mcp` sandbox model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)