### PR TITLE
Answer the follow-up questions in the write call that already knows them (Phase 1.2 + 1.4)

### DIFF
--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -10,6 +10,8 @@ import { z } from 'zod';
 import { Parser, Builder } from 'xml2js';
 import { getConfigManager, fallbackPackagePath } from '../utils/configManager.js';
 import { describePackagesRootScan } from '../utils/packagesRoot.js';
+import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
+import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck } from './inlineWriteVerification.js';
 import { registerCustomModel, resolveObjectPrefix, applyObjectPrefix, getObjectSuffix, applyObjectSuffix, getExtensionNamingStyle } from '../utils/modelClassifier.js';
 import { PackageResolver } from '../utils/packageResolver.js';
 import { crossModelWriteRefusal } from '../utils/crossModelWriteGuard.js';
@@ -4854,13 +4856,25 @@ export async function handleCreateD365File(
                 });
               }
 
+              // Index the new object in-process. The parser is right here, so making
+              // the agent spend a round trip on update_symbol_index — which this very
+              // response used to instruct it to do — plus another on the lookup that
+              // failed for want of it, was pure waste.
+              const indexNote = await upsertWrittenFileIntoIndex(smartResult.filePath, context);
+              // Verify the write here rather than leaving the caller to spend a
+              // verify_d365fo_project round trip asking what this call already knows.
+              const verifyNote = renderWriteVerification(
+                await verifyWrittenFile(smartResult.filePath, projectPathToUse),
+              );
+              const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
+
               return {
                 content: [
                   {
                     type: 'text',
                     text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create() (Smart)\n` +
                       `📁 ${smartResult.filePath}${projectMsg}\n` +
-                      `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${honestyReport}${rawLabelWarning}`,
+                      `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}`,
                   },
                 ],
               };
@@ -4942,13 +4956,21 @@ export async function handleCreateD365File(
             });
           }
 
+          // Index the new object in-process — see the smart-table path above.
+          const indexNote = await upsertWrittenFileIntoIndex(bridgeResult.filePath, context);
+          // Verify the write — see the smart-table path above.
+          const verifyNote = renderWriteVerification(
+            await verifyWrittenFile(bridgeResult.filePath, projectPathToUse),
+          );
+          const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
+
           return {
             content: [
               {
                 type: 'text',
                 text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create()\n` +
                   `📁 ${bridgeResult.filePath}${projectMsg}\n` +
-                  `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}`,
+                  `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}`,
               },
             ],
           };
@@ -5294,6 +5316,14 @@ export async function handleCreateD365File(
       });
     }
 
+    // Index the new object in-process — see the bridge paths above.
+    const indexNote = await upsertWrittenFileIntoIndex(normalizedFullPath, context);
+    // Verify the write — see the bridge paths above.
+    const verifyNote = renderWriteVerification(
+      await verifyWrittenFile(normalizedFullPath, args.addToProject ? projectPathToUse : undefined),
+    );
+    const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
+
     // Return success message with file path
     return {
       content: [
@@ -5309,6 +5339,9 @@ export async function handleCreateD365File(
             tableHonestyReport +
             rawLabelBpWarning(args.properties, finalObjectName) +
             projectMessage +
+            verifyNote +
+            indexNote +
+            bpNote +
             `\n${nextSteps}\n` +
             `⛔ TASK COMPLETE — do NOT call \`generate\`, \`generate\`, or \`d365fo_file(action="create")\` again for this object.`,
         },

--- a/src/tools/inlineIndexUpsert.ts
+++ b/src/tools/inlineIndexUpsert.ts
@@ -1,0 +1,47 @@
+/**
+ * In-process symbol-index upsert for the create/modify paths.
+ *
+ * A newly created EDT, enum or table is not in the SQLite symbol index until
+ * something indexes it, and until then `search` and every reader that consults
+ * the index behave as though it does not exist. The server said so itself: a
+ * create warned the agent to call update_symbol_index, which it then did — two
+ * more round trips (the index call, then the retried lookup) for a file this
+ * process had just written and can parse in milliseconds.
+ *
+ * The parser is in-process. There is no reason for that to be a round trip.
+ *
+ * Deliberately best-effort and non-fatal: the write already succeeded and is on
+ * disk, so a failure to index must never turn a successful create into an error.
+ * It downgrades to the note the tool used to print, which is exactly the old
+ * behaviour — no worse than before, and only for the cases that actually fail.
+ */
+
+import type { XppServerContext } from '../types/context.js';
+import { indexOneFile } from './updateSymbolIndex.js';
+
+/**
+ * Suffix appended to a write response, or '' when there is nothing to say.
+ *
+ * The context is accepted partially: the create path threads a narrowed
+ * `{ bridge, symbolIndex }` around, and the indexer only ever reads
+ * `symbolIndex`. Requiring the full shape here would mean widening that,
+ * for no benefit.
+ */
+export async function upsertWrittenFileIntoIndex(
+  filePath: string | undefined,
+  context: Partial<XppServerContext> | undefined,
+): Promise<string> {
+  if (!filePath || !context?.symbolIndex) return '';
+
+  try {
+    const result = await indexOneFile(filePath, context as XppServerContext);
+    if (result.isError) {
+      return `\n⚠️ Written, but the symbol index could not be updated: ${result.text}\n` +
+             `   Run update_symbol_index(filePath="${filePath}") before searching for it.`;
+    }
+    return '\n🔎 Symbol index updated in place — no update_symbol_index call needed.';
+  } catch (e: any) {
+    return `\n⚠️ Written, but the symbol index could not be updated: ${e?.message ?? e}\n` +
+           `   Run update_symbol_index(filePath="${filePath}") before searching for it.`;
+  }
+}

--- a/src/tools/inlineWriteVerification.ts
+++ b/src/tools/inlineWriteVerification.ts
@@ -1,0 +1,120 @@
+/**
+ * Inline post-write verification for the create/modify paths.
+ *
+ * The conventional loop is create → verify_d365fo_project → run_bp_check: two
+ * extra round trips per object, both asking questions the writing call already
+ * had the answers to. It knows the path it wrote and the project it registered
+ * the file in; checking that the bytes are on disk and that the .rnrproj really
+ * references them is two filesystem reads, not a round trip.
+ *
+ * Kept deliberately narrow. This is NOT verify_d365fo_project — that tool sweeps
+ * a whole project and cross-checks every object, which is a different job and
+ * still worth its own call. This answers only "did the thing I just claimed to
+ * do actually land", which is precisely the question the follow-up call was
+ * being spent on.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { Parser } from 'xml2js';
+
+export interface WriteVerification {
+  /** The file exists on disk and is non-empty. */
+  onDisk: boolean;
+  /** Byte length written, when readable. */
+  bytes?: number;
+  /** True/false when a project path was supplied and readable; undefined otherwise. */
+  inProject?: boolean;
+}
+
+/** True when `projectPath`'s .rnrproj has a Content Include resolving to `filePath`. */
+async function isReferencedByProject(projectPath: string, filePath: string): Promise<boolean | undefined> {
+  try {
+    const xml = await fs.readFile(projectPath, 'utf-8');
+    const parsed = await new Parser({ explicitArray: true }).parseStringPromise(xml);
+    const projectDir = path.dirname(projectPath);
+    const target = path.resolve(filePath).toLowerCase();
+
+    for (const group of (parsed?.Project?.ItemGroup ?? []) as any[]) {
+      const contents: any[] = Array.isArray(group?.Content) ? group.Content : [];
+      for (const c of contents) {
+        const include: string | undefined = c?.$?.Include;
+        if (!include) continue;
+        // Includes are project-relative, and Windows-relative at that; resolve
+        // rather than string-compare, or a legitimate entry reads as missing.
+        if (path.resolve(projectDir, include.replace(/\\/g, path.sep)).toLowerCase() === target) return true;
+      }
+    }
+    return false;
+  } catch {
+    // Unreadable/absent project file is not evidence either way — say nothing
+    // rather than report a false "not registered" on a write that was fine.
+    return undefined;
+  }
+}
+
+/** Check that a just-written file is where it should be. Never throws. */
+export async function verifyWrittenFile(
+  filePath: string | undefined,
+  projectPath?: string,
+): Promise<WriteVerification> {
+  if (!filePath) return { onDisk: false };
+  try {
+    const stat = await fs.stat(filePath);
+    const result: WriteVerification = { onDisk: stat.isFile() && stat.size > 0, bytes: stat.size };
+    if (projectPath) result.inProject = await isReferencedByProject(projectPath, filePath);
+    return result;
+  } catch {
+    return { onDisk: false };
+  }
+}
+
+/**
+ * Opt-in best-practice check on the object just written.
+ *
+ * Off by default and deliberately so: xppbp needs the compiler and takes
+ * seconds, which is the wrong trade for the common case. But when the caller
+ * knows it wants one — the last object of a feature, say — running it here
+ * saves the round trip that the separate run_bp_check call costs, and this call
+ * already knows the object's type and name.
+ *
+ * `bpCheck` is not in the wire schema; it is accepted nested in `params` like
+ * every other d365fo_file knob, and documented in the op-spec. It costs no
+ * schema bytes and the budget has none to spare.
+ */
+export async function runInlineBpCheck(
+  bpCheck: unknown,
+  objectType: string,
+  objectName: string,
+  context: unknown,
+): Promise<string> {
+  if (bpCheck !== true && bpCheck !== 'true') return '';
+  try {
+    const { runBpCheckTool } = await import('./runBpCheck.js');
+    const result: any = await runBpCheckTool({ objects: [{ objectType, objectName }] }, context as any);
+    const text = (result?.content ?? [])
+      .filter((c: any) => c?.type === 'text' && typeof c.text === 'string')
+      .map((c: any) => c.text)
+      .join('\n')
+      .trim();
+    return text ? `\n\n### Best-practice check (bpCheck=true)\n${text}` : '';
+  } catch (e: any) {
+    // Never turn a successful write into a failure over an advisory check.
+    return `\n⚠️ bpCheck requested but could not run: ${e?.message ?? e}`;
+  }
+}
+
+/** One-line summary for a write response, or '' when there is nothing worth saying. */
+export function renderWriteVerification(v: WriteVerification): string {
+  if (!v.onDisk) {
+    return `\n❌ Verification: the file is NOT on disk after a reported success — treat this write as failed.`;
+  }
+  const parts = [`on disk (${v.bytes} bytes)`];
+  if (v.inProject === true) parts.push('referenced by the .rnrproj');
+  // Only the negative is worth the bytes; `undefined` means we could not tell.
+  if (v.inProject === false) {
+    return `\n✅ Verified: ${parts.join(', ')}` +
+           `\n⚠️ Verification: the .rnrproj does NOT reference this file — it will not compile until it does.`;
+  }
+  return `\n✅ Verified: ${parts.join(', ')}.`;
+}

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -47,6 +47,8 @@ import {
   isFormPatternEnforceEnabled,
 } from './validateFormPattern.js';
 import { validateEdtExtensionChange } from '../utils/edtExtensionValidator.js';
+import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
+import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck } from './inlineWriteVerification.js';
 import { lintXppSelect } from '../utils/xppSelectLint.js';
 import {
   getRequiredParams, renderOpSpec, OP_PARAM_ALIASES,
@@ -2935,6 +2937,25 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         `(Pass autoCorrect=false to have corrections like this raise an error instead.)`
       : '';
 
+    // Re-index the modified object in-process. A modify changes the symbols the
+    // index holds (a renamed field, a new method), and the parser is right here —
+    // making the agent spend a round trip on update_symbol_index for a file this
+    // process just wrote, and another on the lookup that failed for want of it,
+    // was pure waste.
+    const indexNote = await upsertWrittenFileIntoIndex(actualFilePath, context);
+
+    // Verify the write here rather than leaving the caller to spend a
+    // verify_d365fo_project round trip asking what this call already knows.
+    // The project path resolved inside the addToProject branch is block-scoped,
+    // and a modify commonly runs with addToProject off — re-resolve it here so the
+    // .rnrproj check still happens (config reads are cached).
+    const verifyProjectPath =
+      args.projectPath || (await getConfigManager().getProjectPath()) || undefined;
+    const verifyNote = renderWriteVerification(
+      await verifyWrittenFile(actualFilePath, verifyProjectPath),
+    );
+    const bpNote = await runInlineBpCheck((args as any).bpCheck, objectType, objectName, context);
+
     return {
       content: [
         {
@@ -2942,7 +2963,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
           text:
             `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()${autoCorrectNote}\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
-            `🔧 API: ${bridgeResult.message}${xppLintNote}${addFieldBpNote}${backupNote}` +
+            `🔧 API: ${bridgeResult.message}${xppLintNote}${addFieldBpNote}${backupNote}${verifyNote}${indexNote}${bpNote}` +
             (ignoredParamsWarning ? `\n\n${ignoredParamsWarning}` : '') + `\n\n` +
             `**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate`,
         },

--- a/src/tools/opSpecs.ts
+++ b/src/tools/opSpecs.ts
@@ -67,6 +67,11 @@ const D365FO_FILE_OVERRIDE_PARAMS: Record<string, string> = {
   packagePath: 'Base package path (default: auto-detected PackagesLocalDirectory).',
   solutionPath: 'VS solution directory — used to find the .rnrproj when projectPath is unset.',
   workspacePath: '[modify] Workspace path used to locate the object file.',
+  bpCheck:
+    '[create|modify] true = run the best-practice check on the object in THIS call, ' +
+    'instead of spending a round trip on run_bp_check afterwards. Off by default: ' +
+    'xppbp needs the compiler and takes seconds, which is the wrong trade for the common case. ' +
+    'The write result already carries an on-disk + .rnrproj verification without it.',
 };
 
 /** Every topic the lookup answers, grouped for the index listing. */

--- a/src/tools/updateSymbolIndex.ts
+++ b/src/tools/updateSymbolIndex.ts
@@ -293,7 +293,15 @@ async function refreshOnly(context: XppServerContext) {
  * job — it is per-batch, not per-file, which is what made a multi-object update
  * cost one full DiskProvider rebuild per object.
  */
-async function indexOneFile(
+/**
+ * Index ONE file into the SQLite symbol/label index.
+ *
+ * Exported so the create/modify paths can do this in-process on their way out
+ * (see inlineIndexUpsert.ts) instead of the agent spending a round trip on
+ * update_symbol_index — which was the last legitimate mid-task reason to call
+ * that tool at all.
+ */
+export async function indexOneFile(
   filePath: string,
   context: XppServerContext,
 ): Promise<{ text: string; isError: boolean }> {

--- a/tests/tools/inlineIndexUpsert.test.ts
+++ b/tests/tools/inlineIndexUpsert.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Phase 1.2 — index the written file in-process.
+ *
+ * A newly created EDT, enum or table was not in the SQLite symbol index until
+ * something indexed it, and until then `search` and every index-backed reader
+ * behaved as though it did not exist. The server said so itself: a create
+ * warned the agent to call update_symbol_index, which it then did — two more
+ * round trips (the index call, then the retried lookup) for a file this process
+ * had just written and can parse in milliseconds.
+ *
+ * The failure path matters as much as the happy one: the write already
+ * succeeded and is on disk, so a failure to index must never turn a successful
+ * create into an error. It has to degrade to the note the tool used to print.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockIndexOneFile } = vi.hoisted(() => ({ mockIndexOneFile: vi.fn() }));
+
+vi.mock('../../src/tools/updateSymbolIndex', () => ({ indexOneFile: mockIndexOneFile }));
+
+import { upsertWrittenFileIntoIndex } from '../../src/tools/inlineIndexUpsert';
+
+const ctx = { symbolIndex: {} } as any;
+
+describe('upsertWrittenFileIntoIndex', () => {
+  beforeEach(() => {
+    mockIndexOneFile.mockReset();
+    mockIndexOneFile.mockResolvedValue({ text: 'indexed', isError: false });
+  });
+
+  it('indexes the written file and says so', async () => {
+    const note = await upsertWrittenFileIntoIndex('K:/PLD/Pkg/Model/AxTable/Foo.xml', ctx);
+
+    expect(mockIndexOneFile).toHaveBeenCalledWith('K:/PLD/Pkg/Model/AxTable/Foo.xml', ctx);
+    expect(note).toContain('Symbol index updated in place');
+    expect(note).toContain('no update_symbol_index call needed');
+  });
+
+  it('degrades to the old instruction when indexing fails, without failing the write', async () => {
+    mockIndexOneFile.mockResolvedValue({ text: 'parse error', isError: true });
+
+    const note = await upsertWrittenFileIntoIndex('K:/PLD/Pkg/Model/AxTable/Foo.xml', ctx);
+
+    expect(note).toContain('symbol index could not be updated');
+    expect(note).toContain('update_symbol_index(filePath=');
+  });
+
+  it('swallows a thrown indexer rather than propagating into the write result', async () => {
+    mockIndexOneFile.mockRejectedValue(new Error('database is locked'));
+
+    const note = await upsertWrittenFileIntoIndex('K:/PLD/Pkg/Model/AxTable/Foo.xml', ctx);
+
+    expect(note).toContain('database is locked');
+    expect(note).toContain('update_symbol_index(filePath=');
+  });
+
+  it('does nothing without a path or a symbol index', async () => {
+    expect(await upsertWrittenFileIntoIndex(undefined, ctx)).toBe('');
+    expect(await upsertWrittenFileIntoIndex('K:/x.xml', {} as any)).toBe('');
+    expect(mockIndexOneFile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/inlineWriteVerification.test.ts
+++ b/tests/tools/inlineWriteVerification.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Phase 1.4 — verify the write in the call that made it.
+ *
+ * The conventional loop was create → verify_d365fo_project → run_bp_check: two
+ * extra round trips per object, both asking questions the writing call already
+ * had the answers to. It knows the path it wrote and the project it registered
+ * the file in; checking that the bytes are on disk and that the .rnrproj really
+ * references them is two filesystem reads, not a round trip.
+ *
+ * The negative case is the one that earns its keep: this project has a
+ * documented history of writes that report ✅ and leave nothing usable behind
+ * (empty security objects, tables with no fields, files absent from the
+ * .rnrproj). A success message that has actually looked at the disk is a
+ * different claim from one that has not.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { verifyWrittenFile, renderWriteVerification } from '../../src/tools/inlineWriteVerification';
+
+let base: string;
+let xmlPath: string;
+let projectPath: string;
+
+beforeAll(() => {
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'inlineverify-'));
+  const modelDir = path.join(base, 'MyPackage', 'MyModel', 'AxTable');
+  fs.mkdirSync(modelDir, { recursive: true });
+  xmlPath = path.join(modelDir, 'ContosoXyzTable.xml');
+  fs.writeFileSync(xmlPath, '<AxTable><Name>ContosoXyzTable</Name></AxTable>');
+
+  projectPath = path.join(base, 'MyPackage', 'MyModel', 'MyModel.rnrproj');
+  // Includes are project-RELATIVE and Windows-relative — the check has to resolve
+  // them, not string-compare, or a legitimate entry reads as missing.
+  fs.writeFileSync(projectPath,
+    `<Project><ItemGroup><Content Include="AxTable\\ContosoXyzTable.xml" /></ItemGroup></Project>`);
+});
+
+afterAll(() => {
+  try { fs.rmSync(base, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('verifyWrittenFile', () => {
+  it('confirms a file that is really on disk', async () => {
+    const v = await verifyWrittenFile(xmlPath);
+    expect(v.onDisk).toBe(true);
+    expect(v.bytes).toBeGreaterThan(0);
+  });
+
+  it('reports a missing file as not on disk', async () => {
+    const v = await verifyWrittenFile(path.join(base, 'nope.xml'));
+    expect(v.onDisk).toBe(false);
+  });
+
+  it('treats an empty file as not written', async () => {
+    const empty = path.join(base, 'empty.xml');
+    fs.writeFileSync(empty, '');
+    const v = await verifyWrittenFile(empty);
+    expect(v.onDisk).toBe(false);
+  });
+
+  it('resolves a project-relative Include rather than string-comparing it', async () => {
+    const v = await verifyWrittenFile(xmlPath, projectPath);
+    expect(v.inProject).toBe(true);
+  });
+
+  it('reports a file the .rnrproj does not reference', async () => {
+    const orphan = path.join(path.dirname(xmlPath), 'ContosoOrphan.xml');
+    fs.writeFileSync(orphan, '<AxTable/>');
+    const v = await verifyWrittenFile(orphan, projectPath);
+    expect(v.inProject).toBe(false);
+  });
+
+  it('says nothing about the project when the .rnrproj is unreadable', async () => {
+    // An absent project file is not evidence either way — reporting "not
+    // registered" there would be a false alarm on a write that was fine.
+    const v = await verifyWrittenFile(xmlPath, path.join(base, 'missing.rnrproj'));
+    expect(v.inProject).toBeUndefined();
+  });
+
+  it('never throws on a bad path', async () => {
+    await expect(verifyWrittenFile(undefined)).resolves.toMatchObject({ onDisk: false });
+  });
+});
+
+describe('renderWriteVerification', () => {
+  it('contradicts the ✅ when the file is not there', () => {
+    const text = renderWriteVerification({ onDisk: false });
+    expect(text).toContain('NOT on disk');
+    expect(text).toMatch(/treat this write as failed/i);
+  });
+
+  it('warns when the .rnrproj does not reference the file', () => {
+    const text = renderWriteVerification({ onDisk: true, bytes: 120, inProject: false });
+    expect(text).toContain('does NOT reference');
+    expect(text).toMatch(/will not compile/i);
+  });
+
+  it('stays to one line when everything is fine', () => {
+    const text = renderWriteVerification({ onDisk: true, bytes: 120, inProject: true });
+    expect(text.trim().split('\n')).toHaveLength(1);
+    expect(text).toContain('Verified');
+  });
+
+  it('does not claim anything about the project when it could not tell', () => {
+    const text = renderWriteVerification({ onDisk: true, bytes: 120 });
+    expect(text).not.toMatch(/rnrproj/i);
+    expect(text).toContain('Verified');
+  });
+});


### PR DESCRIPTION
**Phases 1.2 and 1.4** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4). Two round-trip findings, one theme: after a create or modify, the agent was made to spend further calls asking things this process had just established.

> ⚠️ Stacked: `perf/write-path-round-trips` → `perf/prepare-bundles-opspec` (#856) → `perf/batch-modify-operations` (#855) → `perf/schema-headroom` (#854). Merge in that order.

## 1.2 — index the written file in-process

A new EDT, enum or table was absent from the SQLite symbol index until something indexed it, so `search` and every index-backed reader behaved as though it did not exist. **The server said so itself**: the create response instructed the agent to call `update_symbol_index`, which it then did — *two* more round trips (the index call, then the retried lookup) for a file this process had just written and can parse in milliseconds.

The parser is in-process. There was never a reason for that to be a round trip.

Deliberately best-effort: the write already succeeded and is on disk, so a failure to index must never turn a successful create into an error. It degrades to **exactly the note the tool used to print** — the old behaviour, and only for the cases that actually fail.

## 1.4 — verify the write in the call that made it

The conventional loop was create → `verify_d365fo_project` → `run_bp_check`. The writing call knows the path it wrote and the project it registered the file in; checking that the bytes are on disk and that the `.rnrproj` really references them is **two filesystem reads**, not two round trips.

Details that matter:
- The `.rnrproj` check **resolves** project-relative Includes rather than string-comparing them — they are Windows-relative, so a string compare reads a legitimate entry as missing.
- An unreadable or absent project file says **nothing**, rather than reporting a false "not registered" on a write that was fine.
- An empty file counts as not written.

**The negative case is what earns this.** This project has a documented history of writes that report ✅ and leave nothing usable behind — empty security objects, tables with no fields, files absent from the `.rnrproj`. A success message that has actually looked at the disk is a different claim from one that has not.

`bpCheck` stays **opt-in** — xppbp needs the compiler and takes seconds, the wrong trade for the common case — and rides in `params` rather than the wire schema, so it costs **zero** schema bytes. Documented in the op-spec.

## Scope, deliberately

This is **not** `verify_d365fo_project`, which sweeps a whole project and cross-checks every object. That remains its own call, worth making. This answers only *"did the thing I just claimed to do actually land"* — precisely what the follow-up call was being spent on.

## Verification

Two new test files, 15 tests. The verification suite covers the missing-file, empty-file, orphaned-from-project, unreadable-project and resolve-relative-Include cases; the index suite covers the failure and throw paths degrading to the old instruction rather than failing the write.

Full suite: 2889 passed, `tsc --noEmit` clean. No schema-budget change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)