### PR TITLE
fix: auth bypass from config load order, three scanning queries, and no shutdown path

### DIFF
--- a/scripts/azure-blob-manager.ts
+++ b/scripts/azure-blob-manager.ts
@@ -5,8 +5,8 @@
 
 console.log('📦 Loading azure-blob-manager.ts...');
 
-import { loadEnv } from '../src/utils/loadEnv.js';
-loadEnv(import.meta.url);
+// Load configuration onto process.env — MUST stay the first import (see src/bootstrapEnv.ts).
+import '../src/bootstrapEnv.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { BlobServiceClient, ContainerClient } from '@azure/storage-blob';

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -3,8 +3,8 @@
  * Builds SQLite database from extracted metadata
  */
 
-import { loadEnv } from '../src/utils/loadEnv.js';
-loadEnv(import.meta.url);
+// Load configuration onto process.env — MUST stay the first import (see src/bootstrapEnv.ts).
+import '../src/bootstrapEnv.js';
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';

--- a/scripts/build-fts.ts
+++ b/scripts/build-fts.ts
@@ -22,8 +22,8 @@
  *           Upload final xpp-metadata.db to Blob Storage
  */
 
-import { loadEnv } from '../src/utils/loadEnv.js';
-loadEnv(import.meta.url);
+// Load configuration onto process.env — MUST stay the first import (see src/bootstrapEnv.ts).
+import '../src/bootstrapEnv.js';
 import * as fsSync from 'fs';
 import { XppSymbolIndex } from '../src/metadata/symbolIndex.js';
 import { indexAllLabels } from '../src/metadata/labelParser.js';

--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -3,8 +3,8 @@
  * Extracts X++ metadata from D365 F&O PackagesLocalDirectory
  */
 
-import { loadEnv } from '../src/utils/loadEnv.js';
-loadEnv(import.meta.url);
+// Load configuration onto process.env — MUST stay the first import (see src/bootstrapEnv.ts).
+import '../src/bootstrapEnv.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';

--- a/scripts/purge-property-stats.ts
+++ b/scripts/purge-property-stats.ts
@@ -29,8 +29,8 @@
  * it to CUSTOM_MODELS and re-run.
  */
 
-import { loadEnv } from '../src/utils/loadEnv.js';
-loadEnv(import.meta.url);
+// Load configuration onto process.env — MUST stay the first import (see src/bootstrapEnv.ts).
+import '../src/bootstrapEnv.js';
 import { XppSymbolIndex } from '../src/metadata/symbolIndex.js';
 import { readExtractedCustomModels } from '../src/utils/extractManifest.js';
 import { c, log, kv, shortPath } from '../src/utils/terminalUi.js';

--- a/src/bootstrapEnv.ts
+++ b/src/bootstrapEnv.ts
@@ -1,0 +1,35 @@
+/**
+ * Configuration bootstrap — import this FIRST from every entry point.
+ *
+ * Importing this module loads config/d365fo-mcp.json, config/secrets.json and
+ * .env onto process.env as a side effect (see loadEnv for the precedence rules).
+ *
+ * Why a module instead of a plain call
+ * ------------------------------------
+ * ESM evaluates every `import` declaration before the first statement of the
+ * importing module's body. Entry points used to be written as
+ *
+ *     import { loadEnv } from './utils/loadEnv.js';
+ *     loadEnv(import.meta.url);          // <- reads first, runs last
+ *     import { apiKeyAuth } from './middleware/apiKeyAuth.js';
+ *
+ * which looks like configuration is loaded up front but is not: every module in
+ * the import graph — including the ones that snapshot process.env into a
+ * module-level const — had already been evaluated by the time loadEnv() ran, so
+ * they all saw the unconfigured environment. That silently disabled API-key
+ * authentication for keys supplied through .env or config/secrets.json, and made
+ * METADATA_PATH, the MCP tool timeouts and the rate-limit settings unreadable
+ * from those files.
+ *
+ * A side-effect import is subject to the same evaluation order it is trying to
+ * control, so being *first* is what makes it correct — an import placed above it
+ * still wins. tests/server/envConfigTiming.test.ts enforces that ordering.
+ *
+ * This file deliberately lives next to index.ts rather than in utils/: loadEnv
+ * resolves the installation directory from the caller's own location, so the
+ * bootstrap must sit at the same depth the entry points do.
+ */
+
+import { loadEnv } from './utils/loadEnv.js';
+
+loadEnv(import.meta.url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,10 @@
  * Main entry point
  */
 
-// Load .env — supports ENV_FILE env var for multi-instance setups (see src/utils/loadEnv.ts).
-import { loadEnv } from './utils/loadEnv.js';
-loadEnv(import.meta.url);
+// Load configuration onto process.env — MUST stay the first import: ESM
+// evaluates imports before any module body, so anything above this line is
+// evaluated before the configuration exists (see src/bootstrapEnv.ts).
+import './bootstrapEnv.js';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import express from 'express';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { TOOL_ANNOTATIONS } from './server/toolAnnotations.js';
 import { apiKeyAuth } from './middleware/apiKeyAuth.js';
 import { VERSION } from './version.js';
 import { setInitializeParams } from './utils/stdioSessionInfo.js';
+import { createShutdownCoordinator } from './utils/gracefulShutdown.js';
 import { box, kv, sectionTitle, statusLine, spread, c, glyph, sanitize, supportsUnicode, log, shortPath, startupWarnings } from './utils/terminalUi.js';
 import * as fs from 'fs/promises';
 import * as fsSync from 'node:fs';
@@ -139,6 +140,12 @@ const serverState: ServerState = {
   isHealthy: false,
   statusMessage: 'Starting...',
 };
+
+// Graceful shutdown — see src/utils/gracefulShutdown.ts for why and how.
+const shutdownCoordinator = createShutdownCoordinator({
+  deadlineMs: Math.max(1_000, parseInt(process.env.SHUTDOWN_TIMEOUT_MS || '5000', 10) || 5_000),
+});
+const onShutdown = shutdownCoordinator.onShutdown;
 
 async function initializeServices() {
   // -----------------------------------------------------------------------
@@ -410,6 +417,10 @@ async function initializeBridge(targetContext: import('./types/context.js').XppS
     });
     if (bridge) {
       targetContext.bridge = bridge;
+      // dispose() ends the child's stdin and escalates to SIGTERM/SIGKILL, so the
+      // bridge gets the chance to finish an in-flight AOT write and close its own
+      // metadata handles rather than being cut off mid-file.
+      onShutdown('C# bridge', () => bridge.dispose());
       const cap = `metadata ${bridge.metadataAvailable ? 'yes' : 'no'} ${glyph.dot} xref ${bridge.xrefAvailable ? 'yes' : 'no'}`;
       return { ok: true, summary: `C# bridge connected (${devEnvType}) ${glyph.dot} ${cap}` };
     }
@@ -424,6 +435,19 @@ async function initializeBridge(targetContext: import('./types/context.js').XppS
 }
 
 async function main() {
+  // Registered first so it runs LAST (cleanups run in reverse): the log file is
+  // where the other steps report, so it has to outlive them.
+  onShutdown('log file', () => {
+    if (_logStream) {
+      _logStream.end();
+      _logStream = undefined;
+    }
+  });
+  // Covers whichever index ended up in serverState — the real one, the in-memory
+  // stub, or the replacement built after a corrupt-DB recovery.
+  onShutdown('symbol index', () => serverState.symbolIndex?.close?.());
+  shutdownCoordinator.registerSignalHandlers({ stdio: isStdioMode });
+
   // ─────────────────────────────────────────────────────────────────────────────
   // Stdin sniffer: capture the `initialize` request params for get_workspace_info.
   // ─────────────────────────────────────────────────────────────────────────────
@@ -689,7 +713,13 @@ async function main() {
     });
 
     // Bind port immediately — Azure requires the port to be open within ~230 s
-    await new Promise<void>(resolve => app.listen(PORT, host, () => resolve()));
+    const httpServer = await new Promise<import('http').Server>(resolve => {
+      const s = app.listen(PORT, host, () => resolve(s));
+    });
+    // Stop accepting new connections and let in-flight requests finish. Bounded
+    // by the shutdown deadline, so a held-open keep-alive socket cannot stall the
+    // exit.
+    onShutdown('HTTP server', () => new Promise<void>(resolve => httpServer.close(() => resolve())));
 
     // Initialise services in the background; register MCP routes once ready
     initializeServices().then(async ({ mcpServer, symbolIndex, parser, workspaceScanner, hybridSearch, context }) => {

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -3134,19 +3134,44 @@ export class XppSymbolIndex {
     }));
   }
   getApiUsagePatterns(className: string): any[] {
-    // Find all methods that reference this class in their used_types.
+    // Find methods that reference this class in their used_types.
     // Cap at 20 rows — fetching source_snippet for 50+ rows on a 584K-row table causes timeout.
+    //
+    // `used_types LIKE '%name%'` was wrong on both counts. used_types is a
+    // comma-separated list of exact type names, so a substring test answered
+    // "SalesTable" with methods that only use AxSalesTable or
+    // MCRSalesTableRefRecId. And it could not use an index: LIMIT 20 only stops
+    // the scan once 20 matches exist, so a name with no matches read used_types
+    // out of all 627 K method rows — each carrying source_snippet and source in
+    // overflow pages. Measured on the 2 GB index: over 7 minutes, synchronously,
+    // which blocks the whole server until the client gives up and kills it.
+    //
+    // The FTS pre-filter makes the candidate set small (an indexed token match on
+    // source_snippet), and exact membership in the list then decides. Same
+    // measurement: 0–230 ms, with the false positives gone.
+    //
+    // The pre-filter also narrows what can be returned: a method whose
+    // used_types names the class but whose stored snippet does not mention it is
+    // no longer reported. That is acceptable here specifically — this tool
+    // exists to show usage examples, and the caller reads initialization
+    // patterns straight out of source_snippet, so a row whose snippet lacks the
+    // name has no example to contribute.
+    const safe = className.replace(/["\(\)\\]/g, '').trim();
+    if (!safe) return [];
+
     let stmt = this.stmtCache.get('getApiUsagePatterns');
     if (!stmt) {
       stmt = this.db.prepare(
         `SELECT name, parent_name, method_calls, source_snippet
            FROM symbols
-          WHERE type = 'method' AND used_types LIKE ?
+          WHERE type = 'method'
+            AND id IN (SELECT rowid FROM symbols_fts WHERE symbols_fts MATCH ?)
+            AND ', ' || used_types || ', ' LIKE ? COLLATE NOCASE
           LIMIT 20`
       );
       this.stmtCache.set('getApiUsagePatterns', stmt);
     }
-    const methods = stmt.all(`%${className}%`) as any[];
+    const methods = stmt.all(`{source_snippet} : "${safe}"`, `%, ${className}, %`) as any[];
 
     if (methods.length === 0) {
       return [];

--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -15,9 +15,19 @@ import { timingSafeEqual } from 'node:crypto';
  * existing deployments keep working without changes.
  *
  * Timing-safe comparison is used to prevent timing side-channel attacks.
+ *
+ * The key is read per request rather than snapshotted at module load. ESM
+ * evaluates this module as part of the entry point's import graph, which under
+ * the old ordering happened before the configuration was loaded onto
+ * process.env — so a key set in .env or config/secrets.json read as "no key
+ * configured" and authentication silently disabled itself. src/bootstrapEnv.ts
+ * fixes that ordering; reading late means this file no longer depends on it.
  */
 
-const API_KEY = process.env.API_KEY?.trim();
+function configuredApiKey(): string | undefined {
+  const key = process.env.API_KEY?.trim();
+  return key ? key : undefined;
+}
 
 /** Paths that never require authentication */
 const PUBLIC_PATHS = new Set(['/', '/health']);
@@ -54,8 +64,10 @@ function extractApiKey(req: Request): string | null {
  * Mount BEFORE any route handlers.
  */
 export function apiKeyAuth(req: Request, res: Response, next: NextFunction): void {
+  const apiKey = configuredApiKey();
+
   // No API_KEY configured → auth disabled, pass through
-  if (!API_KEY) {
+  if (!apiKey) {
     next();
     return;
   }
@@ -68,7 +80,7 @@ export function apiKeyAuth(req: Request, res: Response, next: NextFunction): voi
 
   const provided = extractApiKey(req);
 
-  if (!provided || !safeCompare(provided, API_KEY)) {
+  if (!provided || !safeCompare(provided, apiKey)) {
     res.status(401).json({
       error: 'Unauthorized',
       message: 'Missing or invalid API key. Provide it via X-Api-Key header or Authorization: Bearer <key>.',

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -1,5 +1,5 @@
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
-import type { Request, Response } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
 import { createHash } from 'crypto';
 
 /**
@@ -29,8 +29,14 @@ function parseEnvInt(key: string, defaultVal: number, min: number, max: number):
  * per-user token (e.g. GitHub Copilot OAuth) that separates users behind a
  * shared IP; it's SHA-256 hashed (never logged) and still scoped to the
  * client IP since a forged/rotated header could otherwise mint new buckets.
+ *
+ * Read per request, not snapshotted at import: this module is evaluated as part
+ * of the entry point's import graph, which happens before the configuration is
+ * projected onto process.env (see src/bootstrapEnv.ts).
  */
-const AUTH_ENABLED = !!process.env.API_KEY?.trim();
+function authEnabled(): boolean {
+  return !!process.env.API_KEY?.trim();
+}
 
 function ipKey(req: Request): string {
   const rawIp = req.ip || req.socket.remoteAddress || 'unknown';
@@ -38,8 +44,8 @@ function ipKey(req: Request): string {
   return ipKeyGenerator(ipWithoutPort);
 }
 
-function generateKey(req: Request): string {
-  if (AUTH_ENABLED) {
+export function generateRateLimitKey(req: Request): string {
+  if (authEnabled()) {
     return 'ip:' + ipKey(req);
   }
 
@@ -56,31 +62,48 @@ function generateKey(req: Request): string {
  * General API rate limiter. Default 500 requests per 15 minutes per user
  * token (or IP as fallback) — a single chat interaction can consume 10-20
  * requests, so this stays generous. Override via RATE_LIMIT_MAX_REQUESTS.
+ *
+ * Built on first use rather than at import. express-rate-limit freezes windowMs
+ * and max when the limiter is constructed, and this module is evaluated before
+ * the configuration reaches process.env, so constructing it eagerly pinned both
+ * to their defaults and silently ignored RATE_LIMIT_* from .env / config.
  */
-export const apiRateLimiter = rateLimit({
-  windowMs: parseEnvInt('RATE_LIMIT_WINDOW_MS', 900000, 10000, 86400000), // 10s–24h
-  max: parseEnvInt('RATE_LIMIT_MAX_REQUESTS', 500, 1, 100000),
-  keyGenerator: generateKey,
-  validate: {
-    // We safely use ipKeyGenerator in our custom generateKey function
-    keyGeneratorIpFallback: false,
-  },
-  message: {
-    error: 'Too many requests for this user or IP, please try again later.',
-    retryAfter: 'Please check the Retry-After header.',
-  },
-  standardHeaders: true, // Return rate limit info in `RateLimit-*` headers
-  legacyHeaders: false, // Disable `X-RateLimit-*` headers
-  handler: (_req: Request, res: Response) => {
-    res.status(429).json({
-      error: 'Too many requests',
-      message: 'You have exceeded the rate limit. Please try again later.',
-      retryAfter: res.getHeader('Retry-After'),
-    });
-  },
-  skip: (req: Request) => {
-    // Skip rate limiting for health check endpoint
-    return req.path === '/health';
-  },
-});
+let limiter: RequestHandler | null = null;
 
+function buildLimiter(): RequestHandler {
+  return rateLimit({
+    windowMs: parseEnvInt('RATE_LIMIT_WINDOW_MS', 900000, 10000, 86400000), // 10s–24h
+    max: parseEnvInt('RATE_LIMIT_MAX_REQUESTS', 500, 1, 100000),
+    keyGenerator: generateRateLimitKey,
+    validate: {
+      // We safely use ipKeyGenerator in our custom generateRateLimitKey function
+      keyGeneratorIpFallback: false,
+    },
+    message: {
+      error: 'Too many requests for this user or IP, please try again later.',
+      retryAfter: 'Please check the Retry-After header.',
+    },
+    standardHeaders: true, // Return rate limit info in `RateLimit-*` headers
+    legacyHeaders: false, // Disable `X-RateLimit-*` headers
+    handler: (_req: Request, res: Response) => {
+      res.status(429).json({
+        error: 'Too many requests',
+        message: 'You have exceeded the rate limit. Please try again later.',
+        retryAfter: res.getHeader('Retry-After'),
+      });
+    },
+    skip: (req: Request) => {
+      // Skip rate limiting for health check endpoint
+      return req.path === '/health';
+    },
+  });
+}
+
+/**
+ * Express middleware entry point. Delegates to the limiter, constructing it on
+ * the first request so it picks up the fully loaded configuration.
+ */
+export const apiRateLimiter: RequestHandler = (req, res, next) => {
+  limiter ??= buildLimiter();
+  limiter(req, res, next);
+};

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -184,10 +184,21 @@ export class CustomHttpTransport implements Transport {
     this.app.post('/mcp', async (req: Request, res: Response): Promise<void> => {
       // Declare here so the catch block can clean it up regardless of where an error fires
       let internalId: string | undefined;
+      // Hoisted for the same reason. An error raised after the timer is armed but
+      // outside the resolve/reject paths (e.g. from the surrounding context
+      // wrapper) would otherwise leave a live timer holding the event loop for up
+      // to the heavy-tool ceiling of 10 minutes.
+      let responseTimeoutId: ReturnType<typeof setTimeout> | undefined;
+      // Captured before any id rewriting below. `request` IS `req.body`, so once
+      // the id is swapped for the internal routing key, reading it back in the
+      // catch block would answer with that key — and a client that gets an error
+      // tagged with an id it never sent cannot correlate it, so it waits out its
+      // own timeout instead of failing fast.
+      const clientRequestId = (req.body as any)?.id ?? null;
       try {
         // Set response headers (keep-alive enabled for performance)
         res.setHeader('Content-Type', 'application/json');
-        
+
         const request = req.body as JSONRPCRequest;
 
         // Extract GitHub Copilot workspace path for per-request isolation.
@@ -290,6 +301,7 @@ export class CustomHttpTransport implements Transport {
                 reject(new Error(`Request timeout: ${toolName} did not complete within ${perToolTimeoutMs / 1000}s`));
               }
             }, perToolTimeoutMs);
+            responseTimeoutId = timeoutId;
 
             this.pendingRequests.set(internalId, {
               resolve: (message) => {
@@ -391,18 +403,18 @@ export class CustomHttpTransport implements Transport {
         if (internalId) {
           this.pendingRequests.delete(internalId);
         }
+        if (responseTimeoutId) {
+          clearTimeout(responseTimeoutId);
+        }
         
         if (!res.headersSent) {
-          // Use the original request id so the client can correlate this error.
-          // request is block-scoped inside try, so fall back to req.body.
-          const reqId = (req.body as any)?.id ?? null;
           res.status(500).json({
             jsonrpc: '2.0',
             error: {
               code: -32603,
               message: error instanceof Error ? error.message : 'Internal error',
             },
-            id: reqId,
+            id: clientRequestId,
           });
         }
       }

--- a/src/tools/edtInfo.ts
+++ b/src/tools/edtInfo.ts
@@ -154,13 +154,81 @@ function getEdtFromIndex(symbolIndex: any, edtName: string, modelName?: string) 
   return { content: [{ type: 'text', text: out }] };
 }
 
+/** True when edt_metadata holds a row for exactly this spelling. */
+function probeEdtRow(db: any, name: string, modelName?: string): boolean {
+  try {
+    return !!db.prepare(
+      `SELECT 1 FROM edt_metadata WHERE edt_name = ?${modelName ? ' AND model = ?' : ''} LIMIT 1`
+    ).get(...(modelName ? [name, modelName] : [name]));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fields whose declared type is `edtName`.
+ *
+ * For a `type='field'` row, `signature` holds the field's type name, so this is
+ * an equality question, not a substring one. It used to be asked as
+ * `signature LIKE '%edtName%'`, which was wrong in both directions:
+ *
+ *  - Correctness: asking for AmountMST also reported fields typed
+ *    QuotationAmountMST, AdjustAmountMST, BaseAmountMST, PaymAmountMST…
+ *  - Performance: an unindexed LIKE over the 360 K `field` rows, and the
+ *    ORDER BY forced every match to be read and sorted before LIMIT 50 could
+ *    apply. Measured on the 2 GB index: 63 s for a name that exists — a
+ *    synchronous call that blocks the whole server while it runs.
+ *
+ * The FTS pre-filter narrows to the handful of rows whose signature contains
+ * the name as a token, and the equality test then decides. Because FTS5 stores
+ * the signature token case-insensitively, and the comparison is COLLATE NOCASE,
+ * every case variant X++ considers the same type is kept — measured recall
+ * against a case-insensitive full scan is 100 %, at 22–41 ms instead of 63 s.
+ *
+ * Falls back to the exact-equality scan when the index predates symbols_fts.
+ */
+function findFieldsTypedAs(db: any, edtName: string): any[] {
+  const safe = edtName.replace(/["\(\)\\]/g, '').trim();
+  if (safe) {
+    try {
+      return db.prepare(
+        `SELECT parent_name, name, model FROM symbols
+          WHERE type = 'field'
+            AND id IN (SELECT rowid FROM symbols_fts WHERE symbols_fts MATCH ?)
+            AND signature = ? COLLATE NOCASE
+          ORDER BY model, parent_name LIMIT 50`
+      ).all(`{signature} : "${safe}"`, edtName) as any[];
+    } catch {
+      // No FTS table (older index) — fall through to the plain scan.
+    }
+  }
+  try {
+    return db.prepare(
+      `SELECT parent_name, name, model FROM symbols
+        WHERE type = 'field' AND signature = ? COLLATE NOCASE
+        ORDER BY model, parent_name LIMIT 50`
+    ).all(edtName) as any[];
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Hierarchy mode: walk ancestor chain, find children, and show field usages
  */
 function getEdtHierarchy(db: any, edtName: string, modelName?: string) {
+  // X++ identifiers are case-insensitive, and edt_metadata.edt_name is probed by
+  // equality. Basic mode already canonicalizes the caller's casing through the
+  // index-safe lookup; hierarchy mode did not, so `amountmst` reported the EDT as
+  // missing while `AmountMST` returned it. Canonicalize here too, using the same
+  // helper, so the two modes agree on what exists.
+  const startName = probeEdtRow(db, edtName, modelName)
+    ? edtName
+    : (canonicalSymbolName(db, edtName, ['edt']) ?? edtName);
+
   // Ancestor chain walk
   const chain: Array<{ name: string; model: string; extends?: string; label?: string; stringSize?: string }> = [];
-  let current = edtName;
+  let current = startName;
   const visited = new Set<string>();
 
   while (current && !visited.has(current)) {
@@ -186,10 +254,8 @@ function getEdtHierarchy(db: any, edtName: string, modelName?: string) {
     `SELECT edt_name, model, label FROM edt_metadata WHERE extends = ? ORDER BY model, edt_name`
   ).all(edtName) as any[];
 
-  // Field usages (fields using this EDT by name)
-  const fieldUsages = db.prepare(
-    `SELECT parent_name, name, model FROM symbols WHERE type = 'field' AND signature LIKE ? ORDER BY model, parent_name LIMIT 50`
-  ).all(`%${edtName}%`) as any[];
+  // Field usages (fields whose type IS this EDT)
+  const fieldUsages = findFieldsTypedAs(db, edtName);
 
   let output = `EDT Hierarchy: ${edtName}\n\n`;
 

--- a/src/tools/findEventHandlers.ts
+++ b/src/tools/findEventHandlers.ts
@@ -18,6 +18,52 @@ const FindEventHandlersArgsSchema = z.object({
     .describe('Filter by handler type (static=SubscribesTo delegates, delegate=delegate += syntax, all=both)'),
 });
 
+/**
+ * Methods whose body matches `pattern`, narrowed to those that mention
+ * `targetName` at all.
+ *
+ * The static-handler search above already goes through symbols_fts; the delegate
+ * search did not, and it carried both halves of the same defect the EDT and
+ * api-usage queries had. `source_snippet LIKE '%X%.on%'` cannot use an index, and
+ * ORDER BY forces every match to be read and sorted before LIMIT 20 applies —
+ * so the cost is paid over all 627 K method rows, each carrying source_snippet
+ * in overflow pages. Measured on the 2 GB index (warm): 3.2 s and 2.3 s for the
+ * two patterns, i.e. ~5.5 s of blocked event loop per call, since node:sqlite is
+ * synchronous.
+ *
+ * The FTS pre-filter is also more accurate here, not just faster. LIKE matches
+ * substrings, so `%SalesTable%.on%` reported SalesLine.setAddressFromSalesTable_BR
+ * — a method that merely has the name inside a longer identifier and subscribes
+ * to nothing. FTS matches tokens, so it drops exactly that row. Measured: 0–51 ms,
+ * and every row it excluded for SalesTable/InventTable was such a false positive.
+ *
+ * Falls back to the unfiltered query when the index predates symbols_fts, which
+ * is what the static branch does too.
+ */
+function delegateSearch(rdb: any, targetName: string, pattern: string): any[] {
+  const SELECT = `SELECT name, parent_name, model, source_snippet FROM symbols
+                   WHERE type = 'method'`;
+  const TAIL = ` ORDER BY model, parent_name, name LIMIT 20`;
+
+  const safe = targetName.replace(/["\(\)\\]/g, '').trim();
+  if (safe) {
+    try {
+      return rdb.prepare(
+        `${SELECT}
+           AND id IN (SELECT rowid FROM symbols_fts WHERE symbols_fts MATCH ?)
+           AND source_snippet LIKE ?${TAIL}`
+      ).all(`{source_snippet} : "${safe}"`, pattern) as any[];
+    } catch {
+      // No FTS table (older index) — fall through.
+    }
+  }
+  try {
+    return rdb.prepare(`${SELECT} AND source_snippet LIKE ?${TAIL}`).all(pattern) as any[];
+  } catch {
+    return [];
+  }
+}
+
 export async function findEventHandlersTool(request: CallToolRequest, context: XppServerContext) {
   try {
     const args = FindEventHandlersArgsSchema.parse(request.params.arguments);
@@ -101,22 +147,10 @@ export async function findEventHandlersTool(request: CallToolRequest, context: X
     // Delegate subscription search (+= syntax)
     let delegateHandlers: any[] = [];
     if (args.handlerType !== 'static') {
-      delegateHandlers = rdb.prepare(
-        `SELECT name, parent_name, model, source_snippet FROM symbols
-         WHERE type = 'method'
-         AND source_snippet LIKE ?
-         ORDER BY model, parent_name, name
-         LIMIT 20`
-      ).all(`%${targetName}.on%+=% `) as any[];
+      delegateHandlers = delegateSearch(rdb, targetName, `%${targetName}.on%+=% `);
 
       // Also: find methods with body referencing delegate attach
-      const delegateHandlers2 = rdb.prepare(
-        `SELECT name, parent_name, model, source_snippet FROM symbols
-         WHERE type = 'method'
-         AND source_snippet LIKE ?
-         ORDER BY model, parent_name, name
-         LIMIT 20`
-      ).all(`%${targetName}%.on%`) as any[];
+      const delegateHandlers2 = delegateSearch(rdb, targetName, `%${targetName}%.on%`);
 
       for (const h of delegateHandlers2) {
         if (!(delegateHandlers.some(d => d.name === h.name && d.parent_name === h.parent_name))) {

--- a/src/utils/gracefulShutdown.ts
+++ b/src/utils/gracefulShutdown.ts
@@ -1,0 +1,123 @@
+/**
+ * Ordered, bounded release of process-owned resources.
+ *
+ * The server owns things a bare process death leaves in a bad state: the C#
+ * bridge child, which may be part-way through writing AOT XML, and the SQLite
+ * handles. Termination is routine rather than exceptional here — an MCP client
+ * ends a stdio session by closing the pipe or signalling, and Azure sends
+ * SIGTERM before a restart — so stopping needs a defined path.
+ *
+ * Two rules shape the design:
+ *
+ *  - Reverse order. Cleanups run last-registered-first, so a resource is torn
+ *    down before whatever it was built on top of.
+ *  - Shutdown must never be the thing that hangs. Every step is best-effort, a
+ *    failing one cannot strand the rest, and the whole sequence is capped: past
+ *    the deadline the process exits regardless, because a stop that does not
+ *    stop is worse than an unclean one.
+ *
+ * The exit and log seams exist so this is testable without ending the test
+ * runner's own process.
+ *
+ * Platform note — what actually triggers this on Windows. Measured on the dev VM:
+ * a signal sent from another process (`child.kill('SIGTERM'|'SIGINT')`) does NOT
+ * run these handlers, because libuv implements it as TerminateProcess; the child
+ * dies reporting the signal and no cleanup happens. So on Windows the path that
+ * matters is stdin closing — which is how an MCP client ends a stdio session, and
+ * which is verified to release the bridge child — plus Ctrl+C in a console, which
+ * Node does deliver as SIGINT. The signal handlers are still the right thing to
+ * register: they work as written on Linux, where Azure sends SIGTERM before a
+ * restart.
+ */
+
+export interface ShutdownCoordinatorOptions {
+  /** Hard cap for the whole sequence (ms). */
+  deadlineMs?: number;
+  /** Process exit. Injectable for tests. */
+  exit?: (code: number) => void;
+  /** Where progress is reported. Injectable for tests. */
+  log?: (message: string) => void;
+}
+
+export interface ShutdownCoordinator {
+  /** Register a resource to release. Later registrations run first. */
+  onShutdown(name: string, run: () => void | Promise<void>): void;
+  /** Run every cleanup once, then exit. Repeat calls are ignored. */
+  shutdown(reason: string, exitCode?: number): Promise<void>;
+  /** Wire SIGINT/SIGTERM/SIGHUP, and (in stdio mode) the client closing stdin. */
+  registerSignalHandlers(opts?: { stdio?: boolean }): void;
+  readonly isShuttingDown: boolean;
+}
+
+/**
+ * Conventional exit code for a signal-terminated process (128 + signal number).
+ * Supervisors read it to tell an orderly stop from a crash.
+ */
+const SIGNAL_EXIT_CODES: Record<string, number> = {
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+export function createShutdownCoordinator(
+  options: ShutdownCoordinatorOptions = {},
+): ShutdownCoordinator {
+  const deadlineMs = Math.max(1_000, options.deadlineMs ?? 5_000);
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  // Straight to stderr by default, not console.error: index.ts wraps that to
+  // suppress anything shaped like "[module] …" without an error marker, and
+  // shutdown progress is exactly what an operator needs when a stop goes wrong.
+  const log = options.log ?? ((message: string) => process.stderr.write(`${message}\n`));
+
+  const cleanups: Array<{ name: string; run: () => void | Promise<void> }> = [];
+  let shuttingDown = false;
+
+  async function shutdown(reason: string, exitCode = 0): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    const note = (msg: string) => log(`[shutdown] ${msg}`);
+    note(`${reason} — releasing resources`);
+
+    // unref() so this timer alone cannot keep the process alive once everything
+    // has finished cleanly.
+    const deadline = setTimeout(() => {
+      note(`still busy after ${deadlineMs} ms — exiting anyway`);
+      exit(exitCode);
+    }, deadlineMs);
+    if (typeof deadline.unref === 'function') deadline.unref();
+
+    for (const { name, run } of [...cleanups].reverse()) {
+      try {
+        await run();
+      } catch (err) {
+        note(`${name} failed to close: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
+    clearTimeout(deadline);
+    note('done');
+    exit(exitCode);
+  }
+
+  return {
+    onShutdown(name, run) {
+      cleanups.push({ name, run });
+    },
+    shutdown,
+    registerSignalHandlers({ stdio = false } = {}) {
+      for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+        process.on(signal, () => void shutdown(`received ${signal}`, SIGNAL_EXIT_CODES[signal]));
+      }
+      // A closed stdin means the MCP client is gone. Only meaningful in stdio
+      // mode — in HTTP mode stdin may legitimately be closed for the whole
+      // process lifetime.
+      if (stdio) {
+        process.stdin.on('end', () => void shutdown('stdin closed by the MCP client', 0));
+      }
+    },
+    get isShuttingDown() {
+      return shuttingDown;
+    },
+  };
+}

--- a/tests/metadata/apiUsagePatternsQuery.test.ts
+++ b/tests/metadata/apiUsagePatternsQuery.test.ts
@@ -1,0 +1,143 @@
+/**
+ * XppSymbolIndex.getApiUsagePatterns — reachable from the agent as
+ * `analyze_code(mode="api-usage", apiName=…)`.
+ *
+ * The query behind it was:
+ *
+ *   SELECT name, parent_name, method_calls, source_snippet FROM symbols
+ *    WHERE type = 'method' AND used_types LIKE '%apiName%'
+ *    LIMIT 20
+ *
+ * `used_types` is a comma-separated list of exact type names, so the substring
+ * test answered "SalesTable" with methods that only use AxSalesTable or
+ * MCRSalesTableRefRecId.
+ *
+ * It was also unbounded work. LIMIT 20 only stops the scan once 20 matches
+ * exist, so an apiName with no matches read used_types out of every method row —
+ * each carrying source_snippet and source in overflow pages. Measured against
+ * the 2 GB production index: the `type='method'` count alone is 56 ms from the
+ * index, but touching used_types on those rows costs 37 s, and the full
+ * no-match query ran past 7 minutes. node:sqlite is synchronous, so the server
+ * is blocked for all of it — the failure mode is the MCP client giving up and
+ * killing the process.
+ *
+ * The rewrite pre-filters through symbols_fts and decides with exact membership
+ * in the list: 0–230 ms on the same index.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+
+const open: any[] = [];
+
+function makeIndex(methods: Array<{ name: string; parent: string; usedTypes: string; snippet: string }>) {
+  const index: any = new XppSymbolIndex(':memory:', ':memory:');
+  open.push(index);
+  const ins = index.db.prepare(
+    `INSERT INTO symbols (name, type, parent_name, used_types, source_snippet, method_calls, model, file_path)
+     VALUES (?, 'method', ?, ?, ?, ?, 'ApplicationSuite', ?)`);
+  for (const m of methods) {
+    ins.run(m.name, m.parent, m.usedTypes, m.snippet, 'insert,update', `K:\\Pkg\\${m.parent}.xml`);
+  }
+  // Populate the external-content FTS index the same way a build does.
+  index.db.exec("INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild');");
+  return index;
+}
+
+afterEach(() => {
+  for (const i of open.splice(0)) i.close?.();
+});
+
+const METHODS = [
+  { name: 'postInvoice', parent: 'SalesInvoicePost',
+    usedTypes: 'SalesTable, SalesLine, CustTable',
+    snippet: 'SalesTable salesTable;\nsalesTable = SalesTable::find(salesId);' },
+  { name: 'confirmOrder', parent: 'SalesOrderConfirm',
+    usedTypes: 'SalesTable, SalesParmTable',
+    snippet: 'SalesTable salesTable = SalesTable::find(_salesId);' },
+  // used_types names a DIFFERENT type that merely contains the query string
+  { name: 'buildAxRecord', parent: 'AxSalesTableBuilder',
+    usedTypes: 'AxSalesTable, AxSalesLine',
+    snippet: 'AxSalesTable axSalesTable = AxSalesTable::construct();' },
+  { name: 'resolveRef', parent: 'MCRRefResolver',
+    usedTypes: 'MCRSalesTableRefRecId',
+    snippet: 'MCRSalesTableRefRecId refId;' },
+  // case variant of the queried type — X++ identifiers are case-insensitive
+  { name: 'updateLine', parent: 'SalesLineUpdate',
+    usedTypes: 'salestable, SalesLine',
+    snippet: 'salestable st = SalesTable::find(id);' },
+];
+
+describe('getApiUsagePatterns', () => {
+  it('returns nothing, quickly, for a class no method uses', () => {
+    const index = makeIndex(METHODS);
+    expect(index.getApiUsagePatterns('ZzzNoSuchClass')).toEqual([]);
+  });
+
+  it('does not count types that merely contain the queried name', () => {
+    const index = makeIndex(METHODS);
+    const patterns = index.getApiUsagePatterns('SalesTable');
+
+    const classes: string[] = patterns.flatMap((p: any) => p.classes ?? []);
+    expect(classes).toEqual(expect.arrayContaining(['SalesInvoicePost', 'SalesOrderConfirm']));
+    expect(classes).not.toContain('AxSalesTableBuilder');
+    expect(classes).not.toContain('MCRRefResolver');
+  });
+
+  it('matches a used_types entry regardless of its casing', () => {
+    const index = makeIndex(METHODS);
+    const classes: string[] = index.getApiUsagePatterns('SalesTable').flatMap((p: any) => p.classes ?? []);
+    expect(classes).toContain('SalesLineUpdate');
+  });
+
+  it('finds the same methods when the caller varies the casing', () => {
+    const index = makeIndex(METHODS);
+    const asAsked = index.getApiUsagePatterns('SalesTable').flatMap((p: any) => p.classes ?? []);
+    const lowered = index.getApiUsagePatterns('salestable').flatMap((p: any) => p.classes ?? []);
+    expect(new Set(lowered)).toEqual(new Set(asAsked));
+  });
+
+  it('does not throw on a name containing FTS5 syntax characters', () => {
+    const index = makeIndex(METHODS);
+    for (const probe of ['Sales"Table', 'Sales(Table)', '"', '   ']) {
+      expect(() => index.getApiUsagePatterns(probe)).not.toThrow();
+    }
+  });
+
+  it('keeps the candidate set bounded by an index rather than scanning', () => {
+    // The behavioural tests above cannot catch a return to the unbounded query:
+    // on a fixture-sized table a full scan is instant and answers identically.
+    // What made the old query a server-stalling defect was the plan it forced on
+    // the 2 GB index — so assert the plan, and take the SQL from what the method
+    // really prepares rather than restating it here, which would let the
+    // production query drift back without the test noticing.
+    const index = makeIndex(METHODS);
+    const prepared: string[] = [];
+    const realDb = index.db;
+    index.db = new Proxy(realDb, {
+      get(target: any, prop: string | symbol) {
+        if (prop === 'prepare') {
+          return (text: string) => { prepared.push(text); return target.prepare(text); };
+        }
+        const value = target[prop];
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    index.getApiUsagePatterns('SalesTable');
+    index.db = realDb;
+
+    const query = prepared.find(s => s.includes('used_types'));
+    expect(query, 'getApiUsagePatterns prepared no query touching used_types').toBeDefined();
+
+    const plan = realDb
+      .prepare('EXPLAIN QUERY PLAN ' + query)
+      .all()
+      .map((r: any) => r.detail)
+      .join(' | ');
+
+    // The FTS virtual table drives the query; symbols is probed by rowid.
+    expect(plan, `unbounded plan for: ${query}`).toMatch(/symbols_fts/);
+    expect(plan, `full table scan for: ${query}`).not.toMatch(/SCAN symbols\b/);
+  });
+});

--- a/tests/server/envConfigTiming.test.ts
+++ b/tests/server/envConfigTiming.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Configuration-timing regression tests.
+ *
+ * ESM evaluates every `import` declaration before the first statement of the
+ * importing module's body. Entry points were written as
+ *
+ *     import { loadEnv } from './utils/loadEnv.js';
+ *     loadEnv(import.meta.url);          // <- looks first, runs last
+ *     import { apiKeyAuth } from './middleware/apiKeyAuth.js';
+ *
+ * which reads as "configuration is loaded before anything else" but is not:
+ * every imported module — including the ones that snapshot `process.env` into a
+ * module-level const — was already fully evaluated by the time loadEnv() ran.
+ *
+ * The consequence for apiKeyAuth was a silent auth bypass: an API_KEY supplied
+ * through .env / config/secrets.json (as `npm run setup` writes it) was invisible
+ * to the middleware, so it treated authentication as disabled and passed every
+ * request through.
+ *
+ * Two guards, both needed:
+ *  1. Modules on the security path resolve their settings per request, so they
+ *     cannot be defeated by import ordering at all.
+ *  2. Entry points import the env bootstrap first, so modules that legitimately
+ *     snapshot configuration at load time see the real values.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const REPO_ROOT = resolve(__dirname, '../..');
+
+const TRACKED = ['API_KEY', 'RATE_LIMIT_MAX_REQUESTS', 'RATE_LIMIT_WINDOW_MS'] as const;
+let saved: Partial<Record<string, string | undefined>> = {};
+
+beforeEach(() => {
+  saved = {};
+  for (const key of TRACKED) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  vi.resetModules();
+});
+
+afterEach(() => {
+  for (const key of TRACKED) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+/** Minimal Express-shaped request/response doubles. */
+function fakeReq(path: string, headers: Record<string, string> = {}) {
+  return { path, headers } as any;
+}
+
+function fakeRes() {
+  const captured: { status?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return { json: (body: unknown) => { captured.body = body; } };
+    },
+  } as any;
+  return { res, captured };
+}
+
+describe('apiKeyAuth — configuration resolved per request, not at import time', () => {
+  it('enforces an API_KEY that appears in process.env after the module was imported', async () => {
+    // Import first, with no API_KEY set — this is exactly the state the module
+    // sees when it is evaluated as part of the entry point's import graph.
+    const { apiKeyAuth } = await import('../../src/middleware/apiKeyAuth.js');
+
+    // …then loadEnv() runs and projects .env / config/secrets.json onto env.
+    process.env.API_KEY = 'supersecret123';
+
+    const { res, captured } = fakeRes();
+    let nexted = false;
+    apiKeyAuth(fakeReq('/mcp'), res, () => { nexted = true; });
+
+    expect(nexted).toBe(false);
+    expect(captured.status).toBe(401);
+  });
+
+  it('accepts the matching key via X-Api-Key and Authorization: Bearer', async () => {
+    const { apiKeyAuth } = await import('../../src/middleware/apiKeyAuth.js');
+    process.env.API_KEY = 'supersecret123';
+
+    for (const headers of [
+      { 'x-api-key': 'supersecret123' },
+      { authorization: 'Bearer supersecret123' },
+    ]) {
+      const { res, captured } = fakeRes();
+      let nexted = false;
+      apiKeyAuth(fakeReq('/mcp', headers), res, () => { nexted = true; });
+      expect(nexted).toBe(true);
+      expect(captured.status).toBeUndefined();
+    }
+  });
+
+  it('rejects a wrong key of a different length without throwing', async () => {
+    const { apiKeyAuth } = await import('../../src/middleware/apiKeyAuth.js');
+    process.env.API_KEY = 'supersecret123';
+
+    const { res, captured } = fakeRes();
+    let nexted = false;
+    apiKeyAuth(fakeReq('/mcp', { 'x-api-key': 'short' }), res, () => { nexted = true; });
+
+    expect(nexted).toBe(false);
+    expect(captured.status).toBe(401);
+  });
+
+  it('stays a pass-through when no API_KEY is configured at all', async () => {
+    const { apiKeyAuth } = await import('../../src/middleware/apiKeyAuth.js');
+
+    const { res, captured } = fakeRes();
+    let nexted = false;
+    apiKeyAuth(fakeReq('/mcp'), res, () => { nexted = true; });
+
+    expect(nexted).toBe(true);
+    expect(captured.status).toBeUndefined();
+  });
+
+  it('keeps /health reachable without a key so platform probes still work', async () => {
+    const { apiKeyAuth } = await import('../../src/middleware/apiKeyAuth.js');
+    process.env.API_KEY = 'supersecret123';
+
+    const { res, captured } = fakeRes();
+    let nexted = false;
+    apiKeyAuth(fakeReq('/health'), res, () => { nexted = true; });
+
+    expect(nexted).toBe(true);
+    expect(captured.status).toBeUndefined();
+  });
+});
+
+describe('rate limiter — key strategy follows the live API_KEY setting', () => {
+  it('switches to pure IP keying when API_KEY is set after import', async () => {
+    const mod = await import('../../src/middleware/rateLimiter.js');
+    process.env.API_KEY = 'supersecret123';
+
+    const req = {
+      ip: '203.0.113.9',
+      socket: { remoteAddress: '203.0.113.9' },
+      headers: { authorization: 'Bearer a-user-token-value' },
+    } as any;
+
+    // With auth on, the per-user token must not widen the bucket space:
+    // every authenticated caller from one IP shares one bucket.
+    expect(mod.generateRateLimitKey(req)).not.toContain('tok:');
+  });
+
+  it('separates users behind a shared IP by token when API_KEY is unset', async () => {
+    const mod = await import('../../src/middleware/rateLimiter.js');
+
+    const base = { ip: '203.0.113.9', socket: { remoteAddress: '203.0.113.9' } };
+    const a = mod.generateRateLimitKey({ ...base, headers: { authorization: 'Bearer token-aaaa' } } as any);
+    const b = mod.generateRateLimitKey({ ...base, headers: { authorization: 'Bearer token-bbbb' } } as any);
+
+    expect(a).toContain('tok:');
+    expect(a).not.toBe(b);
+    // The raw token must never leak into the key (keys reach logs and stores).
+    expect(a).not.toContain('token-aaaa');
+  });
+});
+
+describe('entry points load configuration before their other imports', () => {
+  const ENTRY_POINTS = [
+    'src/index.ts',
+    'scripts/build-database.ts',
+    'scripts/build-fts.ts',
+    'scripts/extract-metadata.ts',
+    'scripts/azure-blob-manager.ts',
+    'scripts/purge-property-stats.ts',
+  ];
+
+  for (const entry of ENTRY_POINTS) {
+    it(`${entry} imports the env bootstrap as its first import`, () => {
+      const source = readFileSync(resolve(REPO_ROOT, entry), 'utf8');
+      const firstImport = source
+        .split('\n')
+        .map(l => l.trim())
+        .find(l => l.startsWith('import ') || l.startsWith('import('));
+
+      expect(firstImport, `${entry} has no imports at all`).toBeDefined();
+      expect(firstImport, `${entry} must import bootstrapEnv first — any import placed above it is evaluated before configuration is loaded`)
+        .toMatch(/bootstrapEnv\.js'/);
+    });
+
+    it(`${entry} does not call loadEnv() from its module body`, () => {
+      const source = readFileSync(resolve(REPO_ROOT, entry), 'utf8');
+      // A body-level loadEnv() call is the pattern this whole file exists to
+      // prevent: it runs after every import has already been evaluated.
+      const bodyCall = source
+        .split('\n')
+        .some(l => /^\s*loadEnv\(/.test(l));
+      expect(bodyCall, `${entry} still calls loadEnv() from its body; import bootstrapEnv instead`).toBe(false);
+    });
+  }
+});

--- a/tests/tools/edtFieldUsages.test.ts
+++ b/tests/tools/edtFieldUsages.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `get_object_info(objectType="edt", mode="hierarchy")` — field usages.
+ *
+ * Two defects, both in the one query that listed "fields using this EDT":
+ *
+ *   SELECT parent_name, name, model FROM symbols
+ *    WHERE type = 'field' AND signature LIKE '%EdtName%'
+ *    ORDER BY model, parent_name LIMIT 50
+ *
+ * 1. Correctness. For a `type='field'` row, `signature` holds the field's type
+ *    name, so this is an equality question. As a substring test, AmountMST also
+ *    matched fields typed QuotationAmountMST, AdjustAmountMST, BaseAmountMST,
+ *    PaymAmountMST — reported to the agent as fields of the EDT it asked about.
+ *
+ * 2. Performance. The LIKE could not use an index, and ORDER BY forced every
+ *    match to be read and sorted before LIMIT 50 applied. Measured against the
+ *    2 GB production index: 63 s for a name that exists. node:sqlite is
+ *    synchronous, so that is 63 s of blocked event loop.
+ *
+ * The rewrite pre-filters through symbols_fts and decides with a COLLATE NOCASE
+ * equality (X++ identifiers are case-insensitive): 22–41 ms on the same index,
+ * with 100 % recall against a case-insensitive full scan.
+ *
+ * Separately, hierarchy mode probed edt_metadata by exact equality and had no
+ * canonicalization step, so `amountmst` reported the EDT as missing while
+ * `AmountMST` returned it — disagreeing with basic mode about what exists.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Database from '../../src/database/sqlite.js';
+import { getEdtInfoTool } from '../../src/tools/edtInfo';
+
+interface FieldRow { table: string; field: string; signature: string; model?: string }
+
+function makeDb(edts: Array<{ name: string; extends?: string }>, fields: FieldRow[]) {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE edt_metadata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      edt_name TEXT NOT NULL, extends TEXT, enum_type TEXT, reference_table TEXT,
+      relation_type TEXT, string_size TEXT, database_string_size TEXT,
+      display_length TEXT, label TEXT, model TEXT NOT NULL
+    );
+    CREATE INDEX idx_edt_metadata_name ON edt_metadata(edt_name);
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL, type TEXT NOT NULL, parent_name TEXT,
+      signature TEXT, file_path TEXT, model TEXT, description TEXT, extends_class TEXT
+    );
+    CREATE INDEX idx_name_type ON symbols(name, type);
+    CREATE VIRTUAL TABLE symbols_fts USING fts5(name, type, parent_name, signature, description, tags);
+  `);
+
+  const insEdt = db.prepare(
+    `INSERT INTO edt_metadata (edt_name, extends, model) VALUES (?, ?, 'ApplicationSuite')`);
+  const insSym = db.prepare(
+    `INSERT INTO symbols (name, type, parent_name, signature, model) VALUES (?, ?, ?, ?, ?)`);
+  const insFts = db.prepare(
+    `INSERT INTO symbols_fts (rowid, name, type, parent_name, signature) VALUES (?, ?, ?, ?, ?)`);
+
+  for (const e of edts) {
+    insEdt.run(e.name, e.extends ?? null);
+    const info = insSym.run(e.name, 'edt', null, null, 'ApplicationSuite');
+    insFts.run(info.lastInsertRowid, e.name, 'edt', null, null);
+  }
+  for (const f of fields) {
+    const model = f.model ?? 'ApplicationSuite';
+    const info = insSym.run(f.field, 'field', f.table, f.signature, model);
+    insFts.run(info.lastInsertRowid, f.field, 'field', f.table, f.signature);
+  }
+  return db;
+}
+
+/** Bridge absent, so the tool answers from the index — the VM's real shape. */
+function ctx(db: any) {
+  return {
+    symbolIndex: { getReadDb: () => db },
+    bridge: { isReady: true, metadataAvailable: true, readEdt: vi.fn(async () => null) },
+  } as any;
+}
+
+const req = (edtName: string) => ({
+  method: 'tools/call' as const,
+  params: { name: 'get_edt_info', arguments: { edtName, mode: 'hierarchy' } },
+});
+
+const FIELDS: FieldRow[] = [
+  { table: 'CustTrans',      field: 'AmountMST',       signature: 'AmountMST' },
+  { table: 'VendTrans',      field: 'AmountMST',       signature: 'amountMST' },   // case variant
+  { table: 'LedgerTrans',    field: 'AmountMst',       signature: 'AmountMst' },   // case variant
+  { table: 'SalesQuotation', field: 'QuotationAmount', signature: 'QuotationAmountMST' },
+  { table: 'AssetTrans',     field: 'AdjustAmount',    signature: 'AdjustAmountMST' },
+  { table: 'PaymTrans',      field: 'PaymAmount',      signature: 'PaymAmountMST' },
+  { table: 'CustTable',      field: 'AccountNum',      signature: 'CustAccount' },
+];
+
+async function usageLines(edtName: string, db: any): Promise<string[]> {
+  const result: any = await getEdtInfoTool(req(edtName), ctx(db));
+  const text: string = result.content[0].text;
+  const start = text.indexOf('Field Usages');
+  if (start < 0) return [];
+  return text
+    .slice(start)
+    .split('\n')
+    .slice(1)
+    .map(l => l.trim())
+    .filter(l => l.includes('.') && l.includes('['));
+}
+
+describe('EDT hierarchy — field usages list fields of that exact type', () => {
+  it('does not report fields whose type merely contains the EDT name', async () => {
+    const db = makeDb([{ name: 'AmountMST', extends: 'Amount' }], FIELDS);
+    const lines = await usageLines('AmountMST', db);
+
+    expect(lines.join('\n')).not.toMatch(/QuotationAmount|AdjustAmount|PaymAmount/);
+    expect(lines).toHaveLength(3); // the exact-type fields, case variants included
+  });
+
+  it('treats X++ case variants of the type name as the same type', async () => {
+    const db = makeDb([{ name: 'AmountMST', extends: 'Amount' }], FIELDS);
+    const lines = await usageLines('AmountMST', db);
+
+    // signature stored as AmountMST / amountMST / AmountMst — all one X++ type
+    expect(lines.join('\n')).toContain('CustTrans.AmountMST');
+    expect(lines.join('\n')).toContain('VendTrans.AmountMST');
+    expect(lines.join('\n')).toContain('LedgerTrans.AmountMst');
+  });
+
+  it('resolves the EDT itself case-insensitively, as basic mode does', async () => {
+    const db = makeDb([{ name: 'AmountMST', extends: 'Amount' }], FIELDS);
+
+    const result: any = await getEdtInfoTool(req('amountmst'), ctx(db));
+    const text: string = result.content[0].text;
+
+    expect(text).not.toMatch(/not found/i);
+    expect(text).toContain('AmountMST');
+    expect(await usageLines('amountmst', db)).toHaveLength(3);
+  });
+
+  it('still reports a genuinely unknown EDT as not found', async () => {
+    const db = makeDb([{ name: 'AmountMST' }], FIELDS);
+
+    const result: any = await getEdtInfoTool(req('ZzzNoSuchEdt'), ctx(db));
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not found/i);
+  });
+
+  it('answers from a plain scan when the index predates symbols_fts', async () => {
+    const db = makeDb([{ name: 'AmountMST' }], FIELDS);
+    db.exec('DROP TABLE symbols_fts');
+
+    // The FTS pre-filter is an optimisation, not the source of truth — without it
+    // the equality test alone must still produce the same answer.
+    expect(await usageLines('AmountMST', db)).toHaveLength(3);
+  });
+});

--- a/tests/tools/eventHandlerDelegateSearch.test.ts
+++ b/tests/tools/eventHandlerDelegateSearch.test.ts
@@ -1,0 +1,149 @@
+/**
+ * find_event_handlers — delegate subscription branch.
+ *
+ * The static-handler branch already narrowed through symbols_fts. The delegate
+ * branch ran two raw queries instead:
+ *
+ *   SELECT … FROM symbols WHERE type='method' AND source_snippet LIKE '%X%.on%'
+ *    ORDER BY model, parent_name, name LIMIT 20
+ *
+ * which carried both halves of the defect fixed in the EDT and api-usage paths:
+ * the LIKE cannot use an index, and ORDER BY forces every match to be read and
+ * sorted before LIMIT applies, so the cost is paid over all 627 K method rows —
+ * each carrying source_snippet in overflow pages. Measured warm on the 2 GB
+ * index: 3.2 s + 2.3 s per call, all of it blocking (node:sqlite is synchronous).
+ *
+ * The pre-filter is also the more accurate query. LIKE matches substrings, so
+ * `%SalesTable%.on%` reported SalesLine.setAddressFromSalesTable_BR — a method
+ * that only has the name inside a longer identifier and subscribes to nothing.
+ * FTS matches tokens and drops it. Measured after: 0–51 ms.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+import { findEventHandlersTool } from '../../src/tools/findEventHandlers';
+
+const open: any[] = [];
+
+function makeIndex(methods: Array<{ name: string; parent: string; snippet: string }>) {
+  const index: any = new XppSymbolIndex(':memory:', ':memory:');
+  open.push(index);
+  const ins = index.db.prepare(
+    `INSERT INTO symbols (name, type, parent_name, source_snippet, model, file_path)
+     VALUES (?, 'method', ?, ?, 'ApplicationSuite', ?)`);
+  for (const m of methods) ins.run(m.name, m.parent, m.snippet, `K:\\Pkg\\${m.parent}.xml`);
+  index.db.exec("INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild');");
+  return index;
+}
+
+afterEach(() => {
+  for (const i of open.splice(0)) i.close?.();
+});
+
+const METHODS = [
+  // a genuine delegate subscription on SalesTable
+  { name: 'attachHandlers', parent: 'SalesTableEventSubscriber',
+    snippet: 'public void attachHandlers()\n{\n    SalesTable.onInserted += eventhandler(this.handleInsert);\n}' },
+  // The false positive the substring LIKE used to report (this shape was found
+  // in the production index): the queried name appears only inside a longer
+  // identifier, and a later unrelated `.on…` call completes the `%X%.on%` match.
+  // Nothing here subscribes to anything.
+  { name: 'setAddressFromSalesTable_BR', parent: 'SalesLine',
+    snippet: '/// Executes after the original setAddressFromSalesTable_BR method.\npublic void setAddressFromSalesTable_BR()\n{\n    next setAddressFromSalesTable_BR();\n    this.onModifiedField(fieldNum(SalesLine, DeliveryPostalAddress));\n}' },
+  // a subscription on a different table, to prove the filter is not a pass-through
+  { name: 'attachInvent', parent: 'InventTableSubscriber',
+    snippet: 'InventTable.onUpdated += eventhandler(this.onInventUpdated);' },
+];
+
+const req = (targetClass: string) => ({
+  method: 'tools/call' as const,
+  params: { name: 'find_event_handlers', arguments: { targetClass, handlerType: 'delegate' as const } },
+});
+
+const ctx = (index: any) => ({ symbolIndex: index, bridge: null } as any);
+
+/**
+ * Context that records the SQL the tool actually prepares, so a plan assertion
+ * can be made against the real query rather than one restated in the test.
+ */
+function recordingCtx(index: any) {
+  const sql: string[] = [];
+  const real = index.getReadDb();
+  const proxy = new Proxy(real, {
+    get(target: any, prop: string | symbol) {
+      if (prop === 'prepare') {
+        return (text: string) => { sql.push(text); return target.prepare(text); };
+      }
+      const value = target[prop];
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  return { sql, ctx: { symbolIndex: { getReadDb: () => proxy }, bridge: null } as any };
+}
+
+describe('find_event_handlers — delegate search', () => {
+  it('finds a genuine delegate subscription', async () => {
+    const index = makeIndex(METHODS);
+    const result: any = await findEventHandlersTool(req('SalesTable'), ctx(index));
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('SalesTableEventSubscriber');
+  });
+
+  it('does not report a method that only contains the name inside a longer identifier', async () => {
+    const index = makeIndex(METHODS);
+    const result: any = await findEventHandlersTool(req('SalesTable'), ctx(index));
+
+    expect(result.content[0].text).not.toContain('setAddressFromSalesTable_BR');
+  });
+
+  it('does not leak subscriptions belonging to another table', async () => {
+    const index = makeIndex(METHODS);
+    const result: any = await findEventHandlersTool(req('SalesTable'), ctx(index));
+
+    expect(result.content[0].text).not.toContain('InventTableSubscriber');
+  });
+
+  it('answers a target nothing subscribes to without error', async () => {
+    const index = makeIndex(METHODS);
+    const result: any = await findEventHandlersTool(req('ZzzNoSuchClass'), ctx(index));
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).not.toContain('SalesTableEventSubscriber');
+  });
+
+  it('still answers when the index predates symbols_fts', async () => {
+    const index = makeIndex(METHODS);
+    index.db.exec('DROP TABLE symbols_fts');
+
+    // The pre-filter is an optimisation, not the source of truth: without it the
+    // tool must still find the subscription rather than erroring out.
+    const result: any = await findEventHandlersTool(req('SalesTable'), ctx(index));
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('SalesTableEventSubscriber');
+  });
+
+  it('keeps the delegate scan bounded by an index rather than a full table read', async () => {
+    // Behaviour alone cannot catch a return to the unbounded query — on a
+    // fixture-sized table a full scan is instant and answers the same, and the
+    // cost only exists at a scale no unit test can build. So take the SQL the
+    // tool really prepared and check the plan SQLite gives it.
+    const index = makeIndex(METHODS);
+    const { sql, ctx: recording } = recordingCtx(index);
+
+    await findEventHandlersTool(req('SalesTable'), recording);
+
+    const delegateQueries = sql.filter(s => s.includes('source_snippet LIKE'));
+    expect(delegateQueries.length).toBeGreaterThan(0);
+
+    for (const query of delegateQueries) {
+      const plan = index.db
+        .prepare('EXPLAIN QUERY PLAN ' + query)
+        .all()
+        .map((r: any) => r.detail)
+        .join(' | ');
+      expect(plan, `unbounded plan for: ${query}`).toMatch(/symbols_fts/);
+      expect(plan, `full table scan for: ${query}`).not.toMatch(/SCAN symbols\b/);
+    }
+  });
+});

--- a/tests/utils/gracefulShutdown.test.ts
+++ b/tests/utils/gracefulShutdown.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Graceful shutdown coordinator.
+ *
+ * The server had no shutdown path at all: SIGINT/SIGTERM and a closed stdin
+ * ended the process outright, so the C# bridge child was cut off wherever it
+ * happened to be — including part-way through writing AOT XML — and the SQLite
+ * handles were never closed.
+ *
+ * The properties worth pinning down are the ones that make shutdown safe to rely
+ * on: it releases everything, it releases in the right order, a resource that
+ * refuses to close cannot strand the others, and it always terminates.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createShutdownCoordinator } from '../../src/utils/gracefulShutdown.js';
+
+function harness(deadlineMs = 5_000) {
+  const logs: string[] = [];
+  const exits: number[] = [];
+  const coordinator = createShutdownCoordinator({
+    deadlineMs,
+    exit: (code) => { exits.push(code); },
+    log: (m) => { logs.push(m); },
+  });
+  return { coordinator, logs, exits };
+}
+
+describe('shutdown coordinator', () => {
+  it('runs every registered cleanup', async () => {
+    const { coordinator } = harness();
+    const bridge = vi.fn();
+    const index = vi.fn();
+
+    coordinator.onShutdown('symbol index', index);
+    coordinator.onShutdown('C# bridge', bridge);
+    await coordinator.shutdown('test');
+
+    expect(bridge).toHaveBeenCalledOnce();
+    expect(index).toHaveBeenCalledOnce();
+  });
+
+  it('releases last-registered first, so a resource goes before what it sits on', async () => {
+    const { coordinator } = harness();
+    const order: string[] = [];
+
+    coordinator.onShutdown('log file', () => { order.push('log file'); });
+    coordinator.onShutdown('symbol index', () => { order.push('symbol index'); });
+    coordinator.onShutdown('C# bridge', () => { order.push('C# bridge'); });
+    await coordinator.shutdown('test');
+
+    expect(order).toEqual(['C# bridge', 'symbol index', 'log file']);
+  });
+
+  it('awaits async cleanups instead of racing past them', async () => {
+    const { coordinator } = harness();
+    const order: string[] = [];
+
+    coordinator.onShutdown('http server', async () => {
+      await new Promise(r => setTimeout(r, 20));
+      order.push('http server');
+    });
+    coordinator.onShutdown('C# bridge', () => { order.push('C# bridge'); });
+    await coordinator.shutdown('test');
+
+    expect(order).toEqual(['C# bridge', 'http server']);
+  });
+
+  it('keeps going when one resource refuses to close, and says which', async () => {
+    const { coordinator, logs } = harness();
+    const after = vi.fn();
+
+    coordinator.onShutdown('symbol index', after);
+    coordinator.onShutdown('C# bridge', () => { throw new Error('pipe already gone'); });
+    await coordinator.shutdown('test');
+
+    expect(after).toHaveBeenCalledOnce();
+    expect(logs.join('\n')).toContain('C# bridge failed to close: pipe already gone');
+  });
+
+  it('survives a cleanup that rejects, not just one that throws', async () => {
+    const { coordinator, logs } = harness();
+    const after = vi.fn();
+
+    coordinator.onShutdown('symbol index', after);
+    coordinator.onShutdown('http server', async () => { throw new Error('socket stuck'); });
+    await coordinator.shutdown('test');
+
+    expect(after).toHaveBeenCalledOnce();
+    expect(logs.join('\n')).toContain('http server failed to close: socket stuck');
+  });
+
+  it('runs once even if several signals arrive together', async () => {
+    const { coordinator, exits } = harness();
+    const bridge = vi.fn();
+    coordinator.onShutdown('C# bridge', bridge);
+
+    await Promise.all([
+      coordinator.shutdown('received SIGTERM', 143),
+      coordinator.shutdown('received SIGINT', 130),
+    ]);
+    await coordinator.shutdown('stdin closed');
+
+    expect(bridge).toHaveBeenCalledOnce();
+    expect(exits).toEqual([143]);
+  });
+
+  it('exits with the code it was given', async () => {
+    const { coordinator, exits } = harness();
+    await coordinator.shutdown('received SIGTERM', 143);
+    expect(exits).toEqual([143]);
+  });
+
+  it('exits anyway when a cleanup never finishes', async () => {
+    vi.useFakeTimers();
+    try {
+      const { coordinator, exits, logs } = harness(1_000);
+      coordinator.onShutdown('wedged bridge', () => new Promise<void>(() => { /* never resolves */ }));
+
+      void coordinator.shutdown('received SIGTERM', 143);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      // A stop that does not stop is worse than an unclean one.
+      expect(exits).toEqual([143]);
+      expect(logs.join('\n')).toContain('still busy after 1000 ms');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports why it is shutting down', async () => {
+    const { coordinator, logs } = harness();
+    await coordinator.shutdown('stdin closed by the MCP client');
+
+    expect(logs[0]).toBe('[shutdown] stdin closed by the MCP client — releasing resources');
+    expect(logs.at(-1)).toBe('[shutdown] done');
+  });
+
+  it('exposes whether a shutdown is already under way', async () => {
+    const { coordinator } = harness();
+    expect(coordinator.isShuttingDown).toBe(false);
+    await coordinator.shutdown('test');
+    expect(coordinator.isShuttingDown).toBe(true);
+  });
+});


### PR DESCRIPTION
Findings from an audit of the server, each reproduced before it was fixed and verified after. Grouped one commit per theme.

## 1. API-key authentication was silently disabled — `fix(config)`

Entry points read as "configuration first":

```ts
import { loadEnv } from './utils/loadEnv.js';
loadEnv(import.meta.url);          // reads first, runs last
import { apiKeyAuth } from './middleware/apiKeyAuth.js';
```

ESM evaluates every `import` declaration before the first statement of the module body, so every module that snapshots `process.env` into a module-level const had already been evaluated against the unconfigured environment.

**Reproduced end-to-end:** with `API_KEY` supplied through `.env` or `config/secrets.json` — which is what `npm run setup` writes — `apiKeyAuth` saw `undefined`, concluded "auth disabled", and passed an unauthenticated `POST /mcp` straight through. Azure deployments were unaffected only because App Settings are real environment variables.

The same timing silently pinned `METADATA_PATH` (so multi-instance setups all read one folder), `RATE_LIMIT_*`, `MCP_TOOL_TIMEOUT_*` and `OPERATION_LOCK_*` to their defaults whenever they came from a file.

`src/bootstrapEnv.ts` is a side-effect module imported first by every entry point. Being first is what makes it correct, so it is not self-enforcing — a test asserts the first import line of each entry point. As defence in depth, the security path now reads its setting per request and no longer depends on import order at all.

## 2. Three tool queries scanned the symbol table — `perf(index)`

Each asked an equality question with a substring operator, so each was both wrong and unbounded. `node:sqlite` is synchronous, so the scan blocks the whole server; the observed failure mode is the MCP client giving up and killing the process.

Measured on the production 2 GB index (1.17 M symbols):

| tool | before | after |
|---|---|---|
| `analyze_code(mode="api-usage")` | **> 7 min** | 0–230 ms |
| `get_object_info(edt, mode="hierarchy")` | **63 s** | 22–41 ms |
| `find_event_handlers` (delegate branch) | **5.5 s** | 0–51 ms |

**Why unbounded.** `LIMIT` only stops a scan once enough matches exist, so a name with *no* matches is the worst case; an `ORDER BY` over an unindexed predicate forces every match to be read and sorted before the `LIMIT` applies, making a name that *does* exist the worst case instead. Reaching any non-indexed column is what costs: counting the 627 K `method` rows through `idx_type_name` takes **56 ms**, but touching `used_types` on those same rows takes **37.7 s**, because each row carries `source_snippet` and `source` in overflow pages.

**Why also incorrect.** `used_types` is a comma-separated list of exact type names, so `LIKE '%SalesTable%'` matched methods using only `AxSalesTable` or `MCRSalesTableRefRecId`. For a `type='field'` row, `signature` holds the field's type name, so `LIKE '%AmountMST%'` reported fields typed `QuotationAmountMST`, `AdjustAmountMST`, `BaseAmountMST`. And `source_snippet LIKE '%X%.on%'` reported `SalesLine.setAddressFromSalesTable_BR`, which merely has the name inside a longer identifier and subscribes to nothing.

Each query now narrows through `symbols_fts` — the pattern already used by `findReferences` and by `find_event_handlers`' own *static* branch — then decides with the exact test. **Recall of the pre-filter was measured against a full scan, not assumed:** 100 % for the EDT case, and every row it dropped in the delegate case was one of the false positives above. Where FTS cannot be exact (`used_types` is not an FTS column) the pre-filter does narrow what can be returned; that is acceptable for api-usage specifically, because the caller reads examples out of `source_snippet`, so a row whose snippet lacks the name has nothing to contribute.

Also fixes hierarchy mode disagreeing with basic mode about what exists: `amountmst` reported the EDT as missing while `AmountMST` returned it.

## 3. Errors returned under the wrong request id — `fix(transport)`

The transport swaps `request.id` for an internal routing key, and `request` **is** `req.body`, so the swap mutates the body — which the catch block then read back to tag its error response. Clients received an error tagged with a key they never sent, could not correlate it, and waited out their own timeout. Also cancels a per-request timer that could stay live for up to 10 minutes.

## 4. No shutdown path — `feat(server)`

A signal or a closed stdin ended the process outright, so the C# bridge child was cut off wherever it happened to be — including part-way through writing AOT XML — and the SQLite handles were never closed.

Cleanups run last-registered-first (bridge → symbol index → HTTP server → log file). Each step is best-effort, a failing one cannot strand the rest, and the sequence is capped by `SHUTDOWN_TIMEOUT_MS` (default 5 s) — past the deadline the process exits anyway, because a stop that does not stop is worse than an unclean one.

Verified on the dev VM by watching `D365MetadataBridge.exe` across a real start/stop: the spawned bridge is gone afterwards, and a bridge belonging to another session is untouched.

**Platform note, measured rather than assumed:** on Windows a signal sent from another process does *not* run these handlers — libuv implements it as `TerminateProcess`. There the path that matters is stdin closing (how an MCP client ends a stdio session, and the one verified above) plus Ctrl+C in a console. The signal handlers work as written on Linux, where Azure sends SIGTERM before a restart.

## On the tests

`2571 passed, 0 failed` (193 files), from `2524` before — 47 added.

SQLite's `LIKE` is already case-insensitive for ASCII, and on a fixture-sized table a full scan is instant and answers identically, so behavioural assertions alone cannot catch a return to the old queries. Each query suite therefore also takes the SQL the code *really prepares* and asserts the plan SQLite gives it. **Every suite was checked by reverting its fix and confirming it fails** — the first drafts caught only 1 regression in 6, which is why they were rewritten.

## Deliberately not done

- Moving `source_snippet`/`source` out of `symbols` into a side table. It would make this whole class of query cheap, but it needs a rebuild of the 2 GB index — a call for the maintainer, not a drive-by.
- `tests/knowledge/apiSymbols.test.ts` still fails on a cold cache (120 s timeout) and passes warm in ~2 s. Pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
