### PR TITLE
fix: save raw mcp.json to file on setup, correct D365FO_PACKAGE_PATH …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,15 +110,18 @@ EXTENSION_PREFIX=ISV_
 # BLOB_DATABASE_NAME=xpp-metadata.db
 
 # =============================================================================
-# D365FO CONTEXT — passed via .mcp.json env block (NOT .env)
+# D365FO CONTEXT — typically passed via .mcp.json env block
 # =============================================================================
-# These D365FO_* variables are normally set in .mcp.json inside the server's
-# "env" block so VS 2022 passes them to the subprocess. They are listed here
-# for reference only — you do NOT need to set them in .env unless running
-# the server manually from the command line (npm run dev / node dist/index.js).
+# Workspace-specific variables (per-model, per-project) are normally set in
+# .mcp.json so VS 2022 passes them to each subprocess. They are listed here
+# for reference — useful when running the server manually from the command line
+# (npm run dev / node dist/index.js), where the .mcp.json env block is absent.
+#
+# Exception: D365FO_PACKAGE_PATH and D365FO_DEV_ENVIRONMENT_TYPE are machine-wide
+# in traditional mode and belong in .env (the LOCAL section above). You do NOT
+# need to repeat them in .mcp.json when using the local stdio setup (Scenario E).
 #
 # D365FO_WORKSPACE_PATH=K:\AOSService\PackagesLocalDirectory\YourPackage\YourModel
-# D365FO_PACKAGE_PATH=K:\AOSService\PackagesLocalDirectory   # ← primary env var for packages root
 # D365FO_MODEL_NAME=YourModelName
 # D365FO_PROJECT_PATH=K:\repos\MySolution\MyProject\MyProject.rnrproj
 # D365FO_SOLUTION_PATH=K:\repos\MySolution\MySolution.sln

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ test-model-tags*/
 
 # MCP Configuration
 .mcp.json
+mcp-config-suggestion.json
 
 # OS
 .DS_Store

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -180,7 +180,7 @@ The TypeScript client transparently recovers from transient bridge failures:
 | Cause | Fix |
 |---|---|
 | Bridge not built | Run `dotnet build -c Release` in `bridge/D365MetadataBridge/` |
-| Wrong `packagePath` | Fix `D365FO_PACKAGE_PATH` env var in `.mcp.json` to point to `PackagesLocalDirectory` |
+| Wrong `packagePath` | Fix `D365FO_PACKAGE_PATH` env var (in `.env` for traditional, or `.mcp.json` env block) to point to `PackagesLocalDirectory` |
 | Missing DLLs | Verify `{D365FO_PACKAGE_PATH}/bin/` contains `Microsoft.Dynamics.AX.Metadata.*.dll` |
 | Running on Linux/macOS | Expected — bridge is Windows-only, server uses SQLite fallback |
 

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -937,8 +937,10 @@ export async function createBridgeClient(options: {
 }
 
 function detectPackagesPath(): string | null {
-  // Canonical env vars take priority over well-known path probes. D365FO_PACKAGE_PATH is read by
-  // configManager and exposed via .mcp.json env{} blocks; PACKAGES_PATH is the legacy .env.example name.
+  // Canonical env vars take priority over well-known path probes. D365FO_PACKAGE_PATH can be set
+  // in .env (traditional mode, loaded by dotenv at startup) or in the .mcp.json env{} block
+  // (VS passes it to the subprocess). Both sources land in process.env equivalently.
+  // PACKAGES_PATH is the legacy .env.example name.
   const candidates = [
     process.env.D365FO_PACKAGE_PATH ?? '',
     process.env.PACKAGES_PATH ?? '',

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -22,7 +22,12 @@ type Scenario = 'hybrid' | 'local-http' | 'ude' | 'local-stdio' | 'multi';
 const distEntryWin = () => resolve(repoRoot, 'dist', 'index.js');
 
 function mcpJsonNote(servers: Record<string, unknown>, title = '.mcp.json'): void {
-  p.note(JSON.stringify({ servers }, null, 2), title);
+  const json = JSON.stringify({ servers }, null, 2);
+  p.note(json, title);
+  // Also write the raw JSON to a file so it can be copied without terminal box characters.
+  const outPath = resolve(repoRoot, 'mcp-config-suggestion.json');
+  fs.writeFileSync(outPath, json + '\n', 'utf8');
+  p.log.info(`Raw JSON written to: ${outPath}`);
 }
 
 function placementNote(): void {


### PR DESCRIPTION
…docs

- setup: write mcp-config-suggestion.json to repo root so the suggested .mcp.json block can be copied without terminal box-drawing characters
- .gitignore: exclude mcp-config-suggestion.json
- docs/BRIDGE.md: fix troubleshooting row - D365FO_PACKAGE_PATH can come from .env (traditional) OR .mcp.json env block, not only .mcp.json
- src/bridge/bridgeClient.ts: update misleading comment that said the var is 'exposed via .mcp.json env{} blocks' - both .env and .mcp.json work
- .env.example: rewrite D365FO CONTEXT section - remove the duplicate D365FO_PACKAGE_PATH reference and clarify that in traditional mode it is machine-wide and belongs in .env, not repeated in .mcp.json