### PR TITLE
fix(cli): create fresh instances in the top-level layout so they are discoverable

### DIFF
--- a/src/cli/instances.ts
+++ b/src/cli/instances.ts
@@ -5,6 +5,7 @@
  */
 import * as fs from 'node:fs';
 import { join } from 'node:path';
+import { configCandidates } from '../config/configFile.js';
 import { settingByPath } from '../config/settings.js';
 import { paths } from './context.js';
 import { openInstanceStore, readSetting, saveStore, writeSetting } from './settingsStore.js';
@@ -26,7 +27,10 @@ export function listInstances(): Instance[] {
     .filter(e => e.isDirectory())
     .map(e => {
       const dir = join(paths.instancesDir, e.name);
-      return { name: e.name, dir, envFile: join(dir, '.env'), configFile: join(dir, 'd365fo-mcp.json') };
+      // Accept either instance layout: the top-level d365fo-mcp.json, or the
+      // config/ form an older build's wizard wrote. Prefer the top-level one.
+      const configFile = configCandidates(dir).find(p => fs.existsSync(p)) ?? join(dir, 'd365fo-mcp.json');
+      return { name: e.name, dir, envFile: join(dir, '.env'), configFile };
     })
     .filter(i => fs.existsSync(i.configFile) || fs.existsSync(i.envFile))
     .map(i => {
@@ -55,7 +59,7 @@ export function createInstance(name: string, port: number): Instance {
   const dir = join(paths.instancesDir, name);
   const envFile = join(dir, '.env');
   const configFile = join(dir, 'd365fo-mcp.json');
-  if (fs.existsSync(configFile) || fs.existsSync(envFile)) {
+  if (configCandidates(dir).some(p => fs.existsSync(p)) || fs.existsSync(envFile)) {
     throw new Error(`Instance '${name}' already exists.`);
   }
   fs.mkdirSync(join(dir, 'data'), { recursive: true });

--- a/src/cli/instances.ts
+++ b/src/cli/instances.ts
@@ -58,7 +58,6 @@ export function suggestPort(instances: Instance[]): number {
 export function createInstance(name: string, port: number): Instance {
   const dir = join(paths.instancesDir, name);
   const envFile = join(dir, '.env');
-  const configFile = join(dir, 'd365fo-mcp.json');
   if (configCandidates(dir).some(p => fs.existsSync(p)) || fs.existsSync(envFile)) {
     throw new Error(`Instance '${name}' already exists.`);
   }
@@ -74,5 +73,7 @@ export function createInstance(name: string, port: number): Instance {
   writeSetting(store, settingByPath('index.metadataPath')!, './metadata');
   saveStore(store);
 
-  return { name, dir, envFile, configFile, port };
+  // store.configPath rather than a second literal: where a fresh config lands is
+  // resolveConfigFiles' decision, and the two must not drift apart.
+  return { name, dir, envFile, configFile: store.configPath, port };
 }

--- a/src/cli/settingsStore.ts
+++ b/src/cli/settingsStore.ts
@@ -36,10 +36,10 @@ export interface SettingsStore {
  * Open the store for a base directory (repo root, or an instance folder).
  * `legacyEnvFile` is the .env that used to hold the same settings, if any.
  */
-export function openStore(baseDir: string, legacyEnvFile: string | null): SettingsStore {
+export function openStore(baseDir: string, legacyEnvFile: string | null, fallbackConfigPath?: string): SettingsStore {
   // allowEnvOverride: false — the CLI opens several stores in one process, so a
   // D365FO_CONFIG inherited from the shell must not redirect all of them.
-  const files = resolveConfigFiles(baseDir, { allowEnvOverride: false });
+  const files = resolveConfigFiles(baseDir, { allowEnvOverride: false, fallbackConfigPath });
   return {
     dir: files.dir,
     baseDir: files.baseDir,
@@ -53,7 +53,9 @@ export function openStore(baseDir: string, legacyEnvFile: string | null): Settin
 
 /** Store rooted at an instance folder: instances/<name>/d365fo-mcp.json. */
 export function openInstanceStore(instanceDir: string): SettingsStore {
-  return openStore(instanceDir, join(instanceDir, '.env'));
+  // A fresh instance has no config yet; write it to the top-level instance
+  // layout (not the config/ repo layout) so listInstances() can find it.
+  return openStore(instanceDir, join(instanceDir, '.env'), join(instanceDir, 'd365fo-mcp.json'));
 }
 
 /** Effective value of a setting, or undefined when nothing configures it. */

--- a/src/config/configFile.ts
+++ b/src/config/configFile.ts
@@ -81,12 +81,23 @@ function readJson(file: string): ConfigObject | null {
  * `allowEnvOverride` is what the running server wants (D365FO_CONFIG points it
  * at one specific instance); the CLI passes false, since it manages several
  * targets in one process and must not collapse them all onto that one file.
+ *
+ * `fallbackConfigPath` is where a not-yet-created config should be written when
+ * neither candidate exists. It defaults to the repo layout (<baseDir>/config/…);
+ * an instance passes its top-level <baseDir>/d365fo-mcp.json so a freshly created
+ * instance lands in the instance layout listInstances() discovers, not under
+ * config/ (where it would be invisible to list/rebuild/run).
  */
-export function resolveConfigFiles(baseDir: string, opts?: { allowEnvOverride?: boolean }): ResolvedConfigFiles {
+export function resolveConfigFiles(
+  baseDir: string,
+  opts?: { allowEnvOverride?: boolean; fallbackConfigPath?: string },
+): ResolvedConfigFiles {
   const explicit = opts?.allowEnvOverride === false ? undefined : process.env.D365FO_CONFIG?.trim();
   const configPath = explicit
     ? resolve(explicit)
-    : configCandidates(baseDir).find(p => fs.existsSync(p)) ?? join(baseDir, 'config', 'd365fo-mcp.json');
+    : configCandidates(baseDir).find(p => fs.existsSync(p))
+      ?? opts?.fallbackConfigPath
+      ?? join(baseDir, 'config', 'd365fo-mcp.json');
 
   const dir = dirname(configPath);
   return {

--- a/src/config/configFile.ts
+++ b/src/config/configFile.ts
@@ -83,10 +83,12 @@ function readJson(file: string): ConfigObject | null {
  * targets in one process and must not collapse them all onto that one file.
  *
  * `fallbackConfigPath` is where a not-yet-created config should be written when
- * neither candidate exists. It defaults to the repo layout (<baseDir>/config/…);
- * an instance passes its top-level <baseDir>/d365fo-mcp.json so a freshly created
- * instance lands in the instance layout listInstances() discovers, not under
- * config/ (where it would be invisible to list/rebuild/run).
+ * no candidate exists — and, like the candidates themselves, only when
+ * D365FO_CONFIG did not already name the file outright. It defaults to the repo
+ * layout (<baseDir>/config/…); an instance passes its top-level
+ * <baseDir>/d365fo-mcp.json so a freshly created instance lands in the instance
+ * layout listInstances() discovers, not under config/ (where it would be
+ * invisible to list/rebuild/run).
  */
 export function resolveConfigFiles(
   baseDir: string,

--- a/tests/cli/instances.test.ts
+++ b/tests/cli/instances.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Instance discovery — which directories under instances/ count as an instance,
+ * and where a new one's configuration is written.
+ *
+ * Load-bearing because the two halves have to agree: `instance add` writes a
+ * config file, and every other command (list, run, rebuild, upgrade) finds the
+ * instance again only by looking for that same file. When they disagreed the
+ * wizard produced an instance its own management commands reported as "not
+ * found" — the config went to instances/<name>/config/d365fo-mcp.json while
+ * discovery looked at instances/<name>/d365fo-mcp.json.
+ *
+ * The data root is mocked to a temp directory: the suite runs from a checkout,
+ * where paths.instancesDir is the real instances/ folder of the repo.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createInstance, getInstance, listInstances } from '../../src/cli/instances.js';
+import { writeConfigFile } from '../../src/config/configFile.js';
+
+const state = vi.hoisted(() => ({ root: '' }));
+
+vi.mock('../../src/cli/context.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../src/cli/context.js')>();
+  return {
+    ...actual,
+    dataRoot: () => state.root,
+    // A getter, like the real one: state.root changes between tests.
+    paths: { ...actual.paths, get instancesDir() { return join(state.root, 'instances'); } },
+  };
+});
+
+const instanceDir = (name: string) => join(state.root, 'instances', name);
+
+beforeEach(() => {
+  state.root = fs.mkdtempSync(join(os.tmpdir(), 'd365fo-instances-'));
+});
+
+afterEach(() => {
+  fs.rmSync(state.root, { recursive: true, force: true });
+});
+
+describe('listInstances', () => {
+  it('is empty when nothing has been created yet', () => {
+    expect(listInstances()).toEqual([]);
+  });
+
+  it('finds an instance in the top-level layout and reads its port', () => {
+    writeConfigFile(join(instanceDir('alpha'), 'd365fo-mcp.json'), { server: { port: 3005 } });
+
+    const [alpha] = listInstances();
+    expect(alpha.name).toBe('alpha');
+    expect(alpha.configFile).toBe(join(instanceDir('alpha'), 'd365fo-mcp.json'));
+    expect(alpha.port).toBe(3005);
+  });
+
+  it('finds an instance an older build wrote under config/', () => {
+    // Regression: this layout was invisible, so `instance list`, `run`,
+    // `rebuild` and `upgrade` all reported the instance as not found.
+    writeConfigFile(join(instanceDir('legacy'), 'config', 'd365fo-mcp.json'), { server: { port: 3006 } });
+
+    const [legacy] = listInstances();
+    expect(legacy.name).toBe('legacy');
+    expect(legacy.configFile).toBe(join(instanceDir('legacy'), 'config', 'd365fo-mcp.json'));
+    expect(legacy.port).toBe(3006);
+    expect(getInstance('legacy')).toBeDefined();
+  });
+
+  it('prefers the top-level config when both layouts are present', () => {
+    writeConfigFile(join(instanceDir('both'), 'd365fo-mcp.json'), { server: { port: 3007 } });
+    writeConfigFile(join(instanceDir('both'), 'config', 'd365fo-mcp.json'), { server: { port: 9999 } });
+
+    const [both] = listInstances();
+    expect(both.configFile).toBe(join(instanceDir('both'), 'd365fo-mcp.json'));
+    expect(both.port).toBe(3007);
+  });
+
+  it('still recognises an instance configured by a legacy .env alone', () => {
+    fs.mkdirSync(instanceDir('envonly'), { recursive: true });
+    fs.writeFileSync(join(instanceDir('envonly'), '.env'), 'PORT=3008\n', 'utf8');
+
+    const [envOnly] = listInstances();
+    expect(envOnly.name).toBe('envonly');
+    expect(envOnly.port).toBe(3008);
+  });
+
+  it('ignores a directory that holds neither a config nor a .env', () => {
+    fs.mkdirSync(join(instanceDir('empty'), 'data'), { recursive: true });
+    expect(listInstances()).toEqual([]);
+  });
+});
+
+describe('createInstance', () => {
+  it('writes the config where listInstances looks for it', () => {
+    const created = createInstance('fresh', 3010);
+
+    expect(created.configFile).toBe(join(instanceDir('fresh'), 'd365fo-mcp.json'));
+    expect(fs.existsSync(join(instanceDir('fresh'), 'config', 'd365fo-mcp.json'))).toBe(false);
+    expect(fs.existsSync(join(instanceDir('fresh'), 'data'))).toBe(true);
+    expect(fs.existsSync(join(instanceDir('fresh'), 'metadata'))).toBe(true);
+
+    const found = getInstance('fresh');
+    expect(found?.port).toBe(3010);
+    expect(found?.configFile).toBe(created.configFile);
+  });
+
+  it('refuses to clobber an instance that already exists in either layout', () => {
+    writeConfigFile(join(instanceDir('top'), 'd365fo-mcp.json'), { server: { port: 3011 } });
+    writeConfigFile(join(instanceDir('old'), 'config', 'd365fo-mcp.json'), { server: { port: 3012 } });
+
+    expect(() => createInstance('top', 3020)).toThrow(/already exists/);
+    expect(() => createInstance('old', 3021)).toThrow(/already exists/);
+    // The existing configuration is untouched by the refused create.
+    expect(getInstance('old')?.port).toBe(3012);
+  });
+});

--- a/tests/utils/configFile.test.ts
+++ b/tests/utils/configFile.test.ts
@@ -20,8 +20,10 @@ import { SETTINGS, parseValue, serializeValue, settingByPath } from '../../src/c
 import {
   conflictingLegacyValues,
   migrateLegacyEnv,
+  openInstanceStore,
   openStore,
   readSetting,
+  saveStore,
   writeSetting,
 } from '../../src/cli/settingsStore.js';
 
@@ -129,6 +131,16 @@ describe('config file', () => {
     expect(env.GROUNDING_SECRET).toBe('s3cret');
   });
 
+  it('defaults a not-yet-created config to the repo layout (config/)', () => {
+    const files = resolveConfigFiles(tmp, { allowEnvOverride: false });
+    expect(files.configPath).toBe(join(tmp, 'config', 'd365fo-mcp.json'));
+  });
+
+  it('writes a not-yet-created config to the supplied fallback path', () => {
+    const files = resolveConfigFiles(tmp, { allowEnvOverride: false, fallbackConfigPath: join(tmp, 'd365fo-mcp.json') });
+    expect(files.configPath).toBe(join(tmp, 'd365fo-mcp.json'));
+  });
+
   it('honours D365FO_CONFIG only when the caller allows it', () => {
     const explicit = join(tmp, 'elsewhere', 'custom.json');
     writeConfigFile(explicit, { naming: { prefix: 'FROM_ENV' } });
@@ -146,6 +158,27 @@ describe('settings store', () => {
     fs.writeFileSync(file, content);
     return file;
   };
+
+  it('creates a fresh instance config at the top level, not under config/', () => {
+    // Regression: the wizard used to write instances/<name>/config/d365fo-mcp.json,
+    // which listInstances() (top-level d365fo-mcp.json | .env) could not discover.
+    const instanceDir = join(tmp, 'instances', 'gamma');
+    fs.mkdirSync(instanceDir, { recursive: true });
+    const store = openInstanceStore(instanceDir);
+    expect(store.configPath).toBe(join(instanceDir, 'd365fo-mcp.json'));
+
+    writeSetting(store, settingByPath('server.port')!, 3007);
+    saveStore(store);
+    expect(fs.existsSync(join(instanceDir, 'd365fo-mcp.json'))).toBe(true);
+    expect(fs.existsSync(join(instanceDir, 'config', 'd365fo-mcp.json'))).toBe(false);
+  });
+
+  it('still finds an existing instance config written under config/ by an older build', () => {
+    const instanceDir = join(tmp, 'instances', 'delta');
+    writeConfigFile(join(instanceDir, 'config', 'd365fo-mcp.json'), { naming: { prefix: 'OLDBUILD' } });
+    const store = openInstanceStore(instanceDir);
+    expect(readSetting(store, settingByPath('naming.prefix')!)).toBe('OLDBUILD');
+  });
 
   it('falls back to a legacy .env when the JSON does not define a value', () => {
     const envFile = writeEnv('EXTENSION_PREFIX=OLD\nPORT=3005\n');


### PR DESCRIPTION
## Issue

`d365fo-mcp instance add` wrote the new instance config to `instances/<name>/config/d365fo-mcp.json`, but `listInstances()` only looks for `instances/<name>/d365fo-mcp.json` (or a legacy `.env`). The freshly created instance was therefore invisible to `instance list`, `rebuild`, `run` and `upgrade` — the wizard produced an instance its own management commands could not see, and its "Next steps" pointed at commands that then reported the instance as not found.

Root cause: for a not-yet-created config, `resolveConfigFiles()` always fell back to the repo layout (`<baseDir>/config/d365fo-mcp.json`). Instances need the top-level instance layout that the docs, `instances/d365fo-mcp.template.json` and `add-instance.ps1` all promise.

## Fix

- **`resolveConfigFiles`**: add an optional `fallbackConfigPath` used only when neither candidate exists; the default is unchanged, so the repo root still lands on `config/d365fo-mcp.json`.
- **`openInstanceStore`**: pass the instance's own top-level `d365fo-mcp.json` as that fallback, so a fresh instance is written where discovery looks.
- **`listInstances` / `createInstance`**: recognise either candidate location, so an instance an older build already wrote under `config/` is still found (and the create-time guard still refuses to clobber it).
