### PR TITLE
fix(bridge): let add-control address the form design root (unblocks form-lifecycle)

### DIFF
--- a/bridge/D365MetadataBridge/Services/FormAuthoringDefaults.cs
+++ b/bridge/D365MetadataBridge/Services/FormAuthoringDefaults.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace D365MetadataBridge.Services
+{
+    /// <summary>
+    /// Pure, dependency-free helpers for the form authoring surface (create/add-control).
+    ///
+    /// Deliberately references NO Microsoft.Dynamics.* type so it can be compiled and
+    /// unit-tested away from a D365FO installation — see
+    /// tests/bridge/formAuthoringDefaults.test.ts, which compiles THIS FILE with the
+    /// plain .NET SDK and asserts the behaviour below without an AOS or a metadata model.
+    /// </summary>
+    internal static class FormAuthoringDefaults
+    {
+        /// <summary>Name of the method that carries a form's class declaration in AxForm XML.</summary>
+        public const string ClassDeclarationMethodName = "classDeclaration";
+
+        /// <summary>True when <paramref name="methodName"/> denotes the form class declaration.</summary>
+        public static bool IsClassDeclarationMethod(string? methodName)
+            => methodName != null
+               && string.Equals(methodName.Trim(), ClassDeclarationMethodName, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// True when <paramref name="parentControl"/> addresses the form DESIGN ROOT rather than a
+        /// named control inside it.
+        ///
+        /// Why this exists: AddControl used to resolve its parent purely with
+        /// FindControlRecursive(design, parentControl), which only ever walks design.Controls and
+        /// therefore can NEVER return the design itself. On a form whose design has no controls yet,
+        /// every possible parentControl value failed by construction, so a form could never receive
+        /// its FIRST top-level control (corpus: 2026-07-21T18__L2-form-modify-controls__c262b19).
+        ///
+        /// Recognised sentinels: null / empty / whitespace, "Design", "FormDesign", "Root",
+        /// the form name itself, and "&lt;FormName&gt;Design" — i.e. every spelling an agent
+        /// plausibly reaches for when it wants "put this at the top level".
+        /// </summary>
+        public static bool IsDesignRootSentinel(string? parentControl, string? formName)
+        {
+            if (string.IsNullOrWhiteSpace(parentControl)) return true;
+
+            var p = parentControl!.Trim();
+            if (string.Equals(p, "Design", StringComparison.OrdinalIgnoreCase)) return true;
+            if (string.Equals(p, "FormDesign", StringComparison.OrdinalIgnoreCase)) return true;
+            if (string.Equals(p, "Root", StringComparison.OrdinalIgnoreCase)) return true;
+
+            if (!string.IsNullOrWhiteSpace(formName))
+            {
+                var f = formName!.Trim();
+                if (string.Equals(p, f, StringComparison.OrdinalIgnoreCase)) return true;
+                if (string.Equals(p, f + "Design", StringComparison.OrdinalIgnoreCase)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The class declaration every AxForm must carry. Without it xppc fails with
+        /// "The 'classDeclaration' is missing from element '&lt;Form&gt;'", i.e. a bridge-created
+        /// form was dead on arrival (corpus: 2026-07-21T18__L2-form-modify-controls__c262b19).
+        /// Shape mirrors GenerateD365Xml.generateAxFormXml (src/tools/generateD365Xml.ts) so the
+        /// bridge create path and the XML fallback produce the same form.
+        /// </summary>
+        public static string DefaultFormClassDeclaration(string formName)
+            => "[Form]\npublic class " + formName + " extends FormRun\n{\n}\n";
+    }
+}

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -1050,6 +1050,7 @@ namespace D365MetadataBridge.Services
 
             var axForm = new AxForm { Name = name };
 
+            var unknownProperties = new List<string>();
             if (properties != null)
             {
                 foreach (var kv in properties)
@@ -1058,14 +1059,42 @@ namespace D365MetadataBridge.Services
                     {
                         case "label": axForm.Design.Caption = kv.Value; break;
                         case "caption": axForm.Design.Caption = kv.Value; break;
+                        // properties.dataSource used to be accepted and silently dropped, so a
+                        // form created with it came out with an empty <DataSources /> and the
+                        // caller only found out at compile/runtime. Honour it: the value is the
+                        // TABLE name, and the data source takes the same name (D365FO convention).
+                        case "datasource":
+                        case "table":
+                            if (!string.IsNullOrWhiteSpace(kv.Value))
+                                axForm.AddDataSource(CreateFormDataSourceRoot(kv.Value.Trim(), kv.Value.Trim(), null));
+                            break;
+                        default:
+                            unknownProperties.Add(kv.Key);
+                            break;
                     }
                 }
             }
 
+            var hasClassDeclaration = false;
             if (methods != null)
             {
                 foreach (var m in methods)
+                {
+                    if (FormAuthoringDefaults.IsClassDeclarationMethod(m.Name)) hasClassDeclaration = true;
                     axForm.AddMethod(new AxMethod { Name = m.Name, Source = m.Source ?? "" });
+                }
+            }
+
+            // Without a classDeclaration xppc rejects the form outright
+            // ("The 'classDeclaration' is missing from element '<Form>'"), i.e. every
+            // bridge-created form was uncompilable. Supply the standard one when absent.
+            if (!hasClassDeclaration)
+            {
+                axForm.AddMethod(new AxMethod
+                {
+                    Name = FormAuthoringDefaults.ClassDeclarationMethodName,
+                    Source = FormAuthoringDefaults.DefaultFormClassDeclaration(name),
+                });
             }
 
             var provider = _provider.Forms as IMetaFormProvider
@@ -1073,7 +1102,41 @@ namespace D365MetadataBridge.Services
             provider.Create(axForm, msi);
 
             var filePath = GetExpectedPath("AxForm", name, modelName);
-            return new { success = true, objectType = "form", objectName = name, modelName, filePath, api = "IMetaFormProvider.Create" };
+            return new
+            {
+                success = true,
+                objectType = "form",
+                objectName = name,
+                modelName,
+                filePath,
+                api = "IMetaFormProvider.Create",
+                // Never drop a property silently — an ignored key must be visible to the caller.
+                warnings = unknownProperties.Count == 0
+                    ? null
+                    : new[] { $"Ignored unsupported form properties: {string.Join(", ", unknownProperties)}. Supported: label/caption, dataSource." },
+            };
+        }
+
+        /// <summary>
+        /// Creates a top-level (root) form data source. AxFormDataSource is abstract and a
+        /// top-level source MUST be an AxFormDataSourceRoot — picking the first concrete
+        /// AxFormDataSourceConcrete subtype can yield AxFormDataSourceReferenced (used for
+        /// nested/referenced sources), which AxForm.AddDataSource then fails to cast.
+        /// </summary>
+        private AxFormDataSourceConcrete CreateFormDataSourceRoot(string dsName, string table, string? joinSource)
+        {
+            var assembly = typeof(AxClass).Assembly;
+            var dsType = assembly.GetType("Microsoft.Dynamics.AX.Metadata.MetaModel.AxFormDataSourceRoot")
+                ?? assembly.GetTypes().FirstOrDefault(t =>
+                       typeof(AxFormDataSourceConcrete).IsAssignableFrom(t) && !t.IsAbstract
+                       && t.Name == "AxFormDataSourceRoot")
+                ?? throw new InvalidOperationException(
+                    "AxFormDataSourceRoot type not found in metadata assembly — use xmlContent fallback");
+            dynamic ds = Activator.CreateInstance(dsType)!;
+            ds.Name = dsName;
+            ds.Table = table;
+            if (!string.IsNullOrEmpty(joinSource)) ds.JoinSource = joinSource;
+            return (AxFormDataSourceConcrete)ds;
         }
 
         /// <summary>
@@ -2294,8 +2357,21 @@ namespace D365MetadataBridge.Services
             // Navigate to parent control in the design tree
             var design = axForm.Design;
             var parent = FindControlRecursive(design, parentControl);
+
+            // FindControlRecursive only ever walks design.Controls, so it can never return the
+            // design ROOT. Fall back to the design itself when parentControl is a design-root
+            // sentinel ("Design", the form name, empty/omitted, ...) — otherwise a form whose
+            // design has no controls yet can never receive its FIRST top-level control, which
+            // blocked every form-lifecycle eval case (see FormAuthoringDefaults).
+            // A real control wins over the sentinel: the recursive lookup is tried first, so a
+            // control genuinely NAMED "Design" still resolves to itself.
+            if (parent == null && FormAuthoringDefaults.IsDesignRootSentinel(parentControl, formName))
+                parent = design;
+
             if (parent == null)
-                throw new InvalidOperationException($"Parent control '{parentControl}' not found in form '{formName}'");
+                throw new InvalidOperationException(
+                    $"Parent control '{parentControl}' not found in form '{formName}'. " +
+                    "Pass parentControl=\"Design\" (or omit it) to add a control at the top level of the form design.");
 
             // Create the control using reflection (AxFormControl is abstract)
             var control = CreateFormControl(controlType, controlName, dataSource, dataField, label);
@@ -2333,23 +2409,7 @@ namespace D365MetadataBridge.Services
                             return new { success = true, operation = "add-data-source", objectType, objectName, dsName, table, skipped = true, reason = $"data source '{(string)dyn.Name}' already binds table '{table}'", api = "IMetaFormProvider.Update" };
                     }
 
-                    // AxFormDataSource hierarchy is abstract. A top-level form data source
-                    // MUST be an AxFormDataSourceRoot — picking the first concrete
-                    // AxFormDataSourceConcrete subtype can yield AxFormDataSourceReferenced
-                    // (used for nested/referenced sources), which AxForm.AddDataSource then
-                    // fails to cast to AxFormDataSourceRoot. Resolve the Root type explicitly.
-                    var assembly = typeof(AxClass).Assembly;
-                    var dsType = assembly.GetType("Microsoft.Dynamics.AX.Metadata.MetaModel.AxFormDataSourceRoot")
-                        ?? assembly.GetTypes().FirstOrDefault(t =>
-                               typeof(AxFormDataSourceConcrete).IsAssignableFrom(t) && !t.IsAbstract
-                               && t.Name == "AxFormDataSourceRoot")
-                        ?? throw new InvalidOperationException(
-                            "AxFormDataSourceRoot type not found in metadata assembly — use xmlContent fallback");
-                    dynamic ds = Activator.CreateInstance(dsType)!;
-                    ds.Name = dsName;
-                    ds.Table = table;
-                    if (!string.IsNullOrEmpty(joinSource)) ds.JoinSource = joinSource;
-                    axForm.AddDataSource((AxFormDataSourceConcrete)ds);
+                    axForm.AddDataSource(CreateFormDataSourceRoot(dsName, table, joinSource));
 
                     ((IMetaFormProvider)_provider.Forms).Update(axForm, msi);
                     return new { success = true, operation = "add-data-source", objectType, objectName, dsName, table, api = "IMetaFormProvider.Update" };

--- a/src/tools/d365foFileOpSpecs.ts
+++ b/src/tools/d365foFileOpSpecs.ts
@@ -321,6 +321,9 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
       'controlDataSource', 'controlDataField', 'controlType', 'controlLabel',
       'positionType', 'previousSibling', 'baseFormName',
     ],
+    note: 'objectType="form": parentControl="Design" adds the control at the TOP LEVEL of the '
+      + 'form design — use it for the first control on a form whose design is still empty. '
+      + 'Otherwise pass the exact name of an existing container (Tab, TabPage, Group, Grid).',
   },
   'add-enum-value': {
     required: ['enumValueName'],

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -528,7 +528,13 @@ export function isUnresolvedObjectError(message: string | undefined): boolean {
   // resolution and must not trigger the refresh+retry or the "could not resolve"
   // guidance: replace-code's "oldCode not found in <obj>.<method>", a missing
   // method/field/index, etc. The object was resolved — only the snippet/member wasn't.
-  if (/\b(oldcode|new ?code|code|snippet|method|field|index|relation|element)\b[^.]*\bnot found/i.test(message)) {
+  //
+  // `control` / `data source` are in this list because the bridge's add-control
+  // failure reads "Parent control 'X' not found in form 'Y'" — the form WAS read
+  // successfully. Misclassifying it as unresolved produced the factually wrong
+  // "the C# metadata bridge could not find '<form>' in its metadata model"
+  // (corpus: 2026-07-21T18__L2-form-modify-controls__c262b19).
+  if (/\b(oldcode|new ?code|code|snippet|method|field|index|relation|element|control|data ?source|value)\b[^.]*\bnot found/i.test(message)) {
     return false;
   }
   // Genuine object-resolution failures: a quoted object name "'X' not found",
@@ -555,11 +561,11 @@ function unresolvedObjectError(
     `This is typical right after creating an object in the same session — the bridge's metadata ` +
     `roots are fixed at startup, so a file written this session may not be in its model.\n` +
     `Auto-refresh was already attempted once and still failed.\n\n` +
-    `Reliable fallback (works for tables, forms, classes created this session):\n` +
-    `  Read ${objectName}.xml with get_object_info, add the ${operation.replace('add-', '')} ` +
-    `element directly to the XML, then re-write the whole file:\n` +
-    `  d365fo_file(action="create", overwrite=true, xmlContent="<complete updated XML>")\n\n` +
-    `Alternative — try in order:\n` +
+    // Deliberately NOT suggesting `d365fo_file(action="create", overwrite=true,
+    // xmlContent=...)` here: rewriting a whole object from hand-authored XML is the
+    // exact escape hatch that loses metadata the provider would have written, and it
+    // is never the right remedy for a *modify* failure. Fix the resolution instead.
+    `Try in order:\n` +
     `  1. update_symbol_index({ filePath: "<path to ${objectName}.xml>" })\n` +
     `  2. Check D365FO_CUSTOM_PACKAGES_PATH points to the correct metadata folder.\n` +
     `  3. Confirm ${objectName}.xml actually exists on disk.\n` +
@@ -665,9 +671,12 @@ const ModifyD365FileArgsSchema = z.object({
     'e.g. "MyCustPriorityTier". Used as <Name> inside <FormControl>.'
   ),
   parentControl: z.string().optional().describe(
-    'Name of the existing parent control/tab/group in the base form to insert into. ' +
+    'Name of the existing parent control/tab/group to insert into. ' +
     'e.g. "TabGeneral", "HeaderGroup", "TabPageSales". ' +
-    'Becomes the <Parent> element of the AxFormExtensionControl wrapper.'
+    'On objectType="form", pass "Design" to add the control at the TOP LEVEL of the form ' +
+    'design (required for the first control on a form whose design is still empty). ' +
+    'On objectType="form-extension" it becomes the <Parent> element of the ' +
+    'AxFormExtensionControl wrapper.'
   ),
   controlDataSource: z.string().optional().describe(
     'Data source name for the new control binding (e.g. "CustTable"). ' +
@@ -1791,6 +1800,15 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         );
       }
       let opErrorMsg = `Bridge operation '${operation}' failed: ${bridgeResult!.message}`;
+      if (operation === 'add-control' && /parent control .* not found/i.test(bridgeResult!.message ?? '')) {
+        opErrorMsg +=
+          `\n\n💡 The ${objectType} '${objectName}' WAS found — only the parent container was not.\n` +
+          `  • To add a control at the TOP LEVEL of the form design, pass parentControl="Design".\n` +
+          `  • Otherwise list the existing containers first: get_object_info(objectType="${objectType}", name="${objectName}")\n` +
+          `    and pass the exact container name (e.g. a Tab, TabPage, Group or Grid) as parentControl.\n` +
+          `  • Do not rewrite the whole object from hand-authored XML — it loses metadata the ` +
+          `provider writes for you. Fix the parentControl instead.`;
+      }
       if (operation === 'replace-code' && /oldCode not found/i.test(bridgeResult!.message ?? '')) {
         opErrorMsg +=
           `\n\n💡 Tip: The oldCode must match the exact source currently on disk.\n` +

--- a/tests/bridge/formAuthoringDefaults.test.ts
+++ b/tests/bridge/formAuthoringDefaults.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression tests — C# bridge form-authoring defaults
+ *
+ * Corpus evidence:
+ *   eval/corpus/runs/2026-07-21T18__L2-form-modify-controls__c262b19.json
+ *
+ * Defects pinned here (all on bridge/D365MetadataBridge/Services/MetadataWriteService.cs):
+ *
+ *  (#8)  AddControl resolved its parent with FindControlRecursive(design, parentControl),
+ *        which only walks design.Controls and can never return the design ROOT. A form
+ *        whose design has no controls could never receive its FIRST top-level control —
+ *        every parentControl value failed by construction, blocking the whole
+ *        form-lifecycle coverage leaf.
+ *  (#9)  CreateForm accepted properties.dataSource and silently dropped it.
+ *  (#10) CreateForm emitted no classDeclaration, so xppc rejected every bridge-created
+ *        form with "The 'classDeclaration' is missing from element '<Form>'".
+ *
+ * The behavioural half of #8/#10 is exercised for real: FormAuthoringDefaults.cs is
+ * deliberately free of any Microsoft.Dynamics.* reference, so this test compiles it with
+ * the plain .NET SDK and runs it — no AOS, no metadata model, no VM. If `dotnet` is not
+ * on PATH the behavioural block skips and the structural assertions still run.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BRIDGE_SERVICES = path.join(REPO_ROOT, 'bridge', 'D365MetadataBridge', 'Services');
+const HELPER_CS = path.join(BRIDGE_SERVICES, 'FormAuthoringDefaults.cs');
+const WRITE_SERVICE_CS = path.join(BRIDGE_SERVICES, 'MetadataWriteService.cs');
+
+const hasDotnet = (): boolean => {
+  const r = spawnSync('dotnet', ['--version'], { stdio: 'ignore', shell: true });
+  return r.status === 0;
+};
+
+// ─── Structural assertions (always run — no toolchain required) ───────────────
+
+describe('MetadataWriteService form-authoring wiring (structural)', () => {
+  let src = '';
+  beforeAll(() => {
+    src = fs.readFileSync(WRITE_SERVICE_CS, 'utf-8');
+  });
+
+  it('AddControl falls back to the design root when parentControl is a sentinel', () => {
+    const addControl = src.slice(
+      src.indexOf('public object AddControl('),
+      src.indexOf('public object AddDataSource('),
+    );
+    expect(addControl).not.toBe('');
+    expect(addControl).toContain('FormAuthoringDefaults.IsDesignRootSentinel(parentControl, formName)');
+    // The recursive lookup must still be tried FIRST, so a control genuinely named
+    // "Design" keeps resolving to itself rather than to the design container.
+    expect(addControl.indexOf('FindControlRecursive(design, parentControl)'))
+      .toBeLessThan(addControl.indexOf('IsDesignRootSentinel'));
+  });
+
+  it('CreateForm supplies a classDeclaration when the caller did not', () => {
+    const createForm = src.slice(
+      src.indexOf('public object CreateForm('),
+      src.indexOf('public object CreateMenu('),
+    );
+    expect(createForm).not.toBe('');
+    expect(createForm).toContain('FormAuthoringDefaults.IsClassDeclarationMethod');
+    expect(createForm).toContain('FormAuthoringDefaults.DefaultFormClassDeclaration(name)');
+  });
+
+  it('CreateForm honours properties.dataSource instead of dropping it', () => {
+    const createForm = src.slice(
+      src.indexOf('public object CreateForm('),
+      src.indexOf('public object CreateMenu('),
+    );
+    expect(createForm).toContain('case "datasource":');
+    expect(createForm).toContain('CreateFormDataSourceRoot');
+  });
+
+  it('CreateForm reports any property key it could not apply (no silent drop)', () => {
+    const createForm = src.slice(
+      src.indexOf('public object CreateForm('),
+      src.indexOf('public object CreateMenu('),
+    );
+    expect(createForm).toContain('unknownProperties');
+    expect(createForm).toContain('warnings');
+  });
+});
+
+// ─── Behavioural assertions (compile + run the pure helper with the .NET SDK) ─
+
+const HARNESS_MAIN = `
+using System;
+using System.Collections.Generic;
+using D365MetadataBridge.Services;
+
+public static class Harness
+{
+    public static void Main()
+    {
+        // parentControl values that MUST resolve to the form design root
+        string[] sentinels = { "Design", "design", "  Design  ", "FormDesign", "Root", "", "   ", "MyForm", "MyFormDesign" };
+        foreach (var s in sentinels)
+            Console.WriteLine("sentinel|" + s + "|" + FormAuthoringDefaults.IsDesignRootSentinel(s, "MyForm"));
+
+        Console.WriteLine("sentinel|<null>|" + FormAuthoringDefaults.IsDesignRootSentinel(null, "MyForm"));
+
+        // values that must NOT be treated as the design root
+        string[] nonSentinels = { "TabGeneral", "HeaderGroup", "Grid", "DesignTab", "MyFormGrid" };
+        foreach (var s in nonSentinels)
+            Console.WriteLine("nonsentinel|" + s + "|" + FormAuthoringDefaults.IsDesignRootSentinel(s, "MyForm"));
+
+        Console.WriteLine("decl|" + FormAuthoringDefaults.IsClassDeclarationMethod("classDeclaration"));
+        Console.WriteLine("decl|" + FormAuthoringDefaults.IsClassDeclarationMethod("ClassDeclaration"));
+        Console.WriteLine("decl|" + FormAuthoringDefaults.IsClassDeclarationMethod("init"));
+        Console.WriteLine("decl|" + FormAuthoringDefaults.IsClassDeclarationMethod(null));
+
+        Console.WriteLine("source|" + FormAuthoringDefaults.DefaultFormClassDeclaration("MyForm").Replace("\\n", "\\\\n"));
+    }
+}
+`;
+
+const HARNESS_CSPROJ = `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <AssemblyName>FormAuthoringDefaultsHarness</AssemblyName>
+    <RootNamespace>Harness</RootNamespace>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <StartupObject>Harness</StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="FormAuthoringDefaults.cs" />
+  </ItemGroup>
+</Project>
+`;
+
+describe.runIf(hasDotnet())('FormAuthoringDefaults (compiled + executed)', () => {
+  let output = '';
+
+  beforeAll(() => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fad-harness-'));
+    fs.copyFileSync(HELPER_CS, path.join(dir, 'FormAuthoringDefaults.cs'));
+    // internal → public so the harness in another assembly can call it
+    const helper = fs.readFileSync(path.join(dir, 'FormAuthoringDefaults.cs'), 'utf-8')
+      .replace('internal static class FormAuthoringDefaults', 'public static class FormAuthoringDefaults');
+    fs.writeFileSync(path.join(dir, 'FormAuthoringDefaults.cs'), helper, 'utf-8');
+    fs.writeFileSync(path.join(dir, 'Program.cs'), HARNESS_MAIN, 'utf-8');
+    fs.writeFileSync(path.join(dir, 'Harness.csproj'), HARNESS_CSPROJ, 'utf-8');
+
+    output = execFileSync('dotnet', ['run', '--project', path.join(dir, 'Harness.csproj'), '-v', 'q', '--nologo'], {
+      encoding: 'utf-8',
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  }, 300_000);
+
+  const lines = () => output.split(/\r?\n/).filter(Boolean);
+
+  it('treats every design-root spelling as the design container', () => {
+    const results = lines().filter((l) => l.startsWith('sentinel|'));
+    expect(results.length).toBeGreaterThanOrEqual(10);
+    for (const r of results) {
+      expect(r, `expected design-root sentinel: ${r}`).toMatch(/\|True$/);
+    }
+  });
+
+  it('does not swallow a real container name as a design-root sentinel', () => {
+    const results = lines().filter((l) => l.startsWith('nonsentinel|'));
+    expect(results.length).toBe(5);
+    for (const r of results) {
+      expect(r, `expected NOT a sentinel: ${r}`).toMatch(/\|False$/);
+    }
+  });
+
+  it('recognises classDeclaration case-insensitively and nothing else', () => {
+    const results = lines().filter((l) => l.startsWith('decl|'));
+    expect(results).toEqual(['decl|True', 'decl|True', 'decl|False', 'decl|False']);
+  });
+
+  it('emits a compilable form class declaration', () => {
+    const src = lines().find((l) => l.startsWith('source|'))!.slice('source|'.length);
+    expect(src).toContain('[Form]');
+    expect(src).toContain('public class MyForm extends FormRun');
+  });
+});

--- a/tests/tools/addControlDesignRoot.test.ts
+++ b/tests/tools/addControlDesignRoot.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression tests — add-control on the form DESIGN ROOT
+ *
+ * Corpus evidence:
+ *   eval/corpus/runs/2026-07-21T18__L2-form-modify-controls__c262b19.json
+ *
+ * Two defects are pinned here, both on the `add-control` path:
+ *
+ *  (#8) The C# bridge resolved `parentControl` purely with
+ *       `FindControlRecursive(design, parentControl)`, which only ever walks
+ *       `design.Controls` and can therefore never return the design ROOT. A form whose
+ *       design has no controls yet could not receive its FIRST top-level control, so
+ *       every `parentControl` value failed by construction. The bridge-side fix lives in
+ *       FormAuthoringDefaults.IsDesignRootSentinel (covered by
+ *       tests/bridge/formAuthoringDefaults.test.ts); this file pins the TS contract that
+ *       "Design" is the documented way to address the design root.
+ *
+ * (#11) When the bridge said "Parent control 'Design' not found in form 'X'", the TS
+ *       layer misclassified it as an OBJECT-resolution failure and told the caller the
+ *       bridge "could not find '<form>' in its metadata model" — factually wrong, the
+ *       form had just been read. The attached "Reliable fallback" then recommended
+ *       `d365fo_file(action="create", overwrite=true, xmlContent=...)`, i.e. the
+ *       hand-authored-XML escape hatch the eval loop exists to prevent.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool, isUnresolvedObjectError } from '../../src/tools/modifyD365File';
+import { D365FO_FILE_OP_SPECS } from '../../src/tools/d365foFileOpSpecs';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// ─── Bridge mock ─────────────────────────────────────────────────────────────
+
+const { mockBridgeAddControl, mockBridgeRefreshProvider } = vi.hoisted(() => ({
+  mockBridgeAddControl: vi.fn(),
+  mockBridgeRefreshProvider: vi.fn(async () => ({ success: true })),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return {
+    ...actual,
+    bridgeAddControl: mockBridgeAddControl,
+    bridgeRefreshProvider: mockBridgeRefreshProvider,
+    bridgeValidateAfterWrite: vi.fn(async () => null),
+  };
+});
+
+// ─── Module mocks (same shape as form-control-method-inplace.test.ts) ─────────
+
+/** Form whose design has NO controls — the exact shape that used to be unfixable. */
+const EMPTY_DESIGN_FORM_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>ConDemoCtrlNoteForm</Name>
+\t<SourceCode>
+\t\t<Methods xmlns="" />
+\t</SourceCode>
+\t<DataSources />
+\t<Design>
+\t\t<Controls xmlns="" />
+\t</Design>
+</AxForm>`;
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (p.endsWith('.xml')) return EMPTY_DESIGN_FORM_XML;
+    if (p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+  copyFile: vi.fn(async () => {}),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (m: string) => ({
+      packageName: m,
+      modelName: m,
+      rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({
+      packageName: p,
+      modelName: m,
+      rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+const FORM_FILE_PATH =
+  'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxForm\\ConDemoCtrlNoteForm.xml';
+
+const req = (name: string, args: Record<string, unknown> = {}): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name, arguments: args },
+});
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare: vi.fn(() => stmt) },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {}),
+      generateSearchKey: vi.fn((q: string) => `k:${q}`),
+    } as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    bridge: { isReady: true, metadataAvailable: true } as any,
+  };
+};
+
+const addControlReq = (parentControl: string) =>
+  req('modify_d365fo_file', {
+    objectType: 'form',
+    objectName: 'ConDemoCtrlNoteForm',
+    operation: 'add-control',
+    controlName: 'SubjectField',
+    parentControl,
+    controlDataSource: 'ConDemoCtrlNote',
+    controlDataField: 'Subject',
+    controlType: 'String',
+    filePath: FORM_FILE_PATH,
+  });
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('add-control: addressing the form design root', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    mockBridgeAddControl.mockReset();
+    mockBridgeRefreshProvider.mockClear();
+  });
+
+  it('forwards parentControl="Design" to the bridge unchanged (design-root sentinel)', async () => {
+    mockBridgeAddControl.mockResolvedValue({
+      success: true,
+      message: "✅ Control 'SubjectField' added to 'Design'",
+    });
+
+    const result = await modifyD365FileTool(addControlReq('Design'), ctx);
+
+    expect(result.isError).toBeFalsy();
+    expect(mockBridgeAddControl).toHaveBeenCalledTimes(1);
+    // parentControl is argument #4 (bridge, objectName, controlName, parentControl, …)
+    expect(mockBridgeAddControl.mock.calls[0][3]).toBe('Design');
+  });
+
+  it('documents "Design" as the way to reach the top level of a form design', () => {
+    const spec = D365FO_FILE_OP_SPECS['add-control'];
+    expect(spec).toBeTruthy();
+    expect(spec!.note ?? '').toMatch(/parentControl="Design"/);
+  });
+
+  describe('when the bridge reports a genuine parent-control-not-found', () => {
+    const BRIDGE_MSG = "Parent control 'TabGeneral' not found in form 'ConDemoCtrlNoteForm'";
+
+    beforeEach(() => {
+      mockBridgeAddControl.mockResolvedValue({ success: false, message: BRIDGE_MSG });
+    });
+
+    it('is NOT classified as an object-resolution failure', () => {
+      expect(isUnresolvedObjectError(BRIDGE_MSG)).toBe(false);
+      // …while a real object-resolution failure still is.
+      expect(isUnresolvedObjectError("Form 'ConDemoCtrlNoteForm' not found")).toBe(true);
+    });
+
+    it('does not claim the form itself could not be found', async () => {
+      const result = await modifyD365FileTool(addControlReq('TabGeneral'), ctx);
+
+      expect(result.isError).toBeTruthy();
+      const text = result.content[0].text as string;
+      expect(text).toContain(BRIDGE_MSG);
+      expect(text).not.toMatch(/could not resolve form/i);
+      expect(text).not.toMatch(/could not find .* in its metadata model/i);
+    });
+
+    it('never suggests create overwrite=true / hand-authored xmlContent as the remedy', async () => {
+      const result = await modifyD365FileTool(addControlReq('TabGeneral'), ctx);
+      const text = result.content[0].text as string;
+
+      expect(text).not.toMatch(/overwrite=true/);
+      expect(text).not.toMatch(/xmlContent="<complete updated XML>"/);
+    });
+
+    it('points at parentControl="Design" for a top-level control instead', async () => {
+      const result = await modifyD365FileTool(addControlReq('TabGeneral'), ctx);
+      const text = result.content[0].text as string;
+
+      expect(text).toMatch(/parentControl="Design"/);
+    });
+  });
+});
+
+describe('unresolvedObjectError guidance (all modify operations)', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    mockBridgeAddControl.mockReset();
+  });
+
+  it('does not offer the hand-authored-XML rewrite for a real resolution failure either', async () => {
+    mockBridgeAddControl.mockResolvedValue({
+      success: false,
+      message: "Form 'ConDemoCtrlNoteForm' not found",
+    });
+
+    const result = await modifyD365FileTool(addControlReq('Design'), ctx);
+
+    expect(result.isError).toBeTruthy();
+    const text = result.content[0].text as string;
+    expect(text).toMatch(/could not resolve/i); // this one IS a resolution failure
+    expect(text).not.toMatch(/overwrite=true/);
+  });
+});


### PR DESCRIPTION
## Cluster

Top actionable **TOOL_DEFECT** cluster from the 2026-07-21 golden-capture sweep: the
**form authoring surface** (`d365fo_file` create-form + `modify add-control`).

Corpus evidence:
- `eval/corpus/runs/2026-07-21T18__L2-form-modify-controls__c262b19.json`
- `eval/corpus/runs/2026-07-21T18__L2-table-modify-lifecycle__c262b19.json`

## The blocking defect (#8)

`MetadataWriteService.AddControl` resolved its parent with
`FindControlRecursive(design, parentControl)` alone. That helper only ever iterates
`container.Controls`, so **it can never return the design root**. A form whose design has no
controls yet could therefore never receive its *first* top-level control — every
`parentControl` value failed by construction ("Design", the form name, before/after
`update_symbol_index`, after a clean build: all identical).

Blast radius: eval cases `L2-form-modify-controls` **and** `L3-form-add-datasource-lines`,
i.e. the whole `form-lifecycle` core coverage leaf.

Fix: `AddControl` falls back to the design container when `parentControl` is a design-root
sentinel (`"Design"`, `"FormDesign"`, `"Root"`, the form name, `"<Form>Design"`,
empty/omitted). The recursive lookup runs **first**, so a control genuinely named `Design`
still resolves to itself.

> Note for reviewers: the older mined defect this case targeted (`AxFormControl{Type}` vs
> `AxForm{Type}Control` type resolution) is genuinely fixed and was verified by the sweep —
> `add-control` into an *existing* container already writes correct XML. This was an
> adjacent, still-open defect.

## Also fixed in the same cluster

| # | Defect | Fix |
|---|--------|-----|
| 10 | `CreateForm` emitted no `classDeclaration`, so xppc rejected **every** bridge-created form (`The 'classDeclaration' is missing from element '<Form>'`) | supplies the standard `[Form] / extends FormRun` declaration when the caller did not, matching `GenerateD365Xml.generateAxFormXml` |
| 9 | `properties.dataSource` accepted and silently dropped → empty `<DataSources />` | honoured via the extracted `CreateFormDataSourceRoot` (now shared with `AddDataSource`); any property key the create path cannot apply is returned as an explicit `warnings` entry rather than vanishing |
| 11 | `"Parent control 'X' not found in form 'Y'"` was misclassified as an **object**-resolution failure, so the tool reported the bridge "could not find `<form>` in its metadata model" — factually wrong — and its "Reliable fallback" recommended `d365fo_file(action="create", overwrite=true, xmlContent=…)`, the hand-authored-XML escape hatch the eval loop exists to prevent | `isUnresolvedObjectError` no longer swallows control/data-source failures; the XML-rewrite suggestion is removed from the modify remedy path entirely; `add-control` failures now point at `parentControl="Design"` |

## Repro tests (VM-free)

- `tests/bridge/formAuthoringDefaults.test.ts` — the pure sentinel / classDeclaration logic
  now lives in a **dependency-free** `FormAuthoringDefaults.cs` (no `Microsoft.Dynamics.*`
  reference), which this test **compiles and runs with the plain .NET SDK** — no AOS, no
  metadata model, no VM. Plus structural assertions that `AddControl` / `CreateForm` are
  actually wired to it. The behavioural block skips cleanly if `dotnet` is absent.
- `tests/tools/addControlDesignRoot.test.ts` — TS layer: `parentControl="Design"` reaches
  the bridge unchanged, a parent-not-found is not reported as a missing form, and neither
  error path offers `overwrite=true` / hand-authored `xmlContent`.

**10 of the 15 new assertions fail on `main`**, all 15 pass on this branch.

## Validation

- `npx vitest run` → **1910 passed**, 2 skipped. Three failures, all pre-existing and
  unrelated, confirmed by re-running with this branch's source changes stashed:
  - `tests/eval/oracleCli.test.ts` ×2 — the fixture case it pins is no longer
    `golden_pending` after the sweep captured its golden (uncommitted eval work).
  - `tests/knowledge/apiSymbols.test.ts` — known cold-cache 120 s timeout on the 2 GB
    symbol DB; passes in 1.8 s warm.
- `npx tsc --noEmit` → clean.
- `npm run eval:report` → unchanged (40 runs, build 73% / bp 40% / golden 23%); this change
  touches no scoring code, so the held-out split cannot move.

## ⚠️ Bridge binary is NOT live yet

The C# **compiles clean** against the local metamodel, but the output could not be copied
into `bin/Release/`: two `D365MetadataBridge.exe` processes are running and hold the file.
`bin/Release/D365MetadataBridge.exe` is therefore still the pre-fix binary.

To pick the fix up on the VM: **close the MCP clients** (so the bridge processes exit), then

```
dotnet build bridge/D365MetadataBridge/D365MetadataBridge.csproj -c Release
```

and restart the MCP server. Until that is done, defects #8/#9/#10 remain live at runtime —
only the TS-side #11 fix takes effect from a plain server restart.

## Deferred

The table-side silent-success family is a real hazard of the same class but a different
surface, and the guard is not small — deferred to a follow-up:
**#5** `add-relation` dropping `relationCardinality` / `relatedTableCardinality` /
`relationshipType`, **#6** `modify-field` reporting success for an unrecognised param key,
and `add-index` accepting `allowDuplicates` instead of `indexAllowDuplicates`.

Not auto-merged — please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
