### PR TITLE
fix: grounding defects — unknown vs empty parameter lists, Descriptor visibility, ER/dual-write knowledge, AllowRowVersionChangeTracking

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -1504,7 +1504,7 @@ namespace D365MetadataBridge.Services
                         ?? throw new ArgumentException($"Table '{objectName}' not found");
                     var msi = GetModelSaveInfoForObject(_provider.Tables, objectName);
                     if (!SetAxTableProperty(obj, propertyPath, propertyValue))
-                        throw new ArgumentException($"Unknown AxTable property '{propertyPath}' — nothing was written. Supported: label, developerDocumentation, configurationKey, formRef, tableGroup, cacheLookup, clusteredIndex, primaryIndex, replacementKey, saveDataPerCompany, allowRowVersionChangeTracking, tableType, supportInheritance, instanceRelationType, extends, titleField1, titleField2.");
+                        throw new ArgumentException($"Unknown AxTable property '{propertyPath}' — nothing was written. Supported: label, developerDocumentation, configurationKey, formRef, tableGroup, cacheLookup, clusteredIndex, primaryIndex, replacementKey, saveDataPerCompany, allowRowVersionChangeTracking, createdBy, createdDateTime, createdTransactionId, modifiedBy, modifiedDateTime, modifiedTransactionId, tableType, supportInheritance, instanceRelationType, extends, titleField1, titleField2.");
                     ((IMetaTableProvider)_provider.Tables).Update(obj, msi);
                     return new { success = true, operation = "modify-property", objectType, objectName, propertyPath, propertyValue, api = "Update" };
                 }
@@ -2656,6 +2656,12 @@ namespace D365MetadataBridge.Services
                 case "allowrowversionchangetracking":
                     tbl.AllowRowVersionChangeTracking = ParseNoYes(value);
                     break;
+                case "createdby": tbl.CreatedBy = ParseNoYes(value); break;
+                case "createddatetime": tbl.CreatedDateTime = ParseNoYes(value); break;
+                case "createdtransactionid": tbl.CreatedTransactionId = ParseNoYes(value); break;
+                case "modifiedby": tbl.ModifiedBy = ParseNoYes(value); break;
+                case "modifieddatetime": tbl.ModifiedDateTime = ParseNoYes(value); break;
+                case "modifiedtransactionid": tbl.ModifiedTransactionId = ParseNoYes(value); break;
                 case "tabletype":
                     if (!Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.TableType>(value, true, out var tt))
                         throw new ArgumentException(

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -1504,7 +1504,7 @@ namespace D365MetadataBridge.Services
                         ?? throw new ArgumentException($"Table '{objectName}' not found");
                     var msi = GetModelSaveInfoForObject(_provider.Tables, objectName);
                     if (!SetAxTableProperty(obj, propertyPath, propertyValue))
-                        throw new ArgumentException($"Unknown AxTable property '{propertyPath}' — nothing was written. Supported: label, developerDocumentation, configurationKey, formRef, tableGroup, cacheLookup, clusteredIndex, primaryIndex, replacementKey, saveDataPerCompany, tableType, supportInheritance, instanceRelationType, extends, titleField1, titleField2.");
+                        throw new ArgumentException($"Unknown AxTable property '{propertyPath}' — nothing was written. Supported: label, developerDocumentation, configurationKey, formRef, tableGroup, cacheLookup, clusteredIndex, primaryIndex, replacementKey, saveDataPerCompany, allowRowVersionChangeTracking, tableType, supportInheritance, instanceRelationType, extends, titleField1, titleField2.");
                     ((IMetaTableProvider)_provider.Tables).Update(obj, msi);
                     return new { success = true, operation = "modify-property", objectType, objectName, propertyPath, propertyValue, api = "Update" };
                 }
@@ -1546,6 +1546,16 @@ namespace D365MetadataBridge.Services
                     if (!SetAxViewProperty(obj, propertyPath, propertyValue))
                         throw new ArgumentException($"Unknown AxView property '{propertyPath}' — nothing was written. Supported: label, developerDocumentation.");
                     ((IMetaViewProvider)_provider.Views).Update(obj, msi);
+                    return new { success = true, operation = "modify-property", objectType, objectName, propertyPath, propertyValue, api = "Update" };
+                }
+                case "data-entity":
+                {
+                    var obj = _provider.DataEntityViews.Read(objectName)
+                        ?? throw new ArgumentException($"Data entity '{objectName}' not found");
+                    var msi = GetModelSaveInfoForObject(_provider.DataEntityViews, objectName);
+                    if (!SetAxDataEntityViewProperty(obj, propertyPath, propertyValue))
+                        throw new ArgumentException($"Unknown AxDataEntityView property '{propertyPath}' — nothing was written. Supported: label, developerDocumentation, primaryKey, isPublic, publicEntityName, publicCollectionName, dataManagementEnabled, dataManagementStagingTable, entityCategory, allowRowVersionChangeTracking, allowRetention.");
+                    ((IMetaDataEntityViewProvider)_provider.DataEntityViews).Update(obj, msi);
                     return new { success = true, operation = "modify-property", objectType, objectName, propertyPath, propertyValue, api = "Update" };
                 }
                 case "menu-item-action":
@@ -2642,6 +2652,10 @@ namespace D365MetadataBridge.Services
                 case "savedatapercompany":
                     tbl.SaveDataPerCompany = ParseNoYes(value);
                     break;
+                // Dual-write's table-side change-tracking prerequisite.
+                case "allowrowversionchangetracking":
+                    tbl.AllowRowVersionChangeTracking = ParseNoYes(value);
+                    break;
                 case "tabletype":
                     if (!Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.TableType>(value, true, out var tt))
                         throw new ArgumentException(
@@ -2720,6 +2734,39 @@ namespace D365MetadataBridge.Services
                     break;
                 default:
                     Console.Error.WriteLine($"[WriteService] Unknown AxQuery property: {prop}");
+                    return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// AxDataEntityView property setter. AllowRowVersionChangeTracking is
+        /// dual-write's change-tracking switch and is also required on every
+        /// source table.
+        /// </summary>
+        private bool SetAxDataEntityViewProperty(AxDataEntityView e, string prop, string value)
+        {
+            switch (prop.ToLowerInvariant())
+            {
+                case "label": e.Label = value; break;
+                case "developerdocumentation": e.DeveloperDocumentation = value; break;
+                case "primarykey": e.PrimaryKey = value; break;
+                case "publicentityname": e.PublicEntityName = value; break;
+                case "publiccollectionname": e.PublicCollectionName = value; break;
+                case "datamanagementstagingtable": e.DataManagementStagingTable = value; break;
+                case "ispublic": e.IsPublic = ParseNoYes(value); break;
+                case "datamanagementenabled": e.DataManagementEnabled = ParseNoYes(value); break;
+                case "allowrowversionchangetracking": e.AllowRowVersionChangeTracking = ParseNoYes(value); break;
+                case "allowretention": e.AllowRetention = ParseNoYes(value); break;
+                case "entitycategory":
+                    if (!Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.EntityCategory>(value, true, out var ec))
+                        throw new ArgumentException(
+                            $"'{value}' is not a valid EntityCategory. Valid values: " +
+                            string.Join(", ", Enum.GetNames(typeof(Microsoft.Dynamics.AX.Metadata.Core.MetaModel.EntityCategory))) + ".");
+                    e.EntityCategory = ec;
+                    break;
+                default:
+                    Console.Error.WriteLine($"[WriteService] Unknown AxDataEntityView property: {prop}");
                     return false;
             }
             return true;

--- a/eval/knowledge-audit.snapshot.json
+++ b/eval/knowledge-audit.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "capturedAt": "2026-07-28T11:15:48.861Z",
-  "indexedAt": "2026-07-28T06:46:19.478Z",
+  "capturedAt": "2026-07-30T05:28:34.893Z",
+  "indexedAt": "2026-07-29T18:58:39.113Z",
   "ok": [
     "alerts-business-events|attribute|DataContract",
     "alerts-business-events|attribute|DataContractAttribute",
@@ -83,6 +83,7 @@
     "electronic-reporting|declaration|ERIFormatMappingRun",
     "electronic-reporting|declaration|ERModelDefinitionInputParametersAction",
     "electronic-reporting|new|ERModelDefinitionInputParametersAction",
+    "electronic-reporting|static-call|ERModelDefinitionInputParametersAction::addParameter",
     "electronic-reporting|static-call|ERObjectsFactory::createFormatMappingRunByFormatMappingId",
     "error-handling|static-call|CLRInterop::getLastException",
     "error-handling|static-call|Exception::CLRError",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -1209,7 +1209,7 @@ const BRIDGE_MODIFY_OPS = new Set([
  */
 const BRIDGE_MODIFY_TYPES = new Set([
   'class', 'table', 'enum', 'edt',
-  'form', 'query', 'view',
+  'form', 'query', 'view', 'data-entity',
   'class-extension', 'table-extension', 'form-extension', 'enum-extension',
   'menu-item-action', 'menu-item-display', 'menu-item-output',
   'menu',

--- a/src/metadata/modelDescriptor.ts
+++ b/src/metadata/modelDescriptor.ts
@@ -1,0 +1,153 @@
+/**
+ * Model descriptor reader — `<PackagesLocalDirectory>/<Package>/Descriptor/<Model>.xml`.
+ *
+ * `<ModuleReferences>` is the only statement of what a model may see: xppc
+ * resolves types against the referenced packages, not against everything
+ * installed, so an indexed type can still be invisible to the model being
+ * compiled. The visible set is the model's own package plus its DIRECT
+ * references — walking the closure would mark such a type visible again and
+ * hide the defect this exists to catch.
+ *
+ * Not a compiler: a table in a referenced package can still need a further
+ * reference because a third package contributes a table extension to it.
+ *
+ * build_d365fo_project reads the same element to order its build queue and
+ * calls straight into `parseModuleReferences`.
+ */
+
+import { readFile } from 'fs/promises';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import * as path from 'path';
+
+/**
+ * Extract every `<d2p1:string>` entry of a descriptor's `<ModuleReferences>`.
+ * The sibling `<ModelReferences>` is `i:nil` in every descriptor observed on a
+ * real box, so the flat scan cannot pick up entries from it.
+ */
+export function parseModuleReferences(descriptorXml: string): string[] {
+  return Array.from(descriptorXml.matchAll(/<d2p1:string>\s*([^<\s]+)\s*<\/d2p1:string>/g))
+    .map(m => m[1].trim())
+    .filter(Boolean);
+}
+
+/**
+ * Read a model's direct module references, or null when it has no readable
+ * descriptor — which callers must treat as unknown, never as "references nothing".
+ */
+export async function readModuleReferences(
+  packagesPath: string,
+  modelName: string,
+): Promise<string[] | null> {
+  try {
+    return parseModuleReferences(
+      await readFile(path.join(packagesPath, modelName, 'Descriptor', `${modelName}.xml`), 'utf-8'),
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** The PackagesLocalDirectory root contained in a package or workspace path. */
+export function packagesRootFromPath(candidate: string | undefined | null): string | null {
+  if (!candidate) return null;
+  const m = /^(.+[\\/]PackagesLocalDirectory)(?:[\\/]|$)/i.exec(candidate.replace(/\//g, '\\'));
+  return m ? m[1] : null;
+}
+
+export interface ModelVisibility {
+  /** Target model, for diagnostics. */
+  model: string;
+  /** PackagesLocalDirectory root the indexed file paths are relative to. */
+  packagesRoot: string;
+  /** Lower-cased package folder names the model may reference (incl. its own). */
+  visiblePackages: ReadonlySet<string>;
+  /**
+   * Package folder owning an indexed file, or null when the path is not under
+   * this packages root. Null means "cannot tell" and must silence the check.
+   */
+  packageOf(filePath: string): string | null;
+}
+
+/**
+ * Locate `<Model>.xml`. `<root>/<Model>/Descriptor/<Model>.xml` is the common
+ * layout and costs one stat; ISV models inside a differently-named package fall
+ * back to a single bounded sweep of the root's package folders.
+ */
+function findDescriptor(packagesRoot: string, modelName: string): { file: string; pkg: string } | null {
+  const direct = path.join(packagesRoot, modelName, 'Descriptor', `${modelName}.xml`);
+  if (existsSync(direct)) return { file: direct, pkg: modelName };
+  let entries: string[];
+  try {
+    entries = readdirSync(packagesRoot);
+  } catch {
+    return null;
+  }
+  for (const pkg of entries) {
+    const file = path.join(packagesRoot, pkg, 'Descriptor', `${modelName}.xml`);
+    if (existsSync(file)) return { file, pkg };
+  }
+  return null;
+}
+
+/** Cache key → resolved visibility (or null when it could not be resolved). */
+const visibilityCache = new Map<string, ModelVisibility | null>();
+
+/**
+ * Build (and memoise) the visibility oracle for `modelName`; null whenever the
+ * answer would be a guess. Callers must then skip the check — a missing
+ * descriptor turning into a wall of errors is worse than the gap it closes.
+ */
+export function getModelVisibility(
+  packagesRoot: string | null | undefined,
+  modelName: string | null | undefined,
+): ModelVisibility | null {
+  if (!packagesRoot || !modelName) return null;
+  const key = `${packagesRoot.toLowerCase()}|${modelName.toLowerCase()}`;
+  const cached = visibilityCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const built = buildModelVisibility(packagesRoot, modelName);
+  visibilityCache.set(key, built);
+  return built;
+}
+
+/** Uncached form — exported for tests, which need a fresh fixture each time. */
+export function buildModelVisibility(
+  packagesRoot: string | null | undefined,
+  modelName: string | null | undefined,
+): ModelVisibility | null {
+  if (!packagesRoot || !modelName) return null;
+  const found = findDescriptor(packagesRoot, modelName);
+  if (!found) return null;
+
+  let refs: string[];
+  try {
+    refs = parseModuleReferences(readFileSync(found.file, 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  const visiblePackages = new Set<string>([found.pkg.toLowerCase()]);
+  for (const ref of refs) visiblePackages.add(ref.toLowerCase());
+
+  const rootPrefix = packagesRoot.replace(/\//g, '\\').replace(/\\+$/, '').toLowerCase() + '\\';
+  return {
+    model: modelName,
+    packagesRoot,
+    visiblePackages,
+    packageOf(filePath: string): string | null {
+      if (!filePath) return null;
+      const norm = filePath.replace(/\//g, '\\');
+      // Case-insensitive: index and config disagree on the root's casing
+      // (`K:\AOSService\…` vs `K:\AosService\…`) for the same directory.
+      if (!norm.toLowerCase().startsWith(rootPrefix)) return null;
+      const segment = norm.slice(rootPrefix.length).split('\\')[0];
+      return segment || null;
+    },
+  };
+}
+
+/** Test seam — drops the memoised visibility oracles. */
+export function clearModelVisibilityCache(): void {
+  visibilityCache.clear();
+}

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -8,6 +8,7 @@ import { Worker } from 'node:worker_threads';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { XppSymbol } from './types.js';
+import { renderMethodSignature } from './xppDeclaration.js';
 import { isStandardModel } from '../utils/modelClassifier.js';
 import { c, log } from '../utils/terminalUi.js';
 
@@ -1706,13 +1707,12 @@ export class XppSymbolIndex {
         // Add method symbols with enhanced metadata
         if (classData.methods && Array.isArray(classData.methods)) {
           for (const method of classData.methods) {
-            const params = method.parameters?.map((p: any) => `${p.type} ${p.name}`).join(', ') || '';
             
             this.addSymbol({
               name: method.name,
               type: 'method',
               parentName: classData.name,
-              signature: `${method.returnType} ${method.name}(${params})`,
+              signature: renderMethodSignature(method),
               filePath: sourceFilePath,
               model,
               description: method.documentation,
@@ -1778,12 +1778,11 @@ export class XppSymbolIndex {
         // Add method symbols (parallel to indexClasses)
         if (tableData.methods && Array.isArray(tableData.methods)) {
           for (const method of tableData.methods) {
-            const params = method.parameters?.map((p: any) => `${p.type} ${p.name}`).join(', ') || '';
             this.addSymbol({
               name: method.name,
               type: 'method',
               parentName: tableData.name,
-              signature: `${method.returnType} ${method.name}(${params})`,
+              signature: renderMethodSignature(method),
               filePath: sourceFilePath,
               model,
               description: method.documentation,
@@ -2100,12 +2099,11 @@ export class XppSymbolIndex {
         // Add method symbols (views and data-entities can have display/computed methods)
         if (viewData.methods && Array.isArray(viewData.methods)) {
           for (const method of viewData.methods) {
-            const params = method.parameters?.map((p: any) => `${p.type} ${p.name}`).join(', ') || '';
             this.addSymbol({
               name: method.name,
               type: 'method',
               parentName: viewName,
-              signature: `${method.returnType} ${method.name}(${params})`,
+              signature: renderMethodSignature(method),
               filePath: sourceFilePath,
               model,
               description: method.documentation,

--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -39,6 +39,12 @@ export interface XppMethodInfo {
   visibility: 'public' | 'private' | 'protected';
   returnType: string;
   parameters: XppParameterInfo[];
+  /**
+   * Declaration unparseable, so `parameters` is empty for lack of evidence
+   * rather than because the method takes none. Arity checks must skip, not
+   * assume zero.
+   */
+  parametersUnknown?: boolean;
   isStatic: boolean;
   source: string;
   documentation?: string;
@@ -54,6 +60,8 @@ export interface XppMethodInfo {
 export interface XppParameterInfo {
   name: string;
   type: string;
+  /** Default as declared; a dropped default makes an optional parameter look required. */
+  defaultValue?: string;
 }
 
 export interface XppTableInfo {

--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -336,6 +336,7 @@ export class XppMetadataParser {
         visibility: this.parseVisibility(method.Visibility),
         returnType: decl?.returnType || method.ReturnType || 'void',
         parameters: this.toParameterInfo(decl),
+        parametersUnknown: decl === null,
         isStatic: decl?.modifiers.includes('static') ?? false,
         source: source,
         documentation: method.DeveloperDocumentation || undefined,
@@ -536,9 +537,17 @@ export class XppMetadataParser {
     return Array.isArray(value) ? value : [value];
   }
 
-  /** Declaration parameters narrowed to the shape XppMethodInfo carries. */
+  /**
+   * Declaration parameters narrowed to the shape XppMethodInfo carries.
+   * A null decl yields `[]`; the `parametersUnknown` flag set alongside is what
+   * tells that apart from a genuinely empty list, so don't read this alone.
+   */
   private toParameterInfo(decl: XppDeclaration | null): XppParameterInfo[] {
-    return decl?.parameters.map(p => ({ type: p.type, name: p.name })) ?? [];
+    return decl?.parameters.map(p => (
+      p.defaultValue
+        ? { type: p.type, name: p.name, defaultValue: p.defaultValue }
+        : { type: p.type, name: p.name }
+    )) ?? [];
   }
 
   /**
@@ -676,6 +685,7 @@ export class XppMetadataParser {
         visibility: 'public', // Forms typically have public methods
         returnType: decl?.returnType || 'void',
         parameters: this.toParameterInfo(decl),
+        parametersUnknown: decl === null,
         isStatic: decl?.modifiers.includes('static') ?? false,
         source,
         sourceSnippet: source.split('\n').slice(0, 10).join('\n'),

--- a/src/metadata/xppDeclaration.ts
+++ b/src/metadata/xppDeclaration.ts
@@ -28,6 +28,34 @@ export interface XppDeclaration {
   parameters: XppDeclarationParameter[];
 }
 
+/** Rendered for a parameter list that could not be read; not legal X++, so it can't collide with a real one. */
+export const UNKNOWN_PARAMETER_LIST = '...';
+
+/** The subset of a method that `renderMethodSignature` needs. */
+export interface RenderableMethod {
+  name: string;
+  returnType?: string;
+  parameters?: ReadonlyArray<{ type: string; name: string; defaultValue?: string }> | null;
+  /** See XppMethodInfo.parametersUnknown. */
+  parametersUnknown?: boolean;
+}
+
+/**
+ * Render `ReturnType name(Type _a, Type _b = default)` for the symbol index.
+ *
+ * Defaults are kept and an unreadable list renders as `(...)`, never `()` —
+ * resolve_references reads this string back and gates writes on it, so `()` is
+ * a positive claim of zero parameters that consumers act on.
+ */
+export function renderMethodSignature(method: RenderableMethod): string {
+  const params = method.parametersUnknown
+    ? UNKNOWN_PARAMETER_LIST
+    : (method.parameters ?? [])
+      .map(p => `${p.type} ${p.name}${p.defaultValue ? ` = ${p.defaultValue}` : ''}`)
+      .join(', ');
+  return `${method.returnType ?? 'void'} ${method.name}(${params})`;
+}
+
 export interface XppClassHeader {
   kind: 'class' | 'interface';
   name: string;
@@ -144,6 +172,19 @@ function isNameToken(t: string): boolean {
 }
 
 /**
+ * Slice `raw` from `from`, trimmed to the extent that still carries content in
+ * the blanked twin — comments became whitespace there and so drop out, while
+ * string literals survive (their quotes are not blanked).
+ */
+function sliceByBlankedExtent(raw: string, blanked: string, from: number): string {
+  let start = from;
+  while (start < blanked.length && /\s/.test(blanked[start])) start++;
+  let end = blanked.length;
+  while (end > start && /\s/.test(blanked[end - 1])) end--;
+  return raw.slice(start, end).replace(/\s+/g, ' ');
+}
+
+/**
  * Parse one "Type _name [= default]" parameter; null when it doesn't look like
  * a declared parameter (which is how a call's arguments are told apart from a
  * declaration's parameter list).
@@ -158,8 +199,11 @@ function parseParameter(raw: string, blanked: string): XppDeclarationParameter |
     else if (c === ')' || c === ']') depth--;
     else if (c === '=' && depth === 0) { eq = i; break; }
   }
-  const left = (eq >= 0 ? raw.slice(0, eq) : raw).trim().replace(/\s+/g, ' ');
-  const defaultValue = eq >= 0 ? raw.slice(eq + 1).trim().replace(/\s+/g, ' ') : undefined;
+  // Type and name come off the blanked twin: the standard models interleave
+  // pragma comments inside wrapped parameter lists, and read raw those look
+  // like a leading type token, failing the parameter and discarding the lot.
+  const left = (eq >= 0 ? blanked.slice(0, eq) : blanked).trim().replace(/\s+/g, ' ');
+  const defaultValue = eq >= 0 ? sliceByBlankedExtent(raw, blanked, eq + 1) : undefined;
 
   const tokens = left.split(' ').filter(Boolean);
   if (tokens.length < 2) return null;

--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -18,7 +18,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
         action: {
           type: 'string',
           enum: ['create', 'modify', 'generate'],
-          description: 'create = new object file (write); modify = edit existing object (write); generate = XML text only (no write).',
+          description: 'See the three bullets above — create and modify write, generate does not.',
         },
         objectType: {
           type: 'string',
@@ -58,7 +58,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
         },
         sourceCode: {
           type: 'string',
-          description: 'X++ source for the object. FOR CLASSES the content is auto-split: <Declaration> = the class line + ALL member variables inside the outer { }; <Methods> = each method AFTER the closing }. CRITICAL: member variables MUST sit inside the class { }, methods after — never reversed.'
+          description: 'X++ source for the object. FOR CLASSES the content is auto-split: <Declaration> = the class line + ALL member variables inside the outer { }; <Methods> = each method AFTER the closing }.'
         },
         properties: {
           type: 'object',
@@ -76,7 +76,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
             '• security-duty: label, privileges[]\n' +
             '• security-role: label, duties[], privileges[]\n' +
             '• menu-item-*: label, object, objectType\n' +
-            '• data-entity: primaryTable, fields[{name,dataField?}], dataManagementEnabled? (default false; true needs a staging table)\n' +
+            '• data-entity: primaryTable, fields[{name,dataField?}], primaryKey?, primaryKeyFields?[], isPublic?, entityCategory?, dynamicFields?, allowRowVersionChangeTracking? (dual-write: set on the source TABLES too), dataManagementEnabled? (needs staging table)\n' +
             '• map: label?, developerDocumentation?, fields[{name,type?,edt?,enumType?,stringSize?}], mappingTable?, mappings?[{mapField,mapFieldTo}] (one connection/field by default)\n' +
             '• query: title?, dataSource (root table; table also works), dataSourceName?, fields?[{name,field?}]\n' +
             '• view: query (existing AxQuery), fields[{name,dataField?}] — dataSource defaults to query\n' +

--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -18,7 +18,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
         action: {
           type: 'string',
           enum: ['create', 'modify', 'generate'],
-          description: 'See the three bullets above — create and modify write, generate does not.',
+          description: 'One of the three modes described above.',
         },
         objectType: {
           type: 'string',
@@ -42,7 +42,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
         },
         objectName: {
           type: 'string',
-          description: 'Base name WITHOUT model prefix — the tool prepends EXTENSION_PREFIX (or modelName) and detects an existing prefix. Extension classes: pass "{Base}_Extension" with NO prefix infix (produces e.g. "SalesFormLetterMY_Extension"). NEVER hand-build the prefix.'
+          description: 'Base name WITHOUT model prefix — the tool prepends EXTENSION_PREFIX (or modelName) and detects an existing prefix. Extension classes: pass "{Base}_Extension" with NO prefix infix. NEVER hand-build the prefix.'
         },
         modelName: {
           type: 'string',
@@ -65,7 +65,7 @@ Model from .mcp.json; prefix auto-applied from EXTENSION_PREFIX. Classes: member
           description:
             'Additional properties by objectType:\n' +
             '• class: extends, implements, isFinal, isAbstract\n' +
-            '• table: label, tableGroup, tableType, titleField1/2, fields[{name,type?|edt?|fieldType?,enumType?,label?,mandatory?}] — enum fields need enumType (+ optionally fieldType:"AxTableFieldEnum")\n' +
+            '• table: label, tableGroup, tableType, titleField1/2, cacheLookup?, primaryIndex?, allowRowVersionChangeTracking? (dual-write), created/modifiedBy/DateTime?, fields[{name,type?|edt?|fieldType?,enumType?,label?,mandatory?}] — enum fields need enumType (+ optionally fieldType:"AxTableFieldEnum")\n' +
             '• enum: label, useEnumValue, configurationKey, isExtensible, enumValues[{name,value?,label?,helpText?}]\n' +
             '• enum-extension: enumValues[{name,label?,value?,countryRegionCodes?}]\n' +
             '• table-extension: fields[{name,edt?,enumType?,label?,mandatory?,fieldType?}] — enum fields need fieldType:"AxTableFieldEnum" + enumType\n' +

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -12,6 +12,7 @@ import { forceReleaseLock } from '../utils/operationLocks.js';
 import { lookupErrorFix } from './d365foErrorHelp.js';
 import { generateRuntimeMetadata } from './generateMetadata.js';
 import { compileModelLabels, type CompileLabelsResult } from './compileLabels.js';
+import { readModuleReferences } from '../metadata/modelDescriptor.js';
 
 const execFileAsync = util.promisify(execFile);
 
@@ -405,21 +406,14 @@ async function resolveBuildQueue(
     if (visited.has(modelName.toLowerCase())) return;
     visited.add(modelName.toLowerCase());
 
-    // Read descriptor
-    const descriptorPath = path.join(customPackagesPath, modelName, 'Descriptor', `${modelName}.xml`);
-    let content: string;
-    try {
-      content = await readFile(descriptorPath, 'utf-8');
-    } catch {
+    // Shared reader: resolve_references reads the same element to decide type
+    // visibility, and one parser keeps the two from drifting apart.
+    const refs = await readModuleReferences(customPackagesPath, modelName);
+    if (refs === null) {
       // No descriptor — still include this model but can't follow its deps
       order.push(modelName);
       return;
     }
-
-    // Extract all <d2p1:string> entries inside <ModuleReferences>
-    const refs = Array.from(content.matchAll(/<d2p1:string>\s*([^<\s]+)\s*<\/d2p1:string>/g))
-      .map(m => m[1].trim())
-      .filter(Boolean);
 
     // Visit custom/ISV dependencies first (skip Microsoft standard models)
     for (const ref of refs) {

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -24,7 +24,7 @@ import { gateOnReferenceErrors } from './resolveReferences.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
 import { renderAxTableProperties } from '../utils/axTablePropertyOrder.js';
 import { buildAxSecurityPrivilegeXml } from './securityPrivilegeXml.js';
-import { buildAxDataEntityXml } from './dataEntityXml.js';
+import { buildAxDataEntityXml, isYes } from './dataEntityXml.js';
 import { resolveEdtBaseType, resolveEdtEnumType, heuristicEdtBaseType, isEnumName, bridgeEdtBaseType } from './generateSmartTable.js';
 import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
 import { buildAxMapXml } from './mapXml.js';
@@ -750,6 +750,10 @@ ${methodsXml}\t</SourceCode>
       TableGroup: properties?.tableGroup || 'Main',
       TitleField1: properties?.titleField1,
       TitleField2: properties?.titleField2,
+      // Dual-write's table-side prerequisite; without it the entity syncs once
+      // and then stops seeing changes.
+      AllowRowVersionChangeTracking:
+        isYes(properties?.allowRowVersionChangeTracking) ? 'Yes' : undefined,
       CacheLookup: properties?.cacheLookup,
       ClusteredIndex: properties?.clusteredIndex,
       PrimaryIndex: primaryIndex,

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -755,6 +755,13 @@ ${methodsXml}\t</SourceCode>
       AllowRowVersionChangeTracking:
         isYes(properties?.allowRowVersionChangeTracking) ? 'Yes' : undefined,
       CacheLookup: properties?.cacheLookup,
+      // Audit system fields — NoYes, ranked but previously unreachable.
+      CreatedBy: isYes(properties?.createdBy) ? 'Yes' : undefined,
+      CreatedDateTime: isYes(properties?.createdDateTime) ? 'Yes' : undefined,
+      CreatedTransactionId: isYes(properties?.createdTransactionId) ? 'Yes' : undefined,
+      ModifiedBy: isYes(properties?.modifiedBy) ? 'Yes' : undefined,
+      ModifiedDateTime: isYes(properties?.modifiedDateTime) ? 'Yes' : undefined,
+      ModifiedTransactionId: isYes(properties?.modifiedTransactionId) ? 'Yes' : undefined,
       ClusteredIndex: properties?.clusteredIndex,
       PrimaryIndex: primaryIndex,
       // ReplacementKey mirrors PrimaryIndex unless the caller says otherwise.

--- a/src/tools/dataEntityXml.ts
+++ b/src/tools/dataEntityXml.ts
@@ -96,7 +96,7 @@ const STANDARD_FIELD_GROUPS: Array<{ name: string; autoPopulate?: boolean }> = [
 ];
 
 /** NoYes-ish inputs: true / "Yes" / "true" / 1 all mean Yes. */
-function isYes(value: unknown): boolean {
+export function isYes(value: unknown): boolean {
   if (value === true) return true;
   if (typeof value === 'number') return value === 1;
   if (typeof value === 'string') {

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -323,11 +323,17 @@ ${methodsXml}\t</SourceCode>
     const titleField2Xml = titleField2
       ? `\t<TitleField2>${titleField2}</TitleField2>\n`
       : '';
-    // Dual-write's table-side prerequisite. Belongs after the Title block and
-    // before the collections — see src/utils/axTablePropertyOrder.ts.
-    const changeTrackingXml = isYes(properties?.allowRowVersionChangeTracking)
-      ? '\t<AllowRowVersionChangeTracking>Yes</AllowRowVersionChangeTracking>\n'
-      : '';
+    // Canonical order: Title block → these → collections. See axTablePropertyOrder.
+    const noYes = (key: string, tag: string) =>
+      isYes(properties?.[key]) ? `\t<${tag}>Yes</${tag}>\n` : '';
+    const extendedXml =
+      noYes('allowRowVersionChangeTracking', 'AllowRowVersionChangeTracking') +
+      noYes('createdBy', 'CreatedBy') +
+      noYes('createdDateTime', 'CreatedDateTime') +
+      noYes('createdTransactionId', 'CreatedTransactionId') +
+      noYes('modifiedBy', 'ModifiedBy') +
+      noYes('modifiedDateTime', 'ModifiedDateTime') +
+      noYes('modifiedTransactionId', 'ModifiedTransactionId');
 
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
@@ -342,7 +348,7 @@ public class ${tableName} extends common
 \t</SourceCode>
 \t<Label>${label}</Label>
 \t<TableGroup>${tableGroup}</TableGroup>
-${titleField1Xml}${titleField2Xml}${changeTrackingXml}\t<DeleteActions />
+${titleField1Xml}${titleField2Xml}${extendedXml}\t<DeleteActions />
 \t<FieldGroups>
 \t\t<AxTableFieldGroup>
 \t\t\t<Name>AutoReport</Name>

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -12,7 +12,7 @@ import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils
 import { reindentXppSource } from '../utils/xppFormat.js';
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
 import { buildAxSecurityPrivilegeXml } from './securityPrivilegeXml.js';
-import { buildAxDataEntityXml } from './dataEntityXml.js';
+import { buildAxDataEntityXml, isYes } from './dataEntityXml.js';
 import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
 import { buildAxEdtExtensionXml } from './edtExtensionXml.js';
 import { buildAxDataEntityViewExtensionXml } from './dataEntityViewExtensionXml.js';
@@ -323,6 +323,11 @@ ${methodsXml}\t</SourceCode>
     const titleField2Xml = titleField2
       ? `\t<TitleField2>${titleField2}</TitleField2>\n`
       : '';
+    // Dual-write's table-side prerequisite. Belongs after the Title block and
+    // before the collections — see src/utils/axTablePropertyOrder.ts.
+    const changeTrackingXml = isYes(properties?.allowRowVersionChangeTracking)
+      ? '\t<AllowRowVersionChangeTracking>Yes</AllowRowVersionChangeTracking>\n'
+      : '';
 
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
@@ -337,7 +342,7 @@ public class ${tableName} extends common
 \t</SourceCode>
 \t<Label>${label}</Label>
 \t<TableGroup>${tableGroup}</TableGroup>
-${titleField1Xml}${titleField2Xml}\t<DeleteActions />
+${titleField1Xml}${titleField2Xml}${changeTrackingXml}\t<DeleteActions />
 \t<FieldGroups>
 \t\t<AxTableFieldGroup>
 \t\t\t<Name>AutoReport</Name>

--- a/src/tools/resolveReferences.ts
+++ b/src/tools/resolveReferences.ts
@@ -27,7 +27,18 @@
 
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { distinctSymbolTypesNocase, lookupSymbolNocase } from '../utils/symbolLookup.js';
+import { canonicalSymbolName, distinctSymbolTypesNocase, lookupSymbolNocase } from '../utils/symbolLookup.js';
+import {
+  UNKNOWN_PARAMETER_LIST,
+  parseXppDeclaration,
+  renderMethodSignature,
+} from '../metadata/xppDeclaration.js';
+import {
+  getModelVisibility,
+  packagesRootFromPath,
+  type ModelVisibility,
+} from '../metadata/modelDescriptor.js';
+import { getConfigManager } from '../utils/configManager.js';
 
 export const resolveReferencesArgsSchema = z.object({
   code: z.string().describe(
@@ -49,7 +60,8 @@ export interface ReferenceViolation {
     | 'unknown-field'
     | 'unknown-label'
     | 'unknown-intrinsic-target'
-    | 'arity-mismatch';
+    | 'arity-mismatch'
+    | 'not-visible-from-model';
   severity: 'error' | 'warning';
   line: number;
   identifier: string;
@@ -75,6 +87,11 @@ export interface ResolverDeps {
     labelFileId?: string,
   ): Array<{ labelId: string; labelFileId: string }>;
   getLabelFileIds(): Array<{ labelFileId: string }>;
+  /**
+   * Optional Descriptor-backed answer to "may the target model see this type?".
+   * Presence in the index is not visibility. Absent, the check is not run.
+   */
+  visibility?: ModelVisibility;
 }
 
 const XPP_KEYWORDS = new Set([
@@ -288,7 +305,11 @@ function menuItemExists(deps: ResolverDeps, name: string): boolean {
   }
 }
 
-interface MethodRow { signature: string | null }
+interface MethodRow {
+  signature: string | null;
+  /** X++ body as indexed — arityOf() re-derives the parameter list from it. */
+  source: string | null;
+}
 
 /** Look up a method on an object, walking the extends_class chain (classes). */
 function findMethod(
@@ -305,7 +326,7 @@ function findMethod(
     const ownerHit = lookupSymbolNocase(deps.db, ownerName);
     const owner = ownerHit?.name ?? ownerName;
     const row = deps.db.prepare(
-      `SELECT signature FROM symbols
+      `SELECT signature, source FROM symbols
        WHERE parent_name = ? AND type = 'method' AND name = ? COLLATE NOCASE
        LIMIT 1`,
     ).get(owner, methodName) as MethodRow | undefined;
@@ -334,7 +355,7 @@ function findMethod(
             (typeof m === 'string' ? m : (m as { name?: string })?.name ?? '')
               .toLowerCase() === target,
           )) {
-            return { signature: null };
+            return { signature: null, source: null };
           }
         } catch { /* malformed JSON — skip */ }
       }
@@ -346,6 +367,58 @@ function findMethod(
     }
   } catch { /* DB error — treat as not found */ }
   return undefined;
+}
+
+/**
+ * Report a top-level type that IS in the index but lives in a package the target
+ * model does not reference. Silent whenever the answer would be a guess; it only
+ * fires when EVERY indexed occurrence is provably out of reach.
+ *
+ * `lookupSymbolsNocase` with a multi-row limit is NOT usable here: a type name
+ * never yields that many top-level rows, so its short-circuit never fires and
+ * the FTS5 fallback runs to exhaustion — measured 45 ms → 5003 ms for one class
+ * body. Canonicalize at limit 1, then probe BINARY `name = ?` on idx_name_type.
+ * A differently cased duplicate elsewhere is missed, which only makes the check
+ * quieter — the direction it must fail in.
+ */
+function checkModelVisibility(
+  deps: ResolverDeps,
+  typeName: string,
+  line: number,
+): ReferenceViolation | undefined {
+  const vis = deps.visibility;
+  if (!vis) return undefined;
+  let hits: Array<{ file_path: string | null }>;
+  try {
+    const canonical = canonicalSymbolName(deps.db, typeName);
+    if (!canonical) return undefined;
+    hits = deps.db
+      .prepare('SELECT file_path FROM symbols WHERE name = ? AND parent_name IS NULL LIMIT 16')
+      .all(canonical) as Array<{ file_path: string | null }>;
+  } catch {
+    return undefined;
+  }
+  if (hits.length === 0) return undefined;
+
+  const packages = new Set<string>();
+  for (const hit of hits) {
+    const pkg = hit.file_path ? vis.packageOf(hit.file_path) : null;
+    if (!pkg) return undefined;                                  // cannot tell
+    if (vis.visiblePackages.has(pkg.toLowerCase())) return undefined; // reachable
+    packages.add(pkg);
+  }
+
+  return {
+    kind: 'not-visible-from-model',
+    severity: 'error',
+    line,
+    identifier: typeName,
+    detail:
+      `"${typeName}" is indexed, but only in package ${[...packages].join(' / ')}, which model ` +
+      `${vis.model} does not reference. xppc will reject it ("does not denote a class, a table, ` +
+      `or an extended data type"). Add the package to ${vis.model}'s Descriptor ModuleReferences, ` +
+      `or use a type from a referenced package.`,
+  };
 }
 
 /** Check a field on a table: indexed fields, system fields, extension fields. */
@@ -391,16 +464,56 @@ function fieldExists(deps: ResolverDeps, tableName: string, fieldName: string): 
 
 interface Arity { min: number; max: number }
 
-/** Parse "ReturnType name(Type a, Type b = x)" → {min, max}. */
+/**
+ * Parse "ReturnType name(Type a, Type b = x)" → {min, max}; undefined when the
+ * signature licenses no arity claim. `(...)` is renderMethodSignature's marker
+ * for a declaration it could not read and must not be read as zero parameters.
+ */
 function parseSignatureArity(signature: string): Arity | undefined {
   const open = signature.indexOf('(');
   const close = signature.lastIndexOf(')');
   if (open === -1 || close === -1 || close < open) return undefined;
   const inner = signature.slice(open + 1, close).trim();
+  if (inner === UNKNOWN_PARAMETER_LIST) return undefined;
   if (inner === '') return { min: 0, max: 0 };
   const params = splitTopLevel(inner);
   const optional = params.filter(p => p.includes('=')).length;
   return { min: params.length - optional, max: params.length };
+}
+
+/**
+ * Arity to hold a call against: the method's own declaration first, the rendered
+ * `signature` only as a fallback.
+ *
+ * The rendering that produced the rows already in the index dropped parameter
+ * defaults, so `CustTable::find` is stored as `find(CustAccount, boolean)` and
+ * the legal `find(_account)` reads as a mismatch. Fixing the renderer fixes
+ * future rows; parsing the stored declaration fixes today's, with no reindex.
+ *
+ * Returns the text to quote alongside, so the diagnostic shows whichever list
+ * the verdict came from.
+ */
+function arityOf(method: MethodRow, methodName: string): { arity: Arity; shown: string } | undefined {
+  if (method.source) {
+    const decl = parseXppDeclaration(method.source, methodName);
+    if (decl) {
+      const optional = decl.parameters.filter(p => p.defaultValue !== undefined).length;
+      return {
+        arity: { min: decl.parameters.length - optional, max: decl.parameters.length },
+        shown: renderMethodSignature({
+          name: decl.name,
+          returnType: decl.returnType,
+          parameters: decl.parameters,
+        }),
+      };
+    }
+    // An unreadable stored declaration is exactly the case that rendered as
+    // `()`, so falling through to the signature would trust that lie.
+    return undefined;
+  }
+  if (!method.signature) return undefined;
+  const arity = parseSignatureArity(method.signature);
+  return arity ? { arity, shown: method.signature.trim() } : undefined;
 }
 
 /** Split on top-level commas (ignores commas inside (), [], <>). */
@@ -510,6 +623,23 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
       || KERNEL_TYPES.has(lower)
       || locals.declaredNames.has(lower)
       || lookupTypes(name).length > 0;
+  };
+
+  // Memoised per call and reported once per type — a name commonly appears as
+  // both a declared buffer and a `Type::member` receiver. True when invisible,
+  // so callers can skip the checks that assume the type is usable.
+  const visibilityVerdicts = new Map<string, ReferenceViolation | null>();
+  const reportIfInvisible = (name: string, line: number): boolean => {
+    if (!deps.visibility) return false;
+    const lower = name.toLowerCase();
+    if (XPP_BUILTIN_TYPES.has(lower) || KERNEL_TYPES.has(lower)) return false;
+    let verdict = visibilityVerdicts.get(lower);
+    if (verdict === undefined) {
+      verdict = checkModelVisibility(deps, name, line) ?? null;
+      visibilityVerdicts.set(lower, verdict);
+      if (verdict) violations.push(verdict);
+    }
+    return verdict !== null;
   };
 
   // 1. Label references (from original string literals)
@@ -633,6 +763,8 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
       });
       continue;
     }
+    // Indexed is not the same as reachable from the model being compiled.
+    if (reportIfInvisible(typeName, line)) continue;
     if (types.includes('enum')) {
       // Enum values are not indexed as symbols — the enum itself is proven.
       verifiedCount++;
@@ -652,14 +784,15 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
     }
     verifiedCount++;
 
-    // Arity check when the call site and the signature are both parseable
-    if (method.signature) {
-      const arity = parseSignatureArity(method.signature);
+    // Arity check when the call site and the declaration are both parseable
+    {
+      const resolved = arityOf(method, member);
       const callOpen = cleaned.indexOf('(', (m.index ?? 0) + m[0].length);
       const between = callOpen === -1
         ? ''
         : cleaned.slice((m.index ?? 0) + m[0].length, callOpen);
-      if (arity && callOpen !== -1 && between.trim() === '') {
+      if (resolved && callOpen !== -1 && between.trim() === '') {
+        const { arity, shown } = resolved;
         const argsText = extractCallArgs(cleaned, callOpen);
         if (argsText !== undefined) {
           const n = countCallArgs(argsText);
@@ -669,9 +802,9 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
               severity: 'error',
               line,
               identifier: `${typeName}::${member}`,
-              detail: `Call passes ${n} argument(s), but the indexed signature expects ${
+              detail: `Call passes ${n} argument(s), but the declaration expects ${
                 arity.min === arity.max ? arity.min : `${arity.min}–${arity.max}`
-              }: ${method.signature.trim()}`,
+              }: ${shown}`,
             });
           }
         }
@@ -686,7 +819,7 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
     if (reportedTypes.has(lower)) continue;
     reportedTypes.add(lower);
     if (isKnownType(typeName)) {
-      verifiedCount++;
+      if (!reportIfInvisible(typeName, 0)) verifiedCount++;
     } else {
       violations.push({
         kind: 'unknown-type',
@@ -750,6 +883,25 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
   return { violations, verifiedCount };
 }
 
+/**
+ * Descriptor visibility oracle for the configured target model, or undefined.
+ * Resolution stays limited to values already in the loaded configuration: this
+ * runs on every resolve_references call, and ConfigManager's drive-probing
+ * discovery would be exactly the blocking scan that gets the server killed.
+ */
+export function resolverModelVisibility(): ModelVisibility | undefined {
+  try {
+    const ctx = getConfigManager().getContext();
+    const model = (ctx?.modelName ?? process.env.D365FO_MODEL_NAME ?? '').trim();
+    if (!model) return undefined;
+    const root = packagesRootFromPath(ctx?.packagePath)
+      ?? packagesRootFromPath(ctx?.workspacePath);
+    return getModelVisibility(root, model) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** True when the label file id is present in the labels index. */
 function labelFileExists(deps: ResolverDeps, fileId: string): boolean {
   try {
@@ -782,6 +934,7 @@ export function gateOnReferenceErrors(
       db: symbolIndex.getReadDb(),
       getLabelById: symbolIndex.getLabelById.bind(symbolIndex),
       getLabelFileIds: symbolIndex.getLabelFileIds.bind(symbolIndex),
+      visibility: resolverModelVisibility(),
     });
   } catch {
     return null; // never block writes on resolver failure
@@ -824,6 +977,7 @@ export async function resolveReferencesTool(
       db: context.symbolIndex.getReadDb(),
       getLabelById: context.symbolIndex.getLabelById.bind(context.symbolIndex),
       getLabelFileIds: context.symbolIndex.getLabelFileIds.bind(context.symbolIndex),
+      visibility: resolverModelVisibility(),
     });
   } catch (error) {
     return {
@@ -845,7 +999,10 @@ export async function resolveReferencesTool(
         type: 'text',
         text:
           `✅ resolve_references: all ${result.verifiedCount} reference(s) verified against the index${suffix}.\n` +
-          `No hallucinated symbols detected. Safe to proceed with the write operation.`,
+          `No hallucinated symbols detected. This is a name-existence check, not a compile: ` +
+          `arity/type compatibility, table extensions contributed by unreferenced packages, ` +
+          `and anything the index could not read are outside its reach. ` +
+          `build_d365fo_project remains the only proof it compiles.`,
       }],
     };
   }
@@ -865,7 +1022,11 @@ export async function resolveReferencesTool(
     lines.push('');
   }
   if (errors.length > 0) {
-    lines.push('**Fix all errors before writing** — these identifiers do not exist in the indexed codebase.');
+    lines.push(
+      '**Fix all errors before writing** — these identifiers could not be resolved against the ' +
+      'indexed codebase (`not-visible-from-model` means the name exists but its package is not ' +
+      'referenced by the target model).',
+    );
   } else {
     lines.push('Warnings are informational (kernel classes and new labels are not indexable). Review, then proceed.');
   }

--- a/src/tools/resolveReferences.ts
+++ b/src/tools/resolveReferences.ts
@@ -749,7 +749,9 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
     const line = lineOf(cleaned, m.index ?? 0);
     const lower = typeName.toLowerCase();
 
-    if (locals.declaredNames.has(lower)) continue;
+    // No declaredNames guard, unlike the instance path: `::` only ever applies
+    // to a type, and `CustTable custTable;` differs only in the first letter's
+    // case — so the guard disabled this check for the commonest code there is.
     if (KERNEL_TYPES.has(lower)) { verifiedCount++; continue; } // no metadata for kernel statics
 
     const types = lookupTypes(typeName);

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -4,6 +4,7 @@ import { XppMetadataParser } from '../metadata/xmlParser.js';
 import { parseLabelFile } from '../metadata/labelParser.js';
 import type { XppServerContext } from '../types/context.js';
 import type { XppSymbol } from '../metadata/types.js';
+import { renderMethodSignature } from '../metadata/xppDeclaration.js';
 import { bridgeRefreshProvider } from '../bridge/index.js';
 
 // Tool registration (name, description, inputSchema) lives inline in
@@ -317,12 +318,11 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
           });
           insertedCount++;
           for (const method of classData.methods ?? []) {
-            const params = method.parameters?.map((p: any) => `${p.type} ${p.name}`).join(', ') ?? '';
             symbolIndex.addSymbol({
               name: method.name,
               type: 'method',
               parentName: classData.name,
-              signature: `${method.returnType} ${method.name}(${params})`,
+              signature: renderMethodSignature(method),
               filePath,
               model,
               source: method.source,
@@ -365,12 +365,11 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
           // them, and the delete above just removed them; skipping them here
           // would silently drop a table's methods on every incremental reindex.
           for (const method of tableData.methods ?? []) {
-            const params = method.parameters?.map((p: any) => `${p.type} ${p.name}`).join(', ') ?? '';
             symbolIndex.addSymbol({
               name: method.name,
               type: 'method',
               parentName: tableData.name,
-              signature: `${method.returnType} ${method.name}(${params})`,
+              signature: renderMethodSignature(method),
               filePath,
               model,
               source: method.source,

--- a/src/tools/validateCode.ts
+++ b/src/tools/validateCode.ts
@@ -192,7 +192,8 @@ export async function validateCodeTool(request: CallToolRequest, context: XppSer
           content: [{
             type: 'text' as const,
             text: `✅ resolve_references: all ${verified} reference(s) verified against the index${contextName ? ` in ${contextName}` : ''}.\n` +
-              `No hallucinated symbols detected. Safe to proceed with the write operation.`,
+              `No hallucinated symbols detected. This is a name-existence check, not a compile — ` +
+              `build_d365fo_project remains the only proof it compiles.`,
           }],
         };
       }

--- a/src/tools/xppKnowledge.ts
+++ b/src/tools/xppKnowledge.ts
@@ -1493,16 +1493,20 @@ MySalesConfirmedBusinessEvent::newFromContract(contract).send();`,
     summary:
       'Electronic Reporting (ER) is the D365FO framework for configurable business document generation ' +
       '(invoices, SEPA, VAT files). From X++ you can: (1) run an ER format programmatically, ' +
-      '(2) extend an ER model mapping via CoC, (3) pass data from X++ to ER via a custom ER data source.',
+      '(2) expose X++ data to a format by binding a plain class as a model-mapping data source. ' +
+      'The model, mapping and format are configured in the UI and are NOT AOT elements.',
     rules: [
       'Run ER format from X++: use ERObjectsFactory to get an ERIFormatMappingRun (note the ERI… prefix — there is no IERFormatMappingRun), then call run()',
-      'Pass parameters to ER: build an ERModelDefinitionInputParametersAction (addParameter/applyTo) and hand it to withParameter()',
+      'ERObjectsFactory::createFormatMappingRunByFormatMappingId(ERFormatMappingID, str _fileName, boolean _showPromptDialog, boolean _showInfologMessage, boolean _forceRunDraft) — 5 arguments, all required',
+      'Pass parameters: ERModelDefinitionInputParametersAction::addParameter(str, anytype) then applyTo(_parameters), where _parameters comes from formatRun.getDatasourceDefinitionParameters(); run unattended via runUnattended(_parameters)',
+      'Many ERI… names (ERIDataSource, ERIModelDefinitionParameters, ERIModelDefinitionParamsAction) are .NET types from Microsoft.Dynamics365.LocalizationFramework, NOT AOT artifacts — search() cannot find them; only ERI… names with an AxClass file (ERIFormatMappingRun, ERIDataSourceProvider) are verifiable',
+      'To expose X++ data to a format: write an ORDINARY public class with a static construct() and public parm methods, then bind it in the model mapping as data source type "Dynamics 365 for Operations \\ Class". No interface to implement, no registration — ER reflects over the public members',
+      'ERIDataSourceProvider exists but declares only `ERIDataSource getDataSource()` and nothing in the AOT implements it — do not build on it',
+      'Every string a format reads must come from a label, and the class DeveloperDocumentation should name the model mapping data source that binds it',
       'NEVER modify ER configurations in code — use ER designer in D365FO UI or import from LCS',
       'ER configurations are stored in ERSolutionTable / ERVendorTable — do NOT touch DB directly',
-      'To extend ER model mapping: implement IERModelMappingExtension on your class (CoC not possible for ER)',
-      'For custom data sources: create a class implementing ERIDataSourceProvider and register it',
+      'ER classes ARE extensible by CoC (ERParameters, ERInvoicingServiceParameters and others carry class extensions); what cannot be edited in code is the configuration, not the framework',
       'ER format file path: System administration > Electronic reporting > Reporting configurations',
-      'For testing: use ERObjectsFactory::createFormatMappingRunByFormatMappingId()',
       'Country-specific ER formats loaded via localization features — check ERSolutionRepositoryTable',
     ],
     examples: [
@@ -1511,7 +1515,7 @@ MySalesConfirmedBusinessEvent::newFromContract(contract).send();`,
         code: `// Run an ER format programmatically and return the output as a file
 using Microsoft.Dynamics365.LocalizationFramework;
 
-public static void runErFormat(ERFormatMappingId _formatMappingId, FilePath _outputPath)
+public static void runErFormat(ERFormatMappingID _formatMappingId, FilePath _outputPath)
 {
     ERIFormatMappingRun formatRun = ERObjectsFactory::createFormatMappingRunByFormatMappingId(
         _formatMappingId,
@@ -1520,12 +1524,50 @@ public static void runErFormat(ERFormatMappingId _formatMappingId, FilePath _out
         false,              // _showInfologMessage
         false);             // _forceRunDraft
 
-    // Optionally push user-input parameter values into the model definition
+    // Push parameter values through the run's own definition parameters.
     ERModelDefinitionInputParametersAction paramsAction = new ERModelDefinitionInputParametersAction();
-    formatRun.withParameter(paramsAction);
+    paramsAction.addParameter('DocumentId', _documentId);
+    paramsAction.applyTo(formatRun.getDatasourceDefinitionParameters());
 
-    // Run and get output
     formatRun.run();
+}`,
+      },
+      {
+        label: 'Class bound as a model-mapping data source',
+        code: `/// <summary>
+/// ER binding: model mapping "Demo rental invoice (mapping)" binds this class through its data
+/// source "DemoErInvoiceProvider", declared as "Dynamics 365 for Operations \\ Class".
+/// </summary>
+public class ConDemoErDataProvider
+{
+    private Num documentId;
+    private Amount totalAmount;
+
+    // No base class and no interface: ER reflects over the public members, so
+    // anything the format reads must be public — protected state is unreachable.
+    public static ConDemoErDataProvider construct()
+    {
+        return new ConDemoErDataProvider();
+    }
+
+    public container getInvoiceTotals(Num _documentId)
+    {
+        documentId = _documentId;
+        // ... aggregate ...
+        return [documentId, totalAmount];
+    }
+
+    public Num parmDocumentId(Num _documentId = documentId)
+    {
+        documentId = _documentId;
+        return documentId;
+    }
+
+    // Every string the format reads comes from a label, never a literal.
+    public Description parmTotalsCaption()
+    {
+        return "@ConDemo:ErInvoiceTotals";
+    }
 }`,
       },
     ],
@@ -1789,6 +1831,8 @@ else
       'Virtual entities expose F&O data in Dataverse without data duplication.',
     rules: [
       'Dual-write operates on data entities — ensure entities are OData-enabled and public',
+      'Change tracking is a TWO-SIDED prerequisite and the entity half is not enough: the AxDataEntityView needs <AllowRowVersionChangeTracking>Yes</…> AND every source AxTable it reads needs the same element. Miss the table half and the entity syncs on the initial load, then silently stops picking up changes',
+      'The element is AllowRowVersionChangeTracking on BOTH artifacts — NOT ChangeTrackingEnabled, which is not a MetaModel.AxDataEntityView property at all; on AxTable it sits directly before <CacheLookup>, after the Title/label block',
       'Table maps define column-level mappings between F&O entity fields and Dataverse table columns',
       'Initial sync: always run from the side with the most complete data set',
       'Error handling: dual-write has a retry mechanism — failed records go to an error queue',

--- a/src/utils/axTablePropertyOrder.ts
+++ b/src/utils/axTablePropertyOrder.ts
@@ -33,6 +33,11 @@ export const AX_TABLE_MANDATORY_PROPERTIES = [
 
 /** Block 2 — extended properties, alphabetical, written only when set. */
 export const AX_TABLE_EXTENDED_PROPERTIES = [
+  // 3,962 of the 18,337 shipped tables set AllowRowVersionChangeTracking (157
+  // AllowRetention), both directly before CacheLookup. This list doubles as the
+  // writer's whitelist, so an absent name is dropped, not just misordered.
+  'AllowRetention',
+  'AllowRowVersionChangeTracking',
   'CacheLookup',
   'ClusteredIndex',
   'CreatedBy',

--- a/tests/metadata/modelDescriptor.test.ts
+++ b/tests/metadata/modelDescriptor.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Descriptor reader + visibility oracle. Fixtures are real directory trees:
+ * both the probe order and packageOf() are path-shaped, and a mocked fs would
+ * not exercise either.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseModuleReferences,
+  readModuleReferences,
+  packagesRootFromPath,
+  buildModelVisibility,
+} from '../../src/metadata/modelDescriptor';
+
+const descriptorXml = (refs: string[]) => `<?xml version="1.0" encoding="utf-8"?>
+<AxModelInfo xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+  <ModelReferences i:nil="true" xmlns:i="http://www.w3.org/2001/XMLSchema-instance" />
+  <ModuleReferences>
+${refs.map(r => `    <d2p1:string>${r}</d2p1:string>`).join('\n')}
+  </ModuleReferences>
+</AxModelInfo>`;
+
+let root: string;
+
+beforeAll(async () => {
+  root = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'descriptor-test-')), 'PackagesLocalDirectory');
+  const write = async (pkg: string, model: string, refs: string[]) => {
+    const dir = path.join(root, pkg, 'Descriptor');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, `${model}.xml`), descriptorXml(refs), 'utf-8');
+  };
+  await write('Contoso', 'Contoso', ['ApplicationSuite', 'Ledger']);
+  // ISV layout: the model lives inside a differently named package.
+  await write('IsvPackage', 'IsvModel', ['ApplicationFoundation']);
+  await fs.mkdir(path.join(root, 'Tax'), { recursive: true });
+});
+
+afterAll(async () => {
+  await fs.rm(path.dirname(root), { recursive: true, force: true });
+});
+
+describe('parseModuleReferences', () => {
+  it('reads every entry and ignores the nil sibling list', () => {
+    expect(parseModuleReferences(descriptorXml(['A', 'B', 'C']))).toEqual(['A', 'B', 'C']);
+  });
+
+  it('returns an empty list for a descriptor with no references', () => {
+    expect(parseModuleReferences('<AxModelInfo />')).toEqual([]);
+  });
+});
+
+describe('readModuleReferences', () => {
+  it('reads a model whose package shares its name', async () => {
+    expect(await readModuleReferences(root, 'Contoso')).toEqual(['ApplicationSuite', 'Ledger']);
+  });
+
+  // Null is "unknown", never "references nothing" — callers must not treat a
+  // missing descriptor as an empty reference set.
+  it('returns null when there is no descriptor', async () => {
+    expect(await readModuleReferences(root, 'NoSuchModel')).toBeNull();
+  });
+});
+
+describe('packagesRootFromPath', () => {
+  it('extracts the root from a package or workspace path', () => {
+    expect(packagesRootFromPath('K:\\AosService\\PackagesLocalDirectory'))
+      .toBe('K:\\AosService\\PackagesLocalDirectory');
+    expect(packagesRootFromPath('K:\\AosService\\PackagesLocalDirectory\\Contoso\\Contoso'))
+      .toBe('K:\\AosService\\PackagesLocalDirectory');
+    expect(packagesRootFromPath('K:/AosService/PackagesLocalDirectory/Contoso'))
+      .toBe('K:\\AosService\\PackagesLocalDirectory');
+  });
+
+  it('returns null for a path that is not under a packages root', () => {
+    expect(packagesRootFromPath('K:\\repos\\d365fo-mcp-server')).toBeNull();
+    expect(packagesRootFromPath(undefined)).toBeNull();
+  });
+});
+
+describe('buildModelVisibility', () => {
+  it('includes the model\'s own package plus its direct references', () => {
+    const vis = buildModelVisibility(root, 'Contoso')!;
+    expect(vis.model).toBe('Contoso');
+    expect([...vis.visiblePackages].sort()).toEqual(['applicationsuite', 'contoso', 'ledger']);
+  });
+
+  // References are NOT followed transitively: ApplicationSuite references Tax,
+  // and closing over that would mark Tax visible and hide the defect the oracle
+  // exists to catch.
+  it('does not close over the reference graph', () => {
+    expect(buildModelVisibility(root, 'Contoso')!.visiblePackages.has('tax')).toBe(false);
+  });
+
+  it('finds a model inside a differently named package', () => {
+    const vis = buildModelVisibility(root, 'IsvModel')!;
+    expect([...vis.visiblePackages].sort()).toEqual(['applicationfoundation', 'isvpackage']);
+  });
+
+  it('returns null rather than guessing', () => {
+    expect(buildModelVisibility(root, 'NoSuchModel')).toBeNull();
+    expect(buildModelVisibility(null, 'Contoso')).toBeNull();
+    expect(buildModelVisibility(root, undefined)).toBeNull();
+  });
+
+  describe('packageOf', () => {
+    // The index records the root as the scanner saw it while config supplies its
+    // own casing; both name the same directory.
+    it('is case-insensitive about the root and separator-agnostic', () => {
+      const vis = buildModelVisibility(root, 'Contoso')!;
+      expect(vis.packageOf(path.join(root, 'Tax', 'AxEdt', 'TaxAmountCur.xml'))).toBe('Tax');
+      expect(vis.packageOf(path.join(root.toUpperCase(), 'Tax', 'AxEdt', 'X.xml'))).toBe('Tax');
+      expect(vis.packageOf(`${root.replace(/\\/g, '/')}/Tax/AxEdt/X.xml`)).toBe('Tax');
+    });
+
+    it('returns null for a path outside the packages root', () => {
+      const vis = buildModelVisibility(root, 'Contoso')!;
+      expect(vis.packageOf('K:\\src\\Elsewhere.xml')).toBeNull();
+      expect(vis.packageOf('')).toBeNull();
+    });
+  });
+});

--- a/tests/metadata/xmlParser-method-params.test.ts
+++ b/tests/metadata/xmlParser-method-params.test.ts
@@ -64,10 +64,58 @@ describe('XppMetadataParser method declarations', () => {
     const method = result.data!.methods.find(m => m.name === 'construct')!;
     expect(method.returnType).toBe('PurchFormLetter_Invoice');
     expect(method.isStatic).toBe(true);
+    // Defaults are carried: dropping them makes an optional parameter look required.
     expect(method.parameters).toEqual([
-      { type: 'IdentifierName', name: '_className' },
-      { type: 'IdentifierName', name: '_methodName' },
-      { type: 'SysOperationExecutionMode', name: '_executionMode' },
+      { type: 'IdentifierName', name: '_className', defaultValue: 'classStr(FormletterService)' },
+      {
+        type: 'IdentifierName',
+        name: '_methodName',
+        defaultValue: 'methodStr(FormletterService, postPurchaseOrderInvoice)',
+      },
+      {
+        type: 'SysOperationExecutionMode',
+        name: '_executionMode',
+        defaultValue: 'SysOperationExecutionMode::Synchronous',
+      },
+    ]);
+    expect(method.parametersUnknown).toBe(false);
+  });
+
+  it('flags an unreadable declaration as unknown rather than zero-parameter', async () => {
+    const file = await writeClass('MysteryClass', [{ name: 'mystery', source: '    return 1 + 2;' }]);
+
+    const result = await new XppMetadataParser().parseClassFile(file, 'TestModel');
+
+    expect(result.success).toBe(true);
+    const method = result.data!.methods.find(m => m.name === 'mystery')!;
+    expect(method.parameters).toEqual([]);
+    expect(method.parametersUnknown).toBe(true);
+  });
+
+  it('reads parameter types past a pragma comment interleaved in the list', async () => {
+    // Read off raw text, `//<GEERU><GEEU>` looks like a type token, the parameter
+    // fails to validate, and all-or-nothing discards the whole declaration.
+    const source = [
+      'public static server NumberSeq newGetVoucherFromId(RefRecId _voucherSequenceId,',
+      '    boolean _makeDecisionLater = false,',
+      '    //<GEERU><GEEU>',
+      '    UnknownNoYes _allowManual = UnknownNoYes::Unknown',
+      '    //</GEERU></GEEU>',
+      '    )',
+      '{',
+      '    return null;',
+      '}',
+    ].join('\n');
+    const file = await writeClass('NumberSeq', [{ name: 'newGetVoucherFromId', source }]);
+
+    const result = await new XppMetadataParser().parseClassFile(file, 'TestModel');
+
+    const method = result.data!.methods.find(m => m.name === 'newGetVoucherFromId')!;
+    expect(method.parametersUnknown).toBe(false);
+    expect(method.parameters).toEqual([
+      { type: 'RefRecId', name: '_voucherSequenceId' },
+      { type: 'boolean', name: '_makeDecisionLater', defaultValue: 'false' },
+      { type: 'UnknownNoYes', name: '_allowManual', defaultValue: 'UnknownNoYes::Unknown' },
     ]);
   });
 

--- a/tests/tools/createWriterDefects.test.ts
+++ b/tests/tools/createWriterDefects.test.ts
@@ -170,6 +170,17 @@ describe('#13 AxTable canonical element order', () => {
     expect(xml).not.toContain('<TitleField1></TitleField1>');
     expect(xml).not.toContain('<TitleField1>');
     expect(xml).toContain('<Label>ConDemoAgentNote</Label>');
+    expect(xml).not.toContain('<AllowRowVersionChangeTracking>');
+  });
+
+  it('emits AllowRowVersionChangeTracking in canonical position when asked', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('ConDemoAgentNote', {
+      titleField1: 'Subject', allowRowVersionChangeTracking: true,
+    });
+    expect(xml).toContain('<AllowRowVersionChangeTracking>Yes</AllowRowVersionChangeTracking>');
+    expect(xml.indexOf('<TitleField1>')).toBeLessThan(xml.indexOf('<AllowRowVersionChangeTracking>'));
+    expect(xml.indexOf('<AllowRowVersionChangeTracking>')).toBeLessThan(xml.indexOf('<DeleteActions'));
+    expect(runRules(xml, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
   });
 
   it('validate_code(xml-table) FLAGS a misordered document (it used to report "no violations")', () => {
@@ -323,6 +334,23 @@ describe('#37 upsertAxTableProperty inserts in canonical order', () => {
     expect(axTableElementRank('Label')).toBeLessThan(axTableElementRank('Fields'));
     expect(axTableElementRank('SomethingElse')).toBe(Number.MAX_SAFE_INTEGER);
     expect(AX_TABLE_ELEMENT_ORDER[0]).toBe('ConfigurationKey');
+  });
+
+  // Dual-write's table-side prerequisite. The rank lookup doubles as the
+  // writer's whitelist, so an unranked name is dropped rather than misordered.
+  it('places AllowRowVersionChangeTracking after the Title block, before CacheLookup', () => {
+    expect(axTableElementRank('AllowRowVersionChangeTracking'))
+      .toBeGreaterThan(axTableElementRank('TitleField2'));
+    expect(axTableElementRank('AllowRowVersionChangeTracking'))
+      .toBeLessThan(axTableElementRank('CacheLookup'));
+    expect(axTableElementRank('AllowRetention'))
+      .toBeLessThan(axTableElementRank('AllowRowVersionChangeTracking'));
+
+    const out = upsertAxTableProperty(table, 'AllowRowVersionChangeTracking', 'Yes');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<AllowRowVersionChangeTracking>Yes</AllowRowVersionChangeTracking>');
+    expect(out!.indexOf('<TableGroup>')).toBeLessThan(out!.indexOf('<AllowRowVersionChangeTracking>'));
+    expect(runRules(out!, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
   });
 });
 

--- a/tests/tools/createWriterDefects.test.ts
+++ b/tests/tools/createWriterDefects.test.ts
@@ -183,6 +183,31 @@ describe('#13 AxTable canonical element order', () => {
     expect(runRules(xml, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
   });
 
+  // All six are NoYes on AxTable and were already ranked, but no writer surface
+  // reached them — so a case asking for ModifiedDateTime could not be satisfied.
+  it('emits the audit system fields in canonical order', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('ConDemoAgentNote', {
+      titleField1: 'Subject', cacheLookup: 'Found',
+      createdBy: true, createdDateTime: true, createdTransactionId: true,
+      modifiedBy: true, modifiedDateTime: true, modifiedTransactionId: true,
+    });
+    const seq = ['CacheLookup', 'CreatedBy', 'CreatedDateTime', 'CreatedTransactionId',
+      'ModifiedBy', 'ModifiedDateTime', 'ModifiedTransactionId'];
+    const positions = seq.map(t => xml.indexOf(`<${t}>`));
+    expect(positions.every(p => p > 0)).toBe(true);
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThan(positions[i - 1]);
+    }
+    expect(runRules(xml, 'xml-table').filter(v => v.rule === 'XML006')).toHaveLength(0);
+  });
+
+  it('omits the audit system fields unless asked', () => {
+    const xml = XmlTemplateGenerator.generateAxTableXml('ConDemoAgentNote', { titleField1: 'Subject' });
+    for (const t of ['CreatedBy', 'CreatedDateTime', 'ModifiedBy', 'ModifiedDateTime']) {
+      expect(xml).not.toContain(`<${t}>`);
+    }
+  });
+
   it('validate_code(xml-table) FLAGS a misordered document (it used to report "no violations")', () => {
     const misordered = `<?xml version="1.0" encoding="utf-8"?>
 <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">

--- a/tests/tools/resolve-references.test.ts
+++ b/tests/tools/resolve-references.test.ts
@@ -260,6 +260,23 @@ describe('resolveXppReferences — arity checks', () => {
     expect(errors[0].kind).toBe('arity-mismatch');
   });
 
+  // `CustTable custTable;` is the universal convention and differs from the type
+  // only in the first letter's case, so a declaredNames guard on the `::` path
+  // skipped the check for almost every real method body.
+  it('still checks Type::member when a local is named after the type', () => {
+    const code = `public class ConDemoProbe
+{
+    public void run()
+    {
+        CustTable custTable;
+        custTable = CustTable::find("c1", true, 42);
+    }
+}`;
+    const errors = errorsOf(code);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('arity-mismatch');
+  });
+
   // A default whose VALUE contains parens (`= curUserId()`) must still count as
   // optional — splitTopLevel keeps them balanced.
   it('treats a trailing function-call default as optional (#18)', () => {

--- a/tests/tools/resolve-references.test.ts
+++ b/tests/tools/resolve-references.test.ts
@@ -272,6 +272,153 @@ describe('resolveXppReferences — arity checks', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0].kind).toBe('arity-mismatch');
   });
+
+  // `(...)` is renderMethodSignature's marker for a declaration the indexer
+  // could not read. Reading it as zero parameters made every real call a
+  // mismatch (NumberSeq::newGetVoucherFromId, indexed as `()`).
+  it('makes no arity claim against an unknown parameter list', () => {
+    const scratch = new XppSymbolIndex(':memory:', ':memory:');
+    try {
+      scratch.addSymbol({
+        name: 'Opaque', type: 'class', filePath: '/x.xml', model: 'Test',
+      } as any);
+      scratch.addSymbol({
+        name: 'mystery', type: 'method', parentName: 'Opaque',
+        signature: 'void mystery(...)', filePath: '/x.xml', model: 'Test',
+      } as any);
+      const d = makeDeps(scratch.getReadDb());
+      for (const call of ['Opaque::mystery();', 'Opaque::mystery(1);', 'Opaque::mystery(1, 2, 3);']) {
+        expect(resolveXppReferences(call, d).violations.filter(v => v.kind === 'arity-mismatch'))
+          .toEqual([]);
+      }
+    } finally {
+      scratch.close();
+    }
+  });
+
+  // The signature already in the index dropped defaults, so it under-reports the
+  // optional count. The stored declaration is authoritative and needs no reindex.
+  it('derives arity from the stored declaration, not the rendered signature', () => {
+    const scratch = new XppSymbolIndex(':memory:', ':memory:');
+    try {
+      scratch.addSymbol({
+        name: 'Legacy', type: 'class', filePath: '/x.xml', model: 'Test',
+      } as any);
+      scratch.addSymbol({
+        name: 'find', type: 'method', parentName: 'Legacy',
+        signature: 'Legacy find(LegacyId _id, boolean _forUpdate)',
+        source: 'static Legacy find(LegacyId _id, boolean _forUpdate = false)\n{\n    return null;\n}',
+        filePath: '/x.xml', model: 'Test',
+      } as any);
+      const d = makeDeps(scratch.getReadDb());
+      expect(resolveXppReferences('Legacy::find(id);', d)
+        .violations.filter(v => v.kind === 'arity-mismatch')).toEqual([]);
+
+      const tooMany = resolveXppReferences('Legacy::find(id, true, 1);', d)
+        .violations.filter(v => v.kind === 'arity-mismatch');
+      expect(tooMany).toHaveLength(1);
+      expect(tooMany[0].detail).toContain('_forUpdate = false');
+    } finally {
+      scratch.close();
+    }
+  });
+
+  // A stored declaration this parser refuses to read is the case that rendered
+  // as `()`, so the signature must not be trusted as a fallback.
+  it('stays silent when the stored declaration is unreadable', () => {
+    const scratch = new XppSymbolIndex(':memory:', ':memory:');
+    try {
+      scratch.addSymbol({
+        name: 'Murky', type: 'class', filePath: '/x.xml', model: 'Test',
+      } as any);
+      scratch.addSymbol({
+        name: 'go', type: 'method', parentName: 'Murky',
+        signature: 'void go()',
+        source: '    return 1 + 2;',
+        filePath: '/x.xml', model: 'Test',
+      } as any);
+      const d = makeDeps(scratch.getReadDb());
+      expect(resolveXppReferences('Murky::go(1, 2);', d)
+        .violations.filter(v => v.kind === 'arity-mismatch')).toEqual([]);
+    } finally {
+      scratch.close();
+    }
+  });
+});
+
+// ─── Model visibility ────────────────────────────────────────────────────────
+
+describe('resolveXppReferences — Descriptor visibility', () => {
+  const ROOT = 'K:\\AosService\\PackagesLocalDirectory';
+  const visibility = {
+    model: 'Contoso',
+    packagesRoot: ROOT,
+    visiblePackages: new Set(['contoso', 'applicationsuite']),
+    packageOf: (filePath: string) => {
+      const lower = filePath.toLowerCase();
+      const prefix = ROOT.toLowerCase() + '\\';
+      if (!lower.startsWith(prefix)) return null;
+      return filePath.slice(prefix.length).split('\\')[0] || null;
+    },
+  };
+
+  let scoped: XppSymbolIndex;
+  let scopedDeps: ResolverDeps;
+
+  beforeAll(() => {
+    scoped = new XppSymbolIndex(':memory:', ':memory:');
+    const add = (name: string, type: string, pkg: string) => scoped.addSymbol({
+      name, type, filePath: `${ROOT}\\${pkg}\\AxTable\\${name}.xml`, model: pkg,
+    } as any);
+    add('TaxAmountCur', 'edt', 'Tax');            // indexed, package not referenced
+    add('CustTable', 'table', 'ApplicationSuite'); // referenced
+    // Same name in two packages, one of them reachable ⇒ must stay silent.
+    add('SharedName', 'class', 'Tax');
+    scoped.addSymbol({
+      name: 'SharedName', type: 'class',
+      filePath: `${ROOT}\\ApplicationSuite\\AxClass\\SharedName.xml`, model: 'ApplicationSuite',
+    } as any);
+    // Outside the packages root ⇒ cannot tell which package owns it.
+    scoped.addSymbol({
+      name: 'WorkspaceType', type: 'class', filePath: 'K:\\src\\WorkspaceType.xml', model: 'Other',
+    } as any);
+    scopedDeps = { ...makeDeps(scoped.getReadDb()), visibility };
+  });
+
+  afterAll(() => scoped.close());
+
+  const kindsOf = (code: string, d = scopedDeps) =>
+    resolveXppReferences(code, d).violations.map(v => v.kind);
+
+  it('reports a type whose only package the model does not reference', () => {
+    const violations = resolveXppReferences('TaxAmountCur amount;', scopedDeps).violations;
+    expect(violations.map(v => v.kind)).toEqual(['not-visible-from-model']);
+    expect(violations[0].severity).toBe('error');
+    expect(violations[0].detail).toContain('Tax');
+    expect(violations[0].detail).toContain('Contoso');
+  });
+
+  it('accepts a type from a referenced package', () => {
+    expect(kindsOf('CustTable custTable;')).toEqual([]);
+  });
+
+  it('stays silent when any occurrence of the name is reachable', () => {
+    expect(kindsOf('SharedName x;')).toEqual([]);
+  });
+
+  it('stays silent when the indexed path is outside the packages root', () => {
+    expect(kindsOf('WorkspaceType x;')).toEqual([]);
+  });
+
+  it('runs no check at all without an oracle', () => {
+    const noOracle = makeDeps(scoped.getReadDb());
+    expect(kindsOf('TaxAmountCur amount;', noOracle)).toEqual([]);
+  });
+
+  it('reports an invisible type once, not per occurrence', () => {
+    const code = 'TaxAmountCur a;\nTaxAmountCur b;\nTaxAmountCur c;';
+    expect(kindsOf(code)).toEqual(['not-visible-from-model']);
+  });
 });
 
 // ─── Labels ──────────────────────────────────────────────────────────────────

--- a/tests/tools/updateSymbolIndex.test.ts
+++ b/tests/tools/updateSymbolIndex.test.ts
@@ -346,7 +346,8 @@ describe('update_symbol_index table re-indexing preserves field EDT/EnumType', (
       name: 'find',
       type: 'method',
       parentName: 'MyTable',
-      signature: 'MyTable find(ContosoMyId _myId, boolean _forUpdate)',
+      // `= false` is kept: without it `find(_myId)` reads as an arity mismatch.
+      signature: 'MyTable find(ContosoMyId _myId, boolean _forUpdate = false)',
       filePath,
       model: 'MyModel',
     });

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -30,10 +30,14 @@ const CHARS_PER_TOKEN = 4;
 // (findings #36), generate_object scaffold `fields[]`/`preview` (#21), and the
 // five coverage-closure objectTypes (macro, configuration-key, security-policy,
 // aggregate-measurement, license-code) that took the T flag green on the last
-// create-path holes in the taxonomy.
+// create-path holes in the taxonomy, then the data-entity writer properties
+// (primaryKey, isPublic, entityCategory, dynamicFields,
+// allowRowVersionChangeTracking) that were implemented but unadvertised — paid
+// for in part by dropping the member-variable rule from `sourceCode`, where it
+// was the third statement of the same thing.
 // Headroom is small on purpose so creep is caught early.
 const TOTAL_BUDGET = 63_300;
-const LARGEST_TOOL_BUDGET = 9_800;
+const LARGEST_TOOL_BUDGET = 9_900;
 
 async function getTools(): Promise<Array<{ name: string }>> {
   const ctx: any = { symbolIndex: {}, parser: {} };


### PR DESCRIPTION
Six defects found while running the L4-posting and L3-electronic-reporting eval cases, in three commits.

## 1. `resolve_references` was confidently wrong (f580535)

**Arity false positives.** `parseParameter` read type and name off the RAW text, so a country-pragma comment interleaved in a wrapped parameter list looked like a leading type token; the parameter failed to validate and the all-or-nothing rule discarded the whole declaration. The caller collapsed that `null` into `[]`, which rendered as `()` — a positive claim of zero parameters. Defaults were dropped from the rendered signature too, so every optional parameter read as required.

- `parseParameter` reads the blanked twin; defaults keep their raw text
- `XppMethodInfo.parametersUnknown` + `XppParameterInfo.defaultValue`
- `renderMethodSignature` is now the single renderer; an unknown list renders `(...)`, never `()`
- `arityOf()` derives arity from the stored declaration first, so **the fix applies to rows already indexed with no reindex**

Measured against the real AOT: **0 regressions over 30 000 methods**, 24 newly parsed, 3 improved (comment text no longer leaks into a default value). `NumberSeq::newGetVoucherFromId` went from `void newGetVoucherFromId()` to its full four-parameter signature. All four recorded false positives are gone; genuine mismatches still fire.

**Types invisible to the target model.** Presence in the index is not visibility — xppc resolves against the model's referenced packages. The resolver reported "all 18 reference(s) verified" for a body xppc rejected with *"The name TaxAmountCur does not denote a class, a table, or an extended data type"*. New `src/metadata/modelDescriptor.ts` reads `<ModuleReferences>` (one parser, shared with `build_d365fo_project`'s build-queue ordering) and `resolve_references` reports `not-visible-from-model` only when EVERY indexed occurrence is provably out of reach. References are deliberately not followed transitively.

**0 false positives across 257 X++ bodies from the 158 golden files**, all of which built clean in the sandbox.

The first draft used `lookupSymbolsNocase` at limit 8, whose short-circuit never fires for a type name, so the FTS5 fallback ran to exhaustion: **45 ms → 5003 ms** per class body. Canonicalize at limit 1, then probe BINARY `name = ?` — **73 ms**.

The clean verdict no longer claims "Safe to proceed with the write operation" (both `resolve_references` and `validate_code(references)`); it states what it checked and names `build_d365fo_project` as the only proof of a compile.

## 2. Knowledge base (1e9ddb0)

`electronic-reporting` carried claims that do not hold against the AOT:

- `IERModelMappingExtension` does not exist anywhere — the rule telling agents to implement it was unfollowable
- "CoC not possible for ER" is false; ER classes carry class extensions
- `withParameter()` takes `ERIModelDefinitionParamsAction`, not an AOT artifact at all; the entry named an X++ class in its place
- `ERIDataSourceProvider` declares only `ERIDataSource getDataSource()` and nothing in the AOT implements it

What actually works — and what the captured golden does — is an ordinary class with a static `construct()` and public parm methods, bound in the model mapping as data source type "Dynamics 365 for Operations \ Class". Also recorded: many `ERI…` names are .NET types from `Microsoft.Dynamics365.LocalizationFramework`, so `search()` cannot confirm them.

`dual-write` said nothing about change tracking, and the entity half alone is a silent failure. Both the `AxDataEntityView` and every source `AxTable` need `<AllowRowVersionChangeTracking>Yes</…>`.

`d365fo_file`'s schema documented `data-entity` as primaryTable/fields/dataManagementEnabled only, so six implemented properties were undiscoverable. Paid for by dropping the member-variable rule from `sourceCode`, where it was the third statement of the same thing.

## 3. Writers (015d697)

`AllowRowVersionChangeTracking` was absent from `AX_TABLE_ELEMENT_ORDER`, and because the rank lookup doubles as the writer's whitelist it was **dropped**, not merely misordered. Reflection over `Microsoft.Dynamics.AX.Metadata` confirms it and `AllowRetention` are `NoYes` properties on `AxTable`; a census over all 18 337 shipped files puts them directly before `<CacheLookup>`.

`data-entity` was advertised as a supported `[modify]` objectType but rejected by `canBridgeModify` and by `SetProperty`'s default arm. Added, with `SetAxDataEntityViewProperty` covering the eleven properties confirmed by reflection.

## Verification

- `tsc --noEmit` clean; **183 files / 2465 tests pass** on the VM
- Bridge C# compiles clean against the real metadata assemblies (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WwDug2ExgxaK6zADZkYVZ