### PR TITLE
fix(release): generate real notes for the first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,23 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
+          # `git describe` fails when no earlier tag exists (the first release);
+          # without the guard the range collapses to HEAD..HEAD and the notes
+          # come out empty. Merge commits are dropped — the PR titles they carry
+          # are less informative than the underlying conventional commits.
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
           echo "## What's Changed" > CHANGELOG.md
-          git log $(git describe --tags --abbrev=0 HEAD^)..HEAD --pretty=format:"- %s (%h)" >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          if [ -n "$PREV_TAG" ]; then
+            echo "Changes since $PREV_TAG:" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            git log "$PREV_TAG..HEAD" --no-merges --pretty=format:"- %s (%h)" >> CHANGELOG.md
+          else
+            echo "Initial release — 30 most recent commits:" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            git log HEAD --no-merges --max-count=30 --pretty=format:"- %s (%h)" >> CHANGELOG.md
+          fi
+          echo "" >> CHANGELOG.md
 
       - name: Create Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Problem

The changelog step in `release.yml` ran:

```bash
git log $(git describe --tags --abbrev=0 HEAD^)..HEAD --pretty=format:"- %s (%h)"
```

`git describe --tags --abbrev=0 HEAD^` **fails when no earlier tag exists** — exactly the situation for the upcoming first release (the repo has no `v*` tags). The substitution then expands to nothing, the range collapses to `..HEAD` (≡ `HEAD..HEAD`, empty), and the release notes come out as a bare `## What's Changed`. Because the failure happens inside a command substitution, `set -e` does not trip and the step still reports success — silent, not loud.

## Fix

Guard the tag lookup and branch:

- **previous tag exists** → `<prev>..HEAD`, headed with "Changes since `<tag>`" (unchanged behaviour, just safe).
- **no previous tag** (first release) → 30 most recent commits, headed with "Initial release".

Both paths now pass `--no-merges`: this repo merges via PR, and the merge-commit subjects (`Merge pull request #712 from dynamics365ninja/feat/…`) are less informative than the conventional commits underneath them.

## Testing

Both branches were executed locally under `bash -eo pipefail` (the shell GitHub Actions uses) against the real history:

- **No-tag path** (current repo state) → 30 entries, correctly headed. Verified it produces non-empty notes where the old code produced none.
- **Previous-tag path** → simulated with a temporary local tag on `a4dc30a`; emitted exactly the two commits since it. Temp tag deleted, no tags remain in the repo.

Follows PR #712; this lands before the first `v1.0.0` tag so the initial GitHub Release ships with real notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)