### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps `package.json` / `package-lock.json` to **1.6.0**. Nothing else changes — the release notes and the npm publish are produced by `.github/workflows/release.yml` when the `v1.6.0` tag is pushed.

Minor (not patch) because v1.5.2..HEAD contains new capability, not just fixes.

## Highlights since v1.5.2

**Features**
- `feat(knowledge)`: new class-inheritance topic; corrected CoC-on-inherited guidance

**Inheritance-aware lookups**
- `get_method` resolves methods inherited from a base class
- `extension_info` / `get_object_info` see inherited members; eligibility fixed
- `extension_info` takes access modifiers from the bridge, via `getCompletionMembers`
- `prepare` walks the extends chain for inherited methods

**Scaffolding / build fixes**
- report field EDTs resolved from the index instead of a hardcoded ladder, reconciled with the emitted field and RDL type
- real extension XML emitted for data-entity and menu-item extensions
- a finished build is never replayed as a fresh result
- `setup` no longer copies `.mcp.json` into the staging folder

**Paths**
- `process.platform` read per call rather than once at import
- AosService located by scanning drives instead of guessing `K:`

**Eval loop**
- class-inheritance case added and its coverage orphan closed; several L2/L3/L4 leaves closed with captured goldens
- all 65 captured goldens re-verified against the compiler — 65/65 clean
- coverage gate no longer depends on checkout line endings

## Verification

- `npm run build` — clean
- `npx vitest run` — 180 files, 2378 passed, 2 skipped

## Release steps after merge

```
git checkout main && git pull
git tag v1.6.0 && git push origin v1.6.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
