### PR TITLE
feat(bp-check): batch objects[] form and no silent class default

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -116,7 +116,7 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 |------|--------------|----------------|
 | `build_d365fo_project` | MSBuild compilation with structured xppc diagnostics (severity, object, line, fix hints for the first errors) | *"Build the project and show the errors"* |
 | `trigger_db_sync` | Database sync for the current model | *"Sync the database"* |
-| `run_bp_check` | Microsoft Best Practices (xppbp.exe) analysis | *"Run a BP check on my model"* |
+| `run_bp_check` | Microsoft Best Practices (xppbp.exe) analysis — `objects: [{objectType, objectName}]` checks several objects in one call (shared preamble once, findings grouped per object) | *"Run a BP check on my model"* · *"BP check the table, its extension class and the enum"* |
 | `run_systest_class` | Execute SysTest unit tests via SysTestConsole.exe (requires an interactive console session) | *"Run the MyServiceTest class"* |
 | `update_symbol_index` | Re-index a single changed file without restart | *"Refresh the index for the table I just created"* |
 

--- a/src/server/toolSchemas/runBpCheck.ts
+++ b/src/server/toolSchemas/runBpCheck.ts
@@ -10,9 +10,21 @@ export const runBpCheckTool = {
     inputSchema: {
       type: 'object',
       properties: {
+        objects: {
+          type: 'array',
+          description: 'Check several objects in ONE call — preferred over targetFilter. Shared preamble is printed once and findings are grouped per object.',
+          items: {
+            type: 'object',
+            properties: {
+              objectType: { type: 'string', description: 'class, table, form, enum, view, query, edt, ... Looked up in the symbol index if omitted.' },
+              objectName: { type: 'string', description: 'Object name.' },
+            },
+            required: ['objectName'],
+          },
+        },
         projectPath: { type: 'string', description: 'Absolute path to the .rnrproj file to analyze. Auto-detected from .mcp.json if omitted.' },
-        targetFilter: { type: 'string', description: 'Optional: filter results to a specific object name (class, table, form, enum, ...).' },
-        targetElementType: { type: 'string', description: 'Element type for the filter when using xppbp 10.0.24+ (equals-style CLI). Common values: class, table, form, enum, view, query. Defaults to "class" when targetFilter is set but this is omitted.' },
+        targetFilter: { type: 'string', description: 'Single-object form: object name to check. Use objects[] for more than one.' },
+        targetElementType: { type: 'string', description: 'Element type for targetFilter. Looked up in the symbol index if omitted; ambiguous or unknown names error rather than being assumed to be a class.' },
         modelName: { type: 'string', description: 'Model name to check. Auto-detected from .mcp.json if omitted.' },
         packagePath: { type: 'string', description: 'PackagesLocalDirectory root path. Auto-detected from .mcp.json if omitted.' },
       },

--- a/src/tools/runBpCheck.ts
+++ b/src/tools/runBpCheck.ts
@@ -5,6 +5,7 @@ import fs from 'fs/promises';
 import { getConfigManager } from '../utils/configManager.js';
 import { defaultPackagesRoot, findPackagesRoot } from '../utils/packagesRoot.js';
 import { withOperationLock } from '../utils/operationLocks.js';
+import { lookupSymbolsNocase, type DbLike } from '../utils/symbolLookup.js';
 import { compileModelLabels } from './compileLabels.js';
 
 const execFileAsync = util.promisify(execFile);
@@ -14,6 +15,38 @@ const execFileAsync = util.promisify(execFile);
 
 // Keyword that xppbp.exe prints when it doesn't recognise the arguments
 const HELP_TEXT_PATTERN = /^usage:|BPCheck Tool|^xppbp\.exe|unrecognized|missing required|X\+\+ Best Practice Options/im;
+
+// Lines that carry an actual finding — never folded into the shared preamble.
+const FINDING_LINE_PATTERN = /BPError|BPWarning|<Diagnostic|BestPractices (Warning|Error):/i;
+
+/**
+ * Symbol-index type → xppbp element-type token, used when the caller omits the
+ * type (#828). A class extension is an AxClass file carrying [ExtensionOf], so
+ * it checks as `class`; the remaining Ax*Extension kinds use the concatenated
+ * AOT spelling. Index types with no xppbp equivalent are deliberately absent —
+ * an unmapped name errors instead of being guessed at.
+ */
+const INDEX_TYPE_TO_ELEMENT_TYPE: Record<string, string> = {
+  class:             'class',
+  'class-extension': 'class',
+  table:             'table',
+  'table-extension': 'tableextension',
+  form:              'form',
+  'form-extension':  'formextension',
+  enum:              'enum',
+  'enum-extension':  'enumextension',
+  edt:               'edt',
+  'edt-extension':   'edtextension',
+  view:              'view',
+  query:             'query',
+  map:               'map',
+  report:            'report',
+  menu:              'menu',
+  service:           'service',
+  macro:             'macro',
+};
+
+const RESOLVABLE_INDEX_TYPES = Object.keys(INDEX_TYPE_TO_ELEMENT_TYPE);
 
 // Tool registration (name, description, inputSchema) lives inline in
 // src/server/mcpServer.ts - the single source of truth for tool instructions.
@@ -61,9 +94,128 @@ export function describeScope(targetFilter: string, output: string): string {
   );
 }
 
-export const runBpCheckTool = async (params: any, _context: any) => {
-  const { targetFilter, targetElementType } = params;
+/** One object as the caller asked for it — the type may still be missing. */
+export interface RequestedTarget {
+  name: string;
+  /** Explicit element type, when the caller supplied one. */
+  type?: string;
+}
+
+/**
+ * Normalize the two accepted call shapes into one list: the batch form
+ * `objects: [{objectType, objectName}]` (mirrors verify_d365fo_project) and the
+ * original single-target `targetElementType` + `targetFilter`. A bare string is
+ * accepted wherever an object entry is — `objects: "MyClass"` and
+ * `objects: ["MyClass"]` both mean a one-element list.
+ */
+export function normalizeTargets(params: any): RequestedTarget[] {
+  const raw = Array.isArray(params?.objects)
+    ? params.objects
+    : params?.objects
+    ? [params.objects]
+    : [];
+
+  const targets: RequestedTarget[] = [];
+  for (const entry of raw) {
+    if (typeof entry === 'string') {
+      if (entry.trim()) targets.push({ name: entry.trim() });
+    } else if (entry && typeof entry === 'object' && typeof entry.objectName === 'string' && entry.objectName.trim()) {
+      const type = typeof entry.objectType === 'string' && entry.objectType.trim()
+        ? entry.objectType.trim()
+        : undefined;
+      targets.push({ name: entry.objectName.trim(), type });
+    }
+  }
+
+  if (targets.length === 0 && typeof params?.targetFilter === 'string' && params.targetFilter.trim()) {
+    const type = typeof params?.targetElementType === 'string' && params.targetElementType.trim()
+      ? params.targetElementType.trim()
+      : undefined;
+    targets.push({ name: params.targetFilter.trim(), type });
+  }
+  return targets;
+}
+
+/**
+ * Element type for a name the caller did not type, looked up in the symbol
+ * index. `run_bp_check` used to fall back to `class`, which silently checked
+ * the wrong element kind and cost a round trip (#828) — an ambiguous or
+ * unknown name now errors instead.
+ */
+export function resolveElementType(
+  name: string,
+  db: DbLike | undefined,
+): { elementType?: string; error?: string } {
+  if (!db) {
+    return {
+      error:
+        `Cannot determine the element type of "${name}" — the symbol index is not available here.\n` +
+        `Pass the type explicitly, e.g. { objects: [{ objectType: "table", objectName: "${name}" }] }.`,
+    };
+  }
+
+  let hits: Array<{ type: string }> = [];
   try {
+    hits = lookupSymbolsNocase(db, name, { types: RESOLVABLE_INDEX_TYPES, limit: 5 });
+  } catch {
+    /* index unusable — treated the same as "not found" below */
+  }
+
+  const elementTypes = [...new Set(hits.map(h => INDEX_TYPE_TO_ELEMENT_TYPE[h.type]).filter(Boolean))];
+  if (elementTypes.length === 1) return { elementType: elementTypes[0] };
+
+  if (elementTypes.length > 1) {
+    return {
+      error:
+        `"${name}" is ambiguous — the index has it as ${elementTypes.join(' and ')}.\n` +
+        `Say which one, e.g. { objects: [{ objectType: "${elementTypes[0]}", objectName: "${name}" }] }.`,
+    };
+  }
+  return {
+    error:
+      `Cannot determine the element type of "${name}" — no object of a checkable type is indexed under that name.\n` +
+      `Pass the type explicitly, e.g. { objects: [{ objectType: "table", objectName: "${name}" }] }, ` +
+      `or run update_symbol_index if the object is new.`,
+  };
+}
+
+/**
+ * Split the preamble xppbp repeats on every invocation (banner, memory counter,
+ * enabled-rules list) off the front of a batch's outputs, so it can be printed
+ * once instead of once per object (#828). Lines are compared with digits
+ * masked, because the memory counter differs by a megabyte between runs.
+ * A single output has nothing to share and is returned untouched.
+ */
+export function splitSharedPreamble(outputs: string[]): { preamble: string[]; bodies: string[][] } {
+  const lineSets = outputs.map(o => o.split(/\r?\n/));
+  if (lineSets.length < 2) return { preamble: [], bodies: lineSets };
+
+  const shape = (line: string) => line.replace(/\d+/g, '#').trimEnd();
+  const preamble: string[] = [];
+  let i = 0;
+  scan: while (true) {
+    const first = lineSets[0][i];
+    if (first === undefined || FINDING_LINE_PATTERN.test(first)) break;
+    const key = shape(first);
+    for (const lines of lineSets) {
+      if (lines[i] === undefined || shape(lines[i]) !== key) break scan;
+    }
+    preamble.push(first);
+    i++;
+  }
+  return { preamble, bodies: lineSets.map(lines => lines.slice(i)) };
+}
+
+export const runBpCheckTool = async (params: any, context: any) => {
+  try {
+    const requested = normalizeTargets(params);
+    if (params?.objects !== undefined && requested.length === 0) {
+      return {
+        content: [{ type: 'text', text: '❌ `objects` was supplied but contained no usable entry.\n\nEach entry needs an `objectName`, e.g. { objects: [{ objectType: "table", objectName: "MyTable" }] }.' }],
+        isError: true
+      };
+    }
+
     const configManager = getConfigManager();
     await configManager.ensureLoaded();
 
@@ -118,6 +270,32 @@ export const runBpCheckTool = async (params: any, _context: any) => {
       };
     }
 
+    // Every requested object needs a concrete element type before anything runs —
+    // a partially resolvable batch is reported as one error, not half-checked.
+    let db: DbLike | undefined;
+    try {
+      db = context?.symbolIndex?.getReadDb?.();
+    } catch {
+      /* index unavailable — resolveElementType says so instead of guessing */
+    }
+    const targets: Array<{ name: string; elementType: string }> = [];
+    const resolveErrors: string[] = [];
+    for (const t of requested) {
+      if (t.type) {
+        targets.push({ name: t.name, elementType: t.type.toLowerCase() });
+        continue;
+      }
+      const { elementType, error } = resolveElementType(t.name, db);
+      if (elementType) targets.push({ name: t.name, elementType });
+      else resolveErrors.push(error!);
+    }
+    if (resolveErrors.length > 0) {
+      return {
+        content: [{ type: 'text', text: `❌ ${resolveErrors.join('\n\n')}` }],
+        isError: true
+      };
+    }
+
     // metadataPath: X++ source XML (custom model metadata). compilerMetadataPath: compiled
     // binaries + framework metadata (UDE: Microsoft packages root; CHE: same as metadataPath).
     const metadataPath = customPackagesPath || packagesRoot;
@@ -128,7 +306,7 @@ export const runBpCheckTool = async (params: any, _context: any) => {
     // (with BPUnusedStrFmtArgument cascading from them). A BP check can be run
     // without a build in between — recompile stale labels here too, otherwise
     // creating a label and checking it immediately still produces the bogus
-    // errors this costs about a second to prevent.
+    // errors this costs about a second to prevent. Batch runs pay it once.
     const labelResult = await compileModelLabels(compilerMetadataPath, metadataPath, modelName);
     if (!labelResult.success) {
       console.error(`[run_bp_check] label compilation failed: ${labelResult.message}`);
@@ -145,171 +323,164 @@ export const runBpCheckTool = async (params: any, _context: any) => {
      * when -compilerMetadata is not recognized.
      */
 
+    /** Positional element selector, or `-all` for a whole-model run. */
+    const selector = (target: { name: string; elementType: string } | null): string =>
+      target ? `${target.elementType}:${target.name}` : '-all';
+
     // Style A — colon separator with -compilerMetadata
     //
     // #25: `-all` means "check the whole model" and xppbp does NOT recognise
     // `-filter:` — so this style silently ignored the requested scope (a run
     // filtered to one class returned warnings for two unrelated table elements).
-    // With a targetFilter we therefore drop `-all` and append the positional
+    // With a target we therefore drop `-all` and append the positional
     // `<type>:<Name>` element selector this xppbp understands.
-    const buildArgsColonStyle = (metadataFlag: string, compilerMetadataFlag: string): string[] => {
-      const a: string[] = [
-        `${metadataFlag}${metadataPath}`,
-        `-module:${modelName}`,
-        `-model:${modelName}`,
-        `${compilerMetadataFlag}${compilerMetadataPath}`,
-      ];
-      if (targetFilter) {
-        a.push(`${(targetElementType ?? 'class').toLowerCase()}:${targetFilter}`);
-      } else {
-        a.push(`-all`);
-      }
-      return a;
-    };
+    const buildArgsColonStyle = (
+      metadataFlag: string,
+      compilerMetadataFlag: string,
+      target: { name: string; elementType: string } | null,
+    ): string[] => [
+      `${metadataFlag}${metadataPath}`,
+      `-module:${modelName}`,
+      `-model:${modelName}`,
+      `${compilerMetadataFlag}${compilerMetadataPath}`,
+      selector(target),
+    ];
 
     // Style B — equals separator (xppbp 10.0.24+: positional "<type>:<Name>" filter, no leading dash)
-    const buildArgsEqStyle = ({ compilerMetadata }: { compilerMetadata: boolean }): string[] => {
-      const a: string[] = [
-        `-metadata=${metadataPath}`,
-        `-module=${modelName}`,
-        `-model=${modelName}`,
-      ];
-
+    const buildArgsEqStyle = (
+      { compilerMetadata }: { compilerMetadata: boolean },
+      target: { name: string; elementType: string } | null,
+    ): string[] => [
+      `-metadata=${metadataPath}`,
+      `-module=${modelName}`,
+      `-model=${modelName}`,
       // -compilerMetadata= is the newer flag; fall back to -packagesRoot= for older xppbp
-      if (compilerMetadata) {
-        a.push(`-compilerMetadata=${compilerMetadataPath}`);
-      } else {
-        a.push(`-packagesRoot=${compilerMetadataPath}`);
-      }
-
-      // Positional element filter: "<type>:<Name>" — type comes from targetElementType
-      // (defaults to 'class' when omitted for backwards compatibility). `-all` is
-      // mutually exclusive with it: passing both checks the whole model (#25).
-      if (targetFilter) {
-        const elemType = (targetElementType ?? 'class').toLowerCase();
-        a.push(`${elemType}:${targetFilter}`);
-      } else {
-        a.push(`-all`);
-      }
-      return a;
-    };
+      compilerMetadata ? `-compilerMetadata=${compilerMetadataPath}` : `-packagesRoot=${compilerMetadataPath}`,
+      // `-all` is mutually exclusive with the positional filter: passing both
+      // checks the whole model (#25).
+      selector(target),
+    ];
 
     // Style C — fallback when -compilerMetadata is not recognized
-    const buildArgsFallbackStyle = (): string[] => {
-      const a: string[] = [
-        `-metadata:${metadataPath}`,
-        `-packagesRoot:${compilerMetadataPath}`,
-        `-module:${modelName}`,
-        `-model:${modelName}`,
-      ];
-      if (targetFilter) {
-        a.push(`${(targetElementType ?? 'class').toLowerCase()}:${targetFilter}`);
-      } else {
-        a.push(`-all`);
-      }
-      return a;
-    };
+    const buildArgsFallbackStyle = (target: { name: string; elementType: string } | null): string[] => [
+      `-metadata:${metadataPath}`,
+      `-packagesRoot:${compilerMetadataPath}`,
+      `-module:${modelName}`,
+      `-model:${modelName}`,
+      selector(target),
+    ];
 
-    let stdout = '';
-    let stderr = '';
+    const styles: Array<{ label: string; build: (t: { name: string; elementType: string } | null) => string[] }> = [
+      { label: '-compilerMetadata: colon',        build: t => buildArgsColonStyle('-metadata:', '-compilerMetadata:', t) },
+      { label: '-compilerMetadata= equals',       build: t => buildArgsEqStyle({ compilerMetadata: true }, t) },
+      { label: '-packagesRoot= equals fallback',  build: t => buildArgsEqStyle({ compilerMetadata: false }, t) },
+      { label: '-packagesRoot: colon fallback',   build: t => buildArgsFallbackStyle(t) },
+    ];
 
-    const { combined, lastStdout, lastStderr } = await withOperationLock(
+    // One entry per object; `null` is the unfiltered whole-model run.
+    const runTargets: Array<{ name: string; elementType: string } | null> = targets.length > 0 ? targets : [null];
+
+    const combinedByTarget = await withOperationLock(
       `bp:${modelName}`,
       async () => {
-        // Attempt 1: colon style with -compilerMetadata: (UDE: separates custom and framework paths)
-        const args1 = buildArgsColonStyle('-metadata:', '-compilerMetadata:');
-        console.error(`[run_bp_check] Attempt 1 (-compilerMetadata: colon): "${xppbpPath}" ${args1.join(' ')}`);
-        try {
-          ({ stdout, stderr } = await tryXppbp(xppbpPath, args1));
-        } catch (e: any) {
-          stdout = e.stdout ?? '';
-          stderr = e.stderr ?? '';
-        }
-        let localCombined = [stdout, stderr].filter(Boolean).join('\n').trim();
+        // The flag style is a property of the installed xppbp, not of the object:
+        // once one works, later objects in the batch start from it instead of
+        // paying the fallback chain again.
+        let preferredStyle = 0;
+        const outputs: string[] = [];
 
-        // Attempt 2: equals style with -compilerMetadata= (xppbp 10.0.24+)
-        if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
-          const args2 = buildArgsEqStyle({ compilerMetadata: true });
-          console.error(`[run_bp_check] Attempt 2 (-compilerMetadata= equals): "${xppbpPath}" ${args2.join(' ')}`);
-          try {
-            ({ stdout, stderr } = await tryXppbp(xppbpPath, args2));
-          } catch (e: any) {
-            stdout = e.stdout ?? '';
-            stderr = e.stderr ?? '';
+        for (const target of runTargets) {
+          let combined = '';
+          for (let i = preferredStyle; i < styles.length; i++) {
+            const args = styles[i].build(target);
+            console.error(`[run_bp_check] Attempt ${i + 1} (${styles[i].label}) for ${selector(target)}: "${xppbpPath}" ${args.join(' ')}`);
+            let stdout = '';
+            let stderr = '';
+            try {
+              ({ stdout, stderr } = await tryXppbp(xppbpPath, args));
+            } catch (e: any) {
+              stdout = e.stdout ?? '';
+              stderr = e.stderr ?? '';
+            }
+            combined = [stdout, stderr].filter(Boolean).join('\n').trim();
+            if (!HELP_TEXT_PATTERN.test(combined) && combined !== '') {
+              preferredStyle = i;
+              break;
+            }
           }
-          localCombined = [stdout, stderr].filter(Boolean).join('\n').trim();
+          outputs.push(combined);
         }
 
-        // Attempt 3: equals style with -packagesRoot= (fallback for older xppbp)
-        if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
-          const args3 = buildArgsEqStyle({ compilerMetadata: false });
-          console.error(`[run_bp_check] Attempt 3 (-packagesRoot= equals fallback): "${xppbpPath}" ${args3.join(' ')}`);
-          try {
-            ({ stdout, stderr } = await tryXppbp(xppbpPath, args3));
-          } catch (e: any) {
-            stdout = e.stdout ?? '';
-            stderr = e.stderr ?? '';
-          }
-          localCombined = [stdout, stderr].filter(Boolean).join('\n').trim();
-        }
-
-        // Attempt 4: colon style with -packagesRoot: (oldest fallback)
-        if (HELP_TEXT_PATTERN.test(localCombined) || localCombined === '') {
-          const args4 = buildArgsFallbackStyle();
-          console.error(`[run_bp_check] Attempt 4 (-packagesRoot: colon fallback): "${xppbpPath}" ${args4.join(' ')}`);
-          try {
-            ({ stdout, stderr } = await tryXppbp(xppbpPath, args4));
-          } catch (e: any) {
-            stdout = e.stdout ?? '';
-            stderr = e.stderr ?? '';
-          }
-          localCombined = [stdout, stderr].filter(Boolean).join('\n').trim();
-        }
-
-        return { combined: localCombined, lastStdout: stdout, lastStderr: stderr };
+        return outputs;
       },
     );
 
-    stdout = lastStdout;
-    stderr = lastStderr;
-
-    // If still showing help text, report a useful diagnostic
-    if (HELP_TEXT_PATTERN.test(combined)) {
+    // If the first target still shows help text, no flag style works on this
+    // xppbp at all — report that once rather than per object.
+    if (HELP_TEXT_PATTERN.test(combinedByTarget[0])) {
       return {
         content: [{
           type: 'text',
-          text: `❌ xppbp.exe returned its help text for all four flag-style attempts (-compilerMetadata:, -compilerMetadata=, -packagesRoot= with equals, -packagesRoot: with colon).\n\nThis usually means the installed xppbp.exe version uses an unrecognised CLI format.\n\nRaw output:\n\n${combined}`
+          text: `❌ xppbp.exe returned its help text for all four flag-style attempts (-compilerMetadata:, -compilerMetadata=, -packagesRoot= with equals, -packagesRoot: with colon).\n\nThis usually means the installed xppbp.exe version uses an unrecognised CLI format.\n\nRaw output:\n\n${combinedByTarget[0]}`
         }],
         isError: true
       };
     }
 
-    // xppbp prints violations as plain text on stdout/stderr (-car: generates an Excel file instead).
-    const logContent = combined;
-
     // xppbp emits either "BPError..."/XML <Diagnostic severity="error"> or
     // "BestPractices Warning/Error: ..." — both count as a violation.
-    const hasIssues = /BPError|<Diagnostic|severity="error"|BestPractices (Warning|Error):/i.test(logContent)
-      || /BPError|severity\s*[:=]\s*error/i.test(combined)
-      || /^Warnings:\s*[1-9]/m.test(combined)
-      || /^Errors:\s*[1-9]/m.test(combined);
+    const hasIssues = (output: string) =>
+      /BPError|<Diagnostic|severity="error"|BestPractices (Warning|Error):/i.test(output)
+      || /severity\s*[:=]\s*error/i.test(output)
+      || /^Warnings:\s*[1-9]/m.test(output)
+      || /^Errors:\s*[1-9]/m.test(output);
 
-    const summary = hasIssues ? '⚠️ BP Check completed with issues' : '✅ BP Check passed';
-    const details = logContent || combined || '(no output)';
+    const header = `Model: ${modelName}` + (resolvedProjectPath ? `\nProject: ${resolvedProjectPath}` : '');
 
-    // #25: report honestly whether the requested scope actually took effect —
-    // attribution used to require reading rule names and guessing.
-    const scopeNote = targetFilter ? describeScope(targetFilter, combined) : '';
+    // Single target (and the whole-model run) keep the original layout — there
+    // is no preamble to share and existing callers read this shape.
+    if (runTargets.length === 1) {
+      const combined = combinedByTarget[0];
+      const target = runTargets[0];
+      // #25: report honestly whether the requested scope actually took effect —
+      // attribution used to require reading rule names and guessing.
+      const scopeNote = target ? describeScope(target.name, combined) : '';
+      return {
+        content: [{
+          type: 'text',
+          text: `${hasIssues(combined) ? '⚠️ BP Check completed with issues' : '✅ BP Check passed'}\n\n${header}` +
+            (target ? `\nFilter: ${selector(target)}` : '') +
+            scopeNote +
+            labelNote +
+            `\n\n${combined || '(no output)'}`
+        }]
+      };
+    }
+
+    // Batch: one preamble, findings grouped per object (#828).
+    const { preamble, bodies } = splitSharedPreamble(combinedByTarget);
+    const issueCount = combinedByTarget.filter(hasIssues).length;
+
+    const groups = runTargets.map((target, i) => {
+      const combined = combinedByTarget[i];
+      const body = bodies[i].join('\n').trim();
+      return (
+        `── ${selector(target)} ── ${hasIssues(combined) ? '⚠️ issues' : '✅ clean'}` +
+        (target ? describeScope(target.name, combined) : '') +
+        `\n${body || '(no findings)'}`
+      );
+    });
 
     return {
       content: [{
         type: 'text',
-        text: `${summary}\n\nModel: ${modelName}` +
-          (resolvedProjectPath ? `\nProject: ${resolvedProjectPath}` : '') +
-          (targetFilter ? `\nFilter: ${(targetElementType ?? 'class').toLowerCase()}:${targetFilter}` : '') +
-          scopeNote +
+        text: `${issueCount > 0 ? '⚠️ BP Check completed with issues' : '✅ BP Check passed'} — ` +
+          `${runTargets.length} objects checked, ${issueCount} with findings\n\n${header}` +
           labelNote +
-          `\n\n${details}`
+          (preamble.length > 0
+            ? `\n\nShared xppbp preamble (identical for all ${runTargets.length} objects, shown once):\n${preamble.join('\n').trim()}`
+            : '') +
+          `\n\n${groups.join('\n\n')}`
       }]
     };
   } catch (error: any) {

--- a/src/utils/toolProgressMessage.ts
+++ b/src/utils/toolProgressMessage.ts
@@ -142,7 +142,11 @@ export function buildProgressMessage(toolName: string, args: Record<string, any>
     case 'trigger_db_sync':
       return `🗄️ Triggering database sync${a.tableName ? ` for ${a.tableName}` : ''}`;
     case 'run_bp_check':
-      return `🔍 Running Best Practices check${a.targetFilter ? ` on ${a.targetFilter}` : ''}`;
+      return `🔍 Running Best Practices check${
+        Array.isArray(a.objects) && a.objects.length > 0
+          ? ` on ${a.objects.length} object${a.objects.length === 1 ? '' : 's'}`
+          : a.targetFilter ? ` on ${a.targetFilter}` : ''
+      }`;
     case 'run_systest_class':
       return `🧪 Running unit tests: ${a.className ?? ''}`;
     case 'review_workspace_changes':

--- a/tests/tools/runBpCheck.test.ts
+++ b/tests/tools/runBpCheck.test.ts
@@ -482,7 +482,10 @@ describe('run_bp_check — violation detection', () => {
       cb(null, { stdout: '✅', stderr: '' });
     });
 
-    const result = await runBpCheckTool({ modelName: 'MyModel', targetFilter: 'MyClass' }, {});
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', targetFilter: 'MyClass', targetElementType: 'class' },
+      {},
+    );
 
     expect(result.content[0].text).toContain('Filter: class:MyClass');
     const args = capturedArgs(0);
@@ -581,6 +584,279 @@ describe('run_bp_check — targetFilter actually scopes (#25)', () => {
     );
 
     expect(result.content[0].text as string).toContain('Scope: honoured');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #828: batch form + no silent `class` default
+//
+// Checking three objects used to cost four sequential calls (~64 s, 4 round
+// trips) and repeated the whole xppbp preamble each time — and the one call
+// that omitted targetElementType silently checked `class:<Table>`.
+// ---------------------------------------------------------------------------
+
+/** Minimal symbol-index stand-in that serves lookupSymbolsNocase queries. */
+function fakeContext(rows: Array<{ name: string; type: string }>) {
+  const db = {
+    prepare: (sql: string) => ({
+      get: () => undefined,
+      all: (...params: any[]) => {
+        // Exact probe: (name, ...types, limit). FTS probe: (matchExpr, name, ...types, limit).
+        const isFts = /symbols_fts/.test(sql);
+        const name = String(isFts ? params[1] : params[0]);
+        const types = params.slice(isFts ? 2 : 1, -1) as string[];
+        return rows
+          .filter(r => r.name.toLowerCase() === name.toLowerCase())
+          .filter(r => types.length === 0 || types.includes(r.type))
+          .map(r => ({ name: r.name, type: r.type, model: 'MyModel', extends_class: null, file_path: null }));
+      },
+    }),
+  };
+  return { symbolIndex: { getReadDb: () => db } };
+}
+
+/** The positional `<type>:<Name>` selector xppbp was invoked with. */
+function selectorOf(args: string[]): string {
+  return args.find(a => !a.startsWith('-')) ?? '-all';
+}
+
+describe('run_bp_check — batch objects[] (#828)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    detectedRoots.splice(0, detectedRoots.length, CHE_PKG);
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    allowPaths([CHE_PKG, CHE_XPPBP]);
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: '✅', stderr: '' });
+    });
+  });
+
+  it('checks every object in one call, one xppbp run each', async () => {
+    const result = await runBpCheckTool(
+      {
+        modelName: 'MyModel',
+        objects: [
+          { objectType: 'table', objectName: 'ConDemoTicket' },
+          { objectType: 'class', objectName: 'ConDemoTicket_Extension' },
+          { objectType: 'enum',  objectName: 'ConDemoStatus' },
+        ],
+      },
+      {},
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+    expect(selectorOf(capturedArgs(0))).toBe('table:ConDemoTicket');
+    expect(selectorOf(capturedArgs(1))).toBe('class:ConDemoTicket_Extension');
+    expect(selectorOf(capturedArgs(2))).toBe('enum:ConDemoStatus');
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('3 objects checked');
+    expect(text).toContain('── table:ConDemoTicket ──');
+    expect(text).toContain('── class:ConDemoTicket_Extension ──');
+    expect(text).toContain('── enum:ConDemoStatus ──');
+  });
+
+  it('emits the repeated xppbp preamble once and groups findings per object', async () => {
+    const preamble = (mb: number) =>
+      'Microsoft (R) X++ Best Practice Tool\n' +
+      `Memory usage at start of execution is ${mb} MB\n` +
+      'Enabled rules: ALL\n';
+    execFileMock.mockImplementation((_f: string, a: string[], _o: any, cb: Function) => {
+      const sel = selectorOf(a);
+      const finding = sel.startsWith('table')
+        ? 'BPErrorTableMissingFormRef: K:\\Pkg\\M\\M\\AxTable\\ConDemoTicket.xml\nErrors: 1'
+        : 'Errors: 0\nWarnings: 0';
+      cb(null, { stdout: preamble(sel.startsWith('table') ? 27 : 28) + finding, stderr: '' });
+    });
+
+    const result = await runBpCheckTool(
+      {
+        modelName: 'MyModel',
+        objects: [
+          { objectType: 'table', objectName: 'ConDemoTicket' },
+          { objectType: 'enum',  objectName: 'ConDemoStatus' },
+        ],
+      },
+      {},
+    );
+
+    const text = result.content[0].text as string;
+    // Banner and enabled-rules line appear exactly once, in the shared block…
+    expect(text.match(/Microsoft \(R\) X\+\+ Best Practice Tool/g)).toHaveLength(1);
+    expect(text.match(/Enabled rules: ALL/g)).toHaveLength(1);
+    // …even though the memory counter differed by a megabyte between runs.
+    expect(text.match(/Memory usage at start of execution/g)).toHaveLength(1);
+    expect(text).toContain('Shared xppbp preamble');
+    // The findings themselves stay attached to their object.
+    expect(text).toContain('BPErrorTableMissingFormRef');
+    expect(text).toContain('⚠️ BP Check completed with issues');
+    expect(text).toContain('2 objects checked, 1 with findings');
+  });
+
+  it('reuses the flag style that worked, instead of re-walking the fallback chain', async () => {
+    const HELP_OUTPUT = 'X++ Best Practice Options:\n  -metadata:<path>\n';
+    execFileMock.mockImplementation((_f: string, a: string[], _o: any, cb: Function) => {
+      // Only the equals style is understood by this xppbp.
+      if (a.some(x => /^-metadata:/.test(x))) cb(null, { stdout: HELP_OUTPUT, stderr: '' });
+      else                                    cb(null, { stdout: '✅', stderr: '' });
+    });
+
+    await runBpCheckTool(
+      {
+        modelName: 'MyModel',
+        objects: [
+          { objectType: 'table', objectName: 'A' },
+          { objectType: 'table', objectName: 'B' },
+          { objectType: 'table', objectName: 'C' },
+        ],
+      },
+      {},
+    );
+
+    // Object 1 pays attempts 1+2; objects 2 and 3 start straight at attempt 2.
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('accepts bare strings as one-element entries when the type is resolvable', async () => {
+    const ctx = fakeContext([{ name: 'ConDemoTicket', type: 'table' }]);
+
+    const result = await runBpCheckTool({ modelName: 'MyModel', objects: ['ConDemoTicket'] }, ctx);
+
+    expect(result.isError).toBeFalsy();
+    expect(selectorOf(capturedArgs(0))).toBe('table:ConDemoTicket');
+  });
+
+  it('rejects an objects[] with no usable entry', async () => {
+    const result = await runBpCheckTool({ modelName: 'MyModel', objects: [{ objectType: 'table' }] }, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('no usable entry');
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the single-target form working and unchanged', async () => {
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', targetFilter: 'ConDemoTicket', targetElementType: 'table' },
+      {},
+    );
+
+    const text = result.content[0].text as string;
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(text).toContain('Filter: table:ConDemoTicket');
+    expect(text).not.toContain('objects checked');
+  });
+});
+
+describe('run_bp_check — omitted element type never defaults to class (#828)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    detectedRoots.splice(0, detectedRoots.length, CHE_PKG);
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    allowPaths([CHE_PKG, CHE_XPPBP]);
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: '✅', stderr: '' });
+    });
+  });
+
+  it('resolves the type from the symbol index — a table checks as table, not class', async () => {
+    const ctx = fakeContext([{ name: 'ConDemoTicket', type: 'table' }]);
+
+    const result = await runBpCheckTool({ modelName: 'MyModel', targetFilter: 'ConDemoTicket' }, ctx);
+
+    expect(result.isError).toBeFalsy();
+    expect(selectorOf(capturedArgs(0))).toBe('table:ConDemoTicket');
+    expect(result.content[0].text).toContain('Filter: table:ConDemoTicket');
+  });
+
+  it('resolves a class extension (an AxClass carrying [ExtensionOf]) as class', async () => {
+    const ctx = fakeContext([{ name: 'ConDemoTicket_Extension', type: 'class-extension' }]);
+
+    await runBpCheckTool({ modelName: 'MyModel', objects: [{ objectName: 'ConDemoTicket_Extension' }] }, ctx);
+
+    expect(selectorOf(capturedArgs(0))).toBe('class:ConDemoTicket_Extension');
+  });
+
+  it('errors instead of guessing when the name is not indexed', async () => {
+    const ctx = fakeContext([]);
+
+    const result = await runBpCheckTool({ modelName: 'MyModel', targetFilter: 'Unknown' }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Cannot determine the element type');
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('errors when the name is ambiguous across element kinds', async () => {
+    const ctx = fakeContext([
+      { name: 'ConDemo', type: 'table' },
+      { name: 'ConDemo', type: 'class' },
+    ]);
+
+    const result = await runBpCheckTool({ modelName: 'MyModel', targetFilter: 'ConDemo' }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('ambiguous');
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('errors when no symbol index is available at all', async () => {
+    const result = await runBpCheckTool({ modelName: 'MyModel', targetFilter: 'ConDemoTicket' }, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('symbol index is not available');
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('reports every unresolvable object of a batch in one error', async () => {
+    const ctx = fakeContext([{ name: 'ConDemoTicket', type: 'table' }]);
+
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', objects: ['ConDemoTicket', 'Ghost1', 'Ghost2'] },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text as string;
+    expect(text).toContain('Ghost1');
+    expect(text).toContain('Ghost2');
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('still runs the whole model when neither objects nor targetFilter is given', async () => {
+    const result = await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+    expect(result.isError).toBeFalsy();
+    expect(capturedArgs(0)).toContain('-all');
+  });
+});
+
+describe('splitSharedPreamble (#828 helper)', () => {
+  it('returns a single output untouched — there is nothing to share', async () => {
+    const { splitSharedPreamble } = await import('../../src/tools/runBpCheck');
+    const { preamble, bodies } = splitSharedPreamble(['banner\nErrors: 0']);
+    expect(preamble).toEqual([]);
+    expect(bodies[0].join('\n')).toBe('banner\nErrors: 0');
+  });
+
+  it('stops at the first finding line even when it is common to every output', async () => {
+    const { splitSharedPreamble } = await import('../../src/tools/runBpCheck');
+    const out = 'banner\nBPErrorXmlDocMissing: same\ntail';
+    const { preamble, bodies } = splitSharedPreamble([out, out]);
+    expect(preamble).toEqual(['banner']);
+    expect(bodies[0].join('\n')).toContain('BPErrorXmlDocMissing');
   });
 });
 

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -41,7 +41,13 @@ const CHARS_PER_TOKEN = 4;
 // on the wire — only the prose naming them does, and that was paid for by
 // tightening the `params` description rather than by moving the ceiling.
 // Headroom is small on purpose so creep is caught early.
-const TOTAL_BUDGET = 63_300;
+//
+// run_bp_check's `objects[]` batch form (#828) does raise it: it is a genuinely
+// new array-of-object parameter, and it buys back far more than it costs —
+// checking three objects went from three ListTools-priced round trips to one.
+// The single-target `targetFilter`/`targetElementType` descriptions were
+// tightened at the same time to pay for part of it.
+const TOTAL_BUDGET = 63_700;
 const LARGEST_TOOL_BUDGET = 9_900;
 
 async function getTools(): Promise<Array<{ name: string }>> {


### PR DESCRIPTION
Checking three objects with `run_bp_check` cost 4 sequential calls, 64,1 s of server time and 4 agent round trips in the session audit (#824) — and one of those calls omitted `targetElementType`, so it silently checked `class:<Table>` and was wasted outright. Each result body also repeated the whole xppbp preamble (model, project path, filter, `Memory usage at start of execution is 27 MB`, enabled-rules banner) into the transcript.

## What changed

**`src/tools/runBpCheck.ts`** — rewritten around a list of targets instead of a single filter:

- `normalizeTargets()` folds the two accepted call shapes into one list: the new `objects: [{objectType, objectName}]` (mirrors `verify_d365fo_project`) and the original `targetElementType` + `targetFilter`. A bare string is accepted wherever an entry is, so `objects: "MyClass"` and `objects: ["MyClass"]` both mean a one-element list.
- The batch runs server-side inside a **single** `withOperationLock` acquisition, compiling model labels **once** for the whole batch. The xppbp flag style is a property of the installed binary, not of the object, so once one of the four styles works the remaining objects start from it instead of re-walking the fallback chain — three objects on an equals-style xppbp cost 4 process launches, not 6.
- `splitSharedPreamble()` strips the leading lines that every run repeats and prints them once under `Shared xppbp preamble (…, shown once)`. Lines are compared with digits masked so the memory counter (27 MB vs 28 MB) still matches, and the scan stops at the first finding-shaped line so a genuinely common finding is never swallowed into the banner.
- `resolveElementType()` looks an omitted type up in the symbol index (`context.symbolIndex.getReadDb()`, via the existing index-safe `lookupSymbolsNocase` helper) through an explicit `INDEX_TYPE_TO_ELEMENT_TYPE` map. A class extension resolves to `class` because it is an AxClass file carrying `[ExtensionOf]`. Nothing falls back to `class`.

**`src/server/toolSchemas/runBpCheck.ts`** — adds `objects[]`; `targetFilter`/`targetElementType` descriptions retargeted at the single-object case and tightened.

**`src/utils/toolProgressMessage.ts`** — progress line reports the object count for a batch.

**`docs/MCP_TOOLS.md`** — tool row mentions the batch form. No tool was added, so no count in `NEW_TOOL_CHECKLIST.md` moved.

## Acceptance criteria

| Criterion | How it is met |
|---|---|
| `run_bp_check` accepts `objects[]` and returns grouped findings from one call | `normalizeTargets()` + the per-target loop; output is `⚠️/✅ BP Check … — N objects checked, M with findings`, one shared preamble block, then a `── <type>:<Name> ── ⚠️ issues/✅ clean` group per object, each keeping its own `#25` scope note. Covered by *checks every object in one call* and *emits the repeated xppbp preamble once and groups findings per object*. |
| omitted `targetElementType` either resolves correctly or errors, never silently picks `class` | `resolveElementType()`. Resolved → runs with the real type; not indexed / ambiguous / no index available → `isError` with the explicit-type call to make, and **xppbp is never launched**. A batch reports every unresolvable name in one error rather than half-checking. Five tests in *omitted element type never defaults to class*. |
| single-target callers keep working | The `targetFilter`/`targetElementType` path produces byte-identical output to before (same `Filter:` line, same scope note, same body — the batch layout only engages for more than one target). The whole-model `-all` run is untouched. Covered by *keeps the single-target form working and unchanged* and by the pre-existing `#25` suite, unmodified. |

## Test coverage

`tests/tools/runBpCheck.test.ts` grows from 33 to 47 tests: batch fan-out and selectors, preamble dedup incl. the differing memory counter, flag-style memoisation, bare-string entries, empty `objects[]`, single-target regression, the five type-resolution paths (table, class extension, unindexed, ambiguous, no index), the whole-model run, and two direct `splitSharedPreamble` unit tests.

One pre-existing test changed: *includes filter name in output when targetFilter is supplied* used to assert `Filter: class:MyClass` from a bare `targetFilter: 'MyClass'` — that assertion **was** the silent-`class` behaviour, so it now passes `targetElementType: 'class'` explicitly.

Full suite: **205 files, 2721 passed, 9 skipped**. `npx tsc --noEmit` clean.

## ⚠️ Shared constant — needs reconciling

`tests/utils/toolSchemaBudget.test.ts` `TOTAL_BUDGET`: **63_300 → 63_700** (actual payload 63_663 chars). A sibling PR is bumping the same constant, so expect a conflict here.

## Deliberately left out

- **One xppbp invocation for the whole batch.** xppbp's positional selector is a single `<type>:<Name>` token — it has no documented multi-element form — so this is a server-side loop, as the issue allows. The caller still pays exactly one round trip, and the flag-style memo removes the redundant process launches the fallback chain used to cost.
- **Extension element-type spellings.** `table-extension` → `tableextension` (and the form/enum/edt equivalents) is the concatenated AOT spelling and is unverified against a live xppbp; it only applies when the type is *resolved*, never when the caller types one. Index types with no plausible xppbp equivalent (security artefacts, menu items, services groups) are absent from the map on purpose and error rather than guess.

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)
