### PR TITLE
Scope replaceCode's last-resort fallback to the requested method (audit finding 5, CRITICAL)

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -4129,8 +4129,17 @@ namespace D365MetadataBridge.Services
                             catch { /* control may not have Methods */ }
 
                             // Fallback: some SDK versions may expose Source directly on the DataControl item
-                            // (for cases where control name IS the method name, e.g. flat override list)
-                            if (!replaced)
+                            // (for cases where control name IS the method name, e.g. flat override list).
+                            // Only safe when we can tie this item to the request: either the caller named
+                            // this control ("PostButton.clicked"), or the item's own name IS the method.
+                            // Without that check an unqualified methodName ("clicked") would match every
+                            // control in the form and rewrite the first unrelated one that happens to
+                            // contain oldCode, while the caller is told 'clicked' was edited.
+                            bool itemIsRequestedMember = controlNameFilter != null
+                                || effectiveMethodName == null
+                                || string.Equals(ctrlName, effectiveMethodName, StringComparison.OrdinalIgnoreCase);
+
+                            if (!replaced && itemIsRequestedMember)
                             {
                                 try
                                 {
@@ -4179,19 +4188,27 @@ namespace D365MetadataBridge.Services
                     catch { }
                 }
 
-                // Absolute last resort: scan ALL reachable Source properties for oldCode (no method name filter)
-                // This handles edge cases where the SDK stores the code in an unexpected location.
+                // Absolute last resort: scan the SourceCode sub-collections for the requested member,
+                // for edge cases where the SDK stores it under an unexpected CONTAINER. The method
+                // scope travels with it — a fallback that ignored methodName silently rewrote a
+                // DIFFERENT method whenever the target one did not contain oldCode, and still
+                // reported success, so the caller believed its edit had landed.
                 if (!replaced)
                 {
-                    replaced = ReplaceCodeInXmlFallback(dyn, oldCode, newCode);
+                    replaced = ReplaceCodeInXmlFallback(dyn, methodName, controlNameFilter, effectiveMethodName, oldCode, newCode);
                 }
 
                 return replaced;
             }
             catch (Exception ex)
             {
+                // A genuine failure (SDK binder fault, provider I/O) is NOT "the snippet is absent".
+                // Returning false here made every caller report "oldCode not found", which sends the
+                // calling agent off retrying different snippets against a healthy method instead of
+                // surfacing the real fault. Surface it, keeping the original as InnerException.
                 Console.Error.WriteLine($"[WriteService] ReplaceInMethods failed: {ex.Message}");
-                return false;
+                throw new InvalidOperationException(
+                    $"replace-code failed while editing {(methodName != null ? $"method '{methodName}'" : "object source")}: {ex.Message}", ex);
             }
         }
 
@@ -4273,14 +4290,33 @@ namespace D365MetadataBridge.Services
         }
 
         /// <summary>
-        /// Absolute last-resort fallback: enumerate all iterable collections exposed by SourceCode
+        /// Absolute last-resort fallback: enumerate the iterable collections exposed by SourceCode
         /// (Methods, DataSources, DataControls, Members) and any nested items looking for Source
-        /// properties that contain oldCode. Replaces globally. Used when structured access fails.
+        /// properties that contain oldCode. Used when structured access fails.
         /// For DataControls, also iterates into each control's Methods sub-collection.
+        ///
+        /// The fallback widens the CONTAINER it looks in, never the member it edits: when the caller
+        /// named a method, only members carrying that name are eligible. An unnamed member cannot be
+        /// proven to be the target, so it is skipped rather than edited on a text match.
         /// </summary>
-        private bool ReplaceCodeInXmlFallback(dynamic axObject, string oldCode, string newCode)
+        private bool ReplaceCodeInXmlFallback(dynamic axObject, string? methodName, string? controlNameFilter,
+            string? effectiveMethodName, string oldCode, string newCode)
         {
             bool replaced = false;
+
+            // Accepts the same name spellings the structured passes accept for one member:
+            // the bare method name, the raw "Control.method" the caller sent, and the
+            // "Control_method" flattening some form shapes use.
+            bool IsRequestedMember(string? memberName)
+            {
+                if (effectiveMethodName == null) return true;   // caller scoped to the whole object
+                if (memberName == null) return false;
+                return string.Equals(memberName, effectiveMethodName, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(memberName, methodName, StringComparison.OrdinalIgnoreCase)
+                    || (controlNameFilter != null && string.Equals(memberName,
+                            $"{controlNameFilter}_{effectiveMethodName}", StringComparison.OrdinalIgnoreCase));
+            }
+
             try
             {
                 // Try all known sub-collections on SourceCode
@@ -4302,13 +4338,17 @@ namespace D365MetadataBridge.Services
                         {
                             try
                             {
+                                string? itemName = null;
+                                try { itemName = (string?)item.Name; } catch { }
+                                if (!IsRequestedMember(itemName)) continue;
+
                                 string? src = null;
                                 try { src = (string?)item.Source; } catch { }
                                 if (src != null && src.Contains(oldCode))
                                 {
                                     item.Source = src.Replace(oldCode, newCode);
                                     replaced = true;
-                                    Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced in SourceCode.{colName} item '{(string?)item.Name ?? "?"}'");
+                                    Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced in SourceCode.{colName} item '{itemName ?? "?"}'");
                                 }
                             }
                             catch { }
@@ -4333,6 +4373,13 @@ namespace D365MetadataBridge.Services
                                     string ctrlName = "?";
                                     try { ctrlName = (string)ctrl.Name; } catch { }
 
+                                    // A control-scoped request ("PostButton.clicked") stays inside its
+                                    // control; reaching into a sibling control would edit an override
+                                    // the caller never named.
+                                    if (controlNameFilter != null &&
+                                        !string.Equals(ctrlName, controlNameFilter, StringComparison.OrdinalIgnoreCase))
+                                        continue;
+
                                     // Try methods inside control
                                     try
                                     {
@@ -4340,12 +4387,16 @@ namespace D365MetadataBridge.Services
                                         {
                                             try
                                             {
+                                                string? mName = null;
+                                                try { mName = (string?)m.Name; } catch { }
+                                                if (!IsRequestedMember(mName)) continue;
+
                                                 string? src = (string?)m.Source;
                                                 if (src != null && src.Contains(oldCode))
                                                 {
                                                     m.Source = src.Replace(oldCode, newCode);
                                                     replaced = true;
-                                                    Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced in DataControls.{ctrlName}.{(string?)m.Name ?? "?"}");
+                                                    Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced in DataControls.{ctrlName}.{mName ?? "?"}");
                                                 }
                                             }
                                             catch { }
@@ -4353,18 +4404,24 @@ namespace D365MetadataBridge.Services
                                     }
                                     catch { }
 
-                                    // Also try direct Source on control object (flat override lists)
-                                    try
+                                    // Also try direct Source on control object (flat override lists).
+                                    // Eligible only when the caller named this control, or the control's
+                                    // own name is the method name — otherwise this item is some other
+                                    // control's code and must not absorb the edit.
+                                    if (controlNameFilter != null || IsRequestedMember(ctrlName))
                                     {
-                                        string? src = (string?)ctrl.Source;
-                                        if (src != null && src.Contains(oldCode))
+                                        try
                                         {
-                                            ctrl.Source = src.Replace(oldCode, newCode);
-                                            replaced = true;
-                                            Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced direct Source on DataControl '{ctrlName}'");
+                                            string? src = (string?)ctrl.Source;
+                                            if (src != null && src.Contains(oldCode))
+                                            {
+                                                ctrl.Source = src.Replace(oldCode, newCode);
+                                                replaced = true;
+                                                Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback: replaced direct Source on DataControl '{ctrlName}'");
+                                            }
                                         }
+                                        catch { }
                                     }
-                                    catch { }
                                 }
                                 catch { }
                             }
@@ -4375,7 +4432,11 @@ namespace D365MetadataBridge.Services
             }
             catch (Exception ex)
             {
+                // Swallowing this used to leave the caller with "oldCode not found" even though the
+                // scan never completed — and possibly with a partial edit already applied. Let it out
+                // so ReplaceInMethods reports a real error and no Update is attempted.
                 Console.Error.WriteLine($"[WriteService] ReplaceCodeInXmlFallback failed: {ex.Message}");
+                throw;
             }
             return replaced;
         }

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "f6da40c4b39c39c05833f9ec284084794319f5f51b68d6a798db460783700b7c",
+  "sourceHash": "6344117e635ba98886f98bd2732b101fcdd36750ec5f8d110015e6c0d9198a54",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7858.27",
-  "builtAt": "2026-08-04T05:49:49.967Z"
+  "metamodelFileVersion": "7.0.7996.33",
+  "builtAt": "2026-08-08T12:10:17.178Z"
 }

--- a/tests/bridge/replaceCodeScopingParity.test.ts
+++ b/tests/bridge/replaceCodeScopingParity.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression test — C# bridge `replaceCode` must never edit a method it was not asked to edit.
+ *
+ * MetadataWriteService.ReplaceInMethods() walks a chain of increasingly loose passes looking for
+ * `oldCode`. The last link, ReplaceCodeInXmlFallback(), used to take only (axObject, oldCode,
+ * newCode) — no method scope at all. So whenever the REQUESTED method did not contain the snippet,
+ * the fallback found it in some other member, rewrote that one, and ReplaceCode returned
+ * `success: true` naming the method the caller asked for. The caller's edit had silently landed in
+ * an unrelated method.
+ *
+ * The same catch block also turned genuine exceptions (SDK binder faults, provider I/O) into
+ * `return false`, which every ReplaceCode arm reports as "oldCode not found" — steering the calling
+ * agent into retrying different snippets against a perfectly healthy method instead of surfacing
+ * the real failure.
+ *
+ * Repo tests cannot exercise this: it lives in C# behind the metadata SDK, and the TypeScript side
+ * mocks BridgeClient. This is the cheap standing guard on the source itself.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const WRITE_SERVICE_CS = path.join(
+  path.resolve(__dirname, '..', '..'),
+  'bridge', 'D365MetadataBridge', 'Services', 'MetadataWriteService.cs',
+);
+
+let source: string;
+
+/**
+ * Slices a member body: from its signature up to the next member declaration, which in this file
+ * is always a `///` doc comment / access modifier at 8-space indentation.
+ */
+function memberBody(marker: string): string {
+  const start = source.indexOf(marker);
+  expect(start, `member not found — signature changed? ${marker}`).toBeGreaterThanOrEqual(0);
+  const rest = source.slice(start);
+  const next = rest.slice(marker.length).search(/\n {8}(?:\/\/\/|private|public|internal|protected)/);
+  return next === -1 ? rest : rest.slice(0, marker.length + next);
+}
+
+/** Every index at which `needle` occurs in `haystack`. */
+function indicesOf(haystack: string, needle: string): number[] {
+  const out: number[] = [];
+  for (let i = haystack.indexOf(needle); i !== -1; i = haystack.indexOf(needle, i + 1)) out.push(i);
+  return out;
+}
+
+describe('bridge replaceCode — fallback stays inside the requested method', () => {
+  beforeAll(() => {
+    source = fs.readFileSync(WRITE_SERVICE_CS, 'utf8');
+  });
+
+  it('ReplaceCodeInXmlFallback takes the method scope as parameters', () => {
+    expect(
+      source,
+      'ReplaceCodeInXmlFallback must receive methodName / controlNameFilter / effectiveMethodName — ' +
+        'without them it replaces oldCode in ANY member and reports success for the requested one',
+    ).toMatch(
+      /private bool ReplaceCodeInXmlFallback\(\s*dynamic axObject,\s*string\? methodName,\s*string\? controlNameFilter,\s*string\? effectiveMethodName,\s*string oldCode,\s*string newCode\s*\)/,
+    );
+  });
+
+  it('every call site forwards the method scope', () => {
+    const callSites = indicesOf(source, 'ReplaceCodeInXmlFallback(')
+      // Drop the declaration; keep invocations.
+      .filter((at) => !/private bool $/.test(source.slice(Math.max(0, at - 13), at)))
+      .map((at) => {
+        const tail = source.slice(at, at + 300);
+        const end = tail.indexOf(';');
+        return end === -1 ? tail : tail.slice(0, end);
+      });
+
+    expect(callSites.length, 'expected exactly one ReplaceCodeInXmlFallback invocation').toBe(1);
+
+    for (const args of callSites) {
+      for (const param of ['methodName', 'controlNameFilter', 'effectiveMethodName']) {
+        expect(
+          args,
+          `ReplaceCodeInXmlFallback invoked without '${param}' — an unscoped fallback silently ` +
+            `edits a different method and still returns success`,
+        ).toContain(param);
+      }
+    }
+  });
+
+  it('guards every replacement inside the fallback with a name check', () => {
+    const body = memberBody('private bool ReplaceCodeInXmlFallback(dynamic axObject,');
+
+    expect(body, 'fallback lost its name predicate').toContain('IsRequestedMember');
+
+    // The predicate must refuse an unnamed member: a member we cannot name is a member we cannot
+    // prove is the target, so it must not be edited on a bare text match.
+    expect(body).toMatch(/if \(memberName == null\) return false;/);
+
+    // A control-scoped request ("PostButton.clicked") must not reach a sibling control.
+    expect(
+      body,
+      'fallback iterates DataControls without honouring controlNameFilter — it can edit an ' +
+        'override on a control the caller never named',
+    ).toMatch(/controlNameFilter != null &&\s*!string\.Equals\(ctrlName, controlNameFilter[\s\S]{0,80}continue;/);
+
+    // Each Source write must sit downstream of a scope guard.
+    const writes = indicesOf(body, '.Source = src.Replace(');
+    expect(
+      writes.length,
+      'expected the three known Source writes in the fallback (SourceCode.<collection> item, ' +
+        'DataControl method, DataControl direct Source)',
+    ).toBe(3);
+
+    for (const at of writes) {
+      const preceding = body.slice(Math.max(0, at - 900), at);
+      expect(
+        /IsRequestedMember\(|controlNameFilter != null/.test(preceding),
+        `an unguarded Source write at fallback offset ${at} — a replacement with no name/control ` +
+          `check crosses a method boundary`,
+      ).toBe(true);
+    }
+  });
+
+  it('does not let an unqualified methodName match a control-level Source in ReplaceInMethods', () => {
+    const body = memberBody('private bool ReplaceInMethods(object axObject,');
+    expect(
+      body,
+      'the direct-Source DataControl fallback must be tied to the request (control named, or the ' +
+        'control name IS the method) — otherwise methodName="clicked" rewrites the first control ' +
+        'in the form that happens to contain oldCode',
+    ).toMatch(/bool itemIsRequestedMember[\s\S]{0,400}if \(!replaced && itemIsRequestedMember\)/);
+  });
+});
+
+describe('bridge replaceCode — real errors are not reported as "oldCode not found"', () => {
+  beforeAll(() => {
+    source = fs.readFileSync(WRITE_SERVICE_CS, 'utf8');
+  });
+
+  it('ReplaceInMethods rethrows instead of returning false on exception', () => {
+    const body = memberBody('private bool ReplaceInMethods(object axObject,');
+
+    const catchAt = body.indexOf('catch (Exception ex)');
+    expect(catchAt, 'ReplaceInMethods has no typed catch — did the method get restructured?')
+      .toBeGreaterThan(0);
+
+    const tail = body.slice(catchAt);
+    expect(
+      tail,
+      'a swallowed exception becomes `false`, which every ReplaceCode arm reports as ' +
+        '"oldCode not found" — the agent then retries different snippets instead of seeing the ' +
+        'real fault',
+    ).not.toMatch(/return false;/);
+    expect(tail).toContain('throw new InvalidOperationException');
+    expect(tail, 'the original exception must survive as InnerException').toMatch(/,\s*ex\);/);
+  });
+
+  it('ReplaceCodeInXmlFallback rethrows instead of swallowing', () => {
+    const body = memberBody('private bool ReplaceCodeInXmlFallback(dynamic axObject,');
+    const catchAt = body.indexOf('catch (Exception ex)');
+    expect(catchAt, 'fallback has no typed catch — did the method get restructured?').toBeGreaterThan(0);
+    expect(
+      body.slice(catchAt),
+      'swallowing here leaves the caller with "oldCode not found" after an aborted scan, possibly ' +
+        'with a partial edit already applied',
+    ).toContain('throw;');
+  });
+
+  it('every "oldCode not found" message names the method that was searched', () => {
+    const lines = source
+      .split('\n')
+      .filter((l) => l.includes('throw new InvalidOperationException($"oldCode not found'));
+    expect(lines.length, 'expected one not-found throw per ReplaceCode object-type arm').toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(line, `not-found message omits methodName: ${line.trim()}`).toContain('methodName');
+    }
+  });
+});


### PR DESCRIPTION
**Phase 0.6** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4). Audit finding 5, severity **critical**.

## The problem

`ReplaceCodeInXmlFallback` was documented as replacing "globally" and did exactly that: it scanned every reachable `Source` for `oldCode` with **no filter on `methodName`**. When the target method did not contain the snippet, a *different* method was silently rewritten and `success` was returned — the caller was told its edit landed where it asked.

Separately, `ReplaceInMethods`'s catch swallowed genuine exceptions (SDK binder faults, provider I/O) into `return false`, which every caller reports as `"oldCode not found"`. That is not a cosmetic mislabel: `src/tools/modifyD365File.ts:2832` keys its "re-fetch the source and copy the exact snippet" hint off `/oldCode not found/i`, so a real fault sent the calling agent off retrying different snippets against a perfectly healthy method.

## The fix

The fallback now widens the **container** it looks in, never the **member** it edits. A local `IsRequestedMember` predicate gates all three `Source` writes, accepting the same name spellings the structured passes accept for one member (bare name, raw `Ctrl.method`, flattened `Ctrl_method`). A member whose name cannot be read is skipped — it cannot be *proven* to be the target. A control-scoped request stays inside its control.

Exceptions now surface as `InvalidOperationException` with the original as `InnerException`, reaching the dispatcher's existing `catch (Exception)` exactly like the pre-existing not-found throw — no process-level change. The genuine not-found path is untouched and already names the method.

## Slightly beyond the audit's anchors

The direct-`Source` DataControl path in `ReplaceInMethods` had the identical defect one level up: gated only on `controlNameFilter`, so an unqualified `methodName` (`"clicked"`) matched every control and rewrote the first one containing `oldCode`. Fixed in the same pass since it is the same failure mode in the same chain — flagging it here in case you want it split out.

## Verification

`dotnet build` — succeeded, 0 warnings, 0 errors (metamodel 7.0.7996.33).

New `tests/bridge/replaceCodeScopingParity.test.ts` (7 tests) follows the repo's C#-grep parity convention. Negative control: against pre-fix source **6 of 7 fail** (the 7th was already true).

Full suite: 2847 passed.

## Known caveat — one behavioural narrowing

Not verified against a live form on the VM; the claims about which SDK container actually holds a given override rest on reading the existing code. If some SDK shape stores a form override under `SourceCode.DataSources` with the *datasource* name on the item and the method code in its `Source`, the scoped fallback will now **skip** where it previously replaced. That is judged correct — it cannot be proven to be the target — but it is the one case that could surface as a new "oldCode not found" on an edit that used to *appear* to succeed. If that appears in practice, the safe recovery is to iterate methods nested under `DataSources`; that was deliberately not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)