### PR TITLE
fix(property_stats): only mine models Microsoft actually authored

### DIFF
--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -67,6 +67,18 @@ async function buildDatabase() {
   // Create symbol index with separate labels database
   const symbolIndex = new XppSymbolIndex(OUTPUT_DB, OUTPUT_LABELS_DB);
 
+  // The extract phase is the only place that knows which models are non-Microsoft on UDE
+  // (path rule under the custom root; CUSTOM_MODELS is empty there by design). Read the
+  // manifest unconditionally — not just when scoping a `custom` rebuild — so the
+  // property-stats miners never mine our own or an ISV's objects as "standard platform".
+  const extractManifestCustomModels = readExtractedCustomModels(INPUT_PATH);
+  if (extractManifestCustomModels !== undefined) {
+    symbolIndex.setNonMicrosoftModels(extractManifestCustomModels);
+    console.log(kv('Non-MS models', extractManifestCustomModels.length > 0
+      ? c.dim(`${extractManifestCustomModels.length} from extract manifest (excluded from property stats)`)
+      : c.dim('none recorded by extract manifest')));
+  }
+
   // Optimize for bulk loading: use MEMORY journal during build
   log.step('Setting bulk load optimizations (MEMORY journal)...');
   // Close read-pool connections first: SQLite cannot grant locking_mode = EXCLUSIVE
@@ -107,8 +119,8 @@ async function buildDatabase() {
 
     // When CUSTOM_MODELS is empty, bridge the classification from extract-metadata's manifest.
     // `undefined` = no manifest (legacy/blob-download flow); an array (even empty) = the extract
-    // run's authoritative custom set. Read once so we can tell those two apart.
-    const manifestCustomModels = CUSTOM_MODELS.length > 0 ? undefined : readExtractedCustomModels(INPUT_PATH);
+    // run's authoritative custom set. Read above so we can tell those two apart.
+    const manifestCustomModels = CUSTOM_MODELS.length > 0 ? undefined : extractManifestCustomModels;
 
     if (CUSTOM_MODELS.length > 0) {
       // Expand patterns (e.g., "My*" → ["MyModel", "MyFinanceCore", ...])

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -34,6 +34,12 @@ export class XppSymbolIndex {
   // Buffer for property_stats observations — flushed once per model (batch INSERT)
   // Key: "nodeType|property|value|model", Value: accumulated count
   private propStatBuffer: Map<string, number> = new Map();
+  // Per-run "not authored by Microsoft" set (lowercased), supplied by the caller —
+  // see setNonMicrosoftModels(). null = caller said nothing, fall back to isStandardModel().
+  private nonMicrosoftModels: Set<string> | null = null;
+  // isStandardModel() re-parses env on every call and the miners run per node; the
+  // answer is constant per model within a run. Cleared by setNonMicrosoftModels().
+  private mineableModelCache: Map<string, boolean> = new Map();
 
   // Read-only connection pool: WAL mode allows N readers + 1 writer without
   // blocking each other. Pool size: READ_POOL_SIZE env var (default 3, clamped 1-8).
@@ -1991,7 +1997,12 @@ export class XppSymbolIndex {
               node.patternVersion ?? null,
               JSON.stringify(node.childSequence ?? []),
             );
-            if (node.nodePath === 'Design') {
+            // form_patterns rows above are per-model FACTS and are stored for every model;
+            // property_stats is a corpus of "what the standard platform does", so the same
+            // gate as recordTablePropertyStats() applies here. Without it our own forms and
+            // ISV forms skew the mined pattern distribution that generateSmartForm's
+            // defaultFormPattern() picks from — on every environment, not just UDE.
+            if (node.nodePath === 'Design' && this.isMineableModel(model)) {
               this.recordPropertyStat('AxFormDesign', 'Pattern', node.pattern, model);
               this.recordPropertyStat(
                 'AxFormDesign',
@@ -2629,12 +2640,45 @@ export class XppSymbolIndex {
   }
 
   /**
+   * Tell the index which models this run knows to be non-Microsoft, overriding the
+   * name-based `isStandardModel()` heuristic for the property-stats miners.
+   *
+   * `isStandardModel()` reads CUSTOM_MODELS/EXTENSION_PREFIX from the environment, and
+   * `build-database` runs as a separate process where CUSTOM_MODELS is deliberately empty
+   * on UDE (custom models are path-auto-detected during extract — see
+   * src/utils/extractManifest.ts). Without this, our own model and every third-party ISV
+   * model under the custom root are mined as if Microsoft had authored them, and the
+   * mined defaults that `prepare`/`generate_object`/`validate_code` present as platform
+   * convention are really our own past habits fed back to us.
+   *
+   * The list is additive: a model here is never mined, and models not listed still go
+   * through `isStandardModel()`. Pass an empty array to assert "the caller checked and
+   * found none" — that is different from never calling this at all.
+   */
+  setNonMicrosoftModels(models: string[]): void {
+    this.nonMicrosoftModels = new Set(models.map(m => m.toLowerCase()));
+    this.mineableModelCache.clear();
+  }
+
+  /**
+   * Single gate for every property-stats miner: may this model's metadata be mined as
+   * evidence of "what the standard Microsoft platform does"?
+   */
+  private isMineableModel(model: string): boolean {
+    const cached = this.mineableModelCache.get(model);
+    if (cached !== undefined) return cached;
+    const mineable = !this.nonMicrosoftModels?.has(model.toLowerCase()) && isStandardModel(model);
+    this.mineableModelCache.set(model, mineable);
+    return mineable;
+  }
+
+  /**
    * Mine property statistics from one parsed table JSON. Only standard
    * (Microsoft) models are mined — the stats answer "what does the standard
    * platform do", not "what did our customizations do".
    */
   private recordTablePropertyStats(tableData: any, model: string): void {
-    if (!isStandardModel(model)) return;
+    if (!this.isMineableModel(model)) return;
     const presence = (v: unknown) => (v ? '(present)' : '(absent)');
     try {
       // xmlParser defaults label to the table name — same value means no real label

--- a/src/utils/extractManifest.ts
+++ b/src/utils/extractManifest.ts
@@ -29,11 +29,16 @@ export interface ExtractManifest {
    *
    * On UDE this means "non-Microsoft — lives under the custom root", which includes
    * third-party ISV models that ship X++ source. It does NOT mean "models you own" or
-   * "models that are safe to write into": the runtime write guard and the pattern-stats
-   * miner deliberately keep their own name-based `isCustomModel()`/`isStandardModel()`
-   * classification and do not read this manifest. Consumers that need "is this our code"
-   * must not treat this list as an answer to that question — today its only consumer is
-   * `build-database`'s scoping of a `custom` rebuild.
+   * "models that are safe to write into": the runtime write guard keeps its own name-based
+   * `isCustomModel()` classification and does not read this manifest. Consumers that need
+   * "is this our code" must not treat this list as an answer to that question.
+   *
+   * Consumers today, both in `build-database`:
+   *  - scoping of a `custom` rebuild;
+   *  - `XppSymbolIndex.setNonMicrosoftModels()`, which excludes these models from the
+   *    property-stats corpus ("what does the standard platform do"). "Non-Microsoft" is
+   *    exactly the right granularity there — ISV conventions are no more platform
+   *    convention than ours.
    */
   customModels: string[];
 }

--- a/tests/metadata/property-stats-mining-gate.test.ts
+++ b/tests/metadata/property-stats-mining-gate.test.ts
@@ -1,0 +1,206 @@
+/**
+ * #722: which models may be mined into property_stats.
+ *
+ * property_stats is a corpus of "what does the standard Microsoft platform do" — prepare,
+ * generate_object and validate_code present its majority values as platform convention.
+ * Two holes let non-Microsoft code in:
+ *
+ *   1. the table miner's gate is isStandardModel(), which reads CUSTOM_MODELS from the
+ *      environment — empty by design in build-database on UDE, so our own model and every
+ *      third-party ISV model under the custom root were mined as Microsoft's;
+ *   2. the AxFormDesign pattern miner had no gate at all, on any environment.
+ *
+ * Both now run through XppSymbolIndex.isMineableModel(), which honours the non-Microsoft
+ * set that build-database supplies from the extract manifest.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { clearAutoDetectedModels } from '../../src/utils/modelClassifier';
+
+let tmpDir: string;
+const originalCustomModels = process.env.CUSTOM_MODELS;
+const originalPrefix = process.env.EXTENSION_PREFIX;
+const originalModelName = process.env.D365FO_MODEL_NAME;
+
+/** A table whose properties the miner would record: label, table group, index presence. */
+async function writeTable(root: string, model: string, name: string): Promise<void> {
+  const dir = path.join(root, model, 'tables');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.json`), JSON.stringify({
+    name,
+    label: `${name} label`,
+    tableGroup: 'Main',
+    primaryIndex: 'RecIdIdx',
+    fields: [{ name: 'AccountNum', extendedDataType: 'CustAccount' }],
+  }));
+}
+
+/** A form with a Design pattern node — the second miner. */
+async function writeForm(root: string, model: string, name: string, pattern: string): Promise<void> {
+  const dir = path.join(root, model, 'forms');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${name}.json`), JSON.stringify({
+    name,
+    patternNodes: [{ nodePath: 'Design', pattern, patternVersion: '1.1', childSequence: [] }],
+  }));
+}
+
+function statCount(index: XppSymbolIndex, nodeType: string, property: string, model: string): number {
+  const row = index.getReadDb().prepare(
+    'SELECT COALESCE(SUM(count), 0) AS n FROM property_stats WHERE node_type = ? AND property = ? AND model = ?',
+  ).get(nodeType, property, model) as { n: number };
+  return row.n;
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stats-gate-'));
+  // The gate must not depend on ambient env — build-database on UDE has none of these set.
+  delete process.env.CUSTOM_MODELS;
+  delete process.env.EXTENSION_PREFIX;
+  delete process.env.D365FO_MODEL_NAME;
+  clearAutoDetectedModels();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  for (const [k, v] of [
+    ['CUSTOM_MODELS', originalCustomModels],
+    ['EXTENSION_PREFIX', originalPrefix],
+    ['D365FO_MODEL_NAME', originalModelName],
+  ] as const) {
+    if (v === undefined) delete process.env[k]; else process.env[k] = v;
+  }
+  clearAutoDetectedModels();
+});
+
+describe('table property stats', () => {
+  it('mines a Microsoft model', async () => {
+    await writeTable(tmpDir, 'ApplicationSuite', 'CustTable');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ApplicationSuite')).toBe(1);
+    index.close?.();
+  });
+
+  it('REGRESSION: skips a model the caller declared non-Microsoft, with CUSTOM_MODELS empty', async () => {
+    // The UDE shape: nothing in the environment marks ContosoRobotics as ours, so
+    // isStandardModel() says "standard" — only the extract manifest knows better.
+    await writeTable(tmpDir, 'ContosoRobotics', 'ConRoboTable');
+    await writeTable(tmpDir, 'ApplicationSuite', 'CustTable');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.setNonMicrosoftModels(['ContosoRobotics']);
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ContosoRobotics')).toBe(0);
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ApplicationSuite')).toBe(1);
+    index.close?.();
+  });
+
+  it('excludes third-party ISV models too, not just our own', async () => {
+    await writeTable(tmpDir, 'SomeIsvSolution', 'IsvTable');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.setNonMicrosoftModels(['ContosoRobotics', 'SomeIsvSolution']);
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxTable', 'TableGroup', 'SomeIsvSolution')).toBe(0);
+    index.close?.();
+  });
+
+  it('the declared set is matched case-insensitively', async () => {
+    await writeTable(tmpDir, 'ContosoRobotics', 'ConRoboTable');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.setNonMicrosoftModels(['contosorobotics']);
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ContosoRobotics')).toBe(0);
+    index.close?.();
+  });
+
+  it('CUSTOM_MODELS still excludes a model when no set was declared', async () => {
+    process.env.CUSTOM_MODELS = 'ContosoRobotics';
+    await writeTable(tmpDir, 'ContosoRobotics', 'ConRoboTable');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ContosoRobotics')).toBe(0);
+    index.close?.();
+  });
+});
+
+describe('AxFormDesign pattern stats', () => {
+  it('mines a Microsoft model', async () => {
+    await writeForm(tmpDir, 'ApplicationSuite', 'CustTableListPage', 'ListPage');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxFormDesign', 'Pattern', 'ApplicationSuite')).toBe(1);
+    index.close?.();
+  });
+
+  it('REGRESSION: skips a declared non-Microsoft model (this miner had no gate at all)', async () => {
+    await writeForm(tmpDir, 'ContosoRobotics', 'ConRoboForm', 'SimpleList');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.setNonMicrosoftModels(['ContosoRobotics']);
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxFormDesign', 'Pattern', 'ContosoRobotics')).toBe(0);
+    index.close?.();
+  });
+
+  it('REGRESSION: skips a CUSTOM_MODELS model on a traditional environment', async () => {
+    // Not UDE-specific: before the fix, any environment with custom forms skewed the
+    // mined pattern distribution that generateSmartForm falls back to.
+    process.env.CUSTOM_MODELS = 'ContosoRobotics';
+    await writeForm(tmpDir, 'ContosoRobotics', 'ConRoboForm', 'SimpleList');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxFormDesign', 'Pattern', 'ContosoRobotics')).toBe(0);
+    index.close?.();
+  });
+
+  it('form_patterns rows are still recorded for excluded models', async () => {
+    // The gate is about the STATS corpus only — per-model pattern facts stay queryable,
+    // otherwise form_info/cross-checks would lose sight of custom forms entirely.
+    await writeForm(tmpDir, 'ContosoRobotics', 'ConRoboForm', 'SimpleList');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.setNonMicrosoftModels(['ContosoRobotics']);
+    await index.indexMetadataDirectory(tmpDir);
+
+    const row = index.getReadDb().prepare(
+      'SELECT COUNT(*) AS n FROM form_patterns WHERE model = ?',
+    ).get('ContosoRobotics') as { n: number };
+    expect(row.n).toBe(1);
+    index.close?.();
+  });
+});
+
+describe('setNonMicrosoftModels semantics', () => {
+  it('an empty declaration leaves isStandardModel() in charge', async () => {
+    process.env.CUSTOM_MODELS = 'ContosoRobotics';
+    await writeTable(tmpDir, 'ContosoRobotics', 'ConRoboTable');
+    await writeTable(tmpDir, 'ApplicationSuite', 'CustTable');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.setNonMicrosoftModels([]);
+    await index.indexMetadataDirectory(tmpDir);
+
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ContosoRobotics')).toBe(0);
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ApplicationSuite')).toBe(1);
+    index.close?.();
+  });
+});


### PR DESCRIPTION
Fixes #722.

## Problem

`property_stats` is the corpus behind "what does the standard Microsoft platform do" — `prepare`, `generate_object` and `validate_code` present its majority values as platform convention. Two holes let non-Microsoft code in:

1. **`recordTablePropertyStats()` gates on `isStandardModel()`**, which reads `CUSTOM_MODELS` from the environment. In `build-database` on UDE that variable is empty *by design* (custom models are path-auto-detected during extract — see `src/utils/extractManifest.ts`), so our own model and every third-party ISV model under the custom root were mined as if Microsoft had authored them.

2. **The `AxFormDesign` pattern miner had no gate at all** — every model, every environment. Not UDE-specific: any environment with custom forms has been skewing the mined pattern distribution that `generateSmartForm`'s `defaultFormPattern()` picks from.

The failure mode is invisible: the output looks exactly like a legitimately mined default, so the server recommends our own past habits back to us as platform convention. The bigger the custom/ISV footprint, the stronger the loop.

## Fix

- `XppSymbolIndex.setNonMicrosoftModels(models)` gives the index a **per-run** notion of "not authored by Microsoft" that does not depend on env vars (case-insensitive, memoized per model).
- Both miners now share one gate, `isMineableModel()` — so fixing the table miner alone can't leak through the form miner.
- `scripts/build-database.ts` reads the extract manifest **unconditionally** (previously only when scoping a `custom` rebuild) and feeds it in. The extract phase is the one place that knows the truth on UDE. "Non-Microsoft" is the right granularity here: ISV conventions are no more platform convention than ours.

Behaviour is unchanged where nothing is declared — models outside the set still fall through to `isStandardModel()`, and callers that never call the setter (runtime startup indexing, `scripts/test-*`) behave exactly as before. `form_patterns` rows are unaffected: those are per-model *facts*, not corpus, and `form_info`/cross-checks still need them for custom forms.

`src/utils/extractManifest.ts`'s docstring is updated — it previously stated the miner deliberately does not read the manifest.

## Operational note

`property_stats` counts are cumulative (`SUM(count)`), so **an existing database keeps its polluted rows until a full rebuild** (`EXTRACT_MODE=all`). No schema-version mechanism exists in this repo to force that automatically; incremental builds will simply stop adding new pollution.

## Tests

New `tests/metadata/property-stats-mining-gate.test.ts` (10 cases) indexes real temp metadata dirs through `indexMetadataDirectory`, covering: Microsoft model still mined; declared non-Microsoft model skipped with `CUSTOM_MODELS` empty (the UDE shape); ISV models excluded; case-insensitive matching; `CUSTOM_MODELS` path still works with no declaration; both regressions for the form miner (declared set + `CUSTOM_MODELS` on traditional); `form_patterns` rows preserved; empty declaration leaves `isStandardModel()` in charge.

The form-miner regression was verified to fail against the pre-fix `symbolIndex.ts`. `tests/metadata`, `propertyStats`, `smartXmlBuilderMinedDefaults` and `golden/form-pattern-gate` all pass (97 tests); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)