### PR TITLE
Bridge lifecycle + stop the C# write path reporting success it did not achieve (Phase 2.5)

### DIFF
--- a/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
+++ b/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
@@ -10,9 +10,36 @@ namespace D365MetadataBridge.Services
     /// <summary>
     /// Provides cross-reference queries using the DYNAMICSXREFDB SQL database.
     /// This replaces the FTS5 text-search approach with real compiler-resolved references.
+    ///
+    /// ## Query failures are errors, never empty results
+    ///
+    /// Every method here answers one question — "what else touches this?" — and the answer
+    /// drives whether it is safe to change something. A failed query used to be returned as
+    /// a SUCCESSFUL response carrying count=0 plus an `error` field, which reads to any
+    /// caller that does not inspect the extra field as the strongest possible clearance:
+    /// "nothing references this, go ahead". A down or unreachable xref database therefore
+    /// produced false negatives on exactly the question the service exists to answer, and
+    /// the more broken the database, the safer everything looked.
+    ///
+    /// So failures throw. RequestDispatcher.HandleXref turns them into a JSON-RPC error, and
+    /// the TS adapters already treat a rejected call as "no answer from the bridge" and fall
+    /// back to their own scan instead of trusting a zero.
     /// </summary>
     public class CrossReferenceService
     {
+        /// <summary>
+        /// Rethrows a failed xref query as an error the dispatcher will surface, with the
+        /// query's subject in the message so the caller can see what was NOT answered.
+        /// </summary>
+        private static Exception QueryFailed(string operation, string subject, Exception cause)
+        {
+            Console.Error.WriteLine($"[CrossRefService] {operation}({subject}) failed: {cause.Message}");
+            return new InvalidOperationException(
+                $"Cross-reference query {operation}('{subject}') failed: {cause.Message}. " +
+                "This is NOT an empty result — the cross-reference database did not answer, so nothing " +
+                "can be concluded about references to this object.", cause);
+        }
+
         private readonly string _connectionString;
 
         public CrossReferenceService(string server, string database)
@@ -209,8 +236,7 @@ namespace D365MetadataBridge.Services
             }
             catch (SqlException ex)
             {
-                Console.Error.WriteLine($"[CrossRefService] SQL error: {ex.Message}");
-                return new { objectPath, count = 0, references = new List<ReferenceInfoModel>(), error = ex.Message };
+                throw QueryFailed("findReferences", objectPath, ex);
             }
 
             return new { objectPath, count = references.Count, references };
@@ -335,15 +361,7 @@ namespace D365MetadataBridge.Services
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"[WARN] FindExtensionClasses({baseClassName}): {ex.Message}");
-                return new
-                {
-                    baseClassName,
-                    count = 0,
-                    extensions = new List<ExtensionClassDetailModel>(),
-                    error = ex.Message,
-                    _source = "C# bridge (DYNAMICSXREFDB)"
-                };
+                throw QueryFailed("findExtensionClasses", baseClassName, ex);
             }
         }
 
@@ -447,8 +465,7 @@ namespace D365MetadataBridge.Services
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"[WARN] FindEventSubscribers({targetName}): {ex.Message}");
-                return new { targetName, count = 0, handlers = results, error = ex.Message, _source = "C# bridge (DYNAMICSXREFDB)" };
+                throw QueryFailed("findEventSubscribers", targetName, ex);
             }
         }
 
@@ -574,8 +591,7 @@ namespace D365MetadataBridge.Services
             }
             catch (SqlException ex)
             {
-                Console.Error.WriteLine($"[CrossRefService] FindApiUsageCallers SQL error: {ex.Message}");
-                return new { apiName, count = 0, callers = new List<ApiUsageCallerModel>(), error = ex.Message, _source = "C# bridge (DYNAMICSXREFDB)" };
+                throw QueryFailed("findApiUsageCallers", apiName, ex);
             }
 
             // Group by caller class for pattern summary

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -125,11 +125,34 @@ namespace D365MetadataBridge.Services
         {
             var sw = System.Diagnostics.Stopwatch.StartNew();
             var factory = new MetadataProviderFactory();
+            var previous = _provider;
             _provider = CreatePrimaryProvider(factory, _packagesPath, _referencePackagesPath);
+            // Hand the new provider over BEFORE releasing the old one, so nothing is
+            // holding a provider that is about to be disposed.
             OnProviderRefreshed?.Invoke(_provider);
+            // Every write auto-refreshes (HandleWrite refreshAfterSuccess), so a long
+            // authoring session builds one DiskProvider per write. Dropping the old one
+            // on the floor kept its file handles and per-package metadata caches alive
+            // over the whole PackagesLocalDirectory until GC felt like it — the bridge
+            // grew until it stopped answering, which is the state the client sees as a
+            // wedged process.
+            DisposeProvider(previous);
             sw.Stop();
             Console.Error.WriteLine($"[MetadataService] Provider refreshed in {sw.ElapsedMilliseconds}ms");
             return new { refreshed = true, elapsedMs = sw.ElapsedMilliseconds };
+        }
+
+        /// <summary>
+        /// Releases a superseded provider. Whether DiskProvider implements IDisposable
+        /// varies across metamodel versions, so this asks rather than assumes; a failure
+        /// to release is logged and swallowed because the replacement is already live and
+        /// the refresh itself succeeded.
+        /// </summary>
+        private static void DisposeProvider(IMetadataProvider? provider)
+        {
+            if (provider is not IDisposable disposable) return;
+            try { disposable.Dispose(); }
+            catch (Exception ex) { Console.Error.WriteLine($"[WARN] Failed to dispose superseded metadata provider: {ex.Message}"); }
         }
 
         /// <summary>

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -22,6 +22,10 @@ namespace D365MetadataBridge.Services
         // Cache resolved ModelSaveInfo per model name
         private readonly Dictionary<string, ModelSaveInfo> _modelCache = new Dictionary<string, ModelSaveInfo>(StringComparer.OrdinalIgnoreCase);
 
+        // Cache the publisher verdict per model name — see IsMicrosoftModel. Cleared with
+        // _modelCache in UpdateProvider for the same reason: it is read off the provider.
+        private readonly Dictionary<string, bool> _microsoftModelCache = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
         public MetadataWriteService(IMetadataProvider provider, string packagesPath)
         {
             _provider = provider;
@@ -30,10 +34,21 @@ namespace D365MetadataBridge.Services
 
         /// <summary>
         /// Called by MetadataReadService.RefreshProvider() to keep the write service in sync.
+        ///
+        /// The model cache is derived from the provider (ResolveModelSaveInfo asks
+        /// _provider.ModelManifest first), so it cannot outlive it. A model the OLD manifest
+        /// did not enumerate — the usual case for a model that was just deployed, or created
+        /// and not yet built — falls back to the descriptor scan, whose ModelSaveInfo carries
+        /// the SequenceId as Id and SequenceId=0; that is exactly the shape that makes
+        /// IMetadataProvider.Create() throw NullReferenceException. Cached, it survived every
+        /// later refresh, so the refresh that finally made the manifest able to answer
+        /// correctly changed nothing and every subsequent create into that model kept NREing.
         /// </summary>
         public void UpdateProvider(IMetadataProvider newProvider)
         {
             _provider = newProvider;
+            _modelCache.Clear();
+            _microsoftModelCache.Clear();
         }
 
         // ========================
@@ -162,6 +177,69 @@ namespace D365MetadataBridge.Services
                 Console.Error.WriteLine($"[WriteService] Error parsing descriptor {xmlPath}: {ex.Message}");
                 return null;
             }
+        }
+
+        // ========================
+        // MODEL OWNERSHIP
+        // ========================
+
+        /// <summary>
+        /// Is this model shipped by Microsoft?
+        ///
+        /// Answered from the model manifest's Publisher, which is the model's own
+        /// declaration of who owns it — not a name list that goes stale with every
+        /// release, and not the layer (a partner solution can sit in a low layer).
+        ///
+        /// Default-allow on purpose: an unreadable manifest, or a model the manifest
+        /// does not enumerate, answers false. A guard that cannot see the evidence must
+        /// not start refusing writes that work today; the cost of the rare miss is the
+        /// behaviour we already had, while a false positive would block a customer's own
+        /// model with no way around it from inside the tool.
+        /// </summary>
+        private bool IsMicrosoftModel(string? modelName)
+        {
+            if (string.IsNullOrWhiteSpace(modelName)) return false;
+            if (_microsoftModelCache.TryGetValue(modelName!, out var cached)) return cached;
+
+            var isMicrosoft = false;
+            try
+            {
+                var manifest = _provider.ModelManifest;
+                if (manifest != null)
+                {
+                    foreach (var mi in manifest.ListModelInfos())
+                    {
+                        if (!string.Equals(mi.Name, modelName, StringComparison.OrdinalIgnoreCase)) continue;
+                        isMicrosoft = (mi.Publisher ?? "").IndexOf("Microsoft", StringComparison.OrdinalIgnoreCase) >= 0;
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[WriteService] Publisher lookup failed for model '{modelName}': {ex.Message}");
+            }
+
+            _microsoftModelCache[modelName!] = isMicrosoft;
+            return isMicrosoft;
+        }
+
+        /// <summary>
+        /// Refuses a write into a Microsoft-shipped model.
+        ///
+        /// The bridge resolves its target by NAME and writes wherever that name lives, so
+        /// nothing about a request distinguishes "modify my object" from "modify the base
+        /// application". The TS modify path checks ownership from the resolved FILE path,
+        /// but that is a different resolution than the one the bridge performs and it is
+        /// not on every route into these methods (batchModify, a direct RPC). This is the
+        /// check at the point of the actual write.
+        /// </summary>
+        private void AssertModelWritable(ModelSaveInfo? msi, string operation, string objectName, string alternative)
+        {
+            if (msi == null || !IsMicrosoftModel(msi.Name)) return;
+            throw new InvalidOperationException(
+                $"Refusing {operation} on '{objectName}': it belongs to Microsoft-shipped model '{msi.Name}'. " +
+                $"Writing into the base application is not repeatable — the next platform update overwrites it. {alternative}");
         }
 
         // ========================
@@ -665,10 +743,15 @@ namespace D365MetadataBridge.Services
                 default: axEdt = new AxEdtString { Name = name }; break;
             }
 
+            // stringSize on a non-string base type is the common miss here (see
+            // SetAxEdtProperty): the EDT is created either way, so report the drop rather
+            // than fail the create — but do not let it pass as applied.
+            var unsupportedProperties = new List<string>();
             if (properties != null)
             {
                 foreach (var kv in properties)
-                    SetAxEdtProperty(axEdt, kv.Key, kv.Value);
+                    if (!SetAxEdtProperty(axEdt, kv.Key, kv.Value))
+                        unsupportedProperties.Add(kv.Key);
             }
 
             var edtProvider = _provider.Edts as IMetaEdtProvider
@@ -676,7 +759,7 @@ namespace D365MetadataBridge.Services
             edtProvider.Create(axEdt, msi);
 
             var filePath = GetExpectedPath("AxEdt", name, modelName);
-            return new { success = true, objectType = "edt", objectName = name, modelName, filePath, api = "IMetaEdtProvider.Create" };
+            return new { success = true, objectType = "edt", objectName = name, modelName, filePath, unsupportedProperties, api = "IMetaEdtProvider.Create" };
         }
 
         /// <summary>
@@ -709,10 +792,14 @@ namespace D365MetadataBridge.Services
             }
             axQuery.Name = name;
 
+            // The concrete subclass decides which of these exist at all (SetAxQueryProperty),
+            // so what could not be written is part of the answer.
+            var unsupportedProperties = new List<string>();
             if (properties != null)
             {
                 foreach (var kv in properties)
-                    SetAxQueryProperty(axQuery, kv.Key, kv.Value);
+                    if (!SetAxQueryProperty(axQuery, kv.Key, kv.Value))
+                        unsupportedProperties.Add(kv.Key);
             }
 
             var queryProvider = _provider.Queries as IMetaQueryProvider
@@ -720,7 +807,7 @@ namespace D365MetadataBridge.Services
             queryProvider.Create(axQuery, msi);
 
             var filePath = GetExpectedPath("AxQuery", name, modelName);
-            return new { success = true, objectType = "query", objectName = name, modelName, filePath, api = "IMetaQueryProvider.Create" };
+            return new { success = true, objectType = "query", objectName = name, modelName, filePath, unsupportedProperties, api = "IMetaQueryProvider.Create" };
         }
 
         /// <summary>
@@ -766,18 +853,14 @@ namespace D365MetadataBridge.Services
                 ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axMI = new AxMenuItemAction { Name = name };
 
-            if (properties != null)
-            {
-                foreach (var kv in properties)
-                    SetAxMenuItemProperty(axMI, kv.Key, kv.Value);
-            }
+            var unsupportedProperties = ApplyMenuItemProperties(axMI, properties);
 
             var provider = _provider.MenuItemActions as IMetaMenuItemActionProvider
                 ?? throw new InvalidOperationException("DiskProvider.MenuItemActions does not implement IMetaMenuItemActionProvider");
             provider.Create(axMI, msi);
 
             var filePath = GetExpectedPath("AxMenuItemAction", name, modelName);
-            return new { success = true, objectType = "menu-item-action", objectName = name, modelName, filePath, api = "IMetaMenuItemActionProvider.Create" };
+            return new { success = true, objectType = "menu-item-action", objectName = name, modelName, filePath, unsupportedProperties, api = "IMetaMenuItemActionProvider.Create" };
         }
 
         /// <summary>
@@ -789,18 +872,14 @@ namespace D365MetadataBridge.Services
                 ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axMI = new AxMenuItemDisplay { Name = name };
 
-            if (properties != null)
-            {
-                foreach (var kv in properties)
-                    SetAxMenuItemProperty(axMI, kv.Key, kv.Value);
-            }
+            var unsupportedProperties = ApplyMenuItemProperties(axMI, properties);
 
             var provider = _provider.MenuItemDisplays as IMetaMenuItemDisplayProvider
                 ?? throw new InvalidOperationException("DiskProvider.MenuItemDisplays does not implement IMetaMenuItemDisplayProvider");
             provider.Create(axMI, msi);
 
             var filePath = GetExpectedPath("AxMenuItemDisplay", name, modelName);
-            return new { success = true, objectType = "menu-item-display", objectName = name, modelName, filePath, api = "IMetaMenuItemDisplayProvider.Create" };
+            return new { success = true, objectType = "menu-item-display", objectName = name, modelName, filePath, unsupportedProperties, api = "IMetaMenuItemDisplayProvider.Create" };
         }
 
         /// <summary>
@@ -812,18 +891,29 @@ namespace D365MetadataBridge.Services
                 ?? throw new ArgumentException($"Model '{modelName}' not found in {_packagesPath}");
             var axMI = new AxMenuItemOutput { Name = name };
 
-            if (properties != null)
-            {
-                foreach (var kv in properties)
-                    SetAxMenuItemProperty(axMI, kv.Key, kv.Value);
-            }
+            var unsupportedProperties = ApplyMenuItemProperties(axMI, properties);
 
             var provider = _provider.MenuItemOutputs as IMetaMenuItemOutputProvider
                 ?? throw new InvalidOperationException("DiskProvider.MenuItemOutputs does not implement IMetaMenuItemOutputProvider");
             provider.Create(axMI, msi);
 
             var filePath = GetExpectedPath("AxMenuItemOutput", name, modelName);
-            return new { success = true, objectType = "menu-item-output", objectName = name, modelName, filePath, api = "IMetaMenuItemOutputProvider.Create" };
+            return new { success = true, objectType = "menu-item-output", objectName = name, modelName, filePath, unsupportedProperties, api = "IMetaMenuItemOutputProvider.Create" };
+        }
+
+        /// <summary>
+        /// Applies a property bag to any of the three menu item types and returns the keys
+        /// that did NOT apply. Shared because Action/Display/Output differ only in their
+        /// provider — the property surface is AxMenuItem's for all three.
+        /// </summary>
+        private List<string> ApplyMenuItemProperties(dynamic axMI, Dictionary<string, string>? properties)
+        {
+            var unsupported = new List<string>();
+            if (properties == null) return unsupported;
+            foreach (var kv in properties)
+                if (!SetAxMenuItemProperty(axMI, kv.Key, kv.Value))
+                    unsupported.Add(kv.Key);
+            return unsupported;
         }
 
         /// <summary>
@@ -2702,7 +2792,20 @@ namespace D365MetadataBridge.Services
         }
 
         /// <summary>
-        /// Renames a field on a table or table-extension. Also fixes index DataField refs, field group refs, and (for tables) TitleField1/2.
+        /// Renames a field on a table or table-extension, repointing every reference to it
+        /// that lives on the same object: indexes, full-text indexes, field groups, relation
+        /// constraints, Map connections and (for tables) TitleField1/2.
+        ///
+        /// Relations, FullTextIndexes and Mappings used to be skipped, and the reported
+        /// success was the whole problem: the rename left them pointing at a field name that
+        /// no longer exists, so the very next build failed on the renamed table while the
+        /// tool had already said ✅ and moved on. Nothing here can be left to the caller —
+        /// a dangling DataField is not a warning in D365FO, it is a compile error.
+        ///
+        /// Out of scope, and deliberately so: references from OTHER objects (a foreign
+        /// table's relation whose RelatedField names this field, forms, X++ code). They are
+        /// separate files under separate model ownership; find_references over the xref
+        /// database is the tool for those.
         /// </summary>
         public object RenameField(string tableName, string oldName, string newName)
         {
@@ -2719,31 +2822,27 @@ namespace D365MetadataBridge.Services
                 if (target == null)
                     throw new InvalidOperationException($"Field '{oldName}' not found on table '{tableName}'");
                 target.Name = newName;
-                // Fix index DataField references
-                foreach (AxTableIndex idx in axTable.Indexes)
+
+                var repointed = new Dictionary<string, int>
                 {
-                    foreach (AxTableIndexField ixf in idx.Fields)
-                    {
-                        if (string.Equals(ixf.DataField, oldName, StringComparison.OrdinalIgnoreCase))
-                            ixf.DataField = newName;
-                    }
-                }
-                // Fix TitleField1/2
+                    ["indexes"] = RepointIndexFields(axTable.Indexes, oldName, newName),
+                    ["fullTextIndexes"] = RepointFullTextIndexFields(axTable.FullTextIndexes, oldName, newName),
+                    ["fieldGroups"] = RepointFieldGroupFields(axTable.FieldGroups, oldName, newName),
+                    ["relationConstraints"] = RepointRelationFields(axTable.Relations, oldName, newName),
+                    ["mappingConnections"] = RepointMappingFields(axTable.Mappings, oldName, newName),
+                };
+
+                // TitleField1/2 hold a field name directly (no wrapper element); extensions
+                // have no equivalent because the base table owns those properties.
+                var titleFields = 0;
                 if (string.Equals(axTable.TitleField1, oldName, StringComparison.OrdinalIgnoreCase))
-                    axTable.TitleField1 = newName;
+                { axTable.TitleField1 = newName; titleFields++; }
                 if (string.Equals(axTable.TitleField2, oldName, StringComparison.OrdinalIgnoreCase))
-                    axTable.TitleField2 = newName;
-                // Fix field group references
-                foreach (AxTableFieldGroup fg in axTable.FieldGroups)
-                {
-                    foreach (AxTableFieldGroupField fgf in fg.Fields)
-                    {
-                        if (string.Equals(fgf.DataField, oldName, StringComparison.OrdinalIgnoreCase))
-                            fgf.DataField = newName;
-                    }
-                }
+                { axTable.TitleField2 = newName; titleFields++; }
+                repointed["titleFields"] = titleFields;
+
                 ((IMetaTableProvider)_provider.Tables).Update(axTable, msi);
-                return new { success = true, operation = "rename-field", objectName = tableName, oldName, newName, api = "IMetaTableProvider.Update" };
+                return new { success = true, operation = "rename-field", objectName = tableName, oldName, newName, repointedReferences = repointed, api = "IMetaTableProvider.Update" };
             }
 
             var axExt = _provider.TableExtensions.Read(tableName);
@@ -2759,31 +2858,138 @@ namespace D365MetadataBridge.Services
                 if (target == null)
                     throw new InvalidOperationException($"Field '{oldName}' not found on table-extension '{tableName}'");
                 target.Name = newName;
-                // Fix index DataField references
-                foreach (AxTableIndex idx in axExt.Indexes)
+
+                // An extension carries the same collections plus two of its own:
+                // FieldGroupExtensions (fields appended to a BASE table's group) and
+                // RelationExtensions (constraints appended to a BASE table's relation).
+                // Both can name a field this extension declares, so both must move too.
+                var repointedExt = new Dictionary<string, int>
                 {
-                    foreach (AxTableIndexField ixf in idx.Fields)
-                    {
-                        if (string.Equals(ixf.DataField, oldName, StringComparison.OrdinalIgnoreCase))
-                            ixf.DataField = newName;
-                    }
-                }
-                // Fix field group references (TitleField1/2 not applicable to extensions)
-                foreach (AxTableFieldGroup fg in axExt.FieldGroups)
-                {
-                    foreach (AxTableFieldGroupField fgf in fg.Fields)
-                    {
-                        if (string.Equals(fgf.DataField, oldName, StringComparison.OrdinalIgnoreCase))
-                            fgf.DataField = newName;
-                    }
-                }
+                    ["indexes"] = RepointIndexFields(axExt.Indexes, oldName, newName),
+                    ["fullTextIndexes"] = RepointFullTextIndexFields(axExt.FullTextIndexes, oldName, newName),
+                    ["fieldGroups"] = RepointFieldGroupFields(axExt.FieldGroups, oldName, newName),
+                    ["relationConstraints"] = RepointRelationFields(axExt.Relations, oldName, newName),
+                    ["mappingConnections"] = RepointMappingFields(axExt.Mappings, oldName, newName),
+                };
+
+                var fieldGroupExtensions = 0;
+                foreach (AxTableFieldGroupExtension fge in axExt.FieldGroupExtensions)
+                    fieldGroupExtensions += RepointFieldGroupFieldList(fge.Fields, oldName, newName);
+                repointedExt["fieldGroupExtensions"] = fieldGroupExtensions;
+
+                var relationExtensions = 0;
+                foreach (AxTableRelationExtension re in axExt.RelationExtensions)
+                    relationExtensions += RepointConstraintFields(re.RelationConstraints, oldName, newName);
+                repointedExt["relationExtensions"] = relationExtensions;
+
                 var extProvider = _provider.TableExtensions as IMetaTableExtensionProvider
                     ?? throw new InvalidOperationException("IMetaTableExtensionProvider not available");
                 extProvider.Update(axExt, msi);
-                return new { success = true, operation = "rename-field", objectName = tableName, oldName, newName, api = "IMetaTableExtensionProvider.Update" };
+                return new { success = true, operation = "rename-field", objectName = tableName, oldName, newName, repointedReferences = repointedExt, api = "IMetaTableExtensionProvider.Update" };
             }
 
             throw new ArgumentException($"Table or table-extension '{tableName}' not found");
+        }
+
+        // ── rename-field reference repointing ──
+        // One helper per collection that can name a table field, each returning how many
+        // references it moved so RenameField can report the repair instead of asserting it.
+
+        private static int RepointIndexFields(IEnumerable<AxTableIndex> indexes, string oldName, string newName)
+        {
+            var moved = 0;
+            foreach (AxTableIndex idx in indexes)
+            {
+                foreach (AxTableIndexField ixf in idx.Fields)
+                {
+                    if (string.Equals(ixf.DataField, oldName, StringComparison.OrdinalIgnoreCase))
+                    { ixf.DataField = newName; moved++; }
+                }
+            }
+            return moved;
+        }
+
+        /// <summary>
+        /// FullTextIndexes is a collection of its own (AxTableFullTextIndex), separate from
+        /// Indexes, but its entries are the same AxTableIndexField elements.
+        /// </summary>
+        private static int RepointFullTextIndexFields(IEnumerable<AxTableFullTextIndex> indexes, string oldName, string newName)
+        {
+            var moved = 0;
+            foreach (AxTableFullTextIndex idx in indexes)
+            {
+                foreach (AxTableIndexField ixf in idx.Fields)
+                {
+                    if (string.Equals(ixf.DataField, oldName, StringComparison.OrdinalIgnoreCase))
+                    { ixf.DataField = newName; moved++; }
+                }
+            }
+            return moved;
+        }
+
+        private static int RepointFieldGroupFields(IEnumerable<AxTableFieldGroup> groups, string oldName, string newName)
+        {
+            var moved = 0;
+            foreach (AxTableFieldGroup fg in groups)
+                moved += RepointFieldGroupFieldList(fg.Fields, oldName, newName);
+            return moved;
+        }
+
+        private static int RepointFieldGroupFieldList(IEnumerable<AxTableFieldGroupField> fields, string oldName, string newName)
+        {
+            var moved = 0;
+            foreach (AxTableFieldGroupField fgf in fields)
+            {
+                if (string.Equals(fgf.DataField, oldName, StringComparison.OrdinalIgnoreCase))
+                { fgf.DataField = newName; moved++; }
+            }
+            return moved;
+        }
+
+        private static int RepointRelationFields(IEnumerable<AxTableRelation> relations, string oldName, string newName)
+        {
+            var moved = 0;
+            foreach (AxTableRelation rel in relations)
+                moved += RepointConstraintFields(rel.Constraints, oldName, newName);
+            return moved;
+        }
+
+        /// <summary>
+        /// Only the LOCAL side of a constraint is ours to rename: Field names a column on
+        /// this table, RelatedField names one on the related table. Two constraint kinds
+        /// carry a local Field (…ConstraintField and …ConstraintFixed); …ConstraintRelatedFixed
+        /// has none. The constraint's own Name is left alone — it is an element identifier the
+        /// compiler never resolves against the field list, so rewriting it would be churn.
+        /// </summary>
+        private static int RepointConstraintFields(IEnumerable<AxTableRelationConstraint> constraints, string oldName, string newName)
+        {
+            var moved = 0;
+            foreach (AxTableRelationConstraint c in constraints)
+            {
+                if (c is AxTableRelationConstraintField cf && string.Equals(cf.Field, oldName, StringComparison.OrdinalIgnoreCase))
+                { cf.Field = newName; moved++; }
+                else if (c is AxTableRelationConstraintFixed cx && string.Equals(cx.Field, oldName, StringComparison.OrdinalIgnoreCase))
+                { cx.Field = newName; moved++; }
+            }
+            return moved;
+        }
+
+        /// <summary>
+        /// In an AxTableMapping connection, MapField names the field on the MAP and MapFieldTo
+        /// names the field on this table — so a local rename moves MapFieldTo only.
+        /// </summary>
+        private static int RepointMappingFields(IEnumerable<AxTableMapping> mappings, string oldName, string newName)
+        {
+            var moved = 0;
+            foreach (AxTableMapping m in mappings)
+            {
+                foreach (AxTableMappingConnection c in m.Connections)
+                {
+                    if (string.Equals(c.MapFieldTo, oldName, StringComparison.OrdinalIgnoreCase))
+                    { c.MapFieldTo = newName; moved++; }
+                }
+            }
+            return moved;
         }
 
         /// <summary>Removes a field from a table or table-extension.</summary>
@@ -2883,6 +3089,13 @@ namespace D365MetadataBridge.Services
         /// only take new values through an AxEnumExtension, so without it the ONLY write
         /// path to a shipped enum was create-time (CreateEnumExtension) — an extension with
         /// a wrong or missing value had no repair path at all.
+        ///
+        /// Base-first resolution is what makes the ownership guard necessary here rather
+        /// than optional. Ask for a value on "SalesStatus" and Enums.Read hits Microsoft's
+        /// enum; the extension branch is never reached, because an extension is named
+        /// "SalesStatus.&lt;Something&gt;Extension" and no caller asking for the base ever
+        /// spells that. So the natural request — "add a value to this shipped enum" — wrote
+        /// the value straight into ApplicationSuite and reported success.
         /// </summary>
         public object AddEnumValue(string enumName, string valueName, int value, string? label, string? countryRegionCodes = null)
         {
@@ -2894,6 +3107,9 @@ namespace D365MetadataBridge.Services
             if (axEnum != null)
             {
                 var msi = GetModelSaveInfoForObject(_provider.Enums, enumName);
+                AssertModelWritable(msi, "add-enum-value", enumName,
+                    $"Extend it instead: create an enum-extension of '{enumName}' in your own model " +
+                    "(the base enum must have IsExtensible=Yes), then add the value to that extension.");
                 axEnum.AddEnumValue(axVal);
                 ((IMetaEnumProvider)_provider.Enums).Update(axEnum, msi);
                 return new { success = true, operation = "add-enum-value", objectName = enumName, valueName, value, api = "IMetaEnumProvider.Update" };
@@ -2903,6 +3119,10 @@ namespace D365MetadataBridge.Services
             if (axExt != null)
             {
                 var msi = GetModelSaveInfoForObject(_provider.EnumExtensions, enumName);
+                // An extension is the sanctioned route, but not when the extension itself is
+                // Microsoft's — that is still the base application.
+                AssertModelWritable(msi, "add-enum-value", enumName,
+                    "Create your own enum-extension of the same base enum and add the value there.");
                 axExt.EnumValues.Add(axVal);
                 var extProvider = _provider.EnumExtensions as IMetaEnumExtensionProvider
                     ?? throw new InvalidOperationException("IMetaEnumExtensionProvider not available");
@@ -3192,11 +3412,18 @@ namespace D365MetadataBridge.Services
                     "Pass parentControl=\"Design\" (or omit it) to add a control at the top level of the form design.");
 
             // Create the control using reflection (AxFormControl is abstract)
-            var control = CreateFormControl(controlType, controlName, dataSource, dataField, label);
+            var control = CreateFormControl(controlType, controlName, dataSource, dataField, label, out var unsupportedProperties);
             AddChildControl(parent, control);
 
             ((IMetaFormProvider)_provider.Forms).Update(axForm, msi);
-            return new { success = true, operation = "add-control", objectName = formName, controlName, parentControl, controlType, api = "IMetaFormProvider.Update" };
+            return new
+            {
+                success = true, operation = "add-control", objectName = formName, controlName, parentControl, controlType,
+                // Same contract as the create ops: what was asked for and did NOT apply is
+                // named, so an unbound control cannot pass for a bound one.
+                unsupportedProperties,
+                api = "IMetaFormProvider.Update",
+            };
         }
 
         /// <summary>
@@ -3449,7 +3676,14 @@ namespace D365MetadataBridge.Services
                 case "helptext": edt.HelpText = value; break;
                 case "extends": edt.Extends = value; break;
                 case "stringsize":
-                    if (edt is AxEdtString strEdt && int.TryParse(value, out var ss)) strEdt.StringSize = ss;
+                    // Only AxEdtString has a StringSize. On an int/real/enum EDT there is
+                    // nowhere to put it — which used to fall straight through to `return true`,
+                    // so "set stringSize=60" on the wrong base type reported success over an
+                    // EDT whose length never changed.
+                    if (edt is not AxEdtString strEdt) return false;
+                    if (!int.TryParse(value, out var ss))
+                        throw new ArgumentException($"stringSize must be an integer — got '{value}'.");
+                    strEdt.StringSize = ss;
                     break;
                 case "referencetable": edt.ReferenceTable = value; break;
                 case "basetype": break; // handled at construction time
@@ -3464,16 +3698,23 @@ namespace D365MetadataBridge.Services
         {
             // AxQuery is abstract — properties may vary by subclass. Use dynamic for safety.
             dynamic dq = q;
+            // A subclass that does not carry the property throws on the assignment. That is a
+            // property NOT written, so it returns false (the caller turns that into an error /
+            // an unsupportedProperties entry) — it used to be caught, logged and reported as
+            // applied, which is the same hollow success as an unknown key.
             switch (prop.ToLowerInvariant())
             {
                 case "title":
-                    try { dq.Title = value; } catch { Console.Error.WriteLine($"[WriteService] AxQuery.Title not available on this subclass"); }
+                    try { dq.Title = value; }
+                    catch { Console.Error.WriteLine($"[WriteService] AxQuery.Title not available on this subclass"); return false; }
                     break;
                 case "description":
-                    try { dq.Description = value; } catch { Console.Error.WriteLine($"[WriteService] AxQuery.Description not available on this subclass"); }
+                    try { dq.Description = value; }
+                    catch { Console.Error.WriteLine($"[WriteService] AxQuery.Description not available on this subclass"); return false; }
                     break;
                 case "allowcrosscompany":
-                    try { dq.AllowCrossCompany = ParseNoYes(value); } catch { Console.Error.WriteLine($"[WriteService] AxQuery.AllowCrossCompany not available"); }
+                    try { dq.AllowCrossCompany = ParseNoYes(value); }
+                    catch { Console.Error.WriteLine($"[WriteService] AxQuery.AllowCrossCompany not available"); return false; }
                     break;
                 default:
                     Console.Error.WriteLine($"[WriteService] Unknown AxQuery property: {prop}");
@@ -3539,13 +3780,24 @@ namespace D365MetadataBridge.Services
                 case "label": mi.Label = value; break;
                 case "helptext": mi.HelpText = value; break;
                 case "object": mi.Object = value; break;
+                // A value the enum does not know is rejected with the legal ones, the way
+                // TableType / EntityCategory already are. Swallowing the failed parse left the
+                // property at its metamodel default and reported success, so a menu item asked
+                // for ObjectType=Form silently shipped pointing at nothing — and the caller
+                // only found out when the menu item did not open.
                 case "objecttype":
-                    if (Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.MenuItemObjectType>(value, true, out var ot))
-                        mi.ObjectType = ot;
+                    if (!Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.MenuItemObjectType>(value, true, out var ot))
+                        throw new ArgumentException(
+                            $"'{value}' is not a valid menu item ObjectType. Valid values: " +
+                            string.Join(", ", Enum.GetNames(typeof(Microsoft.Dynamics.AX.Metadata.Core.MetaModel.MenuItemObjectType))) + ".");
+                    mi.ObjectType = ot;
                     break;
                 case "openmode":
-                    if (Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.OpenMode>(value, true, out var om))
-                        mi.OpenMode = om;
+                    if (!Enum.TryParse<Microsoft.Dynamics.AX.Metadata.Core.MetaModel.OpenMode>(value, true, out var om))
+                        throw new ArgumentException(
+                            $"'{value}' is not a valid menu item OpenMode. Valid values: " +
+                            string.Join(", ", Enum.GetNames(typeof(Microsoft.Dynamics.AX.Metadata.Core.MetaModel.OpenMode))) + ".");
+                    mi.OpenMode = om;
                     break;
                 case "normalimage": mi.NormalImage = value; break;
                 case "imagelocation":
@@ -3918,7 +4170,7 @@ namespace D365MetadataBridge.Services
 
         /// <summary>Creates a form control of the specified type.</summary>
         private dynamic CreateFormControl(string controlType, string controlName,
-            string? dataSource, string? dataField, string? label)
+            string? dataSource, string? dataField, string? label, out List<string> unsupportedProperties)
         {
             // D365FO form control classes follow the naming convention AxForm{Type}Control
             // (e.g. AxFormStringControl, AxFormRealControl, AxFormGridControl) — verified
@@ -3975,17 +4227,27 @@ namespace D365MetadataBridge.Services
 
             dynamic ctrl = Activator.CreateInstance(ctrlType)!;
             ctrl.Name = controlName;
+
+            // Not every AxForm*Control carries these: a Group, Tab or CommandButton has no
+            // DataSource/DataField, and the assignment throws. Swallowing that produced the
+            // worst possible outcome — an UNBOUND control reported as added and bound, which
+            // renders as an empty control on the form and reads as a working one in the tool
+            // output. Report what did not stick; the caller decides whether that is fatal.
+            unsupportedProperties = new List<string>();
             if (!string.IsNullOrEmpty(dataSource))
             {
-                try { ctrl.DataSource = dataSource; } catch { }
+                try { ctrl.DataSource = dataSource; }
+                catch { unsupportedProperties.Add("dataSource"); }
             }
             if (!string.IsNullOrEmpty(dataField))
             {
-                try { ctrl.DataField = dataField; } catch { }
+                try { ctrl.DataField = dataField; }
+                catch { unsupportedProperties.Add("dataField"); }
             }
             if (!string.IsNullOrEmpty(label))
             {
-                try { ctrl.Label = label; } catch { }
+                try { ctrl.Label = label; }
+                catch { unsupportedProperties.Add("label"); }
             }
             return ctrl;
         }

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "f6da40c4b39c39c05833f9ec284084794319f5f51b68d6a798db460783700b7c",
+  "sourceHash": "fc8dfdadbe129faac0ffda646c8655c0acb9997cac90bb7524550350448d7b01",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7858.27",
-  "builtAt": "2026-08-04T05:49:49.967Z"
+  "metamodelFileVersion": "7.0.7996.33",
+  "builtAt": "2026-08-08T12:10:57.977Z"
 }

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -1222,6 +1222,20 @@ const BRIDGE_MODIFY_TYPES = new Set([
 ]);
 
 /**
+ * Names the properties the bridge could not write, for appending to a success message.
+ *
+ * The C# side has reported `unsupportedProperties` for a while, but nothing on this side
+ * read it: an EDT whose stringSize had nowhere to go, or a Group control that cannot hold
+ * the DataSource it was handed, still produced a bare ✅. Reporting it in C# and dropping
+ * it here is the same silence with more steps.
+ */
+export function unappliedSuffix(result: { unsupportedProperties?: string[] }): string {
+  const dropped = result.unsupportedProperties ?? [];
+  if (dropped.length === 0) return '';
+  return `\n⚠️ NOT applied — this object type has nowhere to store them: ${dropped.join(', ')}`;
+}
+
+/**
  * Checks if bridge can handle this create operation.
  */
 export function canBridgeCreate(objectType: string): boolean {
@@ -1264,7 +1278,7 @@ export async function bridgeCreateObject(
       return {
         success: true,
         filePath: result.filePath,
-        message: `✅ Created via ${result.api ?? 'IMetadataProvider'} — file: ${result.filePath}`,
+        message: `✅ Created via ${result.api ?? 'IMetadataProvider'} — file: ${result.filePath}` + unappliedSuffix(result),
       };
     } else {
       return { success: false, message: `Bridge createObject returned success=false` };
@@ -1934,7 +1948,7 @@ export async function bridgeAddControl(
     return {
       success: result.success,
       message: result.success
-        ? `✅ Control '${controlName}' added to '${parentControl}' via ${result.api}`
+        ? `✅ Control '${controlName}' added to '${parentControl}' via ${result.api}` + unappliedSuffix(result)
         : `Bridge addControl returned success=false`,
     };
   } catch (e) {

--- a/src/bridge/bridgeClient.ts
+++ b/src/bridge/bridgeClient.ts
@@ -89,6 +89,8 @@ const MAX_RESTARTS = envInt('BRIDGE_MAX_RESTARTS', 3);              // max child
 const RESTART_WINDOW_MS = 60_000;
 const PING_TIMEOUT_MS = 5_000;
 const RETRY_BASE_DELAY_MS = 250;
+const KILL_GRACE_MS = envInt('BRIDGE_KILL_GRACE_MS', 2_000);        // stdin-end → SIGTERM
+const KILL_HARD_MS = envInt('BRIDGE_KILL_HARD_MS', 3_000);          // SIGTERM → SIGKILL, and SIGKILL → give up
 
 /**
  * Methods safe to auto-retry on timeout/pipe error: idempotent READS only.
@@ -105,13 +107,23 @@ const RETRYABLE_METHODS = new Set([
   'findApiUsageCallers', 'resolveObjectInfo', 'validateObject', 'discoverFormPatterns',
 ]);
 
-/** Errors that indicate a transient transport problem (vs. a deterministic bridge error). */
-function isTransientError(err: unknown): boolean {
+/**
+ * Errors that indicate a transient transport problem (vs. a deterministic bridge error).
+ *
+ * Exported for the lifecycle test, which derives the message the child-exit handler
+ * actually produces and checks it lands here: the two used to disagree. This matched
+ * only the phrase "exited unexpectedly", which no code path ever emitted — the exit
+ * handler said "Bridge process exited before becoming ready", so a child that crashed
+ * with a READ in flight (the AOS metadata provider dying mid-query is the common case)
+ * was classified as a deterministic failure and thrown at the caller instead of being
+ * retried against a respawned child.
+ */
+export function isTransientError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return (
     msg.includes('timed out') ||
     msg.includes('Bridge is not ready') ||
-    msg.includes('exited unexpectedly') ||
+    msg.includes('Bridge process exited') ||
     msg.includes('Bridge process error') ||
     msg.includes('Failed to write to bridge stdin') ||
     msg.includes('Bridge restarting')
@@ -120,6 +132,23 @@ function isTransientError(err: unknown): boolean {
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * True when `promise` settled within `ms`. The timer is cleared on the fast path so
+ * a pending kill-escalation deadline cannot hold the event loop open after the child
+ * has already exited.
+ */
+async function settledWithin(promise: Promise<unknown>, ms: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), ms);
+  });
+  try {
+    return await Promise.race([promise.then(() => true), expired]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export interface BridgeClientOptions {
@@ -239,7 +268,9 @@ export class BridgeClient extends EventEmitter {
     return new Promise<BridgeReadyPayload>((resolve, reject) => {
       const timeout = setTimeout(() => {
         // Kill only the child; the client stays usable for a later restart()/dispose().
-        this.killChild();
+        // Not awaited — this rejects the ready promise now and lets the escalation
+        // run behind it; a later dispose() has nothing left to wait for either way.
+        void this.killChild();
         reject(new Error(`Bridge process did not become ready within ${this.options.readyTimeoutMs ?? READY_TIMEOUT_MS}ms`));
       }, this.options.readyTimeoutMs ?? READY_TIMEOUT_MS);
 
@@ -345,9 +376,14 @@ export class BridgeClient extends EventEmitter {
         clearTimeout(timeout);
         this._isReady = false;
         console.error(`[BridgeClient] Process exited: code=${code}, signal=${signal}`);
-        const exitErr = new Error(`Bridge process exited before becoming ready: code=${code}, signal=${signal}`);
-        this.rejectAllPending(exitErr);
-        reject(exitErr);
+        // Two different audiences, two different truths. The spawn promise only
+        // matters before ready, so "before becoming ready" is right there. In-flight
+        // calls are the opposite case — the child was up and serving them — and they
+        // must get a message isTransientError() recognises, or a read that was in the
+        // pipe when the child crashed is reported as a hard failure instead of being
+        // retried against a respawned child.
+        this.rejectAllPending(new Error(`Bridge process exited unexpectedly: code=${code}, signal=${signal}`));
+        reject(new Error(`Bridge process exited before becoming ready: code=${code}, signal=${signal}`));
       });
     });
   }
@@ -465,7 +501,9 @@ export class BridgeClient extends EventEmitter {
     this.restartPromise = (async () => {
       console.error('[BridgeClient] Restarting bridge child process…');
       this.rejectAllPending(new Error('Bridge restarting'));
-      this.killChild();
+      // Awaited: respawning while the old child still holds the packages directory
+      // is what a restart exists to get away from.
+      await this.killChild();
       this._isReady = false;
       this.readyPayload = null;
       this.buffer = '';
@@ -497,8 +535,17 @@ export class BridgeClient extends EventEmitter {
     if (typeof this.healthTimer.unref === 'function') this.healthTimer.unref();
   }
 
-  /** Gracefully shut down the bridge process */
-  dispose(): void {
+  /**
+   * Gracefully shut down the bridge process.
+   *
+   * Awaitable, and the shutdown coordinator does await it: the escalation below is
+   * driven by timers, and unref'd timers scheduled by a synchronous dispose() never
+   * get to fire — the process exits first. A child that had gone unresponsive was
+   * therefore left running with the packages directory open, so the next server start
+   * met a second bridge holding the same metadata, and the user met an orphan they
+   * had to find in Task Manager.
+   */
+  async dispose(): Promise<void> {
     if (this._disposed) return;
     this._disposed = true;
     this._isReady = false;
@@ -508,31 +555,38 @@ export class BridgeClient extends EventEmitter {
       this.healthTimer = null;
     }
     this.rejectAllPending(new Error('BridgeClient disposed'));
-    this.killChild();
+    await this.killChild();
   }
 
-  /** Kill the current child process (used by dispose and restart). */
-  private killChild(): void {
-    // Capture the reference before clearing this.process so the deferred SIGTERM closure retains it.
+  /**
+   * Kill the current child process (used by dispose and restart), escalating until
+   * it is actually gone: end stdin so it can finish an in-flight AOT write, then
+   * SIGTERM, then SIGKILL. Resolves when the child exits, or after the last step's
+   * budget — shutdown must not be the thing that hangs.
+   */
+  private async killChild(): Promise<void> {
+    // Capture the reference before clearing this.process so the exit listener below
+    // (and any late event from the replaced child) cannot touch its successor.
     const child = this.process;
     this.process = null;
-    if (child) {
-      try {
-        child.stdin?.end();
-        const graceful = setTimeout(() => {
-          if (!child.killed) {
-            try { child.kill('SIGTERM'); } catch { /* already gone */ }
-          }
-        }, 2000);
-        // SIGKILL fallback if SIGTERM did not terminate within another 3s.
-        const hard = setTimeout(() => {
-          if (!child.killed) {
-            try { child.kill('SIGKILL'); } catch { /* already gone */ }
-          }
-        }, 5000);
-        if (typeof graceful.unref === 'function') graceful.unref();
-        if (typeof hard.unref === 'function') hard.unref();
-      } catch { /* ignore */ }
+    if (!child) return;
+    if (child.exitCode !== null || child.signalCode !== null) return;
+
+    const exited = new Promise<void>((resolve) => {
+      child.once('exit', () => resolve());
+    });
+
+    try { child.stdin?.end(); } catch { /* pipe already gone */ }
+    if (await settledWithin(exited, KILL_GRACE_MS)) return;
+
+    console.error('[BridgeClient] Child did not exit on stdin close — sending SIGTERM');
+    try { child.kill('SIGTERM'); } catch { /* already gone */ }
+    if (await settledWithin(exited, KILL_HARD_MS)) return;
+
+    console.error('[BridgeClient] Child survived SIGTERM — sending SIGKILL');
+    try { child.kill('SIGKILL'); } catch { /* already gone */ }
+    if (!(await settledWithin(exited, KILL_HARD_MS))) {
+      console.error(`[BridgeClient] Child pid=${child.pid} did not die after SIGKILL — abandoning it`);
     }
   }
 
@@ -992,7 +1046,7 @@ export async function createBridgeClient(options: {
     return client;
   } catch (err) {
     console.error(`[BridgeClient] Initialization failed: ${err}`);
-    client.dispose();
+    await client.dispose();
     return null;
   }
 }

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -441,6 +441,12 @@ export interface BridgeWriteResult {
   fieldType?: string;
   propertyPath?: string;
   propertyValue?: string;
+  /**
+   * Properties the caller asked for that the bridge could NOT write — an EDT stringSize
+   * on a non-string base type, a DataSource on a control that has none. Present on the
+   * create ops and on add-control; the write itself still succeeded.
+   */
+  unsupportedProperties?: string[];
   api?: string;
 }
 

--- a/tests/bridge/bridgeLifecycle.test.ts
+++ b/tests/bridge/bridgeLifecycle.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Bridge lifecycle regressions (audit finding #26).
+ *
+ * Four separate ways the bridge's life cycle leaked state, all of which end in the same
+ * place — a bridge that answers wrongly or not at all, from a server that thinks it is
+ * healthy:
+ *
+ *   (i)   a child crash was classified as a deterministic error, so an in-flight READ was
+ *         surfaced as a hard failure instead of being retried against a respawned child;
+ *   (ii)  dispose() scheduled its SIGTERM/SIGKILL escalation on unref'd timers and returned
+ *         immediately, so a wedged child outlived the server that spawned it;
+ *   (iii) RefreshProvider() replaced the DiskProvider without releasing the old one, and
+ *         every write triggers a refresh;
+ *   (iv)  the write service's model cache survived UpdateProvider(), so a ModelSaveInfo
+ *         derived from a descriptor (Id=SequenceId, SequenceId=0 — the shape that makes
+ *         IMetadataProvider.Create() throw NullReferenceException) was served forever, and
+ *         the refresh that would have fixed it changed nothing.
+ *
+ * (i) and (ii) are testable here. (iii) and (iv) live in C# that only runs on a D365FO VM,
+ * so they are guarded the way the repo already guards C# invariants: by reading the source.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { EventEmitter } from 'events';
+import { BridgeClient, isTransientError } from '../../src/bridge/bridgeClient';
+import { READ_SERVICE_CS, WRITE_SERVICE_CS, readStripped, methodBody } from './csharpSource';
+
+const BRIDGE_CLIENT_TS = path.join(
+  path.resolve(__dirname, '..', '..'),
+  'src', 'bridge', 'bridgeClient.ts',
+);
+
+function makeClient(): BridgeClient {
+  const client = new BridgeClient({ packagesPath: 'C:\\NonExistent', maxRetries: 2 });
+  (client as any)._isReady = true;
+  return client;
+}
+
+describe('child crash classification', () => {
+  /**
+   * Derived from the source rather than hard-coded: the defect was precisely that the
+   * message the exit handler produces and the message isTransientError() looks for had
+   * drifted apart, and a literal copied into the test would drift the same way.
+   */
+  function childExitMessage(): string {
+    const source = fs.readFileSync(BRIDGE_CLIENT_TS, 'utf8');
+    const handler = source.slice(source.indexOf("child.on('exit'"), source.indexOf("child.on('exit'") + 1500);
+
+    const call = handler.match(/rejectAllPending\(\s*([\s\S]*?)\s*\);/);
+    expect(call, 'the exit handler no longer rejects in-flight calls via rejectAllPending').toBeTruthy();
+
+    // The message is either inline or held in a local — accept both, so this measures the
+    // wording rather than the shape of the statement that carries it.
+    const arg = call![1].trim();
+    let template = arg.match(/new Error\(`([^`]+)`\)/)?.[1];
+    if (!template && /^\w+$/.test(arg)) {
+      template = handler.match(new RegExp(`(?:const|let)\\s+${arg}\\s*=\\s*new Error\\(\`([^\`]+)\``))?.[1];
+    }
+    expect(template, `could not read the message rejectAllPending is given: ${arg}`).toBeTruthy();
+
+    return template!.replace(/\$\{code\}/g, '3221225477').replace(/\$\{signal\}/g, 'null');
+  }
+
+  it('treats the message in-flight calls get on a child crash as transient', () => {
+    const message = childExitMessage();
+    expect(
+      isTransientError(new Error(message)),
+      `a crash reported as "${message}" is not recognised as transient — an in-flight read ` +
+        'is thrown at the caller instead of being retried against a respawned child',
+    ).toBe(true);
+  });
+
+  it('retries a read whose child died mid-call', async () => {
+    const client = makeClient();
+    const callOnce = vi.fn()
+      .mockRejectedValueOnce(new Error(childExitMessage()))
+      .mockResolvedValueOnce({ name: 'CustTable' });
+    (client as any).callOnce = callOnce;
+    (client as any).ensureHealthy = vi.fn().mockResolvedValue(undefined);
+
+    await expect(client.call('readTable', { tableName: 'CustTable' })).resolves.toEqual({ name: 'CustTable' });
+    expect(callOnce).toHaveBeenCalledTimes(2);
+  });
+
+  it('still refuses to retry a write whose child died mid-call', async () => {
+    const client = makeClient();
+    const callOnce = vi.fn().mockRejectedValue(new Error(childExitMessage()));
+    (client as any).callOnce = callOnce;
+    (client as any).ensureHealthy = vi.fn();
+
+    await expect(client.call('createObject', {})).rejects.toThrow('exited');
+    expect(callOnce).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('dispose', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** A child that ignores stdin close and every signal — the wedged case dispose exists for. */
+  function unresponsiveChild() {
+    const child = new EventEmitter() as any;
+    child.pid = 4242;
+    child.exitCode = null;
+    child.signalCode = null;
+    child.stdin = { end: vi.fn(), writable: true };
+    child.kill = vi.fn();
+    return child;
+  }
+
+  it('escalates to SIGTERM then SIGKILL and resolves rather than hanging', async () => {
+    vi.useFakeTimers();
+    const client = makeClient();
+    const child = unresponsiveChild();
+    (client as any).process = child;
+
+    const pending = client.dispose();
+    expect(
+      typeof (pending as any)?.then,
+      'dispose() must be awaitable — an escalation scheduled by a synchronous dispose never ' +
+        'runs, because the process exits before the timers fire',
+    ).toBe('function');
+
+    let settled = false;
+    void pending.then(() => { settled = true; });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(child.stdin.end).toHaveBeenCalled();
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it('resolves as soon as the child exits, without escalating', async () => {
+    vi.useFakeTimers();
+    const client = makeClient();
+    const child = unresponsiveChild();
+    child.stdin.end = vi.fn(() => { setTimeout(() => child.emit('exit', 0, null), 10); });
+    (client as any).process = child;
+
+    const pending = client.dispose();
+    await vi.advanceTimersByTimeAsync(50);
+    await pending;
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+});
+
+describe('C# provider lifecycle (source parity)', () => {
+  let readService: string;
+  let writeService: string;
+
+  beforeAll(() => {
+    readService = readStripped(READ_SERVICE_CS);
+    writeService = readStripped(WRITE_SERVICE_CS);
+  });
+
+  it('RefreshProvider releases the DiskProvider it replaces', () => {
+    const body = methodBody(readService, 'public object RefreshProvider()');
+    expect(
+      body,
+      'RefreshProvider builds a new DiskProvider without releasing the old one — and every ' +
+        'write auto-refreshes, so an authoring session accumulates providers holding the ' +
+        'whole packages directory open until the bridge stops answering',
+    ).toMatch(/Dispose/);
+  });
+
+  it('UpdateProvider drops the caches read off the previous provider', () => {
+    const body = methodBody(writeService, 'public void UpdateProvider(IMetadataProvider newProvider)');
+    expect(
+      body,
+      '_modelCache survives UpdateProvider — a descriptor-derived ModelSaveInfo (SequenceId=0) ' +
+        'cached before the model reached the manifest keeps NREing IMetadataProvider.Create() ' +
+        'no matter how many times the provider is refreshed',
+    ).toContain('_modelCache.Clear()');
+    expect(body).toContain('_microsoftModelCache.Clear()');
+  });
+});

--- a/tests/bridge/bridgeResilience.test.ts
+++ b/tests/bridge/bridgeResilience.test.ts
@@ -150,6 +150,10 @@ describe('restart', () => {
 
     const p1 = client.restart();
     const p2 = client.restart();
+    // restart() awaits killChild before respawning (it must not build a second child while
+    // the old one still holds the packages directory), so the spawn stub only runs — and
+    // only then hands back resolveSpawn — a turn of the event loop later.
+    await new Promise(resolve => setImmediate(resolve));
     resolveSpawn();
     await Promise.all([p1, p2]);
     expect(spawnAndWaitReady).toHaveBeenCalledTimes(1);

--- a/tests/bridge/csharpSource.ts
+++ b/tests/bridge/csharpSource.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared loader for the C#-source parity tests.
+ *
+ * The bridge's behaviour is not reachable from vitest — D365MetadataBridge.exe only runs
+ * on a Windows VM with D365FO installed — so the repo's standing guard for C#-side
+ * invariants is a TypeScript test that reads the C# source (see
+ * tests/bridge/addFieldDispatchParity.test.ts for the original of the pattern).
+ *
+ * Comments are stripped before any assertion runs. Without that, these tests are trivially
+ * satisfiable by the explanatory comment describing the fix — which is exactly the text a
+ * later refactor is most likely to leave behind after deleting the code it describes.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BRIDGE_DIR = path.join(path.resolve(__dirname, '..', '..'), 'bridge', 'D365MetadataBridge');
+
+export const WRITE_SERVICE_CS = path.join(BRIDGE_DIR, 'Services', 'MetadataWriteService.cs');
+export const READ_SERVICE_CS = path.join(BRIDGE_DIR, 'Services', 'MetadataReadService.cs');
+export const XREF_SERVICE_CS = path.join(BRIDGE_DIR, 'Services', 'CrossReferenceService.cs');
+
+/**
+ * Removes `//` line comments and block comments, leaving string and char literals intact
+ * (a `//` inside a literal is data, not a comment). Newlines are preserved so the result
+ * still slices cleanly by method.
+ */
+export function stripComments(source: string): string {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    if (c === '"' || c === "'") {
+      // Verbatim strings (@"…") escape a quote by doubling it, not with a backslash.
+      const verbatim = c === '"' && source[i - 1] === '@';
+      out += c;
+      i++;
+      while (i < source.length) {
+        if (!verbatim && source[i] === '\\') { out += source[i] + (source[i + 1] ?? ''); i += 2; continue; }
+        if (source[i] === c) {
+          if (verbatim && source[i + 1] === c) { out += c + c; i += 2; continue; }
+          out += c;
+          i++;
+          break;
+        }
+        out += source[i];
+        i++;
+      }
+      continue;
+    }
+
+    if (c === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') i++;
+      continue;
+    }
+
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        if (source[i] === '\n') out += '\n';
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+/** Comment-stripped contents of a C# source file. */
+export function readStripped(file: string): string {
+  return stripComments(fs.readFileSync(file, 'utf8'));
+}
+
+/**
+ * The body of a C# method, from its signature to the matching closing brace.
+ * `signature` must be a distinctive fragment of the declaration line.
+ */
+export function methodBody(source: string, signature: string): string {
+  const start = source.indexOf(signature);
+  if (start === -1) throw new Error(`method not found in C# source: ${signature}`);
+  const open = source.indexOf('{', start);
+  if (open === -1) throw new Error(`no body found for: ${signature}`);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces after: ${signature}`);
+}

--- a/tests/bridge/writeCorrectnessParity.test.ts
+++ b/tests/bridge/writeCorrectnessParity.test.ts
@@ -1,0 +1,167 @@
+/**
+ * MetadataWriteService correctness guards (audit findings #13, #17, #28).
+ *
+ * All three are the same class of defect — the bridge reports ✅ over a write that did not
+ * do what was asked — and none of them can be reproduced from vitest, because the write
+ * service only runs against a real D365FO metadata provider on a Windows VM. So they are
+ * guarded the way the repo already guards C# invariants: by reading the C# source, with
+ * comments stripped so the explanation of a fix cannot stand in for the fix.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { WRITE_SERVICE_CS, readStripped, methodBody } from './csharpSource';
+
+let source: string;
+
+beforeAll(() => {
+  source = readStripped(WRITE_SERVICE_CS);
+});
+
+describe('#13 rename-field repoints every reference on the object', () => {
+  let body: string;
+
+  beforeAll(() => {
+    body = methodBody(source, 'public object RenameField(string tableName, string oldName, string newName)');
+  });
+
+  // Each of these names a field, and a stale one is a compile error on the next build —
+  // not a warning — while rename-field had already reported success.
+  it.each([
+    ['indexes', 'RepointIndexFields'],
+    ['full-text indexes', 'RepointFullTextIndexFields'],
+    ['field groups', 'RepointFieldGroupFields'],
+    ['relation constraints', 'RepointRelationFields'],
+    ['Map connections', 'RepointMappingFields'],
+  ])('repoints %s', (_label, helper) => {
+    const calls = body.match(new RegExp(`${helper}\\(`, 'g')) ?? [];
+    expect(
+      calls.length,
+      `RenameField does not call ${helper} on both the table and the table-extension branch — ` +
+        'the rename leaves references pointing at a field name that no longer exists, and the ' +
+        'table stops compiling while the tool reports success',
+    ).toBe(2);
+  });
+
+  it('repoints the extension-only collections too', () => {
+    expect(body).toContain('FieldGroupExtensions');
+    expect(body).toContain('RelationExtensions');
+  });
+
+  it('reports what it repointed instead of only asserting success', () => {
+    const returns = body.match(/repointedReferences/g) ?? [];
+    expect(returns.length, 'both rename-field branches must report the references they moved').toBe(2);
+  });
+
+  it('moves only the LOCAL side of a relation constraint', () => {
+    const helper = methodBody(source, 'private static int RepointConstraintFields(');
+    // RelatedField names a column on the OTHER table; rewriting it here would point a
+    // working constraint at a field that does not exist there.
+    expect(helper).toContain('cf.Field = newName');
+    expect(helper).not.toContain('RelatedField = newName');
+  });
+
+  it('moves only MapFieldTo in a Map connection', () => {
+    const helper = methodBody(source, 'private static int RepointMappingFields(');
+    // MapField names the field on the MAP; only MapFieldTo names one on this table.
+    expect(helper).toContain('c.MapFieldTo = newName');
+    expect(helper).not.toContain('c.MapField = newName');
+  });
+});
+
+describe('#17 add-enum-value ownership guard', () => {
+  it('refuses both branches when the target lives in a Microsoft model', () => {
+    const body = methodBody(
+      source,
+      'public object AddEnumValue(string enumName, string valueName, int value, string? label, string? countryRegionCodes = null)',
+    );
+    const guards = body.match(/AssertModelWritable\(/g) ?? [];
+    expect(
+      guards.length,
+      'AddEnumValue resolves the BASE enum first, so asking for a value on a shipped enum ' +
+        'writes straight into Microsoft\'s model and reports success — both the enum and the ' +
+        'enum-extension branch need the guard',
+    ).toBe(2);
+  });
+
+  it('decides ownership from the model manifest publisher, and defaults to allowing the write', () => {
+    const body = methodBody(source, 'private bool IsMicrosoftModel(string? modelName)');
+    // Publisher, not a hard-coded model list (which goes stale every release) and not the
+    // layer (Microsoft ships the Tutorial model in the usr layer).
+    expect(body).toContain('Publisher');
+    expect(
+      body,
+      'the verdict must start at false so an unreadable manifest cannot start refusing writes ' +
+        'that work today — a false positive would block a customer\'s own model with no way out',
+    ).toContain('var isMicrosoft = false;');
+  });
+
+  it('throws rather than reporting a skipped write as success', () => {
+    const body = methodBody(source, 'private void AssertModelWritable(');
+    expect(body).toContain('throw new InvalidOperationException');
+  });
+});
+
+describe('#28 property setters report what they could not write', () => {
+  it('EDT stringSize fails on a non-string base type instead of returning true', () => {
+    const body = methodBody(source, 'private bool SetAxEdtProperty(AxEdt edt, string prop, string value)');
+    const stringSize = body.slice(body.indexOf('case "stringsize":'), body.indexOf('case "referencetable":'));
+    expect(
+      stringSize,
+      'stringSize on an int/real/enum EDT has nowhere to go; falling through to `return true` ' +
+        'reports a length that was never written',
+    ).toMatch(/return false/);
+  });
+
+  it('menu-item enum values are rejected with the legal ones, not silently dropped', () => {
+    const body = methodBody(source, 'private bool SetAxMenuItemProperty(dynamic mi, string prop, string value)');
+    for (const [prop, marker] of [['objecttype', 'MenuItemObjectType'], ['openmode', 'OpenMode']]) {
+      const arm = body.slice(body.indexOf(`case "${prop}":`));
+      const armBody = arm.slice(0, arm.indexOf('break;'));
+      expect(
+        armBody,
+        `an unparseable ${prop} left the property at its metamodel default and reported success — ` +
+          'the menu item then shipped pointing at nothing',
+      ).toContain('throw new ArgumentException');
+      expect(armBody).toContain(marker);
+    }
+  });
+
+  it('AxQuery subclass misses are reported, not caught and passed off as applied', () => {
+    const body = methodBody(source, 'private bool SetAxQueryProperty(AxQuery q, string prop, string value)');
+    const swallowed = body.match(/catch \{ Console\.Error\.WriteLine\([^)]*\); \}/g) ?? [];
+    expect(
+      swallowed.length,
+      'a catch that logs and falls through to `return true` is the same hollow success as an ' +
+        'unknown key — the property was not written',
+    ).toBe(0);
+    expect((body.match(/return false;/g) ?? []).length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('form control bindings that do not stick are named in the result', () => {
+    const create = methodBody(source, 'private dynamic CreateFormControl(');
+    expect(
+      create,
+      'a Group/Tab/Button control has no DataSource; `catch { }` produced an UNBOUND control ' +
+        'reported as added and bound',
+    ).not.toMatch(/catch \{ \}/);
+    expect(create).toContain('unsupportedProperties.Add("dataSource")');
+    expect(create).toContain('unsupportedProperties.Add("dataField")');
+
+    const addControl = methodBody(source, 'public object AddControl(string formName, string controlName, string parentControl,');
+    expect(addControl, 'add-control must return what did not apply').toContain('unsupportedProperties');
+  });
+
+  it('create paths that use these setters report the keys that did not apply', () => {
+    for (const signature of [
+      'public object CreateEdt(',
+      'public object CreateQuery(string name, string modelName, Dictionary<string, string>? properties)',
+      'public object CreateMenuItemAction(string name, string modelName, Dictionary<string, string>? properties)',
+      'public object CreateMenuItemDisplay(string name, string modelName, Dictionary<string, string>? properties)',
+      'public object CreateMenuItemOutput(string name, string modelName, Dictionary<string, string>? properties)',
+    ]) {
+      const body = methodBody(source, signature);
+      expect(body, `${signature} discards the setter result — an unwritable property vanishes`)
+        .toContain('unsupportedProperties');
+    }
+  });
+});

--- a/tests/bridge/xrefErrorPropagationParity.test.ts
+++ b/tests/bridge/xrefErrorPropagationParity.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Cross-reference failures must not be reported as empty results (audit finding #27).
+ *
+ * Every method in CrossReferenceService answers "what else touches this?", and the answer
+ * decides whether it is safe to change something. A failed SQL query used to come back as a
+ * SUCCESSFUL response carrying `count = 0` plus an `error` field — which reads, to any caller
+ * that does not go looking for the extra field, as the strongest possible clearance: nothing
+ * references this. The worse the database's state, the safer everything looked.
+ *
+ * The service only runs against DYNAMICSXREFDB on a D365FO VM, so this is a source-level
+ * guard, comment-stripped so the explanation cannot pass for the code.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { XREF_SERVICE_CS, readStripped } from './csharpSource';
+
+let source: string;
+
+beforeAll(() => {
+  source = readStripped(XREF_SERVICE_CS);
+});
+
+describe('cross-reference query failures', () => {
+  it('never returns a result object carrying an error field', () => {
+    const inBand = source.match(/error\s*=\s*ex\.Message/g) ?? [];
+    expect(
+      inBand.length,
+      'a catch block still returns `error = ex.Message` inside a success response — the caller ' +
+        'sees count=0 and concludes "no references, safe to change" while the database is down',
+    ).toBe(0);
+  });
+
+  it('has no catch block that returns a zero count', () => {
+    // Slice each catch body and require that none of them ends in a `return`: the only
+    // correct exits from a failed query are `throw` and propagation.
+    const catches = [...source.matchAll(/catch\s*\([^)]*\)\s*\{/g)];
+    expect(catches.length, 'CrossReferenceService should still have catch blocks to check').toBeGreaterThan(0);
+
+    for (const match of catches) {
+      const start = match.index! + match[0].length - 1;
+      let depth = 0;
+      let body = '';
+      for (let i = start; i < source.length; i++) {
+        body += source[i];
+        if (source[i] === '{') depth++;
+        else if (source[i] === '}' && --depth === 0) break;
+      }
+      expect(
+        body,
+        `a catch block returns a value instead of propagating:\n${body.trim().slice(0, 300)}`,
+      ).not.toMatch(/\breturn\b/);
+    }
+  });
+
+  it('routes failures through a helper that says the query was not answered', () => {
+    expect(source).toContain('private static Exception QueryFailed(');
+    const throws = source.match(/throw QueryFailed\(/g) ?? [];
+    expect(
+      throws.length,
+      'all four query methods (findReferences, findExtensionClasses, findEventSubscribers, ' +
+        'findApiUsageCallers) must surface a failure as an error',
+    ).toBe(4);
+  });
+});
+
+describe('the dispatcher turns a thrown xref failure into an error response', () => {
+  it('HandleXref has no catch-all that fabricates a success', async () => {
+    const { readStripped: read } = await import('./csharpSource');
+    const path = await import('path');
+    const dispatcher = read(path.join(
+      path.resolve(__dirname, '..', '..'),
+      'bridge', 'D365MetadataBridge', 'Protocol', 'RequestDispatcher.cs',
+    ));
+    const start = dispatcher.indexOf('private Task<BridgeResponse> HandleXref(');
+    expect(start, 'HandleXref not found — the throw above would have no receiver').toBeGreaterThan(0);
+    const body = dispatcher.slice(start, dispatcher.indexOf('private ', start + 10));
+    expect(body).toContain('BridgeResponse.CreateError');
+  });
+});


### PR DESCRIPTION
**Phase 2.5** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4) — audit findings 13, 17, 26, 27, 28. All five reproduced in source; none was already fixed.

## 26 — bridge lifecycle (four parts)

- **Crash misclassified.** `isTransientError` matched the phrase `"exited unexpectedly"` — which **no code path ever emitted**. The exit handler said `"Bridge process exited before becoming ready"`. So a child crash with a READ in flight was classified deterministic and thrown at the caller instead of retried. In-flight calls now get a distinct message and the matcher tests for what is actually emitted.
- **Wedged child orphaned at shutdown.** `dispose()` is now `async` and awaits `killChild()`, which escalates stdin-end → SIGTERM → SIGKILL against the child's real `exit` event. Previously the escalation sat on `unref`'d timers behind a *synchronous* `dispose()`, so the process exited before they fired. `src/index.ts` already awaited the shutdown callback — its comment describing SIGTERM/SIGKILL escalation is now actually true.
- **Leaked DiskProvider.** `RefreshProvider` now releases the old provider. Every write auto-refreshes, so this was one leaked provider *per write*.
- **Stale `_modelCache`.** `UpdateProvider` now clears it. This is the historical Create-NRE precondition: a descriptor-derived `ModelSaveInfo` (SequenceId=0) cached before the model reached the manifest survived every later refresh.

## 13 — `RenameField` left dangling references

Now repoints Relations (constraint `Field` only — `RelatedField` names a column on the *other* table), FullTextIndexes and Mappings (`MapFieldTo` only), plus `FieldGroupExtensions`/`RelationExtensions` for table-extensions, and returns per-collection counts. Explicitly out of scope and documented: references from *other* objects — different files, different model ownership, `find_references` is the tool for that.

## 17 — `AddEnumValue` could write into a Microsoft model

Ownership now comes from the model manifest's **`Publisher`** — not a name list and not the layer. The agent verified this on the live VM by dumping all 209 models: Microsoft's read `Microsoft Corporation`/`Microsoft`, custom ones read `ARICOMA`/`Milnet92`, and **Microsoft's `Tutorial` model sits in layer 14**, which would have defeated a layer-based rule. The guard is **default-allow**: an unreadable manifest answers "writable", so it cannot start refusing writes that work today.

**Survey of the rest of the modify surface** (requested): the gap is structural, not local to enums — every modify method resolves by name and writes into whatever model owns the target. Two mitigating facts: the TS path has its own model-ownership and cross-model guards, and for most types the extension has a *different* name (`CustTable.FooExtension`) so base-first resolution is not reachable from a normal request. Enums are the case where the natural request — "add a value to this shipped enum" — names the base directly. Widening the guard to the whole surface was deliberately **not** done here; the helper is written to be reusable if that is wanted.

## 27 — cross-reference errors read as "no references, safe to change"

All four query methods now propagate instead of returning `{count: 0, error}` inside a *successful* response. The dispatcher already renders a thrown exception as `-32603`, and the TS adapters already treat a rejected call as "no answer, fall back" rather than "zero references".

## 28 — hollow-success setters

EDT `stringSize` returns false on a non-string base type and throws on a non-integer; menu-item `ObjectType`/`OpenMode` throw with the legal value list (matching the file's existing convention); `SetAxQueryProperty`'s three `catch { log }` arms return false; `CreateFormControl` collects failed bindings into `unsupportedProperties`.

**On reusing `unsupportedProperties`:** it was the right shape but **reported nothing** — no TypeScript in the repo read that field, so the C# create ops had been emitting it into the void. It is now on `BridgeWriteResult` and surfaced in `bridgeAdapter.ts`.

## Verification

- `dotnet build` — 0 warnings, 0 errors (metamodel 7.0.7996.33 from the real VM DLLs, so every metamodel type touched is compiler-verified).
- `tsc --noEmit` clean; full suite **2868 passed**.
- Negative control: **26 of 28 new assertions fail** against pre-fix source. The 2 that passed are documented guards, not regressions.

## Not verified

**Nothing was exercised against live metadata.** No `RenameField` on a real table with relations, no `AddEnumValue` against a Microsoft enum, no forced xref outage. The C# parity tests prove the code is *there*, not that it behaves correctly at runtime. The one runtime fact confirmed on the VM is `ModelInfo.Publisher`.

One existing test (`bridgeResilience` — "shares a single in-flight restart") was modified: it relied on `restart()` reaching `spawnAndWaitReady` synchronously, and `await this.killChild()` now precedes it. That is a real consequence of the fix, not a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)