### PR TITLE
fix(prefix,workspace): one effective-prefix resolution point; retry detection instead of warning at boot

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -232,7 +232,7 @@ Restart the editor, open the AI chat, and ask:
 
 The first prompt should trigger a `search` tool call returning results from **your** metadata — including ISV models no training data has ever seen. That is the signal that grounding works, not just that the server is reachable.
 
-On an installed server, `npx d365fo-mcp doctor` checks the same ground from the other side: Node version, build, native binding, index size, bridge, and any stale configuration.
+On an installed server, `npx d365fo-mcp doctor` checks the same ground from the other side: Node version, build, native binding, index size, bridge, and any stale configuration. It also names the source that resolves your workspace — the workspace path, the packages path, `D365FO_SOLUTIONS_PATH`, or `workspace.modelName` in the config — and flags a prefix conflict when the model's own objects use a different prefix from `naming.prefix` (the model's own naming wins; `EXTENSION_PREFIX_SOURCE=config` pins the configured value).
 
 
 # Logging & diagnostics

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -17,6 +17,9 @@ import { conflictingLegacyValues, readPath, readSetting, type SettingsStore } fr
 import { instanceTarget, rootTarget, type Target } from '../target.js';
 import { isXppConfigStale, listXppConfigs, xppConfigDir } from '../xppConfig.js';
 import { describePackagesRootScan, packagesRoots } from '../../utils/packagesRoot.js';
+import { autoDetectD365Project } from '../../utils/workspaceDetector.js';
+import { describeWorkspaceDetection } from '../../utils/workspaceDetectionStatus.js';
+import { inferPrefixFromObjectNames } from '../../utils/modelPrefixInference.js';
 
 type Severity = 'ok' | 'warn' | 'fail' | 'info';
 
@@ -117,6 +120,122 @@ function checkPackagesRoot(store: SettingsStore, label: string): CheckResult[] {
       ? `set environment.packagePath to ${detected[0]} (${SETUP_COMMAND})`
       : `point environment.packagePath at this machine's PackagesLocalDirectory (${SETUP_COMMAND})`,
   }];
+}
+
+/**
+ * Which detection source resolves the workspace — and which model it lands on.
+ *
+ * The server's own log used to say only that detection had failed, from a pass
+ * that ran before its sources were up; the user then had to infer the real
+ * resolution from an unrelated tool error (#833). Running the same detector here
+ * states the answer outright, and names every source it looked at when there
+ * isn't one.
+ */
+export async function checkWorkspaceDetection(
+  store: SettingsStore,
+  label: string,
+): Promise<{ modelName: string | null; checks: CheckResult[] }> {
+  const configuredModel = String(readSetting(store, settingByPath('workspace.modelName')!) ?? '').trim();
+  const workspacePath = String(readSetting(store, settingByPath('workspace.path')!) ?? '').trim();
+
+  if (configuredModel) {
+    return {
+      modelName: configuredModel,
+      checks: [{
+        severity: 'ok',
+        message: `${label}: model "${configuredModel}" comes from configuration (workspace.modelName) — no auto-detection needed`,
+      }],
+    };
+  }
+
+  const detected = await autoDetectD365Project(workspacePath || undefined);
+  if (!detected) {
+    return {
+      modelName: null,
+      checks: [{
+        severity: 'warn',
+        message: `${label}: ${describeWorkspaceDetection()}`,
+        fix: `set workspace.modelName / workspace.projectPath (${SETUP_COMMAND}), or point workspace.solutionsPath at your solutions root`,
+      }],
+    };
+  }
+  return {
+    modelName: detected.modelName,
+    checks: [{
+      severity: 'ok',
+      message: `${label}: model "${detected.modelName}" detected from ${detected.detectionSource ?? 'auto-detection'}` +
+        (detected.projectPath ? `\n   project: ${detected.projectPath}` : ''),
+    }],
+  };
+}
+
+/**
+ * The configured prefix against the one the model's own objects use.
+ *
+ * These two disagreeing is normal — a single configured prefix cannot be right
+ * for every model — but the server resolves the model's own naming ABOVE the
+ * configuration, so a user reading only their config has the wrong answer. State
+ * both, and how to pin the configured one.
+ */
+export function checkPrefixResolution(
+  configuredPrefix: string,
+  modelName: string | null,
+  modelObjectNames: string[],
+  label: string,
+): CheckResult[] {
+  const inferred = modelName ? inferPrefixFromObjectNames(modelObjectNames, modelName) : null;
+  const bare = (s: string) => s.replace(/_+$/, '').toLowerCase();
+
+  if (!inferred?.regular) {
+    if (!configuredPrefix) {
+      return [{
+        severity: 'warn',
+        message: `${label}: no prefix configured and none inferable — new objects will be prefixed with the model name`,
+        fix: `set naming.prefix to your ISV prefix (${SETUP_COMMAND})`,
+      }];
+    }
+    return [{ severity: 'ok', message: `${label}: prefix "${configuredPrefix}" (naming.prefix)` }];
+  }
+  if (!configuredPrefix || bare(inferred.regular) === bare(configuredPrefix)) {
+    return [{
+      severity: 'ok',
+      message: `${label}: prefix "${inferred.regular}" — model "${modelName}"'s own objects and the configuration agree`,
+    }];
+  }
+  return [{
+    severity: 'warn',
+    message: `${label}: prefix conflict — model "${modelName}"'s objects use "${inferred.regular}" ` +
+      `(${inferred.coverage}/${inferred.sampleSize}), naming.prefix says "${configuredPrefix}". ` +
+      `The model's own naming wins, so new objects are named "${inferred.regular}…".`,
+    fix: 'EXTENSION_PREFIX_SOURCE=config pins the configured value instead',
+  }];
+}
+
+/**
+ * The object names doctor infers a prefix from. Read straight out of the symbol
+ * index — the same rows the server's inference reads (SymbolIndex.getModelObjectNames)
+ * — and empty whenever there is no index to read, which is not a prefix problem.
+ */
+async function modelObjectNames(dbPath: string, modelName: string): Promise<string[]> {
+  if (!fs.existsSync(dbPath)) return [];
+  try {
+    const { default: Database } = await import('../../database/sqlite.js');
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const rows = db.prepare(
+        `SELECT name FROM symbols
+         WHERE model = ?
+           AND parent_name IS NULL
+           AND type NOT IN ('method', 'field')
+         LIMIT 400`
+      ).all(modelName) as Array<{ name: string }>;
+      return rows.map(r => r.name);
+    } finally {
+      db.close();
+    }
+  } catch {
+    return [];
+  }
 }
 
 /** A legacy .env that disagrees with the config is a trap: the config wins. */
@@ -257,6 +376,16 @@ export async function doctorCommand(): Promise<void> {
 
   // Database (root)
   emit(checkDb(root.store, paths.defaultDb, 'Root'));
+
+  // Which source resolves the workspace, and the prefix that follows from it —
+  // both were previously only inferable from a tool error (#833).
+  const detection = await checkWorkspaceDetection(root.store, 'Workspace');
+  for (const r of detection.checks) emit(r);
+  const configuredPrefix = String(readSetting(root.store, settingByPath('naming.prefix')!) ?? '').trim();
+  const names = detection.modelName
+    ? await modelObjectNames(readPath(root.store, settingByPath('index.dbPath')!, paths.defaultDb), detection.modelName)
+    : [];
+  for (const r of checkPrefixResolution(configuredPrefix, detection.modelName, names, 'Naming')) emit(r);
 
   // C# bridge: the only write path; Windows-only.
   if (isWindows) {

--- a/src/tools/prefixDiagnostics.ts
+++ b/src/tools/prefixDiagnostics.ts
@@ -12,39 +12,17 @@
  *    model's own objects, from EXTENSION_PREFIX, or from the model name, and a
  *    bare "Effective prefix: ConFin" under "EXTENSION_PREFIX: Con" reads as
  *    approved rather than as the disagreement it is.
- */
-
-import { resolveObjectPrefix } from '../utils/modelClassifier.js';
-import { getInferredModelPrefix } from '../utils/modelPrefixInference.js';
-import { crossModelWriteAllowedByConfig } from '../utils/crossModelWriteGuard.js';
-
-/**
- * The model a write would actually land in.
  *
- * Normally the anchor: a project switch does not move writes. But when the
- * operator has allowed writes into the switched-to model in configuration, the
- * guard lets them through and they land in the ACTIVE model — so that is the
- * model whose prefix a create would apply. Reporting the anchor's prefix there
- * would be the same defect one state over.
+ * The resolution itself lives in utils/effectivePrefix.ts, which
+ * validate_object_naming reads too — the two used to resolve it separately and
+ * contradict each other (#833).
  */
-export function modelWritesLandIn(
-  anchorModel: string | null,
-  activeModel: string | null,
-): string | null {
-  if (!activeModel || sameModel(activeModel, anchorModel)) return anchorModel;
-  return crossModelWriteAllowedByConfig(activeModel) ? activeModel : anchorModel;
-}
 
-/**
- * Model names compare case-insensitively everywhere else (crossModelWriteGuard's
- * eq, ConfigManager's anchor bookkeeping). Comparing them exactly here would
- * report a switch — and a whole "writes are NOT switched" section — for two
- * spellings of one model.
- */
-function sameModel(a: string | null, b: string | null): boolean {
-  if (!a || !b) return a === b;
-  return a.trim().toLowerCase() === b.trim().toLowerCase();
-}
+import {
+  prefixConflictWarning, resolveEffectivePrefix, sameModel,
+} from '../utils/effectivePrefix.js';
+
+export { modelWritesLandIn } from '../utils/effectivePrefix.js';
 
 export interface PrefixDiagnostics {
   /**
@@ -69,28 +47,8 @@ export function buildPrefixDiagnostics(
   writeModel: string | null,
   readModel: string | null,
 ): PrefixDiagnostics {
-  const extensionPrefixEnv = process.env.EXTENSION_PREFIX?.trim() || null;
-  const learned = writeModel ? getInferredModelPrefix(writeModel) : null;
-  const effectivePrefix = resolveObjectPrefix(writeModel ?? '');
-
-  // "0/13 objects" is what this said when the token came from the model's
-  // extension ELEMENTS rather than its regular objects (coverage is the regular
-  // objects' count, and there were none to agree). A line that contradicts
-  // itself in the section built to make the prefix checkable is worse than a
-  // vaguer one, so each origin now states the evidence it actually has.
-  const source = learned?.regular
-    ? learned.coverage > 0
-      ? `inferred from ${learned.coverage}/${learned.sampleSize} objects of model "${writeModel}"`
-      : `inferred from the extension elements of model "${writeModel}"`
-    : extensionPrefixEnv
-      ? 'EXTENSION_PREFIX'
-      : 'model name (nothing configured)';
-
-  // Compared bare, because "DEMO_" in the model and "DEMO" in the env agree.
-  const bare = (s: string) => s.replace(/_+$/, '').toLowerCase();
-  const disagrees =
-    !!learned?.regular && !!extensionPrefixEnv &&
-    bare(learned.regular) !== bare(extensionPrefixEnv);
+  const resolution = resolveEffectivePrefix(writeModel);
+  const { prefix: effectivePrefix, source, configured: extensionPrefixEnv, inferred: learned } = resolution;
 
   const switched = !!writeModel && !!readModel && !sameModel(writeModel, readModel);
 
@@ -109,11 +67,9 @@ export function buildPrefixDiagnostics(
   // is one line above, so what is wrong is already visible.
   const lines = [`Prefix      : ${effectivePrefix || '(none)'}  (${source})`];
   if (switched) lines.push(switchNote);
-  if (disagrees) {
-    lines.push(
-      `⚠️  The model's own objects use "${learned?.regular}", overriding EXTENSION_PREFIX="${extensionPrefixEnv}". ` +
-      `To pin the configured value instead: EXTENSION_PREFIX_SOURCE=config.`,
-    );
+  const conflictWarning = prefixConflictWarning(resolution);
+  if (conflictWarning) {
+    lines.push(`⚠️  ${conflictWarning}`);
   } else if (!learned?.regular && !extensionPrefixEnv) {
     lines.push(
       `⚠️  EXTENSION_PREFIX is not set — the model name is being used as the prefix. ` +
@@ -129,7 +85,7 @@ export function buildPrefixDiagnostics(
   ];
   if (switched) verboseLines.push(switchNote);
   verboseLines.push(
-    disagrees
+    resolution.conflict
       ? disagreeNote
       : learned?.regular
         ? `✅ Prefix "${effectivePrefix}" comes from the objects model "${writeModel}" already contains.`

--- a/src/tools/validateObjectNaming.ts
+++ b/src/tools/validateObjectNaming.ts
@@ -8,8 +8,12 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import {
-  getObjectSuffix, getExtensionNamingStyle, resolveObjectPrefix, deriveExtensionInfix,
+  getObjectSuffix, getExtensionNamingStyle, deriveExtensionInfix,
 } from '../utils/modelClassifier.js';
+import {
+  matchPrefixCandidate, modelWritesLandIn, prefixCandidates, prefixConflictWarning,
+  resolveEffectivePrefix, type PrefixCandidate,
+} from '../utils/effectivePrefix.js';
 import { getConfigManager } from '../utils/configManager.js';
 import { lookupSymbolNocase, lookupSymbolsNocase } from '../utils/symbolLookup.js';
 
@@ -58,22 +62,44 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
     }
 
     // The model whose convention is being validated against: explicit arg, else the
-    // model this workspace targets. It decides the prefix, so it is resolved BEFORE
-    // the prefix — a workspace on ContosoFinanceSK must validate against ContosoSK even
-    // when EXTENSION_PREFIX still says something else.
+    // model WRITES land in — the same model get_workspace_info reports the prefix for
+    // (see prefixDiagnostics). Reading the active model here instead made the two
+    // tools disagree after a project switch. The await lets a detection still in
+    // flight finish: reading null resolves the prefix from EXTENSION_PREFIX alone and
+    // validates against a token the server itself would not apply (#833).
+    const configManager = getConfigManager();
+    await configManager.getAutoDetectedModelName();
+    const activeModel = configManager.getModelName();
     const namingStyle = getExtensionNamingStyle();
-    const modelName = args.modelName?.trim() || getConfigManager().getModelName() || '';
+    const modelName = args.modelName?.trim() ||
+      modelWritesLandIn(configManager.getWriteAnchorModel() ?? activeModel, activeModel) || '';
     const useModelName = namingStyle === 'model-name' && !!modelName;
 
-    // Resolve model prefix: explicit arg → the active model's own prefix
-    // (resolveObjectPrefix: learned from that model's objects, else EXTENSION_PREFIX,
-    // else the model name) → DB auto-detect for an unconfigured workspace.
+    // Resolve model prefix: explicit arg → the effective prefix for that model
+    // (resolveEffectivePrefix: learned from the model's own objects, else
+    // EXTENSION_PREFIX, else the model name) → DB auto-detect for an unconfigured
+    // workspace.
     // NOT upper-cased: "ContosoFin" is a PascalCase prefix, and "CONTOSOFIN" would make every
     // suggested name and every startsWith() check below wrong.
-    let prefix = args.modelPrefix?.trim() || '';
-    if (!prefix) {
-      prefix = resolveObjectPrefix(modelName) || detectModelPrefix(db, name);
-    }
+    const resolution = resolveEffectivePrefix(modelName);
+    const explicitPrefix = args.modelPrefix?.trim() || '';
+    const prefix = explicitPrefix || resolution.prefix || detectModelPrefix(db, name);
+
+    // An explicitly passed prefix is the caller's decision and the only candidate;
+    // otherwise every token that could rightfully prefix a name in this workspace
+    // counts, so a disagreement between model and configuration produces a warning
+    // naming both rather than an error against whichever one the server picked.
+    const resolvedCandidates = prefixCandidates(resolution);
+    const candidates: PrefixCandidate[] = explicitPrefix
+      ? [{ token: explicitPrefix.replace(/_+$/, ''), label: 'the prefix you passed', effective: true }]
+      : resolvedCandidates.length > 0
+        ? resolvedCandidates
+        : prefix
+          ? [{ token: prefix, label: 'the prefix detected from the symbol index', effective: true }]
+          : [];
+    // Stated once, wherever the name lands: the reader cannot otherwise tell which
+    // of the two tokens the validation above used.
+    const conflictWarning = explicitPrefix ? null : prefixConflictWarning(resolution);
     // Token embedded in extension element/class names — the model's own infix when its
     // existing extensions state one (ContosoFinanceSK → "ContosoSK"), else derived.
     const extensionInfix = prefix ? deriveExtensionInfix(prefix, modelName) : '';
@@ -176,14 +202,21 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
 
     // Rule set 2: new object naming rules
     if (!isExtension) {
+      /** The candidate prefix the name turned out to carry, once one is found. */
+      let separator: PrefixCandidate | null = null;
+
       // Underscores are allowed only as a prefix separator: {Prefix}_{Rest}
       // (e.g. valid "MY_VendPaymTermsMaintain", invalid "MYVendPaymTerms_Helper").
       if (name.includes('_')) {
         const underscoreIdx = name.indexOf('_');
         const beforeUnderscore = name.slice(0, underscoreIdx);
-        const hasPrefixSeparator = !!prefix &&
-          beforeUnderscore.toLowerCase() === prefix.toLowerCase();
-        if (!hasPrefixSeparator) {
+        // Matched against every candidate prefix, not just the winning one: while
+        // the model's own naming and EXTENSION_PREFIX disagree, "Other_MyObject"
+        // IS prefix-separator form — under the token the server did not pick. The
+        // conflict is reported as a warning below; declaring the name invalid
+        // contradicts the prefix the server itself reports as effective (#833).
+        separator = matchPrefixCandidate(beforeUnderscore, candidates);
+        if (!separator) {
           errors.push(
             `Non-extension objects must not contain underscores. ` +
             `The only allowed underscore is as a prefix separator: ` +
@@ -194,9 +227,16 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
       }
 
       if (prefix) {
-        if (!name.toLowerCase().startsWith(prefix.toLowerCase())) {
+        const leading = separator ??
+          candidates.find(c => name.toLowerCase().startsWith(c.token.toLowerCase()));
+        if (!leading) {
           warnings.push(`Proposed name does not start with model prefix "${prefix}". All custom objects should be prefixed to avoid conflicts.`);
           suggestions.push(`Prefixed name: ${prefix}${name}`);
+        } else if (!leading.effective) {
+          warnings.push(
+            `"${name}" carries "${leading.token}" (${leading.label}), not the prefix this server ` +
+            `applies, "${prefix}" (${resolution.source}).`
+          );
         }
       }
 
@@ -229,6 +269,12 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
       }
     }
 
+    // The model's own naming and EXTENSION_PREFIX disagree. Reported wherever the
+    // name landed, because every rule above ran against ONE of the two tokens and
+    // the reader cannot otherwise tell which — the state that produced a false
+    // ERROR on a name that was correct under the effective prefix (#833).
+    if (conflictWarning) warnings.push(conflictWarning);
+
     // Rule set 3: conflict detection
     const dbType = args.objectType === 'class-extension' ? 'class-extension' :
       args.objectType === 'table-extension' ? 'table-extension' :
@@ -251,7 +297,13 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
     let output = `Validation: "${name}" as ${args.objectType}\n`;
     if (args.baseObjectName) output += `Base Object: ${args.baseObjectName}\n`;
     if (prefix) {
-      output += `Model Prefix: ${prefix}${modelName ? ` (model ${modelName})` : ''}\n`;
+      // The origin comes along, because the same prefix line in get_workspace_info
+      // carries it — without it the two read as two independent opinions.
+      const origin = explicitPrefix ? 'passed in' : resolution.source;
+      // The inferred-prefix origin already names the model; repeating it reads as
+      // two different models.
+      const modelPart = modelName && !origin.includes(`"${modelName}"`) ? `model ${modelName}, ` : '';
+      output += `Model Prefix: ${prefix}${modelName ? ` (${modelPart}${origin})` : ''}\n`;
     }
     if (isExtension) {
       output += useModelName

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -13,6 +13,9 @@ import { registerCustomModel, getCustomModels } from './modelClassifier.js';
 import { XppConfigProvider, type XppEnvironmentConfig } from './xppConfigProvider.js';
 import { FALLBACK_PACKAGES_ROOT, findPackagesRoot } from './packagesRoot.js';
 import { debugLog } from './logger.js';
+import {
+  recordDetectionSuccess, reportUnresolvedDetection, resetWorkspaceDetectionStatus,
+} from './workspaceDetectionStatus.js';
 
 export interface McpContext {
   workspacePath?: string;
@@ -94,6 +97,10 @@ class ConfigManager {
   // active project off the model this workspace itself resolved to. `anchorModel` is
   // that original model and it survives further switches — see getWriteAnchorModel().
   private toolForcedProject: { anchorModel: string; forcedModel: string } | null = null;
+  // The sources available the last time detection ran, and whether the retry that
+  // a change in them buys has been spent — see ensureProjectDetection().
+  private lastDetectionFingerprint: string | null = null;
+  private detectionRetried = false;
 
   constructor(configPath?: string) {
     // Default to .mcp.json in current directory or parent directories
@@ -149,6 +156,7 @@ class ConfigManager {
     }
 
     this.autoDetectionAttempted = true;
+    this.lastDetectionFingerprint = this.detectionSourceFingerprint(workspacePath);
 
     // .rnrproj files only exist on Windows D365FO VMs — skip scan on Azure/Linux
     if (process.platform !== 'win32') {
@@ -189,6 +197,7 @@ class ConfigManager {
             // Prefer model name already resolved via Priority 4 (from PackagesLocalDirectory regex)
             modelName: detectedProject?.modelName || pkgScan.modelName,
             packagePath: packagePathHint,
+            detectionSource: 'the configured packagePath',
           };
           console.error(`[ConfigManager] ✅ Found .rnrproj via packagePath scan: ${pkgScan.projectPath}`);
         } else {
@@ -239,10 +248,23 @@ class ConfigManager {
       );
       console.error(`   ModelName: ${detectedProject.modelName}`);
       console.error(`   SolutionPath: ${detectedProject.solutionPath}`);
+      if (detectedProject.detectionSource) {
+        console.error(`   Source: ${detectedProject.detectionSource}`);
+      }
+      // Recorded here rather than at each route's own return: this is the point
+      // the result survives the staleness guard and becomes the answer.
+      recordDetectionSuccess(
+        detectedProject.detectionSource ?? 'workspace auto-detection',
+        detectedProject.modelName,
+        detectedProject.projectPath ?? null,
+      );
       // ✨ Register the auto-detected model as custom
       registerCustomModel(detectedProject.modelName);
     } else {
-      console.error('[ConfigManager] ⚠️ Auto-detection failed - no .rnrproj files found');
+      // Not a warning: the D365FO_SOLUTIONS_PATH scan below still runs, and
+      // .mcp.json may name the model outright. reportUnresolvedDetection() warns
+      // once nothing has resolved it and a caller actually needs one (#833).
+      debugLog('[ConfigManager] No .rnrproj found in the workspace pass');
     }
 
     // Scan D365FO_SOLUTIONS_PATH for all available projects (for solution-switching support).
@@ -281,7 +303,72 @@ class ConfigManager {
         }
         this.autoDetectedProject = primary;
         registerCustomModel(primary.modelName);
+        recordDetectionSuccess('the D365FO_SOLUTIONS_PATH scan', primary.modelName, primary.projectPath ?? null);
         console.error(`[ConfigManager] ✅ Using first found project as primary: ${primary.modelName}`);
+      }
+    }
+  }
+
+  /**
+   * The detection sources available right now, as a comparable string.
+   *
+   * A first pass that ran before the workspace roots / packagePath arrived looked
+   * at strictly less than a later one would — that is the race behind the boot
+   * warning (#833). A change in this fingerprint is what makes a retry worth the
+   * filesystem scan; an unchanged one would repeat the same walk for the same
+   * answer.
+   */
+  private detectionSourceFingerprint(workspacePath?: string): string {
+    const ctx = this.config?.servers?.context;
+    return JSON.stringify([
+      workspacePath ?? null,
+      this.runtimeContext.workspacePath ?? null,
+      this.runtimeContext.packagePath ?? null,
+      this.runtimeContext.projectPath ?? null,
+      ctx?.workspacePath ?? null,
+      ctx?.packagePath ?? null,
+      ctx?.projectPath ?? null,
+      ctx?.modelName ?? null,
+      process.env.D365FO_SOLUTIONS_PATH ?? null,
+      this.allDetectedProjects.length,
+    ]);
+  }
+
+  /**
+   * Run workspace detection if it has not run yet, and re-run it once when the
+   * first pass came up empty and a source it needs has appeared since.
+   *
+   * The first pass fires roughly two seconds into startup, before the bridge and
+   * the workspace roots are up; treating its result as final is what made the
+   * server report "could not auto-detect" for a workspace it went on to resolve
+   * moments later (#833). Only when the retry has also failed — and a caller
+   * actually needs a project — is the warning emitted.
+   */
+  private async ensureProjectDetection(workspacePath?: string): Promise<void> {
+    if (!this.autoDetectionAttempted) {
+      await this.autoDetectProject(workspacePath);
+    } else if (
+      !this.autoDetectedProject &&
+      !this.detectionRetried &&
+      this.lastDetectionFingerprint !== null &&
+      this.detectionSourceFingerprint(workspacePath) !== this.lastDetectionFingerprint
+    ) {
+      this.detectionRetried = true;
+      this.autoDetectionAttempted = false;
+      this.autoDetectionCache.delete(workspacePath || 'default');
+      console.error('[ConfigManager] Re-running workspace detection — sources have come up since the first pass');
+      await this.autoDetectProject(workspacePath);
+    }
+
+    // A model named in .mcp.json (or D365FO_MODEL_NAME) settles the question just
+    // as well as a scan does — recorded so `doctor` reports THAT as the source
+    // that won, rather than an unresolved detection nothing was waiting for.
+    if (!this.autoDetectedProject) {
+      const configured = this.getModelNameWithSource();
+      if (configured.modelName) {
+        recordDetectionSuccess(configured.source, configured.modelName, this.runtimeContext.projectPath ?? null);
+      } else {
+        reportUnresolvedDetection();
       }
     }
   }
@@ -305,6 +392,10 @@ class ConfigManager {
       if (!this.autoDetectionCache.has(cacheKey)) {
         this.autoDetectionAttempted = false;
         this.autoDetectedProject = null;
+        // A different workspace resolves to a different project — what the last
+        // one detected, and the retry it was owed, say nothing about this one.
+        this.detectionRetried = false;
+        resetWorkspaceDetectionStatus();
         // A workspace this server has never seen — the user moved, so the write
         // anchor of the PREVIOUS workspace must not survive into this one. Left
         // standing it becomes the mirror of the bug it prevents: every write into
@@ -325,6 +416,7 @@ class ConfigManager {
             this.autoDetectedProject = matched;
             this.autoDetectionAttempted = true;
             this.autoDetectionCache.set(cacheKey, matched);
+            recordDetectionSuccess('a known project matching the workspace path', matched.modelName, matched.projectPath ?? null);
             console.error(`[ConfigManager] ⚡ Workspace matched known project: ${matched.modelName} (gen ${this.detectionGeneration})`);
             return;
           }
@@ -388,6 +480,7 @@ class ConfigManager {
         this.autoDetectionAttempted = true;
         this.autoDetectionCache.set(rootPath, match);
         registerCustomModel(match.modelName);
+        recordDetectionSuccess('the workspace root path', match.modelName, match.projectPath ?? null);
         // The workspace itself resolved a project — the user moved, not the agent.
         this.toolForcedProject = null;
         console.error(`[ConfigManager] ⚡ Root matched project: ${match.modelName} (gen ${gen}, ${match.projectPath})`);
@@ -410,6 +503,7 @@ class ConfigManager {
             this.autoDetectionAttempted = true;
             this.autoDetectionCache.set(rootPath, gitMatch);
             registerCustomModel(gitMatch.modelName);
+            recordDetectionSuccess(`the git branch name "${branch}"`, gitMatch.modelName, gitMatch.projectPath ?? null);
             this.toolForcedProject = null;   // genuine workspace move — see above
             console.error(`[ConfigManager] 🌿 Git branch "${branch}" → project: ${gitMatch.modelName} (gen ${gen})`);
             return;
@@ -970,10 +1064,7 @@ class ConfigManager {
       ]);
     }
 
-    if (!this.autoDetectionAttempted) {
-      const ctx = this.config?.servers?.context;
-      await this.autoDetectProject(this.runtimeContext.workspacePath || ctx?.workspacePath);
-    } else if (!this.autoDetectedProject && this.detectionInProgress) {
+    if (this.autoDetectionAttempted && !this.autoDetectedProject && this.detectionInProgress) {
       // autoDetectionAttempted was set immediately when background scan started,
       // but the scan hasn't finished yet — wait up to 5 s for the result.
       await Promise.race([
@@ -982,6 +1073,8 @@ class ConfigManager {
       ]);
       this.detectionInProgress = null;
     }
+    const ctx = this.config?.servers?.context;
+    await this.ensureProjectDetection(this.runtimeContext.workspacePath || ctx?.workspacePath);
 
     // Model name
     const { modelName, source: modelSource } = this.getModelNameWithSource();
@@ -1141,18 +1234,15 @@ class ConfigManager {
    * running. Bounded the same way getWorkspaceInfoDiagnostics() bounds it.
    */
   private async awaitPendingDetection(): Promise<void> {
-    if (!this.autoDetectionAttempted) {
-      const ctx = this.config?.servers?.context;
-      await this.autoDetectProject(this.runtimeContext.workspacePath || ctx?.workspacePath);
-      return;
-    }
-    if (!this.autoDetectedProject && this.detectionInProgress) {
+    if (this.autoDetectionAttempted && !this.autoDetectedProject && this.detectionInProgress) {
       await Promise.race([
         this.detectionInProgress,
         new Promise<void>(resolve => setTimeout(resolve, 5_000)),
       ]);
       this.detectionInProgress = null;
     }
+    const ctx = this.config?.servers?.context;
+    await this.ensureProjectDetection(this.runtimeContext.workspacePath || ctx?.workspacePath);
   }
 
   /**
@@ -1198,9 +1288,7 @@ class ConfigManager {
     }
 
     // Priority 3: Auto-detection
-    if (!this.autoDetectionAttempted) {
-      await this.autoDetectProject(this.runtimeContext.workspacePath || context?.workspacePath);
-    }
+    await this.ensureProjectDetection(this.runtimeContext.workspacePath || context?.workspacePath);
 
     return this.autoDetectedProject?.projectPath || null;
   }
@@ -1222,9 +1310,7 @@ class ConfigManager {
     }
 
     // Priority 3: Auto-detection
-    if (!this.autoDetectionAttempted) {
-      await this.autoDetectProject(this.runtimeContext.workspacePath || context?.workspacePath);
-    }
+    await this.ensureProjectDetection(this.runtimeContext.workspacePath || context?.workspacePath);
 
     return this.autoDetectedProject?.solutionPath || null;
   }
@@ -1262,10 +1348,8 @@ class ConfigManager {
    * the real model to the user.
    */
   async getRawAutoDetectedModelName(): Promise<string | null> {
-    if (!this.autoDetectionAttempted) {
-      const context = this.config?.servers?.context;
-      await this.autoDetectProject(this.runtimeContext.workspacePath || context?.workspacePath);
-    }
+    const context = this.config?.servers?.context;
+    await this.ensureProjectDetection(this.runtimeContext.workspacePath || context?.workspacePath);
     return this.autoDetectedProject?.modelName || null;
   }
 
@@ -1281,10 +1365,8 @@ class ConfigManager {
       return alreadyKnown;
     }
 
-    if (!this.autoDetectionAttempted) {
-      const context = this.config?.servers?.context;
-      await this.autoDetectProject(this.runtimeContext.workspacePath || context?.workspacePath);
-    }
+    const context = this.config?.servers?.context;
+    await this.ensureProjectDetection(this.runtimeContext.workspacePath || context?.workspacePath);
 
     return this.autoDetectedProject?.modelName || null;
   }

--- a/src/utils/effectivePrefix.ts
+++ b/src/utils/effectivePrefix.ts
@@ -1,0 +1,159 @@
+/**
+ * The single place that answers "which prefix does this session actually apply?"
+ *
+ * Two components used to answer it separately: get_workspace_info reported the
+ * prefix the ACTIVE MODEL's own objects use, while validate_object_naming
+ * checked names against the configured EXTENSION_PREFIX. With the two
+ * disagreeing — the ordinary state, since a globally configured prefix cannot be
+ * right for every model — the server reported one token as authoritative and
+ * then rejected names built from it (#833). The resolution therefore lives here
+ * and both tools read it, together with the candidates a name may legitimately
+ * carry while the disagreement lasts.
+ *
+ * The resolution ORDER is not restated here: resolveRawPrefix() in
+ * modelClassifier.ts owns it (model objects → EXTENSION_PREFIX → model name).
+ * This module adds what the callers need on top of the winning token — where it
+ * came from, what lost, and whether the two disagree at all.
+ */
+
+import { resolveObjectPrefix } from './modelClassifier.js';
+import { getInferredModelPrefix, type InferredModelPrefix } from './modelPrefixInference.js';
+import { crossModelWriteAllowedByConfig } from './crossModelWriteGuard.js';
+
+/** Everything a caller needs to state, and justify, the prefix it applies. */
+export interface EffectivePrefix {
+  /** The model the prefix was resolved FOR — the one writes land in. */
+  modelName: string | null;
+  /** The prefix a write applies, trailing '_' stripped. '' when nothing resolves. */
+  prefix: string;
+  /** Where `prefix` came from, in prose ("inferred from 27/27 objects of model …"). */
+  source: string;
+  /** EXTENSION_PREFIX as configured, trimmed; null when unset. */
+  configured: string | null;
+  /** The token the model's own objects use; null when it has none to teach. */
+  inferred: InferredModelPrefix | null;
+  /** True when the model's objects and EXTENSION_PREFIX name different tokens. */
+  conflict: boolean;
+}
+
+/** A prefix a proposed name may legitimately carry, and what it is. */
+export interface PrefixCandidate {
+  /** The bare token, without the regular-object underscore. */
+  token: string;
+  /** How to name this candidate in a message. */
+  label: string;
+  /** True for the token the server would actually apply. */
+  effective: boolean;
+}
+
+/**
+ * Compare prefixes bare: "DEMO_" from the model's objects and "DEMO" in the
+ * environment are the same prefix — the underscore belongs to the regular-object
+ * form, not to the token.
+ */
+function bare(token: string): string {
+  return token.replace(/_+$/, '');
+}
+
+/**
+ * The model a write would actually land in.
+ *
+ * Normally the anchor: a project switch does not move writes. But when the
+ * operator has allowed writes into the switched-to model in configuration, the
+ * guard lets them through and they land in the ACTIVE model — so that is the
+ * model whose prefix a create would apply. Reporting the anchor's prefix there
+ * would be the same defect one state over.
+ */
+export function modelWritesLandIn(
+  anchorModel: string | null,
+  activeModel: string | null,
+): string | null {
+  if (!activeModel || sameModel(activeModel, anchorModel)) return anchorModel;
+  return crossModelWriteAllowedByConfig(activeModel) ? activeModel : anchorModel;
+}
+
+/**
+ * Model names compare case-insensitively everywhere else (crossModelWriteGuard's
+ * eq, ConfigManager's anchor bookkeeping). Comparing them exactly here would
+ * report a switch — and a whole "writes are NOT switched" section — for two
+ * spellings of one model.
+ */
+export function sameModel(a: string | null, b: string | null): boolean {
+  if (!a || !b) return a === b;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/**
+ * Resolve the prefix for the model writes land in, with its origin and whatever
+ * it overruled.
+ */
+export function resolveEffectivePrefix(modelName: string | null): EffectivePrefix {
+  const configured = process.env.EXTENSION_PREFIX?.trim() || null;
+  const inferred = modelName ? getInferredModelPrefix(modelName) : null;
+  const prefix = resolveObjectPrefix(modelName ?? '');
+
+  // "0/13 objects" is what this said when the token came from the model's
+  // extension ELEMENTS rather than its regular objects (coverage is the regular
+  // objects' count, and there were none to agree). A line that contradicts
+  // itself in the section built to make the prefix checkable is worse than a
+  // vaguer one, so each origin states the evidence it actually has.
+  const source = inferred?.regular
+    ? inferred.coverage > 0
+      ? `inferred from ${inferred.coverage}/${inferred.sampleSize} objects of model "${modelName}"`
+      : `inferred from the extension elements of model "${modelName}"`
+    : configured
+      ? 'EXTENSION_PREFIX'
+      : 'model name (nothing configured)';
+
+  const conflict =
+    !!inferred?.regular && !!configured && bare(inferred.regular).toLowerCase() !== bare(configured).toLowerCase();
+
+  return { modelName: modelName || null, prefix, source, configured, inferred, conflict };
+}
+
+/**
+ * The tokens a proposed name may legitimately start with. Exactly one entry
+ * while configuration and model agree; while they disagree the loser stays a
+ * candidate, because a name built from it is a naming-convention question for
+ * the operator to settle, not an error for the server to declare.
+ */
+export function prefixCandidates(resolution: EffectivePrefix): PrefixCandidate[] {
+  const out: PrefixCandidate[] = [];
+  const add = (token: string | null | undefined, label: string, effective: boolean) => {
+    const t = bare(token?.trim() ?? '');
+    if (!t || out.some(c => c.token.toLowerCase() === t.toLowerCase())) return;
+    out.push({ token: t, label, effective });
+  };
+
+  add(resolution.prefix, 'the effective prefix', true);
+  add(
+    resolution.inferred?.regular,
+    `the prefix model "${resolution.modelName}"'s own objects use`,
+    false,
+  );
+  add(resolution.configured, 'the configured EXTENSION_PREFIX', false);
+  return out;
+}
+
+/** The candidate `token` is, or null when it is none of them. */
+export function matchPrefixCandidate(
+  token: string,
+  candidates: PrefixCandidate[],
+): PrefixCandidate | null {
+  const needle = bare(token).toLowerCase();
+  if (!needle) return null;
+  return candidates.find(c => c.token.toLowerCase() === needle) ?? null;
+}
+
+/**
+ * The one warning both tools emit while the two sources disagree: it names both
+ * candidates and how to pin the configured one. Null when there is no conflict.
+ */
+export function prefixConflictWarning(resolution: EffectivePrefix): string | null {
+  if (!resolution.conflict) return null;
+  return (
+    `The model's own objects use "${resolution.inferred!.regular}", overriding ` +
+    `EXTENSION_PREFIX="${resolution.configured}". ` +
+    `To pin the configured value instead: EXTENSION_PREFIX_SOURCE=config.`
+  );
+}

--- a/src/utils/workspaceDetectionStatus.ts
+++ b/src/utils/workspaceDetectionStatus.ts
@@ -1,0 +1,120 @@
+/**
+ * What workspace detection resolved, and from which source.
+ *
+ * The detector used to warn from inside its own last fallback: "⚠️ Could not
+ * auto-detect D365FO project from any source", printed roughly two seconds into
+ * startup, before the sources it needs were up. Detection then succeeded by
+ * another route — the packagePath scan, the solutions-path scan, .mcp.json — and
+ * the warning stayed in the log, blaming configuration that was fine (#833).
+ *
+ * The detector therefore only RECORDS what it tried; whether that is worth a
+ * warning is decided here, once, at the moment a caller actually needs a project
+ * and every source has had its chance. A success recorded after a warning
+ * retracts it, because a stale warning in a log is indistinguishable from a live
+ * one.
+ */
+
+import { debugLog } from './logger.js';
+
+export interface WorkspaceDetectionStatus {
+  /** True once any source produced a model. */
+  resolved: boolean;
+  /** Which source won — the answer to "why this model?". */
+  source: string | null;
+  modelName: string | null;
+  projectPath: string | null;
+  /** Sources the most recent unsuccessful pass looked at, in order. */
+  tried: string[];
+  /** Detection passes run so far (a retry after new sources appear is a second). */
+  attempts: number;
+  /** True once the unresolved warning has actually been printed. */
+  warned: boolean;
+}
+
+const status: WorkspaceDetectionStatus = {
+  resolved: false,
+  source: null,
+  modelName: null,
+  projectPath: null,
+  tried: [],
+  attempts: 0,
+  warned: false,
+};
+
+/** A source produced a model. Retracts an earlier warning if one was printed. */
+export function recordDetectionSuccess(
+  source: string,
+  modelName: string,
+  projectPath?: string | null,
+): void {
+  // Re-recording the same answer is not a new attempt: several callers pass
+  // through the same resolution and the attempt count is what the warning cites.
+  if (status.resolved && status.source === source && status.modelName === modelName) return;
+
+  const wasWarned = status.warned && !status.resolved;
+  status.resolved = true;
+  status.source = source;
+  status.modelName = modelName;
+  status.projectPath = projectPath ?? null;
+  status.attempts++;
+  status.warned = false;
+
+  if (wasWarned) {
+    console.error(
+      `[WorkspaceDetector] ✅ Detection resolved after all: model "${modelName}" from ${source} ` +
+      `— the earlier "could not auto-detect" warning no longer applies`
+    );
+  }
+}
+
+/**
+ * A pass ended without a model. Deliberately silent: the sources it lists may
+ * still come up, and reportUnresolvedDetection() decides when that has stopped
+ * being plausible.
+ */
+export function recordDetectionFailure(tried: string[]): void {
+  if (status.resolved) return;
+  status.tried = tried;
+  status.attempts++;
+  debugLog(`[WorkspaceDetector] No project from: ${tried.join(', ') || '(no source available)'}`);
+}
+
+/** The current state — for doctor, get_workspace_info and tests. */
+export function getWorkspaceDetectionStatus(): Readonly<WorkspaceDetectionStatus> {
+  return { ...status };
+}
+
+/**
+ * Warn that no project could be detected — once, and only while that is still
+ * true. Returns true when a warning was printed.
+ */
+export function reportUnresolvedDetection(): boolean {
+  if (status.resolved || status.warned) return false;
+  status.warned = true;
+  console.error(
+    `[WorkspaceDetector] ⚠️ Could not auto-detect a D365FO project after ${status.attempts} ` +
+    `attempt(s). Sources tried: ${status.tried.join(', ') || '(none available)'}. ` +
+    `Set modelName/projectPath in .mcp.json, or D365FO_SOLUTIONS_PATH, to resolve it explicitly.`
+  );
+  return true;
+}
+
+/** One line for `d365fo-mcp doctor` and startup diagnostics. */
+export function describeWorkspaceDetection(): string {
+  if (status.resolved) {
+    return `model "${status.modelName}" detected from ${status.source}` +
+      (status.projectPath ? ` (${status.projectPath})` : '');
+  }
+  return `no D365FO project detected — tried: ${status.tried.join(', ') || '(none available)'}`;
+}
+
+/** Test isolation, and a workspace switch that starts detection over. */
+export function resetWorkspaceDetectionStatus(): void {
+  status.resolved = false;
+  status.source = null;
+  status.modelName = null;
+  status.projectPath = null;
+  status.tried = [];
+  status.attempts = 0;
+  status.warned = false;
+}

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs/promises';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import { debugLog } from './logger.js';
+import { recordDetectionFailure, recordDetectionSuccess } from './workspaceDetectionStatus.js';
 
 export interface D365ProjectInfo {
   /** Path to the .rnrproj file. May be undefined when model was detected from PackagesLocalDirectory path. */
@@ -25,6 +26,12 @@ export interface D365ProjectInfo {
    * anything that registers a file into a VS project.
    */
   ambiguousProjects?: string[];
+  /**
+   * Which of autoDetectD365Project's sources produced this result — the answer
+   * to "why this model?", reported by `d365fo-mcp doctor` and recorded in the
+   * detection status so a later success can retract an earlier warning (#833).
+   */
+  detectionSource?: string;
 }
 
 /**
@@ -285,11 +292,20 @@ export async function detectD365Project(workspacePath: string, maxDepth: number 
 export async function autoDetectD365Project(
   explicitWorkspacePath?: string
 ): Promise<D365ProjectInfo | null> {
+  // Every source consulted, in order, so a failure can say what it looked at
+  // instead of the bare "from any source" that named nothing (#833).
+  const tried: string[] = [];
+  const won = (source: string, result: D365ProjectInfo): D365ProjectInfo => {
+    recordDetectionSuccess(source, result.modelName, result.projectPath ?? null);
+    return { ...result, detectionSource: source };
+  };
+
   // Priority 1: Explicit workspace path
   if (explicitWorkspacePath) {
     debugLog(`[WorkspaceDetector] Using explicit workspace path: ${explicitWorkspacePath}`);
+    tried.push('workspace path');
     const result = await detectD365Project(explicitWorkspacePath);
-    if (result) return result;
+    if (result) return won('the workspace path', result);
   }
 
   // Priority 2: Current working directory (skip if it's a Node.js project —
@@ -300,16 +316,18 @@ export async function autoDetectD365Project(
     debugLog(`[WorkspaceDetector] Skipping cwd (Node.js project): ${cwd}`);
   } else {
     debugLog(`[WorkspaceDetector] Trying current working directory: ${cwd}`);
+    tried.push('current working directory');
     const cwdResult = await detectD365Project(cwd);
-    if (cwdResult) return cwdResult;
+    if (cwdResult) return won('the current working directory', cwdResult);
   }
 
   // Priority 3: Explicit env vars
   const envWorkspace = process.env.WORKSPACE_PATH;
   if (envWorkspace) {
     debugLog(`[WorkspaceDetector] Trying WORKSPACE_PATH env var: ${envWorkspace}`);
+    tried.push('WORKSPACE_PATH');
     const envResult = await detectD365Project(envWorkspace);
-    if (envResult) return envResult;
+    if (envResult) return won('the WORKSPACE_PATH env var', envResult);
   }
 
   // Priority 3b: D365FO_SOLUTIONS_PATH — scan root for ALL D365FO projects, use
@@ -318,8 +336,9 @@ export async function autoDetectD365Project(
   const solutionsRoot = process.env.D365FO_SOLUTIONS_PATH;
   if (solutionsRoot) {
     debugLog(`[WorkspaceDetector] Scanning D365FO_SOLUTIONS_PATH: ${solutionsRoot}`);
+    tried.push('D365FO_SOLUTIONS_PATH');
     const result = await detectD365Project(solutionsRoot, 6);
-    if (result) return result;
+    if (result) return won('D365FO_SOLUTIONS_PATH', result);
   }
 
   // Priority 4: Well-known VS project directories (Windows only).
@@ -343,6 +362,7 @@ export async function autoDetectD365Project(
       }
       return p;
     };
+    tried.push('well-known project directories');
     for (const searchRoot of wellKnownPaths) {
       try {
         const files = await findProjectFiles(searchRoot);
@@ -381,12 +401,12 @@ export async function autoDetectD365Project(
               : null;
             debugLog(`[WorkspaceDetector] ✅ Found project via well-known path: ${projectPath}`);
             debugLog(`[WorkspaceDetector]    ModelName: ${modelName}`);
-            return {
+            return won(`the well-known directory ${loggedSearchRoot}`, {
               modelName,
               projectPath,
               solutionPath,
               packagePath: packagePath || undefined,
-            };
+            });
           }
         }
       } catch {
@@ -399,6 +419,7 @@ export async function autoDetectD365Project(
   // e.g. K:\AOSService\PackagesLocalDirectory\MyEnhancedDataSharing → "MyEnhancedDataSharing"
   if (explicitWorkspacePath) {
     const normalized = path.normalize(explicitWorkspacePath);
+    tried.push('PackagesLocalDirectory path');
 
     // K:\...\PackagesLocalDirectory\PackageName\ModelName
     const twoLevelMatch = normalized.match(
@@ -408,11 +429,11 @@ export async function autoDetectD365Project(
       const packagePath = twoLevelMatch[1];
       const packageName = twoLevelMatch[2];
       const modelName = twoLevelMatch[3];
-      return {
+      return won('the PackagesLocalDirectory path', {
         modelName,
         packageName,
         packagePath,
-      };
+      });
     }
 
     const match = normalized.match(/^(.+[\\]PackagesLocalDirectory)[\\]([^\\]+)\\?$/i);
@@ -423,14 +444,18 @@ export async function autoDetectD365Project(
       debugLog(`[WorkspaceDetector]    Package path: ${packagePath}`);
       debugLog(`[WorkspaceDetector]    Note: projectPath unknown — addToProject=true requires projectPath in .mcp.json`);
       // projectPath and solutionPath omitted — not derivable from this path form
-      return {
+      return won('the PackagesLocalDirectory path', {
         modelName,
         packagePath,
-      };
+      });
     }
   }
 
-  console.error('[WorkspaceDetector] ⚠️ Could not auto-detect D365FO project from any source');
+  // No warning here. This function is one of several routes to a project — the
+  // packagePath scan and the solutions-path scan run after it, and .mcp.json may
+  // settle it outright — so "from any source" was false at the moment it printed.
+  // reportUnresolvedDetection() warns later, if it is still true.
+  recordDetectionFailure(tried);
   return null;
 }
 

--- a/tests/cli/doctorWorkspace.test.ts
+++ b/tests/cli/doctorWorkspace.test.ts
@@ -1,0 +1,50 @@
+/**
+ * `d365fo-mcp doctor` reports WHICH detection source won, and whether the
+ * configured prefix disagrees with the one the model's own objects use (#833).
+ *
+ * Both were previously only inferable — the detection source from a tool error,
+ * the prefix conflict from reading get_workspace_info and noticing that the
+ * effective value was not the configured one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkPrefixResolution } from '../../src/cli/commands/doctor.js';
+
+/** Four objects, all carrying "ConSK_" — enough for the inference to trust it. */
+const MODEL_OBJECTS = [
+  'ConSK_VendPaymentTable', 'ConSK_CustInvoiceJour',
+  'ConSK_LedgerJournalTrans', 'ConSK_TaxReportTable',
+];
+
+describe('doctor — prefix resolution', () => {
+  it('names both candidates when the model and the configuration disagree', () => {
+    const [result] = checkPrefixResolution('Con', 'ContosoFinanceSK', MODEL_OBJECTS, 'Naming');
+
+    expect(result.severity).toBe('warn');
+    expect(result.message).toContain('ConSK_');
+    expect(result.message).toContain('"Con"');
+    expect(result.message).toContain('The model\'s own naming wins');
+    expect(result.fix).toContain('EXTENSION_PREFIX_SOURCE=config');
+  });
+
+  it('is quiet when the two agree, underscore or not', () => {
+    const [result] = checkPrefixResolution('ConSK', 'ContosoFinanceSK', MODEL_OBJECTS, 'Naming');
+
+    expect(result.severity).toBe('ok');
+    expect(result.message).toContain('agree');
+  });
+
+  it('reports the configured prefix when the model has nothing to teach', () => {
+    const [result] = checkPrefixResolution('Con', 'BrandNewModel', [], 'Naming');
+
+    expect(result.severity).toBe('ok');
+    expect(result.message).toContain('naming.prefix');
+  });
+
+  it('warns when neither source has a prefix to offer', () => {
+    const [result] = checkPrefixResolution('', 'BrandNewModel', [], 'Naming');
+
+    expect(result.severity).toBe('warn');
+    expect(result.message).toContain('no prefix configured');
+  });
+});

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -60,6 +60,9 @@ vi.mock('../../src/utils/configManager', () => ({
     ensureLoaded: vi.fn(async () => {}),
     getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
     getModelName: vi.fn(() => 'MyModel'),
+    // validate_object_naming awaits this so a detection still in flight cannot
+    // leave it resolving the prefix for a null model (#833).
+    getAutoDetectedModelName: vi.fn(async () => 'MyModel'),
     // Writes are measured against the anchor, not the active model (see getWriteAnchorModel).
     getWriteAnchorModel: vi.fn(() => 'MyModel'),
     getToolProjectSwitch: vi.fn(() => null),

--- a/tests/tools/prefixResolutionAgreement.test.ts
+++ b/tests/tools/prefixResolutionAgreement.test.ts
@@ -1,0 +1,154 @@
+/**
+ * get_workspace_info and validate_object_naming must not disagree about the
+ * effective prefix (#833).
+ *
+ * The reported state: get_workspace_info resolved the prefix from the model's
+ * own objects and said so, and validate_object_naming then rejected a name built
+ * from that very prefix as an ERROR — "the only allowed underscore is as a prefix
+ * separator" — because it had checked the CONFIGURED prefix instead. Both tools
+ * now read utils/effectivePrefix.ts, and a disagreement between the model and the
+ * configuration produces a warning naming both candidates.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { validateObjectNamingTool } from '../../src/tools/validateObjectNaming.js';
+import { buildPrefixDiagnostics } from '../../src/tools/prefixDiagnostics.js';
+import {
+  setModelObjectNameSource, clearInferredModelPrefixes,
+} from '../../src/utils/modelPrefixInference.js';
+
+const MODEL = 'ContosoFinanceSK';
+/** The model's own objects — every one of them prefixed "ConSK_". */
+const MODEL_OBJECTS = [
+  'ConSK_VendPaymentTable', 'ConSK_CustInvoiceJour',
+  'ConSK_LedgerJournalTrans', 'ConSK_TaxReportTable',
+];
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    getModelName: () => MODEL,
+    getWriteAnchorModel: () => MODEL,
+    getAutoDetectedModelName: async () => MODEL,
+  })),
+}));
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'validate_object_naming', arguments: args },
+});
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  const db = { prepare: vi.fn(() => stmt) };
+  return {
+    symbolIndex: { db, getReadDb: () => db } as any,
+    parser: {} as any,
+    cache: {} as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+  };
+};
+
+const validate = async (args: Record<string, unknown>): Promise<string> => {
+  const result = await validateObjectNamingTool(req(args), buildContext());
+  return String(result.content[0].text);
+};
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  clearInferredModelPrefixes();
+  setModelObjectNameSource(model => (model === MODEL ? MODEL_OBJECTS : []));
+  delete process.env.EXTENSION_PREFIX_SOURCE;
+  delete process.env.EXTENSION_SUFFIX;
+  // The configured prefix is the SHORT one — the disagreement under test.
+  process.env.EXTENSION_PREFIX = 'Con';
+});
+
+afterEach(() => {
+  setModelObjectNameSource(null);
+  clearInferredModelPrefixes();
+  process.env = { ...originalEnv };
+});
+
+describe('effective prefix — validate_object_naming vs get_workspace_info', () => {
+  it('accepts a name in prefix-separator form under the INFERRED prefix', async () => {
+    // The exact call from the report: rejected with a bare ERROR even though the
+    // server itself had just reported "ConSK" as the effective prefix.
+    const out = await validate({ objectType: 'enum', proposedName: 'ConSK_NewEnum' });
+
+    expect(out).not.toMatch(/ERRORS \(\d/);
+    expect(out).toContain('Model Prefix: ConSK');
+  });
+
+  it('validates against the same prefix get_workspace_info reports', async () => {
+    const reported = buildPrefixDiagnostics(MODEL, MODEL).effectivePrefix;
+    const out = await validate({ objectType: 'enum', proposedName: 'ConSK_NewEnum' });
+
+    expect(reported).toBe('ConSK');
+    expect(out).toContain(`Model Prefix: ${reported}`);
+    // …and its origin, so the two lines can be compared at all.
+    expect(out).toContain('inferred from 4/4 objects of model "ContosoFinanceSK"');
+  });
+
+  it('names both candidates and how to pin the configured one', async () => {
+    const out = await validate({ objectType: 'enum', proposedName: 'ConSK_NewEnum' });
+
+    expect(out).toMatch(/WARNINGS \(\d/);
+    expect(out).toContain('"ConSK_"');
+    expect(out).toContain('EXTENSION_PREFIX="Con"');
+    expect(out).toContain('EXTENSION_PREFIX_SOURCE=config');
+  });
+
+  it('warns rather than errors on a name carrying the CONFIGURED prefix', async () => {
+    // "Con_NewEnum" is prefix-separator form too — under the token that lost.
+    const out = await validate({ objectType: 'enum', proposedName: 'Con_NewEnum' });
+
+    expect(out).not.toMatch(/ERRORS \(\d/);
+    expect(out).toContain('the configured EXTENSION_PREFIX');
+    expect(out).toContain('ConSK');
+  });
+
+  it('still errors on an underscore that is no prefix separator at all', async () => {
+    const out = await validate({ objectType: 'enum', proposedName: 'Random_NewEnum' });
+
+    expect(out).toMatch(/ERRORS \(\d/);
+    expect(out).toContain('must not contain underscores');
+  });
+
+  it('says nothing about a conflict when the two agree', async () => {
+    process.env.EXTENSION_PREFIX = 'ConSK';
+    const out = await validate({ objectType: 'enum', proposedName: 'ConSK_NewEnum' });
+
+    expect(out).not.toMatch(/ERRORS \(\d/);
+    expect(out).not.toContain('EXTENSION_PREFIX_SOURCE=config');
+  });
+
+  it('honours EXTENSION_PREFIX_SOURCE=config in both tools at once', async () => {
+    // The documented escape hatch: the configured value becomes authoritative,
+    // so it is what get_workspace_info reports AND what validation enforces.
+    process.env.EXTENSION_PREFIX_SOURCE = 'config';
+    clearInferredModelPrefixes();
+
+    expect(buildPrefixDiagnostics(MODEL, MODEL).effectivePrefix).toBe('Con');
+    const accepted = await validate({ objectType: 'enum', proposedName: 'Con_NewEnum' });
+    expect(accepted).not.toMatch(/ERRORS \(\d/);
+    expect(accepted).toContain('Model Prefix: Con');
+
+    const rejected = await validate({ objectType: 'enum', proposedName: 'ConSK_NewEnum' });
+    expect(rejected).toMatch(/ERRORS \(\d/);
+  });
+
+  it('leaves an explicitly passed modelPrefix as the only candidate', async () => {
+    const out = await validate({
+      objectType: 'enum', proposedName: 'ConSK_NewEnum', modelPrefix: 'Con',
+    });
+
+    expect(out).toContain('Model Prefix: Con');
+    expect(out).toMatch(/ERRORS \(\d/);
+    // The caller pinned the prefix, so the server's own disagreement is not news.
+    expect(out).not.toContain('EXTENSION_PREFIX_SOURCE=config');
+  });
+});

--- a/tests/utils/detectionRetry.test.ts
+++ b/tests/utils/detectionRetry.test.ts
@@ -1,0 +1,122 @@
+/**
+ * ConfigManager re-runs workspace detection once the sources it needs are up
+ * (#833).
+ *
+ * The first pass fires roughly two seconds into startup, before the bridge and
+ * the workspace roots have arrived. Treating its empty result as final is what
+ * made the server report "could not auto-detect" for a workspace it resolved
+ * moments later by another route.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getConfigManager } from '../../src/utils/configManager.js';
+import { getWorkspaceDetectionStatus, resetWorkspaceDetectionStatus } from '../../src/utils/workspaceDetectionStatus.js';
+
+const detected = {
+  modelName: 'ContosoCore',
+  projectPath: 'K:\\Solutions\\Contoso\\Contoso\\Contoso.rnrproj',
+  solutionPath: 'K:\\Solutions\\Contoso',
+  detectionSource: 'the workspace path',
+};
+
+const autoDetect = vi.fn(async () => null as any);
+const detectProject = vi.fn(async () => null as any);
+
+vi.mock('../../src/utils/workspaceDetector', async (orig) => {
+  const actual = await orig<typeof import('../../src/utils/workspaceDetector')>();
+  return {
+    ...actual,
+    autoDetectD365Project: (...args: any[]) => autoDetect(...(args as [])),
+    detectD365Project: (...args: any[]) => detectProject(...(args as [])),
+    scanAllD365Projects: vi.fn(async () => []),
+  };
+});
+
+/** A ConfigManager with no config file and nothing detected yet. */
+function makeManager() {
+  const ConfigManagerClass = Object.getPrototypeOf(getConfigManager()).constructor;
+  const mgr = new ConfigManagerClass('/nonexistent/.mcp.json');
+  (mgr as any).config = { servers: { context: {} } };
+  (mgr as any).xppConfigLoaded = true;
+  (mgr as any).xppConfig = null;
+  return mgr as any;
+}
+
+let stderr: ReturnType<typeof vi.spyOn>;
+const logged = () => stderr.mock.calls.map(c => c.join(' ')).join('\n');
+const savedSolutionsPath = process.env.D365FO_SOLUTIONS_PATH;
+const realPlatform = process.platform;
+
+/** Detection only scans .rnrproj on Windows, and CI is Linux. */
+function pretendWindows(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  resetWorkspaceDetectionStatus();
+  autoDetect.mockReset().mockResolvedValue(null);
+  detectProject.mockReset().mockResolvedValue(null);
+  delete process.env.D365FO_SOLUTIONS_PATH;
+  delete process.env.D365FO_MODEL_NAME;
+  stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+  pretendWindows('win32');
+});
+
+afterEach(() => {
+  pretendWindows(realPlatform);
+  stderr.mockRestore();
+  resetWorkspaceDetectionStatus();
+  if (savedSolutionsPath !== undefined) process.env.D365FO_SOLUTIONS_PATH = savedSolutionsPath;
+});
+
+describe('detection retry', () => {
+  it('stays silent on the boot pass and resolves on the retry', async () => {
+    const mgr = makeManager();
+
+    // Boot: nothing is configured yet and nothing is found.
+    await (mgr as any).autoDetectProject(undefined);
+    expect(logged()).not.toMatch(/[Cc]ould not auto-detect/);
+
+    // The workspace root arrives (roots/list, or the packagePath from .mcp.json).
+    autoDetect.mockResolvedValue(detected);
+    (mgr as any).runtimeContext.workspacePath = 'K:\\Solutions\\Contoso';
+
+    await mgr.getRawAutoDetectedModelName();
+
+    expect(autoDetect).toHaveBeenCalledTimes(2);
+    expect(await mgr.getRawAutoDetectedModelName()).toBe('ContosoCore');
+    expect(logged()).not.toMatch(/[Cc]ould not auto-detect/);
+  });
+
+  it('spends the retry once, not on every call', async () => {
+    const mgr = makeManager();
+
+    await (mgr as any).autoDetectProject(undefined);
+    (mgr as any).runtimeContext.workspacePath = 'K:\\Solutions\\Contoso';
+    await mgr.getRawAutoDetectedModelName();
+    await mgr.getRawAutoDetectedModelName();
+    await mgr.getSolutionPath();
+
+    // Two passes: the boot one and the single retry the new source bought.
+    expect(autoDetect).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns once nothing has resolved it and a caller needed one', async () => {
+    const mgr = makeManager();
+
+    await mgr.getRawAutoDetectedModelName();
+
+    expect(logged()).toMatch(/Could not auto-detect/);
+    expect(getWorkspaceDetectionStatus().resolved).toBe(false);
+  });
+
+  it('does not warn when the model is named in configuration', async () => {
+    const mgr = makeManager();
+    (mgr as any).config = { servers: { context: { modelName: 'ContosoCore' } } };
+
+    await mgr.getRawAutoDetectedModelName();
+
+    expect(logged()).not.toMatch(/Could not auto-detect/);
+    expect(getWorkspaceDetectionStatus().source).toBe('.mcp.json');
+  });
+});

--- a/tests/utils/effectivePrefix.test.ts
+++ b/tests/utils/effectivePrefix.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The single resolution point for the effective prefix (#833).
+ *
+ * Everything downstream — the get_workspace_info prefix section, the underscore
+ * rule in validate_object_naming, the doctor check — reads this, so what counts
+ * as a conflict and which tokens stay legitimate candidates is decided once.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  matchPrefixCandidate, prefixCandidates, prefixConflictWarning, resolveEffectivePrefix,
+} from '../../src/utils/effectivePrefix.js';
+import {
+  setModelObjectNameSource, clearInferredModelPrefixes,
+} from '../../src/utils/modelPrefixInference.js';
+
+const MODEL = 'ContosoFinanceSK';
+const MODEL_OBJECTS = [
+  'ConSK_VendPaymentTable', 'ConSK_CustInvoiceJour',
+  'ConSK_LedgerJournalTrans', 'ConSK_TaxReportTable',
+];
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  clearInferredModelPrefixes();
+  setModelObjectNameSource(model => (model === MODEL ? MODEL_OBJECTS : []));
+  delete process.env.EXTENSION_PREFIX;
+  delete process.env.EXTENSION_PREFIX_SOURCE;
+});
+
+afterEach(() => {
+  setModelObjectNameSource(null);
+  clearInferredModelPrefixes();
+  process.env = { ...originalEnv };
+});
+
+describe('resolveEffectivePrefix', () => {
+  it('prefers the model\'s own naming and says where it came from', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    const resolution = resolveEffectivePrefix(MODEL);
+
+    expect(resolution.prefix).toBe('ConSK');
+    expect(resolution.source).toBe('inferred from 4/4 objects of model "ContosoFinanceSK"');
+    expect(resolution.configured).toBe('Con');
+    expect(resolution.conflict).toBe(true);
+  });
+
+  it('treats "ConSK_" and "ConSK" as the same prefix', () => {
+    // The underscore belongs to the regular-object form, not to the token.
+    process.env.EXTENSION_PREFIX = 'ConSK';
+
+    expect(resolveEffectivePrefix(MODEL).conflict).toBe(false);
+    expect(prefixConflictWarning(resolveEffectivePrefix(MODEL))).toBeNull();
+  });
+
+  it('falls back to EXTENSION_PREFIX for a model with nothing to teach', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    const resolution = resolveEffectivePrefix('BrandNewModel');
+
+    expect(resolution.prefix).toBe('Con');
+    expect(resolution.source).toBe('EXTENSION_PREFIX');
+    expect(resolution.conflict).toBe(false);
+  });
+
+  it('lets EXTENSION_PREFIX_SOURCE=config win, leaving nothing to conflict with', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    process.env.EXTENSION_PREFIX_SOURCE = 'config';
+    const resolution = resolveEffectivePrefix(MODEL);
+
+    expect(resolution.prefix).toBe('Con');
+    expect(resolution.inferred).toBeNull();
+    expect(resolution.conflict).toBe(false);
+  });
+});
+
+describe('prefixCandidates', () => {
+  it('keeps the losing token as a candidate while the two disagree', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    const candidates = prefixCandidates(resolveEffectivePrefix(MODEL));
+
+    expect(candidates.map(c => c.token)).toEqual(['ConSK', 'Con']);
+    expect(candidates[0].effective).toBe(true);
+    expect(candidates[1].effective).toBe(false);
+    expect(candidates[1].label).toContain('EXTENSION_PREFIX');
+  });
+
+  it('offers exactly one candidate when the two agree', () => {
+    process.env.EXTENSION_PREFIX = 'ConSK_';
+
+    expect(prefixCandidates(resolveEffectivePrefix(MODEL))).toHaveLength(1);
+  });
+
+  it('matches a candidate case-insensitively and ignores the separator', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    const candidates = prefixCandidates(resolveEffectivePrefix(MODEL));
+
+    expect(matchPrefixCandidate('consk', candidates)?.effective).toBe(true);
+    expect(matchPrefixCandidate('Con_', candidates)?.effective).toBe(false);
+    expect(matchPrefixCandidate('Random', candidates)).toBeNull();
+    expect(matchPrefixCandidate('', candidates)).toBeNull();
+  });
+});
+
+describe('prefixConflictWarning', () => {
+  it('names both candidates and how to pin the configured one', () => {
+    process.env.EXTENSION_PREFIX = 'Con';
+    const warning = prefixConflictWarning(resolveEffectivePrefix(MODEL))!;
+
+    expect(warning).toContain('"ConSK_"');
+    expect(warning).toContain('EXTENSION_PREFIX="Con"');
+    expect(warning).toContain('EXTENSION_PREFIX_SOURCE=config');
+  });
+});

--- a/tests/utils/workspaceDetectionStatus.test.ts
+++ b/tests/utils/workspaceDetectionStatus.test.ts
@@ -1,0 +1,110 @@
+/**
+ * When workspace detection may warn, and which source it reports as the winner
+ * (#833).
+ *
+ * The detector used to print "⚠️ Could not auto-detect D365FO project from any
+ * source" from inside its own last fallback, roughly two seconds into startup —
+ * before the packagePath scan, the solutions-path scan and .mcp.json had had
+ * their turn. Detection then succeeded by one of those routes and the warning
+ * stayed in the log, blaming configuration that was fine.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { autoDetectD365Project } from '../../src/utils/workspaceDetector.js';
+import {
+  describeWorkspaceDetection, getWorkspaceDetectionStatus, recordDetectionSuccess,
+  reportUnresolvedDetection, resetWorkspaceDetectionStatus,
+} from '../../src/utils/workspaceDetectionStatus.js';
+
+const tempDirs: string[] = [];
+async function makeTempWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'd365fo-detection-status-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+let stderr: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetWorkspaceDetectionStatus();
+  stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  stderr.mockRestore();
+  resetWorkspaceDetectionStatus();
+  await Promise.all(tempDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+/** Everything written to stderr during the test, as one string. */
+const logged = () => stderr.mock.calls.map(c => c.join(' ')).join('\n');
+
+describe('workspace detection status', () => {
+  it('does not warn when a detection pass finds nothing', async () => {
+    // The pass is one route among several; the packagePath and solutions-path
+    // scans run after it and .mcp.json may settle the model outright.
+    const empty = await makeTempWorkspace();
+
+    const result = await autoDetectD365Project(empty);
+
+    expect(result).toBeNull();
+    expect(logged()).not.toMatch(/[Cc]ould not auto-detect/);
+    expect(getWorkspaceDetectionStatus().resolved).toBe(false);
+    expect(getWorkspaceDetectionStatus().tried).toContain('workspace path');
+  });
+
+  it('names the source that won', async () => {
+    const workspace = await makeTempWorkspace();
+    const dir = path.join(workspace, 'ProjectAlpha');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'ProjectAlpha.rnrproj'),
+      '<?xml version="1.0" encoding="utf-8"?>\n<Project><Model>AlphaModel</Model></Project>\n',
+      'utf-8',
+    );
+
+    const result = await autoDetectD365Project(workspace);
+
+    expect(result?.detectionSource).toBe('the workspace path');
+    expect(describeWorkspaceDetection()).toContain('model "AlphaModel" detected from the workspace path');
+  });
+
+  it('lists the sources it looked at instead of "any source"', () => {
+    reportUnresolvedDetection();
+
+    expect(logged()).toMatch(/Could not auto-detect/);
+    expect(logged()).toContain('Sources tried');
+  });
+
+  it('warns at most once', () => {
+    expect(reportUnresolvedDetection()).toBe(true);
+    expect(reportUnresolvedDetection()).toBe(false);
+  });
+
+  it('never warns once a source has resolved the project', () => {
+    recordDetectionSuccess('the configured packagePath', 'ContosoCore', 'K:\\p\\Contoso.rnrproj');
+
+    expect(reportUnresolvedDetection()).toBe(false);
+    expect(logged()).not.toMatch(/Could not auto-detect/);
+  });
+
+  it('retracts a warning that a later success proved wrong', () => {
+    reportUnresolvedDetection();
+    recordDetectionSuccess('the D365FO_SOLUTIONS_PATH scan', 'ContosoCore');
+
+    expect(logged()).toMatch(/Detection resolved after all/);
+    expect(getWorkspaceDetectionStatus().warned).toBe(false);
+    expect(getWorkspaceDetectionStatus().source).toBe('the D365FO_SOLUTIONS_PATH scan');
+  });
+
+  it('does not count re-recording the same answer as a new attempt', () => {
+    recordDetectionSuccess('.mcp.json', 'ContosoCore');
+    recordDetectionSuccess('.mcp.json', 'ContosoCore');
+
+    expect(getWorkspaceDetectionStatus().attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
Two config-resolution defects from the session audit (#824), fixed together because both are "two components answered the same question differently".

## Part 2 — one resolution point for the effective prefix

`get_workspace_info` reported the prefix inferred from the model's own objects and explicitly said it overrode `EXTENSION_PREFIX`; `validate_object_naming` then validated against the **configured** prefix and returned a bare ERROR for `<Inferred>_NewEnum` — a name that *is* prefix-separator form under the token the server had just called effective.

- **New `src/utils/effectivePrefix.ts`** — the single resolution point. Given the model writes land in, it returns the prefix, its origin in prose, the configured value, the inferred value, and whether the two conflict. It also owns `modelWritesLandIn`/`sameModel` (moved out of `prefixDiagnostics.ts`, which re-exports `modelWritesLandIn` so existing importers are untouched). The resolution ORDER is unchanged and still lives in `resolveRawPrefix()`.
- **`src/tools/prefixDiagnostics.ts`** (the `get_workspace_info` prefix section) now reads it. Output strings are byte-identical — its 14 existing tests pass unchanged.
- **`src/tools/validateObjectNaming.ts`** now reads it too, for the same model: the **write anchor** via `modelWritesLandIn(getWriteAnchorModel(), getModelName())`, not the active model (they differ after a project switch), and it awaits `getAutoDetectedModelName()` first so a detection still in flight cannot leave it resolving the prefix for a null model — the state that silently falls back to `EXTENSION_PREFIX`.
- While configured and inferred disagree, **both tokens stay legitimate candidates**. The underscore rule matches `beforeUnderscore` against the candidate list instead of one winner, so prefix-separator form under either token is no longer an ERROR; the result carries a warning naming both candidates and `EXTENSION_PREFIX_SOURCE=config`. An explicitly passed `modelPrefix` remains the caller's decision and the only candidate.
- The `Model Prefix:` header line now carries the origin (`inferred from 4/4 objects of model "X"` / `EXTENSION_PREFIX`), so the two tools' prefix lines are comparable rather than reading as two independent opinions.

## Part 1 — workspace auto-detection

- **`src/utils/workspaceDetectionStatus.ts`** (new) records what detection tried and which source won. `autoDetectD365Project` no longer prints `⚠️ Could not auto-detect … from any source` — it was false at the moment it printed, since the packagePath scan, the solutions-path scan and `.mcp.json` all run afterwards. Each successful route now tags its result with `detectionSource`.
- **`ConfigManager.ensureProjectDetection()`** (new) replaces the seven `if (!autoDetectionAttempted) autoDetectProject(...)` guards. It runs detection if it never ran, and **re-runs it once** when the first pass came up empty and a source has appeared since (fingerprint over workspace/package/project paths, `D365FO_SOLUTIONS_PATH`, configured model, known-project count). The retry is spent once, not per call.
- The warning is emitted only from there — a caller needed a project, the retry has been spent, and neither a scan nor configuration resolved one. A model named in `.mcp.json`/`D365FO_MODEL_NAME` counts as resolved and is recorded as the winning source. A success recorded after a warning **retracts it** in the log.

## doctor

`d365fo-mcp doctor` gained two checks (`checkWorkspaceDetection`, `checkPrefixResolution`, both exported for tests): the source that resolved the workspace and the model it landed on, and a prefix conflict naming both candidates with `EXTENSION_PREFIX_SOURCE=config` as the fix. The prefix check reads the model's object names straight from the symbol index (same query as `SymbolIndex.getModelObjectNames`) and stays silent when there is no index.

## Acceptance

| Criterion | How it is met |
| --- | --- |
| no `Could not auto-detect` warning when detection subsequently succeeds | The detector only records; the warning is emitted once, from `ensureProjectDetection`, after the retry and only while nothing (scan or config) has resolved a model — and a later success prints an explicit retraction. Covered by `detectionRetry.test.ts` ("stays silent on the boot pass and resolves on the retry") and `workspaceDetectionStatus.test.ts`. |
| `validate_object_naming` and `get_workspace_info` never disagree about the effective prefix | Both call `resolveEffectivePrefix()` for the write-anchor model. `prefixResolutionAgreement.test.ts` asserts the validator's `Model Prefix:` line equals `buildPrefixDiagnostics().effectivePrefix`, including under `EXTENSION_PREFIX_SOURCE=config`. |
| a prefix conflict produces a warning naming both candidates, not a false error | `<Inferred>_NewEnum` now returns no ERRORS and one warning quoting `"ConSK_"`, `EXTENSION_PREFIX="Con"` and `EXTENSION_PREFIX_SOURCE=config`; a name carrying the configured token is likewise a warning; a genuine non-prefix underscore (`Random_NewEnum`) still errors. |
| doctor reports which detection source won | `checkWorkspaceDetection` prints `model "X" detected from <source>` (or the list of sources tried) plus the project path. |
| doctor surfaces the prefix conflict | `checkPrefixResolution` warns with both tokens, the inference coverage, and the pin instruction. |

## Tests

`npx vitest run` — **210 files, 2737 passed, 9 skipped**, 0 failures (was 2706 before; +31 new). `npx tsc --noEmit` clean.

New: `tests/utils/effectivePrefix.test.ts` (8), `tests/tools/prefixResolutionAgreement.test.ts` (8), `tests/utils/workspaceDetectionStatus.test.ts` (7), `tests/utils/detectionRetry.test.ts` (4), `tests/cli/doctorWorkspace.test.ts` (4). One existing mock in `tests/tools/file-ops.test.ts` gained `getAutoDetectedModelName` (the real `ConfigManager` has it; the mock predates the await).

## Notes / deliberately not done

- No MCP tool-surface change (no new tools, no schema edits), so `docs/NEW_TOOL_CHECKLIST.md` does not apply — only `validate_object_naming`'s **output text** changed.
- The conflict warning is emitted on every `validate_object_naming` call while the two sources disagree, not only when the proposed name engages the prefix. That is one extra line in a genuinely ambiguous state, and it matches what `get_workspace_info` already prints.
- The `get_object_info` "not found … ensure .mcp.json has the correct modelName/projectPath" text mentioned in the issue is left alone: with detection fixed it no longer fires for this cause, and rewording it belongs with the not-found guidance work rather than here.
- The retry is capped at one per workspace (reset when the workspace changes). An unbounded retry would repeat a full filesystem walk on every getter for the same answer.

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)
