### PR TITLE
fix(eval): close the writer defects — a view is a valid datasource, and SyncEngine has no -viewlist

### DIFF
--- a/docs/eval-sweep-findings-2026-07-21.md
+++ b/docs/eval-sweep-findings-2026-07-21.md
@@ -35,6 +35,20 @@ C# edit is worse than an open ticket.
 
 ## Corrected attribution
 
+- **The `-viewlist` finding was misdiagnosed.** It was filed as "tables and views are both put in
+  `-viewlist`; they must be split by object type". Verified on the VM against SyncEngine 7.0.30743
+  / platform 7.0.7858.27: **`-viewlist` is not a SyncEngine argument at all.** The parameter dump
+  lists one `TableOrViewList` (fed by `-synclist`), plus `DropTableOrViewList`,
+  `TableExtensionList`, `CompositeEntityList` and `ADEsList` — no view list of any kind. Passing it
+  prints `Invalid argument -viewlist=<names> specified` and the run **continues** with those names
+  dropped, so the requested view was never synced and nothing failed. The fix is one list, not two;
+  splitting them would have reproduced the original bug in a tidier shape.
+  Two things fell out of that VM run and are fixed alongside it: `trigger_db_sync` scored the
+  outcome by grepping the whole log for `error|failed|exception`, and SyncEngine logs a benign
+  startup warning (`Failed to abort paused PostServiceync resumable index … Invalid column name
+  'DEFERREDOPERATIONSTATE'`) on **every** sync in this environment — so every green run was reported
+  ❌. The verdict now comes from SyncEngine's own completion line, with a rejected argument and an
+  explicit failure line as overrides.
 - **#26 was misfiled** and is NOT overwrite hygiene. There is no backup writer on the
   create/overwrite path at all. The only `.backup-<ts>` writer is `createFileBackup`
   (`modifyD365File.ts`), reached from `ensureRecoverableModification`, which *deliberately* forces

--- a/docs/eval-sweep-findings-2026-07-21.md
+++ b/docs/eval-sweep-findings-2026-07-21.md
@@ -33,20 +33,6 @@ C# edit is worse than an open ticket.
 - Only `fullBuild` runs metadata validation. An incremental build reported 0 errors on a model with
   2 real metadata errors, so `pass@build` from incremental runs is weaker than it looks.
 
-## Open — writers
-
-Three defects the same corpus record (2026-07-22T04__L2-form-over-view) raised alongside #37,
-never separately filed:
-
-- `generate_object(scaffold, form)` resolves `dataSource` against TABLES only, so a form over a
-  VIEW fails with "not found in the symbol index" even after `update_symbol_index`.
-  `object_patterns` resolves the same view fine — the defect is the scaffold's own lookup.
-- `d365fo_file(create, objectType="view")` defaults each `AxViewFieldBound` `<DataSource>` to the
-  QUERY name instead of the query's root data source name. Passing `fields[].dataSource`
-  explicitly works — only the default is wrong.
-- `trigger_db_sync(tables=[…], syncViews=true)` puts BOTH tables and views in `-viewlist`;
-  SyncEngine aborts with "Invalid argument -viewlist=…". They must be split by object type.
-
 ## Corrected attribution
 
 - **#26 was misfiled** and is NOT overwrite hygiene. There is no backup writer on the

--- a/src/server/toolSchemas/triggerDbSync.ts
+++ b/src/server/toolSchemas/triggerDbSync.ts
@@ -18,11 +18,11 @@ export const triggerDbSyncTool = {
         tables: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Partial sync: sync only these tables (faster). Example: ["CustTable", "MyNewTable"]. Omit for full-model sync.',
+          description: 'Partial sync: sync only these tables/views (faster). Example: ["CustTable", "MyNewTable"]. Views may be listed here too — they are routed to the view list automatically. Omit for full-model sync.',
         },
         tableName: { type: 'string', description: 'Single-table shorthand — equivalent to tables=["tableName"]. Kept for backwards compatibility.' },
         projectPath: { type: 'string', description: 'Path to .rnrproj file. Auto-extracts table/view names for partial sync. Auto-detected from .mcp.json when no explicit tables given.' },
-        syncViews: { type: 'boolean', description: 'Also sync views and data entities. Required after creating/modifying data entities. Default: false.' },
+        syncViews: { type: 'boolean', description: 'FULL sync only: also sync views and data entities. Ignored for partial sync, where views are routed by name. Default: false.' },
         connectionString: { type: 'string', description: 'SQL Server connection string. Default: "Data Source=localhost;Initial Catalog=AxDB;Integrated Security=True".' },
         packagePath: { type: 'string', description: 'PackagesLocalDirectory root. Auto-detected from .mcp.json if omitted.' },
       },

--- a/src/server/toolSchemas/triggerDbSync.ts
+++ b/src/server/toolSchemas/triggerDbSync.ts
@@ -18,11 +18,11 @@ export const triggerDbSyncTool = {
         tables: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Partial sync: sync only these tables/views (faster). Example: ["CustTable", "MyNewTable"]. Views may be listed here too — they are routed to the view list automatically. Omit for full-model sync.',
+          description: 'Partial sync: sync only these tables/views (faster). Example: ["CustTable", "MyNewView"]. Views and data entities go in this same list. Omit for full-model sync.',
         },
         tableName: { type: 'string', description: 'Single-table shorthand — equivalent to tables=["tableName"]. Kept for backwards compatibility.' },
         projectPath: { type: 'string', description: 'Path to .rnrproj file. Auto-extracts table/view names for partial sync. Auto-detected from .mcp.json when no explicit tables given.' },
-        syncViews: { type: 'boolean', description: 'FULL sync only: also sync views and data entities. Ignored for partial sync, where views are routed by name. Default: false.' },
+        syncViews: { type: 'boolean', description: 'FULL sync only: use syncmode FullAllAndViews. Not needed for partial sync — name the view in tables[] instead. Default: false.' },
         connectionString: { type: 'string', description: 'SQL Server connection string. Default: "Data Source=localhost;Initial Catalog=AxDB;Integrated Security=True".' },
         packagePath: { type: 'string', description: 'PackagesLocalDirectory root. Auto-detected from .mcp.json if omitted.' },
       },

--- a/src/tools/dbSync.ts
+++ b/src/tools/dbSync.ts
@@ -7,11 +7,21 @@ import { withOperationLock } from '../utils/operationLocks.js';
 import { lookupSymbolNocase, type DbLike } from '../utils/symbolLookup.js';
 
 /**
- * AOT folders that map to syncable DB objects, and which SyncEngine list each
- * one belongs in. `-synclist` takes tables; `-viewlist` takes views and data
- * entity views. SyncEngine aborts with "Invalid argument -viewlist=…" when a
- * table name appears in the view list, so the split is not cosmetic
- * (docs/eval-sweep-findings-2026-07-21.md, "Open — writers").
+ * AOT folders that map to syncable DB objects, and what kind of object each one
+ * holds.
+ *
+ * There is NO separate view list: SyncEngine takes tables and views in the same
+ * `-synclist`, which it reports back as `TableOrViewList`. `-viewlist` is not a
+ * SyncEngine argument at all — passing it prints
+ *
+ *     Invalid argument -viewlist=<names> specified
+ *
+ * and the run CONTINUES with those names silently dropped, so a requested view
+ * was never synced and nothing failed. Verified 2026-07-22 against SyncEngine
+ * 7.0.30743 / platform 7.0.7858.27 on the dev VM; the parameter dump lists
+ * TableOrViewList, DropTableOrViewList, TableExtensionList, CompositeEntityList
+ * and ADEsList, and no view list of any kind. The `kind` below therefore only
+ * drives what the tool REPORTS, never argument routing.
  */
 const SYNCABLE_AOT_FOLDERS = new Map<string, SyncKind>([
   ['AxTable', 'table'],
@@ -21,10 +31,10 @@ const SYNCABLE_AOT_FOLDERS = new Map<string, SyncKind>([
   ['AxDataEntityViewExtension', 'view'],
 ]);
 
-/** Which SyncEngine list an object belongs in. */
+/** What kind of object a sync target is — reported, not routed on. */
 type SyncKind = 'table' | 'view';
 
-/** A syncable object plus the list it belongs in. */
+/** A syncable object plus what kind it is. */
 interface SyncTarget {
   name: string;
   kind: SyncKind;
@@ -160,14 +170,10 @@ export async function extractTablesFromProject(projectPath: string): Promise<Syn
 }
 
 /**
- * Classify explicitly named objects into the table/view lists using the symbol
- * index. Unknown names stay tables: that is the pre-existing behaviour and the
- * only safe default for an object created this session and not yet indexed —
- * SyncEngine ignores a name it cannot resolve in `-synclist`, but rejects the
- * whole invocation when `-viewlist` names a non-view.
- *
- * Returns the classified targets plus any names the index could not resolve, so
- * the caller can say so instead of silently guessing.
+ * Label explicitly named objects as table or view using the symbol index, so the
+ * tool can report what it actually synced. Both kinds go into the same
+ * `-synclist`, so a wrong label costs nothing but an inaccurate summary; an
+ * unknown name is reported as such rather than silently called a table.
  */
 export function classifySyncTargets(
   names: string[],
@@ -205,6 +211,74 @@ async function checkStaticMetadata(packagesRoot: string, modelName: string): Pro
       '  Right-click project → Rebuild\n' +
       'Then retry db sync.';
   }
+}
+
+/**
+ * Build the SyncEngine command line. Pure, so the argument shape can be gated by
+ * a test instead of only by a 3-minute run against a live AxDB.
+ *
+ * `targets` empty ⇒ full sync. Tables and views share `-synclist`; `-viewlist`
+ * must never appear (see SYNCABLE_AOT_FOLDERS for the verified reason).
+ */
+export function buildSyncEngineArgs(opts: {
+  targets: SyncTarget[];
+  syncViews: boolean;
+  metadataBinPath: string;
+  connStr: string;
+}): string[] {
+  const isPartial = opts.targets.length > 0;
+  const syncMode = isPartial
+    ? 'PartialList'
+    : opts.syncViews ? 'FullAllAndViews' : 'FullAll';
+
+  const args = [
+    `-syncmode=${syncMode}`,
+    `-metadatabinaries=${opts.metadataBinPath}`,
+    `-connect=${opts.connStr}`,
+  ];
+  if (isPartial) {
+    args.push(`-synclist=${opts.targets.map(t => t.name).join(',')}`);
+  } else {
+    // Only for a full sync — verbose diagnostics add real overhead.
+    args.push('-verbosediagnostics');
+  }
+  return args;
+}
+
+/**
+ * Decide whether a SyncEngine run actually succeeded.
+ *
+ * The old test — "any line contains error/failed/exception" — reported ❌ for a
+ * sync that completed cleanly, because SyncEngine logs a benign startup warning
+ * on this environment (`Log level - Warning | Failed to abort paused
+ * PostServiceync resumable index from last run: SqlException … Invalid column
+ * name 'DEFERREDOPERATIONSTATE'`) before it does any work. Every partial sync on
+ * this VM tripped it, so a green run was indistinguishable from a red one.
+ *
+ * SyncEngine states its own verdict: it prints `<SyncMode> finished` and
+ * `Sync finished and took <n> milliseconds` only on a completed run. Take that
+ * as the signal, and keep two overrides that a completion line must not hide:
+ * a rejected argument (which is silently ignored — how the bogus `-viewlist`
+ * went unnoticed) and an explicit failure/abort line.
+ */
+export function classifySyncOutcome(rawOutput: string): { succeeded: boolean; reason: string } {
+  const invalidArg = rawOutput.match(/^.*Invalid argument .*$/mi)?.[0]?.trim();
+  if (invalidArg) {
+    // SyncEngine drops the argument and carries on, so this never fails the run
+    // on its own — the caller must be told the request was not honoured.
+    return { succeeded: false, reason: `SyncEngine rejected an argument: ${invalidArg}` };
+  }
+  const hardFailure = rawOutput.match(
+    /^.*\b(sync failed|synchronization failed|aborting sync|unhandled exception|fatal error)\b.*$/mi,
+  )?.[0]?.trim();
+  if (hardFailure) {
+    return { succeeded: false, reason: hardFailure };
+  }
+  const completed = /\bSync finished and took\b/i.test(rawOutput)
+    || /\b(PartialList|FullAll|FullAllAndViews|PartialTables|FullTables) finished\b/i.test(rawOutput);
+  return completed
+    ? { succeeded: true, reason: 'SyncEngine reported completion' }
+    : { succeeded: false, reason: 'SyncEngine never reported completion' };
 }
 
 /** Truncate output to avoid huge MCP responses. */
@@ -299,39 +373,13 @@ export const dbSyncTool = async (params: any, context: any) => {
 
     // SyncEngine needs the PackagesLocalDirectory root — it reads StaticMetadata
     // from every model's bin folder, not just the current model's.
-    const metadataBinPath = packagesRoot;
-    const connStr = params.connectionString
-      || 'Data Source=localhost;Initial Catalog=AxDB;Integrated Security=True';
-
-    let syncMode: string;
-    if (isPartial) {
-      syncMode = 'PartialList';
-    } else if (syncViews) {
-      syncMode = 'FullAllAndViews';
-    } else {
-      syncMode = 'FullAll';
-    }
-
-    const args: string[] = [
-      `-syncmode=${syncMode}`,
-      `-metadatabinaries=${metadataBinPath}`,
-      `-connect=${connStr}`,
-    ];
-    // Only add verbosediagnostics for full sync (adds overhead)
-    if (!isPartial) {
-      args.push('-verbosediagnostics');
-    }
-    if (isPartial) {
-      // Tables and views go in SEPARATE lists. Putting a table name in -viewlist
-      // makes SyncEngine abort with "Invalid argument -viewlist=…", so an empty
-      // side is omitted entirely rather than mirrored from the other one.
-      if (partialTables.length > 0) {
-        args.push(`-synclist=${partialTables.join(',')}`);
-      }
-      if (partialViews.length > 0) {
-        args.push(`-viewlist=${partialViews.join(',')}`);
-      }
-    }
+    const args = buildSyncEngineArgs({
+      targets: syncTargets,
+      syncViews,
+      metadataBinPath: packagesRoot,
+      connStr: params.connectionString
+        || 'Data Source=localhost;Initial Catalog=AxDB;Integrated Security=True',
+    });
 
     console.error(`[trigger_db_sync] Running: "${syncEnginePath}" ${maskConnectArgs(args).join(' ')}`);
 
@@ -350,8 +398,8 @@ export const dbSyncTool = async (params: any, context: any) => {
 
     const rawOutput = [stdout, stderr].filter(Boolean).join('\n').trim();
     const output = truncateOutput(rawOutput);
-    const hasErrors = /\b(error|failed|exception)\b/i.test(rawOutput) &&
-      !/0 error/i.test(rawOutput);  // "0 errors" is success
+    const verdict = classifySyncOutcome(rawOutput);
+    const hasErrors = !verdict.succeeded;
 
     const scopeParts: string[] = [];
     if (partialTables.length > 0) {
@@ -360,11 +408,12 @@ export const dbSyncTool = async (params: any, context: any) => {
     if (partialViews.length > 0) {
       scopeParts.push(`${partialViews.length} view(s): ${partialViews.join(', ')}`);
     }
-    // Say so when a name was synced as a table only because the index had never
-    // heard of it — the alternative is a silent misclassification.
+    // Names the index has never seen are still passed to SyncEngine (it resolves
+    // against the compiled metadata, not our index), but say so — a typo and a
+    // genuinely new object look identical from here.
     const unresolvedNote = unresolvedNames.length > 0
-      ? `\n⚠️ Not in the symbol index, synced as table(s): ${unresolvedNames.join(', ')}.` +
-        ' If any of these is a view, run `update_symbol_index` first.'
+      ? `\n⚠️ Not in the symbol index — synced anyway, but unverifiable from here: ` +
+        `${unresolvedNames.join(', ')}. Run \`update_symbol_index\` if these are new objects.`
       : '';
     const scopeDesc = isPartial
       ? `Partial sync — ${scopeParts.join('; ')}` +
@@ -375,7 +424,7 @@ export const dbSyncTool = async (params: any, context: any) => {
     return {
       content: [{
         type: 'text',
-        text: (hasErrors ? '❌ DB Sync failed' : '✅ DB Sync completed') +
+        text: (hasErrors ? `❌ DB Sync failed — ${verdict.reason}` : '✅ DB Sync completed') +
           ` (${elapsedSec}s)` +
           `\n\n${scopeDesc}` +
           `\n\n${output || '(no output)'}`

--- a/src/tools/dbSync.ts
+++ b/src/tools/dbSync.ts
@@ -4,11 +4,31 @@ import fs from 'fs/promises';
 import { Parser } from 'xml2js';
 import { getConfigManager } from '../utils/configManager.js';
 import { withOperationLock } from '../utils/operationLocks.js';
+import { lookupSymbolNocase, type DbLike } from '../utils/symbolLookup.js';
 
-/** AOT folders that map to syncable DB objects (tables, table extensions, views, data entities). */
-const SYNCABLE_AOT_FOLDERS = new Set([
-  'AxTable', 'AxTableExtension', 'AxView', 'AxDataEntityView', 'AxDataEntityViewExtension',
+/**
+ * AOT folders that map to syncable DB objects, and which SyncEngine list each
+ * one belongs in. `-synclist` takes tables; `-viewlist` takes views and data
+ * entity views. SyncEngine aborts with "Invalid argument -viewlist=…" when a
+ * table name appears in the view list, so the split is not cosmetic
+ * (docs/eval-sweep-findings-2026-07-21.md, "Open — writers").
+ */
+const SYNCABLE_AOT_FOLDERS = new Map<string, SyncKind>([
+  ['AxTable', 'table'],
+  ['AxTableExtension', 'table'],
+  ['AxView', 'view'],
+  ['AxDataEntityView', 'view'],
+  ['AxDataEntityViewExtension', 'view'],
 ]);
+
+/** Which SyncEngine list an object belongs in. */
+type SyncKind = 'table' | 'view';
+
+/** A syncable object plus the list it belongs in. */
+interface SyncTarget {
+  name: string;
+  kind: SyncKind;
+}
 
 /** Max output length returned to the client (characters). */
 const MAX_OUTPUT_LENGTH = 8_000;
@@ -105,15 +125,17 @@ function runWithStreaming(
 }
 
 /**
- * Extract table/view names from a .rnrproj project file.
- * Looks for Content Include entries like "AxTable\MyTable", "AxTableExtension\MyExt", etc.
+ * Extract syncable object names from a .rnrproj project file, tagged with the
+ * SyncEngine list they belong in. Looks for Content Include entries like
+ * "AxTable\MyTable", "AxView\MyView", "AxTableExtension\MyExt", etc. — the AOT
+ * folder is authoritative for the table/view split.
  */
-async function extractTablesFromProject(projectPath: string): Promise<string[]> {
+export async function extractTablesFromProject(projectPath: string): Promise<SyncTarget[]> {
   const parser = new Parser({ explicitArray: true });
   const xml = await fs.readFile(projectPath, 'utf-8');
   const parsed = await parser.parseStringPromise(xml);
 
-  const tables: string[] = [];
+  const targets: SyncTarget[] = [];
   const itemGroups: any[] = parsed?.Project?.ItemGroup ?? [];
   for (const group of itemGroups) {
     const contents: any[] = Array.isArray(group.Content) ? group.Content : [];
@@ -123,17 +145,49 @@ async function extractTablesFromProject(projectPath: string): Promise<string[]> 
       // Format: "AxTable\MyTableName" or "AxTableExtension\SomeExt"
       const sep = inc.includes('\\') ? '\\' : inc.includes('/') ? '/' : '\\';
       const parts = inc.split(sep);
-      if (parts.length >= 2 && SYNCABLE_AOT_FOLDERS.has(parts[0])) {
+      const kind = parts.length >= 2 ? SYNCABLE_AOT_FOLDERS.get(parts[0]) : undefined;
+      if (kind) {
         // For extensions like "CustTable.MyExt", extract base table name
         const objectName = parts[1];
         const baseName = objectName.includes('.') ? objectName.split('.')[0] : objectName;
-        if (baseName && !tables.includes(baseName)) {
-          tables.push(baseName);
+        if (baseName && !targets.some(t => t.name === baseName)) {
+          targets.push({ name: baseName, kind });
         }
       }
     }
   }
-  return tables;
+  return targets;
+}
+
+/**
+ * Classify explicitly named objects into the table/view lists using the symbol
+ * index. Unknown names stay tables: that is the pre-existing behaviour and the
+ * only safe default for an object created this session and not yet indexed —
+ * SyncEngine ignores a name it cannot resolve in `-synclist`, but rejects the
+ * whole invocation when `-viewlist` names a non-view.
+ *
+ * Returns the classified targets plus any names the index could not resolve, so
+ * the caller can say so instead of silently guessing.
+ */
+export function classifySyncTargets(
+  names: string[],
+  db: DbLike | undefined,
+): { targets: SyncTarget[]; unresolved: string[] } {
+  const targets: SyncTarget[] = [];
+  const unresolved: string[] = [];
+  for (const name of names) {
+    let kind: SyncKind = 'table';
+    if (db) {
+      const hit = lookupSymbolNocase(db, name, ['table', 'view']);
+      if (hit) {
+        kind = hit.type === 'view' ? 'view' : 'table';
+      } else {
+        unresolved.push(name);
+      }
+    }
+    targets.push({ name, kind });
+  }
+  return { targets, unresolved };
 }
 
 /**
@@ -165,7 +219,7 @@ function truncateOutput(text: string): string {
 // Tool registration (name, description, inputSchema) lives inline in
 // src/server/mcpServer.ts - the single source of truth for tool instructions.
 
-export const dbSyncTool = async (params: any, _context: any) => {
+export const dbSyncTool = async (params: any, context: any) => {
   const { syncViews = false } = params;
   try {
     const configManager = getConfigManager();
@@ -200,24 +254,37 @@ export const dbSyncTool = async (params: any, _context: any) => {
       console.error(`[trigger_db_sync] ${metadataWarning}`);
     }
 
-    // Resolve table list: explicit tables[]/tableName > projectPath extraction > full sync
-    let tableList: string[] = [
+    // Resolve object list: explicit tables[]/tableName > projectPath extraction > full sync
+    const explicitNames: string[] = [
       ...(params.tables ?? []),
       ...(params.tableName ? [params.tableName] : []),
     ].filter((t: string) => t.trim().length > 0);
 
+    let syncTargets: SyncTarget[] = [];
+    let unresolvedNames: string[] = [];
     let projectExtracted = false;
-    if (tableList.length === 0) {
-      // Try to extract tables from project file for smart partial sync
+    if (explicitNames.length > 0) {
+      // The caller names objects without saying what they are; the symbol index
+      // decides which SyncEngine list each belongs in.
+      let db: DbLike | undefined;
+      try {
+        db = context?.symbolIndex?.getReadDb?.();
+      } catch {
+        /* index unavailable — everything falls back to the table list */
+      }
+      ({ targets: syncTargets, unresolved: unresolvedNames } =
+        classifySyncTargets(explicitNames, db));
+    } else {
+      // Try to extract syncable objects from the project file for smart partial sync
       const projectPath = params.projectPath || await configManager.getProjectPath();
       if (projectPath) {
         try {
           await fs.access(projectPath);
           const extracted = await extractTablesFromProject(projectPath);
           if (extracted.length > 0) {
-            tableList = extracted;
+            syncTargets = extracted;
             projectExtracted = true;
-            console.error(`[trigger_db_sync] Extracted ${extracted.length} syncable objects from project: ${extracted.join(', ')}`);
+            console.error(`[trigger_db_sync] Extracted ${extracted.length} syncable objects from project: ${extracted.map(t => t.name).join(', ')}`);
           }
         } catch (e: any) {
           console.error(`[trigger_db_sync] Could not read project file ${projectPath}: ${e.message}`);
@@ -226,7 +293,9 @@ export const dbSyncTool = async (params: any, _context: any) => {
       }
     }
 
-    const isPartial = tableList.length > 0;
+    const partialTables = syncTargets.filter(t => t.kind === 'table').map(t => t.name);
+    const partialViews = syncTargets.filter(t => t.kind === 'view').map(t => t.name);
+    const isPartial = syncTargets.length > 0;
 
     // SyncEngine needs the PackagesLocalDirectory root — it reads StaticMetadata
     // from every model's bin folder, not just the current model's.
@@ -253,9 +322,14 @@ export const dbSyncTool = async (params: any, _context: any) => {
       args.push('-verbosediagnostics');
     }
     if (isPartial) {
-      args.push(`-synclist=${tableList.join(',')}`);
-      if (syncViews) {
-        args.push(`-viewlist=${tableList.join(',')}`);
+      // Tables and views go in SEPARATE lists. Putting a table name in -viewlist
+      // makes SyncEngine abort with "Invalid argument -viewlist=…", so an empty
+      // side is omitted entirely rather than mirrored from the other one.
+      if (partialTables.length > 0) {
+        args.push(`-synclist=${partialTables.join(',')}`);
+      }
+      if (partialViews.length > 0) {
+        args.push(`-viewlist=${partialViews.join(',')}`);
       }
     }
 
@@ -279,10 +353,23 @@ export const dbSyncTool = async (params: any, _context: any) => {
     const hasErrors = /\b(error|failed|exception)\b/i.test(rawOutput) &&
       !/0 error/i.test(rawOutput);  // "0 errors" is success
 
+    const scopeParts: string[] = [];
+    if (partialTables.length > 0) {
+      scopeParts.push(`${partialTables.length} table(s): ${partialTables.join(', ')}`);
+    }
+    if (partialViews.length > 0) {
+      scopeParts.push(`${partialViews.length} view(s): ${partialViews.join(', ')}`);
+    }
+    // Say so when a name was synced as a table only because the index had never
+    // heard of it — the alternative is a silent misclassification.
+    const unresolvedNote = unresolvedNames.length > 0
+      ? `\n⚠️ Not in the symbol index, synced as table(s): ${unresolvedNames.join(', ')}.` +
+        ' If any of these is a view, run `update_symbol_index` first.'
+      : '';
     const scopeDesc = isPartial
-      ? `Partial sync — ${tableList.length} table(s): ${tableList.join(', ')}` +
+      ? `Partial sync — ${scopeParts.join('; ')}` +
         (projectExtracted ? ' (extracted from project)' : '') +
-        (syncViews ? ' + views' : '')
+        unresolvedNote
       : `Full sync — model: ${modelName}${syncViews ? ' (tables + views)' : ''}`;
 
     return {

--- a/src/tools/generateSmartForm.ts
+++ b/src/tools/generateSmartForm.ts
@@ -24,6 +24,12 @@ import { findBaseFormXml } from './modifyD365File.js';
 import { getFieldControlMap, getTableTitleField, type FieldControlMap } from '../utils/fieldControlTypes.js';
 import { lookupSymbolNocase } from '../utils/symbolLookup.js';
 
+/**
+ * Symbol types a form datasource may bind to. Views are indexed as 'view'
+ * (see symbolIndex.indexViews) and are legal in <Table> just like tables.
+ */
+const DATASOURCE_TYPES = ['table', 'view'] as const;
+
 interface GenerateSmartFormArgs {
   name: string;
   label?: string;
@@ -259,6 +265,8 @@ export async function handleGenerateSmartForm(
   const builder = new SmartXmlBuilder(symbolIndex);
   let dataSources: FormDataSourceSpec[] = [];
   let controls: FormControlSpec[] = [];
+  /** Note surfaced when the primary datasource resolved to a view, not a table. */
+  let viewDataSourceNote = '';
 
   // Strategy 1: copy datasources from an existing form
   if (copyFrom) {
@@ -309,13 +317,19 @@ export async function handleGenerateSmartForm(
   if (dataSource && !copyFrom) {
     // Validates the table exists and fuzzy-corrects pluralisation (e.g. "...Tables" -> "...Table").
     let dataSourceResolved = dataSource;
+    // A form datasource may be a VIEW as well as a table — the AOT accepts any of
+    // them in <Table>. Resolving against 'table' alone rejected a view that
+    // object_patterns resolves fine, so a form over a view was unbuildable through
+    // the scaffold (docs/eval-sweep-findings-2026-07-21.md, "Open — writers").
+    let dataSourceIsView = false;
     try {
       const db = symbolIndex.getReadDb();
       // Index-safe nocase lookup; also canonicalizes the casing so the field
       // probes below stay BINARY on idx_parent_type_name.
-      const directHit = lookupSymbolNocase(db, dataSource, ['table']);
+      const directHit = lookupSymbolNocase(db, dataSource, DATASOURCE_TYPES);
       if (directHit) {
         dataSourceResolved = directHit.name;
+        dataSourceIsView = directHit.type === 'view';
       } else {
         const add = (n: string | undefined) => {
           const v = (n ?? '').trim();
@@ -325,21 +339,22 @@ export async function handleGenerateSmartForm(
         add(dataSource.replace(/s$/i, ''));
         add(dataSource.replace(/Tables?$/i, 'Table'));
         add(dataSource.replace(/Table$/i, ''));
-        const matched = candidates
-          .map(c => lookupSymbolNocase(db, c, ['table']))
-          .find(r => r)?.name;
-        if (matched) {
-          console.log(`[generateSmartForm] dataSource "${dataSource}" → "${matched}" (auto-corrected)`);
-          dataSourceResolved = matched;
+        const matchedHit = candidates
+          .map(c => lookupSymbolNocase(db, c, DATASOURCE_TYPES))
+          .find(r => r);
+        if (matchedHit) {
+          console.log(`[generateSmartForm] dataSource "${dataSource}" → "${matchedHit.name}" (auto-corrected)`);
+          dataSourceResolved = matchedHit.name;
+          dataSourceIsView = matchedHit.type === 'view';
         } else {
           const alt = db.prepare(
-            `SELECT name FROM symbols WHERE type = 'table' AND name LIKE ? COLLATE NOCASE ORDER BY LENGTH(name) ASC LIMIT 1`,
+            `SELECT name FROM symbols WHERE type IN ('table', 'view') AND name LIKE ? COLLATE NOCASE ORDER BY LENGTH(name) ASC LIMIT 1`,
           ).get(`${dataSource.replace(/s$/i, '')}%`) as { name: string } | undefined;
           const suggestion = alt ? `\n\nDid you mean \`dataSource="${alt.name}"\`?` : '';
           return {
             content: [{
               type: 'text',
-              text: `❌ Table "${dataSource}" not found in the symbol index.${suggestion}\n\nIf the table was just created in this session, call \`update_symbol_index\` first, then retry.`,
+              text: `❌ Table or view "${dataSource}" not found in the symbol index.${suggestion}\n\nIf the object was just created in this session, call \`update_symbol_index\` first, then retry.`,
             }],
           };
         }
@@ -348,7 +363,9 @@ export async function handleGenerateSmartForm(
       /* index unavailable — proceed with provided name */
     }
 
-    console.log(`[generateSmartForm] Creating datasource for table: ${dataSourceResolved}`);
+    console.log(
+      `[generateSmartForm] Creating datasource for ${dataSourceIsView ? 'view' : 'table'}: ${dataSourceResolved}`,
+    );
     dataSources.push({
       name: dataSourceResolved,
       table: dataSourceResolved,
@@ -356,6 +373,14 @@ export async function handleGenerateSmartForm(
       allowCreate: true,
       allowDelete: true,
     });
+    if (dataSourceIsView) {
+      // The pattern templates do not carry AllowCreate/Edit/Delete, so the emitted
+      // datasource keeps the writable default. A view is read-only at runtime —
+      // say so rather than let the caller assume an editable grid.
+      viewDataSourceNote =
+        `\n   ℹ️ "${dataSourceResolved}" is a VIEW — read-only at runtime. Set ` +
+        `AllowCreate/AllowEdit/AllowDelete to No on the datasource if the form must not offer editing.`;
+    }
 
     if (formPattern) {
       try {
@@ -636,7 +661,7 @@ export async function handleGenerateSmartForm(
     : builder.defaultFormPattern();
   const primaryDs = dataSources[0];
   let xml: string;
-  let cloneNotes = linesTableNote;
+  let cloneNotes = linesTableNote + viewDataSourceNote;
 
   if (cloneFrom) {
     const sourceXml = await findBaseFormXml(cloneFrom, symbolIndex);
@@ -790,7 +815,7 @@ export async function handleGenerateSmartForm(
     // Pattern-compatibility pre-check (see cloneFromPatternMismatchWarning).
     const mismatch = cloneFromPatternMismatchWarning(formPattern, xml, cloneResult.sourceFormName);
     if (mismatch) noteLines.push(`   ${mismatch}`);
-    cloneNotes = `\n${noteLines.join('\n')}`;
+    cloneNotes = `${viewDataSourceNote}\n${noteLines.join('\n')}`;
   } else {
     const templateOpts = {
       formName: finalName,

--- a/src/utils/fieldControlTypes.ts
+++ b/src/utils/fieldControlTypes.ts
@@ -80,11 +80,117 @@ export function parseTableFieldControls(tableXml: string): FieldControlMap {
 }
 
 /**
+ * A view's own XML carries no field TYPES — an `<AxViewFieldBound>` only names
+ * the underlying table field. Parse the bindings so the types can be picked up
+ * from the tables the view's query reads.
+ *
+ * `dataSource` is the QUERY datasource alias, not a table name; resolving it
+ * needs the query (see {@link parseQueryDataSourceTables}).
+ */
+export function parseViewFieldBindings(
+  viewXml: string,
+): Array<{ name: string; dataField: string; dataSource?: string }> {
+  const out: Array<{ name: string; dataField: string; dataSource?: string }> = [];
+  const fieldRe = /<AxViewField\b[^>]*?i:type="AxViewFieldBound"[^>]*>([\s\S]*?)<\/AxViewField>/g;
+  let m: RegExpExecArray | null;
+  while ((m = fieldRe.exec(viewXml)) !== null) {
+    const body = m[1];
+    const name = body.match(/<Name>([^<]+)<\/Name>/)?.[1]?.trim();
+    if (!name) continue;
+    const dataField = body.match(/<DataField>([^<]+)<\/DataField>/)?.[1]?.trim() ?? name;
+    const dataSource = body.match(/<DataSource>([^<]+)<\/DataSource>/)?.[1]?.trim();
+    out.push({ name, dataField, dataSource });
+  }
+  return out;
+}
+
+/**
+ * Map a query's datasource ALIASES to the tables behind them. In AxQuery XML a
+ * datasource's `<Table>` always directly follows its `<Name>`, at every nesting
+ * level, so one pass over that pair covers root and child datasources alike.
+ */
+export function parseQueryDataSourceTables(queryXml: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const re = /<Name>([^<]+)<\/Name>\s*<Table>([^<]+)<\/Table>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(queryXml)) !== null) {
+    map.set(m[1].trim(), m[2].trim());
+  }
+  return map;
+}
+
+/** The `<Query>` an AxView is built on, or undefined for a query-less view. */
+export function parseViewQueryName(viewXml: string): string | undefined {
+  const v = viewXml.match(/<Query>([^<]*)<\/Query>/)?.[1]?.trim();
+  return v ? v : undefined;
+}
+
+/** AOT XML of a top-level object, via the symbol index. Empty string when unavailable. */
+function readIndexedObjectXml(db: any, name: string, types: readonly string[]): string {
+  const hit = lookupSymbolNocase(db, name, types);
+  const p = hit?.file_path;
+  if (!p || !fs.existsSync(p)) return '';
+  try {
+    return fs.readFileSync(p, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Field→control-type map for a VIEW: hop view → query → the query's tables, and
+ * type each view field from the table field it is bound to.
+ *
+ * Without this every control on a form over a view came out as a plain String —
+ * enums, dates and reals included — because the view XML the map was parsed from
+ * contains no `AxTableField` at all.
+ */
+function getViewFieldControlMap(db: any, viewXml: string, depth = 0): FieldControlMap {
+  const map: FieldControlMap = new Map();
+  const bindings = parseViewFieldBindings(viewXml);
+  if (bindings.length === 0) return map;
+
+  const queryName = parseViewQueryName(viewXml);
+  const aliasToTable = queryName
+    ? parseQueryDataSourceTables(readIndexedObjectXml(db, queryName, ['query']))
+    : new Map<string, string>();
+
+  // One parse per underlying object, not per field. A query datasource may itself
+  // be a VIEW (GeneralJournalUnionView reads GeneralJournalWithSubledgerView), so
+  // this recurses — bounded, because a cyclic view chain would not compile but a
+  // malformed one on disk still must not hang the scaffold.
+  const MAX_VIEW_DEPTH = 4;
+  const sourceMaps = new Map<string, FieldControlMap>();
+  const mapForSource = (name: string): FieldControlMap => {
+    let m = sourceMaps.get(name);
+    if (!m) {
+      const xml = readIndexedObjectXml(db, name, ['table', 'view']);
+      m = /^\s*<AxView[\s>]/m.test(xml)
+        ? (depth < MAX_VIEW_DEPTH ? getViewFieldControlMap(db, xml, depth + 1) : new Map())
+        : parseTableFieldControls(xml);
+      sourceMaps.set(name, m);
+    }
+    return m;
+  };
+
+  for (const b of bindings) {
+    // The alias usually equals the object name, so it is a sane last resort.
+    const source = (b.dataSource && aliasToTable.get(b.dataSource)) || b.dataSource;
+    if (!source) continue;
+    const hit = mapForSource(source).get(b.dataField.toLowerCase());
+    if (hit) map.set(b.name.toLowerCase(), hit);
+  }
+  return map;
+}
+
+/**
  * Build a field→control-type map for a table by locating its AOT XML through the
  * symbol index (any field row of the table carries the table's `file_path`).
+ * Views are supported too, through the extra query→table hop described in
+ * {@link getViewFieldControlMap}.
  *
  * @param db   read-only better-sqlite3 handle (symbolIndex.getReadDb())
- * @param table table name
+ * @param table table (or view) name
  */
 export function getFieldControlMap(db: any, table: string): FieldControlMap {
   try {
@@ -100,7 +206,10 @@ export function getFieldControlMap(db: any, table: string): FieldControlMap {
       )
       .get(canonical) as { file_path?: string } | undefined;
     if (!row?.file_path || !fs.existsSync(row.file_path)) return new Map();
-    return parseTableFieldControls(fs.readFileSync(row.file_path, 'utf-8'));
+    const xml = fs.readFileSync(row.file_path, 'utf-8');
+    // An AxView document has no AxTableField to parse — take the view route.
+    if (/^\s*<AxView[\s>]/m.test(xml)) return getViewFieldControlMap(db, xml);
+    return parseTableFieldControls(xml);
   } catch {
     return new Map();
   }

--- a/tests/tools/evalSweepWriterDefects2.test.ts
+++ b/tests/tools/evalSweepWriterDefects2.test.ts
@@ -3,20 +3,36 @@
  * `2026-07-22T04__L2-form-over-view` raised alongside #37 and that were filed
  * under "Open — writers" in docs/eval-sweep-findings-2026-07-21.md.
  *
- * Covered here (both VM-free):
+ * Covered here (all VM-free):
  *   - generate_object(scaffold, form) rejected a VIEW as `dataSource` because
  *     the scaffold's own lookup was scoped to tables only, even though
  *     object_patterns resolves the same view.
- *   - trigger_db_sync(tables=[…], syncViews=true) put tables AND views in
- *     `-viewlist`; SyncEngine aborts with "Invalid argument -viewlist=…".
+ *   - trigger_db_sync emitted `-viewlist`, which is not a SyncEngine argument:
+ *     it prints "Invalid argument -viewlist=… specified", CONTINUES, and drops
+ *     those names — so a requested view was never synced and nothing failed.
+ *     Verified against SyncEngine 7.0.30743 on the dev VM, whose parameter dump
+ *     has one `TableOrViewList` fed by `-synclist` and no view list at all.
+ *   - every control on a form over a view came out String, because the map was
+ *     parsed from view XML, which holds no AxTableField at all.
  *
- * The third (view <DataSource> defaulting to the query name) is #38 and is
- * already gated by tests/tools/createWriterDefects.test.ts.
+ * The remaining item (view <DataSource> defaulting to the query name) is #38 and
+ * is already gated by tests/tools/createWriterDefects.test.ts.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { handleGenerateSmartForm } from '../../src/tools/generateSmartForm';
-import { classifySyncTargets, extractTablesFromProject } from '../../src/tools/dbSync';
+import {
+  buildSyncEngineArgs,
+  classifySyncOutcome,
+  classifySyncTargets,
+  extractTablesFromProject,
+} from '../../src/tools/dbSync';
+import {
+  getFieldControlMap,
+  parseQueryDataSourceTables,
+  parseViewFieldBindings,
+  parseViewQueryName,
+} from '../../src/utils/fieldControlTypes';
 import type { DbLike } from '../../src/utils/symbolLookup';
 import fs from 'fs/promises';
 import os from 'os';
@@ -29,10 +45,15 @@ import path from 'path';
  * the FTS fallback, honouring the `type IN (…)` filter so a lookup scoped to
  * tables genuinely cannot see a view.
  */
-function fakeDb(rows: Array<{ name: string; type: string }>): DbLike {
+function fakeDb(rows: Array<{ name: string; type: string; file_path?: string }>): DbLike {
   return {
     prepare: (sql: string) => ({
-      get: () => undefined,
+      // getFieldControlMap reaches an object's XML through one of its field rows.
+      get: (...params: unknown[]) => {
+        if (!sql.includes("type = 'field'")) return undefined;
+        const owner = rows.find(r => r.name === String(params[0]));
+        return owner?.file_path ? { file_path: owner.file_path } : undefined;
+      },
       all: (...params: unknown[]) => {
         const isFts = sql.includes('symbols_fts');
         // exact:  [name, ...types, limit]      fts: [match, name, ...types, limit]
@@ -43,7 +64,7 @@ function fakeDb(rows: Array<{ name: string; type: string }>): DbLike {
             ? r.name.toLowerCase() === name.toLowerCase()
             : r.name === name))
           .filter(r => types.length === 0 || types.includes(r.type))
-          .map(r => ({ ...r, model: 'MyModel', extends_class: null, file_path: null }));
+          .map(r => ({ model: 'MyModel', extends_class: null, file_path: null, ...r }));
       },
     }),
   };
@@ -111,13 +132,13 @@ describe('generate_object(scaffold, form) accepts a view as dataSource', () => {
 
 // ── trigger_db_sync list routing ────────────────────────────────────────────
 
-describe('trigger_db_sync splits tables and views into their own SyncEngine lists', () => {
+describe('trigger_db_sync sends tables and views in the one list SyncEngine has', () => {
   const db = fakeDb([
     { name: 'ConDemoNoteHeader', type: 'table' },
     { name: 'ConDemoNoteView', type: 'view' },
   ]);
 
-  it('routes each explicit name by its indexed type', () => {
+  it('labels each explicit name by its indexed type (for the summary, not for routing)', () => {
     const { targets, unresolved } = classifySyncTargets(
       ['ConDemoNoteHeader', 'ConDemoNoteView'],
       db,
@@ -129,26 +150,58 @@ describe('trigger_db_sync splits tables and views into their own SyncEngine list
     expect(unresolved).toEqual([]);
   });
 
-  it('never puts a table in the view list — the failure SyncEngine aborts on', () => {
+  it('keeps every requested name — a view must not be dropped on its way to -synclist', () => {
     const { targets } = classifySyncTargets(['ConDemoNoteHeader', 'ConDemoNoteView'], db);
-    const views = targets.filter(t => t.kind === 'view').map(t => t.name);
-    expect(views).toEqual(['ConDemoNoteView']);
-    expect(views).not.toContain('ConDemoNoteHeader');
+    expect(targets.map(t => t.name).join(',')).toBe('ConDemoNoteHeader,ConDemoNoteView');
   });
 
-  it('falls back to the table list for an unindexed name, and says so', () => {
+  it('reports an unindexed name instead of vouching for it', () => {
     const { targets, unresolved } = classifySyncTargets(['BrandNewTable'], db);
     expect(targets).toEqual([{ name: 'BrandNewTable', kind: 'table' }]);
     expect(unresolved).toEqual(['BrandNewTable']);
   });
 
-  it('classifies everything as a table when no index is available (pre-fix behaviour)', () => {
+  it('labels everything a table when no index is available (unchanged behaviour)', () => {
     const { targets, unresolved } = classifySyncTargets(['ConDemoNoteView'], undefined);
     expect(targets).toEqual([{ name: 'ConDemoNoteView', kind: 'table' }]);
     expect(unresolved).toEqual([]);
   });
 
-  it('takes the split from the AOT folder when extracting from a project file', async () => {
+  it('never emits -viewlist — SyncEngine has no such argument', () => {
+    const args = buildSyncEngineArgs({
+      targets: [
+        { name: 'ConDemoNoteHeader', kind: 'table' },
+        { name: 'ConDemoNoteView', kind: 'view' },
+      ],
+      syncViews: true,
+      metadataBinPath: 'K:\\Pkg',
+      connStr: 'Data Source=localhost',
+    });
+    expect(args.some(a => a.startsWith('-viewlist'))).toBe(false);
+    // Both names, one list — the parameter SyncEngine reports as TableOrViewList.
+    expect(args).toContain('-synclist=ConDemoNoteHeader,ConDemoNoteView');
+    expect(args).toContain('-syncmode=PartialList');
+  });
+
+  it('still uses FullAllAndViews for a full sync with syncViews', () => {
+    const args = buildSyncEngineArgs({
+      targets: [], syncViews: true, metadataBinPath: 'K:\\Pkg', connStr: 'Data Source=localhost',
+    });
+    expect(args).toContain('-syncmode=FullAllAndViews');
+    expect(args).toContain('-verbosediagnostics');
+    expect(args.some(a => a.startsWith('-synclist'))).toBe(false);
+    expect(args.some(a => a.startsWith('-viewlist'))).toBe(false);
+  });
+
+  it('keeps -verbosediagnostics off the partial path', () => {
+    const args = buildSyncEngineArgs({
+      targets: [{ name: 'ConDemoNoteHeader', kind: 'table' }],
+      syncViews: false, metadataBinPath: 'K:\\Pkg', connStr: 'Data Source=localhost',
+    });
+    expect(args).not.toContain('-verbosediagnostics');
+  });
+
+  it('takes the kind from the AOT folder when extracting from a project file', async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'dbsync-'));
     const projectPath = path.join(dir, 'Demo.rnrproj');
     await fs.writeFile(projectPath, `<?xml version="1.0" encoding="utf-8"?>
@@ -173,5 +226,178 @@ describe('trigger_db_sync splits tables and views into their own SyncEngine list
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ── control types for a form over a view ────────────────────────────────────
+
+describe('form controls over a view are typed from the underlying table', () => {
+  // Shapes taken from the real AOT: ApplicationSuite/Foundation/AxView/
+  // ActivityListOpenStatusView.xml and its AxQuery/ActivityListOpenStatus.xml.
+  const VIEW_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoNoteView</Name>
+\t<TitleField1>NoteId</TitleField1>
+\t<Query>ConDemoNoteQuery</Query>
+\t<Fields>
+\t\t<AxViewField xmlns=""
+\t\t\ti:type="AxViewFieldBound">
+\t\t\t<Name>NoteId</Name>
+\t\t\t<DataField>NoteId</DataField>
+\t\t\t<DataSource>ConDemoNoteHeader</DataSource>
+\t\t</AxViewField>
+\t\t<AxViewField xmlns=""
+\t\t\ti:type="AxViewFieldBound">
+\t\t\t<Name>ViewNoteStatus</Name>
+\t\t\t<DataField>NoteStatus</DataField>
+\t\t\t<DataSource>ConDemoNoteHeader</DataSource>
+\t\t</AxViewField>
+\t\t<AxViewField xmlns=""
+\t\t\ti:type="AxViewFieldBound">
+\t\t\t<Name>NoteDate</Name>
+\t\t\t<DataField>NoteDate</DataField>
+\t\t\t<DataSource>ConDemoNoteHeader</DataSource>
+\t\t</AxViewField>
+\t</Fields>
+</AxView>
+`;
+
+  const QUERY_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxQuery xmlns:i="http://www.w3.org/2001/XMLSchema-instance" i:type="AxQuerySimple">
+\t<Name>ConDemoNoteQuery</Name>
+\t<DataSources>
+\t\t<AxQuerySimpleRootDataSource>
+\t\t\t<Name>ConDemoNoteHeader</Name>
+\t\t\t<Table>ConDemoNoteHeaderTable</Table>
+\t\t\t<DataSources />
+\t\t</AxQuerySimpleRootDataSource>
+\t</DataSources>
+</AxQuery>
+`;
+
+  const TABLE_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoNoteHeaderTable</Name>
+\t<Fields>
+\t\t<AxTableField xmlns=""
+\t\t\t\ti:type="AxTableFieldString">
+\t\t\t<Name>NoteId</Name>
+\t\t</AxTableField>
+\t\t<AxTableField xmlns=""
+\t\t\t\ti:type="AxTableFieldEnum">
+\t\t\t<Name>NoteStatus</Name>
+\t\t\t<EnumType>ConDemoNoteStatus</EnumType>
+\t\t</AxTableField>
+\t\t<AxTableField xmlns=""
+\t\t\t\ti:type="AxTableFieldDate">
+\t\t\t<Name>NoteDate</Name>
+\t\t</AxTableField>
+\t</Fields>
+</AxTable>
+`;
+
+  let dir: string;
+  let db: DbLike;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'viewtypes-'));
+    const write = async (n: string, xml: string) => {
+      const p = path.join(dir, `${n}.xml`);
+      await fs.writeFile(p, xml, 'utf-8');
+      return p;
+    };
+    db = fakeDb([
+      { name: 'ConDemoNoteView', type: 'view', file_path: await write('ConDemoNoteView', VIEW_XML) },
+      { name: 'ConDemoNoteQuery', type: 'query', file_path: await write('ConDemoNoteQuery', QUERY_XML) },
+      { name: 'ConDemoNoteHeaderTable', type: 'table', file_path: await write('ConDemoNoteHeaderTable', TABLE_XML) },
+    ]);
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('types each view field from the table field it is bound to', () => {
+    const map = getFieldControlMap(db, 'ConDemoNoteView');
+    // Keyed by the VIEW field name, typed by the TABLE field behind it.
+    expect(map.get('noteid')?.typeValue).toBe('String');
+    expect(map.get('viewnotestatus')?.typeValue).toBe('ComboBox');
+    expect(map.get('notedate')?.typeValue).toBe('Date');
+  });
+
+  it('does not fall back to String for everything (the defect)', () => {
+    const map = getFieldControlMap(db, 'ConDemoNoteView');
+    const values = [...map.values()].map(v => v.typeValue);
+    expect(values.every(v => v === 'String')).toBe(false);
+  });
+
+  it('resolves the view → query → table hop step by step', () => {
+    const bindings = parseViewFieldBindings(VIEW_XML);
+    expect(bindings).toEqual([
+      { name: 'NoteId', dataField: 'NoteId', dataSource: 'ConDemoNoteHeader' },
+      { name: 'ViewNoteStatus', dataField: 'NoteStatus', dataSource: 'ConDemoNoteHeader' },
+      { name: 'NoteDate', dataField: 'NoteDate', dataSource: 'ConDemoNoteHeader' },
+    ]);
+    expect(parseViewQueryName(VIEW_XML)).toBe('ConDemoNoteQuery');
+    // The datasource ALIAS is not the table name — that is the whole point of the hop.
+    expect(parseQueryDataSourceTables(QUERY_XML).get('ConDemoNoteHeader')).toBe('ConDemoNoteHeaderTable');
+  });
+
+  it('leaves a plain table map exactly as it was', () => {
+    const map = getFieldControlMap(db, 'ConDemoNoteHeaderTable');
+    expect(map.get('noteid')?.typeValue).toBe('String');
+    expect(map.get('notestatus')?.typeValue).toBe('ComboBox');
+    expect(map.get('notedate')?.typeValue).toBe('Date');
+  });
+
+  it('returns an empty map — not a crash — when the query cannot be resolved', () => {
+    const orphan = fakeDb([{ name: 'ConDemoNoteView', type: 'view', file_path: path.join(dir, 'ConDemoNoteView.xml') }]);
+    expect(getFieldControlMap(orphan, 'ConDemoNoteView').size).toBe(0);
+  });
+});
+
+// ── the sync verdict itself ─────────────────────────────────────────────────
+
+describe('trigger_db_sync reports the outcome SyncEngine actually reported', () => {
+  // Verbatim from a real run on the dev VM, 2026-07-22 (SyncEngine 7.0.30743).
+  // The benign startup warning fires on EVERY sync in this environment.
+  const BENIGN_WARNING =
+    `Log level - Warning | Failed to abort paused PostServiceync resumable index from last run: ` +
+    `System.Data.SqlClient.SqlException (0x80131904): Invalid column name 'DEFERREDOPERATIONSTATE'.\n` +
+    `   at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection)`;
+  const COMPLETED =
+    `2026-07-22T12:04:35.1357614+00:00 PartialList finished. Time elapsed: 00:02:03.4793213.\n` +
+    `Sync finished and took 141001 milliseconds.`;
+
+  it('a completed sync is a success even though the log says "Failed"/"Exception"', () => {
+    const v = classifySyncOutcome(`${BENIGN_WARNING}\n${COMPLETED}`);
+    expect(v.succeeded).toBe(true);
+  });
+
+  it('the old any-word-anywhere heuristic is what called that run a failure', () => {
+    // Pinned so nobody reintroduces it: this is the exact test that was wrong.
+    const old = /\b(error|failed|exception)\b/i.test(`${BENIGN_WARNING}\n${COMPLETED}`);
+    expect(old).toBe(true);
+    expect(classifySyncOutcome(`${BENIGN_WARNING}\n${COMPLETED}`).succeeded).toBe(true);
+  });
+
+  it('a rejected argument fails the run even when SyncEngine carries on to completion', () => {
+    // Exactly how the bogus -viewlist went unnoticed: dropped, then "finished".
+    const v = classifySyncOutcome(
+      `Invalid argument -viewlist=ActivityListOpenStatusView specified\n${COMPLETED}`,
+    );
+    expect(v.succeeded).toBe(false);
+    expect(v.reason).toContain('-viewlist');
+  });
+
+  it('a run that never reports completion is a failure', () => {
+    expect(classifySyncOutcome(BENIGN_WARNING).succeeded).toBe(false);
+    expect(classifySyncOutcome('').succeeded).toBe(false);
+  });
+
+  it('an explicit failure line is a failure regardless of a completion line', () => {
+    const v = classifySyncOutcome(`Sync failed for table CustTable\n${COMPLETED}`);
+    expect(v.succeeded).toBe(false);
+    expect(v.reason).toContain('Sync failed');
   });
 });

--- a/tests/tools/evalSweepWriterDefects2.test.ts
+++ b/tests/tools/evalSweepWriterDefects2.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression gate for the three writer defects the 2026-07-22 corpus record
+ * `2026-07-22T04__L2-form-over-view` raised alongside #37 and that were filed
+ * under "Open — writers" in docs/eval-sweep-findings-2026-07-21.md.
+ *
+ * Covered here (both VM-free):
+ *   - generate_object(scaffold, form) rejected a VIEW as `dataSource` because
+ *     the scaffold's own lookup was scoped to tables only, even though
+ *     object_patterns resolves the same view.
+ *   - trigger_db_sync(tables=[…], syncViews=true) put tables AND views in
+ *     `-viewlist`; SyncEngine aborts with "Invalid argument -viewlist=…".
+ *
+ * The third (view <DataSource> defaulting to the query name) is #38 and is
+ * already gated by tests/tools/createWriterDefects.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleGenerateSmartForm } from '../../src/tools/generateSmartForm';
+import { classifySyncTargets, extractTablesFromProject } from '../../src/tools/dbSync';
+import type { DbLike } from '../../src/utils/symbolLookup';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+// ── a symbol index that knows exactly one object, of a given type ───────────
+
+/**
+ * Minimal DB double for utils/symbolLookup: it answers the exact-case probe and
+ * the FTS fallback, honouring the `type IN (…)` filter so a lookup scoped to
+ * tables genuinely cannot see a view.
+ */
+function fakeDb(rows: Array<{ name: string; type: string }>): DbLike {
+  return {
+    prepare: (sql: string) => ({
+      get: () => undefined,
+      all: (...params: unknown[]) => {
+        const isFts = sql.includes('symbols_fts');
+        // exact:  [name, ...types, limit]      fts: [match, name, ...types, limit]
+        const name = String(params[isFts ? 1 : 0]);
+        const types = params.slice(isFts ? 2 : 1, -1).map(String);
+        return rows
+          .filter(r => (isFts
+            ? r.name.toLowerCase() === name.toLowerCase()
+            : r.name === name))
+          .filter(r => types.length === 0 || types.includes(r.type))
+          .map(r => ({ ...r, model: 'MyModel', extends_class: null, file_path: null }));
+      },
+    }),
+  };
+}
+
+const symbolIndexOver = (rows: Array<{ name: string; type: string }>) => ({
+  searchSymbols: vi.fn(() => []),
+  getSymbolByName: vi.fn(() => undefined),
+  getTableFields: vi.fn(() => []),
+  getCustomModels: vi.fn(() => ['MyModel']),
+  db: fakeDb(rows),
+  getReadDb: vi.fn(function (this: any) { return this.db; }),
+}) as any;
+
+// ── form scaffold over a view ───────────────────────────────────────────────
+
+describe('generate_object(scaffold, form) accepts a view as dataSource', () => {
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    vi.stubEnv('EXTENSION_PREFIX', '');
+  });
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    vi.unstubAllEnvs();
+  });
+
+  it('binds the form to an indexed VIEW instead of failing "not found in the symbol index"', async () => {
+    const result = await handleGenerateSmartForm(
+      { name: 'ConDemoNoteViewForm', modelName: 'MyModel', dataSource: 'ConDemoNoteView' },
+      symbolIndexOver([{ name: 'ConDemoNoteView', type: 'view' }]),
+    );
+    const text = (result?.content[0].text as string) ?? '';
+    expect(text).not.toContain('not found in the symbol index');
+    expect(text).toContain('<Table>ConDemoNoteView</Table>');
+  });
+
+  it('says the datasource is a read-only view — the templates emit the writable default', async () => {
+    const result = await handleGenerateSmartForm(
+      { name: 'ConDemoNoteViewForm', modelName: 'MyModel', dataSource: 'ConDemoNoteView' },
+      symbolIndexOver([{ name: 'ConDemoNoteView', type: 'view' }]),
+    );
+    const text = (result?.content[0].text as string) ?? '';
+    expect(text).toContain('is a VIEW — read-only at runtime');
+  });
+
+  it('says nothing of the sort for a TABLE datasource (unchanged behaviour)', async () => {
+    const result = await handleGenerateSmartForm(
+      { name: 'ConDemoNoteHeaderForm', modelName: 'MyModel', dataSource: 'ConDemoNoteHeader' },
+      symbolIndexOver([{ name: 'ConDemoNoteHeader', type: 'table' }]),
+    );
+    const text = (result?.content[0].text as string) ?? '';
+    expect(text).toContain('<Table>ConDemoNoteHeader</Table>');
+    expect(text).not.toContain('is a VIEW');
+  });
+
+  it('still reports a name that is neither table nor view', async () => {
+    const result = await handleGenerateSmartForm(
+      { name: 'GhostForm', modelName: 'MyModel', dataSource: 'GhostObject' },
+      symbolIndexOver([{ name: 'ConDemoNoteView', type: 'view' }]),
+    );
+    const text = (result?.content[0].text as string) ?? '';
+    expect(text).toContain('not found in the symbol index');
+  });
+});
+
+// ── trigger_db_sync list routing ────────────────────────────────────────────
+
+describe('trigger_db_sync splits tables and views into their own SyncEngine lists', () => {
+  const db = fakeDb([
+    { name: 'ConDemoNoteHeader', type: 'table' },
+    { name: 'ConDemoNoteView', type: 'view' },
+  ]);
+
+  it('routes each explicit name by its indexed type', () => {
+    const { targets, unresolved } = classifySyncTargets(
+      ['ConDemoNoteHeader', 'ConDemoNoteView'],
+      db,
+    );
+    expect(targets).toEqual([
+      { name: 'ConDemoNoteHeader', kind: 'table' },
+      { name: 'ConDemoNoteView', kind: 'view' },
+    ]);
+    expect(unresolved).toEqual([]);
+  });
+
+  it('never puts a table in the view list — the failure SyncEngine aborts on', () => {
+    const { targets } = classifySyncTargets(['ConDemoNoteHeader', 'ConDemoNoteView'], db);
+    const views = targets.filter(t => t.kind === 'view').map(t => t.name);
+    expect(views).toEqual(['ConDemoNoteView']);
+    expect(views).not.toContain('ConDemoNoteHeader');
+  });
+
+  it('falls back to the table list for an unindexed name, and says so', () => {
+    const { targets, unresolved } = classifySyncTargets(['BrandNewTable'], db);
+    expect(targets).toEqual([{ name: 'BrandNewTable', kind: 'table' }]);
+    expect(unresolved).toEqual(['BrandNewTable']);
+  });
+
+  it('classifies everything as a table when no index is available (pre-fix behaviour)', () => {
+    const { targets, unresolved } = classifySyncTargets(['ConDemoNoteView'], undefined);
+    expect(targets).toEqual([{ name: 'ConDemoNoteView', kind: 'table' }]);
+    expect(unresolved).toEqual([]);
+  });
+
+  it('takes the split from the AOT folder when extracting from a project file', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'dbsync-'));
+    const projectPath = path.join(dir, 'Demo.rnrproj');
+    await fs.writeFile(projectPath, `<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="AxTable\\ConDemoNoteHeader" />
+    <Content Include="AxTableExtension\\CustTable.ConDemoExt" />
+    <Content Include="AxView\\ConDemoNoteView" />
+    <Content Include="AxDataEntityView\\ConDemoNoteEntity" />
+    <Content Include="AxClass\\ConDemoService" />
+  </ItemGroup>
+</Project>
+`, 'utf-8');
+    try {
+      const targets = await extractTablesFromProject(projectPath);
+      expect(targets).toEqual([
+        { name: 'ConDemoNoteHeader', kind: 'table' },
+        { name: 'CustTable', kind: 'table' },
+        { name: 'ConDemoNoteView', kind: 'view' },
+        { name: 'ConDemoNoteEntity', kind: 'view' },
+      ]);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes the **"Open — writers"** section of `docs/eval-sweep-findings-2026-07-21.md`, raised by
`eval/corpus/runs/2026-07-22T04__L2-form-over-view`. Every claim below was verified against the
real symbol index and the real SyncEngine on the dev VM, not reasoned about in-repo.

## 1. A view is a valid form datasource

`generate_object(scaffold, form)` resolved `dataSource` against `type='table'` only, so a form over
a view failed with "not found in the symbol index" even after `update_symbol_index` — while
`object_patterns` resolved the same view fine. On the live index:

```
lookupSymbolNocase('ActivityListOpenStatusView', ['table'])        -> NOT FOUND   (pre-fix path)
lookupSymbolNocase('ActivityListOpenStatusView', ['table','view']) -> view
```

It now resolves against table+view, and reports when the resolved datasource is a read-only view.
The pattern templates carry no `AllowCreate/Edit/Delete`, so the emitted XML keeps the writable
default — the note says so rather than pretending otherwise.

## 2. SyncEngine has no `-viewlist` — the finding was misdiagnosed

The finding said tables and views both land in `-viewlist` and "must be split by object type". The
split was implemented, tested, and committed (`bf1de9c`) — and then disproved by the VM.
SyncEngine 7.0.30743 / platform 7.0.7858.27:

```
Invalid argument -viewlist=ActivityListOpenStatusView specified
=== SyncEngine Parameters ===
TableOrViewList: AbbreviationsStaging          <- the view is gone
DropTableOrViewList / TableExtensionList / CompositeEntityList / ADEsList
```

There is one list, fed by `-synclist`. `-viewlist` is not an argument at all: it is rejected and
the run **continues** with those names dropped, so the requested view was never synced and nothing
failed. Splitting the lists would have reproduced the original bug in a tidier shape.

Both kinds now go in `-synclist`, verified end to end:

```
-synclist=AbbreviationsStaging,ActivityListOpenStatusView
TableOrViewList: AbbreviationsStaging,ActivityListOpenStatusView
PartialList finished. Time elapsed: 00:02:03
```

The table/view labelling survives only to describe what was synced, never to route arguments.

## 3. A green sync was reported as a failure

That run also showed `❌ DB Sync failed` for a sync that completed. The verdict grepped the whole
log for `error|failed|exception`, and SyncEngine logs a benign startup warning on **every** sync in
this environment (`Failed to abort paused PostServiceync resumable index … Invalid column name
'DEFERREDOPERATIONSTATE'`) — so a green run was indistinguishable from a red one. The verdict now
comes from SyncEngine's own completion line, with two overrides a completion line must not hide: a
rejected argument (exactly what would have made the bogus `-viewlist` loud) and an explicit failure
line. Re-run after the fix: `✅ DB Sync completed (121s)`.

## 4. Controls on a form over a view were all String

`getFieldControlMap` parsed the view's own XML, which contains no `AxTableField` at all. It now
hops view → query → the query's datasources, recursing when a datasource is itself a view (bounded
at depth 4 — `GeneralJournalUnionView` reads `GeneralJournalWithSubledgerView`). Against the real
index:

| view | typed before → after |
|---|---|
| `GeneralJournalUnionView` | 0 → 36 |
| `MCRCustomerSearchView` | 75 → 87 |
| `CustInvoiceJourAdjustmentView` | 102/106, real enum/date/real mix |
| `CustTable` (control) | 193 → 193, unchanged |

Remaining untyped fields are unbound/computed — they degrade to String exactly as before.

## Not in scope

The view `<DataSource>` default was already fixed as #38; it was only still listed in the doc.
`docs/eval-sweep-findings-2026-07-21.md` loses the "Open — writers" section and gains the
`-viewlist` ground truth under "Corrected attribution", so nobody re-splits the lists later.

## Testing

`tests/tools/evalSweepWriterDefects2.test.ts` — 22 VM-free cases, including a pin on the old
`error|failed|exception` heuristic (the exact test that was wrong) and a gate that `-viewlist` is
never emitted. Full suite: 2145 passed. `tests/knowledge/apiSymbols.test.ts` times out on a cold
2 GB DB and passes warm in ~2 s — the known flake, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
