### PR TITLE
test(eval): record L4-ssrs-report-multidataset PASS with draft golden

### DIFF
--- a/eval/corpus/runs/2026-07-28T04__L4-ssrs-report-multidataset__39adafe.json
+++ b/eval/corpus/runs/2026-07-28T04__L4-ssrs-report-multidataset__39adafe.json
@@ -1,0 +1,108 @@
+{
+  "run_id": "2026-07-28T04__L4-ssrs-report-multidataset__39adafe",
+  "case_id": "L4-ssrs-report-multidataset",
+  "tier": 4,
+  "timestamp": "2026-07-28T04:51:00.460Z",
+  "server_git_sha": "39adafe",
+  "generated_artifacts": [
+    "ConDemoNoteReportMulti.menuitem.metadata.xml",
+    "ConDemoNoteReportMulti.metadata.xml",
+    "ConDemoNoteReportMultiContract.metadata.xml",
+    "ConDemoNoteReportMultiController.metadata.xml",
+    "ConDemoNoteReportMultiDP.metadata.xml",
+    "ConDemoNoteReportMultiSummaryTmp.metadata.xml",
+    "ConDemoNoteReportMultiTmp.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "object": "ConDemoNoteReportMultiController",
+        "type": "class",
+        "rule": "BPLocalVariableNotUsed",
+        "text": "The local variable 'contract' is not used. (scaffold-emitted prePromptModifyContract stub body is a comment)"
+      },
+      {
+        "object": "ConDemoNoteReportMultiTmp",
+        "type": "table",
+        "rule": "BPErrorTablePrimaryKeyEditable",
+        "text": "The primary key must not be editable."
+      },
+      {
+        "object": "ConDemoNoteReportMultiTmp",
+        "type": "table",
+        "rule": "BPErrorTablePrimaryKeyNotMandatory",
+        "text": "The primary key must be mandatory."
+      },
+      {
+        "object": "ConDemoNoteReportMultiTmp",
+        "type": "table",
+        "rule": "BPErrorTableMissingFormRef",
+        "text": "No form ref is specified."
+      },
+      {
+        "object": "ConDemoNoteReportMultiSummaryTmp",
+        "type": "table",
+        "rule": "BPErrorTablePrimaryKeyEditable",
+        "text": "The primary key must not be editable."
+      },
+      {
+        "object": "ConDemoNoteReportMultiSummaryTmp",
+        "type": "table",
+        "rule": "BPErrorTablePrimaryKeyNotMandatory",
+        "text": "The primary key must be mandatory."
+      },
+      {
+        "object": "ConDemoNoteReportMultiSummaryTmp",
+        "type": "table",
+        "rule": "BPErrorTableMissingFormRef",
+        "text": "No form ref is specified."
+      },
+      {
+        "object": "ConDemoNoteReportMulti",
+        "type": "menuitemoutput",
+        "rule": "BPErrorMenuItemNotCoveredByPrivilege",
+        "text": "'AxMenuItemOutput' 'ConDemoNoteReportMulti' is not covered by privilege."
+      }
+    ]
+  },
+  "golden_diff": null,
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": null,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT",
+  "platform_build": "xppc 7.0.7858.27",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "The additionalDatasets feature itself is CORRECT: one call produced all 7 objects, both TempDB tmp tables, a DP with an [SRSReportDataSetAttribute] getter per tmp table, two <AxReportDataSet> entries and two RDL <DataSet>/<Tablix> pairs; a full build is clean (0 errors). The defect is in FIELD TYPING. generateSmartReport.suggestEdtFromFieldName() (src/tools/generateSmartReport.ts:1303-1327) is a hardcoded keyword ladder that NEVER consults the EDT index and falls through to 'String255'. The generateObject schema documents fieldsHint for scaffold:report as 'EDTs auto-suggested from the index' (identical wording to scaffold:table, which DOES hit the index), so this is a documented-vs-actual mismatch. Concretely, prepare(mode='create') returned Num/Name/Counter from the index for the very same field names NoteId/Subject/LineCount, yet the scaffold emitted <ExtendedDataType>String255</ExtendedDataType> for all three. The semantic damage is largest on the summary dataset: LineCount, a count, becomes a string field, its AxReportDataSetField DataType becomes System.String (so SSRS cannot format/aggregate it numerically), and the DP is forced to wrap the aggregate with int642Str(). Two frozen sibling goldens (L4-ssrs-report-basic, L4-ssrs-report-advanced) already bake in the same String255 shape, so this is a pre-existing behaviour, not a regression from this run. SECOND, INDEPENDENT FINDING (build-oracle blind spot, evidenced by negative test): xppc does NOT validate the AxReport dataset -> DP linkage. Replacing the Summary dataset's <Query> with 'SELECT * FROM ConBogusNoSuchDP.ConBogusNoSuchTmp' (a class and table that do not exist) still produced 'Build succeeded / Errors: 0' under a FULL build with Metadata Validation running ('Metadata: validate report' executed). The contrast case proves the oracle is otherwise live: pointing AxMenuItemOutput/Object at ConBogusNoSuchController in the same model failed with 'Metadata Error: AxMenuItemOutput/ConDemoNoteReportMulti/Object: Class ConBogusNoSuchController does not exist.' So for AxReport, pass@build is NOT evidence that the dataset wiring is right; correctness here was established by structural inspection + an element-vocabulary diff against standard multi-dataset RDP reports (ApplicationSuite/Foundation AgreementConfirmation.xml, AssetStatementRowSetup.xml), which matched. PROVENANCE CAVEAT: server_git_sha is stamped from live repo HEAD (39adafe), but the RUNNING MCP server binary was built from b28515f - a later commit rebuilt dist/ while the server process still holds the old modules. The behaviour recorded here is b28515f's.",
+  "suggested_fix_area": "src/tools/generateSmartReport.ts - replace the hardcoded suggestEdtFromFieldName() keyword ladder with the same index-backed EDT resolution generateSmartTable/prepare() use (suggest_edt), so scaffold:report matches its own documented fieldsHint contract; at minimum stop defaulting count/qty-like names to String255. Secondary: src/eval/oracle - the build dimension cannot certify AxReport dataset wiring, so an AxReport-aware structural assertion (dataset name/Query resolves to an existing DP class + [SRSReportDataSetAttribute] getter) belongs in validate_code or a report-specific check.",
+  "evidence_refs": [
+    "negative test A: AxReport/DataSets/AxReportDataSet[ConDemoNoteReportMultiSummaryTmp]/Query -> 'SELECT * FROM ConBogusNoSuchDP.ConBogusNoSuchTmp'; full build Errors: 0 (blind spot)",
+    "negative test B: AxMenuItemOutput/ConDemoNoteReportMulti/Object -> 'ConBogusNoSuchController'; full build Errors: 1, 'Metadata Error: ... does not exist' (oracle live)",
+    "src/tools/generateSmartReport.ts:1303-1327 suggestEdtFromFieldName() - hardcoded ladder, returns 'String255' as fallback, never queries edt index",
+    "src/server/toolSchemas/generateObject.ts - fieldsHint documented as '[scaffold:table|report] ... EDTs auto-suggested from the index'",
+    "prepare(mode=create) index suggestions for the same names: NoteId -> Num, Subject -> smmSubject/EventSubject, LineCount -> Counter",
+    "eval/goldens/L4-ssrs-report-basic/ConDemoNoteReportTmp.metadata.xml and eval/goldens/L4-ssrs-report-advanced/ConDemoNoteReportAdvTmp.metadata.xml already carry String255 (pre-existing, not a regression)",
+    "vocabulary diff vs K:\\AosService\\PackagesLocalDirectory\\ApplicationSuite\\Foundation\\AxReport\\AgreementConfirmation.xml and AssetStatementRowSetup.xml: no unexpected elements",
+    "golden NOT frozen - draft only, see eval/goldens/L4-ssrs-report-multidataset/README.md"
+  ]
+}

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMulti.menuitem.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMulti.menuitem.metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemOutput xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+	<Name>ConDemoNoteReportMulti</Name>
+	<Label>@TaxTransactionInquiry:HeaderNote</Label>
+	<Object>ConDemoNoteReportMultiController</Object>
+	<ObjectType>Class</ObjectType>
+</AxMenuItemOutput>

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMulti.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMulti.metadata.xml
@@ -1,0 +1,605 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxReport xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V2">
+	<Name>ConDemoNoteReportMulti</Name>
+	<DataMethods />
+	<DataSets>
+		<AxReportDataSet xmlns="">
+			<Name>ConDemoNoteReportMultiTmp</Name>
+			<DataSourceType>ReportDataProvider</DataSourceType>
+			<Query>SELECT * FROM ConDemoNoteReportMultiDP.ConDemoNoteReportMultiTmp</Query>
+			<FieldGroups />
+			<Fields>
+			<AxReportDataSetField>
+				<Name>NoteId</Name>
+				<Alias>ConDemoNoteReportMultiTmp.1.NoteId</Alias>
+				<DataType>System.String</DataType>
+				<DisplayWidth>Auto</DisplayWidth>
+				<UserDefined>false</UserDefined>
+			</AxReportDataSetField>
+			<AxReportDataSetField>
+				<Name>Subject</Name>
+				<Alias>ConDemoNoteReportMultiTmp.1.Subject</Alias>
+				<DataType>System.String</DataType>
+				<DisplayWidth>Auto</DisplayWidth>
+				<UserDefined>false</UserDefined>
+			</AxReportDataSetField>
+			</Fields>
+			<Parameters>
+				<AxReportDataSetParameter>
+					<Name>AX_PartitionKey</Name>
+					<Alias>AX_PartitionKey</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_PartitionKey</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_CompanyName</Name>
+					<Alias>AX_CompanyName</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_CompanyName</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_UserContext</Name>
+					<Alias>AX_UserContext</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_UserContext</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_RenderingCulture</Name>
+					<Alias>AX_RenderingCulture</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_RenderingCulture</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_ReportContext</Name>
+					<Alias>AX_ReportContext</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_ReportContext</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_RdpPreProcessedId</Name>
+					<Alias>AX_RdpPreProcessedId</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_RdpPreProcessedId</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>CONDEMONOTEREPORTMULTIDP_DynamicParameter</Name>
+					<Alias>CONDEMONOTEREPORTMULTIDP_DynamicParameter</Alias>
+					<DataType>Microsoft.Dynamics.AX.Framework.Services.Client.QueryMetadata</DataType>
+					<Parameter>CONDEMONOTEREPORTMULTIDP_DynamicParameter</Parameter>
+				</AxReportDataSetParameter>
+			</Parameters>
+		</AxReportDataSet>
+		<AxReportDataSet xmlns="">
+			<Name>ConDemoNoteReportMultiSummaryTmp</Name>
+			<DataSourceType>ReportDataProvider</DataSourceType>
+			<Query>SELECT * FROM ConDemoNoteReportMultiDP.ConDemoNoteReportMultiSummaryTmp</Query>
+			<FieldGroups />
+			<Fields>
+			<AxReportDataSetField>
+				<Name>Subject</Name>
+				<Alias>ConDemoNoteReportMultiSummaryTmp.1.Subject</Alias>
+				<DataType>System.String</DataType>
+				<DisplayWidth>Auto</DisplayWidth>
+				<UserDefined>false</UserDefined>
+			</AxReportDataSetField>
+			<AxReportDataSetField>
+				<Name>LineCount</Name>
+				<Alias>ConDemoNoteReportMultiSummaryTmp.1.LineCount</Alias>
+				<DataType>System.String</DataType>
+				<DisplayWidth>Auto</DisplayWidth>
+				<UserDefined>false</UserDefined>
+			</AxReportDataSetField>
+			</Fields>
+			<Parameters>
+				<AxReportDataSetParameter>
+					<Name>AX_PartitionKey</Name>
+					<Alias>AX_PartitionKey</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_PartitionKey</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_CompanyName</Name>
+					<Alias>AX_CompanyName</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_CompanyName</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_UserContext</Name>
+					<Alias>AX_UserContext</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_UserContext</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_RenderingCulture</Name>
+					<Alias>AX_RenderingCulture</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_RenderingCulture</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_ReportContext</Name>
+					<Alias>AX_ReportContext</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_ReportContext</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>AX_RdpPreProcessedId</Name>
+					<Alias>AX_RdpPreProcessedId</Alias>
+					<DataType>System.String</DataType>
+					<Parameter>AX_RdpPreProcessedId</Parameter>
+				</AxReportDataSetParameter>
+				<AxReportDataSetParameter>
+					<Name>CONDEMONOTEREPORTMULTIDP_DynamicParameter</Name>
+					<Alias>CONDEMONOTEREPORTMULTIDP_DynamicParameter</Alias>
+					<DataType>Microsoft.Dynamics.AX.Framework.Services.Client.QueryMetadata</DataType>
+					<Parameter>CONDEMONOTEREPORTMULTIDP_DynamicParameter</Parameter>
+				</AxReportDataSetParameter>
+			</Parameters>
+		</AxReportDataSet>
+	</DataSets>
+	<DefaultParameterGroup>
+		<Name xmlns="">Parameters</Name>
+		<ReportParameterBases xmlns="">
+			<AxReportParameterBase xmlns=""
+					i:type="AxReportParameter">
+				<Name>AX_PartitionKey</Name>
+				<AllowBlank>true</AllowBlank>
+				<Nullable>true</Nullable>
+				<UserVisibility>Hidden</UserVisibility>
+				<DefaultValue />
+				<Values />
+			</AxReportParameterBase>
+			<AxReportParameterBase xmlns=""
+					i:type="AxReportParameter">
+				<Name>AX_CompanyName</Name>
+				<UserVisibility>Hidden</UserVisibility>
+				<DefaultValue />
+				<Values />
+			</AxReportParameterBase>
+			<AxReportParameterBase xmlns=""
+					i:type="AxReportParameter">
+				<Name>AX_UserContext</Name>
+				<AllowBlank>true</AllowBlank>
+				<Nullable>true</Nullable>
+				<UserVisibility>Hidden</UserVisibility>
+				<DefaultValue />
+				<Values />
+			</AxReportParameterBase>
+			<AxReportParameterBase xmlns=""
+					i:type="AxReportParameter">
+				<Name>AX_RenderingCulture</Name>
+				<AllowBlank>true</AllowBlank>
+				<Nullable>true</Nullable>
+				<UserVisibility>Hidden</UserVisibility>
+				<DefaultValue />
+				<Values />
+			</AxReportParameterBase>
+			<AxReportParameterBase xmlns=""
+					i:type="AxReportParameter">
+				<Name>AX_ReportContext</Name>
+				<AllowBlank>true</AllowBlank>
+				<Nullable>true</Nullable>
+				<UserVisibility>Hidden</UserVisibility>
+				<DefaultValue />
+				<Values />
+			</AxReportParameterBase>
+			<AxReportParameterBase xmlns=""
+					i:type="AxReportParameter">
+				<Name>AX_RdpPreProcessedId</Name>
+				<AllowBlank>true</AllowBlank>
+				<Nullable>true</Nullable>
+				<UserVisibility>Hidden</UserVisibility>
+				<DefaultValue />
+				<Values />
+			</AxReportParameterBase>
+			<AxReportParameterBase xmlns=""
+					i:type="AxReportParameter">
+				<Name>CONDEMONOTEREPORTMULTIDP_DynamicParameter</Name>
+				<AllowBlank>true</AllowBlank>
+				<DataType>Microsoft.Dynamics.AX.Framework.Services.Client.QueryMetadata</DataType>
+				<Nullable>true</Nullable>
+				<UserVisibility>Hidden</UserVisibility>
+				<DefaultValue />
+				<Values />
+			</AxReportParameterBase>
+		</ReportParameterBases>
+	</DefaultParameterGroup>
+	<Designs>
+		<AxReportDesign xmlns=""
+				i:type="AxReportPrecisionDesign">
+			<Name>Report</Name>
+			<Caption>@TaxTransactionInquiry:HeaderNote</Caption>
+			<Text><![CDATA[<?xml version="1.0" encoding="utf-8"?>
+<Report xmlns="http://schemas.microsoft.com/sqlserver/reporting/2016/01/reportdefinition" xmlns:rd="http://schemas.microsoft.com/SQLServer/reporting/reportdesigner">
+  <AutoRefresh>0</AutoRefresh>
+  <DataSources>
+    <DataSource Name="AutoGen__ReportDataProvider">
+      <Transaction>true</Transaction>
+      <ConnectionProperties>
+        <DataProvider>AXREPORTDATAPROVIDER</DataProvider>
+        <ConnectString />
+        <IntegratedSecurity>true</IntegratedSecurity>
+      </ConnectionProperties>
+      <rd:DataSourceID>e89fdf66-070c-457b-a911-0d7f15f31e17</rd:DataSourceID>
+    </DataSource>
+  </DataSources>
+  <DataSets>
+    <DataSet Name="ConDemoNoteReportMultiTmp">
+      <rd:DataSetID>f587958b-961a-4279-b11e-5adf56840530</rd:DataSetID>
+      <Query>
+        <DataSourceName>AutoGen__ReportDataProvider</DataSourceName>
+        <QueryParameters>
+          <QueryParameter Name="AX_PartitionKey">
+            <Value>=Parameters!AX_PartitionKey.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_CompanyName">
+            <Value>=Parameters!AX_CompanyName.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_UserContext">
+            <Value>=Parameters!AX_UserContext.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_RenderingCulture">
+            <Value>=Parameters!AX_RenderingCulture.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_ReportContext">
+            <Value>=Parameters!AX_ReportContext.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_RdpPreProcessedId">
+            <Value>=Parameters!AX_RdpPreProcessedId.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="CONDEMONOTEREPORTMULTIDP_DynamicParameter">
+            <Value>=Parameters!CONDEMONOTEREPORTMULTIDP_DynamicParameter.Value</Value>
+          </QueryParameter>
+        </QueryParameters>
+        <CommandText>SELECT * FROM ConDemoNoteReportMultiDP.ConDemoNoteReportMultiTmp</CommandText>
+        <rd:UseGenericDesigner>true</rd:UseGenericDesigner>
+      </Query>
+      <Fields>
+        <Field Name="NoteId">
+          <DataField>ConDemoNoteReportMultiTmp.1.NoteId</DataField>
+          <rd:TypeName>System.String</rd:TypeName>
+        </Field>
+        <Field Name="Subject">
+          <DataField>ConDemoNoteReportMultiTmp.1.Subject</DataField>
+          <rd:TypeName>System.String</rd:TypeName>
+        </Field>
+      </Fields>
+      <rd:DataSetInfo>
+        <rd:DataSetName>ConDemoNoteReportMultiTmp</rd:DataSetName>
+        <rd:TableName>Fields</rd:TableName>
+        <rd:TableAdapterFillMethod>Fill</rd:TableAdapterFillMethod>
+        <rd:TableAdapterGetDataMethod>GetData</rd:TableAdapterGetDataMethod>
+        <rd:TableAdapterName>FieldsTableAdapter</rd:TableAdapterName>
+      </rd:DataSetInfo>
+    </DataSet>
+    <DataSet Name="ConDemoNoteReportMultiSummaryTmp">
+      <rd:DataSetID>0a29c241-afbe-4b9a-bb58-42f5951d9b48</rd:DataSetID>
+      <Query>
+        <DataSourceName>AutoGen__ReportDataProvider</DataSourceName>
+        <QueryParameters>
+          <QueryParameter Name="AX_PartitionKey">
+            <Value>=Parameters!AX_PartitionKey.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_CompanyName">
+            <Value>=Parameters!AX_CompanyName.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_UserContext">
+            <Value>=Parameters!AX_UserContext.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_RenderingCulture">
+            <Value>=Parameters!AX_RenderingCulture.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_ReportContext">
+            <Value>=Parameters!AX_ReportContext.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="AX_RdpPreProcessedId">
+            <Value>=Parameters!AX_RdpPreProcessedId.Value</Value>
+          </QueryParameter>
+          <QueryParameter Name="CONDEMONOTEREPORTMULTIDP_DynamicParameter">
+            <Value>=Parameters!CONDEMONOTEREPORTMULTIDP_DynamicParameter.Value</Value>
+          </QueryParameter>
+        </QueryParameters>
+        <CommandText>SELECT * FROM ConDemoNoteReportMultiDP.ConDemoNoteReportMultiSummaryTmp</CommandText>
+        <rd:UseGenericDesigner>true</rd:UseGenericDesigner>
+      </Query>
+      <Fields>
+        <Field Name="Subject">
+          <DataField>ConDemoNoteReportMultiSummaryTmp.1.Subject</DataField>
+          <rd:TypeName>System.String</rd:TypeName>
+        </Field>
+        <Field Name="LineCount">
+          <DataField>ConDemoNoteReportMultiSummaryTmp.1.LineCount</DataField>
+          <rd:TypeName>System.String</rd:TypeName>
+        </Field>
+      </Fields>
+      <rd:DataSetInfo>
+        <rd:DataSetName>ConDemoNoteReportMultiSummaryTmp</rd:DataSetName>
+        <rd:TableName>Fields</rd:TableName>
+        <rd:TableAdapterFillMethod>Fill</rd:TableAdapterFillMethod>
+        <rd:TableAdapterGetDataMethod>GetData</rd:TableAdapterGetDataMethod>
+        <rd:TableAdapterName>FieldsTableAdapter</rd:TableAdapterName>
+      </rd:DataSetInfo>
+    </DataSet>
+  </DataSets>
+  <ReportSections>
+    <ReportSection>
+            <PageHeader>
+        <PrintOnFirstPage>true</PrintOnFirstPage>
+        <PrintOnLastPage>true</PrintOnLastPage>
+        <Height>0.5in</Height>
+        <ReportItems>
+          <Textbox Name="CompanyName">
+            <CanGrow>true</CanGrow>
+            <Value>=Parameters!AX_CompanyName.Value</Value>
+            <Style><FontWeight>Bold</FontWeight><FontSize>10pt</FontSize></Style>
+            <Top>0in</Top><Left>0in</Left><Width>4in</Width><Height>0.25in</Height>
+          </Textbox>
+          <Textbox Name="ReportTitle">
+            <CanGrow>true</CanGrow>
+            <Value>@TaxTransactionInquiry:HeaderNote</Value>
+            <Style><FontSize>9pt</FontSize></Style>
+            <Top>0.25in</Top><Left>0in</Left><Width>4in</Width><Height>0.25in</Height>
+          </Textbox>
+          <Textbox Name="ExecutionTime">
+            <CanGrow>true</CanGrow>
+            <Value>=Globals!ExecutionTime</Value>
+            <Style><TextAlign>Right</TextAlign><FontSize>8pt</FontSize></Style>
+            <Top>0in</Top><Left>4in</Left><Width>3in</Width><Height>0.25in</Height>
+          </Textbox>
+        </ReportItems>
+      </PageHeader>
+      <Body>
+        <ReportItems>
+        <Tablix Name="Tablix_ConDemoNoteReportMultiTmp">
+          <TablixBody>
+            <TablixColumns>
+            <TablixColumn><Width>1.5in</Width></TablixColumn>
+            <TablixColumn><Width>1.5in</Width></TablixColumn>
+            </TablixColumns>
+            <TablixRows>
+              <TablixRow><Height>0.25in</Height><TablixCells>
+            <TablixCell><CellContents>
+              <Textbox Name="Textbox_NoteId_H">
+                <CanGrow>true</CanGrow><Value>NoteId</Value>
+                <Style><FontWeight>Bold</FontWeight>
+                  <BackgroundColor>LightGrey</BackgroundColor>
+                  <Border><Style>Solid</Style></Border>
+                  <PaddingLeft>2pt</PaddingLeft><PaddingRight>2pt</PaddingRight>
+                  <PaddingTop>2pt</PaddingTop><PaddingBottom>2pt</PaddingBottom>
+                </Style></Textbox>
+            </CellContents></TablixCell>
+            <TablixCell><CellContents>
+              <Textbox Name="Textbox_Subject_H">
+                <CanGrow>true</CanGrow><Value>Subject</Value>
+                <Style><FontWeight>Bold</FontWeight>
+                  <BackgroundColor>LightGrey</BackgroundColor>
+                  <Border><Style>Solid</Style></Border>
+                  <PaddingLeft>2pt</PaddingLeft><PaddingRight>2pt</PaddingRight>
+                  <PaddingTop>2pt</PaddingTop><PaddingBottom>2pt</PaddingBottom>
+                </Style></Textbox>
+            </CellContents></TablixCell>
+              </TablixCells></TablixRow>
+              <TablixRow><Height>0.25in</Height><TablixCells>
+            <TablixCell><CellContents>
+              <Textbox Name="Textbox_NoteId">
+                <CanGrow>true</CanGrow><Value>=Fields!NoteId.Value</Value>
+                <Style><Border><Style>Solid</Style></Border>
+                  <PaddingLeft>2pt</PaddingLeft><PaddingRight>2pt</PaddingRight>
+                  <PaddingTop>2pt</PaddingTop><PaddingBottom>2pt</PaddingBottom>
+                </Style></Textbox>
+            </CellContents></TablixCell>
+            <TablixCell><CellContents>
+              <Textbox Name="Textbox_Subject">
+                <CanGrow>true</CanGrow><Value>=Fields!Subject.Value</Value>
+                <Style><Border><Style>Solid</Style></Border>
+                  <PaddingLeft>2pt</PaddingLeft><PaddingRight>2pt</PaddingRight>
+                  <PaddingTop>2pt</PaddingTop><PaddingBottom>2pt</PaddingBottom>
+                </Style></Textbox>
+            </CellContents></TablixCell>
+              </TablixCells></TablixRow>
+            </TablixRows>
+          </TablixBody>
+          <TablixColumnHierarchy><TablixMembers>
+          <TablixMember />
+          <TablixMember />
+          </TablixMembers></TablixColumnHierarchy>
+          <TablixRowHierarchy><TablixMembers>
+            <TablixMember>
+              <KeepWithGroup>After</KeepWithGroup>
+              <RepeatOnNewPage>true</RepeatOnNewPage>
+            </TablixMember>
+            <TablixMember><Group Name="Details_ConDemoNoteReportMultiTmp"><DataGroupName>Details_ConDemoNoteReportMultiTmp</DataGroupName></Group></TablixMember>
+          </TablixMembers></TablixRowHierarchy>
+          <DataSetName>ConDemoNoteReportMultiTmp</DataSetName>
+          <Top>0.5in</Top><Left>0.5in</Left>
+          <Height>0.5in</Height><Width>3in</Width>
+          <Style><Border><Style>Solid</Style></Border></Style>
+        </Tablix>
+        <Tablix Name="Tablix_ConDemoNoteReportMultiSummaryTmp">
+          <TablixBody>
+            <TablixColumns>
+            <TablixColumn><Width>1.5in</Width></TablixColumn>
+            <TablixColumn><Width>1.5in</Width></TablixColumn>
+            </TablixColumns>
+            <TablixRows>
+              <TablixRow><Height>0.25in</Height><TablixCells>
+            <TablixCell><CellContents>
+              <Textbox Name="Textbox_Subject_H">
+                <CanGrow>true</CanGrow><Value>Subject</Value>
+                <Style><FontWeight>Bold</FontWeight>
+                  <BackgroundColor>LightGrey</BackgroundColor>
+                  <Border><Style>Solid</Style></Border>
+                  <PaddingLeft>2pt</PaddingLeft><PaddingRight>2pt</PaddingRight>
+                  <PaddingTop>2pt</PaddingTop><PaddingBottom>2pt</PaddingBottom>
+                </Style></Textbox>
+            </CellContents></TablixCell>
+            <TablixCell><CellContents>
+              <Textbox Name="Textbox_LineCount_H">
+                <CanGrow>true</CanGrow><Value>LineCount</Value>
+                <Style><FontWeight>Bold</FontWeight>
+                  <BackgroundColor>LightGrey</BackgroundColor>
+                  <Border><Style>Solid</Style></Border>
+                  <PaddingLeft>2pt</PaddingLeft><PaddingRight>2pt</PaddingRight>
+                  <PaddingTop>2pt</PaddingTop><PaddingBottom>2pt</PaddingBottom>
+                </Style></Textbox>
+            </CellContents></TablixCell>
+              </TablixCells></TablixRow>
+              <TablixRow><Height>0.25in</Height><TablixCells>
+            <TablixCell><CellContents>
+              <Textbox Name="Textbox_Subject">
+                <CanGrow>true</CanGrow><Value>=Fields!Subject.Value</Value>
+                <Style><Border><Style>Solid</Style></Border>
+                  <PaddingLeft>2pt</PaddingLeft><PaddingRight>2pt</PaddingRight>
+                  <PaddingTop>2pt</PaddingTop><PaddingBottom>2pt</PaddingBottom>
+                </Style></Textbox>
+            </CellContents></TablixCell>
+            <TablixCell><CellContents>
+              <Textbox Name="Textbox_LineCount">
+                <CanGrow>true</CanGrow><Value>=Fields!LineCount.Value</Value>
+                <Style><Border><Style>Solid</Style></Border>
+                  <PaddingLeft>2pt</PaddingLeft><PaddingRight>2pt</PaddingRight>
+                  <PaddingTop>2pt</PaddingTop><PaddingBottom>2pt</PaddingBottom>
+                </Style></Textbox>
+            </CellContents></TablixCell>
+              </TablixCells></TablixRow>
+            </TablixRows>
+          </TablixBody>
+          <TablixColumnHierarchy><TablixMembers>
+          <TablixMember />
+          <TablixMember />
+          </TablixMembers></TablixColumnHierarchy>
+          <TablixRowHierarchy><TablixMembers>
+            <TablixMember>
+              <KeepWithGroup>After</KeepWithGroup>
+              <RepeatOnNewPage>true</RepeatOnNewPage>
+            </TablixMember>
+            <TablixMember><Group Name="Details_ConDemoNoteReportMultiSummaryTmp"><DataGroupName>Details_ConDemoNoteReportMultiSummaryTmp</DataGroupName></Group></TablixMember>
+          </TablixMembers></TablixRowHierarchy>
+          <DataSetName>ConDemoNoteReportMultiSummaryTmp</DataSetName>
+          <Top>0.5in</Top><Left>0.5in</Left>
+          <Height>0.5in</Height><Width>3in</Width>
+          <Style><Border><Style>Solid</Style></Border></Style>
+        </Tablix>
+        </ReportItems>
+        <Height>1in</Height>
+        <Style>
+          <Border>
+            <Style>None</Style>
+          </Border>
+        </Style>
+      </Body>
+      <Width>7.5in</Width>
+      <Page>
+        <PageHeight>11.69in</PageHeight>
+        <PageWidth>8.27in</PageWidth>
+        <InteractiveHeight>11in</InteractiveHeight>
+        <InteractiveWidth>8.5in</InteractiveWidth>
+        <LeftMargin>0.2in</LeftMargin>
+        <TopMargin>0.2in</TopMargin>
+        <Style />
+      </Page>
+    </ReportSection>
+  </ReportSections>
+  <ReportParameters>
+    <ReportParameter Name="AX_PartitionKey">
+      <DataType>String</DataType>
+      <Nullable>true</Nullable>
+      <AllowBlank>true</AllowBlank>
+      <Prompt>AX_PartitionKey</Prompt>
+      <Hidden>true</Hidden>
+    </ReportParameter>
+    <ReportParameter Name="AX_CompanyName">
+      <DataType>String</DataType>
+      <Prompt>AX_CompanyName</Prompt>
+      <Hidden>true</Hidden>
+    </ReportParameter>
+    <ReportParameter Name="AX_UserContext">
+      <DataType>String</DataType>
+      <Nullable>true</Nullable>
+      <AllowBlank>true</AllowBlank>
+      <Prompt>AX_UserContext</Prompt>
+      <Hidden>true</Hidden>
+    </ReportParameter>
+    <ReportParameter Name="AX_RenderingCulture">
+      <DataType>String</DataType>
+      <Nullable>true</Nullable>
+      <AllowBlank>true</AllowBlank>
+      <Prompt>AX_RenderingCulture</Prompt>
+      <Hidden>true</Hidden>
+    </ReportParameter>
+    <ReportParameter Name="AX_ReportContext">
+      <DataType>String</DataType>
+      <Nullable>true</Nullable>
+      <AllowBlank>true</AllowBlank>
+      <Prompt>AX_ReportContext</Prompt>
+      <Hidden>true</Hidden>
+      <UsedInQuery>true</UsedInQuery>
+    </ReportParameter>
+    <ReportParameter Name="AX_RdpPreProcessedId">
+      <DataType>String</DataType>
+      <Nullable>true</Nullable>
+      <AllowBlank>true</AllowBlank>
+      <Prompt>AX_RdpPreProcessedId</Prompt>
+      <Hidden>true</Hidden>
+    </ReportParameter>
+    <ReportParameter Name="CONDEMONOTEREPORTMULTIDP_DynamicParameter">
+      <DataType>String</DataType>
+      <Nullable>true</Nullable>
+      <AllowBlank>true</AllowBlank>
+      <Prompt>CONDEMONOTEREPORTMULTIDP_DynamicParameter</Prompt>
+      <Hidden>true</Hidden>
+    </ReportParameter>
+  </ReportParameters>
+  <ReportParametersLayout>
+    <GridLayoutDefinition>
+      <NumberOfColumns>7</NumberOfColumns>
+      <NumberOfRows>1</NumberOfRows>
+      <CellDefinitions>
+        <CellDefinition>
+          <ColumnIndex>0</ColumnIndex>
+          <RowIndex>0</RowIndex>
+          <ParameterName>AX_PartitionKey</ParameterName>
+        </CellDefinition>
+        <CellDefinition>
+          <ColumnIndex>1</ColumnIndex>
+          <RowIndex>0</RowIndex>
+          <ParameterName>AX_CompanyName</ParameterName>
+        </CellDefinition>
+        <CellDefinition>
+          <ColumnIndex>2</ColumnIndex>
+          <RowIndex>0</RowIndex>
+          <ParameterName>AX_UserContext</ParameterName>
+        </CellDefinition>
+        <CellDefinition>
+          <ColumnIndex>3</ColumnIndex>
+          <RowIndex>0</RowIndex>
+          <ParameterName>AX_RenderingCulture</ParameterName>
+        </CellDefinition>
+        <CellDefinition>
+          <ColumnIndex>4</ColumnIndex>
+          <RowIndex>0</RowIndex>
+          <ParameterName>AX_ReportContext</ParameterName>
+        </CellDefinition>
+        <CellDefinition>
+          <ColumnIndex>5</ColumnIndex>
+          <RowIndex>0</RowIndex>
+          <ParameterName>AX_RdpPreProcessedId</ParameterName>
+        </CellDefinition>
+        <CellDefinition>
+          <ColumnIndex>6</ColumnIndex>
+          <RowIndex>0</RowIndex>
+          <ParameterName>CONDEMONOTEREPORTMULTIDP_DynamicParameter</ParameterName>
+        </CellDefinition>
+      </CellDefinitions>
+    </GridLayoutDefinition>
+  </ReportParametersLayout>
+  <Language>en-US</Language>
+  <rd:ReportUnitType>Inch</rd:ReportUnitType>
+  <rd:ReportID>c1067ad5-d650-46f8-8973-87c806c5f804</rd:ReportID>
+</Report>]]></Text>
+			<DisableIndividualTransformation>
+				<Name>DisableIndividualTransformation</Name>
+			</DisableIndividualTransformation>
+		</AxReportDesign>
+	</Designs>
+	<EmbeddedImages />
+</AxReport>

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiContract.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiContract.metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoNoteReportMultiContract</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Data contract for the @TaxTransactionInquiry:HeaderNote report.
+/// Defines dialog parameters shown to the user before report execution.
+/// </summary>
+[DataContractAttribute]
+public class ConDemoNoteReportMultiContract
+{
+    // No dialog parameters
+
+}
+]]></Declaration>
+		<Methods />
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiController.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiController.metadata.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoNoteReportMultiController</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Controller for the @TaxTransactionInquiry:HeaderNote report.
+/// Extends <c>SrsReportRunController</c> to provide menu item integration
+/// and pre-prompt contract initialization.
+/// </summary>
+public class ConDemoNoteReportMultiController extends SrsReportRunController
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>main</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Entry point for the report. Creates the controller and starts execution.
+    /// </summary>
+    /// <param name="_args">The <c>Args</c> object from the menu item caller.</param>
+    public static void main(Args _args)
+    {
+        ConDemoNoteReportMultiController controller = new ConDemoNoteReportMultiController();
+        controller.parmReportName(ssrsReportStr(ConDemoNoteReportMulti, Report));
+        controller.parmArgs(_args);
+        controller.startOperation();
+    }
+
+]]></Source>
+			</Method>
+
+			<Method>
+				<Name>prePromptModifyContract</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Modifies the contract before the dialog is shown to the user.
+    /// Override to set default parameter values or pre-fill from the caller record.
+    /// </summary>
+    protected void prePromptModifyContract()
+    {
+        ConDemoNoteReportMultiContract contract = this.parmReportContract().parmRdpContract() as ConDemoNoteReportMultiContract;
+        // TODO: Set default parameter values here
+        // Example: contract.parmFromDate(DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone()));
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiDP.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiDP.metadata.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoNoteReportMultiDP</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Data provider for the @TaxTransactionInquiry:HeaderNote report.
+/// Extends <c>SrsReportDataProviderBase</c> and populates the <c>ConDemoNoteReportMultiTmp</c> temporary table.
+/// </summary>
+[
+    SRSReportParameterAttribute(classStr(ConDemoNoteReportMultiContract))
+]
+public class ConDemoNoteReportMultiDP extends SrsReportDataProviderBase
+{
+    ConDemoNoteReportMultiTmp conDemoNoteReportMultiTmp;
+    ConDemoNoteReportMultiSummaryTmp conDemoNoteReportMultiSummaryTmp;
+
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>getConDemoNoteReportMultiTmp</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Returns the temporary table buffer used by the report dataset.
+    /// </summary>
+    /// <returns>The <c>ConDemoNoteReportMultiTmp</c> table buffer.</returns>
+    [SRSReportDataSetAttribute(tableStr(ConDemoNoteReportMultiTmp))]
+    public ConDemoNoteReportMultiTmp getConDemoNoteReportMultiTmp()
+    {
+        select conDemoNoteReportMultiTmp;
+        return conDemoNoteReportMultiTmp;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>getConDemoNoteReportMultiSummaryTmp</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Returns the <c>ConDemoNoteReportMultiSummaryTmp</c> buffer for the "Summary" dataset.
+    /// </summary>
+    /// <returns>The <c>ConDemoNoteReportMultiSummaryTmp</c> table buffer.</returns>
+    [SRSReportDataSetAttribute(tableStr(ConDemoNoteReportMultiSummaryTmp))]
+    public ConDemoNoteReportMultiSummaryTmp getConDemoNoteReportMultiSummaryTmp()
+    {
+        select conDemoNoteReportMultiSummaryTmp;
+        return conDemoNoteReportMultiSummaryTmp;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>processReport</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Main data processing method. Populates both temporary tables that back the
+    /// report datasets: the detail rows and the per-subject summary rows.
+    /// </summary>
+    public void processReport()
+    {
+        ConDemoNoteHeader   noteHeader;
+        ConDemoNoteHeader   noteHeaderSummary;
+
+        // Detail dataset - one row per note header.
+        insert_recordset conDemoNoteReportMultiTmp (NoteId, Subject)
+        select NoteId, Subject
+        from noteHeader;
+
+        // Summary dataset - one row per distinct subject with its line count.
+        while select Subject, count(RecId)
+        from noteHeaderSummary
+        group by Subject
+        {
+            conDemoNoteReportMultiSummaryTmp.clear();
+            conDemoNoteReportMultiSummaryTmp.Subject   = noteHeaderSummary.Subject;
+            conDemoNoteReportMultiSummaryTmp.LineCount = int642Str(noteHeaderSummary.RecId);
+            conDemoNoteReportMultiSummaryTmp.insert();
+        }
+    }
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiSummaryTmp.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiSummaryTmp.metadata.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoNoteReportMultiSummaryTmp</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// The <c>ConDemoNoteReportMultiSummaryTmp</c> table.
+/// </summary>
+public class ConDemoNoteReportMultiSummaryTmp extends common
+{
+}
+]]></Declaration>
+		<Methods />
+	</SourceCode>
+	<Label>@TaxTransactionInquiry:HeaderNote</Label>
+	<TableGroup>Main</TableGroup>
+	<TitleField1>Subject</TitleField1>
+	<TitleField2>LineCount</TitleField2>
+	<CacheLookup>None</CacheLookup>
+	<ClusteredIndex>ConDemoNoteReportMultiSummaryTmpIdx</ClusteredIndex>
+	<PrimaryIndex>ConDemoNoteReportMultiSummaryTmpIdx</PrimaryIndex>
+	<ReplacementKey>ConDemoNoteReportMultiSummaryTmpIdx</ReplacementKey>
+	<SaveDataPerCompany>No</SaveDataPerCompany>
+	<TableType>TempDB</TableType>
+	<DeleteActions />
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>Subject</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>LineCount</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>Subject</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>LineCount</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+	</FieldGroups>
+	<Fields>
+		<AxTableField xmlns=""
+				i:type="AxTableFieldString">
+			<Name>Subject</Name>
+			<ExtendedDataType>String255</ExtendedDataType>
+		</AxTableField>
+		<AxTableField xmlns=""
+				i:type="AxTableFieldString">
+			<Name>LineCount</Name>
+			<ExtendedDataType>String255</ExtendedDataType>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes>
+		<AxTableIndex>
+			<Name>ConDemoNoteReportMultiSummaryTmpIdx</Name>
+			<AlternateKey>Yes</AlternateKey>
+			<AllowDuplicates>No</AllowDuplicates>
+			<Fields>
+				<AxTableIndexField>
+					<DataField>Subject</DataField>
+				</AxTableIndexField>
+			</Fields>
+		</AxTableIndex>
+	</Indexes>
+	<Mappings />
+	<Relations />
+	<StateMachines />
+</AxTable>

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiTmp.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiTmp.metadata.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoNoteReportMultiTmp</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// The <c>ConDemoNoteReportMultiTmp</c> table.
+/// </summary>
+public class ConDemoNoteReportMultiTmp extends common
+{
+}
+]]></Declaration>
+		<Methods />
+	</SourceCode>
+	<Label>@TaxTransactionInquiry:HeaderNote</Label>
+	<TableGroup>Main</TableGroup>
+	<TitleField1>NoteId</TitleField1>
+	<TitleField2>Subject</TitleField2>
+	<CacheLookup>None</CacheLookup>
+	<ClusteredIndex>ConDemoNoteReportMultiTmpIdx</ClusteredIndex>
+	<PrimaryIndex>ConDemoNoteReportMultiTmpIdx</PrimaryIndex>
+	<ReplacementKey>ConDemoNoteReportMultiTmpIdx</ReplacementKey>
+	<SaveDataPerCompany>No</SaveDataPerCompany>
+	<TableType>TempDB</TableType>
+	<DeleteActions />
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>NoteId</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>Subject</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>NoteId</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>Subject</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+	</FieldGroups>
+	<Fields>
+		<AxTableField xmlns=""
+				i:type="AxTableFieldString">
+			<Name>NoteId</Name>
+			<ExtendedDataType>String255</ExtendedDataType>
+		</AxTableField>
+		<AxTableField xmlns=""
+				i:type="AxTableFieldString">
+			<Name>Subject</Name>
+			<ExtendedDataType>String255</ExtendedDataType>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes>
+		<AxTableIndex>
+			<Name>ConDemoNoteReportMultiTmpIdx</Name>
+			<AlternateKey>Yes</AlternateKey>
+			<AllowDuplicates>No</AllowDuplicates>
+			<Fields>
+				<AxTableIndexField>
+					<DataField>NoteId</DataField>
+				</AxTableIndexField>
+			</Fields>
+		</AxTableIndex>
+	</Indexes>
+	<Mappings />
+	<Relations />
+	<StateMachines />
+</AxTable>

--- a/eval/goldens/L4-ssrs-report-multidataset/README.md
+++ b/eval/goldens/L4-ssrs-report-multidataset/README.md
@@ -1,0 +1,91 @@
+# Golden: L4-ssrs-report-multidataset — DRAFT, NOT FROZEN
+
+The case stays `golden_pending: true`. This capture would enshrine the
+`generateSmartReport` field-typing gap described below, so it is kept as a draft
+reference only — **fix first, capture second**.
+
+Captured 2026-07-28 on the D365FO dev VM. Model `Contoso`, `EXTENSION_PREFIX=Con`
+(authored name `DemoNoteReportMulti` → AOT name `ConDemoNoteReportMulti`),
+xppc 7.0.7858.27.
+
+**Provenance caveat:** the corpus record stamps `server_git_sha: 39adafe` (live
+repo HEAD), but the *running* MCP server binary was built from **`b28515f`** — a
+later commit rebuilt `dist/` while the server process still holds the old
+modules. The behaviour captured here is `b28515f`'s.
+
+Corpus record: `eval/corpus/runs/2026-07-28T04__L4-ssrs-report-multidataset__39adafe.json`.
+
+## Artifacts (all 7 from a single `generate_object(mode="scaffold", objectType="report", …)` call)
+
+| File | Type | Notes |
+|---|---|---|
+| `ConDemoNoteReportMultiTmp.metadata.xml` | AxTable | `TableType=TempDB`, detail dataset (`NoteId`, `Subject`) |
+| `ConDemoNoteReportMultiSummaryTmp.metadata.xml` | AxTable | `TableType=TempDB`, summary dataset (`Subject`, `LineCount`) |
+| `ConDemoNoteReportMultiContract.metadata.xml` | AxClass | `[DataContractAttribute]`, no dialog params |
+| `ConDemoNoteReportMultiDP.metadata.xml` | AxClass | `extends SrsReportDataProviderBase`; **one `[SRSReportDataSetAttribute]` getter per tmp table**; hand-completed `processReport()` |
+| `ConDemoNoteReportMultiController.metadata.xml` | AxClass | `extends SrsReportRunController`, `main()` + `prePromptModifyContract()` stub |
+| `ConDemoNoteReportMulti.menuitem.metadata.xml` | AxMenuItemOutput | → Controller class |
+| `ConDemoNoteReportMulti.metadata.xml` | AxReport | two `<AxReportDataSet>`; RDL carries two `<DataSet>` + two `<Tablix>` |
+
+The `additionalDatasets` feature under test works: both tmp tables, both DP
+getters, both `AxReportDataSet` entries and both RDL tablixes were produced by
+the one scaffold call. Full build: **0 errors**. BP: **0 errors, 8 warnings**.
+
+## Why this is a draft (writer defect it would bake in)
+
+`suggestEdtFromFieldName()` in `src/tools/generateSmartReport.ts:1303-1327` is a
+hardcoded keyword ladder that **never consults the EDT index** and falls through
+to `String255`. The `generateObject` schema documents `fieldsHint` for
+`scaffold:report` as *"EDTs auto-suggested from the index"* — the same wording as
+`scaffold:table`, which does hit the index. In this run `prepare(mode="create")`
+returned `NoteId → Num`, `Subject → smmSubject/EventSubject`, `LineCount → Counter`
+from the index for the identical field names, yet all three fields were emitted as
+`<ExtendedDataType>String255</ExtendedDataType>`.
+
+It hurts most on the summary dataset: `LineCount`, a count, becomes a string, its
+`AxReportDataSetField/DataType` becomes `System.String` (SSRS cannot format or
+aggregate it numerically), and the DP must wrap the aggregate in `int642Str()`.
+
+The same `String255` shape is **already frozen** in the sibling goldens
+`L4-ssrs-report-basic/ConDemoNoteReportTmp.metadata.xml` and
+`L4-ssrs-report-advanced/ConDemoNoteReportAdvTmp.metadata.xml` — so this is
+pre-existing behaviour, not a regression. When the writer is fixed, all three
+report goldens should be re-captured together.
+
+## Build oracle blind spot found here (negative test)
+
+`pass@build` does **not** certify AxReport dataset wiring. Repointing the Summary
+dataset's `<Query>` at a non-existent provider —
+
+```
+<Query>SELECT * FROM ConBogusNoSuchDP.ConBogusNoSuchTmp</Query>
+```
+
+— still produced `Build succeeded / Errors: 0` under a **full** build with
+Metadata Validation running (`Metadata: validate report` executed). The contrast
+test proves the oracle is otherwise live: pointing
+`AxMenuItemOutput/ConDemoNoteReportMulti/Object` at `ConBogusNoSuchController`
+failed the very next full build with
+
+```
+Metadata Error: AxMenuItemOutput/ConDemoNoteReportMulti/Object: Class 'ConBogusNoSuchController' does not exist.
+```
+
+Correctness of the report XML here was therefore established structurally, plus an
+element-vocabulary diff against the standard multi-dataset RDP reports
+`ApplicationSuite/Foundation/AxReport/AgreementConfirmation.xml` and
+`AssetStatementRowSetup.xml` (no unexpected elements; `<Caption>` under
+`AxReportPrecisionDesign` is used by 92 Foundation reports).
+
+## BP warnings (8, all from the scaffold shape — 0 errors)
+
+- `BPLocalVariableNotUsed` ×1 — the scaffolded `prePromptModifyContract()` declares
+  `contract` and leaves the body a TODO comment.
+- `BPErrorTablePrimaryKeyEditable`, `BPErrorTablePrimaryKeyNotMandatory`,
+  `BPErrorTableMissingFormRef` ×2 tables — the scaffold gives report tmp tables a
+  Main-table shape (unique alternate-key index on the first field, `ReplacementKey`).
+- `BPErrorMenuItemNotCoveredByPrivilege` ×1 — no privilege is in
+  `target_artifact_types`.
+
+Each was obtained with an explicit `targetFilter` (a filterless `run_bp_check`
+mints a false clean).


### PR DESCRIPTION
Evidence-only PR: one corpus record + one **draft** golden. No source changes, no
coverage movement — `L4-ssrs-report-multidataset` stays `golden_pending`, so the
Multi-dataset SSRS leaf is **not** closed (total stays 64/77).

## The feature works

One `generate_object(mode="scaffold", objectType="report", additionalDatasets=[…])`
call produced all 7 objects: two `TableType=TempDB` tmp tables, a DP carrying one
`[SRSReportDataSetAttribute]` getter **per** tmp table, a contract, a controller, an
`AxMenuItemOutput`, and an `AxReport` with two `<AxReportDataSet>` entries plus two RDL
`<DataSet>`/`<Tablix>` pairs. `processReport()` was hand-completed via
`d365fo_file(action="modify", operation="add-method")`; both static gates passed first
try, and this time `validate_code(references)` was **not** a false positive.

Full build `Errors: 0`. BP: 0 errors, 8 warnings, all from the scaffold shape. Every BP
run used an explicit `targetFilter` (each reported "1 elements processed").

## Why the golden is a draft

**TOOL_DEFECT — `scaffold:report` ignores the EDT index.**
`suggestEdtFromFieldName()` in `src/tools/generateSmartReport.ts` is a private, hardcoded
keyword ladder ending in `return 'String255'` that never queries the DB — despite a doc
comment claiming it is *"shared with generateSmartTable"*. The table side has a real
index-backed resolver (`resolveBestEdt`: `edt_metadata` exact → canonical → fuzzy with
confidence → heuristic last), and the schema documents `fieldsHint` **identically for
both**: *"EDTs auto-suggested from the index"*.

In this run `prepare(mode="create")` returned `NoteId → Num`, `Subject → smmSubject`,
`LineCount → Counter` for the same names, yet all three came out `String255`. It bites
hardest on `LineCount`: a count becomes a string, its `AxReportDataSetField/DataType`
becomes `System.String` (no SSRS numeric formatting or aggregation), and the DP has to
wrap the aggregate in `int642Str()`.

Pre-existing, not a regression — the same shape is **already frozen** in the
`L4-ssrs-report-basic` and `L4-ssrs-report-advanced` goldens, so a fix has to re-capture
all three together. That is deliberately not in this PR.

## Build-oracle blind spot

`pass@build` does **not** certify AxReport dataset wiring. Repointing the Summary dataset
at a non-existent provider still gave `Errors: 0` under a **full** build with
`Metadata: validate report` executing. The contrast test proves the oracle is otherwise
live: pointing `AxMenuItemOutput/…/Object` at a bogus controller failed the next full
build with `Metadata Error: … Class does not exist`. Report correctness was therefore
established structurally, plus an element-vocabulary diff against
`ApplicationSuite\Foundation\AxReport\AgreementConfirmation.xml` and
`AssetStatementRowSetup.xml` (clean).

## Provenance and hygiene

- `server_git_sha` is stamped `39adafe` (live HEAD) but the running server binary was
  built from **`b28515f`** — recorded explicitly in the record and the golden README
  rather than left to the misleading stamp.
- Descriptor unchanged; the existing 9 module references sufficed.
- Rollback verified: 7 AOT files, 7 whole `<Content>` blocks and the 3 scaffold-added
  `<Folder>` entries removed from `ContosoDemo.rnrproj` (well-formed, zero residue), the
  auto-created `.backup-*` file removed, and 5 stale copies purged from
  `Contoso\XppMetadata\Contoso\` — that directory is a cross-run leakage vector still
  holding ~58 objects from earlier cases that no longer exist in source. A final full
  build regenerated `bin\*.md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcXx5YZHTQ7fCHSSGevm7c
