### PR TITLE
fix(bridge): wait for a starting bridge instead of reporting "not connected"

### DIFF
--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -79,7 +79,9 @@ function envIntZero(name: string, fallback: number): number {
 }
 
 // Configurable via env so large installations / slow VMs can raise the limits.
-const READY_TIMEOUT_MS = envInt('BRIDGE_READY_TIMEOUT_MS', 30_000); // 30s for metadata provider init
+// Exported so the readiness gate (bridgeReadiness.ts) bounds its wait by the
+// same budget the child process is actually given to come up.
+export const READY_TIMEOUT_MS = envInt('BRIDGE_READY_TIMEOUT_MS', 30_000); // 30s for metadata provider init
 const CALL_TIMEOUT_MS = envInt('BRIDGE_CALL_TIMEOUT_MS', 60_000);   // 60s per call (large searches can take time)
 const MAX_RETRIES = envIntZero('BRIDGE_MAX_RETRIES', 2);            // retries for READ calls only (0 = disabled)
 const HEALTHCHECK_MS = envIntZero('BRIDGE_HEALTHCHECK_MS', 0);      // idle ping interval (0 = disabled)

--- a/src/bridge/bridgeReadiness.ts
+++ b/src/bridge/bridgeReadiness.ts
@@ -1,0 +1,166 @@
+/**
+ * Bridge startup readiness gate.
+ *
+ * The MCP tool list goes live the moment the handshake completes, but the C#
+ * bridge is spawned out-of-band (see `initializeBridge` in src/index.ts) and
+ * needs a few seconds to bring up its metadata provider. Until then
+ * `context.bridge` is undefined, so a bridge-backed tool called in that window
+ * fell through every read path and reported a configuration problem — a
+ * diagnostic dead end, because nothing is wrong and the identical call succeeds
+ * seconds later (issue #826).
+ *
+ * The fix has two halves, both in this module:
+ *  1. `awaitBridgeReady` — the dispatcher waits (bounded) for a startup that is
+ *     still in flight, so the agent never observes the race. Trading a 3-second
+ *     LLM round trip for a 2-second in-process wait is a straight win.
+ *  2. `bridgeStartupState` / `describeBridgeStartup` — when the wait genuinely
+ *     times out, the "not found" messages can say the bridge is still starting
+ *     instead of telling the user to go fix a config that is fine.
+ */
+
+import { READY_TIMEOUT_MS } from './bridgeClient.js';
+
+/**
+ * Handle to the one-shot bridge startup attempt, attached to the server context.
+ * `done` never rejects — a failed startup is a settled attempt with no bridge.
+ */
+export interface BridgeStartup {
+  /** Resolves when the startup attempt has settled (bridge attached, or given up). */
+  readonly done: Promise<void>;
+  /** True once `done` has resolved. Lets callers classify without awaiting. */
+  readonly settled: boolean;
+}
+
+/**
+ * The readiness slice of XppServerContext. Structural rather than the concrete
+ * context type so message helpers in src/utils can use it without importing the
+ * whole server context (and so tests can pass a two-field stub).
+ */
+export interface BridgeReadinessSource {
+  bridge?: { isReady?: boolean; metadataAvailable?: boolean };
+  bridgeStartup?: BridgeStartup;
+}
+
+/**
+ * Wrap the in-flight bridge startup so the dispatcher can both await it and ask
+ * synchronously whether it has settled. Swallows rejections deliberately: the
+ * caller's own error reporting owns the failure, this handle only tracks timing.
+ */
+export function trackBridgeStartup(attempt: Promise<unknown>): BridgeStartup {
+  const handle = {
+    settled: false,
+    done: attempt.then(
+      () => { handle.settled = true; },
+      () => { handle.settled = true; },
+    ),
+  };
+  return handle;
+}
+
+/**
+ * Tools whose answers come from (or are materially improved by) the C# bridge.
+ * These are gated on bridge readiness; everything else dispatches immediately.
+ *
+ * Membership tracks the tool implementations that reach `context.bridge` — see
+ * tests/tools/bridgeReadinessGate.test.ts, which fails if a tool starts using
+ * the bridge without being listed here.
+ */
+export const BRIDGE_BACKED_TOOLS = new Set([
+  'search',
+  'batch_get_info',
+  'get_object_info',
+  'get_method',
+  'find_references',
+  'extension_info',
+  'security_info',
+  'generate_object',
+  'd365fo_file',
+  'labels',
+  'prepare',
+  'analyze_code',
+  'update_symbol_index',
+  'undo_last_modification',
+]);
+
+/**
+ * Outcome of waiting for the bridge before running a bridge-backed tool.
+ *  - `ready`       the bridge is up; the tool gets live metadata
+ *  - `unavailable` startup settled without a bridge (no D365FO install / bad config)
+ *  - `timeout`     still starting after the bounded wait — a genuinely slow start
+ *  - `not-tracked` nothing wired a startup attempt (HTTP pre-init, unit tests)
+ */
+export type BridgeWaitOutcome = 'ready' | 'unavailable' | 'timeout' | 'not-tracked';
+
+/** Synchronous view of where the bridge startup stands right now. */
+export type BridgeStartupState = 'ready' | 'starting' | 'unavailable';
+
+/**
+ * Classify the bridge without waiting. `starting` is the state that used to be
+ * misreported as "not connected".
+ */
+export function bridgeStartupState(context: BridgeReadinessSource): BridgeStartupState {
+  if (context.bridge?.isReady) return 'ready';
+  // A startup attempt that has not settled is still in flight — the bridge may
+  // yet appear. Once it has settled, a missing bridge is a real absence.
+  if (context.bridgeStartup && !context.bridgeStartup.settled) return 'starting';
+  return 'unavailable';
+}
+
+/**
+ * Wait (bounded) for a bridge startup that is still in flight.
+ *
+ * Returns immediately when the bridge is already up, when the startup attempt
+ * has already settled, or when no attempt is tracked at all — so the common
+ * warm-server path costs nothing.
+ */
+export async function awaitBridgeReady(
+  context: BridgeReadinessSource,
+  timeoutMs: number = READY_TIMEOUT_MS,
+): Promise<BridgeWaitOutcome> {
+  if (context.bridge?.isReady) return 'ready';
+
+  const startup = context.bridgeStartup;
+  if (!startup) return 'not-tracked';
+  if (startup.settled) return context.bridge?.isReady ? 'ready' : 'unavailable';
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<'timeout'>(resolve => {
+    timer = setTimeout(() => resolve('timeout'), timeoutMs);
+    // Never hold the process open just for this watchdog.
+    if (typeof timer.unref === 'function') timer.unref();
+  });
+  try {
+    const raced = await Promise.race([startup.done.then(() => 'settled' as const), timeout]);
+    if (raced === 'timeout') return 'timeout';
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+  return context.bridge?.isReady ? 'ready' : 'unavailable';
+}
+
+/**
+ * The bridge half of a "not found" message, for tools that exhausted bridge,
+ * symbol index and disk. Splits the two cases the old text conflated: a bridge
+ * that is still coming up (retry — the config is fine) versus one that is
+ * genuinely absent (check the config).
+ *
+ * Returns null when the bridge is up and healthy — the object really is missing,
+ * and the caller owns that wording.
+ */
+export function describeBridgeStartup(context: BridgeReadinessSource): string | null {
+  switch (bridgeStartupState(context)) {
+    case 'starting':
+      return (
+        `The C# bridge is still starting — this is a cold-start race, NOT a configuration problem, ` +
+        `and NOT evidence that the object does not exist. Retry the identical call in a few seconds.`
+      );
+    case 'unavailable':
+      return (
+        `The C# bridge is not connected. Ensure the bridge exe is built and D365FO metadata ` +
+        `is accessible. Check .mcp.json → context.packagePath (and context.microsoftPackagesPath ` +
+        `for UDE environments).`
+      );
+    default:
+      return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { apiKeyAuth } from './middleware/apiKeyAuth.js';
 import { VERSION } from './version.js';
 import { setInitializeParams } from './utils/stdioSessionInfo.js';
 import { setModelObjectNameSource } from './utils/modelPrefixInference.js';
+import { trackBridgeStartup } from './bridge/bridgeReadiness.js';
 import { createShutdownCoordinator } from './utils/gracefulShutdown.js';
 import { box, kv, sectionTitle, statusLine, spread, c, glyph, sanitize, supportsUnicode, log, shortPath, startupWarnings } from './utils/terminalUi.js';
 import * as fs from 'fs/promises';
@@ -606,7 +607,11 @@ async function main() {
     // Step 3b: Initialize C# bridge in parallel with DB load (non-blocking)
     // The bridge provides live metadata from Microsoft's IMetadataProvider API
     // and cross-reference queries — only available on Windows VMs with D365FO.
-    void initializeBridge(stubContext).then(s => (s.ok ? log.ok(s.summary) : log.warn(s.summary)));
+    // The attempt is tracked on the context so bridge-backed tools called in the
+    // first seconds wait for it instead of reporting a phantom "not connected".
+    stubContext.bridgeStartup = trackBridgeStartup(
+      initializeBridge(stubContext).then(s => (s.ok ? log.ok(s.summary) : log.warn(s.summary))),
+    );
 
     // Step 4: load real database in the background
     const dbLoadStart = Date.now();
@@ -744,8 +749,12 @@ async function main() {
       // never block startup, so cap the wait; it keeps connecting in the
       // background afterwards and attaches to the context once ready.
       if (context) {
+        const attempt = initializeBridge(context);
+        // Tracked before the bounded race below, so a bridge that is still
+        // connecting when the banner gives up is still awaited by tool calls.
+        context.bridgeStartup = trackBridgeStartup(attempt);
         const status = await Promise.race<BridgeStatus>([
-          initializeBridge(context),
+          attempt,
           new Promise<BridgeStatus>(r => setTimeout(
             () => r({ ok: true, summary: 'C# bridge still connecting in the background' + glyph.ellipsis }), 6000)),
         ]);

--- a/src/tools/enumInfo.ts
+++ b/src/tools/enumInfo.ts
@@ -64,7 +64,7 @@ export async function getEnumInfoTool(request: CallToolRequest, context: XppServ
     }
 
     let text = `Enum "${args.enumName}" not found via bridge, symbol index, or on disk.\n`;
-    text += bridgeUnavailableNote(context.bridge);
+    text += bridgeUnavailableNote(context);
     try {
       text += buildObjectTypeMismatchMessage(context.symbolIndex.getReadDb(), args.enumName, 'enum');
     } catch { /* DB unavailable */ }

--- a/src/tools/formInfo.ts
+++ b/src/tools/formInfo.ts
@@ -15,6 +15,7 @@ import { promises as fs } from 'fs';
 import { parseStringPromise } from 'xml2js';
 import { tryBridgeForm } from '../bridge/bridgeAdapter.js';
 import { readIndexedXml } from '../utils/indexedXmlLookup.js';
+import { describeBridgeStartup } from '../bridge/bridgeReadiness.js';
 import { assertWritePathAllowed } from '../utils/pathContainment.js';
 
 const GetFormInfoArgsSchema = z.object({
@@ -129,13 +130,13 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
     }
 
     // Determine why the bridge returned nothing to give an actionable error message.
+    // "still starting" and "not connected" are different problems with different
+    // remedies (retry vs. fix the config) — describeBridgeStartup separates them.
     let bridgeNote: string;
-    if (!context.bridge?.isReady) {
-      bridgeNote =
-        `The C# bridge is not connected. Ensure the bridge exe is built and D365FO metadata ` +
-        `is accessible. Check .mcp.json → context.packagePath (and context.microsoftPackagesPath ` +
-        `for UDE environments).`;
-    } else if (!context.bridge.metadataAvailable) {
+    const startupNote = describeBridgeStartup(context);
+    if (startupNote) {
+      bridgeNote = startupNote;
+    } else if (!context.bridge?.metadataAvailable) {
       bridgeNote =
         `The C# bridge is connected but the metadata provider failed to initialize. ` +
         `Check the bridge log for details — the packages path may be incorrect or the ` +

--- a/src/tools/queryInfo.ts
+++ b/src/tools/queryInfo.ts
@@ -80,7 +80,7 @@ export async function getQueryInfoTool(request: CallToolRequest, context: XppSer
     }
 
     let text = `Query "${args.queryName}" not found via bridge, symbol index, or on disk.\n`;
-    text += bridgeUnavailableNote(context.bridge);
+    text += bridgeUnavailableNote(context);
     try {
       text += buildObjectTypeMismatchMessage(context.symbolIndex.getReadDb(), args.queryName, 'query');
     } catch { /* DB unavailable */ }

--- a/src/tools/reportInfo.ts
+++ b/src/tools/reportInfo.ts
@@ -143,7 +143,7 @@ export async function getReportInfoTool(request: CallToolRequest, context: XppSe
       content: [{
         type: 'text',
         text: `❌ Report "${reportName}" not found via bridge or symbol index.` +
-          bridgeUnavailableNote(context.bridge) + `\n` +
+          bridgeUnavailableNote(context) + `\n` +
           `If this is a newly-created report, pass the explicit \`filePath\` parameter:\n` +
           `  get_object_info(objectType="report", name="${reportName}", options={filePath:"<absolute path to .xml>"})`,
       }],

--- a/src/tools/tableInfo.ts
+++ b/src/tools/tableInfo.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { findD365FileOnDisk } from './modifyD365File.js';
 import { tryBridgeTable } from '../bridge/bridgeAdapter.js';
+import { bridgeUnavailableNote } from '../utils/indexedXmlLookup.js';
 
 const TableInfoArgsSchema = z.object({
   tableName: z.string().describe('Name of the X++ table'),
@@ -62,10 +63,16 @@ export async function tableInfoTool(request: CallToolRequest, context: XppServer
       }
     }
 
+    // 4. Nothing anywhere. Say WHY before saying "not found": a bridge that is
+    //    still starting (cold-start race) or absent means the object may exist
+    //    and simply wasn't reachable — telling the agent to go fix .mcp.json is
+    //    a diagnostic dead end in both cases (issue #826).
     return {
       content: [{
         type: 'text',
-        text: `Table "${args.tableName}" not found via bridge, symbol index, or on disk.\n\nIf this is a newly created table, ensure .mcp.json has the correct modelName/projectPath so the server can locate it.`,
+        text: `Table "${args.tableName}" not found via bridge, symbol index, or on disk.` +
+          bridgeUnavailableNote(context) +
+          `\nIf this is a newly created table, ensure .mcp.json has the correct modelName/projectPath so the server can locate it.`,
       }],
       isError: true,
     };

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -3,6 +3,7 @@ import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { XppServerContext } from '../types/context.js';
 import { getConfigManager } from '../utils/configManager.js';
 import { SERVER_MODE, LOCAL_TOOLS, isToolAllowedInMode } from '../server/serverMode.js';
+import { BRIDGE_BACKED_TOOLS, awaitBridgeReady } from '../bridge/bridgeReadiness.js';
 import { searchUnifiedTool } from './searchUnified.js';
 import { batchGetInfoTool } from './batchGetInfo.js';
 import { getObjectInfoTool } from './getObjectInfo.js';
@@ -146,6 +147,16 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       configManager.setRuntimeContext({ workspacePath });
     }
 
+    // The C# bridge starts out-of-band, so the tool list can be live while
+    // `context.bridge` is still undefined. Wait for a startup that is in flight
+    // before the tool decides anything — otherwise a 2-second cold-start race is
+    // reported as "the object does not exist" / "check your config" (issue #826).
+    // Started here, awaited after the dbReady block, so the two waits overlap and
+    // a cold start costs max(db, bridge) rather than their sum.
+    const bridgeWait = BRIDGE_BACKED_TOOLS.has(toolName)
+      ? { t0: Date.now(), outcome: awaitBridgeReady(context) }
+      : null;
+
     // ctx.dbReady resolves once the real symbol database is loaded; await it so
     // tools use the real index instead of silently returning empty results.
     // LOCAL_TOOLS need no DB (filesystem/in-memory config only) and skip the wait.
@@ -174,6 +185,19 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       const elapsed = Date.now() - t0;
       if (elapsed > 200) {
         console.error(`[toolHandler] ⏳ ${toolName}: DB was loading, waited ${elapsed} ms`);
+      }
+    }
+
+    // Collect the bridge wait started above. Every outcome falls through to the
+    // tool: `ready` is the point of the wait, `unavailable`/`not-tracked` mean
+    // the symbol-index and disk fallbacks are the answer, and even on `timeout`
+    // the tool may still resolve the object from the index — it just gets to
+    // describe the bridge as "still starting" instead of "not connected".
+    if (bridgeWait) {
+      const outcome = await bridgeWait.outcome;
+      const elapsed = Date.now() - bridgeWait.t0;
+      if (elapsed > 200) {
+        console.error(`[toolHandler] ⏳ ${toolName}: bridge was starting, waited ${elapsed} ms → ${outcome}`);
       }
     }
 

--- a/src/tools/viewInfo.ts
+++ b/src/tools/viewInfo.ts
@@ -233,7 +233,7 @@ function formatViewFromSymbols(context: XppServerContext, viewName: string, mode
 
 function buildNotFoundText(context: XppServerContext, viewName: string): string {
   let text = `View "${viewName}" not found via bridge, symbol index, or on disk.\n`;
-  text += bridgeUnavailableNote(context.bridge);
+  text += bridgeUnavailableNote(context);
   try {
     text += buildObjectTypeMismatchMessage(context.symbolIndex.getReadDb(), viewName, 'view');
   } catch { /* DB unavailable */ }

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -7,6 +7,7 @@ import type { XppMetadataParser } from '../metadata/xmlParser.js';
 import type { WorkspaceScanner } from '../workspace/workspaceScanner.js';
 import type { HybridSearch } from '../workspace/hybridSearch.js';
 import type { BridgeClient } from '../bridge/bridgeClient.js';
+import type { BridgeStartup } from '../bridge/bridgeReadiness.js';
 
 /**
  * Editor context from IDE (VS2022, VS2026)
@@ -42,6 +43,13 @@ export interface XppServerContext {
    * instead of the SQLite symbol index.
    */
   bridge?: BridgeClient;
+  /**
+   * Tracks the one-shot C# bridge startup attempt, which runs in parallel with
+   * the DB load and only sets `bridge` once it succeeds. Bridge-backed tools
+   * await it (bounded) so a cold-start race is never reported as a missing
+   * object or a broken configuration. Absent when nothing spawned a bridge.
+   */
+  bridgeStartup?: BridgeStartup;
   /**
    * Resolves when the real symbol database has been loaded.
    * Present only in stdio mode when the stub pattern is active.

--- a/src/utils/indexedXmlLookup.ts
+++ b/src/utils/indexedXmlLookup.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs';
 import { promises as fsp } from 'fs';
 import { lookupSymbolNocase } from './symbolLookup.js';
 import { resolveDbPathLocally } from './metadataResolver.js';
+import { bridgeStartupState, type BridgeReadinessSource } from '../bridge/bridgeReadiness.js';
 
 export interface IndexedObjectRef {
   /** Canonical name as stored in the index (may differ in casing from the request). */
@@ -112,9 +113,19 @@ export function indexedSourceNote(source: string): string {
 /**
  * Explain why the bridge produced nothing, so "not found" is never mistaken for
  * "does not exist" when the bridge is simply unavailable.
+ *
+ * Takes the server context (not just `context.bridge`) so a bridge that is still
+ * starting is reported as a cold-start race rather than as a broken config — the
+ * conflation behind issue #826.
  */
-export function bridgeUnavailableNote(bridge: { isReady?: boolean; metadataAvailable?: boolean } | undefined): string {
+export function bridgeUnavailableNote(context: BridgeReadinessSource | undefined): string {
+  const bridge = context?.bridge;
   if (bridge?.isReady && bridge?.metadataAvailable) return '';
+  if (context && bridgeStartupState(context) === 'starting') {
+    return `\n⏳ The C# metadata bridge is still starting, so only the symbol index and disk were ` +
+      `checked. This is a cold-start race, not a configuration problem — retry in a few seconds ` +
+      `before concluding the object does not exist.\n`;
+  }
   return `\n⚠️ The C# metadata bridge is ${bridge?.isReady ? 'running without metadata access' : 'not connected'}, ` +
     `so only the symbol index and disk were checked.\n`;
 }

--- a/tests/bridge/bridgeReadiness.test.ts
+++ b/tests/bridge/bridgeReadiness.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Regression tests for issue #826 — bridge-backed tools were advertised before
+ * the C# bridge was ready.
+ *
+ * The MCP tool list goes live as soon as the handshake completes, but the bridge
+ * is spawned out-of-band and only lands on `context.bridge` once it is up. A
+ * bridge-backed tool called in that window fell through every read path and
+ * answered `Table "X" not found via bridge, symbol index, or on disk` /
+ * `The C# bridge is not connected. … check .mcp.json`. Both are diagnostic dead
+ * ends: nothing is wrong, and the identical call succeeded 19 s later in the
+ * audited session.
+ *
+ * What is asserted here:
+ *  1. the dispatcher waits for an in-flight startup, so a cold call returns the
+ *     same answer as a warm one (the acceptance criterion in the issue);
+ *  2. only a genuine timeout / genuine absence produces an error message, and
+ *     the two are worded differently ("still starting" vs "not connected");
+ *  3. BRIDGE_BACKED_TOOLS does not drift away from the tools that actually
+ *     reach `context.bridge`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  trackBridgeStartup,
+  bridgeStartupState,
+  awaitBridgeReady,
+  describeBridgeStartup,
+  BRIDGE_BACKED_TOOLS,
+  type BridgeReadinessSource,
+} from '../../src/bridge/bridgeReadiness';
+import { bridgeUnavailableNote } from '../../src/utils/indexedXmlLookup';
+
+const READY_BRIDGE = { isReady: true, metadataAvailable: true };
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => { resolve = r; });
+  return { promise, resolve };
+}
+
+describe('bridge startup tracking', () => {
+  it('reports settled only after the attempt resolves', async () => {
+    const d = deferred();
+    const startup = trackBridgeStartup(d.promise);
+
+    expect(startup.settled).toBe(false);
+    d.resolve();
+    await startup.done;
+    expect(startup.settled).toBe(true);
+  });
+
+  it('treats a failed startup as settled rather than propagating the rejection', async () => {
+    const startup = trackBridgeStartup(Promise.reject(new Error('spawn ENOENT')));
+
+    await expect(startup.done).resolves.toBeUndefined();
+    expect(startup.settled).toBe(true);
+  });
+});
+
+describe('bridgeStartupState', () => {
+  it('is "starting" only while an attempt is in flight', async () => {
+    const d = deferred();
+    const ctx: BridgeReadinessSource = { bridgeStartup: trackBridgeStartup(d.promise) };
+
+    expect(bridgeStartupState(ctx)).toBe('starting');
+
+    d.resolve();
+    await ctx.bridgeStartup!.done;
+    // Settled with no bridge attached — a real absence, not a race.
+    expect(bridgeStartupState(ctx)).toBe('unavailable');
+  });
+
+  it('is "unavailable" when nothing ever tried to start a bridge', () => {
+    expect(bridgeStartupState({})).toBe('unavailable');
+  });
+
+  it('is "ready" once the bridge is attached', () => {
+    expect(bridgeStartupState({ bridge: READY_BRIDGE })).toBe('ready');
+  });
+});
+
+describe('awaitBridgeReady', () => {
+  it('returns immediately when the bridge is already up', async () => {
+    const t0 = Date.now();
+    await expect(awaitBridgeReady({ bridge: READY_BRIDGE })).resolves.toBe('ready');
+    expect(Date.now() - t0).toBeLessThan(50);
+  });
+
+  it('does not wait when no startup attempt is tracked', async () => {
+    const t0 = Date.now();
+    await expect(awaitBridgeReady({})).resolves.toBe('not-tracked');
+    expect(Date.now() - t0).toBeLessThan(50);
+  });
+
+  it('waits for an in-flight startup and reports the bridge that arrived', async () => {
+    const ctx: BridgeReadinessSource = {};
+    ctx.bridgeStartup = trackBridgeStartup(
+      new Promise<void>(r => setTimeout(() => { ctx.bridge = READY_BRIDGE; r(); }, 60)),
+    );
+
+    await expect(awaitBridgeReady(ctx, 5_000)).resolves.toBe('ready');
+    expect(ctx.bridge).toBe(READY_BRIDGE);
+  });
+
+  it('reports "unavailable" when the attempt settles without a bridge', async () => {
+    const ctx: BridgeReadinessSource = {
+      bridgeStartup: trackBridgeStartup(new Promise<void>(r => setTimeout(r, 20))),
+    };
+    await expect(awaitBridgeReady(ctx, 5_000)).resolves.toBe('unavailable');
+  });
+
+  it('reports "timeout" — and only "timeout" — for a startup that never finishes', async () => {
+    const ctx: BridgeReadinessSource = { bridgeStartup: trackBridgeStartup(deferred().promise) };
+    await expect(awaitBridgeReady(ctx, 30)).resolves.toBe('timeout');
+  });
+});
+
+describe('startup-aware not-found wording', () => {
+  it('tells the agent to retry — not to fix its config — while the bridge is starting', () => {
+    const ctx: BridgeReadinessSource = { bridgeStartup: trackBridgeStartup(deferred().promise) };
+
+    const note = describeBridgeStartup(ctx)!;
+    expect(note).toContain('still starting');
+    expect(note).not.toContain('.mcp.json');
+    expect(note).not.toContain('not connected');
+
+    const indexNote = bridgeUnavailableNote(ctx);
+    expect(indexNote).toContain('still starting');
+    expect(indexNote).not.toContain('not connected');
+  });
+
+  it('keeps the "check your config" text for a bridge that genuinely failed to start', () => {
+    const note = describeBridgeStartup({})!;
+    expect(note).toContain('not connected');
+    expect(note).toContain('.mcp.json');
+
+    expect(bridgeUnavailableNote({})).toContain('not connected');
+  });
+
+  it('says nothing about the bridge when it is up and healthy', () => {
+    expect(describeBridgeStartup({ bridge: READY_BRIDGE })).toBeNull();
+    expect(bridgeUnavailableNote({ bridge: READY_BRIDGE })).toBe('');
+  });
+});
+
+// The dispatcher path — this is the acceptance criterion: a get_object_info
+// issued milliseconds after the handshake must match a warm call.
+
+const BRIDGE_TABLE_TEXT = '# Table: CustTable\n\n(served by the C# bridge)';
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return {
+    ...actual,
+    // Name-independent so a cold call and a warm call (different names, to dodge
+    // the dispatcher's dedup cache) are comparable byte for byte.
+    tryBridgeTable: async (bridge: any) =>
+      bridge?.isReady ? { content: [{ type: 'text', text: BRIDGE_TABLE_TEXT }] } : null,
+  };
+});
+
+type CallHandler = (request: any, extra: any) => Promise<any>;
+
+function buildFakeServer(): { server: any; getCallHandler: () => CallHandler } {
+  let callHandler: CallHandler | undefined;
+  const server = {
+    setRequestHandler(schema: unknown, handler: CallHandler) {
+      if (schema === CallToolRequestSchema) callHandler = handler;
+    },
+    async sendLoggingMessage() {},
+  };
+  return {
+    server,
+    getCallHandler: () => {
+      if (!callHandler) throw new Error('CallTool handler was not registered');
+      return callHandler;
+    },
+  };
+}
+
+function call(handler: CallHandler, name: string, args: Record<string, unknown>) {
+  return handler({ method: 'tools/call', params: { name, arguments: args } }, { _meta: {} });
+}
+
+describe('dispatcher gate — cold start (issue #826)', () => {
+  it('a call issued right after the handshake matches a warm call', async () => {
+    const { registerToolHandler } = await import('../../src/tools/toolHandler');
+    const BRIDGE_SPAWN_MS = 120;
+
+    const context: any = { symbolIndex: {} };
+    context.bridgeStartup = trackBridgeStartup(
+      new Promise<void>(r => setTimeout(() => { context.bridge = READY_BRIDGE; r(); }, BRIDGE_SPAWN_MS)),
+    );
+
+    const { server, getCallHandler } = buildFakeServer();
+    registerToolHandler(server, context);
+
+    // Cold: the bridge has not landed on the context yet.
+    expect(context.bridge).toBeUndefined();
+    const t0 = Date.now();
+    const cold: any = await call(getCallHandler(), 'get_object_info', {
+      objectType: 'table', name: 'ColdRaceTable',
+    });
+    const elapsed = Date.now() - t0;
+
+    // Warm: same tool, different name so the dedup cache cannot answer it.
+    const warm: any = await call(getCallHandler(), 'get_object_info', {
+      objectType: 'table', name: 'WarmTable',
+    });
+
+    expect(cold.isError).toBeFalsy();
+    expect(cold.content[0].text).toContain(BRIDGE_TABLE_TEXT);
+    expect(cold.content[0].text).not.toContain('not connected');
+    expect(cold.content[0].text).not.toContain('not found');
+    expect(cold).toEqual(warm);
+    // The answer came from the wait, not from luck.
+    expect(elapsed).toBeGreaterThanOrEqual(BRIDGE_SPAWN_MS - 20);
+  });
+
+  it('does not wait for tools that never touch the bridge', async () => {
+    const { registerToolHandler } = await import('../../src/tools/toolHandler');
+
+    const context: any = { symbolIndex: {} };
+    // A startup that never settles — a gated tool would block on it.
+    context.bridgeStartup = trackBridgeStartup(deferred().promise);
+
+    const { server, getCallHandler } = buildFakeServer();
+    registerToolHandler(server, context);
+
+    const t0 = Date.now();
+    const res: any = await call(getCallHandler(), 'get_knowledge', {
+      kind: 'knowledge', topic: 'bridge-readiness-probe',
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(Date.now() - t0).toBeLessThan(1_000);
+  });
+});
+
+// Drift guard — the gate is only correct if the set names every bridge user.
+
+describe('BRIDGE_BACKED_TOOLS coverage', () => {
+  const HERE = path.dirname(fileURLToPath(import.meta.url));
+  const SRC = path.resolve(HERE, '..', '..', 'src');
+
+  /** Entry module per tool, mirroring the `switch (toolName)` in toolHandler.ts. */
+  const TOOL_ENTRY: Record<string, string> = {
+    search: 'tools/searchUnified.ts',
+    batch_get_info: 'tools/batchGetInfo.ts',
+    get_object_info: 'tools/getObjectInfo.ts',
+    generate_object: 'tools/generateObject.ts',
+    analyze_code: 'tools/analyzeCode.ts',
+    d365fo_file: 'tools/d365foFile.ts',
+    find_references: 'tools/findReferences.ts',
+    get_method: 'tools/getMethod.ts',
+    labels: 'tools/labels.ts',
+    object_patterns: 'tools/objectPatterns.ts',
+    suggest_edt: 'tools/suggestEdt.ts',
+    security_info: 'tools/securityInfo.ts',
+    extension_info: 'tools/extensionInfo.ts',
+    validate_object_naming: 'tools/validateObjectNaming.ts',
+    verify_d365fo_project: 'tools/verifyD365Project.ts',
+    update_symbol_index: 'tools/updateSymbolIndex.ts',
+    build_d365fo_project: 'tools/buildProject.ts',
+    trigger_db_sync: 'tools/dbSync.ts',
+    run_bp_check: 'tools/runBpCheck.ts',
+    run_systest_class: 'tools/sysTestRunner.ts',
+    review_workspace_changes: 'tools/reviewWorkspaceChanges.ts',
+    undo_last_modification: 'tools/undoLastModification.ts',
+    get_knowledge: 'tools/getKnowledge.ts',
+    validate_code: 'tools/validateCode.ts',
+    prepare: 'tools/prepare.ts',
+  };
+
+  /** `context.bridge` / `ctx.bridge` / `bridge?.isReady` — how a module reaches the bridge. */
+  const USES_BRIDGE = /(context|ctx)\s*\.\s*bridge\b|\bbridge\s*\?\.\s*isReady\b/;
+
+  function reachesBridge(entry: string): boolean {
+    const seen = new Set<string>();
+    const stack = [path.resolve(SRC, entry)];
+    while (stack.length > 0) {
+      const file = stack.pop()!;
+      if (seen.has(file)) continue;
+      seen.add(file);
+      let text: string;
+      try { text = fs.readFileSync(file, 'utf8'); } catch { continue; }
+      // bridgeReadiness itself inspects context.bridge — it is the gate, not a user.
+      if (!file.endsWith('bridgeReadiness.ts') && USES_BRIDGE.test(text)) return true;
+      const specs = [
+        ...text.matchAll(/from\s+'(\.[^']+)'/g),
+        ...text.matchAll(/import\(\s*'(\.[^']+)'\s*\)/g),
+      ].map(m => m[1]);
+      for (const spec of specs) {
+        const resolved = path.resolve(path.dirname(file), spec).replace(/\.js$/, '.ts');
+        if (fs.existsSync(resolved)) stack.push(resolved);
+      }
+    }
+    return false;
+  }
+
+  it('gates every tool whose implementation reaches context.bridge', () => {
+    const missing = Object.entries(TOOL_ENTRY)
+      .filter(([tool, entry]) => reachesBridge(entry) && !BRIDGE_BACKED_TOOLS.has(tool))
+      .map(([tool]) => tool);
+
+    expect(missing, `tools using the bridge but not gated on its readiness: ${missing.join(', ')}`)
+      .toEqual([]);
+  });
+
+  it('lists only real tool names', () => {
+    for (const tool of BRIDGE_BACKED_TOOLS) {
+      expect(Object.keys(TOOL_ENTRY)).toContain(tool);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The server announces its tool list as soon as the MCP handshake completes, but the C# bridge is initialised out-of-band (`initializeBridge()` runs non-blocking, in parallel with the DB load) and only lands on `context.bridge` **after** it succeeds. So by construction the tool list can be live while there is no bridge on the context at all.

A bridge-backed tool called in that window fell through every read path (bridge → symbol index → disk) and answered one of:

```
Table "<Table>" not found via bridge, symbol index, or on disk.
If this is a newly created table, ensure .mcp.json has the correct modelName/projectPath …
```
```
Form "<Table>" not found.
The C# bridge is not connected. Ensure the bridge exe is built … Check .mcp.json → context.packagePath …
```

Both are diagnostic dead ends: they tell the agent its config is broken when it is not. In the audited session the identical calls succeeded 19 s later, after a detour through `get_workspace_info` and a `search` — roughly 20 s and ~12 AIU spent on a 2-second startup race, plus a stretch of transcript that permanently claims the object does not exist.

## The change

New `src/bridge/bridgeReadiness.ts` models the startup as a *tracked attempt*, which is what was missing — `BridgeClient` already models readiness for a bridge that exists, but during startup `context.bridge` is `undefined`, so `isReady` had nothing to answer.

- **`trackBridgeStartup(promise)` → `BridgeStartup { done, settled }`** — wraps the in-flight `initializeBridge()` promise. Never rejects; a failed startup is a *settled* attempt with no bridge. Attached to the context in both `src/index.ts` startup paths (stdio at step 3b, HTTP before the 6 s banner race — so a bridge still connecting when the banner gives up is still awaited by tool calls).
- **`awaitBridgeReady(context, timeoutMs = READY_TIMEOUT_MS)`** — returns `ready` / `unavailable` / `timeout` / `not-tracked`. Returns immediately when the bridge is already up, when the attempt already settled, or when nothing tracked one, so the warm path costs nothing. `READY_TIMEOUT_MS` is now exported from `bridgeClient.ts` so the gate is bounded by the same budget the child process actually gets (still `BRIDGE_READY_TIMEOUT_MS`-configurable).
- **Dispatcher gate** (`src/tools/toolHandler.ts`) — `BRIDGE_BACKED_TOOLS` are gated on it. The wait is *started* before the existing `dbReady` block and *collected* after, so the two overlap: a cold start costs `max(db, bridge)`, not their sum, and the worst case stays under VS Code's ~60 s client timeout.
- **Message split** — `describeBridgeStartup()` (used by `formInfo`) and `bridgeUnavailableNote()` (used by `tableInfo`, `enumInfo`, `queryInfo`, `viewInfo`, `reportInfo`) now separate *still starting* ("cold-start race, not a configuration problem, and not evidence the object is missing — retry") from *genuinely absent* (the existing "check your config" text, unchanged). `bridgeUnavailableNote` now takes the context rather than `context.bridge`, since the startup state lives beside the bridge; `tableInfo`'s flat message, which had no bridge note at all, now carries one.

No tool-surface change — no new tools, schemas or counts, so nothing in `docs/NEW_TOOL_CHECKLIST.md` applies.

## Acceptance criteria

**"a tool call issued immediately after `tools/list` on a cold server either succeeds or reports a real problem — never 'bridge is not connected' while the bridge is mid-start"**

Met on both halves:
- *Never observes the race* — the dispatcher awaits an in-flight startup before the tool decides anything, so a bridge that comes up within the timeout serves the call normally.
- *Only a real problem is reported* — on a genuine `timeout` the tool still runs (it may resolve the object from the index), and if it does end up empty, `bridgeStartupState()` is still `starting`, so the message says "still starting … retry" rather than "not connected / fix .mcp.json". The old config text is reached only when the attempt has settled with no bridge, or no bridge was ever attempted.

**"regression test: call `get_object_info` within ~100 ms of the handshake on a cold start and assert the result matches a warm call"**

`tests/bridge/bridgeReadiness.test.ts` → *"a call issued right after the handshake matches a warm call"*: drives the real `registerToolHandler` with a context whose bridge only arrives after 120 ms, calls `get_object_info(objectType="table")` immediately (asserting `context.bridge` is still undefined at call time), and asserts the cold result `toEqual` a subsequent warm call. The two calls use different object names so the dispatcher's dedup cache cannot manufacture the match, and the bridge mock is name-independent so byte equality is meaningful. Elapsed time is asserted `>= 120 ms` so the match comes from the wait rather than from luck.

Verified the test fails on the unfixed dispatcher: stashing only `toolHandler.ts` turns it red (`expected true to be falsy` — the cold call returns `isError`).

## Test coverage

`tests/bridge/bridgeReadiness.test.ts` — 17 new tests:

- `trackBridgeStartup` — settles on resolve; a rejected startup settles instead of propagating.
- `bridgeStartupState` — `starting` only while in flight, `unavailable` once settled with no bridge or when nothing was attempted, `ready` when attached.
- `awaitBridgeReady` — no wait when ready / when untracked; waits and picks up the bridge that arrives; `unavailable` on settled-without-bridge; `timeout` (and only `timeout`) on a startup that never finishes.
- Wording — "still starting" text mentions neither `.mcp.json` nor "not connected"; the genuine-absence text keeps both; a healthy bridge produces no note at all.
- Dispatcher — the cold-start acceptance test above, plus a check that a non-bridge tool (`get_knowledge`) is *not* blocked by a startup that never settles.
- Drift guard — walks the static import graph from each tool's entry module and fails if a tool reaching `context.bridge` is missing from `BRIDGE_BACKED_TOOLS` (this is how `labels` was caught during development), and that every listed name is a real tool.

Full suite: **206 files, 2723 passed, 9 skipped**, `npx tsc --noEmit` clean, `npm run build` clean.

## Deliberately not done

- The gate does not *fail* a call on `timeout` — it falls through to the tool. A 30 s-slow bridge is often still answerable from the symbol index, and turning a degraded read into a hard error would be a regression.
- `READY_TIMEOUT_MS` (30 s default) was kept as the bound, per the issue. It is safe here only because the bridge wait overlaps the 55 s `dbReady` wait rather than adding to it; if either bound is raised later, that overlap is the invariant to preserve.

Closes #826

🤖 Generated with [Claude Code](https://claude.com/claude-code)
