### PR TITLE
Disable buildReferencedModels option in build_d365fo_project

### DIFF
--- a/src/server/toolSchemas/buildD365foProject.ts
+++ b/src/server/toolSchemas/buildD365foProject.ts
@@ -9,8 +9,7 @@ export const buildD365foProjectTool = {
     description:
       'Build a D365FO model with xppc.exe (compiles the ENTIRE model, not one project). ' +
       'Blocks until done — call ONCE per build, do NOT poll (wait:false = legacy polling mode). ' +
-      'fullBuild:true fixes "not been successfully compiled since it was last changed" stale-symbol errors; ' +
-      'buildReferencedModels:true builds custom/ISV dependencies first.',
+      'fullBuild:true fixes "not been successfully compiled since it was last changed" stale-symbol errors.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -32,7 +31,7 @@ export const buildD365foProjectTool = {
         },
         buildReferencedModels: {
           type: 'boolean',
-          description: 'Also build all custom/ISV models this model depends on before building the target. Skips Microsoft standard models.',
+          description: 'DISABLED — always ignored. Rebuilding dependency models on every build slows the run down and referenced models are expected to already be compiled.',
         },
         wait: {
           type: 'boolean',

--- a/src/tools/buildProject.ts
+++ b/src/tools/buildProject.ts
@@ -933,7 +933,11 @@ export const buildProjectTool = async (params: any, _context: any, onProgress?: 
   try {
     const force                 = params.force                === true;
     const fullBuild             = params.fullBuild            === true;
-    const buildReferencedModels = params.buildReferencedModels === true;
+    // Disabled: rebuilding referenced models drags in every custom/ISV
+    // dependency on each build and slows the whole run down for no benefit —
+    // dependencies are expected to already be compiled. The parameter is
+    // accepted but always ignored.
+    const buildReferencedModels = false;
 
     const configManager = getConfigManager();
     await configManager.ensureLoaded();


### PR DESCRIPTION
Rebuilding custom/ISV dependency models on every build slows down the entire run, and referenced models are expected to already be compiled. The \uildReferencedModels\ parameter is now always ignored (hardcoded to \alse\ in the handler); the tool schema documents it as disabled.