### PR TITLE
fix(form-scaffold): warn when a form references an "Overview" field group

### DIFF
--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -841,6 +841,32 @@ export async function handleGenerateSmartForm(
     }
   }
 
+  // Several patterns (SimpleList's Grid, and the FieldsFieldGroups Group control
+  // on SimpleListDetails/DetailsMaster) bind <DataGroup>Overview</DataGroup> —
+  // this ONLY builds if the datasource table has a matching AxTableFieldGroup
+  // named "Overview". A brand-new/custom table created earlier in the same
+  // session almost never has one yet, so the very next build fails with
+  // "Field group 'Overview' does not exist" — a confusing failure with no clue
+  // back to this control. Confirmed on this exact scaffold path (corpus:
+  // eval/corpus/runs/2026-07-07T11__L3-form-add-datasource-lines__cb1b73d.json,
+  // eval/corpus/runs/2026-07-07T15__L4-master-security-slice__cb1b73d.json).
+  // This tool has no bridge/table-write access here to auto-create the field
+  // group (and a prior investigation found that even a same-session
+  // add-field-group call did not reliably become visible to xppc's build —
+  // suspected metadata-provider staleness, unconfirmed without a live VM
+  // re-check) — surface the dependency loudly instead of failing silently.
+  if (/<DataGroup>Overview<\/DataGroup>/.test(xml)) {
+    const overviewDsTable =
+      xml.match(/<AxFormDataSource[^>]*>\s*<Name>[^<]+<\/Name>\s*<Table>([^<]+)<\/Table>/)?.[1]
+      ?? primaryDs?.table ?? primaryDs?.name ?? dataSources[0]?.table;
+    cloneNotes +=
+      `\n   ⚠️ This form references a field group named "Overview" on ` +
+      `${overviewDsTable ?? 'the datasource table'} — verify it already exists, or add one BEFORE ` +
+      `building via d365fo_file(action="modify", objectType="table", objectName="${overviewDsTable ?? '<table>'}", ` +
+      `operation="add-field-group", fieldGroupName="Overview", fieldGroupFields=[...]). Without it the ` +
+      `build fails with "Field group 'Overview' does not exist".`;
+  }
+
   console.log(`[generateSmartForm] Generated XML (${xml.length} bytes)`);
 
   // Self-test: generated XML must conform to its declared pattern.

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -911,6 +911,51 @@ describe('generate_smart_form', () => {
     expect(text).toContain('Generated deterministically from the form-pattern catalog');
     expect(text).not.toContain('No dedicated template');
   });
+
+  it('DetailsMaster warns that the Overview FastTab needs a matching table field group', async () => {
+    // Regression: eval/corpus/runs/2026-07-07T11__L3-form-add-datasource-lines__cb1b73d.json,
+    // eval/corpus/runs/2026-07-07T15__L4-master-security-slice__cb1b73d.json — DetailsMaster's
+    // FieldsFieldGroups TabPage always emits <DataGroup>Overview</DataGroup> on its inner Group
+    // control, but the scaffold never creates (or checks for) a matching AxTableFieldGroup named
+    // "Overview" on the bound table. A brand-new custom table almost never has one, so the very
+    // next build silently fails with "Field group 'Overview' does not exist" and no pointer back
+    // to this control. This tool has no table-write access to auto-create the field group (and a
+    // prior investigation found even a same-session add-field-group call unreliable against
+    // xppc's build — unconfirmed without a live VM re-check), so it must surface the dependency
+    // loudly instead.
+    const result = await handleGenerateSmartForm(
+      {
+        name: 'MyDetailsForm',
+        modelName: 'MyModel',
+        dataSource: 'MyCustomTable',
+        formPattern: 'DetailsMaster',
+      },
+      ctx.symbolIndex,
+    );
+    const text = result?.content[0].text as string;
+    expect(text).toContain('<DataGroup>Overview</DataGroup>');
+    expect(text).toContain('references a field group named "Overview"');
+    expect(text).toContain('MyCustomTable');
+    expect(text).toContain('add-field-group');
+  });
+
+  it('Dialog (no DataGroup="Overview" anywhere in its template) does NOT emit the field-group warning', async () => {
+    // Unlike SimpleList/SimpleListDetails/DetailsMaster (all of which reference a field group
+    // named "Overview" somewhere — Grid.DataGroup or the FieldsFieldGroups Group.DataGroup),
+    // Dialog's template has no such reference, so the warning must not fire unconditionally.
+    const result = await handleGenerateSmartForm(
+      {
+        name: 'MyDialogForm',
+        modelName: 'MyModel',
+        dataSource: 'MyCustomTable',
+        formPattern: 'Dialog',
+      },
+      ctx.symbolIndex,
+    );
+    const text = result?.content[0].text as string;
+    expect(text).not.toContain('<DataGroup>Overview</DataGroup>');
+    expect(text).not.toContain('references a field group named "Overview"');
+  });
 });
 
 // ─── suggest_edt ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`eval/corpus/runs/2026-07-07T11__L3-form-add-datasource-lines__cb1b73d.json` and `eval/corpus/runs/2026-07-07T15__L4-master-security-slice__cb1b73d.json` (confirmed across TableOfContents/SimpleListDetails/DetailsMaster): the DetailsMaster/SimpleListDetails FieldsFieldGroups Group control (and SimpleList's Grid control) always emit `<DataGroup>Overview</DataGroup>`, but the scaffold never checks for or creates a matching `AxTableFieldGroup` named `"Overview"` on the bound table. A brand-new custom table created earlier in the same session almost never has one, so the very next build fails with `"Field group 'Overview' does not exist"` — with no clue back to which control caused it.

## Fix (what this PR resolves)
`generateSmartForm.ts` now surfaces the dependency as a loud, actionable note in the tool's response (pointing at the exact `d365fo_file(modify, add-field-group)` call to run first) whenever the emitted XML references `DataGroup=Overview`, instead of staying silent until the confusing downstream build failure.

## What this does NOT fix (VM-gated follow-up — not claimed resolved)
A prior investigation (recorded in the corpus) found that even a **same-session** `add-field-group` call did not reliably become visible to xppc's build despite persisting correctly to the table's XML on disk — suspected metadata-provider/xppc build-cache staleness. **Auto-creating the field group as part of the scaffold call was deliberately NOT attempted here**: it would add a live table-write side effect this repo cannot verify actually resolves the build (the evidence suggests it may not, due to the separate caching issue), so claiming it "fixed" the build failure would be unverified.

**Concrete next step to close this out fully** (needs the eval-implementer role, on the VM):
1. Re-run `L3-form-add-datasource-lines` and `L4-master-security-slice` with this warning in place — confirm the agent now pre-creates the field group before building.
2. Isolate the caching hypothesis: run `add-field-group`, then force a **fresh reconnect/new session** (not just `update_symbol_index`/`fullBuild+force` within the same session) before building — if that resolves it, the fix belongs in the bridge/session-management layer (e.g. auto-reconnect after certain modify ops); if it still fails, this is a deeper xppc/SDK behavior outside this repo's control and the right fix is likely "avoid emitting DataGroup=Overview unless the field group is proven to exist" instead.

## Evidence
- `eval/corpus/runs/2026-07-07T11__L3-form-add-datasource-lines__cb1b73d.json`
- `eval/corpus/runs/2026-07-07T15__L4-master-security-slice__cb1b73d.json`

## Test plan
- [x] New tests in `tests/tools/code-generation.test.ts`: DetailsMaster scaffold emits the warning naming the bound table and the `add-field-group` call to run; Dialog (a pattern with no `DataGroup=Overview` reference at all) does not.
- [x] `npx vitest run` — full suite green (101 files / 1516 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV