### PR TITLE
fix(get_method): resolve methods inherited from a base class

### DIFF
--- a/src/tools/getMethodSource.ts
+++ b/src/tools/getMethodSource.ts
@@ -12,6 +12,7 @@ import type { XppServerContext } from '../types/context.js';
 import type { XppMetadataParser } from '../metadata/xmlParser.js';
 import { tryBridgeMethodSource } from '../bridge/bridgeAdapter.js';
 import { canonicalSymbolName } from '../utils/symbolLookup.js';
+import { inheritedOwnerCandidates } from '../utils/inheritanceChain.js';
 
 const GetMethodSourceArgsSchema = z.object({
   className: z.string().describe('Name of the class containing the method'),
@@ -43,6 +44,12 @@ export async function getMethodSourceTool(request: CallToolRequest, context: Xpp
     const xmlResult = await tryXmlMethodSource(context, className, methodName);
     if (xmlResult) return xmlResult;
 
+    // Inherited methods: both readers above see declared members only, so a
+    // class that inherits the method rather than declaring it would report a
+    // false "not found". Retry against the declaring ancestor.
+    const inherited = await tryInheritedMethodSource(context, className, methodName);
+    if (inherited) return inherited;
+
     // Bridge and XML both unavailable — try fuzzy name suggestions from SQLite
     let hint = '';
     try {
@@ -72,7 +79,7 @@ export async function getMethodSourceTool(request: CallToolRequest, context: Xpp
     return {
       content: [{
         type: 'text',
-        text: `❌ Method **${className}.${methodName}** not found.${hint}\n\nUse \`get_object_info(objectType="class", name="${className}")\` to see all available methods.`,
+        text: `❌ Method **${className}.${methodName}** not found — neither ${className} nor any class it extends declares it.${hint}\n\nUse \`get_object_info(objectType="class", name="${className}")\` to see all available methods.`,
       }],
       isError: true,
     };
@@ -101,6 +108,57 @@ function resolveClassName(context: XppServerContext, requested: string): string 
   } catch {
     return requested; // DB not available — bridge/XML may still resolve it
   }
+}
+
+/**
+ * Retry the bridge and XML readers against the ancestors of `className`, for a
+ * method the class inherits rather than declares. Returns the declaring class's
+ * source, annotated so the caller cannot mistake it for a declared member.
+ */
+async function tryInheritedMethodSource(
+  context: XppServerContext,
+  className: string,
+  methodName: string,
+): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean } | null> {
+  let rdb: any;
+  try {
+    rdb = context.symbolIndex.getReadDb();
+  } catch {
+    return null; // DB not available — no chain to walk
+  }
+
+  const bridgeUsable = Boolean(context.bridge?.isReady && context.bridge?.metadataAvailable);
+  for (const ancestor of inheritedOwnerCandidates(rdb, className, methodName, bridgeUsable)) {
+    const fromBridge = await tryBridgeMethodSource(context.bridge, ancestor, methodName);
+    if (fromBridge) return annotateInherited(fromBridge as any, className, ancestor, methodName);
+
+    const fromXml = await tryXmlMethodSource(context, ancestor, methodName);
+    if (fromXml) return annotateInherited(fromXml, className, ancestor, methodName);
+  }
+  return null;
+}
+
+/** Insert the "inherited from" note under the result's `## Class.method` heading. */
+function annotateInherited(
+  result: { content: Array<{ type: 'text'; text: string }>; isError?: boolean },
+  requestedClass: string,
+  declaringClass: string,
+  methodName: string,
+): { content: Array<{ type: 'text'; text: string }>; isError?: boolean } {
+  const note =
+    `\n> ℹ️ **Inherited method.** \`${requestedClass}\` does not declare \`${methodName}\` — ` +
+    `it inherits it from \`${declaringClass}\`, whose source is shown below.\n` +
+    `> For CoC, wrap it on \`${declaringClass}\`; the wrapper then runs for **every** subclass, ` +
+    `so guard the body with \`if (this is ${requestedClass})\` when only that one is meant.\n`;
+
+  const [first, ...rest] = result.content;
+  if (!first || typeof first.text !== 'string') return result;
+  // The readers open with "## <Class>.<method>"; keep the note directly under it.
+  const nl = first.text.indexOf('\n');
+  const text = nl === -1
+    ? `${first.text}\n${note}`
+    : `${first.text.slice(0, nl + 1)}${note}${first.text.slice(nl + 1)}`;
+  return { ...result, content: [{ ...first, text }, ...rest] };
 }
 
 /**

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -15,6 +15,7 @@ import type { BridgeClient } from '../bridge/bridgeClient.js';
 import type { XppMetadataParser } from '../metadata/xmlParser.js';
 import { parseXppDeclaration } from '../metadata/xppDeclaration.js';
 import { canonicalSymbolName } from '../utils/symbolLookup.js';
+import { inheritedOwnerCandidates } from '../utils/inheritanceChain.js';
 
 /** Object types that can own methods. */
 const OBJECT_TYPES = ['class', 'table', 'view', 'data-entity'] as const;
@@ -58,24 +59,7 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
     // here would scan every class/table/view row instead (~86k rows, 4–8 s warm).
     const className = canonicalSymbolName(rdb, args.className, OBJECT_TYPES) ?? args.className;
 
-    let classRow: any;
-    if (modelName) {
-      classRow = rdb.prepare(`
-        SELECT file_path, model, name, type
-        FROM symbols
-        WHERE type IN ${OBJECT_TYPES_SQL} AND name = ? AND model = ?
-        ORDER BY CASE type WHEN 'class' THEN 0 WHEN 'table' THEN 1 ELSE 2 END
-        LIMIT 1
-      `).get(className, modelName);
-    } else {
-      classRow = rdb.prepare(`
-        SELECT file_path, model, name, type
-        FROM symbols
-        WHERE type IN ${OBJECT_TYPES_SQL} AND name = ?
-        ORDER BY CASE type WHEN 'class' THEN 0 WHEN 'table' THEN 1 ELSE 2 END, model
-        LIMIT 1
-      `).get(className);
-    }
+    const classRow: any = loadOwnerRow(rdb, className, modelName);
 
     if (!classRow) {
       const typeMismatch = buildObjectTypeMismatchMessage(rdb, className);
@@ -118,6 +102,31 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
     );
     if (xmlSignature) return xmlSignature;
 
+    // 4. Inherited methods. Every reader above sees declared members only, so a
+    // class that inherits the method rather than declaring it reports a false
+    // "not found" — and for CoC that is the common case, because the class
+    // worth wrapping is usually a leaf. Retry the same readers against the
+    // declaring ancestor. Only when the class itself has no method row: if it
+    // does declare the method, its own (index-only) signature below is the
+    // right answer, not a base class's.
+    if (!methodRow) {
+      const bridgeUsable = Boolean(context.bridge?.isReady && context.bridge?.metadataAvailable);
+      for (const ancestor of inheritedOwnerCandidates(rdb, className, methodName, bridgeUsable)) {
+        const row: any = loadOwnerRow(rdb, ancestor);
+        const model = row?.model ?? classRow.model;
+
+        const inheritedBridge = await tryBridgeMethodSignature(
+          context.bridge, ancestor, methodName, model, includeCoc, className,
+        );
+        if (inheritedBridge) return inheritedBridge;
+
+        const inheritedXml = await tryXmlMethodSignature(
+          parser, row?.file_path, ancestor, methodName, model, includeCoc, row?.type, className,
+        );
+        if (inheritedXml) return inheritedXml;
+      }
+    }
+
     // Last resort: use SQLite signature column if available. No declaration is
     // parsed on this path, so the index's own `name` is the canonical spelling
     // to render rather than the caller's argument (#691).
@@ -151,7 +160,8 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
         content: [{
           type: 'text',
           text: `❌ Method **${className}.${methodName}** not found.\n\n` +
-            `The method is not in the symbol index and could not be retrieved via bridge or XML.\n` +
+            `Neither ${className} nor any class it extends declares it, and it could not be ` +
+            `retrieved via bridge or XML.\n` +
             `This is common for:\n` +
             `- **Delegate methods** (declared with the \`delegate\` keyword)\n` +
             `- **Event handler subscriptions** (\`[SubscribesTo]\` handlers in extension classes)\n\n` +
@@ -184,8 +194,38 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
 }
 
 /**
+ * Locate a method owner (class/table/view/data-entity) in the index. `name` is
+ * expected to be canonical, so this stays a BINARY probe on idx_name_type.
+ */
+function loadOwnerRow(rdb: any, name: string, modelName?: string): any {
+  try {
+    if (modelName) {
+      return rdb.prepare(`
+        SELECT file_path, model, name, type
+        FROM symbols
+        WHERE type IN ${OBJECT_TYPES_SQL} AND name = ? AND model = ?
+        ORDER BY CASE type WHEN 'class' THEN 0 WHEN 'table' THEN 1 ELSE 2 END
+        LIMIT 1
+      `).get(name, modelName);
+    }
+    return rdb.prepare(`
+      SELECT file_path, model, name, type
+      FROM symbols
+      WHERE type IN ${OBJECT_TYPES_SQL} AND name = ?
+      ORDER BY CASE type WHEN 'class' THEN 0 WHEN 'table' THEN 1 ELSE 2 END, model
+      LIMIT 1
+    `).get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Try C# bridge for method signature. Returns null to signal fallback when
  * the bridge is unavailable.
+ *
+ * `inheritedBy` is the class the caller asked about when it differs from
+ * `className` (the declaring class this call is reading).
  */
 async function tryBridgeMethodSignature(
   bridge: BridgeClient | undefined,
@@ -193,6 +233,7 @@ async function tryBridgeMethodSignature(
   methodName: string,
   modelName: string,
   includeCoc: boolean,
+  inheritedBy?: string,
 ): Promise<any | null> {
   if (!bridge?.isReady || !bridge.metadataAvailable) return null;
   try {
@@ -203,7 +244,7 @@ async function tryBridgeMethodSignature(
     if (!signature) return null;
 
     const obsoleteWarning = detectObsolete(ms.source);
-    const result = formatOutput(className, signature, modelName, includeCoc, obsoleteWarning);
+    const result = formatOutput(className, signature, modelName, includeCoc, obsoleteWarning, inheritedBy);
     return result;
   } catch (e) {
     console.error(`[methodSignature] Bridge getMethodSource(${className}, ${methodName}) failed: ${e}`);
@@ -223,6 +264,7 @@ async function tryXmlMethodSignature(
   modelName: string,
   includeCoc: boolean,
   objectType?: string,
+  inheritedBy?: string,
 ): Promise<any | null> {
   if (!parser || !filePath) return null;
   try {
@@ -243,7 +285,7 @@ async function tryXmlMethodSignature(
     if (!signature) return null;
 
     const obsoleteWarning = detectObsolete(method.source);
-    const result = formatOutput(className, signature, modelName, includeCoc, obsoleteWarning);
+    const result = formatOutput(className, signature, modelName, includeCoc, obsoleteWarning, inheritedBy);
     return result;
   } catch (e) {
     console.error(`[methodSignature] XML parse for ${className}.${methodName} failed: ${e}`);
@@ -412,10 +454,15 @@ function formatOutput(
   signature: MethodSignature,
   modelName: string,
   includeCocTemplate: boolean = false,
-  obsoleteWarning: string = ''
+  obsoleteWarning: string = '',
+  inheritedBy?: string
 ): any {
   let output = `# Method: \`${className}.${signature.methodName}\`\n`;
   output += `**Model:** ${modelName}  **Returns:** ${signature.returnType}  **Modifiers:** ${signature.modifiers.join(', ') || 'none'}\n`;
+  if (inheritedBy) {
+    output += `\n> ℹ️ **Inherited method.** \`${inheritedBy}\` does not declare \`${signature.methodName}\` — ` +
+      `it inherits it from \`${className}\`, which is where the signature below comes from.\n`;
+  }
   if (obsoleteWarning) output += obsoleteWarning + '\n';
   output += `\n\`\`\`xpp\n${signature.signature}\n\`\`\`\n`;
 
@@ -426,6 +473,11 @@ function formatOutput(
   if (includeCocTemplate) {
     output += `\n## Chain of Command Template\n\`\`\`xpp\n${signature.cocTemplate}\`\`\`\n`;
     output += `Replace \`OriginalClassName\` with \`${className}\`.\n`;
+    if (inheritedBy) {
+      output += `\n⚠️ Target \`${className}\` — the class that declares the method — not \`${inheritedBy}\`. ` +
+        `The wrapper then runs for **every** subclass of \`${className}\`; if the change is meant for ` +
+        `\`${inheritedBy}\` only, guard the body with \`if (this is ${inheritedBy})\`.\n`;
+    }
   } else {
     output += `\n> 💡 Pass \`includeCocTemplate: true\` to get the CoC extension template.\n`;
   }

--- a/src/utils/inheritanceChain.ts
+++ b/src/utils/inheritanceChain.ts
@@ -1,0 +1,108 @@
+/**
+ * Inheritance-chain helpers for method lookup.
+ *
+ * Every method reader probes the object the caller named: the bridge reads
+ * `Classes.Read(name).Methods`, the XML path parses that one file, and SQLite
+ * matches `parent_name = <name>`. All three see *declared* members only, so a
+ * method the class inherits reports a false "not found" — the CoC path hits
+ * this constantly, because the class worth wrapping is often a leaf whose
+ * interesting methods live on a base class (SalesFormLetter_Invoice does not
+ * declare `promptAndRun`; SalesFormLetter does).
+ *
+ * These helpers climb `symbols.extends_class` so a reader can retry against the
+ * class that actually declares the method. SQLite is the locator (indexed,
+ * sub-ms) and the bridge/XML stays the reader.
+ */
+
+import { lookupSymbolNocase, type DbLike } from './symbolLookup.js';
+
+/**
+ * Object types whose `extends_class` carries method inheritance. Tables are
+ * included for table inheritance (SupportInheritance/Extends); EDT `extends`
+ * is a type chain, not a method chain, so EDTs are deliberately absent.
+ */
+const INHERITING_TYPES = ['class', 'table'] as const;
+
+/**
+ * Depth cap. Real AOT chains are under ten (SalesFormLetter_Invoice → … →
+ * RunBase is five); the cap only bounds the damage from a cyclic
+ * `extends_class` in a corrupt index — a name-based cycle guard runs too.
+ */
+const MAX_DEPTH = 12;
+
+/**
+ * Ancestors of `name`, nearest first, in canonical (as-indexed) casing.
+ * The class itself is not included. Returns [] when the object is unknown,
+ * has no base, or the DB is unavailable.
+ */
+export function inheritanceAncestors(db: DbLike, name: string, maxDepth = MAX_DEPTH): string[] {
+  if (!name) return [];
+  const chain: string[] = [];
+  try {
+    const seen = new Set<string>([name.toLowerCase()]);
+    let current = lookupSymbolNocase(db, name, INHERITING_TYPES);
+    while (current?.extends_class && chain.length < maxDepth) {
+      const parentName = current.extends_class.trim();
+      if (!parentName || seen.has(parentName.toLowerCase())) break;
+      seen.add(parentName.toLowerCase());
+
+      const parent = lookupSymbolNocase(db, parentName, INHERITING_TYPES);
+      // Emit the base even when it is not indexed (e.g. a kernel class such as
+      // Object): the bridge may still be able to read it. Climbing stops there
+      // because there is no row to read the next `extends_class` from.
+      chain.push(parent?.name ?? parentName);
+      if (!parent) break;
+      current = parent;
+    }
+  } catch { /* DB error — treat as "no chain known" */ }
+  return chain;
+}
+
+/**
+ * Nearest ancestor of `className` that declares `methodName` according to the
+ * symbol index, or undefined when no ancestor does (or the index doesn't know).
+ *
+ * `className` itself is not probed — callers have already tried it directly.
+ *
+ * Index-safe: `parent_name = ?` stays BINARY on idx_parent_type_name (the
+ * ancestor names come back canonically cased from `inheritanceAncestors`), so
+ * `COLLATE NOCASE` applies only inside one object's already-narrow member range.
+ */
+export function findDeclaringAncestor(
+  db: DbLike,
+  className: string,
+  methodName: string,
+): string | undefined {
+  if (!className || !methodName) return undefined;
+  try {
+    const stmt = db.prepare(
+      `SELECT 1 AS x FROM symbols
+       WHERE type = 'method' AND parent_name = ? AND name = ? COLLATE NOCASE
+       LIMIT 1`,
+    );
+    for (const ancestor of inheritanceAncestors(db, className)) {
+      if (stmt.get(ancestor, methodName) !== undefined) return ancestor;
+    }
+  } catch { /* DB error — fall through to "unknown" */ }
+  return undefined;
+}
+
+/**
+ * Owners to retry a failed method read against, nearest ancestor first.
+ *
+ * When the index knows which ancestor declares the method, that is the only
+ * candidate — one extra read instead of a walk. Otherwise the answer depends on
+ * how expensive a miss is: the bridge answers in-process, so probing the whole
+ * chain is fine, but the XML path pays a file parse with a 3 s timeout per
+ * level, so an unlocated method is not worth walking blindly.
+ */
+export function inheritedOwnerCandidates(
+  db: DbLike,
+  className: string,
+  methodName: string,
+  bridgeAvailable: boolean,
+): string[] {
+  const declaring = findDeclaringAncestor(db, className, methodName);
+  if (declaring) return [declaring];
+  return bridgeAvailable ? inheritanceAncestors(db, className) : [];
+}

--- a/tests/tools/method-inheritance.test.ts
+++ b/tests/tools/method-inheritance.test.ts
@@ -1,0 +1,227 @@
+/**
+ * get_method against an inherited method, on a REAL in-memory symbol index
+ * built through the real extraction pipeline (parseClassFile → JSON →
+ * indexMetadataDirectory → tool).
+ *
+ * Regression: every reader behind get_method sees *declared* members only —
+ * the bridge reads `Classes.Read(name).Methods`, the XML path parses that one
+ * file, SQLite matches `parent_name = <name>`. Nothing walked `extends`, so a
+ * method the named class inherits came back as "not found" with no hint that it
+ * exists one level up. Verified on the VM before the fix:
+ * get_method("SalesFormLetter_Invoice", "promptAndRun") failed even though the
+ * direct parent SalesFormLetter declares it.
+ *
+ * The chain here is two levels deep on purpose — a fix that only consults the
+ * direct parent still fails the grandparent case.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { XppMetadataParser } from '../../src/metadata/xmlParser';
+import { getMethodSignatureTool } from '../../src/tools/methodSignature';
+import { getMethodSourceTool } from '../../src/tools/getMethodSource';
+import { inheritanceAncestors, findDeclaringAncestor } from '../../src/utils/inheritanceChain';
+import type { XppServerContext } from '../../src/types/context';
+
+const MODEL = 'MyCustomModel';
+
+let tmpDir: string;
+let index: XppSymbolIndex;
+let context: XppServerContext;
+
+const axClassXml = (
+  name: string,
+  declaration: string,
+  methods: Array<{ name: string; source: string }>,
+) => [
+  '<?xml version="1.0" encoding="utf-8"?>',
+  '<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">',
+  `  <Name>${name}</Name>`,
+  '  <SourceCode>',
+  `    <Declaration><![CDATA[${declaration}]]></Declaration>`,
+  '    <Methods>',
+  ...methods.flatMap(m => [
+    '      <Method>',
+    `        <Name>${m.name}</Name>`,
+    `        <Source><![CDATA[${m.source}]]></Source>`,
+    '      </Method>',
+  ]),
+  '    </Methods>',
+  '  </SourceCode>',
+  '</AxClass>',
+].join('\n');
+
+// C_Base ◄── B_Mid ◄── A_Leaf, each declaring one method of its own.
+const CLASSES = [
+  axClassXml('C_Base', 'public class C_Base\n{\n}', [
+    { name: 'baseOnly', source: 'public boolean baseOnly(str _reason)\n{\n    return true;\n}' },
+    { name: 'overridden', source: 'public int overridden()\n{\n    return 1;\n}' },
+  ]),
+  axClassXml('B_Mid', 'public class B_Mid extends C_Base\n{\n}', [
+    { name: 'midOnly', source: 'public void midOnly(int _qty)\n{\n}' },
+  ]),
+  axClassXml('A_Leaf', 'public class A_Leaf extends B_Mid\n{\n}', [
+    { name: 'leafOnly', source: 'public str leafOnly()\n{\n    return "leaf";\n}' },
+    { name: 'overridden', source: 'public int overridden()\n{\n    return 2;\n}' },
+  ]),
+];
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'method-inherit-'));
+  const aotDir = path.join(tmpDir, 'aot');
+  const metadataDir = path.join(tmpDir, 'extracted', MODEL, 'classes');
+  await fs.mkdir(aotDir, { recursive: true });
+  await fs.mkdir(metadataDir, { recursive: true });
+
+  const parser = new XppMetadataParser();
+  for (const xml of CLASSES) {
+    const name = /<Name>([^<]+)<\/Name>/.exec(xml)![1];
+    const file = path.join(aotDir, `${name}.xml`);
+    await fs.writeFile(file, xml, 'utf-8');
+
+    const parsed = await parser.parseClassFile(file, MODEL);
+    // sourcePath is what the indexer stores as file_path, and it is the file the
+    // XML fallback re-parses — it must point at the AxClass XML, not the JSON.
+    await fs.writeFile(
+      path.join(metadataDir, `${name}.json`),
+      JSON.stringify({ ...parsed.data, sourcePath: file }, null, 2),
+    );
+  }
+
+  index = new XppSymbolIndex(':memory:', ':memory:');
+  await index.indexMetadataDirectory(path.join(tmpDir, 'extracted'));
+  // No bridge: the XML fallback is the reader under test, which is also the
+  // configuration the tools run in off-VM.
+  context = { symbolIndex: index, parser, bridge: undefined } as unknown as XppServerContext;
+});
+
+afterAll(async () => {
+  index.close();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const sigReq = (args: Record<string, unknown>) => ({
+  method: 'tools/call' as const,
+  params: { name: 'get_method_signature', arguments: args },
+});
+const srcReq = (args: Record<string, unknown>) => ({
+  method: 'tools/call' as const,
+  params: { name: 'get_method_source', arguments: args },
+});
+
+describe('inheritance chain helpers', () => {
+  it('walks past the direct parent', () => {
+    expect(inheritanceAncestors(index.getReadDb(), 'A_Leaf')).toEqual(['B_Mid', 'C_Base']);
+  });
+
+  it('canonicalizes a mis-cased start name', () => {
+    expect(inheritanceAncestors(index.getReadDb(), 'a_leaf')).toEqual(['B_Mid', 'C_Base']);
+  });
+
+  it('returns [] for a class with no base', () => {
+    expect(inheritanceAncestors(index.getReadDb(), 'C_Base')).toEqual([]);
+  });
+
+  it('locates the nearest ancestor declaring a method', () => {
+    const db = index.getReadDb();
+    expect(findDeclaringAncestor(db, 'A_Leaf', 'midOnly')).toBe('B_Mid');
+    expect(findDeclaringAncestor(db, 'A_Leaf', 'baseOnly')).toBe('C_Base');
+    // Declared on A_Leaf itself — ancestors are not consulted for it here, but
+    // C_Base also declares it, so "nearest ancestor" must be reported honestly.
+    expect(findDeclaringAncestor(db, 'A_Leaf', 'overridden')).toBe('C_Base');
+    expect(findDeclaringAncestor(db, 'A_Leaf', 'noSuchMethod')).toBeUndefined();
+  });
+});
+
+describe('get_method(include="signature") on inherited methods', () => {
+  it('finds a method declared on the direct parent', async () => {
+    const result = await getMethodSignatureTool(
+      sigReq({ className: 'A_Leaf', methodName: 'midOnly' }),
+      context,
+    );
+    const text = result.content?.[0]?.text ?? '';
+    expect(result.isError).toBeFalsy();
+    expect(text).toContain('void midOnly(int _qty)');
+    expect(text).toContain('Inherited method');
+    expect(text).toContain('B_Mid');
+  });
+
+  it('finds a method declared two levels up', async () => {
+    const result = await getMethodSignatureTool(
+      sigReq({ className: 'A_Leaf', methodName: 'baseOnly' }),
+      context,
+    );
+    const text = result.content?.[0]?.text ?? '';
+    expect(result.isError).toBeFalsy();
+    expect(text).toContain('boolean baseOnly(str _reason)');
+    expect(text).toContain('C_Base');
+  });
+
+  it('points the CoC template at the declaring class, not the named one', async () => {
+    const result = await getMethodSignatureTool(
+      sigReq({ className: 'A_Leaf', methodName: 'baseOnly', includeCocTemplate: true }),
+      context,
+    );
+    const text = result.content?.[0]?.text ?? '';
+    expect(text).toContain('Replace `OriginalClassName` with `C_Base`');
+    expect(text).toContain('if (this is A_Leaf)');
+  });
+
+  it('prefers the class itself over an ancestor that also declares the method', async () => {
+    const result = await getMethodSignatureTool(
+      sigReq({ className: 'A_Leaf', methodName: 'overridden' }),
+      context,
+    );
+    const text = result.content?.[0]?.text ?? '';
+    expect(text).toContain('A_Leaf.overridden');
+    expect(text).not.toContain('Inherited method');
+  });
+
+  it('still reports a method that exists nowhere in the chain', async () => {
+    const result = await getMethodSignatureTool(
+      sigReq({ className: 'A_Leaf', methodName: 'noSuchMethod' }),
+      context,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not found/i);
+  });
+});
+
+describe('get_method(include="source") on inherited methods', () => {
+  it('returns the declaring class source, annotated', async () => {
+    const result = await getMethodSourceTool(
+      srcReq({ className: 'A_Leaf', methodName: 'baseOnly' }),
+      context,
+    );
+    const text = result.content?.[0]?.text ?? '';
+    expect(result.isError).toBeFalsy();
+    expect(text).toContain('return true;');
+    expect(text).toContain('Inherited method');
+    expect(text).toContain('C_Base');
+    // The heading still names the class the source actually came from.
+    expect(text.split('\n')[0]).toContain('C_Base.baseOnly');
+  });
+
+  it('does not annotate a method the class declares itself', async () => {
+    const result = await getMethodSourceTool(
+      srcReq({ className: 'A_Leaf', methodName: 'leafOnly' }),
+      context,
+    );
+    const text = result.content?.[0]?.text ?? '';
+    expect(result.isError).toBeFalsy();
+    expect(text).toContain('return "leaf";');
+    expect(text).not.toContain('Inherited method');
+  });
+
+  it('still errors for a method that exists nowhere in the chain', async () => {
+    const result = await getMethodSourceTool(
+      srcReq({ className: 'A_Leaf', methodName: 'noSuchMethod' }),
+      context,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not found/i);
+  });
+});


### PR DESCRIPTION
## Problem

`get_method` returned **not found** for any method the named class does not declare itself. Reported symptom was "CoC lookup only searches one level" — it was actually **zero** levels.

All three readers behind the tool see *declared* members only:

| reader | probe |
|---|---|
| C# bridge | `Classes.Read(name).Methods` |
| XML fallback | parses that one AxClass file |
| SQLite | `parent_name = <name>` |

None of them walked `extends`.

This hits the CoC path hardest, because the class worth wrapping is usually a leaf whose interesting methods live on a base class. Reproduced on the VM before the fix:

```
get_method("SalesFormLetter_Invoice", "promptAndRun")
  → ❌ Method not found
```

…even though the **direct parent** `SalesFormLetter` declares it.

## Fix

New `src/utils/inheritanceChain.ts` walks `symbols.extends_class`:

- `inheritanceAncestors()` — nearest first, canonical casing, name-based cycle guard + depth cap 12
- `findDeclaringAncestor()` — SQLite as the **locator**, bridge/XML stays the **reader**, so a hit costs one extra read rather than a walk of the whole chain
- The chain is only walked blind when the index cannot locate the method, and then only when the bridge is available — the XML path pays a 3 s timeout per level, so walking it blind is not worth it

`methodSignature.ts` / `getMethodSource.ts` retry the readers against the declaring ancestor. The retry runs **only** when the class has no method row of its own, so an override on the subclass still wins.

Output names the declaring class and says so explicitly:

```
# Method: `SalesFormLetter.promptAndRun`

> ℹ️ Inherited method. `SalesFormLetter_Invoice` does not declare `promptAndRun` —
> it inherits it from `SalesFormLetter`, which is where the signature below comes from.
```

The CoC template targets the declaring class, with the subclass-scope caveat:

```
Replace `OriginalClassName` with `C_Base`.
⚠️ Target `C_Base` — the class that declares the method — not `A_Leaf`.
   The wrapper then runs for every subclass; guard with `if (this is A_Leaf)`.
```

## Tests

`tests/tools/method-inheritance.test.ts` — real in-memory index built through the real extraction pipeline (`parseClassFile` → JSON → `indexMetadataDirectory` → tool). The chain is **two levels deep on purpose**: a fix that only consults the direct parent still fails the grandparent case.

12 tests covering the walk helpers, direct parent, grandparent, override precedence, CoC template targeting, and the unchanged not-found path.

Full suite: 2326 passed. The one failure is the known `apiSymbols.test.ts` cold-cache timeout (passes warm in ~2 s, re-verified).

## Verified live on the VM (after reconnect)

| case | result |
|---|---|
| direct parent — `SalesFormLetter_Invoice.promptAndRun` | ✅ resolves to `SalesFormLetter` |
| grandparent — `SalesFormLetter_Invoice.parmBatchGroupId` | ✅ resolves to `FormLetterServiceController` (2 levels) |
| own declared method — `SalesFormLetter_Invoice.run` | ✅ no false "inherited" annotation |
| unknown method | ✅ still errors, message now says the chain was searched |

## Note

The output deliberately does **not** claim the X++ compiler rejects CoC on an inherited method via the subclass — that is unverified here. It only states that wrapping the declaring class works, and flags the broader subclass scope. If that rule is confirmed, it belongs in the `coc-authoring` KB topic, which currently does not mention inheritance at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
