### PR TITLE
fix(workspaceDetector): stop silently picking the wrong .rnrproj when multiple projects exist

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -73,7 +73,11 @@ async function withProjectFileLock<T>(projectPath: string, fn: () => Promise<T>)
  * wrong project.
  */
 function buildNoProjectPathWarning(): string {
-  const candidates = getConfigManager().getAllDetectedProjects();
+  // The WORKSPACE candidates, not getAllDetectedProjects(): under
+  // D365FO_SOLUTIONS_PATH the latter lists every project across every solution,
+  // which would put a wrong count behind "in this workspace" and can run to
+  // dozens of lines in what should be a short, actionable warning.
+  const candidates = getConfigManager().getWorkspaceProjectCandidates();
   if (candidates.length > 1) {
     return `\n⚠️ addToProject=true but no projectPath could be resolved: ${candidates.length} .rnrproj ` +
       `files were found in this workspace and none matched unambiguously.\n` +

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -82,7 +82,13 @@ function buildNoProjectPathWarning(): string {
       candidates.map(c => `   - ${c.modelName}: ${c.projectPath ?? '(no .rnrproj)'}`).join('\n') + '\n';
   }
   return `\n⚠️ addToProject=true but no projectPath could be resolved.\n` +
-    `Add projectPath to .mcp.json or pass it as a parameter.`;
+    `The file was created on disk but was NOT added to any Visual Studio project.\n\n` +
+    `Pass projectPath as a parameter, or add it to your .mcp.json:\n` +
+    `  {\n` +
+    `    "servers": { "context": {\n` +
+    `      "projectPath": "K:\\\\VSProjects\\\\YourSolution\\\\YourModel\\\\YourModel.rnrproj"\n` +
+    `    } }\n` +
+    `  }\n`;
 }
 
 const CreateD365FileArgsSchema = z.object({
@@ -133,13 +139,9 @@ const CreateD365FileArgsSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Path to .rnrproj file. Effectively MANDATORY, not optional, in any workspace with more than one ' +
-      'D365FO project/model: auto-detection can only resolve unambiguously when exactly one .rnrproj is ' +
-      'found (or one uniquely matches the workspace name). Whenever a workspace has multiple .rnrproj ' +
-      'files, auto-detection deliberately refuses to guess between them — call get_workspace_info first ' +
-      'to see the detected candidates, then pass this parameter explicitly on every create call so the ' +
-      'file is registered into the intended project instead of being silently added to the wrong one or ' +
-      'not added at all.'
+      'Path to .rnrproj file. Required for addToProject in any workspace holding more than one .rnrproj: ' +
+      'auto-detection resolves a project only when there is exactly one, or one whose folder matches the ' +
+      'workspace name, and otherwise refuses to guess. Call get_workspace_info to list the candidates.'
     ),
   solutionPath: z
     .string()

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -63,6 +63,28 @@ async function withProjectFileLock<T>(projectPath: string, fn: () => Promise<T>)
   }
 }
 
+/**
+ * Builds the "no projectPath could be resolved" warning shown when
+ * addToProject=true but neither projectPath/solutionPath nor auto-detection
+ * produced a usable path. When multiple .rnrproj files exist in the workspace,
+ * auto-detection deliberately refuses to guess between them (see
+ * workspaceDetector.ts detectD365Project) — list the candidates so the caller
+ * knows to pass projectPath explicitly instead of silently landing on the
+ * wrong project.
+ */
+function buildNoProjectPathWarning(): string {
+  const candidates = getConfigManager().getAllDetectedProjects();
+  if (candidates.length > 1) {
+    return `\n⚠️ addToProject=true but no projectPath could be resolved: ${candidates.length} .rnrproj ` +
+      `files were found in this workspace and none matched unambiguously.\n` +
+      `The file was created on disk but was NOT added to any Visual Studio project.\n\n` +
+      `Pass projectPath explicitly to target the right one:\n` +
+      candidates.map(c => `   - ${c.modelName}: ${c.projectPath ?? '(no .rnrproj)'}`).join('\n') + '\n';
+  }
+  return `\n⚠️ addToProject=true but no projectPath could be resolved.\n` +
+    `Add projectPath to .mcp.json or pass it as a parameter.`;
+}
+
 const CreateD365FileArgsSchema = z.object({
   objectType: z
     .enum([
@@ -110,7 +132,15 @@ const CreateD365FileArgsSchema = z.object({
   projectPath: z
     .string()
     .optional()
-    .describe('Path to .rnrproj file. Required for addToProject to work. If not specified, auto-detected from .mcp.json or workspace context.'),
+    .describe(
+      'Path to .rnrproj file. Effectively MANDATORY, not optional, in any workspace with more than one ' +
+      'D365FO project/model: auto-detection can only resolve unambiguously when exactly one .rnrproj is ' +
+      'found (or one uniquely matches the workspace name). Whenever a workspace has multiple .rnrproj ' +
+      'files, auto-detection deliberately refuses to guess between them — call get_workspace_info first ' +
+      'to see the detected candidates, then pass this parameter explicitly on every create call so the ' +
+      'file is registered into the intended project instead of being silently added to the wrong one or ' +
+      'not added at all.'
+    ),
   solutionPath: z
     .string()
     .optional()
@@ -4761,8 +4791,7 @@ export async function handleCreateD365File(
                     projectMsg = `\n⚠️ Could not add to project: ${projErr}`;
                   }
                 } else {
-                  projectMsg = `\n⚠️ addToProject=true but no projectPath could be resolved.\n` +
-                    `Add projectPath to .mcp.json or pass it as a parameter.`;
+                  projectMsg = buildNoProjectPathWarning();
                 }
               }
 
@@ -4858,8 +4887,7 @@ export async function handleCreateD365File(
                 projectMsg = `\n⚠️ Could not add to project: ${projErr}`;
               }
             } else {
-              projectMsg = `\n⚠️ addToProject=true but no projectPath could be resolved.\n` +
-                `Add projectPath to .mcp.json or pass it as a parameter.`;
+              projectMsg = buildNoProjectPathWarning();
             }
           }
 
@@ -5213,15 +5241,8 @@ export async function handleCreateD365File(
         }
       } else if (!projectMessage) {
         // No projectPath found from any source — surface this in the response so AI and user see it
-        projectMessage = `\n⚠️ addToProject=true but no projectPath could be resolved.\n` +
-          `The file was created on disk but was NOT added to the Visual Studio project.\n\n` +
-          `To fix this, add projectPath to your .mcp.json:\n` +
-          `  {\n` +
-          `    "servers": { "context": {\n` +
-          `      "projectPath": "K:\\\\VSProjects\\\\YourSolution\\\\YourModel\\\\YourModel.rnrproj"\n` +
-          `    } }\n` +
-          `  }\n` +
-          `Until then, add the file manually in Visual Studio: right-click project → Add Existing Item → ${normalizedFullPath}\n`;
+        projectMessage = buildNoProjectPathWarning() +
+          `\nUntil resolved, add the file manually in Visual Studio: right-click project → Add Existing Item → ${normalizedFullPath}\n`;
       }
     }
 

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -479,7 +479,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         const allProjects = configManager.getAllDetectedProjects();
         if (allProjects.length > 1) {
           lines.push(``);
-          lines.push(`## Available Projects (D365FO_SOLUTIONS_PATH)`);
+          lines.push(`## Available Projects`);
           lines.push(``);
           for (const p of allProjects) {
             const active = p.projectPath === projectPath ? '▶ ' : '  ';

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -67,10 +67,16 @@ class ConfigManager {
   private autoDetectionAttempted: boolean = false;
   // Auto-detection results cached per workspace path.
   private autoDetectionCache = new Map<string, D365ProjectInfo | null>();
-  // All known .rnrproj candidates: from the D365FO_SOLUTIONS_PATH scan when that is
-  // configured, otherwise from the workspace itself when auto-detection could not
-  // settle on one project.
+  // All projects found by the D365FO_SOLUTIONS_PATH scan. Solution switching and
+  // matchProjectForWorkspace() read this, and both need the full picture across
+  // every solution — so nothing else may write to it.
   private allDetectedProjects: D365ProjectInfo[] = [];
+  // The .rnrproj files sitting in the WORKSPACE when auto-detection could not pick
+  // one of them. Kept apart from allDetectedProjects above: sharing one field made
+  // a populated candidate list look like a completed solutions-path scan, which
+  // both suppressed that scan and let its "use the first project found" fallback
+  // adopt an arbitrary workspace .rnrproj — the very bug this branch removes.
+  private workspaceProjectCandidates: D365ProjectInfo[] = [];
   // Monotonically-increasing counter identifying each background detection call;
   // a scan whose generation is stale by the time it finishes is discarded so it
   // can't overwrite a more recent, more specific scan's result.
@@ -191,11 +197,13 @@ class ConfigManager {
     // none unambiguously "the" one) or nothing was found. Record every candidate so
     // callers that need a project (addToProject, get_workspace_info) can name the
     // real alternatives instead of a generic "could not resolve". Only runs on this
-    // failure path, once per workspace, and never overwrites a solutions-path scan.
-    if (!detectedProject?.projectPath && workspacePath && this.allDetectedProjects.length === 0) {
+    // failure path, once per workspace, and into its own field: allDetectedProjects
+    // belongs to the solutions-path scan below, which must neither be skipped
+    // because this list is non-empty nor draw its fallback project from it.
+    if (!detectedProject?.projectPath && workspacePath) {
       const candidates = await scanAllD365Projects(workspacePath);
       if (candidates.length > 0) {
-        this.allDetectedProjects = candidates;
+        this.workspaceProjectCandidates = candidates;
         console.error(
           `[ConfigManager] No project auto-selected — ${candidates.length} candidate(s) in workspace: ` +
           candidates.map(c => c.modelName).join(', ')
@@ -1023,13 +1031,24 @@ class ConfigManager {
   }
 
   /**
-   * Returns all known .rnrproj candidates — from the D365FO_SOLUTIONS_PATH scan, or
-   * from the workspace when auto-detection found several and could not pick one.
-   * Used by get_workspace_info to list available projects for solution switching,
-   * and by createD365File to name the alternatives when projectPath is missing.
+   * Returns all projects discovered by the D365FO_SOLUTIONS_PATH scan.
+   * Used by get_workspace_info to list available projects for solution switching.
    */
   getAllDetectedProjects(): D365ProjectInfo[] {
     return this.allDetectedProjects;
+  }
+
+  /**
+   * The .rnrproj files found in the WORKSPACE when auto-detection refused to pick
+   * one of them. Empty whenever a project was resolved — these are the concrete
+   * alternatives createD365File names when addToProject has no projectPath to use.
+   *
+   * Not the same list as getAllDetectedProjects(): that one spans every solution
+   * under D365FO_SOLUTIONS_PATH and would answer "which projects exist anywhere",
+   * not "which projects is this workspace ambiguous between".
+   */
+  getWorkspaceProjectCandidates(): D365ProjectInfo[] {
+    return this.workspaceProjectCandidates;
   }
 
   /**

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -67,7 +67,9 @@ class ConfigManager {
   private autoDetectionAttempted: boolean = false;
   // Auto-detection results cached per workspace path.
   private autoDetectionCache = new Map<string, D365ProjectInfo | null>();
-  // All projects found when D365FO_SOLUTIONS_PATH is configured.
+  // All known .rnrproj candidates: from the D365FO_SOLUTIONS_PATH scan when that is
+  // configured, otherwise from the workspace itself when auto-detection could not
+  // settle on one project.
   private allDetectedProjects: D365ProjectInfo[] = [];
   // Monotonically-increasing counter identifying each background detection call;
   // a scan whose generation is stale by the time it finishes is discarded so it
@@ -185,6 +187,22 @@ class ConfigManager {
       }
     }
 
+    // No projectPath resolved — either the workspace is ambiguous (several .rnrproj,
+    // none unambiguously "the" one) or nothing was found. Record every candidate so
+    // callers that need a project (addToProject, get_workspace_info) can name the
+    // real alternatives instead of a generic "could not resolve". Only runs on this
+    // failure path, once per workspace, and never overwrites a solutions-path scan.
+    if (!detectedProject?.projectPath && workspacePath && this.allDetectedProjects.length === 0) {
+      const candidates = await scanAllD365Projects(workspacePath);
+      if (candidates.length > 0) {
+        this.allDetectedProjects = candidates;
+        console.error(
+          `[ConfigManager] No project auto-selected — ${candidates.length} candidate(s) in workspace: ` +
+          candidates.map(c => c.modelName).join(', ')
+        );
+      }
+    }
+
     // Store in cache (PERFORMANCE FIX)
     this.autoDetectionCache.set(cacheKey, detectedProject);
 
@@ -202,7 +220,11 @@ class ConfigManager {
     } else if (detectedProject) {
       this.autoDetectedProject = detectedProject;
       console.error('[ConfigManager] ✅ Auto-detection successful:');
-      console.error(`   ProjectPath: ${detectedProject.projectPath}`);
+      console.error(
+        detectedProject.ambiguousProjects
+          ? `   ProjectPath: (not auto-selected — ${detectedProject.ambiguousProjects.length} candidates share this model; pass projectPath explicitly)`
+          : `   ProjectPath: ${detectedProject.projectPath}`
+      );
       console.error(`   ModelName: ${detectedProject.modelName}`);
       console.error(`   SolutionPath: ${detectedProject.solutionPath}`);
       // ✨ Register the auto-detected model as custom
@@ -1001,8 +1023,10 @@ class ConfigManager {
   }
 
   /**
-   * Returns all projects discovered by the D365FO_SOLUTIONS_PATH scan.
-   * Used by get_workspace_info to list available projects for solution switching.
+   * Returns all known .rnrproj candidates — from the D365FO_SOLUTIONS_PATH scan, or
+   * from the workspace when auto-detection found several and could not pick one.
+   * Used by get_workspace_info to list available projects for solution switching,
+   * and by createD365File to name the alternatives when projectPath is missing.
    */
   getAllDetectedProjects(): D365ProjectInfo[] {
     return this.allDetectedProjects;

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -17,6 +17,14 @@ export interface D365ProjectInfo {
   /** Base PackagesLocalDirectory path, if known */
   packagePath?: string;
   packageName?: string;     // Package containing this model (may differ from model name in UDE)
+  /**
+   * Every .rnrproj found when the workspace held more than one and none could be
+   * resolved unambiguously. Set only on ambiguous results, where projectPath and
+   * solutionPath are deliberately left undefined: the model is known (all
+   * candidates agree on it) but the caller must pass projectPath explicitly for
+   * anything that registers a file into a VS project.
+   */
+  ambiguousProjects?: string[];
 }
 
 /**
@@ -113,8 +121,62 @@ export async function extractModelNameFromProject(projectPath: string): Promise<
 }
 
 /**
+ * Read the <Model> name of every candidate .rnrproj, keyed by project path.
+ * Unreadable projects are omitted.
+ */
+async function readModelNames(projectFiles: string[]): Promise<Map<string, string>> {
+  const byPath = new Map<string, string>();
+  for (const pf of projectFiles) {
+    const model = await extractModelNameFromProject(pf);
+    if (model) byPath.set(pf, model);
+  }
+  return byPath;
+}
+
+/**
+ * Distinct non-demo model names across the candidates, lower-cased for comparison
+ * but returned in original casing (first occurrence wins).
+ */
+function distinctCustomModels(models: Iterable<string>): string[] {
+  const seen = new Map<string, string>();
+  for (const m of models) {
+    if (isMicrosoftDemoModel(m)) continue;
+    const key = m.toLowerCase();
+    if (!seen.has(key)) seen.set(key, m);
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Pick the .rnrproj that is unambiguously "the" project for this workspace.
+ * Exactly one candidate wins outright; with several, only a folder name matching
+ * the workspace base name counts (D365FO multi-project solution convention).
+ * Returns null when the choice would be a guess.
+ */
+function resolvePrimaryProject(workspacePath: string, projectFiles: string[]): string | null {
+  if (projectFiles.length === 1) return projectFiles[0];
+
+  const wpBase = path.basename(workspacePath).toLowerCase();
+  const nameMatch = projectFiles.find(
+    p => path.basename(path.dirname(p)).toLowerCase() === wpBase,
+  );
+  if (nameMatch) {
+    debugLog(`[WorkspaceDetector] Solution-name match → ${path.basename(nameMatch)}`);
+    return nameMatch;
+  }
+  return null;
+}
+
+/**
  * Detect D365FO project information from workspace path
  * This is automatically called when GitHub Copilot provides workspace context
+ *
+ * When several .rnrproj files exist and none is unambiguously the intended one,
+ * no project is selected — picking "the first one found" silently registered new
+ * files into an arbitrary, unrelated VS project. The model name still resolves
+ * whenever every candidate agrees on it (the common case: one model split across
+ * several projects), so only project-registering operations are held back; those
+ * results carry `ambiguousProjects` and no projectPath.
  */
 export async function detectD365Project(workspacePath: string, maxDepth: number = 5): Promise<D365ProjectInfo | null> {
   try {
@@ -131,36 +193,31 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
     debugLog(`[WorkspaceDetector] Found ${projectFiles.length} .rnrproj file(s):`);
     projectFiles.forEach(p => debugLog(`   - ${p}`));
 
-    // Prefer the .rnrproj whose own folder name matches the workspace base name
-    // (D365FO multi-project solution convention). With exactly one candidate,
-    // use it. With multiple candidates and no unambiguous match, refuse to
-    // guess — silently picking projectFiles[0] previously caused new files to
-    // be registered into an arbitrary, unrelated "first found" project.
-    let primaryProject: string;
-    if (projectFiles.length === 1) {
-      primaryProject = projectFiles[0];
-    } else {
-      const wpBase = path.basename(workspacePath).toLowerCase();
-      const nameMatch = projectFiles.find(
-        p => path.basename(path.dirname(p)).toLowerCase() === wpBase,
+    let primaryProject = resolvePrimaryProject(workspacePath, projectFiles);
+
+    if (!primaryProject) {
+      // Ambiguous workspace: report the model when every candidate agrees on one
+      // (one model split across several projects), but never a projectPath.
+      // Only this branch needs every candidate's model — with a resolved primary
+      // we read one file, as before (solution roots can hold dozens of projects).
+      const models = await readModelNames(projectFiles);
+      const customModels = distinctCustomModels(models.values());
+      debugLog(
+        `[WorkspaceDetector] Ambiguous: ${projectFiles.length} .rnrproj files and none matches the ` +
+        `workspace name — not auto-selecting a project. Candidates:\n` +
+        projectFiles.map(p => `   - ${p}`).join('\n')
       );
-      if (nameMatch) {
-        primaryProject = nameMatch;
-        debugLog(`[WorkspaceDetector] Solution-name match → ${path.basename(nameMatch)}`);
-      } else {
-        console.error(
-          `[WorkspaceDetector] ⚠️ Ambiguous: ${projectFiles.length} .rnrproj files found and none match ` +
-          `the workspace name — refusing to auto-select one. Candidates:\n` +
-          projectFiles.map(p => `   - ${p}`).join('\n') +
-          `\nCaller must pass projectPath explicitly.`
-        );
+      if (customModels.length !== 1) {
+        debugLog(`[WorkspaceDetector] Candidates span ${customModels.length} custom model(s) — model name unresolved too`);
         return null;
       }
+      debugLog(`[WorkspaceDetector] All candidates share model "${customModels[0]}" — model resolved, projectPath left unset`);
+      return { modelName: customModels[0], ambiguousProjects: projectFiles };
     }
 
     // Prefer a non-demo model when the initially selected primaryProject has a
     // Microsoft demo model name (e.g. FleetManagement).
-    const modelName = await extractModelNameFromProject(primaryProject);
+    let modelName = await extractModelNameFromProject(primaryProject);
     if (modelName && isMicrosoftDemoModel(modelName) && projectFiles.length > 1) {
       debugLog(`[WorkspaceDetector] Primary .rnrproj has MS demo model "${modelName}" — looking for better candidate`);
       for (const pf of projectFiles) {
@@ -169,6 +226,9 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
         if (altModel && !isMicrosoftDemoModel(altModel)) {
           debugLog(`[WorkspaceDetector] Skipping demo model "${modelName}", using "${altModel}" from ${path.basename(pf)}`);
           primaryProject = pf;
+          // Keep model and project in step — reporting the demo model alongside
+          // the replacement project would mis-target every downstream lookup.
+          modelName = altModel;
           break;
         }
       }
@@ -275,7 +335,26 @@ export async function autoDetectD365Project(
         if (files.length > 0) {
           const loggedSearchRoot = sanitizePathForLog(searchRoot);
           debugLog(`[WorkspaceDetector] Found ${files.length} .rnrproj file(s) in ${loggedSearchRoot}`);
-          const projectPath = files[0]; // take first (most likely the user's project)
+          // Same no-guessing rule as detectD365Project — and it matters more here,
+          // since this root is not the user's workspace: picking "first found"
+          // could land on a project from an entirely unrelated solution.
+          let projectPath = files[0];
+          if (files.length > 1) {
+            const rootModels = await readModelNames(files);
+            const customModels = distinctCustomModels(rootModels.values());
+            if (customModels.length !== 1) {
+              debugLog(
+                `[WorkspaceDetector] Skipping ${loggedSearchRoot}: ${files.length} .rnrproj files spanning ` +
+                `${customModels.length} custom model(s) — too ambiguous to auto-select. ` +
+                `Set D365FO_SOLUTIONS_PATH or pass projectPath explicitly.`
+              );
+              continue;
+            }
+            // Exactly one custom model here, but the alphabetically first file may
+            // still be a demo project — take a project that actually carries it.
+            const owning = files.find(f => rootModels.get(f) === customModels[0]);
+            if (owning) projectPath = owning;
+          }
           const modelName = await extractModelNameFromProject(projectPath);
           if (modelName) {
             const solutionPath = path.dirname(path.dirname(projectPath));

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -132,9 +132,14 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
     projectFiles.forEach(p => debugLog(`   - ${p}`));
 
     // Prefer the .rnrproj whose own folder name matches the workspace base name
-    // (D365FO multi-project solution convention); else the first file found.
-    let primaryProject = projectFiles[0];
-    if (projectFiles.length > 1) {
+    // (D365FO multi-project solution convention). With exactly one candidate,
+    // use it. With multiple candidates and no unambiguous match, refuse to
+    // guess — silently picking projectFiles[0] previously caused new files to
+    // be registered into an arbitrary, unrelated "first found" project.
+    let primaryProject: string;
+    if (projectFiles.length === 1) {
+      primaryProject = projectFiles[0];
+    } else {
       const wpBase = path.basename(workspacePath).toLowerCase();
       const nameMatch = projectFiles.find(
         p => path.basename(path.dirname(p)).toLowerCase() === wpBase,
@@ -142,6 +147,14 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
       if (nameMatch) {
         primaryProject = nameMatch;
         debugLog(`[WorkspaceDetector] Solution-name match → ${path.basename(nameMatch)}`);
+      } else {
+        console.error(
+          `[WorkspaceDetector] ⚠️ Ambiguous: ${projectFiles.length} .rnrproj files found and none match ` +
+          `the workspace name — refusing to auto-select one. Candidates:\n` +
+          projectFiles.map(p => `   - ${p}`).join('\n') +
+          `\nCaller must pass projectPath explicitly.`
+        );
+        return null;
       }
     }
 

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -196,23 +196,37 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
     let primaryProject = resolvePrimaryProject(workspacePath, projectFiles);
 
     if (!primaryProject) {
-      // Ambiguous workspace: report the model when every candidate agrees on one
-      // (one model split across several projects), but never a projectPath.
-      // Only this branch needs every candidate's model — with a resolved primary
-      // we read one file, as before (solution roots can hold dozens of projects).
+      // Ambiguous by folder name — but the candidates' models may still settle it.
+      // Only this branch needs every candidate's model; with a resolved primary we
+      // read one file, as before (solution roots can hold dozens of projects).
       const models = await readModelNames(projectFiles);
       const customModels = distinctCustomModels(models.values());
       debugLog(
-        `[WorkspaceDetector] Ambiguous: ${projectFiles.length} .rnrproj files and none matches the ` +
-        `workspace name — not auto-selecting a project. Candidates:\n` +
-        projectFiles.map(p => `   - ${p}`).join('\n')
+        `[WorkspaceDetector] ${projectFiles.length} .rnrproj files and none matches the workspace ` +
+        `name. Candidates:\n` + projectFiles.map(p => `   - ${p}`).join('\n')
       );
       if (customModels.length !== 1) {
-        debugLog(`[WorkspaceDetector] Candidates span ${customModels.length} custom model(s) — model name unresolved too`);
+        debugLog(`[WorkspaceDetector] Candidates span ${customModels.length} custom model(s) — nothing to resolve`);
         return null;
       }
-      debugLog(`[WorkspaceDetector] All candidates share model "${customModels[0]}" — model resolved, projectPath left unset`);
-      return { modelName: customModels[0], ambiguousProjects: projectFiles };
+
+      // Exactly one custom model across the candidates. If exactly one project
+      // CARRIES it, that project is not a guess — the others are Microsoft demo
+      // projects (the VS wizard default nobody renamed), which is the ordinary
+      // shape of a workspace holding a leftover tutorial project alongside the
+      // real one. Refusing here would drop a projectPath the previous code got
+      // right, and addToProject would silently stop working for those users.
+      const owning = projectFiles.filter(p => models.get(p) === customModels[0]);
+      if (owning.length === 1) {
+        debugLog(`[WorkspaceDetector] Only ${path.basename(owning[0])} carries custom model "${customModels[0]}" → resolved`);
+        primaryProject = owning[0];
+      } else {
+        debugLog(
+          `[WorkspaceDetector] ${owning.length} projects share model "${customModels[0]}" — model resolved, ` +
+          `projectPath left unset (only the caller knows which one to register files into)`
+        );
+        return { modelName: customModels[0], ambiguousProjects: projectFiles };
+      }
     }
 
     // Prefer a non-demo model when the initially selected primaryProject has a
@@ -335,25 +349,29 @@ export async function autoDetectD365Project(
         if (files.length > 0) {
           const loggedSearchRoot = sanitizePathForLog(searchRoot);
           debugLog(`[WorkspaceDetector] Found ${files.length} .rnrproj file(s) in ${loggedSearchRoot}`);
-          // Same no-guessing rule as detectD365Project — and it matters more here,
-          // since this root is not the user's workspace: picking "first found"
-          // could land on a project from an entirely unrelated solution.
+          // The same no-guessing rule as detectD365Project, and applied at least
+          // as strictly: this root is NOT the user's workspace, so a wrong pick
+          // lands on a project from an entirely unrelated solution. A root is
+          // usable only when exactly one project carries exactly one custom
+          // model; "one model split across several projects" resolves the model
+          // in a workspace but is not enough out here, where there is no
+          // workspace name to appeal to and no caller who knows the answer.
           let projectPath = files[0];
           if (files.length > 1) {
             const rootModels = await readModelNames(files);
             const customModels = distinctCustomModels(rootModels.values());
-            if (customModels.length !== 1) {
+            const owning = customModels.length === 1
+              ? files.filter(f => rootModels.get(f) === customModels[0])
+              : [];
+            if (owning.length !== 1) {
               debugLog(
-                `[WorkspaceDetector] Skipping ${loggedSearchRoot}: ${files.length} .rnrproj files spanning ` +
-                `${customModels.length} custom model(s) — too ambiguous to auto-select. ` +
-                `Set D365FO_SOLUTIONS_PATH or pass projectPath explicitly.`
+                `[WorkspaceDetector] Skipping ${loggedSearchRoot}: ${files.length} .rnrproj files across ` +
+                `${customModels.length} custom model(s), ${owning.length} of them carrying it — too ` +
+                `ambiguous to auto-select. Set D365FO_SOLUTIONS_PATH or pass projectPath explicitly.`
               );
               continue;
             }
-            // Exactly one custom model here, but the alphabetically first file may
-            // still be a demo project — take a project that actually carries it.
-            const owning = files.find(f => rootModels.get(f) === customModels[0]);
-            if (owning) projectPath = owning;
+            projectPath = owning[0];
           }
           const modelName = await extractModelNameFromProject(projectPath);
           if (modelName) {

--- a/tests/utils/ambiguousProjectCandidates.test.ts
+++ b/tests/utils/ambiguousProjectCandidates.test.ts
@@ -77,7 +77,7 @@ describe('ambiguous workspace — candidate listing', () => {
     await (mgr as any).autoDetectProject(WORKSPACE);
 
     expect(scanAllD365Projects).toHaveBeenCalledWith(WORKSPACE);
-    expect(mgr.getAllDetectedProjects().map(p => p.projectPath)).toEqual(
+    expect(mgr.getWorkspaceProjectCandidates().map(p => p.projectPath)).toEqual(
       CANDIDATES.map(p => p.projectPath),
     );
   });
@@ -100,6 +100,28 @@ describe('ambiguous workspace — candidate listing', () => {
     await (mgr as any).autoDetectProject(WORKSPACE);
 
     expect(scanAllD365Projects).not.toHaveBeenCalled();
-    expect(mgr.getAllDetectedProjects()).toEqual([]);
+    expect(mgr.getWorkspaceProjectCandidates()).toEqual([]);
+  });
+
+  it('keeps the candidate list out of the solutions-path list', async () => {
+    // Two lists, two meanings. Feeding workspace candidates into
+    // allDetectedProjects made a populated list look like a finished
+    // D365FO_SOLUTIONS_PATH scan, so the scan below was skipped as unnecessary
+    // AND its "no project detected → use the first one found" fallback adopted an
+    // arbitrary workspace .rnrproj — reinstating, one branch over, exactly the
+    // silent wrong-project pick this change removes.
+    const SOLUTIONS = [
+      { projectPath: 'K:\\solutions\\Fin\\Fin.rnrproj', modelName: 'IsvFin', solutionPath: 'K:\\solutions\\Fin' },
+    ];
+    process.env.D365FO_SOLUTIONS_PATH = 'K:\\solutions';
+    vi.mocked(scanAllD365Projects).mockImplementation(async (root: string) =>
+      (root === WORKSPACE ? CANDIDATES : SOLUTIONS) as any);
+    const mgr = makeManager();
+
+    await (mgr as any).autoDetectProject(WORKSPACE);
+
+    expect(scanAllD365Projects).toHaveBeenCalledWith('K:\\solutions');
+    expect(mgr.getAllDetectedProjects().map(p => p.modelName)).toEqual(['IsvFin']);
+    expect(mgr.getWorkspaceProjectCandidates().map(p => p.modelName)).toEqual(['ContosoCore', 'ContosoCore']);
   });
 });

--- a/tests/utils/ambiguousProjectCandidates.test.ts
+++ b/tests/utils/ambiguousProjectCandidates.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Candidate listing for ambiguous workspaces
+ *
+ * When auto-detection refuses to pick a .rnrproj, the tools that need one
+ * (createD365File's addToProject, get_workspace_info) must be able to name the
+ * real alternatives. getAllDetectedProjects() used to be fed exclusively by the
+ * D365FO_SOLUTIONS_PATH scan, so in the very setup that triggers the refusal —
+ * a multi-project workspace, no D365FO_SOLUTIONS_PATH — it returned an empty
+ * list and the warning degraded to a generic "could not resolve".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const AMBIGUOUS = {
+  modelName: 'ContosoCore',
+  ambiguousProjects: [
+    'K:\\repos\\Contoso\\Alpha\\Alpha.rnrproj',
+    'K:\\repos\\Contoso\\Beta\\Beta.rnrproj',
+  ],
+};
+
+const CANDIDATES = [
+  { projectPath: 'K:\\repos\\Contoso\\Alpha\\Alpha.rnrproj', modelName: 'ContosoCore', solutionPath: 'K:\\repos\\Contoso' },
+  { projectPath: 'K:\\repos\\Contoso\\Beta\\Beta.rnrproj', modelName: 'ContosoCore', solutionPath: 'K:\\repos\\Contoso' },
+];
+
+vi.mock('../../src/utils/workspaceDetector.js', () => ({
+  autoDetectD365Project: vi.fn(async () => AMBIGUOUS),
+  detectD365Project:     vi.fn(async () => null),
+  scanAllD365Projects:   vi.fn(async () => CANDIDATES),
+  detectGitBranch:       vi.fn(async () => null),
+  extractModelNameFromProject: vi.fn(async () => 'ContosoCore'),
+  isMicrosoftDemoModel: vi.fn(() => false),
+}));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); }),
+}));
+
+vi.mock('fs', async (orig) => {
+  const actual = await orig<typeof import('fs')>();
+  return { ...actual, existsSync: vi.fn(() => false), realpathSync: vi.fn((p: string) => p) };
+});
+
+import { getConfigManager } from '../../src/utils/configManager.js';
+import { scanAllD365Projects } from '../../src/utils/workspaceDetector.js';
+
+const WORKSPACE = 'K:\\repos\\Contoso';
+
+/** Fresh ConfigManager with detection not yet attempted. */
+function makeManager() {
+  const proto = Object.getPrototypeOf(getConfigManager());
+  const mgr = new proto.constructor('/nonexistent/.mcp.json') as ReturnType<typeof getConfigManager>;
+  (mgr as any).config = { servers: {} };
+  (mgr as any).xppConfigLoaded = true;
+  (mgr as any).xppConfig = null;
+  (mgr as any).runtimeContext = {};
+  return mgr;
+}
+
+// .rnrproj scanning is Windows-only in autoDetectProject; pretend we are there
+// so the test is meaningful on Linux CI too.
+const realPlatform = process.platform;
+beforeEach(() => {
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  delete process.env.D365FO_SOLUTIONS_PATH;
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+});
+
+describe('ambiguous workspace — candidate listing', () => {
+  it('records the workspace candidates when no project could be auto-selected', async () => {
+    const mgr = makeManager();
+
+    await (mgr as any).autoDetectProject(WORKSPACE);
+
+    expect(scanAllD365Projects).toHaveBeenCalledWith(WORKSPACE);
+    expect(mgr.getAllDetectedProjects().map(p => p.projectPath)).toEqual(
+      CANDIDATES.map(p => p.projectPath),
+    );
+  });
+
+  it('keeps the resolved model name even though no project was selected', async () => {
+    const mgr = makeManager();
+
+    await (mgr as any).autoDetectProject(WORKSPACE);
+
+    expect(mgr.getModelName()).toBe('ContosoCore');
+  });
+
+  it('does not re-scan the workspace when a project was resolved', async () => {
+    const { autoDetectD365Project } = await import('../../src/utils/workspaceDetector.js');
+    vi.mocked(autoDetectD365Project).mockResolvedValueOnce({
+      ...CANDIDATES[0],
+    } as any);
+    const mgr = makeManager();
+
+    await (mgr as any).autoDetectProject(WORKSPACE);
+
+    expect(scanAllD365Projects).not.toHaveBeenCalled();
+    expect(mgr.getAllDetectedProjects()).toEqual([]);
+  });
+});

--- a/tests/utils/workspaceDetector.test.ts
+++ b/tests/utils/workspaceDetector.test.ts
@@ -63,6 +63,23 @@ describe('detectD365Project', () => {
     expect(result).toBeNull();
   });
 
+  it('resolves the one project carrying the custom model, demo projects aside', async () => {
+    // The ordinary shape of a real workspace: a leftover tutorial project the VS
+    // wizard named FleetManagement, next to the project actually being worked on.
+    // Neither folder matches the workspace name, so folder-name matching gives up
+    // — but only one of them carries a custom model, so there is nothing to guess
+    // and refusing here would drop a projectPath that used to resolve correctly.
+    const workspace = await makeTempWorkspace();
+    await makeProject(workspace, 'Tutorial', 'FleetManagement');
+    const real = await makeProject(workspace, 'Custom', 'ContosoCore');
+
+    const result = await detectD365Project(workspace);
+
+    expect(result?.projectPath).toBe(real);
+    expect(result?.modelName).toBe('ContosoCore');
+    expect(result?.ambiguousProjects).toBeUndefined();
+  });
+
   it('still resolves the model when ambiguous candidates all share one model', async () => {
     // A single model split across several VS projects is the common D365FO
     // layout. The project stays unresolved (only the caller knows which one to

--- a/tests/utils/workspaceDetector.test.ts
+++ b/tests/utils/workspaceDetector.test.ts
@@ -1,0 +1,90 @@
+/**
+ * WorkspaceDetector Tests
+ * Covers: detectD365Project's handling of ambiguous multi-project workspaces.
+ *
+ * A workspace containing more than one .rnrproj must never be silently
+ * resolved to "the first one found" — that previously caused newly created
+ * files to be registered into an arbitrary, unrelated VS project. These tests
+ * use real temp directories (detectD365Project does real fs I/O) rather than
+ * mocking fs, since the behavior under test is directory-tree traversal.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { detectD365Project } from '../../src/utils/workspaceDetector';
+
+const RNRPROJ_TEMPLATE = (modelName: string) =>
+  `<?xml version="1.0" encoding="utf-8"?>\n<Project><Model>${modelName}</Model></Project>\n`;
+
+async function makeProject(root: string, relDir: string, modelName: string): Promise<string> {
+  const dir = path.join(root, relDir);
+  await fs.mkdir(dir, { recursive: true });
+  const projectPath = path.join(dir, `${modelName}.rnrproj`);
+  await fs.writeFile(projectPath, RNRPROJ_TEMPLATE(modelName), 'utf-8');
+  return projectPath;
+}
+
+const tempDirs: string[] = [];
+async function makeTempWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'd365fo-workspace-detector-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+describe('detectD365Project', () => {
+  it('resolves the single .rnrproj when only one exists', async () => {
+    const workspace = await makeTempWorkspace();
+    const projectPath = await makeProject(workspace, 'ProjectAlpha', 'ProjectAlphaModel');
+
+    const result = await detectD365Project(workspace);
+
+    expect(result?.projectPath).toBe(projectPath);
+    expect(result?.modelName).toBe('ProjectAlphaModel');
+  });
+
+  it('refuses to guess when multiple .rnrproj exist and none matches the workspace name', async () => {
+    // Regression test: when two unrelated projects exist and neither folder
+    // name matches the workspace, the detector must not silently fall back to
+    // whichever .rnrproj sorts first alphabetically — that previously caused
+    // newly created files to be registered into the wrong VS project.
+    const workspace = await makeTempWorkspace();
+    await makeProject(workspace, 'ProjectAlpha', 'ProjectAlphaModel');
+    await makeProject(workspace, 'ProjectBeta', 'ProjectBetaModel');
+
+    const result = await detectD365Project(workspace);
+
+    expect(result).toBeNull();
+  });
+
+  it('resolves unambiguously when one .rnrproj folder name matches the workspace basename', async () => {
+    const tempRoot = await makeTempWorkspace();
+    // Workspace root is itself the intended project's folder, and directly
+    // contains its .rnrproj — so its own folder name matches the workspace
+    // basename. A second, unrelated .rnrproj also exists in a subfolder
+    // (e.g. a nested/legacy project) but must not win.
+    const workspace = path.join(tempRoot, 'ProjectBeta');
+    await fs.mkdir(workspace, { recursive: true });
+    const intendedProject = await makeProject(workspace, '.', 'ProjectBetaModel');
+    await makeProject(workspace, 'ProjectAlpha', 'ProjectAlphaModel');
+
+    const result = await detectD365Project(workspace);
+
+    expect(result?.projectPath).toBe(intendedProject);
+    expect(result?.modelName).toBe('ProjectBetaModel');
+  });
+
+  it('returns null when no .rnrproj files exist', async () => {
+    const workspace = await makeTempWorkspace();
+
+    const result = await detectD365Project(workspace);
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/utils/workspaceDetector.test.ts
+++ b/tests/utils/workspaceDetector.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { detectD365Project } from '../../src/utils/workspaceDetector';
+import { autoDetectD365Project, detectD365Project } from '../../src/utils/workspaceDetector';
 
 const RNRPROJ_TEMPLATE = (modelName: string) =>
   `<?xml version="1.0" encoding="utf-8"?>\n<Project><Model>${modelName}</Model></Project>\n`;
@@ -61,6 +61,55 @@ describe('detectD365Project', () => {
     const result = await detectD365Project(workspace);
 
     expect(result).toBeNull();
+  });
+
+  it('still resolves the model when ambiguous candidates all share one model', async () => {
+    // A single model split across several VS projects is the common D365FO
+    // layout. The project stays unresolved (only the caller knows which one to
+    // register files into), but the model is not in doubt — dropping it would
+    // break every read-only tool for no reason.
+    const workspace = await makeTempWorkspace();
+    const alpha = await makeProject(workspace, 'Alpha', 'ContosoCore');
+    const beta = await makeProject(workspace, 'Beta', 'ContosoCore');
+
+    const result = await detectD365Project(workspace);
+
+    expect(result?.modelName).toBe('ContosoCore');
+    expect(result?.projectPath).toBeUndefined();
+    expect(result?.solutionPath).toBeUndefined();
+    expect(result?.ambiguousProjects?.sort()).toEqual([alpha, beta].sort());
+  });
+
+  it('does not fall through to other detection sources once a workspace is ambiguous', async () => {
+    // Guard against the ambiguity refusal being "fixed" by letting the search
+    // continue into cwd / well-known dirs (K:\VSProjects and friends), which
+    // would pick an arbitrary project from an entirely unrelated solution —
+    // strictly worse than picking the wrong one inside the user's workspace.
+    const workspace = await makeTempWorkspace();
+    await makeProject(workspace, 'Alpha', 'ContosoCore');
+    await makeProject(workspace, 'Beta', 'ContosoCore');
+
+    const result = await autoDetectD365Project(workspace);
+
+    expect(result?.modelName).toBe('ContosoCore');
+    expect(result?.projectPath).toBeUndefined();
+    expect(result?.ambiguousProjects).toHaveLength(2);
+  });
+
+  it('keeps model and project in step when skipping a Microsoft demo model', async () => {
+    const tempRoot = await makeTempWorkspace();
+    // Name match lands on the demo project, so the demo-model rescue kicks in
+    // and switches to the custom one — the reported model must switch with it,
+    // not stay "FleetManagement" while projectPath points at ContosoCore.
+    const workspace = path.join(tempRoot, 'DemoSolution');
+    await fs.mkdir(workspace, { recursive: true });
+    await makeProject(workspace, '.', 'FleetManagement');
+    const customProject = await makeProject(workspace, 'Custom', 'ContosoCore');
+
+    const result = await detectD365Project(workspace);
+
+    expect(result?.projectPath).toBe(customProject);
+    expect(result?.modelName).toBe('ContosoCore');
   });
 
   it('resolves unambiguously when one .rnrproj folder name matches the workspace basename', async () => {


### PR DESCRIPTION
detectD365Project() previously defaulted to projectFiles[0] (alphabetically first) whenever a workspace contained more than one .rnrproj and no unique signal disambiguated them, causing addToProject to silently register new files into an unrelated project. It now only auto-resolves when exactly one .rnrproj exists, or one uniquely matches the workspace folder name; otherwise it returns null so the caller must pass projectPath explicitly.

createD365File.ts's "no projectPath could be resolved" warning (previously duplicated 3x with generic text) now lists every detected candidate when the workspace is ambiguous, and the projectPath schema description spells out that it is effectively mandatory in multi-project workspaces.

Adds regression tests for detectD365Project covering the single-project, ambiguous-multi-project, name-match-resolved, and no-project cases.