### PR TITLE
fix(deploy): drop better-sqlite3 preflight that blocked App Service startup

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -14,13 +14,12 @@ if [ ! -d "dist" ]; then
   exit 1
 fi
 
-# Verify better-sqlite3 native addon is loadable.
-# If this fails, the deployment was done without pre-compiled node_modules.
-# Fix: run the d365fo-mcp-app-deploy pipeline which compiles on ubuntu-latest
-# and ships pre-built binaries — App Service has no make/gcc to rebuild here.
-if ! node -e "require('better-sqlite3')" 2>/dev/null; then
-  echo "FATAL: better-sqlite3 binary is incompatible with Node $(node --version)."
-  echo "Deploy using the d365fo-mcp-app-deploy pipeline to ship pre-built binaries."
+# Verify node:sqlite is present. It is core since Node 24 (the `engines` floor),
+# so this can only fail if App Service is running an older runtime than the
+# linuxFxVersion in infrastructure/main.bicep declares.
+if ! node -e "require('node:sqlite')" 2>/dev/null; then
+  echo "FATAL: node:sqlite unavailable on Node $(node --version); Node 24+ required."
+  echo "Check linuxFxVersion (NODE|24-lts) on the App Service."
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

`Deploy to Azure` failed on the health-check step — 25 attempts, all HTTP 000.

The build, tests and zip deploy were all fine. The container never started: `startup.sh` runs under `set -e` and gated the server on a `require('better-sqlite3')` preflight. Since e5d4b0f (`refactor(database): replace better-sqlite3 with core node:sqlite`) that package is no longer in `node_modules`, so the check failed on every boot and exited before `node dist/index.js` ran.

## Fix

Preflight now checks `node:sqlite`, which is core since Node 24 — already the `engines` floor and the `linuxFxVersion` (`NODE|24-lts`) in `infrastructure/main.bicep`. The only way it can now trip is an App Service actually running an older runtime, which is what the new message points at.

## Verification

- `node -e "require('node:sqlite')"` passes on Node 24 (v24.13.1 locally).
- Remaining `better-sqlite3` mentions in `src/database/sqlite.ts` and `tests/packaging/allowScripts.test.ts` are comments documenting the migration; no functional references left.

Real confirmation is the deploy run on merge — the health check is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
