### PR TITLE
Settle the scheduled provider refresh at the bridge-readiness gate (Phase 1.6 follow-up)

### DIFF
--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -7,6 +7,7 @@ import {
   isToolAllowedInMode, isToolInProfile,
 } from '../server/serverMode.js';
 import { BRIDGE_BACKED_TOOLS, awaitBridgeReady } from '../bridge/bridgeReadiness.js';
+import * as debouncedRefresh from '../bridge/debouncedRefresh.js';
 import { searchUnifiedTool } from './searchUnified.js';
 import { getObjectInfoTool } from './getObjectInfo.js';
 import { findReferencesTool } from './findReferences.js';
@@ -202,6 +203,16 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       if (elapsed > 200) {
         console.error(`[toolHandler] ⏳ ${toolName}: bridge was starting, waited ${elapsed} ms → ${outcome}`);
       }
+
+      // Settle any provider rebuild a previous write scheduled but did not wait
+      // for. Writers now schedule the rebuild instead of awaiting it (so it
+      // leaves the response path), which means the freshness guarantee has to be
+      // re-established by the READER — otherwise a get_object_info issued right
+      // after a create could see a provider up to SETTLE_MS staler than before.
+      // Every bridge-backed tool passes through here, so this is the one place
+      // that covers reads and writes alike; it is a synchronously-resolved
+      // no-op when nothing is outstanding, so it costs a tick, not 400 ms.
+      await debouncedRefresh.flush();
     }
 
     // Enforce server mode: block local tools in read-only (Azure) mode, block search/analysis

--- a/tests/bridge/readerSettlesScheduledRefresh.test.ts
+++ b/tests/bridge/readerSettlesScheduledRefresh.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The reader half of the schedule/settle contract introduced with the
+ * debounced provider refresh.
+ *
+ * Writers no longer await `refreshProvider()` — they schedule it, so the
+ * DiskProvider rebuild leaves the response path. That moves the freshness
+ * guarantee onto the READER: without one, a `get_object_info` issued right
+ * after a create could see a provider up to SETTLE_MS staler than it did
+ * before the change, which is a (narrow) regression in exactly the direction
+ * the eager refresh existed to prevent.
+ *
+ * Every bridge-backed tool passes through the readiness gate in toolHandler,
+ * so settling there covers reads and writes alike — one place instead of one
+ * per reader, and impossible to forget when a reader is added.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+const handler = readFileSync('src/tools/toolHandler.ts', 'utf8');
+
+/** Source with comments stripped, so an explanatory comment cannot satisfy an assertion. */
+const code = handler
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^[ \t]*\/\/.*$/gm, '');
+
+describe('bridge-backed tools settle a scheduled provider refresh', () => {
+  it('flushes the coalescer inside the bridge-readiness gate', () => {
+    expect(code).toMatch(/debouncedRefresh\.flush\(\)/);
+
+    // It has to be INSIDE the `if (bridgeWait)` block: flushing for tools that
+    // never touch the bridge would be pointless work on every single call.
+    const gate = code.slice(code.indexOf('if (bridgeWait)'));
+    const gateEnd = gate.indexOf('\n    }');
+    expect(gate.slice(0, gateEnd)).toMatch(/await debouncedRefresh\.flush\(\)/);
+  });
+
+  it('settles AFTER the bridge is ready, not before', () => {
+    // Flushing before the bridge exists would rebuild nothing and then let the
+    // real write-scheduled rebuild sit unsettled behind it.
+    const block = code.slice(code.indexOf('if (bridgeWait)'));
+    expect(block.indexOf('await bridgeWait.outcome'))
+      .toBeLessThan(block.indexOf('debouncedRefresh.flush()'));
+  });
+
+  it('gates on the shared BRIDGE_BACKED_TOOLS set so a new reader is covered automatically', () => {
+    expect(code).toMatch(/BRIDGE_BACKED_TOOLS\.has\(toolName\)/);
+  });
+});


### PR DESCRIPTION
Follow-up to **#862** (Phase 1.6), closing the one residual that PR names.

## Why

Writers now *schedule* the DiskProvider rebuild instead of awaiting it, so it leaves the response path. That moves the freshness guarantee onto the **reader**: without one, a `get_object_info` issued right after a create could see a provider up to `SETTLE_MS` staler than before — a narrow regression in exactly the direction the eager refresh existed to prevent, and this project has a documented Create-NRE whose precondition was a stale provider.

## Where

`toolHandler`'s bridge-readiness gate, not the three reader files. Every bridge-backed tool passes through it, so:

- reads and writes are covered by **one** call instead of one per reader;
- it cannot be forgotten when a reader is added — the gate keys off the shared `BRIDGE_BACKED_TOOLS` set;
- it does not collide with the reader-payload work in #860, which owns `getObjectInfo.ts`/`formInfo.ts`/`reportInfo.ts`.

Placed **after** `await bridgeWait.outcome`: flushing before the bridge is ready would rebuild nothing and then leave the real write-scheduled rebuild sitting unsettled behind it.

`flush()` is a synchronously-resolved no-op when nothing is outstanding, so this costs a tick — not the 400 ms that naively awaiting `refresh()` would have cost a single create.

## Verification

Source-level test (comment-stripped, so an explanatory comment cannot satisfy an assertion) pinning that the flush is inside the gate, after the readiness await, and behind the shared tool set. **2 of 3 fail** without the change; the third is the guard that the gate still keys off `BRIDGE_BACKED_TOOLS`.

Full suite: 2863 passed, `tsc --noEmit` clean.

Kept separate from #862 so that PR stays reviewable — fold it in if you prefer one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)