### PR TITLE
fix(security): report unknown OLS coverage instead of omitting the section

### DIFF
--- a/src/tools/securityCoverageInfo.ts
+++ b/src/tools/securityCoverageInfo.ts
@@ -24,6 +24,28 @@ function candidateTypes(objectType: string): string[] {
   return [objectType];
 }
 
+/**
+ * Rendered instead of silence when no OLS policies can be found AND none are
+ * indexed at all — an XDS-constrained table would otherwise look identical to an
+ * unconstrained one, turning a security question into a false negative (#690).
+ */
+const OLS_UNKNOWN =
+  `Row-level security (OLS): ⚠️ unknown — AxSecurityPolicy objects are not indexed in this database.\n` +
+  `  This is NOT the same as "no row-level security": a policy constraining this table would not be visible here.\n` +
+  `  Rebuild the metadata database with a current extractor to index security policies.\n\n`;
+
+/**
+ * Whether the security_policies table holds any row at all.
+ *
+ * `LIMIT 1` with no WHERE stops at the first row, so this reads a single page
+ * and cannot degrade into the kind of scan #686 documents — it stays O(1)
+ * regardless of how many policies are indexed. Throws when the table is absent;
+ * callers treat that the same as empty.
+ */
+function policiesIndexed(db: { prepare(sql: string): { get(...p: unknown[]): unknown } }): boolean {
+  return db.prepare('SELECT 1 FROM security_policies LIMIT 1').get() !== undefined;
+}
+
 export async function securityCoverageInfoTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = SecurityCoverageInfoArgsSchema.parse(request.params.arguments);
@@ -66,10 +88,14 @@ export async function securityCoverageInfoTool(request: CallToolRequest, context
             olsSection += '\n';
           }
           olsSection += '\n';
+        } else if (!policiesIndexed(db)) {
+          olsSection += OLS_UNKNOWN;
         }
       } catch (e) {
-        // security_policies table may not exist in older databases — non-fatal
+        // security_policies missing entirely (databases built before the
+        // extractor landed) — same unknown as an empty table, not "none".
         if (process.env.DEBUG_LOGGING === 'true') console.warn('[securityCoverageInfo] security_policies query failed:', e);
+        olsSection += OLS_UNKNOWN;
       }
     }
 

--- a/tests/tools/security-coverage-ols.test.ts
+++ b/tests/tools/security-coverage-ols.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression: get_security_coverage_for_object must not answer "no row-level
+ * security" when it simply has no OLS data (#690).
+ *
+ * The OLS section used to render only when the security_policies query returned
+ * rows, so a database whose security_policies table is empty (any DB assembled
+ * from a prebuilt standard-model database built before the AxSecurityPolicy
+ * extractor landed) made an XDS-constrained table look exactly like an
+ * unconstrained one — a silent false negative on a security question.
+ *
+ * The distinction under test is "no policies for THIS table" (honest none) vs
+ * "no policies indexed at all" (unknown).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { securityCoverageInfoTool } from '../../src/tools/securityCoverageInfo';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'get_security_coverage_for_object', arguments: args },
+});
+
+const textOf = (r: any) => r.content.map((c: any) => c.text).join('\n');
+
+/**
+ * Route mock query results by a substring of the SQL text (see
+ * new-object-info.test.ts). `throws` simulates a table absent from the schema.
+ *
+ * Both security_policies statements share the table name, so they are routed on
+ * disjoint substrings: 'WHERE primary_table' for the lookup, 'SELECT 1 FROM
+ * security_policies' for the emptiness probe.
+ */
+type Route = { match: string; get?: any; all?: any[]; throws?: boolean };
+const routedDb = (routes: Route[]) => ({
+  prepare: vi.fn((sql: string) => {
+    const r = routes.find(rt => sql.includes(rt.match));
+    if (r?.throws) throw new Error('no such table: security_policies');
+    return {
+      get: vi.fn(() => r?.get),
+      all: vi.fn(() => r?.all ?? []),
+      run: vi.fn(() => ({ changes: 0 })),
+    };
+  }),
+});
+
+const ctx = (db: any): XppServerContext =>
+  ({ symbolIndex: { getReadDb: vi.fn(() => db) } } as any);
+
+/** The table exists in the symbol index; symbolLookup reads it via all(). */
+const CUST_TABLE: Route = {
+  match: 'FROM symbols s',
+  all: [{ name: 'CustTable', type: 'table', model: 'Foundation', extends_class: null, file_path: '/CustTable.xml' }],
+};
+
+const POLICY_ROW = {
+  policy_name: 'CustTablePolicy', query_name: 'CustTableQuery',
+  operation: 'AllOperations', constrained_table: 1, label: '@SYS1',
+};
+
+describe('security coverage OLS section (#690)', () => {
+  it('flags OLS as unknown when no policies are indexed at all', async () => {
+    const db = routedDb([
+      CUST_TABLE,
+      { match: 'WHERE primary_table', all: [] },
+      { match: 'SELECT 1 FROM security_policies', get: undefined }, // table empty
+    ]);
+    const r: any = await securityCoverageInfoTool(req({ objectName: 'CustTable', objectType: 'table' }), ctx(db));
+
+    const text = textOf(r);
+    expect(text).toContain('unknown');
+    expect(text).toContain('not indexed');
+    // The caveat must actively deny the "none" reading a silent omission implied.
+    expect(text).toContain('NOT the same as "no row-level security"');
+  });
+
+  it('stays silent about OLS when policies ARE indexed but none constrain this table', async () => {
+    const db = routedDb([
+      CUST_TABLE,
+      { match: 'WHERE primary_table', all: [] },
+      { match: 'SELECT 1 FROM security_policies', get: { 1: 1 } }, // table populated
+    ]);
+    const r: any = await securityCoverageInfoTool(req({ objectName: 'CustTable', objectType: 'table' }), ctx(db));
+
+    // "No policies for this table" is a real answer — it must not be muddied
+    // by an unknown-coverage caveat.
+    expect(textOf(r)).not.toContain('unknown');
+    expect(textOf(r)).not.toContain('not indexed');
+  });
+
+  it('flags OLS as unknown when the security_policies table is absent (older database)', async () => {
+    const db = routedDb([
+      CUST_TABLE,
+      { match: 'security_policies', throws: true },
+    ]);
+    const r: any = await securityCoverageInfoTool(req({ objectName: 'CustTable', objectType: 'table' }), ctx(db));
+
+    expect(r.isError).toBeFalsy();
+    expect(textOf(r)).toContain('unknown');
+  });
+
+  it('still renders constraining policies when they are indexed', async () => {
+    const db = routedDb([
+      CUST_TABLE,
+      { match: 'WHERE primary_table', all: [POLICY_ROW] },
+      { match: 'SELECT 1 FROM security_policies', get: { 1: 1 } },
+    ]);
+    const r: any = await securityCoverageInfoTool(req({ objectName: 'CustTable', objectType: 'table' }), ctx(db));
+
+    const text = textOf(r);
+    expect(text).toContain('CustTablePolicy');
+    expect(text).toContain('CustTableQuery');
+    expect(text).not.toContain('not indexed');
+  });
+
+  it('does not probe OLS for an object type that cannot carry a policy', async () => {
+    const db = routedDb([
+      { match: 'FROM symbols s', all: [{ name: 'CustPost', type: 'class', model: 'Foundation', extends_class: null, file_path: '/CustPost.xml' }] },
+      { match: 'SELECT 1 FROM security_policies', get: undefined },
+    ]);
+    const r: any = await securityCoverageInfoTool(req({ objectName: 'CustPost', objectType: 'class' }), ctx(db));
+
+    // OLS applies to tables; an unknown-coverage caveat on a class is noise.
+    expect(textOf(r)).not.toContain('not indexed');
+  });
+});


### PR DESCRIPTION
Fixes #690.

## Problem

`security_coverage_info` rendered its row-level security (OLS) section only when the `security_policies` query returned rows. When that table is unpopulated the section was **omitted entirely** — so an XDS-constrained table looked exactly like a table with no row-level security. The tool answered a security question with a silent false negative rather than a caveat.

The extraction pipeline supports `AxSecurityPolicy` end to end, but a database assembled from a **prebuilt standard-model database** built before those extractors landed (`1e4d18e`, 2026-06-13) has `security_policies` empty while the objects exist on disk.

## Fix (part 1 of the issue)

Distinguish *"no policies constrain this table"* (an honest none) from *"no policies indexed at all"* (an unknown), and say so:

```
Row-level security (OLS): ⚠️ unknown — AxSecurityPolicy objects are not indexed in this database.
  This is NOT the same as "no row-level security": a policy constraining this table would not be visible here.
  Rebuild the metadata database with a current extractor to index security policies.
```

A `security_policies` table missing entirely (older databases) now takes the same caveat path instead of the silent one — it is the same unknown, and the old `try/catch` only kept it from crashing.

This converts a silent false negative into a known unknown. **Part 2 of the issue — republishing the prebuilt standard-model DB with a current extractor — is not addressed here** and remains open.

## Performance

The probe is `SELECT 1 FROM security_policies LIMIT 1`. `LIMIT` short-circuits after one row, so it stays O(1) regardless of how many policies are indexed — it cannot degrade into the kind of full scan #686 documents. Measured against the real 2 GB production DB: **0.04 ms/call** (1000 calls incl. `prepare()` in 41 ms).

## Verification

- Real 2 GB production DB (121 policies indexed): `CustTable` still renders its real constraining policy (`RetailCustomer` via `RetailXDSCustomer`) with **no** caveat — the populated path is unaffected.
- Real production schema with `security_policies` empty (a fresh `XppSymbolIndex`, i.e. the exact issue condition): renders the caveat.
- New `tests/tools/security-coverage-ols.test.ts` — 5 cases. The 2 targeting the bug fail without the fix; the 3 guards (populated-but-no-match stays silent, policies still render, no caveat for a class) hold either way.
- Full suite: 1690 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)