### PR TITLE
fix(modelClassifier): match EXTENSION_PREFIX case-insensitively

### DIFF
--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -389,9 +389,35 @@ export function isCustomModel(modelName: string): boolean {
   const extensionPrefix = getExtensionPrefix();
 
   const isInCustomList = customModels.some(pattern => matchesPattern(pattern, modelName));
-  const hasExtensionPrefix = !!(extensionPrefix && modelName.startsWith(extensionPrefix));
+  const hasExtensionPrefix = matchesExtensionPrefix(extensionPrefix, modelName);
 
   return isInCustomList || hasExtensionPrefix;
+}
+
+/**
+ * Does `modelName` start with the configured EXTENSION_PREFIX?
+ *
+ * Two deliberate normalizations, both aligning this check with the rest of the file:
+ *
+ *  - **Case-insensitive**, like every other comparison here (CUSTOM_MODELS via
+ *    matchesPattern(), D365FO_MODEL_NAME, applyObjectPrefix()'s double-prefix guards).
+ *    EXTENSION_PREFIX=contoso now recognises a model named ContosoRobotics.
+ *
+ *  - **Trailing '_' stripped**, because getExtensionPrefix() returns EXTENSION_PREFIX raw
+ *    while resolveObjectPrefix() strips it. Model names rarely carry the underscore
+ *    (EXTENSION_PREFIX="XY_" names objects XY_CustTable but the MODEL is usually XyRobotics),
+ *    so matching the raw form only would leave those models classified as standard — the
+ *    exact silent failure this guards against. "XY_" therefore matches both XY_Robotics
+ *    and XyRobotics.
+ *
+ * A prefix of only underscores has no bare form; fall back to the raw value rather than
+ * degenerating into an empty prefix that matches every model.
+ */
+function matchesExtensionPrefix(extensionPrefix: string, modelName: string): boolean {
+  const rawPrefix = extensionPrefix.trim().toLowerCase();
+  if (!rawPrefix) return false;
+  const effective = rawPrefix.replace(/_+$/, '') || rawPrefix;
+  return modelName.toLowerCase().startsWith(effective);
 }
 
 /**

--- a/tests/utils/isCustomModel.test.ts
+++ b/tests/utils/isCustomModel.test.ts
@@ -106,3 +106,66 @@ describe('isCustomModel — existing signals still hold', () => {
     expect(isCustomModel('WHSCustomExtensions')).toBe(true);
   });
 });
+
+/**
+ * #721: the EXTENSION_PREFIX branch was the one case-SENSITIVE comparison in a file
+ * whose every other comparison — and this function's own docstring — is case-insensitive.
+ * The misclassification is silent: the write guard (modifyD365File), the contextRanker
+ * boost and the property-stats miner all read isCustomModel(), so the user only sees a
+ * server behaving as if their model weren't theirs.
+ */
+describe('isCustomModel — EXTENSION_PREFIX matching (#721)', () => {
+  function onlyPrefix(prefix: string): void {
+    process.env.EXTENSION_PREFIX = prefix;
+    delete process.env.D365FO_MODEL_NAME;
+    delete process.env.CUSTOM_MODELS;
+    clearAutoDetectedModels();
+  }
+
+  it('REGRESSION: lowercase prefix matches a PascalCase model', () => {
+    onlyPrefix('contoso');
+    expect(isCustomModel('ContosoRobotics')).toBe(true);
+  });
+
+  it('REGRESSION: uppercase prefix matches a PascalCase model', () => {
+    onlyPrefix('CONTOSO');
+    expect(isCustomModel('ContosoRobotics')).toBe(true);
+  });
+
+  it('mixed-case prefix matches a differently-cased model', () => {
+    onlyPrefix('WhS');
+    expect(isCustomModel('WHSCustomExtensions')).toBe(true);
+  });
+
+  /**
+   * Decision pinned here: getExtensionPrefix() returns EXTENSION_PREFIX raw (underscore
+   * included) while resolveObjectPrefix() strips it, so "XY_" matches BOTH the literal
+   * underscore form and the bare PascalCase form a model name normally uses.
+   */
+  it('underscore-style prefix matches the literal underscore form', () => {
+    onlyPrefix('XY_');
+    expect(isCustomModel('XY_Robotics')).toBe(true);
+  });
+
+  it('underscore-style prefix also matches the bare form of the model name', () => {
+    onlyPrefix('XY_');
+    expect(isCustomModel('XyRobotics')).toBe(true);
+  });
+
+  it('an all-underscore prefix does not match every model', () => {
+    // Stripping would leave an empty prefix, and ''.startsWith() is true for everything.
+    onlyPrefix('_');
+    expect(isCustomModel('ApplicationSuite')).toBe(false);
+  });
+
+  it('still scoped — an unrelated model stays standard', () => {
+    onlyPrefix('contoso');
+    expect(isCustomModel('ApplicationSuite')).toBe(false);
+  });
+
+  it('an empty/whitespace prefix matches nothing', () => {
+    onlyPrefix('   ');
+    expect(isCustomModel('ApplicationSuite')).toBe(false);
+    expect(isCustomModel('ContosoRobotics')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #721.

## Problem

`isCustomModel()` compared `EXTENSION_PREFIX` with a case-**sensitive** `startsWith()` — the one such comparison in a file where everything else is case-insensitive (`CUSTOM_MODELS` via `matchesPattern()`, `D365FO_MODEL_NAME`, `applyObjectPrefix()`'s double-prefix guards), and where the function's own docstring promises "case-insensitive".

So `EXTENSION_PREFIX=contoso` did not recognise a model named `ContosoRobotics`, and it fell through to "standard".

The failure is silent and non-local, because `isStandardModel()` is just the negation:

- the write guard (`src/tools/modifyD365File.ts`) refuses writes to your own model as "standard model";
- the `contextRanker` boost never applies to your own code;
- the property-stats miner mixes your tables into the "what the standard platform does" corpus (#722).

## Fix

One predicate, `matchesExtensionPrefix()`, with two normalizations:

- **case-insensitive**, aligning with the rest of the file;
- **trailing `_` stripped**, because `getExtensionPrefix()` returns `EXTENSION_PREFIX` raw while `resolveObjectPrefix()` strips it. Model names normally don't carry the underscore (`EXTENSION_PREFIX="XY_"` names objects `XY_CustTable`, but the model is usually `XyRobotics`), so matching only the raw form left exactly those models classified as standard. `XY_` now matches both `XY_Robotics` and `XyRobotics` — the decision the issue asked to pin, and it is pinned by tests.

A prefix of only underscores falls back to the raw value instead of degenerating into an empty prefix that matches every model.

## Tests

New cases in `tests/utils/isCustomModel.test.ts`: lowercase/uppercase/mixed-case prefix vs a PascalCase model, both underscore forms, the all-underscore guard, an empty/whitespace prefix, and a scoping check that an unrelated model stays standard. `tests/utils/applyObjectPrefix.test.ts` still green (43 tests), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)