### PR TITLE
fix(eval-oracle): key multi-artifact actual files by their own basename

### DIFF
--- a/src/eval/oracle/actualArtifactResolution.ts
+++ b/src/eval/oracle/actualArtifactResolution.ts
@@ -1,0 +1,83 @@
+/**
+ * Multi-artifact (`--actual-dir`) actual-file resolution for src/eval/oracle/cli.ts.
+ * Pure logic + fs reads — no CLI argv/process side effects — split out so it can be
+ * unit-tested without triggering the CLI script's `main()` (docs/AGENT_EVAL_LOOP.md §6).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { canonicalizePrefix } from './normalize.js';
+
+/**
+ * Resolve the actual-dir file matching a golden artifact filename. Tries an
+ * exact filename match first (fast path, and the only path when golden and
+ * actual happen to share the same EXTENSION_PREFIX session); if that misses,
+ * falls back to matching on the PREFIX-CANONICALISED filename (the golden's
+ * filename is itself typically a prefixed object name, e.g.
+ * "AslMyContract.metadata.xml", produced under a different session than the
+ * one that generated the actual artifacts) so a whole L3/L4 multi-artifact
+ * case doesn't spuriously score every artifact as missing/extra under prefix
+ * drift alone.
+ */
+export function resolveActualFile(
+  actualDir: string,
+  goldenName: string,
+  goldenPrefix: string,
+  actualPrefix: string,
+): string | undefined {
+  const direct = path.join(actualDir, goldenName);
+  if (fs.existsSync(direct)) return direct;
+  const canonGolden = canonicalizePrefix(goldenName, goldenPrefix);
+  const candidate = fs.readdirSync(actualDir)
+    .filter(f => f.endsWith('.metadata.xml'))
+    .find(f => canonicalizePrefix(f, actualPrefix) === canonGolden);
+  return candidate ? path.join(actualDir, candidate) : undefined;
+}
+
+/**
+ * Build the `actualArtifacts` map for a multi-artifact (`--actual-dir`) run,
+ * one entry per golden artifact name.
+ *
+ * Regression: this used to key every entry by the GOLDEN's own filename
+ * (`actualArtifacts[name] = ...` inside a `for (const name of
+ * artifactNames)` loop) even when the resolved actual file had a DIFFERENT
+ * literal prefix (e.g. golden "AslMyContract.metadata.xml" resolved to actual
+ * file "FmMcpMyContract.metadata.xml" under prefix-agnostic matching —
+ * `resolveActualFile`'s whole point). `evaluateMulti`/`normalizeMultiArtifact`
+ * then canonicalises each artifact KEY with `actualPrefix` — but a key that's
+ * still the GOLDEN's literal name doesn't contain `actualPrefix` at all, so
+ * `canonicalizePrefix` is a no-op on it, and the golden side's key (correctly
+ * canonicalised from ITS OWN prefix) never matches. Every path in the
+ * artifact then shows up as wholesale `missing` (under the golden's canonical
+ * key) AND `extra` (under the actual's un-canonicalised key), even when the
+ * content is byte-identical. Keying by the RESOLVED actual file's own
+ * basename (which DOES contain `actualPrefix`) fixes the canonicalisation on
+ * both sides consistently — matching the documented multi-artifact contract
+ * (src/eval/oracle/normalize.ts's `normalizeMultiArtifact` doc comment).
+ *
+ * A golden artifact with NO resolvable actual file (genuinely missing, not a
+ * prefix-matching miss) keeps the golden's own name as the key with empty
+ * content — unchanged from before; there is no real actual basename to key it
+ * by, and the empty content correctly registers every one of that artifact's
+ * paths as `missing`.
+ */
+export function buildActualArtifactsMap(
+  actualDir: string,
+  artifactNames: string[],
+  goldenPrefix: string,
+  actualPrefix: string,
+): { actualArtifacts: Record<string, string>; matchedActualFiles: Set<string> } {
+  const actualArtifacts: Record<string, string> = {};
+  const matchedActualFiles = new Set<string>();
+  for (const name of artifactNames) {
+    const actualFile = resolveActualFile(actualDir, name, goldenPrefix, actualPrefix);
+    if (actualFile) {
+      const actualBasename = path.basename(actualFile);
+      actualArtifacts[actualBasename] = fs.readFileSync(actualFile, 'utf8');
+      matchedActualFiles.add(actualBasename);
+    } else {
+      actualArtifacts[name] = '';
+    }
+  }
+  return { actualArtifacts, matchedActualFiles };
+}

--- a/src/eval/oracle/cli.ts
+++ b/src/eval/oracle/cli.ts
@@ -33,9 +33,10 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import {
   evaluate, evaluateMulti, renderDiff, renderNormalized, normalizeAotXml, parseSysTestResult,
-  GOLDEN_CAPTURE_PREFIX, canonicalizePrefix, type CaseSpec,
+  GOLDEN_CAPTURE_PREFIX, type CaseSpec,
 } from './index.js';
 import { resolveRegularObjectPrefixToken } from '../../utils/modelClassifier.js';
+import { buildActualArtifactsMap } from './actualArtifactResolution.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
@@ -68,32 +69,6 @@ function listGoldenArtifacts(caseId: string): string[] {
 function shortSha(): string {
   try { return execSync('git rev-parse --short HEAD', { cwd: REPO_ROOT }).toString().trim(); }
   catch { return 'unknown'; }
-}
-
-/**
- * Resolve the actual-dir file matching a golden artifact filename. Tries an
- * exact filename match first (fast path, and the only path when golden and
- * actual happen to share the same EXTENSION_PREFIX session); if that misses,
- * falls back to matching on the PREFIX-CANONICALISED filename (the golden's
- * filename is itself typically a prefixed object name, e.g.
- * "AslMyContract.metadata.xml", produced under a different session than the
- * one that generated the actual artifacts) so a whole L3/L4 multi-artifact
- * case doesn't spuriously score every artifact as missing/extra under prefix
- * drift alone.
- */
-function resolveActualFile(
-  actualDir: string,
-  goldenName: string,
-  goldenPrefix: string,
-  actualPrefix: string,
-): string | undefined {
-  const direct = path.join(actualDir, goldenName);
-  if (fs.existsSync(direct)) return direct;
-  const canonGolden = canonicalizePrefix(goldenName, goldenPrefix);
-  const candidate = fs.readdirSync(actualDir)
-    .filter(f => f.endsWith('.metadata.xml'))
-    .find(f => canonicalizePrefix(f, actualPrefix) === canonGolden);
-  return candidate ? path.join(actualDir, candidate) : undefined;
 }
 
 /** Flags that consume the following argv element as their value. */
@@ -155,14 +130,11 @@ async function main(): Promise<void> {
     const artifactNames = listGoldenArtifacts(caseId);
     if (artifactNames.length === 0) throw new Error(`No *.metadata.xml goldens in ${goldenDir(caseId)}`);
     const goldenArtifacts: Record<string, string> = {};
-    const actualArtifacts: Record<string, string> = {};
-    const matchedActualFiles = new Set<string>();
     for (const name of artifactNames) {
       goldenArtifacts[name] = fs.readFileSync(path.join(goldenDir(caseId), name), 'utf8');
-      const actualFile = resolveActualFile(resolvedActualDir, name, goldenPrefix, actualPrefix);
-      actualArtifacts[name] = actualFile ? fs.readFileSync(actualFile, 'utf8') : '';
-      if (actualFile) matchedActualFiles.add(path.basename(actualFile));
     }
+    const { actualArtifacts, matchedActualFiles } =
+      buildActualArtifactsMap(resolvedActualDir, artifactNames, goldenPrefix, actualPrefix);
     // Surface extra actual files (produced but not golden-expected, and not already
     // matched to a golden artifact above under prefix-canonicalised filename matching) too.
     for (const f of fs.readdirSync(resolvedActualDir).filter(f => f.endsWith('.metadata.xml'))) {

--- a/tests/eval/oracleCli.test.ts
+++ b/tests/eval/oracleCli.test.ts
@@ -1,0 +1,99 @@
+/**
+ * src/eval/oracle/cli.ts's multi-artifact (`--actual-dir`) artifact-map
+ * building — VM-free, real temp directories (no fs mocking needed).
+ *
+ * Regression (eval/corpus/runs/2026-07-06T18__L1-form-basic__f2c8bfe.json,
+ * finding #3): `actualArtifacts` used to be keyed by the GOLDEN's own
+ * filename even when the resolved actual file had a DIFFERENT literal
+ * prefix (prefix-agnostic matching is the whole point of resolveActualFile).
+ * evaluateMulti/normalizeMultiArtifact then canonicalises each artifact KEY
+ * against `actualPrefix` — a key that's still the golden's literal name
+ * doesn't contain actualPrefix, so canonicalisation silently no-ops, and the
+ * golden side's key (correctly canonicalised) never matches. Every path in
+ * the artifact then showed up as wholesale `missing` + `extra` even when the
+ * content was byte-identical. Confirmed by the implementer re-running the
+ * same two artifacts through the single-file oracle path (no --actual-dir),
+ * which produced clean, accurate diffs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { buildActualArtifactsMap } from '../../src/eval/oracle/actualArtifactResolution';
+
+describe('buildActualArtifactsMap', () => {
+  let actualDir: string;
+
+  beforeEach(() => {
+    actualDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-cli-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(actualDir, { recursive: true, force: true });
+  });
+
+  it('keys a resolved actual file by ITS OWN basename, not the golden filename, when prefixes differ', () => {
+    // Golden expects "AslMyContract.metadata.xml"; the actual VM session ran under
+    // a DIFFERENT EXTENSION_PREFIX ("FmMcp") and produced "FmMcpMyContract.metadata.xml".
+    const actualContent = '<AxClass><Name>FmMcpMyContract</Name></AxClass>';
+    fs.writeFileSync(path.join(actualDir, 'FmMcpMyContract.metadata.xml'), actualContent, 'utf8');
+
+    const { actualArtifacts, matchedActualFiles } = buildActualArtifactsMap(
+      actualDir,
+      ['AslMyContract.metadata.xml'],
+      'Asl',
+      'FmMcp',
+    );
+
+    // The regression: this used to be keyed 'AslMyContract.metadata.xml' (the golden's
+    // name), which desyncs prefix-canonicalisation downstream. Must be the actual
+    // file's own basename instead.
+    expect(Object.keys(actualArtifacts)).toEqual(['FmMcpMyContract.metadata.xml']);
+    expect(actualArtifacts['FmMcpMyContract.metadata.xml']).toBe(actualContent);
+    expect(actualArtifacts['AslMyContract.metadata.xml']).toBeUndefined();
+    expect(matchedActualFiles.has('FmMcpMyContract.metadata.xml')).toBe(true);
+  });
+
+  it('keeps the golden filename as the key (empty content) when no actual file resolves at all', () => {
+    const { actualArtifacts, matchedActualFiles } = buildActualArtifactsMap(
+      actualDir, // empty directory — nothing to match
+      ['AslMissingArtifact.metadata.xml'],
+      'Asl',
+      'FmMcp',
+    );
+    expect(actualArtifacts).toEqual({ 'AslMissingArtifact.metadata.xml': '' });
+    expect(matchedActualFiles.size).toBe(0);
+  });
+
+  it('a direct filename match (same prefix session) keys by that same name', () => {
+    const content = '<AxClass><Name>AslMyContract</Name></AxClass>';
+    fs.writeFileSync(path.join(actualDir, 'AslMyContract.metadata.xml'), content, 'utf8');
+
+    const { actualArtifacts, matchedActualFiles } = buildActualArtifactsMap(
+      actualDir,
+      ['AslMyContract.metadata.xml'],
+      'Asl',
+      'Asl',
+    );
+    expect(actualArtifacts).toEqual({ 'AslMyContract.metadata.xml': content });
+    expect(matchedActualFiles.has('AslMyContract.metadata.xml')).toBe(true);
+  });
+
+  it('handles multiple golden artifacts independently, some matched under a different prefix, some missing', () => {
+    fs.writeFileSync(path.join(actualDir, 'FmMcpContract.metadata.xml'), 'CONTRACT', 'utf8');
+    // No file for "Controller" at all.
+
+    const { actualArtifacts, matchedActualFiles } = buildActualArtifactsMap(
+      actualDir,
+      ['AslContract.metadata.xml', 'AslController.metadata.xml'],
+      'Asl',
+      'FmMcp',
+    );
+    expect(actualArtifacts).toEqual({
+      'FmMcpContract.metadata.xml': 'CONTRACT',
+      'AslController.metadata.xml': '',
+    });
+    expect(matchedActualFiles).toEqual(new Set(['FmMcpContract.metadata.xml']));
+  });
+});


### PR DESCRIPTION
## Summary
`eval/corpus/runs/2026-07-06T18__L1-form-basic__f2c8bfe.json` (finding #3): `src/eval/oracle/cli.ts`'s `--actual-dir` (multi-artifact) mode keyed `actualArtifacts` by the GOLDEN's own filename even when the resolved actual file had a DIFFERENT literal `EXTENSION_PREFIX` (e.g. golden `"AslMyContract.metadata.xml"` resolved — via `resolveActualFile`'s own prefix-agnostic matching — to actual file `"FmMcpMyContract.metadata.xml"`).

`evaluateMulti`/`normalizeMultiArtifact` then canonicalises each artifact KEY against `actualPrefix` (§6.2/§6.4) — but a key that is still the golden's literal name doesn't contain `actualPrefix` at all, so canonicalisation silently no-ops on it, while the golden side's key (correctly canonicalised from its own prefix) does change. The two canonical keys never match, so **every path in that artifact shows up as wholesale `missing` (under the golden's canonical key) AND `extra` (under the actual's un-canonicalised key) — even when the content is byte-identical.**

Confirmed by the implementer re-running the same two artifacts through the single-file oracle path (no `--actual-dir`), which produced clean, accurate diffs — isolating the bug to the multi-artifact key-building, not the diffing logic itself.

## Fix
- Extracts the artifact-map-building logic into a new pure module (`src/eval/oracle/actualArtifactResolution.ts`) — the CLI script runs `main()` unconditionally at import time, so this logic needed to live somewhere importable from a test without triggering that.
- Fixes it to key a resolved actual file by **its own basename** (which does carry `actualPrefix`) instead of the golden's name. A genuinely-missing artifact (no actual file resolves at all) keeps the golden's name as the key with empty content — unchanged from before.

## Evidence
- `eval/corpus/runs/2026-07-06T18__L1-form-basic__f2c8bfe.json`

## Test plan
- [x] New `tests/eval/oracleCli.test.ts` (4 tests, using real temp directories — no fs mocking): resolved-under-a-different-prefix case keys by the actual basename; genuinely-missing artifact keeps the golden name with empty content; same-prefix direct match; mixed batch (one resolved under a different prefix, one missing).
- [x] Confirmed load-bearing: reverted the key-building fix only and re-ran — 2 of 4 tests fail exactly as the corpus symptom describes.
- [x] `npx vitest run` — full suite green (102 files / 1518 tests).
- [x] Manually ran `npm run eval:score` with no args — CLI still boots and prints usage (no import-time crash from the refactor).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV