### PR TITLE
Commit the pre-fix round-trip baseline (Phase 1 measurement, before half)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -81,3 +81,39 @@ Two gaps worth knowing about, because a green check does not mean what it looks 
 52.92% branches / 67.59% functions / 63.77% lines) so ordinary churn stays green
 while a real regression does not. Raise them when coverage rises; never lower them
 to make a build green.
+
+## Measuring round-trip cost
+
+The unit tests say whether the server is correct. They say nothing about what a
+session *costs*, and cost here is dominated by round trips rather than payload
+size: every tool call re-bills the whole cached context, so the floor is
+~1.6–2.2 AIU per call before any work happens.
+
+`d365fo-mcp session <log>` measures that from an agent-host debug log (see
+issue #845). It fits the cost model, attributes the total, counts the tool-turns
+that issued exactly ONE call, and lists the per-tool carry cost — the number that
+identifies where context actually accumulates.
+
+```bash
+# Copilot Chat writes one directory per session:
+#   %APPDATA%/Code/User/workspaceStorage/*/GitHub.copilot-chat/debug-logs/<id>/main.jsonl
+npm run cli -- session <path-to-main.jsonl>
+npm run cli -- session <path-to-main.jsonl> --json   # for tracking across releases
+```
+
+### The committed baseline
+
+`eval/round-trip-baseline.json` holds the numbers for two sessions measured
+**before** the Phase 1 round-trip work landed (the first audit PR merged
+2026-08-08T12:22Z; both sessions predate it). It exists so the improvement can be
+shown with numbers instead of re-derived by hand.
+
+To produce the "after" half: run a session of the **same shape** as one of the
+baseline entries against the current build, then compare `totals.costAiu`,
+`roundTrips.singleCallShare` and the `topCarry` table. Shape matters — the two
+baseline sessions differ by 305 vs 178 AIU because they are different tasks, so a
+delta against a differently-shaped session measures the task, not the change.
+
+⚠️ **Never commit a raw log.** They contain real prompts and customer object
+names. The baseline holds derived numbers only, and the test fixture for the
+analyzer is redacted.

--- a/eval/round-trip-baseline.json
+++ b/eval/round-trip-baseline.json
@@ -1,0 +1,160 @@
+{
+  "schemaVersion": 1,
+  "measuredOn": "2026-08-08",
+  "measuredAgainst": "main BEFORE the Phase 1 round-trip work — the first audit PR (#848) merged 2026-08-08T12:22Z, and both sessions below predate that.",
+  "producedBy": "d365fo-mcp session <log> --json",
+  "privacy": "Derived numbers only. The raw logs hold real prompts and customer object names and must never be committed.",
+  "howToCompare": "Run a session of the same shape against the current build, then: npm run cli -- session <log> --json  and compare totals.costAiu, roundTrips.singleCallShare and the topCarry table against the entries here.",
+  "sessions": [
+    {
+      "session": "A",
+      "note": "the session audited in issue #824",
+      "totals": {
+        "costAiu": 305.18,
+        "requests": 95,
+        "billedRequests": 89,
+        "wallMinutes": 16.71
+      },
+      "fit": {
+        "usable": true,
+        "rates": {
+          "cached": 20,
+          "uncached": 249.99,
+          "output": 1000
+        }
+      },
+      "attribution": {
+        "cachedInput": 196.21,
+        "uncachedInput": 38.58,
+        "output": 70.39,
+        "fixedPrefix": 39.88,
+        "carry": 37.24,
+        "floorPerRequest": 2.2
+      },
+      "roundTrips": {
+        "toolCalls": 118,
+        "toolTurns": 88,
+        "singleCallTurns": 66,
+        "parallelTurns": 22,
+        "singleCallShare": 0.75,
+        "callsPerToolTurn": 1.34,
+        "avoidableRoundTrips": 5
+      },
+      "failedCalls": 2,
+      "resultsTruncated": 11,
+      "topCarry": [
+        {
+          "tool": "read_file",
+          "calls": 14,
+          "resultTokens": 13973,
+          "carryAiu": 13.51
+        },
+        {
+          "tool": "labels",
+          "calls": 6,
+          "resultTokens": 3842,
+          "carryAiu": 5.31
+        },
+        {
+          "tool": "get_knowledge",
+          "calls": 2,
+          "resultTokens": 2506,
+          "carryAiu": 3.21
+        },
+        {
+          "tool": "get_object_info",
+          "calls": 13,
+          "resultTokens": 1850,
+          "carryAiu": 2.82
+        },
+        {
+          "tool": "d365fo_file",
+          "calls": 10,
+          "resultTokens": 2320,
+          "carryAiu": 2.59
+        },
+        {
+          "tool": "grep_search",
+          "calls": 5,
+          "resultTokens": 3280,
+          "carryAiu": 1.82
+        }
+      ]
+    },
+    {
+      "session": "B",
+      "note": "a second pre-fix session, different task shape",
+      "totals": {
+        "costAiu": 177.54,
+        "requests": 69,
+        "billedRequests": 63,
+        "wallMinutes": 17.99
+      },
+      "fit": {
+        "usable": true,
+        "rates": {
+          "cached": 20,
+          "uncached": 249.99,
+          "output": 999.98
+        }
+      },
+      "attribution": {
+        "cachedInput": 103.36,
+        "uncachedInput": 29.29,
+        "output": 44.89,
+        "fixedPrefix": 27.46,
+        "carry": 18.14,
+        "floorPerRequest": 1.64
+      },
+      "roundTrips": {
+        "toolCalls": 114,
+        "toolTurns": 63,
+        "singleCallTurns": 36,
+        "parallelTurns": 27,
+        "singleCallShare": 0.57,
+        "callsPerToolTurn": 1.81,
+        "avoidableRoundTrips": 3
+      },
+      "failedCalls": 7,
+      "resultsTruncated": 3,
+      "topCarry": [
+        {
+          "tool": "get_knowledge",
+          "calls": 13,
+          "resultTokens": 6568,
+          "carryAiu": 5.44
+        },
+        {
+          "tool": "labels",
+          "calls": 23,
+          "resultTokens": 4208,
+          "carryAiu": 3.5
+        },
+        {
+          "tool": "get_object_info",
+          "calls": 15,
+          "resultTokens": 3228,
+          "carryAiu": 2.24
+        },
+        {
+          "tool": "prepare",
+          "calls": 4,
+          "resultTokens": 2658,
+          "carryAiu": 1.89
+        },
+        {
+          "tool": "d365fo_file",
+          "calls": 8,
+          "resultTokens": 1585,
+          "carryAiu": 0.93
+        },
+        {
+          "tool": "search",
+          "calls": 4,
+          "resultTokens": 514,
+          "carryAiu": 0.59
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The [audit plan](https://claude.ai/code/artifact/a74d4aab-cedd-4e75-84fa-c55014600bf4)'s closing section asks for the Phase 1 saving to be **shown with numbers**, measured before and after via issue #845. #866 built the instrument; this is the **before** half, measured with it so it never has to be re-derived by hand.

## ⚠️ The "after" half cannot be produced yet — and I will not fake it

I checked every Copilot session log on this machine. There are four; two use the MCP server:

| session | when | d365fo calls |
|---|---|---|
| A (`dd9edf20…`) | 2026-08-07 19:30 | 60 |
| B (`31b37af3…`) | 2026-08-08 06:21 | 89 |

The first audit PR (#848) merged at **2026-08-08T12:22Z**. **Both sessions predate it by hours**, so both are pre-fix — there is no post-fix session in existence, and one cannot be synthesised. Producing the after number means running a session of the same shape against the current build; `docs/TESTING.md` now says exactly how.

## The baseline

```
A  305.18 AIU · 118 calls · 66/88 (75%) single-call tool-turns · 5 avoidable · 2 failed
B  177.54 AIU · 114 calls · 36/63 (57%) single-call tool-turns · 3 avoidable · 7 failed
```

**Both are recorded on purpose.** They differ by 305 vs 178 AIU because they are different *tasks* — so a delta measured against a differently-shaped session measures the task, not the change. That caveat is the most important thing in this PR and it is written into `TESTING.md` rather than left implicit.

## What the baseline already pins, and how it maps onto Phase 1

- **Session B's largest single carry cost is `get_knowledge`** — 13 calls, 6,568 result tokens, 5.44 AIU. That is precisely the op-spec discovery hop that Phase 1.3 removes by returning the contract from `prepare`. If Phase 1 worked, this row should shrink.
- **5 and 3 avoidable round trips** from consecutive turns reaching for a pluralisable tool (`get_object_info` in both).
- **2 and 7 failed calls**, each a full round trip that bought nothing — session B's list includes `get_method`, now folded into `get_object_info` by Phase 1.5.
- Session A's fitted rates reproduce #824 exactly (20 / 249.99 / 1000, RMSE 2.65e-5), which is the evidence the arithmetic is trustworthy.

## Privacy

**Derived numbers only.** The raw logs hold real prompts and customer object names; they are not committed, the sessions are labelled A/B rather than by id, and the local file paths are stripped. `TESTING.md` states the rule.

## Verification

`tsc --noEmit` clean · `biome lint` clean · full suite 3194 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)