### PR TITLE
chore(release): v1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 1.8.0 in package.json and package-lock.json
- Covers work merged since v1.7.0: extension write coverage closes out across table/form/data-entity extensions (relation, index, field-group, enum-value, data-source, add-field fallbacks), label re-index and symbol-index resync fixes, and the eval loop reaching 78/78 (100%) case coverage

## Test plan
- [x] `npm run build` passes clean
- [x] `npx vitest run` — 2514 passed, 2 skipped; 2 timeouts in `extensions-security.test.ts` confirmed flaky/environment-dependent (pass in isolation), unrelated to this version-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)