### PR TITLE
fix: run symbol-count scans off the event loop so MCP clients don't kill the server

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -23,6 +23,22 @@ Get the D365 F&O MCP Server running with GitHub Copilot in 5 steps.
 
 ## Step 2 — Clone and build
 
+### Interactive setup (recommended)
+
+The first-time setup wizard walks you through everything below — scenario selection, C# bridge build, `.env` configuration, index build — and prints the `.mcp.json` block to paste in Step 3:
+
+```powershell
+git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
+cd K:\d365fo-mcp-server
+npm install
+npm run setup        # first-time setup wizard
+npm run doctor       # health check — verifies Node, build, index, bridge
+```
+
+If the wizard completed, skip the manual steps and continue with [Step 3](#step-3--connect-copilot).
+
+### Manual setup
+
 ```powershell
 git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
 cd K:\d365fo-mcp-server

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,8 +219,8 @@ async function initializeServices() {
     }
 
     // Initialize symbol index and parser (DB path is shown in the startup header).
-    // The open + count is synchronous and can block for a while on a large DB,
-    // so announce it first — otherwise the output looks frozen during the load.
+    // The open is synchronous and can block briefly on a large DB, so announce
+    // it first — otherwise the output looks frozen during the load.
     log.step('Loading symbols' + glyph.ellipsis);
     serverState.statusMessage = 'Loading metadata database...';
     const dbLoadStart = Date.now();
@@ -232,11 +232,14 @@ async function initializeServices() {
     await new Promise<void>(r => setImmediate(r));
 
     let symbolIndex: XppSymbolIndex;
-    let symbolCount = 0;
+    let dbHasSymbols = false;
 
     try {
       symbolIndex = new XppSymbolIndex(DB_PATH, LABELS_DB_PATH);
-      symbolCount = symbolIndex.getSymbolCount();
+      // Cheap O(1) probe — NOT getSymbolCount(): a full COUNT scan of a 2 GB DB
+      // blocks the event loop for 30-60 s, which starves the MCP handshake and
+      // makes clients (VS Code Copilot) time out and kill the server.
+      dbHasSymbols = symbolIndex.hasAnySymbols();
     } catch (error: any) {
       console.error(statusLine('err', 'Failed to open database:'), error);
 
@@ -252,7 +255,7 @@ async function initializeServices() {
 
         // Try again with fresh database
         symbolIndex = new XppSymbolIndex(DB_PATH, LABELS_DB_PATH);
-        symbolCount = symbolIndex.getSymbolCount();
+        dbHasSymbols = symbolIndex.hasAnySymbols();
         log.warn('Symbol index is now empty. To restore, run: npm run index-metadata');
       } else {
         throw error;
@@ -262,7 +265,7 @@ async function initializeServices() {
     const parser = new XppMetadataParser();
 
     // Check if database needs indexing
-    if (symbolCount === 0) {
+    if (!dbHasSymbols) {
       log.warn('No symbols found in database — run `npm run index-metadata` first');
       log.detail('or set METADATA_PATH and the server will index on startup');
 
@@ -285,10 +288,16 @@ async function initializeServices() {
         log.warn('Metadata path not accessible — starting with empty index');
       }
     } else {
-      const b = symbolIndex.getSymbolCountByType();
-      const n = (x: number) => (x || 0).toLocaleString('en-US');
-      log.ok(`Loaded ${symbolCount.toLocaleString('en-US')} symbols in ${((Date.now() - dbLoadStart) / 1000).toFixed(1)}s`);
-      log.detail(`${n(b.class)} classes ${glyph.dot} ${n(b.table)} tables ${glyph.dot} ${n(b.form)} forms ${glyph.dot} ${n(b.query)} queries ${glyph.dot} ${n(b.view)} views`);
+      log.ok(`Database opened in ${((Date.now() - dbLoadStart) / 1000).toFixed(1)}s ${glyph.dot} counting symbols in background`);
+      // The count scan runs in a worker thread (getSymbolCounts) so it never
+      // blocks MCP requests; the breakdown is logged when it lands.
+      void symbolIndex.getSymbolCounts().then(({ total, byType: b }) => {
+        const n = (x: number) => (x || 0).toLocaleString('en-US');
+        log.ok(`Counted ${total.toLocaleString('en-US')} symbols in ${((Date.now() - dbLoadStart) / 1000).toFixed(1)}s`);
+        log.detail(`${n(b.class)} classes ${glyph.dot} ${n(b.table)} tables ${glyph.dot} ${n(b.form)} forms ${glyph.dot} ${n(b.query)} queries ${glyph.dot} ${n(b.view)} views`);
+      }).catch(err => {
+        console.error(statusLine('warn', 'Symbol count failed:'), err);
+      });
     }
 
     serverState.symbolIndex = symbolIndex;
@@ -654,7 +663,8 @@ async function main() {
         service: 'd365fo-mcp-server',
         version: '1.0.0',
         message: serverState.statusMessage,
-        symbols: serverState.symbolIndex?.getSymbolCount() || 0,
+        // Cached-only: a health probe must never trigger a 30-60 s COUNT scan.
+        symbols: serverState.symbolIndex?.getCachedSymbolCounts()?.total || 0,
       });
     });
 

--- a/src/metadata/symbolCountsWorker.ts
+++ b/src/metadata/symbolCountsWorker.ts
@@ -1,0 +1,42 @@
+/**
+ * Symbol-counts worker thread.
+ *
+ * COUNT(*) / GROUP BY over the symbols table is a full index scan — on a
+ * 2 GB production database with a cold OS file cache it takes 30-60+ seconds.
+ * better-sqlite3 is synchronous, so running it on the main thread blocks the
+ * event loop and the MCP server cannot answer tools/list or the first tool
+ * call; the client (VS Code Copilot) times out after 60 s and kills the
+ * server. Running the scan here, on a separate thread with its own read-only
+ * connection, keeps the main thread free (WAL mode allows concurrent readers).
+ *
+ * Spawned by XppSymbolIndex.getSymbolCounts(); posts a single message:
+ *   { ok: true, total, byType } | { ok: false, error }
+ */
+
+import { parentPort, workerData } from 'node:worker_threads';
+import Database from 'better-sqlite3';
+
+const { dbPath } = workerData as { dbPath: string };
+
+try {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    db.pragma('busy_timeout = 5000');
+    // One GROUP BY scan yields both the per-type breakdown and (summed) the
+    // total — half the work of separate COUNT(*) + GROUP BY queries.
+    const rows = db
+      .prepare(`SELECT type, COUNT(*) as count FROM symbols GROUP BY type`)
+      .all() as Array<{ type: string; count: number }>;
+    const byType: Record<string, number> = {};
+    let total = 0;
+    for (const row of rows) {
+      byType[row.type] = row.count;
+      total += row.count;
+    }
+    parentPort!.postMessage({ ok: true, total, byType });
+  } finally {
+    db.close();
+  }
+} catch (e) {
+  parentPort!.postMessage({ ok: false, error: String(e) });
+}

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -4,6 +4,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { Worker } from 'node:worker_threads';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { XppSymbol } from './types.js';
@@ -17,6 +18,12 @@ import { c, log } from '../utils/terminalUi.js';
 const isCI = (): boolean => {
   return !!(process.env.CI || process.env.TF_BUILD || process.env.GITHUB_ACTIONS);
 };
+
+/** Total + per-type symbol counts (both come from one GROUP BY scan). */
+export interface SymbolCounts {
+  total: number;
+  byType: Record<string, number>;
+}
 
 export class XppSymbolIndex {
   public db: Database.Database; // Public for direct pragma access in build scripts
@@ -34,11 +41,17 @@ export class XppSymbolIndex {
   private readPool: Database.Database[] = [];
   private labelsReadPool: Database.Database[] = [];
   private readPoolRR = 0;
+  // Symbol-count scans are expensive (full index scan of 1M+ rows, 30-60 s
+  // cold) — memoize the result and compute it off-thread (see getSymbolCounts).
+  private dbPath: string;
+  private symbolCountsCache: SymbolCounts | null = null;
+  private symbolCountsPromise: Promise<SymbolCounts> | null = null;
   // Per-connection prepared-statement cache.  Prepared statements are bound to
   // their originating connection and cannot be shared across connections.
   private perConnStmtCache = new WeakMap<Database.Database, Map<string, Database.Statement>>();
 
   constructor(dbPath: string, labelsDbPath?: string) {
+    this.dbPath = dbPath;
     // Ensure database directory exists
     const dbDir = path.dirname(dbPath);
     if (!fs.existsSync(dbDir)) {
@@ -745,6 +758,7 @@ export class XppSymbolIndex {
    * Add a symbol to the index with enhanced metadata
    */
   addSymbol(symbol: XppSymbol): void {
+    this.invalidateSymbolCounts();
     let stmt = this.stmtCache.get('addSymbol');
     if (!stmt) {
       stmt = this.db.prepare(`
@@ -800,6 +814,7 @@ export class XppSymbolIndex {
 
     // The FTS trigger (symbols_fts AFTER DELETE) handles FTS cleanup automatically
     const result = this.db.prepare(`DELETE FROM symbols WHERE file_path = ?`).run(filePath);
+    this.invalidateSymbolCounts();
     return { deletedCount: result.changes, objectNames };
   }
 
@@ -971,24 +986,114 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Get symbol count
+   * Get symbol count.
+   *
+   * WARNING: without a warm cache this is a full index scan — 30-60 s on a
+   * large production DB with a cold file cache, and better-sqlite3 blocks the
+   * event loop for the whole scan. Server request paths must use
+   * getSymbolCounts() (off-thread) or getCachedSymbolCounts() instead; the
+   * synchronous form is for build scripts and post-indexing logging where the
+   * DB is small or already hot.
    */
   getSymbolCount(): number {
+    if (this.symbolCountsCache) return this.symbolCountsCache.total;
     const stmt = this.getReadDb().prepare('SELECT COUNT(*) as count FROM symbols');
     return (stmt.get() as { count: number }).count;
   }
 
   /**
-   * Get symbol count by type
+   * Get symbol count by type. Same event-loop-blocking caveat as getSymbolCount().
    */
   getSymbolCountByType(): Record<string, number> {
-    const stmt = this.getReadDb().prepare(
-      `SELECT type, COUNT(*) as count FROM symbols GROUP BY type`
-    );
-    const rows = stmt.all() as { type: string; count: number }[];
-    const result: Record<string, number> = {};
-    for (const row of rows) result[row.type] = row.count;
-    return result;
+    if (this.symbolCountsCache) return this.symbolCountsCache.byType;
+    return this.computeSymbolCountsSync().byType;
+  }
+
+  /**
+   * Cheap emptiness probe — O(1) regardless of table size. Use this instead of
+   * getSymbolCount() === 0 on startup paths.
+   */
+  hasAnySymbols(): boolean {
+    const row = this.getReadDb()
+      .prepare('SELECT EXISTS(SELECT 1 FROM symbols) as present')
+      .get() as { present: number };
+    return row.present === 1;
+  }
+
+  /**
+   * Memoized counts if already computed this session, else null. Never scans —
+   * safe on any request path (health endpoints, status displays).
+   */
+  getCachedSymbolCounts(): SymbolCounts | null {
+    return this.symbolCountsCache;
+  }
+
+  /**
+   * Total + per-type symbol counts without blocking the event loop.
+   *
+   * The scan runs in a worker thread with its own read-only connection (WAL
+   * allows concurrent readers), so the MCP server keeps answering protocol
+   * requests while it runs. The result is memoized; concurrent callers share
+   * one in-flight computation. Falls back to a synchronous scan when the
+   * worker cannot start (:memory: DBs are per-connection and invisible to
+   * another thread; under tsx/vitest the compiled worker .js does not exist).
+   */
+  async getSymbolCounts(): Promise<SymbolCounts> {
+    if (this.symbolCountsCache) return this.symbolCountsCache;
+    if (this.symbolCountsPromise) return this.symbolCountsPromise;
+
+    const promise = this.computeSymbolCountsInWorker()
+      .catch(() => this.computeSymbolCountsSync())
+      .then(counts => {
+        // Only memoize if no write invalidated the computation while it ran.
+        if (this.symbolCountsPromise === promise) {
+          this.symbolCountsCache = counts;
+        }
+        return counts;
+      });
+    this.symbolCountsPromise = promise;
+    return promise;
+  }
+
+  /** Drop memoized counts — call after any write that changes symbol rows. */
+  private invalidateSymbolCounts(): void {
+    this.symbolCountsCache = null;
+    this.symbolCountsPromise = null;
+  }
+
+  private computeSymbolCountsSync(): SymbolCounts {
+    const rows = this.getReadDb()
+      .prepare(`SELECT type, COUNT(*) as count FROM symbols GROUP BY type`)
+      .all() as { type: string; count: number }[];
+    const byType: Record<string, number> = {};
+    let total = 0;
+    for (const row of rows) {
+      byType[row.type] = row.count;
+      total += row.count;
+    }
+    return { total, byType };
+  }
+
+  private computeSymbolCountsInWorker(): Promise<SymbolCounts> {
+    if (this.dbPath === ':memory:') {
+      return Promise.reject(new Error('in-memory DB is not visible to worker threads'));
+    }
+    return new Promise<SymbolCounts>((resolve, reject) => {
+      const worker = new Worker(new URL('./symbolCountsWorker.js', import.meta.url), {
+        workerData: { dbPath: this.dbPath },
+      });
+      worker.once('message', (msg: { ok: boolean; total?: number; byType?: Record<string, number>; error?: string }) => {
+        if (msg.ok) {
+          resolve({ total: msg.total!, byType: msg.byType! });
+        } else {
+          reject(new Error(msg.error));
+        }
+        void worker.terminate();
+      });
+      worker.once('error', reject);
+      // A promise settles only once — this covers "exited before messaging".
+      worker.once('exit', code => reject(new Error(`counts worker exited with code ${code}`)));
+    });
   }
 
   /**
@@ -2849,6 +2954,7 @@ export class XppSymbolIndex {
    * Clear all symbols
    */
   clear(): void {
+    this.invalidateSymbolCounts();
     this.db.exec('DELETE FROM symbols');
     this.db.exec('DELETE FROM table_relations');
     this.db.exec('DELETE FROM form_datasources');
@@ -2880,6 +2986,7 @@ export class XppSymbolIndex {
     // user-supplied data. The actual model name values flow through SQLite's
     // parameterized binding via .run(...modelNames), so there is no injection risk.
     const placeholders = modelNames.map(() => '?').join(',');
+    this.invalidateSymbolCounts();
 
     // Wrap all deletes in a single transaction so the database never ends up
     // in a partially-cleared state if one statement fails mid-way.

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -413,7 +413,8 @@ export class CustomHttpTransport implements Transport {
       res.json({
         status: 'healthy',
         timestamp: new Date().toISOString(),
-        symbols: this.context.symbolIndex.getSymbolCount(),
+        // Cached-only: a health probe must never trigger a 30-60 s COUNT scan.
+        symbols: this.context.symbolIndex.getCachedSymbolCounts()?.total ?? 0,
       });
     });
   }

--- a/src/workspace/contextSnapshot.ts
+++ b/src/workspace/contextSnapshot.ts
@@ -158,8 +158,12 @@ export async function buildContextSnapshot(
     lastIndexedAt: null as string | null,
   };
   try {
-    index.totalSymbols = symbolIndex.getSymbolCount();
-    index.byType = symbolIndex.getSymbolCountByType();
+    // Off-thread + memoized — the synchronous count getters block the event
+    // loop for 30-60 s on a cold 2 GB DB, which would starve the MCP transport
+    // during the very first get_workspace_info call.
+    const counts = await symbolIndex.getSymbolCounts();
+    index.totalSymbols = counts.total;
+    index.byType = counts.byType;
     index.indexedModels = Array.from(symbolIndex.getIndexedModels()).sort();
     index.lastIndexedAt = symbolIndex.getLastIndexedAt?.() ?? null;
   } catch {


### PR DESCRIPTION
## Problem

GitHub Copilot (VS Code) killed the stdio MCP server right after the handshake / first tool call. Reproduced with a scripted stdio client mimicking Copilot: `tools/list` timed out with `MCP error -32001` after 60 s and the client terminated the subprocess.

Root cause: `getSymbolCount()` (`SELECT COUNT(*)`, ~8 s) and `getSymbolCountByType()` (`GROUP BY type`, ~31 s) are full index scans over 1.17M rows in a 2 GB production DB — 30-60+ s with a cold file cache. better-sqlite3 is synchronous, so the scans blocked the event loop:

- during background startup in `initializeServices()` — exactly the window in which the client sends `tools/list`, and
- inside the first `get_workspace_info` call via `contextSnapshot.ts`.

While blocked, the server cannot answer any MCP request; the client times out and kills the server.

## Fix

- **New `src/metadata/symbolCountsWorker.ts`** — the scan runs in a worker thread with its own read-only connection (WAL allows concurrent readers). One `GROUP BY` scan yields both total and per-type counts (half the work of the previous two queries).
- **`XppSymbolIndex`**: `getSymbolCounts()` (async, memoized, dedupes concurrent callers, sync fallback for `:memory:` DBs and tsx/vitest where the compiled worker doesn't exist), `getCachedSymbolCounts()` (never scans), `hasAnySymbols()` (O(1) emptiness probe). Cache invalidated on every symbol-row write (`addSymbol`, `removeSymbolsByFile`, `clear`, `clearModels`).
- **Startup (`src/index.ts`)**: the needs-indexing decision uses `hasAnySymbols()`; the symbol breakdown is logged in the background when the worker finishes.
- **`get_workspace_info`** (`contextSnapshot.ts`) awaits the worker instead of scanning synchronously; **health endpoints** (`index.ts`, `transport.ts`) serve cached counts only.

## Docs

`docs/QUICK_START.md` Step 2 now leads with the `npm run setup` interactive wizard (+ `npm run doctor`) as the recommended path — previously it was only mentioned in the README.

## Verification

- Repro client (handshake → `tools/list` → `get_workspace_info` → `search`) against the 2 GB production DB: `get_workspace_info` answers in ~6 s (previously timed out at 60 s), `search` in ~11 s, server stays up.
- `npm run build` clean; full unit suite passes (110 files, 1582 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
