### PR TITLE
fix(index): build the index in the chosen installation directory

### DIFF
--- a/src/cli/commands/indexCmd.ts
+++ b/src/cli/commands/indexCmd.ts
@@ -4,7 +4,7 @@
  * instances/rebuild-instance.ps1 minus the git-pull step (that lives in
  * `d365fo-mcp update`).
  */
-import { installMode, isWindows, paths } from '../context.js';
+import { dataRoot, installMode, isWindows, paths } from '../context.js';
 import { runNode } from '../exec.js';
 import { listInstances } from '../instances.js';
 import { instanceTarget, pickTarget, rootTarget, targetEnv, Target } from '../target.js';
@@ -27,6 +27,12 @@ function scriptArgs(tsSource: string, bundle: string): string[] {
 /** Run extract + build-database for one target. Returns true on success. */
 export async function rebuildIndex(target: Target): Promise<boolean> {
   const env = targetEnv(target);
+  // Run from the target's own directory, not the package: the index scripts
+  // fall back to relative literals ('./data/xpp-metadata.db') whenever a
+  // setting is absent AND no config file exists to anchor it, and the default
+  // cwd of runNode is repoRoot — which for an npm install is the package npm
+  // replaces on every update, on whatever drive npm happens to live on.
+  const cwd = target.instance?.dir ?? dataRoot();
 
   if (isWindows) {
     const expanded = normalizeXppConfigName(target.store);
@@ -34,13 +40,13 @@ export async function rebuildIndex(target: Target): Promise<boolean> {
   }
 
   p.log.step(`[1/2] Extracting metadata (${target.label})…`);
-  if (await runNode(scriptArgs(paths.extractScript, paths.extractScriptDist), { env }) !== 0) {
+  if (await runNode(scriptArgs(paths.extractScript, paths.extractScriptDist), { cwd, env }) !== 0) {
     p.log.error(`Metadata extraction failed for ${target.label}`);
     return false;
   }
 
   p.log.step(`[2/2] Building database (${target.label})…`);
-  if (await runNode(['--max-old-space-size=6144', ...scriptArgs(paths.buildDbScript, paths.buildDbScriptDist)], { env }) !== 0) {
+  if (await runNode(['--max-old-space-size=6144', ...scriptArgs(paths.buildDbScript, paths.buildDbScriptDist)], { cwd, env }) !== 0) {
     p.log.error(`Database build failed for ${target.label}`);
     return false;
   }

--- a/src/config/configFile.ts
+++ b/src/config/configFile.ts
@@ -128,6 +128,31 @@ export function toEnvRecord(files: Pick<ResolvedConfigFiles, 'baseDir' | 'config
   return out;
 }
 
+/**
+ * The path settings the wizard never writes, resolved against `baseDir`.
+ *
+ * DB_PATH, LABELS_DB_PATH and METADATA_PATH are advanced settings with
+ * relative defaults, so a normal setup leaves them out of the config file
+ * entirely and every consumer falls back to its own `'./data/…'` literal —
+ * which resolves from process.cwd(). For a git checkout that is the repo, and
+ * the answer happens to be right. For an npm install it is the *package*
+ * directory: `d365fo-mcp index` spawns the build scripts with cwd = repoRoot,
+ * so a 2 GB index landed next to the installed package, on whatever drive npm
+ * lives on, instead of in the installation directory the user chose in setup
+ * (issue: build ran out of space on C: and SQLite aborted the transaction).
+ *
+ * Emitting the defaults here pins them to the installation directory instead.
+ * A checkout is its own data directory, so its paths do not move.
+ */
+export function defaultPathEnv(baseDir: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const setting of SETTINGS) {
+    if (setting.type !== 'path' || typeof setting.default !== 'string' || setting.default === '') continue;
+    out[setting.env] = isAbsolute(setting.default) ? setting.default : resolve(baseDir, setting.default);
+  }
+  return out;
+}
+
 /** Write the config file, creating its directory. Keys are emitted in registry order. */
 export function writeConfigFile(configPath: string, config: ConfigObject): void {
   fs.mkdirSync(dirname(configPath), { recursive: true });

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1324,6 +1324,44 @@ export class XppSymbolIndex {
    *                   database (a custom-model build: ~10K of ~1.2M symbols, where the full
    *                   rebuild cost 327s against 5s of actual indexing work).
    */
+  /**
+   * Turn a write failure inside a model transaction into an error that names
+   * the database being written and, when the drive is the likely cause, how
+   * much room is left on it.
+   *
+   * A full disk makes SQLite roll the transaction back itself, so better-sqlite3's
+   * wrapper then fails to COMMIT and the only thing the user sees is
+   * "cannot commit - no transaction is active" with a stack inside the library —
+   * no path, no mention of space. That message sent at least one user hunting
+   * for a corrupt index when the index was simply being written to the wrong
+   * (and nearly full) drive.
+   */
+  private describeWriteFailure(err: unknown, model: string): Error {
+    const original = err instanceof Error ? err : new Error(String(err));
+    const message = original.message;
+    const diskRelated = /disk is full|SQLITE_FULL|disk I\/O error|no transaction is active/i.test(message);
+    if (!diskRelated) return original;
+
+    let space = '';
+    try {
+      const stat = fs.statfsSync(path.dirname(path.resolve(this.dbPath)));
+      const freeGb = (Number(stat.bavail) * Number(stat.bsize)) / 1024 ** 3;
+      space = ` (${freeGb.toFixed(1)} GB free there)`;
+    } catch {
+      // statfs is best-effort — the path advice below is the useful part.
+    }
+
+    const wrapped = new Error(
+      `Writing model '${model}' to ${this.dbPath} failed: ${message}\n` +
+      `The index is written to that path${space}. A full disk makes SQLite roll the write back on its own, ` +
+      `which is what surfaces as "cannot commit - no transaction is active".\n` +
+      `Point the installation at a drive with room (a full index needs several GB): ` +
+      `re-run 'd365fo-mcp setup' and choose another directory, or set index.dbPath / index.metadataPath in d365fo-mcp.json.`,
+    );
+    wrapped.cause = original;
+    return wrapped;
+  }
+
   async indexMetadataDirectory(
     metadataPath: string,
     modelNames?: string | string[],
@@ -1521,7 +1559,11 @@ export class XppSymbolIndex {
         // Mark model as done atomically with its data (same transaction)
         markProgress?.run(model, Date.now());
       });
-      tx();
+      try {
+        tx();
+      } catch (err) {
+        throw this.describeWriteFailure(err, model);
+      }
 
       const modelDuration = ((Date.now() - modelStartTime) / 1000).toFixed(1);
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);

--- a/src/utils/loadEnv.ts
+++ b/src/utils/loadEnv.ts
@@ -10,6 +10,8 @@
  *      caller picked on purpose)
  *   3. config/d365fo-mcp.json + config/secrets.json
  *   4. the ambient repo-root .env (pre-wizard installations keep working)
+ *   5. the built-in defaults for path settings, resolved against the
+ *      installation directory (see defaultPathEnv)
  *
  * Multiple instances run from one source folder by pointing each at its own
  * config or .env file:
@@ -26,7 +28,7 @@ import dotenv from 'dotenv';
 import { existsSync } from 'fs';
 import { dirname, isAbsolute, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { resolveConfigFiles, toEnvRecord } from '../config/configFile.js';
+import { defaultPathEnv, resolveConfigFiles, toEnvRecord } from '../config/configFile.js';
 
 /** Env vars whose relative paths should resolve from the .env file directory. */
 const PATH_VARS = ['DB_PATH', 'LABELS_DB_PATH', 'METADATA_PATH'] as const;
@@ -115,6 +117,14 @@ export function loadEnv(callerImportMetaUrl: string): void {
   const files = resolveConfigFiles(envDir);
   for (const [key, value] of Object.entries(toEnvRecord(files))) {
     if (!fromRealEnv.has(key) && !pinnedByEnvFile.has(key)) process.env[key] = value;
+  }
+
+  // Lowest precedence of all: the defaults for the path settings nobody writes
+  // out, anchored to the installation directory rather than process.cwd(). See
+  // defaultPathEnv — without this the index of an npm install is built beside
+  // the package instead of in the directory chosen during setup.
+  for (const [key, value] of Object.entries(defaultPathEnv(files.baseDir))) {
+    if (!process.env[key]) process.env[key] = value;
   }
 
   // Bridge the public D365FO_-prefixed setting name to the internal

--- a/tests/utils/loadEnv.test.ts
+++ b/tests/utils/loadEnv.test.ts
@@ -218,11 +218,15 @@ describe('relative path resolution', () => {
   });
 
   it('leaves an explicit PATH_VAR alone — the default is the lowest precedence', () => {
-    process.env.DB_PATH = 'K:\\d365fo-mcp\\data\\xpp-metadata.db';
+    // A path the surrounding OS agrees is absolute: a drive-letter path is one
+    // on Windows only, and on the Linux CI it would be treated as relative and
+    // resolved against envDir — testing the resolution rule, not this one.
+    const chosen = path.resolve('/chosen-install-dir', 'data', 'xpp-metadata.db');
+    process.env.DB_PATH = chosen;
 
     loadEnv(FAKE_CALLER_URL);
 
-    expect(process.env.DB_PATH).toBe('K:\\d365fo-mcp\\data\\xpp-metadata.db');
+    expect(process.env.DB_PATH).toBe(chosen);
     // The ones nobody set still get the anchored default.
     expect(process.env.METADATA_PATH).toBe(path.resolve('/repo', './extracted-metadata'));
   });

--- a/tests/utils/loadEnv.test.ts
+++ b/tests/utils/loadEnv.test.ts
@@ -204,13 +204,27 @@ describe('relative path resolution', () => {
     expect(process.env.DB_PATH).toBe(path.resolve('/instances/alpha', './data/xpp.db'));
   });
 
-  it('does not change PATH_VARS that are already unset', () => {
-    // No env vars set by dotenv mock → nothing to resolve
+  it('anchors unset PATH_VARS to the installation directory, not process.cwd()', () => {
+    // Nothing configures them: the wizard writes neither, since all three are
+    // advanced settings with defaults. They must still come out absolute and
+    // under the installation directory — leaving them unset made every consumer
+    // fall back to './data/…' against process.cwd(), which for an npm install
+    // is the package directory rather than the directory chosen in setup.
     loadEnv(FAKE_CALLER_URL);
 
-    expect(process.env.DB_PATH).toBeUndefined();
-    expect(process.env.LABELS_DB_PATH).toBeUndefined();
-    expect(process.env.METADATA_PATH).toBeUndefined();
+    expect(process.env.DB_PATH).toBe(path.resolve('/repo', './data/xpp-metadata.db'));
+    expect(process.env.LABELS_DB_PATH).toBe(path.resolve('/repo', './data/xpp-metadata-labels.db'));
+    expect(process.env.METADATA_PATH).toBe(path.resolve('/repo', './extracted-metadata'));
+  });
+
+  it('leaves an explicit PATH_VAR alone — the default is the lowest precedence', () => {
+    process.env.DB_PATH = 'K:\\d365fo-mcp\\data\\xpp-metadata.db';
+
+    loadEnv(FAKE_CALLER_URL);
+
+    expect(process.env.DB_PATH).toBe('K:\\d365fo-mcp\\data\\xpp-metadata.db');
+    // The ones nobody set still get the anchored default.
+    expect(process.env.METADATA_PATH).toBe(path.resolve('/repo', './extracted-metadata'));
   });
 });
 


### PR DESCRIPTION
## What

The metadata index of an npm install was built next to the installed package instead of in the installation directory chosen during `d365fo-mcp setup`.

`DB_PATH`, `LABELS_DB_PATH` and `METADATA_PATH` are advanced settings with relative defaults, so the wizard never writes them into `d365fo-mcp.json`. Nothing then defines them, and every consumer falls back to its own `'./data/…'` literal — which resolves from `process.cwd()`. `rebuildIndex` spawns the index scripts through `runNode`, whose default cwd is `repoRoot` (`src/cli/exec.ts`). For a git checkout that is the repo and the answer is accidentally right; for an npm install it is the package directory under `AppData\Roaming\npm`, on whatever drive npm lives on — and `npm install -g` deletes that directory on the next update.

Reported by a user who pointed setup at a drive with room (K:) and watched the build fill C: and die with:

```
Fatal error: cannot commit - no transaction is active
SqliteError: cannot commit - no transaction is active
    at sqliteTransaction (…/better-sqlite3/lib/methods/transaction.js:69:9)
    at _XppSymbolIndex.indexMetadataDirectory (…/dist/scripts/build-database.js:2048:7)
```

That message is the second half of the problem: a full disk makes SQLite roll the transaction back on its own, so better-sqlite3 then fails to COMMIT and the user sees a stack inside the library with no path and no mention of space.

## How

- **`src/config/configFile.ts`** — new `defaultPathEnv(baseDir)`: the defaults of `path`-typed settings, resolved against the config base dir rather than left for a consumer to resolve against cwd.
- **`src/utils/loadEnv.ts`** — applies them at the lowest precedence of all: real env > `ENV_FILE` .env > config > ambient .env > defaults. All three paths now come out absolute and anchored to the installation directory, for the server and the build scripts alike.
- **`src/cli/commands/indexCmd.ts`** — extract/build run with `cwd` set to the target's own directory (instance dir, else `dataRoot()`), covering the case where no config file exists to anchor anything.
- **`src/metadata/symbolIndex.ts`** — `describeWriteFailure()` wraps a failed model transaction with the model name, the database path, the free space on that drive, and an explanation of where "cannot commit" comes from.

## Reviewer notes

- **A git checkout is unaffected.** `configBaseDir` for `config/d365fo-mcp.json` is the repo root, which is also the old cwd, so every existing checkout keeps exactly its current paths.
- **Existing npm installs move.** After this change `d365fo-mcp index` writes to the installation directory; a partial index already sitting in `…\node_modules\d365fo-mcp\data\` is dead weight and can be deleted. That is the intended correction, not a migration this PR performs.
- `tests/utils/loadEnv.test.ts` had a case (`does not change PATH_VARS that are already unset`) that pinned exactly the buggy behaviour — rewritten to assert the anchored defaults, plus a new case proving an explicit value still wins.
- Full unit suite passes except `tests/packaging/publishedFiles.test.ts`, which fails on `main` too in a tree without `dist/scripts/` (needs `npm run build:scripts`). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
