### PR TITLE
feat(bridge): build the C# bridge outside the npm package

### DIFF
--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -15,7 +15,7 @@ Same prerequisites and build steps as the Copilot guide — no VS 2022 required.
 | Node.js 24.x LTS | [nodejs.org](https://nodejs.org) |
 | Claude Code CLI | `npm install -g @anthropic-ai/claude-code` |
 | Python 3.x | Needed by `node-gyp` for native SQLite |
-| .NET Framework 4.8 Developer Pack | Required for the C# bridge (file create/modify on D365FO VMs) |
+| .NET SDK | Required for the C# bridge (file create/modify on D365FO VMs) |
 
 ```powershell
 git clone https://github.com/dynamics365ninja/d365fo-mcp-server.git K:\d365fo-mcp-server

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -121,6 +121,7 @@ The metadata-provider child process — the only write path to the AOT.
 | `bridge.maxRetries` | advanced | `BRIDGE_MAX_RETRIES` | `2` | Read calls are retried after a health-checked restart of the child process. Writes are never retried — a timed-out write may already have been applied. 0 disables retries. |
 | `bridge.healthcheckMs` | advanced | `BRIDGE_HEALTHCHECK_MS` | `0` | Proactively detects a wedged bridge while idle. 0 disables the ping. |
 | `bridge.maxRestarts` | advanced | `BRIDGE_MAX_RESTARTS` | `3` | Circuit breaker: after this many respawns within 60 s the server stops trying. |
+| `bridge.exePath` | advanced | `D365FO_BRIDGE_EXE_PATH` | — | Absolute path to D365MetadataBridge.exe. Leave empty to auto-detect inside the installation — the setup wizard fills this in for an npm install, where the binary is built outside the package so that updating the package does not delete it. |
 | `bridge.logFile` | advanced | `D365FO_BRIDGE_LOG_FILE` | — | Absolute path the C# bridge appends its own diagnostics to. |
 | `bridge.fsScanTimeoutMs` | advanced | `D365FO_FS_SCAN_TIMEOUT_MS` | `3000` | Budget for the filesystem scan used when the bridge cannot answer an extension lookup (minimum 500). |
 | `bridge.disableFsFallback` | advanced | `D365FO_DISABLE_FS_FALLBACK` | `false` | Makes extension lookups bridge-only. Turn on to diagnose stale-index issues — results get stricter, not faster. |
@@ -204,6 +205,7 @@ Downloading a pre-built index from blob storage instead of building it locally.
     "maxRetries": 2,
     "healthcheckMs": 0,
     "maxRestarts": 3,
+    "exePath": "",
     "logFile": "",
     "fsScanTimeoutMs": 3000,
     "disableFsFallback": false

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -81,7 +81,7 @@ claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https:/
 |------------|----------------|------------|
 | Visual Studio 2022 ≥ 17.14 (or 2026) | Visual Studio Installer | all scenarios |
 | GitHub Copilot extension | VS → Extensions | Copilot users |
-| .NET Framework 4.8 Dev Pack | pre-installed on D365FO VMs | C# bridge (writes) |
+| .NET SDK | pre-installed on D365FO VMs, else [dotnet.microsoft.com](https://dotnet.microsoft.com/download) | C# bridge (writes) |
 | Node.js 24.x LTS | [nodejs.org](https://nodejs.org), or `Install-D365SupportingSoftware -Name node.js` | installed for you by the one-liner |
 | Git | [git-scm.com](https://git-scm.com) | installed for you by the one-liner |
 | Python 3.x | option in the Node.js installer | only if npm cannot fetch a prebuilt `better-sqlite3` binary and has to compile it |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -42,7 +42,7 @@ flowchart TD
 | Visual Studio 2022 / 2026 | ≥ 17.14 / any | MCP support |
 | GitHub Copilot extension | latest | agent mode |
 | Node.js + Python | 24.x LTS / 3.x | local & hybrid (native SQLite build) |
-| .NET Framework 4.8 Dev Pack | 4.8 | C# bridge — **all writes** (pre-installed on D365FO VMs) |
+| .NET SDK | any current | C# bridge — **all writes** (pre-installed on D365FO VMs) |
 | Git | any | local & hybrid |
 
 ## Enable MCP (one-time)

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -845,12 +845,27 @@ export class BridgeClient extends EventEmitter {
 
   // Private helpers
 
+  /**
+   * Locate the bridge binary.
+   *
+   * An explicit path wins and is not second-guessed: it is how an npm install
+   * finds a binary built outside the package (updating the package deletes
+   * anything inside it, and the bridge has to be built per environment — see
+   * the metamodel version check in Program.cs), and how one machine can point
+   * several configurations at different builds.
+   *
+   * Everything else falls back to the in-installation search, unchanged.
+   */
   private resolveBridgeExe(): string {
-    if (this.options.bridgeExePath) {
-      if (!fs.existsSync(this.options.bridgeExePath)) {
-        throw new Error(`Bridge exe not found at: ${this.options.bridgeExePath}`);
+    const configured = this.options.bridgeExePath?.trim() || process.env.D365FO_BRIDGE_EXE_PATH?.trim();
+    if (configured) {
+      if (!fs.existsSync(configured)) {
+        throw new Error(
+          `Bridge exe not found at the configured path: ${configured}\n` +
+          '  Set bridge.exePath (D365FO_BRIDGE_EXE_PATH) to the built binary, or clear it to auto-detect.'
+        );
       }
-      return this.options.bridgeExePath;
+      return configured;
     }
 
     const __filename = fileURLToPath(import.meta.url);

--- a/src/cli/bridgePath.ts
+++ b/src/cli/bridgePath.ts
@@ -1,0 +1,25 @@
+/**
+ * Pinning the bridge binary's location into a configuration.
+ *
+ * The server finds the bridge by searching inside its own installation. That
+ * works for a checkout, where the binary is built into the project. An npm
+ * install builds it into the data directory instead — the package is replaced
+ * on every update, so anything inside it is temporary — and nothing in the
+ * package-relative search would ever look there. The wizard therefore records
+ * the path, for the root config and for each instance.
+ *
+ * Written only when the binary actually exists: an empty setting means "search
+ * for it", which is the right answer for a read-only install and for a
+ * checkout, and a stale absolute path would turn a missing bridge into a hard
+ * error instead of a fallback.
+ */
+import * as fs from 'node:fs';
+import { installMode, paths } from './context.js';
+import { settingByPath } from '../config/settings.js';
+import { writeSetting, type SettingsStore } from './settingsStore.js';
+
+export function pinBridgeExe(store: SettingsStore): void {
+  if (installMode === 'git') return;
+  if (!fs.existsSync(paths.bridgeExe)) return;
+  writeSetting(store, settingByPath('bridge.exePath')!, paths.bridgeExe);
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -10,6 +10,7 @@ import { relative, resolve } from 'node:path';
 import { p } from '../ui.js';
 import { settingByPath } from '../../config/settings.js';
 import { bridgeBuildCommand, dataRoot, installMode, isWindows, paths, repoRoot } from '../context.js';
+import { commandExists } from '../exec.js';
 import { listInstances } from '../instances.js';
 import { checkRelease } from '../npmRegistry.js';
 import { conflictingLegacyValues, readPath, readSetting, type SettingsStore } from '../settingsStore.js';
@@ -205,11 +206,18 @@ export async function doctorCommand(): Promise<void> {
 
   // C# bridge: the only write path; Windows-only.
   if (isWindows) {
-    emit(fs.existsSync(paths.bridgeExe)
-      ? { severity: 'ok', message: 'C# bridge built (D365MetadataBridge.exe)' }
+    if (fs.existsSync(paths.bridgeExe)) {
+      emit({ severity: 'ok', message: `C# bridge built (${paths.bridgeExe})` });
+    } else if (await commandExists('dotnet')) {
       // Absolute path: outside a checkout the user is nowhere near the bridge,
       // and a relative `cd bridge\...` would just fail.
-      : { severity: 'warn', message: 'C# bridge not built — server runs read-only', fix: bridgeBuildCommand() });
+      emit({ severity: 'warn', message: 'C# bridge not built — server runs read-only', fix: bridgeBuildCommand() });
+    } else {
+      // Naming the real prerequisite beats printing a build command that
+      // cannot run. Only checked when the bridge is missing — a built bridge
+      // needs no SDK, and asking would be noise on every healthy install.
+      emit({ severity: 'warn', message: 'C# bridge not built and no .NET SDK to build it — server runs read-only', fix: 'install the .NET SDK from https://dotnet.microsoft.com/download, then: d365fo-mcp setup' });
+    }
     const dir = xppConfigDir();
     const configs = listXppConfigs();
     if (dir && fs.existsSync(dir)) {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -9,7 +9,7 @@ import * as fs from 'node:fs';
 import { relative, resolve } from 'node:path';
 import { p } from '../ui.js';
 import { settingByPath } from '../../config/settings.js';
-import { dataRoot, installMode, isWindows, paths, repoRoot } from '../context.js';
+import { bridgeBuildCommand, dataRoot, installMode, isWindows, paths, repoRoot } from '../context.js';
 import { listInstances } from '../instances.js';
 import { checkRelease } from '../npmRegistry.js';
 import { conflictingLegacyValues, readPath, readSetting, type SettingsStore } from '../settingsStore.js';
@@ -209,7 +209,7 @@ export async function doctorCommand(): Promise<void> {
       ? { severity: 'ok', message: 'C# bridge built (D365MetadataBridge.exe)' }
       // Absolute path: outside a checkout the user is nowhere near the bridge,
       // and a relative `cd bridge\...` would just fail.
-      : { severity: 'warn', message: 'C# bridge not built — server runs read-only', fix: `cd "${paths.bridgeDir}" && dotnet build -c Release` });
+      : { severity: 'warn', message: 'C# bridge not built — server runs read-only', fix: bridgeBuildCommand() });
     const dir = xppConfigDir();
     const configs = listXppConfigs();
     if (dir && fs.existsSync(dir)) {

--- a/src/cli/commands/instance.ts
+++ b/src/cli/commands/instance.ts
@@ -7,6 +7,7 @@
 import * as fs from 'node:fs';
 import { resolve } from 'node:path';
 import { settingByPath, settingsInSection } from '../../config/settings.js';
+import { pinBridgeExe } from '../bridgePath.js';
 import { createInstance, getInstance, listInstances, suggestPort } from '../instances.js';
 import { mcpJsonNote, placementNote, stdioServer } from '../mcpJson.js';
 import { selectXppConfig } from './config.js';
@@ -87,6 +88,9 @@ export async function instanceAddCommand(name: string | undefined, portArg: stri
 
   // Same questions as the root wizard, scoped to this instance's config file.
   const store = openInstanceStore(inst.dir);
+  // Instances share the one bridge binary this machine built, and need to be
+  // told where it is for the same reason the root config does.
+  pinBridgeExe(store);
   p.log.step('D365FO environment — where this instance reads its X++ packages');
   const envType = String(await askSetting(store, envTypeSetting, {
     initial: listXppConfigs().length > 0 ? 'ude' : 'traditional',

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -11,10 +11,10 @@
  */
 import * as fs from 'node:fs';
 import { relative, resolve } from 'node:path';
-import { dataRoot, installMode, isWindows, paths, repoRoot, setDataRoot } from '../context.js';
+import { DOTNET_MISSING, dataRoot, installMode, isWindows, paths, repoRoot, setDataRoot } from '../context.js';
 import type { SectionId } from '../../config/settings.js';
 import { settingByPath, settingsInSection } from '../../config/settings.js';
-import { runExe, runShell } from '../exec.js';
+import { commandExists, runExe, runShell } from '../exec.js';
 import { pinBridgeExe } from '../bridgePath.js';
 import { mcpJsonNote, placementNote, stdioServer } from '../mcpJson.js';
 import { checkRelease } from '../npmRegistry.js';
@@ -111,6 +111,11 @@ async function maybeBuildBridge(scenario: Scenario): Promise<boolean> {
     p.log.warn('Skipped — the server will run read-only until you build it.');
     return true;
   }
+  if (!await commandExists('dotnet')) {
+    p.log.warn(DOTNET_MISSING);
+    return true; // read-only is a working state; refusing the whole wizard is not
+  }
+
   const args = ['build', '-c', 'Release'];
   // An npm install builds outside the package so the binary survives an
   // update; a checkout keeps MSBuild's default so nothing about it changes.
@@ -124,7 +129,15 @@ async function maybeBuildBridge(scenario: Scenario): Promise<boolean> {
   }
   p.log.step('Building C# bridge (dotnet build -c Release)…');
   if (await runExe('dotnet', args, { cwd: paths.bridgeDir }) !== 0) {
-    p.log.error('Bridge build failed — check .NET Framework 4.8 Dev Pack and the NuGet feed (docs/SETUP.md).');
+    // Not the .NET Framework 4.8 Dev Pack: the project references
+    // Microsoft.NETFramework.ReferenceAssemblies.net48, which supplies the
+    // reference assemblies from NuGet precisely so the targeting pack does not
+    // have to be installed. What a build needs is the SDK (checked above),
+    // a reachable NuGet feed, and the D365FO assemblies it compiles against.
+    p.log.error(
+      'Bridge build failed. Usual causes: no route to nuget.org for the restore, ' +
+      'or no D365FO bin directory to compile against (docs/SETUP.md).',
+    );
     return false;
   }
   p.log.success('C# bridge built.');

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -15,6 +15,7 @@ import { dataRoot, installMode, isWindows, paths, repoRoot, setDataRoot } from '
 import type { SectionId } from '../../config/settings.js';
 import { settingByPath, settingsInSection } from '../../config/settings.js';
 import { runExe, runShell } from '../exec.js';
+import { pinBridgeExe } from '../bridgePath.js';
 import { mcpJsonNote, placementNote, stdioServer } from '../mcpJson.js';
 import { checkRelease } from '../npmRegistry.js';
 import { askAdvanced, askSecrets, askSetting, askSettings } from '../settingsPrompt.js';
@@ -111,6 +112,9 @@ async function maybeBuildBridge(scenario: Scenario): Promise<boolean> {
     return true;
   }
   const args = ['build', '-c', 'Release'];
+  // An npm install builds outside the package so the binary survives an
+  // update; a checkout keeps MSBuild's default so nothing about it changes.
+  if (paths.bridgeOutDir) args.push('-o', paths.bridgeOutDir);
   if (scenario === 'ude') {
     const binPath = await askText({
       message: 'UDE: path to the FrameworkDirectory\\bin folder (Enter to let MSBuild auto-detect)',
@@ -261,6 +265,9 @@ export async function setupCommand(): Promise<void> {
   }
 
   const store = openRootStore();
+  // Before either branch saves: the server cannot find a bridge built outside
+  // the package unless the config says where it is.
+  pinBridgeExe(store);
 
   if (scenario === 'hybrid') {
     // The Azure half is configured through App Service settings; this wizard

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -7,8 +7,8 @@
  * build); an npm install reinstalls itself from the registry.
  */
 import * as fs from 'node:fs';
-import { bridgeBuildCommand, installMode, isWindows, paths } from '../context.js';
-import { runExe, runShell } from '../exec.js';
+import { DOTNET_MISSING, bridgeBuildCommand, installMode, isWindows, paths } from '../context.js';
+import { commandExists, runExe, runShell } from '../exec.js';
 import { listInstances } from '../instances.js';
 import { checkRelease } from '../npmRegistry.js';
 import { instanceTarget, rootTarget } from '../target.js';
@@ -87,7 +87,9 @@ export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
         ? 'Rebuild the C# bridge now? (required to restore writes)'
         : 'Rebuild the C# bridge (recommended after a D365FO version upgrade)?',
     );
-    if (rebuild) {
+    if (rebuild && !await commandExists('dotnet')) {
+      p.log.warn(DOTNET_MISSING);
+    } else if (rebuild) {
       // Same output directory the wizard used, or the rebuild would land in
       // the package and the configured bridge.exePath would still point at
       // the old binary outside it.

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -7,7 +7,7 @@
  * build); an npm install reinstalls itself from the registry.
  */
 import * as fs from 'node:fs';
-import { installMode, isWindows, paths } from '../context.js';
+import { bridgeBuildCommand, installMode, isWindows, paths } from '../context.js';
 import { runExe, runShell } from '../exec.js';
 import { listInstances } from '../instances.js';
 import { checkRelease } from '../npmRegistry.js';
@@ -19,10 +19,9 @@ import { rebuildIndex } from './indexCmd.js';
  * What to do about the C# bridge after the code has been refreshed.
  *
  * Both inputs are needed, and *when* they are sampled is the whole point.
- * `hadBridge` is taken before the update, because `npm install -g` replaces
- * the package directory and takes the bridge binary with it; asking only
- * afterwards would read every npm-mode update as "this install never needed
- * writes" and silently drop the write path.
+ * `hadBridge` is taken before the update: judged on the after-state alone, a
+ * bridge the update destroyed is indistinguishable from one that was never
+ * built, and the difference is whether the server just lost its write path.
  *
  *   none     — there was no bridge, so this install does not use writes
  *   optional — the bridge survived; rebuilding is a post-upgrade nicety
@@ -56,11 +55,11 @@ export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
     }
   }
 
-  // Sampled before the update, not after: the bridge binary lives inside the
-  // package, and `npm install -g` replaces the package wholesale. Asking
-  // afterwards would always find it missing, skip the rebuild as "this install
-  // never needed writes", and leave a server that had the write path silently
-  // read-only until someone noticed.
+  // Sampled before the update rather than after. The bridge is built outside
+  // the package now, so an update should leave it alone — but this is what
+  // proves it did: if the binary was there before and is gone after, the
+  // update destroyed the write path, and saying so beats reading the absence
+  // as "this install never needed writes" and silently moving on.
   const hadBridge = isWindows && fs.existsSync(paths.bridgeExe);
 
   const steps: [string, () => Promise<number>][] = installMode === 'npm'
@@ -89,7 +88,11 @@ export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
         : 'Rebuild the C# bridge (recommended after a D365FO version upgrade)?',
     );
     if (rebuild) {
-      if (await runExe('dotnet', ['build', '-c', 'Release'], { cwd: paths.bridgeDir }) !== 0) {
+      // Same output directory the wizard used, or the rebuild would land in
+      // the package and the configured bridge.exePath would still point at
+      // the old binary outside it.
+      const buildArgs = ['build', '-c', 'Release', ...(paths.bridgeOutDir ? ['-o', paths.bridgeOutDir] : [])];
+      if (await runExe('dotnet', buildArgs, { cwd: paths.bridgeDir }) !== 0) {
         p.log.error(gone
           ? 'Bridge build failed — the server stays read-only until it succeeds.'
           : 'Bridge build failed — writes may use the previous bridge binary.');
@@ -100,7 +103,7 @@ export async function updateCommand(opts: { yes?: boolean }): Promise<void> {
     } else if (gone) {
       // Declining is allowed, but it must not be quiet: the capability was
       // there before this command ran and is not there now.
-      p.log.warn(`Skipped — the server runs read-only. Rebuild later with:\n   cd "${paths.bridgeDir}" && dotnet build -c Release`);
+      p.log.warn(`Skipped — the server runs read-only. Rebuild later with:\n   ${bridgeBuildCommand()}`);
     }
   }
 

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -150,16 +150,50 @@ export const paths = {
   /** Where the wizard drops the ready-to-paste .mcp.json block. */
   get mcpSuggestion(): string { return resolve(currentDataRoot, 'mcp-config-suggestion.json'); },
 
+  /**
+   * Where `dotnet build` puts the bridge.
+   *
+   * A checkout keeps MSBuild's own default inside the project, exactly as
+   * before. An npm install cannot: the project lives in the package, and
+   * `npm install -g` replaces the package — so the build output would be
+   * deleted by the very next update, taking the server's only write path with
+   * it. It goes to the data directory instead, which updates never touch.
+   *
+   * Prebuilding the binary and shipping it in the package is not an option
+   * either: every D365FO platform build stamps assembly version 7.0.0.0 and
+   * differs only in FileVersion, so a bridge built elsewhere loads the local
+   * metamodel without complaint and then fails at JIT time (issue #703, and
+   * the version check in Program.cs). It has to be built per environment.
+   */
+  get bridgeOutDir(): string | null {
+    return installMode === 'git' ? null : resolve(currentDataRoot, 'bridge');
+  },
+
   // Code — always in the package, never in the data directory.
   distEntry: resolve(repoRoot, 'dist', 'index.js'),
   bridgeDir: resolve(repoRoot, 'bridge', 'D365MetadataBridge'),
-  bridgeExe: resolve(repoRoot, 'bridge', 'D365MetadataBridge', 'bin', 'Release', 'D365MetadataBridge.exe'),
+  get bridgeExe(): string {
+    return installMode === 'git'
+      ? resolve(repoRoot, 'bridge', 'D365MetadataBridge', 'bin', 'Release', 'D365MetadataBridge.exe')
+      : resolve(currentDataRoot, 'bridge', 'D365MetadataBridge.exe');
+  },
   extractScript: resolve(repoRoot, 'scripts', 'extract-metadata.ts'),
   buildDbScript: resolve(repoRoot, 'scripts', 'build-database.ts'),
   /** esbuild bundles of the two scripts above — what an npm install ships instead of the sources. */
   extractScriptDist: resolve(repoRoot, 'dist', 'scripts', 'extract-metadata.js'),
   buildDbScriptDist: resolve(repoRoot, 'dist', 'scripts', 'build-database.js'),
 };
+
+/**
+ * The exact command that builds the bridge for this installation, for every
+ * message that tells a user to run it by hand. An npm install needs the `-o`
+ * that puts the output outside the package; printing the bare command would
+ * put the binary somewhere the next update deletes.
+ */
+export function bridgeBuildCommand(): string {
+  const out = paths.bridgeOutDir ? ` -o "${paths.bridgeOutDir}"` : '';
+  return `cd "${paths.bridgeDir}" && dotnet build -c Release${out}`;
+}
 
 /**
  * True when this copy can rebuild an index — the one capability that separates

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -190,6 +190,21 @@ export const paths = {
  * that puts the output outside the package; printing the bare command would
  * put the binary somewhere the next update deletes.
  */
+/**
+ * What to say when the bridge cannot be built because the .NET SDK is absent.
+ *
+ * Deliberately does not mention the .NET Framework 4.8 Developer Pack, which
+ * earlier messages here blamed: the project references
+ * Microsoft.NETFramework.ReferenceAssemblies.net48, which supplies those
+ * reference assemblies from NuGet exactly so the targeting pack need not be
+ * installed. Sending people to install a 100 MB pack they do not need, while
+ * the actual missing prerequisite goes unnamed, is worse than saying nothing.
+ */
+export const DOTNET_MISSING =
+  'The .NET SDK is not on PATH, so the C# bridge cannot be built — the server will run read-only.\n' +
+  '   Install it from https://dotnet.microsoft.com/download (the SDK, not just the runtime),\n' +
+  '   then run `d365fo-mcp setup` again. Reads and search work without it.';
+
 export function bridgeBuildCommand(): string {
   const out = paths.bridgeOutDir ? ` -o "${paths.bridgeOutDir}"` : '';
   return `cd "${paths.bridgeDir}" && dotnet build -c Release${out}`;

--- a/src/cli/exec.ts
+++ b/src/cli/exec.ts
@@ -47,6 +47,24 @@ export function runExe(cmd: string, args: string[], opts: RunOptions = {}): Prom
   return spawnAndWait(cmd, args, opts, false);
 }
 
+/**
+ * Whether an executable is on PATH.
+ *
+ * Used to check a prerequisite before spawning it: `runExe` on a missing
+ * binary rejects with a bare `spawn <name> ENOENT`, which tells a user
+ * nothing about what to install. Runs the command rather than probing PATH by
+ * hand so it agrees with what the spawn will actually find.
+ */
+export function commandExists(cmd: string, versionArg = '--version'): Promise<boolean> {
+  return new Promise(resolvePromise => {
+    const child = spawn(cmd, [versionArg], { stdio: 'ignore', shell: false });
+    child.on('error', () => resolvePromise(false));
+    // A non-zero exit still proves the binary is there and runnable; only
+    // failure to spawn at all means it is missing.
+    child.on('close', () => resolvePromise(true));
+  });
+}
+
 /** Throwing variant — use for steps where a failure must abort the flow. */
 export async function mustSucceed(promise: Promise<number>, what: string): Promise<void> {
   const code = await promise;

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -565,6 +565,18 @@ export const SETTINGS: Setting[] = [
     default: 3,
   },
   {
+    path: 'bridge.exePath',
+    env: 'D365FO_BRIDGE_EXE_PATH',
+    section: 'bridge',
+    tier: 'advanced',
+    type: 'path',
+    label: 'Bridge executable',
+    description:
+      'Absolute path to D365MetadataBridge.exe. Leave empty to auto-detect inside the installation — ' +
+      'the setup wizard fills this in for an npm install, where the binary is built outside the package ' +
+      'so that updating the package does not delete it.',
+  },
+  {
     path: 'bridge.logFile',
     env: 'D365FO_BRIDGE_LOG_FILE',
     section: 'bridge',

--- a/tests/bridge/bridgeExeResolution.test.ts
+++ b/tests/bridge/bridgeExeResolution.test.ts
@@ -1,0 +1,80 @@
+/**
+ * How the server locates the bridge binary.
+ *
+ * An npm install builds the bridge outside the package — an update replaces
+ * the package, and anything inside it with it — so nothing in the
+ * package-relative search would ever find it. The configured path is what
+ * closes that gap, which makes two properties matter: it has to be honoured,
+ * and a wrong one has to say so rather than fall back to a binary built for a
+ * different environment. (Bridges are per-environment: every D365FO platform
+ * build stamps assembly version 7.0.0.0, so a mismatched one loads fine and
+ * dies later at JIT time — issue #703.)
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { BridgeClient } from '../../src/bridge/bridgeClient.js';
+
+let tmp: string;
+
+/** Reach the private resolver without spawning anything. */
+function resolveExe(client: BridgeClient): string {
+  return (client as unknown as { resolveBridgeExe(): string }).resolveBridgeExe();
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(join(os.tmpdir(), 'd365fo-bridge-'));
+  delete process.env.D365FO_BRIDGE_EXE_PATH;
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+  delete process.env.D365FO_BRIDGE_EXE_PATH;
+});
+
+describe('bridge exe resolution', () => {
+  it('uses an explicitly configured path', () => {
+    const exe = join(tmp, 'D365MetadataBridge.exe');
+    fs.writeFileSync(exe, '');
+    const client = new BridgeClient({ packagesPath: tmp, bridgeExePath: exe });
+    expect(resolveExe(client)).toBe(exe);
+  });
+
+  it('reads the path from the environment when no option is passed', () => {
+    // This is the live route: the wizard writes bridge.exePath into the
+    // config, and loadEnv projects it onto D365FO_BRIDGE_EXE_PATH.
+    const exe = join(tmp, 'D365MetadataBridge.exe');
+    fs.writeFileSync(exe, '');
+    process.env.D365FO_BRIDGE_EXE_PATH = exe;
+    const client = new BridgeClient({ packagesPath: tmp });
+    expect(resolveExe(client)).toBe(exe);
+  });
+
+  it('fails loudly when the configured path is wrong', () => {
+    // Never silently fall through to the in-package search: that binary was
+    // built for whatever environment happened to build it.
+    const missing = join(tmp, 'nope', 'D365MetadataBridge.exe');
+    const client = new BridgeClient({ packagesPath: tmp, bridgeExePath: missing });
+    expect(() => resolveExe(client)).toThrow(/configured path/i);
+  });
+
+  it('ignores an empty setting and falls back to the search', () => {
+    // An unset `path` setting serialises as '', which must mean "auto-detect"
+    // rather than "look for a file called ''".
+    process.env.D365FO_BRIDGE_EXE_PATH = '   ';
+    const client = new BridgeClient({ packagesPath: tmp, bridgeExePath: '' });
+
+    // Whether the search then succeeds depends on the machine — a developer
+    // VM has the bridge built in-tree, a Linux CI runner never does — so
+    // assert on the branch taken rather than the outcome: a blank value must
+    // reach the search, not be reported as a configured path that is missing.
+    let error: unknown;
+    try {
+      expect(resolveExe(client)).toMatch(/D365MetadataBridge\.exe$/);
+    } catch (err) {
+      error = err;
+    }
+    if (error) expect(String(error)).toMatch(/Bridge executable not found/);
+  });
+});

--- a/tests/cli/commandExists.test.ts
+++ b/tests/cli/commandExists.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Prerequisite probing.
+ *
+ * `commandExists` gates the bridge build. Both mistakes it could make are
+ * user-visible and unhelpful: a false negative tells someone with a working
+ * .NET SDK to go install one, and a false positive lets the wizard spawn a
+ * binary that is not there, producing `spawn dotnet ENOENT` — which names
+ * nothing a user can act on.
+ *
+ * Deliberately probes `node` rather than `dotnet`: this suite runs on Linux CI
+ * where no .NET SDK exists, and the property under test is the probe, not the
+ * machine.
+ */
+import { describe, it, expect } from 'vitest';
+import { commandExists } from '../../src/cli/exec.js';
+
+describe('commandExists', () => {
+  it('finds an executable that is on PATH', async () => {
+    await expect(commandExists('node')).resolves.toBe(true);
+  });
+
+  it('reports a missing executable rather than throwing', async () => {
+    // The spawn fails with ENOENT; surfacing that as an exception would abort
+    // a wizard that only wanted to know whether to offer the build.
+    await expect(commandExists('d365fo-definitely-not-installed')).resolves.toBe(false);
+  });
+
+  it('counts a non-zero exit as present', async () => {
+    // Presence is the question, not health: an SDK that errors on a bad flag
+    // is still an SDK, and reporting it missing would send the user to
+    // reinstall something they already have.
+    await expect(commandExists('node', '--not-a-real-flag')).resolves.toBe(true);
+  });
+});

--- a/tests/cli/context.test.ts
+++ b/tests/cli/context.test.ts
@@ -17,6 +17,7 @@ import * as os from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
+  bridgeBuildCommand,
   dataRoot,
   installMode,
   isGitCheckout,
@@ -58,6 +59,15 @@ describe('data root in a checkout', () => {
     expect(paths.bridgeExe).toBe(
       resolve(repoRoot, 'bridge', 'D365MetadataBridge', 'bin', 'Release', 'D365MetadataBridge.exe'),
     );
+  });
+
+  it('leaves the bridge build where MSBuild puts it', () => {
+    // An npm install redirects the build out of the package with `-o`, because
+    // an update would delete it there. A checkout must not be redirected: its
+    // binary is already outside the blast radius of `git pull`, and moving it
+    // would strand every bridge built by an earlier version.
+    expect(paths.bridgeOutDir).toBeNull();
+    expect(bridgeBuildCommand()).toBe(`cd "${paths.bridgeDir}" && dotnet build -c Release`);
   });
 });
 


### PR DESCRIPTION
Follow-up to #723. Two related things: the bridge stops being built somewhere an update deletes, and the prerequisite for building it is finally named correctly.

## 1. The bridge is built outside the package

In an npm install the C# bridge was built into the package directory, and `npm install -g d365fo-mcp@latest` replaces that directory wholesale — so every update deleted the server's only write path. #723 softened the symptom into a prompt (`bridgeAction`); this removes the cause.

The obvious alternative — ship a prebuilt binary in the package — was investigated and **rejected**, for two independent reasons:

1. **It would be wrong more often than right.** Every D365FO platform build stamps assembly version `7.0.0.0` and differs only in `FileVersion`, so neither the CLR binder nor the `AssemblyResolve` → `LoadFrom` path can tell two metamodels apart. A bridge built against one loads another without complaint and then fails at JIT time with `MissingMethodException`/`TypeLoadException`, deep inside a metadata call and far from the cause. That is issue #703, and the existing mitigation is a diagnostic in `Program.cs` telling the user to rebuild against their environment. Shipping one binary to everyone ships that mismatch to everyone.
2. **It cannot be built in CI.** The csproj globs `Microsoft.Dynamics.*.dll` from `$(D365BinPath)`, a local D365FO installation, and targets `net48`. `release.yml` runs on `ubuntu-latest`. Prebuilding would need a self-hosted Windows D365FO runner, or a binary committed to git that goes stale on every platform upgrade.

So the bridge stays built per environment; `dotnet build` just takes `-o <dataRoot>/bridge` for an npm install, next to the configuration and the index, where updates never reach. The server cannot find a binary there by searching its own installation, so the wizard records the location in a new `bridge.exePath` setting (`D365FO_BRIDGE_EXE_PATH`), for the root config and for each instance.

An empty setting still means "auto-detect". A configured path that does not exist is now an error rather than a silent fallback: the binary the search would otherwise find was built for whatever environment built it, and per the above that is exactly the failure mode worth refusing.

## 2. The prerequisite was documented wrong

Setup, doctor and three docs pages all said the bridge needs the **.NET Framework 4.8 Developer Pack**. It does not. The project references `Microsoft.NETFramework.ReferenceAssemblies.net48`, which supplies those reference assemblies from NuGet precisely so the targeting pack need not be installed — confirmed on the VM, where `C:\Program Files (x86)\Reference Assemblies\...\v4.8` does not exist at all and the build succeeds from the restored package. What a build needs is the **.NET SDK**.

That misinformation costs a user a download they do not need and still leaves them read-only, with the actual missing prerequisite unnamed. So the prerequisite is now checked rather than guessed: `commandExists` probes for the SDK before anything spawns it, in both the wizard and `update`. Previously a machine without it got `spawn dotnet ENOENT` thrown out of the wizard.

A missing SDK is a warning and a skipped build, not a failed setup — reads and search work without the bridge, so read-only is a working state to land in, deliberately and with the reason stated. Doctor distinguishes the two cases too, since printing a build command to someone with no SDK to run it is not a fix.

## For the reviewer

**A checkout is untouched.** `bridgeOutDir` is null there, so MSBuild's default applies, `bridge.exePath` is never written, and the resolution order is the one it has always had. Moving it would strand every bridge built by an earlier version. `tests/cli/context.test.ts` pins both the path and the exact build command.

`bridgeBuildCommand()` centralises the command printed by `doctor` and `update`, so the `-o` cannot be forgotten in a message telling a user to run it by hand. `update`'s own rebuild passes it too — without that, a rebuild would land in the package while `bridge.exePath` still pointed outside it.

`bridgeAction` from #723 keeps its job but changes character: with the binary outside the package an update should now leave it alone, so that check becomes the proof it did rather than the mechanism that papers over it.

## Testing

- 1891 tests pass. New coverage for exe resolution (configured path honoured, env var honoured, wrong path fails loudly, blank value falls through to the search) and for the prerequisite probe (present, missing, and non-zero exit still counting as present).
- Both new suites were written to pass on a machine **without** a built bridge or a .NET SDK, since the Linux CI runner has neither — the resolution test was verified by hiding the in-tree binary and re-running. (A test in #723 shipped a Windows-only assumption and failed CI; this was checked against that failure mode before pushing.)
- Verified on the VM: built with `-o` into a scratch directory, spawned through the real `BridgeClient`, and read `CustTable`'s full metadata back from the AOT — `metadata=true`.

## Still open

`install.ps1` still clones the repository rather than using the npm path. That is the last piece, and it is now unblocked: the bridge survives updates, and the SDK prerequisite is detected and explained rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)