### PR TITLE
fix(d365fo_file): apply the corrections modify already prints, instead of erroring

### DIFF
--- a/src/tools/d365foFileOpSpecs.ts
+++ b/src/tools/d365foFileOpSpecs.ts
@@ -87,6 +87,13 @@ export const D365FO_FILE_PARAM_SPECS: Record<string, { type: string; description
       'it writes AxTableFieldEnum + EnumType, no EDT.',
   },
   fieldStringSize: { type: 'string', description: 'String size to set on a string-typed field.' },
+  autoCorrect: {
+    type: 'boolean (default true)',
+    description:
+      'Apply a correction the server has already fully determined — one valid reading only — and report ' +
+      'it as a "Note:" line in the result, instead of failing the call. false = strict: every such case ' +
+      'errors again (deterministic callers, eval harness).',
+  },
   dataField: {
     type: 'string',
     description:
@@ -315,12 +322,13 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
   },
   'add-field': {
     required: ['fieldName'],
-    optional: ['fieldType', 'fieldBaseType', 'fieldEnumType', 'fieldMandatory', 'fieldLabel', 'dataField', 'dataSource', 'fieldGroupName'],
+    optional: ['fieldType', 'fieldBaseType', 'fieldEnumType', 'fieldMandatory', 'fieldLabel', 'dataField', 'dataSource', 'fieldGroupName', 'autoCorrect'],
     mutationOneOf: ['fieldType', 'fieldEnumType', 'dataField'],
     note:
       'Enum field: pass fieldEnumType="<enum name>" and NO fieldType — an enum-typed table field ' +
       'is an AxTableFieldEnum with an EnumType and needs no EDT. (fieldType is the EDT name here, ' +
-      'never an XML element name like "AxTableFieldEnum".) ' +
+      'never an XML element name like "AxTableFieldEnum" — that one is read as fieldEnumType when the ' +
+      'enum is unambiguous, unless autoCorrect=false.) ' +
       'Table/table-extension: otherwise fieldType (EDT) is REQUIRED. data-entity-extension: pass dataField AND ' +
       'dataSource instead — BOTH, or nothing is written; a mapped field has no EDT of its own, it points ' +
       'at dataField on the entity data source dataSource. fieldGroupName is optional and only applies to ' +
@@ -392,7 +400,11 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
   'remove-field-group': { required: ['fieldGroupName'], optional: [] },
   'add-field-to-field-group': {
     required: ['fieldGroupName', 'fieldName'],
-    optional: ['extendBaseFieldGroup'],
+    optional: ['extendBaseFieldGroup', 'autoCorrect'],
+    note:
+      'table-extension: a group owned by the BASE table is detected and extended through ' +
+      '<FieldGroupExtensions> on its own (reported as a Note) — pass extendBaseFieldGroup=true to state ' +
+      'it up front, or autoCorrect=false to have the mismatch error instead.',
   },
   'add-field-modification': {
     required: ['fieldName'],
@@ -443,6 +455,7 @@ export const D365FO_FILE_CORE_PARAMS: ReadonlySet<string> = new Set([
   'filePath', 'workspacePath', 'modelName', 'model', 'packageName', 'packagePath',
   // side options
   'createBackup', 'addToProject', 'projectPath', 'solutionPath', 'groundingToken',
+  'autoCorrect',
 ]);
 
 /**

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -1429,6 +1429,11 @@ const ModifyD365FileArgsSchema = z.object({
   propertyValue: z.string().optional().describe('New property value'),
   
   // Options
+  autoCorrect: z.boolean().optional().default(true).describe(
+    'Apply a correction the server has already fully determined (exactly one valid reading, derivable ' +
+    'from state the server holds) instead of failing the call — reported as a "Note:" line in the result. ' +
+    'Set false for strict behaviour: every such case becomes an error again (eval harness / deterministic callers).'
+  ),
   createBackup: z.boolean().optional().default(false).describe('Create a .bak backup of the file before modifying it (default: false). Changes can also be reverted with undo_last_modification (git checkout) without a backup. When the file is NOT inside a git repository, a backup is created automatically even with false, since undo_last_modification would not work there.'),
   modelName: z.string().optional().describe('Model name (auto-detected if not provided). Pass this if the file was just created and is not yet indexed.'),
   packageName: z.string().optional().describe('Package name. Auto-resolved if omitted.'),
@@ -1595,6 +1600,13 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // This makes add-control seamless — no prior get_object_info(form) call required.
     let addControlNote = '';
     let generationNote = '';
+
+    // Corrections applied instead of a refusal (see AUTO-CORRECT below). Rendered
+    // into the success payload so the agent still learns the right call, and so the
+    // behaviour stays auditable.
+    const autoCorrect = args.autoCorrect !== false;
+    const autoCorrectNotes: string[] = [];
+
     if (operation === 'add-control' && objectType === 'form-extension' && args.parentControl) {
       const resolution = await resolveParentControl(
         objectName,
@@ -1825,6 +1837,11 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       throw new Error(`Operation '${operation}' on object type '${objectType}' is not supported by the bridge.`);
     }
 
+    // The field name as the caller spelled it, before the prefix below rewrites it:
+    // the enum-name derivation in add-field matches against the UNPREFIXED name
+    // (a field named after its enum is prefixed, the enum it names is not).
+    const preprefixFieldName = typeof args.fieldName === 'string' ? args.fieldName : undefined;
+
     // Members added INSIDE an extension must carry the model's prefix — an
     // extension lives in your model but its host object is Microsoft's, so an
     // unprefixed field/index/enum value collides with anything Microsoft or
@@ -2031,7 +2048,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         // (the mapped-field path above has no fieldType at all), so the type-specific half
         // of the contract is enforced here instead of silently falling through to a null
         // bridge result and a generic "required parameters may be missing".
-        const enumTypeArg = ((args as any).fieldEnumType as string | undefined)?.trim() || undefined;
+        let enumTypeArg = ((args as any).fieldEnumType as string | undefined)?.trim() || undefined;
 
         // fieldType is an EDT NAME here. In `create` the sibling key fields[].fieldType is
         // the XML element name ("AxTableFieldEnum"), and that collision gets carried over
@@ -2042,20 +2059,40 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         // whose name happens to read that way, and refusing a valid EDT is the
         // same class of wrong answer this check exists to prevent.
         if (args.fieldType && /^Ax(Table|View|Query|Map|DataEntityView)[A-Za-z]*Field[A-Za-z0-9]*$/i.test(args.fieldType)) {
-          return {
-            content: [{
-              type: 'text',
-              text:
-                `❌ fieldType="${args.fieldType}" is an XML element name, not an EDT — nothing was written.\n` +
-                `On add-field, fieldType is the EDT NAME (e.g. "TransDate", "ItemId"); the XML element is ` +
-                `chosen from fieldBaseType.\n` +
-                `For an enum field pass fieldEnumType="<enum name>" instead — no EDT is needed:\n` +
-                `  d365fo_file(action="modify", objectType="${objectType}", objectName="…", ` +
-                `operation="add-field", fieldName="${args.fieldName ?? 'MyField'}", fieldEnumType="MyEnum")\n` +
-                `\n${renderOpSpec('add-field')}`,
-            }],
-            isError: true,
-          };
+          // ── AUTO-CORRECT ──────────────────────────────────────────────────
+          // The *Enum element is the one member of that family that names its own
+          // fix: it says "this is an enum field", and the enum itself is either in
+          // the same payload (fieldEnumType) or is the field's own name confirmed
+          // as an enum in the symbol index. Both leave exactly ONE valid reading,
+          // so apply it. Every other element name (AxTableFieldString, …) carries
+          // no EDT to derive and still errors.
+          const derivedEnum = autoCorrect
+            ? resolveEnumForFieldElement(args.fieldType, enumTypeArg, [args.fieldName, preprefixFieldName], symbolIndex)
+            : undefined;
+          if (derivedEnum) {
+            noteAutoCorrection(
+              autoCorrectNotes,
+              `fieldType="${args.fieldType}" is an XML element name; treated as fieldEnumType="${derivedEnum}". ` +
+              `Pass fieldEnumType (and no fieldType) for an enum field.`,
+            );
+            enumTypeArg = derivedEnum;
+            args.fieldType = undefined;   // an enum field takes no EDT
+          } else {
+            return {
+              content: [{
+                type: 'text',
+                text:
+                  `❌ fieldType="${args.fieldType}" is an XML element name, not an EDT — nothing was written.\n` +
+                  `On add-field, fieldType is the EDT NAME (e.g. "TransDate", "ItemId"); the XML element is ` +
+                  `chosen from fieldBaseType.\n` +
+                  `For an enum field pass fieldEnumType="<enum name>" instead — no EDT is needed:\n` +
+                  `  d365fo_file(action="modify", objectType="${objectType}", objectName="…", ` +
+                  `operation="add-field", fieldName="${args.fieldName ?? 'MyField'}", fieldEnumType="MyEnum")\n` +
+                  `\n${renderOpSpec('add-field')}`,
+              }],
+              isError: true,
+            };
+          }
         }
 
         if (args.fieldName && !args.fieldType && !enumTypeArg) {
@@ -2423,13 +2460,52 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'add-field-to-field-group': {
         if ((args as any).fieldGroupName && args.fieldName) {
+          const groupName = (args as any).fieldGroupName as string;
+          const extendFlag = (args as any).extendBaseFieldGroup as boolean | undefined;
           bridgeResult = await bridgeAddFieldToFieldGroup(
             context.bridge,
             objectName,
-            (args as any).fieldGroupName,
+            groupName,
             args.fieldName,
-            (args as any).extendBaseFieldGroup,
+            extendFlag,
           );
+
+          // ── AUTO-CORRECT ────────────────────────────────────────────────────
+          // The bridge refuses with a message that states its own fix: the group is
+          // absent from the extension's own <FieldGroups>, so if the BASE table
+          // defines it, <FieldGroupExtensions> is the only place the field can go.
+          // Confirm that against the base table's XML before acting — the bridge
+          // does not check it, and creating a FieldGroupExtension for a group that
+          // exists nowhere would write metadata no form ever reads.
+          // Only when the caller left extendBaseFieldGroup unset: an explicit
+          // false is a decision, not an omission.
+          if (
+            autoCorrect &&
+            extendFlag === undefined &&
+            objectType === 'table-extension' &&
+            bridgeResult && !bridgeResult.success &&
+            isBaseFieldGroupMissError(bridgeResult.message)
+          ) {
+            const baseTable = objectName.split('.')[0];
+            if (await baseObjectDefinesFieldGroup(baseTable, groupName, symbolIndex)) {
+              const retried = await bridgeAddFieldToFieldGroup(
+                context.bridge,
+                objectName,
+                groupName,
+                args.fieldName,
+                true,
+              );
+              if (retried?.success) {
+                bridgeResult = retried;
+                noteAutoCorrection(
+                  autoCorrectNotes,
+                  `'${groupName}' is defined by the base table "${baseTable}"; extended it through ` +
+                  `<FieldGroupExtensions> instead of creating a new group. ` +
+                  `Pass extendBaseFieldGroup=true for a base-table group.`,
+                );
+              }
+            }
+          }
         }
         break;
       }
@@ -2847,12 +2923,19 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       addFieldBpNote = `\n\n${notes.join('\n')}`;
     }
 
+    // Corrections the server applied on its own. Kept in the payload so the agent
+    // learns the correct form for next time and the write stays auditable.
+    const autoCorrectNote = autoCorrectNotes.length > 0
+      ? `\n\n${autoCorrectNotes.map(n => `📝 Note: ${n}`).join('\n')}\n` +
+        `(Pass autoCorrect=false to have corrections like this raise an error instead.)`
+      : '';
+
     return {
       content: [
         {
           type: 'text',
           text:
-            `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()\n\n` +
+            `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()${autoCorrectNote}\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
             `🔧 API: ${bridgeResult.message}${xppLintNote}${addFieldBpNote}${backupNote}` +
             (ignoredParamsWarning ? `\n\n${ignoredParamsWarning}` : '') + `\n\n` +
@@ -3422,6 +3505,20 @@ function allControlsFromFormXmlObj(xmlObj: any): ResolvedControl[] {
  * Returns raw XML content, or null if not accessible.
  */
 export async function findBaseFormXml(baseFormName: string, symbolIndex: any): Promise<string | null> {
+  return findBaseObjectXml('form', baseFormName, symbolIndex);
+}
+
+/**
+ * Locate the XML of a base (non-extension) object on disk, trying DB path →
+ * remapped path → filesystem scan. `objectType` is both the symbols-table type
+ * and the findD365FileOnDisk key ('form', 'table', …).
+ * Returns raw XML content, or null if not accessible.
+ */
+export async function findBaseObjectXml(
+  objectType: string,
+  objectName: string,
+  symbolIndex: any,
+): Promise<string | null> {
   // Helper: read a file, transparently following JSON metadata proxies.
   async function tryRead(p: string): Promise<string | null> {
     try {
@@ -3442,8 +3539,8 @@ export async function findBaseFormXml(baseFormName: string, symbolIndex: any): P
   try {
     const rdb = symbolIndex.getReadDb();
     const row = rdb.prepare(
-      `SELECT file_path FROM symbols WHERE type = 'form' AND name = ? LIMIT 1`
-    ).get(baseFormName) as any;
+      `SELECT file_path FROM symbols WHERE type = ? AND name = ? LIMIT 1`
+    ).get(objectType, objectName) as any;
     if (row?.file_path) dbFilePath = row.file_path;
   } catch { /* ignore */ }
 
@@ -3470,10 +3567,72 @@ export async function findBaseFormXml(baseFormName: string, symbolIndex: any): P
   }
 
   // 2. Filesystem scan using model from config
-  const diskPath = await findD365FileOnDisk('form', baseFormName);
+  const diskPath = await findD365FileOnDisk(objectType, objectName);
   if (diskPath) return tryRead(diskPath);
 
   return null;
+}
+
+// ── Auto-correction helpers ────────────────────────────────────────────────
+// A correction is applied ONLY where the failure has exactly one valid reading
+// that the server can derive from state it already holds. Everything else keeps
+// erroring — a wrong write costs far more than the retry round trip this saves.
+
+/** Record a correction, ignoring a repeat from the bridge auto-refresh retry. */
+function noteAutoCorrection(notes: string[], note: string): void {
+  if (!notes.includes(note)) notes.push(note);
+}
+
+/**
+ * add-field was given an XML element name as fieldType. For the *Enum element
+ * — and only that one — the intent is unambiguous ("this field is enum-typed"),
+ * so the enum name is all that is missing. It comes from the payload itself
+ * (fieldEnumType), or from the field name when the symbol index confirms an enum
+ * of exactly that name. Anything else returns undefined and the call still fails.
+ */
+function resolveEnumForFieldElement(
+  fieldTypeElement: string,
+  explicitEnumType: string | undefined,
+  fieldNameCandidates: readonly (string | undefined)[],
+  symbolIndex: any,
+): string | undefined {
+  if (!/Enum$/i.test(fieldTypeElement)) return undefined;
+  if (explicitEnumType) return explicitEnumType;
+
+  for (const candidate of fieldNameCandidates) {
+    if (!candidate) continue;
+    try {
+      const row = symbolIndex.getReadDb().prepare(
+        `SELECT name FROM symbols WHERE type = 'enum' AND name = ? COLLATE NOCASE LIMIT 1`
+      ).get(candidate) as { name?: string } | undefined;
+      // Use the INDEXED spelling — the caller's casing may differ from the AOT name.
+      if (row?.name) return row.name;
+    } catch { /* index unavailable — no derivation, keep erroring */ }
+  }
+  return undefined;
+}
+
+/** The bridge's add-field-to-field-group refusal that names extendBaseFieldGroup as its fix. */
+function isBaseFieldGroupMissError(message: string | undefined): boolean {
+  if (!message) return false;
+  return /field group .* not found on table-extension/i.test(message)
+    && /extendBaseFieldGroup=true/i.test(message);
+}
+
+/** True when the base table's own <FieldGroups> defines `groupName`. */
+async function baseObjectDefinesFieldGroup(
+  baseTableName: string,
+  groupName: string,
+  symbolIndex: any,
+): Promise<boolean> {
+  const xml = await findBaseObjectXml('table', baseTableName, symbolIndex);
+  if (!xml) return false;
+  // <Name> is the first child of every <AxTableFieldGroup>, so a non-greedy hop
+  // from the opening tag to the first Name reads one group name per block.
+  for (const m of xml.matchAll(/<AxTableFieldGroup>[\s\S]*?<Name>([^<]+)<\/Name>/g)) {
+    if (m[1].trim().toLowerCase() === groupName.trim().toLowerCase()) return true;
+  }
+  return false;
 }
 
 /**

--- a/tests/tools/autoCorrectRecoverable.test.ts
+++ b/tests/tools/autoCorrectRecoverable.test.ts
@@ -1,0 +1,379 @@
+/**
+ * d365fo_file [modify] — failures that state their own fix are applied, not returned.
+ *
+ * From the session audit (#824/#827): two add-field/field-group calls failed with an
+ * error message that spelled out the exact corrected call, the agent re-issued that
+ * call verbatim, and it succeeded. The round trip was pure cost — the server had
+ * already reached the conclusion it refused to act on.
+ *
+ * The rule these tests pin: a correction is applied ONLY when there is exactly one
+ * valid reading derivable from state the server already holds (the payload, the
+ * symbol index, the base object's XML). Anything ambiguous still errors, and
+ * autoCorrect=false restores the strict behaviour the eval harness depends on.
+ *
+ * The `Note:` wording is asserted verbatim — it is what the agent reads to learn
+ * the correct form, so it must not drift silently.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool } from '../../src/tools/modifyD365File';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const {
+  mockBridgeAddField,
+  mockBridgeModifyField,
+  mockBridgeRemoveField,
+  mockBridgeAddFieldToFieldGroup,
+  mockBridgeRefreshProvider,
+} = vi.hoisted(() => ({
+  mockBridgeAddField: vi.fn(async () => ({ success: true, message: '✅ Field added' })),
+  mockBridgeModifyField: vi.fn(async () => ({ success: true, message: '✅ Field modified' })),
+  mockBridgeRemoveField: vi.fn(async () => ({ success: true, message: '✅ Field removed' })),
+  mockBridgeAddFieldToFieldGroup: vi.fn(async () => ({ success: true, message: '✅ Field added to group' })),
+  mockBridgeRefreshProvider: vi.fn(async () => ({ success: true, elapsedMs: 1 })),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return {
+    ...actual,
+    bridgeAddField: mockBridgeAddField,
+    bridgeModifyField: mockBridgeModifyField,
+    bridgeRemoveField: mockBridgeRemoveField,
+    bridgeAddFieldToFieldGroup: mockBridgeAddFieldToFieldGroup,
+    bridgeRefreshProvider: mockBridgeRefreshProvider,
+    bridgeValidateAfterWrite: vi.fn(async () => null),
+  };
+});
+
+const BASE_TABLE_XML =
+  `<?xml version="1.0" encoding="utf-8"?>\n<AxTable><Name>ConRentalAgreement</Name>` +
+  `<FieldGroups>` +
+  `<AxTableFieldGroup><Name>Administration</Name><Fields><AxTableFieldGroupField><DataField>CreatedBy</DataField></AxTableFieldGroupField></Fields></AxTableFieldGroup>` +
+  `<AxTableFieldGroup><Name>AutoReport</Name><Fields /></AxTableFieldGroup>` +
+  `</FieldGroups></AxTable>`;
+
+const BASE_TABLE_PATH =
+  'K:\\PackagesLocalDirectory\\AppSuite\\AppSuite\\AxTable\\ConRentalAgreement.xml';
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (typeof p === 'string' && p.endsWith('ConRentalAgreement.xml')) return BASE_TABLE_XML;
+    if (typeof p === 'string' && p.endsWith('.xml')) {
+      return `<?xml version="1.0" encoding="utf-8"?>\n<AxTableExtension><Name>ConRentalAgreement.ConExtension</Name><Fields /></AxTableExtension>`;
+    }
+    if (typeof p === 'string' && p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+  copyFile: vi.fn(async () => {}),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getWriteAnchorModel: vi.fn(() => 'MyModel'),
+    getToolProjectSwitch: vi.fn(() => null),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (m: string) => ({
+      packageName: m, modelName: m, rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({
+      packageName: p, modelName: m, rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  // Members added to an extension are prefixed — the enum-name derivation has to
+  // see through that (the field carries the prefix, the enum it names does not).
+  resolveRegularObjectPrefixToken: vi.fn(() => 'Con'),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+const EXT_PATH =
+  'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTableExtension\\ConRentalAgreement.ConExtension.xml';
+const TABLE_PATH =
+  'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\ConChangeLog.xml';
+
+/**
+ * Symbol index stub: `indexedEnums` are the enum names the index knows, and the
+ * base table resolves to a file the fs mock can read.
+ */
+const buildContext = (indexedEnums: string[] = []): XppServerContext => {
+  const prepare = vi.fn((sql: string) => ({
+    all: vi.fn(() => []),
+    run: vi.fn(),
+    get: vi.fn((...params: any[]) => {
+      if (/FROM symbols WHERE type = 'enum'/.test(sql)) {
+        const wanted = String(params[0] ?? '').toLowerCase();
+        const hit = indexedEnums.find(e => e.toLowerCase() === wanted);
+        return hit ? { name: hit } : undefined;
+      }
+      if (/SELECT file_path FROM symbols WHERE type = \?/.test(sql)) {
+        return params[0] === 'table' && params[1] === 'ConRentalAgreement'
+          ? { file_path: BASE_TABLE_PATH }
+          : undefined;
+      }
+      return undefined;
+    }),
+  }));
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {}),
+      generateSearchKey: vi.fn((q: string) => `k:${q}`),
+    } as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    bridge: { isReady: true, metadataAvailable: true } as any,
+  };
+};
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'modify_d365fo_file', arguments: args },
+});
+
+const addFieldReq = (params: Record<string, unknown>) =>
+  req({
+    objectType: 'table',
+    objectName: 'ConChangeLog',
+    operation: 'add-field',
+    filePath: TABLE_PATH,
+    fieldName: 'ConQualityTier',
+    ...params,
+  });
+
+const addToGroupReq = (params: Record<string, unknown>) =>
+  req({
+    objectType: 'table-extension',
+    objectName: 'ConRentalAgreement.ConExtension',
+    operation: 'add-field-to-field-group',
+    filePath: EXT_PATH,
+    fieldGroupName: 'Administration',
+    fieldName: 'ConQualityTier',
+    ...params,
+  });
+
+const GROUP_MISS_MESSAGE =
+  `Bridge error [-32603]: Error in addFieldToFieldGroup: Field group 'Administration' not found on ` +
+  `table-extension 'ConRentalAgreement.ConExtension'. If it is a group defined by the BASE table, pass ` +
+  `extendBaseFieldGroup=true to append the field through <FieldGroupExtensions> instead.`;
+
+const textOf = (result: any): string => (result.content?.[0] as any)?.text ?? '';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBridgeAddField.mockResolvedValue({ success: true, message: '✅ Field added' });
+  mockBridgeModifyField.mockResolvedValue({ success: true, message: '✅ Field modified' });
+  mockBridgeRemoveField.mockResolvedValue({ success: true, message: '✅ Field removed' });
+  mockBridgeAddFieldToFieldGroup.mockResolvedValue({ success: true, message: '✅ Field added to group' });
+});
+
+describe('add-field — fieldType="AxTableFieldEnum" is read as fieldEnumType when the enum is certain', () => {
+  it('applies the call when the enum name is in the same payload', async () => {
+    const result = await modifyD365FileTool(
+      addFieldReq({ fieldType: 'AxTableFieldEnum', fieldEnumType: 'ConQualityTier' }),
+      buildContext(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    const [, , fieldName, baseType, edt] = mockBridgeAddField.mock.calls[0] as any[];
+    expect(fieldName).toBe('ConQualityTier');
+    expect(baseType).toBe('Enum');
+    expect(edt).toBeUndefined();          // the element name must NOT become an EDT
+    expect(mockBridgeModifyField).toHaveBeenCalledWith(
+      expect.anything(), 'ConChangeLog', 'ConQualityTier', { enumType: 'ConQualityTier' },
+    );
+
+    expect(textOf(result)).toContain(
+      'Note: fieldType="AxTableFieldEnum" is an XML element name; treated as fieldEnumType="ConQualityTier". ' +
+      'Pass fieldEnumType (and no fieldType) for an enum field.',
+    );
+    expect(textOf(result)).toContain('autoCorrect=false');
+  });
+
+  it('derives the enum from the field name when the symbol index confirms one', async () => {
+    const result = await modifyD365FileTool(
+      addFieldReq({ fieldType: 'AxTableFieldEnum' }),
+      buildContext(['ConQualityTier']),
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(mockBridgeModifyField).toHaveBeenCalledWith(
+      expect.anything(), 'ConChangeLog', 'ConQualityTier', { enumType: 'ConQualityTier' },
+    );
+    expect(textOf(result)).toContain('treated as fieldEnumType="ConQualityTier"');
+  });
+
+  it('uses the enum spelling from the index, not the caller\'s casing', async () => {
+    const result = await modifyD365FileTool(
+      addFieldReq({ fieldName: 'conqualitytier', fieldType: 'AxTableFieldEnum' }),
+      buildContext(['ConQualityTier']),
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(textOf(result)).toContain('treated as fieldEnumType="ConQualityTier"');
+  });
+
+  it('sees through the extension member prefix applied to the field name', async () => {
+    // The caller asks for field "QualityTier" on a table-extension; the tool renames
+    // it to "ConQualityTier" before the write. The enum is still "QualityTier".
+    const result = await modifyD365FileTool(
+      req({
+        objectType: 'table-extension',
+        objectName: 'ConRentalAgreement.ConExtension',
+        operation: 'add-field',
+        filePath: EXT_PATH,
+        fieldName: 'QualityTier',
+        fieldType: 'AxTableFieldEnum',
+      }),
+      buildContext(['QualityTier']),
+    );
+
+    expect(result.isError).toBeFalsy();
+    const [, , fieldName] = mockBridgeAddField.mock.calls[0] as any[];
+    expect(fieldName).toBe('ConQualityTier');       // prefix still applied to the field
+    expect(textOf(result)).toContain('treated as fieldEnumType="QualityTier"');
+  });
+
+  it('still refuses when no enum can be derived', async () => {
+    const result = await modifyD365FileTool(
+      addFieldReq({ fieldType: 'AxTableFieldEnum' }),
+      buildContext(),                                // index knows no such enum
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('is an XML element name, not an EDT');
+    expect(mockBridgeAddField).not.toHaveBeenCalled();
+  });
+
+  it('still refuses the other AxTableField* element names, enum name or not', async () => {
+    for (const bad of ['AxTableFieldString', 'AxTableFieldReal', 'AxTableFieldInt64']) {
+      const result = await modifyD365FileTool(
+        addFieldReq({ fieldType: bad, fieldEnumType: 'ConQualityTier' }),
+        buildContext(['ConQualityTier']),
+      );
+      expect(result.isError, bad).toBe(true);
+    }
+    expect(mockBridgeAddField).not.toHaveBeenCalled();
+  });
+
+  it('autoCorrect=false reproduces the strict refusal', async () => {
+    const result = await modifyD365FileTool(
+      addFieldReq({ fieldType: 'AxTableFieldEnum', fieldEnumType: 'ConQualityTier', autoCorrect: false }),
+      buildContext(['ConQualityTier']),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('is an XML element name, not an EDT');
+    expect(mockBridgeAddField).not.toHaveBeenCalled();
+  });
+});
+
+describe('add-field-to-field-group — a base-table group is extended, not refused', () => {
+  it('retries through <FieldGroupExtensions> when the base table defines the group', async () => {
+    mockBridgeAddFieldToFieldGroup
+      .mockResolvedValueOnce({ success: false, message: GROUP_MISS_MESSAGE })
+      .mockResolvedValueOnce({ success: true, message: "✅ Field 'ConQualityTier' added to group 'Administration' in <FieldGroupExtensions>" });
+
+    const result = await modifyD365FileTool(addToGroupReq({}), buildContext());
+
+    expect(result.isError).toBeFalsy();
+    expect(mockBridgeAddFieldToFieldGroup).toHaveBeenCalledTimes(2);
+    const secondCall = mockBridgeAddFieldToFieldGroup.mock.calls[1] as any[];
+    expect(secondCall[4]).toBe(true);               // extendBaseFieldGroup
+
+    expect(textOf(result)).toContain(
+      `Note: 'Administration' is defined by the base table "ConRentalAgreement"; extended it through ` +
+      `<FieldGroupExtensions> instead of creating a new group. ` +
+      `Pass extendBaseFieldGroup=true for a base-table group.`,
+    );
+  });
+
+  it('does not retry when the base table has no such group', async () => {
+    mockBridgeAddFieldToFieldGroup.mockResolvedValue({
+      success: false,
+      message: GROUP_MISS_MESSAGE.replace(/Administration/g, 'Nonexistent'),
+    });
+
+    const result = await modifyD365FileTool(
+      addToGroupReq({ fieldGroupName: 'Nonexistent' }),
+      buildContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(mockBridgeAddFieldToFieldGroup).toHaveBeenCalledTimes(1);
+    expect(textOf(result)).toContain('extendBaseFieldGroup=true');   // the bridge's own guidance
+  });
+
+  it('leaves an explicit extendBaseFieldGroup=false alone — that is a decision, not an omission', async () => {
+    mockBridgeAddFieldToFieldGroup.mockResolvedValue({ success: false, message: GROUP_MISS_MESSAGE });
+
+    const result = await modifyD365FileTool(
+      addToGroupReq({ extendBaseFieldGroup: false }),
+      buildContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(mockBridgeAddFieldToFieldGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it('autoCorrect=false reproduces the strict failure', async () => {
+    mockBridgeAddFieldToFieldGroup.mockResolvedValue({ success: false, message: GROUP_MISS_MESSAGE });
+
+    const result = await modifyD365FileTool(
+      addToGroupReq({ autoCorrect: false }),
+      buildContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(mockBridgeAddFieldToFieldGroup).toHaveBeenCalledTimes(1);
+    expect(textOf(result)).toContain("Field group 'Administration' not found");
+  });
+
+  it('adds no note when the first call already succeeds', async () => {
+    const result = await modifyD365FileTool(
+      addToGroupReq({ extendBaseFieldGroup: true }),
+      buildContext(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(mockBridgeAddFieldToFieldGroup).toHaveBeenCalledTimes(1);
+    expect(textOf(result)).not.toContain('Note:');
+  });
+});


### PR DESCRIPTION
Two `d365fo_file(action="modify")` failures returned an error message that stated the exact corrected call. The agent re-issued that call verbatim and it succeeded. The server had already reached the conclusion it refused to act on.

Both now apply the correction and report it with a `Note:` line in the success payload — the agent still learns the correct form, and the write stays auditable.

## What changed

**`src/tools/modifyD365File.ts`**

- `add-field` with `fieldType="AxTableFieldEnum"` — the `*Enum` element is the one member of that family that states its own fix ("this field is enum-typed"); only the enum name is missing. It is taken from `fieldEnumType` in the same payload, or from the field name when the symbol index confirms an enum of exactly that name (the pre-prefix spelling is tried too, since extension members get prefixed and the enum they name does not). Every other `AxTableField*` element name carries no derivable EDT and **still errors**.
- `add-field-to-field-group` on a `table-extension` where the bridge reports the group missing and names `extendBaseFieldGroup=true` as the fix — retried through `<FieldGroupExtensions>`, but only after confirming the BASE table's own `<FieldGroups>` actually defines the group. The bridge does not check that, and a `FieldGroupExtension` for a group that exists nowhere would be metadata no form ever reads. An explicit `extendBaseFieldGroup=false` is left alone — that is a decision, not an omission.
- `findBaseFormXml` generalised to `findBaseObjectXml(objectType, …)` (form path unchanged) so the base **table** XML can be read for that confirmation.
- New helpers: `noteAutoCorrection` (de-dupes across the bridge auto-refresh retry), `resolveEnumForFieldElement`, `isBaseFieldGroupMissError`, `baseObjectDefinesFieldGroup`.

**`src/tools/d365foFileOpSpecs.ts`** — `autoCorrect` added to `D365FO_FILE_CORE_PARAMS` + `D365FO_FILE_PARAM_SPECS`, listed as optional on both affected ops, and both op notes updated. No wire-schema property was added, so the ListTools token budget is untouched (`toolSchemaBudget` green).

## Acceptance criteria

| Criterion | How it is met |
| --- | --- |
| both cases succeed on the first call, with a note in the result | Case 1 and case 2 above; notes rendered under the `✅ … applied` header as `📝 Note: …` plus one line naming `autoCorrect=false` |
| the note text is asserted in tests so the agent-facing wording stays stable | Both note strings are asserted verbatim in `tests/tools/autoCorrectRecoverable.test.ts` |
| `autoCorrect: false` reproduces today's strict behaviour | One test per case asserts the error comes back and that no write (case 1) / no retry (case 2) happens |

## The sweep

Grepped `src/tools/d365foFile.ts`, `src/tools/modifyD365File.ts`, `src/bridge/` (and the C# write service the bridge messages come from) for error strings containing "pass ", "instead", "use ".

Corrected here: the two above.

Judged **not** safe to auto-correct, and left erroring:

- "You pasted a slice of the .xml file. Pass ONLY the X++ code" — which part is the X++ is a judgement call; stripping risks writing mangled source.
- "was called with no parameter that changes anything — Pass at least one of …" — nothing to derive; no value was supplied at all.
- Standard-model write refusal ("create an extension instead") — a safety guard; it must never create an object the user did not ask for.
- `replace-code` called with `sourceCode`/`methodCode` — `sourceCode` is a whole method, `oldCode` is a snippet; the only reading that works changes the operation.
- `add-field` on a `data-entity-extension` missing one of `dataField`/`dataSource` — an entity has many data sources; the missing half is not determined.
- Bridge "Parent control 'X' not found … pass parentControl=\"Design\"" — fuzzy `parentControl` is already auto-resolved upstream, and falling back to `Design` would silently move the control somewhere the caller did not ask for.
- Bridge "Unsupported menu item type … Use 'display', 'action', or 'output'" — three candidates, ambiguous.
- Bridge "TableGroup values … Pass them via the tableType parameter instead" — would write a different property than the caller named, and the fix belongs in the C# bridge (needs a rebuild/redeploy), not here.
- Bridge "use XML fallback" messages — internal capability signals; the TS side already falls back where a fallback exists.

`src/bridge/bridgeAdapter.ts` has no self-fixing error strings of its own — it passes the C# messages through.

## Tests

- New `tests/tools/autoCorrectRecoverable.test.ts` — 12 tests: payload-derived enum, index-derived enum, index casing wins, derivation through the extension member prefix, no-derivation still refuses, other `AxTableField*` names still refuse, `autoCorrect=false` strict; base-group retry + note, no retry when the base table lacks the group, explicit `extendBaseFieldGroup=false` untouched, `autoCorrect=false` strict, no note on a plain success.
- Full suite: **206 files, 2718 passed, 9 skipped**. `npx tsc --noEmit` clean.

## Deliberately not done

The eval harness is not switched to `autoCorrect: false` — the escape hatch exists, but flipping the harness would change existing runs/goldens and belongs to the eval loop, not this fix.

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)
