### PR TITLE
feat(installer): install from npm instead of cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,20 @@ Structural violations (wrong order, missing container, disallowed control) **blo
 
 ## Quick Start
 
-**Installing on your own D365FO VM** — the usual case. One line in PowerShell installs the prerequisites, clones the repository and runs the setup wizard, which builds the C# bridge and the metadata index for you:
+**Installing on your own D365FO VM** — the usual case. One line in PowerShell installs Node.js if it is missing, installs the server from npm, and runs the setup wizard, which asks where the index should live and builds the C# bridge for you:
 
 ```powershell
 irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/install.ps1 | iex
 ```
+
+Already have Node.js 24+? Then the one-liner has nothing to bootstrap and you can skip it:
+
+```powershell
+npm install -g d365fo-mcp
+d365fo-mcp setup
+```
+
+Re-running either is safe. An installation made before the npm package existed is a git checkout, and both are left exactly where they are and updated in place.
 
 **Your team already runs a shared server?** Then you install nothing — point your editor at it:
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -83,7 +83,7 @@ claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https:/
 | GitHub Copilot extension | VS → Extensions | Copilot users |
 | .NET SDK | pre-installed on D365FO VMs, else [dotnet.microsoft.com](https://dotnet.microsoft.com/download) | C# bridge (writes) |
 | Node.js 24.x LTS | [nodejs.org](https://nodejs.org), or `Install-D365SupportingSoftware -Name node.js` | installed for you by the one-liner |
-| Git | [git-scm.com](https://git-scm.com) | installed for you by the one-liner |
+| Git | [git-scm.com](https://git-scm.com) | only for a git-checkout installation, or to work on the source |
 | Python 3.x | option in the Node.js installer | only if npm cannot fetch a prebuilt `better-sqlite3` binary and has to compile it |
 
 ## 2. Install
@@ -92,15 +92,17 @@ claude mcp add-json --scope user d365fo-mcp-tools '{"type":"http","url":"https:/
 irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/install.ps1 | iex
 ```
 
-The installer checks for Node.js and Git (installing them if missing), clones the repository, runs `npm install`, and hands off to the setup wizard — which selects your scenario, builds the C# bridge, asks only the settings that scenario needs, builds the index if you want one, and prints the `.mcp.json` block for step 3.
+The installer checks for Node.js (installing it if missing), installs the server with `npm install -g d365fo-mcp`, and hands off to the setup wizard — which selects your scenario, asks where the configuration and the index should live, builds the C# bridge, asks only the settings that scenario needs, builds the index if you want one, and prints the `.mcp.json` block for step 3.
 
-Safe to re-run: an existing installation is updated (`git pull`) rather than re-cloned. Override with environment variables set on the same line:
+With Node.js 24+ already present the one-liner has nothing to bootstrap, so `npm install -g d365fo-mcp` followed by `d365fo-mcp setup` does the same thing.
+
+Safe to re-run. Installations made before the npm package became self-contained are git checkouts that hold their configuration and index inside the checkout; those are detected and updated in place (`git pull`) instead, so nothing moves and no index is rebuilt. Override with environment variables set on the same line:
 
 | Variable | Effect |
 |---|---|
-| `$env:D365FO_MCP_DIR` | install directory (default `K:\d365fo-mcp-server`) |
+| `$env:D365FO_MCP_DIR` | where to look for an existing checkout (default `K:\d365fo-mcp-server`) |
 | `$env:D365FO_MCP_YES = '1'` | non-interactive, accept defaults |
-| `$env:D365FO_MCP_NO_WIZARD = '1'` | clone + `npm install` only, skip the wizard |
+| `$env:D365FO_MCP_NO_WIZARD = '1'` | install only, skip the wizard |
 
 Answers are saved to `config/d365fo-mcp.json` (secrets to `config/secrets.json`) — there is no `.env` to fill in. Every key, its default and the matching environment variable: [CONFIGURATION.md](CONFIGURATION.md). An older `.env` keeps working and is imported the first time the wizard runs.
 
@@ -126,7 +128,7 @@ npm run build-database
 
 </details>
 
-> **Why not `npx d365fo-mcp setup`?** The CLI is on npm as [`d365fo-mcp`](https://www.npmjs.com/package/d365fo-mcp), but `setup`, `update` and `index` need the repository itself — `scripts/`, dev dependencies and `git pull`. Run from a bare `npx` they stop and refer you back here rather than half-configuring the machine. Only `connect` (Path A) is self-sufficient.
+> **The npm package is the installation.** [`d365fo-mcp`](https://www.npmjs.com/package/d365fo-mcp) carries the compiled server, the index scripts and the C# bridge sources, so `npm install -g d365fo-mcp` followed by `d365fo-mcp setup` needs no clone. The one-liner above exists to install Node.js first, which npm cannot do for itself. Only `npx d365fo-mcp` without a global install stays a `connect`-only client, since it has nowhere to keep an installation.
 
 ## 3. Configure your editor
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,29 +1,40 @@
-# D365 F&O MCP Server — one-line installer (Windows PowerShell 5.1+ / PowerShell 7+)
+# D365 F&O MCP Server - one-line installer (Windows PowerShell 5.1+ / PowerShell 7+)
 #
 #   irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-mcp-server/main/install.ps1 | iex
 #
-# Bootstraps a full installation: verifies (and installs, if missing) Node.js 24+
-# and Git, clones the repository, runs npm install, and hands off to the
-# interactive setup wizard (npm run setup). Safe to re-run — an existing
-# installation is updated (git pull) instead of re-cloned.
+# Bootstraps a full installation and hands off to the interactive setup wizard,
+# which asks where the configuration and the metadata index should live and
+# builds the C# bridge. Safe to re-run.
+#
+# There are two paths, because the package on npm became a full installation
+# (it carries the C# bridge sources and the index scripts) while every
+# installation made before that is a git checkout:
+#
+#   fresh machine      npm install -g d365fo-mcp  ->  d365fo-mcp setup
+#   existing checkout  git pull + npm install     ->  npm run setup
+#
+# The checkout path is kept because those installations already hold a
+# configuration and a multi-gigabyte index in the checkout itself. Switching
+# them to a global install would leave two copies of everything and rebuild an
+# index that takes hours, so a checkout is detected and updated in place. Only
+# that path needs Git at all.
 #
 # The script is piped through Invoke-Expression, so configuration is taken from
 # environment variables instead of parameters:
 #
-#   $env:D365FO_MCP_DIR = 'D:\tools\d365fo-mcp-server'   # install directory
+#   $env:D365FO_MCP_DIR = 'D:\tools\d365fo-mcp-server'   # where to look for an existing checkout
 #   $env:D365FO_MCP_YES = '1'                            # non-interactive: accept all defaults
-#   $env:D365FO_MCP_NO_WIZARD = '1'                      # clone + npm install only, skip the wizard
+#   $env:D365FO_MCP_NO_WIZARD = '1'                      # install only, skip the wizard
 #
-# D365FO VMs are Windows Server, where winget is usually unavailable — Node.js
+# D365FO VMs are Windows Server, where winget is usually unavailable - Node.js
 # falls back to the official MSI (nodejs.org) and Git to portable MinGit.
 
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
-$RepoUrl = 'https://github.com/dynamics365ninja/d365fo-mcp-server.git'
 $MinNodeMajor = 24
 # Pinned MinGit fallback for machines without winget (Windows Server). Portable,
-# extracted under %LOCALAPPDATA% — used only when git is not already installed.
+# extracted under %LOCALAPPDATA% - used only when git is not already installed.
 $MinGitUrl = 'https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
 
 function Write-Step([string]$msg)  { Write-Host "==> $msg" -ForegroundColor Cyan }
@@ -32,13 +43,6 @@ function Write-Note([string]$msg)  { Write-Host "  * $msg" -ForegroundColor Yell
 function Fail([string]$msg) { Write-Host "  x $msg" -ForegroundColor Red; exit 1 }
 
 $NonInteractive = $env:D365FO_MCP_YES -and $env:D365FO_MCP_YES -ne '0' -and $env:D365FO_MCP_YES -ne 'false'
-
-function Ask-Default([string]$question, [string]$default) {
-    if ($NonInteractive) { return $default }
-    $answer = Read-Host "$question [$default]"
-    if ([string]::IsNullOrWhiteSpace($answer)) { return $default }
-    return $answer.Trim().Trim('"')
-}
 
 # Re-read PATH from the registry so tools installed a moment ago resolve
 # without opening a new shell.
@@ -62,7 +66,7 @@ function Install-NodeMsi {
     Write-Step "Downloading Node.js $MinNodeMajor LTS from nodejs.org"
     $index = Invoke-RestMethod 'https://nodejs.org/dist/index.json'
     $version = ($index | Where-Object { $_.version -match "^v$MinNodeMajor\." } | Select-Object -First 1).version
-    if (-not $version) { Fail "No Node.js v$MinNodeMajor release found on nodejs.org — install manually from https://nodejs.org" }
+    if (-not $version) { Fail "No Node.js v$MinNodeMajor release found on nodejs.org - install manually from https://nodejs.org" }
     $msi = Join-Path $env:TEMP "node-$version-x64.msi"
     Invoke-WebRequest "https://nodejs.org/dist/$version/node-$version-x64.msi" -OutFile $msi
     if (Test-Admin) {
@@ -72,7 +76,7 @@ function Install-NodeMsi {
     } elseif ($NonInteractive) {
         Fail "Installing Node.js needs an elevated shell in non-interactive mode. Run PowerShell as Administrator, or install Node.js $MinNodeMajor LTS from https://nodejs.org and re-run."
     } else {
-        Write-Step "Installing Node.js $version — the installer window will ask for elevation"
+        Write-Step "Installing Node.js $version - the installer window will ask for elevation"
         $proc = Start-Process msiexec -ArgumentList "/i `"$msi`"" -Wait -PassThru
         if ($proc.ExitCode -ne 0) { Fail "Node.js install did not complete (exit $($proc.ExitCode))" }
     }
@@ -92,9 +96,9 @@ function Ensure-Node {
     } else {
         Install-NodeMsi
     }
-    if (-not (Test-Cmd node)) { Fail 'Node.js still not on PATH — open a new PowerShell window and re-run this script.' }
+    if (-not (Test-Cmd node)) { Fail 'Node.js still not on PATH - open a new PowerShell window and re-run this script.' }
     $major = [int]((node -v) -replace '^v(\d+)\..*', '$1')
-    if ($major -lt $MinNodeMajor) { Fail "Node.js $(node -v) is still below $MinNodeMajor — install Node $MinNodeMajor LTS from https://nodejs.org and re-run." }
+    if ($major -lt $MinNodeMajor) { Fail "Node.js $(node -v) is still below $MinNodeMajor - install Node $MinNodeMajor LTS from https://nodejs.org and re-run." }
     Write-Ok "Node.js $(node -v)"
 }
 
@@ -106,7 +110,7 @@ function Ensure-Git {
         Refresh-Path
         if (Test-Cmd git) { Write-Ok "$(git --version)"; return }
     }
-    # Portable MinGit fallback — no installer, no elevation needed.
+    # Portable MinGit fallback - no installer, no elevation needed.
     Write-Step 'Installing portable MinGit (no winget on this machine)'
     $minGitDir = Join-Path $env:LOCALAPPDATA 'd365fo-mcp\MinGit'
     $zip = Join-Path $env:TEMP 'MinGit.zip'
@@ -118,8 +122,99 @@ function Ensure-Git {
     if ($userPath -notlike "*$gitCmd*") {
         [Environment]::SetEnvironmentVariable('Path', "$userPath;$gitCmd", 'User')
     }
-    if (-not (Test-Cmd git)) { Fail 'Git installation failed — install Git from https://git-scm.com and re-run.' }
+    if (-not (Test-Cmd git)) { Fail 'Git installation failed - install Git from https://git-scm.com and re-run.' }
     Write-Ok "$(git --version) (portable)"
+}
+
+# Locate an installation made before the npm package became self-contained.
+#
+# Probed rather than asked: a fresh install has no directory to name any more
+# (the wizard asks where the data should live, and the code goes to the global
+# node_modules), so prompting everyone for a path only to ignore it would be
+# worse than silent detection. The candidates are exactly the defaults previous
+# versions of this script used.
+function Find-Checkout {
+    $candidates = @()
+    if ($env:D365FO_MCP_DIR) { $candidates += $env:D365FO_MCP_DIR }
+    $candidates += 'K:\d365fo-mcp-server'
+    $candidates += (Join-Path $env:USERPROFILE 'd365fo-mcp-server')
+
+    foreach ($dir in $candidates) {
+        if (Test-Path (Join-Path $dir '.git')) { return $dir }
+    }
+    # An explicitly named directory that holds something else is a mistake worth
+    # stopping on: installing beside it would leave two installations.
+    if ($env:D365FO_MCP_DIR -and (Test-Path $env:D365FO_MCP_DIR) -and (Get-ChildItem $env:D365FO_MCP_DIR -Force | Select-Object -First 1)) {
+        Fail "$($env:D365FO_MCP_DIR) exists, is not empty, and is not a git checkout. Empty it or point `$env:D365FO_MCP_DIR elsewhere."
+    }
+    return $null
+}
+
+# The pre-npm layout: sources, dependencies, configuration and index all in one
+# checkout. Updated in place, exactly as earlier versions of this script did.
+function Update-Checkout([string]$dir) {
+    Write-Note "Existing checkout found at $dir - updating it in place."
+    Write-Note 'Installations made this way keep their configuration and index in the checkout, so they are left as they are.'
+    Ensure-Git
+
+    Write-Step "Updating $dir"
+    git -C $dir pull --ff-only
+    if ($LASTEXITCODE -ne 0) { Fail 'git pull failed - resolve the conflict in the install directory and re-run.' }
+
+    Push-Location $dir
+    try {
+        Write-Step 'Installing dependencies (npm install)'
+        npm install
+        if ($LASTEXITCODE -ne 0) { Fail 'npm install failed - see the error above (better-sqlite3 needs a prebuilt binary or Python + build tools).' }
+
+        if ($env:D365FO_MCP_NO_WIZARD) {
+            Write-Note 'Skipping the setup wizard (D365FO_MCP_NO_WIZARD set).'
+            Write-Host ''
+            Write-Host "Next: cd $dir; npm run setup" -ForegroundColor Magenta
+            return
+        }
+        Write-Step 'Starting the setup wizard'
+        npm run setup
+        Write-Host ''
+        Write-Host 'Useful commands (run from the install directory):' -ForegroundColor Magenta
+        Write-Host '  npm run doctor        health check'
+        Write-Host '  npm run cli -- start  run the server'
+        Write-Host '  npm run cli -- update update to the latest version'
+    } finally {
+        Pop-Location
+    }
+}
+
+# The npm path: no clone, no build, no Git. The package carries the compiled
+# server, the index scripts and the C# bridge sources; the wizard asks where the
+# configuration and the index should live and builds the bridge from there.
+function Install-FromNpm {
+    Write-Step 'Installing d365fo-mcp from npm'
+    npm install -g d365fo-mcp@latest
+    if ($LASTEXITCODE -ne 0) { Fail 'npm install -g failed - see the error above.' }
+    # The npm global bin directory may have been added to PATH by an installer
+    # that ran moments ago in this same session.
+    Refresh-Path
+
+    if (-not (Test-Cmd 'd365fo-mcp')) {
+        Fail 'd365fo-mcp installed but is not on PATH - open a new PowerShell window and run: d365fo-mcp setup'
+    }
+    Write-Ok 'd365fo-mcp installed'
+
+    if ($env:D365FO_MCP_NO_WIZARD) {
+        Write-Note 'Skipping the setup wizard (D365FO_MCP_NO_WIZARD set).'
+        Write-Host ''
+        Write-Host 'Next: d365fo-mcp setup' -ForegroundColor Magenta
+        return
+    }
+
+    Write-Step 'Starting the setup wizard'
+    d365fo-mcp setup
+    Write-Host ''
+    Write-Host 'Useful commands (from anywhere):' -ForegroundColor Magenta
+    Write-Host '  d365fo-mcp doctor     health check'
+    Write-Host '  d365fo-mcp start      run the server'
+    Write-Host '  d365fo-mcp update     update to the latest release'
 }
 
 # --- main -------------------------------------------------------------------
@@ -130,53 +225,15 @@ if ($env:OS -ne 'Windows_NT') {
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
 Write-Host ''
-Write-Host 'D365 F&O MCP Server — installer' -ForegroundColor Magenta
+Write-Host 'D365 F&O MCP Server - installer' -ForegroundColor Magenta
 Write-Host ''
 
 Write-Step 'Checking prerequisites'
 Ensure-Node
-Ensure-Git
 
-# Default next to the D365FO service volume when it exists (traditional VMs),
-# otherwise the user profile (UDE / client machines).
-if ($env:D365FO_MCP_DIR) {
-    $installDir = $env:D365FO_MCP_DIR
+$checkout = Find-Checkout
+if ($checkout) {
+    Update-Checkout $checkout
 } else {
-    if (Test-Path 'K:\AosService') { $default = 'K:\d365fo-mcp-server' } else { $default = Join-Path $env:USERPROFILE 'd365fo-mcp-server' }
-    $installDir = Ask-Default 'Install directory' $default
-}
-
-if (Test-Path (Join-Path $installDir '.git')) {
-    Write-Step "Existing installation found — updating ($installDir)"
-    git -C $installDir pull --ff-only
-    if ($LASTEXITCODE -ne 0) { Fail 'git pull failed — resolve the conflict in the install directory and re-run.' }
-} elseif ((Test-Path $installDir) -and (Get-ChildItem $installDir -Force | Select-Object -First 1)) {
-    Fail "$installDir exists and is not empty (and is not a git checkout). Set `$env:D365FO_MCP_DIR to a different directory and re-run."
-} else {
-    Write-Step "Cloning into $installDir"
-    git clone $RepoUrl $installDir
-    if ($LASTEXITCODE -ne 0) { Fail 'git clone failed — check network access to github.com.' }
-}
-
-Push-Location $installDir
-try {
-    Write-Step 'Installing dependencies (npm install)'
-    npm install
-    if ($LASTEXITCODE -ne 0) { Fail 'npm install failed — see the error above (better-sqlite3 needs a prebuilt binary or Python + build tools).' }
-
-    if ($env:D365FO_MCP_NO_WIZARD) {
-        Write-Note 'Skipping the setup wizard (D365FO_MCP_NO_WIZARD set).'
-        Write-Host ''
-        Write-Host "Next: cd $installDir; npm run setup" -ForegroundColor Magenta
-    } else {
-        Write-Step 'Starting the setup wizard'
-        npm run setup
-        Write-Host ''
-        Write-Host 'Useful commands (run from the install directory):' -ForegroundColor Magenta
-        Write-Host '  npm run doctor        health check'
-        Write-Host '  npm run cli -- start  run the server'
-        Write-Host '  npm run cli -- update update to the latest version'
-    }
-} finally {
-    Pop-Location
+    Install-FromNpm
 }


### PR DESCRIPTION
Completes the series started in #723 and continued in #724.

## Why

The npm package is now a full installation: it carries the compiled server, the index scripts and the C# bridge sources (#723), and the wizard keeps configuration, index and bridge binary outside the package so an update cannot delete them (#724). The installer's remaining job — clone a repository so there is something to run — no longer exists.

What it still has to do is install **Node.js**, because `npm install -g` cannot bootstrap the runtime it needs. That is why the one-liner does not simply disappear.

```
before   Node + Git (winget, else MinGit) -> git clone -> npm install -> npm run setup
after    Node                             -> npm install -g d365fo-mcp -> d365fo-mcp setup
```

## Existing installations are left alone

Every installation made before the package became self-contained is a git checkout that holds its configuration **and a multi-gigabyte index inside the checkout**. Switching those to a global install would leave two copies of everything and rebuild an index that takes hours, so a checkout is detected and updated in place exactly as before. Nobody already running this notices a change, and only that path bootstraps Git at all — the MinGit fallback stops running for the common case.

Detection is probed rather than asked. A fresh install has no directory to name any more: the wizard asks where the data should live, and the code goes to the global `node_modules`. Prompting everyone for an install path only to ignore it would be worse than looking in the three places earlier versions of this script used. `$env:D365FO_MCP_DIR` keeps working with its meaning narrowed to "where to look for a checkout", and a directory named there holding something else still stops the run rather than installing beside it.

## A pre-existing parse bug, fixed in passing

`install.ps1` contained em-dashes and arrows. Windows PowerShell 5.1 reads a `.ps1` without a BOM as ANSI, so those UTF-8 bytes became stray quote characters and the file **failed to parse** — reproduced against the version already on `main`, so it predates this rewrite:

```
PS 5.1, main's install.ps1:  The string is missing the terminator: '.
```

The `irm | iex` path was unaffected, because HTTP carries the charset and `iex` parses a decoded string rather than a file — which is why nobody hit it. Anyone who saved the file and ran it locally did. Both characters were decorative, so they are now ASCII and the file parses identically under either PowerShell, at any encoding.

CI only ever caught this class of bug halfway: `lint-installer.yml` parses with `pwsh` 7, which defaults to UTF-8.

## Testing

- Parsed under **both** Windows PowerShell 5.1 and the pwsh 7 parser CI uses — clean in both, where `main` is clean only in the second.
- All three detection branches exercised in isolation, with the functions dot-sourced so nothing actually installed: no checkout anywhere returns empty (npm path), a checkout at `D365FO_MCP_DIR` is returned (update path), and a non-empty non-checkout fails with the intended message and exit 1.
- 1891 unit tests pass (unchanged by this PR — it touches no TypeScript).

**Not tested end to end**, and deliberately so: a real run would `npm install -g d365fo-mcp@latest`, which today is 1.1.0 — the release *before* any of this work. The npm path can only be verified for real once a version carrying #723 and #724 is published. Until then the checkout path is what everyone gets, and that path is unchanged.

## Docs

README and QUICK_START described cloning. Both now describe the npm install, including the manual `npm install -g d365fo-mcp && d365fo-mcp setup` for anyone who already has Node. The "Why not `npx d365fo-mcp setup`?" callout said the CLI cannot set up a machine without the repository — the exact thing that changed — and now explains the opposite. The Git prerequisite is marked as checkout-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)