### PR TITLE
perf(labels): bound and compact labels(action="search") results

### DIFF
--- a/src/server/toolSchemas/labels.ts
+++ b/src/server/toolSchemas/labels.ts
@@ -34,9 +34,14 @@ export const labelsTool = {
           type: 'string',
           description: '[search] Language/locale (default: en-US). Examples: cs, de, sk.',
         },
-        limit: {
+        maxResults: {
           type: 'number',
-          description: '[search] Maximum number of results (default 30).',
+          description: '[search] Max labels listed (default 10, alias `limit`); a truncated set reports how many more matched.',
+        },
+        limit: { type: 'number', description: '[search] Alias of maxResults.' },
+        verbose: {
+          type: 'boolean',
+          description: '[search] Default one line per label; true = full multi-line block.',
         },
         // action=search
         query: {

--- a/src/tools/searchLabels.ts
+++ b/src/tools/searchLabels.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { getConfigManager } from '../utils/configManager.js';
 import {
+  crossModelLabelWarning,
   formatLabelReference,
   isLabelLikelyResolvable,
   labelProvenanceWarning,
@@ -38,8 +39,27 @@ const SearchLabelsArgsSchema = z.object({
     .string()
     .optional()
     .describe('Restrict results to a specific label file ID (e.g. ContosoExt, SYS)'),
-  limit: z.number().optional().default(30).describe('Maximum number of results (default 30)'),
+  maxResults: z
+    .number()
+    .optional()
+    .describe('Maximum number of labels to list (default 10). Truncated sets report how many more matched.'),
+  limit: z.number().optional().describe('Legacy alias of maxResults.'),
+  verbose: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('One line per label by default; true restores the multi-line text/comment/model block.'),
 });
+
+/** Labels listed per search unless the caller raises it — a broad phrase query matches dozens (#832). */
+const DEFAULT_MAX_RESULTS = 10;
+
+/**
+ * How many rows to pull from the index beyond the display cap so the footer can
+ * state an exact "and N more". Bounded on purpose — an exact count is not worth
+ * scanning the whole label index, so past this the footer says "N+ more".
+ */
+const OVERFETCH_CAP = 200;
 
 /** Best-effort current model: explicit arg → configured model → env. Never throws. */
 function resolveCurrentModel(explicit?: string): string | undefined {
@@ -55,9 +75,14 @@ export async function searchLabelsTool(request: CallToolRequest, context: XppSer
   try {
     const args = SearchLabelsArgsSchema.parse(request.params.arguments);
     const { symbolIndex } = context;
-    const { query, language, model, labelFileId, limit } = args;
+    const { query, language, model, labelFileId, verbose } = args;
 
-    let results = symbolIndex.searchLabels(query, { language, model, labelFileId, limit });
+    const requested = args.maxResults ?? args.limit;
+    const maxResults = requested !== undefined && requested > 0 ? Math.floor(requested) : DEFAULT_MAX_RESULTS;
+    // Over-fetch so the truncation footer can quantify what it hid.
+    const probeLimit = Math.max(maxResults + 1, OVERFETCH_CAP);
+
+    const results = symbolIndex.searchLabels(query, { language, model, labelFileId, limit: probeLimit });
 
     if (results.length === 0) {
       return {
@@ -86,26 +111,62 @@ export async function searchLabelsTool(request: CallToolRequest, context: XppSer
       comment: r.comment ?? null,
     });
 
+    const currentModel = resolveCurrentModel(args.model);
+
+    // The index was queried past the display cap; only the first maxResults are rendered.
+    const hidden = Math.max(0, results.length - maxResults);
+    const atProbeCap = results.length >= probeLimit;
+    const total = `${results.length}${atProbeCap ? '+' : ''}`;
+    const scope = `[language: ${language}${model ? `, model: ${model}` : ''}]`;
+
     const lines: string[] = [
-      `Found ${results.length} label(s) matching "${query}" [language: ${language}${model ? `, model: ${model}` : ''}]:`,
+      hidden > 0
+        ? `Found ${total} label(s) matching "${query}" ${scope} — showing first ${maxResults}:`
+        : `Found ${results.length} label(s) matching "${query}" ${scope}:`,
       '',
     ];
 
-    const currentModel = resolveCurrentModel(args.model);
+    const normalised = results.slice(0, maxResults).map(normalise);
 
-    const normalised = results.map(normalise);
+    // Owners of the flagged rows, in result order — named once below instead of
+    // repeating the same sentence on every line (#832).
+    const flaggedModels: string[] = [];
+    let flaggedCount = 0;
 
     for (const r of normalised) {
       // X++ label reference syntax — never double-prefix an id that already
       // carries its label file id (#33/#41: `@SYS:@SYS67433` is rejected by xppbp).
       const ref = formatLabelReference(r.labelFileId, r.labelId);
       const resolvable = isLabelLikelyResolvable(r.labelFileId, r.model, currentModel);
-      lines.push(`  ${ref}${resolvable ? '' : `   ${labelProvenanceWarning(r.model)}`}`);
-      lines.push(`  Text    : ${r.text}`);
-      if (r.comment) lines.push(`  Comment : ${r.comment}`);
-      lines.push(`  Model   : ${r.model}  |  LabelFile: ${r.labelFileId}`);
+      if (!resolvable) {
+        flaggedCount++;
+        if (!flaggedModels.includes(r.model)) flaggedModels.push(r.model);
+      }
+
+      if (verbose) {
+        lines.push(`  ${ref}${resolvable ? '' : `   ${labelProvenanceWarning(r.model)}`}`);
+        lines.push(`  Text    : ${r.text}`);
+        if (r.comment) lines.push(`  Comment : ${r.comment}`);
+        lines.push(`  Model   : ${r.model}  |  LabelFile: ${r.labelFileId}`);
+        lines.push('');
+      } else {
+        // One line per label: @File:Id — "Text" [owner], with ⚠️ marking the rows
+        // the hoisted ownership warning below is about.
+        const text = (r.text ?? '').replace(/\s+/g, ' ').trim();
+        lines.push(`  ${ref} — "${text}" [${r.model}]${resolvable ? '' : ' ⚠️'}`);
+      }
+    }
+
+    if (hidden > 0) {
+      if (!verbose) lines.push('');
+      lines.push(`… and ${hidden}${atProbeCap ? '+' : ''} more — narrow the query or raise maxResults`);
+      lines.push('');
+    } else if (!verbose) {
       lines.push('');
     }
+
+    // Once per result set, not once per label (#832).
+    if (flaggedCount > 0 && !verbose) lines.push(crossModelLabelWarning(flaggedModels, flaggedCount));
 
     // Only ever *recommend* a label the model can actually resolve — suggesting an
     // unreferenced one is what produced BPErrorUnknownLabel in the sweep (#33/#41).

--- a/src/utils/labelReference.ts
+++ b/src/utils/labelReference.ts
@@ -77,3 +77,20 @@ export function labelProvenanceWarning(labelModel: string | undefined): string {
   return `⚠️ owned by model "${labelModel ?? 'unknown'}" — resolves only if your model references ` +
     `that package; otherwise xppbp reports BPErrorUnknownLabel`;
 }
+
+/** How many owning models the hoisted warning names before it stops listing them. */
+const MAX_NAMED_MODELS = 5;
+
+/**
+ * One warning for a whole result set instead of one per row (#832): repeating
+ * {@link labelProvenanceWarning} on every hit cost ~2,5 kB per search and said
+ * the same sentence up to 30 times. `models` are the distinct owners of the
+ * flagged rows, in result order.
+ */
+export function crossModelLabelWarning(models: string[], flaggedCount: number): string {
+  const named = models.slice(0, MAX_NAMED_MODELS).map(m => m || 'unknown');
+  const rest = models.length - named.length;
+  const list = named.join(', ') + (rest > 0 ? `, +${rest} more` : '');
+  return `⚠️ ${flaggedCount} result(s) marked ⚠️ are owned by other models (${list}) — each resolves ` +
+    `only if your model references that package; otherwise xppbp reports BPErrorUnknownLabel.`;
+}

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -188,6 +188,123 @@ describe('search_labels', () => {
   });
 });
 
+// ─── search_labels result budget (#832) ──────────────────────────────────────
+
+describe('search_labels result budget (#832)', () => {
+  let ctx: XppServerContext;
+
+  /** N hits owned by `model`, ids Label0…LabelN-1 — mimics a broad phrase query. */
+  const manyLabels = (n: number, model = 'Foundation') =>
+    Array.from({ length: n }, (_, i) => makeLabelResult({
+      labelId: `Label${i}`, labelFileId: model, model, text: `value cannot be less than ${i}`,
+      comment: 'Some developer comment that used to be printed for every single hit',
+    }));
+
+  beforeEach(() => { ctx = buildContext(); });
+
+  it('caps the listing at 10 labels by default and says how many more matched', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue(manyLabels(30));
+
+    const text = (await searchLabelsTool(req('search_labels', { query: 'lower value' }), ctx)).content[0].text as string;
+
+    expect(text).toContain('showing first 10');
+    expect(text).toContain('… and 20 more — narrow the query or raise maxResults');
+    expect(text).toContain('@Foundation:Label9');
+    expect(text).not.toContain('@Foundation:Label10');
+  });
+
+  it('honours maxResults and its legacy `limit` alias', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue(manyLabels(30));
+
+    const wide = (await searchLabelsTool(req('search_labels', { query: 'x', maxResults: 25 }), ctx)).content[0].text as string;
+    expect(wide).toContain('@Foundation:Label24');
+    expect(wide).toContain('… and 5 more');
+
+    const legacy = (await searchLabelsTool(req('search_labels', { query: 'x', limit: 3 }), ctx)).content[0].text as string;
+    expect(legacy).toContain('@Foundation:Label2');
+    expect(legacy).not.toContain('@Foundation:Label3');
+    expect(legacy).toContain('… and 27 more');
+  });
+
+  it('over-fetches past the display cap so the footer count is exact', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue(manyLabels(30));
+    await searchLabelsTool(req('search_labels', { query: 'lower value' }), ctx);
+
+    const opts = (ctx.symbolIndex.searchLabels as any).mock.calls[0][1];
+    expect(opts.limit).toBeGreaterThan(30);
+  });
+
+  it('emits no footer when everything matched fits', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue(manyLabels(4));
+
+    const text = (await searchLabelsTool(req('search_labels', { query: 'x' }), ctx)).content[0].text as string;
+
+    expect(text).toContain('Found 4 label(s)');
+    expect(text).not.toContain('more — narrow the query');
+  });
+
+  it('states the cross-model ownership warning once per result set, not once per label', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      ...manyLabels(6, 'Foundation'),
+      ...manyLabels(4, 'RevenueRecognition'),
+    ]);
+
+    const text = (await searchLabelsTool(req('search_labels', { query: 'x' }), ctx)).content[0].text as string;
+
+    // …once for the whole set, naming the models that need a package reference —
+    // and never again as the per-label sentence that used to repeat on every hit.
+    expect(text.match(/owned by other models/g) ?? []).toHaveLength(1);
+    expect(text).not.toContain('owned by model "');
+    expect(text).toContain('10 result(s) marked');
+    expect(text).toContain('Foundation, RevenueRecognition');
+  });
+
+  it('renders one line per label by default', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'CustName', labelFileId: 'MyModel', model: 'MyModel', text: 'Customer name' }),
+    ]);
+
+    const text = (await searchLabelsTool(req('search_labels', { query: 'customer' }), ctx)).content[0].text as string;
+
+    expect(text).toContain('@MyModel:CustName — "Customer name" [MyModel]');
+    expect(text).not.toContain('Text    :');
+    expect(text).not.toContain('Comment :');
+  });
+
+  it('keeps a multi-line hit on a single line', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'Multi', text: 'first line\nsecond   line' }),
+    ]);
+
+    const text = (await searchLabelsTool(req('search_labels', { query: 'x' }), ctx)).content[0].text as string;
+    const hit = text.split('\n').filter(l => l.trim().startsWith('@MyModel:Multi —'));
+
+    expect(hit).toHaveLength(1);
+    expect(hit[0]).toContain('"first line second line"');
+  });
+
+  it('verbose=true restores the multi-line block for callers that want full detail', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'CustName', text: 'Customer name', comment: 'Header caption' }),
+    ]);
+
+    const text = (await searchLabelsTool(req('search_labels', { query: 'customer', verbose: true }), ctx)).content[0].text as string;
+
+    expect(text).toContain('Text    : Customer name');
+    expect(text).toContain('Comment : Header caption');
+    expect(text).toContain('Model   : MyModel  |  LabelFile: MyModel');
+  });
+
+  it('is dramatically cheaper than the verbose form for a broad query', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue(manyLabels(30));
+
+    const compact = (await searchLabelsTool(req('search_labels', { query: 'x' }), ctx)).content[0].text as string;
+    const verbose = (await searchLabelsTool(req('search_labels', { query: 'x', verbose: true, maxResults: 30 }), ctx)).content[0].text as string;
+
+    expect(compact.length).toBeLessThan(verbose.length / 3);
+  });
+});
+
 // ─── get_label_info ──────────────────────────────────────────────────────────
 
 describe('get_label_info', () => {

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -41,7 +41,12 @@ const CHARS_PER_TOKEN = 4;
 // on the wire — only the prose naming them does, and that was paid for by
 // tightening the `params` description rather than by moving the ceiling.
 // Headroom is small on purpose so creep is caught early.
-const TOTAL_BUDGET = 63_300;
+//
+// Raised once more for labels(action="search") maxResults/verbose (#832): a
+// broad phrase query returned 30 four-line blocks (~2,5 kB per call), so ~230
+// wire chars buy a bounded, one-line-per-label default — the schema pays once
+// per session, the result paid on every call and on every later re-read.
+const TOTAL_BUDGET = 63_600;
 const LARGEST_TOOL_BUDGET = 9_900;
 
 async function getTools(): Promise<Array<{ name: string }>> {


### PR DESCRIPTION
## Why

From the session audit (#824): `labels(action="search")` returned every match as a
four-line block with no cap. Six searches cost 15 359 B in one session — the third
largest context contributor of any tool — and the `"lower value"` query alone came
back with 30 entries, each repeating the same cross-model ownership sentence.
The cost is structural: an early result is re-read by every later request.

## What changed

- **`src/tools/searchLabels.ts`** — `maxResults` (default **10**) caps the listing;
  the legacy `limit` is accepted as an alias so existing callers keep working. The
  index is over-fetched past the display cap (`OVERFETCH_CAP = 200`) so the footer
  can state an exact count: `… and 20 more — narrow the query or raise maxResults`
  (beyond the over-fetch cap it degrades honestly to `200+ more`).
- **Default rendering is one line per label**: `  @File:Id — "Text" [owner]`, with a
  trailing `⚠️` marking rows the hoisted ownership warning refers to. Whitespace in
  the label text is collapsed so a multi-line label still occupies one line.
  `verbose: true` restores today's multi-line `Text/Comment/Model` block verbatim.
- **`src/utils/labelReference.ts`** — new `crossModelLabelWarning(models, count)`;
  the per-label `labelProvenanceWarning` is now only used by `verbose` mode.
- **`src/server/toolSchemas/labels.ts`** — `maxResults` + `verbose` documented,
  `limit` demoted to a one-line alias.

Sample output for a 30-hit query dropped from ~4 kB to ~1,1 kB:

```
Found 30 label(s) matching "lower value" [language: en-US] — showing first 10:

  @SYS:ValueCannotBeLessThan0 — "value cannot be less than 0." [ApplicationPlatform]
  @Foundation:ValueCannotBeLessThan1 — "value cannot be less than 1." [Foundation] ⚠️
  …
… and 20 more — narrow the query or raise maxResults

⚠️ 6 result(s) marked ⚠️ are owned by other models (Foundation) — each resolves only if
your model references that package; otherwise xppbp reports BPErrorUnknownLabel.
💡 Use the label reference syntax in X++:  literalStr("@SYS:ValueCannotBeLessThan0")
```

## Acceptance

| Criterion | How it is met |
| --- | --- |
| A broad query returns a bounded, clearly-truncated result set | `maxResults` defaults to 10; truncation is announced twice — `— showing first 10` in the header and the `… and N more — narrow the query or raise maxResults` footer. Tests: *caps the listing at 10 labels by default…*, *honours maxResults and its legacy `limit` alias*, *over-fetches past the display cap so the footer count is exact*, *emits no footer when everything matched fits*. |
| The cross-model ownership warning appears once per result set | Hoisted out of the per-label loop into one line naming the distinct owning models (first 5, then `+N more`) and how many rows are flagged. Test: *states the cross-model ownership warning once per result set, not once per label* asserts exactly one occurrence and that the old per-label sentence is gone. |
| Existing callers that want the full detail can still get it | `verbose: true` reproduces the previous block; `limit` still works as before (only its default changed from 30 to 10). Tests: *verbose=true restores the multi-line block…*, *renders one line per label by default*. |

Note on `verbose`: it is deliberately today's format **verbatim**, including the
per-label warning — it is the "give me everything" escape hatch, and the token cost
the issue is about is on the default path. Say the word if you would rather have the
hoisted warning there too.

## Tests

- 9 new cases in `tests/tools/labels.test.ts` under `search_labels result budget (#832)`,
  including a cost assertion that the compact form is <1/3 the size of the verbose one.
- `tests/utils/toolSchemaBudget.test.ts`: `TOTAL_BUDGET` raised 63 300 → 63 600 chars
  (actual 63 541) with a comment explaining the trade — ~230 wire chars paid once per
  session against ~1,4 kB saved per search call and on every later re-read. The
  per-tool cap is untouched (`labels` 5 954 → 6 215, well under 9 900).
- Full suite: **205 files, 2 715 passed / 9 skipped**, `npx tsc --noEmit` clean.

## Out of scope / follow-up

The issue notes the same treatment likely applies to `search` (7 calls, 4 304 B) and
`get_knowledge` (2 calls, 10 022 B, both truncated by the debug log's cap). Those are
untouched here on purpose — worth their own issues so they can be reviewed separately.

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)
