### PR TITLE
fix(bridge): close single-op RPC dispatch gaps left by PR #804

### DIFF
--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -535,6 +535,53 @@ namespace D365MetadataBridge.Protocol
                             return _writeService!.RemoveIndex(tableName, indexName);
                         });
 
+                    // This is the single-op RPC that BridgeClient.addFullTextIndex()/
+                    // addTableMapping() actually call — it must carry the same four cases
+                    // HandleBatchModify() has below, or every real request dies with
+                    // "-32601 Unknown method" no matter how correct the C# write path is.
+                    case "addfulltextindex":
+                        return HandleWrite(request, () =>
+                        {
+                            var tableName = request.GetStringParam("objectName")
+                                ?? throw new ArgumentException("Missing: objectName");
+                            var indexName = request.GetStringParam("indexName")
+                                ?? throw new ArgumentException("Missing: indexName");
+                            return _writeService!.AddFullTextIndex(tableName, indexName,
+                                request.GetParam<System.Collections.Generic.List<string>>("fields"));
+                        });
+
+                    case "removefulltextindex":
+                        return HandleWrite(request, () =>
+                        {
+                            var tableName = request.GetStringParam("objectName")
+                                ?? throw new ArgumentException("Missing: objectName");
+                            var indexName = request.GetStringParam("indexName")
+                                ?? throw new ArgumentException("Missing: indexName");
+                            return _writeService!.RemoveFullTextIndex(tableName, indexName);
+                        });
+
+                    case "addtablemapping":
+                        return HandleWrite(request, () =>
+                        {
+                            var tableName = request.GetStringParam("objectName")
+                                ?? throw new ArgumentException("Missing: objectName");
+                            var mapName = request.GetStringParam("mapName")
+                                ?? throw new ArgumentException("Missing: mapName");
+                            return _writeService!.AddTableMapping(tableName, mapName,
+                                request.GetStringParam("mappingTable"),
+                                request.GetParam<System.Collections.Generic.List<WriteMappingConnection>>("connections"));
+                        });
+
+                    case "removetablemapping":
+                        return HandleWrite(request, () =>
+                        {
+                            var tableName = request.GetStringParam("objectName")
+                                ?? throw new ArgumentException("Missing: objectName");
+                            var mapName = request.GetStringParam("mapName")
+                                ?? throw new ArgumentException("Missing: mapName");
+                            return _writeService!.RemoveTableMapping(tableName, mapName);
+                        });
+
                     case "addrelation":
                         return HandleWrite(request, () =>
                         {
@@ -595,7 +642,12 @@ namespace D365MetadataBridge.Protocol
                                 ?? throw new ArgumentException("Missing: fieldGroupName");
                             var fieldName = request.GetStringParam("fieldName")
                                 ?? throw new ArgumentException("Missing: fieldName");
-                            return _writeService!.AddFieldToFieldGroup(tableName, groupName, fieldName);
+                            // This is the single-op RPC BridgeClient.addFieldToFieldGroup() actually
+                            // calls — dropping extendBaseFieldGroup here silently reverts every
+                            // caller to the extension-owns-the-group path (see HandleBatchModify()
+                            // below, which forwards it correctly).
+                            return _writeService!.AddFieldToFieldGroup(tableName, groupName, fieldName,
+                                request.GetBoolParam("extendBaseFieldGroup") ?? false);
                         });
 
                     case "modifyfield":

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "52c4cf8b8fad27e6cee175c52f19de2c7661ce1d31626cca0fc62d613aa819af",
+  "sourceHash": "f6da40c4b39c39c05833f9ec284084794319f5f51b68d6a798db460783700b7c",
   "sourceFileCount": 9,
   "metamodelFileVersion": "7.0.7858.27",
-  "builtAt": "2026-08-03T17:44:01.463Z"
+  "builtAt": "2026-08-04T05:49:49.967Z"
 }

--- a/tests/bridge/fullTextIndexTableMappingDispatchParity.test.ts
+++ b/tests/bridge/fullTextIndexTableMappingDispatchParity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression test — C# bridge dispatch parity for the ops PR #804 added.
+ *
+ * RequestDispatcher.cs dispatches every write op from TWO places:
+ *
+ *   1. the single-op RPC arm in Dispatch() — this is the one BridgeClient.<op>()
+ *      actually calls, and therefore the one every real d365fo_file modify request
+ *      goes through;
+ *   2. the corresponding arm inside HandleBatchModify().
+ *
+ * PR #804 added `add-full-text-index` / `remove-full-text-index` /
+ * `add-table-mapping` / `remove-table-mapping` to (2) only. (1) had no case for
+ * any of the four at all, so BridgeClient.addFullTextIndex() etc. — which call
+ * Dispatch() directly, not HandleBatchModify() — died with "-32601 Unknown
+ * method" on every real call, despite the ops being fully implemented in
+ * MetadataWriteService and advertised as supported in the tool schema.
+ *
+ * The same PR also added `extendBaseFieldGroup` to `AddFieldToFieldGroup`, and
+ * forwarded it in (2) but not (1): BridgeClient.addFieldToFieldGroup() — which
+ * also goes through Dispatch() — silently dropped the flag, so a caller passing
+ * extendBaseFieldGroup=true always got the "extension owns the group" behaviour
+ * and a confusing error telling them to pass the flag they already passed.
+ *
+ * Repo tests could not catch either defect — they mock BridgeClient, so they
+ * assert the arguments Node SENDS, never the ones C# READS (or whether C# has a
+ * route for the method name at all). This is the cheap standing guard.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DISPATCHER_CS = path.join(
+  path.resolve(__dirname, '..', '..'),
+  'bridge', 'D365MetadataBridge', 'Protocol', 'RequestDispatcher.cs',
+);
+
+let source: string;
+
+/**
+ * Slices the body of a `case "<name>":` arm — up to the next case label that
+ * starts a DIFFERENT arm. Consecutive fall-through labels (e.g.
+ * `case "addfulltextindex":` immediately followed by `case "add-full-text-index":`)
+ * share one body, so they are skipped rather than treated as the end.
+ */
+function caseBody(from: number): string {
+  let cursor = from;
+  for (;;) {
+    const next = source.indexOf('case "', cursor + 1);
+    if (next === -1) return source.slice(from);
+    if (/^\s*$/.test(source.slice(source.indexOf(':', cursor) + 1, next))) {
+      cursor = next;
+      continue;
+    }
+    return source.slice(from, next);
+  }
+}
+
+/** Both occurrences of `case "<op>":` — [Dispatch() single-op body, HandleBatchModify() body]. */
+function bothSites(op: string): [string, string] {
+  const first = source.indexOf(`case "${op}":`);
+  expect(first, `no dispatch site found for '${op}'`).toBeGreaterThanOrEqual(0);
+  const second = source.indexOf(`case "${op}":`, first + 1);
+  expect(
+    second,
+    `'${op}' has only ONE dispatch site — expected the single-op RPC arm in ` +
+      `Dispatch() plus the arm in HandleBatchModify()`,
+  ).toBeGreaterThan(first);
+  return [caseBody(first), caseBody(second)];
+}
+
+describe('bridge dispatch parity — full-text-index / table-mapping / extendBaseFieldGroup', () => {
+  beforeAll(() => {
+    source = fs.readFileSync(DISPATCHER_CS, 'utf8');
+  });
+
+  it.each([
+    'addfulltextindex',
+    'removefulltextindex',
+    'addtablemapping',
+    'removetablemapping',
+  ])('dispatches %s from exactly the two known sites', (op) => {
+    const sites = source.match(new RegExp(`case "${op}":`, 'g')) ?? [];
+    expect(
+      sites.length,
+      `'${op}' must be reachable from Dispatch() (single-op RPC) AND HandleBatchModify() — ` +
+        `found ${sites.length} site(s). If this is 1, the single-op RPC that BridgeClient ` +
+        `actually calls has no route and every real request fails with "Unknown method".`,
+    ).toBe(2);
+  });
+
+  it('forwards indexName + fields on both addFullTextIndex dispatch sites', () => {
+    const [single, batch] = bothSites('addfulltextindex');
+    expect(single).toContain('GetStringParam("indexName")');
+    expect(single).toMatch(/GetParam<[^>]*List<string>[^>]*>\("fields"\)/);
+    expect(batch).toContain('S("indexName")');
+    expect(batch).toMatch(/GetTypedParam<[^>]*List<string>[^>]*>\("fields"\)/);
+  });
+
+  it('forwards indexName on both removeFullTextIndex dispatch sites', () => {
+    const [single, batch] = bothSites('removefulltextindex');
+    expect(single).toContain('GetStringParam("indexName")');
+    expect(batch).toContain('S("indexName")');
+  });
+
+  it('forwards mapName + mappingTable + connections on both addTableMapping dispatch sites', () => {
+    const [single, batch] = bothSites('addtablemapping');
+    expect(single).toContain('GetStringParam("mapName")');
+    expect(single).toContain('GetStringParam("mappingTable")');
+    expect(single).toMatch(/GetParam<[^>]*List<WriteMappingConnection>[^>]*>\("connections"\)/);
+    expect(batch).toContain('S("mapName")');
+    expect(batch).toContain('S("mappingTable")');
+    expect(batch).toMatch(/GetTypedParam<[^>]*List<WriteMappingConnection>[^>]*>\("connections"\)/);
+  });
+
+  it('forwards mapName on both removeTableMapping dispatch sites', () => {
+    const [single, batch] = bothSites('removetablemapping');
+    expect(single).toContain('GetStringParam("mapName")');
+    expect(batch).toContain('S("mapName")');
+  });
+
+  it('forwards extendBaseFieldGroup on both addFieldToFieldGroup dispatch sites', () => {
+    const [single, batch] = bothSites('addfieldtofieldgroup');
+    expect(
+      single,
+      'single-op addFieldToFieldGroup drops extendBaseFieldGroup — a caller extending a ' +
+        'base-table field group always gets the "extension owns the group" behaviour instead',
+    ).toContain('GetBoolParam("extendBaseFieldGroup")');
+    expect(batch).toContain('B("extendBaseFieldGroup")');
+  });
+});


### PR DESCRIPTION
## Summary

Auditing merged PR #804 (found while separately auditing #800) turned up two instances of the exact defect class #804 itself was largely about fixing: a write op patched on only ONE of `RequestDispatcher.cs`'s two dispatch sites.

`RequestDispatcher.cs` dispatches write ops from two places:
1. the single-op RPC arm in `Dispatch()` — reads params via `request.GetStringParam("x")`; this is what `BridgeClient.<op>()` and therefore every real `d365fo_file` modify request actually calls.
2. the arm inside `HandleBatchModify()` — reads params via the local `S("x")`/`B("x")` helpers; only used for genuine multi-op batch requests.

**Finding 1 — four ops with zero single-op route.** `add-full-text-index` / `remove-full-text-index` / `add-table-mapping` / `remove-table-mapping` were added to `HandleBatchModify()` only. `Dispatch()` had no `case` for any of them at all — `BridgeClient.addFullTextIndex()` etc. call `Dispatch()` directly, so every real invocation fell to `default:` and died with `-32601 Unknown method`, despite the ops being fully implemented in `MetadataWriteService` and fully advertised as supported in the tool schema (`d365foFileOpSpecs.ts`, `canBridgeModify()`). No XML fallback exists for these ops, so this was a hard, guaranteed failure, not silent corruption — but the feature was 100% non-functional since #804 merged.

**Finding 2 — a parameter silently dropped.** `AddFieldToFieldGroup`'s new `extendBaseFieldGroup` parameter was forwarded on the batch arm but not on `Dispatch()`'s single-op arm, which kept calling the 3-argument overload. Every real call defaulted to `false`, silently reverting to the "extension owns the group" behaviour and throwing an error that (confusingly) told the caller to pass a flag they had already passed.

`tests/bridge/canBridgeModify.test.ts` (added by #804) could not catch either — it only asserts the TS-side allowlist, never talks to the real C# dispatcher, matching the exact blind spot this defect class always has: repo tests mock `BridgeClient`, so they assert what Node sends, never what C# actually routes.

## Fix

- `RequestDispatcher.cs`: added the missing `case "addfulltextindex"` / `"removefulltextindex"` / `"addtablemapping"` / `"removetablemapping"` arms to `Dispatch()`, mirroring the batch arm's parameter extraction.
- `RequestDispatcher.cs`: `case "addfieldtofieldgroup"` in `Dispatch()` now forwards `extendBaseFieldGroup` via `request.GetBoolParam(...)`.
- New `tests/bridge/fullTextIndexTableMappingDispatchParity.test.ts`, following the existing `addFieldDispatchParity.test.ts` template — asserts both dispatch sites exist and forward the same parameters for each of the five affected ops.

## Test plan

- [x] `npm run bridge:build` (`--no-incremental`, scratch output) — compiles clean against metamodel `7.0.7858.27` on the D365FO dev VM; `bridge/build-attestation.json` regenerated.
- [x] `npm run bridge:attest` — sources match the attestation.
- [x] New parity test verified BOTH ways: `git stash` on `RequestDispatcher.cs` reproduces all 9 failures at exactly the expected assertions (missing case / dropped param), `stash pop` + fix passes all 9.
- [x] `npx vitest run tests/bridge/` — 10 files, 64 tests, all pass.
- [x] `npm run build` — clean TypeScript build, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)