### PR TITLE
fix: class create can emit an AxClass whose Name disagrees with its own X++ class keyword

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -549,6 +549,41 @@ export class XmlTemplateGenerator {
   }
 
   /**
+   * If `declaration`'s own `class`/`interface` header names something other than
+   * `className` (e.g. the object is being created as "FmMcpFoo" but the caller's
+   * X++ still says `class Foo`), rename every self-reference to that stale name —
+   * in the header AND in every method body (constructor calls, return types,
+   * etc.) — to `className`.
+   *
+   * Left unfixed, the AOT object's `<Name>` (which the create path always sets to
+   * the resolved `className`, independent of whatever the caller typed in
+   * `sourceCode`) does not match its own X++ class keyword — a hard xppc build
+   * error ("class must be named the same as the object it is contained in"),
+   * confirmed by corpus evidence: the caller passed an already-correct,
+   * fully-resolved objectName ("FmMcpXyzNoteFormatter") — so the existing
+   * objectName-vs-finalObjectName prefix-mismatch guard below never fired — while
+   * sourceCode's `class XyzNoteFormatter` used the bare, unprefixed name
+   * (eval/corpus/runs/2026-07-06T16__L1-class-basic__73707ff.json).
+   */
+  static normalizeSelfReferenceName<T extends { name: string; source?: string }>(
+    className: string,
+    declaration: string,
+    methods: T[],
+  ): { declaration: string; methods: T[] } {
+    const declaredName = declaration.match(/\b(?:class|interface)\s+(\w+)/)?.[1];
+    if (!declaredName || declaredName === className) return { declaration, methods };
+
+    const re = new RegExp(`\\b${declaredName}\\b`, 'g');
+    return {
+      declaration: declaration.replace(re, className),
+      methods: methods.map(m => ({
+        ...m,
+        source: m.source !== undefined ? m.source.replace(re, className) : m.source,
+      })) as T[],
+    };
+  }
+
+  /**
    * Parse X++ sourceCode into declaration + methods for the C# bridge.
    *
    * Used by the bridge-first creation path in create_d365fo_file — the C# side
@@ -556,14 +591,21 @@ export class XmlTemplateGenerator {
    * objects {name, source} which it sets on the AxClass via IMetadataProvider.
    *
    * Delegates to splitXppClassSource after decoding any XML entities.
+   *
+   * `className` is the resolved AOT object name the bridge will create this
+   * class under (`finalObjectName`) — passing it lets self-references in the
+   * caller's sourceCode that don't match get corrected (normalizeSelfReferenceName).
    */
-  static parseSourceForBridge(sourceCode: string): {
+  static parseSourceForBridge(sourceCode: string, className?: string): {
     declaration: string;
     methods: { name: string; source?: string }[];
   } {
     // Same entity-decoding as generateAxClassXml to handle AI-generated &lt; etc.
     const cleaned = decodeXmlEntitiesFromXppSource(sourceCode);
-    const result = XmlTemplateGenerator.splitXppClassSource(cleaned);
+    const split = XmlTemplateGenerator.splitXppClassSource(cleaned);
+    const result = className
+      ? XmlTemplateGenerator.normalizeSelfReferenceName(className, split.declaration, split.methods)
+      : split;
     return {
       declaration: result.declaration,
       // The bridge stores each method's source verbatim (no reformatting on its
@@ -591,7 +633,12 @@ export class XmlTemplateGenerator {
     // Split full X++ source into Declaration (class header + fields) and Methods.
     // D365FO XML requires member variable declarations in <Declaration> and
     // each method body as a separate <Method> element under <Methods>.
-    const { declaration, methods } = XmlTemplateGenerator.splitXppClassSource(rawSource);
+    const rawSplit = XmlTemplateGenerator.splitXppClassSource(rawSource);
+    // Correct any stale self-reference (caller's class/interface name doesn't match
+    // the resolved `className`) so the emitted <Name> and X++ class keyword agree.
+    const { declaration, methods } = XmlTemplateGenerator.normalizeSelfReferenceName(
+      className, rawSplit.declaration, rawSplit.methods,
+    );
 
     const extendsAttr = properties?.extends
       ? `\t<Extends>${properties.extends}</Extends>\n`
@@ -4015,7 +4062,7 @@ export async function handleCreateD365File(
 
         // For classes: parse sourceCode into declaration + methods
         if ((args.objectType === 'class' || args.objectType === 'class-extension') && args.sourceCode) {
-          const parsed = XmlTemplateGenerator.parseSourceForBridge(args.sourceCode);
+          const parsed = XmlTemplateGenerator.parseSourceForBridge(args.sourceCode, finalObjectName);
           bridgeParams.declaration = parsed.declaration;
           bridgeParams.methods = parsed.methods;
         }

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -563,6 +563,79 @@ describe('XmlTemplateGenerator.splitXppClassSource', () => {
   });
 });
 
+// ─── XmlTemplateGenerator.normalizeSelfReferenceName ────────────────────────
+//
+// Regression for eval/corpus/runs/2026-07-06T16__L1-class-basic__73707ff.json
+// (classification: TOOL_DEFECT, build.succeeded: false): the caller passed an
+// already-fully-resolved objectName ("FmMcpXyzNoteFormatter") but sourceCode's
+// own `class XyzNoteFormatter` used the bare, unprefixed name. Because
+// objectName itself needed no prefix-normalizing (finalObjectName ===
+// args.objectName), the existing xmlContent-only "CRITICAL FIX" guard in
+// create_d365fo_file (keyed on finalObjectName !== args.objectName) never
+// fired, so the AOT object's <Name> disagreed with its own X++ class keyword
+// — a hard xppc build error.
+describe('XmlTemplateGenerator.normalizeSelfReferenceName', () => {
+  it('renames a stale self-reference in the header and in method bodies (construct pattern)', () => {
+    const declaration = 'public class XyzNoteFormatter\n{\n    str prefix;\n\n}';
+    const methods = [
+      { name: 'new', source: 'public void new(str _prefix)\n    {\n        prefix = _prefix;\n    }' },
+      {
+        name: 'construct',
+        source: 'public static XyzNoteFormatter construct(str _prefix)\n    {\n        return new XyzNoteFormatter(_prefix);\n    }',
+      },
+    ];
+
+    const result = XmlTemplateGenerator.normalizeSelfReferenceName('FmMcpXyzNoteFormatter', declaration, methods);
+
+    expect(result.declaration).toContain('public class FmMcpXyzNoteFormatter');
+    expect(result.declaration).not.toMatch(/(?<!FmMcp)XyzNoteFormatter/);
+    const construct = result.methods.find(m => m.name === 'construct')!;
+    expect(construct.source).toContain('public static FmMcpXyzNoteFormatter construct');
+    expect(construct.source).toContain('return new FmMcpXyzNoteFormatter(_prefix);');
+    expect(construct.source).not.toMatch(/\bXyzNoteFormatter\b/);
+  });
+
+  it('is a no-op when the declared name already matches className', () => {
+    const declaration = 'public class FmMcpFoo\n{\n}';
+    const methods = [{ name: 'run', source: 'public void run()\n    {\n    }' }];
+    const result = XmlTemplateGenerator.normalizeSelfReferenceName('FmMcpFoo', declaration, methods);
+    expect(result.declaration).toBe(declaration);
+    expect(result.methods).toEqual(methods);
+  });
+
+  it('generateAxClassXml applies the correction end-to-end (Name element + Declaration + method Source agree)', () => {
+    const sourceCode =
+      'public class XyzNoteFormatter\n{\n    str prefix;\n}\n\n' +
+      'public static XyzNoteFormatter construct(str _prefix)\n{\n    return new XyzNoteFormatter(_prefix);\n}';
+    const xml = XmlTemplateGenerator.generateAxClassXml('FmMcpXyzNoteFormatter', sourceCode);
+
+    expect(xml).toContain('<Name>FmMcpXyzNoteFormatter</Name>');
+    expect(xml).toContain('public class FmMcpXyzNoteFormatter');
+    expect(xml).toContain('public static FmMcpXyzNoteFormatter construct');
+    expect(xml).toContain('return new FmMcpXyzNoteFormatter(_prefix);');
+    // No leftover reference to the stale, unprefixed self-name anywhere in the XML.
+    expect(xml).not.toMatch(/\bXyzNoteFormatter\b/);
+  });
+
+  it('parseSourceForBridge applies the correction when className is passed (bridge CREATE path)', () => {
+    const sourceCode =
+      'class XyzNoteFormatter\n{\n    str prefix;\n}\n\n' +
+      'public static XyzNoteFormatter construct(str _prefix)\n{\n    return new XyzNoteFormatter(_prefix);\n}';
+    const parsed = XmlTemplateGenerator.parseSourceForBridge(sourceCode, 'FmMcpXyzNoteFormatter');
+
+    expect(parsed.declaration).toContain('class FmMcpXyzNoteFormatter');
+    const construct = parsed.methods.find(m => m.name === 'construct')!;
+    expect(construct.source).toContain('FmMcpXyzNoteFormatter construct');
+    expect(construct.source).toContain('new FmMcpXyzNoteFormatter(_prefix)');
+  });
+
+  it('parseSourceForBridge without className (legacy callers) leaves self-references untouched', () => {
+    const sourceCode = 'class Foo\n{\n}\n\npublic static Foo construct()\n{\n    return new Foo();\n}';
+    const parsed = XmlTemplateGenerator.parseSourceForBridge(sourceCode);
+    expect(parsed.declaration).toContain('class Foo');
+  });
+});
+
 // ─── XmlTemplateGenerator security generators ───────────────────────────────
 
 describe('XmlTemplateGenerator security duty/role generators', () => {


### PR DESCRIPTION
## Summary

- `d365fo_file(create, objectType="class"/"class-extension")` writes the resolved AOT object name to `<Name>` but never checked that the caller's `sourceCode` (`class Foo { ... }`) actually declares that same name — so a caller that passes an already-correctly-prefixed `objectName` but types an unprefixed/bare self-reference in `sourceCode` gets a class whose metadata `Name` disagrees with its own X++ class keyword (and every self-reference in its methods: constructor calls, return types). This is a hard xppc build error.
- An existing guard (the "CRITICAL FIX" block in `create_d365fo_file`) already patches the *other* mismatch shape — `objectName` itself needing prefix normalization (`finalObjectName !== args.objectName`) — but it's keyed on the wrong pair of values, so it never fires when `objectName` was already correct while `sourceCode`'s own self-references were not. It also only runs on the `xmlContent` fallback path, never on the bridge-first CREATE path (`bridgeCreateObject` via `parseSourceForBridge`), which is what full/VM-mode sessions normally use.
- Fix: `XmlTemplateGenerator.normalizeSelfReferenceName(className, declaration, methods)` extracts the caller's declared class/interface name and, when it differs from the resolved `className`, renames every self-reference (header + every method body) to match — mirroring `reindentXppSource`'s "derive the canonical form regardless of what the caller typed" approach. Wired into both call sites that know the final resolved name: `generateAxClassXml` (local template / `xmlContent`-fallback path) and `parseSourceForBridge` (bridge-first CREATE path, now takes an optional `className` param).

## Evidence (corpus, VM-produced, not committed)

`eval/corpus/runs/2026-07-06T16__L1-class-basic__73707ff.json` (classification: `TOOL_DEFECT`, `build.succeeded: false`):

- Case `L1-class-basic` ("plain standalone class") — caller passed `objectName = "FmMcpXyzNoteFormatter"` (already correctly resolved).
- Golden-diff `changed`:
  - `AxClass/SourceCode/Declaration`: expected `public class PFXXyzNoteFormatter\n{ ... }`, actual `class XyzNoteFormatter\n{ ... }` (bare, unprefixed self-reference — and build failed).
  - `AxClass/SourceCode/Methods/Method[construct]/Source`: expected `... PFXXyzNoteFormatter construct(...) { return new PFXXyzNoteFormatter(...); }`, actual `... XyzNoteFormatter construct(...) { return new XyzNoteFormatter(...); }`.

This exact shape — `finalObjectName === args.objectName` (no prefix normalization needed) while the caller's own X++ text used a different, unprefixed self-name — is precisely what the existing `finalObjectName !== args.objectName` guard misses.

## Before / after

**Before (unfixed code, confirmed by stashing the src change):**
```
$ npx vitest run tests/tools/code-generation.test.ts -t "normalizeSelfReferenceName"
 FAIL  generateAxClassXml applies the correction end-to-end (Name element + Declaration + method Source agree)
 FAIL  parseSourceForBridge applies the correction when className is passed (bridge CREATE path)
 FAIL  renames a stale self-reference in the header and in method bodies (construct pattern)
 4 failed | 1 passed | 78 skipped
```

**After (this PR):**
```
$ npx vitest run
 Test Files  101 passed (101)
      Tests  1510 passed (1510)
```

## Test plan

- [x] New regression tests in `tests/tools/code-generation.test.ts` (`describe('XmlTemplateGenerator.normalizeSelfReferenceName', ...)`) reproduce the corpus defect deterministically, VM-free — 4/5 fail on unfixed `main`, all 5 pass after the fix.
- [x] Full suite green: `npx vitest run` → 101 files / 1510 tests passing (includes `tests/eval/goldens.test.ts`, the golden-integrity gate).
- [x] `npx tsc --noEmit -p .` clean.
- [x] Scope check: only the two call sites that know the resolved object name (`generateAxClassXml`, `parseSourceForBridge`) were touched; the pre-existing `finalObjectName !== args.objectName` guard is left in place (still useful for the raw-`xmlContent` scenario) — no double-replacement, verified by the new tests and the full suite.
- [x] Corpus is VM-produced local evidence and intentionally not committed (`eval/corpus/runs/` stays gitignored) — the new unit tests are the durable, VM-free regression proof per `docs/AGENT_EVAL_LOOP.md` §10. A future implementer run on the VM re-scoring `L1-class-basic` is expected to confirm `build.succeeded: true` / `golden_match: true`.

https://claude.ai/code/session_01LqjPNZKjz5819guJbtk8xL