### PR TITLE
Stop directXmlModifyProperty from corrupting non-leaf XML elements (audit finding 3, CRITICAL)

### DIFF
--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -352,7 +352,9 @@ async function directXmlReplaceCode(
  *
  * `propertyPath` is a bare element name (no XPath/dotted-path support).
  * Refuses to act if the element is missing (returns null so the caller
- * surfaces the original bridge error) or ambiguous (appears more than once).
+ * surfaces the original bridge error), ambiguous (appears more than once),
+ * or is not a leaf — string replacement can only express a text value, and
+ * writing one over an element that has children produces malformed XML.
  */
 async function directXmlModifyProperty(
   filePath: string,
@@ -368,6 +370,20 @@ async function directXmlModifyProperty(
 
     const tagName = propertyPath.split(/[./]/).pop()!;
 
+    // tagName is interpolated into RegExp source below. Anything that is not a
+    // plain XML element name has no meaning here anyway, and letting it through
+    // either throws on an unbalanced metacharacter (caught, surfacing a
+    // misleading "bridge error") or silently matches the wrong elements.
+    if (!/^[A-Za-z_][A-Za-z0-9_.:-]*$/.test(tagName)) {
+      return {
+        success: false,
+        message:
+          `❌ directXmlModifyProperty: '${propertyPath}' does not name a plain XML element ` +
+          `(resolved to "${tagName}") — nothing was written.`,
+      };
+    }
+    const tagRe = tagName.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&');
+
     // Forms first: the bridge refuses modify-property for AxForm entirely, and the
     // generic path below cannot serve Design properties either — Caption/Style also
     // occur on controls, so it sees several matches and refuses (#37).
@@ -380,8 +396,9 @@ async function directXmlModifyProperty(
       };
     }
 
-    const openTagRe = new RegExp(`<${tagName}\\b[^>]*>[\\s\\S]*?</${tagName}>`, 'g');
-    const selfClosingRe = new RegExp(`<${tagName}\\b([^>]*)/>`, 'g');
+    const openTagRe = new RegExp(`<${tagRe}\\b[^>]*>[\\s\\S]*?</${tagRe}>`, 'g');
+    const selfClosingRe = new RegExp(`<${tagRe}\\b([^>]*)/>`, 'g');
+    const openTagOnlyRe = new RegExp(`^<${tagRe}\\b[^>]*>`);
 
     const openMatches = content.match(openTagRe) ?? [];
     const selfClosingMatches = content.match(selfClosingRe) ?? [];
@@ -422,8 +439,30 @@ async function directXmlModifyProperty(
       };
     }
 
+    // Leaf guard. The replacement below can only express a text value, so an
+    // element that has children must be refused: the old `>[\s\S]*?<` rewrite
+    // stopped at the FIRST child tag and produced `<Tag>NewValue<Child>…`,
+    // i.e. structurally broken XML written to disk and reported as success.
+    // Counting matches (above) does not catch this — one match can still be a
+    // container.
+    if (openMatches.length === 1) {
+      const inner = openMatches[0]
+        .replace(openTagOnlyRe, '')
+        .replace(new RegExp(`</${tagRe}>$`), '');
+      if (inner.includes('<')) {
+        return {
+          success: false,
+          message:
+            `❌ directXmlModifyProperty: <${tagName}> in ${filePath} contains child elements — ` +
+            `it holds structure, not a text value. Refusing to overwrite it (nothing was written).`,
+        };
+      }
+    }
+
+    // Function replacers throughout: `escapedValue` escapes XML metacharacters
+    // but not `$`, which a string replacement would read as a capture reference.
     const updated = openMatches.length === 1
-      ? content.replace(openTagRe, m => m.replace(/>[\s\S]*?</, `>${escapedValue}<`))
+      ? content.replace(openTagRe, m => `${openTagOnlyRe.exec(m)![0]}${escapedValue}</${tagName}>`)
       : content.replace(selfClosingRe, (_m, attrs) => `<${tagName}${attrs}>${escapedValue}</${tagName}>`);
 
     await fs.writeFile(filePath, normalizeD365Xml(updated), 'utf-8');

--- a/tests/tools/directXmlModifyPropertyLeafGuard.test.ts
+++ b/tests/tools/directXmlModifyPropertyLeafGuard.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression (audit finding 3, CRITICAL): directXmlModifyProperty corrupted
+ * non-leaf XML elements.
+ *
+ * The guard counted how many times <Tag> occurred and refused only when there
+ * was more than one. A single occurrence that happens to be a CONTAINER passed
+ * that check, and the value rewrite `m.replace(/>[\s\S]*?</, '>' + v + '<')`
+ * is non-greedy — it stopped at the first child tag, producing
+ *   <DeleteActions>NewValue<AxTableDeleteAction>…</AxTableDeleteAction></DeleteActions>
+ * i.e. structurally broken XML written to disk and reported as success.
+ *
+ * Separately, `tagName` was interpolated into `new RegExp` unescaped.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { modifyD365FileTool } from '../../src/tools/modifyD365File';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const { mockBridgeSetProperty, mockWriteFile } = vi.hoisted(() => ({
+  mockBridgeSetProperty: vi.fn(async () => ({ success: false, message: 'Bridge error [-32602]: unsupported' })),
+  mockWriteFile: vi.fn(async () => {}),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return { ...actual, bridgeSetProperty: mockBridgeSetProperty, bridgeValidateAfterWrite: vi.fn(async () => null) };
+});
+
+/** A container element (<DeleteActions>) and a leaf (<Label>) on the same table. */
+const TABLE_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+	<Name>ContosoXyzNoteHeader</Name>
+	<Label>Old label</Label>
+	<DeleteActions>
+		<AxTableDeleteAction>
+			<Name>ContosoXyzNoteLine</Name>
+			<DeleteAction>Cascade</DeleteAction>
+		</AxTableDeleteAction>
+	</DeleteActions>
+</AxTable>`;
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (p.endsWith('.xml')) return TABLE_XML;
+    if (p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: mockWriteFile,
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+  readdir: vi.fn(async () => []),
+  copyFile: vi.fn(async () => {}),
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'MyModel'),
+    getWriteAnchorModel: vi.fn(() => 'MyModel'),
+    getToolProjectSwitch: vi.fn(() => null),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'MyPackage'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (m: string) => ({ packageName: m, modelName: m, rootPath: 'K:\\PackagesLocalDirectory' })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({ packageName: p, modelName: m, rootPath: 'K:\\PackagesLocalDirectory' })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+const FILE_PATH = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\ContosoXyzNoteHeader.xml';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: {
+    name: 'modify_d365fo_file',
+    arguments: {
+      objectType: 'table',
+      objectName: 'ContosoXyzNoteHeader',
+      operation: 'modify-property',
+      filePath: FILE_PATH,
+      ...args,
+    },
+  },
+});
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  return {
+    symbolIndex: {
+      searchSymbols: vi.fn(() => []),
+      getSymbolByName: vi.fn(() => undefined),
+      getCustomModels: vi.fn(() => ['MyModel']),
+      db: { prepare: vi.fn(() => stmt) },
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    } as any,
+    parser: {} as any,
+    cache: { get: vi.fn(async () => null), set: vi.fn(async () => {}), generateSearchKey: vi.fn((q: string) => `k:${q}`) } as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+    bridge: { isReady: true, metadataAvailable: true } as any,
+  };
+};
+
+/** The XML actually handed to writeFile, if any. */
+const writtenXml = (): string | undefined =>
+  mockWriteFile.mock.calls.map(c => (c as unknown as [string, string])[1]).find(c => typeof c === 'string' && c.includes('<AxTable'));
+
+describe('directXmlModifyProperty — leaf guard and tagName escaping (regression)', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    mockBridgeSetProperty.mockClear();
+    mockWriteFile.mockClear();
+    mockBridgeSetProperty.mockResolvedValue({ success: false, message: 'Bridge error [-32602]: unsupported' });
+  });
+
+  it('refuses to overwrite a container element instead of writing malformed XML', async () => {
+    const result = await modifyD365FileTool(req({ propertyPath: 'DeleteActions', propertyValue: 'Cascade' }), ctx);
+
+    expect(result.isError).toBeTruthy();
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/child elements/i);
+    // The decisive assertion: nothing structurally broken reached the disk.
+    expect(writtenXml()).toBeUndefined();
+  });
+
+  it('still sets a genuine leaf element', async () => {
+    const result = await modifyD365FileTool(req({ propertyPath: 'Label', propertyValue: 'New label' }), ctx);
+
+    expect(result.isError).toBeFalsy();
+    const xml = writtenXml();
+    expect(xml).toContain('<Label>New label</Label>');
+    // The untouched container is still intact.
+    expect(xml).toContain('<AxTableDeleteAction>');
+  });
+
+  it('writes a value containing `$&` literally rather than as a capture reference', async () => {
+    await modifyD365FileTool(req({ propertyPath: 'Label', propertyValue: 'A$&B' }), ctx);
+    expect(writtenXml()).toContain('<Label>A$&amp;B</Label>');
+  });
+
+  it('rejects a propertyPath that is not a plain XML element name', async () => {
+    const result = await modifyD365FileTool(req({ propertyPath: 'Label(x', propertyValue: 'v' }), ctx);
+
+    expect(result.isError).toBeTruthy();
+    expect((result.content[0] as { text: string }).text).toMatch(/does not name a plain XML element/i);
+    expect(writtenXml()).toBeUndefined();
+  });
+});

--- a/tests/tools/directXmlModifyPropertyLeafGuard.test.ts
+++ b/tests/tools/directXmlModifyPropertyLeafGuard.test.ts
@@ -52,6 +52,10 @@ vi.mock('fs/promises', () => ({
   stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
   readdir: vi.fn(async () => []),
   copyFile: vi.fn(async () => {}),
+  // Direct-XML edits go through a temp-file + rename now, so the mock has to
+  // stub those two syscalls as well or the write throws and the fallback fails.
+  rename: vi.fn(async () => {}),
+  rm: vi.fn(async () => {}),
 }));
 
 vi.mock('../../src/utils/configManager', () => ({


### PR DESCRIPTION
**Phase 0.2** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4). Audit finding 3, severity **critical**.

## Defect 1 — container elements were overwritten into malformed XML

The ambiguity guard counted how many times `<Tag>` occurred and refused only when there was **more than one**. A single occurrence that happens to be a *container* passed that check. The value rewrite is non-greedy:

```js
m.replace(/>[\s\S]*?</, `>${escapedValue}<`)
```

so it stopped at the first child tag:

```xml
<DeleteActions>Cascade<AxTableDeleteAction>…</AxTableDeleteAction></DeleteActions>
```

Structurally broken XML, written to disk, reported as ✅ success.

Now the single match is checked for child content and a container is refused outright, and the replacement rebuilds the element from its captured open tag instead of splicing at the first `<`.

## Defect 2 — `tagName` reached `new RegExp` unescaped

A metacharacter in `propertyPath` either threw (`Invalid regular expression: … Unterminated group` — caught, then surfaced as a *misleading bridge error*, visible in the pre-fix test output) or silently matched the wrong elements. `tagName` is now validated as a plain XML element name and escaped anyway.

## Also

Both replacements now use function replacers. `escapedValue` escapes XML metacharacters but not `$`, and a string replacement reads `$&` as a capture reference.

## Verification

New `tests/tools/directXmlModifyPropertyLeafGuard.test.ts`: container refusal (asserting nothing reached `writeFile`), the still-working leaf case, a `$&` value, and the metachar path. **3 of 4 fail without the fix.**

Full suite: 2851 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)