### PR TITLE
feat(setup): add D365FO_WORKSPACE_PATH to setup wizard; remove azure-…

### DIFF
--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -400,26 +400,12 @@ async function extractMetadata() {
     const modelDirs = entries.filter(e => e.isDirectory() || e.isSymbolicLink()).map(e => e.name);
 
     for (const modelName of modelDirs) {
-      // Skip FormAdaptor models
-      if (modelName.endsWith('FormAdaptor')) {
-        log.detail(`${glyph.arrow} skip FormAdaptor model: ${modelName}`);
-        continue;
-      }
-
-      // Apply model-level filtering
-      if (FILTER_MODE === 'custom-only' && !isCustomModel(modelName)) {
-        log.detail(`${glyph.arrow} skip standard model: ${modelName}`);
-        continue;
-      }
-      if (FILTER_MODE === 'standard-only' && isCustomModel(modelName)) {
-        log.detail(`${glyph.arrow} skip custom model: ${modelName}`);
-        continue;
-      }
-
       const modelPath = path.join(packagePath, modelName);
 
       // Check if this directory contains X++ metadata (has AxClass, AxTable, etc.)
       // Support both uppercase and lowercase directory names (Linux case-sensitivity)
+      // Do this first so non-model directories (bin, Resources, Reports, …) are
+      // silently skipped before any model-name-based filtering is applied.
       const hasAxClass = await fs.access(path.join(modelPath, 'AxClass')).then(() => true)
         .catch(() => fs.access(path.join(modelPath, 'axclass')).then(() => true).catch(() => false));
       const hasAxTable = await fs.access(path.join(modelPath, 'AxTable')).then(() => true)
@@ -435,6 +421,22 @@ async function extractMetadata() {
 
       if (!hasAxClass && !hasAxTable && !hasAxEnum && !hasAxEdt && !hasAxView && !hasAxDataEntityView) {
         // Skip directories that don't contain X++ metadata
+        continue;
+      }
+
+      // Skip FormAdaptor models
+      if (modelName.endsWith('FormAdaptor')) {
+        log.detail(`${glyph.arrow} skip FormAdaptor model: ${modelName}`);
+        continue;
+      }
+
+      // Apply model-level filtering
+      if (FILTER_MODE === 'custom-only' && !isCustomModel(modelName)) {
+        log.detail(`${glyph.arrow} skip standard model: ${modelName}`);
+        continue;
+      }
+      if (FILTER_MODE === 'standard-only' && isCustomModel(modelName)) {
+        log.detail(`${glyph.arrow} skip custom model: ${modelName}`);
         continue;
       }
 

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -17,7 +17,7 @@ import { listXppConfigs } from '../xppConfig.js';
 import { rebuildIndex } from './indexCmd.js';
 import { instanceAddCommand } from './instance.js';
 
-type Scenario = 'azure' | 'hybrid' | 'local-http' | 'ude' | 'local-stdio' | 'multi';
+type Scenario = 'hybrid' | 'local-http' | 'ude' | 'local-stdio' | 'multi';
 
 const distEntryWin = () => resolve(repoRoot, 'dist', 'index.js');
 
@@ -159,19 +159,9 @@ export async function setupCommand(): Promise<void> {
     { value: 'local-http', label: 'C — Local HTTP', hint: 'several clients on this machine share one server on a port' },
     { value: 'ude', label: 'D — UDE', hint: 'Unified Developer Experience / Power Platform Tools' },
     { value: 'multi', label: 'F — Multi-instance', hint: 'several D365FO clients on one machine, one instance each' },
-    { value: 'azure', label: 'A — Azure client', hint: 'read-only connection to a team server; no local install' },
   ]);
 
-  // A: nothing to install
-  if (scenario === 'azure') {
-    const url = await askText({ message: 'Azure server URL', placeholder: 'https://your-server.azurewebsites.net/mcp/', required: true });
-    mcpJsonNote({ 'd365fo-mcp-tools': { url } });
-    placementNote();
-    p.outro('Done. For real development (writes on your VM) re-run setup and pick Scenario B.');
-    return;
-  }
-
-  // Everything else needs the local clone installed and built
+  // All scenarios need the local clone installed and built
   if (!await ensureInstalledAndBuilt()) { process.exitCode = 1; return; }
   if (!await maybeBuildBridge(scenario)) { process.exitCode = 1; return; }
 
@@ -211,11 +201,16 @@ export async function setupCommand(): Promise<void> {
 
   if (scenario === 'ude') {
     const modelName = await askText({ message: 'Model name for code generation (D365FO_MODEL_NAME)', required: true });
+    const workspacePath = await askText({
+      message: 'Two-level workspace path …\\PackagesLocalDirectory\\<Package>\\<Model> (D365FO_WORKSPACE_PATH)',
+      placeholder: 'K:\\AosService\\PackagesLocalDirectory\\YourPackage\\YourModel',
+      required: true,
+    });
     mcpJsonNote({
       'd365fo-mcp-tools': {
         command: 'node',
         args: [distEntryWin()],
-        env: { D365FO_MODEL_NAME: modelName, D365FO_DEV_ENVIRONMENT_TYPE: 'ude' },
+        env: { D365FO_MODEL_NAME: modelName, D365FO_DEV_ENVIRONMENT_TYPE: 'ude', D365FO_WORKSPACE_PATH: workspacePath },
       },
     });
     placementNote();
@@ -228,9 +223,15 @@ export async function setupCommand(): Promise<void> {
     message: 'Folder scanned for .rnrproj solutions (D365FO_SOLUTIONS_PATH; Enter to skip)',
     placeholder: 'K:\\repos\\MySolution\\projects',
   });
+  const workspacePath = await askText({
+    message: 'Two-level workspace path …\\PackagesLocalDirectory\\<Package>\\<Model> (D365FO_WORKSPACE_PATH)',
+    placeholder: 'K:\\AosService\\PackagesLocalDirectory\\YourPackage\\YourModel',
+    required: true,
+  });
   const env: Record<string, string> = {
     DB_PATH: paths.defaultDb,
     LABELS_DB_PATH: paths.defaultLabelsDb,
+    D365FO_WORKSPACE_PATH: workspacePath,
   };
   if (solutionsPath) env.D365FO_SOLUTIONS_PATH = solutionsPath;
   mcpJsonNote({ 'd365fo-mcp-tools': { command: 'node', args: [distEntryWin()], env } });

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1165,7 +1165,9 @@ export class XppSymbolIndex {
     // Sort largest models first — ensures Foundation (56K files) is indexed before any CI timeout
     let models = allModels;
     if (!modelName) {
+      log.detail(`Scanning ${allModels.length} model(s) to determine build order...`);
       models = this.sortModelsBySize(metadataPath, allModels);
+      log.detail(`Build order determined (largest model first: ${models[0] ?? '—'})`);
     }
 
     // Skip already-indexed models when resuming (RESUME=true)
@@ -1198,6 +1200,14 @@ export class XppSymbolIndex {
       modelIndex++;
       const modelPath = path.join(metadataPath, model);
       const modelStartTime = Date.now();
+      const progressPercent = ((modelIndex / models.length) * 100).toFixed(0);
+
+      // Show which model is being processed RIGHT NOW (before the slow transaction)
+      if (isCI()) {
+        log.detail(`[${progressPercent}%] indexing ${model}...`);
+      } else {
+        process.stdout.write(`\r      ${c.dim(`[${progressPercent}%]`)} ${model.padEnd(40)} ${c.dim('indexing...')}`);
+      }
 
       const tx = this.db.transaction(() => {
         const classesPath = path.join(modelPath, 'classes');
@@ -1296,14 +1306,13 @@ export class XppSymbolIndex {
       tx();
 
       const modelDuration = ((Date.now() - modelStartTime) / 1000).toFixed(1);
-      const progressPercent = ((modelIndex / models.length) * 100).toFixed(0);
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
-      
+
       if (isCI()) {
-        // CI environment: use normal console.log (one line per model)
+        // CI environment: overwrite the "indexing..." line with the completed summary
         log.detail(`[${progressPercent}%] ${model} - ${modelDuration}s (${elapsed}s total)`);
       } else {
-        // Interactive terminal: overwrite same line for compact output
+        // Interactive terminal: overwrite the "indexing..." line with completed summary
         process.stdout.write(`\r      ${c.dim(`[${progressPercent}%]`)} ${model.padEnd(40)} ${c.dim(`${modelDuration}s (${elapsed}s total)`)}`);
       }
     }


### PR DESCRIPTION
…only scenario

- setup: add required D365FO_WORKSPACE_PATH prompt to scenarios D (UDE) and E (local-stdio)
- setup: remove scenario A (Azure client) — not a recommended standalone option
- extract-metadata: check X++ directory structure before model-name filtering so non-model dirs (bin, Resources, ...) are silently skipped without name-based checks
- symbolIndex: show 'indexing...' progress line before the slow DB transaction starts; add build-order log lines for easier CI diagnosis