### PR TITLE
eval: close L2-virtual-entity-power-platform golden (Power Platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://img.shields.io/badge/tests-1400%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
-[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-93.6%25-lightgrey.svg)](eval/COVERAGE.md)
+[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-94.9%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -9,7 +9,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
 | core | 44 | 44 | **100%** |
-| total | 73 | 78 | 93.6% |
+| total | 74 | 78 | 94.9% |
 
 ## Data model (12/12)
 
@@ -97,7 +97,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Warehouse management (WHS) | total | ✅ | — | ✅ | Eval case authored for the X++ half (work creation through the WHS framework); templates/directives stay configured data. Golden pending VM capture. |
 | Trade agreements & pricing | total | ✅ | — | ✅ | Eval case authored (PriceDisc price/discount resolution); golden pending VM capture. |
 
-## Integration (7/9)
+## Integration (8/9)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
@@ -106,7 +106,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Custom services / OData actions | core | ✅ | ✅ | ✅ | L3-custom-service-basic |
 | Data management framework (DMF/DIXF) | total | ✅ | ✅ | ✅ | L3-dmf-entity-import-slice |
 | Dual-write (Dataverse) | total | ✅ | ✅ | ✅ | L3-dualwrite-entity-mapping |
-| Power Platform / virtual entities | total | ✅ | — | ✅ | Eval case authored (entity marked up for virtual-entity exposure); golden pending VM capture. |
+| Power Platform / virtual entities | total | ✅ | ✅ | ✅ | L2-virtual-entity-power-platform |
 | Reading Excel / CSV files | total | ✅ | ✅ | ✅ | L3-file-csv-import |
 | Direct SQL execution | total | ✅ | ✅ | ✅ | L2-direct-sql-connection |
 | Aggregate measurements / analytics | total | ✅ | — | ✅ | Knowledge entry + create path added; eval case authored, golden pending VM capture. |
@@ -134,7 +134,6 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Weight | Leaf | Missing |
 | ---: | --- | --- |
 | 1 | Aggregate measurements / analytics | missing E |
-| 1 | Power Platform / virtual entities | missing E |
 | 1 | Trade agreements & pricing | missing E |
 | 1 | Warehouse management (WHS) | missing E |
 | 1 | Extensible data security (XDS) | missing E |

--- a/eval/cases/L2-virtual-entity-power-platform.json
+++ b/eval/cases/L2-virtual-entity-power-platform.json
@@ -8,7 +8,7 @@
     "AxDataEntityView"
   ],
   "golden_path": "eval/goldens/L2-virtual-entity-power-platform/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/corpus/runs/2026-08-03T19__L2-virtual-entity-power-platform__6257ed4.json
+++ b/eval/corpus/runs/2026-08-03T19__L2-virtual-entity-power-platform__6257ed4.json
@@ -1,0 +1,40 @@
+{
+  "run_id": "2026-08-03T19__L2-virtual-entity-power-platform__6257ed4",
+  "case_id": "L2-virtual-entity-power-platform",
+  "tier": 2,
+  "timestamp": "2026-08-03T19:19:06.584Z",
+  "server_git_sha": "6257ed4",
+  "generated_artifacts": [
+    "ConDemoVirtualSource.metadata.xml",
+    "ConDemoVirtualSourceEntity.metadata.xml",
+    "/SecurityPrivileges/ConDemoVirtualSourceEntityMaintain (companion, required to clear DataEntitySecurityPrivilegeCheck BP error; not in target_artifact_types)"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS"
+}

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -8,8 +8,8 @@
   "total": {
     "tier": "all",
     "total": 78,
-    "covered": 73,
-    "percent": 93.6
+    "covered": 74,
+    "percent": 94.9
   },
   "leaves": [
     {
@@ -1034,10 +1034,12 @@
       "tier": "total",
       "weight": 1,
       "k": true,
-      "e": false,
+      "e": true,
       "t": true,
-      "covered": false,
-      "cases": []
+      "covered": true,
+      "cases": [
+        "L2-virtual-entity-power-platform"
+      ]
     },
     {
       "id": "file-io",

--- a/eval/goldens/L2-virtual-entity-power-platform/ConDemoVirtualSourceEntity.metadata.xml
+++ b/eval/goldens/L2-virtual-entity-power-platform/ConDemoVirtualSourceEntity.metadata.xml
@@ -1,12 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AxDataEntityView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 	<Name>ConDemoVirtualSourceEntity</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+public class ConDemoVirtualSourceEntity extends common
+{
+}
+]]></Declaration>
+		<Methods />
+	</SourceCode>
 	<Label>@TaxTransactionInquiry:HeaderNote</Label>
 	<EntityCategory>Master</EntityCategory>
 	<IsPublic>Yes</IsPublic>
 	<PrimaryKey>EntityKey</PrimaryKey>
 	<PublicCollectionName>ConDemoVirtualSources</PublicCollectionName>
 	<PublicEntityName>ConDemoVirtualSource</PublicEntityName>
+	<DeleteActions />
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+	</FieldGroups>
 	<Fields>
 		<AxDataEntityViewField xmlns=""
 			i:type="AxDataEntityViewMappedField">
@@ -34,6 +66,7 @@
 	<Mappings />
 	<Ranges />
 	<Relations />
+	<StateMachines />
 	<ViewMetadata>
 		<Name>Metadata</Name>
 		<SourceCode>

--- a/eval/goldens/L2-virtual-entity-power-platform/README.md
+++ b/eval/goldens/L2-virtual-entity-power-platform/README.md
@@ -1,43 +1,120 @@
-# Golden: L2-virtual-entity-power-platform — DRAFT, NOT FROZEN
+# Golden: L2-virtual-entity-power-platform — FROZEN
 
-The case is still `golden_pending: true`. This capture enshrines the
-AxDataEntityView writer gap described at the bottom of this file, so it is kept
-as a draft reference only — "fix first, capture second". Re-capture and flip
-`golden_pending` off once the writer emits `SourceCode` / `FieldGroups` /
-`DeleteActions` / `StateMachines`.
+`golden_pending: false` since 2026-08-03. Every byte in this golden comes from
+the grounded `d365fo_file` path; nothing here is hand-authored.
 
-Captured 2026-07-27, server SHA b28515f, platform xppc 7.0 (VM), model `Contoso`,
-`EXTENSION_PREFIX=Con` -> object names are `ConDemoVirtualSource` /
-`ConDemoVirtualSourceEntity`.
+| Capture | Server SHA | Role |
+|---|---|---|
+| 2026-07-27 (draft) | `b28515f` | first attempt; AxDataEntityView writer omitted `SourceCode`/`FieldGroups`/`DeleteActions`/`StateMachines` |
+| 2026-08-03 (freeze) | `6257ed4` | full grounded re-run with `properties.standardStructure: true`; golden byte-matched |
 
-Artifacts (the case's `target_artifact_types`):
+Platform xppc 7.0.7858.27, model `Contoso`, `EXTENSION_PREFIX=Con` -> object
+names are `ConDemoVirtualSource` / `ConDemoVirtualSourceEntity`.
 
-- `ConDemoVirtualSource.metadata.xml` — AxTable, TableGroup Main, `SourceCode`
-  (EDT Num, mandatory) + `Description` (EDT Name), unique alternate-key index
-  `VirtualSourceIdx` (`AlternateKey=Yes`, no `AllowDuplicates` = unique) and
-  `ReplacementKey=VirtualSourceIdx`.
-- `ConDemoVirtualSourceEntity.metadata.xml` — AxDataEntityView, `IsPublic=Yes`,
-  `PublicEntityName=ConDemoVirtualSource`, `PublicCollectionName=ConDemoVirtualSources`,
-  `EntityCategory=Master`, `PrimaryKey=EntityKey` -> `AxDataEntityViewKey[EntityKey]`
-  over `SourceCode` (natural key, **not** RecId), real `ViewMetadata` query over
-  `ConDemoVirtualSource`.
+## The writer gap the draft found is fixed
+
+The draft README recorded a TOOL_DEFECT: `d365fo_file(action="create",
+objectType="data-entity", ...)` produced an `AxDataEntityView` missing
+`<SourceCode>`, `<FieldGroups>` (incl. `AutoIdentification`),
+`<DeleteActions/>` and `<StateMachines/>` — present in 3236/3236 (and, per the
+current `dataEntityXml.ts` census, 5859/5859) shipped `AxDataEntityView`
+files. The build was green anyway because the deserializer defaults the
+missing elements, so the draft golden was kept unfrozen ("fix first, capture
+second").
+
+This is now fixed on server SHA `6257ed4` (`src/tools/dataEntityXml.ts`,
+`buildAxDataEntityXml`): an opt-in `properties.standardStructure: true` (also
+implied by passing `declaration`/`methods`/`fieldGroups`) emits the canonical
+`<SourceCode>` (class declaration + `<Methods />`), the five standard
+`<FieldGroups>` (`AutoReport`/`AutoLookup`/`AutoIdentification`/`AutoSummary`/
+`AutoBrowse`), `<DeleteActions />` and `<StateMachines />`. Verified live: the
+call
+
+```
+d365fo_file(action="create", objectType="data-entity", objectName="DemoVirtualSourceEntity",
+  properties={ primaryTable: "ConDemoVirtualSource", fields: [...], primaryKeyField: "SourceCode",
+    entityCategory: "Master", isPublic: true, publicEntityName: "ConDemoVirtualSource",
+    publicCollectionName: "ConDemoVirtualSources", label: "@TaxTransactionInquiry:HeaderNote",
+    standardStructure: true })
+```
+
+wrote `ConDemoVirtualSourceEntity.xml` with a full `<SourceCode>` block, all
+five `<FieldGroups>`, `<DeleteActions />` and `<StateMachines />` — read back
+from disk (`K:\AosService\PackagesLocalDirectory\Contoso\Contoso\AxDataEntityView\ConDemoVirtualSourceEntity.xml`)
+and confirmed byte-for-byte, not just trusted from the tool's own success
+message. This golden is the re-capture.
+
+## Artifacts captured (the case's `target_artifact_types`)
+
+- `ConDemoVirtualSource.metadata.xml` — `AxTable`, `TableGroup=Main`, label
+  `@TaxTransactionInquiry:HeaderNote`, `SourceCode` (EDT `Num`, mandatory) +
+  `Description` (EDT `Name`), unique alternate-key index `VirtualSourceIdx`
+  (`AlternateKey=Yes`, no `AllowDuplicates` = unique), `ReplacementKey=VirtualSourceIdx`.
+  Produced via `d365fo_file(action="create", objectType="table", ...)` +
+  `operation="add-index"` (`indexAlternateKey`/`indexAllowDuplicates` are the
+  correct parameter names — a first attempt with `alternateKey`/
+  `allowDuplicates` was silently ignored by the bridge, see below) +
+  `operation="modify-property"` for `ReplacementKey`.
+- `ConDemoVirtualSourceEntity.metadata.xml` — `AxDataEntityView`,
+  `IsPublic=Yes`, `PublicEntityName=ConDemoVirtualSource`,
+  `PublicCollectionName=ConDemoVirtualSources`, `EntityCategory=Master`,
+  `PrimaryKey=EntityKey` -> `AxDataEntityViewKey[EntityKey]` over `SourceCode`
+  (natural key, **not** RecId), real `ViewMetadata` query over
+  `ConDemoVirtualSource`, plus the standard-structure elements described above.
 
 ## Required companion NOT in this golden
 
-`AxSecurityPrivilege ConDemoVirtualSourceEntityMaintain` (DataEntityPermissions ->
-`ConDemoVirtualSourceEntity`, Grant CRUD = Allow). Without it xppbp raises the BP
-**error** `DataEntitySecurityPrivilegeCheck`, which the case instruction forbids.
-It is omitted here only because `AxSecurityPrivilege` is not in the case's
-`target_artifact_types`; a re-run must still create it.
+`AxSecurityPrivilege ConDemoVirtualSourceEntityMaintain` (`DataEntityPermissions`
+-> `ConDemoVirtualSourceEntity`, Grant CRUD = Allow, created via
+`d365fo_file(action="create", objectType="security-privilege",
+properties={ dataEntity: "ConDemoVirtualSourceEntity", accessLevel: "maintain" })`).
+Without it xppbp raises the BP **error** `DataEntitySecurityPrivilegeCheck`,
+which the case instruction forbids ("zero BP errors"). It is omitted here
+only because `AxSecurityPrivilege` is not in the case's `target_artifact_types`;
+a re-run must still create it.
 
-## Known deviations from standard-model shape (writer gap, see corpus record)
+## Minor tool friction found this run (not a scoring blocker)
 
-The generated AxDataEntityView omits `<SourceCode>` (entity class declaration),
-`<FieldGroups>` (incl. `AutoIdentification`), `<DeleteActions/>` and
-`<StateMachines/>` — all present in 3236/3236 AxDataEntityView files in
-ApplicationSuite/Foundation. The build is green because the deserializer defaults
-them. **This golden must be refreshed once that writer gap is fixed.**
+`d365fo_file(action="modify", operation="add-index", params={alternateKey,
+allowDuplicates})` accepted the call and reported success, but silently
+dropped both parameters with an explicit warning naming the correct keys
+(`indexAlternateKey`, `indexAllowDuplicates`) in the same response. The
+warning was accurate and actionable, so this is not a defect — the tool told
+the caller exactly what to fix — but the parameter-name mismatch itself
+(`alternateKey` vs `indexAlternateKey`) is worth aligning with
+`generate_object`'s own vocabulary (which uses bare `alternateKey`) to avoid
+the extra round trip.
 
-BP result at capture: 0 errors, 3 warnings attributable to this case
-(`BPErrorPrivilegeNotCoveredByDuty`, `BPErrorDeveloperDocumentationNotDefined`,
-`BPErrorTableMissingFormRef`) — all out of the case's declared scope.
+## Build / BP at capture (2026-08-03, SHA 6257ed4)
+
+- FULL build (`fullBuild: true`): **0 errors**, 1 unrelated warning (Commerce
+  PricingEngine external assembly not found — pre-existing, unrelated to this
+  case).
+- BP, filtered per object (`run_bp_check` with an explicit `targetFilter` +
+  `targetElementType` — the unfiltered call reports a false "BP Check passed"
+  with zero elements processed, do not trust it):
+  - `ConDemoVirtualSource` (table): 2 warnings, 0 errors —
+    `BPErrorDeveloperDocumentationNotDefined`, `BPErrorTableMissingFormRef` —
+    both out of the case's declared scope (same pattern warnings every
+    Demo table in this catalog carries).
+  - `ConDemoVirtualSourceEntity` (DataEntityView): **0 warnings, 0 errors** —
+    "1 elements processed."
+  - `ConDemoVirtualSourceEntityMaintain` (privilege, companion): 1 warning
+    (`BPErrorPrivilegeNotCoveredByDuty`), 0 errors.
+
+The case's own gate is "zero BP **errors**" — satisfied. `bp_clean` in the
+corpus score is `0` because that dimension counts *warnings* too; the residual
+2 warnings on the table are the same out-of-scope, pre-existing pattern
+warnings the frozen `L3-dmf-entity-import-slice` golden also carries, and
+this run is classified `PASS` on the same convention.
+
+## Descriptor
+
+No package added. `TaxTransactionInquiry` (label file for
+`@TaxTransactionInquiry:HeaderNote`) lives in **Foundation**, which `Contoso.xml`
+already references (same label already used by other Demo tables in this
+catalog).
+
+## Corpus record
+
+`eval/corpus/runs/2026-08-03T19__L2-virtual-entity-power-platform__6257ed4.json`


### PR DESCRIPTION
## Summary
- Re-ran eval case `L2-virtual-entity-power-platform` (Integration section, Power Platform / virtual entities leaf) on the VM. The AxDataEntityView writer gap that previously kept this golden as a draft (missing `<SourceCode>`, `<FieldGroups>`, `<DeleteActions/>`, `<StateMachines/>` — present in 3236/3236 real shipped entities) is confirmed fixed on `main` via the opt-in `properties.standardStructure: true` param on `d365fo_file(create, objectType="data-entity")`.
- Grounded tool path only: table + data entity (IsPublic=Yes, natural-field key, not RecId) + companion security privilege, all via `d365fo_file(create)`.
- Full build: 0 errors. Filtered BP check: 0 errors on the scored objects (AxTable, AxDataEntityView).
- Froze the real capture in place of the old draft, flipped `golden_pending: false`, wrote the corpus record, and regenerated `eval/COVERAGE.md`.
- Coverage: Integration 7/9 -> 8/9, total 73/78 -> 74/78 (94.9%).

## Test plan
- [x] `npm run eval:score` against the new golden — `golden_match: 1`, no structural deltas
- [x] Full VM build (`fullBuild: true`) — 0 errors
- [x] `run_bp_check` filtered to the scored objects — 0 errors
- [x] Sandbox rolled back (`undo_last_modification`), `.rnrproj` verified clean diskside
- [x] `npm run eval:coverage` regenerated `eval/COVERAGE.md` / `eval/coverage.json` / README badge

Corpus record: `eval/corpus/runs/2026-08-03T19__L2-virtual-entity-power-platform__6257ed4.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)