### PR TITLE
Warn when the bridge loads a different metamodel than it was built against

### DIFF
--- a/bridge/D365MetadataBridge/D365MetadataBridge.csproj
+++ b/bridge/D365MetadataBridge/D365MetadataBridge.csproj
@@ -61,4 +61,56 @@
     </Reference>
   </ItemGroup>
 
+  <!--
+    Record WHICH metamodel build we compiled against, so the bridge can warn at
+    startup when it is pointed at an environment shipping a different one.
+
+    This matters because every platform build stamps the SAME assembly version
+    (7.0.0.0) and differs only in FileVersion (e.g. 7.0.7690.155 vs 7.0.7996.33).
+    The CLR binder therefore cannot tell them apart, and the AssemblyResolve →
+    LoadFrom path in Program.cs does not enforce identity — a mismatched DLL
+    loads silently and only blows up later as MissingMethodException /
+    TypeLoadException at JIT time, far from the cause.  See issue #703.
+  -->
+  <Target Name="CaptureMetamodelBuildVersion"
+          BeforeTargets="BeforeCompile"
+          Inputs="$(D365BinPath)\Microsoft.Dynamics.AX.Metadata.dll"
+          Outputs="$(IntermediateOutputPath)BuildInfo.g.cs">
+    <PropertyGroup>
+      <_MetamodelDll>$(D365BinPath)\Microsoft.Dynamics.AX.Metadata.dll</_MetamodelDll>
+    </PropertyGroup>
+    <GetFileVersion FilePath="$(_MetamodelDll)" Condition="Exists('$(_MetamodelDll)')">
+      <Output TaskParameter="Version" PropertyName="_MetamodelFileVersion" />
+    </GetFileVersion>
+    <Message Importance="high"
+             Text="Bridge compiles against metamodel $(_MetamodelFileVersion) from $(D365BinPath)"
+             Condition="'$(_MetamodelFileVersion)' != ''" />
+    <Warning Text="D365BinPath '$(D365BinPath)' has no Microsoft.Dynamics.AX.Metadata.dll — the runtime version check will be disabled."
+             Condition="'$(_MetamodelFileVersion)' == ''" />
+    <WriteLinesToFile File="$(IntermediateOutputPath)BuildInfo.g.cs" Overwrite="true" WriteOnlyWhenDifferent="true"
+                      Lines="// &lt;auto-generated /&gt; Produced by the CaptureMetamodelBuildVersion target.;namespace D365MetadataBridge;{;    internal static class BuildInfo;    {;        /// &lt;summary&gt;FileVersion of the Microsoft.Dynamics.AX.Metadata.dll this build compiled against, or &quot;&quot; if unknown.&lt;/summary&gt;;        internal const string MetamodelFileVersion = &quot;$(_MetamodelFileVersion)&quot;%3B;        /// &lt;summary&gt;bin directory those reference assemblies came from, or &quot;&quot; if unknown.&lt;/summary&gt;;        internal const string MetamodelBinPath = @&quot;$(D365BinPath)&quot;%3B;    };}" />
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)BuildInfo.g.cs" />
+      <FileWrites Include="$(IntermediateOutputPath)BuildInfo.g.cs" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    MSBuild has no built-in task for reading a file's FileVersion (GetAssemblyIdentity
+    returns the assembly version — 7.0.0.0 for every platform build, which is exactly
+    the value that cannot distinguish them).
+  -->
+  <UsingTask TaskName="GetFileVersion" TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <FilePath ParameterType="System.String" Required="true" />
+      <Version ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs">
+        Version = System.Diagnostics.FileVersionInfo.GetVersionInfo(FilePath).FileVersion ?? "";
+      </Code>
+    </Task>
+  </UsingTask>
+
 </Project>

--- a/bridge/D365MetadataBridge/Program.cs
+++ b/bridge/D365MetadataBridge/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -108,6 +109,7 @@ namespace D365MetadataBridge
             Log.WriteLine($"[INFO] Assembly resolution configured for: {primaryBinPath}");
             if (fallbackBinPath != null && Directory.Exists(fallbackBinPath))
                 Log.WriteLine($"[INFO] Additional assembly search path: {fallbackBinPath}");
+            ReportMetamodelVersion(primaryBinPath, fallbackBinPath);
 
             // Delegate to RunBridge — a separate method whose JIT compilation is
             // deferred (NoInlining) until AFTER AssemblyResolve is registered.
@@ -266,6 +268,62 @@ namespace D365MetadataBridge
             var stdout = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
             await stdout.WriteLineAsync(json);
             await stdout.FlushAsync();
+        }
+
+        /// <summary>
+        /// Log the metamodel build we compiled against vs. the one we are about to load,
+        /// and warn when they differ.
+        ///
+        /// Every D365FO platform build stamps assembly version 7.0.0.0 and varies only in
+        /// FileVersion, so the CLR binder cannot tell two metamodels apart — and the
+        /// AssemblyResolve → LoadFrom path below does not enforce identity either.  A bridge
+        /// built against 7.0.7996 therefore loads 7.0.7690 without complaint and fails much
+        /// later with MissingMethodException / TypeLoadException at JIT time.  This turns that
+        /// silent divergence into one line in the log.  See issue #703.
+        ///
+        /// Diagnostic only — never fails startup, since a mismatch is usually harmless.
+        /// Touches no D365FO types, so it is safe to call from Main.
+        /// </summary>
+        private static void ReportMetamodelVersion(string primaryBinPath, string? fallbackBinPath)
+        {
+            const string MetadataDll = "Microsoft.Dynamics.AX.Metadata.dll";
+            try
+            {
+                string? runtimeDll = null;
+                foreach (var searchPath in new[] { primaryBinPath, fallbackBinPath })
+                {
+                    if (searchPath == null) continue;
+                    var candidate = Path.Combine(searchPath, MetadataDll);
+                    if (File.Exists(candidate)) { runtimeDll = candidate; break; }
+                }
+
+                if (runtimeDll == null)
+                {
+                    Log.WriteLine($"[WARN] {MetadataDll} not found under {primaryBinPath} — metadata operations will fail.");
+                    return;
+                }
+
+                var runtimeVersion = FileVersionInfo.GetVersionInfo(runtimeDll).FileVersion ?? "unknown";
+                Log.WriteLine($"[INFO] Metamodel runtime: {runtimeVersion} ({runtimeDll})");
+
+                var builtAgainst = BuildInfo.MetamodelFileVersion;
+                if (string.IsNullOrEmpty(builtAgainst))
+                {
+                    Log.WriteLine("[INFO] Metamodel build version unknown — version check skipped.");
+                }
+                else if (builtAgainst != runtimeVersion)
+                {
+                    Log.WriteLine($"[WARN] Metamodel version mismatch: built against {builtAgainst} " +
+                                  $"(from {BuildInfo.MetamodelBinPath}), loading {runtimeVersion}.");
+                    Log.WriteLine("[WARN] Usually harmless, but if metadata calls fail with MissingMethodException " +
+                                  "or TypeLoadException, rebuild the bridge against this environment: " +
+                                  $"dotnet build -c Release -p:D365BinPath=\"{Path.GetDirectoryName(runtimeDll)}\"");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.WriteLine($"[WARN] Metamodel version check failed: {ex.Message}");
+            }
         }
 
         private static void SetupAssemblyResolution(string primaryBinPath, string? fallbackBinPath = null)

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -215,6 +215,28 @@ feed, add the public source explicitly:
 dotnet build -c Release -p:D365BinPath="<FrameworkDirectory>\bin" --source https://api.nuget.org/v3/index.json
 ```
 
+### Metamodel version mismatch
+
+The bridge compiles against the `Microsoft.Dynamics.*` assemblies in `D365BinPath` but loads
+them at runtime from whichever environment it is pointed at. On a machine spanning several
+platform builds those can differ. Every build stamps assembly version `7.0.0.0` and varies
+only in file version, so the CLR cannot tell them apart — a mismatched metamodel loads
+silently and surfaces much later as `MissingMethodException` or `TypeLoadException`.
+
+The bridge logs both versions at startup and warns when they diverge:
+
+```
+[INFO] Metamodel runtime: 7.0.7690.155 (K:\AosService\PackagesLocalDirectory\bin\...)
+[WARN] Metamodel version mismatch: built against 7.0.7996.33 (from ...), loading 7.0.7690.155.
+```
+
+The warning is informational — differing builds are usually compatible. If metadata calls do
+fail with the exceptions above, rebuild against that environment:
+
+```powershell
+dotnet build -c Release -p:D365BinPath="<that environment>\bin"
+```
+
 ### Output shows SQLite data, not bridge data
 
 Check if the result was served from cache (cache hit occurs before bridge check), or the


### PR DESCRIPTION
Groundwork for #703. This does not decide the pinned-vs-per-environment question that issue asks — it makes the divergence visible so that question can be answered with data.

## Why

The bridge compiles against the `Microsoft.Dynamics.*` assemblies at `D365BinPath` ([csproj](../blob/main/bridge/D365MetadataBridge/D365MetadataBridge.csproj#L58-L62)) but resolves them at runtime from whichever environment it is pointed at ([Program.cs](../blob/main/bridge/D365MetadataBridge/Program.cs#L98-L107)). On a machine spanning several platform builds those differ.

Two facts make that fail badly rather than loudly:

1. **Every platform build stamps assembly version `7.0.0.0`** and varies only in `FileVersion` (verified on a dev box: `7.0.7858.27` file version, `7.0.0.0` assembly version). The CLR binder cannot tell two metamodels apart.
2. `Assembly.LoadFrom` called from an `AssemblyResolve` handler **does not enforce identity**, so nothing else catches it either.

A bridge built against 7.0.7996 therefore loads 7.0.7690 without complaint and fails much later with `MissingMethodException` / `TypeLoadException` at JIT time — far from the cause, with nothing in the log pointing at the version gap.

## What this does

Captures the reference metamodel's `FileVersion` at build time into a generated `BuildInfo` constant, compares it against the loaded one at startup, logs both, and warns on divergence. Diagnostic only — differing builds are usually compatible, so it never fails startup.

Matching environment (quiet):
```
[INFO] Metamodel runtime: 7.0.7858.27 (K:\AosService\PackagesLocalDirectory\bin\Microsoft.Dynamics.AX.Metadata.dll)
```

Mismatched:
```
[WARN] Metamodel version mismatch: built against 7.0.7858.27 (from K:\...\bin), loading 7.0.20023.
[WARN] Usually harmless, but if metadata calls fail with MissingMethodException or TypeLoadException,
       rebuild the bridge against this environment: dotnet build -c Release -p:D365BinPath="..."
```

MSBuild has no built-in task for reading a file's `FileVersion` (`GetAssemblyIdentity` returns the assembly version — `7.0.0.0`, precisely the value that cannot distinguish builds), hence the small `RoslynCodeTaskFactory` inline task. When `D365BinPath` is unset or has no metamodel DLL, the constant is empty and the runtime check quietly skips.

## Testing

- `dotnet build -c Release` clean, 0 warnings; build log confirms `Bridge compiles against metamodel 7.0.7858.27 from K:\AosService\PackagesLocalDirectory\bin`.
- Matching path exercised against the real `PackagesLocalDirectory` — logs the version, no warning.
- Mismatch path exercised by pointing `--bin-path` at a staged bin holding a differently-versioned DLL under the metamodel's name — both warning lines fire, with the correct rebuild command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
