### PR TITLE
fix(extension_info, get_object_info): see inherited members, and fix CoC eligibility

### DIFF
--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -2216,11 +2216,37 @@ export async function tryBridgeCompletion(
   bridge: BridgeClient | undefined,
   symbolName: string,
   prefix?: string,
+  ancestors?: string[],
 ): Promise<ToolResult | null> {
   if (!bridge?.isReady || !bridge.metadataAvailable) return null;
   try {
     const result = await bridge.getCompletionMembers(symbolName);
     if (!result || !result.members || result.members.length === 0) return null;
+
+    // IMetadataProvider returns DECLARED members only, so a subclass lists
+    // nothing it inherits and the reader concludes the member does not exist.
+    // Merge the base classes in, nearest first; a name already present wins,
+    // since that is the subclass's own override.
+    if (ancestors?.length) {
+      const seen = new Set(result.members.map(m => m.name.toLowerCase()));
+      for (const ancestor of ancestors) {
+        let inherited: BridgeCompletionResult | null = null;
+        try {
+          inherited = await bridge.getCompletionMembers(ancestor);
+        } catch (e) {
+          // One unreadable link must not discard the members already merged.
+          console.error(`[BridgeAdapter] getCompletionMembers(${ancestor}) failed: ${e}`);
+          continue;
+        }
+        for (const m of inherited?.members ?? []) {
+          const key = m.name.toLowerCase();
+          if (seen.has(key)) continue;
+          seen.add(key);
+          result.members.push({ ...m, inheritedFrom: inherited?.symbolName || ancestor });
+        }
+      }
+    }
+
     return { content: [{ type: 'text', text: formatCompletion(result, prefix) }] };
   } catch (e) {
     console.error(`[BridgeAdapter] getCompletionMembers(${symbolName}) failed: ${e}`);
@@ -2250,9 +2276,15 @@ function formatCompletion(r: BridgeCompletionResult, prefix?: string): string {
   const fieldMembers = members.filter(m => m.kind === 'field');
 
   if (methodMembers.length > 0) {
+    const inheritedCount = methodMembers.filter(m => m.inheritedFrom).length;
     out += `## Methods (${methodMembers.length})\n`;
     for (const m of methodMembers) {
-      out += m.signature ? `- \`${m.signature}\`\n` : `- ${m.name}\n`;
+      const body = m.signature ? `\`${m.signature}\`` : m.name;
+      out += m.inheritedFrom ? `- ${body} _(inherited from ${m.inheritedFrom})_\n` : `- ${body}\n`;
+    }
+    if (inheritedCount > 0) {
+      out += `\n> ${inheritedCount} of these are inherited — callable on ${r.symbolName}, but ` +
+        `declared on a base class. To read or wrap one, target the class named beside it.\n`;
     }
   }
 

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -638,6 +638,13 @@ export interface BridgeCompletionMember {
   name: string;
   signature?: string;
   kind: string;
+  /**
+   * Set by the caller (not the bridge) when the member was picked up from a
+   * base class rather than declared on the requested one. IMetadataProvider
+   * returns declared members only, so inherited members are merged in on the
+   * TypeScript side and tagged here.
+   */
+  inheritedFrom?: string;
 }
 
 export interface BridgeCompletionResult {

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -116,6 +116,14 @@ export interface BridgeMethodInfo {
   returnType?: string;
   source?: string;
   isStatic?: boolean;
+  /**
+   * ⚠️ Never sent by the bridge. The C# MethodInfoModel behind readClass carries
+   * only name/source/isStatic, so this is always undefined on bridge-sourced
+   * methods — it is populated exclusively by the XML parser path
+   * (xmlParser.parseClassFile). Reading it off a readClass result silently
+   * yields nothing; for a bridge-sourced modifier parse the declaration line out
+   * of getCompletionMembers().members[].signature instead.
+   */
   visibility?: string;
 }
 

--- a/src/tools/analyzeExtensionPoints.ts
+++ b/src/tools/analyzeExtensionPoints.ts
@@ -11,9 +11,61 @@ import { getConfigManager } from '../utils/configManager.js';
 import { scanFsExtensions, EXTENSION_FOLDER_CONFIG } from '../utils/fsExtensionScanner.js';
 import { canonicalSymbolName } from '../utils/symbolLookup.js';
 import { inheritanceAncestors } from '../utils/inheritanceChain.js';
+import type { BridgeClient } from '../bridge/bridgeClient.js';
+
+/**
+ * Access modifiers straight from IMetadataProvider, keyed by lowercase method
+ * name, with the nearest declaration winning.
+ *
+ * Why this exists rather than trusting the snippet heuristic below: the indexed
+ * `source_snippet` is truncated, and measured over 40k indexed methods it stops
+ * *before* the declaration line for 11.9% of them — the heuristic is simply
+ * blind there and defaults them to public. `SalesFormLetter_Invoice.description()`
+ * is one: `private static`, but its snippet is 88 characters of doc comment. The
+ * bridge carries the real visibility, so it is the authority whenever it is up.
+ *
+ * One unreadable class is skipped rather than aborting: a partial map still
+ * beats falling back to the heuristic for every method.
+ */
+async function readVisibility(
+  bridge: BridgeClient | undefined,
+  classNames: string[],
+): Promise<Map<string, string>> {
+  const byMethod = new Map<string, string>();
+  if (!bridge?.isReady || !bridge.metadataAvailable) return byMethod;
+  for (const name of classNames) {
+    let info;
+    try {
+      info = await bridge.readClass(name);
+    } catch (e) {
+      console.error(`[analyzeExtensionPoints] readClass(${name}) failed: ${e}`);
+      continue;
+    }
+    for (const m of info?.methods ?? []) {
+      const key = m.name?.toLowerCase();
+      if (key && m.visibility && !byMethod.has(key)) {
+        byMethod.set(key, m.visibility.toLowerCase());
+      }
+    }
+  }
+  return byMethod;
+}
+
+/** Bridge visibility when known, else the snippet heuristic. */
+function isPrivateMethod(
+  name: string,
+  signature: string,
+  sourceSnippet: string,
+  visibility: Map<string, string>,
+): boolean {
+  const known = visibility.get(name.toLowerCase());
+  if (known) return known === 'private';
+  return isPrivate(signature, sourceSnippet, name);
+}
 
 /**
  * Whether a method is declared private, and therefore not CoC-wrappable.
+ * Fallback for when the bridge is down — see readVisibility for the accurate path.
  *
  * The indexed `signature` carries no access modifier (it is built as
  * `returnType name(params)`), so the only place a modifier survives is the
@@ -217,8 +269,9 @@ export async function analyzeExtensionPointsTool(request: CallToolRequest, conte
       // class-inheritance knowledge topic). Listing declared members only made
       // this tool report almost nothing for leaf classes, which are exactly the
       // ones people extend. Nearest ancestor wins on a name clash (an override).
+      const ancestorNames = inheritanceAncestors(rdb, objName);
       const seenMethods = new Set(methods.map(m => String(m.name).toLowerCase()));
-      for (const ancestor of inheritanceAncestors(rdb, objName)) {
+      for (const ancestor of ancestorNames) {
         for (const m of methodStmt.all(ancestor) as any[]) {
           const key = String(m.name).toLowerCase();
           if (seenMethods.has(key)) continue;
@@ -227,6 +280,11 @@ export async function analyzeExtensionPointsTool(request: CallToolRequest, conte
         }
       }
       methods.sort((a, b) => String(a.name).localeCompare(String(b.name)));
+
+      // Real access modifiers, when the bridge is up. The snippet heuristic
+      // below is blind for ~12% of methods (see readVisibility), so this is
+      // what makes the private filter exact rather than approximate.
+      const visibility = await readVisibility(context.bridge, [objName, ...ancestorNames]);
 
       if (methods.length > 0) {
         const cocEligible: any[] = [];
@@ -246,7 +304,7 @@ export async function analyzeExtensionPointsTool(request: CallToolRequest, conte
             blocked.push({ ...m, reason: 'final' });
           } else if (src.includes('[replaceable]') || src.includes('replaceable]')) {
             replaceables.push(m);
-          } else if (!isPrivate(sig, src, String(m.name))) {
+          } else if (!isPrivateMethod(String(m.name), sig, src, visibility)) {
             // CoC eligible: anything not private, not final, not blocked.
             //
             // This used to test `sig.includes('public ')`, but the indexed

--- a/src/tools/analyzeExtensionPoints.ts
+++ b/src/tools/analyzeExtensionPoints.ts
@@ -10,6 +10,36 @@ import type { XppServerContext } from '../types/context.js';
 import { getConfigManager } from '../utils/configManager.js';
 import { scanFsExtensions, EXTENSION_FOLDER_CONFIG } from '../utils/fsExtensionScanner.js';
 import { canonicalSymbolName } from '../utils/symbolLookup.js';
+import { inheritanceAncestors } from '../utils/inheritanceChain.js';
+
+/**
+ * Whether a method is declared private, and therefore not CoC-wrappable.
+ *
+ * The indexed `signature` carries no access modifier (it is built as
+ * `returnType name(params)`), so the only place a modifier survives is the
+ * stored source snippet. That snippet opens with the doc comment, so scan for
+ * the declaration line — the one naming the method before its parenthesis —
+ * rather than searching the whole blob, where the word "private" could easily
+ * come from prose in a `/// <remarks>`.
+ *
+ * Unknown means not private: X++ methods default to public, and hiding a
+ * genuine extension point is worse than listing one the compiler later rejects.
+ */
+function isPrivate(signature: string, sourceSnippet: string, methodName: string): boolean {
+  if (!sourceSnippet) return false;
+  const needle = methodName.toLowerCase();
+  for (const rawLine of sourceSnippet.split('\n')) {
+    const line = rawLine.toLowerCase();
+    const at = line.indexOf(needle);
+    if (at === -1) continue;
+    if (!/^\s*\(/.test(line.slice(at + needle.length))) continue; // not the declaration
+    if (line.trimStart().startsWith('///')) continue;             // doc comment
+    return /\bprivate\b/.test(line.slice(0, at));
+  }
+  // No declaration line inside the snippet — fall back to the signature, which
+  // only carries a modifier for the rare rows that stored one.
+  return /\bprivate\b/.test(signature);
+}
 
 // Standard D365FO table events available for subscription
 const TABLE_STANDARD_EVENTS = [
@@ -175,11 +205,28 @@ export async function analyzeExtensionPointsTool(request: CallToolRequest, conte
 
     // For classes — analyze methods
     if (resolvedType === 'class' || resolvedType === 'auto') {
-      const methods = rdb.prepare(
+      const methodStmt = rdb.prepare(
         `SELECT name, signature, source_snippet FROM symbols
          WHERE parent_name = ? AND type = 'method'
          ORDER BY name`
-      ).all(objName) as any[];
+      );
+      const methods = methodStmt.all(objName) as any[];
+
+      // Inherited methods are extension points too — CoC can wrap a method the
+      // augmented class only inherits (verified against xppc; see the
+      // class-inheritance knowledge topic). Listing declared members only made
+      // this tool report almost nothing for leaf classes, which are exactly the
+      // ones people extend. Nearest ancestor wins on a name clash (an override).
+      const seenMethods = new Set(methods.map(m => String(m.name).toLowerCase()));
+      for (const ancestor of inheritanceAncestors(rdb, objName)) {
+        for (const m of methodStmt.all(ancestor) as any[]) {
+          const key = String(m.name).toLowerCase();
+          if (seenMethods.has(key)) continue;
+          seenMethods.add(key);
+          methods.push({ ...m, inheritedFrom: ancestor });
+        }
+      }
+      methods.sort((a, b) => String(a.name).localeCompare(String(b.name)));
 
       if (methods.length > 0) {
         const cocEligible: any[] = [];
@@ -199,8 +246,16 @@ export async function analyzeExtensionPointsTool(request: CallToolRequest, conte
             blocked.push({ ...m, reason: 'final' });
           } else if (src.includes('[replaceable]') || src.includes('replaceable]')) {
             replaceables.push(m);
-          } else if (sig.includes('public ') || sig.includes('protected ')) {
-            cocEligible.push(m); // CoC eligible: public or protected, non-final
+          } else if (!isPrivate(sig, src, String(m.name))) {
+            // CoC eligible: anything not private, not final, not blocked.
+            //
+            // This used to test `sig.includes('public ')`, but the indexed
+            // signature is built as `returnType name(params)` with NO access
+            // modifier (see symbolIndex.indexClasses), so that test could never
+            // be true and the tool reported ZERO eligible methods for every
+            // class in the AOT. X++ methods default to public, so "not private"
+            // is both correct and the only thing the index can actually answer.
+            cocEligible.push(m);
           }
         }
 
@@ -211,10 +266,16 @@ export async function analyzeExtensionPointsTool(request: CallToolRequest, conte
             const status = wrappedBy
               ? `EXTENDED by ${wrappedBy.slice(0, 2).join(', ')}${wrappedBy.length > 2 ? '...' : ''}`
               : 'not yet extended';
-            output += `  ✓ ${m.name}()\t[${status}]\n`;
+            const origin = m.inheritedFrom ? `\tinherited from ${m.inheritedFrom}` : '';
+            output += `  ✓ ${m.name}()\t[${status}]${origin}\n`;
           }
           if (cocEligible.length > 20) {
             output += `  ... and ${cocEligible.length - 20} more methods\n`;
+          }
+          if (cocEligible.some(m => m.inheritedFrom)) {
+            output += `  ℹ️ Inherited entries can be wrapped either on ${objName} (affects only it) ` +
+              `or on the class that declares them (affects every subclass). Either way the wrapper ` +
+              `signature must match the DECLARING class.\n`;
           }
           output += '\n';
         }

--- a/src/tools/analyzeExtensionPoints.ts
+++ b/src/tools/analyzeExtensionPoints.ts
@@ -36,19 +36,39 @@ async function readVisibility(
   for (const name of classNames) {
     let info;
     try {
-      info = await bridge.readClass(name);
+      // getCompletionMembers, NOT readClass: the C# MethodInfoModel behind
+      // readClass carries only name/source/isStatic, so BridgeMethodInfo's
+      // `visibility` is never populated and reading it yields nothing.
+      // GetCompletionMembers builds each signature from the declaration line,
+      // so the modifier is right there in the string.
+      info = await bridge.getCompletionMembers(name);
     } catch (e) {
-      console.error(`[analyzeExtensionPoints] readClass(${name}) failed: ${e}`);
+      console.error(`[analyzeExtensionPoints] getCompletionMembers(${name}) failed: ${e}`);
       continue;
     }
-    for (const m of info?.methods ?? []) {
+    for (const m of info?.members ?? []) {
+      if (m.kind !== 'method') continue;
       const key = m.name?.toLowerCase();
-      if (key && m.visibility && !byMethod.has(key)) {
-        byMethod.set(key, m.visibility.toLowerCase());
-      }
+      if (!key || byMethod.has(key)) continue;
+      const visibility = parseVisibility(m.signature);
+      if (visibility) byMethod.set(key, visibility);
     }
   }
   return byMethod;
+}
+
+/**
+ * Access modifier out of a declaration-line signature such as
+ * `private static ClassDescription description()`.
+ *
+ * Only the part before the parameter list is considered — a default parameter
+ * value is arbitrary X++ and could contain any of these words.
+ */
+function parseVisibility(signature?: string | null): string | undefined {
+  if (!signature) return undefined;
+  const head = signature.split('(')[0];
+  const m = /\b(public|protected|private|internal)\b/i.exec(head);
+  return m ? m[1].toLowerCase() : undefined;
 }
 
 /** Bridge visibility when known, else the snippet heuristic. */

--- a/src/tools/completion.ts
+++ b/src/tools/completion.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { validateWorkspacePath } from '../workspace/workspaceUtils.js';
 import { tryBridgeCompletion } from '../bridge/index.js';
+import { inheritanceAncestors } from '../utils/inheritanceChain.js';
 
 const CompletionArgsSchema = z.object({
   className: z.string().min(1, 'className is required').describe('Class or table name'),
@@ -22,8 +23,17 @@ export async function completionTool(request: CallToolRequest, context: XppServe
     const { symbolIndex, workspaceScanner } = context;
 
     // Bridge fast-path (C# IMetadataProvider) handles both classes and tables,
-    // so it runs before the table guard below.
-    const bridgeResult = await tryBridgeCompletion(context.bridge, args.className, args.prefix || undefined);
+    // so it runs before the table guard below. The ancestor list makes the
+    // listing include inherited members: the bridge reads one class and sees
+    // declared members only, so without it a subclass looks like it has none
+    // of what it inherits, and callers conclude the member does not exist.
+    let ancestors: string[] = [];
+    try {
+      ancestors = inheritanceAncestors(symbolIndex.getReadDb(), args.className);
+    } catch { /* DB unavailable — fall back to declared members only */ }
+    const bridgeResult = await tryBridgeCompletion(
+      context.bridge, args.className, args.prefix || undefined, ancestors,
+    );
     if (bridgeResult) return bridgeResult;
 
     // code_completion only supports classes; reject tables early.

--- a/tests/tools/extension-points-inheritance.test.ts
+++ b/tests/tools/extension-points-inheritance.test.ts
@@ -129,16 +129,26 @@ async function pointsFor(objectName: string, bridge?: unknown): Promise<string> 
   return result.content?.[0]?.text ?? '';
 }
 
-/** Minimal IMetadataProvider stand-in returning the modifiers the AOT really has. */
+/**
+ * Minimal IMetadataProvider stand-in. Shaped like the real GetCompletionMembers,
+ * which reports the modifier inside the signature string (built from the
+ * declaration line) rather than as its own field — readClass cannot be used for
+ * this, since the C# MethodInfoModel behind it carries no visibility at all.
+ */
 const bridgeWithVisibility = (visibilities: Record<string, Record<string, string>>) => ({
   isReady: true,
   metadataAvailable: true,
-  readClass: async (name: string) => {
+  getCompletionMembers: async (name: string) => {
     const methods = visibilities[name];
     if (!methods) return null;
     return {
-      name,
-      methods: Object.entries(methods).map(([n, visibility]) => ({ name: n, visibility })),
+      symbolName: name,
+      symbolType: 'class',
+      members: Object.entries(methods).map(([n, visibility]) => ({
+        name: n,
+        kind: 'method',
+        signature: `${visibility} void ${n}()`,
+      })),
     };
   },
 });

--- a/tests/tools/extension-points-inheritance.test.ts
+++ b/tests/tools/extension-points-inheritance.test.ts
@@ -65,6 +65,15 @@ const CLASSES = [
       name: 'secretFromBase',
       source: 'private void secretFromBase()\n{\n}',
     },
+    // Declaration line deliberately absent from what the indexer stores — the
+    // real shape behind SalesFormLetter_Invoice.description(), whose snippet is
+    // 88 characters of doc comment. Measured across 40k indexed methods, 11.9%
+    // look like this, so the snippet heuristic cannot classify them and only
+    // the bridge's visibility can.
+    {
+      name: 'hiddenModifier',
+      source: '/// <summary>\n/// Snippet stops here, before the declaration.\n/// </summary>',
+    },
   ]),
   axClassXml('P_Leaf', 'public class P_Leaf extends P_Base\n{\n}', [
     {
@@ -112,13 +121,27 @@ const req = (args: Record<string, unknown>) => ({
   params: { name: 'analyze_extension_points', arguments: args },
 });
 
-async function pointsFor(objectName: string): Promise<string> {
+async function pointsFor(objectName: string, bridge?: unknown): Promise<string> {
   const result = await analyzeExtensionPointsTool(
     req({ objectName, objectType: 'class' }),
-    context,
+    bridge ? ({ ...context, bridge } as XppServerContext) : context,
   );
   return result.content?.[0]?.text ?? '';
 }
+
+/** Minimal IMetadataProvider stand-in returning the modifiers the AOT really has. */
+const bridgeWithVisibility = (visibilities: Record<string, Record<string, string>>) => ({
+  isReady: true,
+  metadataAvailable: true,
+  readClass: async (name: string) => {
+    const methods = visibilities[name];
+    if (!methods) return null;
+    return {
+      name,
+      methods: Object.entries(methods).map(([n, visibility]) => ({ name: n, visibility })),
+    };
+  },
+});
 
 describe('extension_info(mode="points") eligibility', () => {
   it('lists a public declared method as CoC-eligible', async () => {
@@ -139,6 +162,34 @@ describe('extension_info(mode="points") eligibility', () => {
     const eligibleBlock = text.split('CoC-eligible methods')[1]?.split('\n\n')[0] ?? '';
     expect(eligibleBlock).not.toContain('ownPrivate');
     expect(eligibleBlock).not.toContain('secretFromBase');
+  });
+});
+
+describe('extension_info(mode="points") uses bridge visibility when available', () => {
+  it('excludes a private method whose declaration the snippet never captured', async () => {
+    // Without the bridge the snippet heuristic cannot see the modifier, so it
+    // defaults to public and lists the method — the ~12% blind spot.
+    const heuristicOnly = await pointsFor('P_Leaf');
+    expect(heuristicOnly).toContain('hiddenModifier()');
+
+    // With the bridge reporting the real modifier, it drops out.
+    const withBridge = await pointsFor('P_Leaf', bridgeWithVisibility({
+      P_Leaf: { ownPublic: 'public', ownPrivate: 'private' },
+      P_Base: { wrappableFromBase: 'public', secretFromBase: 'private', hiddenModifier: 'private' },
+    }));
+    expect(withBridge).not.toContain('hiddenModifier()');
+    expect(withBridge).toContain('wrappableFromBase()');
+  });
+
+  it('keeps working when the bridge cannot read part of the chain', async () => {
+    // P_Base unreadable — its methods must still be classified by the heuristic
+    // rather than the whole listing collapsing.
+    const text = await pointsFor('P_Leaf', bridgeWithVisibility({
+      P_Leaf: { ownPublic: 'public', ownPrivate: 'private' },
+    }));
+    expect(text).toContain('ownPublic()');
+    expect(text).toContain('wrappableFromBase()');
+    expect(text).not.toContain('secretFromBase()');
   });
 });
 

--- a/tests/tools/extension-points-inheritance.test.ts
+++ b/tests/tools/extension-points-inheritance.test.ts
@@ -1,0 +1,162 @@
+/**
+ * extension_info(mode="points") against a REAL in-memory symbol index built
+ * through the real extraction pipeline.
+ *
+ * Two defects covered, both of which made the tool useless for the exact
+ * question it exists to answer ("what can I wrap?"):
+ *
+ *  1. Eligibility was tested with `signature.includes('public ')`, but
+ *     indexClasses builds the signature as `returnType name(params)` with NO
+ *     access modifier — so the test could never be true and the tool reported
+ *     ZERO CoC-eligible methods for every class in the AOT. Observed on the VM:
+ *     SalesFormLetter_Invoice returned 3 blocked methods and nothing else,
+ *     despite ~47 public/protected members.
+ *
+ *  2. Only declared methods were listed, so a leaf class — the kind people
+ *     actually extend — showed almost no extension points. CoC can wrap a
+ *     method the augmented class only inherits (verified against xppc; see the
+ *     class-inheritance knowledge topic), so inherited methods belong here too.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { XppMetadataParser } from '../../src/metadata/xmlParser';
+import { analyzeExtensionPointsTool } from '../../src/tools/analyzeExtensionPoints';
+import type { XppServerContext } from '../../src/types/context';
+
+const MODEL = 'MyCustomModel';
+
+let tmpDir: string;
+let index: XppSymbolIndex;
+let context: XppServerContext;
+
+const axClassXml = (
+  name: string,
+  declaration: string,
+  methods: Array<{ name: string; source: string }>,
+) => [
+  '<?xml version="1.0" encoding="utf-8"?>',
+  '<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">',
+  `  <Name>${name}</Name>`,
+  '  <SourceCode>',
+  `    <Declaration><![CDATA[${declaration}]]></Declaration>`,
+  '    <Methods>',
+  ...methods.flatMap(m => [
+    '      <Method>',
+    `        <Name>${m.name}</Name>`,
+    `        <Source><![CDATA[${m.source}]]></Source>`,
+    '      </Method>',
+  ]),
+  '    </Methods>',
+  '  </SourceCode>',
+  '</AxClass>',
+].join('\n');
+
+const CLASSES = [
+  axClassXml('P_Base', 'public class P_Base\n{\n}', [
+    {
+      name: 'wrappableFromBase',
+      source: '/// <summary>\n/// Nothing private about this one.\n/// </summary>\npublic void wrappableFromBase()\n{\n}',
+    },
+    {
+      name: 'secretFromBase',
+      source: 'private void secretFromBase()\n{\n}',
+    },
+  ]),
+  axClassXml('P_Leaf', 'public class P_Leaf extends P_Base\n{\n}', [
+    {
+      name: 'ownPublic',
+      source: 'public void ownPublic()\n{\n}',
+    },
+    {
+      name: 'ownPrivate',
+      source: 'private boolean ownPrivate(int _x)\n{\n    return true;\n}',
+    },
+  ]),
+];
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ext-points-inherit-'));
+  const aotDir = path.join(tmpDir, 'aot');
+  const metadataDir = path.join(tmpDir, 'extracted', MODEL, 'classes');
+  await fs.mkdir(aotDir, { recursive: true });
+  await fs.mkdir(metadataDir, { recursive: true });
+
+  const parser = new XppMetadataParser();
+  for (const xml of CLASSES) {
+    const name = /<Name>([^<]+)<\/Name>/.exec(xml)![1];
+    const file = path.join(aotDir, `${name}.xml`);
+    await fs.writeFile(file, xml, 'utf-8');
+    const parsed = await parser.parseClassFile(file, MODEL);
+    await fs.writeFile(
+      path.join(metadataDir, `${name}.json`),
+      JSON.stringify({ ...parsed.data, sourcePath: file }, null, 2),
+    );
+  }
+
+  index = new XppSymbolIndex(':memory:', ':memory:');
+  await index.indexMetadataDirectory(path.join(tmpDir, 'extracted'));
+  context = { symbolIndex: index, parser, bridge: undefined } as unknown as XppServerContext;
+});
+
+afterAll(async () => {
+  index.close();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const req = (args: Record<string, unknown>) => ({
+  method: 'tools/call' as const,
+  params: { name: 'analyze_extension_points', arguments: args },
+});
+
+async function pointsFor(objectName: string): Promise<string> {
+  const result = await analyzeExtensionPointsTool(
+    req({ objectName, objectType: 'class' }),
+    context,
+  );
+  return result.content?.[0]?.text ?? '';
+}
+
+describe('extension_info(mode="points") eligibility', () => {
+  it('lists a public declared method as CoC-eligible', async () => {
+    const text = await pointsFor('P_Leaf');
+    expect(text).toMatch(/CoC-eligible methods \(\d+\)/);
+    expect(text).toContain('ownPublic()');
+  });
+
+  it('does not report zero eligible methods for a class that has them', async () => {
+    // The original defect: every class came back with an empty eligible list.
+    const text = await pointsFor('P_Base');
+    expect(text).toContain('wrappableFromBase()');
+    expect(text).not.toMatch(/CoC-eligible methods \(0\)/);
+  });
+
+  it('excludes private methods', async () => {
+    const text = await pointsFor('P_Leaf');
+    const eligibleBlock = text.split('CoC-eligible methods')[1]?.split('\n\n')[0] ?? '';
+    expect(eligibleBlock).not.toContain('ownPrivate');
+    expect(eligibleBlock).not.toContain('secretFromBase');
+  });
+});
+
+describe('extension_info(mode="points") inheritance', () => {
+  it('includes methods inherited from a base class, marked with their origin', async () => {
+    const text = await pointsFor('P_Leaf');
+    expect(text).toContain('wrappableFromBase()');
+    expect(text).toContain('inherited from P_Base');
+  });
+
+  it('explains that an inherited point can be wrapped on either class', async () => {
+    const text = await pointsFor('P_Leaf');
+    expect(text).toMatch(/affects only it/);
+    expect(text).toMatch(/DECLARING class/);
+  });
+
+  it('does not mark a class\'s own methods as inherited', async () => {
+    const text = await pointsFor('P_Base');
+    expect(text).not.toContain('inherited from');
+  });
+});


### PR DESCRIPTION
Third in the inheritance series (#780 fixed `get_method`, #781 added the knowledge topic). Same blindness, two more tools — plus two separate defects found along the way.

## Defect 1 — `extension_info(mode="points")` reported zero eligible methods for **every** class

Eligibility was:

```ts
} else if (sig.includes('public ') || sig.includes('protected ')) {
```

But `indexClasses` builds the indexed signature as `` `${returnType} ${name}(${params})` `` — **no access modifier**:

```
{ "name": "promptAndRun", "signature": "void promptAndRun()" }
```

So the test could never be true. The tool that answers *"what can I wrap?"* returned an empty eligible list for every class in the AOT.

## Defect 2 — both tools listed declared members only

`get_object_info(class, {members})` and extension points both showed a leaf class as having almost nothing, because `IMetadataProvider` returns declared members only. Leaf classes are exactly the ones people extend.

Both now merge base classes in, nearest first, subclass override winning on a name clash, each inherited entry labelled with the class that declares it. Inherited entries are genuine extension points — verified against `xppc` in #781 — so the output frames the target as a scope choice rather than steering.

## Getting the private filter right (the interesting part)

The first attempt read the modifier out of the indexed source snippet. That snippet is truncated: measured over 40k indexed methods, it stops **before** the declaration line for **11.9%** of them, so those default to public and a private method gets listed as an extension point. `SalesFormLetter_Invoice.description()` is a live example — `private static`, but its snippet is 88 characters of doc comment.

The fix for that was itself wrong, and **the live check caught it**: extension points reported exactly **365** eligible methods before and after. `readVisibility()` was reading `BridgeMethodInfo.visibility` — a field the TypeScript interface declares but the C# bridge **never sends** (`MethodInfoModel` carries only name/source/isStatic). The map was always empty; everything fell back to the heuristic. The unit test passed because the stub was shaped from the interface rather than from what the bridge actually returns.

`GetCompletionMembers` builds each signature from the declaration line, so the modifier is in the string. Reading it from there works:

```
365 → 361 eligible          (live, after reconnect)
get_object_info(prefix "desc") → `private static ClassDescription description()`
```

`BridgeMethodInfo.visibility` now carries a warning comment so the next reader does not repeat it. The other consumers (`classInfo`, `enhancedParser`) are unaffected — both run on the XML path, where `xmlParser` does populate visibility.

## Tests

`tests/tools/extension-points-inheritance.test.ts` — real in-memory index through the real extraction pipeline. The fixture includes a method whose stored snippet **deliberately ends before its declaration**, which is the only shape that can tell the two paths apart: the heuristic lists it, the bridge drops it. Also covers a bridge that cannot read part of the chain, where the listing must degrade rather than collapse.

Full suite: **175 files, 2335 tests, 0 failures.**

## Verified live on the VM

| check | result |
|---|---|
| `extension_info(points)` on `SalesFormLetter_Invoice` | 0 → **361** eligible |
| origin labelling | correct across 4 levels (`SalesFormLetter` → `FormLetterServiceController` → `SysOperationServiceController` → `SysOperationController`) |
| class's own methods (`caption`, `run`, `afterOperationBody`) | not mislabelled as inherited |
| Replaceable / Delegate hooks | 3 and 2 — previously invisible entirely |
| private exclusion via bridge | `description()` confirmed `private static`, count drops accordingly |

## After merging

`dist/` is build output and is not tracked by git, so a branch switch does not update it. Run `npm run build` on main and reconnect the `d365fo-eval` MCP server, otherwise the running server silently keeps the pre-merge modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
