### PR TITLE
chore(release): v1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v1.5.1 (patch)

Version bump 1.5.0 -> 1.5.1 - bugfix-only release, no breaking changes.

Pre-release checks:
- npm test: 170 files, 2255 tests passed (2 skipped)
- npm run build: clean

Changes since v1.5.0:
- fix(bridge): merge nuget.org into restrictive D365FO VM NuGet feeds (#770) - fixes NU1101 restoring System.Text.Json / Microsoft.NETFramework.ReferenceAssemblies.net48 during \
pm run setup\ / \dotnet build\ on D365FO VMs whose machine-wide NuGet.config only lists offline sources.

After this PR merges, tag main as v1.5.1 and push the tag to trigger the release workflow (GitHub Release + npm publish).