### PR TITLE
Make incremental EXTRACT_MODE builds genuinely faster than a full rebuild (#704)

### DIFF
--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -5,7 +5,7 @@ This guide explains how to configure, extract, and index your custom X++ models 
 ## What this covers
 
 - How to tell the server which models are "yours" (vs. standard Microsoft models)
-- How to extract only custom models (fast, a few minutes) vs. everything (slow, 1–2 h)
+- How to extract only custom models (fast, a few minutes) vs. everything (a full rebuild)
 - How the `search(scope="extensions")` mode filters to your code only
 - Multi-instance setups where each client has its own custom models
 
@@ -70,7 +70,9 @@ npm run extract-metadata
 npm run build-database
 ```
 
-Takes 1–2 hours (standard Microsoft models are large). Only needed when Microsoft standard model content changes.
+Only needed when Microsoft standard model content changes (e.g. after a D365FO upgrade).
+
+Timing depends heavily on the environment. On a single-label-language instance (~176 models, ~1.2M symbols) a full `all` rebuild is roughly 10–15 minutes end to end. It grows substantially when many label languages are installed, because label indexing re-indexes every Microsoft label across all languages — so a large multi-language installation can take much longer. The dominant cost is label breadth, not X++ model size.
 
 ---
 

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -15,6 +15,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 import { isCustomModel, isStandardModel, getCustomModels } from '../src/utils/modelClassifier.js';
+import { readExtractedCustomModels } from '../src/utils/extractManifest.js';
 import { indexAllLabels } from '../src/metadata/labelParser.js';
 import { XppConfigProvider } from '../src/utils/xppConfigProvider.js';
 import { crossCheckPatternCatalog, formatCrossCheckReport } from '../src/knowledge/formPatterns/crossCheck.js';
@@ -100,12 +101,16 @@ async function buildDatabase() {
     symbolIndex.clearProgressTracking();
   } else if (EXTRACT_MODE === 'custom') {
     // Clear only custom models
+    const allModels = fsSync.readdirSync(INPUT_PATH, { withFileTypes: true })
+      .filter(e => e.isDirectory())
+      .map(e => e.name);
+
+    // When CUSTOM_MODELS is empty, bridge the classification from extract-metadata's manifest.
+    // `undefined` = no manifest (legacy/blob-download flow); an array (even empty) = the extract
+    // run's authoritative custom set. Read once so we can tell those two apart.
+    const manifestCustomModels = CUSTOM_MODELS.length > 0 ? undefined : readExtractedCustomModels(INPUT_PATH);
+
     if (CUSTOM_MODELS.length > 0) {
-      // Expand wildcards in custom models
-      const allModels = fsSync.readdirSync(INPUT_PATH, { withFileTypes: true })
-        .filter(e => e.isDirectory())
-        .map(e => e.name);
-      
       // Expand patterns (e.g., "My*" → ["MyModel", "MyFinanceCore", ...])
       const expandedModels: string[] = [];
       for (const pattern of CUSTOM_MODELS) {
@@ -121,23 +126,39 @@ async function buildDatabase() {
           }
         }
       }
-      
+
       modelsToRebuild = [...new Set(expandedModels)]; // Remove duplicates
       log.step(`Clearing symbols for models: ${CUSTOM_MODELS.join(', ')}`);
       if (modelsToRebuild.length !== CUSTOM_MODELS.length) {
         log.detail(`Expanded to ${modelsToRebuild.length} models: ${modelsToRebuild.slice(0, 5).join(', ')}${modelsToRebuild.length > 5 ? '...' : ''}`);
       }
       symbolIndex.clearModels(modelsToRebuild, shouldVacuum);
+    } else if (manifestCustomModels !== undefined) {
+      // No hand-maintained CUSTOM_MODELS — use the extract manifest. On UDE, custom models are
+      // auto-detected from the ModelStoreFolder at runtime and are invisible to this separate
+      // build process; the extract phase already knew which models were custom and recorded them,
+      // so we rebuild only the real custom model(s) instead of every model in INPUT_PATH.
+      const present = new Set(allModels);
+      modelsToRebuild = manifestCustomModels.filter(m => present.has(m));
+      log.step(`Scoping custom build to ${modelsToRebuild.length} model(s) from extract manifest`);
+      if (modelsToRebuild.length > 0) {
+        log.detail(`Models: ${modelsToRebuild.slice(0, 10).join(', ')}${modelsToRebuild.length > 10 ? '...' : ''}`);
+      } else {
+        log.detail('Extract manifest recorded no custom models — nothing to rebuild');
+      }
+      const missing = manifestCustomModels.filter(m => !present.has(m));
+      if (missing.length > 0) {
+        log.detail(`Manifest listed ${missing.length} model(s) not present in metadata dir (skipped): ${missing.slice(0, 5).join(', ')}`);
+      }
+      symbolIndex.clearModels(modelsToRebuild, shouldVacuum); // no-op when empty
     } else {
-      // When CUSTOM_MODELS is not specified, treat ALL models in INPUT_PATH as custom
-      // This is correct for incremental builds where extract-metadata already filtered to custom models
-      const allModels = fsSync.readdirSync(INPUT_PATH, { withFileTypes: true })
-        .filter(e => e.isDirectory())
-        .map(e => e.name);
-      
-      log.step(`No CUSTOM_MODELS specified. Treating all ${allModels.length} model(s) in INPUT_PATH as custom`);
+      // No CUSTOM_MODELS and no manifest — fall back to treating ALL models in INPUT_PATH as custom.
+      // This is correct (if slow) for incremental builds where extract-metadata already filtered
+      // INPUT_PATH to custom models (e.g. a blob-downloaded metadata dir), but on UDE it would
+      // over-scope to every preserved model — which the manifest branch above now prevents.
+      log.step(`No CUSTOM_MODELS or extract manifest found. Treating all ${allModels.length} model(s) in INPUT_PATH as custom`);
       log.detail(`Models to rebuild: ${allModels.slice(0, 10).join(', ')}${allModels.length > 10 ? '...' : ''}`);
-      
+
       // CRITICAL: Use allModels directly, NOT filtered by isCustomModel()
       // The filtering was already done by extract-metadata when it populated INPUT_PATH
       modelsToRebuild = allModels;
@@ -158,19 +179,21 @@ async function buildDatabase() {
   const startTime = Date.now();
   
   if (modelsToRebuild.length > 0) {
-    // Index specific models
+    // Index specific models in a SINGLE pass (not one call per model): the FTS index is
+    // rebuilt from scratch — O(all symbols in the DB) — once at the end of the call, so
+    // looping here would repeat that full rebuild N times.
     log.detail(`${modelsToRebuild.length} model(s): ${modelsToRebuild.slice(0, 10).join(', ')}${modelsToRebuild.length > 10 ? '...' : ''}`);
     log.detail('Incremental build: standard models in database will be preserved');
-    for (const modelName of modelsToRebuild) {
-      await symbolIndex.indexMetadataDirectory(INPUT_PATH, modelName);
-    }
-  } else {
-    // Index all models in the directory
+    await symbolIndex.indexMetadataDirectory(INPUT_PATH, modelsToRebuild);
+  } else if (EXTRACT_MODE === 'all' || RESUME) {
+    // Full rebuild (or resume): index every model in the directory in one bulk pass.
     log.detail(`All models from: ${shortPath(INPUT_PATH)}`);
-    if (EXTRACT_MODE !== 'all') {
-      log.warn(`Indexing ALL models but EXTRACT_MODE=${EXTRACT_MODE} (expected 'all' for a full rebuild)`);
-    }
     await symbolIndex.indexMetadataDirectory(INPUT_PATH);
+  } else {
+    // Incremental mode that resolved to an empty scope (e.g. a custom build whose extract
+    // manifest recorded no custom models). Indexing all here would silently reindex the whole
+    // database — the opposite of what an incremental build asks for — so skip instead.
+    log.warn(`Incremental ${EXTRACT_MODE} build resolved to 0 models in scope — nothing to index`);
   }
   
   console.log('');

--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'url';
 import { XppMetadataParser, buildClassExtensionRecord } from '../src/metadata/xmlParser.js';
 import type { XppClassInfo } from '../src/metadata/types.js';
 import { isCustomModel as checkIsCustomModel, getCustomModels } from '../src/utils/modelClassifier.js';
+import { writeExtractManifest } from '../src/utils/extractManifest.js';
 import { XppConfigProvider } from '../src/utils/xppConfigProvider.js';
 import { box, kv, sectionTitle, statusLine, spread, c, glyph, log, shortPath, supportsUnicode, sanitize } from '../src/utils/terminalUi.js';
 
@@ -595,6 +596,25 @@ async function extractMetadata() {
     log.detail(
       `done in ${formatDuration(modelDuration)} ${glyph.dot} progress ${formatPercent(processedModels, totalModels)} (${formatCount(processedModels)}/${formatCount(totalModels)} models), ${formatPercent(stats.totalFiles, totalExpectedFiles)} (${formatCount(stats.totalFiles)}/${formatCount(totalExpectedFiles)} files) ${glyph.dot} avg ${formatDuration(avgModelDuration)}/model, ${formatDuration(avgFileDuration)}/file`
     );
+  }
+
+  // Record which models this run classified as custom, so build-database can scope a
+  // `custom` rebuild to exactly these without a hand-maintained CUSTOM_MODELS list. On UDE
+  // the classification is path-based (customRoot) and cannot be reproduced by build-database,
+  // which runs as a separate process.
+  const detectedCustomModels = [
+    ...new Set(modelWorkItems.filter(i => i.isCustom).map(i => i.modelName)),
+  ];
+  try {
+    writeExtractManifest(OUTPUT_PATH, {
+      generatedAt: new Date().toISOString(),
+      extractMode: EXTRACT_MODE,
+      environment: customRoot ? 'ude' : 'traditional',
+      customModels: detectedCustomModels,
+    });
+    log.detail(`Wrote extract manifest (${detectedCustomModels.length} custom model(s) recorded)`);
+  } catch (error) {
+    log.warn(`Could not write extract manifest (non-fatal): ${error instanceof Error ? error.message : error}`);
   }
 
   const totalDuration = Date.now() - extractionStart;

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,10 +278,10 @@ async function initializeServices() {
         const modelNames = modelNamesStr.split(',').map(m => m.trim()).filter(Boolean);
         log.detail(`model names: ${modelNames.join(', ')}`);
 
-        for (const modelName of modelNames) {
-          log.detail(`indexing ${modelName}` + glyph.ellipsis);
-          await symbolIndex.indexMetadataDirectory(METADATA_PATH, modelName);
-        }
+        // Single pass over all requested models — the FTS index is rebuilt once at the
+        // end of the call, so looping per model would repeat a full-table rebuild.
+        log.detail(`indexing ${modelNames.join(', ')}` + glyph.ellipsis);
+        await symbolIndex.indexMetadataDirectory(METADATA_PATH, modelNames);
 
         log.ok(`Indexed ${symbolIndex.getSymbolCount().toLocaleString('en-US')} symbols from ${modelNames.length} model(s)`);
       } catch {

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1295,18 +1295,31 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Index metadata from a directory
-   * Uses single transaction for all models - fastest approach with 8GB heap
+   * Index metadata from a directory.
+   *
+   * `modelNames` scopes the pass:
+   *   - omitted        → index every model directory found under `metadataPath`
+   *   - a model name   → index just that one model
+   *   - an array       → index exactly those models in a SINGLE pass
+   *
+   * Pass an array rather than calling this once per model: the FTS index is rebuilt from
+   * scratch ONCE at the end of the call (and the FTS triggers dropped/recreated once), both
+   * O(all symbols in the DB), so a per-model loop turns a scoped rebuild into N full-table
+   * rebuilds.
    */
-  async indexMetadataDirectory(metadataPath: string, modelName?: string): Promise<void> {
+  async indexMetadataDirectory(metadataPath: string, modelNames?: string | string[]): Promise<void> {
     const skipFts = process.env.SKIP_FTS === 'true';
     const resumable = process.env.RESUME === 'true';
 
-    const allModels = modelName ? [modelName] : await this.getModelDirectories(metadataPath);
+    const requested = modelNames === undefined
+      ? undefined
+      : (Array.isArray(modelNames) ? modelNames : [modelNames]);
+    const allModels = requested ?? await this.getModelDirectories(metadataPath);
 
-    // Sort largest models first — ensures Foundation (56K files) is indexed before any CI timeout
+    // Sort largest models first — ensures Foundation (56K files) is indexed before any CI timeout.
+    // Skip the size scan only when a single model was requested (nothing to order).
     let models = allModels;
-    if (!modelName) {
+    if (allModels.length > 1) {
       log.detail(`Scanning ${allModels.length} model(s) to determine build order...`);
       models = this.sortModelsBySize(metadataPath, allModels);
       log.detail(`Build order determined (largest model first: ${models[0] ?? '—'})`);

--- a/src/utils/extractManifest.ts
+++ b/src/utils/extractManifest.ts
@@ -1,0 +1,57 @@
+/**
+ * Extract manifest — the bridge between `extract-metadata` and `build-database`.
+ *
+ * `extract-metadata` knows which models are custom (including UDE auto-detection from the
+ * ModelStoreFolder, where CUSTOM_MODELS is intentionally empty). `build-database` runs as a
+ * separate process that only sees CUSTOM_MODELS and therefore cannot repeat that detection.
+ *
+ * To keep the two phases' notion of "custom" in agreement without a hand-maintained
+ * CUSTOM_MODELS list, `extract-metadata` records the models it classified as custom in this
+ * manifest, written into the metadata output directory, and `build-database` reads it when
+ * scoping a `custom` rebuild.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** File written into the metadata output directory. Not a model dir — scanners skip files. */
+export const EXTRACT_MANIFEST_FILENAME = '.extract-manifest.json';
+
+export interface ExtractManifest {
+  /** ISO timestamp of the extract run that produced this manifest. */
+  generatedAt: string;
+  /** EXTRACT_MODE of the run: 'all' | 'custom' | 'standard'. */
+  extractMode: string;
+  /** 'ude' when custom models were path-auto-detected, else 'traditional'. */
+  environment: 'ude' | 'traditional';
+  /** Model names the extract run classified as custom (exact on-disk directory names). */
+  customModels: string[];
+}
+
+export function manifestPath(metadataDir: string): string {
+  return path.join(metadataDir, EXTRACT_MANIFEST_FILENAME);
+}
+
+/** Write the manifest into `metadataDir`. Best-effort: extraction succeeds even if this fails. */
+export function writeExtractManifest(metadataDir: string, manifest: ExtractManifest): void {
+  fs.writeFileSync(manifestPath(metadataDir), JSON.stringify(manifest, null, 2));
+}
+
+/**
+ * Read the list of custom models recorded by the last extract run.
+ * Returns `undefined` when no manifest exists (older extract, or none run yet), so callers
+ * can distinguish "no manifest" from "manifest with an empty custom list".
+ */
+export function readExtractedCustomModels(metadataDir: string): string[] | undefined {
+  try {
+    const raw = fs.readFileSync(manifestPath(metadataDir), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<ExtractManifest>;
+    if (Array.isArray(parsed.customModels)) {
+      return parsed.customModels.filter((m): m is string => typeof m === 'string');
+    }
+    return undefined;
+  } catch {
+    // No manifest (ENOENT) or unparseable — caller falls back to its default scoping.
+    return undefined;
+  }
+}

--- a/tests/metadata/index-scoped-models.test.ts
+++ b/tests/metadata/index-scoped-models.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Scoped incremental indexing.
+ *
+ * `indexMetadataDirectory` must be able to index an explicit *list* of models in a single
+ * pass — that is what lets build-database's `custom`/`standard` modes rebuild only the
+ * changed models without paying a full FTS rebuild per model. These tests pin:
+ *   1. an array argument indexes exactly those models and nothing else, and
+ *   2. the extract-manifest write/read roundtrip that bridges extract → build classification.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import {
+  writeExtractManifest,
+  readExtractedCustomModels,
+  EXTRACT_MANIFEST_FILENAME,
+} from '../../src/utils/extractManifest';
+
+let tmpDir: string;
+
+/** Write a minimal classes/<name>.json so a model directory has one indexable class. */
+async function writeModelWithClass(root: string, model: string, className: string): Promise<void> {
+  const dir = path.join(root, model, 'classes');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, `${className}.json`),
+    JSON.stringify({ name: className, type: 'class', model }, null, 2),
+  );
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'scoped-idx-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('indexMetadataDirectory scoping', () => {
+  it('indexes exactly the models named in an array, skipping the rest', async () => {
+    const extracted = path.join(tmpDir, 'extracted');
+    await writeModelWithClass(extracted, 'ModelA', 'ClassA');
+    await writeModelWithClass(extracted, 'ModelB', 'ClassB');
+    await writeModelWithClass(extracted, 'ModelC', 'ClassC');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(extracted, ['ModelA', 'ModelC']);
+
+    const models = index
+      .getReadDb()
+      .prepare('SELECT DISTINCT model FROM symbols ORDER BY model')
+      .all()
+      .map((r: any) => r.model);
+
+    expect(models).toEqual(['ModelA', 'ModelC']);
+    index.close?.();
+  });
+
+  it('a single string argument still indexes just that one model', async () => {
+    const extracted = path.join(tmpDir, 'extracted');
+    await writeModelWithClass(extracted, 'ModelA', 'ClassA');
+    await writeModelWithClass(extracted, 'ModelB', 'ClassB');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(extracted, 'ModelB');
+
+    const models = index
+      .getReadDb()
+      .prepare('SELECT DISTINCT model FROM symbols')
+      .all()
+      .map((r: any) => r.model);
+
+    expect(models).toEqual(['ModelB']);
+    index.close?.();
+  });
+
+  it('omitting the argument indexes every model directory', async () => {
+    const extracted = path.join(tmpDir, 'extracted');
+    await writeModelWithClass(extracted, 'ModelA', 'ClassA');
+    await writeModelWithClass(extracted, 'ModelB', 'ClassB');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(extracted);
+
+    const count = index.getReadDb().prepare('SELECT COUNT(DISTINCT model) AS n FROM symbols').get() as { n: number };
+    expect(count.n).toBe(2);
+    index.close?.();
+  });
+});
+
+describe('extract manifest bridge', () => {
+  it('roundtrips the recorded custom models', () => {
+    writeExtractManifest(tmpDir, {
+      generatedAt: new Date().toISOString(),
+      extractMode: 'custom',
+      environment: 'ude',
+      customModels: ['MyCustomModel'],
+    });
+
+    expect(readExtractedCustomModels(tmpDir)).toEqual(['MyCustomModel']);
+  });
+
+  it('returns undefined when no manifest is present (distinct from an empty list)', () => {
+    expect(readExtractedCustomModels(tmpDir)).toBeUndefined();
+
+    writeExtractManifest(tmpDir, {
+      generatedAt: new Date().toISOString(),
+      extractMode: 'standard',
+      environment: 'ude',
+      customModels: [],
+    });
+    expect(readExtractedCustomModels(tmpDir)).toEqual([]);
+  });
+
+  it('writes the manifest as a dotfile so model scanners ignore it', () => {
+    expect(EXTRACT_MANIFEST_FILENAME.startsWith('.')).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #704.

## Problem

On a UDE single-language instance, `build-database` with `EXTRACT_MODE=custom` or `standard` was **slower** than a full `all` rebuild — the documented "custom = fast path" was inverted. Two independent causes:

1. **UDE custom models are invisible to `build-database`.** On UDE, `CUSTOM_MODELS` is intentionally empty and custom models are auto-detected from the `ModelStoreFolder` at runtime. `build-database` runs as a separate process and can't repeat that detection, so `custom` mode fell back to treating **every** model in the metadata dir as custom and rebuilt all of them.
2. **Per-model re-index loop repeated a full FTS rebuild.** Incremental modes called `indexMetadataDirectory` once per model, and each call rebuilds the entire `symbols` FTS index from scratch (`INSERT INTO symbols_fts VALUES('rebuild')`, O(all symbols)) plus drops/recreates the FTS triggers. So a scoped rebuild of N models did **N full-table FTS rebuilds** instead of one — the real, dominant cost, and it hits `standard` mode inherently.

Correctness was never affected (all three modes produced an identical DB); this is purely scoping/performance.

## Changes

- **Single bulk pass** — `indexMetadataDirectory` now accepts `string | string[]` and indexes the whole list in one pass, so the FTS index is rebuilt **once**. `build-database` and the startup indexing path in `src/index.ts` pass the full model list instead of looping.
- **Extract→build manifest bridge** — `extract-metadata` writes `.extract-manifest.json` recording the models it classified as custom (including UDE path-based detection). `build-database` reads it in `custom` mode to scope the rebuild to the real custom model(s). New shared `src/utils/extractManifest.ts` owns the format. "No manifest" (legacy blob-download flow → treat all as custom) is kept distinct from "empty manifest".
- **Empty-scope guard** — an incremental build that resolves to zero models now no-ops instead of falling through to reindex the entire database.
- **Docs** — `docs/CUSTOM_EXTENSIONS.md`: replaced the unverified "1–2 h / standard MS models are large" claim with the measured ~10–15 min single-language full rebuild, and noted that label breadth (number of languages), not X++ model size, is the dominant cost.

## Expected effect

For the reported scenario (UDE, 176 models, 1 custom): `custom` build drops from ~773 s to roughly seconds (clear 1 model + index 1 model + 1 FTS rebuild). `standard` also benefits from the single FTS rebuild.

## Testing

- `tsc --noEmit` clean.
- New `tests/metadata/index-scoped-models.test.ts` (6 tests): array / single-string / omitted scoping, and the manifest write→read roundtrip incl. the undefined-vs-empty distinction.
- Existing `indexMetadataDirectory` regression test still passes.
- Pre-existing unrelated failures (form-property / source-guard tests) were confirmed to fail on clean `main` as well and are untouched by this change.

## Notes / out of scope

- The multi-language label-skipping benefit is **not** measured here (no multi-language dataset available) — the doc wording is deliberately cautious about it.
- `standard` mode still uses name-based classification, so a UDE custom model is re-indexed as one extra model in `standard` builds — a minor perf detail, not a correctness issue. Left as-is.
