### PR TITLE
perf: speed up metadata extraction with adaptive concurrency

### DIFF
--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -7,6 +7,7 @@ import { loadEnv } from '../src/utils/loadEnv.js';
 loadEnv(import.meta.url);
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import * as os from 'os';
 import { fileURLToPath } from 'url';
 import { XppMetadataParser, buildClassExtensionRecord } from '../src/metadata/xmlParser.js';
 import type { XppClassInfo } from '../src/metadata/types.js';
@@ -197,6 +198,81 @@ function formatPercent(current: number, total: number): string {
   return `${formatDecimal((current / total) * 100)}%`;
 }
 
+function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  const normalized = Math.floor(parsed);
+  return normalized > 0 ? normalized : fallback;
+}
+
+function parsePositiveFloatEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function hostParallelism(): number {
+  try {
+    return typeof os.availableParallelism === 'function'
+      ? os.availableParallelism()
+      : os.cpus().length;
+  } catch {
+    return 4;
+  }
+}
+
+const DEFAULT_FILE_CONCURRENCY = Math.max(2, Math.min(24, hostParallelism()));
+const FILE_CONCURRENCY = parsePositiveIntEnv('EXTRACT_FILE_CONCURRENCY', DEFAULT_FILE_CONCURRENCY);
+const MAX_FILE_CONCURRENCY = parsePositiveIntEnv('EXTRACT_FILE_CONCURRENCY_MAX', Math.max(FILE_CONCURRENCY, 24));
+const HEAVY_MULTIPLIER = parsePositiveFloatEnv('EXTRACT_HEAVY_MULTIPLIER', 1);
+const LIGHT_MULTIPLIER = parsePositiveFloatEnv('EXTRACT_LIGHT_MULTIPLIER', 1.25);
+
+type WorkloadProfile = 'heavy' | 'light';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function getAdaptiveConcurrency(fileCount: number, profile: WorkloadProfile): number {
+  if (fileCount <= 0) return 1;
+
+  let concurrency = FILE_CONCURRENCY;
+
+  // Large batches in big models can saturate disk and parser CPU; reduce fanout.
+  if (fileCount >= 5000) {
+    concurrency = Math.floor(concurrency * 0.55);
+  } else if (fileCount >= 2500) {
+    concurrency = Math.floor(concurrency * 0.7);
+  } else if (fileCount >= 1000) {
+    concurrency = Math.floor(concurrency * 0.85);
+  } else if (fileCount <= 200) {
+    // Small batches benefit from a slight boost to hide FS latency.
+    concurrency = Math.ceil(concurrency * 1.15);
+  }
+
+  const multiplier = profile === 'light' ? LIGHT_MULTIPLIER : HEAVY_MULTIPLIER;
+  concurrency = Math.floor(concurrency * multiplier);
+
+  return clamp(concurrency, 1, Math.min(MAX_FILE_CONCURRENCY, fileCount));
+}
+
+async function forEachWithConcurrency<T>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async (_unused, workerIndex) => {
+    for (let i = workerIndex; i < items.length; i += concurrency) {
+      await worker(items[i]);
+    }
+  });
+  await Promise.all(workers);
+}
+
 /** The model-level values every extractor needs, threaded through AOT_EXTRACTORS. */
 interface ModelContext {
   parser: XppMetadataParser;
@@ -318,11 +394,10 @@ async function countXmlFilesInDirectory(dirPath: string): Promise<number> {
 
 /** Expected XML file count for a model, over exactly the folders the extractors read. */
 export async function countModelXmlFiles(dirsByLowerName: Map<string, string>): Promise<number> {
-  let total = 0;
-  for (const dirPath of resolveDirs(dirsByLowerName, EXTRACTED_AOT_DIRS)) {
-    total += await countXmlFilesInDirectory(dirPath);
-  }
-  return total;
+  const totals = await Promise.all(
+    resolveDirs(dirsByLowerName, EXTRACTED_AOT_DIRS).map(dirPath => countXmlFilesInDirectory(dirPath)),
+  );
+  return totals.reduce((sum, count) => sum + count, 0);
 }
 
 async function extractMetadata() {
@@ -363,6 +438,10 @@ async function extractMetadata() {
 
   console.log(kv('Source', metadataRoots.join(', ')));
   console.log(kv('Output', shortPath(OUTPUT_PATH)));
+  console.log(kv('File workers', formatCount(FILE_CONCURRENCY)));
+  console.log(kv('File workers max', formatCount(MAX_FILE_CONCURRENCY)));
+  console.log(kv('Heavy multiplier', formatDecimal(HEAVY_MULTIPLIER)));
+  console.log(kv('Light multiplier', formatDecimal(LIGHT_MULTIPLIER)));
   
   if (EXTRACT_MODE === 'custom') {
     if (MODELS_TO_EXTRACT.length > 0) {
@@ -725,10 +804,11 @@ async function extractClasses(
 ) {
   const files = await fs.readdir(classesPath);
   const xmlFiles = files.filter(f => f.endsWith('.xml'));
+  const fileConcurrency = getAdaptiveConcurrency(xmlFiles.length, 'heavy');
 
-  log.detail(`Classes: ${formatCount(xmlFiles.length)} files`);
+  log.detail(`Classes: ${formatCount(xmlFiles.length)} files (${formatCount(fileConcurrency)} workers)`);
 
-  for (const file of xmlFiles) {
+  await forEachWithConcurrency(xmlFiles, fileConcurrency, async (file) => {
     const filePath = path.join(classesPath, file);
     stats.totalFiles++;
 
@@ -738,14 +818,15 @@ async function extractClasses(
       if (!classInfo.success || !classInfo.data) {
         log.warn(`Failed to parse ${file}: ${classInfo.error || 'Unknown error'}`);
         stats.errors++;
-        continue;
+        return;
       }
+      const classData = classInfo.data;
       
       // Save as JSON
       const outputDir = path.join(OUTPUT_PATH, modelName, 'classes');
       await fs.mkdir(outputDir, { recursive: true });
-      const outputFile = path.join(outputDir, `${classInfo.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(classInfo.data, isCustom ? sourcePathReplacer : undefined, 2));
+      const outputFile = path.join(outputDir, `${classData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify(classData, isCustom ? sourcePathReplacer : undefined, 2));
 
       stats.classes++;
 
@@ -753,14 +834,14 @@ async function extractClasses(
       // indexed as a class (it is a real AxClass) and additionally gets an
       // extension record, which is what find_coc_extensions and
       // resolve_references' extension-method path query.
-      if (classInfo.data.extensionOf) {
-        await writeClassExtensionRecord(classInfo.data, modelName, stats, isCustom);
+      if (classData.extensionOf) {
+        await writeClassExtensionRecord(classData, modelName, stats, isCustom);
       }
     } catch (error) {
       log.err(`Error parsing ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 
 }
 
@@ -798,10 +879,11 @@ async function extractTables(
 ) {
   const files = await fs.readdir(tablesPath);
   const xmlFiles = files.filter(f => f.endsWith('.xml'));
+  const fileConcurrency = getAdaptiveConcurrency(xmlFiles.length, 'heavy');
 
-  log.detail(`Tables: ${formatCount(xmlFiles.length)} files`);
+  log.detail(`Tables: ${formatCount(xmlFiles.length)} files (${formatCount(fileConcurrency)} workers)`);
 
-  for (const file of xmlFiles) {
+  await forEachWithConcurrency(xmlFiles, fileConcurrency, async (file) => {
     const filePath = path.join(tablesPath, file);
     stats.totalFiles++;
 
@@ -811,21 +893,22 @@ async function extractTables(
       if (!tableInfo.success || !tableInfo.data) {
         log.warn(`Failed to parse ${file}: ${tableInfo.error || 'Unknown error'}`);
         stats.errors++;
-        continue;
+        return;
       }
+      const tableData = tableInfo.data;
       
       // Save as JSON
       const outputDir = path.join(OUTPUT_PATH, modelName, 'tables');
       await fs.mkdir(outputDir, { recursive: true });
-      const outputFile = path.join(outputDir, `${tableInfo.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(tableInfo.data, isCustom ? sourcePathReplacer : undefined, 2));
+      const outputFile = path.join(outputDir, `${tableData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify(tableData, isCustom ? sourcePathReplacer : undefined, 2));
 
       stats.tables++;
     } catch (error) {
       log.err(`Error parsing ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 
 }
 
@@ -838,10 +921,11 @@ async function extractForms(
 ) {
   const files = await fs.readdir(formsPath);
   const xmlFiles = files.filter(f => f.endsWith('.xml'));
+  const fileConcurrency = getAdaptiveConcurrency(xmlFiles.length, 'heavy');
 
-  log.detail(`Forms: ${formatCount(xmlFiles.length)} files`);
+  log.detail(`Forms: ${formatCount(xmlFiles.length)} files (${formatCount(fileConcurrency)} workers)`);
 
-  for (const file of xmlFiles) {
+  await forEachWithConcurrency(xmlFiles, fileConcurrency, async (file) => {
     const filePath = path.join(formsPath, file);
     stats.totalFiles++;
 
@@ -852,7 +936,7 @@ async function extractForms(
       if (!result.success || !result.data) {
         log.err(`Error parsing ${file}: ${result.error || 'Unknown error'}`);
         stats.errors++;
-        continue;
+        return;
       }
       
       const formInfo = result.data;
@@ -867,7 +951,7 @@ async function extractForms(
       log.err(`Error parsing ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 
 }
 
@@ -879,10 +963,11 @@ async function extractQueries(
 ) {
   const files = await fs.readdir(queriesPath);
   const xmlFiles = files.filter(f => f.endsWith('.xml'));
+  const fileConcurrency = getAdaptiveConcurrency(xmlFiles.length, 'light');
 
-  log.detail(`Queries: ${formatCount(xmlFiles.length)} files`);
+  log.detail(`Queries: ${formatCount(xmlFiles.length)} files (${formatCount(fileConcurrency)} workers)`);
 
-  for (const file of xmlFiles) {
+  await forEachWithConcurrency(xmlFiles, fileConcurrency, async (file) => {
     const filePath = path.join(queriesPath, file);
     stats.totalFiles++;
 
@@ -906,7 +991,7 @@ async function extractQueries(
       log.err(`Error parsing ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 
 }
 
@@ -922,9 +1007,10 @@ async function extractViews(
   for (const sourceDir of sourceDirs) {
     const files = await fs.readdir(sourceDir);
     const xmlFiles = files.filter(f => f.endsWith('.xml'));
+    const fileConcurrency = getAdaptiveConcurrency(xmlFiles.length, 'heavy');
     totalXmlFiles += xmlFiles.length;
 
-    for (const file of xmlFiles) {
+    await forEachWithConcurrency(xmlFiles, fileConcurrency, async (file) => {
       const filePath = path.join(sourceDir, file);
       stats.totalFiles++;
 
@@ -934,15 +1020,16 @@ async function extractViews(
         if (!viewInfo.success || !viewInfo.data) {
           log.warn(`Failed to parse ${file}: ${viewInfo.error || 'Unknown error'}`);
           stats.errors++;
-          continue;
+          return;
         }
+        const viewData = viewInfo.data;
 
         const outputDir = path.join(OUTPUT_PATH, modelName, 'views');
         await fs.mkdir(outputDir, { recursive: true });
-        const outputFile = path.join(outputDir, `${viewInfo.data.name}.json`);
-        await fs.writeFile(outputFile, JSON.stringify(viewInfo.data, isCustom ? sourcePathReplacer : undefined, 2));
+        const outputFile = path.join(outputDir, `${viewData.name}.json`);
+        await fs.writeFile(outputFile, JSON.stringify(viewData, isCustom ? sourcePathReplacer : undefined, 2));
 
-        if (viewInfo.data.type === 'data-entity') {
+        if (viewData.type === 'data-entity') {
           stats.dataEntities++;
         } else {
           stats.views++;
@@ -951,7 +1038,7 @@ async function extractViews(
         log.err(`Error parsing ${file}: ${error instanceof Error ? error.message : error}`);
         stats.errors++;
       }
-    }
+    });
   }
 
   log.detail(`Views/Data entities: ${formatCount(totalXmlFiles)} files`);
@@ -965,10 +1052,11 @@ async function extractEnums(
 ) {
   const files = await fs.readdir(enumsPath);
   const xmlFiles = files.filter(f => f.endsWith('.xml'));
+  const fileConcurrency = getAdaptiveConcurrency(xmlFiles.length, 'light');
 
-  log.detail(`Enums: ${formatCount(xmlFiles.length)} files`);
+  log.detail(`Enums: ${formatCount(xmlFiles.length)} files (${formatCount(fileConcurrency)} workers)`);
 
-  for (const file of xmlFiles) {
+  await forEachWithConcurrency(xmlFiles, fileConcurrency, async (file) => {
     const filePath = path.join(enumsPath, file);
     stats.totalFiles++;
 
@@ -985,7 +1073,7 @@ async function extractEnums(
       log.err(`Error parsing ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 
 }
 
@@ -998,10 +1086,11 @@ async function extractEdts(
 ) {
   const files = await fs.readdir(edtsPath);
   const xmlFiles = files.filter(f => f.endsWith('.xml'));
+  const fileConcurrency = getAdaptiveConcurrency(xmlFiles.length, 'heavy');
 
-  log.detail(`EDTs: ${formatCount(xmlFiles.length)} files`);
+  log.detail(`EDTs: ${formatCount(xmlFiles.length)} files (${formatCount(fileConcurrency)} workers)`);
 
-  for (const file of xmlFiles) {
+  await forEachWithConcurrency(xmlFiles, fileConcurrency, async (file) => {
     const filePath = path.join(edtsPath, file);
     stats.totalFiles++;
 
@@ -1012,7 +1101,7 @@ async function extractEdts(
       if (!result.success || !result.data) {
         log.err(`Error parsing ${file}: ${result.error || 'Unknown error'}`);
         stats.errors++;
-        continue;
+        return;
       }
       
       const edtInfo = result.data;
@@ -1027,7 +1116,7 @@ async function extractEdts(
       log.err(`Error parsing ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 
 }
 
@@ -1047,12 +1136,13 @@ async function extractReports(
   const xmlFiles = files.filter(f => f.endsWith('.xml'));
 
   if (xmlFiles.length === 0) return;
-  log.detail(`Reports: ${formatCount(xmlFiles.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(xmlFiles.length, 'light');
+  log.detail(`Reports: ${formatCount(xmlFiles.length)} files (${formatCount(fileConcurrency)} workers)`);
 
   const outputDir = path.join(OUTPUT_PATH, modelName, 'reports');
   await fs.mkdir(outputDir, { recursive: true });
 
-  for (const file of xmlFiles) {
+  await forEachWithConcurrency(xmlFiles, fileConcurrency, async (file) => {
     const filePath = path.join(reportsPath, file);
     stats.totalFiles++;
 
@@ -1074,7 +1164,7 @@ async function extractReports(
       log.err(`Error extracting report ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 async function extractSecurityPrivileges(
@@ -1086,23 +1176,25 @@ async function extractSecurityPrivileges(
 ) {
   const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
   if (files.length === 0) return;
-  log.detail(`Security privileges: ${formatCount(files.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(files.length, 'heavy');
+  log.detail(`Security privileges: ${formatCount(files.length)} files (${formatCount(fileConcurrency)} workers)`);
   const outputDir = path.join(OUTPUT_PATH, modelName, 'security-privileges');
   await fs.mkdir(outputDir, { recursive: true });
-  for (const file of files) {
+  await forEachWithConcurrency(files, fileConcurrency, async (file) => {
     const filePath = path.join(dirPath, file);
     stats.totalFiles++;
     try {
       const result = await parser.parseSecurityPrivilegeFile(filePath);
-      if (!result.success || !result.data) { stats.errors++; continue; }
-      const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-privilege' }, isCustom ? sourcePathReplacer : undefined, 2));
+      if (!result.success || !result.data) { stats.errors++; return; }
+      const privilegeData = result.data;
+      const outputFile = path.join(outputDir, `${privilegeData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...privilegeData, model: modelName, type: 'security-privilege' }, isCustom ? sourcePathReplacer : undefined, 2));
       stats.securityPrivileges++;
     } catch (error) {
       log.err(`Error extracting security privilege ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 async function extractSecurityDuties(
@@ -1114,23 +1206,25 @@ async function extractSecurityDuties(
 ) {
   const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
   if (files.length === 0) return;
-  log.detail(`Security duties: ${formatCount(files.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(files.length, 'heavy');
+  log.detail(`Security duties: ${formatCount(files.length)} files (${formatCount(fileConcurrency)} workers)`);
   const outputDir = path.join(OUTPUT_PATH, modelName, 'security-duties');
   await fs.mkdir(outputDir, { recursive: true });
-  for (const file of files) {
+  await forEachWithConcurrency(files, fileConcurrency, async (file) => {
     const filePath = path.join(dirPath, file);
     stats.totalFiles++;
     try {
       const result = await parser.parseSecurityDutyFile(filePath);
-      if (!result.success || !result.data) { stats.errors++; continue; }
-      const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-duty' }, isCustom ? sourcePathReplacer : undefined, 2));
+      if (!result.success || !result.data) { stats.errors++; return; }
+      const dutyData = result.data;
+      const outputFile = path.join(outputDir, `${dutyData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...dutyData, model: modelName, type: 'security-duty' }, isCustom ? sourcePathReplacer : undefined, 2));
       stats.securityDuties++;
     } catch (error) {
       log.err(`Error extracting security duty ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 async function extractSecurityRoles(
@@ -1142,23 +1236,25 @@ async function extractSecurityRoles(
 ) {
   const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
   if (files.length === 0) return;
-  log.detail(`Security roles: ${formatCount(files.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(files.length, 'heavy');
+  log.detail(`Security roles: ${formatCount(files.length)} files (${formatCount(fileConcurrency)} workers)`);
   const outputDir = path.join(OUTPUT_PATH, modelName, 'security-roles');
   await fs.mkdir(outputDir, { recursive: true });
-  for (const file of files) {
+  await forEachWithConcurrency(files, fileConcurrency, async (file) => {
     const filePath = path.join(dirPath, file);
     stats.totalFiles++;
     try {
       const result = await parser.parseSecurityRoleFile(filePath);
-      if (!result.success || !result.data) { stats.errors++; continue; }
-      const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'security-role' }, isCustom ? sourcePathReplacer : undefined, 2));
+      if (!result.success || !result.data) { stats.errors++; return; }
+      const roleData = result.data;
+      const outputFile = path.join(outputDir, `${roleData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...roleData, model: modelName, type: 'security-role' }, isCustom ? sourcePathReplacer : undefined, 2));
       stats.securityRoles++;
     } catch (error) {
       log.err(`Error extracting security role ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 async function extractMenuItems(
@@ -1175,23 +1271,25 @@ async function extractMenuItems(
 
   const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
   if (files.length === 0) return;
-  log.detail(`Menu items (${itemType}): ${formatCount(files.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(files.length, 'heavy');
+  log.detail(`Menu items (${itemType}): ${formatCount(files.length)} files (${formatCount(fileConcurrency)} workers)`);
   const outputDir = path.join(OUTPUT_PATH, modelName, outDirName);
   await fs.mkdir(outputDir, { recursive: true });
-  for (const file of files) {
+  await forEachWithConcurrency(files, fileConcurrency, async (file) => {
     const filePath = path.join(dirPath, file);
     stats.totalFiles++;
     try {
       const result = await parser.parseMenuItemFile(filePath, itemType);
-      if (!result.success || !result.data) { stats.errors++; continue; }
-      const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: `menu-item-${itemType}` }, isCustom ? sourcePathReplacer : undefined, 2));
+      if (!result.success || !result.data) { stats.errors++; return; }
+      const menuItemData = result.data;
+      const outputFile = path.join(outputDir, `${menuItemData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...menuItemData, model: modelName, type: `menu-item-${itemType}` }, isCustom ? sourcePathReplacer : undefined, 2));
       (stats as any)[statKey]++;
     } catch (error) {
       log.err(`Error extracting menu item (${itemType}) ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 async function extractExtensions(
@@ -1223,24 +1321,26 @@ async function extractExtensions(
 
   const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
   if (files.length === 0) return;
-  log.detail(`${extensionType}s: ${formatCount(files.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(files.length, 'heavy');
+  log.detail(`${extensionType}s: ${formatCount(files.length)} files (${formatCount(fileConcurrency)} workers)`);
   const outputDir = path.join(OUTPUT_PATH, modelName, outDirName);
   await fs.mkdir(outputDir, { recursive: true });
-  for (const file of files) {
+  await forEachWithConcurrency(files, fileConcurrency, async (file) => {
     const filePath = path.join(dirPath, file);
     stats.totalFiles++;
     try {
       const result = await parser.parseExtensionFile(filePath, extensionType);
-      if (!result.success || !result.data) { stats.errors++; continue; }
-      const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: extensionType }, isCustom ? sourcePathReplacer : undefined, 2));
+      if (!result.success || !result.data) { stats.errors++; return; }
+      const extensionData = result.data;
+      const outputFile = path.join(outputDir, `${extensionData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...extensionData, model: modelName, type: extensionType }, isCustom ? sourcePathReplacer : undefined, 2));
       const statKey = statKeyMap[extensionType];
       if (statKey) (stats as any)[statKey]++;
     } catch (error) {
       log.err(`Error extracting ${extensionType} ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 async function extractServices(
@@ -1252,23 +1352,25 @@ async function extractServices(
 ) {
   const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
   if (files.length === 0) return;
-  log.detail(`Services: ${formatCount(files.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(files.length, 'heavy');
+  log.detail(`Services: ${formatCount(files.length)} files (${formatCount(fileConcurrency)} workers)`);
   const outputDir = path.join(OUTPUT_PATH, modelName, 'services');
   await fs.mkdir(outputDir, { recursive: true });
-  for (const file of files) {
+  await forEachWithConcurrency(files, fileConcurrency, async (file) => {
     const filePath = path.join(dirPath, file);
     stats.totalFiles++;
     try {
       const result = await parser.parseServiceFile(filePath);
-      if (!result.success || !result.data) { stats.errors++; continue; }
-      const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'service' }, isCustom ? sourcePathReplacer : undefined, 2));
+      if (!result.success || !result.data) { stats.errors++; return; }
+      const serviceData = result.data;
+      const outputFile = path.join(outputDir, `${serviceData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...serviceData, model: modelName, type: 'service' }, isCustom ? sourcePathReplacer : undefined, 2));
       stats.services++;
     } catch (error) {
       log.err(`Error extracting service ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 async function extractServiceGroups(
@@ -1280,23 +1382,25 @@ async function extractServiceGroups(
 ) {
   const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
   if (files.length === 0) return;
-  log.detail(`Service groups: ${formatCount(files.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(files.length, 'heavy');
+  log.detail(`Service groups: ${formatCount(files.length)} files (${formatCount(fileConcurrency)} workers)`);
   const outputDir = path.join(OUTPUT_PATH, modelName, 'service-groups');
   await fs.mkdir(outputDir, { recursive: true });
-  for (const file of files) {
+  await forEachWithConcurrency(files, fileConcurrency, async (file) => {
     const filePath = path.join(dirPath, file);
     stats.totalFiles++;
     try {
       const result = await parser.parseServiceGroupFile(filePath);
-      if (!result.success || !result.data) { stats.errors++; continue; }
-      const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type: 'service-group' }, isCustom ? sourcePathReplacer : undefined, 2));
+      if (!result.success || !result.data) { stats.errors++; return; }
+      const serviceGroupData = result.data;
+      const outputFile = path.join(outputDir, `${serviceGroupData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...serviceGroupData, model: modelName, type: 'service-group' }, isCustom ? sourcePathReplacer : undefined, 2));
       stats.serviceGroups++;
     } catch (error) {
       log.err(`Error extracting service group ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 /**
@@ -1316,23 +1420,25 @@ async function extractSimpleType(
 ) {
   const files = (await fs.readdir(dirPath)).filter(f => f.endsWith('.xml'));
   if (files.length === 0) return;
-  log.detail(`${label}: ${formatCount(files.length)} files`);
+  const fileConcurrency = getAdaptiveConcurrency(files.length, 'heavy');
+  log.detail(`${label}: ${formatCount(files.length)} files (${formatCount(fileConcurrency)} workers)`);
   const outputDir = path.join(OUTPUT_PATH, modelName, outDirName);
   await fs.mkdir(outputDir, { recursive: true });
-  for (const file of files) {
+  await forEachWithConcurrency(files, fileConcurrency, async (file) => {
     const filePath = path.join(dirPath, file);
     stats.totalFiles++;
     try {
       const result = await parseFn(filePath);
-      if (!result.success || !result.data) { stats.errors++; continue; }
-      const outputFile = path.join(outputDir, `${result.data.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...result.data, model: modelName, type }, isCustom ? sourcePathReplacer : undefined, 2));
+      if (!result.success || !result.data) { stats.errors++; return; }
+      const parsedData = result.data;
+      const outputFile = path.join(outputDir, `${parsedData.name}.json`);
+      await fs.writeFile(outputFile, JSON.stringify({ ...parsedData, model: modelName, type }, isCustom ? sourcePathReplacer : undefined, 2));
       (stats as any)[statKey]++;
     } catch (error) {
       log.err(`Error extracting ${label} ${file}: ${error instanceof Error ? error.message : error}`);
       stats.errors++;
     }
-  }
+  });
 }
 
 async function extractMaps(parser: XppMetadataParser, dirPath: string, modelName: string, stats: ExtractionStats, isCustom = false) {

--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -114,15 +114,17 @@ export function buildClassExtensionRecord(
 }
 
 export class XppMetadataParser {
-  private parser: Parser;
   private enhancedParser: EnhancedXppParser;
 
-  constructor() {
-    this.parser = new Parser({
+  private get parser(): Parser {
+    return new Parser({
       explicitArray: false,
       mergeAttrs: true,
       trim: true,
     });
+  }
+
+  constructor() {
     this.enhancedParser = new EnhancedXppParser();
   }
 


### PR DESCRIPTION
## Summary
- Speeds up metadata extraction on large models (especially Foundation/ApplicationSuite).
- Introduces bounded parallel processing across metadata extractors.
- Adds adaptive worker throttling based on batch size and workload profile.
- Makes XML parsing reentrant-safe for concurrent execution.

## What changed
- Added configurable concurrency controls:
  - EXTRACT_FILE_CONCURRENCY
  - EXTRACT_FILE_CONCURRENCY_MAX
  - EXTRACT_HEAVY_MULTIPLIER
  - EXTRACT_LIGHT_MULTIPLIER
- Added adaptive concurrency selection for heavy vs light extractor workloads.
- Parallelized XML counting in planning phase.
- Switched extractor loops from sequential processing to bounded concurrency workers.
- Updated XML parser instantiation to avoid shared parser state under concurrency.
- Added startup logging of effective worker settings for easier tuning.

## Validation
- npm run build passed.
- TypeScript diagnostics on touched files are clean.

## Notes
- Default behavior remains safe; tuning can be done via env vars without code changes.
- Recommended starting profile for large standard models:
  - EXTRACT_FILE_CONCURRENCY=10
  - EXTRACT_FILE_CONCURRENCY_MAX=16
  - EXTRACT_HEAVY_MULTIPLIER=0.9
  - EXTRACT_LIGHT_MULTIPLIER=1.2