### PR TITLE
fix: report scaffold emits non-existent SysOperationMandatoryAttribute for mandatory contract params

### DIFF
--- a/src/tools/generateSmartReport.ts
+++ b/src/tools/generateSmartReport.ts
@@ -552,7 +552,13 @@ export async function handleGenerateSmartReport(
   const contractParmMethods = contractParms.map(p => {
     const methodName = `parm${p.name.charAt(0).toUpperCase()}${p.name.slice(1)}`;
     const labelAttr = p.label ? `,\n        SysOperationLabelAttribute('${p.label}')` : '';
-    const mandatoryAttr = p.mandatory ? `,\n        SysOperationMandatoryAttribute(true)` : '';
+    // NOTE: there is no such class as SysOperationMandatoryAttribute in D365FO —
+    // an earlier version of this generator emitted `SysOperationMandatoryAttribute(true)`
+    // here for mandatory params, which fails to compile ("Class ... was not found")
+    // on every report whose contract has a mandatory dialog field (found building eval
+    // scenario 5 — inventory aging analytics, InventLocationId mandatory=true). Mandatory
+    // enforcement for a SysOperation/report contract is done in validate() (built below),
+    // via checkFailed() — not via a per-parameter attribute — so no attribute is emitted.
     // Use explicit defaultValue when provided, else fall back to the member variable (standard parm pattern)
     const defaultExpr = p.defaultValue ? p.defaultValue : p.name;
     return [
@@ -561,7 +567,7 @@ export async function handleGenerateSmartReport(
       `    /// </summary>`,
       `    /// <param name="_${p.name}">The ${p.name} value.</param>`,
       `    /// <returns>The current ${p.name} value.</returns>`,
-      `    [DataMemberAttribute('${p.name}')${labelAttr}${mandatoryAttr}]`,
+      `    [DataMemberAttribute('${p.name}')${labelAttr}]`,
       `    public ${p.type} ${methodName}(${p.type} _${p.name} = ${defaultExpr})`,
       `    {`,
       `        ${p.name} = _${p.name};`,

--- a/tests/tools/generateSmartReport.test.ts
+++ b/tests/tools/generateSmartReport.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression (eval scenario 5 — inventory aging analytics): generate_object(mode="scaffold",
+ * objectType="report") emitted `SysOperationMandatoryAttribute(true)` on a Contract parm method
+ * for any contractParams entry with mandatory:true. No such class exists in D365FO — the build
+ * failed with "Class 'SysOperationMandatoryAttribute' was not found. Are you missing a module
+ * reference?" on every report with a mandatory dialog field (e.g. InventLocationId mandatory=true).
+ * Mandatory enforcement for a SysOperation/report contract is already correctly done via the
+ * generated validate() method's checkFailed() call — no per-parameter attribute is needed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(() => true),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getAutoDetectedModelName: vi.fn(async () => 'MyModel'),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+}));
+
+vi.mock('../../src/tools/createD365File', async (orig) => {
+  const actual = await orig<typeof import('../../src/tools/createD365File')>();
+  return {
+    ...actual,
+    ProjectFileManager: vi.fn().mockImplementation(() => ({
+      addToProject: vi.fn(async () => true),
+    })),
+  };
+});
+
+import fs from 'fs';
+import { handleGenerateSmartReport } from '../../src/tools/generateSmartReport';
+
+function createSymbolIndexStub() {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined) };
+  return {
+    getReadDb: vi.fn(() => ({ prepare: vi.fn(() => stmt) })),
+  } as any;
+}
+
+describe('generate_object(scaffold, report) contract mandatory param', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fs.existsSync as any).mockReturnValue(true);
+  });
+
+  it('never emits the non-existent SysOperationMandatoryAttribute for a mandatory contractParam', async () => {
+    const symbolIndex = createSymbolIndexStub();
+
+    await handleGenerateSmartReport(
+      {
+        name: 'InventAgingReport',
+        fieldsHint: 'ItemId, InventLocationId',
+        contractParams: [
+          { name: 'InventLocationId', type: 'InventLocationId', mandatory: true, label: 'Warehouse' },
+          { name: 'AsOfDate', type: 'TransDate', mandatory: false, label: 'As of date' },
+        ],
+        modelName: 'MyModel',
+      } as any,
+      symbolIndex
+    );
+
+    const writeCalls = (fs.writeFileSync as any).mock.calls as Array<[string, string, string]>;
+    const contractWrite = writeCalls.find(([targetPath]) => targetPath.includes('Contract.xml'));
+    expect(contractWrite).toBeDefined();
+
+    const contractXml = contractWrite![1];
+    expect(contractXml).not.toContain('SysOperationMandatoryAttribute');
+    expect(contractXml).toContain('DataMemberAttribute');
+    // Mandatory enforcement still happens, just via validate()/checkFailed, not an attribute.
+    expect(contractXml).toContain('public boolean validate()');
+    expect(contractXml).toContain('checkFailed');
+    expect(contractXml).toContain('InventLocationId');
+  });
+});

--- a/tests/tools/generateSmartReport.test.ts
+++ b/tests/tools/generateSmartReport.test.ts
@@ -6,16 +6,14 @@
  * reference?" on every report with a mandatory dialog field (e.g. InventLocationId mandatory=true).
  * Mandatory enforcement for a SysOperation/report contract is already correctly done via the
  * generated validate() method's checkFailed() call — no per-parameter attribute is needed.
+ *
+ * The tool has two output paths depending on process.platform: Windows writes files to disk via
+ * fs.writeFileSync, non-Windows (Azure/Linux — this is how the CI runner sees it) returns every
+ * generated object's XML embedded as text instead. The test forces the platform-independent
+ * non-Windows path so it behaves identically in CI and locally, without needing to mock fs/
+ * ProjectFileManager (neither is reached on that path).
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-vi.mock('fs', () => ({
-  default: {
-    existsSync: vi.fn(() => true),
-    mkdirSync: vi.fn(),
-    writeFileSync: vi.fn(),
-  },
-}));
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../src/utils/configManager', () => ({
   getConfigManager: vi.fn(() => ({
@@ -35,17 +33,6 @@ vi.mock('../../src/utils/modelClassifier', () => ({
   applyObjectSuffix: vi.fn((name: string) => name),
 }));
 
-vi.mock('../../src/tools/createD365File', async (orig) => {
-  const actual = await orig<typeof import('../../src/tools/createD365File')>();
-  return {
-    ...actual,
-    ProjectFileManager: vi.fn().mockImplementation(() => ({
-      addToProject: vi.fn(async () => true),
-    })),
-  };
-});
-
-import fs from 'fs';
 import { handleGenerateSmartReport } from '../../src/tools/generateSmartReport';
 
 function createSymbolIndexStub() {
@@ -56,15 +43,24 @@ function createSymbolIndexStub() {
 }
 
 describe('generate_object(scaffold, report) contract mandatory param', () => {
+  const originalPlatform = process.platform;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    (fs.existsSync as any).mockReturnValue(true);
+    // Force the non-Windows (Azure/Linux) code path, which returns every generated
+    // object's XML as text instead of writing to disk — deterministic regardless of
+    // which OS actually runs the test (local Windows VM vs. the Linux CI runner).
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
   it('never emits the non-existent SysOperationMandatoryAttribute for a mandatory contractParam', async () => {
     const symbolIndex = createSymbolIndexStub();
 
-    await handleGenerateSmartReport(
+    const result = await handleGenerateSmartReport(
       {
         name: 'InventAgingReport',
         fieldsHint: 'ItemId, InventLocationId',
@@ -77,16 +73,15 @@ describe('generate_object(scaffold, report) contract mandatory param', () => {
       symbolIndex
     );
 
-    const writeCalls = (fs.writeFileSync as any).mock.calls as Array<[string, string, string]>;
-    const contractWrite = writeCalls.find(([targetPath]) => targetPath.includes('Contract.xml'));
-    expect(contractWrite).toBeDefined();
+    const text = result.content[0].text as string;
 
-    const contractXml = contractWrite![1];
-    expect(contractXml).not.toContain('SysOperationMandatoryAttribute');
-    expect(contractXml).toContain('DataMemberAttribute');
-    // Mandatory enforcement still happens, just via validate()/checkFailed, not an attribute.
-    expect(contractXml).toContain('public boolean validate()');
-    expect(contractXml).toContain('checkFailed');
-    expect(contractXml).toContain('InventLocationId');
+    // Sanity: the Contract class was actually generated and embedded in the output.
+    expect(text).toContain('InventAgingReportContract');
+    expect(text).toContain('DataMemberAttribute');
+    // Mandatory enforcement still happens, just via validate()/checkFailed, not a
+    // per-parameter attribute — the class this was hallucinated for does not exist.
+    expect(text).not.toContain('SysOperationMandatoryAttribute');
+    expect(text).toContain('public boolean validate()');
+    expect(text).toContain('checkFailed');
   });
 });


### PR DESCRIPTION
## Summary
- `generate_object(mode="scaffold", objectType="report")` wrote `SysOperationMandatoryAttribute(true)` on a Contract parm method for any `contractParams` entry with `mandatory: true`. No such class exists in D365FO.
- Build fails with: `Class 'SysOperationMandatoryAttribute' was not found. Are you missing a module reference?` — on every report whose dialog has a mandatory field.
- Mandatory enforcement for a SysOperation/report contract is already correctly handled by the generated `validate()` method's `checkFailed()` call (emitted by the same generator) — the attribute was redundant even when it happened to compile, and here it doesn't.

## Evidence (this run)
Building eval scenario 5 (inventory aging analytics, `docs/USAGE_EXAMPLES.md` scenario 5), scaffolding `FmMcpInventAgingReport` with `contractParams=[{name:"InventLocationId", mandatory:true, ...}, {name:"AsOfDate", mandatory:false, ...}]` produced a `Contract` class whose generated `parmInventLocationId` carried:
```
[DataMemberAttribute('InventLocationId'),
SysOperationLabelAttribute('Warehouse'),
SysOperationMandatoryAttribute(true)]
```
First build failed:
```
FmMcpInventAgingReportContract.Method/parmInventLocationId (line 18, col 5): Class 'SysOperationMandatoryAttribute' was not found. Are you missing a module reference?
```
The same generated class's `validate()` method already contained the correct check:
```
if (!InventLocationId) { ret = checkFailed(strFmt("@SYS53419", "InventLocationId")); }
```
confirming the attribute was pure hallucination, not a real enforcement mechanism.

## Fix
`src/tools/generateSmartReport.ts`: stop emitting the `mandatoryAttr` attribute fragment for contract parm methods. `validate()` remains the sole (and correct) mandatory-enforcement mechanism, unchanged.

## Test plan
- [x] `npm test` — 100 files / 1487 tests passed, no regressions
- [x] New `tests/tools/generateSmartReport.test.ts` asserts the generated Contract class never contains `SysOperationMandatoryAttribute`, still contains `DataMemberAttribute` and the `validate()`/`checkFailed` enforcement
- [x] Manually reproduced and fixed live on the `fm-mcp` eval sandbox during scenario 5 (patched the sandbox object via `replace-code`, rebuilt clean — 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)