### PR TITLE
fix(object-info): fall back to the symbol index when the bridge is silent

### DIFF
--- a/src/tools/dataEntityInfo.ts
+++ b/src/tools/dataEntityInfo.ts
@@ -2,14 +2,18 @@
  * Data Entity Info Tool
  * Retrieve rich D365FO-specific metadata for data entities (OData, DMF, staging, sources).
  *
- * PRIMARY: C# bridge (IMetadataProvider) — 100% reliable, always available on VM.
- * SQLite "did you mean?" kept only on error path.
+ * Read-path priority:
+ *   1. C# bridge readDataEntity (IMetadataProvider) — live metadata.
+ *   2. get_object_info(view) reader — data entities are indexed as type 'view', so its
+ *      extracted-metadata / XML / disk chain answers when the bridge is silent.
+ *   3. Fuzzy "did you mean?" suggestions from the index.
  */
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { tryBridgeDataEntity } from '../bridge/bridgeAdapter.js';
+import { getViewInfoTool } from './viewInfo.js';
 
 const DataEntityInfoArgsSchema = z.object({
   entityName: z.string().describe('Name of the data entity (AxDataEntityView)'),
@@ -23,7 +27,15 @@ export async function dataEntityInfoTool(request: CallToolRequest, context: XppS
     const bridgeResult = await tryBridgeDataEntity(context.bridge, args.entityName);
     if (bridgeResult) return bridgeResult;
 
-    // Bridge returned nothing — try fuzzy name suggestions from DB
+    // Bridge silent — reuse the view reader's symbol-index/XML/disk chain.
+    // Data entities are AxDataEntityView files and are indexed as type 'view'.
+    const viaView = await getViewInfoTool(
+      { method: 'tools/call', params: { name: 'get_view_info', arguments: { viewName: args.entityName } } },
+      context,
+    ) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+    if (!viaView?.isError) return viaView;
+
+    // Nothing resolved — fuzzy name suggestions from DB
     let text = `Data entity not found: ${args.entityName}\n`;
     try {
       const db = context.symbolIndex.getReadDb();

--- a/src/tools/enumInfo.ts
+++ b/src/tools/enumInfo.ts
@@ -2,14 +2,25 @@
  * Get Enum Info Tool
  * Extract enum values and enum properties.
  *
- * PRIMARY: C# bridge (IMetadataProvider) — 100% reliable, always available on VM.
- * No SQLite / XML fallback needed — bridge returns complete enum metadata.
+ * Read-path priority (same chain as tableInfo / viewInfo):
+ *   1. C# bridge (IMetadataProvider) — live metadata.
+ *   2. Symbol index → extracted-metadata JSON / AxEnum XML (indexed or remapped path).
+ *   3. Disk scan — an enum created this session and not yet indexed.
  */
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { parseStringPromise } from 'xml2js';
 import type { XppServerContext } from '../types/context.js';
 import { tryBridgeEnum } from '../bridge/bridgeAdapter.js';
+import { readEnumRawXml, buildObjectTypeMismatchMessage } from '../utils/metadataResolver.js';
+import {
+  resolveIndexedObject,
+  readXmlFile,
+  indexedSourceNote,
+  bridgeUnavailableNote,
+} from '../utils/indexedXmlLookup.js';
+import { findD365FileOnDisk } from './modifyD365File.js';
 
 const GetEnumInfoArgsSchema = z.object({
   enumName: z.string().describe('Name of the enum'),
@@ -23,17 +34,41 @@ export async function getEnumInfoTool(request: CallToolRequest, context: XppServ
   try {
     const args = GetEnumInfoArgsSchema.parse(request.params.arguments);
 
-    // C# bridge (IMetadataProvider — live D365FO metadata, always available)
+    // 1. C# bridge (IMetadataProvider — live D365FO metadata)
     const bridgeResult = await tryBridgeEnum(context.bridge, args.enumName);
     if (bridgeResult) return bridgeResult;
 
-    return {
-      content: [{
-        type: 'text',
-        text: `Enum "${args.enumName}" not found. Bridge returned no data — ensure the enum exists in D365FO metadata.`,
-      }],
-      isError: true,
-    };
+    // 2. Symbol index → extracted metadata JSON, then the indexed XML file.
+    //    A silent bridge is not proof the enum is missing (#14).
+    const ref = await resolveIndexedObject(
+      context.symbolIndex.getReadDb(), args.enumName, ['enum'], args.modelName,
+    );
+    if (ref) {
+      const extractedXml = await readEnumRawXml(ref.model, ref.name);
+      const xml = extractedXml
+        ?? (ref.localPath ? await readXmlFile(ref.localPath) : null);
+      const source = extractedXml ? 'symbol index (extracted metadata)' : `XML: ${ref.localPath}`;
+      const formatted = xml && await formatEnumXml(ref.name, ref.model, xml, source, args.includeLabels);
+      if (formatted) return formatted;
+    }
+
+    // 3. Disk scan — an enum created this session and not yet indexed
+    const diskPath = await findD365FileOnDisk('enum', args.enumName, args.modelName);
+    if (diskPath) {
+      const xml = await readXmlFile(diskPath);
+      const formatted = xml && await formatEnumXml(
+        args.enumName, args.modelName ?? 'Unknown', xml,
+        `live file (not yet in bridge metadata): ${diskPath}`, args.includeLabels,
+      );
+      if (formatted) return formatted;
+    }
+
+    let text = `Enum "${args.enumName}" not found via bridge, symbol index, or on disk.\n`;
+    text += bridgeUnavailableNote(context.bridge);
+    try {
+      text += buildObjectTypeMismatchMessage(context.symbolIndex.getReadDb(), args.enumName, 'enum');
+    } catch { /* DB unavailable */ }
+    return { content: [{ type: 'text', text }], isError: true };
   } catch (error) {
     return {
       content: [{
@@ -43,6 +78,47 @@ export async function getEnumInfoTool(request: CallToolRequest, context: XppServ
       isError: true,
     };
   }
+}
+
+/** Parse AxEnum XML and render values. Returns null when the XML isn't an AxEnum. */
+async function formatEnumXml(
+  enumName: string,
+  model: string,
+  xml: string,
+  source: string,
+  includeLabels: boolean,
+): Promise<{ content: { type: 'text'; text: string }[] } | null> {
+  let axEnum: any;
+  try {
+    axEnum = (await parseStringPromise(xml))?.AxEnum;
+  } catch {
+    return null;
+  }
+  if (!axEnum) return null;
+
+  const values = (axEnum.EnumValues?.[0]?.AxEnumValue ?? []).map((v: any) => ({
+    name: v.Name?.[0] ?? 'Unknown',
+    value: v.Value?.[0] != null ? parseInt(v.Value[0], 10) : 0,
+    label: includeLabels ? v.Label?.[0] : undefined,
+  }));
+
+  let out = `# Enum: \`${axEnum.Name?.[0] ?? enumName}\`\n\n`;
+  out += `**Model:** ${model}\n`;
+  out += `**Extensible:** ${axEnum.IsExtensible?.[0] === 'Yes' ? 'Yes' : 'No'}\n`;
+  out += `**Use Enum Value:** ${axEnum.UseEnumValue?.[0] === 'Yes' ? 'Yes' : 'No'}\n`;
+  if (axEnum.Label?.[0]) out += `**Label:** ${axEnum.Label[0]}\n`;
+  out += indexedSourceNote(source);
+
+  if (values.length > 0) {
+    out += `## 📋 Enum Values (${values.length})\n\n`;
+    out += `| Name | Value${includeLabels ? ' | Label' : ''} |\n`;
+    out += `|------|-------${includeLabels ? '|-------' : ''}|\n`;
+    for (const v of values) {
+      out += `| ${v.name} | ${v.value}${includeLabels ? ` | ${v.label || '—'}` : ''} |\n`;
+    }
+  }
+
+  return { content: [{ type: 'text', text: out }] };
 }
 
 // Tool registration (name, description, inputSchema) lives inline in

--- a/src/tools/formInfo.ts
+++ b/src/tools/formInfo.ts
@@ -14,6 +14,7 @@ import type { XppServerContext } from '../types/context.js';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
 import { tryBridgeForm } from '../bridge/bridgeAdapter.js';
+import { readIndexedXml } from '../utils/indexedXmlLookup.js';
 import { assertWritePathAllowed } from '../utils/pathContainment.js';
 
 const GetFormInfoArgsSchema = z.object({
@@ -111,6 +112,21 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
 
     const bridgeResult = await tryBridgeForm(context.bridge, formName);
     if (bridgeResult) return bridgeResult;
+
+    // Symbol index → form XML. A silent bridge is not proof the form is missing:
+    // it also happens when the bridge is down or its provider does not cover that
+    // package, while `search` still resolves the form.
+    const indexed = await readIndexedXml(
+      context.symbolIndex.getReadDb(), formName, ['form'], args.modelName,
+    );
+    if (indexed) {
+      try {
+        return await parseAndFormatForm(
+          indexed.ref.name, indexed.ref.model, indexed.xml,
+          includeControls, includeDataSources, includeMethods, searchControl,
+        );
+      } catch { /* not a usable AxForm XML — fall through to the error below */ }
+    }
 
     // Determine why the bridge returned nothing to give an actionable error message.
     let bridgeNote: string;

--- a/src/tools/queryInfo.ts
+++ b/src/tools/queryInfo.ts
@@ -2,14 +2,25 @@
  * Get Query Info Tool
  * Extract query structure: datasources, ranges, joins.
  *
- * PRIMARY: C# bridge (IMetadataProvider) — 100% reliable, always available on VM.
- * No SQLite path-lookup / XML parsing needed — bridge returns complete query metadata.
+ * Read-path priority (same chain as tableInfo / viewInfo):
+ *   1. C# bridge (IMetadataProvider) — live metadata.
+ *   2. Symbol index → query XML (indexed path, or remapped onto the local packages root).
+ *   3. Disk scan — a query created this session and not yet indexed.
  */
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { parseStringPromise } from 'xml2js';
 import type { XppServerContext } from '../types/context.js';
 import { tryBridgeQuery } from '../bridge/bridgeAdapter.js';
+import { buildObjectTypeMismatchMessage } from '../utils/metadataResolver.js';
+import {
+  readIndexedXml,
+  readXmlFile,
+  indexedSourceNote,
+  bridgeUnavailableNote,
+} from '../utils/indexedXmlLookup.js';
+import { findD365FileOnDisk } from './modifyD365File.js';
 
 const GetQueryInfoArgsSchema = z.object({
   queryName: z.string().describe('Name of the query'),
@@ -21,21 +32,59 @@ const GetQueryInfoArgsSchema = z.object({
   workspacePath: z.string().optional().describe('Path to workspace'),
 });
 
+interface QueryRange {
+  field: string;
+  value: string;
+  operator?: string;
+}
+
+interface QueryDataSource {
+  name: string;
+  table: string;
+  fetchMode: string;
+  ranges: QueryRange[];
+  joins: QueryDataSource[];
+  fields: string[];
+}
+
 export async function getQueryInfoTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = GetQueryInfoArgsSchema.parse(request.params.arguments);
 
-    // C# bridge (IMetadataProvider — live D365FO metadata, always available)
+    // 1. C# bridge (IMetadataProvider — live D365FO metadata)
     const bridgeResult = await tryBridgeQuery(context.bridge, args.queryName);
     if (bridgeResult) return bridgeResult;
 
-    return {
-      content: [{
-        type: 'text',
-        text: `Query "${args.queryName}" not found. Bridge returned no data — ensure the query exists in D365FO metadata.`,
-      }],
-      isError: true,
-    };
+    // 2. Symbol index → XML. The bridge returning nothing is NOT proof the query is
+    //    missing — it also happens when the bridge is down or its provider does not
+    //    cover that package, while `search` still resolves the object.
+    const indexed = await readIndexedXml(
+      context.symbolIndex.getReadDb(), args.queryName, ['query'], args.modelName,
+    );
+    if (indexed) {
+      const formatted = await formatQueryXml(
+        indexed.ref.name, indexed.ref.model, indexed.xml, `XML: ${indexed.ref.localPath}`, args,
+      );
+      if (formatted) return formatted;
+    }
+
+    // 3. Disk scan — a query created this session and not yet indexed
+    const diskPath = await findD365FileOnDisk('query', args.queryName, args.modelName);
+    if (diskPath) {
+      const xml = await readXmlFile(diskPath);
+      const formatted = xml && await formatQueryXml(
+        args.queryName, args.modelName ?? 'Unknown', xml,
+        `live file (not yet in bridge metadata): ${diskPath}`, args,
+      );
+      if (formatted) return formatted;
+    }
+
+    let text = `Query "${args.queryName}" not found via bridge, symbol index, or on disk.\n`;
+    text += bridgeUnavailableNote(context.bridge);
+    try {
+      text += buildObjectTypeMismatchMessage(context.symbolIndex.getReadDb(), args.queryName, 'query');
+    } catch { /* DB unavailable */ }
+    return { content: [{ type: 'text', text }], isError: true };
   } catch (error) {
     return {
       content: [{
@@ -47,5 +96,115 @@ export async function getQueryInfoTool(request: CallToolRequest, context: XppSer
   }
 }
 
+/** Parse AxQuery XML and render the datasource hierarchy. Returns null when the XML isn't an AxQuery. */
+async function formatQueryXml(
+  queryName: string,
+  model: string,
+  xml: string,
+  source: string,
+  opts: { includeRanges: boolean; includeJoins: boolean; includeFields: boolean },
+): Promise<{ content: { type: 'text'; text: string }[] } | null> {
+  let axQuery: any;
+  try {
+    axQuery = (await parseStringPromise(xml))?.AxQuery;
+  } catch {
+    return null;
+  }
+  if (!axQuery) return null;
+
+  const dataSources = axQuery.DataSources?.[0]
+    ? extractDataSources(axQuery.DataSources[0], opts)
+    : [];
+
+  let out = `# Query: \`${queryName}\`\n\n**Model:** ${model}\n`;
+  if (axQuery.Description?.[0]) out += `**Description:** ${axQuery.Description[0]}\n`;
+  out += indexedSourceNote(source);
+
+  if (dataSources.length > 0) {
+    out += `## 📊 Data Sources\n\n`;
+    out += formatHierarchy(dataSources, 0, opts);
+  }
+  out += `## 📈 Summary\n\n`;
+  out += `- **Data Sources:** ${countDataSources(dataSources)}\n`;
+  out += `- **Total Ranges:** ${countRanges(dataSources)}\n`;
+
+  return { content: [{ type: 'text', text: out }] };
+}
+
+function extractDataSources(
+  node: any,
+  opts: { includeRanges: boolean; includeJoins: boolean; includeFields: boolean },
+): QueryDataSource[] {
+  const out: QueryDataSource[] = [];
+  // Root/embedded datasources use different element names across query flavours.
+  const nodes = [
+    ...(node.AxQuerySimpleRootDataSource ?? []),
+    ...(node.AxQuerySimpleEmbeddedDataSource ?? []),
+    ...(node.AxQuerySimpleRootObject ?? []),
+  ];
+  for (const dsNode of nodes) {
+    out.push({
+      name: dsNode.Name?.[0] ?? 'Unknown',
+      table: dsNode.Table?.[0] ?? 'Unknown',
+      fetchMode: dsNode.FetchMode?.[0] ?? 'Unknown',
+      ranges: opts.includeRanges && dsNode.Ranges?.[0] ? extractRanges(dsNode.Ranges[0]) : [],
+      fields: opts.includeFields && dsNode.Fields?.[0] ? extractFields(dsNode.Fields[0]) : [],
+      joins: opts.includeJoins && dsNode.DataSources?.[0] ? extractDataSources(dsNode.DataSources[0], opts) : [],
+    });
+  }
+  return out;
+}
+
+function extractRanges(node: any): QueryRange[] {
+  return (node.AxQuerySimpleDataSourceRange ?? []).map((r: any) => ({
+    field: r.Field?.[0] ?? 'Unknown',
+    value: r.Value?.[0] ?? '',
+    operator: r.Operator?.[0],
+  }));
+}
+
+function extractFields(node: any): string[] {
+  return (node.AxQuerySimpleDataSourceField ?? []).map((f: any) => f.Field?.[0] ?? 'Unknown');
+}
+
+function formatHierarchy(
+  dataSources: QueryDataSource[],
+  indent: number,
+  opts: { includeRanges: boolean; includeJoins: boolean; includeFields: boolean },
+): string {
+  let out = '';
+  const pad = '  '.repeat(indent);
+  for (const ds of dataSources) {
+    out += `${pad}### ${ds.name}\n\n${pad}**Table:** \`${ds.table}\`\n${pad}**Fetch Mode:** ${ds.fetchMode}\n\n`;
+    if (opts.includeRanges && ds.ranges.length > 0) {
+      out += `${pad}**Ranges:**\n`;
+      for (const r of ds.ranges) {
+        out += `${pad}- **${r.field}**${r.operator ? ` (${r.operator})` : ''}: \`${r.value}\`\n`;
+      }
+      out += '\n';
+    }
+    if (opts.includeFields && ds.fields.length > 0) {
+      out += `${pad}**Fields (${ds.fields.length}):**\n`;
+      for (const f of ds.fields.slice(0, 10)) out += `${pad}- ${f}\n`;
+      if (ds.fields.length > 10) out += `${pad}- ... (${ds.fields.length - 10} more fields)\n`;
+      out += '\n';
+    }
+    if (opts.includeJoins && ds.joins.length > 0) {
+      out += `${pad}**Joined Data Sources:**\n\n`;
+      out += formatHierarchy(ds.joins, indent + 1, opts);
+    }
+  }
+  return out;
+}
+
+function countDataSources(dataSources: QueryDataSource[]): number {
+  return dataSources.reduce((n, ds) => n + 1 + countDataSources(ds.joins), 0);
+}
+
+function countRanges(dataSources: QueryDataSource[]): number {
+  return dataSources.reduce((n, ds) => n + ds.ranges.length + countRanges(ds.joins), 0);
+}
+
 // Tool registration (name, description, inputSchema) lives inline in
 // src/server/mcpServer.ts - the single source of truth for tool instructions.
+

--- a/src/tools/reportInfo.ts
+++ b/src/tools/reportInfo.ts
@@ -15,6 +15,7 @@ import type { XppServerContext } from '../types/context.js';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
 import { tryBridgeReport } from '../bridge/bridgeAdapter.js';
+import { readIndexedXml, bridgeUnavailableNote } from '../utils/indexedXmlLookup.js';
 import { assertWritePathAllowed } from '../utils/pathContainment.js';
 
 const GetReportInfoArgsSchema = z.object({
@@ -115,29 +116,34 @@ export async function getReportInfoTool(request: CallToolRequest, context: XppSe
         };
       }
 
-      const xmlObj = await parseStringPromise(xmlContent, { explicitArray: true, mergeAttrs: false, trim: true });
-      const axReport = xmlObj?.AxReport;
-      if (!axReport) {
+      const parsed = await buildReportResponse(
+        xmlContent, reportName, 'Unknown', explicitFilePath, includeFields ?? true, includeRdl ?? false,
+      );
+      if (!parsed) {
         return { content: [{ type: 'text', text: `❌ File does not contain a valid <AxReport> root element.` }], isError: true };
       }
+      return parsed;
+    }
 
-      const info: ReportInfo = {
-        name:                first(axReport.Name) ?? reportName,
-        model:               'Unknown',
-        filePath:            explicitFilePath,
-        hasDataMethods:      !!axReport.DataMethods && axReport.DataMethods[0] !== '',
-        embeddedImageCount:  countItems(axReport.EmbeddedImages?.[0], 'AxReportEmbeddedImage'),
-        dataSets:            extractDataSets(axReport, includeFields ?? true),
-        designs:             extractDesigns(axReport, includeRdl ?? false),
-      };
-
-      return formatOutput(info, includeFields ?? true, includeRdl ?? false);
+    // 3. Symbol index → report XML. A silent bridge is not proof the report is
+    //    missing — it also happens when the bridge is down or its provider does not
+    //    cover that package, while `search` still resolves the report.
+    const indexed = await readIndexedXml(
+      context.symbolIndex.getReadDb(), reportName, ['report'], args.modelName,
+    );
+    if (indexed) {
+      const parsed = await buildReportResponse(
+        indexed.xml, indexed.ref.name, indexed.ref.model, indexed.ref.localPath ?? '',
+        includeFields ?? true, includeRdl ?? false,
+      );
+      if (parsed) return parsed;
     }
 
     return {
       content: [{
         type: 'text',
-        text: `❌ Report "${reportName}" not found via bridge.\n\n` +
+        text: `❌ Report "${reportName}" not found via bridge or symbol index.` +
+          bridgeUnavailableNote(context.bridge) + `\n` +
           `If this is a newly-created report, pass the explicit \`filePath\` parameter:\n` +
           `  get_object_info(objectType="report", name="${reportName}", options={filePath:"<absolute path to .xml>"})`,
       }],
@@ -152,6 +158,41 @@ export async function getReportInfoTool(request: CallToolRequest, context: XppSe
       isError: true,
     };
   }
+}
+
+/**
+ * Parse AxReport XML and render the tool response.
+ * Shared by the explicit-filePath bypass and the symbol-index fallback.
+ * Returns null when the XML has no <AxReport> root.
+ */
+async function buildReportResponse(
+  xmlContent: string,
+  reportName: string,
+  model: string,
+  filePath: string,
+  includeFields: boolean,
+  includeRdl: boolean,
+) {
+  let axReport: any;
+  try {
+    const xmlObj = await parseStringPromise(xmlContent, { explicitArray: true, mergeAttrs: false, trim: true });
+    axReport = xmlObj?.AxReport;
+  } catch {
+    return null;
+  }
+  if (!axReport) return null;
+
+  const info: ReportInfo = {
+    name:                first(axReport.Name) ?? reportName,
+    model,
+    filePath,
+    hasDataMethods:      !!axReport.DataMethods && axReport.DataMethods[0] !== '',
+    embeddedImageCount:  countItems(axReport.EmbeddedImages?.[0], 'AxReportEmbeddedImage'),
+    dataSets:            extractDataSets(axReport, includeFields),
+    designs:             extractDesigns(axReport, includeRdl),
+  };
+
+  return formatOutput(info, includeFields, includeRdl);
 }
 
 function first(arr: any): string | undefined {

--- a/src/tools/viewInfo.ts
+++ b/src/tools/viewInfo.ts
@@ -1,15 +1,29 @@
 /**
  * Get View Info Tool
- * Extract data entity view structure: computed columns, relations, methods.
+ * Extract view / data entity view structure: fields, computed columns, relations, methods.
  *
- * PRIMARY: C# bridge (IMetadataProvider) — 100% reliable, always available on VM.
- * No SQLite / XML fallback needed — bridge returns complete view metadata.
+ * Read-path priority (mirrors tableInfo):
+ *   1. C# bridge readView       — live AxView metadata (IMetadataProvider).
+ *   2. C# bridge readDataEntity — AxDataEntityView; the symbol index stores data
+ *      entities as type 'view', so `objectType="view"` legitimately resolves them.
+ *   3. Symbol index → extracted metadata JSON / XML on disk — serves offline,
+ *      Azure-hosted and "package not on this box" (UDE) scenarios, where `search`
+ *      finds the view but the bridge's DiskProvider does not.
+ *   4. Disk scan — a view created this session and not yet indexed.
  */
 
+import * as path from 'path';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { tryBridgeView } from '../bridge/bridgeAdapter.js';
+import { tryBridgeView, tryBridgeDataEntity } from '../bridge/bridgeAdapter.js';
+import { readViewMetadata, buildObjectTypeMismatchMessage } from '../utils/metadataResolver.js';
+import {
+  resolveIndexedObject,
+  indexedSourceNote,
+  bridgeUnavailableNote,
+} from '../utils/indexedXmlLookup.js';
+import { findD365FileOnDisk } from './modifyD365File.js';
 
 const GetViewInfoArgsSchema = z.object({
   viewName: z.string().describe('Name of the view or data entity'),
@@ -21,19 +35,53 @@ const GetViewInfoArgsSchema = z.object({
   workspacePath: z.string().optional().describe('Path to workspace'),
 });
 
+/** Normalised view shape shared by the extracted-metadata JSON and the XML parser. */
+interface ViewLike {
+  name: string;
+  model?: string;
+  type?: 'view' | 'data-entity';
+  label?: string;
+  isPublic?: boolean;
+  isReadOnly?: boolean;
+  primaryKey?: string;
+  fields?: Array<{
+    name: string;
+    dataSource?: string;
+    dataField?: string;
+    dataMethod?: string;
+    isComputed?: boolean;
+  }>;
+  relations?: Array<{
+    name: string;
+    relatedTable: string;
+    cardinality?: string;
+    fields?: Array<{ field: string; relatedField: string }>;
+  }>;
+  methods?: Array<{ name: string } | string>;
+}
+
 export async function getViewInfoTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = GetViewInfoArgsSchema.parse(request.params.arguments);
 
-    // C# bridge (IMetadataProvider — live D365FO metadata, always available)
+    // 1. C# bridge — AxView (live D365FO metadata)
     const bridgeResult = await tryBridgeView(context.bridge, args.viewName);
     if (bridgeResult) return bridgeResult;
 
+    // 2. C# bridge — AxDataEntityView (data entities are indexed as type 'view')
+    const entityResult = await tryBridgeDataEntity(context.bridge, args.viewName);
+    if (entityResult) return entityResult;
+
+    // 3. Symbol index → extracted metadata / XML
+    const indexResult = await buildViewResponseFromIndex(context, args.viewName, args.modelName);
+    if (indexResult) return indexResult;
+
+    // 4. Disk scan — a view created this session and not yet indexed
+    const diskResult = await buildViewResponseFromDisk(context, args.viewName, args.modelName);
+    if (diskResult) return diskResult;
+
     return {
-      content: [{
-        type: 'text',
-        text: `View "${args.viewName}" not found. Bridge returned no data — ensure the view exists in D365FO metadata.`,
-      }],
+      content: [{ type: 'text', text: buildNotFoundText(context, args.viewName) }],
       isError: true,
     };
   } catch (error) {
@@ -45,6 +93,151 @@ export async function getViewInfoTool(request: CallToolRequest, context: XppServ
       isError: true,
     };
   }
+}
+
+/**
+ * Serve view info from the symbol index: extracted-metadata JSON first, then the
+ * indexed XML file (remapped to the local packages path when the DB stores a
+ * build-agent path). Falls back to the indexed field/method symbols so a view the
+ * index knows about is never reported as "not found".
+ */
+async function buildViewResponseFromIndex(
+  context: XppServerContext,
+  viewName: string,
+  modelName?: string,
+): Promise<{ content: { type: 'text'; text: string }[] } | null> {
+  let ref;
+  try {
+    ref = await resolveIndexedObject(context.symbolIndex.getReadDb(), viewName, ['view'], modelName);
+  } catch {
+    return null; // DB unavailable
+  }
+  if (!ref) return null;
+  const model = ref.model;
+
+  // Pre-extracted JSON (works without a D365FO installation)
+  const extracted = await readViewMetadata(model, ref.name);
+  if (extracted) {
+    return {
+      content: [{ type: 'text', text: formatViewLike(extracted, model, 'symbol index (extracted metadata)') }],
+    };
+  }
+
+  // XML on disk — the indexed path, or the same path remapped locally
+  if (ref.localPath) {
+    const parsed = await context.parser.parseViewFile(ref.localPath, model);
+    if (parsed.success && parsed.data) {
+      return { content: [{ type: 'text', text: formatViewLike(parsed.data, model, `XML: ${ref.localPath}`) }] };
+    }
+  }
+
+  // Last resort — the field/method symbols captured at index time
+  return { content: [{ type: 'text', text: formatViewFromSymbols(context, ref.name, model) }] };
+}
+
+async function buildViewResponseFromDisk(
+  context: XppServerContext,
+  viewName: string,
+  modelName?: string,
+): Promise<{ content: { type: 'text'; text: string }[] } | null> {
+  for (const objectType of ['view', 'data-entity'] as const) {
+    const diskPath = await findD365FileOnDisk(objectType, viewName, modelName);
+    if (!diskPath) continue;
+    const model = modelName || path.basename(path.dirname(path.dirname(diskPath)));
+    const parsed = await context.parser.parseViewFile(diskPath, model);
+    if (parsed.success && parsed.data) {
+      return {
+        content: [{
+          type: 'text',
+          text: formatViewLike(parsed.data, model, `live file (not yet in bridge metadata): ${diskPath}`),
+        }],
+      };
+    }
+  }
+  return null;
+}
+
+function formatViewLike(v: ViewLike, model: string, source: string): string {
+  const kind = v.type === 'data-entity' ? 'Data Entity View' : 'View';
+  let out = `# ${kind}: ${v.name}\n\n`;
+  if (v.label) out += `**Label:** ${v.label}\n`;
+  out += `**Model:** ${v.model || model}\n`;
+  if (v.isPublic != null) out += `**Public:** ${v.isPublic ? 'Yes' : 'No'}\n`;
+  if (v.isReadOnly != null) out += `**Read-Only:** ${v.isReadOnly ? 'Yes' : 'No'}\n`;
+  if (v.primaryKey) out += `**Primary Key:** ${v.primaryKey}\n`;
+  out += indexedSourceNote(source);
+
+  const fields = v.fields ?? [];
+  if (fields.length > 0) {
+    const computed = fields.filter(f => f.isComputed || (!!f.dataMethod && !f.dataField));
+    const mapped = fields.filter(f => !computed.includes(f));
+
+    out += `## 📊 Fields (${fields.length})\n\n`;
+    if (mapped.length > 0) {
+      out += `### Mapped Fields (${mapped.length})\n\n`;
+      out += `| Field Name | Data Source | Data Field |\n|---|---|---|\n`;
+      for (const f of mapped) out += `| ${f.name} | ${f.dataSource ?? '—'} | ${f.dataField ?? '—'} |\n`;
+      out += '\n';
+    }
+    if (computed.length > 0) {
+      out += `### Computed Fields (${computed.length})\n\n`;
+      out += `| Field Name | Data Method |\n|---|---|\n`;
+      for (const f of computed) out += `| ${f.name} | ${f.dataMethod ?? '—'} |\n`;
+      out += '\n';
+    }
+  }
+
+  const relations = v.relations ?? [];
+  if (relations.length > 0) {
+    out += `## 🔗 Relations (${relations.length})\n\n`;
+    for (const rel of relations) {
+      out += `- **${rel.name}** → ${rel.relatedTable}${rel.cardinality ? ` (${rel.cardinality})` : ''}\n`;
+      for (const c of rel.fields ?? []) out += `  - ${c.field} = ${c.relatedField}\n`;
+    }
+    out += '\n';
+  }
+
+  const methods = v.methods ?? [];
+  if (methods.length > 0) {
+    out += `## 🔧 Methods (${methods.length})\n\n`;
+    for (const m of methods) out += `- ${typeof m === 'string' ? m : m.name}\n`;
+  }
+
+  return out;
+}
+
+/** Build a minimal view report from the field/method rows stored in the symbol index. */
+function formatViewFromSymbols(context: XppServerContext, viewName: string, model: string): string {
+  let fields: Array<{ name: string; signature: string | null }> = [];
+  let methods: Array<{ name: string; signature: string | null }> = [];
+  try {
+    const db = context.symbolIndex.getReadDb();
+    fields = db.prepare(
+      `SELECT name, signature FROM symbols WHERE parent_name = ? AND type = 'field' ORDER BY name`
+    ).all(viewName) as typeof fields;
+    methods = db.prepare(
+      `SELECT name, signature FROM symbols WHERE parent_name = ? AND type = 'method' ORDER BY name`
+    ).all(viewName) as typeof methods;
+  } catch { /* DB unavailable — emit the header only */ }
+
+  let out = `# View: ${viewName}\n\n**Model:** ${model}\n`;
+  out += `_Source: symbol index (bridge and view XML unavailable — field types and relations are not included)._\n\n`;
+  out += `## Fields (${fields.length})\n\n`;
+  for (const f of fields) out += `- **${f.name}**${f.signature ? ` → ${f.signature}` : ''}\n`;
+  if (methods.length > 0) {
+    out += `\n## Methods (${methods.length})\n\n`;
+    for (const m of methods) out += `- ${m.signature || m.name}\n`;
+  }
+  return out;
+}
+
+function buildNotFoundText(context: XppServerContext, viewName: string): string {
+  let text = `View "${viewName}" not found via bridge, symbol index, or on disk.\n`;
+  text += bridgeUnavailableNote(context.bridge);
+  try {
+    text += buildObjectTypeMismatchMessage(context.symbolIndex.getReadDb(), viewName, 'view');
+  } catch { /* DB unavailable */ }
+  return text;
 }
 
 // Tool registration (name, description, inputSchema) lives inline in

--- a/src/utils/indexedXmlLookup.ts
+++ b/src/utils/indexedXmlLookup.ts
@@ -1,0 +1,120 @@
+/**
+ * Indexed-object XML lookup.
+ *
+ * Shared fallback path for the get_object_info readers: when the C# bridge returns
+ * no data (bridge not connected, running without metadata access, or its DiskProvider
+ * simply does not cover that package), the symbol index usually still knows the object
+ * — `search` finds it. Reporting "not found" in that situation is wrong and has burned
+ * agents repeatedly (see eval corpus: EDT "Bridge returned no data" while the same EDTs
+ * resolved through search / validate_code).
+ *
+ * This module resolves an indexed object to a readable local XML string:
+ *   1. symbol index row (case-insensitive, index-safe via lookupSymbolNocase)
+ *   2. the indexed file path if it exists on this machine
+ *   3. the same path remapped onto the configured packages root (the DB may store
+ *      Azure DevOps build-agent paths)
+ *   4. extracted-metadata JSON files, which wrap the XML in a `raw` property
+ */
+
+import * as fs from 'fs';
+import { promises as fsp } from 'fs';
+import { lookupSymbolNocase } from './symbolLookup.js';
+import { resolveDbPathLocally } from './metadataResolver.js';
+
+export interface IndexedObjectRef {
+  /** Canonical name as stored in the index (may differ in casing from the request). */
+  name: string;
+  model: string;
+  /** Path recorded in the symbol index — may point at a build agent. */
+  indexedPath: string | null;
+  /** Readable path on this machine (indexed or remapped), null when unreachable. */
+  localPath: string | null;
+}
+
+/** Look up a top-level object in the symbol index and resolve a readable local path. */
+export async function resolveIndexedObject(
+  db: unknown,
+  name: string,
+  types: readonly string[],
+  modelName?: string,
+): Promise<IndexedObjectRef | null> {
+  let hit;
+  try {
+    hit = lookupSymbolNocase(db as any, name, types);
+  } catch {
+    return null; // DB unavailable
+  }
+  if (!hit) return null;
+  // lookupSymbolNocase matches on name already; re-assert it so a loose caller/DB
+  // stub can never make a reader render an unrelated object under the asked name.
+  if (hit.name?.toLowerCase() !== name.toLowerCase()) return null;
+
+  return {
+    name: hit.name,
+    model: modelName || hit.model || 'Unknown',
+    indexedPath: hit.file_path,
+    localPath: await resolveLocalPath(hit.file_path),
+  };
+}
+
+/** Resolve an indexed file path to something readable here, or null. */
+export async function resolveLocalPath(indexedPath: string | null): Promise<string | null> {
+  if (!indexedPath) return null;
+  try {
+    if (fs.existsSync(indexedPath)) return indexedPath;
+  } catch { /* ignore */ }
+  return resolveDbPathLocally(indexedPath);
+}
+
+/**
+ * Read XML from a local file. Extracted-metadata JSON files wrap the original XML
+ * in a `raw` property — unwrap those transparently. Returns null when unreadable.
+ */
+export async function readXmlFile(filePath: string): Promise<string | null> {
+  let content: string;
+  try {
+    content = await fsp.readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+  if (content.trimStart().startsWith('{')) {
+    try {
+      const data = JSON.parse(content);
+      return typeof data.raw === 'string' ? data.raw : null;
+    } catch {
+      return null;
+    }
+  }
+  return content;
+}
+
+/** Symbol-index lookup + XML read in one step. Returns null when either step fails. */
+export async function readIndexedXml(
+  db: unknown,
+  name: string,
+  types: readonly string[],
+  modelName?: string,
+): Promise<{ ref: IndexedObjectRef; xml: string } | null> {
+  const ref = await resolveIndexedObject(db, name, types, modelName);
+  if (!ref?.localPath) return null;
+  const xml = await readXmlFile(ref.localPath);
+  return xml ? { ref, xml } : null;
+}
+
+/**
+ * Standard footer for a reader that answered from the index instead of the bridge —
+ * makes the provenance (and its limits) explicit to the agent.
+ */
+export function indexedSourceNote(source: string): string {
+  return `_Source: ${source} — the C# bridge returned no data for this object._\n\n`;
+}
+
+/**
+ * Explain why the bridge produced nothing, so "not found" is never mistaken for
+ * "does not exist" when the bridge is simply unavailable.
+ */
+export function bridgeUnavailableNote(bridge: { isReady?: boolean; metadataAvailable?: boolean } | undefined): string {
+  if (bridge?.isReady && bridge?.metadataAvailable) return '';
+  return `\n⚠️ The C# metadata bridge is ${bridge?.isReady ? 'running without metadata access' : 'not connected'}, ` +
+    `so only the symbol index and disk were checked.\n`;
+}

--- a/tests/tools/object-info.test.ts
+++ b/tests/tools/object-info.test.ts
@@ -27,6 +27,7 @@ const {
   mockTryBridgeForm,
   mockTryBridgeQuery,
   mockTryBridgeView,
+  mockTryBridgeDataEntity,
   mockTryBridgeReport,
   mockTryBridgeTable,
 } = vi.hoisted(() => ({
@@ -35,6 +36,7 @@ const {
   mockTryBridgeForm: vi.fn(async () => null),
   mockTryBridgeQuery: vi.fn(async () => null),
   mockTryBridgeView: vi.fn(async () => null),
+  mockTryBridgeDataEntity: vi.fn(async () => null),
   mockTryBridgeReport: vi.fn(async () => null),
   mockTryBridgeTable: vi.fn(async () => null),
 }));
@@ -46,6 +48,7 @@ vi.mock('../../src/bridge/bridgeAdapter', () => ({
   tryBridgeForm: mockTryBridgeForm,
   tryBridgeQuery: mockTryBridgeQuery,
   tryBridgeView: mockTryBridgeView,
+  tryBridgeDataEntity: mockTryBridgeDataEntity,
   tryBridgeReport: mockTryBridgeReport,
   tryBridgeMethodSource: vi.fn(async () => null),
 }));
@@ -386,6 +389,38 @@ describe('get_object_info (view)', () => {
     const result = await getObjectInfoTool(req('get_object_info', { objectType: 'view', name:'NoView' }), ctx);
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/not found|no.*view/i);
+  });
+
+  it('falls back to the data-entity bridge reader (data entities are indexed as views)', async () => {
+    mockTryBridgeDataEntity.mockResolvedValueOnce({
+      content: [{ type: 'text', text: '# Data Entity: `CustCustomerV3Entity`\n' }],
+    } as any);
+
+    const result = await getObjectInfoTool(req('get_object_info', { objectType: 'view', name:'CustCustomerV3Entity' }), ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('CustCustomerV3Entity');
+  });
+
+  it('falls back to the symbol index when the bridge has no view (search finds it, bridge does not)', async () => {
+    // Bridge readers return null (package not on this box / bridge without metadata),
+    // but the symbol index knows the view — it must not be reported as "not found".
+    ctx.symbolIndex.db.prepare = vi.fn((sql: string) => {
+      if (/FROM symbols s/.test(sql)) {
+        return makeStmt([{
+          name: 'TaxTransDeclarationView', type: 'view', model: 'Tax',
+          extends_class: null, file_path: '/Views/TaxTransDeclarationView.xml',
+        }]);
+      }
+      if (/type = 'field'/.test(sql)) {
+        return makeStmt([{ name: 'TaxCode', signature: 'TaxTrans.TaxCode' }]);
+      }
+      return makeStmt();
+    }) as any;
+
+    const result = await getObjectInfoTool(req('get_object_info', { objectType: 'view', name:'TaxTransDeclarationView' }), ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('TaxTransDeclarationView');
+    expect(result.content[0].text).toContain('TaxCode');
   });
 
   it('returns error when viewName is missing', async () => {

--- a/tests/tools/objectinfo-index-fallback.test.ts
+++ b/tests/tools/objectinfo-index-fallback.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Symbol-index fallback for the get_object_info readers.
+ *
+ * Regression guard for the "bridge silent ⇒ object does not exist" bug class:
+ * `search` resolved e.g. TaxTransDeclarationView while get_object_info answered
+ * "not found. Bridge returned no data". Every reader must fall back to the symbol
+ * index (and disk) before it claims an object is missing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { XppServerContext } from '../../src/types/context';
+
+// Bridge returns nothing for every reader — the scenario under test.
+vi.mock('../../src/bridge/bridgeAdapter', () => ({
+  tryBridgeTable: vi.fn(async () => null),
+  tryBridgeClass: vi.fn(async () => null),
+  tryBridgeEnum: vi.fn(async () => null),
+  tryBridgeEdt: vi.fn(async () => null),
+  tryBridgeForm: vi.fn(async () => null),
+  tryBridgeQuery: vi.fn(async () => null),
+  tryBridgeView: vi.fn(async () => null),
+  tryBridgeDataEntity: vi.fn(async () => null),
+  tryBridgeReport: vi.fn(async () => null),
+  tryBridgeMethodSource: vi.fn(async () => null),
+}));
+
+// No disk scan — the index path is what these tests exercise.
+vi.mock('../../src/tools/modifyD365File', async (orig) => {
+  const actual = await orig<typeof import('../../src/tools/modifyD365File')>();
+  return { ...actual, findD365FileOnDisk: vi.fn(async () => null) };
+});
+
+// No extracted-metadata store in the test env → readers must use the indexed XML.
+vi.mock('../../src/utils/metadataResolver', async (orig) => {
+  const actual = await orig<typeof import('../../src/utils/metadataResolver')>();
+  return {
+    ...actual,
+    readEnumRawXml: vi.fn(async () => null),
+    readViewMetadata: vi.fn(async () => null),
+    buildObjectTypeMismatchMessage: vi.fn(() => ''),
+  };
+});
+
+const INDEX_ROOT = 'K:\\Indexed';
+
+const XML: Record<string, string> = {
+  'SalesTableListPage.xml':
+    `<?xml version="1.0"?><AxQuery><Name>SalesTableListPage</Name><Title>@SYS1</Title>` +
+    `<DataSources><AxQuerySimpleRootDataSource><Name>SalesTable</Name><Table>SalesTable</Table>` +
+    `</AxQuerySimpleRootDataSource></DataSources></AxQuery>`,
+  'SalesStatus.xml':
+    `<?xml version="1.0"?><AxEnum><Name>SalesStatus</Name><IsExtensible>Yes</IsExtensible>` +
+    `<EnumValues><AxEnumValue><Name>Backorder</Name><Value>1</Value><Label>@SYS1</Label></AxEnumValue>` +
+    `</EnumValues></AxEnum>`,
+  'SalesTable.xml':
+    `<?xml version="1.0"?><AxForm><Name>SalesTable</Name><DataSources><AxFormDataSource>` +
+    `<Name>SalesTable</Name><Table>SalesTable</Table></AxFormDataSource></DataSources></AxForm>`,
+  'SalesInvoiceReport.xml':
+    `<?xml version="1.0"?><AxReport><Name>SalesInvoiceReport</Name><DataSets><AxReportDataSet>` +
+    `<Name>SalesInvoiceDS</Name><DataSourceType>Query</DataSourceType><Query>SalesInvoiceQuery</Query>` +
+    `</AxReportDataSet></DataSets></AxReport>`,
+};
+
+// Indexed paths exist and are readable; everything else is absent.
+vi.mock('fs', async (orig) => {
+  const actual = await orig<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn((p: any) => String(p).startsWith(INDEX_ROOT)),
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(async (p: any) => {
+        const file = String(p).split('\\').pop() ?? '';
+        if (XML[file]) return XML[file];
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }),
+    },
+  };
+});
+
+import { getObjectInfoTool } from '../../src/tools/getObjectInfo';
+import { dataEntityInfoTool } from '../../src/tools/dataEntityInfo';
+
+const req = (name: string, args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name, arguments: args },
+});
+
+const makeStmt = (rows: any[] = [], row: any = undefined) => ({
+  all: vi.fn(() => rows),
+  get: vi.fn(() => row),
+  run: vi.fn(() => ({ changes: 0 })),
+});
+
+/** DB that knows exactly one top-level object, like the real symbol index does. */
+function indexWith(name: string, type: string, model = 'ApplicationSuite', fields: any[] = []) {
+  return vi.fn((sql: string) => {
+    if (/FROM symbols s\b/.test(sql)) {
+      return makeStmt([{
+        name, type, model, extends_class: null,
+        file_path: `${INDEX_ROOT}\\${model}\\${name}.xml`,
+      }]);
+    }
+    if (/'field'/.test(sql)) return makeStmt(fields);
+    return makeStmt();
+  });
+}
+
+const buildContext = (prepare: any): XppServerContext => ({
+  symbolIndex: {
+    searchSymbols: vi.fn(() => []),
+    getSymbolByName: vi.fn(() => undefined),
+    getClassMethods: vi.fn(() => []),
+    getTableFields: vi.fn(() => []),
+    db: { prepare },
+    getReadDb: vi.fn(function (this: any) { return this.db; }),
+  } as any,
+  parser: {
+    parseViewFile: vi.fn(async () => ({ success: false })),
+  } as any,
+  cache: {
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => {}),
+  } as any,
+  workspaceScanner: {} as any,
+  hybridSearch: {} as any,
+});
+
+describe('get_object_info — symbol-index fallback when the bridge is silent', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('query: resolves from the indexed AxQuery XML', async () => {
+    const ctx = buildContext(indexWith('SalesTableListPage', 'query'));
+    const result = await getObjectInfoTool(
+      req('get_object_info', { objectType: 'query', name: 'SalesTableListPage' }), ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/^# Query/);
+    expect(result.content[0].text).toContain('SalesTableListPage');
+    expect(result.content[0].text).toContain('SalesTable');
+  });
+
+  it('enum: resolves from the indexed AxEnum XML', async () => {
+    const ctx = buildContext(indexWith('SalesStatus', 'enum'));
+    const result = await getObjectInfoTool(
+      req('get_object_info', { objectType: 'enum', name: 'SalesStatus' }), ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/^# Enum/);
+    expect(result.content[0].text).toContain('SalesStatus');
+    expect(result.content[0].text).toContain('Backorder');
+  });
+
+  it('form: resolves from the indexed AxForm XML', async () => {
+    const ctx = buildContext(indexWith('SalesTable', 'form'));
+    const result = await getObjectInfoTool(
+      req('get_object_info', { objectType: 'form', name: 'SalesTable' }), ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/^# Form/);
+    expect(result.content[0].text).toContain('SalesTable');
+  });
+
+  it('report: resolves from the indexed AxReport XML', async () => {
+    const ctx = buildContext(indexWith('SalesInvoiceReport', 'report'));
+    const result = await getObjectInfoTool(
+      req('get_object_info', { objectType: 'report', name: 'SalesInvoiceReport' }), ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/^# AxReport/);
+    expect(result.content[0].text).toContain('SalesInvoiceDS');
+  });
+
+  it('data entity: falls back through the view reader (entities are indexed as views)', async () => {
+    const ctx = buildContext(
+      indexWith('CustCustomerV3Entity', 'view', 'ApplicationSuite', [{ name: 'AccountNum', signature: 'CustTable.AccountNum' }]),
+    );
+    const result = await dataEntityInfoTool(
+      req('get_data_entity_info', { entityName: 'CustCustomerV3Entity' }), ctx,
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('CustCustomerV3Entity');
+    expect(result.content[0].text).toContain('AccountNum');
+  });
+
+  it('still reports not-found (with a bridge note) when the index is empty', async () => {
+    const ctx = buildContext(vi.fn(() => makeStmt()));
+    const result = await getObjectInfoTool(
+      req('get_object_info', { objectType: 'query', name: 'NoSuchQuery' }), ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not found/i);
+  });
+});


### PR DESCRIPTION
## Problem

`get_object_info` readers treated "bridge returned no data" as "object does not exist".

Reported case:

- `search({query:"TaxTransDeclarationView"})` -> `⭐ Exact name match: TaxTransDeclarationView (view)`
- `get_object_info({objectType:"view", name:"TaxTransDeclarationView"})` -> `View "TaxTransDeclarationView" not found. Bridge returned no data — ensure the view exists in D365FO metadata.`

The bridge `PickProvider` only looks at the primary DiskProvider and the reference (UDE) provider, so any package outside those roots returns null. The same silent-null happens when the bridge is not connected or runs without metadata access. Every bridge-only reader then reported a false "not found".

## Fix

New `src/utils/indexedXmlLookup.ts`:

- `resolveIndexedObject` — case-insensitive symbol-index lookup (`lookupSymbolNocase`) with a name re-assert, DB failures degrade to `null`
- `resolveLocalPath` — indexed path, else remapped onto the configured packages root (the DB may store Azure DevOps build-agent paths)
- `readXmlFile` — reads XML, transparently unwrapping extracted-metadata JSON (`{ raw: "<xml>" }`)
- `indexedSourceNote` / `bridgeUnavailableNote` — explicit provenance, and an error text that distinguishes "bridge unavailable" from "does not exist"

Every reader now runs the same chain, already proven in `tableInfo` / `edtInfo`:

**bridge -> symbol index -> disk scan -> honest not-found text**

| Reader | Change |
| --- | --- |
| `viewInfo` | index/disk chain + `tryBridgeDataEntity` (AxDataEntityView is indexed as type `view`) |
| `queryInfo` | AxQuery XML from the index |
| `enumInfo` | extracted metadata, then AxEnum XML |
| `formInfo` | AxForm XML through the existing formatter |
| `reportInfo` | shared `buildReportResponse` for both the explicit `filePath` bypass and the index path |
| `dataEntityInfo` | delegates to the view reader, keeps the fuzzy "did you mean?" suggestions as the last step |

## Tests

- new `tests/tools/objectinfo-index-fallback.test.ts` — bridge silent + index populated for query / enum / form / report / data entity, plus the still-not-found case
- `tests/tools/object-info.test.ts` — view via the data-entity bridge reader, and view via the symbol index

`npx tsc --noEmit` clean, full suite `npx vitest run`: 181 files / 2386 passed, 2 skipped.
