### PR TITLE
Apply several modify operations in one call via operations[] (Phase 1.1)

### DIFF
--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -94,8 +94,18 @@ Model + prefix auto-applied. Classes: member vars inside the class { }, methods 
             'modify-property',
           ],
           description:
-            '[modify] REQUIRED. add-method also UPDATES in place; replace-code is the surgical oldCode→newCode path. ' +
+            '[modify] REQUIRED unless using operations[]. add-method also UPDATES in place; replace-code is the surgical oldCode→newCode path. ' +
             'Parameters: get_knowledge(kind="op-spec", topic="<operation>").'
+        },
+        operations: {
+          type: 'array',
+          maxItems: 20,
+          description:
+            '[modify] PREFERRED for 2+ edits to the SAME object — ONE call, not one per edit. ' +
+            'Entries are {operation, …op-spec params}; objectType/objectName/modelName stay top-level. ' +
+            'Applied in order, stopped at the first failure, per-operation results back. ' +
+            '3 fields + their field groups + an index: 7 calls flat, 1 here.',
+          items: { type: 'object', additionalProperties: true },
         },
         params: {
           type: 'object',

--- a/src/tools/d365foFile.ts
+++ b/src/tools/d365foFile.ts
@@ -39,6 +39,116 @@ function subRequest(name: string, args: Record<string, unknown>): CallToolReques
   return { method: 'tools/call', params: { name, arguments: args } };
 }
 
+/** Ceiling on one batch — matches get_object_info's objects[] cap. */
+const MAX_BATCH_OPERATIONS = 20;
+
+/** Concatenated text of a tool result, for folding into the batch report. */
+function resultText(result: any): string {
+  return (result?.content ?? [])
+    .filter((c: any) => c?.type === 'text' && typeof c.text === 'string')
+    .map((c: any) => c.text)
+    .join('\n')
+    .trim();
+}
+
+/**
+ * Run several modify operations against one object in a SINGLE tool call.
+ *
+ * This is the largest round-trip saving available: a table change is never one
+ * operation. "add three fields" is 3 calls, each field then wants a field-group
+ * entry (the add-field response says so in as many words), and an index or a
+ * relation adds more — 8 to 14 round trips for one ordinary task, every one of
+ * them re-billing the whole cached context.
+ *
+ * Each operation goes through the ORDINARY single-op path rather than through
+ * the bridge's own batchModify. That is deliberate: the round trip being paid
+ * for is the MCP one, not the bridge IPC (which is local and costs
+ * milliseconds), and modifyD365FileTool is where path containment, backups,
+ * prefix application, .rnrproj registration, the direct-XML fallbacks and the
+ * per-operation validation live. Routing operations[] straight at the bridge
+ * would buy nothing measurable and would silently drop every one of those
+ * guards — including the ones that exist because a bridge write failed.
+ *
+ * Sequential, never parallel: the operations mutate one file, and direct-XML
+ * writes are read-modify-write with no locking, so concurrent ones interleave
+ * and lose edits.
+ */
+async function runModifyBatch(
+  rest: Record<string, unknown>,
+  context: XppServerContext,
+): Promise<any> {
+  const { operations, ...shared } = rest as { operations: unknown[] } & Record<string, unknown>;
+
+  if (operations.length === 0) {
+    return {
+      content: [{ type: 'text', text: '❌ d365fo_file(action="modify"): operations[] is empty — pass at least one { operation, … } entry.' }],
+      isError: true,
+    };
+  }
+  if (operations.length > MAX_BATCH_OPERATIONS) {
+    return {
+      content: [{ type: 'text', text: `❌ d365fo_file(action="modify"): operations[] has ${operations.length} entries, max ${MAX_BATCH_OPERATIONS}. Split it across calls.` }],
+      isError: true,
+    };
+  }
+
+  const results: Array<{ label: string; ok: boolean; text: string }> = [];
+  let stoppedAt = -1;
+
+  for (let i = 0; i < operations.length; i++) {
+    const entry = operations[i];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      results.push({ label: `#${i + 1}`, ok: false, text: 'entry is not an object — expected { operation, … }' });
+      stoppedAt = i;
+      break;
+    }
+    // Per-entry keys win over the shared ones, so objectType/objectName/modelName
+    // are stated once at the top level and an entry can still override them.
+    const entryArgs = { ...shared, ...(entry as Record<string, unknown>) };
+    const opName = String((entry as any).operation ?? '(missing operation)');
+
+    if (!(entry as any).operation) {
+      results.push({ label: `#${i + 1}`, ok: false, text: 'entry has no `operation` key' });
+      stoppedAt = i;
+      break;
+    }
+
+    const result = await modifyD365FileTool(subRequest('modify_d365fo_file', entryArgs), context);
+    const ok = !result?.isError;
+    results.push({ label: `#${i + 1} ${opName}`, ok, text: resultText(result) });
+
+    // Stop on the first failure. These operations are ordered on purpose — a
+    // field group references a field added two operations earlier — so carrying
+    // on past a failure produces a cascade of confusing secondary errors on top
+    // of a half-applied change.
+    if (!ok) { stoppedAt = i; break; }
+  }
+
+  const succeeded = results.filter(r => r.ok).length;
+  const failed = results.length - succeeded;
+  const skipped = operations.length - results.length;
+
+  const head =
+    `${failed === 0 ? '✅' : '⚠️'} d365fo_file(action="modify") — ${succeeded}/${operations.length} operation(s) applied` +
+    (failed ? `, failed at #${stoppedAt + 1}` : '') +
+    (skipped ? `, ${skipped} not attempted` : '');
+
+  const body = results
+    .map(r => `\n\n### ${r.ok ? '✅' : '❌'} ${r.label}\n${r.text || '(no output)'}`)
+    .join('');
+
+  const tail = failed
+    ? `\n\n> Operations run in order and stop at the first failure, because a later one usually ` +
+      `depends on an earlier one. The ${succeeded} operation(s) above it ARE applied — fix the failing ` +
+      `entry and re-send only the remaining ones.`
+    : '';
+
+  return {
+    content: [{ type: 'text', text: head + body + tail }],
+    isError: failed > 0,
+  };
+}
+
 export async function d365foFileTool(request: CallToolRequest, context: XppServerContext) {
   const parsed = D365FileArgsSchema.safeParse(request.params.arguments ?? {});
   if (!parsed.success) {
@@ -62,6 +172,9 @@ export async function d365foFileTool(request: CallToolRequest, context: XppServe
     return handleCreateD365File(subRequest('create_d365fo_file', rest), context);
   }
   if (action === 'modify') {
+    if (Array.isArray(rest.operations)) {
+      return runModifyBatch(rest, context);
+    }
     return modifyD365FileTool(subRequest('modify_d365fo_file', rest), context);
   }
   // generate: handler takes the request only (no context).

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -2907,12 +2907,17 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // Two BP rules fire on a field that compiles perfectly, so they are invisible
     // until a BP run several steps later — and one of them (the label copy) then
     // needs new labels, i.e. rework of what was just written. Say it here instead.
+    //
+    // The field-group note used to spell out a whole follow-up call, so the agent
+    // made one: every add-field manufactured a second round trip. It now points at
+    // operations[], where the group entry travels in the SAME call as the field.
     let addFieldBpNote = '';
     if (operation === 'add-field' && (objectType === 'table' || objectType === 'table-extension')) {
       const notes = [
-        `⚠️ BP: a table field must belong to a field group (BPErrorTableFieldNotInFieldGroup):\n` +
-        `   d365fo_file(action="modify", objectType="${objectType}", objectName="${objectName}", ` +
-        `operation="add-field-to-field-group", fieldName="${args.fieldName}", fieldGroupName="<group>")`,
+        `⚠️ BP: a table field must belong to a field group (BPErrorTableFieldNotInFieldGroup). ` +
+        `Send the group entry in the SAME call next time — d365fo_file(action="modify", ` +
+        `objectType="${objectType}", objectName="${objectName}", operations=[{operation:"add-field", …}, ` +
+        `{operation:"add-field-to-field-group", fieldName:"${args.fieldName}", fieldGroupName:"<group>"}]).`,
       ];
       if ((args as any).fieldEnumType) {
         notes.push(

--- a/tests/tools/modifyBatchOperations.test.ts
+++ b/tests/tools/modifyBatchOperations.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Phase 1.1 — several modify operations in ONE tool call.
+ *
+ * The audit's largest round-trip finding: a table change is never one
+ * operation. "add three fields" was 3 calls, each add-field response then told
+ * the agent to make a field-group call (in as many words), and an index or
+ * relation added more — 8 to 14 round trips for one ordinary task, every one of
+ * them re-billing the whole cached context.
+ *
+ * Each entry goes through the ORDINARY single-op path, so the guards
+ * (containment, backups, prefixing, .rnrproj registration, direct-XML
+ * fallbacks) all still run. These tests pin the batch semantics: order,
+ * stop-at-first-failure, shared-vs-entry key precedence, and that the failure
+ * report says what was and was not applied.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const { mockModify } = vi.hoisted(() => ({ mockModify: vi.fn() }));
+
+vi.mock('../../src/tools/modifyD365File', () => ({
+  modifyD365FileTool: mockModify,
+}));
+vi.mock('../../src/tools/createD365File', () => ({ handleCreateD365File: vi.fn() }));
+vi.mock('../../src/tools/generateD365Xml', () => ({ handleGenerateD365Xml: vi.fn() }));
+
+import { d365foFileTool } from '../../src/tools/d365foFile';
+
+const ctx = {} as any;
+const ok = (text: string) => ({ content: [{ type: 'text', text }] });
+const fail = (text: string) => ({ content: [{ type: 'text', text }], isError: true });
+
+const call = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'd365fo_file', arguments: { action: 'modify', ...args } },
+});
+
+/** The arguments each forwarded single-op call actually received. */
+const forwarded = () => mockModify.mock.calls.map(c => (c[0] as CallToolRequest).params.arguments as any);
+
+const text = (r: any) => r.content[0].text as string;
+
+describe('d365fo_file(action="modify") with operations[]', () => {
+  beforeEach(() => {
+    mockModify.mockReset();
+    mockModify.mockImplementation(async () => ok('applied'));
+  });
+
+  it('runs every operation in one call, in order', async () => {
+    const result = await d365foFileTool(call({
+      objectType: 'table',
+      objectName: 'ContosoXyzTable',
+      operations: [
+        { operation: 'add-field', fieldName: 'AccountNum' },
+        { operation: 'add-field', fieldName: 'Amount' },
+        { operation: 'add-field-to-field-group', fieldName: 'AccountNum', fieldGroupName: 'AutoReport' },
+      ],
+    }), ctx);
+
+    expect(mockModify).toHaveBeenCalledTimes(3);
+    expect(forwarded().map(a => a.operation)).toEqual(['add-field', 'add-field', 'add-field-to-field-group']);
+    expect(result.isError).toBeFalsy();
+    expect(text(result)).toContain('3/3 operation(s) applied');
+  });
+
+  it('carries shared keys into every entry, and lets an entry override them', async () => {
+    await d365foFileTool(call({
+      objectType: 'table',
+      objectName: 'ContosoXyzTable',
+      modelName: 'ContosoExt',
+      operations: [
+        { operation: 'add-field', fieldName: 'A' },
+        { operation: 'add-field', fieldName: 'B', objectName: 'ContosoOtherTable' },
+      ],
+    }), ctx);
+
+    const [first, second] = forwarded();
+    expect(first).toMatchObject({ objectType: 'table', objectName: 'ContosoXyzTable', modelName: 'ContosoExt', fieldName: 'A' });
+    expect(second).toMatchObject({ objectName: 'ContosoOtherTable', modelName: 'ContosoExt', fieldName: 'B' });
+  });
+
+  it('stops at the first failure instead of cascading into it', async () => {
+    mockModify
+      .mockImplementationOnce(async () => ok('field added'))
+      .mockImplementationOnce(async () => fail('❌ EDT "Iteger" does not exist'))
+      .mockImplementationOnce(async () => ok('should never run'));
+
+    const result = await d365foFileTool(call({
+      objectType: 'table',
+      objectName: 'ContosoXyzTable',
+      operations: [
+        { operation: 'add-field', fieldName: 'A' },
+        { operation: 'add-field', fieldName: 'B' },
+        { operation: 'add-index', indexName: 'Idx' },
+      ],
+    }), ctx);
+
+    expect(mockModify).toHaveBeenCalledTimes(2);
+    expect(result.isError).toBe(true);
+    const t = text(result);
+    expect(t).toContain('1/3 operation(s) applied');
+    expect(t).toContain('failed at #2');
+    expect(t).toContain('1 not attempted');
+    // The partial state has to be stated — the first field IS on disk.
+    expect(t).toMatch(/ARE applied/);
+    expect(t).toContain('Iteger');
+  });
+
+  it('rejects an empty operations[]', async () => {
+    const result = await d365foFileTool(call({ objectType: 'table', objectName: 'T', operations: [] }), ctx);
+    expect(result.isError).toBe(true);
+    expect(text(result)).toContain('operations[] is empty');
+    expect(mockModify).not.toHaveBeenCalled();
+  });
+
+  it('caps the batch size rather than accepting an unbounded list', async () => {
+    const operations = Array.from({ length: 21 }, (_, i) => ({ operation: 'add-field', fieldName: `F${i}` }));
+    const result = await d365foFileTool(call({ objectType: 'table', objectName: 'T', operations }), ctx);
+    expect(result.isError).toBe(true);
+    expect(text(result)).toContain('max 20');
+    expect(mockModify).not.toHaveBeenCalled();
+  });
+
+  it('rejects an entry with no operation key before writing anything', async () => {
+    const result = await d365foFileTool(call({
+      objectType: 'table', objectName: 'T',
+      operations: [{ fieldName: 'A' }],
+    }), ctx);
+    expect(result.isError).toBe(true);
+    expect(text(result)).toContain('no `operation` key');
+    expect(mockModify).not.toHaveBeenCalled();
+  });
+
+  it('leaves the single-operation form untouched', async () => {
+    await d365foFileTool(call({
+      objectType: 'table', objectName: 'T', operation: 'add-field', fieldName: 'A',
+    }), ctx);
+
+    expect(mockModify).toHaveBeenCalledTimes(1);
+    expect(forwarded()[0]).toMatchObject({ operation: 'add-field', fieldName: 'A' });
+    // No batch wrapper around a single op.
+    expect(forwarded()[0].operations).toBeUndefined();
+  });
+
+  it('accepts operations[] nested in params, like every other modify parameter', async () => {
+    await d365foFileTool(call({
+      objectType: 'table', objectName: 'T',
+      params: { operations: [{ operation: 'add-field', fieldName: 'A' }] },
+    }), ctx);
+
+    expect(mockModify).toHaveBeenCalledTimes(1);
+    expect(forwarded()[0]).toMatchObject({ operation: 'add-field', fieldName: 'A' });
+  });
+});

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -55,10 +55,16 @@ const CHARS_PER_TOKEN = 4;
 //   • the 23-value object-type enum was inlined THREE times in `search`; the two
 //     nested copies now point at the top-level one.
 //
+// Raised DELIBERATELY, by 451 chars, to spend part of that headroom on
+// d365fo_file's operations[] (4,781 -> 5,232): several edits to one object in a
+// single call. This is the trade the trim was for — the description costs ~450
+// chars once per session, and it removes six or more round trips from every
+// ordinary table change, each of which re-bills the entire cached context.
+//
 // Headroom is small on purpose so creep is caught early: both ceilings are the
 // next round hundred above the measured payload.
-const TOTAL_BUDGET = 49_900;
-const LARGEST_TOOL_BUDGET = 4_800;
+const TOTAL_BUDGET = 50_300;
+const LARGEST_TOOL_BUDGET = 5_300;
 
 async function getTools(): Promise<Array<{ name: string }>> {
   const ctx: any = { symbolIndex: {}, parser: {} };
@@ -105,7 +111,7 @@ describe('tool schema token budget', () => {
     const tools = await getTools();
     const byName = new Map(tools.map(t => [t.name, t]));
 
-    for (const [name, cap] of [['d365fo_file', 5_000], ['generate_object', 3_400]] as const) {
+    for (const [name, cap] of [['d365fo_file', 5_300], ['generate_object', 3_400]] as const) {
       const tool: any = byName.get(name);
       expect(tool, `${name} is not published`).toBeDefined();
       const chars = JSON.stringify(tool).length;


### PR DESCRIPTION
**Phase 1.1** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4) — the largest round-trip saving in it.

> ⚠️ **Stacked on #854** (Phase 1.5). Base is `perf/schema-headroom`; merge #854 first and this retargets to `main`. The dependency is real, not cosmetic: on `main` this change puts the ListTools payload at **54,052 chars against a 53,500 budget**. #854's trim is what pays for it.

## The problem

A table change is never one operation. "Add three fields" was 3 calls; each `add-field` response then told the agent to make a field-group call — in as many words, so it did; an index or a relation added more. **8–14 round trips for one ordinary task**, and each round trip re-bills the entire cached context.

## The change

`d365fo_file(action="modify")` now takes `operations[]`: entries of `{operation, …op-spec params}`, with `objectType`/`objectName`/`modelName` stated once at the top level. Seven calls become one.

```js
d365fo_file(action="modify", objectType="table", objectName="ContosoXyzTable", operations=[
  { operation: "add-field", fieldName: "AccountNum", edt: "CustAccount" },
  { operation: "add-field-to-field-group", fieldName: "AccountNum", fieldGroupName: "AutoReport" },
  { operation: "add-index", indexName: "AccountIdx", indexFields: [{ fieldName: "AccountNum" }] },
])
```

## One deliberate departure from the plan's wording

The plan says `operations[] → bridgeBatchModify`. **Each entry goes through the ordinary single-op path instead.** Reasoning:

- The round trip being paid for is the **MCP** one. The bridge IPC is local and costs milliseconds — routing at `bridgeBatchModify` would save nothing the user can measure.
- `modifyD365FileTool` is where path containment, backups, prefix application, `.rnrproj` registration, the direct-XML fallbacks and per-operation validation live. Going straight to the bridge would silently drop **every one of those guards** — including the fallbacks that exist precisely *because* a bridge write failed, and the containment guard Phase 0.1 just fixed.

So the full user-visible win is captured with none of the safety loss. `bridgeBatchModify` stays unused; #853 remains worth merging on its own merits (the batch path is reachable from other callers), but this no longer depends on it.

## Semantics, and why

- **Sequential, never parallel** — the operations mutate one file, and direct-XML writes are read-modify-write with no locking (audit finding 21), so concurrent ones interleave and lose edits.
- **Stop at the first failure**, not best-effort — these are ordered on purpose (a field group references a field added two operations earlier), so continuing produces a cascade of secondary errors on top of a half-applied change. The report states plainly what *is* applied and what was not attempted, so the agent can re-send only the remainder.
- **Capped at 20** entries.
- Per-entry keys override the shared ones.
- The single-`operation` form is untouched.

## Also

Retires the `add-field` BP note that spelled out a complete follow-up call and thereby **manufactured a round trip on every single add-field**. It now points at `operations[]`, where the group entry travels in the same call as the field.

## Cost

`d365fo_file`: 4,781 → 5,232 chars. Ceilings raised 451 chars **deliberately**, with the reason recorded in the budget test — this is the trade #854's trim existed to fund: ~450 chars once per session against six or more round trips removed from every ordinary table change.

## Verification

New `tests/tools/modifyBatchOperations.test.ts` (8 tests): ordering, shared-vs-entry key precedence, stop-at-first-failure with the partial-state report, empty/oversized/malformed rejection before anything is written, the single-op form unaffected, and `operations[]` nested in `params`.

Full suite: 2865 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)