### PR TITLE
eval: land the L3-parallel-batch-tasks and L3-print-management-report goldens

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://img.shields.io/badge/tests-1400%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
-[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-85.9%25-lightgrey.svg)](eval/COVERAGE.md)
+[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-87.2%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://img.shields.io/badge/tests-1400%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
-[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-87.2%25-lightgrey.svg)](eval/COVERAGE.md)
+[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-88.5%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -9,7 +9,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
 | core | 44 | 44 | **100%** |
-| total | 68 | 78 | 87.2% |
+| total | 69 | 78 | 88.5% |
 
 ## Data model (12/12)
 
@@ -67,13 +67,13 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Menus & submenu nesting | core | ✅ | ✅ | ✅ | L4-master-security-slice |
 | Tiles & KPIs | total | ✅ | ✅ | ✅ | L2-tile-cue-over-query |
 
-## Reporting (2/4)
+## Reporting (3/4)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | SSRS report (DP + contract + controller) | core | ✅ | ✅ | ✅ | L4-ssrs-report-advanced, L4-ssrs-report-basic |
 | Multi-dataset SSRS report | total | ✅ | ✅ | ✅ | L4-ssrs-report-multidataset |
-| Print management | total | ✅ | — | ✅ | Eval case authored (document node + settings resolution); golden pending VM capture. |
+| Print management | total | ✅ | ✅ | ✅ | L3-print-management-report |
 | Electronic Reporting (ER) | total | ✅ | — | ✅ | Eval case authored for the X++ half (ER data provider); the ER model/mapping/format stay UI-configured and out of scope. Golden pending VM capture. |
 
 ## Frameworks (13/16)
@@ -136,7 +136,6 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | 2 | Data management framework (DMF/DIXF) | missing E |
 | 2 | Dual-write (Dataverse) | missing E |
 | 2 | Posting engine (LedgerVoucher) | missing E |
-| 2 | Print management | missing E |
 | 1 | Aggregate measurements / analytics | missing E |
 | 1 | Electronic Reporting (ER) | missing E |
 | 1 | Power Platform / virtual entities | missing E |

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -9,7 +9,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
 | core | 44 | 44 | **100%** |
-| total | 67 | 78 | 85.9% |
+| total | 68 | 78 | 87.2% |
 
 ## Data model (12/12)
 
@@ -76,12 +76,12 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Print management | total | ✅ | — | ✅ | Eval case authored (document node + settings resolution); golden pending VM capture. |
 | Electronic Reporting (ER) | total | ✅ | — | ✅ | Eval case authored for the X++ half (ER data provider); the ER model/mapping/format stay UI-configured and out of scope. Golden pending VM capture. |
 
-## Frameworks (12/16)
+## Frameworks (13/16)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | SysOperation / batch | core | ✅ | ✅ | ✅ | L3-batch-basic |
-| Parallel batch processing | total | ✅ | — | ✅ | Eval case authored (BatchHeader runtime tasks); golden pending VM capture. |
+| Parallel batch processing | total | ✅ | ✅ | ✅ | L3-parallel-batch-tasks |
 | Async & retryable batch (BatchRetryable/runAsync) | total | ✅ | ✅ | ✅ | L3-batch-retryable-basic |
 | Number sequences | core | ✅ | ✅ | ✅ | L2-numberseq-basic |
 | Financial dimensions | core | ✅ | ✅ | ✅ | L2-dimension-basic |
@@ -135,7 +135,6 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | ---: | --- | --- |
 | 2 | Data management framework (DMF/DIXF) | missing E |
 | 2 | Dual-write (Dataverse) | missing E |
-| 2 | Parallel batch processing | missing E |
 | 2 | Posting engine (LedgerVoucher) | missing E |
 | 2 | Print management | missing E |
 | 1 | Aggregate measurements / analytics | missing E |
@@ -150,4 +149,4 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 - Knowledge entries no leaf claims (**unproven knowledge**): none
 - Eval cases no leaf claims (**unmapped proof**): L2-oracle-discriminator-random-wrapper-name, L4-headerlines-document-slice
 
-_Generated 2026-07-28._
+_Generated 2026-07-29._

--- a/eval/cases/L3-parallel-batch-tasks.json
+++ b/eval/cases/L3-parallel-batch-tasks.json
@@ -7,7 +7,7 @@
     "AxClass"
   ],
   "golden_path": "eval/goldens/L3-parallel-batch-tasks/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/cases/L3-print-management-report.json
+++ b/eval/cases/L3-print-management-report.json
@@ -8,7 +8,7 @@
     "AxEnum"
   ],
   "golden_path": "eval/goldens/L3-print-management-report/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/corpus/runs/2026-07-29T07__L3-parallel-batch-tasks__d1ccb46.json
+++ b/eval/corpus/runs/2026-07-29T07__L3-parallel-batch-tasks__d1ccb46.json
@@ -1,0 +1,68 @@
+{
+  "run_id": "2026-07-29T07__L3-parallel-batch-tasks__d1ccb46",
+  "case_id": "L3-parallel-batch-tasks",
+  "tier": 3,
+  "timestamp": "2026-07-29T07:41:39.142Z",
+  "server_git_sha": "d1ccb46",
+  "generated_artifacts": [
+    "Contoso/Contoso/AxClass/ConDemoParallelContract.xml",
+    "Contoso/Contoso/AxClass/ConDemoParallelWorker.xml",
+    "Contoso/Contoso/AxClass/ConDemoParallelScheduler.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "rule": "BPUpgradeCodeSysEntryPointAttribute",
+        "severity": "warning",
+        "object": "ConDemoParallelWorker.processBundle",
+        "message": "SysEntryPoint attribute has been deprecated, you can safely remove the attribute.",
+        "inScope": false,
+        "note": "Mandated verbatim by the case instruction ([SysEntryPointAttribute] on processBundle); also emitted by xppc as a compile warning. 0 BP errors."
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT",
+  "platform_build": "xppc 7.0.7858.27",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "Case deliverables all produced, full build clean (0 errors), golden match. Two tool-path gaps observed. (1) PRIMARY TOOL_DEFECT: build_d365fo_project never runs labelc.exe, so labels created via labels(action=\"create\") are never compiled into <Package>/Resources/<LabelFile>.dll. Contoso had no Resources/ folder at all after two full builds. Consequence: xppbp reported BPErrorUnknownLabel for @Contoso:DemoParallelBundleProcessed and @Contoso:DemoParallelTaskCaption, plus 5 cascading bogus BPUnusedStrFmtArgument warnings (it cannot see the %n placeholders inside the unresolved label text). Proven deterministically: running bin\\labelc.exe -metadata=K:\\AosService\\PackagesLocalDirectory -output=...\\Contoso\\Resources -modelmodule=Contoso (the exact command VS records in HBReavis/CompileLabels.xml) made all 6 warnings disappear with no source change. The grounded tool path alone cannot reach a label-clean BP result. (2) SECONDARY: d365fo_file(action=\"modify\", operation=\"replace-code\") cannot target a class Declaration - the C# bridge answers \"oldCode not found in <Class>\" for text that is verbatim in <Declaration>, and the tool silently falls back to a direct XML edit (and drops a .backup-<ts> file inside the AxClass AOT folder, which is residue the metadata store then sees). Reproduced 3/3 times on 3 different classes. The remaining bp_clean:0 is NOT a defect: the single surviving warning is BPUpgradeCodeSysEntryPointAttribute, which the case instruction requires verbatim. Zero BP errors, as the case demands.",
+  "suggested_fix_area": "src/tools/build (build_d365fo_project): run bin/labelc.exe -metadata=<packagesRoot> -output=<packagesRoot>/<Package>/Resources -modelmodule=<Model> before/after xppc, as Visual Studio does, and surface its diagnostics; alternatively have labels(action=\"create\") trigger it. Secondary: src/tools/file modify/replace-code - make the bridge search the Declaration as well as Methods, and write the auto-backup outside the AxClass folder.",
+  "evidence_refs": [
+    "eval/goldens/L3-parallel-batch-tasks/ (frozen golden, 3 artifacts, captured 2026-07-29)",
+    "run_bp_check(targetFilter=ConDemoParallelWorker) BEFORE labelc: BPErrorUnknownLabel:1 BPUnusedStrFmtArgument:3 BPUpgradeCodeSysEntryPointAttribute:1 BPXmlDocNoDocumentationComments:1 (6 warnings, 0 errors)",
+    "run_bp_check(targetFilter=ConDemoParallelScheduler) BEFORE labelc: BPErrorUnknownLabel:1 BPUnusedStrFmtArgument:2 BPXmlDocNoDocumentationComments:1 (4 warnings, 0 errors)",
+    "run_bp_check AFTER labelc.exe + class XmlDoc: Contract 0/0, Scheduler 0/0, Worker 1 warning (BPUpgradeCodeSysEntryPointAttribute), 0 errors",
+    "K:\\AosService\\PackagesLocalDirectory\\HBReavis\\CompileLabels.xml (the labelc.exe command line VS runs; no equivalent file exists for Contoso)",
+    "Negative probe ConParallelNegProbe (full build FAILED as designed): \"Type mismatch in BatchHeader.addRuntimeTask argument 1. The expected type is Batchable, but the actual type is ConDemoParallelContract.\" + \"The instance method designated by argument processBundleDoesNotExist does not exist.\" - proves the clean build really type-checks the fan-out and methodStr, so build:1 is meaningful evidence.",
+    "Full build (fullBuild:true) x3: 0 errors, 2 warnings (1 unrelated Commerce PricingEngine external reference, 1 SysEntryPointAttribute obsolete)"
+  ]
+}

--- a/eval/corpus/runs/2026-07-29T11__L3-print-management-report__33f6418.json
+++ b/eval/corpus/runs/2026-07-29T11__L3-print-management-report__33f6418.json
@@ -1,0 +1,37 @@
+{
+  "run_id": "2026-07-29T11__L3-print-management-report__33f6418",
+  "case_id": "L3-print-management-report",
+  "tier": 3,
+  "timestamp": "2026-07-29T11:11:57.123Z",
+  "server_git_sha": "33f6418",
+  "generated_artifacts": [
+    "ConDemoPrintDocType.metadata.xml",
+    "ConDemoPrintMgmtDocType.metadata.xml",
+    "ConDemoPrintMgmtRunner.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "PASS"
+}

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -8,8 +8,8 @@
   "total": {
     "tier": "all",
     "total": 78,
-    "covered": 67,
-    "percent": 85.9
+    "covered": 68,
+    "percent": 87.2
   },
   "leaves": [
     {
@@ -754,10 +754,12 @@
       "tier": "total",
       "weight": 2,
       "k": true,
-      "e": false,
+      "e": true,
       "t": true,
-      "covered": false,
-      "cases": []
+      "covered": true,
+      "cases": [
+        "L3-parallel-batch-tasks"
+      ]
     },
     {
       "id": "async-retryable-batch",

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -8,8 +8,8 @@
   "total": {
     "tier": "all",
     "total": 78,
-    "covered": 68,
-    "percent": 87.2
+    "covered": 69,
+    "percent": 88.5
   },
   "leaves": [
     {
@@ -716,10 +716,12 @@
       "tier": "total",
       "weight": 2,
       "k": true,
-      "e": false,
+      "e": true,
       "t": true,
-      "covered": false,
-      "cases": []
+      "covered": true,
+      "cases": [
+        "L3-print-management-report"
+      ]
     },
     {
       "id": "electronic-reporting",

--- a/eval/goldens/L3-parallel-batch-tasks/ConDemoParallelContract.metadata.xml
+++ b/eval/goldens/L3-parallel-batch-tasks/ConDemoParallelContract.metadata.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Golden metadata for eval case: L3-parallel-batch-tasks (artifact 1 of 3: data contract)
+  Captured: 2026-07-29, server SHA: d1ccb46
+  Platform: xppc 7.0.7858.27
+-->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoParallelContract</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Serializable data contract that carries the note ID bounds of one parallel batch bundle.
+/// </summary>
+[DataContractAttribute]
+class ConDemoParallelContract
+{
+    Num fromNoteId;
+    Num toNoteId;
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>parmFromNoteId</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Gets or sets the first note ID of the bundle that one parallel batch task handles.
+    /// </summary>
+    /// <param name = "_fromNoteId">The first note ID of the bundle.</param>
+    /// <returns>The first note ID of the bundle.</returns>
+    [DataMemberAttribute,
+    SysOperationLabelAttribute(literalStr("@Contoso:DemoParallelBundleFrom")),
+    SysOperationDisplayOrderAttribute('1')]
+    public Num parmFromNoteId(Num _fromNoteId = fromNoteId)
+    {
+        fromNoteId = _fromNoteId;
+        return fromNoteId;
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmToNoteId</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Gets or sets the last note ID of the bundle that one parallel batch task handles.
+    /// </summary>
+    /// <param name = "_toNoteId">The last note ID of the bundle.</param>
+    /// <returns>The last note ID of the bundle.</returns>
+    [DataMemberAttribute,
+    SysOperationLabelAttribute(literalStr("@Contoso:DemoParallelBundleTo")),
+    SysOperationDisplayOrderAttribute('2')]
+    public Num parmToNoteId(Num _toNoteId = toNoteId)
+    {
+        toNoteId = _toNoteId;
+        return toNoteId;
+    }
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-parallel-batch-tasks/ConDemoParallelScheduler.metadata.xml
+++ b/eval/goldens/L3-parallel-batch-tasks/ConDemoParallelScheduler.metadata.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Golden metadata for eval case: L3-parallel-batch-tasks (artifact 3 of 3: BatchHeader fan-out scheduler)
+  Captured: 2026-07-29, server SHA: d1ccb46
+  Platform: xppc 7.0.7858.27
+-->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoParallelScheduler</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Fans the <c>ConDemoNoteHeader</c> processing out into one parallel batch task per bundle.
+/// </summary>
+class ConDemoParallelScheduler
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>scheduleAll</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Partitions the <c>ConDemoNoteHeader</c> rows into bundles and schedules one batch task
+    /// per bundle on a single batch job, so that the bundles are processed in parallel.
+    /// </summary>
+    public static void scheduleAll()
+    {
+        BatchHeader batchHeader;
+        ConDemoNoteHeader noteHeader;
+        Num bundleFromNoteId;
+        Num bundleToNoteId;
+        RecId inheritFromTaskId;
+        int rowsInBundle;
+        int bundleCount;
+
+        batchHeader = BatchHeader::construct();
+        inheritFromTaskId = ConDemoParallelScheduler::currentBatchTaskId();
+
+        while select NoteId from noteHeader
+        order by NoteId
+        {
+            if (rowsInBundle == 0)
+            {
+                bundleFromNoteId = noteHeader.NoteId;
+            }
+
+            bundleToNoteId = noteHeader.NoteId;
+            rowsInBundle++;
+
+            if (rowsInBundle >= ConDemoParallelScheduler::bundleSize())
+            {
+                ConDemoParallelScheduler::addBundleTask(batchHeader, bundleFromNoteId, bundleToNoteId, inheritFromTaskId);
+                bundleCount++;
+                rowsInBundle = 0;
+            }
+        }
+
+        if (rowsInBundle > 0)
+        {
+            ConDemoParallelScheduler::addBundleTask(batchHeader, bundleFromNoteId, bundleToNoteId, inheritFromTaskId);
+            bundleCount++;
+        }
+
+        if (bundleCount > 0)
+        {
+            batchHeader.parmCaption(literalStr("@Contoso:DemoParallelJobCaption"));
+            batchHeader.save();
+        }
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>addBundleTask</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Adds one runtime batch task for a single bundle to the batch job.
+    /// </summary>
+    /// <param name = "_batchHeader">The batch job that collects the parallel tasks.</param>
+    /// <param name = "_fromNoteId">The first note ID of the bundle.</param>
+    /// <param name = "_toNoteId">The last note ID of the bundle.</param>
+    /// <param name = "_inheritFromTaskId">The batch task the new task inherits its settings from.</param>
+    private static void addBundleTask(
+    BatchHeader _batchHeader,
+    Num _fromNoteId,
+    Num _toNoteId,
+    RecId _inheritFromTaskId)
+    {
+        SysOperationServiceController controller;
+        ConDemoParallelContract contract;
+
+        controller = new SysOperationServiceController(
+        classStr(ConDemoParallelWorker),
+        methodStr(ConDemoParallelWorker, processBundle),
+        SysOperationExecutionMode::Synchronous);
+
+        contract = controller.getDataContractObject('_contract') as ConDemoParallelContract;
+        contract.parmFromNoteId(_fromNoteId);
+        contract.parmToNoteId(_toNoteId);
+
+        controller.batchInfo().parmCaption(strFmt("@Contoso:DemoParallelTaskCaption", _fromNoteId, _toNoteId));
+
+        _batchHeader.addRuntimeTask(controller, _inheritFromTaskId);
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>currentBatchTaskId</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Gets the record ID of the currently executing batch task, or zero when not running in batch.
+    /// </summary>
+    /// <returns>The record ID of the currently executing batch task.</returns>
+    private static RecId currentBatchTaskId()
+    {
+        Batch currentTask = BatchHeader::getCurrentBatchTask();
+
+        return currentTask.RecId;
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>bundleSize</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Gets the number of <c>ConDemoNoteHeader</c> rows that one parallel batch task processes.
+    /// </summary>
+    /// <returns>The bundle size.</returns>
+    private static int bundleSize()
+    {
+        return 100;
+    }
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-parallel-batch-tasks/ConDemoParallelWorker.metadata.xml
+++ b/eval/goldens/L3-parallel-batch-tasks/ConDemoParallelWorker.metadata.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Golden metadata for eval case: L3-parallel-batch-tasks (artifact 2 of 3: SysOperation worker service)
+  Captured: 2026-07-29, server SHA: d1ccb46
+  Platform: xppc 7.0.7858.27
+-->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoParallelWorker</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// SysOperation service that processes one bundle of <c>ConDemoNoteHeader</c> rows per batch task.
+/// </summary>
+class ConDemoParallelWorker
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>processBundle</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Processes exactly the <c>ConDemoNoteHeader</c> bundle that the contract identifies.
+    /// </summary>
+    /// <param name = "_contract">The data contract that carries the bundle bounds.</param>
+    /// <remarks>
+    /// One parallel batch task invokes this method once, for one bundle only, so that the
+    /// bundles scheduled by <c>ConDemoParallelScheduler</c> are processed concurrently.
+    /// </remarks>
+    [SysEntryPointAttribute]
+    public void processBundle(ConDemoParallelContract _contract)
+    {
+        ConDemoNoteHeader noteHeader;
+        Num fromNoteId;
+        Num toNoteId;
+        int processed;
+
+        fromNoteId = _contract.parmFromNoteId();
+        toNoteId = _contract.parmToNoteId();
+
+        while select noteHeader
+        where noteHeader.NoteId >= fromNoteId
+        && noteHeader.NoteId <= toNoteId
+        {
+            processed++;
+        }
+
+        info(strFmt("@Contoso:DemoParallelBundleProcessed", processed, fromNoteId, toNoteId));
+    }
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-parallel-batch-tasks/README.md
+++ b/eval/goldens/L3-parallel-batch-tasks/README.md
@@ -1,0 +1,72 @@
+# L3-parallel-batch-tasks — golden notes
+
+**Status: FROZEN.** All three required deliverables were written through the grounded
+tool path and verified on the VM, so `golden_pending` is `false` in
+`eval/cases/L3-parallel-batch-tasks.json`.
+
+Captured 2026-07-29, server SHA `d1ccb46`, xppc 7.0.7858.27, model `Contoso`,
+`EXTENSION_PREFIX=Con`.
+
+| Artifact | Role |
+|---|---|
+| `ConDemoParallelContract.metadata.xml` | `[DataContractAttribute]` contract, two `[DataMemberAttribute]` `parm` methods over the bundle's from/to `NoteId`. Scalar `Num` members only — serializable, no `List`/`Map`. |
+| `ConDemoParallelWorker.metadata.xml` | SysOperation service; `[SysEntryPointAttribute] public void processBundle(ConDemoParallelContract _contract)` selects **only** the contract's `NoteId` range. |
+| `ConDemoParallelScheduler.metadata.xml` | `public static void scheduleAll()` — `BatchHeader::construct()`, one `addRuntimeTask(SysOperationServiceController, inheritFromTaskId)` per bundle, then `save()`. The work is **not** done inline. |
+
+## Grounded signatures (all read off the real AOT before writing)
+
+- `static BatchHeader construct(recId _batchJobId = 0)`
+- `void addRuntimeTask(Batchable batchTask, recId inheritFromTaskId, BatchConstraintType constraintType = BatchConstraintType::And)`
+- `void save(BatchStatus status = BatchStatus::Waiting)`
+- `public BatchCaption parmCaption(BatchCaption _caption = caption)` (on both `BatchHeader` and `BatchInfo`)
+- `public static Batch getCurrentBatchTask()` — documented to return *an empty record* when not in batch, so `.RecId` is safe
+- `SysOperationServiceController.new(IdentifierName _className='', IdentifierName _methodName='', SysOperationExecutionMode _executionMode = SysOperationExecutionMode::Asynchronous)`
+- `public Object getDataContractObject(IdentifierName _parameterName = '')`
+
+## Negative proof that the clean build is meaningful
+
+A throwaway probe class was compiled and then removed. The full build failed exactly
+as designed, which is what makes `build: 1` on the real artifacts evidence rather than
+noise:
+
+```
+Type mismatch in 'BatchHeader.addRuntimeTask' argument 1.
+  The expected type is 'Batchable', but the actual type is 'ConDemoParallelContract'.
+The instance method designated by argument 'processBundleDoesNotExist' does not exist.
+```
+
+So the compiler really does enforce `Batchable` on argument 1 (i.e. the fan-out via
+`SysOperationServiceController` is genuine) and really does resolve
+`methodStr(ConDemoParallelWorker, processBundle)`.
+
+## Accepted BP warning (`bp_clean: 0`, **0 BP errors**)
+
+`BPUpgradeCodeSysEntryPointAttribute` on `ConDemoParallelWorker.processBundle`
+("SysEntryPoint attribute has been deprecated"). xppc emits the same thing as a
+compile warning. It is **mandated verbatim by the case instruction**, so it cannot be
+removed without failing the case. The harness's `bp_clean` counts warnings of any
+severity, hence `0`; the case's own gate — zero BP *errors* — is met.
+
+## Reproduction caveat: labels must be compiled separately
+
+The classes reference `@Contoso:DemoParallel*` labels created with
+`labels(action="create")`. `build_d365fo_project` does **not** run `labelc.exe`, so the
+labels are never compiled into `Contoso/Resources/Contoso.dll` and xppbp reports
+`BPErrorUnknownLabel` plus cascading bogus `BPUnusedStrFmtArgument` warnings. Until
+that gap is closed in the server, a re-run must compile labels out of band:
+
+```
+bin\labelc.exe -metadata="K:\AosService\PackagesLocalDirectory" ^
+               -output="K:\AosService\PackagesLocalDirectory\Contoso\Resources" ^
+               -modelmodule="Contoso"
+```
+
+(the exact command Visual Studio records in `HBReavis/CompileLabels.xml`). Doing so
+removed all six label-related warnings with no source change — see the
+`TOOL_DEFECT` record `eval/corpus/runs/2026-07-29T07__L3-parallel-batch-tasks__d1ccb46.json`.
+
+## Fixture
+
+`ConDemoNoteHeader` is a harness INPUT fixture (`eval/fixtures/`). It is read by the
+worker and the scheduler and is **kept** by the rollback — this case neither creates
+nor deletes it.

--- a/eval/goldens/L3-print-management-report/ConDemoPrintDocType.metadata.xml
+++ b/eval/goldens/L3-print-management-report/ConDemoPrintDocType.metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoPrintDocType</Name>
+	<Label>@Contoso:DemoPrintDocTypeName</Label>
+	<UseEnumValue>No</UseEnumValue>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>DemoConfirmation</Name>
+			<Label>@Contoso:DemoPrintDocTypeConfirmation</Label>
+		</AxEnumValue>
+	</EnumValues>
+	<IsExtensible>true</IsExtensible>
+</AxEnum>

--- a/eval/goldens/L3-print-management-report/ConDemoPrintMgmtDocType.metadata.xml
+++ b/eval/goldens/L3-print-management-report/ConDemoPrintMgmtDocType.metadata.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoPrintMgmtDocType</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Registers the demo confirmation document node in print management.
+/// </summary>
+public class ConDemoPrintMgmtDocType extends PrintMgmtDocType
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>new</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Initializes a new instance of the <c>ConDemoPrintMgmtDocType</c> class.
+    /// </summary>
+    protected void new()
+    {
+        super();
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>newDemoDocType</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Creates an instance of the <c>ConDemoPrintMgmtDocType</c> class.
+    /// </summary>
+    /// <returns>
+    /// An instance of the <c>ConDemoPrintMgmtDocType</c> class.
+    /// </returns>
+    public static ConDemoPrintMgmtDocType newDemoDocType()
+    {
+        return new ConDemoPrintMgmtDocType();
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>getDemoDocumentType</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Retrieves the demo document type that this node registers.
+    /// </summary>
+    /// <returns>
+    /// The <c>ConDemoPrintDocType</c> element that is handled by this node.
+    /// </returns>
+    public ConDemoPrintDocType getDemoDocumentType()
+    {
+        return ConDemoPrintDocType::DemoConfirmation;
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>getDefaultReportFormat</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Retrieves the default report format for the demo confirmation document.
+    /// </summary>
+    /// <returns>
+    /// The name of the SSRS report design that prints the demo confirmation document.
+    /// </returns>
+    public PrintMgmtReportFormatName getDefaultReportFormat()
+    {
+        return 'ConDemoConfirmation.Report';
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>getDisplayName</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Retrieves the description of the demo confirmation document node.
+    /// </summary>
+    /// <returns>
+    /// The description that is shown for the node in the print management setup.
+    /// </returns>
+    public str getDisplayName()
+    {
+        return "@Contoso:DemoPrintMgmtNodeDescription";
+    }
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-print-management-report/ConDemoPrintMgmtRunner.metadata.xml
+++ b/eval/goldens/L3-print-management-report/ConDemoPrintMgmtRunner.metadata.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoPrintMgmtRunner</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Resolves print management settings for demo confirmation documents and prints them.
+/// </summary>
+public class ConDemoPrintMgmtRunner
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>printFor</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Prints the demo confirmation document that is identified by the specified document number.
+    /// </summary>
+    /// <param name = "_documentId">
+    /// The identifier of the document that must be printed.
+    /// </param>
+    /// <remarks>
+    /// The print destination is always taken from the print management setup that is resolved through
+    /// <c>ConDemoPrintMgmtDocType</c> and the <c>PrintMgmtSettings</c> table. No print destination is
+    /// constructed by hand.
+    /// </remarks>
+    public static void printFor(Num _documentId)
+    {
+        ConDemoPrintMgmtDocType     demoDocType;
+        PrintMgmtReportFormatName   reportFormatName;
+        PrintMgmtSettings           printMgmtSettings;
+        PrintMgmtReportFormat       printMgmtReportFormat;
+        PrintMgmtPrintSettingDetail printSettingDetail;
+        SrsReportRunController      controller;
+        SrsReportDataContract       reportContract;
+        SRSPrintDestinationSettings printDestinationSettings;
+
+        demoDocType      = ConDemoPrintMgmtDocType::newDemoDocType();
+        reportFormatName = demoDocType.getDefaultReportFormat();
+
+        select firstonly printMgmtSettings
+        join printMgmtReportFormat
+        where printMgmtReportFormat.RecId == printMgmtSettings.ReportFormat
+        && printMgmtReportFormat.Name == reportFormatName;
+
+        if (!printMgmtSettings.RecId)
+        {
+            info(strFmt("@Contoso:DemoPrintNoSettingConfigured", _documentId));
+            return;
+        }
+
+        controller = new SrsReportRunController();
+        controller.parmReportName(reportFormatName);
+        controller.parmShowDialog(false);
+
+        reportContract           = controller.parmReportContract();
+        printDestinationSettings = reportContract.parmPrintSettings();
+        printDestinationSettings.unpack(printMgmtSettings.PrintJobSettings);
+
+        printSettingDetail = new PrintMgmtPrintSettingDetail();
+        printSettingDetail.parmReportFormatName(printMgmtReportFormat.Name);
+        printSettingDetail.parmInstanceName(printMgmtSettings.Description);
+        printSettingDetail.parmNumberOfCopies(printMgmtSettings.NumberOfCopies);
+        printSettingDetail.parmPrintJobSettings(printDestinationSettings);
+
+        reportContract.parmPrintSettings(printSettingDetail.parmPrintJobSettings());
+
+        controller.startOperation();
+    }
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-print-management-report/README.md
+++ b/eval/goldens/L3-print-management-report/README.md
@@ -1,0 +1,139 @@
+# Golden: L3-print-management-report — FROZEN
+
+Captured 2026-07-29, server SHA 33f6418, xppc 7.0.7858.27 (VM), model `Contoso`,
+`EXTENSION_PREFIX=Con`. Every artifact was written through
+`prepare(create)` -> `d365fo_file(action="create")`. No `overwrite`, no hand-edited
+XML, no filesystem writes.
+
+## Artifacts
+
+- `ConDemoPrintDocType.metadata.xml` — AxEnum, `IsExtensible=true`,
+  label `@Contoso:DemoPrintDocTypeName`, single element `DemoConfirmation`
+  (label `@Contoso:DemoPrintDocTypeConfirmation`).
+- `ConDemoPrintMgmtDocType.metadata.xml` — AxClass **extending `PrintMgmtDocType`**
+  (ApplicationFoundation). Overrides the two framework members:
+  `public PrintMgmtReportFormatName getDefaultReportFormat()` returning the SSRS
+  report design name as a plain single-quoted str constant
+  (ConDemoConfirmation.Report), and `public str getDisplayName()` returning the
+  node description label `"@Contoso:DemoPrintMgmtNodeDescription"` (double quotes =
+  compile-time label resolution). Plus `newDemoDocType()` (factory; the base
+  `new()` is `protected`, and the base `construct(PrintMgmtDocumentType)` name is
+  deliberately not reused) and `getDemoDocumentType()` tying the class to the new
+  base enum.
+- `ConDemoPrintMgmtRunner.metadata.xml` — AxClass with
+  `public static void printFor(Num _documentId)`. Resolves the setup by asking the
+  doc-type class for its format name, joining `PrintMgmtReportFormat` to
+  `PrintMgmtSettings`, and — when nothing is set up — infologs the labelled message
+  `@Contoso:DemoPrintNoSettingConfigured` through `strFmt` with the document id.
+  The `SRSPrintDestinationSettings` instance is **never constructed**: it is taken
+  from `SrsReportRunController.parmReportContract().parmPrintSettings()` and loaded
+  with the stored print-management job settings via
+  `unpack(PrintMgmtSettings.PrintJobSettings)`, then handed back through
+  `PrintMgmtPrintSettingDetail.parmPrintJobSettings()`.
+
+## Grounding (every signature confirmed, none guessed)
+
+`get_knowledge(topic="print-management")` first, then against the real AOT:
+
+| Member used | Confirmed signature | Source |
+|---|---|---|
+| `PrintMgmtDocType.getDefaultReportFormat()` | `public PrintMgmtReportFormatName getDefaultReportFormat()` | `get_method` |
+| `PrintMgmtDocType.getDisplayName()` | `public str getDisplayName()` | `get_method` |
+| `PrintMgmtDocType.new()` | `protected void new()` | `get_object_info` |
+| `PrintMgmtPrintSettingDetail.parmPrintJobSettings()` | takes/returns `SRSPrintDestinationSettings` | `get_object_info` |
+| `PrintMgmtPrintSettingDetail.parmReportFormatName / parmInstanceName / parmNumberOfCopies` | as listed on the class | `get_object_info` |
+| `PrintMgmtSettings` (TABLE, not a class) | fields `ReportFormat`, `PrintJobSettings` (`PrintJobSettingsPacked`), `NumberOfCopies`, `Description`, `ParentId`, `PriorityId` | `get_object_info(objectType="table")` |
+| `PrintMgmtReportFormat` (TABLE) | `Name` (`PrintMgmtReportFormatName`), `RecId`, `DocumentType`, `System` | `get_object_info(objectType="table")` |
+| `SrsReportRunController.parmReportContract()` | `public SrsReportDataContract parmReportContract(...)`; the getter lazily calls `getReportContract()`, so it is safe right after `parmReportName()` | `get_method` (read the body) |
+| `SrsReportDataContract.parmPrintSettings()` | `public SRSPrintDestinationSettings parmPrintSettings(...)` | `get_object_info(members="names")` |
+| `SRSPrintDestinationSettings.unpack()` | `public boolean unpack(container _pack)` | `get_object_info(members="names")` |
+| `SysOperationController.startOperation()` | `public SysOperationStartResult startOperation()` | `get_method` |
+
+Notable grounding corrections against the naive guess:
+
+- `PrintMgmtSettings` and `PrintMgmtDocInstance` are **tables**, not classes
+  (`search(type="class")` returns nothing for either).
+- `PrintMgmtDocType` has **no subclasses in the standard model** and no abstract
+  members; the standard extension seam is the delegate
+  `getDefaultReportFormatDelegate(PrintMgmtDocumentType, EventHandlerResult)`.
+- `PrintMgmtNode` (abstract) is a different concept — hierarchy nodes, with
+  `getDisplayCaptionImplementation` / `getNodeType` — and is not what a
+  `...PrintMgmtDocType` class implements.
+
+## Design decision worth challenging
+
+A production print-management registration extends the **`PrintMgmtDocumentType`**
+enum and subscribes to `PrintMgmtDocType.getDefaultReportFormatDelegate`; settings
+are then resolved by
+`PrintMgmtPrintContext.setHierarchyContext(PrintMgmtHierarchyType, PrintMgmtNodeType, PrintMgmtDocumentType, Common)`
+plus `PrintMgmt::getSettings()`. The case instruction instead asks for a **base
+enum** `DemoPrintDocType`, and every one of those APIs is typed on
+`PrintMgmtDocumentType`, so the delegate/context path is closed to a custom base
+enum. The capture therefore registers the node by **subclassing `PrintMgmtDocType`
+and overriding the two members by name**, which is what "the members the framework
+expects" means here and — unlike a delegate handler — is enforced by the compiler
+(see negative probe 1). The `PrintMgmtReportFormat` -> `PrintMgmtSettings` join is
+the resolution path a custom document type can actually take.
+
+## Negative probes (a green build is not proof)
+
+Three deliberate breakages, each applied with
+`d365fo_file(action="modify", operation="replace-code")` and followed by a
+`fullBuild: true` build. All were restored, and the restored files were verified
+byte-identical to these goldens.
+
+1. **Member signature** — `getDefaultReportFormat` return type changed from
+   `PrintMgmtReportFormatName` to `boolean`. Build **FAILED**, 3 errors, headed by:
+   "Method 'boolean ConDemoPrintMgmtDocType.getDefaultReportFormat()' does not
+   override 'str(PrintMgmtReportFormatName) PrintMgmtDocType.getDefaultReportFormat()'
+   because the return type must be 'str(PrintMgmtReportFormatName)' instead of
+   'boolean'." — plus "Cannot implicitly convert from type 'boolean' to type
+   'str(PrintMgmtReportFormatName)'" in `ConDemoPrintMgmtRunner.printFor`. This
+   proves the class genuinely OVERRIDES a framework member rather than merely
+   declaring a same-named one, and that the runner is type-bound to it.
+2. **Resolved-settings call** — `printSettingDetail.parmPrintJobSettings(printDestinationSettings)`
+   changed to pass the raw packed container `printMgmtSettings.PrintJobSettings`.
+   Build **FAILED**, 1 error: "Type mismatch in
+   'PrintMgmtPrintSettingDetail.parmPrintJobSettings' argument 1. The expected type
+   is 'SRSPrintDestinationSettings', but the actual type is
+   'container(PrintJobSettingsPacked)'." The settings really must travel as a
+   resolved `SRSPrintDestinationSettings`; the packed field cannot be
+   short-circuited.
+3. **Label** — the infolog label swapped for a non-existent
+   `@Contoso:DemoPrintNoSettingConfiguredBogus`. The build still **succeeded**
+   (unknown labels are not compile errors) and the FILTERED BP run reported exactly
+   the historical poison pair: `BPErrorUnknownLabel: 1` and
+   `BPUnusedStrFmtArgument: 1`. Restoring the real label made the same filtered BP
+   run clean. So xppbp does validate the label (the clean result below means
+   something), and the labelc-before-build/BP fix works: a label created with
+   `labels(action="create")` now compiles.
+
+## Build / BP at capture
+
+- FULL build (`fullBuild: true`, target model): **0 errors**, 1 unrelated warning
+  (Commerce `PricingEngine` external assembly — present on every build of this VM).
+  The build log shows "Labels compiled for Contoso — Done compiling 1 label files!"
+  before xppc runs.
+- BP: one FILTERED run per object (`targetFilter` + `targetElementType`, each
+  reporting "1 elements processed"): `class:ConDemoPrintMgmtDocType` 0 errors /
+  0 warnings, `class:ConDemoPrintMgmtRunner` 0/0, `enum:ConDemoPrintDocType` 0/0.
+
+## Labels
+
+Created for this case with `labels(action="create")` in label file `Contoso`
+(model `Contoso`, en-US) and removed again at rollback, because
+`Contoso.en-US.label.txt` is shared across cases and is kept empty:
+
+- `DemoPrintDocTypeName` = "Demo print document type"
+- `DemoPrintDocTypeConfirmation` = "Demo confirmation"
+- `DemoPrintMgmtNodeDescription` = "Demo confirmation document"
+- `DemoPrintNoSettingConfigured` = "No print management setting is configured for document %1."
+
+A re-run must re-create them before creating the objects.
+
+## Descriptor
+
+No package reference added. `PrintMgmtDocType`, `PrintMgmtSettings`,
+`PrintMgmtReportFormat`, `PrintMgmtPrintSettingDetail`, `SrsReportRunController`,
+`SrsReportDataContract` and `SRSPrintDestinationSettings` all live in
+**ApplicationFoundation**, which `Contoso.xml` already references.


### PR DESCRIPTION
Follow-up to #794, which was merged into `fix/build-compiles-labels` instead of `main`, so its contents never reached the default branch. The labelc fix itself (33f6418) already landed via #793 — the merge-base of this branch with `main` is that commit, so the three commits here carry only the eval work:

- goldens for `L3-parallel-batch-tasks` (ConDemoParallelContract / Scheduler / Worker + README)
- goldens for `L3-print-management-report` (ConDemoPrintDocType / PrintMgmtDocType / PrintMgmtRunner + README)
- the two corresponding corpus run records
- `golden_pending: true -> false` on both cases
- coverage bump to 88.5% (`eval/coverage.json`, `eval/COVERAGE.md`, `README.md`)

Note: the `eval/parallel-batch-golden` branch is a rebased duplicate of `d84b344` (identical patch-id `f43a8c48`) forked from a pre-#792 main. It is fully superseded by this PR and can be deleted rather than merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)