### PR TITLE
Add label where-used (cross-references) to find_references

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -59,7 +59,7 @@ One unified reader covers every object type via `objectType`; type-specific flag
 |------|--------------|----------------|
 | `get_object_info` † | Read one object's metadata by `objectType`: `class`, `table`, `form`, `query`, `view`, `enum`, `edt`, `report`, `data-entity`, `menu-item`, `service`, `map`, `config-key`, `security-policy`, `macro`. Options: `{includeRdl}` (report), `{searchControl}` (form), `{compact:false}` (class), `{mode:"hierarchy"}` (edt), `{filter}` (macro). For classes, `{members:"names"}` (optional `{prefix}`) returns a fast IntelliSense-style member-name list. | *"Show the structure of SalesFormLetter"* · *"Methods on SalesTable starting with calc"* · *"Datasets of the SalesInvoice report"* |
 | `get_method` † | Method `include="signature"` (exact signature — **mandatory before CoC**), `include="source"` (full X++ body), or `include="both"` (default) | *"Signature of SalesFormLetter.run?"* · *"Show me the body of CustTable.validateWrite"* |
-| `find_references` † | Where-used analysis, xref-enriched (reference type, caller class/method) | *"Where is updateInventory called from?"* |
+| `find_references` † | Where-used analysis, xref-enriched (reference type, caller class/method). Also does **label where-used** — `targetType="label"` or an `@…` id (e.g. `@WAX2194`, `@ApplicationPlatform:AbortButtonText`) — returning every referencing object type (tables, forms, EDTs, enums, reports, menu items, …), grouped by source type | *"Where is updateInventory called from?"* · *"What references label @SYS9694?"* |
 
 ## 🏷️ Label Management (1)
 
@@ -68,6 +68,8 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
 | `labels` | `action=search` — full-text query across 20M+ label rows, all languages · `action=info` — all translations of a labelId (or list label files when omitted) · `action=create` — add a label to all language files of a model · `action=rename` — rename a label ID across .label.txt, X++ and XML | *"Is there a label for 'payment terms'?"* · *"Show translations of @SYS12345"* · *"Create label 'Priority tier' in en-US, cs, de"* · *"Rename label MyOldId to MyNewId everywhere"* |
+
+> **Label where-used** (which objects reference a label) is not a `labels` action — use `find_references` with `targetType="label"` or an `@…` id. See Advanced Object Info above.
 
 ## 🧠 Code Intelligence (2)
 

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -426,6 +426,7 @@ export async function tryBridgeReferences(
   target: string | string[],
   limit = 50,
   displayName?: string,
+  formatAs: 'default' | 'label' = 'default',
 ): Promise<BridgeReferencesOutcome> {
   if (!bridge?.isReady || !bridge.xrefAvailable) return { status: 'unavailable' };
   // Accept several candidate paths (e.g. one per container type when an owner
@@ -454,6 +455,14 @@ export async function tryBridgeReferences(
   // No rows: "empty" is authoritative only when nothing went wrong; otherwise
   // signal "error" so the caller falls back instead of trusting the 0.
   if (merged.length === 0) return errored ? { status: 'error' } : { status: 'empty' };
+
+  // Labels are referenced from every object type (tables, forms, EDTs, enums,
+  // reports, menu items, security objects, …), mostly via declarative metadata
+  // properties rather than X++ code — so they get a dedicated formatter that
+  // groups by source object type and surfaces the referencing property.
+  if (formatAs === 'label') {
+    return { status: 'ok', result: formatLabelReferences(merged, label, limit) };
+  }
 
   {
     const refs = { count: merged.length, references: merged };
@@ -514,6 +523,130 @@ export async function tryBridgeReferences(
 
     return { status: 'ok', result: { content: [{ type: 'text', text: out }] } };
   }
+}
+
+// LABEL REFERENCES (formatting)
+
+/**
+ * Friendly display name for an xref source-container segment. Handles both xref
+ * path conventions seen for label references: code references use plural,
+ * slash-prefixed containers ("/Classes/…", "/Tables/…"), while declarative
+ * metadata references use singular containers with no leading slash
+ * ("Table/…", "Form/…", "EdtString/…", "MenuItemDisplay/…").
+ */
+const XREF_SOURCE_TYPE_LABELS: Record<string, string> = {
+  classes: 'Class', class: 'Class',
+  tables: 'Table', table: 'Table', tableextension: 'Table extension',
+  forms: 'Form', form: 'Form', formextension: 'Form extension',
+  views: 'View', view: 'View', viewextension: 'View extension',
+  maps: 'Map', map: 'Map',
+  queries: 'Query', querysimple: 'Query',
+  enum: 'Enum', enums: 'Enum', enumextension: 'Enum extension',
+  reports: 'Report', report: 'Report',
+  dataentityviews: 'Data entity', dataentityview: 'Data entity',
+  compositedataentityview: 'Composite data entity', dataentityviewextension: 'Data entity extension',
+  aggregatedataentity: 'Aggregate data entity', aggregatedimension: 'Aggregate dimension',
+  aggregatemeasurement: 'Aggregate measurement',
+  menu: 'Menu', menuextension: 'Menu extension',
+  menuitemdisplay: 'Menu item (display)', menuitemaction: 'Menu item (action)', menuitemoutput: 'Menu item (output)',
+  securityprivilege: 'Security privilege', securityduty: 'Security duty',
+  securityrole: 'Security role', securitypolicy: 'Security policy',
+  configurationkey: 'Configuration key', configurationkeygroup: 'Configuration key group',
+  tile: 'Tile', kpi: 'KPI', licensecode: 'License code', resource: 'Resource',
+};
+
+function friendlyXrefSourceType(container: string): string {
+  const key = container.toLowerCase();
+  if (XREF_SOURCE_TYPE_LABELS[key]) return XREF_SOURCE_TYPE_LABELS[key];
+  if (key.startsWith('edt')) return 'EDT';            // EdtString, EdtEnum, EdtReal, EdtInt64, …
+  if (key.startsWith('workflow')) return 'Workflow';  // WorkflowTemplate, WorkflowApproval, …
+  return container || 'Other';
+}
+
+interface ParsedLabelSource {
+  type: string;        // friendly source type, e.g. "Form", "EDT", "Table"
+  objectName: string;  // referencing object, e.g. "AbatementCertificate_IN"
+  detail?: string;     // X++ method (code ref) or referencing property (metadata ref)
+}
+
+/**
+ * Parse an xref source path for a label reference into (type, object, detail).
+ * Examples:
+ *   "/Classes/WhsWorkManualComplete/Methods/performValidation" → Class · WhsWorkManualComplete · performValidation
+ *   "Form/AbatementCertificate_IN/FormDesign/.../ShowData?Text" → Form  · AbatementCertificate_IN · Text
+ *   "EdtString/ABNControllingCorporation_AU?HelpText"          → EDT   · ABNControllingCorporation_AU · HelpText
+ */
+function parseLabelSource(sourcePath: string): ParsedLabelSource {
+  const parts = sourcePath.split('/').filter(Boolean);
+  const type = friendlyXrefSourceType(parts[0] ?? '');
+
+  let objectName = parts[1] ?? sourcePath;
+  const objQ = objectName.indexOf('?');            // e.g. "EdtString/Foo?HelpText" — object is 2nd segment
+  if (objQ >= 0) objectName = objectName.substring(0, objQ);
+
+  let detail: string | undefined;
+  const mi = parts.indexOf('Methods');
+  if (mi >= 0 && parts[mi + 1]) {
+    detail = parts[mi + 1].split('?')[0];           // X++ method name (code reference)
+  } else {
+    const q = sourcePath.lastIndexOf('?');
+    if (q >= 0) detail = sourcePath.substring(q + 1); // referencing property: Label/Caption/HelpText/Text/…
+  }
+  return { type, objectName, detail };
+}
+
+/**
+ * Format label where-used results, grouped by source object type. Unlike the
+ * default (caller/method-oriented) formatter, this makes the object-type spread
+ * explicit — a label is typically referenced far more from metadata (form
+ * captions, field/EDT labels, menu-item captions, …) than from X++ code.
+ */
+function formatLabelReferences(references: BridgeReferenceInfo[], label: string, limit: number): ToolResult {
+  type LabelRefRow = ParsedLabelSource & { module?: string; line: number };
+  const parsed: LabelRefRow[] = references.map(r => ({
+    ...parseLabelSource(r.sourcePath),
+    module: r.sourceModule,
+    line: r.line,
+  }));
+
+  let out = `# References to label \`${label}\`\n\n`;
+  out += `**Total:** ${references.length} reference(s) found\n`;
+  out += `_Source: C# bridge (DYNAMICSXREFDB) — includes both X++ code and declarative metadata references_\n\n`;
+
+  // Summary: count by source object type (most-referenced first)
+  const byType = new Map<string, number>();
+  for (const p of parsed) byType.set(p.type, (byType.get(p.type) || 0) + 1);
+  out += `## 📊 By source object type\n\n`;
+  for (const [type, count] of [...byType.entries()].sort((a, b) => b[1] - a[1])) {
+    out += `- **${type}**: ${count} reference(s)\n`;
+  }
+  out += `\n`;
+
+  // Detail: grouped by type, capped at `limit` total rows
+  out += `## 📍 References\n\n`;
+  const visible = parsed.slice(0, limit);
+  const groups = new Map<string, LabelRefRow[]>();
+  for (const p of visible) {
+    const bucket = groups.get(p.type) ?? [];
+    bucket.push(p);
+    groups.set(p.type, bucket);
+  }
+  for (const [type, refs] of [...groups.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    out += `### ${type} (${refs.length})\n\n`;
+    for (const r of refs) {
+      const loc = r.line > 0 ? `:${r.line}` : '';
+      const mod = r.module ? ` [${r.module}]` : '';
+      const det = r.detail ? ` › ${r.detail}` : '';
+      out += `- **${r.objectName}**${det}${loc}${mod}\n`;
+    }
+    out += `\n`;
+  }
+
+  if (references.length > limit) {
+    out += `> ⚠️ Showing first ${limit} of ${references.length} references. Raise \`limit\` to see more.\n`;
+  }
+
+  return { content: [{ type: 'text', text: out }] };
 }
 
 // SEARCH

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -571,9 +571,16 @@ interface ParsedLabelSource {
 
 /**
  * Parse an xref source path for a label reference into (type, object, detail).
+ * `detail` names *where on the object* the label is used, so a reader can jump
+ * straight to it — the X++ method for code refs, or "<member> › <property>" for
+ * declarative metadata refs (the referencing field / enum value / form control
+ * plus the property it sits on). The member is omitted when the property is
+ * declared directly on the object itself (e.g. an EDT's own HelpText).
  * Examples:
  *   "/Classes/WhsWorkManualComplete/Methods/performValidation" → Class · WhsWorkManualComplete · performValidation
- *   "Form/AbatementCertificate_IN/FormDesign/.../ShowData?Text" → Form  · AbatementCertificate_IN · Text
+ *   "Form/AbatementCertificate_IN/FormDesign/.../ShowData?Text" → Form  · AbatementCertificate_IN · ShowData › Text
+ *   "Table/Foo/Fields/Bar?Label"                               → Table · Foo · Bar › Label
+ *   "Enum/ABC/EnumValue/A?Label"                               → Enum  · ABC · A › Label
  *   "EdtString/ABNControllingCorporation_AU?HelpText"          → EDT   · ABNControllingCorporation_AU · HelpText
  */
 function parseLabelSource(sourcePath: string): ParsedLabelSource {
@@ -590,7 +597,14 @@ function parseLabelSource(sourcePath: string): ParsedLabelSource {
     detail = parts[mi + 1].split('?')[0];           // X++ method name (code reference)
   } else {
     const q = sourcePath.lastIndexOf('?');
-    if (q >= 0) detail = sourcePath.substring(q + 1); // referencing property: Label/Caption/HelpText/Text/…
+    if (q >= 0) {
+      const property = sourcePath.substring(q + 1); // property: Label/Caption/HelpText/Text/…
+      // The member the property sits on is the last path segment before the "?"
+      // (a form control, table field, enum value, …). Keep it unless it *is* the
+      // object — a property declared directly on the object needs no member.
+      const member = (parts[parts.length - 1] ?? '').split('?')[0];
+      detail = member && member !== objectName ? `${member} › ${property}` : property;
+    }
   }
   return { type, objectName, detail };
 }
@@ -613,7 +627,10 @@ function formatLabelReferences(references: BridgeReferenceInfo[], label: string,
   out += `**Total:** ${references.length} reference(s) found\n`;
   out += `_Source: C# bridge (DYNAMICSXREFDB) — includes both X++ code and declarative metadata references_\n\n`;
 
-  // Summary: count by source object type (most-referenced first)
+  // Summary: count by source object type (most-referenced first). This counts
+  // ALL references, whereas the detail section below is capped at `limit` — so
+  // each truncated group carries a "showing X of Y" marker to keep the two
+  // sections reconcilable.
   const byType = new Map<string, number>();
   for (const p of parsed) byType.set(p.type, (byType.get(p.type) || 0) + 1);
   out += `## 📊 By source object type\n\n`;
@@ -632,7 +649,11 @@ function formatLabelReferences(references: BridgeReferenceInfo[], label: string,
     groups.set(p.type, bucket);
   }
   for (const [type, refs] of [...groups.entries()].sort((a, b) => b[1].length - a[1].length)) {
-    out += `### ${type} (${refs.length})\n\n`;
+    // When the overall `limit` truncates a group, show "shown of total" so the
+    // rows below don't appear to contradict the summary count above.
+    const total = byType.get(type) ?? refs.length;
+    const heading = refs.length < total ? `${refs.length} of ${total}` : `${refs.length}`;
+    out += `### ${type} (${heading})\n\n`;
     for (const r of refs) {
       const loc = r.line > 0 ? `:${r.line}` : '';
       const mod = r.module ? ` [${r.module}]` : '';

--- a/src/server/toolSchemas/findReferences.ts
+++ b/src/server/toolSchemas/findReferences.ts
@@ -6,18 +6,18 @@
 
 export const findReferencesTool = {
     name: 'find_references',
-    description: 'Find all references (where-used) to a class, method, field, table, or enum. Essential for impact analysis before refactoring. For a method, SCOPE it to its declaring type — pass "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable"), set ownerName alongside a bare method name, or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name (no owner) matches that name on every type and over-reports.',
+    description: 'Find all references (where-used) to a class, method, field, table, enum, or LABEL. Essential for impact analysis before refactoring. For a method, SCOPE it to its declaring type — pass "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable"), set ownerName alongside a bare method name, or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name (no owner) matches that name on every type and over-reports. For a label, pass the label id as targetName (e.g. "@WAX2194" or "@MyLabelFile:MyLabel"); results span every referencing object type (tables, forms, EDTs, enums, reports, menu items, …), not just code, and require the xref database (DYNAMICSXREFDB, full server mode).',
     inputSchema: {
       type: 'object',
       properties: {
         targetName: {
           type: 'string',
-          description: 'Target name. Method where-used: qualify as "Owner.method" or pass an AOT path "/Tables/<Table>/Methods/<method>" for a result scoped to one declaring type (matches Visual Studio xref). A bare method name is name-only and over-reports.'
+          description: 'Target name. Method where-used: qualify as "Owner.method" or pass an AOT path "/Tables/<Table>/Methods/<method>" for a result scoped to one declaring type (matches Visual Studio xref). A bare method name is name-only and over-reports. Label where-used: pass the label id exactly as written — old format "@WAX2194" or new format "@LabelFile:LabelId" (e.g. "@ApplicationPlatform:AbortButtonText").'
         },
         targetType: {
           type: 'string',
-          enum: ['class', 'method', 'field', 'table', 'enum', 'edt', 'form', 'query', 'view', 'report', 'all'],
-          description: 'Type of the target to search for',
+          enum: ['class', 'method', 'field', 'table', 'enum', 'edt', 'form', 'query', 'view', 'report', 'label', 'all'],
+          description: 'Type of the target to search for. Use "label" for label where-used (or just pass an "@…" / "/Labels/@…" targetName).',
           default: 'all'
         },
         ownerName: {

--- a/src/tools/findReferences.ts
+++ b/src/tools/findReferences.ts
@@ -12,9 +12,9 @@ import { tryBridgeReferences } from '../bridge/bridgeAdapter.js';
 
 const FindReferencesArgsSchema = z.object({
   // "name" is accepted as an alias for "targetName"
-  targetName: z.string().optional().describe('Name of the target. For a precise, type-scoped method where-used, qualify it as "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable") or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name matches that name on every type.'),
+  targetName: z.string().optional().describe('Name of the target. For a precise, type-scoped method where-used, qualify it as "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable") or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name matches that name on every type. For a label, pass the label id ("@WAX2194" or "@LabelFile:LabelId").'),
   name: z.string().optional().describe('Alias for targetName.'),
-  targetType: z.enum(['method', 'class', 'table', 'field', 'enum', 'all']).optional().describe('Type of the target to search for'),
+  targetType: z.enum(['method', 'class', 'table', 'field', 'enum', 'edt', 'form', 'query', 'view', 'report', 'label', 'all']).optional().describe('Type of the target to search for'),
   ownerName: z.string().optional().describe('Declaring table/class/form that owns the method, when targetName is just the bare method name. Used to scope the where-used to a single type (matches Visual Studio xref).'),
   scope: z.enum(['all', 'workspace', 'standard', 'custom']).optional().default('all').describe('Search scope'),
   limit: z.number().optional().default(50).describe('Maximum results to return'),
@@ -37,6 +37,22 @@ const TYPE_TO_XREF_CONTAINER: Record<string, string> = {
   map: 'Maps',
   'data-entity': 'DataEntityViews',
 };
+
+/**
+ * Detect and normalize a label where-used target. Labels live in the xref DB
+ * under "/Labels/@<ref>", where <ref> is either the old concatenated form
+ * ("@WAX2194") or the newer "@LabelFile:LabelId" form
+ * ("@ApplicationPlatform:AbortButtonText"). Both forms are stored verbatim in
+ * the xref Names table, so we match exactly and never convert between them.
+ * Returns the "/Labels/@…" path, or null when the target isn't a label.
+ */
+export function resolveLabelTarget(targetName: string, targetType?: string): string | null {
+  const t = targetName.trim();
+  if (/^\/Labels\//i.test(t)) return t;                          // already an xref label path
+  if (t.startsWith('@')) return `/Labels/${t}`;                  // "@WAX2194" / "@ApplicationPlatform:Foo"
+  if (targetType === 'label') return `/Labels/@${t}`;            // bare id + explicit targetType
+  return null;
+}
 
 /**
  * Resolve which xref containers an owner name exists as (Tables/Classes/…).
@@ -84,6 +100,37 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
     const { symbolIndex } = context;
     const { targetType, scope, limit, includeContext, ownerName } = args;
     const targetName = (args.targetName ?? args.name)!; // accept "name" alias
+
+    // LABEL where-used — route to the xref bridge with a "/Labels/@…" path.
+    // Every referencing object type (tables, forms, EDTs, enums, reports, menu
+    // items, security objects, views, maps, …) comes back — most label uses are
+    // declarative metadata (captions, field/EDT labels), not X++ code.
+    const labelPath = resolveLabelTarget(targetName, targetType);
+    if (labelPath) {
+      const outcome = await tryBridgeReferences(context.bridge, labelPath, limit, targetName, 'label');
+      if (outcome.status === 'ok') return outcome.result;
+      if (outcome.status === 'empty') {
+        return { content: [{ type: 'text', text:
+          `# References to label \`${targetName}\`\n\n**Total References Found:** 0\n` +
+          `_Source: C# bridge (DYNAMICSXREFDB)_\n\n` +
+          `No references found. Verify the label id is written exactly as stored — ` +
+          `\`@WAX2194\` (old format) or \`@LabelFile:LabelId\` (new format, e.g. \`@ApplicationPlatform:AbortButtonText\`). ` +
+          `Use labels(action="search") to find the exact id from label text.\n` }] };
+      }
+      // error / unavailable — label where-used needs the xref DB. The name-only
+      // FTS scan can't see declarative metadata references, so don't fake a
+      // partial answer by falling through to it.
+      const why = outcome.status === 'unavailable'
+        ? 'The cross-reference bridge is not available in this server mode.'
+        : 'The cross-reference query failed — check the bridge log.';
+      return { content: [{ type: 'text', text:
+        `# References to label \`${targetName}\`\n\n` +
+        `⚠️ Label where-used requires the cross-reference database (DYNAMICSXREFDB), available when ` +
+        `the server runs in full mode with a UDE/local xref DB configured. ${why}\n\n` +
+        `Unlike code symbols, label references live mostly in declarative metadata (form captions, ` +
+        `field/EDT labels, menu-item captions, …) that is not in the text index — so there is no ` +
+        `reliable fallback.\n` }], isError: outcome.status === 'error' };
+    }
 
     // Target shape: AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"),
     // owner-qualified ("SalesTable.initFromSalesQuotationTable"), or bare name.

--- a/tests/tools/label-references.integration.test.ts
+++ b/tests/tools/label-references.integration.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Label where-used — REAL xref DB smoke test (VM / full-mode only).
+ *
+ * The unit tests (label-references.test.ts) mock the bridge, so they prove the
+ * TS routing/formatting but NOT the core cross-layer claim of this feature:
+ * that the existing generic xref query matches a "/Labels/@…" target path and
+ * that both stored id forms ("@WAX2194", "@LabelFile:LabelId") resolve — no C#
+ * change. That can only be verified against a real DYNAMICSXREFDB.
+ *
+ * This suite closes that gap. It is OPT-IN and skipped everywhere the VM isn't
+ * present (normal CI, dev boxes), so it never flakes the default `npm test`:
+ *
+ *   # on a D365FO VM / UDE with a compiled xref DB:
+ *   D365FO_XREF_INTEGRATION=1 npx vitest run tests/tools/label-references.integration.test.ts
+ *
+ * Optional overrides (defaults target platform labels that are broadly
+ * referenced, but any environment may differ — point these at a label you know
+ * exists in your model):
+ *   D365FO_XREF_TEST_LABEL=@SYS9694          # a widely-referenced label id
+ *   D365FO_XREF_TEST_LABEL_NEWFORM=@ApplicationPlatform:AbortButtonText
+ *   D365FO_PACKAGE_PATH / D365FO_XREF_SERVER / D365FO_XREF_DB  # bridge connection
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createBridgeClient } from '../../src/bridge/bridgeClient';
+import { tryBridgeReferences } from '../../src/bridge/bridgeAdapter';
+import { resolveLabelTarget } from '../../src/tools/findReferences';
+import type { BridgeClient } from '../../src/bridge/bridgeClient';
+
+const RUN = !!process.env.D365FO_XREF_INTEGRATION;
+const OLD_FORM = process.env.D365FO_XREF_TEST_LABEL ?? '@SYS9694';
+const NEW_FORM = process.env.D365FO_XREF_TEST_LABEL_NEWFORM ?? '@ApplicationPlatform:AbortButtonText';
+
+// skipIf keeps the default test run green off-VM; opting in with a VM that has
+// no xref DB fails loudly in beforeAll (a config error the operator wants told).
+describe.skipIf(!RUN)('label where-used — real DYNAMICSXREFDB', () => {
+  let bridge: BridgeClient | null = null;
+
+  beforeAll(async () => {
+    bridge = await createBridgeClient({
+      xrefServer: process.env.D365FO_XREF_SERVER || undefined,
+      xrefDatabase: process.env.D365FO_XREF_DB || undefined,
+    });
+    if (!bridge) throw new Error('createBridgeClient returned null — set D365FO_PACKAGE_PATH to a valid PackagesLocalDirectory.');
+    if (!bridge.xrefAvailable) throw new Error('Bridge is up but xref DB is unavailable — configure DYNAMICSXREFDB (D365FO_XREF_SERVER/D365FO_XREF_DB) for full mode.');
+  }, 180_000);
+
+  afterAll(() => { bridge?.dispose(); });
+
+  it('resolves an old-form label id to a "/Labels/@…" path and queries it without a bridge error', async () => {
+    const path = resolveLabelTarget(OLD_FORM);
+    expect(path).toBe(`/Labels/${OLD_FORM}`);
+
+    const outcome = await tryBridgeReferences(bridge!, path!, 50, OLD_FORM, 'label');
+    // The claim under test: the generic xref query MATCHES a label path (no SQL
+    // error, bridge is available). 'ok' or 'empty' both prove that; 'error' /
+    // 'unavailable' would mean the label path isn't understood by the query.
+    expect(outcome.status === 'ok' || outcome.status === 'empty').toBe(true);
+    if (outcome.status === 'ok') {
+      const text = (outcome.result.content[0] as { text: string }).text;
+      expect(text).toContain('By source object type');
+      expect(text).toContain(`References to label \`${OLD_FORM}\``);
+    }
+  }, 60_000);
+
+  it('resolves a new-form "@LabelFile:LabelId" id verbatim (colon preserved) and queries it', async () => {
+    const path = resolveLabelTarget(NEW_FORM);
+    expect(path).toBe(`/Labels/${NEW_FORM}`);
+
+    const outcome = await tryBridgeReferences(bridge!, path!, 50, NEW_FORM, 'label');
+    expect(outcome.status === 'ok' || outcome.status === 'empty').toBe(true);
+  }, 60_000);
+});

--- a/tests/tools/label-references.test.ts
+++ b/tests/tools/label-references.test.ts
@@ -92,9 +92,27 @@ describe('tryBridgeReferences — label formatting', () => {
 
     expect(text).toContain('WhsWorkManualComplete');
     expect(text).toContain('performValidation');               // X++ method (code ref)
-    expect(text).toContain('ABNControllingCorporation_AU');
-    expect(text).toContain('HelpText');                        // declarative property
-    expect(text).toContain('Text');                            // form control caption property
+    // Declarative refs name the member the property sits on, not just the leaf
+    // property — so "which field/control/value" survives, not only "Label"/"Text".
+    expect(text).toContain('ShowData › Text');                 // form control › caption property
+    expect(text).toContain('A › Label');                       // enum value › label property
+    // …except when the property is on the object itself (no redundant member).
+    expect(text).toContain('ABNControllingCorporation_AU** › HelpText');
+  });
+
+  it('marks a per-type group as truncated when limit cuts into it', async () => {
+    // 6 refs, all Class, but limit=4 → the Class group must read "4 of 6",
+    // reconciling with the summary count above it.
+    const many = Array.from({ length: 6 }, (_, i) => ({
+      sourcePath: `/Classes/Cls${i}/Methods/m${i}`, sourceModule: 'ApplicationSuite', line: i + 1, column: 1,
+    }));
+    const bridge = makeXrefBridge(many);
+    const outcome = await tryBridgeReferences(bridge, '/Labels/@WAX2194', 4, '@WAX2194', 'label');
+    const text = (outcome as any).result.content[0].text as string;
+
+    expect(text).toContain('**Class**: 6 reference(s)');       // summary: full population
+    expect(text).toContain('### Class (4 of 6)');              // detail: truncated marker
+    expect(text).toContain('Showing first 4 of 6 references');
   });
 
   it('reports xref bridge unavailable', async () => {

--- a/tests/tools/label-references.test.ts
+++ b/tests/tools/label-references.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Label where-used (cross-reference) tests for find_references.
+ *
+ * Covers three layers:
+ *   1. resolveLabelTarget — normalizing "@WAX2194" / "@File:Id" / "/Labels/…" / bare-id
+ *      into the "/Labels/@…" xref path (and rejecting non-labels).
+ *   2. tryBridgeReferences(formatAs='label') — grouping references by SOURCE object
+ *      type across both xref path conventions (code "/Classes/…" and declarative
+ *      metadata "Table/…", "EdtString/…", …), surfacing the referencing property.
+ *   3. findReferencesTool — end-to-end routing of a label target to the xref bridge,
+ *      plus the graceful message when the xref DB is unavailable.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { findReferencesTool, resolveLabelTarget } from '../../src/tools/findReferences';
+import { tryBridgeReferences } from '../../src/bridge/bridgeAdapter';
+import type { BridgeClient } from '../../src/bridge/bridgeClient';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// Source paths mirror the real DYNAMICSXREFDB shapes for label references:
+// code refs use "/Classes/…/Methods/…"; declarative metadata refs use singular,
+// slash-free containers ("Table/…", "EdtString/…") with a trailing "?Property".
+const SAMPLE_REFS = [
+  { sourcePath: '/Classes/WhsWorkManualComplete/Methods/performValidation', sourceModule: 'ApplicationSuite', line: 753, column: 43 },
+  { sourcePath: '/Classes/WHSControlSortLicensePlateId/Methods/process', sourceModule: 'ApplicationSuite', line: 36, column: 26 },
+  { sourcePath: '/Tables/AccountantLogisticsLocation_BR/Methods/validateDelete', sourceModule: 'ApplicationSuite', line: 12, column: 9 },
+  { sourcePath: 'Form/AbatementCertificate_IN/FormDesign/FormDesign/FormButtonControl/ShowData?Text', sourceModule: 'ApplicationSuite', line: 0, column: 0 },
+  { sourcePath: 'EdtString/ABNControllingCorporation_AU?HelpText', sourceModule: 'ApplicationSuite', line: 0, column: 0 },
+  { sourcePath: 'Enum/ABC/EnumValue/A?Label', sourceModule: 'ApplicationSuite', line: 0, column: 0 },
+  { sourcePath: 'MenuItemDisplay/AbatementCertificate_IN?Label', sourceModule: 'ApplicationSuite', line: 0, column: 0 },
+];
+
+function makeXrefBridge(refs = SAMPLE_REFS): BridgeClient {
+  return {
+    isReady: true,
+    metadataAvailable: true,
+    xrefAvailable: true,
+    findReferences: vi.fn(async (_target: string) => ({ count: refs.length, references: refs })),
+  } as unknown as BridgeClient;
+}
+
+// ─── resolveLabelTarget ────────────────────────────────────────────────────────
+
+describe('resolveLabelTarget', () => {
+  it('normalizes a concatenated "@WAX2194" id to a /Labels/ path', () => {
+    expect(resolveLabelTarget('@WAX2194')).toBe('/Labels/@WAX2194');
+  });
+
+  it('normalizes a "@LabelFile:LabelId" id verbatim (keeps the colon)', () => {
+    expect(resolveLabelTarget('@ApplicationPlatform:AbortButtonText')).toBe('/Labels/@ApplicationPlatform:AbortButtonText');
+  });
+
+  it('passes through an explicit /Labels/ AOT path unchanged', () => {
+    expect(resolveLabelTarget('/Labels/@WAX2194')).toBe('/Labels/@WAX2194');
+  });
+
+  it('accepts a bare id only when targetType is "label"', () => {
+    expect(resolveLabelTarget('WAX2194', 'label')).toBe('/Labels/@WAX2194');
+    expect(resolveLabelTarget('WAX2194')).toBeNull();          // no @, no targetType → not a label
+  });
+
+  it('does not misclassify a normal symbol as a label', () => {
+    expect(resolveLabelTarget('SalesTable')).toBeNull();
+    expect(resolveLabelTarget('SalesTable.find', 'method')).toBeNull();
+  });
+});
+
+// ─── tryBridgeReferences (label formatter) ─────────────────────────────────────
+
+describe('tryBridgeReferences — label formatting', () => {
+  it('groups references by source object type across both path conventions', async () => {
+    const bridge = makeXrefBridge();
+    const outcome = await tryBridgeReferences(bridge, '/Labels/@WAX2194', 50, '@WAX2194', 'label');
+    expect(outcome.status).toBe('ok');
+    const text = (outcome as any).result.content[0].text as string;
+
+    expect(text).toContain('References to label `@WAX2194`');
+    expect(text).toContain('**Total:** 7 reference(s)');
+    // Both code paths and declarative-metadata paths are classified:
+    expect(text).toContain('**Class**: 2');
+    expect(text).toContain('**Table**: 1');
+    expect(text).toContain('**Form**: 1');
+    expect(text).toContain('**EDT**: 1');                       // EdtString → EDT
+    expect(text).toContain('**Enum**: 1');
+    expect(text).toContain('**Menu item (display)**: 1');
+  });
+
+  it('surfaces the referencing member (method) and property', async () => {
+    const bridge = makeXrefBridge();
+    const outcome = await tryBridgeReferences(bridge, '/Labels/@WAX2194', 50, '@WAX2194', 'label');
+    const text = (outcome as any).result.content[0].text as string;
+
+    expect(text).toContain('WhsWorkManualComplete');
+    expect(text).toContain('performValidation');               // X++ method (code ref)
+    expect(text).toContain('ABNControllingCorporation_AU');
+    expect(text).toContain('HelpText');                        // declarative property
+    expect(text).toContain('Text');                            // form control caption property
+  });
+
+  it('reports xref bridge unavailable', async () => {
+    const bridge = { isReady: true, xrefAvailable: false } as unknown as BridgeClient;
+    const outcome = await tryBridgeReferences(bridge, '/Labels/@WAX2194', 50, '@WAX2194', 'label');
+    expect(outcome.status).toBe('unavailable');
+  });
+});
+
+// ─── findReferencesTool (end-to-end routing) ───────────────────────────────────
+
+function labelRequest(targetName: string, targetType?: string): CallToolRequest {
+  return {
+    method: 'tools/call',
+    params: { name: 'find_references', arguments: { targetName, ...(targetType ? { targetType } : {}) } },
+  };
+}
+
+describe('findReferencesTool — label routing', () => {
+  it('routes an "@…" target to the xref bridge with a /Labels/ path and label formatting', async () => {
+    const bridge = makeXrefBridge();
+    const ctx: any = { symbolIndex: {}, bridge };
+    const result = await findReferencesTool(labelRequest('@WAX2194'), ctx);
+    const text = (result.content[0] as { text: string }).text;
+
+    // Bridge queried with the normalized label path
+    expect((bridge.findReferences as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith('/Labels/@WAX2194');
+    // Label-specific output (not the generic caller-oriented format)
+    expect(text).toContain('By source object type');
+    expect(text).toContain('**Form**: 1');
+  });
+
+  it('explains that label where-used needs the xref DB when the bridge is unavailable', async () => {
+    const bridge = { isReady: true, xrefAvailable: false } as unknown as BridgeClient;
+    const ctx: any = { symbolIndex: {}, bridge };
+    const result = await findReferencesTool(labelRequest('@WAX2194'), ctx);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('requires the cross-reference database');
+    expect(text).toContain('DYNAMICSXREFDB');
+  });
+
+  it('returns an authoritative zero (with guidance) on a clean empty from the bridge', async () => {
+    const bridge = {
+      isReady: true, xrefAvailable: true,
+      findReferences: vi.fn(async () => ({ count: 0, references: [] })),
+    } as unknown as BridgeClient;
+    const ctx: any = { symbolIndex: {}, bridge };
+    const result = await findReferencesTool(labelRequest('@ApplicationPlatform:DoesNotExist'), ctx);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('**Total References Found:** 0');
+    expect(text).toContain('exactly as stored');
+  });
+});

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -24,11 +24,11 @@ import { createXppMcpServer } from '../../src/server/mcpServer';
 const CHARS_PER_TOKEN = 4;
 
 // Ceilings in characters of serialized JSON. Current actuals (2026-07, after
-// the structural schema diet moved d365fo_file modify-op params into a single
-// `params` object with error-driven per-op specs — see d365foFileOpSpecs.ts):
-// total ≈ 60,368 · d365fo_file ≈ 8,390 (generate_object ≈ 7,996 is now a close
-// second). Headroom is small on purpose so creep is caught early.
-const TOTAL_BUDGET = 61_200;
+// adding label where-used to find_references — a new capability, so the ceiling
+// was raised deliberately: total ≈ 61,350 · d365fo_file ≈ 8,390 (generate_object
+// ≈ 7,996 is now a close second). Headroom is small on purpose so creep is
+// caught early.
+const TOTAL_BUDGET = 61_600;
 const LARGEST_TOOL_BUDGET = 8_800;
 
 async function getTools(): Promise<Array<{ name: string }>> {


### PR DESCRIPTION
## Issue
`find_references` covered classes, methods, fields, tables, and enums, but there was no way to find what references a **label**. The data exists in the compiler-built xref DB (DYNAMICSXREFDB) — the same source Visual Studio's "Find references" uses — but no tool exposed it.

## Fix
`find_references` now accepts a label target (`targetType="label"`, or an `@…` id / `/Labels/@…` path). It normalizes to the `/Labels/@<ref>` xref path and returns every referencing object type — tables, forms, EDTs, enums, reports, menu items, views, and more — grouped by source object type, surfacing the referencing method (code) or property (metadata).

- Both stored id forms are matched verbatim: old `@WAX2194` and new `@LabelFile:LabelId`.
- No C# bridge change — the existing generic xref query matches any target path, so a label path flows through the already-compiled bridge unchanged.
- When the xref DB is unavailable, the tool says so rather than returning a partial text-index answer that can't see declarative metadata references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)