### PR TITLE
eval: close L3-dmf-entity-import-slice golden (DMF/DIXF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://img.shields.io/badge/tests-1400%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
-[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-92.3%25-lightgrey.svg)](eval/COVERAGE.md)
+[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-93.6%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -9,7 +9,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
 | core | 44 | 44 | **100%** |
-| total | 72 | 78 | 92.3% |
+| total | 73 | 78 | 93.6% |
 
 ## Data model (12/12)
 
@@ -97,14 +97,14 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Warehouse management (WHS) | total | ✅ | — | ✅ | Eval case authored for the X++ half (work creation through the WHS framework); templates/directives stay configured data. Golden pending VM capture. |
 | Trade agreements & pricing | total | ✅ | — | ✅ | Eval case authored (PriceDisc price/discount resolution); golden pending VM capture. |
 
-## Integration (6/9)
+## Integration (7/9)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | Data entity (OData) | core | ✅ | ✅ | ✅ | L4-entity-security |
 | Data entity extension | total | ✅ | ✅ | ✅ | L3-data-entity-extension-field |
 | Custom services / OData actions | core | ✅ | ✅ | ✅ | L3-custom-service-basic |
-| Data management framework (DMF/DIXF) | total | ✅ | — | ✅ | Eval case authored (import-ready entity + staging hook); golden pending VM capture. |
+| Data management framework (DMF/DIXF) | total | ✅ | ✅ | ✅ | L3-dmf-entity-import-slice |
 | Dual-write (Dataverse) | total | ✅ | ✅ | ✅ | L3-dualwrite-entity-mapping |
 | Power Platform / virtual entities | total | ✅ | — | ✅ | Eval case authored (entity marked up for virtual-entity exposure); golden pending VM capture. |
 | Reading Excel / CSV files | total | ✅ | ✅ | ✅ | L3-file-csv-import |
@@ -133,7 +133,6 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 
 | Weight | Leaf | Missing |
 | ---: | --- | --- |
-| 2 | Data management framework (DMF/DIXF) | missing E |
 | 1 | Aggregate measurements / analytics | missing E |
 | 1 | Power Platform / virtual entities | missing E |
 | 1 | Trade agreements & pricing | missing E |
@@ -145,4 +144,4 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 - Knowledge entries no leaf claims (**unproven knowledge**): none
 - Eval cases no leaf claims (**unmapped proof**): L2-oracle-discriminator-random-wrapper-name, L4-headerlines-document-slice
 
-_Generated 2026-07-30._
+_Generated 2026-08-03._

--- a/eval/cases/L3-dmf-entity-import-slice.json
+++ b/eval/cases/L3-dmf-entity-import-slice.json
@@ -8,7 +8,7 @@
     "AxDataEntityView"
   ],
   "golden_path": "eval/goldens/L3-dmf-entity-import-slice/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/corpus/runs/2026-08-03T18__L3-dmf-entity-import-slice__44e7380.json
+++ b/eval/corpus/runs/2026-08-03T18__L3-dmf-entity-import-slice__44e7380.json
@@ -1,0 +1,77 @@
+{
+  "run_id": "2026-08-03T18__L3-dmf-entity-import-slice__44e7380",
+  "case_id": "L3-dmf-entity-import-slice",
+  "tier": 3,
+  "timestamp": "2026-08-03T18:44:47.195Z",
+  "server_git_sha": "44e7380",
+  "generated_artifacts": [
+    "ConDemoImportTarget.metadata.xml",
+    "ConDemoImportTargetEntity.metadata.xml",
+    "/Tables/ConDemoImportTargetEntityStaging (companion, required by DataManagementStagingTable; not in target_artifact_types)",
+    "/SecurityPrivileges/ConDemoImportTargetEntityMaintain (companion, required to clear DataEntitySecurityPrivilegeCheck BP error; not in target_artifact_types)"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "code": "BPErrorTablePrimaryKeyEditable",
+        "element": "AxTable/ConDemoImportTarget/ImportTargetIdx/DocumentCode"
+      },
+      {
+        "code": "BPErrorDeveloperDocumentationNotDefined",
+        "element": "AxTable/ConDemoImportTarget"
+      },
+      {
+        "code": "BPErrorTableMissingFormRef",
+        "element": "AxTable/ConDemoImportTarget"
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "PASS",
+  "platform_build": "xppc 7.0.7858.27",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": [
+        "validate_code xml-table on ConDemoImportTargetEntityStaging flagged EnumType NoYes as unknown - false positive, NoYes is the standard kernel enum used verbatim in the shipped reference CashDiscountStaging.xml this table was modeled on; build proves it resolves with 0 errors",
+        "validate_code xpp on the entity sourceCode flagged @SYS23986 as an unknown label and ConDemoImportTargetEntityStaging as an unknown type - both false positives"
+      ]
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "RE-CAPTURE confirming both TOOL_DEFECTs recorded in the 2026-07-27T23 draft (server SHA e8e2eb9) are fixed on current main (44e7380), verified live against the running MCP server, not assumed from the draft README claim. First, d365fo_file action=create objectType=data-entity with sourceCode containing validateWrite plus postGetStagingData no longer drops the X++: the written ConDemoImportTargetEntity.xml carries a full SourceCode Declaration plus Methods block with both methods verbatim, confirmed by reading the file back after create rather than trusting the tool success message. createD365File.ts data-entity case now splits sourceCode via parseSourceForBridge and forwards declaration and methods into buildAxDataEntityXml in dataEntityXml.ts, which now supports standardStructure, declaration, methods and fieldGroups, implied automatically once declaration or methods are passed, matching the fix location the draft suggested_fix_area named. Second, the BRIDGE_MODIFY_TYPES gap is now moot for this case path since create carried the X++ directly and no add-method modify call was needed, but confirmed present in the built dist bridge adapter regardless: BRIDGE_MODIFY_TYPES now includes data-entity. Both objects built clean on a full build with fullBuild true, not incremental, so the Metadata Validation phase ran, 0 errors, 1 unrelated Commerce PricingEngine ExternalReference warning. All four objects, table, entity, staging table and privilege, were BP-checked clean of ERRORS via targetFilter scoped run_bp_check calls; the unfiltered call is documented elsewhere as a false passed result, so only filtered calls were trusted here, and each one reported an explicit elements processed line so absence of findings is real. Residual bp_clean 0 is exactly the 3 out-of-scope warnings already documented in the draft, BPErrorTablePrimaryKeyEditable, BPErrorDeveloperDocumentationNotDefined and BPErrorTableMissingFormRef; none are BP ERRORS since xppbp reports them as BestPractices Warning lines, so the case own gate of zero BP errors is satisfied. Classified PASS rather than KNOWLEDGE_GAP following the same convention the frozen L3-dualwrite-entity-mapping golden used for an identical warning shape. golden_match is 1 against the golden captured this session, the two target_artifact_types files byte identical to what the grounded tool path wrote, after the prior DRAFT golden, which was missing SourceCode, FieldGroups, DeleteActions and StateMachines, was overwritten with the working capture.",
+  "suggested_fix_area": "None for this case path; both previously blocking writer and bridge defects are fixed and reproduced working end to end with zero hand authored XML: prepare, then validate_code references plus syntax, then d365fo_file create for all four objects, table, staging table, data entity with embedded X++, and security privilege. Residual minor items, none case blocking: validate_code references still false positives on the kernel enum NoYes and on legacy SYS labels or newly created same session tables, documented elsewhere as a recurring validator gap; run_bp_check requires an explicit targetElementType value from a fixed vocabulary such as DataEntityView rather than the d365fo_file objectType convention, and passing the wrong one silently returns a misleading BP Check passed result with the explanation buried in the body instead of failing loudly, which is easy to miss and was caught here only by checking for an elements processed line.",
+  "evidence_refs": [
+    "eval/cases/L3-dmf-entity-import-slice.json",
+    "eval/goldens/L3-dmf-entity-import-slice/README.md prior DRAFT, now superseded by the rewritten README",
+    "eval/corpus/runs/2026-07-27T23__L3-dmf-entity-import-slice__e8e2eb9.json prior blocked draft run, same case, server SHA e8e2eb9",
+    "K:/AosService/PackagesLocalDirectory/Contoso/Contoso/AxDataEntityView/ConDemoImportTargetEntity.xml, rolled back after run, read back post-create to confirm SourceCode with both methods actually persisted",
+    "dist/bridge/bridgeAdapter.js lines 1080 to 1086 show BRIDGE_MODIFY_TYPES includes data-entity; dist/tools/dataEntityXml.js lines 132 to 186 show buildSourceCodeXml and standardStructure; dist/tools/createD365File.js lines 1418 to 1431 show the data-entity case forwarding sourceCode via parseSourceForBridge, all read directly from the dist the running MCP server loads",
+    "build_d365fo_project fullBuild true reported Build succeeded, Errors 0, Warnings 1 unrelated Commerce PricingEngine assembly",
+    "run_bp_check targetFilter ConDemoImportTarget targetElementType table reported 3 warnings 0 errors; targetFilter ConDemoImportTargetEntity targetElementType DataEntityView reported 0 warnings 0 errors and 1 elements processed; targetFilter ConDemoImportTargetEntityStaging targetElementType table reported 2 warnings 0 errors; targetFilter ConDemoImportTargetEntityMaintain targetElementType SecurityPrivilege reported 1 warning 0 errors",
+    "npm run eval:score for L3-dmf-entity-import-slice with actual-dir pointing at a scratch directory containing ConDemoImportTarget.metadata.xml and ConDemoImportTargetEntity.metadata.xml, bp-warnings 3, classification PASS, write, reported golden match with no structural deltas"
+  ]
+}

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -8,8 +8,8 @@
   "total": {
     "tier": "all",
     "total": 78,
-    "covered": 72,
-    "percent": 92.3
+    "covered": 73,
+    "percent": 93.6
   },
   "leaves": [
     {
@@ -1006,10 +1006,12 @@
       "tier": "total",
       "weight": 2,
       "k": true,
-      "e": false,
+      "e": true,
       "t": true,
-      "covered": false,
-      "cases": []
+      "covered": true,
+      "cases": [
+        "L3-dmf-entity-import-slice"
+      ]
     },
     {
       "id": "dual-write",

--- a/eval/goldens/L3-dmf-entity-import-slice/ConDemoImportTarget.metadata.xml
+++ b/eval/goldens/L3-dmf-entity-import-slice/ConDemoImportTarget.metadata.xml
@@ -20,6 +20,7 @@ public class ConDemoImportTarget extends common
 	<ClusteredIndex>ImportTargetIdx</ClusteredIndex>
 	<PrimaryIndex>ImportTargetIdx</PrimaryIndex>
 	<ReplacementKey>ImportTargetIdx</ReplacementKey>
+	<SaveDataPerCompany>Yes</SaveDataPerCompany>
 	<DeleteActions />
 	<FieldGroups>
 		<AxTableFieldGroup>
@@ -66,18 +67,18 @@ public class ConDemoImportTarget extends common
 	</FieldGroups>
 	<Fields>
 		<AxTableField xmlns=""
-			i:type="AxTableFieldString">
+				i:type="AxTableFieldString">
 			<Name>DocumentCode</Name>
 			<ExtendedDataType>Num</ExtendedDataType>
 			<Mandatory>Yes</Mandatory>
 		</AxTableField>
 		<AxTableField xmlns=""
-			i:type="AxTableFieldString">
+				i:type="AxTableFieldString">
 			<Name>Description</Name>
 			<ExtendedDataType>Name</ExtendedDataType>
 		</AxTableField>
 		<AxTableField xmlns=""
-			i:type="AxTableFieldReal">
+				i:type="AxTableFieldReal">
 			<Name>Amount</Name>
 			<ExtendedDataType>AmountCur</ExtendedDataType>
 		</AxTableField>
@@ -87,6 +88,7 @@ public class ConDemoImportTarget extends common
 		<AxTableIndex>
 			<Name>ImportTargetIdx</Name>
 			<AlternateKey>Yes</AlternateKey>
+			<AllowDuplicates>No</AllowDuplicates>
 			<Fields>
 				<AxTableIndexField>
 					<DataField>DocumentCode</DataField>

--- a/eval/goldens/L3-dmf-entity-import-slice/ConDemoImportTargetEntity.metadata.xml
+++ b/eval/goldens/L3-dmf-entity-import-slice/ConDemoImportTargetEntity.metadata.xml
@@ -1,6 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AxDataEntityView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 	<Name>ConDemoImportTargetEntity</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+public class ConDemoImportTargetEntity extends common
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>validateWrite</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Rejects a non-positive Amount with a labelled error.
+    /// </summary>
+    /// <returns>true if the write is valid; otherwise, false.</returns>
+    public boolean validateWrite()
+    {
+        boolean ret;
+
+        ret = super();
+
+        if (ret && this.Amount <= 0)
+        {
+            ret = checkFailed("@SYS23986");
+        }
+
+        return ret;
+    }
+
+]]></Source>
+			</Method>
+
+			<Method>
+				<Name>postGetStagingData</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// DMF staging post-load hook: normalizes DocumentCode to upper case in the staging table.
+    /// </summary>
+    /// <param name = "_dmfDefinitionGroupExecution">The execution context for import.</param>
+    public static void postGetStagingData(DMFDefinitionGroupExecution _dmfDefinitionGroupExecution)
+    {
+        ConDemoImportTargetEntityStaging stagingTable;
+
+        ttsbegin;
+        while select forupdate stagingTable
+        where stagingTable.DefinitionGroup == _dmfDefinitionGroupExecution.DefinitionGroup
+        && stagingTable.ExecutionId == _dmfDefinitionGroupExecution.ExecutionId
+        {
+            stagingTable.DocumentCode = strUpr(stagingTable.DocumentCode);
+            stagingTable.update();
+        }
+        ttscommit;
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
 	<Label>@TaxTransactionInquiry:HeaderNote</Label>
 	<DataManagementEnabled>Yes</DataManagementEnabled>
 	<DataManagementStagingTable>ConDemoImportTargetEntityStaging</DataManagementStagingTable>
@@ -9,6 +66,30 @@
 	<PrimaryKey>EntityKey</PrimaryKey>
 	<PublicCollectionName>ConDemoImportTargets</PublicCollectionName>
 	<PublicEntityName>ConDemoImportTarget</PublicEntityName>
+	<DeleteActions />
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+	</FieldGroups>
 	<Fields>
 		<AxDataEntityViewField xmlns=""
 			i:type="AxDataEntityViewMappedField">
@@ -42,6 +123,7 @@
 	<Mappings />
 	<Ranges />
 	<Relations />
+	<StateMachines />
 	<ViewMetadata>
 		<Name>Metadata</Name>
 		<SourceCode>

--- a/eval/goldens/L3-dmf-entity-import-slice/README.md
+++ b/eval/goldens/L3-dmf-entity-import-slice/README.md
@@ -1,94 +1,120 @@
-# Golden: L3-dmf-entity-import-slice — DRAFT, NOT FROZEN
+# Golden: L3-dmf-entity-import-slice - FROZEN
 
-The case stays `golden_pending: true`. This capture is **functionally incomplete**
-and is kept only as a draft reference / regression baseline — "fix first,
-capture second". Do NOT flip `golden_pending` off against these files.
+`golden_pending: false` since 2026-08-03. Every byte comes from the grounded
+`d365fo_file` path; nothing here is hand-authored.
 
-Captured 2026-07-27, server SHA e8e2eb9, xppc 7.0.7858.27 (VM), model `Contoso`,
-`EXTENSION_PREFIX=Con`.
+| Capture | Server SHA | Role |
+|---|---|---|
+| 2026-07-27 (draft) | `e8e2eb9` | first attempt; both AxDataEntityView writer defects still present, entity had no methods |
+| 2026-08-03 (freeze) | `44e7380` | full grounded run, `Errors: 0`, 0 BP errors, both methods present, golden byte-matched |
 
-## Why it is not frozen
+Platform xppc 7.0.7858.27, model `Contoso`, `EXTENSION_PREFIX=Con`.
 
-The case asks the data entity to carry two methods:
+## The two defects the draft found are fixed
 
-- `public boolean validateWrite()` — reject a non-positive `Amount` with a labelled error
-- `public static void postGetStagingData(DMFDefinitionGroupExecution)` — the DMF
-  hook after the staging load, normalising `DocumentCode` to upper case
-  (name+signature confirmed against `CashDiscountEntity` / `AgingPeriodDefinitionEntity`,
-  not guessed)
+The draft README recorded two TOOL_DEFECTs blocking this case:
 
-**Neither could be written.** There is no grounded tool path that puts X++ on an
-`AxDataEntityView`:
+1. `d365fo_file(action="create", objectType="data-entity", sourceCode=...)` used
+   to silently drop the X++.
+2. `d365fo_file(action="modify", objectType="data-entity", operation="add-method")`
+   used to reject with "Operation add-method on object type data-entity is not
+   supported by the bridge" - `data-entity` was in the tool's own objectType enum
+   but missing from the bridge's internal allowlist.
 
-- `d365fo_file(action="create", objectType="data-entity", sourceCode=…)` silently
-  drops `sourceCode` (`createD365File.ts:1550` → `generateAxDataEntityXml(objectName, properties)`;
-  `dataEntityXml.ts` emits no `<SourceCode>` element at all).
-- `d365fo_file(action="modify", objectType="data-entity", operation="add-method")`
-  → *"Operation add-method on object type data-entity is not supported by the
-  bridge"*. `data-entity` is in the modify tool's own objectType enum and in its
-  advertised description, but missing from `BRIDGE_MODIFY_TYPES`
-  (`bridgeAdapter.ts:1210`) — every modify op on a data entity dead-ends.
+Both are verified fixed on server SHA `44e7380` against the live MCP server
+(checked directly in the running `dist/`, not just `src/`, per the project's
+stale-dist caution):
 
-So the captured `ConDemoImportTargetEntity.metadata.xml` has the right DMF
-metadata and **no behaviour**. Re-capture once the writer emits `<SourceCode>`.
+- `dist/tools/dataEntityXml.js` now has `buildSourceCodeXml` and a
+  `standardStructure` flag (implied whenever `declaration`/`methods`/`fieldGroups`
+  are passed) that emits `<SourceCode>`, the five standard `<FieldGroups>`, empty
+  `<DeleteActions/>` and `<StateMachines/>`.
+- `dist/tools/createD365File.js` (data-entity create case) now splits the
+  top-level `sourceCode` X++ argument via `parseSourceForBridge` and forwards
+  `{declaration, methods}` into the shared builder, instead of discarding it.
+- `dist/bridge/bridgeAdapter.js`'s `BRIDGE_MODIFY_TYPES` now includes
+  `data-entity` (this path was not exercised this run - `create` carried the
+  X++ directly - but it is confirmed present for the add-method/replace-code
+  repair path other cases may need).
+
+The write was verified end to end, not just trusted: after
+`d365fo_file(action="create", objectType="data-entity", sourceCode=<X++ with both
+methods>, ...)` reported success, the written
+`ConDemoImportTargetEntity.xml` was read back from disk and confirmed to contain
+a full `<SourceCode><Declaration>...</Declaration><Methods>...` block with both
+`validateWrite` and `postGetStagingData` verbatim.
 
 ## Artifacts captured (the case's `target_artifact_types`)
 
-- `ConDemoImportTarget.metadata.xml` — AxTable, `TableGroup=Main`,
+- `ConDemoImportTarget.metadata.xml` - AxTable, `TableGroup=Main`,
   label `@TaxTransactionInquiry:HeaderNote`, `DocumentCode` (EDT `Num`, mandatory),
   `Description` (EDT `Name`), `Amount` (EDT `AmountCur`), unique alternate-key index
-  `ImportTargetIdx` (`AlternateKey=Yes`, no `AllowDuplicates` ⇒ unique) with
-  `PrimaryIndex`/`ClusteredIndex`/`ReplacementKey=ImportTargetIdx`.
-- `ConDemoImportTargetEntity.metadata.xml` — AxDataEntityView, `IsPublic=Yes`,
+  `ImportTargetIdx` (`AlternateKey=Yes`, `AllowDuplicates=No`), `PrimaryIndex`/
+  `ClusteredIndex`/`ReplacementKey=ImportTargetIdx`.
+- `ConDemoImportTargetEntity.metadata.xml` - AxDataEntityView, `IsPublic=Yes`,
   `PublicEntityName=ConDemoImportTarget`, `PublicCollectionName=ConDemoImportTargets`,
   `EntityCategory=Master`, `DataManagementEnabled=Yes`,
   `DataManagementStagingTable=ConDemoImportTargetEntityStaging`,
-  `PrimaryKey=EntityKey` → `AxDataEntityViewKey[EntityKey]` over `DocumentCode`
-  (natural key, **not** RecId), real `ViewMetadata` query over `ConDemoImportTarget`.
-  **Missing the two required methods — see above.**
+  `PrimaryKey=EntityKey` over `DocumentCode` (natural key, not RecId), real
+  `ViewMetadata` query over `ConDemoImportTarget`, and a real `<SourceCode>` block
+  with:
+  - `public boolean validateWrite()` - calls `super()`, then rejects a
+    non-positive `Amount` via `checkFailed("@SYS23986")` ("Amount must be
+    positive.", ApplicationPlatform/SYS - always resolvable, no new label needed).
+  - `public static void postGetStagingData(DMFDefinitionGroupExecution
+    _dmfDefinitionGroupExecution)` - the exact name and signature confirmed
+    against the shipped `CashDiscountEntity`/`AgingPeriodDefinitionEntity`, not
+    guessed. Loops the staging table filtered by `DefinitionGroup`/`ExecutionId`
+    and upper-cases `DocumentCode` via `strUpr`.
 
 ## Required companions NOT in this golden
 
-1. `AxTable ConDemoImportTargetEntityStaging` — the create writer hard-codes
+Same two companions the draft already identified and created (still required,
+still out of `target_artifact_types`):
+
+1. `AxTable ConDemoImportTargetEntityStaging` - the create writer sets
    `DataManagementStagingTable = <Entity>Staging` whenever
-   `dataManagementEnabled: true` and offers no way to leave it empty. xppc
-   **rejects a dangling staging table** during the full build:
-   `Metadata Error: AxDataEntityView/ConDemoImportTargetEntity/DataManagementStagingTable:
-   Table 'ConDemoImportTargetEntityStaging' does not exist.`
-   (Negative test satisfied: the property is load-bearing.) The table was therefore
-   created — `TableGroup=Staging`, `DefinitionGroup`/`ExecutionId`/`IsSelected`/
-   `TransferStatus` control fields + the three entity fields, alternate key
-   `StagingIdx` — modelled on `ApplicationSuite/Foundation/AxTable/CashDiscountStaging.xml`.
-   It is not in `target_artifact_types`, so it is not captured here.
-2. `AxSecurityPrivilege ConDemoImportTargetEntityMaintain` — without it xppbp raises
-   the BP **error** `DataEntitySecurityPrivilegeCheck`, which the case instruction
-   forbids ("zero BP errors"). Also out of `target_artifact_types`; a re-run must
-   still create it.
+   `dataManagementEnabled: true`; xppc rejects a dangling reference to it during
+   a FULL build. Modeled on
+   `ApplicationSuite/Foundation/AxTable/CashDiscountStaging.xml`: TableGroup=Staging,
+   `DefinitionGroup`/`ExecutionId`/`IsSelected`/`TransferStatus` control fields +
+   the three entity fields, alternate key `StagingIdx`.
+2. `AxSecurityPrivilege ConDemoImportTargetEntityMaintain` - without it xppbp
+   raises the BP **error** `DataEntitySecurityPrivilegeCheck`, which the case
+   instruction forbids ("zero BP errors").
 
-## Known deviations from standard-model shape (writer gap)
+## Build / BP at capture (2026-08-03, SHA 44e7380)
 
-The generated AxDataEntityView omits `<SourceCode>`, `<FieldGroups>`,
-`<DeleteActions/>` and `<StateMachines/>` — all present in the standard
-AxDataEntityView files of ApplicationSuite/Foundation. The deserializer defaults
-them, so build and BP stay green while the object diverges from every standard
-model. Same gap as `eval/goldens/L2-virtual-entity-power-platform/README.md`,
-but here it is case-fatal rather than cosmetic.
+- FULL build (`fullBuild: true`): **0 errors**, 1 unrelated warning (Commerce
+  PricingEngine external assembly not found).
+- BP, filtered per object (`run_bp_check` with an explicit `targetFilter` +
+  `targetElementType` - the unfiltered call reports a false "BP Check passed"
+  with zero elements processed, do not trust it):
+  - `ConDemoImportTarget` (table): 3 warnings, 0 errors -
+    `BPErrorTablePrimaryKeyEditable`, `BPErrorDeveloperDocumentationNotDefined`,
+    `BPErrorTableMissingFormRef` - all out of the case's declared scope.
+  - `ConDemoImportTargetEntity` (DataEntityView): **0 warnings, 0 errors** -
+    "1 elements processed."
+  - `ConDemoImportTargetEntityStaging` (table, companion): 2 warnings, 0 errors.
+  - `ConDemoImportTargetEntityMaintain` (privilege, companion): 1 warning
+    (`BPErrorPrivilegeNotCoveredByDuty`), 0 errors.
+  - `targetElementType` must be a value from xppbp's own vocabulary
+    (`DataEntityView`, `table`, `SecurityPrivilege`, ...) - passing the
+    `d365fo_file` objectType spelling (`data-entity-view`) is rejected with an
+    explanatory line inside a nominally "passed" response; easy to miss.
 
-## Build / BP at capture
-
-- FULL build (`fullBuild: true`): **0 errors**, 1 unrelated warning
-  (Commerce PricingEngine external assembly).
-  An *incremental* build of the same XML reported "Build succeeded / Errors: 0"
-  even while the staging-table metadata error existed — the Metadata Validation
-  phase only runs on a full build. Never accept an incremental green build here.
-- BP: **0 errors**, 9 warnings — `BPErrorTablePrimaryKeyEditable` ×4,
-  `BPErrorTablePrimaryKeyNotMandatory`, `BPErrorDeveloperDocumentationNotDefined` ×2,
-  `BPErrorTableMissingFormRef`, `BPErrorPrivilegeNotCoveredByDuty` — all out of the
-  case's declared scope. NOTE: `run_bp_check` *without* `targetFilter` reported
-  "BP Check passed" and found nothing; only the filtered runs surfaced these.
+The case's own gate is "zero BP **errors**" - satisfied. `bp_clean` in the
+corpus score is `0` because that dimension counts *warnings* too; the residual
+3 warnings on the table are the same out-of-scope, pre-existing pattern warnings
+the frozen `L3-dualwrite-entity-mapping` golden also carries, and this run is
+classified `PASS` on the same convention.
 
 ## Descriptor
 
 No package added. `DMFDefinitionGroupExecution`, `DMFEntity`,
 `DMFDefinitionGroupName`, `DMFExecutionId`, `DMFIsSelected` and `DMFTransferStatus`
 all live in **ApplicationFoundation**, which `Contoso.xml` already references.
+
+## Corpus record
+
+`eval/corpus/runs/2026-08-03T18__L3-dmf-entity-import-slice__44e7380.json`


### PR DESCRIPTION
## Summary
- Re-ran eval case `L3-dmf-entity-import-slice` (Integration section, DMF/DIXF leaf) on the VM. The two TOOL_DEFECTs that previously blocked it (data-entity `create` silently dropping `sourceCode`, and `data-entity` missing from the bridge's supported `add-method` modify types) turned out to already be fixed on `main` — verified live against the running server's `dist/`, not just `src/`.
- Grounded tool path only: table + companion staging table + data entity (with `validateWrite`/`postGetStagingData` overrides) + companion security privilege, all via `d365fo_file(create)`.
- Full build: 0 errors. Filtered BP check: 0 errors on the scored objects (AxTable, AxDataEntityView).
- Froze the real capture in place of the old methodless draft, flipped `golden_pending: false`, wrote the corpus record, and regenerated `eval/COVERAGE.md`.
- Coverage: Integration 6/9 -> 7/9, total 72/78 -> 73/78 (93.6%).

## Test plan
- [x] `npm run eval:score` against the new golden — `golden_match: 1`, no structural deltas
- [x] Full VM build (`fullBuild: true`) — 0 errors
- [x] `run_bp_check` filtered to the two scored objects — 0 errors
- [x] Sandbox rolled back (`undo_last_modification`), `.rnrproj` verified clean
- [x] `npm run eval:coverage` regenerated `eval/COVERAGE.md` / `eval/coverage.json` / README badge

Corpus record: `eval/corpus/runs/2026-08-03T18__L3-dmf-entity-import-slice__44e7380.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)