### PR TITLE
fix: remove MseeP security badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/dynamics365ninja-d365fo-mcp-server-badge.png)](https://mseep.ai/app/dynamics365ninja-d365fo-mcp-server)
-
 # D365 F&O MCP Server
 
 <div align="center">


### PR DESCRIPTION
Removes the MseeP.ai security assessment badge from the top of the README.