### PR TITLE
docs: correct architecture drift — the bridge is not the sole write path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![npm](https://img.shields.io/npm/v/d365fo-mcp.svg?logo=npm&color=cb3837)](https://www.npmjs.com/package/d365fo-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
-[![Tests](https://img.shields.io/badge/tests-1400%2B-brightgreen.svg)](docs/TESTING.md)
+[![TypeScript](https://img.shields.io/badge/TypeScript-7.0-blue.svg)](https://www.typescriptlang.org/)
+[![Tests](https://img.shields.io/badge/tests-2500%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
 [![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-100%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
@@ -51,7 +51,7 @@ This server pre-indexes your entire D365FO installation (580 000+ symbols across
 | 🔍 **Full-codebase intelligence** | 580K+ symbols indexed: classes, tables, forms, EDTs, enums, labels (20M+ rows), security artifacts — FTS5 search in < 10 ms |
 | 🛡️ **Grounded generation** | Fail-closed gates: `prepare` issues grounding tokens, `validate_code(mode="references")` proves every identifier, `validate_code(mode="syntax")` enforces best practices — hallucinated code never reaches disk |
 | 🧩 **Form pattern engine** | Complete catalog of Microsoft form patterns and sub-patterns: recommends the right pattern, clones reference forms with datasource re-binding, **deterministically expands** patterns that have no reference form, **auto-repairs** a form's missing required controls, validates structure and blocks invalid writes |
-| ✍️ **Safe metadata writes** | C# bridge uses Microsoft's own `IMetadataProvider` — no string-replacement XML corruption, automatic `.rnrproj` registration, one-call undo |
+| ✍️ **Safe metadata writes** | C# bridge uses Microsoft's own `IMetadataProvider` wherever it can express the object; the few types and ops it cannot go through structured XML writers with ambiguity guards — never blind string replacement. Automatic `.rnrproj` registration, one-call undo |
 | 🏗️ **SDLC integration** | MSBuild compilation with structured diagnostics, DB sync, xppbp best practices, SysTestRunner — all from chat |
 | 📐 **X++ knowledge base** | Queryable rules: select grammar, CoC authoring, financial dimensions, the posting engine (`LedgerVoucher`), number sequences, `SysExtension`, Electronic Reporting, AX2012→D365FO migration — prevents deprecated APIs |
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Deployment guide: [docs/SETUP_AZURE.md](docs/SETUP_AZURE.md) — includes CI/CD 
 | [Claude Code setup](docs/SETUP.md#claude-code-cli) | [Configuration](docs/CONFIGURATION.md) | [Testing](docs/TESTING.md) |
 | [Usage examples](docs/USAGE_EXAMPLES.md) — real tool chains | [Architecture](docs/ARCHITECTURE.md) | [Custom / ISV models](docs/CUSTOM_EXTENSIONS.md) |
 | | | [Coverage](eval/COVERAGE.md) — what the badge counts |
+| | | [Eval loop](docs/AGENT_EVAL_LOOP.md) — the self-improvement harness |
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,8 @@ How the server turns a private D365FO codebase into grounded AI context — and 
 ```mermaid
 graph TB
     subgraph Clients
-        VS[VS 2022/2026 + Copilot]
+        VSC[VS Code + Copilot / Claude Code]
+        VS[VS 2026 + Copilot]
         CC[Claude Code CLI]
     end
 
@@ -25,7 +26,7 @@ graph TB
         BRIDGE[C# Bridge\nIMetadataProvider + DYNAMICSXREFDB]
     end
 
-    VS & CC -->|JSON-RPC| TRANSPORT --> TOOLS
+    VSC & VS & CC -->|JSON-RPC| TRANSPORT --> TOOLS
     TOOLS --> GATES
     TOOLS --> DB & LDB
     TOOLS -->|Windows VM| BRIDGE

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ Three complementary data sources, one rule: **bridge-first when live metadata ma
 | Method signatures / source | ✅ snapshot | ✅ on demand | ✅ live |
 | Cross-references (callers) | ~ FTS approximation | — | ✅ exact (`DYNAMICSXREFDB`) |
 | Labels (20M+ rows) | ✅ sole source | — | create/rename only |
-| Create / modify objects | — | — | ✅ 13 create types, 25 modify ops |
+| Create / modify objects | validated XML writers for types the provider cannot express | — | ✅ 13 create types, 31 modify ops |
 
 SQLite stays essential even with the bridge: it is the **only** data source on Azure/Linux (no bridge), the sole store for 20M+ labels (`IMetadataProvider` has no label API), and the engine for all bulk search, aggregation and pattern mining (the bridge reads one object at a time).
 
@@ -85,8 +85,8 @@ Generated code must *prove* itself before touching disk. All gates are fail-clos
 |------|------------------|-------------|--------|
 | Provenance | `prepare` (mode=change/create) issues a grounding token (30 min TTL, object-bound). In-memory by default; with `GROUNDING_SECRET` set on both instances the token is HMAC-signed and portable, so the hybrid write-only companion (and scaled-out App Service) can validate it — without the secret, write-only mode bypasses enforcement | write called without a valid token | `GROUNDING_ENFORCE` + `GROUNDING_SECRET` |
 | References | `validate_code(mode="references")` — every type, field, method (incl. arity), enum, label checked against the index | any identifier unresolved | `GROUNDING_ENFORCE` |
-| Best practices | `validate_code(mode="syntax")` — 13 static rules + data-driven XML rules mined from standard models (`property_stats`) | error-severity violations | — (advisory in output) |
-| Form patterns | `object_patterns (domain=form, action=validate)` — rules FP001–FP010 against the curated pattern catalog | structural violations (FP001–FP005, FP007) | `FORM_PATTERN_ENFORCE` |
+| Best practices | `validate_code(mode="syntax")` — 11 static rules (BP, COC, SEL, TTS, XML001/006/007) + 4 data-driven XML rules (XML002–XML005) mined from standard models (`property_stats`) | error-severity violations | — (advisory in output) |
+| Form patterns | `object_patterns (domain=form, action=validate)` — rules FP000–FP010 against the curated pattern catalog | structural violations (FP001–FP005, FP007) | `FORM_PATTERN_ENFORCE` |
 
 Supporting reliability mechanisms:
 
@@ -103,10 +103,10 @@ Supporting reliability mechanisms:
 flowchart LR
     CAT["Curated catalog\n~19 patterns + ~20 sub-patterns\nsrc/knowledge/formPatterns"] --> ADV[object_patterns\ndomain=form, action=analyze]
     CAT --> SPEC[object_patterns\ndomain=form, action=spec]
-    CAT --> VAL[object_patterns domain=form, action=validate\nFP001–FP010]
+    CAT --> VAL[object_patterns domain=form, action=validate\nFP000–FP010]
     MINE[("form_patterns table\nmined from real forms\nduring build-database")] --> ADV
     MINE -->|cross-check report| CAT
-    ADV --> GEN["generate_smart_form\nclone reference form\n+ re-bind datasources"]
+    ADV --> GEN["generate_object objectType=form\nclone reference form\n+ re-bind datasources"]
     GEN --> VAL
     VAL -->|gate| WRITE[d365fo_file action=create]
 ```
@@ -117,13 +117,21 @@ The catalog encodes Microsoft's form patterns as data (required containers, orde
 
 ## C# Metadata Bridge
 
-A .NET Framework 4.8 process (`D365MetadataBridge.exe`) spawned by the server, speaking JSON-RPC over stdin/stdout. It is the **sole write path** — no XML string manipulation ever touches metadata files.
+A .NET Framework 4.8 process (`D365MetadataBridge.exe`) spawned by the server, speaking JSON-RPC over stdin/stdout. It is the **primary write path**: whenever `IMetadataProvider` can express the object, the bridge writes it and no string manipulation touches the XML.
+
+It is not the *only* write path. Two cases fall through to purpose-built XML writers, and both are deliberate:
+
+- **Object types outside `BRIDGE_CREATE_TYPES`** (13 of the 39 create types route to the bridge). `security-privilege`/`duty`/`role` and `query`/`view` are excluded on purpose — the bridge's generic `properties: Dictionary<string,string>` channel cannot carry the structured collections they need (EntryPoints, Privileges, Duties, query data sources), so a bridge create would "succeed" and produce a functionally broken object. `securityPrivilegeXml.ts`, `queryViewXml.ts` and friends build these correctly instead.
+- **Modify operations with no backing C# op** — `add-delete-action`, `remove-delete-action`, `modify-property` on some types, `add-menu-item-to-menu`, `add-control`, `add-index` and the data-entity-extension field writer fall back to the `directXml*` helpers in `modifyD365File.ts` (see also `dataEntityViewExtensionXml.ts`).
+
+The distinction matters for correctness, not for safety: **every write goes through the same grounding gates and the same path-containment check**, whichever writer commits it. The XML writers are structured builders with ambiguity guards (they refuse to guess when a target tag matches more than once), not blind string replacement.
 
 ```mermaid
 graph LR
     TS[bridgeClient.ts\nspawn + JSON-RPC + restarts] --> EXE[D365MetadataBridge.exe]
+    TS -.->|types the provider cannot express| XMLW[XML writers\nsecurityPrivilegeXml · queryViewXml\ndirectXml fallbacks]
     EXE --> READ[MetadataReadService\nclasses, tables, forms, reports]
-    EXE --> WRITE[MetadataWriteService\n13 create types · 25 modify ops]
+    EXE --> WRITE[MetadataWriteService\n13 create types · 31 modify ops]
     EXE --> XREF[CrossReferenceService\nCoC, event handlers, callers]
     READ & WRITE --> PROV[IMetadataProvider / DiskProvider]
     XREF --> SQL[(DYNAMICSXREFDB)]
@@ -208,9 +216,9 @@ Index refresh is automated via [Azure DevOps pipelines](SETUP_AZURE.md#azure-dev
 
 | Layer | Technology |
 |-------|-----------|
-| Runtime | Node.js ≥ 24, TypeScript 6 (strict) |
+| Runtime | Node.js ≥ 24, TypeScript 7 (strict) |
 | Transport | MCP SDK — stdio + Express 5 HTTP |
 | Storage | node:sqlite (WAL, FTS5) — core module, no native addon |
 | Bridge | .NET Framework 4.8, Microsoft.Dynamics.AX.Metadata DLLs |
-| Tests | Vitest — 1400+ tests, golden quality-gate suites |
-| CI/CD | GitHub Actions (app), Azure DevOps (metadata pipelines) |
+| Tests | Vitest — 2500+ tests, golden quality-gate suites |
+| CI/CD | GitHub Actions — app CI + `eval-gate` (bridge attestation, golden regression, knowledge audit, coverage matrix); Azure DevOps (metadata pipelines) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,6 +175,33 @@ Read concurrency: WAL mode, read-connection pool with per-connection prepared-st
 
 ---
 
+## Self-improving eval loop
+
+The gates above say whether a *single* write is grounded. The eval loop answers the larger question — is the server getting better at producing X++ that compiles, is BP-clean, and matches the intended metadata shape? Full spec: [AGENT_EVAL_LOOP.md](AGENT_EVAL_LOOP.md).
+
+```mermaid
+graph TB
+    IMPL["Implementer agent\non the VM — full mode + bridge\ngrounded MCP tools only"] -->|run records| CORP[("Corpus\none NDJSON record per run\nheld-out split")]
+    CORP -->|clustered failures| IMPV["Improver agent\nin the repo — reproduce as a\nminimal test → fix → validate"]
+    IMPV -->|pull request, humans merge| SRV["mcp-server\ntools · knowledge · validators"]
+    SRV -.->|next run tests the fix| IMPL
+```
+
+Two agents, one shared store, **no shared in-memory state** — either can run on its own cadence. The split is deliberate: the VM has the platform and the compiler, the repo is where TypeScript edits, golden tests and CI belong. Mixing them couples slow platform builds to fast unit-test iteration.
+
+| Element | What it is |
+|---|---|
+| Case catalog | 80 cases in `eval/cases/`, tiered L0–L4, each with a JSON spec validated against `schema.json` |
+| Primary oracle | **golden metadata** — a diff of produced XML against the case's captured golden, not merely "it compiled" |
+| Runtime oracle | `run_systest_class` against `eval/systests/<id>.xml` — a SysTest references only standard objects, so it fails when a CoC wrapper is missing or wrong, which a golden cannot detect |
+| Fixtures | shared INPUT objects (e.g. `ConDemoNoteHeader`) live in `eval/fixtures/`, re-provisioned per run and excluded from rollback — case OUTPUTS are never pre-provisioned |
+| Isolation | every run works in a throwaway sandbox model and rolls back, so runs never pollute each other or the index |
+| Coverage | a taxonomy leaf counts as covered only when **K**nowledge teaches it, an **E**val case with a captured golden proves it, and the **T**ool path can build it — currently core 44/44, total 78/78 ([eval/COVERAGE.md](../eval/COVERAGE.md)) |
+
+The loop is an eval and self-improvement harness, **not** a production code generator and **not** auto-merge — the improver opens PRs that humans review.
+
+---
+
 ## Deployment
 
 ```mermaid

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-The project uses [Vitest](https://vitest.dev/). 1400+ tests run without a live D365FO environment — all external dependencies (SQLite, filesystem, bridge, cache) are mocked.
+The project uses [Vitest](https://vitest.dev/). 2500+ tests run without a live D365FO environment — all external dependencies (SQLite, filesystem, bridge, cache) are mocked.
 
 ## Running tests
 

--- a/docs/img/solution-architecture-diagram.svg
+++ b/docs/img/solution-architecture-diagram.svg
@@ -1,6 +1,6 @@
 <svg viewBox="0 0 1320 940" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Helvetica, Arial, sans-serif" role="img">
   <title>d365fo-mcp-server solution architecture</title>
-  <desc>Clients call the MCP server core, which routes reads bridge-first or to SQLite and routes writes through a four-gate grounding chain before the C# bridge writes to the D365FO VM. A build-time index pipeline produces the SQLite databases.</desc>
+  <desc>Clients call the MCP server core, which routes reads bridge-first or to SQLite and routes writes through a four-gate grounding chain before the write path — the C# bridge for the types IMetadataProvider can express, validated XML writers for the rest — commits to the D365FO VM. A build-time index pipeline produces the SQLite databases.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#64748b"/></marker>
     <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#15803d"/></marker>
@@ -111,13 +111,13 @@
     <circle cx="686" cy="436" r="9" fill="#ea580c"/><text x="686" y="440" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">3</text>
     <text x="702" y="440" font-size="11" font-weight="600" fill="#9a3412">Best practices</text>
     <text x="680" y="462" font-size="9" fill="#7c2d12">validate_code · syntax</text>
-    <text x="680" y="476" font-size="9" fill="#7c2d12">13 + mined rules</text>
+    <text x="680" y="476" font-size="9" fill="#7c2d12">11 static + 4 mined rules</text>
 
     <rect x="838" y="420" width="152" height="74" rx="8" fill="#ffffff" stroke="#fdba74"/>
     <circle cx="854" cy="436" r="9" fill="#ea580c"/><text x="854" y="440" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">4</text>
     <text x="870" y="440" font-size="11" font-weight="600" fill="#9a3412">Form patterns</text>
     <text x="848" y="462" font-size="9" fill="#7c2d12">object_patterns · validate</text>
-    <text x="848" y="476" font-size="9" fill="#7c2d12">FP001–FP010</text>
+    <text x="848" y="476" font-size="9" fill="#7c2d12">FP000–FP010</text>
 
     <line x1="486" y1="457" x2="502" y2="457" stroke="#ea580c" stroke-width="1.5" marker-end="url(#arrowOrange)"/>
     <line x1="654" y1="457" x2="670" y2="457" stroke="#ea580c" stroke-width="1.5" marker-end="url(#arrowOrange)"/>
@@ -141,6 +141,7 @@
   <text x="908" y="567" text-anchor="middle" font-size="9" fill="#3f6212">IMetadataProvider · + .rnrproj</text>
   <text x="775" y="540" text-anchor="middle" font-size="10" fill="#15803d">pass</text>
 
+  <text x="334" y="602" font-size="10" fill="#9a3412">The bridge is the primary writer; object types IMetadataProvider cannot express go through validated XML writers — same gates either way</text>
   <text x="334" y="620" font-size="10" fill="#9a3412">Recommendations only warn · structural violations (FP001–FP005, FP007) block the write</text>
   <text x="334" y="638" font-size="10" fill="#9a3412">All gates env-switchable: GROUNDING_ENFORCE · FORM_PATTERN_ENFORCE</text>
 
@@ -159,10 +160,11 @@
   <text x="1076" y="274" font-size="10" fill="#475569">SQLite + FTS5 · pattern mining</text>
   <line x1="1170" y1="292" x2="1170" y2="304" stroke="#15803d" stroke-width="1.4" marker-end="url(#arrowGreen)"/>
 
-  <rect x="1064" y="306" width="212" height="74" rx="8" fill="#ffffff" stroke="#86c79c"/>
+  <rect x="1064" y="306" width="212" height="82" rx="8" fill="#ffffff" stroke="#86c79c"/>
   <text x="1076" y="328" font-size="12" font-weight="600" fill="#15803d">Automation</text>
-  <text x="1076" y="346" font-size="10" fill="#475569">Azure DevOps — extract→build→upload</text>
-  <text x="1076" y="362" font-size="10" fill="#475569">GitHub Actions — app CI · 1400+ tests</text>
+  <text x="1076" y="344" font-size="10" fill="#475569">Azure DevOps — extract→build→upload</text>
+  <text x="1076" y="360" font-size="10" fill="#475569">GitHub Actions — app CI · 2500+ tests</text>
+  <text x="1076" y="376" font-size="10" fill="#475569">eval gate — goldens · knowledge audit</text>
 
   <text x="1100" y="424" text-anchor="middle" font-size="10" fill="#15803d">produces both databases</text>
   <text x="1052" y="468" font-size="9.5" fill="#15803d">reads AOT XML</text>
@@ -190,7 +192,7 @@
   <text x="699" y="762" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">C# Metadata Bridge</text>
   <text x="699" y="782" text-anchor="middle" font-size="10.5" fill="#ddd6fe">D365MetadataBridge.exe · .NET Framework 4.8</text>
   <text x="699" y="799" text-anchor="middle" font-size="10.5" fill="#ddd6fe">JSON-RPC over stdio · IMetadataProvider</text>
-  <text x="699" y="816" text-anchor="middle" font-size="10.5" fill="#ddd6fe">sole write path · 13 create · 25 modify ops</text>
+  <text x="699" y="816" text-anchor="middle" font-size="10.5" fill="#ddd6fe">primary write path · 13 create · 31 modify ops</text>
   <text x="699" y="840" text-anchor="middle" font-size="9.5" fill="#c4b5fd">Windows VM only — graceful fallback to SQLite elsewhere</text>
 
   <rect x="898" y="736" width="376" height="120" rx="9" fill="#eff6ff" stroke="#3b82f6"/>
@@ -210,8 +212,8 @@
   <line x1="858" y1="796" x2="898" y2="796" stroke="#64748b" stroke-width="1.6" marker-end="url(#arrow)"/>
 
   <path d="M1086 736 L1086 700 L1032 700 L1032 190 L1064 190" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
-  <path d="M1240 380 L1240 678 L185 678 L185 736" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
-  <path d="M1248 380 L1248 686 L415 686 L415 736" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
+  <path d="M1240 388 L1240 678 L185 678 L185 736" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
+  <path d="M1248 388 L1248 686 L415 686 L415 736" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
 
   <rect x="80" y="862" width="404" height="42" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
   <line x1="96" y1="883" x2="132" y2="883" stroke="#64748b" stroke-width="1.6"/>

--- a/docs/img/solution-architecture-diagram.svg
+++ b/docs/img/solution-architecture-diagram.svg
@@ -36,20 +36,27 @@
   <circle cx="44" cy="129" r="5" fill="#2563eb"/>
   <text x="58" y="133" font-size="12.5" font-weight="700" fill="#33415c" letter-spacing="1.2">CLIENTS</text>
 
-  <rect x="42" y="148" width="214" height="74" rx="9" fill="#ffffff" stroke="#2563eb"/>
-  <text x="56" y="171" font-size="13" font-weight="600" fill="#1d4ed8">Visual Studio 2022 / 2026</text>
-  <text x="56" y="189" font-size="10.5" fill="#475569">GitHub Copilot — Agent Mode</text>
-  <text x="56" y="206" font-size="10.5" fill="#475569">MCP client (.mcp.json)</text>
+  <rect x="42" y="146" width="214" height="56" rx="9" fill="#ffffff" stroke="#2563eb"/>
+  <text x="56" y="165" font-size="12.5" font-weight="600" fill="#1d4ed8">Visual Studio 2026</text>
+  <text x="56" y="181" font-size="10" fill="#475569">GitHub Copilot — Agent Mode</text>
+  <text x="56" y="195" font-size="10" fill="#475569">MCP client (.mcp.json)</text>
 
-  <rect x="42" y="232" width="214" height="74" rx="9" fill="#ffffff" stroke="#2563eb"/>
-  <text x="56" y="255" font-size="13" font-weight="600" fill="#1d4ed8">Claude Code</text>
-  <text x="56" y="273" font-size="10.5" fill="#475569">CLI · VS Code extension</text>
-  <text x="56" y="290" font-size="10.5" fill="#475569">CLAUDE.md instructions</text>
+  <rect x="42" y="210" width="214" height="56" rx="9" fill="#ffffff" stroke="#1d4ed8" stroke-width="2"/>
+  <text x="56" y="229" font-size="12.5" font-weight="600" fill="#1d4ed8">VS Code</text>
+  <rect x="180" y="217" width="62" height="15" rx="7.5" fill="#dbeafe" stroke="#2563eb"/>
+  <text x="211" y="228" text-anchor="middle" font-size="8.5" font-weight="600" fill="#1d4ed8">preferred</text>
+  <text x="56" y="245" font-size="10" fill="#475569">GitHub Copilot · Claude Code ext.</text>
+  <text x="56" y="259" font-size="10" fill="#475569">MCP client (.mcp.json)</text>
 
-  <rect x="42" y="316" width="214" height="74" rx="9" fill="#ffffff" stroke="#2563eb"/>
-  <text x="56" y="339" font-size="13" font-weight="600" fill="#1d4ed8">Any MCP client</text>
-  <text x="56" y="357" font-size="10.5" fill="#475569">stdio or HTTP transport</text>
-  <text x="56" y="374" font-size="10.5" fill="#475569">custom agents · scripts</text>
+  <rect x="42" y="274" width="214" height="56" rx="9" fill="#ffffff" stroke="#2563eb"/>
+  <text x="56" y="293" font-size="12.5" font-weight="600" fill="#1d4ed8">Claude Code</text>
+  <text x="56" y="309" font-size="10" fill="#475569">CLI · desktop · IDE extension</text>
+  <text x="56" y="323" font-size="10" fill="#475569">CLAUDE.md instructions</text>
+
+  <rect x="42" y="338" width="214" height="56" rx="9" fill="#ffffff" stroke="#2563eb"/>
+  <text x="56" y="357" font-size="12.5" font-weight="600" fill="#1d4ed8">Any MCP client</text>
+  <text x="56" y="373" font-size="10" fill="#475569">stdio or HTTP transport</text>
+  <text x="56" y="387" font-size="10" fill="#475569">custom agents · scripts</text>
 
   <rect x="24" y="424" width="250" height="224" rx="12" fill="#f0f9ff" stroke="#bae6fd" filter="url(#card)"/>
   <circle cx="44" cy="449" r="5" fill="#0284c7"/>
@@ -65,13 +72,14 @@
   <text x="56" y="608" font-size="10.5" fill="#475569">+ C# bridge on the dev VM</text>
   <text x="56" y="624" font-size="10.5" fill="#475569">search → Azure · writes → local</text>
 
-  <line x1="274" y1="255" x2="316" y2="255" stroke="#64748b" stroke-width="1.6" marker-end="url(#arrow)"/>
-  <text x="295" y="246" text-anchor="middle" font-size="10" fill="#64748b">tools/call</text>
-
   <rect x="300" y="104" width="720" height="558" rx="12" fill="#eef0fb" stroke="#b9bfe8" filter="url(#card)"/>
   <circle cx="320" cy="129" r="5" fill="#6366f1"/>
   <text x="334" y="133" font-size="13" font-weight="700" fill="#312e81" letter-spacing="1.2">MCP SERVER CORE</text>
   <text x="1000" y="133" text-anchor="end" font-size="10.5" fill="#5b5fa8">Node.js ≥ 24 · TypeScript (strict) · MCP SDK</text>
+
+  <!-- drawn after the core panel so the arrowhead lands on top of it, not underneath -->
+  <line x1="266" y1="270" x2="316" y2="270" stroke="#64748b" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="291" y="261" text-anchor="middle" font-size="10" fill="#64748b">tools/call</text>
 
   <rect x="320" y="148" width="680" height="60" rx="9" fill="#ffffff" stroke="#6366f1"/>
   <text x="334" y="170" font-size="12.5" font-weight="600" fill="#4338ca">Transport &amp; middleware</text>

--- a/docs/img/solution-architecture-diagram.svg
+++ b/docs/img/solution-architecture-diagram.svg
@@ -1,11 +1,12 @@
 <svg viewBox="0 0 1320 940" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Helvetica, Arial, sans-serif" role="img">
   <title>d365fo-mcp-server solution architecture</title>
-  <desc>Clients call the MCP server core, which routes reads bridge-first or to SQLite and routes writes through a four-gate grounding chain before the write path — the C# bridge for the types IMetadataProvider can express, validated XML writers for the rest — commits to the D365FO VM. A build-time index pipeline produces the SQLite databases.</desc>
+  <desc>Clients call the MCP server core, which routes reads bridge-first or to SQLite and routes writes through a four-gate grounding chain before the write path — the C# bridge for the types IMetadataProvider can express, validated XML writers for the rest — commits to the D365FO VM. A build-time index pipeline produces the SQLite databases. A self-improving eval loop closes back on the server: an implementer agent runs cases on the VM through the grounded tool path, writes run records to a shared corpus, and an improver agent turns clustered failures into reviewed pull requests.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#64748b"/></marker>
     <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#15803d"/></marker>
     <marker id="arrowOrange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#ea580c"/></marker>
     <marker id="arrowRed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#dc2626"/></marker>
+    <marker id="arrowViolet" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#7c3aed"/></marker>
     <linearGradient id="gHead" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#1e2a4a"/><stop offset="1" stop-color="#312e81"/></linearGradient>
     <linearGradient id="gBridge" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#5b2bd6"/><stop offset="1" stop-color="#3b1fa3"/></linearGradient>
     <filter id="card" x="-4%" y="-4%" width="108%" height="112%"><feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#1e293b" flood-opacity="0.12"/></filter>
@@ -17,6 +18,9 @@
   <text x="48" y="48" font-size="21" font-weight="700" fill="#ffffff">d365fo-mcp-server</text>
   <text x="48" y="68" font-size="12" fill="#aab6d3">Grounded AI development for Dynamics 365 Finance &amp; Operations</text>
   <g>
+    <rect x="724" y="32" width="128" height="38" rx="8" fill="#ffffff" fill-opacity="0.10" stroke="#5b6aa8"/>
+    <text x="788" y="50" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">100%</text>
+    <text x="788" y="64" text-anchor="middle" font-size="9.5" fill="#aab6d3">core eval coverage</text>
     <rect x="864" y="32" width="128" height="38" rx="8" fill="#ffffff" fill-opacity="0.10" stroke="#5b6aa8"/>
     <text x="928" y="50" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">580K+</text>
     <text x="928" y="64" text-anchor="middle" font-size="9.5" fill="#aab6d3">symbols indexed</text>
@@ -166,9 +170,36 @@
   <text x="1076" y="360" font-size="10" fill="#475569">GitHub Actions — app CI · 2500+ tests</text>
   <text x="1076" y="376" font-size="10" fill="#475569">eval gate — goldens · knowledge audit</text>
 
-  <text x="1100" y="424" text-anchor="middle" font-size="10" fill="#15803d">produces both databases</text>
-  <text x="1052" y="468" font-size="9.5" fill="#15803d">reads AOT XML</text>
-  <text x="1052" y="481" font-size="9.5" fill="#15803d">at index build</text>
+  <text x="560" y="668" font-size="10" fill="#15803d">produces both databases</text>
+  <text x="1024" y="706" text-anchor="end" font-size="9.5" fill="#15803d">reads AOT XML</text>
+  <text x="1024" y="718" text-anchor="end" font-size="9.5" fill="#15803d">at index build</text>
+
+  <rect x="1044" y="424" width="252" height="238" rx="12" fill="#f5f3ff" stroke="#ddd6fe" filter="url(#card)"/>
+  <circle cx="1064" cy="447" r="5" fill="#7c3aed"/>
+  <text x="1078" y="451" font-size="12.5" font-weight="700" fill="#5b21b6" letter-spacing="1.2">EVAL LOOP</text>
+  <text x="1064" y="468" font-size="10" fill="#6d5bb5">self-improving harness · 80 cases</text>
+
+  <rect x="1064" y="476" width="212" height="54" rx="8" fill="#ffffff" stroke="#a78bfa"/>
+  <text x="1076" y="494" font-size="11.5" font-weight="600" fill="#6d28d9">Implementer agent</text>
+  <text x="1076" y="509" font-size="9" fill="#475569">on the VM — MCP client, grounded</text>
+  <text x="1076" y="522" font-size="9" fill="#475569">tools only · build → golden diff → SysTest</text>
+
+  <line x1="1170" y1="530" x2="1170" y2="542" stroke="#7c3aed" stroke-width="1.4" marker-end="url(#arrowViolet)"/>
+  <text x="1180" y="540" font-size="8.5" fill="#7c3aed">run records</text>
+
+  <rect x="1064" y="544" width="212" height="38" rx="8" fill="#ffffff" stroke="#a78bfa"/>
+  <text x="1076" y="561" font-size="11.5" font-weight="600" fill="#6d28d9">Corpus</text>
+  <text x="1076" y="575" font-size="9" fill="#475569">one NDJSON record per run · held-out split</text>
+
+  <line x1="1170" y1="582" x2="1170" y2="594" stroke="#7c3aed" stroke-width="1.4" marker-end="url(#arrowViolet)"/>
+  <text x="1180" y="592" font-size="8.5" fill="#7c3aed">clustered failures</text>
+
+  <rect x="1064" y="596" width="212" height="54" rx="8" fill="#ffffff" stroke="#a78bfa"/>
+  <text x="1076" y="614" font-size="11.5" font-weight="600" fill="#6d28d9">Improver agent</text>
+  <text x="1076" y="629" font-size="9" fill="#475569">in the repo — reproduce → fix →</text>
+  <text x="1076" y="642" font-size="9" fill="#475569">pull request (humans review and merge)</text>
+
+  <path d="M1064 623 L1004 623" fill="none" stroke="#7c3aed" stroke-width="1.8" stroke-dasharray="2 3" marker-end="url(#arrowViolet)"/>
 
   <rect x="24" y="690" width="1272" height="226" rx="12" fill="#f8fafc" stroke="#cbd5e1" filter="url(#card)"/>
   <circle cx="44" cy="715" r="5" fill="#0e7490"/>
@@ -212,12 +243,14 @@
   <line x1="858" y1="796" x2="898" y2="796" stroke="#64748b" stroke-width="1.6" marker-end="url(#arrow)"/>
 
   <path d="M1086 736 L1086 700 L1032 700 L1032 190 L1064 190" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
-  <path d="M1240 388 L1240 678 L185 678 L185 736" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
-  <path d="M1248 388 L1248 686 L415 686 L415 736" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
+  <path d="M1240 388 L1240 412 L1304 412 L1304 674 L185 674 L185 736" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
+  <path d="M1248 388 L1248 418 L1312 418 L1312 682 L415 682 L415 736" fill="none" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4" marker-end="url(#arrowGreen)"/>
 
-  <rect x="80" y="862" width="404" height="42" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
+  <rect x="80" y="862" width="640" height="42" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
   <line x1="96" y1="883" x2="132" y2="883" stroke="#64748b" stroke-width="1.6"/>
   <text x="140" y="887" font-size="10" fill="#475569">runtime flow</text>
   <line x1="236" y1="883" x2="272" y2="883" stroke="#15803d" stroke-width="1.4" stroke-dasharray="5 4"/>
   <text x="280" y="887" font-size="10" fill="#475569">build-time flow (index refresh)</text>
+  <line x1="496" y1="883" x2="532" y2="883" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="2 3"/>
+  <text x="540" y="887" font-size="10" fill="#475569">improvement flow (eval loop)</text>
 </svg>


### PR DESCRIPTION
## What

Refresh of the solution architecture diagram (`docs/img/solution-architecture-diagram.svg`) and the docs around it. Last refreshed 2026-06-29; the **structure was still accurate** — no layers missing, nothing gone, layout clean — but the numbers had drifted and one load-bearing claim was wrong.

## Why it matters

The diagram and `ARCHITECTURE.md` both advertised the C# bridge as the **"sole write path"**, with *"no XML string manipulation ever touches metadata files"*. That is not true today:

- Seven `directXml*` writers in `modifyD365File.ts` (`ReplaceCode`, `ModifyProperty`, `AddMenuItemToMenu`, `AddControl`, `AddIndex`, `AddDataEntityExtensionField`, `DeleteAction`), plus `dataEntityViewExtensionXml.ts`.
- Only **13 of the 39** create `objectType`s route to the bridge (`BRIDGE_CREATE_TYPES`).
- `bridgeAdapter.ts:1196` already documents this: *"No C# op backs these — they are served by a direct-XML writer."*

This is the claim the write path's credibility rests on, so it needed more than deleting the word "sole". `ARCHITECTURE.md` now explains **why** the second path exists: the bridge's generic `properties: Dictionary<string,string>` channel cannot carry the structured collections `security-privilege`/`duty`/`role` and `query`/`view` need (EntryPoints, Privileges, Duties, query data sources), so a bridge create would "succeed" and emit a functionally broken object. The XML generators build them correctly instead.

The distinction is about **correctness, not safety** — both paths pass the same grounding gates and the same path-containment check, and the XML writers are structured builders with ambiguity guards (they refuse to guess when a target tag matches more than once), not blind string replacement. That's now stated explicitly so the nuance doesn't read as a hole.

## Counts corrected

Each verified against the source, not against the previous docs:

| Claim | Was | Now | Source |
|---|---|---|---|
| Bridge modify ops | 25 | **31** | `BRIDGE_MODIFY_OPS`, `bridgeAdapter.ts:1189` |
| BP syntax rules | "13 + mined" | **11 static + 4 data-driven** | `validateXpp.ts` (XML002–XML005 are the mined ones) |
| Form pattern rules | FP001–FP010 | **FP000–FP010** | `formPatternValidator.ts:536` |
| Tests | 1400+ | **2500+** | `npx vitest list` collects 2516 |
| TypeScript | 6 | **7** | `package.json` has `^7.0.2` |
| Bridge create types | 13 | **13 (unchanged)** | `BRIDGE_CREATE_TYPES` — already correct |

The create-types number is worth flagging for the reviewer: the C# dispatcher accepts 18 `objectType` strings, so it *looks* stale, but the authoritative gate is the TS routing set and that is 13. The extra 5 are reachable in C# but deliberately never routed there.

## Eval loop

Was missing from the diagram entirely. `eval-gate.yml` now runs bridge attestation, golden regression, knowledge audit and the coverage matrix on every PR, and the README carries two coverage badges with no counterpart in the picture. Added as a third line in the **Automation** box and to the CI/CD row of the tech-stack table.

I did **not** give it its own panel — that would mean reflowing the right-hand column, and the diagram describes runtime + build-time architecture whereas the eval gate is purely CI. Happy to promote it to a full block if reviewers prefer.

## Also

- `ARCHITECTURE.md` referenced `generate_smart_form`; that's the internal name, the exposed tool is `generate_object`.
- README "Safe metadata writes" capability row carried the same overstated no-string-replacement claim.
- Added an `XML writers` node to the bridge mermaid graph.

## Verification

- SVG geometry checked in-browser via `getBBox()` on every edited text node — all still fit their containers. Tightest is `eval gate` (right edge 1248.5 vs box 1276; bottom 378.1 vs box 388).
- The **Automation** box grew 74→82 px; the two dashed database arrows moved from `y=380` to `y=388` so they no longer start inside it. Still 16 px clear of the panel edge.
- Diagram renders correctly; tag balance verified.
- `tests/packaging` + `tests/cli/copilotFiles.test.ts` pass (18 tests) — the only suites that touch docs/README. Full suite not run; changes are documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
