### PR TITLE
fix(cli): give instances stuck in the old config/ layout a way out

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -189,6 +189,8 @@ npx d365fo-mcp instance run clientA     # start on its port
 
 Provisioning instances from a script instead of interactively? Copy `instances\d365fo-mcp.template.json` to `instances\<name>\d365fo-mcp.json` and fill in the blanks. The `instances\*.ps1` scripts remain for installations still configured through per-instance `.env` files.
 
+> **Instance config under `instances\<name>\config\`?** Some builds wrote it one level deeper. Such an instance still runs, but `D365FO_CONFIG=instances\<name>\d365fo-mcp.json` as written above then names a file that does not exist and the server starts on defaults. `d365fo-mcp doctor` flags it; `instance upgrade <name>` moves `d365fo-mcp.json` and `secrets.json` up one level, or move the two files yourself.
+
 ### Keeping instances in sync
 
 Updating the server code and reindexing an instance's database are **separate** steps, at different scopes:

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -11,7 +11,7 @@ import { p } from '../ui.js';
 import { settingByPath } from '../../config/settings.js';
 import { bridgeBuildCommand, dataRoot, installMode, isWindows, paths, repoRoot } from '../context.js';
 import { commandExists } from '../exec.js';
-import { listInstances } from '../instances.js';
+import { isLegacyInstanceLayout, listInstances, type Instance } from '../instances.js';
 import { checkRelease } from '../npmRegistry.js';
 import { conflictingLegacyValues, readPath, readSetting, type SettingsStore } from '../settingsStore.js';
 import { instanceTarget, rootTarget, type Target } from '../target.js';
@@ -95,6 +95,24 @@ function legacyEnvChecks(target: Target, label: string): CheckResult[] {
     message: `${label}: .env and d365fo-mcp.json disagree — the JSON config wins:\n` +
       conflicts.map(c => `   ${c.setting.env}: .env=${c.envValue} · config=${c.configValue}`).join('\n'),
     fix: 'delete the stale keys from .env (or the whole file once the config is complete)',
+  }];
+}
+
+/**
+ * An instance whose config still lives under instances/<name>/config/.
+ * It runs, so this is not a failure — but the docs, the template and
+ * add-instance.ps1 all name the top-level path, so following any of them
+ * points D365FO_CONFIG at a file that does not exist and the server starts on
+ * defaults instead. Say which file is real and how to end up where the docs
+ * already claim it is.
+ */
+function layoutChecks(inst: Instance): CheckResult[] {
+  if (!isLegacyInstanceLayout(inst)) return [];
+  const target = resolve(inst.dir, 'd365fo-mcp.json');
+  return [{
+    severity: 'warn',
+    message: `Instance '${inst.name}': config is in the old layout (${inst.configFile}) — the docs all say ${target}`,
+    fix: `d365fo-mcp instance upgrade ${inst.name} moves it, or move d365fo-mcp.json and secrets.json up one level by hand`,
   }];
 }
 
@@ -235,6 +253,7 @@ export async function doctorCommand(): Promise<void> {
     for (const inst of instances) {
       const target = instanceTarget(inst);
       emit(checkConfig(target, `Instance '${inst.name}'`));
+      for (const r of layoutChecks(inst)) emit(r);
       for (const r of legacyEnvChecks(target, `Instance '${inst.name}'`)) emit(r);
       emit(checkDb(target.store, resolve(inst.dir, 'data', 'xpp-metadata.db'), `Instance '${inst.name}'`));
       if (isWindows && isXppConfigStale(target.store)) {

--- a/src/cli/commands/instance.ts
+++ b/src/cli/commands/instance.ts
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import { resolve } from 'node:path';
 import { settingByPath, settingsInSection } from '../../config/settings.js';
 import { pinBridgeExe } from '../bridgePath.js';
-import { createInstance, getInstance, listInstances, suggestPort } from '../instances.js';
+import { createInstance, getInstance, listInstances, normalizeInstanceLayout, suggestPort } from '../instances.js';
 import { mcpJsonNote, placementNote, stdioServer } from '../mcpJson.js';
 import { selectXppConfig } from './config.js';
 import { askAdvanced, askSetting, askSettings } from '../settingsPrompt.js';
@@ -175,6 +175,16 @@ export async function instanceUpgradeCommand(name: string | undefined): Promise<
       }),
     );
     inst = getInstance(picked)!;
+  }
+
+  // The one command that already rewrites an instance's configuration is also
+  // where an instance left in the old instances/<name>/config/ layout gets out
+  // of it — every doc and script names the top-level path, so an instance that
+  // keeps the old one silently ignores a D365FO_CONFIG copied from them.
+  const moved = normalizeInstanceLayout(inst);
+  if (moved.length > 0) {
+    p.log.success(`Moved out of the old config/ layout: ${moved.join(', ')}`);
+    inst = getInstance(inst.name)!;
   }
 
   const store = openInstanceStore(inst.dir);

--- a/src/cli/instances.ts
+++ b/src/cli/instances.ts
@@ -4,7 +4,7 @@
  * (or a legacy .env from before the setup wizard wrote JSON).
  */
 import * as fs from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { configCandidates } from '../config/configFile.js';
 import { settingByPath } from '../config/settings.js';
 import { paths } from './context.js';
@@ -42,6 +42,45 @@ export function listInstances(): Instance[] {
 
 export function getInstance(name: string): Instance | undefined {
   return listInstances().find(i => i.name === name);
+}
+
+/**
+ * Whether this instance's configuration sits in instances/<name>/config/, the
+ * layout a build between the old wizard and #727 wrote. It keeps working —
+ * configBaseDir() strips the trailing `config` folder, so ./data/… still
+ * resolves to the instance folder — but every doc, script and note describes
+ * the top-level form, so a user following them points D365FO_CONFIG at a file
+ * that does not exist and the server silently starts on defaults.
+ */
+export function isLegacyInstanceLayout(inst: Instance): boolean {
+  return basename(dirname(inst.configFile)).toLowerCase() === 'config';
+}
+
+/**
+ * Move an instance out of the config/ layout: d365fo-mcp.json and secrets.json
+ * go up one level, and the folder is removed when nothing else is left in it.
+ * Returns the files that were moved (empty when there was nothing to do).
+ *
+ * Deliberately not called from openInstanceStore: a write hidden inside a read
+ * would fire from every command, including the read-only ones. The explicit
+ * callers are `instance upgrade` (which already rewrites the config) and the
+ * fix line `doctor` prints.
+ */
+export function normalizeInstanceLayout(inst: Instance): string[] {
+  if (!isLegacyInstanceLayout(inst)) return [];
+  const configDir = dirname(inst.configFile);
+  const moved: string[] = [];
+  for (const file of ['d365fo-mcp.json', 'secrets.json']) {
+    const from = join(configDir, file);
+    const to = join(inst.dir, file);
+    // A top-level file already there wins (listInstances prefers it); moving
+    // the config/ copy over it would silently replace the live configuration.
+    if (!fs.existsSync(from) || fs.existsSync(to)) continue;
+    fs.renameSync(from, to);
+    moved.push(to);
+  }
+  if (fs.existsSync(configDir) && fs.readdirSync(configDir).length === 0) fs.rmdirSync(configDir);
+  return moved;
 }
 
 /** Next free port: max of existing instance ports + 1, or 3001. */

--- a/tests/cli/instances.test.ts
+++ b/tests/cli/instances.test.ts
@@ -16,7 +16,13 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createInstance, getInstance, listInstances } from '../../src/cli/instances.js';
+import {
+  createInstance,
+  getInstance,
+  isLegacyInstanceLayout,
+  listInstances,
+  normalizeInstanceLayout,
+} from '../../src/cli/instances.js';
 import { writeConfigFile } from '../../src/config/configFile.js';
 
 const state = vi.hoisted(() => ({ root: '' }));
@@ -88,6 +94,63 @@ describe('listInstances', () => {
   it('ignores a directory that holds neither a config nor a .env', () => {
     fs.mkdirSync(join(instanceDir('empty'), 'data'), { recursive: true });
     expect(listInstances()).toEqual([]);
+  });
+});
+
+describe('normalizeInstanceLayout', () => {
+  const secrets = (dir: string) => join(dir, 'secrets.json');
+
+  it('moves config and secrets up one level and drops the empty config folder', () => {
+    const dir = instanceDir('legacy');
+    writeConfigFile(join(dir, 'config', 'd365fo-mcp.json'), { server: { port: 3030 } });
+    fs.writeFileSync(secrets(join(dir, 'config')), '{"auth":{"clientSecret":"x"}}\n', 'utf8');
+
+    const inst = getInstance('legacy')!;
+    expect(isLegacyInstanceLayout(inst)).toBe(true);
+
+    const moved = normalizeInstanceLayout(inst);
+    expect(moved).toEqual([join(dir, 'd365fo-mcp.json'), secrets(dir)]);
+    expect(fs.existsSync(join(dir, 'config'))).toBe(false);
+
+    // Discovery now agrees with what the docs tell the user to point at.
+    const after = getInstance('legacy')!;
+    expect(after.configFile).toBe(join(dir, 'd365fo-mcp.json'));
+    expect(after.port).toBe(3030);
+    expect(isLegacyInstanceLayout(after)).toBe(false);
+  });
+
+  it('is a no-op for an instance already in the top-level layout', () => {
+    writeConfigFile(join(instanceDir('modern'), 'd365fo-mcp.json'), { server: { port: 3031 } });
+
+    const inst = getInstance('modern')!;
+    expect(isLegacyInstanceLayout(inst)).toBe(false);
+    expect(normalizeInstanceLayout(inst)).toEqual([]);
+    expect(getInstance('modern')?.port).toBe(3031);
+  });
+
+  it('never overwrites a top-level file that already exists', () => {
+    // listInstances() prefers the top-level config, so it is the live one —
+    // the config/ copy is a leftover and must not replace it.
+    const dir = instanceDir('both');
+    writeConfigFile(join(dir, 'd365fo-mcp.json'), { server: { port: 3032 } });
+    writeConfigFile(join(dir, 'config', 'd365fo-mcp.json'), { server: { port: 9999 } });
+
+    // Reached through the config/ path, as `doctor` would after a manual move
+    // of the config alone left the stale copy behind.
+    const stale = { ...getInstance('both')!, configFile: join(dir, 'config', 'd365fo-mcp.json') };
+    expect(normalizeInstanceLayout(stale)).toEqual([]);
+    expect(getInstance('both')?.port).toBe(3032);
+    expect(fs.existsSync(join(dir, 'config', 'd365fo-mcp.json'))).toBe(true);
+  });
+
+  it('leaves a config folder holding anything else in place', () => {
+    const dir = instanceDir('extra');
+    writeConfigFile(join(dir, 'config', 'd365fo-mcp.json'), { server: { port: 3033 } });
+    fs.writeFileSync(join(dir, 'config', 'notes.txt'), 'keep me\n', 'utf8');
+
+    normalizeInstanceLayout(getInstance('extra')!);
+    expect(getInstance('extra')?.configFile).toBe(join(dir, 'd365fo-mcp.json'));
+    expect(fs.readFileSync(join(dir, 'config', 'notes.txt'), 'utf8')).toBe('keep me\n');
   });
 });
 


### PR DESCRIPTION
Closes #744.

## Why

Instances created by a build between the old wizard and #727 keep their configuration in `instances/<name>/config/d365fo-mcp.json`. #727 made them visible again to `listInstances()`, and they keep working — `configBaseDir()` strips the trailing `config` folder, so `./data/xpp-metadata.db` still resolves to the instance folder.

What was missing is a way out. Nothing moved the file and nothing told the user they were in that layout, while `docs/SETUP.md`, `instances/d365fo-mcp.template.json` and `instances/add-instance.ps1` all describe the top-level form. A user following them sets `D365FO_CONFIG` to a file that does not exist, and the server silently starts on defaults.

## What changed

- **`normalizeInstanceLayout()`** (`src/cli/instances.ts`) moves `d365fo-mcp.json` and `secrets.json` up one level and removes the `config/` folder when nothing else is left in it. It never overwrites a top-level file that already exists: `listInstances()` prefers that one, so it is the live configuration and the `config/` copy is the leftover. Alongside it, `isLegacyInstanceLayout()` answers the question without moving anything.
- **`instance upgrade`** runs the move (option 2 in the issue) — the one command that already rewrites an instance's configuration — and logs what it moved.
- **`doctor`** warns for such an instance (option 1), naming the file that is actually loaded, the path the docs describe, and both ways out.
- **`docs/SETUP.md`** gains a note under Scenario F so the doc/reality mismatch — the part the issue says actually bites — is addressed even for someone who never runs `doctor`.

Option 3 (moving on first read inside `openInstanceStore`) is deliberately not implemented: a write hidden inside a read would fire from every command, including the read-only ones. The comment on `normalizeInstanceLayout` records that.

## Reviewer notes

- The move is only reachable for installations that ran a build between the old wizard and #727, so nothing here fires on a healthy install — `isLegacyInstanceLayout()` is false and every new code path returns early.
- `instance upgrade` re-resolves the instance after the move, since `inst.configFile` is stale at that point.
- 4 new tests in `tests/cli/instances.test.ts`: the move, the no-op on a current instance, the refusal to clobber a top-level file, and a `config/` folder holding an unrelated file being left in place.
- `tsc --noEmit` clean; `tests/cli` + `tests/utils/configFile.test.ts` 69/69 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)