### PR TITLE
fix: route table create through the bridge's BP-smart createSmartTable path

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -14,7 +14,7 @@ import { PackageResolver } from '../utils/packageResolver.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
 import { reindentXppSource } from '../utils/xppFormat.js';
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
-import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject, bridgeRefreshProvider } from '../bridge/index.js';
+import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject, bridgeCreateSmartTable, bridgeRefreshProvider } from '../bridge/index.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
 import { gateOnFormPatternErrors, isFormPatternEnforceEnabled } from './validateFormPattern.js';
 import { validateFormExtensionControlShape, buildFormExtensionShapeError } from '../utils/formExtensionShapeValidator.js';
@@ -4155,6 +4155,127 @@ export async function handleCreateD365File(
         if (args.objectType === 'edt' && bridgeParams.properties && 'edtType' in bridgeParams.properties) {
           const { edtType, ...rest } = bridgeParams.properties;
           bridgeParams.properties = { ...rest, BaseType: edtType };
+        }
+
+        // For plain 'table' creates, prefer the bridge's BP-smart path
+        // (CreateSmartTable) over the generic createObject/CreateTable RPC.
+        // CreateTable writes exactly what the caller passed and nothing more —
+        // no CacheLookup, PrimaryIndex/ClusteredIndex/ReplacementKey, TitleField1/2,
+        // or the 5 standard FieldGroups (AutoReport/AutoLookup/AutoIdentification/
+        // AutoSummary/AutoBrowse) that every real D365FO table gets. generate_object
+        // (mode="scaffold"/"generate", objectType="table") already routes through
+        // CreateSmartTable and gets these correctly; the plain create verb — the
+        // one a generic "create a table" instruction naturally maps to — silently
+        // produced a BP-defaults-free skeleton instead (eval corpus: L1-table-basic,
+        // L3-form-detailstransaction, L4-ssrs-report-basic — golden_diff missing
+        // CacheLookup/ClusteredIndex/PrimaryIndex/ReplacementKey/TitleField1/TitleField2
+        // and all 5 standard FieldGroups). Try the smart path first; any failure or
+        // unavailability falls through to the existing generic bridgeCreateObject/XML
+        // paths below, unchanged.
+        if (args.objectType === 'table') {
+          const rawTableProps = (args.properties as Record<string, unknown> | undefined) ?? {};
+          const smartTableGroup = typeof rawTableProps.tableGroup === 'string' ? rawTableProps.tableGroup : undefined;
+          const smartTableType = typeof rawTableProps.tableType === 'string' ? rawTableProps.tableType : undefined;
+          const smartLabel = typeof rawTableProps.label === 'string' ? rawTableProps.label : undefined;
+          const smartExtraProperties = scalarProperties
+            ? Object.fromEntries(
+                Object.entries(scalarProperties).filter(
+                  ([k]) => !['tableGroup', 'tableType', 'label'].includes(k),
+                ),
+              )
+            : undefined;
+
+          try {
+            const smartResult = await bridgeCreateSmartTable(context.bridge, {
+              objectName: finalObjectName,
+              modelName: actualModelName,
+              tableGroup: smartTableGroup,
+              tableType: smartTableType,
+              label: smartLabel ?? finalObjectName,
+              fields: bridgeParams.fields,
+              extraFieldGroups: bridgeParams.fieldGroups,
+              indexes: bridgeParams.indexes,
+              relations: bridgeParams.relations,
+              methods: bridgeParams.methods,
+              extraProperties: smartExtraProperties && Object.keys(smartExtraProperties).length > 0
+                ? smartExtraProperties
+                : undefined,
+            });
+
+            if (smartResult?.success && smartResult.filePath) {
+              console.error(`[create_d365fo_file] ✅ Created via C# bridge (BP-smart): ${smartResult.filePath}`);
+
+              let projectMsg = '';
+              if (args.addToProject !== false) {
+                if (projectPathToUse) {
+                  try {
+                    const projectManager = new ProjectFileManager();
+                    await projectManager.addToProject(
+                      projectPathToUse,
+                      args.objectType,
+                      finalObjectName,
+                      smartResult.filePath,
+                    );
+                    projectMsg = `\n✅ Added to project: ${path.basename(projectPathToUse)}`;
+                  } catch (projErr) {
+                    projectMsg = `\n⚠️ Could not add to project: ${projErr}`;
+                  }
+                } else if (solutionPathToUse) {
+                  try {
+                    const detectedPath = await ProjectFileFinder.findProjectInSolution(
+                      solutionPathToUse,
+                      actualModelName,
+                    );
+                    if (detectedPath) {
+                      const projectManager = new ProjectFileManager();
+                      await projectManager.addToProject(
+                        detectedPath,
+                        args.objectType,
+                        finalObjectName,
+                        smartResult.filePath,
+                      );
+                      projectMsg = `\n✅ Added to project: ${path.basename(detectedPath)}`;
+                    } else {
+                      projectMsg = `\n⚠️ Could not find .rnrproj for model '${actualModelName}' in ${solutionPathToUse}`;
+                    }
+                  } catch (projErr) {
+                    projectMsg = `\n⚠️ Could not add to project: ${projErr}`;
+                  }
+                } else {
+                  projectMsg = `\n⚠️ addToProject=true but no projectPath could be resolved.\n` +
+                    `Add projectPath to .mcp.json or pass it as a parameter.`;
+                }
+              }
+
+              // Eagerly refresh the bridge provider so the new object is immediately
+              // resolvable by subsequent modify calls in the same session.
+              try { await bridgeRefreshProvider(context.bridge); } catch { /* best-effort */ }
+
+              const rawLabelWarning = rawLabelBpWarning(args.properties, finalObjectName);
+              const bp = smartResult.bpDefaults;
+              const bpSummary = bp
+                ? `\n📋 BP defaults: CacheLookup=${bp.cacheLookup ?? '(n/a)'}, TitleField1=${bp.titleField1 ?? '(none)'}, ` +
+                  `TitleField2=${bp.titleField2 ?? '(none)'}, PrimaryIndex=${bp.primaryIndex ?? '(none)'}, ` +
+                  `ClusteredIndex=${bp.clusteredIndex ?? '(none)'}`
+                : '';
+
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create() (Smart)\n` +
+                      `📁 ${smartResult.filePath}${projectMsg}\n` +
+                      `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${rawLabelWarning}`,
+                  },
+                ],
+              };
+            }
+            console.error(
+              `[create_d365fo_file] createSmartTable returned ${JSON.stringify(smartResult)} — falling back to generic bridge create`,
+            );
+          } catch (smartErr) {
+            console.error(`[create_d365fo_file] createSmartTable failed, falling back to generic bridge create: ${smartErr}`);
+          }
         }
 
         const bridgeResult = await bridgeCreateObject(context.bridge, bridgeParams);

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -619,6 +619,109 @@ describe('create_d365fo_file', () => {
     expect(sentParams.fields[0].enumType).toBe('NoYes');
   });
 
+  it('table create routes through the bridge\'s BP-smart createSmartTable path, not the generic createObject/CreateTable RPC', async () => {
+    // Regression (eval corpus: L1-table-basic, L3-form-detailstransaction, L4-ssrs-report-basic —
+    // 2026-07-06/07 runs, golden_diff missing CacheLookup/ClusteredIndex/PrimaryIndex/
+    // ReplacementKey/TitleField1/TitleField2 and all 5 standard FieldGroups). d365fo_file(action=
+    // "create", objectType="table") went straight to the bridge's generic createObject RPC, which
+    // dispatches to C# CreateTable() — a bare writer that only emits exactly what the caller
+    // passed. The bridge ALSO exposes createSmartTable (C# CreateSmartTable()), which auto-derives
+    // CacheLookup/TitleField1/TitleField2/PrimaryIndex/ClusteredIndex/ReplacementKey and the 5
+    // standard FieldGroups — but only generate_object(mode="scaffold"/"generate", objectType=
+    // "table") used it. The plain create verb — the one a generic "create a table" instruction
+    // naturally maps to — never did, silently producing a BP-defaults-free skeleton. Fixed by
+    // trying createSmartTable first for objectType==='table' and only falling back to the generic
+    // path if it's unavailable/fails.
+    const createSmartTable = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml',
+      api: 'IMetaTableProvider.Create (Smart)',
+      bpDefaults: {
+        cacheLookup: 'Found',
+        titleField1: 'Subject',
+        titleField2: 'NoteId',
+        primaryIndex: 'NoteIdx',
+        clusteredIndex: 'NoteIdx',
+      },
+    }));
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml',
+      api: 'IMetaTableProvider.Create',
+    }));
+    const ctx = buildContext();
+    (ctx as any).bridge = {
+      isReady: true,
+      metadataAvailable: true,
+      createSmartTable,
+      createObject,
+      validateObject: vi.fn(async () => null),
+    };
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'table',
+        objectName: 'MyTable',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: {
+          tableGroup: 'Main',
+          label: 'My table',
+          fields: [{ name: 'NoteId', type: 'String', mandatory: true }],
+          indexes: [{ name: 'NoteIdx', fields: ['NoteId'], unique: true }],
+        },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(createSmartTable).toHaveBeenCalledTimes(1);
+    expect(createObject).not.toHaveBeenCalled();
+
+    const sentParams = createSmartTable.mock.calls[0][0];
+    expect(sentParams.objectName).toBe('MyTable');
+    expect(sentParams.tableGroup).toBe('Main');
+    expect(sentParams.label).toBe('My table');
+    expect(sentParams.fields).toEqual([{ name: 'NoteId', type: 'String', mandatory: true }]);
+    // tableGroup/tableType/label must NOT be duplicated into extraProperties.
+    expect(sentParams.extraProperties).toBeUndefined();
+
+    expect(result.content[0].text).toMatch(/Smart/);
+    expect(result.content[0].text).toMatch(/BP defaults/);
+  });
+
+  it('table create falls back to the generic createObject/CreateTable RPC when the bridge has no createSmartTable support', async () => {
+    // Same defect as above, opposite side: an older/degraded bridge that only exposes the
+    // generic createObject RPC (no createSmartTable) must still succeed via the pre-existing
+    // fallback path — the smart-table routing must never be a hard requirement.
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml',
+      api: 'IMetaTableProvider.Create',
+    }));
+    const ctx = buildContext();
+    // No createSmartTable on this bridge mock at all.
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, createObject, validateObject: vi.fn(async () => null) };
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', {
+        objectType: 'table',
+        objectName: 'MyTable',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: { fields: [{ name: 'NoteId', type: 'String' }] },
+      }),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(createObject).toHaveBeenCalledTimes(1);
+  });
+
   it('table create resolves a "...DateTime"-named EDT to UtcDateTime, not String', async () => {
     // Regression (eval scenario 2): heuristicEdtBaseType('TransDateTime') used to return
     // undefined (see edt-resolution.test.ts for the root cause), so with no index entry


### PR DESCRIPTION
## Summary
- `d365fo_file(action="create", objectType="table")` went straight to the bridge's generic `createObject` RPC, which dispatches to C# `MetadataWriteService.CreateTable()` — a bare writer that emits exactly what the caller passed and nothing more (no `CacheLookup`, `TitleField1`/`TitleField2`, `PrimaryIndex`/`ClusteredIndex`/`ReplacementKey`, or the 5 standard FieldGroups every real D365FO table has).
- The bridge already has a second RPC, `createSmartTable` (C# `CreateSmartTable()`), that auto-derives all of those BP-smart defaults — but only `generate_object(mode="scaffold"/"generate", objectType="table")` routed through it. The plain `create` verb, the one a generic "create a table" instruction naturally maps to, never did.
- Fixed by trying `bridgeCreateSmartTable` first for `objectType==='table'` inside `handleCreateD365File` (`src/tools/createD365File.ts`), falling back to the existing generic `bridgeCreateObject`/XML paths unchanged if it's unavailable or fails.

## Evidence (eval corpus — VM-produced, not committed to this repo)
Three separate corpus records show the identical missing-property signature, all traced to the same root cause (`bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs`'s `createObject` dispatch routing `objectType="table"` to `CreateTable()` instead of `CreateSmartTable()`):
- `eval/corpus/runs/2026-07-06T19__L1-table-basic__cb1b73d.json` — missing `CacheLookup`, `ClusteredIndex`, `PrimaryIndex`, `ReplacementKey`, `TitleField2`, all 5 standard FieldGroups.
- `eval/corpus/runs/2026-07-07T12__L3-form-detailstransaction__cb1b73d.json` — same signature on the case's underlying line table.
- `eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__1-tmp-table.json` — same signature on the report's temp table.

These all fall inside the corpus's largest failure cluster (`[TOOL_DEFECT] TOOL_DEFECT`, priority=108, freq=27) from `npm run eval:clusters`, a catch-all bucket of older records with no recorded `root_cause_hypothesis` — the root cause here was re-derived directly from each record's `golden_diff` and confirmed by reading the C# bridge dispatch code.

## Regression test
`tests/tools/file-ops.test.ts`:
- New test asserts `createSmartTable` is called (and `createObject` is **not**) when the bridge supports it, and that `tableGroup`/`label`/`fields`/`indexes` are correctly threaded through and not duplicated into `extraProperties`.
- New fallback test asserts the old generic `createObject` path still works unchanged when the bridge mock only exposes `createObject` (matching every pre-existing table-create test in this file).
- Confirmed the new primary test **fails** against pre-fix code (`git stash` the source change, rerun — fails with `createSmartTable` called 0 times) and **passes** after the fix, with all other 70 tests in the file unaffected either way.

## Validation
- `npx vitest run` — full suite green: **101 files / 1512 tests passed** (includes the golden-integrity gate in `tests/eval/goldens.test.ts`).
- `npm run eval:report` — corpus scoreboard unchanged (40 runs, VM-produced, not regenerable from this checkout); this PR does not touch any golden or corpus file.
- `npx tsc --noEmit` — clean.

## Test plan
- [x] `npx vitest run` (full suite, 101/101 files, 1512/1512 tests)
- [x] New regression test fails on pre-fix `main`, passes after the fix
- [x] All pre-existing `objectType: 'table'` create tests (EDT/enum resolution, index normalization, etc.) still pass unchanged
- [ ] Human review — do not merge without sign-off

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LqjPNZKjz5819guJbtk8xL