### PR TITLE
fix(form-patterns): scaffold datasource method stubs into the SourceCode mirror

### DIFF
--- a/src/knowledge/formPatterns/methodStubs.ts
+++ b/src/knowledge/formPatterns/methodStubs.ts
@@ -184,8 +184,14 @@ function methodXml(stub: MethodStub, indent: string): string {
  * Inject method stubs into AxForm XML (string-level, format-preserving):
  *  - form methods: appended after the classDeclaration </Method> inside
  *    SourceCode > Methods
- *  - datasource methods: inserted as a <Methods> block right after the
- *    primary AxFormDataSource's <Name> (merged when one already exists)
+ *  - datasource methods: inserted into the SourceCode > DataSources >
+ *    DataSource > Methods mirror section (merged when a <DataSource> for the
+ *    target datasource already exists), NOT the top-level
+ *    DataSources > AxFormDataSource element — no shipped D365FO form ever
+ *    populates a <Methods> child there, and doing so desyncs xppc's
+ *    positional schema binding for that element (the following <Table> then
+ *    deserializes as empty — "datasource 'X' refers to table '' which does
+ *    not exist" — even though the emitted <Table> text is correct).
  *
  * Returns the new XML and the names of injected methods.
  */
@@ -198,23 +204,89 @@ export function injectMethodStubs(
   let result = xml;
   const injected: string[] = [];
 
-  // Insert a <Methods> block right after a datasource's <Name>. Returns the
-  // updated XML (or the original when the datasource/methods aren't found).
+  // Insert a <Methods> block for `targetDs` into the SourceCode mirror's
+  // <DataSources> collection (self-closed/empty on a fresh scaffold; may
+  // already contain entries on a cloned-from-real-form source, or from a
+  // prior call to this same function for a different datasource). Returns
+  // the updated XML (or the original when SourceCode/DataSources or the
+  // methods list is missing).
   const injectDsMethods = (src: string, targetDs: string, methods: MethodStub[]): string => {
     if (methods.length === 0 || !targetDs) return src;
-    // Search from the real <DataSources> region so a same-named SourceCode method
-    // can't be mistaken for the datasource's <Name>.
-    const dsRegion = src.indexOf('<AxFormDataSource');
-    const nameTag = `<Name>${targetDs}</Name>`;
-    const nameIdx = src.indexOf(nameTag, dsRegion === -1 ? 0 : dsRegion);
-    if (nameIdx === -1) return src;
-    const insertAt = nameIdx + nameTag.length;
-    const block =
-      `\n\t\t\t<Methods>\n` +
-      methods.map((s) => methodXml(s, '\t\t\t\t')).join('') +
-      `\t\t\t</Methods>`;
+
+    // Scope to <SourceCode>...</SourceCode> so the top-level DataSources
+    // collection (which follows SourceCode in every template) is never touched.
+    const scStart = src.indexOf('<SourceCode>');
+    const scEnd = scStart === -1 ? -1 : src.indexOf('</SourceCode>', scStart);
+    if (scStart === -1 || scEnd === -1) return src;
+
+    // The SourceCode mirror's own <DataSources> — self-closed when empty
+    // (`<DataSources xmlns="" />`), open when it already carries entries.
+    const dsOpenMatch = /<DataSources([^>]*?)(\/>|>)/.exec(src.slice(scStart, scEnd));
+    if (!dsOpenMatch) return src;
+    const dsOpenStart = scStart + dsOpenMatch.index;
+    const dsOpenEnd = dsOpenStart + dsOpenMatch[0].length;
+    const dsAttrs = dsOpenMatch[1].trimEnd(); // e.g. ` xmlns=""` (drop any space before the `/>`/`>`)
+    const selfClosed = dsOpenMatch[2] === '/>';
+
+    const methodsBlock =
+      `\t\t\t\t<Methods>\n` +
+      methods.map((s) => methodXml(s, '\t\t\t\t\t')).join('') +
+      `\t\t\t\t</Methods>\n`;
     injected.push(...methods.map((s) => `${targetDs}.${s.name}`));
-    return src.slice(0, insertAt) + block + src.slice(insertAt);
+
+    if (selfClosed) {
+      // Expand the empty placeholder into a single-entry collection.
+      const dataSourceBlock =
+        `<DataSources${dsAttrs}>\n` +
+        `\t\t\t<DataSource>\n` +
+        `\t\t\t\t<Name>${targetDs}</Name>\n` +
+        methodsBlock +
+        `\t\t\t</DataSource>\n` +
+        `\t\t</DataSources>`;
+      return src.slice(0, dsOpenStart) + dataSourceBlock + src.slice(dsOpenEnd);
+    }
+
+    // Already open: find the closing </DataSources> for THIS collection
+    // (bounded to the SourceCode region so a later top-level tag can't match).
+    const dsCloseIdx = src.indexOf('</DataSources>', dsOpenEnd);
+    if (dsCloseIdx === -1 || dsCloseIdx > scEnd) return src;
+
+    const dsRegion = src.slice(dsOpenEnd, dsCloseIdx);
+    const nameTag = `<Name>${targetDs}</Name>`;
+    const nameIdxInRegion = dsRegion.indexOf(nameTag);
+
+    if (nameIdxInRegion === -1) {
+      // No existing <DataSource> for this datasource — append a new one just
+      // before the collection's closing tag. Strip the closing tag's own
+      // trailing indent first so appending doesn't compound it.
+      const before = src.slice(0, dsCloseIdx).replace(/[ \t]+$/, '');
+      const dataSourceBlock =
+        `\t\t\t<DataSource>\n` +
+        `\t\t\t\t<Name>${targetDs}</Name>\n` +
+        methodsBlock +
+        `\t\t\t</DataSource>\n\t\t`;
+      return before + dataSourceBlock + src.slice(dsCloseIdx);
+    }
+
+    // Existing <DataSource> found. Merge into its <Methods> if present,
+    // otherwise insert a fresh <Methods> block right after <Name>.
+    const nameIdxAbs = dsOpenEnd + nameIdxInRegion;
+    const afterNameAbs = nameIdxAbs + nameTag.length;
+    const existingMethodsMatch = /^\s*<Methods\s*\/>|^\s*<Methods>([\s\S]*?)<\/Methods>/.exec(
+      src.slice(afterNameAbs, dsCloseIdx),
+    );
+    if (existingMethodsMatch) {
+      const matchStart = afterNameAbs + existingMethodsMatch.index;
+      const matchEnd = matchStart + existingMethodsMatch[0].length;
+      const replacement =
+        `\n\t\t\t\t<Methods>\n` +
+        methods.map((s) => methodXml(s, '\t\t\t\t\t')).join('') +
+        (existingMethodsMatch[1] ?? '') +
+        `\t\t\t\t</Methods>`;
+      return src.slice(0, matchStart) + replacement + src.slice(matchEnd);
+    }
+    const inserted = `\n${methodsBlock.replace(/\n$/, '')}`;
+    return src.slice(0, afterNameAbs) + inserted + src.slice(afterNameAbs);
   };
 
   if (stubs.formMethods.length > 0) {

--- a/tests/knowledge/formPatterns/methodStubs.test.ts
+++ b/tests/knowledge/formPatterns/methodStubs.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression: generate_object(mode="scaffold", objectType="form",
+ * includeMethodStubs=true) injected the requested per-datasource method stubs
+ * (e.g. active/validateWrite/initValue) directly inside the TOP-LEVEL
+ * <DataSources><AxFormDataSource> element, immediately after <Name> and
+ * BEFORE <Table> — a location no shipped D365FO form ever populates (verified
+ * byte-for-byte against real standard forms, e.g. CustParameters/
+ * BankParameters, by a prior improver run). Real datasource method overrides
+ * live exclusively in the SourceCode mirror section
+ * (SourceCode/DataSources/DataSource/Methods/Method).
+ *
+ * Injecting a <Methods> element ahead of <Table> inside AxFormDataSource
+ * desyncs xppc's positional schema binding for that element, so <Table>
+ * (present and byte-correct in the file) deserializes as an empty table
+ * reference — "datasource 'X' refers to table '' which does not exist" — a
+ * BUILD FAILURE, even though object_patterns(domain=form, action=validate)
+ * reports zero errors on the broken file.
+ *
+ * Confirmed across three form patterns (TableOfContents, DetailsTransaction,
+ * DetailsMaster) in the corpus:
+ *   eval/corpus/runs/2026-07-07T12__L3-numberseq-module-slice__cb1b73d.json
+ *   eval/corpus/runs/2026-07-07T15__L4-master-security-slice__cb1b73d.json
+ * (both cite an identical prior finding on DetailsTransaction).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FormPatternTemplates } from '../../../src/utils/formPatternTemplates';
+import { injectMethodStubs, methodStubsForPattern } from '../../../src/knowledge/formPatterns/methodStubs';
+
+/** Byte-offset span of a top-level element by tag name (first occurrence). */
+function spanOf(xml: string, openTag: string, closeTag: string): { start: number; end: number } {
+  const start = xml.indexOf(openTag);
+  if (start < 0) throw new Error(`${openTag} not found`);
+  const end = xml.indexOf(closeTag, start);
+  if (end < 0) throw new Error(`${closeTag} not found (unclosed ${openTag})`);
+  return { start, end: end + closeTag.length };
+}
+
+describe('injectMethodStubs — datasource method placement', () => {
+  it('places datasource method stubs in SourceCode/DataSources/DataSource, NOT the top-level AxFormDataSource', () => {
+    const stubs = methodStubsForPattern('DetailsMaster', 'CustTable');
+    const xml = FormPatternTemplates.buildDetailsMaster({
+      formName: 'MyForm',
+      dsName: 'CustTable',
+      dsTable: 'CustTable',
+      gridFields: ['AccountNum'],
+    });
+    const result = injectMethodStubs(xml, stubs, 'CustTable');
+
+    // The top-level <DataSources><AxFormDataSource> element must be untouched:
+    // Name immediately followed by Table, no <Methods> in between (this is the
+    // exact desync that broke xppc's positional schema binding).
+    const topLevelDs = spanOf(result.xml, '\t<DataSources>', '\n\t</DataSources>');
+    const topLevelDsXml = result.xml.slice(topLevelDs.start, topLevelDs.end);
+    expect(topLevelDsXml).not.toContain('<Methods>');
+    expect(topLevelDsXml.indexOf('<Name>CustTable</Name>'))
+      .toBeLessThan(topLevelDsXml.indexOf('<Table>CustTable</Table>'));
+    // Table must immediately follow Name (no injected element between them).
+    expect(topLevelDsXml).toMatch(/<Name>CustTable<\/Name>\s*<Table>CustTable<\/Table>/);
+
+    // The SourceCode mirror section must carry the injected methods instead.
+    const sourceCodeSpan = spanOf(result.xml, '<SourceCode>', '</SourceCode>');
+    const sourceCodeXml = result.xml.slice(sourceCodeSpan.start, sourceCodeSpan.end);
+    expect(sourceCodeXml).toContain('<DataSource>');
+    expect(sourceCodeXml).toContain('<Name>CustTable</Name>');
+    expect(sourceCodeXml).toContain('public int active()');
+    expect(sourceCodeXml).toContain('public boolean validateWrite()');
+
+    // And they must be nested DataSources > DataSource > Methods > Method, not
+    // a bare Methods sibling.
+    expect(sourceCodeXml).toMatch(
+      /<DataSources[^>]*>\s*<DataSource>\s*<Name>CustTable<\/Name>\s*<Methods>/,
+    );
+  });
+
+  it('still reports the injected datasource methods by name', () => {
+    const stubs = methodStubsForPattern('DetailsMaster', 'CustTable');
+    const xml = FormPatternTemplates.buildDetailsMaster({
+      formName: 'MyForm',
+      dsName: 'CustTable',
+      dsTable: 'CustTable',
+      gridFields: ['AccountNum'],
+    });
+    const result = injectMethodStubs(xml, stubs, 'CustTable');
+    expect(result.injected).toContain('CustTable.active');
+    expect(result.injected).toContain('CustTable.validateWrite');
+  });
+
+  it('handles BOTH a header and a lines datasource (DetailsTransaction) without corrupting the top-level DataSources collection', () => {
+    const stubs = methodStubsForPattern('DetailsTransaction', 'Header', 'Lines');
+    const xml = FormPatternTemplates.buildDetailsTransaction({
+      formName: 'MyForm',
+      dsName: 'Header',
+      dsTable: 'Header',
+      linesDsName: 'Lines',
+      linesDsTable: 'Lines',
+      gridFields: ['LineNum'],
+    });
+    const result = injectMethodStubs(xml, stubs, 'Header', 'Lines');
+
+    const topLevelDs = spanOf(result.xml, '\t<DataSources>', '\n\t</DataSources>');
+    const topLevelDsXml = result.xml.slice(topLevelDs.start, topLevelDs.end);
+    expect(topLevelDsXml).not.toContain('<Methods>');
+
+    const sourceCodeSpan = spanOf(result.xml, '<SourceCode>', '</SourceCode>');
+    const sourceCodeXml = result.xml.slice(sourceCodeSpan.start, sourceCodeSpan.end);
+    // Both datasources' stubs land in the SourceCode mirror, each under its own <DataSource>.
+    expect(sourceCodeXml.match(/<DataSource>/g)?.length).toBe(2);
+    expect(result.injected).toContain('Header.active');
+    expect(result.injected).toContain('Lines.initValue');
+  });
+
+  it('the datasource-stub-injected XML still passes the pattern validator (no new errors)', async () => {
+    const { validateFormPatternXml } = await import('../../../src/validation/formPatternValidator');
+    const stubs = methodStubsForPattern('SimpleList', 'TestDS');
+    const xml = FormPatternTemplates.buildSimpleList({
+      formName: 'MyForm',
+      dsName: 'TestDS',
+      dsTable: 'TestTable',
+      gridFields: ['F1'],
+    });
+    const result = injectMethodStubs(xml, stubs, 'TestDS');
+    const report = await validateFormPatternXml(result.xml);
+    expect(report.violations.filter((v) => v.severity === 'error')).toEqual([]);
+  });
+
+  it('merges into an existing SourceCode/DataSource entry (clone-from-real-form scenario) rather than duplicating <DataSource>', () => {
+    // Simulate a form whose SourceCode mirror already carries an entry for
+    // the datasource (e.g. cloned from a real shipped form that already
+    // overrides a different method on it).
+    const baseStubs = methodStubsForPattern('DetailsMaster', 'CustTable');
+    const xml = FormPatternTemplates.buildDetailsMaster({
+      formName: 'MyForm',
+      dsName: 'CustTable',
+      dsTable: 'CustTable',
+      gridFields: ['AccountNum'],
+    });
+    const first = injectMethodStubs(xml, { formMethods: [], dataSourceMethods: [baseStubs.dataSourceMethods[0]] }, 'CustTable');
+
+    // A second injection targeting the SAME datasource must land inside the
+    // existing <DataSource><Name>CustTable</Name> entry's <Methods>, not
+    // create a second sibling <DataSource>.
+    const second = injectMethodStubs(
+      first.xml,
+      { formMethods: [], dataSourceMethods: [baseStubs.dataSourceMethods[1]] },
+      'CustTable',
+    );
+
+    const sourceCodeSpan = second.xml.slice(
+      second.xml.indexOf('<SourceCode>'),
+      second.xml.indexOf('</SourceCode>'),
+    );
+    expect(sourceCodeSpan.match(/<DataSource>/g)?.length).toBe(1);
+    expect(sourceCodeSpan.match(/<Methods>/g)?.length).toBe(1);
+    expect(sourceCodeSpan).toContain('public int active()');
+    expect(sourceCodeSpan).toContain('public boolean validateWrite()');
+  });
+});


### PR DESCRIPTION
## Summary
- `generate_object(mode="scaffold", objectType="form", includeMethodStubs=true)` injected the requested per-datasource method stubs (`active`/`validateWrite`/`initValue`) directly inside the top-level `DataSources > AxFormDataSource` element, immediately after `<Name>` and BEFORE `<Table>`. No shipped D365FO form ever populates a `<Methods>` child there — real datasource method overrides live exclusively in the `SourceCode > DataSources > DataSource > Methods` mirror section, which the scaffold left as an empty `<DataSources xmlns="" />` placeholder.
- Inserting a `<Methods>` element ahead of `<Table>` desyncs xppc's positional schema binding for `AxFormDataSource`, so the following `<Table>` (present and byte-correct in the file) deserializes as an empty table reference — `"datasource 'X' refers to table '' which does not exist"` — a **build failure** that `object_patterns(domain=form, action=validate)` does not catch (it reported zero errors on the broken file).
- Confirmed across **three** form patterns (TableOfContents, DetailsTransaction, DetailsMaster) in the corpus. This matches this repo's own tracked note ("Form-scaffold Methods misplacement (recurring)" — previously flagged as unfixed).

## Root cause
`injectDsMethods` in `src/knowledge/formPatterns/methodStubs.ts` searched for the datasource's `<Name>` starting from the FIRST `<AxFormDataSource` occurrence (the top-level collection) and spliced a `<Methods>` block right after it — the wrong element entirely.

## Fix
Scopes the search to the `<SourceCode>...</SourceCode>` region and targets its own `<DataSources>` mirror collection instead:
- Expands the self-closed `<DataSources xmlns="" />` placeholder into a `<DataSource><Name>/<Methods>` entry on first use.
- Merges into an existing `<DataSource>` entry (rather than duplicating one) when the SourceCode mirror already carries one for that datasource — covers both the "second datasource on the same form" case (header+lines) and a clone-from-a-real-form source that already has SourceCode-mirror content.
- The top-level `AxFormDataSource` element is left completely untouched (`<Name>` immediately followed by `<Table>`, as every shipped form has it).

## Evidence
- `eval/corpus/runs/2026-07-07T12__L3-numberseq-module-slice__cb1b73d.json`
- `eval/corpus/runs/2026-07-07T15__L4-master-security-slice__cb1b73d.json`

Both carry a detailed `root_cause_hypothesis` from a prior improver/implementer run pinpointing this exact defect, including a byte-for-byte comparison against real shipped forms (CustParameters, BankParameters) confirming the correct element location.

## Test plan
- [x] New `tests/knowledge/formPatterns/methodStubs.test.ts`:
  - Reproduces the bug against `main` (verified failing before the fix): asserts the top-level `AxFormDataSource` has no injected `<Methods>` and `<Name>` is immediately followed by `<Table>`, and that the SourceCode mirror carries the methods instead, correctly nested `DataSources > DataSource > Methods > Method`.
  - Header + lines datasource (DetailsTransaction) — both land in the SourceCode mirror, each under its own `<DataSource>`, top-level collection untouched.
  - Merge path: two stub-injection calls for the same datasource merge into one `<DataSource>` (not a duplicate).
  - Injected XML still passes `validateFormPatternXml` with no new errors.
- [x] `npx vitest run` — full suite green (102 files / 1519 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV