### PR TITLE
fix: replace forbidden Asl/fm-mcp prefixes with Contoso/Demo

### DIFF
--- a/.claude/agents/eval-implementer.md
+++ b/.claude/agents/eval-implementer.md
@@ -1,6 +1,6 @@
 ---
 name: eval-implementer
-description: Implementer role of the D365FO agent eval loop. Runs ON THE VM (mcp-server in full mode + C# bridge) against the fm-mcp sandbox model. Takes an eval case id, drives the grounded MCP tool path to implement it, builds, scores against the golden/SysTest oracle, writes a corpus record, and rolls back. Use when asked to "run eval case <id>", "run the implementer", or execute a case end-to-end on the VM.
+description: Implementer role of the D365FO agent eval loop. Runs ON THE VM (mcp-server in full mode + C# bridge) against the Contoso sandbox model. Takes an eval case id, drives the grounded MCP tool path to implement it, builds, scores against the golden/SysTest oracle, writes a corpus record, and rolls back. Use when asked to "run eval case <id>", "run the implementer", or execute a case end-to-end on the VM.
 tools: Bash, Read, Grep, Glob, mcp__d365fo-eval__prepare, mcp__d365fo-eval__search, mcp__d365fo-eval__get_object_info, mcp__d365fo-eval__batch_get_info, mcp__d365fo-eval__extension_info, mcp__d365fo-eval__find_references, mcp__d365fo-eval__validate_code, mcp__d365fo-eval__validate_object_naming, mcp__d365fo-eval__generate_object, mcp__d365fo-eval__d365fo_file, mcp__d365fo-eval__build_d365fo_project, mcp__d365fo-eval__run_systest_class, mcp__d365fo-eval__run_bp_check, mcp__d365fo-eval__trigger_db_sync, mcp__d365fo-eval__verify_d365fo_project, mcp__d365fo-eval__undo_last_modification, mcp__d365fo-eval__update_symbol_index, mcp__d365fo-eval__get_workspace_info, mcp__d365fo-eval__get_method, mcp__d365fo-eval__get_knowledge, mcp__d365fo-eval__analyze_code, mcp__d365fo-eval__security_info, mcp__d365fo-eval__suggest_edt, mcp__d365fo-eval__labels, mcp__d365fo-eval__object_patterns, mcp__d365fo-eval__review_workspace_changes
 model: inherit
 ---
@@ -13,11 +13,11 @@ dev VM** with the mcp-server in `full` mode + the C# bridge connected.
 `validate_code`, `generate_object`, `d365fo_file`, `build_d365fo_project`,
 `run_systest_class`, …) must be connected in this session. If they are not, stop
 and tell the user — this role only works on the VM. Never target a real
-customisation model; **all writes are pinned to the `fm-mcp` sandbox** (§11).
+customisation model; **all writes are pinned to the `Contoso` sandbox** (§11).
 
 ## The loop, for the given case id (read `eval/cases/<id>.json` first)
 
-1. **Isolate** — confirm the empty `fm-mcp` sandbox model exists and any model
+1. **Isolate** — confirm the empty `Contoso` sandbox model exists and any model
    references the case notes (e.g. FleetManagement) are present in its Descriptor.
 2. **Implement (grounded only)** — drive the case `instruction` through the tool
    path: `prepare` → query tools (`search`, `object_info`, `extension_info`, …) →

--- a/.claude/commands/eval-run.md
+++ b/.claude/commands/eval-run.md
@@ -13,5 +13,5 @@ First read `eval/cases/$ARGUMENTS.json`. The subagent carries the full loop
 (isolate → implement grounded-only → static gate → build → golden/SysTest oracle
 via `npm run eval:score` → write corpus record → roll back → triage hypothesis).
 It requires the d365fo MCP tools connected in full mode on the VM and pins all
-writes to the `fm-mcp` sandbox — if those tools are not available, it will say so
+writes to the `Contoso` sandbox — if those tools are not available, it will say so
 and stop. Relay the corpus record and pass/fail verdict back to me.

--- a/src/eval/oracle/actualArtifactResolution.ts
+++ b/src/eval/oracle/actualArtifactResolution.ts
@@ -14,7 +14,7 @@ import { canonicalizePrefix } from './normalize.js';
  * actual happen to share the same EXTENSION_PREFIX session); if that misses,
  * falls back to matching on the PREFIX-CANONICALISED filename (the golden's
  * filename is itself typically a prefixed object name, e.g.
- * "AslMyContract.metadata.xml", produced under a different session than the
+ * "ContosoMyContract.metadata.xml", produced under a different session than the
  * one that generated the actual artifacts) so a whole L3/L4 multi-artifact
  * case doesn't spuriously score every artifact as missing/extra under prefix
  * drift alone.
@@ -41,8 +41,8 @@ export function resolveActualFile(
  * Regression: this used to key every entry by the GOLDEN's own filename
  * (`actualArtifacts[name] = ...` inside a `for (const name of
  * artifactNames)` loop) even when the resolved actual file had a DIFFERENT
- * literal prefix (e.g. golden "AslMyContract.metadata.xml" resolved to actual
- * file "FmMcpMyContract.metadata.xml" under prefix-agnostic matching —
+ * literal prefix (e.g. golden "ContosoMyContract.metadata.xml" resolved to actual
+ * file "DemoMyContract.metadata.xml" under prefix-agnostic matching —
  * `resolveActualFile`'s whole point). `evaluateMulti`/`normalizeMultiArtifact`
  * then canonicalises each artifact KEY with `actualPrefix` — but a key that's
  * still the GOLDEN's literal name doesn't contain `actualPrefix` at all, so

--- a/src/eval/oracle/cli.ts
+++ b/src/eval/oracle/cli.ts
@@ -72,14 +72,6 @@ function shortSha(): string {
 }
 
 /** Flags that consume the following argv element as their value. */
-  const candidate = fs.readdirSync(actualDir)
-    .filter(f => f.endsWith('.metadata.xml'))
-    .find(f => canonicalizePrefix(f, actualPrefix) === canonGolden);
-  return candidate ? path.join(actualDir, candidate) : undefined;
-}
-
->>>>>>> a80f9ee (fix: replace forbidden Asl/fm-mcp prefixes with Contoso/Demo throughout)
-/** Flags that consume the following argv element as their value. */
 const VALUE_FLAGS = [
   '--golden', '--actual-dir', '--bp-warnings', '--systest', '--classification',
   '--golden-prefix', '--actual-prefix',

--- a/src/eval/oracle/cli.ts
+++ b/src/eval/oracle/cli.ts
@@ -12,7 +12,7 @@
  *     --bp-warnings <n>   number of BP warnings (default: 0)
  *     --systest <file>    text file with the `run_systest_class` output (runtime oracle)
  *     --classification <C> rubric class for the record (default: derived)
- *     --golden-prefix <p> EXTENSION_PREFIX the golden was captured under (default: GOLDEN_CAPTURE_PREFIX, "Asl")
+ *     --golden-prefix <p> EXTENSION_PREFIX the golden was captured under (default: GOLDEN_CAPTURE_PREFIX, "Contoso")
  *     --actual-prefix <p> EXTENSION_PREFIX the actual was produced under (default: read from THIS
  *                         process's EXTENSION_PREFIX env var — the session that ran the case)
  *     --write             append a corpus record to eval/corpus/runs/
@@ -71,6 +71,14 @@ function shortSha(): string {
   catch { return 'unknown'; }
 }
 
+/** Flags that consume the following argv element as their value. */
+  const candidate = fs.readdirSync(actualDir)
+    .filter(f => f.endsWith('.metadata.xml'))
+    .find(f => canonicalizePrefix(f, actualPrefix) === canonGolden);
+  return candidate ? path.join(actualDir, candidate) : undefined;
+}
+
+>>>>>>> a80f9ee (fix: replace forbidden Asl/fm-mcp prefixes with Contoso/Demo throughout)
 /** Flags that consume the following argv element as their value. */
 const VALUE_FLAGS = [
   '--golden', '--actual-dir', '--bp-warnings', '--systest', '--classification',

--- a/src/eval/oracle/normalize.ts
+++ b/src/eval/oracle/normalize.ts
@@ -33,15 +33,15 @@ const DEFAULT_IGNORES = ['**/ModelSaveInfo', '**/ModelSaveInfo/**', '**/@Id', '*
  * under THIS prefix — it is not re-derived per run.
  *
  * A later eval run is free to configure ANY EXTENSION_PREFIX for its sandbox
- * session (e.g. "FmMcp") — `d365fo_file`/`generate_object` correctly apply the
+ * session (e.g. "Demo") — `d365fo_file`/`generate_object` correctly apply the
  * CURRENT session's prefix to every new object per their documented contract
- * (src/utils/modelClassifier.ts). An object named "FmMcpXyzNoteSubject" and a
- * golden named "AslXyzNoteSubject" describe the SAME object under two
+ * (src/utils/modelClassifier.ts). An object named "DemoXyzNoteSubject" and a
+ * golden named "ContosoXyzNoteSubject" describe the SAME object under two
  * different prefix sessions — that is not a semantic difference, and must not
  * fail `golden_match` (see the corpus record that surfaced this:
  * eval/corpus/runs/2026-07-06T10__L0-edt-basic__4fafcd8.json).
  */
-export const GOLDEN_CAPTURE_PREFIX = 'Asl';
+export const GOLDEN_CAPTURE_PREFIX = 'Contoso';
 
 /** Escape a literal string for embedding in a RegExp. */
 function escapeRegExp(s: string): string {
@@ -62,7 +62,7 @@ const PREFIX_PLACEHOLDER = 'PFX';
  * immediately after a non-alphanumeric character — `.`, `(`, `,`, `_`,
  * whitespace, …) AND require the prefix to be immediately followed by an
  * uppercase letter (the PascalCase continuation of the object's own name,
- * e.g. `AslXyzNoteSubject`, `CustGroup.AslExtension`, `classStr(AslXyzNoteSubject)`).
+ * e.g. `ContosoXyzNoteSubject`, `CustGroup.ContosoExtension`, `classStr(ContosoXyzNoteSubject)`).
  * This keeps the substitution narrow: an incidental occurrence of the prefix
  * text inside unrelated free-form content (e.g. a label) is left alone.
  */
@@ -320,7 +320,7 @@ export function renderNormalized(map: Map<string, string>): string {
  *
  * `artifacts` keys are filenames (e.g. "MyContract.metadata.xml") — stable,
  * case-author-chosen identifiers, not full paths. The filename itself is
- * typically the prefixed object name (e.g. "AslMyContract.metadata.xml"), so
+ * typically the prefixed object name (e.g. "ContosoMyContract.metadata.xml"), so
  * it is canonicalised with `prefix` too (see `normalizeAotXml`) — otherwise a
  * golden captured under one prefix and an actual produced under another would
  * combine under different `<filename>::` keys and false-mismatch wholesale.

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -550,7 +550,7 @@ export class XmlTemplateGenerator {
 
   /**
    * If `declaration`'s own `class`/`interface` header names something other than
-   * `className` (e.g. the object is being created as "FmMcpFoo" but the caller's
+   * `className` (e.g. the object is being created as "ContosoFoo" but the caller's
    * X++ still says `class Foo`), rename every self-reference to that stale name —
    * in the header AND in every method body (constructor calls, return types,
    * etc.) — to `className`.
@@ -560,7 +560,7 @@ export class XmlTemplateGenerator {
    * `sourceCode`) does not match its own X++ class keyword — a hard xppc build
    * error ("class must be named the same as the object it is contained in"),
    * confirmed by corpus evidence: the caller passed an already-correct,
-   * fully-resolved objectName ("FmMcpXyzNoteFormatter") — so the existing
+   * fully-resolved objectName ("ContosoXyzNoteFormatter") — so the existing
    * objectName-vs-finalObjectName prefix-mismatch guard below never fired — while
    * sourceCode's `class XyzNoteFormatter` used the bare, unprefixed name
    * (eval/corpus/runs/2026-07-06T16__L1-class-basic__73707ff.json).

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -412,7 +412,7 @@ export async function handleGenerateSmartForm(
         add(ln.replace(/Table(Lines?)$/i, 'Line'));
         add(ln.replace(/Table(Lines?)$/i, '$1'));
         if (dataSource) {
-          const base = dataSource.replace(/Table$/i, ''); // header base, e.g. AslRentAgreement
+          const base = dataSource.replace(/Table$/i, ''); // header base, e.g. ContosoRentAgreement
           add(`${base}Line`);
           add(`${base}Lines`);
           add(`${base}TransLine`);
@@ -456,8 +456,8 @@ export async function handleGenerateSmartForm(
 
     // Datasource name: by D365FO convention it equals the (corrected) table name.
     // Honor an explicit linesDataSource ONLY when it is a genuinely distinct name —
-    // not just the wrong pluralized guess (e.g. "AslRentAgreementLines") that the
-    // table auto-correction above already resolved to "AslRentAgreementLine".
+    // not just the wrong pluralized guess (e.g. "ContosoRentAgreementLines") that the
+    // table auto-correction above already resolved to "ContosoRentAgreementLine".
     // Otherwise the form ends up with a datasource named after a non-existent table.
     // Local const captures the (possibly auto-corrected) table name so TS keeps the
     // non-undefined narrowing through the reassignments above.

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1127,7 +1127,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
 
     // 3b. Derive the authoritative object name from the resolved file path.
     //     The caller may pass objectName="RentEquipment" while the file on disk
-    //     is AslRentEquipment.xml (auto-prefixed at create time). The C# bridge
+    //     is ContosoRentEquipment.xml (auto-prefixed at create time). The C# bridge
     //     resolves objects by name from its metadata model — if the name doesn't
     //     match the file it will always return null, regardless of refreshes.
     //     Use path.win32.basename so Windows backslash paths are handled correctly
@@ -1908,7 +1908,7 @@ async function findD365File(
 
   // Resolve by the given name first; if that misses, retry once with the model
   // prefix applied. create_d365fo_file auto-prefixes new object names (e.g.
-  // "RentEquipmentTable" → "AslRentEquipmentTable"), so a modify call with the bare
+  // "RentEquipmentTable" → "ContosoRentEquipmentTable"), so a modify call with the bare
   // name would otherwise fail to locate the file. The bridge object name is then
   // re-derived from the resolved file's basename, so the prefixed name flows through.
   const direct = await resolveD365FileByName(symbolIndex, objectType, objectName, modelName, packagePath);

--- a/src/tools/xppKnowledge.ts
+++ b/src/tools/xppKnowledge.ts
@@ -628,12 +628,12 @@ class MyReportDP extends SRSReportDataProviderBase
     examples: [
       {
         label: 'Module class — register the reference in loadModule() (correct API)',
-        code: `public class NumberSeqModuleAslRent extends NumberSeqApplicationModule
+        code: `public class NumberSeqModuleContosoRent extends NumberSeqApplicationModule
 {
     protected void loadModule()
     {
         NumberSeqDatatype datatype = NumberSeqDatatype::construct();
-        datatype.parmDatatypeId(extendedTypeNum(AslRentEquipmentId));
+        datatype.parmDatatypeId(extendedTypeNum(ContosoRentEquipmentId));
         datatype.parmReferenceHelp(literalStr("Equipment ID"));
         datatype.parmWizardIsContinuous(false);
         datatype.parmWizardIsManual(NoYes::No);
@@ -647,7 +647,7 @@ class MyReportDP extends SRSReportDataProviderBase
 
     public NumberSeqModule numberSeqModule()
     {
-        return NumberSeqModule::AslRent;  // your NumberSeqModule enum value
+        return NumberSeqModule::ContosoRent;  // your NumberSeqModule enum value
     }
 }`,
       },
@@ -660,10 +660,10 @@ public NumberSeqFormHandler numberSeqFormHandler()
     if (!numberSeqFormHandler)
     {
         numberSeqFormHandler = NumberSeqFormHandler::newForm(
-            AslRentParameters::numRefAslRentEquipmentId().NumberSequenceId, // RefRecId, not a string
+            ContosoRentParameters::numRefContosoRentEquipmentId().NumberSequenceId, // RefRecId, not a string
             element,
-            AslRentEquipmentTable_ds,
-            fieldNum(AslRentEquipmentTable, AslRentEquipmentId));
+            ContosoRentEquipmentTable_ds,
+            fieldNum(ContosoRentEquipmentTable, ContosoRentEquipmentId));
     }
     return numberSeqFormHandler;
 }`,
@@ -671,10 +671,10 @@ public NumberSeqFormHandler numberSeqFormHandler()
       {
         label: 'Fetching next number at runtime',
         code: `NumberSequenceReference numSeqRef =
-    NumberSeqReference::findReference(extendedTypeNum(AslRentEquipmentId));
+    NumberSeqReference::findReference(extendedTypeNum(ContosoRentEquipmentId));
 
 NumberSeq numSeq = NumberSeq::newGetNum(numSeqRef);
-AslRentEquipmentId newId = numSeq.num();
+ContosoRentEquipmentId newId = numSeq.num();
 
 // If the insert is rolled back, release the number:
 // numSeq.abort();`,

--- a/tests/eval/oracle.test.ts
+++ b/tests/eval/oracle.test.ts
@@ -20,7 +20,7 @@ import {
 
 const ENUM_GOLDEN = `<?xml version="1.0" encoding="utf-8"?>
 <AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>AslXyzNoteStatus</Name>
+  <Name>ContosoXyzNoteStatus</Name>
   <Label>Note status</Label>
   <UseEnumValue>No</UseEnumValue>
   <IsExtensible>true</IsExtensible>
@@ -34,7 +34,7 @@ const ENUM_GOLDEN = `<?xml version="1.0" encoding="utf-8"?>
 // Same enum, values REORDERED — must still match (collections are order-independent).
 const ENUM_REORDERED = `<?xml version="1.0" encoding="utf-8"?>
 <AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-  <Name>AslXyzNoteStatus</Name>
+  <Name>ContosoXyzNoteStatus</Name>
   <Label>Note status</Label>
   <UseEnumValue>No</UseEnumValue>
   <IsExtensible>true</IsExtensible>
@@ -57,7 +57,7 @@ describe('globToRegExp', () => {
 describe('normalizeAotXml', () => {
   it('flattens elements + attributes to a path → value map', async () => {
     const map = await normalizeAotXml(ENUM_GOLDEN);
-    expect(map.get('AxEnum/Name')).toBe('AslXyzNoteStatus');
+    expect(map.get('AxEnum/Name')).toBe('ContosoXyzNoteStatus');
     expect(map.get('AxEnum/UseEnumValue')).toBe('No');
     expect(map.get('AxEnum/IsExtensible')).toBe('true');
     // Collection members keyed by <Name>, not position.
@@ -110,8 +110,8 @@ describe('normalizeAotXml', () => {
       <AxFormExtensionControl>
         <Name>FormExtensionControlfse38xiwz</Name>
         <FormControl i:type="AxFormCheckBoxControl">
-          <Name>Grid_AslHasNotes</Name>
-          <DataField>AslHasNotes</DataField>
+          <Name>Grid_ContosoHasNotes</Name>
+          <DataField>ContosoHasNotes</DataField>
         </FormControl>
         <Parent>Grid</Parent>
       </AxFormExtensionControl>
@@ -119,12 +119,12 @@ describe('normalizeAotXml', () => {
     const map = await normalizeAotXml(xml);
     // FormControl itself is also keyed by its own Name (pre-existing behavior for any
     // single Name-bearing child) — the fix is the OUTER AxFormExtensionControl key.
-    expect(map.get('AxFormExtension/Controls/AxFormExtensionControl[Grid_AslHasNotes]/FormControl[Grid_AslHasNotes]/DataField'))
-      .toBe('AslHasNotes');
-    expect(map.get('AxFormExtension/Controls/AxFormExtensionControl[Grid_AslHasNotes]/Parent')).toBe('Grid');
+    expect(map.get('AxFormExtension/Controls/AxFormExtensionControl[Grid_ContosoHasNotes]/FormControl[Grid_ContosoHasNotes]/DataField'))
+      .toBe('ContosoHasNotes');
+    expect(map.get('AxFormExtension/Controls/AxFormExtensionControl[Grid_ContosoHasNotes]/Parent')).toBe('Grid');
     // The wrapper's own random Name is still recorded as a leaf value (under the stable key) —
     // just no longer used as the KEY itself.
-    expect(map.get('AxFormExtension/Controls/AxFormExtensionControl[Grid_AslHasNotes]/Name'))
+    expect(map.get('AxFormExtension/Controls/AxFormExtensionControl[Grid_ContosoHasNotes]/Name'))
       .toBe('FormExtensionControlfse38xiwz');
   });
 
@@ -133,8 +133,8 @@ describe('normalizeAotXml', () => {
       <AxFormExtensionControl>
         <Name>FormExtensionControl${wrapperId}</Name>
         <FormControl i:type="AxFormCheckBoxControl">
-          <Name>Grid_AslHasNotes</Name>
-          <DataField>AslHasNotes</DataField>
+          <Name>Grid_ContosoHasNotes</Name>
+          <DataField>ContosoHasNotes</DataField>
         </FormControl>
         <Parent>Grid</Parent>
       </AxFormExtensionControl>
@@ -198,44 +198,44 @@ describe('scoreRun', () => {
 });
 
 describe('normalizeMultiArtifact', () => {
-  const CONTRACT = `<AxClass><Name>AslMyContract</Name><SourceCode><Declaration><![CDATA[class AslMyContract {}]]></Declaration></SourceCode></AxClass>`;
-  const CONTROLLER = `<AxClass><Name>AslMyController</Name><SourceCode><Declaration><![CDATA[class AslMyController {}]]></Declaration></SourceCode></AxClass>`;
+  const CONTRACT = `<AxClass><Name>ContosoMyContract</Name><SourceCode><Declaration><![CDATA[class ContosoMyContract {}]]></Declaration></SourceCode></AxClass>`;
+  const CONTROLLER = `<AxClass><Name>ContosoMyController</Name><SourceCode><Declaration><![CDATA[class ContosoMyController {}]]></Declaration></SourceCode></AxClass>`;
 
   it('prefixes each artifact\'s paths with its filename', async () => {
     const map = await normalizeMultiArtifact({
-      'AslMyContract.metadata.xml': CONTRACT,
-      'AslMyController.metadata.xml': CONTROLLER,
+      'ContosoMyContract.metadata.xml': CONTRACT,
+      'ContosoMyController.metadata.xml': CONTROLLER,
     });
-    expect(map.get('AslMyContract.metadata.xml::AxClass/Name')).toBe('AslMyContract');
-    expect(map.get('AslMyController.metadata.xml::AxClass/Name')).toBe('AslMyController');
+    expect(map.get('ContosoMyContract.metadata.xml::AxClass/Name')).toBe('ContosoMyContract');
+    expect(map.get('ContosoMyController.metadata.xml::AxClass/Name')).toBe('ContosoMyController');
   });
 
   it('an entirely missing artifact diffs as all-missing under its prefix', async () => {
     const golden = await normalizeMultiArtifact({
-      'AslMyContract.metadata.xml': CONTRACT,
-      'AslMyController.metadata.xml': CONTROLLER,
+      'ContosoMyContract.metadata.xml': CONTRACT,
+      'ContosoMyController.metadata.xml': CONTROLLER,
     });
-    const actual = await normalizeMultiArtifact({ 'AslMyContract.metadata.xml': CONTRACT });
+    const actual = await normalizeMultiArtifact({ 'ContosoMyContract.metadata.xml': CONTRACT });
     const diff = diffNormalized(golden, actual);
     expect(diff.matched).toBe(false);
-    expect(diff.missing.every(p => p.startsWith('AslMyController.metadata.xml::'))).toBe(true);
+    expect(diff.missing.every(p => p.startsWith('ContosoMyController.metadata.xml::'))).toBe(true);
   });
 
   it('an unexpected extra artifact diffs as all-extra under its prefix', async () => {
-    const golden = await normalizeMultiArtifact({ 'AslMyContract.metadata.xml': CONTRACT });
+    const golden = await normalizeMultiArtifact({ 'ContosoMyContract.metadata.xml': CONTRACT });
     const actual = await normalizeMultiArtifact({
-      'AslMyContract.metadata.xml': CONTRACT,
-      'AslMyController.metadata.xml': CONTROLLER,
+      'ContosoMyContract.metadata.xml': CONTRACT,
+      'ContosoMyController.metadata.xml': CONTROLLER,
     });
     const diff = diffNormalized(golden, actual);
     expect(diff.matched).toBe(false);
-    expect(diff.extra.every(p => p.startsWith('AslMyController.metadata.xml::'))).toBe(true);
+    expect(diff.extra.every(p => p.startsWith('ContosoMyController.metadata.xml::'))).toBe(true);
   });
 });
 
 describe('evaluateMulti (end-to-end, multi-artifact)', () => {
-  const CONTRACT = `<AxClass><Name>AslMyContract</Name></AxClass>`;
-  const CONTROLLER = `<AxClass><Name>AslMyController</Name></AxClass>`;
+  const CONTRACT = `<AxClass><Name>ContosoMyContract</Name></AxClass>`;
+  const CONTROLLER = `<AxClass><Name>ContosoMyController</Name></AxClass>`;
 
   it('scores a perfect multi-artifact run as golden_match=1', async () => {
     const res = await evaluateMulti({
@@ -254,7 +254,7 @@ describe('evaluateMulti (end-to-end, multi-artifact)', () => {
       goldenArtifacts: { 'Contract.metadata.xml': CONTRACT, 'Controller.metadata.xml': CONTROLLER },
       actualArtifacts: {
         'Contract.metadata.xml': CONTRACT,
-        'Controller.metadata.xml': CONTROLLER.replace('AslMyController', 'AslWrongName'),
+        'Controller.metadata.xml': CONTROLLER.replace('ContosoMyController', 'ContosoWrongName'),
       },
       build: { succeeded: true, bpWarnings: [] },
     });
@@ -290,18 +290,18 @@ describe('evaluate (end-to-end oracle)', () => {
 
 // Regression: a prefix-hardcoding bug discovered during a full-catalog eval run
 // (eval/corpus/runs/2026-07-06T10__L0-edt-basic__4fafcd8.json, classification
-// VALIDATOR_GAP). The L0-edt-basic golden was captured under EXTENSION_PREFIX="Asl"
-// (root object "AslXyzNoteSubject"); a run against a sandbox configured with
-// EXTENSION_PREFIX="FmMcp" correctly produced "FmMcpXyzNoteSubject" — the server
+// VALIDATOR_GAP). The L0-edt-basic golden was captured under EXTENSION_PREFIX="Contoso"
+// (root object "ContosoXyzNoteSubject"); a run against a sandbox configured with
+// EXTENSION_PREFIX="Demo" correctly produced "DemoXyzNoteSubject" — the server
 // applied ITS session's configured prefix per its documented contract
 // (src/utils/modelClassifier.ts). Every other field matched byte-for-byte, yet the
 // oracle's literal string compare on the root Name spuriously failed golden_match.
 // Fixed by making normalize.ts canonicalise prefixed identifiers away before
 // diffing, given each side's own EXTENSION_PREFIX (docs/AGENT_EVAL_LOOP.md §6.2).
 describe('prefix-agnostic golden comparison (regression: eval/corpus/runs/2026-07-06T10__L0-edt-basic__4fafcd8.json)', () => {
-  const EDT_GOLDEN_ASL = `<?xml version="1.0" encoding="utf-8"?>
+  const EDT_GOLDEN_CONTOSO = `<?xml version="1.0" encoding="utf-8"?>
 <AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="" i:type="AxEdtString">
-  <Name>AslXyzNoteSubject</Name>
+  <Name>ContosoXyzNoteSubject</Name>
   <Extends>Name</Extends>
   <Label>Note subject</Label>
   <ArrayElements />
@@ -309,40 +309,40 @@ describe('prefix-agnostic golden comparison (regression: eval/corpus/runs/2026-0
   <TableReferences />
 </AxEdt>`;
 
-  // Same logical object, produced under a DIFFERENT session's EXTENSION_PREFIX ("FmMcp"
-  // instead of "Asl") — this is the actual VM output that triggered the corpus record above.
-  const EDT_ACTUAL_FMMCP = EDT_GOLDEN_ASL.replace(/AslXyzNoteSubject/g, 'FmMcpXyzNoteSubject');
+  // Same logical object, produced under a DIFFERENT session's EXTENSION_PREFIX ("Demo"
+  // instead of "Contoso") — this is the actual VM output that triggered the corpus record above.
+  const EDT_ACTUAL_DEMO = EDT_GOLDEN_CONTOSO.replace(/ContosoXyzNoteSubject/g, 'DemoXyzNoteSubject');
 
   it('canonicalizePrefix reduces both prefix sessions to the same placeholder', () => {
-    expect(canonicalizePrefix('AslXyzNoteSubject', 'Asl'))
-      .toBe(canonicalizePrefix('FmMcpXyzNoteSubject', 'FmMcp'));
+    expect(canonicalizePrefix('ContosoXyzNoteSubject', 'Contoso'))
+      .toBe(canonicalizePrefix('DemoXyzNoteSubject', 'Demo'));
   });
 
   it('does NOT strip a prefix-shaped substring that is not at an identifier boundary', () => {
-    // "CustAslThing" — "Asl" is not at a boundary (preceded by a letter), so it must be left alone.
-    expect(canonicalizePrefix('CustAslThing', 'Asl')).toBe('CustAslThing');
+    // "CustContosoThing" — "Contoso" is not at a boundary (preceded by a letter), so it must be left alone.
+    expect(canonicalizePrefix('CustContosoThing', 'Contoso')).toBe('CustContosoThing');
   });
 
   it('does NOT strip when the prefix is not followed by an uppercase letter (not a real prefix use)', () => {
-    // A free-text label that happens to contain "Asl" mid-sentence, lowercase continuation.
-    expect(canonicalizePrefix('Asleep at the wheel', 'Asl')).toBe('Asleep at the wheel');
+    // A free-text label that starts with "Contoso" but is not followed by an uppercase letter.
+    expect(canonicalizePrefix('Contoso at the wheel', 'Contoso')).toBe('Contoso at the wheel');
   });
 
   it('normalizeAotXml: root Name canonicalises identically for two different EXTENSION_PREFIX sessions', async () => {
-    const golden = await normalizeAotXml(EDT_GOLDEN_ASL, [], 'Asl');
-    const actual = await normalizeAotXml(EDT_ACTUAL_FMMCP, [], 'FmMcp');
+    const golden = await normalizeAotXml(EDT_GOLDEN_CONTOSO, [], 'Contoso');
+    const actual = await normalizeAotXml(EDT_ACTUAL_DEMO, [], 'Demo');
     expect(golden.get('AxEdt/Name')).toBe(actual.get('AxEdt/Name'));
     expect(diffNormalized(golden, actual).matched).toBe(true);
   });
 
-  it('evaluate(): golden_match=1 for an EDT captured under "Asl" and produced under "FmMcp" (this session\'s prefix)', async () => {
+  it('evaluate(): golden_match=1 for an EDT captured under "Contoso" and produced under "Demo" (this session\'s prefix)', async () => {
     const res = await evaluate({
       caseSpec: { id: 'L0-edt-basic', tier: 0, ignore: ['AxEdt/@Id', '**/ModelSaveInfo'] },
-      actualXml: EDT_ACTUAL_FMMCP,
-      goldenXml: EDT_GOLDEN_ASL,
+      actualXml: EDT_ACTUAL_DEMO,
+      goldenXml: EDT_GOLDEN_CONTOSO,
       build: { succeeded: true, bpWarnings: [{ code: 'BPErrorLabelIsText' }] },
       goldenPrefix: GOLDEN_CAPTURE_PREFIX,
-      actualPrefix: 'FmMcp',
+      actualPrefix: 'Demo',
     });
     expect(res.goldenDiff.changed).toEqual([]);
     expect(res.goldenDiff.matched).toBe(true);
@@ -352,8 +352,8 @@ describe('prefix-agnostic golden comparison (regression: eval/corpus/runs/2026-0
   it('WITHOUT prefix canonicalisation (both prefixes empty) the same pair still mismatches — proves the fix is load-bearing', async () => {
     const res = await evaluate({
       caseSpec: { id: 'L0-edt-basic', tier: 0, ignore: ['AxEdt/@Id', '**/ModelSaveInfo'] },
-      actualXml: EDT_ACTUAL_FMMCP,
-      goldenXml: EDT_GOLDEN_ASL,
+      actualXml: EDT_ACTUAL_DEMO,
+      goldenXml: EDT_GOLDEN_CONTOSO,
       build: { succeeded: true, bpWarnings: [{ code: 'BPErrorLabelIsText' }] },
       // no goldenPrefix/actualPrefix — legacy literal-string comparison
     });
@@ -364,41 +364,41 @@ describe('prefix-agnostic golden comparison (regression: eval/corpus/runs/2026-0
   it('a genuinely different root Name (not just a prefix change) still correctly mismatches', async () => {
     const res = await evaluate({
       caseSpec: { id: 'L0-edt-basic', tier: 0 },
-      actualXml: EDT_GOLDEN_ASL.replace('AslXyzNoteSubject', 'AslCompletelyDifferentEdt'),
-      goldenXml: EDT_GOLDEN_ASL,
+      actualXml: EDT_GOLDEN_CONTOSO.replace('ContosoXyzNoteSubject', 'ContosoCompletelyDifferentEdt'),
+      goldenXml: EDT_GOLDEN_CONTOSO,
       build: { succeeded: true, bpWarnings: [] },
-      goldenPrefix: 'Asl',
-      actualPrefix: 'Asl',
+      goldenPrefix: 'Contoso',
+      actualPrefix: 'Contoso',
     });
     expect(res.score.golden_match).toBe(0);
   });
 
   it('normalizeMultiArtifact: canonicalises the prefixed FILENAME key too, so a multi-artifact case matches across prefix sessions', async () => {
-    const CONTRACT_ASL = `<AxClass><Name>AslMyContract</Name></AxClass>`;
-    const CONTRACT_FMMCP = `<AxClass><Name>FmMcpMyContract</Name></AxClass>`;
-    const golden = await normalizeMultiArtifact({ 'AslMyContract.metadata.xml': CONTRACT_ASL }, [], 'Asl');
-    const actual = await normalizeMultiArtifact({ 'FmMcpMyContract.metadata.xml': CONTRACT_FMMCP }, [], 'FmMcp');
+    const CONTRACT_CONTOSO = `<AxClass><Name>ContosoMyContract</Name></AxClass>`;
+    const CONTRACT_DEMO = `<AxClass><Name>DemoMyContract</Name></AxClass>`;
+    const golden = await normalizeMultiArtifact({ 'ContosoMyContract.metadata.xml': CONTRACT_CONTOSO }, [], 'Contoso');
+    const actual = await normalizeMultiArtifact({ 'DemoMyContract.metadata.xml': CONTRACT_DEMO }, [], 'Demo');
     expect(diffNormalized(golden, actual).matched).toBe(true);
   });
 
   it('evaluateMulti(): a multi-artifact case matches across prefix sessions end-to-end', async () => {
-    const CONTRACT_ASL = `<AxClass><Name>AslMyContract</Name></AxClass>`;
-    const CONTROLLER_ASL = `<AxClass><Name>AslMyController</Name></AxClass>`;
-    const CONTRACT_FMMCP = `<AxClass><Name>FmMcpMyContract</Name></AxClass>`;
-    const CONTROLLER_FMMCP = `<AxClass><Name>FmMcpMyController</Name></AxClass>`;
+    const CONTRACT_CONTOSO = `<AxClass><Name>ContosoMyContract</Name></AxClass>`;
+    const CONTROLLER_CONTOSO = `<AxClass><Name>ContosoMyController</Name></AxClass>`;
+    const CONTRACT_DEMO = `<AxClass><Name>DemoMyContract</Name></AxClass>`;
+    const CONTROLLER_DEMO = `<AxClass><Name>DemoMyController</Name></AxClass>`;
     const res = await evaluateMulti({
       caseSpec: { id: 'L3-batch-basic', tier: 3 },
       goldenArtifacts: {
-        'AslMyContract.metadata.xml': CONTRACT_ASL,
-        'AslMyController.metadata.xml': CONTROLLER_ASL,
+        'ContosoMyContract.metadata.xml': CONTRACT_CONTOSO,
+        'ContosoMyController.metadata.xml': CONTROLLER_CONTOSO,
       },
       actualArtifacts: {
-        'FmMcpMyContract.metadata.xml': CONTRACT_FMMCP,
-        'FmMcpMyController.metadata.xml': CONTROLLER_FMMCP,
+        'DemoMyContract.metadata.xml': CONTRACT_DEMO,
+        'DemoMyController.metadata.xml': CONTROLLER_DEMO,
       },
       build: { succeeded: true, bpWarnings: [] },
-      goldenPrefix: 'Asl',
-      actualPrefix: 'FmMcp',
+      goldenPrefix: 'Contoso',
+      actualPrefix: 'Demo',
     });
     expect(res.goldenDiff.matched).toBe(true);
     expect(res.score.golden_match).toBe(1);

--- a/tests/eval/oracleCli.test.ts
+++ b/tests/eval/oracleCli.test.ts
@@ -34,66 +34,66 @@ describe('buildActualArtifactsMap', () => {
   });
 
   it('keys a resolved actual file by ITS OWN basename, not the golden filename, when prefixes differ', () => {
-    // Golden expects "AslMyContract.metadata.xml"; the actual VM session ran under
-    // a DIFFERENT EXTENSION_PREFIX ("FmMcp") and produced "FmMcpMyContract.metadata.xml".
-    const actualContent = '<AxClass><Name>FmMcpMyContract</Name></AxClass>';
-    fs.writeFileSync(path.join(actualDir, 'FmMcpMyContract.metadata.xml'), actualContent, 'utf8');
+    // Golden expects "ContosoMyContract.metadata.xml"; the actual VM session ran under
+    // a DIFFERENT EXTENSION_PREFIX ("Demo") and produced "DemoMyContract.metadata.xml".
+    const actualContent = '<AxClass><Name>DemoMyContract</Name></AxClass>';
+    fs.writeFileSync(path.join(actualDir, 'DemoMyContract.metadata.xml'), actualContent, 'utf8');
 
     const { actualArtifacts, matchedActualFiles } = buildActualArtifactsMap(
       actualDir,
-      ['AslMyContract.metadata.xml'],
-      'Asl',
-      'FmMcp',
+      ['ContosoMyContract.metadata.xml'],
+      'Contoso',
+      'Demo',
     );
 
-    // The regression: this used to be keyed 'AslMyContract.metadata.xml' (the golden's
+    // The regression: this used to be keyed 'ContosoMyContract.metadata.xml' (the golden's
     // name), which desyncs prefix-canonicalisation downstream. Must be the actual
     // file's own basename instead.
-    expect(Object.keys(actualArtifacts)).toEqual(['FmMcpMyContract.metadata.xml']);
-    expect(actualArtifacts['FmMcpMyContract.metadata.xml']).toBe(actualContent);
-    expect(actualArtifacts['AslMyContract.metadata.xml']).toBeUndefined();
-    expect(matchedActualFiles.has('FmMcpMyContract.metadata.xml')).toBe(true);
+    expect(Object.keys(actualArtifacts)).toEqual(['DemoMyContract.metadata.xml']);
+    expect(actualArtifacts['DemoMyContract.metadata.xml']).toBe(actualContent);
+    expect(actualArtifacts['ContosoMyContract.metadata.xml']).toBeUndefined();
+    expect(matchedActualFiles.has('DemoMyContract.metadata.xml')).toBe(true);
   });
 
   it('keeps the golden filename as the key (empty content) when no actual file resolves at all', () => {
     const { actualArtifacts, matchedActualFiles } = buildActualArtifactsMap(
       actualDir, // empty directory — nothing to match
-      ['AslMissingArtifact.metadata.xml'],
-      'Asl',
-      'FmMcp',
+      ['ContosoMissingArtifact.metadata.xml'],
+      'Contoso',
+      'Demo',
     );
-    expect(actualArtifacts).toEqual({ 'AslMissingArtifact.metadata.xml': '' });
+    expect(actualArtifacts).toEqual({ 'ContosoMissingArtifact.metadata.xml': '' });
     expect(matchedActualFiles.size).toBe(0);
   });
 
   it('a direct filename match (same prefix session) keys by that same name', () => {
-    const content = '<AxClass><Name>AslMyContract</Name></AxClass>';
-    fs.writeFileSync(path.join(actualDir, 'AslMyContract.metadata.xml'), content, 'utf8');
+    const content = '<AxClass><Name>ContosoMyContract</Name></AxClass>';
+    fs.writeFileSync(path.join(actualDir, 'ContosoMyContract.metadata.xml'), content, 'utf8');
 
     const { actualArtifacts, matchedActualFiles } = buildActualArtifactsMap(
       actualDir,
-      ['AslMyContract.metadata.xml'],
-      'Asl',
-      'Asl',
+      ['ContosoMyContract.metadata.xml'],
+      'Contoso',
+      'Contoso',
     );
-    expect(actualArtifacts).toEqual({ 'AslMyContract.metadata.xml': content });
-    expect(matchedActualFiles.has('AslMyContract.metadata.xml')).toBe(true);
+    expect(actualArtifacts).toEqual({ 'ContosoMyContract.metadata.xml': content });
+    expect(matchedActualFiles.has('ContosoMyContract.metadata.xml')).toBe(true);
   });
 
   it('handles multiple golden artifacts independently, some matched under a different prefix, some missing', () => {
-    fs.writeFileSync(path.join(actualDir, 'FmMcpContract.metadata.xml'), 'CONTRACT', 'utf8');
+    fs.writeFileSync(path.join(actualDir, 'DemoContract.metadata.xml'), 'CONTRACT', 'utf8');
     // No file for "Controller" at all.
 
     const { actualArtifacts, matchedActualFiles } = buildActualArtifactsMap(
       actualDir,
-      ['AslContract.metadata.xml', 'AslController.metadata.xml'],
-      'Asl',
-      'FmMcp',
+      ['ContosoContract.metadata.xml', 'ContosoController.metadata.xml'],
+      'Contoso',
+      'Demo',
     );
     expect(actualArtifacts).toEqual({
-      'FmMcpContract.metadata.xml': 'CONTRACT',
-      'AslController.metadata.xml': '',
+      'DemoContract.metadata.xml': 'CONTRACT',
+      'ContosoController.metadata.xml': '',
     });
-    expect(matchedActualFiles).toEqual(new Set(['FmMcpContract.metadata.xml']));
+    expect(matchedActualFiles).toEqual(new Set(['DemoContract.metadata.xml']));
   });
 });

--- a/tests/eval/systest.test.ts
+++ b/tests/eval/systest.test.ts
@@ -10,23 +10,23 @@ import { scoreRun } from '../../src/eval/oracle/score';
 
 const PASSED = `✅ Tests passed
 
-Class: AslNoteStatusTest
-Model: fm-mcp
+Class: ContosoNoteStatusTest
+Model: Contoso
 
 SysTestRunner: 3 tests run, 3 passed, 0 failed.`;
 
 const FAILED = `❌ Tests FAILED
 
-Class: AslNoteStatusTest
-Model: fm-mcp
+Class: ContosoNoteStatusTest
+Model: Contoso
 
 SysTestRunner: 3 tests run, 2 passed, 1 failed.
-AslNoteStatusTest::testArchivedTransition failed: Assert.areEqual expected 'Archived' actual 'Active'`;
+ContosoNoteStatusTest::testArchivedTransition failed: Assert.areEqual expected 'Archived' actual 'Active'`;
 
 const INDETERMINATE = `⚠️ Tests completed (check output)
 
-Class: AslThing
-Model: fm-mcp
+Class: ContosoThing
+Model: Contoso
 
 (no recognizable pass/fail markers)`;
 
@@ -58,7 +58,7 @@ describe('parseSysTestResult', () => {
     expect(r.ran).toBe(true);
     expect(r.passed).toBe(false);
     expect(r.failures.length).toBeGreaterThanOrEqual(1);
-    expect(r.failures.some(f => f.test === 'AslNoteStatusTest::testArchivedTransition')).toBe(true);
+    expect(r.failures.some(f => f.test === 'ContosoNoteStatusTest::testArchivedTransition')).toBe(true);
     expect(r.failures.some(f => /Assert\.areEqual/.test(f.message))).toBe(true);
   });
 

--- a/tests/eval/systestCase.test.ts
+++ b/tests/eval/systestCase.test.ts
@@ -64,12 +64,12 @@ describe('L2-coc-extension SysTest asset', () => {
 
   it('scores systest=1 when this class passes and systest=0 when it fails', () => {
     const passed = parseSysTestResult(
-      `✅ Tests passed\n\nClass: ${TEST_CLASS}\nModel: fm-mcp\n\nSysTestRunner: 2 tests run, 2 passed, 0 failed.`,
+      `✅ Tests passed\n\nClass: ${TEST_CLASS}\nModel: Contoso\n\nSysTestRunner: 2 tests run, 2 passed, 0 failed.`,
     );
     expect(passed).toEqual({ ran: true, passed: true, failures: [] });
 
     const failed = parseSysTestResult(
-      `❌ Tests FAILED\n\nClass: ${TEST_CLASS}\nModel: fm-mcp\n\n` +
+      `❌ Tests FAILED\n\nClass: ${TEST_CLASS}\nModel: Contoso\n\n` +
         `SysTestRunner: 2 tests run, 1 passed, 1 failed.\n` +
         `${TEST_CLASS}::testCarFactsSummaryAppendsVerifiedSuffix failed: ` +
         `Assert.areEqual expected 'Adventure Works Fuji [verified]' actual 'Adventure Works Fuji'`,
@@ -124,12 +124,12 @@ describe('L3-batch-basic SysTest asset', () => {
 
   it('scores systest=1 when this class passes and systest=0 when it fails', () => {
     const passed = parseSysTestResult(
-      `✅ Tests passed\n\nClass: ${TEST_CLASS}\nModel: fm-mcp\n\nSysTestRunner: 2 tests run, 2 passed, 0 failed.`,
+      `✅ Tests passed\n\nClass: ${TEST_CLASS}\nModel: Contoso\n\nSysTestRunner: 2 tests run, 2 passed, 0 failed.`,
     );
     expect(passed).toEqual({ ran: true, passed: true, failures: [] });
 
     const failed = parseSysTestResult(
-      `❌ Tests FAILED\n\nClass: ${TEST_CLASS}\nModel: fm-mcp\n\n` +
+      `❌ Tests FAILED\n\nClass: ${TEST_CLASS}\nModel: Contoso\n\n` +
         `SysTestRunner: 2 tests run, 1 passed, 1 failed.\n` +
         `${TEST_CLASS}::testEffectiveBatchSizeMultipliesByPriorityFactor failed: ` +
         `Assert.areEqual expected 30 actual 13`,
@@ -181,12 +181,12 @@ describe('L2-event-handler-basic SysTest asset', () => {
 
   it('scores systest=1 when this class passes and systest=0 when it fails', () => {
     const passed = parseSysTestResult(
-      `✅ Tests passed\n\nClass: ${TEST_CLASS}\nModel: fm-mcp\n\nSysTestRunner: 2 tests run, 2 passed, 0 failed.`,
+      `✅ Tests passed\n\nClass: ${TEST_CLASS}\nModel: Contoso\n\nSysTestRunner: 2 tests run, 2 passed, 0 failed.`,
     );
     expect(passed).toEqual({ ran: true, passed: true, failures: [] });
 
     const failed = parseSysTestResult(
-      `❌ Tests FAILED\n\nClass: ${TEST_CLASS}\nModel: fm-mcp\n\n` +
+      `❌ Tests FAILED\n\nClass: ${TEST_CLASS}\nModel: Contoso\n\n` +
         `SysTestRunner: 2 tests run, 1 passed, 1 failed.\n` +
         `${TEST_CLASS}::testInsertingWithBlankSubjectGetsDefaulted failed: ` +
         `Assert.areEqual expected '(no subject)' actual ''`,

--- a/tests/tools/clonePatternMismatch.test.ts
+++ b/tests/tools/clonePatternMismatch.test.ts
@@ -61,10 +61,10 @@ describe('checkTableMappingCoverage', () => {
 
   it('flags a target table with zero known fields as unknown (not a silent skip)', () => {
     const result = checkTableMappingCoverage(
-      { CustGroup: 'AslSalesPostingAuditLog' },
+      { CustGroup: 'ContosoSalesPostingAuditLog' },
       (table) => (table === 'CustGroup' ? CUSTGROUP_FIELDS : []),
     );
-    expect(result.unknownTargets).toEqual(['AslSalesPostingAuditLog']);
+    expect(result.unknownTargets).toEqual(['ContosoSalesPostingAuditLog']);
     expect(result.poorOverlap).toEqual([]);
   });
 
@@ -114,8 +114,8 @@ describe('checkTableMappingCoverage', () => {
 
   it('skips the overlap check when the source table itself is unknown/too small', () => {
     const result = checkTableMappingCoverage(
-      { UnknownSource: 'AslSalesPostingAuditLog' },
-      (table) => (table === 'AslSalesPostingAuditLog' ? ['SalesId', 'PostingType'] : null),
+      { UnknownSource: 'ContosoSalesPostingAuditLog' },
+      (table) => (table === 'ContosoSalesPostingAuditLog' ? ['SalesId', 'PostingType'] : null),
     );
     expect(result.unknownTargets).toEqual([]);
     expect(result.poorOverlap).toEqual([]);

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -567,7 +567,7 @@ describe('XmlTemplateGenerator.splitXppClassSource', () => {
 //
 // Regression for eval/corpus/runs/2026-07-06T16__L1-class-basic__73707ff.json
 // (classification: TOOL_DEFECT, build.succeeded: false): the caller passed an
-// already-fully-resolved objectName ("FmMcpXyzNoteFormatter") but sourceCode's
+// already-fully-resolved objectName ("ContosoXyzNoteFormatter") but sourceCode's
 // own `class XyzNoteFormatter` used the bare, unprefixed name. Because
 // objectName itself needed no prefix-normalizing (finalObjectName ===
 // args.objectName), the existing xmlContent-only "CRITICAL FIX" guard in
@@ -585,20 +585,20 @@ describe('XmlTemplateGenerator.normalizeSelfReferenceName', () => {
       },
     ];
 
-    const result = XmlTemplateGenerator.normalizeSelfReferenceName('FmMcpXyzNoteFormatter', declaration, methods);
+    const result = XmlTemplateGenerator.normalizeSelfReferenceName('ContosoXyzNoteFormatter', declaration, methods);
 
-    expect(result.declaration).toContain('public class FmMcpXyzNoteFormatter');
-    expect(result.declaration).not.toMatch(/(?<!FmMcp)XyzNoteFormatter/);
+    expect(result.declaration).toContain('public class ContosoXyzNoteFormatter');
+    expect(result.declaration).not.toMatch(/(?<!Contoso)XyzNoteFormatter/);
     const construct = result.methods.find(m => m.name === 'construct')!;
-    expect(construct.source).toContain('public static FmMcpXyzNoteFormatter construct');
-    expect(construct.source).toContain('return new FmMcpXyzNoteFormatter(_prefix);');
+    expect(construct.source).toContain('public static ContosoXyzNoteFormatter construct');
+    expect(construct.source).toContain('return new ContosoXyzNoteFormatter(_prefix);');
     expect(construct.source).not.toMatch(/\bXyzNoteFormatter\b/);
   });
 
   it('is a no-op when the declared name already matches className', () => {
-    const declaration = 'public class FmMcpFoo\n{\n}';
+    const declaration = 'public class ContosoFoo\n{\n}';
     const methods = [{ name: 'run', source: 'public void run()\n    {\n    }' }];
-    const result = XmlTemplateGenerator.normalizeSelfReferenceName('FmMcpFoo', declaration, methods);
+    const result = XmlTemplateGenerator.normalizeSelfReferenceName('ContosoFoo', declaration, methods);
     expect(result.declaration).toBe(declaration);
     expect(result.methods).toEqual(methods);
   });
@@ -607,12 +607,12 @@ describe('XmlTemplateGenerator.normalizeSelfReferenceName', () => {
     const sourceCode =
       'public class XyzNoteFormatter\n{\n    str prefix;\n}\n\n' +
       'public static XyzNoteFormatter construct(str _prefix)\n{\n    return new XyzNoteFormatter(_prefix);\n}';
-    const xml = XmlTemplateGenerator.generateAxClassXml('FmMcpXyzNoteFormatter', sourceCode);
+    const xml = XmlTemplateGenerator.generateAxClassXml('ContosoXyzNoteFormatter', sourceCode);
 
-    expect(xml).toContain('<Name>FmMcpXyzNoteFormatter</Name>');
-    expect(xml).toContain('public class FmMcpXyzNoteFormatter');
-    expect(xml).toContain('public static FmMcpXyzNoteFormatter construct');
-    expect(xml).toContain('return new FmMcpXyzNoteFormatter(_prefix);');
+    expect(xml).toContain('<Name>ContosoXyzNoteFormatter</Name>');
+    expect(xml).toContain('public class ContosoXyzNoteFormatter');
+    expect(xml).toContain('public static ContosoXyzNoteFormatter construct');
+    expect(xml).toContain('return new ContosoXyzNoteFormatter(_prefix);');
     // No leftover reference to the stale, unprefixed self-name anywhere in the XML.
     expect(xml).not.toMatch(/\bXyzNoteFormatter\b/);
   });
@@ -621,12 +621,12 @@ describe('XmlTemplateGenerator.normalizeSelfReferenceName', () => {
     const sourceCode =
       'class XyzNoteFormatter\n{\n    str prefix;\n}\n\n' +
       'public static XyzNoteFormatter construct(str _prefix)\n{\n    return new XyzNoteFormatter(_prefix);\n}';
-    const parsed = XmlTemplateGenerator.parseSourceForBridge(sourceCode, 'FmMcpXyzNoteFormatter');
+    const parsed = XmlTemplateGenerator.parseSourceForBridge(sourceCode, 'ContosoXyzNoteFormatter');
 
-    expect(parsed.declaration).toContain('class FmMcpXyzNoteFormatter');
+    expect(parsed.declaration).toContain('class ContosoXyzNoteFormatter');
     const construct = parsed.methods.find(m => m.name === 'construct')!;
-    expect(construct.source).toContain('FmMcpXyzNoteFormatter construct');
-    expect(construct.source).toContain('new FmMcpXyzNoteFormatter(_prefix)');
+    expect(construct.source).toContain('ContosoXyzNoteFormatter construct');
+    expect(construct.source).toContain('new ContosoXyzNoteFormatter(_prefix)');
   });
 
   it('parseSourceForBridge without className (legacy callers) leaves self-references untouched', () => {
@@ -681,12 +681,12 @@ describe('XmlTemplateGenerator security duty/role generators', () => {
 describe('XmlTemplateGenerator security duty/role EXTENSION generators', () => {
   it('emits AxSecurityPrivilegeReference entries on a duty extension', () => {
     const xml = XmlTemplateGenerator.generateAxSecurityDutyExtensionXml(
-      'SalesOrderProgressInquire.AslExtension',
-      { privileges: ['AslSalesPostingAuditLogView'] },
+      'SalesOrderProgressInquire.ContosoExtension',
+      { privileges: ['ContosoSalesPostingAuditLogView'] },
     );
     expect(xml).toContain('<AxSecurityDutyExtension');
-    expect(xml).toContain('<Name>SalesOrderProgressInquire.AslExtension</Name>');
-    expect(xml).toContain('<AxSecurityPrivilegeReference>\n\t\t\t<Name>AslSalesPostingAuditLogView</Name>');
+    expect(xml).toContain('<Name>SalesOrderProgressInquire.ContosoExtension</Name>');
+    expect(xml).toContain('<AxSecurityPrivilegeReference>\n\t\t\t<Name>ContosoSalesPostingAuditLogView</Name>');
     expect(xml).toContain('<PropertyModifications />');
     // No <Label> — duty extensions don't carry one (only the base duty does).
     expect(xml).not.toContain('<Label>');
@@ -707,11 +707,11 @@ describe('XmlTemplateGenerator security duty/role EXTENSION generators', () => {
 
   it('emits duty + privilege references on a role extension', () => {
     const xml = XmlTemplateGenerator.generateAxSecurityRoleExtensionXml(
-      'SystemUser.AslExtension',
+      'SystemUser.ContosoExtension',
       { duties: ['MyDuty1'], privileges: ['MyPrivilege1'] },
     );
     expect(xml).toContain('<AxSecurityRoleExtension');
-    expect(xml).toContain('<Name>SystemUser.AslExtension</Name>');
+    expect(xml).toContain('<Name>SystemUser.ContosoExtension</Name>');
     expect(xml).toContain('<DirectAccessPermissions />');
     expect(xml).toContain('<AxSecurityDutyReference>\n\t\t\t<Name>MyDuty1</Name>');
     expect(xml).toContain('<AxSecurityPrivilegeReference>\n\t\t\t<Name>MyPrivilege1</Name>');
@@ -845,9 +845,9 @@ describe('selectUnbuildableEdts (scaffold pre-write gate)', () => {
 
   it('allows a same-session EDT that is on disk but unindexed (xppc reads disk)', () => {
     // Separator-agnostic so this holds on both Windows (path.join → "\") and Linux CI ("/").
-    const onDisk = (p: string) => p.replace(/\\/g, '/').endsWith('AxEdt/AslSessionEdt.xml');
+    const onDisk = (p: string) => p.replace(/\\/g, '/').endsWith('AxEdt/ContosoSessionEdt.xml');
     const blocked = selectUnbuildableEdts(
-      [{ field: 'A', edt: 'AslSessionEdt' }, { field: 'B', edt: 'GhostEdt' }],
+      [{ field: 'A', edt: 'ContosoSessionEdt' }, { field: 'B', edt: 'GhostEdt' }],
       modelDir,
       onDisk,
     );

--- a/tests/tools/formModifyPropertyFallback.test.ts
+++ b/tests/tools/formModifyPropertyFallback.test.ts
@@ -33,10 +33,10 @@ vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
 
 const FORM_XML_ONE_CAPTION = `<?xml version="1.0" encoding="utf-8"?>
 <AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
-	<Name>AslXyzNoteHeaderList</Name>
+	<Name>ContosoXyzNoteHeaderList</Name>
 	<Design>
 		<Caption xmlns="">Note headers</Caption>
-		<DataSource xmlns="">AslXyzNoteHeader</DataSource>
+		<DataSource xmlns="">ContosoXyzNoteHeader</DataSource>
 	</Design>
 </AxForm>`;
 
@@ -104,7 +104,7 @@ vi.mock('../../src/utils/modelClassifier', () => ({
   isStandardModel: vi.fn(() => false),
 }));
 
-const FORM_FILE_PATH = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxForm\\AslXyzNoteHeaderList.xml';
+const FORM_FILE_PATH = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxForm\\ContosoXyzNoteHeaderList.xml';
 
 const req = (name: string, args: Record<string, unknown> = {}): CallToolRequest => ({
   method: 'tools/call',
@@ -151,7 +151,7 @@ describe('modify-property direct-XML fallback for forms (regression)', () => {
     const result = await modifyD365FileTool(
       req('modify_d365fo_file', {
         objectType: 'form',
-        objectName: 'AslXyzNoteHeaderList',
+        objectName: 'ContosoXyzNoteHeaderList',
         operation: 'modify-property',
         propertyPath: 'Caption',
         propertyValue: '@MyModel:HeaderNote',
@@ -174,7 +174,7 @@ describe('modify-property direct-XML fallback for forms (regression)', () => {
     const result = await modifyD365FileTool(
       req('modify_d365fo_file', {
         objectType: 'form',
-        objectName: 'AslXyzNoteHeaderList',
+        objectName: 'ContosoXyzNoteHeaderList',
         operation: 'modify-property',
         propertyPath: 'Caption',
         propertyValue: '@MyModel:HeaderNote',
@@ -192,7 +192,7 @@ describe('modify-property direct-XML fallback for forms (regression)', () => {
     const result = await modifyD365FileTool(
       req('modify_d365fo_file', {
         objectType: 'form',
-        objectName: 'AslXyzNoteHeaderList',
+        objectName: 'ContosoXyzNoteHeaderList',
         operation: 'modify-property',
         propertyPath: 'ThisPropertyDoesNotExist',
         propertyValue: 'x',

--- a/tests/tools/sysTestRunner.test.ts
+++ b/tests/tools/sysTestRunner.test.ts
@@ -9,7 +9,7 @@ const { accessMock, execFileMock, readFileMock, cfgEnsureLoaded, cfgGetModelName
     cb(null, { stdout: '✅ Tests passed', stderr: '' });
   });
   const cfgEnsureLoaded = vi.fn();
-  const cfgGetModelName = vi.fn().mockReturnValue('fm-mcp');
+  const cfgGetModelName = vi.fn().mockReturnValue('Contoso');
   const cfgGetPackagePath = vi.fn().mockReturnValue('K:\\AOSService\\PackagesLocalDirectory');
   return { accessMock, execFileMock, readFileMock, cfgEnsureLoaded, cfgGetModelName, cfgGetPackagePath };
 });
@@ -53,7 +53,7 @@ describe('run_systest_class — binary resolution', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     cfgEnsureLoaded.mockResolvedValue(undefined);
-    cfgGetModelName.mockReturnValue('fm-mcp');
+    cfgGetModelName.mockReturnValue('Contoso');
     cfgGetPackagePath.mockReturnValue(PKG);
     readFileMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
     execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
@@ -64,7 +64,7 @@ describe('run_systest_class — binary resolution', () => {
   it('prefers SysTestConsole.exe when present', async () => {
     allowPaths([SYSTEST_CONSOLE]);
 
-    const result = await sysTestRunnerTool({ className: 'AslMyTest' }, {});
+    const result = await sysTestRunnerTool({ className: 'ContosoMyTest' }, {});
 
     expect(result.isError).toBeFalsy();
     const [exe] = execFileMock.mock.calls[0];
@@ -74,10 +74,10 @@ describe('run_systest_class — binary resolution', () => {
   it('uses /test: and /xml: flags for SysTestConsole.exe', async () => {
     allowPaths([SYSTEST_CONSOLE]);
 
-    await sysTestRunnerTool({ className: 'AslMyTest' }, {});
+    await sysTestRunnerTool({ className: 'ContosoMyTest' }, {});
 
     const args = capturedArgs(0);
-    expect(args).toContain('/test:AslMyTest');
+    expect(args).toContain('/test:ContosoMyTest');
     expect(args.some(a => a.startsWith('/xml:'))).toBe(true);
     // SysTestConsole has no -model:/-packagePath: flags (unlike the legacy fallback)
     expect(args.some(a => a.startsWith('-model:'))).toBe(false);
@@ -86,20 +86,20 @@ describe('run_systest_class — binary resolution', () => {
   it('falls back to SysTestRunner.exe when SysTestConsole.exe is absent', async () => {
     allowPaths([SYSTEST_RUNNER]);
 
-    const result = await sysTestRunnerTool({ className: 'AslMyTest', testMethod: 'testFoo' }, {});
+    const result = await sysTestRunnerTool({ className: 'ContosoMyTest', testMethod: 'testFoo' }, {});
 
     expect(result.isError).toBeFalsy();
     const [exe] = execFileMock.mock.calls[0];
     expect(exe).toBe(SYSTEST_RUNNER);
     const args = capturedArgs(0);
-    expect(args).toContain('-name:AslMyTest::testFoo');
-    expect(args).toContain('-model:fm-mcp');
+    expect(args).toContain('-name:ContosoMyTest::testFoo');
+    expect(args).toContain('-model:Contoso');
   });
 
   it('errors when neither binary is found', async () => {
     allowPaths([]);
 
-    const result = await sysTestRunnerTool({ className: 'AslMyTest' }, {});
+    const result = await sysTestRunnerTool({ className: 'ContosoMyTest' }, {});
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Neither SysTestConsole.exe nor SysTestRunner.exe found');
@@ -109,7 +109,7 @@ describe('run_systest_class — binary resolution', () => {
   it('errors when model name cannot be determined', async () => {
     cfgGetModelName.mockReturnValue(null);
 
-    const result = await sysTestRunnerTool({ className: 'AslMyTest' }, {});
+    const result = await sysTestRunnerTool({ className: 'ContosoMyTest' }, {});
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Cannot determine model name');
@@ -119,7 +119,7 @@ describe('run_systest_class — binary resolution', () => {
   it('notes that testMethod is ignored when running via SysTestConsole.exe', async () => {
     allowPaths([SYSTEST_CONSOLE]);
 
-    const result = await sysTestRunnerTool({ className: 'AslMyTest', testMethod: 'testFoo' }, {});
+    const result = await sysTestRunnerTool({ className: 'ContosoMyTest', testMethod: 'testFoo' }, {});
 
     expect(result.content[0].text).toContain('no per-method filter');
   });
@@ -129,7 +129,7 @@ describe('run_systest_class — interactive console blocker', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     cfgEnsureLoaded.mockResolvedValue(undefined);
-    cfgGetModelName.mockReturnValue('fm-mcp');
+    cfgGetModelName.mockReturnValue('Contoso');
     cfgGetPackagePath.mockReturnValue(PKG);
     allowPaths([SYSTEST_CONSOLE]);
   });
@@ -146,7 +146,7 @@ describe('run_systest_class — interactive console blocker', () => {
       cb(err);
     });
 
-    const result = await sysTestRunnerTool({ className: 'AslMyTest' }, {});
+    const result = await sysTestRunnerTool({ className: 'ContosoMyTest' }, {});
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('requires an interactive console session');
@@ -155,10 +155,10 @@ describe('run_systest_class — interactive console blocker', () => {
 
   it('a plain test failure is NOT misclassified as the interactive-console blocker', async () => {
     execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
-      cb(null, { stdout: '❌ Tests FAILED\n\nAslMyTest::testFoo failed: assertion error', stderr: '' });
+      cb(null, { stdout: '❌ Tests FAILED\n\nContosoMyTest::testFoo failed: assertion error', stderr: '' });
     });
 
-    const result = await sysTestRunnerTool({ className: 'AslMyTest' }, {});
+    const result = await sysTestRunnerTool({ className: 'ContosoMyTest' }, {});
 
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text).toContain('Tests FAILED');

--- a/tests/tools/validate-xpp.test.ts
+++ b/tests/tools/validate-xpp.test.ts
@@ -254,7 +254,7 @@ describe('XML rules', () => {
     // the base table already has one.
     const xml = `
       <AxTableExtension>
-        <Name>CustGroup.AslExtension</Name>
+        <Name>CustGroup.ContosoExtension</Name>
         <Fields>
           <AxTableField i:type="AxTableFieldInt">
             <Name>NotePriority</Name>

--- a/tests/utils/pathContainmentSymlink.test.ts
+++ b/tests/utils/pathContainmentSymlink.test.ts
@@ -31,16 +31,16 @@ import * as path from 'path';
 import { assertWritePathAllowed } from '../../src/utils/pathContainment.js';
 
 let symlinkOk = true;
-const MODEL = 'fmmcp';
+const MODEL = 'contoso';
 
 beforeAll(() => {
-  // Real store: <real>/fmmcp/fmmcp/AxTable/Foo.xml
+  // Real store: <real>/contoso/contoso/AxTable/Foo.xml
   const realModelRoot = path.join(ctx.real, MODEL);
   const realAxTable = path.join(realModelRoot, MODEL, 'AxTable');
   fs.mkdirSync(realAxTable, { recursive: true });
   fs.writeFileSync(path.join(realAxTable, 'Foo.xml'), '<AxTable><Name>Foo</Name></AxTable>');
 
-  // Allowed root: <pld>, with <pld>/fmmcp symlinked to the real model root.
+  // Allowed root: <pld>, with <pld>/contoso symlinked to the real model root.
   fs.mkdirSync(ctx.pld, { recursive: true });
   try {
     const type = process.platform === 'win32' ? 'junction' : 'dir';

--- a/tests/utils/resolveRegularObjectPrefixToken.test.ts
+++ b/tests/utils/resolveRegularObjectPrefixToken.test.ts
@@ -27,13 +27,13 @@ describe('resolveRegularObjectPrefixToken', () => {
   });
 
   it('returns the PascalCase prefix as-is for a normal prefix', () => {
-    process.env.EXTENSION_PREFIX = 'FmMcp';
-    expect(resolveRegularObjectPrefixToken()).toBe('FmMcp');
+    process.env.EXTENSION_PREFIX = 'ContosoDemo';
+    expect(resolveRegularObjectPrefixToken()).toBe('ContosoDemo');
   });
 
   it('capitalizes a lowercase-first prefix (matches applyObjectPrefix\'s own capitalisation)', () => {
-    process.env.EXTENSION_PREFIX = 'fmMcp';
-    expect(resolveRegularObjectPrefixToken()).toBe('FmMcp');
+    process.env.EXTENSION_PREFIX = 'contosoDemo';
+    expect(resolveRegularObjectPrefixToken()).toBe('ContosoDemo');
   });
 
   it('keeps the trailing underscore for underscore-style prefixes', () => {
@@ -42,7 +42,7 @@ describe('resolveRegularObjectPrefixToken', () => {
   });
 
   it('matches the literal token applyObjectPrefix actually prepends to a regular object name', () => {
-    for (const prefix of ['FmMcp', 'Asl', 'XY_', 'Contoso']) {
+    for (const prefix of ['ContosoDemo', 'Demo', 'XY_', 'Contoso']) {
       process.env.EXTENSION_PREFIX = prefix;
       const token = resolveRegularObjectPrefixToken();
       const named = applyObjectPrefix('MyTable', resolveObjectPrefix(''));


### PR DESCRIPTION
## Summary

Prefixes \Asl\ and \m-mcp\ are strictly forbidden in examples, tests, and documentation — they are real customer/internal identifiers that must not appear in generic code samples.

All occurrences have been replaced with the generic alternatives \Contoso\ (golden prefix) and \Demo\ (actual/session prefix).

## Changes

### Source files
- \src/eval/oracle/normalize.ts\ — \GOLDEN_CAPTURE_PREFIX = 'Contoso'\ (was \'Asl'\), all example identifiers in comments
- \src/eval/oracle/cli.ts\ — \--golden-prefix\ default example
- \src/tools/xppKnowledge.ts\ — number sequence code examples (\AslRent*\ → \ContosoRent*\)
- \src/tools/generateSmartForm.ts\, \modifyD365File.ts\, \createD365File.ts\ — inline comments

### Test files
- \	ests/eval/oracle.test.ts\ — all \Asl*\/\FmMcp*\ fixtures
- \	ests/eval/systest.test.ts\, \systestCase.test.ts\ — \m-mcp\ model name
- \	ests/tools/sysTestRunner.test.ts\ — \m-mcp\ + \AslMyTest\
- \	ests/tools/code-generation.test.ts\ — security extension names, \
ormalizeSelfReferenceName\ tests
- \	ests/tools/clonePatternMismatch.test.ts\, \alidate-xpp.test.ts\, \ormModifyPropertyFallback.test.ts\
- \	ests/utils/resolveRegularObjectPrefixToken.test.ts\ — \FmMcp\/\Asl\ → \ContosoDemo\/\Demo\
- \	ests/utils/pathContainmentSymlink.test.ts\ — model name \mmcp\ → \contoso\

### Agent files
- \.claude/agents/eval-implementer.md\ + \.claude/commands/eval-run.md\ — sandbox model name

## Test plan
\
px vitest run\ — 106 test files, 1549 tests, all green.