### PR TITLE
fix(ci): build before testing, and stop the packaging gate failing unbuilt

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,11 +35,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm test -- --run
-
+      # Build first: tests/packaging/publishedFiles.test.ts inspects what
+      # `npm pack` would publish, which is dist/ — with the old order it saw an
+      # unbuilt tree and failed. Building first also surfaces a type error
+      # before spending a minute on the suite.
       - name: Build TypeScript
         run: npm run build
+
+      - name: Run tests
+        run: npm test -- --run
 
       - name: Prepare deployment files
         run: |

--- a/tests/packaging/publishedFiles.test.ts
+++ b/tests/packaging/publishedFiles.test.ts
@@ -10,16 +10,29 @@
  *
  * The list is computed with `npm pack --dry-run`, which is the same code path
  * `npm publish` uses, rather than by re-implementing npm's include rules here.
+ *
+ * That makes the suite a check on *build output*: almost everything published
+ * comes from dist/, so an unbuilt tree packs a near-empty tarball and every
+ * assertion below fails for a reason that has nothing to do with packaging.
+ * It is skipped rather than failed in that case — `vitest` on a fresh clone is
+ * a reasonable thing to do, and a wall of red teaching people to ignore this
+ * suite is worse than not running it. CI builds before testing, so the gate is
+ * always live where it decides anything.
  */
 import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { describe, it, expect, beforeAll } from 'vitest';
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
+/** Whether `npm run build` has produced anything for `npm pack` to publish. */
+const isBuilt = fs.existsSync(path.join(REPO_ROOT, 'dist', 'index.js'));
+
 let packed: string[];
 
 beforeAll(() => {
+  if (!isBuilt) return;
   // --ignore-scripts: prepublishOnly would otherwise run a full build here.
   // npm is a .cmd shim on Windows, which cannot be spawned without a shell
   // (EINVAL since the Node 18 hardening) — hence execSync over a constant
@@ -33,7 +46,24 @@ beforeAll(() => {
   packed = report[0].files.map(f => f.path.replace(/\\/g, '/'));
 }, 120_000);
 
-describe('published package contents', () => {
+/**
+ * The skip above is a local-convenience escape hatch, and an escape hatch that
+ * can quietly swallow the whole suite is worth one assertion of its own: if a
+ * workflow ever runs the tests before building again, this fails loudly
+ * instead of the packaging gate disappearing unnoticed.
+ */
+describe('packaging gate', () => {
+  it('is not skipped in CI', () => {
+    if (!process.env.CI) return;
+    expect(
+      isBuilt,
+      'dist/ is missing in CI, so the published-contents checks below were skipped. ' +
+      'Build before running the tests (see .github/workflows).',
+    ).toBe(true);
+  });
+});
+
+describe.skipIf(!isBuilt)('published package contents', () => {
   it('ships the CLI entry point the bin field names', () => {
     expect(packed).toContain('dist/cli/index.js');
     expect(packed).toContain('dist/index.js');


### PR DESCRIPTION
`main` is red. **Deploy to Azure** has been failing since #723 merged, and again after #724 — I only checked eval-gate, which stayed green, so I missed it.

## What broke

`tests/packaging/publishedFiles.test.ts` (added in #723) inspects what `npm pack` would publish. Almost all of that is `dist/`, so on an unbuilt tree it packs a near-empty tarball and the assertions fail:

```
expected [ 'LICENSE', 'README.md', …(9) ] to include 'dist/cli/index.js'
```

Those 11 entries are LICENSE, README, package.json and the eight bridge source files — everything except the build output.

`deploy.yml` runs the tests **before** building:

```yaml
- run: npm ci
- run: npm test -- --run     # dist/ does not exist yet
- run: npm run build
```

`eval-gate.yml` builds first, which is why the gate passed there and the problem stayed invisible.

The failure message is the nastiest part: it names `dist/cli/index.js` as missing *from the package*, which reads as a packaging bug. Nothing points at step ordering.

## Fix

**Build before testing in `deploy.yml`.** The two steps are independent and the deployment package is assembled later, so this only moves the build earlier — and it surfaces a type error before spending a minute on 1900 tests.

**The suite skips itself on an unbuilt tree** rather than failing. Running `vitest` on a fresh clone is a reasonable thing to do, and a wall of red that teaches people to ignore this suite is worse than not running it.

**One assertion always runs** and fails when CI skipped the rest. An escape hatch that can quietly swallow a gate deserves its own check: if a workflow ever reintroduces the old order, it breaks loudly and says why, instead of the packaging gate silently ceasing to decide anything.

## Testing

All three states exercised by moving `dist/` aside:

| State | Result |
|---|---|
| built | 9 pass |
| unbuilt, local | 3 pass, 6 skipped |
| unbuilt, `CI=true` | guard fails: "dist/ is missing in CI, so the published-contents checks below were skipped" |

Full suite green (1892 passing).

## Note

This does not touch #725, which is based on `main` and unaffected — it changes no TypeScript and no workflow this PR edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)