### PR TITLE
Fix the batch bridge path: boxed JsonElement bools, swallowed shape errors, empty structures (audit finding 4, CRITICAL)

### DIFF
--- a/bridge/D365MetadataBridge/Models/Models.cs
+++ b/bridge/D365MetadataBridge/Models/Models.cs
@@ -781,23 +781,46 @@ namespace D365MetadataBridge.Models
         /// <summary>
         /// Deserializes a typed parameter from the Params dictionary.
         /// Values arrive as JsonElement from System.Text.Json — convert to the target type.
+        ///
+        /// The old `catch { return null; }` made a WRONGLY SHAPED parameter
+        /// indistinguishable from an absent one, and the dispatcher's
+        /// `?? throw new ArgumentException("Missing: fields")` then told the caller the key
+        /// was missing while it sat right there in the request. That is the param-shape
+        /// contract bug this project keeps re-living — e.g. constraints sent as
+        /// [{fieldName, relatedFieldName}] when this side reads [{field, relatedField}], or
+        /// index fields sent as [{fieldName}] when this side reads a flat string[]. A
+        /// failure now names the parameter and shows what actually arrived.
+        ///
+        /// JsonOptions.Default is used so the batch path resolves property names exactly the
+        /// way the single-op BridgeRequest.GetParam&lt;T&gt; does; deserializing without it was
+        /// a second, quieter way for the two paths to disagree.
         /// </summary>
         public T? GetTypedParam<T>(string key) where T : class
         {
             if (Params == null || !Params.TryGetValue(key, out var raw) || raw == null)
                 return null;
+            // Already the correct type (in-process caller, not a JSON round trip).
+            if (raw is T typed) return typed;
+
+            var json = raw is System.Text.Json.JsonElement je
+                ? je.GetRawText()
+                : System.Text.Json.JsonSerializer.Serialize(raw, Protocol.JsonOptions.Default);
             try
             {
-                if (raw is System.Text.Json.JsonElement je)
-                    return System.Text.Json.JsonSerializer.Deserialize<T>(je.GetRawText());
-                // Already correct type
-                if (raw is T typed) return typed;
-                // Fallback: serialize then deserialize
-                var json = System.Text.Json.JsonSerializer.Serialize(raw);
-                return System.Text.Json.JsonSerializer.Deserialize<T>(json);
+                // A JSON `null` deserializes to null here — same as an absent key, which is
+                // what the caller's "Missing: <key>" message correctly describes.
+                return System.Text.Json.JsonSerializer.Deserialize<T>(json, Protocol.JsonOptions.Default);
             }
-            catch { return null; }
+            catch (System.Text.Json.JsonException ex)
+            {
+                throw new System.ArgumentException(
+                    $"Parameter '{key}' has the wrong shape: {ex.Message} Received: {Preview(json)}");
+            }
         }
+
+        /// <summary>Caps the echoed payload — a batch op can carry a large array.</summary>
+        private static string Preview(string json) =>
+            json.Length <= 300 ? json : json.Substring(0, 300) + "…(truncated)";
     }
 
     public class BatchOperationResult

--- a/bridge/D365MetadataBridge/Protocol/BridgeProtocol.cs
+++ b/bridge/D365MetadataBridge/Protocol/BridgeProtocol.cs
@@ -48,18 +48,19 @@ namespace D365MetadataBridge.Protocol
         }
 
         /// <summary>
-        /// Helper to extract a boolean parameter from Params
+        /// Helper to extract a boolean parameter from Params.
+        /// Reads through ParamCoercion so this path and HandleBatchModify cannot disagree
+        /// about what a given value means.
         /// </summary>
         public bool? GetBoolParam(string name)
         {
             if (Params == null || Params.Value.ValueKind != JsonValueKind.Object)
                 return null;
 
-            if (Params.Value.TryGetProperty(name, out var prop) &&
-                (prop.ValueKind == JsonValueKind.True || prop.ValueKind == JsonValueKind.False))
-                return prop.GetBoolean();
+            if (!Params.Value.TryGetProperty(name, out var prop))
+                return null;
 
-            return null;
+            return ParamCoercion.ToBool(prop, name);
         }
 
         /// <summary>
@@ -113,6 +114,80 @@ namespace D365MetadataBridge.Protocol
                 }
             }
             return dict;
+        }
+    }
+
+    /// <summary>
+    /// Parameter coercion shared by BOTH dispatch paths.
+    ///
+    /// The single-op path reads its params straight off the request's JsonElement; the
+    /// batch path gets them as Dictionary&lt;string, object&gt;, whose values System.Text.Json
+    /// boxes as JsonElement. JsonElement does not implement IConvertible, so the batch
+    /// path's Convert.ToBoolean(value) threw InvalidCastException ("Object must implement
+    /// IConvertible") for EVERY operation carrying a bool — mandatory, allowDuplicates,
+    /// alternateKey, extendBaseFieldGroup — and HandleBatchModify's per-op catch reported
+    /// that cast as the operation's reason for failing. Booleans are read by JSON kind, in
+    /// one place, so the two paths cannot drift apart again.
+    /// </summary>
+    public static class ParamCoercion
+    {
+        /// <summary>
+        /// Boolean from a raw (boxed) batch parameter value.
+        /// </summary>
+        public static bool? ToBool(object? value, string paramName)
+        {
+            switch (value)
+            {
+                case null: return null;
+                case bool b: return b;
+                case JsonElement el: return ToBool(el, paramName);
+                case string s: return ParseBoolText(s, paramName, s);
+                default:
+                    throw new ArgumentException(
+                        $"Parameter '{paramName}' must be a boolean — got {value.GetType().Name} '{value}'.");
+            }
+        }
+
+        /// <summary>
+        /// Boolean from a JSON value. Absent/null yields null so the caller's own default
+        /// applies; a value that is present but not readable as a boolean throws rather
+        /// than degrading to false — a silent false writes a field that is not mandatory,
+        /// or an index that allows duplicates, and reports success either way.
+        ///
+        /// The string spellings are accepted because the AxTable XML value is No/Yes and
+        /// callers reach for that form (#27); it is a typo, not a shape, that fails here.
+        /// </summary>
+        public static bool? ToBool(JsonElement el, string paramName)
+        {
+            switch (el.ValueKind)
+            {
+                case JsonValueKind.True: return true;
+                case JsonValueKind.False: return false;
+                case JsonValueKind.Null:
+                case JsonValueKind.Undefined: return null;
+                case JsonValueKind.String: return ParseBoolText(el.GetString(), paramName, el.GetRawText());
+                case JsonValueKind.Number when el.TryGetInt32(out var n) && (n == 0 || n == 1):
+                    return n == 1;
+                default:
+                    throw new ArgumentException(
+                        $"Parameter '{paramName}' must be a boolean — got {el.ValueKind} {el.GetRawText()}. " +
+                        "Accepted: true/false, \"true\"/\"false\", \"Yes\"/\"No\", 1/0.");
+            }
+        }
+
+        private static bool? ParseBoolText(string? text, string paramName, string received)
+        {
+            switch (text?.Trim().ToLowerInvariant())
+            {
+                case null:
+                case "": return null;
+                case "true": case "yes": case "1": return true;
+                case "false": case "no": case "0": return false;
+                default:
+                    throw new ArgumentException(
+                        $"Parameter '{paramName}' must be a boolean — got {received}. " +
+                        "Accepted: true/false, \"true\"/\"false\", \"Yes\"/\"No\", 1/0.");
+            }
         }
     }
 

--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -951,7 +951,12 @@ namespace D365MetadataBridge.Protocol
 
                         // Extract string helper
                         string? S(string key) => p.TryGetValue(key, out var v) ? v?.ToString() : null;
-                        bool? B(string key) => p.TryGetValue(key, out var v) && v != null ? Convert.ToBoolean(v) : null;
+                        // System.Text.Json boxes every params value as JsonElement, which does
+                        // not implement IConvertible — Convert.ToBoolean(v) therefore threw
+                        // InvalidCastException on every batch op carrying a bool, and the catch
+                        // below reported that cast as the operation's failure. Same coercion as
+                        // the single-op arms' request.GetBoolParam.
+                        bool? B(string key) => p.TryGetValue(key, out var v) ? ParamCoercion.ToBool(v, key) : null;
 
                         switch (op.Operation.ToLowerInvariant())
                         {

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -271,13 +271,10 @@ namespace D365MetadataBridge.Services
                     axIdx.AllowDuplicates = ix.AllowDuplicates ? Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.Yes : Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.No;
                     if (ix.AlternateKey)
                         axIdx.AlternateKey = Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.Yes;
-                    if (ix.Fields != null)
+                    foreach (var ixf in RequireIndexFields(name, ix.Name, ix.Fields))
                     {
-                        foreach (var ixf in ix.Fields)
-                        {
-                            var axIxField = new AxTableIndexField { DataField = ixf };
-                            axIdx.AddField(axIxField);
-                        }
+                        var axIxField = new AxTableIndexField { DataField = ixf };
+                        axIdx.AddField(axIxField);
                     }
                     axTable.AddIndex(axIdx);
                 }
@@ -289,19 +286,8 @@ namespace D365MetadataBridge.Services
                 foreach (var rel in relations)
                 {
                     var axRel = new AxTableRelation { Name = rel.Name, RelatedTable = rel.RelatedTable ?? "" };
-                    if (rel.Constraints != null)
-                    {
-                        foreach (var c in rel.Constraints)
-                        {
-                            var constraint = new AxTableRelationConstraintField
-                            {
-                                Name = c.Field ?? "",
-                                Field = c.Field ?? "",
-                                RelatedField = c.RelatedField ?? ""
-                            };
-                            axRel.AddConstraint(constraint);
-                        }
-                    }
+                    foreach (var c in RequireRelationConstraints(name, rel.Name, rel.Constraints))
+                        axRel.AddConstraint(NewRelationConstraint(rel.Name, c));
                     axTable.AddRelation(axRel);
                 }
             }
@@ -444,11 +430,8 @@ namespace D365MetadataBridge.Services
                         axIdx.AllowDuplicates = Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.No;
                         if (uniqueIndexName == null) uniqueIndexName = ix.Name;
                     }
-                    if (ix.Fields != null)
-                    {
-                        foreach (var ixf in ix.Fields)
-                            axIdx.AddField(new AxTableIndexField { DataField = ixf });
-                    }
+                    foreach (var ixf in RequireIndexFields(name, ix.Name, ix.Fields))
+                        axIdx.AddField(new AxTableIndexField { DataField = ixf });
                     axTable.AddIndex(axIdx);
                 }
             }
@@ -535,18 +518,8 @@ namespace D365MetadataBridge.Services
                 foreach (var rel in relations)
                 {
                     var axRel = new AxTableRelation { Name = rel.Name, RelatedTable = rel.RelatedTable ?? "" };
-                    if (rel.Constraints != null)
-                    {
-                        foreach (var c in rel.Constraints)
-                        {
-                            axRel.AddConstraint(new AxTableRelationConstraintField
-                            {
-                                Name = c.Field ?? "",
-                                Field = c.Field ?? "",
-                                RelatedField = c.RelatedField ?? "",
-                            });
-                        }
-                    }
+                    foreach (var c in RequireRelationConstraints(name, rel.Name, rel.Constraints))
+                        axRel.AddConstraint(NewRelationConstraint(rel.Name, c));
                     axTable.AddRelation(axRel);
                 }
             }
@@ -949,11 +922,8 @@ namespace D365MetadataBridge.Services
                         : Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.No;
                     if (ix.AlternateKey)
                         axIdx.AlternateKey = Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.Yes;
-                    if (ix.Fields != null)
-                    {
-                        foreach (var ixf in ix.Fields)
-                            axIdx.AddField(new AxTableIndexField { DataField = ixf });
-                    }
+                    foreach (var ixf in RequireIndexFields(name, ix.Name, ix.Fields))
+                        axIdx.AddField(new AxTableIndexField { DataField = ixf });
                     axExt.Indexes.Add(axIdx);
                 }
             }
@@ -964,18 +934,8 @@ namespace D365MetadataBridge.Services
                 foreach (var rel in relations)
                 {
                     var axRel = new AxTableRelation { Name = rel.Name, RelatedTable = rel.RelatedTable ?? "" };
-                    if (rel.Constraints != null)
-                    {
-                        foreach (var c in rel.Constraints)
-                        {
-                            axRel.AddConstraint(new AxTableRelationConstraintField
-                            {
-                                Name = c.Field ?? "",
-                                Field = c.Field ?? "",
-                                RelatedField = c.RelatedField ?? ""
-                            });
-                        }
-                    }
+                    foreach (var c in RequireRelationConstraints(name, rel.Name, rel.Constraints))
+                        axRel.AddConstraint(NewRelationConstraint(rel.Name, c));
                     axExt.Relations.Add(axRel);
                 }
             }
@@ -1997,18 +1957,44 @@ namespace D365MetadataBridge.Services
         // TABLE INDEX OPERATIONS
         // ========================
 
+        /// <summary>
+        /// The field list of an index, refused when it holds nothing usable.
+        ///
+        /// A null/empty `fields` serialized as &lt;Fields /&gt; and the call returned
+        /// success: the index compiles, raises no BP warning, and indexes nothing — the
+        /// silent-empty-write failure mode, where the object is only discovered to be
+        /// inert long after the caller was told it was written. The usual cause is a
+        /// param-shape mismatch (fields sent as [{fieldName}] instead of a flat string[]),
+        /// so failing here is also what makes that visible.
+        /// </summary>
+        private static List<string> RequireIndexFields(string tableName, string indexName, List<string>? fields)
+        {
+            if (fields == null || fields.Count == 0)
+                throw new ArgumentException(
+                    $"Index '{indexName}' on '{tableName}' has no fields — pass the field names as a string array in 'fields'. " +
+                    "An index with an empty <Fields /> collection compiles clean and indexes nothing.");
+
+            for (var i = 0; i < fields.Count; i++)
+            {
+                if (string.IsNullOrWhiteSpace(fields[i]))
+                    throw new ArgumentException(
+                        $"Index '{indexName}' on '{tableName}': fields[{i}] is empty. " +
+                        "Every entry must name a field on the table.");
+            }
+            return fields;
+        }
+
         /// <summary>Adds an index to a table or table-extension.</summary>
         public object AddIndex(string tableName, string indexName, List<string>? fields, bool allowDuplicates, bool alternateKey)
         {
+            var indexFields = RequireIndexFields(tableName, indexName, fields);
+
             var axIdx = new AxTableIndex { Name = indexName };
             axIdx.AllowDuplicates = allowDuplicates ? Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.Yes : Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.No;
             if (alternateKey)
                 axIdx.AlternateKey = Microsoft.Dynamics.AX.Metadata.Core.MetaModel.NoYes.Yes;
-            if (fields != null)
-            {
-                foreach (var f in fields)
-                    axIdx.AddField(new AxTableIndexField { DataField = f });
-            }
+            foreach (var f in indexFields)
+                axIdx.AddField(new AxTableIndexField { DataField = f });
 
             var axTable = _provider.Tables.Read(tableName);
             if (axTable != null)
@@ -2016,7 +2002,7 @@ namespace D365MetadataBridge.Services
                 var msi = GetModelSaveInfoForObject(_provider.Tables, tableName);
                 axTable.AddIndex(axIdx);
                 ((IMetaTableProvider)_provider.Tables).Update(axTable, msi);
-                return new { success = true, operation = "add-index", objectName = tableName, indexName, fieldCount = fields?.Count ?? 0, api = "IMetaTableProvider.Update" };
+                return new { success = true, operation = "add-index", objectName = tableName, indexName, fieldCount = indexFields.Count, api = "IMetaTableProvider.Update" };
             }
 
             var axExt = _provider.TableExtensions.Read(tableName);
@@ -2027,7 +2013,7 @@ namespace D365MetadataBridge.Services
                 var extProvider = _provider.TableExtensions as IMetaTableExtensionProvider
                     ?? throw new InvalidOperationException("IMetaTableExtensionProvider not available");
                 extProvider.Update(axExt, msi);
-                return new { success = true, operation = "add-index", objectName = tableName, indexName, fieldCount = fields?.Count ?? 0, api = "IMetaTableExtensionProvider.Update" };
+                return new { success = true, operation = "add-index", objectName = tableName, indexName, fieldCount = indexFields.Count, api = "IMetaTableExtensionProvider.Update" };
             }
 
             throw new ArgumentException($"Table or table-extension '{tableName}' not found");
@@ -2089,12 +2075,11 @@ namespace D365MetadataBridge.Services
         /// </summary>
         public object AddFullTextIndex(string tableName, string indexName, List<string>? fields)
         {
+            var indexFields = RequireIndexFields(tableName, indexName, fields);
+
             var axIdx = new AxTableFullTextIndex { Name = indexName };
-            if (fields != null)
-            {
-                foreach (var f in fields)
-                    axIdx.Fields.Add(new AxTableIndexField { DataField = f });
-            }
+            foreach (var f in indexFields)
+                axIdx.Fields.Add(new AxTableIndexField { DataField = f });
 
             var axTable = _provider.Tables.Read(tableName);
             if (axTable != null)
@@ -2102,7 +2087,7 @@ namespace D365MetadataBridge.Services
                 var msi = GetModelSaveInfoForObject(_provider.Tables, tableName);
                 axTable.FullTextIndexes.Add(axIdx);
                 ((IMetaTableProvider)_provider.Tables).Update(axTable, msi);
-                return new { success = true, operation = "add-full-text-index", objectName = tableName, indexName, fieldCount = fields?.Count ?? 0, api = "IMetaTableProvider.Update" };
+                return new { success = true, operation = "add-full-text-index", objectName = tableName, indexName, fieldCount = indexFields.Count, api = "IMetaTableProvider.Update" };
             }
 
             var axExt = _provider.TableExtensions.Read(tableName);
@@ -2113,7 +2098,7 @@ namespace D365MetadataBridge.Services
                 var extProvider = _provider.TableExtensions as IMetaTableExtensionProvider
                     ?? throw new InvalidOperationException("IMetaTableExtensionProvider not available");
                 extProvider.Update(axExt, msi);
-                return new { success = true, operation = "add-full-text-index", objectName = tableName, indexName, fieldCount = fields?.Count ?? 0, api = "IMetaTableExtensionProvider.Update" };
+                return new { success = true, operation = "add-full-text-index", objectName = tableName, indexName, fieldCount = indexFields.Count, api = "IMetaTableExtensionProvider.Update" };
             }
 
             throw new ArgumentException($"Table or table-extension '{tableName}' not found");
@@ -2259,6 +2244,45 @@ namespace D365MetadataBridge.Services
         // ========================
 
         /// <summary>
+        /// One relation constraint, refused when either side is blank.
+        ///
+        /// `Field = c.Field ?? ""` wrote a nameless &lt;AxTableRelationConstraintField&gt;:
+        /// the relation was reported as added, joined nothing, and the damage surfaced
+        /// only at compile time. Blank on BOTH sides is the signature of the param-shape
+        /// mismatch the TS side remaps around — constraints arriving as
+        /// {fieldName, relatedFieldName} deserialize into a WriteRelationConstraint whose
+        /// two properties are null. Name it instead of writing it.
+        /// </summary>
+        private static AxTableRelationConstraintField NewRelationConstraint(string relationName, WriteRelationConstraint c)
+        {
+            var field = c.Field?.Trim();
+            var relatedField = c.RelatedField?.Trim();
+            if (string.IsNullOrEmpty(field) || string.IsNullOrEmpty(relatedField))
+                throw new ArgumentException(
+                    $"Relation '{relationName}' has a constraint with an empty field name " +
+                    $"(field='{c.Field}', relatedField='{c.RelatedField}'). Every constraint needs both keys: " +
+                    "{\"field\": \"<field on this table>\", \"relatedField\": \"<field on the related table>\"}.");
+
+            return new AxTableRelationConstraintField { Name = field, Field = field, RelatedField = relatedField };
+        }
+
+        /// <summary>
+        /// The constraint list of a relation, refused when empty — a relation with no
+        /// constraint fields joins nothing, so writing one is the same silent-empty-write
+        /// as an index with no fields.
+        /// </summary>
+        private static List<WriteRelationConstraint> RequireRelationConstraints(
+            string tableName, string relationName, List<WriteRelationConstraint>? constraints)
+        {
+            if (constraints == null || constraints.Count == 0)
+                throw new ArgumentException(
+                    $"Relation '{relationName}' on '{tableName}' has no constraints — pass 'constraints' as " +
+                    "[{\"field\": \"<field on this table>\", \"relatedField\": \"<field on the related table>\"}]. " +
+                    "A relation with an empty <Constraints /> collection joins nothing.");
+            return constraints;
+        }
+
+        /// <summary>
         /// Adds a relation to a table.
         ///
         /// Cardinality / RelatedTableCardinality / RelationshipType are real
@@ -2274,22 +2298,14 @@ namespace D365MetadataBridge.Services
             List<WriteRelationConstraint>? constraints,
             string? cardinality = null, string? relatedTableCardinality = null, string? relationshipType = null)
         {
+            var relationConstraints = RequireRelationConstraints(tableName, relationName, constraints);
+
             var axRel = new AxTableRelation { Name = relationName, RelatedTable = relatedTable };
             SetEnumProperty(axRel, "Cardinality", cardinality);
             SetEnumProperty(axRel, "RelatedTableCardinality", relatedTableCardinality);
             SetEnumProperty(axRel, "RelationshipType", relationshipType);
-            if (constraints != null)
-            {
-                foreach (var c in constraints)
-                {
-                    axRel.AddConstraint(new AxTableRelationConstraintField
-                    {
-                        Name = c.Field ?? "",
-                        Field = c.Field ?? "",
-                        RelatedField = c.RelatedField ?? ""
-                    });
-                }
-            }
+            foreach (var c in relationConstraints)
+                axRel.AddConstraint(NewRelationConstraint(relationName, c));
 
             var axTable = _provider.Tables.Read(tableName);
             if (axTable != null)
@@ -2341,26 +2357,18 @@ namespace D365MetadataBridge.Services
                     }
 
                     var added = new List<string>();
-                    if (constraints != null)
+                    foreach (var c in relationConstraints)
                     {
-                        foreach (var c in constraints)
+                        var constraint = NewRelationConstraint(relationName, c);
+                        var already = false;
+                        foreach (AxTableRelationConstraint existing in relExt.RelationConstraints)
                         {
-                            var field = c.Field ?? "";
-                            var already = false;
-                            foreach (AxTableRelationConstraint existing in relExt.RelationConstraints)
-                            {
-                                if (string.Equals(existing.Name, field, StringComparison.OrdinalIgnoreCase))
-                                { already = true; break; }
-                            }
-                            if (already) continue;
-                            relExt.RelationConstraints.Add(new AxTableRelationConstraintField
-                            {
-                                Name = field,
-                                Field = field,
-                                RelatedField = c.RelatedField ?? ""
-                            });
-                            added.Add(field);
+                            if (string.Equals(existing.Name, constraint.Name, StringComparison.OrdinalIgnoreCase))
+                            { already = true; break; }
                         }
+                        if (already) continue;
+                        relExt.RelationConstraints.Add(constraint);
+                        added.Add(constraint.Name);
                     }
 
                     extProvider.Update(axExt, msi);

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "f6da40c4b39c39c05833f9ec284084794319f5f51b68d6a798db460783700b7c",
+  "sourceHash": "2244786290932fdb91407d1fc7756a5e065625d0d370e43460942f8680249ed0",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7858.27",
-  "builtAt": "2026-08-04T05:49:49.967Z"
+  "metamodelFileVersion": "7.0.7996.33",
+  "builtAt": "2026-08-08T12:10:46.772Z"
 }

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -657,6 +657,20 @@ async function directXmlAddIndex(
   allowDuplicates: boolean | undefined,
   alternateKey: boolean | undefined,
 ): Promise<{ success: boolean; message: string } | null> {
+  // The bridge refuses an index with no fields (it writes <Fields /> — an index that
+  // compiles, warns about nothing and indexes nothing). This fallback runs precisely
+  // when the bridge call failed, so without the same gate it would catch the refusal
+  // and land the empty index anyway, under a ✅.
+  const namedFields = (fields ?? []).filter(f => typeof f === 'string' && f.trim() !== '');
+  if (namedFields.length === 0) {
+    return {
+      success: false,
+      message:
+        `Index '${indexName}' has no fields — pass indexFields as [{ fieldName: "<field>" }]. ` +
+        `An index with an empty <Fields /> collection compiles clean and indexes nothing.`,
+    };
+  }
+
   try {
     const rawContent = await fs.readFile(filePath, 'utf-8');
     const content = rawContent.replace(/^﻿/, '').replace(/\r\n/g, '\n');
@@ -682,22 +696,19 @@ async function directXmlAddIndex(
       };
     }
 
-    const fieldElements = (fields ?? [])
+    const fieldElements = namedFields
       .map(f =>
         `\t\t\t\t<AxTableIndexField>\n` +
         `\t\t\t\t\t<DataField>${f}</DataField>\n` +
         `\t\t\t\t</AxTableIndexField>`)
       .join('\n');
-    const fieldsBlock = fieldElements
-      ? `\t\t\t<Fields>\n${fieldElements}\n\t\t\t</Fields>`
-      : `\t\t\t<Fields />`;
 
     const newElement =
       `\t\t<AxTableIndex>\n` +
       `\t\t\t<Name>${indexName}</Name>\n` +
       `\t\t\t<AllowDuplicates>${allowDuplicates ? 'Yes' : 'No'}</AllowDuplicates>\n` +
       (alternateKey ? `\t\t\t<AlternateKey>Yes</AlternateKey>\n` : '') +
-      `${fieldsBlock}\n` +
+      `\t\t\t<Fields>\n${fieldElements}\n\t\t\t</Fields>\n` +
       `\t\t</AxTableIndex>`;
 
     let updated: string;

--- a/tests/bridge/batchBoolAndEmptyStructureGuards.test.ts
+++ b/tests/bridge/batchBoolAndEmptyStructureGuards.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Regression test — C# bridge batch-path health.
+ *
+ * Three defects the repo's own tests structurally cannot see, because every TS
+ * test mocks BridgeClient and therefore asserts what Node SENDS, never what C#
+ * READS or WRITES:
+ *
+ *  (a) HandleBatchModify's `B()` helper called Convert.ToBoolean(value). The batch
+ *      params arrive as Dictionary<string, object> whose values System.Text.Json
+ *      boxes as JsonElement, and JsonElement does not implement IConvertible — so
+ *      EVERY batch op carrying a bool (mandatory, allowDuplicates, alternateKey,
+ *      extendBaseFieldGroup) died with "Object must implement IConvertible",
+ *      reported by the per-op catch as that operation's reason for failing. The
+ *      single-op arms never had the bug: they read through GetBoolParam. Both
+ *      paths must now go through the shared ParamCoercion.
+ *
+ *  (b) BatchOperationRequest.GetTypedParam swallowed deserialization failures into
+ *      null, so a wrongly-SHAPED parameter was indistinguishable from an absent one
+ *      and the dispatcher answered "Missing: fields" for a key that was right there
+ *      — the param-shape contract bug this project keeps re-living. It also
+ *      deserialized without JsonOptions.Default, i.e. under different property-name
+ *      rules than the single-op GetParam<T>.
+ *
+ *  (c) MetadataWriteService wrote structurally useless objects and returned success:
+ *      AddIndex with fields == null serialized <Fields /> (an index that compiles,
+ *      warns about nothing and indexes nothing), and the relation builders wrote
+ *      `Field = c.Field ?? ""` — a nameless constraint whose damage only shows at
+ *      compile time. Same "silent empty write" family as the security-privilege
+ *      create defect: builds clean, 0 warnings, non-functional.
+ *
+ * These are source greps rather than behavioural assertions because the behaviour
+ * lives in a C# process that the TS suite does not start.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BRIDGE_DIR = path.join(
+  path.resolve(__dirname, '..', '..'),
+  'bridge', 'D365MetadataBridge',
+);
+const DISPATCHER_CS = path.join(BRIDGE_DIR, 'Protocol', 'RequestDispatcher.cs');
+const PROTOCOL_CS = path.join(BRIDGE_DIR, 'Protocol', 'BridgeProtocol.cs');
+const MODELS_CS = path.join(BRIDGE_DIR, 'Models', 'Models.cs');
+const WRITE_SERVICE_CS = path.join(BRIDGE_DIR, 'Services', 'MetadataWriteService.cs');
+
+let dispatcher: string;
+let protocol: string;
+let models: string;
+let writeService: string;
+
+/**
+ * Drops comments. Every fix here is deliberately DOCUMENTED by naming the old broken
+ * construct ("Convert.ToBoolean(v) therefore threw…", "`Field = c.Field ?? \"\"` wrote
+ * a nameless…"), so a raw grep would match the explanation and pass — or fail — for
+ * the wrong reason.
+ */
+function code(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+}
+
+/** Body of HandleBatchModify — from its signature to the end of the file's last method. */
+function batchModifyBody(source: string): string {
+  const start = source.indexOf('private Task<BridgeResponse> HandleBatchModify');
+  expect(start, 'HandleBatchModify not found — the batch path was renamed').toBeGreaterThan(0);
+  return source.slice(start);
+}
+
+/** Body of a C# method, from its signature to the start of the next member (any visibility). */
+function methodBody(source: string, signature: string): string {
+  const start = source.indexOf(signature);
+  expect(start, `method not found: ${signature}`).toBeGreaterThan(0);
+  const rest = source.slice(start + signature.length);
+  const next = rest.search(/\n {8}(?:public|private|internal|protected)\s/);
+  return next === -1 ? source.slice(start) : rest.slice(0, next);
+}
+
+describe('bridge batch path — boolean coercion (finding a)', () => {
+  beforeAll(() => {
+    dispatcher = fs.readFileSync(DISPATCHER_CS, 'utf8');
+    protocol = fs.readFileSync(PROTOCOL_CS, 'utf8');
+  });
+
+  it('never calls Convert.ToBoolean on a batch parameter', () => {
+    expect(
+      code(batchModifyBody(dispatcher)),
+      'Convert.ToBoolean(JsonElement) throws InvalidCastException ("Object must ' +
+        'implement IConvertible") — every batch op with a bool parameter fails with ' +
+        'that nonsense message instead of running',
+    ).not.toContain('Convert.ToBoolean');
+  });
+
+  it('routes batch booleans through the shared ParamCoercion helper', () => {
+    const body = code(batchModifyBody(dispatcher));
+    const helper = body.match(/bool\?\s*B\(string key\)\s*=>([^;]+);/);
+    expect(helper, "the batch path's B() bool helper is gone or was reshaped").not.toBeNull();
+    expect(
+      helper![1],
+      'the batch bool helper must use the same coercion as the single-op arms, or the ' +
+        'two paths disagree about what "mandatory": "true" means',
+    ).toContain('ParamCoercion.ToBool');
+  });
+
+  it('routes single-op booleans through the same helper', () => {
+    expect(code(protocol)).toMatch(/public bool\?\s*GetBoolParam\(string name\)[\s\S]*?ParamCoercion\.ToBool/);
+  });
+
+  it('ParamCoercion reads booleans by JSON kind and refuses anything else', () => {
+    const coercion = code(protocol.slice(protocol.indexOf('public static class ParamCoercion')));
+    expect(coercion).toContain('JsonValueKind.True');
+    expect(coercion).toContain('JsonValueKind.False');
+    // A present-but-unreadable value must throw, not degrade to false: a silent false
+    // writes a non-mandatory field / a duplicate-allowing index and reports success.
+    expect(coercion).toContain('throw new ArgumentException');
+  });
+
+  it('still passes the bool params of the batch ops that carry them', () => {
+    const body = batchModifyBody(dispatcher);
+    for (const param of ['mandatory', 'allowDuplicates', 'alternateKey', 'extendBaseFieldGroup']) {
+      expect(body, `batch path stopped forwarding '${param}'`).toContain(`B("${param}")`);
+    }
+  });
+});
+
+describe('bridge batch path — typed parameter shape errors (finding b)', () => {
+  beforeAll(() => {
+    models = fs.readFileSync(MODELS_CS, 'utf8');
+  });
+
+  it('GetTypedParam does not swallow a deserialization failure into null', () => {
+    const body = code(methodBody(models, 'public T? GetTypedParam<T>(string key)'));
+    expect(
+      body,
+      'a bare `catch { return null; }` makes a wrongly-shaped parameter look absent, and ' +
+        'the dispatcher then reports "Missing: <key>" for a key the caller did supply',
+    ).not.toMatch(/catch\s*\{\s*return null;\s*\}/);
+    expect(body).toContain('catch (System.Text.Json.JsonException');
+    expect(body).toContain('throw new System.ArgumentException');
+  });
+
+  it('GetTypedParam names the offending parameter in the error', () => {
+    const body = methodBody(models, 'public T? GetTypedParam<T>(string key)');
+    expect(
+      body,
+      'the whole point of the error is telling the caller WHICH parameter is misshapen',
+    ).toMatch(/throw new System\.ArgumentException\([\s\S]*?\{key\}/);
+  });
+
+  it('GetTypedParam deserializes with JsonOptions.Default, like the single-op GetParam', () => {
+    const body = code(methodBody(models, 'public T? GetTypedParam<T>(string key)'));
+    const deserializeCalls = body.match(/JsonSerializer\.Deserialize<T>\([^)]*\)/g) ?? [];
+    expect(deserializeCalls.length).toBeGreaterThan(0);
+    for (const call of deserializeCalls) {
+      expect(
+        call,
+        'deserializing without JsonOptions.Default gives the batch path different ' +
+          'property-name rules than the single-op path — a second way for the two to drift',
+      ).toContain('JsonOptions.Default');
+    }
+  });
+});
+
+describe('bridge write service — empty structure gates (finding c)', () => {
+  beforeAll(() => {
+    writeService = fs.readFileSync(WRITE_SERVICE_CS, 'utf8');
+  });
+
+  it('declares the shared gates', () => {
+    expect(writeService).toContain('private static List<string> RequireIndexFields(');
+    expect(writeService).toContain('private static AxTableRelationConstraintField NewRelationConstraint(');
+    expect(writeService).toContain(
+      'private static List<WriteRelationConstraint> RequireRelationConstraints(',
+    );
+  });
+
+  it('AddIndex refuses an index with no fields instead of writing <Fields />', () => {
+    const body = methodBody(
+      writeService,
+      'public object AddIndex(string tableName, string indexName, List<string>? fields',
+    );
+    expect(
+      body,
+      'AddIndex with fields == null wrote an index with zero fields and returned ' +
+        'success — it compiles, raises no BP warning and indexes nothing',
+    ).toContain('RequireIndexFields(');
+  });
+
+  it('AddFullTextIndex refuses a full-text index with no fields', () => {
+    const body = methodBody(
+      writeService,
+      'public object AddFullTextIndex(string tableName, string indexName, List<string>? fields',
+    );
+    expect(body).toContain('RequireIndexFields(');
+  });
+
+  it('AddRelation refuses missing constraints and blank constraint field names', () => {
+    const body = methodBody(writeService, 'public object AddRelation(string tableName, string relationName');
+    expect(body).toContain('RequireRelationConstraints(');
+    expect(body).toContain('NewRelationConstraint(');
+  });
+
+  it('no relation builder writes a nameless constraint any more', () => {
+    // `Field = c.Field ?? ""` produced an <AxTableRelationConstraintField> with an
+    // empty <Field>/<Name>: the relation reports as added, joins nothing, and only
+    // fails at compile time. Its usual cause is the {fieldName} vs {field} param-shape
+    // mismatch, i.e. BOTH sides deserialize to null.
+    expect(code(writeService)).not.toMatch(/Field\s*=\s*c\.Field\s*\?\?/);
+    expect(code(writeService)).not.toMatch(/RelatedField\s*=\s*c\.RelatedField\s*\?\?/);
+  });
+
+  it('every index/relation builder is gated, including the create paths', () => {
+    const source = code(writeService);
+    // One gate call per construction site: AddIndex, AddFullTextIndex, CreateTable,
+    // CreateSmartTable, CreateTableExtension.
+    expect((source.match(/RequireIndexFields\(/g) ?? []).length).toBeGreaterThanOrEqual(6);
+    // AddRelation, CreateTable, CreateSmartTable, CreateTableExtension (+ declaration).
+    expect((source.match(/RequireRelationConstraints\(/g) ?? []).length).toBeGreaterThanOrEqual(5);
+    // Every AxTableRelationConstraintField now comes from the gate, so the type is
+    // constructed in exactly one place.
+    expect((source.match(/new AxTableRelationConstraintField/g) ?? []).length).toBe(1);
+  });
+});


### PR DESCRIPTION
**Phase 0.5** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4). Audit finding 4, severity **critical**. This is the **prerequisite for Phase 1.1** (exposing `batchModify`) — the batch path has to be healthy before any tool routes traffic onto it.

## (a) Boxed `JsonElement` bools

The single-op path reads params off the request's `JsonElement`; the batch path gets `Dictionary<string, object>`, whose values System.Text.Json boxes as `JsonElement`. `JsonElement` does not implement `IConvertible`, so `Convert.ToBoolean(value)` threw `InvalidCastException` ("Object must implement IConvertible") for **every** batch operation carrying a bool — `mandatory`, `allowDuplicates`, `alternateKey`, `extendBaseFieldGroup` — and the per-op catch reported that cast as the operation's reason for failing.

New shared `ParamCoercion` reads booleans by `JsonValueKind`; **both** paths now go through it, so they cannot drift again.

Two deliberate behaviour choices worth reviewer attention:
- A value that is **present but unreadable** as a bool now **throws** instead of degrading to `false`. A silent `false` writes a non-mandatory field or a duplicate-allowing index and reports success.
- Accepted spellings widened to `"true"/"false"`, `"Yes"/"No"`, `1/0` — callers reach for the AxTable XML `No`/`Yes` form. This also changes the *single-op* path, which previously returned `null` (→ caller default `false`) for a stringified bool. Same silent-misinterpretation family, but it is scope beyond the literal batch finding.

## (b) `GetTypedParam` swallowing shape errors

`catch { return null; }` is gone; a `JsonException` now throws an `ArgumentException` naming the parameter and echoing the received JSON (capped at 300 chars), and deserialization uses `JsonOptions.Default` to match the single-op `GetParam<T>`. Previously a wrongly-shaped parameter was reported as `"Missing: fields"` **even though the key was present** — a live reincarnation of the historical param-shape incident. A JSON `null` still yields `null`; that genuinely is equivalent to absent.

## (c) Empty-structure gates

Three validators (`RequireIndexFields`, `NewRelationConstraint`, `RequireRelationConstraints`) applied at **every** construction site, not only the ones the audit named: `AddIndex`, `AddFullTextIndex` (the identical defect one function down), `AddRelation` (both the `Relations` and `RelationExtensions` branches), and the index/relation loops in `CreateTable`, `CreateSmartTable`, `CreateTableExtension`. `new AxTableRelationConstraintField` now exists in exactly one place.

Extending past the named line ranges was deliberate — leaving the identical silent-empty-write in `AddFullTextIndex` and the create paths would have been a half-fix. The cost: a create carrying a fieldless index or constraintless relation now fails the **whole** create rather than writing a junk member.

## One TS change, on purpose

`src/tools/modifyD365File.ts` — `directXmlAddIndex` runs *precisely when the bridge call fails*, and it happily wrote `<Fields />`. Without the same gate there, the C# fix would have made things **worse**: the bridge's new refusal would be caught by the fallback and the empty index landed anyway, under a ✅. The fallback now refuses a fieldless index with the same message.

## Verification

- `dotnet build` — succeeded, 0 warnings, 0 errors.
- `tsc --noEmit` clean. Full suite: 2854 passed.
- New `tests/bridge/batchBoolAndEmptyStructureGuards.test.ts` (14 tests), greps comment-stripped source so the explanatory comments naming the old broken construct cannot satisfy the assertions. Negative control: **13 of 14 fail** with the changes stashed.

## Not verified

Compile-time and source-grep only — nothing exercised against a live bridge process. Specifically unobserved: that a real batch `mandatory: true` resolves end to end; that the new `ArgumentException`s surface through `HandleBatchModify`'s per-op catch as readable per-operation errors; and that no legitimate flow creates a table with a deliberately constraintless relation, which would now hard-fail.

Left untouched: the `<Constraints />` emitter in `createD365File.ts` still tolerates empty constraints — a separate path, worth closing if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)