### PR TITLE
Close the `..` traversal hole in the path containment guard (audit finding 1, CRITICAL)

### DIFF
--- a/src/utils/pathContainment.ts
+++ b/src/utils/pathContainment.ts
@@ -54,21 +54,81 @@ function isAbsoluteCrossPlatform(p: string): boolean {
 }
 
 function toAbsolute(p: string): string {
+  // Already-absolute input is NOT handed to path.resolve: on POSIX it would treat
+  // a Windows-style "C:\…" path as relative and prefix the cwd, and this server is
+  // routinely asked about Windows paths from a Linux host (tests, Azure proxy).
+  // `..` collapsing is therefore done lexically by lexicalResolve below, which is
+  // what actually neutralises traversal — see the note there.
   return isAbsoluteCrossPlatform(p) ? p : path.resolve(p);
+}
+
+/** Split an absolute path into its root prefix (`C:/`, `//server/share/`, `/`) and the rest. */
+function splitRoot(p: string): { root: string; rest: string } {
+  const s = p.replace(/\\/g, '/');
+  const unc = /^(\/\/[^/]+\/[^/]+)(?:\/|$)/.exec(s);
+  if (unc) return { root: unc[1] + '/', rest: s.slice(unc[0].length) };
+  const drive = /^([a-zA-Z]:)\//.exec(s);
+  if (drive) return { root: drive[1] + '/', rest: s.slice(drive[0].length) };
+  if (s.startsWith('/')) return { root: '/', rest: s.slice(1) };
+  return { root: '', rest: s };
+}
+
+/**
+ * Absolute, POSIX-separated, with `.` and `..` segments collapsed lexically.
+ *
+ * This is the step that makes containment sound. Without it an already-absolute
+ * path kept its `..` segments all the way through both the root check and the
+ * AOT-shape check — `<root>/Pkg/Model/AxTable/a.xml/../../../../../evil/x.xml`
+ * starts under an allowed root and its first four segments are shaped like a
+ * valid AOT path, so it passed every guard and Win32 collapsed it only at the
+ * moment of the write, landing anywhere on disk.
+ *
+ * Returns null when the path climbs above its own root: such a path has no
+ * meaning as a target here and is rejected outright rather than clamped.
+ */
+function lexicalResolve(p: string): string | null {
+  if (!p) return null;
+  const { root, rest } = splitRoot(toAbsolute(p));
+  const out: string[] = [];
+  for (const seg of rest.split('/')) {
+    if (!seg || seg === '.') continue;
+    if (seg === '..') {
+      if (out.length === 0) return null; // escapes above the root
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return (root + out.join('/')).replace(/\/+$/, '');
 }
 
 /** Absolute + POSIX separators, WITHOUT symlink resolution (the as-given form). */
 function lexicalNorm(p: string): string {
-  if (!p) return '';
-  return toAbsolute(p).replace(/\\/g, '/').replace(/\/+$/, '');
+  return lexicalResolve(p) ?? '';
 }
 
-/** Absolute + POSIX separators WITH symlink resolution (realpath). */
+/**
+ * Absolute + POSIX separators WITH symlink resolution (realpath).
+ *
+ * A write target usually does not exist yet, so realpathSync throws on the full
+ * path; we then resolve the deepest ancestor that DOES exist and re-append the
+ * remainder, so a new file under a symlinked model directory still resolves
+ * through that symlink instead of silently falling back to the lexical form.
+ */
 function realNorm(p: string): string {
-  if (!p) return '';
-  let abs = toAbsolute(p);
-  try { abs = realpathSync(abs); } catch { /* may not exist yet — ok */ }
-  return abs.replace(/\\/g, '/').replace(/\/+$/, '');
+  const lex = lexicalResolve(p);
+  if (lex === null) return '';
+  const posix = (s: string) => s.replace(/\\/g, '/').replace(/\/+$/, '');
+  try { return posix(realpathSync(lex)); } catch { /* target may not exist yet */ }
+  const { root, rest } = splitRoot(lex);
+  const segs = rest.split('/').filter(Boolean);
+  for (let i = segs.length - 1; i > 0; i--) {
+    try {
+      const real = posix(realpathSync(root + segs.slice(0, i).join('/')));
+      return [real, ...segs.slice(i)].join('/');
+    } catch { /* keep climbing */ }
+  }
+  return lex;
 }
 
 /** Back-compat alias — defaults to the realpath form. */
@@ -160,6 +220,12 @@ export async function assertWritePathAllowed(
   // file path; the AOT-shape check below must slice with the SAME form that
   // matched, so both are carried through instead of pre-collapsing to realpath.
   const fileLex = lexicalNorm(filePath);
+  if (!fileLex) {
+    return {
+      ok: false,
+      reason: `Refusing to write to a path that traverses above its own root: "${filePath}"`,
+    };
+  }
   const fileReal = realNorm(filePath);
 
   // 1. Root containment
@@ -279,6 +345,12 @@ export async function assertReadRootAllowed(dirPath: string): Promise<PathContai
   }
   if (!isAbsoluteCrossPlatform(dirPath)) {
     return { ok: false, reason: `dirPath must be absolute: "${dirPath}"` };
+  }
+  if (!lexicalNorm(dirPath)) {
+    return {
+      ok: false,
+      reason: `Refusing to scan a path that traverses above its own root: "${dirPath}"`,
+    };
   }
 
   // dirPath is passed raw (not pre-realpath'd) so isUnder can match it lexically

--- a/tests/utils/pathContainmentTraversal.test.ts
+++ b/tests/utils/pathContainmentTraversal.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression (audit finding 1, CRITICAL): the containment guard was bypassable.
+ *
+ * `toAbsolute()` returned an already-absolute path verbatim, so `..` segments
+ * survived normalisation. A path like
+ *   <root>/Pkg/Model/AxTable/a.xml/../../../../../evil/target.xml
+ * starts under an allowed root (root check passes) and its first four segments
+ * are Pkg / Model / AxTable / a.xml (AOT-shape check passes, since that check
+ * only inspects those four). Win32 collapsed the `..` only at write time —
+ * i.e. the guard approved a write to an arbitrary location on disk.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../src/utils/configManager.js', () => ({
+  getConfigManager: () => ({
+    ensureLoaded: async () => {},
+    getPackagePath: () => 'C:/PLD',
+    getCustomPackagesPath: async () => null,
+    getMicrosoftPackagesPath: async () => null,
+  }),
+  fallbackPackagePath: () => 'C:/never',
+}));
+
+import { assertWritePathAllowed, assertReadRootAllowed, isFileUnderRoot } from '../../src/utils/pathContainment.js';
+
+describe('pathContainment — `..` traversal', () => {
+  it('rejects the AxTable-segment traversal that escapes the allowed root', async () => {
+    const attack = 'C:/PLD/Pkg/Model/AxTable/a.xml/../../../../../evil/target.xml';
+    const r = await assertWritePathAllowed(attack, 'Model');
+    expect(r.ok).toBe(false);
+    expect(r.canonicalPath).toBeUndefined();
+  });
+
+  it('rejects the same traversal spelled with Windows separators', async () => {
+    const attack = 'C:\\PLD\\Pkg\\Model\\AxTable\\a.xml\\..\\..\\..\\..\\..\\evil\\target.xml';
+    const r = await assertWritePathAllowed(attack, 'Model');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a path that climbs above its own root', async () => {
+    const r = await assertWritePathAllowed('C:/../evil/Pkg/Model/AxTable/Foo.xml', 'Model');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/traverses above its own root/i);
+  });
+
+  it('collapses harmless `..` inside the root instead of leaking it into canonicalPath', async () => {
+    const r = await assertWritePathAllowed(
+      'C:/PLD/Other/Junk/../../Pkg/Model/AxTable/Foo.xml',
+      'Model',
+    );
+    expect(r.ok).toBe(true);
+    expect(r.canonicalPath).toBe('C:/PLD/Pkg/Model/AxTable/Foo.xml');
+    expect(r.canonicalPath).not.toContain('..');
+    expect(r.packageSegment).toBe('Pkg');
+    expect(r.modelSegment).toBe('Model');
+  });
+
+  it('still enforces the model hint against the COLLAPSED path, not the written one', async () => {
+    // Traversal used to relocate the write while the shape check still read the
+    // pre-collapse segments — so the model hint was checked against a model the
+    // file would never land in.
+    const r = await assertWritePathAllowed(
+      'C:/PLD/Pkg/Model/AxTable/a.xml/../../../../OtherPkg/ApplicationSuite/AxTable/Foo.xml',
+      'Model',
+    );
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/Model mismatch/i);
+  });
+
+  it('rejects traversal on the read side too (assertReadRootAllowed)', async () => {
+    const r = await assertReadRootAllowed('C:/PLD/Pkg/../../../Windows/System32');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a traversing glob result in isFileUnderRoot', () => {
+    expect(isFileUnderRoot('C:/PLD/Pkg/../../evil/Foo.xml', 'C:/PLD')).toBe(false);
+    expect(isFileUnderRoot('C:/PLD/Pkg/Model/AxTable/Foo.xml', 'C:/PLD')).toBe(true);
+  });
+});


### PR DESCRIPTION
**Phase 0.1** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4). Audit finding 1, severity **critical**.

## The hole

`toAbsolute()` returned an already-absolute path verbatim — `path.resolve` was only reached for relative input — so `..` segments survived every layer of normalisation and reached the write untouched:

```
<root>/Pkg/Model/AxTable/a.xml/../../../../../evil/target.xml
```

- **Root check passes**: the string starts under an allowed root.
- **AOT-shape check passes**: it only inspects the first four segments, which are `Pkg` / `Model` / `AxTable` / `a.xml` — a perfectly valid shape.
- **Win32 collapses the `..` at write time**, landing the file anywhere on disk.

`assertReadRootAllowed` and `isFileUnderRoot` shared the same hole. This module is documented as "the single authoritative place that decides whether a given absolute path is an acceptable write target".

## The fix

The absolute path cannot simply be handed to `path.resolve`: on POSIX that treats `C:\...` as relative and prefixes the cwd, and this server is routinely asked about Windows paths from a Linux host (tests, Azure proxy). That is exactly why the verbatim return existed.

So `..` and `.` are now collapsed **lexically**, preserving drive / UNC / POSIX root prefixes, and a path that climbs above its own root is **rejected outright** rather than clamped. Harmless in-root `..` still collapses normally, and `canonicalPath` can no longer carry a `..` into the writer.

Additionally: `realNorm` now resolves against the deepest **existing** ancestor when the target does not exist yet. Previously `realpathSync` threw on every not-yet-created file and the symlink form silently degraded to the lexical one.

## Verification

New `tests/utils/pathContainmentTraversal.test.ts` covers the AxTable-segment attack in both separator spellings, root escape, harmless in-root `..` collapsing, the model-hint cross-check against the *collapsed* path, the read side, and glob results. **All 7 fail without the fix.**

Full suite: 2854 passed, `tsc --noEmit` clean. The existing symlink and broadening containment tests still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)