### PR TITLE
Decouple code updates from instance DB rebuilds; clarify custom-model docs

### DIFF
--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -34,6 +34,8 @@ EXTRACT_MODE=custom
 
 **How custom model detection works:** Everything listed in `CUSTOM_MODELS` is treated as your code. All other models are automatically classified as Microsoft standard. The server never requires you to maintain a static list of Microsoft model names — the list auto-adapts to new D365FO versions.
 
+**What to put in `CUSTOM_MODELS`:** list **every** non-Microsoft model you have source for — both the models you author into **and** any source-ISV models you only extend (never modify) — not just the ones you actively change. The classification drives `search(scope="extensions")`, workspace context ranking, form-pattern mining (ISV objects must stay out of the mined *standard* pattern catalog), and the Azure custom-build pipeline — all of which want ISV code classified as custom. Binary-only ISV models (shipped as compiled DLLs with no object XML) are never indexed, so there is no need to list them.
+
 ### UDE (Unified Developer Experience / Power Platform Tools)
 
 In UDE environments, custom models are **auto-detected** from the custom packages path (`ModelStoreFolder` in your XPP config file). You do not need to set `CUSTOM_MODELS`:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -182,11 +182,32 @@ One machine, several D365FO clients — each instance gets its own `.env`, datab
 ```powershell
 .\instances\add-instance.ps1            # interactive: name + port → instances\<name>\{.env,data,metadata}
 # edit instances\<name>\.env: XPP_CONFIG_NAME, EXTENSION_PREFIX, D365FO_MODEL_NAME
-.\instances\rebuild-instance.ps1 clientA   # extract + build index for the instance (--all for all)
+.\instances\rebuild-instance.ps1 clientA   # first build: extract + build index (--all for all instances)
 .\instances\run-instance.ps1 clientA       # start on its port
 ```
 
 Or the CLI equivalents: `npx d365fo-mcp instance add|rebuild|run|upgrade [name]` (interactive when the name is omitted; `instance upgrade` repoints an instance after a UDE version upgrade).
+
+### Keeping instances in sync
+
+Updating the server code and reindexing an instance's database are **separate** steps, at different scopes:
+
+- **Server binaries are repo-global.** All instances run the same `dist/`, so update it once — never per instance:
+  ```powershell
+  git pull; npm install; npm run build      # once; then restart the instances
+  ```
+- **Databases are per-instance.** `rebuild-instance.ps1` runs a full reindex from the current source. Only reindex when it's actually needed:
+
+  | What changed | Command |
+  |---|---|
+  | First build of an instance | `rebuild-instance.ps1 <name>` |
+  | **Microsoft base** upgraded (UDE version) | `upgrade-instance.ps1 <name>` |
+  | Pull changed the **parser / DB schema** | `rebuild-instance.ps1 --all` |
+  | Runtime-only code change | *(just `npm run build` + restart — no reindex)* |
+
+  Add `--all` to rebuild every instance.
+
+> `rebuild-instance.ps1` deliberately does **not** `git pull` or build binaries: that is a repo-wide action, and doing it while rebuilding a single instance would leave the others running new binaries against an old-schema database.
 
 Point a per-solution `.mcp.json` at the right port:
 

--- a/instances/.env.template
+++ b/instances/.env.template
@@ -56,6 +56,10 @@ D365FO_MODEL_NAME=
 # =============================================================================
 INCLUDE_LABELS=true
 LABEL_LANGUAGES=en-US
+
+# Local instance rebuilds always do a full build. The engine also supports
+# incremental 'custom'/'standard' values (used by the Azure data pipelines), but
+# the instance scripts intentionally do not use them — see rebuild-instance.ps1.
 EXTRACT_MODE=all
 
 # Label sort order: "alphabetical" (default) or "append" (new labels added at end of file)

--- a/instances/rebuild-instance.ps1
+++ b/instances/rebuild-instance.ps1
@@ -173,6 +173,10 @@ function Migrate-DevEnvTypeName([string]$envFile) {
 function Rebuild-SingleInstance([System.IO.DirectoryInfo]$inst) {
     $envFile = Join-Path $inst.FullName '.env'
     $env:ENV_FILE = $envFile
+    # Force a full rebuild regardless of what EXTRACT_MODE the instance .env
+    # happens to have set — dotenv does not override already-set process env
+    # vars, so this wins over a stray 'custom'/'standard' value in the file.
+    $env:EXTRACT_MODE = 'all'
 
     Write-Host ''
     Write-Host ('=' * 60) -ForegroundColor DarkGray

--- a/instances/rebuild-instance.ps1
+++ b/instances/rebuild-instance.ps1
@@ -1,11 +1,29 @@
 <#
 .SYNOPSIS
-    Rebuild databases for one or all MCP server instances.
+    Rebuild (reindex) the databases for one or all MCP server instances.
 .DESCRIPTION
-    Lists available instances and lets you pick which one to rebuild,
-    with an "All instances" option at the end.
-    You can also pass the instance name directly: .\instances\rebuild-instance.ps1 alpha
-    Or rebuild everything:                        .\instances\rebuild-instance.ps1 --all
+    Runs a FULL reindex of an instance's metadata databases from the CURRENT
+    source (extract + build via tsx). It does NOT update the server binaries —
+    that is a repo-global step you run yourself, because it affects every
+    instance at once.
+
+    Full update flow after a git pull:
+      1. git pull                     # and decide what actually changed
+      2. npm install; npm run build   # ONCE — rebuilds dist/ that ALL instances run
+      3. rebuild only if the pull changed the parser / DB schema:
+           .\instances\rebuild-instance.ps1 <name>          # one instance
+           .\instances\rebuild-instance.ps1 --all           # every instance
+    Most code changes are runtime-only: after step 2 just restart the instances,
+    no reindex needed. Reindex only for parser/extraction/schema changes.
+
+    This always does a full (EXTRACT_MODE=all) rebuild. The engine also supports
+    incremental 'custom'/'standard' builds, but they are not exposed here: on UDE
+    the build phase cannot see the auto-detected custom models, and the per-model
+    reindex path is slower than a full rebuild on single-language instances, so a
+    full rebuild is both simplest and fastest for local instances.
+
+    You can pass the instance name directly: .\instances\rebuild-instance.ps1 alpha
+    Rebuild everything:                       .\instances\rebuild-instance.ps1 --all
 #>
 param(
     [string]$InstanceName,
@@ -224,34 +242,13 @@ if ($All) {
     }
 }
 
-# ── Optionally update code first ────────────────────────────────────────────
-Write-Host ''
-$pullAnswer = Read-Host 'Pull latest code from Git? [Y/n]'
-if ($pullAnswer -ne 'n') {
-    Write-Host ''
-    Write-Host '[Git] Pulling latest...' -ForegroundColor DarkGray
-    & git pull
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host 'ERROR: git pull failed' -ForegroundColor Red
-        exit 1
-    }
-
-    Write-Host '[npm] Installing dependencies...' -ForegroundColor DarkGray
-    & npm install
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host 'ERROR: npm install failed' -ForegroundColor Red
-        exit 1
-    }
-
-    Write-Host '[tsc] Building TypeScript...' -ForegroundColor DarkGray
-    & npm run build
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host 'ERROR: TypeScript build failed' -ForegroundColor Red
-        exit 1
-    }
-} else {
-    Write-Host 'Skipping code update.' -ForegroundColor DarkGray
-}
+# ── Code updates are a separate, repo-global step (by design) ────────────────
+# This script only reindexes databases. Updating the server binaries
+# (git pull; npm install; npm run build) is a repo-wide operation that affects
+# EVERY instance's shared dist/ at once — doing it here while rebuilding a single
+# instance would leave the other instances running new binaries against an
+# old-schema database. Run the code update yourself, once, then rebuild the
+# instance(s) that need it. See the .DESCRIPTION for the full flow.
 
 # ── Check for new settings ──────────────────────────────────────────────────
 $hasNewSettings = $false


### PR DESCRIPTION
## Issue

- `instances/rebuild-instance.ps1` coupled a **repo-global** code update (`git pull` + `npm install` + `npm run build`) into a **per-instance** database rebuild. All instances share the same `dist/`, so updating the binaries during a single-instance rebuild left the *other* instances running new binaries against an old-schema database.
- The docs didn't clarify (a) that updating code and reindexing a database are separate steps at different scopes, or (b) what belongs in `CUSTOM_MODELS`.

## Fix

- **`rebuild-instance.ps1`**: removed the in-script `git pull` / `npm install` / `npm run build`; it now only reindexes, always a full `EXTRACT_MODE=all` rebuild. Documents why the incremental `custom`/`standard` modes are not exposed here (on UDE the build phase can't see the auto-detected custom models, and the per-model reindex is slower than a full rebuild on single-language instances — see #704).
- **`docs/SETUP.md`**: adds a "Keeping instances in sync" section explaining the repo-global code update vs the per-instance reindex, and when a reindex is actually needed.
- **`instances/.env.template`**: notes the instance scripts don't use the incremental `EXTRACT_MODE` values.
- **`docs/CUSTOM_EXTENSIONS.md`**: `CUSTOM_MODELS` should list all non-Microsoft source models (yours + source-ISV you only extend), not just the ones you modify, with the rationale; binary-only ISV models aren't indexed so don't need listing.