### PR TITLE
eval: add corpus run records for L0–L4 cases (2026-07-06/07)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,6 @@ coverage/
 # Internal planning docs
 docs/plans/
 
-# Eval runtime data — per-run corpus records stay local (one file per run, noisy).
-# Goldens ARE tracked: they are reviewed contracts and the regression-gate anchors.
-eval/corpus/runs/
-
 # C# Bridge build artifacts
 bridge/D365MetadataBridge/bin/
 bridge/D365MetadataBridge/obj/

--- a/eval/corpus/runs/2026-07-06T10__L0-edt-basic__4fafcd8.json
+++ b/eval/corpus/runs/2026-07-06T10__L0-edt-basic__4fafcd8.json
@@ -1,0 +1,49 @@
+﻿{
+  "run_id": "2026-07-06T10__L0-edt-basic__4fafcd8",
+  "case_id": "L0-edt-basic",
+  "tier": 0,
+  "timestamp": "2026-07-06T10:50:34.816Z",
+  "server_git_sha": "4fafcd8",
+  "generated_artifacts": [
+    "ConDemoNoteSubject.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxEdt/Name",
+        "expected": "ConDemoNoteSubject",
+        "actual": "ConDemoNoteSubject"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 0
+  },
+  "classification": "VALIDATOR_GAP",
+  "root_cause_hypothesis": "The only golden delta is the root AxEdt/Name value (golden=\"ConDemoNoteSubject\" vs actual=\"ConDemoNoteSubject\"); Extends, Label (raw text, matching the golden BPErrorLabelIsText note), and all other structure match exactly. The mismatch is caused entirely by the sandbox EXTENSION_PREFIX for this session (\"Con\") differing from the prefix in effect when the L0-edt-basic golden was captured (\"Con\") — d365fo_file(action=create) correctly auto-applied the CURRENT session prefix per its documented contract, so the produced object is the intended/correct output for this environment. The eval oracle normalizer (src/eval/oracle/normalize.ts) does a literal string compare on the root Name and has no prefix-agnostic comparison, and the case ignore list ([AxEdt/@Id, **/ModelSaveInfo]) does not account for prefix drift, so every run of this (and likely every Con-prefixed) case in an environment configured with a different EXTENSION_PREFIX will spuriously fail golden_match on Name alone even when the object is semantically correct.",
+  "suggested_fix_area": "eval oracle (src/eval/oracle/normalize.ts / diff.ts): add an EXTENSION_PREFIX-aware comparison mode for the root object Name (strip known/likely prefix before compare, or accept a per-run configured-prefix substitution), OR re-capture/parametrize the Con-prefixed goldens so the case ignore list can mask the prefix portion of Name. Not a defect in d365fo_file or the generation tool path itself.",
+  "evidence_refs": [
+    "eval/goldens/L0-edt-basic/ConDemoNoteSubject.metadata.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxEdt/ConDemoNoteSubject.xml",
+    "eval/corpus/runs/2026-07-06T10__L0-edt-basic__4fafcd8.json"
+  ]
+}

--- a/eval/corpus/runs/2026-07-06T16__L0-enum-basic__cc58c3f.json
+++ b/eval/corpus/runs/2026-07-06T16__L0-enum-basic__cc58c3f.json
@@ -1,0 +1,36 @@
+﻿{
+  "run_id": "2026-07-06T16__L0-enum-basic__cc58c3f",
+  "case_id": "L0-enum-basic",
+  "tier": 0,
+  "timestamp": "2026-07-06T16:41:09.858Z",
+  "server_git_sha": "cc58c3f",
+  "generated_artifacts": [
+    "ConDemoNoteStatus.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 0
+  },
+  "classification": "KNOWLEDGE_GAP"
+}

--- a/eval/corpus/runs/2026-07-06T16__L1-class-basic__73707ff.json
+++ b/eval/corpus/runs/2026-07-06T16__L1-class-basic__73707ff.json
@@ -1,0 +1,45 @@
+﻿{
+  "run_id": "2026-07-06T16__L1-class-basic__73707ff",
+  "case_id": "L1-class-basic",
+  "tier": 1,
+  "timestamp": "2026-07-06T16:44:14.372Z",
+  "server_git_sha": "73707ff",
+  "generated_artifacts": [
+    "ConDemoNoteFormatter.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Declaration",
+        "expected": "public class PFXDemoNoteFormatter\n{\n    str prefix;\n\n}",
+        "actual": "class DemoNoteFormatter\n{\n    str prefix;\n\n}"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[construct]/Source",
+        "expected": "public static PFXDemoNoteFormatter construct(str _prefix)\n    {\n        return new PFXDemoNoteFormatter(_prefix);\n    }",
+        "actual": "public static DemoNoteFormatter construct(str _prefix)\n    {\n        return new DemoNoteFormatter(_prefix);\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-06T17__L1-form-detailsmaster__0c446d2.json
+++ b/eval/corpus/runs/2026-07-06T17__L1-form-detailsmaster__0c446d2.json
@@ -1,0 +1,40 @@
+﻿{
+  "run_id": "2026-07-06T17__L1-form-detailsmaster__0c446d2",
+  "case_id": "L1-form-detailsmaster",
+  "tier": 1,
+  "timestamp": "2026-07-06T17:36:45.227Z",
+  "server_git_sha": "0c446d2",
+  "generated_artifacts": [
+    "actual-form.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxForm/Design/Caption",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "PFXDemoNoteHeaderMaster"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json
@@ -1,0 +1,64 @@
+﻿{
+  "run_id": "2026-07-06T17__L1-form-dialog__cb1b73d",
+  "case_id": "L1-form-dialog",
+  "tier": 1,
+  "timestamp": "2026-07-06T17:48:49.616Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxForm/ConDemoNoteHeaderDialog"
+  ],
+  "static_gate": {
+    "references": { "passed": true },
+    "syntax": { "passed": true }
+  },
+  "build": {
+    "succeeded": false,
+    "errors": [
+      {
+        "message": "Form 'ConDemoNoteHeaderDialog' datasource 'ConDemoNoteHeader' refers to table 'ConDemoNoteHeader' which does not exist."
+      },
+      {
+        "message": "AxForm/ConDemoNoteHeaderDialog/DataSources/ConDemoNoteHeader/Table: Table 'ConDemoNoteHeader' does not exist."
+      },
+      {
+        "message": "AxForm/ConDemoNoteHeaderDialog/Design/Controls/DialogBody/Controls/NoteId/DataField: Field 'NoteId' does not exist on data source 'ConDemoNoteHeader'."
+      },
+      {
+        "message": "AxForm/ConDemoNoteHeaderDialog/Design/Controls/DialogBody/Controls/Subject/DataField: Field 'Subject' does not exist on data source 'ConDemoNoteHeader'."
+      }
+    ],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxForm/Design/Caption",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "PFXDemoNoteHeaderDialog"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "get_object_info/generate_object(mode=scaffold) resolved the form's bound table (ConDemoNoteHeader) purely from a stale symbol-index snapshot (get_object_info reported 'Served from symbol index (bridge unavailable)') left over from an earlier, already-rolled-back L1-form-basic run. No AxTable file for that name exists anywhere on disk in this environment (confirmed via search + filesystem scan), and prepare(mode=create) also reported the same phantom collision. The scaffold tool trusted this stale index entry, generated a structurally-correct Dialog form (0 references/syntax/pattern errors, near-perfect golden match apart from the always-present raw-text Caption vs. reused-label quirk seen across this whole Note-form case family), but the bound table does not physically exist so xppc fails 4 compile errors. This is not a defect in the Dialog-pattern scaffolding itself (structure matches golden exactly); it is a symbol-index staleness issue: update_symbol_index() with no filePath (bridge/workspace refresh) does not invalidate/rebuild the deeper 'symbol index' DB that get_object_info/generate_object fall back to when the live bridge is unavailable, so deleted objects keep resolving as if they still existed.",
+  "suggested_fix_area": "mcp-server symbol-index layer: either (a) have the bridge-unavailable fallback path in get_object_info/generate_object(scaffold) verify the object file still exists on disk before trusting a cached index hit, or (b) give update_symbol_index a mode that fully invalidates/rebuilds stale table/class entries (not just the bridge cache + workspace scan) so a prior run's rollback doesn't leave phantom objects resolvable by later sessions. Separately: consider whether the eval case portfolio should provide a shared, checked-in fixture table (ConDemoNoteHeader per golden capture) so downstream form-pattern cases (dialog/lookup/detailsmaster) don't implicitly depend on L1-form-basic's table surviving un-rolled-back.",
+  "evidence_refs": [
+    "eval/goldens/L1-form-dialog/ConDemoNoteHeaderDialog.metadata.xml",
+    "eval/goldens/L1-form-basic/ConDemoNoteHeader.metadata.xml",
+    "eval/corpus/runs/2026-07-06T17__L1-form-detailsmaster__0c446d2.json"
+  ]
+}

--- a/eval/corpus/runs/2026-07-06T17__L1-form-listpage__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T17__L1-form-listpage__cb1b73d.json
@@ -1,0 +1,59 @@
+﻿{
+  "run_id": "2026-07-06T17__L1-form-listpage__cb1b73d",
+  "case_id": "L1-form-listpage",
+  "tier": 1,
+  "timestamp": "2026-07-06T17:59:43.967Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxTable/ConDemoNoteHeader (prerequisite fixture, not scored)",
+    "AxForm/ConDemoNoteHeaderListPage"
+  ],
+  "static_gate": {
+    "references": { "passed": true },
+    "syntax": { "passed": true }
+  },
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      { "rule": "BPErrorLabelIsText", "target": "AxForm/ConDemoNoteHeaderListPage/FormDesign/FormDesign", "message": "Property 'Caption' must have a label ID as its value, and 'ConDemoNoteHeaderListPage' is not a label ID." },
+      { "rule": "BPErrorCaptionNotDefined", "target": "AxForm/.../ActionPaneTab", "message": "No value is given for the Caption property." },
+      { "rule": "BPErrorCaptionNotDefined", "target": "AxForm/.../NewButtonGroup", "message": "No value is given for the Caption property." },
+      { "rule": "BPErrorCaptionNotDefined", "target": "AxForm/.../MaintainButtonGroup", "message": "No value is given for the Caption property." }
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxForm/Design/Caption",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "PFXDemoNoteHeaderListPage"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "Two independent findings. (1) Fixture staleness (worked around, not scored): prepare(mode='create') and get_object_info reported ConDemoNoteHeader as an already-existing table ('Served from symbol index (bridge unavailable)') even though no AxTable file existed anywhere on disk in this sandbox (confirmed by full filesystem search) -- a stale symbol-index ghost entry surviving a prior un-rolled-back run, same phenomenon already recorded today in eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json. update_symbol_index() with no filePath does not clear it. I created the minimal prerequisite table myself via the grounded scaffold path (matching the L1-form-basic case's spec: NoteId/Subject fields, Main table group, reused label @TaxTransactionInquiry:HeaderNote) so this case's own signal wasn't drowned out by a missing-fixture build failure. (2) The case's own defect: generate_object(mode='scaffold', objectType='form', formPattern='ListPage') set Design/Caption to the literal form name ('ConDemoNoteHeaderListPage') instead of reusing the bound datasource table's Label (@TaxTransactionInquiry:HeaderNote), even though that Label is resolvable via the bridge (get_object_info confirmed it). This is structurally identical to the golden (pattern validator: 1/1 containers carry sub-pattern, ListPage vUX7 1.0) and to the same Caption-as-literal-text deviation seen in the L1-form-dialog and L1-form-lookup goldens' family, i.e. this is a systemic scaffold default, not a one-off. It costs bp_clean (BPErrorLabelIsText + 3x BPErrorCaptionNotDefined cascading from the un-labeled ActionPane/ButtonGroups) and golden_match (Design/Caption changed) even though the build itself is clean (0 xppc errors) and the pattern shape is otherwise a perfect match (0 missing, 0 extra).",
+  "suggested_fix_area": "generate_object(mode='scaffold', objectType='form'): when a dataSource table is supplied and that table has a non-empty Label, default the form's Design/Caption (and, ideally, propagate a caption onto ActionPaneTab/ButtonGroup children so BPErrorCaptionNotDefined isn't triggered by the standard ActionPane skeleton) to the table's Label instead of the raw form name literal. Separately (shared with the L1-form-dialog finding): the bridge-unavailable fallback path behind get_object_info/prepare's collision check should verify the object file still exists on disk before trusting a symbol-index hit, so a rolled-back run doesn't leave phantom prerequisite objects for the next case run.",
+  "evidence_refs": [
+    "eval/goldens/L1-form-listpage/ConDemoNoteHeaderListPage.metadata.xml",
+    "eval/goldens/L1-form-basic/ConDemoNoteHeader.metadata.xml",
+    "eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxForm/ConDemoNoteHeaderListPage.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoNoteHeader.xml"
+  ]
+}

--- a/eval/corpus/runs/2026-07-06T18__L1-form-basic__f2c8bfe.json
+++ b/eval/corpus/runs/2026-07-06T18__L1-form-basic__f2c8bfe.json
@@ -1,0 +1,67 @@
+﻿{
+  "run_id": "2026-07-06T18__L1-form-basic__f2c8bfe",
+  "case_id": "L1-form-basic",
+  "tier": 1,
+  "timestamp": "2026-07-06T18:05:00.000Z",
+  "server_git_sha": "f2c8bfe",
+  "generated_artifacts": [
+    "contoso/contoso/AxTable/ConDemoNoteHeader.xml",
+    "contoso/contoso/AxForm/ConDemoNoteHeaderList.xml"
+  ],
+  "static_gate": {
+    "references": { "passed": true },
+    "syntax": { "passed": true }
+  },
+  "build": {
+    "succeeded": false,
+    "errors": [
+      { "text": "Metadata Error: AxTable/ConDemoNoteHeader/ReplacementKey: Index 'DemoNoteHeaderIdx' does not exist." },
+      { "text": "Metadata Error: AxForm/ConDemoNoteHeaderList/Design/Controls/Grid/DataGroup: Field group 'Overview' does not exist." }
+    ],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [
+      "PFXDemoNoteHeader.metadata.xml::AxTable/CacheLookup",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/ClusteredIndex",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoBrowse]/Name",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoIdentification]/AutoPopulate",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoIdentification]/Name",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[NoteId]/DataField",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[Subject]/DataField",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Name",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[NoteId]/DataField",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[Subject]/DataField",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Name",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoSummary]/Name",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/PrimaryIndex",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/ReplacementKey",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/SourceCode/Declaration",
+      "PFXDemoNoteHeader.metadata.xml::AxTable/TitleField2"
+    ],
+    "changed": [
+      { "path": "PFXDemoNoteHeaderList.metadata.xml::AxForm/Design/Caption", "golden": "@TaxTransactionInquiry:HeaderNote", "actual": "PFXDemoNoteHeaderList" }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "Two independent defects. (1) PRIMARY / build-breaking: d365fo_file(action='modify', operation='modify-property') on an AxTable silently no-ops for the ReplacementKey property specifically (reports '✅ ... set via Update' but the XML value is unchanged on disk) after the referenced index was recreated via remove-index+add-index; ClusteredIndex/PrimaryIndex/TitleField1 modify-property calls on the SAME table worked correctly, so this looks like a property-specific bug in the bridge's AxTable property setter, not a generic modify-property limitation. The stale ReplacementKey then references a since-removed index name and fails the xppc build (Metadata Error: ReplacementKey: Index 'DemoNoteHeaderIdx' does not exist). (2) SECONDARY / cross-scaffold inconsistency: generate_object(mode='scaffold', objectType='table') auto-populates FieldGroups with AutoReport/AutoLookup/AutoIdentification/AutoSummary/AutoBrowse but never an 'Overview' group, while generate_object(mode='scaffold', objectType='form', formPattern='SimpleList') always emits Grid/DataGroup=Overview; combining both scaffolds for the same table (exactly what this case's instruction requires) reliably fails the build with 'Field group Overview does not exist' unless the table scaffold is told to leave FieldGroups empty (the golden's own capture used an empty <FieldGroups/>, sidestepping the conflict via the framework's implicit-default field groups). (3) Separate, non-blocking harness defect found in src/eval/oracle/cli.ts's --actual-dir multi-artifact path: it keys `actualArtifacts` by the GOLDEN's filename literal instead of the resolved actual file's own basename, so per-artifact canonicalizePrefix(key, actualPrefix) never converts the golden-literal-prefixed key ('Con...') into the shared 'PFX...' placeholder whenever actualPrefix != goldenPrefix, causing every path in the run to spuriously show up as wholesale missing+extra even though content-level values match. Confirmed by re-running the same two artifacts through the single-file oracle path (no --actual-dir), which produced clean, accurate diffs (table: 0 missing/16 extra scaffold-default noise/0 changed; form: 0 missing/0 extra/1 changed = only Caption, an out-of-scope-for-this-instruction known deviation). This corpus record's golden_diff was reconstructed from those two correct single-file runs.",
+  "suggested_fix_area": "C# bridge IMetadataProvider.Update path for AxTable.ReplacementKey (modify-property); generate_object scaffold defaults reconciliation between table FieldGroups and SimpleList form DataGroup; src/eval/oracle/cli.ts resolveActualFile/actualArtifacts keying (use path.basename(actualFile) instead of the golden loop variable `name`).",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoNoteHeader.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxForm/ConDemoNoteHeaderList.xml"
+  ]
+}

--- a/eval/corpus/runs/2026-07-06T18__L1-form-lookup__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T18__L1-form-lookup__cb1b73d.json
@@ -1,0 +1,40 @@
+﻿{
+  "run_id": "2026-07-06T18__L1-form-lookup__cb1b73d",
+  "case_id": "L1-form-lookup",
+  "tier": 1,
+  "timestamp": "2026-07-06T18:07:23.349Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderLookup.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxForm/Design/Caption",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "PFXDemoNoteHeaderLookup"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-06T18__L1-form-simplelistdetails__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T18__L1-form-simplelistdetails__cb1b73d.json
@@ -1,0 +1,43 @@
+﻿{
+  "run_id": "2026-07-06T18__L1-form-simplelistdetails__cb1b73d",
+  "case_id": "L1-form-simplelistdetails",
+  "tier": 1,
+  "timestamp": "2026-07-06T18:17:53.364Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderDetails.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxForm/Design/Caption",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "PFXDemoNoteHeaderDetails"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-06T18__L1-form-tableofcontents__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T18__L1-form-tableofcontents__cb1b73d.json
@@ -1,0 +1,46 @@
+﻿{
+  "run_id": "2026-07-06T18__L1-form-tableofcontents__cb1b73d",
+  "case_id": "L1-form-tableofcontents",
+  "tier": 1,
+  "timestamp": "2026-07-06T18:26:05.088Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderToc.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxForm/Design/Caption",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "PFXDemoNoteHeaderToc"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-06T18__L1-form-workspace__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T18__L1-form-workspace__cb1b73d.json
@@ -1,0 +1,45 @@
+﻿{
+  "run_id": "2026-07-06T18__L1-form-workspace__cb1b73d",
+  "case_id": "L1-form-workspace",
+  "tier": 1,
+  "timestamp": "2026-07-06T18:34:57.194Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderWorkspace.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxForm/Design/Caption",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "PFXDemoNoteHeaderWorkspace"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-06T18__L1-map-basic__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T18__L1-map-basic__cb1b73d.json
@@ -1,0 +1,56 @@
+﻿{
+  "run_id": "2026-07-06T18__L1-map-basic__cb1b73d",
+  "case_id": "L1-map-basic",
+  "tier": 1,
+  "timestamp": "2026-07-06T18:45:01.842Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteMap.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxMap/Fields/AxMapBaseField[NoteId]/ExtendedDataType",
+      "AxMap/Fields/AxMapBaseField[Subject]/ExtendedDataType",
+      "AxMap/Mappings/AxTableMapping/Connections/AxTableMappingConnection/MapField",
+      "AxMap/Mappings/AxTableMapping/Connections/AxTableMappingConnection/MapFieldTo",
+      "AxMap/Mappings/AxTableMapping/MappingTable"
+    ],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "d365fo_file(action=\"create\", objectType=\"map\") silently drops two parts of the properties payload for AxMap: (1) fields[].edt is never written as <ExtendedDataType> for AxMapFieldString entries (NoteId/Subject came out with no EDT at all), and (2) the top-level properties.mappings array (mappingTable + connections) is ignored outright -- the written <Mappings/> element is always empty regardless of input. Root cause is almost certainly that AxMap scaffolding support is newer/thinner than table/enum scaffolding (the golden itself notes objectType was previously unsupported), so the properties-to-XML mapper for this objectType was never wired up for these two shapes. Separately, d365fo_file(action=\"modify\") does not accept objectType=\"map\" at all (confirmed via a direct call, which errored with a Zod enum-mismatch listing only class/table/form/enum/query/view/edt/data-entity/report/*-extension/menu-item-*/menu/security-*), so there is also no grounded post-create repair path for a map -- create is the only entry point and it is the one that is defective. A secondary, likely unrelated defect found while building the prerequisite fixture table: d365fo_file(action=\"modify\", operation=\"modify-property\") reported success (\"Property CreatedDateTime=Yes set via Update\") for both a real property name and a deliberately bogus one (XXXInvalidProp), but neither write actually persisted to the XML on disk -- false-positive success reporting for this operation on AxTable, at least for boolean top-level properties. Worked around by adding an explicit CreatedDateTime field instead for the prerequisite table, which does not affect this case own scored artifact (the map).",
+  "suggested_fix_area": "mcp-server AxMap create path: wire properties.fields[].edt -> AxMapFieldString/ExtendedDataType (and equivalent for other AxMapField* subtypes) and properties.mappings[] -> AxTableMapping/Connections/AxTableMappingConnection in the map XML generator used by d365fo_file(action=\"create\", objectType=\"map\"). Also add objectType=\"map\" to the d365fo_file(action=\"modify\") allowed-objectType enum with at least an add-mapping/modify-field operation, so a map can be fixed up post-create without hand-editing XML. Separately (lower priority, different object type): investigate why modify-property on AxTable reports success without persisting for at least CreatedDateTime and an invalid property name -- it should either write the value or fail loudly, not silently no-op while reporting success.",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxMap/ConDemoNoteMap.xml (pre-rollback; missing ExtendedDataType + empty Mappings)",
+    "eval/goldens/L1-map-basic/DemoNoteMap.AxMap.metadata.xml"
+  ]
+}

--- a/eval/corpus/runs/2026-07-06T18__L1-query-view-basic__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T18__L1-query-view-basic__cb1b73d.json
@@ -1,0 +1,61 @@
+﻿{
+  "run_id": "2026-07-06T18__L1-query-view-basic__cb1b73d",
+  "case_id": "L1-query-view-basic",
+  "tier": 1,
+  "timestamp": "2026-07-06T18:57:04Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxTable/ConDemoNoteHeader.xml (prerequisite fixture, not scored)",
+    "AxQuery/ConDemoNoteHeaderQuery.xml",
+    "AxView/ConDemoNoteHeaderView.xml"
+  ],
+  "static_gate": {
+    "references": { "passed": true },
+    "syntax": { "passed": true }
+  },
+  "build": {
+    "succeeded": false,
+    "errors": [
+      { "message": "Metadata Error: AxView/ConDemoNoteHeaderView/Fields/NoteId/DataSource: Data source 'ConDemoNoteHeaderQuery' does not exist or is not part of the first root data source in the query." },
+      { "message": "Metadata Error: AxView/ConDemoNoteHeaderView/Fields/Subject/DataSource: Data source 'ConDemoNoteHeaderQuery' does not exist or is not part of the first root data source in the query." },
+      { "message": "MetadataProvider Error: On the 'ConDemoNoteHeaderView' view, the 'NoteId' field does not have a valid datasource." },
+      { "message": "MetadataProvider Error: On the 'ConDemoNoteHeaderView' view, the 'Subject' field does not have a valid datasource." }
+    ],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "ConDemoNoteHeaderQuery.metadata.xml::AxQuery/DataSources/AxQuerySimpleRootDataSource[PFXDemoNoteHeader]/Fields/AxQuerySimpleDataSourceField[NoteId]/Field",
+      "ConDemoNoteHeaderQuery.metadata.xml::AxQuery/DataSources/AxQuerySimpleRootDataSource[PFXDemoNoteHeader]/Fields/AxQuerySimpleDataSourceField[NoteId]/Name",
+      "ConDemoNoteHeaderQuery.metadata.xml::AxQuery/DataSources/AxQuerySimpleRootDataSource[PFXDemoNoteHeader]/Fields/AxQuerySimpleDataSourceField[Subject]/Field",
+      "ConDemoNoteHeaderQuery.metadata.xml::AxQuery/DataSources/AxQuerySimpleRootDataSource[PFXDemoNoteHeader]/Fields/AxQuerySimpleDataSourceField[Subject]/Name",
+      "ConDemoNoteHeaderQuery.metadata.xml::AxQuery/DataSources/AxQuerySimpleRootDataSource[PFXDemoNoteHeader]/Name",
+      "ConDemoNoteHeaderQuery.metadata.xml::AxQuery/DataSources/AxQuerySimpleRootDataSource[PFXDemoNoteHeader]/Table"
+    ],
+    "extra": [],
+    "changed": [
+      { "path": "ConDemoNoteHeaderQuery.metadata.xml::AxQuery/Title", "golden": "@TaxTransactionInquiry:HeaderNote", "actual": "PFXDemoNoteHeaderQuery" },
+      { "path": "ConDemoNoteHeaderView.metadata.xml::AxView/Fields/AxViewField[NoteId]/DataSource", "golden": "PFXDemoNoteHeader", "actual": "PFXDemoNoteHeaderQuery" },
+      { "path": "ConDemoNoteHeaderView.metadata.xml::AxView/Fields/AxViewField[Subject]/DataSource", "golden": "PFXDemoNoteHeader", "actual": "PFXDemoNoteHeaderQuery" },
+      { "path": "ConDemoNoteHeaderView.metadata.xml::AxView/Label", "golden": "@TaxTransactionInquiry:HeaderNote", "actual": "PFXDemoNoteHeaderView" }
+    ]
+  },
+  "systest": { "ran": false, "passed": null, "failures": [] },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "No grounded MCP tool operation exists to add a root DataSource (table + selected fields) to an AxQuery. d365fo_file(action='create', objectType='query') always emits an empty <DataSources /> classDeclaration-only skeleton. d365fo_file(action='modify', objectType='query', operation='add-data-source') is explicitly rejected by the C# bridge ('add-data-source not supported for objectType query'); operation='add-field' misinterprets the query name as a table name and fails with a table-not-found error; operation='modify-property' has no supported propertyPath for query DataSources; generate_object(mode='scaffold') only accepts objectType table/form/report, not query; and passing an ad-hoc 'properties' object (table/dataSourceName/fields, mirroring the data-entity shape) to d365fo_file(action='create', objectType='query', overwrite=true) is silently ignored (DataSources stays empty, no error). By contrast d365fo_file(action='create', objectType='view') DOES silently honor an undocumented properties shape ({query, fields:[{name,dataField}]}) to populate AxView/Query and AxView/Fields -- but since the upstream query never got a root datasource, the tool has no way to know the real datasource name and defaults AxViewFieldBound/DataSource to the query's own name, which is invalid. The downstream effect: the query keeps its scaffold Title (raw object name) instead of a reusable label (no tool step ever prompts/sets Title from the labels index either), and the build fails outright with 4 xppc metadata errors ('field does not have a valid datasource') because the view's bound fields point at a non-existent datasource. validate_code(mode='references') does not catch any of this (0 references checked on either document) -- it has no notion of AxQuery/AxView structural well-formedness, only symbol-name hallucination.",
+  "suggested_fix_area": "Add a d365fo_file(action='modify', objectType='query', operation='add-data-source') bridge implementation that creates an AxQuerySimpleRootDataSource (Name=table name, Table=table, Fields=[{Name,Field}] from an explicit fields list) -- mirroring the existing add-field-group/add-relation table operations -- and/or extend generate_object(mode='scaffold', objectType='query') to accept a fieldsHint/dataSource pair the way table scaffolding already does. Additionally, either make the AxView create-time 'properties' fields/query shape officially documented (it currently works but is unlisted in the tool schema) or reject it with a clear error rather than silently defaulting DataSource to the query's own name when the referenced datasource doesn't exist yet.",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxQuery/ConDemoNoteHeaderQuery.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxView/ConDemoNoteHeaderView.xml",
+    "eval/goldens/L1-query-view-basic/ConDemoNoteHeaderQuery.metadata.xml",
+    "eval/goldens/L1-query-view-basic/ConDemoNoteHeaderView.metadata.xml"
+  ]
+}

--- a/eval/corpus/runs/2026-07-06T19__L1-table-basic__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T19__L1-table-basic__cb1b73d.json
@@ -1,0 +1,69 @@
+﻿{
+  "run_id": "2026-07-06T19__L1-table-basic__cb1b73d",
+  "case_id": "L1-table-basic",
+  "tier": 1,
+  "timestamp": "2026-07-06T19:03:06.531Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoAgentNote.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxTable/CacheLookup",
+      "AxTable/ClusteredIndex",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoBrowse]/Name",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoIdentification]/AutoPopulate",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoIdentification]/Name",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[NoteId]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[NoteText]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[Subject]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Name",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[NoteDateTime]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[NoteId]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[NoteText]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[Subject]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Name",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoSummary]/Name",
+      "AxTable/PrimaryIndex",
+      "AxTable/ReplacementKey",
+      "AxTable/SourceCode/Declaration",
+      "AxTable/TitleField2"
+    ],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxTable/Label",
+        "expected": "@SYS13887",
+        "actual": "@AC:DemoAgentNote"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 1
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-06T19__L2-business-event-basic__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T19__L2-business-event-basic__cb1b73d.json
@@ -1,0 +1,92 @@
+﻿{
+  "run_id": "2026-07-06T19__L2-business-event-basic__cb1b73d",
+  "case_id": "L2-business-event-basic",
+  "tier": 2,
+  "timestamp": "2026-07-06T19:20:18Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxTable/ConDemoNoteHeader.xml (prerequisite fixture, not scored)",
+    "AxClass/ConDemoNoteHeaderCreatedContract.xml",
+    "AxClass/ConDemoNoteHeaderCreatedBusinessEvent.xml"
+  ],
+  "static_gate": {
+    "references": {
+      "passed": true
+    },
+    "syntax": {
+      "passed": true
+    }
+  },
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {
+        "message": "BestPractices Warning: AxClass ConDemoNoteHeaderCreatedContract/Method/newFromNoteHeader: BPXmlDocNoDocumentationComments: No XML documentation headers are provided for 'ConDemoNoteHeaderCreatedContract.newFromNoteHeader'."
+      },
+      {
+        "message": "BestPractices Warning: AxClass ConDemoNoteHeaderCreatedContract: BPXmlDocNoDocumentationComments: No XML documentation headers are provided for 'ConDemoNoteHeaderCreatedContract'."
+      },
+      {
+        "message": "BestPractices Warning: AxClass ConDemoNoteHeaderCreatedBusinessEvent/Method/newFromContract: BPXmlDocNoDocumentationComments: No XML documentation headers are provided for 'ConDemoNoteHeaderCreatedBusinessEvent.newFromContract'."
+      },
+      {
+        "message": "BestPractices Warning: AxClass ConDemoNoteHeaderCreatedBusinessEvent: BPXmlDocNoDocumentationComments: No XML documentation headers are provided for 'ConDemoNoteHeaderCreatedBusinessEvent'."
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "ConDemoNoteHeaderCreatedContract.metadata.xml::AxClass/SourceCode/Methods/Method[newFromNoteHeader]/Source",
+        "golden": "public static PFXDemoNoteHeaderCreatedContract newFromNoteHeader(PFXDemoNoteHeader _noteHeader)\n{\n    PFXDemoNoteHeaderCreatedContract contract = new PFXDemoNoteHeaderCreatedContract();\n    contract.parmNoteId(_noteHeader.NoteId);\n    contract.parmSubject(_noteHeader.Subject);\n    return contract;\n}",
+        "actual": "public static PFXDemoNoteHeaderCreatedContract newFromNoteHeader(PFXDemoNoteHeader _noteHeader)\n    {\n        PFXDemoNoteHeaderCreatedContract contract = new PFXDemoNoteHeaderCreatedContract();\n        contract.parmNoteId(_noteHeader.NoteId);\n        contract.parmSubject(_noteHeader.Subject);\n        return contract;\n    }"
+      },
+      {
+        "path": "ConDemoNoteHeaderCreatedContract.metadata.xml::AxClass/SourceCode/Methods/Method[parmNoteId]/Source",
+        "golden": "[DataMemberAttribute('NoteId')]\npublic Num parmNoteId(Num _noteId = noteId)\n{\n    noteId = _noteId;\n    return noteId;\n}",
+        "actual": "[DataMemberAttribute('NoteId')]\n    public Num parmNoteId(Num _noteId = noteId)\n    {\n        noteId = _noteId;\n        return noteId;\n    }"
+      },
+      {
+        "path": "ConDemoNoteHeaderCreatedContract.metadata.xml::AxClass/SourceCode/Methods/Method[parmSubject]/Source",
+        "golden": "[DataMemberAttribute('Subject')]\npublic Name parmSubject(Name _subject = subject)\n{\n    subject = _subject;\n    return subject;\n}",
+        "actual": "[DataMemberAttribute('Subject')]\n    public Name parmSubject(Name _subject = subject)\n    {\n        subject = _subject;\n        return subject;\n    }"
+      },
+      {
+        "path": "ConDemoNoteHeaderCreatedBusinessEvent.metadata.xml::AxClass/SourceCode/Methods/Method[newFromContract]/Source",
+        "golden": "public static PFXDemoNoteHeaderCreatedBusinessEvent newFromContract(PFXDemoNoteHeaderCreatedContract _contract)\n{\n    PFXDemoNoteHeaderCreatedBusinessEvent event = new PFXDemoNoteHeaderCreatedBusinessEvent();\n    event.contract = _contract;\n    return event;\n}",
+        "actual": "public static PFXDemoNoteHeaderCreatedBusinessEvent newFromContract(PFXDemoNoteHeaderCreatedContract _contract)\n    {\n        PFXDemoNoteHeaderCreatedBusinessEvent event = new PFXDemoNoteHeaderCreatedBusinessEvent();\n        event.contract = _contract;\n        return event;\n    }"
+      },
+      {
+        "path": "ConDemoNoteHeaderCreatedBusinessEvent.metadata.xml::AxClass/SourceCode/Methods/Method[buildContract]/Source",
+        "golden": "[Hookable(false)]\npublic BusinessEventsContract buildContract()\n{\n    return contract;\n}",
+        "actual": "[Hookable(false)]\n    public BusinessEventsContract buildContract()\n    {\n        return contract;\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "d365fo_file(action='create', objectType='class') auto-splits a class's sourceCode into <Declaration> (class line + member vars) and per-method <Methods>/<Method>/<Source> entries as documented, but it unconditionally re-indents every top-level method body by one extra level (4 spaces) versus what was supplied, regardless of whether the input methods were authored at column 0 (the tool's own documented convention: 'methods after the closing }') or nested inside the class braces. Reproduced twice: first with methods nested inside the class body (produced 8-space-indented bodies, worse), then again after rewriting with methods placed at column 0 after the closing brace exactly as instructed by the tool description (still produced a spurious uniform 4-space indent on every method's signature/braces/body). The golden fixtures for this case (and, per the eval oracle's exact-line-match normalize.ts, which only trims/CRLF-normalizes and does not dedent) store method Source blocks with the method signature and closing brace at column 0. Net effect: two semantically-identical, build-clean, reference-clean classes score golden_match=0 purely on whitespace the author has no way to suppress through the create tool's public sourceCode contract.",
+  "suggested_fix_area": "d365fo_file(action='create', objectType='class') method-source formatting: the auto-split/write path should preserve (or normalize to zero) the base indentation level of each extracted top-level method rather than adding a fixed 4-space indent, so create-time output matches the column-0-method convention documented in the tool's own guidance and used by the golden corpus. Alternatively/additionally, eval/src/eval/oracle/normalize.ts could dedent each Method/Source block to a common minimum-indentation baseline before line-diffing, so build-clean/reference-clean code isn't penalized for a formatting-only discrepancy that has no semantic bearing.",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoNoteHeader.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxClass/ConDemoNoteHeaderCreatedContract.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxClass/ConDemoNoteHeaderCreatedBusinessEvent.xml",
+    "eval/goldens/L2-business-event-basic/ConDemoNoteHeaderCreatedContract.metadata.xml",
+    "eval/goldens/L2-business-event-basic/ConDemoNoteHeaderCreatedBusinessEvent.metadata.xml"
+  ]
+}

--- a/eval/corpus/runs/2026-07-06T19__L2-class-method-ops__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-06T19__L2-class-method-ops__cb1b73d.json
@@ -1,0 +1,52 @@
+﻿{
+  "run_id": "2026-07-06T19__L2-class-method-ops__cb1b73d",
+  "case_id": "L2-class-method-ops",
+  "tier": 2,
+  "timestamp": "2026-07-06T19:34:50Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxClass/ConDemoCalcOps.xml",
+    "AxTable/ConDemoCalcData.xml"
+  ],
+  "static_gate": {
+    "references": {
+      "passed": true
+    },
+    "syntax": {
+      "passed": true
+    }
+  },
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      { "message": "AxTable ConDemoCalcData: BPErrorTableMissingGroupAutoReport: The table has no fields in the AutoReport field group." },
+      { "message": "AxTable ConDemoCalcData: BPErrorTableTitleField1NotDeclared: No field has been specified for the Title Field1 property." },
+      { "message": "AxTable ConDemoCalcData: BPErrorDeveloperDocumentationNotDefined: The mandatory property DeveloperDocumentation is not specified." },
+      { "message": "AxTable ConDemoCalcData/TableFieldString/ItemName: BPErrorTableFieldNotInFieldGroup: The table's field is not a member of a field group." },
+      { "message": "AxTable ConDemoCalcData/TableFieldReal/Qty: BPErrorTableFieldNotInFieldGroup: The table's field is not a member of a field group." },
+      { "message": "AxClass ConDemoCalcOps/Method/multiply: BPXmlDocNoDocumentationComments: No XML documentation headers are provided for 'ConDemoCalcOps.multiply'." },
+      { "message": "AxClass ConDemoCalcOps: BPXmlDocNoDocumentationComments: No XML documentation headers are provided for 'ConDemoCalcOps'." }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS",
+  "root_cause_hypothesis": "Not a failure of this run. eval/cases/L2-class-method-ops.json carries \"golden_pending\": true and eval/goldens/L2-class-method-ops/ does not exist yet, so `npm run eval:score` throws ENOENT (findGolden scans the missing dir) -- confirmed by direct invocation, not worked around. score.golden_match is reported as 0/unscorable by convention (no golden_diff object is included -- there is nothing to diff), not because the produced metadata was verified wrong; manual inspection of both artifacts confirms full conformance to the instruction: class ConDemoCalcOps ends with exactly two methods (multiply returning `_a * _b`, not the stub `return 0` it started as; static construct() returning `new ConDemoCalcOps()`), and tempScratch is absent after add-method+remove-method. Table ConDemoCalcData has ItemName (Name EDT)/Qty (Qty EDT), a static find(Name _itemName, boolean _forUpdate=false) selecting firstonly by ItemName, and displayDoubleQty returning `2 * this.Qty`. Both compiled clean (xppc, 0 errors) and passed validate_code references+syntax gates before every write. Separately (secondary observation, not this run's terminal defect): d365fo_file(modify, add-table-method, tableMethodType='find') first resolved the ItemName field's parameter type as the literal field name \"ItemName\" instead of its EDT \"Name\", because the table had just been created via d365fo_file(create) in the same session and its fields were not yet in the symbol index (the tool did emit its own warning about this). Calling update_symbol_index(filePath=<table.xml>) then removing+re-adding the table method resolved it correctly (`Name _itemName`) on the second attempt -- a known/documented staleness class (the tool's own docs warn 'EDTs/enums created this session are not yet indexed'), self-corrected within the grounded path, so it did not survive into the scored artifact and is not scored as a defect here. The already-known indentation-reflow defect (d365fo_file create/modify re-indenting method bodies vs. golden's column-0 convention) was NOT reproduced as a blocking issue this run since there is no golden to diff against yet; it would need to be checked once a reviewed golden is captured.",
+  "suggested_fix_area": "(1) Author + human-review the golden for L2-class-method-ops (eval/goldens/L2-class-method-ops/{ConDemoCalcOps,ConDemoCalcData}.metadata.xml or equivalent Con-prefixed capture) so future runs can score golden_match; flip golden_pending to false once committed. (2) Consider whether add-table-method / table-method scaffolding should proactively index a table it was just asked to modify (or at least surface the same 'not yet indexed, call update_symbol_index first' guidance it already gives for EDTs) so operators don't need to discover the field-type mis-resolution via the warning text and manually recover.",
+  "evidence_refs": [
+    "eval/cases/L2-class-method-ops.json",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxClass/ConDemoCalcOps.xml (rolled back after run)",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoCalcData.xml (rolled back after run)"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T04__L2-coc-extension__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T04__L2-coc-extension__cb1b73d.json
@@ -1,0 +1,62 @@
+﻿{
+  "run_id": "2026-07-07T04__L2-coc-extension__cb1b73d",
+  "case_id": "L2-coc-extension",
+  "tier": 2,
+  "timestamp": "2026-07-07T04:42:36.601Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "L2-coc-extension.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/Name",
+        "expected": "FMVehicleDataContractCon_Extension",
+        "actual": "FMVehicleDataContractCon_Extension"
+      },
+      {
+        "path": "AxClass/SourceCode/Declaration",
+        "expected": "[ExtensionOf(classStr(FMVehicleDataContract))]\nfinal class FMVehicleDataContractCon_Extension\n{\n}",
+        "actual": "[ExtensionOf(classStr(FMVehicleDataContract))]\nfinal class FMVehicleDataContractCon_Extension\n{\n}"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[CarFactsSummary]/Source",
+        "expected": "/// <summary>\n/// Appends a verification marker to the car-facts summary text.\n/// </summary>\npublic str CarFactsSummary(str carFactsSummary)\n{\n    return next CarFactsSummary(carFactsSummary) + ' [verified]';\n}",
+        "actual": "/// <summary>\n    /// Appends a verification marker to the car-facts summary text.\n    /// </summary>\n    public str CarFactsSummary(str carFactsSummary)\n    {\n        return next CarFactsSummary(carFactsSummary) + ' [verified]';\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "VALIDATOR_GAP",
+  "root_cause_hypothesis": "The build/artifact is correct (build succeeded, class content semantically matches the golden), but the oracle's golden diff shows 3 false 'changed' entries. (1) canonicalizePrefix() in src/eval/oracle/normalize.ts requires the EXTENSION_PREFIX token to be followed by an uppercase letter '(?=[A-Z])' to canonicalize it to the PFX placeholder; the common '{Base}{Prefix}_Extension' CoC-wrapper naming convention has the prefix followed by '_' (not uppercase), so neither the golden's 'Con' nor the actual's 'Con' infix gets canonicalized, and AxClass/Name + the Declaration's class-name line false-mismatch across ANY two prefix sessions for every _Extension-suffixed class. (2) The Method Source diff is a systemic method-body indentation difference: golden Method/Source captures have the method signature/body dedented to column 0 with only the block body at +4 spaces, while the current bridge (d365fo_file) always writes Method/Source with the whole method (including the signature line) indented one extra level (as if still nested under the class braces); normalizeText() only trims the whole string and normalizes CRLF, it does not dedent per line. This exact indentation-diff pattern recurs verbatim in multiple other already-recorded corpus runs (e.g. 2026-07-06T18 ConDemoNoteFormatter and ConDemoNoteHeaderCreatedContract/BusinessEvent runs), confirming it is systemic, not case-specific.",
+  "suggested_fix_area": "src/eval/oracle/normalize.ts: canonicalizePrefix() lookahead should also allow the prefix to be followed by '_' (the _Extension infix convention), e.g. change `(?=[A-Z])` to `(?=[A-Z_])` (or a more targeted check for the '_Extension' suffix); and normalizeAotXml()/normalizeText() should dedent Method/Source blocks (e.g. strip a common leading-whitespace amount from every line) before comparing, so a whole-method-body indentation shift does not register as a semantic diff.",
+  "evidence_refs": [
+    "eval/corpus/runs/2026-07-07T04__L2-coc-extension__cb1b73d.json",
+    "eval/corpus/runs/2026-07-06T19__L2-business-event-basic__cb1b73d.json (same Method/Source indentation diff pattern)",
+    "src/eval/oracle/normalize.ts:68-72 (canonicalizePrefix)",
+    "src/eval/oracle/normalize.ts:106-113 (normalizeText)"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T04__L2-delegate-basic-handler__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T04__L2-delegate-basic-handler__cb1b73d.json
@@ -1,0 +1,40 @@
+{
+  "run_id": "2026-07-07T04__L2-delegate-basic-handler__cb1b73d",
+  "case_id": "L2-delegate-basic",
+  "tier": 2,
+  "timestamp": "2026-07-07T04:56:31.355Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "L2-delegate-basic.handler.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS"
+}

--- a/eval/corpus/runs/2026-07-07T04__L2-delegate-basic-subject__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T04__L2-delegate-basic-subject__cb1b73d.json
@@ -1,0 +1,40 @@
+{
+  "run_id": "2026-07-07T04__L2-delegate-basic-subject__cb1b73d",
+  "case_id": "L2-delegate-basic",
+  "tier": 2,
+  "timestamp": "2026-07-07T04:56:14.798Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "L2-delegate-basic.subject.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS"
+}

--- a/eval/corpus/runs/2026-07-07T05__L2-dimension-basic__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T05__L2-dimension-basic__cb1b73d.json
@@ -1,0 +1,51 @@
+{
+  "run_id": "2026-07-07T05__L2-dimension-basic__cb1b73d",
+  "case_id": "L2-dimension-basic",
+  "tier": 2,
+  "timestamp": "2026-07-07T05:06:55.888Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "L2-dimension-basic.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxTable/SourceCode/Methods/Method[dimensionDisplayValue]/Source",
+        "expected": "public display str dimensionDisplayValue()\n{\n    DimensionAttributeValueSetStorage dimStorage;\n\n    if (!this.DefaultDimension)\n    {\n        return '';\n    }\n\n    dimStorage = DimensionAttributeValueSetStorage::find(this.DefaultDimension);\n\n    return dimStorage.toString();\n}",
+        "actual": "public display str dimensionDisplayValue()\n    {\n        DimensionAttributeValueSetStorage dimStorage;\n\n        if (!this.DefaultDimension)\n        {\n            return '';\n        }\n\n        dimStorage = DimensionAttributeValueSetStorage::find(this.DefaultDimension);\n\n        return dimStorage.toString();\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T05__L2-enum-extension-empty-values__cb1b73d--class.json
+++ b/eval/corpus/runs/2026-07-07T05__L2-enum-extension-empty-values__cb1b73d--class.json
@@ -1,0 +1,37 @@
+﻿{
+  "run_id": "2026-07-07T05__L2-enum-extension-empty-values__cb1b73d",
+  "case_id": "L2-enum-extension-empty-values",
+  "tier": 2,
+  "timestamp": "2026-07-07T05:19:44.941Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoEnumExtProbe.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS"
+}

--- a/eval/corpus/runs/2026-07-07T05__L2-enum-extension-empty-values__cb1b73d--enumext.json
+++ b/eval/corpus/runs/2026-07-07T05__L2-enum-extension-empty-values__cb1b73d--enumext.json
@@ -1,0 +1,34 @@
+﻿{
+  "run_id": "2026-07-07T05__L2-enum-extension-empty-values__cb1b73d",
+  "case_id": "L2-enum-extension-empty-values",
+  "tier": 2,
+  "timestamp": "2026-07-07T05:20:04.523Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "NumberSeqModule.ConExtension.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS"
+}

--- a/eval/corpus/runs/2026-07-07T05__L2-enum-modify-values__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T05__L2-enum-modify-values__cb1b73d.json
@@ -1,0 +1,42 @@
+﻿{
+  "run_id": "2026-07-07T05__L2-enum-modify-values__cb1b73d",
+  "case_id": "L2-enum-modify-values",
+  "tier": 2,
+  "timestamp": "2026-07-07T05:35:20.860Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "actual_ConDemoModStatus.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxEnum/EnumValues/AxEnumValue[Completed]/Label",
+      "AxEnum/EnumValues/AxEnumValue[Completed]/Name",
+      "AxEnum/EnumValues/AxEnumValue[Completed]/Value"
+    ],
+    "extra": [
+      "AxEnum/EnumValues/AxEnumValue[Closed]/Label",
+      "AxEnum/EnumValues/AxEnumValue[Closed]/Name",
+      "AxEnum/EnumValues/AxEnumValue[Closed]/Value"
+    ],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T05__L2-event-handler-basic__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T05__L2-event-handler-basic__cb1b73d.json
@@ -1,0 +1,44 @@
+﻿{
+  "run_id": "2026-07-07T05__L2-event-handler-basic__cb1b73d",
+  "case_id": "L2-event-handler-basic",
+  "tier": 2,
+  "timestamp": "2026-07-07T05:57:26.485Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderEH.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Methods/Method[onInserting]/Source",
+        "expected": "[DataEventHandler(tableStr(PFXDemoNoteHeader), DataEventType::Inserting)]\npublic static void onInserting(Common _sender, DataEventArgs _e)\n{\n    PFXDemoNoteHeader noteHeader = _sender as PFXDemoNoteHeader;\n\n    if (!noteHeader.Subject)\n    {\n        noteHeader.Subject = '(no subject)';\n    }\n}",
+        "actual": "[DataEventHandler(tableStr(PFXDemoNoteHeader), DataEventType::Inserting)]\n    public static void onInserting(Common _sender, DataEventArgs _e)\n    {\n        PFXDemoNoteHeader noteHeader = _sender as PFXDemoNoteHeader;\n\n        if (!noteHeader.Subject)\n        {\n            noteHeader.Subject = '(no subject)';\n        }\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T06__L2-form-extension-basic__cb1b73d__CustGroupFormExt.json
+++ b/eval/corpus/runs/2026-07-07T06__L2-form-extension-basic__cb1b73d__CustGroupFormExt.json
@@ -1,0 +1,50 @@
+﻿{
+  "run_id": "2026-07-07T06__L2-form-extension-basic__cb1b73d",
+  "case_id": "L2-form-extension-basic",
+  "tier": 2,
+  "timestamp": "2026-07-07T06:21:24.971Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "CustGroupFormExt.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_PFXHasNotes]/FormControl[Grid_PFXHasNotes]/@type",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_PFXHasNotes]/FormControl[Grid_PFXHasNotes]/DataField",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_PFXHasNotes]/FormControl[Grid_PFXHasNotes]/DataSource",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_PFXHasNotes]/FormControl[Grid_PFXHasNotes]/FormControlExtension/@nil",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_PFXHasNotes]/FormControl[Grid_PFXHasNotes]/Name",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_PFXHasNotes]/FormControl[Grid_PFXHasNotes]/Type",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_PFXHasNotes]/Parent"
+    ],
+    "extra": [
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_ConHasNotes]/FormControl[Grid_ConHasNotes]/@type",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_ConHasNotes]/FormControl[Grid_ConHasNotes]/DataField",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_ConHasNotes]/FormControl[Grid_ConHasNotes]/DataSource",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_ConHasNotes]/FormControl[Grid_ConHasNotes]/FormControlExtension/@nil",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_ConHasNotes]/FormControl[Grid_ConHasNotes]/Name",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_ConHasNotes]/FormControl[Grid_ConHasNotes]/Type",
+      "AxFormExtension/Controls/AxFormExtensionControl[Grid_ConHasNotes]/Parent"
+    ],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T06__L2-form-extension-basic__cb1b73d__CustGroupTableExt.json
+++ b/eval/corpus/runs/2026-07-07T06__L2-form-extension-basic__cb1b73d__CustGroupTableExt.json
@@ -1,0 +1,44 @@
+﻿{
+  "run_id": "2026-07-07T06__L2-form-extension-basic__cb1b73d",
+  "case_id": "L2-form-extension-basic",
+  "tier": 2,
+  "timestamp": "2026-07-07T06:21:17.780Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "CustGroupTableExt.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxTableExtension/Fields/AxTableField[PFXHasNotes]/@type",
+      "AxTableExtension/Fields/AxTableField[PFXHasNotes]/EnumType",
+      "AxTableExtension/Fields/AxTableField[PFXHasNotes]/Label",
+      "AxTableExtension/Fields/AxTableField[PFXHasNotes]/Name"
+    ],
+    "extra": [
+      "AxTableExtension/Fields/AxTableField[ConHasNotes]/@type",
+      "AxTableExtension/Fields/AxTableField[ConHasNotes]/EnumType",
+      "AxTableExtension/Fields/AxTableField[ConHasNotes]/Label",
+      "AxTableExtension/Fields/AxTableField[ConHasNotes]/Name"
+    ],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T06__L2-form-modify-controls__cb1b73d__form.json
+++ b/eval/corpus/runs/2026-07-07T06__L2-form-modify-controls__cb1b73d__form.json
@@ -1,0 +1,49 @@
+﻿{
+  "run_id": "2026-07-07T06__L2-form-modify-controls__cb1b73d",
+  "case_id": "L2-form-modify-controls",
+  "tier": 2,
+  "timestamp": "2026-07-07T06:50:00.000Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "contoso/contoso/AxForm/ConDemoCtrlNoteForm.xml"
+  ],
+  "static_gate": {
+    "references": { "passed": true },
+    "syntax": { "passed": true }
+  },
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxForm/Design/Controls/AxFormGroupControl[HeaderGroup]",
+      "AxForm/Design/Controls/AxFormGridControl[MainGrid]",
+      "AxForm/Design/Controls/AxFormGridControl[MainGrid]/Controls/AxFormStringControl[NoteId]",
+      "AxForm/Design/Controls/AxFormGridControl[MainGrid]/Controls/AxFormStringControl[Subject]"
+    ],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "Regression CONFIRMED as described in the case. d365fo_file(action='modify', objectType='form', operation='add-control') cannot add a top-level control as a direct child of the form's root <Design> container when the design starts with zero existing controls (the case's own mandated starting state: 'the initial create must contain only the data source and an empty design'). Reproduced with the exact case-required first control (Group 'HeaderGroup'): every parentControl value tried was rejected with the SAME inner bridge error 'Parent control '<value>' not found in form <formName>' -- tried 'Design' (the AxFormDesign's conventional/default Name, consistent with how other default-valued boolean properties like AxTableIndex/AllowDuplicates are omitted from serialized XML elsewhere in this same run), the empty string, and the form's own name, each after a fresh update_symbol_index (both filePath-targeted and bare refresh) to rule out stale-metadata-root false negatives -- get_object_info confirmed the form WAS resolved (0 controls, 1 data source) immediately before each attempt, and the bridge error text itself says 'Error in addControl: Parent control ... not found', i.e. object resolution succeeded and only the parent-control lookup failed. Source-level evidence (src/tools/modifyD365File.ts add-control case, this repo) shows add-control's only special-cased fallback path is for objectType='form-extension' (directXmlAddControl, because AxFormExtensionControl's <Parent> is a plain string the bridge's Forms.Read can never resolve for an extension name) -- there is NO equivalent path for a plain 'form' whose Design has no addressable named control yet, i.e. no way to seed the very first top-level control via this operation. This is a genuine, reproducible gap distinct from the metadata-root-freshness class of issue the tool's own error message suggests. Per the case's explicit instruction, the create-overwrite and hand-authored-XML fallbacks were NOT used, so the form was left with its data source only (0 controls) -- functionally incomplete relative to the 3-control spec, though it still builds clean as-is.",
+  "suggested_fix_area": "C# bridge AddControl implementation (or the modifyD365File.ts add-control case wrapping it): needs a special-cased path, analogous to the existing form-extension directXmlAddControl fallback, for adding a control directly under AxForm/Design (i.e. treat a well-known parentControl sentinel -- or parentControl omitted -- as 'root of Design.Controls' instead of requiring a name match against an existing AxFormControl). Until fixed, this class of case (build up a form's Design purely via add-control, starting from an empty design) cannot pass without a disallowed hand-authored-XML fallback.",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxForm/ConDemoCtrlNoteForm.xml",
+    "C:/repos/d365fo-mcp-server/src/tools/modifyD365File.ts"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T06__L2-form-modify-controls__cb1b73d__table.json
+++ b/eval/corpus/runs/2026-07-07T06__L2-form-modify-controls__cb1b73d__table.json
@@ -1,0 +1,53 @@
+﻿{
+  "run_id": "2026-07-07T06__L2-form-modify-controls__cb1b73d",
+  "case_id": "L2-form-modify-controls",
+  "tier": 2,
+  "timestamp": "2026-07-07T06:40:00.000Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "contoso/contoso/AxTable/ConDemoCtrlNote.xml"
+  ],
+  "static_gate": {
+    "references": {
+      "passed": true
+    },
+    "syntax": {
+      "passed": true
+    }
+  },
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS",
+  "root_cause_hypothesis": "No golden was captured for this case yet (golden_pending: true) so golden_match here is a structural self-check placeholder, not a real oracle comparison -- see the sibling '__form' record for the case's actual (negative) outcome. Table half of the instruction (fields NoteId/Num-mandatory, Subject/Name, unique index NoteIdx via alternate-key semantics) was fully achievable through the grounded d365fo_file create/modify path and builds clean. Bp warnings (6) are expected for a minimal scaffold table with no field groups/title fields, not tool defects.",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoCtrlNote.xml"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T07__L2-form-over-view__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T07__L2-form-over-view__cb1b73d.json
@@ -1,0 +1,146 @@
+﻿{
+  "run_id": "2026-07-07T07__L2-form-over-view__cb1b73d",
+  "case_id": "L2-form-over-view",
+  "tier": 2,
+  "timestamp": "2026-07-07T07:26:53.095Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "contoso/contoso/AxTable/ConDemoViewSrc.xml",
+    "contoso/contoso/AxQuery/ConDemoActiveViewQuery.xml",
+    "contoso/contoso/AxView/ConDemoActiveView.xml",
+    "contoso/contoso/AxForm/ConDemoActiveViewList.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxForm/DataSources/AxFormDataSource[PFXDemoActiveView]/Fields/AxFormDataSourceField[Code]/DataField",
+      "AxForm/DataSources/AxFormDataSource[PFXDemoActiveView]/Fields/AxFormDataSourceField[Descr]/DataField",
+      "AxForm/DataSources/AxFormDataSource[PFXDemoActiveView]/InsertIfEmpty",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/@type",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/AlignChild",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/AlignChildren",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/ArrangeMethod",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/Controls/AxFormControl[ButtonGroup]/@type",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/Controls/AxFormControl[ButtonGroup]/ArrangeMethod",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/Controls/AxFormControl[ButtonGroup]/FormControlExtension/@nil",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/Controls/AxFormControl[ButtonGroup]/Name",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/Controls/AxFormControl[ButtonGroup]/Type",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/ElementPosition",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/FilterExpression",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/FormControlExtension/@nil",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/Name",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/Type",
+      "AxForm/Design/Controls/AxFormControl[ActionPane]/VerticalSpacing",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/@type",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/ArrangeMethod",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/ExtensionProperties/AxFormControlExtensionProperty[defaultColumnName]/Name",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/ExtensionProperties/AxFormControlExtensionProperty[defaultColumnName]/Type",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/ExtensionProperties/AxFormControlExtensionProperty[defaultColumnName]/Value",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/ExtensionProperties/AxFormControlExtensionProperty[placeholderText]/Name",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/ExtensionProperties/AxFormControlExtensionProperty[placeholderText]/Type",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/ExtensionProperties/AxFormControlExtensionProperty[targetControlName]/Name",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/ExtensionProperties/AxFormControlExtensionProperty[targetControlName]/Type",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/ExtensionProperties/AxFormControlExtensionProperty[targetControlName]/Value",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/FormControlExtension[QuickFilterControl]/Name",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl[QuickFilterControl]/Name",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/FormControlExtension/@nil",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/FrameType",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Name",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Pattern",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/PatternVersion",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Style",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Type",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/ViewEditMode",
+      "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/WidthMode",
+      "AxForm/Design/Controls/AxFormControl[Grid]/@type",
+      "AxForm/Design/Controls/AxFormControl[Grid]/AlternateRowShading",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Code]/@type",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Code]/DataField",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Code]/DataSource",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Code]/FormControlExtension/@nil",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Code]/Name",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Code]/Type",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Descr]/@type",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Descr]/DataField",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Descr]/DataSource",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Descr]/FormControlExtension/@nil",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Descr]/Name",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Descr]/Type",
+      "AxForm/Design/Controls/AxFormControl[Grid]/DataGroup",
+      "AxForm/Design/Controls/AxFormControl[Grid]/DataSource",
+      "AxForm/Design/Controls/AxFormControl[Grid]/ElementPosition",
+      "AxForm/Design/Controls/AxFormControl[Grid]/FilterExpression",
+      "AxForm/Design/Controls/AxFormControl[Grid]/FormControlExtension/@nil",
+      "AxForm/Design/Controls/AxFormControl[Grid]/MultiSelect",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Name",
+      "AxForm/Design/Controls/AxFormControl[Grid]/ShowRowLabels",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Style",
+      "AxForm/Design/Controls/AxFormControl[Grid]/Type",
+      "AxForm/Design/Controls/AxFormControl[Grid]/VerticalSpacing",
+      "AxForm/Design/DataSource",
+      "AxForm/Design/HideIfEmpty",
+      "AxForm/Design/Pattern",
+      "AxForm/Design/PatternVersion",
+      "AxForm/Design/Style",
+      "AxForm/Design/TitleDataSource"
+    ],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxForm/Design/Caption",
+        "expected": "Active view list",
+        "actual": "@SCM:Description"
+      },
+      {
+        "path": "AxForm/SourceCode/Methods/Method[classDeclaration]/Source",
+        "expected": "[Form]\npublic class PFXDemoActiveViewList extends FormRun\n{\n}",
+        "actual": "[Form]\n    public class PFXDemoActiveViewList extends FormRun\n    {\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT",
+  "static_gate": {
+    "references": {
+      "passed": true
+    },
+    "syntax": {
+      "passed": true
+    }
+  },
+  "root_cause_hypothesis": "Regression CONFIRMED exactly as described in the case. generate_object(mode='scaffold', objectType='form', dataSource='ConDemoActiveView') fails with the literal message quoted in the case (\"Table 'ConDemoActiveView' not found in the symbol index\") even immediately after update_symbol_index (both filePath-targeted and bare-refresh forms) and even though get_object_info(objectType='view', name='ConDemoActiveView') resolves the view correctly via the bridge with both fields mapped. Root cause found in source (src/tools/generateSmartForm.ts, dataSource resolution block): the lookup runs `SELECT name FROM symbols WHERE type = 'table' AND name = ? COLLATE NOCASE` - a HARDCODED type='table' filter - so a data source backed by an AxView (indexed under type='view') can never match regardless of index freshness; this is a query-filter bug, not a staleness bug, matching the case's own framing. To produce the form without hand-authoring XML, I fell back to d365fo_file(action='create', objectType='form', properties={pattern, dataSource, dataSourceTable, gridFields}) since createD365File.ts's local generateAxFormXml/FormPatternTemplates builder path accepts the same property shape with no symbol-index gate - but in this bridge-connected session that create call was actually serviced by the C# bridge's IMetaFormProvider.Create() (message: 'via IMetadataProvider.Create()'), which silently ignored pattern/dataSource/dataSourceTable/gridFields entirely (only Caption came through as a generic scalar property), producing a near-empty AxForm skeleton with no DataSources, no Design/Pattern, no Controls, and - discovered only via a forced fullBuild - missing even the mandatory classDeclaration SourceCode method (a genuine compile error the first incremental build silently glossed over: 'Errors: 0' was stale/cached). I then rebuilt the form incrementally via legitimate modify operations: add-data-source (objectType=form) DID work over the view-backed name (bridgeAddDataSource is not gated by type='table' the way generateSmartForm's dataSource resolution is) and add-method('classDeclaration') fixed the compile error. However, modify-property(propertyPath='Pattern'|'DataSource', ...) on the plain form failed every time ('modify-property not supported for objectType 'form' via bridge'; its documented XML-fallback only edits an EXISTING single-occurrence element, so it cannot seed a brand-new Pattern/DataSource element under Design), and add-control(parentControl='Design', ...) reproduced the EXACT same known regression documented for L2-form-modify-controls ('Parent control 'Design' not found in form ...') when Design has zero controls - confirming that bug is not view-specific but a general 'cannot seed the first top-level control on a plain AxForm' limitation. End result: the table (ConDemoViewSrc), query (ConDemoActiveViewQuery) and view (ConDemoActiveView) all build clean via the grounded path with no defects; the FORM builds clean (0 xppc errors) but is structurally incomplete versus the intended SimpleList pattern - it has a working AxFormDataSource over the view but no Design/Pattern, no Design/DataSource/TitleDataSource, and none of the ActionPane/CustomFilterGroup/Grid controls (confirmed by diffing against a same-tool-generated reference: calling the SAME generate_object(scaffold) over the underlying TABLE instead of the view produces the full, correct SimpleList XML in one shot, proving the pattern-template builder itself works fine and the defect is purely the view/table symbol-index gate plus the follow-on bridge-Create() gap for forms). Per the case's explicit rule, no hand-authored XML fallback was used to force completeness.",
+  "suggested_fix_area": "(1) PRIMARY: src/tools/generateSmartForm.ts dataSource resolution - change `WHERE type = 'table'` to also accept `type = 'view'` (threading the distinction through so the emitted AxFormDataSource/Table element is still correct, since AOT uses <Table> for both table- and view-backed datasources) so generate_object(scaffold, form) can build a complete SimpleList/etc. pattern over a view in one shot exactly as it does for a table. (2) SECONDARY (compounding, only encountered because of (1)): d365fo_file(action='create', objectType='form') should route non-extension property-rich form creates (pattern/dataSource/dataSourceTable/gridFields present) through the local FormPatternTemplates XML generator rather than the bridge's IMetaFormProvider.Create(), OR the bridge CreateForm() should itself honor pattern/dataSource/gridFields and always emit classDeclaration (a create producing metadata with a hard compile error should not report bare success). (3) modify-property's form XML-fallback (directXmlModifyProperty) only edits an existing single-occurrence element - it cannot seed a brand-new Pattern/DataSource element under an empty Design; if (1)/(2) aren't fixed, a form-building-blocks path needs an 'add-property-if-missing' variant. (4) add-control's 'Parent control not found' when Design has 0 controls (see L2-form-modify-controls) is the same root cause blocking any incremental form-building fallback and should be fixed together with this case.",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoViewSrc.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxQuery/ConDemoActiveViewQuery.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxView/ConDemoActiveView.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxForm/ConDemoActiveViewList.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxForm/ConDemoActiveViewListRef.xml (reference-only: same scaffold call over the TABLE instead of the view, produced the full correct SimpleList pattern - isolates the defect to the view/table symbol-index gate)",
+    "C:/repos/d365fo-mcp-server/src/tools/generateSmartForm.ts",
+    "C:/repos/d365fo-mcp-server/src/tools/createD365File.ts",
+    "C:/repos/d365fo-mcp-server/src/tools/modifyD365File.ts"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T07__L2-interface-abstract-basic__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T07__L2-interface-abstract-basic__cb1b73d.json
@@ -1,0 +1,40 @@
+﻿{
+  "run_id": "2026-07-07T07__L2-interface-abstract-basic__cb1b73d",
+  "case_id": "L2-interface-abstract-basic",
+  "tier": 2,
+  "timestamp": "2026-07-07T07:36:39.639Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "IDemoNoteRenderer.AxClass.metadata.xml",
+    "DemoNotePlainRenderer.AxClass.metadata.xml",
+    "DemoNoteRendererBase.AxClass.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "KNOWLEDGE_GAP"
+}

--- a/eval/corpus/runs/2026-07-07T10__L2-numberseq-basic__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T10__L2-numberseq-basic__cb1b73d.json
@@ -1,0 +1,60 @@
+﻿{
+  "run_id": "2026-07-07T10__L2-numberseq-basic__cb1b73d",
+  "case_id": "L2-numberseq-basic",
+  "tier": 2,
+  "timestamp": "2026-07-07T10:04:17.891Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "NumberSeqModuleExt.AxEnumExtension.metadata.xml",
+    "NumberSeqModuleDemoNote.AxClass.metadata.xml",
+    "DemoNoteId.AxEdt.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "NumberSeqModuleExt.AxEnumExtension.metadata.xml::AxEnumExtension/EnumValues/AxEnumValue[PFXDemoNote]/Label",
+      "NumberSeqModuleExt.AxEnumExtension.metadata.xml::AxEnumExtension/EnumValues/AxEnumValue[PFXDemoNote]/Name"
+    ],
+    "extra": [
+      "NumberSeqModuleExt.AxEnumExtension.metadata.xml::AxEnumExtension/EnumValues/AxEnumValue[ConDemoNote]/Label",
+      "NumberSeqModuleExt.AxEnumExtension.metadata.xml::AxEnumExtension/EnumValues/AxEnumValue[ConDemoNote]/Name"
+    ],
+    "changed": [
+      {
+        "path": "NumberSeqModuleDemoNote.AxClass.metadata.xml::AxClass/SourceCode/Methods/Method[numberSeqModule]/Source",
+        "expected": "public NumberSeqModule numberSeqModule()\n    {\n        return NumberSeqModule::PFXDemoNote;\n    }",
+        "actual": "public NumberSeqModule numberSeqModule()\n    {\n        return NumberSeqModule::ConDemoNote;\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "VALIDATOR_GAP",
+  "root_cause_hypothesis": "The grounded implementation is byte-correct per the case instruction: EDT ConDemoNoteId (String extends Num), AxEnumExtension NumberSeqModule.ConExtension adding enum value literally named 'ConDemoNote' (the instruction mandates this exact literal, not a prefix-derived name), and class ConNumberSeqModuleDemoNote overriding loadModule()/numberSeqModule() exactly matching the golden logic modulo the Con vs Con object-name prefix. The oracle canonicalizePrefix(goldenPrefix='Con') rewrites the golden enum-value token 'ConDemoNote' to placeholder 'PFXDemoNote' because it happens to start with the GOLDEN_CAPTURE_PREFIX string 'Con', even though 'ConDemoNote' is a literal enum-value identifier specified verbatim by the case, not a model-prefixed object name. The actual output (produced under actualPrefix='Con') is never canonicalized the same way, so the diff reports false missing/extra/changed on every place ConDemoNote appears (enum value Name/Label and the numberSeqModule() return statement). This matches a known/expected oracle gap called out in the run brief (over-matching literal Con-shaped identifiers unrelated to the model prefix).",
+  "suggested_fix_area": "src/eval/oracle canonicalizePrefix / prefix-agnostic diff normalizer -- needs to distinguish a case-mandated literal identifier (e.g. an enum value name spelled out verbatim in the case instruction) from a genuine model-prefixed object name before rewriting golden tokens to the PFX placeholder.",
+  "evidence_refs": [
+    "eval/cases/L2-numberseq-basic.json",
+    "eval/goldens/L2-numberseq-basic/NumberSeqModuleExt.AxEnumExtension.metadata.xml",
+    "eval/goldens/L2-numberseq-basic/NumberSeqModuleDemoNote.AxClass.metadata.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxEnumExtension/NumberSeqModule.ConExtension.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxClass/ConNumberSeqModuleDemoNote.xml",
+    "src/eval/oracle/cli.ts (canonicalizePrefix usage)"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T10__L2-oracle-discriminator-random-wrapper-name__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T10__L2-oracle-discriminator-random-wrapper-name__cb1b73d.json
@@ -1,0 +1,34 @@
+{
+  "run_id": "2026-07-07T10__L2-oracle-discriminator-random-wrapper-name__cb1b73d",
+  "case_id": "L2-oracle-discriminator-random-wrapper-name",
+  "tier": 2,
+  "timestamp": "2026-07-07T10:23:28.594Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "CustGroupFormExt.AxFormExtension.actual.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS"
+}

--- a/eval/corpus/runs/2026-07-07T10__L2-table-extension__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T10__L2-table-extension__cb1b73d.json
@@ -1,0 +1,40 @@
+﻿{
+  "run_id": "2026-07-07T10__L2-table-extension__cb1b73d",
+  "case_id": "L2-table-extension",
+  "tier": 2,
+  "timestamp": "2026-07-07T10:40:43.866Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "CustGroup.ConExtension.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxTableExtension/Fields/AxTableField[NotePriority]/ExtendedDataType",
+        "expected": "Counter",
+        "actual": "Priority"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T11__L2-table-modify-lifecycle__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T11__L2-table-modify-lifecycle__cb1b73d.json
@@ -1,0 +1,63 @@
+﻿{
+  "run_id": "2026-07-07T11__L2-table-modify-lifecycle__cb1b73d",
+  "case_id": "L2-table-modify-lifecycle",
+  "tier": 2,
+  "timestamp": "2026-07-07T11:08:17.000Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxTable/ConDemoModLifecycle.xml"
+  ],
+  "static_gate": {
+    "references": {
+      "passed": true
+    },
+    "syntax": {
+      "passed": true
+    }
+  },
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {
+        "message": "AxTable ConDemoModLifecycle: BPTableWithRecIdIndexMissingReplacementKey."
+      },
+      {
+        "message": "AxTable ConDemoModLifecycle CustAccount: BPErrorEDTNotMigrated."
+      },
+      {
+        "message": "AxTable ConDemoModLifecycle CustTable: BPErrorTableRelationshipPropertiesCompleteness."
+      },
+      {
+        "message": "AxTable ConDemoModLifecycle: BPErrorTableMissingGroupAutoReport."
+      },
+      {
+        "message": "AxTable ConDemoModLifecycle CustAccount: BPErrorTableFieldNotInFieldGroup."
+      },
+      {
+        "message": "AxTable ConDemoModLifecycle: BPUpgradeMetadataEDTRelation."
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT",
+  "evidence_refs": [
+    "eval/cases/L2-table-modify-lifecycle.json",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoModLifecycle.xml (rolled back after run)",
+    "npm run eval:score -- L2-table-modify-lifecycle <actual> --bp-warnings 6 => ENOENT scandir eval/goldens/L2-table-modify-lifecycle (golden_pending, confirmed by direct invocation)",
+    "run_bp_check(modelName=contoso, targetFilter=ConDemoModLifecycle) output (6 residual warnings after fixing Label/DeveloperDocumentation/field-group-label text-label issues)"
+  ],
+  "root_cause_hypothesis": "eval/cases/L2-table-modify-lifecycle.json carries golden_pending: true and eval/goldens/L2-table-modify-lifecycle/ does not exist, so npm run eval:score throws ENOENT (findGolden scans the missing dir) -- confirmed by direct invocation (see evidence_refs), not worked around. score.golden_match is reported as 0 (unscorable) by convention -- no reviewed golden exists to diff against -- not because the produced metadata was verified wrong.\n\nManual field-by-field verification against the instruction confirms full conformance: the final ConDemoModLifecycle table has exactly three fields (NoteCode: Num EDT, Mandatory=Yes; Description: Name EDT, Mandatory=Yes; CustAccount: CustAccount EDT), exactly one index (CodeIdx, AlternateKey=Yes, on NoteCode, no AllowDuplicates element which the add-index tool itself documents as defaulting to unique/false), exactly one relation (CustTable, CustAccount=AccountNum, standard CustTable_* convention shape), exactly one field group (Overview, containing NoteCode and Description only), TitleField1=Description, and TempQty/TmpIdx are absent from the final table -- all achieved exclusively through d365fo_file(action=modify) operations (add-field x2, modify-field, rename-field, add-index x2, remove-index, add-relation, add-field-group, add-field-to-field-group x2, remove-field, modify-property x2), zero hand-authored or overwrite XML. Build is clean (xppc: 0 errors).\n\nClassification is TOOL_DEFECT rather than a clean PASS because two separate, reproducible tool defects were found and did not self-correct within the grounded path; both are silent-success no-ops unrelated to the case core scored requirements (the instruction never mentions ReplacementKey or relation Cardinality/RelationshipType), but they are genuine gaps in the exact modify surface this case exercises.\n\nDEFECT 1 (add-relation): d365fo_file(modify, add-relation, params={relationName, relatedTable, relationConstraints, relationCardinality: ZeroMore, relatedTableCardinality: ZeroOne, relationshipType: Association}) -- all three optional param names match exactly the spec the tool itself returns when probed with an empty params object -- reports a successful relation-add, but the written AxTableRelation XML never contains Cardinality, RelatedTableCardinality, or RelationshipType elements; reproduced twice (once inline with the first add-relation call, once again after an isolated remove-relation plus add-relation retry done to rule out a same-file race from an earlier parallel-write mistake on my part). This directly causes BPErrorTableRelationshipPropertiesCompleteness and very likely BPErrorEDTNotMigrated/BPUpgradeMetadataEDTRelation too (the BP checker may not recognize an incompletely-specified AxTableRelation as a valid migration target for the CustAccount EDT implicit relation).\n\nDEFECT 2 (modify-property): d365fo_file(modify, modify-property, params={propertyPath: ReplacementKey, propertyValue: CodeIdx}) reports a successful property update, but the table XML never gained a ReplacementKey element (confirmed on a plain, isolated, non-parallel retry) -- yet modify-property does work correctly for other table-root scalar properties in the exact same session (TitleField1, Label, DeveloperDocumentation all applied and persisted correctly), so ReplacementKey specifically looks to be missing from an internal property-name allowlist/mapping, and modify-property silently no-ops for unrecognized property names instead of erroring the way add-index/add-relation do for missing REQUIRED params.\n\nSECONDARY OBSERVATION (self-corrected, not scored as a defect): labels(action=create, labelFileId=contoso, ...) happily created a new AxLabelFile using the literal model name contoso (which contains a hyphen) as the LabelFileId; the resulting label reference was rejected by the BP checker as BPErrorLabelIsText (not a label ID) even though it is syntactically the tool own suggested @LabelFile:LabelId form -- almost certainly because a hyphenated LabelFileId is not a legal X++/label identifier and the BP checker label-reference matcher simply does not accept it. Recreating the same label under the pre-existing AC labelFileId (also model contoso, no hyphen) resolved cleanly and the BP warning disappeared.\n\nTwo more minor param-naming near-misses (not defects, just noted for the improver): alternateKey/unique are not the accepted add-index param names (the tool silently accepted and ignored them without a validation error, only the empty-params probe surfaced the real names indexAlternateKey/indexAllowDuplicates); similarly modify-field propertyName/propertyValue guess was silently ignored (the correct name is fieldMandatory). Silently accepting and dropping unrecognized keys, rather than warning or erroring on them, is what let both DEFECT 1 and DEFECT 2 pass undetected on the first attempt and is arguably the umbrella root cause tying all of these together.",
+  "suggested_fix_area": "(1) d365fo_file(modify, add-relation): fix relationCardinality/relatedTableCardinality/relationshipType so they actually populate Cardinality/RelatedTableCardinality/RelationshipType on the written AxTableRelation (bridge IMetaTableProvider.Update relation-constraint mapping).\n(2) d365fo_file(modify, modify-property): add ReplacementKey (and audit other AxTable root scalar properties for the same gap) to whatever property-name allowlist modify-property uses, or -- safer -- make modify-property error on any propertyPath it does not recognize instead of returning a misleading success.\n(3) More generally: have d365fo_file(action=modify) validate and reject unknown keys in params for every operation, not just missing REQUIRED ones, so a wrong param name surfaces immediately instead of silently no-oping (this is the pattern that caused both defects above plus the add-index/modify-field near-misses).\n(4) labels(action=create): sanitize or reject a LabelFileId derived from a hyphenated model name (or document that labelFileId must be a legal identifier distinct from the model name) so a freshly-created label file does not produce an unresolvable label reference.\n(5) Author and human-review the golden for L2-table-modify-lifecycle (eval/goldens/L2-table-modify-lifecycle/ConDemoModLifecycle.metadata.xml or an Con-prefixed capture) so future runs can score golden_match; flip golden_pending to false once committed."
+}

--- a/eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__contract.json
+++ b/eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__contract.json
@@ -1,0 +1,61 @@
+﻿{
+  "run_id": "2026-07-07T11__L3-batch-basic__cb1b73d",
+  "case_id": "L3-batch-basic",
+  "tier": 3,
+  "timestamp": "2026-07-07T11:28:24.691Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoBatchContract.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Declaration",
+        "expected": "[DataContractAttribute]\nclass PFXDemoBatchContract\n{\n    int batchSize;\n    int priorityFactor;\n}",
+        "actual": "[DataContractAttribute]\nclass PFXDemoBatchContract\n{\n    int batchSize;\n    int priorityFactor;\n\n}"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[parmBatchSize]/Source",
+        "expected": "[DataMemberAttribute,\n SysOperationLabelAttribute(literalStr(\"@PFXRent:DemoBatchSize\")),\n SysOperationDisplayOrderAttribute('1')]\npublic int parmBatchSize(int _batchSize = batchSize)\n{\n    batchSize = _batchSize;\n    return batchSize;\n}",
+        "actual": "public int parmBatchSize(int _batchSize = batchSize)\n    {\n        batchSize = _batchSize;\n        return batchSize;\n    }"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[parmPriorityFactor]/Source",
+        "expected": "[DataMemberAttribute,\n SysOperationLabelAttribute(literalStr(\"@PFXRent:DemoPriorityFactor\")),\n SysOperationDisplayOrderAttribute('2')]\npublic int parmPriorityFactor(int _priorityFactor = priorityFactor)\n{\n    priorityFactor = _priorityFactor;\n    return priorityFactor;\n}",
+        "actual": "public int parmPriorityFactor(int _priorityFactor = priorityFactor)\n    {\n        priorityFactor = _priorityFactor;\n        return priorityFactor;\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__controller.json
+++ b/eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__controller.json
@@ -1,0 +1,56 @@
+﻿{
+  "run_id": "2026-07-07T11__L3-batch-basic__cb1b73d",
+  "case_id": "L3-batch-basic",
+  "tier": 3,
+  "timestamp": "2026-07-07T11:28:28.751Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoBatchController.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Methods/Method[construct]/Source",
+        "expected": "/// <summary>\n/// Constructs the controller for the batch operation.\n/// </summary>\npublic static PFXDemoBatchController construct()\n{\n    PFXDemoBatchController controller = new PFXDemoBatchController();\n    controller.parmClassName(classStr(PFXDemoBatchService));\n    controller.parmMethodName(methodStr(PFXDemoBatchService, process));\n    return controller;\n}",
+        "actual": "/// <summary>\n    /// Constructs the controller for the batch operation.\n    /// </summary>\n    public static PFXDemoBatchController construct()\n    {\n        PFXDemoBatchController controller = new PFXDemoBatchController();\n        controller.parmClassName(classStr(PFXDemoBatchService));\n        controller.parmMethodName(methodStr(PFXDemoBatchService, process));\n        return controller;\n    }"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[main]/Source",
+        "expected": "/// <summary>\n/// Entry point invoked from the menu item.\n/// </summary>\npublic static void main(Args _args)\n{\n    PFXDemoBatchController controller = PFXDemoBatchController::construct();\n    controller.parmDialogCaption(literalStr(\"@PFXRent:DemoProcessBatch\"));\n    controller.startOperation();\n}",
+        "actual": "/// <summary>\n    /// Entry point invoked from the menu item.\n    /// </summary>\n    public static void main(Args _args)\n    {\n        PFXDemoBatchController controller = PFXDemoBatchController::construct();\n        controller.parmDialogCaption(literalStr(\"@AC:DemoProcessBatch\"));\n        controller.startOperation();\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__menuitem.json
+++ b/eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__menuitem.json
@@ -1,0 +1,51 @@
+﻿{
+  "run_id": "2026-07-07T11__L3-batch-basic__cb1b73d",
+  "case_id": "L3-batch-basic",
+  "tier": 3,
+  "timestamp": "2026-07-07T11:28:42.368Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoProcessBatch.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxMenuItemAction/Label",
+        "expected": "@PFXRent:DemoProcessBatch",
+        "actual": "@AC:DemoProcessBatch"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "VALIDATOR_GAP"
+}

--- a/eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__service.json
+++ b/eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__service.json
@@ -1,0 +1,56 @@
+﻿{
+  "run_id": "2026-07-07T11__L3-batch-basic__cb1b73d",
+  "case_id": "L3-batch-basic",
+  "tier": 3,
+  "timestamp": "2026-07-07T11:28:26.621Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoBatchService.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Methods/Method[calculateEffectiveBatchSize]/Source",
+        "expected": "/// <summary>\n/// Pure, deterministic helper: the requested batch size scaled by the priority factor.\n/// </summary>\npublic int calculateEffectiveBatchSize(PFXDemoBatchContract _contract)\n{\n    return _contract.parmBatchSize() * _contract.parmPriorityFactor();\n}",
+        "actual": "/// <summary>\n    /// Pure, deterministic helper: the requested batch size scaled by the priority factor.\n    /// </summary>\n    public int calculateEffectiveBatchSize(PFXDemoBatchContract _contract)\n    {\n        return _contract.parmBatchSize() * _contract.parmPriorityFactor();\n    }"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[process]/Source",
+        "expected": "/// <summary>\n/// Batch entry point invoked by the SysOperation controller.\n/// </summary>\npublic void process(PFXDemoBatchContract _contract)\n{\n    info(strFmt(\"Effective batch size: %1\", this.calculateEffectiveBatchSize(_contract)));\n}",
+        "actual": "/// <summary>\n    /// Batch entry point invoked by the SysOperation controller.\n    /// </summary>\n    public void process(PFXDemoBatchContract _contract)\n    {\n        info(strFmt(\"Effective batch size: %1\", this.calculateEffectiveBatchSize(_contract)));\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T11__L3-form-add-datasource-lines__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T11__L3-form-add-datasource-lines__cb1b73d.json
@@ -1,0 +1,59 @@
+﻿{
+  "run_id": "2026-07-07T11__L3-form-add-datasource-lines__cb1b73d",
+  "case_id": "L3-form-add-datasource-lines",
+  "tier": 3,
+  "timestamp": "2026-07-07T11:59:05.882Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxTable/ConDemoDocHeader",
+    "AxTable/ConDemoDocLine",
+    "AxForm/ConDemoDocForm"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [
+      {
+        "phase": "Metadata Validation",
+        "message": "Metadata Error: AxForm/ConDemoDocForm/Design/Controls/Tab/Controls/FormTabPageDetail/Controls/DetailTab/Controls/TabPageOverview/Controls/OverviewGroup/DataGroup: Field group 'Overview' does not exist."
+      }
+    ],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "The DetailsMaster/DetailsTransaction form scaffold (generate_object mode=scaffold, objectType=form) emits a TabPage with Pattern=FieldsFieldGroups whose Group control carries <DataGroup>Overview</DataGroup>, but the scaffold never creates a matching AxTableFieldGroup named 'Overview' on the bound table -- so a freshly-scaffolded DetailsMaster/DetailsTransaction form never builds standalone. Adding the missing field group afterwards via the sanctioned d365fo_file(modify, add-field-group) call DOES persist correctly to the table's XML (verified on disk, field group present with DocId/Description) and the C# bridge's get_object_info/search index picks it up after update_symbol_index, but xppc's own 'Metadata: validate forms' pass keeps reporting \"Field group 'Overview' does not exist\" build after build -- identical text, identical location -- even after: (1) removing and re-adding the field group to force a content/timestamp change, (2) update_symbol_index (both targeted and the no-path bridge refresh), (3) build_d365fo_project with fullBuild=true, and (4) fullBuild+force=true (kills/restarts the compiler process). This is the same SHAPE of defect recorded in docs/USAGE_EXAMPLES.md section 1 (a cross-object metadata reference added via a modify op within the same session is invisible to the xppc build's own validation pass, and survives fullBuild+force) -- there it was a form-datasource-to-table reference reporting an empty table name; here it is a form-control-to-table-fieldgroup reference reporting the field group as missing. Separately, and lower severity: (a) d365fo_file(modify, add-relation) silently dropped both relationshipType='Composition' and the cardinality/relatedTableCardinality params (confirmed by re-reading the written XML -- only Name/RelatedTable/Constraints persisted); (b) d365fo_file(modify, add-data-source) silently dropped linkType='ActiveLink' (no <LinkType> element in the written XML despite the param being accepted without error); (c) the offline object_patterns(form, validate) tool passed a placement (Grid control nested in a TabPage with PanelStyle=Grid, no declared sub-pattern) that the real xppc FormPatternValidation pass then rejected as an ERROR ('not allowed at its current location by pattern Details Master') -- a validator/build disagreement (VALIDATOR_GAP) distinct from the field-group defect that blocked the final build.",
+  "suggested_fix_area": "generate_object(mode='scaffold', objectType='form', formPattern=DetailsMaster|DetailsTransaction): either stop emitting DataGroup='Overview' on the auto-generated FieldsFieldGroups TabPage unless the bound table already has that field group, or auto-create the referenced field group on the table as part of the scaffold. Separately: investigate why xppc's 'Metadata: validate forms' pass does not observe a table field group added earlier in the same session via d365fo_file(modify, add-field-group) even after fullBuild+force -- likely a stale metadata-model snapshot cached by the C# bridge/IMetadataProvider layer that xppc reads through, not invalidated by the build's own cache-refresh flags. Also: d365fo_file(modify, add-relation) should persist relationshipType/cardinality/relatedTableCardinality params instead of silently dropping them, and add-data-source should persist linkType. Finally, align object_patterns(form, validate)'s placement rules for Grid controls inside Details* patterns with the real xppc FormPatternValidation rules so the offline gate catches what the compiler will reject.",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxForm/ConDemoDocForm.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoDocHeader.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoDocLine.xml",
+    "docs/USAGE_EXAMPLES.md#1"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T12__L3-form-detailstransaction__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T12__L3-form-detailstransaction__cb1b73d.json
@@ -1,0 +1,55 @@
+﻿{
+  "run_id": "2026-07-07T12__L3-form-detailstransaction__cb1b73d",
+  "case_id": "L3-form-detailstransaction",
+  "tier": 3,
+  "timestamp": "2026-07-07T12:14:39.584Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "DemoNoteHeaderLine.AxTable.metadata.xml",
+    "DemoNoteTransaction.AxForm.metadata.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/CacheLookup",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/ClusteredIndex",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoBrowse]/Name",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoIdentification]/AutoPopulate",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoIdentification]/Name",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[LineNum]/DataField",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[LineText]/DataField",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[NoteId]/DataField",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Name",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[LineNum]/DataField",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[LineText]/DataField",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[NoteId]/DataField",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Name",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/FieldGroups/AxTableFieldGroup[AutoSummary]/Name",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/PrimaryIndex",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/ReplacementKey",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/SourceCode/Declaration",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/TitleField1",
+      "DemoNoteHeaderLine.AxTable.metadata.xml::AxTable/TitleField2"
+    ],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T12__L3-numberseq-module-slice__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T12__L3-numberseq-module-slice__cb1b73d.json
@@ -1,0 +1,69 @@
+﻿{
+  "run_id": "2026-07-07T12__L3-numberseq-module-slice__cb1b73d",
+  "case_id": "L3-numberseq-module-slice",
+  "tier": 3,
+  "timestamp": "2026-07-07T12:40:00.000Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxEdt/ConDemoSliceId.xml",
+    "AxEnumExtension/NumberSeqModule.ConExtension.xml",
+    "AxClass/ConNumberSeqModuleDemoSlice.xml",
+    "AxTable/ConDemoSliceParameters.xml",
+    "AxForm/ConDemoSliceParametersForm.xml"
+  ],
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": [
+        "NoYes::No and NoYes::Yes flagged by validate_code(mode=references) as unknown-static-member. NoYes is a real, ubiquitous standard AX enum but is absent from the symbol index under its exact base name; identical tokens in the L2-numberseq-basic sibling case built clean with zero errors, so this is treated as a known validator false positive, not a real reference error."
+      ]
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "build": {
+    "succeeded": false,
+    "errors": [
+      { "message": "Form dynamics://Form/ConDemoSliceParametersForm: Form ConDemoSliceParametersForm datasource ConDemoSliceParameters refers to table which does not exist (empty table reference)." },
+      { "message": "AxForm/ConDemoSliceParametersForm TabPageGeneral_Key DataField: Field Key does not exist on data source ConDemoSliceParameters." },
+      { "message": "AxForm/ConDemoSliceParametersForm TabPageSetup_Key DataField: Field Key does not exist on data source ConDemoSliceParameters." }
+    ],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "npm run eval:score for this case throws ENOENT scandir eval/goldens/L3-numberseq-module-slice because golden_pending is true and no golden has been captured yet (confirmed by direct invocation). That is a separate, expected condition, not the outcome of this run. The actual, terminal outcome is a genuine BUILD FAILURE caused by a tool defect, described below. Objects 1 through 4 were fully grounded and are believed correct: EDT ConDemoSliceId (String extends Num, label at SYS1161 reused from the standard NumberSequenceReference.NumberSequenceId label); AxEnumExtension NumberSeqModule.ConExtension adding the literal value DemoSlice as mandated by the case; AxClass ConNumberSeqModuleDemoSlice extending NumberSeqApplicationModule with loadModule() registering a NumberSeqDatatype via NumberSeqDatatype colon colon construct plus parm star methods plus this.create(datatype), matching the proven L2-numberseq-basic golden shape exactly (only the datatype id and reference help text differ); numberSeqModule() returning NumberSeqModule colon colon DemoSlice; and a static buildModulesMapSubsciber(Map) method carrying the SubscribesTo attribute on NumberSeqGlobal.buildModulesMapDelegate that calls NumberSeqGlobal colon colon addModuleToMap(classnum(ConNumberSeqModuleDemoSlice), numberSeqModuleNamesMap). This registration-hook shape was grounded, not guessed: find_references on NumberSeqGlobal.addModuleToMap surfaced roughly 30 real standard callers (for example NumberSeqModuleBank.buildModulesMapSubsciber), all following this identical static-method-on-the-module-class-itself pattern, which is why the hook was added as a method on the module class rather than inventing a separate handler class. AxTable ConDemoSliceParameters is a singleton Parameter table with a Key field (EDT ParametersKey, reused from CustParameters), a unique index named Key, PrimaryIndex and ClusteredIndex both set to Key, a find(boolean _forUpdate) method following the CustParameters singleton convention (select firstonly with index Key where Key equals 0, create on miss), and numRefDemoSliceId() returning NumberSeqReference colon colon findReference(extendedTypeNum(ConDemoSliceId)) matching the exact CustParameters.numRefCustAccount() shape. All four objects read back correctly from disk after every write and were never implicated in the build failure. The build failure is entirely attributable to object 5, the form. generate_object(mode=scaffold, objectType=form, formPattern=TableOfContents, dataSource=ConDemoSliceParameters, includeMethodStubs=true) is the tool-recommended, blessed grounded path for this case: object_patterns(domain=form, action=analyze, recommend=...) suggested TableOfContents citing CustParameters, VendParameters and BankParameters as reference forms; a direct cloneFrom=CustParameters attempt was correctly self-blocked by the tool own pre-clone field-overlap check (1 of 210 fields shared), which itself redirected to the formPattern plus dataSource scaffold path used here. The tool wrote the two requested method stubs (ConDemoSliceParameters.initValue and ConDemoSliceParameters.validateWrite) directly inside the TOP-LEVEL AxFormDataSource Methods element, positioned immediately after Name and BEFORE Table. Byte-for-byte comparison against real standard forms (CustParameters and BankParameters, both cited by the tool itself as this pattern reference forms) confirms the top-level AxFormDataSource element never carries a Methods child in any shipped form; datasource method overrides live exclusively in the SourceCode mirror section (SourceCode, DataSources, DataSource, Methods, Method), which the scaffold instead left as an empty placeholder in our generated file. Inserting a Methods element into the top-level AxFormDataSource ahead of Table desyncs positional schema binding, so the Table element (whose text content was verified byte-correct as ConDemoSliceParameters) is deserialized by xppc as an empty table reference, producing the refers-to-table error plus two cascading Field Key does not exist errors for the two field-bound controls the same scaffold call correctly generated elsewhere in the file. object_patterns(domain=form, action=validate) does not catch this: it reported zero errors and four warnings on this exact broken file. Per task instructions this was NOT hand-patched to force a green build; the tool output is scored and reported as produced.",
+  "suggested_fix_area": "generate_object(mode=scaffold, objectType=form, includeMethodStubs=true): move injected per-datasource method stubs out of the top-level DataSources AxFormDataSource element and into the SourceCode DataSources DataSource Methods Method mirror section, matching every shipped form (CustParameters, BankParameters), leaving the top-level AxFormDataSource with only its real metadata properties (Name, Table, Fields, ReferencedDataSources, LinkType, Allow-star, InsertIfEmpty, DataSourceLinks, DerivedDataSources) in schema order. Also: the structural form-pattern validator (object_patterns validate) does not catch a Methods element in a location no real AxFormDataSource ever populates, nor an empty or corrupted Table value on a data source; either the validator or a references-mode XML check analogous to validate_code(mode=references, codeType=xml-table) should flag this before a build is attempted. Separately and non-blocking: validate_code(mode=references) reports NoYes::No and NoYes::Yes as unknown-static-member even though NoYes is one of the most common standard AX enums and the identical tokens built clean in the L2-numberseq-basic sibling case; the symbol index appears to be missing the base NoYes enum specifically (a fuzzy search for NoYes returns only NoYes-suffixed variants, never the exact base enum) and should be re-indexed. Once the form-scaffold defect is fixed, author and human-review the golden for L3-numberseq-module-slice (5 artifacts) and flip golden_pending to false; also reconcile the case target_artifact_types (lists AxClass twice) against the grounded single-class registration-hook pattern confirmed here, so future runs know whether a second class is actually expected.",
+  "evidence_refs": [
+    "eval/cases/L3-numberseq-module-slice.json",
+    "eval/cases/L2-numberseq-basic.json",
+    "eval/goldens/L2-numberseq-basic/NumberSeqModuleDemoNote.AxClass.metadata.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxEdt/ConDemoSliceId.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxEnumExtension/NumberSeqModule.ConExtension.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxClass/ConNumberSeqModuleDemoSlice.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoSliceParameters.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxForm/ConDemoSliceParametersForm.xml",
+    "C:/AOSService/PackagesLocalDirectory/ApplicationSuite/Foundation/AxForm/CustParameters.xml",
+    "C:/AOSService/PackagesLocalDirectory/ApplicationSuite/Foundation/AxForm/BankParameters.xml",
+    "find_references(NumberSeqGlobal.addModuleToMap)",
+    "npm run eval:score for L3-numberseq-module-slice throws ENOENT scandir eval/goldens/L3-numberseq-module-slice"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T12__L4-bridge-drops-data-entity-primarytable-fields-on-create__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T12__L4-bridge-drops-data-entity-primarytable-fields-on-create__cb1b73d.json
@@ -1,0 +1,67 @@
+﻿{
+  "run_id": "2026-07-07T12__L4-bridge-drops-data-entity-primarytable-fields-on-create__cb1b73d",
+  "case_id": "L4-bridge-drops-data-entity-primarytable-fields-on-create",
+  "tier": 4,
+  "timestamp": "2026-07-07T12:53:08.753Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConSmallItemEntity.xml"
+  ],
+  "static_gate": {
+    "references": { "passed": true, "unresolved": [] },
+    "syntax": { "passed": true, "violations": [] }
+  },
+  "build": {
+    "succeeded": false,
+    "errors": [
+      {
+        "message": "Metadata Error: AxDataEntityView/ConSmallItemEntity/DataManagementStagingTable: Table 'ConSmallItemEntityStaging' does not exist.",
+        "source": "xppc.exe full build, contoso"
+      }
+    ],
+    "bpWarnings": [
+      { "rule": "DataEntitySecurityPrivilegeCheck", "severity": "Error" },
+      { "rule": "BPErrorEDTNotMigrated" },
+      { "rule": "BPErrorTableRelationshipPropertiesCompleteness" },
+      { "rule": "BPErrorTablePrimaryKeyEditable" },
+      { "rule": "BPErrorLabelIsText" },
+      { "rule": "BPErrorDeveloperDocumentationNotDefined" },
+      { "rule": "BPErrorTableMissingFormRef" },
+      { "rule": "BPUpgradeMetadataDeleteAction" },
+      { "rule": "BPUpgradeMetadataEDTRelation" }
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [
+      "AxDataEntityView/DataManagementStagingTable"
+    ],
+    "changed": [
+      {
+        "path": "AxDataEntityView/DataManagementEnabled",
+        "expected": "No",
+        "actual": "Yes"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "The specific defect this case targets (d365fo_file create/objectType=data-entity silently dropping properties.primaryTable and properties.fields, producing an empty AxDataEntityView) did NOT reproduce in this session: the produced ConSmallItemEntity.xml has a fully populated <Fields> (3 AxDataEntityViewMappedField entries mapped to ConSmallItem) and a populated <ViewMetadata><DataSources> with an AxQuerySimpleRootDataSource rooted on ConSmallItem carrying the same 3 fields -- i.e. the create tool's data-entity path now honours primaryTable/fields as passed (fixed, or was already fixed since the 2026-06-30 mined defect). However, the same create call unconditionally defaults DataManagementEnabled=Yes and DataManagementStagingTable=<EntityName>Staging without creating (or offering to create) that staging table, so the very next full build fails with 'Table <Name>Staging does not exist.' No golden was previously captured for this case (golden_pending=true, no eval/goldens/<id>/ dir on disk); scored here against a manually-authored, NOT reviewed/committed reference (kept in the session scratchpad only, not eval/goldens) that mirrors the actual output but with DataManagementEnabled=No / no staging table, since that is the correct default shape for an entity whose instruction never asked for staging. A DataEntitySecurityPrivilegeCheck BP error and several unrelated BP warnings on the prerequisite table were also observed but are expected/out of scope (no security privilege or label IDs were requested by the instruction).",
+  "suggested_fix_area": "d365fo_file(action=create, objectType=data-entity) property defaulting in the bridge's data-entity XML template: stop auto-setting DataManagementEnabled=Yes / DataManagementStagingTable=<Name>Staging unless the caller explicitly requests data-management staging (or actually scaffold the staging table alongside the entity when defaulting it on). Track as a follow-up defect distinct from the primaryTable/fields-dropping defect this case was originally mined for, which appears already resolved -- recommend flipping golden_pending to false and committing a golden once this staging-table default is fixed (so the golden can reflect a build that actually compiles).",
+  "evidence_refs": [
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxDataEntityView/ConSmallItemEntity.xml",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConSmallItem.xml (prerequisite table created this run, rolled back)"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T14__L4-entity-security-duty__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T14__L4-entity-security-duty__cb1b73d.json
@@ -1,0 +1,43 @@
+﻿{
+  "run_id": "2026-07-07T14__L4-entity-security__cb1b73d",
+  "case_id": "L4-entity-security",
+  "tier": 4,
+  "timestamp": "2026-07-07T14:38:24.006Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderDuty.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxSecurityDuty/Label",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "@AC:PFXNoteHeaderDuty"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T14__L4-entity-security-entity__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T14__L4-entity-security-entity__cb1b73d.json
@@ -1,0 +1,55 @@
+﻿{
+  "run_id": "2026-07-07T14__L4-entity-security__cb1b73d",
+  "case_id": "L4-entity-security",
+  "tier": 4,
+  "timestamp": "2026-07-07T14:37:42.749Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderEntity.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxDataEntityView/EntityCategory",
+        "expected": "Master",
+        "actual": "Transaction"
+      },
+      {
+        "path": "AxDataEntityView/Label",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "PFXDemoNoteHeaderEntity"
+      },
+      {
+        "path": "AxDataEntityView/PublicCollectionName",
+        "expected": "DemoNoteHeaders",
+        "actual": "PFXDemoNoteHeaderEntityCollection"
+      },
+      {
+        "path": "AxDataEntityView/PublicEntityName",
+        "expected": "DemoNoteHeader",
+        "actual": "PFXDemoNoteHeaderEntity"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T14__L4-entity-security-menuitem__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T14__L4-entity-security-menuitem__cb1b73d.json
@@ -1,0 +1,40 @@
+﻿{
+  "run_id": "2026-07-07T14__L4-entity-security__cb1b73d",
+  "case_id": "L4-entity-security",
+  "tier": 4,
+  "timestamp": "2026-07-07T14:37:53.250Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderDisplay.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxMenuItemDisplay/Label",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "@AC:PFXNoteHeaders"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T14__L4-entity-security-privilege__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T14__L4-entity-security-privilege__cb1b73d.json
@@ -1,0 +1,42 @@
+﻿{
+  "run_id": "2026-07-07T14__L4-entity-security__cb1b73d",
+  "case_id": "L4-entity-security",
+  "tier": 4,
+  "timestamp": "2026-07-07T14:38:10.313Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderMaintain.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxSecurityPrivilege/Label",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "@AC:PFXNoteHeaderMaintain"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T14__L4-entity-security-role__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T14__L4-entity-security-role__cb1b73d.json
@@ -1,0 +1,40 @@
+﻿{
+  "run_id": "2026-07-07T14__L4-entity-security__cb1b73d",
+  "case_id": "L4-entity-security",
+  "tier": 4,
+  "timestamp": "2026-07-07T14:38:43.694Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderRole.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxSecurityRole/Label",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "@AC:PFXNoteHeaderRole"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T14__L4-headerlines-document-slice__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T14__L4-headerlines-document-slice__cb1b73d.json
@@ -1,0 +1,72 @@
+﻿{
+  "run_id": "2026-07-07T14__L4-headerlines-document-slice__cb1b73d",
+  "case_id": "L4-headerlines-document-slice",
+  "tier": 4,
+  "timestamp": "2026-07-07T14:57:09.000Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxEnum/ConDemoRentStatus.xml",
+    "AxEdt/ConDemoRentAgreementId.xml",
+    "AxTable/ConDemoRentHeader.xml",
+    "AxTable/ConDemoRentLine.xml",
+    "AxEnumExtension/NumberSeqModule.ConExtension.xml",
+    "AxClass/ConNumberSeqModuleDemoRent.xml",
+    "AxForm/ConDemoRentAgreement.xml",
+    "AxMenuItemDisplay/ConDemoRentAgreementMI.xml",
+    "AxSecurityPrivilege/ConDemoRentMaintain.xml",
+    "AxSecurityDuty/ConDemoRentDuty.xml",
+    "AxSecurityRole/ConDemoRentClerk.xml"
+  ],
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": [
+        "NoYes::No and NoYes::Yes flagged by validate_code(mode=references) as unknown-static-member on ConNumberSeqModuleDemoRent.loadModule(), a known validator false positive (NoYes is a real, ubiquitous standard enum missing from the index under its exact base name -- reproduces the same finding recorded in the L3-numberseq-module-slice corpus run). validate_code(mode=syntax) passed clean on the same source, and the two AxTable XMLs (ConDemoRentHeader, ConDemoRentLine) both passed validate_code(mode=references, codeType=xml-table) with 8/8 references verified and zero errors."
+      ]
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "build": {
+    "succeeded": false,
+    "errors": [
+      {
+        "message": "Form dynamics://Form/ConDemoRentAgreement: Form 'ConDemoRentAgreement' datasource 'ConDemoRentHeaderLine' refers to table 'ConDemoRentHeaderLine' which does not exist."
+      },
+      {
+        "message": "Form dynamics://Form/ConDemoRentAgreement: Form 'ConDemoRentAgreement' datasource 'ConDemoRentHeader' refers to table '' which does not exist (cascaded binder failure from the broken joined datasource; the raw XML's own Table element for this datasource is intact and byte-correct)."
+      }
+    ],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "npm run eval:score throws ENOENT scandir eval/goldens/L4-headerlines-document-slice because golden_pending is true and no golden dir exists yet, confirmed by direct invocation with EXTENSION_PREFIX=Con exported. That is expected and separate from this run terminal outcome: a genuine BUILD FAILURE caused by a reproducible tool defect in the DetailsTransaction form scaffold, with 10 of the 11 required objects grounded and believed fully correct. Objects 1-4 (AxEnum ConDemoRentStatus with Open/Confirmed/Returned/Cancelled reusing standard labels CashManagement Open, CashManagement Confirmed, Res Returned, SYS CancelledState; AxEdt ConDemoRentAgreementId extending Num reusing GLS 220539 Agreement ID label; AxTable ConDemoRentHeader with RentAgreementId mandatory, CustAccount, FromDate, ToDate, Status fields, a unique RentAgreementIdIdx index, a CustTable relation on CustAccount to AccountNum, an Overview field group over all five fields, and TitleField1 set to RentAgreementId; AxTable ConDemoRentLine with RentAgreementId, LineNum, ItemName, Qty, LineAmount fields, a RentAgreementIdx index on RentAgreementId plus LineNum, and an DemoRentHeader relation on RentAgreementId to RentAgreementId) were all created via d365fo_file create plus modify operations, read back correctly from disk after every write, and passed validate_code references mode with 8 of 8 verified in each table and zero hallucinated symbols. Objects 5-6 (AxEnumExtension NumberSeqModule ConExtension adding value DemoRent as the case mandates; AxClass ConNumberSeqModuleDemoRent extending NumberSeqApplicationModule with loadModule registering a NumberSeqDatatype for ConDemoRentAgreementId via NumberSeqDatatype construct plus parm methods plus this create call, numberSeqModule returning NumberSeqModule DemoRent, and a static buildModulesMapSubsciber Map method carrying SubscribesTo on NumberSeqGlobal buildModulesMapDelegate calling NumberSeqGlobal addModuleToMap) were grounded via get_method on NumberSeqModuleBank.loadModule (include source) and find_references on NumberSeqGlobal.addModuleToMap (45 real standard callers, all the identical static-method-on-the-module-class pattern), matching the proven shape exactly. Objects 8-11 (menu item, privilege, duty, role) were all created cleanly; ConDemoRentMaintain EntryPoints correctly reference ConDemoRentAgreementMI as MenuItemDisplay. One separately-known, non-blocking defect reproduced here, not scored as the terminal failure: d365fo_file create for security-duty emits Privileges containing AxSecurityRolePermissionSet with just a Name element, instead of the AxSecurityPrivilegeReference shape shipped duties use -- functionally wired but will very likely trigger a BP shape-mismatch warning once a build succeeds far enough to run BP checks. The DELETE ACTION mandated by the case, a relation to DemoRentHeader plus a cascading delete action, could not be added at all: there is no add-delete-action or any AxTableDeleteAction-shaped operation in the modify tool operation set, so this specific sub-requirement is an uncovered tool-surface gap, not attempted by hand. The TERMINAL, build-blocking defect is object 7, the form. object_patterns domain form action analyze recommend correctly recommended DetailsTransaction citing SalesTable, PurchTable, ProjInvoiceJournal as reference forms; generate_object mode scaffold objectType form cloneFrom SalesTable tableMapping was tried first per the tool own preferred workflow and was correctly self-blocked by the pre-clone field-overlap check (1 of 185 and 2 of 198 fields shared), which itself redirected to a formPattern plus dataSource scaffold. generate_object mode scaffold objectType form formPattern DetailsTransaction dataSource ConDemoRentHeader includeMethodStubs true was then called (single dataSource param) and produced a rich, mostly well-formed DetailsTransaction structure (ActionPane, NavigationList side panel, FastTabs, header, lines and grid tab pages all correctly bound to ConDemoRentHeader fields) BUT auto-invented a SECOND AxFormDataSource named and typed ConDemoRentHeaderLine -- guessing a HeaderTable-plus-Line naming convention for the lines table that does not match the actual, case-mandated lines table name ConDemoRentLine, and never referencing the real ConDemoRentLine table anywhere in the file. This left the LinesGrid, LinesActionPaneStrip and LineViewLineDetails controls bound to a DataSource pointing at a nonexistent table, and xppc build correctly failed with a message that datasource ConDemoRentHeaderLine refers to table ConDemoRentHeaderLine which does not exist, plus a second cascaded error reporting the FIRST, header datasource table as empty, even though the raw XML Table element for that datasource is intact -- apparently a binder-cascade artifact of the broken joined datasource, not a second independent corruption. Per the case forward-only mandate, this was NOT hand-patched and NOT rolled back and retried: an attempt was made to fix it exclusively through the grounded modify surface and hit two further, confirmed tool gaps: first, d365fo_file modify objectType form operation add-data-source on the base AxForm returns a note stating form-extension only in its own required-parameter error message, meaning add-data-source is documented by the tool itself as applicable only to AxFormExtension objects, not to a base AxForm own DataSources collection, so there is no grounded way to add or replace a base-form datasource after initial scaffold; second, d365fo_file modify operation modify-property with propertyPath targeting the second datasource Table element failed twice, once with a plain slash path and once with a Name-predicate-qualified path, both returning an error that the Table tag appears two times and is ambiguous, refusing to guess which one, confirming modify-property counts raw tag-name occurrences file-wide rather than resolving structurally-scoped paths, so it cannot disambiguate between the two AxFormDataSource elements Table children. object_patterns domain form action validate on the broken file reported zero errors and only three cosmetic FP002 sub-pattern-version warnings -- it does not perform semantic table-existence checking on datasource bindings, so it did not catch this before the build.",
+  "suggested_fix_area": "First, generate_object mode scaffold objectType form formPattern DetailsTransaction with a single dataSource table: stop auto-inventing a second Line-suffixed datasource when only one table is supplied -- either require or accept an explicit second table for the lines datasource, mirroring the multi-table dataSource syntax the tool itself suggests as a SimpleList fallback (a comma separated list of two tables), or omit the second datasource entirely and document that DetailsTransaction scaffolding from a single table needs a follow-up step. Second, d365fo_file modify objectType form operation add-data-source: either lift the form-extension-only restriction so it also supports adding or replacing a datasource on a base AxForm (the exact scenario this case needs to recover from a bad scaffold), or add a dedicated base-form datasource repoint or remove operation. Third, modify-property: resolve propertyPath structurally, respecting a Name qualifier or an index, instead of a file-wide same-tag-name count-and-refuse heuristic, so a qualified or indexed path can disambiguate repeated sibling tag names such as Table across multiple datasources. Fourth, object_patterns action validate: add a semantic check, or point users at an xml-form validate_code references codeType which does not currently exist, that flags a form datasource whose Table does not resolve to an existing table in the symbol index, since the structural pattern validator alone passes broken forms like this one. Fifth, add an add-delete-action or AxTableDeleteAction operation to the table modify surface -- there is currently no grounded way to add a cascading DeleteAction to a table relation at all. Sixth, re-index the base NoYes enum since fuzzy search currently only returns NoYes-suffixed variants, never the exact base enum, matching the same finding from the L3-numberseq-module-slice run. Seventh, security-duty and security-role create should emit AxSecurityPrivilegeReference and AxSecurityDutyReference, matching shipped objects, instead of AxSecurityRolePermissionSet and AxSecurityRoleDutyPermission, per the already-tracked defect. Once the first three items are fixed, re-run this case, author and human-review the golden for L4-headerlines-document-slice, and flip golden_pending to false.",
+  "evidence_refs": [
+    "C:AOSServicePackagesLocalDirectory\contoso\contosoAxFormConDemoRentAgreement.xml",
+    "C:AOSServicePackagesLocalDirectory\contoso\contosoAxTableConDemoRentHeader.xml",
+    "C:AOSServicePackagesLocalDirectory\contoso\contosoAxTableConDemoRentLine.xml",
+    "C:AOSServicePackagesLocalDirectory\contoso\contosoAxClassConNumberSeqModuleDemoRent.xml",
+    "C:AOSServicePackagesLocalDirectory\contoso\contosoAxSecurityDutyConDemoRentDuty.xml",
+    "npm run eval:score -- L4-headerlines-document-slice <actual> => ENOENT scandir eval/goldens/L4-headerlines-document-slice (golden_pending, confirmed by direct invocation)"
+  ]
+}

--- a/eval/corpus/runs/2026-07-07T15__L4-master-security-slice__cb1b73d.json
+++ b/eval/corpus/runs/2026-07-07T15__L4-master-security-slice__cb1b73d.json
@@ -1,0 +1,99 @@
+﻿{
+  "run_id": "2026-07-07T15__L4-master-security-slice__cb1b73d",
+  "case_id": "L4-master-security-slice",
+  "tier": 4,
+  "timestamp": "2026-07-07T15:33:06.000Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "AxTable/ConDemoAsset.xml",
+    "AxForm/ConDemoAssetDetails.xml",
+    "AxMenuItemDisplay/ConDemoAssetDetailsMI.xml",
+    "AxMenu/ConDemoAssetMenu.xml",
+    "AxSecurityPrivilege/ConDemoAssetView.xml",
+    "AxSecurityPrivilege/ConDemoAssetMaintain.xml",
+    "AxSecurityDuty/ConDemoAssetDuty.xml",
+    "AxSecurityRole/ConDemoAssetManager.xml"
+  ],
+  "static_gate": {
+    "references": {
+      "passed": true
+    },
+    "syntax": {
+      "passed": true
+    }
+  },
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {
+        "message": "AxSecurityDuty ConDemoAssetDuty: BPErrorDutyHasNoPrivileges."
+      },
+      {
+        "message": "AxSecurityDuty ConDemoAssetDuty: BPErrorDutyNotCoveredByRole."
+      },
+      {
+        "message": "AxSecurityPrivilege ConDemoAssetView: BPErrorPrivilegeNotCoveredByDuty."
+      },
+      {
+        "message": "AxSecurityPrivilege ConDemoAssetMaintain: BPErrorPrivilegeNotCoveredByDuty."
+      },
+      {
+        "message": "AxForm ConDemoAssetDetails FormDesign: Unknown label @EnterpriseAssetManagementAppSuite:EntAssetObject (model not referenced by contoso)."
+      },
+      {
+        "message": "AxForm ConDemoAssetDetails TabPageOverview: BPErrorLabelIsText: Caption 'Overview' is raw text, not a label ID."
+      },
+      {
+        "message": "AxForm ConDemoAssetDetails TabPageGeneral: BPErrorLabelIsText: Caption 'General' is raw text, not a label ID."
+      },
+      {
+        "message": "AxTable ConDemoAsset: BPCheckAlternateKeyAbsent (no AlternateKey-flagged index)."
+      },
+      {
+        "message": "AxTable ConDemoAsset: BPErrorTableMissingGroupAutoReport."
+      },
+      {
+        "message": "AxTable ConDemoAsset TableFieldGroup Overview: BPErrorLabelNotDefined."
+      },
+      {
+        "message": "AxTable ConDemoAsset: BPErrorDeveloperDocumentationNotDefined."
+      },
+      {
+        "message": "AxTable ConDemoAsset: BPErrorTableNoCaching."
+      },
+      {
+        "message": "AxTable ConDemoAsset: BPErrorTableMissingFormRef."
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT",
+  "evidence_refs": [
+    "eval/cases/L4-master-security-slice.json",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxTable/ConDemoAsset.xml (rolled back after run)",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxForm/ConDemoAssetDetails.xml (rolled back after run)",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxMenuItemDisplay/ConDemoAssetDetailsMI.xml (rolled back after run)",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxMenu/ConDemoAssetMenu.xml (rolled back after run)",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxSecurityPrivilege/ConDemoAssetView.xml (rolled back after run)",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxSecurityPrivilege/ConDemoAssetMaintain.xml (rolled back after run)",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxSecurityDuty/ConDemoAssetDuty.xml (rolled back after run)",
+    "C:/AOSService/PackagesLocalDirectory/contoso/contoso/AxSecurityRole/ConDemoAssetManager.xml (rolled back after run)",
+    "npm run eval:score -- L4-master-security-slice <actual> --bp-warnings 13 => ENOENT scandir eval/goldens/L4-master-security-slice (golden_pending, confirmed by direct invocation with EXTENSION_PREFIX=Con exported)",
+    "security_info(mode=coverage, objectName=ConDemoAssetDetailsMI, objectType=menu-item) confirms non-empty end-to-end resolution: both privileges -> duty ConDemoAssetDuty -> role ConDemoAssetManager, despite the malformed wrapper elements in the raw XML",
+    "run_bp_check(modelName=contoso) output before/after label fixes (18 warnings -> 13 warnings)"
+  ],
+  "root_cause_hypothesis": "npm run eval:score throws ENOENT scandir eval/goldens/L4-master-security-slice because golden_pending is true and no golden dir exists yet, confirmed by direct invocation with EXTENSION_PREFIX=Con exported. That is expected and separate from this run's actual outcome: BUILD IS CLEAN (0 errors) and the full master-data slice (table, DetailsMaster form, menu item, menu, 2 privileges, duty, role) was produced end to end through the grounded tool path only (prepare -> search/get_object_info for EDTs -> generate_object(fields) -> d365fo_file create/modify -> object_patterns validate -> validate_code references/syntax -> build -> run_bp_check -> security_info coverage), with zero hand-authored or hand-patched XML. security_info(mode=coverage) confirms the case's explicit correctness bar is met: both privileges resolve through the duty to the role with non-empty, correct Read/Update/Create/Delete grants (View: Read only; Maintain: full CRUD) -- not an empty skeleton. Classification is TOOL_DEFECT rather than PASS because three separate, reproducible tool defects were hit along the way, two of which left permanent residue in the scored artifacts because the grounded modify surface has no way to correct them.\n\nDEFECT 1 (build-blocking, worked around, not present in final artifact): generate_object(mode=\"scaffold\", objectType=\"form\", formPattern=\"DetailsMaster\", includeMethodStubs=true) injected the requested per-datasource method stubs (active/validateWrite) directly inside the top-level AxFormDataSource's <Methods> element, positioned immediately after <Name> and BEFORE <Table>. This desyncs positional schema binding exactly as previously seen on DetailsTransaction/TableOfContents scaffolds (see prior L3-numberseq-module-slice and L4-headerlines-document-slice runs): xppc fails with \"datasource 'ConDemoAsset' refers to table '' which does not exist\", even though the raw <Table> text is present and correct in the file. This is the first confirmation of this exact defect on the DetailsMaster pattern too, so it is not pattern-specific -- it is the includeMethodStubs=true code path generically across at least three form patterns now. Worked around (not hand-patched) by deleting the broken file via undo_last_modification and regenerating with includeMethodStubs=false, omitting the datasource lifecycle stubs entirely, since the case's core deliverables (controls, grid, FastTabs) do not depend on them and there is no supported d365fo_file(modify) operation to add a datasource-scoped method after the fact (add-method targets the form's own SourceCode, not a specific AxFormDataSource).\n\nDEFECT 2 (permanent residue, unfixable via grounded surface): d365fo_file(action=\"create\", objectType=\"security-duty\", properties.privileges=[...]) and objectType=\"security-role\" (properties.duties=[...]) both emit the wrong wrapper element shape -- <AxSecurityRolePermissionSet> instead of <AxSecurityPrivilegeReference> under AxSecurityDuty/Privileges, and <AxSecurityRoleDutyPermission> instead of <AxSecurityDutyReference> under AxSecurityRole/Duties -- confirming the already-tracked defect (functionally wired per security_info, but wrong BP-checkable shape). This directly causes 4 of the 13 residual BP warnings (BPErrorDutyHasNoPrivileges, BPErrorDutyNotCoveredByRole, BPErrorPrivilegeNotCoveredByDuty x2), because the BP checker's schema-aware coverage rules do not recognize the wrong element names as valid references even though the C# bridge's own security_info reader does resolve them correctly. There is no d365fo_file(modify) operation to rename/replace these wrapper elements; modify-property returned \"Operation 'modify-property' on object type 'security-duty'/'security-role' is not supported by the bridge\" for both types, so this could not be corrected without hand-editing XML, which was correctly avoided per the task's guardrail.\n\nDEFECT 3 (partially my own mistake, but blocked by a genuine tool limitation): I initially reused labels from EnterpriseAssetManagementAppSuite and AssetLeasing for the table/duty/menu/form-caption/privilege labels; contoso's Descriptor only references ApplicationFoundation/ApplicationPlatform/ApplicationSuite, so those labels correctly triggered BPErrorUnknownLabel. Re-grounded via labels(action=\"search\") and fixed table/duty/menu/Maintain-privilege/role labels to labels reused from referenced models (@Budget:LineAssetSource = \"Asset\", @SalesAndMarketing:Maintain, @SYS313197 = \"Manager\") via d365fo_file(modify, modify-property) where supported, or create+overwrite=true where modify-property was unsupported for the object type -- eliminating 4 of the original 5 unknown-label warnings and both non-coverage-related duty/role label issues. However ONE unknown-label warning (the form's Design/Caption, still pointing at the unreferenced EnterpriseAssetManagementAppSuite label) and the form scaffold's own two raw-text FastTab captions (\"Overview\"/\"General\", which I never supplied -- the scaffold tool's own default output) could NOT be corrected: d365fo_file(modify, objectType=\"form\", operation=\"modify-property\", propertyPath=\"Design/Caption\") failed with \"<Caption> appears 3 times in [file] -- ambiguous, refusing to guess which one\", confirming the already-known modify-property structural-path limitation (it counts raw tag-name occurrences file-wide rather than resolving structurally-scoped/qualified paths) blocks fixing form Design captions on any form with more than one Caption-bearing control, which is nearly all non-trivial forms. There is no other grounded operation (no \"modify-control\" op) to target a specific Design element's property by structural path.\n\nSECONDARY OBSERVATION (informational, not scored): the labels(action=\"search\"/\"info\") tool displays legacy SYS-family label files (SYS, WAX, TRX, SYP, GLS, GEE, RET) using a malformed doubled-@ syntax in its own \"Usage in metadata XML\" guidance, e.g. \"<Label>@SYS:@SYS313197</Label>\", which the BP checker correctly rejects with BPErrorLabelIsText (\"not a label ID\"); the correct legacy syntax is the plain single-@ form \"@SYS313197\", confirmed both by the EDT TransDate's own pre-existing Label (\"@SYS7402\", single-@, no BP complaint at all) and by successfully eliminating the role's BPErrorLabelIsText warning after switching to \"@SYS313197\". This is a real, reproducible defect in the labels tool's own suggested usage syntax for any legacy/SYS-style label file, independent of this case's security content.\n\nRemaining 6 BP warnings (BPCheckAlternateKeyAbsent, BPErrorTableMissingGroupAutoReport, BPErrorLabelNotDefined on the Overview field group, BPErrorDeveloperDocumentationNotDefined, BPErrorTableNoCaching, BPErrorTableMissingFormRef) are generic table-hygiene items the case instruction never mandates (it only asks for the unique AssetIdx index, TitleField1=Name, and an Overview field group, all of which are present and correct) and are treated as expected background noise for a minimal master table, consistent with prior corpus records' treatment of similarly-scoped tables.",
+  "suggested_fix_area": "(1) generate_object(mode=\"scaffold\", objectType=\"form\", includeMethodStubs=true): move injected per-datasource method stubs out of the top-level AxFormDataSource element (which must keep Name/Table/Fields/... in schema order with no <Methods> child) and into the SourceCode/DataSources/DataSource/Methods mirror section, matching every shipped form -- this defect is now confirmed across three different form patterns (TableOfContents, DetailsTransaction, DetailsMaster), so it looks like a generic code path, not pattern-specific.\n(2) d365fo_file(action=\"create\", objectType=\"security-duty\"|\"security-role\"): emit <AxSecurityPrivilegeReference>/<AxSecurityDutyReference> instead of <AxSecurityRolePermissionSet>/<AxSecurityRoleDutyPermission>, matching shipped objects (already-tracked defect, reconfirmed here).\n(3) d365fo_file(action=\"modify\", operation=\"modify-property\"): (a) support security-privilege/security-duty/security-role object types (currently \"not supported by the bridge\" for all three, forcing a create+overwrite=true workaround which is only viable for objects with no other unique state); (b) resolve propertyPath structurally instead of refusing whenever a tag name (e.g. Caption) appears more than once file-wide -- accept an indexed or Name-qualified path so a specific Design control's property can be targeted (this blocks fixing raw-text FastTab captions or a form's own Design/Caption on essentially any non-trivial form).\n(4) labels(action=\"search\"/\"info\"): fix the \"Usage in X++\"/\"Usage in metadata XML\" guidance for legacy SYS-family label files (SYS, WAX, TRX, SYP, GLS, GEE, RET) -- it currently suggests a malformed doubled-@ syntax (\"@SYS:@SYS313197\") that the BP checker rejects; the correct form is the plain single-@ legacy syntax (\"@SYS313197\").\n(5) Author and human-review the golden for L4-master-security-slice (8 artifacts: table, form, menu item, menu, 2 privileges, duty, role) so future runs can score golden_match; flip golden_pending to false once fixes (1)-(2) land so the golden can reflect a fully BP-clean build."
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__1-tmp-table.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__1-tmp-table.json
@@ -1,0 +1,34 @@
+{
+  "run_id": "2026-07-07T16__L4-ssrs-report-advanced__cb1b73d",
+  "case_id": "L4-ssrs-report-advanced",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:17:17.182Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "1-tmp-table.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "PASS"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__2-contract.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__2-contract.json
@@ -1,0 +1,34 @@
+{
+  "run_id": "2026-07-07T16__L4-ssrs-report-advanced__cb1b73d",
+  "case_id": "L4-ssrs-report-advanced",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:17:18.649Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "2-contract.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "PASS"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__3-dp.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__3-dp.json
@@ -1,0 +1,51 @@
+﻿{
+  "run_id": "2026-07-07T16__L4-ssrs-report-advanced__cb1b73d",
+  "case_id": "L4-ssrs-report-advanced",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:17:19.914Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "3-dp.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxClass/SourceCode/Methods/Method[getConDemoNoteReportAdvTmp]/Name",
+      "AxClass/SourceCode/Methods/Method[getConDemoNoteReportAdvTmp]/Source"
+    ],
+    "extra": [
+      "AxClass/SourceCode/Methods/Method[getConDemoNoteReportAdvTmp]/Name",
+      "AxClass/SourceCode/Methods/Method[getConDemoNoteReportAdvTmp]/Source"
+    ],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Declaration",
+        "expected": "/// <summary>\n/// Data provider for the @TaxTransactionInquiry:HeaderNote report.\n/// Extends <c>SrsReportDataProviderBase</c> and populates the <c>PFXDemoNoteReportAdvTmp</c> temporary table.\n/// </summary>\n[\n    SRSReportParameterAttribute(classStr(PFXDemoNoteReportAdvContract))\n]\npublic class PFXDemoNoteReportAdvDP extends SrsReportDataProviderBase\n{\n    PFXDemoNoteReportAdvTmp conDemoNoteReportAdvTmp;\n\n}",
+        "actual": "/// <summary>\n/// Data provider for the @TaxTransactionInquiry:HeaderNote report.\n/// Extends <c>SrsReportDataProviderBase</c> and populates the <c>PFXDemoNoteReportAdvTmp</c> temporary table.\n/// </summary>\n[\n    SRSReportParameterAttribute(classStr(PFXDemoNoteReportAdvContract))\n]\npublic class PFXDemoNoteReportAdvDP extends SrsReportDataProviderBase\n{\n    PFXDemoNoteReportAdvTmp conDemoNoteReportAdvTmp;\n\n}"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[processReport]/Source",
+        "expected": "/// <summary>\n    /// Main data processing method. Populates the <c>PFXDemoNoteReportAdvTmp</c> temporary table\n    /// with report data based on the contract parameters.\n    /// </summary>\n    public void processReport()\n    {\n        PFXDemoNoteReportAdvContract contract = this.parmDataContract() as PFXDemoNoteReportAdvContract;\n        str subjectFilter = contract.parmSubjectFilter();\n        PFXDemoNoteHeader noteHeader;\n\n        if (!subjectFilter)\n        {\n            subjectFilter = '*';\n        }\n\n        insert_recordset conDemoNoteReportAdvTmp (NoteId, Subject)\n            select NoteId, Subject from noteHeader\n                where noteHeader.Subject like subjectFilter;\n    }",
+        "actual": "/// <summary>\n    /// Main data processing method. Populates the <c>PFXDemoNoteReportAdvTmp</c> temporary table\n    /// with report data based on the contract parameters.\n    /// </summary>\n    public void processReport()\n    {\n        PFXDemoNoteReportAdvContract contract = this.parmDataContract() as PFXDemoNoteReportAdvContract;\n        str subjectFilter = contract.parmSubjectFilter();\n        PFXDemoNoteHeader noteHeader;\n\n        if (!subjectFilter)\n        {\n            subjectFilter = '*';\n        }\n\n        insert_recordset conDemoNoteReportAdvTmp (NoteId, Subject)\n            select NoteId, Subject from noteHeader\n                where noteHeader.Subject like subjectFilter;\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "VALIDATOR_GAP"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__4-controller.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__4-controller.json
@@ -1,0 +1,36 @@
+{
+  "run_id": "2026-07-07T16__L4-ssrs-report-advanced__cb1b73d",
+  "case_id": "L4-ssrs-report-advanced",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:17:21.240Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "4-controller.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "KNOWLEDGE_GAP"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__5-menuitem.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__5-menuitem.json
@@ -1,0 +1,36 @@
+{
+  "run_id": "2026-07-07T16__L4-ssrs-report-advanced__cb1b73d",
+  "case_id": "L4-ssrs-report-advanced",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:17:22.706Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "5-menuitem.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": [
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "KNOWLEDGE_GAP"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__6-report.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d__6-report.json
@@ -1,0 +1,56 @@
+﻿{
+  "run_id": "2026-07-07T16__L4-ssrs-report-advanced__cb1b73d",
+  "case_id": "L4-ssrs-report-advanced",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:17:24.067Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "6-report.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportAdvTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTADVDP_DynamicParameter]/Alias",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportAdvTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTADVDP_DynamicParameter]/DataType",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportAdvTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTADVDP_DynamicParameter]/Name",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportAdvTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTADVDP_DynamicParameter]/Parameter",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/@type",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/AllowBlank",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/DataType",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/Name",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/Nullable",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/UserVisibility"
+    ],
+    "extra": [
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportAdvTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTADVDP_DynamicParameter]/Alias",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportAdvTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTADVDP_DynamicParameter]/DataType",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportAdvTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTADVDP_DynamicParameter]/Name",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportAdvTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTADVDP_DynamicParameter]/Parameter",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/@type",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/AllowBlank",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/DataType",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/Name",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/Nullable",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTADVDP_DynamicParameter]/UserVisibility"
+    ],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "VALIDATOR_GAP"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__1-tmp-table.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__1-tmp-table.json
@@ -1,0 +1,74 @@
+﻿{
+  "run_id": "2026-07-07T16__L4-ssrs-report-basic__cb1b73d",
+  "case_id": "L4-ssrs-report-basic",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:03:14.785Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteReportTmp.metadata.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxTable/TableGroup"
+    ],
+    "extra": [
+      "AxTable/ClusteredIndex",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoBrowse]/Name",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoIdentification]/AutoPopulate",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoIdentification]/Name",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[NoteId]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Fields/AxTableFieldGroupField[Subject]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoLookup]/Name",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[NoteId]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Fields/AxTableFieldGroupField[Subject]/DataField",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoReport]/Name",
+      "AxTable/FieldGroups/AxTableFieldGroup[AutoSummary]/Name",
+      "AxTable/Fields/AxTableField[NoteId]/Mandatory",
+      "AxTable/Indexes/AxTableIndex[DemoNoteReportTmpIdx]/AlternateKey",
+      "AxTable/Indexes/AxTableIndex[DemoNoteReportTmpIdx]/Fields/AxTableIndexField[NoteId]/DataField",
+      "AxTable/Indexes/AxTableIndex[DemoNoteReportTmpIdx]/Name",
+      "AxTable/PrimaryIndex",
+      "AxTable/ReplacementKey",
+      "AxTable/SaveDataPerCompany",
+      "AxTable/SourceCode/Declaration",
+      "AxTable/TitleField1",
+      "AxTable/TitleField2"
+    ],
+    "changed": [
+      {
+        "path": "AxTable/Fields/AxTableField[NoteId]/ExtendedDataType",
+        "expected": "Num",
+        "actual": "PlCorrNoteId"
+      },
+      {
+        "path": "AxTable/Fields/AxTableField[Subject]/ExtendedDataType",
+        "expected": "Name",
+        "actual": "smmSubject"
+      },
+      {
+        "path": "AxTable/Label",
+        "expected": "@TaxTransactionInquiry:HeaderNote",
+        "actual": "Note report temp table"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__2-contract.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__2-contract.json
@@ -1,0 +1,40 @@
+﻿{
+  "run_id": "2026-07-07T16__L4-ssrs-report-basic__cb1b73d",
+  "case_id": "L4-ssrs-report-basic",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:03:35.673Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteReportContract.metadata.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Declaration",
+        "expected": "[DataContractAttribute]\npublic final class PFXDemoNoteReportContract\n{\n}",
+        "actual": "/// <summary>\n/// Data contract for the Demo Note Report report.\n/// Defines dialog parameters shown to the user before report execution.\n/// </summary>\n[DataContractAttribute]\npublic class PFXDemoNoteReportContract\n{\n    // No dialog parameters\n\n}"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__3-dp.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__3-dp.json
@@ -1,0 +1,51 @@
+﻿{
+  "run_id": "2026-07-07T16__L4-ssrs-report-basic__cb1b73d",
+  "case_id": "L4-ssrs-report-basic",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:03:58.231Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteReportDP.metadata.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxClass/SourceCode/Methods/Method[getConDemoNoteReportTmp]/Name",
+      "AxClass/SourceCode/Methods/Method[getConDemoNoteReportTmp]/Source"
+    ],
+    "extra": [
+      "AxClass/SourceCode/Methods/Method[getConDemoNoteReportTmp]/Name",
+      "AxClass/SourceCode/Methods/Method[getConDemoNoteReportTmp]/Source"
+    ],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Declaration",
+        "expected": "[SRSReportParameterAttribute(classStr(PFXDemoNoteReportContract))]\npublic class PFXDemoNoteReportDP extends SRSReportDataProviderBase\n{\n    PFXDemoNoteReportTmp tmpTable;\n}",
+        "actual": "/// <summary>\n/// Data provider for the Demo Note Report report.\n/// Extends <c>SrsReportDataProviderBase</c> and populates the <c>PFXDemoNoteReportTmp</c> temporary table.\n/// </summary>\n[\n    SRSReportParameterAttribute(classStr(PFXDemoNoteReportContract))\n]\npublic class PFXDemoNoteReportDP extends SrsReportDataProviderBase\n{\n    PFXDemoNoteReportTmp conDemoNoteReportTmp;\n\n}"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[processReport]/Source",
+        "expected": "public void processReport()\n{\n    PFXDemoNoteHeader noteHeader;\n\n    delete_from tmpTable;\n\n    insert_recordset tmpTable (NoteId, Subject)\n        select NoteId, Subject\n        from noteHeader;\n}",
+        "actual": "/// <summary>\n    /// Main data processing method. Populates the <c>PFXDemoNoteReportTmp</c> temporary table\n    /// with report data based on the contract parameters.\n    /// </summary>\n    public void processReport()\n    {\n        // No contract parameters\n\n        // TODO: Replace with actual query / business logic\n        // Example pattern:\n        //   while select sourceTable\n        //       where sourceTable.Field == paramValue\n        //   {\n        //       conDemoNoteReportTmp.clear();\n        //       conDemoNoteReportTmp.NoteId = ''; // TODO: populate from data source\n        //       conDemoNoteReportTmp.Subject = ''; // TODO: populate from data source\n        //       conDemoNoteReportTmp.insert();\n        //   }\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__4-controller.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__4-controller.json
@@ -1,0 +1,40 @@
+﻿{
+  "run_id": "2026-07-07T16__L4-ssrs-report-basic__cb1b73d",
+  "case_id": "L4-ssrs-report-basic",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:04:50.706Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteReportController.metadata.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Methods/Method[main]/Source",
+        "expected": "public static void main(Args _args)\n{\n    PFXDemoNoteReportController controller = new PFXDemoNoteReportController();\n    controller.parmReportName(ssrsReportStr(PFXDemoNoteReport, Design));\n    controller.parmArgs(_args);\n    controller.startOperation();\n}",
+        "actual": "public static void main(Args _args)\n    {\n        PFXDemoNoteReportController controller = new PFXDemoNoteReportController();\n        controller.parmReportName(ssrsReportStr(PFXDemoNoteReport, Design));\n        controller.parmArgs(_args);\n        controller.startOperation();\n    }"
+      }
+    ]
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}

--- a/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__5-report.json
+++ b/eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d__5-report.json
@@ -1,0 +1,64 @@
+﻿{
+  "run_id": "2026-07-07T16__L4-ssrs-report-basic__cb1b73d",
+  "case_id": "L4-ssrs-report-basic",
+  "tier": 4,
+  "timestamp": "2026-07-07T16:04:51.930Z",
+  "server_git_sha": "cb1b73d",
+  "generated_artifacts": [
+    "ConDemoNoteReport.metadata.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [],
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTDP_DynamicParameter]/Alias",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTDP_DynamicParameter]/DataType",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTDP_DynamicParameter]/Name",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTDP_DynamicParameter]/Parameter",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/@type",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/AllowBlank",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/DataType",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/Name",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/Nullable",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/UserVisibility",
+      "AxReport/Designs/AxReportDesign[Design]/@type",
+      "AxReport/Designs/AxReportDesign[Design]/Caption",
+      "AxReport/Designs/AxReportDesign[Design]/DisableIndividualTransformation[DisableIndividualTransformation]/Name",
+      "AxReport/Designs/AxReportDesign[Design]/Name"
+    ],
+    "extra": [
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTDP_DynamicParameter]/Alias",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTDP_DynamicParameter]/DataType",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTDP_DynamicParameter]/Name",
+      "AxReport/DataSets/AxReportDataSet[PFXDemoNoteReportTmp]/Parameters/AxReportDataSetParameter[CONDEMONOTEREPORTDP_DynamicParameter]/Parameter",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/@type",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/AllowBlank",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/DataType",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/Name",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/Nullable",
+      "AxReport/DefaultParameterGroup/ReportParameterBases/AxReportParameterBase[CONDEMONOTEREPORTDP_DynamicParameter]/UserVisibility",
+      "AxReport/Designs/AxReportDesign[Report]/@type",
+      "AxReport/Designs/AxReportDesign[Report]/Caption",
+      "AxReport/Designs/AxReportDesign[Report]/DisableIndividualTransformation[DisableIndividualTransformation]/Name",
+      "AxReport/Designs/AxReportDesign[Report]/Name"
+    ],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT"
+}


### PR DESCRIPTION
Unignore eval/corpus/runs/ and commit 57 run records covering:
- L0: edt-basic, enum-basic
- L1: class, form (all patterns), map, query-view, table
- L2: business-event, class-method-ops, coc-extension, delegate, dimension, enum-extension/modify, event-handler, form-extension/modify-controls/over-view, interface-abstract, numberseq, oracle-discriminator, table-extension/modify-lifecycle
- L3: batch, form-add-datasource-lines, form-detailstransaction, numberseq-module-slice
- L4: bridge data-entity fix, entity-security slice, headerlines, master-security, ssrs-report (basic + advanced)