### PR TITLE
fix(xmlParser): read class inheritance from the Declaration CDATA

### DIFF
--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -21,7 +21,13 @@ import type {
 } from './types.js';
 import { EnhancedXppParser } from './enhancedParser.js';
 import { walkFormDesign, collectPatternNodes } from './formPatternMiner.js';
-import { parseXppDeclaration, type XppDeclaration } from './xppDeclaration.js';
+import {
+  parseXppDeclaration,
+  parseXppClassHeader,
+  blankCommentsAndStrings,
+  type XppDeclaration,
+  type XppClassHeader,
+} from './xppDeclaration.js';
 
 export class XppMetadataParser {
   private parser: Parser;
@@ -55,11 +61,21 @@ export class XppMetadataParser {
       const methodsData = axClass.SourceCode?.Methods?.Method || axClass.Methods?.Method;
 
       const parsedMethods = this.parseMethods(methodsData, className);
-      const parsedImplements = this.parseImplements(axClass.Implements);
-      const parsedDeclaration = this.extractClassDeclaration(axClass);
-      const isAbstract = axClass.IsAbstract === 'Yes' || axClass.IsAbstract === 'true';
-      const isFinal = axClass.IsFinal === 'Yes' || axClass.IsFinal === 'true';
-      const extendsClass = axClass.Extends || undefined;
+
+      // Inheritance lives in the Declaration CDATA as X++ text, not in XML
+      // elements — see parseXppClassHeader. The element reads are kept only as
+      // a fallback for hand-written/synthetic AxClass XML in tests and tools.
+      const header = parseXppClassHeader(this.cdataText(axClass.SourceCode?.Declaration));
+
+      const parsedImplements = header?.implements.length
+        ? header.implements
+        : this.parseImplements(axClass.Implements);
+      const parsedDeclaration = this.extractClassDeclaration(axClass, header);
+      const isAbstract = header?.isAbstract
+        ?? (axClass.IsAbstract === 'Yes' || axClass.IsAbstract === 'true');
+      const isFinal = header?.isFinal
+        ?? (axClass.IsFinal === 'Yes' || axClass.IsFinal === 'true');
+      const extendsClass = header?.extends || axClass.Extends || undefined;
 
       const classInfoBase = {
         name: className,
@@ -168,17 +184,43 @@ export class XppMetadataParser {
     }
   }
 
+  /**
+   * Text of a CDATA-bearing element. xml2js hands back a plain string, unless
+   * the element carries an attribute (mergeAttrs) — then the text sits under
+   * `_` and the raw value is an object.
+   */
+  private cdataText(node: unknown): string {
+    if (typeof node === 'string') return node;
+    const text = (node as { _?: unknown } | null | undefined)?._;
+    return typeof text === 'string' ? text : '';
+  }
+
   private parseImplements(implementsStr?: string | any): string[] {
     if (!implementsStr) return [];
     if (typeof implementsStr !== 'string') return [];
     return implementsStr.split(',').map(i => i.trim()).filter(Boolean);
   }
 
-  private extractClassDeclaration(axClass: any): string {
+  /**
+   * The class's declaration line. Rebuilt from the parsed Declaration CDATA so
+   * it reflects what the source actually says; falls back to synthesising one
+   * from XML elements when there is no declaration to read.
+   */
+  private extractClassDeclaration(axClass: any, header?: XppClassHeader | null): string {
     const modifiers: string[] = [];
+    if (header) {
+      if (header.isAbstract) modifiers.push('abstract');
+      if (header.isFinal) modifiers.push('final');
+      let decl = modifiers.length > 0 ? `${modifiers.join(' ')} ` : '';
+      decl += `${header.kind} ${header.name}`;
+      if (header.extends) decl += ` extends ${header.extends}`;
+      if (header.implements.length) decl += ` implements ${header.implements.join(', ')}`;
+      return decl;
+    }
+
     if (axClass.IsAbstract === 'Yes' || axClass.IsAbstract === 'true') modifiers.push('abstract');
     if (axClass.IsFinal === 'Yes' || axClass.IsFinal === 'true') modifiers.push('final');
-    
+
     let decl = modifiers.length > 0 ? `${modifiers.join(' ')} ` : '';
     decl += `class ${axClass.Name}`;
     if (axClass.Extends) decl += ` extends ${axClass.Extends}`;
@@ -791,18 +833,29 @@ export class XppMetadataParser {
       if (!root) return { success: false, error: `Cannot parse extension type: ${extensionType}` };
 
       const name: string = root.Name || '';
-      const extendsValue: string = root.Extends || root.BaseObject || '';
 
-      // For class extensions, base object name is inferred from Extends or the name itself
-      // Class extension names follow the pattern "BaseClass.Suffix" or "BaseClass_Suffix_Extension"
-      let baseObjectName = extendsValue;
-      if (!baseObjectName && extensionType === 'class-extension') {
-        // Try to parse from declaration: [ExtensionOf(classStr(BaseName))]
-        const decl: string = root.SourceCode?.Declaration || '';
-        const match = decl.match(/ExtensionOf\s*\(\s*classStr\s*\(\s*(\w+)\s*\)/i)
-          ?? decl.match(/ExtensionOf\s*\(\s*tableStr\s*\(\s*(\w+)\s*\)/i)
-          ?? decl.match(/ExtensionOf\s*\(\s*formStr\s*\(\s*(\w+)\s*\)/i);
-        baseObjectName = match?.[1] || '';
+      // No Ax*Extension XML carries <Extends>/<BaseObject> — these reads are a
+      // fallback for synthetic XML only. Real files identify the base object
+      // either by the [ExtensionOf(<kind>Str(Base))] attribute on the
+      // declaration (class extensions) or by the "Base.<Suffix>" name
+      // convention (every other kind), so both are read here. Leaving this
+      // empty silently kills every extension_metadata lookup keyed on
+      // base_object_name — resolve_references' extension-method and
+      // table-extension-field checks, and table_extension_info.
+      let baseObjectName: string = root.Extends || root.BaseObject || '';
+
+      if (!baseObjectName) {
+        // Comments/strings blanked so a mention in a doc comment can't match.
+        const decl = blankCommentsAndStrings(this.cdataText(root.SourceCode?.Declaration));
+        // Any intrinsic: classStr / tableStr / formStr / enumStr /
+        // extendedTypeStr / dataEntityViewStr.
+        baseObjectName = decl.match(/ExtensionOf\s*\(\s*\w+Str\s*\(\s*([\w.]+)\s*\)/i)?.[1] || '';
+      }
+
+      if (!baseObjectName && name.includes('.')) {
+        // "SalesTable.FooExtension" → "SalesTable"; the suffix may itself
+        // contain dots ("OMLegalEntity.Extension.Retail"), so split on the first.
+        baseObjectName = name.slice(0, name.indexOf('.'));
       }
 
       // Extract added fields

--- a/src/metadata/xppDeclaration.ts
+++ b/src/metadata/xppDeclaration.ts
@@ -22,6 +22,15 @@ export interface XppDeclaration {
   parameters: XppDeclarationParameter[];
 }
 
+export interface XppClassHeader {
+  kind: 'class' | 'interface';
+  name: string;
+  extends?: string;
+  implements: string[];
+  isAbstract: boolean;
+  isFinal: boolean;
+}
+
 export interface XppDeclarationParameter {
   type: string;
   name: string;
@@ -210,6 +219,58 @@ function tryDeclarationAt(source: string, blanked: string, nameStart: number): X
   }
 
   return { modifiers, returnType, parameters };
+}
+
+/**
+ * Parse the header of an AxClass `<SourceCode><Declaration>` CDATA block —
+ * `[attributes] [modifiers] class Name [extends Base] [implements A, B] {`.
+ *
+ * The inheritance clause exists ONLY as X++ text here; AxClass XML has no
+ * <Extends>/<Implements>/<IsAbstract>/<IsFinal> elements, so reading those
+ * (as this parser used to) yields undefined for every class in the AOT.
+ *
+ * Two traps this avoids, both measured against the real AOT:
+ *  - The header routinely wraps across lines (~17% of implements lists are
+ *    multi-line), so it is closed by the body's '{', never by end-of-line.
+ *  - Doc comments above the class say things like "extends the base class",
+ *    so a regex over the raw CDATA harvests `extends the`. Comments and
+ *    strings are blanked first, and the search is anchored at the class
+ *    keyword rather than run over the whole block.
+ *
+ * Returns null when no class/interface header is present.
+ */
+export function parseXppClassHeader(declaration: string): XppClassHeader | null {
+  if (!declaration || typeof declaration !== 'string') return null;
+
+  const blanked = blankCommentsAndStrings(declaration);
+  const kw = /\b(class|interface)\s+([\w.]+)/.exec(blanked);
+  if (!kw) return null;
+
+  // The header runs from the keyword to the body's opening brace. A declaration
+  // block with no brace (malformed/truncated) still yields a usable header.
+  const braceIdx = blanked.indexOf('{', kw.index);
+  const headEnd = braceIdx < 0 ? blanked.length : braceIdx;
+  const head = blanked.slice(kw.index, headEnd);
+
+  // Modifiers sit before the keyword on its own line; attributes on preceding
+  // lines are excluded, and a blanked attribute body can't inject a keyword.
+  const lineStart = blanked.lastIndexOf('\n', kw.index) + 1;
+  const modifiers = blanked.slice(lineStart, kw.index);
+
+  const extendsMatch = /\bextends\s+([\w.]+)/i.exec(head);
+  const implementsMatch = /\bimplements\s+([\s\S]+)$/i.exec(head);
+  const implementsList = implementsMatch
+    ? implementsMatch[1].split(',').map(s => s.trim()).filter(Boolean)
+    : [];
+
+  return {
+    kind: kw[1] as 'class' | 'interface',
+    name: kw[2],
+    extends: extendsMatch?.[1],
+    implements: implementsList,
+    isAbstract: /\babstract\b/i.test(modifiers),
+    isFinal: /\bfinal\b/i.test(modifiers),
+  };
 }
 
 /**

--- a/tests/metadata/xmlParser-class-inheritance.test.ts
+++ b/tests/metadata/xmlParser-class-inheritance.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Class inheritance extraction from the Declaration CDATA.
+ *
+ * Regression (#688): parseClassFile read inheritance from <Extends>,
+ * <Implements>, <IsAbstract> and <IsFinal> XML elements. No AxClass file has
+ * any of them — the clause exists only as X++ text in <SourceCode><Declaration>
+ * — so extends_class/implements_interfaces were NULL for every class in the
+ * index, and isAbstract/isFinal false for every class. Everything keyed on
+ * those columns (find_references extends/implements, resolve_references'
+ * inheritance walk, class rendering) silently returned nothing.
+ *
+ * The same element-reading bug applied to Ax*Extension files, leaving
+ * base_object_name empty for every extension_metadata row.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppMetadataParser } from '../../src/metadata/xmlParser';
+import { parseXppClassHeader } from '../../src/metadata/xppDeclaration';
+
+let tmpDir: string;
+
+const writeClass = async (name: string, declaration: string) => {
+  const xml = [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">',
+    `  <Name>${name}</Name>`,
+    '  <SourceCode>',
+    `    <Declaration><![CDATA[${declaration}]]></Declaration>`,
+    '  </SourceCode>',
+    '</AxClass>',
+  ].join('\n');
+  const file = path.join(tmpDir, `${name}.xml`);
+  await fs.writeFile(file, xml, 'utf-8');
+  return file;
+};
+
+const writeExtension = async (rootTag: string, name: string, declaration?: string) => {
+  const xml = [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    `<${rootTag} xmlns:i="http://www.w3.org/2001/XMLSchema-instance">`,
+    `  <Name>${name}</Name>`,
+    ...(declaration
+      ? ['  <SourceCode>', `    <Declaration><![CDATA[${declaration}]]></Declaration>`, '  </SourceCode>']
+      : []),
+    `</${rootTag}>`,
+  ].join('\n');
+  const file = path.join(tmpDir, `${name}.xml`);
+  await fs.writeFile(file, xml, 'utf-8');
+  return file;
+};
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xpp-class-inherit-'));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('parseXppClassHeader', () => {
+  it('reads extends and implements off the class header', () => {
+    const h = parseXppClassHeader('class Foo extends Bar implements IBaz\n{\n}');
+    expect(h).toMatchObject({ kind: 'class', name: 'Foo', extends: 'Bar', implements: ['IBaz'] });
+  });
+
+  it('reads an implements list that wraps across lines', () => {
+    // ~17% of real implements lists are multi-line; a line-bounded regex drops them.
+    const h = parseXppClassHeader(
+      'class Handler implements\n    IFirstHandler,\n    ISecondHandler,\n    IThirdHandler\n{\n}',
+    );
+    expect(h?.implements).toEqual(['IFirstHandler', 'ISecondHandler', 'IThirdHandler']);
+  });
+
+  it('ignores "extends" mentioned in a doc comment above the class', () => {
+    // A regex over the raw CDATA harvests `extends the` here.
+    const h = parseXppClassHeader(
+      '/// <summary>\n/// This class extends the accounting distribution rule.\n/// </summary>\nclass AccDistRule extends AccountingDistributionRule\n{\n}',
+    );
+    expect(h?.extends).toBe('AccountingDistributionRule');
+  });
+
+  it('does not treat a commented-out implements clause as real', () => {
+    const h = parseXppClassHeader('// class Old implements IGone\nclass New extends Base\n{\n}');
+    expect(h?.name).toBe('New');
+    expect(h?.implements).toEqual([]);
+  });
+
+  it('reads abstract and final off the class line, not the body', () => {
+    const abstract = parseXppClassHeader('[Attr]\nabstract class A extends B\n{\n    final void m() {}\n}');
+    expect(abstract).toMatchObject({ isAbstract: true, isFinal: false });
+
+    const final = parseXppClassHeader('public final class C\n{\n}');
+    expect(final).toMatchObject({ isAbstract: false, isFinal: true });
+  });
+
+  it('does not mistake an attribute name for a modifier', () => {
+    const h = parseXppClassHeader('[FinalizeAttribute]\nclass D\n{\n}');
+    expect(h?.isFinal).toBe(false);
+  });
+
+  it('survives an attribute string containing braces', () => {
+    const h = parseXppClassHeader('[SysObsolete("use {0} instead")]\nclass E extends F\n{\n}');
+    expect(h?.extends).toBe('F');
+  });
+
+  it('handles interfaces and namespaced base types', () => {
+    expect(parseXppClassHeader('interface IThing\n{\n}')).toMatchObject({ kind: 'interface', name: 'IThing' });
+    expect(parseXppClassHeader('class G extends Microsoft.Dynamics.Foo\n{\n}')?.extends)
+      .toBe('Microsoft.Dynamics.Foo');
+  });
+
+  it('returns null when there is no class header', () => {
+    expect(parseXppClassHeader('')).toBeNull();
+    expect(parseXppClassHeader('// just a comment')).toBeNull();
+  });
+});
+
+describe('parseClassFile inheritance', () => {
+  it('populates extends/implements/isFinal from the Declaration CDATA', async () => {
+    const file = await writeClass(
+      'PurchFormLetter_Invoice',
+      '\n[SysOperationJournaledParametersAttribute(true)]\nfinal class PurchFormLetter_Invoice extends PurchFormLetter implements BatchRetryable\n{\n    str packed;\n}\n',
+    );
+    const result = await new XppMetadataParser().parseClassFile(file, 'ApplicationSuite');
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      name: 'PurchFormLetter_Invoice',
+      extends: 'PurchFormLetter',
+      implements: ['BatchRetryable'],
+      isFinal: true,
+      isAbstract: false,
+    });
+    expect(result.data?.declaration)
+      .toBe('final class PurchFormLetter_Invoice extends PurchFormLetter implements BatchRetryable');
+  });
+
+  it('still parses when Declaration carries an attribute (xml2js yields an object, not a string)', async () => {
+    const xml = [
+      '<?xml version="1.0" encoding="utf-8"?>',
+      '<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">',
+      '  <Name>Attributed</Name>',
+      '  <SourceCode>',
+      '    <Declaration xml:space="preserve"><![CDATA[class Attributed extends Base\n{\n}]]></Declaration>',
+      '  </SourceCode>',
+      '</AxClass>',
+    ].join('\n');
+    const file = path.join(tmpDir, 'Attributed.xml');
+    await fs.writeFile(file, xml, 'utf-8');
+
+    const result = await new XppMetadataParser().parseClassFile(file, 'M');
+    expect(result.success).toBe(true);
+    expect(result.data?.extends).toBe('Base');
+  });
+
+  it('leaves extends undefined for a base class that extends nothing', async () => {
+    const file = await writeClass('Standalone', 'class Standalone\n{\n}');
+    const result = await new XppMetadataParser().parseClassFile(file, 'M');
+
+    expect(result.data?.extends).toBeUndefined();
+    expect(result.data?.implements).toEqual([]);
+  });
+});
+
+describe('parseExtensionFile base object', () => {
+  it('reads the base object from the ExtensionOf attribute', async () => {
+    const file = await writeExtension(
+      'AxClassExtension',
+      'SalesTable_Extension',
+      '[ExtensionOf(classStr(SalesTableType))]\nfinal class SalesTable_Extension\n{\n}',
+    );
+    const result = await new XppMetadataParser().parseExtensionFile(file, 'class-extension');
+    expect(result.data?.baseObjectName).toBe('SalesTableType');
+  });
+
+  it('reads the base object from the name convention for a table extension', async () => {
+    // Real AxTableExtension XML has no <Extends> and no declaration at all.
+    const file = await writeExtension('AxTableExtension', 'AccountingDistributionTmpTax.ApplicationSuite_Extension');
+    const result = await new XppMetadataParser().parseExtensionFile(file, 'table-extension');
+    expect(result.data?.baseObjectName).toBe('AccountingDistributionTmpTax');
+  });
+
+  it('splits the name on the first dot when the suffix contains dots', async () => {
+    const file = await writeExtension('AxTableExtension', 'OMLegalEntity.Extension.Retail');
+    const result = await new XppMetadataParser().parseExtensionFile(file, 'table-extension');
+    expect(result.data?.baseObjectName).toBe('OMLegalEntity');
+  });
+
+  it('reads the base object for a form extension', async () => {
+    const file = await writeExtension('AxFormExtension', 'AccountingDistribution.SubBillDeferralExtension');
+    const result = await new XppMetadataParser().parseExtensionFile(file, 'form-extension');
+    expect(result.data?.baseObjectName).toBe('AccountingDistribution');
+  });
+});


### PR DESCRIPTION
Fixes the parser half of #688, plus the same bug in `parseExtensionFile` that the issue didn't cover but that hits the same resolver function.

## What was broken

`parseClassFile` read inheritance from `<Extends>`, `<Implements>`, `<IsAbstract>` and `<IsFinal>` XML elements. **No AxClass file has any of them** — the clause exists only as X++ text inside `<SourceCode><Declaration>`. Verified against a freshly built index: `extends_class` and `implements_interfaces` are NULL for all **59,285** classes, and no row of any symbol type has `extends_class` set.

`parseExtensionFile` had the same element-reading bug (`root.Extends || root.BaseObject`, neither of which exists in `AxTableExtension` XML). Its `ExtensionOf` CDATA fallback was gated on `extensionType === 'class-extension'`, so `base_object_name` is empty for all **3,134** `extension_metadata` rows.

## Why this is worse than a no-bridge fallback gap

The issue frames this as no-bridge fidelity. But `resolveReferences.ts` has **no bridge path at all** — it's DB-only, so its inheritance walk was broken *unconditionally*. It backs `validate_code` and, via `gateOnReferenceErrors`, the write gate for `create_d365fo_file` / `modify_d365fo_file`.

Reproduced against a real class pair from the index (`InterCompanyUpdateRemPhys extends InterCompanyUpdate`, `parmBuffer` defined on the base):

```
InterCompanyUpdateRemPhys::parmBuffer(buf)
→ [error] unknown-static-member: Static method "parmBuffer" not found on
  InterCompanyUpdateRemPhys (checked inheritance chain and extensions).
```

Control case (calling the method on the base, where it's declared) resolves clean. So legitimate X++ got a severity-`error` — and the message claims it checked the inheritance chain and extensions, which it structurally could not. Of the three lookup paths in `findMethod`, only direct methods worked; inheritance (`extends_class`) and extension methods (`base_object_name`) were both dead. Same for `fieldExists` and table-extension fields — which is why the extension fix belongs in this PR rather than a separate one.

## Approach

Inheritance now goes through a shared `parseXppClassHeader` in `xppDeclaration.ts`, reusing the `blankCommentsAndStrings` primitive added in #687 for the same underlying lesson. The issue's suggested regexes are **not** what landed — measured against the real AOT, they're wrong in two ways:

- **Multi-line headers.** ~17% of implements lists wrap across lines, so the header is closed by the body's `{`, never by end-of-line. Exactly the #687 trap.
- **Comment poisoning.** Doc comments say `/// This class extends the ...`, so a regex over the raw CDATA harvests `extends the` — ~0.4% of classes (~240 rows at full scale) would get values like `"the"` and `"class"`. That's *worse* than NULL: the fallback queries would return silently wrong answers instead of nothing.

Extension base objects are read from `[ExtensionOf(<kind>Str(Base))]` for any intrinsic, then from the `Base.<Suffix>` name convention that all 3,134 extension names follow (split on the **first** dot — the suffix may contain dots, e.g. `OMLegalEntity.Extension.Retail`).

## Validation

Against the real AOT, not just fixtures:

| | before | after |
|---|---|---|
| AxClass parsed (800 random) | — | 800/800, 0 name mismatches, 0 garbage values |
| classes with `extends` | 0 | 52.6% (matches a 5,862-file baseline of 52.7%) |
| classes with `implements` | 0 | 15.3% |
| `isFinal` | false everywhere | 43% |
| extension files with base object (60 random) | 0/3,134 | 60/60, all resolving to a real indexed object |

Full suite green (1,645 tests). 16 new tests; **13 of them fail against the old code**.

## Why it survived this long

The seam was untested. `resolve-references.test.ts` injects `extendsClass` into the index by hand, so the inheritance walk was proven to work — while the parser that fills that column never did. Both sides green, the join between them untested. The new tests pin the parser's contract.

## Notes for the maintainer

- **Requires a reindex** (`npm run index-metadata`) to backfill the class rows. A cheaper alternative to rebuilding the 2 GB DB is a targeted `UPDATE` backfill over the 59,285 class `file_path`s — worth it if the rebuild is disruptive. Note 1,343 class rows carry relative paths and need `CUSTOM_MODELS_PATH` resolution.
- **Does not fix `find_coc_extensions`.** There are zero `class-extension` rows in `symbols` *and* in `extension_metadata`, so both of its branches return nothing regardless of `extends_class`. That's an extraction-side gap, filed separately as #693: class extensions are ordinary AxClass files carrying [ExtensionOf(...)], and extraction scans an AxClassExtension folder the AOT does not have — so ~4,545 class extensions are never indexed as extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

