### PR TITLE
perf(index): keep scoped builds O(scope), not O(database)

### DIFF
--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -60,7 +60,13 @@ npm run extract-metadata
 npm run build-database
 ```
 
-Takes a few minutes. Use after every code change or sprint.
+Use after every code change or sprint. Cost scales with your custom models, not with the
+database: every step is scoped to them, including full-text index maintenance and ANALYZE
+(which run over the whole database on an `all` rebuild only). On a ~1.2M-symbol instance
+a 3-model, ~10K-symbol build takes well under a minute.
+
+`ANALYZE=true npm run build-database` forces the query-planner statistics to be recomputed
+if you ever need them refreshed without a full rebuild.
 
 ### Everything (first-time setup or after D365FO upgrade)
 

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -179,12 +179,18 @@ async function buildDatabase() {
   const startTime = Date.now();
   
   if (modelsToRebuild.length > 0) {
-    // Index specific models in a SINGLE pass (not one call per model): the FTS index is
-    // rebuilt from scratch — O(all symbols in the DB) — once at the end of the call, so
-    // looping here would repeat that full rebuild N times.
+    // Index specific models in a SINGLE pass (not one call per model): a per-model loop
+    // would repeat the whole end-of-call FTS maintenance N times.
+    //
+    // FTS strategy: `custom` scopes the build to the custom models — a small fraction of
+    // the database (~10K of ~1.2M symbols here) — so the triggers maintain symbols_fts far
+    // more cheaply than re-tokenising every row (measured 327s vs 5s of real indexing work
+    // on a cold cache). `standard` covers nearly the whole database, where the bulk rebuild
+    // still wins.
+    const ftsStrategy = EXTRACT_MODE === 'custom' ? 'incremental' : 'rebuild';
     log.detail(`${modelsToRebuild.length} model(s): ${modelsToRebuild.slice(0, 10).join(', ')}${modelsToRebuild.length > 10 ? '...' : ''}`);
     log.detail('Incremental build: standard models in database will be preserved');
-    await symbolIndex.indexMetadataDirectory(INPUT_PATH, modelsToRebuild);
+    await symbolIndex.indexMetadataDirectory(INPUT_PATH, modelsToRebuild, { ftsStrategy });
   } else if (EXTRACT_MODE === 'all' || RESUME) {
     // Full rebuild (or resume): index every model in the directory in one bulk pass.
     log.detail(`All models from: ${shortPath(INPUT_PATH)}`);
@@ -282,12 +288,16 @@ async function buildDatabase() {
       let grandTotalModels = 0;
 
       if (isIncrementalCustomBuild) {
-        symbolIndex.clearLabelsForModels(modelsToRebuild);
+        // Both steps stay O(scope): the labels_fts triggers maintain the index for the
+        // cleared and re-inserted rows, instead of two delete-all + re-INSERT passes over
+        // every en-US label in the database (485K rows here, 284s on a cold cache).
+        symbolIndex.clearLabelsForModels(modelsToRebuild, { ftsStrategy: 'incremental' });
         for (const rootPath of validRoots) {
           const { totalLabels, modelsIndexed } = await indexAllLabels(
             symbolIndex,
             rootPath,
             (modelName) => modelsToRebuild.includes(modelName),
+            { ftsStrategy: 'incremental' },
           );
           grandTotalLabels += totalLabels;
           grandTotalModels += modelsIndexed;
@@ -344,7 +354,16 @@ async function buildDatabase() {
     // ANALYZE + optimize: persist query-planner stats into the DB so the production
     // server can open it with zero warmup cost (skipped when SKIP_FTS=true because
     // build-fts will run these tasks at the end of phase 2).
-    symbolIndex.runPostBuildTasks();
+    //
+    // ANALYZE reads the whole database (309s cold for 2 GB + 585 MB here) and an
+    // incremental build changes well under 1% of the rows, which does not move the
+    // planner's stats — so run it on a full rebuild only, or on demand via ANALYZE=true.
+    if (EXTRACT_MODE === 'all' || process.env.ANALYZE === 'true') {
+      symbolIndex.runPostBuildTasks();
+    } else {
+      log.info(`Skipping ANALYZE for incremental ${EXTRACT_MODE} build (use ANALYZE=true to force)`);
+      log.detail('Planner statistics from the last full rebuild stay valid');
+    }
   }
 
   // Show breakdown by type

--- a/src/metadata/labelParser.ts
+++ b/src/metadata/labelParser.ts
@@ -182,7 +182,7 @@ export async function indexModelLabels(
   symbolIndex: XppSymbolIndex,
   modelDir: string,
   model: string,
-  opts?: { skipFtsRebuild?: boolean },
+  opts?: { skipFtsRebuild?: boolean; keepTriggers?: boolean },
 ): Promise<number> {
   const labelFiles = await discoverLabelFiles(modelDir);
   if (labelFiles.length === 0) return 0;
@@ -226,7 +226,12 @@ export async function indexAllLabels(
   symbolIndex: XppSymbolIndex,
   packagesPath: string,
   modelFilter?: (modelName: string) => boolean,
+  opts?: { ftsStrategy?: 'rebuild' | 'incremental' },
 ): Promise<{ totalLabels: number; modelsIndexed: number }> {
+  // 'incremental' keeps the labels_fts triggers live so only the scanned models' labels are
+  // tokenised, instead of re-inserting every en-US label in the database afterwards. Only
+  // worth it when modelFilter narrows the scan to a small set (a custom-model build).
+  const incrementalFts = opts?.ftsStrategy === 'incremental';
   let totalLabels = 0;
   let modelsIndexed = 0;
 
@@ -288,7 +293,10 @@ export async function indexAllLabels(
     }
 
     for (const { modelDir, modelName } of modelDirs) {
-      const count = await indexModelLabels(symbolIndex, modelDir, modelName, { skipFtsRebuild: true });
+      const count = await indexModelLabels(symbolIndex, modelDir, modelName, {
+        skipFtsRebuild: true,
+        keepTriggers: incrementalFts,
+      });
       if (count > 0) {
         totalLabels += count;
         modelsIndexed++;
@@ -299,7 +307,8 @@ export async function indexAllLabels(
   }
 
   // Rebuild FTS once for all models rather than per-model (avoids O(n^2) rebuild cost).
-  if (totalLabels > 0) {
+  // Skipped under 'incremental': the triggers already kept labels_fts in sync per row.
+  if (totalLabels > 0 && !incrementalFts) {
     symbolIndex.rebuildLabelsFts();
   }
 

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -723,33 +723,41 @@ export class XppSymbolIndex {
   /**
    * Create FTS triggers for keeping symbols_fts in sync
    * Extracted to allow disabling during bulk inserts and re-enabling after
+   *
+   * symbols_fts is an external-content table, so removals and updates MUST hand the OLD
+   * column values back to FTS5 via the 'delete' command. A plain `DELETE FROM symbols_fts`
+   * (or `UPDATE symbols_fts SET`) cannot work: the trigger runs AFTER the content row is
+   * already gone, leaving FTS5 nothing to re-derive the row's terms from — it fails with
+   * "missing row N from content table" and strands the old terms in the index.
+   *
+   * Dropped and recreated rather than CREATE-IF-NOT-EXISTS so databases still carrying the
+   * earlier (broken) definitions are repaired on the next index run.
    */
   private createFTSTriggers(): void {
+    this.db.exec('DROP TRIGGER IF EXISTS symbols_ai;');
+    this.db.exec('DROP TRIGGER IF EXISTS symbols_ad;');
+    this.db.exec('DROP TRIGGER IF EXISTS symbols_au;');
+
     this.db.exec(`
-      CREATE TRIGGER IF NOT EXISTS symbols_ai AFTER INSERT ON symbols BEGIN
+      CREATE TRIGGER symbols_ai AFTER INSERT ON symbols BEGIN
         INSERT INTO symbols_fts(rowid, name, type, parent_name, signature, description, tags, source_snippet, inline_comments)
         VALUES (new.id, new.name, new.type, new.parent_name, new.signature, new.description, new.tags, new.source_snippet, new.inline_comments);
       END;
     `);
 
     this.db.exec(`
-      CREATE TRIGGER IF NOT EXISTS symbols_ad AFTER DELETE ON symbols BEGIN
-        DELETE FROM symbols_fts WHERE rowid = old.id;
+      CREATE TRIGGER symbols_ad AFTER DELETE ON symbols BEGIN
+        INSERT INTO symbols_fts(symbols_fts, rowid, name, type, parent_name, signature, description, tags, source_snippet, inline_comments)
+        VALUES ('delete', old.id, old.name, old.type, old.parent_name, old.signature, old.description, old.tags, old.source_snippet, old.inline_comments);
       END;
     `);
 
     this.db.exec(`
-      CREATE TRIGGER IF NOT EXISTS symbols_au AFTER UPDATE ON symbols BEGIN
-        UPDATE symbols_fts SET
-          name = new.name,
-          type = new.type,
-          parent_name = new.parent_name,
-          signature = new.signature,
-          description = new.description,
-          tags = new.tags,
-          source_snippet = new.source_snippet,
-          inline_comments = new.inline_comments
-        WHERE rowid = new.id;
+      CREATE TRIGGER symbols_au AFTER UPDATE ON symbols BEGIN
+        INSERT INTO symbols_fts(symbols_fts, rowid, name, type, parent_name, signature, description, tags, source_snippet, inline_comments)
+        VALUES ('delete', old.id, old.name, old.type, old.parent_name, old.signature, old.description, old.tags, old.source_snippet, old.inline_comments);
+        INSERT INTO symbols_fts(rowid, name, type, parent_name, signature, description, tags, source_snippet, inline_comments)
+        VALUES (new.id, new.name, new.type, new.parent_name, new.signature, new.description, new.tags, new.source_snippet, new.inline_comments);
       END;
     `);
   }
@@ -1302,14 +1310,30 @@ export class XppSymbolIndex {
    *   - a model name   → index just that one model
    *   - an array       → index exactly those models in a SINGLE pass
    *
-   * Pass an array rather than calling this once per model: the FTS index is rebuilt from
-   * scratch ONCE at the end of the call (and the FTS triggers dropped/recreated once), both
-   * O(all symbols in the DB), so a per-model loop turns a scoped rebuild into N full-table
-   * rebuilds.
+   * Pass an array rather than calling this once per model: with the default
+   * `ftsStrategy: 'rebuild'` the FTS index is rebuilt from scratch ONCE at the end of the
+   * call, which is O(all symbols in the DB), so a per-model loop turns a scoped rebuild
+   * into N full-table rebuilds.
+   *
+   * `ftsStrategy` picks how symbols_fts is brought up to date:
+   *   - 'rebuild'     (default) drop the FTS triggers, bulk-insert, then re-tokenise the
+   *                   WHOLE symbols table. Cost is O(all symbols) regardless of scope —
+   *                   right for a full or near-full rebuild, where it beats per-row triggers.
+   *   - 'incremental' keep the FTS triggers live so only the touched rows are re-tokenised.
+   *                   Cost is O(scope). Use it when the scope is a small fraction of the
+   *                   database (a custom-model build: ~10K of ~1.2M symbols, where the full
+   *                   rebuild cost 327s against 5s of actual indexing work).
    */
-  async indexMetadataDirectory(metadataPath: string, modelNames?: string | string[]): Promise<void> {
+  async indexMetadataDirectory(
+    metadataPath: string,
+    modelNames?: string | string[],
+    opts?: { ftsStrategy?: 'rebuild' | 'incremental' },
+  ): Promise<void> {
     const skipFts = process.env.SKIP_FTS === 'true';
     const resumable = process.env.RESUME === 'true';
+    // Incremental FTS only makes sense for a scoped pass; an unscoped one touches
+    // every row anyway, so the bulk rebuild is strictly cheaper.
+    const incrementalFts = opts?.ftsStrategy === 'incremental' && modelNames !== undefined && !skipFts;
 
     const requested = modelNames === undefined
       ? undefined
@@ -1337,10 +1361,22 @@ export class XppSymbolIndex {
 
     const startTime = Date.now();
 
-    // Disable FTS triggers during bulk insert — we rebuild FTS once at the end
-    this.db.exec('DROP TRIGGER IF EXISTS symbols_ai;');
-    this.db.exec('DROP TRIGGER IF EXISTS symbols_au;');
-    this.db.exec('DROP TRIGGER IF EXISTS symbols_ad;');
+    if (incrementalFts) {
+      // Keep the FTS triggers live so each touched row maintains symbols_fts itself.
+      // createFTSTriggers() is CREATE TRIGGER IF NOT EXISTS, so this also repairs a
+      // database left trigger-less by an interrupted SKIP_FTS build.
+      this.createFTSTriggers();
+      // Rows are written with INSERT OR REPLACE. SQLite fires delete triggers for the
+      // rows a REPLACE displaces ONLY when recursive triggers are enabled; without this
+      // the displaced row's symbols_fts entry would survive as an orphan pointing at a
+      // rowid that no longer exists in the content table.
+      this.db.pragma('recursive_triggers = ON');
+    } else {
+      // Disable FTS triggers during bulk insert — we rebuild FTS once at the end
+      this.db.exec('DROP TRIGGER IF EXISTS symbols_ai;');
+      this.db.exec('DROP TRIGGER IF EXISTS symbols_au;');
+      this.db.exec('DROP TRIGGER IF EXISTS symbols_ad;');
+    }
 
     // Prepare progress statement (executes inside each model's transaction)
     const markProgress = resumable
@@ -1506,7 +1542,11 @@ export class XppSymbolIndex {
       console.log(''); // New line after progress
     }
 
-    if (skipFts) {
+    if (incrementalFts) {
+      // FTS was maintained row-by-row by the triggers — nothing left to do.
+      this.db.pragma('recursive_triggers = OFF');
+      log.ok(`Indexed ${models.length} model(s) in ${duration}s (FTS updated incrementally)`);
+    } else if (skipFts) {
       // Phase 1 of two-phase CI build: symbols only, FTS deferred to build-fts step
       log.info(`Skipping FTS rebuild (SKIP_FTS=true) - run 'npm run build-fts' to finish`);
       this.createFTSTriggers();
@@ -3066,6 +3106,11 @@ export class XppSymbolIndex {
     const placeholders = modelNames.map(() => '?').join(',');
     this.invalidateSymbolCounts();
 
+    // The symbols_ad trigger is what removes the cleared rows from symbols_fts. It is
+    // normally already in place, but an interrupted SKIP_FTS build can leave the database
+    // trigger-less — recreate it (IF NOT EXISTS) so a clear can never orphan FTS rows.
+    this.createFTSTriggers();
+
     // Wrap all deletes in a single transaction so the database never ends up
     // in a partially-cleared state if one statement fails mid-way.
     const deleteAll = this.db.transaction(() => {
@@ -3286,12 +3331,20 @@ export class XppSymbolIndex {
       comment?: string;
       filePath: string;
     }>,
-    opts?: { skipFtsRebuild?: boolean },
+    opts?: { skipFtsRebuild?: boolean; keepTriggers?: boolean },
   ): void {
-    // Disable FTS triggers during bulk insert
-    this.labelsDb.exec(`DROP TRIGGER IF EXISTS labels_ai`);
-    this.labelsDb.exec(`DROP TRIGGER IF EXISTS labels_ad`);
-    this.labelsDb.exec(`DROP TRIGGER IF EXISTS labels_au`);
+    if (opts?.keepTriggers) {
+      // Scoped/incremental insert: let the triggers maintain labels_fts per row instead of
+      // re-tokenising every en-US label afterwards. Recursive triggers are required so the
+      // rows displaced by INSERT OR REPLACE fire labels_ad and don't leave orphaned FTS
+      // entries pointing at dead rowids.
+      this.labelsDb.pragma('recursive_triggers = ON');
+    } else {
+      // Disable FTS triggers during bulk insert
+      this.labelsDb.exec(`DROP TRIGGER IF EXISTS labels_ai`);
+      this.labelsDb.exec(`DROP TRIGGER IF EXISTS labels_ad`);
+      this.labelsDb.exec(`DROP TRIGGER IF EXISTS labels_au`);
+    }
 
     const insert = this.labelsDb.prepare(`
       INSERT OR REPLACE INTO labels (label_id, label_file_id, model, language, text, comment, file_path)
@@ -3305,6 +3358,12 @@ export class XppSymbolIndex {
     });
 
     insertMany(entries);
+
+    if (opts?.keepTriggers) {
+      // labels_fts is already up to date — the triggers maintained it row by row.
+      this.labelsDb.pragma('recursive_triggers = OFF');
+      return;
+    }
 
     // Rebuild FTS unless the caller will do a single rebuild after all batches
     if (!opts?.skipFtsRebuild) {
@@ -3556,10 +3615,13 @@ export class XppSymbolIndex {
   /**
    * Remove all labels for the given models (used during incremental rebuild)
    */
-  clearLabelsForModels(models: string[]): void {
+  clearLabelsForModels(models: string[], opts?: { ftsStrategy?: 'rebuild' | 'incremental' }): void {
     const placeholders = models.map(() => '?').join(',');
     this.labelsDb.prepare(`DELETE FROM labels WHERE model IN (${placeholders})`).run(...models);
-    this.rebuildLabelsFts();
+    // 'incremental': the labels_ad trigger already dropped each deleted row from labels_fts,
+    // so the full delete-all + re-INSERT of every en-US label (O(all labels)) is pure waste
+    // when only a handful of models were cleared.
+    if (opts?.ftsStrategy !== 'incremental') this.rebuildLabelsFts();
   }
 
   /**

--- a/tests/metadata/incremental-fts.test.ts
+++ b/tests/metadata/incremental-fts.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Incremental FTS maintenance for scoped builds.
+ *
+ * A `custom` build touches a tiny fraction of the database (~10K of ~1.2M symbols on a real
+ * instance), but the default strategy re-tokenises the WHOLE symbols table afterwards —
+ * measured at 327s against 5s of actual indexing work on a cold cache, with the labels index
+ * and ANALYZE each costing another ~300s. `ftsStrategy: 'incremental'` instead keeps the FTS
+ * triggers live so only the touched rows are re-tokenised.
+ *
+ * That is only safe if the trigger-maintained index is indistinguishable from a full rebuild.
+ * These tests pin exactly that, including the trap that motivated the recursive_triggers
+ * pragma: rows are written with INSERT OR REPLACE, and SQLite fires delete triggers for the
+ * rows a REPLACE displaces ONLY when recursive triggers are enabled — without it every
+ * re-index would leave orphaned FTS entries pointing at dead rowids.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+let tmpDir: string;
+
+async function writeModelWithClass(root: string, model: string, className: string): Promise<void> {
+  const dir = path.join(root, model, 'classes');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, `${className}.json`),
+    JSON.stringify({ name: className, type: 'class', model }, null, 2),
+  );
+}
+
+/**
+ * Names reachable THROUGH the FTS index for a term.
+ *
+ * A plain `SELECT ... FROM symbols_fts` would not do: on an external-content table that
+ * reads the content table and would pass even with a completely stale index. Only a MATCH
+ * query is answered from the index itself, so it is the one probe that can see drift.
+ */
+function ftsSearch(index: XppSymbolIndex, term: string): string[] {
+  return index.db
+    .prepare('SELECT name FROM symbols_fts WHERE symbols_fts MATCH ? ORDER BY name')
+    .all(term)
+    .map((r: any) => r.name);
+}
+
+/**
+ * FTS5's own verification that the index matches its external content table.
+ * Throws SQLITE_CORRUPT when they have drifted — e.g. when an orphaned index entry
+ * points at a rowid the content table no longer has.
+ */
+function expectFtsIntact(index: XppSymbolIndex): void {
+  expect(() =>
+    index.db.exec("INSERT INTO symbols_fts(symbols_fts) VALUES('integrity-check');"),
+  ).not.toThrow();
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'incr-fts-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('symbols FTS: incremental strategy', () => {
+  it('produces the same index a full rebuild would', async () => {
+    const extracted = path.join(tmpDir, 'extracted');
+    await writeModelWithClass(extracted, 'ModelA', 'ClassA');
+    await writeModelWithClass(extracted, 'ModelB', 'ClassB');
+
+    const incremental = new XppSymbolIndex(':memory:', ':memory:');
+    await incremental.indexMetadataDirectory(extracted, ['ModelA', 'ModelB'], { ftsStrategy: 'incremental' });
+
+    const rebuilt = new XppSymbolIndex(':memory:', ':memory:');
+    await rebuilt.indexMetadataDirectory(extracted, ['ModelA', 'ModelB'], { ftsStrategy: 'rebuild' });
+
+    expect(ftsSearch(incremental, 'ClassA')).toEqual(['ClassA']);
+    expect(ftsSearch(incremental, 'ClassB')).toEqual(['ClassB']);
+    expect(ftsSearch(incremental, 'ClassA')).toEqual(ftsSearch(rebuilt, 'ClassA'));
+    expect(ftsSearch(incremental, 'class')).toEqual(ftsSearch(rebuilt, 'class'));
+    expectFtsIntact(incremental);
+
+    incremental.close?.();
+    rebuilt.close?.();
+  });
+
+  it('leaves no orphaned FTS rows when a model is re-indexed over itself', async () => {
+    // The INSERT OR REPLACE path: the second pass displaces every row of ModelA. Without
+    // recursive triggers the displaced rows keep their symbols_fts entries, which then
+    // point at rowids that no longer exist in the content table.
+    const extracted = path.join(tmpDir, 'extracted');
+    await writeModelWithClass(extracted, 'ModelA', 'ClassA');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(extracted, ['ModelA'], { ftsStrategy: 'incremental' });
+    await index.indexMetadataDirectory(extracted, ['ModelA'], { ftsStrategy: 'incremental' });
+
+    // One row in, one row out — a surviving orphan would show up as a duplicate hit here
+    // and as a corrupt index in the integrity check.
+    expect(ftsSearch(index, 'ClassA')).toEqual(['ClassA']);
+    expectFtsIntact(index);
+
+    index.close?.();
+  });
+
+  it('drops the cleared models out of the FTS index too', async () => {
+    const extracted = path.join(tmpDir, 'extracted');
+    await writeModelWithClass(extracted, 'ModelA', 'ClassA');
+    await writeModelWithClass(extracted, 'ModelB', 'ClassB');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(extracted, ['ModelA', 'ModelB'], { ftsStrategy: 'incremental' });
+
+    // Mirrors build-database: clear the scoped models, then re-index them.
+    index.clearModels(['ModelA']);
+    expect(ftsSearch(index, 'ClassA')).toEqual([]);
+    expect(ftsSearch(index, 'ClassB')).toEqual(['ClassB']);
+    expectFtsIntact(index);
+
+    await index.indexMetadataDirectory(extracted, ['ModelA'], { ftsStrategy: 'incremental' });
+    expect(ftsSearch(index, 'ClassA')).toEqual(['ClassA']);
+    expect(ftsSearch(index, 'ClassB')).toEqual(['ClassB']);
+    expectFtsIntact(index);
+
+    index.close?.();
+  });
+
+  it('keeps the rebuilt strategy for an unscoped pass', async () => {
+    // 'incremental' is meaningless without a scope — an unscoped pass touches every row,
+    // so it must fall back to the bulk rebuild rather than paying per-row trigger cost.
+    const extracted = path.join(tmpDir, 'extracted');
+    await writeModelWithClass(extracted, 'ModelA', 'ClassA');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(extracted, undefined, { ftsStrategy: 'incremental' });
+
+    expect(ftsSearch(index, 'ClassA')).toEqual(['ClassA']);
+    expectFtsIntact(index);
+
+    index.close?.();
+  });
+});
+
+describe('labels FTS: incremental strategy', () => {
+  const label = (labelId: string, model: string, text: string, language = 'en-US') => ({
+    labelId,
+    labelFileId: `${model}Labels`,
+    model,
+    language,
+    text,
+    filePath: `C:/pkg/${model}/${model}Labels.${language}.label.txt`,
+  });
+
+  /**
+   * Label ids reachable through the index for a term. As on the symbols side, only a MATCH
+   * query is answered from the index — labels_fts is external-content too.
+   *
+   * No integrity-check counterpart here: labels_fts deliberately indexes en-US rows only,
+   * so FTS5 would report that partial index as corrupt by design.
+   */
+  function ftsLabelSearch(index: XppSymbolIndex, term: string): string[] {
+    return index.labelsDb
+      .prepare('SELECT label_id FROM labels_fts WHERE labels_fts MATCH ? ORDER BY label_id')
+      .all(term)
+      .map((r: any) => r.label_id);
+  }
+
+  it('matches a full rebuild, and clearing a model prunes its FTS rows', () => {
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+
+    index.bulkAddLabels(
+      [
+        label('@Cus:Hello', 'CustomModel', 'Hello'),
+        label('@Cus:Bye', 'CustomModel', 'Goodbye'),
+        label('@Cus:Hello', 'CustomModel', 'Ahoj', 'cs'),
+        label('@Std:Keep', 'StandardModel', 'Keep me'),
+      ],
+      { skipFtsRebuild: true, keepTriggers: true },
+    );
+    expect(ftsLabelSearch(index, 'Hello')).toEqual(['@Cus:Hello']);
+    expect(ftsLabelSearch(index, 'Keep')).toEqual(['@Std:Keep']);
+    // Non-en-US rows stay out of the index.
+    expect(ftsLabelSearch(index, 'Ahoj')).toEqual([]);
+
+    index.clearLabelsForModels(['CustomModel'], { ftsStrategy: 'incremental' });
+    expect(ftsLabelSearch(index, 'Hello')).toEqual([]);
+    expect(ftsLabelSearch(index, 'Goodbye')).toEqual([]);
+    // The untouched standard model must survive both the clear and the FTS pruning.
+    expect(ftsLabelSearch(index, 'Keep')).toEqual(['@Std:Keep']);
+    expect(index.labelsDb.prepare('SELECT COUNT(*) n FROM labels').get()).toEqual({ n: 1 });
+
+    index.bulkAddLabels([label('@Cus:Hello', 'CustomModel', 'Hello again')], {
+      skipFtsRebuild: true,
+      keepTriggers: true,
+    });
+    expect(ftsLabelSearch(index, 'again')).toEqual(['@Cus:Hello']);
+
+    // Same oracle as the symbols side: the incrementally maintained index must answer
+    // exactly like one rebuilt from scratch.
+    const terms = ['Hello', 'again', 'Goodbye', 'Keep', 'Ahoj'];
+    const incremental = terms.map(t => ftsLabelSearch(index, t));
+    index.rebuildLabelsFts();
+    expect(terms.map(t => ftsLabelSearch(index, t))).toEqual(incremental);
+
+    index.close?.();
+  });
+
+  it('leaves no orphaned FTS rows when the same label is re-inserted', () => {
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+
+    index.bulkAddLabels([label('@Cus:Hello', 'CustomModel', 'First')], {
+      skipFtsRebuild: true,
+      keepTriggers: true,
+    });
+    index.bulkAddLabels([label('@Cus:Hello', 'CustomModel', 'Second')], {
+      skipFtsRebuild: true,
+      keepTriggers: true,
+    });
+
+    // The replaced row must be gone from the index, not merely shadowed by the new one.
+    expect(ftsLabelSearch(index, 'First')).toEqual([]);
+    expect(ftsLabelSearch(index, 'Second')).toEqual(['@Cus:Hello']);
+
+    index.close?.();
+  });
+});


### PR DESCRIPTION
## Problem

`EXTRACT_MODE=custom` still took over 15 minutes, despite #706 scoping the rebuild to the custom models. Timings from a real build on a 1.17M-symbol instance with a cold page cache:

| step | time |
|---|---|
| indexing the 3 custom models | **5.5 s** |
| symbols FTS rebuild | 327.5 s |
| label indexing (two full `labels_fts` rebuilds) | 283.8 s |
| ANALYZE + optimize | 309.3 s |
| **total** | **~920 s** |

#706 fixed *which models get indexed* — and that part works, it is the 5.5 s line. What it did not touch is what runs afterwards: three steps whose cost is O(the whole database) no matter how little changed. The build re-tokenised all 1,173,125 symbols (including ~281 MB of `source_snippet`/`inline_comments`) because 10,023 rows moved, re-inserted all 485,038 en-US labels because 6,646 moved, and re-ANALYZEd 2.7 GB for a sub-1% row change. That is 99.4% of the runtime.

Cold cache is the normal state on a D365FO VM — AOS and SQL Server keep free RAM at ~4 GB of 32, so a 2.7 GB database set never stays resident between builds. The same build on a warm cache took 38 s, which is why this did not show up earlier.

## Change

- **`ftsStrategy` on `indexMetadataDirectory`.** `'incremental'` keeps the FTS triggers live so only touched rows are re-tokenised; `'rebuild'` (default) keeps the bulk re-tokenise. build-database opts into `'incremental'` for `custom` only — `standard` and `all` cover the whole database, where the bulk rebuild still wins. No heuristics: the caller that knows the scope makes the call.
- **Same for labels.** `clearLabelsForModels` and `indexAllLabels` no longer delete-all + re-INSERT every en-US label to account for a few thousand rows.
- **ANALYZE on full rebuilds or on demand** (`ANALYZE=true`). A sub-1% row change does not move planner statistics.

## Latent FTS corruption fixed along the way

The new tests failed with `fts5: missing row 1 from content table` and the cause was production code, not the test. `symbols_fts` is an external-content table, so a removal must hand the OLD column values back via the `'delete'` command — which is exactly what the labels triggers already did. `symbols_ad` instead ran `DELETE FROM symbols_fts WHERE rowid = old.id`, which cannot work: the trigger fires *after* the content row is gone, so FTS5 has nothing left to re-derive the row's terms from and the old terms stay in the index. Same for `symbols_au`.

This means every runtime symbol delete/update (`removeSymbolsByFile` and friends) has been drifting the index. It stayed invisible because each build rebuilt FTS wholesale. Triggers are now dropped and recreated on each index run, so databases carrying the old definitions repair themselves.

Related: rows are written with `INSERT OR REPLACE`, and SQLite fires delete triggers for the rows a REPLACE displaces *only* when recursive triggers are enabled. Hence the pragma around the incremental passes — without it every re-index would orphan FTS entries.

## Verification

Against the real 2 GB instance database (on a copy):

- build **920 s → 19 s**; label step 283.8 s → 1.2 s
- `INSERT INTO symbols_fts(symbols_fts) VALUES('integrity-check')` passes after an incremental build
- 9,303 custom symbols reachable through `MATCH`; standard labels untouched (14,171 hits for `invoice`)

`tests/metadata/incremental-fts.test.ts` pins that the incrementally maintained index answers exactly like a rebuilt one, that re-indexing a model over itself orphans nothing, and that a cleared model leaves the FTS index. The assertions go through `MATCH` queries deliberately: a plain `SELECT` over an external-content table reads the *content* table and would pass against a completely stale index. The `recursive_triggers` pragma was mutation-tested — removing it fails the suite.

Full suite: 1813 passed. Two unrelated pre-existing failures in the working tree at the time (`toolSchemaBudget`, from in-progress `toolSchemas/*` edits, and the known `apiSymbols` cold-cache timeout) are not touched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
