### PR TITLE
fix(data-entity): default DataManagementEnabled=No (staging table was never created)

### DIFF
--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -73,7 +73,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             '• security-duty: label, privileges[]\n' +
             '• security-role: label, duties[], privileges[]\n' +
             '• menu-item-*: label, object, objectType\n' +
-            '• data-entity: primaryTable, fields[{name,dataField?}]'
+            '• data-entity: primaryTable, fields[{name,dataField?}], dataManagementEnabled? (default false — set true ONLY if the staging table already exists, else the build fails)'
         },
         addToProject: {
           type: 'boolean',

--- a/src/tools/dataEntityXml.ts
+++ b/src/tools/dataEntityXml.ts
@@ -4,17 +4,28 @@
  * createD365File.ts and generateD365Xml.ts each expose a mirrored
  * XmlTemplateGenerator class; both delegate here so the two cannot drift.
  *
- * properties.primaryTable    – REQUIRED for a functional entity: the root table.
- * properties.fields          – [{ name, dataField? }] one AxDataEntityViewMappedField
- *                               + one query datasource field per entry, both sourced
- *                               from primaryTable. dataField defaults to name.
- * properties.primaryKeyField – field `name` to use as the entity key (default: fields[0].name).
- * properties.entityCategory  – Master | Transaction | Reference | Document | Parameter
- *                               (default: Transaction).
+ * properties.primaryTable          – REQUIRED for a functional entity: the root table.
+ * properties.fields                – [{ name, dataField? }] one AxDataEntityViewMappedField
+ *                                     + one query datasource field per entry, both sourced
+ *                                     from primaryTable. dataField defaults to name.
+ * properties.primaryKeyField       – field `name` to use as the entity key (default: fields[0].name).
+ * properties.entityCategory        – Master | Transaction | Reference | Document | Parameter
+ *                                     (default: Transaction).
+ * properties.dataManagementEnabled – opt IN to data-management/DIXF staging (default: false —
+ *                                     see below). When true, properties.dataManagementStagingTable
+ *                                     overrides the default `${entityName}Staging` name.
  *
  * Without primaryTable + at least one field, this emits an inert skeleton
  * (no query) that can never function as a data entity — callers should
  * always pass both.
+ *
+ * DataManagementEnabled defaults to "No" (regression: this used to hard-code
+ * "Yes" + DataManagementStagingTable=`${entityName}Staging` unconditionally —
+ * every generated entity then failed its very next build with "Table
+ * '<Name>Staging' does not exist", since this tool has no path that creates a
+ * staging table. Enabling data-management for a real staging scenario is an
+ * explicit opt-in via properties.dataManagementEnabled — the caller is then
+ * responsible for the staging table existing (create it as its own table).
  */
 export function buildAxDataEntityXml(entityName: string, properties?: Record<string, any>): string {
   const label = properties?.label || entityName;
@@ -24,15 +35,19 @@ export function buildAxDataEntityXml(entityName: string, properties?: Record<str
   const primaryTable: string | undefined = properties?.primaryTable;
   const fields: Array<{ name: string; dataField?: string }> | undefined =
     Array.isArray(properties?.fields) ? properties.fields : undefined;
+  const dataManagementEnabled = properties?.dataManagementEnabled === true;
+  const dataManagementXml = dataManagementEnabled
+    ? `\t<DataManagementEnabled>Yes</DataManagementEnabled>\n` +
+      `\t<DataManagementStagingTable>${properties?.dataManagementStagingTable || `${entityName}Staging`}</DataManagementStagingTable>\n`
+    : `\t<DataManagementEnabled>No</DataManagementEnabled>\n` +
+      `\t<DataManagementStagingTable />\n`;
 
   if (!primaryTable || !fields || fields.length === 0) {
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxDataEntityView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${entityName}</Name>
 \t<Label>${label}</Label>
-\t<DataManagementEnabled>Yes</DataManagementEnabled>
-\t<DataManagementStagingTable>${entityName}Staging</DataManagementStagingTable>
-\t<EntityCategory>${entityCategory}</EntityCategory>
+${dataManagementXml}\t<EntityCategory>${entityCategory}</EntityCategory>
 \t<IsPublic>Yes</IsPublic>
 \t<PublicCollectionName>${publicCollectionName}</PublicCollectionName>
 \t<PublicEntityName>${publicEntityName}</PublicEntityName>
@@ -64,9 +79,7 @@ export function buildAxDataEntityXml(entityName: string, properties?: Record<str
 <AxDataEntityView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${entityName}</Name>
 \t<Label>${label}</Label>
-\t<DataManagementEnabled>Yes</DataManagementEnabled>
-\t<DataManagementStagingTable>${entityName}Staging</DataManagementStagingTable>
-\t<EntityCategory>${entityCategory}</EntityCategory>
+${dataManagementXml}\t<EntityCategory>${entityCategory}</EntityCategory>
 \t<IsPublic>Yes</IsPublic>
 \t<PrimaryKey>EntityKey</PrimaryKey>
 \t<PublicCollectionName>${publicCollectionName}</PublicCollectionName>

--- a/tests/tools/dataEntityXml.test.ts
+++ b/tests/tools/dataEntityXml.test.ts
@@ -1,0 +1,67 @@
+/**
+ * buildAxDataEntityXml (src/tools/dataEntityXml.ts).
+ *
+ * Regression:
+ * eval/corpus/runs/2026-07-07T12__L4-bridge-drops-data-entity-primarytable-fields-on-create__cb1b73d.json
+ * — d365fo_file(action="create", objectType="data-entity") unconditionally
+ * hard-coded <DataManagementEnabled>Yes</DataManagementEnabled> and
+ * <DataManagementStagingTable>${entityName}Staging</DataManagementStagingTable>
+ * with no path that ever creates that staging table, so the very next full
+ * build failed: "Metadata Error: AxDataEntityView/.../DataManagementStagingTable:
+ * Table '<Name>Staging' does not exist." Every data entity this tool ever
+ * created was build-broken by default. Fixed by defaulting
+ * DataManagementEnabled=No (self-closed, empty DataManagementStagingTable)
+ * unless the caller explicitly opts in via properties.dataManagementEnabled.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildAxDataEntityXml } from '../../src/tools/dataEntityXml';
+
+describe('buildAxDataEntityXml — DataManagementEnabled defaulting', () => {
+  it('defaults DataManagementEnabled=No with an empty staging table (skeleton branch: no primaryTable/fields)', () => {
+    const xml = buildAxDataEntityXml('ConSmallItemEntity');
+    expect(xml).toContain('<DataManagementEnabled>No</DataManagementEnabled>');
+    expect(xml).toContain('<DataManagementStagingTable />');
+    expect(xml).not.toContain('ConSmallItemEntityStaging');
+    expect(xml).not.toContain('<DataManagementEnabled>Yes</DataManagementEnabled>');
+  });
+
+  it('defaults DataManagementEnabled=No with an empty staging table (full branch: primaryTable + fields given)', () => {
+    const xml = buildAxDataEntityXml('ConSmallItemEntity', {
+      primaryTable: 'ConSmallItem',
+      fields: [{ name: 'ItemId' }, { name: 'Name' }],
+    });
+    expect(xml).toContain('<DataManagementEnabled>No</DataManagementEnabled>');
+    expect(xml).toContain('<DataManagementStagingTable />');
+    expect(xml).not.toContain('Staging<');
+    // The real fix this case was originally mined for (primaryTable/fields honoured) still works.
+    expect(xml).toContain('<DataField>ItemId</DataField>');
+    expect(xml).toContain('<Table>ConSmallItem</Table>');
+  });
+
+  it('opts IN to data management when properties.dataManagementEnabled=true, defaulting the staging table name', () => {
+    const xml = buildAxDataEntityXml('ConSmallItemEntity', {
+      primaryTable: 'ConSmallItem',
+      fields: [{ name: 'ItemId' }],
+      dataManagementEnabled: true,
+    });
+    expect(xml).toContain('<DataManagementEnabled>Yes</DataManagementEnabled>');
+    expect(xml).toContain('<DataManagementStagingTable>ConSmallItemEntityStaging</DataManagementStagingTable>');
+  });
+
+  it('opts IN with an explicit staging table name override', () => {
+    const xml = buildAxDataEntityXml('ConSmallItemEntity', {
+      primaryTable: 'ConSmallItem',
+      fields: [{ name: 'ItemId' }],
+      dataManagementEnabled: true,
+      dataManagementStagingTable: 'ConCustomStagingTable',
+    });
+    expect(xml).toContain('<DataManagementStagingTable>ConCustomStagingTable</DataManagementStagingTable>');
+  });
+
+  it('an unset/false dataManagementEnabled behaves identically to omitting the property', () => {
+    const withFalse = buildAxDataEntityXml('X', { dataManagementEnabled: false });
+    const withOmitted = buildAxDataEntityXml('X', {});
+    expect(withFalse).toBe(withOmitted);
+  });
+});


### PR DESCRIPTION
## Summary
`eval/corpus/runs/2026-07-07T12__L4-bridge-drops-data-entity-primarytable-fields-on-create__cb1b73d.json`: the case's original `TOOL_DEFECT` (primaryTable/fields dropped, mined 2026-06-30) is already fixed — the run confirms a fully populated `<Fields>` and `<ViewMetadata><DataSources>`. But the run surfaced a **new** defect: `d365fo_file(action="create", objectType="data-entity")` unconditionally hard-coded `<DataManagementEnabled>Yes</DataManagementEnabled>` and `<DataManagementStagingTable>${entityName}Staging</DataManagementStagingTable>`, with no path anywhere in this tool that creates that staging table. The very next full build failed:

```
Metadata Error: AxDataEntityView/ConSmallItemEntity/DataManagementStagingTable: Table 'ConSmallItemEntityStaging' does not exist.
```

**Every data entity this tool ever created was build-broken by default.**

## Fix
`src/tools/dataEntityXml.ts`'s `buildAxDataEntityXml` is the single shared template both `createD365File.ts` and `generateD365Xml.ts` delegate to (so neither `create` nor `generate` can drift). Now defaults `DataManagementEnabled=No` with an empty, self-closed `<DataManagementStagingTable />`, unless the caller explicitly opts in via a new `properties.dataManagementEnabled=true` (with an optional `properties.dataManagementStagingTable` name override) — the caller is then responsible for the staging table actually existing.

Also documents the new property in the `d365fo_file` tool schema's `data-entity` properties line.

## Evidence
- `eval/corpus/runs/2026-07-07T12__L4-bridge-drops-data-entity-primarytable-fields-on-create__cb1b73d.json`

**Note:** this case's golden is not yet captured (`golden_pending: true`, no `eval/goldens/L4-bridge-drops-data-entity-primarytable-fields-on-create/` directory) — authoring it requires a real VM build per §6.4 (verifying the entity now builds clean end-to-end) and is out of scope for a VM-free improver session. A follow-up eval-implementer VM run should re-run this case and, once verified, author and commit the golden (flip `golden_pending` to `false`).

## Test plan
- [x] New `tests/tools/dataEntityXml.test.ts` (5 tests): defaults to `No` + empty staging table in both the skeleton and full-featured template branches; opt-in via `dataManagementEnabled=true` (default staging name + explicit override); `dataManagementEnabled: false` is byte-identical to omitting the property.
- [x] `npx vitest run tests/utils/toolSchemaBudget.test.ts` — the tool-schema description addition stays within the token-budget ceilings.
- [x] `npx vitest run` — full suite green (102 files / 1519 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV