### PR TITLE
feat(cli): make an npm install a full installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/node": "^26.0.1",
         "@types/xml2js": "^0.4.14",
         "@vitest/coverage-v8": "^4.1.4",
+        "esbuild": "^0.28.1",
         "tsx": "^4.21.0",
         "typescript": "^7.0.2",
         "vitest": "^4.1.4"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "d365fo-mcp": "dist/cli/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "!dist/**/*.map",
+    "!dist/eval/**",
+    "bridge/D365MetadataBridge",
+    "!bridge/D365MetadataBridge/bin/**",
+    "!bridge/D365MetadataBridge/obj/**"
   ],
   "repository": {
     "type": "git",
@@ -24,7 +29,8 @@
     "setup": "tsx src/cli/index.ts setup",
     "doctor": "tsx src/cli/index.ts doctor",
     "config:docs": "tsx scripts/generate-config-docs.ts",
-    "build": "tsc",
+    "build": "tsc && npm run build:scripts",
+    "build:scripts": "esbuild scripts/extract-metadata.ts scripts/build-database.ts scripts/build-fts.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts && esbuild src/metadata/symbolCountsWorker.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts",
     "prepublishOnly": "npm run build",
     "start": "node dist/index.js",
     "test": "vitest",
@@ -78,6 +84,7 @@
     "@types/node": "^26.0.1",
     "@types/xml2js": "^0.4.14",
     "@vitest/coverage-v8": "^4.1.4",
+    "esbuild": "^0.28.1",
     "tsx": "^4.21.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.4"

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -9,7 +9,7 @@ import * as fs from 'node:fs';
 import { relative, resolve } from 'node:path';
 import { p } from '../ui.js';
 import { settingByPath } from '../../config/settings.js';
-import { installMode, isWindows, paths, repoRoot } from '../context.js';
+import { dataRoot, installMode, isWindows, paths, repoRoot } from '../context.js';
 import { listInstances } from '../instances.js';
 import { checkRelease } from '../npmRegistry.js';
 import { conflictingLegacyValues, readPath, readSetting, type SettingsStore } from '../settingsStore.js';
@@ -25,6 +25,11 @@ interface CheckResult {
 }
 
 const REQUIRED_NODE_MAJOR = 24;
+/**
+ * How to reach the wizard from here. `npm run setup` only exists in a checkout
+ * — an npm install has no package scripts of its own to run.
+ */
+const SETUP_COMMAND = installMode === 'git' ? 'npm run setup' : 'd365fo-mcp setup';
 /** Below this size the index is almost certainly incomplete (SETUP.md troubleshooting). */
 const MIN_HEALTHY_DB_BYTES = 100 * 1024 * 1024;
 
@@ -60,20 +65,20 @@ function checkDb(store: SettingsStore, defaultDb: string, label: string): CheckR
 /** The structured config the setup wizard writes — absent means never set up. */
 function checkConfig(target: Target, label: string): CheckResult {
   if (fs.existsSync(target.store.configPath)) {
-    const shown = relative(repoRoot, target.store.configPath) || target.store.configPath;
+    const shown = relative(dataRoot(), target.store.configPath) || target.store.configPath;
     return { severity: 'ok', message: `${label}: configuration present (${shown})` };
   }
   if (target.envFile) {
     return {
       severity: 'warn',
       message: `${label}: no d365fo-mcp.json — running on the legacy .env only`,
-      fix: 'npm run setup — imports the .env and writes the structured config',
+      fix: `${SETUP_COMMAND} — imports the .env and writes the structured config`,
     };
   }
   return {
     severity: 'info',
     message: `${label}: not configured — fine when everything comes from the .mcp.json env block`,
-    fix: 'npm run setup',
+    fix: SETUP_COMMAND,
   };
 }
 
@@ -168,16 +173,27 @@ export async function doctorCommand(): Promise<void> {
     ? { severity: 'ok', message: `Node.js ${process.versions.node}` }
     : { severity: 'fail', message: `Node.js ${process.versions.node} — ${REQUIRED_NODE_MAJOR}.x required (package.json engines)`, fix: 'install Node 24 LTS' });
 
-  // Install + build
-  const hasNodeModules = fs.existsSync(resolve(repoRoot, 'node_modules'));
-  emit(hasNodeModules
-    ? { severity: 'ok', message: 'Dependencies installed (node_modules)' }
-    : { severity: 'fail', message: 'node_modules missing', fix: 'npm install' });
-  // Only meaningful once the dependencies exist — otherwise it just restates the failure above.
-  if (hasNodeModules) emit(await checkNativeBinding());
+  // Install + build. A global npm install resolves its dependencies from the
+  // parent node_modules, so a package-local one neither exists nor means
+  // anything there — the binding check below is the honest signal in both
+  // layouts, and the only one worth failing on.
+  if (installMode === 'git') {
+    const hasNodeModules = fs.existsSync(resolve(repoRoot, 'node_modules'));
+    emit(hasNodeModules
+      ? { severity: 'ok', message: 'Dependencies installed (node_modules)' }
+      : { severity: 'fail', message: 'node_modules missing', fix: 'npm install' });
+    // Only meaningful once the dependencies exist — otherwise it just restates the failure above.
+    if (hasNodeModules) emit(await checkNativeBinding());
+  } else {
+    emit(await checkNativeBinding());
+  }
   emit(fs.existsSync(paths.distEntry)
     ? { severity: 'ok', message: 'Server built (dist/index.js)' }
     : { severity: 'fail', message: 'dist/index.js missing — server not built', fix: 'npm run build' });
+
+  // Where this installation keeps its state — the first thing to check when
+  // the wizard's answers appear to have vanished after an update.
+  emit({ severity: 'info', message: `Installed from ${installMode}; data directory: ${dataRoot()}` });
 
   // Configuration
   const root = rootTarget();
@@ -191,7 +207,9 @@ export async function doctorCommand(): Promise<void> {
   if (isWindows) {
     emit(fs.existsSync(paths.bridgeExe)
       ? { severity: 'ok', message: 'C# bridge built (D365MetadataBridge.exe)' }
-      : { severity: 'warn', message: 'C# bridge not built — server runs read-only', fix: 'cd bridge\\D365MetadataBridge && dotnet build -c Release' });
+      // Absolute path: outside a checkout the user is nowhere near the bridge,
+      // and a relative `cd bridge\...` would just fail.
+      : { severity: 'warn', message: 'C# bridge not built — server runs read-only', fix: `cd "${paths.bridgeDir}" && dotnet build -c Release` });
     const dir = xppConfigDir();
     const configs = listXppConfigs();
     if (dir && fs.existsSync(dir)) {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -9,8 +9,9 @@ import * as fs from 'node:fs';
 import { relative, resolve } from 'node:path';
 import { p } from '../ui.js';
 import { settingByPath } from '../../config/settings.js';
-import { isWindows, paths, repoRoot } from '../context.js';
+import { installMode, isWindows, paths, repoRoot } from '../context.js';
 import { listInstances } from '../instances.js';
+import { checkRelease } from '../npmRegistry.js';
 import { conflictingLegacyValues, readPath, readSetting, type SettingsStore } from '../settingsStore.js';
 import { instanceTarget, rootTarget, type Target } from '../target.js';
 import { isXppConfigStale, listXppConfigs, xppConfigDir } from '../xppConfig.js';
@@ -116,6 +117,27 @@ async function checkNativeBinding(): Promise<CheckResult> {
   }
 }
 
+/**
+ * Whether this copy is the latest published release.
+ *
+ * Never a hard failure: an old copy still works, and a VM with no route to the
+ * registry must not fail its health check over it.
+ */
+async function checkReleaseFreshness(): Promise<CheckResult> {
+  const status = await checkRelease();
+  if (status.latest === null) {
+    return { severity: 'info', message: `d365fo-mcp ${status.current} — npm registry unreachable, cannot check for a newer release` };
+  }
+  if (status.behind) {
+    return {
+      severity: 'warn',
+      message: `d365fo-mcp ${status.current} — ${status.latest} is available`,
+      fix: installMode === 'npm' ? 'npm install -g d365fo-mcp@latest' : 'd365fo-mcp update',
+    };
+  }
+  return { severity: 'ok', message: `d365fo-mcp ${status.current} (latest)` };
+}
+
 async function probeHealth(port: number, label: string): Promise<CheckResult> {
   try {
     const res = await fetch(`http://localhost:${port}/health`, { signal: AbortSignal.timeout(1500) });
@@ -136,6 +158,9 @@ export async function doctorCommand(): Promise<void> {
     if (r.severity === 'fail') failures++;
     report(r);
   };
+
+  // Release freshness — advisory, and silent about a registry it cannot reach.
+  emit(await checkReleaseFreshness());
 
   // Runtime
   const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);

--- a/src/cli/commands/indexCmd.ts
+++ b/src/cli/commands/indexCmd.ts
@@ -4,12 +4,25 @@
  * instances/rebuild-instance.ps1 minus the git-pull step (that lives in
  * `d365fo-mcp update`).
  */
-import { isWindows, paths } from '../context.js';
+import { installMode, isWindows, paths } from '../context.js';
 import { runNode } from '../exec.js';
 import { listInstances } from '../instances.js';
 import { instanceTarget, pickTarget, rootTarget, targetEnv, Target } from '../target.js';
-import { askSelect, p, requireGitCheckout } from '../ui.js';
+import { askSelect, p, requireFullInstall } from '../ui.js';
 import { normalizeXppConfigName } from '../xppConfig.js';
+
+/**
+ * Node arguments that run one index script.
+ *
+ * A checkout runs the TypeScript through tsx; an npm install has neither the
+ * sources nor tsx and runs the esbuild bundle instead. The bundle sits one
+ * level deeper than the sources, so its `loadEnv(import.meta.url)` would look
+ * for dist/.env — harmless, because `targetEnv` names the config explicitly
+ * whenever one exists, and before that there is nothing to find either way.
+ */
+function scriptArgs(tsSource: string, bundle: string): string[] {
+  return installMode === 'git' ? ['--import', 'tsx/esm', tsSource] : [bundle];
+}
 
 /** Run extract + build-database for one target. Returns true on success. */
 export async function rebuildIndex(target: Target): Promise<boolean> {
@@ -21,13 +34,13 @@ export async function rebuildIndex(target: Target): Promise<boolean> {
   }
 
   p.log.step(`[1/2] Extracting metadata (${target.label})…`);
-  if (await runNode(['--import', 'tsx/esm', paths.extractScript], { env }) !== 0) {
+  if (await runNode(scriptArgs(paths.extractScript, paths.extractScriptDist), { env }) !== 0) {
     p.log.error(`Metadata extraction failed for ${target.label}`);
     return false;
   }
 
   p.log.step(`[2/2] Building database (${target.label})…`);
-  if (await runNode(['--max-old-space-size=6144', '--import', 'tsx/esm', paths.buildDbScript], { env }) !== 0) {
+  if (await runNode(['--max-old-space-size=6144', ...scriptArgs(paths.buildDbScript, paths.buildDbScriptDist)], { env }) !== 0) {
     p.log.error(`Database build failed for ${target.label}`);
     return false;
   }
@@ -38,7 +51,7 @@ export async function rebuildIndex(target: Target): Promise<boolean> {
 
 export async function indexCommand(instanceName: string | undefined, opts: { all?: boolean; yes?: boolean }): Promise<void> {
   p.intro('d365fo-mcp index');
-  if (!requireGitCheckout()) return;
+  if (!requireFullInstall()) return;
 
   let targets: Target[];
   if (opts.all) {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -11,7 +11,7 @@
  */
 import * as fs from 'node:fs';
 import { relative, resolve } from 'node:path';
-import { installMode, isWindows, paths, repoRoot } from '../context.js';
+import { dataRoot, installMode, isWindows, paths, repoRoot, setDataRoot } from '../context.js';
 import type { SectionId } from '../../config/settings.js';
 import { settingByPath, settingsInSection } from '../../config/settings.js';
 import { runExe, runShell } from '../exec.js';
@@ -32,6 +32,47 @@ const setting = (path: string) => {
   if (!found) throw new Error(`Unknown setting: ${path}`); // registry typo — fail loudly at first use
   return found;
 };
+
+/**
+ * Ask an npm install where to keep its configuration, index and instances.
+ *
+ * `npm install -g d365fo-mcp@latest` replaces the package directory, so none
+ * of that can live inside it. Asking also puts the choice of *drive* in the
+ * user's hands, which matters more than it looks: a full index is upwards of
+ * 2 GB, and the default under %LOCALAPPDATA% is on C: — routinely the smallest
+ * disk on a D365FO VM.
+ *
+ * A checkout skips this entirely; it is its own data directory.
+ */
+async function configureDataRoot(): Promise<void> {
+  if (installMode === 'git') return;
+
+  const current = dataRoot();
+  const configured = fs.existsSync(paths.rootConfig);
+  if (configured && !await askConfirm(`Installation directory is ${current} — move it?`, false)) {
+    return;
+  }
+
+  const chosen = await askText({
+    message: 'Where should the configuration and the metadata index live?',
+    placeholder: current,
+    initialValue: current,
+    required: true,
+  });
+  if (resolve(chosen) === current) {
+    setDataRoot(current); // records the pointer even when the default was kept
+    return;
+  }
+  if (configured) {
+    p.log.warn(
+      `The existing configuration stays in ${current}.\n` +
+      '   Copy config\\ and data\\ across by hand if you want to keep the index; ' +
+      'otherwise it will be rebuilt from scratch.',
+    );
+  }
+  setDataRoot(chosen);
+  p.log.success(`Installation directory: ${dataRoot()}`);
+}
 
 /** npm install + npm run build, skipping steps that are already done. */
 async function ensureInstalledAndBuilt(): Promise<boolean> {
@@ -88,7 +129,7 @@ async function maybeBuildBridge(scenario: Scenario): Promise<boolean> {
 
 /** Open the root store and fold an existing .env into it. */
 function openRootStore(): SettingsStore {
-  const store = openStore(repoRoot, paths.rootEnv);
+  const store = openStore(dataRoot(), paths.rootEnv);
   const migrated = migrateLegacyEnv(store);
   if (migrated.length > 0) {
     p.log.success(
@@ -174,10 +215,10 @@ async function maybeBuildIndex(): Promise<boolean> {
 }
 
 export function savedNote(store: SettingsStore): void {
-  const rel = relative(repoRoot, store.configPath) || store.configPath;
+  const rel = relative(dataRoot(), store.configPath) || store.configPath;
   const lines = [`Settings written to ${rel}`];
   if (fs.existsSync(store.secretsPath)) {
-    lines.push(`Secrets written to ${relative(repoRoot, store.secretsPath)} (git-ignored, owner-only)`);
+    lines.push(`Secrets written to ${relative(dataRoot(), store.secretsPath)} (git-ignored, owner-only)`);
   }
   lines.push('', 'Edit it by re-running `d365fo-mcp setup` or by hand — it is plain JSON.');
   p.note(lines.join('\n'), 'Configuration');
@@ -205,6 +246,9 @@ export async function setupCommand(): Promise<void> {
     { value: 'ude', label: 'D — UDE', hint: 'Unified Developer Experience / Power Platform Tools' },
     { value: 'multi', label: 'F — Multi-instance', hint: 'several D365FO clients on one machine, one instance each' },
   ]);
+
+  // Before anything is written: every path below hangs off the data directory.
+  await configureDataRoot();
 
   // All scenarios need the local clone installed and built
   if (!await ensureInstalledAndBuilt()) { process.exitCode = 1; return; }

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -11,15 +11,16 @@
  */
 import * as fs from 'node:fs';
 import { relative, resolve } from 'node:path';
-import { isWindows, paths, repoRoot } from '../context.js';
+import { installMode, isWindows, paths, repoRoot } from '../context.js';
 import type { SectionId } from '../../config/settings.js';
 import { settingByPath, settingsInSection } from '../../config/settings.js';
 import { runExe, runShell } from '../exec.js';
 import { mcpJsonNote, placementNote, stdioServer } from '../mcpJson.js';
+import { checkRelease } from '../npmRegistry.js';
 import { askAdvanced, askSecrets, askSetting, askSettings } from '../settingsPrompt.js';
 import { migrateLegacyEnv, openStore, readSetting, saveStore, writeSetting, type SettingsStore } from '../settingsStore.js';
 import { rootTarget } from '../target.js';
-import { askConfirm, askSelect, askText, p, requireGitCheckout } from '../ui.js';
+import { askConfirm, askSelect, askText, p, requireFullInstall } from '../ui.js';
 import { listXppConfigs } from '../xppConfig.js';
 import { rebuildIndex } from './indexCmd.js';
 import { instanceAddCommand } from './instance.js';
@@ -34,6 +35,12 @@ const setting = (path: string) => {
 
 /** npm install + npm run build, skipping steps that are already done. */
 async function ensureInstalledAndBuilt(): Promise<boolean> {
+  // An npm install arrives with its dependencies resolved and dist/ prebuilt,
+  // and has no sources to compile — there is nothing here for it to do.
+  if (installMode === 'npm') {
+    p.log.success('Installed from npm — dependencies and build are already in place.');
+    return true;
+  }
   if (!fs.existsSync(resolve(repoRoot, 'node_modules'))) {
     p.log.step('Installing dependencies (npm install)…');
     if (await runShell('npm install') !== 0) { p.log.error('npm install failed.'); return false; }
@@ -178,7 +185,18 @@ export function savedNote(store: SettingsStore): void {
 
 export async function setupCommand(): Promise<void> {
   p.intro('d365fo-mcp setup — first-time setup');
-  if (!requireGitCheckout()) return;
+  if (!requireFullInstall()) return;
+
+  // Setting up an already-stale copy wastes the longest step there is: the
+  // index build. Say so before it starts, but never block on it — plenty of
+  // D365FO VMs have no route to the registry.
+  const release = await checkRelease();
+  if (release.behind) {
+    p.log.warn(
+      `This is d365fo-mcp ${release.current}; ${release.latest} is published.\n` +
+      `   Updating first avoids rebuilding the index twice: ${installMode === 'npm' ? 'npm install -g d365fo-mcp@latest' : 'd365fo-mcp update'}`,
+    );
+  }
 
   const scenario = await askSelect<Scenario>('How will this developer machine use the MCP server? (docs/SETUP.md)', [
     { value: 'local-stdio', label: 'E — Local stdio ★', hint: 'single developer on a D365FO VM; VS launches the server' },

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,26 +1,47 @@
 /**
- * `d365fo-mcp update [--yes]` — pull the latest code, reinstall dependencies,
- * rebuild TypeScript, and optionally rebuild the C# bridge and the metadata
- * index (the "Update" flow SETUP.md documents as git pull && npm install &&
- * npm run build).
+ * `d365fo-mcp update [--yes]` — bring the installation to the latest release,
+ * then optionally rebuild the C# bridge and the metadata index.
+ *
+ * How the code is refreshed depends on how it was installed: a checkout runs
+ * the "Update" flow SETUP.md documents (git pull && npm install && npm run
+ * build); an npm install reinstalls itself from the registry.
  */
 import * as fs from 'node:fs';
-import { isWindows, paths } from '../context.js';
+import { installMode, isWindows, paths } from '../context.js';
 import { runExe, runShell } from '../exec.js';
 import { listInstances } from '../instances.js';
+import { checkRelease } from '../npmRegistry.js';
 import { instanceTarget, rootTarget } from '../target.js';
-import { askConfirm, p, requireGitCheckout } from '../ui.js';
+import { askConfirm, p, requireFullInstall } from '../ui.js';
 import { rebuildIndex } from './indexCmd.js';
 
 export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
   p.intro('d365fo-mcp update');
-  if (!requireGitCheckout()) return;
+  if (!requireFullInstall()) return;
 
-  const steps: [string, () => Promise<number>][] = [
-    ['git pull', () => runExe('git', ['pull'])],
-    ['npm install', () => runShell('npm install')],
-    ['npm run build', () => runShell('npm run build')],
-  ];
+  // Say up front what the update is moving towards. A checkout tracks a branch
+  // rather than the registry, so there the comparison is informational only —
+  // being "ahead" of the latest release is the normal state on main.
+  const release = await checkRelease();
+  if (release.latest === null) {
+    p.log.warn(`Running ${release.current} — npm registry unreachable, so this update runs blind.`);
+  } else if (release.behind) {
+    p.log.step(`Running ${release.current}; latest published release is ${release.latest}.`);
+  } else {
+    p.log.success(`Running ${release.current} — already the latest published release.`);
+    if (installMode === 'npm' && !opts.yes && !await askConfirm('Reinstall anyway?', false)) {
+      p.outro('Nothing to update.');
+      return;
+    }
+  }
+
+  const steps: [string, () => Promise<number>][] = installMode === 'npm'
+    ? [['npm install -g d365fo-mcp@latest', () => runShell('npm install -g d365fo-mcp@latest')]]
+    : [
+      ['git pull', () => runExe('git', ['pull'])],
+      ['npm install', () => runShell('npm install')],
+      ['npm run build', () => runShell('npm run build')],
+    ];
   for (const [label, run] of steps) {
     p.log.step(label);
     if (await run() !== 0) {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -15,6 +15,27 @@ import { instanceTarget, rootTarget } from '../target.js';
 import { askConfirm, p, requireFullInstall } from '../ui.js';
 import { rebuildIndex } from './indexCmd.js';
 
+/**
+ * What to do about the C# bridge after the code has been refreshed.
+ *
+ * Both inputs are needed, and *when* they are sampled is the whole point.
+ * `hadBridge` is taken before the update, because `npm install -g` replaces
+ * the package directory and takes the bridge binary with it; asking only
+ * afterwards would read every npm-mode update as "this install never needed
+ * writes" and silently drop the write path.
+ *
+ *   none     — there was no bridge, so this install does not use writes
+ *   optional — the bridge survived; rebuilding is a post-upgrade nicety
+ *   required — the update removed a bridge that was there, so the write path
+ *              is gone until it is rebuilt
+ */
+export type BridgeAction = 'none' | 'optional' | 'required';
+
+export function bridgeAction(hadBridge: boolean, existsNow: boolean): BridgeAction {
+  if (!hadBridge) return 'none';
+  return existsNow ? 'optional' : 'required';
+}
+
 export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
   p.intro('d365fo-mcp update');
   if (!requireFullInstall()) return;
@@ -35,6 +56,13 @@ export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
     }
   }
 
+  // Sampled before the update, not after: the bridge binary lives inside the
+  // package, and `npm install -g` replaces the package wholesale. Asking
+  // afterwards would always find it missing, skip the rebuild as "this install
+  // never needed writes", and leave a server that had the write path silently
+  // read-only until someone noticed.
+  const hadBridge = isWindows && fs.existsSync(paths.bridgeExe);
+
   const steps: [string, () => Promise<number>][] = installMode === 'npm'
     ? [['npm install -g d365fo-mcp@latest', () => runShell('npm install -g d365fo-mcp@latest')]]
     : [
@@ -51,16 +79,28 @@ export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
     }
   }
 
-  // Only rebuild the bridge if it was built before — a missing exe means this install never needed writes.
-  if (isWindows && fs.existsSync(paths.bridgeExe)) {
-    const rebuild = opts.yes || await askConfirm('Rebuild the C# bridge (recommended after a D365FO version upgrade)?');
+  const action = bridgeAction(hadBridge, fs.existsSync(paths.bridgeExe));
+  if (action !== 'none') {
+    const gone = action === 'required';
+    if (gone) p.log.warn('The update replaced the package, so the C# bridge binary is gone — writes stay unavailable until it is rebuilt.');
+    const rebuild = opts.yes || await askConfirm(
+      gone
+        ? 'Rebuild the C# bridge now? (required to restore writes)'
+        : 'Rebuild the C# bridge (recommended after a D365FO version upgrade)?',
+    );
     if (rebuild) {
       if (await runExe('dotnet', ['build', '-c', 'Release'], { cwd: paths.bridgeDir }) !== 0) {
-        p.log.error('Bridge build failed — writes may use the previous bridge binary.');
+        p.log.error(gone
+          ? 'Bridge build failed — the server stays read-only until it succeeds.'
+          : 'Bridge build failed — writes may use the previous bridge binary.');
         process.exitCode = 1;
         return;
       }
       p.log.success('C# bridge rebuilt.');
+    } else if (gone) {
+      // Declining is allowed, but it must not be quiet: the capability was
+      // there before this command ran and is not there now.
+      p.log.warn(`Skipped — the server runs read-only. Rebuild later with:\n   cd "${paths.bridgeDir}" && dotnet build -c Release`);
     }
   }
 

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -15,12 +15,28 @@ const __cliDir = dirname(fileURLToPath(import.meta.url));
 export const repoRoot = resolve(__cliDir, '../..');
 
 /**
- * True when the CLI runs from a git checkout — the only supported layout for
- * setup/update/index. Those commands need scripts/, devDependencies (tsx) and
- * `git pull`, none of which exist when the package runs from the npx cache or
- * a release tarball.
+ * True when the CLI runs from a git checkout — sources, devDependencies (tsx)
+ * and `git pull` are all available, so setup/update/index run the TypeScript
+ * directly.
  */
 export const isGitCheckout = fs.existsSync(resolve(repoRoot, '.git'));
+
+/**
+ * How this copy was installed, which decides how the same commands do their
+ * work:
+ *
+ *   git — a checkout: index scripts run from scripts/*.ts through tsx, and
+ *         `update` is git pull + npm install + npm run build.
+ *   npm — installed from the registry: there are no sources and no tsx, so the
+ *         index scripts run as the bundles under dist/scripts/, and `update`
+ *         is `npm install -g d365fo-mcp@latest`.
+ *
+ * A copy that is neither (an npx cache of a release published before the
+ * bundles existed) reports 'npm' but fails `isFullInstall` below, so the user
+ * is pointed at the installer instead of failing halfway through a rebuild.
+ */
+export type InstallMode = 'git' | 'npm';
+export const installMode: InstallMode = isGitCheckout ? 'git' : 'npm';
 
 /** Bootstrap one-liner printed when a command needs a full installation. */
 export const installOneLiner =
@@ -39,6 +55,15 @@ export const paths = {
   bridgeExe: resolve(repoRoot, 'bridge', 'D365MetadataBridge', 'bin', 'Release', 'D365MetadataBridge.exe'),
   extractScript: resolve(repoRoot, 'scripts', 'extract-metadata.ts'),
   buildDbScript: resolve(repoRoot, 'scripts', 'build-database.ts'),
+  /** esbuild bundles of the two scripts above — what an npm install ships instead of the sources. */
+  extractScriptDist: resolve(repoRoot, 'dist', 'scripts', 'extract-metadata.js'),
+  buildDbScriptDist: resolve(repoRoot, 'dist', 'scripts', 'build-database.js'),
 } as const;
+
+/**
+ * True when this copy can rebuild an index — the one capability that separates
+ * a full installation from a bare `npx d365fo-mcp connect` client.
+ */
+export const isFullInstall = isGitCheckout || fs.existsSync(paths.extractScriptDist);
 
 export const isWindows = process.platform === 'win32';

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,10 +1,19 @@
 /**
- * CLI context — repo-root resolution shared by all commands.
+ * CLI context — the two roots every command resolves against.
  *
- * The CLI runs either from src/cli (tsx during development) or dist/cli
- * (built). Both are exactly two levels below the repo root, so resolve
- * relative to this file rather than process.cwd() — developers invoke the
- * CLI from arbitrary directories.
+ * `repoRoot` is where the *code* lives. The CLI runs either from src/cli (tsx
+ * during development) or dist/cli (built); both are exactly two levels below
+ * it, so resolve relative to this file rather than process.cwd() — the CLI is
+ * invoked from arbitrary directories.
+ *
+ * `dataRoot` is where *this installation's* configuration, metadata index and
+ * instances live. In a git checkout the two are the same directory and nothing
+ * about the old layout changes. An npm install has to separate them: `npm
+ * install -g d365fo-mcp@latest` replaces the package directory wholesale, so a
+ * config file or a 2 GB index kept inside it would not survive a single
+ * update. There the setup wizard asks for a directory and records it in a
+ * pointer file kept outside the package, which is how the next version finds
+ * the same installation again.
  */
 import * as fs from 'node:fs';
 import { fileURLToPath } from 'url';
@@ -42,15 +51,107 @@ export const installMode: InstallMode = isGitCheckout ? 'git' : 'npm';
 export const installOneLiner =
   'irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/install.ps1 | iex';
 
+export const isWindows = process.platform === 'win32';
+
+/**
+ * Per-user state directory — holds the pointer file, and nothing else.
+ *
+ * It must sit outside both roots: outside the package because an update
+ * deletes that, and outside the data directory because the pointer is what
+ * locates the data directory in the first place.
+ */
+function stateDir(): string {
+  const local = process.env.LOCALAPPDATA;
+  if (isWindows && local) return resolve(local, 'd365fo-mcp');
+  const xdg = process.env.XDG_CONFIG_HOME;
+  if (xdg) return resolve(xdg, 'd365fo-mcp');
+  return resolve(process.env.HOME ?? process.env.USERPROFILE ?? '.', '.config', 'd365fo-mcp');
+}
+
+/** Records which directory holds this user's installation. */
+export const installPointerFile = resolve(stateDir(), 'install.json');
+
+/**
+ * The data directory named by a pointer file, or null.
+ *
+ * Every failure collapses to null on purpose: the file is absent before the
+ * first setup, and a truncated or hand-edited one is no more usable than a
+ * missing one. Throwing here would break `connect`, which needs neither.
+ */
+export function readInstallPointer(file: string): string | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as { dataRoot?: unknown };
+    return typeof parsed.dataRoot === 'string' && parsed.dataRoot.length > 0 ? parsed.dataRoot : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Record `dir` as the data directory, creating both it and the pointer's folder. */
+export function writeInstallPointer(file: string, dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({ dataRoot: dir }, null, 2) + '\n', 'utf8');
+}
+
+/**
+ * Default data directory for an npm install that has not been set up yet.
+ * Deliberately not under the package, and not the current directory — the CLI
+ * is run from wherever the user happens to be standing.
+ */
+function defaultDataRoot(): string {
+  return resolve(stateDir(), 'installation');
+}
+
+function resolveDataRoot(): string {
+  // A checkout is self-contained: config/, data/ and instances/ live in it and
+  // survive `git pull`, so it never consults the pointer file. This is what
+  // keeps every existing installation on exactly its current paths.
+  if (installMode === 'git') return repoRoot;
+  const override = process.env.D365FO_MCP_HOME?.trim();
+  if (override) return resolve(override);
+  return readInstallPointer(installPointerFile) ?? defaultDataRoot();
+}
+
+let currentDataRoot = resolveDataRoot();
+
+/** Where this installation keeps its configuration, index and instances. */
+export function dataRoot(): string {
+  return currentDataRoot;
+}
+
+/**
+ * Point this installation at `dir` and remember it for future runs.
+ *
+ * Only meaningful for an npm install; a checkout is its own data directory and
+ * calling this on one would split it in two.
+ */
+export function setDataRoot(dir: string): void {
+  const target = resolve(dir);
+  writeInstallPointer(installPointerFile, target);
+  currentDataRoot = target;
+}
+
+/**
+ * Paths every command works from.
+ *
+ * Getters rather than plain strings: `setDataRoot` runs in the middle of the
+ * setup wizard, and the entries below it must reflect the directory the user
+ * just chose, not the one that was current when this module was imported.
+ */
 export const paths = {
   /** Legacy configuration file — still read as a fallback, no longer written. */
-  rootEnv: resolve(repoRoot, '.env'),
-  rootConfig: resolve(repoRoot, 'config', 'd365fo-mcp.json'),
-  rootSecrets: resolve(repoRoot, 'config', 'secrets.json'),
-  instancesDir: resolve(repoRoot, 'instances'),
+  get rootEnv(): string { return resolve(currentDataRoot, '.env'); },
+  get rootConfig(): string { return resolve(currentDataRoot, 'config', 'd365fo-mcp.json'); },
+  get rootSecrets(): string { return resolve(currentDataRoot, 'config', 'secrets.json'); },
+  get instancesDir(): string { return resolve(currentDataRoot, 'instances'); },
+  get defaultDb(): string { return resolve(currentDataRoot, 'data', 'xpp-metadata.db'); },
+  get defaultLabelsDb(): string { return resolve(currentDataRoot, 'data', 'xpp-metadata-labels.db'); },
+  /** Where the wizard drops the ready-to-paste .mcp.json block. */
+  get mcpSuggestion(): string { return resolve(currentDataRoot, 'mcp-config-suggestion.json'); },
+
+  // Code — always in the package, never in the data directory.
   distEntry: resolve(repoRoot, 'dist', 'index.js'),
-  defaultDb: resolve(repoRoot, 'data', 'xpp-metadata.db'),
-  defaultLabelsDb: resolve(repoRoot, 'data', 'xpp-metadata-labels.db'),
   bridgeDir: resolve(repoRoot, 'bridge', 'D365MetadataBridge'),
   bridgeExe: resolve(repoRoot, 'bridge', 'D365MetadataBridge', 'bin', 'Release', 'D365MetadataBridge.exe'),
   extractScript: resolve(repoRoot, 'scripts', 'extract-metadata.ts'),
@@ -58,12 +159,10 @@ export const paths = {
   /** esbuild bundles of the two scripts above — what an npm install ships instead of the sources. */
   extractScriptDist: resolve(repoRoot, 'dist', 'scripts', 'extract-metadata.js'),
   buildDbScriptDist: resolve(repoRoot, 'dist', 'scripts', 'build-database.js'),
-} as const;
+};
 
 /**
  * True when this copy can rebuild an index — the one capability that separates
  * a full installation from a bare `npx d365fo-mcp connect` client.
  */
 export const isFullInstall = isGitCheckout || fs.existsSync(paths.extractScriptDist);
-
-export const isWindows = process.platform === 'win32';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,7 +27,7 @@ import { setupCommand } from './commands/setup.js';
 import { startCommand } from './commands/start.js';
 import { updateCommand } from './commands/update.js';
 import { askSelect, p } from './ui.js';
-import { isGitCheckout } from './context.js';
+import { isFullInstall } from './context.js';
 import { VERSION } from '../version.js';
 import { listInstances } from './instances.js';
 
@@ -106,13 +106,14 @@ instance.command('upgrade')
 async function mainMenu(): Promise<void> {
   p.intro('d365fo-mcp — D365 F&O MCP Server management');
   const hasInstances = listInstances().length > 0;
-  // Outside a checkout only `connect` can actually do anything, so it leads —
-  // everything above it in the full list would just print the installer hint.
+  // Without a full installation only `connect` can actually do anything, so it
+  // leads — everything above it in the full list would just print the
+  // installer hint.
   const connectEntry = { value: 'connect', label: 'Connect', hint: 'use a server someone already deployed' };
   const action = await askSelect('What do you want to do?', [
-    ...(isGitCheckout ? [] : [connectEntry]),
+    ...(isFullInstall ? [] : [connectEntry]),
     { value: 'setup', label: 'Setup', hint: 'first-time setup wizard' },
-    ...(isGitCheckout ? [connectEntry] : []),
+    ...(isFullInstall ? [connectEntry] : []),
     { value: 'config', label: 'Change settings', hint: 'edit one area of the configuration' },
     { value: 'doctor', label: 'Doctor', hint: 'check environment & installation' },
     { value: 'start', label: 'Start server', hint: hasInstances ? 'root or an instance' : 'root server' },

--- a/src/cli/mcpJson.ts
+++ b/src/cli/mcpJson.ts
@@ -5,8 +5,8 @@
  * the same shape — only the config path differs.
  */
 import * as fs from 'node:fs';
-import { resolve } from 'node:path';
-import { repoRoot } from './context.js';
+import { dirname, resolve } from 'node:path';
+import { paths, repoRoot } from './context.js';
 import type { SettingsStore } from './settingsStore.js';
 import { p } from './ui.js';
 
@@ -32,8 +32,11 @@ export function stdioServer(store: SettingsStore, extraEnv?: Record<string, stri
 export function mcpJsonNote(servers: Record<string, unknown>, title = '.mcp.json'): void {
   const json = JSON.stringify({ servers }, null, 2);
   p.note(json, title);
-  // Also write the raw JSON to a file so it can be copied without terminal box characters.
-  const outPath = resolve(repoRoot, 'mcp-config-suggestion.json');
+  // Also write the raw JSON to a file so it can be copied without terminal box
+  // characters. It goes to the data directory, not the package: an npm install
+  // replaces the package on every update, and may not even be writable.
+  const outPath = paths.mcpSuggestion;
+  fs.mkdirSync(dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, json + '\n', 'utf8');
   p.log.info(`Raw JSON written to: ${outPath}`);
 }

--- a/src/cli/npmRegistry.ts
+++ b/src/cli/npmRegistry.ts
@@ -1,0 +1,92 @@
+/**
+ * "Is this copy current?" — a release check against the npm registry.
+ *
+ * An installation that sits on an old release is the most common cause of a
+ * bug report that was already fixed, and nothing in the CLI used to say so:
+ * `d365fo-mcp update` happily reported success after pulling a branch that had
+ * long since been superseded. `doctor`, `setup` and `update` now all ask the
+ * registry what the latest published version is and compare it with VERSION.
+ *
+ * The check is advisory in every caller — D365FO VMs are frequently offline or
+ * behind a proxy, and a failed lookup must never block a setup or an update.
+ * Every failure path therefore returns null rather than throwing, and the
+ * request is time-boxed so an unreachable registry costs seconds, not minutes.
+ */
+import { VERSION } from '../version.js';
+
+export const PACKAGE_NAME = 'd365fo-mcp';
+
+/** Default registry, overridable the same way npm itself allows. */
+function registryBase(): string {
+  const configured = process.env.npm_config_registry?.trim();
+  const base = configured && configured.length > 0 ? configured : 'https://registry.npmjs.org';
+  return base.replace(/\/+$/, '');
+}
+
+/**
+ * The version published under the `latest` dist-tag, or null when the registry
+ * cannot be reached, answers with an error, or returns something unexpected.
+ *
+ * The dist-tags endpoint is used rather than the package document: it answers
+ * with a few dozen bytes instead of several megabytes of release metadata.
+ */
+export async function fetchLatestVersion(timeoutMs = 4000): Promise<string | null> {
+  try {
+    const res = await fetch(`${registryBase()}/-/package/${PACKAGE_NAME}/dist-tags`, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const tags = (await res.json()) as Record<string, unknown>;
+    const latest = tags.latest;
+    return typeof latest === 'string' && latest.length > 0 ? latest : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Numeric part of a semver string, ignoring any prerelease/build suffix. */
+function core(version: string): number[] {
+  return version
+    .replace(/^v/, '')
+    .split(/[-+]/)[0]
+    .split('.')
+    .map(part => Number.parseInt(part, 10))
+    .map(n => (Number.isFinite(n) ? n : 0));
+}
+
+/**
+ * True when `current` is strictly behind `latest`.
+ *
+ * Only the major.minor.patch triple is compared. A prerelease is treated as
+ * its release version, so 1.2.0-rc.1 does not report itself as behind 1.2.0 —
+ * whoever installed a prerelease did it deliberately and does not need to be
+ * nagged onto the release they were testing against.
+ */
+export function isBehind(current: string, latest: string): boolean {
+  const a = core(current);
+  const b = core(latest);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const left = a[i] ?? 0;
+    const right = b[i] ?? 0;
+    if (left !== right) return left < right;
+  }
+  return false;
+}
+
+export interface ReleaseStatus {
+  current: string;
+  /** null when the registry could not be reached. */
+  latest: string | null;
+  behind: boolean;
+}
+
+/** Compare the running version against the registry. Never throws. */
+export async function checkRelease(timeoutMs?: number): Promise<ReleaseStatus> {
+  const latest = await fetchLatestVersion(timeoutMs);
+  return {
+    current: VERSION,
+    latest,
+    behind: latest !== null && isBehind(VERSION, latest),
+  };
+}

--- a/src/cli/target.ts
+++ b/src/cli/target.ts
@@ -4,7 +4,7 @@
  * positional instance name, or asks interactively when instances exist.
  */
 import * as fs from 'node:fs';
-import { paths, repoRoot } from './context.js';
+import { dataRoot, paths } from './context.js';
 import { Instance, listInstances } from './instances.js';
 import { openInstanceStore, openStore, type SettingsStore } from './settingsStore.js';
 import { askSelect } from './ui.js';
@@ -34,7 +34,7 @@ export function rootTarget(): Target {
     name: 'root',
     label: 'root server',
     envFile: fs.existsSync(paths.rootEnv) ? paths.rootEnv : null,
-    store: openStore(repoRoot, paths.rootEnv),
+    store: openStore(dataRoot(), paths.rootEnv),
     port: null,
   };
 }
@@ -67,7 +67,7 @@ export async function pickTarget(instanceName: string | undefined, message: stri
   if (instances.length === 0) return rootTarget();
 
   const choice = await askSelect(message, [
-    { value: 'root', label: 'root server', hint: repoRoot },
+    { value: 'root', label: 'root server', hint: dataRoot() },
     ...instances.map(i => ({ value: i.name, label: i.name, hint: i.port !== null ? `port ${i.port}` : undefined })),
   ]);
   return choice === 'root' ? rootTarget() : instanceTarget(instances.find(i => i.name === choice)!);

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -5,7 +5,7 @@
  */
 import * as p from '@clack/prompts';
 import type { Option } from '@clack/prompts';
-import { installOneLiner, isGitCheckout } from './context.js';
+import { installOneLiner, isFullInstall } from './context.js';
 
 export { p };
 
@@ -37,18 +37,19 @@ export async function askSelect<T extends string>(message: string, options: Opti
 }
 
 /**
- * Guard for commands that only work inside a git checkout (setup, update,
- * index). Running from the npx cache or an unpacked release tarball lacks
- * scripts/, devDependencies and git — point the user at the installer instead
- * of failing halfway through.
+ * Guard for commands that need a full installation (setup, update, index) —
+ * a git checkout, or an npm install carrying the dist/scripts bundles. Running
+ * from the npx cache of an older release has neither, so point the user at the
+ * installer instead of failing halfway through a rebuild.
  */
-export function requireGitCheckout(): boolean {
-  if (isGitCheckout) return true;
-  p.log.error('This copy of d365fo-mcp is not a full installation — no git checkout found.');
+export function requireFullInstall(): boolean {
+  if (isFullInstall) return true;
+  p.log.error('This copy of d365fo-mcp is not a full installation — it can only run `connect`.');
   p.log.info(
     'Install the server with PowerShell:\n' +
     `  ${installOneLiner}\n` +
-    'then run this command again from the install directory (npm run cli -- <command>).',
+    'or update this copy in place:\n' +
+    '  npm install -g d365fo-mcp@latest',
   );
   process.exitCode = 1;
   return false;

--- a/src/utils/loadEnv.ts
+++ b/src/utils/loadEnv.ts
@@ -23,12 +23,47 @@
  */
 
 import dotenv from 'dotenv';
-import { dirname, isAbsolute, resolve } from 'path';
+import { existsSync } from 'fs';
+import { dirname, isAbsolute, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { resolveConfigFiles, toEnvRecord } from '../config/configFile.js';
 
 /** Env vars whose relative paths should resolve from the .env file directory. */
 const PATH_VARS = ['DB_PATH', 'LABELS_DB_PATH', 'METADATA_PATH'] as const;
+
+/**
+ * The installation directory a module should read its configuration from.
+ *
+ * Callers sit at different depths: the server is `dist/index.js` and the index
+ * scripts are `scripts/*.ts` in a checkout, all one level down — but their
+ * bundled counterparts are `dist/scripts/*.js`, two levels down. Assuming one
+ * level, as this used to, made a bundle look for `dist/config/` and silently
+ * fall through to every default: the wrong packages path, and worse, the
+ * default DB_PATH, so a standalone run would write beside the real index
+ * instead of the configured one.
+ *
+ * The search starts one level up, so any caller that resolved correctly before
+ * still matches on the first try and nothing about its behaviour changes. Only
+ * a caller that finds nothing keeps climbing, and only for two more levels —
+ * enough for `dist/scripts`, and short enough that a machine with no
+ * configuration at all cannot wander into an unrelated directory above the
+ * installation.
+ */
+function installRootFrom(callerDir: string): string {
+  let dir = resolve(callerDir, '..');
+  for (let up = 0; up < 3; up++) {
+    const hasConfig = existsSync(join(dir, 'config', 'd365fo-mcp.json'))
+      || existsSync(join(dir, 'd365fo-mcp.json'))
+      || existsSync(join(dir, '.env'));
+    if (hasConfig) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Nothing found: keep the historical answer, so the caller ends up reporting
+  // a missing file at the path it always looked at.
+  return resolve(callerDir, '..');
+}
 
 /**
  * Load environment variables from a .env file.
@@ -42,7 +77,7 @@ export function loadEnv(callerImportMetaUrl: string): void {
 
   const envPath = process.env.ENV_FILE
     ? resolve(process.env.ENV_FILE)
-    : resolve(callerDir, '../.env');
+    : resolve(installRootFrom(callerDir), '.env');
 
   // Everything already present is a real environment variable (shell, .mcp.json
   // env{} block, App Settings) and outranks both files below.

--- a/tests/cli/context.test.ts
+++ b/tests/cli/context.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Where an installation keeps its state.
+ *
+ * Two things are load-bearing here. First, a git checkout must keep behaving
+ * exactly as it did before the npm-install layout existed: config/, data/ and
+ * instances/ in the checkout, no pointer file involved. Every existing
+ * installation is a checkout, so a regression here silently relocates a user's
+ * configuration and their multi-gigabyte index.
+ *
+ * Second, the pointer file is the only thing that survives `npm install -g
+ * d365fo-mcp@latest` — it is what lets the new package find the installation
+ * the old one set up. A corrupt pointer must degrade to "not configured yet",
+ * never to a crash, because `connect` has to keep working without either.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  dataRoot,
+  installMode,
+  isGitCheckout,
+  paths,
+  readInstallPointer,
+  repoRoot,
+  writeInstallPointer,
+} from '../../src/cli/context.js';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(join(os.tmpdir(), 'd365fo-context-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('data root in a checkout', () => {
+  // The suite runs from the checkout, so this is the real thing rather than a
+  // simulation of it.
+  it('is the checkout itself', () => {
+    expect(isGitCheckout).toBe(true);
+    expect(installMode).toBe('git');
+    expect(dataRoot()).toBe(repoRoot);
+  });
+
+  it('keeps config, data and instances on their historical paths', () => {
+    expect(paths.rootConfig).toBe(resolve(repoRoot, 'config', 'd365fo-mcp.json'));
+    expect(paths.rootSecrets).toBe(resolve(repoRoot, 'config', 'secrets.json'));
+    expect(paths.rootEnv).toBe(resolve(repoRoot, '.env'));
+    expect(paths.instancesDir).toBe(resolve(repoRoot, 'instances'));
+    expect(paths.defaultDb).toBe(resolve(repoRoot, 'data', 'xpp-metadata.db'));
+  });
+
+  it('resolves code paths against the package, not the data directory', () => {
+    expect(paths.distEntry).toBe(resolve(repoRoot, 'dist', 'index.js'));
+    expect(paths.bridgeExe).toBe(
+      resolve(repoRoot, 'bridge', 'D365MetadataBridge', 'bin', 'Release', 'D365MetadataBridge.exe'),
+    );
+  });
+});
+
+describe('install pointer', () => {
+  it('round-trips the data directory', () => {
+    const file = join(tmp, 'state', 'install.json');
+    const target = join(tmp, 'installation');
+    writeInstallPointer(file, target);
+    expect(readInstallPointer(file)).toBe(target);
+  });
+
+  it('creates both the data directory and the pointer folder', () => {
+    const file = join(tmp, 'deep', 'state', 'install.json');
+    const target = join(tmp, 'deep', 'installation');
+    writeInstallPointer(file, target);
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it('reports "unset" for a missing, corrupt or empty pointer', () => {
+    expect(readInstallPointer(join(tmp, 'absent.json'))).toBeNull();
+
+    const corrupt = join(tmp, 'corrupt.json');
+    fs.writeFileSync(corrupt, '{ this is not json', 'utf8');
+    expect(readInstallPointer(corrupt)).toBeNull();
+
+    const empty = join(tmp, 'empty.json');
+    fs.writeFileSync(empty, JSON.stringify({ dataRoot: '' }), 'utf8');
+    expect(readInstallPointer(empty)).toBeNull();
+
+    const wrongType = join(tmp, 'wrong.json');
+    fs.writeFileSync(wrongType, JSON.stringify({ dataRoot: 42 }), 'utf8');
+    expect(readInstallPointer(wrongType)).toBeNull();
+  });
+});

--- a/tests/cli/npmRegistry.test.ts
+++ b/tests/cli/npmRegistry.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Release-freshness comparison.
+ *
+ * `isBehind` decides whether the CLI nags the user to update, so both of its
+ * failure modes are user-visible: a false positive tells someone on the latest
+ * release to reinstall, and a false negative leaves a stale VM believing it is
+ * current — the state that produces bug reports for already-fixed defects.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchLatestVersion, isBehind } from '../../src/cli/npmRegistry.js';
+
+describe('isBehind', () => {
+  it('detects a newer release at every level of the triple', () => {
+    expect(isBehind('1.1.0', '2.0.0')).toBe(true);
+    expect(isBehind('1.1.0', '1.2.0')).toBe(true);
+    expect(isBehind('1.1.0', '1.1.1')).toBe(true);
+  });
+
+  it('is false for the same version and for a copy ahead of the registry', () => {
+    expect(isBehind('1.1.0', '1.1.0')).toBe(false);
+    expect(isBehind('1.2.0', '1.1.0')).toBe(false);
+    expect(isBehind('2.0.0', '1.9.9')).toBe(false);
+  });
+
+  it('compares numerically, not lexically', () => {
+    // The bug a string compare would produce: '10' < '9' as text.
+    expect(isBehind('1.10.0', '1.9.0')).toBe(false);
+    expect(isBehind('1.9.0', '1.10.0')).toBe(true);
+  });
+
+  it('treats a prerelease as its release version', () => {
+    // Whoever installed 1.2.0-rc.1 did it deliberately; do not nag them onto
+    // the release they are testing against.
+    expect(isBehind('1.2.0-rc.1', '1.2.0')).toBe(false);
+    expect(isBehind('1.2.0-rc.1', '1.3.0')).toBe(true);
+  });
+
+  it('tolerates a missing patch component and a v prefix', () => {
+    expect(isBehind('1.1', '1.1.0')).toBe(false);
+    expect(isBehind('v1.1.0', 'v1.2.0')).toBe(true);
+  });
+});
+
+describe('fetchLatestVersion', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the latest dist-tag', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ latest: '3.4.5', next: '4.0.0-rc.1' }),
+    }));
+    await expect(fetchLatestVersion()).resolves.toBe('3.4.5');
+  });
+
+  it('honours npm_config_registry so a private mirror is used', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ latest: '1.0.0' }) });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('npm_config_registry', 'https://npm.internal.example/');
+    await fetchLatestVersion();
+    expect(fetchMock.mock.calls[0][0]).toBe('https://npm.internal.example/-/package/d365fo-mcp/dist-tags');
+  });
+
+  // The offline case is the common one on a D365FO VM: it must degrade to
+  // "unknown", never throw into a setup or an update that would otherwise work.
+  it('returns null when the registry is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ENOTFOUND')));
+    await expect(fetchLatestVersion()).resolves.toBeNull();
+  });
+
+  it('returns null on an error response and on a malformed body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    await expect(fetchLatestVersion()).resolves.toBeNull();
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ latest: 42 }) }));
+    await expect(fetchLatestVersion()).resolves.toBeNull();
+  });
+});

--- a/tests/cli/updateBridge.test.ts
+++ b/tests/cli/updateBridge.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Whether `update` offers to rebuild the C# bridge.
+ *
+ * The bridge binary lives inside the package, and `npm install -g
+ * d365fo-mcp@latest` replaces the package directory wholesale — so an npm-mode
+ * update deletes the only write path the server has. The decision therefore
+ * cannot be made from the state after the update alone: the exe is always
+ * missing by then, which reads identically to "this install never built one"
+ * and skips the rebuild. A server that could write before the update would
+ * come back read-only, with nothing said about it.
+ *
+ * Hence two inputs, one sampled on each side of the update.
+ */
+import { describe, it, expect } from 'vitest';
+import { bridgeAction } from '../../src/cli/commands/update.js';
+
+describe('bridgeAction', () => {
+  it('does nothing when this install never had a bridge', () => {
+    // Read-only, hybrid and azure-client setups: no dotnet, nothing to rebuild.
+    expect(bridgeAction(false, false)).toBe('none');
+  });
+
+  it('offers an optional rebuild when the bridge survived the update', () => {
+    // The git-checkout case: `git pull` leaves bin/Release alone, so rebuilding
+    // is a post-D365FO-upgrade nicety rather than a repair.
+    expect(bridgeAction(true, true)).toBe('optional');
+  });
+
+  it('requires a rebuild when the update removed a bridge that was there', () => {
+    // The npm case, and the regression this guards: judged on the after-state
+    // alone this is indistinguishable from 'none'.
+    expect(bridgeAction(true, false)).toBe('required');
+  });
+
+  it('does not invent work when a bridge appears from nowhere', () => {
+    // Not reachable through the update flow, but the answer should still be
+    // "leave it alone" rather than a rebuild prompt for something untouched.
+    expect(bridgeAction(false, true)).toBe('none');
+  });
+});

--- a/tests/packaging/publishedFiles.test.ts
+++ b/tests/packaging/publishedFiles.test.ts
@@ -1,0 +1,75 @@
+/**
+ * What the published tarball must and must not contain.
+ *
+ * `npm i -g d365fo-mcp` is a full installation: the CLI runs the setup wizard,
+ * builds the C# bridge and rebuilds the metadata index from the package
+ * directory, with no checkout and no devDependencies to fall back on. Every
+ * file those steps need therefore has to survive `npm pack` — and `files`
+ * entries override .gitignore, so it is just as easy to publish something that
+ * should never leave the machine.
+ *
+ * The list is computed with `npm pack --dry-run`, which is the same code path
+ * `npm publish` uses, rather than by re-implementing npm's include rules here.
+ */
+import { execSync } from 'node:child_process';
+import * as path from 'node:path';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+let packed: string[];
+
+beforeAll(() => {
+  // --ignore-scripts: prepublishOnly would otherwise run a full build here.
+  // npm is a .cmd shim on Windows, which cannot be spawned without a shell
+  // (EINVAL since the Node 18 hardening) — hence execSync over a constant
+  // command line rather than execFileSync with an args array.
+  const out = execSync('npm pack --dry-run --json --ignore-scripts', {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const report = JSON.parse(out) as [{ files: { path: string }[] }];
+  packed = report[0].files.map(f => f.path.replace(/\\/g, '/'));
+}, 120_000);
+
+describe('published package contents', () => {
+  it('ships the CLI entry point the bin field names', () => {
+    expect(packed).toContain('dist/cli/index.js');
+    expect(packed).toContain('dist/index.js');
+  });
+
+  it('ships the bundled index scripts, so an npm install can build an index', () => {
+    // These are what src/cli/context.ts calls extractScriptDist/buildDbScriptDist;
+    // without them `d365fo-mcp index` has nothing to run outside a checkout.
+    expect(packed).toContain('dist/scripts/extract-metadata.js');
+    expect(packed).toContain('dist/scripts/build-database.js');
+    // Loaded by `new Worker(new URL('./symbolCountsWorker.js', import.meta.url))`
+    // from inside the build-database bundle, so it must sit beside it.
+    expect(packed).toContain('dist/scripts/symbolCountsWorker.js');
+  });
+
+  it('ships the C# bridge sources, so the wizard can build the write path', () => {
+    expect(packed).toContain('bridge/D365MetadataBridge/D365MetadataBridge.csproj');
+    expect(packed).toContain('bridge/D365MetadataBridge/Program.cs');
+  });
+
+  it('leaves build output of the bridge behind', () => {
+    const artefacts = packed.filter(p => /^bridge\/.*\/(bin|obj)\//.test(p));
+    expect(artefacts, 'bridge build output must not be published').toEqual([]);
+  });
+
+  it('never publishes local configuration', () => {
+    // config/d365fo-mcp.json and config/secrets.json are this machine's
+    // settings — git-ignored, and a `files` entry naming config/ would
+    // republish them to every user and overwrite theirs on install.
+    const local = packed.filter(p => p.startsWith('config/'));
+    expect(local, 'local configuration must not be published').toEqual([]);
+  });
+
+  it('leaves developer-only weight out', () => {
+    expect(packed.filter(p => p.endsWith('.map'))).toEqual([]);
+    expect(packed.filter(p => p.startsWith('dist/eval/'))).toEqual([]);
+    expect(packed.filter(p => p.startsWith('data/'))).toEqual([]);
+  });
+});

--- a/tests/utils/loadEnvDepth.test.ts
+++ b/tests/utils/loadEnvDepth.test.ts
@@ -14,7 +14,7 @@
  */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { loadEnv } from '../../src/utils/loadEnv.js';
@@ -22,16 +22,34 @@ import { loadEnv } from '../../src/utils/loadEnv.js';
 let tmp: string;
 let savedEnv: NodeJS.ProcessEnv;
 
+/**
+ * A distinctive packages path that is absolute on this platform.
+ *
+ * It has to be: a relative packagePath is resolved against the config's own
+ * directory, which is correct behaviour but would make the assertions below
+ * measure that resolution rather than which config was found. A literal
+ * `K:\...` is absolute on Windows and relative everywhere else, so hard-coding
+ * one passes locally and fails on the Linux CI runner.
+ */
+function packagesPath(name: string): string {
+  return resolve(tmp, name, 'PackagesLocalDirectory');
+}
+
 /** An installation root holding a config that names a distinctive path. */
 function makeInstall(packagePath: string): string {
   const root = fs.mkdtempSync(join(tmp, 'install-'));
+  writeConfig(root, packagePath);
+  return root;
+}
+
+/** Write config/d365fo-mcp.json under `root`. */
+function writeConfig(root: string, packagePath: string): void {
   fs.mkdirSync(join(root, 'config'), { recursive: true });
   fs.writeFileSync(
     join(root, 'config', 'd365fo-mcp.json'),
     JSON.stringify({ version: 1, environment: { type: 'traditional', packagePath } }),
     'utf8',
   );
-  return root;
 }
 
 /** Call loadEnv as if from a module living at `<root>/<...segments>/mod.js`. */
@@ -58,29 +76,27 @@ afterEach(() => {
 
 describe('loadEnv config discovery', () => {
   it('finds the config from one level down (server at dist/, scripts at scripts/)', () => {
-    const root = makeInstall('K:\\One\\PackagesLocalDirectory');
+    const expected = packagesPath('one');
+    const root = makeInstall(expected);
     loadFrom(root, 'dist');
-    expect(process.env.D365FO_PACKAGE_PATH).toBe('K:\\One\\PackagesLocalDirectory');
+    expect(process.env.D365FO_PACKAGE_PATH).toBe(expected);
   });
 
   it('finds the config from two levels down (bundles at dist/scripts/)', () => {
-    const root = makeInstall('K:\\Two\\PackagesLocalDirectory');
+    const expected = packagesPath('two');
+    const root = makeInstall(expected);
     loadFrom(root, 'dist', 'scripts');
-    expect(process.env.D365FO_PACKAGE_PATH).toBe('K:\\Two\\PackagesLocalDirectory');
+    expect(process.env.D365FO_PACKAGE_PATH).toBe(expected);
   });
 
   it('prefers the nearest installation when one is nested inside another', () => {
     // Guards the upward walk against climbing past the installation it is in.
-    const outer = makeInstall('K:\\Outer\\PackagesLocalDirectory');
+    const outer = makeInstall(packagesPath('outer'));
+    const expected = packagesPath('inner');
     const inner = join(outer, 'inner');
-    fs.mkdirSync(join(inner, 'config'), { recursive: true });
-    fs.writeFileSync(
-      join(inner, 'config', 'd365fo-mcp.json'),
-      JSON.stringify({ version: 1, environment: { type: 'traditional', packagePath: 'K:\\Inner\\PackagesLocalDirectory' } }),
-      'utf8',
-    );
+    writeConfig(inner, expected);
     loadFrom(inner, 'dist');
-    expect(process.env.D365FO_PACKAGE_PATH).toBe('K:\\Inner\\PackagesLocalDirectory');
+    expect(process.env.D365FO_PACKAGE_PATH).toBe(expected);
   });
 
   it('leaves the variable unset when there is no configuration anywhere', () => {
@@ -90,11 +106,12 @@ describe('loadEnv config discovery', () => {
   });
 
   it('still lets an explicit ENV_FILE win over discovery', () => {
-    const root = makeInstall('K:\\Config\\PackagesLocalDirectory');
+    const root = makeInstall(packagesPath('from-config'));
+    const pinned = packagesPath('from-env-file');
     const envFile = join(tmp, 'pinned.env');
-    fs.writeFileSync(envFile, 'D365FO_PACKAGE_PATH=K:\\Pinned\\PackagesLocalDirectory\n', 'utf8');
+    fs.writeFileSync(envFile, `D365FO_PACKAGE_PATH=${pinned}\n`, 'utf8');
     process.env.ENV_FILE = envFile;
     loadFrom(root, 'dist', 'scripts');
-    expect(process.env.D365FO_PACKAGE_PATH).toBe('K:\\Pinned\\PackagesLocalDirectory');
+    expect(process.env.D365FO_PACKAGE_PATH).toBe(pinned);
   });
 });

--- a/tests/utils/loadEnvDepth.test.ts
+++ b/tests/utils/loadEnvDepth.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Configuration discovery from callers at different depths.
+ *
+ * `loadEnv` used to assume every caller sits exactly one level below the
+ * installation root — true for `dist/index.js` and for `scripts/*.ts`, but not
+ * for their esbuild bundles at `dist/scripts/*.js`. A bundle therefore looked
+ * for `dist/config/`, found nothing, and fell through to every built-in
+ * default: the wrong packages path, and the default DB_PATH, so a standalone
+ * run would write beside the real index rather than the configured one.
+ *
+ * Both depths are pinned here because the shallow one is the regression risk:
+ * the search must still match on its first try for callers that already
+ * resolved correctly.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadEnv } from '../../src/utils/loadEnv.js';
+
+let tmp: string;
+let savedEnv: NodeJS.ProcessEnv;
+
+/** An installation root holding a config that names a distinctive path. */
+function makeInstall(packagePath: string): string {
+  const root = fs.mkdtempSync(join(tmp, 'install-'));
+  fs.mkdirSync(join(root, 'config'), { recursive: true });
+  fs.writeFileSync(
+    join(root, 'config', 'd365fo-mcp.json'),
+    JSON.stringify({ version: 1, environment: { type: 'traditional', packagePath } }),
+    'utf8',
+  );
+  return root;
+}
+
+/** Call loadEnv as if from a module living at `<root>/<...segments>/mod.js`. */
+function loadFrom(root: string, ...segments: string[]): void {
+  const dir = join(root, ...segments);
+  fs.mkdirSync(dir, { recursive: true });
+  loadEnv(pathToFileURL(join(dir, 'mod.js')).href);
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(join(os.tmpdir(), 'd365fo-loadenv-'));
+  savedEnv = { ...process.env };
+  // loadEnv treats anything already set as a real environment variable that
+  // outranks the config, which would mask what this test is measuring.
+  delete process.env.D365FO_PACKAGE_PATH;
+  delete process.env.ENV_FILE;
+  delete process.env.D365FO_CONFIG;
+});
+
+afterEach(() => {
+  process.env = savedEnv;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('loadEnv config discovery', () => {
+  it('finds the config from one level down (server at dist/, scripts at scripts/)', () => {
+    const root = makeInstall('K:\\One\\PackagesLocalDirectory');
+    loadFrom(root, 'dist');
+    expect(process.env.D365FO_PACKAGE_PATH).toBe('K:\\One\\PackagesLocalDirectory');
+  });
+
+  it('finds the config from two levels down (bundles at dist/scripts/)', () => {
+    const root = makeInstall('K:\\Two\\PackagesLocalDirectory');
+    loadFrom(root, 'dist', 'scripts');
+    expect(process.env.D365FO_PACKAGE_PATH).toBe('K:\\Two\\PackagesLocalDirectory');
+  });
+
+  it('prefers the nearest installation when one is nested inside another', () => {
+    // Guards the upward walk against climbing past the installation it is in.
+    const outer = makeInstall('K:\\Outer\\PackagesLocalDirectory');
+    const inner = join(outer, 'inner');
+    fs.mkdirSync(join(inner, 'config'), { recursive: true });
+    fs.writeFileSync(
+      join(inner, 'config', 'd365fo-mcp.json'),
+      JSON.stringify({ version: 1, environment: { type: 'traditional', packagePath: 'K:\\Inner\\PackagesLocalDirectory' } }),
+      'utf8',
+    );
+    loadFrom(inner, 'dist');
+    expect(process.env.D365FO_PACKAGE_PATH).toBe('K:\\Inner\\PackagesLocalDirectory');
+  });
+
+  it('leaves the variable unset when there is no configuration anywhere', () => {
+    const bare = fs.mkdtempSync(join(tmp, 'bare-'));
+    loadFrom(bare, 'dist', 'scripts');
+    expect(process.env.D365FO_PACKAGE_PATH).toBeUndefined();
+  });
+
+  it('still lets an explicit ENV_FILE win over discovery', () => {
+    const root = makeInstall('K:\\Config\\PackagesLocalDirectory');
+    const envFile = join(tmp, 'pinned.env');
+    fs.writeFileSync(envFile, 'D365FO_PACKAGE_PATH=K:\\Pinned\\PackagesLocalDirectory\n', 'utf8');
+    process.env.ENV_FILE = envFile;
+    loadFrom(root, 'dist', 'scripts');
+    expect(process.env.D365FO_PACKAGE_PATH).toBe('K:\\Pinned\\PackagesLocalDirectory');
+  });
+});


### PR DESCRIPTION
## Why

`npm i d365fo-mcp` shipped `dist/` only, so the published package was a thin client: it could run `connect` and nothing else. `setup`, `index` and `update` all refused to run outside a git checkout, which is why the README points at `irm …/install.ps1 | iex` rather than at the package npmjs advertises. Getting a working server required cloning the repository.

This makes the package itself a full installation, so the installer can eventually shrink to "bootstrap Node, then `npm i -g d365fo-mcp && d365fo-mcp setup`".

## What changed

**The package carries what a full install needs.** `files` gains the C# bridge sources (so the wizard can build the write path) and the index scripts, bundled with esbuild into `dist/scripts/` — they used to run through `tsx`, a devDependency an npm install does not get. Sourcemaps and `dist/eval/` come out. Tarball is 1.1 MB, 4.5 MB unpacked.

`symbolCountsWorker.js` is bundled alongside them deliberately: `build-database` loads it via `new Worker(new URL('./symbolCountsWorker.js', import.meta.url))`, so it has to sit next to the bundle or the build silently falls back to the synchronous path.

**The CLI knows which layout it is running from.** `installMode` (`'git' | 'npm'`) and `isFullInstall` replace the binary `isGitCheckout` gate. Index scripts run from `scripts/*.ts` through tsx in a checkout and from the bundles otherwise; `update` is `git pull && npm install && npm run build` in a checkout and `npm install -g d365fo-mcp@latest` otherwise.

**Code and state are two roots.** `npm install -g d365fo-mcp@latest` replaces the package directory wholesale, so a config file or a multi-gigabyte index kept inside it would not survive a single update. `repoRoot` keeps holding the code; `dataRoot()` holds configuration, index and instances. An npm install asks for the directory during setup and records it in `%LOCALAPPDATA%\d365fo-mcp\install.json`, outside the package — that pointer is how the next version finds the same installation. `D365FO_MCP_HOME` overrides it for CI and for testing an install without touching your own.

Asking rather than defaulting also puts the choice of *drive* in the user's hands, which is the point on a D365FO VM: `%LOCALAPPDATA%` is on C:, routinely the smallest disk there, and a full index does not fit.

**Release freshness check.** `src/cli/npmRegistry.ts` compares the running version against the registry's `latest` dist-tag. `doctor` reports it, `setup` warns *before* the index build (the longest step there is, and not worth doing twice), `update` says what it is moving towards and offers to skip a no-op reinstall. Time-boxed, and returns null on any failure — D365FO VMs are frequently offline and an unreachable registry must never block a setup.

## For the reviewer

**Nothing changes for a git checkout.** `dataRoot()` resolves to `repoRoot` there and never consults the pointer file, so every existing installation keeps exactly the paths it has today. `tests/cli/context.test.ts` pins that: the suite runs from a checkout, so those assertions are the real thing rather than a simulation.

**A near-miss worth knowing about.** `files` entries override `.gitignore`, so an entry naming `config/` made `npm pack` include this machine's local `config/d365fo-mcp.json`. Caught before publishing and now gated by `tests/packaging/publishedFiles.test.ts`, which asserts tarball contents through `npm pack --dry-run` — the same code path `publish` uses — rather than re-implementing npm's include rules.

`paths` became getters because `setDataRoot` runs in the middle of the wizard and the entries below it must reflect the directory the user just chose, not the one current at import time.

## Testing

- 1862 tests pass; new coverage for version comparison, the install pointer, and published file contents.
- Verified end to end: packed the tarball, installed it into a scratch project, ran `doctor` against a data directory outside the package. It reports npm mode, the right data directory, skips the package-local `node_modules` check that means nothing for a global install, and prints commands that exist in that layout (`d365fo-mcp setup`, not `npm run setup`; an absolute path to the bridge).

## Follow-ups, not in this PR

- **`npm 12` `allowScripts` under a global install.** Installing the tarball warned that `better-sqlite3`'s install script is not covered — with no root `package.json` to pre-approve it, `npm i -g` may leave the native binding unbuilt, which surfaces much later as a runtime error when the index is opened. Worth confirming on a clean VM before the installer switches to the npm path.
- **`install.ps1`** shrinks to Node bootstrap + `npm i -g` + `setup`, as a separate PR once the above is verified on a VM.
- **Prebuilt bridge binary** (and/or the .NET Framework 4.8 Dev Pack in the bootstrap) — without it a fresh install silently runs read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)