### PR TITLE
fix(modify): let add-index complete for same-session tables (cluster #16/#23/#29)

### DIFF
--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -516,6 +516,93 @@ async function directXmlAddControl(
 }
 
 /**
+ * Direct XML fallback for add-index on a TABLE.
+ *
+ * The C# bridge's AddIndex resolves its target via _provider.Tables.Read(name),
+ * whose DiskProvider metadata roots are fixed at bridge startup. A table CREATED
+ * THIS SESSION is therefore reported "Table '<name>' not found" — even after
+ * update_symbol_index and even when an explicit filePath was supplied (filePath
+ * only steers the TS-side file lookup, never the bridge's own name resolution).
+ * Corpus evidence: 2026-07-21T19__L2-error-handling-infolog (add-index on
+ * ConDemoTicket failed 3×) and 2026-07-21T20__L3-workflow-document-submit
+ * (add-index on ConDemoWfRequest). With no working grounded path the only way to
+ * land the index was d365fo_file(action="create", overwrite=true) — the whole-file
+ * escape hatch the eval loop forbids.
+ *
+ * This writes an <AxTableIndex> element straight into the table's <Indexes>
+ * collection, in the exact shape the D365FO SDK serialises (verified against a
+ * captured golden): <Name>, <AllowDuplicates>, optional <AlternateKey>, then
+ * <Fields> of <AxTableIndexField><DataField>. <Indexes> is a collection sibling,
+ * NOT part of the order-sensitive top-level property block, so appending to it is
+ * safe. It edits the file on disk, so it is unaffected by what the bridge loaded.
+ */
+async function directXmlAddIndex(
+  filePath: string,
+  indexName: string,
+  fields: string[] | undefined,
+  allowDuplicates: boolean | undefined,
+  alternateKey: boolean | undefined,
+): Promise<{ success: boolean; message: string } | null> {
+  try {
+    const rawContent = await fs.readFile(filePath, 'utf-8');
+    const content = rawContent.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+    // Only tables carry an <Indexes> collection — bail on any other shape so a
+    // mis-typed objectType never corrupts a non-table file.
+    if (!/<AxTable\b/.test(content)) return null;
+
+    // Idempotent: if an index with this name already exists, report success
+    // rather than writing a duplicate (mirrors directXmlAddControl).
+    if (new RegExp(`<AxTableIndex>\\s*<Name>${indexName}</Name>`).test(content)) {
+      return {
+        success: true,
+        message: `✅ Index '${indexName}' already present in ${filePath} — skipped (idempotent).`,
+      };
+    }
+
+    const fieldElements = (fields ?? [])
+      .map(f =>
+        `\t\t\t\t<AxTableIndexField>\n` +
+        `\t\t\t\t\t<DataField>${f}</DataField>\n` +
+        `\t\t\t\t</AxTableIndexField>`)
+      .join('\n');
+    const fieldsBlock = fieldElements
+      ? `\t\t\t<Fields>\n${fieldElements}\n\t\t\t</Fields>`
+      : `\t\t\t<Fields />`;
+
+    const newElement =
+      `\t\t<AxTableIndex>\n` +
+      `\t\t\t<Name>${indexName}</Name>\n` +
+      `\t\t\t<AllowDuplicates>${allowDuplicates ? 'Yes' : 'No'}</AllowDuplicates>\n` +
+      (alternateKey ? `\t\t\t<AlternateKey>Yes</AlternateKey>\n` : '') +
+      `${fieldsBlock}\n` +
+      `\t\t</AxTableIndex>`;
+
+    let updated: string;
+    if (content.includes('<Indexes />')) {
+      updated = content.replace('<Indexes />', `<Indexes>\n${newElement}\n\t</Indexes>`);
+    } else if (content.includes('</Indexes>')) {
+      updated = content.replace('</Indexes>', `${newElement}\n\t</Indexes>`);
+    } else {
+      // No <Indexes> collection at all — not a shape we can safely patch.
+      return null;
+    }
+
+    if (updated === content) return null;
+
+    await fs.writeFile(filePath, normalizeD365Xml(updated), 'utf-8');
+    console.error(`[modify_d365fo_file] ✅ directXmlAddIndex: added '${indexName}' to ${filePath}`);
+    return {
+      success: true,
+      message: `✅ Index '${indexName}' added via direct XML fallback (bridge could not resolve the same-session table). File: ${filePath}`,
+    };
+  } catch (err) {
+    console.error(`[modify_d365fo_file] directXmlAddIndex failed: ${err}`);
+    return null;
+  }
+}
+
+/**
  * Heuristic: does a bridge failure message indicate the C# provider could not
  * resolve the target object (vs. a genuine operation error like "index already
  * exists")? An unresolved object is the one failure worth a refresh+retry,
@@ -1411,6 +1498,23 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             (args as any).indexAllowDuplicates,
             (args as any).indexAlternateKey,
           );
+          // Fallback: the bridge's AddIndex resolves the table via
+          // _provider.Tables.Read, whose metadata roots are fixed at startup, so a
+          // table CREATED THIS SESSION reports "Table '<name>' not found" — even
+          // after update_symbol_index and even when an explicit filePath was
+          // supplied (see corpus L2-error-handling-infolog / L3-workflow-document-
+          // submit). Rather than push the agent into the forbidden whole-file
+          // overwrite, write the index straight into the on-disk XML.
+          if (!bridgeResult || !bridgeResult.success) {
+            const xmlFallbackResult = await directXmlAddIndex(
+              actualFilePath,
+              (args as any).indexName,
+              indexFieldNames,
+              (args as any).indexAllowDuplicates,
+              (args as any).indexAlternateKey,
+            );
+            if (xmlFallbackResult) bridgeResult = xmlFallbackResult;
+          }
         }
         break;
       }

--- a/tests/tools/addIndexSameSession.test.ts
+++ b/tests/tools/addIndexSameSession.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Regression tests — add-index on a table CREATED THIS SESSION
+ *
+ * Corpus evidence:
+ *   eval/corpus/runs/2026-07-21T19__L2-error-handling-infolog__c262b19.json
+ *   eval/corpus/runs/2026-07-21T20__L3-workflow-document-submit__c262b19.json
+ *
+ * Defect cluster #16 / #23 / #29 (all on the bridge-backed modify surface):
+ *
+ *  The C# bridge's AddIndex resolves its table via _provider.Tables.Read(name),
+ *  whose DiskProvider metadata roots are fixed at bridge startup. A table created
+ *  earlier in the SAME session is therefore reported "Table '<name>' not found" —
+ *  even after a successful update_symbol_index(filePath) and even when an explicit
+ *  filePath was supplied (filePath only steers the TS-side file lookup, never the
+ *  bridge's own name resolution — #23). With no working grounded path, every
+ *  table-shaped case in the sweep was forced into d365fo_file(action="create",
+ *  overwrite=true) — the whole-file escape hatch the eval loop forbids (HEADLINE 2).
+ *
+ *  The C# resolution itself needs the live Microsoft.Dynamics metadata provider and
+ *  cannot be exercised VM-free, so the fix lands TS-side: when the bridge cannot
+ *  resolve the same-session table, add-index now writes the <AxTableIndex> straight
+ *  into the on-disk <Indexes> collection (directXmlAddIndex) — the same direct-XML
+ *  fallback pattern that already backs modify-property / replace-code /
+ *  add-menu-item-to-menu / add-control(form-extension). These tests pin that the
+ *  grounded op now COMPLETES instead of dead-ending, in the exact serialised shape.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool } from '../../src/tools/modifyD365File';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// ─── Bridge mock: simulate the same-session resolution failure ────────────────
+
+const { mockBridgeAddIndex, mockBridgeRefreshProvider } = vi.hoisted(() => ({
+  mockBridgeAddIndex: vi.fn(),
+  mockBridgeRefreshProvider: vi.fn(async () => ({ success: true, elapsedMs: 1 })),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return {
+    ...actual,
+    bridgeAddIndex: mockBridgeAddIndex,
+    bridgeRefreshProvider: mockBridgeRefreshProvider,
+    bridgeValidateAfterWrite: vi.fn(async () => null),
+  };
+});
+
+// ─── fs/promises mock (capture writeFile output) ──────────────────────────────
+
+/** A table created this session, still with an EMPTY <Indexes /> collection. */
+const TABLE_NO_INDEX_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoTicket</Name>
+\t<SourceCode>
+\t\t<Declaration><![CDATA[
+public class ConDemoTicket extends common
+{
+}
+]]></Declaration>
+\t\t<Methods />
+\t</SourceCode>
+\t<Label>@TaxTransactionInquiry:HeaderNote</Label>
+\t<TitleField1>TicketId</TitleField1>
+\t<DeleteActions />
+\t<FieldGroups />
+\t<Fields>
+\t\t<AxTableField xmlns="" i:type="AxTableFieldString">
+\t\t\t<Name>TicketId</Name>
+\t\t\t<ExtendedDataType>Num</ExtendedDataType>
+\t\t</AxTableField>
+\t</Fields>
+\t<FullTextIndexes />
+\t<Indexes />
+\t<Mappings />
+\t<Relations />
+\t<StateMachines />
+</AxTable>`;
+
+const { mockWriteFile } = vi.hoisted(() => ({ mockWriteFile: vi.fn(async () => {}) }));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (typeof p === 'string' && p.endsWith('.xml')) return TABLE_NO_INDEX_XML;
+    if (typeof p === 'string' && p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: mockWriteFile,
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+  copyFile: vi.fn(async () => {}),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (m: string) => ({
+      packageName: m,
+      modelName: m,
+      rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({
+      packageName: p,
+      modelName: m,
+      rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+const TABLE_FILE_PATH =
+  'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\ConDemoTicket.xml';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'modify_d365fo_file', arguments: args },
+});
+
+const addIndexReq = (extra: Record<string, unknown> = {}) =>
+  req({
+    objectType: 'table',
+    objectName: 'ConDemoTicket',
+    operation: 'add-index',
+    indexName: 'TicketIdx',
+    indexFields: [{ fieldName: 'TicketId' }],
+    indexAlternateKey: true,
+    filePath: TABLE_FILE_PATH,
+    ...extra,
+  });
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare: vi.fn(() => stmt) },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {}),
+      generateSearchKey: vi.fn((q: string) => `k:${q}`),
+    } as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    bridge: { isReady: true, metadataAvailable: true } as any,
+  };
+};
+
+/** Return the XML content of the writeFile call that landed the index. */
+const capturedIndexXml = (): string | undefined => {
+  const call = mockWriteFile.mock.calls.find(
+    (c: any[]) => typeof c[1] === 'string' && c[1].includes('<AxTableIndex>'),
+  );
+  return call?.[1] as string | undefined;
+};
+
+describe('add-index on a same-session table (bridge cannot resolve it)', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    mockBridgeAddIndex.mockReset();
+    mockBridgeRefreshProvider.mockClear();
+    mockWriteFile.mockClear();
+  });
+
+  // The exact bridge failure the corpus recorded: the C# provider's fixed
+  // metadata roots don't contain the table written this session.
+  const RESOLUTION_FAILURE = { success: false, message: "Table 'ConDemoTicket' not found" };
+
+  it('completes via the direct-XML fallback instead of dead-ending', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+
+    const result = await modifyD365FileTool(addIndexReq(), ctx);
+
+    // On main this throws unresolvedObjectError (isError) — the whole point.
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text as string;
+    expect(text).toMatch(/direct XML fallback/i);
+    // The op reports SUCCESS, not the dead-end "could not resolve" GUIDANCE that
+    // used to steer the agent away (the honest one-line reason may still mention
+    // that the bridge could not resolve it — that is a note, not a failure).
+    expect(text).not.toMatch(/Bridge operation '.*' could not resolve/i);
+  });
+
+  it('never steers the agent into create overwrite=true', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+    const result = await modifyD365FileTool(addIndexReq(), ctx);
+    const text = result.content[0].text as string;
+    expect(text).not.toMatch(/overwrite=true/);
+  });
+
+  it('writes the AxTableIndex into the <Indexes> collection in canonical shape', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+
+    await modifyD365FileTool(addIndexReq(), ctx);
+
+    const xml = capturedIndexXml();
+    expect(xml).toBeTruthy();
+    // The index lands inside the <Indexes> collection, not loose in the file.
+    expect(xml).toMatch(/<Indexes>[\s\S]*<AxTableIndex>[\s\S]*<\/AxTableIndex>[\s\S]*<\/Indexes>/);
+    // Canonical element order: Name, AllowDuplicates, AlternateKey, Fields.
+    expect(xml).toMatch(
+      /<AxTableIndex>\s*<Name>TicketIdx<\/Name>\s*<AllowDuplicates>No<\/AllowDuplicates>\s*<AlternateKey>Yes<\/AlternateKey>\s*<Fields>\s*<AxTableIndexField>\s*<DataField>TicketId<\/DataField>\s*<\/AxTableIndexField>\s*<\/Fields>\s*<\/AxTableIndex>/,
+    );
+    // The empty self-closing collection must be gone.
+    expect(xml).not.toContain('<Indexes />');
+  });
+
+  it('omits <AlternateKey> when not requested and defaults AllowDuplicates to No', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+
+    await modifyD365FileTool(
+      addIndexReq({ indexAlternateKey: undefined, indexAllowDuplicates: undefined }),
+      ctx,
+    );
+
+    const xml = capturedIndexXml();
+    expect(xml).toBeTruthy();
+    expect(xml).toContain('<AllowDuplicates>No</AllowDuplicates>');
+    expect(xml).not.toContain('<AlternateKey>');
+  });
+
+  it('does not run the fallback when the bridge itself succeeded', async () => {
+    mockBridgeAddIndex.mockResolvedValue({
+      success: true,
+      message: "✅ Index 'TicketIdx' added via IMetaTableProvider.Update",
+    });
+
+    const result = await modifyD365FileTool(addIndexReq(), ctx);
+
+    expect(result.isError).toBeFalsy();
+    // The bridge wrote the index through the provider — no direct-XML write of it.
+    expect(capturedIndexXml()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The defect cluster (2026-07-21 sweep — HEADLINE 2)

The bridge-backed `modify` surface is **dead for objects created earlier in the same session**. `add-index` resolves its table via the C# provider's `_provider.Tables.Read(name)` (`bridge/D365MetadataBridge/Services/MetadataWriteService.cs:1704`), whose DiskProvider metadata roots are **fixed at bridge startup**. A table written this session is reported `Table '<name>' not found` — even after a successful `update_symbol_index(filePath)`, and even when an explicit `filePath` was supplied (`filePath` only steers the TS-side file lookup, never the bridge's own name resolution — **#23**).

With no working grounded path, every table-shaped case in the sweep was forced into `d365fo_file(action="create", overwrite=true)` — the whole-file rewrite escape hatch the eval loop forbids. `bp_clean`/`golden_match` stayed green while the tool path being *measured* was not what produced the output.

Corpus evidence:
- `eval/corpus/runs/2026-07-21T19__L2-error-handling-infolog__c262b19.json` — `add-index` on `ConDemoTicket` failed 3×, incl. after `update_symbol_index(filePath)`.
- `eval/corpus/runs/2026-07-21T20__L3-workflow-document-submit__c262b19.json` — `add-index` on `ConDemoWfRequest` with explicit `filePath`.
- `eval/corpus/runs/2026-07-21T20__L4-master-security-slice__c262b19.json` — the umbrella #29 (whole modify surface).

## Root cause confirmed (VM-free)

Read the code, not guessed:
- The `add-index` bridge call (`src/tools/modifyD365File.ts`) and the client (`src/bridge/bridgeAdapter.ts:1362`) pass **only `objectName`** — `filePath` never reaches the bridge, so it cannot influence C# resolution (**#23** proven in code).
- The C# handler does `_provider.Tables.Read(tableName) ?? throw "Table '<name>' not found"`. That `Read` needs the live `Microsoft.Dynamics.AX.Metadata` DiskProvider, which only exists on the VM (`D365BinPath` glob in the `.csproj`). **The C# resolution path is therefore not reproducible VM-free** — a valuable finding on its own.

## The fix

Because the C# disk-load fix can't be validated in-repo, the fix lands **TS-side**, mirroring the direct-XML fallback pattern that already backs `modify-property` / `replace-code` / `add-menu-item-to-menu` / `add-control(form-extension)`:

- New `directXmlAddIndex(...)` writes the `<AxTableIndex>` straight into the table's on-disk `<Indexes>` collection when the bridge cannot resolve the same-session table.
- `<Indexes>` is a collection sibling, **not** part of the order-sensitive top-level property block (finding #13), so appending is safe. Element order (`Name`, `AllowDuplicates`, optional `AlternateKey`, `Fields`) is verified byte-for-byte against a captured golden.
- Idempotent (skips if an index of that name already exists); bails on any non-table shape.

This removes the last reason a same-session table modify dead-ends, so the grounded path no longer needs the forbidden `create overwrite=true`.

## Stacking

Based on **`fix/form-design-root-add-control` (PR #728)**, not `main`, so the modify-resolution fix and the #8 form-design-root fix land in ONE bridge rebuild. This PR does **not** touch #728's methods — #728 owns the control-tree walk and the #11 diagnostic honesty change (which already removed the `overwrite=true` recommendation); this PR owns the table-resolution fallback. Distinct code paths.

## Scope note

`add-field-group` and `modify-field` are part of the same #29 family but are **deferred**: their canonical element ordering (label position, field sub-property order) is subject to the #13 silent-drop trap and cannot be verified VM-free. Emitting unverified XML there would risk corrupting a golden — better to keep #728's honest diagnostic until the ordering is captured from the VM. The fallback pattern here extends to them once that shape is confirmed.

## Validation (anti-overfitting)

- New repro `tests/tools/addIndexSameSession.test.ts`: **3 of 5 assertions fail on the base branch**, all 5 pass with the fix.
- `npx vitest run tests/tools tests/bridge` → 973 passed.
- `npx vitest run tests/eval` (incl. golden-integrity gate) → 253 passed.
- `npx tsc --noEmit` → clean.
- `npm run eval:report` runs clean (corpus scoreboard unaffected — TS fix, no scoring/golden change).

Golden re-capture on the VM after the bridge rebuild will convert the affected cases off the `overwrite=true` escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsY56fJuvoiEXjCVRR2b6M