### PR TITLE
Escape free text in every XML builder through one shared escaper (audit finding 7, CRITICAL)

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from 'fs/promises';
+import { escapeXml } from '../utils/xmlEscape.js';
 import * as path from 'path';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
@@ -833,7 +834,7 @@ ${methodsXml}\t</SourceCode>
         fieldsXml += `\t\t<AxTableField xmlns=""\n\t\t\ti:type="${iType}">\n`;
         fieldsXml += `\t\t\t<Name>${f.name}</Name>\n`;
         if (f.edt)       fieldsXml += `\t\t\t<ExtendedDataType>${f.edt}</ExtendedDataType>\n`;
-        if (f.label)     fieldsXml += `\t\t\t<Label>${f.label}</Label>\n`;
+        if (f.label)     fieldsXml += `\t\t\t<Label>${escapeXml(f.label)}</Label>\n`;
         if (f.mandatory) fieldsXml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
         if (f.enumType)  fieldsXml += `\t\t\t<EnumType>${f.enumType}</EnumType>\n`;
         fieldsXml += `\t\t</AxTableField>\n`;
@@ -948,8 +949,8 @@ ${fieldsXml}\t<FullTextIndexes />
         autoValue = intValue + 1;
         enumValuesXml += `\t\t<AxEnumValue>\n`;
         enumValuesXml += `\t\t\t<Name>${v.name}</Name>\n`;
-        if (v.label) enumValuesXml += `\t\t\t<Label>${v.label}</Label>\n`;
-        if (v.helpText) enumValuesXml += `\t\t\t<HelpText>${v.helpText}</HelpText>\n`;
+        if (v.label) enumValuesXml += `\t\t\t<Label>${escapeXml(v.label)}</Label>\n`;
+        if (v.helpText) enumValuesXml += `\t\t\t<HelpText>${escapeXml(v.helpText)}</HelpText>\n`;
         // Omit <Value> when UseEnumValue=No (position-based ordering) or for implicit 0
         if (intValue !== 0 && !suppressExplicitValues) enumValuesXml += `\t\t\t<Value>${intValue}</Value>\n`;
         enumValuesXml += `\t\t</AxEnumValue>\n`;
@@ -964,7 +965,7 @@ ${fieldsXml}\t<FullTextIndexes />
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${enumName}</Name>
-${configKeyXml}\t<Label>${label}</Label>
+${configKeyXml}\t<Label>${escapeXml(label)}</Label>
 \t<UseEnumValue>${useEnumValue}</UseEnumValue>
 ${enumValuesXml}${isExtensibleXml}</AxEnum>
 `;
@@ -1152,7 +1153,7 @@ ${enumValuesXml}${isExtensibleXml}</AxEnum>
       if (ds.fields && ds.fields.length > 0) {
         const entries = ds.fields.map(f => {
           const alias      = f.alias    || `${ds.tmpTableName}.1.${f.name}`;
-          const capLine    = f.caption          ? `\n\t\t\t\t<Caption>${f.caption}</Caption>`                                 : '';
+          const capLine    = f.caption          ? `\n\t\t\t\t<Caption>${escapeXml(f.caption)}</Caption>`                                 : '';
           const dtLine     = f.dataType         ? `\n\t\t\t\t<DataType>${f.dataType}</DataType>`                              : '';
           const disableLine = f.disableAutoCreate ? `\n\t\t\t\t<DisableAutoCreateInDataRegion>true</DisableAutoCreateInDataRegion>` : '';
           return [
@@ -1521,7 +1522,7 @@ ${rdlParamLayoutXml}
     };
 
     // ── Design block ──
-    const captionLine = properties?.caption ? `\n\t\t\t<Caption>${properties.caption}</Caption>` : '';
+    const captionLine = properties?.caption ? `\n\t\t\t<Caption>${escapeXml(properties.caption)}</Caption>` : '';
     const styleLine   = properties?.style   ? `\n\t\t\t<Style>${properties.style}</Style>`       : '';
     const rdlContent  = properties?.rdlContent as string | undefined;
     // Sanitize: fix old-schema <Header> inside <TablixMember> — renamed to <TablixHeader> in 2016 RDL.
@@ -2485,11 +2486,7 @@ ${defaultParamGroupXml}
    */
   static encodeReportTextElement(xml: string): string {
     return xml.replace(/<Text><!\[CDATA\[([\s\S]*?)\]\]><\/Text>/g, (_match, rdlInner: string) => {
-      const encoded = rdlInner
-        .replace(/&/g, '&amp;')   // must be first to avoid double-encoding
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
-      return `<Text>${encoded}</Text>`;
+      return `<Text>${escapeXml(rdlInner)}</Text>`;
     });
   }
 
@@ -2525,7 +2522,7 @@ ${defaultParamGroupXml}
 <AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns=""
 \ti:type="${edtType}">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>${extends_}
+\t<Label>${escapeXml(label)}</Label>${extends_}
 \t<ArrayElements />
 \t<Relations />
 \t<TableReferences />${stringSize}
@@ -2588,8 +2585,8 @@ ${defaultParamGroupXml}
         enumValuesXml += `\n\t\t<AxEnumValue>`;
         enumValuesXml += `\n\t\t\t<Name>${v.name}</Name>`;
         if (v.countryRegionCodes) enumValuesXml += `\n\t\t\t<CountryRegionCodes>${v.countryRegionCodes}</CountryRegionCodes>`;
-        if (v.label) enumValuesXml += `\n\t\t\t<Label>${v.label}</Label>`;
-        if (v.helpText) enumValuesXml += `\n\t\t\t<HelpText>${v.helpText}</HelpText>`;
+        if (v.label) enumValuesXml += `\n\t\t\t<Label>${escapeXml(v.label)}</Label>`;
+        if (v.helpText) enumValuesXml += `\n\t\t\t<HelpText>${escapeXml(v.helpText)}</HelpText>`;
         if (v.value !== undefined && v.value !== 0) enumValuesXml += `\n\t\t\t<Value>${v.value}</Value>`;
         enumValuesXml += `\n\t\t</AxEnumValue>`;
       }
@@ -2638,7 +2635,7 @@ ${enumValuesXml}
         fieldsXml += `\t\t<AxTableField xmlns=""\n\t\t\ti:type="${iType}">\n`;
         fieldsXml += `\t\t\t<Name>${f.name}</Name>\n`;
         if (f.edt)       fieldsXml += `\t\t\t<ExtendedDataType>${f.edt}</ExtendedDataType>\n`;
-        if (f.label)     fieldsXml += `\t\t\t<Label>${f.label}</Label>\n`;
+        if (f.label)     fieldsXml += `\t\t\t<Label>${escapeXml(f.label)}</Label>\n`;
         if (f.mandatory) fieldsXml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
         if (f.enumType)  fieldsXml += `\t\t\t<EnumType>${f.enumType}</EnumType>\n`;
         fieldsXml += `\t\t</AxTableField>\n`;
@@ -2656,7 +2653,7 @@ ${enumValuesXml}
       fieldGroupsXml = '\t<FieldGroups>\n';
       for (const fg of fgSpecs) {
         fieldGroupsXml += `\t\t<AxTableFieldGroup>\n\t\t\t<Name>${fg.name}</Name>\n`;
-        if (fg.label) fieldGroupsXml += `\t\t\t<Label>${fg.label}</Label>\n`;
+        if (fg.label) fieldGroupsXml += `\t\t\t<Label>${escapeXml(fg.label)}</Label>\n`;
         const fgFields = Array.isArray(fg.fields) ? fg.fields : [];
         if (fgFields.length === 0) {
           fieldGroupsXml += `\t\t\t<Fields />\n`;
@@ -2855,7 +2852,7 @@ ${relationsXml}
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 ${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
 </AxSecurityDuty>`;
   }
@@ -2872,7 +2869,7 @@ ${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privil
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<DirectAccessPermissions />
 ${this.securityRefContainer('Duties', 'AxSecurityDutyReference', duties)}
 ${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
@@ -2982,8 +2979,8 @@ public final class ${contractName} extends BusinessEventsContract
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxTile xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
-\t<HelpText>${helpText}</HelpText>
+\t<Label>${escapeXml(label)}</Label>
+\t<HelpText>${escapeXml(helpText)}</HelpText>
 \t<TileType>${tileType}</TileType>${menuItem ? `\n\t<MenuItemName>${menuItem}</MenuItemName>\n\t<MenuItemType>Display</MenuItemType>` : ''}${query ? `\n\t<Query>${query}</Query>` : ''}
 \t<Size>Wide</Size>
 \t<RefreshFrequency>600</RefreshFrequency>
@@ -3003,8 +3000,8 @@ public final class ${contractName} extends BusinessEventsContract
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxKPI xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
-\t<HelpText>${helpText}</HelpText>${measure ? `\n\t<Measure>${measure}</Measure>` : ''}${dimension ? `\n\t<MeasureDimension>${dimension}</MeasureDimension>` : ''}
+\t<Label>${escapeXml(label)}</Label>
+\t<HelpText>${escapeXml(helpText)}</HelpText>${measure ? `\n\t<Measure>${measure}</Measure>` : ''}${dimension ? `\n\t<MeasureDimension>${dimension}</MeasureDimension>` : ''}
 \t<Goal>0</Goal>
 \t<GoalType>None</GoalType>
 \t<Trend>None</Trend>
@@ -3054,7 +3051,7 @@ public final class ${contractName} extends BusinessEventsContract
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxConfigurationKey xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>${parentKey ? `\n\t<ParentKey>${parentKey}</ParentKey>` : ''}${licenseCode ? `\n\t<LicenseCode>${licenseCode}</LicenseCode>` : ''}${tags ? `\n\t<Tags>${tags}</Tags>` : ''}
+\t<Label>${escapeXml(label)}</Label>${parentKey ? `\n\t<ParentKey>${parentKey}</ParentKey>` : ''}${licenseCode ? `\n\t<LicenseCode>${licenseCode}</LicenseCode>` : ''}${tags ? `\n\t<Tags>${escapeXml(tags)}</Tags>` : ''}
 </AxConfigurationKey>`;
   }
 
@@ -3088,7 +3085,7 @@ public final class ${contractName} extends BusinessEventsContract
 \t<Name>${name}</Name>
 \t<ConstrainedTable>${constrainedTable}</ConstrainedTable>
 \t<Enabled>${enabled}</Enabled>
-\t<Label>${label}</Label>${contextType ? `\n\t<ContextType>${contextType}</ContextType>` : ''}${roleName ? `\n\t<RoleName>${roleName}</RoleName>` : ''}${primaryTable ? `\n\t<PrimaryTable>${primaryTable}</PrimaryTable>` : ''}${query ? `\n\t<Query>${query}</Query>` : ''}
+\t<Label>${escapeXml(label)}</Label>${contextType ? `\n\t<ContextType>${contextType}</ContextType>` : ''}${roleName ? `\n\t<RoleName>${roleName}</RoleName>` : ''}${primaryTable ? `\n\t<PrimaryTable>${primaryTable}</PrimaryTable>` : ''}${query ? `\n\t<Query>${query}</Query>` : ''}
 \t<ConstrainedTables>${constrainedXml ? `\n${constrainedXml}\n\t` : ''}</ConstrainedTables>
 </AxSecurityPolicy>`;
   }
@@ -3208,7 +3205,7 @@ public final class ${contractName} extends BusinessEventsContract
 <AxLicenseCode xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
 \t<Group>${group}</Group>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<Package>${pkg}</Package>
 \t<PublicKey>${publicKey}</PublicKey>
 </AxLicenseCode>`;
@@ -3222,7 +3219,7 @@ public final class ${contractName} extends BusinessEventsContract
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxMenu xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<Elements />
 </AxMenu>`;
   }
@@ -3293,7 +3290,7 @@ public final class ${contractName} extends BusinessEventsContract
     return `<?xml version="1.0" encoding="utf-8"?>
 <${elemName} xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<Object>${targetObject}</Object>${objectTypeXml}
 </${elemName}>`;
   }

--- a/src/tools/dataEntityViewExtensionXml.ts
+++ b/src/tools/dataEntityViewExtensionXml.ts
@@ -62,9 +62,7 @@ export interface AxDataEntityViewExtensionFieldGroupSpec {
   fields: string[];
 }
 
-function escapeXmlText(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
+import { escapeXml as escapeXmlText } from '../utils/xmlEscape.js';
 
 /**
  * Sub-elements of AxDataEntityViewField, in shipped order: the presentation

--- a/src/tools/dataEntityXml.ts
+++ b/src/tools/dataEntityXml.ts
@@ -91,6 +91,8 @@
  * properties.dataManagementEnabled — the caller is then responsible for the
  * staging table existing (create it as its own table).
  */
+import { escapeXml } from '../utils/xmlEscape.js';
+
 
 /** The five field groups every shipped data entity carries (5810/5859). */
 const STANDARD_FIELD_GROUPS: Array<{ name: string; autoPopulate?: boolean }> = [
@@ -214,7 +216,7 @@ export function buildAxDataEntityXml(entityName: string, properties?: Record<str
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxDataEntityView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${entityName}</Name>
-${sourceCodeXml}\t<Label>${label}</Label>
+${sourceCodeXml}\t<Label>${escapeXml(label)}</Label>
 ${changeTrackingXml}${dataManagementXml}\t<EntityCategory>${entityCategory}</EntityCategory>
 ${isPublicXml}${publicNamesXml}${deleteActionsXml}${fieldGroupsXml}\t<Fields />
 \t<Keys />
@@ -259,7 +261,7 @@ ${stateMachinesXml}\t<ViewMetadata />
   return `<?xml version="1.0" encoding="utf-8"?>
 <AxDataEntityView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${entityName}</Name>
-${sourceCodeXml}\t<Label>${label}</Label>
+${sourceCodeXml}\t<Label>${escapeXml(label)}</Label>
 ${changeTrackingXml}${dataManagementXml}\t<EntityCategory>${entityCategory}</EntityCategory>
 ${isPublicXml}\t<PrimaryKey>${keyName}</PrimaryKey>
 ${publicNamesXml}${deleteActionsXml}${fieldGroupsXml}\t<Fields>

--- a/src/tools/edtExtensionXml.ts
+++ b/src/tools/edtExtensionXml.ts
@@ -28,9 +28,7 @@ const NAMED_PROPERTY_MODIFICATIONS: Array<[string, string]> = [
   ['formHelp', 'FormHelp'],
 ];
 
-function escapeXmlText(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
+import { escapeXml as escapeXmlText } from '../utils/xmlEscape.js';
 
 /**
  * @param name  Full extension element name, dot notation: BaseEdt.<Prefix>Extension

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import { escapeXml } from '../utils/xmlEscape.js';
 import { z } from 'zod';
 import { getConfigManager } from '../utils/configManager.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
@@ -346,7 +347,7 @@ public class ${tableName} extends common
 ]]></Declaration>
 \t\t<Methods />
 \t</SourceCode>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<TableGroup>${tableGroup}</TableGroup>
 ${titleField1Xml}${titleField2Xml}${extendedXml}\t<DeleteActions />
 \t<FieldGroups>
@@ -422,8 +423,8 @@ ${titleField1Xml}${titleField2Xml}${extendedXml}\t<DeleteActions />
         autoValue = intValue + 1;
         enumValuesXml += `\t\t<AxEnumValue>\n`;
         enumValuesXml += `\t\t\t<Name>${v.name}</Name>\n`;
-        if (v.label) enumValuesXml += `\t\t\t<Label>${v.label}</Label>\n`;
-        if (v.helpText) enumValuesXml += `\t\t\t<HelpText>${v.helpText}</HelpText>\n`;
+        if (v.label) enumValuesXml += `\t\t\t<Label>${escapeXml(v.label)}</Label>\n`;
+        if (v.helpText) enumValuesXml += `\t\t\t<HelpText>${escapeXml(v.helpText)}</HelpText>\n`;
         // Omit <Value> when UseEnumValue=No (position-based ordering) or for implicit 0
         if (intValue !== 0 && !suppressExplicitValues) enumValuesXml += `\t\t\t<Value>${intValue}</Value>\n`;
         enumValuesXml += `\t\t</AxEnumValue>\n`;
@@ -438,7 +439,7 @@ ${titleField1Xml}${titleField2Xml}${extendedXml}\t<DeleteActions />
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${enumName}</Name>
-${configKeyXml}\t<Label>${label}</Label>
+${configKeyXml}\t<Label>${escapeXml(label)}</Label>
 \t<UseEnumValue>${useEnumValue}</UseEnumValue>
 ${enumValuesXml}${isExtensibleXml}</AxEnum>
 `;
@@ -617,7 +618,7 @@ ${enumValuesXml}${isExtensibleXml}</AxEnum>
       if (ds.fields && ds.fields.length > 0) {
         const entries = ds.fields.map(f => {
           const alias      = f.alias    || `${ds.tmpTableName}.1.${f.name}`;
-          const capLine    = f.caption          ? `\n\t\t\t\t<Caption>${f.caption}</Caption>`                                 : '';
+          const capLine    = f.caption          ? `\n\t\t\t\t<Caption>${escapeXml(f.caption)}</Caption>`                                 : '';
           const dtLine     = f.dataType         ? `\n\t\t\t\t<DataType>${f.dataType}</DataType>`                              : '';
           const disableLine = f.disableAutoCreate ? `\n\t\t\t\t<DisableAutoCreateInDataRegion>true</DisableAutoCreateInDataRegion>` : '';
           return [
@@ -977,7 +978,7 @@ ${rdlParamLayoutXml}
 </Report>`;
     };
 
-    const captionLine = properties?.caption ? `\n\t\t\t<Caption>${properties.caption}</Caption>` : '';
+    const captionLine = properties?.caption ? `\n\t\t\t<Caption>${escapeXml(properties.caption)}</Caption>` : '';
     const styleLine   = properties?.style   ? `\n\t\t\t<Style>${properties.style}</Style>`       : '';
     const rdlContent  = properties?.rdlContent as string | undefined;
     // Sanitize: fix old-schema <Header> inside <TablixMember> — renamed to <TablixHeader> in 2016 RDL.
@@ -1121,7 +1122,7 @@ ${defaultParamGroupXml}
 <AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns=""
 \ti:type="${edtType}">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>${extends_}
+\t<Label>${escapeXml(label)}</Label>${extends_}
 \t<ArrayElements />
 \t<Relations />
 \t<TableReferences />${stringSize}
@@ -1180,8 +1181,8 @@ ${defaultParamGroupXml}
         enumValuesXml += `\n\t\t<AxEnumValue>`;
         enumValuesXml += `\n\t\t\t<Name>${v.name}</Name>`;
         if (v.countryRegionCodes) enumValuesXml += `\n\t\t\t<CountryRegionCodes>${v.countryRegionCodes}</CountryRegionCodes>`;
-        if (v.label) enumValuesXml += `\n\t\t\t<Label>${v.label}</Label>`;
-        if (v.helpText) enumValuesXml += `\n\t\t\t<HelpText>${v.helpText}</HelpText>`;
+        if (v.label) enumValuesXml += `\n\t\t\t<Label>${escapeXml(v.label)}</Label>`;
+        if (v.helpText) enumValuesXml += `\n\t\t\t<HelpText>${escapeXml(v.helpText)}</HelpText>`;
         if (v.value !== undefined && v.value !== 0) enumValuesXml += `\n\t\t\t<Value>${v.value}</Value>`;
         enumValuesXml += `\n\t\t</AxEnumValue>`;
       }
@@ -1212,7 +1213,7 @@ ${enumValuesXml}
         fieldsXml += `\t\t<AxTableField xmlns=""\n\t\t\ti:type="${iType}">\n`;
         fieldsXml += `\t\t\t<Name>${f.name}</Name>\n`;
         if (f.edt)       fieldsXml += `\t\t\t<ExtendedDataType>${f.edt}</ExtendedDataType>\n`;
-        if (f.label)     fieldsXml += `\t\t\t<Label>${f.label}</Label>\n`;
+        if (f.label)     fieldsXml += `\t\t\t<Label>${escapeXml(f.label)}</Label>\n`;
         if (f.mandatory) fieldsXml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
         if (f.enumType)  fieldsXml += `\t\t\t<EnumType>${f.enumType}</EnumType>\n`;
         fieldsXml += `\t\t</AxTableField>\n`;
@@ -1230,7 +1231,7 @@ ${enumValuesXml}
       fieldGroupsXml = '\t<FieldGroups>\n';
       for (const fg of fgSpecs) {
         fieldGroupsXml += `\t\t<AxTableFieldGroup>\n\t\t\t<Name>${fg.name}</Name>\n`;
-        if (fg.label) fieldGroupsXml += `\t\t\t<Label>${fg.label}</Label>\n`;
+        if (fg.label) fieldGroupsXml += `\t\t\t<Label>${escapeXml(fg.label)}</Label>\n`;
         const fgFields = Array.isArray(fg.fields) ? fg.fields : [];
         if (fgFields.length === 0) {
           fieldGroupsXml += `\t\t\t<Fields />\n`;
@@ -1403,7 +1404,7 @@ ${relationsXml}
     return `<?xml version="1.0" encoding="utf-8"?>
 <${elemName} xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<Object>${targetObject}</Object>${objectTypeXml}
 </${elemName}>`;
   }
@@ -1413,7 +1414,7 @@ ${relationsXml}
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxMenu xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<Elements />
 </AxMenu>`;
   }
@@ -1440,7 +1441,7 @@ ${relationsXml}
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<Privileges />
 </AxSecurityDuty>`;
   }
@@ -1450,7 +1451,7 @@ ${relationsXml}
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<DirectAccessPermissions />
 \t<Duties />
 \t<Privileges />
@@ -1584,8 +1585,7 @@ export async function handleGenerateD365Xml(
     if (args.objectType === 'report') {
       xmlContent = xmlContent.replace(
         /<Text><!\[CDATA\[([\s\S]*?)\]\]><\/Text>/g,
-        (_m, inner: string) =>
-          `<Text>${inner.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</Text>`
+        (_m, inner: string) => `<Text>${escapeXml(inner)}</Text>`
       );
     }
 

--- a/src/tools/generateTableFields.ts
+++ b/src/tools/generateTableFields.ts
@@ -15,6 +15,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
+import { escapeXml } from '../utils/xmlEscape.js';
 import {
   resolveBestEdt,
   resolveEdtBaseType,
@@ -85,9 +86,6 @@ export function axTableFieldType(edt?: string, type?: string, enumType?: string)
   return 'AxTableFieldString';
 }
 
-function escapeXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
 
 /** Render one <AxTableField> fragment (D365FO generic i:type format). */
 export function buildFieldXml(f: ResolvedField): string {

--- a/src/tools/mapXml.ts
+++ b/src/tools/mapXml.ts
@@ -6,6 +6,8 @@
  * underlying table via <Mappings><AxTableMapping><Connections> entries pairing
  * each map field name (MapField) with the target table's field name (MapFieldTo).
  */
+import { escapeXml } from '../utils/xmlEscape.js';
+
 
 const FIELD_TYPE_TO_AXTYPE: Record<string, string> = {
   Int: 'AxMapFieldInt',
@@ -95,7 +97,7 @@ public class ${mapName} extends common
 }
 ]]></Declaration>
 \t\t<Methods />
-\t</SourceCode>${developerDocumentation ? `\n\t<DeveloperDocumentation>${developerDocumentation}</DeveloperDocumentation>` : ''}${label ? `\n\t<Label>${label}</Label>` : ''}
+\t</SourceCode>${developerDocumentation ? `\n\t<DeveloperDocumentation>${escapeXml(developerDocumentation)}</DeveloperDocumentation>` : ''}${label ? `\n\t<Label>${escapeXml(label)}</Label>` : ''}
 \t<FieldGroups />
 \t<Fields>
 ${fieldsXml}

--- a/src/tools/menuItemExtensionXml.ts
+++ b/src/tools/menuItemExtensionXml.ts
@@ -49,9 +49,7 @@ export type AxMenuItemExtensionRootElement =
   | 'AxMenuItemActionExtension'
   | 'AxMenuItemOutputExtension';
 
-function escapeXmlText(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
+import { escapeXml as escapeXmlText } from '../utils/xmlEscape.js';
 
 /**
  * @param rootElement  AxMenuItem{Display,Action,Output}Extension

--- a/src/tools/queryViewXml.ts
+++ b/src/tools/queryViewXml.ts
@@ -13,6 +13,8 @@
  * and its own <Fields> are AxViewFieldBound entries pointing at that query's
  * datasource alias; it does not embed its own ViewMetadata/DataSources.
  */
+import { escapeXml } from '../utils/xmlEscape.js';
+
 
 /**
  * properties.dataSource — REQUIRED for a functional query: the root table.
@@ -29,7 +31,7 @@ export function buildAxQueryXml(queryName: string, properties?: Record<string, a
   // query a BPErrorLabelIsText (L3-xds-policy-constrained-table run). Emit it only
   // when the caller supplies one.
   const title: string | undefined = properties?.title || properties?.label;
-  const titleXml = title ? `\t<Title>${title}</Title>\n` : '';
+  const titleXml = title ? `\t<Title>${escapeXml(title)}</Title>\n` : '';
   const dataSource: string | undefined = properties?.dataSource || properties?.table;
   const dataSourceName: string = properties?.dataSourceName || dataSource || '';
   const fields: Array<{ name: string; field?: string }> | undefined =
@@ -113,7 +115,7 @@ ${titleXml}\t<DataSources />
         const field = r.field || r.name;
         return `\t\t\t\t<AxQuerySimpleDataSourceRange>
 \t\t\t\t\t<Name>${r.name || field}</Name>
-\t\t\t\t\t<Field>${field}</Field>${r.value !== undefined && r.value !== '' ? `\n\t\t\t\t\t<Value>${r.value}</Value>` : ''}
+\t\t\t\t\t<Field>${field}</Field>${r.value !== undefined && r.value !== '' ? `\n\t\t\t\t\t<Value>${escapeXml(r.value)}</Value>` : ''}
 \t\t\t\t</AxQuerySimpleDataSourceRange>`;
       }).join('\n')}\n\t\t\t</Ranges>\n`
     : '\t\t\t<Ranges />\n';
@@ -189,7 +191,7 @@ export function buildAxViewXml(viewName: string, properties?: Record<string, any
     return `<?xml version="1.0" encoding="utf-8"?>
 <AxView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${viewName}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<Fields />
 \t<Mappings />
 \t<ViewMetadata />
@@ -207,7 +209,7 @@ export function buildAxViewXml(viewName: string, properties?: Record<string, any
   return `<?xml version="1.0" encoding="utf-8"?>
 <AxView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${viewName}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t<Query>${query}</Query>
 \t<Fields>
 ${fieldsXml}

--- a/src/tools/securityPrivilegeXml.ts
+++ b/src/tools/securityPrivilegeXml.ts
@@ -17,6 +17,8 @@
  * properties.accessLevel   – 'view' | 'maintain' | 'read' (default: 'view' = Read only)
  * properties.dataEntity    – Name of the data entity to grant permissions on (optional)
  */
+import { escapeXml } from '../utils/xmlEscape.js';
+
 export function buildAxSecurityPrivilegeXml(name: string, properties?: Record<string, any>): string {
   const label = properties?.label || '@TODO:LabelId';
   const targetObject: string | undefined = properties?.targetObject;
@@ -53,7 +55,7 @@ export function buildAxSecurityPrivilegeXml(name: string, properties?: Record<st
   return `<?xml version="1.0" encoding="utf-8"?>
 <AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${name}</Name>
-\t<Label>${label}</Label>
+\t<Label>${escapeXml(label)}</Label>
 \t${dataEntityPermissionsElement}
 \t<DirectAccessPermissions />
 \t<EntryPoints>${entryPointsXml}</EntryPoints>

--- a/src/tools/serviceXml.ts
+++ b/src/tools/serviceXml.ts
@@ -18,6 +18,8 @@
  * <Class>, <ExternalName> and <ServiceOperations>, so those are always emitted
  * (defaulting to the service name) rather than left out.
  */
+import { escapeXml } from '../utils/xmlEscape.js';
+
 
 interface ServiceOperationDef {
   /** Externally visible operation name. Defaults to `method`. */
@@ -96,7 +98,7 @@ export function buildAxServiceXml(serviceName: string, properties?: Record<strin
   return `<?xml version="1.0" encoding="utf-8"?>
 <AxService xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
 \t<Name>${serviceName}</Name>
-\t<Class>${serviceClass}</Class>${description ? `\n\t<Description>${description}</Description>` : ''}
+\t<Class>${serviceClass}</Class>${description ? `\n\t<Description>${escapeXml(description)}</Description>` : ''}
 \t<ExternalName>${externalName}</ExternalName>${namespace ? `\n\t<Namespace>${namespace}</Namespace>` : ''}
 ${operationsBlock}
 </AxService>
@@ -128,7 +130,7 @@ export function buildAxServiceGroupXml(groupName: string, properties?: Record<st
 
   return `<?xml version="1.0" encoding="utf-8"?>
 <AxServiceGroup xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${groupName}</Name>${autoDeploy ? `\n\t<AutoDeploy>${autoDeploy}</AutoDeploy>` : ''}${description ? `\n\t<Description>${description}</Description>` : ''}
+\t<Name>${groupName}</Name>${autoDeploy ? `\n\t<AutoDeploy>${autoDeploy}</AutoDeploy>` : ''}${description ? `\n\t<Description>${escapeXml(description)}</Description>` : ''}
 ${servicesBlock}
 </AxServiceGroup>
 `;

--- a/src/utils/smartXmlBuilder.ts
+++ b/src/utils/smartXmlBuilder.ts
@@ -5,6 +5,7 @@
  */
 
 import { FormPatternTemplates, FormPattern } from './formPatternTemplates.js';
+import { escapeXml as escapeXmlText } from './xmlEscape.js';
 import { ensureXppDocComment } from './xppDocGen.js';
 import { decodeXmlEntitiesFromXppSource } from '../tools/modifyD365File.js';
 import { type FieldControlMap, controlForField } from './fieldControlTypes.js';
@@ -567,15 +568,13 @@ export class SmartXmlBuilder {
   }
 
   /**
-   * Escape XML special characters
+   * Escape XML special characters. Delegates to the shared escaper — every one
+   * of these call sites writes TEXT content, where the Microsoft serializer
+   * leaves quotes alone, so the old local `&quot;`/`&apos;` handling only made
+   * our files differ from shipped ones.
    */
   private escapeXml(text: string): string {
-    return text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&apos;');
+    return escapeXmlText(text);
   }
 
   /**

--- a/src/utils/xmlEscape.ts
+++ b/src/utils/xmlEscape.ts
@@ -1,0 +1,41 @@
+/**
+ * The single XML escaper for every metadata builder.
+ *
+ * Most builders in src/tools interpolate caller-supplied strings straight into
+ * XML template literals. Labels, descriptions, help text and developer
+ * documentation are free text, so an ampersand or angle bracket in any of them
+ * (`label: "Purchases & Sales"`) writes malformed XML into
+ * PackagesLocalDirectory — and the create path adds the file to the .rnrproj
+ * before anything parses it, so the failure surfaces much later as an
+ * unexplained build break.
+ *
+ * Before this module five builders carried their own private copy of the
+ * escaper and disagreed about what to escape, while the rest escaped nothing at
+ * all. Import from here instead of writing a sixth.
+ *
+ * IMPORTANT: escaping is not idempotent — `&` becomes `&amp;`, so applying it
+ * twice yields `&amp;amp;`. Escape at the point where a raw value enters XML,
+ * never on a fragment that is already XML.
+ */
+
+/**
+ * Escape a value for use as XML **text content**.
+ *
+ * Only `&`, `<` and `>` are escaped, matching what the Microsoft metadata
+ * serializer emits for text nodes — escaping quotes here too would round-trip
+ * correctly but make our files differ needlessly from shipped ones.
+ */
+export function escapeXml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Escape a value for use inside a double-quoted XML **attribute**.
+ * Adds `"` to the text-content set so the attribute cannot be terminated early.
+ */
+export function escapeXmlAttr(value: unknown): string {
+  return escapeXml(value).replace(/"/g, '&quot;');
+}

--- a/tests/tools/xmlEscaping.test.ts
+++ b/tests/tools/xmlEscaping.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression (audit finding 7, CRITICAL): almost no XML builder escaped the
+ * free text it interpolated.
+ *
+ * `label: "Purchases & Sales"` wrote a bare `&` into PackagesLocalDirectory,
+ * and the create path adds the file to the .rnrproj BEFORE anything parses it —
+ * so the malformed XML surfaced much later as an unexplained build break rather
+ * than as a rejected call. Only smartXmlBuilder and four extension builders
+ * escaped anything, each with its own private copy of the escaper.
+ *
+ * Every builder below is asserted by PARSING its output: an unescaped `&` or
+ * `<` makes the document unparseable, which is the actual failure.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseStringPromise } from 'xml2js';
+import { escapeXml, escapeXmlAttr } from '../../src/utils/xmlEscape';
+import { buildAxSecurityPrivilegeXml } from '../../src/tools/securityPrivilegeXml';
+import { buildAxQueryXml, buildAxViewXml } from '../../src/tools/queryViewXml';
+import { buildAxDataEntityXml } from '../../src/tools/dataEntityXml';
+import { buildAxServiceXml, buildAxServiceGroupXml } from '../../src/tools/serviceXml';
+import { buildAxMapXml } from '../../src/tools/mapXml';
+import { SmartXmlBuilder } from '../../src/utils/smartXmlBuilder';
+
+/** The value that used to corrupt every generated file. */
+const NASTY = 'Purchases & Sales <Ltd> "quoted"';
+
+const parses = async (xml: string) => {
+  await expect(parseStringPromise(xml)).resolves.toBeDefined();
+};
+
+describe('escapeXml', () => {
+  it('escapes the three text-content metacharacters', () => {
+    expect(escapeXml('a & b < c > d')).toBe('a &amp; b &lt; c &gt; d');
+  });
+
+  it('escapes `&` first so nothing is double-encoded', () => {
+    expect(escapeXml('<')).toBe('&lt;');
+    expect(escapeXml('&lt;')).toBe('&amp;lt;');
+  });
+
+  it('leaves quotes alone in text content but escapes them in attributes', () => {
+    // The Microsoft serializer does not escape quotes in text nodes; matching it
+    // keeps generated files byte-comparable with shipped ones.
+    expect(escapeXml('say "hi"')).toBe('say "hi"');
+    expect(escapeXmlAttr('say "hi"')).toBe('say &quot;hi&quot;');
+  });
+
+  it('renders null/undefined as empty rather than the string "null"', () => {
+    expect(escapeXml(null)).toBe('');
+    expect(escapeXml(undefined)).toBe('');
+  });
+});
+
+describe('builders emit parseable XML for free text containing & and <', () => {
+  it('AxSecurityPrivilege', async () => {
+    const xml = buildAxSecurityPrivilegeXml('ContosoXyzPrivilege', {
+      label: NASTY,
+      targetObject: 'ContosoXyzMenuItem',
+    });
+    await parses(xml);
+    expect(xml).toContain('Purchases &amp; Sales &lt;Ltd&gt;');
+  });
+
+  it('AxQuery title', async () => {
+    const xml = buildAxQueryXml('ContosoXyzQuery', { title: NASTY, dataSource: 'CustTable' });
+    await parses(xml);
+  });
+
+  it('AxQuery range value (an X++ expression, commonly with < or &&)', async () => {
+    const xml = buildAxQueryXml('ContosoXyzQuery', {
+      dataSource: 'CustTable',
+      ranges: [{ field: 'AccountNum', value: '<(currentUserId())' }],
+    });
+    await parses(xml);
+  });
+
+  it('AxView', async () => {
+    const xml = buildAxViewXml('ContosoXyzView', { label: NASTY, query: 'ContosoXyzQuery' });
+    await parses(xml);
+  });
+
+  it('AxDataEntityView', async () => {
+    const xml = buildAxDataEntityXml('ContosoXyzEntity', {
+      label: NASTY,
+      primaryTable: 'CustTable',
+      fields: [{ name: 'AccountNum' }],
+    });
+    await parses(xml);
+  });
+
+  it('AxService description', async () => {
+    const xml = buildAxServiceXml('ContosoXyzService', {
+      serviceClass: 'ContosoXyzServiceClass',
+      description: NASTY,
+    });
+    await parses(xml);
+  });
+
+  it('AxServiceGroup description', async () => {
+    const xml = buildAxServiceGroupXml('ContosoXyzServiceGroup', { description: NASTY });
+    await parses(xml);
+  });
+
+  it('AxMap label and developer documentation', async () => {
+    const xml = buildAxMapXml('ContosoXyzMap', {
+      label: NASTY,
+      developerDocumentation: NASTY,
+      fields: [{ name: 'AccountNum', type: 'String' }],
+    });
+    await parses(xml);
+  });
+
+  it('SmartXmlBuilder table with a nasty field label', async () => {
+    const xml = new SmartXmlBuilder().buildTableXml({
+      name: 'ContosoXyzTable',
+      label: NASTY,
+      fields: [{ name: 'AccountNum', type: 'String', label: NASTY }],
+    });
+    await parses(xml);
+  });
+});


### PR DESCRIPTION
**Phase 0.3** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4). Audit finding 7, severity **critical**.

## The problem

Only `smartXmlBuilder` and four extension builders escaped anything — each carrying its own private copy of the escaper, and the three copies disagreed about what to escape. Every other builder interpolated caller-supplied text straight into an XML template literal:

```ts
`\t<Label>${label}</Label>`
```

So `label: "Purchases & Sales"` wrote a bare `&` into PackagesLocalDirectory. The create path adds the file to the `.rnrproj` **before anything parses it**, so this did not surface as a rejected call — it surfaced much later as an unexplained build break.

## The fix

New `src/utils/xmlEscape.ts` is the single escaper:

- `escapeXml()` — text content: `&`, `<`, `>`. Deliberately *not* quotes: the Microsoft serializer leaves those alone in text nodes, and escaping them would make generated files differ needlessly from shipped ones.
- `escapeXmlAttr()` — adds `"` for attribute values.

Applied to every free-text element across the builders (`Label`, `HelpText`, `Description`, `Caption`, `Title`, `Tags`, `DeveloperDocumentation`, and query range values, which carry X++ expressions and so routinely contain `<` and `&&`). The five duplicate escapers now delegate to it, including two ad-hoc inline CDATA→entity re-encoders.

Object names and enum values were left alone — they are validated identifiers, so escaping them is a no-op that would only add noise.

## Verification

New `tests/tools/xmlEscaping.test.ts` asserts by **parsing** each builder's output with a label containing `&`, `<` and quotes — unparseable output is the actual failure mode. **8 of the 13 fail without the fix** (the 5 that pass are the escaper's own unit tests plus `SmartXmlBuilder`, which already escaped).

Full suite: 2860 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)