### PR TITLE
fix(eval-corpus): guard against thin/empty evidence in corpus records

### DIFF
--- a/docs/AGENT_EVAL_LOOP.md
+++ b/docs/AGENT_EVAL_LOOP.md
@@ -132,6 +132,16 @@ One record per `(case_id, run_id)`. Store as newline-delimited JSON now; a SQLit
 
 The record is **self-contained evidence** — the improver agent must be able to act on it without access to the original VM session.
 
+**Never write an empty placeholder object into an evidence array.** `build.bpWarnings`,
+`build.errors`, `systest.failures`, and `golden_diff.changed` each carry `N` entries when the
+corresponding count is `N` — but every entry must include the actual `run_bp_check`/`build`/
+`validate_code` output (at minimum a `message`), not `{}`. An empty array (`[]`, zero
+warnings/failures/deltas) is a real, meaningful result; an empty *object inside* a non-empty
+array means "there was one, but nothing was recorded about it" — which makes the record
+unconfirmable by a VM-free improver session (`eval/corpus/schema.json` requires
+`minProperties: 1` on each entry; `npm run eval:evidence-gaps` lists every corpus record that
+violates this, see src/eval/improver/corpusShapeGuard.ts).
+
 ---
 
 ## 6. Golden-metadata oracle (primary correctness signal)

--- a/eval/corpus/schema.json
+++ b/eval/corpus/schema.json
@@ -49,8 +49,8 @@
       "required": ["succeeded"],
       "properties": {
         "succeeded": { "type": "boolean" },
-        "errors": { "type": "array", "items": { "type": "object" } },
-        "bpWarnings": { "type": "array", "items": { "type": "object" } }
+        "errors": { "type": "array", "items": { "type": "object", "minProperties": 1 } },
+        "bpWarnings": { "type": "array", "items": { "type": "object", "minProperties": 1 } }
       }
     },
     "golden_diff": {
@@ -61,7 +61,7 @@
         "matched": { "type": "boolean" },
         "missing": { "type": "array", "items": { "type": "string" } },
         "extra": { "type": "array", "items": { "type": "string" } },
-        "changed": { "type": "array", "items": { "type": "object" } }
+        "changed": { "type": "array", "items": { "type": "object", "minProperties": 1 } }
       }
     },
     "systest": {
@@ -70,7 +70,7 @@
       "properties": {
         "ran": { "type": "boolean" },
         "passed": { "type": ["boolean", "null"] },
-        "failures": { "type": "array", "items": { "type": "object" } }
+        "failures": { "type": "array", "items": { "type": "object", "minProperties": 1 } }
       },
       "required": ["ran"]
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "eval:knowledge": "tsx src/eval/improver/knowledgeFeedbackCli.ts",
     "eval:flakes": "tsx src/eval/improver/flakeDetectionCli.ts",
     "eval:mine": "tsx src/eval/improver/caseMiningCli.ts",
-    "eval:brief": "tsx src/eval/improver/fixBriefCli.ts"
+    "eval:brief": "tsx src/eval/improver/fixBriefCli.ts",
+    "eval:evidence-gaps": "tsx src/eval/improver/evidenceGapCli.ts"
   },
   "keywords": [
     "mcp",

--- a/src/eval/improver/corpusShapeGuard.ts
+++ b/src/eval/improver/corpusShapeGuard.ts
@@ -1,0 +1,113 @@
+/**
+ * Corpus evidence-shape guard (docs/AGENT_EVAL_LOOP.md §5 — "The record is
+ * self-contained evidence — the improver agent must be able to act on it
+ * without access to the original VM session").
+ *
+ * Regression: several corpus records (e.g.
+ * eval/corpus/runs/2026-07-06T16__L0-enum-basic__cc58c3f.json,
+ * eval/corpus/runs/2026-07-07T07__L2-interface-abstract-basic__cb1b73d.json,
+ * eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d.json ×2)
+ * were classified KNOWLEDGE_GAP purely because `score.bp_clean === 0`, but
+ * every entry in `build.bpWarnings` is a literal empty object (`{}`) — the
+ * implementer recorded THAT there were N warnings but not their rule/target/
+ * message, so no improver session (VM-free by design) can ever confirm what
+ * the actual defect was. `eval/corpus/schema.json` allowed this (each item
+ * only required `{"type":"object"}`, satisfied by `{}`), so nothing ever
+ * flagged the gap.
+ *
+ * This module is a pure, VM-free shape check: it flags "thin evidence" —
+ * array-of-object fields (bpWarnings / errors / systest.failures /
+ * golden_diff.changed) whose entries carry zero properties — separately from
+ * classification, so a future improver run (or the implementer, before it
+ * even writes the record) can catch this class of gap immediately instead of
+ * silently losing the evidence, and cluster/report tooling can distinguish
+ * "confirmed defect, no fix yet" from "cannot be confirmed at all — needs a
+ * fresh VM capture".
+ */
+
+/** Where in a corpus record to look for evidence-carrying object arrays. */
+const EVIDENCE_ARRAY_FIELDS: ReadonlyArray<{
+  path: string;
+  get: (record: any) => unknown;
+}> = [
+  { path: 'build.errors', get: (r) => r?.build?.errors },
+  { path: 'build.bpWarnings', get: (r) => r?.build?.bpWarnings },
+  { path: 'systest.failures', get: (r) => r?.systest?.failures },
+  { path: 'golden_diff.changed', get: (r) => r?.golden_diff?.changed },
+];
+
+export interface ThinEvidenceIssue {
+  /** e.g. "build.bpWarnings[0]" */
+  path: string;
+  reason: string;
+}
+
+/** True for a plain object with zero own enumerable properties: `{}`. */
+function isEmptyObject(v: unknown): v is Record<string, never> {
+  return v != null && typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0;
+}
+
+/**
+ * Scan a corpus record's evidence-carrying arrays for entries that are empty
+ * placeholder objects. An empty ARRAY (`[]`) is fine — it means "zero
+ * warnings/failures/deltas", a real, meaningful result. An empty OBJECT
+ * *inside* the array (`{}`) is the defect: "there was one, but we recorded
+ * nothing about it".
+ */
+export function findThinEvidence(record: unknown): ThinEvidenceIssue[] {
+  const issues: ThinEvidenceIssue[] = [];
+  for (const field of EVIDENCE_ARRAY_FIELDS) {
+    const arr = field.get(record);
+    if (!Array.isArray(arr)) continue;
+    arr.forEach((item, i) => {
+      if (isEmptyObject(item)) {
+        issues.push({
+          path: `${field.path}[${i}]`,
+          reason: 'empty object — no rule/message/target/path captured for this entry',
+        });
+      }
+    });
+  }
+  return issues;
+}
+
+/** True when the record has at least one thin-evidence entry. */
+export function hasThinEvidence(record: unknown): boolean {
+  return findThinEvidence(record).length > 0;
+}
+
+/**
+ * True when a record's classification cannot be confirmed purely from what
+ * it contains — its score implies a real signal fired (bp_clean=0, a
+ * golden_diff mismatch, etc.) but the arrays that would explain WHY are
+ * either absent or entirely thin-evidence. Distinct from `hasThinEvidence`:
+ * a record can carry ONE thin entry alongside other well-formed ones and
+ * still be actionable (e.g. golden_diff.changed has real deltas even if one
+ * bpWarnings entry is thin) — this checks whether the record is a total loss.
+ */
+export function isUnconfirmable(record: any): boolean {
+  if (!record || typeof record !== 'object') return false;
+  const classification = record.classification;
+  if (classification === 'PASS' || classification === undefined) return false;
+
+  const score = record.score ?? {};
+  const bpFlaggedButThin =
+    score.bp_clean === 0 &&
+    Array.isArray(record.build?.bpWarnings) &&
+    record.build.bpWarnings.length > 0 &&
+    record.build.bpWarnings.every(isEmptyObject);
+  const goldenFlaggedButThin =
+    score.golden_match === 0 &&
+    Array.isArray(record.golden_diff?.changed) &&
+    record.golden_diff.changed.length > 0 &&
+    record.golden_diff.changed.every(isEmptyObject) &&
+    (record.golden_diff?.missing?.length ?? 0) === 0 &&
+    (record.golden_diff?.extra?.length ?? 0) === 0;
+
+  const noHypothesis =
+    (typeof record.root_cause_hypothesis !== 'string' || record.root_cause_hypothesis.trim() === '') &&
+    (typeof record.suggested_fix_area !== 'string' || record.suggested_fix_area.trim() === '') &&
+    (!Array.isArray(record.evidence_refs) || record.evidence_refs.length === 0);
+
+  return noHypothesis && (bpFlaggedButThin || goldenFlaggedButThin);
+}

--- a/src/eval/improver/evidenceGap.ts
+++ b/src/eval/improver/evidenceGap.ts
@@ -1,0 +1,65 @@
+/**
+ * Evidence-gap report (docs/AGENT_EVAL_LOOP.md §5, §9) — pure logic, VM-free.
+ *
+ * This is the actionable handoff for the gap fixed by
+ * src/eval/improver/corpusShapeGuard.ts: a record can score `bp_clean=0` /
+ * `golden_match=0` yet carry zero diagnostic detail (`build.bpWarnings`
+ * populated with empty `{}` placeholders instead of `{rule, target,
+ * message}`). Such a record cannot be triaged by a VM-free improver session
+ * — it needs a fresh eval-implementer run that captures full detail.
+ */
+
+import { findThinEvidence, isUnconfirmable, type ThinEvidenceIssue } from './corpusShapeGuard.js';
+
+export interface CorpusRunLike {
+  run_id: string;
+  case_id: string;
+  classification: string;
+  [key: string]: unknown;
+}
+
+export interface EvidenceGapReportEntry {
+  run_id: string;
+  case_id: string;
+  classification: string;
+  unconfirmable: boolean;
+  issues: ThinEvidenceIssue[];
+}
+
+export function buildEvidenceGapReport(runs: CorpusRunLike[]): EvidenceGapReportEntry[] {
+  const out: EvidenceGapReportEntry[] = [];
+  for (const r of runs) {
+    const issues = findThinEvidence(r);
+    if (issues.length === 0) continue;
+    out.push({
+      run_id: r.run_id,
+      case_id: r.case_id,
+      classification: r.classification,
+      unconfirmable: isUnconfirmable(r),
+      issues,
+    });
+  }
+  // Unconfirmable-first (needs a VM re-run to unblock at all), then by case_id.
+  return out.sort((a, b) =>
+    Number(b.unconfirmable) - Number(a.unconfirmable) || a.case_id.localeCompare(b.case_id));
+}
+
+export function renderEvidenceGapReport(entries: EvidenceGapReportEntry[]): string {
+  if (entries.length === 0) return 'No thin-evidence corpus records — every non-PASS run carries confirmable detail. 🎉';
+  const lines: string[] = [`# Corpus evidence gaps (${entries.length} run(s))\n`];
+  const unconfirmable = entries.filter(e => e.unconfirmable);
+  if (unconfirmable.length > 0) {
+    lines.push(
+      `${unconfirmable.length} run(s) are UNCONFIRMABLE — classified non-PASS with zero recoverable ` +
+      `diagnostic detail (no root_cause_hypothesis/suggested_fix_area/evidence_refs, and every relevant ` +
+      `evidence array is empty-placeholder-only). These need a fresh eval-implementer VM run for the same ` +
+      `case that captures full bpWarnings/golden_diff detail before an improver session can act on them.\n`,
+    );
+  }
+  for (const e of entries) {
+    lines.push(`${e.unconfirmable ? '[UNCONFIRMABLE]' : '[partial]'} ${e.case_id} — ${e.classification}`);
+    lines.push(`   run: ${e.run_id}`);
+    for (const issue of e.issues) lines.push(`   - ${issue.path}: ${issue.reason}`);
+  }
+  return lines.join('\n');
+}

--- a/src/eval/improver/evidenceGapCli.ts
+++ b/src/eval/improver/evidenceGapCli.ts
@@ -1,0 +1,34 @@
+/**
+ * Evidence-gap CLI — list corpus records whose classification cannot be
+ * confirmed because their evidence-carrying arrays are thin/empty
+ * (docs/AGENT_EVAL_LOOP.md §5, §9). VM-free.
+ *
+ *   tsx src/eval/improver/evidenceGapCli.ts [--json]
+ */
+
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { loadJsonRecords } from './corpusIO.js';
+import { buildEvidenceGapReport, renderEvidenceGapReport, type CorpusRunLike } from './evidenceGap.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+
+function loadRuns(): CorpusRunLike[] {
+  const dir = path.join(REPO_ROOT, 'eval', 'corpus', 'runs');
+  return loadJsonRecords(
+    dir,
+    (r): r is CorpusRunLike => r != null && typeof r === 'object' && typeof (r as CorpusRunLike).classification === 'string',
+  );
+}
+
+const asJson = process.argv.includes('--json');
+const runs = loadRuns();
+const report = buildEvidenceGapReport(runs);
+
+if (asJson) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  console.log(`Loaded ${runs.length} corpus run(s).\n`);
+  console.log(renderEvidenceGapReport(report));
+}

--- a/tests/eval/corpusShapeGuard.test.ts
+++ b/tests/eval/corpusShapeGuard.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Corpus evidence-shape guard (docs/AGENT_EVAL_LOOP.md §5).
+ *
+ * Regression: eval/corpus/runs/2026-07-06T16__L0-enum-basic__cc58c3f.json,
+ * eval/corpus/runs/2026-07-07T07__L2-interface-abstract-basic__cb1b73d.json, and
+ * eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d.json (x2,
+ * the "4-controller"/"5-menuitem" sub-artifacts) were all classified
+ * KNOWLEDGE_GAP purely because `score.bp_clean === 0`, yet `build.bpWarnings`
+ * is populated with literal `{}` placeholders — the corpus's OWN
+ * self-contained-evidence contract (§5) was violated with nothing to catch
+ * it. Fixtures below are the actual recorded shapes (trimmed to the
+ * fields under test) from those four runs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { findThinEvidence, hasThinEvidence, isUnconfirmable } from '../../src/eval/improver/corpusShapeGuard';
+
+describe('findThinEvidence / hasThinEvidence', () => {
+  it('flags every empty-object entry in build.bpWarnings (regression: L0-enum-basic)', () => {
+    const record = {
+      run_id: '2026-07-06T16__L0-enum-basic__cc58c3f',
+      case_id: 'L0-enum-basic',
+      classification: 'KNOWLEDGE_GAP',
+      build: { succeeded: true, errors: [], bpWarnings: [{}] },
+      golden_diff: { matched: true, missing: [], extra: [], changed: [] },
+      score: { build: 1, bp_clean: 0, golden_match: 1, systest: null, tier_weight: 0 },
+    };
+    expect(hasThinEvidence(record)).toBe(true);
+    expect(findThinEvidence(record)).toEqual([
+      { path: 'build.bpWarnings[0]', reason: expect.stringContaining('empty object') },
+    ]);
+  });
+
+  it('flags multiple thin entries (regression: L2-interface-abstract-basic, 3 empty bpWarnings)', () => {
+    const record = {
+      run_id: '2026-07-07T07__L2-interface-abstract-basic__cb1b73d',
+      case_id: 'L2-interface-abstract-basic',
+      classification: 'KNOWLEDGE_GAP',
+      build: { succeeded: true, errors: [], bpWarnings: [{}, {}, {}] },
+      golden_diff: { matched: true, missing: [], extra: [], changed: [] },
+      score: { build: 1, bp_clean: 0, golden_match: 1, systest: null, tier_weight: 2 },
+    };
+    const issues = findThinEvidence(record);
+    expect(issues.map(i => i.path)).toEqual([
+      'build.bpWarnings[0]', 'build.bpWarnings[1]', 'build.bpWarnings[2]',
+    ]);
+  });
+
+  it('an EMPTY ARRAY is fine — zero warnings is a real, meaningful result, not thin evidence', () => {
+    const record = {
+      run_id: 'x', case_id: 'x', classification: 'PASS',
+      build: { succeeded: true, errors: [], bpWarnings: [] },
+      golden_diff: { matched: true, missing: [], extra: [], changed: [] },
+      score: { build: 1, bp_clean: 1, golden_match: 1, systest: null, tier_weight: 1 },
+    };
+    expect(hasThinEvidence(record)).toBe(false);
+  });
+
+  it('a well-formed bpWarnings entry with real content is not flagged (regression control: L2-business-event-basic)', () => {
+    const record = {
+      run_id: 'x', case_id: 'L2-business-event-basic', classification: 'TOOL_DEFECT',
+      build: {
+        succeeded: true,
+        errors: [],
+        bpWarnings: [
+          { message: "BestPractices Warning: AxClass X/Method/y: BPXmlDocNoDocumentationComments: No XML documentation headers are provided for 'X.y'." },
+        ],
+      },
+      golden_diff: { matched: false, missing: [], extra: [], changed: [{ path: 'a/b', expected: '1', actual: '2' }] },
+      score: { build: 1, bp_clean: 0, golden_match: 0, systest: null, tier_weight: 2 },
+    };
+    expect(hasThinEvidence(record)).toBe(false);
+  });
+
+  it('also flags thin entries in golden_diff.changed and systest.failures', () => {
+    const record = {
+      run_id: 'x', case_id: 'x', classification: 'VALIDATOR_GAP',
+      build: { succeeded: true, errors: [], bpWarnings: [] },
+      golden_diff: { matched: false, missing: [], extra: [], changed: [{}] },
+      systest: { ran: true, passed: false, failures: [{}] },
+      score: { build: 1, bp_clean: 1, golden_match: 0, systest: 0, tier_weight: 1 },
+    };
+    const paths = findThinEvidence(record).map(i => i.path);
+    expect(paths).toEqual(expect.arrayContaining(['golden_diff.changed[0]', 'systest.failures[0]']));
+  });
+});
+
+describe('isUnconfirmable', () => {
+  it('a bp_clean=0 record with only thin bpWarnings AND no hypothesis/evidence_refs is unconfirmable (regression: L4-ssrs-report-advanced 4-controller/5-menuitem)', () => {
+    const record = {
+      run_id: '2026-07-07T16__L4-ssrs-report-advanced__cb1b73d',
+      case_id: 'L4-ssrs-report-advanced',
+      classification: 'KNOWLEDGE_GAP',
+      build: { succeeded: true, errors: [], bpWarnings: [{}] },
+      golden_diff: { matched: true, missing: [], extra: [], changed: [] },
+      score: { build: 1, bp_clean: 0, golden_match: 1, systest: null, tier_weight: 4 },
+    };
+    expect(isUnconfirmable(record)).toBe(true);
+  });
+
+  it('PASS records are never unconfirmable regardless of shape', () => {
+    expect(isUnconfirmable({ classification: 'PASS', score: { bp_clean: 0 }, build: { bpWarnings: [{}] } })).toBe(false);
+  });
+
+  it('a record WITH a root_cause_hypothesis is NOT unconfirmable even with thin bpWarnings — the improver has something to act on', () => {
+    const record = {
+      run_id: 'x', case_id: 'x', classification: 'TOOL_DEFECT',
+      build: { succeeded: true, errors: [], bpWarnings: [{}] },
+      golden_diff: { matched: false, missing: [], extra: [], changed: [{ path: 'a', expected: '1', actual: '2' }] },
+      score: { build: 1, bp_clean: 0, golden_match: 0, systest: null, tier_weight: 2 },
+      root_cause_hypothesis: 'the generator omitted X',
+    };
+    expect(isUnconfirmable(record)).toBe(false);
+  });
+
+  it('golden_match=0 explained by missing/extra (not changed) is NOT the thin-"changed" case, even with an empty changed[]', () => {
+    const record = {
+      run_id: 'x', case_id: 'L1-table-basic', classification: 'TOOL_DEFECT',
+      build: { succeeded: true, errors: [], bpWarnings: [] },
+      golden_diff: { matched: false, missing: ['A/B'], extra: [], changed: [] },
+      score: { build: 1, bp_clean: 1, golden_match: 0, systest: null, tier_weight: 1 },
+    };
+    // golden_diff.missing has real content — golden_match=0 IS explained (by `missing`,
+    // not thin `changed` entries), so this is NOT the "total loss" case.
+    expect(isUnconfirmable(record)).toBe(false);
+  });
+
+  it('bp_clean=0 with thin bpWarnings makes a record unconfirmable even when golden_match independently passed', () => {
+    const record = {
+      run_id: 'x', case_id: 'L1-table-basic', classification: 'TOOL_DEFECT',
+      build: { succeeded: true, errors: [], bpWarnings: [{}, {}] },
+      golden_diff: { matched: true, missing: [], extra: [], changed: [] },
+      score: { build: 1, bp_clean: 0, golden_match: 1, systest: null, tier_weight: 1 },
+    };
+    // The bp_clean=0 signal has zero recoverable detail — that dimension of the
+    // classification cannot be confirmed, regardless of golden_match.
+    expect(isUnconfirmable(record)).toBe(true);
+    expect(hasThinEvidence(record)).toBe(true);
+  });
+});

--- a/tests/eval/evidenceGap.test.ts
+++ b/tests/eval/evidenceGap.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Evidence-gap report building/rendering (docs/AGENT_EVAL_LOOP.md §5, §9).
+ * VM-free — see src/eval/improver/evidenceGapCli.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildEvidenceGapReport, renderEvidenceGapReport } from '../../src/eval/improver/evidenceGap';
+
+describe('buildEvidenceGapReport', () => {
+  it('is empty for a corpus with no thin evidence', () => {
+    const runs = [
+      { run_id: 'a', case_id: 'A', tier: 1, classification: 'PASS', build: { succeeded: true, bpWarnings: [] } },
+    ];
+    expect(buildEvidenceGapReport(runs as any)).toEqual([]);
+  });
+
+  it('surfaces unconfirmable runs first, then confirmable-but-partially-thin ones, sorted by case_id', () => {
+    const runs = [
+      {
+        run_id: 'z-run', case_id: 'Z-case', classification: 'TOOL_DEFECT',
+        build: { succeeded: true, bpWarnings: [{ message: 'a real warning' }, {}] },
+        golden_diff: { matched: false, missing: ['x'], extra: [], changed: [] },
+        score: { bp_clean: 0, golden_match: 0 },
+      },
+      {
+        run_id: 'a-run', case_id: 'A-case', classification: 'KNOWLEDGE_GAP',
+        build: { succeeded: true, bpWarnings: [{}] },
+        golden_diff: { matched: true, missing: [], extra: [], changed: [] },
+        score: { bp_clean: 0, golden_match: 1 },
+      },
+    ];
+    const report = buildEvidenceGapReport(runs as any);
+    expect(report.map(r => r.case_id)).toEqual(['A-case', 'Z-case']);
+    expect(report[0].unconfirmable).toBe(true); // A-case: no hypothesis, thin bpWarnings, nothing else to go on
+    expect(report[1].unconfirmable).toBe(false); // Z-case: golden_diff.missing gives a real, confirmable signal
+  });
+});
+
+describe('renderEvidenceGapReport', () => {
+  it('renders the all-clear message when there are no gaps', () => {
+    expect(renderEvidenceGapReport([])).toContain('No thin-evidence');
+  });
+
+  it('renders unconfirmable entries with an explanatory banner and per-issue detail', () => {
+    const report = buildEvidenceGapReport([
+      {
+        run_id: 'r1', case_id: 'C1', classification: 'KNOWLEDGE_GAP',
+        build: { succeeded: true, bpWarnings: [{}] },
+        golden_diff: { matched: true, missing: [], extra: [], changed: [] },
+        score: { bp_clean: 0, golden_match: 1 },
+      },
+    ] as any);
+    const text = renderEvidenceGapReport(report);
+    expect(text).toContain('UNCONFIRMABLE');
+    expect(text).toContain('C1');
+    expect(text).toContain('build.bpWarnings[0]');
+    expect(text).toContain('fresh eval-implementer VM run');
+  });
+});


### PR DESCRIPTION
## Summary
- 4 corpus records (`L0-enum-basic`, `L2-interface-abstract-basic`, `L4-ssrs-report-advanced` ×2) were classified `KNOWLEDGE_GAP` purely because `score.bp_clean===0`, but every `build.bpWarnings` entry was a literal empty object (`{}`) — the implementer recorded THAT there were warnings but not their rule/target/message.
- `docs/AGENT_EVAL_LOOP.md` §5 already commits every corpus record to being "self-contained evidence... without access to the original VM session", but `eval/corpus/schema.json` allowed `{}` (each item only required `{"type":"object"}`), so nothing ever flagged the violation, and these 4 runs became permanently unrecoverable dead ends for a VM-free improver session.
- **This does not (and cannot, VM-free) recover the lost `bpWarnings` content for the 4 flagged historical runs** — that evidence is gone. What it does: closes the systemic gap so a repeat is caught immediately instead of silently degrading cluster analysis, and gives a durable, actionable handoff list (`npm run eval:evidence-gaps`) for whichever eval-implementer VM session picks these cases back up.

## Changes
- `eval/corpus/schema.json`: `bpWarnings`/`errors`/`systest.failures`/`golden_diff.changed` items now require `minProperties: 1` (documents the contract; an empty ARRAY — zero warnings — is still fine, only an empty *object inside* the array is rejected).
- `src/eval/improver/corpusShapeGuard.ts`: pure VM-free shape check (`findThinEvidence` / `hasThinEvidence` / `isUnconfirmable`) distinguishing "zero warnings" (fine) from "N warnings, zero detail recorded" (the defect).
- `src/eval/improver/evidenceGap.ts` + `evidenceGapCli.ts` (`npm run eval:evidence-gaps`): actionable checklist of every corpus run with thin evidence, split into `UNCONFIRMABLE` (needs a fresh eval-implementer VM run to recover any detail at all — no `root_cause_hypothesis`/`suggested_fix_area`/`evidence_refs` either) vs. `partial` (thin on one dimension but confirmable via another, e.g. `golden_diff.missing` explains a mismatch even if `bpWarnings` is thin).
- `docs/AGENT_EVAL_LOOP.md` §5: explicit "never write an empty placeholder object into an evidence array" guidance for future implementer runs.

Stacked on #658 (uses its `corpusIO.ts` loader) — this PR's diff will shrink once that one merges.

## Evidence
- `eval/corpus/runs/2026-07-06T16__L0-enum-basic__cc58c3f.json`
- `eval/corpus/runs/2026-07-07T07__L2-interface-abstract-basic__cb1b73d.json`
- `eval/corpus/runs/2026-07-07T16__L4-ssrs-report-advanced__cb1b73d.json` (×2: the "4-controller"/"5-menuitem" sub-artifacts)

Running `npm run eval:evidence-gaps` today additionally surfaces 20 more corpus runs with at least one thin `bpWarnings` entry (16 of which are fully `UNCONFIRMABLE`) — this PR's tooling is what makes that visible for the first time; fixing each of those individually is out of scope here (needs per-case VM re-capture, tracked as a standing checklist via this new CLI, not a code fix).

## Test plan
- [x] New `tests/eval/corpusShapeGuard.test.ts` (10 tests) using the real flagged records' structure as fixtures, plus control cases (empty array is fine; a record with a real hypothesis is not unconfirmable; a record whose golden_diff.missing carries real content is confirmable via that signal even with thin bpWarnings alongside it).
- [x] New `tests/eval/evidenceGap.test.ts` (4 tests) for report building/rendering/sorting.
- [x] `npx vitest run` — full suite green (104 files / 1537 tests).
- [x] Manually ran `npm run eval:evidence-gaps` against the real (BOM-fixed) corpus — confirms the 4 originally-flagged runs plus 20 more are surfaced correctly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV