### PR TITLE
perf(tools): stop advertising update_symbol_index as a create/modify follow-up

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -118,7 +118,7 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 | `trigger_db_sync` | Database sync for the current model | *"Sync the database"* |
 | `run_bp_check` | Microsoft Best Practices (xppbp.exe) analysis | *"Run a BP check on my model"* |
 | `run_systest_class` | Execute SysTest unit tests via SysTestConsole.exe (requires an interactive console session) | *"Run the MyServiceTest class"* |
-| `update_symbol_index` | Re-index a single changed file without restart | *"Refresh the index for the table I just created"* |
+| `update_symbol_index` | Re-index file(s) changed **outside** this server, without a restart — `d365fo_file` create/modify already refresh the index themselves, so no follow-up call is needed after a write | *"I edited that table in Visual Studio — re-index it"* |
 
 ## ✅ Quality & Grounding (3)
 

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -136,6 +136,6 @@ Nothing uncovered.
 ## Orphans
 
 - Knowledge entries no leaf claims (**unproven knowledge**): none
-- Eval cases no leaf claims (**unmapped proof**): L2-oracle-discriminator-random-wrapper-name, L3-enum-field-form-downgrade-guard, L4-headerlines-document-slice
+- Eval cases no leaf claims (**unmapped proof**): L0-create-readback-no-reindex, L2-oracle-discriminator-random-wrapper-name, L3-enum-field-form-downgrade-guard, L4-headerlines-document-slice
 
-_Generated 2026-08-07._
+_Generated 2026-08-08._

--- a/eval/cases/L0-create-readback-no-reindex.json
+++ b/eval/cases/L0-create-readback-no-reindex.json
@@ -1,0 +1,23 @@
+{
+  "id": "L0-create-readback-no-reindex",
+  "title": "Create then read back without a follow-up update_symbol_index",
+  "tier": 0,
+  "instruction": "Create a new extensible enum named DemoIndexProbeStatus in the sandbox model with two values: Open (0) and Closed (1), label text Open = 'Open', Closed = 'Closed'. Then read it back with get_object_info(objectType=\"enum\") and report its values. Use exactly ONE tool call for the read-back: d365fo_file(action=\"create\") refreshes the index on its way out, so do NOT call update_symbol_index in between — the enum must resolve without it. Known efficiency defect as of 2026-08-07 (#830, session audit #824): the tool description told the agent to call update_symbol_index after every create, costing a dedicated round trip per created object for a DiskProvider rebuild that could not see anything new. Fail conditions: the read-back needs an update_symbol_index call to resolve the enum, or the run spends a turn on update_symbol_index after the create.",
+  "target_artifact_types": [
+    "AxEnum"
+  ],
+  "golden_path": "eval/goldens/L0-create-readback-no-reindex/",
+  "golden_pending": true,
+  "ignore": [
+    "AxEnum/@Id",
+    "AxEnum/EnumValues/AxEnumValue/@Id",
+    "**/ModelSaveInfo"
+  ],
+  "tags": [
+    "enum",
+    "index-freshness",
+    "tool-efficiency",
+    "mined"
+  ],
+  "split": "holdout"
+}

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -1246,6 +1246,7 @@
   "orphans": {
     "knowledge": [],
     "cases": [
+      "L0-create-readback-no-reindex",
       "L2-oracle-discriminator-random-wrapper-name",
       "L3-enum-field-form-downgrade-guard",
       "L4-headerlines-document-slice"

--- a/src/index.ts
+++ b/src/index.ts
@@ -789,7 +789,7 @@ async function main() {
           { name: 'verify_d365fo_project',        desc: 'Verify objects exist on disk and are referenced in the .rnrproj project file' },
         ]},
         { icon: '🏗️ ', category: 'SDLC & Build Tools', tools: [
-          { name: 'update_symbol_index',          desc: 'Index a newly generated XML file immediately (no restart needed)' },
+          { name: 'update_symbol_index',          desc: 'Re-index a file changed outside this server (create/modify refresh it themselves)' },
           { name: 'build_d365fo_project',         desc: 'Run MSBuild compilation locally to capture errors' },
           { name: 'trigger_db_sync',              desc: 'Run a database sync for the current model' },
           { name: 'run_bp_check',                 desc: 'Run Microsoft Best Practices (xppbp.exe) analysis' },

--- a/src/server/toolSchemas/updateSymbolIndex.ts
+++ b/src/server/toolSchemas/updateSymbolIndex.ts
@@ -7,13 +7,14 @@
 export const updateSymbolIndexTool = {
     name: 'update_symbol_index',
     description:
-      'Index a newly generated or modified D365FO XML file immediately so references to it work without restarting the server. ' +
-      'Call this after d365fo_file(action="create") — pass the created file\'s `filePath` — to make the new object instantly searchable AND, for new AxEnum/AxEdt files, resolvable by scaffolding (so enum fields become AxTableFieldEnum and EDT fields get the correct base type). ' +
-      'Call WITHOUT `filePath` for a lightweight refresh: it refreshes the C# bridge provider and drops workspace caches so objects created via the bridge this session become resolvable (does NOT fully index them into the symbol DB).',
+      'Index D365FO XML file(s) changed OUTSIDE this server (hand edit, Visual Studio, git checkout). ' +
+      'Do NOT call after d365fo_file create/modify — those refresh the index on their way out, so a follow-up call is a wasted round trip. ' +
+      'One genuine same-session case: a brand-new AxEdt/AxEnum you are about to name in a generate_object `fieldsHint`. ' +
+      'Omit `filePath` for a bridge/cache refresh only (no symbol-DB indexing).',
     inputSchema: {
       type: 'object',
       properties: {
-        filePath: { type: ['string', 'array'], items: { type: 'string' }, description: 'Absolute path to the modified or created XML file (e.g. K:\\\\AosService\\\\PackagesLocalDirectory\\\\MyModel\\\\MyModel\\\\AxClass\\\\MyClass.xml), or an ARRAY — batch them, each call costs a bridge refresh.' },
+        filePath: { type: ['string', 'array'], items: { type: 'string' }, description: 'Absolute path to the changed XML file, or an ARRAY — batch them, each call costs a bridge refresh.' },
       },
     },
   };

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -167,6 +167,16 @@ function newestMtimeMs(filePaths: string[]): number {
 }
 
 /**
+ * Said out loud when the call was redundant (#830). The skip itself is old news;
+ * saying nothing about it is what kept the agent making the call — four times in
+ * one audited session, each as the only tool call in its turn.
+ */
+const REDUNDANT_CALL_NOTE =
+  'ℹ️ This call was not needed. The bridge provider was already refreshed after these file(s) ' +
+  'were written — `d365fo_file` create/modify refreshes it on its way out, so no rebuild was run. ' +
+  'Only call `update_symbol_index` for files changed OUTSIDE this server.';
+
+/**
  * Refresh the C# provider once for the whole batch — and only when it could
  * actually learn something.
  *
@@ -179,18 +189,21 @@ function newestMtimeMs(filePaths: string[]): number {
 async function refreshBridgeForBatch(
   context: XppServerContext,
   filePaths: string[],
-): Promise<string> {
+): Promise<{ note: string; redundant: boolean }> {
   const newest = newestMtimeMs(filePaths);
   if (newest > 0 && getLastRefreshStartedAt() > newest) {
-    return 'Bridge provider already refreshed after these files were written — skipped.';
+    return { note: REDUNDANT_CALL_NOTE, redundant: true };
   }
   try {
     const result = await bridgeRefreshProvider(context.bridge);
-    return result
-      ? `Bridge provider refreshed in ${result.elapsedMs}ms.`
-      : 'Bridge provider not available (skipped).';
+    return {
+      note: result
+        ? `Bridge provider refreshed in ${result.elapsedMs}ms.`
+        : 'Bridge provider not available (skipped).',
+      redundant: false,
+    };
   } catch (e: any) {
-    return `Bridge refresh skipped: ${e?.message ?? e}`;
+    return { note: `Bridge refresh skipped: ${e?.message ?? e}`, redundant: false };
   }
 }
 
@@ -209,18 +222,25 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
 
   // One refresh for the batch, before indexing, so a per-file failure cannot
   // leave the provider stale.
-  const bridgeNote = await refreshBridgeForBatch(context, filePaths);
+  const bridge = await refreshBridgeForBatch(context, filePaths);
 
   const results: Array<{ text: string; isError: boolean }> = [];
   for (const fp of filePaths) {
     results.push(await indexOneFile(fp, context));
   }
 
+  // A redundant call leads with the note instead of burying it under a success
+  // message the agent reads as "this call did something" (#830). The SQLite
+  // reindex below still runs — it is milliseconds, and nothing else populates
+  // the symbol DB — but the expensive DiskProvider rebuild was skipped.
+  const lead = bridge.redundant ? `${bridge.note}\n\n` : '';
+  const trail = bridge.redundant ? '' : bridge.note;
+
   // Single file keeps its original single-message shape; only a real batch gets
   // the roll-up, so existing callers and their assertions see no change.
   if (results.length === 1) {
     return {
-      content: [{ type: 'text', text: `${results[0].text}\n\n${bridgeNote}` }],
+      content: [{ type: 'text', text: `${lead}${results[0].text}${trail ? `\n\n${trail}` : ''}` }],
       ...(results[0].isError ? { isError: true } : {}),
     };
   }
@@ -230,7 +250,8 @@ export const updateSymbolIndexTool = async (params: any, context: XppServerConte
     content: [{
       type: 'text',
       text:
-        `Indexed ${results.length - failed}/${results.length} file(s) in one pass. ${bridgeNote}\n\n` +
+        `${lead}Indexed ${results.length - failed}/${results.length} file(s) in one pass.` +
+        `${trail ? ` ${trail}` : ''}\n\n` +
         results.map(r => r.text).join('\n\n'),
     }],
     ...(failed === results.length ? { isError: true } : {}),

--- a/tests/tools/updateSymbolIndexBatch.test.ts
+++ b/tests/tools/updateSymbolIndexBatch.test.ts
@@ -97,6 +97,46 @@ describe('update_symbol_index batching', () => {
     expect(result.content[0].text).toContain('already refreshed');
   });
 
+  // #830: the skip was silent, so the agent kept spending a round trip on it —
+  // four times in one audited session. A redundant call now says so first.
+  it('leads a redundant single-file call with the not-needed note', async () => {
+    const file = writeObject('Contoso', 'ConAlpha');
+    markRefreshStarted(Date.now() + 1000);
+
+    const { content } = await updateSymbolIndexTool({ filePath: file }, makeContext());
+    const text: string = content[0].text;
+
+    expect(text.startsWith('ℹ️ This call was not needed.')).toBe(true);
+    expect(text).toContain('d365fo_file');
+    expect(text).toContain('OUTSIDE this server');
+    // The note replaces the bridge line, it does not add a second one.
+    expect(text).not.toContain('Bridge provider refreshed');
+    // The SQLite reindex — the only thing that populates the symbol DB — still ran.
+    expect(text).toContain('Symbol index updated for **ConAlpha**');
+  });
+
+  it('leads a redundant batch call with the note too', async () => {
+    const files = ['ConAlpha', 'ConBeta'].map(n => writeObject('Contoso', n));
+    markRefreshStarted(Date.now() + 1000);
+
+    const { content } = await updateSymbolIndexTool({ filePath: files }, makeContext());
+    const text: string = content[0].text;
+
+    expect(refreshProvider).not.toHaveBeenCalled();
+    expect(text.startsWith('ℹ️ This call was not needed.')).toBe(true);
+    expect(text).toContain('2/2');
+  });
+
+  it('says nothing about redundancy when the refresh was genuinely needed', async () => {
+    markRefreshStarted(Date.now() - 60_000);
+    const file = writeObject('Contoso', 'ConAlpha');
+
+    const { content } = await updateSymbolIndexTool({ filePath: file }, makeContext());
+
+    expect(content[0].text).not.toContain('This call was not needed');
+    expect(content[0].text).toContain('Bridge provider refreshed');
+  });
+
   it('does refresh when a file changed after the last refresh', async () => {
     markRefreshStarted(Date.now() - 60_000);
     const file = writeObject('Contoso', 'ConAlpha');

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -159,6 +159,19 @@ describe('tool inventory contract', () => {
     expect(projectName).toContain('reads span every model already');
   });
 
+  it('does not advertise update_symbol_index as a follow-up to create/modify', () => {
+    // #830: the old description opened with "Call this after
+    // d365fo_file(action=create)", so the agent did — four times in one audited
+    // session, each as the only tool call in its turn, for a DiskProvider rebuild
+    // the create had already done. The tool stays (external edits are real), but
+    // the text the agent reads has to say so, and is pinned here.
+    const updateIndex = toolSchemas.find(t => t.name === 'update_symbol_index')!;
+
+    expect(updateIndex.description).toContain('OUTSIDE this server');
+    expect(updateIndex.description).toContain('Do NOT call after d365fo_file create/modify');
+    expect(updateIndex.description).not.toMatch(/Call this after d365fo_file/);
+  });
+
   it('includes critical diagnostics and SDLC tools in both inventories', () => {
     const criticalTools = [
       'get_workspace_info',


### PR DESCRIPTION
Option **(b)** from #830: the tool stays advertised (external edits are real, and #825 owns the overall tool surface), but the contract it advertises is now explicit and a redundant call says so out loud.

## The problem

The dedup mechanism was already correct — `refreshBridgeForBatch` skips the DiskProvider rebuild when `getLastRefreshStartedAt()` shows a refresh began after the newest file was written, which is always the case right after a `d365fo_file` create/modify. What was missing was one level up: the description opened with *"Call this after `d365fo_file(action="create")`"*, so the agent dutifully did — 4 calls in the audited session, each the only tool call in its turn (~12 AIU, ~15 s) — and the skip was silent, so the response still read like the call had done something.

## What changed

| File | Change |
|---|---|
| `src/server/toolSchemas/updateSymbolIndex.ts` | Description rewritten: leads with *"changed OUTSIDE this server"* + *"Do NOT call after d365fo_file create/modify"*. 315 chars shorter on the wire (848 → 533 incl. the `filePath` param text). |
| `src/tools/updateSymbolIndex.ts` | `refreshBridgeForBatch` now returns `{ note, redundant }`; a redundant call **leads** its response with `ℹ️ This call was not needed. …` instead of appending a buried "already refreshed — skipped" line. Applies to both the single-file and the batch shape. |
| `src/index.ts` | Startup-catalog one-liner brought in line (one line, unchanged position). |
| `docs/MCP_TOOLS.md` | SDLC table row + example prompt rewritten for the external-edit case. |
| `eval/cases/L0-create-readback-no-reindex.json` | New case (see below). |

## Acceptance criteria

- **"creating an object via `d365fo_file` needs no follow-up `update_symbol_index` for the object to be visible"** — already true and unchanged: create/modify call `bridgeRefreshProvider` on their way out, which `markRefreshStarted()`s and rebuilds the provider the readers resolve through. Nothing in this PR alters that path; the PR removes the *advice* that contradicted it.
- **"a redundant call returns instantly with an explicit note"** — the expensive part (the full DiskProvider rebuild, ~1 s) is skipped, as before, and the response now opens with the note naming `d365fo_file` and *"only … for files changed OUTSIDE this server"*.
- **"its description tells the agent not to make it"** — done, and pinned by a test so it cannot drift back.
- **"eval case: create → read back, assert one tool call, not two"** — `L0-create-readback-no-reindex`: create an extensible enum, then read it back with `get_object_info` in exactly one call, with explicit fail conditions ("the read-back needs an `update_symbol_index` call to resolve the enum, or the run spends a turn on `update_symbol_index` after the create"). `golden_pending: true` per repo convention — the golden can only be captured from a real build on the VM (§6.4), so it is exempt from the goldens CI gate until an eval-implementer run lands it. `split: holdout`, as new cases require.

## Deliberately not done (scope calls, stated rather than silently narrowed)

1. **The redundant call still runs the SQLite reindex.** Only this tool writes the symbol DB — `d365fo_file` create/modify never touch it (verified: no `symbolIndex.addSymbol` anywhere in `createD365File.ts`). Short-circuiting the whole handler would break `generate_object` `fieldsHint` EDT/enum resolution and same-session `search`. The reindex is a single XML parse plus a few inserts — milliseconds against the ~1 s rebuild that is skipped — so "returns instantly" holds.
2. **Because of (1), the description keeps one short exception clause** — *"a brand-new AxEdt/AxEnum you are about to name in a `generate_object` fieldsHint"*. The blunt no-exceptions wording from the issue would have contradicted `generate_object`'s own `fieldsHint` hint, which is genuinely correct, and a contradiction between two schemas is worse for the agent than one extra clause. Everything else is as blunt as the issue asked.
3. **`TOTAL_BUDGET` in `tests/utils/toolSchemaBudget.test.ts` was not lowered** by the 315 chars saved, even though its comment invites that — parallel branches are moving other schemas and re-ratcheting now would just create conflicts.
4. **No change to `.github/copilot-instructions.md`** — it never mentions this tool (checked); the "call `update_symbol_index`" strings elsewhere in `src/tools/*` are all *not-found recovery* guidance, a different situation from a fresh create, and belong to #826/#803.

## Tests

- `tests/tools/updateSymbolIndexBatch.test.ts` — 3 new cases: redundant single-file call leads with the note and still reports the SQLite reindex; redundant batch call leads with it too; a genuinely needed refresh says nothing about redundancy and reports the rebuild.
- `tests/utils/toolInventory.test.ts` — new case pinning the description text (same pattern as the existing `get_workspace_info` schema-text pin).
- Targeted: 24 files / 431 tests passed. Full suite: **205 files, 2710 passed, 9 skipped**. `npx tsc --noEmit` clean.

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
