### PR TITLE
fix(form-scaffold): default Caption to the bound table's reused Label

### DIFF
--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -122,6 +122,44 @@ export const generateSmartFormTool: Tool = {
 };
 
 /**
+ * Default Design/Caption for a scaffolded form (pure — no DB access).
+ *
+ * Regression (eval/corpus/runs/2026-07-06T17__L1-form-listpage__cb1b73d.json,
+ * cross-referenced by L1-form-dialog and L1-form-lookup — "a systemic
+ * scaffold default, not a one-off"): when neither an explicit `caption` nor
+ * `label` argument was given, the caption defaulted to the raw object name
+ * (e.g. "PFXDemoNoteHeaderListPage") instead of reusing the bound
+ * datasource table's own Label — even though that Label is resolvable via
+ * the bridge/symbol index and is exactly the value real D365FO forms use
+ * (raw-text captions also trip BPErrorLabelIsText and cascade into
+ * BPErrorCaptionNotDefined on unlabeled ActionPane/ButtonGroups). Reusing
+ * the bound table's Label when available is both more correct and BP-clean.
+ */
+export function resolveFormCaption(
+  explicitCaption: string | undefined,
+  explicitLabel: string | undefined,
+  tableLabel: string | undefined,
+  fallbackName: string,
+): string {
+  return explicitCaption || explicitLabel || tableLabel || fallbackName;
+}
+
+/**
+ * Look up a table's own Label reference (e.g. "@TaxTransactionInquiry:HeaderNote")
+ * from the symbol index, for use as a scaffolded form's default caption. Returns
+ * undefined when the table is unindexed or has no Label recorded — callers fall
+ * back to `label`/the raw object name via `resolveFormCaption`.
+ */
+export function lookupTableLabel(symbolIndex: XppSymbolIndex, table: string | undefined): string | undefined {
+  if (!table) return undefined;
+  try {
+    return symbolIndex.getSymbolByName?.(table, 'table')?.signature || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Pre-write check for cloneFrom: cloning copies the reference form's control
  * hierarchy and sub-patterns verbatim. If the caller asked for a different
  * pattern than the reference declares, the result will likely violate the
@@ -747,7 +785,7 @@ export async function handleGenerateSmartForm(
       formName: finalName,
       dsName: primaryDs?.name,
       dsTable: primaryDs?.table,
-      caption: caption || label || finalName,
+      caption: resolveFormCaption(caption, label, lookupTableLabel(symbolIndex, primaryDs?.table), finalName),
       gridFields,
       fieldTypes,
       linesDsName: linesDsNameResolved ?? (linesTableResolved || undefined),

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -889,6 +889,80 @@ describe('generate_smart_form', () => {
     expect(result?.content[0].text).toContain('MyCustomTable');
   });
 
+  it('defaults the Caption to the bound table\'s own reused Label, not the raw object name', async () => {
+    // Regression: eval/corpus/runs/2026-07-06T17__L1-form-listpage__cb1b73d.json (cross-
+    // referenced by L1-form-dialog and L1-form-lookup as "a systemic scaffold default, not
+    // a one-off"): with no explicit caption/label given, Caption used to fall back to the
+    // raw object name ("PFXDemoNoteHeaderListPage") instead of the table's real Label,
+    // even though that Label is resolvable via the symbol index.
+    const labelCtx = buildContext({
+      symbolIndex: {
+        ...ctx.symbolIndex,
+        getSymbolByName: vi.fn((name: string, type: string) =>
+          type === 'table' && name === 'ConDemoNoteHeader'
+            ? { name, type: 'table', signature: '@TaxTransactionInquiry:HeaderNote' }
+            : undefined,
+        ),
+      } as any,
+    });
+
+    const result = await handleGenerateSmartForm(
+      {
+        name: 'ConDemoNoteHeaderListPage',
+        modelName: 'MyModel',
+        dataSource: 'ConDemoNoteHeader',
+        formPattern: 'ListPage',
+      },
+      labelCtx.symbolIndex,
+    );
+    const text = result?.content[0].text as string;
+    expect(text).toContain('<Caption xmlns="">@TaxTransactionInquiry:HeaderNote</Caption>');
+    expect(text).not.toContain('<Caption xmlns="">ConDemoNoteHeaderListPage</Caption>');
+    expect(text).not.toContain('<Caption xmlns="">PFXConDemoNoteHeaderListPage</Caption>');
+  });
+
+  it('an explicit caption argument still wins over the table Label', async () => {
+    const labelCtx = buildContext({
+      symbolIndex: {
+        ...ctx.symbolIndex,
+        getSymbolByName: vi.fn((name: string, type: string) =>
+          type === 'table' && name === 'ConDemoNoteHeader'
+            ? { name, type: 'table', signature: '@TaxTransactionInquiry:HeaderNote' }
+            : undefined,
+        ),
+      } as any,
+    });
+
+    const result = await handleGenerateSmartForm(
+      {
+        name: 'ConDemoNoteHeaderListPage',
+        modelName: 'MyModel',
+        dataSource: 'ConDemoNoteHeader',
+        formPattern: 'ListPage',
+        caption: '@MyModel:ExplicitCaption',
+      },
+      labelCtx.symbolIndex,
+    );
+    const text = result?.content[0].text as string;
+    expect(text).toContain('<Caption xmlns="">@MyModel:ExplicitCaption</Caption>');
+  });
+
+  it('falls back to the (resolved) object name when the table has no indexed Label (unchanged behaviour)', async () => {
+    const result = await handleGenerateSmartForm(
+      {
+        name: 'MyUnlabeledForm',
+        modelName: 'MyModel',
+        dataSource: 'UnindexedTable',
+        formPattern: 'ListPage',
+      },
+      ctx.symbolIndex, // default mock: getSymbolByName always returns undefined
+    );
+    const text = result?.content[0].text as string;
+    // No table Label available — falls back to the resolved object name, same as before
+    // this fix (no @Label-style caption is emitted; whatever name the object resolved to).
+    expect(text).toMatch(/<Caption xmlns="">[^@<]*MyUnlabeledForm<\/Caption>/);
+  });
+
   it('expands a template-less pattern deterministically from the catalog', async () => {
     // "Task" (TaskSingle) has a catalog spec but no hand-written builder
     // template. It used to silently degrade to SimpleList; now the deterministic


### PR DESCRIPTION
## Summary
`eval/corpus/runs/2026-07-06T17__L1-form-listpage__cb1b73d.json` (explicitly cross-referenced by the `L1-form-dialog` and `L1-form-lookup` goldens as *"a systemic scaffold default, not a one-off"*): when `generate_object(mode=scaffold, objectType=form)` was called with no explicit `caption`/`label` argument, `Design/Caption` defaulted to the raw object name (e.g. `"PFXDemoNoteHeaderListPage"`) instead of reusing the bound datasource table's own Label — even though that Label is resolvable via the bridge/symbol index and is exactly the value real D365FO forms use for this. A raw-text caption also trips `BPErrorLabelIsText` and cascades into `BPErrorCaptionNotDefined` warnings on the form's unlabeled ActionPane/ButtonGroups.

## Root cause
`templateOpts.caption` resolved as `caption || label || finalName` — the object name — with no attempt to look up the bound table's Label at all.

## Fix
`src/tools/generateSmartForm.ts` adds:
- `lookupTableLabel` — reads a table's Label via `symbolIndex.getSymbolByName(table, 'table').signature` (the same column `tableInfo.ts` and other callers already rely on for table Labels).
- `resolveFormCaption` — pure helper: explicit `caption` > explicit `label` > table's reused Label > raw object name.

Wired into the template (non-`cloneFrom`) scaffold path.

## Evidence
- `eval/corpus/runs/2026-07-06T17__L1-form-listpage__cb1b73d.json`

## Test plan
- [x] New tests in `tests/tools/code-generation.test.ts`: defaults to the table's reused Label when no caption/label is given; an explicit `caption` argument still wins over the table Label; falls back to the resolved object name (unchanged) when the table has no indexed Label.
- [x] Confirmed load-bearing: reverted the fix only and re-ran — the "defaults to table Label" test fails as expected.
- [x] `npx vitest run` — full suite green (101 files / 1517 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTkR734GWnrwKw1ok2RADV