### PR TITLE
fix(eval): coverage gate must not depend on checkout line endings

### DIFF
--- a/src/eval/coverage/artifactCompare.ts
+++ b/src/eval/coverage/artifactCompare.ts
@@ -1,0 +1,61 @@
+/**
+ * Staleness comparison for the generated coverage artifacts.
+ *
+ * Split out of coverageCli so it can be tested without importing the CLI,
+ * which runs `process.exit(main())` at module load.
+ */
+
+import type { CoverageReport } from './coverage.js';
+
+export const BADGE_START = '<!-- coverage-badge:start -->';
+export const BADGE_END = '<!-- coverage-badge:end -->';
+
+/**
+ * CRLF -> LF. Every staleness comparison runs through this.
+ *
+ * The artifacts are written with `\n`, but git checks them out with `\r\n`
+ * wherever `core.autocrlf=true` (the default on Windows), so the old byte
+ * comparison called every such checkout stale — while `git diff` showed
+ * nothing, because git normalizes back on the way in. `--check` was dead
+ * locally on Windows yet green in CI (ubuntu-latest), and the "obvious" fix —
+ * regenerate and commit — commits CRLF artifacts and breaks the gate on Linux
+ * instead.
+ *
+ * Line endings are not content here, so normalize rather than pin them: the
+ * gate then holds under any core.autocrlf / .gitattributes setting instead of
+ * depending on every clone agreeing.
+ */
+export const normalizeEol = (s: string): string => s.replace(/\r\n/g, '\n');
+
+/** A file's dominant line ending, so a rewrite doesn't leave it mixed. */
+export function dominantEol(s: string): string {
+  return /\r\n/.test(s) ? '\r\n' : '\n';
+}
+
+/**
+ * The generation timestamp must not make --check fail on an unchanged run.
+ * Normalizes first: with CRLF the `$` anchor sits after a stray `\r`, so the
+ * strip silently misses and every run looks stale.
+ */
+export function stripGeneratedAt(md: string): string {
+  return normalizeEol(md).replace(/^_Generated .*_$/m, '');
+}
+
+/**
+ * Rewrites the README badge block from the report. The badge is the public
+ * reliability number — generated, never hand-edited, so it cannot quietly
+ * disagree with eval/coverage.json.
+ */
+export function withBadge(readme: string, report: CoverageReport): string {
+  const colour = report.core.percent >= 90 ? 'brightgreen' : report.core.percent >= 70 ? 'yellow' : 'orange';
+  const badge =
+    `[![Core coverage](https://img.shields.io/badge/core_coverage-${report.core.percent}%25-${colour}.svg)](eval/COVERAGE.md) ` +
+    `[![Total coverage](https://img.shields.io/badge/total_coverage-${report.total.percent}%25-lightgrey.svg)](eval/COVERAGE.md)`;
+  const start = readme.indexOf(BADGE_START);
+  const end = readme.indexOf(BADGE_END);
+  if (start < 0 || end < 0) return readme;
+  // Match the file's own line ending: splicing `\n` into a CRLF README would
+  // leave two mixed lines behind on every run.
+  const nl = dominantEol(readme);
+  return `${readme.slice(0, start + BADGE_START.length)}${nl}${badge}${nl}${readme.slice(end)}`;
+}

--- a/src/eval/coverage/coverageCli.ts
+++ b/src/eval/coverage/coverageCli.ts
@@ -13,25 +13,7 @@
 import * as fs from 'fs';
 import { renderMarkdown, danglingReferences, type CoverageReport } from './coverage.js';
 import { buildReport, JSON_PATH, MD_PATH, README_PATH } from './sources.js';
-
-const BADGE_START = '<!-- coverage-badge:start -->';
-const BADGE_END = '<!-- coverage-badge:end -->';
-
-/**
- * Rewrites the README badge block from the report. The badge is the public
- * reliability number promised in the LinkedIn thread — it is generated, never
- * hand-edited, so it cannot quietly disagree with eval/coverage.json.
- */
-function withBadge(readme: string, report: CoverageReport): string {
-  const colour = report.core.percent >= 90 ? 'brightgreen' : report.core.percent >= 70 ? 'yellow' : 'orange';
-  const badge =
-    `[![Core coverage](https://img.shields.io/badge/core_coverage-${report.core.percent}%25-${colour}.svg)](eval/COVERAGE.md) ` +
-    `[![Total coverage](https://img.shields.io/badge/total_coverage-${report.total.percent}%25-lightgrey.svg)](eval/COVERAGE.md)`;
-  const start = readme.indexOf(BADGE_START);
-  const end = readme.indexOf(BADGE_END);
-  if (start < 0 || end < 0) return readme;
-  return `${readme.slice(0, start + BADGE_START.length)}\n${badge}\n${readme.slice(end)}`;
-}
+import { normalizeEol, stripGeneratedAt, withBadge } from './artifactCompare.js';
 
 /** Machine-readable artifact — the shape the README badge and CI read. */
 function toJson(report: CoverageReport) {
@@ -52,11 +34,6 @@ function toJson(report: CoverageReport) {
     })),
     orphans: report.orphans,
   };
-}
-
-/** The generation timestamp must not make --check fail on an unchanged run. */
-function stripGeneratedAt(md: string): string {
-  return md.replace(/^_Generated .*_$/m, '');
 }
 
 function main(): number {
@@ -85,11 +62,13 @@ function main(): number {
 
   if (check) {
     const stale: string[] = [];
-    if (!fs.existsSync(JSON_PATH) || fs.readFileSync(JSON_PATH, 'utf8') !== json) stale.push('eval/coverage.json');
+    if (!fs.existsSync(JSON_PATH) || normalizeEol(fs.readFileSync(JSON_PATH, 'utf8')) !== normalizeEol(json)) {
+      stale.push('eval/coverage.json');
+    }
     if (!fs.existsSync(MD_PATH) || stripGeneratedAt(fs.readFileSync(MD_PATH, 'utf8')) !== stripGeneratedAt(markdown)) {
       stale.push('eval/COVERAGE.md');
     }
-    if (readme !== readmeNext) stale.push('README.md (coverage badge)');
+    if (normalizeEol(readme) !== normalizeEol(readmeNext)) stale.push('README.md (coverage badge)');
     if (stale.length > 0) {
       console.error(`❌ stale coverage artifact(s): ${stale.join(', ')} — run \`npm run eval:coverage\` and commit.`);
       return 1;

--- a/tests/eval/coverageArtifactCompare.test.ts
+++ b/tests/eval/coverageArtifactCompare.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `eval:coverage --check` must not depend on how git checked the artifacts out.
+ *
+ * Regression, found 2026-07-28 right after merging to main: the gate reported
+ *
+ *     ❌ stale coverage artifact(s): eval/coverage.json, eval/COVERAGE.md,
+ *        README.md (coverage badge) — run `npm run eval:coverage` and commit.
+ *
+ * while `git diff` was EMPTY. The artifacts are written with `\n`, but
+ * `core.autocrlf=true` (git's default on Windows, and what this repo's dev VM
+ * uses — measured: 1231 CRLF, 0 bare LF in a freshly checked-out
+ * eval/coverage.json) converts them to `\r\n` on checkout. The byte comparison
+ * then called every such checkout stale, and git normalized back on the way
+ * in, so nothing showed in the diff.
+ *
+ * Why it mattered rather than being cosmetic: the gate passed in CI
+ * (ubuntu-latest, LF) and failed for every Windows developer, so locally it
+ * proved nothing — and the natural "fix", regenerating and committing, would
+ * have committed CRLF artifacts and broken the gate on Linux instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeEol,
+  dominantEol,
+  stripGeneratedAt,
+  withBadge,
+  BADGE_START,
+  BADGE_END,
+} from '../../src/eval/coverage/artifactCompare';
+import type { CoverageReport } from '../../src/eval/coverage/coverage';
+
+const report = (corePct: number, totalPct: number) => ({
+  core: { tier: 'core', total: 44, covered: 44, percent: corePct },
+  total: { tier: 'all', total: 78, covered: 67, percent: totalPct },
+  leaves: [],
+  orphans: { knowledge: [], cases: [] },
+  queue: [],
+} as unknown as CoverageReport);
+
+const MD = [
+  '# Coverage — what "100%" means',
+  '',
+  '_Generated 2026-07-28_',
+  '',
+  '| leaf | K | E | T |',
+].join('\n');
+
+const README = [
+  '# d365fo-mcp-server',
+  '',
+  BADGE_START,
+  '[![Core coverage](https://img.shields.io/badge/core_coverage-97.7%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-84.6%25-lightgrey.svg)](eval/COVERAGE.md)',
+  BADGE_END,
+  '',
+  'Body text.',
+].join('\n');
+
+const toCrlf = (s: string) => s.replace(/\n/g, '\r\n');
+
+describe('coverage artifact staleness ignores line endings', () => {
+  it('the same markdown compares equal whether checked out LF or CRLF', () => {
+    expect(stripGeneratedAt(toCrlf(MD))).toBe(stripGeneratedAt(MD));
+  });
+
+  it('strips the generated-at line even with CRLF (the `$` anchor sat after a stray \\r)', () => {
+    expect(stripGeneratedAt(toCrlf(MD))).not.toContain('_Generated');
+    expect(stripGeneratedAt(MD)).not.toContain('_Generated');
+  });
+
+  it('still detects REAL markdown drift, so the gate is not merely disarmed', () => {
+    const changed = MD.replace('| leaf | K | E | T |', '| leaf | K | E |');
+    expect(stripGeneratedAt(toCrlf(changed))).not.toBe(stripGeneratedAt(MD));
+  });
+
+  it('the same JSON compares equal across line endings, but differing JSON does not', () => {
+    const json = '{\n  "core": 44\n}\n';
+    expect(normalizeEol(toCrlf(json))).toBe(normalizeEol(json));
+    expect(normalizeEol('{\n  "core": 43\n}\n')).not.toBe(normalizeEol(json));
+  });
+});
+
+describe('withBadge keeps the README consistent', () => {
+  it('is idempotent on an unchanged report — the badge block does not churn', () => {
+    const current = withBadge(README, report(97.7, 84.6));
+    expect(normalizeEol(current)).toBe(normalizeEol(README));
+  });
+
+  it('is idempotent on a CRLF README too (this was the third false "stale")', () => {
+    const crlf = toCrlf(README);
+    expect(normalizeEol(withBadge(crlf, report(97.7, 84.6)))).toBe(normalizeEol(crlf));
+  });
+
+  it('preserves CRLF instead of splicing in mixed endings', () => {
+    const out = withBadge(toCrlf(README), report(100, 85.9));
+    expect(out).not.toMatch(/[^\r]\n/);      // no bare LF left behind
+    expect(dominantEol(out)).toBe('\r\n');
+  });
+
+  it('preserves LF on an LF README', () => {
+    const out = withBadge(README, report(100, 85.9));
+    expect(out).not.toContain('\r');
+  });
+
+  it('still rewrites the badge when the numbers actually change', () => {
+    const out = withBadge(README, report(100, 85.9));
+    expect(out).toContain('core_coverage-100%25-brightgreen');
+    expect(out).toContain('total_coverage-85.9%25-lightgrey');
+    expect(out).not.toContain('core_coverage-97.7');
+  });
+
+  it('leaves a README without the badge markers untouched', () => {
+    const plain = '# no badge here\n';
+    expect(withBadge(plain, report(100, 85.9))).toBe(plain);
+  });
+});


### PR DESCRIPTION
## The bug

`npm run eval:coverage -- --check` failed on **every Windows checkout**, while `git diff` showed nothing:

```
❌ stale coverage artifact(s): eval/coverage.json, eval/COVERAGE.md,
   README.md (coverage badge) — run `npm run eval:coverage` and commit.
```

The artifacts are written with `\n`, but `core.autocrlf=true` (git's default on Windows, and what the dev VM uses) converts them to `\r\n` on checkout. Measured on a fresh checkout of `eval/coverage.json`:

```
CRLF: 1231   bare LF: 0
```

The byte comparison then called them stale — and git normalized back on the way in, so nothing ever appeared in the diff.

## Why this wasn't cosmetic

The gate **passed in CI** (`eval-gate.yml` runs on `ubuntu-latest`, LF) and **failed for every Windows developer**. So locally it proved nothing, and the natural "fix" — regenerate and commit — would have committed CRLF artifacts and broken the gate on Linux instead.

A gate that cries wolf on one platform and can be silenced by breaking the other is worse than no gate.

## The fix

Line endings are not content for this comparison, so **normalize** rather than pin them with `.gitattributes`. The gate then holds under any `core.autocrlf` setting instead of depending on every clone agreeing.

Three places were affected, not one:

| Artifact | Why it reported stale |
|---|---|
| `eval/coverage.json` | Plain byte comparison against freshly generated `\n` content. |
| `eval/COVERAGE.md` | Worse — `stripGeneratedAt` uses `^_Generated .*_$`, and under CRLF the `$` anchor sits after a stray `\r`, so the strip silently missed and the **timestamp alone** made it look stale. |
| README badge | `withBadge` always spliced `\n`, so on a CRLF README the rewrite differed every run. |

`withBadge` now matches the file's own line ending, so a rewrite no longer leaves two mixed lines behind.

The helpers moved to `artifactCompare.ts` to be testable at all: `coverageCli` runs `process.exit(main())` at module load, so importing it from a test would run the CLI and kill the test process.

## Verification

**Confirmed red before the fix** — 2 of 10 fail, including the CRLF strip and the mixed-endings splice.

The tests deliberately assert the gate still catches **real** drift (changed markdown, changed JSON, changed badge numbers), so this is not just disarming it.

```
✅ coverage up to date — core 44/44 (100%), total 67/78 (85.9%)
```

353 eval tests pass · `tsc --noEmit` clean · no artifact regenerated or recommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182Dqj7bduTYw1VSY8a8F4b