### PR TITLE
fix(modify-enum-value): add enumValueNewName to actually rename a value

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -2121,6 +2121,7 @@ namespace D365MetadataBridge.Services
                         case "value":
                             if (int.TryParse(kv.Value, out var iv)) target.Value = iv;
                             break;
+                        case "name": target.Name = kv.Value; break;
                     }
                 }
             }

--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -140,7 +140,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             'add-index {indexName, indexFields[{fieldName}]} · add-relation {relationName, relatedTable, relationConstraints?} · ' +
             'add-field-group {fieldGroupName, fieldGroupFields?} · add-data-source {dataSourceName, dataSourceTable} · ' +
             'add-control {controlName, parentControl, controlDataSource?, controlDataField?} · ' +
-            'enum ops {enumValueName, enumValueLabel?, enumValueInt?} · add-menu-item-to-menu {menuItemToAdd} · ' +
+            'enum ops {enumValueName, enumValueNewName?(modify-enum-value rename), enumValueLabel?, enumValueInt?} · add-menu-item-to-menu {menuItemToAdd} · ' +
             'modify-property {propertyPath, propertyValue} · add-table-method {tableMethodType, tableKeyField?} · ' +
             'add-display-method {methodName, displayMethodReturnEdt}. ' +
             'A missing/wrong parameter returns the COMPLETE spec (names, types, descriptions) for that operation — ' +

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -605,7 +605,13 @@ const ModifyD365FileArgsSchema = z.object({
   // For add-enum-value / modify-enum-value / remove-enum-value
   enumValueName: z.string().optional().describe(
     'Enum value name for add-enum-value / modify-enum-value / remove-enum-value. ' +
-    'E.g. "Approved", "Pending", "Rejected".'
+    'E.g. "Approved", "Pending", "Rejected". For modify-enum-value this is the EXISTING ' +
+    'name used to locate the value — see enumValueNewName to rename it.'
+  ),
+  enumValueNewName: z.string().optional().describe(
+    'modify-enum-value ONLY: renames the enum value (its Name/identifier) from ' +
+    'enumValueName to this. Numeric value and label are unaffected unless ' +
+    'enumValueInt/enumValueLabel are also given.'
   ),
   enumValueLabel: z.string().optional().describe(
     'Label reference for the enum value (e.g. "@MyModel:Approved"). ' +
@@ -1588,6 +1594,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       case 'modify-enum-value': {
         if ((args as any).enumValueName) {
           const evProps: Record<string, string> = {};
+          if ((args as any).enumValueNewName) evProps.name = (args as any).enumValueNewName;
           if ((args as any).enumValueLabel) evProps.label = (args as any).enumValueLabel;
           if ((args as any).enumValueInt !== undefined) evProps.value = String((args as any).enumValueInt);
           bridgeResult = await bridgeModifyEnumValue(

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -1628,6 +1628,70 @@ describe('modify_d365fo_file', () => {
     expect(constraints).toEqual([{ field: 'CategoryId', relatedField: 'CategoryId' }]);
   });
 
+  it('modify-enum-value forwards enumValueNewName as a "name" property so the value can be RENAMED', async () => {
+    // Regression: eval/corpus/runs/2026-07-07T05__L2-enum-modify-values__cb1b73d.json —
+    // case instruction: "modify-enum-value to rename Closed to Completed, keeping its
+    // numeric value 2". The tool had NO parameter to change an enum value's own Name —
+    // only enumValueLabel (Label) and enumValueInt (Value) were ever forwarded, so a
+    // "rename" request silently did nothing to the Name and the enum kept "Closed".
+    // Confirmed both "Priority" and every other rename target is unreachable: the
+    // handler's evProps dict never had a "name" key, and the C# bridge's
+    // ModifyEnumValue switch (MetadataWriteService.cs) never had a "name" case either.
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxEnum><Name>ConDemoModStatus</Name></AxEnum>`,
+    );
+
+    const modifyEnumValue = vi.fn(async () => ({ success: true, api: 'IMetaEnumProvider.Update' }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, modifyEnumValue, refreshProvider: vi.fn() };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'enum',
+        objectName: 'ConDemoModStatus',
+        operation: 'modify-enum-value',
+        enumValueName: 'Closed',
+        enumValueNewName: 'Completed',
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxEnum\\ConDemoModStatus.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(modifyEnumValue).toHaveBeenCalledTimes(1);
+    const [enumName, valueName, props] = modifyEnumValue.mock.calls[0];
+    expect(enumName).toBe('ConDemoModStatus');
+    expect(valueName).toBe('Closed'); // the EXISTING name, used to locate the value
+    expect(props).toEqual({ name: 'Completed' });
+  });
+
+  it('modify-enum-value still forwards label/value without enumValueNewName (back-compat, unchanged)', async () => {
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxEnum><Name>ConDemoModStatus</Name></AxEnum>`,
+    );
+
+    const modifyEnumValue = vi.fn(async () => ({ success: true, api: 'IMetaEnumProvider.Update' }));
+    (ctx as any).bridge = { isReady: true, metadataAvailable: true, modifyEnumValue, refreshProvider: vi.fn() };
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'enum',
+        objectName: 'ConDemoModStatus',
+        operation: 'modify-enum-value',
+        enumValueName: 'Active',
+        enumValueLabel: '@ConDemo:Active',
+        enumValueInt: 1,
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxEnum\\ConDemoModStatus.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const [, , props] = modifyEnumValue.mock.calls[0];
+    expect(props).toEqual({ label: '@ConDemo:Active', value: '1' });
+  });
+
   it('derives objectName from filePath when objectName is omitted', async () => {
     const fsMod = await import('fs/promises');
     (fsMod.readFile as any).mockResolvedValueOnce(


### PR DESCRIPTION
## Summary
`eval/corpus/runs/2026-07-07T05__L2-enum-modify-values__cb1b73d.json`'s case instruction is unambiguous and self-contained regardless of golden state: *"modify-enum-value to rename Closed to Completed, keeping its numeric value 2 ... The final enum must contain exactly Active (1), Completed (2), Archived (3) — nothing else"*. The actual run's `golden_diff` shows the enum ended up with `"Closed"` (extra) instead of `"Completed"` (missing) — **the rename never happened.**

## Root cause
`modify-enum-value` had no parameter, TS-side mapping, or C#-side switch case to change an enum value's own `Name` at all. Only `Label` (`enumValueLabel`) and `Value` (`enumValueInt`) were ever forwarded into the properties dict:
- `src/tools/modifyD365File.ts`'s `modify-enum-value` handler only ever built `evProps.label`/`evProps.value`.
- `bridge/D365MetadataBridge/Services/MetadataWriteService.cs`'s `ModifyEnumValue` switch only ever handled `"label"`/`"value"` — no `"name"` case, so even a hypothetical caller passing one would be silently ignored.

`d365fo_file(modify, objectType=enum, operation=modify-enum-value)` could tweak a value's label or number but could **never rename it**, regardless of what the caller passed.

## Fix (3 layers, matching how label/value are already wired)
- `src/tools/modifyD365File.ts`: new `enumValueNewName` Zod field; when present, forwarded as `evProps.name`.
- `bridge/D365MetadataBridge/Services/MetadataWriteService.cs`: `ModifyEnumValue` now handles a `"name"` property key (`target.Name = kv.Value`) alongside the existing `"label"`/`"value"` cases.
- `src/server/toolSchemas/d365foFile.ts`: documents `enumValueNewName` in the `modify-enum-value` operation summary.

## Evidence
- `eval/corpus/runs/2026-07-07T05__L2-enum-modify-values__cb1b73d.json`

**Note:** this case's golden is not yet captured (`golden_pending: true`, no `eval/goldens/L2-enum-modify-values/` directory) — authoring it requires a real VM build per §6.4 and is out of scope for a VM-free improver session. The root cause above is confirmed directly from the case's own self-contained instruction text, independent of the missing golden. A follow-up eval-implementer VM run should re-run this case (now that the rename capability exists) and, once verified correct, author the golden.

## Test plan
- [x] New tests in `tests/tools/file-ops.test.ts`: `modify-enum-value` forwards `enumValueNewName` as `{name: ...}` to the bridge; back-compat unchanged when `enumValueNewName` is omitted (label/value still forwarded as before).
- [x] Confirmed load-bearing: reverted the TS handler change only and re-ran — the rename test fails as expected (`props` is `undefined` since the properties dict stayed empty).
- [x] `npx vitest run` — full suite green (101 files / 1516 tests). (The C# bridge change cannot be exercised by this repo's vitest suite — it is validated by direct code inspection matching the existing label/value pattern; a live VM re-run of the case is the closing verification step.)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV