### PR TITLE
fix(setup): stop writing README.md into the solutions folder

### DIFF
--- a/src/cli/copilotFiles.ts
+++ b/src/cli/copilotFiles.ts
@@ -9,6 +9,10 @@
  * folder, or, when that is unknown, into a staging folder with a README
  * naming the two destinations.
  *
+ * The README belongs to the staging folder only. The solutions folder is the
+ * user's own projects directory, so the direct copy leaves nothing there but
+ * `.github\copilot-instructions.md` and says the rest on the console.
+ *
  * The README points at the one .mcp.json `mcpJsonNote()` writes in the data
  * root rather than copying it: the staging folder sits in that same data
  * root, so a second copy is only one more file to keep in sync.
@@ -24,7 +28,7 @@ import { askConfirm, p } from './ui.js';
 /** The copy shipped with this installation — package root in both install modes. */
 const copilotSource = (): string => resolve(repoRoot, '.github', 'copilot-instructions.md');
 
-function writeCopilotSetupReadme(targetDir: string, opts: { copilotAlreadyPlaced: boolean }): void {
+function writeCopilotSetupReadme(targetDir: string): void {
   const readmePath = resolve(targetDir, 'README.md');
   const lines = [
     '# VS setup quick guide',
@@ -37,9 +41,7 @@ function writeCopilotSetupReadme(targetDir: string, opts: { copilotAlreadyPlaced
     `   - Generated copy: ${paths.mcpSuggestion}`,
     '',
     '2. Copy .github/copilot-instructions.md',
-    opts.copilotAlreadyPlaced
-      ? '   - Already placed here: .github\\copilot-instructions.md'
-      : '   - Destination: a parent folder of your solution directories',
+    '   - Destination: a parent folder of your solution directories',
     '   - Why: provides mandatory D365FO tool-routing and safety rules for Copilot',
     '',
     '3. Restart Visual Studio after copying files.',
@@ -74,9 +76,11 @@ export async function maybePrepareCopilotInstructions(solutionsPath: string): Pr
     const targetDir = resolve(target, '.github');
     fs.mkdirSync(targetDir, { recursive: true });
     fs.copyFileSync(source, resolve(targetDir, 'copilot-instructions.md'));
-    writeCopilotSetupReadme(target, { copilotAlreadyPlaced: true });
     p.log.success(`Prepared: ${resolve(targetDir, 'copilot-instructions.md')}`);
-    p.log.success(`Prepared: ${resolve(target, 'README.md')}`);
+    p.log.info(
+      'Still to do: copy .mcp.json to %USERPROFILE%\\.mcp.json (or next to your .sln), then restart Visual Studio.\n' +
+      `   Generated copy: ${paths.mcpSuggestion}`,
+    );
     return;
   }
 
@@ -84,7 +88,7 @@ export async function maybePrepareCopilotInstructions(solutionsPath: string): Pr
   const stageGitHubDir = resolve(stageDir, '.github');
   fs.mkdirSync(stageGitHubDir, { recursive: true });
   fs.copyFileSync(source, resolve(stageGitHubDir, 'copilot-instructions.md'));
-  writeCopilotSetupReadme(stageDir, { copilotAlreadyPlaced: false });
+  writeCopilotSetupReadme(stageDir);
 
   if (wantsDirectCopy && !target) {
     p.log.warn('Solutions folder is empty, so files were prepared in the local staging folder instead.');

--- a/tests/cli/copilotFiles.test.ts
+++ b/tests/cli/copilotFiles.test.ts
@@ -4,9 +4,10 @@
  * Both files (.mcp.json and .github\copilot-instructions.md) have to be placed
  * for Copilot to route through the MCP tools at all, so the wizard's copy step
  * is load-bearing rather than a convenience: when it silently does nothing the
- * user ends up with a server the agent never uses. The README is what tells
- * them where the files go, which makes "was a README written" part of the
- * contract, not decoration.
+ * user ends up with a server the agent never uses. The staging folder's README
+ * is what tells them where the files go, which makes "was a README written"
+ * part of the contract there — and "was one *not* written" part of it in the
+ * user's own solutions folder.
  */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -48,7 +49,10 @@ afterEach(() => {
 describe('maybePrepareCopilotInstructions', () => {
   const stagingDir = () => resolve(installDir, 'copilot-setup');
 
-  it('copies the instructions and writes a README into the solutions folder', async () => {
+  it('copies only the instructions into the solutions folder', async () => {
+    // The solutions folder is the user's own projects directory: a README
+    // dropped next to their repos is litter, so the direct copy leaves the
+    // one file that has to be there and says the rest on the console.
     const solutions = resolve(tmpRoot, 'repos');
     fs.mkdirSync(solutions);
 
@@ -56,9 +60,8 @@ describe('maybePrepareCopilotInstructions', () => {
 
     expect(fs.existsSync(stagingDir())).toBe(false);
     expect(fs.readFileSync(resolve(solutions, '.github', 'copilot-instructions.md'), 'utf8')).toBe('# rules\n');
-    const readme = fs.readFileSync(resolve(solutions, 'README.md'), 'utf8');
-    expect(readme).toContain('Already placed here');
-    expect(readme).toContain(resolve(installDir, '.mcp.json'));
+    expect(fs.existsSync(resolve(solutions, 'README.md'))).toBe(false);
+    expect(fs.readdirSync(solutions)).toEqual(['.github']);
   });
 
   it('creates the solutions folder when it does not exist yet', async () => {


### PR DESCRIPTION
## Problem

`d365fo-mcp setup` (and `instance add`), when it copies `copilot-instructions.md` straight into the configured solutions folder, also wrote a generated `README.md` there. That folder is the user's own projects directory — the note is one-time setup guidance, not a file that belongs next to their repos.

## Change

- The direct-copy path places only `.github\copilot-instructions.md`. The remaining step (where `.mcp.json` goes, restart Visual Studio) is printed to the console instead of left on disk.
- The staging-folder path is unchanged: there the README is load-bearing, since nothing in that folder is in its final location and the file is what names the two destinations.
- With one caller left, `copilotAlreadyPlaced` drops out of `writeCopilotSetupReadme`.

## Test

`tests/cli/copilotFiles.test.ts` now asserts the solutions folder ends up containing `.github` and nothing else; the staging-folder cases are untouched. 6/6 pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)