### PR TITLE
refactor(setup): stop copying .mcp.json into the staging folder

### DIFF
--- a/src/cli/commands/instance.ts
+++ b/src/cli/commands/instance.ts
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import { resolve } from 'node:path';
 import { settingByPath, settingsInSection } from '../../config/settings.js';
 import { pinBridgeExe } from '../bridgePath.js';
-import { finalizeStagedCopilotFiles, maybePrepareCopilotInstructions } from '../copilotFiles.js';
+import { maybePrepareCopilotInstructions } from '../copilotFiles.js';
 import { createInstance, getInstance, listInstances, normalizeInstanceLayout, suggestPort } from '../instances.js';
 import { mcpJsonNote, placementNote, stdioServer } from '../mcpJson.js';
 import { selectXppConfig } from './config.js';
@@ -115,7 +115,7 @@ export async function instanceAddCommand(name: string | undefined, portArg: stri
   // Copilot needs the instructions file just as much as it needs .mcp.json,
   // and an instance is somebody's only setup run — asking here is the only
   // chance scenario F gets.
-  const copilotPlan = await maybePrepareCopilotInstructions(
+  await maybePrepareCopilotInstructions(
     String(readSetting(store, settingByPath('workspace.solutionsPath')!) ?? ''),
   );
 
@@ -128,7 +128,6 @@ export async function instanceAddCommand(name: string | undefined, portArg: stri
     },
     `.mcp.json — keep the stdio entry OR the http one, not both`,
   );
-  finalizeStagedCopilotFiles(copilotPlan);
   placementNote();
 
   p.note(

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -16,7 +16,7 @@ import type { SectionId } from '../../config/settings.js';
 import { settingByPath, settingsInSection } from '../../config/settings.js';
 import { commandExists, runExe, runShell } from '../exec.js';
 import { pinBridgeExe } from '../bridgePath.js';
-import { finalizeStagedCopilotFiles, maybePrepareCopilotInstructions } from '../copilotFiles.js';
+import { maybePrepareCopilotInstructions } from '../copilotFiles.js';
 import { mcpJsonNote, placementNote, stdioServer } from '../mcpJson.js';
 import { checkRelease } from '../npmRegistry.js';
 import { askAdvanced, askSecrets, askSetting, askSettings } from '../settingsPrompt.js';
@@ -295,7 +295,7 @@ export async function setupCommand(): Promise<void> {
     const url = await askText({ message: 'Azure server URL', placeholder: 'https://your-server.azurewebsites.net/mcp/', required: true });
     await configureEnvironment(store, scenario);
     await configureWorkspace(store, scenario);
-    const copilotPlan = await maybePrepareCopilotInstructions(solutionsPath(store));
+    await maybePrepareCopilotInstructions(solutionsPath(store));
     await configureNaming(store);
     await askSecrets(store, ['behavior']);
     await askAdvanced(store, ['environment', 'workspace', 'naming', 'bridge', 'behavior', 'server']);
@@ -306,7 +306,6 @@ export async function setupCommand(): Promise<void> {
       'd365fo-azure': { url },
       'd365fo-local': stdioServer(store),
     });
-    finalizeStagedCopilotFiles(copilotPlan);
     placementNote();
     p.outro('Hybrid setup complete — no local index needed (Azure serves the search).');
     return;
@@ -316,7 +315,7 @@ export async function setupCommand(): Promise<void> {
   writeSetting(store, setting('server.mode'), 'full');
   await configureEnvironment(store, scenario);
   await configureWorkspace(store, scenario);
-  const copilotPlan = await maybePrepareCopilotInstructions(solutionsPath(store));
+  await maybePrepareCopilotInstructions(solutionsPath(store));
   await configureNaming(store);
   await configureIndex(store);
 
@@ -335,7 +334,6 @@ export async function setupCommand(): Promise<void> {
 
   if (scenario === 'local-http') {
     mcpJsonNote({ 'd365fo-mcp-tools': { url: `http://localhost:${port}/mcp/` } });
-    finalizeStagedCopilotFiles(copilotPlan);
     placementNote();
     p.outro('Done. Start the server with: d365fo-mcp start');
     return;
@@ -344,7 +342,6 @@ export async function setupCommand(): Promise<void> {
   // D / E — the IDE spawns dist/index.js itself and is pointed at the config
   // file; every other setting comes from there.
   mcpJsonNote({ 'd365fo-mcp-tools': stdioServer(store) });
-  finalizeStagedCopilotFiles(copilotPlan);
   placementNote();
   p.outro('Done. VS spawns the server automatically — no manual start needed.');
 }

--- a/src/cli/copilotFiles.ts
+++ b/src/cli/copilotFiles.ts
@@ -6,8 +6,12 @@
  * built-in file tools and edits X++ behind the metadata provider's back. Both
  * files therefore have to be placed for a working install, so the wizards
  * offer to put this one down as well — either straight into the solutions
- * folder, or, when that is unknown, into a staging folder next to the
- * generated .mcp.json with a README naming the two destinations.
+ * folder, or, when that is unknown, into a staging folder with a README
+ * naming the two destinations.
+ *
+ * The README points at the one .mcp.json `mcpJsonNote()` writes in the data
+ * root rather than copying it: the staging folder sits in that same data
+ * root, so a second copy is only one more file to keep in sync.
  *
  * Shared by `setup` (scenarios B–E) and `instance add` (scenario F), which
  * both end on the same two-file placement step.
@@ -17,15 +21,10 @@ import { resolve } from 'node:path';
 import { dataRoot, paths, repoRoot } from './context.js';
 import { askConfirm, p } from './ui.js';
 
-export type CopilotFilePlan = { stagingDir?: string };
-
 /** The copy shipped with this installation — package root in both install modes. */
 const copilotSource = (): string => resolve(repoRoot, '.github', 'copilot-instructions.md');
 
-function writeCopilotSetupReadme(
-  targetDir: string,
-  opts: { includeLocalMcpCopy: boolean; copilotAlreadyPlaced: boolean },
-): void {
+function writeCopilotSetupReadme(targetDir: string, opts: { copilotAlreadyPlaced: boolean }): void {
   const readmePath = resolve(targetDir, 'README.md');
   const lines = [
     '# VS setup quick guide',
@@ -35,9 +34,7 @@ function writeCopilotSetupReadme(
     '1. Copy .mcp.json',
     '   - Recommended (all solutions): %USERPROFILE%\\.mcp.json',
     '   - Per solution: place .mcp.json next to your .sln file',
-    opts.includeLocalMcpCopy
-      ? '   - Local copy prepared here: .mcp.json'
-      : `   - Local copy path: ${paths.mcpSuggestion}`,
+    `   - Generated copy: ${paths.mcpSuggestion}`,
     '',
     '2. Copy .github/copilot-instructions.md',
     opts.copilotAlreadyPlaced
@@ -54,18 +51,17 @@ function writeCopilotSetupReadme(
  * Offer to place copilot-instructions.md, falling back to a staging folder.
  *
  * `solutionsPath` is what the user gave for workspace.solutionsPath; when it
- * is empty there is nowhere to copy to, so the files are staged instead and
- * the returned plan tells {@link finalizeStagedCopilotFiles} to complete it
- * once the .mcp.json exists.
+ * is empty there is nowhere to copy to, so the file is staged instead and the
+ * README says where it has to end up.
  */
-export async function maybePrepareCopilotInstructions(solutionsPath: string): Promise<CopilotFilePlan> {
+export async function maybePrepareCopilotInstructions(solutionsPath: string): Promise<void> {
   const source = copilotSource();
   if (!fs.existsSync(source)) {
     p.log.warn(
       'Cannot find copilot-instructions.md in this installation; skipping copy helper.\n' +
       `   Looked for: ${source}`,
     );
-    return {};
+    return;
   }
 
   const wantsDirectCopy = await askConfirm(
@@ -78,17 +74,17 @@ export async function maybePrepareCopilotInstructions(solutionsPath: string): Pr
     const targetDir = resolve(target, '.github');
     fs.mkdirSync(targetDir, { recursive: true });
     fs.copyFileSync(source, resolve(targetDir, 'copilot-instructions.md'));
-    writeCopilotSetupReadme(target, { includeLocalMcpCopy: false, copilotAlreadyPlaced: true });
+    writeCopilotSetupReadme(target, { copilotAlreadyPlaced: true });
     p.log.success(`Prepared: ${resolve(targetDir, 'copilot-instructions.md')}`);
     p.log.success(`Prepared: ${resolve(target, 'README.md')}`);
-    return {};
+    return;
   }
 
   const stageDir = resolve(dataRoot(), 'copilot-setup');
   const stageGitHubDir = resolve(stageDir, '.github');
   fs.mkdirSync(stageGitHubDir, { recursive: true });
   fs.copyFileSync(source, resolve(stageGitHubDir, 'copilot-instructions.md'));
-  writeCopilotSetupReadme(stageDir, { includeLocalMcpCopy: false, copilotAlreadyPlaced: false });
+  writeCopilotSetupReadme(stageDir, { copilotAlreadyPlaced: false });
 
   if (wantsDirectCopy && !target) {
     p.log.warn('Solutions folder is empty, so files were prepared in the local staging folder instead.');
@@ -96,16 +92,4 @@ export async function maybePrepareCopilotInstructions(solutionsPath: string): Pr
     p.log.info('Copy was skipped; files were prepared in a local staging folder for later use.');
   }
   p.log.info(`Staging folder: ${stageDir}`);
-  return { stagingDir: stageDir };
-}
-
-/** Add the generated .mcp.json to the staging folder — call after mcpJsonNote(). */
-export function finalizeStagedCopilotFiles(plan: CopilotFilePlan): void {
-  if (!plan.stagingDir) return;
-  const localMcp = paths.mcpSuggestion;
-  if (fs.existsSync(localMcp)) {
-    fs.copyFileSync(localMcp, resolve(plan.stagingDir, '.mcp.json'));
-    writeCopilotSetupReadme(plan.stagingDir, { includeLocalMcpCopy: true, copilotAlreadyPlaced: false });
-    p.log.success(`Prepared: ${resolve(plan.stagingDir, '.mcp.json')}`);
-  }
 }

--- a/tests/cli/copilotFiles.test.ts
+++ b/tests/cli/copilotFiles.test.ts
@@ -29,7 +29,7 @@ vi.mock('../../src/cli/ui.js', () => ({
   p: { log: { warn: vi.fn(), info: vi.fn(), success: vi.fn(), error: vi.fn(), step: vi.fn() } },
 }));
 
-const { finalizeStagedCopilotFiles, maybePrepareCopilotInstructions } = await import('../../src/cli/copilotFiles.js');
+const { maybePrepareCopilotInstructions } = await import('../../src/cli/copilotFiles.js');
 
 beforeEach(() => {
   tmpRoot = fs.mkdtempSync(resolve(os.tmpdir(), 'copilot-files-'));
@@ -46,13 +46,15 @@ afterEach(() => {
 });
 
 describe('maybePrepareCopilotInstructions', () => {
+  const stagingDir = () => resolve(installDir, 'copilot-setup');
+
   it('copies the instructions and writes a README into the solutions folder', async () => {
     const solutions = resolve(tmpRoot, 'repos');
     fs.mkdirSync(solutions);
 
-    const plan = await maybePrepareCopilotInstructions(solutions);
+    await maybePrepareCopilotInstructions(solutions);
 
-    expect(plan.stagingDir).toBeUndefined();
+    expect(fs.existsSync(stagingDir())).toBe(false);
     expect(fs.readFileSync(resolve(solutions, '.github', 'copilot-instructions.md'), 'utf8')).toBe('# rules\n');
     const readme = fs.readFileSync(resolve(solutions, 'README.md'), 'utf8');
     expect(readme).toContain('Already placed here');
@@ -67,23 +69,34 @@ describe('maybePrepareCopilotInstructions', () => {
     expect(fs.existsSync(resolve(solutions, '.github', 'copilot-instructions.md'))).toBe(true);
   });
 
-  it('stages the files when no solutions folder is configured', async () => {
-    const plan = await maybePrepareCopilotInstructions('   ');
+  it('stages the file when no solutions folder is configured', async () => {
+    await maybePrepareCopilotInstructions('   ');
 
-    expect(plan.stagingDir).toBe(resolve(installDir, 'copilot-setup'));
-    expect(fs.existsSync(resolve(plan.stagingDir!, '.github', 'copilot-instructions.md'))).toBe(true);
-    expect(fs.readFileSync(resolve(plan.stagingDir!, 'README.md'), 'utf8')).toContain('a parent folder');
+    expect(fs.existsSync(resolve(stagingDir(), '.github', 'copilot-instructions.md'))).toBe(true);
+    expect(fs.readFileSync(resolve(stagingDir(), 'README.md'), 'utf8')).toContain('a parent folder');
   });
 
-  it('stages the files when the user declines the copy', async () => {
+  it('stages the file when the user declines the copy', async () => {
     confirmAnswer = false;
     const solutions = resolve(tmpRoot, 'repos');
     fs.mkdirSync(solutions);
 
-    const plan = await maybePrepareCopilotInstructions(solutions);
+    await maybePrepareCopilotInstructions(solutions);
 
-    expect(plan.stagingDir).toBe(resolve(installDir, 'copilot-setup'));
+    expect(fs.existsSync(resolve(stagingDir(), '.github', 'copilot-instructions.md'))).toBe(true);
     expect(fs.existsSync(resolve(solutions, '.github'))).toBe(false);
+  });
+
+  it('points the staged README at the one .mcp.json instead of copying it', async () => {
+    // The staging folder lives inside the data directory the .mcp.json is
+    // written to, so a copy would be the same file twice, one of them stale.
+    fs.writeFileSync(resolve(installDir, '.mcp.json'), '{"servers":{}}\n');
+
+    await maybePrepareCopilotInstructions('');
+
+    expect(fs.existsSync(resolve(stagingDir(), '.mcp.json'))).toBe(false);
+    expect(fs.readFileSync(resolve(stagingDir(), 'README.md'), 'utf8'))
+      .toContain(resolve(installDir, '.mcp.json'));
   });
 
   it('skips without asking when the installation does not ship the file', async () => {
@@ -91,25 +104,8 @@ describe('maybePrepareCopilotInstructions', () => {
     // the wizard asked nothing and the user never learned a file was needed.
     fs.rmSync(resolve(packageRoot, '.github'), { recursive: true });
 
-    const plan = await maybePrepareCopilotInstructions(resolve(tmpRoot, 'repos'));
+    await maybePrepareCopilotInstructions(resolve(tmpRoot, 'repos'));
 
-    expect(plan.stagingDir).toBeUndefined();
-    expect(fs.existsSync(resolve(installDir, 'copilot-setup'))).toBe(false);
-  });
-});
-
-describe('finalizeStagedCopilotFiles', () => {
-  it('adds the generated .mcp.json to the staging folder and updates the README', async () => {
-    const plan = await maybePrepareCopilotInstructions('');
-    fs.writeFileSync(resolve(installDir, '.mcp.json'), '{"servers":{}}\n');
-
-    finalizeStagedCopilotFiles(plan);
-
-    expect(fs.readFileSync(resolve(plan.stagingDir!, '.mcp.json'), 'utf8')).toBe('{"servers":{}}\n');
-    expect(fs.readFileSync(resolve(plan.stagingDir!, 'README.md'), 'utf8')).toContain('prepared here');
-  });
-
-  it('does nothing when the copy went straight to the solutions folder', () => {
-    expect(() => finalizeStagedCopilotFiles({})).not.toThrow();
+    expect(fs.existsSync(stagingDir())).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

When the user declines the copy, `setup` stages the files in `<dataRoot>\copilot-setup\` — and then copied `<dataRoot>\.mcp.json` in beside them. Both live in the same data directory, so that was the same file twice, with the copy free to go stale as soon as the wizard is re-run with different answers.

## What changed

- The staged README names the generated file by absolute path (`- Generated copy: <dataRoot>\.mcp.json`) instead of shipping a duplicate.
- With nothing left to add after `mcpJsonNote()`, the two-stage API goes away: `finalizeStagedCopilotFiles()` and the `CopilotFilePlan` threaded through both wizards are gone, and `maybePrepareCopilotInstructions()` returns `void`. Three call sites in `setup.ts` and one in `instance.ts` get simpler.

## Tests

`tests/cli/copilotFiles.test.ts` rewritten for the stateless API, plus a new case asserting `copilot-setup\.mcp.json` is never created and the README points at the real one.

`npx tsc --noEmit` clean, unit suite green. No version bump — release later.