### PR TITLE
fix(modify): stop d365fo_file(modify) discarding parameters in silence (corpus cluster #35)

### DIFF
--- a/docs/eval-sweep-findings-2026-07-21.md
+++ b/docs/eval-sweep-findings-2026-07-21.md
@@ -339,18 +339,38 @@ live AND effective: `add-control parentControl="Design"` on a zero-control desig
 `✅ Control 'ProbeGroup' added to 'Design' via IMetaFormProvider.Update`. #8 is therefore CLOSED.
 `L3-form-add-datasource-lines` went from 58 `refers to table ''` build errors to **0**.
 
-## 35. THE CLUSTER: bridge modify ops SILENTLY DISCARD optional parameters (TOOL_DEFECT, top priority)
-Accepted, `✅ success` returned, **absent from the written XML, no warning**. Proven three times
-in one sweep, and it generalises the previously separate #5 and #27 into ONE class of bug:
-- `add-relation` drops `relationshipType` / `relationCardinality` / `relatedTableCardinality`
-  (xppbp then names exactly those three) — this is #5.
-- `add-data-source` drops `linkType=Active`.
-- `add-index` drops `allowDuplicates` / `alternateKey` — related to #27.
-Consequence for scoring: the residual `bp_clean: 0` on all three form cases is **tool-gap blocked,
-not output quality** — `BPCheckAlternateKeyAbsent` is unreachable because `alternateKey` is
-dropped, and the relationship-properties rule because the relation params are dropped.
-Fix direction: a dropped/unrecognised parameter must either be serialised or reported as a
-warning — never silently accepted (same principle as #6).
+## 35. Modify ops SILENTLY DISCARD parameters (TOOL_DEFECT, top priority) — ⏳ ADDRESSED by PR #731
+
+**⚠️ CORRECTION (2026-07-22): the original "ONE class of bug" framing below was WRONG.**
+The #731 audit traced each op and found **three distinct bugs in three different layers** — and
+one of the three symptoms was not a parameter drop at all. Corrected root causes:
+
+| op | param(s) | actual root cause |
+|---|---|---|
+| `add-relation` (#5) | `relationshipType`, `relationCardinality`, `relatedTableCardinality` | TS-side drop **and** C# gap — `modifyD365File.ts` never forwards them, `bridgeClient.addRelation` has no such params, and `MetadataWriteService.AddRelation` (:1812) writes `Name`/`RelatedTable`/constraints only |
+| `modify-field` (#6) | any misspelled key (e.g. `mandatory`) | **Zod strips unknown keys** — the value vanished before any code saw it, yet the op still answered `✅ … modified via IMetaTableProvider.Update` |
+| `add-index` (#35) | `allowDuplicates` / `alternateKey` | **NOT a param drop and NOT a C# bug** — `AddIndex` (:1765) serialises both. The observed absence was an artefact of the same-session dead-end (#29) forcing the whole-file overwrite |
+| `add-index` (#27) | `indexAllowDuplicates` | Zod `boolean` vs XML `No`/`Yes` |
+| `add-data-source` | `linkType` | **C#-side only** — `CreateFormDataSourceRoot` (:1126) ignores it; the value reaches the signature and stops |
+| `add-enum-value` | `enumValueHelpText` | **NEW finding from the audit** — advertised, forwarded by nobody, no bridge param |
+
+The lead that motivated the audit (the adapter passing only `objectName`, per #23) **did not
+reproduce** on current `main`: `bridgeAddIndex`/`bridgeAddDataSource` do forward their params today.
+
+What PR #731 shipped: the op-spec registry became a parameter ledger (`findIgnoredParams()` with
+near-miss suggestions, `OP_UNHONOURED_PARAMS` as an explicit confession list), `modifyD365File.ts`
+now reads the **raw** arguments pre-Zod-strip and accounts for every key (`⚠️ … did not reach the
+written XML`), rejects mutation calls carrying no mutation param, writes the three relation
+properties on disk with their documented defaults, and coerces the index NoYes flags. It also
+folded in the orphaned `e94835f` (`directXmlAddIndex` from PR #729), which had never reached `main`.
+
+**Still open, honestly unverifiable in-repo** (the bridge cannot compile without the VM's
+`Microsoft.Dynamics.AX.Metadata` assemblies): the proper C#-side fixes for `add-data-source`
+`linkType` and `add-enum-value` `enumValueHelpText`, and the proper C# `add-relation` property
+serialisation. Those got the loud-warning treatment only — no unverified C# behavioural change.
+
+Consequence for scoring (unchanged): the residual `bp_clean: 0` on the three form cases is
+**tool-gap blocked, not output quality**.
 
 ## 36. No operation exists for table DeleteActions (TOOL_DEFECT, coverage gap)
 A cascading delete action is simply inexpressible through the tool surface.

--- a/src/tools/d365foFileOpSpecs.ts
+++ b/src/tools/d365foFileOpSpecs.ts
@@ -204,6 +204,10 @@ export const D365FO_FILE_PARAM_SPECS: Record<string, { type: string; description
   },
   // enum values
   enumValueName: { type: 'string', description: 'Enum value name (e.g. "Approved").' },
+  enumValueNewName: {
+    type: 'string',
+    description: 'modify-enum-value: rename the value located by enumValueName to this.',
+  },
   enumValueLabel: { type: 'string', description: 'Label reference (e.g. "@MyModel:Approved").' },
   enumValueHelpText: { type: 'string', description: 'Help-text reference (optional).' },
   enumValueInt: { type: 'number', description: 'Explicit integer value (omitted = next available).' },
@@ -224,6 +228,14 @@ export interface D365FileOpSpec {
   required: string[];
   /** Params the operation understands beyond the required ones. */
   optional: string[];
+  /**
+   * Optional params of which AT LEAST ONE must be supplied for the operation to
+   * mutate anything. Without one of them the op writes nothing, so reporting
+   * success would be a lie (corpus finding #6: `modify-field {fieldName,
+   * mandatory:true}` returned "✅ Field 'Description' modified" while the wrong
+   * key meant nothing was written).
+   */
+  mutationOneOf?: string[];
   /** Op-level guidance that used to live in the published schema. */
   note?: string;
 }
@@ -260,6 +272,7 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
   'modify-field': {
     required: ['fieldName'],
     optional: ['fieldType', 'fieldMandatory', 'fieldLabel', 'fieldHelpText', 'fieldEnumType', 'fieldStringSize'],
+    mutationOneOf: ['fieldType', 'fieldMandatory', 'fieldLabel', 'fieldHelpText', 'fieldEnumType', 'fieldStringSize'],
   },
   'rename-field': {
     required: ['fieldName', 'fieldNewName'],
@@ -331,7 +344,8 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
   },
   'modify-enum-value': {
     required: ['enumValueName'],
-    optional: ['enumValueLabel', 'enumValueInt'],
+    optional: ['enumValueNewName', 'enumValueLabel', 'enumValueInt'],
+    mutationOneOf: ['enumValueNewName', 'enumValueLabel', 'enumValueInt'],
   },
   'remove-enum-value': { required: ['enumValueName'], optional: [] },
   'add-menu-item-to-menu': {
@@ -340,6 +354,163 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
   },
   'modify-property': { required: ['propertyPath', 'propertyValue'], optional: [] },
 };
+
+/**
+ * Params every modify call accepts regardless of operation (routing, file
+ * resolution, project/backup handling). Anything outside this set and outside
+ * the operation's own spec is not consumed by the operation.
+ */
+export const D365FO_FILE_CORE_PARAMS: ReadonlySet<string> = new Set([
+  // routing / dispatch
+  'action', 'params', 'operation', 'objectType', 'objectName',
+  // file + model resolution
+  'filePath', 'workspacePath', 'modelName', 'model', 'packageName', 'packagePath',
+  // side options
+  'createBackup', 'addToProject', 'projectPath', 'solutionPath', 'groundingToken',
+]);
+
+/**
+ * Params an operation ADVERTISES but the write path does not actually serialise.
+ * They must never be accepted in silence — the caller has to learn that the
+ * value did not reach the XML (corpus cluster #35).
+ *
+ * Keep this list empty-by-default: an entry here is a confession, not a design.
+ * Each one is a VM-side (C#) task, tracked with the reason it cannot be honoured
+ * TS-side.
+ */
+export const OP_UNHONOURED_PARAMS: Record<string, Record<string, string>> = {
+  'add-enum-value': {
+    enumValueHelpText:
+      'nothing carries a help text for a new enum value — the dispatcher forwards name/value/label/' +
+      'countryRegionCodes only, and the bridge AddEnumValue has no helpText parameter. ' +
+      'Add the help text on the enum value afterwards in Visual Studio.',
+  },
+  'add-data-source': {
+    linkType:
+      "the bridge's AddDataSource passes linkType no further than its own signature — " +
+      'CreateFormDataSourceRoot() sets Name/Table/JoinSource only, so no <LinkType> element is written. ' +
+      'Set it afterwards on the data source in the form XML (or in Visual Studio) until the bridge is fixed.',
+  },
+};
+
+/** One parameter the caller supplied that the operation will not consume. */
+export interface IgnoredParam {
+  name: string;
+  /**
+   * unknown      — not a parameter of ANY operation (usually a misspelling)
+   * other-op     — a real parameter, but not one this operation reads
+   * not-honoured — accepted by this operation, but never written (see OP_UNHONOURED_PARAMS)
+   */
+  reason: 'unknown' | 'other-op' | 'not-honoured';
+  /** Closest parameter of THIS operation, when the name looks like a near-miss. */
+  suggestion?: string;
+  /** Why the value is dropped (for 'not-honoured'). */
+  detail?: string;
+}
+
+/** Every parameter name known to any operation (plus aliases). */
+function allKnownParamNames(): Set<string> {
+  const names = new Set<string>(Object.keys(D365FO_FILE_PARAM_SPECS));
+  for (const spec of Object.values(D365FO_FILE_OP_SPECS)) {
+    for (const p of [...spec.required, ...spec.optional]) names.add(p);
+  }
+  for (const aliases of Object.values(OP_PARAM_ALIASES)) {
+    for (const a of aliases) names.add(a);
+  }
+  return names;
+}
+
+/** Params this operation reads, including aliases of its required params. */
+function opParamNames(operation: string): string[] {
+  const spec = D365FO_FILE_OP_SPECS[operation];
+  if (!spec) return [];
+  const names = [...spec.required, ...spec.optional];
+  for (const p of spec.required) names.push(...(OP_PARAM_ALIASES[p] ?? []));
+  return names;
+}
+
+/**
+ * Near-miss suggestion for an unrecognised key: `mandatory` → `fieldMandatory`,
+ * `allowDuplicates` → `indexAllowDuplicates`, `alternateKey` → `indexAlternateKey`.
+ * Only suffix/prefix containment is used — no fuzzy distance guessing.
+ */
+function suggestParam(operation: string, key: string): string | undefined {
+  const k = key.toLowerCase();
+  const candidates = opParamNames(operation);
+  return (
+    candidates.find(p => p.toLowerCase() === k) ??
+    candidates.find(p => p.toLowerCase().endsWith(k)) ??
+    candidates.find(p => k.endsWith(p.toLowerCase()))
+  );
+}
+
+/**
+ * Parameters the caller supplied that the operation will NOT consume.
+ *
+ * The wire schema advertises a free-form `params` object and the Zod schema
+ * strips unknown keys, so a misspelled or misplaced parameter used to vanish
+ * without a trace and the op still answered "✅". Everything this returns must
+ * be surfaced to the caller.
+ */
+export function findIgnoredParams(
+  operation: string,
+  providedKeys: readonly string[],
+): IgnoredParam[] {
+  if (!D365FO_FILE_OP_SPECS[operation]) return [];
+  const known = allKnownParamNames();
+  const mine = new Set(opParamNames(operation));
+  const unhonoured = OP_UNHONOURED_PARAMS[operation] ?? {};
+
+  const ignored: IgnoredParam[] = [];
+  for (const key of providedKeys) {
+    if (D365FO_FILE_CORE_PARAMS.has(key)) continue;
+    if (mine.has(key)) {
+      if (unhonoured[key]) ignored.push({ name: key, reason: 'not-honoured', detail: unhonoured[key] });
+      continue;
+    }
+    ignored.push({
+      name: key,
+      reason: known.has(key) ? 'other-op' : 'unknown',
+      suggestion: suggestParam(operation, key),
+    });
+  }
+  return ignored;
+}
+
+/** Human-readable warning block for ignored params (empty string when none). */
+export function renderIgnoredParamsWarning(operation: string, ignored: readonly IgnoredParam[]): string {
+  if (ignored.length === 0) return '';
+  const lines = ignored.map(p => {
+    if (p.reason === 'not-honoured') {
+      return `  ⚠️ ${p.name}: NOT WRITTEN — ${p.detail}`;
+    }
+    const what = p.reason === 'unknown'
+      ? 'not a recognised d365fo_file parameter'
+      : `not read by operation '${operation}'`;
+    const hint = p.suggestion ? ` — did you mean '${p.suggestion}'?` : '';
+    return `  ⚠️ ${p.name}: IGNORED (${what})${hint}`;
+  });
+  return [
+    `⚠️ ${ignored.length} parameter(s) did not reach the written XML:`,
+    ...lines,
+    `The value(s) above were NOT applied. Re-run with the correct parameter name(s).`,
+  ].join('\n');
+}
+
+/**
+ * Reports that an operation was called with none of the params that would make
+ * it mutate anything (see D365FileOpSpec.mutationOneOf). Returns the list of
+ * candidate params, or [] when the call is fine.
+ */
+export function findMissingMutationParams(
+  operation: string,
+  providedKeys: readonly string[],
+): string[] {
+  const oneOf = D365FO_FILE_OP_SPECS[operation]?.mutationOneOf;
+  if (!oneOf || oneOf.length === 0) return [];
+  const provided = new Set(providedKeys);
+  return oneOf.some(p => provided.has(p)) ? [] : [...oneOf];
+}
 
 /** Required params for an operation ([] for unknown ops — matches old paramHints). */
 export function getRequiredParams(operation: string): string[] {

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -40,7 +40,10 @@ import {
 } from './validateFormPattern.js';
 import { validateEdtExtensionChange } from '../utils/edtExtensionValidator.js';
 import { lintXppSelect } from '../utils/xppSelectLint.js';
-import { getRequiredParams, renderOpSpec, OP_PARAM_ALIASES } from './d365foFileOpSpecs.js';
+import {
+  getRequiredParams, renderOpSpec, OP_PARAM_ALIASES,
+  findIgnoredParams, renderIgnoredParamsWarning, findMissingMutationParams,
+} from './d365foFileOpSpecs.js';
 import { lookupSymbolNocase } from '../utils/symbolLookup.js';
 
 /**
@@ -516,6 +519,197 @@ async function directXmlAddControl(
 }
 
 /**
+ * Normalises a NoYes-shaped flag to a boolean.
+ *
+ * The wire type is boolean, but the value these params end up as in AxTable XML
+ * is `No`/`Yes`, so callers legitimately pass the string spelling (corpus #27:
+ * indexAllowDuplicates="No" was rejected with a bare "expected boolean").
+ * Anything unrecognised returns undefined so the op's own default applies.
+ */
+export function coerceNoYesFlag(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const v = value.trim().toLowerCase();
+    if (v === 'yes' || v === 'true' || v === '1') return true;
+    if (v === 'no' || v === 'false' || v === '0') return false;
+  }
+  return undefined;
+}
+
+/**
+ * Direct XML fallback for add-index on a TABLE.
+ *
+ * The C# bridge's AddIndex resolves its target via _provider.Tables.Read(name),
+ * whose DiskProvider metadata roots are fixed at bridge startup. A table CREATED
+ * THIS SESSION is therefore reported "Table '<name>' not found" — even after
+ * update_symbol_index and even when an explicit filePath was supplied (filePath
+ * only steers the TS-side file lookup, never the bridge's own name resolution).
+ * Corpus evidence: 2026-07-21T19__L2-error-handling-infolog (add-index on
+ * ConDemoTicket failed 3×) and 2026-07-21T20__L3-workflow-document-submit.
+ * With no working grounded path the only way to land the index was
+ * d365fo_file(action="create", overwrite=true) — the whole-file escape hatch the
+ * eval loop forbids.
+ *
+ * This writes an <AxTableIndex> element straight into the table's <Indexes>
+ * collection, in the shape the D365FO SDK serialises: <Name>, <AllowDuplicates>,
+ * optional <AlternateKey>, then <Fields> of <AxTableIndexField><DataField>.
+ * <Indexes> is a collection sibling, NOT part of the order-sensitive top-level
+ * property block, so appending to it is safe. Unlike the bridge it edits the file
+ * on disk, so it is unaffected by what the provider loaded at startup — and it
+ * carries allowDuplicates/alternateKey, which the whole-file overwrite workaround
+ * dropped (cluster #35).
+ */
+async function directXmlAddIndex(
+  filePath: string,
+  indexName: string,
+  fields: string[] | undefined,
+  allowDuplicates: boolean | undefined,
+  alternateKey: boolean | undefined,
+): Promise<{ success: boolean; message: string } | null> {
+  try {
+    const rawContent = await fs.readFile(filePath, 'utf-8');
+    const content = rawContent.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+    // Only tables carry an <Indexes> collection — bail on any other shape so a
+    // mis-typed objectType never corrupts a non-table file.
+    if (!/<AxTable\b/.test(content)) return null;
+
+    // Idempotent: if an index with this name already exists, report success
+    // rather than writing a duplicate (mirrors directXmlAddControl).
+    if (new RegExp(`<AxTableIndex>\\s*<Name>${indexName}</Name>`).test(content)) {
+      return {
+        success: true,
+        message: `✅ Index '${indexName}' already present in ${filePath} — skipped (idempotent).`,
+      };
+    }
+
+    const fieldElements = (fields ?? [])
+      .map(f =>
+        `\t\t\t\t<AxTableIndexField>\n` +
+        `\t\t\t\t\t<DataField>${f}</DataField>\n` +
+        `\t\t\t\t</AxTableIndexField>`)
+      .join('\n');
+    const fieldsBlock = fieldElements
+      ? `\t\t\t<Fields>\n${fieldElements}\n\t\t\t</Fields>`
+      : `\t\t\t<Fields />`;
+
+    const newElement =
+      `\t\t<AxTableIndex>\n` +
+      `\t\t\t<Name>${indexName}</Name>\n` +
+      `\t\t\t<AllowDuplicates>${allowDuplicates ? 'Yes' : 'No'}</AllowDuplicates>\n` +
+      (alternateKey ? `\t\t\t<AlternateKey>Yes</AlternateKey>\n` : '') +
+      `${fieldsBlock}\n` +
+      `\t\t</AxTableIndex>`;
+
+    let updated: string;
+    if (content.includes('<Indexes />')) {
+      updated = content.replace('<Indexes />', `<Indexes>\n${newElement}\n\t</Indexes>`);
+    } else if (content.includes('</Indexes>')) {
+      updated = content.replace('</Indexes>', `${newElement}\n\t</Indexes>`);
+    } else {
+      // No <Indexes> collection at all — not a shape we can safely patch.
+      return null;
+    }
+
+    if (updated === content) return null;
+
+    await fs.writeFile(filePath, normalizeD365Xml(updated), 'utf-8');
+    console.error(`[modify_d365fo_file] ✅ directXmlAddIndex: added '${indexName}' to ${filePath}`);
+    return {
+      success: true,
+      message: `✅ Index '${indexName}' added via direct XML fallback (bridge could not resolve the same-session table). File: ${filePath}`,
+    };
+  } catch (err) {
+    console.error(`[modify_d365fo_file] directXmlAddIndex failed: ${err}`);
+    return null;
+  }
+}
+
+/**
+ * Writes the relation properties the bridge drops into an <AxTableRelation>.
+ *
+ * add-relation documents relationCardinality / relatedTableCardinality /
+ * relationshipType WITH defaults, but neither bridgeClient.addRelation nor the
+ * C# MetadataWriteService.AddRelation carries them: AddRelation only sets Name,
+ * RelatedTable and the constraints. The result was a relation that reports
+ * "✅ Relation 'X' added" and then fails BP with
+ * BPErrorTableRelationshipPropertiesCompleteness naming exactly those three
+ * properties — with no repair path, because modify-property rejects
+ * Relations/<name>/RelationshipType (corpus findings #5 / #35).
+ *
+ * The C# side cannot be fixed or tested without the VM's metadata assemblies, so
+ * the properties are written on disk after the relation lands. Element order is
+ * the one both in-repo generators emit (createD365File.ts / generateTableRelation.ts,
+ * matching the SDK serialiser): Name, Cardinality, RelatedTable,
+ * RelatedTableCardinality, RelationshipType, Constraints. Order matters — AxTable
+ * XML silently drops misordered properties (#13) — so nothing is guessed here:
+ * each element is anchored to the sibling it must follow, and the function is a
+ * no-op if the anchor is absent or the property is already present.
+ */
+export async function directXmlEnsureRelationProperties(
+  filePath: string,
+  relationName: string,
+  cardinality: string,
+  relatedTableCardinality: string,
+  relationshipType: string,
+): Promise<{ applied: string[] } | null> {
+  try {
+    const rawContent = await fs.readFile(filePath, 'utf-8');
+    const content = rawContent.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+    // Locate the <AxTableRelation> block that carries this <Name>.
+    const relRegex = /<AxTableRelation>[\s\S]*?<\/AxTableRelation>/g;
+    let block: string | undefined;
+    for (const m of content.matchAll(relRegex)) {
+      if (new RegExp(`<Name>${relationName}</Name>`).test(m[0])) { block = m[0]; break; }
+    }
+    if (!block) return null;
+
+    const indent = /\n(\s*)<Name>/.exec(block)?.[1] ?? '\t\t\t';
+    let patched = block;
+    const applied: string[] = [];
+
+    // <Cardinality> goes directly after <Name>.
+    if (!/<Cardinality>/.test(patched)) {
+      patched = patched.replace(
+        new RegExp(`(<Name>${relationName}</Name>)`),
+        `$1\n${indent}<Cardinality>${cardinality}</Cardinality>`,
+      );
+      applied.push(`Cardinality=${cardinality}`);
+    }
+    // <RelatedTableCardinality> and <RelationshipType> go after <RelatedTable>,
+    // in that order.
+    const relatedTableMatch = /<RelatedTable>[^<]*<\/RelatedTable>/.exec(patched);
+    if (relatedTableMatch) {
+      let insertion = '';
+      if (!/<RelatedTableCardinality>/.test(patched)) {
+        insertion += `\n${indent}<RelatedTableCardinality>${relatedTableCardinality}</RelatedTableCardinality>`;
+        applied.push(`RelatedTableCardinality=${relatedTableCardinality}`);
+      }
+      if (!/<RelationshipType>/.test(patched)) {
+        insertion += `\n${indent}<RelationshipType>${relationshipType}</RelationshipType>`;
+        applied.push(`RelationshipType=${relationshipType}`);
+      }
+      if (insertion) {
+        patched = patched.replace(relatedTableMatch[0], `${relatedTableMatch[0]}${insertion}`);
+      }
+    }
+
+    if (applied.length === 0 || patched === block) return { applied: [] };
+
+    const updated = content.replace(block, patched);
+    await fs.writeFile(filePath, normalizeD365Xml(updated), 'utf-8');
+    console.error(
+      `[modify_d365fo_file] ✅ directXmlEnsureRelationProperties: ${applied.join(', ')} on '${relationName}' in ${filePath}`,
+    );
+    return { applied };
+  } catch (err) {
+    console.error(`[modify_d365fo_file] directXmlEnsureRelationProperties failed: ${err}`);
+    return null;
+  }
+}
+
+/**
  * Heuristic: does a bridge failure message indicate the C# provider could not
  * resolve the target object (vs. a genuine operation error like "index already
  * exists")? An unresolved object is the one failure worth a refresh+retry,
@@ -772,9 +966,17 @@ const ModifyD365FileArgsSchema = z.object({
     fieldName: z.string(),
     direction: z.enum(['Asc', 'Desc']).optional(),
   })).optional().describe('Fields that make up the index. Required for add-index.'),
-  indexAllowDuplicates: z.boolean().optional().describe('Whether index allows duplicates (default: false = unique).'),
-  indexAlternateKey: z.boolean().optional().describe('Whether index is an alternate key.'),
-  indexEnabled: z.boolean().optional().describe('Whether index is enabled (default: true).'),
+  // Accept the XML spelling too: the AxTable element value is No/Yes, so callers
+  // naturally pass "Yes"/"No" and used to get a bare "expected boolean" (#27).
+  indexAllowDuplicates: z.union([z.boolean(), z.string()]).optional().describe(
+    'Whether index allows duplicates (default: false = unique). Accepts true/false or the XML spelling "Yes"/"No".'
+  ),
+  indexAlternateKey: z.union([z.boolean(), z.string()]).optional().describe(
+    'Whether index is an alternate key. Accepts true/false or the XML spelling "Yes"/"No".'
+  ),
+  indexEnabled: z.union([z.boolean(), z.string()]).optional().describe(
+    'Whether index is enabled (default: true). Accepts true/false or the XML spelling "Yes"/"No".'
+  ),
 
   // For add-relation / remove-relation (table, table-extension)
   relationName: z.string().optional().describe('Relation name for add-relation / remove-relation.'),
@@ -866,6 +1068,36 @@ const ModifyD365FileArgsSchema = z.object({
 export async function modifyD365FileTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = ModifyD365FileArgsSchema.parse(request.params.arguments);
+
+    // ── Silent-parameter-drop guard (corpus cluster #35, #6) ─────────────────
+    // The published schema advertises a free-form `params` object and the Zod
+    // schema STRIPS unknown keys, so a misspelled or misplaced parameter used to
+    // disappear without a trace while the op still answered "✅ … modified".
+    // Read the RAW arguments (pre-strip) and account for every key: either the
+    // operation consumes it, or the caller is told it was dropped.
+    const rawArgs = (request.params.arguments ?? {}) as Record<string, unknown>;
+    const providedKeys = Object.keys(rawArgs).filter(k => rawArgs[k] !== undefined);
+    const ignoredParams = findIgnoredParams(String(args.operation), providedKeys);
+    const ignoredParamsWarning = renderIgnoredParamsWarning(String(args.operation), ignoredParams);
+
+    // A call that carries none of the params that would mutate anything must not
+    // report success: `modify-field {fieldName, mandatory:true}` (wrong key —
+    // it is fieldMandatory) wrote nothing and still answered
+    // "✅ Field 'Description' modified via IMetaTableProvider.Update".
+    const missingMutation = findMissingMutationParams(String(args.operation), providedKeys);
+    if (missingMutation.length > 0) {
+      return {
+        content: [{
+          type: 'text',
+          text:
+            `❌ '${args.operation}' was called with no parameter that changes anything — nothing would be written.\n` +
+            `Pass at least one of: ${missingMutation.join(', ')}.\n` +
+            (ignoredParamsWarning ? `\n${ignoredParamsWarning}\n` : '') +
+            `\n${renderOpSpec(String(args.operation))}`,
+        }],
+        isError: true,
+      };
+    }
 
     // Decode XML entities in X++ payloads. An AI that copied entity-encoded code (an
     // SSRS <Text> block, or escaped doc comments like "/// &lt;summary&gt;") sends
@@ -1403,14 +1635,37 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
           const indexFieldNames: string[] | undefined = Array.isArray((args as any).indexFields)
             ? (args as any).indexFields.map((f: any) => (typeof f === 'string' ? f : f?.fieldName)).filter(Boolean)
             : undefined;
+          // indexAllowDuplicates / indexAlternateKey are booleans on the wire, but
+          // the AxTable XML value is No/Yes — callers naturally pass the STRING and
+          // used to get a bare "expected boolean" rejection (#27). Accept both.
+          const allowDuplicates = coerceNoYesFlag((args as any).indexAllowDuplicates);
+          const alternateKey = coerceNoYesFlag((args as any).indexAlternateKey);
           bridgeResult = await bridgeAddIndex(
             context.bridge,
             objectName,
             (args as any).indexName,
             indexFieldNames,
-            (args as any).indexAllowDuplicates,
-            (args as any).indexAlternateKey,
+            allowDuplicates,
+            alternateKey,
           );
+          // Fallback: the bridge's AddIndex resolves the table via
+          // _provider.Tables.Read, whose metadata roots are fixed at startup, so a
+          // table CREATED THIS SESSION reports "Table '<name>' not found" — even
+          // after update_symbol_index and even when an explicit filePath was
+          // supplied (see corpus L2-error-handling-infolog / L3-workflow-document-
+          // submit). Rather than push the agent into the forbidden whole-file
+          // overwrite (which also drops allowDuplicates/alternateKey — #35), write
+          // the index straight into the on-disk XML.
+          if (!bridgeResult || !bridgeResult.success) {
+            const xmlFallbackResult = await directXmlAddIndex(
+              actualFilePath,
+              (args as any).indexName,
+              indexFieldNames,
+              allowDuplicates,
+              alternateKey,
+            );
+            if (xmlFallbackResult) bridgeResult = xmlFallbackResult;
+          }
         }
         break;
       }
@@ -1445,6 +1700,30 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             (args as any).relatedTable,
             constraints,
           );
+          // The relation properties add-relation documents (with defaults) are
+          // carried by NEITHER bridgeClient.addRelation NOR the C# AddRelation —
+          // it writes Name/RelatedTable/Constraints only, so the op answered
+          // "✅ Relation 'X' added" and xppbp then raised
+          // BPErrorTableRelationshipPropertiesCompleteness naming exactly the three
+          // dropped properties, with no repair path (modify-property rejects
+          // Relations/<name>/RelationshipType). Findings #5 / #35. The C# fix needs
+          // the VM's metadata assemblies, so write them on disk here — applying the
+          // documented defaults, exactly as the create path does.
+          if (bridgeResult?.success) {
+            const relProps = await directXmlEnsureRelationProperties(
+              actualFilePath,
+              (args as any).relationName,
+              (args as any).relationCardinality ?? 'ZeroMore',
+              (args as any).relatedTableCardinality ?? 'ExactlyOne',
+              (args as any).relationshipType ?? 'Association',
+            );
+            if (relProps && relProps.applied.length > 0) {
+              bridgeResult = {
+                success: true,
+                message: `${bridgeResult.message} (+ ${relProps.applied.join(', ')} written directly to the XML)`,
+              };
+            }
+          }
         }
         break;
       }
@@ -1891,7 +2170,8 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
           text:
             `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
-            `🔧 API: ${bridgeResult.message}${xppLintNote}${backupNote}\n\n` +
+            `🔧 API: ${bridgeResult.message}${xppLintNote}${backupNote}` +
+            (ignoredParamsWarning ? `\n\n${ignoredParamsWarning}` : '') + `\n\n` +
             `**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate`,
         },
       ],

--- a/tests/tools/addIndexSameSession.test.ts
+++ b/tests/tools/addIndexSameSession.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Regression tests — add-index on a table CREATED THIS SESSION
+ *
+ * Corpus evidence:
+ *   eval/corpus/runs/2026-07-21T19__L2-error-handling-infolog__c262b19.json
+ *   eval/corpus/runs/2026-07-21T20__L3-workflow-document-submit__c262b19.json
+ *
+ * Defect cluster #16 / #23 / #29 (all on the bridge-backed modify surface):
+ *
+ *  The C# bridge's AddIndex resolves its table via _provider.Tables.Read(name),
+ *  whose DiskProvider metadata roots are fixed at bridge startup. A table created
+ *  earlier in the SAME session is therefore reported "Table '<name>' not found" —
+ *  even after a successful update_symbol_index(filePath) and even when an explicit
+ *  filePath was supplied (filePath only steers the TS-side file lookup, never the
+ *  bridge's own name resolution — #23). With no working grounded path, every
+ *  table-shaped case in the sweep was forced into d365fo_file(action="create",
+ *  overwrite=true) — the whole-file escape hatch the eval loop forbids (HEADLINE 2).
+ *
+ *  The C# resolution itself needs the live Microsoft.Dynamics metadata provider and
+ *  cannot be exercised VM-free, so the fix lands TS-side: when the bridge cannot
+ *  resolve the same-session table, add-index now writes the <AxTableIndex> straight
+ *  into the on-disk <Indexes> collection (directXmlAddIndex) — the same direct-XML
+ *  fallback pattern that already backs modify-property / replace-code /
+ *  add-menu-item-to-menu / add-control(form-extension). These tests pin that the
+ *  grounded op now COMPLETES instead of dead-ending, in the exact serialised shape.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool } from '../../src/tools/modifyD365File';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// ─── Bridge mock: simulate the same-session resolution failure ────────────────
+
+const { mockBridgeAddIndex, mockBridgeRefreshProvider } = vi.hoisted(() => ({
+  mockBridgeAddIndex: vi.fn(),
+  mockBridgeRefreshProvider: vi.fn(async () => ({ success: true, elapsedMs: 1 })),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return {
+    ...actual,
+    bridgeAddIndex: mockBridgeAddIndex,
+    bridgeRefreshProvider: mockBridgeRefreshProvider,
+    bridgeValidateAfterWrite: vi.fn(async () => null),
+  };
+});
+
+// ─── fs/promises mock (capture writeFile output) ──────────────────────────────
+
+/** A table created this session, still with an EMPTY <Indexes /> collection. */
+const TABLE_NO_INDEX_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoTicket</Name>
+\t<SourceCode>
+\t\t<Declaration><![CDATA[
+public class ConDemoTicket extends common
+{
+}
+]]></Declaration>
+\t\t<Methods />
+\t</SourceCode>
+\t<Label>@TaxTransactionInquiry:HeaderNote</Label>
+\t<TitleField1>TicketId</TitleField1>
+\t<DeleteActions />
+\t<FieldGroups />
+\t<Fields>
+\t\t<AxTableField xmlns="" i:type="AxTableFieldString">
+\t\t\t<Name>TicketId</Name>
+\t\t\t<ExtendedDataType>Num</ExtendedDataType>
+\t\t</AxTableField>
+\t</Fields>
+\t<FullTextIndexes />
+\t<Indexes />
+\t<Mappings />
+\t<Relations />
+\t<StateMachines />
+</AxTable>`;
+
+const { mockWriteFile } = vi.hoisted(() => ({ mockWriteFile: vi.fn(async () => {}) }));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (typeof p === 'string' && p.endsWith('.xml')) return TABLE_NO_INDEX_XML;
+    if (typeof p === 'string' && p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: mockWriteFile,
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+  copyFile: vi.fn(async () => {}),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (m: string) => ({
+      packageName: m,
+      modelName: m,
+      rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({
+      packageName: p,
+      modelName: m,
+      rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+const TABLE_FILE_PATH =
+  'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\ConDemoTicket.xml';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'modify_d365fo_file', arguments: args },
+});
+
+const addIndexReq = (extra: Record<string, unknown> = {}) =>
+  req({
+    objectType: 'table',
+    objectName: 'ConDemoTicket',
+    operation: 'add-index',
+    indexName: 'TicketIdx',
+    indexFields: [{ fieldName: 'TicketId' }],
+    indexAlternateKey: true,
+    filePath: TABLE_FILE_PATH,
+    ...extra,
+  });
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare: vi.fn(() => stmt) },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {}),
+      generateSearchKey: vi.fn((q: string) => `k:${q}`),
+    } as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    bridge: { isReady: true, metadataAvailable: true } as any,
+  };
+};
+
+/** Return the XML content of the writeFile call that landed the index. */
+const capturedIndexXml = (): string | undefined => {
+  const call = mockWriteFile.mock.calls.find(
+    (c: any[]) => typeof c[1] === 'string' && c[1].includes('<AxTableIndex>'),
+  );
+  return call?.[1] as string | undefined;
+};
+
+describe('add-index on a same-session table (bridge cannot resolve it)', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    mockBridgeAddIndex.mockReset();
+    mockBridgeRefreshProvider.mockClear();
+    mockWriteFile.mockClear();
+  });
+
+  // The exact bridge failure the corpus recorded: the C# provider's fixed
+  // metadata roots don't contain the table written this session.
+  const RESOLUTION_FAILURE = { success: false, message: "Table 'ConDemoTicket' not found" };
+
+  it('completes via the direct-XML fallback instead of dead-ending', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+
+    const result = await modifyD365FileTool(addIndexReq(), ctx);
+
+    // On main this throws unresolvedObjectError (isError) — the whole point.
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text as string;
+    expect(text).toMatch(/direct XML fallback/i);
+    // The op reports SUCCESS, not the dead-end "could not resolve" GUIDANCE that
+    // used to steer the agent away (the honest one-line reason may still mention
+    // that the bridge could not resolve it — that is a note, not a failure).
+    expect(text).not.toMatch(/Bridge operation '.*' could not resolve/i);
+  });
+
+  it('never steers the agent into create overwrite=true', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+    const result = await modifyD365FileTool(addIndexReq(), ctx);
+    const text = result.content[0].text as string;
+    expect(text).not.toMatch(/overwrite=true/);
+  });
+
+  it('writes the AxTableIndex into the <Indexes> collection in canonical shape', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+
+    await modifyD365FileTool(addIndexReq(), ctx);
+
+    const xml = capturedIndexXml();
+    expect(xml).toBeTruthy();
+    // The index lands inside the <Indexes> collection, not loose in the file.
+    expect(xml).toMatch(/<Indexes>[\s\S]*<AxTableIndex>[\s\S]*<\/AxTableIndex>[\s\S]*<\/Indexes>/);
+    // Canonical element order: Name, AllowDuplicates, AlternateKey, Fields.
+    expect(xml).toMatch(
+      /<AxTableIndex>\s*<Name>TicketIdx<\/Name>\s*<AllowDuplicates>No<\/AllowDuplicates>\s*<AlternateKey>Yes<\/AlternateKey>\s*<Fields>\s*<AxTableIndexField>\s*<DataField>TicketId<\/DataField>\s*<\/AxTableIndexField>\s*<\/Fields>\s*<\/AxTableIndex>/,
+    );
+    // The empty self-closing collection must be gone.
+    expect(xml).not.toContain('<Indexes />');
+  });
+
+  it('omits <AlternateKey> when not requested and defaults AllowDuplicates to No', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+
+    await modifyD365FileTool(
+      addIndexReq({ indexAlternateKey: undefined, indexAllowDuplicates: undefined }),
+      ctx,
+    );
+
+    const xml = capturedIndexXml();
+    expect(xml).toBeTruthy();
+    expect(xml).toContain('<AllowDuplicates>No</AllowDuplicates>');
+    expect(xml).not.toContain('<AlternateKey>');
+  });
+
+  it('does not run the fallback when the bridge itself succeeded', async () => {
+    mockBridgeAddIndex.mockResolvedValue({
+      success: true,
+      message: "✅ Index 'TicketIdx' added via IMetaTableProvider.Update",
+    });
+
+    const result = await modifyD365FileTool(addIndexReq(), ctx);
+
+    expect(result.isError).toBeFalsy();
+    // The bridge wrote the index through the provider — no direct-XML write of it.
+    expect(capturedIndexXml()).toBeUndefined();
+  });
+});

--- a/tests/tools/modifyParamSilentDrop.test.ts
+++ b/tests/tools/modifyParamSilentDrop.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Regression tests — d365fo_file(modify) must never DISCARD a parameter in silence.
+ *
+ * Corpus evidence (2026-07-21 sweep, findings #5 / #6 / #27 / #35 "THE CLUSTER"):
+ *   eval/corpus/runs/2026-07-21T18__L2-table-modify-lifecycle__c262b19.json
+ *   eval/corpus/runs/2026-07-21T19__L2-performance-set-based__c262b19.json
+ *   eval/corpus/runs/2026-07-21T20__L4-master-security-slice__c262b19.json
+ *
+ * The shared shape: a parameter is accepted, the op answers "✅ success", and the
+ * value is absent from the written XML with no warning anywhere.
+ *   • #5  add-relation dropped relationshipType / relationCardinality /
+ *         relatedTableCardinality — all three documented WITH defaults in the op's
+ *         own spec — and xppbp then raised
+ *         BPErrorTableRelationshipPropertiesCompleteness naming exactly those three.
+ *   • #6  modify-field {fieldName, mandatory:true} answered "✅ Field 'Description'
+ *         modified via IMetaTableProvider.Update" while writing nothing (the key is
+ *         fieldMandatory; the Zod schema strips unknown keys).
+ *   • #27 indexAllowDuplicates is a boolean but the XML value is No/Yes, so the
+ *         natural string spelling was rejected with a bare "expected boolean".
+ *   • #35 add-data-source drops linkType (C#-side: CreateFormDataSourceRoot sets
+ *         Name/Table/JoinSource only) — it can only be reported, not fixed, in-repo.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool, coerceNoYesFlag } from '../../src/tools/modifyD365File';
+import {
+  findIgnoredParams,
+  findMissingMutationParams,
+  renderIgnoredParamsWarning,
+} from '../../src/tools/d365foFileOpSpecs';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// ─── Bridge mock ──────────────────────────────────────────────────────────────
+
+const {
+  mockBridgeModifyField, mockBridgeAddRelation, mockBridgeAddIndex,
+  mockBridgeAddDataSource, mockBridgeRefreshProvider,
+} = vi.hoisted(() => ({
+  mockBridgeModifyField: vi.fn(),
+  mockBridgeAddRelation: vi.fn(),
+  mockBridgeAddIndex: vi.fn(),
+  mockBridgeAddDataSource: vi.fn(),
+  mockBridgeRefreshProvider: vi.fn(async () => ({ success: true, elapsedMs: 1 })),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return {
+    ...actual,
+    bridgeModifyField: mockBridgeModifyField,
+    bridgeAddRelation: mockBridgeAddRelation,
+    bridgeAddIndex: mockBridgeAddIndex,
+    bridgeAddDataSource: mockBridgeAddDataSource,
+    bridgeRefreshProvider: mockBridgeRefreshProvider,
+    bridgeValidateAfterWrite: vi.fn(async () => null),
+  };
+});
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/**
+ * A table exactly as the bridge leaves it after add-relation: the relation carries
+ * Name / RelatedTable / Constraints and NOTHING else. Copied from the captured
+ * golden eval/goldens/L2-table-modify-lifecycle/ConDemoModLifecycle.metadata.xml,
+ * which enshrines the defect.
+ */
+const TABLE_WITH_BARE_RELATION = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoModLifecycle</Name>
+\t<SourceCode>
+\t\t<Declaration><![CDATA[
+public class ConDemoModLifecycle extends common
+{
+}
+]]></Declaration>
+\t\t<Methods />
+\t</SourceCode>
+\t<DeleteActions />
+\t<FieldGroups />
+\t<Fields>
+\t\t<AxTableField xmlns="" i:type="AxTableFieldString">
+\t\t\t<Name>CustAccount</Name>
+\t\t\t<ExtendedDataType>CustAccount</ExtendedDataType>
+\t\t</AxTableField>
+\t</Fields>
+\t<FullTextIndexes />
+\t<Indexes />
+\t<Mappings />
+\t<Relations>
+\t\t<AxTableRelation>
+\t\t\t<Name>CustTable</Name>
+\t\t\t<RelatedTable>CustTable</RelatedTable>
+\t\t\t<Constraints>
+\t\t\t\t<AxTableRelationConstraint xmlns="" i:type="AxTableRelationConstraintField">
+\t\t\t\t\t<Name>CustAccount</Name>
+\t\t\t\t\t<Field>CustAccount</Field>
+\t\t\t\t\t<RelatedField>AccountNum</RelatedField>
+\t\t\t\t</AxTableRelationConstraint>
+\t\t\t</Constraints>
+\t\t</AxTableRelation>
+\t</Relations>
+\t<StateMachines />
+</AxTable>`;
+
+const FORM_EXTENSION_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>CustTable.ConDemoExt</Name>
+\t<Controls />
+\t<DataSources />
+</AxFormExtension>`;
+
+const { mockWriteFile, currentXml } = vi.hoisted(() => ({
+  mockWriteFile: vi.fn(async () => {}),
+  currentXml: { value: '' },
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (typeof p === 'string' && p.endsWith('.xml')) return currentXml.value;
+    if (typeof p === 'string' && p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: mockWriteFile,
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+  copyFile: vi.fn(async () => {}),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (m: string) => ({ packageName: m, modelName: m, rootPath: 'K:\\PackagesLocalDirectory' })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({ packageName: p, modelName: m, rootPath: 'K:\\PackagesLocalDirectory' })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+const TABLE_FILE_PATH = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\ConDemoModLifecycle.xml';
+const FORM_EXT_FILE_PATH = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxFormExtension\\CustTable.ConDemoExt.xml';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'modify_d365fo_file', arguments: args },
+});
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare: vi.fn(() => stmt) },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {}),
+      generateSearchKey: vi.fn((q: string) => `k:${q}`),
+    } as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    bridge: { isReady: true, metadataAvailable: true } as any,
+  };
+};
+
+/** XML of the last write to the object file. */
+function writtenXml(): string | undefined {
+  const calls = mockWriteFile.mock.calls as unknown as Array<[string, string, string]>;
+  const hit = [...calls].reverse().find(c => typeof c[0] === 'string' && c[0].endsWith('.xml') && !c[0].includes('.backup'));
+  return hit?.[1];
+}
+
+const textOf = (r: any) => r.content.map((c: any) => c.text).join('\n');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentXml.value = TABLE_WITH_BARE_RELATION;
+  mockBridgeModifyField.mockResolvedValue({ success: true, message: '✅ Field modified via IMetaTableProvider.Update' });
+  mockBridgeAddRelation.mockResolvedValue({ success: true, message: "✅ Relation 'CustTable' added via IMetaTableProvider.Update" });
+  mockBridgeAddIndex.mockResolvedValue({ success: true, message: "✅ Index added via IMetaTableProvider.Update" });
+  mockBridgeAddDataSource.mockResolvedValue({ success: true, message: '✅ Data source added via IMetaFormProvider.Update' });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#6 — a mutation op with no recognised mutation param must not claim success', () => {
+  it('rejects modify-field {fieldName, mandatory:true} instead of answering ✅', async () => {
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoModLifecycle',
+        operation: 'modify-field',
+        fieldName: 'Description',
+        mandatory: true, // WRONG KEY — the real one is fieldMandatory
+        filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    const text = textOf(result);
+    // It must name the correct parameter, not just fail.
+    expect(text).toContain('fieldMandatory');
+    // And it must not have pretended to write anything.
+    expect(text).not.toContain('IMetaTableProvider.Update');
+    expect(mockBridgeModifyField).not.toHaveBeenCalled();
+    expect(writtenXml()).toBeUndefined();
+  });
+
+  it('still accepts modify-field with a real mutation param', async () => {
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoModLifecycle',
+        operation: 'modify-field',
+        fieldName: 'Description',
+        fieldMandatory: true,
+        filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(mockBridgeModifyField).toHaveBeenCalled();
+  });
+});
+
+describe('#35 — an accepted-but-dropped parameter must be reported, never silent', () => {
+  it('warns about off-op index params (allowDuplicates / alternateKey) and suggests the real names', async () => {
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoModLifecycle',
+        operation: 'add-index',
+        indexName: 'TicketIdx',
+        indexFields: [{ fieldName: 'CustAccount' }],
+        allowDuplicates: false, // dropped: the param is indexAllowDuplicates
+        alternateKey: true,     // dropped: the param is indexAlternateKey
+        filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+
+    const text = textOf(result);
+    expect(text).toContain('allowDuplicates');
+    expect(text).toContain('indexAllowDuplicates');
+    expect(text).toContain('alternateKey');
+    expect(text).toContain('indexAlternateKey');
+    expect(text).toMatch(/did not reach the written XML/);
+  });
+
+  it('warns that add-data-source does not write linkType (C#-side drop)', async () => {
+    currentXml.value = FORM_EXTENSION_XML;
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'form-extension',
+        objectName: 'CustTable.ConDemoExt',
+        operation: 'add-data-source',
+        dataSourceName: 'CustTrans',
+        dataSourceTable: 'CustTrans',
+        joinSource: 'CustTable',
+        linkType: 'Active',
+        filePath: FORM_EXT_FILE_PATH,
+      }),
+      buildContext(),
+    );
+
+    const text = textOf(result);
+    expect(text).toContain('linkType');
+    expect(text).toMatch(/NOT WRITTEN/);
+  });
+
+  it('does not warn when every parameter is consumed', async () => {
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoModLifecycle',
+        operation: 'add-index',
+        indexName: 'TicketIdx',
+        indexFields: [{ fieldName: 'CustAccount' }],
+        indexAlternateKey: true,
+        filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+    expect(textOf(result)).not.toContain('did not reach the written XML');
+  });
+});
+
+describe('#5 — add-relation must write the relation properties it documents', () => {
+  it('writes Cardinality / RelatedTableCardinality / RelationshipType with the documented defaults', async () => {
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoModLifecycle',
+        operation: 'add-relation',
+        relationName: 'CustTable',
+        relatedTable: 'CustTable',
+        relationConstraints: [{ fieldName: 'CustAccount', relatedFieldName: 'AccountNum' }],
+        filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    const xml = writtenXml();
+    expect(xml).toBeDefined();
+    expect(xml).toContain('<Cardinality>ZeroMore</Cardinality>');
+    expect(xml).toContain('<RelatedTableCardinality>ExactlyOne</RelatedTableCardinality>');
+    expect(xml).toContain('<RelationshipType>Association</RelationshipType>');
+  });
+
+  it('writes the explicitly supplied values', async () => {
+    await modifyD365FileTool(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoModLifecycle',
+        operation: 'add-relation',
+        relationName: 'CustTable',
+        relatedTable: 'CustTable',
+        relationCardinality: 'ZeroOne',
+        relatedTableCardinality: 'ZeroOne',
+        relationshipType: 'Composition',
+        filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+
+    const xml = writtenXml()!;
+    expect(xml).toContain('<Cardinality>ZeroOne</Cardinality>');
+    expect(xml).toContain('<RelatedTableCardinality>ZeroOne</RelatedTableCardinality>');
+    expect(xml).toContain('<RelationshipType>Composition</RelationshipType>');
+  });
+
+  it('emits the SDK element order (misordered AxTable properties are silently dropped — #13)', async () => {
+    await modifyD365FileTool(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoModLifecycle',
+        operation: 'add-relation',
+        relationName: 'CustTable',
+        relatedTable: 'CustTable',
+        filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+
+    const xml = writtenXml()!;
+    const relation = /<AxTableRelation>[\s\S]*?<\/AxTableRelation>/.exec(xml)![0];
+    const order = [...relation.matchAll(/<(Name|Cardinality|RelatedTable|RelatedTableCardinality|RelationshipType|Constraints)>/g)]
+      .map(m => m[1])
+      // <Name> also appears inside a constraint — keep only the first occurrence of each.
+      .filter((v, i, a) => a.indexOf(v) === i);
+    expect(order).toEqual([
+      'Name', 'Cardinality', 'RelatedTable', 'RelatedTableCardinality', 'RelationshipType', 'Constraints',
+    ]);
+  });
+
+  it('is idempotent — a relation that already carries the properties is not rewritten', async () => {
+    // First call writes them…
+    await modifyD365FileTool(
+      req({
+        objectType: 'table', objectName: 'ConDemoModLifecycle', operation: 'add-relation',
+        relationName: 'CustTable', relatedTable: 'CustTable', filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+    currentXml.value = writtenXml()!;
+    mockWriteFile.mockClear();
+
+    // …the second call finds nothing to add.
+    await modifyD365FileTool(
+      req({
+        objectType: 'table', objectName: 'ConDemoModLifecycle', operation: 'add-relation',
+        relationName: 'CustTable', relatedTable: 'CustTable', filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+    expect(writtenXml()).toBeUndefined();
+  });
+});
+
+describe('#27 — NoYes-shaped index flags accept the XML spelling', () => {
+  it('coerceNoYesFlag maps Yes/No and true/false, and ignores anything else', () => {
+    expect(coerceNoYesFlag('Yes')).toBe(true);
+    expect(coerceNoYesFlag('no')).toBe(false);
+    expect(coerceNoYesFlag(true)).toBe(true);
+    expect(coerceNoYesFlag('true')).toBe(true);
+    expect(coerceNoYesFlag(undefined)).toBeUndefined();
+    expect(coerceNoYesFlag('Maybe')).toBeUndefined();
+  });
+
+  it('accepts indexAllowDuplicates="No" instead of rejecting it with "expected boolean"', async () => {
+    // Bridge cannot resolve the same-session table → direct-XML fallback writes it,
+    // so the flag value is observable in the file.
+    mockBridgeAddIndex.mockResolvedValue({ success: false, message: "Table 'ConDemoModLifecycle' not found" });
+
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoModLifecycle',
+        operation: 'add-index',
+        indexName: 'CustAccountIdx',
+        indexFields: [{ fieldName: 'CustAccount' }],
+        indexAllowDuplicates: 'No',
+        indexAlternateKey: 'Yes',
+        filePath: TABLE_FILE_PATH,
+      }),
+      buildContext(),
+    );
+
+    expect(textOf(result)).not.toMatch(/expected boolean/i);
+    expect(result.isError).toBeFalsy();
+    const xml = writtenXml()!;
+    expect(xml).toContain('<AllowDuplicates>No</AllowDuplicates>');
+    expect(xml).toContain('<AlternateKey>Yes</AlternateKey>');
+  });
+});
+
+describe('parameter-accounting helpers', () => {
+  it('classifies an unknown key, an off-op key and a not-honoured key', () => {
+    expect(findIgnoredParams('modify-field', ['fieldName', 'mandatory'])).toEqual([
+      { name: 'mandatory', reason: 'unknown', suggestion: 'fieldMandatory' },
+    ]);
+    expect(findIgnoredParams('add-relation', ['relationName', 'relatedTable', 'indexName'])).toEqual([
+      { name: 'indexName', reason: 'other-op', suggestion: undefined },
+    ]);
+    expect(findIgnoredParams('add-data-source', ['dataSourceName', 'dataSourceTable', 'linkType'])).toEqual([
+      { name: 'linkType', reason: 'not-honoured', detail: expect.stringContaining('CreateFormDataSourceRoot') },
+    ]);
+  });
+
+  it('never flags core params or params the op consumes', () => {
+    expect(findIgnoredParams('add-relation', [
+      'objectType', 'objectName', 'operation', 'filePath', 'modelName', 'createBackup',
+      'relationName', 'relatedTable', 'relationConstraints',
+      'relationCardinality', 'relatedTableCardinality', 'relationshipType',
+    ])).toEqual([]);
+  });
+
+  it('accepts an alias of a required param (methodCode for sourceCode)', () => {
+    expect(findIgnoredParams('add-method', ['methodName', 'methodCode'])).toEqual([]);
+  });
+
+  it('reports the two enum-value drops the audit turned up', () => {
+    // add-enum-value advertises enumValueHelpText, but the dispatcher forwards
+    // name/value/label/countryRegionCodes only and the bridge has no helpText
+    // parameter — nothing carries it, so it must be reported.
+    expect(findIgnoredParams('add-enum-value', ['enumValueName', 'enumValueHelpText'])).toEqual([
+      { name: 'enumValueHelpText', reason: 'not-honoured', detail: expect.stringContaining('AddEnumValue') },
+    ]);
+    // enumValueNewName IS honoured by modify-enum-value (it was simply missing
+    // from the op-spec registry) — it must not be flagged.
+    expect(findIgnoredParams('modify-enum-value', ['enumValueName', 'enumValueNewName'])).toEqual([]);
+  });
+
+  it('says nothing for an unknown operation rather than guessing', () => {
+    expect(findIgnoredParams('teleport-object', ['whatever'])).toEqual([]);
+    expect(renderIgnoredParamsWarning('teleport-object', [])).toBe('');
+  });
+
+  it('flags a mutation op called with no mutation param', () => {
+    expect(findMissingMutationParams('modify-field', ['fieldName'])).toContain('fieldMandatory');
+    expect(findMissingMutationParams('modify-field', ['fieldName', 'fieldLabel'])).toEqual([]);
+    // Ops without a mutationOneOf list are unaffected.
+    expect(findMissingMutationParams('remove-field', ['fieldName'])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The cluster

Corpus finding **#35** (umbrella over **#5**, **#6**, **#27**): a parameter is accepted, the op returns `✅ success`, and the value is **absent from the written XML with no warning**. It caps `bp_clean` corpus-wide — `BPCheckAlternateKeyAbsent` and `BPErrorTableRelationshipPropertiesCompleteness` are unsatisfiable through the tool path, so a BP-complete table is reachable only via the forbidden whole-file overwrite.

I audited every affected op before assuming where the drop lives. It is **not one bug — it is three, one per layer**:

| op | param(s) | root cause | fix |
|---|---|---|---|
| `add-relation` | `relationCardinality`, `relatedTableCardinality`, `relationshipType` | **TS-side drop + C#-side gap.** Dispatcher never forwards them; `bridgeClient.addRelation` has no such params; `MetadataWriteService.AddRelation` writes `Name`/`RelatedTable`/`Constraints` only | properties written on disk after the relation lands |
| `modify-field` | any misspelled key (`mandatory`) | **Zod strips unknown keys** — the value vanished before any code saw it | raw-key accounting + no-op rejection |
| `add-index` | `allowDuplicates`/`alternateKey` | **C# honours them**; the drop came from the same-session fallback path (whole-file overwrite) | folded in orphaned `directXmlAddIndex`, which writes both |
| `add-index` | `indexAllowDuplicates` typing (#27) | Zod boolean vs XML `No`/`Yes` | accepts both spellings |
| `add-data-source` | `linkType` | **C#-side, VM-only.** `CreateFormDataSourceRoot()` sets `Name`/`Table`/`JoinSource` only — `linkType` reaches the method signature and stops there | **cannot be fixed VM-free** → declared + reported as `NOT WRITTEN` |
| `add-enum-value` | `enumValueHelpText` | **found by this audit.** Advertised, forwarded by nobody, no bridge param | declared + reported as `NOT WRITTEN` |

## What changed

**`src/tools/d365foFileOpSpecs.ts`** — the op-spec registry becomes the parameter ledger:
- `findIgnoredParams()` classifies every supplied key as `unknown` (misspelling, with a near-miss suggestion: `mandatory` → `fieldMandatory`), `other-op`, or `not-honoured`.
- `OP_UNHONOURED_PARAMS` — the explicit confession list for params that reach nothing. Two entries, both VM-side C# follow-ups.
- `mutationOneOf` + `findMissingMutationParams()` — ops that write nothing without one of these params.
- Registry gap fixed: `enumValueNewName` was advertised in the tool schema but missing from the spec (surfaced by the new guard, caught by an existing test).

**`src/tools/modifyD365File.ts`**:
- reads the **raw** arguments (pre-Zod-strip) and accounts for every key; unconsumed keys become a named `⚠️ … did not reach the written XML` block in the result.
- `modify-field` / `modify-enum-value` with no mutation param now **error with the correct param name** instead of answering `✅ … modified via IMetaTableProvider.Update`.
- `directXmlEnsureRelationProperties()` writes the three relation properties (documented defaults applied) after add-relation succeeds.
- `coerceNoYesFlag()` + widened Zod for the index NoYes flags.
- folds in **orphaned commit `e94835f` (PR #729)** — `directXmlAddIndex`, which was merged into the #728 branch and never reached `main`.

### Element order (finding #13)

Nothing is guessed. The relation order — `Name, Cardinality, RelatedTable, RelatedTableCardinality, RelationshipType, Constraints` — is the order **both** in-repo generators already emit (`createD365File.ts`, `generateTableRelation.ts`), each element is anchored to the sibling it must follow, and a test asserts the emitted order explicitly. No committed golden was edited.

## Where I could not validate VM-free — stated plainly

- **`add-data-source` `linkType`** is a genuine C#-side serialisation bug. The bridge cannot be compiled here (`D365BinPath` needs the VM's `Microsoft.Dynamics.AX.Metadata` assemblies), so I did **not** ship an unverifiable C# change. It is option (3): the drop is now loud.
- **`add-enum-value` `enumValueHelpText`** — same, and it needs a new bridge parameter as well.
- The proper `add-relation` fix is also C#-side (`AxTableRelation.Cardinality` etc.). The on-disk write is the VM-free-provable equivalent; the C# task remains open.

## Evidence

- `eval/corpus/runs/2026-07-21T18__L2-table-modify-lifecycle__c262b19.json` (#5, #6)
- `eval/corpus/runs/2026-07-21T19__L2-performance-set-based__c262b19.json` (#27)
- `eval/corpus/runs/2026-07-21T20__L4-master-security-slice__c262b19.json` (#35)
- `eval/corpus/runs/2026-07-21T19__L2-error-handling-infolog__c262b19.json`, `eval/corpus/runs/2026-07-21T20__L3-workflow-document-submit__c262b19.json` (add-index fallback)
- `docs/eval-sweep-findings-2026-07-21.md` §5, §6, §27, §35

## Validation

**Repro tests, all failing on `main`:**
- `tests/tools/modifyParamSilentDrop.test.ts` — 17 tests (16 fail on main; the 17th pins the enum-registry gap this audit exposed)
- `tests/tools/addIndexSameSession.test.ts` — 5 tests, restored from `e94835f`

```
# on main (fix reverted)
Tests  16 failed | 5 passed (21)

# with the fix
Tests  22 passed (22)
```

**Anti-overfitting / held-out:**
```
npx vitest run  →  149 files | 1968 passed | 2 skipped   (incl. tests/eval/goldens.test.ts)
npm run eval:report → unchanged (44 runs, overall build=80% bp=39% golden=36%)
```
The corpus scoreboard is a record of past VM runs and cannot move without a new capture — the held-out signal here is the full suite, which includes the golden-integrity gate and every existing `d365fo_file` test. One existing test (`file-ops.test.ts` modify-enum-value rename) legitimately caught the missing `enumValueNewName` registry entry; that is fixed in the registry, not by weakening the test.

Base is current `main` (`586836c`, after #728 and #730). No overlap with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsY56fJuvoiEXjCVRR2b6M
