### PR TITLE
Reconcile root and instance env templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,10 @@ CUSTOM_MODELS=YourCustomModel1,YourCustomModel2
 # SQLite database with indexed X++ metadata
 DB_PATH=./data/xpp-metadata.db
 
+# Separate SQLite database with indexed labels (dual-database architecture)
+# Defaults to ./data/xpp-metadata-labels.db (alongside DB_PATH) — uncomment to override.
+# LABELS_DB_PATH=./data/xpp-metadata-labels.db
+
 # Output folder for extracted XML metadata
 METADATA_PATH=./extracted-metadata
 

--- a/instances/.env.template
+++ b/instances/.env.template
@@ -91,6 +91,12 @@ EXTRACT_MODE=all
 # Bridge timeouts (milliseconds). Raise on large installations or slow VMs.
 # BRIDGE_READY_TIMEOUT_MS=30000   # wait for the C# bridge to become ready (default 30000)
 # BRIDGE_CALL_TIMEOUT_MS=60000    # per-call timeout for a single bridge request (default 60000)
+#
+# Bridge resilience. READ calls are auto-retried on timeout/pipe error with a
+# health-checked restart of the child process in between; WRITE calls are never retried.
+# BRIDGE_MAX_RETRIES=2            # max retries for read calls (0 = disabled)
+# BRIDGE_HEALTHCHECK_MS=0         # idle ping interval in ms (0 = disabled)
+# BRIDGE_MAX_RESTARTS=3           # max child respawns per 60s before giving up
 
 # =============================================================================
 # SERVER OPTIONS
@@ -98,3 +104,11 @@ EXTRACT_MODE=all
 NODE_ENV=development
 LOG_LEVEL=info
 MCP_SERVER_MODE=full
+
+# =============================================================================
+# FORM PATTERN ENFORCEMENT
+# =============================================================================
+# Structural form-pattern violations block form writes in d365fo_file
+# (action="create" / modify add-control). Enabled by default; set to false to
+# log pattern errors without blocking.
+# FORM_PATTERN_ENFORCE=true


### PR DESCRIPTION
## Issue

The root `.env.example` and `instances/.env.template` drifted apart. Each gained configuration keys the other never mirrored:

- `LABELS_DB_PATH` existed only in `instances/.env.template` — the root base template didn't document the labels (dual-database) path at all.
- `BRIDGE_MAX_RETRIES`, `BRIDGE_HEALTHCHECK_MS`, `BRIDGE_MAX_RESTARTS`, and `FORM_PATTERN_ENFORCE` were added to the root `.env.example` only. New instances (created from `instances/.env.template`) were born without them, so the missing-settings check flagged them as discrepancies on every run.

## Fix

- Add `LABELS_DB_PATH` to root `.env.example`.
- Mirror the three `BRIDGE_*` resilience keys and `FORM_PATTERN_ENFORCE` into `instances/.env.template`.
- `GROUNDING_SECRET` is intentionally left out of the instance template — it applies only to hybrid / scaled-out deployments, not local instances.
