### PR TITLE
perf(index): index symbols.file_path, and take the object prefix from the active model

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -71,7 +71,8 @@ How generated objects, extensions and fields are named.
 
 | Key | Asked | Env var | Default | Description |
 | --- | --- | --- | --- | --- |
-| `naming.prefix` | setup | `EXTENSION_PREFIX` | — | Your ISV/customer prefix. Prepended to every generated object, field and method name and enforced by the naming validator, so BP checks pass on the first build. |
+| `naming.prefix` | setup | `EXTENSION_PREFIX` | — | Your ISV/customer prefix. Prepended to every generated object, field and method name and enforced by the naming validator, so BP checks pass on the first build. Used as the **fallback**: when the active model's existing objects already show a prefix, that one wins — see [Where the prefix comes from](CUSTOM_EXTENSIONS.md#where-the-prefix-comes-from). |
+| — | — | `EXTENSION_PREFIX_SOURCE` | — | Set to `config` to make `EXTENSION_PREFIX` authoritative again instead of learning each model's prefix from its own objects. |
 | `naming.suffix` | advanced | `EXTENSION_SUFFIX` | — | Optional suffix appended to new object names (MyTableZZ with suffix "ZZ"). Most projects use only a prefix — leave empty unless your convention requires one. |
 | `naming.extensionStyle` | advanced | `EXTENSION_NAMING_STYLE` | `prefix` | Whether extension classes/elements embed the prefix (per the Microsoft prefix guideline) or the model name (the Visual Studio default). Use model-name when your model name is long but your prefix is a short abbreviation. Values: `prefix` — CustTable.CrExtension — embeds the extension prefix; `model-name` — CustTable.ContosoRobotics — embeds the model name (VS default). |
 

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -82,6 +82,20 @@ Timing depends heavily on the environment. On a single-label-language instance (
 
 ---
 
+## Where the prefix comes from
+
+Development normally spans several models, each with its own prefix, and `EXTENSION_PREFIX` is a single value chosen once during setup. So the **active model's own objects decide the prefix**, and the configured value is the fallback:
+
+1. **The prefix the model's existing objects already use.** A model whose tables are `HBR_ArchiveAccDocErrorLog`, `HBR_AssetIPFairValue`… and whose extensions are `AssetBookTable.HBRExtension` teaches the tools both tokens — `HBR_` for new objects and members, `HBR` as the extension infix. Switching to a sibling model whose objects say `HBC_` switches the prefix with it, with no reconfiguration.
+2. **`EXTENSION_PREFIX`** — used for a model with nothing to learn from, e.g. one that is still empty.
+3. **The model name**, when neither of the above applies.
+
+Inference is conservative: a model whose objects show no consistent prefix (fewer than four of them, or under 60 % agreement) falls through to step 2 rather than guessing. `get_workspace_info` reports the effective prefix and where it came from.
+
+```env
+EXTENSION_PREFIX_SOURCE=config   # pin step 2 above step 1 (pre-1.8.2 behaviour)
+```
+
 ## Extension Naming Style
 
 When code-gen tools name an **extension element** (table/form/view/etc. extension) or an **extension class** (CoC / augmentation), the token that distinguishes your extension from others is controlled by `EXTENSION_NAMING_STYLE`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.8.0",
+  "version": "1.8.2",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -1093,6 +1093,9 @@ export async function bridgeRefreshProvider(
 ): Promise<{ refreshed: boolean; elapsedMs: number } | null> {
   if (!bridge?.isReady || !bridge.metadataAvailable) return null;
   try {
+    // Recorded so callers that only need the provider to be no older than a
+    // given write can skip a redundant rebuild — see debouncedRefresh.
+    debouncedRefresh.markRefreshStarted();
     return await bridge.refreshProvider();
   } catch (e) {
     console.error(`[BridgeAdapter] refreshProvider failed: ${e}`);

--- a/src/bridge/debouncedRefresh.ts
+++ b/src/bridge/debouncedRefresh.ts
@@ -18,6 +18,33 @@ let pending: {
 } | null = null;
 
 /**
+ * When the most recent provider refresh STARTED (epoch ms), across both this
+ * module and the direct bridgeRefreshProvider() path.
+ *
+ * Start rather than completion, because only a refresh that began after a file
+ * was written is guaranteed to have read it. Callers use this to skip a refresh
+ * that would rediscover nothing: a create/modify already refreshes the provider
+ * on its way out, so the update_symbol_index call that follows it was paying for
+ * a second full DiskProvider rebuild that could not see anything new.
+ */
+let lastRefreshStartedAt = 0;
+
+/** Epoch ms at which the last provider refresh started; 0 if none yet. */
+export function getLastRefreshStartedAt(): number {
+  return lastRefreshStartedAt;
+}
+
+/** Record that a refresh is starting now. Called by every refresh path. */
+export function markRefreshStarted(at: number = Date.now()): void {
+  if (at > lastRefreshStartedAt) lastRefreshStartedAt = at;
+}
+
+/** Forget the recorded refresh time (test isolation). */
+export function resetRefreshTracking(): void {
+  lastRefreshStartedAt = 0;
+}
+
+/**
  * Request a bridge refresh. If one is already pending, the settle timer
  * resets (up to MAX_WAIT_MS). All callers receive the same result.
  */
@@ -68,6 +95,7 @@ function executeRefresh(): void {
   const { resolve, bridge } = pending;
   pending = null;
 
+  markRefreshStarted();
   bridge.refreshProvider()
     .then(result => resolve(result))
     .catch(err => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { TOOL_ANNOTATIONS } from './server/toolAnnotations.js';
 import { apiKeyAuth } from './middleware/apiKeyAuth.js';
 import { VERSION } from './version.js';
 import { setInitializeParams } from './utils/stdioSessionInfo.js';
+import { setModelObjectNameSource } from './utils/modelPrefixInference.js';
 import { createShutdownCoordinator } from './utils/gracefulShutdown.js';
 import { box, kv, sectionTitle, statusLine, spread, c, glyph, sanitize, supportsUnicode, log, shortPath, startupWarnings } from './utils/terminalUi.js';
 import * as fs from 'fs/promises';
@@ -270,6 +271,11 @@ async function initializeServices() {
         throw error;
       }
     }
+
+    // Let object naming learn each model's prefix from the objects that model
+    // already contains, instead of applying one configured EXTENSION_PREFIX to
+    // every model a developer works in (see utils/modelPrefixInference.ts).
+    setModelObjectNameSource(model => symbolIndex.getModelObjectNames(model));
 
     const parser = new XppMetadataParser();
 

--- a/src/metadata/buildIndexWorker.ts
+++ b/src/metadata/buildIndexWorker.ts
@@ -1,0 +1,38 @@
+/**
+ * Index-build worker thread.
+ *
+ * CREATE INDEX over an already-populated table is a full table read plus a
+ * B-tree write — ~8 s on the 2 GB production symbol DB. node:sqlite is
+ * synchronous, so running that on the main thread blocks the event loop for its
+ * whole duration and the MCP client (VS Code Copilot) can time the server out
+ * before it answers its first request. Running it here, on its own connection,
+ * keeps the main thread serving; WAL mode lets this write proceed alongside the
+ * main thread's readers.
+ *
+ * Spawned by XppSymbolIndex.ensureFilePathIndexes() and posts a single message:
+ *   { ok: true, elapsedMs } | { ok: false, error }
+ *
+ * The connection is NOT read-only (unlike symbolCountsWorker) — this one writes.
+ */
+
+import { parentPort, workerData } from 'node:worker_threads';
+import Database from '../database/sqlite.js';
+
+const { dbPath, sql } = workerData as { dbPath: string; sql: string; indexName: string };
+
+try {
+  const db = new Database(dbPath);
+  try {
+    // A WAL checkpoint racing with a main-thread reader returns SQLITE_BUSY
+    // immediately without this; the build is background work, so it can afford
+    // to wait far longer than the 5 s used elsewhere.
+    db.pragma('busy_timeout = 120000');
+    const started = Date.now();
+    db.exec(sql);
+    parentPort!.postMessage({ ok: true, elapsedMs: Date.now() - started });
+  } finally {
+    db.close();
+  }
+} catch (e) {
+  parentPort!.postMessage({ ok: false, error: String(e) });
+}

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -50,6 +50,9 @@ export class XppSymbolIndex {
   // Symbol-count scans are expensive (full index scan of 1M+ rows, 30-60 s
   // cold) — memoize the result and compute it off-thread (see getSymbolCounts).
   private dbPath: string;
+  // Needed alongside dbPath so ensureFilePathIndexes() can size the labels DB
+  // and hand its path to the background index builder.
+  private labelsDbPath: string = ':memory:';
   private symbolCountsCache: SymbolCounts | null = null;
   private symbolCountsPromise: Promise<SymbolCounts> | null = null;
   // Per-connection prepared-statement cache.  Prepared statements are bound to
@@ -69,6 +72,7 @@ export class XppSymbolIndex {
     // Labels live in a separate DB so the main symbol DB stays small and fast;
     // labels can be huge (20M+ rows) without affecting search performance.
     const labelPath = labelsDbPath || dbPath.replace('.db', '-labels.db');
+    this.labelsDbPath = labelPath;
     this.labelsDb = new Database(labelPath);
 
     // journal_mode should be set by caller (MEMORY for build, WAL for production).
@@ -715,6 +719,97 @@ export class XppSymbolIndex {
       CREATE INDEX IF NOT EXISTS idx_md_define ON macro_defines(define_name);
       CREATE INDEX IF NOT EXISTS idx_md_model ON macro_defines(model);
     `);
+
+    this.ensureFilePathIndexes();
+  }
+
+  /**
+   * Index `symbols.file_path` and `labels.file_path`.
+   *
+   * Both are the lookup key of removeSymbolsByFile()/removeLabelsByFile(), which
+   * every update_symbol_index, undo_last_modification and resync runs first.
+   * Unindexed, each of those calls scans the entire table — measured on the 2 GB
+   * production DB at 319 s (the SELECT of object names) + 173 s (the DELETE) for
+   * indexing a SINGLE new object, versus 0 ms once the index exists. That is why
+   * indexing one freshly created object cost as much as a rebuild.
+   *
+   * Deliberately not part of the CREATE INDEX block above. node:sqlite is
+   * synchronous, and building this index over an already-populated production
+   * table takes ~8 s, so doing it inline would block the event loop for the whole
+   * of startup — the failure mode that makes MCP clients time out and kill the
+   * server. On an empty or small DB (a fresh build, the test suite, :memory:) the
+   * build is instant and runs here; on a large existing DB it is handed to a
+   * worker thread, and until it finishes those deletes simply stay as slow as
+   * they are today.
+   */
+  private ensureFilePathIndexes(): void {
+    const missing = (db: Database, indexName: string): boolean =>
+      !db.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`).get(indexName);
+
+    // Size is read off the file rather than counted, because COUNT(*) on the
+    // table we are trying to speed up is itself one of the slow scans.
+    const isLarge = (dbFile: string): boolean => {
+      if (dbFile === ':memory:') return false;
+      try {
+        return fs.statSync(dbFile).size > 200 * 1024 * 1024;
+      } catch {
+        return false;
+      }
+    };
+
+    const labelsPath = this.labelsDbPath;
+    const work: Array<{ db: Database; dbFile: string; sql: string; name: string }> = [];
+    if (missing(this.db, 'idx_symbols_file_path')) {
+      work.push({
+        db: this.db,
+        dbFile: this.dbPath,
+        name: 'idx_symbols_file_path',
+        sql: 'CREATE INDEX IF NOT EXISTS idx_symbols_file_path ON symbols(file_path);',
+      });
+    }
+    if (missing(this.labelsDb, 'idx_labels_file_path')) {
+      work.push({
+        db: this.labelsDb,
+        dbFile: labelsPath,
+        name: 'idx_labels_file_path',
+        sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path ON labels(file_path);',
+      });
+    }
+
+    for (const item of work) {
+      if (isLarge(item.dbFile)) {
+        this.buildIndexInWorker(item.dbFile, item.sql, item.name);
+      } else {
+        item.db.exec(item.sql);
+      }
+    }
+  }
+
+  /**
+   * Build one index on a separate thread so the main event loop keeps serving.
+   * WAL mode allows the worker's write to proceed alongside main-thread readers.
+   * Best-effort: a failure leaves the index absent, which is exactly the state
+   * the server ran in before, so it is logged and never thrown.
+   */
+  private buildIndexInWorker(dbPath: string, sql: string, indexName: string): void {
+    try {
+      const worker = new Worker(new URL('./buildIndexWorker.js', import.meta.url), {
+        workerData: { dbPath, sql, indexName },
+      });
+      // unref() so a pending index build never keeps the process alive on exit.
+      worker.unref();
+      worker.once('message', (msg: { ok: boolean; elapsedMs?: number; error?: string }) => {
+        if (msg.ok) {
+          console.error(`[SymbolIndex] Built ${indexName} in background (${msg.elapsedMs}ms)`);
+        } else {
+          console.error(`[SymbolIndex] Background build of ${indexName} failed: ${msg.error}`);
+        }
+        void worker.terminate();
+      });
+      worker.once('error', e => console.error(`[SymbolIndex] ${indexName} worker error: ${e}`));
+    } catch (e) {
+      console.error(`[SymbolIndex] Could not start ${indexName} worker: ${e}`);
+    }
   }
 
   /**
@@ -835,6 +930,29 @@ export class XppSymbolIndex {
    * even when the DB stores a different path form than the caller passed.
    * Returns the names of top-level objects that were removed (for cache invalidation).
    */
+  /**
+   * Top-level object names belonging to one model — the evidence from which a
+   * model's naming prefix is inferred (see utils/modelPrefixInference.ts).
+   *
+   * Deliberately narrow and bounded: only `name`, only root objects, capped at
+   * `limit`. Reading whole rows here would pull source snippets across the wire
+   * and turn a 450 ms lookup into a slow one. Extension objects are included on
+   * purpose — a dot-notation extension states the model's infix outright.
+   */
+  getModelObjectNames(model: string, limit = 400): string[] {
+    if (!model) return [];
+    const rows = this.getReadDb()
+      .prepare(
+        `SELECT name FROM symbols
+         WHERE model = ?
+           AND parent_name IS NULL
+           AND type NOT IN ('method', 'field')
+         LIMIT ?`
+      )
+      .all(model, limit) as Array<{ name: string }>;
+    return rows.map(r => r.name);
+  }
+
   removeSymbolsByFile(filePath: string): { deletedCount: number; objectNames: string[] } {
     const forms = this.filePathForms(filePath);
     const placeholders = forms.map(() => '?').join(', ');

--- a/src/server/toolSchemas/updateSymbolIndex.ts
+++ b/src/server/toolSchemas/updateSymbolIndex.ts
@@ -13,7 +13,7 @@ export const updateSymbolIndexTool = {
     inputSchema: {
       type: 'object',
       properties: {
-        filePath: { type: 'string', description: 'Absolute path to the modified or created XML file (e.g. K:\\\\AosService\\\\PackagesLocalDirectory\\\\MyModel\\\\MyModel\\\\AxClass\\\\MyClass.xml). Omit to run a lightweight bridge/workspace refresh instead of indexing a specific file.' },
+        filePath: { type: ['string', 'array'], items: { type: 'string' }, description: 'Absolute path to the modified or created XML file (e.g. K:\\\\AosService\\\\PackagesLocalDirectory\\\\MyModel\\\\MyModel\\\\AxClass\\\\MyClass.xml), or an ARRAY — batch them, each call costs a bridge refresh.' },
       },
     },
   };

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -14,7 +14,7 @@ import util from 'util';
 import path from 'path';
 import { parseStringPromise } from 'xml2js';
 import { getConfigManager, fallbackPackagePath, extractModelFromFilePath } from '../utils/configManager.js';
-import { isStandardModel, resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
+import { isStandardModel, resolveObjectPrefix, applyObjectPrefix, resolveRegularObjectPrefixToken } from '../utils/modelClassifier.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { resolveDbPathLocally } from '../utils/metadataResolver.js';
 import { assertWritePathAllowed } from '../utils/pathContainment.js';
@@ -1794,6 +1794,21 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       throw new Error(`Operation '${operation}' on object type '${objectType}' is not supported by the bridge.`);
     }
 
+    // Members added INSIDE an extension must carry the model's prefix — an
+    // extension lives in your model but its host object is Microsoft's, so an
+    // unprefixed field/index/enum value collides with anything Microsoft or
+    // another ISV adds to the same host later. Microsoft's naming guideline
+    // spells this out ("Fields in extensions → {Prefix}{FieldName}") and BP
+    // rejects the unprefixed form. This is applied once, here, so every writer
+    // below (bridge op and direct-XML fallback alike) sees the final name.
+    const memberPrefixNote = applyExtensionMemberPrefix(
+      args,
+      objectType,
+      operation,
+      resolvedModelFromPath || modelName || getConfigManager().getModelName() || '',
+    );
+    if (memberPrefixNote) generationNote += memberPrefixNote;
+
     let bridgeResult: { success: boolean; message: string } | null = null;
     let _bridgeRetried = false;
     // Retry loop: on the first null result with all required params present,
@@ -2724,6 +2739,77 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       isError: true,
     };
   }
+}
+
+/** Object types whose members belong to a Microsoft-owned host object. */
+const EXTENSION_OBJECT_TYPES = new Set([
+  'table-extension', 'form-extension', 'enum-extension', 'edt-extension',
+  'view-extension', 'query-extension', 'map-extension', 'data-entity-extension',
+  'class-extension', 'menu-extension',
+  'menu-item-display-extension', 'menu-item-action-extension', 'menu-item-output-extension',
+  'security-duty-extension', 'security-role-extension',
+]);
+
+/**
+ * Which `args` key each operation mints a NEW member name in, for extensions.
+ *
+ * Deliberately absent:
+ *  - every method operation. A CoC/extension-class method name must MATCH the
+ *    base method it wraps (`public void insert() { next insert(); }`) — renaming
+ *    it turns an override into a dead method that never runs.
+ *  - add-field-to-field-group's fieldGroupName. That names an EXISTING, usually
+ *    Microsoft-owned group being extended; prefixing it would point the write at
+ *    a group that does not exist.
+ *  - every remove-/modify- operation, which addresses members that already exist
+ *    under whatever name they were created with.
+ */
+const EXTENSION_MEMBER_NAME_ARG: Record<string, string> = {
+  'add-field': 'fieldName',
+  'add-index': 'indexName',
+  'add-full-text-index': 'indexName',
+  'add-field-group': 'fieldGroupName',
+  'add-enum-value': 'enumValueName',
+};
+
+/**
+ * Prefix the new member name this operation carries, when writing into an
+ * extension. Mutates `args` in place and returns a note for the response (empty
+ * when nothing changed), so the agent learns the real name and addresses the
+ * member correctly in its next call.
+ *
+ * Idempotent: a name that already carries the prefix — in either the underscore
+ * or the bare form, case-insensitively — is left untouched, so an agent that
+ * prefixes by hand does not end up with HBR_HBR_Foo.
+ */
+export function applyExtensionMemberPrefix(
+  args: Record<string, any>,
+  objectType: string,
+  operation: string,
+  modelName: string,
+): string {
+  if (!EXTENSION_OBJECT_TYPES.has(objectType)) return '';
+
+  const argKey = EXTENSION_MEMBER_NAME_ARG[operation];
+  if (!argKey) return '';
+
+  const original = args[argKey];
+  if (typeof original !== 'string' || original.trim().length === 0) return '';
+
+  const token = resolveRegularObjectPrefixToken(modelName);
+  if (!token) return '';
+
+  const bare = token.replace(/_+$/, '');
+  const lower = original.toLowerCase();
+  if (lower.startsWith(token.toLowerCase()) || lower.startsWith(bare.toLowerCase())) return '';
+
+  const prefixed = `${token}${original.charAt(0).toUpperCase()}${original.slice(1)}`;
+  args[argKey] = prefixed;
+  console.error(`[modifyD365File] Extension member prefixed: ${original} → ${prefixed} (model ${modelName})`);
+
+  return (
+    `\n\n> 🔖 Named \`${prefixed}\` — members added to an extension carry model ` +
+    `"${modelName}"'s prefix \`${token}\`. Use that name in later calls.`
+  );
 }
 
 /**

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -6,6 +6,7 @@ import type { XppServerContext } from '../types/context.js';
 import type { XppSymbol } from '../metadata/types.js';
 import { renderMethodSignature } from '../metadata/xppDeclaration.js';
 import { bridgeRefreshProvider } from '../bridge/index.js';
+import { getLastRefreshStartedAt } from '../bridge/debouncedRefresh.js';
 
 // Tool registration (name, description, inputSchema) lives inline in
 // src/server/mcpServer.ts - the single source of truth for tool instructions.
@@ -137,44 +138,148 @@ function parseLabelFileName(filePath: string): { labelFileId: string; language: 
   };
 }
 
+/**
+ * Accept one path or many. Callers that just created a handful of objects used to
+ * have to make one tool call per file, and each of those calls paid for its own
+ * full DiskProvider rebuild — the batch form pays for one.
+ */
+function normalizeFilePaths(filePath: unknown): string[] {
+  const raw = Array.isArray(filePath) ? filePath : [filePath];
+  return raw
+    .filter((p): p is string => typeof p === 'string')
+    .map(p => p.trim())
+    .filter(p => p.length > 0);
+}
+
+/**
+ * Newest mtime across the batch; 0 when nothing exists on disk (pure deletions).
+ * Used to decide whether the bridge provider is already new enough.
+ */
+function newestMtimeMs(filePaths: string[]): number {
+  let newest = 0;
+  for (const fp of filePaths) {
+    try {
+      const { mtimeMs } = fs.statSync(fp);
+      if (mtimeMs > newest) newest = mtimeMs;
+    } catch { /* deleted or unreadable — nothing to date */ }
+  }
+  return newest;
+}
+
+/**
+ * Refresh the C# provider once for the whole batch — and only when it could
+ * actually learn something.
+ *
+ * d365fo_file's create/modify paths already refresh the provider on their way
+ * out, so the update_symbol_index call that conventionally follows them was
+ * rebuilding a provider that had been rebuilt moments earlier and could not see
+ * anything new. A refresh that STARTED after the newest file was written has, by
+ * definition, already read every file in this batch.
+ */
+async function refreshBridgeForBatch(
+  context: XppServerContext,
+  filePaths: string[],
+): Promise<string> {
+  const newest = newestMtimeMs(filePaths);
+  if (newest > 0 && getLastRefreshStartedAt() > newest) {
+    return 'Bridge provider already refreshed after these files were written — skipped.';
+  }
+  try {
+    const result = await bridgeRefreshProvider(context.bridge);
+    return result
+      ? `Bridge provider refreshed in ${result.elapsedMs}ms.`
+      : 'Bridge provider not available (skipped).';
+  } catch (e: any) {
+    return `Bridge refresh skipped: ${e?.message ?? e}`;
+  }
+}
+
 export const updateSymbolIndexTool = async (params: any, context: XppServerContext) => {
-  const { filePath } = params;
+  const filePaths = normalizeFilePaths(params?.filePath);
+
+  // Refresh mode (no filePath): refreshes the bridge provider and drops workspace
+  // caches, lighter than a full reindex. Per-object SQLite indexing still needs filePath.
+  if (filePaths.length === 0) {
+    return refreshOnly(context);
+  }
+
+  // A file just changed on disk — drop the workspace scan cache so the
+  // context pipeline (recently-edited / active object) reflects it at once.
+  context.workspaceScanner?.invalidate?.();
+
+  // One refresh for the batch, before indexing, so a per-file failure cannot
+  // leave the provider stale.
+  const bridgeNote = await refreshBridgeForBatch(context, filePaths);
+
+  const results: Array<{ text: string; isError: boolean }> = [];
+  for (const fp of filePaths) {
+    results.push(await indexOneFile(fp, context));
+  }
+
+  // Single file keeps its original single-message shape; only a real batch gets
+  // the roll-up, so existing callers and their assertions see no change.
+  if (results.length === 1) {
+    return {
+      content: [{ type: 'text', text: `${results[0].text}\n\n${bridgeNote}` }],
+      ...(results[0].isError ? { isError: true } : {}),
+    };
+  }
+
+  const failed = results.filter(r => r.isError).length;
+  return {
+    content: [{
+      type: 'text',
+      text:
+        `Indexed ${results.length - failed}/${results.length} file(s) in one pass. ${bridgeNote}\n\n` +
+        results.map(r => r.text).join('\n\n'),
+    }],
+    ...(failed === results.length ? { isError: true } : {}),
+  };
+};
+
+/** Bridge/cache refresh with no file to index. */
+async function refreshOnly(context: XppServerContext) {
+  context.workspaceScanner?.invalidate?.();
+  let bridgeNote = 'Bridge provider not available (skipped).';
+  try {
+    const refreshResult = await bridgeRefreshProvider(context.bridge);
+    if (refreshResult) {
+      bridgeNote = `Bridge provider refreshed in ${refreshResult.elapsedMs}ms — newly created objects are now resolvable by bridge-backed operations.`;
+    }
+  } catch (e: any) {
+    bridgeNote = `Bridge refresh skipped: ${e?.message ?? e}`;
+  }
+  // Note: deliberately no touchLastIndexed() here — nothing was reindexed in
+  // SQLite, and bumping the timestamp would make get_workspace_info report a
+  // possibly stale index as fresh (see src/utils/indexStaleness.ts).
+  return {
+    content: [{
+      type: 'text',
+      text:
+        `🔄 **Bridge/cache refresh** (no filePath supplied).\n\n` +
+        `${bridgeNote}\n` +
+        `Workspace scan cache invalidated.\n\n` +
+        `ℹ️ The SQLite symbol index itself was NOT reindexed. To fully index a specific new ` +
+        `object into the searchable symbol DB (so scaffolding resolves its EDTs/enums and ` +
+        `references work), call this tool again with \`filePath\` pointing at the created ` +
+        `\`.xml\` (e.g. the new AxEnum/AxEdt/AxTable file).`,
+    }],
+  };
+}
+
+/**
+ * Index (or clean up after) exactly ONE file. The bridge refresh is the caller's
+ * job — it is per-batch, not per-file, which is what made a multi-object update
+ * cost one full DiskProvider rebuild per object.
+ */
+async function indexOneFile(
+  filePath: string,
+  context: XppServerContext,
+): Promise<{ text: string; isError: boolean }> {
+  const ok = (text: string) => ({ text, isError: false });
+  const err = (text: string) => ({ text, isError: true });
   try {
     const { symbolIndex } = context;
-
-    // Refresh mode (no filePath): refreshes the bridge provider and drops workspace
-    // caches, lighter than a full reindex. Per-object SQLite indexing still needs filePath.
-    if (!filePath || (typeof filePath === 'string' && filePath.trim().length === 0)) {
-      context.workspaceScanner?.invalidate?.();
-      let bridgeNote = 'Bridge provider not available (skipped).';
-      try {
-        const refreshResult = await bridgeRefreshProvider(context.bridge);
-        if (refreshResult) {
-          bridgeNote = `Bridge provider refreshed in ${refreshResult.elapsedMs}ms — newly created objects are now resolvable by bridge-backed operations.`;
-        }
-      } catch (e: any) {
-        bridgeNote = `Bridge refresh skipped: ${e?.message ?? e}`;
-      }
-      // Note: deliberately no touchLastIndexed() here — nothing was reindexed in
-      // SQLite, and bumping the timestamp would make get_workspace_info report a
-      // possibly stale index as fresh (see src/utils/indexStaleness.ts).
-      return {
-        content: [{
-          type: 'text',
-          text:
-            `🔄 **Bridge/cache refresh** (no filePath supplied).\n\n` +
-            `${bridgeNote}\n` +
-            `Workspace scan cache invalidated.\n\n` +
-            `ℹ️ The SQLite symbol index itself was NOT reindexed. To fully index a specific new ` +
-            `object into the searchable symbol DB (so scaffolding resolves its EDTs/enums and ` +
-            `references work), call this tool again with \`filePath\` pointing at the created ` +
-            `\`.xml\` (e.g. the new AxEnum/AxEdt/AxTable file).`,
-        }],
-      };
-    }
-    // A file just changed on disk — drop the workspace scan cache so the
-    // context pipeline (recently-edited / active object) reflects it at once.
-    context.workspaceScanner?.invalidate?.();
     const pathParts = filePath.split(/[\\/]/);
     const fileName = pathParts[pathParts.length - 1] ?? filePath;
     const objectName = fileName.replace(/\.[^.]+$/, '');
@@ -192,11 +297,8 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
       // 2. Remove labels from labels DB (label files live alongside XML)
       const labelCount = symbolIndex.removeLabelsByFile(filePath);
 
-      // 3. Refresh bridge so it no longer sees the deleted file
-      try {
-        await bridgeRefreshProvider(context.bridge);
-      } catch { /* bridge not available */ }
-
+      // The bridge refresh that stops it seeing the deleted file is the caller's
+      // per-batch one.
       symbolIndex.touchLastIndexed?.();
 
       const parts_cleaned: string[] = [];
@@ -204,13 +306,7 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
       if (labelCount > 0) parts_cleaned.push(`${labelCount} label(s)`);
       const summary = parts_cleaned.length > 0 ? parts_cleaned.join(' + ') : 'no stale entries found';
 
-      return {
-        content: [{
-          type: 'text',
-          text: `🗑️ File deleted — cleaned up ${summary} for **${objectName}** (${objectType}).\n` +
-            `Bridge refreshed.`
-        }]
-      };
+      return ok(`🗑️ File deleted — cleaned up ${summary} for **${objectName}** (${objectType}).`);
     }
 
     // File exists: re-index
@@ -220,13 +316,9 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
     if (isLabelTextFile(filePath)) {
       const parsedFileName = parseLabelFileName(filePath);
       if (!parsedFileName) {
-        return {
-          content: [{
-            type: 'text',
-            text: `❌ Error updating label index: invalid label filename format for ${path.basename(filePath)} (expected {LabelFileId}.{locale}.label.txt).`,
-          }],
-          isError: true,
-        };
+        return err(
+          `❌ Error updating label index: invalid label filename format for ${path.basename(filePath)} (expected {LabelFileId}.{locale}.label.txt).`
+        );
       }
 
       const { labelFileId, language } = parsedFileName;
@@ -249,23 +341,16 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
           insertedCount = labels.length;
         }
       } catch (e: any) {
-        return {
-          content: [{ type: 'text', text: `❌ Error updating label index: ${e.message}` }],
-          isError: true,
-        };
+        return err(`❌ Error updating label index: ${e.message}`);
       }
 
       symbolIndex.touchLastIndexed?.();
 
-      return {
-        content: [{
-          type: 'text',
-          text: `✅ Label index updated for **${path.basename(filePath)}** (model: ${model}, language: ${language}).\n\n` +
-            `Removed: ${removedCount} stale entr${removedCount === 1 ? 'y' : 'ies'}\n` +
-            `Inserted: ${insertedCount} label${insertedCount !== 1 ? 's' : ''}`,
-
-        }],
-      };
+      return ok(
+        `✅ Label index updated for **${path.basename(filePath)}** (model: ${model}, language: ${language}).\n\n` +
+        `Removed: ${removedCount} stale entr${removedCount === 1 ? 'y' : 'ies'}\n` +
+        `Inserted: ${insertedCount} label${insertedCount !== 1 ? 's' : ''}`
+      );
     }
 
     const parser = new XppMetadataParser();
@@ -277,15 +362,7 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
     // or PackagesLocalDirectory-relative, either slash style) — see symbolIndex.ts.
     const { deletedCount } = symbolIndex.removeSymbolsByFile(filePath);
 
-    // 1b. Refresh C# bridge metadata provider so it picks up the updated file
-    try {
-      const refreshResult = await bridgeRefreshProvider(context.bridge);
-      if (refreshResult) {
-        console.error(`[update_symbol_index] Bridge provider refreshed in ${refreshResult.elapsedMs}ms`);
-      }
-    } catch (e) {
-      console.error(`[update_symbol_index] Bridge refresh skipped: ${e}`);
-    }
+    // The C# bridge provider refresh happens once per batch in the caller.
 
     // 2. Re-parse the XML and insert fresh symbols
     let insertedCount = 0;
@@ -636,19 +713,13 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
 
     symbolIndex.touchLastIndexed?.();
 
-    return {
-      content: [{
-        type: 'text',
-        text: `✅ Symbol index updated for **${objectName}** (${objectType}, model: ${model}).\n\n` +
-          `Removed: ${deletedCount} stale entr${deletedCount === 1 ? 'y' : 'ies'}\n` +
-          `Inserted: ${insertedCount} symbol${insertedCount !== 1 ? 's' : ''}`
-      }]
-    };
+    return ok(
+      `✅ Symbol index updated for **${objectName}** (${objectType}, model: ${model}).\n\n` +
+      `Removed: ${deletedCount} stale entr${deletedCount === 1 ? 'y' : 'ies'}\n` +
+      `Inserted: ${insertedCount} symbol${insertedCount !== 1 ? 's' : ''}`
+    );
   } catch (error: any) {
     console.error('Error updating symbol index:', error);
-    return {
-      content: [{ type: 'text', text: `❌ Error updating symbol index: ${error.message}` }],
-      isError: true
-    };
+    return err(`❌ Error updating symbol index (${path.basename(filePath)}): ${error.message}`);
   }
-};
+}

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -10,6 +10,8 @@
  * - All other models are considered Microsoft standard models
  */
 
+import { getInferredModelPrefix } from './modelPrefixInference.js';
+
 // Runtime registry for auto-detected custom models
 const autoDetectedCustomModels = new Set<string>();
 
@@ -130,6 +132,32 @@ export function applyObjectSuffix(objectName: string, suffix: string): string {
 }
 
 /**
+ * Resolve the RAW prefix token for a model — the form that still carries a
+ * trailing underscore when the convention has one ("HBR_", "ISV_"), because that
+ * underscore decides how every other name is built.
+ *
+ * Priority — the ACTIVE MODEL outranks configuration:
+ * 1. The prefix the model's own objects already use (see modelPrefixInference).
+ *    Development spans many models, each with its own prefix; the workspace
+ *    knows which model is open, so that is the authoritative source. A globally
+ *    configured "Isv" must not override a model whose objects all say "IsvFin".
+ * 2. EXTENSION_PREFIX from configuration — the fallback for a model with nothing
+ *    to learn from, e.g. one that is still empty.
+ * 3. modelName itself, when nothing else is configured.
+ *
+ * Set EXTENSION_PREFIX_SOURCE=config to pin step 2 above step 1.
+ */
+function resolveRawPrefix(modelName: string): string {
+  const learned = modelName ? getInferredModelPrefix(modelName) : null;
+  if (learned?.regular) return learned.regular;
+
+  const envPrefix = process.env.EXTENSION_PREFIX?.trim();
+  if (envPrefix) return envPrefix;
+
+  return modelName || '';
+}
+
+/**
  * Resolve the clean prefix to use when naming newly created D365FO objects.
  *
  * Microsoft naming guidelines (https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/naming-guidelines-extensions):
@@ -138,24 +166,15 @@ export function applyObjectSuffix(objectName: string, suffix: string): string {
  *  - Extension classes   → {BaseElement}{Prefix}_Extension                     (e.g. SalesFormLetterContoso_Extension)
  *  - Fields in extensions→ {Prefix}{FieldName}                                 (e.g. WHSApprovingWorker)
  *
- * Priority (EXTENSION_PREFIX has higher priority than modelName):
- * 1. EXTENSION_PREFIX env var (trailing '_' stripped — the underscore is NOT part of the prefix)
- * 2. modelName as fallback (only if EXTENSION_PREFIX is not set)
+ * Returns the prefix with any trailing '_' stripped — the underscore is not part
+ * of the prefix itself, only of the form used for regular objects. See
+ * resolveRawPrefix() for the priority order, and resolveRegularObjectPrefixToken()
+ * for the token actually prepended to a name.
  *
- * Returns empty string when both are empty.
+ * Returns empty string when nothing resolves.
  */
 export function resolveObjectPrefix(modelName: string): string {
-  const envPrefix = process.env.EXTENSION_PREFIX?.trim();
-
-  if (envPrefix) {
-    return envPrefix.replace(/_+$/, '');
-  }
-
-  if (modelName) {
-    return modelName.replace(/_+$/, '');
-  }
-
-  return '';
+  return resolveRawPrefix(modelName).replace(/_+$/, '');
 }
 
 /**
@@ -168,13 +187,22 @@ export function resolveObjectPrefix(modelName: string): string {
  *   - All-caps prefix "WHS" with "WHS_" in env → infix "Whs"
  *   - All-caps prefix "WHS" with "WHS" in env  → infix "WHS" (unchanged)
  *
- * Detection: if EXTENSION_PREFIX env var ends with '_', apply first-upper + rest-lower.
+ * Detection: if the winning raw prefix ends with '_', apply first-upper + rest-lower.
+ *
+ * When `modelName` is given and that model's own extensions already state their
+ * infix, it is used verbatim instead of being derived. The two are genuinely
+ * independent: model HBReavis names regular objects "HBR_Foo" but its extensions
+ * "AssetBookTable.HBRExtension" — deriving would produce "HbrExtension" and every
+ * name would silently diverge from the model's existing convention.
  */
-export function deriveExtensionInfix(resolvedPrefix: string): string {
+export function deriveExtensionInfix(resolvedPrefix: string, modelName?: string): string {
   if (!resolvedPrefix) return '';
-  const rawEnvPrefix = process.env.EXTENSION_PREFIX?.trim() ?? '';
-  const envHasUnderscore = rawEnvPrefix.endsWith('_');
-  if (envHasUnderscore) {
+
+  const learned = modelName ? getInferredModelPrefix(modelName) : null;
+  if (learned?.infix) return learned.infix;
+
+  const rawPrefix = modelName ? resolveRawPrefix(modelName) : (process.env.EXTENSION_PREFIX?.trim() ?? '');
+  if (rawPrefix.endsWith('_')) {
     // XY_ → Xy  (first char uppercase, remaining chars lowercase)
     return resolvedPrefix.charAt(0).toUpperCase() + resolvedPrefix.slice(1).toLowerCase();
   }
@@ -196,11 +224,11 @@ export function deriveExtensionInfix(resolvedPrefix: string): string {
  * logic. Returns '' when no prefix is configured.
  */
 export function resolveRegularObjectPrefixToken(modelName?: string): string {
-  const resolved = resolveObjectPrefix(modelName ?? '');
-  if (!resolved) return '';
-  const rawEnvPrefix = process.env.EXTENSION_PREFIX?.trim() ?? '';
-  const envHasUnderscore = rawEnvPrefix.endsWith('_');
-  return envHasUnderscore ? rawEnvPrefix : resolved.charAt(0).toUpperCase() + resolved.slice(1);
+  const raw = resolveRawPrefix(modelName ?? '');
+  if (!raw) return '';
+  if (raw.endsWith('_')) return raw;
+  const resolved = raw.replace(/_+$/, '');
+  return resolved.charAt(0).toUpperCase() + resolved.slice(1);
 }
 
 /**
@@ -228,16 +256,19 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
   // elements/classes only (VS default); regular new objects are unaffected.
   const useModelName = !!modelName && getExtensionNamingStyle() === 'model-name';
 
-  // Extension infix form — PascalCase without underscore (e.g. "XY" → "Xy" when env had "XY_")
-  const extensionInfix = deriveExtensionInfix(prefix);
+  // Extension infix form — PascalCase without underscore (e.g. "XY" → "Xy" when env had "XY_"),
+  // or the model's own infix when its existing extensions state one.
+  const extensionInfix = deriveExtensionInfix(prefix, modelName);
 
-  // Regular object prefix keeps the underscore for underscore-style env prefixes
-  //   EXTENSION_PREFIX="XY_" → regularPrefix="XY_" → XY_CustTable
-  //   EXTENSION_PREFIX="Contoso" → regularPrefix="Contoso" → ContosoCustTable
-  const rawEnvPrefix = process.env.EXTENSION_PREFIX?.trim() ?? '';
-  const envHasUnderscore = rawEnvPrefix.endsWith('_');
+  // Regular object prefix keeps the underscore for underscore-style prefixes
+  //   "XY_"     → regularPrefix="XY_"     → XY_CustTable
+  //   "Contoso" → regularPrefix="Contoso" → ContosoCustTable
+  // The raw form comes from the model when one is given, so a model whose objects
+  // use "HBR_" keeps the underscore even though EXTENSION_PREFIX says otherwise.
+  const rawPrefix = modelName ? resolveRawPrefix(modelName) : (process.env.EXTENSION_PREFIX?.trim() ?? '');
+  const envHasUnderscore = rawPrefix.endsWith('_');
   const regularPrefix = envHasUnderscore
-    ? rawEnvPrefix
+    ? rawPrefix
     : prefix.charAt(0).toUpperCase() + prefix.slice(1);
 
   // Dot-notation extension elements: BaseObject.{Infix}Extension (standard AOT naming)

--- a/src/utils/modelPrefixInference.ts
+++ b/src/utils/modelPrefixInference.ts
@@ -1,0 +1,237 @@
+/**
+ * Infer a model's object prefix from the objects that model already contains.
+ *
+ * Why this exists: `EXTENSION_PREFIX` is a single value chosen once, during
+ * `setup`. Real development spans several models — a developer works in
+ * HBReavis today and HBReavisCus tomorrow — and each of those carries its own
+ * prefix (HBR_ and HBC_ respectively). A single configured value cannot be right
+ * for all of them, and nobody is going to re-run setup on every context switch.
+ * The information is already on disk: the model's existing objects state its
+ * prefix far more reliably than any configuration does.
+ *
+ * So the active model's own naming wins, and the configured `EXTENSION_PREFIX`
+ * becomes the fallback for models that have nothing to learn from (a brand-new,
+ * empty model) — see resolveObjectPrefix() in modelClassifier.ts for the order.
+ *
+ * Two tokens are inferred, because D365FO uses two different forms and they are
+ * NOT derivable from one another (HBR_ / HBR, but Con / Con):
+ *   - `regular` — prepended to new objects and to members added inside an
+ *     extension:  HBR_MandatoryReasonCode, HBR_ArchiveAccDocErrorLog
+ *   - `infix`   — embedded in extension element/class names:
+ *     AssetBookTable.HBRExtension, AccountingSourceExplorerHBR_Extension
+ *
+ * Inference is deliberately conservative: a model whose objects show no
+ * consistent prefix yields null, and the configured value is used unchanged.
+ */
+
+/** The two prefix tokens a model's own objects reveal. */
+export interface InferredModelPrefix {
+  /** Token prepended to new objects and to members added inside extensions. */
+  regular: string;
+  /** Token embedded in extension element and extension class names. */
+  infix: string;
+  /** How many sampled names carried `regular` (diagnostics only). */
+  coverage: number;
+  /** How many names the inference looked at (diagnostics only). */
+  sampleSize: number;
+}
+
+/** Minimum non-extension objects needed before a prefix is trusted. */
+const MIN_SAMPLE = 4;
+/** Share of sampled names that must carry the token. */
+const MIN_COVERAGE = 0.6;
+/** Longest prefix token considered; beyond this it is a domain word, not a prefix. */
+const MAX_TOKEN_LEN = 12;
+
+/**
+ * Split a PascalCase / SCREAMING_CASE name into its leading segments.
+ * "ConDemoNoteHeader" → [Con, Demo, Note, Header]
+ * "HBRArchiveAccDoc"  → [HBR, Archive, Acc, Doc]   (a run of capitals is one segment)
+ */
+function segments(name: string): string[] {
+  return name.match(/[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+/g) ?? [];
+}
+
+/**
+ * Candidate leading tokens for one object name — the substrings that could
+ * plausibly be "the prefix" of the model this name belongs to.
+ */
+function leadingTokenCandidates(name: string): string[] {
+  const out: string[] = [];
+
+  // Underscore style (HBR_Foo, ISV_Bar): everything up to and including the
+  // first underscore, which is the whole token — the underscore is part of it.
+  const us = name.indexOf('_');
+  if (us >= 1 && us <= MAX_TOKEN_LEN) out.push(name.slice(0, us + 1));
+
+  // PascalCase style (ConDemoNoteHeader): the first one or two segments. Two,
+  // because a prefix is sometimes itself compound ("IsvFin" over "Isv").
+  const segs = segments(name);
+  let acc = '';
+  for (let i = 0; i < Math.min(2, segs.length); i++) {
+    acc += segs[i];
+    if (acc.length >= 2 && acc.length <= MAX_TOKEN_LEN) out.push(acc);
+  }
+
+  return out;
+}
+
+/** Pick the candidate covering the most names; ties go to the longer token. */
+function bestCovering(names: string[], candidates: Iterable<string>): { token: string; coverage: number } | null {
+  let best: { token: string; coverage: number } | null = null;
+  for (const token of new Set(candidates)) {
+    const coverage = names.filter(n => n.startsWith(token)).length;
+    if (
+      !best ||
+      coverage > best.coverage ||
+      (coverage === best.coverage && token.length > best.token.length)
+    ) {
+      best = { token, coverage };
+    }
+  }
+  return best;
+}
+
+/**
+ * The infix carried by dot-notation extension elements, which state it outright:
+ * "AssetBookTable.HBRExtension" → "HBR". The most frequent one wins; a single
+ * stray element is not enough to overrule the rest.
+ */
+function inferInfixFromDotExtensions(dotNames: string[]): string | null {
+  const counts = new Map<string, number>();
+  for (const name of dotNames) {
+    const suffix = name.slice(name.lastIndexOf('.') + 1);
+    if (!/extension$/i.test(suffix)) continue;
+    const token = suffix.slice(0, -'Extension'.length);
+    if (token.length < 2 || token.length > MAX_TOKEN_LEN) continue;
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  let winner: { token: string; n: number } | null = null;
+  let total = 0;
+  for (const [token, n] of counts) {
+    total += n;
+    if (!winner || n > winner.n) winner = { token, n };
+  }
+  if (!winner || total === 0) return null;
+  return winner.n / total >= MIN_COVERAGE ? winner.token : null;
+}
+
+/**
+ * Derive the extension infix from a regular token when no extension element
+ * exists to read it off. Mirrors the documented EXTENSION_PREFIX rule:
+ * underscore style "XY_" → "Xy", PascalCase "Contoso" → "Contoso".
+ */
+function deriveInfixFrom(regular: string): string {
+  const bare = regular.replace(/_+$/, '');
+  if (!bare) return '';
+  return regular.endsWith('_')
+    ? bare.charAt(0).toUpperCase() + bare.slice(1).toLowerCase()
+    : bare.charAt(0).toUpperCase() + bare.slice(1);
+}
+
+/**
+ * Infer a model's prefix from the names of the objects it contains.
+ * Returns null when the names show no consistent prefix.
+ *
+ * `names` are object names as stored in the AOT — regular objects
+ * ("HBR_AssetIPFairValue"), dot-notation extensions ("AssetBookTable.HBRExtension")
+ * and extension classes ("AccountingSourceExplorerHBR_Extension") mixed together.
+ */
+export function inferPrefixFromObjectNames(names: string[]): InferredModelPrefix | null {
+  const clean = names.map(n => n.trim()).filter(Boolean);
+
+  const dotNames = clean.filter(n => n.includes('.'));
+  // Extension classes carry the token as a SUFFIX, so they say nothing about the
+  // leading token and would only dilute its coverage.
+  const regulars = clean.filter(n => !n.includes('.') && !n.endsWith('_Extension'));
+
+  const infixFromElements = inferInfixFromDotExtensions(dotNames);
+
+  const candidates = regulars.flatMap(leadingTokenCandidates);
+  const best = regulars.length >= MIN_SAMPLE ? bestCovering(regulars, candidates) : null;
+  const regularOk = best && best.coverage / regulars.length >= MIN_COVERAGE;
+
+  if (!regularOk && !infixFromElements) return null;
+
+  // Each token is preferred from direct evidence and derived from the other only
+  // when its own evidence is missing.
+  const regular = regularOk ? best!.token : infixFromElements!;
+  const infix = infixFromElements ?? deriveInfixFrom(regular);
+
+  return {
+    regular,
+    infix,
+    coverage: regularOk ? best!.coverage : 0,
+    sampleSize: regulars.length,
+  };
+}
+
+// ── Registry ────────────────────────────────────────────────────────────────
+// resolveObjectPrefix() is synchronous and called from dozens of places that
+// have no database handle, so the lookup is a cached registry fed by a source
+// installed once at startup (see setModelObjectNameSource).
+
+/** Supplies the object names of one model. Returns [] when it cannot answer. */
+export type ModelObjectNameSource = (modelName: string) => string[];
+
+let nameSource: ModelObjectNameSource | null = null;
+// null value = "looked, found nothing usable" — cached so a model without a
+// learnable prefix is not re-queried on every name that gets generated.
+const inferred = new Map<string, InferredModelPrefix | null>();
+
+/**
+ * Install the source of model object names (the symbol index, in the server).
+ * Called once during startup; passing null disables inference.
+ */
+export function setModelObjectNameSource(source: ModelObjectNameSource | null): void {
+  nameSource = source;
+  inferred.clear();
+}
+
+/** Seed a model's inferred prefix directly, bypassing the source (tests, CLI). */
+export function primeInferredModelPrefix(modelName: string, names: string[]): void {
+  inferred.set(modelName.toLowerCase(), inferPrefixFromObjectNames(names));
+}
+
+/** Drop every cached inference (test isolation, workspace switch). */
+export function clearInferredModelPrefixes(): void {
+  inferred.clear();
+}
+
+/**
+ * True when the operator has opted out of learning prefixes from the model and
+ * wants the configured EXTENSION_PREFIX to be authoritative, as it was before.
+ */
+function inferenceDisabled(): boolean {
+  return process.env.EXTENSION_PREFIX_SOURCE?.trim().toLowerCase() === 'config';
+}
+
+/**
+ * The prefix this model's own objects use, or null when it has none to teach us
+ * (empty model, no source installed, or inference switched off).
+ */
+export function getInferredModelPrefix(modelName: string): InferredModelPrefix | null {
+  if (!modelName || inferenceDisabled()) return null;
+
+  const key = modelName.toLowerCase();
+  const cached = inferred.get(key);
+  if (cached !== undefined) return cached;
+
+  let result: InferredModelPrefix | null = null;
+  try {
+    const names = nameSource?.(modelName) ?? [];
+    result = names.length > 0 ? inferPrefixFromObjectNames(names) : null;
+    if (result) {
+      console.error(
+        `[ModelPrefix] Model "${modelName}" uses prefix "${result.regular}" ` +
+        `(extension infix "${result.infix}") — inferred from ${result.coverage}/${result.sampleSize} of its objects`
+      );
+    }
+  } catch (e) {
+    console.error(`[ModelPrefix] Inference failed for "${modelName}": ${e}`);
+    result = null;
+  }
+
+  inferred.set(key, result);
+  return result;
+}

--- a/tests/metadata/filePathIndex.test.ts
+++ b/tests/metadata/filePathIndex.test.ts
@@ -1,0 +1,84 @@
+/**
+ * symbols.file_path / labels.file_path must be indexed.
+ *
+ * removeSymbolsByFile() is the first thing every update_symbol_index,
+ * undo_last_modification and resync runs, and it looks rows up by file_path.
+ * Unindexed, both of its statements scan the whole table — measured on the 2 GB
+ * production DB at 319 s (the SELECT) + 173 s (the DELETE) to index a SINGLE
+ * newly created object, against 0 ms once the index exists. That is why indexing
+ * one object felt like a full rebuild, and it is a regression worth pinning:
+ * the index is invisible in behaviour and easy to drop by accident.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+
+const dirs: string[] = [];
+const opened: XppSymbolIndex[] = [];
+function tempIndex(): XppSymbolIndex {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'd365fo-file-path-index-'));
+  dirs.push(dir);
+  const idx = new XppSymbolIndex(path.join(dir, 'symbols.db'), path.join(dir, 'labels.db'));
+  opened.push(idx);
+  return idx;
+}
+
+afterEach(() => {
+  // Windows keeps a lock on an open SQLite file, so close before removing —
+  // and tolerate a failed removal rather than failing an otherwise green test.
+  for (const idx of opened) { try { idx.close(); } catch { /* already closed */ } }
+  opened.length = 0;
+  for (const d of dirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* locked */ } }
+  dirs.length = 0;
+});
+
+describe('file_path indexes', () => {
+  it('creates them on a fresh database', () => {
+    const idx = tempIndex();
+
+    const symbolIdx = idx.db
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_symbols_file_path'`)
+      .get();
+    const labelIdx = idx.labelsDb
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_labels_file_path'`)
+      .get();
+
+    expect(symbolIdx).toBeTruthy();
+    expect(labelIdx).toBeTruthy();
+  });
+
+  it('makes removeSymbolsByFile look up by index instead of scanning', () => {
+    const idx = tempIndex();
+    const filePath = 'K:\\AosService\\PackagesLocalDirectory\\Contoso\\Contoso\\AxEnum\\ConDemoModStatus.xml';
+
+    // Enough rows that the planner has a real choice to make — on a handful of
+    // rows it picks a scan whether or not the index exists, so a tiny fixture
+    // would let the regression through.
+    idx.db.transaction(() => {
+      for (let i = 0; i < 2000; i++) {
+        idx.addSymbol({
+          name: `Filler${i}`,
+          type: 'class',
+          filePath: `K:\\AosService\\PackagesLocalDirectory\\Other\\Other\\AxClass\\Filler${i}.xml`,
+          model: 'Other',
+        });
+      }
+      idx.addSymbol({ name: 'ConDemoModStatus', type: 'enum', filePath, model: 'Contoso' });
+    })();
+    idx.db.exec('ANALYZE;');
+
+    // The plan is the assertion: "SCAN symbols" here means every future
+    // single-object index call re-reads the entire table.
+    const plan = idx.db
+      .prepare(`EXPLAIN QUERY PLAN SELECT DISTINCT name FROM symbols WHERE file_path IN (?, ?) AND parent_name IS NULL`)
+      .all(filePath, filePath) as Array<{ detail: string }>;
+
+    expect(plan.some(r => r.detail.includes('idx_symbols_file_path'))).toBe(true);
+    expect(plan.some(r => /^SCAN symbols/.test(r.detail))).toBe(false);
+
+    expect(idx.removeSymbolsByFile(filePath).deletedCount).toBe(1);
+  });
+});

--- a/tests/tools/addFieldDataEntityExtension.test.ts
+++ b/tests/tools/addFieldDataEntityExtension.test.ts
@@ -145,6 +145,11 @@ vi.mock('../../src/utils/modelClassifier', () => ({
   registerCustomModel: vi.fn(),
   resolveObjectPrefix: vi.fn(() => ''),
   applyObjectPrefix: vi.fn((name: string) => name),
+  // Empty, like resolveObjectPrefix above: these cases are about the mapped-field
+  // binding and XML shape, so leaving names unprefixed keeps the fixtures
+  // readable. Extension member prefixing has its own tests
+  // (tests/tools/extensionMemberPrefix).
+  resolveRegularObjectPrefixToken: vi.fn(() => ''),
   getObjectSuffix: vi.fn(() => ''),
   applyObjectSuffix: vi.fn((name: string) => name),
   isCustomModel: vi.fn(() => true),

--- a/tests/tools/addIndexSameSession.test.ts
+++ b/tests/tools/addIndexSameSession.test.ts
@@ -162,6 +162,10 @@ vi.mock('../../src/utils/modelClassifier', () => ({
   registerCustomModel: vi.fn(),
   resolveObjectPrefix: vi.fn(() => ''),
   applyObjectPrefix: vi.fn((name: string) => name),
+  // Empty, like resolveObjectPrefix above: these cases are about index XML
+  // shape, so leaving names unprefixed keeps the fixtures readable. Extension
+  // member prefixing has its own tests (tests/tools/extensionMemberPrefix).
+  resolveRegularObjectPrefixToken: vi.fn(() => ''),
   getObjectSuffix: vi.fn(() => ''),
   applyObjectSuffix: vi.fn((name: string) => name),
   isCustomModel: vi.fn(() => true),

--- a/tests/tools/extensionMemberPrefix.test.ts
+++ b/tests/tools/extensionMemberPrefix.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Prefixing of members added INSIDE an extension.
+ *
+ * An extension lives in your model but its host object is Microsoft's, so an
+ * unprefixed field/index/enum value collides with whatever Microsoft or another
+ * ISV adds to the same host later — Microsoft's naming guideline requires the
+ * prefix and BP rejects the bare form. The tool used to pass fieldName straight
+ * through to the bridge, so `add-field` on a table extension wrote an unprefixed
+ * field while `create` on the same model prefixed the object name.
+ *
+ * Ground truth: K:\…\HBReavis\HBReavis\AxTableExtension\AssetBookTable.HBRExtension.xml
+ * contains <Name>HBR_MandatoryReasonCode</Name> — prefixed with the REGULAR
+ * token (HBR_), not the extension infix (HBR).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyExtensionMemberPrefix } from '../../src/tools/modifyD365File.js';
+import {
+  setModelObjectNameSource,
+  clearInferredModelPrefixes,
+} from '../../src/utils/modelPrefixInference.js';
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  clearInferredModelPrefixes();
+  setModelObjectNameSource(null);
+  delete process.env.EXTENSION_PREFIX;
+  delete process.env.EXTENSION_PREFIX_SOURCE;
+  process.env.EXTENSION_PREFIX = 'HBR_';
+});
+
+afterEach(() => {
+  setModelObjectNameSource(null);
+  clearInferredModelPrefixes();
+  process.env = { ...originalEnv };
+});
+
+describe('applyExtensionMemberPrefix', () => {
+  it('prefixes a field added to a table extension', () => {
+    const args: Record<string, any> = { fieldName: 'MandatoryReasonCode' };
+
+    const note = applyExtensionMemberPrefix(args, 'table-extension', 'add-field', 'HBReavis');
+
+    expect(args.fieldName).toBe('HBR_MandatoryReasonCode');
+    expect(note).toContain('HBR_MandatoryReasonCode');
+  });
+
+  it('prefixes indexes, field groups and enum values too', () => {
+    const index: Record<string, any> = { indexName: 'ByReasonCode' };
+    const group: Record<string, any> = { fieldGroupName: 'Approval' };
+    const value: Record<string, any> = { enumValueName: 'PendingReview' };
+
+    applyExtensionMemberPrefix(index, 'table-extension', 'add-index', 'HBReavis');
+    applyExtensionMemberPrefix(group, 'table-extension', 'add-field-group', 'HBReavis');
+    applyExtensionMemberPrefix(value, 'enum-extension', 'add-enum-value', 'HBReavis');
+
+    expect(index.indexName).toBe('HBR_ByReasonCode');
+    expect(group.fieldGroupName).toBe('HBR_Approval');
+    expect(value.enumValueName).toBe('HBR_PendingReview');
+  });
+
+  it('leaves a name that already carries the prefix untouched', () => {
+    const args: Record<string, any> = { fieldName: 'HBR_MandatoryReasonCode' };
+
+    expect(applyExtensionMemberPrefix(args, 'table-extension', 'add-field', 'HBReavis')).toBe('');
+    expect(args.fieldName).toBe('HBR_MandatoryReasonCode');
+  });
+
+  it('recognises the bare form of an underscore prefix as already applied', () => {
+    // An agent that hand-builds "HBRSomething" must not end up with HBR_HBRSomething.
+    const args: Record<string, any> = { fieldName: 'HBRMandatoryReasonCode' };
+
+    applyExtensionMemberPrefix(args, 'table-extension', 'add-field', 'HBReavis');
+
+    expect(args.fieldName).toBe('HBRMandatoryReasonCode');
+  });
+
+  it('does not touch fields on a plain table', () => {
+    // A table you own is entirely yours — its fields need no prefix, and adding
+    // one would contradict every field the create path already wrote.
+    const args: Record<string, any> = { fieldName: 'ApprovingWorker' };
+
+    applyExtensionMemberPrefix(args, 'table', 'add-field', 'HBReavis');
+
+    expect(args.fieldName).toBe('ApprovingWorker');
+  });
+
+  it('never renames a method on a class extension', () => {
+    // A CoC method name must match the base method it wraps; prefixing it turns
+    // an override into dead code that never runs.
+    const args: Record<string, any> = { methodName: 'insert' };
+
+    applyExtensionMemberPrefix(args, 'class-extension', 'add-method', 'HBReavis');
+
+    expect(args.methodName).toBe('insert');
+  });
+
+  it('never renames the field group targeted by add-field-to-field-group', () => {
+    // That group already exists and is usually Microsoft's (e.g. "Setup").
+    const args: Record<string, any> = { fieldGroupName: 'Setup', fieldName: 'HBR_MandatoryReasonCode' };
+
+    applyExtensionMemberPrefix(args, 'table-extension', 'add-field-to-field-group', 'HBReavis');
+
+    expect(args.fieldGroupName).toBe('Setup');
+  });
+
+  it('never renames a member being removed or modified', () => {
+    const removed: Record<string, any> = { fieldName: 'HBR_Legacy' };
+    const modified: Record<string, any> = { fieldName: 'SomeExistingField' };
+
+    applyExtensionMemberPrefix(removed, 'table-extension', 'remove-field', 'HBReavis');
+    applyExtensionMemberPrefix(modified, 'table-extension', 'modify-field', 'HBReavis');
+
+    expect(removed.fieldName).toBe('HBR_Legacy');
+    expect(modified.fieldName).toBe('SomeExistingField');
+  });
+
+  it('uses the prefix inferred from the model over the configured one', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    setModelObjectNameSource(() => [
+      'HBC_REMLeaseContractLineUGs', 'HBC_OldDebtsReportController',
+      'HBC_OldDebtsReportDP', 'HBC_AssetFirstUseDate',
+    ]);
+    const args: Record<string, any> = { fieldName: 'BankAccountVerified' };
+
+    applyExtensionMemberPrefix(args, 'table-extension', 'add-field', 'HBReavisCus');
+
+    expect(args.fieldName).toBe('HBC_BankAccountVerified');
+  });
+
+  it('changes nothing when no prefix resolves at all', () => {
+    delete process.env.EXTENSION_PREFIX;
+    setModelObjectNameSource(() => []);
+    const args: Record<string, any> = { fieldName: 'ApprovingWorker' };
+
+    expect(applyExtensionMemberPrefix(args, 'table-extension', 'add-field', '')).toBe('');
+    expect(args.fieldName).toBe('ApprovingWorker');
+  });
+});

--- a/tests/tools/updateSymbolIndexBatch.test.ts
+++ b/tests/tools/updateSymbolIndexBatch.test.ts
@@ -1,0 +1,127 @@
+/**
+ * update_symbol_index: one bridge refresh per CALL, not per object.
+ *
+ * Indexing N freshly created objects meant N tool calls, each rebuilding the C#
+ * DiskProvider from scratch (266 ms measured on the reference VM, and the whole
+ * provider is thrown away and recreated each time). Worse, d365fo_file's
+ * create/modify paths already refresh the provider on their way out, so the very
+ * next update_symbol_index call was rebuilding a provider that could not
+ * possibly see anything new.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const refreshProvider = vi.fn(async () => ({ refreshed: true, elapsedMs: 5 }));
+
+vi.mock('../../src/bridge/index.js', () => ({
+  bridgeRefreshProvider: vi.fn(async (bridge: any) => (bridge ? refreshProvider() : null)),
+}));
+
+import { updateSymbolIndexTool } from '../../src/tools/updateSymbolIndex.js';
+import { markRefreshStarted, resetRefreshTracking } from '../../src/bridge/debouncedRefresh.js';
+
+const AOT_XML = (name: string) =>
+  `<?xml version="1.0" encoding="utf-8"?>\n<AxEnum><Name>${name}</Name></AxEnum>\n`;
+
+let workspace: string;
+
+/** Minimal context: the tool only touches these members on this path. */
+function makeContext() {
+  const added: Array<{ name: string }> = [];
+  return {
+    bridge: { isReady: true, metadataAvailable: true },
+    workspaceScanner: { invalidate: vi.fn() },
+    symbolIndex: {
+      db: { transaction: (fn: () => void) => fn },
+      addSymbol: (s: any) => { added.push(s); },
+      removeSymbolsByFile: () => ({ deletedCount: 0, objectNames: [] }),
+      removeLabelsByFile: () => 0,
+      touchLastIndexed: vi.fn(),
+      added,
+    },
+  } as any;
+}
+
+function writeObject(model: string, name: string): string {
+  const dir = path.join(workspace, model, model, 'AxEnum');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${name}.xml`);
+  fs.writeFileSync(file, AOT_XML(name), 'utf-8');
+  return file;
+}
+
+beforeEach(() => {
+  workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'd365fo-update-index-'));
+  refreshProvider.mockClear();
+  resetRefreshTracking();
+});
+
+afterEach(() => {
+  try { fs.rmSync(workspace, { recursive: true, force: true }); } catch { /* locked */ }
+  resetRefreshTracking();
+});
+
+describe('update_symbol_index batching', () => {
+  it('refreshes the bridge once for a whole array of files', async () => {
+    const files = ['ConAlpha', 'ConBeta', 'ConGamma'].map(n => writeObject('Contoso', n));
+    const context = makeContext();
+
+    const result = await updateSymbolIndexTool({ filePath: files }, context);
+
+    expect(refreshProvider).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toContain('3/3');
+    expect(context.symbolIndex.added.map((s: any) => s.name).sort())
+      .toEqual(['ConAlpha', 'ConBeta', 'ConGamma']);
+  });
+
+  it('still accepts a single path and keeps its single-file message', async () => {
+    const file = writeObject('Contoso', 'ConAlpha');
+
+    const result = await updateSymbolIndexTool({ filePath: file }, makeContext());
+
+    expect(result.content[0].text).toContain('Symbol index updated for **ConAlpha**');
+    expect(result.content[0].text).not.toContain('1/1');
+  });
+
+  it('skips the refresh when one already ran after the files were written', async () => {
+    const file = writeObject('Contoso', 'ConAlpha');
+    // What d365fo_file(create) does on its way out, before the agent calls us.
+    markRefreshStarted(Date.now() + 1000);
+
+    const result = await updateSymbolIndexTool({ filePath: file }, makeContext());
+
+    expect(refreshProvider).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('already refreshed');
+  });
+
+  it('does refresh when a file changed after the last refresh', async () => {
+    markRefreshStarted(Date.now() - 60_000);
+    const file = writeObject('Contoso', 'ConAlpha');
+
+    await updateSymbolIndexTool({ filePath: file }, makeContext());
+
+    expect(refreshProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports per-file failures without abandoning the rest of the batch', async () => {
+    const good = writeObject('Contoso', 'ConAlpha');
+    const missing = path.join(workspace, 'Contoso', 'Contoso', 'AxEnum', 'ConGone.xml');
+
+    const result = await updateSymbolIndexTool({ filePath: [good, missing] }, makeContext());
+
+    // A missing file is a deletion, not an error — both entries are accounted for.
+    expect(result.content[0].text).toContain('2/2');
+    expect(result.content[0].text).toContain('ConAlpha');
+    expect(result.content[0].text).toContain('ConGone');
+  });
+
+  it('falls back to the refresh-only mode when no path is given', async () => {
+    const result = await updateSymbolIndexTool({}, makeContext());
+
+    expect(refreshProvider).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).toContain('Bridge/cache refresh');
+  });
+});

--- a/tests/utils/modelPrefixInference.test.ts
+++ b/tests/utils/modelPrefixInference.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Prefix inference from a model's own objects.
+ *
+ * A single configured EXTENSION_PREFIX cannot be right for a developer who works
+ * across several models — on the reference VM, HBReavis names its objects HBR_*
+ * and HBReavisCus names them HBC_*, while EXTENSION_PREFIX says "Con". The name
+ * samples below are taken verbatim from that machine's PackagesLocalDirectory,
+ * so these tests pin the inference against real AOT naming rather than invented
+ * examples.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  inferPrefixFromObjectNames,
+  setModelObjectNameSource,
+  getInferredModelPrefix,
+  clearInferredModelPrefixes,
+} from '../../src/utils/modelPrefixInference.js';
+import {
+  resolveObjectPrefix,
+  resolveRegularObjectPrefixToken,
+  deriveExtensionInfix,
+  applyObjectPrefix,
+} from '../../src/utils/modelClassifier.js';
+
+// Real object names from K:\AosService\PackagesLocalDirectory\HBReavis\HBReavis
+const HB_REAVIS = [
+  'HBR_ArchiveAccDocErrorLog',
+  'HBR_AssetIPFairValue',
+  'HBR_AssetIPFairValueStaging',
+  'HBR_AssetsDepreciationSimulationTmp',
+  'HBR_BackIntegrationLink',
+  'HBR_BusinessPartnerStaging',
+  'HBR_AccrualDateFrom',
+  'HBR_AllowAutomaticSalesInvoicePosting',
+  'AccountingSourceExplorerTmp.HBRExtension',
+  'AssetBookTable.HBRExtension',
+  'AssetDepSuspension_CZ.HBRExtension',
+  'AccountingSourceExplorerHBR_Extension',
+  'AgreementGenerationPurchToSalesStrategyHBR_Extension',
+];
+
+// …\HBReavisCus\HBReavisCus — same solution, different model, different prefix.
+const HB_REAVIS_CUS = [
+  'HBC_REMLeaseContractLineUGs',
+  'HBC_REMLeaseContractLineUGsStaging',
+  'HBC_OldDebtsReportController',
+  'HBC_OldDebtsReportDP',
+  'HBC_SalesInvoiceHeaderEmailHandler',
+  'HBC_AssetFirstUseDate',
+  'AssetTable.HBCExtension',
+  'CustTransFormHBC_Extension',
+];
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  clearInferredModelPrefixes();
+  setModelObjectNameSource(null);
+  delete process.env.EXTENSION_PREFIX;
+  delete process.env.EXTENSION_PREFIX_SOURCE;
+  delete process.env.EXTENSION_NAMING_STYLE;
+});
+
+afterEach(() => {
+  setModelObjectNameSource(null);
+  clearInferredModelPrefixes();
+  process.env = { ...originalEnv };
+});
+
+describe('inferPrefixFromObjectNames', () => {
+  it('reads the underscore prefix and the extension infix as separate tokens', () => {
+    const result = inferPrefixFromObjectNames(HB_REAVIS);
+
+    // The two are NOT derivable from one another: deriving "HBR_" per the
+    // documented rule yields the infix "Hbr", but the model's own extensions
+    // spell it "HBRExtension".
+    expect(result?.regular).toBe('HBR_');
+    expect(result?.infix).toBe('HBR');
+  });
+
+  it('distinguishes two models that share a solution', () => {
+    expect(inferPrefixFromObjectNames(HB_REAVIS_CUS)?.regular).toBe('HBC_');
+    expect(inferPrefixFromObjectNames(HB_REAVIS_CUS)?.infix).toBe('HBC');
+  });
+
+  it('reads a PascalCase prefix with no underscore', () => {
+    const result = inferPrefixFromObjectNames([
+      'ConDemoNoteHeader', 'ConDemoModStatus', 'ConRentalAgreement', 'ConRentalLine',
+    ]);
+
+    expect(result?.regular).toBe('Con');
+    expect(result?.infix).toBe('Con');
+  });
+
+  it('prefers the longer compound token when the objects agree on it', () => {
+    // The scenario that motivated the change: configuration says "Isv", but this
+    // model's objects consistently say "IsvFin".
+    const result = inferPrefixFromObjectNames([
+      'IsvFinPostingProfile', 'IsvFinLedgerJournal', 'IsvFinVendPayment', 'IsvFinCustBalance',
+    ]);
+
+    expect(result?.regular).toBe('IsvFin');
+  });
+
+  it('infers nothing from objects that share no prefix', () => {
+    expect(inferPrefixFromObjectNames([
+      'CustTable', 'VendInvoiceJour', 'SalesLine', 'InventTrans', 'LedgerJournalTable',
+    ])).toBeNull();
+  });
+
+  it('infers nothing from a model too small to be evidence', () => {
+    // A brand-new model with one or two objects proves nothing — the configured
+    // prefix must stay in charge rather than be overruled by a coincidence.
+    expect(inferPrefixFromObjectNames(['ConDemoNoteHeader', 'ConDemoModStatus'])).toBeNull();
+  });
+
+  it('ignores extension classes when measuring the leading token', () => {
+    // Extension classes carry the token as a SUFFIX (…HBR_Extension). Counting
+    // them as regular objects would drag the leading-token coverage below the
+    // threshold and lose an otherwise obvious prefix.
+    const suffixHeavy = [
+      'HBR_ArchiveAccDocErrorLog', 'HBR_AssetIPFairValue', 'HBR_BackIntegrationLink', 'HBR_AccrualDateFrom',
+      'AccountingSourceExplorerHBR_Extension', 'AcsAsset_AssetPreAcquisitionHelperHBR_Extension',
+      'AcsBasic_ACFeatureManagementHBR_Extension', 'AgreementGenerationSalesToPurchStrategyHBR_Extension',
+      'AccountingSourceExplorerProcessorHBR_Extension',
+    ];
+
+    expect(inferPrefixFromObjectNames(suffixHeavy)?.regular).toBe('HBR_');
+  });
+});
+
+describe('prefix resolution order', () => {
+  it('lets the active model outrank the configured prefix', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    setModelObjectNameSource(model => (model === 'HBReavis' ? HB_REAVIS : []));
+
+    expect(resolveObjectPrefix('HBReavis')).toBe('HBR');
+    expect(resolveRegularObjectPrefixToken('HBReavis')).toBe('HBR_');
+  });
+
+  it('gives each model its own prefix within one session', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    setModelObjectNameSource(model =>
+      model === 'HBReavis' ? HB_REAVIS : model === 'HBReavisCus' ? HB_REAVIS_CUS : []);
+
+    expect(resolveRegularObjectPrefixToken('HBReavis')).toBe('HBR_');
+    expect(resolveRegularObjectPrefixToken('HBReavisCus')).toBe('HBC_');
+  });
+
+  it('falls back to the configured prefix for a model with nothing to teach', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    setModelObjectNameSource(() => []);
+
+    expect(resolveObjectPrefix('BrandNewModel')).toBe('Con');
+  });
+
+  it('falls back to the model name when nothing is configured either', () => {
+    setModelObjectNameSource(() => []);
+
+    expect(resolveObjectPrefix('BrandNewModel')).toBe('BrandNewModel');
+  });
+
+  it('honours EXTENSION_PREFIX_SOURCE=config as an opt-out', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    process.env.EXTENSION_PREFIX_SOURCE = 'config';
+    setModelObjectNameSource(() => HB_REAVIS);
+
+    expect(resolveObjectPrefix('HBReavis')).toBe('Con');
+  });
+
+  it('applies the model prefix to a new object name', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    setModelObjectNameSource(() => HB_REAVIS);
+
+    expect(applyObjectPrefix('AssetRegister', resolveObjectPrefix('HBReavis'), 'HBReavis'))
+      .toBe('HBR_AssetRegister');
+  });
+
+  it('uses the model\'s own infix for extension element names', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    setModelObjectNameSource(() => HB_REAVIS);
+
+    // Deriving from "HBR_" would give "CustTable.HbrExtension", which does not
+    // match the model's dozens of existing …HBRExtension elements.
+    expect(deriveExtensionInfix(resolveObjectPrefix('HBReavis'), 'HBReavis')).toBe('HBR');
+    expect(applyObjectPrefix('CustTable.Extension', resolveObjectPrefix('HBReavis'), 'HBReavis'))
+      .toBe('CustTable.HBRExtension');
+  });
+
+  it('leaves behaviour unchanged when no model prefix can be inferred', () => {
+    // The pre-existing contract for EXTENSION_PREFIX="XY_", which many setups
+    // rely on: regular objects keep the underscore, the infix does not.
+    process.env.EXTENSION_PREFIX = 'XY_';
+    setModelObjectNameSource(() => []);
+
+    expect(resolveObjectPrefix('SomeModel')).toBe('XY');
+    expect(resolveRegularObjectPrefixToken('SomeModel')).toBe('XY_');
+    expect(deriveExtensionInfix('XY', 'SomeModel')).toBe('Xy');
+    expect(applyObjectPrefix('CustTable', 'XY', 'SomeModel')).toBe('XY_CustTable');
+  });
+});
+
+describe('inference caching', () => {
+  it('queries the source once per model', () => {
+    let calls = 0;
+    setModelObjectNameSource(model => { calls++; return model === 'HBReavis' ? HB_REAVIS : []; });
+
+    getInferredModelPrefix('HBReavis');
+    getInferredModelPrefix('HBReavis');
+    resolveObjectPrefix('HBReavis');
+
+    expect(calls).toBe(1);
+  });
+
+  it('caches the "nothing to learn" answer too', () => {
+    // Otherwise every generated name re-runs the query against the 2 GB DB for
+    // exactly the models where it can never succeed.
+    let calls = 0;
+    setModelObjectNameSource(() => { calls++; return []; });
+
+    getInferredModelPrefix('EmptyModel');
+    getInferredModelPrefix('EmptyModel');
+
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
Three issues that all showed up as "simple things are slow" or "the generated name is wrong". Measurements below are from the reference VM's 2 GB production symbol DB.

## 1. `symbols.file_path` was never indexed

`removeSymbolsByFile()` is the first thing every `update_symbol_index`, `undo_last_modification` and resync runs, and both of its statements look rows up by `file_path`. With no index on that column, each of them scans the whole table:

| operation, indexing ONE new object | before | after |
| --- | --- | --- |
| `SELECT DISTINCT name … WHERE file_path IN (…)` | 319 s | 0 ms |
| `DELETE FROM symbols WHERE file_path IN (…)` | 173 s | 0 ms |
| bridge provider refresh | 266 ms | 266 ms |

So indexing a single freshly created object cost about eight minutes, and the bridge refresh everyone suspected was noise next to it.

Building the index takes ~8 s on an already-populated table, and `node:sqlite` is synchronous — doing that inline would block the event loop through startup, which is the failure mode that makes MCP clients time out and kill the server. It therefore runs in a worker thread (`buildIndexWorker.ts`, mirroring the existing `symbolCountsWorker`) when the DB is large, and inline when it is small or fresh. Until it finishes, those deletes stay exactly as slow as they are today. `labels.file_path` had the same hole and gets the same treatment.

## 2. `update_symbol_index` refreshed the bridge once per object

`filePath` now also accepts an array, and the provider is refreshed **once per call** rather than once per file. On top of that, the refresh is skipped when one already started after the newest file in the batch was written — `d365fo_file`'s create/modify paths already refresh on their way out, so the `update_symbol_index` call that conventionally follows was rebuilding a provider that could not possibly see anything new.

Single-path calls keep their exact previous response shape; only real batches get a roll-up line.

## 3. The prefix now comes from the active model, not from `EXTENSION_PREFIX`

`EXTENSION_PREFIX` is one value chosen once during setup, but development spans several models and each has its own prefix. On the reference VM:

| model | its objects | its extensions |
| --- | --- | --- |
| `Demo` | `DEM_ArchiveAccDocErrorLog`, `DEM_AssetIPFairValue`, … | `AssetBookTable.DEVExtension` |
| `DemoCus` | `DEC_REMLeaseContractLineUGs`, `DEC_OldDebtsReportDP`, … | `AssetTable.DECExtension` |
| `Contoso` | `ConDemoNoteHeader`, `ConDemoModStatus` | — |

…while `EXTENSION_PREFIX` says `Con` for all three. Creating an object while working in Demo produced `ConAssetRegister` instead of `DEM_AssetRegister`. Re-running setup on every context switch is not a workflow, and the information is already on disk: the model's own objects state its prefix more reliably than configuration does.

New order in `resolveObjectPrefix()`:

1. the prefix the active model's existing objects use,
2. `EXTENSION_PREFIX` — for a model with nothing to learn from, e.g. one still empty,
3. the model name.

Two tokens are inferred separately, because they are **not** derivable from one another — deriving from `DEM__` by the documented rule yields the infix `DEM_`, but the model's dozens of existing elements spell it `DEMExtension`:

- `regular` → `DEM__`, prepended to new objects and to members added inside extensions
- `infix` → `DEM`, embedded in extension element and class names

Inference is deliberately conservative: at least four non-extension objects and 60 % agreement, otherwise it falls through to the configured value rather than guessing. Extension classes are excluded from the leading-token count because they carry the token as a *suffix*. `EXTENSION_PREFIX_SOURCE=config` restores the previous order.

The lookup is a narrow, bounded, model-scoped query (`name` only, root objects, `LIMIT 400` — 450 ms on the 2 GB DB), cached per model including the negative answer, and reached through a source installed once at startup so `resolveObjectPrefix()` stays synchronous for its dozens of call sites.

## Members added inside an extension now carry the prefix

An extension lives in your model but its host object is Microsoft's, so an unprefixed field collides with whatever Microsoft or another ISV adds to the same host later. Microsoft's guideline requires the prefix and the model's own extensions already follow it — `AssetBookTable.DEMExtension` contains `<Name>DEM_MandatoryReasonCode</Name>`. `add-field` passed `fieldName` straight through, so `create` prefixed the object name while `add-field` did not.

Applied to `add-field`, `add-index`, `add-full-text-index`, `add-field-group` and `add-enum-value`. Deliberately **not** applied to:

- any method operation — a CoC method name must match the base method it wraps, so renaming turns an override into dead code that never runs;
- `add-field-to-field-group`'s group name — that group already exists and is usually Microsoft's (`Setup`);
- every remove/modify operation, which addresses members that already exist.

The response reports the applied name so the agent addresses the member correctly in its next call.

## Testing

Full suite green: 197 files, 2606 passed. New coverage:

- `tests/utils/modelPrefixInference.test.ts` — inference and resolution order, with object-name samples taken verbatim from the VM's `PackagesLocalDirectory` rather than invented ones; includes a case pinning that unchanged behaviour when nothing can be inferred (`EXTENSION_PREFIX="XY_"` still gives `XY_CustTable` and infix `Xy`).
- `tests/tools/extensionMemberPrefix.test.ts` — what gets prefixed and, just as importantly, what must not be.
- `tests/metadata/filePathIndex.test.ts` — asserts the query plan uses the index, over a fixture large enough that the planner has a real choice to make.
- `tests/tools/updateSymbolIndexBatch.test.ts` — one refresh per batch, the skip, and the single-path response shape.

Two existing test files needed `resolveRegularObjectPrefixToken` added to their `modelClassifier` mock; both keep it returning `''` so their fixtures stay unprefixed.

## Release

`package.json` goes to **1.8.2**. Note it still read `1.8.0` — the `v1.8.1` tag never carried a bump, so this also closes that drift. Tagging is left to you: pushing `v1.8.2` is what triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
