### PR TITLE
docs(extract): drop an issue reference that points at the wrong PR

### DIFF
--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -187,7 +187,7 @@ interface AotExtractor {
  * This is the single source of truth for both the extraction work and the progress
  * denominator (EXTRACTED_AOT_DIRS is derived from it), so the two cannot drift apart.
  * They previously did: only 9 folders were counted while ~36 were extracted, which put
- * progress past 100% (#694).
+ * progress past 100%.
  *
  * No AxClassExtension: the AOT has no such folder. Class extensions are AxClass files
  * carrying [ExtensionOf(...)], and extractClasses emits their records (#693).
@@ -253,7 +253,7 @@ const MODEL_MARKER_DIRS = ['AxClass', 'AxTable', 'AxEnum', 'AxEdt', 'AxView', 'A
  * Reading the directory once and matching case-insensitively is what keeps a folder
  * from resolving twice: probing 'AxClass' and then an 'axclass' twin hits the same
  * directory on case-insensitive filesystems, which double-counted every folder on
- * Windows and made extractViews parse each view file twice (#694).
+ * Windows and made extractViews parse each view file twice.
  */
 export async function mapModelDirs(modelPath: string): Promise<Map<string, string>> {
   const byLowerName = new Map<string, string>();
@@ -575,7 +575,7 @@ async function extractMetadata() {
 
     // Resolve the model's folders once, then run every extractor whose folders exist.
     // AOT_EXTRACTORS is the same list countModelXmlFiles counted, so the numerator and
-    // the denominator cover exactly the same folders (#694).
+    // the denominator cover exactly the same folders.
     const ctx: ModelContext = { parser, modelName, stats, isCustom };
     const dirsByLowerName = await mapModelDirs(modelPath);
 

--- a/tests/utils/extractMetadataDirs.test.ts
+++ b/tests/utils/extractMetadataDirs.test.ts
@@ -1,5 +1,5 @@
 /**
- * extract-metadata folder resolution tests (#694 — progress percentage over 100%)
+ * extract-metadata folder resolution tests (extraction progress percentage over 100%)
  *
  * The extraction progress denominator used to be counted from a hand-written list of
  * 9 folders paired with lowercase twins ('AxClass', 'axclass', …), while the extractors
@@ -71,7 +71,7 @@ describe('EXTRACTED_AOT_DIRS', () => {
       'AxClass', 'AxTable', 'AxForm', 'AxQuery', 'AxView',
       'AxDataEntityView', 'AxEnum', 'AxEdt', 'AxReport',
     ]));
-    // Everything below incremented the numerator with no matching denominator (#694).
+    // Everything below incremented the numerator with no matching denominator.
     expect(EXTRACTED_AOT_DIRS).toEqual(expect.arrayContaining([
       'AxTableExtension', 'AxFormExtension', 'AxMapExtension',
       'AxSecurityPrivilege', 'AxSecurityDuty', 'AxSecurityRole',


### PR DESCRIPTION
The folder-resolution comments cited (#694) for the progress-percentage bug, but #694 is the merged PR that indexed class extensions from [ExtensionOf]. No issue tracks the progress bug, so the number is dropped rather than corrected; the surrounding text already describes what the bug was. The (#693) references are left as they are — they are about class extensions and point at the right issue.