### PR TITLE
fix: case-insensitive object-name lookup (#686)

### DIFF
--- a/src/tools/analyzeExtensionPoints.ts
+++ b/src/tools/analyzeExtensionPoints.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { getConfigManager } from '../utils/configManager.js';
 import { scanFsExtensions, EXTENSION_FOLDER_CONFIG } from '../utils/fsExtensionScanner.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 // Standard D365FO table events available for subscription
 const TABLE_STANDARD_EVENTS = [
@@ -31,7 +32,13 @@ export async function analyzeExtensionPointsTool(request: CallToolRequest, conte
   try {
     const args = AnalyzeExtensionPointsArgsSchema.parse(request.params.arguments);
     const rdb = context.symbolIndex.getReadDb();
-    const objName = args.objectName;
+    // Resolve the caller's casing to the canonical AOT name once (#686) — the
+    // method/datasource probes below are parent-scoped on this name.
+    const objName = canonicalSymbolName(
+      rdb,
+      args.objectName,
+      args.objectType === 'auto' ? ['class', 'table', 'form'] : [args.objectType],
+    ) ?? args.objectName;
 
     // Resolve object type
     let resolvedType = args.objectType;

--- a/src/tools/configKeyInfo.ts
+++ b/src/tools/configKeyInfo.ts
@@ -8,6 +8,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 const GetConfigKeyInfoArgsSchema = z.object({
   name: z.string().describe('Name of the AxConfigurationKey or AxLicenseCode (e.g. "AdvancedLedgerEntry")'),
@@ -15,8 +16,13 @@ const GetConfigKeyInfoArgsSchema = z.object({
 
 export async function getConfigKeyInfoTool(request: CallToolRequest, context: XppServerContext) {
   try {
-    const { name } = GetConfigKeyInfoArgsSchema.parse(request.params.arguments);
+    const args = GetConfigKeyInfoArgsSchema.parse(request.params.arguments);
     const db = context.symbolIndex.getReadDb();
+
+    // Resolve the caller's casing to the canonical AOT name once, against both
+    // types this tool accepts (#686). The parent-chain / children probes below
+    // walk DB-sourced names, which are already canonical.
+    const name = canonicalSymbolName(db, args.name, ['configuration-key', 'license-code']) ?? args.name;
 
     // Configuration key: signature holds the parent key name.
     const key = db.prepare(

--- a/src/tools/generateSmartReport.ts
+++ b/src/tools/generateSmartReport.ts
@@ -32,6 +32,7 @@ import { getConfigManager } from '../utils/configManager.js';
 import { resolveObjectPrefix, applyObjectPrefix, getObjectSuffix, applyObjectSuffix } from '../utils/modelClassifier.js';
 import { extractModelFromProject, findProjectInSolution } from '../utils/projectUtils.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
+import { canonicalSymbolName, lookupSymbolNocase } from '../utils/symbolLookup.js';
 
 interface ReportFieldSpec {
   /** Field name on the TmpTable (e.g. "ItemId", "Amount") */
@@ -352,11 +353,10 @@ export async function handleGenerateSmartReport(
       }
 
       if (!srcTmpTable) {
-        // Fallback: direct naming convention <ReportName>Tmp
-        const directTmp = db.prepare(
-          `SELECT name FROM symbols WHERE type = 'table' AND name = ? LIMIT 1`
-        ).get(`${copyFrom}Tmp`) as { name: string } | undefined;
-        srcTmpTable = directTmp?.name;
+        // Fallback: direct naming convention <ReportName>Tmp. Case-insensitive —
+        // copyFrom is caller-supplied, so the derived name may not match the
+        // canonical casing (#686).
+        srcTmpTable = lookupSymbolNocase(db, `${copyFrom}Tmp`, ['table'])?.name;
       }
 
       if (srcTmpTable) {
@@ -1398,8 +1398,12 @@ function resolveFieldType(edtName: string | undefined, db: any): string | undefi
  * table reference — instead of the generic `getNo(1)` / `Common` pattern.
  * Returns undefined when the query is not in the index (non-Windows, or unknown query).
  */
-function resolveAotQueryFirstTable(queryName: string, db: any): string | undefined {
+function resolveAotQueryFirstTable(requestedQueryName: string, db: any): string | undefined {
   try {
+    // Resolve the caller's casing to the canonical AOT name once (#686), so the
+    // parent-scoped probe below stays BINARY and on-index.
+    const queryName = canonicalSymbolName(db, requestedQueryName, ['query']) ?? requestedQueryName;
+
     // Strategy 1: explicit query_datasource symbols (parent_name = query name)
     const ds = db.prepare(
       `SELECT name FROM symbols

--- a/src/tools/getMethodSource.ts
+++ b/src/tools/getMethodSource.ts
@@ -11,16 +11,29 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import type { XppMetadataParser } from '../metadata/xmlParser.js';
 import { tryBridgeMethodSource } from '../bridge/bridgeAdapter.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 const GetMethodSourceArgsSchema = z.object({
   className: z.string().describe('Name of the class containing the method'),
   methodName: z.string().describe('Name of the method'),
 });
 
+/** Object types that can own methods. */
+const OBJECT_TYPES = ['class', 'table', 'view', 'data-entity'] as const;
+const OBJECT_TYPES_SQL = `(${OBJECT_TYPES.map(t => `'${t}'`).join(', ')})`;
+
 export async function getMethodSourceTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = GetMethodSourceArgsSchema.parse(request.params.arguments);
-    const { className, methodName } = args;
+    const { methodName } = args;
+
+    // Resolve the caller's casing to the canonical AOT name once, up front.
+    // X++ treats AOT identifiers case-insensitively but the index stores the
+    // canonical name, and every lookup below (bridge included) matches by exact
+    // name — so a casing mismatch would otherwise miss all three layers and
+    // report a false "not found" (#686, e.g. WhsrfControlData → WHSRFControlData,
+    // whose own filename disagrees with its AOT name).
+    const className = resolveClassName(context, args.className);
 
     // C# bridge (IMetadataProvider — live D365FO metadata, always available)
     const bridgeResult = await tryBridgeMethodSource(context.bridge, className, methodName);
@@ -72,6 +85,25 @@ export async function getMethodSourceTool(request: CallToolRequest, context: Xpp
 }
 
 /**
+ * Canonical (as-indexed) casing for a method owner, falling back to the name as
+ * given when the index has no match or is unavailable — an unresolved name still
+ * flows through to the normal "not found" path.
+ *
+ * Index-safe by construction: `canonicalSymbolName` probes exact case on
+ * idx_name_type first and only falls back to FTS. Matching with
+ * `name = ? COLLATE NOCASE` here instead would drop to a scan of every
+ * class/table/view row (~86k rows, 4–8 s warm) and the parent_name hint query
+ * below would cost ~48 s — past the MCP client timeout. See src/utils/symbolLookup.ts.
+ */
+function resolveClassName(context: XppServerContext, requested: string): string {
+  try {
+    return canonicalSymbolName(context.symbolIndex.getReadDb(), requested, OBJECT_TYPES) ?? requested;
+  } catch {
+    return requested; // DB not available — bridge/XML may still resolve it
+  }
+}
+
+/**
  * Try XML file parsing for method source.
  * Fallback when C# bridge is unavailable (Azure, Linux, bridge not running).
  * Mirrors the pattern from classInfo.ts: parse XML with timeout guard.
@@ -84,15 +116,15 @@ async function tryXmlMethodSource(
   const { parser, symbolIndex } = context;
   if (!parser) return null;
 
-  // Locate the class file path from SQLite
-  const OBJECT_TYPES = `('class', 'table', 'view', 'data-entity')`;
+  // Locate the class file path from SQLite. `className` is already canonical
+  // (resolveClassName), so this stays a BINARY probe on idx_name_type.
   let classRow: any;
   try {
     const rdb = symbolIndex.getReadDb();
     classRow = rdb.prepare(`
       SELECT file_path, model, type
       FROM symbols
-      WHERE type IN ${OBJECT_TYPES} AND name = ?
+      WHERE type IN ${OBJECT_TYPES_SQL} AND name = ?
       ORDER BY CASE type WHEN 'class' THEN 0 WHEN 'table' THEN 1 ELSE 2 END, model
       LIMIT 1
     `).get(className);

--- a/src/tools/getTablePatterns.ts
+++ b/src/tools/getTablePatterns.ts
@@ -7,6 +7,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 const GetTablePatternsArgsSchema = z.object({
   tableGroup: z.enum(['Main', 'Transaction', 'Parameter', 'Group', 'Reference', 'Miscellaneous', 'WorksheetHeader', 'WorksheetLine'])
@@ -94,15 +95,19 @@ export async function getTablePatternsTool(request: CallToolRequest, context: Xp
   }
 }
 
-async function analyzeSimilarTable(symbolIndex: any, tableName: string, limit: number): Promise<string> {
+async function analyzeSimilarTable(symbolIndex: any, requestedName: string, limit: number): Promise<string> {
   const rdb = symbolIndex.getReadDb();
+  // Resolve the caller's casing to the canonical AOT name once (#686), so the
+  // field/relation probes below stay BINARY and on-index.
+  const tableName = canonicalSymbolName(rdb, requestedName, ['table']) ?? requestedName;
+
   // Get table info
   const tableRow = rdb.prepare(`
     SELECT * FROM symbols WHERE type = 'table' AND name = ? LIMIT 1
   `).get(tableName);
 
   if (!tableRow) {
-    throw new Error(`Table "${tableName}" not found`);
+    throw new Error(`Table "${requestedName}" not found`);
   }
 
   // Get fields

--- a/src/tools/macroInfo.ts
+++ b/src/tools/macroInfo.ts
@@ -9,6 +9,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { lookupSymbolNocase } from '../utils/symbolLookup.js';
 
 const GetMacroInfoArgsSchema = z.object({
   macroName: z.string().describe('Name of the AxMacroDictionary (macro library, e.g. "AOT", "SysQuery")'),
@@ -20,9 +21,9 @@ export async function getMacroInfoTool(request: CallToolRequest, context: XppSer
     const { macroName, filter } = GetMacroInfoArgsSchema.parse(request.params.arguments);
     const db = context.symbolIndex.getReadDb();
 
-    const symbol = db.prepare(
-      `SELECT name, model, file_path FROM symbols WHERE name = ? AND type = 'macro' LIMIT 1`
-    ).get(macroName) as { name: string; model: string; file_path: string } | undefined;
+    // Case-insensitive by AOT semantics, index-safe by construction (#686):
+    // exact-case probe first, FTS fallback only for a casing mismatch.
+    const symbol = lookupSymbolNocase(db, macroName, ['macro']);
 
     if (!symbol) {
       return {
@@ -31,9 +32,11 @@ export async function getMacroInfoTool(request: CallToolRequest, context: XppSer
       };
     }
 
+    // Side tables are keyed by the canonical name — pass symbol.name, not the
+    // caller's casing, so this stays a BINARY hit.
     let defines = db.prepare(
       `SELECT define_name, define_value FROM macro_defines WHERE macro_name = ? ORDER BY define_name`
-    ).all(macroName) as { define_name: string; define_value: string }[];
+    ).all(symbol.name) as { define_name: string; define_value: string }[];
 
     if (filter) {
       const f = filter.toLowerCase();

--- a/src/tools/mapInfo.ts
+++ b/src/tools/mapInfo.ts
@@ -7,6 +7,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { lookupSymbolNocase } from '../utils/symbolLookup.js';
 
 const GetMapInfoArgsSchema = z.object({
   mapName: z.string().describe('Name of the AxMap object (e.g. "LogMap")'),
@@ -17,9 +18,8 @@ export async function getMapInfoTool(request: CallToolRequest, context: XppServe
     const { mapName } = GetMapInfoArgsSchema.parse(request.params.arguments);
     const db = context.symbolIndex.getReadDb();
 
-    const symbol = db.prepare(
-      `SELECT name, extends_class, model, file_path FROM symbols WHERE name = ? AND type = 'map' LIMIT 1`
-    ).get(mapName) as { name: string; extends_class?: string; model: string; file_path: string } | undefined;
+    // Case-insensitive by AOT semantics, index-safe by construction (#686).
+    const symbol = lookupSymbolNocase(db, mapName, ['map']);
 
     if (!symbol) {
       return {
@@ -28,9 +28,10 @@ export async function getMapInfoTool(request: CallToolRequest, context: XppServe
       };
     }
 
+    // Side table is keyed by the canonical name — pass symbol.name.
     const mappings = db.prepare(
       `SELECT mapping_table, field_connections FROM map_mappings WHERE map_name = ? ORDER BY mapping_table`
-    ).all(mapName) as { mapping_table: string; field_connections: number }[];
+    ).all(symbol.name) as { mapping_table: string; field_connections: number }[];
 
     const lines: string[] = [];
     lines.push(`# AxMap: \`${symbol.name}\``);

--- a/src/tools/menuItemInfo.ts
+++ b/src/tools/menuItemInfo.ts
@@ -7,6 +7,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { tryBridgeMenuItem } from '../bridge/index.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 const MenuItemInfoArgsSchema = z.object({
   name: z.string().describe('Name of the menu item'),
@@ -14,22 +15,31 @@ const MenuItemInfoArgsSchema = z.object({
     .describe('Menu item type filter (display=AxMenuItemDisplay, action=AxMenuItemAction, output=AxMenuItemOutput, any=all types)'),
 });
 
+const typeMap: Record<string, string> = {
+  display: 'menu-item-display',
+  action: 'menu-item-action',
+  output: 'menu-item-output',
+};
+const ALL_MENU_ITEM_TYPES = Object.values(typeMap);
+
 export async function menuItemInfoTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = MenuItemInfoArgsSchema.parse(request.params.arguments);
 
+    // Resolve the caller's casing to the canonical AOT name before the bridge
+    // call (#686) — the bridge matches by exact name too.
+    let name = args.name;
+    try {
+      const types = args.itemType === 'any' ? ALL_MENU_ITEM_TYPES : [typeMap[args.itemType]];
+      name = canonicalSymbolName(context.symbolIndex.getReadDb(), args.name, types) ?? args.name;
+    } catch { /* DB not available — bridge may still resolve it */ }
+
     // Bridge fast-path (C# IMetadataProvider)
-    const bridgeResult = await tryBridgeMenuItem(context.bridge, args.name, args.itemType);
+    const bridgeResult = await tryBridgeMenuItem(context.bridge, name, args.itemType);
     if (bridgeResult) return bridgeResult;
 
     // Fallback: SQLite index
     const db = context.symbolIndex.getReadDb();
-
-    const typeMap: Record<string, string> = {
-      display: 'menu-item-display',
-      action: 'menu-item-action',
-      output: 'menu-item-output',
-    };
 
     let symbolQuery: string;
     let symbolParams: any[];
@@ -38,11 +48,11 @@ export async function menuItemInfoTool(request: CallToolRequest, context: XppSer
       symbolQuery = `SELECT name, type, description, signature, model, file_path FROM symbols
         WHERE name = ? AND type IN ('menu-item-display', 'menu-item-action', 'menu-item-output')
         ORDER BY type`;
-      symbolParams = [args.name];
+      symbolParams = [name];
     } else {
       symbolQuery = `SELECT name, type, description, signature, model, file_path FROM symbols
         WHERE name = ? AND type = ?`;
-      symbolParams = [args.name, typeMap[args.itemType]];
+      symbolParams = [name, typeMap[args.itemType]];
     }
 
     const symbols = db.prepare(symbolQuery).all(...symbolParams) as any[];

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -13,6 +13,11 @@ import type { XppServerContext } from '../types/context.js';
 import { buildObjectTypeMismatchMessage } from '../utils/metadataResolver.js';
 import type { BridgeClient } from '../bridge/bridgeClient.js';
 import type { XppMetadataParser } from '../metadata/xmlParser.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
+
+/** Object types that can own methods. */
+const OBJECT_TYPES = ['class', 'table', 'view', 'data-entity'] as const;
+const OBJECT_TYPES_SQL = `(${OBJECT_TYPES.map(t => `'${t}'`).join(', ')})`;
 
 
 const GetMethodSignatureArgsSchema = z.object({
@@ -41,17 +46,23 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
   try {
     const args = GetMethodSignatureArgsSchema.parse(request.params.arguments);
     const { symbolIndex, parser } = context;
-    const { className, methodName, modelName } = args;
-
-    // 1. Find the class/table/view — methods live on all three object types
-    const OBJECT_TYPES = `('class', 'table', 'view', 'data-entity')`;
+    const { methodName, modelName } = args;
     const rdb = symbolIndex.getReadDb();
+
+    // 1. Find the class/table/view — methods live on all three object types.
+    // Resolve the caller's casing to the canonical AOT name first: X++ treats
+    // AOT identifiers case-insensitively, but the probes below match by exact
+    // name, so a mismatch would report a false "not found" (#686). Canonicalizing
+    // once keeps those probes BINARY and on-index — `name = ? COLLATE NOCASE`
+    // here would scan every class/table/view row instead (~86k rows, 4–8 s warm).
+    const className = canonicalSymbolName(rdb, args.className, OBJECT_TYPES) ?? args.className;
+
     let classRow: any;
     if (modelName) {
       classRow = rdb.prepare(`
         SELECT file_path, model, name, type
         FROM symbols
-        WHERE type IN ${OBJECT_TYPES} AND name = ? AND model = ?
+        WHERE type IN ${OBJECT_TYPES_SQL} AND name = ? AND model = ?
         ORDER BY CASE type WHEN 'class' THEN 0 WHEN 'table' THEN 1 ELSE 2 END
         LIMIT 1
       `).get(className, modelName);
@@ -59,7 +70,7 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
       classRow = rdb.prepare(`
         SELECT file_path, model, name, type
         FROM symbols
-        WHERE type IN ${OBJECT_TYPES} AND name = ?
+        WHERE type IN ${OBJECT_TYPES_SQL} AND name = ?
         ORDER BY CASE type WHEN 'class' THEN 0 WHEN 'table' THEN 1 ELSE 2 END, model
         LIMIT 1
       `).get(className);
@@ -79,16 +90,19 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
     }
 
     // 2. Find the method in database (advisory — delegates and SubscribesTo handlers may be absent)
+    // COLLATE NOCASE on the method name is safe here: `parent_name` is canonical
+    // and `type`/`parent_name` narrow the range to one object's members before
+    // the case-insensitive comparison runs.
     const methodStmt = rdb.prepare(`
       SELECT name, signature, parent_name, file_path
       FROM symbols
       WHERE type = 'method'
-        AND name = ?
         AND parent_name = ?
+        AND name = ? COLLATE NOCASE
       LIMIT 1
     `);
 
-    const methodRow = methodStmt.get(methodName, className);
+    const methodRow = methodStmt.get(className, methodName);
 
     // 3. C# bridge (IMetadataProvider — live source, always current)
     const includeCoc = args.includeCocTemplate ?? false;

--- a/src/tools/securityArtifactInfo.ts
+++ b/src/tools/securityArtifactInfo.ts
@@ -7,12 +7,20 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { tryBridgeSecurityArtifact } from '../bridge/index.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 const SecurityArtifactInfoArgsSchema = z.object({
   name: z.string().describe('Name of the security privilege, duty, or role'),
   artifactType: z.enum(['privilege', 'duty', 'role']).describe('Type of security artifact'),
   includeChain: z.boolean().optional().default(true).describe('Walk the full hierarchy (role→duties→privileges→entry points)'),
 });
+
+/** Symbol type backing each artifactType. */
+const SYMBOL_TYPE = {
+  privilege: 'security-privilege',
+  duty: 'security-duty',
+  role: 'security-role',
+} as const;
 
 export async function securityArtifactInfoTool(
   request: CallToolRequest,
@@ -21,9 +29,19 @@ export async function securityArtifactInfoTool(
   try {
     const args = SecurityArtifactInfoArgsSchema.parse(request.params.arguments);
 
+    // Resolve the caller's casing to the canonical AOT name before anything else
+    // (#686) — the bridge matches by exact name too, so canonicalizing here fixes
+    // the bridge path as well as the SQLite fallback below.
+    let name = args.name;
+    try {
+      name = canonicalSymbolName(
+        context.symbolIndex.getReadDb(), args.name, [SYMBOL_TYPE[args.artifactType]],
+      ) ?? args.name;
+    } catch { /* DB not available — bridge may still resolve it */ }
+
     // Bridge fast-path (C# IMetadataProvider)
     const bridgeResult = await tryBridgeSecurityArtifact(
-      context.bridge, args.name, args.artifactType, args.includeChain ?? true,
+      context.bridge, name, args.artifactType, args.includeChain ?? true,
     );
     if (bridgeResult) return bridgeResult;
 
@@ -31,11 +49,11 @@ export async function securityArtifactInfoTool(
     const rdb = context.symbolIndex.getReadDb();
 
     if (args.artifactType === 'privilege') {
-      return getPrivilegeInfo(rdb, args.name, args.includeChain ?? true);
+      return getPrivilegeInfo(rdb, name, args.includeChain ?? true);
     } else if (args.artifactType === 'duty') {
-      return getDutyInfo(rdb, args.name, args.includeChain ?? true);
+      return getDutyInfo(rdb, name, args.includeChain ?? true);
     } else {
-      return getRoleInfo(rdb, args.name, args.includeChain ?? true);
+      return getRoleInfo(rdb, name, args.includeChain ?? true);
     }
   } catch (error) {
     return {

--- a/src/tools/securityCoverageInfo.ts
+++ b/src/tools/securityCoverageInfo.ts
@@ -7,6 +7,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 const SecurityCoverageInfoArgsSchema = z.object({
   objectName: z.string().describe('Name of the form, table, class, or menu item to check security coverage for'),
@@ -14,11 +15,23 @@ const SecurityCoverageInfoArgsSchema = z.object({
     .describe('Type of the object (auto=detect from symbol index)'),
 });
 
+const MENU_ITEM_TYPES = ['menu-item-display', 'menu-item-action', 'menu-item-output'];
+
+/** Symbol types a given objectType arg could resolve to. */
+function candidateTypes(objectType: string): string[] {
+  if (objectType === 'menu-item') return MENU_ITEM_TYPES;
+  if (objectType === 'auto') return ['form', 'table', 'class', ...MENU_ITEM_TYPES];
+  return [objectType];
+}
+
 export async function securityCoverageInfoTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = SecurityCoverageInfoArgsSchema.parse(request.params.arguments);
     const db = context.symbolIndex.getReadDb();
-    const objName = args.objectName;
+    // Resolve the caller's casing to the canonical AOT name once (#686) — every
+    // probe and side-table join below keys off this name.
+    const objName = canonicalSymbolName(db, args.objectName, candidateTypes(args.objectType))
+      ?? args.objectName;
 
     let resolvedType = args.objectType;
     if (resolvedType === 'auto') {

--- a/src/tools/securityPolicyInfo.ts
+++ b/src/tools/securityPolicyInfo.ts
@@ -18,9 +18,12 @@ export async function getSecurityPolicyInfoTool(request: CallToolRequest, contex
     const { policyName } = GetSecurityPolicyInfoArgsSchema.parse(request.params.arguments);
     const db = context.symbolIndex.getReadDb();
 
+    // COLLATE NOCASE is safe on this side table (#686): security_policies holds
+    // one row per policy (thousands at most), so a mismatch costs a small scan —
+    // unlike `symbols`, where the same shape scans 1.17M rows.
     const policy = db.prepare(
       `SELECT policy_name, primary_table, query_name, operation, constrained_table, label, model
-       FROM security_policies WHERE policy_name = ? LIMIT 1`
+       FROM security_policies WHERE policy_name = ? COLLATE NOCASE LIMIT 1`
     ).get(policyName) as {
       policy_name: string; primary_table?: string; query_name?: string;
       operation?: string; constrained_table: number; label?: string; model: string;
@@ -33,9 +36,10 @@ export async function getSecurityPolicyInfoTool(request: CallToolRequest, contex
       };
     }
 
+    // policy.policy_name is canonical — keeps this symbols probe BINARY.
     const file = db.prepare(
       `SELECT file_path FROM symbols WHERE name = ? AND type = 'security-policy' LIMIT 1`
-    ).get(policyName) as { file_path?: string } | undefined;
+    ).get(policy.policy_name) as { file_path?: string } | undefined;
 
     const lines: string[] = [];
     lines.push(`# AxSecurityPolicy: \`${policy.policy_name}\``);

--- a/src/tools/serviceInfo.ts
+++ b/src/tools/serviceInfo.ts
@@ -11,6 +11,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 const GetServiceInfoArgsSchema = z.object({
   serviceName: z.string().describe('Name of the AxService object (e.g. "AifUserSessionService")'),
@@ -20,8 +21,12 @@ const GetServiceInfoArgsSchema = z.object({
 export async function getServiceInfoTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = GetServiceInfoArgsSchema.parse(request.params.arguments);
-    const { serviceName, includeOperations } = args;
+    const { includeOperations } = args;
     const db = context.symbolIndex.getReadDb();
+
+    // Resolve the caller's casing to the canonical AOT name once (#686), then
+    // keep every probe below BINARY and on-index.
+    const serviceName = canonicalSymbolName(db, args.serviceName, ['service']) ?? args.serviceName;
 
     const symbol = db.prepare(
       `SELECT name, signature, description, model, file_path FROM symbols WHERE name = ? AND type = 'service' LIMIT 1`

--- a/src/tools/tableExtensionInfo.ts
+++ b/src/tools/tableExtensionInfo.ts
@@ -15,6 +15,7 @@ import type { XppServerContext } from '../types/context.js';
 import { getConfigManager } from '../utils/configManager.js';
 import { scanFsExtensions } from '../utils/fsExtensionScanner.js';
 import { tryBridgeTableExtensions } from '../bridge/index.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 
 const TableExtensionInfoArgsSchema = z.object({
   tableName: z.string().describe('Base table name whose extensions to find'),
@@ -26,13 +27,21 @@ export async function tableExtensionInfoTool(request: CallToolRequest, context: 
   try {
     const args = TableExtensionInfoArgsSchema.parse(request.params.arguments);
 
+    // Resolve the caller's casing to the canonical AOT name before the bridge
+    // call (#686) — the bridge matches by exact name too, and every probe and
+    // extension_metadata join below keys off this name.
+    let tableName = args.tableName;
+    try {
+      tableName = canonicalSymbolName(context.symbolIndex.getReadDb(), args.tableName, ['table'])
+        ?? args.tableName;
+    } catch { /* DB not available — bridge may still resolve it */ }
+
     // Bridge fast-path (C# IMetadataProvider)
-    const bridgeResult = await tryBridgeTableExtensions(context.bridge, args.tableName);
+    const bridgeResult = await tryBridgeTableExtensions(context.bridge, tableName);
     if (bridgeResult) return bridgeResult;
 
     // Fallback: SQLite index + filesystem
     const db = context.symbolIndex.getReadDb();
-    const tableName = args.tableName;
 
     // Verify the base table exists
     const baseTable = db.prepare(

--- a/src/tools/validateFormPattern.ts
+++ b/src/tools/validateFormPattern.ts
@@ -18,6 +18,7 @@ import {
   type FormPatternViolation,
 } from '../validation/formPatternValidator.js';
 import { resolveSubPattern } from '../knowledge/formPatterns/index.js';
+import { canonicalSymbolName } from '../utils/symbolLookup.js';
 import {
   walkFormDesign,
   type FormControlNode,
@@ -98,9 +99,11 @@ export async function validateFormPatternTool(
       source = filePath;
     } else if (!formXml && formName) {
       const db = context?.symbolIndex?.getReadDb?.();
+      // Resolve the caller's casing to the canonical AOT name first (#686).
+      const canonicalForm = db ? (canonicalSymbolName(db, formName, ['form']) ?? formName) : formName;
       const row = db
         ?.prepare(`SELECT file_path FROM symbols WHERE type = 'form' AND name = ? LIMIT 1`)
-        ?.get(formName) as { file_path?: string } | undefined;
+        ?.get(canonicalForm) as { file_path?: string } | undefined;
       if (!row?.file_path) {
         return {
           isError: true,

--- a/src/tools/validateObjectNaming.ts
+++ b/src/tools/validateObjectNaming.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { getObjectSuffix, getExtensionNamingStyle } from '../utils/modelClassifier.js';
 import { getConfigManager } from '../utils/configManager.js';
+import { lookupSymbolNocase, lookupSymbolsNocase } from '../utils/symbolLookup.js';
 
 const ValidateObjectNamingArgsSchema = z.object({
   proposedName: z.string().describe('The proposed object name to validate'),
@@ -161,9 +162,9 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
           args.objectType.includes('form') ? ['form'] :
           args.objectType.includes('enum') ? ['enum'] : ['edt'];
 
-        const baseExists = db.prepare(
-          `SELECT name FROM symbols WHERE name = ? AND type IN (${dbTypes.map(() => '?').join(',')}) LIMIT 1`
-        ).get(baseObjectName, ...dbTypes) as any;
+        // Case-insensitive: the base object may be spelled with different casing
+        // than the canonical AOT name (#686).
+        const baseExists = lookupSymbolNocase(db, baseObjectName, dbTypes);
 
         if (!baseExists) {
           warnings.push(`Base object "${baseObjectName}" not found in symbol index for types: ${dbTypes.join(', ')}. Ensure it's indexed.`);
@@ -235,9 +236,11 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
       args.objectType === 'data-entity' ? 'view' :
       args.objectType;
 
-    const exactConflict = db.prepare(
-      `SELECT name, type, model FROM symbols WHERE name = ? ORDER BY model LIMIT 5`
-    ).all(name) as any[];
+    // AOT names are case-insensitive, so an existing object differing only in
+    // casing IS a conflict — a case-sensitive probe here reported a false
+    // "no existing objects" (#686). Scoped to top-level objects: a method or
+    // field sharing the name is not an AOT naming conflict.
+    const exactConflict = lookupSymbolsNocase(db, name, { limit: 5 });
 
     const similarSymbols = db.prepare(
       `SELECT name, type, model FROM symbols WHERE name LIKE ? AND type = ? ORDER BY name LIMIT 5`
@@ -294,7 +297,7 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
       output += `  ✓ No existing objects named "${name}" found\n`;
     }
 
-    if (similarSymbols.length > 0 && !exactConflict.some(c => c.name === name)) {
+    if (similarSymbols.length > 0 && !exactConflict.some(c => c.name.toLowerCase() === name.toLowerCase())) {
       output += `  Similar ${args.objectType} names:\n`;
       for (const s of similarSymbols) {
         output += `    ${s.name} [${s.model}]\n`;

--- a/tests/tools/extensions-security.test.ts
+++ b/tests/tools/extensions-security.test.ts
@@ -330,6 +330,8 @@ describe('analyze_extension_points', () => {
     // object type resolution
     db.stmt.get.mockReturnValue({ type: 'class' });
     db.stmt.all
+      // canonical-name probe (symbolLookup, #686) — runs before everything else
+      .mockReturnValueOnce([{ name: 'SalesFormLetter', type: 'class', model: 'M', extends_class: null, file_path: '' }])
       .mockReturnValueOnce([]) // existing extensions
       .mockReturnValueOnce([  // methods
         { name: 'run', type: 'method', signature: 'void run()', is_final: 0 },

--- a/tests/tools/method-case-insensitive.test.ts
+++ b/tests/tools/method-case-insensitive.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression: case-insensitive object-name resolution in get_method (#686).
+ *
+ * The reported repro is WHSRFControlData — a standard class whose canonical AOT
+ * name is upper-case (`WHSRFControlData`) while its file on disk is
+ * `WhsrfControlData.xml`, so the misleading filename makes the lower-case
+ * spelling a natural guess. Every lookup layer matched by exact name, so the
+ * mismatch produced a false "method not found" with no "did you mean" hint.
+ *
+ * These run against a REAL in-memory index: the fix depends on the FTS fallback
+ * inside symbolLookup, which a get()-only fake DB would not exercise (it calls
+ * .all()).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { getMethodSignatureTool } from '../../src/tools/methodSignature';
+import { getMethodSourceTool } from '../../src/tools/getMethodSource';
+import { getMacroInfoTool } from '../../src/tools/macroInfo';
+import { validateObjectNamingTool } from '../../src/tools/validateObjectNaming';
+import { analyzeExtensionPointsTool } from '../../src/tools/analyzeExtensionPoints';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+let index: XppSymbolIndex;
+let context: XppServerContext;
+
+const symbol = (over: Record<string, unknown>) => ({
+  name: '',
+  type: 'class',
+  filePath: '/x.xml',
+  model: 'Foundation',
+  ...over,
+}) as any;
+
+const req = (name: string, args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name, arguments: args },
+});
+
+const textOf = (r: any) => r.content.map((c: any) => c.text).join('\n');
+
+beforeAll(() => {
+  index = new XppSymbolIndex(':memory:', ':memory:');
+  index.addSymbol(symbol({ name: 'WHSRFControlData' }));
+  index.addSymbol(symbol({
+    name: 'processLegacyControl', type: 'method', parentName: 'WHSRFControlData',
+    signature: 'public container processLegacyControl(container _con)',
+  }));
+  index.addSymbol(symbol({ name: 'AOT', type: 'macro' }));
+  context = { symbolIndex: index, bridge: undefined } as unknown as XppServerContext;
+});
+
+afterAll(() => index.close());
+
+describe('get_method name resolution is case-insensitive (#686)', () => {
+  it('signature: resolves a class requested with non-canonical casing', async () => {
+    const r: any = await getMethodSignatureTool(
+      req('get_method', { className: 'WhsrfControlData', methodName: 'processLegacyControl' }),
+      context,
+    );
+    expect(textOf(r)).toContain('processLegacyControl');
+    expect(r.isError).toBeFalsy();
+  });
+
+  it('signature: resolves a method requested with non-canonical casing', async () => {
+    const r: any = await getMethodSignatureTool(
+      req('get_method', { className: 'WHSRFControlData', methodName: 'ProcessLegacyControl' }),
+      context,
+    );
+    expect(r.isError).toBeFalsy();
+  });
+
+  it('signature: canonical casing keeps working', async () => {
+    const r: any = await getMethodSignatureTool(
+      req('get_method', { className: 'WHSRFControlData', methodName: 'processLegacyControl' }),
+      context,
+    );
+    expect(r.isError).toBeFalsy();
+  });
+
+  it('a genuinely unknown class still reports not found', async () => {
+    const r: any = await getMethodSignatureTool(
+      req('get_method', { className: 'NoSuchClassAnywhere', methodName: 'foo' }),
+      context,
+    );
+    expect(r.isError).toBe(true);
+  });
+
+  it('source: mis-cased class still emits the "did you mean" hint', async () => {
+    // The hint query is parent-scoped; before the fix a case-sensitive
+    // parent_name gate returned 0 candidates and the hint was silently dropped.
+    const r: any = await getMethodSourceTool(
+      req('get_method', { className: 'WhsrfControlData', methodName: 'processLegacy' }),
+      context,
+    );
+    expect(r.isError).toBe(true);
+    expect(textOf(r)).toContain('Similar methods');
+    expect(textOf(r)).toContain('processLegacyControl');
+  });
+});
+
+describe('other object-name lookups are case-insensitive (#686)', () => {
+  it('get_macro_info resolves a mis-cased macro library', async () => {
+    const r: any = await getMacroInfoTool(req('get_macro_info', { macroName: 'aot' }), context);
+    expect(r.isError).toBeFalsy();
+    expect(textOf(r)).toContain('AOT');
+  });
+
+  it('analyze_extension_points resolves a mis-cased class', async () => {
+    const r: any = await analyzeExtensionPointsTool(
+      req('analyze_extension_points', { objectName: 'whsrfcontroldata', objectType: 'class' }),
+      context,
+    );
+    // Reports the canonical name, not the caller's casing.
+    expect(textOf(r)).toContain('WHSRFControlData');
+  });
+
+  it('validate_object_naming flags a conflict differing only in casing', async () => {
+    // AOT names are case-insensitive, so this IS a real conflict — before the
+    // fix the case-sensitive probe reported "no existing objects".
+    const r: any = await validateObjectNamingTool(
+      req('validate_object_naming', { proposedName: 'WhsrfControlData', objectType: 'class' }),
+      context,
+    );
+    expect(textOf(r)).toContain('already exists');
+    expect(textOf(r)).toContain('WHSRFControlData');
+  });
+});

--- a/tests/tools/new-object-info.test.ts
+++ b/tests/tools/new-object-info.test.ts
@@ -25,6 +25,11 @@ const req = (name: string, args: Record<string, unknown> = {}): CallToolRequest 
 /**
  * Build a db whose prepare(sql) returns a statement that resolves get()/all()
  * by matching the first routing rule whose `match` substring appears in the SQL.
+ *
+ * Note: tools that resolve an object name go through symbolLookup (see #686),
+ * whose exact-case probe is `SELECT ... FROM symbols s WHERE s.name = ? ...`
+ * and returns rows via all() — so route those on 'FROM symbols s' with `all`,
+ * not on a `type = '<x>'` literal (the type is a bound parameter there).
  */
 type Route = { match: string; get?: any; all?: any[] };
 const routedDb = (routes: Route[]) => ({
@@ -75,7 +80,7 @@ describe('get_service_info', () => {
 describe('get_map_info', () => {
   it('lists mapped tables (happy path)', async () => {
     const db = routedDb([
-      { match: "type = 'map'", get: { name: 'LogMap', extends_class: 'common', model: 'M', file_path: 'p' } },
+      { match: 'FROM symbols s', all: [{ name: 'LogMap', type: 'map', extends_class: 'common', model: 'M', file_path: 'p' }] },
       { match: 'FROM map_mappings', all: [{ mapping_table: 'SysDataBaseLog', field_connections: 4 }] },
     ]);
     const res = await getMapInfoTool(req('get_map_info', { mapName: 'LogMap' }), ctx(db));
@@ -135,7 +140,7 @@ describe('get_security_policy_info', () => {
 describe('get_macro_info', () => {
   it('lists defines and applies filter (happy path)', async () => {
     const db = routedDb([
-      { match: "type = 'macro'", get: { name: 'AOT', model: 'M', file_path: 'p' } },
+      { match: 'FROM symbols s', all: [{ name: 'AOT', type: 'macro', model: 'M', file_path: 'p' }] },
       { match: 'FROM macro_defines', all: [
         { define_name: 'TablesPath', define_value: "'\\Tables'" },
         { define_name: 'ViewsPath', define_value: "'\\Views'" },
@@ -156,7 +161,7 @@ describe('get_macro_info', () => {
 describe('get_object_info (unified dispatch)', () => {
   it('dispatches to the map reader for objectType=map', async () => {
     const db = routedDb([
-      { match: "type = 'map'", get: { name: 'LogMap', extends_class: 'common', model: 'M', file_path: 'p' } },
+      { match: 'FROM symbols s', all: [{ name: 'LogMap', type: 'map', extends_class: 'common', model: 'M', file_path: 'p' }] },
       { match: 'FROM map_mappings', all: [{ mapping_table: 'SysDataBaseLog', field_connections: 4 }] },
     ]);
     const res = await getObjectInfoTool(req('get_object_info', { objectType: 'map', name: 'LogMap' }), ctx(db));
@@ -166,7 +171,7 @@ describe('get_object_info (unified dispatch)', () => {
 
   it('forwards options to the underlying reader (macro filter)', async () => {
     const db = routedDb([
-      { match: "type = 'macro'", get: { name: 'AOT', model: 'M', file_path: 'p' } },
+      { match: 'FROM symbols s', all: [{ name: 'AOT', type: 'macro', model: 'M', file_path: 'p' }] },
       { match: 'FROM macro_defines', all: [
         { define_name: 'TablesPath', define_value: "'\\Tables'" },
         { define_name: 'ViewsPath', define_value: "'\\Views'" },


### PR DESCRIPTION
Fixes #686.

## The bug

X++ treats AOT identifiers case-insensitively, but the symbol index stores the canonical name and every lookup matched by exact name. A casing mismatch reported a false **"method not found"** for an object that plainly exists.

The reported repro is `WHSRFControlData` — whose own file on disk is `WhsrfControlData.xml`. Filename and canonical AOT name disagree, which is what makes the wrong casing a natural guess. Confirmed against the production DB:

| Query | Result |
|---|---|
| `name = 'WhsrfControlData'` | 0 rows |
| `name = 'WHSRFControlData'` | the class, `processLegacyControl` present |

All three resolver layers missed. @kklyandev asked whether the bridge is also case-sensitive — **it is**: `tryBridgeMethodSource` passes the caller's `className` straight to D365 `IMetadataProvider`, which matches by exact AOT name.

## Why not `COLLATE NOCASE`

The issue suggested appending `COLLATE NOCASE` / giving the columns a NOCASE collation. Measured against the production 2 GB DB, that trades a fast wrong answer for a server-killing hang:

| Query | `COLLATE NOCASE` | This PR |
|---|---|---|
| Class lookup | **8040 ms** | **2 ms** |
| "did you mean" hint | **48424 ms** | **27 ms** |

`COLLATE NOCASE` cannot use the BINARY name indexes, so `EXPLAIN` degrades to `SEARCH symbols USING INDEX idx_type_name (type=?)` — an 86k-row scan constrained only by `type`, not by name. better-sqlite3 is synchronous, so the 48 s hint query (which runs on `get_method`'s **error path** — exactly this issue's scenario) blocks the event loop past the MCP client's 60 s timeout and the client kills the server. That is the failure d93f004 / 45a79a3 / 59cc420 removed.

## The fix

Resolve the caller's casing to the canonical name **once up front** via the existing `src/utils/symbolLookup.ts` helper (exact-case probe on `idx_name_type`, FTS phrase fallback only on mismatch), then keep every downstream probe BINARY and on-index. Canonicalizing *before* the bridge call fixes that layer too.

Applied to the two tools in the report plus the 14 others that never canonicalized (found via the repo-wide grep the issue suggested). Two things worth flagging:

- **`validate_object_naming`'s conflict check was case-sensitive** — an existing object differing only in casing reported "✓ No existing objects named X". A real AOT naming conflict, silently missed.
- `COLLATE NOCASE` is *kept* where the range is already narrow: the small `security_policies` side table, and a method name after its parent is canonicalized.

## Verification

E2E against the real 2 GB DB (1.17M symbols), bridge absent, all mis-cased:

```
PASS [ 236ms] get_method(WhsrfControlData.processLegacyControl)   <- was a false "not found"
PASS [  61ms] get_method mis-cased + bad method                   <- "Similar methods" hint now appears
PASS [  31ms] analyze_extension_points (aadauthenticationresult)
PASS [1818ms] table_extension_info (acocostcentertypestaging)
PASS [ 787ms] security_coverage_info (ACOCOSTCENTER_BR)
PASS [  36ms] security_artifact_info (acodelete_br)
PASS [  94ms] menu_item_info (ACOJOURNALNAME_BR)
PASS [  38ms] validate_object_naming (mis-cased conflict now flagged)
PASS [ 220ms] unknown name still fails fast, no scan
```

Full suite: 1612 passed. Typecheck clean. New tests run against a **real in-memory index** — a `get()`-only fake DB cannot exercise symbolLookup's FTS fallback, which calls `.all()`. Confirmed all 6 bug-specific tests fail without the src changes (the 2 control tests pass either way).

The workaround in the issue (canonical casing) keeps working — covered by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)