### PR TITLE
Unify the generate/create mirrors for table, form and security duty/role (audit finding 2, CRITICAL)

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -5,6 +5,14 @@
 
 import * as fs from 'fs/promises';
 import { escapeXml } from '../utils/xmlEscape.js';
+import { buildAxTableXml } from './tableXml.js';
+import { buildAxFormXml } from './formXml.js';
+import {
+  buildAxSecurityDutyXml,
+  buildAxSecurityRoleXml,
+  buildAxSecurityDutyExtensionXml,
+  buildAxSecurityRoleExtensionXml,
+} from './securityDutyRoleXml.js';
 import * as path from 'path';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
@@ -24,9 +32,8 @@ import { validateFormExtensionControlShape, buildFormExtensionShapeError } from 
 import { FormPatternTemplates } from '../utils/formPatternTemplates.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
-import { renderAxTableProperties } from '../utils/axTablePropertyOrder.js';
 import { buildAxSecurityPrivilegeXml } from './securityPrivilegeXml.js';
-import { buildAxDataEntityXml, isYes } from './dataEntityXml.js';
+import { buildAxDataEntityXml } from './dataEntityXml.js';
 import { resolveEdtBaseType, resolveEdtEnumType, heuristicEdtBaseType, isEnumName, bridgeEdtBaseType } from './generateSmartTable.js';
 import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
 import { buildAxMapXml } from './mapXml.js';
@@ -242,46 +249,6 @@ export class ProjectFileFinder {
 
     return null;
   }
-}
-
-/**
- * Map a D365FO base type name to the XML i:type attribute used in <AxTableField>.
- * If the explicit fieldType is not a known primitive, fall back to name-based heuristics
- * using edtName (same heuristics as SmartXmlBuilder.getAxTableFieldType).
- */
-function fieldTypeToAxType(fieldType: string, edtName?: string): string {
-  const typeMap: Record<string, string> = {
-    String:      'AxTableFieldString',
-    Integer:     'AxTableFieldInt',
-    Int64:       'AxTableFieldInt64',
-    Real:        'AxTableFieldReal',
-    Date:        'AxTableFieldDate',
-    DateTime:    'AxTableFieldUtcDateTime',
-    UtcDateTime: 'AxTableFieldUtcDateTime',
-    Enum:        'AxTableFieldEnum',
-    GUID:        'AxTableFieldGuid',
-    Guid:        'AxTableFieldGuid',
-    Container:   'AxTableFieldContainer',
-  };
-
-  const explicit = typeMap[fieldType];
-  if (explicit) return explicit;
-
-  // Fall back to EDT name heuristics (mirrors SmartXmlBuilder.getAxTableFieldType)
-  const hint = edtName || fieldType;
-  if (hint) {
-    const e = hint.toLowerCase();
-    if (e === 'recid' || e.endsWith('recid') || e.includes('refrecid')) return 'AxTableFieldInt64';
-    if (e.includes('utcdatetime') || (e.includes('datetime') && !e.includes('transdate'))) return 'AxTableFieldUtcDateTime';
-    if (e.includes('date') && !e.includes('time') && !e.includes('update')) return 'AxTableFieldDate';
-    if (e.includes('amount') || e.includes('mst') || e.includes('price') || e.includes('qty')
-        || e.includes('percent') || e === 'real') return 'AxTableFieldReal';
-    if (e === 'noyesid' || e.endsWith('noyesid') || e === 'noyes') return 'AxTableFieldEnum';
-    if ((e.endsWith('int') || e.includes('count') || e.includes('level'))
-        && !e.includes('account') && !e.includes('name')) return 'AxTableFieldInt';
-  }
-
-  return 'AxTableFieldString';
 }
 
 /**
@@ -773,137 +740,13 @@ ${methodsXml}\t</SourceCode>
     properties?: Record<string, any>,
     sourceCode?: string,
   ): string {
-    const primaryIndex = properties?.primaryIndex || '';
-
-    // Property block, emitted in CANONICAL ORDER. AxTable XML is order-sensitive
-    // and a misordered property is dropped without a word — see
-    // src/utils/axTablePropertyOrder.ts and findings #13. Empty values are omitted
-    // rather than written as <TitleField1></TitleField1>, matching the shipped
-    // tables and the VM-captured golden eval/goldens/L1-table-basic.
-    const propertiesXml = renderAxTableProperties({
-      ConfigurationKey: properties?.configurationKey,
-      DeveloperDocumentation: properties?.developerDocumentation,
-      FormRef: properties?.formRef,
-      Label: properties?.label || tableName,
-      TableGroup: properties?.tableGroup || 'Main',
-      TitleField1: properties?.titleField1,
-      TitleField2: properties?.titleField2,
-      // Dual-write's table-side prerequisite; without it the entity syncs once
-      // and then stops seeing changes.
-      AllowRowVersionChangeTracking:
-        isYes(properties?.allowRowVersionChangeTracking) ? 'Yes' : undefined,
-      CacheLookup: properties?.cacheLookup,
-      // Audit system fields — NoYes, ranked but previously unreachable.
-      CreatedBy: isYes(properties?.createdBy) ? 'Yes' : undefined,
-      CreatedDateTime: isYes(properties?.createdDateTime) ? 'Yes' : undefined,
-      CreatedTransactionId: isYes(properties?.createdTransactionId) ? 'Yes' : undefined,
-      ModifiedBy: isYes(properties?.modifiedBy) ? 'Yes' : undefined,
-      ModifiedDateTime: isYes(properties?.modifiedDateTime) ? 'Yes' : undefined,
-      ModifiedTransactionId: isYes(properties?.modifiedTransactionId) ? 'Yes' : undefined,
-      ClusteredIndex: properties?.clusteredIndex,
-      PrimaryIndex: primaryIndex,
-      // ReplacementKey mirrors PrimaryIndex unless the caller says otherwise.
-      ReplacementKey: properties?.replacementKey || primaryIndex,
-      SaveDataPerCompany: properties?.saveDataPerCompany,
-      SupportInheritance: properties?.supportInheritance,
-      // TableType: TempDB / InMemory; omitted for Regular, which is the default.
-      TableType: properties?.tableType,
-    });
-
-    // Build <Fields> block from properties.fields array (TableFieldSpec[]).
-    // Copilot may pass field definitions via properties.fields or via sourceCode JSON —
-    // both paths merge into properties before calling here (see generate()).
-    // Field-spec keys are unified with the table-extension path (generateAxTableExtensionXml):
-    // accept an explicit AxTableField* i:type (fieldType), a primitive base type (type),
-    // or infer AxTableFieldEnum from enumType — and always emit <EnumType> for enum fields.
-    const fieldSpecs: Array<{
-      name: string; edt?: string; type?: string; fieldType?: string; enumType?: string; mandatory?: boolean; label?: string;
-    }> = Array.isArray(properties?.fields) ? properties.fields : [];
-
-    let fieldsXml: string;
-    if (fieldSpecs.length === 0) {
-      fieldsXml = '\t<Fields />\n';
-    } else {
-      fieldsXml = '\t<Fields>\n';
-      for (const f of fieldSpecs) {
-        // Determine i:type: explicit AxTableField* wins; otherwise derive from the
-        // primitive type / enumType / EDT name heuristics. NEVER default to
-        // AxTableFieldString blindly when an EDT or enumType is present.
-        const iType = f.fieldType
-          ?? fieldTypeToAxType(f.type || (f.enumType ? 'Enum' : 'String'), f.edt);
-        fieldsXml += `\t\t<AxTableField xmlns=""\n\t\t\ti:type="${iType}">\n`;
-        fieldsXml += `\t\t\t<Name>${f.name}</Name>\n`;
-        if (f.edt)       fieldsXml += `\t\t\t<ExtendedDataType>${f.edt}</ExtendedDataType>\n`;
-        if (f.label)     fieldsXml += `\t\t\t<Label>${escapeXml(f.label)}</Label>\n`;
-        if (f.mandatory) fieldsXml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
-        if (f.enumType)  fieldsXml += `\t\t\t<EnumType>${f.enumType}</EnumType>\n`;
-        fieldsXml += `\t\t</AxTableField>\n`;
-      }
-      fieldsXml += '\t</Fields>\n';
-    }
-
-    // X++ passed in `sourceCode` used to be discarded outright: the caller got a ✅
-    // and an empty <Methods /> on disk, discoverable only by reading the file back
-    // (findings #19). Table source is class-shaped (`public class X extends common`
-    // + methods), so the class splitter handles it; when the caller passed only
-    // method bodies the splitter still returns them as methods.
-    const parsedSource = sourceCode?.trim()
-      ? XmlTemplateGenerator.parseSourceForBridge(sourceCode, tableName)
-      : undefined;
-    const declarationXpp =
-      parsedSource?.declaration?.trim()
-      && /\bclass\s+\w+/.test(parsedSource.declaration)
-        ? parsedSource.declaration.trim()
-        : `public class ${tableName} extends common\n{\n}`;
-    const methodsFromSource = parsedSource?.methods ?? [];
-    const methodsXml = methodsFromSource.length === 0
-      ? '\t\t<Methods />'
-      : `\t\t<Methods>\n${methodsFromSource
-          .map(m =>
-            `\t\t\t<Method>\n\t\t\t\t<Name>${m.name}</Name>\n` +
-            `\t\t\t\t<Source><![CDATA[\n${m.source ?? ''}\n\n]]></Source>\n\t\t\t</Method>`)
-          .join('\n')}\n\t\t</Methods>`;
-
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${tableName}</Name>
-\t<SourceCode>
-\t\t<Declaration><![CDATA[
-${declarationXpp}
-]]></Declaration>
-${methodsXml}
-\t</SourceCode>
-${propertiesXml}\t<DeleteActions />
-\t<FieldGroups>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoReport</Name>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoLookup</Name>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoIdentification</Name>
-\t\t\t<AutoPopulate>Yes</AutoPopulate>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoSummary</Name>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoBrowse</Name>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t</FieldGroups>
-${fieldsXml}\t<FullTextIndexes />
-\t<Indexes />
-\t<Mappings />
-\t<Relations />
-\t<StateMachines />
-</AxTable>
-`;
+    return buildAxTableXml(
+      tableName,
+      properties,
+      sourceCode?.trim()
+        ? XmlTemplateGenerator.parseSourceForBridge(sourceCode, tableName)
+        : undefined,
+    );
   }
 
   /**
@@ -988,23 +831,9 @@ ${enumValuesXml}${isExtensibleXml}</AxEnum>
    */
   static generateAxFormXml(
     formName: string,
-    properties?: Record<string, any>
+    properties?: Record<string, any>,
   ): string {
-    const rawPattern = properties?.pattern || properties?.formTemplate;
-    const pattern = rawPattern
-      ? FormPatternTemplates.normalizePattern(String(rawPattern))
-      : 'SimpleList';
-
-    return FormPatternTemplates.build(pattern, {
-      formName,
-      dsName: properties?.dataSource || undefined,
-      dsTable: properties?.dataSourceTable || properties?.dataSource || undefined,
-      caption: properties?.caption,
-      gridFields: Array.isArray(properties?.gridFields) ? properties.gridFields : undefined,
-      linesDsName: properties?.linesDataSource,
-      linesDsTable: properties?.linesDataSourceTable || properties?.linesDataSource,
-      sections: Array.isArray(properties?.sections) ? properties.sections : undefined,
-    });
+    return buildAxFormXml(formName, properties);
   }
 
   /**
@@ -2812,49 +2641,11 @@ ${relationsXml}
   }
 
   /**
-   * Normalize a name list that may arrive as an array or a comma/semicolon/
-   * newline-separated string (models pass either). Returns trimmed, non-empty names.
-   */
-  static normalizeNameList(value: any): string[] {
-    if (!value) return [];
-    const arr = Array.isArray(value) ? value : String(value).split(/[,;\n]+/);
-    return arr.map((s: any) => String(s).trim()).filter((s: string) => s.length > 0);
-  }
-
-  /**
-   * Render a security reference container: a self-closing tag when empty, or the
-   * wrapped child references (e.g. <AxSecurityPrivilegeReference><Name>…</Name></…>).
-   *
-   * The child element name matters: a duty/role that lists its privileges under
-   * `AxSecurityRolePermissionSet` / `AxSecurityRoleDutyPermission` deserializes into
-   * an EMPTY reference list, so the whole duty→privilege→role chain is dead —
-   * xppbp then reports BPErrorDutyHasNoPrivileges / BPErrorPrivilegeNotCoveredByDuty /
-   * BPErrorDutyNotCoveredByRole for references that are physically in the file.
-   * The correct names are AxSecurityPrivilegeReference / AxSecurityDutyReference
-   * (the same ones the *Extension writers below and generateD365Xml.ts already use).
-   * Evidence: docs/eval-sweep-findings-2026-07-21.md #31 (L4-master-security-slice run).
-   */
-  private static securityRefContainer(container: string, childTag: string, names: string[]): string {
-    if (names.length === 0) return `\t<${container} />`;
-    const children = names
-      .map(n => `\t\t<${childTag}>\n\t\t\t<Name>${n}</Name>\n\t\t</${childTag}>`)
-      .join('\n');
-    return `\t<${container}>\n${children}\n\t</${container}>`;
-  }
-
-  /**
    * Generate AxSecurityDuty XML.
    * properties.privileges – privilege names to reference (array or comma-separated).
    */
   static generateAxSecurityDutyXml(name: string, properties?: Record<string, any>): string {
-    const label = properties?.label || '@TODO:LabelId';
-    const privileges = this.normalizeNameList(properties?.privileges);
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${name}</Name>
-\t<Label>${escapeXml(label)}</Label>
-${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
-</AxSecurityDuty>`;
+    return buildAxSecurityDutyXml(name, properties);
   }
 
   /**
@@ -2863,18 +2654,7 @@ ${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privil
    * properties.privileges – privilege names to reference directly on the role.
    */
   static generateAxSecurityRoleXml(name: string, properties?: Record<string, any>): string {
-    const label = properties?.label || '@TODO:LabelId';
-    const duties = this.normalizeNameList(properties?.duties);
-    const privileges = this.normalizeNameList(properties?.privileges);
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${name}</Name>
-\t<Label>${escapeXml(label)}</Label>
-\t<DirectAccessPermissions />
-${this.securityRefContainer('Duties', 'AxSecurityDutyReference', duties)}
-${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
-\t<SubRoles />
-</AxSecurityRole>`;
+    return buildAxSecurityRoleXml(name, properties);
   }
 
   /**
@@ -2886,13 +2666,7 @@ ${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privil
    * properties.privileges – privilege names to add to the base duty (array or comma-separated).
    */
   static generateAxSecurityDutyExtensionXml(name: string, properties?: Record<string, any>): string {
-    const privileges = this.normalizeNameList(properties?.privileges);
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityDutyExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${name}</Name>
-${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
-\t<PropertyModifications />
-</AxSecurityDutyExtension>`;
+    return buildAxSecurityDutyExtensionXml(name, properties);
   }
 
   /**
@@ -2904,16 +2678,7 @@ ${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privil
    * properties.privileges – privilege names to add directly to the base role.
    */
   static generateAxSecurityRoleExtensionXml(name: string, properties?: Record<string, any>): string {
-    const duties = this.normalizeNameList(properties?.duties);
-    const privileges = this.normalizeNameList(properties?.privileges);
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityRoleExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${name}</Name>
-\t<DirectAccessPermissions />
-${this.securityRefContainer('Duties', 'AxSecurityDutyReference', duties)}
-${this.securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
-\t<PropertyModifications />
-</AxSecurityRoleExtension>`;
+    return buildAxSecurityRoleExtensionXml(name, properties);
   }
 
   /**

--- a/src/tools/formXml.ts
+++ b/src/tools/formXml.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared builder for AxForm XML.
+ *
+ * createD365File.ts and generateD365Xml.ts each expose a mirrored
+ * XmlTemplateGenerator class; both delegate here so the two cannot drift
+ * (mirrors the securityPrivilegeXml.ts / queryViewXml.ts pattern).
+ *
+ * The generate mirror had drifted all the way to ignoring its input: its
+ * parameter was literally named `_properties` and it returned a fixed empty
+ * shell — no pattern, no data source, no controls, no caption. Since the
+ * documented hybrid flow is generate → create(xmlContent), a caller who asked
+ * for a SimpleList form over a table got an empty form on disk, and an empty
+ * form builds clean.
+ */
+
+import { FormPatternTemplates } from '../utils/formPatternTemplates.js';
+
+/**
+ * Build an AxForm from a design pattern.
+ *
+ * The pattern comes from `properties.pattern` (the design pattern) or
+ * `properties.formTemplate` (the VS template name); both are fuzzy strings
+ * normalized to a canonical pattern. When neither is given we default to
+ * SimpleList — the most common shape for a new setup table.
+ */
+export function buildAxFormXml(formName: string, properties?: Record<string, any>): string {
+  const rawPattern = properties?.pattern || properties?.formTemplate;
+  const pattern = rawPattern
+    ? FormPatternTemplates.normalizePattern(String(rawPattern))
+    : 'SimpleList';
+
+  return FormPatternTemplates.build(pattern, {
+    formName,
+    dsName: properties?.dataSource || undefined,
+    dsTable: properties?.dataSourceTable || properties?.dataSource || undefined,
+    caption: properties?.caption,
+    gridFields: Array.isArray(properties?.gridFields) ? properties.gridFields : undefined,
+    linesDsName: properties?.linesDataSource,
+    linesDsTable: properties?.linesDataSourceTable || properties?.linesDataSource,
+    sections: Array.isArray(properties?.sections) ? properties.sections : undefined,
+  });
+}

--- a/src/tools/generateD365Xml.ts
+++ b/src/tools/generateD365Xml.ts
@@ -7,13 +7,21 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { escapeXml } from '../utils/xmlEscape.js';
+import { buildAxTableXml } from './tableXml.js';
+import { buildAxFormXml } from './formXml.js';
+import {
+  buildAxSecurityDutyXml,
+  buildAxSecurityRoleXml,
+  buildAxSecurityDutyExtensionXml,
+  buildAxSecurityRoleExtensionXml,
+} from './securityDutyRoleXml.js';
 import { z } from 'zod';
 import { getConfigManager } from '../utils/configManager.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
 import { reindentXppSource } from '../utils/xppFormat.js';
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
 import { buildAxSecurityPrivilegeXml } from './securityPrivilegeXml.js';
-import { buildAxDataEntityXml, isYes } from './dataEntityXml.js';
+import { buildAxDataEntityXml } from './dataEntityXml.js';
 import { buildAxQueryXml, buildAxViewXml } from './queryViewXml.js';
 import { buildAxEdtExtensionXml } from './edtExtensionXml.js';
 import { buildAxDataEntityViewExtensionXml } from './dataEntityViewExtensionXml.js';
@@ -313,71 +321,7 @@ ${methodsXml}\t</SourceCode>
     tableName: string,
     properties?: Record<string, any>
   ): string {
-    const label = properties?.label || tableName;
-    const tableGroup = properties?.tableGroup || 'Main';
-    const titleField1 = properties?.titleField1 || '';
-    const titleField2 = properties?.titleField2 || '';
-
-    const titleField1Xml = titleField1
-      ? `\t<TitleField1>${titleField1}</TitleField1>\n`
-      : '';
-    const titleField2Xml = titleField2
-      ? `\t<TitleField2>${titleField2}</TitleField2>\n`
-      : '';
-    // Canonical order: Title block → these → collections. See axTablePropertyOrder.
-    const noYes = (key: string, tag: string) =>
-      isYes(properties?.[key]) ? `\t<${tag}>Yes</${tag}>\n` : '';
-    const extendedXml =
-      noYes('allowRowVersionChangeTracking', 'AllowRowVersionChangeTracking') +
-      noYes('createdBy', 'CreatedBy') +
-      noYes('createdDateTime', 'CreatedDateTime') +
-      noYes('createdTransactionId', 'CreatedTransactionId') +
-      noYes('modifiedBy', 'ModifiedBy') +
-      noYes('modifiedDateTime', 'ModifiedDateTime') +
-      noYes('modifiedTransactionId', 'ModifiedTransactionId');
-
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${tableName}</Name>
-\t<SourceCode>
-\t\t<Declaration><![CDATA[
-public class ${tableName} extends common
-{
-}
-]]></Declaration>
-\t\t<Methods />
-\t</SourceCode>
-\t<Label>${escapeXml(label)}</Label>
-\t<TableGroup>${tableGroup}</TableGroup>
-${titleField1Xml}${titleField2Xml}${extendedXml}\t<DeleteActions />
-\t<FieldGroups>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoReport</Name>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoLookup</Name>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoIdentification</Name>
-\t\t\t<AutoPopulate>Yes</AutoPopulate>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoSummary</Name>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t\t<AxTableFieldGroup>
-\t\t\t<Name>AutoBrowse</Name>
-\t\t\t<Fields />
-\t\t</AxTableFieldGroup>
-\t</FieldGroups>
-\t<Fields />
-\t<Indexes />
-\t<Relations />
-</AxTable>
-`;
+    return buildAxTableXml(tableName, properties);
   }
 
   /**
@@ -450,37 +394,9 @@ ${enumValuesXml}${isExtensibleXml}</AxEnum>
    */
   static generateAxFormXml(
     formName: string,
-    _properties?: Record<string, any>
+    properties?: Record<string, any>
   ): string {
-    // D365FO forms require xmlns="Microsoft.Dynamics.AX.Metadata.V6" and SourceCode first
-    // NOTE: <Label> is intentionally absent — AxForm files do not carry a top-level <Label>.
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
-\t<Name>${formName}</Name>
-\t<SourceCode>
-\t\t<Methods xmlns="">
-\t\t\t<Method>
-\t\t\t\t<Name>classDeclaration</Name>
-\t\t\t\t<Source><!\[CDATA[
-    [Form]
-    public class ${formName} extends FormRun
-    {
-    }
-
-]]></Source>
-\t\t\t</Method>
-\t\t</Methods>
-\t\t<DataSources xmlns="" />
-\t\t<DataControls xmlns="" />
-\t\t<Members xmlns="" />
-\t</SourceCode>
-\t<DataSources />
-\t<Design>
-\t\t<Controls xmlns="" />
-\t</Design>
-\t<Parts />
-</AxForm>
-`;
+    return buildAxFormXml(formName, properties);
   }
 
   /**
@@ -1437,41 +1353,11 @@ ${relationsXml}
   }
 
   static generateAxSecurityDutyXml(name: string, properties?: Record<string, any>): string {
-    const label = properties?.label || '@TODO:LabelId';
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${name}</Name>
-\t<Label>${escapeXml(label)}</Label>
-\t<Privileges />
-</AxSecurityDuty>`;
+    return buildAxSecurityDutyXml(name, properties);
   }
 
   static generateAxSecurityRoleXml(name: string, properties?: Record<string, any>): string {
-    const label = properties?.label || '@TODO:LabelId';
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${name}</Name>
-\t<Label>${escapeXml(label)}</Label>
-\t<DirectAccessPermissions />
-\t<Duties />
-\t<Privileges />
-\t<SubRoles />
-</AxSecurityRole>`;
-  }
-
-  /** Normalize a name list that may arrive as an array or a comma/semicolon/newline-separated string. */
-  private static normalizeNameList(value: any): string[] {
-    if (!value) return [];
-    const arr = Array.isArray(value) ? value : String(value).split(/[,;\n]+/);
-    return arr.map((s: any) => String(s).trim()).filter((s: string) => s.length > 0);
-  }
-
-  private static refContainer(container: string, childTag: string, names: string[]): string {
-    if (names.length === 0) return `\t<${container} />`;
-    const children = names
-      .map(n => `\t\t<${childTag}>\n\t\t\t<Name>${n}</Name>\n\t\t</${childTag}>`)
-      .join('\n');
-    return `\t<${container}>\n${children}\n\t</${container}>`;
+    return buildAxSecurityRoleXml(name, properties);
   }
 
   /**
@@ -1479,13 +1365,7 @@ ${relationsXml}
    * without overlaying it. Name convention: "<BaseDuty>.<PrefixOrModel>Extension".
    */
   static generateAxSecurityDutyExtensionXml(name: string, properties?: Record<string, any>): string {
-    const privileges = this.normalizeNameList(properties?.privileges);
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityDutyExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${name}</Name>
-${this.refContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
-\t<PropertyModifications />
-</AxSecurityDutyExtension>`;
+    return buildAxSecurityDutyExtensionXml(name, properties);
   }
 
   /**
@@ -1493,16 +1373,7 @@ ${this.refContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
    * role without overlaying it. Name convention: "<BaseRole>.<PrefixOrModel>Extension".
    */
   static generateAxSecurityRoleExtensionXml(name: string, properties?: Record<string, any>): string {
-    const duties = this.normalizeNameList(properties?.duties);
-    const privileges = this.normalizeNameList(properties?.privileges);
-    return `<?xml version="1.0" encoding="utf-8"?>
-<AxSecurityRoleExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-\t<Name>${name}</Name>
-\t<DirectAccessPermissions />
-${this.refContainer('Duties', 'AxSecurityDutyReference', duties)}
-${this.refContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
-\t<PropertyModifications />
-</AxSecurityRoleExtension>`;
+    return buildAxSecurityRoleExtensionXml(name, properties);
   }
 }
 

--- a/src/tools/securityDutyRoleXml.ts
+++ b/src/tools/securityDutyRoleXml.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared builders for AxSecurityDuty / AxSecurityRole and their extensions.
+ *
+ * createD365File.ts and generateD365Xml.ts each expose a mirrored
+ * XmlTemplateGenerator class; both delegate here so the two cannot drift
+ * (mirrors the securityPrivilegeXml.ts / queryViewXml.ts pattern).
+ *
+ * This module exists because they DID drift, badly. The create path was fixed
+ * after the "security chain silent empty write" incident; the generate mirror
+ * kept hard-coding `<Privileges />` and `<Duties />` regardless of what the
+ * caller passed. Since the documented hybrid flow is
+ * generate → create(xmlContent), that mirror wrote empty, non-functional
+ * security objects to disk — and they build perfectly clean, so nothing fails
+ * until someone notices the role grants nothing.
+ */
+
+import { escapeXml } from '../utils/xmlEscape.js';
+
+/**
+ * Normalize a name list that may arrive as an array or a comma/semicolon/
+ * newline-separated string (models pass either). Returns trimmed, non-empty names.
+ */
+export function normalizeNameList(value: any): string[] {
+  if (!value) return [];
+  const arr = Array.isArray(value) ? value : String(value).split(/[,;\n]+/);
+  return arr.map((s: any) => String(s).trim()).filter((s: string) => s.length > 0);
+}
+
+/**
+ * Render a security reference container: a self-closing tag when empty, or the
+ * wrapped child references (e.g. <AxSecurityPrivilegeReference><Name>…</Name></…>).
+ *
+ * The child element name matters: a duty/role that lists its privileges under
+ * `AxSecurityRolePermissionSet` / `AxSecurityRoleDutyPermission` deserializes into
+ * an EMPTY reference list, so the whole duty→privilege→role chain is dead —
+ * xppbp then reports BPErrorDutyHasNoPrivileges / BPErrorPrivilegeNotCoveredByDuty /
+ * BPErrorDutyNotCoveredByRole for references that are physically in the file.
+ * The correct names are AxSecurityPrivilegeReference / AxSecurityDutyReference.
+ * Evidence: docs/eval-sweep-findings-2026-07-21.md #31 (L4-master-security-slice run).
+ */
+export function securityRefContainer(container: string, childTag: string, names: string[]): string {
+  if (names.length === 0) return `\t<${container} />`;
+  const children = names
+    .map(n => `\t\t<${childTag}>\n\t\t\t<Name>${n}</Name>\n\t\t</${childTag}>`)
+    .join('\n');
+  return `\t<${container}>\n${children}\n\t</${container}>`;
+}
+
+/**
+ * AxSecurityDuty.
+ * properties.privileges – privilege names to reference (array or comma-separated).
+ */
+export function buildAxSecurityDutyXml(name: string, properties?: Record<string, any>): string {
+  const label = properties?.label || '@TODO:LabelId';
+  const privileges = normalizeNameList(properties?.privileges);
+  return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${escapeXml(label)}</Label>
+${securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
+</AxSecurityDuty>`;
+}
+
+/**
+ * AxSecurityRole.
+ * properties.duties     – duty names to reference (array or comma-separated).
+ * properties.privileges – privilege names to reference directly on the role.
+ */
+export function buildAxSecurityRoleXml(name: string, properties?: Record<string, any>): string {
+  const label = properties?.label || '@TODO:LabelId';
+  const duties = normalizeNameList(properties?.duties);
+  const privileges = normalizeNameList(properties?.privileges);
+  return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<Label>${escapeXml(label)}</Label>
+\t<DirectAccessPermissions />
+${securityRefContainer('Duties', 'AxSecurityDutyReference', duties)}
+${securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
+\t<SubRoles />
+</AxSecurityRole>`;
+}
+
+/**
+ * AxSecurityDutyExtension — adds privileges to an EXISTING (often Microsoft-owned)
+ * duty without overlaying it. Real Microsoft object type, e.g.
+ * K:\...\ApplicationCommon\AxSecurityDutyExtension\BatchJobMaintain.ApplicationCommon.xml.
+ * Name convention: "<BaseDuty>.<PrefixOrModel>Extension" (same dot-notation as
+ * menu-extension / table-extension — see DOT_NOTATION_EXTENSION_TYPES).
+ * properties.privileges – privilege names to add to the base duty.
+ */
+export function buildAxSecurityDutyExtensionXml(name: string, properties?: Record<string, any>): string {
+  const privileges = normalizeNameList(properties?.privileges);
+  return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDutyExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+${securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
+\t<PropertyModifications />
+</AxSecurityDutyExtension>`;
+}
+
+/**
+ * AxSecurityRoleExtension — adds duties and/or privileges to an EXISTING (often
+ * Microsoft-owned) role without overlaying it. Real Microsoft object type, e.g.
+ * K:\...\ApplicationCommon\AxSecurityRoleExtension\SystemUser.ApplicationCommon.xml.
+ * Name convention: "<BaseRole>.<PrefixOrModel>Extension".
+ * properties.duties     – duty names to add to the base role.
+ * properties.privileges – privilege names to add directly to the base role.
+ */
+export function buildAxSecurityRoleExtensionXml(name: string, properties?: Record<string, any>): string {
+  const duties = normalizeNameList(properties?.duties);
+  const privileges = normalizeNameList(properties?.privileges);
+  return `<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRoleExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${name}</Name>
+\t<DirectAccessPermissions />
+${securityRefContainer('Duties', 'AxSecurityDutyReference', duties)}
+${securityRefContainer('Privileges', 'AxSecurityPrivilegeReference', privileges)}
+\t<PropertyModifications />
+</AxSecurityRoleExtension>`;
+}

--- a/src/tools/tableXml.ts
+++ b/src/tools/tableXml.ts
@@ -1,0 +1,217 @@
+/**
+ * Shared builder for AxTable XML.
+ *
+ * createD365File.ts and generateD365Xml.ts each expose a mirrored
+ * XmlTemplateGenerator class; both delegate here so the two cannot drift
+ * (mirrors the securityPrivilegeXml.ts / queryViewXml.ts pattern).
+ *
+ * They had already drifted: the create copy grew canonical property ordering,
+ * a real <Fields> block and X++ source handling, while the generate copy kept
+ * emitting a bare `<Fields />` and a hand-rolled property block in a different
+ * order. Since the documented hybrid flow is generate → create(xmlContent),
+ * every table produced that way lost all of its fields — silently, because a
+ * table with no fields still builds clean.
+ */
+
+import { escapeXml } from '../utils/xmlEscape.js';
+import { renderAxTableProperties } from '../utils/axTablePropertyOrder.js';
+import { isYes } from './dataEntityXml.js';
+
+/** Field spec as accepted by the tool surface; every key is optional but `name`. */
+export interface AxTableFieldSpec {
+  name: string;
+  edt?: string;
+  type?: string;
+  fieldType?: string;
+  enumType?: string;
+  mandatory?: boolean;
+  label?: string;
+}
+
+/** X++ source already split by the caller (see XmlTemplateGenerator.parseSourceForBridge). */
+export interface ParsedTableSource {
+  declaration?: string;
+  methods?: Array<{ name: string; source?: string }>;
+}
+
+/**
+ * Map a D365FO base type name to the XML i:type attribute used in <AxTableField>.
+ * If the explicit fieldType is not a known primitive, fall back to name-based heuristics
+ * using edtName (same heuristics as SmartXmlBuilder.getAxTableFieldType).
+ */
+export function fieldTypeToAxType(fieldType: string, edtName?: string): string {
+  const typeMap: Record<string, string> = {
+    String:      'AxTableFieldString',
+    Integer:     'AxTableFieldInt',
+    Int64:       'AxTableFieldInt64',
+    Real:        'AxTableFieldReal',
+    Date:        'AxTableFieldDate',
+    DateTime:    'AxTableFieldUtcDateTime',
+    UtcDateTime: 'AxTableFieldUtcDateTime',
+    Enum:        'AxTableFieldEnum',
+    GUID:        'AxTableFieldGuid',
+    Guid:        'AxTableFieldGuid',
+    Container:   'AxTableFieldContainer',
+  };
+
+  const explicit = typeMap[fieldType];
+  if (explicit) return explicit;
+
+  // Fall back to EDT name heuristics (mirrors SmartXmlBuilder.getAxTableFieldType)
+  const hint = edtName || fieldType;
+  if (hint) {
+    const e = hint.toLowerCase();
+    if (e === 'recid' || e.endsWith('recid') || e.includes('refrecid')) return 'AxTableFieldInt64';
+    if (e.includes('utcdatetime') || (e.includes('datetime') && !e.includes('transdate'))) return 'AxTableFieldUtcDateTime';
+    if (e.includes('date') && !e.includes('time') && !e.includes('update')) return 'AxTableFieldDate';
+    if (e.includes('amount') || e.includes('mst') || e.includes('price') || e.includes('qty')
+        || e.includes('percent') || e === 'real') return 'AxTableFieldReal';
+    if (e === 'noyesid' || e.endsWith('noyesid') || e === 'noyes') return 'AxTableFieldEnum';
+    if ((e.endsWith('int') || e.includes('count') || e.includes('level'))
+        && !e.includes('account') && !e.includes('name')) return 'AxTableFieldInt';
+  }
+
+  return 'AxTableFieldString';
+}
+
+/** Render the <Fields> block from the caller's field specs. */
+export function buildAxTableFieldsXml(fieldSpecs: AxTableFieldSpec[]): string {
+  if (fieldSpecs.length === 0) return '\t<Fields />\n';
+
+  let xml = '\t<Fields>\n';
+  for (const f of fieldSpecs) {
+    // Determine i:type: explicit AxTableField* wins; otherwise derive from the
+    // primitive type / enumType / EDT name heuristics. NEVER default to
+    // AxTableFieldString blindly when an EDT or enumType is present.
+    const iType = f.fieldType
+      ?? fieldTypeToAxType(f.type || (f.enumType ? 'Enum' : 'String'), f.edt);
+    xml += `\t\t<AxTableField xmlns=""\n\t\t\ti:type="${iType}">\n`;
+    xml += `\t\t\t<Name>${f.name}</Name>\n`;
+    if (f.edt)       xml += `\t\t\t<ExtendedDataType>${f.edt}</ExtendedDataType>\n`;
+    if (f.label)     xml += `\t\t\t<Label>${escapeXml(f.label)}</Label>\n`;
+    if (f.mandatory) xml += `\t\t\t<Mandatory>Yes</Mandatory>\n`;
+    if (f.enumType)  xml += `\t\t\t<EnumType>${f.enumType}</EnumType>\n`;
+    xml += `\t\t</AxTableField>\n`;
+  }
+  return xml + '\t</Fields>\n';
+}
+
+/**
+ * Build a complete AxTable document.
+ *
+ * `parsedSource` is supplied pre-split by the caller rather than parsed here:
+ * the splitter lives on XmlTemplateGenerator and pulling it down would drag the
+ * whole create tool in behind it. Callers with no X++ simply omit it.
+ */
+export function buildAxTableXml(
+  tableName: string,
+  properties?: Record<string, any>,
+  parsedSource?: ParsedTableSource,
+): string {
+  const primaryIndex = properties?.primaryIndex || '';
+
+  // Property block, emitted in CANONICAL ORDER. AxTable XML is order-sensitive
+  // and a misordered property is dropped without a word — see
+  // src/utils/axTablePropertyOrder.ts and findings #13. Empty values are omitted
+  // rather than written as <TitleField1></TitleField1>, matching the shipped
+  // tables and the VM-captured golden eval/goldens/L1-table-basic.
+  const propertiesXml = renderAxTableProperties({
+    ConfigurationKey: properties?.configurationKey,
+    DeveloperDocumentation: properties?.developerDocumentation,
+    FormRef: properties?.formRef,
+    Label: properties?.label || tableName,
+    TableGroup: properties?.tableGroup || 'Main',
+    TitleField1: properties?.titleField1,
+    TitleField2: properties?.titleField2,
+    // Dual-write's table-side prerequisite; without it the entity syncs once
+    // and then stops seeing changes.
+    AllowRowVersionChangeTracking:
+      isYes(properties?.allowRowVersionChangeTracking) ? 'Yes' : undefined,
+    CacheLookup: properties?.cacheLookup,
+    // Audit system fields — NoYes, ranked but previously unreachable.
+    CreatedBy: isYes(properties?.createdBy) ? 'Yes' : undefined,
+    CreatedDateTime: isYes(properties?.createdDateTime) ? 'Yes' : undefined,
+    CreatedTransactionId: isYes(properties?.createdTransactionId) ? 'Yes' : undefined,
+    ModifiedBy: isYes(properties?.modifiedBy) ? 'Yes' : undefined,
+    ModifiedDateTime: isYes(properties?.modifiedDateTime) ? 'Yes' : undefined,
+    ModifiedTransactionId: isYes(properties?.modifiedTransactionId) ? 'Yes' : undefined,
+    ClusteredIndex: properties?.clusteredIndex,
+    PrimaryIndex: primaryIndex,
+    // ReplacementKey mirrors PrimaryIndex unless the caller says otherwise.
+    ReplacementKey: properties?.replacementKey || primaryIndex,
+    SaveDataPerCompany: properties?.saveDataPerCompany,
+    SupportInheritance: properties?.supportInheritance,
+    // TableType: TempDB / InMemory; omitted for Regular, which is the default.
+    TableType: properties?.tableType,
+  });
+
+  // Build <Fields> block from properties.fields array.
+  // Copilot may pass field definitions via properties.fields or via sourceCode JSON —
+  // both paths merge into properties before calling here.
+  // Field-spec keys are unified with the table-extension path: accept an explicit
+  // AxTableField* i:type (fieldType), a primitive base type (type), or infer
+  // AxTableFieldEnum from enumType — and always emit <EnumType> for enum fields.
+  const fieldsXml = buildAxTableFieldsXml(
+    Array.isArray(properties?.fields) ? properties.fields : [],
+  );
+
+  // X++ passed in `sourceCode` used to be discarded outright: the caller got a ✅
+  // and an empty <Methods /> on disk, discoverable only by reading the file back
+  // (findings #19). Table source is class-shaped (`public class X extends common`
+  // + methods), so the class splitter handles it; when the caller passed only
+  // method bodies the splitter still returns them as methods.
+  const declarationXpp =
+    parsedSource?.declaration?.trim()
+    && /\bclass\s+\w+/.test(parsedSource.declaration)
+      ? parsedSource.declaration.trim()
+      : `public class ${tableName} extends common\n{\n}`;
+  const methodsFromSource = parsedSource?.methods ?? [];
+  const methodsXml = methodsFromSource.length === 0
+    ? '\t\t<Methods />'
+    : `\t\t<Methods>\n${methodsFromSource
+        .map(m =>
+          `\t\t\t<Method>\n\t\t\t\t<Name>${m.name}</Name>\n` +
+          `\t\t\t\t<Source><![CDATA[\n${m.source ?? ''}\n\n]]></Source>\n\t\t\t</Method>`)
+        .join('\n')}\n\t\t</Methods>`;
+
+  return `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>${tableName}</Name>
+\t<SourceCode>
+\t\t<Declaration><![CDATA[
+${declarationXpp}
+]]></Declaration>
+${methodsXml}
+\t</SourceCode>
+${propertiesXml}\t<DeleteActions />
+\t<FieldGroups>
+\t\t<AxTableFieldGroup>
+\t\t\t<Name>AutoReport</Name>
+\t\t\t<Fields />
+\t\t</AxTableFieldGroup>
+\t\t<AxTableFieldGroup>
+\t\t\t<Name>AutoLookup</Name>
+\t\t\t<Fields />
+\t\t</AxTableFieldGroup>
+\t\t<AxTableFieldGroup>
+\t\t\t<Name>AutoIdentification</Name>
+\t\t\t<AutoPopulate>Yes</AutoPopulate>
+\t\t\t<Fields />
+\t\t</AxTableFieldGroup>
+\t\t<AxTableFieldGroup>
+\t\t\t<Name>AutoSummary</Name>
+\t\t\t<Fields />
+\t\t</AxTableFieldGroup>
+\t\t<AxTableFieldGroup>
+\t\t\t<Name>AutoBrowse</Name>
+\t\t\t<Fields />
+\t\t</AxTableFieldGroup>
+\t</FieldGroups>
+${fieldsXml}\t<FullTextIndexes />
+\t<Indexes />
+\t<Mappings />
+\t<Relations />
+\t<StateMachines />
+</AxTable>
+`;
+}

--- a/tests/tools/generateCreateParity.test.ts
+++ b/tests/tools/generateCreateParity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression (audit finding 2, CRITICAL): the generate mirror threw content away.
+ *
+ * createD365File.ts and generateD365Xml.ts each expose an XmlTemplateGenerator
+ * class that is supposed to be a mirror. Three of them had drifted:
+ *
+ *   • security duty/role — hard-coded `<Privileges />` / `<Duties />` regardless
+ *     of what the caller passed. The create path was fixed after the "security
+ *     chain silent empty write" incident; the mirror was not.
+ *   • table — emitted a bare `<Fields />`, so every field was dropped.
+ *   • form — its parameter was literally named `_properties`; it ignored the
+ *     design pattern, data source, caption and controls entirely.
+ *
+ * The documented hybrid flow is generate → create(xmlContent), so that mirror
+ * wrote empty, non-functional objects to disk. All of them build perfectly
+ * clean, which is why this went unnoticed.
+ *
+ * The two halves now delegate to shared builders. These tests assert both that
+ * they agree AND that the agreed-upon output actually carries the content —
+ * two empty shells would agree too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { XmlTemplateGenerator as CreateGen } from '../../src/tools/createD365File';
+import { XmlTemplateGenerator as GenerateGen } from '../../src/tools/generateD365Xml';
+
+describe('generate/create builder parity', () => {
+  it('AxSecurityDuty — same XML, and the privileges are actually in it', () => {
+    const props = { label: '@Contoso:DutyLabel', privileges: ['ContosoXyzMaintain', 'ContosoXyzView'] };
+
+    const created = CreateGen.generateAxSecurityDutyXml('ContosoXyzDuty', props);
+    const generated = GenerateGen.generateAxSecurityDutyXml('ContosoXyzDuty', props);
+
+    expect(generated).toBe(created);
+    expect(generated).toContain('<AxSecurityPrivilegeReference>');
+    expect(generated).toContain('<Name>ContosoXyzMaintain</Name>');
+    expect(generated).toContain('<Name>ContosoXyzView</Name>');
+    expect(generated).not.toContain('<Privileges />');
+  });
+
+  it('AxSecurityRole — same XML, and the duties and privileges are actually in it', () => {
+    const props = {
+      label: '@Contoso:RoleLabel',
+      duties: 'ContosoXyzDuty,ContosoXyzOtherDuty',
+      privileges: ['ContosoXyzMaintain'],
+    };
+
+    const created = CreateGen.generateAxSecurityRoleXml('ContosoXyzRole', props);
+    const generated = GenerateGen.generateAxSecurityRoleXml('ContosoXyzRole', props);
+
+    expect(generated).toBe(created);
+    expect(generated).toContain('<AxSecurityDutyReference>');
+    expect(generated).toContain('<Name>ContosoXyzOtherDuty</Name>');
+    expect(generated).not.toContain('<Duties />');
+    expect(generated).not.toContain('<Privileges />');
+  });
+
+  it('AxSecurityDutyExtension / AxSecurityRoleExtension — same XML', () => {
+    const dutyExt = { privileges: ['ContosoXyzMaintain'] };
+    expect(GenerateGen.generateAxSecurityDutyExtensionXml('BatchJobMaintain.ContosoExtension', dutyExt))
+      .toBe(CreateGen.generateAxSecurityDutyExtensionXml('BatchJobMaintain.ContosoExtension', dutyExt));
+
+    const roleExt = { duties: ['ContosoXyzDuty'], privileges: ['ContosoXyzMaintain'] };
+    expect(GenerateGen.generateAxSecurityRoleExtensionXml('SystemUser.ContosoExtension', roleExt))
+      .toBe(CreateGen.generateAxSecurityRoleExtensionXml('SystemUser.ContosoExtension', roleExt));
+  });
+
+  it('AxTable — same XML, and the fields survive', () => {
+    const props = {
+      label: '@Contoso:TableLabel',
+      tableGroup: 'Main',
+      fields: [
+        { name: 'AccountNum', edt: 'CustAccount' },
+        { name: 'Amount', type: 'Real', label: 'Amount' },
+        { name: 'Status', enumType: 'NoYes' },
+      ],
+    };
+
+    const created = CreateGen.generateAxTableXml('ContosoXyzTable', props);
+    const generated = GenerateGen.generateAxTableXml('ContosoXyzTable', props);
+
+    expect(generated).toBe(created);
+    expect(generated).toContain('<Name>AccountNum</Name>');
+    expect(generated).toContain('<ExtendedDataType>CustAccount</ExtendedDataType>');
+    expect(generated).toContain('i:type="AxTableFieldReal"');
+    expect(generated).toContain('<EnumType>NoYes</EnumType>');
+    // The whole point: the fields block is no longer self-closing.
+    expect(generated).not.toContain('<Fields />\n\t<FullTextIndexes />');
+  });
+
+  it('AxTable — canonical property order reaches the generate side too', () => {
+    // The generate copy hand-rolled its own property block in a different order,
+    // and AxTable XML drops a misordered property without a word.
+    const xml = GenerateGen.generateAxTableXml('ContosoXyzTable', {
+      label: 'L', titleField1: 'AccountNum', cacheLookup: 'Found', tableGroup: 'Main',
+    });
+    expect(xml.indexOf('<Label>')).toBeLessThan(xml.indexOf('<TableGroup>'));
+    expect(xml).toContain('<CacheLookup>Found</CacheLookup>');
+  });
+
+  it('AxForm — same XML, and the pattern/data source are honoured', () => {
+    const props = {
+      pattern: 'SimpleList',
+      dataSource: 'ContosoXyzTable',
+      caption: 'Contoso setup',
+      gridFields: ['AccountNum', 'Amount'],
+    };
+
+    const created = CreateGen.generateAxFormXml('ContosoXyzForm', props);
+    const generated = GenerateGen.generateAxFormXml('ContosoXyzForm', props);
+
+    expect(generated).toBe(created);
+    // The old mirror returned a fixed shell: empty DataSources, empty Controls.
+    expect(generated).toContain('ContosoXyzTable');
+    expect(generated).not.toContain('<DataSources />');
+    expect(generated).not.toContain('<Controls xmlns="" />');
+  });
+});


### PR DESCRIPTION
**Phase 0.4** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4). Audit finding 2, severity **critical**.

> ⚠️ **Stacked on #850** (Phase 0.3) — both touch the same two files. Base is `fix/xml-escaping-builders`; merge #850 first and this retargets to `main` cleanly.

## The problem

`createD365File.ts` and `generateD365Xml.ts` each expose an `XmlTemplateGenerator` that is supposed to be a mirror. Three had drifted into **throwing the caller's content away**:

| Builder | Generate-side behaviour |
|---|---|
| security duty / role | Hard-coded `<Privileges />` and `<Duties />` regardless of what was passed. The create path was fixed after the *"security chain silent empty write"* incident; the mirror was not. |
| table | Emitted a bare `<Fields />`, dropping every field, and hand-rolled its property block in a **different order** — and AxTable drops a misordered property without a word. |
| form | Its parameter was literally named `_properties`. It ignored the design pattern, data source, caption and controls outright and returned a fixed empty shell. |

The documented hybrid flow is **generate → create(`xmlContent`)**, so that mirror wrote empty, non-functional objects into PackagesLocalDirectory. Every one of them **builds perfectly clean** — which is exactly why this went unnoticed, and is the same failure signature as the security-chain incident.

## The fix

Extracts the create-side (correct) implementations into shared builders — `tableXml.ts`, `formXml.ts`, `securityDutyRoleXml.ts` — following the convention already established by `securityPrivilegeXml.ts` / `queryViewXml.ts` / `dataEntityXml.ts`, and points both halves at them. The duplicated helpers (`fieldTypeToAxType`, `normalizeNameList`, `securityRefContainer`/`refContainer`) collapse into one copy each.

Deliberately extracted to *new shared modules* rather than having one mirror import the other: the two files already form a direct import cycle that Phase 3.1 is meant to break, and this keeps from deepening it.

`buildAxTableXml` takes `parsedSource` pre-split rather than parsing X++ itself — the splitter lives on `XmlTemplateGenerator` and pulling it down would drag the whole create tool in behind it.

## Verification

New `tests/tools/generateCreateParity.test.ts` asserts both that the two halves **agree** and that the agreed-upon output **actually carries the content** — two empty shells would agree too. **5 of its 6 cases fail against the pre-fix mirrors.**

Full suite: 2866 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)