### PR TITLE
fix(create): stop the table writer from swallowing configurationKey (#35 create half)

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -224,11 +224,14 @@ namespace D365MetadataBridge.Services
 
             var axTable = new AxTable { Name = name };
 
-            // Apply table-level properties (Label, TableGroup, CacheLookup, etc.)
+            // Apply table-level properties (Label, TableGroup, CacheLookup, etc.).
+            // Finding #35: an unknown key was dropped in silence — report it instead.
+            var unsupportedProperties = new List<string>();
             if (properties != null)
             {
                 foreach (var kv in properties)
-                    SetAxTableProperty(axTable, kv.Key, kv.Value);
+                    if (!SetAxTableProperty(axTable, kv.Key, kv.Value))
+                        unsupportedProperties.Add(kv.Key);
             }
 
             // Add fields
@@ -318,7 +321,14 @@ namespace D365MetadataBridge.Services
             tableProvider.Create(axTable, msi);
 
             var filePath = GetExpectedPath("AxTable", name, modelName);
-            return new { success = true, objectType = "table", objectName = name, modelName, filePath, api = "IMetaTableProvider.Create" };
+            return new
+            {
+                success = true, objectType = "table", objectName = name, modelName, filePath,
+                api = "IMetaTableProvider.Create",
+                appliedProperties = (properties?.Keys ?? Enumerable.Empty<string>())
+                    .Where(k => !unsupportedProperties.Contains(k)).ToList(),
+                unsupportedProperties,
+            };
         }
 
         /// <summary>
@@ -549,10 +559,15 @@ namespace D365MetadataBridge.Services
             }
 
             // ── Apply any extra properties (overrides auto-set values if needed) ──
+            // Finding #35: the return value used to be thrown away, so an unknown key
+            // (configurationKey, …) produced a stderr line nobody reads and a ✅ to the
+            // caller. Collect what did NOT apply and report it in the response.
+            var unsupportedProperties = new List<string>();
             if (extraProperties != null)
             {
                 foreach (var kv in extraProperties)
-                    SetAxTableProperty(axTable, kv.Key, kv.Value);
+                    if (!SetAxTableProperty(axTable, kv.Key, kv.Value))
+                        unsupportedProperties.Add(kv.Key);
             }
 
             // ── Write to disk via IMetadataProvider ──
@@ -569,6 +584,9 @@ namespace D365MetadataBridge.Services
                 modelName,
                 filePath,
                 api = "IMetaTableProvider.Create (Smart)",
+                appliedProperties = (extraProperties?.Keys ?? Enumerable.Empty<string>())
+                    .Where(k => !unsupportedProperties.Contains(k)).ToList(),
+                unsupportedProperties,
                 bpDefaults = new
                 {
                     cacheLookup = axTable.CacheLookup.ToString(),
@@ -1486,7 +1504,7 @@ namespace D365MetadataBridge.Services
                         ?? throw new ArgumentException($"Table '{objectName}' not found");
                     var msi = GetModelSaveInfoForObject(_provider.Tables, objectName);
                     if (!SetAxTableProperty(obj, propertyPath, propertyValue))
-                        throw new ArgumentException($"Unknown AxTable property '{propertyPath}' — nothing was written. Supported: label, developerDocumentation, tableGroup, cacheLookup, clusteredIndex, primaryIndex, replacementKey, saveDataPerCompany, tableType, supportInheritance, instanceRelationType, extends, titleField1, titleField2.");
+                        throw new ArgumentException($"Unknown AxTable property '{propertyPath}' — nothing was written. Supported: label, developerDocumentation, configurationKey, formRef, tableGroup, cacheLookup, clusteredIndex, primaryIndex, replacementKey, saveDataPerCompany, tableType, supportInheritance, instanceRelationType, extends, titleField1, titleField2.");
                     ((IMetaTableProvider)_provider.Tables).Update(obj, msi);
                     return new { success = true, operation = "modify-property", objectType, objectName, propertyPath, propertyValue, api = "Update" };
                 }
@@ -2598,13 +2616,25 @@ namespace D365MetadataBridge.Services
             {
                 case "label": tbl.Label = value; break;
                 case "developerdocumentation": tbl.DeveloperDocumentation = value; break;
+                // ConfigurationKey / FormRef were missing here, so EVERY writer that
+                // funnels through this switch (CreateTable, CreateSmartTable,
+                // modify-property) discarded them while answering success — the table
+                // half of finding #35. Both are plain string properties on AxTable.
+                case "configurationkey": tbl.ConfigurationKey = value; break;
+                case "formref": tbl.FormRef = value; break;
                 case "tablegroup":
-                    if (Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.TableGroup>(value, true, out var tg))
-                        tbl.TableGroup = tg;
+                    if (!Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.TableGroup>(value, true, out var tg))
+                        throw new ArgumentException(
+                            $"'{value}' is not a valid TableGroup. Valid values: " +
+                            string.Join(", ", Enum.GetNames(typeof(Microsoft.Dynamics.AX.Metadata.Core.MetaModel.TableGroup))) + ".");
+                    tbl.TableGroup = tg;
                     break;
                 case "cachelookup":
-                    if (Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.RecordCacheLevel>(value, true, out var cl))
-                        tbl.CacheLookup = cl;
+                    if (!Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.RecordCacheLevel>(value, true, out var cl))
+                        throw new ArgumentException(
+                            $"'{value}' is not a valid CacheLookup. Valid values: " +
+                            string.Join(", ", Enum.GetNames(typeof(Microsoft.Dynamics.AX.Metadata.Core.MetaModel.RecordCacheLevel))) + ".");
+                    tbl.CacheLookup = cl;
                     break;
                 case "clusteredindex": tbl.ClusteredIndex = value; break;
                 case "primaryindex": tbl.PrimaryIndex = value; break;
@@ -2613,8 +2643,11 @@ namespace D365MetadataBridge.Services
                     tbl.SaveDataPerCompany = ParseNoYes(value);
                     break;
                 case "tabletype":
-                    if (Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.TableType>(value, true, out var tt))
-                        tbl.TableType = tt;
+                    if (!Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.TableType>(value, true, out var tt))
+                        throw new ArgumentException(
+                            $"'{value}' is not a valid TableType. Valid values: " +
+                            string.Join(", ", Enum.GetNames(typeof(Microsoft.Dynamics.AX.Metadata.Core.MetaModel.TableType))) + ".");
+                    tbl.TableType = tt;
                     break;
                 case "supportinheritance":
                     tbl.SupportInheritance = ParseNoYes(value);

--- a/eval/corpus/runs/2026-07-22T16__L2-config-key-gated-table__0e1e367.json
+++ b/eval/corpus/runs/2026-07-22T16__L2-config-key-gated-table__0e1e367.json
@@ -1,0 +1,58 @@
+{
+  "run_id": "2026-07-22T16__L2-config-key-gated-table__0e1e367",
+  "case_id": "L2-config-key-gated-table",
+  "tier": 2,
+  "timestamp": "2026-07-22T16:59:17.949Z",
+  "server_git_sha": "0e1e367",
+  "generated_artifacts": [
+    {
+      "path": "AxConfigurationKey/ConDemoModuleKey.xml",
+      "type": "AxConfigurationKey"
+    },
+    {
+      "path": "AxTable/ConDemoGatedSetting.xml",
+      "type": "AxTable"
+    },
+    {
+      "path": "AxMenuItemDisplay/ConDemoGatedSettingMI.xml",
+      "type": "AxMenuItemDisplay"
+    }
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": null,
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": null,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT",
+  "static_gate": {
+    "references_passed": true,
+    "syntax_passed": true,
+    "violations": []
+  },
+  "root_cause_hypothesis": "Build clean (0 errors) and all 3 artifacts produced, but two grounded-path defects surfaced. (1) d365fo_file(action=create, objectType=table) silently DROPS properties.configurationKey: the same property IS honoured by objectType=menu-item-display (ConfigurationKey landed in the MI XML on first write), but the table create path emitted no ConfigurationKey element and no dropped-parameter warning - the finding #35 shape. Workaround needed a second call, modify-property propertyPath=ConfigurationKey, which succeeded only via the direct-XML fallback (bridge reported the element did not exist). (2) modify(add-index) accepts indexAllowDuplicates without warning but never writes AllowDuplicates (tested as boolean false and string \"No\"); sibling indexAlternateKey in the same call DID write. Harmless here because the metadata default is already No, but it is a silent-drop. Secondary VALIDATOR_GAP: validate_code(mode=references, codeType=xml-table) does not resolve <ConfigurationKey> - a bogus ConTotallyBogusKeyXyz passed clean. bp_clean=0 is a case-design artefact, not a defect: the 4 warnings on the case objects (BPErrorMenuItemNotCoveredByPrivilege, BPTableWithRecIdIndexMissingReplacementKey, BPErrorDeveloperDocumentationNotDefined, BPErrorTableMissingFormRef) cannot all be cleared without a form and a privilege, which the case does not ask for; the case text only demands zero BP ERRORS, and errors were 0.",
+  "suggested_fix_area": "d365fo_file table create writer (properties.configurationKey passthrough + dropped-param honesty); add-index writer (indexAllowDuplicates); validate_code xml-table reference resolver (ConfigurationKey element)",
+  "evidence_refs": [
+    "K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxTable/ConDemoGatedSetting.xml",
+    "K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxMenuItemDisplay/ConDemoGatedSettingMI.xml",
+    "K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxConfigurationKey/ConDemoModuleKey.xml"
+  ]
+}

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -29,6 +29,10 @@ import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
 import { buildAxMapXml } from './mapXml.js';
 import { buildAxServiceXml, buildAxServiceGroupXml } from './serviceXml.js';
 import { recordCreatedArtifact } from './createdArtifactLedger.js';
+import {
+  reconcileTableCreateProperties,
+  renderTableCreateHonestyReport,
+} from './createTablePropertyHonesty.js';
 
 /**
  * Per-project-file mutex to serialise concurrent addToProject calls.
@@ -3746,6 +3750,35 @@ function rawLabelBpWarning(properties: unknown, objectName: string): string {
 }
 
 /**
+ * Post-write parameter honesty for a table create (cluster #35).
+ *
+ * The metadata writer — bridge or template — accepts `properties` it does not know
+ * how to write and reports ✅ anyway: `configurationKey` reached neither the smart
+ * nor the generic bridge create because C# SetAxTableProperty() has no case for it
+ * (corpus run 2026-07-22T16__L2-config-key-gated-table). Re-read what actually
+ * landed on disk, write back anything repairable in canonical element order, and
+ * return a report for whatever still could not be honoured. Best-effort by design:
+ * a read/write failure here must never turn a successful create into an error.
+ */
+async function reconcileCreatedTableProperties(
+  filePath: string | undefined,
+  properties: unknown,
+): Promise<string> {
+  if (!filePath || !properties || typeof properties !== 'object') return '';
+  try {
+    const onDisk = await fs.readFile(filePath, 'utf-8');
+    const reconciled = reconcileTableCreateProperties(onDisk, properties as Record<string, unknown>);
+    if (reconciled.patched.length > 0) {
+      await fs.writeFile(filePath, normalizeD365Xml(reconciled.xml), 'utf-8');
+    }
+    return renderTableCreateHonestyReport(reconciled);
+  } catch (e) {
+    console.error(`[create_d365fo_file] table property reconcile skipped: ${e}`);
+    return '';
+  }
+}
+
+/**
  * Create D365FO file handler function
  */
 export async function handleCreateD365File(
@@ -4588,6 +4621,12 @@ export async function handleCreateD365File(
               try { await bridgeRefreshProvider(context.bridge); } catch { /* best-effort */ }
 
               const rawLabelWarning = rawLabelBpWarning(args.properties, finalObjectName);
+              // #35: CreateSmartTable ignores every property its C# switch does not
+              // know (configurationKey, formRef, …) — repair or report, never drop.
+              const honestyReport = await reconcileCreatedTableProperties(
+                smartResult.filePath,
+                args.properties,
+              );
               const bp = smartResult.bpDefaults;
               const bpSummary = bp
                 ? `\n📋 BP defaults: CacheLookup=${bp.cacheLookup ?? '(n/a)'}, TitleField1=${bp.titleField1 ?? '(none)'}, ` +
@@ -4612,7 +4651,7 @@ export async function handleCreateD365File(
                     type: 'text',
                     text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create() (Smart)\n` +
                       `📁 ${smartResult.filePath}${projectMsg}\n` +
-                      `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${rawLabelWarning}`,
+                      `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${honestyReport}${rawLabelWarning}`,
                   },
                 ],
               };
@@ -4678,6 +4717,11 @@ export async function handleCreateD365File(
           try { await bridgeRefreshProvider(context.bridge); } catch { /* best-effort */ }
 
           const rawLabelWarning = rawLabelBpWarning(args.properties, finalObjectName);
+          // #35: C# CreateTable() runs the same SetAxTableProperty() switch as the
+          // smart path and ignores its return value just as thoroughly.
+          const honestyReport = args.objectType === 'table'
+            ? await reconcileCreatedTableProperties(bridgeResult.filePath, args.properties)
+            : '';
 
           // Record the freshly-created file for non-git undo (see smart-table path).
           if (!fileExisted) {
@@ -4695,7 +4739,7 @@ export async function handleCreateD365File(
                 type: 'text',
                 text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create()\n` +
                   `📁 ${bridgeResult.filePath}${projectMsg}\n` +
-                  `🔧 API: ${bridgeResult.message}${rawLabelWarning}`,
+                  `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}`,
               },
             ],
           };
@@ -4837,6 +4881,16 @@ export async function handleCreateD365File(
       /<\/Method>\n(\t*)<Method>/g,
       '</Method>\n\n$1<Method>'
     );
+
+    // #35: the template writer knows a FIXED property list too — anything else the
+    // caller passed lands nowhere. Reconcile before the write so a repairable
+    // property is emitted in canonical order and the rest is reported, not dropped.
+    let tableHonestyReport = '';
+    if (args.objectType === 'table') {
+      const reconciled = reconcileTableCreateProperties(xmlContent, args.properties);
+      xmlContent = reconciled.xml;
+      tableHonestyReport = renderTableCreateHonestyReport(reconciled);
+    }
 
     // Form pattern gate: structural pattern violations (FP001-FP005, FP007)
     // block the write when FORM_PATTERN_ENFORCE is enabled (default).
@@ -5053,6 +5107,7 @@ export async function handleCreateD365File(
             `🔧 Type: ${objectFolder}\n` +
             bridgeValidation +
             formPatternWarnings +
+            tableHonestyReport +
             rawLabelBpWarning(args.properties, finalObjectName) +
             projectMessage +
             `\n${nextSteps}\n` +

--- a/src/tools/createTablePropertyHonesty.ts
+++ b/src/tools/createTablePropertyHonesty.ts
@@ -1,0 +1,243 @@
+/**
+ * Create-path parameter honesty for AxTable.
+ *
+ * Cluster #35 ("a write op silently drops an optional parameter"), create half.
+ * Corpus evidence: eval/corpus/runs/2026-07-22T16__L2-config-key-gated-table__0e1e367.json
+ *
+ *   d365fo_file(action="create", objectType="table",
+ *               properties={ configurationKey: "ConDemoModuleKey" })
+ *
+ * answered ✅ over an AxTable with no <ConfigurationKey> at all and no warning.
+ * The same property IS honoured by the menu-item-display writer, so the caller has
+ * no way to guess which writers keep their promises. Root cause: the create goes
+ * through the bridge's CreateSmartTable, whose C# SetAxTableProperty() switch has
+ * no `configurationkey` (nor `formref`) case — the unknown key hits `default:`,
+ * logs to the bridge's stderr, and returns false, which CreateSmartTable ignores.
+ *
+ * This module closes the hole from the TypeScript side, so it works against an
+ * OLD bridge binary too (no rebuild required):
+ *
+ *   1. Every scalar property the caller passed is reconciled against the XML that
+ *      was actually written.
+ *   2. A property that did not land but CAN be expressed as an AxTable element is
+ *      written on disk in canonical order (upsertAxTableProperty — the same repair
+ *      the modify surface already uses for FormRef).
+ *   3. Anything left over — a property that does not exist at table level, or one
+ *      whose value is not legal for its enum — is REPORTED, never dropped silently.
+ *
+ * Deliberately conservative: a property that is already present in the document is
+ * left exactly as the writer produced it (no value overwriting), and a value that
+ * equals the serializer-omitted default counts as honoured rather than being
+ * written redundantly. Both rules keep this off the golden-metadata diff.
+ */
+
+import {
+  AX_TABLE_ELEMENT_ORDER,
+  AX_TABLE_NON_EXISTENT_PROPERTIES,
+  upsertAxTableProperty,
+} from '../utils/axTablePropertyOrder.js';
+
+/** Keys of `properties` that are handled by their own bridge parameter, not as elements. */
+const STRUCTURAL_TABLE_KEYS = new Set(
+  [
+    'fields',
+    'fieldgroups',
+    'indexes',
+    'relations',
+    'methods',
+    'deleteactions',
+    'values',
+    'enumvalues',
+    'mappings',
+    'statemachines',
+    'fulltextindexes',
+  ].map(k => k.toLowerCase()),
+);
+
+/**
+ * Enum-typed table properties and their legal values. An illegal value is reported
+ * with the legal list instead of being written — the same contract the bridge's
+ * add-relation path adopted in 8be57d7 ("'Nonsense' is not a valid RelationshipType.
+ * Valid values: …") rather than silently leaving the default in place.
+ */
+const AX_TABLE_ENUM_VALUES: Record<string, readonly string[]> = {
+  TableGroup: [
+    'Miscellaneous', 'Parameter', 'Group', 'Main', 'Transaction',
+    'WorksheetHeader', 'WorksheetLine', 'TransactionHeader', 'TransactionLine',
+    'Reference', 'Framework',
+  ],
+  CacheLookup: ['None', 'NotInTTS', 'Found', 'FoundAndEmpty', 'EntireTable'],
+  TableType: ['Regular', 'RegularTable', 'InMemory', 'TempDB'],
+  ValidTimeStateFieldType: ['None', 'Date', 'UtcDateTime'],
+  SaveDataPerCompany: ['Yes', 'No'],
+  SupportInheritance: ['Yes', 'No'],
+  SystemTable: ['Yes', 'No'],
+  Visible: ['Yes', 'No'],
+};
+
+/** NoYes-typed properties, where `true`/`false` must be spelled Yes/No in XML. */
+const NO_YES_PROPERTIES = new Set(['SaveDataPerCompany', 'SupportInheritance', 'SystemTable', 'Visible']);
+
+/**
+ * Values the AxTable serializer omits because they ARE the default. Requesting one
+ * of these and getting no element back is not a dropped parameter — writing it would
+ * add an element no shipped table has.
+ */
+const AX_TABLE_OMITTED_DEFAULTS: Record<string, readonly string[]> = {
+  TableGroup: ['Miscellaneous'],
+  CacheLookup: ['NotInTTS'],
+  TableType: ['Regular', 'RegularTable'],
+  ValidTimeStateFieldType: ['None'],
+  SaveDataPerCompany: ['Yes'],
+  SupportInheritance: ['No'],
+  SystemTable: ['No'],
+  Visible: ['Yes'],
+};
+
+/** A property the create writer accepted but could not honour. */
+export interface UnhonouredCreateProperty {
+  /** The key as the caller spelled it. */
+  name: string;
+  /** The value the caller asked for. */
+  value: string;
+  /** Why it could not be written. */
+  detail: string;
+}
+
+export interface TableCreateReconcileResult {
+  /** The document, with every repairable dropped property written back in. */
+  xml: string;
+  /** Properties that the writer dropped and this repair wrote on disk. */
+  patched: { name: string; element: string; value: string }[];
+  /** Properties that could not be written at all — must be surfaced to the caller. */
+  unhonoured: UnhonouredCreateProperty[];
+}
+
+/** Canonical AxTable element name for a caller-supplied key, or undefined if unknown. */
+function canonicalElement(key: string): string | undefined {
+  const lower = key.toLowerCase();
+  const known = AX_TABLE_ELEMENT_ORDER.find((e: string) => e.toLowerCase() === lower);
+  if (known) return known;
+  const nonExistent = Object.keys(AX_TABLE_NON_EXISTENT_PROPERTIES).find(e => e.toLowerCase() === lower);
+  if (nonExistent) return nonExistent;
+  return undefined;
+}
+
+/** Normalise a caller value to its XML spelling (booleans → Yes/No for NoYes props). */
+function normaliseValue(element: string | undefined, raw: string | number | boolean): string {
+  const s = String(raw);
+  if (element && NO_YES_PROPERTIES.has(element)) {
+    if (/^(true|yes|1)$/i.test(s)) return 'Yes';
+    if (/^(false|no|0)$/i.test(s)) return 'No';
+  }
+  return s;
+}
+
+/** Does the document already carry a non-empty value for this element? */
+function elementPresent(xml: string, element: string): boolean {
+  const re = new RegExp(`<${element}>\\s*([^<]*?)\\s*</${element}>`);
+  const m = re.exec(xml);
+  return m ? m[1].length > 0 : false;
+}
+
+/**
+ * Reconcile the properties the caller asked for against the AxTable XML that was
+ * actually written. Only scalar values are considered — collections travel as their
+ * own bridge parameters and are checked elsewhere.
+ */
+export function reconcileTableCreateProperties(
+  xml: string,
+  properties: Record<string, unknown> | undefined,
+): TableCreateReconcileResult {
+  const result: TableCreateReconcileResult = { xml, patched: [], unhonoured: [] };
+  if (!properties || !/<AxTable[\s>]/.test(xml)) return result;
+
+  for (const [key, rawValue] of Object.entries(properties)) {
+    if (rawValue === undefined || rawValue === null) continue;
+    if (!['string', 'number', 'boolean'].includes(typeof rawValue)) continue;
+    if (STRUCTURAL_TABLE_KEYS.has(key.toLowerCase())) continue;
+    if (String(rawValue).length === 0) continue;
+
+    const element = canonicalElement(key);
+    const value = normaliseValue(element, rawValue as string | number | boolean);
+
+    // A name that does not exist at table level — never write it, always say so.
+    if (element && AX_TABLE_NON_EXISTENT_PROPERTIES[element]) {
+      result.unhonoured.push({ name: key, value, detail: AX_TABLE_NON_EXISTENT_PROPERTIES[element] });
+      continue;
+    }
+
+    // The writer honoured it (or emitted its own value) — leave the document alone.
+    const probe = element ?? key.charAt(0).toUpperCase() + key.slice(1);
+    if (elementPresent(result.xml, probe)) continue;
+
+    if (!element) {
+      result.unhonoured.push({
+        name: key,
+        value,
+        detail:
+          `'${key}' is not a known AxTable property, so the writer could not place it in the ` +
+          `order-sensitive property block. Check the spelling against the AxTable metamodel, or ` +
+          `pass it through d365fo_file(action="modify", operation="modify-property").`,
+      });
+      continue;
+    }
+
+    // Requested value IS the serializer default — absence is correct, not a drop.
+    const omitted = AX_TABLE_OMITTED_DEFAULTS[element];
+    if (omitted?.some(d => d.toLowerCase() === value.toLowerCase())) continue;
+
+    const legal = AX_TABLE_ENUM_VALUES[element];
+    if (legal && !legal.some(v => v.toLowerCase() === value.toLowerCase())) {
+      result.unhonoured.push({
+        name: key,
+        value,
+        detail: `'${value}' is not a valid ${element}. Valid values: ${legal.join(', ')}.`,
+      });
+      continue;
+    }
+
+    const canonicalValue = legal?.find(v => v.toLowerCase() === value.toLowerCase()) ?? value;
+    const patchedXml = upsertAxTableProperty(result.xml, element, canonicalValue);
+    if (patchedXml) {
+      result.xml = patchedXml;
+      result.patched.push({ name: key, element, value: canonicalValue });
+    } else {
+      result.unhonoured.push({
+        name: key,
+        value,
+        detail:
+          `<${element}> has no defined position in the AxTable element order, so writing it ` +
+          `could corrupt the document (the deserializer drops misordered elements silently). ` +
+          `It was NOT written.`,
+      });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Caller-facing report for a reconciled table create. Empty string when the writer
+ * honoured everything — silence here means "nothing was dropped", which is exactly
+ * the guarantee that was missing.
+ */
+export function renderTableCreateHonestyReport(result: TableCreateReconcileResult): string {
+  const parts: string[] = [];
+  if (result.patched.length > 0) {
+    parts.push(
+      `\n🔧 Written after the create (the metadata writer dropped ${result.patched.length === 1 ? 'it' : 'them'}): ` +
+        result.patched.map(p => `<${p.element}>${p.value}</${p.element}>`).join(', ') +
+        `\n   The C# bridge's SetAxTableProperty() does not know ${result.patched.map(p => p.element).join('/')}; ` +
+        `the value was written into the AxTable XML in canonical element order instead.`,
+    );
+  }
+  if (result.unhonoured.length > 0) {
+    parts.push(
+      `\n⚠️ DROPPED — ${result.unhonoured.length} propert${result.unhonoured.length === 1 ? 'y was' : 'ies were'} ` +
+        `accepted but NOT written:\n` +
+        result.unhonoured.map(p => `   • ${p.name}=${p.value} — ${p.detail}`).join('\n'),
+    );
+  }
+  return parts.join('\n');
+}

--- a/tests/tools/createTableParamSilentDrop.test.ts
+++ b/tests/tools/createTableParamSilentDrop.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Cluster #35, create half — d365fo_file(action="create", objectType="table") must
+ * never DISCARD an optional property in silence.
+ *
+ * Corpus evidence:
+ *   eval/corpus/runs/2026-07-22T16__L2-config-key-gated-table__0e1e367.json
+ *     "d365fo_file(action=create, objectType=table) silently DROPS
+ *      properties.configurationKey: the same property IS honoured by
+ *      objectType=menu-item-display … the table create path emitted no
+ *      ConfigurationKey element and no dropped-parameter warning"
+ *   evidence_refs:
+ *     K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxTable/ConDemoGatedSetting.xml
+ *     K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxMenuItemDisplay/ConDemoGatedSettingMI.xml
+ *
+ * Root cause, reproduced here without the VM: the create routes through the bridge's
+ * CreateSmartTable, whose C# SetAxTableProperty() switch has no `configurationkey`
+ * case — the key falls into `default:`, whose return value CreateSmartTable ignored.
+ * The mock bridge below writes exactly the document the real (pre-fix) bridge wrote:
+ * every known property, and nothing for the unknown ones.
+ *
+ * The contract asserted: every scalar property the caller passes either lands in the
+ * XML or is named in the response as dropped. No third option.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleCreateD365File } from '../../src/tools/createD365File';
+import {
+  reconcileTableCreateProperties,
+  renderTableCreateHonestyReport,
+} from '../../src/tools/createTablePropertyHonesty';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// ─── In-memory filesystem ────────────────────────────────────────────────────
+// The reconcile step re-reads what the writer actually produced, so the mock has
+// to behave like a disk, not like a stub that always answers the same string.
+
+const { files } = vi.hoisted(() => ({ files: new Map<string, string>() }));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (files.has(p)) return files.get(p)!;
+    if (p.endsWith('.rnrproj')) return `<Project><ItemGroup /></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: vi.fn(async (p: string, content: string) => { files.set(p, content); }),
+  copyFile: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async (p: string) => {
+    if (/^[A-Za-z]:[\\/]?$/.test(p) || p === '/') return;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false, size: 1024 })),
+  readdir: vi.fn(async () => []),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return { ...actual, bridgeValidateAfterWrite: vi.fn(async () => null) };
+});
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (modelName: string) => ({
+      packageName: modelName, modelName, rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({
+      packageName: p, modelName: m, rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  getExtensionNamingStyle: vi.fn(() => 'prefix'),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'create_d365fo_file', arguments: args },
+});
+
+const TABLE_PATH = 'K:\\PackagesLocalDirectory\\Contoso\\Contoso\\AxTable\\ConDemoGatedSetting.xml';
+
+/** The AxTable the real CreateSmartTable wrote on the VM — no <ConfigurationKey>. */
+const smartTableXmlAsWrittenByTheBridge = (name: string) =>
+  `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<SourceCode>
+\t\t<Declaration><![CDATA[
+public class ${name} extends common
+{
+}
+]]></Declaration>
+\t\t<Methods />
+\t</SourceCode>
+\t<Label>Gated setting</Label>
+\t<TableGroup>Main</TableGroup>
+\t<TitleField1>SettingId</TitleField1>
+\t<CacheLookup>Found</CacheLookup>
+\t<ClusteredIndex>SettingIdx</ClusteredIndex>
+\t<PrimaryIndex>SettingIdx</PrimaryIndex>
+\t<DeleteActions />
+\t<FieldGroups />
+\t<Fields />
+\t<Indexes />
+\t<Relations />
+</AxTable>`;
+
+/** A bridge that behaves exactly like the pre-fix C# SetAxTableProperty switch. */
+const legacyBridge = () => {
+  const createSmartTable = vi.fn(async (params: any) => {
+    files.set(TABLE_PATH, smartTableXmlAsWrittenByTheBridge(params.objectName));
+    return {
+      success: true,
+      filePath: TABLE_PATH,
+      api: 'IMetaTableProvider.Create (Smart)',
+      bpDefaults: { cacheLookup: 'Found', titleField1: 'SettingId', primaryIndex: 'SettingIdx' },
+    };
+  });
+  return {
+    createSmartTable,
+    bridge: {
+      isReady: true,
+      metadataAvailable: true,
+      createSmartTable,
+      createObject: vi.fn(async () => { throw new Error('generic create must not be used'); }),
+      validateObject: vi.fn(async () => null),
+      refreshProvider: vi.fn(async () => ({ success: true })),
+    } as any,
+  };
+};
+
+const buildContext = (bridge?: unknown) => ({
+  bridge,
+  symbolIndex: {
+    searchSymbols: vi.fn(() => []),
+    getSymbolByName: vi.fn(() => undefined),
+    getCustomModels: vi.fn(() => ['Contoso']),
+    db: { prepare: vi.fn(() => ({ all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() })) },
+    getReadDb: vi.fn(function (this: any) { return this.db; }),
+  },
+} as any);
+
+beforeEach(() => {
+  files.clear();
+  vi.clearAllMocks();
+});
+
+// ─── The corpus defect, end to end ───────────────────────────────────────────
+
+describe('#35 create table: properties.configurationKey must not vanish', () => {
+  it('writes <ConfigurationKey> even when the metadata writer drops it', async () => {
+    const { bridge } = legacyBridge();
+    const result = await handleCreateD365File(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoGatedSetting',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: {
+          label: 'Gated setting',
+          tableGroup: 'Main',
+          configurationKey: 'ConDemoModuleKey',
+        },
+      }),
+      buildContext(bridge),
+    );
+
+    expect((result as any).isError).toBeFalsy();
+
+    // The whole point of the case: the config key is IN the table on disk.
+    const onDisk = files.get(TABLE_PATH)!;
+    expect(onDisk).toContain('<ConfigurationKey>ConDemoModuleKey</ConfigurationKey>');
+
+    // AxTable is order-sensitive: ConfigurationKey precedes Label/TableGroup or the
+    // deserializer drops it without a word (see axTablePropertyOrder).
+    expect(onDisk.indexOf('<ConfigurationKey>')).toBeLessThan(onDisk.indexOf('<Label>'));
+    expect(onDisk.indexOf('<ConfigurationKey>')).toBeLessThan(onDisk.indexOf('<TableGroup>'));
+
+    // And the caller is told, rather than being handed a bare ✅.
+    expect(result.content[0].text).toMatch(/ConfigurationKey/);
+  });
+
+  it('reports a property that cannot be written at all instead of answering a bare ✅', async () => {
+    const { bridge } = legacyBridge();
+    const result = await handleCreateD365File(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoGatedSetting',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: { label: 'Gated setting', configKey: 'ConDemoModuleKey' },
+      }),
+      buildContext(bridge),
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/DROPPED/);
+    expect(result.content[0].text).toMatch(/configKey/);
+    // Never invent an element for a name the metamodel does not have.
+    expect(files.get(TABLE_PATH)!).not.toContain('ConfigKey>');
+  });
+
+  it('stays silent when the writer honoured everything', async () => {
+    const { bridge } = legacyBridge();
+    const result = await handleCreateD365File(
+      req({
+        objectType: 'table',
+        objectName: 'ConDemoGatedSetting',
+        modelName: 'Contoso',
+        packageName: 'Contoso',
+        packagePath: 'K:\\PackagesLocalDirectory',
+        addToProject: false,
+        properties: {
+          label: 'Gated setting',
+          tableGroup: 'Main',
+          cacheLookup: 'Found',
+          fields: [{ name: 'SettingId', type: 'String' }],
+        },
+      }),
+      buildContext(bridge),
+    );
+
+    expect(result.content[0].text).not.toMatch(/DROPPED/);
+    expect(result.content[0].text).not.toMatch(/Written after the create/);
+  });
+});
+
+// ─── The reconciler itself ───────────────────────────────────────────────────
+
+describe('reconcileTableCreateProperties', () => {
+  const base = smartTableXmlAsWrittenByTheBridge('ConDemoGatedSetting');
+
+  it('patches every string property the writer skipped, in canonical order', () => {
+    const r = reconcileTableCreateProperties(base, {
+      configurationKey: 'ConDemoModuleKey',
+      formRef: 'ConDemoGatedSettingForm',
+      developerDocumentation: '@ConDemo:Doc',
+    });
+    expect(r.unhonoured).toEqual([]);
+    expect(r.patched.map(p => p.element).sort()).toEqual([
+      'ConfigurationKey', 'DeveloperDocumentation', 'FormRef',
+    ]);
+    // ConfigurationKey → DeveloperDocumentation → FormRef → Label
+    const order = ['ConfigurationKey', 'DeveloperDocumentation', 'FormRef', 'Label']
+      .map(e => r.xml.indexOf(`<${e}>`));
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    expect(order.every(i => i >= 0)).toBe(true);
+  });
+
+  it('leaves a property the writer already wrote exactly as it is', () => {
+    const r = reconcileTableCreateProperties(base, { label: 'Something else' });
+    expect(r.patched).toEqual([]);
+    expect(r.unhonoured).toEqual([]);
+    expect(r.xml).toBe(base);
+  });
+
+  it('does not write a value that IS the serializer default', () => {
+    // The AxTable serializer omits these; emitting them would show up as a
+    // golden-metadata diff against every shipped table.
+    const r = reconcileTableCreateProperties(base, {
+      saveDataPerCompany: true,
+      supportInheritance: false,
+      tableType: 'Regular',
+    });
+    expect(r.patched).toEqual([]);
+    expect(r.unhonoured).toEqual([]);
+  });
+
+  it('writes a NON-default NoYes property with the XML spelling, not true/false', () => {
+    const r = reconcileTableCreateProperties(base, { saveDataPerCompany: false });
+    expect(r.xml).toContain('<SaveDataPerCompany>No</SaveDataPerCompany>');
+    expect(r.xml).not.toContain('>false<');
+  });
+
+  it('refuses an illegal enum value and names the legal ones', () => {
+    const r = reconcileTableCreateProperties(base, { tableType: 'Nonsense' });
+    expect(r.patched).toEqual([]);
+    expect(r.unhonoured[0].detail).toMatch(/not a valid TableType/);
+    expect(r.unhonoured[0].detail).toMatch(/TempDB/);
+    expect(r.xml).not.toContain('Nonsense');
+  });
+
+  it('rejects a table-level name that only exists on an index (finding #13)', () => {
+    const r = reconcileTableCreateProperties(base, { alternateKey: 'SettingIdx' });
+    expect(r.patched).toEqual([]);
+    expect(r.unhonoured[0].detail).toMatch(/INDEX property/);
+    expect(r.xml).not.toContain('<AlternateKey>');
+  });
+
+  it('ignores the collections, which travel as their own bridge parameters', () => {
+    const r = reconcileTableCreateProperties(base, {
+      fields: [{ name: 'A' }], indexes: [], relations: [], methods: [], fieldGroups: [],
+    });
+    expect(r.patched).toEqual([]);
+    expect(r.unhonoured).toEqual([]);
+  });
+
+  it('does nothing to a document that is not an AxTable', () => {
+    const enumXml = '<AxEnum><Name>ConDemoEnum</Name></AxEnum>';
+    const r = reconcileTableCreateProperties(enumXml, { configurationKey: 'K' });
+    expect(r.xml).toBe(enumXml);
+    expect(r.patched).toEqual([]);
+  });
+
+  it('renders nothing when there is nothing to say', () => {
+    expect(renderTableCreateHonestyReport({ xml: base, patched: [], unhonoured: [] })).toBe('');
+  });
+});


### PR DESCRIPTION
## The defect

Corpus evidence: `eval/corpus/runs/2026-07-22T16__L2-config-key-gated-table__0e1e367.json`
(included in this PR so the record and its fix land together), case `L2-config-key-gated-table`,
tier 2, classification `TOOL_DEFECT`.

`evidence_refs`:
- `K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxTable/ConDemoGatedSetting.xml` — created with **no `<ConfigurationKey>`**
- `K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxMenuItemDisplay/ConDemoGatedSettingMI.xml` — the **same** property honoured on the first write
- `K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxConfigurationKey/ConDemoModuleKey.xml`

```
d365fo_file(action="create", objectType="table",
            properties={ configurationKey: "ConDemoModuleKey" })
→ ✅ Created table … (and no ConfigurationKey anywhere on disk)
```

The build was green, the static gate was green, and the caller had no way to learn the
property was gone. The asymmetry with `menu-item-display` is the bug: nothing tells a
caller which writers keep their promises.

## Confirmed cause (reproduced in-repo, no VM)

C# `SetAxTableProperty()` — shared by `CreateTable`, `CreateSmartTable` **and**
`modify-property` — has no `configurationkey` case (nor `formref`). The key falls into
`default:`, which logs to the bridge's stderr and returns `false`; both create paths
threw that return value away. That is also why the implementer's workaround
(`modify-property` `ConfigurationKey`) only landed via the tool's direct-XML fallback.

Exactly the shape 8be57d7 fixed for the modify half — a write reported as done that was
never made — with the create path left uncovered.

## The fix

**TypeScript (works against an unchanged bridge binary):** new
`src/tools/createTablePropertyHonesty.ts`. After a table create, every scalar property
the caller passed is reconciled against the XML that actually landed:

1. dropped but expressible as an AxTable element → written back in canonical order
   (`upsertAxTableProperty`, the repair the modify surface already uses for `FormRef`);
2. anything else → **reported**, never dropped.

There is no third outcome any more — that is the whole contract. Widened past
`configurationKey`: it covers every scalar property of the create surface, and is wired
into all three table create paths (bridge smart create, generic bridge create, XML
template fallback).

Deliberately conservative, to stay off the golden diff:
- a property already present is left exactly as the writer produced it (no value overwriting);
- a value that IS the serializer-omitted default (`TableType=Regular`, `SaveDataPerCompany=Yes`, …) counts as honoured rather than written redundantly;
- an illegal enum value is refused with the legal list rather than written;
- a name that does not exist at table level (`alternateKey` — finding #13) is never invented as an element.

**C# bridge — needs a rebuild + MCP restart to take effect.** The TS side above does
*not* depend on it; until the rebuild, the property is patched onto the file instead of
being set through the provider.
- `SetAxTableProperty()` learns `configurationKey` and `formRef` (both plain string properties on `AxTable`); the `modify-property` "Supported:" message is updated to match.
- `CreateTable`/`CreateSmartTable` no longer discard the return value — the response carries `appliedProperties` / `unsupportedProperties`.
- An unparsable `TableGroup`/`CacheLookup`/`TableType` now throws with the legal values instead of silently leaving the default in place (previously `Enum.TryParse` failure fell through and still returned `true`).

## Regression proof

`tests/tools/createTableParamSilentDrop.test.ts` drives the real `handleCreateD365File`
against a mock bridge that reproduces the pre-fix C# switch byte for byte (it writes the
document the VM run produced: every known property, nothing for the unknown ones).

On `main`, with only the TS hook reverted:

```
FAIL … > writes <ConfigurationKey> even when the metadata writer drops it
  expected '…<AxTable…' to contain '<ConfigurationKey>ConDemoModuleKey</ConfigurationKey>'
FAIL … > reports a property that cannot be written at all instead of answering a bare ✅
  expected '✅ Created table …' to match /DROPPED/
```

With the fix: 12/12 pass, including canonical-element-order and
"stays silent when the writer honoured everything".

## Validation (anti-overfitting)

- `npx vitest run` → **165 files, 2186 passed, 2 skipped, 0 failed** — includes the golden-integrity gate `tests/eval/goldens.test.ts`. No committed golden was edited.
- `npx tsc --noEmit` clean.
- `npm run eval:report` on this branch: `build=80% golden=35%` per-tier `L0 100/50 · L1 58/0 · L2 100/50 · L3 71/43 · L4 60/40` — unchanged from before the fix (the corpus is a record of past VM runs; a repo fix cannot move it until the cases are re-run). The held-out signal here is the full golden suite, which is green.
- Verified by construction that the reconciler cannot add an element to a shipped-table-shaped document: defaults are treated as honoured and present properties are left untouched.

## Known but NOT fixed (same VM run, different clusters — filed, not bundled)

- **`add-index` accepts `indexAllowDuplicates` and never writes it.** Tested on the VM as boolean `false` and string `"No"`; the sibling `indexAlternateKey` in the same call DID write. Harmless in that run only because the metadata default is already `No`. Separate writer, separate PR.
- **`validate_code(mode="references")` does not resolve `<ConfigurationKey>` in table XML.** A deliberately bogus `ConTotallyBogusKeyXyz` passed the gate as "verified" — a `VALIDATOR_GAP`, not this `TOOL_DEFECT`. (The 2026-07-23 `L2-license-code-configkey` run reports the same resolver blind spot for `AxLicenseCode`/`AxConfigurationKey`, so the two should be fixed together.)

Not auto-merged — please review, and note the bridge half is inert until the exe is rebuilt on the VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
