### PR TITLE
ci(eval-gate): install with npm ci so the gate tests the committed lock

### DIFF
--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -28,9 +28,8 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      # package-lock.json is gitignored in this repo, so use install (not ci).
       - name: Install dependencies
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
 
       - name: Type-check / build
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Dependencies
 node_modules/
-package-lock.json
 
 # Build outputs
 dist/


### PR DESCRIPTION
Found while auditing #679 (the TypeScript 7 bump). Independent of that PR — this bug predates it.

## The problem

[`eval-gate.yml`](.github/workflows/eval-gate.yml) installed dependencies with `npm install`, justified by this comment:

> `# package-lock.json is gitignored in this repo, so use install (not ci).`

**The premise is false.** `package-lock.json` is tracked — `git ls-files --error-unmatch package-lock.json` finds it. It *was* listed in `.gitignore`, but that entry was inert: `.gitignore` has no effect on files that are already tracked.

## Why it matters

Acting on that false premise, the PR gate resolved dependencies loosely, while **every other CI path uses `npm ci`**:

| Path | Install |
|---|---|
| `eval-gate.yml` (PR gate) | `npm install` ← outlier |
| `deploy.yml`, `release.yml` | `npm ci` |
| all 4 `.azure-pipelines/*` (incl. the production deploy that ships `dist/`) | `npm ci` |

So the gate guarding every PR could green-light a dependency tree different from the one that actually ships. That is exactly backwards for a regression gate — and it matters most on dependency PRs, where the lockfile *is* the change under review.

## The fix

- `npm install` → `npm ci` in the gate, and drop the stale comment.
- Remove the misleading `package-lock.json` line from `.gitignore` — the root cause of the confusion, and inert anyway.

## Verification

`npm ci --dry-run` exits 0 against the current lock, so it is in sync with `package.json` and the gate will not break on this change. The lockfile stays tracked and is confirmed no longer matched by `git check-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)