### PR TITLE
feat(knowledge): class-inheritance topic + correct the CoC-on-inherited guidance

### DIFF
--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -146,7 +146,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 
 ## Orphans
 
-- Knowledge entries no leaf claims (**unproven knowledge**): none
+- Knowledge entries no leaf claims (**unproven knowledge**): class-inheritance
 - Eval cases no leaf claims (**unmapped proof**): L2-oracle-discriminator-random-wrapper-name, L4-headerlines-document-slice
 
 _Generated 2026-07-28._

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -1205,7 +1205,9 @@
     }
   ],
   "orphans": {
-    "knowledge": [],
+    "knowledge": [
+      "class-inheritance"
+    ],
     "cases": [
       "L2-oracle-discriminator-random-wrapper-name",
       "L4-headerlines-document-slice"

--- a/eval/knowledge-audit.snapshot.json
+++ b/eval/knowledge-audit.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "capturedAt": "2026-07-23T12:34:56.804Z",
-  "indexedAt": "2026-07-23T11:27:43.481Z",
+  "capturedAt": "2026-07-28T11:15:48.861Z",
+  "indexedAt": "2026-07-28T06:46:19.478Z",
   "ok": [
     "alerts-business-events|attribute|DataContract",
     "alerts-business-events|attribute|DataContractAttribute",
@@ -21,6 +21,14 @@
     "caching|declaration|RecordViewCache",
     "caching|declaration|SysGlobalObjectCache",
     "caching|new|RecordViewCache",
+    "class-inheritance|attribute|ExtensionOf",
+    "class-inheritance|declaration|FormLetterServiceController",
+    "class-inheritance|declaration|SalesFormLetter_Invoice",
+    "class-inheritance|extends|FormLetterServiceController",
+    "class-inheritance|extends|RunBaseBatch",
+    "class-inheritance|extends|SalesFormLetter",
+    "class-inheritance|intrinsic|SalesFormLetter",
+    "class-inheritance|intrinsic|SalesFormLetter_Invoice",
     "coc-authoring|attribute|ExtensionOf",
     "coc-authoring|attribute|Hookable",
     "coc-authoring|attribute|Replaceable",

--- a/src/tools/getMethodSource.ts
+++ b/src/tools/getMethodSource.ts
@@ -148,8 +148,9 @@ function annotateInherited(
   const note =
     `\n> ℹ️ **Inherited method.** \`${requestedClass}\` does not declare \`${methodName}\` — ` +
     `it inherits it from \`${declaringClass}\`, whose source is shown below.\n` +
-    `> For CoC, wrap it on \`${declaringClass}\`; the wrapper then runs for **every** subclass, ` +
-    `so guard the body with \`if (this is ${requestedClass})\` when only that one is meant.\n`;
+    `> For CoC both targets compile: \`ExtensionOf(classStr(${requestedClass}))\` scopes the wrapper to ` +
+    `\`${requestedClass}\`, \`ExtensionOf(classStr(${declaringClass}))\` applies it to every subclass. ` +
+    `Either way the signature must match \`${declaringClass}\`'s declaration.\n`;
 
   const [first, ...rest] = result.content;
   if (!first || typeof first.text !== 'string') return result;

--- a/src/tools/methodSignature.ts
+++ b/src/tools/methodSignature.ts
@@ -474,9 +474,12 @@ function formatOutput(
     output += `\n## Chain of Command Template\n\`\`\`xpp\n${signature.cocTemplate}\`\`\`\n`;
     output += `Replace \`OriginalClassName\` with \`${className}\`.\n`;
     if (inheritedBy) {
-      output += `\n⚠️ Target \`${className}\` — the class that declares the method — not \`${inheritedBy}\`. ` +
-        `The wrapper then runs for **every** subclass of \`${className}\`; if the change is meant for ` +
-        `\`${inheritedBy}\` only, guard the body with \`if (this is ${inheritedBy})\`.\n`;
+      output += `\n**Pick the target deliberately — both compile:**\n` +
+        `- \`[ExtensionOf(classStr(${inheritedBy}))]\` — wraps the inherited method for \`${inheritedBy}\` only. ` +
+        `The signature must still match \`${className}\`'s declaration exactly; the compiler validates against it ` +
+        `and names \`${className}\` in any mismatch error.\n` +
+        `- \`[ExtensionOf(classStr(${className}))]\` — wraps it at the declaration, so it runs for **every** ` +
+        `subclass of \`${className}\`.\n`;
     }
   } else {
     output += `\n> 💡 Pass \`includeCocTemplate: true\` to get the CoC extension template.\n`;

--- a/src/tools/xppKnowledge.ts
+++ b/src/tools/xppKnowledge.ts
@@ -337,6 +337,7 @@ while (qr.next())
       'Extension class MUST be [ExtensionOf(classStr/tableStr/formStr(Target))]',
       'Extension class MUST be final',
       'Method signature MUST match the original exactly (use get_method(include="signature") tool)',
+      'The target may INHERIT the method rather than declare it — that compiles, and the signature is then validated against the declaring base class. See class-inheritance',
       'ALWAYS call next <methodName>() — skipping it breaks the chain for other extensions',
       'Cannot access private members of the original class',
       'Can wrap public and protected methods — instance AND static (a static wrapper must repeat the "static" modifier); cannot wrap private methods or constructors. Forms cannot have static-method CoC',
@@ -389,7 +390,7 @@ final class SalesFormLetter_MyModel_Extension
 }`,
       },
     ],
-    related: ['event-handlers', 'form-patterns', 'coc-authoring'],
+    related: ['event-handlers', 'form-patterns', 'coc-authoring', 'class-inheritance'],
   },
 
   // ── Event Handlers ──────────────────────────────────────────────────────
@@ -2099,7 +2100,7 @@ public void post()
 }`,
       },
     ],
-    related: ['coc', 'event-handlers'],
+    related: ['coc', 'event-handlers', 'class-inheritance'],
   },
 
   // ── X++ Class & Method Rules ─────────────────────────────────────────────
@@ -2123,7 +2124,106 @@ public void post()
       '"var" keyword only when the type is obvious from initialization; skip when ambiguous',
       'Declare variables close to first use, smallest scope; compiler rejects shadowing',
     ],
-    related: ['coc-authoring', 'coc'],
+    related: ['coc-authoring', 'coc', 'class-inheritance'],
+  },
+
+  // ── Class Inheritance ───────────────────────────────────────────────────
+  {
+    id: 'class-inheritance',
+    title: 'Class Inheritance (extends, super, abstract/final, is/as) — and how it meets CoC',
+    keywords: ['inheritance', 'inherit', 'inherited', 'extends', 'super', 'base class', 'derived class',
+      'subclass', 'superclass', 'ancestor', 'override', 'overriding', 'abstract', 'final class',
+      // NB: no 1–2 character keywords here. scoreEntry() does token.includes(k),
+      // so a keyword like "is" scores against any token containing it
+      // ("nonexistent") and the topic would match essentially every query.
+      'is operator', 'as operator', 'downcast', 'polymorphism', 'virtual',
+      'class hierarchy', 'parent class'],
+    summary:
+      'X++ has single class inheritance and every non-final method is virtual. The trap in D365FO is that ' +
+      'inheritance is invisible in metadata: the AOT stores only DECLARED members, so a subclass never lists ' +
+      'the methods it inherits — you have to walk Extends to find where a method really lives. CoC does cope ' +
+      'with inheritance: a wrapper may target a subclass for a method that subclass only inherits.',
+    rules: [
+      'Single inheritance only — a class may extend exactly one base class. For multiple contracts use interfaces (implements)',
+      'Every non-static, non-final method is virtual: there is no `virtual` and no `override` keyword — redeclaring the same signature in a subclass overrides it',
+      'super() calls the BASE implementation of the method you are currently in — not an arbitrary base method. In new() it must run before `this` is used',
+      'final class = cannot be subclassed; final method = cannot be overridden. abstract class = cannot be instantiated; an abstract method must be implemented by every concrete subclass',
+      'Override visibility must be at least as accessible as the base method; private methods are not overridable (see xpp-class-rules)',
+      '`is` tests the runtime type, `as` is a safe downcast that yields null on failure — prefer both over classId comparisons',
+      'METADATA TRAP: the AOT stores declared members only. get_object_info on a subclass does NOT list inherited methods, and a bridge/XML read of that one class cannot see them. Walk Extends to find the declaring class before concluding a method does not exist',
+      'CoC CAN wrap a method the augmented class only inherits — an extension whose [ExtensionOf] names the subclass, wrapping a method declared on its base class, compiles (verified against xppc)',
+      'Such a wrapper binds to the BASE declaration: its signature is validated against the base, and on a mismatch the compiler says "The augmented class \'<Base>\' provides a method by this name, but ... the parameter profile does not match" — it names the DECLARING class, not the one in your [ExtensionOf]. That is not a mistake in your attribute',
+      'Choosing the CoC target is therefore a SCOPE decision, not a correctness one: extend the subclass to affect only it, extend the declaring class to affect every subclass',
+      'Wrapping a name that exists nowhere in the chain fails with "The next method cannot be invoked in method \'X\' because it\'s not a Chain Of Command Method"',
+      'Subclassing a Microsoft class in your own model does NOT make standard code use your subclass — standard factories instantiate their own type. Use CoC, event handlers, or SysExtension where the base is designed for substitution',
+    ],
+    examples: [
+      {
+        label: 'Where a method actually lives (walk Extends before concluding "not found")',
+        code: `// Real chain in the AOT:
+//   SalesFormLetter_Invoice  extends  SalesFormLetter  extends  FormLetterServiceController
+//
+// promptAndRun() is declared on SalesFormLetter.
+// SalesFormLetter_Invoice INHERITS it but does not declare it, so a member
+// listing of the leaf class will not show it at all. "Not in the list" means
+// "not declared here", never "does not exist".`,
+      },
+      {
+        label: 'CoC on an inherited method — both targets compile, pick by scope',
+        code: `// (a) Narrow: only SalesFormLetter_Invoice is affected.
+[ExtensionOf(classStr(SalesFormLetter_Invoice))]
+final class SalesFormLetter_InvoiceMy_Extension
+{
+    // Signature must match the declaration on SalesFormLetter — that is what
+    // the compiler validates against, and what it names if you get it wrong.
+    public void promptAndRun()
+    {
+        next promptAndRun();
+    }
+}
+
+// (b) Broad: every subclass of SalesFormLetter is affected.
+[ExtensionOf(classStr(SalesFormLetter))]
+final class SalesFormLetterMy_Extension
+{
+    public void promptAndRun()
+    {
+        next promptAndRun();
+    }
+}`,
+      },
+      {
+        label: 'super() and constructor chaining',
+        code: `public class MyPostingBatch extends RunBaseBatch
+{
+    MyPostingBatch  chainedFrom;
+}
+
+public void new()
+{
+    super();            // base construction first — before touching this
+    chainedFrom = null;
+}
+
+public boolean canGoBatch()
+{
+    // super() here = RunBaseBatch's implementation of canGoBatch, not some
+    // other base method. Combine, do not replace, unless you mean to.
+    return super() && this.parmIsChained() == false;
+}`,
+      },
+      {
+        label: 'is / as instead of type ids',
+        code: `FormLetterServiceController  controller = this.buildController();
+
+if (controller is SalesFormLetter_Invoice)
+{
+    SalesFormLetter_Invoice invoice = controller as SalesFormLetter_Invoice;
+    invoice.parmShowDialog(false);
+}`,
+      },
+    ],
+    related: ['coc', 'coc-authoring', 'xpp-class-rules', 'sysextension', 'table-inheritance'],
   },
 
   // ── SysDa Framework ─────────────────────────────────────────────────────

--- a/tests/tools/method-inheritance.test.ts
+++ b/tests/tools/method-inheritance.test.ts
@@ -160,14 +160,22 @@ describe('get_method(include="signature") on inherited methods', () => {
     expect(text).toContain('C_Base');
   });
 
-  it('points the CoC template at the declaring class, not the named one', async () => {
+  // Both [ExtensionOf] targets compile — verified against xppc on the VM by
+  // wrapping an inherited method from a subclass extension. The wrapper binds
+  // to the base declaration: breaking its signature makes the compiler report
+  // "The augmented class 'ConZzInhBase' provides a method by this name, but
+  // ... the parameter profile does not match", naming the DECLARING class even
+  // though [ExtensionOf] named the subclass. So the output must present the
+  // target as a scope choice, not steer to the base.
+  it('offers both CoC targets and does not steer away from the subclass', async () => {
     const result = await getMethodSignatureTool(
       sigReq({ className: 'A_Leaf', methodName: 'baseOnly', includeCocTemplate: true }),
       context,
     );
     const text = result.content?.[0]?.text ?? '';
-    expect(text).toContain('Replace `OriginalClassName` with `C_Base`');
-    expect(text).toContain('if (this is A_Leaf)');
+    expect(text).toContain('classStr(A_Leaf)');
+    expect(text).toContain('classStr(C_Base)');
+    expect(text).toMatch(/every.*subclass/i);
   });
 
   it('prefers the class itself over an ancestor that also declares the method', async () => {


### PR DESCRIPTION
Follow-up to #780. That PR made `get_method` resolve inherited methods; this one fills the knowledge gap behind it — and **corrects guidance #780 shipped based on an unverified assumption.**

## The gap

The knowledge base had **no class-inheritance topic at all**. 63 topics, `table-inheritance` for tables, and exactly one line about class inheritance (`Override visibility must be at least as accessible…` in `xpp-class-rules`). Nothing on `super()`, constructor chaining, `abstract`/`final`, `is`/`as` — and nothing on how inheritance meets CoC, which is the case that actually bites.

## Settled empirically, not from memory

Compiled throwaway classes in the Contoso sandbox on the VM and rolled them back. Three runs:

| # | what | result |
|---|---|---|
| 1 | **negative control** — wrap a name that exists nowhere | ❌ `The next method cannot be invoked in method 'X' because it's not a Chain Of Command Method` |
| 2 | `[ExtensionOf(classStr(Derived))]` wrapping a method declared only on `Base` | ✅ **compiles** |
| 3 | same wrapper, signature deliberately broken | ❌ `The augmented class **'ConZzInhBase'** provides a method by this name, but … the parameter profile does not match` |

Run 1 matters because a falsely-clean build has burned this repo before — it proves the compiler really read the files (run 3 re-proved it on the exact hand-written file whose green result the conclusion rests on).

Run 3 is the decisive one: `[ExtensionOf]` named the **subclass**, but the compiler reports the **base** as the augmented class. It bound to the inherited declaration and validated the signature against it, rather than merely tolerating the name.

## The correction

#780's note said:

> ⚠️ Target `C_Base` — the class that declares the method — **not** `A_Leaf`.

That is wrong in a way that changes the user's design decision — it presents the subclass as an illegal target when it compiles fine. Both notes now present it as what it is, a **scope** choice:

```
**Pick the target deliberately — both compile:**
- [ExtensionOf(classStr(A_Leaf))] — wraps the inherited method for A_Leaf only.
  The signature must still match C_Base's declaration; the compiler validates
  against it and names C_Base in any mismatch error.
- [ExtensionOf(classStr(C_Base))] — wraps it at the declaration, so it runs for
  every subclass of C_Base.
```

The test changed with it: it now asserts both targets are offered instead of asserting the steer.

## Not verified

Whether a subclass wrapper actually **fires** at runtime, and in what order relative to a base wrapper. Neither `SysTestConsole.exe` nor `SysTestRunner.exe` exists on this VM, so the topic states only what the compiler was observed to do and stays silent on runtime ordering rather than guessing.

## New topic

`class-inheritance` — single inheritance, implicit virtual dispatch, `super()` semantics, constructor ordering, `abstract`/`final`, `is`/`as`, the metadata trap (AOT stores declared members only, so a subclass never lists what it inherits), the four CoC rules above, and why subclassing a Microsoft class does not make standard code use your subclass. Cross-linked from `coc`, `coc-authoring`, `xpp-class-rules`.

### One thing worth knowing about the matcher

The topic's keywords deliberately contain **no 1–2 character entries**. `scoreEntry()` does `token.includes(k)`, so a keyword `"is"` scored against any query containing it — `"zzzyyyxxx_nonexistent"` contains `ex-is-tent` — and the topic matched nearly every query. The existing unknown-topic test caught it. Left the matcher alone as out of scope, but it will bite the next person who adds a short keyword; noted in a comment at the keyword list.

## Verification

- Knowledge audit re-captured on the VM: **284 references, 205 resolved, 79 allowlisted, 0 defects**
- Full suite: **174 files, 2327 tests, 0 failures**
- VM left clean: all experiment classes deleted, stale `.rnrproj` entries removed, final full build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
