### PR TITLE
release: v1.9.0 — tool output sized by what the agent can act on

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ Call `get_workspace_info()` before doing anything with D365FO objects.
 |----------|--------|
 | Call fails | STOP. MCP server not connected. Ask user to start it. |
 | `⛔ CONFIGURATION PROBLEM` | STOP. Relay message. Wait for user. |
-| `✅ Configuration looks valid` | Note model name. Proceed. |
+| No `⛔` in the response | Note the `Model` / `Prefix` lines. Proceed. |
 
 ## Terminal Prohibition
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.8.5",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -8,7 +8,7 @@
  *
  * Kept deliberately under 200 lines: the prompt holds only the tool decision
  * tree and hard prohibitions. Everything that is a rule about CODE lives in
- * the queryable knowledge base — get_xpp_knowledge (see the ID table below).
+ * the queryable knowledge base — get_knowledge (see the ID table below).
  */
 
 /**
@@ -119,7 +119,7 @@ You are an AI assistant with access to D365FO MCP tools, assisting with Dynamics
 - No literal strings in \`Info()\`/\`error()\`/labels — use \`@Model:LabelId\` (reuse via \`labels(action="search")\` first)
 - Every public/protected member needs a meaningful \`/// <summary>\` (not "MyClass class.")
 
-**For full rules and examples call \`get_xpp_knowledge(id)\` BEFORE generating code:**
+**For full rules and examples call \`get_knowledge(kind="knowledge", topic=<id>)\` BEFORE generating code:**
 
 | Knowledge ID | Covers |
 |---|---|

--- a/src/server/toolSchemas/getWorkspaceInfo.ts
+++ b/src/server/toolSchemas/getWorkspaceInfo.ts
@@ -21,7 +21,7 @@ export const getWorkspaceInfoTool = {
         diagnostics: {
           type: 'boolean',
           default: false,
-          description: 'Include verbose diagnostic sections (suffix breakdown, stdio session/handshake dump). Use when debugging client-server connectivity.',
+          description: 'Include verbose sections (config sources, suffix, project paths, index scan, stdio handshake). Use when debugging config or connectivity.',
         },
       },
       required: [],

--- a/src/tools/codeGen.ts
+++ b/src/tools/codeGen.ts
@@ -100,7 +100,7 @@ internal final class ${name}
 // D365FO Data Entity: ${name}Entity
 // ══════════════════════════════════════════════════════════════════
 // Data entities are AxDataEntityView XML objects (NOT X++ classes).
-// Use create_d365fo_file(objectType="view") or the VS designer.
+// Use d365fo_file(action="create", objectType="view") or the VS designer.
 //
 // Key properties to set in XML:
 //   PublicEntityName:       "${name}"  (OData singular name)
@@ -123,8 +123,8 @@ internal final class ${name}
 //
 // Workflow:
 //   1. get_object_info(objectType="data-entity", name="similar entity")  → study structure
-//   2. generate_d365fo_xml(objectType="data-entity", ...)  → preview XML
-//   3. create_d365fo_file(objectType="view", ...)  → create file
+//   2. generate_object(mode="scaffold", objectType="data-entity", ...)  → preview XML
+//   3. d365fo_file(action="create", objectType="view", ...)  → create file
 //   4. After deployment: refresh entity list in Data Management workspace
 `,
 
@@ -674,7 +674,7 @@ function menuItemXmlTemplate(name: string, itemType: string, targetObject: strin
 function ssrsReportFullTemplate(name: string): string {
   return `// ══════════════════════════════════════════════════════════════════
 // SSRS Report: ${name}
-// 5 objects required (use create_d365fo_file for each):
+// 5 objects required (use d365fo_file(action="create") for each):
 //   1. ${name}TmpTable  — TempDB table (objectType="table", tableType="TempDB")
 //   2. ${name}Contract  — DataContract class (below)
 //   3. ${name}DP        — Data Provider class (below)
@@ -1087,14 +1087,14 @@ public class ${name}Controller extends MenuFunction
 function dataEntityStagingTemplate(name: string): string {
   return `// ══════════════════════════════════════════════════════════════════════════
 // Data Entity with Staging Table: ${name}
-// 3 objects required (use create_d365fo_file for each):
+// 3 objects required (use d365fo_file(action="create") for each):
 //   1. ${name}StagingTable  — TempDB staging table
 //   2. ${name}Entity        — Data entity (AxDataEntityView)
 //   3. ${name}EntityService — Optional: AIF service class
 // ══════════════════════════════════════════════════════════════════════════
 
 // ── Object 1: Staging table ${name}Staging ─────────────────────────────────
-// create_d365fo_file(objectType="table", objectName="${name}Staging", xmlContent=...)
+// d365fo_file(action="create", objectType="table", objectName="${name}Staging", xmlContent=...)
 // Set: TableType=TempDB (NOT RegularTable), TableGroup=Main
 // Fields mirror the entity's public fields exactly (same names, same EDTs)
 
@@ -1703,7 +1703,7 @@ public class ${name}Service
     }
 }
 
-// ── 3. AOT objects (create via create_d365fo_file) ──────────────────────
+// ── 3. AOT objects (create via d365fo_file(action="create")) ────────────
 // Verify the result afterwards with get_object_info(objectType="service", name="${name}Service").
 // a) AxService XML (real schema: ServiceOperations / AxServiceOperation / Method):
 //    <AxService xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
@@ -1873,7 +1873,10 @@ export async function codeGenTool(request: CallToolRequest) {
       // real codebase (via prepare_change) before generating extension code.
       const groundingError = enforceGrounding(
         args.groundingToken,
-        `generate_code(pattern="${args.pattern}", name="${args.name}")`,
+        // The MCP-visible name, not the internal one: this string is echoed back
+        // as the call the agent must repeat with a token, and `generate_code`
+        // has not been a registered tool since the mega-tool consolidation.
+        `generate_object(mode="pattern", pattern="${args.pattern}", name="${args.name}")`,
         args.name,
       );
       if (groundingError) return groundingError;
@@ -1977,20 +1980,18 @@ export async function codeGenTool(request: CallToolRequest) {
             `Generated ${args.pattern} template for "${displayName}":\n\n` +
             `\`\`\`xpp${code}\n\`\`\`\n\n` +
             `---\n\n` +
-            `${namingNote}\n\n` +
+            namingNote +
+            // Only the CoC signature rule earns a line here: guessing static vs
+            // instance produces code that fails to compile. The rest was a menu
+            // of optional follow-ups — and it named tools that do not exist
+            // (`find_coc_extensions`) with argument forms analyze_code rejects
+            // (positional, not `className`/`methodName`), so following it cost a
+            // failed call before the agent could get anything useful.
             (args.pattern === 'class-extension'
-              ? `💡 **Next Steps (class-extension CoC workflow):**\n\n` +
-                `1. 🚨 Use \`get_method(include="signature", "${displayName}", "<methodName>")\` — **REQUIRED** to get the exact signature (static vs instance, return type, parameters) before writing any CoC method\n` +
-                `2. ✅ Use \`find_coc_extensions("${displayName}", "<methodName>")\` - See existing CoC wrappers for reference\n` +
-                `3. ✅ Use \`analyze_code(mode="implementations", "${displayName}", "<methodName>")\` - Get real implementation examples\n` +
-                `4. ✅ Use \`analyze_code(mode="api-usage", "<ClassName>")\` - See how to use D365FO APIs correctly\n\n` +
-                `⚠️ Never guess static vs instance — always use get_method(include="signature") first.`
-              : `💡 **Next Steps for Better Code Quality:**\n\n` +
-                `1. ✅ Use \`analyze_code(mode="patterns", "<scenario>")\` - Learn what D365FO classes are commonly used together\n` +
-                `2. ✅ Use \`analyze_code(mode="implementations", "${displayName}", "<methodName>")\` - Get real implementation examples\n` +
-                `3. ✅ Use \`analyze_code(mode="completeness", "${displayName}")\` - Check for missing common methods\n` +
-                `4. ✅ Use \`analyze_code(mode="api-usage", "<ClassName>")\` - See how to use D365FO APIs correctly\n\n` +
-                `These tools provide patterns from the actual codebase, not generic templates.`),
+              ? `\n\n⚠️ Before writing any CoC method call \`get_method(include="signature", className="${displayName}", methodName="<methodName>")\` — ` +
+                `never guess static vs instance, the return type or the parameter list. ` +
+                `Existing wrappers: \`extension_info(mode="coc", target="${displayName}")\`.`
+              : ``),
         },
       ],
     };

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -5276,16 +5276,13 @@ export async function handleCreateD365File(
       }
     }
 
-    // Build success message
+    // Only the step the AGENT can take. "Reload the project in VS / refresh the
+    // AOT" is a human's UI chore, repeated on every object of a feature; when it
+    // matters (addToProject failed, no projectPath) `projectMessage` above
+    // already says so, in that specific case.
     const nextSteps = args.addToProject
-      ? `Next steps:\n` +
-        `1. Reload project in Visual Studio (or close/reopen solution)\n` +
-        `2. Build the project to synchronize the object\n` +
-        `3. Refresh AOT in Visual Studio to see the new object\n`
-      : `Next steps:\n` +
-        `1. Add the file to your Visual Studio project (.rnrproj)\n` +
-        `2. Build the project to synchronize the object\n` +
-        `3. Refresh AOT in Visual Studio to see the new object\n`;
+      ? `Next: build_d365fo_project to synchronize the object.\n`
+      : `Next: add the file to your .rnrproj, then build_d365fo_project to synchronize the object.\n`;
 
     // Record the freshly-created file for non-git undo (see the bridge paths above).
     if (!fileExisted) {

--- a/src/tools/extensionStrategyAdvisor.ts
+++ b/src/tools/extensionStrategyAdvisor.ts
@@ -59,7 +59,12 @@ interface StrategyRule {
   risks: readonly string[];
   /** Alternative mechanisms and when to prefer them */
   alternatives: readonly { mechanism: string; when: string }[];
-  /** Suggested MCP tool calls to proceed */
+  /**
+   * Suggested MCP tool calls to proceed. These are copied verbatim by the agent,
+   * so they must name tools that are actually registered (see toolHandler's
+   * dispatch) with the argument form their schema requires — a line here that
+   * predates the mega-tool consolidation buys a guaranteed failed call.
+   */
   nextSteps: readonly string[];
   /** Anti-patterns: common wrong choices for this scenario */
   antiPatterns: readonly { wrong: string; why: string }[];
@@ -86,9 +91,9 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'Form data source validateWrite()', when: 'Validation is UI-specific and should NOT apply to service/entity imports' },
     ],
     nextSteps: [
-      'analyze_extension_points("TableName") — check available events and existing extensions',
-      'find_event_handlers("TableName") — see if someone already handles the same event',
-      'generate_code(pattern="event-handler") — generate the handler skeleton',
+      'extension_info(mode="points", target="TableName") — available events and existing extensions',
+      'extension_info(mode="events", target="TableName") — see if someone already handles the same event',
+      'generate_object(mode="pattern", pattern="event-handler", name="TableName") — handler skeleton',
     ],
     antiPatterns: [
       { wrong: 'Business Event', why: 'Business Events are for outbound notifications, not validation logic' },
@@ -115,8 +120,8 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'Form data source initValue()', when: 'Default depends on form context (e.g. header record of a lines form)' },
     ],
     nextSteps: [
-      'analyze_extension_points("TableName") — check initValue availability',
-      'get_method(include="signature", "TableName", "initValue", includeCocTemplate: true) — get CoC template',
+      'extension_info(mode="points", target="TableName") — check initValue availability',
+      'get_method(include="signature", className="TableName", methodName="initValue") — exact signature for the CoC wrapper',
     ],
     antiPatterns: [
       { wrong: 'Overriding insert()', why: 'insert() is for persistence — defaults belong in initValue()' },
@@ -154,9 +159,9 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'CoC on table.modifiedFieldValue()', when: 'You also need the previous value to decide what to do' },
     ],
     nextSteps: [
-      'analyze_extension_points("TableName") — confirm modifiedField is CoC-eligible and see existing extensions',
-      'get_method(include="signature", "TableName", "modifiedField", includeCocTemplate: true) — get the CoC skeleton',
-      'find_coc_extensions("TableName", "modifiedField") — check for existing wrappers',
+      'extension_info(mode="points", target="TableName") — confirm modifiedField is CoC-eligible and see existing extensions',
+      'get_method(include="signature", className="TableName", methodName="modifiedField") — exact signature for the CoC wrapper',
+      'extension_info(mode="coc", target="TableName", method="modifiedField") — check for existing wrappers',
     ],
     antiPatterns: [
       { wrong: 'CoC on initValue()', why: 'initValue fires only at record creation — it will NOT run when the user later changes the field' },
@@ -187,9 +192,9 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'Replaceable method', when: 'Method is marked [Replaceable] — you can fully replace it (rare in standard app)' },
     ],
     nextSteps: [
-      'analyze_extension_points("ClassName") — see CoC-eligible methods and delegates',
-      'get_method(include="signature", "ClassName", "methodName", includeCocTemplate: true) — get exact CoC skeleton',
-      'find_coc_extensions("ClassName", "methodName") — check for existing CoC wrappers',
+      'extension_info(mode="points", target="ClassName") — see CoC-eligible methods and delegates',
+      'get_method(include="signature", className="ClassName", methodName="methodName") — exact signature for the CoC wrapper',
+      'extension_info(mode="coc", target="ClassName", method="methodName") — check for existing CoC wrappers',
     ],
     antiPatterns: [
       { wrong: 'Copy-paste the entire class', why: 'Over-layering defeats the purpose of extensions and blocks upgrades' },
@@ -220,8 +225,8 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'Dual-write', when: 'Real-time bidirectional sync with Dataverse is needed' },
     ],
     nextSteps: [
-      'get_knowledge(kind="knowledge", "business events") — learn the pattern',
-      'generate_code(pattern="business-event", name="MyEvent") — generate skeleton',
+      'get_knowledge(kind="knowledge", topic="business events") — learn the pattern',
+      'generate_object(mode="pattern", pattern="business-event", name="MyEvent") — generate skeleton',
     ],
     antiPatterns: [
       { wrong: 'CoC calling HttpClient', why: 'Synchronous HTTP in a transaction blocks the user and risks timeout/rollback' },
@@ -253,9 +258,9 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'Composite entity', when: 'Header + lines structure needs to be imported as a document' },
     ],
     nextSteps: [
-      'get_knowledge(kind="knowledge", "data-management-framework") — learn DMF patterns',
-      'search("MyTable", "data-entity") — check if an entity already exists',
-      'generate_code(pattern="data-entity", name="MyEntity") — generate entity skeleton',
+      'get_knowledge(kind="knowledge", topic="data-management-framework") — learn DMF patterns',
+      'search(query="MyTable", type="data-entity") — check if an entity already exists',
+      'generate_object(mode="pattern", pattern="data-entity", name="MyEntity") — generate entity skeleton',
     ],
     antiPatterns: [
       { wrong: 'Direct table insert via custom endpoint', why: 'Bypasses validation, number sequences, and event handlers' },
@@ -286,7 +291,7 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
     ],
     nextSteps: [
       'get_object_info(objectType="form", name="FormName", options={searchControl:"General"}) — find exact control names and hierarchy',
-      'analyze_extension_points("FormName") — check form extension points',
+      'extension_info(mode="points", target="FormName", objectType="form") — check form extension points',
       'd365fo_file(action="create", objectType="form-extension") — create the extension',
     ],
     antiPatterns: [
@@ -319,8 +324,8 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
     ],
     nextSteps: [
       'get_object_info(objectType="report", name="ReportName") — inspect existing report structure',
-      'get_knowledge(kind="knowledge", "ssrs-reports") — patterns for SSRS',
-      'generate_smart(objectType="report", name="MyReport") — generate full SSRS stack',
+      'get_knowledge(kind="knowledge", topic="ssrs-reports") — patterns for SSRS',
+      'generate_object(mode="scaffold", objectType="report", name="MyReport") — generate full SSRS stack',
     ],
     antiPatterns: [
       { wrong: 'Business Event for document delivery', why: 'Business Events send notifications, not formatted documents' },
@@ -346,8 +351,8 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'Custom counter table', when: 'Simple auto-increment without legal entity scope or configurable format (rare — prefer the framework)' },
     ],
     nextSteps: [
-      'get_knowledge(kind="knowledge", "number-sequences") — full pattern reference',
-      'generate_code(pattern="number-seq-handler") — generate skeleton',
+      'get_knowledge(kind="knowledge", topic="number-sequences") — full pattern reference',
+      'generate_object(mode="pattern", pattern="number-seq-handler", name="MyModule") — generate skeleton',
     ],
     antiPatterns: [
       { wrong: 'Identity column / RecId as business number', why: 'RecId is internal — users need formatted, gapless (or configurable) business numbers' },
@@ -376,8 +381,8 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'Table permission framework override', when: 'Granting DML access without a menu item entry point (rare)' },
     ],
     nextSteps: [
-      'get_knowledge(kind="knowledge", "security-privileges-duties") — security pattern reference',
-      'security_info(mode="coverage", "ObjectName") — check existing security chain',
+      'get_knowledge(kind="knowledge", topic="security-privileges-duties") — security pattern reference',
+      'security_info(mode="coverage", objectName="ObjectName") — check existing security chain',
       'd365fo_file(action="create", objectType="security-privilege") — create privilege',
     ],
     antiPatterns: [
@@ -406,9 +411,9 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
       { mechanism: 'Business Event + external processor', when: 'Processing should happen outside D365FO (e.g. Azure Function)' },
     ],
     nextSteps: [
-      'get_knowledge(kind="knowledge", "sysoperation") — SysOperation patterns',
-      'generate_code(pattern="sysoperation", name="MyProcess") — generate SysOperation skeleton',
-      'generate_code(pattern="batch-job", name="MyBatch") — generate RunBaseBatch skeleton',
+      'get_knowledge(kind="knowledge", topic="sysoperation") — SysOperation patterns',
+      'generate_object(mode="pattern", pattern="sysoperation", name="MyProcess") — generate SysOperation skeleton',
+      'generate_object(mode="pattern", pattern="batch-job", name="MyBatch") — generate RunBaseBatch skeleton',
     ],
     antiPatterns: [
       { wrong: 'Thread.Sleep / while-polling in batch', why: 'Use batch recurrence and alerts — polling wastes AOS resources' },

--- a/src/tools/prefixDiagnostics.ts
+++ b/src/tools/prefixDiagnostics.ts
@@ -47,8 +47,15 @@ function sameModel(a: string | null, b: string | null): boolean {
 }
 
 export interface PrefixDiagnostics {
-  /** Lines for the "## Prefix Configuration" section, blank line included. */
+  /**
+   * Compact default: one `Prefix : …` line, plus a note only when something is
+   * actually off (a switch is in effect, or the resolved prefix contradicts the
+   * configuration). Every call of get_workspace_info pays for these tokens, so
+   * the confirmations that only restate the value stay in `verboseLines`.
+   */
   lines: string[];
+  /** Full "## Prefix Configuration" section — diagnostics=true only. */
+  verboseLines: string[];
   /** The prefix a write would apply — for the Extension Naming samples. */
   effectivePrefix: string;
 }
@@ -87,30 +94,50 @@ export function buildPrefixDiagnostics(
 
   const switched = !!writeModel && !!readModel && !sameModel(writeModel, readModel);
 
-  const lines = [
+  const switchNote =
+    `ℹ️  This is the prefix for WRITES, which are anchored to "${writeModel}". "${readModel}" is ` +
+    `merely the active project and its own prefix may differ — see the project-switch note below.`;
+
+  const disagreeNote =
+    `⚠️  The model's own objects use "${learned?.regular}", which overrides EXTENSION_PREFIX="${extensionPrefixEnv}" — new objects will be named "${effectivePrefix}…". If that is wrong, the model's existing objects are the thing to check; set EXTENSION_PREFIX_SOURCE=config to pin the configured value instead.`;
+
+  const notConfiguredNote =
+    `⚠️  EXTENSION_PREFIX is not set in the server environment. The model name "${writeModel}" will be used as prefix. Add EXTENSION_PREFIX=MY (or your ISV prefix) to the .env file and restart the server.`;
+
+  // Compact: the value, its origin, and a warning only when there is one. The
+  // warnings keep the fix but drop the explanation of it — the resolved prefix
+  // is one line above, so what is wrong is already visible.
+  const lines = [`Prefix      : ${effectivePrefix || '(none)'}  (${source})`];
+  if (switched) lines.push(switchNote);
+  if (disagrees) {
+    lines.push(
+      `⚠️  The model's own objects use "${learned?.regular}", overriding EXTENSION_PREFIX="${extensionPrefixEnv}". ` +
+      `To pin the configured value instead: EXTENSION_PREFIX_SOURCE=config.`,
+    );
+  } else if (!learned?.regular && !extensionPrefixEnv) {
+    lines.push(
+      `⚠️  EXTENSION_PREFIX is not set — the model name is being used as the prefix. ` +
+      `Add EXTENSION_PREFIX=MY (your ISV prefix) to .env and restart the server.`,
+    );
+  }
+
+  const verboseLines = [
     `## Prefix Configuration`,
     ``,
     `EXTENSION_PREFIX: ${extensionPrefixEnv ?? '(not set — falling back to model name)'}`,
     `Effective prefix: ${effectivePrefix || '(none)'}  (source: ${source})`,
   ];
-
-  if (switched) {
-    lines.push(
-      `ℹ️  This is the prefix for WRITES, which are anchored to "${writeModel}". "${readModel}" is ` +
-      `merely the active project and its own prefix may differ — see the project-switch note below.`,
-    );
-  }
-
-  lines.push(
+  if (switched) verboseLines.push(switchNote);
+  verboseLines.push(
     disagrees
-      ? `⚠️  The model's own objects use "${learned!.regular}", which overrides EXTENSION_PREFIX="${extensionPrefixEnv}" — new objects will be named "${effectivePrefix}…". If that is wrong, the model's existing objects are the thing to check; set EXTENSION_PREFIX_SOURCE=config to pin the configured value instead.`
+      ? disagreeNote
       : learned?.regular
         ? `✅ Prefix "${effectivePrefix}" comes from the objects model "${writeModel}" already contains.`
         : extensionPrefixEnv
           ? `✅ EXTENSION_PREFIX is set — all new objects will use prefix "${effectivePrefix}".`
-          : `⚠️  EXTENSION_PREFIX is not set in the server environment. The model name "${writeModel}" will be used as prefix. Add EXTENSION_PREFIX=MY (or your ISV prefix) to the .env file and restart the server.`,
+          : notConfiguredNote,
     ``,
   );
 
-  return { lines, effectivePrefix };
+  return { lines, verboseLines, effectivePrefix };
 }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -284,7 +284,9 @@ async function performHybridSearch(
     });
   }
 
-  output += `\n\n💡 **Workspace-aware search** includes both your local project files and D365FO external metadata.`;
+  // No trailing "this search is workspace-aware" note: the 🔹/📦 marker on every
+  // row already says which side a hit came from, and search is the most-called
+  // tool — a fixed footer here is paid for on every call for nothing actionable.
 
   return {
     content: [

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -38,9 +38,14 @@ import {
   getInFlight, registerInFlight, clearInFlight,
 } from '../utils/callDedup.js';
 import { checkIndexStaleness } from '../utils/indexStaleness.js';
-import { buildContextSnapshot, renderContextSnapshotSection } from '../workspace/contextSnapshot.js';
+import {
+  buildContextSnapshot, renderContextSnapshotSection, renderContextSnapshotCompact,
+} from '../workspace/contextSnapshot.js';
 import * as nodePath from 'path';
 import { buildProgressMessage } from '../utils/toolProgressMessage.js';
+
+/** Models named inline by the compact project list before it summarises the rest. */
+const PROJECT_NAMES_SHOWN = 12;
 
 /**
  * Extract workspace path from GitHub Copilot _meta.
@@ -98,6 +103,10 @@ const TOOL_CAP_SIZES: Record<string, number | 'uncapped'> = {
   build_d365fo_project:             'uncapped', // compiler errors can appear late in long logs
   security_info:                    8000,
   extension_info:                   6000,
+  // Default output is ~1 KB. The higher cap exists for diagnostics=true, whose
+  // whole point is the full dump — truncating that at 5000 hid the stdio
+  // handshake section behind the project table.
+  get_workspace_info:               20000,
   default:                          5000,
 };
 
@@ -345,7 +354,9 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         // from — after a project switch those are different models (see
         // buildPrefixDiagnostics and ConfigManager.getWriteAnchorModel).
         const writeModel = modelWritesLandIn(configManager.getWriteAnchorModel() ?? modelName, modelName);
-        const { lines: prefixLines, effectivePrefix } = buildPrefixDiagnostics(writeModel, modelName);
+        const {
+          lines: prefixLines, verboseLines: prefixVerboseLines, effectivePrefix,
+        } = buildPrefixDiagnostics(writeModel, modelName);
         const objectSuffixEnv = process.env.EXTENSION_SUFFIX?.trim() || null;
         const effectiveSuffix = getObjectSuffix();
 
@@ -372,43 +383,34 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         // MS framework path shown in diagnostics; omitted for single-root traditional setups.
         const msFrameworkPath = frameworkDirectory ?? (!customPackagesPath ? null : packagePath);
 
-        // Verbose diagnostic sections cost tokens on every call — opt-in only.
+        // get_workspace_info is called at the start of every session, so every
+        // line here is paid for on a cold context. The default output carries
+        // only what changes what the agent does next — identity, where writes
+        // land, the naming it must apply, and anything that is actually wrong.
+        // Sources, confirmations and the per-project path table are diagnostics.
         const diagnostics = args.diagnostics === true;
 
-        const lines: string[] = [
-          `## D365FO Workspace Configuration`,
-          ``,
-          `Model name      : ${modelName ?? '(not configured)'}  (source: ${modelSource})`,
-          `Custom write path: ${effectiveWritePath ?? '(not configured)'}  (custom metadata, source: ${effectiveWriteSource})`,
-          `Framework dir   : ${msFrameworkPath ?? '(not applicable — single-root setup)'}  (Microsoft metadata, read-only)`,
-          `Project path    : ${projectPath ?? '(not detected)'}  (source: ${projectSource})`,
-          `Env type        : ${envType}`,
-          ``,
-          ...prefixLines,
-        ];
-
-        // A switch moves which project is ACTIVE — nothing else. Reads never
-        // needed it (they span every model regardless) and writes stay anchored
-        // to the model the workspace resolved on its own, so switching cannot be
-        // used to reach an object the cross-model guard refused. Say both here,
-        // before anything is written, so the switch is not mistaken for access.
-        const toolSwitch = configManager.getToolProjectSwitch();
-        if (toolSwitch) {
-          lines.push(
-            `## ⚠️  Project switched — writes are NOT switched`,
-            ``,
-            `"${toolSwitch.forcedModel}" is now the ACTIVE project. This did not change what you ` +
-            `can read: get_object_info, search and find_references span every model, switched or ` +
-            `not, so a switch is never needed to look at another model's code. Writes stay ` +
-            `anchored to "${toolSwitch.anchorModel}" — the model the open workspace targets — and ` +
-            `a create/modify into "${toolSwitch.forcedModel}" will be refused.`,
-            `Tell the user the model they asked about is owned by "${toolSwitch.forcedModel}" and let ` +
-            `THEM decide: extend it from "${toolSwitch.anchorModel}", or allow the write by adding ` +
-            `D365FO_CROSS_MODEL_WRITE_MODELS=${toolSwitch.forcedModel} to the server's .env — that ` +
-            `applies to the next attempt, no restart. Do not decide this on your own.`,
-            ``,
-          );
-        }
+        const lines: string[] = diagnostics
+          ? [
+              `## D365FO Workspace Configuration`,
+              ``,
+              `Model name      : ${modelName ?? '(not configured)'}  (source: ${modelSource})`,
+              `Custom write path: ${effectiveWritePath ?? '(not configured)'}  (custom metadata, source: ${effectiveWriteSource})`,
+              `Framework dir   : ${msFrameworkPath ?? '(not applicable — single-root setup)'}  (Microsoft metadata, read-only)`,
+              `Project path    : ${projectPath ?? '(not detected)'}  (source: ${projectSource})`,
+              `Env type        : ${envType}`,
+              ``,
+              ...prefixVerboseLines,
+            ]
+          : [
+              `## D365FO Workspace`,
+              ``,
+              `Model       : ${modelName ?? '(not configured)'}  (${modelSource})`,
+              ...prefixLines,
+              `Write path  : ${effectiveWritePath ?? '(not configured)'}`,
+              `Project     : ${projectPath ?? '(not detected)'}`,
+              `Env         : ${envType}`,
+            ];
 
         if (diagnostics) {
           lines.push(
@@ -422,7 +424,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
             ``,
           );
         } else if (effectiveSuffix) {
-          lines.push(`Suffix          : "${effectiveSuffix}" appended to new objects (EXTENSION_SUFFIX)`, ``);
+          lines.push(`Suffix      : "${effectiveSuffix}" appended to new objects (EXTENSION_SUFFIX)`);
         }
 
         // Extension naming: prefix is the infix unless EXTENSION_NAMING_STYLE="model-name"
@@ -440,76 +442,59 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         const sampleElemExt = extNamingStyle === 'model-name' && writeModel
           ? `CustTable.${writeModel}`
           : `CustTable.${extInfix}Extension`;
-        lines.push(
-          `## Extension Naming`,
-          ``,
-          `EXTENSION_NAMING_STYLE: ${process.env.EXTENSION_NAMING_STYLE?.trim() || '(not set → "prefix")'}`,
-          extNamingStyle === 'model-name'
-            ? `✅ model-name style — extension token is the MODEL NAME (Visual Studio default).`
-            : `ℹ️  prefix style (default) — extension token is the EXTENSION_PREFIX infix.`,
-          `  • Extension class  → ${sampleClassExt}`,
-          `  • Element extension → ${sampleElemExt}`,
-          `  ⚠️  Pass the BASE object name (e.g. "CustTable") to d365fo_file(action="create") and let the tool apply the token — any infix you embed will be normalised to the above.`,
-          ``,
-        );
-
-        if (isPlaceholder) {
-          const rawDetectedModel = await configManager.getRawAutoDetectedModelName();
-          const detectedHint = rawDetectedModel
-            ? `> ✅ Auto-detected from .rnrproj: **${rawDetectedModel}**\n` +
-              `> Update your .mcp.json: set \`modelName\` to \`"${rawDetectedModel}"\``
-            : `> ⚠️ No .rnrproj was found — make sure the MCP server is running in the right directory.`;
+        if (diagnostics) {
           lines.push(
-            `⛔ CONFIGURATION PROBLEM — model name "${modelName}" is a placeholder, not a real D365FO model.`,
+            `## Extension Naming`,
             ``,
-            `**YOU MUST STOP** and tell the user:`,
-            `> The configured model name "${modelName}" is a placeholder.`,
-            detectedHint,
-            `>`,
-            `> Please check that:`,
-            `> 1. The MCP server is running in the correct workspace directory`,
-            `> 2. The .mcp.json / mcp.json file has the correct modelName`,
-            `> 3. The projectPath points to a valid .rnrproj file`,
-            `>`,
-            `> Do you want to fix the configuration first, or continue with built-in tools (limited functionality)?`,
-          );
-        } else if (isStandardMsModel) {
-          const allProj = configManager.getAllDetectedProjects();
-          const customCandidates = allProj.filter(p => isCustomModel(p.modelName));
-          const hint = customCandidates.length > 0
-            ? `Available custom models: ${customCandidates.map(p => p.modelName).join(', ')}\n` +
-              `Switch with: get_workspace_info(projectName="<model>")`
-            : `No custom models found under D365FO_SOLUTIONS_PATH. Check your project configuration.`;
-          lines.push(
-            `⛔ CONFIGURATION PROBLEM — model name "${modelName}" is a Microsoft standard/demo model, not a custom model.`,
+            `EXTENSION_NAMING_STYLE: ${process.env.EXTENSION_NAMING_STYLE?.trim() || '(not set → "prefix")'}`,
+            extNamingStyle === 'model-name'
+              ? `✅ model-name style — extension token is the MODEL NAME (Visual Studio default).`
+              : `ℹ️  prefix style (default) — extension token is the EXTENSION_PREFIX infix.`,
+            `  • Extension class  → ${sampleClassExt}`,
+            `  • Element extension → ${sampleElemExt}`,
+            `  ⚠️  Pass the BASE object name (e.g. "CustTable") to d365fo_file(action="create") and let the tool apply the token — any infix you embed will be normalised to the above.`,
             ``,
-            `**YOU MUST STOP** and tell the user:`,
-            `> The auto-detected model "${modelName}" is a Microsoft standard model.`,
-            `> This usually happens when a new VS project was created and the default model`,
-            `> in the project wizard ("FleetManagement") was not changed to the correct custom model.`,
-            `>`,
-            `> How to fix:`,
-            `> 1. In Visual Studio, open the .rnrproj file and change <Model>FleetManagement</Model>`,
-            `>    to the correct model name (e.g. <Model>ContosoCore</Model>).`,
-            `> 2. OR explicitly switch to a known project:`,
-            `>    ${hint}`,
-            `> 3. OR add the correct modelName to .mcp.json.`,
           );
         } else {
-          lines.push(`✅ Configuration looks valid. Proceed with D365FO operations using model "${modelName}".`);
+          // The samples ARE the instruction: the style name and the token rule
+          // add nothing once the two produced names are in front of the agent.
+          lines.push(
+            `Extensions  : ${sampleClassExt} · ${sampleElemExt}  ` +
+            `(pass the BASE name to d365fo_file(create) — the tool applies the token)`,
+          );
         }
 
         const allProjects = configManager.getAllDetectedProjects();
         if (allProjects.length > 1) {
-          lines.push(``);
-          lines.push(`## Available Projects`);
-          lines.push(``);
-          for (const p of allProjects) {
-            const active = p.projectPath === projectPath ? '▶ ' : '  ';
-            lines.push(`${active}${p.modelName.padEnd(40)} ${p.projectPath}`);
+          if (diagnostics) {
+            lines.push(``);
+            lines.push(`## Available Projects`);
+            lines.push(``);
+            for (const p of allProjects) {
+              const active = p.projectPath === projectPath ? '▶ ' : '  ';
+              lines.push(`${active}${p.modelName.padEnd(40)} ${p.projectPath}`);
+            }
+            lines.push(``);
+            lines.push(`To switch project: call get_workspace_info with projectName = "<ModelName>"`);
+          } else {
+            // Names only: a switch is by projectName, so the paths are dead
+            // weight — and one solution can hold dozens of them. Duplicated
+            // model names (several projects, one model) collapse to one entry.
+            const seen = new Set<string>();
+            const names: string[] = [];
+            for (const p of allProjects) {
+              const key = p.modelName.toLowerCase();
+              if (seen.has(key)) continue;
+              seen.add(key);
+              names.push(p.projectPath === projectPath ? `▶${p.modelName}` : p.modelName);
+            }
+            const shown = names.slice(0, PROJECT_NAMES_SHOWN);
+            const rest = names.length - shown.length;
+            lines.push(
+              `Projects    : ${shown.join(', ')}${rest > 0 ? `, +${rest} more` : ''}  ` +
+              `(switch: get_workspace_info(projectName="<ModelName>"))`,
+            );
           }
-          lines.push(``);
-          lines.push(`To switch project: call get_workspace_info with projectName = "<ModelName>"`);
         }
 
         // Index freshness — compare workspace mtimes vs last_indexed_at.
@@ -519,7 +504,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
             ? nodePath.join(effectiveWritePath, modelName)
             : null;
           const staleness = checkIndexStaleness(lastIndexedAt, modelMetadataDir);
-          lines.push('', ...staleness.lines);
+          lines.push(...(diagnostics ? ['', ...staleness.lines] : staleness.compactLines));
         } catch {
           // Freshness reporting is best-effort — never break get_workspace_info
         }
@@ -566,9 +551,85 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         // Context Snapshot — recently edited objects + uncommitted X++ changes. Best-effort.
         try {
           const snapshot = await buildContextSnapshot(context);
-          lines.push('', ...renderContextSnapshotSection(snapshot));
+          lines.push(...(diagnostics
+            ? ['', ...renderContextSnapshotSection(snapshot)]
+            : renderContextSnapshotCompact(snapshot)));
         } catch {
           // Snapshot is additive — omit silently on failure.
+        }
+
+        // Everything below is a broken/unusual state. It sits last so the facts
+        // above stay one uninterrupted block in the normal case, and so the
+        // instruction the agent must act on is the last thing it reads.
+
+        // A switch moves which project is ACTIVE — nothing else. Reads never
+        // needed it (they span every model regardless) and writes stay anchored
+        // to the model the workspace resolved on its own, so switching cannot be
+        // used to reach an object the cross-model guard refused. Say both here,
+        // before anything is written, so the switch is not mistaken for access.
+        const toolSwitch = configManager.getToolProjectSwitch();
+        if (toolSwitch) {
+          lines.push(
+            ``,
+            `## ⚠️  Project switched — writes are NOT switched`,
+            ``,
+            `"${toolSwitch.forcedModel}" is now the ACTIVE project. This did not change what you ` +
+            `can read: get_object_info, search and find_references span every model, switched or ` +
+            `not, so a switch is never needed to look at another model's code. Writes stay ` +
+            `anchored to "${toolSwitch.anchorModel}" — the model the open workspace targets — and ` +
+            `a create/modify into "${toolSwitch.forcedModel}" will be refused.`,
+            `Tell the user the model they asked about is owned by "${toolSwitch.forcedModel}" and let ` +
+            `THEM decide: extend it from "${toolSwitch.anchorModel}", or allow the write by adding ` +
+            `D365FO_CROSS_MODEL_WRITE_MODELS=${toolSwitch.forcedModel} to the server's .env — that ` +
+            `applies to the next attempt, no restart. Do not decide this on your own.`,
+          );
+        }
+
+        if (isPlaceholder) {
+          const rawDetectedModel = await configManager.getRawAutoDetectedModelName();
+          const detectedHint = rawDetectedModel
+            ? `> ✅ Auto-detected from .rnrproj: **${rawDetectedModel}**\n` +
+              `> Update your .mcp.json: set \`modelName\` to \`"${rawDetectedModel}"\``
+            : `> ⚠️ No .rnrproj was found — make sure the MCP server is running in the right directory.`;
+          lines.push(
+            ``,
+            `⛔ CONFIGURATION PROBLEM — model name "${modelName}" is a placeholder, not a real D365FO model.`,
+            ``,
+            `**YOU MUST STOP** and tell the user:`,
+            `> The configured model name "${modelName}" is a placeholder.`,
+            detectedHint,
+            `>`,
+            `> Please check that:`,
+            `> 1. The MCP server is running in the correct workspace directory`,
+            `> 2. The .mcp.json / mcp.json file has the correct modelName`,
+            `> 3. The projectPath points to a valid .rnrproj file`,
+            `>`,
+            `> Do you want to fix the configuration first, or continue with built-in tools (limited functionality)?`,
+          );
+        } else if (isStandardMsModel) {
+          const customCandidates = allProjects.filter(p => isCustomModel(p.modelName));
+          const hint = customCandidates.length > 0
+            ? `Available custom models: ${customCandidates.map(p => p.modelName).join(', ')}\n` +
+              `Switch with: get_workspace_info(projectName="<model>")`
+            : `No custom models found under D365FO_SOLUTIONS_PATH. Check your project configuration.`;
+          lines.push(
+            ``,
+            `⛔ CONFIGURATION PROBLEM — model name "${modelName}" is a Microsoft standard/demo model, not a custom model.`,
+            ``,
+            `**YOU MUST STOP** and tell the user:`,
+            `> The auto-detected model "${modelName}" is a Microsoft standard model.`,
+            `> This usually happens when a new VS project was created and the default model`,
+            `> in the project wizard ("FleetManagement") was not changed to the correct custom model.`,
+            `>`,
+            `> How to fix:`,
+            `> 1. In Visual Studio, open the .rnrproj file and change <Model>FleetManagement</Model>`,
+            `>    to the correct model name (e.g. <Model>ContosoCore</Model>).`,
+            `> 2. OR explicitly switch to a known project:`,
+            `>    ${hint}`,
+            `> 3. OR add the correct modelName to .mcp.json.`,
+          );
+        } else if (diagnostics) {
+          lines.push(``, `✅ Configuration looks valid. Proceed with D365FO operations using model "${modelName}".`);
         }
 
         return { content: [{ type: 'text', text: lines.join('\n') }] };

--- a/src/tools/validateFormPattern.ts
+++ b/src/tools/validateFormPattern.ts
@@ -155,7 +155,7 @@ export interface AddControlPatternVerdict {
 }
 
 /**
- * Pre-flight for modify_d365fo_file(add-control): when the target parent
+ * Pre-flight for d365fo_file(action="modify", operation="add-control"): when the target parent
  * container declares a sub-pattern, check the new control's type against the
  * children that sub-pattern allows. Returns null when the parent cannot be
  * found, declares no pattern, or the pattern is unknown — those cases never

--- a/src/utils/indexStaleness.ts
+++ b/src/utils/indexStaleness.ts
@@ -79,7 +79,14 @@ export function findNewestMetadataMtime(rootDir: string): MtimeScanResult | null
 
 export interface StalenessReport {
   status: 'fresh' | 'stale' | 'unknown';
+  /** Full "## Index Freshness" section — diagnostics=true only. */
   lines: string[];
+  /**
+   * Compact default: one `Index : …` line, and the fix only when the index is
+   * actually stale. The scan detail (newest file, files scanned) is diagnostics
+   * material — it changes nothing about what the agent should do next.
+   */
+  compactLines: string[];
 }
 
 /**
@@ -97,7 +104,11 @@ export function checkIndexStaleness(
       'ℹ️  Index has no freshness timestamp yet (built before this feature or never built).',
       '   It will be recorded on the next build-database run or update_symbol_index call.',
     );
-    return { status: 'unknown', lines };
+    return {
+      status: 'unknown',
+      lines,
+      compactLines: ['Index       : no freshness timestamp yet (never indexed?)'],
+    };
   }
 
   const indexedAtMs = Date.parse(lastIndexedAt);
@@ -106,13 +117,21 @@ export function checkIndexStaleness(
 
   if (!modelMetadataDir) {
     lines.push('ℹ️  Model metadata folder not resolved — cannot compare workspace mtimes.');
-    return { status: 'unknown', lines };
+    return {
+      status: 'unknown',
+      lines,
+      compactLines: [`Index       : indexed ${ageHours} h ago (model folder not resolved — not compared)`],
+    };
   }
 
   const scan = findNewestMetadataMtime(modelMetadataDir);
   if (!scan) {
     lines.push(`ℹ️  No metadata files found under ${modelMetadataDir} — nothing to compare.`);
-    return { status: 'unknown', lines };
+    return {
+      status: 'unknown',
+      lines,
+      compactLines: [`Index       : indexed ${ageHours} h ago (no metadata files to compare)`],
+    };
   }
 
   lines.push(
@@ -129,9 +148,20 @@ export function checkIndexStaleness(
       `   Fix: call \`update_symbol_index(filePath="${scan.newestFile.replace(/\\/g, '\\\\')}")\` for the changed file(s),`,
       '   or run `npm run build-database` (EXTRACT_MODE=custom) for a full custom-model refresh.',
     );
-    return { status: 'stale', lines };
+    return {
+      status: 'stale',
+      lines,
+      compactLines: [
+        `Index       : ⚠️  STALE — indexed ${ageHours} h ago, workspace has newer files (lookups may be outdated)`,
+        `              Fix: update_symbol_index(filePath="${scan.newestFile.replace(/\\/g, '\\\\')}")`,
+      ],
+    };
   }
 
   lines.push('✅ Index is up to date with the workspace.');
-  return { status: 'fresh', lines };
+  return {
+    status: 'fresh',
+    lines,
+    compactLines: [`Index       : up to date (indexed ${ageHours} h ago)`],
+  };
 }

--- a/src/workspace/contextSnapshot.ts
+++ b/src/workspace/contextSnapshot.ts
@@ -213,6 +213,35 @@ export async function buildContextSnapshot(
  * as markdown lines for embedding in get_workspace_info. Identity/prefix/index
  * sections are already covered by that tool, so this only adds what is new.
  */
+/** How many recent objects the compact rendering names before summarising. */
+const COMPACT_RECENT_SHOWN = 3;
+
+/**
+ * The same "live" portion as renderContextSnapshotSection, folded into at most
+ * two lines for get_workspace_info's default output. Names only enough recent
+ * objects to orient the agent — the full list, with timestamps and every
+ * uncommitted path, stays behind diagnostics=true and review_workspace_changes.
+ */
+export function renderContextSnapshotCompact(snapshot: ContextSnapshot): string[] {
+  const lines: string[] = [];
+
+  if (snapshot.recentObjects.length > 0) {
+    const shown = snapshot.recentObjects
+      .slice(0, COMPACT_RECENT_SHOWN)
+      .map(o => `${o.name} [${o.type}]`);
+    const rest = snapshot.recentObjects.length - shown.length;
+    lines.push(`Recent edits: ${shown.join(', ')}${rest > 0 ? ` (+${rest} more)` : ''}`);
+  }
+
+  if (snapshot.uncommittedFiles.length > 0) {
+    lines.push(
+      `Uncommitted : ${snapshot.uncommittedFiles.length} X++ file(s) — review_workspace_changes`
+    );
+  }
+
+  return lines;
+}
+
 export function renderContextSnapshotSection(snapshot: ContextSnapshot): string[] {
   const lines: string[] = ['## Context Snapshot', ''];
 

--- a/tests/tools/prefixDiagnostics.test.ts
+++ b/tests/tools/prefixDiagnostics.test.ts
@@ -44,8 +44,13 @@ afterEach(() => {
   process.env = { ...originalEnv };
 });
 
+/** Compact default — what get_workspace_info emits on every call. */
 const text = (model: string | null, readModel: string | null) =>
   buildPrefixDiagnostics(model, readModel).lines.join('\n');
+
+/** Full section — diagnostics=true only. */
+const verbose = (model: string | null, readModel: string | null) =>
+  buildPrefixDiagnostics(model, readModel).verboseLines.join('\n');
 
 describe('buildPrefixDiagnostics', () => {
   it('reports the write anchor\'s prefix after a project switch', () => {
@@ -77,7 +82,19 @@ describe('buildPrefixDiagnostics', () => {
   it('names the origin when the prefix came from the model\'s objects', () => {
     const out = text('ContosoFinanceSK', 'ContosoFinanceSK');
 
-    expect(out).toContain('source: inferred from 4/4 objects of model "ContosoFinanceSK"');
+    expect(out).toContain('inferred from 4/4 objects of model "ContosoFinanceSK"');
+    expect(verbose('ContosoFinanceSK', 'ContosoFinanceSK'))
+      .toContain('source: inferred from 4/4 objects of model "ContosoFinanceSK"');
+  });
+
+  it('is a single line when nothing is off', () => {
+    // Every session pays for this section. A healthy prefix is one line — the
+    // "✅ …comes from the objects…" restatement belongs to diagnostics.
+    process.env.EXTENSION_PREFIX = 'ConSK';
+    const out = text('ContosoFinanceSK', 'ContosoFinanceSK');
+
+    expect(out.split('\n')).toHaveLength(1);
+    expect(out).toBe('Prefix      : ConSK  (inferred from 4/4 objects of model "ContosoFinanceSK")');
   });
 
   it('warns when the model\'s own naming overrules EXTENSION_PREFIX', () => {
@@ -85,26 +102,26 @@ describe('buildPrefixDiagnostics', () => {
     const out = text('ContosoFinanceSK', 'ContosoFinanceSK');
 
     expect(out).toContain('⚠️');
-    expect(out).toContain('overrides EXTENSION_PREFIX="Con"');
+    expect(out).toContain('overriding EXTENSION_PREFIX="Con"');
     expect(out).toContain('EXTENSION_PREFIX_SOURCE=config');
+    expect(verbose('ContosoFinanceSK', 'ContosoFinanceSK')).toContain('overrides EXTENSION_PREFIX="Con"');
   });
 
   it('does not warn when the model and the configuration agree', () => {
     // "ConSK_" from the objects and "ConSK" in the env are the same prefix —
     // the underscore belongs to the regular-object form, not to the token.
     process.env.EXTENSION_PREFIX = 'ConSK';
-    const out = text('ContosoFinanceSK', 'ContosoFinanceSK');
 
-    expect(out).not.toContain('⚠️');
-    expect(out).toContain('✅');
+    expect(text('ContosoFinanceSK', 'ContosoFinanceSK')).not.toContain('⚠️');
+    expect(verbose('ContosoFinanceSK', 'ContosoFinanceSK')).toContain('✅');
   });
 
   it('falls back to EXTENSION_PREFIX for a model with nothing to teach', () => {
     process.env.EXTENSION_PREFIX = 'Con';
-    const out = text('BrandNewModel', 'BrandNewModel');
 
-    expect(out).toContain('source: EXTENSION_PREFIX');
-    expect(out).toContain('✅ EXTENSION_PREFIX is set');
+    expect(text('BrandNewModel', 'BrandNewModel')).toBe('Prefix      : Con  (EXTENSION_PREFIX)');
+    expect(verbose('BrandNewModel', 'BrandNewModel')).toContain('source: EXTENSION_PREFIX');
+    expect(verbose('BrandNewModel', 'BrandNewModel')).toContain('✅ EXTENSION_PREFIX is set');
   });
 
   it('follows the write into the active model when configuration allows it', () => {
@@ -151,13 +168,13 @@ describe('buildPrefixDiagnostics', () => {
     const out = text('MixedModel', 'MixedModel');
 
     expect(out).not.toContain('0/');
-    expect(out).toContain('source: inferred from the extension elements of model "MixedModel"');
+    expect(out).toContain('inferred from the extension elements of model "MixedModel"');
   });
 
   it('tells the operator to configure a prefix when nothing resolves', () => {
     const out = text('BrandNewModel', 'BrandNewModel');
 
-    expect(out).toContain('source: model name (nothing configured)');
+    expect(out).toContain('model name (nothing configured)');
     expect(out).toContain('⚠️  EXTENSION_PREFIX is not set');
   });
 });

--- a/tests/utils/indexStaleness.test.ts
+++ b/tests/utils/indexStaleness.test.ts
@@ -71,6 +71,24 @@ describe('checkIndexStaleness', () => {
   });
 });
 
+describe('checkIndexStaleness compact lines', () => {
+  it('is one line when the index is fresh', () => {
+    // get_workspace_info's default output pays for this on every call, and a
+    // fresh index needs no scan detail — there is nothing to act on.
+    const report = checkIndexStaleness(new Date(Date.now() + 3_600_000).toISOString(), path.join(tmpDir, 'MyModel'));
+    expect(report.compactLines).toHaveLength(1);
+    expect(report.compactLines[0]).toContain('up to date');
+  });
+
+  it('keeps the fix reachable when the index is stale', () => {
+    const report = checkIndexStaleness(new Date(Date.now() - 24 * 3_600_000).toISOString(), path.join(tmpDir, 'MyModel'));
+    const text = report.compactLines.join('\n');
+    expect(report.compactLines).toHaveLength(2);
+    expect(text).toContain('STALE');
+    expect(text).toContain('update_symbol_index');
+  });
+});
+
 describe('symbolIndex last_indexed_at bookkeeping', () => {
   it('touchLastIndexed/getLastIndexedAt round-trips an ISO timestamp', () => {
     const index = new XppSymbolIndex(':memory:', ':memory:');

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { readFileSync, globSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { LOCAL_TOOLS } from '../../src/server/serverMode';
@@ -42,6 +42,39 @@ describe('tool inventory contract', () => {
 
     expect(LOCAL_TOOLS.size).toBe(10);
     expect(mcpServerToolNames.filter(name => !LOCAL_TOOLS.has(name))).toHaveLength(16);
+  });
+
+  it('never tells the agent to call a tool that was retired by a consolidation', () => {
+    // Guidance the agent copies verbatim — `nextSteps` in the strategy advisor,
+    // the "call X next" tails on generators, the system prompt — outlived several
+    // tool renames and kept naming `find_coc_extensions`, `generate_code`,
+    // `get_xpp_knowledge`. Each such line costs a guaranteed Unknown-tool call
+    // plus a retry, which is far more expensive than the line itself.
+    //
+    // Call form only (`name(`): the dispatchers legitimately pass legacy names as
+    // sub-request STRINGS (`subRequest('find_coc_extensions', …)`), where the name
+    // is followed by a quote, never by an open paren.
+    const retired = [
+      'create_d365fo_file', 'modify_d365fo_file', 'generate_code', 'generate_smart',
+      'generate_d365fo_xml', 'find_coc_extensions', 'find_event_handlers',
+      'analyze_extension_points', 'find_extension_points', 'prepare_change',
+      'get_xpp_knowledge', 'validate_xpp', 'search_extensions', 'batch_search',
+      'get_table_info', 'get_class_info', 'get_form_info',
+    ];
+    const pattern = new RegExp(String.raw`\b(${retired.join('|')})\(`, 'g');
+
+    const sources = globSync('src/**/*.ts', { cwd: repoRoot });
+    const offenders: string[] = [];
+    for (const rel of sources) {
+      const text = readRepoFile(rel);
+      text.split('\n').forEach((line, i) => {
+        for (const m of line.matchAll(pattern)) {
+          offenders.push(`${rel}:${i + 1} → ${m[1]}(`);
+        }
+      });
+    }
+
+    expect(offenders, `retired tool names in agent-facing text:\n${offenders.join('\n')}`).toEqual([]);
   });
 
   it('has a tool annotation (title + hints) for every published tool', () => {

--- a/tests/workspace/contextSnapshot.test.ts
+++ b/tests/workspace/contextSnapshot.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   renderContextSnapshotSection,
+  renderContextSnapshotCompact,
   type ContextSnapshot,
 } from '../../src/workspace/contextSnapshot.js';
 import { isClassUri, CLASS_URI_PREFIX } from '../../src/resources/classResource.js';
@@ -70,6 +71,41 @@ describe('renderContextSnapshotSection', () => {
     expect(out).toContain('Uncommitted X++ changes (1)');
     expect(out).toContain('AxTable/MyTable.xml');
     expect(out).toContain('review_workspace_changes');
+  });
+});
+
+describe('renderContextSnapshotCompact', () => {
+  const recent = (name: string) => ({
+    name,
+    type: 'table' as const,
+    path: `K:\\ws\\${name}.xml`,
+    modifiedAt: '2026-06-23T10:30:00.000Z',
+  });
+
+  it('emits nothing when there is nothing in flight', () => {
+    // get_workspace_info runs at every session start; "none detected" twice is
+    // two lines that tell the agent nothing it can act on.
+    expect(renderContextSnapshotCompact(makeSnapshot())).toEqual([]);
+  });
+
+  it('names the first few recent objects and counts the rest', () => {
+    const out = renderContextSnapshotCompact(
+      makeSnapshot({
+        recentObjects: ['A', 'B', 'C', 'D', 'E'].map(recent),
+        uncommittedFiles: ['AxTable/A.xml', 'AxTable/B.xml'],
+      })
+    );
+
+    expect(out).toEqual([
+      'Recent edits: A [table], B [table], C [table] (+2 more)',
+      'Uncommitted : 2 X++ file(s) — review_workspace_changes',
+    ]);
+  });
+
+  it('omits the "+N more" tail when everything fits', () => {
+    const out = renderContextSnapshotCompact(makeSnapshot({ recentObjects: [recent('A')] }));
+
+    expect(out).toEqual(['Recent edits: A [table]']);
   });
 });
 


### PR DESCRIPTION
## v1.9.0 — tool output sized by what the agent can act on

Two themes, both about what the server writes back into the agent's context.

### 1. `get_workspace_info` was ~5 KB per session start

It hit the 5000-char response cap, which truncated its own trailing sections — the index-freshness and context-snapshot blocks were never actually reaching the caller. The default output is now ~1 KB:

```
## D365FO Workspace

Model       : IsvFinance  (auto-detected from .rnrproj)
Prefix      : IsvFin  (inferred from 28/28 objects of model "IsvFinance")
Write path  : K:\AosService\PackagesLocalDirectory
Project     : K:\repos\...\d365fo-mcp-server-live-demo-on.rnrproj
Env         : traditional
Extensions  : ...  (pass the BASE name to d365fo_file(create) — the tool applies the token)
Projects    : ▶...  (switch: get_workspace_info(projectName="<ModelName>"))
Index       : up to date (indexed 3 h ago)
Recent edits: CustTable [table], SalesLine_IsvExtension [class] (+2 more)
Uncommitted : 2 X++ file(s) — review_workspace_changes
```

Moved behind `diagnostics=true`: config sources (`source: …` on every value), `Framework dir`, the `## Prefix Configuration` / `## Extension Naming` / `## Suffix Configuration` sections, the per-project path table, the index scan detail, `## Stdio Session Info`, the full context snapshot, and the `✅ Configuration looks valid` style confirmations.

Unchanged: every warning (`⚠️` prefix conflict, stale index with its fix, `⛔ CONFIGURATION PROBLEM`, project-switch note). They now sit last so the facts stay one uninterrupted block.

The response cap for this tool goes 5000 → 20000, since `diagnostics=true` exists to produce the full dump.

### 2. Fixed footers on the two most-called tools

- `search` appended a static "workspace-aware search includes both your local project files and D365FO external metadata" to every call — the `🔹 WORKSPACE` / `📦 EXTERNAL` marker on each row already says it.
- `d365fo_file(action="create")` appended three Visual Studio UI steps per created object (reload project, build, refresh AOT). Only "build" is something the agent can do; the anti-loop `⛔ TASK COMPLETE` guard stays.

### 3. Guidance naming tools that no longer exist

Found while trimming the `generate_object(mode="pattern")` tail. The mega-tool consolidation renamed the tools but not the strings the agent copies verbatim:

| Location | Named | Registered tool |
|---|---|---|
| `extension_info(mode="strategy")` nextSteps ×11 | `analyze_extension_points`, `find_event_handlers`, `find_coc_extensions`, `generate_code`, `generate_smart` | `extension_info(mode="points"/"events"/"coc")`, `generate_object(mode="pattern"/"scaffold")` |
| `generate_object(mode="pattern")` tail | `find_coc_extensions`, positional `analyze_code` args | `extension_info(mode="coc", target=…)` |
| system prompt | `get_xpp_knowledge(id)` | `get_knowledge(kind="knowledge", topic=…)` |
| generated X++ template comments | `create_d365fo_file`, `generate_d365fo_xml` | `d365fo_file(action="create")`, `generate_object(mode="scaffold")` |

`extension_info(mode="strategy")` is what `prepare` and the instructions steer agents toward, so those `nextSteps` were a reliable source of Unknown-tool calls. Positional argument forms (`get_method(include="signature", "X", "m")`, `search("MyTable", "data-entity")`, `security_info(mode="coverage", "X")`) are corrected to the named form each schema requires.

The `generate_object(mode="pattern")` follow-up menu is reduced to the one line that prevents broken code — read the signature before writing a CoC wrapper — instead of a four-item menu of optional calls.

### Regression test

`tests/utils/toolInventory.test.ts` scans `src/` for 17 retired tool names in **call form** (`name(`). Dispatchers that legitimately forward legacy names as sub-request strings are not matched — there the name is followed by a quote, not a paren. The test finds 23 occurrences on the parent commit.

### Verification

- `npm run build` clean, `tsc --noEmit` clean.
- 2708 tests pass. Two pre-existing failures unrelated to this branch and present on `main`: `tests/bridge/formAuthoringDefaults.test.ts` (needs `dotnet run`, host has no .NET SDK) and `tests/utils/loadEnvDepth.test.ts` (reads the developer's real `.env`).
- Token budget ratchet (`toolSchemaBudget`) still passes — the `diagnostics` description was kept within the existing budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
