### PR TITLE
fix(build): compile labels with labelc.exe before the X++ compile

### DIFF
--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -6,10 +6,12 @@ import { openSync as openSyncFs, closeSync as closeSyncFs } from 'fs';
 import os from 'os';
 import crypto from 'crypto';
 import { getConfigManager } from '../utils/configManager.js';
-import { describePackagesRootScan, findPackagesRoot, packagesRootCandidates } from '../utils/packagesRoot.js';
+import { describePackagesRootScan, findPackagesRoot } from '../utils/packagesRoot.js';
+import { findFrameworkTool } from '../utils/frameworkBin.js';
 import { forceReleaseLock } from '../utils/operationLocks.js';
 import { lookupErrorFix } from './d365foErrorHelp.js';
 import { generateRuntimeMetadata } from './generateMetadata.js';
+import { compileModelLabels, type CompileLabelsResult } from './compileLabels.js';
 
 const execFileAsync = util.promisify(execFile);
 
@@ -381,30 +383,7 @@ async function getModelFromRnrproj(projectPath: string): Promise<string | null> 
 }
 
 async function findXppcExe(microsoftPackagesPath: string | null): Promise<string | null> {
-  const candidates: string[] = [];
-
-  if (microsoftPackagesPath) {
-    candidates.push(path.join(microsoftPackagesPath, 'bin', 'xppc.exe'));
-  }
-
-  // Search AppData for any installed UDE version
-  const appDataLocal = process.env.LOCALAPPDATA ||
-    path.join(process.env.USERPROFILE || 'C:\\Users\\Default', 'AppData', 'Local');
-  const d365Base = path.join(appDataLocal, 'Microsoft', 'Dynamics365');
-  try {
-    const versions = await readdir(d365Base);
-    for (const ver of versions.sort().reverse()) {
-      candidates.push(path.join(d365Base, ver, 'PackagesLocalDirectory', 'bin', 'xppc.exe'));
-    }
-  } catch { /* ignore */ }
-
-  // CHE: whichever volume this image put AosService on (C:, J:, K:, …)
-  candidates.push(...packagesRootCandidates('bin', 'xppc.exe'));
-
-  for (const c of candidates) {
-    try { await access(c); return c; } catch { /* next */ }
-  }
-  return null;
+  return findFrameworkTool(microsoftPackagesPath, 'xppc.exe');
 }
 
 /**
@@ -464,6 +443,28 @@ async function killOrphanedBuildProcesses(): Promise<void> {
   await execFileAsync('taskkill', ['/F', '/IM', 'xppc.exe'], { timeout: 10_000, windowsHide: true })
     .then(({ stdout }) => console.error(`[build_d365fo_project] killed xppc.exe: ${stdout.trim() || '(no output)'}`))
     .catch(() => {});
+}
+
+/**
+ * The label-compilation outcome as it should appear at the top of the build
+ * log. A clean run is silent — nothing was wrong, and a note per build would
+ * only crowd out the compiler output. A FAILED run is loud and says what it
+ * costs, because the symptom it produces (`BPErrorUnknownLabel` on a label
+ * that plainly exists, plus the `BPUnusedStrFmtArgument` warnings that cascade
+ * from it) otherwise reads as broken source code.
+ */
+export function describeLabelCompilation(modelName: string, result: CompileLabelsResult): string {
+  if (result.success) {
+    return result.skipped ? '' : `✅ Labels compiled for ${modelName} — ${result.message}\n\n`;
+  }
+  return [
+    `⚠️ Label compilation FAILED for ${modelName} — ${result.message}`,
+    `   Labels stay uncompiled, so references to them can be reported as`,
+    `   BPErrorUnknownLabel (with BPUnusedStrFmtArgument cascading from them)`,
+    `   even though the source is correct. Fix labelc before trusting those.`,
+    '',
+    '',
+  ].join('\n');
 }
 
 /** Passed through the entire queue so the close handler can launch the next model without re-resolving paths. */
@@ -528,7 +529,24 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
 
   await buildLog('INFO', `xppc.exe args: ${xppcArgs.join(' ')}`);
 
-  const logFd = openSyncFs(state.logFile, 'w');
+  // Labels first — see compileLabels.ts. xppc and xppbp resolve @Model:Id
+  // against the compiled resource assembly, so compiling labels afterwards
+  // would leave THIS build reporting unknown-label errors for labels that are
+  // perfectly well defined, and only clear them on the next one.
+  const labelResult = await compileModelLabels(microsoftPackagesPath, customPackagesPath, modelName, !!useFullBuild);
+  const labelHeader = describeLabelCompilation(modelName, labelResult);
+  if (labelResult.skipped && labelResult.success) {
+    await buildLog('INFO', `labelc skipped for ${modelName}: ${labelResult.message}`);
+  } else if (labelResult.success) {
+    await buildLog('INFO', `labelc compiled ${modelName} labels: ${labelResult.message}`);
+  } else {
+    await buildLog('WARN', `labelc did not compile ${modelName} labels: ${labelResult.message}`);
+  }
+
+  // Truncate the log with the label outcome, then append xppc's output to it,
+  // so a single tail read shows the whole build in the order it happened.
+  await writeFile(state.logFile, labelHeader, 'utf-8');
+  const logFd = openSyncFs(state.logFile, 'a');
 
   const child = spawn(xppcExe, xppcArgs, {
     detached: false,

--- a/src/tools/compileLabels.ts
+++ b/src/tools/compileLabels.ts
@@ -1,0 +1,275 @@
+/**
+ * compileLabels.ts
+ *
+ * Compiles a model's label files into resource assemblies with labelc.exe.
+ *
+ * A label written through `labels(action="create")` lands as a line in
+ * `<model>\AxLabelFile\LabelResources\<lang>\<file>.<lang>.label.txt`. Nothing
+ * reads that text file at compile time: the compiler and the best-practice
+ * checker resolve `@Model:Id` against the compiled resource assembly at
+ * `<model>\Resources\<model>.dll`, which only labelc.exe produces.
+ *
+ * This server never ran labelc, so on a model whose labels had only ever been
+ * created through the MCP tools the `Resources` folder did not exist at all —
+ * every reference to a freshly created label was reported as an unknown label.
+ * Observed 2026-07-29 in the Contoso eval sandbox: two `BPErrorUnknownLabel`
+ * plus five `BPUnusedStrFmtArgument` cascading from them, all six of which
+ * vanished after a manual labelc run with no source change whatsoever. That
+ * makes it the worst kind of diagnostic — it points at correct code, and the
+ * only way to clear it is a step the tool never mentions.
+ *
+ * VS runs label compilation BEFORE the X++ compile, and so must this: labelc
+ * after xppc would leave the current build reporting the stale errors and only
+ * clear them on the next one.
+ */
+
+import { execFile } from 'child_process';
+import util from 'util';
+import path from 'path';
+import { access, readdir, stat } from 'fs/promises';
+import { findFrameworkTool } from '../utils/frameworkBin.js';
+
+const execFileAsync = util.promisify(execFile);
+
+/** labelc spawns csc/al/resgen per label file; a big model takes a few seconds. */
+const LABELC_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface CompileLabelsResult {
+  /** True when labelc was not run at all (nothing to do, or it could not be found). */
+  skipped: boolean;
+  /** False only when a run was attempted and failed. */
+  success: boolean;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Toolchain discovery
+//
+// labelc shells out to csc.exe, al.exe and resgen.exe and finds them on PATH
+// when not told otherwise — which is what VS relies on. The MCP server does not
+// control the PATH it inherits, so pass explicit directories when they can be
+// located and fall back to VS's behaviour when they cannot.
+// ---------------------------------------------------------------------------
+
+const CSC_DIRS = [
+  'C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319',
+  'C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319',
+];
+
+const SDK_BASES = [
+  'C:\\Program Files (x86)\\Microsoft SDKs\\Windows',
+  'C:\\Program Files\\Microsoft SDKs\\Windows',
+];
+
+async function findCscDir(): Promise<string | null> {
+  for (const dir of CSC_DIRS) {
+    try { await access(path.join(dir, 'csc.exe')); return dir; } catch { /* next */ }
+  }
+  return null;
+}
+
+/** Directory holding both al.exe and resgen.exe, newest SDK first. */
+async function findSdkToolsDir(): Promise<string | null> {
+  for (const base of SDK_BASES) {
+    let versions: string[];
+    try {
+      versions = (await readdir(base)).sort().reverse();
+    } catch {
+      continue;
+    }
+    for (const version of versions) {
+      const binDir = path.join(base, version, 'bin');
+      let subDirs: string[] = [];
+      try {
+        subDirs = (await readdir(binDir)).filter(name => /^NETFX .* Tools$/i.test(name)).sort().reverse();
+      } catch {
+        continue;
+      }
+      // The versioned "NETFX x.y Tools" subfolders first, then bin itself for
+      // older SDK layouts that put the tools directly there.
+      for (const sub of [...subDirs, '']) {
+        const dir = sub ? path.join(binDir, sub) : binDir;
+        try {
+          await access(path.join(dir, 'al.exe'));
+          await access(path.join(dir, 'resgen.exe'));
+          return dir;
+        } catch { /* next */ }
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// What needs compiling
+// ---------------------------------------------------------------------------
+
+/**
+ * Every `AxLabelFile` directory in a model package.
+ *
+ * A package folder contains one folder per model it holds, and the label files
+ * sit one level below that — `Contoso\Contoso\AxLabelFile`. The inner name is
+ * the MODEL name, which need not equal the package name, so the layout is
+ * discovered rather than assumed.
+ */
+export async function findLabelFileDirs(packageDir: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(packageDir);
+  } catch {
+    return [];
+  }
+  const hits: string[] = [];
+  for (const entry of entries) {
+    const candidate = path.join(packageDir, entry, 'AxLabelFile');
+    try {
+      await access(candidate);
+      hits.push(candidate);
+    } catch { /* not a model folder with labels */ }
+  }
+  return hits;
+}
+
+/** Newest mtime anywhere under `dirs`, or 0 when they hold nothing readable. */
+async function newestMtime(dirs: string[]): Promise<number> {
+  let newest = 0;
+  const stack = [...dirs];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      try {
+        const { mtimeMs } = await stat(full);
+        if (mtimeMs > newest) newest = mtimeMs;
+      } catch { /* vanished mid-scan */ }
+    }
+  }
+  return newest;
+}
+
+/**
+ * Whether the compiled assemblies no longer describe the label sources.
+ *
+ * Missing output counts as stale, so the case this defect was found in — a
+ * model that never had a `Resources` folder — always compiles. Errs toward
+ * recompiling: labelc costs about a second, while skipping a needed run
+ * reinstates the bogus unknown-label errors this module exists to prevent.
+ */
+export async function labelAssembliesAreStale(
+  labelDirs: string[],
+  resourcesDir: string,
+  moduleName: string,
+): Promise<boolean> {
+  let builtAt: number;
+  try {
+    builtAt = (await stat(path.join(resourcesDir, `${moduleName}.dll`))).mtimeMs;
+  } catch {
+    return true; // never compiled
+  }
+  return (await newestMtime(labelDirs)) > builtAt;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Arguments VS passes, plus explicit toolchain directories when we found them. */
+export function labelcArgs(
+  customPackagesPath: string,
+  modelName: string,
+  resourcesDir: string,
+  cscDir: string | null,
+  sdkToolsDir: string | null,
+): string[] {
+  return [
+    `-Metadata=${customPackagesPath}`,
+    `-Output=${resourcesDir}`,
+    `-ModelModule=${modelName}`,
+    ...(cscDir ? [`-CompilerPath=${cscDir}`] : []),
+    ...(sdkToolsDir ? [`-SdkToolsPath=${sdkToolsDir}`] : []),
+  ];
+}
+
+/** The lines worth keeping out of labelc's verbose progress report. */
+function summarise(output: string): string {
+  const interesting = output
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => /^(Done compiling|Completed label compilation|error|warning)/i.test(line));
+  return interesting.join(' | ') || 'labelc reported no output';
+}
+
+/**
+ * Compile `modelName`'s labels into `<model>\Resources`. Called before xppc so
+ * the compile and BP check that follow can resolve the labels.
+ *
+ * @param microsoftPackagesPath Framework directory holding `bin\labelc.exe`.
+ * @param customPackagesPath    Model store root — the folder containing the model folder.
+ * @param modelName             Package/module to compile labels for.
+ * @param force                 Recompile even when the assemblies look current (full builds).
+ */
+export async function compileModelLabels(
+  microsoftPackagesPath: string,
+  customPackagesPath: string,
+  modelName: string,
+  force = false,
+): Promise<CompileLabelsResult> {
+  const packageDir   = path.join(customPackagesPath, modelName);
+  const resourcesDir = path.join(packageDir, 'Resources');
+
+  const labelDirs = await findLabelFileDirs(packageDir);
+  if (labelDirs.length === 0) {
+    return { skipped: true, success: true, message: `${modelName} has no label files` };
+  }
+
+  if (!force && !(await labelAssembliesAreStale(labelDirs, resourcesDir, modelName))) {
+    return { skipped: true, success: true, message: 'label assemblies are up to date' };
+  }
+
+  const labelcExe = await findFrameworkTool(microsoftPackagesPath, 'labelc.exe');
+  if (!labelcExe) {
+    return {
+      skipped: true,
+      success: false,
+      message:
+        `labelc.exe not found (looked in ${microsoftPackagesPath}\\bin) — labels will not be ` +
+        `compiled, so references to them may be reported as unknown labels`,
+    };
+  }
+
+  const args = labelcArgs(
+    customPackagesPath,
+    modelName,
+    resourcesDir,
+    await findCscDir(),
+    await findSdkToolsDir(),
+  );
+
+  try {
+    const { stdout, stderr } = await execFileAsync(labelcExe, args, {
+      timeout: LABELC_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    const output = [stdout, stderr].filter(Boolean).join('\n');
+    // labelc can report a non-zero compilation result while exiting 0, so the
+    // trailing status line is authoritative rather than the process exit code.
+    const reported = /Completed label compilation in .* with exit code (\d+)/i.exec(output);
+    if (reported && reported[1] !== '0') {
+      return { skipped: false, success: false, message: `labelc.exe reported exit code ${reported[1]}: ${summarise(output)}` };
+    }
+    return { skipped: false, success: true, message: summarise(output) };
+  } catch (err: any) {
+    const output = [err?.stdout, err?.stderr, err?.message].filter(Boolean).join('\n').trim();
+    return { skipped: false, success: false, message: `labelc.exe failed: ${output}` };
+  }
+}

--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -5,8 +5,12 @@ import fs from 'fs/promises';
 import { getConfigManager } from '../utils/configManager.js';
 import { defaultPackagesRoot, findPackagesRoot } from '../utils/packagesRoot.js';
 import { withOperationLock } from '../utils/operationLocks.js';
+import { compileModelLabels } from './compileLabels.js';
 
 const execFileAsync = util.promisify(execFile);
+
+// Label compilation is a precondition for the checker, not a separate concern —
+// see compileLabels.ts for why an uncompiled label reads as a source defect.
 
 // Keyword that xppbp.exe prints when it doesn't recognise the arguments
 const HELP_TEXT_PATTERN = /^usage:|BPCheck Tool|^xppbp\.exe|unrecognized|missing required|X\+\+ Best Practice Options/im;
@@ -118,6 +122,21 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     // binaries + framework metadata (UDE: Microsoft packages root; CHE: same as metadataPath).
     const metadataPath = customPackagesPath || packagesRoot;
     const compilerMetadataPath = microsoftPackagesPath || packagesRoot;
+
+    // xppbp resolves @Model:Id against the compiled label assembly, so labels
+    // that exist only as text in AxLabelFile are reported as BPErrorUnknownLabel
+    // (with BPUnusedStrFmtArgument cascading from them). A BP check can be run
+    // without a build in between — recompile stale labels here too, otherwise
+    // creating a label and checking it immediately still produces the bogus
+    // errors this costs about a second to prevent.
+    const labelResult = await compileModelLabels(compilerMetadataPath, metadataPath, modelName);
+    if (!labelResult.success) {
+      console.error(`[run_bp_check] label compilation failed: ${labelResult.message}`);
+    }
+    const labelNote = labelResult.success
+      ? ''
+      : `\n⚠️ Labels could not be compiled (${labelResult.message}) — any BPErrorUnknownLabel ` +
+        `below may be an artefact of that, not of the source.\n`;
 
     /**
      * xppbp.exe CLI flag styles vary by version — tried in order (A → B → C), stopping at
@@ -289,6 +308,7 @@ export const runBpCheckTool = async (params: any, _context: any) => {
           (resolvedProjectPath ? `\nProject: ${resolvedProjectPath}` : '') +
           (targetFilter ? `\nFilter: ${(targetElementType ?? 'class').toLowerCase()}:${targetFilter}` : '') +
           scopeNote +
+          labelNote +
           `\n\n${details}`
       }]
     };

--- a/src/utils/frameworkBin.ts
+++ b/src/utils/frameworkBin.ts
@@ -1,0 +1,51 @@
+/**
+ * Locating an executable that ships in the D365FO framework `bin` directory
+ * (xppc.exe, labelc.exe, …).
+ *
+ * The same three-step probe applies to every one of them: the configured
+ * Microsoft packages path first, then any UDE install under %LOCALAPPDATA%
+ * (newest version first), then whichever volume this image put AosService on.
+ * It lived inline in buildProject.ts as `findXppcExe` until label compilation
+ * needed the identical lookup for labelc.exe.
+ */
+
+import path from 'path';
+import { access, readdir } from 'fs/promises';
+import { packagesRootCandidates } from './packagesRoot.js';
+
+/**
+ * Absolute path to `exeName` in a D365FO framework bin directory, or null when
+ * no probed location holds it.
+ *
+ * @param microsoftPackagesPath Configured framework directory, when known.
+ * @param exeName               File name, e.g. `xppc.exe`.
+ */
+export async function findFrameworkTool(
+  microsoftPackagesPath: string | null,
+  exeName: string,
+): Promise<string | null> {
+  const candidates: string[] = [];
+
+  if (microsoftPackagesPath) {
+    candidates.push(path.join(microsoftPackagesPath, 'bin', exeName));
+  }
+
+  // Search AppData for any installed UDE version
+  const appDataLocal = process.env.LOCALAPPDATA ||
+    path.join(process.env.USERPROFILE || 'C:\\Users\\Default', 'AppData', 'Local');
+  const d365Base = path.join(appDataLocal, 'Microsoft', 'Dynamics365');
+  try {
+    const versions = await readdir(d365Base);
+    for (const ver of versions.sort().reverse()) {
+      candidates.push(path.join(d365Base, ver, 'PackagesLocalDirectory', 'bin', exeName));
+    }
+  } catch { /* ignore */ }
+
+  // CHE: whichever volume this image put AosService on (C:, J:, K:, …)
+  candidates.push(...packagesRootCandidates('bin', exeName));
+
+  for (const c of candidates) {
+    try { await access(c); return c; } catch { /* next */ }
+  }
+  return null;
+}

--- a/tests/tools/compileLabels.test.ts
+++ b/tests/tools/compileLabels.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Labels must be compiled, and compiled BEFORE the X++ compile. VM-free.
+ *
+ * Observed 2026-07-29 in the Contoso eval sandbox. Labels created through
+ * `labels(action="create")` reached `Contoso.en-US.label.txt`, but
+ * `build_d365fo_project` never ran labelc.exe, so `Contoso\Resources\` did not
+ * exist after two full builds and the BP check reported:
+ *
+ *     BPErrorUnknownLabel  ×2
+ *     BPUnusedStrFmtArgument ×5   (cascading from the two above)
+ *
+ * All six vanished after a single manual labelc run with NO source change —
+ * the diagnostics were pointing at correct code, and the only cure was a step
+ * the tool never took and never mentioned.
+ *
+ * Ordering is half the fix: xppc and xppbp resolve @Model:Id against the
+ * compiled assembly, so a labelc that runs after xppc leaves the current build
+ * reporting the stale errors and clears them only on the next one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  findLabelFileDirs,
+  labelAssembliesAreStale,
+  labelcArgs,
+} from '../../src/tools/compileLabels';
+import { describeLabelCompilation } from '../../src/tools/buildProject';
+
+const MODEL = 'Contoso';
+
+let packagesDir: string;
+let packageDir: string;
+
+async function writeAt(file: string, at: number): Promise<void> {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, 'Label=Value\n', 'utf-8');
+  await fs.utimes(file, new Date(at), new Date(at));
+}
+
+beforeEach(async () => {
+  packagesDir = await fs.mkdtemp(path.join(os.tmpdir(), 'labelc-'));
+  packageDir = path.join(packagesDir, MODEL);
+  await fs.mkdir(packageDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(packagesDir, { recursive: true, force: true });
+});
+
+describe('findLabelFileDirs', () => {
+  it('finds the label folder one level below the package folder', async () => {
+    // Contoso\Contoso\AxLabelFile — the inner name is the MODEL, not the package.
+    const labelDir = path.join(packageDir, MODEL, 'AxLabelFile');
+    await fs.mkdir(labelDir, { recursive: true });
+    expect(await findLabelFileDirs(packageDir)).toEqual([labelDir]);
+  });
+
+  it('finds label folders of every model in a multi-model package', async () => {
+    await fs.mkdir(path.join(packageDir, 'ModelA', 'AxLabelFile'), { recursive: true });
+    await fs.mkdir(path.join(packageDir, 'ModelB', 'AxLabelFile'), { recursive: true });
+    // A model folder without labels must not be reported.
+    await fs.mkdir(path.join(packageDir, 'ModelC', 'AxClass'), { recursive: true });
+    const found = await findLabelFileDirs(packageDir);
+    expect(found.map(d => path.basename(path.dirname(d))).sort()).toEqual(['ModelA', 'ModelB']);
+  });
+
+  it('returns nothing for a package that has no labels at all', async () => {
+    await fs.mkdir(path.join(packageDir, MODEL, 'AxClass'), { recursive: true });
+    expect(await findLabelFileDirs(packageDir)).toEqual([]);
+  });
+
+  it('returns nothing rather than throwing when the package folder is missing', async () => {
+    expect(await findLabelFileDirs(path.join(packagesDir, 'NoSuchModel'))).toEqual([]);
+  });
+});
+
+describe('labelAssembliesAreStale', () => {
+  it('is true when Resources does not exist — the incident', async () => {
+    // The Contoso sandbox had labels and no Resources folder at all, because
+    // labelc had never run. This is the case that must always compile.
+    const labelDir = path.join(packageDir, MODEL, 'AxLabelFile');
+    await writeAt(path.join(labelDir, 'LabelResources', 'en-US', 'Contoso.en-US.label.txt'), Date.now());
+    expect(await labelAssembliesAreStale([labelDir], path.join(packageDir, 'Resources'), MODEL)).toBe(true);
+  });
+
+  it('is true when a label file was edited after the assembly was built', async () => {
+    const builtAt = Date.now() - 60_000;
+    const labelDir = path.join(packageDir, MODEL, 'AxLabelFile');
+    const resourcesDir = path.join(packageDir, 'Resources');
+    await writeAt(path.join(resourcesDir, `${MODEL}.dll`), builtAt);
+    await writeAt(path.join(labelDir, 'LabelResources', 'en-US', 'Contoso.en-US.label.txt'), builtAt + 30_000);
+    expect(await labelAssembliesAreStale([labelDir], resourcesDir, MODEL)).toBe(true);
+  });
+
+  it('is false when the assembly is newer than every label source', async () => {
+    const builtAt = Date.now();
+    const labelDir = path.join(packageDir, MODEL, 'AxLabelFile');
+    const resourcesDir = path.join(packageDir, 'Resources');
+    await writeAt(path.join(labelDir, 'LabelResources', 'en-US', 'Contoso.en-US.label.txt'), builtAt - 60_000);
+    await writeAt(path.join(resourcesDir, `${MODEL}.dll`), builtAt);
+    expect(await labelAssembliesAreStale([labelDir], resourcesDir, MODEL)).toBe(false);
+  });
+
+  it('sees a label file nested several folders deep', async () => {
+    const builtAt = Date.now() - 60_000;
+    const labelDir = path.join(packageDir, MODEL, 'AxLabelFile');
+    const resourcesDir = path.join(packageDir, 'Resources');
+    await writeAt(path.join(resourcesDir, `${MODEL}.dll`), builtAt);
+    await writeAt(path.join(labelDir, 'LabelResources', 'de', 'deep', 'Contoso.de.label.txt'), builtAt + 5_000);
+    expect(await labelAssembliesAreStale([labelDir], resourcesDir, MODEL)).toBe(true);
+  });
+});
+
+describe('labelcArgs', () => {
+  it('matches the invocation Visual Studio records in CompileLabels.xml', () => {
+    // K:\...\bin\labelc.exe -metadata="K:\AosService\PackagesLocalDirectory"
+    //   -output="K:\AosService\PackagesLocalDirectory\HBReavis\Resources"
+    //   -modelmodule="HBReavis"
+    const args = labelcArgs('K:\\AosService\\PackagesLocalDirectory', 'HBReavis',
+      'K:\\AosService\\PackagesLocalDirectory\\HBReavis\\Resources', null, null);
+    expect(args).toEqual([
+      '-Metadata=K:\\AosService\\PackagesLocalDirectory',
+      '-Output=K:\\AosService\\PackagesLocalDirectory\\HBReavis\\Resources',
+      '-ModelModule=HBReavis',
+    ]);
+  });
+
+  it('pins csc and the SDK tools when they were located', () => {
+    // labelc otherwise resolves csc/al/resgen from PATH, which the MCP server
+    // does not control — VS gets away with it because it runs from a dev shell.
+    const args = labelcArgs('K:\\PLD', 'Contoso', 'K:\\PLD\\Contoso\\Resources',
+      'C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319',
+      'C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 Tools');
+    expect(args).toContain('-CompilerPath=C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319');
+    expect(args).toContain(
+      '-SdkToolsPath=C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 Tools',
+    );
+  });
+});
+
+describe('describeLabelCompilation', () => {
+  it('says nothing when there was nothing to do', () => {
+    expect(describeLabelCompilation(MODEL, { skipped: true, success: true, message: 'up to date' })).toBe('');
+  });
+
+  it('confirms a real compilation in one line', () => {
+    const text = describeLabelCompilation(MODEL, {
+      skipped: false, success: true, message: 'Done compiling 1 label files!',
+    });
+    expect(text).toContain('Labels compiled for Contoso');
+    expect(text).toContain('Done compiling 1 label files!');
+  });
+
+  it('names the bogus diagnostics a failure will produce', () => {
+    // Without this the reader sees BPErrorUnknownLabel on a label that plainly
+    // exists and starts editing correct source.
+    const text = describeLabelCompilation(MODEL, {
+      skipped: true, success: false, message: 'labelc.exe not found',
+    });
+    expect(text).toContain('FAILED');
+    expect(text).toContain('BPErrorUnknownLabel');
+  });
+});
+
+describe('build ordering', () => {
+  it('compiles labels before spawning xppc', async () => {
+    // The whole point. labelc after xppc would leave THIS build reporting
+    // unknown-label errors and clear them only on the next one.
+    const order: string[] = [];
+
+    vi.resetModules();
+    vi.doMock('../../src/tools/compileLabels.js', () => ({
+      compileModelLabels: vi.fn(async () => {
+        order.push('labelc');
+        return { skipped: false, success: true, message: 'Done compiling 1 label files!' };
+      }),
+    }));
+    vi.doMock('child_process', () => ({
+      spawn: vi.fn(() => {
+        order.push('xppc');
+        return { pid: 4242, unref: vi.fn(), on: vi.fn() };
+      }),
+      execFile: vi.fn((_f: string, _a: string[], _o: any, cb: Function) => cb(null, { stdout: '', stderr: '' })),
+    }));
+    vi.doMock('fs', () => ({ openSync: vi.fn().mockReturnValue(3), closeSync: vi.fn() }));
+    vi.doMock('fs/promises', () => ({
+      access: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      unlink: vi.fn().mockResolvedValue(undefined),
+      readFile: vi.fn().mockRejectedValue(new Error('ENOENT')),
+      appendFile: vi.fn().mockResolvedValue(undefined),
+      readdir: vi.fn().mockRejectedValue(new Error('ENOENT')),
+      stat: vi.fn().mockResolvedValue({ mtimeMs: 0 }),
+    }));
+    vi.doMock('../../src/utils/configManager.js', () => ({
+      getConfigManager: () => ({
+        ensureLoaded: vi.fn(),
+        getProjectPath: vi.fn().mockResolvedValue(null),
+        getPackagePath: vi.fn().mockReturnValue(null),
+        getContext: vi.fn().mockReturnValue({}),
+        getCustomPackagesPath: vi.fn().mockResolvedValue(null),
+        getMicrosoftPackagesPath: vi.fn().mockResolvedValue(null),
+        getActiveXppConfig: vi.fn().mockResolvedValue(null),
+        getModelName: vi.fn().mockReturnValue(MODEL),
+      }),
+    }));
+    vi.doMock('../../src/utils/operationLocks.js', () => ({
+      withOperationLock: (_k: string, fn: () => any) => fn(),
+      isOperationLockHeld: vi.fn().mockResolvedValue(false),
+      forceReleaseLock: vi.fn().mockResolvedValue(undefined),
+    }));
+    vi.doMock('../../src/utils/packagesRoot.js', () => ({
+      packagesRoots: () => ['K:\\AosService\\PackagesLocalDirectory'],
+      findPackagesRoot: () => 'K:\\AosService\\PackagesLocalDirectory',
+      packagesRootCandidates: (...rel: string[]) =>
+        [path.join('K:\\AosService\\PackagesLocalDirectory', ...rel)],
+      defaultPackagesRoot: () => 'K:\\AosService\\PackagesLocalDirectory',
+      describePackagesRootScan: () => 'Detected packages roots: K:',
+    }));
+
+    const { buildProjectTool } = await import('../../src/tools/buildProject');
+    await buildProjectTool({ wait: false }, {});
+
+    expect(order).toEqual(['labelc', 'xppc']);
+
+    vi.doUnmock('../../src/tools/compileLabels.js');
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
A label created through `labels(action="create")` reached the label text file and stopped there. Nothing compiled it: xppc and xppbp resolve `@Model:Id` against `<model>\Resources\<model>.dll`, which only `labelc.exe` produces, and this server never ran labelc. On a model whose labels had only ever been created through the MCP tools, the `Resources` folder did not exist at all.

The result is the worst kind of diagnostic — it points at correct code and names a step the tool never mentions.

## Reproduction

On the VM, against `ConDemoPrintMgmtRunner` in the Contoso eval sandbox, with `Contoso\Resources` absent:

```
BestPractices Warning: Unknown label '@Contoso:DemoPrintNoSettingConfigured'
BestPractices Warning: The placeholder '%2' to strFmt is not used in the format string.  (×2)

BPErrorUnknownLabel: 1
BPUnusedStrFmtArgument: 2
Warnings: 3
```

After a single `labelc.exe` run, **with no source change of any kind**:

```
Warnings: 0
Errors: 0
```

## The fix

- New `src/tools/compileLabels.ts` invokes labelc with the arguments VS records in `CompileLabels.xml`, plus `-CompilerPath` / `-SdkToolsPath` pinned to located directories rather than left to a PATH the server does not control.
- **Order matters as much as the call.** VS compiles labels *before* the X++ compile, and labelc after xppc would leave the build in hand still reporting the stale errors and clear them only on the next one. `compileModelLabels` therefore runs before xppc is spawned, and its outcome heads the build log.
- `run_bp_check` gets the same treatment: a BP check can follow label creation with no build in between, and that is the path the failure above was found on.
- Recompiling is decided by the disk — missing output, or a label source newer than the assembly. A full build forces it. It errs toward compiling: labelc costs about a second, while a wrongly skipped run reinstates the bogus errors.
- `findXppcExe` becomes `findFrameworkTool` in `src/utils/frameworkBin.ts`, since locating `labelc.exe` needs the identical three-step probe.

A failed label compilation is reported loudly at the top of the build log, naming the diagnostics it will produce, so the reader never starts editing correct source.

## Verification

14 new tests in `tests/tools/compileLabels.test.ts`, including one that asserts labelc runs before the xppc spawn. Full suite green (the one `apiSymbols` failure is the known cold-cache timeout on the 2 GB symbol DB — passes in 1.9 s warm).

End to end on the VM:
- full build compiles labels then xppc — `Labels compiled for Contoso — Done compiling 1 label files!`, build succeeded in 43 s;
- incremental build skips them as up to date;
- the BP check above now passes clean.

Independently confirmed afterwards by the eval case this defect was blocking (`L3-print-management-report`, stacked in #794): both labels it creates compiled and checked clean, and the only `BPErrorUnknownLabel` in the whole run was one deliberately induced by a negative probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9kCe65EKipWtimo7sHmrZ

