### PR TITLE
eval: close the data-entity-extension leaf, re-capture the advanced SSRS golden

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://img.shields.io/badge/tests-1400%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
-[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-84.4%25-lightgrey.svg)](eval/COVERAGE.md)
+[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-85.7%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -9,7 +9,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
 | core | 43 | 43 | **100%** |
-| total | 65 | 77 | 84.4% |
+| total | 66 | 77 | 85.7% |
 
 ## Data model (12/12)
 
@@ -96,12 +96,12 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Warehouse management (WHS) | total | ✅ | — | ✅ | Eval case authored for the X++ half (work creation through the WHS framework); templates/directives stay configured data. Golden pending VM capture. |
 | Trade agreements & pricing | total | ✅ | — | ✅ | Eval case authored (PriceDisc price/discount resolution); golden pending VM capture. |
 
-## Integration (4/9)
+## Integration (5/9)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | Data entity (OData) | core | ✅ | ✅ | ✅ | L4-entity-security |
-| Data entity extension | total | ✅ | — | ✅ | Eval case authored (table extension field surfaced on a standard entity); golden pending VM capture. |
+| Data entity extension | total | ✅ | ✅ | ✅ | L3-data-entity-extension-field |
 | Custom services / OData actions | core | ✅ | ✅ | ✅ | L3-custom-service-basic |
 | Data management framework (DMF/DIXF) | total | ✅ | — | ✅ | Eval case authored (import-ready entity + staging hook); golden pending VM capture. |
 | Dual-write (Dataverse) | total | ✅ | — | ✅ | Eval case authored for the AOT half (business key + change tracking); the dual-write map itself is UI-authored. Golden pending VM capture. |
@@ -132,7 +132,6 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 
 | Weight | Leaf | Missing |
 | ---: | --- | --- |
-| 2 | Data entity extension | missing E |
 | 2 | Data management framework (DMF/DIXF) | missing E |
 | 2 | Dual-write (Dataverse) | missing E |
 | 2 | Parallel batch processing | missing E |

--- a/eval/cases/L3-data-entity-extension-field.json
+++ b/eval/cases/L3-data-entity-extension-field.json
@@ -2,13 +2,13 @@
   "id": "L3-data-entity-extension-field",
   "title": "Data entity extension: surface a table-extension field on an existing entity",
   "tier": 3,
-  "instruction": "In the sandbox model, extend an existing data entity without editing it. Ground it first with get_knowledge(topic=\"data-entities\"). Create: (1) a table extension over CustTable adding one field DemoLoyaltyCode (String, EDT Name) with the sandbox model's prefix; (2) a data entity extension over the standard CustCustomerV3Entity (d365fo_file objectType \"data-entity-extension\") adding a mapped field that binds DemoLoyaltyCode to the entity's CustTable data source, so the field is exposed over OData. Use extension_info/get_object_info to confirm the entity's data-source name before writing the mapped field - a wrong DataSource value compiles but breaks at runtime. Creating a new entity instead of extending the standard one FAILS this case. Both objects must build with zero BP errors.",
+  "instruction": "In the sandbox model, extend an existing data entity without editing it. Ground it first with get_knowledge(topic=\"data-entities\"). Create: (1) a table extension over CustTable adding one field DemoLoyaltyCode (String, EDT Name) with the sandbox model's prefix; (2) a data entity extension over the standard CustCustomerV3Entity (d365fo_file objectType \"data-entity-extension\") adding a mapped field that binds DemoLoyaltyCode to the entity's CustTable data source, so the field is exposed over OData. Use extension_info/get_object_info to confirm the entity's data-source name before writing the mapped field - a wrong DataSource value is a hard compile error (verified twice on xppc 7.0.7858.27), so read it off the base entity rather than guessing from the entity name. Creating a new entity instead of extending the standard one FAILS this case. Both objects must build clean; note that xppbp cannot check an AxDataEntityViewExtension at all (no such element type), so BP evidence covers only the table extension.",
   "target_artifact_types": [
     "AxTableExtension",
     "AxDataEntityViewExtension"
   ],
   "golden_path": "eval/goldens/L3-data-entity-extension-field/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/corpus/runs/2026-07-28T09__L3-data-entity-extension-field__ce4fc57.json
+++ b/eval/corpus/runs/2026-07-28T09__L3-data-entity-extension-field__ce4fc57.json
@@ -1,0 +1,36 @@
+{
+  "run_id": "2026-07-28T09__L3-data-entity-extension-field__ce4fc57",
+  "case_id": "L3-data-entity-extension-field",
+  "tier": 3,
+  "timestamp": "2026-07-28T09:59:26.990Z",
+  "server_git_sha": "ce4fc57",
+  "generated_artifacts": [
+    "CustCustomerV3Entity.ConExtension.metadata.xml",
+    "CustTable.ConExtension.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": false,
+    "bpWarnings": null
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": null,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "PASS"
+}

--- a/eval/corpus/runs/2026-07-28T09__L4-ssrs-report-advanced__ce4fc57.json
+++ b/eval/corpus/runs/2026-07-28T09__L4-ssrs-report-advanced__ce4fc57.json
@@ -1,0 +1,48 @@
+{
+  "run_id": "2026-07-28T09__L4-ssrs-report-advanced__ce4fc57",
+  "case_id": "L4-ssrs-report-advanced",
+  "tier": 4,
+  "timestamp": "2026-07-28T09:41:34.500Z",
+  "server_git_sha": "ce4fc57",
+  "generated_artifacts": [
+    "ConDemoNoteReportAdv.menuitem.metadata.xml",
+    "ConDemoNoteReportAdv.metadata.xml",
+    "ConDemoNoteReportAdvContract.metadata.xml",
+    "ConDemoNoteReportAdvController.metadata.xml",
+    "ConDemoNoteReportAdvDP.metadata.xml",
+    "ConDemoNoteReportAdvTmp.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "PASS"
+}

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -8,8 +8,8 @@
   "total": {
     "tier": "all",
     "total": 77,
-    "covered": 65,
-    "percent": 84.4
+    "covered": 66,
+    "percent": 85.7
   },
   "leaves": [
     {
@@ -954,10 +954,12 @@
       "tier": "total",
       "weight": 2,
       "k": true,
-      "e": false,
+      "e": true,
       "t": true,
-      "covered": false,
-      "cases": []
+      "covered": true,
+      "cases": [
+        "L3-data-entity-extension-field"
+      ]
     },
     {
       "id": "custom-service",

--- a/eval/goldens/L3-data-entity-extension-field/CustCustomerV3Entity.ConExtension.metadata.xml
+++ b/eval/goldens/L3-data-entity-extension-field/CustCustomerV3Entity.ConExtension.metadata.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <AxDataEntityViewExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 	<Name>CustCustomerV3Entity.ConExtension</Name>
 	<DataSources />

--- a/eval/goldens/L3-data-entity-extension-field/README.md
+++ b/eval/goldens/L3-data-entity-extension-field/README.md
@@ -1,66 +1,108 @@
-# Golden: L3-data-entity-extension-field — CAPTURED BUT `golden_pending` STAYS TRUE
+# Golden: L3-data-entity-extension-field — FROZEN
 
-Captured 2026-07-27 on the VM (xppc 7.0.7858.27). Build green, `run_bp_check` 0 errors
-and 0 case-scope warnings for BOTH artifacts.
+`golden_pending: false`. Re-captured 2026-07-28 on the VM (xppc 7.0.7858.27) after the
+extension writer landed in PR #776. Full build: `Errors: 0`.
 
-## Why `golden_pending` is NOT cleared — fix first, capture second
+The previous draft was held back under **fix first, capture second**: the entity extension
+had no grounded tool path at all, so the only way to produce it was hand-written XML.
+That is no longer true — both artifacts below are now verbatim tool output.
 
-`CustTable.ConExtension.metadata.xml` is verbatim tool output
-(`d365fo_file(action="create", objectType="table-extension")`, bridge
-`IMetaTableExtensionProvider.Create`). It matches the standard AxTableExtension
-vocabulary exactly (12/12 elements; 961/963 standard AxTableExtension files carry the
-same six mandatory ones). Nothing pending here.
+## What changed since the draft
 
-`CustCustomerV3Entity.ConExtension.metadata.xml` is the CORRECTED shape — **no grounded
-tool path can produce it today**:
+`CustCustomerV3Entity.ConExtension.metadata.xml` is now produced by
+`d365fo_file(action="create", objectType="data-entity-extension", properties.fields=[…])`
+and is **byte-identical to the hand-corrected shape the draft carried** (the only delta was
+a stray UTF-8 BOM on the hand-written file; no shipped `AxDataEntityViewExtension`, and no
+other file this tool writes, carries one).
 
-* `d365fo_file(action="create", objectType="data-entity-extension")` routes to
-  `GenerateD365XmlTool.generateAxSimpleExtensionXml('AxDataEntityViewExtension', name)`
-  (`src/tools/generateD365Xml.ts:1035`, `:1109`). That helper takes only `(rootElement, name)`
-  — it **ignores `properties` entirely** and emits a 4-line stub:
-  `<Name>` + `<PropertyModifications />`. The `fields` spec is dropped silently, with a
-  success banner and `⛔ TASK COMPLETE`.
-* `d365fo_file(action="modify", objectType="data-entity-extension", operation="add-field")`
-  → `Operation 'add-field' on object type 'data-entity-extension' is not supported by the bridge.`
+Before PR #776 that call routed to `generateAxSimpleExtensionXml(rootElement, name)`, which
+took no `properties` and emitted a 2-element stub (`Name` + `PropertyModifications`) behind a
+success banner. `d365fo_file(action="modify", …, operation="add-field")` was not supported by
+the bridge for this type, so there was no repair route either.
 
-So the only route to a working entity extension is hand-written XML / `overwrite=true` —
-the escape hatch the loop forbids. Refresh this golden (and drop `golden_pending`) once the
-writer emits the mapped field.
+`CustTable.ConExtension.metadata.xml` is unchanged — it was already verbatim tool output.
 
-## Ground truth the golden was checked against
+## Grounding the DataSource value
 
-Element census over all 396 `AxDataEntityViewExtension` files in
-`K:\AosService\PackagesLocalDirectory`: `Name` 395/396, `FieldGroupExtensions` 395,
-`Relations`/`PropertyModifications`/`Fields`/`DataSources` 394, `FieldGroups` 392,
-`Mappings` 388, `FieldModifications` 368. The stub emits 2 of those 9; the golden emits all 9.
-Reference file for the mapped-field shape:
+`<DataSource>CustTable</DataSource>` is the entity's ROOT data-source **name**, read from
+`ApplicationSuite\Foundation\AxDataEntityView\CustCustomerV3Entity.xml`:
+`ViewMetadata/DataSources/AxQuerySimpleRootDataSource/Name = CustTable` (Table = `CustTable`).
+It was not inferred from the entity name.
+
+Reference for the mapped-field shape:
 `ApplicationSuite\Foundation\AxDataEntityViewExtension\BankAccountEntity.CH_QRBill_Extension.xml`
 (`AxDataEntityViewField` with `i:type="AxDataEntityViewMappedField"`, Name/DataField/DataSource).
+Element census over all 396 `AxDataEntityViewExtension` files: `Name` 395/396,
+`FieldGroupExtensions` 395, `Relations`/`PropertyModifications`/`Fields`/`DataSources` 394,
+`FieldGroups` 392, `Mappings` 388, `FieldModifications` 368. The golden emits all 9.
 
-## The DataSource value, and the case's silent-failure premise
+## Oracle negative tests (this golden discriminates)
 
-`<DataSource>CustTable</DataSource>` is the entity's ROOT data source **name**, read from
-`ApplicationSuite\Foundation\AxDataEntityView\CustCustomerV3Entity.xml`:
-`ViewMetadata/DataSources/AxQuerySimpleRootDataSource/Name = CustTable` (Table = CustTable).
-It was NOT inferred from the entity name.
+Both re-verified against the frozen golden:
 
-NEGATIVE TESTS (each a real xppc full build) show the case instruction's premise —
-"a wrong DataSource value compiles but breaks at runtime" — is **FALSE on this build**:
+| Injected shape | `eval:score` result |
+|---|---|
+| `DataSource` → `DirPartyBaseEntity` (a real but wrong data source) | `1 changed` — the `DataSource` path alone |
+| the pre-fix 2-element stub | `4 missing` — `@type`, `Name`, `DataField`, `DataSource` of the mapped field |
 
-* `DataSource=CustGroup` (real table, not a data source of this entity) →
-  `Metadata Error: .../Fields/ConDemoLoyaltyCode/DataSource: Data source 'CustGroup' does not
-  exist or is not part of the first root data source in the query.`
-* `DataSource=DirPartyBaseEntity` (a REAL nested data source of this entity, wrong one) →
-  `Metadata Error: .../Fields/ConDemoLoyaltyCode/DataField: Field 'ConDemoLoyaltyCode' does not
-  exist on data source 'DirPartyBaseEntity'.`
+## The case instruction's premise was wrong — corrected
 
-Both flavours are compile-detected. The case text should be corrected.
+The case used to say a wrong `DataSource` "compiles but breaks at runtime". On xppc
+7.0.7858.27 it is a **hard compile error**, re-confirmed on this run with a real full build:
+
+```
+Metadata Error: AxDataEntityViewExtension/CustCustomerV3Entity.ConExtension/Fields/
+                ConDemoLoyaltyCode/DataField:
+                Field 'ConDemoLoyaltyCode' does not exist on data source 'DirPartyBaseEntity'.
+Errors: 1
+```
+
+(The 2026-07-27 draft additionally recorded `DataSource=CustGroup` — a table that is not a
+data source of this entity at all — failing with
+`Data source 'CustGroup' does not exist or is not part of the first root data source in the query.`)
+The instruction text has been corrected accordingly.
+
+## BP coverage is genuinely partial — `bp_clean: null`, not 0
+
+`run_bp_check` was run per object with an explicit `targetFilter`:
+
+| Target | Element type | Result |
+|---|---|---|
+| `CustTable.ConExtension` | `tableextension` | 0 warnings, 0 errors |
+| `CustCustomerV3Entity.ConExtension` | `dataentityviewextension` | **not checkable** |
+
+xppbp has no `DataEntityViewExtension` element type. Its supported list is Class, Table, Form,
+View, Enum, ExtendedDataType, Menu, ConfigurationKey, LicenseCode, Macro, Map, Query, Service,
+ServiceGroup, MenuItem{Display,Action,Output}, SecurityPrivilege, Infopart, IgnoreList, Report,
+AggregateDimension, AggregateMeasurement, SecurityRole, DataEntityView, AggregateDataEntity,
+SecurityDuty, CompositeDataEntityView, **TableExtension, FormExtension, MenuExtension** — entity
+view extensions are absent. Targeting the merged base entity instead
+(`DataEntityView:CustCustomerV3Entity`) also fails: xppbp runs scoped to the sandbox model and
+the base entity lives in `Foundation` (`DataEntityView 'CustCustomerV3Entity' not found`).
+
+Since the artifact under test is precisely the one xppbp cannot see, the corpus record carries
+`bp_clean: null` (BP not checked) rather than a `0` that would mint a false clean for the case
+as a whole.
+
+**Tool defect found while measuring this:** `run_bp_check` with an unsupported
+`targetElementType` returns the banner `✅ BP Check passed` with `Warnings: 0 / Errors: 0`,
+while the body of the same response says `The element type 'dataentityviewextension' is
+invalid.` Nothing was checked. This is the same false-clean class as the already-documented
+filterless `run_bp_check`.
+
+## Other observation
+
+`d365fo_file(action="create")` auto-applies `EXTENSION_PREFIX` to **objectName only**, never to
+`properties.fields[].name`. Passing `DemoLoyaltyCode` yields `CustTable.ConExtension` (prefixed)
+containing an **unprefixed** field `DemoLoyaltyCode` — which in a real model is a cross-model
+collision risk, since extension fields must be prefixed. The caller has to hand-build the field
+prefix (`ConDemoLoyaltyCode`) even though the tool documents "NEVER hand-build the prefix" for
+object names.
 
 ## Descriptor prerequisite (not part of the golden)
 
 Extending `CustCustomerV3Entity` forces xppc to validate the WHOLE merged entity inside the
-sandbox model's reference closure. `Contoso\Descriptor\Contoso.xml` needed two ModuleReferences
-added — `Dimensions` (owns `DimensionSetEntity`) and `PersonnelCore` (owns EDT
-`HcmPersonnelNumberId`) — otherwise the build fails with 6 metadata errors attributed to
-`AxDataEntityViewExtension/CustCustomerV3Entity.ConExtension/...` even though the extension
-itself names neither type.
+sandbox model's reference closure. `Contoso\Descriptor\Contoso.xml` needs the ModuleReferences
+`Dimensions` (owns `DimensionSetEntity`) and `PersonnelCore` (owns EDT `HcmPersonnelNumberId`);
+without them the build fails with 6 metadata errors attributed to this extension even though it
+names neither type. Both were already present for this run.

--- a/eval/goldens/L4-ssrs-report-advanced/ConDemoNoteReportAdvTmp.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-advanced/ConDemoNoteReportAdvTmp.metadata.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Golden for L4-ssrs-report-advanced (1 of 6): tmp table, generated via generate_object(scaffold, report, contractParams=[...]). Captured 2026-07-01, SHA 6e53a07. -->
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L4-ssrs-report-advanced (1 of 6): tmp table, generated via generate_object(scaffold, report, contractParams=[...]). Captured 2026-07-01, SHA 6e53a07. Re-captured 2026-07-28 after b3d7856+b6f50c9 taught scaffold:report to consult the EDT index: NoteId and Subject were String255 (the hardcoded fallback), they are now PlCorrNoteId and smmSubject. Those two ExtendedDataType values are the ONLY structural delta across all 6 artifacts. -->
 <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 	<Name>ConDemoNoteReportAdvTmp</Name>
 	<SourceCode>
@@ -65,12 +65,12 @@ public class ConDemoNoteReportAdvTmp extends common
 		<AxTableField xmlns=""
 				i:type="AxTableFieldString">
 			<Name>NoteId</Name>
-			<ExtendedDataType>String255</ExtendedDataType>
+			<ExtendedDataType>PlCorrNoteId</ExtendedDataType>
 		</AxTableField>
 		<AxTableField xmlns=""
 				i:type="AxTableFieldString">
 			<Name>Subject</Name>
-			<ExtendedDataType>String255</ExtendedDataType>
+			<ExtendedDataType>smmSubject</ExtendedDataType>
 		</AxTableField>
 	</Fields>
 	<FullTextIndexes />


### PR DESCRIPTION
Two VM runs, both rolled back afterwards. No source changes — this is eval data plus one
corrected case instruction.

## 1. `L3-data-entity-extension-field` — leaf CLOSED

This is the case PR #776 was written to unblock, and it now passes through the grounded path.

Before #776, `d365fo_file(action="create", objectType="data-entity-extension")` routed to
`generateAxSimpleExtensionXml(rootElement, name)`, which took no `properties` and emitted a
2-element stub (`Name` + `PropertyModifications`) behind a success banner and a
`⛔ TASK COMPLETE`. `modify` had no repair route either (`add-field` unsupported by the bridge
for this type). The only way to a working entity extension was hand-written XML — the escape
hatch the loop forbids — so the golden stayed `golden_pending` under **fix first, capture
second**.

The writer now emits the full 9-container shape with the mapped field, and its output is
**byte-identical to the hand-corrected draft**. The only delta was a stray UTF-8 BOM on the
hand-written file; no shipped `AxDataEntityViewExtension` carries one, so the frozen golden
drops it.

Measured on the VM:

- **Full build `Errors: 0`**, with `Metadata: validate data entity view extensions` running.
- **Oracle negative tests** — the golden discriminates the exact regressions it exists to catch:

  | Injected shape | `eval:score` |
  |---|---|
  | `DataSource` → `DirPartyBaseEntity` (real but wrong data source) | `1 changed` — the `DataSource` path alone |
  | the pre-fix 2-element stub | `4 missing` — `@type`, `Name`, `DataField`, `DataSource` |

- `<DataSource>CustTable</DataSource>` was read off the base entity's
  `ViewMetadata/DataSources/AxQuerySimpleRootDataSource/Name`, not guessed from the entity name.

### The case instruction was factually wrong — corrected here

It told the agent a wrong `DataSource` "compiles but breaks at runtime". On xppc 7.0.7858.27 it
is a **hard compile error**, re-confirmed on this run with a real full build:

```
Metadata Error: AxDataEntityViewExtension/CustCustomerV3Entity.ConExtension/Fields/
                ConDemoLoyaltyCode/DataField:
                Field 'ConDemoLoyaltyCode' does not exist on data source 'DirPartyBaseEntity'.
Errors: 1
```

### BP is `null`, not `0` — deliberately

`run_bp_check` per object with an explicit `targetFilter`:

| Target | Element type | Result |
|---|---|---|
| `CustTable.ConExtension` | `tableextension` | 0 warnings, 0 errors |
| `CustCustomerV3Entity.ConExtension` | `dataentityviewextension` | **not checkable** |

xppbp has no `DataEntityViewExtension` element type (it supports `TableExtension`,
`FormExtension`, `MenuExtension` — entity view extensions are absent), and targeting the merged
base entity fails too, because xppbp runs scoped to the sandbox model while
`CustCustomerV3Entity` lives in `Foundation`. The artifact under test is precisely the one BP
cannot see, so the record carries `bp_clean: null` rather than a `0` that would mint a false
clean for the case as a whole.

### Two tool observations, recorded not fixed

- **`run_bp_check` false clean on an unsupported element type.** It returns the banner
  `✅ BP Check passed` with `Warnings: 0 / Errors: 0` while the body of the *same* response says
  `The element type 'dataentityviewextension' is invalid.` Nothing was checked. Same class as
  the already-documented filterless false clean.
- **`create` prefixes `objectName` but never `properties.fields[].name`.** Passing
  `DemoLoyaltyCode` produced a correctly prefixed `CustTable.ConExtension` containing an
  **unprefixed** field. Extension fields must be prefixed to avoid cross-model collisions, so the
  caller has to hand-build the very prefix the tool documents as "NEVER hand-build".

## 2. `L4-ssrs-report-advanced` — golden re-captured

This leaf was already closed, but its golden still froze the pre-fix `String255` shape. Re-run
against `b3d7856`+`b6f50c9`: `NoteId` → `PlCorrNoteId`, `Subject` → `smmSubject`.

Those two `ExtendedDataType` values are the **only** structural delta across all 6 artifacts —
Contract, Controller, DP, menu item and AxReport are untouched, and the dataset `DataType` stays
`System.String` because both EDTs are string-rooted (unlike the multidataset case's Int64
`LineCount`). Full build `Errors: 0`; the oracle negative test flips exactly those two paths;
BP 7 warnings / 0 errors.

`L4-ssrs-report-basic` deliberately does **not** need this — it goes through the table path.

## Coverage

**core 43/43 (100%), total 65 → 66/77 (85.7%).** Closure queue down to 11 leaves.

## Sandbox

Both runs rolled back: the `Contoso` model is back to its 4 baseline files,
`ContosoDemo.rnrproj` back to 3 balanced `<Content>` blocks (verified well-formed), no
`XppMetadata` leftovers, no stray `.backup-*` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcXx5YZHTQ7fCHSSGevm7c
