### PR TITLE
fix(eval): make the golden oracle and bp_clean honest measurements (#24, #2, #3)

### DIFF
--- a/docs/AGENT_EVAL_LOOP.md
+++ b/docs/AGENT_EVAL_LOOP.md
@@ -198,11 +198,25 @@ Per run, layered from cheap to expensive:
 | Signal | Meaning | Gate? |
 |--------|---------|-------|
 | `build` | xppc produced no errors | hard gate — below this, nothing else counts |
-| `bp_clean` | zero best-practice **error**-severity warnings | quality gate |
+| `bp_clean` | `1` = xppbp ran and reported zero **error**-severity warnings, `0` = it ran and reported some, **`null` = it was never run** | quality gate |
 | `golden_match` | normalised metadata == golden | **primary correctness** |
 | `systest` | runtime assertions pass (when present) | deep correctness (optional) |
 
+`bp_clean` is only scored when the capture supplies BP evidence: `tsx src/eval/oracle/cli.ts`
+without `--bp-warnings` records `bp_clean: null` and `build.bp_checked: false`. Pass
+`--bp-warnings 0` **only** when `run_bp_check` actually ran and reported none — the flag used to
+default to 0, which minted a fake `bp_clean: 1` for every capture that skipped xppbp and made the
+dimension untrendable.
+
 Aggregate metrics tracked over time, per tier: `pass@build`, `pass@bp_clean`, `pass@golden`, `pass@systest`, and the headline **tool-defect rate** (should trend down as the improver lands fixes).
+`pass@bp_clean` is averaged over **BP-verified runs only** (`build.bp_checked === true`, or a
+`bp_clean: 0` — which is only reachable from observed warnings); everything else is counted and
+reported as `unverified` instead of being blended in.
+
+The golden diff canonicalises `///` XmlDoc **prose** (a contiguous run of `///` lines collapses to
+one `/// <xmldoc/>` placeholder) — doc-comment wording is not pinned by any case instruction. The
+**presence** of a doc comment is still load-bearing, because that is exactly what
+`BPXmlDocNoDocumentationComments` measures.
 
 ---
 

--- a/src/eval/improver/cli.ts
+++ b/src/eval/improver/cli.ts
@@ -21,7 +21,8 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
 
 interface CorpusRunFull extends CorpusRun {
-  score?: CorpusRun['score'] & { build?: number; bp_clean?: number; golden_match?: number };
+  score?: CorpusRun['score'] & { build?: number; bp_clean?: number | null; golden_match?: number };
+  build?: { bp_checked?: boolean };
 }
 
 function loadRuns(): CorpusRunFull[] {
@@ -59,9 +60,10 @@ function latestScoredCases(runs: CorpusRunFull[], splits: Map<string, Split>): S
     split: splits.get(r.case_id) ?? 'holdout',
     score: {
       build: r.score?.build ?? 0,
-      bp_clean: r.score?.bp_clean ?? 0,
+      bp_clean: r.score?.bp_clean ?? null,
       golden_match: r.score?.golden_match ?? 0,
     },
+    bpChecked: r.build?.bp_checked,
   }));
 }
 

--- a/src/eval/improver/heldout.ts
+++ b/src/eval/improver/heldout.ts
@@ -13,14 +13,28 @@ export type Split = 'train' | 'holdout';
 export interface ScoredCase {
   caseId: string;
   split: Split;
-  score: { build: number; bp_clean: number; golden_match: number };
+  score: { build: number; bp_clean: number | null; golden_match: number };
+  /**
+   * Did the capture actually run xppbp? `undefined` = unknown provenance (every
+   * record written before the flag existed). Mirrors `bpState` in report.ts:
+   * only `bp_clean === 0` proves the check ran, so an unflagged 1 is NOT
+   * comparable with a checked one and is left out of `pass_at_bp_clean`
+   * (docs/eval-sweep-findings-2026-07-21.md #3).
+   */
+  bpChecked?: boolean;
+}
+
+/** 'clean' | 'dirty' | 'unverified' — see `bpState` in report.ts. */
+function bpVerified(c: ScoredCase): boolean {
+  return c.bpChecked === true || c.score.bp_clean === 0;
 }
 
 export interface SplitAggregate {
   count: number;
   /** Fractions in [0,1]. */
   pass_at_build: number;
-  pass_at_bp_clean: number;
+  /** Over BP-VERIFIED cases only; `null` when none carries BP evidence. */
+  pass_at_bp_clean: number | null;
   pass_at_golden: number;
 }
 
@@ -33,7 +47,12 @@ export function aggregate(cases: ScoredCase[]): SplitAggregate {
   return {
     count,
     pass_at_build: frac(cases.filter(c => c.score.build === 1).length, count),
-    pass_at_bp_clean: frac(cases.filter(c => c.score.bp_clean === 1).length, count),
+    pass_at_bp_clean: (() => {
+      const verified = cases.filter(bpVerified);
+      return verified.length === 0
+        ? null
+        : frac(verified.filter(c => c.score.bp_clean === 1).length, verified.length);
+    })(),
     pass_at_golden: frac(cases.filter(c => c.score.golden_match === 1).length, count),
   };
 }
@@ -66,8 +85,13 @@ export function holdoutRegressed(
 ): RegressionResult {
   const regressions: RegressionResult['regressions'] = [];
   for (const m of METRICS) {
-    if (candidate[m] < baseline[m] - epsilon) {
-      regressions.push({ metric: m, baseline: baseline[m], candidate: candidate[m] });
+    const b = baseline[m];
+    const c = candidate[m];
+    // A `null` side means the metric was not measured on that run — there is no
+    // regression to assert, and fabricating a 0 would invent a failure.
+    if (b === null || c === null) continue;
+    if (c < b - epsilon) {
+      regressions.push({ metric: m, baseline: b, candidate: c });
     }
   }
   return { ok: regressions.length === 0, regressions };
@@ -75,7 +99,7 @@ export function holdoutRegressed(
 
 export function renderSplitReport(agg: Record<Split, SplitAggregate>): string {
   const row = (name: string, a: SplitAggregate) =>
-    `  ${name.padEnd(8)} n=${a.count}  build=${pct(a.pass_at_build)}  bp=${pct(a.pass_at_bp_clean)}  golden=${pct(a.pass_at_golden)}`;
+    `  ${name.padEnd(8)} n=${a.count}  build=${pct(a.pass_at_build)}  bp=${a.pass_at_bp_clean === null ? 'n/a' : pct(a.pass_at_bp_clean)}  golden=${pct(a.pass_at_golden)}`;
   return ['# Scores by split', row('train', agg.train), row('holdout', agg.holdout)].join('\n');
 }
 

--- a/src/eval/improver/report.ts
+++ b/src/eval/improver/report.ts
@@ -8,14 +8,44 @@ export interface RunForReport {
   case_id: string;
   tier: number;
   classification: string;
-  score?: { build?: number; bp_clean?: number; golden_match?: number; tier_weight?: number };
+  score?: { build?: number; bp_clean?: number | null; golden_match?: number | null; tier_weight?: number };
+  /** `bp_checked` is the BP-provenance flag written by the oracle CLI (see `bpState`). */
+  build?: { bp_checked?: boolean };
+}
+
+/**
+ * Which of the three BP states a run is in.
+ *
+ * `bp_clean` used to have two values where it needed three: a run whose capture
+ * never ran xppbp scored 1, indistinguishable from a run that ran it and found
+ * nothing. Averaging the two together is meaningless — the number mixes
+ * "BP-clean" with "BP never checked" (docs/eval-sweep-findings-2026-07-21.md #3).
+ *
+ * Going forward the oracle CLI records `build.bp_checked` and `bp_clean: null`,
+ * so the state is explicit. For the ~70 records written BEFORE that flag existed
+ * there is exactly one thing we can honestly infer: `bp_clean: 0` was only ever
+ * reachable from OBSERVED warnings, so a 0 proves the check ran. A legacy 1
+ * proves nothing either way — it is marked `unverified` and kept OUT of the
+ * pass-rate rather than retro-edited into a value nobody measured.
+ */
+export type BpState = 'clean' | 'dirty' | 'unverified';
+
+export function bpState(run: RunForReport): BpState {
+  const bp = run.score?.bp_clean;
+  if (run.build?.bp_checked === true) return bp === 1 ? 'clean' : 'dirty';
+  if (bp === 0) return 'dirty';
+  return 'unverified';
 }
 
 export interface TierStats {
   tier: number;
   count: number;
   pass_at_build: number;
-  pass_at_bp_clean: number;
+  /** Over BP-VERIFIED runs only; `null` when none of them is verified. */
+  pass_at_bp_clean: number | null;
+  /** How many runs in this bucket carry usable BP evidence, and how many do not. */
+  bp_verified: number;
+  bp_unverified: number;
   pass_at_golden: number;
 }
 
@@ -25,7 +55,10 @@ export interface Report {
   /** Fraction of runs whose class is an actionable server gap (the headline metric). */
   toolDefectRate: number;
   pass_at_build: number;
-  pass_at_bp_clean: number;
+  /** Over BP-VERIFIED runs only; `null` when no run carries BP evidence (see `bpState`). */
+  pass_at_bp_clean: number | null;
+  bp_verified: number;
+  bp_unverified: number;
   pass_at_golden: number;
   classificationCounts: Record<string, number>;
 }
@@ -39,9 +72,15 @@ function frac(n: number, d: number): number {
 
 function passRates(runs: RunForReport[]) {
   const n = runs.length;
+  // BP is averaged over VERIFIED runs only — a run with no BP evidence is not
+  // comparable with one that was actually checked, so it is counted, not blended.
+  const states = runs.map(bpState);
+  const verified = states.filter(s => s !== 'unverified').length;
   return {
     pass_at_build: frac(runs.filter(r => r.score?.build === 1).length, n),
-    pass_at_bp_clean: frac(runs.filter(r => r.score?.bp_clean === 1).length, n),
+    pass_at_bp_clean: verified === 0 ? null : frac(states.filter(s => s === 'clean').length, verified),
+    bp_verified: verified,
+    bp_unverified: states.length - verified,
     pass_at_golden: frac(runs.filter(r => r.score?.golden_match === 1).length, n),
   };
 }
@@ -72,18 +111,35 @@ function pct(f: number): string {
   return `${Math.round(f * 100)}%`;
 }
 
+/** Render the BP dimension, never hiding how much of the bucket was unmeasured. */
+function bp(stats: { pass_at_bp_clean: number | null; bp_verified: number; bp_unverified: number }): string {
+  const value = stats.pass_at_bp_clean === null ? 'n/a' : pct(stats.pass_at_bp_clean);
+  const suffix = stats.bp_unverified > 0
+    ? ` [${stats.bp_verified} checked, ${stats.bp_unverified} unverified]`
+    : '';
+  return `bp=${value}${suffix}`;
+}
+
 export function renderReport(r: Report): string {
   if (r.total === 0) return 'No corpus runs to report.';
   const lines: string[] = [
     `# Corpus scoreboard — ${r.total} run(s)`,
     '',
-    `overall   build=${pct(r.pass_at_build)}  bp=${pct(r.pass_at_bp_clean)}  golden=${pct(r.pass_at_golden)}`,
+    `overall   build=${pct(r.pass_at_build)}  ${bp(r)}  golden=${pct(r.pass_at_golden)}`,
     `tool-defect rate: ${pct(r.toolDefectRate)} (TOOL_DEFECT/KNOWLEDGE_GAP/VALIDATOR_GAP)`,
     '',
     '## By tier',
   ];
   for (const t of r.byTier) {
-    lines.push(`  L${t.tier}  n=${t.count}  build=${pct(t.pass_at_build)}  bp=${pct(t.pass_at_bp_clean)}  golden=${pct(t.pass_at_golden)}`);
+    lines.push(`  L${t.tier}  n=${t.count}  build=${pct(t.pass_at_build)}  ${bp(t)}  golden=${pct(t.pass_at_golden)}`);
+  }
+  if (r.bp_unverified > 0) {
+    lines.push(
+      '',
+      `note: ${r.bp_unverified} run(s) carry no BP evidence (captured before \`build.bp_checked\` existed,`,
+      '      or scored with bp_clean: null). They are excluded from the BP pass-rate rather than',
+      '      averaged in — "BP-clean" and "BP never checked" are not the same measurement.',
+    );
   }
   lines.push('', '## Classifications');
   for (const [cls, n] of Object.entries(r.classificationCounts).sort((a, b) => b[1] - a[1])) {

--- a/src/eval/oracle/actualArtifactResolution.ts
+++ b/src/eval/oracle/actualArtifactResolution.ts
@@ -6,7 +6,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { canonicalizePrefix } from './normalize.js';
+import { artifactKey } from './artifactKey.js';
+import { type PrefixSpec } from './prefix.js';
 
 /**
  * Resolve the actual-dir file matching a golden artifact filename. Tries an
@@ -18,19 +19,26 @@ import { canonicalizePrefix } from './normalize.js';
  * one that generated the actual artifacts) so a whole L3/L4 multi-artifact
  * case doesn't spuriously score every artifact as missing/extra under prefix
  * drift alone.
+ *
+ * The fallback compares LOGICAL ARTIFACT KEYS (`artifactKey`), not merely
+ * prefix-canonicalised filenames, so a legacy golden filename
+ * (`DemoEnumExtProbe.AxClass.metadata.xml` — unprefixed stem, `.Ax<Type>`
+ * infix) still pairs with the actual file the VM produced
+ * (`ConDemoEnumExtProbe.metadata.xml`). See artifactKey.ts and
+ * docs/eval-sweep-findings-2026-07-21.md #2.
  */
 export function resolveActualFile(
   actualDir: string,
   goldenName: string,
-  goldenPrefix: string,
-  actualPrefix: string,
+  goldenPrefix: PrefixSpec,
+  actualPrefix: PrefixSpec,
 ): string | undefined {
   const direct = path.join(actualDir, goldenName);
   if (fs.existsSync(direct)) return direct;
-  const canonGolden = canonicalizePrefix(goldenName, goldenPrefix);
+  const canonGolden = artifactKey(goldenName, goldenPrefix);
   const candidate = fs.readdirSync(actualDir)
     .filter(f => f.endsWith('.metadata.xml'))
-    .find(f => canonicalizePrefix(f, actualPrefix) === canonGolden);
+    .find(f => artifactKey(f, actualPrefix) === canonGolden);
   return candidate ? path.join(actualDir, candidate) : undefined;
 }
 
@@ -64,8 +72,8 @@ export function resolveActualFile(
 export function buildActualArtifactsMap(
   actualDir: string,
   artifactNames: string[],
-  goldenPrefix: string,
-  actualPrefix: string,
+  goldenPrefix: PrefixSpec,
+  actualPrefix: PrefixSpec,
 ): { actualArtifacts: Record<string, string>; matchedActualFiles: Set<string> } {
   const actualArtifacts: Record<string, string> = {};
   const matchedActualFiles = new Set<string>();

--- a/src/eval/oracle/artifactKey.ts
+++ b/src/eval/oracle/artifactKey.ts
@@ -1,0 +1,74 @@
+/**
+ * Multi-artifact filename → stable logical key, for pairing a committed golden
+ * artifact with the actual file that reproduces it.
+ *
+ * Golden dirs under `eval/goldens/` use TWO filename conventions
+ * (docs/eval-sweep-findings-2026-07-21.md #2):
+ *
+ *   legacy   `DemoEnumExtProbe.AxClass.metadata.xml`   — UNPREFIXED stem plus an
+ *            `.Ax<Type>` infix, although the file CONTENT is `Con`-prefixed
+ *            (`<Name>ConDemoEnumExtProbe</Name>`)
+ *   current  `ConDemoEnumExtProbe.metadata.xml`        — prefixed stem, no infix
+ *
+ * while the actual artifact copied off the VM is always named after the object
+ * as it exists on disk (`ConDemoEnumExtProbe.metadata.xml`). Comparing raw
+ * filenames — or prefix-canonicalised filenames — therefore paired NOTHING for a
+ * legacy dir, and the whole artifact scored as missing + extra even when its
+ * content was byte-identical.
+ *
+ * Rather than renaming committed goldens (a golden's bytes are the regression
+ * anchor), both sides are reduced to the same logical key:
+ *
+ *   1. drop the `.metadata.xml` suffix,
+ *   2. drop a legacy `.Ax<Type>` type infix,
+ *   3. drop a `.<prefix>Extension` dot-notation extension marker,
+ *   4. canonicalise the EXTENSION_PREFIX to `PFX` (see `canonicalizePrefix`),
+ *   5. drop a LEADING `PFX` — legacy golden filenames omit the prefix the file
+ *      content carries, so prefixed and unprefixed stems must compare equal.
+ *
+ * Steps 2/3/5 are lossy, so `artifactKeyMap` refuses to apply them where they
+ * would make two DIFFERENT filenames on the same side collide (e.g. a dir
+ * holding both `CustGroup` and `CustGroup.ConExtension`): a colliding name keeps
+ * its raw filename as its key, degrading to the previous exact-match behaviour
+ * instead of silently diffing an extension against its base object.
+ */
+
+import { canonicalizePrefix, PREFIX_PLACEHOLDER, type PrefixSpec } from './prefix.js';
+
+const METADATA_SUFFIX = /\.metadata\.xml$/i;
+/** Legacy `<Name>.AxClass` / `.AxTable` / `.AxEnumExtension` … type infix. */
+const TYPE_INFIX = /\.Ax[A-Z][A-Za-z]*$/;
+/** Dot-notation extension marker, once the prefix has been canonicalised. */
+const EXTENSION_MARKER = new RegExp(`\\.${PREFIX_PLACEHOLDER}Extension$`);
+
+/**
+ * Reduce one artifact filename to its logical key. Exported for tests; callers
+ * pairing a SET of names should use `artifactKeyMap`, which additionally
+ * protects against two names collapsing onto the same key.
+ */
+export function artifactKey(filename: string, prefix: PrefixSpec = ''): string {
+  const hadMetadataSuffix = METADATA_SUFFIX.test(filename);
+  let stem = filename.replace(METADATA_SUFFIX, '').replace(TYPE_INFIX, '');
+  stem = canonicalizePrefix(stem, prefix).replace(EXTENSION_MARKER, '');
+  if (stem.startsWith(PREFIX_PLACEHOLDER)) stem = stem.slice(PREFIX_PLACEHOLDER.length);
+  return hadMetadataSuffix ? `${stem}.metadata.xml` : stem;
+}
+
+/**
+ * Key every name in `names` (one side of a diff), keeping a name's RAW filename
+ * as its key whenever the reduced key is not unique within that side. Returns a
+ * `filename → key` map.
+ */
+export function artifactKeyMap(names: readonly string[], prefix: PrefixSpec = ''): Map<string, string> {
+  const counts = new Map<string, number>();
+  for (const name of names) {
+    const key = artifactKey(name, prefix);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const out = new Map<string, string>();
+  for (const name of names) {
+    const key = artifactKey(name, prefix);
+    out.set(name, (counts.get(key) ?? 0) > 1 ? name : key);
+  }
+  return out;
+}

--- a/src/eval/oracle/cli.ts
+++ b/src/eval/oracle/cli.ts
@@ -9,10 +9,10 @@
  *                         (L3/L4 cases that produce several objects). Mutually
  *                         exclusive with the single <actualXml> positional/--golden.
  *     --build-failed      mark build as failed (default: succeeded)
- *     --bp-warnings <n>   number of BP warnings (default: 0)
+ *     --bp-warnings <n>   number of BP warnings xppbp reported (OMIT = BP not checked -> bp_clean: null)
  *     --systest <file>    text file with the `run_systest_class` output (runtime oracle)
  *     --classification <C> rubric class for the record (default: derived)
- *     --golden-prefix <p> EXTENSION_PREFIX the golden was captured under (default: GOLDEN_CAPTURE_PREFIX, "Contoso")
+ *     --golden-prefix <p> EXTENSION_PREFIX the golden was captured under (default: every GOLDEN_CAPTURE_PREFIXES token)
  *     --actual-prefix <p> EXTENSION_PREFIX the actual was produced under (default: read from THIS
  *                         process's EXTENSION_PREFIX env var — the session that ran the case)
  *     --write             append a corpus record to eval/corpus/runs/
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import {
   evaluate, evaluateMulti, renderDiff, renderNormalized, normalizeAotXml, parseSysTestResult,
-  scoreRun, GOLDEN_CAPTURE_PREFIX, type CaseSpec, type GoldenDiff, type Score,
+  scoreRun, GOLDEN_CAPTURE_PREFIXES, type CaseSpec, type GoldenDiff, type Score,
 } from './index.js';
 import { resolveRegularObjectPrefixToken } from '../../utils/modelClassifier.js';
 import { buildActualArtifactsMap } from './actualArtifactResolution.js';
@@ -107,8 +107,24 @@ async function main(): Promise<void> {
   ) as CaseSpec & { ignore?: string[]; golden_pending?: boolean };
 
   const buildSucceeded = !flagSet('--build-failed');
-  const bpCount = Number(arg('--bp-warnings') ?? '0');
-  const build = { succeeded: buildSucceeded, bpWarnings: Array.from({ length: bpCount }, () => ({})) };
+  // `--bp-warnings` ABSENT means xppbp was not run for this capture — NOT "ran and
+  // found nothing". It used to default to 0, which silently minted `bp_clean: 1`
+  // for every run whose operator forgot the flag and made the dimension
+  // untrendable (docs/eval-sweep-findings-2026-07-21.md #3). Leave bpWarnings
+  // undefined so the score records `bp_clean: null` (BP not checked), and say so.
+  const bpArg = arg('--bp-warnings');
+  const bpChecked = bpArg !== undefined;
+  const bpCount = Number(bpArg ?? '0');
+  const build = {
+    succeeded: buildSucceeded,
+    bpWarnings: bpChecked ? Array.from({ length: bpCount }, () => ({})) : undefined,
+  };
+  if (!bpChecked) {
+    console.error(
+      'note: --bp-warnings not supplied → bp_clean: null (BP NOT CHECKED). ' +
+      'Pass `--bp-warnings 0` only if run_bp_check actually ran and reported none.',
+    );
+  }
 
   const systestFile = arg('--systest');
   const systest = systestFile
@@ -121,8 +137,15 @@ async function main(): Promise<void> {
   // (e.g. a local self-check comparing a golden against itself/another golden-shaped fixture,
   // no VM session involved) fall back to the golden's own prefix so that unprefixed-env usage
   // keeps matching exactly as before. Either is overridable for edge cases.
-  const goldenPrefix = arg('--golden-prefix') ?? GOLDEN_CAPTURE_PREFIX;
-  const actualPrefix = arg('--actual-prefix') ?? (resolveRegularObjectPrefixToken() || GOLDEN_CAPTURE_PREFIX);
+  //
+  // Both defaults are the WHOLE set of capture prefixes (`GOLDEN_CAPTURE_PREFIXES`,
+  // currently ["Contoso","Con"]) rather than the single `GOLDEN_CAPTURE_PREFIX`: the
+  // committed corpus is `Con`-prefixed, which "Contoso" can never match, so the old
+  // single-token default left the golden side un-canonicalised and forced operators to
+  // hand-pass `--golden-prefix Con --actual-prefix Con` (docs/eval-sweep-findings-2026-07-21.md #2).
+  const goldenPrefix: string | readonly string[] = arg('--golden-prefix') ?? GOLDEN_CAPTURE_PREFIXES;
+  const actualPrefix: string | readonly string[] =
+    arg('--actual-prefix') ?? (resolveRegularObjectPrefixToken() || GOLDEN_CAPTURE_PREFIXES);
 
   let goldenDiff: GoldenDiff | null;
   let score: Score;
@@ -206,7 +229,9 @@ async function main(): Promise<void> {
     const classification = arg('--classification')
       ?? (score.golden_match === null
         ? 'ENV_FLAKE'
-        : (score.build === 1 && score.golden_match === 1 ? (score.bp_clean === 1 ? 'PASS' : 'KNOWLEDGE_GAP') : 'TOOL_DEFECT'));
+        // bp_clean === null means BP was NOT CHECKED — that is an absence of evidence,
+        // not evidence of a knowledge gap, so only an explicit 0 downgrades to KNOWLEDGE_GAP.
+        : (score.build === 1 && score.golden_match === 1 ? (score.bp_clean === 0 ? 'KNOWLEDGE_GAP' : 'PASS') : 'TOOL_DEFECT'));
     const ts = new Date().toISOString().replace(/[:.]/g, '').slice(0, 13);
     const sha = shortSha();
     const record = {
@@ -216,7 +241,10 @@ async function main(): Promise<void> {
       timestamp: new Date().toISOString(),
       server_git_sha: sha,
       generated_artifacts: generatedArtifacts,
-      build: { succeeded: build.succeeded, errors: [], bpWarnings: build.bpWarnings },
+      // `bp_checked` is the provenance flag that makes bp_clean trendable: a record
+      // WITHOUT it (every pre-2026-07-22 record) has unknown BP provenance and is
+      // reported separately rather than averaged in (#3).
+      build: { succeeded: build.succeeded, errors: [], bp_checked: bpChecked, bpWarnings: build.bpWarnings ?? null },
       golden_diff: goldenDiff,
       systest: systestOut,
       score,

--- a/src/eval/oracle/index.ts
+++ b/src/eval/oracle/index.ts
@@ -13,8 +13,9 @@ import { type SysTestResult } from './systest.js';
 
 export {
   normalizeAotXml, normalizeMultiArtifact, renderNormalized, globToRegExp,
-  GOLDEN_CAPTURE_PREFIX, canonicalizePrefix,
+  GOLDEN_CAPTURE_PREFIX, GOLDEN_CAPTURE_PREFIXES, canonicalizePrefix, type PrefixSpec,
 } from './normalize.js';
+export { artifactKey, artifactKeyMap } from './artifactKey.js';
 export { diffNormalized, renderDiff, type GoldenDiff } from './diff.js';
 export { scoreRun, type Score, type BuildResult, type ScoreInput } from './score.js';
 export { parseSysTestResult, type SysTestResult, type SysTestFailure } from './systest.js';
@@ -39,7 +40,7 @@ export interface EvaluateInput {
    * to '' (no canonicalisation — legacy literal-string comparison), so
    * existing callers that don't pass one are unaffected.
    */
-  goldenPrefix?: string;
+  goldenPrefix?: string | readonly string[];
   /**
    * EXTENSION_PREFIX the actual artifact was produced under (the CURRENT
    * session's configured prefix — see
@@ -47,7 +48,7 @@ export interface EvaluateInput {
    * Defaults to '' (no canonicalisation), so callers that don't know/care
    * about prefix drift keep the legacy literal-string comparison.
    */
-  actualPrefix?: string;
+  actualPrefix?: string | readonly string[];
 }
 
 export interface EvaluateResult {
@@ -83,9 +84,9 @@ export interface EvaluateMultiInput {
   build: BuildResult;
   systest?: SysTestResult | { passed: boolean | null } | null;
   /** See EvaluateInput.goldenPrefix. */
-  goldenPrefix?: string;
+  goldenPrefix?: string | readonly string[];
   /** See EvaluateInput.actualPrefix. */
-  actualPrefix?: string;
+  actualPrefix?: string | readonly string[];
 }
 
 /**

--- a/src/eval/oracle/normalize.ts
+++ b/src/eval/oracle/normalize.ts
@@ -17,6 +17,8 @@
 
 import { parseStringPromise } from 'xml2js';
 import { reindentXppSource } from '../../utils/xppFormat.js';
+import { canonicalizePrefix, type PrefixSpec } from './prefix.js';
+import { artifactKeyMap } from './artifactKey.js';
 
 /**
  * Built-in ignores applied to every document (in addition to per-case globs).
@@ -43,34 +45,26 @@ const DEFAULT_IGNORES = ['**/ModelSaveInfo', '**/ModelSaveInfo/**', '**/@Id', '*
  */
 export const GOLDEN_CAPTURE_PREFIX = 'Contoso';
 
-/** Escape a literal string for embedding in a RegExp. */
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/** Stable placeholder a canonicalised prefix occurrence is replaced with. */
-const PREFIX_PLACEHOLDER = 'PFX';
-
 /**
- * Canonicalise occurrences of `prefix` — the model-naming EXTENSION_PREFIX in
- * effect for THIS document (the golden's fixed capture-time prefix, or the
- * actual's current session-configured prefix) — into a stable placeholder, so
- * a value/key built under one prefix session compares equal to the same
- * value/key built under a different one.
+ * EVERY EXTENSION_PREFIX the committed `eval/goldens/` corpus was captured
+ * under. The corpus was NOT captured under a single prefix: the bulk of it uses
+ * the short token `Con` (`ConDemoNoteSubject`, `CustGroup.ConExtension`, …)
+ * while `GOLDEN_CAPTURE_PREFIX` — the single-prefix default every caller
+ * inherited — is `Contoso`. Because `canonicalizePrefix` requires the prefix to
+ * be followed by an uppercase letter, "Contoso" never matches a `Con`-captured
+ * identifier (`Con` + `t` is lowercase), so the golden side of a diff was in
+ * practice NEVER canonicalised. Scoring then only worked when the operator
+ * hand-passed `--golden-prefix Con --actual-prefix Con`, and passing just one of
+ * the two produced a false mismatch (`golden="PFXDemoEnumExtProbe"` vs
+ * `actual="ConDemoEnumExtProbe"`).
  *
- * Matches are anchored at an identifier-start boundary (string start, or
- * immediately after a non-alphanumeric character — `.`, `(`, `,`, `_`,
- * whitespace, …) AND require the prefix to be immediately followed by an
- * uppercase letter (the PascalCase continuation of the object's own name,
- * e.g. `ContosoXyzNoteSubject`, `CustGroup.ContosoExtension`, `classStr(ContosoXyzNoteSubject)`).
- * This keeps the substitution narrow: an incidental occurrence of the prefix
- * text inside unrelated free-form content (e.g. a label) is left alone.
+ * Canonicalising against the whole set (longest-first, so `Contoso` is consumed
+ * before `Con` can bite into it) makes prefix resolution tolerant instead of
+ * requiring the goldens to be renamed — see docs/eval-sweep-findings-2026-07-21.md #2.
  */
-export function canonicalizePrefix(value: string, prefix: string): string {
-  if (!prefix) return value;
-  const re = new RegExp(`(^|[^A-Za-z0-9])${escapeRegExp(prefix)}(?=[A-Z])`, 'g');
-  return value.replace(re, `$1${PREFIX_PLACEHOLDER}`);
-}
+export const GOLDEN_CAPTURE_PREFIXES: readonly string[] = ['Contoso', 'Con'];
+
+export { canonicalizePrefix, PREFIX_PLACEHOLDER, type PrefixSpec } from './prefix.js';
 
 /** Compile a path glob (`**`, `*`, literal) to an anchored RegExp. */
 export function globToRegExp(glob: string): RegExp {
@@ -126,7 +120,53 @@ function isXppSourcePath(pathPrefix: string): boolean {
  * canonicalisation — it never rewrites a stored artifact.
  */
 function canonicalizeXppSourceText(s: string): string {
-  return reindentXppSource(s, 0);
+  return canonicalizeXppDocComments(reindentXppSource(s, 0));
+}
+
+/**
+ * Placeholder a contiguous run of `///` XmlDoc lines collapses to.
+ * Deliberately still a `///` line: PRESENCE of a doc comment survives the
+ * canonicalisation, only its PROSE is discarded (see below).
+ */
+export const XMLDOC_PLACEHOLDER = '/// <xmldoc/>';
+
+/**
+ * Collapse every contiguous run of `///` XmlDoc lines to a single placeholder
+ * line, keeping the run's own (already re-derived) indentation.
+ *
+ * Why: `///` doc-comment WORDING is not pinned by any case instruction, and
+ * `d365fo_file` auto-injects a class-level doc comment whose text is generated
+ * from the object name. A faithful rerun by an agent that writes different
+ * prose therefore scored `golden_match: 0` for a purely cosmetic reason —
+ * corpus-wide oracle fragility, docs/eval-sweep-findings-2026-07-21.md #24.
+ *
+ * Why COLLAPSE rather than STRIP (the direction the finding suggested):
+ * deleting `///` lines outright would also make a golden that HAS a doc comment
+ * compare equal to an actual that has NONE — and the presence of a doc header is
+ * exactly what the `BPXmlDocNoDocumentationComments` best-practice rule (and
+ * therefore the `bp_clean` dimension) measures. Stripping would mask a real,
+ * BP-visible content difference. Collapsing keeps "a doc comment exists here,
+ * attached to this declaration" load-bearing while making its wording free.
+ *
+ * `///` inside a string literal is not special-cased: X++ string literals use
+ * single quotes and a `///` run is only recognised at the START of a line, so
+ * the only way to hit that is a multi-line literal whose continuation line
+ * begins with `///` — not expressible in X++.
+ */
+function canonicalizeXppDocComments(s: string): string {
+  const out: string[] = [];
+  let inRun = false;
+  for (const line of s.split('\n')) {
+    const m = /^(\s*)\/\/\//.exec(line);
+    if (m) {
+      if (!inRun) out.push(`${m[1]}${XMLDOC_PLACEHOLDER}`);
+      inRun = true;
+      continue;
+    }
+    inRun = false;
+    out.push(line);
+  }
+  return out.join('\n');
 }
 
 /**
@@ -198,7 +238,7 @@ function nestedName(node: Record<string, unknown>): string | undefined {
  * nested name, different random wrapper id) align under the same key rather
  * than false-mismatching on the whole subtree.
  */
-function discriminator(node: Record<string, unknown>, tag: string | undefined, prefix: string): string | undefined {
+function discriminator(node: Record<string, unknown>, tag: string | undefined, prefix: PrefixSpec): string | undefined {
   const own = ownName(node);
   if (own !== undefined && tag && looksAutoGenerated(own, tag)) {
     const nested = nestedName(node);
@@ -212,7 +252,7 @@ function emitAttrs(
   pathPrefix: string,
   out: Map<string, string>,
   matchers: RegExp[],
-  prefix: string,
+  prefix: PrefixSpec,
 ): void {
   if (!attrs) return;
   for (const [name, value] of Object.entries(attrs)) {
@@ -229,7 +269,7 @@ function walk(
   pathPrefix: string,
   out: Map<string, string>,
   matchers: RegExp[],
-  prefix: string,
+  prefix: PrefixSpec,
 ): void {
   if (node == null) return;
 
@@ -284,7 +324,7 @@ function walk(
 export async function normalizeAotXml(
   xml: string,
   ignore: string[] = [],
-  prefix = '',
+  prefix: PrefixSpec = '',
 ): Promise<Map<string, string>> {
   const parsed = await parseStringPromise(xml, {
     explicitArray: true,
@@ -331,19 +371,23 @@ export function renderNormalized(map: Map<string, string>): string {
  * `artifacts` keys are filenames (e.g. "MyContract.metadata.xml") — stable,
  * case-author-chosen identifiers, not full paths. The filename itself is
  * typically the prefixed object name (e.g. "ContosoMyContract.metadata.xml"), so
- * it is canonicalised with `prefix` too (see `normalizeAotXml`) — otherwise a
- * golden captured under one prefix and an actual produced under another would
- * combine under different `<filename>::` keys and false-mismatch wholesale.
+ * it is reduced to a LOGICAL ARTIFACT KEY (`artifactKeyMap`) that also absorbs
+ * the corpus's second, legacy filename convention (unprefixed stem +
+ * `.Ax<Type>` infix) — otherwise a golden captured under one prefix/convention
+ * and an actual produced under another would combine under different
+ * `<filename>::` keys and false-mismatch wholesale.
  */
 export async function normalizeMultiArtifact(
   artifacts: Record<string, string>,
   ignore: string[] = [],
-  prefix = '',
+  prefix: PrefixSpec = '',
 ): Promise<Map<string, string>> {
   const out = new Map<string, string>();
-  for (const name of Object.keys(artifacts).sort()) {
+  const names = Object.keys(artifacts).sort();
+  const keys = artifactKeyMap(names, prefix);
+  for (const name of names) {
     const single = await normalizeAotXml(artifacts[name], ignore, prefix);
-    const canonName = canonicalizePrefix(name, prefix);
+    const canonName = keys.get(name) ?? canonicalizePrefix(name, prefix);
     for (const [path, value] of single) out.set(`${canonName}::${path}`, value);
   }
   return out;

--- a/src/eval/oracle/prefix.ts
+++ b/src/eval/oracle/prefix.ts
@@ -1,0 +1,49 @@
+/**
+ * EXTENSION_PREFIX canonicalisation for the eval golden oracle.
+ *
+ * Split out of normalize.ts so the artifact-key layer (artifactKey.ts) can use
+ * it without an import cycle back through the normalizer.
+ */
+
+/** Escape a literal string for embedding in a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Stable placeholder a canonicalised prefix occurrence is replaced with. */
+export const PREFIX_PLACEHOLDER = 'PFX';
+
+/** One or more EXTENSION_PREFIX tokens to canonicalise a document against. */
+export type PrefixSpec = string | readonly string[];
+
+/**
+ * Canonicalise occurrences of `prefix` — the model-naming EXTENSION_PREFIX in
+ * effect for THIS document (the golden's fixed capture-time prefix, or the
+ * actual's current session-configured prefix) — into a stable placeholder, so
+ * a value/key built under one prefix session compares equal to the same
+ * value/key built under a different one.
+ *
+ * Matches are anchored at an identifier-start boundary (string start, or
+ * immediately after a non-alphanumeric character — `.`, `(`, `,`, `_`,
+ * whitespace, …) AND require the prefix to be immediately followed by an
+ * uppercase letter (the PascalCase continuation of the object's own name,
+ * e.g. `ContosoXyzNoteSubject`, `CustGroup.ContosoExtension`, `classStr(ContosoXyzNoteSubject)`).
+ * This keeps the substitution narrow: an incidental occurrence of the prefix
+ * text inside unrelated free-form content (e.g. a label) is left alone.
+ *
+ * `prefix` may be a SET of tokens (see `GOLDEN_CAPTURE_PREFIXES`). Tokens are
+ * applied longest-first so a longer prefix is consumed before a shorter one
+ * that is its own leading substring (`Contoso` before `Con`) can split it.
+ */
+export function canonicalizePrefix(value: string, prefix: PrefixSpec): string {
+  const tokens = (typeof prefix === 'string' ? [prefix] : [...prefix])
+    .filter(p => !!p)
+    .sort((a, b) => b.length - a.length);
+  let out = value;
+  for (const token of tokens) {
+    const re = new RegExp(`(^|[^A-Za-z0-9])${escapeRegExp(token)}(?=[A-Z])`, 'g');
+    out = out.replace(re, `$1${PREFIX_PLACEHOLDER}`);
+  }
+  return out;
+}
+

--- a/src/eval/oracle/score.ts
+++ b/src/eval/oracle/score.ts
@@ -7,12 +7,31 @@ import type { GoldenDiff } from './diff.js';
 
 export interface BuildResult {
   succeeded: boolean;
+  /**
+   * The BP warnings xppbp actually reported. `undefined` means the best-practice
+   * check was NOT RUN — which is NOT the same as "ran and found nothing", and
+   * must not be scored as clean (see `Score.bp_clean`).
+   */
   bpWarnings?: unknown[];
 }
 
 export interface Score {
   build: 0 | 1;
-  bp_clean: 0 | 1;
+  /**
+   * 1 = xppbp ran and reported no warnings, 0 = xppbp ran and reported some,
+   * `null` = **xppbp was never run**, so this run carries no BP evidence at all.
+   *
+   * The three states used to be two: a run with no BP evidence
+   * (`bpWarnings === undefined`) scored `bp_clean: 1`, indistinguishable from a
+   * genuinely clean run. Older class goldens carry no class-level `///` doc
+   * header yet their corpus records claim `bp_clean: 1` — a faithful rerun of
+   * the same artifact today scores 0 on `BPXmlDocNoDocumentationComments`. So the
+   * dimension mixed "BP-clean" with "BP never checked" and could not be trended
+   * (docs/eval-sweep-findings-2026-07-21.md #3). `null` makes the unchecked state
+   * explicit, and reporting excludes it from the BP pass-rate rather than
+   * averaging incomparable records.
+   */
+  bp_clean: 0 | 1 | null;
   /**
    * 0|1 when a golden was diffed; `null` when the golden dimension was NOT
    * evaluated (case is `golden_pending`, or no `*.metadata.xml` golden exists
@@ -35,7 +54,7 @@ export function scoreRun(input: ScoreInput): Score {
   const { build, goldenDiff, tier, systest } = input;
   return {
     build: build.succeeded ? 1 : 0,
-    bp_clean: (build.bpWarnings?.length ?? 0) === 0 ? 1 : 0,
+    bp_clean: build.bpWarnings === undefined ? null : (build.bpWarnings.length === 0 ? 1 : 0),
     golden_match: goldenDiff.matched ? 1 : 0,
     systest: systest == null || systest.passed == null ? null : (systest.passed ? 1 : 0),
     tier_weight: tier,

--- a/tests/eval/heldout.test.ts
+++ b/tests/eval/heldout.test.ts
@@ -11,8 +11,11 @@ import {
   type ScoredCase,
 } from '../../src/eval/improver/heldout';
 
+// `bpChecked: true` = the capture actually ran xppbp. Since the 2026-07-22
+// scoring-integrity fix (#3) an unchecked run is excluded from pass_at_bp_clean
+// rather than counted as clean.
 const sc = (caseId: string, split: 'train' | 'holdout', b: number, bp: number, g: number): ScoredCase =>
-  ({ caseId, split, score: { build: b, bp_clean: bp, golden_match: g } });
+  ({ caseId, split, score: { build: b, bp_clean: bp, golden_match: g }, bpChecked: true });
 
 describe('aggregate', () => {
   it('computes pass fractions per metric', () => {
@@ -23,8 +26,25 @@ describe('aggregate', () => {
     expect(a.pass_at_golden).toBe(0.5);
   });
 
-  it('is 0 (not NaN) for an empty set', () => {
-    expect(aggregate([])).toEqual({ count: 0, pass_at_build: 0, pass_at_bp_clean: 0, pass_at_golden: 0 });
+  it('is 0 (not NaN) for an empty set — and bp is null, since nothing was measured', () => {
+    expect(aggregate([])).toEqual({ count: 0, pass_at_build: 0, pass_at_bp_clean: null, pass_at_golden: 0 });
+  });
+
+  it('excludes BP-unverified cases from the BP rate instead of counting them clean (#3)', () => {
+    const a = aggregate([
+      sc('a', 'train', 1, 1, 1),
+      { caseId: 'b', split: 'train', score: { build: 1, bp_clean: 1, golden_match: 1 } }, // legacy: unverifiable
+      { caseId: 'c', split: 'train', score: { build: 1, bp_clean: null, golden_match: 1 } }, // BP not run
+    ]);
+    expect(a.count).toBe(3);
+    expect(a.pass_at_bp_clean).toBe(1); // 1 of 1 VERIFIED case, not 2 of 3
+  });
+
+  it('holdoutRegressed skips a metric that was not measured on either side', () => {
+    const unmeasured = { count: 1, pass_at_build: 1, pass_at_bp_clean: null, pass_at_golden: 1 };
+    const measured = { count: 1, pass_at_build: 1, pass_at_bp_clean: 1, pass_at_golden: 1 };
+    expect(holdoutRegressed(measured, unmeasured).ok).toBe(true);
+    expect(holdoutRegressed(unmeasured, measured).ok).toBe(true);
   });
 });
 

--- a/tests/eval/oracleScoringIntegrity.test.ts
+++ b/tests/eval/oracleScoringIntegrity.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Oracle / scoring-integrity regressions from the 2026-07-21 golden-capture sweep
+ * (docs/eval-sweep-findings-2026-07-21.md #24, #2, #3).
+ *
+ * All three are measurement defects: the oracle either failed a faithful
+ * reproduction for a cosmetic reason, or reported a number that was never
+ * measured. Every test here fails on the pre-fix code and is VM-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  evaluate, evaluateMulti, scoreRun, canonicalizePrefix, normalizeAotXml,
+  artifactKey, artifactKeyMap, GOLDEN_CAPTURE_PREFIXES,
+} from '../../src/eval/oracle/index';
+import { resolveActualFile, buildActualArtifactsMap } from '../../src/eval/oracle/actualArtifactResolution';
+import { buildReport, bpState, renderReport, type RunForReport } from '../../src/eval/improver/report';
+
+const CASE = { id: 'L2-x', tier: 2 };
+const BUILD_OK = { succeeded: true, bpWarnings: [] };
+const MATCHED = { matched: true, missing: [] as string[], extra: [] as string[], changed: [] as never[] };
+
+/** An AxClass whose method body is fixed and whose `///` prose is a parameter. */
+function classXml(opts: { name: string; classDoc: string | null; methodDoc: string | null; body?: string }): string {
+  const decl = [
+    ...(opts.classDoc ? [`/// <summary>`, `/// ${opts.classDoc}`, `/// </summary>`] : []),
+    `public class ${opts.name}`,
+    '{',
+    '}',
+  ].join('\n');
+  const src = [
+    ...(opts.methodDoc ? [`    /// <summary>`, `    /// ${opts.methodDoc}`, `    /// </summary>`] : []),
+    `    public static str greet()`,
+    '    {',
+    `        return '${opts.body ?? 'hello'}';`,
+    '    }',
+  ].join('\n');
+  return `<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>${opts.name}</Name>
+  <SourceCode>
+    <Declaration><![CDATA[
+${decl}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>greet</Name>
+        <Source><![CDATA[
+${src}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>`;
+}
+
+// ---------------------------------------------------------------------------
+// #24 — `///` doc comments were load-bearing in class goldens
+// ---------------------------------------------------------------------------
+describe('#24 — XmlDoc prose is not load-bearing, but its PRESENCE still is', () => {
+  it('two artifacts differing ONLY in `///` wording score golden_match: 1', async () => {
+    const golden = classXml({
+      name: 'ConDemoCompanyReader',
+      classDoc: 'Provides con demo company reader functionality.',
+      methodDoc: 'Reads the subject of a note from another legal entity.',
+    });
+    const actual = classXml({
+      name: 'ConDemoCompanyReader',
+      classDoc: 'Reads note subjects across legal entities.',
+      methodDoc: 'Returns the subject for the given note in the given company.',
+    });
+    const res = await evaluate({ caseSpec: CASE, goldenXml: golden, actualXml: actual, build: BUILD_OK });
+    expect(res.goldenDiff.changed).toEqual([]);
+    expect(res.score.golden_match).toBe(1);
+  });
+
+  it('a doc comment run of a DIFFERENT LENGTH still matches (param/returns tags are prose too)', async () => {
+    const golden = classXml({ name: 'C', classDoc: 'One line.', methodDoc: 'A' });
+    const actualXml = classXml({ name: 'C', classDoc: 'One line.', methodDoc: 'A' })
+      .replace('    /// A\n', '    /// A\n    /// <param name = "_x">More prose.</param>\n    /// <returns>Even more.</returns>\n');
+    const res = await evaluate({ caseSpec: CASE, goldenXml: golden, actualXml, build: BUILD_OK });
+    expect(res.score.golden_match).toBe(1);
+  });
+
+  it('ANTI-MASKING: a MISSING doc comment is still a diff (BPXmlDocNoDocumentationComments)', async () => {
+    // Stripping `///` lines outright — the direction the finding suggested — would
+    // make these two compare equal, hiding exactly the difference the BP rule
+    // measures. Collapsing keeps presence load-bearing.
+    const golden = classXml({ name: 'C', classDoc: 'Documented.', methodDoc: 'Documented.' });
+    const actual = classXml({ name: 'C', classDoc: null, methodDoc: null });
+    const res = await evaluate({ caseSpec: CASE, goldenXml: golden, actualXml: actual, build: BUILD_OK });
+    expect(res.score.golden_match).toBe(0);
+  });
+
+  it('ANTI-MASKING: real code differences are untouched by the doc-comment collapse', async () => {
+    const golden = classXml({ name: 'C', classDoc: 'Same.', methodDoc: 'Same.', body: 'hello' });
+    const actual = classXml({ name: 'C', classDoc: 'Same.', methodDoc: 'Same.', body: 'goodbye' });
+    const res = await evaluate({ caseSpec: CASE, goldenXml: golden, actualXml: actual, build: BUILD_OK });
+    expect(res.score.golden_match).toBe(0);
+  });
+
+  it('a `//` (non-XmlDoc) comment is left alone — only `///` runs collapse', async () => {
+    const base = classXml({ name: 'C', classDoc: null, methodDoc: null });
+    const withComment = base.replace("        return 'hello';", "        // explain\n        return 'hello';");
+    const res = await evaluate({ caseSpec: CASE, goldenXml: base, actualXml: withComment, build: BUILD_OK });
+    expect(res.score.golden_match).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2 — golden filename / capture-prefix drift
+// ---------------------------------------------------------------------------
+describe('#2 — prefix resolution is tolerant of both capture prefixes', () => {
+  it('GOLDEN_CAPTURE_PREFIXES canonicalises the `Con`-captured corpus (a single "Contoso" never could)', () => {
+    // `Con` + `t` is lowercase, so "Contoso" cannot match a Con-prefixed identifier:
+    // the golden side of every diff was left literal.
+    expect(canonicalizePrefix('ConDemoEnumExtProbe', 'Contoso')).toBe('ConDemoEnumExtProbe');
+    expect(canonicalizePrefix('ConDemoEnumExtProbe', GOLDEN_CAPTURE_PREFIXES)).toBe('PFXDemoEnumExtProbe');
+    expect(canonicalizePrefix('CustGroup.ConExtension', GOLDEN_CAPTURE_PREFIXES)).toBe('CustGroup.PFXExtension');
+  });
+
+  it('longest-first: "Contoso" is consumed before "Con" can split it', () => {
+    expect(canonicalizePrefix('ContosoDemoNote', GOLDEN_CAPTURE_PREFIXES)).toBe('PFXDemoNote');
+    expect(canonicalizePrefix('ContosoDemoNote ConDemoNote', GOLDEN_CAPTURE_PREFIXES))
+      .toBe('PFXDemoNote PFXDemoNote');
+  });
+
+  it('does not touch an incidental word that merely starts with the token', () => {
+    // "Contract"/"Consume" continue in lowercase; "Convert" does not either.
+    expect(canonicalizePrefix('DataContract Consume Convert', GOLDEN_CAPTURE_PREFIXES))
+      .toBe('DataContract Consume Convert');
+  });
+
+  it('a Con-captured golden matches a Con-produced actual under the DEFAULT prefixes', async () => {
+    const xml = classXml({ name: 'ConDemoEnumExtProbe', classDoc: 'x', methodDoc: 'y' });
+    const res = await evaluate({
+      caseSpec: CASE, goldenXml: xml, actualXml: xml, build: BUILD_OK,
+      goldenPrefix: GOLDEN_CAPTURE_PREFIXES, actualPrefix: GOLDEN_CAPTURE_PREFIXES,
+    });
+    expect(res.score.golden_match).toBe(1);
+  });
+
+  it('a Con-captured golden matches the SAME object produced under a Demo session', async () => {
+    // Same logical object "NoteReader": captured as ConNoteReader, reproduced by a
+    // session configured with EXTENSION_PREFIX=Demo as DemoNoteReader.
+    const golden = classXml({ name: 'ConNoteReader', classDoc: 'x', methodDoc: 'y' });
+    const actual = classXml({ name: 'DemoNoteReader', classDoc: 'x', methodDoc: 'y' });
+    const res = await evaluate({
+      caseSpec: CASE, goldenXml: golden, actualXml: actual, build: BUILD_OK,
+      goldenPrefix: GOLDEN_CAPTURE_PREFIXES, actualPrefix: 'Demo',
+    });
+    expect(res.score.golden_match).toBe(1);
+  });
+
+  it('the mismatch the sweep hit — one side canonicalised, the other not — is gone by default', async () => {
+    const xml = classXml({ name: 'ConDemoEnumExtProbe', classDoc: 'x', methodDoc: 'y' });
+    const skewed = await evaluate({
+      caseSpec: CASE, goldenXml: xml, actualXml: xml, build: BUILD_OK,
+      goldenPrefix: 'Con', actualPrefix: 'Contoso',
+    });
+    // The documented symptom: golden="PFXDemoEnumExtProbe" actual="ConDemoEnumExtProbe".
+    expect(skewed.goldenDiff.changed.some(c =>
+      c.expected === 'PFXDemoEnumExtProbe' && c.actual === 'ConDemoEnumExtProbe')).toBe(true);
+    const defaults = await evaluate({
+      caseSpec: CASE, goldenXml: xml, actualXml: xml, build: BUILD_OK,
+      goldenPrefix: GOLDEN_CAPTURE_PREFIXES, actualPrefix: GOLDEN_CAPTURE_PREFIXES,
+    });
+    expect(defaults.score.golden_match).toBe(1);
+  });
+});
+
+describe('#2 — legacy golden FILENAMES pair with the actual files the VM produced', () => {
+  it('artifactKey reduces both filename conventions to the same logical key', () => {
+    const k = (n: string) => artifactKey(n, GOLDEN_CAPTURE_PREFIXES);
+    expect(k('DemoEnumExtProbe.AxClass.metadata.xml')).toBe(k('ConDemoEnumExtProbe.metadata.xml'));
+    expect(k('DemoNoteFormatter.AxClass.metadata.xml')).toBe(k('ConDemoNoteFormatter.metadata.xml'));
+    expect(k('NumberSeqModule.AxEnumExtension.metadata.xml')).toBe(k('NumberSeqModule.ConExtension.metadata.xml'));
+    // …and keeps genuinely different artifacts apart.
+    expect(k('ConDemoNoteReportAdv.metadata.xml')).not.toBe(k('ConDemoNoteReportAdv.menuitem.metadata.xml'));
+    expect(k('CustGroupFormExt.ConExtension.metadata.xml')).not.toBe(k('CustGroupTableExt.ConExtension.metadata.xml'));
+  });
+
+  it('artifactKeyMap refuses a lossy key that would collide inside one side', () => {
+    const names = ['CustGroup.metadata.xml', 'CustGroup.ConExtension.metadata.xml'];
+    const keys = artifactKeyMap(names, GOLDEN_CAPTURE_PREFIXES);
+    // Both would reduce to "CustGroup.metadata.xml" — so both keep their raw name
+    // instead of an extension silently diffing against its base object.
+    expect(keys.get('CustGroup.metadata.xml')).toBe('CustGroup.metadata.xml');
+    expect(keys.get('CustGroup.ConExtension.metadata.xml')).toBe('CustGroup.ConExtension.metadata.xml');
+  });
+
+  it('resolveActualFile pairs a legacy golden name with the on-disk actual', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-artifact-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'ConDemoEnumExtProbe.metadata.xml'), '<AxClass/>');
+      const hit = resolveActualFile(dir, 'DemoEnumExtProbe.AxClass.metadata.xml', GOLDEN_CAPTURE_PREFIXES, GOLDEN_CAPTURE_PREFIXES);
+      expect(hit && path.basename(hit)).toBe('ConDemoEnumExtProbe.metadata.xml');
+      const miss = resolveActualFile(dir, 'SomethingElse.AxClass.metadata.xml', GOLDEN_CAPTURE_PREFIXES, GOLDEN_CAPTURE_PREFIXES);
+      expect(miss).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('end-to-end: a legacy-named multi-artifact golden dir scores golden_match: 1', async () => {
+    const probe = classXml({ name: 'ConDemoEnumExtProbe', classDoc: 'a', methodDoc: 'b' });
+    const res = await evaluateMulti({
+      caseSpec: CASE,
+      goldenArtifacts: { 'DemoEnumExtProbe.AxClass.metadata.xml': probe },
+      actualArtifacts: { 'ConDemoEnumExtProbe.metadata.xml': probe },
+      build: BUILD_OK,
+      goldenPrefix: GOLDEN_CAPTURE_PREFIXES,
+      actualPrefix: GOLDEN_CAPTURE_PREFIXES,
+    });
+    expect(res.goldenDiff.missing).toEqual([]);
+    expect(res.goldenDiff.extra).toEqual([]);
+    expect(res.score.golden_match).toBe(1);
+  });
+
+  it('buildActualArtifactsMap keeps a genuinely absent artifact absent (no false pairing)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-artifact-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'ConDemoOther.metadata.xml'), '<AxClass/>');
+      const { actualArtifacts } = buildActualArtifactsMap(
+        dir, ['DemoEnumExtProbe.AxClass.metadata.xml'], GOLDEN_CAPTURE_PREFIXES, GOLDEN_CAPTURE_PREFIXES,
+      );
+      expect(actualArtifacts['DemoEnumExtProbe.AxClass.metadata.xml']).toBe('');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3 — bp_clean must distinguish "clean" from "never checked"
+// ---------------------------------------------------------------------------
+describe('#3 — bp_clean has three states, not two', () => {
+  it('no BP evidence scores null, NOT 1', () => {
+    expect(scoreRun({ build: { succeeded: true }, goldenDiff: MATCHED, tier: 2 }).bp_clean).toBeNull();
+  });
+
+  it('an empty warning LIST still means "ran and found nothing" → 1', () => {
+    expect(scoreRun({ build: { succeeded: true, bpWarnings: [] }, goldenDiff: MATCHED, tier: 2 }).bp_clean).toBe(1);
+    expect(scoreRun({ build: { succeeded: true, bpWarnings: [{}] }, goldenDiff: MATCHED, tier: 2 }).bp_clean).toBe(0);
+  });
+
+  it('an unchecked run does not silently become a golden-matching PASS on the BP dimension', () => {
+    const s = scoreRun({ build: { succeeded: true }, goldenDiff: MATCHED, tier: 2 });
+    expect(s).toEqual({ build: 1, bp_clean: null, golden_match: 1, systest: null, tier_weight: 2 });
+  });
+});
+
+describe('#3 — the scoreboard refuses to average incomparable BP records', () => {
+  const run = (over: Partial<RunForReport>): RunForReport =>
+    ({ case_id: 'c', tier: 2, classification: 'PASS', score: { build: 1, golden_match: 1 }, ...over });
+
+  it('classifies the three provenance states', () => {
+    expect(bpState(run({ build: { bp_checked: true }, score: { bp_clean: 1 } }))).toBe('clean');
+    expect(bpState(run({ build: { bp_checked: true }, score: { bp_clean: 0 } }))).toBe('dirty');
+    // Legacy record, no provenance flag: a 0 proves xppbp ran; a 1 proves nothing.
+    expect(bpState(run({ score: { bp_clean: 0 } }))).toBe('dirty');
+    expect(bpState(run({ score: { bp_clean: 1 } }))).toBe('unverified');
+    expect(bpState(run({ score: { bp_clean: null } }))).toBe('unverified');
+    expect(bpState(run({}))).toBe('unverified');
+  });
+
+  it('the BP pass-rate is taken over verified runs only, and the rest are counted', () => {
+    const r = buildReport([
+      run({ case_id: 'a', build: { bp_checked: true }, score: { bp_clean: 1, build: 1, golden_match: 1 } }),
+      run({ case_id: 'b', build: { bp_checked: true }, score: { bp_clean: 0, build: 1, golden_match: 1 } }),
+      run({ case_id: 'c', score: { bp_clean: 1, build: 1, golden_match: 1 } }),   // legacy, unverifiable
+      run({ case_id: 'd', score: { bp_clean: null, build: 1, golden_match: 1 } }), // BP not run
+    ]);
+    expect(r.bp_verified).toBe(2);
+    expect(r.bp_unverified).toBe(2);
+    // 1 of 2 VERIFIED runs was clean. The legacy 1 is NOT counted as a pass —
+    // pre-fix this reported 2/4.
+    expect(r.pass_at_bp_clean).toBe(0.5);
+  });
+
+  it('reports n/a rather than 0% when nothing carries BP evidence', () => {
+    const r = buildReport([run({ case_id: 'a', score: { bp_clean: 1, build: 1, golden_match: 1 } })]);
+    expect(r.pass_at_bp_clean).toBeNull();
+    const text = renderReport(r);
+    expect(text).toContain('bp=n/a');
+    expect(text).toContain('unverified');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard: the committed corpus still normalises under the new default prefixes.
+// ---------------------------------------------------------------------------
+describe('committed goldens under the tolerant default prefixes', () => {
+  const GOLDENS = path.resolve(__dirname, '..', '..', 'eval', 'goldens');
+  const files = fs.existsSync(GOLDENS)
+    ? fs.readdirSync(GOLDENS).flatMap(d => {
+      const dir = path.join(GOLDENS, d);
+      if (!fs.statSync(dir).isDirectory()) return [];
+      return fs.readdirSync(dir).filter(f => f.endsWith('.metadata.xml')).map(f => path.join(dir, f));
+    })
+    : [];
+
+  it('every golden still self-diffs clean with GOLDEN_CAPTURE_PREFIXES applied', async () => {
+    expect(files.length).toBeGreaterThan(0);
+    for (const f of files) {
+      const xml = fs.readFileSync(f, 'utf8');
+      const m = await normalizeAotXml(xml, [], GOLDEN_CAPTURE_PREFIXES);
+      expect(m.size, path.basename(f)).toBeGreaterThan(0);
+    }
+  });
+
+  it('no golden DIR contains two artifacts whose logical keys collide', () => {
+    const dirs = fs.existsSync(GOLDENS) ? fs.readdirSync(GOLDENS) : [];
+    for (const d of dirs) {
+      const dir = path.join(GOLDENS, d);
+      if (!fs.statSync(dir).isDirectory()) continue;
+      const names = fs.readdirSync(dir).filter(f => f.endsWith('.metadata.xml'));
+      const keys = new Set(names.map(n => artifactKey(n, GOLDEN_CAPTURE_PREFIXES)));
+      expect(keys.size, `${d}: ${names.join(', ')}`).toBe(names.length);
+    }
+  });
+});

--- a/tests/eval/report.test.ts
+++ b/tests/eval/report.test.ts
@@ -5,8 +5,16 @@
 import { describe, it, expect } from 'vitest';
 import { buildReport, renderReport, type RunForReport } from '../../src/eval/improver/report';
 
+// `bp_checked: true` marks the run as BP-VERIFIED. Since the 2026-07-22 scoring-integrity
+// fix (docs/eval-sweep-findings-2026-07-21.md #3) the BP pass-rate is taken over verified
+// runs only; the unverified/legacy behaviour has its own coverage in
+// tests/eval/oracleScoringIntegrity.test.ts.
 const run = (tier: number, cls: string, b: number, bp: number, g: number): RunForReport =>
-  ({ case_id: `L${tier}-x${Math.random()}`, tier, classification: cls, score: { build: b, bp_clean: bp, golden_match: g } });
+  ({
+    case_id: `L${tier}-x${Math.random()}`, tier, classification: cls,
+    score: { build: b, bp_clean: bp, golden_match: g },
+    build: { bp_checked: true },
+  });
 
 describe('buildReport', () => {
   it('computes overall and per-tier pass rates', () => {


### PR DESCRIPTION
Fixes the oracle / scoring-integrity batch from `docs/eval-sweep-findings-2026-07-21.md`: **#24, #2, #3**. VM-free — no capture was run, no corpus record was edited.

## #24 — `///` doc comments were load-bearing in class goldens

**Root cause.** `normalize.ts` canonicalised only indentation + CRLF for `Source`/`Declaration`; `///` XmlDoc lines were diffed verbatim. No case instruction pins doc-comment wording and `d365fo_file` auto-injects a class-level comment, so a faithful rerun by an agent that writes different prose scored `golden_match: 0` for a purely cosmetic reason. 28 of the committed goldens carry `///` lines.

**Fix — collapse, not strip.** A contiguous run of `///` lines now reduces to a single `/// <xmldoc/>` placeholder at the run's canonical indentation.

I deliberately did **not** implement the finding's suggested direction (strip `///` lines entirely). Stripping would also make a golden that HAS a doc comment compare equal to an actual that has NONE — and the presence of a doc header is exactly what `BPXmlDocNoDocumentationComments` (and therefore the `bp_clean` dimension) measures. That would mask a real, BP-visible content difference. Collapsing keeps "a doc comment exists here, attached to this declaration" load-bearing and makes only the wording free. Four anti-masking tests lock that in (missing doc comment => still a diff; changed code => still a diff; a plain `//` comment => still a diff).

## #2 — golden filename / capture-prefix drift

**Root cause (two halves, both reproduced in-repo).**

1. *Content prefix.* The committed corpus is `Con`-prefixed (`ConDemoNoteSubject`, `CustGroup.ConExtension`), but the default `goldenPrefix` was `GOLDEN_CAPTURE_PREFIX = "Contoso"`. `canonicalizePrefix` requires the token to be followed by an uppercase letter, and `Con` + `t` is lowercase — so **"Contoso" can never match a `Con`-captured identifier**. The golden side of every diff was left literal, which is why scoring only worked with hand-passed `--golden-prefix Con --actual-prefix Con`, and why passing just one produced the reported `golden="PFXDemoEnumExtProbe" actual="ConDemoEnumExtProbe"`.
2. *Filename.* Legacy golden dirs use `<UnprefixedName>.Ax<Type>.metadata.xml` while the actual file off the VM is `Con<Name>.metadata.xml`, so multi-artifact pairing matched nothing and the artifact scored as missing **and** extra.

**Fix — tolerance, no renames.** `canonicalizePrefix` accepts a set of tokens applied longest-first (`Contoso` consumed before `Con` can split it); both CLI defaults are now `GOLDEN_CAPTURE_PREFIXES = ["Contoso", "Con"]`. New `src/eval/oracle/artifactKey.ts` reduces both filename conventions to one logical key (drop `.metadata.xml`, drop a legacy `.Ax<Type>` infix, drop a `.<prefix>Extension` marker, canonicalise the prefix, drop a leading `PFX`), used by `normalizeMultiArtifact` and `resolveActualFile`. The reduction is lossy, so `artifactKeyMap` refuses it for any name whose key would collide inside the same side — e.g. a dir holding both `CustGroup` and `CustGroup.ConExtension` keeps raw filenames rather than diffing an extension against its base object.

**No golden was renamed and no golden byte changed.** A test asserts no committed golden dir has colliding keys under the new rules.

## #3 — `bp_clean` was not comparable across the corpus

**Root cause.** `scoreRun` did `(build.bpWarnings?.length ?? 0) === 0 ? 1 : 0`, so *absent* BP evidence scored **1**; and the oracle CLI defaulted `--bp-warnings` to `0`. Every capture whose operator skipped xppbp minted a fake `bp_clean: 1`, indistinguishable from a genuinely clean run.

**Fix.**
- `bp_clean` is now `0 | 1 | null`; `null` = xppbp was never run.
- The CLI no longer manufactures a zero: omitting `--bp-warnings` yields `bp_clean: null`, prints a loud stderr note, and writes `build.bp_checked: false` into the record. `bp_clean: null` no longer downgrades the classification to `KNOWLEDGE_GAP` (absence of evidence is not evidence of a gap).
- `report.ts` / `heldout.ts` **refuse to average incomparable records**: `pass@bp_clean` is taken over BP-verified runs only, with `[N checked, M unverified]` and an explanatory note; `n/a` when nothing is verified. `holdoutRegressed` skips a metric that is `null` on either side instead of inventing a failure.

**Historical records are not retro-edited.** The only thing honestly inferable about a pre-flag record is that `bp_clean: 0` proves xppbp ran (a 0 was only reachable from observed warnings). A legacy `bp_clean: 1` proves nothing either way, so it is marked `unverified` and excluded — not rewritten into a value nobody measured.

## Repro tests

New `tests/eval/oracleScoringIntegrity.test.ts` — 24 tests, all failing on `main`:
- #24: prose-only difference => match; different-length doc runs => match; missing doc comment / changed code / `//` comment => still a diff.
- #2: `canonicalizePrefix` against the corpus's real prefix; longest-first; no false hit on `DataContract`/`Consume`; the exact skewed-prefix symptom from the sweep, then gone under defaults; `artifactKey`/`artifactKeyMap` incl. the collision guard; `resolveActualFile` + `buildActualArtifactsMap` on a temp dir (a genuinely absent artifact stays absent); end-to-end `evaluateMulti` on a legacy-named golden dir.
- #3: three-state `scoreRun`; `bpState` provenance table; verified-only averaging; `n/a` rendering.
- Plus a guard that every committed golden still normalises non-empty under the new default prefixes and that no golden dir has colliding artifact keys.

`tests/eval/report.test.ts` and `tests/eval/heldout.test.ts` were updated (their fixtures now mark themselves BP-verified) — an intentional semantic change, explained in-comment. No committed golden was touched.

## Validation

- `npx vitest run tests/eval/` -> **18 files, 288 tests, all pass**, including the `tests/eval/goldens.test.ts` golden-integrity gate.
- `npx vitest run` (full) -> 2 failures in `tests/tools/runBpCheck.test.ts` and `tests/tools/code-generation.test.ts`. Both are **pre-existing, uncommitted work by the parallel improver** in the shared working tree (`src/tools/runBpCheck.ts`, security duty/role generators); neither test imports anything under `src/eval`. Nothing in this PR touches `src/tools`.
- `npm run eval:report`, before -> after:

| | before | after |
|---|---|---|
| overall build | 80% | 80% |
| overall golden | 36% | 36% |
| overall bp | 39% | **0% [27 checked, 17 unverified]** |

- Held-out split (anti-overfitting, §10) — `npm run eval:clusters`:

| split | build | golden | bp before | bp after |
|---|---|---|---|---|
| train (n=3) | 100% -> 100% | 33% -> 33% | 0% | 0% |
| **holdout (n=41)** | **78% -> 78%** | **37% -> 37%** | 41% | **0% [checked-only]** |

`build` and `golden_match` are **unchanged on the held-out split** — nothing here can inflate them, since the corpus is a record of past VM runs. The `bp` move is the point of #3, not a regression: it is the same data restated over the subset that provably ran xppbp. All 27 BP-verified runs had warnings; the 17 records claiming `bp_clean: 1` carry no evidence that xppbp ever ran.

## Evidence refs

- `docs/eval-sweep-findings-2026-07-21.md` #24 (found by `L2-multi-company-changecompany`), #2 (`L2-enum-extension-empty-values`), #3 (`L3-custom-service-basic` + `L2-enum-extension-empty-values`).
- Corpus: `eval/corpus/runs/2026-07-21T19__L2-multi-company-changecompany__c262b19.json`, `eval/corpus/runs/2026-07-07T05__L2-enum-extension-empty-values__cb1b73d--class.json`, `eval/corpus/runs/2026-07-21T18__L3-custom-service-basic__c262b19.json`.

Not auto-merged — please review, in particular the collapse-vs-strip call on #24 and the verified-only BP averaging on #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsY56fJuvoiEXjCVRR2b6M
