### PR TITLE
eval: expand case portfolio with modify-op, defect-regression and composite-slice cases

### DIFF
--- a/eval/cases/L2-class-method-ops.json
+++ b/eval/cases/L2-class-method-ops.json
@@ -1,0 +1,25 @@
+{
+  "id": "L2-class-method-ops",
+  "title": "Class and table method surface via add-method / replace-code / remove-method / display+table methods",
+  "tier": 2,
+  "instruction": "In the sandbox model, create a class XyzCalcOps with a declaration only (no methods in the initial create). Then shape its method surface EXCLUSIVELY through d365fo_file action=modify operations: (1) add-method 'public int multiply(int _a, int _b)' with a stub body returning 0; (2) replace-code on multiply so it returns _a * _b (the golden verifies the final source text, so the stub must not survive); (3) add-method 'public static XyzCalcOps construct()' returning new XyzCalcOps(); (4) add-method tempScratch (any signature), then remove-method tempScratch (it must NOT exist in the final class). Separately, create a table XyzCalcData with fields ItemName (string, Name EDT) and Qty (real, Qty EDT), then via modify: (5) add-table-method a static 'find' method selecting firstonly by ItemName; (6) add-display-method 'displayDoubleQty' returning 2 * this.Qty (display method, Qty EDT return type). Both objects must build clean and validate_code(mode=\"syntax\") must pass on every generated method before it is written.",
+  "target_artifact_types": [
+    "AxClass",
+    "AxTable"
+  ],
+  "golden_path": "eval/goldens/L2-class-method-ops/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "class",
+    "table",
+    "modify",
+    "methods",
+    "deterministic",
+    "multi-artifact"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L2-enum-extension-empty-values.json
+++ b/eval/cases/L2-enum-extension-empty-values.json
@@ -1,0 +1,23 @@
+{
+  "id": "L2-enum-extension-empty-values",
+  "title": "Enum-extension create silently drops EnumValues (regression: NumberSeqModule::<Value> unresolved)",
+  "tier": 2,
+  "instruction": "In the sandbox model, extend the standard NumberSeqModule enum with one new value XyzEvalRent (reuse a standard label from the labels index). After the d365fo_file create, READ BACK the produced enum-extension XML and confirm the AxEnumExtension has a NON-EMPTY <EnumValues> collection containing XyzEvalRent -- do not proceed on the assumption the write worked. This is a regression case: in the recorded run behind docs/USAGE_EXAMPLES.md section 1 (BUILD #1), the enum-extension write path silently produced empty EnumValues, which only surfaced later as a 'NumberSeqModule::Rent unresolved' build error and had to be hand-fixed with a full-XML overwrite. Then prove the value actually resolves at compile time: create a small class XyzEnumExtProbe with a single static method 'public static NumberSeqModule module()' returning NumberSeqModule::XyzEvalRent. Both objects must build clean on the FIRST build -- a hand-fix overwrite after a failed build means the case fails.",
+  "target_artifact_types": [
+    "AxEnumExtension",
+    "AxClass"
+  ],
+  "golden_path": "eval/goldens/L2-enum-extension-empty-values/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "enum-extension",
+    "tool-defect",
+    "mined",
+    "multi-artifact"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L2-enum-modify-values.json
+++ b/eval/cases/L2-enum-modify-values.json
@@ -1,0 +1,21 @@
+{
+  "id": "L2-enum-modify-values",
+  "title": "Enum values maintained via add/modify/remove-enum-value modify operations",
+  "tier": 2,
+  "instruction": "In the sandbox model, create an enum XyzModStatus with three values: Draft (value 0), Active (value 1), Closed (value 2). Reuse standard labels from the labels index for the enum and its values -- do not invent raw text. Then change it EXCLUSIVELY through d365fo_file action=modify operations (no create overwrite=true full-XML rewrites): (1) add-enum-value Archived with value 3; (2) modify-enum-value to rename Closed to Completed, keeping its numeric value 2; (3) add-enum-value Temp with value 4, then remove-enum-value Temp (it must NOT exist in the final enum); (4) remove-enum-value Draft. The final enum must contain exactly Active (1), Completed (2), Archived (3) -- nothing else -- and must build clean.",
+  "target_artifact_types": [
+    "AxEnum"
+  ],
+  "golden_path": "eval/goldens/L2-enum-modify-values/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "enum",
+    "modify",
+    "deterministic"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L2-form-modify-controls.json
+++ b/eval/cases/L2-form-modify-controls.json
@@ -1,0 +1,25 @@
+{
+  "id": "L2-form-modify-controls",
+  "title": "Form controls built exclusively via modify add-control (regression: add-control non-functional)",
+  "tier": 2,
+  "instruction": "In the sandbox model, create a table XyzCtrlNote with fields NoteId (string, Num EDT, mandatory) and Subject (string, Name EDT), plus a unique index NoteIdx on NoteId. Then create a MINIMAL form XyzCtrlNoteForm bound to XyzCtrlNote: the initial create must contain only the data source and an empty design (no visual controls). Add ALL visual controls afterwards, exclusively via d365fo_file action=modify: (1) add-control a Group control HeaderGroup under the design; (2) add-control a Grid MainGrid under the design, with its DataSource property bound to the XyzCtrlNote data source (use modify-property if the grid binding cannot be set at add time); (3) add-control StringEdit columns for NoteId and Subject inside MainGrid, each bound via DataSource/DataField. Do NOT hand-author the controls in the initial create XML and do NOT fall back to create overwrite=true with full form XML if add-control fails -- a fallback means the case fails. This is a regression case: in the recorded run behind docs/USAGE_EXAMPLES.md section 1, add-control failed 6 out of 6 times on a form and hand-authored XML was the only workaround. Both objects must build clean.",
+  "target_artifact_types": [
+    "AxTable",
+    "AxForm"
+  ],
+  "golden_path": "eval/goldens/L2-form-modify-controls/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "form",
+    "modify",
+    "add-control",
+    "tool-defect",
+    "mined",
+    "multi-artifact"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L2-form-over-view.json
+++ b/eval/cases/L2-form-over-view.json
@@ -1,0 +1,25 @@
+{
+  "id": "L2-form-over-view",
+  "title": "Form generated over a view data source (regression: 'table not found' when datasource is a view)",
+  "tier": 2,
+  "instruction": "In the sandbox model, create a small table XyzViewSrc with fields Code (string, Num EDT, mandatory) and Descr (string, Name EDT). Create a view XyzActiveView over XyzViewSrc exposing both fields. Then generate a SimpleList form XyzActiveViewList whose data source is the VIEW XyzActiveView (not the underlying table), with grid controls for Code and Descr, produced through the grounded path (object_patterns / generate_object scaffold, then d365fo_file). This is a regression case: generate_object(objectType=form) is known to report 'table not found' when the target data source is a view rather than a table -- the case passes only if the form is produced over the view through the tool path (hand-authoring the form XML from scratch to route around the defect means the case fails). All three objects must build clean.",
+  "target_artifact_types": [
+    "AxTable",
+    "AxView",
+    "AxForm"
+  ],
+  "golden_path": "eval/goldens/L2-form-over-view/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "form",
+    "view",
+    "tool-defect",
+    "mined",
+    "multi-artifact"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L2-table-modify-lifecycle.json
+++ b/eval/cases/L2-table-modify-lifecycle.json
@@ -1,0 +1,25 @@
+{
+  "id": "L2-table-modify-lifecycle",
+  "title": "Table evolved through the full d365fo_file modify operation chain",
+  "tier": 2,
+  "instruction": "In the sandbox model, create a table XyzModLifecycle with exactly two fields: Code (string, use the Num EDT, mandatory) and Description (string, use the Name EDT). Then evolve it EXCLUSIVELY through d365fo_file action=modify operations -- do NOT rewrite the whole XML via create overwrite=true; falling back to a full-XML rewrite means the case fails (the point is to exercise the modify op surface): (1) add-field CustAccount using the standard CustAccount EDT; (2) add-field TempQty (real, use the Qty EDT); (3) modify-field Description to Mandatory=Yes; (4) rename-field Code to NoteCode; (5) add-index CodeIdx, unique, on NoteCode; (6) add-index TmpIdx on CustAccount, then remove-index TmpIdx (it must NOT exist in the final table); (7) add-relation to CustTable on CustAccount (normal relation, follow codebase conventions for the relation shape); (8) add-field-group Overview, then add-field-to-field-group NoteCode and Description into Overview; (9) remove-field TempQty (it must NOT exist in the final table); (10) modify-property TitleField1 = Description. The final table must contain exactly the fields NoteCode, Description, CustAccount, exactly one index (CodeIdx), one relation and one field group, and must build clean.",
+  "target_artifact_types": [
+    "AxTable"
+  ],
+  "golden_path": "eval/goldens/L2-table-modify-lifecycle/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "table",
+    "modify",
+    "fields",
+    "index",
+    "relation",
+    "fieldgroup",
+    "deterministic"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L3-form-add-datasource-lines.json
+++ b/eval/cases/L3-form-add-datasource-lines.json
@@ -1,0 +1,27 @@
+{
+  "id": "L3-form-add-datasource-lines",
+  "title": "Second (lines) data source + bound grid added to an existing form via modify (regression: datasource refers to table '')",
+  "tier": 3,
+  "instruction": "In the sandbox model, create a header table XyzDocHeader (DocId: string, Num EDT, mandatory; Description: string, Name EDT; unique index DocIdx on DocId; TitleField1 = Description) and a lines table XyzDocLine (DocId: same Num EDT; LineNum: integer, LineNum EDT; ItemName: string, Name EDT; a relation to XyzDocHeader on DocId with a cascading delete action per codebase conventions). Create a form XyzDocForm initially bound ONLY to XyzDocHeader, with a grid showing DocId and Description. Then extend the form EXCLUSIVELY via d365fo_file action=modify: (1) add-data-source for XyzDocLine, joined to the XyzDocHeader data source (JoinSource on the header, ActiveLink join mode, linked on the DocId relation); (2) add-control a Grid LinesGrid bound to the XyzDocLine data source with StringEdit/IntEdit columns for LineNum and ItemName. The build must then succeed with ZERO errors -- in particular zero errors of the shape \"form datasource ... refers to table '' which does not exist\". This is the minimal repro/regression for the UNRESOLVED defect from the recorded run behind docs/USAGE_EXAMPLES.md section 1 (BUILDS #4-#13: 58 identical such errors that survived cache wipes, fullBuild+force and full Fields-list rewrites, forcing a complete sandbox rollback). No hand-authored full-XML fallback is allowed; if the modify path cannot produce a clean build, the case fails and the run record should classify the root cause.",
+  "target_artifact_types": [
+    "AxTable",
+    "AxTable",
+    "AxForm"
+  ],
+  "golden_path": "eval/goldens/L3-form-add-datasource-lines/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "form",
+    "modify",
+    "add-data-source",
+    "add-control",
+    "tool-defect",
+    "mined",
+    "multi-artifact"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L3-numberseq-module-slice.json
+++ b/eval/cases/L3-numberseq-module-slice.json
@@ -1,0 +1,28 @@
+{
+  "id": "L3-numberseq-module-slice",
+  "title": "Full number-sequence wiring slice: module class + registration + parameters table + numRef + TOC form",
+  "tier": 3,
+  "instruction": "In the sandbox model, build the COMPLETE number-sequence wiring that L2-numberseq-basic explicitly leaves out of scope, end to end: (1) an EDT XyzSliceId (String, extends Num, reused standard label); (2) an extension of the standard NumberSeqModule enum adding the value XyzSlice; (3) a class NumberSeqModuleXyzSlice extending NumberSeqApplicationModule -- loadModule() registering a NumberSeqDatatype for XyzSliceId (non-continuous, manual=No, change up/down allowed, DataArea-scoped parameter type) via NumberSeqDatatype::construct() + parm*() methods + this.create(datatype), and numberSeqModule() returning NumberSeqModule::XyzSlice (do NOT assign fields on a NumberSeqReference buffer and do NOT invent this.addModuleEntry() -- these are parm*() methods on NumberSeqDatatype); (4) the registration hook that makes the module load -- ground the exact mechanism in the standard codebase first (search / find_references / get_knowledge on how NumberSeqApplicationModule subclasses get registered, e.g. the load-module event subscription pattern) rather than guessing; (5) a parameters table XyzSliceParameters following the singleton parameters pattern (Key field, find() with createIfNotExist semantics per convention) with a numRefXyzSliceId() method returning the NumberSequenceReference for the EDT; (6) a TableOfContents form XyzSliceParametersForm over the parameters table using the form pattern scaffold. All objects must build clean. This composes into one scoreable slice the exact path that failed piecewise in the recorded run behind docs/USAGE_EXAMPLES.md section 1.",
+  "target_artifact_types": [
+    "AxEdt",
+    "AxEnumExtension",
+    "AxClass",
+    "AxClass",
+    "AxTable",
+    "AxForm"
+  ],
+  "golden_path": "eval/goldens/L3-numberseq-module-slice/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "numbersequence",
+    "enum-extension",
+    "parameters",
+    "tableofcontents",
+    "multi-artifact"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L4-headerlines-document-slice.json
+++ b/eval/cases/L4-headerlines-document-slice.json
@@ -1,0 +1,34 @@
+{
+  "id": "L4-headerlines-document-slice",
+  "title": "Header/lines document slice with number sequence, DetailsTransaction form and security (mini Equipment Rental)",
+  "tier": 4,
+  "instruction": "In the sandbox model, build a scaled-down rental-agreement document module -- the composite shape from the recorded run behind docs/USAGE_EXAMPLES.md section 1 that previously ended in a full sandbox rollback, captured here as one scoreable unit: (1) an enum XyzRentStatus (Open, Confirmed, Returned, Cancelled) and an EDT XyzRentAgreementId (String, extends Num); (2) a header table XyzRentHeader (RentAgreementId: XyzRentAgreementId, mandatory, unique index; CustAccount: standard CustAccount EDT with a relation to CustTable; FromDate and ToDate: TransDate EDT; Status: XyzRentStatus) with TitleField1 and an Overview field group; (3) a lines table XyzRentLine (RentAgreementId; LineNum: LineNum EDT; ItemName: Name EDT; Qty: Qty EDT; LineAmount: AmountCur EDT) with a relation to XyzRentHeader on RentAgreementId and a cascading delete action; (4) number-sequence wiring for RentAgreementId following the L2-numberseq-basic pattern (NumberSeqModule enum-extension value XyzRent + a NumberSeqApplicationModule subclass registering the datatype); (5) a DetailsTransaction form XyzRentAgreement with the header data source plus a joined lines data source and a lines grid -- use the form pattern scaffold and modify operations, not hand-authored XML; (6) a display menu item XyzRentAgreementMI pointing at the form; (7) a privilege XyzRentMaintain (maintain, EntryPoints on the menu item), a duty XyzRentDuty and a role XyzRentClerk chaining it. Reuse standard labels throughout. All objects must build clean in a FORWARD-ONLY run: no full-XML overwrite hand-fixes and no rollback-and-retry of already-written objects -- if a tool write is wrong, the case fails and the run record classifies why.",
+  "target_artifact_types": [
+    "AxEnum",
+    "AxEdt",
+    "AxTable",
+    "AxTable",
+    "AxEnumExtension",
+    "AxClass",
+    "AxForm",
+    "AxMenuItemDisplay",
+    "AxSecurityPrivilege",
+    "AxSecurityDuty",
+    "AxSecurityRole"
+  ],
+  "golden_path": "eval/goldens/L4-headerlines-document-slice/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "detailstransaction",
+    "numbersequence",
+    "security",
+    "header-lines",
+    "modify",
+    "multi-artifact"
+  ],
+  "split": "holdout"
+}

--- a/eval/cases/L4-master-security-slice.json
+++ b/eval/cases/L4-master-security-slice.json
@@ -1,0 +1,34 @@
+{
+  "id": "L4-master-security-slice",
+  "title": "Master data slice: table + DetailsMaster form + menu wiring + privilege/duty/role chain",
+  "tier": 4,
+  "instruction": "In the sandbox model, ship a complete master-data slice for a simple asset register: (1) a table XyzAsset with fields AssetCode (string, Num EDT, mandatory), Name (string, Name EDT) and AcquiredDate (date, TransDate EDT), a unique index AssetIdx on AssetCode, TitleField1 = Name, and an Overview field group; (2) a DetailsMaster form XyzAssetDetails over XyzAsset -- scaffold it via the form pattern tools (object_patterns spec/validate + generate_object scaffold) and complete any missing controls via d365fo_file action=modify add-control, not via full-XML rewrites; (3) a display menu item XyzAssetDetailsMI pointing at the form; (4) a menu XyzAssetMenu containing the menu item (wire it via the add-menu-item-to-menu modify operation); (5) a security privilege XyzAssetView (view access) and a privilege XyzAssetMaintain (maintain access), each granting EntryPoints access to the menu item; (6) a duty XyzAssetDuty grouping both privileges; (7) a role XyzAssetManager grouping the duty. Reuse standard labels throughout (labels tool; no raw text). All objects must build clean, and the security chain must resolve end to end with non-empty grants (verify with security_info) -- empty skeletons that merely compile are not correct.",
+  "target_artifact_types": [
+    "AxTable",
+    "AxForm",
+    "AxMenuItemDisplay",
+    "AxMenu",
+    "AxSecurityPrivilege",
+    "AxSecurityPrivilege",
+    "AxSecurityDuty",
+    "AxSecurityRole"
+  ],
+  "golden_path": "eval/goldens/L4-master-security-slice/",
+  "golden_pending": true,
+  "ignore": [
+    "**/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "security",
+    "privilege",
+    "duty",
+    "role",
+    "form",
+    "detailsmaster",
+    "menu",
+    "modify",
+    "multi-artifact"
+  ],
+  "split": "holdout"
+}


### PR DESCRIPTION
## Summary

Expands the agent_eval_loop case portfolio from 30 to 40 cases, targeting the three weakest coverage areas (all cases `golden_pending: true`, `split: "holdout"` per convention — goldens will be captured on the VM in a follow-up):

### Modify-heavy operations
The recorded Equipment Rental run (docs/USAGE_EXAMPLES.md §1) failed precisely on the `d365fo_file action=modify` surface, which existing cases barely exercise:
- **L2-table-modify-lifecycle** — 10-op chain on a table (add/modify/rename/remove-field, add/remove-index, add-relation, field groups, modify-property)
- **L2-form-modify-controls** — form controls built exclusively via `add-control` (regression: failed 6/6 in the recorded run)
- **L2-enum-modify-values** — add/modify/remove-enum-value with an exact final state
- **L2-class-method-ops** — add-method / replace-code / remove-method + display/table methods

### Known-defect regressions
Following the pattern of `L4-bridge-drops-data-entity-primarytable-fields-on-create`:
- **L2-enum-extension-empty-values** — enum-extension create silently writing empty `EnumValues` (EquipRental BUILD #1), incl. a compile-time probe class
- **L3-form-add-datasource-lines** — minimal repro of the *unresolved* `form datasource refers to table ''` defect (BUILDS #4–#13, 58 errors)
- **L2-form-over-view** — `generate_object` "table not found" when the form datasource is a view

### Composite L3/L4 slices
Only 6/30 cases were L3/L4, while the loop previously broke on composite shapes:
- **L3-numberseq-module-slice** — full number-seq wiring incl. registration hook, parameters table + numRef, TOC form (the exact scope L2-numberseq-basic declares out of scope)
- **L4-master-security-slice** — master table + DetailsMaster form + menu wiring + privilege/duty/role chain
- **L4-headerlines-document-slice** — mini Equipment Rental (header/lines, number-seq, DetailsTransaction form, security) as one scoreable forward-only unit

Instructions are written so that falling back to hand-authored XML fails the case — otherwise regression cases would mask the defect they exist to catch.

## Test plan
- [x] `npx vitest run tests/eval/` — golden-integrity gate + oracle units: 152 passed (new cases validated, exempt from the golden requirement via `golden_pending`)
- [x] `npm run build` — clean
- [x] `npm run eval:report` — catalog loads without error
- [ ] Follow-up (on VM): implementer runs per eval/README.md → capture goldens → drop `golden_pending`

🤖 Generated with [Claude Code](https://claude.com/claude-code)