### PR TITLE
fix(writers): stop the create/generate path emitting metadata that cannot build

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -21,6 +21,7 @@ import { validateFormExtensionControlShape, buildFormExtensionShapeError } from 
 import { FormPatternTemplates } from '../utils/formPatternTemplates.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
+import { renderAxTableProperties } from '../utils/axTablePropertyOrder.js';
 import { buildAxSecurityPrivilegeXml } from './securityPrivilegeXml.js';
 import { buildAxDataEntityXml } from './dataEntityXml.js';
 import { resolveEdtBaseType, resolveEdtEnumType, heuristicEdtBaseType, isEnumName, bridgeEdtBaseType } from './generateSmartTable.js';
@@ -573,7 +574,17 @@ export class XmlTemplateGenerator {
     declaration: string,
     methods: T[],
   ): { declaration: string; methods: T[] } {
-    const declaredName = declaration.match(/\b(?:class|interface)\s+(\w+)/)?.[1];
+    // Match the class/interface header on CODE lines only. Matching the raw text
+    // let a doc comment win: "/// The <c>Foo</c> class is the workflow document"
+    // yields declaredName="is", and the rename then replaced every standalone "is"
+    // in the declaration and in every method body with the class name
+    // ("class is the workflow document" → "class Foo the workflow document").
+    // Reproduced from docs/eval-sweep-findings-2026-07-21.md #22.
+    const codeOnly = declaration
+      .split('\n')
+      .filter(l => !l.trim().startsWith('///') && !l.trim().startsWith('//'))
+      .join('\n');
+    const declaredName = codeOnly.match(/\b(?:class|interface)\s+(\w+)/)?.[1];
     if (!declaredName || declaredName === className) return { declaration, methods };
 
     const re = new RegExp(`\\b${declaredName}\\b`, 'g');
@@ -698,36 +709,34 @@ ${methodsXml}\t</SourceCode>
    */
   static generateAxTableXml(
     tableName: string,
-    properties?: Record<string, any>
+    properties?: Record<string, any>,
+    sourceCode?: string,
   ): string {
-    const label = properties?.label || tableName;
-    const tableGroup = properties?.tableGroup || 'Main';
-    const tableType = properties?.tableType || '';
-    const titleField1 = properties?.titleField1 || '';
-    const titleField2 = properties?.titleField2 || '';
-    const configKey = properties?.configurationKey || '';
     const primaryIndex = properties?.primaryIndex || '';
-    const cacheLookup = properties?.cacheLookup || '';
 
-    // Build optional configuration key
-    const configKeyXml = configKey
-      ? `\t<ConfigurationKey>${configKey}</ConfigurationKey>\n`
-      : '';
-
-    // Build optional cache lookup (only if explicitly set)
-    const cacheLookupXml = cacheLookup
-      ? `\t<CacheLookup>${cacheLookup}</CacheLookup>\n`
-      : '';
-
-    // Build optional primary index (NOTE: ClusteredIndex is NOT in real D365FO files)
-    const primaryIndexXml = primaryIndex
-      ? `\t<PrimaryIndex>${primaryIndex}</PrimaryIndex>\n\t<ReplacementKey>${primaryIndex}</ReplacementKey>\n`
-      : '';
-
-    // Build optional TableType (TempDB, InMemory; omit for Regular — it's the default)
-    const tableTypeXml = tableType
-      ? `\t<TableType>${tableType}</TableType>\n`
-      : '';
+    // Property block, emitted in CANONICAL ORDER. AxTable XML is order-sensitive
+    // and a misordered property is dropped without a word — see
+    // src/utils/axTablePropertyOrder.ts and findings #13. Empty values are omitted
+    // rather than written as <TitleField1></TitleField1>, matching the shipped
+    // tables and the VM-captured golden eval/goldens/L1-table-basic.
+    const propertiesXml = renderAxTableProperties({
+      ConfigurationKey: properties?.configurationKey,
+      DeveloperDocumentation: properties?.developerDocumentation,
+      FormRef: properties?.formRef,
+      Label: properties?.label || tableName,
+      TableGroup: properties?.tableGroup || 'Main',
+      TitleField1: properties?.titleField1,
+      TitleField2: properties?.titleField2,
+      CacheLookup: properties?.cacheLookup,
+      ClusteredIndex: properties?.clusteredIndex,
+      PrimaryIndex: primaryIndex,
+      // ReplacementKey mirrors PrimaryIndex unless the caller says otherwise.
+      ReplacementKey: properties?.replacementKey || primaryIndex,
+      SaveDataPerCompany: properties?.saveDataPerCompany,
+      SupportInheritance: properties?.supportInheritance,
+      // TableType: TempDB / InMemory; omitted for Regular, which is the default.
+      TableType: properties?.tableType,
+    });
 
     // Build <Fields> block from properties.fields array (TableFieldSpec[]).
     // Copilot may pass field definitions via properties.fields or via sourceCode JSON —
@@ -761,22 +770,38 @@ ${methodsXml}\t</SourceCode>
       fieldsXml += '\t</Fields>\n';
     }
 
+    // X++ passed in `sourceCode` used to be discarded outright: the caller got a ✅
+    // and an empty <Methods /> on disk, discoverable only by reading the file back
+    // (findings #19). Table source is class-shaped (`public class X extends common`
+    // + methods), so the class splitter handles it; when the caller passed only
+    // method bodies the splitter still returns them as methods.
+    const parsedSource = sourceCode?.trim()
+      ? XmlTemplateGenerator.parseSourceForBridge(sourceCode, tableName)
+      : undefined;
+    const declarationXpp =
+      parsedSource?.declaration?.trim()
+      && /\bclass\s+\w+/.test(parsedSource.declaration)
+        ? parsedSource.declaration.trim()
+        : `public class ${tableName} extends common\n{\n}`;
+    const methodsFromSource = parsedSource?.methods ?? [];
+    const methodsXml = methodsFromSource.length === 0
+      ? '\t\t<Methods />'
+      : `\t\t<Methods>\n${methodsFromSource
+          .map(m =>
+            `\t\t\t<Method>\n\t\t\t\t<Name>${m.name}</Name>\n` +
+            `\t\t\t\t<Source><![CDATA[\n${m.source ?? ''}\n\n]]></Source>\n\t\t\t</Method>`)
+          .join('\n')}\n\t\t</Methods>`;
+
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${tableName}</Name>
 \t<SourceCode>
 \t\t<Declaration><![CDATA[
-public class ${tableName} extends common
-{
-}
+${declarationXpp}
 ]]></Declaration>
-\t\t<Methods />
+${methodsXml}
 \t</SourceCode>
-${configKeyXml}\t<Label>${label}</Label>
-\t<TableGroup>${tableGroup}</TableGroup>
-${tableTypeXml}\t<TitleField1>${titleField1}</TitleField1>
-\t<TitleField2>${titleField2}</TitleField2>
-${cacheLookupXml}${primaryIndexXml}\t<DeleteActions />
+${propertiesXml}\t<DeleteActions />
 \t<FieldGroups>
 \t\t<AxTableFieldGroup>
 \t\t\t<Name>AutoReport</Name>
@@ -1471,8 +1496,10 @@ ${defaultParamGroupXml}
       case 'class-extension':
         return this.generateAxClassExtensionXml(objectName, sourceCode, properties);
       case 'table': {
-        // sourceCode is not used for tables directly, but Copilot may pass field
-        // definitions as a JSON string in sourceCode. Try to parse and merge into properties.
+        // sourceCode carries either X++ (declaration + methods — see
+        // generateAxTableXml, findings #19) or, from some callers, a JSON blob of
+        // field definitions. Parse the JSON shape into properties; anything else is
+        // treated as X++ and handed to the table generator as source.
         let mergedProperties = properties;
         if (sourceCode && sourceCode.trim().startsWith('{')) {
           try {
@@ -1485,7 +1512,10 @@ ${defaultParamGroupXml}
             // Not valid JSON — ignore
           }
         }
-        return this.generateAxTableXml(objectName, mergedProperties);
+        const tableSource = sourceCode && !sourceCode.trim().startsWith('{')
+          ? sourceCode
+          : undefined;
+        return this.generateAxTableXml(objectName, mergedProperties, tableSource);
       }
       case 'enum':
         return this.generateAxEnumXml(objectName, properties);
@@ -2683,7 +2713,16 @@ ${relationsXml}
 
   /**
    * Render a security reference container: a self-closing tag when empty, or the
-   * wrapped child references (e.g. <AxSecurityRolePermissionSet><Name>…</Name></…>).
+   * wrapped child references (e.g. <AxSecurityPrivilegeReference><Name>…</Name></…>).
+   *
+   * The child element name matters: a duty/role that lists its privileges under
+   * `AxSecurityRolePermissionSet` / `AxSecurityRoleDutyPermission` deserializes into
+   * an EMPTY reference list, so the whole duty→privilege→role chain is dead —
+   * xppbp then reports BPErrorDutyHasNoPrivileges / BPErrorPrivilegeNotCoveredByDuty /
+   * BPErrorDutyNotCoveredByRole for references that are physically in the file.
+   * The correct names are AxSecurityPrivilegeReference / AxSecurityDutyReference
+   * (the same ones the *Extension writers below and generateD365Xml.ts already use).
+   * Evidence: docs/eval-sweep-findings-2026-07-21.md #31 (L4-master-security-slice run).
    */
   private static securityRefContainer(container: string, childTag: string, names: string[]): string {
     if (names.length === 0) return `\t<${container} />`;
@@ -2704,7 +2743,7 @@ ${relationsXml}
 <AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
 \t<Label>${label}</Label>
-${this.securityRefContainer('Privileges', 'AxSecurityRolePermissionSet', privileges)}
+${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
 </AxSecurityDuty>`;
   }
 
@@ -2722,8 +2761,8 @@ ${this.securityRefContainer('Privileges', 'AxSecurityRolePermissionSet', privile
 \t<Name>${name}</Name>
 \t<Label>${label}</Label>
 \t<DirectAccessPermissions />
-${this.securityRefContainer('Duties', 'AxSecurityRoleDutyPermission', duties)}
-${this.securityRefContainer('Privileges', 'AxSecurityRolePermissionSet', privileges)}
+${this.securityRefContainer('Duties', 'AxSecurityDutyReference', duties)}
+${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
 \t<SubRoles />
 </AxSecurityRole>`;
   }
@@ -4192,7 +4231,28 @@ export async function handleCreateD365File(
               source: m.source !== undefined ? reindentXppSource(m.source) : m.source,
             }));
           }
+        }
 
+        // X++ handed to a table create via `sourceCode` reached NOBODY: only
+        // `properties.methods` was forwarded, so a full method body was answered with
+        // ✅ and an empty <Methods /> on disk (findings #19). Parse it the same way the
+        // class path does; an explicit properties.methods still wins.
+        if (
+          (args.objectType === 'table' || args.objectType === 'table-extension') &&
+          args.sourceCode &&
+          !args.sourceCode.trim().startsWith('{') &&
+          !bridgeParams.methods
+        ) {
+          const parsedTableSource = XmlTemplateGenerator.parseSourceForBridge(
+            args.sourceCode,
+            finalObjectName,
+          );
+          if (parsedTableSource.methods.length > 0) {
+            bridgeParams.methods = parsedTableSource.methods;
+          }
+        }
+
+        if ((args.objectType === 'table' || args.objectType === 'table-extension') && args.properties) {
           // Resolve each field's base type from its EDT when the caller only gave
           // `edt` (the documented usage — the tool schema says "EDT auto-resolved
           // when omitted"). Without this, C# CreateTableField() defaults ANY field
@@ -4479,6 +4539,37 @@ export async function handleCreateD365File(
       }
     }
 
+    // A view's <DataSource> must name the referenced QUERY'S ROOT DATASOURCE, not
+    // the query. Neither `query` nor `view` is a bridge create type, so this
+    // template is the only writer for them — read the query off disk (same model
+    // folder) and hand its XML to the builder, which extracts the root name
+    // (docs/eval-sweep-findings-2026-07-21.md #38).
+    let effectiveProperties = args.properties;
+    if (
+      args.objectType === 'view' &&
+      args.properties?.query &&
+      !args.properties?.dataSource &&
+      !args.properties?.queryRootDataSource &&
+      !args.properties?.queryXml
+    ) {
+      const queryFile = path.join(
+        path.dirname(modelPath),
+        'AxQuery',
+        `${String(args.properties.query)}.xml`,
+      );
+      try {
+        const queryXml = await fs.readFile(queryFile, 'utf-8');
+        effectiveProperties = { ...args.properties, queryXml };
+        console.error(`[create_d365fo_file] Resolved view datasource from ${queryFile}`);
+      } catch {
+        console.error(
+          `[create_d365fo_file] ⚠️ Could not read query '${args.properties.query}' at ${queryFile} — ` +
+          `the view's <DataSource> falls back to the query name, which is usually wrong. ` +
+          `Pass properties.dataSource explicitly.`,
+        );
+      }
+    }
+
     // Generate (or use provided) XML content
     let xmlContent = args.xmlContent
       ? args.xmlContent
@@ -4486,7 +4577,7 @@ export async function handleCreateD365File(
           args.objectType,
           finalObjectName,
           args.sourceCode,
-          args.properties
+          effectiveProperties
         );
 
     // Guard against HTML-entity-escaped xmlContent (e.g. "&lt;?xml..." instead of "<?xml...").

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -21,7 +21,7 @@ import { expandPatternToXml, canExpandPattern } from '../utils/formControlExpand
 import { cloneFormXml } from '../utils/formCloner.js';
 import { methodStubsForPattern, injectMethodStubs } from '../knowledge/formPatterns/methodStubs.js';
 import { findBaseFormXml } from './modifyD365File.js';
-import { getFieldControlMap, type FieldControlMap } from '../utils/fieldControlTypes.js';
+import { getFieldControlMap, getTableTitleField, type FieldControlMap } from '../utils/fieldControlTypes.js';
 import { lookupSymbolNocase } from '../utils/symbolLookup.js';
 
 interface GenerateSmartFormArgs {
@@ -376,6 +376,9 @@ export async function handleGenerateSmartForm(
   // Field -> control-type map (enum->ComboBox, date->Date, etc.) so generated controls
   // aren't all typed as String.
   let fieldTypes: FieldControlMap | undefined;
+  // The primary table's TitleField1 — the field a DetailsMaster title control must
+  // bind to (findings #32); undefined when the table declares none.
+  let primaryTitleField: string | undefined;
   let linesFields: string[] = [];
   let linesFieldTypes: FieldControlMap | undefined;
 
@@ -403,6 +406,7 @@ export async function handleGenerateSmartForm(
       const db = symbolIndex.getReadDb();
       gridFields = collectGridFields(db, dataSourceEffective);
       fieldTypes = getFieldControlMap(db, dataSourceEffective);
+      primaryTitleField = getTableTitleField(db, dataSourceEffective);
 
       if (gridFields.length > 0) {
         if (generateControls) {
@@ -795,6 +799,7 @@ export async function handleGenerateSmartForm(
       caption: resolveFormCaption(caption, label, lookupTableLabel(symbolIndex, primaryDs?.table), finalName),
       gridFields,
       fieldTypes,
+      titleField: primaryTitleField,
       linesDsName: linesDsNameResolved ?? (linesTableResolved || undefined),
       linesDsTable: linesTableResolved || undefined,
       linesFields,

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -32,6 +32,10 @@ import {
 import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
 import { heuristicEdtBaseType } from './generateSmartTable.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
+import {
+  upsertAxTableProperty,
+  AX_TABLE_NON_EXISTENT_PROPERTIES,
+} from '../utils/axTablePropertyOrder.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
 import {
@@ -330,7 +334,32 @@ async function directXmlModifyProperty(
     const totalMatches = openMatches.length + selfClosingMatches.length;
 
     if (totalMatches === 0) {
-      return null; // property element not found — let the caller surface the original bridge error
+      // The element does not exist yet. For an AxTable we know the canonical
+      // element order, so it can be INSERTED in the right place instead of failing.
+      // This is what makes properties the C# bridge refuses outright reachable at
+      // all — notably FormRef, whose absence is the very BPErrorTableMissingFormRef
+      // the agent is trying to fix (docs/eval-sweep-findings-2026-07-21.md #37).
+      // Order matters: a property written in the wrong position is dropped without
+      // a word (#13), which is why this goes through upsertAxTableProperty.
+      const nonExistent = AX_TABLE_NON_EXISTENT_PROPERTIES[tagName];
+      if (nonExistent && /<AxTable[\s>]/.test(content)) {
+        return {
+          success: false,
+          message: `❌ '${tagName}' is not an AxTable property — nothing was written. ${nonExistent}`,
+        };
+      }
+      const inserted = upsertAxTableProperty(content, tagName, escapedValue);
+      if (!inserted) {
+        return null; // not a table / unknown property — surface the original bridge error
+      }
+      await fs.writeFile(filePath, normalizeD365Xml(inserted), 'utf-8');
+      console.error(`[modify_d365fo_file] ✅ directXmlModifyProperty fallback: inserted <${tagName}> in ${filePath}`);
+      return {
+        success: true,
+        message:
+          `✅ Property '${propertyPath}'='${propertyValue}' added via direct XML fallback ` +
+          `(the element did not exist; inserted in canonical AxTable element order). File: ${filePath}`,
+      };
     }
     if (totalMatches > 1) {
       return {
@@ -374,12 +403,20 @@ async function directXmlAddMenuItemToMenu(
     const typeMap: Record<string, string> = { display: 'Display', action: 'Action', output: 'Output' };
     const menuItemType = typeMap[menuItemToAddType?.toLowerCase()] ?? 'Display';
 
+    // An AxMenu's <Elements> holds AxMenuElement entries discriminated by i:type —
+    // `AxMenuElementMenuItem` for a menu-item reference. `AxMenuFunctionItem` is not
+    // a type in the metadata model at all (zero of the 73 shipped AxMenu files use
+    // it), so the element deserializes into nothing and the menu comes out empty:
+    // docs/eval-sweep-findings-2026-07-21.md #30. `MenuItemType` is omitted for
+    // MenuItemType stays explicit (Display is the model default and the shipped
+    // files omit it, but writing it costs nothing and keeps display/action/output
+    // unambiguous).
     const newElement =
-      `\t\t<AxMenuFunctionItem>\n` +
+      `\t\t<AxMenuElement xmlns="" i:type="AxMenuElementMenuItem">\n` +
       `\t\t\t<Name>${menuItemToAdd}</Name>\n` +
       `\t\t\t<MenuItemName>${menuItemToAdd}</MenuItemName>\n` +
       `\t\t\t<MenuItemType>${menuItemType}</MenuItemType>\n` +
-      `\t\t</AxMenuFunctionItem>`;
+      `\t\t</AxMenuElement>`;
 
     let updated: string;
     if (content.includes('<Elements />')) {

--- a/src/tools/queryViewXml.ts
+++ b/src/tools/queryViewXml.ts
@@ -56,12 +56,34 @@ ${classDeclaration}
 `;
   }
 
+  // A data source with NO explicit field list only compiles when it is marked
+  // dynamic. xppc rejects the "all fields" shape with "The field list of the data
+  // source 'X' cannot be empty if the dynamic field is set to false", so every
+  // fieldless query this builder produced failed the build
+  // (docs/eval-sweep-findings-2026-07-21.md #20). `properties.dynamicFields` lets a
+  // caller force it either way; otherwise it follows "no explicit fields ⇒ dynamic".
+  //
+  // Position: between <DerivedDataSources> and <Fields>. The captured golden
+  // (eval/goldens/L1-query-view-basic) fixes the surrounding sequence
+  // Name → Table → DataSources → DerivedDataSources → Fields, and DynamicFields
+  // sorts there alphabetically — the same place the AxTable serializer puts its
+  // extended properties (#13). AOT XML silently DROPS misordered elements, so this
+  // position is deliberate, not incidental.
+  const explicitDynamic: boolean | undefined =
+    typeof properties?.dynamicFields === 'boolean'
+      ? properties.dynamicFields
+      : typeof properties?.dynamicFields === 'string'
+        ? /^(yes|true)$/i.test(properties.dynamicFields)
+        : undefined;
+  const dynamicFields = explicitDynamic ?? !fields?.length;
+  const dynamicFieldsXml = dynamicFields ? '\t\t\t<DynamicFields>Yes</DynamicFields>\n' : '';
+
   const fieldsXml = fields?.length
-    ? fields.map(f => `\t\t\t<AxQuerySimpleDataSourceField>
-\t\t\t\t<Name>${f.field || f.name}</Name>
-\t\t\t\t<Field>${f.field || f.name}</Field>
-\t\t\t</AxQuerySimpleDataSourceField>`).join('\n')
-    : '';
+    ? `\t\t\t<Fields>\n${fields.map(f => `\t\t\t\t<AxQuerySimpleDataSourceField>
+\t\t\t\t\t<Name>${f.field || f.name}</Name>
+\t\t\t\t\t<Field>${f.field || f.name}</Field>
+\t\t\t\t</AxQuerySimpleDataSourceField>`).join('\n')}\n\t\t\t</Fields>\n`
+    : '\t\t\t<Fields />\n';
 
   return `<?xml version="1.0" encoding="utf-8"?>
 <AxQuery xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns=""
@@ -75,10 +97,7 @@ ${classDeclaration}
 \t\t\t<Table>${dataSource}</Table>
 \t\t\t<DataSources />
 \t\t\t<DerivedDataSources />
-\t\t\t<Fields>
-${fieldsXml}
-\t\t\t</Fields>
-\t\t\t<Ranges />
+${dynamicFieldsXml}${fieldsXml}\t\t\t<Ranges />
 \t\t\t<GroupBy />
 \t\t\t<Having />
 \t\t\t<OrderBy />
@@ -89,19 +108,49 @@ ${fieldsXml}
 }
 
 /**
- * properties.query      — name of an existing AxQuery this view is built on.
- * properties.dataSource  — that query's root datasource NAME (defaults to
- *                           properties.query — matches the common convention
- *                           of naming a simple query's root datasource after
- *                           its table, and matching buildAxQueryXml's default
- *                           dataSourceName when the caller didn't override it).
- * properties.fields      — [{ name, dataField? }] → one AxViewFieldBound per
- *                           entry, dataField defaults to name.
+ * Extract the root data source NAME from an AxQuery document.
+ *
+ * A view's `<DataSource>` must name the query's root data source — NOT the query
+ * itself. Exported so the create path can resolve it from the query file on disk.
+ */
+export function extractQueryRootDataSourceName(queryXml: string): string | undefined {
+  const root = queryXml.match(
+    /<AxQuerySimpleRootDataSource>[\s\S]*?<Name>([^<]+)<\/Name>/,
+  )?.[1]?.trim();
+  return root ? root : undefined;
+}
+
+/**
+ * properties.query               — name of an existing AxQuery this view is built on.
+ * properties.dataSource          — that query's root datasource NAME.
+ * properties.queryRootDataSource — same thing, resolved by the caller from the
+ *                                   query on disk (see extractQueryRootDataSourceName).
+ * properties.queryXml            — the referenced query's raw XML; the root
+ *                                   datasource name is read out of it.
+ * properties.fields              — [{ name, dataField? }] → one AxViewFieldBound
+ *                                   per entry, dataField defaults to name.
+ *
+ * Resolution order is deliberate: an explicit `dataSource` wins, then a resolved
+ * root name, then the referenced query's own XML. Only as a LAST resort does it
+ * fall back to the query name — which is what it used to do unconditionally, and
+ * which is essentially always wrong: buildAxQueryXml names a simple query's root
+ * datasource after its TABLE, so a view generated from a `…Query` object bound its
+ * fields to a datasource that does not exist
+ * (docs/eval-sweep-findings-2026-07-21.md #38; ground truth in
+ * eval/goldens/L1-query-view-basic, where the view's DataSource is
+ * `ConDemoNoteHeader`, not `ConDemoNoteHeaderQuery`).
  */
 export function buildAxViewXml(viewName: string, properties?: Record<string, any>): string {
   const label = properties?.label || viewName;
   const query: string | undefined = properties?.query;
-  const dataSource: string = properties?.dataSource || query || '';
+  const dataSource: string =
+    properties?.dataSource
+    || properties?.queryRootDataSource
+    || (typeof properties?.queryXml === 'string'
+      ? extractQueryRootDataSourceName(properties.queryXml)
+      : undefined)
+    || query
+    || '';
   const fields: Array<{ name: string; dataField?: string }> | undefined =
     Array.isArray(properties?.fields) ? properties.fields : undefined;
 

--- a/src/tools/validateXpp.ts
+++ b/src/tools/validateXpp.ts
@@ -680,29 +680,51 @@ const XPP_RULES = [
 ];
 
 /**
- * Collect the names of the direct children of the document root, in document
- * order. CDATA is stripped first — X++ inside `<Source><![CDATA[…]]></Source>`
- * is full of `<` characters that would otherwise be read as tags.
+ * Collect the names of the direct children of the document root, in document order.
+ *
+ * Skips CDATA / comments / PIs in a single forward scan rather than stripping them with
+ * chained `.replace()`. Two reasons that matters: removing one region can splice its
+ * neighbours into a NEW delimiter (`<!<!-- -->--` leaves `<!--`), and a non-greedy
+ * `<!--[\s\S]*?-->` does not match an UNTERMINATED comment at all, so it survives intact.
+ * Skipping in place can do neither. CDATA is what makes this necessary in the first place:
+ * X++ inside `<Source><![CDATA[…]]></Source>` is full of `<` that would read as tags.
  */
 function rootChildElements(xml: string): string[] {
-  const stripped = xml
-    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/<\?[\s\S]*?\?>/g, '');
   const out: string[] = [];
   let depth = 0;
-  const tagRe = /<(\/?)([A-Za-z_][\w.-]*)([^>]*?)(\/?)>/g;
-  let m: RegExpExecArray | null;
-  while ((m = tagRe.exec(stripped)) !== null) {
-    const closing = m[1] === '/';
-    const name = m[2];
-    const selfClosing = m[4] === '/';
-    if (closing) {
-      depth--;
+  let i = 0;
+
+  /** End of a skipped region; an unterminated one runs to EOF. */
+  const skipTo = (from: number, terminator: string): number => {
+    const end = xml.indexOf(terminator, from);
+    return end === -1 ? xml.length : end + terminator.length;
+  };
+
+  const tagRe = /<(\/?)([A-Za-z_][\w.-]*)([^>]*?)(\/?)>/y;
+
+  while (i < xml.length) {
+    const lt = xml.indexOf('<', i);
+    if (lt === -1) break;
+
+    // Order matters: the longer delimiters must be tested before the `<!` catch-all.
+    if (xml.startsWith('<![CDATA[', lt)) { i = skipTo(lt + 9, ']]>'); continue; }
+    if (xml.startsWith('<!--', lt)) { i = skipTo(lt + 4, '-->'); continue; }
+    if (xml.startsWith('<?', lt)) { i = skipTo(lt + 2, '?>'); continue; }
+    if (xml.startsWith('<!', lt)) { i = skipTo(lt + 2, '>'); continue; }
+
+    tagRe.lastIndex = lt;
+    const m = tagRe.exec(xml);
+    if (!m) {
+      i = lt + 1;
       continue;
     }
-    if (depth === 1) out.push(name);
-    if (!selfClosing) depth++;
+    if (m[1] === '/') {
+      depth--;
+    } else {
+      if (depth === 1) out.push(m[2]);
+      if (m[4] !== '/') depth++;
+    }
+    i = lt + m[0].length;
   }
   return out;
 }

--- a/src/tools/validateXpp.ts
+++ b/src/tools/validateXpp.ts
@@ -20,6 +20,8 @@
  *   BP004   Developer-only statements left in code (pause / print)
  *   TTS001  Unbalanced ttsbegin / ttscommit
  *   XML001  AxTable XML missing an index with <AlternateKey>Yes</AlternateKey>
+ *   XML006  AxTable elements out of canonical order (silently dropped by the AOT)
+ *   XML007  Table-level property that does not exist in the AxTable model
  *
  * Keyword scans run against a comment/string-masked copy of the source
  * (maskStringsAndComments) to avoid false positives inside literals/comments.
@@ -33,6 +35,11 @@
  */
 
 import { z } from 'zod';
+import {
+  AX_TABLE_ELEMENT_ORDER,
+  AX_TABLE_NON_EXISTENT_PROPERTIES,
+  axTableElementRank,
+} from '../utils/axTablePropertyOrder.js';
 
 // Schema
 
@@ -672,8 +679,95 @@ const XPP_RULES = [
   checkDevArtifacts,
 ];
 
+/**
+ * Collect the names of the direct children of the document root, in document
+ * order. CDATA is stripped first — X++ inside `<Source><![CDATA[…]]></Source>`
+ * is full of `<` characters that would otherwise be read as tags.
+ */
+function rootChildElements(xml: string): string[] {
+  const stripped = xml
+    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<\?[\s\S]*?\?>/g, '');
+  const out: string[] = [];
+  let depth = 0;
+  const tagRe = /<(\/?)([A-Za-z_][\w.-]*)([^>]*?)(\/?)>/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(stripped)) !== null) {
+    const closing = m[1] === '/';
+    const name = m[2];
+    const selfClosing = m[4] === '/';
+    if (closing) {
+      depth--;
+      continue;
+    }
+    if (depth === 1) out.push(name);
+    if (!selfClosing) depth++;
+  }
+  return out;
+}
+
+/**
+ * XML006 — AxTable elements out of canonical order.
+ *
+ * The AOT deserializer drops a misordered property SILENTLY: xppbp then reports
+ * BPErrorLabelNotDefined / BPErrorTableTitleField1NotDeclared /
+ * BPErrorDeveloperDocumentationNotDefined for properties that are physically in
+ * the file, and this validator used to answer "no violations" on exactly that
+ * document (docs/eval-sweep-findings-2026-07-21.md #13).
+ */
+function checkTableElementOrder(code: string): ValidationViolation[] {
+  if (!/<AxTable[\s>]/.test(code)) return [];
+  const children = rootChildElements(code).filter(
+    n => axTableElementRank(n) !== Number.MAX_SAFE_INTEGER,
+  );
+  const violations: ValidationViolation[] = [];
+  for (let i = 1; i < children.length; i++) {
+    const prev = children[i - 1];
+    const cur = children[i];
+    if (axTableElementRank(cur) >= axTableElementRank(prev)) continue;
+    violations.push({
+      rule: 'XML006',
+      severity: 'error',
+      line: lineNumber(code, code.indexOf(`<${cur}`)),
+      excerpt: `<${cur}> appears after <${prev}>`,
+      fix:
+        `AxTable XML is order-sensitive and a misordered element is dropped SILENTLY ` +
+        `(the build stays green, xppbp then reports the property as missing). ` +
+        `Move <${cur}> before <${prev}>. Canonical order: ` +
+        `${AX_TABLE_ELEMENT_ORDER.join(' → ')}.`,
+    });
+    break; // one report per document — fixing the order fixes them all
+  }
+  return violations;
+}
+
+/**
+ * XML007 — a table-level property that does not exist in the AxTable model.
+ * `<AlternateKey>` at table level is the common one: it reads naturally, is
+ * accepted by every writer, and does nothing at all (findings #13).
+ */
+function checkNonExistentTableProperties(code: string): ValidationViolation[] {
+  if (!/<AxTable[\s>]/.test(code)) return [];
+  const violations: ValidationViolation[] = [];
+  for (const name of new Set(rootChildElements(code))) {
+    const explanation = AX_TABLE_NON_EXISTENT_PROPERTIES[name];
+    if (!explanation) continue;
+    violations.push({
+      rule: 'XML007',
+      severity: 'error',
+      line: lineNumber(code, code.indexOf(`<${name}`)),
+      excerpt: `<${name}> is not an AxTable property`,
+      fix: `${explanation} As written this element is ignored by the deserializer — silently.`,
+    });
+  }
+  return violations;
+}
+
 const XML_RULES = [
   checkMissingAlternateKey,
+  checkTableElementOrder,
+  checkNonExistentTableProperties,
 ];
 
 const XML_PROPERTY_RULES = [

--- a/src/utils/axTablePropertyOrder.ts
+++ b/src/utils/axTablePropertyOrder.ts
@@ -1,0 +1,162 @@
+/**
+ * Canonical element order for AxTable XML.
+ *
+ * AxTable documents are ORDER-SENSITIVE and the deserializer drops misordered
+ * property elements SILENTLY: the property is physically in the file, `validate_code`
+ * happily reports "no violations", and xppbp then complains that it is missing
+ * (BPErrorTableTitleField1NotDeclared / BPErrorLabelNotDefined /
+ * BPErrorDeveloperDocumentationNotDefined) with no clue why.
+ * See docs/eval-sweep-findings-2026-07-21.md #13.
+ *
+ * Ground truth for the order below:
+ *   - eval/goldens/L1-table-basic/DemoAgentNote.metadata.xml (VM-captured, built clean):
+ *       Label → TableGroup → TitleField1 → TitleField2 →
+ *       CacheLookup → ClusteredIndex → PrimaryIndex → ReplacementKey → DeleteActions
+ *   - the sweep's own comparison against the shipped CustGroup.xml.
+ *
+ * Two blocks, each internally alphabetical:
+ *   1. the "always serialised" block (ConfigurationKey … TitleField2)
+ *   2. the extended/optional block (CacheLookup … TableType)
+ * Collections (<DeleteActions>, <FieldGroups>, <Fields>, …) follow both.
+ */
+
+/** Block 1 — properties the serialiser always writes, in order. */
+export const AX_TABLE_MANDATORY_PROPERTIES = [
+  'ConfigurationKey',
+  'DeveloperDocumentation',
+  'FormRef',
+  'Label',
+  'TableGroup',
+  'TitleField1',
+  'TitleField2',
+] as const;
+
+/** Block 2 — extended properties, alphabetical, written only when set. */
+export const AX_TABLE_EXTENDED_PROPERTIES = [
+  'CacheLookup',
+  'ClusteredIndex',
+  'CreatedBy',
+  'CreatedDateTime',
+  'CreatedTransactionId',
+  'Modules',
+  'ModifiedBy',
+  'ModifiedDateTime',
+  'ModifiedTransactionId',
+  'PrimaryIndex',
+  'ReplacementKey',
+  'SaveDataPerCompany',
+  'SupportInheritance',
+  'SystemTable',
+  'TableType',
+  'ValidTimeStateFieldType',
+  'Visible',
+] as const;
+
+/** The collection elements that terminate the property block, in serialised order. */
+export const AX_TABLE_COLLECTIONS = [
+  'DeleteActions',
+  'FieldGroups',
+  'Fields',
+  'FullTextIndexes',
+  'Indexes',
+  'Mappings',
+  'Relations',
+  'StateMachines',
+] as const;
+
+/** Full canonical order of everything that follows <SourceCode>. */
+export const AX_TABLE_ELEMENT_ORDER: readonly string[] = [
+  ...AX_TABLE_MANDATORY_PROPERTIES,
+  ...AX_TABLE_EXTENDED_PROPERTIES,
+  ...AX_TABLE_COLLECTIONS,
+];
+
+/**
+ * Table-level property names that DO NOT EXIST in the AxTable metadata model and
+ * are therefore silently ignored (or worse, make the document unreadable).
+ * `AlternateKey` is index-level only — `<AxTableIndex><AlternateKey>Yes</AlternateKey>`
+ * — but reads so naturally at table level that both the writer surface and the
+ * validator missed it (findings #13).
+ */
+export const AX_TABLE_NON_EXISTENT_PROPERTIES: Record<string, string> = {
+  AlternateKey:
+    'AlternateKey is an INDEX property, not a table property. Put <AlternateKey>Yes</AlternateKey> ' +
+    'inside the <AxTableIndex> that should act as the alternate key.',
+  PrimaryKey:
+    'There is no table-level PrimaryKey property. Use <PrimaryIndex> (and <ReplacementKey>) ' +
+    'naming an existing index.',
+  Index:
+    'Indexes are declared as <AxTableIndex> entries inside <Indexes>, not as a table property.',
+};
+
+/** Canonical position of an element; unknown names sort last but keep relative order. */
+export function axTableElementRank(name: string): number {
+  const i = AX_TABLE_ELEMENT_ORDER.indexOf(name);
+  return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+}
+
+/**
+ * Render a property map as canonically ordered `<Tag>value</Tag>` lines.
+ * Entries whose value is undefined/null/'' are omitted — an empty
+ * `<TitleField1 />` is not the same as an absent one to xppbp, and the shipped
+ * tables omit properties they do not set.
+ *
+ * @param props  property name → value
+ * @param indent line prefix (default one tab, matching AxTable XML)
+ */
+export function renderAxTableProperties(
+  props: Record<string, string | number | undefined | null>,
+  indent = '\t',
+): string {
+  const names = Object.keys(props)
+    .filter(n => props[n] !== undefined && props[n] !== null && String(props[n]).length > 0)
+    .sort((a, b) => {
+      const ra = axTableElementRank(a);
+      const rb = axTableElementRank(b);
+      return ra !== rb ? ra - rb : a.localeCompare(b);
+    });
+  return names.map(n => `${indent}<${n}>${props[n]}</${n}>\n`).join('');
+}
+
+/**
+ * Insert (or replace) a single table-level property in an AxTable XML document,
+ * keeping canonical order. Returns null when the document is not an AxTable or
+ * the property is one that does not exist at table level.
+ *
+ * Used by the modify surface so a missing property (e.g. FormRef, which the C#
+ * bridge's setProperty rejects outright — findings #37) can still be written
+ * without corrupting the element order.
+ */
+export function upsertAxTableProperty(
+  xml: string,
+  property: string,
+  value: string,
+): string | null {
+  if (!/<AxTable[\s>]/.test(xml)) return null;
+  if (AX_TABLE_NON_EXISTENT_PROPERTIES[property]) return null;
+  if (axTableElementRank(property) === Number.MAX_SAFE_INTEGER) return null;
+
+  const existing = new RegExp(`([ \\t]*)<${property}\\s*/>|([ \\t]*)<${property}>[\\s\\S]*?</${property}>`);
+  if (existing.test(xml)) {
+    return xml.replace(existing, (m) => {
+      const indent = m.match(/^[ \t]*/)?.[0] ?? '\t';
+      return `${indent}<${property}>${value}</${property}>`;
+    });
+  }
+
+  // Find the first element that must come AFTER this one and insert before it.
+  const rank = axTableElementRank(property);
+  for (const candidate of AX_TABLE_ELEMENT_ORDER) {
+    if (axTableElementRank(candidate) <= rank) continue;
+    const re = new RegExp(`^([ \\t]*)<${candidate}(\\s*/>|>)`, 'm');
+    const m = re.exec(xml);
+    if (!m) continue;
+    const indent = m[1] || '\t';
+    return (
+      xml.slice(0, m.index) +
+      `${indent}<${property}>${value}</${property}>\n` +
+      xml.slice(m.index)
+    );
+  }
+  return null;
+}

--- a/src/utils/fieldControlTypes.ts
+++ b/src/utils/fieldControlTypes.ts
@@ -106,6 +106,41 @@ export function getFieldControlMap(db: any, table: string): FieldControlMap {
   }
 }
 
+/**
+ * Read `<TitleField1>` out of a table's AOT XML. The element is table-level, so
+ * the match is anchored on the FIRST occurrence outside any nested block —
+ * `<TitleField1>` exists nowhere else in an AxTable document, so a plain match
+ * is safe. Returns undefined when the table declares no title field.
+ */
+export function parseTableTitleField(tableXml: string): string | undefined {
+  const v = tableXml.match(/<TitleField1>([^<]*)<\/TitleField1>/)?.[1]?.trim();
+  return v ? v : undefined;
+}
+
+/**
+ * Resolve a table's `TitleField1` through the symbol index (same file_path hop as
+ * {@link getFieldControlMap}). Used by the form scaffold so a DetailsMaster title
+ * control binds to the record's identifying field instead of the alphabetically
+ * first one (docs/eval-sweep-findings-2026-07-21.md #32).
+ */
+export function getTableTitleField(db: any, table: string): string | undefined {
+  try {
+    const canonical = lookupSymbolNocase(db, table)?.name ?? table;
+    const row = db
+      .prepare(
+        `SELECT file_path FROM symbols
+         WHERE type = 'field' AND parent_name = ?
+           AND file_path IS NOT NULL AND file_path != ''
+         LIMIT 1`,
+      )
+      .get(canonical) as { file_path?: string } | undefined;
+    if (!row?.file_path || !fs.existsSync(row.file_path)) return undefined;
+    return parseTableTitleField(fs.readFileSync(row.file_path, 'utf-8'));
+  } catch {
+    return undefined;
+  }
+}
+
 /** Control type for a single field from a (possibly undefined) map, defaulting to String. */
 export function controlForField(field: string, types?: FieldControlMap): ControlTypeInfo {
   return types?.get(field.toLowerCase()) ?? DEFAULT_CONTROL;

--- a/src/utils/formPatternTemplates.ts
+++ b/src/utils/formPatternTemplates.ts
@@ -43,7 +43,23 @@ export interface FormTemplateOptions {
   fieldTypes?: FieldControlMap;
   /** Field → control-type map for the lines table (DetailsTransaction). */
   linesFieldTypes?: FieldControlMap;
+  /**
+   * The datasource table's `TitleField1` — the field a DetailsMaster header
+   * title control must bind to. When omitted the first grid field is used, which
+   * is only ever right by accident: grid fields arrive in ALPHABETICAL order, so
+   * the title ends up bound to whatever field sorts first
+   * (docs/eval-sweep-findings-2026-07-21.md #32).
+   */
+  titleField?: string;
 }
+
+/**
+ * A form control that carries `<DataGroup>` MUST also carry a sibling
+ * `<DataSource>`; the field group is resolved on that datasource's table. Without
+ * it a full build fails with `Field group 'Overview' does not exist` — and an
+ * INCREMENTAL build passes it silently, which is why this survived several
+ * captures (docs/eval-sweep-findings-2026-07-21.md #32, HEADLINE (b)).
+ */
 
 /** Supported top-level D365FO form patterns */
 export type FormPattern =
@@ -385,6 +401,7 @@ ${listFieldControls}\t\t\t\t\t\t</Controls>
 \t\t\t\t\t\t<Name>Overview</Name>
 \t\t\t\t\t\t<Type>Group</Type>
 \t\t\t\t\t\t<DataGroup>Overview</DataGroup>
+\t\t\t\t\t\t<DataSource>${dsName}</DataSource>
 \t\t\t\t\t\t<FormControlExtension
 \t\t\t\t\t\t\ti:nil="true" />
 \t\t\t\t\t\t<Controls>
@@ -462,13 +479,19 @@ ${tabFieldControls}\t\t\t\t\t\t\t\t</Controls>
     // DetailsMaster 1.4 wraps the detail view in a single "Panel Tab" page whose
     // header is a DetailTitleContainer group carrying a TitleField bound to the
     // record's identifying field.
-    const titleField = gridFields[0];
+    // Bind the title to the table's TitleField1 when it is known. `gridFields` is
+    // alphabetically ordered, so gridFields[0] is an arbitrary field — it is only
+    // a last-resort fallback (findings #32).
+    const titleField = opt.titleField && opt.titleField.trim().length > 0
+      ? opt.titleField.trim()
+      : gridFields[0];
+    const titleCtl = controlForField(titleField ?? '', opt.fieldTypes);
     const detailTitleXml = titleField
       ? `\t\t\t\t\t\t\t\t\t<AxFormControl xmlns=""\n` +
-        `\t\t\t\t\t\t\t\t\t\t\ti:type="AxFormStringControl">\n` +
+        `\t\t\t\t\t\t\t\t\t\t\ti:type="${titleCtl.iType}">\n` +
         `\t\t\t\t\t\t\t\t\t\t<Name>TitleField</Name>\n` +
         `\t\t\t\t\t\t\t\t\t\t<Skip>Yes</Skip>\n` +
-        `\t\t\t\t\t\t\t\t\t\t<Type>String</Type>\n` +
+        `\t\t\t\t\t\t\t\t\t\t<Type>${titleCtl.typeValue}</Type>\n` +
         `\t\t\t\t\t\t\t\t\t\t<WidthMode>SizeToAvailable</WidthMode>\n` +
         `\t\t\t\t\t\t\t\t\t\t<FormControlExtension\n\t\t\t\t\t\t\t\t\t\t\ti:nil="true" />\n` +
         `\t\t\t\t\t\t\t\t\t\t<DataField>${titleField}</DataField>\n` +
@@ -638,6 +661,7 @@ ${detailTitleXml}\t\t\t\t\t\t\t\t</Controls>
 \t\t\t\t\t\t\t\t\t\t\t\t<Controls>
 ${overviewFieldControls}\t\t\t\t\t\t\t\t\t\t\t\t</Controls>
 \t\t\t\t\t\t\t\t\t\t\t\t<DataGroup>Overview</DataGroup>
+\t\t\t\t\t\t\t\t\t\t\t\t<DataSource>${dsName}</DataSource>
 \t\t\t\t\t\t\t\t\t\t\t</AxFormControl>
 \t\t\t\t\t\t\t\t\t\t</Controls>
 \t\t\t\t\t\t\t\t\t\t<ColumnsMode>Fill</ColumnsMode>

--- a/src/utils/smartXmlBuilder.ts
+++ b/src/utils/smartXmlBuilder.ts
@@ -8,6 +8,7 @@ import { FormPatternTemplates, FormPattern } from './formPatternTemplates.js';
 import { ensureXppDocComment } from './xppDocGen.js';
 import { decodeXmlEntitiesFromXppSource } from '../tools/modifyD365File.js';
 import { type FieldControlMap, controlForField } from './fieldControlTypes.js';
+import { renderAxTableProperties } from './axTablePropertyOrder.js';
 
 export interface TableFieldSpec {
   name: string;
@@ -125,10 +126,6 @@ export class SmartXmlBuilder {
     }
     xml += `\t</SourceCode>\n`;
 
-    if (label) {
-      xml += `\t<Label>${this.escapeXml(label)}</Label>\n`;
-    }
-
     // 'RegularTable' is the default and is omitted from XML.
     const normalizedTableType = tableType && tableType.toLowerCase() !== 'regulartable' ? tableType : '';
     const isTempTable = normalizedTableType === 'TempDB' || normalizedTableType === 'InMemory';
@@ -153,49 +150,47 @@ export class SmartXmlBuilder {
       || (isTempTable ? 'Main' : this.minedMajority('AxTable', 'TableGroup'))
       || 'Main';
 
-    // BP rule: CacheLookup must be set to avoid the "CacheLookup should be set" BP warning.
-    // TempDB/InMemory tables are session-scoped, not in SQL Server → never cached.
-    if (isTempTable) {
-      xml += `\t<CacheLookup>None</CacheLookup>\n`;
-    } else {
-      const cacheLookupMap: Record<string, string> = {
-        Parameter:       'Found',
-        Group:           'Found',
-        Main:            'Found',
-        Transaction:     'None',
-        WorksheetHeader: 'None',
-        WorksheetLine:   'None',
-        Miscellaneous:   'NotInTTS',
-        Framework:       'Found',
-      };
-      const cacheLookup = cacheLookupMap[effectiveTableGroup] || 'Found';
-      xml += `\t<CacheLookup>${cacheLookup}</CacheLookup>\n`;
-    }
-
-    // BP rule: TempDB/InMemory tables are session-scoped, not company-scoped.
-    xml += `\t<SaveDataPerCompany>${isTempTable ? 'No' : 'Yes'}</SaveDataPerCompany>\n`;
-
-    xml += `\t<TableGroup>${effectiveTableGroup}</TableGroup>\n`;
-
-    if (normalizedTableType) {
-      xml += `\t<TableType>${normalizedTableType}</TableType>\n`;
-    }
+    // BP rule: CacheLookup must be set to avoid the "CacheLookup should be set" BP
+    // warning. TempDB/InMemory tables are session-scoped, not in SQL Server → never cached.
+    const cacheLookupMap: Record<string, string> = {
+      Parameter:       'Found',
+      Group:           'Found',
+      Main:            'Found',
+      Transaction:     'None',
+      WorksheetHeader: 'None',
+      WorksheetLine:   'None',
+      Miscellaneous:   'NotInTTS',
+      Framework:       'Found',
+    };
+    const cacheLookup = isTempTable
+      ? 'None'
+      : (cacheLookupMap[effectiveTableGroup] || 'Found');
 
     const titleCandidates = fields.filter(f => f.name !== 'RecId').slice(0, 2);
-    if (titleCandidates[0]) xml += `\t<TitleField1>${titleCandidates[0].name}</TitleField1>\n`;
-    if (titleCandidates[1]) xml += `\t<TitleField2>${titleCandidates[1].name}</TitleField2>\n`;
-
     const uniqueIdx = indexes?.find(i => i.unique);
-    if (uniqueIdx) {
-      xml += `\t<PrimaryIndex>${uniqueIdx.name}</PrimaryIndex>\n`;
-      xml += `\t<ReplacementKey>${uniqueIdx.name}</ReplacementKey>\n`;
-    }
-
     // BP rule: a table needs a ClusteredIndex to avoid the "no clustered index" warning.
     const clusteredIdx = indexes?.find(i => i.clustered) || uniqueIdx;
-    if (clusteredIdx) {
-      xml += `\t<ClusteredIndex>${clusteredIdx.name}</ClusteredIndex>\n`;
-    }
+
+    // The property block is rendered in CANONICAL ORDER. It used to be written in the
+    // order the BP rules were reasoned about (CacheLookup and SaveDataPerCompany
+    // before TableGroup/TitleField1, ClusteredIndex after ReplacementKey) — and
+    // AxTable XML DROPS a misordered property SILENTLY, so the very BP defaults this
+    // builder exists to set were at risk of being discarded
+    // (docs/eval-sweep-findings-2026-07-21.md #13; canonical order proven by the
+    // VM-captured golden eval/goldens/L1-table-basic).
+    xml += renderAxTableProperties({
+      Label: label ? this.escapeXml(label) : undefined,
+      TableGroup: effectiveTableGroup,
+      TitleField1: titleCandidates[0]?.name,
+      TitleField2: titleCandidates[1]?.name,
+      CacheLookup: cacheLookup,
+      ClusteredIndex: clusteredIdx?.name,
+      PrimaryIndex: uniqueIdx?.name,
+      ReplacementKey: uniqueIdx?.name,
+      // BP rule: TempDB/InMemory tables are session-scoped, not company-scoped.
+      SaveDataPerCompany: isTempTable ? 'No' : 'Yes',
+      TableType: normalizedTableType || undefined,
+    });
 
     // BP rule: relations require matching DeleteActions to avoid a BP warning.
     if (relations && relations.length > 0) {

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -654,7 +654,12 @@ describe('XmlTemplateGenerator security duty/role generators', () => {
       label: '@My:Duty',
       privileges: ['MyView', 'MyMaintain'],
     });
-    expect(xml).toContain('<AxSecurityRolePermissionSet>\n\t\t\t<Name>MyView</Name>');
+    // AxSecurityPrivilegeReference, NOT AxSecurityRolePermissionSet: the latter
+    // deserializes into an empty privilege list, so xppbp reports
+    // BPErrorDutyHasNoPrivileges / BPErrorPrivilegeNotCoveredByDuty for privileges
+    // that are physically in the file (docs/eval-sweep-findings-2026-07-21.md #31).
+    expect(xml).toContain('<AxSecurityPrivilegeReference>\n\t\t\t<Name>MyView</Name>');
+    expect(xml).not.toContain('AxSecurityRolePermissionSet');
     expect(xml).toContain('<Name>MyMaintain</Name>');
     expect(xml).not.toContain('<Privileges />');
   });
@@ -676,7 +681,9 @@ describe('XmlTemplateGenerator security duty/role generators', () => {
     const xml = XmlTemplateGenerator.generateAxSecurityRoleXml('MyRole', {
       duties: ['MyDuty1', 'MyDuty2'],
     });
-    expect(xml).toContain('<AxSecurityRoleDutyPermission>\n\t\t\t<Name>MyDuty1</Name>');
+    // AxSecurityDutyReference — see the duty test above (findings #31).
+    expect(xml).toContain('<AxSecurityDutyReference>\n\t\t\t<Name>MyDuty1</Name>');
+    expect(xml).not.toContain('AxSecurityRoleDutyPermission');
     expect(xml).toContain('<Name>MyDuty2</Name>');
     expect(xml).not.toContain('<Duties />');
   });

--- a/tests/tools/createWriterDefects.test.ts
+++ b/tests/tools/createWriterDefects.test.ts
@@ -215,6 +215,35 @@ describe('#13 AxTable canonical element order', () => {
     expect(runRules(withSource, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
   });
 
+  // The element scan used to strip CDATA/comments with chained `.replace()`. A non-greedy
+  // `<!--[\s\S]*?-->` never matches an UNTERMINATED region, so its contents survived and were
+  // scanned as real elements — a malformed document could then invent violations that are not
+  // there. Skipping regions in a forward scan runs an unterminated one to EOF instead.
+  it('does not scan the contents of an unterminated comment as elements', () => {
+    const xml = `<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoTicket</Name>
+\t<Label>@SYS2</Label>
+\t<TitleField1>Subject</TitleField1>
+\t<!-- <CacheLookup>Found</CacheLookup><DeveloperDocumentation>@SYS1</DeveloperDocumentation>
+\t<Fields />
+</AxTable>`;
+    expect(runRules(xml, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
+  });
+
+  // Same guarantee for CDATA. The block sits directly under the root so its contents WOULD
+  // land at the depth the order check reads — otherwise the test passes either way and proves
+  // nothing.
+  it('does not scan the contents of an unterminated CDATA block as elements', () => {
+    const xml = `<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoTicket</Name>
+\t<Label>@SYS2</Label>
+\t<TitleField1>Subject</TitleField1>
+\t<![CDATA[ if (a < b) { }
+\t<CacheLookup>Found</CacheLookup><DeveloperDocumentation>@SYS1</DeveloperDocumentation>
+</AxTable>`;
+    expect(runRules(xml, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
+  });
+
   it('flags a table-level <AlternateKey>, which does not exist in the AxTable model', () => {
     const bogus = `<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>ConDemoTicket</Name>

--- a/tests/tools/createWriterDefects.test.ts
+++ b/tests/tools/createWriterDefects.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Regression gate for the create/generate WRITER defects found during the
+ * 2026-07-21 golden-capture sweep (docs/eval-sweep-findings-2026-07-21.md).
+ *
+ * Every test here reproduces a defect that shipped a ✅ to the caller while
+ * writing metadata that does not build, does not resolve, or silently loses
+ * what was passed in. All of them are VM-free: the emitters are pure functions.
+ *
+ * Findings covered: #13, #19, #20, #22, #30, #31, #32, #38.
+ * Corpus evidence: eval/corpus/runs/2026-07-21T20__L4-master-security-slice__c262b19.json,
+ *                  eval/corpus/runs/2026-07-21T20__L3-workflow-document-submit__c262b19.json,
+ *                  eval/corpus/runs/2026-07-21T19__L2-error-handling-infolog__c262b19.json
+ */
+
+import { describe, it, expect } from 'vitest';
+import { XmlTemplateGenerator } from '../../src/tools/createD365File';
+import { buildAxQueryXml, buildAxViewXml, extractQueryRootDataSourceName } from '../../src/tools/queryViewXml';
+import { FormPatternTemplates } from '../../src/utils/formPatternTemplates';
+import {
+  AX_TABLE_ELEMENT_ORDER,
+  axTableElementRank,
+  upsertAxTableProperty,
+} from '../../src/utils/axTablePropertyOrder';
+import { parseTableTitleField } from '../../src/utils/fieldControlTypes';
+import { runRules } from '../../src/tools/validateXpp';
+import { SmartXmlBuilder } from '../../src/utils/smartXmlBuilder';
+
+// ── #31: security duty/role references must actually resolve ────────────────
+describe('#31 security duty/role reference element names', () => {
+  it('duty lists privileges as AxSecurityPrivilegeReference', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityDutyXml('ConDemoDuty', {
+      privileges: ['ConDemoPrivilege'],
+    });
+    expect(xml).toContain('<AxSecurityPrivilegeReference>');
+    expect(xml).toContain('<Name>ConDemoPrivilege</Name>');
+    // The old shape deserialized to an empty list → BPErrorDutyHasNoPrivileges.
+    expect(xml).not.toContain('AxSecurityRolePermissionSet');
+  });
+
+  it('role lists duties as AxSecurityDutyReference and privileges as AxSecurityPrivilegeReference', () => {
+    const xml = XmlTemplateGenerator.generateAxSecurityRoleXml('ConDemoRole', {
+      duties: ['ConDemoDuty'],
+      privileges: ['ConDemoPrivilege'],
+    });
+    expect(xml).toContain('<AxSecurityDutyReference>');
+    expect(xml).toContain('<AxSecurityPrivilegeReference>');
+    expect(xml).not.toContain('AxSecurityRoleDutyPermission');
+    expect(xml).not.toContain('AxSecurityRolePermissionSet');
+  });
+
+  it('matches the shape the *Extension writers already used', () => {
+    const roleExt = XmlTemplateGenerator.generateAxSecurityRoleExtensionXml('Base.ConExtension', {
+      duties: ['ConDemoDuty'],
+    });
+    const role = XmlTemplateGenerator.generateAxSecurityRoleXml('ConDemoRole', {
+      duties: ['ConDemoDuty'],
+    });
+    expect(roleExt).toContain('<AxSecurityDutyReference>');
+    expect(role).toContain('<AxSecurityDutyReference>');
+  });
+});
+
+// ── #32: a DataGroup control needs a sibling DataSource ─────────────────────
+describe('#32 form scaffold produces a buildable design', () => {
+  const opts = {
+    formName: 'ConDemoNoteHeaderMaster',
+    dsName: 'ConDemoNoteHeader',
+    dsTable: 'ConDemoNoteHeader',
+    gridFields: ['Alpha', 'NoteId', 'Subject'],
+  };
+
+  for (const pattern of ['SimpleListDetails', 'DetailsMaster'] as const) {
+    it(`${pattern}: every <DataGroup> has a sibling <DataSource>`, () => {
+      const xml = FormPatternTemplates.build(pattern, opts);
+      const groups = [...xml.matchAll(/<DataGroup>([^<]+)<\/DataGroup>\s*\n\s*(<[^>\s]+)/g)];
+      expect(groups.length).toBeGreaterThan(0);
+      for (const g of groups) {
+        // A field group is resolved on the control's datasource table; without a
+        // DataSource sibling a FULL build fails "Field group 'Overview' does not
+        // exist" (an incremental build passes it, which is how this got captured).
+        expect(g[2]).toBe('<DataSource');
+      }
+      expect(xml).toContain('<DataGroup>Overview</DataGroup>\n');
+    });
+  }
+
+  it('DetailsMaster binds TitleField to the table TitleField1, not the alphabetically first field', () => {
+    const xml = FormPatternTemplates.build('DetailsMaster', { ...opts, titleField: 'Subject' });
+    const title = xml.match(/<Name>TitleField<\/Name>[\s\S]*?<\/AxFormControl>/)?.[0] ?? '';
+    expect(title).toContain('<DataField>Subject</DataField>');
+    expect(title).not.toContain('<DataField>Alpha</DataField>');
+  });
+
+  it('falls back to the first grid field only when no TitleField1 is known', () => {
+    const xml = FormPatternTemplates.build('DetailsMaster', opts);
+    const title = xml.match(/<Name>TitleField<\/Name>[\s\S]*?<\/AxFormControl>/)?.[0] ?? '';
+    expect(title).toContain('<DataField>Alpha</DataField>');
+  });
+
+  it('parseTableTitleField reads TitleField1 out of a table document', () => {
+    expect(parseTableTitleField('<AxTable><TitleField1>Subject</TitleField1></AxTable>')).toBe('Subject');
+    expect(parseTableTitleField('<AxTable><TitleField1></TitleField1></AxTable>')).toBeUndefined();
+    expect(parseTableTitleField('<AxTable />')).toBeUndefined();
+  });
+});
+
+// ── #19: table create must not swallow sourceCode ───────────────────────────
+describe('#19 create objectType="table" keeps methods passed in sourceCode', () => {
+  const source = `public class ConDemoWfRequest extends common
+{
+}
+
+public boolean canSubmitToWorkflow(str _workflowType)
+{
+    return true;
+}
+`;
+
+  it('emits the method instead of an empty <Methods />', () => {
+    const xml = XmlTemplateGenerator.generate('table', 'ConDemoWfRequest', source, {});
+    expect(xml).toContain('<Name>canSubmitToWorkflow</Name>');
+    expect(xml).toContain('public boolean canSubmitToWorkflow');
+    expect(xml).not.toContain('<Methods />');
+  });
+
+  it('still emits an empty <Methods /> when no source was given', () => {
+    const xml = XmlTemplateGenerator.generate('table', 'ConDemoWfRequest', undefined, {});
+    expect(xml).toContain('<Methods />');
+  });
+
+  it('still treats a JSON sourceCode payload as field definitions, not X++', () => {
+    const xml = XmlTemplateGenerator.generate(
+      'table',
+      'ConDemoWfRequest',
+      JSON.stringify({ fields: [{ name: 'NoteId', edt: 'Num' }] }),
+      undefined,
+    );
+    expect(xml).toContain('<Name>NoteId</Name>');
+    expect(xml).toContain('<Methods />');
+  });
+});
+
+// ── #13: AxTable element order ──────────────────────────────────────────────
+describe('#13 AxTable canonical element order', () => {
+  it('the writer emits the order captured in eval/goldens/L1-table-basic', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('ConDemoAgentNote', {
+      label: '@SYS13887',
+      tableGroup: 'Main',
+      titleField1: 'Subject',
+      titleField2: 'NoteId',
+      cacheLookup: 'Found',
+      clusteredIndex: 'NoteIdx',
+      primaryIndex: 'NoteIdx',
+      developerDocumentation: '@SYS1234',
+      formRef: 'ConDemoAgentNoteForm',
+      configurationKey: 'LedgerBasic',
+    });
+    const order = ['ConfigurationKey', 'DeveloperDocumentation', 'FormRef', 'Label', 'TableGroup',
+      'TitleField1', 'TitleField2', 'CacheLookup', 'ClusteredIndex', 'PrimaryIndex',
+      'ReplacementKey'];
+    const positions = order.map(t => xml.indexOf(`<${t}>`));
+    expect(positions.every(p => p > 0)).toBe(true);
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThan(positions[i - 1]);
+    }
+  });
+
+  it('omits properties the caller did not set instead of writing empty elements', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('ConDemoAgentNote', {});
+    expect(xml).not.toContain('<TitleField1></TitleField1>');
+    expect(xml).not.toContain('<TitleField1>');
+    expect(xml).toContain('<Label>ConDemoAgentNote</Label>');
+  });
+
+  it('validate_code(xml-table) FLAGS a misordered document (it used to report "no violations")', () => {
+    const misordered = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoTicket</Name>
+\t<CacheLookup>Found</CacheLookup>
+\t<DeveloperDocumentation>@SYS1</DeveloperDocumentation>
+\t<Label>@SYS2</Label>
+\t<TableGroup>Main</TableGroup>
+\t<TitleField1>Subject</TitleField1>
+\t<PrimaryIndex>NoteIdx</PrimaryIndex>
+\t<ReplacementKey>NoteIdx</ReplacementKey>
+\t<Fields />
+\t<Indexes>
+\t\t<AxTableIndex>
+\t\t\t<Name>NoteIdx</Name>
+\t\t\t<AlternateKey>Yes</AlternateKey>
+\t\t</AxTableIndex>
+\t</Indexes>
+</AxTable>`;
+    const violations = runRules(misordered, 'xml-table');
+    const order = violations.filter(v => v.rule === 'XML006');
+    expect(order).toHaveLength(1);
+    expect(order[0].severity).toBe('error');
+    expect(order[0].excerpt).toContain('<DeveloperDocumentation>');
+  });
+
+  it('does not flag a canonically ordered document', () => {
+    const ok = XmlTemplateGenerator.generateAxTableXml('ConDemoTicket', {
+      label: '@SYS2', titleField1: 'Subject', cacheLookup: 'Found', primaryIndex: 'NoteIdx',
+    });
+    expect(runRules(ok, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
+  });
+
+  it('X++ inside CDATA does not confuse the element scan', () => {
+    const withSource = XmlTemplateGenerator.generate(
+      'table',
+      'ConDemoTicket',
+      'public boolean isOpen()\n{\n    return 1 < 2 && 3 > 2;\n}\n',
+      { label: '@SYS2', titleField1: 'Subject' },
+    );
+    expect(runRules(withSource, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
+  });
+
+  it('flags a table-level <AlternateKey>, which does not exist in the AxTable model', () => {
+    const bogus = `<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoTicket</Name>
+\t<Label>@SYS2</Label>
+\t<AlternateKey>Yes</AlternateKey>
+\t<Fields />
+</AxTable>`;
+    const violations = runRules(bogus, 'xml-table').filter(v => v.rule === 'XML007');
+    expect(violations).toHaveLength(1);
+    expect(violations[0].fix).toContain('INDEX property');
+  });
+
+  it('does NOT flag an index-level <AlternateKey>', () => {
+    const good = `<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoTicket</Name>
+\t<Label>@SYS2</Label>
+\t<Indexes>
+\t\t<AxTableIndex>
+\t\t\t<Name>NoteIdx</Name>
+\t\t\t<AlternateKey>Yes</AlternateKey>
+\t\t</AxTableIndex>
+\t</Indexes>
+</AxTable>`;
+    expect(runRules(good, 'xml-table').filter(v => v.rule === 'XML007')).toHaveLength(0);
+  });
+});
+
+describe('#13 the smart table builder emits the same canonical order', () => {
+  it('CacheLookup/SaveDataPerCompany no longer precede TableGroup/TitleField1', () => {
+    const xml = new SmartXmlBuilder().buildTableXml({
+      name: 'ConDemoTicket',
+      label: '@SYS2',
+      tableGroup: 'Main',
+      fields: [{ name: 'TicketId', edt: 'Num' }, { name: 'Subject', edt: 'Name' }],
+      indexes: [{ name: 'TicketIdx', fields: ['TicketId'], unique: true, clustered: true }],
+    });
+    const seq = ['Label', 'TableGroup', 'TitleField1', 'TitleField2', 'CacheLookup',
+      'ClusteredIndex', 'PrimaryIndex', 'ReplacementKey', 'SaveDataPerCompany'];
+    const positions = seq.map(t => xml.indexOf(`<${t}>`));
+    expect(positions.every(p => p > 0)).toBe(true);
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThan(positions[i - 1]);
+    }
+    expect(runRules(xml, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
+  });
+});
+
+// ── #37: a missing table property can be inserted in canonical order ────────
+describe('#37 upsertAxTableProperty inserts in canonical order', () => {
+  const table = XmlTemplateGenerator.generateAxTableXml('ConDemoTicket', {
+    label: '@SYS2', tableGroup: 'Main', titleField1: 'Subject',
+  });
+
+  it('adds FormRef before Label (the bridge rejects FormRef outright)', () => {
+    const out = upsertAxTableProperty(table, 'FormRef', 'ConDemoTicketForm');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<FormRef>ConDemoTicketForm</FormRef>');
+    expect(out!.indexOf('<FormRef>')).toBeLessThan(out!.indexOf('<Label>'));
+    expect(runRules(out!, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
+  });
+
+  it('replaces an existing property in place', () => {
+    const out = upsertAxTableProperty(table, 'TableGroup', 'Transaction');
+    expect(out!).toContain('<TableGroup>Transaction</TableGroup>');
+    expect(out!).not.toContain('<TableGroup>Main</TableGroup>');
+  });
+
+  it('refuses properties that do not exist at table level', () => {
+    expect(upsertAxTableProperty(table, 'AlternateKey', 'Yes')).toBeNull();
+  });
+
+  it('refuses documents that are not AxTable', () => {
+    expect(upsertAxTableProperty('<AxClass><Name>Foo</Name></AxClass>', 'Label', 'x')).toBeNull();
+  });
+
+  it('ranks unknown elements last so they never reorder known ones', () => {
+    expect(axTableElementRank('Label')).toBeLessThan(axTableElementRank('Fields'));
+    expect(axTableElementRank('SomethingElse')).toBe(Number.MAX_SAFE_INTEGER);
+    expect(AX_TABLE_ELEMENT_ORDER[0]).toBe('ConfigurationKey');
+  });
+});
+
+// ── #20 / #38: query and view ───────────────────────────────────────────────
+describe('#20 query with no explicit field list is marked dynamic', () => {
+  it('emits <DynamicFields>Yes</DynamicFields> and an empty <Fields />', () => {
+    const xml = buildAxQueryXml('ConDemoQuery', { dataSource: 'ConDemoNoteHeader' });
+    // xppc: "The field list of the data source 'X' cannot be empty if the dynamic
+    // field is set to false" — every "all fields" query used to fail the build.
+    expect(xml).toContain('<DynamicFields>Yes</DynamicFields>');
+    expect(xml).toContain('<Fields />');
+    expect(xml.indexOf('<DerivedDataSources />')).toBeLessThan(xml.indexOf('<DynamicFields>'));
+    expect(xml.indexOf('<DynamicFields>')).toBeLessThan(xml.indexOf('<Fields />'));
+  });
+
+  it('an explicit field list stays static', () => {
+    const xml = buildAxQueryXml('ConDemoQuery', {
+      dataSource: 'ConDemoNoteHeader',
+      fields: [{ name: 'NoteId' }],
+    });
+    expect(xml).not.toContain('<DynamicFields>');
+    expect(xml).toContain('<Field>NoteId</Field>');
+  });
+
+  it('dynamicFields can be forced by the caller', () => {
+    const xml = buildAxQueryXml('ConDemoQuery', {
+      dataSource: 'ConDemoNoteHeader',
+      fields: [{ name: 'NoteId' }],
+      dynamicFields: 'Yes',
+    });
+    expect(xml).toContain('<DynamicFields>Yes</DynamicFields>');
+    expect(xml).toContain('<Field>NoteId</Field>');
+  });
+});
+
+describe('#38 view field DataSource is the query root datasource, not the query name', () => {
+  const queryXml = buildAxQueryXml('ConDemoNoteHeaderQuery', {
+    dataSource: 'ConDemoNoteHeader',
+    fields: [{ name: 'NoteId' }, { name: 'Subject' }],
+  });
+
+  it('extracts the root datasource name from a query document', () => {
+    expect(extractQueryRootDataSourceName(queryXml)).toBe('ConDemoNoteHeader');
+  });
+
+  it('binds view fields to it (ground truth: eval/goldens/L1-query-view-basic)', () => {
+    const xml = buildAxViewXml('ConDemoNoteHeaderView', {
+      query: 'ConDemoNoteHeaderQuery',
+      queryXml,
+      fields: [{ name: 'NoteId' }, { name: 'Subject' }],
+    });
+    expect(xml).toContain('<DataSource>ConDemoNoteHeader</DataSource>');
+    expect(xml).not.toContain('<DataSource>ConDemoNoteHeaderQuery</DataSource>');
+  });
+
+  it('an explicit dataSource still wins', () => {
+    const xml = buildAxViewXml('ConDemoNoteHeaderView', {
+      query: 'ConDemoNoteHeaderQuery',
+      queryXml,
+      dataSource: 'ExplicitDs',
+      fields: [{ name: 'NoteId' }],
+    });
+    expect(xml).toContain('<DataSource>ExplicitDs</DataSource>');
+  });
+
+  it('falls back to the query name when the query cannot be resolved (documented last resort)', () => {
+    const xml = buildAxViewXml('ConDemoNoteHeaderView', {
+      query: 'ConDemoNoteHeaderQuery',
+      fields: [{ name: 'NoteId' }],
+    });
+    expect(xml).toContain('<DataSource>ConDemoNoteHeaderQuery</DataSource>');
+  });
+});
+
+// ── #22: declaration doc comments must survive the name realignment ─────────
+describe('#22 class create does not corrupt declaration doc comments', () => {
+  const declaration = `/// <summary>
+/// The <c>ConDemoWfRequestDocument</c> class is the workflow document for requests.
+/// </summary>
+public class ConDemoWfRequestDocument extends WorkflowDocument
+{
+}`;
+
+  it('leaves the doc comment alone when the header already matches', () => {
+    const out = XmlTemplateGenerator.normalizeSelfReferenceName(
+      'ConDemoWfRequestDocument',
+      declaration,
+      [],
+    );
+    expect(out.declaration).toContain('class is the workflow document');
+    expect(out.declaration).not.toContain('class ConDemoWfRequestDocument the workflow document');
+  });
+
+  it('still renames a genuinely stale class header', () => {
+    const stale = `/// <summary>
+/// The <c>WfRequestDocument</c> class is the workflow document for requests.
+/// </summary>
+public class WfRequestDocument extends WorkflowDocument
+{
+}`;
+    const out = XmlTemplateGenerator.normalizeSelfReferenceName(
+      'ConDemoWfRequestDocument',
+      stale,
+      [{ name: 'run', source: 'public void run() { WfRequestDocument doc; }' }],
+    );
+    expect(out.declaration).toContain('public class ConDemoWfRequestDocument');
+    expect(out.methods[0].source).toContain('ConDemoWfRequestDocument doc;');
+    // and the comment prose is untouched
+    expect(out.declaration).toContain('class is the workflow document');
+  });
+
+  it('end-to-end: the generated AxClass keeps the sentence intact', () => {
+    const xml = XmlTemplateGenerator.generateAxClassXml('ConDemoWfRequestDocument', declaration);
+    expect(xml).toContain('class is the workflow document');
+  });
+});

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -1769,7 +1769,12 @@ describe('modify_d365fo_file', () => {
     );
     expect(written).toBeDefined();
     const writtenContent: string = written[1];
-    expect(writtenContent).toContain('AxMenuFunctionItem');
+    // An AxMenu's <Elements> holds AxMenuElement entries discriminated by i:type.
+    // `AxMenuFunctionItem` (what this used to write) is not a type in the metadata
+    // model — zero of the 73 shipped AxMenu files use it, so the element
+    // deserialized into nothing: docs/eval-sweep-findings-2026-07-21.md #30.
+    expect(writtenContent).toContain('<AxMenuElement xmlns="" i:type="AxMenuElementMenuItem">');
+    expect(writtenContent).not.toContain('AxMenuFunctionItem');
     expect(writtenContent).toContain('<MenuItemName>ContosoRentEquipmentTable</MenuItemName>');
     expect(writtenContent).toContain('<MenuItemType>Display</MenuItemType>');
   });


### PR DESCRIPTION
Fixes the **create / generate writer** batch from `docs/eval-sweep-findings-2026-07-21.md`.
Everything here is TS-side and proven VM-free; **no unverified C# behavioural change ships in this PR**.

## Priority 1 — unblocks the golden re-capture

### #31 — `create` for security duty/role emitted non-resolving references (HEADLINE (a))
`generateAxSecurityDutyXml` / `generateAxSecurityRoleXml` wrapped their children in
`AxSecurityRolePermissionSet` / `AxSecurityRoleDutyPermission`. Those names do not exist in the
metadata model, so the reference list deserializes EMPTY and xppbp reports
`BPErrorDutyHasNoPrivileges`, `BPErrorPrivilegeNotCoveredByDuty`, `BPErrorDutyNotCoveredByRole`
for references that are physically in the file. Corrected to `AxSecurityPrivilegeReference` /
`AxSecurityDutyReference` — the names `generateAxSecurityDutyExtensionXml`,
`generateAxSecurityRoleExtensionXml` and `generateD365Xml.ts` were already using, which is the
in-repo cross-check.

### #32 — form scaffold produced a non-building design (HEADLINE (b))
Two faults in `src/utils/formPatternTemplates.ts`:
1. the SimpleListDetails and DetailsMaster group controls carried `<DataGroup>Overview</DataGroup>`
   with **no sibling `<DataSource>`** (the SimpleList grid control always had one). A full build
   fails "Field group 'Overview' does not exist"; an incremental build passes it silently, which
   is how it survived several captures.
2. the DetailsMaster `TitleField` control bound to `gridFields[0]` — and grid fields arrive in
   ALPHABETICAL order, so the title was bound to whatever field sorts first. `FormTemplateOptions`
   gained `titleField`, `generateSmartForm` resolves the datasource table's `TitleField1` through
   the new `getTableTitleField()` (same `file_path` hop `getFieldControlMap` already uses), and the
   control type now follows the field type instead of being hard-coded to `AxFormStringControl`.

Both goldens still need the VM re-capture — **not touched here**, and `tests/eval/goldens.test.ts`
is green (it self-diffs, so a template change cannot destabilise it).

## Priority 2 — silent data loss / unbuildable output

### #19 — `create objectType="table"` swallowed `sourceCode`
Neither path looked at it: the bridge branch forwarded only `properties.methods`, and
`generateAxTableXml` never received the argument at all. Both now parse it with the same
`parseSourceForBridge` splitter the class path uses (a JSON `sourceCode` payload is still treated
as field definitions).

### #20 — `create objectType="query"` produced an unbuildable query
A data source with no explicit field list was written without `<DynamicFields>Yes</DynamicFields>`;
xppc rejects it ("The field list of the data source 'X' cannot be empty if the dynamic field is set
to false"), so every "all fields" query failed the build. Fieldless data sources are now dynamic;
`properties.dynamicFields` can force it either way. Position between `<DerivedDataSources>` and
`<Fields>` is deliberate and documented in the code.

### #38 — `create objectType="view"` mis-defaulted the field `DataSource`
It defaulted to the QUERY NAME. `buildAxQueryXml` names a simple query's root data source after its
TABLE, so the view's fields pointed at a data source that does not exist. Added
`extractQueryRootDataSourceName()`; the create path reads the referenced query off disk
(`<model>/AxQuery/<name>.xml`) and hands its XML to the builder. Ground truth:
`eval/goldens/L1-query-view-basic`, where the view's `DataSource` is `ConDemoNoteHeader`, not
`ConDemoNoteHeaderQuery`. Neither `query` nor `view` is a bridge create type, so this template is
the only writer for them.

### #13 — AxTable element order (writer + validator)
New `src/utils/axTablePropertyOrder.ts` encodes the canonical order, with the VM-captured golden
`eval/goldens/L1-table-basic/DemoAgentNote.metadata.xml` as in-repo ground truth
(`Label → TableGroup → TitleField1 → TitleField2 → CacheLookup → ClusteredIndex → PrimaryIndex →
ReplacementKey → DeleteActions`).
* `generateAxTableXml` renders its property block through it and omits unset properties instead of
  writing `<TitleField1></TitleField1>`.
* `SmartXmlBuilder.buildTableXml` was itself misordered — it emitted `CacheLookup` and
  `SaveDataPerCompany` **before** `TableGroup`/`TitleField1`, and `ClusteredIndex` **after**
  `ReplacementKey`, i.e. the BP defaults it exists to set were at risk of being dropped. Now
  rendered through the same helper.
* `validate_code(mode="syntax", codeType="xml-table")` gained **XML006** (order violation, with the
  canonical order in the fix text) and **XML007** (table-level properties that do not exist in the
  model — `AlternateKey` is index-level only). The element scan strips CDATA first so X++ containing
  `<` does not confuse it.

## Priority 3

* **#22** — `normalizeSelfReferenceName` matched `class\s+(\w+)` against the raw declaration, so
  `/// The <c>X</c> class is the workflow document` yielded `declaredName = "is"` and every
  standalone `is` in the declaration and in every method body was rewritten to the class name. It
  now matches on code lines only; a genuinely stale class header is still renamed.
* **#30** — `add-menu-item-to-menu` wrote `<AxMenuFunctionItem>`, which is not a type in the
  metadata model (zero of the 73 shipped `AxMenu` files use it). Now
  `<AxMenuElement xmlns="" i:type="AxMenuElementMenuItem">`, matching the shape the knowledge base
  already documents.
* **#37 (table half)** — `directXmlModifyProperty` refused to act when the element did not exist,
  which is exactly the `FormRef` case (`BPErrorTableMissingFormRef` was unfixable through the tool
  path). It can now INSERT a missing table property via `upsertAxTableProperty`, in canonical order,
  and rejects non-existent properties with an explanation instead of writing them. The forms half of
  #37 is untouched.

## Not reached
`#21` (scaffold ignores `fields[]`, mines EDTs from names, and writes to disk), `#36` (no operation
for table DeleteActions), `#37` forms half, and `#26` — see the review notes below for #26, whose
attribution appears to be wrong.

## Validation
* `npx vitest run` → **150 files, 2002 passed, 2 skipped, 0 failed** on this branch.
* New regression gate: `tests/tools/createWriterDefects.test.ts` (34 tests), one describe block per
  finding; each fails on `main`.
* Two pre-existing tests asserted the defective shapes (`AxMenuFunctionItem` in
  `tests/tools/file-ops.test.ts`, `AxSecurityRolePermissionSet`/`AxSecurityRoleDutyPermission` in
  `tests/tools/code-generation.test.ts`) — updated with the evidence in a comment. **No golden was
  edited.**
* `npm run eval:report` is unchanged (`build=80% golden=36%`, 44 runs) — corpus records are
  VM-produced and cannot move without a re-capture; the anti-overfitting check here is the full
  suite, including every other case's golden self-diff.

## Evidence
`docs/eval-sweep-findings-2026-07-21.md` #13, #19, #20, #22, #30, #31, #32, #37, #38 and the corpus
records `eval/corpus/runs/2026-07-21T20__L4-master-security-slice__c262b19.json`,
`2026-07-21T20__L3-workflow-document-submit__c262b19.json`,
`2026-07-21T19__L2-error-handling-infolog__c262b19.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsY56fJuvoiEXjCVRR2b6M
