### PR TITLE
fix: incremental symbol index skips security-privilege/-duty/-role and menu-item relationship tables

### DIFF
--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -378,6 +378,136 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
       } else {
         tx();
       }
+    } else if (objectType === 'security-privilege') {
+      // Populate security_privilege_entries so security_info(coverage) and
+      // run_bp_check-adjacent duty/role coverage lookups can see this privilege's
+      // entry points. The single-file indexer previously only inserted a bare
+      // symbols row here (via the generic tx() fallback below), never parsing
+      // <EntryPoints>, so any privilege created/re-indexed via update_symbol_index
+      // in the current session was invisible to security_info(coverage) even
+      // though the underlying XML was correct — a false negative traced to this
+      // gap, not to the XML the create/modify tools produced.
+      const result = await parser.parseSecurityPrivilegeFile(filePath);
+      if (result.success && result.data) {
+        const privData = result.data;
+        symbolIndex.addSymbol({
+          name: privData.name ?? objectName,
+          type: 'security-privilege',
+          filePath,
+          model,
+          description: privData.label,
+        });
+        insertedCount++;
+        symbolIndex.db
+          .prepare(`DELETE FROM security_privilege_entries WHERE privilege_name = ? AND model = ?`)
+          .run(privData.name ?? objectName, model);
+        const insertEntry = symbolIndex.db.prepare(`
+          INSERT OR IGNORE INTO security_privilege_entries
+            (privilege_name, entry_point_name, object_type, access_level, model)
+          VALUES (?, ?, ?, ?, ?)
+        `);
+        for (const ep of privData.entryPoints ?? []) {
+          if (!ep.name) continue;
+          insertEntry.run(privData.name ?? objectName, ep.name, ep.objectType ?? null, ep.accessLevel ?? null, model);
+          insertedCount++;
+        }
+      } else {
+        tx();
+      }
+    } else if (objectType === 'security-duty') {
+      // See security-privilege branch above — same gap, for security_duty_privileges.
+      const result = await parser.parseSecurityDutyFile(filePath);
+      if (result.success && result.data) {
+        const dutyData = result.data;
+        symbolIndex.addSymbol({
+          name: dutyData.name ?? objectName,
+          type: 'security-duty',
+          filePath,
+          model,
+          description: dutyData.label,
+        });
+        insertedCount++;
+        symbolIndex.db
+          .prepare(`DELETE FROM security_duty_privileges WHERE duty_name = ? AND model = ?`)
+          .run(dutyData.name ?? objectName, model);
+        const insertPriv = symbolIndex.db.prepare(`
+          INSERT OR IGNORE INTO security_duty_privileges (duty_name, privilege_name, model)
+          VALUES (?, ?, ?)
+        `);
+        for (const priv of dutyData.privileges ?? []) {
+          insertPriv.run(dutyData.name ?? objectName, priv, model);
+          insertedCount++;
+        }
+      } else {
+        tx();
+      }
+    } else if (objectType === 'security-role') {
+      // See security-privilege branch above — same gap, for security_role_duties.
+      const result = await parser.parseSecurityRoleFile(filePath);
+      if (result.success && result.data) {
+        const roleData = result.data;
+        symbolIndex.addSymbol({
+          name: roleData.name ?? objectName,
+          type: 'security-role',
+          filePath,
+          model,
+          description: roleData.label,
+        });
+        insertedCount++;
+        symbolIndex.db
+          .prepare(`DELETE FROM security_role_duties WHERE role_name = ? AND model = ?`)
+          .run(roleData.name ?? objectName, model);
+        const insertDuty = symbolIndex.db.prepare(`
+          INSERT OR IGNORE INTO security_role_duties (role_name, duty_name, model)
+          VALUES (?, ?, ?)
+        `);
+        for (const duty of roleData.duties ?? []) {
+          insertDuty.run(roleData.name ?? objectName, duty, model);
+          insertedCount++;
+        }
+      } else {
+        tx();
+      }
+    } else if (
+      objectType === 'menu-item-display' ||
+      objectType === 'menu-item-action' ||
+      objectType === 'menu-item-output'
+    ) {
+      // Populate menu_item_targets so security_info(coverage)'s primary lookup
+      // (object -> menu items) works for a menu item indexed in the current
+      // session, not just via its symbols-table fallback path.
+      const itemType = objectType === 'menu-item-display' ? 'display' : objectType === 'menu-item-action' ? 'action' : 'output';
+      const result = await parser.parseMenuItemFile(filePath, itemType);
+      if (result.success && result.data) {
+        const miData = result.data;
+        symbolIndex.addSymbol({
+          name: miData.name ?? objectName,
+          type: objectType,
+          filePath,
+          model,
+          description: miData.label,
+        });
+        insertedCount++;
+        symbolIndex.db
+          .prepare(`DELETE FROM menu_item_targets WHERE menu_item_name = ? AND model = ?`)
+          .run(miData.name ?? objectName, model);
+        symbolIndex.db.prepare(`
+          INSERT INTO menu_item_targets
+            (menu_item_name, menu_item_type, target_object, target_type, security_privilege, label, model)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `).run(
+          miData.name ?? objectName,
+          objectType,
+          miData.targetObject ?? null,
+          miData.targetType ?? null,
+          miData.securityPrivilege ?? null,
+          miData.label ?? null,
+          model,
+        );
+        insertedCount++;
+      } else {
+        tx();
+      }
     } else {
       tx();
     }

--- a/tests/tools/updateSymbolIndex.test.ts
+++ b/tests/tools/updateSymbolIndex.test.ts
@@ -35,13 +35,28 @@ vi.mock('../../src/bridge/index.js', () => ({
 import { updateSymbolIndexTool } from '../../src/tools/updateSymbolIndex';
 import type { XppServerContext } from '../../src/types/context';
 
-function createContext(): XppServerContext {
+/** Records every db.prepare(sql).run(...args) call so tests can assert on the exact SQL + bound values. */
+function createRecordingDb() {
+  const calls: Array<{ sql: string; args: any[] }> = [];
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      run: vi.fn((...args: any[]) => {
+        calls.push({ sql, args });
+        return { changes: 0 };
+      }),
+    })),
+    transaction: vi.fn((fn: any) => fn),
+  };
+  return { db, calls };
+}
+
+function createContext(db?: ReturnType<typeof createRecordingDb>['db']): XppServerContext {
   return {
     symbolIndex: {
       removeSymbolsByFile: vi.fn(() => ({ deletedCount: 0, objectNames: [] })),
       removeLabelsByFile: vi.fn(() => 0),
       bulkAddLabels: vi.fn(),
-      db: {
+      db: db ?? {
         prepare: vi.fn(() => ({ run: vi.fn(() => ({ changes: 0 })) })),
         transaction: vi.fn((fn: any) => fn),
       },
@@ -157,5 +172,127 @@ describe('update_symbol_index table re-indexing preserves field EDT/EnumType', (
 
     expect(myIdField?.signature).toBe('ContosoMyId');
     expect(myStatusField?.signature).toBe('ContosoMyStatus');
+  });
+});
+
+describe('update_symbol_index security object re-indexing populates coverage tables', () => {
+  // Regression (eval scenario 5 — inventory aging analytics): the incremental
+  // single-file indexer had no branch for security-privilege/-duty/-role (or
+  // menu-item-*), so any of these objects created/re-indexed in the current
+  // session fell into the generic tx() fallback, which only inserts a bare
+  // symbols row. security_info(mode="coverage") and the security_duty_privileges
+  // / security_role_duties / security_privilege_entries tables it queries were
+  // never populated for same-session objects, so a privilege->duty->role chain
+  // that was correctly wired in the XML (verified by direct read) was reported
+  // as "0 privileges/duties/roles found" — a false negative in our own index,
+  // not in the XML the create tools produced.
+  let context: XppServerContext;
+  let recording: ReturnType<typeof createRecordingDb>;
+
+  beforeEach(() => {
+    recording = createRecordingDb();
+    context = createContext(recording.db);
+    vi.clearAllMocks();
+  });
+
+  it('populates security_privilege_entries from a security-privilege file', async () => {
+    const filePath = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxSecurityPrivilege\\MyPrivilege.xml';
+    existsSyncMock.mockReturnValue(true);
+    readFilePromiseMock.mockResolvedValue(`<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>MyPrivilege</Name>
+  <Label>@MyModel:MyPrivilegeLabel</Label>
+  <DataEntityPermissions />
+  <DirectAccessPermissions />
+  <EntryPoints>
+    <AxSecurityEntryPointReference>
+      <Name>MyMenuItem</Name>
+      <Grant><Read>Allow</Read></Grant>
+      <ObjectName>MyMenuItem</ObjectName>
+      <ObjectType>MenuItemDisplay</ObjectType>
+      <Forms />
+    </AxSecurityEntryPointReference>
+  </EntryPoints>
+  <FormControlOverrides />
+</AxSecurityPrivilege>`);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    const insertCall = recording.calls.find(c =>
+      c.sql.includes('INSERT OR IGNORE INTO security_privilege_entries'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall!.args).toEqual(['MyPrivilege', 'MyMenuItem', 'MenuItemDisplay', 'Read:Allow', 'MyModel']);
+  });
+
+  it('populates security_duty_privileges from a security-duty file', async () => {
+    const filePath = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxSecurityDuty\\MyDuty.xml';
+    existsSyncMock.mockReturnValue(true);
+    readFilePromiseMock.mockResolvedValue(`<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>MyDuty</Name>
+  <Label>@MyModel:MyDutyLabel</Label>
+  <Privileges>
+    <AxSecurityRolePermissionSet><Name>MyPrivilegeOne</Name></AxSecurityRolePermissionSet>
+    <AxSecurityRolePermissionSet><Name>MyPrivilegeTwo</Name></AxSecurityRolePermissionSet>
+  </Privileges>
+</AxSecurityDuty>`);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    const insertCalls = recording.calls.filter(c =>
+      c.sql.includes('INSERT OR IGNORE INTO security_duty_privileges'));
+    expect(insertCalls).toHaveLength(2);
+    expect(insertCalls.map(c => c.args)).toEqual([
+      ['MyDuty', 'MyPrivilegeOne', 'MyModel'],
+      ['MyDuty', 'MyPrivilegeTwo', 'MyModel'],
+    ]);
+  });
+
+  it('populates security_role_duties from a security-role file', async () => {
+    const filePath = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxSecurityRole\\MyRole.xml';
+    existsSyncMock.mockReturnValue(true);
+    readFilePromiseMock.mockResolvedValue(`<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>MyRole</Name>
+  <Label>@MyModel:MyRoleLabel</Label>
+  <DirectAccessPermissions />
+  <Duties>
+    <AxSecurityRoleDutyPermission><Name>MyDuty</Name></AxSecurityRoleDutyPermission>
+  </Duties>
+  <Privileges />
+  <SubRoles />
+</AxSecurityRole>`);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    const insertCall = recording.calls.find(c =>
+      c.sql.includes('INSERT OR IGNORE INTO security_role_duties'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall!.args).toEqual(['MyRole', 'MyDuty', 'MyModel']);
+  });
+
+  it('populates menu_item_targets from a menu-item-display file', async () => {
+    const filePath = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxMenuItemDisplay\\MyMenuItem.xml';
+    existsSyncMock.mockReturnValue(true);
+    readFilePromiseMock.mockResolvedValue(`<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemDisplay xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+  <Name>MyMenuItem</Name>
+  <Label>@MyModel:MyMenuItemLabel</Label>
+  <Object>MyForm</Object>
+  <ObjectType>Form</ObjectType>
+</AxMenuItemDisplay>`);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    const insertCall = recording.calls.find(c =>
+      c.sql.includes('INSERT INTO menu_item_targets'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall!.args).toEqual([
+      'MyMenuItem', 'menu-item-display', 'MyForm', 'Form', null, '@MyModel:MyMenuItemLabel', 'MyModel',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- `update_symbol_index(filePath=...)` had no branch for `security-privilege`, `security-duty`, `security-role`, or `menu-item-display/action/output` — they fell into the generic `tx()` fallback, which only inserts a bare `symbols` row.
- As a result, `security_privilege_entries`, `security_duty_privileges`, `security_role_duties`, and `menu_item_targets` were never populated for an object indexed via the single-file incremental path, so `security_info(mode="coverage")` reported `0 privileges/duties/roles found` for a chain that was actually correctly wired in the XML.
- Fix adds dedicated branches (same shape as the existing class/table/edt/form handling) that call the already-existing but previously-unused `parseSecurityPrivilegeFile` / `parseSecurityDutyFile` / `parseSecurityRoleFile` / `parseMenuItemFile` parsers and populate the relationship tables, deleting stale rows by name+model first so re-indexing stays idempotent.

## Evidence (this run)
Building eval scenario 5 (inventory aging analytics, run evidence: `docs/USAGE_EXAMPLES.md` scenario 5), a privilege → duty → role chain was created (`FmMcpInventAnalyticsView`/`FmMcpInventAnalyticsReportView` privileges → `FmMcpInventAnalyticsInquire` duty → `FmMcpInventAnalyticsViewer` role), each followed by `update_symbol_index`. `security_info(mode="coverage", objectName="FmMcpInventAgingInquiry")` reported:
```
No privileges found granting this menu item
Total privileges with any access: 0 / Total duties: 0 / Total roles with any access: 0
```
A direct read of the duty/role XML on disk confirmed both `<Privileges>` and `<Duties>` were populated correctly — this was purely a false negative in the incremental indexer, consistent with a symptom already flagged (but not root-caused) in an earlier run of the same eval scenario.

## Before / after
- Before: `security-privilege`/`security-duty`/`security-role`/`menu-item-*` re-indexed via `update_symbol_index` never populate the coverage tables → `security_info(coverage)` false-negatives on same-session security chains.
- After: 4 new regression tests assert the exact `INSERT` statement + bound values for each object type; `npm test` green (1491/1491, no regressions).

## Test plan
- [x] `npm test` — 100 files / 1491 tests passed, no regressions
- [x] New regression tests in `tests/tools/updateSymbolIndex.test.ts` cover privilege entry points, duty privileges, role duties, and menu item targets
- [x] Manually reproduced and fixed live on the `fm-mcp` eval sandbox during scenario 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)