### PR TITLE
Fix symbol-index and server-mode defects from 2026-07-17 audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ bridge/D365MetadataBridge/bridge-stderr.log
 .cache/
 deployment.zip
 .claude/settings.local.json
+
+# Transient git worktrees created by Claude Code subagents
+.claude/worktrees/

--- a/docs/AUDIT_2026-07-17.md
+++ b/docs/AUDIT_2026-07-17.md
@@ -1,0 +1,171 @@
+# Audit d365fo-mcp-server — 17. 7. 2026
+
+Rozsah: statický audit celého repozitáře (src 248 souborů / ~72 000 řádků TS, skripty,
+bridge, eval korpus) + spuštění kompletní unit test suite. Audit běžel v linuxovém
+kontejneru **bez** D365FO (žádné PackagesLocalDirectory, žádný Windows/AOS, bridge exe
+nelze sestavit ani spustit) — ověření vůči reálné aplikaci proto nebylo možné; body,
+které je nutné doověřit na VM, jsou označeny **[VM]**.
+
+## Celkový verdikt
+
+Architektura je zralá a čtecí/indexační strana je robustní: 1 690 unit testů ve 120
+souborech prošlo (15 s), kód systematicky ošetřuje chyby (každý tool vrací `isError`
+místo protokolové výjimky), má dedup/loop-detekci, per-tool timeouty, operační zámky,
+retry pouze pro idempotentní čtení a promyšlený dvoufázový CI build databáze.
+
+Slabší je **zápisová/generační vrstva**: vlastní eval korpus (59 běhů, 6.–7. 7. 2026)
+klasifikuje 40 běhů jako TOOL_DEFECT a jen 9 jako PASS. Nejzávažnější třída chyb jsou
+**tichá „úspěšná" no-op selhání** (`modify-property` ohlásí úspěch, ale nic nezapíše).
+
+## 1. Index — co se indexuje a co chybí
+
+### Indexuje se (symbols DB + FTS5)
+- Symboly: class/table/form/query/view/data-entity/enum/edt/report, security
+  (privilege/duty/role), menu items (3 druhy), services, maps, config keys, license
+  codes, security policies, makra + 15 typů extensions.
+- **Zdrojové kódy metod se indexují** — sloupce `source` (celé tělo) a
+  `source_snippet` (prvních ~10 řádků) pro metody tříd, tabulek i form. FTS záměrně
+  prohledává jen `{name, type, parent_name, signature, description, tags}` (výkon);
+  fulltext nad kódem je tedy dostupný jen přes specializované dotazy
+  (`method_calls`, `api_patterns`), ne přes běžné `search`.
+- Odvozené tabulky: `table_relations`, `form_datasources`, `form_patterns` (mined),
+  `edt_metadata`, `security_*`, `menu_item_targets`, `extension_metadata`,
+  `service_operations`, `property_stats` (data-driven BP pravidla), `_index_meta`
+  (staleness timestamp).
+- Labels: separátní DB, FTS jen nad en-US (vědomé rozhodnutí, ~5× menší index).
+
+### Mezery v pokrytí
+1. **AxMenu (základní menu) se neextrahuje vůbec** — menu-extensions ano, cíle menu
+   items ano, `d365fo_file` umí menu vytvořit a `addMenuItemToMenu` do něj zapisovat,
+   ale menu nelze najít přes `search` ani přečíst přes `get_object_info` (typ `menu`
+   neexistuje). Asymetrie zápis-bez-čtení.
+2. **AxQuery je jen stub** (name + sourcePath) — struktura query (datasources, ranges)
+   není v DB; čtení spoléhá na živé XML/bridge. **[VM]** ověřit, co vrací
+   `get_object_info(query)` v `read-only` (Azure) režimu, kde živý filesystem není.
+3. **AxEnum se extrahuje jako `{raw: <xml>}`** — bez parsování; hodnoty enumu nejsou
+   v symbols DB (jméno symbolu se odvozuje z názvu souboru). Koresponduje s eval
+   nálezem „NoYes nelze najít / členové enumu neověřitelní offline".
+4. Neindexované typy: AxWorkflow* (zdůvodněno v #693 — složky prázdné), AxTile,
+   AxKPI, AxAggregateDataEntity, AxCompositeDataEntity, AxResource, AxPerspective.
+   Pro běžný vývoj marginální, ale AxTile/AxKPI se u workspace forem vyskytují.
+
+## 2. Nové nálezy (chyby nalezené tímto auditem)
+
+### 2.1 `updateSymbolIndex.ts` — chybné klíče AOT složek (bug)
+`AOT_FOLDER_TYPE_MAP` obsahuje `'axenumsextension'` a `'axedtsextension'`; skutečné
+složky jsou `AxEnumExtension`/`AxEdtExtension` (25 výskytů správného tvaru jinde
+v repu vs. tyto 2 chybné). Enum/EDT extension se tak při inkrementálním reindexu
+zaindexuje jako typ **`class`**. Navíc v mapě úplně chybí `axdataentityview` (nová
+data entita se zaindexuje jako `class`), `axquerysimpleextension`, `axviewextension`,
+`axservice`, `axmap`, `axconfigurationkey`, `axmacrodictionary` aj.
+
+### 2.2 Mazání stale řádků podle `file_path` je nespolehlivé (bug)
+Plný build ukládá u custom modelů `sourcePath` **relativní s lomítky**
+(`normalizeSourcePath` v extract-metadata), zatímco `update_symbol_index` maže
+`DELETE FROM symbols WHERE file_path = ?` s **absolutní Windows cestou**. U DB
+z CI pipeline se tedy stale řádky (např. smazané metody) nikdy neodmažou; díky
+`INSERT OR REPLACE` + unikátnímu indexu se alespoň nemnoží duplicity, ale smazané
+metody/objekty zůstávají vyhledatelné. Stejný problém má cleanup po smazání souboru
+a `undo_last_modification` → `removeSymbolsByFile`. Doporučení: normalizovat cestu
+na kanonický tvar (relativně k package rootu, `/`, lowercase) při zápisu i mazání.
+
+### 2.3 `update_symbol_index()` bez `filePath` maskuje staleness (bug)
+Refresh režim volá `touchLastIndexed()` ačkoliv SQLite index nepřeindexoval nic —
+`get_workspace_info` pak hlásí „Index is up to date", i když je DB stale.
+
+### 2.4 Write-only režim: inzerované, ale nevolatelné nástroje (bug)
+`mcpServer.ts` v listu nástrojů pro `write-only` režim propouští `ALWAYS_TOOLS`
+(`get_object_info`, `labels`, `d365fo_file`), ale runtime gate v `toolHandler.ts`
+(`SERVER_MODE === 'write-only' && !LOCAL_TOOLS.has(toolName)`) je **zablokuje** —
+`ALWAYS_TOOLS` bypass v handleru chybí. V hybridním nasazení (Azure read-only +
+lokální write-only companion) tak lokální instance odmítne i `d365fo_file`, což je
+přímo v rozporu se záměrem popsaným v komentáři `serverMode.ts`.
+
+### 2.5 Inkrementální reindex je výrazně chudší než plný build (drift)
+- tabulka: indexují se jen fields, **ne metody tabulky** (plný build je indexuje
+  včetně `source`);
+- class s `[ExtensionOf]`: nevznikne/neaktualizuje se záznam v `extension_metadata`
+  (plný build ho generuje přes class-extension record) → `prepare(mode=change)` a
+  `find_coc_extensions` nový wrapper neuvidí do dalšího full rebuildu;
+- form: neaktualizují se `form_datasources` ani `form_patterns`;
+- query/view/service/map: jen jméno.
+Minimálně by to měl tool v odpovědi přiznat („partial reindex — full data after
+build-database").
+
+### 2.6 Undo bez gitu = nevratná modifikace (scénář)
+`undo_last_modification` funguje výhradně nad git repozitářem;
+`d365fo_file(action=modify)` má `createBackup` default **false**. Na VM, kde
+PackagesLocalDirectory/custom metadata nejsou pod gitem, je špatná modifikace
+nevratná. Doporučení: detekovat ne-git prostředí a v něm defaultovat
+`createBackup=true` (nebo aspoň warning v odpovědi modify).
+
+## 3. Známé defekty potvrzené eval korpusem (write vrstva)
+
+59 běhů: 9 PASS / 40 TOOL_DEFECT / 6 VALIDATOR_GAP / 4 KNOWLEDGE_GAP; build prošel
+u 45/59, golden match jen 13/59. Opakující se vzory (viz `eval/corpus/runs/*`):
+
+1. **`modify-property` tiše hlásí úspěch bez persistence** (ReplacementKey,
+   CreatedDateTime, neznámé property names) — nejzávažnější třída; obecně
+   `d365fo_file(modify)` nevaliduje neznámé klíče v params → tiché no-opy.
+2. `add-relation` zahazuje cardinality/relationshipType; `add-data-source` linkType.
+3. Form scaffold: method stubs v top-level `AxFormDataSource` místo SourceCode
+   mirror sekce (potvrzeno u 3 patternů); `DataGroup='Overview'` bez existující
+   field group; chybějící Caption defaulty.
+4. Security duty/role create: špatné elementy (`AxSecurityRolePermissionSet` místo
+   `AxSecurityPrivilegeReference`/`AxSecurityDutyReference`).
+5. Map create nezapisuje fields/mappings; map chybí v modify enum.
+6. `add-control` neumí vložit control do prázdného Design rootu.
+7. Phantom objekty: fallback bez bridge věří symbol indexu bez ověření, že soubor
+   na disku stále existuje (po rollbacku).
+8. Labels: doporučovaná syntaxe pro legacy SYS soubory byla chybná („@SYS:@SYS…");
+   labelFileId z pomlčkového jména modelu vytvoří nerozřešitelnou referenci.
+
+Pozn.: korpus je z 6.–7. 7.; commity po tomto datu už část oprav obsahují
+(get_method casing #7899216, OLS coverage #6298acb). **[VM]** které z bodů 1–8 jsou
+ještě reprodukovatelné, je třeba přeměřit spuštěním eval případů na VM.
+
+## 4. Co je uděláno dobře (robustnost)
+
+- Startup se stub-indexem + odloženým `dbReady` (server odpovídá okamžitě, tooly
+  čekají max 55 s s informativní odpovědí — pod 60s klient timeoutem VS Code).
+- Dedup cache (60 s TTL, chyby se necachují) + koalescence souběžných identických
+  volání + loop-detekce s nápovědou po 3. opakování.
+- Per-tool timeout třídy (fast 30 s / default 120 s / heavy 600 s), unikátní interní
+  request-id proti kolizím souběžných klientů, ochrana proti mutaci dedup cache.
+- BridgeClient: retry jen pro idempotentní čtení, exponenciální backoff, restart cap
+  3×/min, health-check, korektní zabíjení potomka (SIGTERM→SIGKILL), stream error
+  handlery proti pádu celého procesu.
+- Operační zámky: in-process fronta + FS lock s owner.json a dead-PID detekcí.
+- SQLite: WAL v produkci, read-pool, bulk pragmas při buildu, schema migrace ALTERem,
+  FTS triggery, ANALYZE persistovaný do DB, RESUME checkpoint pro přerušený build.
+- FTS sanitizace vstupu + LIKE fallback s korektním `ESCAPE '\'`.
+- Staleness detekce indexu (mtime scan s capem 5 000 souborů) v get_workspace_info.
+- `uncaughtException`/`unhandledRejection` handlery; API key auth (opt-in) +
+  rate limiting; health endpoint bez drahých COUNT dotazů.
+
+## 5. Menší doporučení
+
+- `sanitizeFtsQuery`: stop-word filtr obsahuje `get/find/list/process` — hledání
+  metody, která se tak jmenuje, FTS tiše vyřadí (fallback na LIKE nastane jen při
+  FTS syntax erroru, ne při prázdných tokenech). Zvážit stop-wordy jen když zbývají
+  i jiné tokeny.
+- HTTP režim bez `API_KEY` je otevřený (jen rate-limit) — v SETUP_AZURE zdůraznit,
+  že API_KEY je pro veřejný endpoint povinný.
+- Transport timeout ukončí odpověď, ale ne běžící heavy tool (drží lock dál) —
+  zdokumentovat, případně propagovat cancel do bridge.
+- `extractEnums` neparsuje XML → nevalidní enum soubor se nepozná (uloží se raw).
+- Eval korpus: 1 záznam má nevalidní JSON escape
+  (`2026-07-07T14__L4-headerlines-document-slice__cb1b73d.json`) — improver ho
+  přeskakuje.
+
+## 6. Checklist pro ověření na VM **[VM]**
+
+1. Build C# bridge + `npm run index-metadata` nad Contoso sandboxem — počty symbolů
+   vs. statistiky extraktoru, chyby parsování.
+2. Reprodukce 2.1: vytvořit AxEnumExtension a zavolat `update_symbol_index` — ověřit
+   typ v symbols DB.
+3. Reprodukce 2.2: smazat metodu z třídy, `update_symbol_index`, hledat metodu.
+4. `get_object_info(query)` a enum members ve `read-only` režimu (bez K:\).
+5. `modify-property` na ReplacementKey — přetrvává tichý no-op?
+6. Výkon `search` na plné DB (584k+ řádků) — potvrzení, že column-filter FTS drží
+   latenci.

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { WorkspaceScanner } from './workspace/workspaceScanner.js';
 import { HybridSearch } from './workspace/hybridSearch.js';
 import { initializeDatabase } from './database/download.js';
 import { initializeConfig, getConfigManager } from './utils/configManager.js';
-import { SERVER_MODE, LOCAL_TOOLS } from './server/serverMode.js';
+import { SERVER_MODE, LOCAL_TOOLS, isToolAllowedInMode } from './server/serverMode.js';
 import { TOOL_ANNOTATIONS } from './server/toolAnnotations.js';
 import { apiKeyAuth } from './middleware/apiKeyAuth.js';
 import { setInitializeParams } from './utils/stdioSessionInfo.js';
@@ -770,11 +770,9 @@ async function main() {
       const filteredCatalog = toolCatalog
         .map(cat => ({
           ...cat,
-          tools: cat.tools.filter(t => {
-            if (SERVER_MODE === 'read-only') return !LOCAL_TOOLS.has(t.name);
-            if (SERVER_MODE === 'write-only') return LOCAL_TOOLS.has(t.name);
-            return true;
-          }),
+          // Same predicate as the ListTools filter and runtime gate, so the
+          // startup banner matches what the server actually exposes.
+          tools: cat.tools.filter(t => isToolAllowedInMode(SERVER_MODE, t.name)),
         }))
         .filter(cat => cat.tools.length > 0);
 

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -802,30 +802,63 @@ export class XppSymbolIndex {
   }
 
   /**
+   * All stored forms a file path may take in the index. Full builds store the
+   * JSON's sourcePath: CI-extracted custom models normalize it to a
+   * PackagesLocalDirectory-relative forward-slash path (see normalizeSourcePath
+   * in scripts/extract-metadata.ts), while locally built DBs keep the absolute
+   * Windows path with backslashes. Matching every form keeps stale-row cleanup
+   * working regardless of which build produced the DB.
+   */
+  private filePathForms(filePath: string): string[] {
+    const forms = new Set<string>([
+      filePath,
+      filePath.replace(/\//g, '\\'),
+      filePath.replace(/\\/g, '/'),
+    ]);
+    const m = /[/\\]PackagesLocalDirectory[/\\](.+)$/.exec(filePath);
+    if (m) {
+      const tail = m[1].replace(/\\/g, '/');
+      forms.add(tail);
+      forms.add(tail.replace(/\//g, '\\'));
+    }
+    return [...forms];
+  }
+
+  /**
    * Remove all symbols for a given file path from both the main table and FTS index.
+   * Matches every stored path form (see filePathForms) so stale rows are removed
+   * even when the DB stores a different path form than the caller passed.
    * Returns the names of top-level objects that were removed (for cache invalidation).
    */
   removeSymbolsByFile(filePath: string): { deletedCount: number; objectNames: string[] } {
+    const forms = this.filePathForms(filePath);
+    const placeholders = forms.map(() => '?').join(', ');
+
     // Collect object names BEFORE deletion (for cache invalidation)
     const rows = this.db.prepare(
-      `SELECT DISTINCT name FROM symbols WHERE file_path = ? AND parent_name IS NULL`
-    ).all(filePath) as Array<{ name: string }>;
+      `SELECT DISTINCT name FROM symbols WHERE file_path IN (${placeholders}) AND parent_name IS NULL`
+    ).all(...forms) as Array<{ name: string }>;
     const objectNames = rows.map(r => r.name);
 
     // The FTS trigger (symbols_fts AFTER DELETE) handles FTS cleanup automatically
-    const result = this.db.prepare(`DELETE FROM symbols WHERE file_path = ?`).run(filePath);
+    const result = this.db.prepare(`DELETE FROM symbols WHERE file_path IN (${placeholders})`).run(...forms);
     this.invalidateSymbolCounts();
     return { deletedCount: result.changes, objectNames };
   }
 
   /**
    * Remove all labels for a given file path from the labels DB.
+   * Matches every stored path form (see filePathForms), like removeSymbolsByFile.
    * Also cleans up the labels FTS index.
    * Returns the count of deleted label rows.
    */
   removeLabelsByFile(filePath: string): number {
+    const forms = this.filePathForms(filePath);
+    const placeholders = forms.map(() => '?').join(', ');
     // The labels_ad trigger handles FTS cleanup for en-US rows
-    const result = this.labelsDb.prepare(`DELETE FROM labels WHERE file_path = ?`).run(filePath);
+    const result = this.labelsDb.prepare(
+      `DELETE FROM labels WHERE file_path IN (${placeholders})`
+    ).run(...forms);
     return result.changes;
   }
 
@@ -866,11 +899,15 @@ export class XppSymbolIndex {
     
     // Strip FTS5 special characters – keep alphanumeric, underscore and spaces
     const cleaned = trimmed.replace(/[^\w\s]/g, ' ').trim();
-    const tokens = cleaned
+    const allTokens = cleaned
       .split(/\s+/)
-      .filter(t => t.length > 0)
       .map(t => t.toLowerCase())
-      .filter(t => !stopWords.has(t) && t.length > 1); // Filter stop words and single chars
+      .filter(t => t.length > 1); // Filter single chars
+    // Drop stop words only while a real token remains — a query may legitimately
+    // BE a stop word (e.g. a method literally named "find"), and falling through
+    // to the phrase-search fallback would behave differently for it.
+    const withoutStopWords = allTokens.filter(t => !stopWords.has(t));
+    const tokens = withoutStopWords.length > 0 ? withoutStopWords : allTokens;
     
     // If no tokens remain after filtering, use original query in quotes
     if (tokens.length === 0) {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -14,7 +14,7 @@ import { registerToolHandler } from '../tools/toolHandler.js';
 import { registerResources } from '../resources/index.js';
 import { registerCodeReviewPrompt } from '../prompts/codeReview.js';
 import type { XppServerContext } from '../types/context.js';
-import { SERVER_MODE, LOCAL_TOOLS, ALWAYS_TOOLS } from './serverMode.js';
+import { SERVER_MODE, LOCAL_TOOLS, isToolAllowedInMode } from './serverMode.js';
 import { TOOL_ANNOTATIONS } from './toolAnnotations.js';
 import { getConfigManager } from '../utils/configManager.js';
 
@@ -201,12 +201,13 @@ export function createXppMcpServer(context: XppServerContext): Server {
     })) as typeof allTools.tools;
 
     // Apply server mode filter. ALWAYS_TOOLS bypass the partition and stay
-    // published in every mode.
+    // published in every mode. isToolAllowedInMode is shared with the runtime
+    // gate in toolHandler so the list and the call-time enforcement can't drift.
     if (SERVER_MODE === 'read-only') {
-      allTools.tools = allTools.tools.filter(t => !LOCAL_TOOLS.has(t.name) || ALWAYS_TOOLS.has(t.name));
+      allTools.tools = allTools.tools.filter(t => isToolAllowedInMode(SERVER_MODE, t.name));
       console.error(`[MCP Server] Tool list filtered for read-only mode: ${allTools.tools.length} tools (local tools excluded)`);
     } else if (SERVER_MODE === 'write-only') {
-      allTools.tools = allTools.tools.filter(t => LOCAL_TOOLS.has(t.name) || ALWAYS_TOOLS.has(t.name));
+      allTools.tools = allTools.tools.filter(t => isToolAllowedInMode(SERVER_MODE, t.name));
       console.error(`[MCP Server] Tool list filtered for write-only mode: ${allTools.tools.length} tools (${Array.from(LOCAL_TOOLS).join(', ')})`);
     } else {
       console.error(`[MCP Server] Tool list in full mode: ${allTools.tools.length} tools (no filtering)`);

--- a/src/server/serverMode.ts
+++ b/src/server/serverMode.ts
@@ -68,3 +68,14 @@ export const SERVER_MODE: ServerMode = (() => {
   if (raw === 'write-only' || raw === 'writeonly') return 'write-only';
   return 'full';
 })();
+
+/**
+ * Single source of truth for whether a tool is callable in a given server mode.
+ * Used by BOTH the ListTools filter (mcpServer) and the runtime call gate
+ * (toolHandler) so the advertised tool list and call-time enforcement can
+ * never drift apart. ALWAYS_TOOLS bypass the LOCAL_TOOLS partition in every mode.
+ */
+export function isToolAllowedInMode(mode: ServerMode, toolName: string): boolean {
+  if (mode === 'full' || ALWAYS_TOOLS.has(toolName)) return true;
+  return mode === 'read-only' ? !LOCAL_TOOLS.has(toolName) : LOCAL_TOOLS.has(toolName);
+}

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -8,6 +8,8 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import * as fs from 'fs/promises';
+import { execFile } from 'child_process';
+import util from 'util';
 
 import path from 'path';
 import { parseStringPromise } from 'xml2js';
@@ -819,7 +821,7 @@ const ModifyD365FileArgsSchema = z.object({
   propertyValue: z.string().optional().describe('New property value'),
   
   // Options
-  createBackup: z.boolean().optional().default(false).describe('Create a .bak backup of the file before modifying it (default: false). Changes can also be reverted with undo_last_modification (git checkout) without a backup. Set true when the file is not under source control.'),
+  createBackup: z.boolean().optional().default(false).describe('Create a .bak backup of the file before modifying it (default: false). Changes can also be reverted with undo_last_modification (git checkout) without a backup. When the file is NOT inside a git repository, a backup is created automatically even with false, since undo_last_modification would not work there.'),
   modelName: z.string().optional().describe('Model name (auto-detected if not provided). Pass this if the file was just created and is not yet indexed.'),
   packageName: z.string().optional().describe('Package name. Auto-resolved if omitted.'),
   packagePath: z.string().optional().describe(
@@ -1121,10 +1123,11 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       throw new Error(`Cannot read file: ${filePath}${hint}`);
     }
 
-    // 3. Create backup of the actual XML file
-    if (createBackup) {
-      await createFileBackup(actualFilePath);
-    }
+    // 3. Create backup of the actual XML file. When the target is NOT inside a
+    //    git work tree, the documented undo path (undo_last_modification →
+    //    git checkout) cannot revert the change — force a backup even with
+    //    createBackup=false so a bad modify is never unrecoverable.
+    const backupNote = await ensureRecoverableModification(actualFilePath, createBackup);
 
     // 3b. Derive the authoritative object name from the resolved file path.
     //     The caller may pass objectName="RentEquipment" while the file on disk
@@ -1870,7 +1873,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
           text:
             `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
-            `🔧 API: ${bridgeResult.message}${xppLintNote}\n\n` +
+            `🔧 API: ${bridgeResult.message}${xppLintNote}${backupNote}\n\n` +
             `**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate`,
         },
       ],
@@ -2186,8 +2189,9 @@ export async function findD365FileOnDisk(
  * Create file backup and verify it was written successfully.
  * Throws if the source file is missing or the copy fails, so callers
  * always know whether a valid backup exists before overwriting.
+ * Returns the backup file path.
  */
-async function createFileBackup(filePath: string): Promise<void> {
+async function createFileBackup(filePath: string): Promise<string> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19);
   const backupPath = `${filePath}.backup-${timestamp}`;
   try {
@@ -2202,6 +2206,63 @@ async function createFileBackup(filePath: string): Promise<void> {
       `Failed to create backup at "${backupPath}": ${error instanceof Error ? error.message : String(error)}`
     );
   }
+  return backupPath;
+}
+
+const execFileAsync = util.promisify(execFile);
+
+// Directory → inside-git-work-tree result, cached for the process lifetime so
+// repeated modifies don't re-spawn git for the same metadata folder.
+const gitWorkTreeCache = new Map<string, boolean>();
+
+/**
+ * Cheap check whether a file lives inside a git work tree — i.e. whether
+ * undo_last_modification (git checkout) could revert a change to it.
+ * git not installed, timeout, or any other error → treated as "not a repo".
+ */
+async function isInsideGitWorkTree(filePath: string): Promise<boolean> {
+  const dir = path.dirname(filePath);
+  const cached = gitWorkTreeCache.get(dir);
+  if (cached !== undefined) return cached;
+  let inside = false;
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd: dir,
+      timeout: 5_000,
+      windowsHide: true,
+    });
+    inside = stdout.trim() === 'true';
+  } catch {
+    inside = false;
+  }
+  gitWorkTreeCache.set(dir, inside);
+  return inside;
+}
+
+/**
+ * Backup guard for modify operations. Honors an explicit createBackup=true;
+ * with createBackup=false it force-enables the backup when the target is not
+ * inside a git work tree, because the documented undo path
+ * (undo_last_modification → git checkout) only works inside a repo.
+ * Returns a note to append to the success response ('' when no forced backup
+ * was needed). Exported for unit tests.
+ */
+export async function ensureRecoverableModification(
+  actualFilePath: string,
+  createBackup: boolean,
+): Promise<string> {
+  if (createBackup) {
+    await createFileBackup(actualFilePath);
+    return '';
+  }
+  if (await isInsideGitWorkTree(actualFilePath)) {
+    return '';
+  }
+  const backupPath = await createFileBackup(actualFilePath);
+  return (
+    `\n\nℹ️ Target is not under git — created backup ${backupPath} automatically ` +
+    `(undo_last_modification would not work here).`
+  );
 }
 
 // ─── Form parent-control auto-resolution ────────────────────────────────────

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -2,7 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { XppServerContext } from '../types/context.js';
 import { getConfigManager } from '../utils/configManager.js';
-import { SERVER_MODE, LOCAL_TOOLS } from '../server/serverMode.js';
+import { SERVER_MODE, LOCAL_TOOLS, isToolAllowedInMode } from '../server/serverMode.js';
 import { searchUnifiedTool } from './searchUnified.js';
 import { batchGetInfoTool } from './batchGetInfo.js';
 import { getObjectInfoTool } from './getObjectInfo.js';
@@ -167,14 +167,16 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       }
     }
 
-    // Enforce server mode: block local tools in read-only (Azure) mode, block search/analysis tools in write-only mode
-    if (SERVER_MODE === 'read-only' && LOCAL_TOOLS.has(toolName)) {
+    // Enforce server mode: block local tools in read-only (Azure) mode, block search/analysis
+    // tools in write-only mode. isToolAllowedInMode is the same predicate the ListTools filter
+    // uses (ALWAYS_TOOLS included), so a tool is refused here iff it is not advertised.
+    if (SERVER_MODE === 'read-only' && !isToolAllowedInMode(SERVER_MODE, toolName)) {
       return {
         content: [{ type: 'text', text: `⚠️ Tool '${toolName}' requires local Windows VM filesystem access and is not available in read-only mode.\n\nThis MCP server is running in read-only mode (Azure deployment).\nTo use file operations and workspace diagnostics, configure a local MCP server with MCP_SERVER_MODE=write-only in your .mcp.json.\n\nSee: https://github.com/dynamics365ninja/d365fo-mcp-server/blob/main/docs/MCP_CONFIG.md` }],
         isError: true,
       };
     }
-    if (SERVER_MODE === 'write-only' && !LOCAL_TOOLS.has(toolName)) {
+    if (SERVER_MODE === 'write-only' && !isToolAllowedInMode(SERVER_MODE, toolName)) {
       return {
         content: [{ type: 'text', text: `⚠️ Tool '${toolName}' is not available in write-only mode.\n\nThis local MCP server only handles file operations. Search and analysis tools are provided by the Azure MCP server.` }],
         isError: true,

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -17,18 +17,37 @@ const AOT_FOLDER_TYPE_MAP: Record<string, XppSymbol['type']> = {
   'axform': 'form',
   'axformextension': 'form-extension',
   'axenum': 'enum',
-  'axenumsextension': 'enum-extension',
+  'axenumextension': 'enum-extension',
   'axedt': 'edt',
-  'axedtsextension': 'edt-extension',
+  'axedtextension': 'edt-extension',
   'axquery': 'query',
+  'axquerysimpleextension': 'query-extension',
   'axview': 'view',
+  'axviewextension': 'view-extension',
+  // Full builds store data entities as type 'view' (see indexViews) — keep parity.
+  'axdataentityview': 'view',
+  'axdataentityviewextension': 'data-entity-extension',
   'axreport': 'report',
+  'axmap': 'map',
+  'axmapextension': 'map-extension',
+  'axmenuextension': 'menu-extension',
+  'axservice': 'service',
+  'axservicegroup': 'service-group',
+  'axconfigurationkey': 'configuration-key',
+  'axlicensecode': 'license-code',
+  'axsecuritypolicy': 'security-policy',
+  'axmacrodictionary': 'macro',
   'axsecurityprivilege': 'security-privilege',
   'axsecurityduty': 'security-duty',
+  'axsecuritydutyextension': 'security-duty-extension',
   'axsecurityrole': 'security-role',
+  'axsecurityroleextension': 'security-role-extension',
   'axmenuitemaction': 'menu-item-action',
+  'axmenuitemactionextension': 'menu-item-action-extension',
   'axmenuitemdisplay': 'menu-item-display',
+  'axmenuitemdisplayextension': 'menu-item-display-extension',
   'axmenuitemoutput': 'menu-item-output',
+  'axmenuitemoutputextension': 'menu-item-output-extension',
 };
 
 /**
@@ -99,17 +118,20 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
       } catch (e: any) {
         bridgeNote = `Bridge refresh skipped: ${e?.message ?? e}`;
       }
-      symbolIndex.touchLastIndexed?.();
+      // Note: deliberately no touchLastIndexed() here — nothing was reindexed in
+      // SQLite, and bumping the timestamp would make get_workspace_info report a
+      // possibly stale index as fresh (see src/utils/indexStaleness.ts).
       return {
         content: [{
           type: 'text',
           text:
-            `🔄 **Index refresh** (no filePath supplied).\n\n` +
+            `🔄 **Bridge/cache refresh** (no filePath supplied).\n\n` +
             `${bridgeNote}\n` +
             `Workspace scan cache invalidated.\n\n` +
-            `ℹ️ To fully index a specific new object into the searchable symbol DB (so scaffolding ` +
-            `resolves its EDTs/enums and references work), call this tool again with \`filePath\` ` +
-            `pointing at the created \`.xml\` (e.g. the new AxEnum/AxEdt/AxTable file).`,
+            `ℹ️ The SQLite symbol index itself was NOT reindexed. To fully index a specific new ` +
+            `object into the searchable symbol DB (so scaffolding resolves its EDTs/enums and ` +
+            `references work), call this tool again with \`filePath\` pointing at the created ` +
+            `\`.xml\` (e.g. the new AxEnum/AxEdt/AxTable file).`,
         }],
       };
     }
@@ -213,11 +235,10 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
 
     console.error(`[update_symbol_index] Re-indexing ${objectType} "${objectName}" (model: ${model})`);
 
-    // 1. Remove all existing symbols for this file so stale entries don't linger
-    const deleted = symbolIndex.db
-      .prepare(`DELETE FROM symbols WHERE file_path = ?`)
-      .run(filePath);
-    const deletedCount = deleted.changes;
+    // 1. Remove all existing symbols for this file so stale entries don't linger.
+    // removeSymbolsByFile matches every stored path form (absolute Windows path
+    // or PackagesLocalDirectory-relative, either slash style) — see symbolIndex.ts.
+    const { deletedCount } = symbolIndex.removeSymbolsByFile(filePath);
 
     // 1b. Refresh C# bridge metadata provider so it picks up the updated file
     try {
@@ -301,6 +322,23 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
               signature: field.extendedDataType || field.enumType || field.type,
               filePath,
               model,
+            });
+            insertedCount++;
+          }
+          // Re-insert table methods too — the full build (indexTables) indexes
+          // them, and the delete above just removed them; skipping them here
+          // would silently drop a table's methods on every incremental reindex.
+          for (const method of tableData.methods ?? []) {
+            const params = method.parameters?.map((p: any) => `${p.type} ${p.name}`).join(', ') ?? '';
+            symbolIndex.addSymbol({
+              name: method.name,
+              type: 'method',
+              parentName: tableData.name,
+              signature: `${method.returnType} ${method.name}(${params})`,
+              filePath,
+              model,
+              source: method.source,
+              sourceSnippet: method.sourceSnippet,
             });
             insertedCount++;
           }

--- a/tests/metadata/symbolIndex-ftsStopWords.test.ts
+++ b/tests/metadata/symbolIndex-ftsStopWords.test.ts
@@ -1,0 +1,43 @@
+/**
+ * sanitizeFtsQuery stop-word handling (audit section 5).
+ *
+ * Regression: the stop-word set includes common X++ identifiers (find, get,
+ * list, process, ...). A search for a method literally named "find" had its
+ * only token dropped, and the zero-token fallback then did a phrase search of
+ * the raw string, which behaves differently. Stop words must only be dropped
+ * while at least one non-stop-word token remains.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+let index: XppSymbolIndex;
+
+beforeAll(() => {
+  index = new XppSymbolIndex(':memory:', ':memory:');
+  const sym = (name: string, type: string, parentName?: string) =>
+    index.addSymbol({ name, type, parentName, filePath: '/x.xml', model: 'Test' } as any);
+
+  sym('CustTable', 'table');
+  sym('find', 'method', 'CustTable');
+  sym('findRecord', 'method', 'CustTable');
+  sym('SalesInvoiceHeader', 'table');
+});
+
+afterAll(() => index.close());
+
+describe('searchSymbols with stop-word queries', () => {
+  it('a query that is itself a stop word still matches symbols named like it', () => {
+    const names = index.searchSymbols('find', 20).map(s => s.name);
+
+    expect(names).toContain('find');
+    expect(names).toContain('findRecord');
+  });
+
+  it('still drops stop words when a real token remains', () => {
+    // If 'find' were kept, the implicit-AND FTS query would match nothing here.
+    const names = index.searchSymbols('find SalesInvoiceHeader', 20).map(s => s.name);
+
+    expect(names).toContain('SalesInvoiceHeader');
+  });
+});

--- a/tests/metadata/symbolIndex-removeByFile.test.ts
+++ b/tests/metadata/symbolIndex-removeByFile.test.ts
@@ -1,0 +1,101 @@
+/**
+ * removeSymbolsByFile / removeLabelsByFile path-form matching (audit 2.2).
+ *
+ * Regression: full builds store symbols.file_path as the JSON's sourcePath —
+ * CI-extracted custom models normalize it to a PackagesLocalDirectory-relative
+ * forward-slash path ("Pkg/Model/AxClass/X.xml", see normalizeSourcePath in
+ * scripts/extract-metadata.ts), while locally built DBs keep the absolute
+ * Windows path with backslashes. The removal APIs compared with the exact
+ * string the caller passed (absolute Windows path), so stale rows (deleted
+ * methods, deleted files) were never removed when the stored form differed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+const ABS_X = 'K:\\AosService\\PackagesLocalDirectory\\Pkg\\Model\\AxClass\\X.xml';
+const REL_X = 'Pkg/Model/AxClass/X.xml';
+const ABS_Y = 'K:\\AosService\\PackagesLocalDirectory\\Pkg\\Model\\AxClass\\Y.xml';
+const REL_Z = 'Pkg/Model/AxClass/Z.xml';
+
+let index: XppSymbolIndex;
+
+beforeEach(() => {
+  index = new XppSymbolIndex(':memory:', ':memory:');
+  const sym = (name: string, filePath: string, parentName?: string) =>
+    index.addSymbol({
+      name,
+      type: parentName ? 'method' : 'class',
+      parentName,
+      filePath,
+      model: 'Pkg',
+    } as any);
+
+  sym('X', REL_X);              // CI build: relative forward-slash form
+  sym('doStuff', REL_X, 'X');
+  sym('Y', ABS_Y);              // local build: absolute Windows form
+  sym('Z', REL_Z);              // unrelated object — must survive
+});
+
+afterEach(() => index.close());
+
+const symbolCount = (name: string): number =>
+  (index.db.prepare(`SELECT COUNT(*) AS n FROM symbols WHERE name = ?`).get(name) as any).n;
+
+describe('removeSymbolsByFile', () => {
+  it('deletes rows stored in relative CI form when called with the absolute Windows path', () => {
+    const { deletedCount, objectNames } = index.removeSymbolsByFile(ABS_X);
+
+    expect(deletedCount).toBe(2); // class row + method row
+    expect(objectNames).toEqual(['X']);
+    expect(symbolCount('X')).toBe(0);
+    expect(symbolCount('doStuff')).toBe(0);
+  });
+
+  it('deletes rows stored in absolute form when called with the same absolute path', () => {
+    const { deletedCount, objectNames } = index.removeSymbolsByFile(ABS_Y);
+
+    expect(deletedCount).toBe(1);
+    expect(objectNames).toEqual(['Y']);
+    expect(symbolCount('Y')).toBe(0);
+  });
+
+  it('deletes rows stored in relative form when called with that relative path', () => {
+    const { deletedCount } = index.removeSymbolsByFile(REL_X);
+
+    expect(deletedCount).toBe(2);
+    expect(symbolCount('X')).toBe(0);
+  });
+
+  it('leaves unrelated rows untouched', () => {
+    index.removeSymbolsByFile(ABS_X);
+
+    expect(symbolCount('Y')).toBe(1);
+    expect(symbolCount('Z')).toBe(1);
+  });
+});
+
+describe('removeLabelsByFile', () => {
+  const REL_LABELS = 'Pkg/Model/AxLabelFile/LabelResources/en-US/PkgLabels.en-US.label.txt';
+  const ABS_LABELS = 'K:\\AosService\\PackagesLocalDirectory\\Pkg\\Model\\AxLabelFile\\LabelResources\\en-US\\PkgLabels.en-US.label.txt';
+
+  const labelCount = (labelId: string): number =>
+    (index.labelsDb.prepare(`SELECT COUNT(*) AS n FROM labels WHERE label_id = ?`).get(labelId) as any).n;
+
+  beforeEach(() => {
+    index.bulkAddLabels([
+      { labelId: 'RelStored', labelFileId: 'PkgLabels', model: 'Pkg', language: 'en-US', text: 'Rel', filePath: REL_LABELS },
+      { labelId: 'AbsStored', labelFileId: 'PkgLabels', model: 'Pkg', language: 'en-US', text: 'Abs', filePath: ABS_LABELS },
+      { labelId: 'Unrelated', labelFileId: 'OtherLabels', model: 'Pkg', language: 'en-US', text: 'Other', filePath: 'Pkg/Model/AxLabelFile/LabelResources/en-US/OtherLabels.en-US.label.txt' },
+    ]);
+  });
+
+  it('deletes labels stored in either path form when called with the absolute Windows path', () => {
+    const deleted = index.removeLabelsByFile(ABS_LABELS);
+
+    expect(deleted).toBe(2); // matches both the relative- and absolute-stored rows
+    expect(labelCount('RelStored')).toBe(0);
+    expect(labelCount('AbsStored')).toBe(0);
+    expect(labelCount('Unrelated')).toBe(1);
+  });
+});

--- a/tests/server/serverMode.test.ts
+++ b/tests/server/serverMode.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Server mode gating tests.
+ *
+ * isToolAllowedInMode is the single predicate shared by the ListTools filter
+ * (mcpServer) and the runtime call gate (toolHandler). These tests pin the
+ * contract: ALWAYS_TOOLS bypass the LOCAL_TOOLS partition in EVERY mode, so a
+ * tool advertised by the list filter can never be refused at call time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  LOCAL_TOOLS,
+  ALWAYS_TOOLS,
+  isToolAllowedInMode,
+  type ServerMode,
+} from '../../src/server/serverMode';
+
+const MODES: ServerMode[] = ['full', 'read-only', 'write-only'];
+
+describe('isToolAllowedInMode', () => {
+  it('allows everything in full mode', () => {
+    expect(isToolAllowedInMode('full', 'search')).toBe(true);
+    expect(isToolAllowedInMode('full', 'undo_last_modification')).toBe(true);
+    expect(isToolAllowedInMode('full', 'get_object_info')).toBe(true);
+  });
+
+  it('allows ALWAYS_TOOLS in every mode (regression: write-only refused get_object_info)', () => {
+    for (const mode of MODES) {
+      for (const tool of ALWAYS_TOOLS) {
+        expect(isToolAllowedInMode(mode, tool), `${tool} in ${mode}`).toBe(true);
+      }
+    }
+  });
+
+  it('write-only allows get_object_info (the originally reported defect)', () => {
+    expect(isToolAllowedInMode('write-only', 'get_object_info')).toBe(true);
+    expect(isToolAllowedInMode('write-only', 'labels')).toBe(true);
+    expect(isToolAllowedInMode('write-only', 'd365fo_file')).toBe(true);
+  });
+
+  it('write-only allows local tools and blocks search/analysis tools', () => {
+    for (const tool of LOCAL_TOOLS) {
+      expect(isToolAllowedInMode('write-only', tool), `${tool} in write-only`).toBe(true);
+    }
+    expect(isToolAllowedInMode('write-only', 'search')).toBe(false);
+    expect(isToolAllowedInMode('write-only', 'analyze_code')).toBe(false);
+  });
+
+  it('read-only blocks local tools and allows the rest', () => {
+    for (const tool of LOCAL_TOOLS) {
+      expect(isToolAllowedInMode('read-only', tool), `${tool} in read-only`).toBe(false);
+    }
+    expect(isToolAllowedInMode('read-only', 'search')).toBe(true);
+    expect(isToolAllowedInMode('read-only', 'analyze_code')).toBe(true);
+  });
+});

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -33,6 +33,9 @@ vi.mock('fs/promises', () => ({
     throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
   }),
   writeFile: vi.fn(async () => {}),
+  // Forced pre-modify backup when the target is outside a git work tree
+  // (see ensureRecoverableModification) copies the file before the bridge write.
+  copyFile: vi.fn(async () => {}),
   mkdir: vi.fn(async () => {}),
   // Drive/root paths exist; individual files do not (prevents false "file already exists" errors).
   access: vi.fn(async (p: string) => {

--- a/tests/tools/modifyD365File.backup.test.ts
+++ b/tests/tools/modifyD365File.backup.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Non-revertible-modification guard tests (d365fo_file action=modify).
+ *
+ * undo_last_modification restores files via `git checkout`, which only works
+ * when the target lives inside a git work tree. ensureRecoverableModification
+ * therefore force-enables the pre-modify backup when the file is NOT under
+ * git, so a bad modify with createBackup=false is never unrecoverable.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import util from 'util';
+import { ensureRecoverableModification } from '../../src/tools/modifyD365File';
+
+const execFileAsync = util.promisify(execFile);
+
+// Skip the git-repo cases gracefully when git is not installed (the guard
+// itself treats "git missing" as "not a repo", which the non-repo cases cover).
+const gitAvailable: boolean = await execFileAsync('git', ['--version'])
+  .then(() => true)
+  .catch(() => false);
+
+async function listBackups(filePath: string): Promise<string[]> {
+  const entries = await fs.readdir(path.dirname(filePath));
+  const prefix = `${path.basename(filePath)}.backup-`;
+  return entries.filter(e => e.startsWith(prefix));
+}
+
+describe('ensureRecoverableModification', () => {
+  let tmpDir: string;
+  let xmlFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'modify-backup-'));
+    xmlFile = path.join(tmpDir, 'AxClass', 'TestClass.xml');
+    await fs.mkdir(path.dirname(xmlFile), { recursive: true });
+    await fs.writeFile(xmlFile, '<AxClass><Name>TestClass</Name></AxClass>', 'utf-8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('file outside a git repo + createBackup=false → backup forced and note returned', async () => {
+    const note = await ensureRecoverableModification(xmlFile, false);
+
+    const backups = await listBackups(xmlFile);
+    expect(backups).toHaveLength(1);
+    expect(note).toContain('Target is not under git');
+    expect(note).toContain('undo_last_modification would not work here');
+    expect(note).toContain(backups[0]);
+  });
+
+  it('createBackup=true → backup created, no forced-backup note', async () => {
+    const note = await ensureRecoverableModification(xmlFile, true);
+
+    expect(await listBackups(xmlFile)).toHaveLength(1);
+    expect(note).toBe('');
+  });
+
+  it.skipIf(!gitAvailable)(
+    'file inside a git repo + createBackup=false → no backup, no note',
+    async () => {
+      await execFileAsync('git', ['init'], { cwd: tmpDir });
+
+      const note = await ensureRecoverableModification(xmlFile, false);
+
+      expect(await listBackups(xmlFile)).toHaveLength(0);
+      expect(note).toBe('');
+    },
+  );
+
+  it.skipIf(!gitAvailable)(
+    'git work-tree result is cached per directory (second call spawns no new decision)',
+    async () => {
+      await execFileAsync('git', ['init'], { cwd: tmpDir });
+
+      // Two modifies in the same directory: both must agree (cache returns the
+      // same verdict) and never force a backup inside a repo.
+      expect(await ensureRecoverableModification(xmlFile, false)).toBe('');
+      expect(await ensureRecoverableModification(xmlFile, false)).toBe('');
+      expect(await listBackups(xmlFile)).toHaveLength(0);
+    },
+  );
+});

--- a/tests/tools/updateSymbolIndex.test.ts
+++ b/tests/tools/updateSymbolIndex.test.ts
@@ -56,6 +56,7 @@ function createContext(db?: ReturnType<typeof createRecordingDb>['db']): XppServ
       removeSymbolsByFile: vi.fn(() => ({ deletedCount: 0, objectNames: [] })),
       removeLabelsByFile: vi.fn(() => 0),
       bulkAddLabels: vi.fn(),
+      touchLastIndexed: vi.fn(),
       db: db ?? {
         prepare: vi.fn(() => ({ run: vi.fn(() => ({ changes: 0 })) })),
         transaction: vi.fn((fn: any) => fn),
@@ -125,6 +126,87 @@ describe('update_symbol_index label file reconciliation', () => {
   });
 });
 
+describe('update_symbol_index AOT folder type mapping', () => {
+  // Regression (audit 2.1): the map used non-existent folder names
+  // 'AxEnumsExtension'/'AxEdtsExtension' (the real AOT folders are singular:
+  // AxEnumExtension/AxEdtExtension — see AOT_EXTRACTORS in
+  // scripts/extract-metadata.ts) and lacked entries for many folders, so all
+  // of these objects were silently indexed as type 'class' via the
+  // `?? 'class'` fallback.
+  let context: XppServerContext;
+
+  beforeEach(() => {
+    context = createContext();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['AxEnumExtension', 'enum-extension'],
+    ['AxEdtExtension', 'edt-extension'],
+    // Full builds store data entities as type 'view' (see indexViews) — parity.
+    ['AxDataEntityView', 'view'],
+    ['AxDataEntityViewExtension', 'data-entity-extension'],
+    ['AxViewExtension', 'view-extension'],
+    ['AxQuerySimpleExtension', 'query-extension'],
+    ['AxMenuExtension', 'menu-extension'],
+    ['AxMapExtension', 'map-extension'],
+    ['AxService', 'service'],
+    ['AxServiceGroup', 'service-group'],
+    ['AxMap', 'map'],
+    ['AxConfigurationKey', 'configuration-key'],
+    ['AxLicenseCode', 'license-code'],
+    ['AxSecurityPolicy', 'security-policy'],
+    ['AxMacroDictionary', 'macro'],
+    ['AxSecurityDutyExtension', 'security-duty-extension'],
+    ['AxSecurityRoleExtension', 'security-role-extension'],
+    ['AxMenuItemDisplayExtension', 'menu-item-display-extension'],
+    ['AxMenuItemActionExtension', 'menu-item-action-extension'],
+    ['AxMenuItemOutputExtension', 'menu-item-output-extension'],
+  ])('classifies a file under %s as %s (not the class fallback)', async (folder, expectedType) => {
+    const filePath = `K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\${folder}\\MyObject.xml`;
+    existsSyncMock.mockReturnValue(true);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    const addSymbolCalls = (context.symbolIndex.addSymbol as any).mock.calls.map((c: any[]) => c[0]);
+    const objectSymbol = addSymbolCalls.find((s: any) => s.name === 'MyObject');
+    expect(objectSymbol?.type).toBe(expectedType);
+    // The AOT folder key also drives model extraction (folder before the AOT folder)
+    expect(objectSymbol?.model).toBe('MyModel');
+  });
+});
+
+describe('update_symbol_index refresh mode (no filePath)', () => {
+  let context: XppServerContext;
+
+  beforeEach(() => {
+    context = createContext();
+    vi.clearAllMocks();
+  });
+
+  it('does not bump last_indexed_at and does not claim the SQLite index was refreshed', async () => {
+    // Regression (audit 2.3): refresh mode reindexes nothing in SQLite, but it
+    // used to call touchLastIndexed() anyway — get_workspace_info then reported
+    // a possibly stale index as fresh (see src/utils/indexStaleness.ts).
+    const result = await updateSymbolIndexTool({}, context);
+
+    expect(result.isError).toBeFalsy();
+    expect(context.symbolIndex.touchLastIndexed).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('NOT reindexed');
+  });
+
+  it('still bumps last_indexed_at when a file is actually re-indexed', async () => {
+    const filePath = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxService\\MyService.xml';
+    existsSyncMock.mockReturnValue(true);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    expect(context.symbolIndex.touchLastIndexed).toHaveBeenCalled();
+  });
+});
+
 describe('update_symbol_index table re-indexing preserves field EDT/EnumType', () => {
   let context: XppServerContext;
 
@@ -172,6 +254,57 @@ describe('update_symbol_index table re-indexing preserves field EDT/EnumType', (
 
     expect(myIdField?.signature).toBe('ContosoMyId');
     expect(myStatusField?.signature).toBe('ContosoMyStatus');
+    // Stale-row cleanup must go through removeSymbolsByFile (path-form-agnostic
+    // matching), not an inline `DELETE ... WHERE file_path = ?` (audit 2.2).
+    expect(context.symbolIndex.removeSymbolsByFile).toHaveBeenCalledWith(filePath);
+  });
+
+  it('re-inserts table methods, matching what the full build (indexTables) stores', async () => {
+    // Regression (audit 2.5): the table branch only re-inserted fields, so a
+    // table's previously indexed methods were deleted by the stale-row cleanup
+    // and never re-added on incremental reindex.
+    const filePath = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\MyTable.xml';
+    existsSyncMock.mockReturnValue(true);
+    readFilePromiseMock.mockResolvedValue(`<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>MyTable</Name>
+  <SourceCode>
+    <Methods>
+      <Method>
+        <Name>find</Name>
+        <Source><![CDATA[public static MyTable find(ContosoMyId _myId, boolean _forUpdate = false)
+{
+    MyTable myTable;
+    myTable.selectForUpdate(_forUpdate);
+    select firstonly myTable where myTable.MyId == _myId;
+    return myTable;
+}]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+  <Fields>
+    <AxTableField xmlns="" i:type="AxTableFieldString">
+      <Name>MyId</Name>
+      <ExtendedDataType>ContosoMyId</ExtendedDataType>
+    </AxTableField>
+  </Fields>
+</AxTable>`);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    const addSymbolCalls = (context.symbolIndex.addSymbol as any).mock.calls.map((c: any[]) => c[0]);
+    const findMethod = addSymbolCalls.find((s: any) => s.type === 'method' && s.name === 'find');
+
+    expect(findMethod).toMatchObject({
+      name: 'find',
+      type: 'method',
+      parentName: 'MyTable',
+      signature: 'MyTable find(ContosoMyId _myId, boolean _forUpdate)',
+      filePath,
+      model: 'MyModel',
+    });
+    expect(findMethod.source).toContain('select firstonly myTable');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes for the defects found by the full-repo audit (report included as `docs/AUDIT_2026-07-17.md`, section numbers below refer to it):

- **2.1 — `AOT_FOLDER_TYPE_MAP` wrong/missing keys** ([src/tools/updateSymbolIndex.ts](../blob/HEAD/src/tools/updateSymbolIndex.ts)): the map used non-existent folder names `axenumsextension`/`axedtsextension` (real AOT folders are singular) and lacked ~15 entries (`axdataentityview`, `axservice`, `axmap`, `axconfigurationkey`, …), so all of these objects were silently indexed as type `class` via the `?? 'class'` fallback. Data entities map to type `view` for parity with the full build (`indexViews`).
- **2.2 — stale-row cleanup by `file_path` was unreliable** (`src/metadata/symbolIndex.ts`): full CI builds store PackagesLocalDirectory-relative forward-slash paths while callers pass absolute Windows paths, so `DELETE … WHERE file_path = ?` never matched and deleted methods/objects stayed searchable. `removeSymbolsByFile`/`removeLabelsByFile` now match every stored path form, and `update_symbol_index` routes its inline DELETE through them.
- **2.3 — refresh mode masked staleness** (`updateSymbolIndex.ts`): calling the tool without `filePath` bumped `last_indexed_at` even though nothing was reindexed in SQLite, making `get_workspace_info` report a stale index as fresh. The timestamp bump is removed and the response now states the SQLite index was NOT reindexed.
- **2.4 — write-only mode refused advertised tools** (`serverMode.ts`, `mcpServer.ts`, `toolHandler.ts`, `index.ts`): the ListTools filter let `ALWAYS_TOOLS` (`get_object_info`, `labels`, `d365fo_file`) through in write-only mode, but the runtime gate lacked the bypass and blocked them — breaking the hybrid Azure/local deployment. Introduced a single shared predicate `isToolAllowedInMode` used by the list filter, the runtime gate, and the startup banner so they can never drift.
- **2.5 — incremental table reindex dropped methods** (`updateSymbolIndex.ts`): the table branch only re-inserted fields, so the stale-row cleanup deleted a table's previously indexed methods and never re-added them. Methods are now re-inserted with `source`/`sourceSnippet`, matching the full build.
- **2.6 — unrecoverable modify outside git** (`src/tools/modifyD365File.ts`): `undo_last_modification` works via `git checkout`, but `createBackup` defaults to false — on a VM where PackagesLocalDirectory is not under git, a bad modify was unrecoverable. A backup is now forced when the target is not inside a git work tree (result cached per directory), with a note appended to the tool response.
- **§5 — FTS stop-word over-filtering** (`symbolIndex.ts`): searching for a method literally named `find`/`get`/`list` had its only token dropped by the stop-word filter. Stop words are now only dropped while a non-stop-word token remains.

## Test plan

- 5 new test files + extensions to existing ones (119 tests in the touched files, all passing): AOT folder mapping table, path-form-agnostic removal, refresh-mode timestamp behavior, mode-gating contract (`isToolAllowedInMode`), forced-backup guard, stop-word regression.
- Full unit suite passes locally.
- Audit report section 6 lists follow-ups to verify on the real D365FO VM (bridge build, incremental reindex against real AOT, `modify-property` no-op reproduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)