### PR TITLE
fix(symbol-index): guard against phantom rows for deleted/rolled-back objects

### DIFF
--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -872,23 +872,34 @@ export async function handleGenerateSmartForm(
 
   // Warn when a datasource is bound to a table that does not exist in the index,
   // suggesting the closest real table name.
+  //
+  // Regression (eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json): a
+  // `symbols` row for a table can OUTLIVE the table itself — the index is a cache,
+  // not invalidated when an object is deleted/rolled back on the VM. `SELECT 1 ...
+  // WHERE name = ?` matched a phantom row from a prior (rolled-back) run's table, so
+  // this check silently passed and the scaffold produced a form bound to a table with
+  // no file on disk — a build failure with no warning here. Verify the indexed
+  // file_path still exists before trusting a hit; a stale row is treated the same as
+  // "not found".
   try {
     const db = symbolIndex.getReadDb();
-    const tableExists = db.prepare(
-      `SELECT 1 FROM symbols WHERE type = 'table' AND name = ? COLLATE NOCASE LIMIT 1`,
+    const tableRow = db.prepare(
+      `SELECT file_path FROM symbols WHERE type = 'table' AND name = ? COLLATE NOCASE LIMIT 1`,
     );
     const seenTables = new Set<string>();
     for (const m of xml.matchAll(/<Table>([^<]+)<\/Table>/g)) {
       const table = m[1].trim();
       if (!table || seenTables.has(table.toLowerCase())) continue;
       seenTables.add(table.toLowerCase());
-      if (tableExists.get(table)) continue;
+      const row = tableRow.get(table) as { file_path?: string } | undefined;
+      const stale = row?.file_path && !fs.existsSync(row.file_path);
+      if (row && !stale) continue;
       const stem = table.replace(/s$/i, '');
       const alt = db.prepare(
         `SELECT name FROM symbols WHERE type = 'table' AND name LIKE ? COLLATE NOCASE ORDER BY LENGTH(name) ASC LIMIT 1`,
       ).get(`${stem}%`) as { name: string } | undefined;
       cloneNotes +=
-        `\n   ⚠️ Datasource table "${table}" not found in the index` +
+        `\n   ⚠️ Datasource table "${table}" ${stale ? 'is stale in the index (its file no longer exists on disk — run update_symbol_index)' : 'not found in the index'}` +
         (alt && alt.name.toLowerCase() !== table.toLowerCase() ? ` — did you mean "${alt.name}"?` : '') +
         ` The form will not build until that table exists or the datasource is re-pointed.`;
     }

--- a/src/tools/tableInfo.ts
+++ b/src/tools/tableInfo.ts
@@ -6,6 +6,7 @@
  * FALLBACK: Only for newly created tables not yet indexed, uses disk scan.
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
@@ -82,7 +83,18 @@ export async function tableInfoTool(request: CallToolRequest, context: XppServer
 /**
  * Serve table info entirely from the pre-indexed symbol database.
  * Returns null when the table is not present in the index; caller then falls through
- * to disk parsing. Never reads the filesystem.
+ * to disk parsing.
+ *
+ * Regression (eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json): the DB
+ * index is a cache — it is not invalidated when an object is deleted/rolled back on
+ * the VM outside a symbol-index rebuild. A prior run's rolled-back table kept
+ * resolving here as if it still existed ("Served from symbol index"), and
+ * generate_object(scaffold) trusted that phantom hit to bind a new form's
+ * datasource, producing a form that references a table with no file on disk —
+ * 4 build errors ("Table '<Name>' does not exist"). Guard against a stale row by
+ * checking the indexed filePath actually still exists before trusting the hit;
+ * a stale entry is treated the same as "not found" so the caller's disk-scan
+ * fallback (or the final not-found error, which now hints at re-indexing) applies.
  */
 function buildTableResponseFromDb(
   symbolIndex: any,
@@ -91,6 +103,14 @@ function buildTableResponseFromDb(
 ): { content: { type: 'text'; text: string }[] } | null {
   const tableSym = symbolIndex.getSymbolByName?.(tableName, 'table');
   if (!tableSym) return null;
+  if (tableSym.filePath && !fs.existsSync(tableSym.filePath)) {
+    console.error(
+      `[tableInfo] Stale symbol-index entry for table '${tableName}' — indexed file ` +
+      `'${tableSym.filePath}' no longer exists on disk (likely rolled back/deleted since ` +
+      `the index was built). Treating as not-found; run update_symbol_index to refresh.`,
+    );
+    return null;
+  }
 
   const rdb = symbolIndex.getReadDb();
   const fields = rdb.prepare(

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -889,6 +889,48 @@ describe('generate_smart_form', () => {
     expect(result?.content[0].text).toContain('MyCustomTable');
   });
 
+  it('warns about a STALE datasource table (indexed row, but its file no longer exists on disk)', async () => {
+    // Regression: eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json — a
+    // rolled-back prior run's table left a phantom `symbols` row. The existence
+    // check used to be a bare `SELECT 1 ... WHERE name = ?`, which matched the
+    // stale row and silently skipped the warning — the scaffold then produced a
+    // form bound to a table with no file on disk (4 build errors, no warning).
+    // No fs mocking needed: this fictional package path genuinely does not exist
+    // on the machine running the test, so the real fs.existsSync(...) === false
+    // check exercises the same "stale row" branch a rolled-back VM table would.
+    const staleCtx = buildContext({
+      symbolIndex: {
+        ...ctx.symbolIndex,
+        getReadDb: vi.fn(() => ({
+          prepare: vi.fn((sql: string) => {
+            // The later staleness check (this fix) selects file_path specifically.
+            if (sql.includes('file_path')) {
+              return { get: vi.fn(() => ({ file_path: 'K:\\Definitely\\Does\\Not\\Exist\\GoneTable.xml' })) };
+            }
+            // The earlier "does the table exist at all" lookup (dataSource resolution,
+            // a SEPARATE existing check) — the stale DB row still matches by name here,
+            // same as a real un-invalidated `symbols` row would; the table is only
+            // discovered to be gone once the file_path staleness check runs later.
+            if (sql.includes('SELECT name FROM symbols')) {
+              return { get: vi.fn(() => ({ name: 'GoneTable' })) };
+            }
+            // "closest alternate name" suggestion lookup — no suggestion.
+            return { get: vi.fn(() => undefined) };
+          }),
+        })),
+      } as any,
+    });
+
+    const result = await handleGenerateSmartForm(
+      { name: 'MyStaleForm', modelName: 'MyModel', dataSource: 'GoneTable' },
+      staleCtx.symbolIndex,
+    );
+    const text = result?.content[0].text as string;
+    expect(text).toContain('is stale in the index');
+    expect(text).toContain('GoneTable');
+    expect(text).toContain('update_symbol_index');
+  });
+
   it('expands a template-less pattern deterministically from the catalog', async () => {
     // "Task" (TaskSingle) has a catalog spec but no hand-written builder
     // template. It used to silently degrade to SimpleList; now the deterministic

--- a/tests/tools/tableInfo.test.ts
+++ b/tests/tools/tableInfo.test.ts
@@ -1,0 +1,82 @@
+/**
+ * tableInfoTool — symbol-index staleness guard.
+ *
+ * Regression: eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json.
+ * get_object_info's DB-index fallback path ("Served from symbol index (bridge
+ * unavailable)") trusted a `symbols` row for a table without checking whether
+ * the table's file still exists on disk. A prior (rolled-back) run's table
+ * left a phantom row in the index, which then resolved as if the table still
+ * existed — generate_object(scaffold) went on to bind a form's datasource to
+ * it, producing a form with 4 build errors ("Table '<Name>' does not exist").
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', () => ({
+  tryBridgeTable: vi.fn(async () => null), // force the DB-index fallback path
+}));
+
+vi.mock('../../src/tools/modifyD365File', () => ({
+  findD365FileOnDisk: vi.fn(async () => null), // no disk fallback hit either
+}));
+
+import { tableInfoTool } from '../../src/tools/tableInfo';
+import * as fs from 'fs';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'get_object_info', arguments: args },
+});
+
+function buildContext(tableRow: { name: string; filePath: string; model: string } | null): XppServerContext {
+  return {
+    symbolIndex: {
+      getSymbolByName: vi.fn((name: string, type: string) => {
+        if (type !== 'table' || !tableRow || name !== tableRow.name) return null;
+        return tableRow;
+      }),
+      getReadDb: vi.fn(() => ({
+        prepare: vi.fn(() => ({
+          all: vi.fn(() => []),
+        })),
+      })),
+    } as any,
+    parser: { parseTableFile: vi.fn(async () => ({ success: false })) } as any,
+  } as any;
+}
+
+beforeEach(() => {
+  vi.mocked(fs.existsSync).mockReset().mockReturnValue(true);
+});
+
+describe('tableInfoTool — stale symbol-index guard', () => {
+  it('serves table info from the index when the indexed file still exists on disk', async () => {
+    const ctx = buildContext({ name: 'ConDemoNoteHeader', filePath: 'K:\\Pkg\\Model\\AxTable\\ConDemoNoteHeader.xml', model: 'MyModel' });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const result = await tableInfoTool(req({ tableName: 'ConDemoNoteHeader' }), ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('ConDemoNoteHeader');
+    expect(result.content[0].text).toContain('Served from symbol index');
+  });
+
+  it('treats a stale index row (file no longer on disk) as not-found instead of serving phantom data', async () => {
+    // Regression: this is the exact scenario — a rolled-back table's row survives
+    // in the index; its file no longer exists.
+    const ctx = buildContext({ name: 'ConDemoNoteHeader', filePath: 'K:\\Pkg\\Model\\AxTable\\ConDemoNoteHeader.xml', model: 'MyModel' });
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const result = await tableInfoTool(req({ tableName: 'ConDemoNoteHeader' }), ctx);
+    // Falls through the DB hit (now rejected as stale), no disk fallback (mocked null),
+    // no bridge (mocked null) — ends at the final not-found error, NOT phantom data.
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).not.toContain('Served from symbol index');
+    expect(result.content[0].text).toMatch(/not found/i);
+  });
+});


### PR DESCRIPTION
## Summary
`eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json` and `eval/corpus/runs/2026-07-06T17__L1-form-listpage__cb1b73d.json`: a table rolled back by a prior eval run kept resolving as if it still existed — `get_object_info` reported it *"Served from symbol index (bridge unavailable)"*, and `generate_object(mode=scaffold)` bound a new form's datasource to it, producing a form with 4 build errors (`"Table 'X' does not exist"`) and no warning anywhere in the chain — because the local `symbols` index is a cache that is never invalidated when an object is deleted/rolled back outside a full re-index.

## Root cause
Two call sites had this exact blind spot (both queried the `symbols` table by name only, never checking whether the indexed file still exists):
- `src/tools/tableInfo.ts`'s DB-index fallback (`buildTableResponseFromDb`)
- `src/tools/generateSmartForm.ts`'s "datasource table not found" pre-flight warning

## Fix
Both now check `fs.existsSync(<indexed filePath>)` before trusting a hit:
- `tableInfo.ts`: a stale row is treated as not-found (falls through to the disk-scan/final not-found path) instead of serving phantom data.
- `generateSmartForm.ts`: surfaces a distinct *"stale in the index — run update_symbol_index"* message instead of silently treating a phantom row as a real table.

## Evidence
- `eval/corpus/runs/2026-07-06T17__L1-form-dialog__cb1b73d.json`
- `eval/corpus/runs/2026-07-06T17__L1-form-listpage__cb1b73d.json` (explicitly cross-references the dialog run as "same phenomenon")

## Test plan
- [x] New `tests/tools/tableInfo.test.ts` (2 tests): serves normally when the indexed file exists; treats a stale row (file gone) as not-found.
- [x] New test in `tests/tools/code-generation.test.ts`: `generate_smart_form` warns "is stale in the index" for a datasource table whose indexed `file_path` doesn't exist on disk (using a real, definitely-nonexistent path — no `fs` mocking needed).
- [x] Confirmed both load-bearing: reverted each fix individually and re-ran — the corresponding new tests fail as expected.
- [x] `npx vitest run` — full suite green (103 files / 1521 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV