### PR TITLE
Prefer the longest corroborated model prefix over raw coverage

### DIFF
--- a/src/utils/modelPrefixInference.ts
+++ b/src/utils/modelPrefixInference.ts
@@ -93,13 +93,13 @@ function leadingTokenCandidates(name: string): string[] {
  *
  * Coverage cannot tell a real third segment from a domain word: a model whose
  * objects are all ConDemoNoteHeader / …Line / …Text offers "ConDemoNote" with
- * exactly the same 100 % coverage that makes "AslFinSK" right for AslFinanceSK,
+ * exactly the same 100 % coverage that makes "DemoFinSK" right for DemoFinanceSK,
  * and the longest-wins tie-break then takes the domain word. Both shapes are
  * indistinguishable from the names alone, so a candidate spanning three segments
  * has to be corroborated from OUTSIDE the object names:
  *
- *   - the model's own extensions state it ("VendTable.AslFinSKExtension"), or
- *   - the model NAME contains its segments in order ("Asl|Fin|SK" ⊂ AslFinanceSK,
+ *   - the model's own extensions state it ("VendTable.DemoFinSKExtension"), or
+ *   - the model NAME contains its segments in order ("Demo|Fin|SK" ⊂ DemoFinanceSK,
  *     while "Note" is nowhere in "ConDemo").
  *
  * Uncorroborated, the candidate is dropped and the two-segment token — the
@@ -124,7 +124,7 @@ function tokenAllowed(
 /**
  * Do the token's segments appear in the model name, in order, starting at its
  * first character? Gaps between them are allowed, which is what makes
- * "Asl|Fin|SK" match "AslFinanceSK" — the model spells a segment out where the
+ * "Demo|Fin|SK" match "DemoFinanceSK" — the model spells a segment out where the
  * prefix abbreviates it.
  */
 function modelNameCarries(modelName: string, segs: string[]): boolean {
@@ -149,8 +149,8 @@ function modelNameCarries(modelName: string, segs: string[]): boolean {
  * differently-cased legacy name, an old object from before the prefix went
  * compound) drops the three-segment count below the two-segment count and,
  * under a raw-coverage race, the two-segment token wins EVERY time real data
- * has any exception at all. That is exactly how "AslFinSK" (26/28 objects, a
- * couple of others spelled "AslFinSk_") lost to "AslFin" (28/28) despite being
+ * has any exception at all. That is exactly how "DemoFinSK" (26/28 objects, a
+ * couple of others spelled "DemoFinSk_") lost to "DemoFin" (28/28) despite being
  * the model's actual, corroborated convention.
  * Once a token clears the coverage bar it is trusted; among those, the longest
  * is the most specific answer and wins outright, not merely on a tie.

--- a/src/utils/modelPrefixInference.ts
+++ b/src/utils/modelPrefixInference.ts
@@ -140,15 +140,30 @@ function modelNameCarries(modelName: string, segs: string[]): boolean {
   return true;
 }
 
-/** Pick the candidate covering the most names; ties go to the longer token. */
+/**
+ * Pick the candidate to trust: the LONGEST token that still clears
+ * MIN_COVERAGE, not the one with the highest raw coverage count.
+ *
+ * A shorter candidate is always a prefix of every longer one, so it always
+ * covers at least as many names — one stray object off-convention (a typo, a
+ * differently-cased legacy name, an old object from before the prefix went
+ * compound) drops the three-segment count below the two-segment count and,
+ * under a raw-coverage race, the two-segment token wins EVERY time real data
+ * has any exception at all. That is exactly how "AslFinSK" (26/28 objects, a
+ * couple of others spelled "AslFinSk_") lost to "AslFin" (28/28) despite being
+ * the model's actual, corroborated convention.
+ * Once a token clears the coverage bar it is trusted; among those, the longest
+ * is the most specific answer and wins outright, not merely on a tie.
+ */
 function bestCovering(names: string[], candidates: Iterable<string>): { token: string; coverage: number } | null {
   let best: { token: string; coverage: number } | null = null;
   for (const token of new Set(candidates)) {
     const coverage = names.filter(n => n.startsWith(token)).length;
+    if (coverage / names.length < MIN_COVERAGE) continue;
     if (
       !best ||
-      coverage > best.coverage ||
-      (coverage === best.coverage && token.length > best.token.length)
+      token.length > best.token.length ||
+      (token.length === best.token.length && coverage > best.coverage)
     ) {
       best = { token, coverage };
     }

--- a/tests/utils/modelPrefixInference.test.ts
+++ b/tests/utils/modelPrefixInference.test.ts
@@ -191,28 +191,28 @@ describe('inferPrefixFromObjectNames', () => {
    */
   describe('three-segment tokens are corroborated, not taken on coverage', () => {
     it('accepts one the model name carries, spelled out', () => {
-      // Asl|Fin|SK ⊂ AslFinanceSK: the prefix abbreviates what the name spells.
+      // Demo|Fin|SK ⊂ DemoFinanceSK: the prefix abbreviates what the name spells.
       const result = inferPrefixFromObjectNames([
-        'AslFinSKVendPaymentTable', 'AslFinSKCustInvoiceJour',
-        'AslFinSKLedgerJournalTrans', 'AslFinSKTaxReportTable',
-      ], 'AslFinanceSK');
+        'DemoFinSKVendPaymentTable', 'DemoFinSKCustInvoiceJour',
+        'DemoFinSKLedgerJournalTrans', 'DemoFinSKTaxReportTable',
+      ], 'DemoFinanceSK');
 
-      expect(result?.regular).toBe('AslFinSK');
+      expect(result?.regular).toBe('DemoFinSK');
     });
 
     it('wins on corroboration even when a few objects dilute its raw coverage', () => {
-      // Real AslFinanceSK data: most objects say "AslFinSK_", a couple of older
-      // ones are cased "AslFinSk_" instead. "AslFin" still covers all of them and
-      // used to win outright on that higher raw count — the model's actual,
-      // corroborated convention must win instead because it clears MIN_COVERAGE.
+      // The shape that exposed this: most objects say "DemoFinSK_", a couple of
+      // older ones are cased "DemoFinSk_" instead. "DemoFin" still covers all of
+      // them and used to win outright on that higher raw count — the model's
+      // actual, corroborated convention must win because it clears MIN_COVERAGE.
       const result = inferPrefixFromObjectNames([
-        'AslFinSK_ACFeatureList', 'AslFinSK_CustInvoiceJournalFormHandler',
-        'AslFinSK_LedgerJournalTransApproveFormHandler', 'AslFinSK_TaxTransHandler',
-        'AslFinSK_TaxTransManager', 'AslFinSK_VendInvoiceJournalFormHandler',
-        'AslFinSk_FinanceSK', 'AslFinSk_FinanceSK',
-      ], 'AslFinanceSK');
+        'DemoFinSK_ACFeatureList', 'DemoFinSK_CustInvoiceJournalFormHandler',
+        'DemoFinSK_LedgerJournalTransApproveFormHandler', 'DemoFinSK_TaxTransHandler',
+        'DemoFinSK_TaxTransManager', 'DemoFinSK_VendInvoiceJournalFormHandler',
+        'DemoFinSk_FinanceSK', 'DemoFinSk_FinanceSK',
+      ], 'DemoFinanceSK');
 
-      expect(result?.regular).toBe('AslFinSK_');
+      expect(result?.regular).toBe('DemoFinSK_');
     });
 
     it('accepts one the model\'s own extensions state', () => {

--- a/tests/utils/modelPrefixInference.test.ts
+++ b/tests/utils/modelPrefixInference.test.ts
@@ -200,6 +200,21 @@ describe('inferPrefixFromObjectNames', () => {
       expect(result?.regular).toBe('AslFinSK');
     });
 
+    it('wins on corroboration even when a few objects dilute its raw coverage', () => {
+      // Real AslFinanceSK data: most objects say "AslFinSK_", a couple of older
+      // ones are cased "AslFinSk_" instead. "AslFin" still covers all of them and
+      // used to win outright on that higher raw count — the model's actual,
+      // corroborated convention must win instead because it clears MIN_COVERAGE.
+      const result = inferPrefixFromObjectNames([
+        'AslFinSK_ACFeatureList', 'AslFinSK_CustInvoiceJournalFormHandler',
+        'AslFinSK_LedgerJournalTransApproveFormHandler', 'AslFinSK_TaxTransHandler',
+        'AslFinSK_TaxTransManager', 'AslFinSK_VendInvoiceJournalFormHandler',
+        'AslFinSk_FinanceSK', 'AslFinSk_FinanceSK',
+      ], 'AslFinanceSK');
+
+      expect(result?.regular).toBe('AslFinSK_');
+    });
+
     it('accepts one the model\'s own extensions state', () => {
       const result = inferPrefixFromObjectNames([
         'ContosoFinSKVendPaymentTable', 'ContosoFinSKCustInvoiceJour',


### PR DESCRIPTION
Pre-existing working-tree fix, landed separately from the audit work so the tree is clean.

`bestCovering()` raced prefix candidates on raw coverage count. A shorter token is always a prefix of every longer one, so it always covers at least as many names — one stray off-convention object drops the longer token's count below the shorter one's, and the shorter token wins every time real data has any exception at all. `AslFinSK` (26/28 objects) lost to `AslFin` (28/28) despite being the model's actual, corroborated convention.

Now candidates are gated on `MIN_COVERAGE` first; among survivors the longest (most specific) token wins outright rather than only on a tie.

Regression test added with the real `AslFinanceSK` data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)