### PR TITLE
fix(bridge): honour the dropped write params, and stop reporting no-op modifies

### DIFF
--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -538,7 +538,10 @@ namespace D365MetadataBridge.Protocol
                             var relatedTable = request.GetStringParam("relatedTable")
                                 ?? throw new ArgumentException("Missing: relatedTable");
                             return _writeService!.AddRelation(tableName, relationName, relatedTable,
-                                request.GetParam<System.Collections.Generic.List<WriteRelationConstraint>>("constraints"));
+                                request.GetParam<System.Collections.Generic.List<WriteRelationConstraint>>("constraints"),
+                                request.GetStringParam("relationCardinality") ?? request.GetStringParam("cardinality"),
+                                request.GetStringParam("relatedTableCardinality"),
+                                request.GetStringParam("relationshipType"));
                         });
 
                     case "removerelation":
@@ -965,7 +968,10 @@ namespace D365MetadataBridge.Protocol
                                 writeResult = _writeService.AddRelation(objectName,
                                     S("relationName") ?? throw new ArgumentException("Missing: relationName"),
                                     S("relatedTable") ?? throw new ArgumentException("Missing: relatedTable"),
-                                    op.GetTypedParam<System.Collections.Generic.List<WriteRelationConstraint>>("constraints"));
+                                    op.GetTypedParam<System.Collections.Generic.List<WriteRelationConstraint>>("constraints"),
+                                    S("relationCardinality") ?? S("cardinality"),
+                                    S("relatedTableCardinality"),
+                                    S("relationshipType"));
                                 break;
 
                             case "removerelation":

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -1123,7 +1123,8 @@ namespace D365MetadataBridge.Services
         /// AxFormDataSourceConcrete subtype can yield AxFormDataSourceReferenced (used for
         /// nested/referenced sources), which AxForm.AddDataSource then fails to cast.
         /// </summary>
-        private AxFormDataSourceConcrete CreateFormDataSourceRoot(string dsName, string table, string? joinSource)
+        private AxFormDataSourceConcrete CreateFormDataSourceRoot(string dsName, string table, string? joinSource,
+            string? linkType = null)
         {
             var assembly = typeof(AxClass).Assembly;
             var dsType = assembly.GetType("Microsoft.Dynamics.AX.Metadata.MetaModel.AxFormDataSourceRoot")
@@ -1136,7 +1137,49 @@ namespace D365MetadataBridge.Services
             ds.Name = dsName;
             ds.Table = table;
             if (!string.IsNullOrEmpty(joinSource)) ds.JoinSource = joinSource;
+            // LinkType used to be accepted by the caller and then dropped here, so a join
+            // reported success and serialised without it (findings #35).
+            SetEnumProperty((object)ds, "LinkType", linkType);
             return (AxFormDataSourceConcrete)ds;
+        }
+
+        /// <summary>
+        /// Sets an enum-typed metamodel property from its string name, reflectively.
+        ///
+        /// The metamodel spells these as generated enums (DataSourceLinkType_ITxt,
+        /// Cardinality, RelationshipType …) whose members are the only legal values, so a
+        /// typo cannot be written — but it must not be swallowed either. An unparseable
+        /// value throws with the full member list rather than leaving the property at its
+        /// default, which is exactly how these parameters went missing before: accepted,
+        /// dropped, reported as success.
+        ///
+        /// A null/empty value is a no-op (the caller did not ask for the property).
+        /// </summary>
+        private static void SetEnumProperty(object target, string propertyName, string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+
+            var prop = target.GetType().GetProperty(propertyName)
+                ?? throw new InvalidOperationException(
+                    $"{target.GetType().Name} has no '{propertyName}' property in this metamodel build " +
+                    $"({BuildInfo.MetamodelFileVersion}).");
+            var enumType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+            if (!enumType.IsEnum)
+                throw new InvalidOperationException(
+                    $"{target.GetType().Name}.{propertyName} is {enumType.Name}, not an enum.");
+
+            object parsed;
+            try
+            {
+                parsed = Enum.Parse(enumType, value!.Trim(), ignoreCase: true);
+            }
+            catch (ArgumentException)
+            {
+                throw new ArgumentException(
+                    $"'{value}' is not a valid {propertyName}. Valid values: " +
+                    string.Join(", ", Enum.GetNames(enumType)) + ".");
+            }
+            prop.SetValue(target, parsed);
         }
 
         /// <summary>
@@ -1808,14 +1851,30 @@ namespace D365MetadataBridge.Services
         // TABLE RELATION OPERATIONS
         // ========================
 
-        /// <summary>Adds a relation to a table.</summary>
-        public object AddRelation(string tableName, string relationName, string relatedTable, List<WriteRelationConstraint>? constraints)
+        /// <summary>
+        /// Adds a relation to a table.
+        ///
+        /// Cardinality / RelatedTableCardinality / RelationshipType are real
+        /// AxTableRelation properties (verified against this VM's metamodel), but this
+        /// method used to set only Name, RelatedTable and the constraints — so a relation
+        /// reported "✅ added" and then failed BP with
+        /// BPErrorTableRelationshipPropertiesCompleteness naming exactly those three
+        /// (findings #5 / #35). The TS side patched them onto the XML afterwards as a
+        /// workaround; writing them through the provider is what puts them in the
+        /// serialiser's own element order instead of a hand-anchored one.
+        /// </summary>
+        public object AddRelation(string tableName, string relationName, string relatedTable,
+            List<WriteRelationConstraint>? constraints,
+            string? cardinality = null, string? relatedTableCardinality = null, string? relationshipType = null)
         {
             var axTable = _provider.Tables.Read(tableName)
                 ?? throw new ArgumentException($"Table '{tableName}' not found");
             var msi = GetModelSaveInfoForObject(_provider.Tables, tableName);
 
             var axRel = new AxTableRelation { Name = relationName, RelatedTable = relatedTable };
+            SetEnumProperty(axRel, "Cardinality", cardinality);
+            SetEnumProperty(axRel, "RelatedTableCardinality", relatedTableCardinality);
+            SetEnumProperty(axRel, "RelationshipType", relationshipType);
             if (constraints != null)
             {
                 foreach (var c in constraints)
@@ -1831,7 +1890,14 @@ namespace D365MetadataBridge.Services
             axTable.AddRelation(axRel);
 
             ((IMetaTableProvider)_provider.Tables).Update(axTable, msi);
-            return new { success = true, operation = "add-relation", objectName = tableName, relationName, relatedTable, api = "IMetaTableProvider.Update" };
+            return new
+            {
+                success = true, operation = "add-relation", objectName = tableName, relationName, relatedTable,
+                cardinality = axRel.Cardinality.ToString(),
+                relatedTableCardinality = axRel.RelatedTableCardinality.ToString(),
+                relationshipType = axRel.RelationshipType.ToString(),
+                api = "IMetaTableProvider.Update",
+            };
         }
 
         /// <summary>Removes a relation from a table.</summary>
@@ -1941,13 +2007,15 @@ namespace D365MetadataBridge.Services
                 }
                 if (target == null)
                     throw new InvalidOperationException($"Field '{fieldName}' not found on table '{tableName}'");
+                var applied = new List<string>();
                 if (properties != null)
                 {
                     foreach (var kv in properties)
-                        SetTableFieldProperty(target, kv.Key, kv.Value);
+                        if (SetTableFieldProperty(target, kv.Key, kv.Value)) applied.Add(kv.Key);
                 }
+                RequireSomethingApplied("modify-field", tableName, fieldName, properties, applied, SupportedTableFieldProperties);
                 ((IMetaTableProvider)_provider.Tables).Update(axTable, msi);
-                return new { success = true, operation = "modify-field", objectName = tableName, fieldName, api = "IMetaTableProvider.Update" };
+                return new { success = true, operation = "modify-field", objectName = tableName, fieldName, applied, api = "IMetaTableProvider.Update" };
             }
 
             var axExt = _provider.TableExtensions.Read(tableName);
@@ -1962,15 +2030,17 @@ namespace D365MetadataBridge.Services
                 }
                 if (target == null)
                     throw new InvalidOperationException($"Field '{fieldName}' not found on table-extension '{tableName}'");
+                var applied = new List<string>();
                 if (properties != null)
                 {
                     foreach (var kv in properties)
-                        SetTableFieldProperty(target, kv.Key, kv.Value);
+                        if (SetTableFieldProperty(target, kv.Key, kv.Value)) applied.Add(kv.Key);
                 }
+                RequireSomethingApplied("modify-field", tableName, fieldName, properties, applied, SupportedTableFieldProperties);
                 var extProvider = _provider.TableExtensions as IMetaTableExtensionProvider
                     ?? throw new InvalidOperationException("IMetaTableExtensionProvider not available");
                 extProvider.Update(axExt, msi);
-                return new { success = true, operation = "modify-field", objectName = tableName, fieldName, api = "IMetaTableExtensionProvider.Update" };
+                return new { success = true, operation = "modify-field", objectName = tableName, fieldName, applied, api = "IMetaTableExtensionProvider.Update" };
             }
 
             throw new ArgumentException($"Table or table-extension '{tableName}' not found");
@@ -2183,23 +2253,33 @@ namespace D365MetadataBridge.Services
             if (target == null)
                 throw new InvalidOperationException($"Enum value '{valueName}' not found on enum '{enumName}'");
 
+            var applied = new List<string>();
             if (properties != null)
             {
                 foreach (var kv in properties)
                 {
                     switch (kv.Key.ToLowerInvariant())
                     {
-                        case "label": target.Label = kv.Value; break;
+                        case "label": target.Label = kv.Value; applied.Add(kv.Key); break;
                         case "value":
-                            if (int.TryParse(kv.Value, out var iv)) target.Value = iv;
+                            if (int.TryParse(kv.Value, out var iv)) { target.Value = iv; applied.Add(kv.Key); }
                             break;
-                        case "name": target.Name = kv.Value; break;
+                        case "name": target.Name = kv.Value; applied.Add(kv.Key); break;
+                        case "countryregioncodes": target.CountryRegionCodes = kv.Value; applied.Add(kv.Key); break;
+                        case "configurationkey": target.ConfigurationKey = kv.Value; applied.Add(kv.Key); break;
+                        default:
+                            Console.Error.WriteLine($"[WriteService] Unknown enum value property: {kv.Key}");
+                            break;
                     }
                 }
             }
+            // helpText is deliberately absent: AxEnumValue has no HelpText in the
+            // metamodel (only AxEnum does), so there is nothing to write it to.
+            RequireSomethingApplied("modify-enum-value", enumName, valueName, properties, applied,
+                new[] { "label", "value", "name", "countryRegionCodes", "configurationKey" });
 
             ((IMetaEnumProvider)_provider.Enums).Update(axEnum, msi);
-            return new { success = true, operation = "modify-enum-value", objectName = enumName, valueName, api = "IMetaEnumProvider.Update" };
+            return new { success = true, operation = "modify-enum-value", objectName = enumName, valueName, applied, api = "IMetaEnumProvider.Update" };
         }
 
         /// <summary>Removes a value from an enum.</summary>
@@ -2409,10 +2489,10 @@ namespace D365MetadataBridge.Services
                             return new { success = true, operation = "add-data-source", objectType, objectName, dsName, table, skipped = true, reason = $"data source '{(string)dyn.Name}' already binds table '{table}'", api = "IMetaFormProvider.Update" };
                     }
 
-                    axForm.AddDataSource(CreateFormDataSourceRoot(dsName, table, joinSource));
+                    axForm.AddDataSource(CreateFormDataSourceRoot(dsName, table, joinSource, linkType));
 
                     ((IMetaFormProvider)_provider.Forms).Update(axForm, msi);
-                    return new { success = true, operation = "add-data-source", objectType, objectName, dsName, table, api = "IMetaFormProvider.Update" };
+                    return new { success = true, operation = "add-data-source", objectType, objectName, dsName, table, joinSource, linkType, api = "IMetaFormProvider.Update" };
                 }
                 default:
                     throw new ArgumentException($"add-data-source not supported for objectType '{objectType}' via bridge");
@@ -2926,32 +3006,65 @@ namespace D365MetadataBridge.Services
         }
 
         /// <summary>Sets a property on an existing table field.</summary>
-        private void SetTableFieldProperty(AxTableField field, string prop, string value)
+        /// <summary>Table-field properties SetTableFieldProperty knows how to write.</summary>
+        private static readonly string[] SupportedTableFieldProperties =
+            { "label", "helpText", "mandatory", "allowEdit", "extendedDataType", "stringSize", "enumType" };
+
+        /// <summary>
+        /// Applies one field property. Returns false when the key is unknown, or when it
+        /// is known but does not apply to THIS field type (stringSize on an enum field) —
+        /// the caller turns "nothing applied" into an error instead of a hollow success.
+        /// </summary>
+        private bool SetTableFieldProperty(AxTableField field, string prop, string value)
         {
             switch (prop.ToLowerInvariant())
             {
-                case "label": field.Label = value; break;
-                case "helptext": field.HelpText = value; break;
+                case "label": field.Label = value; return true;
+                case "helptext": field.HelpText = value; return true;
                 case "mandatory":
                     field.Mandatory = ParseNoYes(value);
-                    break;
+                    return true;
                 case "allowedit":
                     field.AllowEdit = ParseNoYes(value);
-                    break;
+                    return true;
                 case "extendeddatatype":
                 case "edt":
                     field.ExtendedDataType = value;
-                    break;
+                    return true;
                 case "stringsize":
-                    if (field is AxTableFieldString sf && int.TryParse(value, out var ss)) sf.StringSize = ss;
-                    break;
+                    if (field is AxTableFieldString sf && int.TryParse(value, out var ss)) { sf.StringSize = ss; return true; }
+                    return false;
                 case "enumtype":
-                    if (field is AxTableFieldEnum ef) ef.EnumType = value;
-                    break;
+                    if (field is AxTableFieldEnum ef) { ef.EnumType = value; return true; }
+                    return false;
                 default:
                     Console.Error.WriteLine($"[WriteService] Unknown table field property: {prop}");
-                    break;
+                    return false;
             }
+        }
+
+        /// <summary>
+        /// Turns a property bag that changed nothing into an error.
+        ///
+        /// Every modify-* op here read its properties, applied whatever it recognised,
+        /// called Update() and returned success — so a caller who sent the parameters in
+        /// the wrong shape (flat instead of nested under `properties`), or a key this
+        /// build does not support, got "✅ modified" over a byte-identical file. The
+        /// modify surface must not report a write it did not make.
+        /// </summary>
+        private static void RequireSomethingApplied(
+            string operation, string objectName, string targetName,
+            Dictionary<string, string>? properties, List<string> applied, IEnumerable<string> supported)
+        {
+            if (applied.Count > 0) return;
+            if (properties == null || properties.Count == 0)
+                throw new ArgumentException(
+                    $"{operation} on '{objectName}.{targetName}' was given no properties, so it would " +
+                    $"change nothing. Pass them under `properties`, e.g. " +
+                    $"properties: {{ \"{supported.First()}\": \"…\" }}. Supported: {string.Join(", ", supported)}.");
+            throw new ArgumentException(
+                $"{operation} on '{objectName}.{targetName}' changed nothing: none of " +
+                $"[{string.Join(", ", properties.Keys)}] could be applied. Supported: {string.Join(", ", supported)}.");
         }
 
         /// <summary>

--- a/docs/eval-sweep-findings-2026-07-21.md
+++ b/docs/eval-sweep-findings-2026-07-21.md
@@ -3,23 +3,18 @@
 Findings from the 2026-07-21/22 golden-capture sweep. **Resolved items are deleted, not archived** —
 git history is the record. Only open work lives here.
 
-## VM-blocked (do NOT "fix" these in-repo)
+## Working on the C# bridge
 
-The C# bridge cannot be compiled or run from this repo — it needs the VM's
-`Microsoft.Dynamics.AX.Metadata` assemblies. Anything below is a VM-side task, and an unverifiable
-C# edit is worse than an open ticket.
+**The bridge builds and runs on this VM.** The old "VM-blocked, do NOT fix in-repo" heading meant
+"from a machine without the D365FO assemblies" — on the dev VM `dotnet build -c Release` in
+`bridge/D365MetadataBridge` takes ~3 s against `K:\AosService\PackagesLocalDirectory\bin`.
 
-- **Same-session resolution root (#16/#23/#28/#29).** Bridge modify ops resolve the target BY NAME
-  against a startup-fixed DiskProvider (`MetadataWriteService` `_provider.Tables.Read(name)`), so an
-  object written this session is not in the model. `filePath` never reaches the bridge — it only
-  steers the TS-side file lookup. Consequence: table-shaped composite cases still fall back to
-  `create overwrite=true`, and a BP-clean table is unreachable through the modify surface.
-  `add-index` and `add-control` have TS-side workarounds; `add-field-group`/`modify-field` do not.
-- **C# halves of #35** — `add-data-source` `linkType` and `add-enum-value` `enumValueHelpText` are
-  accepted but never serialised; `add-relation` properties are written on disk as a workaround
-  rather than by the provider.
-- **#14 residual** — the underlying `ReadEdt` behaviour. The tool is now honest about not knowing;
-  why the bridge returns nothing is not diagnosable here.
+Two gotchas, both cost real time:
+- `bin/Release/D365MetadataBridge.exe` is **locked by the running bridge child process**, so the
+  build fails with MSB3027. Build to a scratch dir (`-p:OutputPath=K:/tmp/bridge-work/`) and drive
+  that exe directly; the committed binary only needs replacing when the MCP server restarts.
+- The bridge types `BridgeRequest.Id` as **string** — a numeric `id` is a parse error, not a
+  mismatched response. And every read method has its own parameter name (`edtName`, not `name`).
 
 ## Needs a VM run
 
@@ -27,14 +22,44 @@ C# edit is worse than an open ticket.
   catch. `L4-entity-security` emits `AxSecurityRolePermissionSet`/`AxSecurityRoleDutyPermission`
   instead of `AxSecurityPrivilegeReference`/`AxSecurityDutyReference` (xppbp proves the chain is
   dead). `L1-form-detailsmaster` is missing the `<DataSource>` sibling and its own corpus record
-  already has `build.succeeded=false`. **Re-capture both once PR #735 (the #31/#32 writer fixes) merges.**
-- **#25 confirmation** — the `run_bp_check` scoping flags are fixed, but one VM run should confirm
-  xppbp accepts the positional `<type>:<Name>` selector in practice.
-- Only `fullBuild` runs metadata validation. An incremental build reported 0 errors on a model with
-  2 real metadata errors, so `pass@build` from incremental runs is weaker than it looks.
+  already has `build.succeeded=false`. **Re-capture both** — PR #735 has merged, so this is now
+  only an eval-run task.
 
 ## Corrected attribution
 
+- **"Same-session resolution root" (#16/#23/#28/#29) is stale.** The premise was that
+  `MetadataWriteService` reads against a DiskProvider fixed at startup, so an object written this
+  session is invisible. Probed on the VM against the live bridge: `createObject` runs through
+  `HandleWrite(..., refreshAfterSuccess: true)`, which calls `MetadataReadService.RefreshProvider()`
+  and pushes the new provider into the write service via `OnProviderRefreshed`. A table created and
+  then modified in the same bridge session resolves — `add-field-group` **and** `modify-field` both
+  succeed, including after a deliberately failed lookup of the name beforehand (no negative caching).
+  What was really broken is below.
+- **#14 is closed, and it was never `ReadEdt`.** `Num`, `Notes` and `CustAccount` — the exact three
+  EDTs the finding named — all read correctly through the bridge and through
+  `get_object_info(objectType="edt")`, sourced from `IMetadataProvider`. `RecId` reports "Object not
+  found" because it is not an EDT. So "Bridge returned no data" was the bridge being **unreachable**
+  at that moment, which makes **#4 (silent direct-XML fallback) the real open item**, not a read bug.
+- **A modify that changed nothing reported success.** Found while probing the above: `modifyField`
+  answered `success: true, api: IMetaTableProvider.Update` over a byte-identical file whenever its
+  properties did not land — the wrong payload shape (flat instead of nested under `properties`, which
+  is what the single-op dispatcher path requires), an unknown key, or a key that does not apply to
+  that field type (`enumType` on a string field). `ModifyEnumValue` had the same hole. Both now refuse
+  to report a write they did not make, and list what they support.
+- **`enumValueHelpText` can never be honoured.** Not a pending C# task: an enum VALUE has no help
+  text in the metamodel. Reflected on platform 7.0.7858.27, `AxEnumValue` exposes Name, Tags, Label,
+  ConfigurationKey, Value, CountryRegionCodes, FeatureClass — no HelpText; only `AxEnum` has
+  Help/HelpText, and real AOT enum XML agrees. `OP_UNHONOURED_PARAMS` now says so instead of
+  promising a fix.
+- **#25 confirmed on the VM.** xppbp documents `[elementtype]:(* or Name)` and accepts it positionally
+  without `-all`: `xppbp -metadata=… -module=Contoso -model=Contoso -compilerMetadata=… table:ConDemoNoteHeader`
+  reports `1 elements processed` and warnings for that table only. The usage text claims `-rules` is
+  required when `-all` is omitted; in practice it defaults to `Enabled rules: *`.
+- **Incremental builds are scope-limited by design, not by a missing flag.** xppc documents
+  `-incremental` as "Compile only the elements that have been changed", so an unchanged element's
+  metadata errors are never revisited — which is exactly how a run scored `pass@build` on a model
+  that does not compile. There is no validation switch to turn on; the build result now says what a
+  green incremental run did and did not cover.
 - **The `-viewlist` finding was misdiagnosed.** It was filed as "tables and views are both put in
   `-viewlist`; they must be split by object type". Verified on the VM against SyncEngine 7.0.30743
   / platform 7.0.7858.27: **`-viewlist` is not a SyncEngine argument at all.** The parameter dump

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -1443,14 +1443,23 @@ export async function bridgeAddRelation(
   relationName: string,
   relatedTable: string,
   constraints?: Array<{ field?: string; relatedField?: string }>,
-): Promise<{ success: boolean; message: string } | null> {
+  properties?: { relationCardinality?: string; relatedTableCardinality?: string; relationshipType?: string },
+): Promise<{ success: boolean; message: string; propertiesWritten?: boolean } | null> {
   if (!bridge?.isReady || !bridge.metadataAvailable) return null;
   try {
-    const result = await bridge.addRelation(tableName, relationName, relatedTable, constraints);
+    const result = await bridge.addRelation(tableName, relationName, relatedTable, constraints, properties);
+    // An older bridge binary silently ignores the extra params; it echoes back only
+    // what it set, so the response says whether the on-disk fallback is still needed.
+    const r = result as unknown as Record<string, unknown>;
+    const propertiesWritten = typeof r.relationshipType === 'string';
     return {
       success: result.success,
+      propertiesWritten,
       message: result.success
-        ? `✅ Relation '${relationName}' added via ${result.api}`
+        ? `✅ Relation '${relationName}' added via ${result.api}` +
+          (propertiesWritten
+            ? ` (Cardinality=${r.cardinality}, RelatedTableCardinality=${r.relatedTableCardinality}, RelationshipType=${r.relationshipType})`
+            : '')
         : `Bridge addRelation returned success=false`,
     };
   } catch (e) {

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -742,9 +742,29 @@ export class BridgeClient extends EventEmitter {
     return this.call<BridgeWriteResult>('removeIndex', { objectName: tableName, indexName });
   }
 
-  /** Add a relation to a table */
-  async addRelation(tableName: string, relationName: string, relatedTable: string, constraints?: Array<{ field?: string; relatedField?: string }>): Promise<BridgeWriteResult> {
-    return this.call<BridgeWriteResult>('addRelation', { objectName: tableName, relationName, relatedTable, constraints });
+  /**
+   * Add a relation to a table.
+   *
+   * `properties` carries Cardinality / RelatedTableCardinality / RelationshipType —
+   * real AxTableRelation properties the bridge now sets through the provider. They
+   * used to be dropped on both sides, which is what raised
+   * BPErrorTableRelationshipPropertiesCompleteness on a relation reported as added
+   * (findings #5 / #35). An invalid value is rejected by the bridge with the list of
+   * legal ones rather than silently ignored.
+   */
+  async addRelation(
+    tableName: string,
+    relationName: string,
+    relatedTable: string,
+    constraints?: Array<{ field?: string; relatedField?: string }>,
+    properties?: { relationCardinality?: string; relatedTableCardinality?: string; relationshipType?: string },
+  ): Promise<BridgeWriteResult> {
+    return this.call<BridgeWriteResult>('addRelation', {
+      objectName: tableName, relationName, relatedTable, constraints,
+      relationCardinality: properties?.relationCardinality,
+      relatedTableCardinality: properties?.relatedTableCardinality,
+      relationshipType: properties?.relationshipType,
+    });
   }
 
   /** Remove a relation from a table */

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -677,12 +677,30 @@ async function renderFinishedBuildResult(
   return {
     content: [{
       type: 'text',
-      text: `${statusIcon} (${finalState.tool}, ${buildMode}, ${duration}s)\n\nModel: ${targetModel}\n\n` +
+      text: `${statusIcon} (${finalState.tool}, ${buildMode}, ${duration}s)\n\nModel: ${targetModel}\n` +
+        incrementalScopeCaveat(succeeded, !!finalState.fullBuild) + '\n' +
         (structured ? `${structured}\n\n--- Raw log ---\n` : '') +
         `${logContent || '(no output)'}`,
     }],
     ...((!succeeded) ? { isError: true } : {}),
   };
+}
+
+/**
+ * What a clean INCREMENTAL build does and does not prove.
+ *
+ * `-incremental` is documented by xppc as "Compile only the elements that have
+ * been changed", so an element it considers unchanged is never recompiled and
+ * its metadata errors are never reported. A model with real metadata errors
+ * therefore builds green incrementally — which is how a run scored pass@build
+ * on a model that does not actually compile. Only a full build sees everything,
+ * so a green incremental result has to say what it covered.
+ */
+function incrementalScopeCaveat(succeeded: boolean, fullBuild: boolean): string {
+  if (!succeeded || fullBuild) return '';
+  return '\nℹ️ Incremental: only CHANGED elements were compiled. A clean result here is not proof ' +
+    'the model compiles — unchanged elements with metadata errors are not revisited. ' +
+    'Use fullBuild: true before trusting a green build (e.g. to score a task as done).\n';
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/d365foFileOpSpecs.ts
+++ b/src/tools/d365foFileOpSpecs.ts
@@ -177,17 +177,21 @@ export const D365FO_FILE_PARAM_SPECS: Record<string, { type: string; description
     type: 'array of { fieldName, relatedFieldName }',
     description: 'Field constraints (local field = related field pairs).',
   },
+  // Value sets are the metamodel enums themselves (verified on platform 7.0.7858.27);
+  // anything outside them is rejected by the bridge with the legal list, not dropped.
   relationCardinality: {
     type: 'string',
-    description: 'Local-side cardinality: ZeroMore | ZeroOne | ExactlyOne (default: ZeroMore).',
+    description:
+      'Local-side cardinality: ZeroOne | ExactlyOne | ZeroMore | OneMore | NotSpecified (default: ZeroMore).',
   },
   relatedTableCardinality: {
     type: 'string',
-    description: 'Related-side cardinality: ZeroMore | ZeroOne | ExactlyOne (default: ExactlyOne).',
+    description: 'Related-side cardinality: ZeroOne | ExactlyOne | NotSpecified (default: ExactlyOne).',
   },
   relationshipType: {
     type: 'string',
-    description: 'Association | Composition | Aggregation | Link | Specialization (default: Association).',
+    description:
+      'Association | Composition | Aggregation | Link | Specialization | NotSpecified (default: Association).',
   },
   // field groups
   fieldGroupName: { type: 'string', description: 'Field group name.' },
@@ -222,7 +226,13 @@ export const D365FO_FILE_PARAM_SPECS: Record<string, { type: string; description
     description: 'modify-enum-value: rename the value located by enumValueName to this.',
   },
   enumValueLabel: { type: 'string', description: 'Label reference (e.g. "@MyModel:Approved").' },
-  enumValueHelpText: { type: 'string', description: 'Help-text reference (optional).' },
+  enumValueHelpText: {
+    type: 'string',
+    description:
+      'NOT WRITABLE — an enum value has no help text in the metamodel (AxEnumValue has no ' +
+      'HelpText property). Kept only so passing it produces an explanation instead of a ' +
+      'spelling suggestion. Use enumValueLabel, or set HelpText on the enum.',
+  },
   enumValueInt: { type: 'number', description: 'Explicit integer value (omitted = next available).' },
   enumValueCountryRegionCodes: {
     type: 'string',
@@ -394,21 +404,17 @@ export const D365FO_FILE_CORE_PARAMS: ReadonlySet<string> = new Set([
  * value did not reach the XML (corpus cluster #35).
  *
  * Keep this list empty-by-default: an entry here is a confession, not a design.
- * Each one is a VM-side (C#) task, tracked with the reason it cannot be honoured
- * TS-side.
+ * An entry is either a pending VM-side (C#) task or — as with the one below — a
+ * parameter the metamodel cannot express at all, in which case the note says so
+ * instead of promising a fix that will never come.
  */
 export const OP_UNHONOURED_PARAMS: Record<string, Record<string, string>> = {
   'add-enum-value': {
     enumValueHelpText:
-      'nothing carries a help text for a new enum value — the dispatcher forwards name/value/label/' +
-      'countryRegionCodes only, and the bridge AddEnumValue has no helpText parameter. ' +
-      'Add the help text on the enum value afterwards in Visual Studio.',
-  },
-  'add-data-source': {
-    linkType:
-      "the bridge's AddDataSource passes linkType no further than its own signature — " +
-      'CreateFormDataSourceRoot() sets Name/Table/JoinSource only, so no <LinkType> element is written. ' +
-      'Set it afterwards on the data source in the form XML (or in Visual Studio) until the bridge is fixed.',
+      'an enum VALUE has no help text in the D365FO metamodel. Verified by reflection on this ' +
+      "platform (7.0.7858.27): AxEnumValue exposes Name, Tags, Label, ConfigurationKey, Value, " +
+      'CountryRegionCodes, FeatureClass — and no HelpText; only the AxEnum itself has Help/HelpText. ' +
+      'Real AOT enum XML agrees. Use enumValueLabel for the value, or set HelpText on the enum.',
   },
 };
 

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1835,29 +1835,36 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
                   relatedField: c?.relatedField ?? c?.relatedFieldName,
                 }))
               : undefined;
+          const relationProperties = {
+            relationCardinality: (args as any).relationCardinality ?? 'ZeroMore',
+            relatedTableCardinality: (args as any).relatedTableCardinality ?? 'ExactlyOne',
+            relationshipType: (args as any).relationshipType ?? 'Association',
+          };
           bridgeResult = await bridgeAddRelation(
             context.bridge,
             objectName,
             (args as any).relationName,
             (args as any).relatedTable,
             constraints,
+            relationProperties,
           );
-          // The relation properties add-relation documents (with defaults) are
-          // carried by NEITHER bridgeClient.addRelation NOR the C# AddRelation —
-          // it writes Name/RelatedTable/Constraints only, so the op answered
-          // "✅ Relation 'X' added" and xppbp then raised
-          // BPErrorTableRelationshipPropertiesCompleteness naming exactly the three
-          // dropped properties, with no repair path (modify-property rejects
-          // Relations/<name>/RelationshipType). Findings #5 / #35. The C# fix needs
-          // the VM's metadata assemblies, so write them on disk here — applying the
-          // documented defaults, exactly as the create path does.
-          if (bridgeResult?.success) {
+          // The bridge now sets Cardinality/RelatedTableCardinality/RelationshipType
+          // through the provider (verified on the VM: they serialise in the SDK's own
+          // element order). Dropping them is what raised
+          // BPErrorTableRelationshipPropertiesCompleteness on a relation reported as
+          // added, with no repair path — modify-property rejects
+          // Relations/<name>/RelationshipType (findings #5 / #35).
+          //
+          // The on-disk writer stays as the fallback for an OLD bridge binary, which
+          // ignores the new params without complaint; it no-ops when the properties are
+          // already present, so the bridge path costs one file read.
+          if (bridgeResult?.success && !(bridgeResult as any).propertiesWritten) {
             const relProps = await directXmlEnsureRelationProperties(
               actualFilePath,
               (args as any).relationName,
-              (args as any).relationCardinality ?? 'ZeroMore',
-              (args as any).relatedTableCardinality ?? 'ExactlyOne',
-              (args as any).relationshipType ?? 'Association',
+              relationProperties.relationCardinality,
+              relationProperties.relatedTableCardinality,
+              relationProperties.relationshipType,
             );
             if (relProps && relProps.applied.length > 0) {
               bridgeResult = {

--- a/tests/bridge/relationProperties.test.ts
+++ b/tests/bridge/relationProperties.test.ts
@@ -1,0 +1,67 @@
+/**
+ * add-relation must carry Cardinality / RelatedTableCardinality / RelationshipType
+ * to the bridge, and must not double-write them on disk when it did.
+ *
+ * Dropping them is what raised BPErrorTableRelationshipPropertiesCompleteness on a
+ * relation the tool reported as added, with no repair path — modify-property rejects
+ * `Relations/<name>/RelationshipType` (findings #5 / #35).
+ *
+ * Ground truth for the values: AxTableRelation on platform 7.0.7858.27 exposes
+ * Cardinality (NotSpecified|ZeroOne|ExactlyOne|ZeroMore|OneMore),
+ * RelatedTableCardinality (NotSpecified|ZeroOne|ExactlyOne) and
+ * RelationshipType (NotSpecified|Association|Composition|Link|Specialization|Aggregation).
+ * A probe against the live bridge serialised all three in the SDK's own element order
+ * (Name → Cardinality → RelatedTable → RelatedTableCardinality → RelationshipType →
+ * Constraints) and rejected an invalid value instead of dropping it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { bridgeAddRelation } from '../../src/bridge/bridgeAdapter';
+
+const fakeBridge = (response: Record<string, unknown>) => {
+  const addRelation = vi.fn(async () => response);
+  return { bridge: { isReady: true, metadataAvailable: true, addRelation } as any, addRelation };
+};
+
+describe('bridgeAddRelation carries the relation properties', () => {
+  it('forwards all three properties to the client', async () => {
+    const { bridge, addRelation } = fakeBridge({
+      success: true, api: 'IMetaTableProvider.Update',
+      cardinality: 'ZeroMore', relatedTableCardinality: 'ExactlyOne', relationshipType: 'Association',
+    });
+    await bridgeAddRelation(bridge, 'ConTable', 'ConRel', 'CustTable', undefined, {
+      relationCardinality: 'ZeroMore',
+      relatedTableCardinality: 'ExactlyOne',
+      relationshipType: 'Association',
+    });
+    expect(addRelation).toHaveBeenCalledWith('ConTable', 'ConRel', 'CustTable', undefined, {
+      relationCardinality: 'ZeroMore',
+      relatedTableCardinality: 'ExactlyOne',
+      relationshipType: 'Association',
+    });
+  });
+
+  it('reports what the bridge actually set, so the caller sees the values', async () => {
+    const { bridge } = fakeBridge({
+      success: true, api: 'IMetaTableProvider.Update',
+      cardinality: 'OneMore', relatedTableCardinality: 'ZeroOne', relationshipType: 'Composition',
+    });
+    const r = await bridgeAddRelation(bridge, 'ConTable', 'ConRel', 'CustTable');
+    expect(r?.propertiesWritten).toBe(true);
+    expect(r?.message).toContain('RelationshipType=Composition');
+    expect(r?.message).toContain('Cardinality=OneMore');
+  });
+
+  it('flags an OLD bridge binary, which echoes no properties back', async () => {
+    // The extra params are simply ignored by a stale exe — the on-disk fallback in
+    // modifyD365File keys off this flag, so it must not be true by accident.
+    const { bridge } = fakeBridge({ success: true, api: 'IMetaTableProvider.Update' });
+    const r = await bridgeAddRelation(bridge, 'ConTable', 'ConRel', 'CustTable');
+    expect(r?.propertiesWritten).toBe(false);
+    expect(r?.message).not.toContain('RelationshipType');
+  });
+
+  it('returns null when the bridge is unavailable (unchanged)', async () => {
+    expect(await bridgeAddRelation(undefined, 'ConTable', 'ConRel', 'CustTable')).toBeNull();
+  });
+});

--- a/tests/tools/modifyParamSilentDrop.test.ts
+++ b/tests/tools/modifyParamSilentDrop.test.ts
@@ -278,7 +278,12 @@ describe('#35 — an accepted-but-dropped parameter must be reported, never sile
     expect(text).toMatch(/did not reach the written XML/);
   });
 
-  it('warns that add-data-source does not write linkType (C#-side drop)', async () => {
+  it('no longer warns about linkType — the bridge writes it now', async () => {
+    // Was: "add-data-source drops linkType (C#-side)". The bridge's
+    // CreateFormDataSourceRoot now sets LinkType, verified on the VM against
+    // AxFormDataSourceRoot.LinkType (DataSourceLinkType_ITxt) — a real
+    // <LinkType>InnerJoin</LinkType> lands in the form XML. Flagging it as
+    // not-honoured would now itself be the lie.
     currentXml.value = FORM_EXTENSION_XML;
     const result = await modifyD365FileTool(
       req({
@@ -294,9 +299,7 @@ describe('#35 — an accepted-but-dropped parameter must be reported, never sile
       buildContext(),
     );
 
-    const text = textOf(result);
-    expect(text).toContain('linkType');
-    expect(text).toMatch(/NOT WRITTEN/);
+    expect(textOf(result)).not.toMatch(/linkType[\s\S]*NOT WRITTEN/);
   });
 
   it('does not warn when every parameter is consumed', async () => {
@@ -454,8 +457,11 @@ describe('parameter-accounting helpers', () => {
     expect(findIgnoredParams('add-relation', ['relationName', 'relatedTable', 'indexName'])).toEqual([
       { name: 'indexName', reason: 'other-op', suggestion: undefined },
     ]);
-    expect(findIgnoredParams('add-data-source', ['dataSourceName', 'dataSourceTable', 'linkType'])).toEqual([
-      { name: 'linkType', reason: 'not-honoured', detail: expect.stringContaining('CreateFormDataSourceRoot') },
+    // linkType used to be the third case here; it is honoured now, so the
+    // not-honoured example is the one the metamodel genuinely cannot express.
+    expect(findIgnoredParams('add-data-source', ['dataSourceName', 'dataSourceTable', 'linkType'])).toEqual([]);
+    expect(findIgnoredParams('add-enum-value', ['enumValueName', 'enumValueHelpText'])).toEqual([
+      { name: 'enumValueHelpText', reason: 'not-honoured', detail: expect.stringContaining('AxEnumValue') },
     ]);
   });
 
@@ -472,11 +478,13 @@ describe('parameter-accounting helpers', () => {
   });
 
   it('reports the two enum-value drops the audit turned up', () => {
-    // add-enum-value advertises enumValueHelpText, but the dispatcher forwards
-    // name/value/label/countryRegionCodes only and the bridge has no helpText
-    // parameter — nothing carries it, so it must be reported.
+    // add-enum-value advertises enumValueHelpText, but an enum VALUE has no help
+    // text in the metamodel at all — AxEnumValue exposes Name/Tags/Label/
+    // ConfigurationKey/Value/CountryRegionCodes/FeatureClass and nothing else
+    // (reflected on platform 7.0.7858.27). This one can never become honoured,
+    // so the detail must say that rather than promise a C# fix.
     expect(findIgnoredParams('add-enum-value', ['enumValueName', 'enumValueHelpText'])).toEqual([
-      { name: 'enumValueHelpText', reason: 'not-honoured', detail: expect.stringContaining('AddEnumValue') },
+      { name: 'enumValueHelpText', reason: 'not-honoured', detail: expect.stringContaining('AxEnumValue') },
     ]);
     // enumValueNewName IS honoured by modify-enum-value (it was simply missing
     // from the op-spec registry) — it must not be flagged.


### PR DESCRIPTION
Closes the **VM-blocked** section of `docs/eval-sweep-findings-2026-07-21.md` and confirms the two
open **needs-a-VM-run** questions. Everything below was probed against the live bridge and the real
metamodel (platform 7.0.7858.27) before it was written.

**The premise of that section was wrong.** The bridge builds and runs on the dev VM —
`dotnet build -c Release` in `bridge/D365MetadataBridge` takes ~3 s against
`K:\AosService\PackagesLocalDirectory\bin`. "VM-blocked" meant "from a machine without the D365FO
assemblies". The heading now says so, with the two gotchas that cost real time: the committed
`bin/Release` exe is locked by the running bridge child process (build to a scratch `OutputPath`),
and `BridgeRequest.Id` is typed `string`, so a numeric `id` is a parse error.

## #35 — both C# halves

| what | before | after |
|---|---|---|
| `add-relation` Cardinality / RelatedTableCardinality / RelationshipType | dropped; TS patched them onto the XML afterwards | set through the provider, serialised in the SDK's own element order |
| `add-data-source` `linkType` | accepted, never written | real `<LinkType>InnerJoin</LinkType>` |
| an invalid enum value | left at the default | `'Nonsense' is not a valid RelationshipType. Valid values: …` |

Serialised by the live bridge, exactly the order the AOT expects (misordered properties are silently
dropped, #13):

```xml
<AxTableRelation>
  <Name>ConDemoNoteHeaderRel</Name>
  <Cardinality>ZeroMore</Cardinality>
  <RelatedTable>ConDemoNoteHeader</RelatedTable>
  <RelatedTableCardinality>ExactlyOne</RelatedTableCardinality>
  <RelationshipType>Association</RelationshipType>
  <Constraints>…</Constraints>
</AxTableRelation>
```

The on-disk writer stays as the fallback for an old bridge binary, keyed off whether the response
echoes the properties back — so a stale exe still produces a BP-clean relation.

**`enumValueHelpText` is not a pending C# task — it is impossible.** An enum VALUE has no help text
in the metamodel: `AxEnumValue` exposes Name, Tags, Label, ConfigurationKey, Value,
CountryRegionCodes, FeatureClass and nothing else; only `AxEnum` has Help/HelpText, and real AOT
enum XML agrees. `OP_UNHONOURED_PARAMS` now says that instead of promising a fix that will never come.

## A modify that changed nothing reported success

Found while probing the above, and worse than what it was filed under. `modifyField` answered
`success: true, api: IMetaTableProvider.Update` over a **byte-identical file** whenever its
properties did not land:

- the wrong payload shape (flat instead of nested under `properties`, which the single-op dispatcher
  path requires — the batch path builds the dict differently, which is how this stayed hidden)
- an unknown key (`helpTxt`)
- a key that does not apply to that field type (`enumType` on a string field)

`ModifyEnumValue` had the same hole, and silently ignored `countryRegionCodes`/`configurationKey`.
Both now refuse to claim a write they did not make and report `applied`:

```
modify-field on 'ConProbeNoop.ProbeId' changed nothing: none of [helpTxt, frobnicate] could be
applied. Supported: label, helpText, mandatory, allowEdit, extendedDataType, stringSize, enumType.
```

## Two findings closed as stale, one reclassified

- **Same-session resolution root (#16/#23/#28/#29)** — stale. `createObject` runs through
  `HandleWrite(…, refreshAfterSuccess: true)`, which calls `RefreshProvider()` and pushes the new
  provider into the write service via `OnProviderRefreshed`. A table created and then modified in the
  same bridge session resolves: `add-field-group` **and** `modify-field` both succeed, including
  after a deliberately failed lookup of the name beforehand (no negative caching).
- **#14 residual** — closed, and it was never `ReadEdt`. `Num`, `Notes` and `CustAccount` — the exact
  three EDTs the finding named — read correctly through the bridge and through
  `get_object_info(objectType="edt")`. (`RecId` reports "Object not found" because it is not an EDT.)
  So "Bridge returned no data" was the bridge being **unreachable**, which promotes **#4, the silent
  direct-XML fallback, to the real open item**.
- **#25** — confirmed. xppbp documents `[elementtype]:(* or Name)` and accepts it positionally
  without `-all`: a filtered run reports `1 elements processed` and warnings for that table only. Its
  usage text claims `-rules` is required when `-all` is omitted; in practice it defaults to
  `Enabled rules: *`.

## Incremental builds

xppc documents `-incremental` as "Compile only the elements that have been changed", so an unchanged
element's metadata errors are never revisited — which is how a run scored `pass@build` on a model
that does not compile. There is no validation switch to turn on, so the honest fix is to stop letting
a green incremental result read as "the model compiles"; `build_d365fo_project` now says what it covered.

## Testing

`tests/bridge/relationProperties.test.ts` (new, 4 cases) covers the property plumbing and the
old-binary fallback flag. `tests/tools/modifyParamSilentDrop.test.ts` updated: `linkType` is no
longer flagged as not-honoured (flagging it would now itself be the lie), and the `enumValueHelpText`
detail asserts the metamodel reason. Full suite: 2154 passed. `tests/knowledge/apiSymbols.test.ts`
times out on a cold 2 GB DB and passes warm — the known flake.

**Note for whoever merges:** the committed `bridge/D365MetadataBridge/bin/Release` binary is NOT
rebuilt here — it is locked while an MCP server is running. Rebuild it after restarting the server,
or the TS changes will talk to the old exe (which ignores the new params gracefully — the on-disk
fallback covers the relation properties, but `linkType` and the no-op guards need the new binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
