### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,7 @@ import { startCommand } from './commands/start.js';
 import { updateCommand } from './commands/update.js';
 import { askSelect, p } from './ui.js';
 import { isGitCheckout } from './context.js';
+import { VERSION } from '../version.js';
 import { listInstances } from './instances.js';
 
 const program = new Command();
@@ -35,7 +36,7 @@ const program = new Command();
 program
   .name('d365fo-mcp')
   .description('Manage the D365 F&O MCP Server: setup, updates, instances, index builds')
-  .version('1.0.0');
+  .version(VERSION);
 
 program.command('connect')
   .argument('[url]', 'URL of the deployed server (e.g. https://your-server.azurewebsites.net)')

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { initializeConfig, getConfigManager } from './utils/configManager.js';
 import { SERVER_MODE, LOCAL_TOOLS, isToolAllowedInMode } from './server/serverMode.js';
 import { TOOL_ANNOTATIONS } from './server/toolAnnotations.js';
 import { apiKeyAuth } from './middleware/apiKeyAuth.js';
+import { VERSION } from './version.js';
 import { setInitializeParams } from './utils/stdioSessionInfo.js';
 import { box, kv, sectionTitle, statusLine, spread, c, glyph, sanitize, supportsUnicode, log, shortPath, startupWarnings } from './utils/terminalUi.js';
 import * as fs from 'fs/promises';
@@ -624,7 +625,7 @@ async function main() {
     const W = 50;
     console.log('');
     for (const line of box([
-      spread(c.bold('D365 F&O MCP Server'), c.dim('v1.0.0'), W),
+      spread(c.bold('D365 F&O MCP Server'), c.dim(`v${VERSION}`), W),
       c.gray('X++ Code Intelligence'),
     ], W)) {
       console.log(line);
@@ -661,7 +662,7 @@ async function main() {
         status: ready ? 'healthy' : 'starting',
         ready,
         service: 'd365fo-mcp-server',
-        version: '1.0.0',
+        version: VERSION,
         message: serverState.statusMessage,
         // Cached-only: a health probe must never trigger a 30-60 s COUNT scan.
         symbols: serverState.symbolIndex?.getCachedSymbolCounts()?.total || 0,

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -4,6 +4,7 @@
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { VERSION } from '../version.js';
 import {
   ListToolsRequestSchema,
   InitializedNotificationSchema,
@@ -99,7 +100,7 @@ export function createXppMcpServer(context: XppServerContext): Server {
   const server = new Server(
     {
       name: `d365fo-mcp-server${serverNameSuffix}`,
-      version: '1.0.0',
+      version: VERSION,
     },
     {
       capabilities: {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,21 @@
+/**
+ * The package version, read from package.json.
+ *
+ * It used to be a literal repeated in four places — the CLI's `--version`, the
+ * startup banner, the /health payload and the MCP server handshake — which
+ * meant a release bump silently left some of them reporting the previous
+ * version. Reading it once makes the version in package.json the only copy.
+ *
+ * `src/version.ts` and `dist/version.js` both sit one level below the package
+ * root, so the same relative path works in the repo and in the published
+ * package (`files: ["dist"]` keeps that layout).
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export const VERSION: string = (
+  JSON.parse(readFileSync(resolve(here, '..', 'package.json'), 'utf8')) as { version: string }
+).version;


### PR DESCRIPTION
Prepares the second release. **Minor, not patch**: the six commits since `v1.0.0` include `feat(cli): add connect`, a new capability rather than a fix, so `1.0.1` would have hidden it.

What ships:

- `feat(cli)` — `connect`, configures an editor for an already-deployed server with no clone
- `chore(release)` — OIDC trusted publishing (no NPM_TOKEN), `allowScripts` drift gate, native-binding check in `doctor`
- `docs` — Quick Start consolidated out of the README, npm package documented, local install leads

## The version was in five places

`npm version` bumps `package.json` and the lockfile. It does not touch the four **literals** that were scattered through the source:

| Where | Reported |
|---|---|
| `d365fo-mcp --version` | `1.0.0` |
| startup banner | `v1.0.0` |
| `/health` payload | `1.0.0` |
| MCP handshake (`mcpServer.ts`) | `1.0.0` |

All four would have kept claiming 1.0.0 after this release — the handshake and `/health` being the ones a user or a support request would actually inspect. They now read `VERSION` from `src/version.ts`, which resolves `package.json` relative to its own location. `src/` and `dist/` both sit one level below the package root, so the path holds in the repo and in the published tarball alike.

## Testing

- Full suite: **133 files, 1797 passed**, 2 skipped.
- `npm pack` → installed the resulting `d365fo-mcp-1.1.0.tgz` into a clean project → the installed binary reports `1.1.0` and lists `connect`. That exercises the published layout, which is the one that would have broken had the relative path been wrong.
- Grepped the source: no version literal remains outside `src/version.ts`.

## After merge

Tagging `v1.1.0` triggers release + npm publish + an Azure redeploy. This is the **first publish over OIDC trusted publishing** — the thing to check afterwards is that provenance still appears on the npm package page, since no token is involved any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)