### PR TITLE
fix(read-tools): stop the read/search/info tools misreporting metadata (#14, #15, #25, #33/#41, #34)

### DIFF
--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -15,6 +15,7 @@ import type { BridgeClient } from './bridgeClient.js';
 import * as debouncedRefresh from './debouncedRefresh.js';
 import { debugLog } from '../utils/logger.js';
 import { reindentXppSource } from '../utils/xppFormat.js';
+import { rankExactFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
 import type {
   BridgeTableInfo,
   BridgeClassInfo,
@@ -672,23 +673,58 @@ function formatLabelReferences(references: BridgeReferenceInfo[], label: string,
 
 // SEARCH
 
+export interface BridgeSearchOptions {
+  /**
+   * Exact-name hits the caller already resolved from the SQLite index with an
+   * index-safe probe. Used to repair defect #15: the bridge fills its result
+   * window in provider-enumeration order and truncates at maxResults, so an
+   * exact match can be missing entirely. Any candidate absent from the bridge
+   * window is spliced in and ranked first.
+   */
+  exactMatches?: Array<{ name: string; type: string }>;
+}
+
 export async function tryBridgeSearch(
   bridge: BridgeClient | undefined,
   query: string,
   objectType?: string,
   maxResults = 50,
+  opts?: BridgeSearchOptions,
 ): Promise<ToolResult | null> {
   if (!bridge?.isReady || !bridge.metadataAvailable) return null;
   try {
     const sr = await bridge.searchObjects(query, objectType, maxResults);
-    if (!sr || sr.results.length === 0) return null;
+    if (!sr) return null;
+
+    // Splice in exact matches the bridge's truncated window missed (#15).
+    const bridgeHits = sr.results ?? [];
+    const known = new Set(bridgeHits.map(r => `${r.name.toLowerCase()} ${r.type}`));
+    const spliced: Array<{ name: string; type: string; fromIndex?: boolean }> = [];
+    for (const cand of opts?.exactMatches ?? []) {
+      if (!isExactNameMatch(query, cand.name)) continue;
+      if (known.has(`${cand.name.toLowerCase()} ${cand.type}`)) continue;
+      known.add(`${cand.name.toLowerCase()} ${cand.type}`);
+      spliced.push({ ...cand, fromIndex: true });
+    }
+
+    const merged = [...spliced, ...bridgeHits];
+    if (merged.length === 0) return null;
+
+    // Exact name matches first — the bridge itself returns provider order (#15).
+    const ranked = rankExactFirst(query, merged, r => r.name).slice(0, Math.max(maxResults, spliced.length));
 
     let out = `# Search: "${query}"${objectType ? ` (type: ${objectType})` : ''}\n\n`;
-    out += `**Results:** ${sr.results.length}\n`;
+    out += `**Results:** ${ranked.length}\n`;
     out += `_Source: C# bridge (IMetadataProvider)_\n\n`;
 
-    for (const r of sr.results.slice(0, maxResults)) {
-      out += `- **${r.name}** (${r.type})\n`;
+    for (const r of ranked) {
+      const exact = isExactNameMatch(query, r.name) ? ' ⭐ exact match' : '';
+      out += `- **${r.name}** (${r.type})${exact}\n`;
+    }
+
+    if (spliced.length > 0) {
+      out += `\n_${spliced.length} exact match(es) came from the SQLite symbol index — ` +
+        `the bridge's result window (maxResults=${maxResults}) did not contain them._\n`;
     }
 
     return { content: [{ type: 'text', text: out }] };

--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -145,7 +145,7 @@ export interface XppSymbol {
       | 'security-duty-extension' | 'security-role-extension'
       | 'menu-item-display-extension' | 'menu-item-action-extension'
       | 'menu-item-output-extension'
-      | 'service' | 'service-group'
+      | 'menu' | 'service' | 'service-group'
       | 'map' | 'configuration-key' | 'license-code' | 'security-policy' | 'macro';
   parentName?: string;
   signature?: string;

--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -812,7 +812,10 @@ export class XppMetadataParser {
       const name: string = root.Name || '';
       const label: string | undefined = root.Label || undefined;
 
-      const rawPrivs = root.Privileges?.AxSecurityRolePermissionSet ??
+      // #34, same family as the role parser: a standard AxSecurityDuty lists its
+      // privileges as <AxSecurityPrivilegeReference>.
+      const rawPrivs = root.Privileges?.AxSecurityPrivilegeReference ??
+                       root.Privileges?.AxSecurityRolePermissionSet ??
                        root.Privileges?.AxSecurityPrivilegePermissionSet;
       const privArray = rawPrivs ? (Array.isArray(rawPrivs) ? rawPrivs : [rawPrivs]) : [];
       const privileges: string[] = privArray
@@ -842,7 +845,12 @@ export class XppMetadataParser {
       const label: string | undefined = root.Label || undefined;
       const description: string | undefined = root.Description || undefined;
 
-      const rawDuties = root.Duties?.AxSecurityRoleDutyPermission ??
+      // #34: a STANDARD AxSecurityRole lists its duties as <AxSecurityDutyReference>.
+      // Only the two legacy/incorrect element names were read here, so a correctly
+      // shaped role parsed as "0 duties" — which security_info(mode=artifact) then
+      // reported as "Duties: none indexed" for a freshly indexed role.
+      const rawDuties = root.Duties?.AxSecurityDutyReference ??
+                        root.Duties?.AxSecurityRoleDutyPermission ??
                         root.Duties?.AxSecurityDutyPermission;
       const dutyArray = rawDuties ? (Array.isArray(rawDuties) ? rawDuties : [rawDuties]) : [];
       const duties: string[] = dutyArray

--- a/src/tools/edtInfo.ts
+++ b/src/tools/edtInfo.ts
@@ -10,6 +10,7 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { tryBridgeEdt } from '../bridge/bridgeAdapter.js';
+import { canonicalSymbolName, lookupSymbolNocase } from '../utils/symbolLookup.js';
 
 const GetEdtInfoArgsSchema = z.object({
   edtName: z.string().describe('Name of the Extended Data Type (EDT)'),
@@ -35,10 +36,28 @@ export async function getEdtInfoTool(request: CallToolRequest, context: XppServe
     const bridgeResult = await tryBridgeEdt(context.bridge, edtName);
     if (bridgeResult) return bridgeResult;
 
+    // Bridge returned nothing. That is NOT evidence the EDT is missing — it also
+    // happens when the bridge is unavailable, when it errored, or when its
+    // provider simply didn't resolve the name (#14: Num / Notes / CustAccount all
+    // returned "Bridge returned no data" while the very same EDTs resolved through
+    // validate_code(references) and appeared in search). Falling through to the
+    // SQLite index is both a real answer and the honest one.
+    const sqliteResult = getEdtFromIndex(symbolIndex, edtName, modelName);
+    if (sqliteResult) return sqliteResult;
+
     return {
       content: [{
         type: 'text',
-        text: `EDT "${edtName}" not found. Bridge returned no data — ensure the EDT exists in D365FO metadata.`,
+        text:
+          `No data available for EDT "${edtName}".\n\n` +
+          `Neither source could answer:\n` +
+          `  • C# bridge (IMetadataProvider): returned no data — it is either unavailable, ` +
+          `or it could not resolve this name.\n` +
+          `  • SQLite symbol index (edt_metadata / symbols): no row for this name.\n\n` +
+          `⚠️ This is "no data", NOT proof the EDT does not exist. Standard EDTs are routinely ` +
+          `resolvable through other paths — before changing working code, cross-check with ` +
+          `search(type="edt", query="${edtName}") or validate_code(mode="references").\n` +
+          `If the EDT was created in this session, index it first: update_symbol_index(filePath=<AxEdt xml>).`,
       }],
       isError: true,
     };
@@ -51,6 +70,88 @@ export async function getEdtInfoTool(request: CallToolRequest, context: XppServe
       isError: true,
     };
   }
+}
+
+/**
+ * Standard-mode SQLite fallback (#14).
+ *
+ * QUERY PLAN: `edt_metadata WHERE edt_name = ?` is an equality probe served by
+ * idx_edt_metadata_name (and idx_edt_metadata_unique when a model is given).
+ * A differently-cased name is canonicalized through `lookupSymbolNocase`
+ * (exact-case probe on idx_name_type + bounded FTS phrase fallback) rather than
+ * with `COLLATE NOCASE` / `LIKE`, which would scan the 1.17M-row symbols table.
+ *
+ * Returns null when the index has nothing, so the caller can say so plainly.
+ */
+function getEdtFromIndex(symbolIndex: any, edtName: string, modelName?: string) {
+  let db: any;
+  try {
+    db = symbolIndex?.getReadDb?.();
+  } catch {
+    return null;
+  }
+  if (!db) return null;
+
+  const readRow = (name: string) => {
+    try {
+      return db.prepare(
+        `SELECT edt_name, extends, enum_type, reference_table, relation_type,
+                string_size, database_string_size, display_length, label, model
+         FROM edt_metadata WHERE edt_name = ?${modelName ? ' AND model = ?' : ''} LIMIT 1`,
+      ).get(...(modelName ? [name, modelName] : [name])) as any;
+    } catch {
+      return undefined;
+    }
+  };
+
+  let row = readRow(edtName);
+  let resolvedName = edtName;
+
+  if (!row) {
+    // Canonicalize the caller's casing through the index-safe symbol lookup.
+    const canonical = canonicalSymbolName(db, edtName, ['edt']);
+    if (canonical && canonical !== edtName) {
+      resolvedName = canonical;
+      row = readRow(canonical);
+    }
+  }
+
+  if (!row) {
+    // No edt_metadata row, but the symbols table may still know the EDT exists
+    // (e.g. indexed by update_symbol_index before edt_metadata was populated).
+    const hit = lookupSymbolNocase(db, edtName, ['edt']);
+    if (!hit) return null;
+    return {
+      content: [{
+        type: 'text',
+        text:
+          `# Extended Data Type: ${hit.name}\n\n` +
+          (hit.model ? `**Model:** ${hit.model}\n` : '') +
+          `_Source: SQLite symbol index (bridge returned no data)_\n\n` +
+          `⚠️ Only the symbol entry is indexed — no \`edt_metadata\` row, so base type / string size / ` +
+          `reference table are NOT available from this server. This is missing data, not an empty EDT.\n` +
+          (hit.file_path ? `\nFile: ${hit.file_path}\n` : ''),
+      }],
+    };
+  }
+
+  let out = `# Extended Data Type: ${row.edt_name ?? resolvedName}\n\n`;
+  if (row.model) out += `**Model:** ${row.model}\n`;
+  out += `_Source: SQLite symbol index (edt_metadata) — the C# bridge returned no data_\n\n`;
+  out += `## 🔧 Core Properties\n\n`;
+  out += `| Property | Value |\n|---|---|\n`;
+  out += `| Extends | ${row.extends || '—'} |\n`;
+  if (row.enum_type) out += `| Enum Type | ${row.enum_type} |\n`;
+  if (row.reference_table) out += `| Reference Table | ${row.reference_table} |\n`;
+  if (row.relation_type) out += `| Relation Type | ${row.relation_type} |\n`;
+  if (row.string_size) out += `| String Size | ${row.string_size} |\n`;
+  if (row.database_string_size) out += `| Database String Size | ${row.database_string_size} |\n`;
+  if (row.display_length) out += `| Display Length | ${row.display_length} |\n`;
+  if (row.label) out += `| Label | ${row.label} |\n`;
+  out += `\nℹ️ Indexed metadata only — properties the extractor does not store ` +
+    `(HelpText, FormHelp, ConfigurationKey, Alignment…) are absent here, not absent from the EDT.\n`;
+
+  return { content: [{ type: 'text', text: out }] };
 }
 
 /**

--- a/src/tools/getLabelInfo.ts
+++ b/src/tools/getLabelInfo.ts
@@ -7,6 +7,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { formatLabelReference } from '../utils/labelReference.js';
 
 const GetLabelInfoArgsSchema = z.object({
   labelId: z
@@ -112,7 +113,9 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
     }
 
     const first = rows[0];
-    const ref = `@${first.labelFileId}:${labelId}`;
+    // #33/#41: never emit `@SYS:@SYS67433` — an id that already carries its label
+    // file id is a complete reference, and xppbp rejects the doubled form.
+    const ref = formatLabelReference(first.labelFileId, labelId);
 
     const lines: string[] = [
       `Label: ${ref}`,

--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -24,6 +24,38 @@ async function tryXppbp(xppbpPath: string, args: string[]): Promise<{ stdout: st
   });
 }
 
+/**
+ * Element names xppbp mentions in its output. Recognises the two shapes it
+ * emits: an AOT file path (`…\AxTable\ConDemoTicket.xml`) and a quoted element
+ * reference (`element 'ConDemoTicket'` / `Table 'ConDemoTicket'`).
+ */
+export function extractReportedElements(output: string): string[] {
+  const names = new Set<string>();
+  for (const m of output.matchAll(/[\\/]Ax[A-Za-z]+[\\/]([A-Za-z0-9_]+)\.xml/g)) names.add(m[1]);
+  for (const m of output.matchAll(/\b(?:element|table|class|form|query|view|enum|edt)\s+'([A-Za-z0-9_]+)'/gi)) {
+    names.add(m[1]);
+  }
+  return [...names];
+}
+
+/**
+ * Scope-verification note for a filtered run (#25). xppbp silently ignores an
+ * unknown filter flag, so a scoped call can quietly return whole-model results;
+ * saying so is better than leaving the agent to attribute findings by hand.
+ */
+export function describeScope(targetFilter: string, output: string): string {
+  const reported = extractReportedElements(output);
+  const foreign = reported.filter(n => n.toLowerCase() !== targetFilter.toLowerCase());
+  if (foreign.length === 0) {
+    return reported.length > 0 ? `\nScope: honoured — findings are for ${targetFilter} only.` : '';
+  }
+  return (
+    `\n⚠️ Scope NOT honoured: xppbp also reported on ${foreign.slice(0, 5).join(', ')}` +
+    `${foreign.length > 5 ? ` (+${foreign.length - 5} more)` : ''}. ` +
+    `Findings below are NOT all attributable to "${targetFilter}" — check each element name before acting.`
+  );
+}
+
 export const runBpCheckTool = async (params: any, _context: any) => {
   const { targetFilter, targetElementType } = params;
   try {
@@ -101,15 +133,24 @@ export const runBpCheckTool = async (params: any, _context: any) => {
      */
 
     // Style A — colon separator with -compilerMetadata
+    //
+    // #25: `-all` means "check the whole model" and xppbp does NOT recognise
+    // `-filter:` — so this style silently ignored the requested scope (a run
+    // filtered to one class returned warnings for two unrelated table elements).
+    // With a targetFilter we therefore drop `-all` and append the positional
+    // `<type>:<Name>` element selector this xppbp understands.
     const buildArgsColonStyle = (metadataFlag: string, compilerMetadataFlag: string): string[] => {
       const a: string[] = [
         `${metadataFlag}${metadataPath}`,
         `-module:${modelName}`,
         `-model:${modelName}`,
         `${compilerMetadataFlag}${compilerMetadataPath}`,
-        `-all`,
       ];
-      if (targetFilter) a.push(`-filter:${targetFilter}`);
+      if (targetFilter) {
+        a.push(`${(targetElementType ?? 'class').toLowerCase()}:${targetFilter}`);
+      } else {
+        a.push(`-all`);
+      }
       return a;
     };
 
@@ -128,13 +169,14 @@ export const runBpCheckTool = async (params: any, _context: any) => {
         a.push(`-packagesRoot=${compilerMetadataPath}`);
       }
 
-      a.push(`-all`);
-
       // Positional element filter: "<type>:<Name>" — type comes from targetElementType
-      // (defaults to 'class' when omitted for backwards compatibility).
+      // (defaults to 'class' when omitted for backwards compatibility). `-all` is
+      // mutually exclusive with it: passing both checks the whole model (#25).
       if (targetFilter) {
         const elemType = (targetElementType ?? 'class').toLowerCase();
         a.push(`${elemType}:${targetFilter}`);
+      } else {
+        a.push(`-all`);
       }
       return a;
     };
@@ -146,9 +188,12 @@ export const runBpCheckTool = async (params: any, _context: any) => {
         `-packagesRoot:${compilerMetadataPath}`,
         `-module:${modelName}`,
         `-model:${modelName}`,
-        `-all`,
       ];
-      if (targetFilter) a.push(`-filter:${targetFilter}`);
+      if (targetFilter) {
+        a.push(`${(targetElementType ?? 'class').toLowerCase()}:${targetFilter}`);
+      } else {
+        a.push(`-all`);
+      }
       return a;
     };
 
@@ -239,12 +284,17 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     const summary = hasIssues ? '⚠️ BP Check completed with issues' : '✅ BP Check passed';
     const details = logContent || combined || '(no output)';
 
+    // #25: report honestly whether the requested scope actually took effect —
+    // attribution used to require reading rule names and guessing.
+    const scopeNote = targetFilter ? describeScope(targetFilter, combined) : '';
+
     return {
       content: [{
         type: 'text',
         text: `${summary}\n\nModel: ${modelName}` +
           (resolvedProjectPath ? `\nProject: ${resolvedProjectPath}` : '') +
-          (targetFilter ? `\nFilter: ${targetFilter}` : '') +
+          (targetFilter ? `\nFilter: ${(targetElementType ?? 'class').toLowerCase()}:${targetFilter}` : '') +
+          scopeNote +
           `\n\n${details}`
       }]
     };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -18,6 +18,42 @@ import {
   formatSuggestions
 } from '../utils/suggestionEngine.js';
 import { tryBridgeSearch } from '../bridge/bridgeAdapter.js';
+import { lookupSymbolsNocase } from '../utils/symbolLookup.js';
+import { rankExactFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
+
+/**
+ * Index-safe probe for symbols whose name EQUALS the query (#15).
+ *
+ * Runs `lookupSymbolsNocase`, i.e. an exact-case equality probe on
+ * idx_name_type followed by a bounded FTS5 phrase match for differently-cased
+ * input. Deliberately NOT `LIKE` and NOT `name = ? COLLATE NOCASE` as the
+ * primary predicate: on the 1.17M-row production symbol DB either shape
+ * degrades to a full scan (80–278 s measured) and blocks the event loop until
+ * MCP clients kill the server.
+ *
+ * Returns [] on any failure — the exact-first repair must never break search.
+ */
+export function probeExactMatches(
+  symbolIndex: any,
+  query: string,
+  types?: string[],
+): Array<{ name: string; type: string; model?: string; filePath?: string }> {
+  if (!query || /[\s*"%]/.test(query)) return [];
+  try {
+    const db = symbolIndex?.getReadDb?.();
+    if (!db) return [];
+    return lookupSymbolsNocase(db, query, { types, limit: 5 })
+      .filter(hit => isExactNameMatch(query, hit.name))
+      .map(hit => ({
+        name: hit.name,
+        type: hit.type,
+        model: hit.model ?? undefined,
+        filePath: hit.file_path ?? undefined,
+      }));
+  } catch {
+    return [];
+  }
+}
 
 const SearchArgsSchema = z.object({
   query: z.string().describe('Search query (class name, method name, etc.)'),
@@ -43,8 +79,18 @@ export async function searchTool(request: CallToolRequest, context: XppServerCon
       return await performHybridSearch(args, context);
     }
 
-    // Try C# bridge first (IMetadataProvider — live D365FO metadata)
-    const bridgeResult = await tryBridgeSearch(context.bridge, args.query, args.type === 'all' ? undefined : args.type, args.limit);
+    // Try C# bridge first (IMetadataProvider — live D365FO metadata).
+    // The exact-name probe is passed along so an exact match that fell outside
+    // the bridge's truncated result window is still ranked first (#15).
+    const searchTypes = args.type === 'all' ? undefined : [args.type];
+    const exactMatches = probeExactMatches(symbolIndex, args.query, searchTypes);
+    const bridgeResult = await tryBridgeSearch(
+      context.bridge,
+      args.query,
+      args.type === 'all' ? undefined : args.type,
+      args.limit,
+      { exactMatches },
+    );
     if (bridgeResult) return bridgeResult;
 
     // Standard external metadata search
@@ -221,7 +267,15 @@ async function performExternalSearch(
 ) {
   try {
     const types = args.type === 'all' ? undefined : [args.type];
-    const results: any[] = symbolIndex.searchSymbols(args.query, args.limit, types) || [];
+    const raw: any[] = symbolIndex.searchSymbols(args.query, args.limit, types) || [];
+
+    // #15: FTS5 `ORDER BY rank` scores token frequency, not name equality, so an
+    // exact-name hit can be missing from (or buried inside) the window. Probe for
+    // it on-index and rank it first.
+    const seen = new Set(raw.map(r => `${String(r.name).toLowerCase()} ${r.type}`));
+    const missingExact = probeExactMatches(symbolIndex, args.query, types)
+      .filter(hit => !seen.has(`${hit.name.toLowerCase()} ${hit.type}`));
+    const results: any[] = rankExactFirst(args.query, [...missingExact, ...raw], r => String(r.name));
 
     if (!results || results.length === 0) {
       const allSymbolNames = symbolIndex.getAllSymbolNames(args.query);
@@ -267,7 +321,15 @@ async function performExternalSearch(
     const tips = args.verbose ? generateContextualTips(args.query, results, args.type) : [];
 
     let output = `Found ${results.length} matches:\n`;
-    
+
+    // #15: the grouped renderer below hides ordering, so call the exact match out
+    // explicitly — that is the whole point of the exact-first repair.
+    const exactHits = results.filter(r => isExactNameMatch(args.query, String(r.name)));
+    if (exactHits.length > 0) {
+      output += `\n⭐ **Exact name match:** ` +
+        exactHits.map(r => `${r.name} (${r.type})`).join(', ') + '\n';
+    }
+
     output += formatRichContext(args.query, results, {
       relatedSearches,
       commonPatterns,

--- a/src/tools/searchLabels.ts
+++ b/src/tools/searchLabels.ts
@@ -12,6 +12,12 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { getConfigManager } from '../utils/configManager.js';
+import {
+  formatLabelReference,
+  isLabelLikelyResolvable,
+  labelProvenanceWarning,
+} from '../utils/labelReference.js';
 
 const SearchLabelsArgsSchema = z.object({
   query: z
@@ -34,6 +40,16 @@ const SearchLabelsArgsSchema = z.object({
     .describe('Restrict results to a specific label file ID (e.g. ContosoExt, SYS)'),
   limit: z.number().optional().default(30).describe('Maximum number of results (default 30)'),
 });
+
+/** Best-effort current model: explicit arg → configured model → env. Never throws. */
+function resolveCurrentModel(explicit?: string): string | undefined {
+  if (explicit) return explicit;
+  try {
+    const configured = getConfigManager().getModelName();
+    if (configured) return configured;
+  } catch { /* config not loaded — fall through */ }
+  return process.env.D365FO_MODEL_NAME || undefined;
+}
 
 export async function searchLabelsTool(request: CallToolRequest, context: XppServerContext) {
   try {
@@ -75,19 +91,36 @@ export async function searchLabelsTool(request: CallToolRequest, context: XppSer
       '',
     ];
 
-    for (const raw of results) {
-      const r = normalise(raw);
-      // X++ label reference syntax
-      const ref = `@${r.labelFileId}:${r.labelId}`;
-      lines.push(`  ${ref}`);
+    const currentModel = resolveCurrentModel(args.model);
+
+    const normalised = results.map(normalise);
+
+    for (const r of normalised) {
+      // X++ label reference syntax — never double-prefix an id that already
+      // carries its label file id (#33/#41: `@SYS:@SYS67433` is rejected by xppbp).
+      const ref = formatLabelReference(r.labelFileId, r.labelId);
+      const resolvable = isLabelLikelyResolvable(r.labelFileId, r.model, currentModel);
+      lines.push(`  ${ref}${resolvable ? '' : `   ${labelProvenanceWarning(r.model)}`}`);
       lines.push(`  Text    : ${r.text}`);
       if (r.comment) lines.push(`  Comment : ${r.comment}`);
       lines.push(`  Model   : ${r.model}  |  LabelFile: ${r.labelFileId}`);
       lines.push('');
     }
 
-    lines.push(`💡 Use the label reference syntax in X++:  literalStr("@${(normalise(results[0])).labelFileId}:${(normalise(results[0])).labelId}")`);
-    lines.push(`💡 Or in metadata XML:  <Label>@${(normalise(results[0])).labelFileId}:${(normalise(results[0])).labelId}</Label>`);
+    // Only ever *recommend* a label the model can actually resolve — suggesting an
+    // unreferenced one is what produced BPErrorUnknownLabel in the sweep (#33/#41).
+    const recommended = normalised.find(r => isLabelLikelyResolvable(r.labelFileId, r.model, currentModel));
+    if (recommended) {
+      const ref = formatLabelReference(recommended.labelFileId, recommended.labelId);
+      lines.push(`💡 Use the label reference syntax in X++:  literalStr("${ref}")`);
+      lines.push(`💡 Or in metadata XML:  <Label>${ref}</Label>`);
+    } else {
+      lines.push(
+        `⚠️ None of these labels is in a core label file (SYS/…) or in your own model, so none is ` +
+        `recommended as-is: referencing one raises BPErrorUnknownLabel unless your model references ` +
+        `its package. Create your own with labels(action="create") instead.`,
+      );
+    }
 
     return {
       content: [{ type: 'text', text: lines.join('\n') }],

--- a/src/tools/securityArtifactInfo.ts
+++ b/src/tools/securityArtifactInfo.ts
@@ -165,6 +165,11 @@ function getDutyInfo(db: any, name: string, includeChain: boolean) {
         output += `  • ${priv.privilege_name}\n`;
       }
     }
+  } else {
+    // #34: same honesty rule as roles — absence of rows is absence of data.
+    output += `\nPrivileges: NO DATA — no rows in the security_duty_privileges index for ` +
+      `"${symbol.name}". Feed it with update_symbol_index(filePath=<AxSecurityDuty xml>) or a full ` +
+      `index build; an unindexed duty is indistinguishable from an empty one here.\n`;
   }
 
   if (roles.length > 0) {
@@ -238,7 +243,16 @@ function getRoleInfo(db: any, name: string, includeChain: boolean) {
       }
     }
   } else {
-    output += `\nDuties: none indexed\n`;
+    // #34: "none indexed" read as "this role has no duties", which is a claim this
+    // tool cannot make — security_role_duties is populated only when the role XML
+    // was parsed by a full build or by update_symbol_index. Say what is actually known.
+    output += `\nDuties: NO DATA — this server has no rows in its security_role_duties index for ` +
+      `"${symbol.name}".\n` +
+      `  This does NOT mean the role has no duties. The table is fed by a full index build or by ` +
+      `update_symbol_index(filePath=<AxSecurityRole xml>); a role that was never indexed looks ` +
+      `identical to an empty one here.\n` +
+      `  To verify: run update_symbol_index on the role's .xml and retry, or read the ` +
+      `<Duties> element of the file directly.\n`;
   }
 
   return { content: [{ type: 'text', text: output }] };

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -30,6 +30,9 @@ const AOT_FOLDER_TYPE_MAP: Record<string, XppSymbol['type']> = {
   'axreport': 'report',
   'axmap': 'map',
   'axmapextension': 'map-extension',
+  // #34: AxMenu was missing here, so a menu was indexed as type=class (the `?? 'class'`
+  // default below) AND model=Unknown (extractModelFromPath only recognised MAPPED folders).
+  'axmenu': 'menu',
   'axmenuextension': 'menu-extension',
   'axservice': 'service',
   'axservicegroup': 'service-group',
@@ -55,10 +58,21 @@ const AOT_FOLDER_TYPE_MAP: Record<string, XppSymbol['type']> = {
  * Pattern: {packagesRoot}\{package}\{model}\Ax{Type}\{Name}.xml
  * or:      {packagesRoot}\{model}\{model}\Ax{Type}\{Name}.xml
  */
+/** Any AOT element folder, mapped or not (AxMenu, AxWorkflowType, …). */
+const AOT_FOLDER_PATTERN = /^ax[a-z]/i;
+
+/** True for an AOT element folder segment — mapped types plus everything else Ax*. */
+export function isAotFolder(segment: string): boolean {
+  return segment.toLowerCase() in AOT_FOLDER_TYPE_MAP || AOT_FOLDER_PATTERN.test(segment);
+}
+
 function extractModelFromPath(filePath: string): string | null {
   const parts = filePath.replace(/\//g, '\\').split('\\');
-  // Find the AOT folder index (e.g. AxClass, AxTable)
-  const aotIdx = parts.findIndex(p => p.toLowerCase() in AOT_FOLDER_TYPE_MAP);
+  // Find the AOT folder index (e.g. AxClass, AxTable).
+  // #34: this used to accept only folders present in AOT_FOLDER_TYPE_MAP, so an
+  // AxMenu path yielded model="Unknown" purely because the type map had a hole.
+  // Any Ax* element folder identifies the model, whether or not we can type it.
+  const aotIdx = parts.findIndex(p => isAotFolder(p));
   if (aotIdx >= 2) {
     return parts[aotIdx - 1]; // folder immediately before the AOT folder = model name
   }
@@ -70,6 +84,28 @@ function extractModelFromPath(filePath: string): string | null {
   }
 
   return null;
+}
+
+/**
+ * Symbol type for an AOT folder segment.
+ *
+ * #34: the old expression was `AOT_FOLDER_TYPE_MAP[folder] ?? 'class'`, which
+ * turned every unmapped AOT folder into a CLASS — an AxMenu was indexed as
+ * `type=class`, poisoning search and every type-scoped lookup. A folder we can
+ * name but not map now yields its own derived type (`AxWorkflowType` →
+ * `workflowtype`) instead of a confident lie; `class` remains the fallback only
+ * when the path carries no AOT folder at all.
+ */
+export function classifyAotFolder(aotFolder: string): XppSymbol['type'] {
+  const key = aotFolder.toLowerCase();
+  const mapped = AOT_FOLDER_TYPE_MAP[key];
+  if (mapped) return mapped;
+  if (AOT_FOLDER_PATTERN.test(aotFolder)) {
+    // Derived, deliberately outside the curated union — it is a truthful label
+    // for a type this server does not model, and stays searchable.
+    return key.replace(/^ax/, '') as XppSymbol['type'];
+  }
+  return 'class';
 }
 
 function isLabelTextFile(filePath: string): boolean {
@@ -142,8 +178,8 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
     const fileName = pathParts[pathParts.length - 1] ?? filePath;
     const objectName = fileName.replace(/\.[^.]+$/, '');
     const parts = filePath.replace(/\//g, '\\').split('\\');
-    const aotFolder = parts.find((p: string) => p.toLowerCase() in AOT_FOLDER_TYPE_MAP) ?? '';
-    const objectType: XppSymbol['type'] = AOT_FOLDER_TYPE_MAP[aotFolder.toLowerCase()] ?? 'class';
+    const aotFolder = parts.find((p: string) => isAotFolder(p)) ?? '';
+    const objectType: XppSymbol['type'] = classifyAotFolder(aotFolder);
 
     // File deleted: clean up stale index entries
     if (!fs.existsSync(filePath)) {

--- a/src/utils/exactMatchRanking.ts
+++ b/src/utils/exactMatchRanking.ts
@@ -1,0 +1,47 @@
+/**
+ * Exact-match-first ranking for object searches.
+ *
+ * Defect #15 (2026-07-21 sweep): `search(type="edt", query="Num")` at limit=40
+ * never surfaced the EDT `Num` — the result window was filled with `NumberOf*` /
+ * `Numeric*` prefix hits. Neither backing search ranks by match quality:
+ *   • the C# bridge scans provider primary keys in provider order and stops at
+ *     `Results.Count >= maxResults` (MetadataReadService.SearchObjects), and
+ *   • the SQLite path orders by FTS5 `rank`, which is a token-frequency score,
+ *     not a name-equality score.
+ * So a short exact name that happens to sort/enumerate late is invisible.
+ *
+ * PERFORMANCE NOTE: ranking here is pure in-memory work over an already-bounded
+ * result window — it never widens a SQL query. The companion "the exact match
+ * was outside the window" probe must stay index-safe; see
+ * `lookupSymbolsNocase` in utils/symbolLookup.ts (exact-case probe on
+ * idx_name_type, bounded FTS phrase fallback — never `LIKE` and never
+ * `COLLATE NOCASE` as the primary predicate).
+ */
+
+/** Lower is better. 0 = exact, 1 = exact ignoring case, 2 = prefix, 3 = everything else. */
+export function exactMatchRank(query: string, name: string): 0 | 1 | 2 | 3 {
+  if (name === query) return 0;
+  const ln = name.toLowerCase();
+  const lq = query.toLowerCase();
+  if (ln === lq) return 1;
+  if (ln.startsWith(lq)) return 2;
+  return 3;
+}
+
+/** True when `name` equals `query` ignoring case. */
+export function isExactNameMatch(query: string, name: string): boolean {
+  return exactMatchRank(query, name) <= 1;
+}
+
+/**
+ * Stable sort putting exact name matches first, then case-insensitive exact,
+ * then prefix matches, leaving the backing search's own order intact within
+ * each band (so bridge/FTS relevance is preserved where it says nothing about
+ * name equality).
+ */
+export function rankExactFirst<T>(query: string, items: T[], nameOf: (item: T) => string): T[] {
+  return items
+    .map((item, idx) => ({ item, idx, rank: exactMatchRank(query, nameOf(item)) }))
+    .sort((a, b) => (a.rank - b.rank) || (a.idx - b.idx))
+    .map(entry => entry.item);
+}

--- a/src/utils/labelReference.ts
+++ b/src/utils/labelReference.ts
@@ -1,0 +1,79 @@
+/**
+ * Label reference formatting + deployability annotation.
+ *
+ * Defect #33/#41 (reproduced twice on the VM): the labels tool advertised
+ * `@SYS:@SYS67433` — it built every reference as `@${labelFileId}:${labelId}`
+ * without noticing that the indexed label id already carries its own
+ * `@FileId` prefix. xppbp rejects that doubled form:
+ *   `BPErrorLabelIsText: '@SYS:@SYS67433' is not a label ID`
+ * The form xppbp accepts is `@SYS67433`.
+ *
+ * Second half of the same finding: the tool happily suggests labels from label
+ * files that are not deployed/referenced here (`@EnterpriseAssetManagementAppSuite:*`,
+ * `@RevenueRecognition:ItemName` → "Unknown label" / `BPErrorUnknownLabel`).
+ * Suggesting a reference the model cannot resolve is a defect, so results carry
+ * an explicit provenance warning instead of reading as ready-to-use.
+ */
+
+/**
+ * Canonical X++/metadata label reference for an indexed label row.
+ *
+ *   ('SYS', '@SYS67433')       → '@SYS67433'   (id already carries its file id)
+ *   ('SYS', 'SYS67433')        → '@SYS67433'   (legacy id-embeds-file-id form)
+ *   ('ContosoExt', 'MyLabel')  → '@ContosoExt:MyLabel'
+ *   ('ContosoExt', '@ContosoExt:MyLabel') → unchanged
+ */
+export function formatLabelReference(labelFileId: string | undefined, labelId: string): string {
+  const id = (labelId ?? '').trim();
+  const fileId = (labelFileId ?? '').trim();
+
+  // Repair an already-doubled reference (`@SYS:@SYS67433` → `@SYS67433`) — the
+  // exact shape xppbp rejects, which can also arrive from stored data.
+  const doubled = /^@[A-Za-z0-9_]+:(@.+)$/.exec(id);
+  if (doubled) return doubled[1];
+
+  // Already a complete reference (either legacy `@SYS123` or `@File:Id`).
+  if (id.startsWith('@')) return id;
+  if (!fileId) return `@${id}`;
+
+  // Legacy form: the id embeds the label file id (`SYS67433` in file `SYS`).
+  // Emitting `@SYS:SYS67433` here is what produced the doubled `@SYS:@SYS67433`
+  // once the stored id kept its `@`; the id-embeds-file-id shape must collapse.
+  if (id.toLowerCase().startsWith(fileId.toLowerCase()) && id.length > fileId.length) {
+    return `@${id}`;
+  }
+
+  return `@${fileId}:${id}`;
+}
+
+/**
+ * Label files that every model can resolve without adding a package reference.
+ * Deliberately small and conservative — anything else gets flagged rather than
+ * silently recommended.
+ */
+const ALWAYS_RESOLVABLE_LABEL_FILES = new Set(
+  ['sys', 'syp', 'sysbp', 'applicationplatform', 'applicationfoundation', 'applicationsuite'],
+);
+
+/**
+ * True when a label reference is safe to hand to the model as-is: it lives in a
+ * core label file or in the caller's own model. Anything else may raise
+ * `BPErrorUnknownLabel` because its owning package is not referenced.
+ */
+export function isLabelLikelyResolvable(
+  labelFileId: string | undefined,
+  labelModel: string | undefined,
+  currentModel?: string,
+): boolean {
+  const fileId = (labelFileId ?? '').toLowerCase();
+  if (ALWAYS_RESOLVABLE_LABEL_FILES.has(fileId)) return true;
+  if (currentModel && (labelModel ?? '').toLowerCase() === currentModel.toLowerCase()) return true;
+  if (currentModel && fileId === currentModel.toLowerCase()) return true;
+  return false;
+}
+
+/** Short inline warning for a label whose owning package may not be referenced. */
+export function labelProvenanceWarning(labelModel: string | undefined): string {
+  return `⚠️ owned by model "${labelModel ?? 'unknown'}" — resolves only if your model references ` +
+    `that package; otherwise xppbp reports BPErrorUnknownLabel`;
+}

--- a/tests/tools/edtInfo-bridge-fallback.test.ts
+++ b/tests/tools/edtInfo-bridge-fallback.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Finding #14 (2026-07-21 golden-capture sweep, HIGH):
+ *   `get_object_info(objectType="edt", name="Num"|"Notes"|"CustAccount")` all
+ *   answered `EDT "X" not found. Bridge returned no data — ensure the EDT exists
+ *   in D365FO metadata.` while the same EDTs resolved through
+ *   validate_code(references) and appeared in search.
+ *
+ * Root cause: getEdtInfoTool's standard mode consulted ONE source (the C# bridge)
+ * and translated "the bridge returned null" — which also means "bridge absent",
+ * "bridge errored", "provider did not resolve the name" — into the factual claim
+ * that the EDT does not exist. The tool held a fully populated `edt_metadata`
+ * table the whole time (hierarchy mode reads it) and never looked.
+ *
+ * That is the worst failure mode in the loop: the agent "corrects" working code
+ * away from a valid standard EDT.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { getEdtInfoTool } from '../../src/tools/edtInfo';
+
+function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: string; model?: string }>) {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE edt_metadata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      edt_name TEXT NOT NULL, extends TEXT, enum_type TEXT, reference_table TEXT,
+      relation_type TEXT, string_size TEXT, database_string_size TEXT,
+      display_length TEXT, label TEXT, model TEXT NOT NULL
+    );
+    CREATE INDEX idx_edt_metadata_name ON edt_metadata(edt_name);
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL, type TEXT NOT NULL, parent_name TEXT,
+      signature TEXT, file_path TEXT, model TEXT, description TEXT, extends_class TEXT
+    );
+    CREATE INDEX idx_name_type ON symbols(name, type);
+    CREATE VIRTUAL TABLE symbols_fts USING fts5(name, type, parent_name, signature, description, tags);
+  `);
+  const insEdt = db.prepare(
+    `INSERT INTO edt_metadata (edt_name, extends, string_size, model) VALUES (?, ?, ?, ?)`,
+  );
+  const insSym = db.prepare(`INSERT INTO symbols (name, type, model) VALUES (?, 'edt', ?)`);
+  const insFts = db.prepare(`INSERT INTO symbols_fts (rowid, name, type) VALUES (?, ?, 'edt')`);
+  for (const r of rows) {
+    insEdt.run(r.name, r.extends ?? null, r.stringSize ?? null, r.model ?? 'ApplicationPlatform');
+    const info = insSym.run(r.name, r.model ?? 'ApplicationPlatform');
+    insFts.run(info.lastInsertRowid, r.name);
+  }
+  return db;
+}
+
+/** Context whose bridge answers exactly like the VM did: nothing, for every EDT. */
+function ctx(db: any) {
+  return {
+    symbolIndex: { getReadDb: () => db },
+    bridge: { isReady: true, metadataAvailable: true, readEdt: vi.fn(async () => null) },
+  } as any;
+}
+
+const req = (edtName: string) => ({
+  method: 'tools/call' as const,
+  params: { name: 'get_edt_info', arguments: { edtName } },
+});
+
+describe('get_edt_info — bridge returns no data (#14)', () => {
+  it('answers from the SQLite index instead of denying that Num exists', async () => {
+    const db = makeDb([{ name: 'Num', extends: 'str', stringSize: '20' }]);
+
+    const result = await getEdtInfoTool(req('Num'), ctx(db));
+
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text as string;
+    expect(text).toContain('Num');
+    expect(text).toContain('SQLite symbol index');
+    // The lie the finding is about must be gone.
+    expect(text).not.toMatch(/not found/i);
+  });
+
+  it.each(['Notes', 'CustAccount'])('resolves the standard EDT %s from the index', async (name) => {
+    const db = makeDb([{ name, extends: 'str' }]);
+    const result = await getEdtInfoTool(req(name), ctx(db));
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text as string).toContain(name);
+  });
+
+  it('resolves a differently-cased name through the canonicalizing lookup', async () => {
+    const db = makeDb([{ name: 'CustAccount', extends: 'str' }]);
+    const result = await getEdtInfoTool(req('custaccount'), ctx(db));
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text as string).toContain('CustAccount');
+  });
+
+  it('falls back to the symbols row when edt_metadata has none, and says so', async () => {
+    const db = makeDb([]);
+    db.prepare(`INSERT INTO symbols (name, type, model) VALUES ('ConDemoId', 'edt', 'Contoso')`).run();
+    db.prepare(`INSERT INTO symbols_fts (rowid, name, type) VALUES (1, 'ConDemoId', 'edt')`).run();
+
+    const result = await getEdtInfoTool(req('ConDemoId'), ctx(db));
+
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text as string;
+    expect(text).toContain('ConDemoId');
+    expect(text).toContain('missing data, not an empty EDT');
+  });
+
+  it('when NOTHING knows the name, reports "no data" and refuses to claim non-existence', async () => {
+    const db = makeDb([{ name: 'Num' }]);
+
+    const result = await getEdtInfoTool(req('NoSuchEdtAnywhere'), ctx(db));
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text as string;
+    expect(text).toContain('No data available');
+    expect(text).toContain('NOT proof the EDT does not exist');
+    // It must point at the sources that DID resolve these EDTs on the VM.
+    expect(text).toContain('validate_code');
+    expect(text).toContain('search(');
+  });
+
+  it('still prefers the bridge when the bridge has data', async () => {
+    const db = makeDb([{ name: 'Num', extends: 'str' }]);
+    const context = ctx(db);
+    context.bridge.readEdt = vi.fn(async () => ({ name: 'Num', baseType: 'String', model: 'AppPlatform' }));
+
+    const result = await getEdtInfoTool(req('Num'), context);
+
+    expect(result.content[0].text as string).toContain('C# bridge');
+  });
+});

--- a/tests/tools/labelReference.test.ts
+++ b/tests/tools/labelReference.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Findings #33 / #41 (2026-07-21 sweep; both halves reproduced twice on the VM).
+ *
+ * (a) The labels tool advertised `@SYS:@SYS67433` — it built every reference as
+ *     `@${labelFileId}:${labelId}` without noticing that the indexed id already
+ *     carries its own `@FileId`. xppbp answers
+ *     `BPErrorLabelIsText: '@SYS:@SYS67433' is not a label ID`; the accepted
+ *     form is `@SYS67433`.
+ * (b) It recommended labels from label files that are not deployed/referenced
+ *     here (`@EnterpriseAssetManagementAppSuite:*`, `@RevenueRecognition:ItemName`
+ *     → "Unknown label" / `BPErrorUnknownLabel`). Suggesting a reference the
+ *     model cannot resolve is a defect, not a nicety.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  formatLabelReference,
+  isLabelLikelyResolvable,
+} from '../../src/utils/labelReference';
+import { searchLabelsTool } from '../../src/tools/searchLabels';
+import { getLabelInfoTool } from '../../src/tools/getLabelInfo';
+
+// ── (a) reference syntax ─────────────────────────────────────────────────────
+
+describe('formatLabelReference (#33/#41a)', () => {
+  it('never doubles the @FileId prefix — the exact string xppbp rejected', () => {
+    expect(formatLabelReference('SYS', '@SYS67433')).toBe('@SYS67433');
+    expect(formatLabelReference('SYS', '@SYS71455')).toBe('@SYS71455');
+    expect(formatLabelReference('SYS', '@SYS:@SYS67433')).not.toContain(':@');
+  });
+
+  it('collapses the legacy id-embeds-file-id form to @SYS67433', () => {
+    expect(formatLabelReference('SYS', 'SYS67433')).toBe('@SYS67433');
+  });
+
+  it('keeps the @File:Id form for a real custom label', () => {
+    expect(formatLabelReference('ContosoExt', 'MyLabel')).toBe('@ContosoExt:MyLabel');
+  });
+
+  it('leaves an already-complete reference alone', () => {
+    expect(formatLabelReference('ContosoExt', '@ContosoExt:MyLabel')).toBe('@ContosoExt:MyLabel');
+  });
+});
+
+// ── (b) deployability ────────────────────────────────────────────────────────
+
+describe('isLabelLikelyResolvable (#33/#41b)', () => {
+  it('treats core label files as resolvable', () => {
+    expect(isLabelLikelyResolvable('SYS', 'ApplicationPlatform', 'Contoso')).toBe(true);
+  });
+
+  it('treats the caller\'s own model as resolvable', () => {
+    expect(isLabelLikelyResolvable('ContosoExt', 'ContosoExt', 'ContosoExt')).toBe(true);
+  });
+
+  it('flags the exact label files that raised BPErrorUnknownLabel on the VM', () => {
+    expect(isLabelLikelyResolvable('EnterpriseAssetManagementAppSuite', 'EnterpriseAssetManagement', 'Contoso')).toBe(false);
+    expect(isLabelLikelyResolvable('RevenueRecognition', 'RevenueRecognition', 'Contoso')).toBe(false);
+  });
+});
+
+// ── tool output ──────────────────────────────────────────────────────────────
+
+function ctxWith(rows: any[]) {
+  return {
+    symbolIndex: {
+      searchLabels: vi.fn(() => rows),
+      getLabelById: vi.fn(() => rows),
+    },
+  } as any;
+}
+
+const searchReq = (query: string) => ({
+  method: 'tools/call' as const,
+  params: { name: 'search_labels', arguments: { query } },
+});
+
+describe('labels(action="search") output (#33/#41)', () => {
+  it('emits @SYS67433, never @SYS:@SYS67433', async () => {
+    const context = ctxWith([
+      { label_id: '@SYS67433', label_file_id: 'SYS', model: 'ApplicationPlatform', language: 'en-US', text: 'Item name' },
+    ]);
+
+    const result = await searchLabelsTool(searchReq('item name'), context);
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('@SYS67433');
+    expect(text).not.toContain('@SYS:@SYS67433');
+    expect(text).not.toContain(':@');
+    expect(text).toContain('<Label>@SYS67433</Label>');
+  });
+
+  it('warns on labels whose owning package may not be referenced', async () => {
+    const context = ctxWith([
+      {
+        label_id: 'ItemName', label_file_id: 'RevenueRecognition', model: 'RevenueRecognition',
+        language: 'en-US', text: 'Item name',
+      },
+    ]);
+
+    const result = await searchLabelsTool(searchReq('item name'), context);
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('BPErrorUnknownLabel');
+    // …and must NOT hand it over as a ready-to-paste recommendation.
+    expect(text).not.toContain('<Label>@RevenueRecognition:ItemName</Label>');
+  });
+
+  it('recommends the resolvable label when the result set is mixed', async () => {
+    const context = ctxWith([
+      {
+        label_id: 'ItemName', label_file_id: 'EnterpriseAssetManagementAppSuite',
+        model: 'EnterpriseAssetManagement', language: 'en-US', text: 'Item name',
+      },
+      { label_id: '@SYS71455', label_file_id: 'SYS', model: 'ApplicationPlatform', language: 'en-US', text: 'Item name' },
+    ]);
+
+    const result = await searchLabelsTool(searchReq('item name'), context);
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('literalStr("@SYS71455")');
+  });
+});
+
+describe('labels(action="info") output (#33/#41)', () => {
+  it('emits the single-@ form for a SYS label', async () => {
+    const context = ctxWith([
+      { labelId: '@SYS71455', labelFileId: 'SYS', model: 'ApplicationPlatform', language: 'en-US', text: 'Item name' },
+    ]);
+
+    const result = await getLabelInfoTool(
+      { method: 'tools/call', params: { name: 'get_label_info', arguments: { labelId: '@SYS71455' } } } as any,
+      context,
+    );
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('@SYS71455');
+    expect(text).not.toContain(':@');
+    expect(text).toContain('<Label>@SYS71455</Label>');
+  });
+});

--- a/tests/tools/runBpCheck.test.ts
+++ b/tests/tools/runBpCheck.test.ts
@@ -453,8 +453,110 @@ describe('run_bp_check — violation detection', () => {
 
     const result = await runBpCheckTool({ modelName: 'MyModel', targetFilter: 'MyClass' }, {});
 
-    expect(result.content[0].text).toContain('Filter: MyClass');
+    expect(result.content[0].text).toContain('Filter: class:MyClass');
     const args = capturedArgs(0);
     expect(args.some(a => a.includes('MyClass'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding #25 (2026-07-21 sweep): run_bp_check(targetFilter=…) does not scope
+//
+// `targetFilter=ConDemoCompanyReader, targetElementType=class` still processed
+// 2 elements and returned only TABLE warnings — attribution had to be done by
+// reading rule names. Two causes in the very first attempt, which is the one
+// that succeeds on this VM:
+//   • it passed `-all` (check the whole model) alongside the filter, and
+//   • it expressed the filter as `-filter:<name>`, which this xppbp does not
+//     recognise, so the scope was silently dropped — and targetElementType was
+//     not carried at all outside the equals style.
+// ---------------------------------------------------------------------------
+describe('run_bp_check — targetFilter actually scopes (#25)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    allowPaths([CHE_PKG, CHE_XPPBP]);
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: '✅', stderr: '' });
+    });
+  });
+
+  it('does NOT pass -all together with a filter (that is what checked the whole model)', async () => {
+    await runBpCheckTool(
+      { modelName: 'MyModel', targetFilter: 'ConDemoCompanyReader', targetElementType: 'class' },
+      {},
+    );
+
+    const args = capturedArgs(0);
+    expect(args).not.toContain('-all');
+    expect(args).toContain('class:ConDemoCompanyReader');
+  });
+
+  it('carries targetElementType in the very first attempt, not only in the equals style', async () => {
+    await runBpCheckTool(
+      { modelName: 'MyModel', targetFilter: 'ConDemoTicket', targetElementType: 'table' },
+      {},
+    );
+
+    expect(capturedArgs(0)).toContain('table:ConDemoTicket');
+    // The unrecognised flag form is gone.
+    expect(capturedArgs(0).some(a => a.startsWith('-filter'))).toBe(false);
+  });
+
+  it('still passes -all when no filter is requested', async () => {
+    await runBpCheckTool({ modelName: 'MyModel' }, {});
+    expect(capturedArgs(0)).toContain('-all');
+  });
+
+  it('reports honestly when xppbp returned findings for other elements', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, {
+        stdout:
+          'BPErrorTableMissingFormRef: K:\\Pkg\\Contoso\\Contoso\\AxTable\\ConDemoTicket.xml\n' +
+          'BPErrorTableFieldGroupEmpty: K:\\Pkg\\Contoso\\Contoso\\AxTable\\ConDemoLine.xml\n',
+        stderr: '',
+      });
+    });
+
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', targetFilter: 'ConDemoCompanyReader', targetElementType: 'class' },
+      {},
+    );
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('Scope NOT honoured');
+    expect(text).toContain('ConDemoTicket');
+    expect(text).toContain('ConDemoLine');
+  });
+
+  it('confirms the scope when every finding belongs to the filtered element', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, {
+        stdout: 'BPErrorXmlDocMissing: K:\\Pkg\\Contoso\\Contoso\\AxClass\\ConDemoCompanyReader.xml\n',
+        stderr: '',
+      });
+    });
+
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', targetFilter: 'ConDemoCompanyReader', targetElementType: 'class' },
+      {},
+    );
+
+    expect(result.content[0].text as string).toContain('Scope: honoured');
+  });
+});
+
+describe('extractReportedElements (#25 helper)', () => {
+  it('reads element names out of AOT paths and quoted references', async () => {
+    const { extractReportedElements } = await import('../../src/tools/runBpCheck');
+    expect(extractReportedElements('warn K:\\Pkg\\M\\M\\AxTable\\ConDemoTicket.xml')).toContain('ConDemoTicket');
+    expect(extractReportedElements("BPError: table 'ConDemoLine' is bad")).toContain('ConDemoLine');
+    expect(extractReportedElements('no elements here')).toEqual([]);
   });
 });

--- a/tests/tools/search-exact-match.test.ts
+++ b/tests/tools/search-exact-match.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Finding #15 (2026-07-21 golden-capture sweep):
+ *   `search(type="edt", query="Num")` at limit=40 never surfaced the EDT `Num`
+ *   — the window was filled with NumberOf* / Numeric* prefix hits.
+ *
+ * Two independent causes, one per backing search:
+ *   • the C# bridge fills its window in provider-enumeration order and truncates
+ *     at maxResults, so a short exact name can be missing altogether;
+ *   • the SQLite path orders by FTS5 `rank` (token frequency), which says
+ *     nothing about name equality.
+ *
+ * PERFORMANCE CONSTRAINT: the repair may not introduce a full-scan query shape
+ * on the 1.17M-row production symbol DB. The exact probe therefore goes through
+ * `lookupSymbolsNocase` (exact-case equality on idx_name_type + bounded FTS
+ * phrase fallback) — asserted below by inspecting the SQL that actually runs.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { tryBridgeSearch } from '../../src/bridge/bridgeAdapter';
+import type { BridgeClient } from '../../src/bridge/bridgeClient';
+import { rankExactFirst, exactMatchRank } from '../../src/utils/exactMatchRanking';
+import { probeExactMatches } from '../../src/tools/search';
+
+// ── ranking primitive ────────────────────────────────────────────────────────
+
+describe('exact-match ranking primitive', () => {
+  it('ranks exact above case-insensitive-exact above prefix above the rest', () => {
+    expect(exactMatchRank('Num', 'Num')).toBe(0);
+    expect(exactMatchRank('Num', 'NUM')).toBe(1);
+    expect(exactMatchRank('Num', 'NumberOfDays')).toBe(2);
+    expect(exactMatchRank('Num', 'AccountNum')).toBe(3);
+  });
+
+  it('is a stable sort — equal-rank items keep the backing search order', () => {
+    const items = ['NumberOfDays', 'NumericSequence', 'Num', 'NumberSequenceCode'];
+    expect(rankExactFirst('Num', items, n => n)).toEqual([
+      'Num', 'NumberOfDays', 'NumericSequence', 'NumberSequenceCode',
+    ]);
+  });
+});
+
+// ── bridge path ──────────────────────────────────────────────────────────────
+
+function makeBridge(results: { name: string; type: string }[]): BridgeClient {
+  return {
+    isReady: true,
+    metadataAvailable: true,
+    searchObjects: vi.fn(async () => ({ results, totalCount: results.length })),
+  } as unknown as BridgeClient;
+}
+
+/** The exact shape observed on the VM: 40 prefix hits, no `Num`. */
+const PREFIX_HITS = Array.from({ length: 40 }, (_, i) => ({
+  name: i % 2 === 0 ? `NumberOf${i}` : `Numeric${i}`,
+  type: 'edt',
+}));
+
+describe('tryBridgeSearch — exact match first (#15)', () => {
+  it('ranks an exact match first when the bridge returned it buried in the window', async () => {
+    const bridge = makeBridge([...PREFIX_HITS.slice(0, 20), { name: 'Num', type: 'edt' }, ...PREFIX_HITS.slice(20)]);
+
+    const result = await tryBridgeSearch(bridge, 'Num', 'edt', 40);
+    const text = (result!.content[0] as { text: string }).text;
+
+    const firstBullet = text.split('\n').find(l => l.startsWith('- '));
+    expect(firstBullet).toContain('**Num**');
+    expect(firstBullet).toContain('exact match');
+  });
+
+  it('splices in an exact match the bridge window truncated away', async () => {
+    // Reproduces the VM observation directly: the bridge returns ONLY prefix
+    // hits, `Num` is beyond its cutoff, and the agent is told the EDT is absent.
+    const bridge = makeBridge(PREFIX_HITS);
+
+    const result = await tryBridgeSearch(bridge, 'Num', 'edt', 40, {
+      exactMatches: [{ name: 'Num', type: 'edt' }],
+    });
+    const text = (result!.content[0] as { text: string }).text;
+
+    expect(text).toContain('**Num**');
+    const firstBullet = text.split('\n').find(l => l.startsWith('- '));
+    expect(firstBullet).toContain('**Num**');
+    expect(text).toContain('SQLite symbol index');
+  });
+
+  it('ignores non-exact "exactMatches" candidates', async () => {
+    const bridge = makeBridge([{ name: 'NumberOfDays', type: 'edt' }]);
+
+    const result = await tryBridgeSearch(bridge, 'Num', 'edt', 40, {
+      exactMatches: [{ name: 'NumberSequenceCode', type: 'edt' }],
+    });
+    const text = (result!.content[0] as { text: string }).text;
+
+    expect(text).not.toContain('NumberSequenceCode');
+  });
+
+  it('does not duplicate an exact match already present in the bridge window', async () => {
+    const bridge = makeBridge([{ name: 'Num', type: 'edt' }, { name: 'NumberOfDays', type: 'edt' }]);
+
+    const result = await tryBridgeSearch(bridge, 'Num', 'edt', 40, {
+      exactMatches: [{ name: 'Num', type: 'edt' }],
+    });
+    const text = (result!.content[0] as { text: string }).text;
+
+    expect(text.match(/\*\*Num\*\*/g)).toHaveLength(1);
+  });
+});
+
+// ── index probe: correctness AND query shape ─────────────────────────────────
+
+/** Minimal symbols schema + FTS mirror, matching src/metadata/symbolIndex.ts. */
+function makeIndexDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL, type TEXT NOT NULL, parent_name TEXT,
+      signature TEXT, file_path TEXT, model TEXT, description TEXT,
+      extends_class TEXT
+    );
+    CREATE INDEX idx_symbols_name ON symbols(name);
+    CREATE INDEX idx_name_type ON symbols(name, type);
+    CREATE VIRTUAL TABLE symbols_fts USING fts5(name, type, parent_name, signature, description, tags);
+  `);
+  const ins = db.prepare(
+    `INSERT INTO symbols (name, type, parent_name, model, file_path) VALUES (?, ?, NULL, ?, ?)`,
+  );
+  const insFts = db.prepare(`INSERT INTO symbols_fts (rowid, name, type) VALUES (?, ?, ?)`);
+  const add = (name: string, type: string) => {
+    const info = ins.run(name, type, 'ApplicationPlatform', `K:\\Ax${type}\\${name}.xml`);
+    insFts.run(info.lastInsertRowid, name, type);
+  };
+  add('Num', 'edt');
+  for (const h of PREFIX_HITS) add(h.name, h.type);
+  add('Num', 'class'); // same name, different type — must be filtered by type
+  return db;
+}
+
+describe('probeExactMatches — index-safe exact probe (#15)', () => {
+  it('finds the exact EDT the FTS ranking buried', () => {
+    const db = makeIndexDb();
+    const hits = probeExactMatches({ getReadDb: () => db }, 'Num', ['edt']);
+    expect(hits.map(h => h.name)).toEqual(['Num']);
+    expect(hits[0].type).toBe('edt');
+  });
+
+  it('resolves a differently-cased query without COLLATE NOCASE as the primary predicate', () => {
+    const db = makeIndexDb();
+    const hits = probeExactMatches({ getReadDb: () => db }, 'num', ['edt']);
+    expect(hits.map(h => h.name)).toEqual(['Num']);
+  });
+
+  it('never emits an unindexed LIKE or a bare COLLATE NOCASE scan (2 GB DB constraint)', () => {
+    const db = makeIndexDb();
+    const seen: string[] = [];
+    const realPrepare = db.prepare.bind(db);
+    (db as any).prepare = (sql: string) => { seen.push(sql); return realPrepare(sql); };
+
+    probeExactMatches({ getReadDb: () => db }, 'num', ['edt']);
+
+    expect(seen.length).toBeGreaterThan(0);
+    for (const sql of seen) {
+      expect(sql).not.toMatch(/LIKE/i);
+      // COLLATE NOCASE is allowed only as a re-check on FTS-narrowed candidates,
+      // never as the sole predicate of a symbols scan.
+      if (/COLLATE NOCASE/i.test(sql)) expect(sql).toMatch(/symbols_fts MATCH/i);
+    }
+    // The first probe must be the exact-case equality served by idx_name_type.
+    expect(seen[0]).toMatch(/s\.name = \?/);
+  });
+
+  it('returns [] instead of throwing when there is no readable DB', () => {
+    expect(probeExactMatches({}, 'Num', ['edt'])).toEqual([]);
+    expect(probeExactMatches({ getReadDb: () => { throw new Error('closed'); } }, 'Num', ['edt'])).toEqual([]);
+  });
+
+  it('skips multi-token / wildcard queries — those are not name lookups', () => {
+    const db = makeIndexDb();
+    expect(probeExactMatches({ getReadDb: () => db }, 'Num ber', ['edt'])).toEqual([]);
+    expect(probeExactMatches({ getReadDb: () => db }, 'Num*', ['edt'])).toEqual([]);
+  });
+});

--- a/tests/tools/securityArtifactIndexing.test.ts
+++ b/tests/tools/securityArtifactIndexing.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Finding #34 (2026-07-21 sweep), second half:
+ *   `security_info(mode=artifact)` reported "Duties: none indexed" for a freshly
+ *   indexed role — its own index table is not fed by update_symbol_index — so it
+ *   could not serve as a verification oracle (xppbp had to).
+ *
+ * Root cause (VM-free, in the parser): `parseSecurityRoleFile` read the duty
+ * list from `<AxSecurityRoleDutyPermission>` / `<AxSecurityDutyPermission>`
+ * only. A STANDARD AxSecurityRole lists duties as `<AxSecurityDutyReference>`
+ * (see finding #31, where the same element-name confusion made the created
+ * chain dead), so a correctly shaped role parsed as ZERO duties and
+ * security_role_duties stayed empty. Same for AxSecurityDuty →
+ * `<AxSecurityPrivilegeReference>`.
+ *
+ * Second defect, same finding: "none indexed" reads as "this role has no
+ * duties", which the tool cannot know. Absence of rows must be reported as
+ * absence of data.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { XppMetadataParser } from '../../src/metadata/xmlParser';
+import { securityArtifactInfoTool } from '../../src/tools/securityArtifactInfo';
+
+function writeTmp(name: string, xml: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'secparse-'));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, xml, 'utf-8');
+  return file;
+}
+
+const ROLE_STANDARD_SHAPE = `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConDemoNoteReaderRole</Name>
+  <Label>Note reader</Label>
+  <Duties>
+    <AxSecurityDutyReference>
+      <Name>ConDemoNoteMaintainDuty</Name>
+    </AxSecurityDutyReference>
+    <AxSecurityDutyReference>
+      <Name>ConDemoNoteViewDuty</Name>
+    </AxSecurityDutyReference>
+  </Duties>
+</AxSecurityRole>`;
+
+const DUTY_STANDARD_SHAPE = `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConDemoNoteMaintainDuty</Name>
+  <Privileges>
+    <AxSecurityPrivilegeReference>
+      <Name>ConDemoNoteMaintainPrivilege</Name>
+    </AxSecurityPrivilegeReference>
+  </Privileges>
+</AxSecurityDuty>`;
+
+describe('security artifact parsing feeds the index (#34)', () => {
+  it('reads role duties from the standard <AxSecurityDutyReference> shape', async () => {
+    const file = writeTmp('ConDemoNoteReaderRole.xml', ROLE_STANDARD_SHAPE);
+    const result = await new XppMetadataParser().parseSecurityRoleFile(file);
+
+    expect(result.success).toBe(true);
+    expect(result.data!.duties).toEqual(['ConDemoNoteMaintainDuty', 'ConDemoNoteViewDuty']);
+  });
+
+  it('reads duty privileges from the standard <AxSecurityPrivilegeReference> shape', async () => {
+    const file = writeTmp('ConDemoNoteMaintainDuty.xml', DUTY_STANDARD_SHAPE);
+    const result = await new XppMetadataParser().parseSecurityDutyFile(file);
+
+    expect(result.success).toBe(true);
+    expect(result.data!.privileges).toEqual(['ConDemoNoteMaintainPrivilege']);
+  });
+
+  it('still reads the legacy permission-set element names', async () => {
+    const legacy = ROLE_STANDARD_SHAPE.replace(/AxSecurityDutyReference/g, 'AxSecurityRoleDutyPermission');
+    const file = writeTmp('Legacy.xml', legacy);
+    const result = await new XppMetadataParser().parseSecurityRoleFile(file);
+
+    expect(result.data!.duties).toHaveLength(2);
+  });
+});
+
+// ── honest "no data" reporting ───────────────────────────────────────────────
+
+function makeSecurityDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL, type TEXT NOT NULL, parent_name TEXT,
+      signature TEXT, file_path TEXT, model TEXT, description TEXT, extends_class TEXT
+    );
+    CREATE INDEX idx_name_type ON symbols(name, type);
+    CREATE VIRTUAL TABLE symbols_fts USING fts5(name, type, parent_name, signature, description, tags);
+    CREATE TABLE security_role_duties (role_name TEXT, duty_name TEXT, model TEXT);
+    CREATE TABLE security_duty_privileges (duty_name TEXT, privilege_name TEXT, model TEXT);
+    CREATE TABLE security_privilege_entries (
+      privilege_name TEXT, entry_point_name TEXT, object_type TEXT, access_level TEXT, model TEXT
+    );
+    INSERT INTO symbols (name, type, model) VALUES ('ConDemoNoteReaderRole', 'security-role', 'Contoso');
+    INSERT INTO symbols (name, type, model) VALUES ('ConDemoNoteMaintainDuty', 'security-duty', 'Contoso');
+    INSERT INTO symbols_fts (rowid, name, type) VALUES (1, 'ConDemoNoteReaderRole', 'security-role');
+    INSERT INTO symbols_fts (rowid, name, type) VALUES (2, 'ConDemoNoteMaintainDuty', 'security-duty');
+  `);
+  return db;
+}
+
+const artifactReq = (name: string, artifactType: string) => ({
+  method: 'tools/call' as const,
+  params: { name: 'get_security_artifact_info', arguments: { name, artifactType } },
+});
+
+describe('security_info(mode=artifact) reports missing data as missing (#34)', () => {
+  it('does not imply a role has no duties when it simply has no rows', async () => {
+    const db = makeSecurityDb();
+    const context = { symbolIndex: { getReadDb: () => db }, bridge: undefined } as any;
+
+    const result = await securityArtifactInfoTool(artifactReq('ConDemoNoteReaderRole', 'role'), context);
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('NO DATA');
+    expect(text).not.toContain('Duties: none indexed');
+    // It must name the way to actually populate the table.
+    expect(text).toContain('update_symbol_index');
+  });
+
+  it('applies the same honesty to a duty with no privilege rows', async () => {
+    const db = makeSecurityDb();
+    const context = { symbolIndex: { getReadDb: () => db }, bridge: undefined } as any;
+
+    const result = await securityArtifactInfoTool(artifactReq('ConDemoNoteMaintainDuty', 'duty'), context);
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('NO DATA');
+    expect(text).toContain('update_symbol_index');
+  });
+
+  it('still lists duties normally when the table IS fed', async () => {
+    const db = makeSecurityDb();
+    db.prepare(`INSERT INTO security_role_duties VALUES ('ConDemoNoteReaderRole', 'ConDemoNoteMaintainDuty', 'Contoso')`).run();
+    const context = { symbolIndex: { getReadDb: () => db }, bridge: undefined } as any;
+
+    const result = await securityArtifactInfoTool(artifactReq('ConDemoNoteReaderRole', 'role'), context);
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('Duties (1)');
+    expect(text).toContain('ConDemoNoteMaintainDuty');
+    expect(text).not.toContain('NO DATA');
+  });
+});

--- a/tests/tools/updateSymbolIndex.test.ts
+++ b/tests/tools/updateSymbolIndex.test.ts
@@ -175,6 +175,52 @@ describe('update_symbol_index AOT folder type mapping', () => {
     // The AOT folder key also drives model extraction (folder before the AOT folder)
     expect(objectSymbol?.model).toBe('MyModel');
   });
+
+  // ── Finding #34 (2026-07-21 sweep) ────────────────────────────────────────
+  // "update_symbol_index indexed an AxMenu as type=class, model=Unknown".
+  // Two holes, one missing map entry: AxMenu was absent from
+  // AOT_FOLDER_TYPE_MAP, so (a) the `?? 'class'` fallback mislabelled it and
+  // (b) extractModelFromPath — which only recognised MAPPED folders — could not
+  // find the model segment either.
+  it('indexes an AxMenu as type=menu, not as a class (#34)', async () => {
+    const filePath = 'K:\\PackagesLocalDirectory\\Contoso\\Contoso\\AxMenu\\ConDemoMenu.xml';
+    existsSyncMock.mockReturnValue(true);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    expect(result.isError).toBeFalsy();
+    const symbols = (context.symbolIndex.addSymbol as any).mock.calls.map((c: any[]) => c[0]);
+    const menu = symbols.find((s: any) => s.name === 'ConDemoMenu');
+    expect(menu?.type).toBe('menu');
+    expect(menu?.type).not.toBe('class');
+    expect(result.content[0].text).toContain('menu');
+  });
+
+  it('resolves the model of an AxMenu instead of reporting Unknown (#34)', async () => {
+    const filePath = 'K:\\PackagesLocalDirectory\\Contoso\\Contoso\\AxMenu\\ConDemoMenu.xml';
+    existsSyncMock.mockReturnValue(true);
+
+    const result = await updateSymbolIndexTool({ filePath }, context);
+
+    const symbols = (context.symbolIndex.addSymbol as any).mock.calls.map((c: any[]) => c[0]);
+    const menu = symbols.find((s: any) => s.name === 'ConDemoMenu');
+    expect(menu?.model).toBe('Contoso');
+    expect(result.content[0].text).not.toContain('Unknown');
+  });
+
+  it('does not claim an unmapped AOT folder is a class (#34)', async () => {
+    // Any Ax* element folder we cannot map must yield a truthful derived type,
+    // never a confident "class".
+    const filePath = 'K:\\PackagesLocalDirectory\\Contoso\\Contoso\\AxWorkflowType\\ConDemoWf.xml';
+    existsSyncMock.mockReturnValue(true);
+
+    await updateSymbolIndexTool({ filePath }, context);
+
+    const symbols = (context.symbolIndex.addSymbol as any).mock.calls.map((c: any[]) => c[0]);
+    const wf = symbols.find((s: any) => s.name === 'ConDemoWf');
+    expect(wf?.type).not.toBe('class');
+    expect(wf?.model).toBe('Contoso');
+  });
 });
 
 describe('update_symbol_index refresh mode (no filePath)', () => {


### PR DESCRIPTION
Read-side batch from `docs/eval-sweep-findings-2026-07-21.md`: **#14, #15, #25, #33/#41, #34**.
Common thread — each of these tools tells the agent something that is not true, and #14 is the
dangerous shape: the agent "corrects" working code away from a valid standard EDT.

## Evidence

| # | corpus record | quoted symptom |
|---|---|---|
| #14 | `eval/corpus/runs/2026-07-21T19__L2-error-handling-infolog__c262b19.json` | "`get_object_info(objectType='edt', ...)` is broken wholesale on this VM: 'Num', 'Notes' and even 'CustAccount' all return \"Bridge returned no data\", while the same EDTs resolve fine through validate_code(references) and appear in search" |
| #15 | same record | "`search(type='edt', query='Num')` never surfaces the EXACT match 'Num' even at limit=40 (only NumberOf*/Numeric* prefix hits) — exact-name hits are not ranked first" |
| #33/#41 | `eval/corpus/runs/2026-07-21T20__L4-master-security-slice__c262b19.json` | "the labels tool advertises '<Label>@SYS:@SYS12345</Label>' for legacy SYS labels, which xppbp rejects with BPErrorLabelIsText (correct form: @SYS12345), and it happily suggests labels from label [files not deployed here]" |
| #34 | same record | "`update_symbol_index` indexed an AxMenu as type=class, model=Unknown"; "`security_info(mode=artifact)` reports 'Duties: none indexed' for a freshly indexed role" |
| #25 | `eval/corpus/runs/2026-07-21T19__L2-multi-company-changecompany__c262b19.json` (narrative in findings §25) | "`targetFilter=ConDemoCompanyReader, targetElementType=class` still processed 2 elements and returned only table warnings" |

## Root cause per finding

**#14 — `get_object_info(edt)`** (`src/tools/edtInfo.ts`)
Standard mode consulted a single source and turned `tryBridgeEdt() === null` into the factual
claim that the EDT does not exist. `null` also means *bridge absent*, *bridge threw*, or *the
provider did not resolve the name* — and hierarchy mode was reading a fully populated
`edt_metadata` table the whole time. Now: bridge -> `edt_metadata` -> `symbols`, and if none of
them knows the name the tool says **"No data available … this is NOT proof the EDT does not
exist"** and points at the paths that DID resolve these EDTs on the VM.
The underlying C# `ReadEdt` behaviour is unverifiable in-repo (the bridge needs the VM's
`Microsoft.Dynamics.AX.Metadata` assemblies), so this is the honest-fallback fix, not a bridge fix.

**#15 — exact-match ranking** (`src/utils/exactMatchRanking.ts`, `bridgeAdapter.ts`, `search.ts`)
Two independent causes, one per backend:
* `MetadataReadService.SearchObjects` scans provider primary keys in enumeration order and
  `return`s at `Results.Count >= maxResults` — a short exact name can be outside the window entirely;
* `searchSymbols` uses FTS5 `ORDER BY rank`, a token-frequency score that says nothing about name equality.

Fix: stable exact-first ranking of the returned window **plus** an exact probe whose hits are spliced
in when the window missed them.

**#25 — `run_bp_check` scoping** (`src/tools/runBpCheck.ts`)
Attempt 1 (the one that succeeds on this VM) passed `-all` **and** `-filter:<name>`. `-all` means
"check the whole model" and `-filter:` is not an xppbp flag, so the scope was silently dropped;
`targetElementType` was honoured only by the equals style. Filter and `-all` are now mutually
exclusive, every style emits the positional `<type>:<Name>` selector, and the output states
whether the scope held (`Scope: honoured` / `Scope NOT honoured: xppbp also reported on …`).

**#33/#41 — labels** (`src/utils/labelReference.ts`, `searchLabels.ts`, `getLabelInfo.ts`)
The reference was built as `@<labelFileId>:<labelId>` with no regard for an id that already carries
its own `@FileId` — giving `@SYS:@SYS67433` and `BPErrorLabelIsText`. `formatLabelReference()`
collapses the legacy id-embeds-file-id shape (and repairs an already-doubled one) to `@SYS67433`.
Second half: results from label files outside the core set / the caller's own model are annotated,
and the "use this" recommendation only ever picks a resolvable label — otherwise it says so plainly.

**#34 — indexing + security oracle** (`updateSymbolIndex.ts`, `xmlParser.ts`, `securityArtifactInfo.ts`)
One missing map entry caused both halves of the first symptom: `AxMenu` was absent from
`AOT_FOLDER_TYPE_MAP`, so `?? 'class'` mislabelled it *and* `extractModelFromPath` — which only
accepted MAPPED folders — could not find the model segment. Mapped `axmenu`, made model extraction
accept any `Ax*` element folder, and replaced the blanket `class` fallback with a derived type
(`AxWorkflowType` -> `workflowtype`) so the index never asserts a type it does not know.
For `security_info`: `parseSecurityRoleFile` read duties only from `<AxSecurityRoleDutyPermission>`
/ `<AxSecurityDutyPermission>` — a **standard** role uses `<AxSecurityDutyReference>` (same
element-name confusion as finding #31), so a correctly shaped role parsed as zero duties and
`security_role_duties` stayed empty. Both shapes are accepted now (duty -> privileges likewise), so
the table is genuinely fed; and the leftover `Duties: none indexed` became an explicit **NO DATA**
that distinguishes "no rows" from "no duties".

## Performance / query-plan reasoning (#15, 2 GB production symbol DB)
Ranking itself is pure in-memory work over an already-bounded window — it widens no query.
The "was the exact match outside the window?" probe reuses `lookupSymbolsNocase`:
exact-case equality on **idx_name_type** first (sub-ms), then a *bounded* FTS5 phrase match for
differently-cased input, re-checked with `COLLATE NOCASE` on FTS-narrowed candidates only. No
`LIKE`, and never `COLLATE NOCASE` as the sole predicate of a `symbols` scan — the shapes measured
at 80–278 s. `tests/tools/search-exact-match.test.ts` intercepts `db.prepare` and asserts exactly
that on the SQL that actually runs. The `edt_metadata` fallback in #14 is an equality probe on
**idx_edt_metadata_name** (or the `(edt_name, model)` unique index when a model is given).

## Repro tests (all fail on `main`)
`tests/tools/edtInfo-bridge-fallback.test.ts` · `tests/tools/search-exact-match.test.ts` ·
`tests/tools/labelReference.test.ts` · `tests/tools/securityArtifactIndexing.test.ts` ·
new `#25` block in `tests/tools/runBpCheck.test.ts` · new `#34` block in `tests/tools/updateSymbolIndex.test.ts`.

Verified: with `src/` reverted to `main`, **30 of these fail**; with the fix, all pass.

## Validation
* `npx tsc --noEmit` — clean.
* `npx vitest run` — **153 files, 2006 passed, 8 skipped, 0 failed** (includes the golden-integrity gate `tests/eval/goldens.test.ts`).
* `npm run eval:report` — unchanged, held-out split not regressed: overall build=80% bp=0% [27 checked, 17 unverified] golden=36%; L0 100/–/50, L1 58/–/0, L2 100/–/53, L3 67/–/50, L4 60/–/40. No golden was edited.

## Scope / honesty notes
* No committed golden was touched.
* Where the repo cannot reach the data, the tool was made honest rather than left stating a
  falsehood: **#14** (bridge `ReadEdt` needs the VM to diagnose — SQLite fallback + "no data
  available"), and the *second* half of **#25** (whether this xppbp build honours the positional
  selector can only be confirmed on the VM — so the run now verifies its own scope from the output
  and says when it was not honoured).
* Untouched by request: `src/tools/modifyD365File.ts`, `src/tools/d365foFileOpSpecs.ts` (PR #731),
  `src/eval/oracle/*` (parallel improver).
* `docs/eval-sweep-findings-2026-07-21.md` deliberately NOT edited — the record is maintained centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsY56fJuvoiEXjCVRR2b6M
