### PR TITLE
Take the DiskProvider rebuild off the response path, memoize EDT resolution, stop the empty-search table scan (Phase 1.6)

### DIFF
--- a/src/bridge/debouncedRefresh.ts
+++ b/src/bridge/debouncedRefresh.ts
@@ -1,6 +1,13 @@
 /**
  * Coalesces multiple rapid refreshProvider() calls into a single call, so that
  * a burst of create/modify operations triggers only one DiskProvider refresh.
+ *
+ * Writers call refresh() and do NOT await it — a full DiskProvider rebuild
+ * serialized into a create's response is seconds the caller pays for a provider
+ * generation nothing may ever read. Anything that must resolve an object written
+ * this session calls flush() first, which is free unless a rebuild is actually
+ * outstanding. The guarantee "a write is visible to the next bridge operation"
+ * therefore survives; only who pays for it moves.
  */
 
 import type { BridgeClient } from './bridgeClient.js';
@@ -14,8 +21,21 @@ let pending: {
   resolve: (v: BridgeRefreshResult | null) => void;
   timer: ReturnType<typeof setTimeout>;
   firstRequestTime: number;
+  /** Newest request in this batch — the point the rebuild has to be no older than. */
+  lastRequestTime: number;
   bridge: BridgeClient;
 } | null = null;
+
+/**
+ * The rebuild currently running, if any.
+ *
+ * flush() must be able to wait for a refresh that already fired on its settle
+ * timer, not just one still queued: a create schedules the refresh and returns,
+ * and the modify that follows it 400 ms later would otherwise be told "nothing
+ * pending" while the DiskProvider is mid-rebuild — the stale-provider state the
+ * eager refresh existed to rule out.
+ */
+let inFlight: Promise<BridgeRefreshResult | null> | null = null;
 
 /**
  * When the most recent provider refresh STARTED (epoch ms), across both this
@@ -39,9 +59,10 @@ export function markRefreshStarted(at: number = Date.now()): void {
   if (at > lastRefreshStartedAt) lastRefreshStartedAt = at;
 }
 
-/** Forget the recorded refresh time (test isolation). */
+/** Forget the recorded refresh time and any in-flight rebuild (test isolation). */
 export function resetRefreshTracking(): void {
   lastRefreshStartedAt = 0;
+  inFlight = null;
 }
 
 /**
@@ -59,15 +80,18 @@ export function refresh(bridge: BridgeClient): Promise<BridgeRefreshResult | nul
     executeRefresh();
   }
 
+  const now = Date.now();
+
   if (pending) {
     // Reset the settle timer (but respect MAX_WAIT_MS)
     clearTimeout(pending.timer);
-    const elapsed = Date.now() - pending.firstRequestTime;
+    pending.lastRequestTime = now;
+    const elapsed = now - pending.firstRequestTime;
     const remaining = Math.max(0, MAX_WAIT_MS - elapsed);
     const delay = Math.min(SETTLE_MS, remaining);
 
     if (delay > 0) {
-      pending.timer = setTimeout(executeRefresh, delay);
+      pending.timer = startTimer(delay);
     } else {
       // Max wait exceeded — fire immediately
       executeRefresh();
@@ -82,39 +106,79 @@ export function refresh(bridge: BridgeClient): Promise<BridgeRefreshResult | nul
   pending = {
     promise,
     resolve,
-    timer: setTimeout(executeRefresh, SETTLE_MS),
-    firstRequestTime: Date.now(),
+    timer: startTimer(SETTLE_MS),
+    firstRequestTime: now,
+    lastRequestTime: now,
     bridge,
   };
 
   return promise;
 }
 
-function executeRefresh(): void {
-  if (!pending) return;
-  const { resolve, bridge } = pending;
-  pending = null;
-
-  markRefreshStarted();
-  bridge.refreshProvider()
-    .then(result => resolve(result))
-    .catch(err => {
-      console.error(`[debouncedRefresh] refreshProvider failed: ${err}`);
-      resolve(null);
-    });
+/**
+ * The settle timer must not be the reason the process stays alive: callers no
+ * longer await the refresh, so a create that returns right before shutdown would
+ * otherwise hold the event loop open for the settle window to rebuild a provider
+ * nobody will read. unref() is absent under some fake-timer implementations.
+ */
+function startTimer(delay: number): ReturnType<typeof setTimeout> {
+  const timer = setTimeout(executeRefresh, delay);
+  (timer as { unref?: () => void }).unref?.();
+  return timer;
 }
 
-/** Flush any pending refresh immediately (used in tests or shutdown). */
+function executeRefresh(): void {
+  if (!pending) return;
+  const { resolve, bridge, lastRequestTime } = pending;
+  pending = null;
+
+  // A direct bridgeRefreshProvider() — update_symbol_index, the modify auto-retry —
+  // may have rebuilt the provider after the newest request in this batch landed.
+  // That rebuild has by definition already read everything the batch wrote, so
+  // running ours would be a second full DiskProvider scan that can discover nothing.
+  if (lastRefreshStartedAt > lastRequestTime) {
+    resolve(null);
+    return;
+  }
+
+  markRefreshStarted();
+  // A throwing refreshProvider must not escape: flush() is awaited on the write
+  // path now, so an exception here would turn a bridge hiccup into a failed
+  // create/modify instead of a stale provider.
+  const run: Promise<BridgeRefreshResult | null> = (async () => bridge.refreshProvider())()
+    .catch(err => {
+      console.error(`[debouncedRefresh] refreshProvider failed: ${err}`);
+      return null;
+    })
+    .then(result => {
+      if (inFlight === run) inFlight = null;
+      resolve(result);
+      return result;
+    });
+  inFlight = run;
+}
+
+/**
+ * Wait until the provider is no older than this moment.
+ *
+ * Free when nothing is outstanding, which is the single-operation case: it must
+ * not become the 400 ms settle window a naive `await refresh()` would impose.
+ * When a write did schedule a rebuild, the caller that actually needs to resolve
+ * the new object pays for it — instead of every writer paying on its way out.
+ */
 export function flush(): Promise<BridgeRefreshResult | null> {
-  if (!pending) return Promise.resolve(null);
-  clearTimeout(pending.timer);
-  const p = pending.promise;
-  executeRefresh();
-  return p;
+  if (pending) {
+    clearTimeout(pending.timer);
+    const p = pending.promise;
+    executeRefresh();
+    return p;
+  }
+  return inFlight ?? Promise.resolve(null);
 }
 
 /** Cancel any pending refresh without executing it (test cleanup). */
 export function cancel(): void {
+  inFlight = null;
   if (!pending) return;
   clearTimeout(pending.timer);
   pending.resolve(null);

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -20,6 +20,9 @@ const isCI = (): boolean => {
   return !!(process.env.CI || process.env.TF_BUILD || process.env.GITHUB_ACTIONS);
 };
 
+/** How many distinct queries keep a memoized "did you mean" candidate pool. */
+const SUGGESTION_CACHE_ENTRIES = 32;
+
 /** Total + per-type symbol counts (both come from one GROUP BY scan). */
 export interface SymbolCounts {
   total: number;
@@ -55,6 +58,12 @@ export class XppSymbolIndex {
   private labelsDbPath: string = ':memory:';
   private symbolCountsCache: SymbolCounts | null = null;
   private symbolCountsPromise: Promise<SymbolCounts> | null = null;
+  // "Did you mean" candidate pools, keyed by query. An agent that guesses a name
+  // wrong tends to guess near it again, and both pools are derived purely from the
+  // index — recomputing them per probe is the whole cost of a failed search.
+  // Bounded so a long session cannot accumulate one entry per typo.
+  private suggestionNamesCache: Map<string, string[]> = new Map();
+  private symbolsByTermCache: Map<string, XppSymbol[]> | null = null;
   // Per-connection prepared-statement cache.  Prepared statements are bound to
   // their originating connection and cannot be shared across connections.
   private perConnStmtCache = new WeakMap<Database, Map<string, Statement>>();
@@ -1215,10 +1224,15 @@ export class XppSymbolIndex {
     return promise;
   }
 
-  /** Drop memoized counts — call after any write that changes symbol rows. */
+  /**
+   * Drop everything memoized from the symbols table — counts and the suggestion
+   * candidate pools. Call after any write that changes symbol rows.
+   */
   private invalidateSymbolCounts(): void {
     this.symbolCountsCache = null;
     this.symbolCountsPromise = null;
+    this.suggestionNamesCache.clear();
+    this.symbolsByTermCache = null;
   }
 
   private computeSymbolCountsSync(): SymbolCounts {
@@ -3481,12 +3495,36 @@ export class XppSymbolIndex {
    * Get candidate symbol names for fuzzy matching ("did you mean" suggestions).
    *
    * When a query is given, candidates are anchored to it: names sharing the
-   * query's leading characters plus names containing its root term (avoids
+   * query's leading characters plus names sharing its root term (avoids
    * always sampling the same alphabetical slice of a 580K-symbol index).
    * Without a query, falls back to the first 5000 names alphabetically.
+   *
+   * Both probes go through symbols_fts. `name LIKE '%root%'` cannot use any index
+   * — SQLite scans all 1.17M rows, synchronously, on exactly the path an agent hits
+   * when it guessed a name wrong, which it does routinely. FTS5 answers a prefix
+   * term from its term index instead. The trade is that infix candidates
+   * ("MyCustTable" for query "CustTable") are no longer offered; they scored below
+   * the 0.7 fuzzy threshold anyway, being far longer than the query.
    */
   getAllSymbolNames(query?: string, limit: number = 2000): string[] {
     const trimmed = query?.trim();
+    const cacheKey = `${trimmed ?? ''}|${limit}`;
+    const cached = this.suggestionNamesCache.get(cacheKey);
+    if (cached) return cached;
+
+    const names = this.computeSymbolNameCandidates(trimmed, limit);
+
+    // Bounded LRU-ish: a session probing dozens of wrong names must not pin an
+    // unbounded number of 2000-name arrays in memory.
+    if (this.suggestionNamesCache.size >= SUGGESTION_CACHE_ENTRIES) {
+      const oldest = this.suggestionNamesCache.keys().next().value;
+      if (oldest !== undefined) this.suggestionNamesCache.delete(oldest);
+    }
+    this.suggestionNamesCache.set(cacheKey, names);
+    return names;
+  }
+
+  private computeSymbolNameCandidates(trimmed: string | undefined, limit: number): string[] {
     if (!trimmed) {
       const stmt = this.db.prepare(`
         SELECT DISTINCT name
@@ -3502,27 +3540,40 @@ export class XppSymbolIndex {
       return names;
     }
 
-    const escapeLike = (value: string): string =>
-      value.replace(/\\/g, '\\\\').replace(/[%_]/g, '\\$&');
-
-    // Typo distance is usually in the tail of the name, so same-prefix names
-    // are the best candidate pool; contains-matches on the root term catch
-    // wrong-prefix typos (e.g. "CusTable" → "CustTable").
+    // Typo distance is usually in the tail of the name, so same-prefix names are
+    // the best candidate pool; the longer root-term prefix catches typos further
+    // in (e.g. "CusTable" → "CustTable") with a tighter, higher-quality window.
     const half = Math.max(1, Math.floor(limit / 2));
-    const prefix = escapeLike(trimmed.slice(0, 2));
-    const root = escapeLike(trimmed.slice(0, Math.max(3, Math.ceil(trimmed.length / 2))));
+    // FTS5 tokenizes on non-alphanumerics, so anything else in the term would be
+    // read as an operator (or a syntax error) rather than matched.
+    const ftsTerm = trimmed.replace(/[^a-zA-Z0-9]/g, '');
+    const prefix = ftsTerm.slice(0, 2);
+    const root = ftsTerm.slice(0, Math.max(3, Math.ceil(ftsTerm.length / 2)));
 
     const names = new Set<string>();
     const db = this.getReadDb();
+    if (prefix.length > 0) {
+      try {
+        const stmt = this.getReadStmt(db, 'suggest_fts_prefix', () =>
+          `SELECT s.name FROM symbols_fts fts JOIN symbols s ON s.id = fts.rowid
+           WHERE symbols_fts MATCH ? LIMIT ?`);
+        for (const probe of new Set([prefix, root])) {
+          for (const row of stmt.iterate(`{name} : "${probe}"*`, half) as IterableIterator<{ name: string }>) {
+            names.add(row.name);
+          }
+        }
+        return [...names];
+      } catch {
+        // FTS table missing (SKIP_FTS build) — fall through to the scan.
+      }
+    }
+
+    const escapeLike = (value: string): string =>
+      value.replace(/\\/g, '\\\\').replace(/[%_]/g, '\\$&');
     try {
       const prefixStmt = this.getReadStmt(db, 'suggest_prefix', () =>
         `SELECT DISTINCT name FROM symbols WHERE name LIKE ? ESCAPE '\\' LIMIT ?`);
-      for (const row of prefixStmt.iterate(`${prefix}%`, half) as IterableIterator<{ name: string }>) {
-        names.add(row.name);
-      }
-      const containsStmt = this.getReadStmt(db, 'suggest_contains', () =>
-        `SELECT DISTINCT name FROM symbols WHERE name LIKE ? ESCAPE '\\' LIMIT ?`);
-      for (const row of containsStmt.iterate(`%${root}%`, half) as IterableIterator<{ name: string }>) {
+      for (const row of prefixStmt.iterate(`${escapeLike(trimmed.slice(0, 2))}%`, half) as IterableIterator<{ name: string }>) {
         names.add(row.name);
       }
     } catch {
@@ -3535,8 +3586,20 @@ export class XppSymbolIndex {
    * Get symbols grouped by term (for relationship analysis)
    * Returns a map of term -> symbols with that term
    * Uses iterator to avoid loading all symbols into memory at once
+   *
+   * Memoized for the lifetime of the index contents: the query takes no arguments
+   * and hydrates the same 3000 rows every time, yet it sits on the failed-search
+   * path next to getAllSymbolNames — so every name an agent probes and misses paid
+   * for a fresh `SELECT *` of 3000 rows on the event loop.
    */
   getSymbolsByTerm(): Map<string, XppSymbol[]> {
+    if (this.symbolsByTermCache) return this.symbolsByTermCache;
+    const built = this.computeSymbolsByTerm();
+    this.symbolsByTermCache = built;
+    return built;
+  }
+
+  private computeSymbolsByTerm(): Map<string, XppSymbol[]> {
     const stmt = this.db.prepare(`
       SELECT *
       FROM symbols

--- a/src/tools/createD365File.ts
+++ b/src/tools/createD365File.ts
@@ -16,7 +16,8 @@ import { crossModelWriteRefusal } from '../utils/crossModelWriteGuard.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
 import { reindentXppSource } from '../utils/xppFormat.js';
 import { decodeXmlEntitiesFromXppSource } from './modifyD365File.js';
-import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject, bridgeCreateSmartTable, bridgeRefreshProvider } from '../bridge/index.js';
+import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject, bridgeCreateSmartTable } from '../bridge/index.js';
+import * as debouncedRefresh from '../bridge/debouncedRefresh.js';
 import { enforceGrounding } from '../utils/provenanceStore.js';
 import { gateOnFormPatternErrors, isFormPatternEnforceEnabled } from './validateFormPattern.js';
 import { validateFormExtensionControlShape, buildFormExtensionShapeError } from '../utils/formExtensionShapeValidator.js';
@@ -4594,6 +4595,13 @@ export async function handleCreateD365File(
 
     if (!args.xmlContent && !skipBridgeForExtensibleEnum && context?.bridge && actualModelName && canBridgeCreate(args.objectType)) {
       try {
+        // Settle any rebuild an earlier write in this session scheduled but did not
+        // wait for. Everything below reads the provider — the base object of an
+        // extension, the EDTs a table's fields extend — so a scaffold that creates
+        // an EDT and then a table using it must not see the pre-EDT model. Free
+        // when no write is outstanding.
+        await debouncedRefresh.flush();
+
         // The bridge's `properties` is a flat string map (C# Dictionary<string,string>).
         // Keep only SCALAR values and stringify them. Structured collections
         // (fields/fieldGroups/indexes/relations/values/enumValues/methods) are
@@ -4674,16 +4682,35 @@ export async function handleCreateD365File(
           // edt_metadata chain → name heuristic.
           if (bridgeParams.fields && bridgeParams.fields.length > 0) {
             const db = context.symbolIndex?.getReadDb?.();
-            for (const f of bridgeParams.fields as Record<string, unknown>[]) {
+            const fieldsToResolve = (bridgeParams.fields as Record<string, unknown>[]).filter(f => {
               const edt = f.edt as string | undefined;
-              if (!edt || f.type) continue;
+              if (!edt || f.type) return false;
+              // An "EDT" that is really an enum name needs AxTableFieldEnum + EnumType;
+              // decided from the local index, so it never reaches the bridge.
               if (db && !f.enumType && isEnumName(edt, db)) {
                 f.enumType = edt;
                 f.type = 'Enum';
                 delete f.edt;
-                continue;
+                return false;
               }
-              const resolved = (await bridgeEdtBaseType(context.bridge, edt))
+              return true;
+            });
+
+            // One readEdt per DISTINCT EDT, all in flight at once. Sequentially awaiting
+            // one round trip per field made a wide table's create wait out N latencies
+            // into the C# process end to end, and fields repeating an EDT paid for it
+            // twice. The bridge dispatch loop is single-threaded, so this pipelines the
+            // requests rather than truly parallelising them — the win is the round trips.
+            const baseTypes = new Map<string, string | undefined>();
+            await Promise.all(
+              [...new Set(fieldsToResolve.map(f => f.edt as string))].map(async edt => {
+                baseTypes.set(edt, await bridgeEdtBaseType(context.bridge, edt));
+              }),
+            );
+
+            for (const f of fieldsToResolve) {
+              const edt = f.edt as string;
+              const resolved = baseTypes.get(edt)
                 ?? (db ? resolveEdtBaseType(edt, db) : undefined)
                 ?? heuristicEdtBaseType(edt);
               if (resolved) {
@@ -4825,9 +4852,13 @@ export async function handleCreateD365File(
                 }
               }
 
-              // Eagerly refresh the bridge provider so the new object is immediately
-              // resolvable by subsequent modify calls in the same session.
-              try { await bridgeRefreshProvider(context.bridge); } catch { /* best-effort */ }
+              // Schedule (do not await) the provider rebuild that makes the new object
+              // resolvable to subsequent bridge calls. Awaiting it serialized a full
+              // DiskProvider rebuild into every create's response — once per object on a
+              // multi-object scaffold — for a provider generation the create itself never
+              // reads. The flush() gate at the top of this block and in modify_d365fo_file
+              // is what preserves same-session resolvability.
+              void debouncedRefresh.refresh(context.bridge);
 
               const rawLabelWarning = rawLabelBpWarning(args.properties, finalObjectName);
               // #35: CreateSmartTable ignores every property its C# switch does not
@@ -4921,9 +4952,8 @@ export async function handleCreateD365File(
             }
           }
 
-          // Eagerly refresh the bridge provider so the new object is immediately
-          // resolvable by subsequent modify calls in the same session.
-          try { await bridgeRefreshProvider(context.bridge); } catch { /* best-effort */ }
+          // Scheduled, not awaited — see the smart-table path above.
+          void debouncedRefresh.refresh(context.bridge);
 
           const rawLabelWarning = rawLabelBpWarning(args.properties, finalObjectName);
           // #35: C# CreateTable() runs the same SetAxTableProperty() switch as the
@@ -5171,9 +5201,11 @@ export async function handleCreateD365File(
       `[create_d365fo_file] ✅ Written: ${normalizedFullPath}  (${fileSizeKb} KB)`
     );
 
-    // Eagerly refresh the bridge provider so the new object is immediately
-    // resolvable by subsequent modify calls in the same session.
-    try { await bridgeRefreshProvider(context?.bridge); } catch { /* best-effort */ }
+    // This path paid for the rebuild TWICE: once here on the response path, and
+    // again inside the fire-and-forget bridgeValidateAfterWrite() below, which
+    // already goes through the same coalescer before reading the object back.
+    // Scheduling here collapses both into the one rebuild validation waits for.
+    if (context?.bridge) void debouncedRefresh.refresh(context.bridge);
 
     // Post-write validation via C# bridge (best-effort, non-fatal, fire-and-forget).
     // Not awaited: the validation goes through the sequential bridge stdin/stdout

--- a/src/tools/generateSmartTable.ts
+++ b/src/tools/generateSmartTable.ts
@@ -1104,6 +1104,18 @@ export async function handleGenerateSmartTable(
 }
 
 /**
+ * Resolved EDT base types for this session. Only RESOLVED answers go in —
+ * "undefined" is also what a same-session EDT returns before the provider rebuild
+ * that created it lands, so caching that would freeze the wrong answer in.
+ */
+const edtBaseTypeCache = new Map<string, string>();
+
+/** Forget memoized EDT base types (test isolation). */
+export function resetEdtBaseTypeCache(): void {
+  edtBaseTypeCache.clear();
+}
+
+/**
  * Resolve an EDT's primitive base type via the C# bridge (live IMetadataProvider).
  *
  * The bridge reads the real AxEdt element type (AxEdtDate/AxEdtReal/AxEdtInt64/…),
@@ -1113,13 +1125,21 @@ export async function handleGenerateSmartTable(
  * (String/Integer/Real/Date/Int64/Guid/…), or undefined when the bridge is
  * unavailable, doesn't know the EDT, or reports it as Enum (enum-backed EDTs are
  * handled separately via the enumType path, so we must not emit a bare "Enum" here).
+ *
+ * Memoized: a table with 20 fields issued 20 readEdt round trips into the C# process
+ * for values that cannot change under it, and the same EDTs recur across every table
+ * in a scaffold.
  */
 export async function bridgeEdtBaseType(bridge: BridgeClient | undefined, edtName: string): Promise<string | undefined> {
   if (!bridge?.isReady) return undefined;
+  const cacheKey = edtName.toLowerCase();
+  const cached = edtBaseTypeCache.get(cacheKey);
+  if (cached !== undefined) return cached;
   try {
     const info = await bridge.readEdt(edtName);
     const bt = (info as any)?.baseType;
     if (typeof bt !== 'string' || bt.length === 0 || bt === 'Enum') return undefined;
+    edtBaseTypeCache.set(cacheKey, bt);
     return bt;
   } catch {
     return undefined;

--- a/src/tools/modifyD365File.ts
+++ b/src/tools/modifyD365File.ts
@@ -31,6 +31,7 @@ import {
   bridgeAddFieldModification, bridgeAddMenuItemToMenu,
   bridgeRefreshProvider,
 } from '../bridge/index.js';
+import * as debouncedRefresh from '../bridge/debouncedRefresh.js';
 import { ProjectFileManager, ProjectFileFinder } from './createD365File.js';
 import { heuristicEdtBaseType } from './generateSmartTable.js';
 import { normalizeD365Xml } from '../utils/d365XmlNormalizer.js';
@@ -1859,6 +1860,12 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       containment.modelSegment || resolvedModelFromPath || modelName || getConfigManager().getModelName() || '',
     );
     if (memberPrefixNote) generationNote += memberPrefixNote;
+
+    // Settle a rebuild an earlier create/modify scheduled but did not wait for, so
+    // an object written moments ago resolves on the FIRST attempt. Without this the
+    // retry loop below would still recover — at the cost of a wasted bridge round
+    // trip plus a full rebuild. Free when no write is outstanding.
+    await debouncedRefresh.flush();
 
     let bridgeResult: { success: boolean; message: string } | null = null;
     let _bridgeRetried = false;

--- a/src/utils/indexStaleness.ts
+++ b/src/utils/indexStaleness.ts
@@ -15,6 +15,23 @@ const MAX_SCANNED_FILES = 5000;
 /** Files newer than the index by less than this are tolerated (clock skew, in-flight writes). */
 const TOLERANCE_MS = 60_000;
 
+/**
+ * How long a completed scan answers for.
+ *
+ * The scan is up to MAX_SCANNED_FILES synchronous statSync calls — 1-3 s of blocked
+ * event loop on Windows — and get_workspace_info ran it on every single call, with
+ * no cache and outside the in-flight dedup. Half of TOLERANCE_MS, so the cache can
+ * never widen the staleness blind spot beyond the one the comparison already grants.
+ */
+const SCAN_CACHE_MS = 30_000;
+
+const scanCache = new Map<string, { at: number; result: MtimeScanResult | null }>();
+
+/** Drop cached scans (test isolation, or after a known workspace write). */
+export function resetMetadataMtimeCache(): void {
+  scanCache.clear();
+}
+
 export interface MtimeScanResult {
   /** Epoch ms of the newest .xml/.label.txt file found */
   newestMtime: number;
@@ -27,8 +44,18 @@ export interface MtimeScanResult {
 /**
  * Recursively find the newest metadata file mtime under rootDir.
  * Returns null when the directory does not exist or contains no metadata files.
+ *
+ * Cached for SCAN_CACHE_MS per root — see that constant for why.
  */
 export function findNewestMetadataMtime(rootDir: string): MtimeScanResult | null {
+  const hit = scanCache.get(rootDir);
+  if (hit && Date.now() - hit.at < SCAN_CACHE_MS) return hit.result;
+  const result = scanNewestMetadataMtime(rootDir);
+  scanCache.set(rootDir, { at: Date.now(), result });
+  return result;
+}
+
+function scanNewestMetadataMtime(rootDir: string): MtimeScanResult | null {
   let newestMtime = 0;
   let newestFile = '';
   let scannedFiles = 0;

--- a/tests/bridge/debouncedRefresh.test.ts
+++ b/tests/bridge/debouncedRefresh.test.ts
@@ -7,7 +7,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Must import AFTER vi.useFakeTimers so setTimeout is intercepted
 vi.useFakeTimers();
 
-import { refresh, flush, cancel } from '../../src/bridge/debouncedRefresh';
+import {
+  refresh, flush, cancel, resetRefreshTracking, markRefreshStarted, getLastRefreshStartedAt,
+} from '../../src/bridge/debouncedRefresh';
 
 const makeBridge = (ready = true) => ({
   isReady: ready,
@@ -18,6 +20,10 @@ const makeBridge = (ready = true) => ({
 describe('debouncedRefresh', () => {
   afterEach(() => {
     cancel(); // clean up any pending state between tests
+    // The fake clock restarts at the same instant for every test, so a refresh
+    // recorded by the previous one sits in this one's future and would look like
+    // an already-satisfied rebuild to the redundancy check in executeRefresh().
+    resetRefreshTracking();
     vi.clearAllTimers();
   });
 
@@ -101,5 +107,58 @@ describe('debouncedRefresh', () => {
 
     // Flush remaining to clean up
     await flush();
+  });
+
+  it('flush waits for a rebuild that already fired on its timer', async () => {
+    // The writer no longer awaits the refresh, so by the time a modify calls
+    // flush() the settle timer may already have started the rebuild. Returning
+    // "nothing pending" there would hand the modify a half-rebuilt provider —
+    // exactly the stale-provider state the eager refresh existed to rule out.
+    let release!: () => void;
+    const bridge = makeBridge();
+    bridge.refreshProvider = vi.fn(
+      () => new Promise(res => { release = () => res({ success: true }); }),
+    );
+
+    refresh(bridge);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(bridge.refreshProvider).toHaveBeenCalledTimes(1);
+
+    let settled = false;
+    const waited = flush().then(r => { settled = true; return r; });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(false);
+
+    release();
+    expect(await waited).toEqual({ success: true });
+    expect(bridge.refreshProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a queued rebuild that a direct refresh has already performed', async () => {
+    // update_symbol_index and the modify auto-retry call bridgeRefreshProvider()
+    // straight through. Once that rebuild has started, the queued one can no
+    // longer discover anything — running it is a second full DiskProvider scan.
+    const bridge = makeBridge();
+    refresh(bridge);
+
+    await vi.advanceTimersByTimeAsync(50);
+    markRefreshStarted(); // stands in for a direct bridgeRefreshProvider()
+    expect(getLastRefreshStartedAt()).toBeGreaterThan(0);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(bridge.refreshProvider).not.toHaveBeenCalled();
+  });
+
+  it('still rebuilds when the write landed after the last refresh started', async () => {
+    // The mirror of the case above: the skip must key off WHEN the refresh was
+    // requested, or a write made during someone else's rebuild is never picked up.
+    const bridge = makeBridge();
+
+    markRefreshStarted();
+    await vi.advanceTimersByTimeAsync(50);
+    refresh(bridge);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(bridge.refreshProvider).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/metadata/symbolIndex-suggestionCost.test.ts
+++ b/tests/metadata/symbolIndex-suggestionCost.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Cost of the failed-search "did you mean" path.
+ *
+ * A search that finds nothing calls getAllSymbolNames() + getSymbolsByTerm(), and
+ * agents probe names they get wrong routinely. Both used to run unindexed work on
+ * every probe: `name LIKE '%root%'` cannot use any index, so SQLite scanned the
+ * whole symbols table, and getSymbolsByTerm re-hydrated the same 3000 rows.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+let index: XppSymbolIndex;
+
+beforeEach(() => {
+  index = new XppSymbolIndex(':memory:', ':memory:');
+  const sym = (name: string, type = 'table') =>
+    index.addSymbol({
+      name, type, filePath: '/x.xml', model: 'Test',
+      usedTypes: 'CustTable', // stored as the raw column value, not an array
+    } as any);
+
+  sym('CustTable');
+  sym('CustInvoiceJour');
+  sym('CustTrans');
+  sym('SalesTable');
+  sym('VendTable');
+});
+
+afterEach(() => index.close());
+
+describe('getAllSymbolNames', () => {
+  it('probes symbols_fts by prefix instead of scanning with LIKE', () => {
+    const getReadStmt = vi.spyOn(index, 'getReadStmt');
+
+    const names = index.getAllSymbolNames('CusTable');
+
+    expect(names).toContain('CustTable');
+    expect(getReadStmt.mock.calls.map(c => c[1])).toContain('suggest_fts_prefix');
+    // The unindexed contains-scan must be gone, not merely supplemented.
+    expect(getReadStmt.mock.calls.map(c => c[1])).not.toContain('suggest_contains');
+  });
+
+  it('answers a repeated probe from cache', () => {
+    index.getAllSymbolNames('CusTable');
+    const getReadStmt = vi.spyOn(index, 'getReadStmt');
+
+    const again = index.getAllSymbolNames('CusTable');
+
+    expect(again).toContain('CustTable');
+    expect(getReadStmt).not.toHaveBeenCalled();
+  });
+
+  it('drops the cached pool when symbols change', () => {
+    index.getAllSymbolNames('Cus');
+    index.addSymbol({ name: 'CusPredicted', type: 'class', filePath: '/y.xml', model: 'Test' } as any);
+
+    expect(index.getAllSymbolNames('Cus')).toContain('CusPredicted');
+  });
+});
+
+describe('getSymbolsByTerm', () => {
+  it('hydrates its 3000-row window once per index generation', () => {
+    const first = index.getSymbolsByTerm();
+    const prepare = vi.spyOn(index.db, 'prepare');
+
+    const second = index.getSymbolsByTerm();
+
+    expect(second).toBe(first);
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds after a write', () => {
+    const first = index.getSymbolsByTerm();
+    index.addSymbol({
+      name: 'CustPostingProfile', type: 'table', filePath: '/z.xml', model: 'Test',
+      usedTypes: 'CustTable', // stored as the raw column value, not an array
+    } as any);
+
+    const second = index.getSymbolsByTerm();
+    expect(second).not.toBe(first);
+    expect(second.has('custpostingprofile')).toBe(true);
+  });
+});

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -10,6 +10,8 @@ import { getExtensionNamingStyle } from '../../src/utils/modelClassifier';
 import { verifyD365ProjectTool } from '../../src/tools/verifyD365Project';
 import { handleCreateD365File } from '../../src/tools/createD365File';
 import { modifyD365FileTool, countTopLevelMethodBodies, splitTopLevelMethodBodies, isUnresolvedObjectError, extractMethodNameFromSource } from '../../src/tools/modifyD365File';
+import { resetEdtBaseTypeCache } from '../../src/tools/generateSmartTable';
+import * as debouncedRefresh from '../../src/bridge/debouncedRefresh';
 import type { XppServerContext } from '../../src/types/context';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
@@ -109,7 +111,14 @@ vi.mock('../../src/utils/modelClassifier', () => ({
 // guard has its own suite (tests/utils/crossModelWriteGuard.test.ts); allow it here
 // so these tests keep testing the thing they are about.
 beforeEach(() => { process.env.D365FO_CROSS_MODEL_WRITE_MODELS = 'Contoso,ContosoRobotics'; });
-afterEach(() => { delete process.env.D365FO_CROSS_MODEL_WRITE_MODELS; });
+afterEach(() => {
+  delete process.env.D365FO_CROSS_MODEL_WRITE_MODELS;
+  // Creates now schedule the provider rebuild instead of awaiting it, so every
+  // create leaves module-level state behind that the next test must not inherit.
+  debouncedRefresh.cancel();
+  debouncedRefresh.resetRefreshTracking();
+  resetEdtBaseTypeCache();
+});
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -2089,5 +2098,170 @@ describe('replace-all-fields EDT base type resolution', () => {
     expect(result.isError).toBeFalsy();
     const passedFields = mockBridgeReplaceAllFields.mock.calls[0][2] as any[];
     expect(passedFields[0]).toMatchObject({ name: 'Qty', edt: 'InventQty', type: 'InventQty' });
+  });
+});
+
+// ─── Provider-refresh scheduling and EDT resolution cost ────────────────────
+
+describe('write-path provider refresh', () => {
+  const CLASS_ARGS = {
+    objectType: 'class',
+    objectName: 'ContosoLatencyProbe',
+    modelName: 'Contoso',
+    packageName: 'Contoso',
+    packagePath: 'K:\\PackagesLocalDirectory',
+    addToProject: false,
+    sourceCode: 'public class ContosoLatencyProbe\n{\n}\n',
+  };
+
+  const bridgeWithRefresh = (extra: Record<string, unknown> = {}) => ({
+    isReady: true,
+    metadataAvailable: true,
+    refreshProvider: vi.fn(async () => ({ refreshed: true, elapsedMs: 7 })),
+    validateObject: vi.fn(async () => null),
+    createObject: vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\Contoso\\Contoso\\AxClass\\ContosoLatencyProbe.xml',
+      message: 'IMetadataProvider.Create',
+    })),
+    ...extra,
+  });
+
+  it('a create answers without waiting for the DiskProvider rebuild', async () => {
+    // The rebuild used to be awaited inside every create, so a multi-object
+    // scaffold paid for a full DiskProvider rebuild per object, on the response
+    // path, for a provider generation the create itself never reads.
+    const ctx = buildContext();
+    const bridge = bridgeWithRefresh();
+    (ctx as any).bridge = bridge;
+
+    const result = await handleCreateD365File(req('create_d365fo_file', CLASS_ARGS), ctx);
+
+    expect((result as any).isError).toBeFalsy();
+    expect(bridge.createObject).toHaveBeenCalledTimes(1);
+    expect(bridge.refreshProvider).not.toHaveBeenCalled();
+  });
+
+  it('the next create settles the rebuild the previous one scheduled', async () => {
+    // The guarantee that survives the deferral: an object written this session is
+    // resolvable to the NEXT bridge operation. A scaffold that creates an EDT and
+    // then a table using it must not read the pre-EDT model.
+    const ctx = buildContext();
+    const bridge = bridgeWithRefresh();
+    (ctx as any).bridge = bridge;
+
+    await handleCreateD365File(req('create_d365fo_file', CLASS_ARGS), ctx);
+    expect(bridge.refreshProvider).not.toHaveBeenCalled();
+
+    await handleCreateD365File(
+      req('create_d365fo_file', { ...CLASS_ARGS, objectName: 'ContosoLatencyProbe2' }),
+      ctx,
+    );
+    expect(bridge.refreshProvider).toHaveBeenCalledTimes(1);
+    // …and the second create's own rebuild is still outstanding, not awaited.
+    expect(bridge.createObject).toHaveBeenCalledTimes(2);
+  });
+
+  it('a modify settles an outstanding rebuild before its first bridge attempt', async () => {
+    // Without this the modify would still recover — via the null-result auto-retry
+    // — but only after a wasted round trip into the C# process.
+    const fsMod = await import('fs/promises');
+    (fsMod.readFile as any).mockResolvedValueOnce(
+      `<?xml version="1.0"?><AxTable><Name>ContosoRentEquipmentTable</Name></AxTable>`,
+    );
+
+    const ctx = buildContext();
+    const addIndex = vi.fn(async () => ({ success: true, api: 'IMetaTableProvider.Update' }));
+    const bridge = bridgeWithRefresh({ addIndex });
+    (ctx as any).bridge = bridge;
+
+    // Stand in for a create earlier in the session that deferred its rebuild.
+    void debouncedRefresh.refresh(bridge as any);
+    expect(bridge.refreshProvider).not.toHaveBeenCalled();
+
+    const result = await modifyD365FileTool(
+      req('modify_d365fo_file', {
+        objectType: 'table',
+        objectName: 'ContosoRentEquipmentTable',
+        operation: 'add-index',
+        indexName: 'EquipmentIdx',
+        indexFields: [{ fieldName: 'ContosoRentEquipmentId' }],
+        filePath: 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\ContosoRentEquipmentTable.xml',
+      }),
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(bridge.refreshProvider).toHaveBeenCalledTimes(1);
+    // One attempt — the refresh happened before it, not as a retry after a null.
+    expect(addIndex).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('EDT base-type resolution cost', () => {
+  const tableArgs = (fields: Array<Record<string, unknown>>) => ({
+    objectType: 'table-extension',
+    objectName: 'ContosoEdtProbe.Extension',
+    modelName: 'Contoso',
+    packageName: 'Contoso',
+    packagePath: 'K:\\PackagesLocalDirectory',
+    addToProject: false,
+    properties: { fields },
+  });
+
+  it('asks the bridge once per DISTINCT edt, and not again in a later create', async () => {
+    // One sequential readEdt per FIELD meant a wide table waited out N round trips
+    // into the single-threaded C# process for values that cannot change under it,
+    // and two fields sharing an EDT paid for it twice.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const readEdt = vi.fn(async (name: string) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve(); // one microtask — a sequential caller can never overlap here
+      inFlight--;
+      return { baseType: name === 'ContosoWhen' ? 'Date' : 'Real' };
+    });
+    const ctx = buildContext();
+    const createObject = vi.fn(async () => ({
+      success: true,
+      filePath: 'K:\\PackagesLocalDirectory\\Contoso\\Contoso\\AxTableExtension\\ContosoEdtProbe.Extension.xml',
+      message: 'IMetadataProvider.Create',
+    }));
+    (ctx as any).bridge = {
+      isReady: true,
+      metadataAvailable: true,
+      readEdt,
+      createObject,
+      refreshProvider: vi.fn(async () => ({ refreshed: true, elapsedMs: 1 })),
+      validateObject: vi.fn(async () => null),
+    };
+
+    const result = await handleCreateD365File(
+      req('create_d365fo_file', tableArgs([
+        { name: 'RateA', edt: 'ContosoAmount' },
+        { name: 'RateB', edt: 'ContosoAmount' },
+        { name: 'When', edt: 'ContosoWhen' },
+      ])),
+      ctx,
+    );
+
+    expect((result as any).isError).toBeFalsy();
+    expect(readEdt).toHaveBeenCalledTimes(2);
+    // Both distinct EDTs were in flight together — the loop no longer awaits one
+    // round trip before issuing the next.
+    expect(maxInFlight).toBe(2);
+    const fields = (createObject.mock.calls[0][0] as any).fields as any[];
+    expect(fields.map(f => f.type)).toEqual(['Real', 'Real', 'Date']);
+
+    // Second create, same EDTs: memoized, so no further round trips at all.
+    await handleCreateD365File(
+      req('create_d365fo_file', {
+        ...tableArgs([{ name: 'RateC', edt: 'ContosoAmount' }]),
+        objectName: 'ContosoEdtProbe2.Extension',
+      }),
+      ctx,
+    );
+    expect(readEdt).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/utils/indexStaleness.test.ts
+++ b/tests/utils/indexStaleness.test.ts
@@ -6,7 +6,9 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { findNewestMetadataMtime, checkIndexStaleness } from '../../src/utils/indexStaleness';
+import {
+  findNewestMetadataMtime, checkIndexStaleness, resetMetadataMtimeCache,
+} from '../../src/utils/indexStaleness';
 import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
 
 let tmpDir: string;
@@ -86,6 +88,32 @@ describe('checkIndexStaleness compact lines', () => {
     expect(report.compactLines).toHaveLength(2);
     expect(text).toContain('STALE');
     expect(text).toContain('update_symbol_index');
+  });
+});
+
+describe('findNewestMetadataMtime scan cache', () => {
+  // get_workspace_info ran this scan on every call: up to 5000 synchronous
+  // statSync calls, 1-3 s of blocked event loop on Windows, uncached and outside
+  // the in-flight dedup.
+  let cacheDir: string;
+
+  beforeAll(() => {
+    cacheDir = path.join(tmpDir, 'CacheModel', 'AxClass');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'First.xml'), '<AxClass/>');
+  });
+
+  it('does not re-walk the tree for a repeated call on the same root', () => {
+    const root = path.join(tmpDir, 'CacheModel');
+    resetMetadataMtimeCache();
+
+    expect(findNewestMetadataMtime(root)!.scannedFiles).toBe(1);
+    fs.writeFileSync(path.join(cacheDir, 'Second.xml'), '<AxClass/>');
+
+    expect(findNewestMetadataMtime(root)!.scannedFiles).toBe(1);
+
+    resetMetadataMtimeCache();
+    expect(findNewestMetadataMtime(root)!.scannedFiles).toBe(2);
   });
 });
 


### PR DESCRIPTION
**Phase 1.6** of the [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4).

## 1 — the awaited eager `refreshProvider`

**Design: writers schedule, readers settle.** Not fire-and-forget — the call-site comment ("so the new object is immediately resolvable by subsequent modify calls") is load-bearing, and this project has a documented Create-NRE whose precondition was a stale provider.

- Writers: the three awaited refreshes in create become `void debouncedRefresh.refresh(...)`.
- Readers: `await flush()` at create's bridge block and before modify's retry loop. `flush()` is a **synchronously-resolved no-op** when nothing is outstanding — which is why this does not make a *single* create 400 ms slower, the trap in naively awaiting `refresh()`.

Supporting fixes found along the way: `flush()` used to return `null` when nothing was pending, which after this change would let a modify run against a provider **mid-rebuild** — so in-flight tracking was added. `executeRefresh` now wraps `refreshProvider()` in an async IIFE because it could throw *synchronously*, and with `flush()` on the write path that would have turned a bridge hiccup into a failed create — this reproduced against the existing mocks. The settle timer is `unref`'d so a deferred rebuild cannot hold the process open at shutdown.

### What this actually buys — less than the finding implied

A create must **read** the provider (extension base objects, field EDTs), so a burst of creates cannot collapse to one rebuild: create *N+1* has to see what create *N* wrote. What you get is (a) the rebuild leaves the response path, (b) the trailing rebuild of a burst is never paid, (c) the XML-fallback path drops from two rebuilds to one — `bridgeValidateAfterWrite` already went through this coalescer and the awaited call was duplicating it, (d) genuinely concurrent writes inside the 400 ms window do coalesce. On a 5-object scaffold, roughly 5 rebuilds → 4 plus the double-rebuild fix. Real, not an order of magnitude.

### The residual, and how it was closed

Bridge-backed **read** paths (`get_object_info`, `find_references`, `extension_info`) could see a provider up to ~400 ms staler. Those files were owned by the reader-payload work, so rather than touch three readers, the follow-up commit settles the coalescer **in `toolHandler`'s bridge-readiness gate** — every bridge-backed tool passes through it, so reads and writes are covered in one place that cannot be forgotten when a reader is added. (Branch `perf/latency-flush`, opened separately so this PR stays reviewable; fold it in if you prefer one.)

## 2 — EDT resolution

Memoized, and the create loop resolves one call per **distinct** EDT via `Promise.all`. Only *resolved* answers are cached: `undefined` is also what a same-session EDT returns before its provider rebuild lands, so caching negatives would freeze a wrong "unknown" in for the session.

Honest caveat: the C# side (`Program.cs` `RunStdioLoop`) is a **strictly serial** read→dispatch→write loop, so `Promise.all` *pipelines* rather than parallelises — the saving is the N−1 Node↔C# round trips, not C# work. **The memoization is the larger win.**

## 3 — empty-search `LIKE '%x%'` over 1.17M rows

Now an FTS prefix probe, with the LIKE retained only as a SKIP_FTS-build fallback, plus a bounded 32-entry per-query memo. Both caches drop on any symbols-table write.

**Known behaviour change:** infix candidates are no longer offered (`MyCustTable` for query `CustTable`) — FTS can only answer prefixes. Such names are far longer than the query and scored under the 0.7 fuzzy threshold anyway, but this is a judgement call, not a provably equivalent rewrite, and it is documented in the code.

## 4 — staleness scan

30 s TTL cache, deliberately **half** the `TOLERANCE_MS = 60_000` the comparison already grants, so the cache cannot widen the staleness blind spot beyond what the check already tolerates.

## Verification

`tsc --noEmit` clean; full suite **2853 passed / 9 skipped**. Negative controls confirmed per finding (5/6, 1/1, 3/5, 1/1). The parallelism claim is bound by a deterministic max-in-flight counter, **not a clock** — this repo has a documented flake problem with real-clock sleeps.

## Worth knowing

A literal **NUL byte** written into a template literal (as a cache-key separator) made git classify `symbolIndex.ts` as binary, skip CRLF normalisation, and produce an 8,025-line whole-file diff. Caught before commit; the separator is now `|`. Failure signature: `git ls-files --eol` showing `w/-text` on a text file. This is the same trap that already left a NUL in `bridgeAdapter.ts`.

## Not verified

Nothing ran against a live bridge or a real 1.17M-row index. The FTS probe's candidate *quality* on a production-sized index, and the actual rebuild timings, rest on reasoning and on call counts against mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)