### PR TITLE
chore(release): publish via trusted publishing, guard npm 12 script blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,18 +79,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Publishes the CLI/server package as `d365fo-mcp` so `npx d365fo-mcp` works.
-  # Requires the NPM_TOKEN repository secret (npm automation token); the job
-  # skips gracefully while the secret is not configured.
+  #
+  # Authenticates via npm trusted publishing (OIDC) — no NPM_TOKEN, no secret to
+  # rotate. npm matches the short-lived id-token against the trusted publisher
+  # configured on the package (org dynamics365ninja, repo d365fo-mcp-server,
+  # workflow release.yml), so renaming this file breaks publishing until the
+  # publisher entry is updated to match.
+  #
+  # Granular tokens with "bypass 2FA" are being retired instead: from early
+  # August 2026 they stop covering sensitive operations, and around January 2027
+  # they lose direct publishing entirely.
+  # https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write   # npm --provenance
+      id-token: write   # required — this is the OIDC credential npm exchanges
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # Trusted publishing needs npm >= 11.5.1 and Node >= 22.14.0; Node 24.x
+      # currently ships npm 11.16, so the bundled npm is enough. Downgrading the
+      # Node line below 22.14 would silently fall back to token auth and fail.
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
@@ -109,12 +121,7 @@ jobs:
             npm version --no-git-tag-version "$TAG_VERSION"
           fi
 
+      # No --provenance flag: trusted publishing attests provenance automatically
+      # for a public repo publishing a public package.
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "NPM_TOKEN secret not set — skipping npm publish."
-            exit 0
-          fi
-          npm publish --provenance --access public
+        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 **26 AI tools that know every X++ class, table, form, and EDT in your D365FO codebase**
 
+[![npm](https://img.shields.io/npm/v/d365fo-mcp.svg?logo=npm&color=cb3837)](https://www.npmjs.com/package/d365fo-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
@@ -106,6 +107,14 @@ npm run doctor       # health check — verifies Node, build, index, bridge
 ```
 
 Day-to-day management runs through the same CLI (`npx d365fo-mcp` or `npm run cli --`): `start`, `update`, `index`, `config` (change one area of the settings without re-running the wizard), and `instance add/list/run/rebuild/upgrade` for multi-instance setups. Every command works non-interactively with arguments, or asks with predefined choices when run bare.
+
+### The npm package
+
+The CLI is published as **[`d365fo-mcp`](https://www.npmjs.com/package/d365fo-mcp)**, so the management commands above are available as `npx d365fo-mcp <command>` without a global install. Inside a checkout `npx` resolves to your local build; elsewhere it fetches the published one.
+
+What it is *not* — yet — is a standalone install path. `setup`, `update` and `index` need the repository itself (`scripts/`, dev dependencies, `git pull`), so run from a bare `npx` they stop and point you back at the one-line installer rather than half-configuring a machine. **Installing the server still means the installer above.**
+
+A checkout-free path is coming for the one case that genuinely doesn't need the repository: a team member connecting to an already-deployed Azure server, where the only local artefact is an `.mcp.json` file.
 
 ### Manual setup
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*
 
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_d365fo-0098FF?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_d365fo-24bfa5?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&quality=insiders&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
+[![Add to Cursor](https://img.shields.io/badge/Cursor-Add_d365fo-000000?style=flat-square&logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=d365fo&config=eyJ1cmwiOiJodHRwczovL3lvdXItc2VydmVyLmF6dXJld2Vic2l0ZXMubmV0L21jcC8ifQ%3D%3D)
+
+*These connect an editor to a server that is already deployed — see [Quick Start](#quick-start) if you still need to set one up.*
+
 </div>
 
 ---
@@ -68,14 +74,16 @@ Structural violations (wrong order, missing container, disallowed control) **blo
 
 ## Quick Start
 
-Two entry points, depending on whether a server already exists:
+**Installing on your own D365FO VM** — the usual case. One line in PowerShell installs the prerequisites, clones the repository and runs the setup wizard, which builds the C# bridge and the metadata index for you:
 
 ```powershell
-# Your team already runs one — connects your editor, nothing installed
-npx d365fo-mcp connect https://your-server.azurewebsites.net
-
-# Setting up your own D365FO VM — installs prerequisites, clones, runs the wizard
 irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/install.ps1 | iex
+```
+
+**Your team already runs a shared server?** Then you install nothing — point your editor at it:
+
+```powershell
+npx d365fo-mcp connect https://your-server.azurewebsites.net
 ```
 
 Both paths in full — prerequisites, editor configuration for every scenario, the required instruction file, and how to verify grounding actually works: **[docs/QUICK_START.md](docs/QUICK_START.md)**

--- a/README.md
+++ b/README.md
@@ -86,7 +86,15 @@ Your team already runs a deployed server? Add it to your editor from here; nothi
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_d365fo-24bfa5?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&quality=insiders&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
 [![Add to Cursor](https://img.shields.io/badge/Cursor-Add_d365fo-000000?style=flat-square&logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=d365fo&config=eyJ1cmwiOiJodHRwczovL3lvdXItc2VydmVyLmF6dXJld2Vic2l0ZXMubmV0L21jcC8ifQ%3D%3D)
 
-VS Code prompts for the server URL; Cursor installs a placeholder you then edit. Visual Studio and Claude Code have no install link — write the `.mcp.json` block by hand, see [docs/QUICK_START.md](docs/QUICK_START.md) and [docs/CLAUDE_CODE_SETUP.md](docs/CLAUDE_CODE_SETUP.md).
+VS Code prompts for the server URL; Cursor installs a placeholder you then edit.
+
+For Visual Studio and Claude Code — which have no install link — or to skip the editing entirely, let the CLI write the config:
+
+```powershell
+npx d365fo-mcp connect https://your-server.azurewebsites.net
+```
+
+It checks the server answers, asks which editor and whether an API key is needed, then merges the entry into that editor's config, leaving any other MCP servers alone. Claude Code is registered through its own `claude mcp add-json`. Scriptable as `npx d365fo-mcp connect <url> --client vs|vscode|cursor|claude --api-key <key> --yes`.
 
 ### One-line install (recommended) — Paths B, C, E
 
@@ -116,9 +124,9 @@ Day-to-day management runs through the same CLI (`npx d365fo-mcp` or `npm run cl
 
 The CLI is published as **[`d365fo-mcp`](https://www.npmjs.com/package/d365fo-mcp)**, so the management commands above are available as `npx d365fo-mcp <command>` without a global install. Inside a checkout `npx` resolves to your local build; elsewhere it fetches the published one.
 
-What it is *not* — yet — is a standalone install path. `setup`, `update` and `index` need the repository itself (`scripts/`, dev dependencies, `git pull`), so run from a bare `npx` they stop and point you back at the one-line installer rather than half-configuring a machine. **Installing the server still means the installer above.**
+`connect` is the one command that needs nothing else — no clone, no build, no index — because Path A's entire installation is a config entry naming a remote URL.
 
-A checkout-free path is coming for the one case that genuinely doesn't need the repository: a team member connecting to an already-deployed Azure server, where the only local artefact is an `.mcp.json` file.
+Everything else does need the repository: `setup`, `update` and `index` use `scripts/`, dev dependencies and `git pull`, so run from a bare `npx` they stop and point you back at the one-line installer rather than half-configuring a machine. **Installing a server still means the installer above.**
 
 ### Manual setup
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*
 
-[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_d365fo-0098FF?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
-[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_d365fo-24bfa5?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&quality=insiders&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
-[![Add to Cursor](https://img.shields.io/badge/Cursor-Add_d365fo-000000?style=flat-square&logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=d365fo&config=eyJ1cmwiOiJodHRwczovL3lvdXItc2VydmVyLmF6dXJld2Vic2l0ZXMubmV0L21jcC8ifQ%3D%3D)
-
-*One-click install connects to an already-deployed server — VS Code asks for the URL, Cursor installs a placeholder to edit. Visual Studio & Claude Code: see [Quick Start](#quick-start).*
-
 </div>
 
 ---
@@ -84,7 +78,17 @@ Pick your path:
 
 Full walkthrough with all scenarios: **[docs/QUICK_START.md](docs/QUICK_START.md)**
 
-### One-line install (recommended)
+### One-click install — Path A
+
+Your team already runs a deployed server? Add it to your editor from here; nothing is installed locally beyond the config entry.
+
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_d365fo-0098FF?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_d365fo-24bfa5?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&quality=insiders&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
+[![Add to Cursor](https://img.shields.io/badge/Cursor-Add_d365fo-000000?style=flat-square&logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=d365fo&config=eyJ1cmwiOiJodHRwczovL3lvdXItc2VydmVyLmF6dXJld2Vic2l0ZXMubmV0L21jcC8ifQ%3D%3D)
+
+VS Code prompts for the server URL; Cursor installs a placeholder you then edit. Visual Studio and Claude Code have no install link — write the `.mcp.json` block by hand, see [docs/QUICK_START.md](docs/QUICK_START.md) and [docs/CLAUDE_CODE_SETUP.md](docs/CLAUDE_CODE_SETUP.md).
+
+### One-line install (recommended) — Paths B, C, E
 
 Paste into PowerShell on the D365FO VM — the installer checks (and installs, if missing) Node.js and Git, clones the repository, runs `npm install`, and starts the interactive setup wizard:
 

--- a/README.md
+++ b/README.md
@@ -68,135 +68,17 @@ Structural violations (wrong order, missing container, disallowed control) **blo
 
 ## Quick Start
 
-Pick your path:
-
-| Path | Who | Install effort |
-|------|-----|---------------|
-| **A — Azure client** | Team member, server already deployed | `.mcp.json` only — 2 minutes |
-| **B — Hybrid** (recommended for teams) | Azure search + local writes on your VM | Clone + build, no indexing |
-| **C/E — Local** | Single developer, everything on the VM | Clone + build + index (~15 min) |
-
-Full walkthrough with all scenarios: **[docs/QUICK_START.md](docs/QUICK_START.md)**
-
-### One-click install — Path A
-
-Your team already runs a deployed server? Add it to your editor from here; nothing is installed locally beyond the config entry.
-
-[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_d365fo-0098FF?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
-[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_d365fo-24bfa5?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&quality=insiders&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
-[![Add to Cursor](https://img.shields.io/badge/Cursor-Add_d365fo-000000?style=flat-square&logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=d365fo&config=eyJ1cmwiOiJodHRwczovL3lvdXItc2VydmVyLmF6dXJld2Vic2l0ZXMubmV0L21jcC8ifQ%3D%3D)
-
-VS Code prompts for the server URL; Cursor installs a placeholder you then edit.
-
-For Visual Studio and Claude Code — which have no install link — or to skip the editing entirely, let the CLI write the config:
+Two entry points, depending on whether a server already exists:
 
 ```powershell
+# Your team already runs one — connects your editor, nothing installed
 npx d365fo-mcp connect https://your-server.azurewebsites.net
-```
 
-It checks the server answers, asks which editor and whether an API key is needed, then merges the entry into that editor's config, leaving any other MCP servers alone. Claude Code is registered through its own `claude mcp add-json`. Scriptable as `npx d365fo-mcp connect <url> --client vs|vscode|cursor|claude --api-key <key> --yes`.
-
-### One-line install (recommended) — Paths B, C, E
-
-Paste into PowerShell on the D365FO VM — the installer checks (and installs, if missing) Node.js and Git, clones the repository, runs `npm install`, and starts the interactive setup wizard:
-
-```powershell
+# Setting up your own D365FO VM — installs prerequisites, clones, runs the wizard
 irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/install.ps1 | iex
 ```
 
-Safe to re-run — an existing installation is updated instead of re-cloned. Configure via env vars when needed: `$env:D365FO_MCP_DIR` (install directory), `$env:D365FO_MCP_YES = '1'` (non-interactive), `$env:D365FO_MCP_NO_WIZARD = '1'` (skip the wizard).
-
-### Interactive setup
-
-Already cloned, or prefer to run the steps yourself? After `npm install`, the management CLI walks you through everything else — scenario selection, C# bridge build, configuration, index build — and prints the `.mcp.json` block to paste. Every answer is explained as it is asked and stored in `config/d365fo-mcp.json`; there is no `.env` to fill in (see **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)** for the full setting reference):
-
-```powershell
-git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
-cd K:\d365fo-mcp-server
-npm install
-npm run setup        # first-time setup wizard
-npm run doctor       # health check — verifies Node, build, index, bridge
-```
-
-Day-to-day management runs through the same CLI (`npx d365fo-mcp` or `npm run cli --`): `start`, `update`, `index`, `config` (change one area of the settings without re-running the wizard), and `instance add/list/run/rebuild/upgrade` for multi-instance setups. Every command works non-interactively with arguments, or asks with predefined choices when run bare.
-
-### The npm package
-
-The CLI is published as **[`d365fo-mcp`](https://www.npmjs.com/package/d365fo-mcp)**, so the management commands above are available as `npx d365fo-mcp <command>` without a global install. Inside a checkout `npx` resolves to your local build; elsewhere it fetches the published one.
-
-`connect` is the one command that needs nothing else — no clone, no build, no index — because Path A's entire installation is a config entry naming a remote URL.
-
-Everything else does need the repository: `setup`, `update` and `index` use `scripts/`, dev dependencies and `git pull`, so run from a bare `npx` they stop and point you back at the one-line installer rather than half-configuring a machine. **Installing a server still means the installer above.**
-
-### Manual setup
-
-```powershell
-# Local / hybrid install (on the D365FO VM)
-git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
-cd K:\d365fo-mcp-server
-npm install
-cd bridge\D365MetadataBridge; dotnet build -c Release; cd ..\..   # C# bridge — required for writes
-npm run build
-
-# Local only — build the metadata index (skip for hybrid)
-npm run setup                     # writes config/d365fo-mcp.json (packages path, models, prefix…)
-npm run extract-metadata
-npm run build-database
-```
-
-> Prefer to write the configuration yourself? `config/d365fo-mcp.json` is plain JSON — every key, default and
-> matching environment variable is listed in [docs/CONFIGURATION.md](docs/CONFIGURATION.md). A pre-existing
-> `.env` keeps working and is imported by the wizard.
-
-### Connect GitHub Copilot
-
-1. Enable *MCP servers in Copilot* at [github.com/settings/copilot/features](https://github.com/settings/copilot/features)
-2. Visual Studio → **Tools → Options → GitHub → Copilot** → *Enable MCP server integration in agent mode*
-3. Create `%USERPROFILE%\.mcp.json`:
-
-```json
-{
-  "servers": {
-    "d365fo-azure": { "url": "https://your-server.azurewebsites.net/mcp/" },
-    "d365fo-local": {
-      "command": "node",
-      "args": ["K:\\d365fo-mcp-server\\dist\\index.js"],
-      "env": {
-        "MCP_SERVER_MODE": "write-only",
-        "D365FO_SOLUTIONS_PATH": "K:\\repos\\MySolution\\projects",
-        "D365FO_WORKSPACE_PATH": "K:\\AosService\\PackagesLocalDirectory\\YourPackage\\YourModel"
-      }
-    }
-  }
-}
-```
-
-4. Copy the instruction files into a parent folder of your solutions (one copy covers everything beneath it):
-
-```powershell
-Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
-```
-
-All options: **[docs/MCP_CONFIG.md](docs/MCP_CONFIG.md)**
-
-### Connect Claude Code
-
-```powershell
-claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https://your-server.azurewebsites.net/mcp/","alwaysLoad":true}'
-Copy-Item "K:\d365fo-mcp-server\.github\copilot-instructions.md" "C:\source\repos\CLAUDE.md"
-```
-
-Stdio variant and troubleshooting: **[docs/CLAUDE_CODE_SETUP.md](docs/CLAUDE_CODE_SETUP.md)**
-
-### Verify
-
-Open the AI chat (Copilot Agent Mode / Claude Code) and ask:
-
-```
-I'm tracing a posting issue — find every table (standard + ISV extensions) that carries the CustAccount field, so I can see where the value could get overwritten.
-```
-
-A `search` tool call returning results from **your** metadata — including your ISV models, which no model's training data has seen — means you're connected.
+Both paths in full — prerequisites, editor configuration for every scenario, the required instruction file, and how to verify grounding actually works: **[docs/QUICK_START.md](docs/QUICK_START.md)**
 
 ---
 
@@ -214,7 +96,7 @@ Deployment guide: [docs/SETUP_AZURE.md](docs/SETUP_AZURE.md) · CI/CD automation
 
 | Getting started | Reference | Operations |
 |-----------------|-----------|------------|
-| [Quick Start](docs/QUICK_START.md) — 5 steps to running | [All 26 tools](docs/MCP_TOOLS.md) | [Azure deployment](docs/SETUP_AZURE.md) |
+| [Quick Start](docs/QUICK_START.md) — connect or install | [All 26 tools](docs/MCP_TOOLS.md) | [Azure deployment](docs/SETUP_AZURE.md) |
 | [Setup scenarios A–F](docs/SETUP.md) | [`.mcp.json` reference](docs/MCP_CONFIG.md) | [DevOps pipelines](docs/PIPELINES.md) |
 | [Claude Code setup](docs/CLAUDE_CODE_SETUP.md) | [Architecture](docs/ARCHITECTURE.md) | [Testing](docs/TESTING.md) |
 | [Usage examples](docs/USAGE_EXAMPLES.md) — real tool chains | [C# Bridge](docs/BRIDGE.md) | [Custom / ISV models](docs/CUSTOM_EXTENSIONS.md) |

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -33,6 +33,8 @@ irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/in
 
 Safe to re-run — an existing installation is updated (`git pull`) instead of re-cloned. Env-var overrides: `$env:D365FO_MCP_DIR` (install directory), `$env:D365FO_MCP_YES = '1'` (non-interactive defaults), `$env:D365FO_MCP_NO_WIZARD = '1'` (clone + install only). If the wizard completed, continue with [Step 3](#step-3--connect-copilot).
 
+> **Why not `npx d365fo-mcp setup`?** The CLI is on npm as [`d365fo-mcp`](https://www.npmjs.com/package/d365fo-mcp) and the management commands (`start`, `doctor`, `config`, `index`, `instance …`) run through it, but `setup`, `update` and `index` need the repository itself — `scripts/`, dev dependencies and `git pull`. Run from a bare `npx` they stop and refer you back here instead of half-configuring the machine. Installing the server means the one-liner above.
+
 ### Interactive setup
 
 The first-time setup wizard walks you through everything below — scenario selection, C# bridge build, configuration, index build — and prints the `.mcp.json` block to paste in Step 3. It asks only what your scenario needs, explains every question, and saves the answers to `config/d365fo-mcp.json` (secrets to `config/secrets.json`), so no `.env` editing is involved:

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -4,8 +4,8 @@ Two very different jobs share this page. Pick yours — each path is self-contai
 
 | Your situation | Path | Effort |
 |---|---|---|
+| You are setting up your own D365FO VM — **the usual case** | [**B–E — Install**](#paths-be--install-on-your-d365fo-vm) | 10 min, or ~25 with a local index |
 | Your team already runs a deployed server | [**A — Connect**](#path-a--connect-to-a-server-someone-else-deployed) | ~2 min, nothing installed |
-| You are setting up your own D365FO VM | [**B–E — Install**](#paths-be--install-on-your-d365fo-vm) | 10 min, or ~25 with a local index |
 | One machine serving several D365FO environments | **F — Multi-instance** | [SETUP.md](SETUP.md#scenario-f-multiple-instances--one-machine-multiple-d365fo-environments) |
 
 Both paths finish with the [instruction file](#the-instruction-file-required) and [verification](#verify) at the bottom — those two are shared.
@@ -14,6 +14,8 @@ Both paths finish with the [instruction file](#the-instruction-file-required) an
 
 
 # Path A — connect to a server someone else deployed
+
+Only if someone has already deployed a shared server for your team — otherwise skip to [Paths B–E](#paths-be--install-on-your-d365fo-vm).
 
 Nothing is installed locally: the whole configuration is one entry naming a remote URL. You need only your editor and the server URL from whoever deployed it (plus an API key, if that deployment enforces one).
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,107 +1,43 @@
 # Quick Start
 
-Get the D365 F&O MCP Server running with GitHub Copilot in 5 steps.
+Two very different jobs share this page. Pick yours — each path is self-contained, so you only read your own.
 
-> **Server already deployed on Azure by your team?** Skip to [Step 3](#step-3--connect-copilot) — you only need a `.mcp.json` file.
->
-> **Using Claude Code instead of Copilot?** See [CLAUDE_CODE_SETUP.md](CLAUDE_CODE_SETUP.md).
+| Your situation | Path | Effort |
+|---|---|---|
+| Your team already runs a deployed server | [**A — Connect**](#path-a--connect-to-a-server-someone-else-deployed) | ~2 min, nothing installed |
+| You are setting up your own D365FO VM | [**B–E — Install**](#paths-be--install-on-your-d365fo-vm) | 10 min, or ~25 with a local index |
+| One machine serving several D365FO environments | **F — Multi-instance** | [SETUP.md](SETUP.md#scenario-f-multiple-instances--one-machine-multiple-d365fo-environments) |
 
----
+Both paths finish with the [instruction file](#the-instruction-file-required) and [verification](#verify) at the bottom — those two are shared.
 
-## Step 1 — Prerequisites
+> Deploying the shared Azure server for your team is a separate job: [SETUP_AZURE.md](SETUP_AZURE.md).
 
-| Requirement | Where to get it | Needed for |
-|------------|----------------|------------|
-| Visual Studio 2022 ≥ 17.14 (or 2026) | Visual Studio Installer | all scenarios |
-| GitHub Copilot extension | VS → Extensions | all scenarios |
-| Node.js 24.x LTS | [nodejs.org](https://nodejs.org) or `Install-D365SupportingSoftware -Name node.js` | local / hybrid |
-| Python 3.x | bundled with Node.js installer (check the option) | local / hybrid |
-| .NET Framework 4.8 Dev Pack | pre-installed on D365FO VMs | C# bridge (writes) |
-| Git | [git-scm.com](https://git-scm.com) | local / hybrid |
 
----
+# Path A — connect to a server someone else deployed
 
-## Step 2 — Clone and build
+Nothing is installed locally: the whole configuration is one entry naming a remote URL. You need only your editor and the server URL from whoever deployed it (plus an API key, if that deployment enforces one).
 
-### One-line install (recommended)
-
-Paste into PowerShell — the installer takes care of the Node.js and Git prerequisites from Step 1 (installs them if missing), clones the repository, runs `npm install`, and hands off to the setup wizard:
-
-```powershell
-irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/install.ps1 | iex
-```
-
-Safe to re-run — an existing installation is updated (`git pull`) instead of re-cloned. Env-var overrides: `$env:D365FO_MCP_DIR` (install directory), `$env:D365FO_MCP_YES = '1'` (non-interactive defaults), `$env:D365FO_MCP_NO_WIZARD = '1'` (clone + install only). If the wizard completed, continue with [Step 3](#step-3--connect-copilot).
-
-> **Why not `npx d365fo-mcp setup`?** The CLI is on npm as [`d365fo-mcp`](https://www.npmjs.com/package/d365fo-mcp) and the management commands (`start`, `doctor`, `config`, `index`, `instance …`) run through it, but `setup`, `update` and `index` need the repository itself — `scripts/`, dev dependencies and `git pull`. Run from a bare `npx` they stop and refer you back here instead of half-configuring the machine. Installing the server means the one-liner above.
-
-### Interactive setup
-
-The first-time setup wizard walks you through everything below — scenario selection, C# bridge build, configuration, index build — and prints the `.mcp.json` block to paste in Step 3. It asks only what your scenario needs, explains every question, and saves the answers to `config/d365fo-mcp.json` (secrets to `config/secrets.json`), so no `.env` editing is involved:
-
-```powershell
-git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
-cd K:\d365fo-mcp-server
-npm install
-npm run setup        # first-time setup wizard
-npm run doctor       # health check — verifies Node, build, index, bridge
-```
-
-If the wizard completed, skip the manual steps and continue with [Step 3](#step-3--connect-copilot).
-
-### Manual setup
-
-```powershell
-git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
-cd K:\d365fo-mcp-server
-npm install
-cd bridge\D365MetadataBridge; dotnet build -c Release; cd ..\..   # C# bridge — required for writes
-npm run build
-```
-
-**Local index** (skip for hybrid — the index lives in Azure):
-
-```powershell
-npm run setup                    # packages path, custom models, prefix, label languages…
-npm run extract-metadata
-npm run build-database
-```
-
-> Writing the configuration by hand instead? `config/d365fo-mcp.json` is plain JSON; every key, its default and
-> the environment variable it maps to are listed in [CONFIGURATION.md](CONFIGURATION.md). An existing `.env` is
-> still read as a fallback and is imported the first time the wizard runs.
-
----
-
-## Step 3 — Connect Copilot
-
-1. [github.com/settings/copilot/features](https://github.com/settings/copilot/features) → enable **MCP servers in Copilot**
-2. Visual Studio: **Tools → Options → GitHub → Copilot** → enable **MCP server integration in agent mode**
-3. Copilot Chat → switch to **Agent Mode**
-4. Create `.mcp.json` — either `%USERPROFILE%\.mcp.json` (all solutions, recommended) or next to a specific `.sln`
-
-Pick your scenario:
-
-| Scenario | What runs where | Best for |
-|----------|----------------|----------|
-| [**A** — Azure client](#a--azure-client) | everything on Azure, read-only | team members |
-| [**B** — Hybrid](#b--hybrid-azure--local-writes) | Azure search + local writes | **teams (recommended)** |
-| [**C** — Local HTTP](#c--local-http) | `npm run dev` on the VM | single developer |
-| [**D** — Local stdio](#d--local-stdio) | VS spawns the process | single developer, zero-config |
-| **E** — UDE | stdio + XPP config auto-detection | UDE / Power Platform Tools — [SETUP.md](SETUP.md#scenario-d-ude-unified-developer-experience) |
-| **F** — Multi-instance | one machine, several clients | agencies — [SETUP.md](SETUP.md#scenario-f-multiple-instances--one-machine-multiple-d365fo-environments) |
-
-### A — Azure client
-
-Let the CLI write it (no clone needed — it merges into your editor's config and leaves other MCP servers alone):
+### Option 1 — the CLI writes it
 
 ```powershell
 npx d365fo-mcp connect https://your-server.azurewebsites.net
 ```
 
-It asks which editor and whether the server needs an API key, verifies the server answers before writing, and registers Claude Code through its own `claude mcp add-json`. Non-interactively: `--client vs|vscode|cursor|claude --api-key <key> --yes`.
+Asks which editor and whether a key is needed, checks the server answers before writing anything, then merges the entry into that editor's config — any other MCP servers you have are left alone. Claude Code is registered through its own `claude mcp add-json`.
 
-Or write it by hand:
+Scriptable: `npx d365fo-mcp connect <url> --client vs|vscode|cursor|claude --api-key <key> --yes`.
+
+### Option 2 — one click
+
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_d365fo-0098FF?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_d365fo-24bfa5?style=flat-square&logo=githubcopilot&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=d365fo&quality=insiders&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22d365fo_server_url%22%2C%22description%22%3A%22D365FO%20MCP%20server%20URL%20(e.g.%20https%3A%2F%2Fyour-server.azurewebsites.net%2Fmcp%2F)%22%7D%5D&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22%24%7Binput%3Ad365fo_server_url%7D%22%7D)
+[![Add to Cursor](https://img.shields.io/badge/Cursor-Add_d365fo-000000?style=flat-square&logo=cursor&logoColor=white)](https://cursor.com/install-mcp?name=d365fo&config=eyJ1cmwiOiJodHRwczovL3lvdXItc2VydmVyLmF6dXJld2Vic2l0ZXMubmV0L21jcC8ifQ%3D%3D)
+
+VS Code prompts for the URL; Cursor installs a placeholder you then edit. Visual Studio and Claude Code have no install link — use Option 1 or 3.
+
+### Option 3 — by hand
+
+Visual Studio reads `%USERPROFILE%\.mcp.json` (all solutions) or a `.mcp.json` next to a specific `.sln`:
 
 ```json
 {
@@ -111,7 +47,7 @@ Or write it by hand:
 }
 ```
 
-If the deployment enforces an API key, add it as a header:
+With an API key, add it as a header:
 
 ```json
 {
@@ -124,9 +60,92 @@ If the deployment enforces an API key, add it as a header:
 }
 ```
 
-> Read-only — cannot write files on your VM. Use **B** for writes.
+Claude Code keeps its config elsewhere:
 
-### B — Hybrid (Azure + local writes)
+```powershell
+claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https://your-server.azurewebsites.net/mcp/","alwaysLoad":true}'
+```
+
+> **Read-only.** An Azure client searches and reads your indexed metadata but cannot write files on your VM. For writes, use the hybrid setup in [Path B](#b--hybrid--azure-search--local-writes).
+
+**Using Copilot?** Also do the [Copilot switches](#enable-copilot-visual-studio) below. Then continue with the [instruction file](#the-instruction-file-required).
+
+
+# Paths B–E — install on your D365FO VM
+
+## 1. Prerequisites
+
+| Requirement | Where to get it | Needed for |
+|------------|----------------|------------|
+| Visual Studio 2022 ≥ 17.14 (or 2026) | Visual Studio Installer | all scenarios |
+| GitHub Copilot extension | VS → Extensions | Copilot users |
+| .NET Framework 4.8 Dev Pack | pre-installed on D365FO VMs | C# bridge (writes) |
+| Node.js 24.x LTS | [nodejs.org](https://nodejs.org), or `Install-D365SupportingSoftware -Name node.js` | installed for you by the one-liner |
+| Git | [git-scm.com](https://git-scm.com) | installed for you by the one-liner |
+| Python 3.x | option in the Node.js installer | only if npm cannot fetch a prebuilt `better-sqlite3` binary and has to compile it |
+
+## 2. Install
+
+```powershell
+irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/install.ps1 | iex
+```
+
+The installer checks for Node.js and Git (installing them if missing), clones the repository, runs `npm install`, and hands off to the setup wizard — which selects your scenario, builds the C# bridge, asks only the settings that scenario needs, builds the index if you want one, and prints the `.mcp.json` block for step 3.
+
+Safe to re-run: an existing installation is updated (`git pull`) rather than re-cloned. Override with environment variables set on the same line:
+
+| Variable | Effect |
+|---|---|
+| `$env:D365FO_MCP_DIR` | install directory (default `K:\d365fo-mcp-server`) |
+| `$env:D365FO_MCP_YES = '1'` | non-interactive, accept defaults |
+| `$env:D365FO_MCP_NO_WIZARD = '1'` | clone + `npm install` only, skip the wizard |
+
+Answers are saved to `config/d365fo-mcp.json` (secrets to `config/secrets.json`) — there is no `.env` to fill in. Every key, its default and the matching environment variable: [CONFIGURATION.md](CONFIGURATION.md). An older `.env` keeps working and is imported the first time the wizard runs.
+
+<details>
+<summary>Prefer to run the steps yourself</summary>
+
+```powershell
+git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server
+cd K:\d365fo-mcp-server
+npm install
+cd bridge\D365MetadataBridge; dotnet build -c Release; cd ..\..   # required for writes
+npm run build
+npm run setup        # scenario, paths, models, prefix, label languages…
+npm run doctor       # verifies Node, build, index, bridge
+```
+
+A local index (skip it for hybrid — that index lives in Azure):
+
+```powershell
+npm run extract-metadata
+npm run build-database
+```
+
+</details>
+
+> **Why not `npx d365fo-mcp setup`?** The CLI is on npm as [`d365fo-mcp`](https://www.npmjs.com/package/d365fo-mcp), but `setup`, `update` and `index` need the repository itself — `scripts/`, dev dependencies and `git pull`. Run from a bare `npx` they stop and refer you back here rather than half-configuring the machine. Only `connect` (Path A) is self-sufficient.
+
+## 3. Configure your editor
+
+### Enable Copilot (Visual Studio)
+
+1. [github.com/settings/copilot/features](https://github.com/settings/copilot/features) → enable **MCP servers in Copilot**
+2. Visual Studio → **Tools → Options → GitHub → Copilot** → enable **MCP server integration in agent mode**
+3. Copilot Chat → switch to **Agent Mode**
+
+Using Claude Code instead? [CLAUDE_CODE_SETUP.md](CLAUDE_CODE_SETUP.md) covers it end to end.
+
+### Then pick the scenario the wizard configured
+
+| Scenario | What runs where | Best for |
+|----------|----------------|----------|
+| [**B** — Hybrid](#b--hybrid--azure-search--local-writes) | Azure search + local writes | **teams (recommended)** |
+| [**C** — Local HTTP](#c--local-http) | `npm run dev` on the VM | single developer |
+| [**D** — Local stdio](#d--local-stdio) | VS spawns the process | single developer, zero-config |
+| **E** — UDE | stdio + XPP config auto-detection | UDE / Power Platform Tools — [SETUP.md](SETUP.md#scenario-d-ude-unified-developer-experience) |
+
+#### B — Hybrid — Azure search + local writes
 
 ```json
 {
@@ -145,7 +164,7 @@ If the deployment enforces an API key, add it as a header:
 }
 ```
 
-### C — Local HTTP
+#### C — Local HTTP
 
 ```json
 {
@@ -155,9 +174,9 @@ If the deployment enforces an API key, add it as a header:
 }
 ```
 
-Start with `cd K:\d365fo-mcp-server && npm run dev`.
+Start the server with `npx d365fo-mcp start` (or `npm run dev`) in the install directory.
 
-### D — Local stdio
+#### D — Local stdio
 
 ```json
 {
@@ -177,34 +196,41 @@ Start with `cd K:\d365fo-mcp-server && npm run dev`.
 }
 ```
 
-> Complete parameter reference (every env var, per-scenario matrix): [MCP_CONFIG.md](MCP_CONFIG.md)
+> Every environment variable and a per-scenario matrix: [MCP_CONFIG.md](MCP_CONFIG.md).
 
----
 
-## Step 4 — Place copilot-instructions.md
+# The instruction file (required)
 
 ```powershell
-# One copy in a common parent folder covers all solutions beneath it
+# One copy in a common parent folder covers every solution beneath it
 Copy-Item -Path ".github" -Destination "C:\source\repos\" -Recurse
 ```
 
-VS 2022 searches for `.github\copilot-instructions.md` upward from the solution folder. **This step is not optional** — it delivers the workflow rules (tool routing, confirm-before-write, terminal prohibition) that the agent relies on.
+VS 2022 searches upward from the solution folder for `.github\copilot-instructions.md`. **Not optional** — it carries the workflow rules the agent depends on: tool routing, confirm-before-write, and the terminal prohibition. Claude Code reads the same content as `CLAUDE.md`:
 
----
+```powershell
+Copy-Item "K:\d365fo-mcp-server\.github\copilot-instructions.md" "C:\source\repos\CLAUDE.md"
+```
 
-## Step 5 — Verify
+Path A users: take the file from [the repository](https://github.com/dynamics365ninja/d365fo-mcp-server/blob/main/.github/copilot-instructions.md) — it is the one thing you do need locally.
+
+
+# Verify
+
+Restart the editor, open the AI chat, and ask:
 
 | Test | Prompt | Confirms |
 |------|--------|----------|
 | Search | `Find every table (standard + ISV) that carries the CustAccount field` | index + connection |
-| Write | `Create a class TestHelper with a static method hello()` | C# bridge |
+| Write | `Create a class TestHelper with a static method hello()` | C# bridge (not Path A) |
 | Forms | `Which form pattern should I use for a setup table with 5 fields?` | pattern advisor |
 
-If the first prompt triggers a `search` tool call with results from your codebase, you are connected.
+The first prompt should trigger a `search` tool call returning results from **your** metadata — including ISV models no training data has ever seen. That is the signal that grounding works, not just that the server is reachable.
 
----
+On an installed server, `npx d365fo-mcp doctor` checks the same ground from the other side: Node version, build, native binding, index size, bridge, and any stale configuration.
 
-## Logging & Diagnostics
+
+# Logging & diagnostics
 
 Add to the `env` block in `.mcp.json` when something isn't working:
 
@@ -218,26 +244,22 @@ Add to the `env` block in `.mcp.json` when something isn't working:
 Get-Content "C:\Temp\d365fo-mcp.log" -Encoding UTF8 -Wait    # watch live
 ```
 
-Healthy startup log:
-
-```
-✅ C# bridge initialized (metadataAvailable: true, xrefAvailable: true)
-```
+A healthy startup logs `✅ C# bridge initialized (metadataAvailable: true, xrefAvailable: true)`:
 
 | Flag | Meaning |
 |------|---------|
 | `metadataAvailable: false` | D365FO DLLs not loaded — check `packagePath` and .NET 4.8 |
 | `xrefAvailable: false` | `DYNAMICSXREFDB` unreachable — non-critical, tools fall back to SQLite |
 
----
 
-## What's next
+# What's next
 
 | Topic | Documentation |
 |-------|--------------|
 | All 26 tools | [MCP_TOOLS.md](MCP_TOOLS.md) |
 | Real-world tool chains (CoC, forms, security, reports) | [USAGE_EXAMPLES.md](USAGE_EXAMPLES.md) |
 | Full `.mcp.json` reference | [MCP_CONFIG.md](MCP_CONFIG.md) |
+| Every setting and its environment variable | [CONFIGURATION.md](CONFIGURATION.md) |
 | Detailed setup scenarios A–F | [SETUP.md](SETUP.md) |
-| Azure deployment | [SETUP_AZURE.md](SETUP_AZURE.md) |
+| Azure deployment (admins) | [SETUP_AZURE.md](SETUP_AZURE.md) |
 | Claude Code CLI | [CLAUDE_CODE_SETUP.md](CLAUDE_CODE_SETUP.md) |

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -93,10 +93,33 @@ Pick your scenario:
 
 ### A — Azure client
 
+Let the CLI write it (no clone needed — it merges into your editor's config and leaves other MCP servers alone):
+
+```powershell
+npx d365fo-mcp connect https://your-server.azurewebsites.net
+```
+
+It asks which editor and whether the server needs an API key, verifies the server answers before writing, and registers Claude Code through its own `claude mcp add-json`. Non-interactively: `--client vs|vscode|cursor|claude --api-key <key> --yes`.
+
+Or write it by hand:
+
 ```json
 {
   "servers": {
     "d365fo-mcp-tools": { "url": "https://your-server.azurewebsites.net/mcp/" }
+  }
+}
+```
+
+If the deployment enforces an API key, add it as a header:
+
+```json
+{
+  "servers": {
+    "d365fo-mcp-tools": {
+      "url": "https://your-server.azurewebsites.net/mcp/",
+      "headers": { "X-Api-Key": "your-key" }
+    }
   }
 }
 ```

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -1,0 +1,302 @@
+/**
+ * `d365fo-mcp connect` — point an editor at an already-deployed server.
+ *
+ * This is the one flow that needs nothing but the CLI itself: scenario A from
+ * docs/SETUP.md, where the whole installation is a config entry naming a remote
+ * URL. It is therefore deliberately free of the git-checkout guard the other
+ * commands carry — `npx d365fo-mcp connect` is the supported way to run it.
+ *
+ * Editor configs are merged, never rewritten: they routinely hold other MCP
+ * servers, and a team member connecting to D365FO must not lose them. Claude
+ * Code is handled through its own `claude mcp add-json` CLI rather than by
+ * editing ~/.claude.json, which also stores session state we have no business
+ * touching.
+ */
+import * as fs from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { runExe } from '../exec.js';
+import { askConfirm, askSelect, askText, ensure, p } from '../ui.js';
+
+/** Server name written into every editor config — matches the docs. */
+const SERVER_NAME = 'd365fo-mcp-tools';
+
+type ClientId = 'vs' | 'vscode' | 'cursor' | 'claude';
+
+interface ClientTarget {
+  /** Absolute path of the config file. */
+  file: string;
+  /** Top-level key holding the server map: Copilot uses `servers`, others `mcpServers`. */
+  key: 'servers' | 'mcpServers';
+}
+
+/** Where each editor keeps its MCP configuration. */
+function clientTarget(client: Exclude<ClientId, 'claude'>): ClientTarget {
+  switch (client) {
+    case 'vs':
+      // Visual Studio reads %USERPROFILE%\.mcp.json for every solution.
+      return { file: join(homedir(), '.mcp.json'), key: 'servers' };
+    case 'vscode':
+      // Workspace-scoped: VS Code picks up .vscode/mcp.json from the folder it opens.
+      return { file: resolve(process.cwd(), '.vscode', 'mcp.json'), key: 'servers' };
+    case 'cursor':
+      return { file: join(homedir(), '.cursor', 'mcp.json'), key: 'mcpServers' };
+  }
+}
+
+/**
+ * Normalise whatever the user pasted into the MCP endpoint.
+ *
+ * People copy the site root from the Azure portal far more often than the
+ * endpoint, so accept both and append the path when it is missing rather than
+ * failing a form validation on it.
+ */
+export function normalizeServerUrl(input: string): { url: string; health: string } | null {
+  let raw = input.trim();
+  if (!raw) return null;
+  // Only prepend a scheme when there is none — prefixing an ftp:// URL would
+  // turn a rejectable input into a nonsense host rather than an error.
+  const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw);
+  if (!hasScheme) raw = `https://${raw}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  if (!parsed.hostname) return null;
+
+  // Strip a trailing /mcp so both the site root and the endpoint reduce to the
+  // same base: /health is served next to /mcp/, never underneath it.
+  const base = parsed.pathname.replace(/\/+$/, '').replace(/\/mcp$/i, '');
+  return {
+    url: `${parsed.origin}${base}/mcp/`,
+    health: `${parsed.origin}${base}/health`,
+  };
+}
+
+interface ProbeResult {
+  ok: boolean;
+  /** Something answered at that address — the URL itself is therefore plausible. */
+  reachable: boolean;
+  detail: string;
+}
+
+/** GET /health so a typo or an asleep App Service is caught before anything is written. */
+async function probe(health: string, apiKey?: string): Promise<ProbeResult> {
+  try {
+    const res = await fetch(health, {
+      headers: apiKey ? { 'X-Api-Key': apiKey } : undefined,
+      signal: AbortSignal.timeout(20_000),
+    });
+    const body = (await res.json().catch(() => ({}))) as { status?: string; symbols?: number };
+    if (res.ok) {
+      const symbols = typeof body.symbols === 'number' ? `${body.symbols.toLocaleString('en-US')} symbols` : 'reachable';
+      return { ok: true, reachable: true, detail: symbols };
+    }
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, reachable: true, detail: `authentication rejected (HTTP ${res.status}) — check the API key` };
+    }
+    // A cold App Service answers 503 while it downloads the index; that is not a misconfiguration.
+    if (res.status === 503) {
+      return { ok: false, reachable: true, detail: `starting up (HTTP 503${body.status ? `: ${body.status}` : ''}) — the URL is right, it needs a minute` };
+    }
+    return { ok: false, reachable: true, detail: `HTTP ${res.status}` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      reachable: false,
+      detail: msg.includes('timeout') || msg.includes('abort') ? 'no answer within 20 s' : msg,
+    };
+  }
+}
+
+/** The server entry itself — HTTP transport plus the key, when the server wants one. */
+function serverEntry(url: string, apiKey: string | undefined, alwaysLoad: boolean): Record<string, unknown> {
+  return {
+    type: 'http',
+    url,
+    ...(apiKey ? { headers: { 'X-Api-Key': apiKey } } : {}),
+    // Without it Claude Code defers the tools and may answer X++ questions from
+    // built-in search instead (docs/CLAUDE_CODE_SETUP.md).
+    ...(alwaysLoad ? { alwaysLoad: true } : {}),
+  };
+}
+
+interface MergeOutcome {
+  json: string;
+  replaced: boolean;
+  siblings: string[];
+}
+
+/**
+ * Merge the entry into an existing config. Returns null when the file exists
+ * but cannot be parsed — overwriting it would destroy the user's other servers,
+ * so the caller stops and asks them to fix it by hand.
+ */
+export function mergeConfig(
+  existing: string | null,
+  key: 'servers' | 'mcpServers',
+  name: string,
+  entry: Record<string, unknown>,
+): MergeOutcome | null {
+  let doc: Record<string, unknown> = {};
+  if (existing !== null && existing.trim() !== '') {
+    try {
+      const parsed: unknown = JSON.parse(existing);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+      doc = parsed as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  const current = doc[key];
+  const servers: Record<string, unknown> =
+    typeof current === 'object' && current !== null && !Array.isArray(current)
+      ? { ...(current as Record<string, unknown>) }
+      : {};
+
+  const replaced = name in servers;
+  servers[name] = entry;
+  doc[key] = servers;
+
+  return {
+    json: JSON.stringify(doc, null, 2) + '\n',
+    replaced,
+    siblings: Object.keys(servers).filter(k => k !== name),
+  };
+}
+
+/** Register with Claude Code through its own CLI — never by editing ~/.claude.json. */
+async function connectClaudeCode(entry: Record<string, unknown>): Promise<void> {
+  const payload = JSON.stringify(entry);
+  const args = ['mcp', 'add-json', '--scope', 'user', SERVER_NAME, payload];
+  p.log.step('Registering with Claude Code (claude mcp add-json)…');
+  const code = await runExe('claude', args).catch(() => 1);
+  if (code === 0) {
+    p.log.success(`Registered as '${SERVER_NAME}' in Claude Code (user scope).`);
+    return;
+  }
+  p.log.warn('Could not run the Claude Code CLI — run this yourself:');
+  p.note(`claude mcp add-json --scope user ${SERVER_NAME} '${payload}'`, 'Claude Code');
+}
+
+export interface ConnectOptions {
+  client?: string;
+  apiKey?: string;
+  yes?: boolean;
+  /** Write even when the server cannot be reached (deployed but currently down). */
+  force?: boolean;
+}
+
+export async function connectCommand(urlArg: string | undefined, opts: ConnectOptions): Promise<void> {
+  p.intro('d365fo-mcp connect — use an already-deployed server');
+
+  // 1. Where the server lives.
+  const rawUrl = urlArg ?? await askText({
+    message: 'URL of the deployed server',
+    placeholder: 'https://your-server.azurewebsites.net',
+    required: true,
+  });
+  const target = normalizeServerUrl(rawUrl);
+  if (!target) {
+    p.log.error(`Not a usable URL: ${rawUrl}`);
+    process.exitCode = 1;
+    return;
+  }
+  p.log.info(`Endpoint: ${target.url}`);
+
+  // 2. The key, when the deployment enforces one.
+  let apiKey = opts.apiKey?.trim() || undefined;
+  if (!apiKey && !opts.yes) {
+    if (await askConfirm('Does the server require an API key? (ask whoever deployed it)', false)) {
+      apiKey = ensure(await p.password({
+        message: 'API key (X-Api-Key)',
+        validate: (v?: string) => (v?.trim() ? undefined : 'Required'),
+      })).trim();
+    }
+  }
+
+  // 3. Prove it answers before touching any config file.
+  p.log.step('Checking the server…');
+  const health = await probe(target.health, apiKey);
+  if (health.ok) {
+    p.log.success(`Server responded (${health.detail}).`);
+  } else {
+    p.log.warn(`Server did not answer cleanly: ${health.detail}`);
+    // Nothing at all answered — almost always a typo. Non-interactive runs stop
+    // here rather than leave a config pointing at an address that does not
+    // exist; --force is the way to say the server is merely down right now.
+    if (!health.reachable && opts.yes && !opts.force) {
+      p.log.error('Nothing answered at that address — not writing a config for it. Re-run with --force to override.');
+      process.exitCode = 1;
+      return;
+    }
+    if (!opts.yes && !opts.force && !await askConfirm('Write the configuration anyway?', false)) {
+      p.outro('Nothing written.');
+      return;
+    }
+  }
+
+  // 4. Which editor.
+  const client = (opts.client as ClientId | undefined) ?? await askSelect<ClientId>('Which editor should use it?', [
+    { value: 'vs', label: 'Visual Studio', hint: '%USERPROFILE%\\.mcp.json — all solutions' },
+    { value: 'vscode', label: 'VS Code', hint: '.vscode/mcp.json in the current folder' },
+    { value: 'claude', label: 'Claude Code', hint: 'registered via the claude CLI' },
+    { value: 'cursor', label: 'Cursor', hint: '~/.cursor/mcp.json' },
+  ]);
+  if (!['vs', 'vscode', 'cursor', 'claude'].includes(client)) {
+    p.log.error(`Unknown client '${client}' — expected vs, vscode, cursor or claude.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const entry = serverEntry(target.url, apiKey, client === 'claude');
+
+  if (client === 'claude') {
+    await connectClaudeCode(entry);
+    p.outro('Done — restart Claude Code to pick up the server.');
+    return;
+  }
+
+  // 5. Merge into the editor config.
+  const { file, key } = clientTarget(client);
+  const existing = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : null;
+  const merged = mergeConfig(existing, key, SERVER_NAME, entry);
+  if (!merged) {
+    p.log.error(`${file} exists but is not valid JSON — fix or move it, then re-run.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (merged.replaced && !opts.yes) {
+    if (!await askConfirm(`'${SERVER_NAME}' is already configured in ${file} — replace it?`)) {
+      p.outro('Nothing written.');
+      return;
+    }
+  }
+
+  fs.mkdirSync(dirname(file), { recursive: true });
+  fs.writeFileSync(file, merged.json, 'utf8');
+  p.log.success(`${merged.replaced ? 'Updated' : 'Added'} '${SERVER_NAME}' in ${file}`);
+  if (merged.siblings.length > 0) {
+    p.log.info(`Left untouched: ${merged.siblings.join(', ')}`);
+  }
+  if (apiKey) {
+    p.log.warn('The API key is stored in that file as plain text — do not commit it.');
+  }
+
+  p.note(
+    client === 'vs'
+      ? 'Restart Visual Studio, then switch Copilot Chat to Agent Mode.\n' +
+        'Copilot also needs .github/copilot-instructions.md in a parent of\n' +
+        'your solution folders — see docs/SETUP.md.'
+      : 'Reload the window to pick up the new server.',
+    'Next',
+  );
+  p.outro('Connected — no clone, no build, no index.');
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -91,6 +91,31 @@ function legacyEnvChecks(target: Target, label: string): CheckResult[] {
   }];
 }
 
+/**
+ * better-sqlite3 is a native module, and npm 12 blocks install scripts that the
+ * root package.json does not pre-approve in `allowScripts`. A blocked build
+ * still exits 0 with only a warning, so the .node binding goes missing silently
+ * and the install looks clean — the failure would otherwise first appear when
+ * the server opens the index. Loading it here turns that into a named problem.
+ */
+async function checkNativeBinding(): Promise<CheckResult> {
+  try {
+    // Importing the module is not enough: better-sqlite3 resolves the addon
+    // lazily on first use, so a missing binding only surfaces when a database
+    // is actually opened. An in-memory one touches no disk.
+    const { default: Database } = await import('better-sqlite3');
+    new Database(':memory:').close();
+    return { severity: 'ok', message: 'better-sqlite3 native binding loads' };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message.split('\n')[0] : String(err);
+    return {
+      severity: 'fail',
+      message: `better-sqlite3 native binding unavailable — ${detail}`,
+      fix: 'npm install-scripts approve better-sqlite3 && npm rebuild better-sqlite3',
+    };
+  }
+}
+
 async function probeHealth(port: number, label: string): Promise<CheckResult> {
   try {
     const res = await fetch(`http://localhost:${port}/health`, { signal: AbortSignal.timeout(1500) });
@@ -119,9 +144,12 @@ export async function doctorCommand(): Promise<void> {
     : { severity: 'fail', message: `Node.js ${process.versions.node} — ${REQUIRED_NODE_MAJOR}.x required (package.json engines)`, fix: 'install Node 24 LTS' });
 
   // Install + build
-  emit(fs.existsSync(resolve(repoRoot, 'node_modules'))
+  const hasNodeModules = fs.existsSync(resolve(repoRoot, 'node_modules'));
+  emit(hasNodeModules
     ? { severity: 'ok', message: 'Dependencies installed (node_modules)' }
     : { severity: 'fail', message: 'node_modules missing', fix: 'npm install' });
+  // Only meaningful once the dependencies exist — otherwise it just restates the failure above.
+  if (hasNodeModules) emit(await checkNativeBinding());
   emit(fs.existsSync(paths.distEntry)
     ? { severity: 'ok', message: 'Server built (dist/index.js)' }
     : { severity: 'fail', message: 'dist/index.js missing — server not built', fix: 'npm run build' });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@
  * PowerShell fallback for the same flows.
  *
  *   d365fo-mcp                  interactive menu
+ *   d365fo-mcp connect [url]    use a deployed server — no clone, no build
  *   d365fo-mcp setup            first-time setup wizard (scenarios A–F)
  *   d365fo-mcp config [section] change settings after setup
  *   d365fo-mcp doctor           environment & installation health check
@@ -18,6 +19,7 @@
  */
 import { Command } from 'commander';
 import { configCommand } from './commands/config.js';
+import { connectCommand } from './commands/connect.js';
 import { doctorCommand } from './commands/doctor.js';
 import { indexCommand } from './commands/indexCmd.js';
 import { instanceAddCommand, instanceListCommand, instanceUpgradeCommand } from './commands/instance.js';
@@ -25,6 +27,7 @@ import { setupCommand } from './commands/setup.js';
 import { startCommand } from './commands/start.js';
 import { updateCommand } from './commands/update.js';
 import { askSelect, p } from './ui.js';
+import { isGitCheckout } from './context.js';
 import { listInstances } from './instances.js';
 
 const program = new Command();
@@ -33,6 +36,15 @@ program
   .name('d365fo-mcp')
   .description('Manage the D365 F&O MCP Server: setup, updates, instances, index builds')
   .version('1.0.0');
+
+program.command('connect')
+  .argument('[url]', 'URL of the deployed server (e.g. https://your-server.azurewebsites.net)')
+  .option('-c, --client <client>', 'vs | vscode | cursor | claude')
+  .option('-k, --api-key <key>', 'API key, when the server enforces one')
+  .option('-y, --yes', 'non-interactive: skip the confirmation questions')
+  .option('-f, --force', 'write even when the server cannot be reached')
+  .description('Point an editor at an already-deployed server (no clone needed)')
+  .action(connectCommand);
 
 program.command('setup')
   .description('First-time setup wizard (deployment scenarios A–F from docs/SETUP.md)')
@@ -93,8 +105,13 @@ instance.command('upgrade')
 async function mainMenu(): Promise<void> {
   p.intro('d365fo-mcp — D365 F&O MCP Server management');
   const hasInstances = listInstances().length > 0;
+  // Outside a checkout only `connect` can actually do anything, so it leads —
+  // everything above it in the full list would just print the installer hint.
+  const connectEntry = { value: 'connect', label: 'Connect', hint: 'use a server someone already deployed' };
   const action = await askSelect('What do you want to do?', [
+    ...(isGitCheckout ? [] : [connectEntry]),
     { value: 'setup', label: 'Setup', hint: 'first-time setup wizard' },
+    ...(isGitCheckout ? [connectEntry] : []),
     { value: 'config', label: 'Change settings', hint: 'edit one area of the configuration' },
     { value: 'doctor', label: 'Doctor', hint: 'check environment & installation' },
     { value: 'start', label: 'Start server', hint: hasInstances ? 'root or an instance' : 'root server' },
@@ -107,6 +124,7 @@ async function mainMenu(): Promise<void> {
     ] : []),
   ]);
   switch (action) {
+    case 'connect': return connectCommand(undefined, {});
     case 'setup': return setupCommand();
     case 'config': return configCommand(undefined, {});
     case 'doctor': return doctorCommand();

--- a/tests/cli/connect.test.ts
+++ b/tests/cli/connect.test.ts
@@ -1,0 +1,109 @@
+/**
+ * `d365fo-mcp connect` — URL normalisation and config merging.
+ *
+ * These two functions decide what lands in a team member's editor config, and
+ * the merge in particular is the destructive one: the file routinely holds
+ * other MCP servers, so losing them would be a real regression rather than a
+ * cosmetic one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mergeConfig, normalizeServerUrl } from '../../src/cli/commands/connect';
+
+describe('normalizeServerUrl', () => {
+  it('appends the endpoint to a site root pasted from the Azure portal', () => {
+    expect(normalizeServerUrl('https://foo.azurewebsites.net')).toEqual({
+      url: 'https://foo.azurewebsites.net/mcp/',
+      health: 'https://foo.azurewebsites.net/health',
+    });
+  });
+
+  it('keeps an endpoint that already carries /mcp, with or without the slash', () => {
+    const expected = {
+      url: 'https://foo.azurewebsites.net/mcp/',
+      health: 'https://foo.azurewebsites.net/health',
+    };
+    expect(normalizeServerUrl('https://foo.azurewebsites.net/mcp')).toEqual(expected);
+    expect(normalizeServerUrl('https://foo.azurewebsites.net/mcp/')).toEqual(expected);
+  });
+
+  it('assumes https when the scheme is missing', () => {
+    expect(normalizeServerUrl('foo.azurewebsites.net')?.url).toBe('https://foo.azurewebsites.net/mcp/');
+  });
+
+  it('keeps an explicit http scheme and port for a local server', () => {
+    expect(normalizeServerUrl('http://localhost:8080')).toEqual({
+      url: 'http://localhost:8080/mcp/',
+      health: 'http://localhost:8080/health',
+    });
+  });
+
+  it('preserves a path prefix, e.g. a reverse-proxied deployment', () => {
+    expect(normalizeServerUrl('https://intra.example.com/d365')).toEqual({
+      url: 'https://intra.example.com/d365/mcp/',
+      health: 'https://intra.example.com/d365/health',
+    });
+  });
+
+  it('rejects input that is not a usable http(s) URL', () => {
+    for (const bad of ['', '   ', 'ftp://foo/mcp', 'http://', 'not a url']) {
+      expect(normalizeServerUrl(bad), bad).toBeNull();
+    }
+  });
+});
+
+describe('mergeConfig', () => {
+  const entry = { type: 'http', url: 'https://foo/mcp/' };
+
+  it('creates the file structure when nothing exists yet', () => {
+    const out = mergeConfig(null, 'servers', 'd365fo-mcp-tools', entry)!;
+    expect(JSON.parse(out.json)).toEqual({ servers: { 'd365fo-mcp-tools': entry } });
+    expect(out.replaced).toBe(false);
+    expect(out.siblings).toEqual([]);
+  });
+
+  it('keeps other MCP servers and unrelated top-level keys intact', () => {
+    const existing = JSON.stringify({
+      inputs: [{ id: 'token' }],
+      servers: { github: { url: 'https://api.github.com/mcp' } },
+    });
+    const out = mergeConfig(existing, 'servers', 'd365fo-mcp-tools', entry)!;
+    const doc = JSON.parse(out.json);
+    expect(doc.servers.github).toEqual({ url: 'https://api.github.com/mcp' });
+    expect(doc.inputs).toEqual([{ id: 'token' }]);
+    expect(out.siblings).toEqual(['github']);
+  });
+
+  it('reports replacement when the entry is already configured', () => {
+    const existing = JSON.stringify({ servers: { 'd365fo-mcp-tools': { url: 'https://old/mcp/' } } });
+    const out = mergeConfig(existing, 'servers', 'd365fo-mcp-tools', entry)!;
+    expect(out.replaced).toBe(true);
+    expect(JSON.parse(out.json).servers['d365fo-mcp-tools']).toEqual(entry);
+  });
+
+  it('honours the mcpServers key used by Cursor', () => {
+    const existing = JSON.stringify({ mcpServers: { other: { url: 'https://x/mcp' } } });
+    const out = mergeConfig(existing, 'mcpServers', 'd365fo-mcp-tools', entry)!;
+    const doc = JSON.parse(out.json);
+    expect(Object.keys(doc)).toEqual(['mcpServers']);
+    expect(doc.mcpServers.other).toBeDefined();
+  });
+
+  it('treats an empty file as no configuration rather than as corruption', () => {
+    expect(mergeConfig('', 'servers', 'd365fo-mcp-tools', entry)).not.toBeNull();
+    expect(mergeConfig('   \n', 'servers', 'd365fo-mcp-tools', entry)).not.toBeNull();
+  });
+
+  it('refuses to touch a file it cannot parse, rather than overwriting it', () => {
+    // The caller turns null into "fix it by hand" — silently rewriting here
+    // would discard whatever servers the user had configured.
+    expect(mergeConfig('{ not json', 'servers', 'd365fo-mcp-tools', entry)).toBeNull();
+    expect(mergeConfig('[]', 'servers', 'd365fo-mcp-tools', entry)).toBeNull();
+    expect(mergeConfig('"a string"', 'servers', 'd365fo-mcp-tools', entry)).toBeNull();
+  });
+
+  it('replaces a servers value of the wrong shape instead of crashing', () => {
+    const out = mergeConfig(JSON.stringify({ servers: 'nonsense' }), 'servers', 'd365fo-mcp-tools', entry)!;
+    expect(JSON.parse(out.json).servers).toEqual({ 'd365fo-mcp-tools': entry });
+  });
+});

--- a/tests/packaging/allowScripts.test.ts
+++ b/tests/packaging/allowScripts.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `allowScripts` drift gate.
+ *
+ * npm 12 blocks package lifecycle scripts (preinstall/install/postinstall)
+ * unless the root package.json pre-approves them by exact `name@version`.
+ * better-sqlite3 is a native module: with its install script blocked, npm still
+ * exits 0 and prints only a warning, the .node binding is never built, and the
+ * failure surfaces much later as a runtime error far from the cause.
+ *
+ * The pins therefore have to track the lockfile. A dependency bump that does
+ * not update `allowScripts` in the same commit would silently stop building the
+ * binding for every user running the installer — this gate turns that into a
+ * failing PR instead.
+ *
+ * Optional packages are exempt: fsevents is macOS-only and degrades to polling.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+interface LockEntry {
+  version?: string;
+  hasInstallScript?: boolean;
+  optional?: boolean;
+}
+
+const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8')) as {
+  allowScripts?: Record<string, boolean>;
+};
+const lock = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package-lock.json'), 'utf8')) as {
+  packages: Record<string, LockEntry>;
+};
+
+const allowScripts = pkg.allowScripts ?? {};
+
+/** `node_modules/foo` and `node_modules/a/node_modules/b` → `foo` / `b`. */
+function packageName(lockPath: string): string {
+  return lockPath.split('node_modules/').pop()!;
+}
+
+/** Every non-optional locked package whose install would run a script. */
+const scriptPackages = Object.entries(lock.packages)
+  .filter(([lockPath, entry]) => lockPath !== '' && entry.hasInstallScript && !entry.optional)
+  .map(([lockPath, entry]) => ({ id: `${packageName(lockPath)}@${entry.version}`, lockPath }));
+
+describe('allowScripts pins', () => {
+  it('covers every non-optional package that runs an install script', () => {
+    // Guards the extraction itself: better-sqlite3 always qualifies, so an
+    // empty list would mean the lockfile shape changed and this gate went
+    // vacuous rather than green.
+    expect(scriptPackages.map(p => p.id)).toContain('better-sqlite3@12.11.1');
+
+    const uncovered = scriptPackages.filter(p => allowScripts[p.id] !== true);
+    expect(
+      uncovered.map(p => p.id),
+      '\nInstall scripts blocked under npm 12 — add each to "allowScripts" in package.json:\n' +
+        uncovered.map(p => `  "${p.id}": true`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('has no stale pin left behind by a dependency bump', () => {
+    const locked = new Set(scriptPackages.map(p => p.id));
+    const stale = Object.keys(allowScripts).filter(id => !locked.has(id));
+    expect(
+      stale,
+      '\nThese "allowScripts" pins match nothing in package-lock.json — the ' +
+        'dependency moved and the approval no longer applies:\n' +
+        stale.map(id => `  ${id}`).join('\n'),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up to the [npm install-time security & GAT bypass2FA changelog](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/). Two independent problems from that post; `d365fo-mcp@1.0.0` is already published, so both are addressed before they can bite.

## 1 — Trusted publishing replaces NPM_TOKEN

Granular tokens with *bypass 2FA* are being retired in two phases: **early August 2026** they stop covering sensitive operations (token management, package access, maintainers, trusted-publishing config), and **around January 2027** they lose direct publishing entirely — reduced to staging a publish that a human approves with 2FA.

The `publish-npm` job now authenticates via **OIDC trusted publishing**, which stores no secret at all. This only became possible now that the package exists on the registry — the trusted publisher is configured in the package's own settings (already done on npmjs.com: org `dynamics365ninja`, repo `d365fo-mcp-server`, workflow `release.yml`).

- `NODE_AUTH_TOKEN` / `NPM_TOKEN` removed, along with the graceful-skip branch that existed only for the unconfigured-secret case.
- `--provenance` dropped: trusted publishing attests provenance automatically for a public repo publishing a public package.
- `id-token: write` retained — under OIDC it is the actual credential, not just a provenance enabler.
- Verified Node 24.x currently ships npm 11.16.0, comfortably over the documented floor (npm ≥ 11.5.1, Node ≥ 22.14.0); noted in a comment so nobody lowers the Node line and silently drops back to token auth.

**After merge:** the `NPM_TOKEN` secret and the npm token itself can be deleted — nothing reads them any more.

## 2 — npm 12 blocks install scripts (the silent one)

npm 12 blocks lifecycle scripts unless the **root** package.json pre-approves them by exact `name@version` in `allowScripts`. `better-sqlite3` is a native module, so this decides whether the server works at all.

Measured under npm 12 against the real dependency:

| install | native binding | exit code |
|---|---|---|
| with `allowScripts` | built | 0 |
| without | **missing** | **0 — warning only** |

The install *looks* clean and the failure only appears much later, when the server opens the index. The repo's existing pins currently match the lockfile exactly (`better-sqlite3@12.11.1`, `esbuild@0.28.1`), so users are fine today — the risk is drift, since the declared range is `^12.9.0` and dependabot is enabled.

- **`tests/packaging/allowScripts.test.ts`** — fails the PR in both directions: a non-optional package with an install script that no pin covers, and a pin matching nothing in the lockfile (the stale-after-bump case). Optional packages are exempt: `fsevents` is macOS-only and degrades to polling. Both failure modes were verified by simulating a bump; each prints the exact line to add.
- **`doctor`** — reports a missing binding by name with the `npm install-scripts approve` fix. It opens an in-memory database rather than merely importing the module: better-sqlite3 resolves its addon **lazily**, so a plain `import` succeeds even with the binding deleted — the first version of this check was a false negative, caught by testing it with the `.node` file renamed away.

## Testing

- Full suite: **132 files, 1784 passed**, 2 skipped (mode switches).
- New guard verified green, then red against a simulated dependency bump, then restored.
- `doctor` verified in both states (binding present → ok; `.node` renamed → fail with the fix line).
- Publish path itself cannot be exercised until the next `v*` tag — that release is the real proof, and the first thing to check is that provenance still appears on the npm page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)