### PR TITLE
feat(build): purge property_stats mined from non-Microsoft models

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,6 +151,8 @@ Dual-database design — symbol searches never scan label rows (**10–30× fast
 
 Each `symbols` row carries enhanced metadata beyond name/type/path: description, semantic tags, source snippet, complexity, used types, extends chain, usage statistics — richer context for generation. Statistical tables (`property_stats`, `form_patterns`) power the data-driven validators and advisors.
 
+`property_stats` is a corpus of **Microsoft-authored models only** — it answers "what does the standard platform do", so mining our own or a third-party ISV's objects would feed our own habits back to us as platform convention. The gate is `XppSymbolIndex.isMineableModel()`, fed by the extract manifest (the only source of truth on UDE, where `CUSTOM_MODELS` is empty by design) plus the name-based `isStandardModel()`. Counts are cumulative, so `build-database` also purges rows that fail today's gate; `npm run purge-property-stats [-- --dry-run]` does the same to an existing database without a rebuild.
+
 Read concurrency: WAL mode, read-connection pool with per-connection prepared-statement caches, 256 MB mmap.
 
 ---

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build-database": "node --max-old-space-size=6144 --import tsx/esm scripts/build-database.ts",
     "build-fts": "node --max-old-space-size=6144 --import tsx/esm scripts/build-fts.ts",
     "index-metadata": "tsx scripts/extract-metadata.ts && node --max-old-space-size=6144 --import tsx/esm scripts/build-database.ts",
+    "purge-property-stats": "tsx scripts/purge-property-stats.ts",
     "blob-manager": "tsx scripts/azure-blob-manager.ts",
     "select-config": "tsx src/cli/index.ts config --xpp-config",
     "test-stdio": "tsx scripts/test-stdio.ts",

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -185,6 +185,15 @@ async function buildDatabase() {
     symbolIndex.clearModels(modelsToRebuild, shouldVacuum);
   }
 
+  // property_stats counts are cumulative, so gating the miners only stops NEW pollution —
+  // rows a previous build wrote for a custom/ISV model survive until deleted. The table is
+  // tiny (one row per node_type/property/value/model), so re-checking it on every build
+  // costs microseconds and needs no reindex.
+  const purged = symbolIndex.purgeNonMineableStats();
+  if (purged.length > 0) {
+    log.info(`Purged property_stats mined from ${purged.length} non-Microsoft model(s): ${purged.slice(0, 10).join(', ')}${purged.length > 10 ? '...' : ''}`);
+  }
+
   // Index the extracted metadata
   console.log('');
   log.step('Indexing metadata...');

--- a/scripts/purge-property-stats.ts
+++ b/scripts/purge-property-stats.ts
@@ -1,0 +1,98 @@
+/**
+ * property_stats Purge Script
+ *
+ * Removes mined property statistics that came from models Microsoft did not author.
+ *
+ * `property_stats` answers "what does the standard platform do" — prepare, generate_object
+ * and validate_code present its majority values as platform convention. Its counts are
+ * cumulative, so gating the miners (see XppSymbolIndex.setNonMicrosoftModels) only stops
+ * NEW pollution: rows an earlier build wrote for your own model or a third-party ISV model
+ * survive until deleted. This script deletes them in place — no reindex, no VACUUM, and it
+ * touches nothing but the property_stats table.
+ *
+ * `npm run build-database` performs the same purge automatically. Use this script to clean
+ * an existing database without waiting for the next build.
+ *
+ * Usage:
+ *   npm run purge-property-stats            # report, then purge
+ *   npm run purge-property-stats -- --dry-run
+ *
+ * Relevant env vars:
+ *   DB_PATH        Path to the SQLite database   (default: ./data/xpp-metadata.db)
+ *   METADATA_PATH  Extracted-metadata dir, read for the extract manifest's custom-model
+ *                  list — the only source of truth on UDE  (default: ./extracted-metadata)
+ *   CUSTOM_MODELS / EXTENSION_PREFIX / D365FO_MODEL_NAME
+ *                  The name-based classification applied to every other model.
+ *
+ * Note: the purge is only as good as the current notion of "non-Microsoft". An ISV model
+ * that neither the extract manifest nor isCustomModel() knows about is NOT removed — add
+ * it to CUSTOM_MODELS and re-run.
+ */
+
+import { loadEnv } from '../src/utils/loadEnv.js';
+loadEnv(import.meta.url);
+import { XppSymbolIndex } from '../src/metadata/symbolIndex.js';
+import { readExtractedCustomModels } from '../src/utils/extractManifest.js';
+import { c, log, kv, shortPath } from '../src/utils/terminalUi.js';
+
+const DB = process.env.DB_PATH || './data/xpp-metadata.db';
+const LABELS_DB = process.env.LABELS_DB_PATH || './data/xpp-metadata-labels.db';
+const METADATA_PATH = process.env.METADATA_PATH || './extracted-metadata';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function observations(index: XppSymbolIndex): number {
+  const row = index.db.prepare('SELECT COALESCE(SUM(count), 0) AS n FROM property_stats').get() as { n: number };
+  return row.n;
+}
+
+async function main(): Promise<void> {
+  console.log('');
+  console.log(kv('Database', shortPath(DB)));
+  console.log(kv('Mode', DRY_RUN ? c.yellow('dry run (nothing deleted)') : c.dim('purge')));
+
+  const index = new XppSymbolIndex(DB, LABELS_DB);
+  try {
+    const manifestModels = readExtractedCustomModels(METADATA_PATH);
+    if (manifestModels !== undefined) {
+      index.setNonMicrosoftModels(manifestModels);
+      console.log(kv('Manifest',c.dim(`${manifestModels.length} non-Microsoft model(s)`)));
+    } else {
+      console.log(kv('Manifest',c.dim('not found — falling back to name-based classification only')));
+    }
+    console.log('');
+
+    const before = observations(index);
+
+    if (DRY_RUN) {
+      const doomed = index.purgeNonMineableStats({ dryRun: true });
+      if (doomed.length === 0) {
+        log.ok('property_stats corpus is already clean — nothing to purge');
+        return;
+      }
+      const placeholders = doomed.map(() => '?').join(',');
+      const row = index.db.prepare(
+        `SELECT COALESCE(SUM(count), 0) AS n FROM property_stats WHERE model IN (${placeholders})`,
+      ).get(...doomed) as { n: number };
+      log.warn(`Would purge ${doomed.length} model(s), ${row.n.toLocaleString('en-US')} of ${before.toLocaleString('en-US')} observations (${(100 * row.n / (before || 1)).toFixed(1)}%)`);
+      for (const m of doomed) log.detail(m);
+      return;
+    }
+
+    const purged = index.purgeNonMineableStats();
+    const after = observations(index);
+
+    if (purged.length === 0) {
+      log.ok('property_stats corpus is already clean — nothing to purge');
+      return;
+    }
+    log.ok(`Purged ${purged.length} model(s): ${(before - after).toLocaleString('en-US')} of ${before.toLocaleString('en-US')} observations removed`);
+    for (const m of purged) log.detail(m);
+  } finally {
+    index.close();
+  }
+}
+
+main().catch(err => {
+  log.err(`Purge failed: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -2673,6 +2673,43 @@ export class XppSymbolIndex {
   }
 
   /**
+   * Delete property_stats rows for models that today's gate would not mine.
+   *
+   * The counts are cumulative (`ON CONFLICT ... count + excluded.count`), so gating the
+   * miners only stops NEW pollution — rows written by an earlier build survive until
+   * something removes them. This is that something, and it is cheap enough to run on every
+   * build: the table is tiny (a few thousand rows, ~150 models on a full D365FO index)
+   * because it stores one row per node_type/property/value/model, not per object.
+   *
+   * Re-evaluates every model actually present in the table rather than only the models
+   * this run was told about, so it also clears historical pollution — e.g. rows mined
+   * before a model was added to CUSTOM_MODELS. It is therefore only as good as the current
+   * notion of "non-Microsoft": an ISV model that neither the extract manifest nor
+   * isStandardModel() knows about stays until it is declared.
+   *
+   * Returns the models purged (empty when the corpus is already clean). With
+   * `{ dryRun: true }` it returns the same list without deleting anything, so callers can
+   * report the damage without duplicating the predicate.
+   */
+  purgeNonMineableStats(opts: { dryRun?: boolean } = {}): string[] {
+    const models = (this.db.prepare('SELECT DISTINCT model FROM property_stats').all() as Array<{ model: string }>)
+      .map(r => r.model);
+    const toPurge = models.filter(m => !this.isMineableModel(m));
+    if (toPurge.length === 0 || opts.dryRun) return toPurge;
+
+    // Chunked to stay clear of SQLITE_MAX_VARIABLE_NUMBER on a pathological model count.
+    const purge = this.db.transaction((names: string[]) => {
+      for (let i = 0; i < names.length; i += 400) {
+        const chunk = names.slice(i, i + 400);
+        const placeholders = chunk.map(() => '?').join(',');
+        this.db.prepare(`DELETE FROM property_stats WHERE model IN (${placeholders})`).run(...chunk);
+      }
+    });
+    purge(toPurge);
+    return toPurge;
+  }
+
+  /**
    * Mine property statistics from one parsed table JSON. Only standard
    * (Microsoft) models are mined — the stats answer "what does the standard
    * platform do", not "what did our customizations do".

--- a/tests/metadata/property-stats-mining-gate.test.ts
+++ b/tests/metadata/property-stats-mining-gate.test.ts
@@ -189,6 +189,108 @@ describe('AxFormDesign pattern stats', () => {
   });
 });
 
+/**
+ * The gate stops NEW pollution, but property_stats counts are cumulative
+ * (ON CONFLICT ... count + excluded.count), so rows an earlier build wrote survive it.
+ * purgeNonMineableStats() is what removes them — cheap enough to run on every build
+ * because the table holds one row per node_type/property/value/model, not per object.
+ */
+describe('purgeNonMineableStats', () => {
+  /** Seed the corpus the way a pre-fix build left it: everything mined, gate or not. */
+  function seedPolluted(index: XppSymbolIndex): void {
+    index.recordPropertyStat('AxTable', 'TableGroup', 'Main', 'ApplicationSuite');
+    index.recordPropertyStat('AxTable', 'TableGroup', 'Main', 'ContosoRobotics');
+    index.recordPropertyStat('AxFormDesign', 'Pattern', 'SimpleList', 'ContosoRobotics');
+    index.recordPropertyStat('AxFormDesign', 'Pattern', 'Custom', 'SomeIsvSolution');
+    index.flushPropertyStats();
+  }
+
+  it('removes rows for declared non-Microsoft models and keeps Microsoft ones', () => {
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    seedPolluted(index);
+
+    index.setNonMicrosoftModels(['ContosoRobotics', 'SomeIsvSolution']);
+    const purged = index.purgeNonMineableStats();
+
+    expect(purged.sort()).toEqual(['ContosoRobotics', 'SomeIsvSolution']);
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ContosoRobotics')).toBe(0);
+    expect(statCount(index, 'AxFormDesign', 'Pattern', 'ContosoRobotics')).toBe(0);
+    expect(statCount(index, 'AxFormDesign', 'Pattern', 'SomeIsvSolution')).toBe(0);
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ApplicationSuite')).toBe(1);
+    index.close?.();
+  });
+
+  it('clears historical pollution the current run was never told about', () => {
+    // The model is not in any declared set — CUSTOM_MODELS alone must be enough, which is
+    // what makes this a cleanup for databases built before the gate existed.
+    process.env.CUSTOM_MODELS = 'ContosoRobotics';
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    seedPolluted(index);
+
+    expect(index.purgeNonMineableStats()).toEqual(['ContosoRobotics']);
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ContosoRobotics')).toBe(0);
+    index.close?.();
+  });
+
+  it('is a no-op on a clean corpus', () => {
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.recordPropertyStat('AxTable', 'TableGroup', 'Main', 'ApplicationSuite');
+    index.flushPropertyStats();
+
+    expect(index.purgeNonMineableStats()).toEqual([]);
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ApplicationSuite')).toBe(1);
+    index.close?.();
+  });
+
+  it('is idempotent — a second run finds nothing left', () => {
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    seedPolluted(index);
+    index.setNonMicrosoftModels(['ContosoRobotics', 'SomeIsvSolution']);
+
+    expect(index.purgeNonMineableStats()).toHaveLength(2);
+    expect(index.purgeNonMineableStats()).toEqual([]);
+    index.close?.();
+  });
+
+  it('dryRun reports the same models without deleting', () => {
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    seedPolluted(index);
+    index.setNonMicrosoftModels(['ContosoRobotics', 'SomeIsvSolution']);
+
+    expect(index.purgeNonMineableStats({ dryRun: true }).sort()).toEqual(['ContosoRobotics', 'SomeIsvSolution']);
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ContosoRobotics')).toBe(1);
+    expect(index.purgeNonMineableStats().sort()).toEqual(['ContosoRobotics', 'SomeIsvSolution']);
+    index.close?.();
+  });
+
+  it('touches only property_stats — symbols and form_patterns survive', async () => {
+    // The purge is corpus hygiene, not a model teardown: clearModels() is the API that
+    // removes a model's data, and confusing the two would silently drop indexed symbols.
+    await writeTable(tmpDir, 'ContosoRobotics', 'ConRoboTable');
+    await writeForm(tmpDir, 'ContosoRobotics', 'ConRoboForm', 'SimpleList');
+
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    await index.indexMetadataDirectory(tmpDir);
+    index.recordPropertyStat('AxTable', 'TableGroup', 'Main', 'ContosoRobotics');
+    index.flushPropertyStats();
+
+    index.setNonMicrosoftModels(['ContosoRobotics']);
+    index.purgeNonMineableStats();
+
+    const symbols = index.getReadDb().prepare(
+      'SELECT COUNT(*) AS n FROM symbols WHERE model = ?',
+    ).get('ContosoRobotics') as { n: number };
+    const patterns = index.getReadDb().prepare(
+      'SELECT COUNT(*) AS n FROM form_patterns WHERE model = ?',
+    ).get('ContosoRobotics') as { n: number };
+
+    expect(symbols.n).toBeGreaterThan(0);
+    expect(patterns.n).toBe(1);
+    expect(statCount(index, 'AxTable', 'TableGroup', 'ContosoRobotics')).toBe(0);
+    index.close?.();
+  });
+});
+
 describe('setNonMicrosoftModels semantics', () => {
   it('an empty declaration leaves isStandardModel() in charge', async () => {
     process.env.CUSTOM_MODELS = 'ContosoRobotics';


### PR DESCRIPTION
Stacked on #742 (base branch is `fix/property-stats-mining-gate`) — it uses the `isMineableModel()` gate that PR introduces. Merge #742 first; the base then retargets to `main` automatically.

Follow-up to the operational note in #742: the mining gate stops *new* pollution, but `property_stats` counts are cumulative, so rows an earlier build wrote survive it.

## Why not just rebuild

Measured on the real 2 GB index: `property_stats` holds **3,302 rows / 145 models / 331,914 observations** — one row per `node_type/property/value/model`, not per object — and it has a `model` column. So the polluted rows are precisely addressable and a `DELETE ... WHERE model IN (...)` is instant. A full rebuild (`EXTRACT_MODE=all`, 30–60 min, and it blocks the MCP server) is the wrong price for that.

## What this adds

- **`XppSymbolIndex.purgeNonMineableStats({ dryRun? })`** — re-evaluates every model actually present in the table against the current gate and deletes the failures. Because it looks at what's *in* the table rather than only at what this run was told about, it also clears **historical** pollution: rows mined before a model was ever added to `CUSTOM_MODELS`. Chunked at 400 params, wrapped in one transaction, idempotent.
- **`build-database` runs it on every build** and reports what it removed.
- **`npm run purge-property-stats`** cleans an existing database with no rebuild; `-- --dry-run` reports using the same predicate.

Scope is deliberately narrow: only `property_stats` rows, never `symbols` or `form_patterns` — `clearModels()` remains the API that removes a model's data, and a test pins that distinction.

## Known limit

The purge is only as good as the current notion of "non-Microsoft". An ISV model that neither the extract manifest nor `isCustomModel()` knows about is **not** removed until it is declared in `CUSTOM_MODELS`. Stated in the script header and in `ARCHITECTURE.md` rather than papered over.

## Verification

Against the real 2 GB index, read-only:

```
  Database .\data\xpp-metadata.db
  Mode     dry run (nothing deleted)
  Manifest 3 non-Microsoft model(s)

  ▲ Would purge 3 model(s), 196 of 331,914 observations (0.1%)
```

6 new cases in `tests/metadata/property-stats-mining-gate.test.ts` (declared set, historical `CUSTOM_MODELS`-only pollution, clean-corpus no-op, idempotence, dry-run, and the "touches only property_stats" guard). 103 tests green across `tests/metadata`, `propertyStats`, `smartXmlBuilderMinedDefaults`, `golden/form-pattern-gate`; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)