### PR TITLE
fix(eval-improver): strip UTF-8 BOM when loading corpus records

### DIFF
--- a/src/eval/improver/cli.ts
+++ b/src/eval/improver/cli.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { clusterRuns, renderClusters, type CorpusRun } from './cluster.js';
+import { loadJsonRecords } from './corpusIO.js';
 import {
   aggregateBySplit, renderSplitReport, type ScoredCase, type Split,
 } from './heldout.js';
@@ -25,14 +26,10 @@ interface CorpusRunFull extends CorpusRun {
 
 function loadRuns(): CorpusRunFull[] {
   const dir = path.join(REPO_ROOT, 'eval', 'corpus', 'runs');
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter(f => f.endsWith('.json'))
-    .map(f => {
-      try { return JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')) as CorpusRunFull; }
-      catch { return null; }
-    })
-    .filter((r): r is CorpusRunFull => r != null && typeof r.classification === 'string');
+  return loadJsonRecords(
+    dir,
+    (r): r is CorpusRunFull => r != null && typeof r === 'object' && typeof (r as CorpusRunFull).classification === 'string',
+  );
 }
 
 /** Map case id → split, read from the case specs (default holdout). */

--- a/src/eval/improver/corpusIO.ts
+++ b/src/eval/improver/corpusIO.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared corpus-record loading for the improver CLIs (docs/AGENT_EVAL_LOOP.md
+ * §10). VM-free — reads `eval/corpus/runs/*.json` from disk.
+ *
+ * The implementer (running on Windows/PowerShell) writes some corpus records
+ * with a UTF-8 BOM. `JSON.parse` throws on a leading BOM, and every loader in
+ * this package swallows parse errors in a bare `catch { return null }` so a
+ * malformed run is skipped rather than crashing the CLI — which silently
+ * dropped the majority of the corpus (52/60 files observed 2026-07-08) from
+ * every report/cluster/brief/flake/knowledge CLI without any error surfaced.
+ * Strip the BOM before parsing so a valid-JSON-except-for-BOM file loads like
+ * any other record.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Strip a leading UTF-8 BOM (U+FEFF), if present, from file text. */
+export function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+/** Parse a JSON file, tolerating a leading UTF-8 BOM. */
+export function readJsonLenient<T = unknown>(filePath: string): T {
+  return JSON.parse(stripBom(fs.readFileSync(filePath, 'utf8'))) as T;
+}
+
+/**
+ * Read every `*.json` file directly under `dir`, parsing each with
+ * {@link readJsonLenient} and keeping only records that pass `isValid`.
+ * A file that fails to parse (bad JSON, not just BOM) or fails `isValid` is
+ * silently skipped — callers that need to know about skips should check the
+ * returned array length against the directory listing themselves.
+ */
+export function loadJsonRecords<T>(dir: string, isValid: (r: unknown) => r is T): T[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: T[] = [];
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith('.json')) continue;
+    let parsed: unknown;
+    try {
+      parsed = readJsonLenient(path.join(dir, f));
+    } catch {
+      continue;
+    }
+    if (isValid(parsed)) out.push(parsed);
+  }
+  return out;
+}

--- a/src/eval/improver/fixBriefCli.ts
+++ b/src/eval/improver/fixBriefCli.ts
@@ -13,20 +13,17 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { clusterRuns } from './cluster.js';
 import { renderFixBrief, buildTopFixBrief, type FixBriefRun } from './fixBrief.js';
+import { loadJsonRecords } from './corpusIO.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
 
 function loadRuns(): FixBriefRun[] {
   const dir = path.join(REPO_ROOT, 'eval', 'corpus', 'runs');
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter(f => f.endsWith('.json'))
-    .map(f => {
-      try { return JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')) as FixBriefRun; }
-      catch { return null; }
-    })
-    .filter((r): r is FixBriefRun => r != null && typeof r.classification === 'string');
+  return loadJsonRecords(
+    dir,
+    (r): r is FixBriefRun => r != null && typeof r === 'object' && typeof (r as FixBriefRun).classification === 'string',
+  );
 }
 
 function arg(flag: string): string | undefined {

--- a/src/eval/improver/flakeDetectionCli.ts
+++ b/src/eval/improver/flakeDetectionCli.ts
@@ -5,24 +5,20 @@
  *   tsx src/eval/improver/flakeDetectionCli.ts [--json]
  */
 
-import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { detectFlakeCandidates, renderFlakeCandidates, type FlakeCorpusRun } from './flakeDetection.js';
+import { loadJsonRecords } from './corpusIO.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
 
 function loadRuns(): FlakeCorpusRun[] {
   const dir = path.join(REPO_ROOT, 'eval', 'corpus', 'runs');
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter(f => f.endsWith('.json'))
-    .map(f => {
-      try { return JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')) as FlakeCorpusRun; }
-      catch { return null; }
-    })
-    .filter((r): r is FlakeCorpusRun => r != null && typeof r.run_id === 'string');
+  return loadJsonRecords(
+    dir,
+    (r): r is FlakeCorpusRun => r != null && typeof r === 'object' && typeof (r as FlakeCorpusRun).run_id === 'string',
+  );
 }
 
 const asJson = process.argv.includes('--json');

--- a/src/eval/improver/knowledgeFeedbackCli.ts
+++ b/src/eval/improver/knowledgeFeedbackCli.ts
@@ -5,26 +5,22 @@
  *   tsx src/eval/improver/knowledgeFeedbackCli.ts [--json]
  */
 
-import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { KNOWLEDGE_BASE } from '../../tools/xppKnowledge.js';
 import { buildKnowledgeProposals, renderKnowledgeProposals } from './knowledgeFeedback.js';
 import type { CorpusRun } from './cluster.js';
+import { loadJsonRecords } from './corpusIO.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
 
 function loadRuns(): CorpusRun[] {
   const dir = path.join(REPO_ROOT, 'eval', 'corpus', 'runs');
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter(f => f.endsWith('.json'))
-    .map(f => {
-      try { return JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')) as CorpusRun; }
-      catch { return null; }
-    })
-    .filter((r): r is CorpusRun => r != null && typeof r.classification === 'string');
+  return loadJsonRecords(
+    dir,
+    (r): r is CorpusRun => r != null && typeof r === 'object' && typeof (r as CorpusRun).classification === 'string',
+  );
 }
 
 const asJson = process.argv.includes('--json');

--- a/src/eval/improver/reportCli.ts
+++ b/src/eval/improver/reportCli.ts
@@ -4,26 +4,26 @@
  * pass-rates and the headline tool-defect rate.
  */
 
-import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { buildReport, renderReport, type RunForReport } from './report.js';
+import { loadJsonRecords } from './corpusIO.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
 
 function loadLatestPerCase(): RunForReport[] {
   const dir = path.join(REPO_ROOT, 'eval', 'corpus', 'runs');
-  if (!fs.existsSync(dir)) return [];
+  const records = loadJsonRecords(
+    dir,
+    (r): r is RunForReport & { run_id: string } =>
+      r != null && typeof r === 'object' &&
+      !!(r as any).case_id && typeof (r as any).classification === 'string',
+  );
   const latest = new Map<string, RunForReport & { run_id: string }>();
-  for (const f of fs.readdirSync(dir)) {
-    if (!f.endsWith('.json')) continue;
-    try {
-      const r = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
-      if (!r.case_id || typeof r.classification !== 'string') continue;
-      const prev = latest.get(r.case_id);
-      if (!prev || r.run_id > prev.run_id) latest.set(r.case_id, r);
-    } catch { /* skip */ }
+  for (const r of records) {
+    const prev = latest.get(r.case_id);
+    if (!prev || r.run_id > prev.run_id) latest.set(r.case_id, r);
   }
   return [...latest.values()];
 }

--- a/tests/eval/corpusIO.test.ts
+++ b/tests/eval/corpusIO.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Corpus record loading (docs/AGENT_EVAL_LOOP.md §10) — BOM tolerance.
+ *
+ * Regression: every improver CLI (`eval:clusters`, `eval:report`, `eval:brief`,
+ * `eval:flakes`, `eval:knowledge`) parsed `eval/corpus/runs/*.json` with a bare
+ * `JSON.parse(fs.readFileSync(f, 'utf8'))` wrapped in `try { } catch { return null }`.
+ * Several implementer-written corpus records carry a leading UTF-8 BOM (observed
+ * 2026-07-08: 52 of 60 files in eval/corpus/runs/), which `JSON.parse` rejects —
+ * and the bare catch swallowed the failure silently, so `npm run eval:clusters`
+ * reported "Loaded 8 corpus run(s)" when 60 were on disk, with no error surfaced.
+ * That starved every downstream cluster/priority/report computation of ~87% of the
+ * evidence. Fixed by stripping a leading BOM before parsing.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { stripBom, readJsonLenient, loadJsonRecords } from '../../src/eval/improver/corpusIO';
+
+describe('stripBom', () => {
+  it('removes a leading UTF-8 BOM character', () => {
+    expect(stripBom('﻿{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('is a no-op when there is no BOM', () => {
+    expect(stripBom('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('is a no-op on an empty string', () => {
+    expect(stripBom('')).toBe('');
+  });
+});
+
+describe('readJsonLenient', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'corpusio-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('parses a plain UTF-8 JSON file', () => {
+    const f = path.join(dir, 'plain.json');
+    fs.writeFileSync(f, '{"run_id":"a","classification":"PASS"}', 'utf8');
+    expect(readJsonLenient(f)).toEqual({ run_id: 'a', classification: 'PASS' });
+  });
+
+  it('parses a JSON file written with a leading UTF-8 BOM (the corpus writer\'s actual output)', () => {
+    const f = path.join(dir, 'bom.json');
+    fs.writeFileSync(f, '﻿{"run_id":"b","classification":"TOOL_DEFECT"}', 'utf8');
+    expect(readJsonLenient(f)).toEqual({ run_id: 'b', classification: 'TOOL_DEFECT' });
+  });
+
+  it('still throws on genuinely malformed JSON (BOM stripping does not mask real corruption)', () => {
+    const f = path.join(dir, 'broken.json');
+    fs.writeFileSync(f, '﻿{not valid json', 'utf8');
+    expect(() => readJsonLenient(f)).toThrow();
+  });
+});
+
+describe('loadJsonRecords', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'corpusio-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const isCorpusRun = (r: unknown): r is { run_id: string; classification: string } =>
+    r != null && typeof r === 'object' && typeof (r as any).classification === 'string';
+
+  it('returns [] when the directory does not exist', () => {
+    expect(loadJsonRecords(path.join(dir, 'does-not-exist'), isCorpusRun)).toEqual([]);
+  });
+
+  it('loads BOM and non-BOM records alike, skipping non-.json and malformed files', () => {
+    fs.writeFileSync(path.join(dir, 'a.json'), '{"run_id":"a","classification":"PASS"}', 'utf8');
+    fs.writeFileSync(path.join(dir, 'b.json'), '﻿{"run_id":"b","classification":"TOOL_DEFECT"}', 'utf8');
+    fs.writeFileSync(path.join(dir, 'c.json'), '﻿{not json', 'utf8');
+    fs.writeFileSync(path.join(dir, 'notes.txt'), '{"run_id":"d","classification":"PASS"}', 'utf8');
+    fs.writeFileSync(path.join(dir, 'd.json'), '{"run_id":"e"}', 'utf8'); // fails isValid (no classification)
+
+    const records = loadJsonRecords(dir, isCorpusRun);
+    const runIds = records.map(r => r.run_id).sort();
+    expect(runIds).toEqual(['a', 'b']);
+  });
+
+  it('demonstrates the regression this fixes: a naive readdir+JSON.parse+bare-catch loader silently drops every BOM file', () => {
+    fs.writeFileSync(path.join(dir, 'a.json'), '{"run_id":"a","classification":"PASS"}', 'utf8');
+    fs.writeFileSync(path.join(dir, 'b.json'), '﻿{"run_id":"b","classification":"TOOL_DEFECT"}', 'utf8');
+
+    const naiveLoaded = fs.readdirSync(dir)
+      .filter(f => f.endsWith('.json'))
+      .map(f => {
+        try { return JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')); }
+        catch { return null; }
+      })
+      .filter((r): r is { run_id: string } => r != null);
+    expect(naiveLoaded.length).toBe(1); // the bug: BOM file silently dropped
+
+    const fixedLoaded = loadJsonRecords(dir, isCorpusRun);
+    expect(fixedLoaded.length).toBe(2); // the fix: both records load
+  });
+});


### PR DESCRIPTION
## Summary
- 52 of 60 files in `eval/corpus/runs/` carry a leading UTF-8 BOM (the implementer runs on Windows). `JSON.parse` rejects a leading BOM, and every improver CLI (`eval:clusters`, `eval:report`, `eval:brief`, `eval:flakes`, `eval:knowledge`) parsed corpus files with a bare `JSON.parse(fs.readFileSync(f, 'utf8'))` wrapped in `try {} catch { return null }` — the parse failure was silently swallowed, so `npm run eval:clusters` reported "Loaded 8 corpus run(s)" when 60 were on disk, starving every downstream cluster/priority/report computation of ~87% of the evidence with no error surfaced.
- Adds `src/eval/improver/corpusIO.ts` (`stripBom` / `readJsonLenient` / `loadJsonRecords`) and wires it into all 5 improver CLIs (`cli.ts`, `reportCli.ts`, `knowledgeFeedbackCli.ts`, `flakeDetectionCli.ts`, `fixBriefCli.ts`).
- This is a prerequisite for accurate corpus triage — every other cluster-priority number in this eval loop was computed on the corrupted 8-file subset until this fix.

## Evidence
- `eval/corpus/runs/*.json` — 52/60 files start with `EF BB BF` (verified via a byte-level scan of the directory).
- Before: `npm run eval:clusters` → `Loaded 8 corpus run(s).`
- After: `npm run eval:clusters` → `Loaded 59 corpus run(s).` (the remaining 1 of 60 is a genuinely malformed file, correctly skipped).

## Test plan
- [x] New `tests/eval/corpusIO.test.ts` — covers `stripBom`, `readJsonLenient` (plain / BOM / malformed), and `loadJsonRecords` (missing dir, mixed BOM/non-BOM/invalid files, and a regression test that demonstrates the naive loader silently drops BOM files while the fixed one doesn't).
- [x] `npx vitest run` — full suite green (102 files / 1528 tests).
- [x] Manually re-ran all 5 `npm run eval:*` CLIs post-fix; all load 59 records without error.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV