### PR TITLE
fix(scaffold): resolve report EDTs from the index and reconcile the field/RDL type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://img.shields.io/badge/tests-1400%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
-[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-83.1%25-lightgrey.svg)](eval/COVERAGE.md)
+[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-84.4%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -9,7 +9,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
 | core | 43 | 43 | **100%** |
-| total | 64 | 77 | 83.1% |
+| total | 65 | 77 | 84.4% |
 
 ## Data model (12/12)
 
@@ -62,16 +62,16 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Form patterns (ListPage, DetailsMaster, …) | core | ✅ | ✅ | ✅ | L1-form-detailsmaster, L1-form-dialog, L1-form-listpage +5 |
 | Form extension | core | ✅ | ✅ | ✅ | L2-form-extension-basic |
 | FormRun lifecycle & data sources | core | ✅ | ✅ | ✅ | L2-form-modify-controls, L3-form-add-datasource-lines |
-| Menu items (display/action/output) | core | ✅ | ✅ | ✅ | L4-ssrs-report-advanced |
+| Menu items (display/action/output) | core | ✅ | ✅ | ✅ | L4-ssrs-report-advanced, L4-ssrs-report-multidataset |
 | Menus & submenu nesting | core | ✅ | ✅ | ✅ | L4-master-security-slice |
 | Tiles & KPIs | total | ✅ | ✅ | ✅ | L2-tile-cue-over-query |
 
-## Reporting (1/4)
+## Reporting (2/4)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | SSRS report (DP + contract + controller) | core | ✅ | ✅ | ✅ | L4-ssrs-report-advanced, L4-ssrs-report-basic |
-| Multi-dataset SSRS report | total | ✅ | — | ✅ | missing E |
+| Multi-dataset SSRS report | total | ✅ | ✅ | ✅ | L4-ssrs-report-multidataset |
 | Print management | total | ✅ | — | ✅ | Eval case authored (document node + settings resolution); golden pending VM capture. |
 | Electronic Reporting (ER) | total | ✅ | — | ✅ | Eval case authored for the X++ half (ER data provider); the ER model/mapping/format stay UI-configured and out of scope. Golden pending VM capture. |
 
@@ -138,7 +138,6 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | 2 | Parallel batch processing | missing E |
 | 2 | Posting engine (LedgerVoucher) | missing E |
 | 2 | Print management | missing E |
-| 2 | Multi-dataset SSRS report | missing E |
 | 1 | Aggregate measurements / analytics | missing E |
 | 1 | Electronic Reporting (ER) | missing E |
 | 1 | Power Platform / virtual entities | missing E |
@@ -151,4 +150,4 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 - Knowledge entries no leaf claims (**unproven knowledge**): none
 - Eval cases no leaf claims (**unmapped proof**): L2-oracle-discriminator-random-wrapper-name, L4-headerlines-document-slice
 
-_Generated 2026-07-27._
+_Generated 2026-07-28._

--- a/eval/cases/L4-ssrs-report-multidataset.json
+++ b/eval/cases/L4-ssrs-report-multidataset.json
@@ -13,7 +13,7 @@
     "AxReport"
   ],
   "golden_path": "eval/goldens/L4-ssrs-report-multidataset/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo",

--- a/eval/corpus/runs/2026-07-28T06__L4-ssrs-report-multidataset__b3d7856.json
+++ b/eval/corpus/runs/2026-07-28T06__L4-ssrs-report-multidataset__b3d7856.json
@@ -1,0 +1,65 @@
+{
+  "run_id": "2026-07-28T06__L4-ssrs-report-multidataset__b3d7856",
+  "case_id": "L4-ssrs-report-multidataset",
+  "tier": 4,
+  "timestamp": "2026-07-28T06:01:44.141Z",
+  "server_git_sha": "b3d7856",
+  "generated_artifacts": [
+    "ConDemoNoteReportMulti.menuitem.metadata.xml",
+    "ConDemoNoteReportMulti.metadata.xml",
+    "ConDemoNoteReportMultiContract.metadata.xml",
+    "ConDemoNoteReportMultiController.metadata.xml",
+    "ConDemoNoteReportMultiDP.metadata.xml",
+    "ConDemoNoteReportMultiSummaryTmp.metadata.xml",
+    "ConDemoNoteReportMultiTmp.metadata.xml"
+  ],
+  "build": {
+    "succeeded": false,
+    "errors": [
+      "Metadata Error: AxTable/ConDemoNoteReportMultiSummaryTmp/Fields/LineCount/ExtendedDataType: Data type mismatch. (xppc 7.0.7858.27, full build, Errors: 1)"
+    ],
+    "bp_checked": false,
+    "bpWarnings": null
+  },
+  "golden_diff": null,
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 0,
+    "bp_clean": null,
+    "golden_match": null,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT",
+  "platform_build": "xppc 7.0.7858.27",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "REGRESSION introduced by the very commit under test (b3d7856). Provenance is trustworthy here: live repo HEAD is b3d7856 on branch fix/report-edt-index and dist/tools/generateSmartReport.js was rebuilt at 05:29 from the 05:24 commit, so server_git_sha is accurate for once - confirmed behaviourally, not merely by timestamp.\n\nSTEP-0 PROBE (the half that works): the EDT index is now genuinely consulted by scaffold:report. Detail tmp NoteId -> PlCorrNoteId, Subject -> smmSubject; summary tmp LineCount -> PurchLineCount. No String255 anywhere. Parity with the table path is exact: generate_object(mode=fields) on the same three names returns byte-identical PlCorrNoteId / smmSubject / PurchLineCount, so suggestEdtFromFieldName really is shared now. The Num/Name pair in the L4-ssrs-report-basic golden came from copying the source table own fields, not from name resolution, so it is not a counter-example.\n\nTHE DEFECT: the resolved EDT and the AxTableField element type (i:type) are computed INDEPENDENTLY and never reconciled, so they can contradict each other. For LineCount the writer emitted i:type=AxTableFieldInt (Int32) while binding ExtendedDataType=PurchLineCount, which extends NumberOfRecords and is Int64. xppc rejects the combination. Before b3d7856 this same field was String255 + AxTableFieldString - internally consistent, so it built clean. Widening the EDT resolver without teaching the i:type chooser about the resolved EDT turned a cosmetic typing defect into a hard build break.\n\nCONFIRMED BY POSITIVE PROBE: flipping only i:type from AxTableFieldInt to AxTableFieldInt64 on that one field, changing nothing else, produced Errors: 0 on a fresh full build (33s, new Write Runtime Metadata phase, vs the 68s failing build - phase timings differ so it is not a stale result). That isolates the fault to the Int32-vs-Int64 disagreement and rules out the EDT choice itself, the report XML and the DP code.\n\nWHY THE i:type CHOOSER GUESSES: generateSmartReport.ts carries its OWN duplicate copy of resolveEdtBaseType (line 1359) whose doc comment claims it is the same as generateSmartTable - it is not. The generateSmartTable copy (line 1131) has an explicit ROOT-EDT branch: when edt_metadata.extends is NULL it returns undefined unless string_size is set, so the caller falls back to a name heuristic; its comment calls this the number-one scaffold-turned-my-date-or-amount-field-into-a-string bug. The generateSmartReport copy lacks that branch and returns String outright. NumberOfRecords IS such a root EDT (verified in edt_metadata: extends=NULL, enum_type=NULL, string_size=NULL - the index has no column at all recording a root EDT primitive). So b3d7856 shared suggestEdtFromFieldName but left resolveEdtBaseType duplicated and stale - the same comment-versus-reality mismatch it was written to remove, one function over.\n\nSECOND, SEPARATE SYMPTOM OF THE SAME ROOT CAUSE: because that stale copy returns String for PurchLineCount, AxReportDataSetField/DataType and the RDL rd:TypeName for LineCount are still System.String. So even had the build passed, the exact damage this case exists to catch - a count SSRS cannot format or aggregate numerically - is NOT yet fixed. The table field type and the RDL type are wrong in opposite directions (Int32 vs String) from the same unreconciled pair.\n\nCARRIED FORWARD from the previous run (still true, independent of this regression): pass@build does not certify AxReport dataset wiring - a dataset repointed at a non-existent DP still built with Errors: 0 under a full build with Metadata: validate report running.",
+  "suggested_fix_area": "src/tools/generateSmartReport.ts - (1) DELETE the duplicate resolveEdtBaseType at ~line 1359 and import the exported one from generateSmartTable, which already handles the root-EDT case; the doc comment already claims they are the same, so make it true. That alone fixes AxReportDataSetField/DataType and the RDL rd:TypeName for LineCount.\n(2) The real fix for the build break: derive the AxTableField i:type FROM the resolved EDT primitive instead of from an independent name heuristic, so ExtendedDataType and i:type can never disagree. NumberOfRecords and PurchLineCount are Int64, so the field must be AxTableFieldInt64. The C# bridge already reports Base Type: Int64 (Extends: NumberOfRecords) for PurchLineCount, so ground truth is available even though edt_metadata cannot express it.\n(3) Consider indexing a root EDT primitive type (an edt_metadata base_type or edt_type column). Both resolvers currently guess by name because the index physically cannot answer what primitive NumberOfRecords is - the shared upstream cause.\n(4) NOTE the same unreconciled pair exists on the TABLE path - generate_object(mode=fields) also returned AxTableFieldInt + PurchLineCount here. scaffold:table is latently exposed to the identical build break; it simply has no golden exercising an Int64-rooted EDT. Fix it in the shared code, not only in the report writer.\n(5) Regression guard: this fault class is invisible to validate_code (both modes passed clean) and only a FULL build catches it. Worth an assertion that the emitted i:type matches the resolved EDT primitive.",
+  "evidence_refs": [
+    "xppc full build (as-generated, 68s): Metadata Error: AxTable/ConDemoNoteReportMultiSummaryTmp/Fields/LineCount/ExtendedDataType: Data type mismatch. Errors: 1",
+    "positive probe (i:type AxTableFieldInt -> AxTableFieldInt64 only): fresh full build Errors: 0, 33s, Write Runtime Metadata phase present - phase timings differ from the failing build, so not stale",
+    "as-generated AxTable/ConDemoNoteReportMultiSummaryTmp: AxTableField i:type=AxTableFieldInt / Name=LineCount / ExtendedDataType=PurchLineCount",
+    "edt_metadata probe: PurchLineCount extends=NumberOfRecords; NumberOfRecords extends=NULL, enum_type=NULL, string_size=NULL (root EDT, primitive not recorded)",
+    "C# bridge get_object_info(edt, PurchLineCount): Base Type: Int64 (Extends: NumberOfRecords) - ground truth via bridge, not via edt_metadata",
+    "src/tools/generateSmartTable.ts:1131-1161 resolveEdtBaseType - HAS the root-EDT branch (returns undefined unless string_size set)",
+    "src/tools/generateSmartReport.ts:1359-1377 resolveEdtBaseType - duplicate, LACKS that branch, returns String at line 1373; doc comment falsely says same as generateSmartTable",
+    "AxReport LineCount: DataType=System.String and RDL rd:TypeName=System.String - still wrong after the fix",
+    "step-0 parity check: generate_object(mode=fields) on NoteId/Subject/LineCount returns PlCorrNoteId / smmSubject / PurchLineCount - identical to scaffold:report",
+    "prior run 2026-07-28T04__L4-ssrs-report-multidataset__39adafe.json (branch eval/ssrs-multidataset-capture): same case, String255 shape, build PASSED",
+    "golden NOT captured - case remains golden_pending: true"
+  ],
+  "notes": "Golden deliberately NOT captured and golden_pending left true. The artifacts do not build, so there is nothing valid to freeze; capturing would enshrine an i:type/ExtendedDataType contradiction. Fix first, capture second still stands. The Multi-dataset SSRS leaf stays open. Scope note: only L4-ssrs-report-advanced carries the old String255 shape from scaffold:report; L4-ssrs-report-basic builds its tmp table via the table path and is unaffected."
+}

--- a/eval/corpus/runs/2026-07-28T09__L4-ssrs-report-multidataset__538cab2.json
+++ b/eval/corpus/runs/2026-07-28T09__L4-ssrs-report-multidataset__538cab2.json
@@ -1,0 +1,52 @@
+{
+  "run_id": "2026-07-28T09__L4-ssrs-report-multidataset__538cab2",
+  "case_id": "L4-ssrs-report-multidataset",
+  "tier": 4,
+  "timestamp": "2026-07-28T09:18:21.689Z",
+  "server_git_sha": "538cab2",
+  "generated_artifacts": [
+    "ConDemoNoteReportMulti.menuitem.metadata.xml",
+    "ConDemoNoteReportMulti.metadata.xml",
+    "ConDemoNoteReportMultiContract.metadata.xml",
+    "ConDemoNoteReportMultiController.metadata.xml",
+    "ConDemoNoteReportMultiDP.metadata.xml",
+    "ConDemoNoteReportMultiSummaryTmp.metadata.xml",
+    "ConDemoNoteReportMultiTmp.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "PASS"
+}

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -8,8 +8,8 @@
   "total": {
     "tier": "all",
     "total": 77,
-    "covered": 64,
-    "percent": 83.1
+    "covered": 65,
+    "percent": 84.4
   },
   "leaves": [
     {
@@ -632,7 +632,8 @@
       "t": true,
       "covered": true,
       "cases": [
-        "L4-ssrs-report-advanced"
+        "L4-ssrs-report-advanced",
+        "L4-ssrs-report-multidataset"
       ]
     },
     {
@@ -685,10 +686,12 @@
       "tier": "total",
       "weight": 2,
       "k": true,
-      "e": false,
+      "e": true,
       "t": true,
-      "covered": false,
-      "cases": []
+      "covered": true,
+      "cases": [
+        "L4-ssrs-report-multidataset"
+      ]
     },
     {
       "id": "print-management",

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMulti.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMulti.metadata.xml
@@ -85,7 +85,7 @@
 			<AxReportDataSetField>
 				<Name>LineCount</Name>
 				<Alias>ConDemoNoteReportMultiSummaryTmp.1.LineCount</Alias>
-				<DataType>System.String</DataType>
+				<DataType>System.Int64</DataType>
 				<DisplayWidth>Auto</DisplayWidth>
 				<UserDefined>false</UserDefined>
 			</AxReportDataSetField>
@@ -219,12 +219,12 @@
         <ConnectString />
         <IntegratedSecurity>true</IntegratedSecurity>
       </ConnectionProperties>
-      <rd:DataSourceID>e89fdf66-070c-457b-a911-0d7f15f31e17</rd:DataSourceID>
+      <rd:DataSourceID>e2bee721-cff2-4421-8c6d-3b3465f60a60</rd:DataSourceID>
     </DataSource>
   </DataSources>
   <DataSets>
     <DataSet Name="ConDemoNoteReportMultiTmp">
-      <rd:DataSetID>f587958b-961a-4279-b11e-5adf56840530</rd:DataSetID>
+      <rd:DataSetID>57c4fdf0-0321-4cab-8908-96143ca249b9</rd:DataSetID>
       <Query>
         <DataSourceName>AutoGen__ReportDataProvider</DataSourceName>
         <QueryParameters>
@@ -272,7 +272,7 @@
       </rd:DataSetInfo>
     </DataSet>
     <DataSet Name="ConDemoNoteReportMultiSummaryTmp">
-      <rd:DataSetID>0a29c241-afbe-4b9a-bb58-42f5951d9b48</rd:DataSetID>
+      <rd:DataSetID>39672a2d-8ffb-4589-8252-ad40454bd645</rd:DataSetID>
       <Query>
         <DataSourceName>AutoGen__ReportDataProvider</DataSourceName>
         <QueryParameters>
@@ -308,7 +308,7 @@
         </Field>
         <Field Name="LineCount">
           <DataField>ConDemoNoteReportMultiSummaryTmp.1.LineCount</DataField>
-          <rd:TypeName>System.String</rd:TypeName>
+          <rd:TypeName>System.Int64</rd:TypeName>
         </Field>
       </Fields>
       <rd:DataSetInfo>
@@ -594,7 +594,7 @@
   </ReportParametersLayout>
   <Language>en-US</Language>
   <rd:ReportUnitType>Inch</rd:ReportUnitType>
-  <rd:ReportID>c1067ad5-d650-46f8-8973-87c806c5f804</rd:ReportID>
+  <rd:ReportID>26b3e577-7303-47a5-aebe-d7b182ca6431</rd:ReportID>
 </Report>]]></Text>
 			<DisableIndividualTransformation>
 				<Name>DisableIndividualTransformation</Name>

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiDP.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiDP.metadata.xml
@@ -54,27 +54,25 @@ public class ConDemoNoteReportMultiDP extends SrsReportDataProviderBase
 				<Name>processReport</Name>
 				<Source><![CDATA[
     /// <summary>
-    /// Main data processing method. Populates both temporary tables that back the
-    /// report datasets: the detail rows and the per-subject summary rows.
+    /// Main data processing method. Populates both report temporary tables:
+    /// the detail rows from <c>ConDemoNoteHeader</c> and one summary row per distinct subject.
     /// </summary>
     public void processReport()
     {
-        ConDemoNoteHeader   noteHeader;
-        ConDemoNoteHeader   noteHeaderSummary;
+        ConDemoNoteHeader   detailSource;
+        ConDemoNoteHeader   summarySource;
 
-        // Detail dataset - one row per note header.
         insert_recordset conDemoNoteReportMultiTmp (NoteId, Subject)
         select NoteId, Subject
-        from noteHeader;
+        from detailSource;
 
-        // Summary dataset - one row per distinct subject with its line count.
         while select Subject, count(RecId)
-        from noteHeaderSummary
-        group by Subject
+        from summarySource
+        group by summarySource.Subject
         {
             conDemoNoteReportMultiSummaryTmp.clear();
-            conDemoNoteReportMultiSummaryTmp.Subject   = noteHeaderSummary.Subject;
-            conDemoNoteReportMultiSummaryTmp.LineCount = int642Str(noteHeaderSummary.RecId);
+            conDemoNoteReportMultiSummaryTmp.Subject   = summarySource.Subject;
+            conDemoNoteReportMultiSummaryTmp.LineCount = summarySource.RecId;
             conDemoNoteReportMultiSummaryTmp.insert();
         }
     }

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiSummaryTmp.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiSummaryTmp.metadata.xml
@@ -64,12 +64,12 @@ public class ConDemoNoteReportMultiSummaryTmp extends common
 		<AxTableField xmlns=""
 				i:type="AxTableFieldString">
 			<Name>Subject</Name>
-			<ExtendedDataType>String255</ExtendedDataType>
+			<ExtendedDataType>smmSubject</ExtendedDataType>
 		</AxTableField>
 		<AxTableField xmlns=""
-				i:type="AxTableFieldString">
+				i:type="AxTableFieldInt64">
 			<Name>LineCount</Name>
-			<ExtendedDataType>String255</ExtendedDataType>
+			<ExtendedDataType>PurchLineCount</ExtendedDataType>
 		</AxTableField>
 	</Fields>
 	<FullTextIndexes />

--- a/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiTmp.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-multidataset/ConDemoNoteReportMultiTmp.metadata.xml
@@ -64,12 +64,12 @@ public class ConDemoNoteReportMultiTmp extends common
 		<AxTableField xmlns=""
 				i:type="AxTableFieldString">
 			<Name>NoteId</Name>
-			<ExtendedDataType>String255</ExtendedDataType>
+			<ExtendedDataType>PlCorrNoteId</ExtendedDataType>
 		</AxTableField>
 		<AxTableField xmlns=""
 				i:type="AxTableFieldString">
 			<Name>Subject</Name>
-			<ExtendedDataType>String255</ExtendedDataType>
+			<ExtendedDataType>smmSubject</ExtendedDataType>
 		</AxTableField>
 	</Fields>
 	<FullTextIndexes />

--- a/eval/goldens/L4-ssrs-report-multidataset/README.md
+++ b/eval/goldens/L4-ssrs-report-multidataset/README.md
@@ -1,19 +1,17 @@
-# Golden: L4-ssrs-report-multidataset — DRAFT, NOT FROZEN
+# Golden: L4-ssrs-report-multidataset — FROZEN
 
-The case stays `golden_pending: true`. This capture would enshrine the
-`generateSmartReport` field-typing gap described below, so it is kept as a draft
-reference only — **fix first, capture second**.
+`golden_pending: false`. This is the re-capture taken **after** the two
+`generateSmartReport` EDT fixes landed (`b3d7856`, `b6f50c9`); the earlier draft
+of this golden was deliberately not frozen because it would have enshrined the
+writer defect described in §"What the re-capture changed".
 
 Captured 2026-07-28 on the D365FO dev VM. Model `Contoso`, `EXTENSION_PREFIX=Con`
 (authored name `DemoNoteReportMulti` → AOT name `ConDemoNoteReportMulti`),
 xppc 7.0.7858.27.
 
-**Provenance caveat:** the corpus record stamps `server_git_sha: 39adafe` (live
-repo HEAD), but the *running* MCP server binary was built from **`b28515f`** — a
-later commit rebuilt `dist/` while the server process still holds the old
-modules. The behaviour captured here is `b28515f`'s.
-
-Corpus record: `eval/corpus/runs/2026-07-28T04__L4-ssrs-report-multidataset__39adafe.json`.
+Corpus record: `eval/corpus/runs/2026-07-28T09__L4-ssrs-report-multidataset__538cab2.json`.
+Superseded drafts: `…T04__…__39adafe.json` (pre-fix behaviour) and
+`…T06__…__b3d7856.json` (the half-fixed state that broke the build).
 
 ## Artifacts (all 7 from a single `generate_object(mode="scaffold", objectType="report", …)` call)
 
@@ -29,30 +27,51 @@ Corpus record: `eval/corpus/runs/2026-07-28T04__L4-ssrs-report-multidataset__39a
 
 The `additionalDatasets` feature under test works: both tmp tables, both DP
 getters, both `AxReportDataSet` entries and both RDL tablixes were produced by
-the one scaffold call. Full build: **0 errors**. BP: **0 errors, 8 warnings**.
+the one scaffold call. Full build: **0 errors** (`Contoso compilation completed`,
+elapsed 00:01:37).
 
-## Why this is a draft (writer defect it would bake in)
+## What the re-capture changed
 
-`suggestEdtFromFieldName()` in `src/tools/generateSmartReport.ts:1303-1327` is a
-hardcoded keyword ladder that **never consults the EDT index** and falls through
-to `String255`. The `generateObject` schema documents `fieldsHint` for
-`scaffold:report` as *"EDTs auto-suggested from the index"* — the same wording as
-`scaffold:table`, which does hit the index. In this run `prepare(mode="create")`
-returned `NoteId → Num`, `Subject → smmSubject/EventSubject`, `LineCount → Counter`
-from the index for the identical field names, yet all three fields were emitted as
-`<ExtendedDataType>String255</ExtendedDataType>`.
+`suggestEdtFromFieldName()` in `generateSmartReport.ts` was a hardcoded keyword
+ladder that never consulted the EDT index and fell through to `String255`, even
+though the `generateObject` schema documents `fieldsHint` for `scaffold:report`
+identically to `scaffold:table` ("EDTs auto-suggested from the index"). Fixing
+that (`b3d7856`) exposed a second fault one function over: `generateSmartReport`
+carried its **own** duplicate `resolveEdtBaseType` whose comment claimed it was
+"same as generateSmartTable" — it was not. The shared copy returns `undefined`
+for a ROOT EDT with no `string_size`; the local copy collapsed that to `'String'`.
 
-It hurts most on the summary dataset: `LineCount`, a count, becomes a string, its
-`AxReportDataSetField/DataType` becomes `System.String` (SSRS cannot format or
-aggregate it numerically), and the DP must wrap the aggregate in `int642Str()`.
+The two halves then went wrong in **opposite** directions on the same field:
 
-The same `String255` shape is **already frozen** in the sibling goldens
-`L4-ssrs-report-basic/ConDemoNoteReportTmp.metadata.xml` and
-`L4-ssrs-report-advanced/ConDemoNoteReportAdvTmp.metadata.xml` — so this is
-pre-existing behaviour, not a regression. When the writer is fixed, all three
-report goldens should be re-captured together.
+| | pre-fix (`39adafe`) | half-fixed (`b3d7856`) | frozen here (`b6f50c9`) |
+|---|---|---|---|
+| `SummaryTmp/Fields/LineCount/@type` | `AxTableFieldString` | `AxTableFieldInt` (Int32) | `AxTableFieldInt64` |
+| `LineCount/ExtendedDataType` | `String255` | `PurchLineCount` | `PurchLineCount` |
+| `AxReportDataSetField[LineCount]/DataType` | `System.String` | `System.String` | `System.Int64` |
+| full build | 0 errors | **`Metadata Error: … /LineCount/ExtendedDataType: Data type mismatch`** | 0 errors |
 
-## Build oracle blind spot found here (negative test)
+`PurchLineCount` roots in the Int64 EDT `NumberOfRecords`, so `SmartXmlBuilder`'s
+EDT-**name** heuristic (`includes('count')` → `AxTableFieldInt`) contradicted the
+EDT chain. Both sides now read one cached primitive per EDT
+(bridge → index → heuristic) and cannot disagree.
+
+**`validate_code` was clean in both modes.** Only a full build ever caught it.
+
+## Oracle negative test (this golden actually discriminates)
+
+Re-injecting the exact regression shape into the scored artifacts — `LineCount`
+back to `AxTableFieldInt` and its `AxReportDataSetField/DataType` back to
+`System.String` — makes `npm run eval:score` fail on precisely those two paths:
+
+```
+❌ golden mismatch — 0 missing, 0 extra, 2 changed.
+  ~ AxReport/DataSets/AxReportDataSet[…SummaryTmp]/Fields/AxReportDataSetField[LineCount]/DataType  (golden="System.Int64" actual="System.String")
+  ~ AxTable/Fields/AxTableField[LineCount]/@type                                                     (golden="AxTableFieldInt64" actual="AxTableFieldInt")
+```
+
+Neither path is swallowed by the case's `ignore` list.
+
+## Known build-oracle blind spot (carried over from the draft capture)
 
 `pass@build` does **not** certify AxReport dataset wiring. Repointing the Summary
 dataset's `<Query>` at a non-existent provider —
@@ -61,9 +80,9 @@ dataset's `<Query>` at a non-existent provider —
 <Query>SELECT * FROM ConBogusNoSuchDP.ConBogusNoSuchTmp</Query>
 ```
 
-— still produced `Build succeeded / Errors: 0` under a **full** build with
-Metadata Validation running (`Metadata: validate report` executed). The contrast
-test proves the oracle is otherwise live: pointing
+— still produced `Errors: 0` under a **full** build with Metadata Validation
+running (`Metadata: validate report` executed). The contrast test proves the
+oracle is otherwise live: pointing
 `AxMenuItemOutput/ConDemoNoteReportMulti/Object` at `ConBogusNoSuchController`
 failed the very next full build with
 
@@ -71,21 +90,38 @@ failed the very next full build with
 Metadata Error: AxMenuItemOutput/ConDemoNoteReportMulti/Object: Class 'ConBogusNoSuchController' does not exist.
 ```
 
-Correctness of the report XML here was therefore established structurally, plus an
+Correctness of the report XML was therefore established structurally, plus an
 element-vocabulary diff against the standard multi-dataset RDP reports
 `ApplicationSuite/Foundation/AxReport/AgreementConfirmation.xml` and
-`AssetStatementRowSetup.xml` (no unexpected elements; `<Caption>` under
-`AxReportPrecisionDesign` is used by 92 Foundation reports).
+`AssetStatementRowSetup.xml`.
 
-## BP warnings (8, all from the scaffold shape — 0 errors)
+## Open quality observation (not a blocker, not frozen as correct)
 
-- `BPLocalVariableNotUsed` ×1 — the scaffolded `prePromptModifyContract()` declares
-  `contract` and leaves the body a TODO comment.
-- `BPErrorTablePrimaryKeyEditable`, `BPErrorTablePrimaryKeyNotMandatory`,
-  `BPErrorTableMissingFormRef` ×2 tables — the scaffold gives report tmp tables a
-  Main-table shape (unique alternate-key index on the first field, `ReplacementKey`).
-- `BPErrorMenuItemNotCoveredByPrivilege` ×1 — no privilege is in
-  `target_artifact_types`.
+`NoteId` resolves to **`PlCorrNoteId`** — a Polish-localization EDT — via
+`resolveBestEdt`'s fuzzy path. This is not a resolver defect: the index holds no
+EDT literally named `NoteId`, and the whole candidate list is fuzzy/localization
+noise (`RefRecId` 0.85 by the "ends with Id" heuristic, then `PlCorrNoteId` 0.84,
+`CustDebitNoteId` 0.81, …). `PlCorrNoteId` extends `Num`, so the *primitive* is
+right and the build is clean. But it drags in a country-specific EDT carrying an
+EDT relation, which is where 2 of the 10 BP warnings below come from. Worth a
+future improver pass on how fuzzy candidates are ranked against localization
+suffixes.
 
-Each was obtained with an explicit `targetFilter` (a filterless `run_bp_check`
-mints a false clean).
+## BP warnings (10, all from the scaffold shape — 0 errors)
+
+Per-object, each obtained with an explicit `targetFilter` (a filterless
+`run_bp_check` mints a false clean):
+
+| Object | Warnings |
+|---|---|
+| `ConDemoNoteReportMultiTmp` (table) | 5 — `BPErrorEDTNotMigrated`, `BPUpgradeMetadataEDTRelation`, `BPErrorTablePrimaryKeyEditable`, `BPErrorTablePrimaryKeyNotMandatory`, `BPErrorTableMissingFormRef` |
+| `ConDemoNoteReportMultiSummaryTmp` (table) | 3 — `BPErrorTablePrimaryKeyEditable`, `BPErrorTablePrimaryKeyNotMandatory`, `BPErrorTableMissingFormRef` |
+| `ConDemoNoteReportMultiController` (class) | 1 — `BPLocalVariableNotUsed` (`prePromptModifyContract()` leaves `contract` unused behind a TODO) |
+| `ConDemoNoteReportMultiDP` (class) | 0 |
+| `ConDemoNoteReportMultiContract` (class) | 0 |
+| `ConDemoNoteReportMulti` (menu item output) | 1 — `BPErrorMenuItemNotCoveredByPrivilege` (no privilege in `target_artifact_types`) |
+
+The primary-key/form-ref trio per table is the scaffold giving report tmp tables a
+Main-table shape (unique alternate-key index on the first field, `ReplacementKey`).
+The count rose from 8 (draft capture) to 10 purely because `NoteId` now resolves to
+a real EDT that carries a relation, instead of the inert `String255`.

--- a/src/tools/generateSmart.ts
+++ b/src/tools/generateSmart.ts
@@ -28,7 +28,7 @@ type SmartHandler = (args: any, context: XppServerContext) => Promise<any>;
 export const GENERATE_SMART_DISPATCH: Record<GenerateSmartType, SmartHandler> = {
   table:  (args, ctx) => handleGenerateSmartTable(args, ctx.symbolIndex, ctx.bridge),
   form:   (args, ctx) => handleGenerateSmartForm(args, ctx.symbolIndex),
-  report: (args, ctx) => handleGenerateSmartReport(args, ctx.symbolIndex),
+  report: (args, ctx) => handleGenerateSmartReport(args, ctx.symbolIndex, ctx.bridge),
 };
 
 const GenerateSmartArgsSchema = z

--- a/src/tools/generateSmartReport.ts
+++ b/src/tools/generateSmartReport.ts
@@ -25,6 +25,10 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { XppSymbolIndex } from '../metadata/symbolIndex.js';
 import { SmartXmlBuilder, TableFieldSpec } from '../utils/smartXmlBuilder.js';
 import { XmlTemplateGenerator } from './createD365File.js';
+import {
+  resolveBestEdt,
+  suggestEdtFromFieldName as heuristicEdtFromFieldName,
+} from './generateSmartTable.js';
 import { ProjectFileManager } from './createD365File.js';
 import path from 'path';
 import fs from 'fs';
@@ -384,8 +388,8 @@ export async function handleGenerateSmartReport(
   if (structuredFields && structuredFields.length > 0 && reportFields.length === 0) {
     reportFields = structuredFields.map(f => ({
       ...f,
-      edt: f.edt || suggestEdtFromFieldName(f.name),
-      dataType: f.dataType || resolveRdlDataType(f.edt || suggestEdtFromFieldName(f.name), rdb),
+      edt: f.edt || suggestEdtFromFieldName(f.name, rdb),
+      dataType: f.dataType || resolveRdlDataType(f.edt || suggestEdtFromFieldName(f.name, rdb), rdb),
     }));
     log(`Using ${reportFields.length} structured fields`);
   }
@@ -394,7 +398,7 @@ export async function handleGenerateSmartReport(
   if (fieldsHint && reportFields.length === 0) {
     const hints = fieldsHint.split(',').map(s => s.trim()).filter(Boolean);
     reportFields = hints.map(h => {
-      const edt = suggestEdtFromFieldName(h);
+      const edt = suggestEdtFromFieldName(h, rdb);
       return {
         name: h,
         edt,
@@ -438,13 +442,13 @@ export async function handleGenerateSmartReport(
     if (ds.fields && ds.fields.length > 0) {
       dsFields = ds.fields.map((f: ReportFieldSpec) => ({
         ...f,
-        edt: f.edt || suggestEdtFromFieldName(f.name),
-        dataType: f.dataType || resolveRdlDataType(f.edt || suggestEdtFromFieldName(f.name), rdb),
+        edt: f.edt || suggestEdtFromFieldName(f.name, rdb),
+        dataType: f.dataType || resolveRdlDataType(f.edt || suggestEdtFromFieldName(f.name, rdb), rdb),
       }));
     } else if (ds.fieldsHint) {
       const hints = ds.fieldsHint.split(',').map((s: string) => s.trim()).filter(Boolean);
       dsFields = hints.map((h: string) => {
-        const edt = suggestEdtFromFieldName(h);
+        const edt = suggestEdtFromFieldName(h, rdb);
         return { name: h, edt, dataType: resolveRdlDataType(edt, rdb) };
       });
     }
@@ -1298,32 +1302,34 @@ function injectGroupedTablix(
 }
 
 /**
- * Suggest EDT based on field name heuristics (shared with generateSmartTable).
+ * Resolve the EDT for a report field name.
+ *
+ * Regression: this used to be a private hardcoded keyword ladder ending in
+ * `return 'String255'` that never touched the DB — despite a doc comment claiming
+ * it was "shared with generateSmartTable" and a tool schema that documents
+ * `fieldsHint` identically for scaffold:table and scaffold:report ("EDTs
+ * auto-suggested from the index"). Only the table side actually hit the index.
+ * Effect: `prepare(mode="create")` resolved NoteId→Num, Subject→smmSubject,
+ * LineCount→Counter while the report writer emitted String255 for all three; a
+ * count then became a string, its AxReportDataSetField/DataType became
+ * System.String (no SSRS numeric formatting or aggregation) and the DP had to
+ * wrap the aggregate in int642Str().
+ * Evidence: eval/corpus/runs/2026-07-28T04__L4-ssrs-report-multidataset__39adafe.json
+ *
+ * Now genuinely shared: resolveBestEdt does edt_metadata exact → canonical →
+ * fuzzy-with-confidence and falls back to generateSmartTable's heuristic ladder,
+ * which is a superset of the one deleted here. Without a DB (Azure/Linux) the
+ * heuristic is used directly, so the two paths agree in both cases.
  */
-function suggestEdtFromFieldName(fieldName: string): string {
-  const n = fieldName.toLowerCase();
-  if (n === 'recid') return 'RecId';
-  if (n === 'accountnum' || n === 'accountnumber') return 'CustAccount';
-  if (n.includes('custaccount') || n.includes('customeraccount')) return 'CustAccount';
-  if (n.includes('vendaccount') || (n.includes('vendor') && n.includes('account'))) return 'VendAccount';
-  if (n === 'name' || n === 'itemname') return 'Name';
-  if (n.includes('name')) return 'Name';
-  if (n === 'description' || n === 'desc') return 'Description';
-  if (n.includes('description')) return 'Description';
-  if (n.includes('amount') || n.includes('balance')) return 'AmountMST';
-  if (n.includes('quantity') || n.includes('qty')) return 'Qty';
-  if (n.includes('price')) return 'PriceUnit';
-  if (n === 'fromdate' || n === 'validfrom') return 'TransDate';
-  if (n === 'todate' || n === 'validto') return 'TransDate';
-  if (n.includes('date')) return 'TransDate';
-  if (n.includes('itemid') || n === 'item') return 'ItemId';
-  if (n.includes('custgroup')) return 'CustGroupId';
-  if (n.includes('cust')) return 'CustAccount';
-  if (n.includes('vend')) return 'VendAccount';
-  if (n.includes('percent') || n.includes('pct')) return 'Percent';
-  if (n.includes('zone')) return 'WHSZoneId';
-  if (n.includes('warehouse') || n === 'whs') return 'InventLocationId';
-  return 'String255';
+function suggestEdtFromFieldName(fieldName: string, db?: any): string {
+  if (db) {
+    try {
+      return resolveBestEdt(fieldName, db);
+    } catch {
+      /* DB unusable — fall through to the shared heuristic */
+    }
+  }
+  return heuristicEdtFromFieldName(fieldName);
 }
 
 /**

--- a/src/tools/generateSmartReport.ts
+++ b/src/tools/generateSmartReport.ts
@@ -28,7 +28,11 @@ import { XmlTemplateGenerator } from './createD365File.js';
 import {
   resolveBestEdt,
   suggestEdtFromFieldName as heuristicEdtFromFieldName,
+  resolveEdtBaseType as sharedResolveEdtBaseType,
+  heuristicEdtBaseType,
+  bridgeEdtBaseType,
 } from './generateSmartTable.js';
+import type { BridgeClient } from '../bridge/bridgeClient.js';
 import { ProjectFileManager } from './createD365File.js';
 import path from 'path';
 import fs from 'fs';
@@ -242,7 +246,8 @@ Examples:
 
 export async function handleGenerateSmartReport(
   args: GenerateSmartReportArgs,
-  symbolIndex: XppSymbolIndex
+  symbolIndex: XppSymbolIndex,
+  bridge?: BridgeClient
 ): Promise<any> {
   const {
     name,
@@ -337,6 +342,22 @@ export async function handleGenerateSmartReport(
 
   const rdb = symbolIndex.getReadDb();
 
+  // ONE resolved primitive per EDT, shared by every consumer: the AxTableField i:type
+  // (resolveFieldType) and the dataset/RDL type (resolveRdlDataType). They used to be
+  // derived independently and could disagree — an Int32 i:type over an Int64 EDT is a
+  // hard "Data type mismatch" build error, while the RDL stayed System.String.
+  const edtPrimitiveCache = new Map<string, string | undefined>();
+  const primitiveOf = async (edt: string | undefined): Promise<string | undefined> => {
+    if (!edt) return undefined;
+    if (!edtPrimitiveCache.has(edt)) {
+      edtPrimitiveCache.set(edt, await resolveEdtPrimitive(edt, rdb, bridge));
+    }
+    return edtPrimitiveCache.get(edt);
+  };
+  /** Cache read for the later sync passes — every EDT has been through primitiveOf by then. */
+  const primitiveOfSync = (edt: string | undefined): string | undefined =>
+    edt ? edtPrimitiveCache.get(edt) : undefined;
+
   let reportFields: ReportFieldSpec[] = [];
 
   // Strategy 1: copyFrom — read fields from existing report's TmpTable
@@ -368,13 +389,14 @@ export async function handleGenerateSmartReport(
           `SELECT name, signature FROM symbols WHERE type = 'field' AND parent_name = ? ORDER BY name`
         ).all(srcTmpTable) as Array<{ name: string; signature: string }>;
 
-        reportFields = dbFields
-          .filter(f => !['RecId', 'RecVersion', 'DataAreaId', 'Partition', 'TableId'].includes(f.name))
-          .map(f => ({
+        for (const f of dbFields) {
+          if (['RecId', 'RecVersion', 'DataAreaId', 'Partition', 'TableId'].includes(f.name)) continue;
+          reportFields.push({
             name: f.name,
             edt: f.signature || undefined,
-            dataType: resolveRdlDataType(f.signature, rdb),
-          }));
+            dataType: resolveRdlDataType(await primitiveOf(f.signature || undefined)),
+          });
+        }
         log(`Copied ${reportFields.length} fields from ${srcTmpTable}`);
       } else {
         log(`⚠ Could not find TmpTable for "${copyFrom}" — falling back to fieldsHint`);
@@ -386,25 +408,28 @@ export async function handleGenerateSmartReport(
 
   // Strategy 2: structuredFields (explicit specs from the caller)
   if (structuredFields && structuredFields.length > 0 && reportFields.length === 0) {
-    reportFields = structuredFields.map(f => ({
-      ...f,
-      edt: f.edt || suggestEdtFromFieldName(f.name, rdb),
-      dataType: f.dataType || resolveRdlDataType(f.edt || suggestEdtFromFieldName(f.name, rdb), rdb),
-    }));
+    for (const f of structuredFields) {
+      const edt = f.edt || suggestEdtFromFieldName(f.name, rdb);
+      reportFields.push({
+        ...f,
+        edt,
+        dataType: f.dataType || resolveRdlDataType(await primitiveOf(edt)),
+      });
+    }
     log(`Using ${reportFields.length} structured fields`);
   }
 
   // Strategy 3: fieldsHint — parse comma-separated names, suggest EDTs
   if (fieldsHint && reportFields.length === 0) {
     const hints = fieldsHint.split(',').map(s => s.trim()).filter(Boolean);
-    reportFields = hints.map(h => {
+    for (const h of hints) {
       const edt = suggestEdtFromFieldName(h, rdb);
-      return {
+      reportFields.push({
         name: h,
         edt,
-        dataType: resolveRdlDataType(edt, rdb),
-      };
-    });
+        dataType: resolveRdlDataType(await primitiveOf(edt)),
+      });
+    }
     log(`Parsed ${reportFields.length} fields from fieldsHint`);
   }
 
@@ -435,34 +460,38 @@ export async function handleGenerateSmartReport(
     fields: ReportFieldSpec[];
     tableFields: TableFieldSpec[];
   };
-  const resolvedExtraDatasets: ResolvedExtraDataset[] = additionalDatasets.map((ds: { name: string; fieldsHint?: string; fields?: ReportFieldSpec[] }) => {
+  const resolvedExtraDatasets: ResolvedExtraDataset[] = [];
+  for (const ds of additionalDatasets as Array<{ name: string; fieldsHint?: string; fields?: ReportFieldSpec[] }>) {
     const cap = ds.name.charAt(0).toUpperCase() + ds.name.slice(1);
     const dsTmpName = `${finalName}${cap}Tmp`;
-    let dsFields: ReportFieldSpec[] = [];
+    const dsFields: ReportFieldSpec[] = [];
     if (ds.fields && ds.fields.length > 0) {
-      dsFields = ds.fields.map((f: ReportFieldSpec) => ({
-        ...f,
-        edt: f.edt || suggestEdtFromFieldName(f.name, rdb),
-        dataType: f.dataType || resolveRdlDataType(f.edt || suggestEdtFromFieldName(f.name, rdb), rdb),
-      }));
+      for (const f of ds.fields) {
+        const edt = f.edt || suggestEdtFromFieldName(f.name, rdb);
+        dsFields.push({
+          ...f,
+          edt,
+          dataType: f.dataType || resolveRdlDataType(await primitiveOf(edt)),
+        });
+      }
     } else if (ds.fieldsHint) {
       const hints = ds.fieldsHint.split(',').map((s: string) => s.trim()).filter(Boolean);
-      dsFields = hints.map((h: string) => {
+      for (const h of hints) {
         const edt = suggestEdtFromFieldName(h, rdb);
-        return { name: h, edt, dataType: resolveRdlDataType(edt, rdb) };
-      });
+        dsFields.push({ name: h, edt, dataType: resolveRdlDataType(await primitiveOf(edt)) });
+      }
     }
-    return {
+    resolvedExtraDatasets.push({
       name: ds.name,
       tmpTableName: dsTmpName,
       fields: dsFields,
       tableFields: dsFields.map((f: ReportFieldSpec) => ({
         name: f.name,
         edt: f.edt,
-        type: resolveFieldType(f.edt, rdb),
+        type: resolveFieldType(primitiveOfSync(f.edt)),
       })),
-    };
-  });
+    });
+  }
 
   const generatedObjects: Array<{
     objectType: string;
@@ -475,7 +504,7 @@ export async function handleGenerateSmartReport(
   const tableFields: TableFieldSpec[] = reportFields.map(f => ({
     name: f.name,
     edt: f.edt,
-    type: resolveFieldType(f.edt, rdb),
+    type: resolveFieldType(primitiveOfSync(f.edt)),
   }));
 
   const builder = new SmartXmlBuilder(symbolIndex);
@@ -1335,9 +1364,7 @@ function suggestEdtFromFieldName(fieldName: string, db?: any): string {
 /**
  * Resolve .NET data type for RDL from an EDT name by checking edt_metadata.
  */
-function resolveRdlDataType(edtName: string | undefined, db: any): string {
-  if (!edtName) return 'System.String';
-  const baseType = resolveEdtBaseType(edtName, db);
+function resolveRdlDataType(baseType: string | undefined): string {
   switch (baseType) {
     case 'Real':        return 'System.Double';
     case 'Integer':     return 'System.Int32';
@@ -1354,34 +1381,42 @@ function resolveRdlDataType(edtName: string | undefined, db: any): string {
 }
 
 /**
- * Walk EDT extends chain to find primitive base type (same as generateSmartTable).
+ * Resolve an EDT's primitive base type — bridge first, then index, then name heuristic.
+ *
+ * Regression this replaces: a private duplicate of resolveEdtBaseType lived here whose
+ * doc comment claimed it was "same as generateSmartTable". It was not. The shared copy
+ * returns `undefined` for a ROOT EDT with no string_size — the index stores extends=null
+ * for AxEdtInt64/Date/Real/String alike, so its primitive is genuinely unknowable from
+ * SQL — while this copy collapsed exactly that case to 'String'.
+ *
+ * The damage was silent and only a full build caught it: resolveFieldType() mapped the
+ * bogus 'String' to `undefined`, SmartXmlBuilder.getAxTableFieldType() then fell through
+ * to its EDT-NAME heuristic (`includes('count')` → AxTableFieldInt, Int32), and the field
+ * was emitted with an Int32 i:type over `PurchLineCount`, which extends the Int64 root EDT
+ * NumberOfRecords:
+ *   Metadata Error: AxTable/…/Fields/LineCount/ExtendedDataType: Data type mismatch.
+ * The resolved EDT and the i:type were computed independently and never reconciled.
+ * Evidence: eval/corpus/runs/2026-07-28T06__L4-ssrs-report-multidataset__b3d7856.json
+ *
+ * Same chain as generateSmartTable's field pass, and for the same reason: only the live
+ * IMetadataProvider can read a root EDT's primitive off the AxEdt itself. Always returns
+ * a concrete type so callers never leave SmartXmlBuilder guessing from the name.
  */
-function resolveEdtBaseType(edtName: string, db: any, depth = 0): string {
-  const PRIMITIVES = new Set([
-    'String', 'Integer', 'Int64', 'Real', 'Date', 'UtcDateTime', 'DateTime',
-    'Enum', 'Container', 'Guid', 'GUID',
-  ]);
-  if (depth > 8) return 'String';
-  if (PRIMITIVES.has(edtName)) return edtName;
-  try {
-    const row = db.prepare(
-      `SELECT extends, enum_type FROM edt_metadata WHERE edt_name = ? LIMIT 1`
-    ).get(edtName) as { extends: string | null; enum_type: string | null } | undefined;
-    if (!row) return 'String';
-    // Enum-based EDT: extends is null but enum_type is set (e.g. SalesStatus, PurchStatus)
-    if (row.enum_type && !row.extends) return 'Enum';
-    if (!row.extends) return 'String';
-    if (PRIMITIVES.has(row.extends)) return row.extends;
-    return resolveEdtBaseType(row.extends, db, depth + 1);
-  } catch { return 'String'; }
+async function resolveEdtPrimitive(
+  edtName: string | undefined,
+  db: any,
+  bridge?: BridgeClient
+): Promise<string | undefined> {
+  if (!edtName) return undefined;
+  return (await bridgeEdtBaseType(bridge, edtName))
+      ?? sharedResolveEdtBaseType(edtName, db)
+      ?? heuristicEdtBaseType(edtName);
 }
 
 /**
  * Resolve AxTableField type from EDT (for SmartXmlBuilder).
  */
-function resolveFieldType(edtName: string | undefined, db: any): string | undefined {
-  if (!edtName) return undefined;
-  const base = resolveEdtBaseType(edtName, db);
+function resolveFieldType(base: string | undefined): string | undefined {
   // SmartXmlBuilder uses these type strings to pick AxTableFieldXxx
   switch (base) {
     case 'Real':        return 'Real';

--- a/tests/tools/generateSmartReport.test.ts
+++ b/tests/tools/generateSmartReport.test.ts
@@ -85,3 +85,82 @@ describe('generate_object(scaffold, report) contract mandatory param', () => {
     expect(text).toContain('checkFailed');
   });
 });
+
+/**
+ * Regression: scaffold:report ignored the EDT index.
+ *
+ * suggestEdtFromFieldName() in generateSmartReport.ts was a private hardcoded keyword
+ * ladder ending in `return 'String255'` that never queried the DB — while its doc comment
+ * claimed it was "shared with generateSmartTable" and the tool schema documents fieldsHint
+ * identically for scaffold:table and scaffold:report ("EDTs auto-suggested from the index").
+ * Only the table side actually hit the index (resolveBestEdt).
+ *
+ * Observed on the VM (eval/corpus/runs/2026-07-28T04__L4-ssrs-report-multidataset__39adafe.json):
+ * prepare(mode="create") resolved NoteId→Num, Subject→smmSubject, LineCount→Counter, yet the
+ * report writer emitted String255 for all three. Worst case is a count becoming a string —
+ * AxReportDataSetField/DataType turns into System.String, killing SSRS numeric formatting and
+ * aggregation and forcing the DP to wrap the aggregate in int642Str().
+ */
+describe('generate_object(scaffold, report) EDT resolution', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  /** Stub whose edt_metadata table contains exactly `edts`, answered by SQL shape. */
+  function createIndexedSymbolIndexStub(edts: Record<string, string>) {
+    const known = new Set(Object.keys(edts));
+    const prepare = vi.fn((sql: string) => ({
+      get: vi.fn((param: string) => {
+        if (sql.includes('extends') || sql.includes('edt_metadata WHERE edt_name = ?')) {
+          return known.has(param)
+            ? { edt_name: param, extends: edts[param] }
+            : undefined;
+        }
+        return undefined;
+      }),
+      all: vi.fn(() => []),
+    }));
+    return { getReadDb: vi.fn(() => ({ prepare })) } as any;
+  }
+
+  it('resolves a field name that IS an EDT through the index instead of defaulting to String255', async () => {
+    const symbolIndex = createIndexedSymbolIndexStub({
+      Num: 'String',
+      Counter: 'Integer',
+    });
+
+    const result = await handleGenerateSmartReport(
+      {
+        name: 'DemoNoteReport',
+        fieldsHint: 'Num, Counter',
+        modelName: 'MyModel',
+      } as any,
+      symbolIndex
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('<ExtendedDataType>Num</ExtendedDataType>');
+    expect(text).toContain('<ExtendedDataType>Counter</ExtendedDataType>');
+    // The whole point: neither field silently became the generic string default.
+    expect(text).not.toContain('<ExtendedDataType>String255</ExtendedDataType>');
+  });
+
+  it('still falls back to the shared heuristic when the index knows nothing', async () => {
+    const symbolIndex = createIndexedSymbolIndexStub({});
+
+    const result = await handleGenerateSmartReport(
+      { name: 'DemoNoteReport', fieldsHint: 'CustAccount', modelName: 'MyModel' } as any,
+      symbolIndex
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('CustAccount');
+  });
+});

--- a/tests/tools/generateSmartReport.test.ts
+++ b/tests/tools/generateSmartReport.test.ts
@@ -164,3 +164,82 @@ describe('generate_object(scaffold, report) EDT resolution', () => {
     expect(text).toContain('CustAccount');
   });
 });
+
+/**
+ * Regression: the resolved EDT and the emitted AxTableField i:type were computed
+ * independently and never reconciled.
+ *
+ * b3d7856 made scaffold:report resolve EDTs from the index, which surfaced a second,
+ * older fault one function over. generateSmartReport carried its OWN duplicate
+ * resolveEdtBaseType whose comment claimed it was "same as generateSmartTable" — it was
+ * not: the shared copy returns undefined for a ROOT EDT with no string_size (the index
+ * stores extends=null for AxEdtInt64/Date/Real/String alike, so the primitive is genuinely
+ * unknowable from SQL), while the local copy collapsed that to 'String'.
+ *
+ * resolveFieldType() then mapped 'String' to undefined, and SmartXmlBuilder fell through
+ * to its EDT-NAME heuristic — `includes('count')` → AxTableFieldInt (Int32) — over
+ * PurchLineCount, which extends the Int64 root EDT NumberOfRecords. Full build:
+ *   Metadata Error: AxTable/…/Fields/LineCount/ExtendedDataType: Data type mismatch.
+ * Meanwhile AxReportDataSetField/DataType and the RDL rd:TypeName stayed System.String —
+ * the two halves were wrong in OPPOSITE directions from the same unreconciled pair.
+ * Evidence: eval/corpus/runs/2026-07-28T06__L4-ssrs-report-multidataset__b3d7856.json
+ *
+ * Both now read one cached primitive per EDT (bridge → index → heuristic), so they cannot
+ * disagree. Invisible to validate_code — only a full build ever caught it.
+ */
+describe('generate_object(scaffold, report) EDT/field-type reconciliation', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  function createEdtChainStub(edts: Record<string, string>) {
+    const prepare = vi.fn((sql: string) => ({
+      get: vi.fn((param: string) =>
+        sql.includes('edt_metadata') && param in edts
+          ? { edt_name: param, extends: edts[param], enum_type: null, string_size: null }
+          : undefined
+      ),
+      all: vi.fn(() => []),
+    }));
+    return { getReadDb: vi.fn(() => ({ prepare })) } as any;
+  }
+
+  it('emits an Int64 field type for an Int64-rooted EDT instead of guessing Int32 from the name', async () => {
+    // "LineCount" is exactly the shape that broke: the name heuristic says Int32,
+    // the EDT chain says Int64. The EDT must win.
+    const symbolIndex = createEdtChainStub({ LineCount: 'Int64' });
+
+    const result = await handleGenerateSmartReport(
+      { name: 'DemoNoteReportMulti', fieldsHint: 'LineCount', modelName: 'MyModel' } as any,
+      symbolIndex
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('AxTableFieldInt64');
+    expect(text).not.toContain('AxTableFieldInt<');
+    expect(text).not.toContain('"AxTableFieldInt"');
+  });
+
+  it('derives the dataset/RDL type from the same primitive as the table field', async () => {
+    const symbolIndex = createEdtChainStub({ LineCount: 'Int64' });
+
+    const result = await handleGenerateSmartReport(
+      { name: 'DemoNoteReportMulti', fieldsHint: 'LineCount', modelName: 'MyModel' } as any,
+      symbolIndex
+    );
+
+    const text = result.content[0].text as string;
+    // The half that used to stay System.String while the table field went Int32.
+    // Anchored on the field itself — System.String legitimately appears elsewhere in the
+    // RDL boilerplate, so a bare not-toContain would assert something untrue.
+    expect(text).toMatch(/<Name>LineCount<\/Name>[\s\S]{0,300}?System\.Int64/);
+    expect(text).not.toMatch(/<Name>LineCount<\/Name>[\s\S]{0,300}?System\.String/);
+  });
+});


### PR DESCRIPTION
Follow-up to #777, which recorded `L4-ssrs-report-multidataset` as PASS-with-draft-golden
because `scaffold:report` never consulted the EDT index. This is that fix — plus the fix
for a regression the first attempt introduced, which the eval loop itself caught.

## 1. `scaffold:report` ignored the EDT index (`b3d7856`)

`suggestEdtFromFieldName()` in `generateSmartReport.ts` was a private hardcoded keyword
ladder ending in `return 'String255'` that never touched the DB — while its own doc comment
claimed it was *"shared with generateSmartTable"* and the tool schema documents `fieldsHint`
identically for `scaffold:table` and `scaffold:report`: *"EDTs auto-suggested from the
index"*. Only the table side actually hit the index.

On the VM, `prepare(mode="create")` resolved `NoteId`, `Subject` and `LineCount` to real
EDTs while the report writer emitted `String255` for all three. Worst case is a count
becoming a string: `AxReportDataSetField/DataType` turns into `System.String`, killing SSRS
numeric formatting and aggregation and forcing the DP to wrap the aggregate in `int642Str()`.

Now delegates to `generateSmartTable`'s `resolveBestEdt` (`edt_metadata` exact → canonical →
fuzzy with confidence), which itself falls back to that module's heuristic ladder — a
superset of the one deleted here.

## 2. …which exposed an unreconciled type triple (`b6f50c9`)

Sharing that one function was **not enough**. `generateSmartReport` carried its OWN
duplicate `resolveEdtBaseType`, whose comment also claimed it was *"same as
generateSmartTable"*. It was not:

| | root EDT, no `string_size` |
| --- | --- |
| shared copy (`generateSmartTable`) | returns `undefined` — the index stores `extends=null` for `AxEdtInt64`/`Date`/`Real`/`String` alike, so the primitive is genuinely unknowable from SQL |
| local copy (`generateSmartReport`) | collapsed it to `'String'` |

The shared copy even carries a comment calling that case *"the #1 scaffold turned my
date/amount field into a string bug"*.

Consequence: `resolveFieldType()` mapped the bogus `'String'` to `undefined`, so
`SmartXmlBuilder.getAxTableFieldType()` fell through to its **EDT-name heuristic**
(`includes('count')` → `AxTableFieldInt`, Int32) over `PurchLineCount`, which extends the
Int64 root EDT `NumberOfRecords`:

```
Metadata Error: AxTable/ConDemoNoteReportMultiSummaryTmp/Fields/LineCount/ExtendedDataType:
                Data type mismatch.
Errors: 1
```

Meanwhile `AxReportDataSetField/DataType` and the RDL `rd:TypeName` stayed `System.String`.
The resolved EDT, the table field type and the dataset type were computed independently and
were wrong in **opposite directions**.

There is now **one primitive per EDT**, cached and shared by all three consumers, resolved
`bridge → index → heuristic` exactly as `generateSmartTable`'s field pass already did — only
the live `IMetadataProvider` can read a root EDT's primitive off the AxEdt itself.
`handleGenerateSmartReport` takes the bridge (`generateSmart.ts` passes `ctx.bridge`, as the
table handler already did) and the field passes are async. The three mappers can no longer
disagree because they read one value.

## Why this took two commits

Worth recording, because it is a repeatable trap in this codebase: a `// same as X` comment
was false **twice in the same file, one function apart**. Unifying the first without checking
its neighbour produced a build break that unit tests and `validate_code` both missed —
`validate_code` was clean in *both* modes; only a full build caught it. The same
unreconciled pair exists on the table path when no bridge is available, so `scaffold:table`
was latently exposed to the identical break; that is why the fix lives in shared code.

## Verification

- 1686 tests green across `tests/tools/` + `tests/utils/`, including 4 new regression tests:
  two locking index-backed EDT resolution, two locking that the table field `i:type` and the
  dataset/RDL type derive from the same primitive (`Int64` EDT → `AxTableFieldInt64` +
  `System.Int64`, never Int32).
- Evidence: `eval/corpus/runs/2026-07-28T06__L4-ssrs-report-multidataset__b3d7856.json`
  (included here) is the run that caught the regression at step 0, before it could freeze a
  golden over broken output.

## Status — verified on the compiler

The end-to-end VM re-capture of `L4-ssrs-report-multidataset` against `b6f50c9` has now run,
and this PR carries its result (`baea8eb`). Measured on the VM, not inferred:

- **Full build of `Contoso`: `Errors: 0`**, elapsed `00:01:37`. This is precisely the step
  `b3d7856` failed on with the `Data type mismatch` above.
- **Golden re-captured and frozen**, `golden_pending: false`:
  `LineCount/@type` `AxTableFieldString` → `AxTableFieldInt64`,
  `ExtendedDataType` `String255` → `PurchLineCount`,
  `AxReportDataSetField/DataType` `System.String` → `System.Int64`.
- **Oracle negative test** — re-injecting the exact regression shape into the scored
  artifacts fails `eval:score` on exactly those two paths and nothing else
  (`0 missing, 0 extra, 2 changed`), so the golden genuinely discriminates and neither path
  is swallowed by the case's `ignore` list.
- **BP per object with an explicit `targetFilter`: 10 warnings, 0 errors** (a filterless
  `run_bp_check` mints a false clean). Up from 8 purely because `NoteId` now resolves to a
  real EDT carrying a relation instead of the inert `String255`.
- Sandbox rolled back: the `Contoso` model is back to its 4 baseline files,
  `ContosoDemo.rnrproj` back to 3 balanced `<Content>` blocks, no `XppMetadata` leftovers.

**Coverage: core 43/43 (100%), total 64 → 65/77 (84.4%)** — the Multi-dataset SSRS leaf is
closed by this PR rather than a follow-up.

### Recorded, but deliberately NOT frozen as correct

`NoteId` resolves to **`PlCorrNoteId`**, a Polish-localization EDT, via `resolveBestEdt`'s
fuzzy path. This is not a resolver defect — the index holds no EDT literally named `NoteId`
and the entire candidate list is fuzzy/localization noise (`RefRecId` 0.85 via the
"ends with Id" heuristic, then `PlCorrNoteId` 0.84, `CustDebitNoteId` 0.81, …) — and
`PlCorrNoteId` extends `Num`, so the primitive is right and the build is clean. But it drags
in a country-specific EDT carrying an EDT relation, which is where 2 of the 10 BP warnings
come from. How fuzzy candidates rank against localization suffixes deserves its own improver
pass; it is documented in the golden's README so the next reader does not mistake it for a
vetted choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcXx5YZHTQ7fCHSSGevm7c
