### PR TITLE
fix(eval): close the four repo-side sweep findings (#7, #21, #36, #37)

### DIFF
--- a/docs/eval-sweep-findings-2026-07-21.md
+++ b/docs/eval-sweep-findings-2026-07-21.md
@@ -33,20 +33,19 @@ C# edit is worse than an open ticket.
 - Only `fullBuild` runs metadata validation. An incremental build reported 0 errors on a model with
   2 real metadata errors, so `pass@build` from incremental runs is weaker than it looks.
 
-## Open — validator
-
-- **#7** — `validate_code(syntax)` raises `BPCheckAlternateKeyAbsent` as a hard ERROR (`XML001`)
-  while xppbp treats it as a warning and the build is clean. A case that legitimately mandates one
-  index cannot satisfy it at all: an error-severity rule a valid, building table cannot pass.
-
 ## Open — writers
 
-- **#21** — `generate_object(scaffold, table)` demands `fieldsHint` despite `fields[]`, mines EDTs
-  from field names, drops enum fields, and WRITES TO DISK despite being generation-only
-  (`undo_last_modification` cannot clean that up — `PackagesLocalDirectory` is not a git repo).
-- **#36** — no operation exists for table DeleteActions, so a cascading delete action is
-  inexpressible.
-- **#37 (forms half)** — `modify-property` is unimplemented for forms. The table half is done.
+Three defects the same corpus record (2026-07-22T04__L2-form-over-view) raised alongside #37,
+never separately filed:
+
+- `generate_object(scaffold, form)` resolves `dataSource` against TABLES only, so a form over a
+  VIEW fails with "not found in the symbol index" even after `update_symbol_index`.
+  `object_patterns` resolves the same view fine — the defect is the scaffold's own lookup.
+- `d365fo_file(create, objectType="view")` defaults each `AxViewFieldBound` `<DataSource>` to the
+  QUERY name instead of the query's root data source name. Passing `fields[].dataSource`
+  explicitly works — only the default is wrong.
+- `trigger_db_sync(tables=[…], syncViews=true)` puts BOTH tables and views in `-viewlist`;
+  SyncEngine aborts with "Invalid argument -viewlist=…". They must be split by object type.
 
 ## Corrected attribution
 

--- a/eval/ROADMAP.md
+++ b/eval/ROADMAP.md
@@ -14,7 +14,7 @@ overwrite-produced output into its golden — fix first, capture second.
 
 ## Capture the remaining pending goldens (VM)
 
-**6 of 50 cases are still `golden_pending`:**
+**7 of 50 cases are still `golden_pending`:**
 
 - `L2-class-method-ops`, `L2-enum-modify-values`, `L3-numberseq-module-slice`
 - `L3-batch-retryable-basic` — still needs its three SysOperation classes authored.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -1126,6 +1126,9 @@ const BRIDGE_MODIFY_OPS = new Set([
   'add-field', 'modify-field', 'rename-field', 'replace-all-fields', 'remove-field',
   'add-index', 'remove-index',
   'add-relation', 'remove-relation',
+  // No C# op backs these — they are served by a direct-XML writer, but they still
+  // pass through the same modify gate.
+  'add-delete-action', 'remove-delete-action',
   'add-field-group', 'remove-field-group', 'add-field-to-field-group',
   'modify-property',
   'add-enum-value', 'modify-enum-value', 'remove-enum-value',

--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -120,6 +120,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             'add-display-method', 'add-table-method',
             'add-index', 'remove-index',
             'add-relation', 'remove-relation',
+            'add-delete-action', 'remove-delete-action',
             'add-field-group', 'remove-field-group', 'add-field-to-field-group',
             'add-field-modification',
             'add-data-source', 'add-control',
@@ -136,6 +137,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             'add-display-method: display method with [SysClientCacheDataMethodAttribute].\n' +
             'add-table-method: canonical find/exist/findByRecId/validateWrite/validateDelete/initValue boilerplate.\n' +
             'add-field-modification: override base-table field label/mandatory in a table-extension.\n' +
+            'add-delete-action: table DeleteActions entry — deleteActionName + optional deleteActionTable/deleteActionType (None|Restricted|Cascade|CascadeRestricted).\n' +
             'modify-property: any object-level property (TableGroup, TitleField1, TableType, Extends…) — see propertyPath.'
         },
         params: {

--- a/src/server/toolSchemas/generateObject.ts
+++ b/src/server/toolSchemas/generateObject.ts
@@ -76,6 +76,7 @@ export const generateObjectTool = {
           description: '[scaffold:table] Storage type: Regular (default, omit), TempDB, InMemory. ⛔ NEVER pass as tableGroup.',
         },
         generateCommonFields: { type: 'boolean', description: '[scaffold:table] Auto-generate common fields based on table group patterns.' },
+        preview: { type: 'boolean', description: '[scaffold:table] Return the XML without writing to disk.' },
         dataSource: { type: 'string', description: '[scaffold:form] Optional: Table name for primary datasource.' },
         formPattern: {
           type: 'string',
@@ -94,7 +95,7 @@ export const generateObjectTool = {
         generateControls: { type: 'boolean', description: '[scaffold:form] Auto-generate grid controls for datasource.' },
         fields: {
           type: 'array',
-          description: '[scaffold:report | fields] Structured field specs. Takes priority over fieldsHint. For mode="fields": name + optional edt/enumType/type/label/mandatory (EDT auto-resolved when omitted).',
+          description: '[scaffold:table|report | fields] Structured field specs; takes priority over fieldsHint. PREFER for enum-backed fields or an explicit EDT — a bare name cannot express either. name + optional edt/enumType/type/label/mandatory (EDT auto-resolved when omitted).',
           items: {
             type: 'object',
             properties: {

--- a/src/tools/d365foFileOpSpecs.ts
+++ b/src/tools/d365foFileOpSpecs.ts
@@ -47,6 +47,19 @@ export const D365FO_FILE_PARAM_SPECS: Record<string, { type: string; description
     type: 'string',
     description: 'Replacement for the first occurrence of oldCode; pass "" to delete the snippet.',
   },
+  // table delete actions
+  deleteActionName: {
+    type: 'string',
+    description: 'Delete action name — conventionally the related table name.',
+  },
+  deleteActionTable: {
+    type: 'string',
+    description: 'Related table the delete action applies to (defaults to deleteActionName).',
+  },
+  deleteActionType: {
+    type: 'string (None | Restricted | Cascade | CascadeRestricted)',
+    description: 'Delete action to take on the related table. Defaults to Restricted.',
+  },
   // table fields
   fieldName: { type: 'string', description: 'Field name.' },
   fieldNewName: {
@@ -309,6 +322,12 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
     optional: ['relationConstraints', 'relationCardinality', 'relatedTableCardinality', 'relationshipType'],
   },
   'remove-relation': { required: ['relationName'], optional: [] },
+  'add-delete-action': {
+    required: ['deleteActionName'],
+    optional: ['deleteActionTable', 'deleteActionType'],
+    note: 'objectType="table" only. deleteActionTable defaults to deleteActionName; deleteActionType defaults to Restricted.',
+  },
+  'remove-delete-action': { required: ['deleteActionName'], optional: [] },
   'add-field-group': {
     required: ['fieldGroupName'],
     optional: ['fieldGroupFields', 'fieldGroupLabel'],

--- a/src/tools/generateSmart.ts
+++ b/src/tools/generateSmart.ts
@@ -59,7 +59,11 @@ export async function generateSmartTool(request: CallToolRequest, context: XppSe
   }
 
   const result = await handler(rest, context);
-  return { content: result?.content ?? [{ type: 'text', text: 'No results returned' }] };
+  // Preserve isError — dropping it reported a rejected generation as a success.
+  return {
+    content: result?.content ?? [{ type: 'text', text: 'No results returned' }],
+    ...(result?.isError ? { isError: true } : {}),
+  };
 }
 
 // Tool registration (name, description, inputSchema) lives inline in

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -565,7 +565,9 @@ export async function handleGenerateSmartTable(
   const resolvedPackagePath = argPackagePath || customPackagesRoot || configManager.getPackagePath();
   // getPackagePath() already probes C:\ and K:\ well-known locations before returning null,
   // so reaching here with null means neither location exists on this machine.
-  if (!resolvedPackagePath && process.platform === 'win32') {
+  // preview never writes, so it must not require a write location — demanding one
+  // made "just show me the XML" fail on any machine without a D365FO install.
+  if (!resolvedPackagePath && process.platform === 'win32' && !preview) {
     throw new Error(
       '\u274c Cannot determine PackagesLocalDirectory path.\n\n' +
       'Neither C:\\AosService\\PackagesLocalDirectory nor K:\\AosService\\PackagesLocalDirectory were found.\n\n' +

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -32,8 +32,15 @@ interface GenerateSmartTableArgs {
   tableType?: string;
   copyFrom?: string;
   fieldsHint?: string;
+  /**
+   * Structured field specs. Takes priority over `fieldsHint`, which can only carry
+   * names and therefore cannot express enum-backed fields or an explicit EDT.
+   */
+  fields?: TableFieldSpec[];
   primaryKeyFields?: string[];
   generateCommonFields?: boolean;
+  /** Return the XML without touching disk. The default Windows path writes the file (eval #21). */
+  preview?: boolean;
   modelName?: string;
   projectPath?: string;
   solutionPath?: string;
@@ -170,8 +177,10 @@ export async function handleGenerateSmartTable(
     tableType,
     copyFrom,
     fieldsHint,
+    fields: fieldSpecs,
     primaryKeyFields,
     generateCommonFields,
+    preview,
     modelName,
     projectPath,
     solutionPath,
@@ -268,9 +277,11 @@ export async function handleGenerateSmartTable(
     }
   }
 
+  const explicitFields = Array.isArray(fieldSpecs) ? fieldSpecs.filter(f => f?.name) : [];
+
   // Strategy 2: Generate common fields based on table group patterns.
-  // Skipped when explicit fieldsHint is given (the caller stated the fields).
-  if (generateCommonFields && !copyFrom && !fieldsHint) {
+  // Skipped when the caller stated the fields (fields[] or fieldsHint).
+  if (generateCommonFields && !copyFrom && !fieldsHint && explicitFields.length === 0) {
     console.log(`[generateSmartTable] Analyzing patterns for table group: ${tableGroup}`);
     try {
       const db = symbolIndex.getReadDb();
@@ -331,16 +342,16 @@ export async function handleGenerateSmartTable(
     }
   }
 
-  // Strategy 3: Parse field hints and suggest EDTs
-  if (fieldsHint && !copyFrom) {
-    console.log(`[generateSmartTable] Parsing field hints: ${fieldsHint}`);
-    const hintFields = fieldsHint.split(',').map(s => s.trim()).filter(s => s.length > 0);
-
-    // Guard: reject reserved system field names before any generation attempt.
-    // Adding a field named e.g. "CreatedDateTime" produces a compiler error:
-    // "Invalid field name; 'CreatedDateTime' is reserved for system fields."
-    // The platform auto-provides these fields; users should NOT declare them.
-    const reservedHits = hintFields.filter(f => RESERVED_SYSTEM_FIELD_NAMES.has(f.toLowerCase()));
+  // Guard: reject reserved system field names before any generation attempt.
+  // Adding a field named e.g. "CreatedDateTime" produces a compiler error:
+  // "Invalid field name; 'CreatedDateTime' is reserved for system fields."
+  // The platform auto-provides these fields; users should NOT declare them.
+  {
+    const declaredNames = explicitFields.length > 0
+      ? explicitFields.map(f => f.name)
+      : (fieldsHint && !copyFrom ? fieldsHint.split(',').map(s => s.trim()).filter(s => s.length > 0) : []);
+    const sourceParam = explicitFields.length > 0 ? 'fields' : 'fieldsHint';
+    const reservedHits = declaredNames.filter(f => RESERVED_SYSTEM_FIELD_NAMES.has(f.toLowerCase()));
     if (reservedHits.length > 0) {
       return {
         content: [{
@@ -369,13 +380,33 @@ export async function handleGenerateSmartTable(
               return `  • "${f}" → ${suggestions[f.toLowerCase()] ?? '"CustomFieldName"'}`;
             }).join('\n')}`,
             ``,
-            `🔄 **Call generate again** with the corrected \`fieldsHint\`.`,
+            `🔄 **Call generate again** with the corrected \`${sourceParam}\`.`,
           ].join('\n'),
         }],
         isError: true,
       };
     }
+  }
 
+  // Strategy 3a: structured field specs. Preferred over fieldsHint — an enum-backed
+  // field or an explicit EDT cannot be expressed by a bare name (eval #21).
+  if (explicitFields.length > 0 && !copyFrom) {
+    const specDb = symbolIndex.getReadDb();
+    for (const spec of explicitFields) {
+      // enumType and an explicit type are authoritative; only resolve an EDT when
+      // neither was given and the caller did not name one.
+      const edt = spec.enumType || spec.type
+        ? spec.edt
+        : (spec.edt ?? resolveBestEdt(spec.name, specDb));
+      fields.push({ ...spec, edt });
+    }
+    console.log(`[generateSmartTable] Added ${explicitFields.length} fields from fields[]`);
+  }
+
+  // Strategy 3b: Parse field hints and suggest EDTs
+  if (fieldsHint && !copyFrom && explicitFields.length === 0) {
+    console.log(`[generateSmartTable] Parsing field hints: ${fieldsHint}`);
+    const hintFields = fieldsHint.split(',').map(s => s.trim()).filter(s => s.length > 0);
     const hintDb = symbolIndex.getReadDb();
 
     for (const hint of hintFields) {
@@ -727,9 +758,9 @@ export async function handleGenerateSmartTable(
     };
   }
 
-  // On non-Windows (Azure/Linux): generate XML via SmartXmlBuilder and return as text
-  // The bridge is not available on non-Windows — file writing is handled by the local companion.
-  if (isNonWindows) {
+  // Text-only path: non-Windows (bridge unavailable, the local companion writes the file)
+  // or an explicit preview=true, which is the only way to scaffold without a disk write.
+  if (isNonWindows || preview) {
     const xml = builder.buildTableXml({
       name: finalName,
       label: label || finalName,
@@ -773,7 +804,9 @@ export async function handleGenerateSmartTable(
           edtWarningBlock,
           noModelNote,
           ``,
-          `ℹ️  MCP server is running on Azure/Linux — file writing is handled by the local Windows companion. This is the expected hybrid workflow.`,
+          preview && !isNonWindows
+            ? `ℹ️  preview=true — nothing was written to disk.`
+            : `ℹ️  MCP server is running on Azure/Linux — file writing is handled by the local Windows companion. This is the expected hybrid workflow.`,
           nextStep,
           ``,
           `\`\`\`xml`,

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -36,6 +36,7 @@ import {
   upsertAxTableProperty,
   AX_TABLE_NON_EXISTENT_PROPERTIES,
 } from '../utils/axTablePropertyOrder.js';
+import { upsertAxFormDesignProperty } from '../utils/axFormDesignProperties.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
 import {
@@ -326,6 +327,19 @@ async function directXmlModifyProperty(
       .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
     const tagName = propertyPath.split(/[./]/).pop()!;
+
+    // Forms first: the bridge refuses modify-property for AxForm entirely, and the
+    // generic path below cannot serve Design properties either — Caption/Style also
+    // occur on controls, so it sees several matches and refuses (#37).
+    const formPatched = upsertAxFormDesignProperty(content, tagName, escapedValue);
+    if (formPatched) {
+      await fs.writeFile(filePath, normalizeD365Xml(formPatched), 'utf-8');
+      return {
+        success: true,
+        message: `✅ Form Design property '${tagName}'='${propertyValue}' set via direct XML (the bridge does not support modify-property for forms). File: ${filePath}`,
+      };
+    }
+
     const openTagRe = new RegExp(`<${tagName}\\b[^>]*>[\\s\\S]*?</${tagName}>`, 'g');
     const selfClosingRe = new RegExp(`<${tagName}\\b([^>]*)/>`, 'g');
 
@@ -662,6 +676,85 @@ async function directXmlAddIndex(
   }
 }
 
+/** DeleteAction values accepted by the AxTable serialiser. */
+export const DELETE_ACTION_TYPES = ['None', 'Restricted', 'Cascade', 'CascadeRestricted'] as const;
+
+/**
+ * add-delete-action / remove-delete-action on a TABLE, written straight to the XML.
+ *
+ * There is no bridge operation for DeleteActions at all (finding #36), so a
+ * cascading delete action was inexpressible through the modify surface — the only
+ * route was the forbidden whole-file overwrite. <DeleteActions> is a collection
+ * sibling, not part of the order-sensitive top-level property block, so patching
+ * it in place is safe. Shape matches MetadataWriteService.cs: Name, Table,
+ * DeleteAction.
+ */
+async function directXmlDeleteAction(
+  filePath: string,
+  mode: 'add' | 'remove',
+  name: string,
+  table: string | undefined,
+  deleteAction: string | undefined,
+): Promise<{ success: boolean; message: string } | null> {
+  try {
+    const rawContent = await fs.readFile(filePath, 'utf-8');
+    const content = rawContent.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+    // Only tables carry <DeleteActions> — bail on any other shape so a mis-typed
+    // objectType never corrupts a non-table file.
+    if (!/<AxTable\b/.test(content)) return null;
+
+    const blockRe = new RegExp(
+      `[\\t ]*<AxTableDeleteAction>\\s*<Name>${escapeRegExp(name)}</Name>[\\s\\S]*?</AxTableDeleteAction>\\n?`,
+    );
+    const existing = blockRe.exec(content);
+
+    if (mode === 'remove') {
+      if (!existing) {
+        return { success: true, message: `✅ Delete action '${name}' not present in ${filePath} — nothing to remove.` };
+      }
+      const updated = content.replace(blockRe, '');
+      await fs.writeFile(filePath, normalizeD365Xml(updated), 'utf-8');
+      return { success: true, message: `✅ Delete action '${name}' removed. File: ${filePath}` };
+    }
+
+    if (existing) {
+      return { success: true, message: `✅ Delete action '${name}' already present in ${filePath} — skipped (idempotent).` };
+    }
+
+    const newElement =
+      `\t\t<AxTableDeleteAction>\n` +
+      `\t\t\t<Name>${name}</Name>\n` +
+      `\t\t\t<Table>${table ?? name}</Table>\n` +
+      `\t\t\t<DeleteAction>${deleteAction ?? 'Restricted'}</DeleteAction>\n` +
+      `\t\t</AxTableDeleteAction>`;
+
+    let updated: string;
+    if (content.includes('<DeleteActions />')) {
+      updated = content.replace('<DeleteActions />', `<DeleteActions>\n${newElement}\n\t</DeleteActions>`);
+    } else if (content.includes('</DeleteActions>')) {
+      updated = content.replace('</DeleteActions>', `${newElement}\n\t</DeleteActions>`);
+    } else {
+      // No <DeleteActions> collection at all — not a shape we can safely patch.
+      return null;
+    }
+    if (updated === content) return null;
+
+    await fs.writeFile(filePath, normalizeD365Xml(updated), 'utf-8');
+    return {
+      success: true,
+      message: `✅ Delete action '${name}' (${deleteAction ?? 'Restricted'} on ${table ?? name}) added. File: ${filePath}`,
+    };
+  } catch (err) {
+    console.error(`[modify_d365fo_file] directXmlDeleteAction failed: ${err}`);
+    return null;
+  }
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Writes the relation properties the bridge drops into an <AxTableRelation>.
  *
@@ -825,6 +918,7 @@ const ModifyD365FileArgsSchema = z.object({
     'add-field', 'modify-field', 'rename-field', 'replace-all-fields', 'remove-field',
     'add-index', 'remove-index',
     'add-relation', 'remove-relation',
+    'add-delete-action', 'remove-delete-action',
     'add-field-group', 'remove-field-group', 'add-field-to-field-group',
     'add-field-modification',
     'add-data-source',
@@ -1025,6 +1119,17 @@ const ModifyD365FileArgsSchema = z.object({
   relationCardinality: z.string().optional().describe('Cardinality on local side: ZeroMore | ZeroOne | ExactlyOne (default: ZeroMore).'),
   relatedTableCardinality: z.string().optional().describe('Cardinality on related side: ZeroMore | ZeroOne | ExactlyOne (default: ExactlyOne).'),
   relationshipType: z.string().optional().describe('Relationship type: Association | Composition | Aggregation | Link | Specialization (default: Association).'),
+
+  // For add-delete-action / remove-delete-action (table)
+  deleteActionTable: z.string().optional().describe(
+    'Related table the delete action applies to (e.g. "SalesLine"). Defaults to deleteActionName.'
+  ),
+  deleteActionName: z.string().optional().describe(
+    'Delete action name — conventionally the related table name. Required for both add- and remove-delete-action.'
+  ),
+  deleteActionType: z.enum(DELETE_ACTION_TYPES).optional().describe(
+    'None | Restricted (default) | Cascade | CascadeRestricted.'
+  ),
 
   // For add-field-group / remove-field-group / add-field-to-field-group (table, table-extension)
   fieldGroupName: z.string().optional().describe('Field group name. For add-field-to-field-group in a table-extension: name of the group (new or existing base-table group).'),
@@ -1770,6 +1875,21 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
             context.bridge,
             objectName,
             (args as any).relationName,
+          );
+        }
+        break;
+      }
+      case 'add-delete-action':
+      case 'remove-delete-action': {
+        // No bridge op exists for DeleteActions (#36) — this is the only path.
+        const daName = (args as any).deleteActionName ?? (args as any).deleteActionTable;
+        if (daName) {
+          bridgeResult = await directXmlDeleteAction(
+            actualFilePath,
+            operation === 'add-delete-action' ? 'add' : 'remove',
+            daName,
+            (args as any).deleteActionTable,
+            (args as any).deleteActionType,
           );
         }
         break;

--- a/src/tools/validateXpp.ts
+++ b/src/tools/validateXpp.ts
@@ -472,8 +472,9 @@ function checkGenericDocComment(code: string): ValidationViolation[] {
 
 /**
  * XML001 — AxTable XML missing an index with <AlternateKey>Yes</AlternateKey>.
- * Every D365FO table must have at least one index marked as alternate key
- * for the BPCheckAlternateKeyAbsent rule.
+ * Warning, not error: xppbp raises BPCheckAlternateKeyAbsent as a warning and the
+ * table still builds. As an error it made a legitimately single-index table
+ * unsatisfiable (eval #7).
  */
 function checkMissingAlternateKey(code: string): ValidationViolation[] {
   const violations: ValidationViolation[] = [];
@@ -485,12 +486,11 @@ function checkMissingAlternateKey(code: string): ValidationViolation[] {
   if (!/<AlternateKey>\s*Yes\s*<\/AlternateKey>/i.test(code)) {
     violations.push({
       rule: 'XML001',
-      severity: 'error',
+      severity: 'warning',
       excerpt: '<AxTable> — no index with <AlternateKey>Yes</AlternateKey>',
-      fix: 'Add at least one <AxTableIndex> with <AlternateKey>Yes</AlternateKey>. ' +
-        'D365FO requires every table to have an alternate key index ' +
-        '(BPCheckAlternateKeyAbsent). ' +
-        'generate_smart adds this automatically via buildPrimaryKeyIndex.',
+      fix: 'Add an <AxTableIndex> with <AlternateKey>Yes</AlternateKey> unless the table ' +
+        'deliberately has none — xppbp reports BPCheckAlternateKeyAbsent as a warning and ' +
+        'the table still builds. generate_smart adds one via buildPrimaryKeyIndex.',
     });
   }
   return violations;

--- a/src/utils/axFormDesignProperties.ts
+++ b/src/utils/axFormDesignProperties.ts
@@ -1,0 +1,89 @@
+/**
+ * AxForm <Design> property upsert.
+ *
+ * The C# bridge rejects modify-property for forms outright ("modify-property not
+ * supported for objectType form via bridge"), so the Design annotations
+ * object_patterns(action="spec") prescribes — Pattern / PatternVersion / Style —
+ * could not be set through any grounded path (findings #37, corpus
+ * 2026-07-22T04__L2-form-over-view). The generic directXmlModifyProperty cannot
+ * serve them either: Caption/Style also occur on controls, so it sees several
+ * matches and refuses to guess.
+ *
+ * Ground truth for shape and order: eval/goldens/L1-form-listpage (VM-captured,
+ * built clean) — Design's direct-child properties carry `xmlns=""`, are
+ * alphabetical, and <Controls> terminates the block.
+ */
+
+/** Direct-child properties of <Design> the serialiser writes. */
+export const AX_FORM_DESIGN_PROPERTIES = new Set([
+  'Caption',
+  'ColumnsMode',
+  'DataSource',
+  'Pattern',
+  'PatternVersion',
+  'ShowDeleteButton',
+  'ShowNewButton',
+  'Style',
+  'TitleDataSource',
+  'ViewEditMode',
+  'WindowResize',
+  'WindowType',
+]);
+
+/**
+ * Set a form Design property, inserting it in alphabetical order when absent.
+ * Returns the updated XML, or null when the document is not an AxForm, has no
+ * <Design>, or the property is not a Design property (so the caller can surface
+ * the original error rather than write something invented).
+ */
+export function upsertAxFormDesignProperty(
+  xml: string,
+  property: string,
+  value: string,
+): string | null {
+  if (!/<AxForm[\s>]/.test(xml)) return null;
+  if (!AX_FORM_DESIGN_PROPERTIES.has(property)) return null;
+
+  const designStart = xml.search(/^[ \t]*<Design>/m);
+  if (designStart === -1) return null;
+  const designOpen = xml.indexOf('>', designStart) + 1;
+
+  // Everything before <Controls> (or </Design> on a control-less form) is the
+  // direct-child property region — nested controls carry their own Caption/Style,
+  // and must never be touched.
+  const controlsRel = xml.slice(designOpen).search(/^[ \t]*<Controls[ />]/m);
+  const endRel = controlsRel !== -1 ? controlsRel : xml.slice(designOpen).search(/^[ \t]*<\/Design>/m);
+  if (endRel === -1) return null;
+  const propsEnd = designOpen + endRel;
+
+  const head = xml.slice(0, designOpen);
+  const region = xml.slice(designOpen, propsEnd);
+  const tail = xml.slice(propsEnd);
+
+  const designIndent = /^([ \t]*)<Design>/m.exec(xml.slice(designStart))?.[1] ?? '\t';
+  const indent = `${designIndent}\t`;
+  const element = `${indent}<${property} xmlns="">${value}</${property}>\n`;
+
+  const existing = new RegExp(
+    `^[ \\t]*<${property}\\b[^>]*?/>[ \\t]*\\n|^[ \\t]*<${property}\\b[^>]*>[\\s\\S]*?</${property}>[ \\t]*\\n`,
+    'm',
+  );
+  if (existing.test(region)) {
+    return head + region.replace(existing, element) + tail;
+  }
+
+  // Insert before the first existing property that sorts after this one.
+  const propLine = /^[ \t]*<([A-Za-z_][\w.-]*)\b/gm;
+  let insertAt: number | null = null;
+  for (let m = propLine.exec(region); m; m = propLine.exec(region)) {
+    if (AX_FORM_DESIGN_PROPERTIES.has(m[1]) && m[1].localeCompare(property) > 0) {
+      insertAt = m.index;
+      break;
+    }
+  }
+  const patched = insertAt === null
+    ? region.replace(/\s*$/, '\n') + element
+    : region.slice(0, insertAt) + element + region.slice(insertAt);
+
+  return head + patched + tail;
+}

--- a/tests/tools/code-generation.test.ts
+++ b/tests/tools/code-generation.test.ts
@@ -810,6 +810,76 @@ describe('generate_smart_table', () => {
     expect(result?.content[0].text).toMatch(/Description|Amount/);
   });
 
+  // eval #21: fieldsHint carries only names, so an enum-backed field or an explicit
+  // EDT could not be expressed and was silently mis-typed as a String EDT.
+  it('accepts structured fields[] and keeps enum fields as AxTableFieldEnum', async () => {
+    const result = await handleGenerateSmartTable(
+      {
+        name: 'ConDemoNote',
+        modelName: 'MyModel',
+        fields: [
+          { name: 'NoteId', edt: 'Description', mandatory: true },
+          { name: 'Status', enumType: 'ConDemoNoteStatus' },
+        ],
+      },
+      ctx.symbolIndex,
+    );
+    const text = result?.content[0].text as string;
+    expect(text).toContain('<EnumType>ConDemoNoteStatus</EnumType>');
+    expect(text).toContain('i:type="AxTableFieldEnum"');
+    // The caller's enum name survives; fieldsHint could never have expressed it.
+    expect(text).toContain('<Name>NoteId</Name>');
+    expect(text).toContain('<Mandatory>Yes</Mandatory>');
+  });
+
+  // eval #21: scaffold is generation-only by name but the Windows path writes the
+  // file, and undo_last_modification cannot clean that up (PackagesLocalDirectory
+  // is not a git repo). preview=true is the no-write route.
+  it('preview=true returns XML without writing on Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const result = await handleGenerateSmartTable(
+      {
+        name: 'ConDemoPreview',
+        modelName: 'MyModel',
+        preview: true,
+        fields: [{ name: 'NoteId', edt: 'Description' }],
+      },
+      ctx.symbolIndex,
+    );
+    const text = result?.content[0].text as string;
+    expect(text).toContain('nothing was written to disk');
+    expect(text).toContain('<AxTable');
+  });
+
+  it('fields[] wins over fieldsHint', async () => {
+    const result = await handleGenerateSmartTable(
+      {
+        name: 'ConDemoNote',
+        modelName: 'MyModel',
+        fieldsHint: 'ShouldBeIgnored',
+        fields: [{ name: 'OnlyThis', edt: 'Description' }],
+      },
+      ctx.symbolIndex,
+    );
+    const text = result?.content[0].text as string;
+    expect(text).toContain('OnlyThis');
+    expect(text).not.toContain('ShouldBeIgnored');
+  });
+
+  it('rejects reserved system field names passed via fields[]', async () => {
+    const result = await handleGenerateSmartTable(
+      {
+        name: 'ConDemoNote',
+        modelName: 'MyModel',
+        fields: [{ name: 'CreatedDateTime' }],
+      },
+      ctx.symbolIndex,
+    );
+    expect(result?.isError).toBe(true);
+    expect(result?.content[0].text).toContain('Reserved system field name');
+    expect(result?.content[0].text).toContain('`fields`');
+  });
+
   it('includes an index when uniqueIndex is specified', async () => {
     const result = await handleGenerateSmartTable(
       {

--- a/tests/tools/d365foFileOpSpecs.test.ts
+++ b/tests/tools/d365foFileOpSpecs.test.ts
@@ -22,7 +22,7 @@ describe('d365fo_file op-spec registry', () => {
     const publishedOps: string[] =
       (d365foFileSchema.inputSchema.properties as any).operation.enum;
     expect(new Set(Object.keys(D365FO_FILE_OP_SPECS))).toEqual(new Set(publishedOps));
-    expect(publishedOps).toHaveLength(25);
+    expect(publishedOps).toHaveLength(27);
   });
 
   it('every required/optional param has a param-spec entry with type and description', () => {

--- a/tests/tools/deleteActionOps.test.ts
+++ b/tests/tools/deleteActionOps.test.ts
@@ -1,0 +1,225 @@
+/**
+ * add-delete-action / remove-delete-action — finding #36.
+ *
+ * The modify surface had no operation for table DeleteActions at all, so a
+ * cascading delete action was inexpressible: the only way to land one was
+ * d365fo_file(action="create", overwrite=true), the whole-file escape hatch the
+ * eval loop forbids. There is no bridge op either (MetadataWriteService only
+ * writes DeleteActions as a side effect of table creation), so the op is backed
+ * by a direct-XML writer — same pattern as directXmlAddIndex.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool } from '../../src/tools/modifyD365File';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return { ...actual, bridgeValidateAfterWrite: vi.fn(async () => null) };
+});
+
+/** Header table with an empty <DeleteActions /> collection. */
+const TABLE_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoHeader</Name>
+\t<SourceCode>
+\t\t<Declaration><![CDATA[
+public class ConDemoHeader extends common
+{
+}
+]]></Declaration>
+\t\t<Methods />
+\t</SourceCode>
+\t<Label>@Contoso:Header</Label>
+\t<DeleteActions />
+\t<FieldGroups />
+\t<Fields>
+\t\t<AxTableField xmlns="" i:type="AxTableFieldString">
+\t\t\t<Name>HeaderId</Name>
+\t\t\t<ExtendedDataType>Num</ExtendedDataType>
+\t\t</AxTableField>
+\t</Fields>
+\t<FullTextIndexes />
+\t<Indexes />
+\t<Mappings />
+\t<Relations />
+\t<StateMachines />
+</AxTable>`;
+
+/** Same table, with one delete action already present. */
+const TABLE_WITH_ACTION_XML = TABLE_XML.replace(
+  '\t<DeleteActions />',
+  '\t<DeleteActions>\n\t\t<AxTableDeleteAction>\n\t\t\t<Name>ConDemoLine</Name>\n' +
+  '\t\t\t<Table>ConDemoLine</Table>\n\t\t\t<DeleteAction>Cascade</DeleteAction>\n' +
+  '\t\t</AxTableDeleteAction>\n\t</DeleteActions>',
+);
+
+const { mockWriteFile, currentXml } = vi.hoisted(() => ({
+  mockWriteFile: vi.fn(async () => {}),
+  currentXml: { value: '' },
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (typeof p === 'string' && p.endsWith('.xml')) return currentXml.value;
+    if (typeof p === 'string' && p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: mockWriteFile,
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+  copyFile: vi.fn(async () => {}),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (m: string) => ({ packageName: m, modelName: m, rootPath: 'K:\\PackagesLocalDirectory' })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({ packageName: p, modelName: m, rootPath: 'K:\\PackagesLocalDirectory' })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+const FILE_PATH = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\ConDemoHeader.xml';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'modify_d365fo_file', arguments: { objectType: 'table', objectName: 'ConDemoHeader', filePath: FILE_PATH, ...args } },
+});
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare: vi.fn(() => stmt) },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: { get: vi.fn(async () => null), set: vi.fn(async () => {}), generateSearchKey: vi.fn((q: string) => `k:${q}`) } as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    bridge: { isReady: true, metadataAvailable: true } as any,
+  };
+};
+
+/** The written XML that carries a delete-action edit. */
+const captured = (): string | undefined => {
+  const call = mockWriteFile.mock.calls.find((c: any[]) => typeof c[1] === 'string' && c[1].includes('<DeleteAction'));
+  return call?.[1] as string | undefined;
+};
+
+describe('table DeleteActions via the modify surface (#36)', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    currentXml.value = TABLE_XML;
+    mockWriteFile.mockClear();
+  });
+
+  it('adds a cascading delete action in canonical shape', async () => {
+    const result = await modifyD365FileTool(
+      req({ operation: 'add-delete-action', deleteActionName: 'ConDemoLine', deleteActionType: 'Cascade' }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const xml = captured();
+    expect(xml).toBeTruthy();
+    expect(xml).toMatch(
+      /<DeleteActions>\s*<AxTableDeleteAction>\s*<Name>ConDemoLine<\/Name>\s*<Table>ConDemoLine<\/Table>\s*<DeleteAction>Cascade<\/DeleteAction>\s*<\/AxTableDeleteAction>\s*<\/DeleteActions>/,
+    );
+    expect(xml).not.toContain('<DeleteActions />');
+  });
+
+  it('never steers the agent into create overwrite=true', async () => {
+    const result = await modifyD365FileTool(
+      req({ operation: 'add-delete-action', deleteActionName: 'ConDemoLine', deleteActionType: 'Cascade' }),
+      ctx,
+    );
+    expect(result.content[0].text as string).not.toMatch(/overwrite=true/);
+  });
+
+  it('defaults deleteActionTable to the name and the type to Restricted', async () => {
+    await modifyD365FileTool(req({ operation: 'add-delete-action', deleteActionName: 'ConDemoLine' }), ctx);
+    const xml = captured();
+    expect(xml).toContain('<Table>ConDemoLine</Table>');
+    expect(xml).toContain('<DeleteAction>Restricted</DeleteAction>');
+  });
+
+  it('honours a deleteActionTable distinct from the action name', async () => {
+    await modifyD365FileTool(
+      req({ operation: 'add-delete-action', deleteActionName: 'Lines', deleteActionTable: 'ConDemoLine', deleteActionType: 'CascadeRestricted' }),
+      ctx,
+    );
+    const xml = captured();
+    expect(xml).toContain('<Name>Lines</Name>');
+    expect(xml).toContain('<Table>ConDemoLine</Table>');
+    expect(xml).toContain('<DeleteAction>CascadeRestricted</DeleteAction>');
+  });
+
+  it('is idempotent — an existing action is not duplicated', async () => {
+    currentXml.value = TABLE_WITH_ACTION_XML;
+    const result = await modifyD365FileTool(
+      req({ operation: 'add-delete-action', deleteActionName: 'ConDemoLine', deleteActionType: 'Cascade' }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text as string).toMatch(/idempotent/i);
+    expect(captured()).toBeUndefined();
+  });
+
+  it('removes an existing delete action', async () => {
+    currentXml.value = TABLE_WITH_ACTION_XML;
+    const result = await modifyD365FileTool(
+      req({ operation: 'remove-delete-action', deleteActionName: 'ConDemoLine' }),
+      ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    const written = mockWriteFile.mock.calls.find(
+      (c: any[]) => typeof c[1] === 'string' && c[1].includes('<AxTable'),
+    )?.[1] as string | undefined;
+    expect(written).toBeTruthy();
+    expect(written).not.toContain('<AxTableDeleteAction>');
+  });
+
+  it('refuses to patch a non-table file', async () => {
+    currentXml.value = `<?xml version="1.0" encoding="utf-8"?>\n<AxEnum><Name>ConDemoStatus</Name></AxEnum>`;
+    const result = await modifyD365FileTool(
+      req({ operation: 'add-delete-action', deleteActionName: 'ConDemoLine' }),
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(captured()).toBeUndefined();
+  });
+});

--- a/tests/tools/formModifyPropertyFallback.test.ts
+++ b/tests/tools/formModifyPropertyFallback.test.ts
@@ -164,14 +164,17 @@ describe('modify-property direct-XML fallback for forms (regression)', () => {
     );
 
     expect(result.isError).toBeFalsy();
-    expect(result.content[0].text).toMatch(/direct XML fallback/i);
+    expect(result.content[0].text).toMatch(/direct XML/i);
     expect(mockWriteFile).toHaveBeenCalledTimes(1);
     const [, writtenContent] = mockWriteFile.mock.calls[0];
     expect(writtenContent).toContain('<Caption xmlns="">@MyModel:HeaderNote</Caption>');
     expect(writtenContent).not.toContain('Note headers');
   });
 
-  it('refuses to guess when the property element appears more than once', async () => {
+  // Was "refuses to guess when the property element appears more than once".
+  // A Design property is no longer ambiguous: #37 added a Design-scoped upsert,
+  // so a Caption elsewhere in the form (a Part, a control) is simply not the target.
+  it('targets the Design property and leaves same-named elements elsewhere alone', async () => {
     currentFormXml = FORM_XML_TWO_CAPTIONS;
 
     const result = await modifyD365FileTool(
@@ -181,6 +184,37 @@ describe('modify-property direct-XML fallback for forms (regression)', () => {
         operation: 'modify-property',
         propertyPath: 'Caption',
         propertyValue: '@MyModel:HeaderNote',
+        filePath: FORM_FILE_PATH,
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockWriteFile.mock.calls[0];
+    expect(written).toContain('<Caption xmlns="">@MyModel:HeaderNote</Caption>');
+    expect(written).toContain('<Caption xmlns="">Second</Caption>');
+    expect(written).not.toContain('<Caption xmlns="">First</Caption>');
+  });
+
+  it('still refuses to guess for a non-Design property that appears more than once', async () => {
+    currentFormXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxForm>
+\t<Design>
+\t\t<Caption xmlns="">First</Caption>
+\t</Design>
+\t<Parts>
+\t\t<Part><HelpText>a</HelpText></Part>
+\t\t<Part><HelpText>b</HelpText></Part>
+\t</Parts>
+</AxForm>`;
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'form',
+        objectName: 'ContosoXyzNoteHeaderList',
+        operation: 'modify-property',
+        propertyPath: 'HelpText',
+        propertyValue: 'c',
         filePath: FORM_FILE_PATH,
       }),
       ctx,

--- a/tests/tools/generateSmartTablePreview.test.ts
+++ b/tests/tools/generateSmartTablePreview.test.ts
@@ -1,0 +1,77 @@
+/**
+ * generate_object(scaffold, table, preview=true) — finding #21.
+ *
+ * scaffold is generation-only by name but the Windows path writes the file, and
+ * undo_last_modification cannot clean that up (PackagesLocalDirectory is not a
+ * git repo). preview=true is the no-write route.
+ *
+ * This file exists separately from code-generation.test.ts because it must run
+ * with NO resolvable PackagesLocalDirectory — the dev VM has K:\AosService, so
+ * the shared suite silently takes the happy path and only CI would catch a
+ * preview that still demands a write location.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleGenerateSmartTable } from '../../src/tools/generateSmartTable';
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    // The machine has no D365FO installation — every source is exhausted.
+    getPackagePath: vi.fn(() => null),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getModelName: vi.fn(() => null),
+    getAutoDetectedModelName: vi.fn(async () => null),
+    getContext: vi.fn(() => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+const symbolIndex = {
+  getReadDb: () => ({
+    prepare: () => ({ all: () => [], get: () => undefined, run: () => {} }),
+  }),
+} as any;
+
+describe('scaffold table preview=true (#21)', () => {
+  beforeEach(() => {
+    // Force the Windows branch — the one that writes to disk.
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    vi.stubEnv('EXTENSION_PREFIX', '');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the XML without demanding a PackagesLocalDirectory', async () => {
+    const result = await handleGenerateSmartTable(
+      {
+        name: 'ConDemoPreview',
+        modelName: 'MyModel',
+        preview: true,
+        fields: [{ name: 'NoteId', edt: 'Description' }],
+      },
+      symbolIndex,
+    );
+
+    const text = result?.content[0].text as string;
+    expect(text).not.toMatch(/Cannot determine PackagesLocalDirectory/);
+    expect(text).toContain('nothing was written to disk');
+    expect(text).toContain('<AxTable');
+    expect(text).toContain('<Name>NoteId</Name>');
+  });
+
+  it('still refuses a real (non-preview) scaffold with no write location', async () => {
+    await expect(
+      handleGenerateSmartTable(
+        { name: 'ConDemoReal', modelName: 'MyModel', fields: [{ name: 'NoteId' }] },
+        symbolIndex,
+      ),
+    ).rejects.toThrow(/Cannot determine PackagesLocalDirectory/);
+  });
+});

--- a/tests/tools/validate-xpp.test.ts
+++ b/tests/tools/validate-xpp.test.ts
@@ -233,6 +233,29 @@ describe('XML rules', () => {
     expect(getText(result)).toContain('XML001');
   });
 
+  it('XML001: is a warning, not a hard error (eval #7)', async () => {
+    // xppbp reports BPCheckAlternateKeyAbsent as a warning and the table builds.
+    // As an error, a case that legitimately mandates one index could never pass.
+    const xml = `
+      <AxTable>
+        <Name>ConDemoAsset</Name>
+        <Label>@Contoso:AssetLabel</Label>
+        <TableGroup>Main</TableGroup>
+        <Indexes>
+          <AxTableIndex>
+            <Name>AssetIdx</Name>
+            <AlternateKey>No</AlternateKey>
+          </AxTableIndex>
+        </Indexes>
+      </AxTable>
+    `;
+    const result = await validateXppTool(req({ code: xml, codeType: 'xml-table' }));
+    expect(getText(result)).toContain('XML001');
+    expect(getText(result)).toContain('[XML001] — WARNING');
+    expect(result.isError).toBeFalsy();
+    expect(getText(result)).toContain('0 error(s)');
+  });
+
   it('XML001: passes when AlternateKey is Yes', async () => {
     const xml = `
       <AxTable>

--- a/tests/utils/axFormDesignProperties.test.ts
+++ b/tests/utils/axFormDesignProperties.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Form Design property upsert — finding #37 (forms half).
+ *
+ * The bridge rejects modify-property for AxForm outright, so the Design
+ * annotations object_patterns(action="spec") prescribes (Pattern / PatternVersion
+ * / Style) had no grounded path at all and the emitted form carried no Pattern
+ * declaration. Corpus: 2026-07-22T04__L2-form-over-view.
+ *
+ * Shape/order ground truth: eval/goldens/L1-form-listpage (VM-captured, clean build).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { upsertAxFormDesignProperty } from '../../src/utils/axFormDesignProperties';
+
+const FORM = `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoActiveList</Name>
+\t<SourceCode>
+\t\t<Methods />
+\t</SourceCode>
+\t<DataSources>
+\t\t<AxFormDataSource>
+\t\t\t<Name>ConDemoActiveView</Name>
+\t\t\t<Table>ConDemoActiveView</Table>
+\t\t</AxFormDataSource>
+\t</DataSources>
+\t<Design>
+\t\t<Caption xmlns="">@Contoso:List</Caption>
+\t\t<DataSource xmlns="">ConDemoActiveView</DataSource>
+\t\t<TitleDataSource xmlns="">ConDemoActiveView</TitleDataSource>
+\t\t<Controls xmlns="">
+\t\t\t<AxFormControl xmlns="" i:type="AxFormGridControl">
+\t\t\t\t<Name>Grid</Name>
+\t\t\t\t<Caption>@Contoso:GridCaption</Caption>
+\t\t\t\t<Style>Tabular</Style>
+\t\t\t</AxFormControl>
+\t\t</Controls>
+\t</Design>
+</AxForm>`;
+
+describe('upsertAxFormDesignProperty (#37 forms half)', () => {
+  it('inserts Pattern in alphabetical order among Design properties', () => {
+    const out = upsertAxFormDesignProperty(FORM, 'Pattern', 'ListPage')!;
+    expect(out).toBeTruthy();
+    expect(out).toMatch(
+      /<DataSource xmlns="">ConDemoActiveView<\/DataSource>\s*\n\s*<Pattern xmlns="">ListPage<\/Pattern>\s*\n\s*<TitleDataSource/,
+    );
+  });
+
+  it('inserts Style after Pattern/PatternVersion and before TitleDataSource', () => {
+    let out = upsertAxFormDesignProperty(FORM, 'Pattern', 'ListPage')!;
+    out = upsertAxFormDesignProperty(out, 'PatternVersion', 'UX7 1.0')!;
+    out = upsertAxFormDesignProperty(out, 'Style', 'ListPage')!;
+    const design = /<Design>([\s\S]*?)<Controls/.exec(out)![1];
+    const order = [...design.matchAll(/<([A-Za-z]+) xmlns="">/g)].map(m => m[1]);
+    expect(order).toEqual(['Caption', 'DataSource', 'Pattern', 'PatternVersion', 'Style', 'TitleDataSource']);
+  });
+
+  it('never touches a control that carries the same property name', () => {
+    const out = upsertAxFormDesignProperty(FORM, 'Style', 'ListPage')!;
+    // The grid's own Style survives untouched — this is exactly what made the
+    // generic single-match fallback refuse to act.
+    expect(out).toContain('<Style>Tabular</Style>');
+    expect(out).toContain('<Style xmlns="">ListPage</Style>');
+  });
+
+  it('replaces an existing Design property in place', () => {
+    const out = upsertAxFormDesignProperty(FORM, 'Caption', '@Contoso:Renamed')!;
+    expect(out).toContain('<Caption xmlns="">@Contoso:Renamed</Caption>');
+    expect(out).not.toContain('<Caption xmlns="">@Contoso:List</Caption>');
+    // No duplicate.
+    expect((out.match(/<Caption xmlns="">/g) ?? []).length).toBe(1);
+  });
+
+  it('appends when nothing sorts after it', () => {
+    const out = upsertAxFormDesignProperty(FORM, 'WindowType', 'Popup')!;
+    expect(out).toMatch(/<TitleDataSource xmlns="">[^<]*<\/TitleDataSource>\s*\n\s*<WindowType xmlns="">Popup<\/WindowType>\s*\n\s*<Controls/);
+  });
+
+  it('returns null for a non-Design property rather than inventing one', () => {
+    expect(upsertAxFormDesignProperty(FORM, 'TableGroup', 'Main')).toBeNull();
+  });
+
+  it('returns null for a non-form document', () => {
+    expect(upsertAxFormDesignProperty('<AxTable><Name>T</Name></AxTable>', 'Pattern', 'ListPage')).toBeNull();
+  });
+});

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -23,13 +23,13 @@ import { createXppMcpServer } from '../../src/server/mcpServer';
 // the human-readable log line, never for assertions.
 const CHARS_PER_TOKEN = 4;
 
-// Ceilings in characters of serialized JSON. Current actuals (2026-07, after
-// adding d365fo_file's `service` + `service-group` objectTypes — two genuinely
-// new AOT capabilities, so the ceilings were raised deliberately (same as the
-// earlier generate_object `additionalDatasets` bump): total ≈ 62,555 ·
-// d365fo_file ≈ 9,493 (now the largest, ahead of generate_object ≈ 8,469).
+// Ceilings in characters of serialized JSON. Current actual ≈ 62,930 · largest
+// tool d365fo_file ≈ 9,5xx (ahead of generate_object ≈ 8,5xx). Raised
+// deliberately whenever a genuinely new AOT capability lands — `service` +
+// `service-group` objectTypes, then d365fo_file's add-/remove-delete-action
+// (findings #36) and generate_object scaffold `fields[]`/`preview` (#21).
 // Headroom is small on purpose so creep is caught early.
-const TOTAL_BUDGET = 62_900;
+const TOTAL_BUDGET = 63_100;
 const LARGEST_TOOL_BUDGET = 9_800;
 
 async function getTools(): Promise<Array<{ name: string }>> {


### PR DESCRIPTION
All four remaining repo-side findings from `docs/eval-sweep-findings-2026-07-21.md` are closed. Every one was provable in-repo — no VM, no C# bridge change. Full suite: **157 files, 2094 passed, 2 skipped**; `tsc --noEmit` clean.

### #7 — validator: XML001 was a hard error
`validate_code(syntax)` raised `BPCheckAlternateKeyAbsent` as severity `error`, so a case that legitimately mandates one index could never satisfy it — an error-severity rule a valid, building table cannot pass. xppbp reports it as a warning and the build is clean; it is now a warning.

### #21 — `generate_object(scaffold, table)`
- Accepts the structured `fields[]` the schema already advertised for `report`/`fields` modes. It takes priority over `fieldsHint`, which carries only names and therefore cannot express an enum-backed field or an explicit EDT — those were silently mis-typed as String EDTs.
- The reserved-system-field-name guard now covers both parameter shapes.
- Adds `preview: true`. The Windows path writes the table to disk despite the tool being generation-only, and `undo_last_modification` cannot clean that up (`PackagesLocalDirectory` is not a git repo).
- Bonus: `generate_smart` dropped `isError` from the handler result, so a *rejected* generation was reported as a success.

### #36 — table DeleteActions were inexpressible
No operation existed at all, so a cascading delete action forced `create overwrite=true` — the escape hatch the eval loop forbids. Adds `add-delete-action` / `remove-delete-action`, backed by a direct-XML writer (there is no C# op for DeleteActions either — `MetadataWriteService` only writes them as a side effect of table creation), in the shape that file writes: `Name`, `Table`, `DeleteAction`. Idempotent, refuses non-table files.

### #37 (forms half) — `modify-property` for forms
The bridge rejects `modify-property` for AxForm outright, and the generic direct-XML fallback could not serve Design properties either: `Caption`/`Style` also occur on controls, so it saw several matches and refused to guess. The result was that the `Pattern` / `PatternVersion` / `Style` annotations `object_patterns(action="spec")` prescribes had **no grounded path** and emitted forms carried no Pattern declaration.

Adds a Design-scoped upsert (alphabetical order, `xmlns=""`, inserted before `<Controls>`), ground truth `eval/goldens/L1-form-listpage` (VM-captured, clean build). One pre-existing test changed meaning and is annotated: a Design property is no longer "ambiguous" just because a Part or control carries the same tag — ambiguity is still refused for non-Design properties.

### Corpus evidence
`2026-07-22T04__L2-form-over-view`, `2026-07-22T03__L2-form-modify-controls`, `2026-07-21T20__L4-master-security-slice`.

### Docs
The findings doc drops the four resolved items (resolved items are deleted, not archived) and files three defects that same form-over-view record raised alongside #37 but that were never separately filed: form scaffold resolves `dataSource` against tables only (never views), `AxViewFieldBound` `<DataSource>` defaults to the query name instead of the query's root data source, and `trigger_db_sync` puts tables and views both in `-viewlist`.

### Release
Version bumped to **1.3.0** (new tool operations). `package-lock.json` was still pinned at 1.1.0 and is resynced. The schema token budget was raised 62,900 → 63,100 deliberately for the two new ops, per that test's own ratchet rule.

Tagging `v1.3.0` after merge triggers `.github/workflows/release.yml` (GitHub release + npm publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)