### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v1.5.0

Version bump 1.4.0 -> 1.5.0 (minor - new feat commit since last release, no breaking changes).

Pre-release checks:
- npm test: 170 files, 2255 tests passed (2 skipped)
- npm run build: clean

Changes since v1.4.0:
- feat(setup): generate .mcp.json and stage copilot setup files
- perf: speed up metadata extraction with adaptive concurrency
- chore: repo cleanup / docs consolidation
- eval: goldens captured, macro/EDT-extension leaves closed, KB fixes

After this PR merges, tag main as v1.5.0 and push the tag to trigger the release workflow (GitHub Release + npm publish).