### PR TITLE
perf(build): stream progress and stop answering fullBuild:true from cache

### DIFF
--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -13,6 +13,7 @@ import { lookupErrorFix } from './d365foErrorHelp.js';
 import { generateRuntimeMetadata } from './generateMetadata.js';
 import { compileModelLabels, type CompileLabelsResult } from './compileLabels.js';
 import { readModuleReferences } from '../metadata/modelDescriptor.js';
+import type { ProgressReporter } from '../utils/progressReporter.js';
 
 const execFileAsync = util.promisify(execFile);
 
@@ -157,6 +158,13 @@ interface BuildJobState {
   startTime: string;
   logFile: string;         // Log for the CURRENT model in the queue
   status: 'running' | 'succeeded' | 'failed';
+  // What a 'running' state is actually doing. 'finalizing' means xppc has
+  // already exited and the in-process close handler is doing post-build work
+  // (runtime metadata regeneration, up to ~90 s) before it can write the final
+  // result. Without this a waiter sees a dead PID, concludes the build was
+  // orphaned and returns a "still running" stub for a build that in fact
+  // succeeded seconds ago — the 185 s double-call of #829.
+  phase?: 'compiling' | 'finalizing';
   exitCode?: number;
   endTime?: string;
   fullBuild?: boolean;
@@ -568,6 +576,11 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
     closeSyncFs(logFd);
     const exitCode = code ?? -1;
 
+    // Publish "xppc is gone, I am finishing up" BEFORE the post-build work, so
+    // a waiter can tell this apart from an orphaned process and keeps waiting
+    // instead of returning a stub for an already-finished build.
+    await writeBuildState({ ...liveState, phase: 'finalizing' }, customPackagesPath).catch(() => {});
+
     // Read the -log file (authoritative source of X++ compiler errors)
     let xppcErrContent = '';
     try {
@@ -790,48 +803,133 @@ function incrementalScopeCaveat(succeeded: boolean, fullBuild: boolean): string 
 
 // ---------------------------------------------------------------------------
 // Block until the build for `targetModel` reaches a non-running state, the
-// tracked process is no longer alive, or `timeoutMs` elapses. Returns the
-// final state when finished, or null when the timeout was hit.
+// tracked process is confirmed gone without a result, or `timeoutMs` elapses.
+//
+// Outcomes:
+//   { outcome: 'finished',  state }  — build reached succeeded/failed
+//   { outcome: 'orphaned',  state }  — process vanished, no result was written
+//   { outcome: 'timeout',   state }  — wait window expired, build still running
 // ---------------------------------------------------------------------------
+
+/** How often the waiter emits an MCP progress notification while blocking. */
+const PROGRESS_INTERVAL_MS = 10_000;
+
+/**
+ * Default wait window. Long on purpose: with progress streaming the caller is
+ * not sitting in silence, and a timeout short enough to fire on a normal build
+ * is the worst of both worlds — it blocks for minutes AND still hands back a
+ * "call me again" stub that costs another round trip (#829).
+ */
+const DEFAULT_WAIT_TIMEOUT_MS = 30 * 60 * 1000;
+
+function resolveWaitTimeoutMs(params: any): number {
+  return (typeof params.waitTimeoutMs === 'number' && params.waitTimeoutMs > 0)
+    ? params.waitTimeoutMs
+    : DEFAULT_WAIT_TIMEOUT_MS;
+}
+
+/**
+ * How long a dead PID is tolerated before the build is called orphaned. The
+ * close handler runs in THIS process and finishes with runtime-metadata
+ * regeneration (two execFile calls capped at 30 s + 60 s), so 'finalizing'
+ * gets a window that comfortably covers it; anything else — an orphan from a
+ * previous server process, a killed xppc — is only given time to settle.
+ */
+const FINALIZING_GRACE_MS = 5 * 60_000;
+const ORPHAN_GRACE_MS = 30_000;
+
+interface WaitOutcome {
+  outcome: 'finished' | 'orphaned' | 'timeout';
+  state: BuildJobState | null;
+}
 
 async function waitForBuildCompletion(
   targetModel: string,
   customPackagesPath: string,
   timeoutMs: number,
-): Promise<BuildJobState | null> {
+  onProgress?: ProgressReporter,
+  startedAt: number = Date.now(),
+): Promise<WaitOutcome> {
   const deadline = Date.now() + timeoutMs;
   // Poll roughly every second; xppc builds typically take many seconds to
   // many minutes, so a 1 s cadence is fine and keeps responsiveness high.
   const pollIntervalMs = 1000;
   let lastState: BuildJobState | null = null;
+  // When the tracked PID was first seen dead — reset whenever it is alive again
+  // (a queue advance briefly runs with pid 0 between models).
+  let pidDeadSince: number | null = null;
+  // 0 = emit on the very first poll. The first update is worth its cost: it
+  // confirms the build is actually under way and starts the client's
+  // timeout-reset clock immediately rather than PROGRESS_INTERVAL_MS later.
+  let lastProgressAt = 0;
+
   while (Date.now() < deadline) {
     const state = await readBuildState(targetModel, customPackagesPath);
     if (state) {
       lastState = state;
-      if (state.status !== 'running') return state;
-      // Process disappeared without writing a final state — give the close
-      // handler up to ~2 s to settle, then return whatever we have so the
-      // caller can surface a sensible "exited unexpectedly" message.
-      if (state.pid && !isProcessAlive(state.pid)) {
-        for (let i = 0; i < 4; i++) {
-          await new Promise(r => setTimeout(r, 500));
-          const refreshed = await readBuildState(targetModel, customPackagesPath);
-          if (refreshed && refreshed.status !== 'running') return refreshed;
-        }
-        return state;
+      if (state.status !== 'running') return { outcome: 'finished', state };
+
+      // pid 0 means a queue advance is in flight (the next model has not been
+      // spawned yet) — transient, never an orphan.
+      const finalizing = state.phase === 'finalizing';
+      const settled = !finalizing && (!state.pid || isProcessAlive(state.pid));
+      if (settled) {
+        pidDeadSince = null;
+      } else {
+        if (pidDeadSince === null) pidDeadSince = Date.now();
+        const grace = finalizing ? FINALIZING_GRACE_MS : ORPHAN_GRACE_MS;
+        if (Date.now() - pidDeadSince > grace) return { outcome: 'orphaned', state };
+      }
+
+      // Report while we wait. This is the whole point of streaming: clients that
+      // pass a progressToken reset their request timeout on each notification,
+      // so a long build finishes inside this single call.
+      if (onProgress && Date.now() - lastProgressAt >= PROGRESS_INTERVAL_MS) {
+        lastProgressAt = Date.now();
+        await onProgress(describeBuildProgress(state, startedAt), Math.round((Date.now() - startedAt) / 1000));
       }
     }
     await new Promise(r => setTimeout(r, pollIntervalMs));
   }
-  // Timed out — return null so the caller emits a "still running" snapshot.
-  return lastState && lastState.status !== 'running' ? lastState : null;
+  return { outcome: 'timeout', state: lastState };
+}
+
+/** One-line "what is happening right now" for a progress notification. */
+function describeBuildProgress(state: BuildJobState, startedAt: number): string {
+  const elapsed = Math.round((Date.now() - startedAt) / 1000);
+  const queue = state.buildQueue && state.buildQueue.length > 1
+    ? ` (${(state.queueIndex ?? 0) + 1}/${state.buildQueue.length})`
+    : '';
+  const what = state.phase === 'finalizing'
+    ? 'finalizing (runtime metadata)'
+    : state.fullBuild ? 'full build' : 'incremental';
+  return `🔨 Building ${state.modelName}${queue} — ${what}, ${elapsed}s elapsed`;
+}
+
+/**
+ * What to do after a wait window expires. The old text ("call again to collect
+ * the final result") made the follow-up poll the obvious move, which is a whole
+ * extra round trip for a build that is still compiling. Name a concrete
+ * waitTimeoutMs instead, so a caller that wants to keep waiting can do it in one
+ * call rather than guessing a number.
+ */
+function renderWaitTimeoutGuidance(elapsedSec: number, timeoutMs: number): string {
+  // Twice what has already elapsed, rounded up to a whole minute and never
+  // below 10 — enough headroom that the next call is very unlikely to time out.
+  const suggestMin = Math.max(10, Math.ceil((elapsedSec * 2) / 60));
+  return [
+    `The build is NOT finished and nothing is lost — it keeps compiling in the background.`,
+    `Waited ${elapsedSec}s of the ${Math.round(timeoutMs / 1000)}s window.`,
+    `To keep waiting in a single call: build_d365fo_project { waitTimeoutMs: ${suggestMin * 60_000} }  (${suggestMin} min).`,
+    `Calling again without waitTimeoutMs re-attaches to the same build — it does not start a second one.`,
+  ].join('\n');
 }
 
 // ---------------------------------------------------------------------------
 // Tool handler
 // ---------------------------------------------------------------------------
 
-export const buildProjectTool = async (params: any, _context: any) => {
+export const buildProjectTool = async (params: any, _context: any, onProgress?: ProgressReporter) => {
   try {
     const force                 = params.force                === true;
     const fullBuild             = params.fullBuild            === true;
@@ -917,19 +1015,47 @@ export const buildProjectTool = async (params: any, _context: any) => {
     const existingState = await readBuildState(targetModel, customPackagesPath);
 
     if (existingState && !force) {
-      // If the caller requests a DIFFERENT build mode than what's cached (e.g. incremental → fullBuild),
-      // and the build is not currently running, discard the stale cached state and fall through
-      // to start a fresh build with the requested mode.
-      const buildModeChanged = existingState.status !== 'running' && fullBuild && !existingState.fullBuild;
-      if (buildModeChanged) {
+      // fullBuild:true is a request to RECOMPILE, not a request for the newest
+      // available result — so a FINISHED state can never satisfy it, not even a
+      // finished full build. Discard it and compile for real. (#829: an explicit
+      // {fullBuild:true} came back as "Collected the result of the build that
+      // ended 19:27:58 … nothing was recompiled by this call".)
+      const fullBuildNeedsFreshRun = existingState.status !== 'running' && fullBuild;
+      if (fullBuildNeedsFreshRun) {
+        await buildLog('INFO', `fullBuild:true — discarding finished state for ${targetModel} and recompiling`);
         await clearBuildState(targetModel, customPackagesPath);
         // intentional fall-through to "start new build" below
       } else {
 
-      const alive   = isProcessAlive(existingState.pid);
+      // A 'finalizing' state has no live PID by definition — xppc exited and the
+      // close handler is still doing post-build work — but it is very much a
+      // running build, not an orphan.
+      const alive   = existingState.phase === 'finalizing' || isProcessAlive(existingState.pid);
       const logTail = await readLogTail(existingState.logFile);
 
       if (existingState.status === 'running' && alive) {
+        // The running build is INCREMENTAL but the caller asked for a full
+        // recompile: attaching to it would answer a fullBuild:true request with
+        // something that is not a full build. Say so plainly instead of
+        // pretending it was honoured. (#829)
+        if (fullBuild && existingState.fullBuild !== true) {
+          const runningFor = Math.round((Date.now() - new Date(existingState.startTime).getTime()) / 1000);
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                `⛔ fullBuild DECLINED — nothing was recompiled by this call.`,
+                ``,
+                `An INCREMENTAL build of ${targetModel} (PID: ${existingState.pid}) has been running for ${runningFor}s.`,
+                `Waiting for it would return an incremental result, which is not what fullBuild:true asks for.`,
+                ``,
+                `Choose one:`,
+                `  • build_d365fo_project { fullBuild: true, force: true } — kill the running build and start the full one now`,
+                `  • build_d365fo_project { fullBuild: true } again once the incremental build has finished`,
+              ].join('\n'),
+            }],
+          };
+        }
         const elapsed       = Math.round((Date.now() - new Date(existingState.startTime).getTime()) / 1000);
         const isQueued      = !!(existingState.buildQueue && existingState.buildQueue.length > 1);
         const queueProgress = isQueued
@@ -945,24 +1071,36 @@ export const buildProjectTool = async (params: any, _context: any) => {
         // a snapshot — this matches the "single call per build" contract.
         const waitForFinish = params.wait !== false;
         if (waitForFinish) {
-          const timeoutMs: number = (typeof params.waitTimeoutMs === 'number' && params.waitTimeoutMs > 0)
-            ? params.waitTimeoutMs
-            : 30 * 60 * 1000;
-          const finalState = await waitForBuildCompletion(targetModel, customPackagesPath, timeoutMs);
-          if (finalState && finalState.status !== 'running') {
+          const timeoutMs = resolveWaitTimeoutMs(params);
+          // A malformed startTime must not leak NaN into a progress payload.
+          const stateStartedAt = new Date(existingState.startTime).getTime();
+          const startedAt = Number.isFinite(stateStartedAt) ? stateStartedAt : Date.now();
+          const wait = await waitForBuildCompletion(
+            targetModel, customPackagesPath, timeoutMs, onProgress, startedAt,
+          );
+          if (wait.outcome === 'finished' && wait.state) {
             await clearBuildState(targetModel, customPackagesPath);
-            return await renderFinishedBuildResult(finalState, targetModel);
+            return await renderFinishedBuildResult(wait.state, targetModel);
+          }
+          const tailLog = await readLogTail(existingState.logFile);
+          if (wait.outcome === 'orphaned') {
+            await clearBuildState(targetModel, customPackagesPath);
+            return {
+              content: [{
+                type: 'text',
+                text: `❌ Build process (PID: ${existingState.pid}) disappeared without reporting a result.\n\nModel: ${targetModel}${completedLine}\n\nRe-run with force: true to start a clean build.\n\n--- Log ---\n${tailLog}`,
+              }],
+              isError: true,
+            };
           }
           // Timed out — emit a "still running" snapshot so the caller can choose
           // to extend the wait window with another call.
-          const tailLog = await readLogTail(existingState.logFile);
           return {
             content: [{
               type: 'text',
               text:
                 `⏳ ${queueProgress} (PID: ${existingState.pid}, running ${elapsed}s; wait timeout reached)${completedLine}\n\n` +
-                `Build continues in background. Call again to collect the final result, ` +
-                `or pass waitTimeoutMs to extend the wait window.\n\n` +
+                renderWaitTimeoutGuidance(elapsed, timeoutMs) + '\n\n' +
                 `--- Latest log ---\n${tailLog}`,
             }],
           };
@@ -1131,28 +1269,48 @@ export const buildProjectTool = async (params: any, _context: any) => {
     const waitForFinish = params.wait !== false;
 
     if (waitForFinish) {
-      const timeoutMs: number = (typeof params.waitTimeoutMs === 'number' && params.waitTimeoutMs > 0)
-        ? params.waitTimeoutMs
-        : 30 * 60 * 1000; // 30 minutes default — covers full builds with referenced models
-      const finalState = await waitForBuildCompletion(targetModel, customPackagesPath, timeoutMs);
-      if (finalState && finalState.status !== 'running') {
+      const timeoutMs = resolveWaitTimeoutMs(params);
+      const startedAt = new Date(initState.startTime).getTime();
+      const wait = await waitForBuildCompletion(
+        targetModel, customPackagesPath, timeoutMs, onProgress, startedAt,
+      );
+      if (wait.outcome === 'finished' && wait.state) {
         await clearBuildState(targetModel, customPackagesPath);
-        return await renderFinishedBuildResult(finalState, targetModel);
+        return await renderFinishedBuildResult(wait.state, targetModel);
+      }
+      const elapsed = Math.round((Date.now() - startedAt) / 1000);
+      const tailLog = await readLogTail(wait.state?.logFile ?? firstLogFile);
+      if (wait.outcome === 'orphaned') {
+        await clearBuildState(targetModel, customPackagesPath);
+        return {
+          content: [{
+            type: 'text',
+            text: [
+              `❌ ${modeLabel} process (PID: ${pid}) disappeared after ${elapsed}s without reporting a result.`,
+              ``,
+              `Target: ${targetModel}${queueDetail}`,
+              `Log:    ${firstLogFile}`,
+              ``,
+              `Re-run with force: true to start a clean build.`,
+              ``,
+              `--- Latest log ---`,
+              tailLog,
+            ].join('\n'),
+          }],
+          isError: true,
+        };
       }
       // Timed out — leave the build running so a follow-up call can collect it.
-      const elapsed = Math.round((Date.now() - new Date(initState.startTime).getTime()) / 1000);
-      const tailLog = await readLogTail(firstLogFile);
       return {
         content: [{
           type: 'text',
           text: [
-            `⏳ ${modeLabel} still running after ${elapsed}s (timeout reached, build continues in background)`,
+            `⏳ ${modeLabel} still running after ${elapsed}s (wait window of ${Math.round(timeoutMs / 1000)}s reached, build continues in background)`,
             ``,
             `Target: ${targetModel}${queueDetail}`,
             `Log:    ${firstLogFile}`,
             ``,
-            `Call **build_d365fo_project** again to collect the final result. ` +
-            `Or pass waitTimeoutMs to extend the wait window in a single call.`,
+            renderWaitTimeoutGuidance(elapsed, timeoutMs),
             ``,
             `--- Latest log ---`,
             tailLog,

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -43,6 +43,7 @@ import {
 } from '../workspace/contextSnapshot.js';
 import * as nodePath from 'path';
 import { buildProgressMessage } from '../utils/toolProgressMessage.js';
+import { createProgressReporter } from '../utils/progressReporter.js';
 
 /** Models named inline by the compact project list before it summarises the rest. */
 const PROJECT_NAMES_SHOWN = 12;
@@ -231,33 +232,11 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       const args = request.params.arguments as Record<string, any> | undefined;
       const progressMsg = buildProgressMessage(toolName, args);
 
-      // Channel 1: notifications/progress (MCP spec) — sent when the client provides a progressToken.
-      const progressToken = (extra._meta as any)?.progressToken;
-      if (progressToken !== undefined && progressToken !== null) {
-        try {
-          await extra.sendNotification({
-            method: 'notifications/progress',
-            params: {
-              progressToken,
-              progress: 0,
-              total: 1,
-              message: progressMsg,
-            } as any,
-          });
-        } catch {
-          // Non-fatal — client may not support progress notifications
-        }
-      }
-
-      // Channel 2: notifications/message (logging) — fallback for clients without progressToken support.
-      try {
-        await server.sendLoggingMessage({
-          level: 'info',
-          data: progressMsg,
-        });
-      } catch {
-        // Non-fatal — logging is best-effort, never block the tool
-      }
+      // Both notification channels (notifications/progress when the client
+      // supplied a progressToken, notifications/message otherwise) live in one
+      // reporter so long-running tools can keep using it after this first step.
+      const reportProgress = createProgressReporter(server, extra as any);
+      await reportProgress(progressMsg, 0);
 
       return (async () => { switch (toolName) {
       case 'search':
@@ -295,7 +274,9 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       case 'update_symbol_index':
         return await updateSymbolIndexTool(request.params.arguments as any, context);
       case 'build_d365fo_project':
-        return await buildProjectTool(request.params.arguments as any, context);
+        // Streams progress while xppc runs, so a build longer than any timeout
+        // still completes inside this one call instead of handing back a stub.
+        return await buildProjectTool(request.params.arguments as any, context, reportProgress);
       case 'trigger_db_sync':
         return await dbSyncTool(request.params.arguments as any, context);
       case 'run_bp_check':

--- a/src/utils/progressReporter.ts
+++ b/src/utils/progressReporter.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-request progress channel for long-running tools.
+ *
+ * A tool that blocks for minutes (build, db sync, test run) is invisible to the
+ * caller while it works, so the only way it could report was to give up on a
+ * timeout and hand back "call me again to collect" — one build turning into
+ * several round trips. MCP already has the mechanism for this: a client that
+ * passes `_meta.progressToken` accepts `notifications/progress` for the life of
+ * the request, and clients that support it also reset their request timeout on
+ * every notification, so a streaming tool stays alive in a SINGLE call.
+ *
+ * Two channels, same as the one-shot notification the dispatcher already sends:
+ *   - notifications/progress — only when the client supplied a progressToken
+ *   - notifications/message  — logging fallback for clients that did not
+ *
+ * Both are best-effort: a client that rejects or ignores them must never fail
+ * or stall the tool.
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+/**
+ * Reports one progress step. `progress` must be monotonically increasing across
+ * calls for the same request (MCP spec); elapsed seconds is the natural choice
+ * for a tool whose total is unknown. `total` may be omitted for open-ended work.
+ */
+export type ProgressReporter = (message: string, progress: number, total?: number) => Promise<void>;
+
+/** The slice of the SDK's request `extra` that the reporter needs. */
+export interface ProgressRequestExtra {
+  _meta?: Record<string, unknown>;
+  sendNotification?: (notification: unknown) => Promise<void>;
+}
+
+/**
+ * Build a reporter bound to one in-flight tool call. Always returns a callable —
+ * when the client offers neither channel the reporter is simply a no-op, so
+ * callers never have to branch on its availability.
+ */
+export function createProgressReporter(
+  server: Pick<Server, 'sendLoggingMessage'>,
+  extra: ProgressRequestExtra | undefined,
+): ProgressReporter {
+  const progressToken = extra?._meta?.progressToken;
+  const sendNotification = extra?.sendNotification;
+  const canNotify = sendNotification !== undefined && progressToken !== undefined && progressToken !== null;
+
+  return async (message: string, progress: number, total?: number): Promise<void> => {
+    if (canNotify) {
+      try {
+        await sendNotification!({
+          method: 'notifications/progress',
+          params: {
+            progressToken,
+            progress,
+            ...(total !== undefined ? { total } : {}),
+            message,
+          },
+        });
+      } catch {
+        // Non-fatal — client may not support progress notifications
+      }
+    }
+
+    try {
+      await server.sendLoggingMessage({ level: 'info', data: message });
+    } catch {
+      // Non-fatal — logging is best-effort, never block the tool
+    }
+  };
+}

--- a/tests/tools/buildProject.test.ts
+++ b/tests/tools/buildProject.test.ts
@@ -287,6 +287,10 @@ describe('build_d365fo_project', () => {
     const result = await buildProjectTool({ projectPath: PROJECT_PATH }, {});
 
     expect(result.content[0].text).toContain('succeeded');
+    // #829 explicitly praises this wording — a collected result must keep
+    // saying, in plain words, that this call compiled nothing.
+    expect(result.content[0].text).toContain('Collected the result of the build that ended');
+    expect(result.content[0].text).toContain('nothing was recompiled by this call');
     expect(result.isError).toBeFalsy();
     expect(spawnMock).not.toHaveBeenCalled();
     // State file should be cleared
@@ -481,6 +485,163 @@ describe('build_d365fo_project', () => {
     expect(firstPath).toBe(secondPath);
 
     vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // #829 — an explicit fullBuild:true is a request to RECOMPILE, not a request
+  // for the newest available result, and a build that outlives the wait window
+  // must not turn into a second "call me again to collect" round trip.
+  // -------------------------------------------------------------------------
+
+  /** State-file JSON for a build that has already finished. */
+  function finishedState(extra: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+      pid: 888,
+      modelName: MODEL_NAME,
+      targetModel: MODEL_NAME,
+      projectPath: PROJECT_PATH,
+      tool: 'xppc.exe',
+      startTime: new Date(Date.now() - 49_000).toISOString(),
+      endTime: new Date().toISOString(),
+      logFile: 'C:\\Temp\\d365build_log_prev.log',
+      status: 'succeeded',
+      exitCode: 0,
+      ...extra,
+    });
+  }
+
+  function serveState(stateJson: string) {
+    readFileMock.mockImplementation(async (p: string) => {
+      if (p.includes('d365build_state')) return stateJson;
+      if (p.endsWith('.rnrproj')) return RNRPROJ_XML;
+      if (p.includes('d365build_log')) return 'Build complete.';
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+  }
+
+  it('fullBuild:true recompiles instead of replaying a finished FULL build', async () => {
+    serveState(finishedState({ fullBuild: true }));
+    // Sources unchanged since the build ended — the cached result would
+    // otherwise be considered perfectly reusable.
+    readdirMock.mockResolvedValue([]);
+    spawnMock.mockReturnValue(makeFakeChild(4242));
+    allowPaths([PROJECT_PATH, XPPC, PKG]);
+
+    const result = await buildProjectTool(
+      { projectPath: PROJECT_PATH, fullBuild: true, wait: false }, {},
+    );
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0];
+    expect(args).not.toContain('-incremental');
+    expect(result.content[0].text).not.toContain('Collected the result');
+    expect(result.content[0].text).toContain('Full build started');
+  });
+
+  it('fullBuild:true recompiles instead of replaying a finished INCREMENTAL build', async () => {
+    serveState(finishedState());
+    readdirMock.mockResolvedValue([]);
+    spawnMock.mockReturnValue(makeFakeChild(4243));
+    allowPaths([PROJECT_PATH, XPPC, PKG]);
+
+    const result = await buildProjectTool(
+      { projectPath: PROJECT_PATH, fullBuild: true, wait: false }, {},
+    );
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(result.content[0].text).not.toContain('Collected the result');
+  });
+
+  it('declines fullBuild:true while an INCREMENTAL build is running, and says why', async () => {
+    serveState(JSON.stringify({
+      pid: 777,
+      modelName: MODEL_NAME,
+      targetModel: MODEL_NAME,
+      tool: 'xppc.exe',
+      startTime: new Date(Date.now() - 20_000).toISOString(),
+      logFile: 'C:\\Temp\\d365build_log_run.log',
+      status: 'running',
+    }));
+    allowPaths([PROJECT_PATH, XPPC, PKG]);
+    const origKill = process.kill.bind(process);
+    vi.spyOn(process, 'kill').mockImplementation((pid: any, sig: any) => {
+      if (pid === 777 && sig === 0) return true as any;
+      return origKill(pid, sig);
+    });
+
+    const result = await buildProjectTool({ projectPath: PROJECT_PATH, fullBuild: true }, {});
+
+    expect(result.content[0].text).toContain('DECLINED');
+    expect(result.content[0].text).toContain('nothing was recompiled by this call');
+    expect(result.content[0].text).toContain('force: true');
+    expect(spawnMock).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('waits through the post-build finalizing phase instead of handing back a "still running" stub', async () => {
+    // The 185 s double-call of #829: xppc exits, the close handler is still
+    // regenerating runtime metadata, and the waiter used to read the dead PID
+    // as "orphaned/timed out" for a build that had in fact just succeeded.
+    const base = {
+      pid: 4242,
+      modelName: MODEL_NAME,
+      targetModel: MODEL_NAME,
+      tool: 'xppc.exe',
+      startTime: new Date(Date.now() - 185_000).toISOString(),
+      logFile: 'C:\\Temp\\d365build_log_fin.log',
+    };
+    let stateReads = 0;
+    readFileMock.mockImplementation(async (p: string) => {
+      if (p.includes('d365build_state')) {
+        stateReads++;
+        return stateReads <= 2
+          ? JSON.stringify({ ...base, status: 'running', phase: 'finalizing' })
+          : JSON.stringify({ ...base, status: 'succeeded', exitCode: 0, endTime: new Date().toISOString() });
+      }
+      if (p.endsWith('.rnrproj')) return RNRPROJ_XML;
+      if (p.includes('d365build_log')) return 'Build complete.';
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    allowPaths([PROJECT_PATH, XPPC, PKG]);
+    // PID 4242 is gone — only the 'finalizing' phase says the build is alive.
+    const origKill = process.kill.bind(process);
+    vi.spyOn(process, 'kill').mockImplementation((pid: any, sig: any) => {
+      if (pid === 4242 && sig === 0) throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+      return origKill(pid, sig);
+    });
+    const onProgress = vi.fn().mockResolvedValue(undefined);
+
+    const result = await buildProjectTool({ projectPath: PROJECT_PATH }, {}, onProgress);
+
+    expect(result.content[0].text).toContain('Build succeeded');
+    expect(result.content[0].text).not.toContain('timeout');
+    expect(spawnMock).not.toHaveBeenCalled();
+    // Progress streamed while blocking, naming the phase the caller cannot see.
+    expect(onProgress).toHaveBeenCalled();
+    expect(onProgress.mock.calls[0][0]).toContain('finalizing');
+    expect(typeof onProgress.mock.calls[0][1]).toBe('number');
+
+    vi.restoreAllMocks();
+  });
+
+  it('timeout message carries the elapsed/window state and a concrete waitTimeoutMs to retry with', async () => {
+    spawnMock.mockReturnValue(makeFakeChild(51));
+    allowPaths([PROJECT_PATH, XPPC, PKG]);
+
+    // 1 ms window — the wait expires before the build can possibly finish.
+    const result = await buildProjectTool(
+      { projectPath: PROJECT_PATH, waitTimeoutMs: 1 }, {},
+    );
+
+    const text = result.content[0].text;
+    expect(text).toContain('still running after');
+    expect(text).toContain('The build is NOT finished');
+    expect(text).toContain('does not start a second one');
+    const suggested = text.match(/waitTimeoutMs: (\d+)/);
+    expect(suggested).toBeTruthy();
+    expect(Number(suggested![1])).toBeGreaterThanOrEqual(600_000);
+    expect(result.isError).toBeFalsy();
   });
 
   it('uses explicit modelName param without requiring projectPath or rnrproj', async () => {

--- a/tests/utils/progressReporter.test.ts
+++ b/tests/utils/progressReporter.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Per-request progress channel (#829).
+ *
+ * A tool that blocks for minutes has exactly one way to stay in a single round
+ * trip: report while it works. Both notification channels are best-effort, so
+ * the contract that matters most is that a client which rejects, or does not
+ * offer, either channel can never fail or stall the tool.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createProgressReporter } from '../../src/utils/progressReporter';
+
+function fakeServer() {
+  return { sendLoggingMessage: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe('createProgressReporter', () => {
+  it('sends notifications/progress when the client supplied a progressToken', async () => {
+    const server = fakeServer();
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const report = createProgressReporter(server as any, { _meta: { progressToken: 'tok-1' }, sendNotification });
+
+    await report('🔨 Building MyModel — 30s elapsed', 30);
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const [notification] = sendNotification.mock.calls[0];
+    expect(notification.method).toBe('notifications/progress');
+    expect(notification.params.progressToken).toBe('tok-1');
+    expect(notification.params.progress).toBe(30);
+    expect(notification.params.message).toContain('Building MyModel');
+    // Unknown total must be omitted rather than guessed.
+    expect('total' in notification.params).toBe(false);
+    // The logging channel always fires too — clients differ in which they show.
+    expect(server.sendLoggingMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes total only when the caller knows it', async () => {
+    const server = fakeServer();
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const report = createProgressReporter(server as any, { _meta: { progressToken: 7 }, sendNotification });
+
+    await report('step', 1, 4);
+
+    expect(sendNotification.mock.calls[0][0].params.total).toBe(4);
+  });
+
+  it('falls back to the logging channel when no progressToken was supplied', async () => {
+    const server = fakeServer();
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const report = createProgressReporter(server as any, { _meta: {}, sendNotification });
+
+    await report('working', 0);
+
+    expect(sendNotification).not.toHaveBeenCalled();
+    expect(server.sendLoggingMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a safe no-op when the request carries no extra at all', async () => {
+    const server = fakeServer();
+    const report = createProgressReporter(server as any, undefined);
+
+    await expect(report('working', 0)).resolves.toBeUndefined();
+    expect(server.sendLoggingMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('never rejects when either channel throws', async () => {
+    const server = { sendLoggingMessage: vi.fn().mockRejectedValue(new Error('transport closed')) };
+    const sendNotification = vi.fn().mockRejectedValue(new Error('unsupported'));
+    const report = createProgressReporter(server as any, { _meta: { progressToken: 'tok' }, sendNotification });
+
+    await expect(report('working', 12)).resolves.toBeUndefined();
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(server.sendLoggingMessage).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Why

From the session audit (#824): `build_d365fo_project` returned **4 times for what was substantially one build** — 233 s, 20 % of session wall time — and the last of those answered an explicit `{fullBuild: true}` with a *previously collected* result.

## Root cause of the "185 s timeout" (this was not a timeout at all)

The default `waitTimeoutMs` has always been 30 minutes, so 185 s could never have been a wait window. What actually happened:

1. `xppc.exe` exits after 185 s.
2. Its `close` handler — which runs **in the MCP server process** — then regenerates runtime metadata (two `execFile` calls capped at 30 s + 60 s) *before* it can write the final `succeeded` state.
3. `waitForBuildCompletion` saw a dead PID, gave the handler **2 s** to settle, and returned the still-`running` state.
4. The caller could not tell that apart from a real timeout, so it printed *"still running after 185s (timeout reached)… call again to collect"* — for a build that had just succeeded.

That is where both the wasted 185 s stall **and** the poll-to-collect round trip came from. So this PR fixes the mechanism rather than only papering over it with a bigger timeout.

## What changed

| Where | Change |
|---|---|
| `src/utils/progressReporter.ts` (new) | `createProgressReporter(server, extra)` — factors both notification channels (`notifications/progress` when the client supplied a `progressToken`, `notifications/message` otherwise) out of the dispatcher so long-running tools can keep reporting after the first step. Always returns a callable; never rejects. |
| `src/tools/toolHandler.ts` | Uses the reporter for the existing one-shot progress message (behaviour-identical, minus a hardcoded `total: 1` for work whose total is unknown) and threads it into `build_d365fo_project`. |
| `src/tools/buildProject.ts` | `BuildJobState.phase`; the close handler publishes `phase: 'finalizing'` **before** the post-build work. `waitForBuildCompletion` streams progress every 10 s and returns a discriminated `finished` / `orphaned` / `timeout` outcome. `fullBuild: true` is never satisfied from a finished state. Timeout message rewritten. |

## Acceptance criteria

**"a build longer than the timeout completes in one tool call, with progress visible"** — met, by two mechanisms:

- Progress is streamed every 10 s (first update on the first poll) with elapsed seconds, model, queue position and phase. Clients that pass a `progressToken` reset their request timeout on each notification, so a long build genuinely finishes inside a single call.
- The `finalizing` phase removes the case that made a *finished* build report as timed out. A dead PID during `finalizing` is now given a 5 min grace (comfortably covering the 90 s of capped metadata work) instead of 2 s; a genuine orphan is given 30 s and then reported honestly as `❌ … disappeared without reporting a result` rather than being disguised as a timeout.
- The default wait window stays 30 min — it was never the 185 s the issue inferred, and the issue's fallback ("raise the default") is therefore already satisfied.

**"`fullBuild: true` never returns a result from a previous build without recompiling"** — met:

- A **finished** state can never satisfy `fullBuild: true`, not even a finished *full* build (the old rule only discarded the cache when the previous build was incremental — which is exactly the audited failure, where the cached state was itself a full build). The state is dropped and xppc runs.
- When an **incremental build is already running**, attaching to it would answer the request with something that is not a full build, so it is **declined in plain words** (`⛔ fullBuild DECLINED — nothing was recompiled by this call`) with the two ways forward (`force: true` now, or call again once it finishes). This is the issue's explicitly permitted "explicit, plainly-worded refusal".

**"keep the cached-result messaging as clear as it is today"** — met, and now pinned: the `Collected the result of the build that ended … nothing was recompiled by this call` wording is untouched and asserted by a test so it cannot silently regress.

**Poll-to-collect round trip** — the timeout text no longer leads with "call again to collect". It now carries the state the agent needs (elapsed vs. window, that nothing is lost, that calling again re-attaches rather than starting a second build) and names a concrete `waitTimeoutMs` value — 2× elapsed, rounded up to whole minutes, floor 10 min — so a caller that wants to keep waiting does it in one call instead of guessing.

## Tests

`tests/tools/buildProject.test.ts` — 6 new/extended cases:

- `fullBuild:true` recompiles instead of replaying a finished **full** build (the audited bug) — asserts xppc is spawned without `-incremental` and the output contains no "Collected the result"
- same for a finished **incremental** build
- `fullBuild:true` is declined, with reasons, while an incremental build is running
- the waiter blocks through the `finalizing` phase (dead PID) and returns `✅ Build succeeded` instead of a "still running" stub — the #829 regression test — and asserts progress was streamed naming the phase
- the timeout message carries elapsed/window state and a concrete `waitTimeoutMs` ≥ 600000
- the cached-result wording assertion added to the existing replay test

`tests/utils/progressReporter.test.ts` (new) — 5 cases: progress channel with a token, `total` omitted when unknown, logging fallback without a token, safe no-op with no `extra`, and never rejecting when either channel throws.

Full suite: **2716 passed, 9 skipped, 206 files**. `npx tsc --noEmit` clean.

## Notes

- **No tool-schema change**, so `TOTAL_BUDGET` in `tests/utils/toolSchemaBudget.test.ts` is untouched. The existing description already says "Blocks until done — call ONCE per build, do NOT poll" and `waitTimeoutMs` already documents the 30 min default, both of which remain accurate.
- The dispatcher's initial progress notification no longer sends `total: 1`. Totals are unknowable for these tools and a fixed `total` would make streamed updates inconsistent within one request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
