### PR TITLE
fix(eval): tolerate any valid EDT choice for L2-table-extension's NotePriority field

### DIFF
--- a/eval/cases/L2-table-extension.json
+++ b/eval/cases/L2-table-extension.json
@@ -10,7 +10,8 @@
   "ignore": [
     "AxTableExtension/@Id",
     "**/AxTableField/@Id",
-    "**/ModelSaveInfo"
+    "**/ModelSaveInfo",
+    "AxTableExtension/Fields/AxTableField/ExtendedDataType"
   ],
   "tags": [
     "table-extension",

--- a/tests/eval/caseIgnoreLists.test.ts
+++ b/tests/eval/caseIgnoreLists.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Case-specific golden-diff tolerances (docs/AGENT_EVAL_LOOP.md §6.2 —
+ * "optional per-case ignore-list / tolerances for legitimately variable
+ * nodes"). VM-free.
+ *
+ * Regression: eval/corpus/runs/2026-07-07T10__L2-table-extension__cb1b73d.json
+ * was classified TOOL_DEFECT for a single golden_diff.changed entry —
+ * NotePriority's ExtendedDataType was "Priority" (actual) vs "Counter"
+ * (golden). The case instruction only says "use suggest_edt / the index to
+ * pick an APPROPRIATE integer or string EDT — do NOT invent a new EDT"; it
+ * never mandates a specific EDT. Both "Priority" and "Counter" are real,
+ * standard D365FO EDTs (confirmed via data/xpp-metadata.db — 23,942 real EDT
+ * symbols indexed, both present) — "Priority" is arguably the more
+ * semantically correct pick for a field literally named "NotePriority"
+ * (Counter is normally used for auto-incrementing line/sequence numbers).
+ * The build was clean (0 BP warnings, not just thin evidence — a real empty
+ * array) and every other field of the golden matched byte-for-byte.
+ *
+ * This was not a tool defect — the golden pinned one arbitrary EDT choice
+ * for an instruction that deliberately leaves the EDT choice up to the
+ * agent's own grounded judgement (suggest_edt), so the oracle needs a
+ * tolerance for it, not the generator a fix. Root cause: an under-specified
+ * case pinned by an over-specified golden. Fixed by adding
+ * "AxTableExtension/Fields/AxTableField/ExtendedDataType" to the case's own
+ * `ignore` list — the documented mechanism for exactly this situation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { evaluate } from '../../src/eval/oracle/index';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+
+function readCase(caseId: string) {
+  return JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'eval', 'cases', `${caseId}.json`), 'utf8'));
+}
+
+function readGolden(caseId: string, file: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, 'eval', 'goldens', caseId, file), 'utf8');
+}
+
+describe('L2-table-extension: NotePriority EDT choice is a legitimate tolerance, not a defect', () => {
+  const caseSpec = readCase('L2-table-extension');
+  const goldenXml = readGolden('L2-table-extension', 'CustGroup.ConExtension.metadata.xml');
+
+  it('the case ignore list includes the ExtendedDataType tolerance', () => {
+    expect(caseSpec.ignore).toContain('AxTableExtension/Fields/AxTableField/ExtendedDataType');
+  });
+
+  it('golden_match=1 when the actual uses a DIFFERENT (but equally valid) EDT than the golden (regression: L2-table-extension, Priority vs Counter)', async () => {
+    const actualXml = goldenXml.replace('<ExtendedDataType>Counter</ExtendedDataType>', '<ExtendedDataType>Priority</ExtendedDataType>');
+    expect(actualXml).not.toBe(goldenXml); // sanity: the substitution actually happened
+
+    const res = await evaluate({
+      caseSpec: { id: caseSpec.id, tier: caseSpec.tier, ignore: caseSpec.ignore },
+      actualXml,
+      goldenXml,
+      build: { succeeded: true, bpWarnings: [] },
+    });
+    expect(res.goldenDiff.changed).toEqual([]);
+    expect(res.score.golden_match).toBe(1);
+  });
+
+  it('a genuinely wrong field NAME (not just EDT) still correctly mismatches — the tolerance is narrowly scoped', async () => {
+    const actualXml = goldenXml.replace(/NotePriority/g, 'NoteUrgency');
+    const res = await evaluate({
+      caseSpec: { id: caseSpec.id, tier: caseSpec.tier, ignore: caseSpec.ignore },
+      actualXml,
+      goldenXml,
+      build: { succeeded: true, bpWarnings: [] },
+    });
+    expect(res.score.golden_match).toBe(0);
+  });
+
+  it('a genuinely wrong field TYPE (i:type, not ExtendedDataType) still correctly mismatches', async () => {
+    const actualXml = goldenXml.replace('i:type="AxTableFieldInt"', 'i:type="AxTableFieldString"');
+    const res = await evaluate({
+      caseSpec: { id: caseSpec.id, tier: caseSpec.tier, ignore: caseSpec.ignore },
+      actualXml,
+      goldenXml,
+      build: { succeeded: true, bpWarnings: [] },
+    });
+    expect(res.score.golden_match).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
`eval/corpus/runs/2026-07-07T10__L2-table-extension__cb1b73d.json` was classified `TOOL_DEFECT` for a single `golden_diff.changed` entry: `NotePriority`'s `ExtendedDataType` was `"Priority"` (actual) vs `"Counter"` (golden). The case instruction only says *"use suggest_edt / the index to pick an **appropriate** integer or string EDT — do NOT invent a new EDT"* — it never mandates a specific EDT.

Both `"Priority"` and `"Counter"` are real, standard D365FO EDTs (confirmed via `data/xpp-metadata.db`, 23,942 indexed EDT symbols) — `"Priority"` is arguably the *more* semantically correct pick for a field literally named `NotePriority` (`Counter` is normally used for auto-incrementing line/sequence numbers). The build was clean (0 BP warnings — a real empty array, not thin evidence) and every other field of the golden matched byte-for-byte.

**This was not a tool defect.** The golden pinned one arbitrary EDT choice for an instruction that deliberately leaves the EDT choice to the agent's own grounded judgement — the oracle needed a tolerance for it, not the generator a fix.

## Fix
Adds `"AxTableExtension/Fields/AxTableField/ExtendedDataType"` to the case's own `ignore` list — the documented mechanism (§6.2 of `docs/AGENT_EVAL_LOOP.md`, "optional per-case ignore-list / tolerances for legitimately variable nodes") for exactly this situation. The tolerance is narrowly scoped to the `ExtendedDataType` leaf only — a genuinely wrong field name or `i:type` still correctly mismatches.

## Evidence
- `eval/corpus/runs/2026-07-07T10__L2-table-extension__cb1b73d.json`

## Test plan
- [x] New `tests/eval/caseIgnoreLists.test.ts` (4 tests): confirms the ignore entry is present; confirms `golden_match=1` for the Priority-vs-Counter substitution (using the real committed golden XML); confirms a genuinely wrong field name still mismatches; confirms a genuinely wrong `i:type` still mismatches.
- [x] Confirmed load-bearing: reverted the case-spec change only and re-ran — the "different EDT" test fails as expected.
- [x] `npx vitest run tests/eval/caseIgnoreLists.test.ts tests/eval/goldens.test.ts` — green (63 tests, golden-integrity gate unaffected).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV