### PR TITLE
fix(eval-oracle): canonicalise X++ source indentation before golden diffing

### DIFF
--- a/src/eval/oracle/normalize.ts
+++ b/src/eval/oracle/normalize.ts
@@ -16,6 +16,7 @@
  */
 
 import { parseStringPromise } from 'xml2js';
+import { reindentXppSource } from '../../utils/xppFormat.js';
 
 /**
  * Built-in ignores applied to every document (in addition to per-case globs).
@@ -104,12 +105,42 @@ function isIgnored(path: string, matchers: RegExp[]): boolean {
 }
 
 /**
+ * Is this path an X++ source-code element (`.../Source` or `.../Declaration`)?
+ * These hold CDATA method bodies / class declarations — X++ is whitespace-
+ * insensitive for indentation, so two builds that differ only in indent depth
+ * are semantically identical and must not register as a `golden_match` diff
+ * (see `canonicalizeXppSourceText` below).
+ */
+function isXppSourcePath(pathPrefix: string): boolean {
+  return /\/(Source|Declaration)$/.test(pathPrefix);
+}
+
+/**
+ * Re-derive indentation from brace depth alone (baseDepth 0), discarding
+ * whatever indentation convention the text actually used. Applied identically
+ * to both the golden and the actual side of a diff, so — per §6.2 of
+ * docs/AGENT_EVAL_LOOP.md ("canonicalise element ordering and whitespace") —
+ * two method bodies with identical tokens but different indentation compare
+ * equal. Reuses the same brace-depth algorithm the generators use to emit
+ * X++ source (src/utils/xppFormat.ts), so this is a comparison-time-only
+ * canonicalisation — it never rewrites a stored artifact.
+ */
+function canonicalizeXppSourceText(s: string): string {
+  return reindentXppSource(s, 0);
+}
+
+/**
  * Normalize text content: CRLF -> LF (the C# bridge writes CRLF into <Source>
  * CDATA; a golden authored or diffed on a different platform may use LF — that
- * is a whitespace-style difference, not a semantic one) then trim.
+ * is a whitespace-style difference, not a semantic one) then trim. X++ source
+ * elements (`Source`/`Declaration`) additionally get indentation canonicalised
+ * (see `canonicalizeXppSourceText`) since X++ doesn't care about indent depth.
  */
-function normalizeText(s: string): string {
-  return s.replace(/\r\n/g, '\n').trim();
+function normalizeText(s: string, pathPrefix?: string): string {
+  const crlfNormalized = s.replace(/\r\n/g, '\n').trim();
+  return pathPrefix && isXppSourcePath(pathPrefix)
+    ? canonicalizeXppSourceText(crlfNormalized)
+    : crlfNormalized;
 }
 
 /** A node's OWN Name/DataField, if any (no recursion). */
@@ -204,7 +235,7 @@ function walk(
 
   // Leaf: a plain string is element text.
   if (typeof node === 'string') {
-    const v = normalizeText(node);
+    const v = normalizeText(node, pathPrefix);
     if (v !== '' && !isIgnored(pathPrefix, matchers)) out.set(pathPrefix, canonicalizePrefix(v, prefix));
     return;
   }
@@ -216,7 +247,7 @@ function walk(
   if ('_' in obj || '$' in obj) {
     emitAttrs(obj.$ as Record<string, unknown> | undefined, pathPrefix, out, matchers, prefix);
     if (typeof obj._ === 'string') {
-      const v = normalizeText(obj._);
+      const v = normalizeText(obj._, pathPrefix);
       if (v !== '' && !isIgnored(pathPrefix, matchers)) out.set(pathPrefix, canonicalizePrefix(v, prefix));
     }
   }

--- a/tests/eval/oracle.test.ts
+++ b/tests/eval/oracle.test.ts
@@ -404,3 +404,126 @@ describe('prefix-agnostic golden comparison (regression: eval/corpus/runs/2026-0
     expect(res.score.golden_match).toBe(1);
   });
 });
+
+// Regression: eval/corpus/runs/2026-07-07T05__L2-dimension-basic__cb1b73d.json and
+// eval/corpus/runs/2026-07-06T19__L2-business-event-basic__cb1b73d.json both scored
+// golden_match=0 (classified TOOL_DEFECT) even though `build` and `bp_clean` passed and
+// the generated Method/Source text was semantically IDENTICAL to the golden — the only
+// delta was indentation depth (e.g. golden's method signature/brace at column 0, actual's
+// at column 4, with every nested line shifted by the same one-level offset). X++ is
+// whitespace-insensitive for indentation, and docs/AGENT_EVAL_LOOP.md §6.2 already commits
+// the oracle to "canonicalise element ordering and whitespace" — but normalizeText() only
+// did CRLF normalisation + trim, so any indentation-convention mismatch (tool vs. golden,
+// or even the D365FO metadata SDK's own on-save reformatting, which is opaque to this repo)
+// spuriously failed golden_match. Fixed by re-deriving indentation from brace depth alone
+// (reusing src/utils/xppFormat.ts's reindentXppSource, baseDepth 0) for `Source`/
+// `Declaration` text specifically before comparing.
+describe('X++ source indentation is not a golden_match diff (regression: L2-dimension-basic / L2-business-event-basic)', () => {
+  const DIMENSION_GOLDEN = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>PFXDemoNoteHeader</Name>
+  <SourceCode>
+    <Methods>
+      <Method>
+        <Name>dimensionDisplayValue</Name>
+        <Source><![CDATA[
+public display str dimensionDisplayValue()
+{
+    DimensionAttributeValueSetStorage dimStorage;
+
+    if (!this.DefaultDimension)
+    {
+        return '';
+    }
+
+    dimStorage = DimensionAttributeValueSetStorage::find(this.DefaultDimension);
+
+    return dimStorage.toString();
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxTable>`;
+
+  // Same method, byte-identical tokens, but the tool's actual bridge/addMethod output
+  // (captured verbatim in the corpus record) indents the brace/body one level deeper.
+  const DIMENSION_ACTUAL = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>PFXDemoNoteHeader</Name>
+  <SourceCode>
+    <Methods>
+      <Method>
+        <Name>dimensionDisplayValue</Name>
+        <Source><![CDATA[
+public display str dimensionDisplayValue()
+    {
+        DimensionAttributeValueSetStorage dimStorage;
+
+        if (!this.DefaultDimension)
+        {
+            return '';
+        }
+
+        dimStorage = DimensionAttributeValueSetStorage::find(this.DefaultDimension);
+
+        return dimStorage.toString();
+    }
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxTable>`;
+
+  it('normalizeAotXml: a Method/Source that differs only in indentation canonicalises to the same value', async () => {
+    const golden = await normalizeAotXml(DIMENSION_GOLDEN);
+    const actual = await normalizeAotXml(DIMENSION_ACTUAL);
+    const path = 'AxTable/SourceCode/Methods/Method[dimensionDisplayValue]/Source';
+    expect(golden.get(path)).toBeDefined();
+    expect(golden.get(path)).toBe(actual.get(path));
+    expect(diffNormalized(golden, actual).matched).toBe(true);
+  });
+
+  it('evaluate(): golden_match=1 for an indentation-only difference in a table display method', async () => {
+    const res = await evaluate({
+      caseSpec: { id: 'L2-dimension-basic', tier: 2 },
+      actualXml: DIMENSION_ACTUAL,
+      goldenXml: DIMENSION_GOLDEN,
+      build: { succeeded: true, bpWarnings: [] },
+    });
+    expect(res.goldenDiff.changed).toEqual([]);
+    expect(res.score.golden_match).toBe(1);
+  });
+
+  it('WITHOUT indentation canonicalisation the same pair still mismatches — proves the fix is load-bearing', () => {
+    // Direct string compare (what normalizeText did before the fix): CRLF-normalise + trim
+    // only, no re-indent. The two CDATA bodies differ byte-for-byte on indentation alone.
+    const rawGolden = DIMENSION_GOLDEN.match(/<!\[CDATA\[([\s\S]*?)\]\]>/)![1].trim();
+    const rawActual = DIMENSION_ACTUAL.match(/<!\[CDATA\[([\s\S]*?)\]\]>/)![1].trim();
+    expect(rawGolden).not.toBe(rawActual);
+  });
+
+  it('a genuinely different method BODY (not just indentation) still correctly mismatches', async () => {
+    const differentBody = DIMENSION_ACTUAL.replace(
+      "return dimStorage.toString();",
+      "return 'wrong';",
+    );
+    const res = await evaluate({
+      caseSpec: { id: 'L2-dimension-basic', tier: 2 },
+      actualXml: differentBody,
+      goldenXml: DIMENSION_GOLDEN,
+      build: { succeeded: true, bpWarnings: [] },
+    });
+    expect(res.score.golden_match).toBe(0);
+    expect(res.goldenDiff.changed.length).toBeGreaterThan(0);
+  });
+
+  it('only applies indentation canonicalisation to Source/Declaration text, not arbitrary element text', async () => {
+    // A Label containing brace-like characters must still compare literally.
+    const xmlA = `<AxTable><Name>T</Name><Label>{weird} label</Label></AxTable>`;
+    const xmlB = `<AxTable><Name>T</Name><Label>{ weird } label</Label></AxTable>`;
+    const a = await normalizeAotXml(xmlA);
+    const b = await normalizeAotXml(xmlB);
+    expect(a.get('AxTable/Label')).not.toBe(b.get('AxTable/Label'));
+  });
+});


### PR DESCRIPTION
## Summary
- `golden_match` compared `Method/Source` and `SourceCode/Declaration` CDATA text almost byte-for-byte (`normalizeText` only did CRLF normalisation + `.trim()`). X++ is whitespace-insensitive for indentation, so two build-clean, reference-clean, semantically-identical method bodies that differ only in indent depth spuriously failed `golden_match` and were misclassified `TOOL_DEFECT`/`VALIDATOR_GAP` — burning improver cycles chasing a formatting artifact instead of a real defect.
- `docs/AGENT_EVAL_LOOP.md` §6.2 already commits the oracle to "canonicalise element ordering **and whitespace**" — this closes that gap by re-deriving indentation from brace depth alone for `Source`/`Declaration` text specifically, reusing the existing `src/utils/xppFormat.ts` `reindentXppSource` helper (`baseDepth 0`). Comparison-time only — never rewrites a stored artifact.

## Root cause (confirmed, not guessed)
Traced `L2-dimension-basic`'s corpus record end-to-end: the golden and the recorded "actual" `dimensionDisplayValue()` method are token-for-token identical, differing only in indent depth (golden: signature/brace at column 0, body at 4 spaces; actual: signature at column 0, brace at 4, body at 8 — a systematic one-level offset). `L2-business-event-basic`'s corpus record already carries a prior improver's `root_cause_hypothesis` explicitly recommending this exact fix ("`eval/src/eval/oracle/normalize.ts` could dedent each Method/Source block to a common minimum-indentation baseline before line-diffing").

## Evidence (verified against the full corpus, not just the two cases above)
16 of 26 recorded `changed` diffs on `Source`/`Declaration` paths across 8 distinct `run_id`s become byte-equal under this canonicalisation:
- `eval/corpus/runs/2026-07-07T05__L2-dimension-basic__cb1b73d.json` (1/1)
- `eval/corpus/runs/2026-07-06T19__L2-business-event-basic__cb1b73d.json` (5/5)
- `eval/corpus/runs/2026-07-07T04__L2-coc-extension__cb1b73d.json` (2/2)
- `eval/corpus/runs/2026-07-07T05__L2-event-handler-basic__cb1b73d.json` (1/1)
- `eval/corpus/runs/2026-07-07T07__L2-form-over-view__cb1b73d.json` (1/1)
- `eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d.json` (3/7 — partial, genuine other defects remain)
- `eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d.json` (2/2)
- `eval/corpus/runs/2026-07-07T16__L4-ssrs-report-basic__cb1b73d.json` (1/4 — partial)

Genuinely different content still correctly mismatches (verified, not assumed): `L1-class-basic` (missing `PFX` prefix — unrelated bug) and `L2-numberseq-basic` stay mismatched (0/1, 0/2) after canonicalisation.

## Test plan
- [x] `tests/eval/oracle.test.ts` — new `describe` block: canonicalised `normalizeAotXml`/`evaluate()` match on an indentation-only diff (using the actual `L2-dimension-basic` corpus text); a synthetic "different method body" case still correctly mismatches; a `Label` containing brace characters is confirmed NOT canonicalised (scope guard — only `Source`/`Declaration` paths are affected).
- [x] Confirmed the new tests are load-bearing: reverted `normalize.ts` only and re-ran — 2 tests fail as expected, proving the fix (not the test) does the work.
- [x] `npx vitest run` — full suite green (101 files / 1519 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV