### PR TITLE
Stop advertising a tool surface that has not existed since 1.9.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@ PowerShell / any terminal command **WILL HANG** in VS 2022 / VS 2026 MCP integra
 | Revert the last write | `undo_last_modification` |
 | Search objects | `search` — multiple via `search(queries[])`, custom-only via `search(scope="extensions")` |
 | Read any object's metadata | `get_object_info(objectType, name, options?)` — objectType ∈ class/table/form/query/view/enum/edt/report/data-entity/menu-item/service/map/config-key/security-policy/macro. 2+ known names: `get_object_info(objects=[{objectType,objectName},…])` — ONE call, never a loop |
-| Method signature for CoC | `get_method(include="signature")` (already returned by `prepare(mode="change")`) |
+| Method signature for CoC | `get_object_info(objectType="class", name, options={method, include:"signature"})` (already returned by `prepare(mode="change")`) |
 | Validate X++ before write | `validate_code(mode="syntax", code)` — offline BP check, <50 ms |
 | X++ rules & patterns | `get_knowledge(kind="knowledge", topic)` — select grammar, CoC, BP rules, SysOperation, workflow, … |
 | Create a NEW form | `object_patterns(domain="form", action="analyze", recommend={...})` → `object_patterns(domain="form", action="spec", pattern)` → `generate_object(mode="scaffold", objectType="form", cloneFrom=referenceForm, tableMapping={...})` → `object_patterns(domain="form", action="validate", xml)` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,34 @@ those are called out explicitly below.
   `D365FO_ALLOW_CROSS_MODEL_WRITE`) and reintroduced a wrong tool count.
 - `QUICK_START.md` and `SETUP.md` disagreed on which setup scenario is D and
   which is E; two dead `SETUP.md#…` anchors.
+- Every remaining place that still advertised the pre-consolidation tool
+  surface. README's **first line** said "25 AI tools"; `MCP_EXTRA_TOOLS` was
+  documented with `security_info,get_method` in README, `MCP_CONFIG.md` and the
+  `server.extraTools` placeholder (which generates `CONFIGURATION.md`); `SETUP.md`
+  promised the write-only companion exposes `get_method`; and
+  `.github/copilot-instructions.md` — handed to the agent verbatim — taught
+  `get_method(include="signature")` as *the* route to a CoC signature, which is a
+  guaranteed unknown-tool call. `get_method`, `suggest_edt` and `batch_get_info`
+  have been folded into `get_object_info`/`prepare` since 1.9.0; their handlers
+  still route, so nothing broke loudly — it just cost a round trip each time.
+- The tool-count gate could not see either shape that had drifted. It matched
+  only a count directly adjacent to "tools", so `"25 AI tools"`,
+  `"25 specialized MCP tools"` and `"18 tools instead of 25"` all passed. It now
+  bridges up to three intervening words and reads the second number of a
+  comparison, and a companion gate forbids naming a retired-but-routable tool in
+  the eight files a reader or an agent is actually pointed at.
+- `tests/utils/loadEnvDepth.test.ts` measured the developer's machine rather than
+  `loadEnv`: with no config in the temp tree, precedence rule 4 falls back to
+  `process.cwd()/.env`, which under vitest is the repo root. Any working
+  (gitignored) `.env` therefore supplied a real `D365FO_PACKAGE_PATH` and the
+  "no configuration anywhere" case failed locally while passing in CI. The test
+  now runs from its own temp directory.
+
+### Removed
+- README's *"Keep the tool catalogue small"* section. The advice it carried
+  (turn off unused tool sets; `MCP_TOOL_PROFILE=core`) is documented where it is
+  configured — [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md) and
+  [`docs/MCP_CONFIG.md`](docs/MCP_CONFIG.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**25 AI tools that know every X++ class, table, form, and EDT in your D365FO codebase**
+**23 AI tools that know every X++ class, table, form, and EDT in your D365FO codebase**
 
 [![npm](https://img.shields.io/npm/v/d365fo-mcp.svg?logo=npm&color=cb3837)](https://www.npmjs.com/package/d365fo-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -29,7 +29,7 @@
 
 AI assistants excel at C#, Python, and JavaScript. X++ is different: your D365FO codebase is private, deeply customized, and invisible to every model — so AI confidently generates code that doesn't compile.
 
-This server pre-indexes your entire D365FO installation (580 000+ symbols across standard, ISV, and custom models) and exposes it as 25 specialized MCP tools. Every signature, every CoC wrapper, every label, every form pattern — verified against your real metadata **before** the AI writes a single line.
+This server pre-indexes your entire D365FO installation (580 000+ symbols across standard, ISV, and custom models) and exposes it as 23 specialized MCP tools. Every signature, every CoC wrapper, every label, every form pattern — verified against your real metadata **before** the AI writes a single line.
 
 ![Solution Architecture](docs/img/solution-architecture-diagram.svg)
 
@@ -98,18 +98,6 @@ npx d365fo-mcp connect https://your-server.azurewebsites.net
 ```
 
 Both paths in full — prerequisites, editor configuration for every scenario, the required instruction file, and how to verify grounding actually works: **[docs/QUICK_START.md](docs/QUICK_START.md)**
-
----
-
-## Keep the tool catalogue small
-
-Every tool your editor advertises is re-sent to the model on **every single request**, and the catalogue is shared across all MCP servers and built-in tool sets in the workspace — not just this one. Two things follow.
-
-**1. Turn off the tool sets you are not using in this workspace.** A measured D365FO session advertised 105 tools: 26 from this server, 14 from a Bicep MCP server that was never called, and ~57 built-in VS Code browser / Python / notebook / dotnet tools that were never called either. Past the host's inline-tool limit (VS Code: ~100 tools) the catalogue stops being sent inline and the model has to call a `tool_search` to *discover* a tool before it can use it — a silent extra round trip per tool it needs. That session spent six dedicated turns and ~20 seconds doing nothing but tool discovery. In VS Code: **Chat → Configure Tools…**, and untick whole tool sets you do not need for the task at hand. Other hosts have the same switch under a different name.
-
-**2. Run this server's `core` profile when the workspace is crowded.** `MCP_TOOL_PROFILE=core` publishes 18 tools instead of 25 — the plan → discover → write → build → verify loop — and drops the specialist ones (`extension_info`, `analyze_code`, `validate_code`, `security_info`, `get_method`, `run_systest_class`, `suggest_edt`). Add individual ones back with `MCP_EXTRA_TOOLS=security_info,get_method`, or set `server.toolProfile` / `server.extraTools` in `d365fo-mcp.json`. The default stays `full`, so an existing setup does not change until you ask it to. See [Configuration](docs/CONFIGURATION.md).
-
-Neither switch loses you any capability — a tool that is not advertised is still there the moment you turn it back on.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -196,7 +196,7 @@ Downloading a pre-built index from blob storage instead of building it locally.
   "server": {
     "mode": "full",
     "toolProfile": "full",
-    "extraTools": "security_info,get_method",
+    "extraTools": "security_info,run_systest_class",
     "port": 8080,
     "host": "0.0.0.0",
     "shutdownTimeoutMs": 5000,

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -73,7 +73,7 @@ Set in the `env` block. The legacy `"context": {...}` block is **deprecated** �
 |----------|---------|---------|
 | `MCP_SERVER_MODE` | `full` | `full` (23 tools) / `read-only` (Azure) / `write-only` (hybrid companion) |
 | `MCP_TOOL_PROFILE` | `full` | `full` (all 23) / `core` (18-tool create-and-build loop) — shrinks the catalogue when the workspace already runs other MCP servers |
-| `MCP_EXTRA_TOOLS` | — | comma-separated tool names added back on top of `core` (e.g. `security_info,get_method`) |
+| `MCP_EXTRA_TOOLS` | — | comma-separated tool names added back on top of `core` (e.g. `security_info,run_systest_class`) |
 | `DB_PATH` / `LABELS_DB_PATH` | repo `data/` | absolute paths to the SQLite databases — **required in stdio mode** |
 | `GROUNDING_ENFORCE` | off | fail-closed grounding gate for write tools — opt in |
 | `GROUNDING_SECRET` | — | shared secret → HMAC-signed portable grounding tokens; required for enforcement in hybrid / scaled-out deployments |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -106,7 +106,7 @@ npm run build
 
 `D365FO_CONFIG` points at the file `npm run setup` wrote — it already holds `server.mode: write-only`, the workspace and the solutions path for this companion. Add a variable to the `env` block only to override the file for that one server entry.
 
-The local companion also exposes the bridge-backed reader `get_object_info` (and `get_method`), so freshly created objects are immediately readable without waiting for an Azure index refresh.
+The local companion also exposes the bridge-backed reader `get_object_info` (including its `options.method` form), so freshly created objects are immediately readable without waiting for an Azure index refresh.
 
 **Update:** `git pull && npm install && npm run build` whenever a new version ships.
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -479,7 +479,7 @@ export const SETTINGS: Setting[] = [
     description:
       'Tool names to publish in addition to the core profile, e.g. security_info,run_systest_class. Ignored when ' +
       'the tool profile is "full".',
-    placeholder: 'security_info,get_method',
+    placeholder: 'security_info,run_systest_class',
   },
   {
     path: 'server.port',

--- a/tests/utils/loadEnvDepth.test.ts
+++ b/tests/utils/loadEnvDepth.test.ts
@@ -21,6 +21,7 @@ import { loadEnv } from '../../src/utils/loadEnv.js';
 
 let tmp: string;
 let savedEnv: NodeJS.ProcessEnv;
+let savedCwd: string;
 
 /**
  * A distinctive packages path that is absolute on this platform.
@@ -67,10 +68,21 @@ beforeEach(() => {
   delete process.env.D365FO_PACKAGE_PATH;
   delete process.env.ENV_FILE;
   delete process.env.D365FO_CONFIG;
+  // Run from a directory with no configuration in it. loadEnv falls back to
+  // `dotenv.config()` — i.e. process.cwd()/.env — when the caller's own install
+  // root has no .env, which is precedence rule 4 and deliberate. Under vitest
+  // the cwd is the repo root, so on any developer machine that has a working
+  // .env (untracked, gitignored) the "no configuration anywhere" case below
+  // loaded THAT file and read the developer's own D365FO_PACKAGE_PATH. It
+  // passed in CI, where no .env exists, and failed locally — the test was
+  // measuring the machine, not the code.
+  savedCwd = process.cwd();
+  process.chdir(tmp);
 });
 
 afterEach(() => {
   process.env = savedEnv;
+  process.chdir(savedCwd);
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -63,13 +63,23 @@ describe('tool inventory contract', () => {
     // stay out. The bare-"all" shape is then re-checked against a window that
     // must mention tools, which is what keeps "8 GB (all 70)" — the label
     // languages — from reading as a tool count.
-    const COUNT_CLAIM = /\b(\d{2})[ -]tools?\b|\ball (\d{2})\b(?=[.)])/g;
+    // Two more shapes were added after the first version of this gate shipped,
+    // because it still passed a README whose FIRST LINE said "25 AI tools":
+    //  • "instead of 25" — the second number in a comparison carries no "tools"
+    //    of its own and does not end the clause;
+    //  • "25 AI tools" / "25 specialized MCP tools" — the count and the noun are
+    //    separated by adjectives, which the adjacency shape above cannot bridge.
+    // The second one allows up to three intervening words, which is what keeps
+    // "~57 built-in VS Code browser / Python / notebook / dotnet tools" (a
+    // measured VS Code catalogue, not a claim about this server) out.
+    const COUNT_CLAIM =
+      /\b(\d{2})(?:[ -][A-Za-z][\w-]*){0,3}[ -]tools?\b|\ball (\d{2})\b(?=[.)])|\binstead of (\d{2})\b/g;
     for (const rel of sources) {
       const text = readRepoFile(rel);
       for (const m of text.matchAll(COUNT_CLAIM)) {
         const window = text.slice(Math.max(0, m.index - 90), m.index + 90);
         if (!/tool/i.test(window)) continue;
-        const n = Number(m[1] ?? m[2]);
+        const n = Number(m[1] ?? m[2] ?? m[3]);
         expect(
           n === published || n === core,
           `${rel}: claims "${m[0].trim()}" but the server publishes ${published} tools ` +
@@ -91,6 +101,47 @@ describe('tool inventory contract', () => {
         `settings.ts still offers '${name}' as a core-profile exclusion, but it is not published`,
       ).toBe(false);
     }
+  });
+
+  it('never tells a reader or an agent to call an unpublished tool', () => {
+    // The gate above only ever read settings.ts, and the src/**/*.ts gate below
+    // cannot list get_method/suggest_edt at all — their handlers are deliberately
+    // still routable, so the name is legitimate inside src. That left the files a
+    // human or an agent actually reads ungated, and every one of them had drifted:
+    // README offered `MCP_EXTRA_TOOLS=security_info,get_method` and listed both
+    // retired names as core-profile exclusions, SETUP promised the companion
+    // exposes `get_method`, MCP_CONFIG used it as the MCP_EXTRA_TOOLS example, and
+    // copilot-instructions.md — the file the agent is handed verbatim — taught
+    // `get_method(include="signature")` as THE route to a CoC signature.
+    //
+    // MCP_TOOLS.md and CHANGELOG.md are excluded on purpose: they are where the
+    // retirement is documented, so naming the old tool there is the point.
+    const retiredButRoutable = ['get_method', 'suggest_edt', 'batch_get_info'];
+    const readerFacing = [
+      'README.md',
+      '.github/copilot-instructions.md',
+      'docs/SETUP.md',
+      'docs/QUICK_START.md',
+      'docs/MCP_CONFIG.md',
+      'docs/CONFIGURATION.md',
+      'docs/ARCHITECTURE.md',
+      'src/config/settings.ts',
+    ];
+    const offenders: string[] = [];
+    for (const rel of readerFacing) {
+      readRepoFile(rel).split('\n').forEach((line, i) => {
+        for (const name of retiredButRoutable) {
+          if (new RegExp(String.raw`\b${name}\b`).test(line)) {
+            offenders.push(`${rel}:${i + 1} → ${name}  |  ${line.trim().slice(0, 110)}`);
+          }
+        }
+      });
+    }
+    expect(
+      offenders,
+      `unpublished tool names in reader-facing text (they route, but nothing should ` +
+      `send anyone to them):\n${offenders.join('\n')}`,
+    ).toEqual([]);
   });
 
   it('keeps local-only tool set aligned with the published tool inventory', () => {


### PR DESCRIPTION
The catalogue has been **23 tools** since `71635d9`. README's *first line* still said 25.

`batch_get_info` folded into `get_object_info(objects[])`, `get_method` into `get_object_info(options.method)`, `suggest_edt` into `prepare(fieldsHint)`. All three handlers still route, so nothing failed loudly — it just cost a round trip every time something sent the agent to a name that is no longer published.

## What was wrong

| File | Claimed |
|---|---|
| `README.md:5` | **"25 AI tools…"** — the first line of the repo |
| `README.md:32` | "exposes it as 25 specialized MCP tools" |
| `README.md:110` | "18 tools instead of 25", and listed `get_method` / `suggest_edt` as core-profile exclusions |
| `README.md:110`, `docs/MCP_CONFIG.md:76` | `MCP_EXTRA_TOOLS=security_info,get_method` — adds back something unpublished |
| `src/config/settings.ts` (placeholder) | same example, and it **generates** `docs/CONFIGURATION.md:199`, so `npm run config:docs` reproduced it every run |
| `docs/SETUP.md:109` | write-only companion "exposes `get_object_info` (and `get_method`)" |
| `.github/copilot-instructions.md:38` | taught `get_method(include="signature")` as *the* route to a CoC signature |

The last one is the expensive one: that file is handed to the agent verbatim.

## Why no gate caught it

`toolInventory.test.ts` matched `\b(\d{2})[ -]tools?\b` — the count must sit next to the noun. `"25 AI tools"` and `"25 specialized MCP tools"` have adjectives in between; `"18 tools instead of 25"` puts the stale number second, where it carries no noun and does not end the clause. Three shapes, none visible.

- The count matcher now bridges up to three intervening words and reads the comparison form. Three, deliberately: it keeps the measured `~57 built-in VS Code browser / Python / notebook / dotnet tools` out, which is a fact about VS Code, not a claim about this server.
- The exclusion check only ever read `settings.ts`, and the `src/**/*.ts` gate *cannot* list `get_method`/`suggest_edt` — their handlers are deliberately routable, so the name is legitimate inside `src`. A second gate now covers the eight reader-facing files, with `MCP_TOOLS.md` and `CHANGELOG.md` excluded because naming the retired tool there is the point.

Both gates were verified against the pre-fix text — each fails with the offending line quoted, e.g. `README.md: claims "25 AI tools" but the server publishes 23 tools (core profile: 18)`.

## Also here

- **Removed** README's *"Keep the tool catalogue small"* section (requested). The advice lives where the switches are configured.
- **`loadEnvDepth.test.ts` was measuring the machine, not the code.** With no config in its temp tree, `loadEnv` falls back to `process.cwd()/.env` — precedence rule 4, deliberate — and under vitest the cwd is the repo root. Any working (gitignored) `.env` therefore supplied a real `D365FO_PACKAGE_PATH`, so *"leaves the variable unset when there is no configuration anywhere"* failed on every developer machine and passed in CI. Confirmed by probing `loadEnv` from a neutral cwd: `undefined`, as the test expects. It now runs from its own temp directory. No production behaviour changed.

## Verification

`3203 passed | 6 skipped`, `tsc --noEmit` clean, `npm run config:docs -- --check` up to date.

Pre-existing and unrelated: `tests/bridge/formAuthoringDefaults.test.ts` fails its `dotnet run` harness — confirmed failing on `main` via `git stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)