### PR TITLE
Return the write contract from prepare instead of making the agent fetch it (Phase 1.3)

### DIFF
--- a/src/server/toolSchemas/prepare.ts
+++ b/src/server/toolSchemas/prepare.ts
@@ -44,6 +44,10 @@ export const prepareTool = {
           type: 'string',
           description: '[change] Target method name when the change involves a specific method (CoC or event handlers). Example: "validateWrite".',
         },
+        operation: {
+          type: 'string',
+          description: '[change] The modify operation you intend to run; its full parameter contract comes back in THIS response, so no separate op-spec call. Defaults to add-method when methodName is given.',
+        },
         proposedName: {
           type: 'string',
           description: '[change] Proposed name for the new extension class/object. When provided, naming validation runs.',

--- a/src/tools/opSpecs.ts
+++ b/src/tools/opSpecs.ts
@@ -105,6 +105,53 @@ export function renderOpSpecIndex(unknownTopic?: string): string {
 }
 
 /**
+ * The op-spec section `prepare` carries in its own output.
+ *
+ * Deferring the parameter contracts out of the wire schema (#825) traded schema
+ * bytes for a DISCOVERY HOP: nearly every write flow then spent a round trip on
+ * get_knowledge(kind="op-spec", …) — or, worse, a failed write that returned the
+ * spec in its error. prepare already knows the objectType and, for a change, the
+ * method, so it can hand the contract over in the call the agent was making
+ * anyway. That is a few hundred bytes against a whole round trip.
+ *
+ * `operation` is used when the caller names one. Otherwise a change targeting a
+ * method is going to write one, so add-method's contract is the right guess; a
+ * change with no method has no confident guess and only gets the pointer.
+ */
+export function renderPrepareOpSpec(args: {
+  mode: 'change' | 'create';
+  objectType?: string;
+  operation?: string;
+  methodName?: string;
+}): string[] {
+  const { mode, objectType, operation, methodName } = args;
+  const lines: string[] = [];
+
+  if (mode === 'create') {
+    if (!objectType) return lines;
+    lines.push(`### Write contract — d365fo_file(action="create", objectType="${objectType}")`);
+    lines.push(renderCreatePropertySpec(objectType));
+  } else {
+    const op = operation && findKey(D365FO_FILE_OP_SPECS, normalize(operation))
+      ? findKey(D365FO_FILE_OP_SPECS, normalize(operation))!
+      : (methodName ? 'add-method' : undefined);
+    if (!op) {
+      lines.push(
+        '### Write contract',
+        'Pick the operation, then get_knowledge(kind="op-spec", topic="<operation>") for its parameters — ' +
+        'or pass `operation` to prepare and the contract comes back here.',
+      );
+      return lines;
+    }
+    lines.push(`### Write contract — d365fo_file(action="modify", operation="${op}")`);
+    lines.push(renderOpSpec(op));
+  }
+
+  lines.push('');
+  return lines;
+}
+
+/**
  * Resolve one topic to its full parameter contract. Resolution order is
  * modify operation → generate_object mode → create objectType; the three key
  * spaces do not overlap, so the order only decides what an ambiguous future

--- a/src/tools/prepareChange.ts
+++ b/src/tools/prepareChange.ts
@@ -25,6 +25,7 @@ import { tryBridgeCocExtensions } from '../bridge/bridgeAdapter.js';
 import { getConfigManager } from '../utils/configManager.js';
 import { lookupSymbolNocase } from '../utils/symbolLookup.js';
 import { findDeclaringAncestor } from '../utils/inheritanceChain.js';
+import { renderPrepareOpSpec } from './opSpecs.js';
 import { rankContext, renderRankedContext } from '../workspace/contextRanker.js';
 
 // Schema
@@ -406,6 +407,15 @@ export async function prepareChangeTool(request: any, context: XppServerContext)
     lines.push(namingText);
     lines.push('');
   }
+
+  // Same reasoning as prepare(create): hand over the write contract here rather
+  // than making the agent fetch it in a separate call.
+  lines.push(...renderPrepareOpSpec({
+    mode: 'change',
+    objectType: resolvedType,
+    operation: (raw as any)?.operation,
+    methodName,
+  }));
 
   lines.push('---');
   lines.push(`**Grounding token:** \`${token}\``);

--- a/src/tools/prepareCreate.ts
+++ b/src/tools/prepareCreate.ts
@@ -18,6 +18,7 @@ import type { XppServerContext } from '../types/context.js';
 import { createProvenanceToken } from '../utils/provenanceStore.js';
 import { getConfigManager } from '../utils/configManager.js';
 import { resolveObjectPrefix, applyObjectPrefix } from '../utils/modelClassifier.js';
+import { renderPrepareOpSpec } from './opSpecs.js';
 import { rankContext, renderRankedContext } from '../workspace/contextRanker.js';
 import { lookupSymbolsNocase, type SymbolHit } from '../utils/symbolLookup.js';
 import { RESERVED_SYSTEM_FIELD_NAMES } from './generateSmartTable.js';
@@ -290,6 +291,10 @@ export async function prepareCreateTool(request: any, context: XppServerContext)
   } catch {
     // Additive — omit on failure.
   }
+
+  // The write contract for this objectType, so the flow does not spend a round
+  // trip on get_knowledge(kind="op-spec") right after this call.
+  lines.push(...renderPrepareOpSpec({ mode: 'create', objectType }));
 
   lines.push('---');
   lines.push(`**Grounding token:** \`${token}\``);

--- a/tests/tools/prepareOpSpec.test.ts
+++ b/tests/tools/prepareOpSpec.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Phase 1.3 — prepare carries the write contract.
+ *
+ * Deferring the parameter contracts out of the wire schema (#825) traded schema
+ * bytes for a DISCOVERY HOP: nearly every write flow then spent a round trip on
+ * get_knowledge(kind="op-spec", …), or a failed write that returned the spec in
+ * its error message. prepare already knows the objectType and, for a change,
+ * the method — so it hands the contract over in the call the agent was making
+ * anyway, a few hundred bytes against a whole round trip.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderPrepareOpSpec } from '../../src/tools/opSpecs';
+
+const render = (args: Parameters<typeof renderPrepareOpSpec>[0]) => renderPrepareOpSpec(args).join('\n');
+
+describe('renderPrepareOpSpec — create', () => {
+  it('returns the objectType properties contract', () => {
+    const out = render({ mode: 'create', objectType: 'table' });
+    expect(out).toContain('d365fo_file(action="create", objectType="table")');
+    // The actual contract, not just a pointer to it.
+    expect(out).toContain('tableGroup');
+    expect(out).toContain('fields[{name');
+  });
+
+  it('answers for an objectType that takes no extra properties', () => {
+    const out = render({ mode: 'create', objectType: 'menu-item-display' });
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('renders nothing without an objectType rather than guessing', () => {
+    expect(renderPrepareOpSpec({ mode: 'create' })).toEqual([]);
+  });
+});
+
+describe('renderPrepareOpSpec — change', () => {
+  it('uses the operation the caller named', () => {
+    const out = render({ mode: 'change', operation: 'add-index' });
+    expect(out).toContain('operation="add-index"');
+    expect(out).toContain('indexFields');
+  });
+
+  it('falls back to add-method when a method is targeted', () => {
+    const out = render({ mode: 'change', methodName: 'validateWrite' });
+    expect(out).toContain('operation="add-method"');
+    expect(out).toContain('methodName');
+  });
+
+  it('prefers the named operation over the methodName guess', () => {
+    const out = render({ mode: 'change', operation: 'replace-code', methodName: 'validateWrite' });
+    expect(out).toContain('operation="replace-code"');
+    expect(out).toContain('oldCode');
+  });
+
+  it('gives the pointer, not a wrong guess, when there is nothing to go on', () => {
+    const out = render({ mode: 'change' });
+    expect(out).toContain('kind="op-spec"');
+    expect(out).not.toContain('operation="add-method"');
+  });
+
+  it('ignores an operation that is not a real one and falls back', () => {
+    const out = render({ mode: 'change', operation: 'not-an-operation', methodName: 'foo' });
+    expect(out).toContain('operation="add-method"');
+  });
+
+  it('stays within the size the round-trip trade assumes (~1 kB)', () => {
+    // The point is to be cheaper than the round trip it removes, not free.
+    for (const args of [
+      { mode: 'create' as const, objectType: 'table' },
+      { mode: 'change' as const, methodName: 'validateWrite' },
+    ]) {
+      expect(render(args).length).toBeLessThan(2_000);
+    }
+  });
+});

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -61,9 +61,15 @@ const CHARS_PER_TOKEN = 4;
 // chars once per session, and it removes six or more round trips from every
 // ordinary table change, each of which re-bills the entire cached context.
 //
+// Raised again by ~200 chars for prepare's `operation`, which makes prepare
+// return the write contract itself. Deferring those contracts out of the schema
+// (#825) had traded bytes for a discovery hop — get_knowledge(kind="op-spec")
+// on nearly every write flow — and this buys the hop back for a fraction of
+// what inlining them cost.
+//
 // Headroom is small on purpose so creep is caught early: both ceilings are the
 // next round hundred above the measured payload.
-const TOTAL_BUDGET = 50_300;
+const TOTAL_BUDGET = 50_500;
 const LARGEST_TOOL_BUDGET = 5_300;
 
 async function getTools(): Promise<Array<{ name: string }>> {


### PR DESCRIPTION
**Phase 1.3** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4).

> ⚠️ Stacked: `perf/prepare-bundles-opspec` → `perf/batch-modify-operations` (#855) → `perf/schema-headroom` (#854). Merge in that order and each retargets to `main`.

## The problem

Deferring the parameter contracts out of the wire schema (#825) was the right call for bytes, but it traded them for a **discovery hop**. Nearly every write flow then spent a round trip on `get_knowledge(kind="op-spec", …)` — or, worse, spent a *failed write* that returned the spec inside its error message.

## The change

`prepare` already knows the `objectType` and, for a change, the method — and it is the call the agent is making anyway at the start of a write. So it now carries the contract in its own output:

| Call | What comes back |
|---|---|
| `prepare(mode="create", objectType="table")` | the `properties` contract for a table |
| `prepare(mode="change", methodName="validateWrite")` | `add-method`'s parameters |
| `prepare(mode="change", operation="add-index")` | that operation's spec |

A change with neither an `operation` nor a `methodName` gets the **pointer**, not a confident-sounding wrong guess — a bad default here would be worse than the hop it replaces.

New optional `operation` parameter on `prepare` so the caller can name the operation it intends.

## Cost

~400 chars (create, table) to ~1.3 kB (add-method) in the *response*, against a whole round trip removed. The schema ceiling moves 200 chars for the new `operation` parameter; the budget test records why.

## Verification

New `tests/tools/prepareOpSpec.test.ts` (9 tests): the create contract is the actual contract and not just a pointer, the named operation wins over the `methodName` guess, an unrecognised operation falls back rather than rendering nonsense, the no-information case gives the pointer, and the rendered section stays under 2 kB so it remains cheaper than the round trip it replaces.

Full suite: 2874 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)