### PR TITLE
fix(search): prioritize custom/ISV models so they aren't buried under Microsoft objects

### DIFF
--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -15,7 +15,7 @@ import type { BridgeClient } from './bridgeClient.js';
 import * as debouncedRefresh from './debouncedRefresh.js';
 import { debugLog } from '../utils/logger.js';
 import { reindentXppSource } from '../utils/xppFormat.js';
-import { rankExactFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
+import { rankCustomFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
 import type {
   BridgeTableInfo,
   BridgeClassInfo,
@@ -682,6 +682,15 @@ export interface BridgeSearchOptions {
    * window is spliced in and ranked first.
    */
   exactMatches?: Array<{ name: string; type: string }>;
+  /**
+   * Keyword hits from CUSTOM/ISV models the caller resolved from the SQLite
+   * index (model-scoped, FTS-driven). The bridge enumerates a single merged
+   * key list dominated by Microsoft standard objects and truncates at
+   * maxResults, so custom matches that enumerate later never reach the client.
+   * These are spliced in and ranked directly after the exact matches (ahead of
+   * Microsoft standard hits) so custom code is always visible.
+   */
+  customMatches?: Array<{ name: string; type: string }>;
 }
 
 export async function tryBridgeSearch(
@@ -707,11 +716,29 @@ export async function tryBridgeSearch(
       spliced.push({ ...cand, fromIndex: true });
     }
 
-    const merged = [...spliced, ...bridgeHits];
+    const key = (n: string, t: string) => `${n.toLowerCase()} ${t}`;
+    const exactKeys = new Set(spliced.map(s => key(s.name, s.type)));
+    const bridgeKeys = new Set(bridgeHits.map(r => key(r.name, r.type)));
+
+    // Custom/ISV matches truncated out of the Microsoft-dominated bridge window:
+    // splice the ones the window missed and flag them so they rank ahead of
+    // Microsoft standard hits (see BridgeSearchOptions.customMatches).
+    const customKeys = new Set((opts?.customMatches ?? []).map(c => key(c.name, c.type)));
+    const customSpliced = (opts?.customMatches ?? [])
+      .filter(c => !exactKeys.has(key(c.name, c.type)) && !bridgeKeys.has(key(c.name, c.type)))
+      .map(c => ({ name: c.name, type: c.type, fromIndex: true as const, custom: true as const }));
+    const splicedCustom = customSpliced.length;
+
+    const merged: Array<{ name: string; type: string; fromIndex?: boolean; custom?: boolean }> = [
+      ...spliced.map(s => ({ ...s })),
+      ...customSpliced,
+      ...bridgeHits.map(r => ({ name: r.name, type: r.type, custom: customKeys.has(key(r.name, r.type)) })),
+    ];
     if (merged.length === 0) return null;
 
     // Exact name matches first — the bridge itself returns provider order (#15).
-    const ranked = rankExactFirst(query, merged, r => r.name).slice(0, Math.max(maxResults, spliced.length));
+    const ranked = rankCustomFirst(query, merged, r => r.name, r => !!r.custom)
+      .slice(0, Math.max(maxResults, spliced.length + splicedCustom));
 
     let out = `# Search: "${query}"${objectType ? ` (type: ${objectType})` : ''}\n\n`;
     out += `**Results:** ${ranked.length}\n`;
@@ -725,6 +752,11 @@ export async function tryBridgeSearch(
     if (spliced.length > 0) {
       out += `\n_${spliced.length} exact match(es) came from the SQLite symbol index — ` +
         `the bridge's result window (maxResults=${maxResults}) did not contain them._\n`;
+    }
+
+    if (splicedCustom > 0) {
+      out += `\n_${splicedCustom} custom/ISV-model match(es) were spliced in from the ` +
+        `SQLite symbol index and prioritized (bridge window maxResults=${maxResults} had truncated them)._\n`;
     }
 
     return { content: [{ type: 'text', text: out }] };

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -28,7 +28,6 @@ export interface SymbolCounts {
 export class XppSymbolIndex {
   public db: Database.Database; // Public for direct pragma access in build scripts
   public labelsDb: Database.Database; // Separate DB for labels (performance optimization)
-  private standardModels: string[] = [];
   private stmtCache: Map<string, Database.Statement> = new Map();
   private labelsStmtCache: Map<string, Database.Statement> = new Map();
   // Buffer for property_stats observations — flushed once per model (batch INSERT)
@@ -103,7 +102,6 @@ export class XppSymbolIndex {
     // optimize/ANALYZE intentionally NOT run here (slow on 500K+ rows) — the
     // pre-built DB already has persisted stats; use runPostBuildTasks() instead.
 
-    this.loadStandardModels();
     this.initializeDatabase();
 
     // Skip pool for :memory: — each new connection would be a separate empty DB.
@@ -243,14 +241,6 @@ export class XppSymbolIndex {
       relatedMethods: row.related_methods || undefined,
       apiPatterns: row.api_patterns || undefined,
     };
-  }
-
-  /**
-   * Kept for compatibility; standard-model determination now lives in
-   * isStandardModel() from modelClassifier (standard = not in CUSTOM_MODELS).
-   */
-  private loadStandardModels(): void {
-    this.standardModels = [];
   }
 
   private initializeDatabase(): void {
@@ -2836,8 +2826,14 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Get list of custom models (non-standard models)
-   * Filters out Microsoft's standard D365 F&O models loaded from config
+   * Get list of custom models (non-standard models).
+   *
+   * Standard-model determination is delegated to `isStandardModel()` from
+   * modelClassifier (CUSTOM_MODELS / EXTENSION_PREFIX / configured target model).
+   * The legacy `this.standardModels` array is always empty (see
+   * `loadStandardModels()`), so filtering against it used to return EVERY model
+   * — including Microsoft's — as "custom". Filtering via `isStandardModel()`
+   * restores the intended custom-only result.
    */
   getCustomModels(): string[] {
     const stmt = this.db.prepare(`
@@ -2849,7 +2845,73 @@ export class XppSymbolIndex {
     const rows = stmt.all() as { model: string }[];
     return rows
       .map(row => row.model)
-      .filter(model => !this.standardModels.includes(model));
+      .filter(model => !isStandardModel(model));
+  }
+
+  /**
+   * Full-text symbol search restricted to CUSTOM/ISV models.
+   *
+   * Broad keyword searches routed through the C# bridge fill their fixed result
+   * window (`maxResults`) in provider-enumeration order, which is dominated by
+   * the far larger Microsoft standard corpus — so custom matches that enumerate
+   * later get truncated and the search looks like it "only returns Microsoft
+   * objects". The search tool probes this method in parallel and splices the
+   * custom hits back in, ranked directly after exact-name matches.
+   *
+   * Index-safe: the FTS5 MATCH drives the query and the `model IN (...)` filter
+   * (idx_symbols_model) narrows to the small custom set. The LIKE fallback (only
+   * reached on an FTS5 syntax error) is also model-scoped, so the selective
+   * `model IN` predicate keeps it off a full `%query%` scan of the whole corpus.
+   */
+  searchCustomModelSymbols(query: string, types?: string[], limit: number = 15): XppSymbol[] {
+    const customModels = this.getCustomModels();
+    if (customModels.length === 0) return [];
+
+    const modelPlaceholders = customModels.map(() => '?').join(',');
+    const ftsQuery = this.sanitizeFtsQuery(query);
+    const db = this.getReadDb();
+
+    let sql = `
+      SELECT s.id, s.name, s.type, s.parent_name, s.signature, s.file_path, s.model, s.description
+      FROM symbols_fts fts
+      JOIN symbols s ON s.id = fts.rowid
+      WHERE symbols_fts MATCH ?
+        AND s.model IN (${modelPlaceholders})
+    `;
+    const params: any[] = [ftsQuery, ...customModels];
+    if (types && types.length > 0) {
+      sql += ` AND s.type IN (${types.map(() => '?').join(',')})`;
+      params.push(...types);
+    }
+    sql += ` ORDER BY rank LIMIT ?`;
+    params.push(limit);
+
+    try {
+      const stmt = db.prepare(sql);
+      return (stmt.all(...params) as any[]).map(row => this.rowToSymbol(row));
+    } catch {
+      // FTS5 syntax error (query contains *, ", (, ), -) → LIKE fallback, still model-scoped.
+      const escapeLikePattern = (value: string): string =>
+        value.replace(/\\/g, '\\\\').replace(/[%_]/g, '\\$&');
+      let fb = `
+        SELECT s.id, s.name, s.type, s.parent_name, s.signature, s.file_path, s.model, s.description
+        FROM symbols s
+        WHERE s.name LIKE ? ESCAPE '\\'
+          AND s.model IN (${modelPlaceholders})
+      `;
+      const fbParams: any[] = [`%${escapeLikePattern(query)}%`, ...customModels];
+      if (types && types.length > 0) {
+        fb += ` AND s.type IN (${types.map(() => '?').join(',')})`;
+        fbParams.push(...types);
+      }
+      fb += ` ORDER BY s.name LIMIT ?`;
+      fbParams.push(limit);
+      try {
+        return (db.prepare(fb).all(...fbParams) as any[]).map(r => this.rowToSymbol(r));
+      } catch {
+        return [];
+      }
+    }
   }
 
   /**

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -19,7 +19,8 @@ import {
 } from '../utils/suggestionEngine.js';
 import { tryBridgeSearch } from '../bridge/bridgeAdapter.js';
 import { lookupSymbolsNocase } from '../utils/symbolLookup.js';
-import { rankExactFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
+import { rankCustomFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
+import { isCustomModel } from '../utils/modelClassifier.js';
 
 /**
  * Index-safe probe for symbols whose name EQUALS the query (#15).
@@ -55,6 +56,39 @@ export function probeExactMatches(
   }
 }
 
+/**
+ * Probe the SQLite index for keyword matches that live in CUSTOM/ISV models.
+ *
+ * Broad keyword searches routed through the C# bridge fill their fixed result
+ * window in provider-enumeration order (Microsoft-dominated) and truncate at
+ * `maxResults`, so custom matches enumerated later never reach the client — the
+ * search then looks like it "returns only Microsoft objects". These hits are
+ * spliced back into the bridge/external results and ranked directly after exact
+ * matches so custom code is always visible. Model-scoped and FTS-driven, so it
+ * stays index-safe (never a full `%query%` scan of the whole corpus).
+ *
+ * Returns [] on any failure — the custom-first repair must never break search.
+ */
+export function probeCustomMatches(
+  symbolIndex: any,
+  query: string,
+  types?: string[],
+  limit = 15,
+): Array<{ name: string; type: string; model?: string; filePath?: string }> {
+  if (!query) return [];
+  try {
+    const hits = symbolIndex?.searchCustomModelSymbols?.(query, types, limit) ?? [];
+    return hits.map((hit: any) => ({
+      name: hit.name,
+      type: hit.type,
+      model: hit.model ?? undefined,
+      filePath: hit.filePath ?? hit.file_path ?? undefined,
+    }));
+  } catch {
+    return [];
+  }
+}
+
 const SearchArgsSchema = z.object({
   query: z.string().describe('Search query (class name, method name, etc.)'),
   type: z.enum([
@@ -65,7 +99,7 @@ const SearchArgsSchema = z.object({
     'enum-extension', 'edt-extension', 'data-entity-extension',
     'all',
   ]).optional().default('all').describe('Filter by object type (all=no filter, use specific type to narrow results)'),
-  limit: z.number().max(100).optional().default(20).describe('Maximum results to return'),
+  limit: z.number().max(100).optional().default(50).describe('Maximum results to return'),
   workspacePath: z.string().optional().describe('Optional workspace path to search local project files in addition to external metadata'),
   includeWorkspace: z.boolean().optional().default(false).describe('Whether to include workspace files in search results (workspace-aware search)'),
   verbose: z.boolean().optional().default(false).describe('Include related-searches/patterns/tips sections in the output'),
@@ -82,14 +116,18 @@ export async function searchTool(request: CallToolRequest, context: XppServerCon
     // Try C# bridge first (IMetadataProvider — live D365FO metadata).
     // The exact-name probe is passed along so an exact match that fell outside
     // the bridge's truncated result window is still ranked first (#15).
+    // The custom-model probe is passed along so custom/ISV matches truncated out
+    // of the Microsoft-dominated bridge window are spliced back in and
+    // prioritized (never "only Microsoft objects").
     const searchTypes = args.type === 'all' ? undefined : [args.type];
     const exactMatches = probeExactMatches(symbolIndex, args.query, searchTypes);
+    const customMatches = probeCustomMatches(symbolIndex, args.query, searchTypes);
     const bridgeResult = await tryBridgeSearch(
       context.bridge,
       args.query,
       args.type === 'all' ? undefined : args.type,
       args.limit,
-      { exactMatches },
+      { exactMatches, customMatches },
     );
     if (bridgeResult) return bridgeResult;
 
@@ -275,7 +313,22 @@ async function performExternalSearch(
     const seen = new Set(raw.map(r => `${String(r.name).toLowerCase()} ${r.type}`));
     const missingExact = probeExactMatches(symbolIndex, args.query, types)
       .filter(hit => !seen.has(`${hit.name.toLowerCase()} ${hit.type}`));
-    const results: any[] = rankExactFirst(args.query, [...missingExact, ...raw], r => String(r.name));
+    for (const hit of missingExact) seen.add(`${hit.name.toLowerCase()} ${hit.type}`);
+
+    // Custom/ISV matches are likewise buried under the Microsoft-dominated FTS
+    // window, so splice any the window missed and mark every custom hit so
+    // rankCustomFirst can lift them just behind the exact matches.
+    const customProbe = probeCustomMatches(symbolIndex, args.query, types);
+    const customKeys = new Set(customProbe.map(h => `${h.name.toLowerCase()} ${h.type}`));
+    const missingCustom = customProbe
+      .filter(hit => !seen.has(`${hit.name.toLowerCase()} ${hit.type}`));
+    for (const hit of missingCustom) seen.add(`${hit.name.toLowerCase()} ${hit.type}`);
+
+    const combined = [...missingExact, ...missingCustom, ...raw];
+    const isCustomHit = (r: any) =>
+      (r.model ? isCustomModel(String(r.model)) : false) ||
+      customKeys.has(`${String(r.name).toLowerCase()} ${r.type}`);
+    const results: any[] = rankCustomFirst(args.query, combined, r => String(r.name), isCustomHit);
 
     if (!results || results.length === 0) {
       const allSymbolNames = symbolIndex.getAllSymbolNames(args.query);

--- a/src/utils/exactMatchRanking.ts
+++ b/src/utils/exactMatchRanking.ts
@@ -45,3 +45,37 @@ export function rankExactFirst<T>(query: string, items: T[], nameOf: (item: T) =
     .sort((a, b) => (a.rank - b.rank) || (a.idx - b.idx))
     .map(entry => entry.item);
 }
+
+/**
+ * Ranking that keeps exact-name matches first but additionally prioritizes
+ * custom/ISV-model symbols directly after them, ahead of the far larger
+ * Microsoft standard corpus.
+ *
+ * Motivation: a broad keyword fills the C# bridge's fixed result window
+ * (`maxResults`) in provider-enumeration order, which is dominated by Microsoft
+ * standard objects, so custom matches that enumerate later get truncated and
+ * the search appears to "return only Microsoft objects". Surfacing custom hits
+ * into their own band guarantees they are visible regardless of window size.
+ *
+ * Tiers (lower first):
+ *   0 = exact name match (any model — an exact Microsoft hit still wins)
+ *   1 = custom-model hit
+ *   2 = everything else
+ * Within a tier the name-quality rank and original order are preserved (stable),
+ * so bridge/FTS relevance is untouched where it says nothing about equality.
+ */
+export function rankCustomFirst<T>(
+  query: string,
+  items: T[],
+  nameOf: (item: T) => string,
+  isCustom: (item: T) => boolean,
+): T[] {
+  return items
+    .map((item, idx) => {
+      const rank = exactMatchRank(query, nameOf(item));
+      const tier = rank <= 1 ? 0 : isCustom(item) ? 1 : 2;
+      return { item, idx, tier, rank };
+    })
+    .sort((a, b) => (a.tier - b.tier) || (a.rank - b.rank) || (a.idx - b.idx))
+    .map(entry => entry.item);
+}

--- a/tests/tools/search-custom-priority.test.ts
+++ b/tests/tools/search-custom-priority.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Custom/ISV-model prioritization in `search`.
+ *
+ * Observation (2026-07-23): broad keyword searches "return only standard
+ * Microsoft objects, not custom code" even though custom models are indexed.
+ *
+ * Root cause: the C# bridge enumerates ONE merged, provider-ordered key list
+ * across all models — dominated by the far larger Microsoft standard corpus —
+ * and truncates at `maxResults` (MetadataReadService.SearchObjects). Custom
+ * matches that enumerate later fall outside the window and never reach the
+ * client. Only exact-name hits were rescued (defect #15); broad keyword hits in
+ * custom models were not.
+ *
+ * The repair probes the SQLite index for custom-model matches and splices them
+ * back in, ranked directly after exact matches (ahead of Microsoft standard
+ * hits). These tests pin that behaviour plus the secondary fix to
+ * `getCustomModels()` (it used to classify every Microsoft model as custom).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { BridgeClient } from '../../src/bridge/bridgeClient';
+import { tryBridgeSearch } from '../../src/bridge/bridgeAdapter';
+import { rankCustomFirst, exactMatchRank } from '../../src/utils/exactMatchRanking';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { clearAutoDetectedModels } from '../../src/utils/modelClassifier';
+
+// ── ranking primitive ────────────────────────────────────────────────────────
+
+describe('rankCustomFirst', () => {
+  it('orders exact > custom > rest, stable within each tier', () => {
+    const items = [
+      { name: 'CustTableMsFoo', custom: false }, // Microsoft substring hit
+      { name: 'CustTable', custom: false },       // exact (Microsoft) — still wins
+      { name: 'CustTableHbrExt', custom: true },  // custom substring hit
+      { name: 'CustTableMsBar', custom: false },
+    ];
+    const ranked = rankCustomFirst('CustTable', items, i => i.name, i => i.custom);
+    expect(ranked.map(i => i.name)).toEqual([
+      'CustTable',        // tier 0 — exact
+      'CustTableHbrExt',  // tier 1 — custom
+      'CustTableMsFoo',   // tier 2 — rest, original order preserved
+      'CustTableMsBar',
+    ]);
+  });
+
+  it('lifts a custom hit above Microsoft PREFIX hits (custom beats name quality)', () => {
+    // A Microsoft prefix match (rank 2) must NOT outrank a custom substring hit —
+    // "prioritize custom" is the whole point.
+    const items = [
+      { name: 'AccountingSourcePrefix', custom: false }, // prefix match, standard
+      { name: 'MyAccountingSourceExt', custom: true },   // substring match, custom
+    ];
+    const ranked = rankCustomFirst('AccountingSource', items, i => i.name, i => i.custom);
+    expect(ranked[0].name).toBe('MyAccountingSourceExt');
+  });
+
+  it('does not disturb exactMatchRank semantics', () => {
+    expect(exactMatchRank('Num', 'Num')).toBe(0);
+    expect(exactMatchRank('Num', 'NUM')).toBe(1);
+  });
+});
+
+// ── bridge splice + prioritization ───────────────────────────────────────────
+
+function makeBridge(results: { name: string; type: string }[]): BridgeClient {
+  return {
+    isReady: true,
+    metadataAvailable: true,
+    searchObjects: vi.fn(async () => ({ results, totalCount: results.length })),
+  } as unknown as BridgeClient;
+}
+
+/** A Microsoft-dominated window with no custom object in it. */
+const MS_WINDOW = Array.from({ length: 40 }, (_, i) => ({
+  name: `CustTableMs${i}`,
+  type: 'table',
+}));
+
+describe('tryBridgeSearch — custom-model prioritization', () => {
+  it('splices a custom hit the Microsoft-dominated window truncated away', async () => {
+    const bridge = makeBridge(MS_WINDOW);
+
+    const result = await tryBridgeSearch(bridge, 'CustTable', 'table', 40, {
+      customMatches: [{ name: 'CustTableHbr_Extension', type: 'table-extension' }],
+    });
+    const text = (result!.content[0] as { text: string }).text;
+
+    expect(text).toContain('CustTableHbr_Extension');
+    expect(text).toContain('custom/ISV-model match');
+  });
+
+  it('ranks the custom hit ahead of Microsoft standard hits (but behind exact)', async () => {
+    // Bridge window: an exact Microsoft match + noise. Custom hit spliced in.
+    const bridge = makeBridge([{ name: 'CustTable', type: 'table' }, ...MS_WINDOW]);
+
+    const result = await tryBridgeSearch(bridge, 'CustTable', 'table', 40, {
+      customMatches: [{ name: 'CustTableHbr_Extension', type: 'table-extension' }],
+    });
+    const text = (result!.content[0] as { text: string }).text;
+    const bullets = text.split('\n').filter(l => l.startsWith('- '));
+
+    expect(bullets[0]).toContain('**CustTable**');            // exact first
+    expect(bullets[0]).toContain('exact match');
+    expect(bullets[1]).toContain('**CustTableHbr_Extension**'); // custom next
+    // A Microsoft noise hit must come only after the custom one.
+    const customIdx = bullets.findIndex(b => b.includes('CustTableHbr_Extension'));
+    const firstMsIdx = bullets.findIndex(b => /CustTableMs\d/.test(b));
+    expect(customIdx).toBeLessThan(firstMsIdx);
+  });
+
+  it('does not duplicate a custom match already inside the bridge window, but still prioritizes it', async () => {
+    const bridge = makeBridge([...MS_WINDOW.slice(0, 20), { name: 'CustTableHbr_Extension', type: 'table-extension' }, ...MS_WINDOW.slice(20)]);
+
+    const result = await tryBridgeSearch(bridge, 'CustTable', 'table', 40, {
+      customMatches: [{ name: 'CustTableHbr_Extension', type: 'table-extension' }],
+    });
+    const text = (result!.content[0] as { text: string }).text;
+    const bullets = text.split('\n').filter(l => l.startsWith('- '));
+
+    expect(text.match(/CustTableHbr_Extension/g)).toHaveLength(1);
+    const customIdx = bullets.findIndex(b => b.includes('CustTableHbr_Extension'));
+    const firstMsIdx = bullets.findIndex(b => /CustTableMs\d/.test(b));
+    expect(customIdx).toBeLessThan(firstMsIdx);
+  });
+
+  it('keeps working without customMatches (backwards compatible)', async () => {
+    const bridge = makeBridge([{ name: 'CustTable', type: 'table' }]);
+    const result = await tryBridgeSearch(bridge, 'CustTable', 'table', 40);
+    const text = (result!.content[0] as { text: string }).text;
+    expect(text).toContain('**CustTable**');
+    expect(text).not.toContain('custom/ISV-model match');
+  });
+});
+
+// ── symbol-index: getCustomModels + searchCustomModelSymbols ──────────────────
+
+describe('XppSymbolIndex custom-model queries', () => {
+  const savedEnv = {
+    CUSTOM_MODELS: process.env.CUSTOM_MODELS,
+    EXTENSION_PREFIX: process.env.EXTENSION_PREFIX,
+    D365FO_MODEL_NAME: process.env.D365FO_MODEL_NAME,
+  };
+
+  beforeEach(() => {
+    clearAutoDetectedModels();
+    process.env.CUSTOM_MODELS = 'MyCustom';
+    process.env.EXTENSION_PREFIX = '';
+    delete process.env.D365FO_MODEL_NAME;
+  });
+
+  afterEach(() => {
+    process.env.CUSTOM_MODELS = savedEnv.CUSTOM_MODELS;
+    process.env.EXTENSION_PREFIX = savedEnv.EXTENSION_PREFIX;
+    if (savedEnv.D365FO_MODEL_NAME === undefined) delete process.env.D365FO_MODEL_NAME;
+    else process.env.D365FO_MODEL_NAME = savedEnv.D365FO_MODEL_NAME;
+    clearAutoDetectedModels();
+  });
+
+  function seed(): XppSymbolIndex {
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.addSymbol({ name: 'CustTable', type: 'table', filePath: '/ms.xml', model: 'ApplicationPlatform' } as any);
+    index.addSymbol({ name: 'LedgerJournalTable', type: 'table', filePath: '/gl.xml', model: 'GeneralLedger' } as any);
+    index.addSymbol({ name: 'CustTableMyExt', type: 'table-extension', filePath: '/c.xml', model: 'MyCustom' } as any);
+    index.addSymbol({ name: 'MyCustomHelper', type: 'class', filePath: '/h.xml', model: 'MyCustom' } as any);
+    return index;
+  }
+
+  it('getCustomModels returns only non-Microsoft models (regression: used to return all)', () => {
+    const index = seed();
+    expect(index.getCustomModels()).toEqual(['MyCustom']);
+    index.close?.();
+  });
+
+  it('searchCustomModelSymbols returns only custom-model matches for a shared name', () => {
+    const index = seed();
+    const hits = index.searchCustomModelSymbols('CustTable');
+    expect(hits.map(h => h.name)).toContain('CustTableMyExt');
+    expect(hits.map(h => h.name)).not.toContain('CustTable'); // the Microsoft one is excluded
+    index.close?.();
+  });
+
+  it('searchCustomModelSymbols returns [] when there are no custom models', () => {
+    process.env.CUSTOM_MODELS = '';
+    const index = new XppSymbolIndex(':memory:', ':memory:');
+    index.addSymbol({ name: 'CustTable', type: 'table', filePath: '/ms.xml', model: 'ApplicationPlatform' } as any);
+    expect(index.searchCustomModelSymbols('CustTable')).toEqual([]);
+    index.close?.();
+  });
+});


### PR DESCRIPTION
## Problem

Broad keyword searches "return only standard Microsoft objects, not custom code" even though custom models are indexed (confirmed: `search(scope="extensions")` returns them).

**Root cause.** Broad searches go through the C# bridge (`IMetadataProvider`). `MetadataReadService.SearchObjects` enumerates **one merged, provider-ordered key list across all models** — dominated by the far larger Microsoft standard corpus — and stops at `maxResults`:

```csharp
if (result.Results.Count >= maxResults) return;
if (n.IndexOf(query, ...) >= 0 && seen.Add(n)) result.Results.Add(...);
```

Custom matches that enumerate later fall outside the window and never reach the client. Only exact‑name hits were rescued (defect #15); broad **keyword** hits in custom models were not.

**Secondary bug.** `getCustomModels()` filtered against `this.standardModels`, which `loadStandardModels()` always left empty → every Microsoft model (`ApplicationFoundation`, `GeneralLedger`, `Ledger`, …) was reported as "custom".

## Changes

- **`XppSymbolIndex.searchCustomModelSymbols()`** — index-safe, model-scoped, FTS-driven probe for keyword matches in custom/ISV models (FTS `MATCH` drives; `model IN (...)` via `idx_symbols_model` narrows; LIKE fallback stays model-scoped).
- **`search` tool** probes custom matches in parallel and splices them into **both** the bridge and external-index paths, ranked directly after exact matches (ahead of Microsoft standard hits) via new **`rankCustomFirst()`** helper (tiers: exact → custom → rest, stable).
- **`tryBridgeSearch`** accepts `customMatches`, dedups against the window, flags custom bridge hits, and notes how many were spliced in.
- **Raise default search limit 20 → 50** so more candidates survive the window.
- **Secondary fix:** `getCustomModels()` now filters via `isStandardModel()`; removed the dead `standardModels` field/method.

## Tests

Adds `tests/tools/search-custom-priority.test.ts`:
- `rankCustomFirst` ordering (exact > custom > rest; custom beats Microsoft prefix hits; stable).
- `tryBridgeSearch` — splices a custom hit the Microsoft-dominated window truncated away; ranks it ahead of standard hits but behind exact; dedups a custom hit already in the window while still prioritizing it; backwards compatible without `customMatches`.
- `getCustomModels` returns only non-Microsoft models (regression for the secondary bug).
- `searchCustomModelSymbols` returns only custom-model matches for a shared name; `[]` when no custom models.

Full suite: **2197 passed**. The only failure is the pre-existing `runIf(hasFullDb)` integration test `tests/knowledge/apiSymbols.test.ts`, which times out against the live 1.17M-row DB and does not touch any changed code.
