### PR TITLE
feat(eval): add new golden metadata for L2 enum extension and probe c…

### DIFF
--- a/.claude/agents/eval-implementer.md
+++ b/.claude/agents/eval-implementer.md
@@ -1,7 +1,7 @@
 ---
 name: eval-implementer
 description: Implementer role of the D365FO agent eval loop. Runs ON THE VM (mcp-server in full mode + C# bridge) against the fm-mcp sandbox model. Takes an eval case id, drives the grounded MCP tool path to implement it, builds, scores against the golden/SysTest oracle, writes a corpus record, and rolls back. Use when asked to "run eval case <id>", "run the implementer", or execute a case end-to-end on the VM.
-tools: Bash, Read, Grep, Glob
+tools: Bash, Read, Grep, Glob, mcp__d365fo-eval__prepare, mcp__d365fo-eval__search, mcp__d365fo-eval__get_object_info, mcp__d365fo-eval__batch_get_info, mcp__d365fo-eval__extension_info, mcp__d365fo-eval__find_references, mcp__d365fo-eval__validate_code, mcp__d365fo-eval__validate_object_naming, mcp__d365fo-eval__generate_object, mcp__d365fo-eval__d365fo_file, mcp__d365fo-eval__build_d365fo_project, mcp__d365fo-eval__run_systest_class, mcp__d365fo-eval__run_bp_check, mcp__d365fo-eval__trigger_db_sync, mcp__d365fo-eval__verify_d365fo_project, mcp__d365fo-eval__undo_last_modification, mcp__d365fo-eval__update_symbol_index, mcp__d365fo-eval__get_workspace_info, mcp__d365fo-eval__get_method, mcp__d365fo-eval__get_knowledge, mcp__d365fo-eval__analyze_code, mcp__d365fo-eval__security_info, mcp__d365fo-eval__suggest_edt, mcp__d365fo-eval__labels, mcp__d365fo-eval__object_patterns, mcp__d365fo-eval__review_workspace_changes
 model: inherit
 ---
 

--- a/eval/goldens/L2-enum-extension-empty-values/NumberSeqModule.AxEnumExtension.metadata.xml
+++ b/eval/goldens/L2-enum-extension-empty-values/NumberSeqModule.AxEnumExtension.metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L2-enum-extension-empty-values (1 of 2): enum-extension adding NumberSeqModule::XyzEvalRent. Captured 2026-07-07, SHA cb1b73d. This is the regression surface under test: BUILD #1 in docs/USAGE_EXAMPLES.md section 1 recorded the create call writing an EMPTY <EnumValues/> here, only caught later as an unresolved-symbol build error. This run's read-back confirmed EnumValues was populated correctly. -->
+<AxEnumExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>NumberSeqModule.AslExtension</Name>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>XyzEvalRent</Name>
+			<Label>@GEE:GEE16817</Label>
+		</AxEnumValue>
+	</EnumValues>
+	<PropertyModifications />
+	<ValueModifications />
+</AxEnumExtension>

--- a/eval/goldens/L2-enum-extension-empty-values/XyzEnumExtProbe.AxClass.metadata.xml
+++ b/eval/goldens/L2-enum-extension-empty-values/XyzEnumExtProbe.AxClass.metadata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L2-enum-extension-empty-values (2 of 2): probe class proving NumberSeqModule::XyzEvalRent resolves at compile time. Captured 2026-07-07, SHA cb1b73d. -->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>AslXyzEnumExtProbe</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+class AslXyzEnumExtProbe
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>module</Name>
+				<Source><![CDATA[
+    public static NumberSeqModule module()
+    {
+        return NumberSeqModule::XyzEvalRent;
+    }
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>


### PR DESCRIPTION
…lass
This pull request adds support and golden files for evaluating enum extension handling in the D365FO agent eval loop. The main changes are the expansion of the eval-implementer agent's toolset and the addition of two golden metadata XML files to verify correct behavior for enum extensions, specifically ensuring that enum values are properly populated and resolvable at compile time.

**Eval agent enhancements:**

* Expanded the `eval-implementer` agent's declared tools to include a comprehensive set of MCP D365FO eval tools, enabling more robust and automated evaluation workflows.

**Golden files for enum extension regression test:**

* Added `NumberSeqModule.AxEnumExtension.metadata.xml` to serve as a golden file verifying that enum extensions correctly include populated `<EnumValues>` (not empty), addressing a prior regression where values were missing and causing build errors.
* Added `XyzEnumExtProbe.AxClass.metadata.xml` as a probe class golden, confirming that the new enum value `NumberSeqModule::XyzEvalRent` is resolvable at compile time, thus validating the fix.