### PR TITLE
Scope UDE custom extract by path so source ISV models are reindexed (follow-up to #704/#706)

### DIFF
--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -534,20 +534,27 @@ async function extractMetadata() {
         continue;
       }
 
+      // Custom classification for this model. On UDE (customRoot set) it is
+      // PATH-based — a model is custom iff it lives under the custom root —
+      // matching the root-level scan above and the manifest flag below. Only fall
+      // back to name-based isCustomModel() for traditional environments that have
+      // no custom root path. Using isCustomModel() here on UDE would drop ISV
+      // models with source under the custom root (their names match neither
+      // D365FO_MODEL_NAME nor EXTENSION_PREFIX), leaving a `custom` build scoped
+      // to just the configured model.
+      const isCustom = customRoot ? rootPath === customRoot : isCustomModel(modelName);
+
       // Apply model-level filtering
-      if (FILTER_MODE === 'custom-only' && !isCustomModel(modelName)) {
+      if (FILTER_MODE === 'custom-only' && !isCustom) {
         log.detail(`${glyph.arrow} skip standard model: ${modelName}`);
         continue;
       }
-      if (FILTER_MODE === 'standard-only' && isCustomModel(modelName)) {
+      if (FILTER_MODE === 'standard-only' && isCustom) {
         log.detail(`${glyph.arrow} skip custom model: ${modelName}`);
         continue;
       }
 
       const expectedXmlFiles = await countModelXmlFiles(modelDirsByLowerName);
-      // In UDE mode: custom iff the package lives under customRoot.
-      // In traditional mode: fall back to name-based detection.
-      const isCustom = customRoot ? rootPath === customRoot : isCustomModel(modelName);
       modelWorkItems.push({ packageName, modelName, modelPath, expectedXmlFiles, isCustom });
     }
   }

--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -45,6 +45,40 @@ const EXTRACT_MODE = process.env.EXTRACT_MODE || 'all';
 const isCustomModel = checkIsCustomModel;
 
 /**
+ * Decide how one model relates to "custom" for this extract run.
+ *
+ * `isCustom` — the classification recorded in the extract manifest and used for
+ * sourcePath normalisation. On UDE (customRoot set) it is PATH-based: a model is custom
+ * iff it lives under the custom root, matching the root-level package scan. Name-based
+ * isCustomModel() is only the fallback for traditional environments with no custom root.
+ * Using isCustomModel() on UDE would drop ISV models that ship source under the custom
+ * root — their names match neither D365FO_MODEL_NAME nor EXTENSION_PREFIX — leaving a
+ * `custom` build scoped to just the configured model (#711).
+ *
+ * `narrowedByConfig` — an explicit CUSTOM_MODELS list still NARROWS a custom-only run on
+ * UDE. The path rule decides what CAN be custom; a hand-maintained list decides how much
+ * of it to extract. The root-level scan ignores CUSTOM_MODELS entirely once customRoot is
+ * set, so without this an operator who set CUSTOM_MODELS="Contoso*" would have no way to
+ * scope a refresh to their own models and would re-extract every ISV under the root.
+ * Only wildcard patterns reach here — exact names take the MODELS_TO_EXTRACT path, which
+ * leaves FILTER_MODE at 'all'.
+ *
+ * Exported so the classification can be tested without running an extraction; the
+ * `customModels` parameter exists so tests need not depend on import-time env capture.
+ */
+export function classifyCustom(
+  rootPath: string,
+  customRoot: string | null,
+  modelName: string,
+  customModels: string[] = CUSTOM_MODELS,
+): { isCustom: boolean; narrowedByConfig: boolean } {
+  const isCustom = customRoot ? rootPath === customRoot : isCustomModel(modelName);
+  const narrowedByConfig =
+    !!customRoot && customModels.length > 0 && !isCustomModel(modelName);
+  return { isCustom, narrowedByConfig };
+}
+
+/**
  * Strip machine-specific prefix so that sourcePath stored in JSON is relative
  * to PackagesLocalDirectory (portable across CI agents and local machines).
  * e.g. "/home/vsts/work/1/PackagesLocalDirectory/App/App/AxClass/X.xml"
@@ -534,23 +568,7 @@ async function extractMetadata() {
         continue;
       }
 
-      // Custom classification for this model. On UDE (customRoot set) it is
-      // PATH-based — a model is custom iff it lives under the custom root —
-      // matching the root-level scan above and the manifest flag below. Only fall
-      // back to name-based isCustomModel() for traditional environments that have
-      // no custom root path. Using isCustomModel() here on UDE would drop ISV
-      // models with source under the custom root (their names match neither
-      // D365FO_MODEL_NAME nor EXTENSION_PREFIX), leaving a `custom` build scoped
-      // to just the configured model.
-      const isCustom = customRoot ? rootPath === customRoot : isCustomModel(modelName);
-
-      // An explicit CUSTOM_MODELS list still NARROWS a custom-only run on UDE. The path
-      // rule decides what CAN be custom; a hand-maintained list decides how much of it to
-      // extract. Only wildcard patterns reach this branch (exact names take the
-      // MODELS_TO_EXTRACT path above, which leaves FILTER_MODE at 'all'), and without this
-      // an operator on UDE would have no way to scope a refresh to their own models — the
-      // root-level scan ignores CUSTOM_MODELS entirely once customRoot is set.
-      const narrowedByConfig = !!customRoot && CUSTOM_MODELS.length > 0 && !isCustomModel(modelName);
+      const { isCustom, narrowedByConfig } = classifyCustom(rootPath, customRoot, modelName);
 
       // Apply model-level filtering
       if (FILTER_MODE === 'custom-only' && !isCustom) {

--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -544,9 +544,21 @@ async function extractMetadata() {
       // to just the configured model.
       const isCustom = customRoot ? rootPath === customRoot : isCustomModel(modelName);
 
+      // An explicit CUSTOM_MODELS list still NARROWS a custom-only run on UDE. The path
+      // rule decides what CAN be custom; a hand-maintained list decides how much of it to
+      // extract. Only wildcard patterns reach this branch (exact names take the
+      // MODELS_TO_EXTRACT path above, which leaves FILTER_MODE at 'all'), and without this
+      // an operator on UDE would have no way to scope a refresh to their own models — the
+      // root-level scan ignores CUSTOM_MODELS entirely once customRoot is set.
+      const narrowedByConfig = !!customRoot && CUSTOM_MODELS.length > 0 && !isCustomModel(modelName);
+
       // Apply model-level filtering
       if (FILTER_MODE === 'custom-only' && !isCustom) {
         log.detail(`${glyph.arrow} skip standard model: ${modelName}`);
+        continue;
+      }
+      if (FILTER_MODE === 'custom-only' && narrowedByConfig) {
+        log.detail(`${glyph.arrow} skip model outside CUSTOM_MODELS patterns: ${modelName}`);
         continue;
       }
       if (FILTER_MODE === 'standard-only' && isCustom) {

--- a/src/utils/extractManifest.ts
+++ b/src/utils/extractManifest.ts
@@ -24,7 +24,17 @@ export interface ExtractManifest {
   extractMode: string;
   /** 'ude' when custom models were path-auto-detected, else 'traditional'. */
   environment: 'ude' | 'traditional';
-  /** Model names the extract run classified as custom (exact on-disk directory names). */
+  /**
+   * Model names the extract run classified as custom (exact on-disk directory names).
+   *
+   * On UDE this means "non-Microsoft — lives under the custom root", which includes
+   * third-party ISV models that ship X++ source. It does NOT mean "models you own" or
+   * "models that are safe to write into": the runtime write guard and the pattern-stats
+   * miner deliberately keep their own name-based `isCustomModel()`/`isStandardModel()`
+   * classification and do not read this manifest. Consumers that need "is this our code"
+   * must not treat this list as an answer to that question — today its only consumer is
+   * `build-database`'s scoping of a `custom` rebuild.
+   */
   customModels: string[];
 }
 

--- a/tests/utils/extractCustomClassification.test.ts
+++ b/tests/utils/extractCustomClassification.test.ts
@@ -1,0 +1,150 @@
+/**
+ * extract-metadata custom classification (`classifyCustom`)
+ *
+ * On UDE the ModelStoreFolder (custom root) holds our own model AND third-party ISV
+ * models that ship X++ source. Two rules have to hold at once, and they pull in opposite
+ * directions — this file pins both.
+ *
+ *   1. #711: with no CUSTOM_MODELS configured, "custom" on UDE means "lives under the
+ *      custom root". Name-based isCustomModel() matches only D365FO_MODEL_NAME (and a
+ *      case-sensitive EXTENSION_PREFIX), so using it here dropped every source ISV before
+ *      it reached the extract manifest, and a `custom` build then reindexed exactly one
+ *      model while the rest of the custom root went stale.
+ *
+ *   2. An explicit CUSTOM_MODELS list must still NARROW that set. The root-level package
+ *      scan ignores CUSTOM_MODELS once customRoot is set, so the model-level check is the
+ *      only place a wildcard can take effect. Making the classification purely path-based
+ *      silently killed `CUSTOM_MODELS="Contoso*"` — the refresh would re-extract every ISV
+ *      under the root with no way to scope it.
+ *
+ * Together: the path rule decides what CAN be custom, an explicit list decides how much of
+ * it to extract. Traditional environments (no custom root) keep name-based behaviour.
+ *
+ * Regression guards:
+ *   - a source ISV under the custom root MUST classify custom when CUSTOM_MODELS is empty
+ *   - CUSTOM_MODELS="Contoso*" MUST keep narrowing that same ISV out of a custom-only run
+ *   - the narrowing MUST NOT leak into traditional environments
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { classifyCustom } from '../../scripts/extract-metadata';
+
+const CUSTOM_ROOT = 'C:\\UDE\\ModelStoreFolder';
+const MS_ROOT = 'C:\\UDE\\PackagesLocalDirectory';
+const TRADITIONAL_ROOT = 'C:\\AOSService\\PackagesLocalDirectory';
+
+/** Env keys isCustomModel() reads — cleared per test so a developer .env cannot leak in. */
+const ENV_KEYS = ['CUSTOM_MODELS', 'EXTENSION_PREFIX', 'D365FO_MODEL_NAME'] as const;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map(k => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe('classifyCustom on UDE with no CUSTOM_MODELS (#711)', () => {
+  beforeEach(() => {
+    process.env.D365FO_MODEL_NAME = 'MyModel';
+  });
+
+  it('classifies a source ISV under the custom root as custom', () => {
+    // The regression #711 fixed: Docentric matches neither D365FO_MODEL_NAME nor any
+    // prefix, so name-based classification dropped it and the manifest listed 1 model.
+    expect(classifyCustom(CUSTOM_ROOT, CUSTOM_ROOT, 'DocentricAXCore', [])).toEqual({
+      isCustom: true,
+      narrowedByConfig: false,
+    });
+  });
+
+  it('classifies the configured model under the custom root as custom', () => {
+    expect(classifyCustom(CUSTOM_ROOT, CUSTOM_ROOT, 'MyModel', []).isCustom).toBe(true);
+  });
+
+  it('classifies Microsoft packages outside the custom root as standard', () => {
+    expect(classifyCustom(MS_ROOT, CUSTOM_ROOT, 'ApplicationSuite', [])).toEqual({
+      isCustom: false,
+      narrowedByConfig: false,
+    });
+  });
+
+  it('does not rescue a model by name when it sits outside the custom root', () => {
+    // Path wins over name on UDE — otherwise the two phases disagree about "custom".
+    expect(classifyCustom(MS_ROOT, CUSTOM_ROOT, 'MyModel', []).isCustom).toBe(false);
+  });
+});
+
+describe('classifyCustom on UDE with CUSTOM_MODELS patterns', () => {
+  beforeEach(() => {
+    process.env.CUSTOM_MODELS = 'Contoso*';
+  });
+
+  const classify = (root: string, model: string) =>
+    classifyCustom(root, CUSTOM_ROOT, model, ['Contoso*']);
+
+  it('keeps a matching model in a custom-only run', () => {
+    expect(classify(CUSTOM_ROOT, 'ContosoRobotics')).toEqual({
+      isCustom: true,
+      narrowedByConfig: false,
+    });
+  });
+
+  it('matches the pattern case-insensitively', () => {
+    expect(classify(CUSTOM_ROOT, 'contosoDemo').narrowedByConfig).toBe(false);
+    expect(classify(CUSTOM_ROOT, 'CONTOSOX').narrowedByConfig).toBe(false);
+  });
+
+  it('narrows out a non-matching ISV under the same custom root', () => {
+    // The guard that matters: without narrowedByConfig, CUSTOM_MODELS="Contoso*" has no
+    // effect anywhere on UDE and this ISV gets re-extracted on every custom refresh.
+    expect(classify(CUSTOM_ROOT, 'DocentricAXCore')).toEqual({
+      isCustom: true,
+      narrowedByConfig: true,
+    });
+  });
+
+  it('leaves the manifest classification path-based while narrowing extraction', () => {
+    // isCustom stays true for the narrowed model: narrowing is about what this RUN
+    // extracts, not about relabelling an ISV as a Microsoft model.
+    expect(classify(CUSTOM_ROOT, 'DocentricAXCore').isCustom).toBe(true);
+  });
+
+  it('does not narrow when CUSTOM_MODELS is empty', () => {
+    delete process.env.CUSTOM_MODELS;
+    expect(classifyCustom(CUSTOM_ROOT, CUSTOM_ROOT, 'DocentricAXCore', []).narrowedByConfig)
+      .toBe(false);
+  });
+});
+
+describe('classifyCustom on traditional environments (no custom root)', () => {
+  it('falls back to name-based classification via CUSTOM_MODELS', () => {
+    process.env.CUSTOM_MODELS = 'Contoso*';
+    expect(classifyCustom(TRADITIONAL_ROOT, null, 'ContosoRobotics', ['Contoso*'])).toEqual({
+      isCustom: true,
+      narrowedByConfig: false,
+    });
+    expect(classifyCustom(TRADITIONAL_ROOT, null, 'ApplicationSuite', ['Contoso*'])).toEqual({
+      isCustom: false,
+      narrowedByConfig: false,
+    });
+  });
+
+  it('honours D365FO_MODEL_NAME', () => {
+    process.env.D365FO_MODEL_NAME = 'MyModel';
+    expect(classifyCustom(TRADITIONAL_ROOT, null, 'MyModel', []).isCustom).toBe(true);
+  });
+
+  it('never sets narrowedByConfig — the name check already decided isCustom', () => {
+    // Applying the narrowing here would double-filter and drop nothing extra, but it
+    // would make the flag mean two different things depending on environment.
+    process.env.CUSTOM_MODELS = 'Contoso*';
+    expect(classifyCustom(TRADITIONAL_ROOT, null, 'DocentricAXCore', ['Contoso*']))
+      .toEqual({ isCustom: false, narrowedByConfig: false });
+  });
+});


### PR DESCRIPTION
Follow-up to #704 (fixed by #706). #706 is a real improvement — the per-model reindex loop is gone (a `standard` build dropped from ~754s to ~140s for me) and the extract→build manifest bridge works well. But on UDE the manifest still under-classifies, so a `custom` refresh under-scopes. This PR closes that gap; the classification question behind it is laid out below for you to weigh.

## Problem

On a UDE environment the ModelStoreFolder (custom root) holds our own model plus third-party ISVs shipped **with X++ source** (e.g. Docentric AX and its satellite packages). After #706, a `custom` extract + build recorded only **one** model as custom:

    { "extractMode": "custom", "environment": "ude", "customModels": [ "MyModel" ] }
    Scoping custom build to 1 model(s) from extract manifest

Build-side scoping is correct — it faithfully reindexes what the manifest lists. The gap is upstream: `extract-metadata.ts` is only half path-based on UDE. The root scan (`~:471`) and the manifest `isCustom` flag (`~:550`) use the path rule (`rootPath === customRoot`), but the model-level filter (`~:538`/`:542`) still calls name-based `isCustomModel(modelName)` even when `customRoot` is set. Since `CUSTOM_MODELS` is empty on UDE and `isCustomModel()` matches only `D365FO_MODEL_NAME` (the `EXTENSION_PREFIX` branch is a case-sensitive `startsWith`), every ISV under the custom root is dropped as "standard" before it can reach the manifest.

Effect: a `custom` refresh after an ISV upgrade or pull reindexes only the configured model and leaves the rest of the source models under the custom root stale. (Binary-only ISVs are correctly out of scope in every mode — no AOT XML, so the `MODEL_MARKER_DIRS` gate skips them. This only concerns ISVs that ship source.)

## Fix

Compute the custom classification once using the same path rule already applied to the manifest flag, and use it for both the `custom-only`/`standard-only` guards and the manifest:

    const isCustom = customRoot ? rootPath === customRoot : isCustomModel(modelName);

On UDE, "custom" now means "lives under the custom root"; on traditional environments (no custom root) behaviour is unchanged. After the change, the manifest lists every source model under the custom root and the `custom` build scopes to them instead of just one.

## The classification question (for your call)

The fix rests on treating source ISV models as **custom**. That's a design decision, so here's the trade-off as I see it — happy to adjust if you weigh it differently.

**For (ISV = custom):**

1. **Refresh scoping** — the point of this PR. After pulling a new ISV build or a platform upgrade, a `custom` refresh should reindex ISV source; if ISV is "standard," the fast path silently skips those changes and the index goes stale.
2. **Pattern-catalog hygiene** — the form-pattern miner learns "standard D365 patterns" from *standard* models. ISV forms carry third-party conventions; classifying ISV custom keeps that corpus Microsoft-only.

**Considered but arguable both ways:** the custom-model boost in `contextRanker`. Boosting ISV helps surface it as part of the solution when answering questions — but your own model is arguably more relevant than a vendor's, so a single "custom" boost over-weights ISV relative to your own code. We don't lean on this either way; noting it so it's clear the spot was considered.

**Against (ISV = standard):** the write guard refuses edits to standard models to prevent modifying code you don't own; classifying ISV custom removes it from that guard.

**Why we weigh the write-guard concern lower:**

- The server can't reliably tell "our source" from "third-party ISV" — both are non-Microsoft siblings under the same custom root. "Microsoft vs non-Microsoft" is path-derivable (all that refresh + pattern-mining need); "ours vs ISV" is per-project developer knowledge that belongs in project config/instructions, not server-derived classification.
- An accidental ISV edit isn't silent — in a version-controlled project it shows up as a changed file under a vendor folder in the diff, and it's recoverable by redeploying the package.
- The high-risk case stays protected: Microsoft base models remain standard, so the write guard still hard-blocks edits to the base application.

If you'd rather keep ISV on the standard side for the write guard's sake, the alternative is to make the guard key on "is this the intended target of the write" rather than on `isStandardModel()` — but that's a larger change; this PR is the minimal one that fixes the refresh scoping.
