### PR TITLE
fix(map): accept edt alongside extendedDataType; document map properties

### DIFF
--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -73,7 +73,8 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             '• security-duty: label, privileges[]\n' +
             '• security-role: label, duties[], privileges[]\n' +
             '• menu-item-*: label, object, objectType\n' +
-            '• data-entity: primaryTable, fields[{name,dataField?}]'
+            '• data-entity: primaryTable, fields[{name,dataField?}]\n' +
+            '• map: label?, developerDocumentation?, fields[{name,type?,edt?,enumType?,stringSize?}], mappingTable?, mappings?[{mapField,mapFieldTo}] (defaults to one connection per field when mappingTable is set)'
         },
         addToProject: {
           type: 'boolean',

--- a/src/tools/mapXml.ts
+++ b/src/tools/mapXml.ts
@@ -24,6 +24,8 @@ interface MapFieldDef {
   name: string;
   type?: string;
   extendedDataType?: string;
+  /** Alias for extendedDataType (matches the table/table-extension field-spec convention). */
+  edt?: string;
   enumType?: string;
   stringSize?: number;
 }
@@ -34,7 +36,16 @@ interface MapMappingConnection {
 }
 
 /**
- * properties.fields         — [{ name, type?, extendedDataType?, enumType?, stringSize? }]
+ * properties.fields         — [{ name, type?, edt?|extendedDataType?, enumType?, stringSize? }]
+ *                              `edt` is the primary key (matches the `table`/`table-extension`
+ *                              field-spec convention used everywhere else in this tool's
+ *                              properties shapes); `extendedDataType` is accepted as an alias
+ *                              since it matches the emitted XML element name — a caller using
+ *                              either spelling gets an EDT written, instead of it being silently
+ *                              dropped (regression: eval/corpus/runs/
+ *                              2026-07-06T18__L1-map-basic__cb1b73d.json — `map` had NO entry in
+ *                              the properties documentation at all, so a caller reasonably
+ *                              guessed `edt` from the table convention and it was silently lost).
  * properties.mappingTable   — name of the underlying AxTable this map targets.
  * properties.mappings       — [{ mapField, mapFieldTo }] connections into that table.
  *                              Defaults to one connection per field (mapFieldTo = name)
@@ -52,7 +63,8 @@ export function buildAxMapXml(mapName: string, properties?: Record<string, any>)
     ? fields.map(f => {
       const axType = FIELD_TYPE_TO_AXTYPE[f.type || 'String'] || 'AxMapFieldString';
       const inner: string[] = [`\t\t\t<Name>${f.name}</Name>`];
-      if (f.extendedDataType) inner.push(`\t\t\t<ExtendedDataType>${f.extendedDataType}</ExtendedDataType>`);
+      const edt = f.extendedDataType || f.edt;
+      if (edt) inner.push(`\t\t\t<ExtendedDataType>${edt}</ExtendedDataType>`);
       if (axType === 'AxMapFieldEnum' && f.enumType) inner.push(`\t\t\t<EnumType>${f.enumType}</EnumType>`);
       if (axType === 'AxMapFieldString' && f.stringSize !== undefined) inner.push(`\t\t\t<StringSize>${f.stringSize}</StringSize>`);
       return `\t\t<AxMapBaseField xmlns=""\n\t\t\ti:type="${axType}">\n${inner.join('\n')}\n\t\t</AxMapBaseField>`;

--- a/tests/tools/mapXml.test.ts
+++ b/tests/tools/mapXml.test.ts
@@ -1,0 +1,70 @@
+/**
+ * buildAxMapXml (src/tools/mapXml.ts).
+ *
+ * Regression: eval/corpus/runs/2026-07-06T18__L1-map-basic__cb1b73d.json —
+ * `map` had NO entry at all in the d365fo_file properties documentation
+ * (every other objectType does), so a caller reasonably guessed field-EDT
+ * property names from the sibling `table`/`table-extension` convention
+ * (`edt`), which buildAxMapXml did not read (only `extendedDataType`) — the
+ * EDT was silently dropped from every generated field.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildAxMapXml } from '../../src/tools/mapXml';
+
+describe('buildAxMapXml — field EDT property name', () => {
+  it('writes ExtendedDataType from the documented extendedDataType key (existing behaviour, unchanged)', () => {
+    const xml = buildAxMapXml('ConDemoNoteMap', {
+      fields: [{ name: 'NoteId', extendedDataType: 'Num' }],
+    });
+    expect(xml).toContain('<ExtendedDataType>Num</ExtendedDataType>');
+  });
+
+  it('ALSO writes ExtendedDataType from `edt` (the table/table-extension field-spec convention) — regression', () => {
+    const xml = buildAxMapXml('ConDemoNoteMap', {
+      fields: [{ name: 'NoteId', edt: 'Num' }],
+    });
+    expect(xml).toContain('<ExtendedDataType>Num</ExtendedDataType>');
+  });
+
+  it('extendedDataType wins when both are somehow given', () => {
+    const xml = buildAxMapXml('ConDemoNoteMap', {
+      fields: [{ name: 'NoteId', extendedDataType: 'Num', edt: 'SomethingElse' }],
+    });
+    expect(xml).toContain('<ExtendedDataType>Num</ExtendedDataType>');
+    expect(xml).not.toContain('SomethingElse');
+  });
+
+  it('omits ExtendedDataType entirely when neither key is given (unchanged)', () => {
+    const xml = buildAxMapXml('ConDemoNoteMap', {
+      fields: [{ name: 'CreatedDateTime', type: 'UtcDateTime' }],
+    });
+    expect(xml).not.toContain('<ExtendedDataType>');
+  });
+});
+
+describe('buildAxMapXml — mappingTable + mappings (documented shape, already correct)', () => {
+  it('writes MappingTable + one connection per field by default', () => {
+    const xml = buildAxMapXml('ConDemoNoteMap', {
+      mappingTable: 'ConDemoNoteHeader',
+      fields: [{ name: 'NoteId', edt: 'Num' }, { name: 'Subject', edt: 'Description' }],
+    });
+    expect(xml).toContain('<MappingTable>ConDemoNoteHeader</MappingTable>');
+    expect(xml).toContain('<MapField>NoteId</MapField>\n\t\t\t\t\t<MapFieldTo>NoteId</MapFieldTo>');
+    expect(xml).toContain('<MapField>Subject</MapField>\n\t\t\t\t\t<MapFieldTo>Subject</MapFieldTo>');
+  });
+
+  it('honours explicit mappings overriding the default 1:1 connection', () => {
+    const xml = buildAxMapXml('ConDemoNoteMap', {
+      mappingTable: 'ConDemoNoteHeader',
+      fields: [{ name: 'NoteId', edt: 'Num' }],
+      mappings: [{ mapField: 'NoteId', mapFieldTo: 'DifferentField' }],
+    });
+    expect(xml).toContain('<MapFieldTo>DifferentField</MapFieldTo>');
+  });
+
+  it('emits an empty <Mappings /> when mappingTable is not given', () => {
+    const xml = buildAxMapXml('ConDemoNoteMap', { fields: [{ name: 'NoteId', edt: 'Num' }] });
+    expect(xml).toContain('<Mappings />');
+  });
+});


### PR DESCRIPTION
## Summary
`eval/corpus/runs/2026-07-06T18__L1-map-basic__cb1b73d.json`: `map` had **no entry at all** in the `d365fo_file` `properties` documentation (every other `objectType` — class/table/enum/edt/form/security-\*/menu-item-\*/data-entity — does). A caller with no guidance reasonably guessed field-EDT property names from the sibling `table`/`table-extension` field-spec convention (`edt`), which `buildAxMapXml` only ever read as `extendedDataType` — the EDT was silently dropped from every generated `AxMapBaseField`.

## Root cause + scope note
`buildAxMapXml`'s `mappingTable` + `mappings` handling for the map's underlying-table wiring was **already correct and fully wired** — the corpus record's second finding ("`properties.mappings` ignored outright") is consistent with a caller guessing a different, nested shape for a wholly undocumented property, not a code defect. Documenting the actual flat shape directly addresses it; new tests confirm the existing (already-correct) behaviour rather than changing it.

## Fix
- `src/tools/mapXml.ts`: field EDT now resolves from `edt` OR `extendedDataType` (`extendedDataType` wins if both are given — it matches the emitted XML element name).
- `src/server/toolSchemas/d365foFile.ts`: adds the missing `• map: ...` properties documentation line (`fields[{name,type?,edt?,enumType?,stringSize?}], mappingTable?, mappings?[{mapField,mapFieldTo}]`).

## Evidence
- `eval/corpus/runs/2026-07-06T18__L1-map-basic__cb1b73d.json`

## Test plan
- [x] New `tests/tools/mapXml.test.ts` (7 tests): `edt` and `extendedDataType` both write `<ExtendedDataType>`; `extendedDataType` wins when both given; neither given emits nothing (unchanged); `mappingTable`/`mappings` default-1:1 and explicit-override behaviour (regression-guard for the already-correct part).
- [x] Confirmed load-bearing: reverted `mapXml.ts` only and re-ran — the `edt` alias test fails as expected.
- [x] `npx vitest run tests/utils/toolSchemaBudget.test.ts` — the new documentation line stays within the token-budget ceilings.
- [x] `npx vitest run` — full suite green (102 files / 1521 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV