### PR TITLE
fix(setup): advanced-settings review no longer skips itself

### DIFF
--- a/src/cli/settingsPrompt.ts
+++ b/src/cli/settingsPrompt.ts
@@ -145,16 +145,31 @@ export async function askAdvanced(store: SettingsStore, sections: SectionId[]): 
     return { value: id, label: `${section.title} (${count})`, hint: section.description };
   });
 
-  const picked = ensure(await multiselect<SectionId>({
-    message: 'Which areas do you want to tune? (space selects, Enter confirms)',
-    options,
-    required: false,
-  }));
+  // A confirm submits the instant `y` is pressed, so the Enter a user habitually
+  // types right after it lands on this prompt and submits an empty selection —
+  // the review they just asked for would silently never happen. Never walk past
+  // an empty pick: confirm it, and pre-select everything on the retry so a
+  // second stray Enter reviews all areas instead of skipping again.
+  let initialValues: SectionId[] = [];
+  for (;;) {
+    const picked = ensure(await multiselect<SectionId>({
+      message: 'Which areas do you want to tune? (space selects, Enter confirms)',
+      options,
+      initialValues,
+      required: false,
+    }));
 
-  for (const id of picked) {
-    const section = SECTIONS.find(s => s.id === id)!;
-    p.log.step(`${section.title} — ${section.description}`);
-    await askSettings(store, settingsInSection(id, 'advanced'));
+    if (picked.length > 0) {
+      for (const id of picked) {
+        const section = SECTIONS.find(s => s.id === id)!;
+        p.log.step(`${section.title} — ${section.description}`);
+        await askSettings(store, settingsInSection(id, 'advanced'));
+      }
+      return;
+    }
+
+    if (await askConfirm('Nothing selected — leave every advanced setting at its default?', true)) return;
+    initialValues = available;
   }
 }
 

--- a/tests/cli/settingsPrompt.test.ts
+++ b/tests/cli/settingsPrompt.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The advanced-settings deep dive must not skip itself.
+ *
+ * `confirm` submits the moment `y` is pressed, so the Enter a user types right
+ * after answering "yes" to "Review advanced settings?" arrives at the section
+ * multiselect and submits it with nothing selected. The review the user just
+ * asked for then never happened and setup walked straight on to the index step —
+ * silently, which is what made it look broken rather than mis-answered.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const multiselect = vi.fn();
+const confirm = vi.fn();
+
+vi.mock('@clack/prompts', () => ({
+  multiselect,
+  confirm,
+  text: vi.fn(),
+  password: vi.fn(),
+  select: vi.fn(),
+  isCancel: (v: unknown) => typeof v === 'symbol',
+  cancel: vi.fn(),
+  log: { step: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+const { askAdvanced } = await import('../../src/cli/settingsPrompt.js');
+const { openStore } = await import('../../src/cli/settingsStore.js');
+
+function store() {
+  return openStore(fs.mkdtempSync(join(os.tmpdir(), 'd365fo-prompt-')), null);
+}
+
+beforeEach(() => {
+  multiselect.mockReset();
+  confirm.mockReset();
+});
+
+describe('askAdvanced', () => {
+  it('asks nothing when the gate is declined', async () => {
+    confirm.mockResolvedValueOnce(false);
+    await askAdvanced(store(), ['index']);
+    expect(multiselect).not.toHaveBeenCalled();
+  });
+
+  it('re-offers the sections when an empty selection was not meant as a skip', async () => {
+    confirm
+      .mockResolvedValueOnce(true)   // review advanced settings?
+      .mockResolvedValueOnce(false)  // no, an empty pick was not a skip
+      .mockResolvedValue(false);     // answers for the boolean settings that follow
+    multiselect
+      .mockResolvedValueOnce([])     // the stray Enter
+      .mockResolvedValueOnce(['index']);
+
+    await askAdvanced(store(), ['index']);
+
+    expect(multiselect).toHaveBeenCalledTimes(2);
+    // The retry pre-selects every offered area, so a second stray Enter reviews
+    // them instead of skipping again.
+    expect(multiselect.mock.calls[1][0].initialValues).toEqual(['index']);
+  });
+
+  it('honours an empty selection that the user confirms', async () => {
+    confirm
+      .mockResolvedValueOnce(true)   // review advanced settings?
+      .mockResolvedValueOnce(true);  // yes, leave everything at its default
+    multiselect.mockResolvedValueOnce([]);
+
+    await askAdvanced(store(), ['index']);
+
+    expect(multiselect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Running `npm run setup` and answering **yes** to *"Review advanced settings?"* jumped straight to the index-build question — the review never appeared.

## Cause

Clack's `confirm` submits **the moment `y` is pressed** (`@clack/core` emits `confirm` on the `y`/`n` keystroke and closes the prompt). The Enter a user habitually types right after `y` therefore arrives at the *next* prompt — the section `multiselect` in `askAdvanced` — and submits it with nothing selected. With `required: false`, `for (const id of picked)` iterated zero times and setup silently moved on, so the step looked skipped rather than mis-answered.

## Fix

`src/cli/settingsPrompt.ts` — an empty selection is never treated as a silent skip:

- empty pick → explicit confirm *"Nothing selected — leave every advanced setting at its default?"*
- if the user says no, the multiselect is re-offered with **every area pre-selected**, so a second stray Enter reviews them instead of skipping again.

## Tests

New `tests/cli/settingsPrompt.test.ts` covers the declined gate, the stray Enter → re-offer with `initialValues`, and a genuinely confirmed empty selection. `tsc --noEmit` clean.

## Note on scope

The same stray-Enter propagation can in principle hit any confirm in setup (the Enter after the final "skip" now falls onto the index question). Fixing that globally would need a debounce over stdin on top of clack; this PR fixes the one place where the consequence was a whole step vanishing without a trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
