### PR TITLE
fix(bridge): merge nuget.org into restrictive D365FO VM NuGet feeds

### DIFF
--- a/bridge/D365MetadataBridge/NuGet.config
+++ b/bridge/D365MetadataBridge/NuGet.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  D365FO dev VMs frequently ship a machine-wide NuGet.config that only lists
+  offline/VS package sources (e.g. "C:\Program Files\dotnet\library-packs" and
+  "Microsoft Visual Studio Offline Packages") — nuget.org isn't in it, so
+  restoring System.Text.Json / Microsoft.NETFramework.ReferenceAssemblies.net48
+  fails with NU1101 even though the machine has internet access.
+
+  This file has no <clear/>, so NuGet MERGES it with whatever the machine/user
+  config already defines — it only adds nuget.org, it never removes the
+  offline sources the D365FO tooling relies on. See docs/SETUP.md
+  "Restrictive NuGet feed".
+-->
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -240,7 +240,7 @@ dotnet build -c Release        # output: bin\Release\D365MetadataBridge.exe (aut
 | Situation | Action |
 |-----------|--------|
 | UDE box (DLLs not in `PackagesLocalDirectory\bin`) | `dotnet build -c Release -p:D365BinPath="<FrameworkDirectory>\bin"` |
-| Restrictive NuGet feed | add `--source https://api.nuget.org/v3/index.json` |
+| `NU1101` restoring `System.Text.Json` / `Microsoft.NETFramework.ReferenceAssemblies.net48` | The bridge ships its own `NuGet.config` that merges nuget.org into whatever offline sources the VM already has, so this is usually already fixed. If it still fails (nuget.org blocked outright), restore once with `dotnet restore --source https://api.nuget.org/v3/index.json` |
 | After a D365FO version upgrade | rebuild to pick up new DLLs |
 
 Healthy startup: `✅ C# bridge initialized (metadataAvailable: true, xrefAvailable: true)`. `xrefAvailable: false` is non-critical (xref tools fall back to SQLite FTS). Full reference: [ARCHITECTURE.md § C# Metadata Bridge](ARCHITECTURE.md#c-metadata-bridge)


### PR DESCRIPTION
Fixes NU1101 during \
pm run setup\ -> bridge build (and plain \dotnet build\) on D365FO VMs whose machine-wide NuGet.config only lists offline sources (VS offline packages, dotnet library-packs) and doesn't include nuget.org:

```
error NU1101: Unable to find package System.Text.Json...
error NU1101: Unable to find package Microsoft.NETFramework.ReferenceAssemblies.net48...
```

Adds \ridge/D365MetadataBridge/NuGet.config\ (no \<clear/>\) which MERGES nuget.org into whatever sources the machine already defines, so restore works without a manual \--source\ flag. Updated the SETUP.md troubleshooting table accordingly.

Verified locally: \dotnet restore\ succeeds in \ridge/D365MetadataBridge\ with the new config.