### PR TITLE
fix(get_method): render the AOT's method casing, not the caller's

### DIFF
--- a/src/metadata/xppDeclaration.ts
+++ b/src/metadata/xppDeclaration.ts
@@ -17,6 +17,12 @@
  */
 
 export interface XppDeclaration {
+  /**
+   * The method name as spelled in the source. X++ identifiers are
+   * case-insensitive, so a caller's `CONSTRUCT` locates the declaration of
+   * `construct` — callers that render a name should prefer this one (#691).
+   */
+  name: string;
   modifiers: string[];
   returnType: string;
   parameters: XppDeclarationParameter[];
@@ -170,7 +176,7 @@ function parseParameter(raw: string, blanked: string): XppDeclarationParameter |
  * Try to read a declaration whose name starts at `nameStart`. Returns null when
  * this occurrence is a call rather than a declaration, or is malformed.
  */
-function tryDeclarationAt(source: string, blanked: string, nameStart: number): XppDeclaration | null {
+function tryDeclarationAt(source: string, blanked: string, nameStart: number, name: string): XppDeclaration | null {
   const openParen = blanked.indexOf('(', nameStart);
   if (openParen < 0) return null;
 
@@ -231,7 +237,7 @@ function tryDeclarationAt(source: string, blanked: string, nameStart: number): X
     }
   }
 
-  return { modifiers, returnType, parameters };
+  return { name, modifiers, returnType, parameters };
 }
 
 /**
@@ -333,6 +339,9 @@ export function callsNext(source: string): boolean {
 /**
  * Locate and parse the declaration of `methodName` in X++ source.
  * Returns null when no trustworthy declaration is found.
+ *
+ * The match is case-insensitive (X++ identifiers are), so the returned `name` is
+ * the source's spelling and may differ in case from `methodName`.
  */
 export function parseXppDeclaration(source: string, methodName: string): XppDeclaration | null {
   if (!source || !methodName) return null;
@@ -347,7 +356,9 @@ export function parseXppDeclaration(source: string, methodName: string): XppDecl
   // call appearing before the declaration can't shadow it.
   const nameRe = new RegExp(`(^|[^\\w.:])(${escapeRegExp(methodName)})\\s*\\(`, 'gi');
   for (const m of blanked.matchAll(nameRe)) {
-    const decl = tryDeclarationAt(source, blanked, m.index + m[1].length);
+    // m[2] is taken from the blanked copy, which leaves identifiers in code
+    // untouched — so it is the verbatim source spelling of the name.
+    const decl = tryDeclarationAt(source, blanked, m.index + m[1].length, m[2]);
     if (decl) return decl;
   }
   return null;

--- a/src/tools/getMethodSource.ts
+++ b/src/tools/getMethodSource.ts
@@ -153,8 +153,12 @@ async function tryXmlMethodSource(
       ? `\n\n> ⚠️ **This method is marked obsolete.** Do NOT generate calls to it.\n> Replacement hint from the attribute: _"${obsoleteMatch[1]}"_\n> Read the hint above and use the stated replacement instead.`
       : '';
 
+    // `method.name` is the AOT's own spelling; the find above is
+    // case-insensitive, so echoing `methodName` would print the caller's casing
+    // for a member that doesn't exist under it (#691). The bridge path already
+    // renders the authoritative `ms.methodName`.
     const text =
-      `## ${className}.${methodName}\n\n` +
+      `## ${className}.${method.name}\n\n` +
       `_Source: XML file parsing (bridge unavailable)_\n` +
       obsoleteWarning +
       `\n\`\`\`xpp\n${method.source}\n\`\`\``;

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -118,10 +118,12 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
     );
     if (xmlSignature) return xmlSignature;
 
-    // Last resort: use SQLite signature column if available
+    // Last resort: use SQLite signature column if available. No declaration is
+    // parsed on this path, so the index's own `name` is the canonical spelling
+    // to render rather than the caller's argument (#691).
     if ((methodRow as any)?.signature) {
       const sigText = (methodRow as any).signature as string;
-      let output = `# Method: \`${className}.${methodName}\`\n`;
+      let output = `# Method: \`${className}.${(methodRow as any).name ?? methodName}\`\n`;
       output += `**Model:** ${classRow.model}\n`;
       output += `_Source: SQLite index (signature only — bridge and XML unavailable)_\n\n`;
       output += `\`\`\`xpp\n${sigText}\n\`\`\`\n`;
@@ -201,7 +203,7 @@ async function tryBridgeMethodSignature(
     if (!signature) return null;
 
     const obsoleteWarning = detectObsolete(ms.source);
-    const result = formatOutput(className, methodName, signature, modelName, includeCoc, obsoleteWarning);
+    const result = formatOutput(className, signature, modelName, includeCoc, obsoleteWarning);
     return result;
   } catch (e) {
     console.error(`[methodSignature] Bridge getMethodSource(${className}, ${methodName}) failed: ${e}`);
@@ -241,7 +243,7 @@ async function tryXmlMethodSignature(
     if (!signature) return null;
 
     const obsoleteWarning = detectObsolete(method.source);
-    const result = formatOutput(className, methodName, signature, modelName, includeCoc, obsoleteWarning);
+    const result = formatOutput(className, signature, modelName, includeCoc, obsoleteWarning);
     return result;
   } catch (e) {
     console.error(`[methodSignature] XML parse for ${className}.${methodName} failed: ${e}`);
@@ -278,15 +280,19 @@ export function parseMethodSignature(source: string, methodName: string): Method
   const decl = parseXppDeclaration(source, methodName);
   if (!decl) return null;
 
-  const { modifiers, returnType, parameters } = decl;
+  // Render the declaration's own spelling, never the caller's argument: the
+  // lookup path is case-insensitive end to end, so `methodName` may be
+  // mis-cased. Echoing it would emit a `next CONSTRUCT(...)` CoC template and a
+  // header naming a member that doesn't exist in the AOT with that spelling (#691).
+  const { name, modifiers, returnType, parameters } = decl;
 
   return {
     modifiers,
     returnType,
-    methodName,
+    methodName: name,
     parameters,
-    signature: buildSignatureString(modifiers, returnType, methodName, parameters),
-    cocTemplate: buildCoCTemplate(modifiers, returnType, methodName, parameters),
+    signature: buildSignatureString(modifiers, returnType, name, parameters),
+    cocTemplate: buildCoCTemplate(modifiers, returnType, name, parameters),
   };
 }
 
@@ -396,15 +402,19 @@ function detectObsolete(source: string): string {
   }\n> Use the stated replacement instead.`;
 }
 
+/**
+ * `signature.methodName` is the declaration's own spelling (#691) — there is
+ * deliberately no separate name parameter, so the caller's possibly mis-cased
+ * argument cannot reach the output.
+ */
 function formatOutput(
   className: string,
-  methodName: string,
   signature: MethodSignature,
   modelName: string,
   includeCocTemplate: boolean = false,
   obsoleteWarning: string = ''
 ): any {
-  let output = `# Method: \`${className}.${methodName}\`\n`;
+  let output = `# Method: \`${className}.${signature.methodName}\`\n`;
   output += `**Model:** ${modelName}  **Returns:** ${signature.returnType}  **Modifiers:** ${signature.modifiers.join(', ') || 'none'}\n`;
   if (obsoleteWarning) output += obsoleteWarning + '\n';
   output += `\n\`\`\`xpp\n${signature.signature}\n\`\`\`\n`;

--- a/tests/tools/method-case-insensitive.test.ts
+++ b/tests/tools/method-case-insensitive.test.ts
@@ -71,6 +71,18 @@ describe('get_method name resolution is case-insensitive (#686)', () => {
     expect(r.isError).toBeFalsy();
   });
 
+  it('signature: renders the indexed method casing, not the caller\'s (#691)', async () => {
+    // Bridge and parser are both absent here, so this exercises the SQLite
+    // last-resort branch — where the index's own `name` is the canonical
+    // spelling available to the header.
+    const r: any = await getMethodSignatureTool(
+      req('get_method', { className: 'whsrfcontroldata', methodName: 'PROCESSLEGACYCONTROL' }),
+      context,
+    );
+    expect(textOf(r)).toContain('WHSRFControlData.processLegacyControl');
+    expect(textOf(r)).not.toContain('PROCESSLEGACYCONTROL');
+  });
+
   it('signature: canonical casing keeps working', async () => {
     const r: any = await getMethodSignatureTool(
       req('get_method', { className: 'WHSRFControlData', methodName: 'processLegacyControl' }),

--- a/tests/tools/method-signature-parse.test.ts
+++ b/tests/tools/method-signature-parse.test.ts
@@ -189,3 +189,53 @@ describe('parseMethodSignature', () => {
     expect(sig!.cocTemplate).toContain('next setName(_name);');
   });
 });
+
+/**
+ * X++ identifiers are case-insensitive, so a mis-cased methodName still locates
+ * the declaration (#687 made the search case-insensitive). The rendered output
+ * must then report the AOT's spelling, not the caller's: a CoC template with
+ * `next CONSTRUCT(...)` compiles, but it is wrong output to hand an agent, and
+ * the header would name a member that exists under no such spelling (#691).
+ */
+describe('parseMethodSignature reports the declaration\'s own casing (#691)', () => {
+  const src = [
+    '    public static PurchFormLetter_Invoice construct(',
+    '        IdentifierName _className = classStr(FormletterService),',
+    '        SysOperationExecutionMode _executionMode = SysOperationExecutionMode::Synchronous)',
+    '    {',
+    '        return new PurchFormLetter_Invoice(_className, _executionMode);',
+    '    }',
+  ].join('\n');
+
+  it('reports the source spelling for an upper-cased request', () => {
+    const sig = parseMethodSignature(src, 'CONSTRUCT');
+    expect(sig).not.toBeNull();
+    expect(sig!.methodName).toBe('construct');
+  });
+
+  it('does not leak the caller\'s casing into the signature', () => {
+    const sig = parseMethodSignature(src, 'CONSTRUCT');
+    expect(sig!.signature).toContain('construct(');
+    expect(sig!.signature).not.toContain('CONSTRUCT');
+  });
+
+  it('does not leak the caller\'s casing into the CoC template', () => {
+    const sig = parseMethodSignature(src, 'CONSTRUCT');
+    // Both the extension method declaration and its next() call.
+    expect(sig!.cocTemplate).toContain('next construct(');
+    expect(sig!.cocTemplate).not.toContain('CONSTRUCT');
+  });
+
+  it('preserves a camelCase declaration requested in lower case', () => {
+    const sig = parseMethodSignature('public void initFromCustTable(CustTable _custTable)\n{\n}', 'initfromcusttable');
+    expect(sig).not.toBeNull();
+    expect(sig!.methodName).toBe('initFromCustTable');
+    expect(sig!.signature).toBe('public void initFromCustTable(CustTable _custTable)');
+    expect(sig!.cocTemplate).toContain('next initFromCustTable(_custTable);');
+  });
+
+  it('canonical casing is unaffected', () => {
+    const sig = parseMethodSignature(src, 'construct');
+    expect(sig!.methodName).toBe('construct');
+  });
+});


### PR DESCRIPTION
Fixes #691.

## Problem

`get_method` canonicalized the **class** name but never the **method** name, so the caller's spelling flowed straight through to the output:

```
get_method(className="purchformletter_invoice", methodName="CONSTRUCT", includeCocTemplate=true)
```
```xpp
# Method: `PurchFormLetter_Invoice.CONSTRUCT`      ← class fixed up, method not
public static PurchFormLetter_Invoice CONSTRUCT(...)
    next CONSTRUCT(_className, _methodName, _executionMode);
```

The real declaration is `construct`. X++ identifiers are case-insensitive so the template still compiles — this is wrong output, not a broken build. It matters because the consumer is an agent: `next CONSTRUCT(...)` is sloppy in a PR, and the header states a member name that exists in the AOT under no such spelling.

## Fix

The authoritative spelling is in the source that was just parsed, so carry it out of the parser: `XppDeclaration` gains `name` (as written in the source), and `parseMethodSignature` prefers it over the caller's argument — fixing the signature, the CoC template and the header at once.

Rather than leave the trap in place, `formatOutput` **drops its `methodName` parameter** and reads `signature.methodName`, so the caller's argument can no longer reach the output at all.

Two paths have no parsed declaration and are handled separately:

| Path | Authoritative source used |
|---|---|
| SQLite last resort | `methodRow.name` (canonical, already SELECTed) |
| `get_method_source` XML fallback | `method.name` from the XML |
| `get_method_source` bridge | already used `ms.methodName` — unchanged |

"Not found" errors still echo the caller's spelling: there is no authoritative name to prefer there, and repeating the request back is the point.

`xmlParser`'s two `parseXppDeclaration` call sites only read `returnType`/`modifiers`/`parameters` and get their name from the XML, so the added field is inert for them.

## Verification

Against the **real AOT** on a D365FO VM (`ApplicationSuite\Foundation\AxClass\PurchFormLetter_Invoice.xml`), which is the issue's exact repro:

| requested | before | after |
|---|---|---|
| `CONSTRUCT` | `next CONSTRUCT(...)` | `next construct(_className, _methodName, _executionMode);` |
| `Construct` | `next Construct(...)` | `next construct(...)` |
| `construct` | `next construct(...)` | `next construct(...)` |

Tests: 5 new regression cases (4 in `method-signature-parse.test.ts`, 1 tool-level in `method-case-insensitive.test.ts`). All 5 fail without the fix and pass with it; the canonical-casing guard holds either way. Full suite: 1690 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)