### PR TITLE
eval: close EDT-extension leaf + fix writer that dropped all its properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://img.shields.io/badge/tests-1400%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
-[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-70.1%25-lightgrey.svg)](eval/COVERAGE.md)
+[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-71.4%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -9,16 +9,16 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
 | core | 43 | 43 | **100%** |
-| total | 54 | 77 | 70.1% |
+| total | 55 | 77 | 71.4% |
 
-## Data model (11/12)
+## Data model (12/12)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | Table | core | ✅ | ✅ | ✅ | L1-table-basic, L2-table-modify-lifecycle |
 | Table extension | core | ✅ | ✅ | ✅ | L2-table-extension |
 | Extended data type | core | ✅ | ✅ | ✅ | L0-edt-basic |
-| EDT extension | total | ✅ | — | ✅ | Eval case authored (EDT + EDT extension via PropertyModifications); golden pending VM capture. |
+| EDT extension | total | ✅ | ✅ | ✅ | L2-edt-extension-basic |
 | Base enum | core | ✅ | ✅ | ✅ | L0-enum-basic |
 | Enum extension | core | ✅ | ✅ | ✅ | L2-enum-extension-empty-values |
 | View | core | ✅ | ✅ | ✅ | L1-query-view-basic, L2-form-over-view |
@@ -45,8 +45,8 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Error handling & infolog | core | ✅ | ✅ | ✅ | L2-error-handling-infolog |
 | SysExtension plug-in pattern | total | ✅ | ✅ | ✅ | L2-sysextension-plugin |
 | Performance patterns | core | ✅ | ✅ | ✅ | L2-performance-set-based |
-| Best-practice (BP) compliance | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +30 |
-| Deprecated APIs & migration | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +30 |
+| Best-practice (BP) compliance | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +31 |
+| Deprecated APIs & migration | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +31 |
 | Optimistic concurrency & UnitOfWork | core | ✅ | ✅ | ✅ | L2-occ-retry-basic |
 | Caching (CacheLookup, SysGlobalObjectCache, RecordViewCache) | total | ✅ | ✅ | ✅ | L2-table-caching-basic |
 | X++ collections & containers (List/Map/Set/Struct) | total | ✅ | ✅ | ✅ | L2-collections-map-list-container |
@@ -126,7 +126,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | SysTest unit testing | core | ✅ | ✅ | ✅ | L2-coc-extension, L2-event-handler-basic, L3-batch-basic |
-| Labels & localisation | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +30 |
+| Labels & localisation | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +31 |
 
 ## Closure queue (uncovered, by frequency weight)
 
@@ -138,7 +138,6 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | 2 | Data entity extension | missing E |
 | 2 | Data management framework (DMF/DIXF) | missing E |
 | 2 | Dual-write (Dataverse) | missing E |
-| 2 | EDT extension | missing E |
 | 2 | Feature management | missing E |
 | 2 | Reading Excel / CSV files | missing E |
 | 2 | Global address book | missing E |

--- a/eval/cases/L2-edt-extension-basic.json
+++ b/eval/cases/L2-edt-extension-basic.json
@@ -2,14 +2,14 @@
   "id": "L2-edt-extension-basic",
   "title": "EDT extension: extend an EDT through PropertyModifications instead of editing it",
   "tier": 2,
-  "instruction": "In the sandbox model, prove the EDT extension path. Ground the extension model first with get_knowledge(topic=\"coc\"). Create: (1) an EDT DemoDocumentCode (String, StringSize 20, labelled, with DeveloperDocumentation); (2) an EDT extension over the standard EDT AccountNum (d365fo_file objectType \"edt-extension\") that adjusts its HelpText through PropertyModifications - the extension element lives in the sandbox model and must not edit the base EDT in place; (3) a table DemoDocumentIndex (label @TaxTransactionInquiry:HeaderNote, table group Main) with one field DocumentCode typed by ConDemoDocumentCode plus a unique alternate-key index DocumentIndexIdx, proving the new EDT resolves at compile time. Editing a base element in place instead of adding the extension element FAILS this case. All three objects must build with zero BP errors.",
+  "instruction": "In the sandbox model, prove the EDT extension path. Ground the extension model first with get_knowledge(topic=\"coc\"). Create: (1) an EDT DemoDocumentCode (String, StringSize 20, labelled, with HelpText - note AxEdtString has no DeveloperDocumentation property, that one is table-only); (2) an EDT extension over the standard EDT AccountNum (d365fo_file objectType \"edt-extension\") that adjusts its HelpText through PropertyModifications - the extension element lives in the sandbox model and must not edit the base EDT in place; (3) a table DemoDocumentIndex (label @TaxTransactionInquiry:HeaderNote, table group Main) with one field DocumentCode typed by ConDemoDocumentCode plus a unique alternate-key index DocumentIndexIdx, proving the new EDT resolves at compile time. Editing a base element in place instead of adding the extension element FAILS this case. All three objects must build with zero BP errors.",
   "target_artifact_types": [
     "AxEdt",
     "AxEdtExtension",
     "AxTable"
   ],
   "golden_path": "eval/goldens/L2-edt-extension-basic/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/corpus/runs/2026-07-23T16__L2-edt-extension-basic__01cd181.json
+++ b/eval/corpus/runs/2026-07-23T16__L2-edt-extension-basic__01cd181.json
@@ -1,0 +1,61 @@
+{
+  "run_id": "2026-07-23T16__L2-edt-extension-basic__01cd181",
+  "case_id": "L2-edt-extension-basic",
+  "tier": 2,
+  "timestamp": "2026-07-23T16:57:05.468Z",
+  "server_git_sha": "01cd181",
+  "generated_artifacts": [
+    "Contoso/AxEdt/ConDemoDocumentCode.xml",
+    "Contoso/AxEdtExtension/AccountNum.ConExtension.xml",
+    "Contoso/AxTable/ConDemoDocumentIndex.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "bp_checked": true,
+    "errors": [],
+    "bpWarnings": [
+      {
+        "rule": "BPErrorTableMissingFormRef",
+        "element": "ConDemoDocumentIndex",
+        "note": "unavoidable - the case creates no form; 7 further warnings belong to the pre-existing ConDemoNoteHeader fixture and are excluded"
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "The edt-extension write path cannot express the only thing an EDT extension exists for. d365fo_file(action=\"create\", objectType=\"edt-extension\") always emits an empty <PropertyModifications /> (and omits <ArrayElements />): properties.helpText / properties.propertyModifications are silently ignored, with no warning (contrast add-index, which does warn about ignored params). action=\"generate\" behaves the same and additionally drops the extension suffix (Name=AccountNum, path AxEdtExtension/AccountNum.xml - an invalid extension element). d365fo_file(action=\"modify\", objectType=\"edt-extension\") is rejected: \"Operation modify-property on object type edt-extension is not supported by the bridge\". The correct artifact could only be produced through the xmlContent+overwrite escape hatch. Secondary: modify-property on AxEdt silently accepts nothing but label/helpText/extends/stringSize/referenceTable, while the create path swallows unknown properties (developerDocumentation) without a warning; add-index is idempotent by NAME, so the tool own remediation advice (\"Re-run with the correct parameter name(s)\") no-ops and the corrected AlternateKey/AllowDuplicates are never applied - remove-index + add-index is required. Case defect: instruction (1) asks for DeveloperDocumentation on an EDT, but AxEdtString has no such property in the metamodel (reflection over Microsoft.Dynamics.AX.Metadata.dll); only AxTable has it. HelpText was used instead.",
+  "suggested_fix_area": "src/tools/d365fo-file (edt-extension writer + bridge AxEdtExtension property mapping): support PropertyModifications on create/generate/modify, emit <ArrayElements />, keep the .<Prefix>Extension suffix in generate mode, and surface ignored-property warnings on every writer path (not just add-index). Also: make add-index re-apply properties on an existing index instead of a name-only idempotent skip. labels(action=\"info\") does not accept the documented new-format id \"@LabelFile:LabelId\" (@TaxTransactionInquiry:HeaderNote -> not found), although search and the split labelId+labelFileId form resolve it. Case text should drop DeveloperDocumentation from the EDT requirement.",
+  "evidence_refs": [
+    "K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxEdtExtension/AccountNum.ConExtension.xml",
+    "K:/AosService/PackagesLocalDirectory/ApplicationSuite/Foundation/AxEdtExtension/PrintMgmtIdentificationTxt.Extension.xml",
+    "K:/AosService/PackagesLocalDirectory/ApplicationSuite/Foundation/AxTable/CustGroup.xml",
+    "eval/goldens/L2-edt-extension-basic/"
+  ]
+}

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -8,8 +8,8 @@
   "total": {
     "tier": "all",
     "total": 77,
-    "covered": 54,
-    "percent": 70.1
+    "covered": 55,
+    "percent": 71.4
   },
   "leaves": [
     {
@@ -62,10 +62,12 @@
       "tier": "total",
       "weight": 2,
       "k": true,
-      "e": false,
+      "e": true,
       "t": true,
-      "covered": false,
-      "cases": []
+      "covered": true,
+      "cases": [
+        "L2-edt-extension-basic"
+      ]
     },
     {
       "id": "enum",
@@ -398,6 +400,7 @@
         "L2-delegate-basic",
         "L2-dimension-basic",
         "L2-dotnet-interop-clrerror",
+        "L2-edt-extension-basic",
         "L2-interface-abstract-basic",
         "L2-license-code-configkey",
         "L2-numberseq-basic",
@@ -444,6 +447,7 @@
         "L2-delegate-basic",
         "L2-dimension-basic",
         "L2-dotnet-interop-clrerror",
+        "L2-edt-extension-basic",
         "L2-interface-abstract-basic",
         "L2-license-code-configkey",
         "L2-numberseq-basic",
@@ -1148,6 +1152,7 @@
         "L2-delegate-basic",
         "L2-dimension-basic",
         "L2-dotnet-interop-clrerror",
+        "L2-edt-extension-basic",
         "L2-interface-abstract-basic",
         "L2-license-code-configkey",
         "L2-numberseq-basic",

--- a/eval/goldens/L2-edt-extension-basic/AccountNum.ConExtension.metadata.xml
+++ b/eval/goldens/L2-edt-extension-basic/AccountNum.ConExtension.metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEdtExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>AccountNum.ConExtension</Name>
+	<ArrayElements />
+	<PropertyModifications>
+		<AxPropertyModification>
+			<Name>HelpText</Name>
+			<Value>@SYS316427</Value>
+		</AxPropertyModification>
+	</PropertyModifications>
+</AxEdtExtension>

--- a/eval/goldens/L2-edt-extension-basic/ConDemoDocumentCode.metadata.xml
+++ b/eval/goldens/L2-edt-extension-basic/ConDemoDocumentCode.metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns=""
+	i:type="AxEdtString">
+	<Name>ConDemoDocumentCode</Name>
+	<HelpText>@SYS4002290</HelpText>
+	<Label>@SYS22574</Label>
+	<ArrayElements />
+	<Relations />
+	<TableReferences />
+	<StringSize>20</StringSize>
+</AxEdt>

--- a/eval/goldens/L2-edt-extension-basic/ConDemoDocumentIndex.metadata.xml
+++ b/eval/goldens/L2-edt-extension-basic/ConDemoDocumentIndex.metadata.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoDocumentIndex</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// The <c>ConDemoDocumentIndex</c> table.
+/// </summary>
+public class ConDemoDocumentIndex extends common
+{
+}
+]]></Declaration>
+		<Methods />
+	</SourceCode>
+	<DeveloperDocumentation>@SYS4002290</DeveloperDocumentation>
+	<Label>@TaxTransactionInquiry:HeaderNote</Label>
+	<TableGroup>Main</TableGroup>
+	<TitleField1>DocumentCode</TitleField1>
+	<CacheLookup>Found</CacheLookup>
+	<ReplacementKey>DocumentIndexIdx</ReplacementKey>
+	<DeleteActions />
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>DocumentCode</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>DocumentCode</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+	</FieldGroups>
+	<Fields>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>DocumentCode</Name>
+			<ExtendedDataType>ConDemoDocumentCode</ExtendedDataType>
+			<Mandatory>Yes</Mandatory>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes>
+		<AxTableIndex>
+			<Name>DocumentIndexIdx</Name>
+			<AlternateKey>Yes</AlternateKey>
+			<Fields>
+				<AxTableIndexField>
+					<DataField>DocumentCode</DataField>
+				</AxTableIndexField>
+			</Fields>
+		</AxTableIndex>
+	</Indexes>
+	<Mappings />
+	<Relations />
+	<StateMachines />
+</AxTable>

--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -70,19 +70,20 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             '• enum-extension: enumValues[{name,label?,value?,countryRegionCodes?}]\n' +
             '• table-extension: fields[{name,edt?,enumType?,label?,mandatory?,fieldType?}] — enum fields need fieldType:"AxTableFieldEnum" + enumType\n' +
             '• edt: label, extends, edtType, stringSize\n' +
+            '• edt-extension: label?, helpText?, stringSize?, extends?, formHelp?, propertyModifications?[{name,value}] = the change\n' +
             '• form: caption, formTemplate, dataSource\n' +
             '• security-privilege: label, targetObject, objectType (MenuItemDisplay|Action|Output), accessLevel (view|maintain), dataEntity (grants perms)\n' +
             '• security-duty: label, privileges[]\n' +
             '• security-role: label, duties[], privileges[]\n' +
             '• menu-item-*: label, object, objectType\n' +
-            '• data-entity: primaryTable, fields[{name,dataField?}], dataManagementEnabled? (default false; true only if staging table exists)\n' +
-            '• map: label?, developerDocumentation?, fields[{name,type?,edt?,enumType?,stringSize?}], mappingTable?, mappings?[{mapField,mapFieldTo}] (defaults to one connection/field when mappingTable set)\n' +
+            '• data-entity: primaryTable, fields[{name,dataField?}], dataManagementEnabled? (default false; true needs a staging table)\n' +
+            '• map: label?, developerDocumentation?, fields[{name,type?,edt?,enumType?,stringSize?}], mappingTable?, mappings?[{mapField,mapFieldTo}] (one connection/field by default)\n' +
             '• query: title?, dataSource (root table; table also works), dataSourceName?, fields?[{name,field?}]\n' +
             '• view: query (existing AxQuery), fields[{name,dataField?}] — dataSource defaults to query\n' +
             '• service: serviceClass (defaults to the service name), externalName?, namespace?, description?, operations["opName"] or [{name?,method?,enableIdempotence?,subscriberAccessLevelRead?}]\n' +
             '• service-group: autoDeploy? (Yes publishes at /api/services), description?, services["MyService"] or [{name?,service?}]\n' +
             '  ⚠ service/service-group CROSS-REFS (serviceClass, services[].service) are written VERBATIM — only objectName is prefixed. ' +
-            'Pass the FINAL name of the already-created service/class (e.g. "ContosoDemoNoteService", not "DemoNoteService"), else the group resolves to nothing — verbatim lets a group also reference an unprefixed Microsoft service (DimensionService).'
+            'Pass the FINAL name (e.g. "ContosoDemoNoteService", not "DemoNoteService") or the group resolves to nothing; verbatim also lets it reference an unprefixed MS service.'
         },
         addToProject: {
           type: 'boolean',

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -27,6 +27,7 @@ import { buildAxDataEntityXml } from './dataEntityXml.js';
 import { resolveEdtBaseType, resolveEdtEnumType, heuristicEdtBaseType, isEnumName, bridgeEdtBaseType } from './generateSmartTable.js';
 import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
 import { buildAxMapXml } from './mapXml.js';
+import { buildAxEdtExtensionXml } from './edtExtensionXml.js';
 import { buildAxServiceXml, buildAxServiceGroupXml } from './serviceXml.js';
 import { recordCreatedArtifact } from './createdArtifactLedger.js';
 import {
@@ -1543,7 +1544,7 @@ ${defaultParamGroupXml}
       case 'form-extension':
         return this.generateAxFormExtensionXml(objectName);
       case 'edt-extension':
-        return this.generateAxSimpleExtensionXml('AxEdtExtension', objectName);
+        return this.generateAxEdtExtensionXml(objectName, properties);
       case 'enum-extension':
         return this.generateAxEnumExtensionXml(objectName, properties);
       case 'data-entity-extension':
@@ -2460,6 +2461,15 @@ ${defaultParamGroupXml}
    * AxMenuItemOutputExtension.
    * Name convention: BaseObjectName.ExtensionName  (e.g. CustTable.MyExtension)
    */
+  /**
+   * Generate AxEdtExtension XML. Delegates to the shared builder so this cannot
+   * drift from generateD365Xml.ts's copy — see edtExtensionXml.ts for the property
+   * contract and why <ArrayElements /> is unconditional.
+   */
+  static generateAxEdtExtensionXml(name: string, properties?: Record<string, any>): string {
+    return buildAxEdtExtensionXml(name, properties);
+  }
+
   static generateAxSimpleExtensionXml(rootElement: string, name: string): string {
     return `<?xml version="1.0" encoding="utf-8"?>
 <${rootElement} xmlns:i="http://www.w3.org/2001/XMLSchema-instance">

--- a/src/tools/edtExtensionXml.ts
+++ b/src/tools/edtExtensionXml.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared AxEdtExtension XML builder.
+ *
+ * Both createD365File.ts and generateD365Xml.ts delegate here so the two copies
+ * cannot drift — the same reason queryViewXml.ts and mapXml.ts exist.
+ *
+ * An EDT extension owns no properties of its own: everything it changes about the
+ * base EDT is an <AxPropertyModification> Name/Value pair. Shape and element order
+ * are copied from the shipped elements, e.g.
+ *   ApplicationSuite\Foundation\AxEdtExtension\DocuOverdueFineTxt_FR.Extension.xml
+ *     <Name>, <ArrayElements />, <PropertyModifications>
+ * All 13 EDT extensions shipped in PackagesLocalDirectory carry <ArrayElements />,
+ * so it is emitted unconditionally. Element ORDER matters: the metadata
+ * deserializer silently drops children it meets out of order.
+ */
+
+export interface AxPropertyModificationSpec {
+  name: string;
+  value: unknown;
+}
+
+/** Named shortcuts, in the order they are appended when the caller supplies them. */
+const NAMED_PROPERTY_MODIFICATIONS: Array<[string, string]> = [
+  ['label', 'Label'],
+  ['helpText', 'HelpText'],
+  ['stringSize', 'StringSize'],
+  ['extends', 'Extends'],
+  ['formHelp', 'FormHelp'],
+];
+
+function escapeXmlText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * @param name  Full extension element name, dot notation: BaseEdt.<Prefix>Extension
+ * @param properties  label / helpText / stringSize / extends / formHelp, plus
+ *   `propertyModifications: [{ name, value }]` as the escape hatch for anything
+ *   not named above. An explicit entry wins over the named shortcut for the
+ *   same property.
+ */
+export function buildAxEdtExtensionXml(
+  name: string,
+  properties?: Record<string, any>
+): string {
+  const mods: AxPropertyModificationSpec[] = [];
+  const push = (modName: string, value: unknown) => {
+    if (value === undefined || value === null || value === '') return;
+    if (mods.some(m => m.name.toLowerCase() === modName.toLowerCase())) return;
+    mods.push({ name: modName, value });
+  };
+
+  const explicit = properties?.propertyModifications;
+  if (Array.isArray(explicit)) {
+    for (const m of explicit) {
+      if (m && m.name !== undefined && m.name !== null && String(m.name) !== '') {
+        push(String(m.name), m.value);
+      }
+    }
+  }
+  for (const [propKey, modName] of NAMED_PROPERTY_MODIFICATIONS) {
+    push(modName, properties?.[propKey]);
+  }
+
+  let modsXml: string;
+  if (mods.length === 0) {
+    modsXml = '\t<PropertyModifications />';
+  } else {
+    modsXml = '\t<PropertyModifications>';
+    for (const m of mods) {
+      modsXml += '\n\t\t<AxPropertyModification>';
+      modsXml += `\n\t\t\t<Name>${escapeXmlText(m.name)}</Name>`;
+      modsXml += `\n\t\t\t<Value>${escapeXmlText(String(m.value))}</Value>`;
+      modsXml += '\n\t\t</AxPropertyModification>';
+    }
+    modsXml += '\n\t</PropertyModifications>';
+  }
+
+  return `<?xml version="1.0" encoding="utf-8"?>
+<AxEdtExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<ArrayElements />
+${modsXml}
+</AxEdtExtension>`;
+}

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -14,6 +14,7 @@ import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
 import { buildAxSecurityPrivilegeXml } from './securityPrivilegeXml.js';
 import { buildAxDataEntityXml } from './dataEntityXml.js';
 import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
+import { buildAxEdtExtensionXml } from './edtExtensionXml.js';
 import { buildAxMapXml } from './mapXml.js';
 import { buildAxServiceXml, buildAxServiceGroupXml } from './serviceXml.js';
 
@@ -1027,7 +1028,7 @@ ${defaultParamGroupXml}
       case 'form-extension':
         return this.generateAxFormExtensionXml(objectName);
       case 'edt-extension':
-        return this.generateAxSimpleExtensionXml('AxEdtExtension', objectName);
+        return this.generateAxEdtExtensionXml(objectName, properties);
       case 'enum-extension':
         return this.generateAxEnumExtensionXml(objectName, properties);
       case 'data-entity-extension':
@@ -1094,6 +1095,15 @@ ${defaultParamGroupXml}
 \t<Relations />
 \t<TableReferences />${stringSize}
 </AxEdt>`;
+  }
+
+  /**
+   * Generate AxEdtExtension XML. Delegates to the shared builder so this cannot
+   * drift from createD365File.ts's copy — see edtExtensionXml.ts for the property
+   * contract and why <ArrayElements /> is unconditional.
+   */
+  static generateAxEdtExtensionXml(name: string, properties?: Record<string, any>): string {
+    return buildAxEdtExtensionXml(name, properties);
   }
 
   static generateAxSimpleExtensionXml(rootElement: string, name: string): string {

--- a/tests/tools/edtExtensionXml.test.ts
+++ b/tests/tools/edtExtensionXml.test.ts
@@ -1,0 +1,95 @@
+/**
+ * buildAxEdtExtensionXml (src/tools/edtExtensionXml.ts).
+ *
+ * Regression: eval/corpus/runs/2026-07-23T16__L2-edt-extension-basic__01cd181.json —
+ * `edt-extension` went through generateAxSimpleExtensionXml(), whose signature takes
+ * only (rootElement, name). Every property the caller passed was therefore silently
+ * dropped and the element came out as an inert
+ *     <AxEdtExtension><Name>…</Name><PropertyModifications /></AxEdtExtension>
+ * with no <ArrayElements /> either. Since an EDT extension changes the base EDT
+ * ONLY through property modifications, that left the objectType with no grounded
+ * path at all — the eval case could only be completed through the xmlContent
+ * escape hatch.
+ *
+ * Shape is pinned against the shipped elements in PackagesLocalDirectory
+ * (13/13 carry <ArrayElements />, e.g. ApplicationSuite\Foundation\AxEdtExtension\
+ * DocuOverdueFineTxt_FR.Extension.xml). Element order matters: the metadata
+ * deserializer silently drops children it meets out of order.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildAxEdtExtensionXml } from '../../src/tools/edtExtensionXml';
+
+describe('buildAxEdtExtensionXml — property modifications', () => {
+  it('turns helpText into an AxPropertyModification instead of dropping it — regression', () => {
+    const xml = buildAxEdtExtensionXml('AccountNum.ConExtension', {
+      helpText: '@SYS12345',
+    });
+    expect(xml).toContain('<AxPropertyModification>');
+    expect(xml).toContain('<Name>HelpText</Name>');
+    expect(xml).toContain('<Value>@SYS12345</Value>');
+  });
+
+  it('maps every named shortcut to its metadata property name', () => {
+    const xml = buildAxEdtExtensionXml('AccountNum.ConExtension', {
+      label: '@SYS1',
+      helpText: '@SYS2',
+      stringSize: 40,
+      extends: 'Num',
+      formHelp: '@SYS3',
+    });
+    for (const name of ['Label', 'HelpText', 'StringSize', 'Extends', 'FormHelp']) {
+      expect(xml).toContain(`<Name>${name}</Name>`);
+    }
+    expect(xml).toContain('<Value>40</Value>');
+  });
+
+  it('accepts an explicit propertyModifications list for properties with no shortcut', () => {
+    const xml = buildAxEdtExtensionXml('AccountNum.ConExtension', {
+      propertyModifications: [{ name: 'DisplayLength', value: 25 }],
+    });
+    expect(xml).toContain('<Name>DisplayLength</Name>');
+    expect(xml).toContain('<Value>25</Value>');
+  });
+
+  it('lets an explicit entry win over the named shortcut for the same property', () => {
+    const xml = buildAxEdtExtensionXml('AccountNum.ConExtension', {
+      propertyModifications: [{ name: 'Label', value: '@SYS_EXPLICIT' }],
+      label: '@SYS_SHORTCUT',
+    });
+    expect(xml).toContain('<Value>@SYS_EXPLICIT</Value>');
+    expect(xml).not.toContain('@SYS_SHORTCUT');
+    expect(xml.match(/<Name>Label<\/Name>/g)).toHaveLength(1);
+  });
+
+  it('escapes XML metacharacters in the value', () => {
+    const xml = buildAxEdtExtensionXml('AccountNum.ConExtension', {
+      helpText: 'A & B <tag>',
+    });
+    expect(xml).toContain('<Value>A &amp; B &lt;tag&gt;</Value>');
+  });
+});
+
+describe('buildAxEdtExtensionXml — element shape', () => {
+  it('always emits ArrayElements, before PropertyModifications (13/13 shipped elements do)', () => {
+    const xml = buildAxEdtExtensionXml('AccountNum.ConExtension', { label: '@SYS1' });
+    expect(xml).toContain('<ArrayElements />');
+    expect(xml.indexOf('<ArrayElements />')).toBeLessThan(xml.indexOf('<PropertyModifications'));
+    expect(xml.indexOf('<Name>AccountNum.ConExtension</Name>'))
+      .toBeLessThan(xml.indexOf('<ArrayElements />'));
+  });
+
+  it('self-closes PropertyModifications when there is nothing to modify', () => {
+    const xml = buildAxEdtExtensionXml('AccountNum.ConExtension');
+    expect(xml).toContain('<PropertyModifications />');
+    expect(xml).toContain('<ArrayElements />');
+  });
+
+  it('matches the shipped root element and declaration verbatim', () => {
+    const xml = buildAxEdtExtensionXml('AccountNum.ConExtension');
+    expect(xml.startsWith('<?xml version="1.0" encoding="utf-8"?>\n')).toBe(true);
+    expect(xml).toContain(
+      '<AxEdtExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">'
+    );
+  });
+});


### PR DESCRIPTION
Stacked on #758.

Ran `L2-edt-extension-basic` end-to-end on the VM (extend a base EDT through `PropertyModifications`, never edit it in place). It surfaced a **TOOL_DEFECT with no grounded workaround**: the `edt-extension` objectType routed through `generateAxSimpleExtensionXml(rootElement, name)`, whose signature takes no properties — so every property the caller passed was silently dropped and the element came out inert:

```xml
<AxEdtExtension><Name>…</Name><PropertyModifications /></AxEdtExtension>
```

with no `<ArrayElements />` either. Since an EDT extension changes the base EDT **only** through property modifications, the objectType had no grounded path at all — the case could previously be completed only through the `xmlContent` escape hatch.

## Fix

New shared builder `src/tools/edtExtensionXml.ts`, delegated to from both `createD365File.ts` and `generateD365Xml.ts` so the two copies cannot drift (same pattern as `queryViewXml`/`mapXml`). It emits `<Name>`, `<ArrayElements />` (13/13 shipped EDT extensions carry it), then `<PropertyModifications>` with one `<AxPropertyModification>` per change. Named shortcuts `label` / `helpText` / `stringSize` / `extends` / `formHelp`, plus a `propertyModifications[]` escape hatch; an explicit entry wins over the shortcut for the same property. Shape and element order copied from `ApplicationSuite\Foundation\AxEdtExtension\DocuOverdueFineTxt_FR.Extension.xml` — order matters, the deserializer drops out-of-order children.

`buildAxEdtExtensionXml('AccountNum.ConExtension', {helpText:'@SYS316427'})` now reproduces the captured golden **byte-for-byte** (verified programmatically). Documented the properties in the `d365fo_file` schema (trimmed adjacent lines to stay under the per-tool token budget).

## Case-text fix

Instruction (1) required `DeveloperDocumentation` on the EDT, but `AxEdtString` has no such property — it is table-only, and xppbp enforces it only on the table. Changed to `HelpText`, which is what actually compiles. (An agent following the old text literally could not satisfy it.)

## Verification

Golden captured and diffed element-by-element against shipped comparables (`DocuOverdueFineTxt_FR.Extension` for the extension; `CustGroup` for the table's unique alternate-key index carrying `<AlternateKey>Yes</AlternateKey>` and no `AllowDuplicates`). **Total coverage 54/77 → 55/77**, core stays 43/43.

New tests `tests/tools/edtExtensionXml.test.ts`: property mapping, explicit-wins, XML escaping, `ArrayElements`-before-`PropertyModifications` ordering, self-close. tsc + affected suites green.

## Other defects this run recorded in the corpus (not fixed here)

- `add-index` is idempotent by name, so the corrective re-run after its own "did you mean `indexAllowDuplicates`?" warning no-ops — `remove-index` + `add-index` was required.
- `labels(action="info")` rejects the `@File:Id` form that `action="search"` accepts.
- `edt` create silently swallows an unsupported `developerDocumentation` property while `modify` correctly rejects it — the two should agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
