### PR TITLE
fix(paths): read process.platform per call, not once at import

### DIFF
--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -54,7 +54,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
         },
         packagePath: {
           type: 'string',
-          description: 'Base package path (default: K:\\AosService\\PackagesLocalDirectory). [modify] also locates objects outside the default dir; for models outside bridge startup roots set D365FO_CUSTOM_PACKAGES_PATH or pass filePath.'
+          description: 'Base package path (default: auto-detected PackagesLocalDirectory). [modify] also locates objects outside the default dir; for models outside bridge startup roots set D365FO_CUSTOM_PACKAGES_PATH or pass filePath.'
         },
         sourceCode: {
           type: 'string',

--- a/src/server/toolSchemas/verifyD365foProject.ts
+++ b/src/server/toolSchemas/verifyD365foProject.ts
@@ -41,7 +41,7 @@ export const verifyD365foProjectTool = {
           description: 'Model name. Auto-detected from mcp.json if omitted.',
         },
         packageName: { type: 'string', description: 'Package name. Auto-resolved from model name if omitted.' },
-        packagePath: { type: 'string', description: 'Base package path (default: K:\\AosService\\PackagesLocalDirectory)' },
+        packagePath: { type: 'string', description: 'Base package path (default: auto-detected PackagesLocalDirectory)' },
       },
     },
   };

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -11,7 +11,7 @@ import type { BridgeClient } from '../bridge/bridgeClient.js';
 import path from 'path';
 import fs from 'fs';
 import { getConfigManager } from '../utils/configManager.js';
-import { defaultPackagesRoot } from '../utils/packagesRoot.js';
+import { defaultPackagesRoot, describePackagesRootScan } from '../utils/packagesRoot.js';
 import { resolveObjectPrefix, applyObjectPrefix, getObjectSuffix, applyObjectSuffix } from '../utils/modelClassifier.js';
 import { ProjectFileManager } from './createD365File.js';
 import { extractModelFromProject, findProjectInSolution } from '../utils/projectUtils.js';
@@ -570,8 +570,8 @@ export async function handleGenerateSmartTable(
   // made "just show me the XML" fail on any machine without a D365FO install.
   if (!resolvedPackagePath && process.platform === 'win32' && !preview) {
     throw new Error(
-      '\u274c Cannot determine PackagesLocalDirectory path.\n\n' +
-      'Neither C:\\AosService\\PackagesLocalDirectory nor K:\\AosService\\PackagesLocalDirectory were found.\n\n' +
+      '❌ Cannot determine PackagesLocalDirectory path.\n\n' +
+      `${describePackagesRootScan()}\n\n` +
       'If your D365FO installation is on a different drive, add one of the following to your .mcp.json:\n' +
       '  \u2022 "packagePath": "<drive>:\\\\AosService\\\\PackagesLocalDirectory"\n' +
       '  \u2022 "workspacePath": "<drive>:\\\\AosService\\\\PackagesLocalDirectory\\\\YourModel"\n' +

--- a/src/tools/verifyD365Project.ts
+++ b/src/tools/verifyD365Project.ts
@@ -89,7 +89,7 @@ const VerifyD365ProjectArgsSchema = z.object({
   packagePath: z
     .string()
     .optional()
-    .describe('Base package path (default: K:\\AosService\\PackagesLocalDirectory)'),
+    .describe('Base package path (default: auto-detected PackagesLocalDirectory)'),
 });
 
 /** Read all Content Include values from a .rnrproj XML file. */

--- a/src/utils/packagesRoot.ts
+++ b/src/utils/packagesRoot.ts
@@ -49,7 +49,13 @@ export interface ProbeIo {
 }
 
 const realIo: ProbeIo = {
-  platform: process.platform,
+  // Read through to process.platform on every access rather than snapshotting it
+  // at import time — a frozen copy makes the scan ignore a platform override, so
+  // the "not on Windows" path can only be exercised on a non-Windows machine and
+  // the corresponding test silently passes on CI while failing on a real VM.
+  get platform(): NodeJS.Platform {
+    return process.platform;
+  },
   isDirectory(target: string): boolean {
     try {
       return fs.statSync(target).isDirectory();

--- a/tests/utils/configManager.test.ts
+++ b/tests/utils/configManager.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getConfigManager, fallbackPackagePath, extractModelFromFilePath } from '../../src/utils/configManager';
+import { resetPackagesRootCache } from '../../src/utils/packagesRoot';
 
 // Prevent real file I/O during unit tests
 vi.mock('fs/promises', () => ({
@@ -171,14 +172,20 @@ describe('explicit modelName overrides workspacePath last-segment extraction', (
 
 describe('no workspacePath configured', () => {
   it('getPackagePath returns null when no path and not on Windows', () => {
-    // Non-Windows platform → well-known probe is skipped
+    // Non-Windows platform → the AosService drive scan is skipped entirely.
+    // The scan memoises its result for the process lifetime, so the cache has to
+    // be dropped on both sides of the override: once so this test scans as Linux
+    // rather than reusing a Windows result, and once afterwards so the empty
+    // Linux result does not leak into whatever runs next.
     const origPlatform = process.platform;
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    resetPackagesRootCache();
 
     const mgr = makeManager({});
     expect(mgr.getPackagePath()).toBeNull();
 
     Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+    resetPackagesRootCache();
   });
 
   it('getModelName falls back to D365FO_MODEL_NAME env var', () => {


### PR DESCRIPTION
Follow-up to #788, found while verifying that PR end-to-end on a real D365FO VM.

#788 itself is sound — on this VM the scan resolves `K:\AosService\PackagesLocalDirectory`, `xppc.exe` builds the Contoso model in 40s with 0 errors, `xppbp.exe` runs, the bridge csproj evaluates `D365BinPath` to `K:\...\bin` and compiles with 0 warnings, and `doctor` reports the new packages-root check as OK. But it left one test red and three cosmetic claims unfinished.

## The bug

`src/utils/packagesRoot.ts` built its filesystem seam as an object literal:

```ts
const realIo: ProbeIo = { platform: process.platform, ... };
```

That freezes the platform at module load. `tests/utils/configManager.test.ts > "getPackagePath returns null when no path and not on Windows"` flips `process.platform` to `'linux'` *after* the import, so the probe no longer switched off and the test got the real `K:` volume where it expected `null`.

**Linux CI never saw this.** There the frozen value is already `'linux'`, the scan short-circuits to `[]`, and the test passes — so the suite stayed green on CI while failing on the only platform the drive scan exists for.

Fix: make `platform` a getter so the seam reads through on every access. The test also resets the memoised scan on both sides of the override, since `packagesRoots()` caches for the process lifetime.

Only the test seam was affected — `process.platform` never changes at runtime, so production behaviour was always correct. Confirmed unchanged on Windows: the scan still returns `K:\AosService\PackagesLocalDirectory`.

## Cosmetic leftovers from #788

- `generateSmartTable.ts` — the "cannot determine PackagesLocalDirectory" error still read *"Neither C:\… nor K:\… were found"* instead of printing `describePackagesRootScan()`, which is what #788's commit message said these errors would do.
- `toolSchemas/d365foFile.ts`, `toolSchemas/verifyD365foProject.ts`, `verifyD365Project.ts` — the agent-visible schemas still documented `default: K:\AosService\PackagesLocalDirectory`, i.e. exactly the wrong-drive claim #788 set out to remove. (#788 did update the zod schema in `createD365File.ts`, just not the MCP schemas.)

The replacement wording is deliberately the same length as the original: `toolSchemaBudget` caps the ListTools payload and `d365fo_file` sat **4 characters** under its per-tool cap — a longer, friendlier phrasing failed the budget test at 9866/9800.

## Verification on the VM

- `npx vitest run` → **180/180 files, 2378 passed, 2 skipped, 0 failed** (was 1 failed before this change)
- `npx tsc --noEmit` → clean
- `npm run build` → clean; `doctor` from the rebuilt `dist/` still reports `packages root OK` and no blocking problems
- `scanPackagesRoots()` with `process.platform` forced to `'linux'` → `[]`; unforced on Windows → `["K:\AosService\PackagesLocalDirectory"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
