### PR TITLE
fix(get_method): parse multi-line X++ method declarations

### DIFF
--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -21,6 +21,7 @@ import type {
 } from './types.js';
 import { EnhancedXppParser } from './enhancedParser.js';
 import { walkFormDesign, collectPatternNodes } from './formPatternMiner.js';
+import { parseXppDeclaration, type XppDeclaration } from './xppDeclaration.js';
 
 export class XppMetadataParser {
   private parser: Parser;
@@ -193,13 +194,14 @@ export class XppMetadataParser {
     return methods.map(method => {
       const source = method.Source || '';
       const methodName = method.Name || 'unknown';
-      
+      const decl = parseXppDeclaration(source, methodName);
+
       const baseMethod: XppMethodInfo = {
         name: methodName,
         visibility: this.parseVisibility(method.Visibility),
-        returnType: this.extractReturnType(source, methodName) || method.ReturnType || 'void',
-        parameters: this.extractParametersFromSource(source, methodName),
-        isStatic: this.isMethodStatic(source),
+        returnType: decl?.returnType || method.ReturnType || 'void',
+        parameters: this.toParameterInfo(decl),
+        isStatic: decl?.modifiers.includes('static') ?? false,
         source: source,
         documentation: method.DeveloperDocumentation || undefined,
       };
@@ -399,107 +401,9 @@ export class XppMetadataParser {
     return Array.isArray(value) ? value : [value];
   }
 
-  /**
-   * Extract parameters from method source code
-   */
-  private extractParametersFromSource(source: string, methodName: string): XppParameterInfo[] {
-    if (!source) return [];
-
-    // Find method signature in source - look for methodName followed by parentheses
-    // Pattern: methodName(param1, param2, ...)
-    const methodPattern = new RegExp(`\\b${this.escapeRegex(methodName)}\\s*\\(([^)]*)\\)`, 'i');
-    const match = source.match(methodPattern);
-
-    if (!match || !match[1]) return [];
-
-    const paramsStr = match[1].trim();
-    if (!paramsStr) return [];
-
-    // Split by comma, but be careful with generic types that contain commas
-    const params = this.splitParameters(paramsStr);
-
-    return params.map(param => {
-      // Parse "Type name" or "Type _name" format
-      const parts = param.trim().split(/\s+/);
-      if (parts.length >= 2) {
-        // Join all but last part as type (handles complex types like "Dictionary<string, int>")
-        const name = parts[parts.length - 1];
-        const type = parts.slice(0, -1).join(' ');
-        return { type, name };
-      }
-      return { type: 'object', name: param.trim() };
-    }).filter(p => p.name.length > 0);
-  }
-
-  /**
-   * Extract return type from method source
-   */
-  private extractReturnType(source: string, methodName: string): string | undefined {
-    if (!source) return undefined;
-
-    // Look for pattern: [modifiers] returnType methodName(
-    const pattern = new RegExp(`\\b(\\w+)\\s+${this.escapeRegex(methodName)}\\s*\\(`, 'i');
-    const match = source.match(pattern);
-
-    if (match && match[1]) {
-      const returnType = match[1];
-      // Filter out modifiers
-      const modifiers = ['public', 'private', 'protected', 'static', 'final', 'abstract', 'internal'];
-      if (!modifiers.includes(returnType.toLowerCase())) {
-        return returnType;
-      }
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Check if method is static from source
-   */
-  private isMethodStatic(source: string): boolean {
-    if (!source) return false;
-    return /\bstatic\s+/i.test(source);
-  }
-
-  /**
-   * Escape special regex characters
-   */
-  private escapeRegex(str: string): string {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  /**
-   * Split parameters by comma, respecting nested generics
-   */
-  private splitParameters(paramsStr: string): string[] {
-    const params: string[] = [];
-    let current = '';
-    let depth = 0;
-
-    for (let i = 0; i < paramsStr.length; i++) {
-      const char = paramsStr[i];
-      
-      if (char === '<' || char === '(') {
-        depth++;
-        current += char;
-      } else if (char === '>' || char === ')') {
-        depth--;
-        current += char;
-      } else if (char === ',' && depth === 0) {
-        if (current.trim()) {
-          params.push(current.trim());
-        }
-        current = '';
-      } else {
-        current += char;
-      }
-    }
-
-    if (current.trim()) {
-      params.push(current.trim());
-    }
-
-    return params;
+  /** Declaration parameters narrowed to the shape XppMethodInfo carries. */
+  private toParameterInfo(decl: XppDeclaration | null): XppParameterInfo[] {
+    return decl?.parameters.map(p => ({ type: p.type, name: p.name })) ?? [];
   }
 
   /**
@@ -629,14 +533,15 @@ export class XppMetadataParser {
     for (const methodNode of methodNodes) {
       const name = methodNode.Name || 'Unknown';
       const source = methodNode.Source || '';
+      const decl = parseXppDeclaration(source, name);
 
       // Parse method info (similar to class methods)
       const methodInfo: any = {
         name,
         visibility: 'public', // Forms typically have public methods
-        returnType: this.extractReturnType(source, name) || 'void',
-        parameters: this.extractParametersFromSource(source, name),
-        isStatic: this.isMethodStatic(source),
+        returnType: decl?.returnType || 'void',
+        parameters: this.toParameterInfo(decl),
+        isStatic: decl?.modifiers.includes('static') ?? false,
         source,
         sourceSnippet: source.split('\n').slice(0, 10).join('\n'),
       };

--- a/src/metadata/xppDeclaration.ts
+++ b/src/metadata/xppDeclaration.ts
@@ -1,0 +1,236 @@
+/**
+ * X++ method declaration parser.
+ *
+ * Shared by the signature tool (src/tools/methodSignature.ts) and the XML
+ * metadata parser (src/metadata/xmlParser.ts) — both used to carry their own
+ * regex-based extractor, and both got multi-line declarations wrong in
+ * different ways.
+ *
+ * X++ declarations routinely wrap the parameter list across several lines
+ * (every standard construct/new* pattern with defaulted params does), so the
+ * declaration is located by position and closed by balanced-paren scanning —
+ * never by assuming it fits on one line, and never by stopping at the first
+ * ')' (which sits inside defaults like `= classStr(FormletterService)`).
+ *
+ * A parse that cannot be trusted returns null so callers fall through to their
+ * own fallbacks, rather than emitting a confidently wrong signature.
+ */
+
+export interface XppDeclaration {
+  modifiers: string[];
+  returnType: string;
+  parameters: XppDeclarationParameter[];
+}
+
+export interface XppDeclarationParameter {
+  type: string;
+  name: string;
+  defaultValue?: string;
+}
+
+export const MODIFIER_KEYWORDS = [
+  'public', 'private', 'protected', 'internal', 'static', 'final', 'abstract', 'display', 'edit',
+];
+
+/**
+ * Keywords that can legally sit directly before `name(` in an expression
+ * (`return foo();`, `if (foo())`). A declaration's return type is never one of
+ * them, so seeing one means we matched a call.
+ */
+const STATEMENT_KEYWORDS = [
+  'return', 'if', 'while', 'for', 'switch', 'throw', 'else', 'do', 'new',
+];
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Produce a same-length copy of X++ source where comment content and
+ * string-literal content are blanked out with spaces (newlines preserved, so
+ * line structure and every index map 1:1 to the original).
+ *
+ * Declaration search, paren balancing and modifier detection all run on this
+ * copy, so they can't be fooled by a method name or keyword mentioned in a
+ * comment/attribute string, or by parens/commas inside string defaults.
+ */
+export function blankCommentsAndStrings(src: string): string {
+  const out = src.split('');
+  let state: 'code' | 'line' | 'block' | 'str' = 'code';
+  let quote = '';
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (state === 'code') {
+      if (c === '/' && d === '/') { state = 'line'; out[i] = out[i + 1] = ' '; i++; }
+      else if (c === '/' && d === '*') { state = 'block'; out[i] = out[i + 1] = ' '; i++; }
+      else if (c === "'" || c === '"') { state = 'str'; quote = c; }
+    } else if (state === 'line') {
+      if (c === '\n') state = 'code';
+      else out[i] = ' ';
+    } else if (state === 'block') {
+      if (c === '*' && d === '/') { state = 'code'; out[i] = out[i + 1] = ' '; i++; }
+      else if (c !== '\n') out[i] = ' ';
+    } else {
+      // Inside a string. Escapes are consumed as a pair so `\'` can't end it —
+      // but never swallow a newline, which would break the 1:1 line mapping.
+      if (c === '\\') { out[i] = ' '; if (d !== undefined && d !== '\n') { out[i + 1] = ' '; i++; } }
+      else if (c === quote) state = 'code';
+      else if (c !== '\n') out[i] = ' ';
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * Split a parameter list on top-level commas only — commas nested inside
+ * parens (intrinsic defaults like methodStr(A, b)) or brackets (container
+ * literals) belong to the parameter, not the list. `blanked` is the
+ * comment/string-blanked twin of `paramSrc` used for structural decisions;
+ * slices are taken from the original so default values stay verbatim.
+ */
+function splitTopLevelParams(paramSrc: string, blanked: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < blanked.length; i++) {
+    const c = blanked[i];
+    if (c === '(' || c === '[') depth++;
+    else if (c === ')' || c === ']') depth--;
+    else if (c === ',' && depth === 0) {
+      parts.push(paramSrc.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(paramSrc.slice(start));
+  return parts;
+}
+
+/** `SalesTable`, `Microsoft.Dynamics.Foo`, or the length in `str 30 _name`. */
+function isTypeToken(t: string): boolean {
+  return /^[A-Za-z_][\w.]*$/.test(t) || /^\d+$/.test(t);
+}
+
+function isNameToken(t: string): boolean {
+  return /^[A-Za-z_]\w*$/.test(t);
+}
+
+/**
+ * Parse one "Type _name [= default]" parameter; null when it doesn't look like
+ * a declared parameter (which is how a call's arguments are told apart from a
+ * declaration's parameter list).
+ */
+function parseParameter(raw: string, blanked: string): XppDeclarationParameter | null {
+  // Split off the default at the first top-level '='
+  let eq = -1;
+  let depth = 0;
+  for (let i = 0; i < blanked.length; i++) {
+    const c = blanked[i];
+    if (c === '(' || c === '[') depth++;
+    else if (c === ')' || c === ']') depth--;
+    else if (c === '=' && depth === 0) { eq = i; break; }
+  }
+  const left = (eq >= 0 ? raw.slice(0, eq) : raw).trim().replace(/\s+/g, ' ');
+  const defaultValue = eq >= 0 ? raw.slice(eq + 1).trim().replace(/\s+/g, ' ') : undefined;
+
+  const tokens = left.split(' ').filter(Boolean);
+  if (tokens.length < 2) return null;
+  const name = tokens[tokens.length - 1];
+  const typeTokens = tokens.slice(0, -1);
+  if (!isNameToken(name) || !typeTokens.every(isTypeToken)) return null;
+  if (eq >= 0 && !defaultValue) return null;
+
+  const type = typeTokens.join(' ');
+  return defaultValue ? { type, name, defaultValue } : { type, name };
+}
+
+/**
+ * Try to read a declaration whose name starts at `nameStart`. Returns null when
+ * this occurrence is a call rather than a declaration, or is malformed.
+ */
+function tryDeclarationAt(source: string, blanked: string, nameStart: number): XppDeclaration | null {
+  const openParen = blanked.indexOf('(', nameStart);
+  if (openParen < 0) return null;
+
+  // Balanced scan (on the blanked copy) to the closing paren, across lines.
+  let depth = 0;
+  let closeParen = -1;
+  for (let i = openParen; i < blanked.length; i++) {
+    const c = blanked[i];
+    if (c === '(') depth++;
+    else if (c === ')') {
+      depth--;
+      if (depth === 0) { closeParen = i; break; }
+    }
+  }
+  if (closeParen < 0) return null;
+
+  // A declaration is followed by its body, or by ';' for abstract/interface
+  // methods. An expression call (`if (foo())`, `foo() + 1`) is not. Nothing
+  // following at all means the source is the bare declaration, which is fine.
+  const after = /^\s*(\S)/.exec(blanked.slice(closeParen + 1));
+  if (after && after[1] !== '{' && after[1] !== ';') return null;
+
+  // Modifiers and return type live on the declaration line, before the name.
+  // Sliced from the blanked twin so a same-line comment or attribute string
+  // can't inject a keyword (`/* static */ public void foo()`).
+  const lineStart = blanked.lastIndexOf('\n', nameStart) + 1;
+  const prefix = blanked.slice(lineStart, nameStart);
+
+  // A declaration's prefix is `[attributes] [modifiers] ReturnType`; an '='
+  // means we matched the right-hand side of an assignment (`x = foo();`).
+  if (prefix.includes('=')) return null;
+
+  const modifiers = MODIFIER_KEYWORDS.filter(k => new RegExp(`\\b${k}\\b`, 'i').test(prefix));
+
+  // Return type: last identifier in the prefix that isn't a modifier keyword.
+  const prefixTokens = prefix.match(/[\w.]+/g) ?? [];
+  const typeTokens = prefixTokens.filter(t => !MODIFIER_KEYWORDS.includes(t.toLowerCase()));
+  const returnType = typeTokens[typeTokens.length - 1];
+  // Every X++ method declares a return type before its name. Without one this
+  // is a bare call (`construct(1);`), not a declaration.
+  if (!returnType || STATEMENT_KEYWORDS.includes(returnType.toLowerCase())) return null;
+
+  // Parameters: original text between the balanced parens (defaults verbatim).
+  const paramSrc = source.slice(openParen + 1, closeParen);
+  const paramBlanked = blanked.slice(openParen + 1, closeParen);
+  const parameters: XppDeclarationParameter[] = [];
+  if (paramBlanked.trim()) {
+    const rawParts = splitTopLevelParams(paramSrc, paramBlanked);
+    const blankedParts = splitTopLevelParams(paramBlanked, paramBlanked);
+    for (let i = 0; i < rawParts.length; i++) {
+      const param = parseParameter(rawParts[i], blankedParts[i]);
+      // All-or-nothing: emitting a partial list would produce a signature and a
+      // CoC `next()` call with the wrong arity — the exact failure this parser
+      // exists to prevent. A list we can't fully read means this isn't a
+      // declaration (or is malformed), so let the caller fall back.
+      if (!param) return null;
+      parameters.push(param);
+    }
+  }
+
+  return { modifiers, returnType, parameters };
+}
+
+/**
+ * Locate and parse the declaration of `methodName` in X++ source.
+ * Returns null when no trustworthy declaration is found.
+ */
+export function parseXppDeclaration(source: string, methodName: string): XppDeclaration | null {
+  if (!source || !methodName) return null;
+
+  const blanked = blankCommentsAndStrings(source);
+
+  // Candidate occurrences: the method name not preceded by a word char, '.' or
+  // ':' (which would make it a call like `this.name(` / `Owner::name(`),
+  // followed by '('. Comments and string contents are blanked, so an attribute
+  // like [SysObsolete('use construct() instead')] can't match. Occurrences are
+  // tried in order and the first one that validates as a declaration wins, so a
+  // call appearing before the declaration can't shadow it.
+  const nameRe = new RegExp(`(^|[^\\w.:])(${escapeRegExp(methodName)})\\s*\\(`, 'gi');
+  for (const m of blanked.matchAll(nameRe)) {
+    const decl = tryDeclarationAt(source, blanked, m.index + m[1].length);
+    if (decl) return decl;
+  }
+  return null;
+}

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -13,6 +13,7 @@ import type { XppServerContext } from '../types/context.js';
 import { buildObjectTypeMismatchMessage } from '../utils/metadataResolver.js';
 import type { BridgeClient } from '../bridge/bridgeClient.js';
 import type { XppMetadataParser } from '../metadata/xmlParser.js';
+import { parseXppDeclaration } from '../metadata/xppDeclaration.js';
 
 
 const GetMethodSignatureArgsSchema = z.object({
@@ -252,168 +253,26 @@ function parseByObjectType(
   }
 }
 
-const MODIFIER_KEYWORDS = [
-  'public', 'private', 'protected', 'internal', 'static', 'final', 'abstract', 'display', 'edit',
-];
-
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
- * Produce a same-length copy of X++ source where comment content and
- * string-literal content are blanked out with spaces (newlines preserved).
- * Declaration search and paren balancing run on this copy so they can't be
- * fooled by a method name mentioned in a comment/attribute string, or by
- * parens/commas inside string defaults. Indexes map 1:1 to the original.
- */
-function blankCommentsAndStrings(src: string): string {
-  const out = src.split('');
-  let state: 'code' | 'line' | 'block' | 'str' = 'code';
-  let quote = '';
-  for (let i = 0; i < src.length; i++) {
-    const c = src[i];
-    const d = src[i + 1];
-    if (state === 'code') {
-      if (c === '/' && d === '/') { state = 'line'; out[i] = out[i + 1] = ' '; i++; }
-      else if (c === '/' && d === '*') { state = 'block'; out[i] = out[i + 1] = ' '; i++; }
-      else if (c === "'" || c === '"') { state = 'str'; quote = c; }
-    } else if (state === 'line') {
-      if (c === '\n') state = 'code';
-      else out[i] = ' ';
-    } else if (state === 'block') {
-      if (c === '*' && d === '/') { state = 'code'; out[i] = out[i + 1] = ' '; i++; }
-      else if (c !== '\n') out[i] = ' ';
-    } else {
-      if (c === '\\') { out[i] = ' '; if (d !== undefined) { out[i + 1] = ' '; i++; } }
-      else if (c === quote) state = 'code';
-      else if (c !== '\n') out[i] = ' ';
-    }
-  }
-  return out.join('');
-}
-
-/**
- * Split a parameter list on top-level commas only — commas nested inside
- * parens (intrinsic defaults like methodStr(A, b)) or brackets (container
- * literals) belong to the parameter, not the list. `blanked` is the
- * comment/string-blanked twin of `paramSrc` used for structural decisions;
- * slices are taken from the original so default values stay verbatim.
- */
-function splitTopLevelParams(paramSrc: string, blanked: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let start = 0;
-  for (let i = 0; i < blanked.length; i++) {
-    const c = blanked[i];
-    if (c === '(' || c === '[') depth++;
-    else if (c === ')' || c === ']') depth--;
-    else if (c === ',' && depth === 0) {
-      parts.push(paramSrc.slice(start, i));
-      start = i + 1;
-    }
-  }
-  parts.push(paramSrc.slice(start));
-  return parts;
-}
-
-/** Parse one "Type _name [= default]" parameter; null when malformed. */
-function parseParameter(
-  raw: string,
-  blanked: string,
-): { type: string; name: string; defaultValue?: string } | null {
-  // Split off the default at the first top-level '='
-  let eq = -1;
-  let depth = 0;
-  for (let i = 0; i < blanked.length; i++) {
-    const c = blanked[i];
-    if (c === '(' || c === '[') depth++;
-    else if (c === ')' || c === ']') depth--;
-    else if (c === '=' && depth === 0) { eq = i; break; }
-  }
-  const left = (eq >= 0 ? raw.slice(0, eq) : raw).trim().replace(/\s+/g, ' ');
-  const defaultValue = eq >= 0 ? raw.slice(eq + 1).trim().replace(/\s+/g, ' ') : undefined;
-
-  const tokens = left.split(' ');
-  if (tokens.length < 2) return null;
-  const name = tokens[tokens.length - 1];
-  const type = tokens.slice(0, -1).join(' ');
-  return defaultValue ? { type, name, defaultValue } : { type, name };
-}
-
 /**
  * Parse method signature from source code.
  *
- * X++ declarations routinely wrap the parameter list across several lines
- * (every standard construct/new* pattern with defaulted params does), so the
- * declaration is located by position and closed by balanced-paren scanning —
- * never by assuming it fits on one line. Exported for unit tests.
+ * The declaration parsing itself lives in ../metadata/xppDeclaration.js and is
+ * shared with the XML metadata parser; this only turns a parsed declaration
+ * into the rendered signature and CoC template. Exported for unit tests.
  */
 export function parseMethodSignature(source: string, methodName: string): MethodSignature | null {
-  if (!source) return null;
+  const decl = parseXppDeclaration(source, methodName);
+  if (!decl) return null;
 
-  const blanked = blankCommentsAndStrings(source);
-
-  // Locate the declaration: the method name not preceded by a word char or
-  // '.' (which would make it a call like `this.name(` / `Owner::name(`),
-  // followed by '('. Comments and string contents are blanked, so an
-  // attribute like [SysObsolete('use construct() instead')] can't match.
-  const nameRe = new RegExp(`(^|[^\\w.:])(${escapeRegExp(methodName)})\\s*\\(`, 'i');
-  const m = nameRe.exec(blanked);
-  if (!m) return null;
-  const nameStart = m.index + m[1].length;
-  const openParen = blanked.indexOf('(', nameStart);
-
-  // Balanced scan (on the blanked copy) to the closing paren, across lines.
-  let depth = 0;
-  let closeParen = -1;
-  for (let i = openParen; i < blanked.length; i++) {
-    const c = blanked[i];
-    if (c === '(') depth++;
-    else if (c === ')') {
-      depth--;
-      if (depth === 0) { closeParen = i; break; }
-    }
-  }
-  if (closeParen < 0) return null;
-
-  // Modifiers and return type live on the declaration line, before the name.
-  const lineStart = source.lastIndexOf('\n', nameStart) + 1;
-  const prefix = source.slice(lineStart, nameStart);
-
-  const modifiers = MODIFIER_KEYWORDS.filter(k => new RegExp(`\\b${k}\\b`, 'i').test(prefix));
-
-  // Return type: last identifier in the prefix that isn't a modifier keyword.
-  const prefixTokens = prefix.match(/[\w.]+/g) ?? [];
-  const typeTokens = prefixTokens.filter(t => !MODIFIER_KEYWORDS.includes(t.toLowerCase()));
-  const returnType = typeTokens.length > 0 ? typeTokens[typeTokens.length - 1] : 'void';
-
-  // Parameters: original text between the balanced parens (defaults verbatim).
-  const paramSrc = source.slice(openParen + 1, closeParen);
-  const paramBlanked = blanked.slice(openParen + 1, closeParen);
-  const parameters: Array<{ type: string; name: string; defaultValue?: string }> = [];
-  if (paramBlanked.trim()) {
-    const rawParts = splitTopLevelParams(paramSrc, paramBlanked);
-    const blankedParts = splitTopLevelParams(paramBlanked, paramBlanked);
-    for (let i = 0; i < rawParts.length; i++) {
-      const param = parseParameter(rawParts[i], blankedParts[i]);
-      if (param) parameters.push(param);
-    }
-  }
-
-  // Build full signature
-  const signature = buildSignatureString(modifiers, returnType, methodName, parameters);
-
-  // Build CoC template
-  const cocTemplate = buildCoCTemplate(modifiers, returnType, methodName, parameters);
+  const { modifiers, returnType, parameters } = decl;
 
   return {
     modifiers,
     returnType,
     methodName,
     parameters,
-    signature,
-    cocTemplate,
+    signature: buildSignatureString(modifiers, returnType, methodName, parameters),
+    cocTemplate: buildCoCTemplate(modifiers, returnType, methodName, parameters),
   };
 }
 

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -252,67 +252,152 @@ function parseByObjectType(
   }
 }
 
+const MODIFIER_KEYWORDS = [
+  'public', 'private', 'protected', 'internal', 'static', 'final', 'abstract', 'display', 'edit',
+];
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
- * Parse method signature from source code
+ * Produce a same-length copy of X++ source where comment content and
+ * string-literal content are blanked out with spaces (newlines preserved).
+ * Declaration search and paren balancing run on this copy so they can't be
+ * fooled by a method name mentioned in a comment/attribute string, or by
+ * parens/commas inside string defaults. Indexes map 1:1 to the original.
  */
-function parseMethodSignature(source: string, methodName: string): MethodSignature | null {
+function blankCommentsAndStrings(src: string): string {
+  const out = src.split('');
+  let state: 'code' | 'line' | 'block' | 'str' = 'code';
+  let quote = '';
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (state === 'code') {
+      if (c === '/' && d === '/') { state = 'line'; out[i] = out[i + 1] = ' '; i++; }
+      else if (c === '/' && d === '*') { state = 'block'; out[i] = out[i + 1] = ' '; i++; }
+      else if (c === "'" || c === '"') { state = 'str'; quote = c; }
+    } else if (state === 'line') {
+      if (c === '\n') state = 'code';
+      else out[i] = ' ';
+    } else if (state === 'block') {
+      if (c === '*' && d === '/') { state = 'code'; out[i] = out[i + 1] = ' '; i++; }
+      else if (c !== '\n') out[i] = ' ';
+    } else {
+      if (c === '\\') { out[i] = ' '; if (d !== undefined) { out[i + 1] = ' '; i++; } }
+      else if (c === quote) state = 'code';
+      else if (c !== '\n') out[i] = ' ';
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * Split a parameter list on top-level commas only — commas nested inside
+ * parens (intrinsic defaults like methodStr(A, b)) or brackets (container
+ * literals) belong to the parameter, not the list. `blanked` is the
+ * comment/string-blanked twin of `paramSrc` used for structural decisions;
+ * slices are taken from the original so default values stay verbatim.
+ */
+function splitTopLevelParams(paramSrc: string, blanked: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < blanked.length; i++) {
+    const c = blanked[i];
+    if (c === '(' || c === '[') depth++;
+    else if (c === ')' || c === ']') depth--;
+    else if (c === ',' && depth === 0) {
+      parts.push(paramSrc.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(paramSrc.slice(start));
+  return parts;
+}
+
+/** Parse one "Type _name [= default]" parameter; null when malformed. */
+function parseParameter(
+  raw: string,
+  blanked: string,
+): { type: string; name: string; defaultValue?: string } | null {
+  // Split off the default at the first top-level '='
+  let eq = -1;
+  let depth = 0;
+  for (let i = 0; i < blanked.length; i++) {
+    const c = blanked[i];
+    if (c === '(' || c === '[') depth++;
+    else if (c === ')' || c === ']') depth--;
+    else if (c === '=' && depth === 0) { eq = i; break; }
+  }
+  const left = (eq >= 0 ? raw.slice(0, eq) : raw).trim().replace(/\s+/g, ' ');
+  const defaultValue = eq >= 0 ? raw.slice(eq + 1).trim().replace(/\s+/g, ' ') : undefined;
+
+  const tokens = left.split(' ');
+  if (tokens.length < 2) return null;
+  const name = tokens[tokens.length - 1];
+  const type = tokens.slice(0, -1).join(' ');
+  return defaultValue ? { type, name, defaultValue } : { type, name };
+}
+
+/**
+ * Parse method signature from source code.
+ *
+ * X++ declarations routinely wrap the parameter list across several lines
+ * (every standard construct/new* pattern with defaulted params does), so the
+ * declaration is located by position and closed by balanced-paren scanning —
+ * never by assuming it fits on one line. Exported for unit tests.
+ */
+export function parseMethodSignature(source: string, methodName: string): MethodSignature | null {
   if (!source) return null;
 
-  // Find method declaration line
-  const lines = source.split('\n');
-  let declarationLine = '';
+  const blanked = blankCommentsAndStrings(source);
 
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed.includes(methodName) && trimmed.includes('(')) {
-      declarationLine = trimmed;
-      break;
+  // Locate the declaration: the method name not preceded by a word char or
+  // '.' (which would make it a call like `this.name(` / `Owner::name(`),
+  // followed by '('. Comments and string contents are blanked, so an
+  // attribute like [SysObsolete('use construct() instead')] can't match.
+  const nameRe = new RegExp(`(^|[^\\w.:])(${escapeRegExp(methodName)})\\s*\\(`, 'i');
+  const m = nameRe.exec(blanked);
+  if (!m) return null;
+  const nameStart = m.index + m[1].length;
+  const openParen = blanked.indexOf('(', nameStart);
+
+  // Balanced scan (on the blanked copy) to the closing paren, across lines.
+  let depth = 0;
+  let closeParen = -1;
+  for (let i = openParen; i < blanked.length; i++) {
+    const c = blanked[i];
+    if (c === '(') depth++;
+    else if (c === ')') {
+      depth--;
+      if (depth === 0) { closeParen = i; break; }
     }
   }
+  if (closeParen < 0) return null;
 
-  if (!declarationLine) return null;
+  // Modifiers and return type live on the declaration line, before the name.
+  const lineStart = source.lastIndexOf('\n', nameStart) + 1;
+  const prefix = source.slice(lineStart, nameStart);
 
-  // Parse modifiers (public, private, protected, static, final, etc.)
-  const modifiers: string[] = [];
-  const modifierKeywords = ['public', 'private', 'protected', 'static', 'final', 'abstract', 'display'];
-  
-  for (const keyword of modifierKeywords) {
-    if (declarationLine.toLowerCase().includes(keyword)) {
-      modifiers.push(keyword);
-    }
-  }
+  const modifiers = MODIFIER_KEYWORDS.filter(k => new RegExp(`\\b${k}\\b`, 'i').test(prefix));
 
-  // Parse return type
-  let returnType = 'void';
-  const returnTypeMatch = declarationLine.match(/(?:public|private|protected|static|final)?\s+(\w+)\s+\w+\s*\(/);
-  if (returnTypeMatch) {
-    returnType = returnTypeMatch[1];
-  }
+  // Return type: last identifier in the prefix that isn't a modifier keyword.
+  const prefixTokens = prefix.match(/[\w.]+/g) ?? [];
+  const typeTokens = prefixTokens.filter(t => !MODIFIER_KEYWORDS.includes(t.toLowerCase()));
+  const returnType = typeTokens.length > 0 ? typeTokens[typeTokens.length - 1] : 'void';
 
-  // Parse parameters
-  const parametersMatch = declarationLine.match(/\((.*?)\)/);
+  // Parameters: original text between the balanced parens (defaults verbatim).
+  const paramSrc = source.slice(openParen + 1, closeParen);
+  const paramBlanked = blanked.slice(openParen + 1, closeParen);
   const parameters: Array<{ type: string; name: string; defaultValue?: string }> = [];
-
-  if (parametersMatch && parametersMatch[1].trim()) {
-    const paramString = parametersMatch[1];
-    const paramParts = paramString.split(',');
-
-    for (const part of paramParts) {
-      const trimmed = part.trim();
-      const paramMatch = trimmed.match(/(\w+)\s+(_?\w+)(?:\s*=\s*(.+))?/);
-      
-      if (paramMatch) {
-        const param: any = {
-          type: paramMatch[1],
-          name: paramMatch[2],
-        };
-        
-        if (paramMatch[3]) {
-          param.defaultValue = paramMatch[3].trim();
-        }
-        
-        parameters.push(param);
-      }
+  if (paramBlanked.trim()) {
+    const rawParts = splitTopLevelParams(paramSrc, paramBlanked);
+    const blankedParts = splitTopLevelParams(paramBlanked, paramBlanked);
+    for (let i = 0; i < rawParts.length; i++) {
+      const param = parseParameter(rawParts[i], blankedParts[i]);
+      if (param) parameters.push(param);
     }
   }
 
@@ -374,8 +459,8 @@ function buildCoCTemplate(
 ): string {
   let template = '';
 
-  // Add modifiers (replace public/private/protected with method attribute)
-  const cocModifiers = modifiers.filter(m => !['public', 'private', 'protected'].includes(m));
+  // Add modifiers (replace access modifiers with method attribute)
+  const cocModifiers = modifiers.filter(m => !['public', 'private', 'protected', 'internal'].includes(m));
   
   template += '[ExtensionOf(classStr(OriginalClassName))]\n';
   template += 'final class OriginalClassName_Extension\n';

--- a/tests/metadata/xmlParser-method-params.test.ts
+++ b/tests/metadata/xmlParser-method-params.test.ts
@@ -1,0 +1,92 @@
+/**
+ * XppMetadataParser method-declaration extraction.
+ *
+ * Regression: the parser's own regex extractors stopped at the first ')' —
+ * `\b<name>\s*\(([^)]*)\)` — so any declaration with a defaulted parameter
+ * (`= classStr(FormletterService)`) was truncated mid-parameter and surfaced
+ * as garbage through get_object_info's class rendering. `static` was likewise
+ * matched anywhere in the method body. Both now go through the shared
+ * declaration parser (src/metadata/xppDeclaration.ts).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppMetadataParser } from '../../src/metadata/xmlParser';
+
+let tmpDir: string;
+
+const writeClass = async (name: string, methods: Array<{ name: string; source: string }>) => {
+  const methodXml = methods
+    .map(m => `      <Method>\n        <Name>${m.name}</Name>\n        <Source><![CDATA[${m.source}]]></Source>\n      </Method>`)
+    .join('\n');
+  const xml = [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">',
+    `  <Name>${name}</Name>`,
+    '  <SourceCode>',
+    '    <Methods>',
+    methodXml,
+    '    </Methods>',
+    '  </SourceCode>',
+    '</AxClass>',
+  ].join('\n');
+  const file = path.join(tmpDir, `${name}.xml`);
+  await fs.writeFile(file, xml, 'utf-8');
+  return file;
+};
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xmlparser-params-test-'));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('XppMetadataParser method declarations', () => {
+  it('keeps every parameter of a multi-line declaration with intrinsic defaults', async () => {
+    const source = [
+      'public static PurchFormLetter_Invoice construct(',
+      '    IdentifierName _className = classStr(FormletterService),',
+      '    IdentifierName _methodName = methodStr(FormletterService, postPurchaseOrderInvoice),',
+      '    SysOperationExecutionMode _executionMode = SysOperationExecutionMode::Synchronous)',
+      '{',
+      '    return new PurchFormLetter_Invoice(_className, _methodName, _executionMode);',
+      '}',
+    ].join('\n');
+    const file = await writeClass('PurchFormLetter_Invoice', [{ name: 'construct', source }]);
+
+    const result = await new XppMetadataParser().parseClassFile(file, 'TestModel');
+
+    expect(result.success).toBe(true);
+    const method = result.data!.methods.find(m => m.name === 'construct')!;
+    expect(method.returnType).toBe('PurchFormLetter_Invoice');
+    expect(method.isStatic).toBe(true);
+    expect(method.parameters).toEqual([
+      { type: 'IdentifierName', name: '_className' },
+      { type: 'IdentifierName', name: '_methodName' },
+      { type: 'SysOperationExecutionMode', name: '_executionMode' },
+    ]);
+  });
+
+  it('does not report a method as static because its body mentions static', async () => {
+    const source = [
+      'public void run()',
+      '{',
+      '    // the static factory is preferred here',
+      '    info("static");',
+      '}',
+    ].join('\n');
+    const file = await writeClass('RunnerClass', [{ name: 'run', source }]);
+
+    const result = await new XppMetadataParser().parseClassFile(file, 'TestModel');
+
+    expect(result.success).toBe(true);
+    const method = result.data!.methods.find(m => m.name === 'run')!;
+    expect(method.isStatic).toBe(false);
+    expect(method.returnType).toBe('void');
+    expect(method.parameters).toEqual([]);
+  });
+});

--- a/tests/tools/method-signature-parse.test.ts
+++ b/tests/tools/method-signature-parse.test.ts
@@ -1,0 +1,127 @@
+/**
+ * parseMethodSignature tests — the X++ declaration parser behind
+ * get_method(include="signature"/"both") and the CoC template.
+ *
+ * Key regression: X++ declarations routinely wrap the parameter list across
+ * several lines (every standard construct/new* pattern with defaulted params
+ * does). The old single-line parser silently returned zero parameters for
+ * those, producing a wrong signature and a CoC template that cannot compile.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseMethodSignature } from '../../src/tools/methodSignature';
+
+describe('parseMethodSignature', () => {
+  it('parses a simple single-line declaration (baseline)', () => {
+    const src = 'public void run()\n{\n    info("Hello");\n}';
+    const sig = parseMethodSignature(src, 'run');
+    expect(sig).not.toBeNull();
+    expect(sig!.modifiers).toEqual(['public']);
+    expect(sig!.returnType).toBe('void');
+    expect(sig!.parameters).toEqual([]);
+    expect(sig!.signature).toBe('public void run()');
+  });
+
+  it('parses a multi-line declaration with defaulted parameters (PurchFormLetter_Invoice.construct shape)', () => {
+    const src = [
+      '    public static PurchFormLetter_Invoice construct(',
+      '        IdentifierName _className = classStr(FormletterService),',
+      '        IdentifierName _methodName = methodStr(FormletterService, postPurchaseOrderInvoice),',
+      '        SysOperationExecutionMode _executionMode = SysOperationExecutionMode::Synchronous)',
+      '    {',
+      '        return new PurchFormLetter_Invoice(_className, _methodName, _executionMode);',
+      '    }',
+    ].join('\n');
+    const sig = parseMethodSignature(src, 'construct');
+    expect(sig).not.toBeNull();
+    expect(sig!.modifiers).toEqual(['public', 'static']);
+    expect(sig!.returnType).toBe('PurchFormLetter_Invoice');
+    expect(sig!.parameters).toEqual([
+      { type: 'IdentifierName', name: '_className', defaultValue: 'classStr(FormletterService)' },
+      { type: 'IdentifierName', name: '_methodName', defaultValue: 'methodStr(FormletterService, postPurchaseOrderInvoice)' },
+      { type: 'SysOperationExecutionMode', name: '_executionMode', defaultValue: 'SysOperationExecutionMode::Synchronous' },
+    ]);
+    // CoC next() call must forward every parameter
+    expect(sig!.cocTemplate).toContain('next construct(_className, _methodName, _executionMode);');
+  });
+
+  it('does not truncate at a nested closing paren inside a default value', () => {
+    const src = 'public static void post(IdentifierName _className = classStr(FormletterService), boolean _late = false)\n{\n}';
+    const sig = parseMethodSignature(src, 'post');
+    expect(sig).not.toBeNull();
+    expect(sig!.parameters).toEqual([
+      { type: 'IdentifierName', name: '_className', defaultValue: 'classStr(FormletterService)' },
+      { type: 'boolean', name: '_late', defaultValue: 'false' },
+    ]);
+  });
+
+  it('does not split on commas nested inside defaults (intrinsics, container literals)', () => {
+    const src = "void doIt(IdentifierName _m = methodStr(FormletterService, postPurchaseOrderInvoice), container _c = ['a', 'b'])\n{\n}";
+    const sig = parseMethodSignature(src, 'doIt');
+    expect(sig).not.toBeNull();
+    expect(sig!.parameters).toHaveLength(2);
+    expect(sig!.parameters[0].defaultValue).toBe('methodStr(FormletterService, postPurchaseOrderInvoice)');
+    expect(sig!.parameters[1]).toEqual({ type: 'container', name: '_c', defaultValue: "['a', 'b']" });
+  });
+
+  it('matches modifiers as whole words only', () => {
+    const sig = parseMethodSignature('public void finalizeOrder()\n{\n}', 'finalizeOrder');
+    expect(sig).not.toBeNull();
+    expect(sig!.modifiers).toEqual(['public']); // not phantom 'final'
+
+    const sig2 = parseMethodSignature('display Amount amountDisplayed()\n{\n}', 'amountDisplayed');
+    expect(sig2).not.toBeNull();
+    expect(sig2!.modifiers).toEqual(['display']);
+    expect(sig2!.returnType).toBe('Amount');
+  });
+
+  it('recognizes internal as an access modifier and keeps it out of the CoC template', () => {
+    const sig = parseMethodSignature('internal final void doWork()\n{\n}', 'doWork');
+    expect(sig).not.toBeNull();
+    expect(sig!.modifiers).toEqual(['internal', 'final']);
+    expect(sig!.returnType).toBe('void');
+    expect(sig!.cocTemplate).not.toContain('internal');
+  });
+
+  it('ignores the method name inside a preceding attribute string or comment', () => {
+    const src = [
+      "[SysObsolete('use construct() instead of newStandard()')]",
+      '// callers should prefer construct() here',
+      'public static MyClass construct(MyArgs _args)',
+      '{',
+      '}',
+    ].join('\n');
+    const sig = parseMethodSignature(src, 'construct');
+    expect(sig).not.toBeNull();
+    expect(sig!.returnType).toBe('MyClass');
+    expect(sig!.parameters).toEqual([{ type: 'MyArgs', name: '_args' }]);
+  });
+
+  it('does not mistake a call for the declaration', () => {
+    const src = [
+      'public void init(SalesTable _salesTable)',
+      '{',
+      '    this.update(_salesTable);',
+      '}',
+    ].join('\n');
+    // 'update' only appears as this.update( — a call, not a declaration on this class
+    const sig = parseMethodSignature(src, 'update');
+    expect(sig).toBeNull();
+  });
+
+  it('returns null for source without a matching declaration or with unbalanced parens', () => {
+    expect(parseMethodSignature('class Foo\n{\n    int x;\n}', 'classDeclaration')).toBeNull();
+    expect(parseMethodSignature('public void broken(int _a', 'broken')).toBeNull();
+    expect(parseMethodSignature('', 'anything')).toBeNull();
+  });
+
+  it('handles parens and commas inside string default values', () => {
+    const src = "void log(str _msg = 'a, b (c)', int _n = 1)\n{\n}";
+    const sig = parseMethodSignature(src, 'log');
+    expect(sig).not.toBeNull();
+    expect(sig!.parameters).toEqual([
+      { type: 'str', name: '_msg', defaultValue: "'a, b (c)'" },
+      { type: 'int', name: '_n', defaultValue: '1' },
+    ]);
+  });
+});

--- a/tests/tools/method-signature-parse.test.ts
+++ b/tests/tools/method-signature-parse.test.ts
@@ -124,4 +124,68 @@ describe('parseMethodSignature', () => {
       { type: 'int', name: '_n', defaultValue: '1' },
     ]);
   });
+
+  // Modifiers/return type are read from the comment- and string-blanked twin,
+  // not the raw line: a same-line comment or attribute must not inject a
+  // keyword. A phantom 'static' would land in the CoC template and not compile.
+  it('does not take modifiers from a same-line comment or attribute string', () => {
+    const sig = parseMethodSignature('/* static */ public void foo()\n{\n}', 'foo');
+    expect(sig).not.toBeNull();
+    expect(sig!.modifiers).toEqual(['public']);
+    expect(sig!.signature).toBe('public void foo()');
+
+    const sig2 = parseMethodSignature(
+      "[SysObsolete('use the static one')] public void foo()\n{\n}", 'foo');
+    expect(sig2).not.toBeNull();
+    expect(sig2!.modifiers).toEqual(['public']);
+    expect(sig2!.returnType).toBe('void');
+  });
+
+  it('parses an abstract/interface declaration terminated by a semicolon', () => {
+    const sig = parseMethodSignature('abstract public void doIt(int _a);', 'doIt');
+    expect(sig).not.toBeNull();
+    expect(sig!.modifiers).toEqual(['public', 'abstract']);
+    expect(sig!.parameters).toEqual([{ type: 'int', name: '_a' }]);
+  });
+
+  it('does not mistake an unqualified call for the declaration', () => {
+    // A bare call statement — arguments are values, not `Type _name` pairs.
+    expect(parseMethodSignature('public void bar()\n{\n    construct(1);\n}', 'construct')).toBeNull();
+    // Right-hand side of an assignment.
+    expect(parseMethodSignature('public void bar()\n{\n    x = construct();\n}', 'construct')).toBeNull();
+    // Inside a condition.
+    expect(parseMethodSignature('public void bar()\n{\n    if (construct())\n    {\n    }\n}', 'construct')).toBeNull();
+    // As a return expression.
+    expect(parseMethodSignature('public Foo bar()\n{\n    return construct();\n}', 'construct')).toBeNull();
+  });
+
+  it('finds the declaration even when a call to it appears first', () => {
+    const src = [
+      'public void caller()',
+      '{',
+      '    this.helper(1);',
+      '}',
+      '',
+      'public void helper(int _a)',
+      '{',
+      '}',
+    ].join('\n');
+    const sig = parseMethodSignature(src, 'helper');
+    expect(sig).not.toBeNull();
+    expect(sig!.parameters).toEqual([{ type: 'int', name: '_a' }]);
+  });
+
+  // A partial list would produce `next foo(_b)` for `foo(_a, _b)` — the same
+  // arity mismatch this parser exists to prevent. Fall through instead.
+  it('returns null rather than emitting a partially parsed parameter list', () => {
+    expect(parseMethodSignature('public void foo(int _a, )\n{\n}', 'foo')).toBeNull();
+    expect(parseMethodSignature('public void foo(_a, int _b)\n{\n}', 'foo')).toBeNull();
+  });
+
+  it('keeps the length of a sized str parameter with the type', () => {
+    const sig = parseMethodSignature('public void setName(str 30 _name)\n{\n}', 'setName');
+    expect(sig).not.toBeNull();
+    expect(sig!.parameters).toEqual([{ type: 'str 30', name: '_name' }]);
+    expect(sig!.cocTemplate).toContain('next setName(_name);');
+  });
 });


### PR DESCRIPTION
## Issue

`get_method(include="signature"/"both")` mis-parses any X++ method whose declaration wraps across multiple lines. `parseMethodSignature` located the declaration by scanning for a *single line* containing the method name and `(`, then extracted parameters with `/\((.*?)\)/` against that one line. When the parameter list continues on the next lines — which every standard `construct`/`new*` pattern with defaulted parameters does — the closing paren is never seen and **all parameters are silently dropped**:

```xpp
public static PurchFormLetter_Invoice construct(
    IdentifierName _className = classStr(FormletterService),
    IdentifierName _methodName = methodStr(FormletterService, postPurchaseOrderInvoice),
    SysOperationExecutionMode _executionMode = SysOperationExecutionMode::Synchronous)
```

parsed as `public static PurchFormLetter_Invoice construct()` with zero parameters, and the CoC template emitted `next construct();` — a guaranteed compile error. The bug hits even with the bridge running, because signature parsing always happens client-side on the source the bridge returns.

Same-function secondary defects: `\((.*?)\)` truncated at the *first* `)`, so even single-line declarations with `classStr(...)` defaults lost parameters; naive `split(',')` broke defaults like `methodStr(FormletterService, postPurchaseOrderInvoice)`; modifiers matched by substring (`finalizeOrder` gained a phantom `final`, `displayOption` gained `display`); and the line scan could lock onto an attribute/comment mentioning the method name, e.g. `[SysObsolete('use construct() instead')]`.

## Fix

Rewrote the declaration extraction in `src/tools/methodSignature.ts`:

- The source is first copied with comment content and string-literal content blanked (same length, indexes align), so declaration search and structural scanning can't be fooled by method names in comments/attribute strings or parens/commas inside string defaults.
- The declaration is located by position (method name not preceded by a word char, `.` or `:`, followed by `(`) and closed by **balanced-paren scanning across lines** — no single-line assumption.
- Parameters split on top-level commas only (nesting-aware for `()` and `[]`), keeping intrinsic defaults and container literals intact; each parses as `Type _name [= default]` with the default taken verbatim from the original source.
- Modifiers match as whole words against the declaration prefix; `internal` and `edit` are now recognized, and `internal` is filtered out of the CoC template together with the other access modifiers.
- Malformed declarations (unbalanced parens) return `null` and fall through to the existing XML/SQLite fallbacks instead of emitting a confidently wrong signature.

`parseMethodSignature` is now exported and covered by unit tests (`tests/tools/method-signature-parse.test.ts`), including the multi-line regression, nested-paren/comma defaults, whole-word modifiers, attribute-string decoys, and unbalanced input.
