### PR TITLE
Let the active project decide the model, and stop crying wolf about the .rnrproj

### DIFF
--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -26,7 +26,7 @@ import { recordBridgeFailure } from './bridgeFailure.js';
 import type { BridgeAttempt } from './bridgeFailure.js';
 import * as debouncedRefresh from './debouncedRefresh.js';
 import { debugLog } from '../utils/logger.js';
-import { reindentXppSource } from '../utils/xppFormat.js';
+import { xppMethodSourceForXml } from '../utils/xppFormat.js';
 import { parseXppDeclaration } from '../metadata/xppDeclaration.js';
 import { rankCustomFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
 import {
@@ -1404,7 +1404,7 @@ export async function bridgeAddMethod(
     // The bridge stores sourceCode verbatim — whatever indentation the caller typed
     // (or didn't) ends up in the AOT XML as-is. Re-derive consistent indentation
     // from brace depth so ragged/flush-left input doesn't produce garbled formatting.
-    const result = await bridge.addMethod(objectType, objectName, methodName, reindentXppSource(sourceCode));
+    const result = await bridge.addMethod(objectType, objectName, methodName, xppMethodSourceForXml(sourceCode));
     return {
       success: result.success,
       message: result.success

--- a/src/knowledge/formPatterns/methodStubs.ts
+++ b/src/knowledge/formPatterns/methodStubs.ts
@@ -7,6 +7,7 @@
  */
 
 import { resolvePattern } from './index.js';
+import { xppMethodSourceForXml } from '../../utils/xppFormat.js';
 
 export interface MethodStub {
   name: string;
@@ -175,7 +176,7 @@ function methodXml(stub: MethodStub, indent: string): string {
   return (
     `${indent}<Method>\n` +
     `${indent}\t<Name>${stub.name}</Name>\n` +
-    `${indent}\t<Source><![CDATA[\n${stub.source}\n]]></Source>\n` +
+    `${indent}\t<Source><![CDATA[\n${xppMethodSourceForXml(stub.source)}]]></Source>\n` +
     `${indent}</Method>\n`
   );
 }
@@ -296,7 +297,7 @@ export function injectMethodStubs(
     if (closeIdx !== -1) {
       const insertAt = closeIdx + '</Method>'.length;
       const block = stubs.formMethods
-        .map((s) => `\n\t\t\t<Method>\n\t\t\t\t<Name>${s.name}</Name>\n\t\t\t\t<Source><![CDATA[\n${s.source}\n]]></Source>\n\t\t\t</Method>`)
+        .map((s) => `\n\t\t\t<Method>\n\t\t\t\t<Name>${s.name}</Name>\n\t\t\t\t<Source><![CDATA[\n${xppMethodSourceForXml(s.source)}]]></Source>\n\t\t\t</Method>`)
         .join('');
       result = result.slice(0, insertAt) + block + result.slice(insertAt);
       injected.push(...stubs.formMethods.map((s) => s.name));

--- a/src/server/toolSchemas/getWorkspaceInfo.ts
+++ b/src/server/toolSchemas/getWorkspaceInfo.ts
@@ -12,7 +12,7 @@ export const getWorkspaceInfoTool = {
       properties: {
         projectName: {
           type: 'string',
-          description: 'Only when the USER says "switch to <project>". Just the model name, e.g. "ContosoEDS"; path resolved from D365FO_SOLUTIONS_PATH. NOT a way to reach another model — reads span every model already, writes stay in the workspace model.',
+          description: 'Only when the USER says "switch to <project>". The PROJECT file name, e.g. "Contoso - FeatureManagement". NOT a model name: one model is built by many projects, so naming it selects none and the call is refused. Reads span every model already.',
         },
         projectPath: {
           type: 'string',

--- a/src/tools/analysis/validateFormPattern.ts
+++ b/src/tools/analysis/validateFormPattern.ts
@@ -19,6 +19,7 @@ import {
 } from '../../validation/formPatternValidator.js';
 import { resolveSubPattern } from '../../knowledge/formPatterns/index.js';
 import { canonicalSymbolName } from '../../utils/symbolLookup.js';
+import { resolveIndexedFilePath } from '../../utils/packagesRoot.js';
 import {
   walkFormDesign,
   type FormControlNode,
@@ -116,8 +117,11 @@ export async function validateFormPatternTool(
           }],
         };
       }
-      formXml = await fs.readFile(row.file_path, 'utf-8');
-      source = `${formName} (${row.file_path})`;
+      // The index stores some file_path values package-relative; read them
+      // against the packages root, not the process cwd. See resolveIndexedFilePath.
+      const resolved = resolveIndexedFilePath(row.file_path);
+      formXml = await fs.readFile(resolved, 'utf-8');
+      source = `${formName} (${resolved})`;
     }
   } catch (error) {
     return {

--- a/src/tools/readers/getWorkspaceInfo.ts
+++ b/src/tools/readers/getWorkspaceInfo.ts
@@ -22,9 +22,8 @@ import { buildPrefixDiagnostics, modelWritesLandIn } from '../analysis/prefixDia
 import {
   buildContextSnapshot, renderContextSnapshotSection, renderContextSnapshotCompact,
 } from '../../workspace/contextSnapshot.js';
-
-/** Models named inline by the compact project list before it summarises the rest. */
-const PROJECT_NAMES_SHOWN = 12;
+import { selectProject, renderSelectionFailure } from '../../workspace/projectSelector.js';
+import { projectDisplayName } from '../../workspace/projectMembership.js';
 
 export async function getWorkspaceInfoTool(
   request: CallToolRequest,
@@ -34,20 +33,28 @@ export async function getWorkspaceInfoTool(
   const configManager = getConfigManager();
   const args = (request as any).params?.arguments || {};
 
-  // projectName: resolve by name from known projects list (user-friendly switch)
+  // projectName: resolve to ONE project. A model name that several projects
+  // build is not a selection — see projectSelector.ts for why picking the first
+  // of them is the bug this replaced.
   if (args.projectName && !args.projectPath) {
-    const needle = (args.projectName as string).toLowerCase();
     const allProjects = configManager.getAllDetectedProjects();
-    const match = allProjects.find(p => p.modelName.toLowerCase() === needle)
-      ?? allProjects.find(p => p.modelName.toLowerCase().includes(needle));
-    if (!match) {
-      const names = allProjects.map(p => p.modelName).join(', ') || '(none — set D365FO_SOLUTIONS_PATH)';
+    const selection = selectProject(args.projectName as string, allProjects);
+    if (selection.kind !== 'resolved') {
       return {
-        content: [{ type: 'text', text: `❌ No project found matching "${args.projectName}".\nAvailable: ${names}` }],
+        content: [{ type: 'text', text: renderSelectionFailure(selection, allProjects) }],
         isError: true,
       };
     }
-    args.projectPath = match.projectPath;
+    if (!selection.project.projectPath) {
+      return {
+        content: [{
+          type: 'text',
+          text: `❌ "${args.projectName}" resolved to model "${selection.project.modelName}", which has no .rnrproj on record — there is nothing to switch to.`,
+        }],
+        isError: true,
+      };
+    }
+    args.projectPath = selection.project.projectPath;
   }
 
   // projectPath: force-switch to specific .rnrproj
@@ -192,27 +199,26 @@ export async function getWorkspaceInfoTool(
       lines.push(``);
       for (const p of allProjects) {
         const active = p.projectPath === projectPath ? '▶ ' : '  ';
-        lines.push(`${active}${p.modelName.padEnd(40)} ${p.projectPath}`);
+        const stem = p.projectPath ? projectDisplayName(p.projectPath) : '(no .rnrproj)';
+        lines.push(`${active}${stem.padEnd(46)} ${p.modelName.padEnd(24)} ${p.projectPath ?? ''}`);
       }
       lines.push(``);
-      lines.push(`To switch project: call get_workspace_info with projectName = "<ModelName>"`);
+      lines.push(`To switch project: get_workspace_info(projectName="<project file name>") — the name in the first column, not the model.`);
     } else {
-      // Names only: a switch is by projectName, so the paths are dead
-      // weight — and one solution can hold dozens of them. Duplicated
-      // model names (several projects, one model) collapse to one entry.
-      const seen = new Set<string>();
-      const names: string[] = [];
-      for (const p of allProjects) {
-        const key = p.modelName.toLowerCase();
-        if (seen.has(key)) continue;
-        seen.add(key);
-        names.push(p.projectPath === projectPath ? `▶${p.modelName}` : p.modelName);
-      }
-      const shown = names.slice(0, PROJECT_NAMES_SHOWN);
-      const rest = names.length - shown.length;
+      // The active project is already on the `Project :` line above, so this
+      // only has to say what else exists and how to reach it.
+      //
+      // It used to list model names, deduped by model — which turned the
+      // fifteen .rnrproj of one model into a single entry called
+      // "ContosoFin" and then told the agent to switch by that name. The
+      // agent did, landed on whichever of the fifteen came first, and wrote
+      // there. The affordance itself was the bug; naming projects costs
+      // fewer bytes than naming models did anyway.
+      const others = allProjects.length - 1;
       lines.push(
-        `Projects    : ${shown.join(', ')}${rest > 0 ? `, +${rest} more` : ''}  ` +
-        `(switch: get_workspace_info(projectName="<ModelName>"))`,
+        `Projects    : ${allProjects.length} in solution` +
+        (others > 0 ? ` (${others} besides the active one)` : '') +
+        `  — list with diagnostics=true; switch with projectName="<project file name>"`,
       );
     }
   }

--- a/src/tools/sdlc/runBpCheck.ts
+++ b/src/tools/sdlc/runBpCheck.ts
@@ -48,6 +48,47 @@ const INDEX_TYPE_TO_ELEMENT_TYPE: Record<string, string> = {
 
 const RESOLVABLE_INDEX_TYPES = Object.keys(INDEX_TYPE_TO_ELEMENT_TYPE);
 
+/**
+ * Translate a caller-supplied objectType into the token xppbp accepts.
+ *
+ * The map above existed but was only consulted when the caller OMITTED the
+ * type; a supplied one was passed through `.toLowerCase()`. So the kebab-case
+ * spelling every other tool in this server takes — `objectType:
+ * "table-extension"`, exactly as verify_d365fo_project documents it — reached
+ * xppbp verbatim and was rejected with "The element type 'table-extension' is
+ * invalid". Same vocabulary, two tools, one of them wrong.
+ *
+ * Anything already in xppbp's own spelling ("TableExtension") still works: it
+ * squashes to the same token.
+ */
+export function normalizeElementType(raw: string): string {
+  const kebab = raw.trim().toLowerCase();
+  const mapped = INDEX_TYPE_TO_ELEMENT_TYPE[kebab];
+  if (mapped) return mapped;
+  return kebab.replace(/[-_\s]/g, '');
+}
+
+/**
+ * xppbp's "I did not run" responses, as a sentence — or '' when it ran.
+ *
+ * A rejected element type makes xppbp print a complaint and no findings, and
+ * "no findings" is indistinguishable from a clean object unless something looks
+ * for the complaint. It did not, so a check that never executed was reported as
+ * `✅ clean`, which is the one BP outcome worse than a failure: it is a pass the
+ * caller will act on.
+ */
+export function describeNonRun(output: string): string {
+  const invalidType = output.match(/The element type '([^']*)' is invalid/i);
+  if (invalidType) {
+    return `xppbp rejected the element type "${invalidType[1]}", so no rules were evaluated for this object. ` +
+      `Use the kebab-case objectType the other tools take (e.g. "table-extension") and it will be translated.`;
+  }
+  if (/\b0 elements processed\b/i.test(output)) {
+    return `xppbp processed 0 elements — the filter matched nothing, so this result is not evidence of a clean object.`;
+  }
+  return '';
+}
+
 // Tool registration (name, description, inputSchema) lives in
 // src/server/toolSchemas/runBpCheck.ts — the single source of truth for tool
 // instructions. It is NOT in mcpServer.ts; that file only spreads the
@@ -284,7 +325,7 @@ export const runBpCheckTool = async (params: any, context: any) => {
     const resolveErrors: string[] = [];
     for (const t of requested) {
       if (t.type) {
-        targets.push({ name: t.name, elementType: t.type.toLowerCase() });
+        targets.push({ name: t.name, elementType: normalizeElementType(t.type) });
         continue;
       }
       const { elementType, error } = resolveElementType(t.name, db);
@@ -444,6 +485,18 @@ export const runBpCheckTool = async (params: any, context: any) => {
     if (runTargets.length === 1) {
       const combined = combinedByTarget[0];
       const target = runTargets[0];
+      const notRun = describeNonRun(combined);
+      if (notRun) {
+        return {
+          content: [{
+            type: 'text',
+            text: `❌ BP Check did NOT run — nothing was verified.\n\n${header}` +
+              (target ? `\nFilter: ${selector(target)}` : '') +
+              `\n\n${notRun}\n\n${combined || '(no output)'}`,
+          }],
+          isError: true,
+        };
+      }
       // #25: report honestly whether the requested scope actually took effect —
       // attribution used to require reading rule names and guessing.
       const scopeNote = target ? describeScope(target.name, combined) : '';
@@ -461,11 +514,19 @@ export const runBpCheckTool = async (params: any, context: any) => {
 
     // Batch: one preamble, findings grouped per object (#828).
     const { preamble, bodies } = splitSharedPreamble(combinedByTarget);
-    const issueCount = combinedByTarget.filter(hasIssues).length;
+    const nonRunByTarget = combinedByTarget.map(describeNonRun);
+    const notRunCount = nonRunByTarget.filter(Boolean).length;
+    const issueCount = combinedByTarget.filter((o, i) => !nonRunByTarget[i] && hasIssues(o)).length;
 
     const groups = runTargets.map((target, i) => {
       const combined = combinedByTarget[i];
       const body = bodies[i].join('\n').trim();
+      const notRun = nonRunByTarget[i];
+      if (notRun) {
+        // A rejected element type produces no findings, and "no findings" used
+        // to render as ✅ clean — a check that never ran, reported as a pass.
+        return `── ${selector(target)} ── ❌ NOT CHECKED\n${notRun}\n${body || ''}`.trimEnd();
+      }
       return (
         `── ${selector(target)} ── ${hasIssues(combined) ? '⚠️ issues' : '✅ clean'}` +
         (target ? describeScope(target.name, combined) : '') +
@@ -473,17 +534,23 @@ export const runBpCheckTool = async (params: any, context: any) => {
       );
     });
 
+    const verdict =
+      notRunCount > 0 ? `❌ BP Check incomplete — ${notRunCount} object(s) were NOT checked`
+      : issueCount > 0 ? '⚠️ BP Check completed with issues'
+      : '✅ BP Check passed';
+
     return {
       content: [{
         type: 'text',
-        text: `${issueCount > 0 ? '⚠️ BP Check completed with issues' : '✅ BP Check passed'} — ` +
+        text: `${verdict} — ` +
           `${runTargets.length} objects checked, ${issueCount} with findings\n\n${header}` +
           labelNote +
           (preamble.length > 0
             ? `\n\nShared xppbp preamble (identical for all ${runTargets.length} objects, shown once):\n${preamble.join('\n').trim()}`
             : '') +
           `\n\n${groups.join('\n\n')}`
-      }]
+      }],
+      ...(notRunCount > 0 ? { isError: true } : {}),
     };
   } catch (error: any) {
     console.error('Error running BP Check:', error);

--- a/src/tools/sdlc/verifyD365Project.ts
+++ b/src/tools/sdlc/verifyD365Project.ts
@@ -8,9 +8,9 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import { Parser } from '../../utils/xml.js';
 import type { XppServerContext } from '../../types/context.js';
 import { getConfigManager } from '../../utils/configManager.js';
+import { readProjectIncludes, resolveMembership, projectDisplayName } from '../../workspace/projectMembership.js';
 import { defaultPackagesRoot } from '../../utils/packagesRoot.js';
 import { PackageResolver } from '../../utils/packageResolver.js';
 
@@ -92,24 +92,6 @@ const VerifyD365ProjectArgsSchema = z.object({
     .describe('Base package path (default: auto-detected PackagesLocalDirectory)'),
 });
 
-/** Read all Content Include values from a .rnrproj XML file. */
-async function readProjectIncludes(projectPath: string): Promise<Set<string>> {
-  const parser = new Parser({ explicitArray: true });
-  const xml = await fs.readFile(projectPath, 'utf-8');
-  const parsed = await parser.parseStringPromise(xml);
-
-  const includes = new Set<string>();
-  const itemGroups: any[] = parsed?.Project?.ItemGroup ?? [];
-  for (const group of itemGroups) {
-    const contents: any[] = Array.isArray(group.Content) ? group.Content : [];
-    for (const c of contents) {
-      const inc: string | undefined = c?.$?.Include;
-      if (inc) includes.add(inc);
-    }
-  }
-  return includes;
-}
-
 export async function verifyD365ProjectTool(
   request: CallToolRequest,
   _context: XppServerContext
@@ -180,6 +162,18 @@ export async function verifyD365ProjectTool(
       }
     }
 
+    // The model's OTHER projects. Membership is a model-wide question: a file
+    // registered in the project that owns it is registered, and calling that
+    // "missing" is how one file ends up in two projects.
+    // Degrades to the active project alone rather than throwing: a solution
+    // scan that has not run yet must narrow this answer, not replace the whole
+    // verification with an error.
+    let siblingProjectPaths: string[] = [];
+    try {
+      siblingProjectPaths = (configManager.getProjectsForModel?.(actualModelName) ?? [])
+        .filter(p => p !== resolvedProjectPath);
+    } catch { /* no sibling projects known */ }
+
     // verify-all mode: when no objects are supplied, derive them from the project's
     // Content Includes (e.g. "AxClass\MyClass" → { class, MyClass }).
     type VerifyObject = { objectType: (typeof OBJECT_TYPES)[number]; objectName: string };
@@ -228,7 +222,9 @@ export async function verifyD365ProjectTool(
       filePath: string;
       diskStatus: 'ok' | 'missing' | 'error';
       diskError?: string;
-      projectStatus: 'ok' | 'missing' | 'no-project';
+      projectStatus: 'ok' | 'missing' | 'elsewhere' | 'no-project';
+      /** Projects referencing the object, when it is not the active one. */
+      ownedBy: string[];
     };
 
     const results: ObjectResult[] = [];
@@ -252,12 +248,21 @@ export async function verifyD365ProjectTool(
         }
       }
 
-      // Project check
+      // Project check, across every project of the model. An object registered
+      // in the project that OWNS it is registered — reporting it as missing
+      // invites a second entry for one file, and then it compiles twice.
       let projectStatus: ObjectResult['projectStatus'] = 'no-project';
-      if (projectIncludes !== null) {
-        // Content Include uses backslash, no .xml extension: "AxClass\MyClass"
-        const includeKey = `${axFolder}\\${obj.objectName}`;
-        projectStatus = projectIncludes.has(includeKey) ? 'ok' : 'missing';
+      let ownedBy: string[] = [];
+      if (resolvedProjectPath || siblingProjectPaths.length > 0) {
+        const membership = await resolveMembership(
+          axFolder, obj.objectName, resolvedProjectPath, siblingProjectPaths,
+        );
+        ownedBy = membership.owners;
+        projectStatus =
+          membership.status === 'active' ? 'ok'
+          : membership.status === 'other' ? 'elsewhere'
+          : membership.status === 'missing' ? 'missing'
+          : 'no-project';
       }
 
       results.push({
@@ -268,6 +273,7 @@ export async function verifyD365ProjectTool(
         diskStatus,
         diskError,
         projectStatus,
+        ownedBy,
       });
     }
 
@@ -290,8 +296,10 @@ export async function verifyD365ProjectTool(
       const projCell =
         r.projectStatus === 'ok'
           ? '✅'
+          : r.projectStatus === 'elsewhere'
+          ? `✅ in ${r.ownedBy.map(projectDisplayName).join(', ')}`
           : r.projectStatus === 'missing'
-          ? `❌ Not in project (\`${r.axFolder}\\${r.objectName}\`)`
+          ? `❌ In no project of this model (\`${r.axFolder}\\${r.objectName}\`)`
           : '⚠️ No project path';
 
       return hasProject
@@ -301,15 +309,25 @@ export async function verifyD365ProjectTool(
 
     const diskOk      = results.filter((r) => r.diskStatus === 'ok').length;
     const diskMissing = results.filter((r) => r.diskStatus !== 'ok').length;
-    const projOk      = results.filter((r) => r.projectStatus === 'ok').length;
-    const projMissing = results.filter((r) => r.projectStatus === 'missing').length;
+    const projOk        = results.filter((r) => r.projectStatus === 'ok').length;
+    const projElsewhere = results.filter((r) => r.projectStatus === 'elsewhere').length;
+    const projMissing   = results.filter((r) => r.projectStatus === 'missing').length;
 
     const summaryLines = [
       `- Checked: ${results.length}`,
       `- On disk ✅: ${diskOk}   Missing from disk ❌: ${diskMissing}`,
     ];
     if (hasProject) {
-      summaryLines.push(`- In project ✅: ${projOk}   Missing from project ❌: ${projMissing}`);
+      summaryLines.push(
+        `- In the active project ✅: ${projOk}` +
+        (projElsewhere > 0 ? `   In another project of this model ✅: ${projElsewhere}` : '') +
+        `   In no project ❌: ${projMissing}`,
+      );
+      if (projElsewhere > 0) {
+        summaryLines.push(
+          `- Objects marked "in <project>" are registered where they belong — do NOT add them to the active project as well.`,
+        );
+      }
     }
     if (projectLoadError) {
       summaryLines.push(`- ⚠️ Could not read project file: ${projectLoadError}`);

--- a/src/tools/smart/generateSmartForm.ts
+++ b/src/tools/smart/generateSmartForm.ts
@@ -11,7 +11,7 @@ import { handleGetFormPatterns } from '../knowledge/getFormPatterns.js';
 import path from 'path';
 import fs from 'fs';
 import { getConfigManager } from '../../utils/configManager.js';
-import { defaultPackagesRoot } from '../../utils/packagesRoot.js';
+import { defaultPackagesRoot, resolveIndexedFilePath } from '../../utils/packagesRoot.js';
 import { resolveObjectPrefix, applyObjectPrefix, getObjectSuffix, applyObjectSuffix } from '../../utils/modelClassifier.js';
 import { ProjectFileManager } from '../../workspace/projectFile.js';
 import { extractModelFromProject, findProjectInSolution } from '../../utils/projectUtils.js';
@@ -1001,7 +1001,9 @@ export async function handleGenerateSmartForm(
       if (!table || seenTables.has(table.toLowerCase())) continue;
       seenTables.add(table.toLowerCase());
       const row = lookupSymbolNocase(db, table, ['table']);
-      const stale = row?.file_path && !fs.existsSync(row.file_path);
+      // Package-relative file_path rows would always miss here and mark a
+      // perfectly good table "stale" — see resolveIndexedFilePath.
+      const stale = row?.file_path && !fs.existsSync(resolveIndexedFilePath(row.file_path));
       if (row && !stale) continue;
       const stem = table.replace(/s$/i, '');
       const alt = db.prepare(

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -19,17 +19,14 @@ import { z } from 'zod';
 import { getConfigManager, fallbackPackagePath } from '../../utils/configManager.js';
 import { describePackagesRootScan } from '../../utils/packagesRoot.js';
 import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
-import { ProjectFileManager, ProjectFileFinder } from '../../workspace/projectFile.js';
-import {
-  axFolderForObjectType, resolveMembership, projectDisplayName, type Membership,
-} from '../../workspace/projectMembership.js';
+import { ProjectFileManager, ProjectFileFinder, registerFileIfOrphaned } from '../../workspace/projectFile.js';
 import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck, membershipOf } from './inlineWriteVerification.js';
 import { registerCustomModel } from '../../utils/modelClassifier.js';
 import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { PackageResolver } from '../../utils/packageResolver.js';
 import { crossModelWriteRefusal } from '../../utils/crossModelWriteGuard.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../../utils/xppDocGen.js';
-import { reindentXppSource } from '../../utils/xppFormat.js';
+import { xppMethodSourceForXml, reindentXppSource } from '../../utils/xppFormat.js';
 import { decodeXmlEntitiesFromXppSource } from '../../utils/xmlEscape.js';
 import { bridgeValidateAfterWrite, canBridgeCreate, bridgeCreateObject, bridgeCreateSmartTable, isBridgeFailure, describeBridgeFailure } from '../../bridge/index.js';
 import type { BridgeFailure } from '../../bridge/index.js';
@@ -94,61 +91,6 @@ function buildNoProjectPathWarning(): string {
     `      "projectPath": "K:\\\\VSProjects\\\\YourSolution\\\\YourModel\\\\YourModel.rnrproj"\n` +
     `    } }\n` +
     `  }\n`;
-}
-
-/**
- * Register an already-existing file into the active project, but only when no
- * project of its model has it.
- *
- * The "only when" is the whole design. A D365FO model is split across many
- * .rnrproj, and each object belongs to exactly one of them; registering a file
- * that its owning project already lists would put one element in two projects
- * and build it twice. So this closes a genuine gap and declines to create a
- * new one — and says which it did, because "already exists" on its own leaves
- * the caller unable to tell a compiling object from a stranded one.
- */
-async function registerExistingFileIfOrphaned(
-  objectType: string,
-  objectName: string,
-  modelName: string | undefined,
-  projectPath: string | undefined,
-): Promise<string> {
-  const axFolder = axFolderForObjectType(objectType);
-
-  let membership: Membership;
-  try {
-    const siblings = (getConfigManager().getProjectsForModel?.(modelName) ?? [])
-      .filter(p => p !== projectPath);
-    membership = await resolveMembership(axFolder, objectName, projectPath, siblings);
-  } catch {
-    // Advisory only: the "already exists" answer the caller came for must not
-    // become an error because a project file could not be inspected.
-    return '';
-  }
-
-  if (membership.status === 'active') return '';
-  if (membership.status === 'unknown') {
-    return `\n\nℹ️ No .rnrproj could be read, so whether this file is registered is unknown.`;
-  }
-  if (membership.status === 'other') {
-    const where = membership.owners.map(projectDisplayName).join(', ');
-    return `\n\n✅ Already registered in ${where} — that project owns it. Nothing to add here.`;
-  }
-
-  if (!projectPath) {
-    return `\n\n⚠️ No project of model "${modelName ?? '(unknown)'}" references \`${axFolder}\\${objectName}\`, ` +
-      `and no active projectPath is configured to add it to. It will not compile until some project does.`;
-  }
-  try {
-    const added = await new ProjectFileManager().addToProject(projectPath, objectType, objectName, '');
-    return added
-      ? `\n\n✅ The file was on disk but in no project of this model — added it to ${path.basename(projectPath)}. ` +
-        `Right-click the project → Reload Project if VS is open.`
-      : '';
-  } catch (e: any) {
-    return `\n\n⚠️ The file is in no project of this model and could not be added to ` +
-      `${path.basename(projectPath)}: ${e?.message ?? e}`;
-  }
 }
 
 const CreateD365FileArgsSchema = z.object({
@@ -635,10 +577,11 @@ export class XmlTemplateGenerator {
       declaration: result.declaration,
       // The bridge stores each method's source verbatim (no reformatting on its
       // side) — re-derive consistent indentation here so this CREATE path gets
-      // the same fix as bridgeAddMethod's MODIFY path.
+      // the same fix as bridgeAddMethod's MODIFY path, and end it the way
+      // shipped metadata does, with the blank line that separates methods.
       methods: result.methods.map(m => ({
         ...m,
-        source: m.source !== undefined ? reindentXppSource(m.source) : m.source,
+        source: m.source !== undefined ? xppMethodSourceForXml(m.source) : m.source,
       })),
     };
   }
@@ -3678,7 +3621,7 @@ export async function handleCreateD365File(
         // in the wire schema. So an object that existed but was unregistered
         // could never BECOME registered — which is how a table extension got
         // edited through a whole session while staying invisible to the build.
-        const projectNote = await registerExistingFileIfOrphaned(
+        const projectNote = await registerFileIfOrphaned(
           args.objectType, finalObjectName, actualModelName, projectPathToUse,
         );
 
@@ -3773,7 +3716,7 @@ export async function handleCreateD365File(
           if (props.methods) {
             bridgeParams.methods = (props.methods as { name: string; source?: string }[]).map(m => ({
               ...m,
-              source: m.source !== undefined ? reindentXppSource(m.source) : m.source,
+              source: m.source !== undefined ? xppMethodSourceForXml(m.source) : m.source,
             }));
           }
         }

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -20,8 +20,12 @@ import { getConfigManager, fallbackPackagePath } from '../../utils/configManager
 import { describePackagesRootScan } from '../../utils/packagesRoot.js';
 import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
 import { ProjectFileManager, ProjectFileFinder } from '../../workspace/projectFile.js';
-import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck } from './inlineWriteVerification.js';
-import { registerCustomModel, resolveObjectPrefix, applyObjectPrefix, getObjectSuffix, applyObjectSuffix, getExtensionNamingStyle } from '../../utils/modelClassifier.js';
+import {
+  axFolderForObjectType, resolveMembership, projectDisplayName, type Membership,
+} from '../../workspace/projectMembership.js';
+import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck, membershipOf } from './inlineWriteVerification.js';
+import { registerCustomModel } from '../../utils/modelClassifier.js';
+import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { PackageResolver } from '../../utils/packageResolver.js';
 import { crossModelWriteRefusal } from '../../utils/crossModelWriteGuard.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../../utils/xppDocGen.js';
@@ -90,6 +94,61 @@ function buildNoProjectPathWarning(): string {
     `      "projectPath": "K:\\\\VSProjects\\\\YourSolution\\\\YourModel\\\\YourModel.rnrproj"\n` +
     `    } }\n` +
     `  }\n`;
+}
+
+/**
+ * Register an already-existing file into the active project, but only when no
+ * project of its model has it.
+ *
+ * The "only when" is the whole design. A D365FO model is split across many
+ * .rnrproj, and each object belongs to exactly one of them; registering a file
+ * that its owning project already lists would put one element in two projects
+ * and build it twice. So this closes a genuine gap and declines to create a
+ * new one — and says which it did, because "already exists" on its own leaves
+ * the caller unable to tell a compiling object from a stranded one.
+ */
+async function registerExistingFileIfOrphaned(
+  objectType: string,
+  objectName: string,
+  modelName: string | undefined,
+  projectPath: string | undefined,
+): Promise<string> {
+  const axFolder = axFolderForObjectType(objectType);
+
+  let membership: Membership;
+  try {
+    const siblings = (getConfigManager().getProjectsForModel?.(modelName) ?? [])
+      .filter(p => p !== projectPath);
+    membership = await resolveMembership(axFolder, objectName, projectPath, siblings);
+  } catch {
+    // Advisory only: the "already exists" answer the caller came for must not
+    // become an error because a project file could not be inspected.
+    return '';
+  }
+
+  if (membership.status === 'active') return '';
+  if (membership.status === 'unknown') {
+    return `\n\nℹ️ No .rnrproj could be read, so whether this file is registered is unknown.`;
+  }
+  if (membership.status === 'other') {
+    const where = membership.owners.map(projectDisplayName).join(', ');
+    return `\n\n✅ Already registered in ${where} — that project owns it. Nothing to add here.`;
+  }
+
+  if (!projectPath) {
+    return `\n\n⚠️ No project of model "${modelName ?? '(unknown)'}" references \`${axFolder}\\${objectName}\`, ` +
+      `and no active projectPath is configured to add it to. It will not compile until some project does.`;
+  }
+  try {
+    const added = await new ProjectFileManager().addToProject(projectPath, objectType, objectName, '');
+    return added
+      ? `\n\n✅ The file was on disk but in no project of this model — added it to ${path.basename(projectPath)}. ` +
+        `Right-click the project → Reload Project if VS is open.`
+      : '';
+  } catch (e: any) {
+    return `\n\n⚠️ The file is in no project of this model and could not be added to ` +
+      `${path.basename(projectPath)}: ${e?.message ?? e}`;
+  }
 }
 
 const CreateD365FileArgsSchema = z.object({
@@ -3364,113 +3423,15 @@ export async function handleCreateD365File(
       };
     }
 
-    // Apply extension prefix to object name
-    const objectPrefix = resolveObjectPrefix(actualModelName);
-    const namingStyle = getExtensionNamingStyle();
-
-    // If EXTENSION_PREFIX differs from modelName, the AI may have embedded the modelName
-    // in the extension name. Strip it so applyObjectPrefix injects the correct prefix only.
-    // NOTE: this stripping only makes sense for the prefix-infix style. Under the
-    // model-name style the model name IS the desired token, so the stripping below is
-    // skipped and applyObjectPrefix (given actualModelName) normalises the name instead.
-    let effectiveObjectName = args.objectName;
-
-    // Case A: dot-notation extension elements (table/form/EDT/enum extensions)
-    // e.g. "CustTable.MyModelExtension" with modelName="MyModel" → "CustTable.Extension"
-    // applyObjectPrefix then produces "CustTable.MyExtension"
-    if (
-      namingStyle !== 'model-name' &&
-      args.objectName.includes('.') &&
-      args.objectName.toLowerCase().endsWith('extension') &&
-      actualModelName &&
-      objectPrefix.toLowerCase() !== actualModelName.toLowerCase()
-    ) {
-      const dotIdx = args.objectName.lastIndexOf('.');
-      const basePart = args.objectName.slice(0, dotIdx);
-      const suffixPart = args.objectName.slice(dotIdx + 1);
-      if (suffixPart.toLowerCase().startsWith(actualModelName.toLowerCase())) {
-        effectiveObjectName = `${basePart}.${suffixPart.slice(actualModelName.length)}`;
-        console.error(
-          `[create_d365fo_file] Stripped model name from dot-notation extension: ` +
-          `${args.objectName} → ${effectiveObjectName}`
-        );
-      }
-    }
-
-    // Case B: extension classes (objectName ends with "_Extension")
-    // e.g. "SalesFormLetterContoso_Extension" with modelName="ContosoExt" → "SalesFormLetter_Extension"
-    // applyObjectPrefix then produces "SalesFormLetterContoso_Extension"
-    if (
-      namingStyle !== 'model-name' &&
-      args.objectName.endsWith('_Extension') &&
-      actualModelName &&
-      objectPrefix.toLowerCase() !== actualModelName.toLowerCase()
-    ) {
-      const baseName = args.objectName.slice(0, -'_Extension'.length);
-      if (baseName.toLowerCase().endsWith(actualModelName.toLowerCase())) {
-        effectiveObjectName = baseName.slice(0, -actualModelName.length) + '_Extension';
-        console.error(
-          `[create_d365fo_file] Stripped model name infix "${actualModelName}" from extension class: ` +
-          `${args.objectName} → ${effectiveObjectName}`
-        );
-      }
-    }
-
-    // Case C: dot-notation extension types provided without a dot (bare base name)
-    // e.g. objectType="table-extension", objectName="PurchTable"
-    // → effectiveObjectName="PurchTable.Extension" so applyObjectPrefix SPECIAL CASE A
-    // produces the correct "PurchTable.ContosoExtension" instead of falling into NORMAL CASE
-    // and producing the wrong "ContosoPurchTable".
-    const DOT_NOTATION_EXTENSION_TYPES = new Set([
-      'table-extension', 'form-extension', 'enum-extension', 'edt-extension',
-      'data-entity-extension', 'menu-item-display-extension', 'menu-item-action-extension',
-      'menu-item-output-extension', 'menu-extension',
-      'security-duty-extension', 'security-role-extension',
-    ]);
-    if (DOT_NOTATION_EXTENSION_TYPES.has(args.objectType) && !effectiveObjectName.includes('.')) {
-      effectiveObjectName = `${effectiveObjectName}.Extension`;
-      console.error(
-        `[create_d365fo_file] Bare extension name auto-converted to dot-notation: ` +
-        `${args.objectName} → ${effectiveObjectName}`
-      );
-    }
-
-    // Case D: class extensions (CoC) provided as a bare base class name, i.e. WITHOUT
-    // the "_Extension" suffix.
-    // e.g. objectType="class-extension", objectName="SalesFormLetter"
-    // → effectiveObjectName="SalesFormLetter_Extension" so applyObjectPrefix's
-    //   extension-class branch produces the correct name for the active style:
-    //     prefix style     → SalesFormLetterCr_Extension
-    //     model-name style → SalesFormLetter_ContosoRobotics_Extension
-    //
-    // Without this, a bare base name has no dot and does not end in "_Extension", so it
-    // falls into applyObjectPrefix's NORMAL CASE and is treated as a brand-new object —
-    // wrongly producing "CrSalesFormLetter". This mirrors the dot-notation Case C above;
-    // class-extension was the only extension type missing bare-name normalisation
-    // (the EXTENSION_NAMING_STYLE work added the model-name branches but assumed the
-    // caller always supplies the "_Extension" form for CoC classes).
-    if (args.objectType === 'class-extension' && !effectiveObjectName.endsWith('_Extension')) {
-      effectiveObjectName = `${effectiveObjectName}_Extension`;
-      console.error(
-        `[create_d365fo_file] Bare class-extension name auto-converted to _Extension form: ` +
-        `${args.objectName} → ${effectiveObjectName}`
-      );
-    }
-
-    // Pass actualModelName so the model-name naming style can use it as the extension
-    // token. For the default prefix style (or non-extension objects) it is ignored.
-    let finalObjectName = applyObjectPrefix(effectiveObjectName, objectPrefix, actualModelName);
-    // Trailing suffix (EXTENSION_SUFFIX) applies to NEW objects only — never to
-    // extension elements/classes. (For the prefix style applyObjectSuffix already
-    // skips _Extension and dot-notation "…Extension" names; this guard additionally
-    // covers the model-name style's "Base.ModelName" form, which has no "Extension"
-    // word and would otherwise wrongly receive the suffix.)
-    const isExtensionObjectType =
-      args.objectType === 'class-extension' || DOT_NOTATION_EXTENSION_TYPES.has(args.objectType);
-    const objectSuffix = getObjectSuffix();
-    if (!isExtensionObjectType) {
-      finalObjectName = applyObjectSuffix(finalObjectName, objectSuffix);
-    }
+    // Name normalisation lives in utils/objectNaming so that modify resolves the
+    // very same name from the very same arguments — the ninety lines that used to
+    // sit here inline were the reason it did not. See normalizeObjectName.
+    const finalObjectName = normalizeObjectName(
+      args.objectName,
+      args.objectType,
+      actualModelName,
+      (note: string) => console.error(`[create_d365fo_file] ${note}`),
+    );
     if (finalObjectName !== args.objectName) {
       console.error(`[create_d365fo_file] Applied naming: ${args.objectName} → ${finalObjectName}`);
     }
@@ -3710,11 +3671,22 @@ export async function handleCreateD365File(
             `(active naming style/prefix), so this is the file that matches your request.`
           : '';
 
+        // A file on disk that no project of the model references is a real gap,
+        // and this early return was the only place that could close it: `create`
+        // used to bail here, before the addToProject block far below, and
+        // `modify` registers nothing unless the caller passes a flag that is not
+        // in the wire schema. So an object that existed but was unregistered
+        // could never BECOME registered — which is how a table extension got
+        // edited through a whole session while staying invisible to the build.
+        const projectNote = await registerExistingFileIfOrphaned(
+          args.objectType, finalObjectName, actualModelName, projectPathToUse,
+        );
+
         return {
           content: [
             {
               type: 'text',
-              text: `⚠️ File already exists: ${normalizedFullPath}${nameNote}${existingSummary}\n\nOptions:\n` +
+              text: `⚠️ File already exists: ${normalizedFullPath}${nameNote}${existingSummary}${projectNote}\n\nOptions:\n` +
                 `  1. Pass overwrite=true together with xmlContent to replace the file.\n` +
                 `  2. Use d365fo_file(action="modify") to make targeted changes (rename-field, replace-all-fields, modify-property, …).\n` +
                 `  3. Choose a different objectName.${inlineContent}`,
@@ -4054,7 +4026,11 @@ export async function handleCreateD365File(
               // Verify the write here rather than leaving the caller to spend a
               // verify_d365fo_project round trip asking what this call already knows.
               const verifyNote = renderWriteVerification(
-                await verifyWrittenFile(smartResult.filePath, projectPathToUse),
+                await verifyWrittenFile(
+                  smartResult.filePath,
+                  projectPathToUse,
+                  membershipOf(args.objectType, finalObjectName, actualModelName),
+                ),
               );
               const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
 
@@ -4151,7 +4127,11 @@ export async function handleCreateD365File(
           const indexNote = await upsertWrittenFileIntoIndex(bridgeResult.filePath, context);
           // Verify the write — see the smart-table path above.
           const verifyNote = renderWriteVerification(
-            await verifyWrittenFile(bridgeResult.filePath, projectPathToUse),
+            await verifyWrittenFile(
+              bridgeResult.filePath,
+              projectPathToUse,
+              membershipOf(args.objectType, finalObjectName, actualModelName),
+            ),
           );
           const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
 
@@ -4526,7 +4506,11 @@ export async function handleCreateD365File(
     const indexNote = await upsertWrittenFileIntoIndex(normalizedFullPath, context);
     // Verify the write — see the bridge paths above.
     const verifyNote = renderWriteVerification(
-      await verifyWrittenFile(normalizedFullPath, args.addToProject ? projectPathToUse : undefined),
+      await verifyWrittenFile(
+        normalizedFullPath,
+        args.addToProject ? projectPathToUse : undefined,
+        membershipOf(args.objectType, finalObjectName, actualModelName),
+      ),
     );
     const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
 

--- a/src/tools/write/inlineWriteVerification.ts
+++ b/src/tools/write/inlineWriteVerification.ts
@@ -15,54 +15,91 @@
  */
 
 import * as fs from 'fs/promises';
-import * as path from 'path';
-import { Parser } from '../../utils/xml.js';
+import {
+  resolveMembership, renderMembership, axFolderForObjectType, type Membership,
+} from '../../workspace/projectMembership.js';
+import { getConfigManager } from '../../utils/configManager.js';
+
+/**
+ * The model's other .rnrproj, or none — never a throw.
+ *
+ * Everything in this module is advisory: the write has already happened and
+ * succeeded by the time any of it runs, so a diagnostic that raises turns a good
+ * write into a reported failure. That is not hypothetical — this call is
+ * evaluated as an ARGUMENT to verifyWrittenFile, outside its try, so an
+ * exception here skips the verification entirely and surfaces as the write
+ * failing. Degrading to "no siblings known" costs a less specific message and
+ * nothing else.
+ */
+function projectsForModelSafe(modelName: string | null | undefined): string[] {
+  try {
+    return getConfigManager().getProjectsForModel?.(modelName) ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The membership question for an object, with the model's other projects filled
+ * in. Call sites pass the model they just wrote into; everything else is looked
+ * up here so a caller cannot forget the siblings and silently get the old
+ * active-project-only answer back.
+ */
+export function membershipOf(
+  objectType: string,
+  objectName: string,
+  modelName: string | null | undefined,
+): { axFolder: string; objectName: string; siblingProjectPaths: string[] } {
+  return {
+    axFolder: axFolderForObjectType(objectType),
+    objectName,
+    siblingProjectPaths: projectsForModelSafe(modelName),
+  };
+}
 
 export interface WriteVerification {
   /** The file exists on disk and is non-empty. */
   onDisk: boolean;
   /** Byte length written, when readable. */
   bytes?: number;
-  /** True/false when a project path was supplied and readable; undefined otherwise. */
-  inProject?: boolean;
+  /**
+   * Where the object is registered across the projects of its model. Undefined
+   * when no project could be read — see projectMembership.ts for why this is a
+   * membership question and not a path comparison.
+   */
+  membership?: Membership;
+  /** AOT folder and name the membership answer is about, for the message. */
+  axFolder?: string;
+  objectName?: string;
 }
 
-/** True when `projectPath`'s .rnrproj has a Content Include resolving to `filePath`. */
-async function isReferencedByProject(projectPath: string, filePath: string): Promise<boolean | undefined> {
-  try {
-    const xml = await fs.readFile(projectPath, 'utf-8');
-    const parsed = await new Parser({ explicitArray: true }).parseStringPromise(xml);
-    const projectDir = path.dirname(projectPath);
-    const target = path.resolve(filePath).toLowerCase();
-
-    for (const group of (parsed?.Project?.ItemGroup ?? []) as any[]) {
-      const contents: any[] = Array.isArray(group?.Content) ? group.Content : [];
-      for (const c of contents) {
-        const include: string | undefined = c?.$?.Include;
-        if (!include) continue;
-        // Includes are project-relative, and Windows-relative at that; resolve
-        // rather than string-compare, or a legitimate entry reads as missing.
-        if (path.resolve(projectDir, include.replace(/\\/g, path.sep)).toLowerCase() === target) return true;
-      }
-    }
-    return false;
-  } catch {
-    // Unreadable/absent project file is not evidence either way — say nothing
-    // rather than report a false "not registered" on a write that was fine.
-    return undefined;
-  }
-}
-
-/** Check that a just-written file is where it should be. Never throws. */
+/**
+ * Check that a just-written file is where it should be. Never throws.
+ *
+ * `siblingProjectPaths` are the other .rnrproj of the same model. Supply them
+ * and an object registered in the project that owns it is reported as such
+ * rather than as missing — the distinction matters, because "missing" invites a
+ * second registration of the same file.
+ */
 export async function verifyWrittenFile(
   filePath: string | undefined,
   projectPath?: string,
+  membershipOf?: { axFolder: string; objectName: string; siblingProjectPaths?: readonly string[] },
 ): Promise<WriteVerification> {
   if (!filePath) return { onDisk: false };
   try {
     const stat = await fs.stat(filePath);
     const result: WriteVerification = { onDisk: stat.isFile() && stat.size > 0, bytes: stat.size };
-    if (projectPath) result.inProject = await isReferencedByProject(projectPath, filePath);
+    if (membershipOf && (projectPath || membershipOf.siblingProjectPaths?.length)) {
+      result.membership = await resolveMembership(
+        membershipOf.axFolder,
+        membershipOf.objectName,
+        projectPath,
+        membershipOf.siblingProjectPaths ?? [],
+      );
+      result.axFolder = membershipOf.axFolder;
+      result.objectName = membershipOf.objectName;
+    }
     return result;
   } catch {
     return { onDisk: false };
@@ -110,11 +147,12 @@ export function renderWriteVerification(v: WriteVerification): string {
     return `\n❌ Verification: the file is NOT on disk after a reported success — treat this write as failed.`;
   }
   const parts = [`on disk (${v.bytes} bytes)`];
-  if (v.inProject === true) parts.push('referenced by the .rnrproj');
-  // Only the negative is worth the bytes; `undefined` means we could not tell.
-  if (v.inProject === false) {
-    return `\n✅ Verified: ${parts.join(', ')}` +
-           `\n⚠️ Verification: the .rnrproj does NOT reference this file — it will not compile until it does.`;
-  }
-  return `\n✅ Verified: ${parts.join(', ')}.`;
+  if (v.membership?.status === 'active') parts.push('referenced by the .rnrproj');
+  const verified = `\n✅ Verified: ${parts.join(', ')}`;
+  // Only 'other' and 'missing' have something to add; 'active' and 'unknown'
+  // are the quiet cases, and quiet is what makes the loud ones mean anything.
+  const note = v.membership
+    ? renderMembership(v.membership, v.axFolder ?? '', v.objectName ?? '')
+    : '';
+  return note ? verified + note : `${verified}.`;
 }

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -37,7 +37,7 @@ import {
   bridgeRefreshProvider,
 } from '../../bridge/index.js';
 import * as debouncedRefresh from '../../bridge/debouncedRefresh.js';
-import { ProjectFileManager, ProjectFileFinder } from '../../workspace/projectFile.js';
+import { ProjectFileFinder, registerFileIfOrphaned } from '../../workspace/projectFile.js';
 import { heuristicEdtBaseType, resolveEdtBaseType, isEnumName } from '../smart/generateSmartTable.js';
 import { normalizeD365Xml } from '../../utils/d365XmlNormalizer.js';
 import {
@@ -1496,10 +1496,19 @@ const ModifyD365FileArgsSchema = z.object({
     'Absolute path to the XML file. Use this when the object was just created and the path is already known ' +
     '(e.g. from d365fo_file(action="create") output). Bypasses symbol DB lookup entirely.'
   ),
-  addToProject: z.boolean().optional().default(false).describe(
-    'When true, adds the modified file to the Visual Studio project (.rnrproj). ' +
-    'Use this when the file exists on disk but is not yet tracked in the VS project. ' +
-    'Requires projectPath or solutionPath (explicit or via .mcp.json). Default: false.'
+  // Defaulted TRUE to match the wire schema, which advertises
+  // `addToProject: { default: true }` for the whole d365fo_file tool and tells
+  // the caller to "keep the default". This defaulted false, so an agent that
+  // followed that instruction — by omitting the parameter — silently got the
+  // opposite. Editing an existing object that was on disk but absent from the
+  // .rnrproj therefore never registered it, no matter how many times it was
+  // edited. Registration is idempotent (ProjectFileManager skips an entry that
+  // is already there), and it is scoped to objects that belong in the active
+  // project: an object owned by another project of the model is left alone.
+  addToProject: z.boolean().optional().default(true).describe(
+    'Add the modified file to the .rnrproj when no project of its model references it yet. ' +
+    'Keep the default — a file missing from every project of its model does not compile. ' +
+    'Set false to skip. Requires projectPath or solutionPath (explicit or via .mcp.json).'
   ),
   projectPath: z.string().optional().describe(
     'Path to .rnrproj file. Required for addToProject to work. Auto-detected from .mcp.json if omitted.'
@@ -2908,7 +2917,15 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       console.error(`[modify_d365fo_file] Bridge validation skipped: ${e}`);
     });
 
-    // Optionally add the file to the Visual Studio project
+    // Register the edited file when no project of its model references it.
+    //
+    // This used to add it to the active project unconditionally whenever the
+    // flag was set — which was safe only because the flag defaulted OFF and
+    // nobody set it. On by default (matching the wire schema, which always
+    // advertised `default: true`), unconditional registration would put objects
+    // owned by another project of the model into the active one as well, and
+    // one file in two projects builds the element twice. registerFileIfOrphaned
+    // makes the membership check the gate: it acts only on a true orphan.
     let projectMessage = '';
     if (args.addToProject) {
       const configManager = getConfigManager();
@@ -2924,28 +2941,12 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         ) || undefined;
       }
 
-      if (resolvedProjectPath) {
-        try {
-          await fs.access(resolvedProjectPath);
-          const projectManager = new ProjectFileManager();
-          const wasAdded = await projectManager.addToProject(
-            resolvedProjectPath,
-            objectType,
-            objectName,
-            actualFilePath
-          );
-          projectMessage = wasAdded
-            ? `\n✅ Added to VS project: \`${resolvedProjectPath}\``
-            : `\n📋 Already in VS project: \`${resolvedProjectPath}\``;
-        } catch (projErr) {
-          const errMsg = projErr instanceof Error ? projErr.message : String(projErr);
-          projectMessage = `\n⚠️ File modified but could not add to VS project: ${errMsg}`;
-        }
-      } else {
-        projectMessage =
-          `\n⚠️ addToProject=true but no projectPath could be resolved.\n` +
-          `Add \`projectPath\` to .mcp.json or pass it explicitly.`;
-      }
+      projectMessage = await registerFileIfOrphaned(
+        objectType,
+        objectName,
+        modelName || configManager.getModelName() || undefined,
+        resolvedProjectPath,
+      );
     }
 
     // Advisory X++ select-statement lint on the source just written (add-method /

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -18,7 +18,8 @@ import util from 'util';
 import path from 'path';
 import { parseStringPromise } from '../../utils/xml.js';
 import { getConfigManager, fallbackPackagePath, extractModelFromFilePath } from '../../utils/configManager.js';
-import { isStandardModel, resolveObjectPrefix, applyObjectPrefix, resolveRegularObjectPrefixToken } from '../../utils/modelClassifier.js';
+import { isStandardModel, resolveRegularObjectPrefixToken } from '../../utils/modelClassifier.js';
+import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { resolveDbPathLocally } from '../../utils/metadataResolver.js';
 import { assertWritePathAllowed } from '../../utils/pathContainment.js';
 import { withFileLock, writeFileAtomic } from '../../utils/atomicFileWrite.js';
@@ -37,7 +38,7 @@ import {
 } from '../../bridge/index.js';
 import * as debouncedRefresh from '../../bridge/debouncedRefresh.js';
 import { ProjectFileManager, ProjectFileFinder } from '../../workspace/projectFile.js';
-import { heuristicEdtBaseType } from '../smart/generateSmartTable.js';
+import { heuristicEdtBaseType, resolveEdtBaseType, isEnumName } from '../smart/generateSmartTable.js';
 import { normalizeD365Xml } from '../../utils/d365XmlNormalizer.js';
 import {
   upsertAxTableProperty,
@@ -53,7 +54,7 @@ import {
 } from '../analysis/validateFormPattern.js';
 import { validateEdtExtensionChange } from '../../utils/edtExtensionValidator.js';
 import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
-import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck } from './inlineWriteVerification.js';
+import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck, membershipOf } from './inlineWriteVerification.js';
 import { lintXppSelect } from '../../utils/xppSelectLint.js';
 import {
   getRequiredParams, renderOpSpec, OP_PARAM_ALIASES,
@@ -545,6 +546,10 @@ const CONTROL_TYPE_TO_FORM_CONTROL: Record<string, { iType: string; typeValue: s
   guid:        { iType: 'AxFormGuidControl',     typeValue: 'Guid' },
   checkbox:    { iType: 'AxFormCheckBoxControl', typeValue: 'CheckBox' },
   combobox:    { iType: 'AxFormComboBoxControl', typeValue: 'ComboBox' },
+  // An enum binds to a ComboBox. Spelled out because "Enum" is what the EDT
+  // resolver and the op-spec both call it, and an unmapped type silently
+  // becomes a String control over enum data.
+  enum:        { iType: 'AxFormComboBoxControl', typeValue: 'ComboBox' },
   button:      { iType: 'AxFormButtonControl',   typeValue: 'Button' },
   group:       { iType: 'AxFormGroupControl',    typeValue: 'Group' },
 };
@@ -2698,18 +2703,13 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       }
       case 'add-control': {
         if ((args as any).controlName && (args as any).parentControl) {
-          // The tool never exposes a `controlType` input (not in the Zod schema below),
-          // so this always used to fall back to the literal string "String" — every
-          // control, regardless of the bound field's actual type, was created as a plain
-          // string edit control. Infer a better default from the field name heuristic
-          // (the same one used for table field base-type resolution) when a
-          // controlDataField is given; this is a best-effort name heuristic, not an
-          // index/bridge EDT lookup (that would need resolving controlDataSource, a form
-          // DATA SOURCE name, back to its bound table — out of scope here), but it is
-          // strictly better than always guessing "String".
           const resolvedControlType =
             (args as any).controlType
-            ?? ((args as any).controlDataField ? heuristicEdtBaseType((args as any).controlDataField) : undefined)
+            ?? resolveControlTypeForField(
+                 (args as any).controlDataSource,
+                 (args as any).controlDataField,
+                 symbolIndex?.getReadDb?.(),
+               )
             ?? 'String';
           bridgeResult = await bridgeAddControl(
             context.bridge,
@@ -3000,7 +3000,11 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     const verifyProjectPath =
       args.projectPath || (await getConfigManager().getProjectPath()) || undefined;
     const verifyNote = renderWriteVerification(
-      await verifyWrittenFile(actualFilePath, verifyProjectPath),
+      await verifyWrittenFile(
+        actualFilePath,
+        verifyProjectPath,
+        membershipOf(objectType, objectName, modelName || getConfigManager().getModelName()),
+      ),
     );
     const bpNote = await runInlineBpCheck((args as any).bpCheck, objectType, objectName, context);
 
@@ -3160,15 +3164,23 @@ async function findD365File(
   const direct = await resolveD365FileByName(symbolIndex, objectType, objectName, modelName, packagePath);
   if (direct) return direct;
 
-  const prefix = resolveObjectPrefix(modelName || getConfigManager().getModelName() || '');
-  if (prefix && !objectType.endsWith('-extension')) {
-    const prefixed = applyObjectPrefix(objectName, prefix);
-    if (prefixed && prefixed.toLowerCase() !== objectName.toLowerCase()) {
-      const viaPrefixed = await resolveD365FileByName(symbolIndex, objectType, prefixed, modelName, packagePath);
-      if (viaPrefixed) {
-        console.error(`[modifyD365File] '${objectName}' not found — resolved via prefixed name '${prefixed}'`);
-        return viaPrefixed;
-      }
+  // Retry under the name `create` would have written the file as.
+  //
+  // The old retry here called applyObjectPrefix and explicitly skipped every
+  // "-extension" type, so `modify(objectType: "table-extension", objectName:
+  // "PurchTable")` never looked for "PurchTable.CtsoExtension" — the exact file
+  // `create` had produced from those same two arguments, whose path it had
+  // printed one call earlier. The answer was "File not found for
+  // table-extension", and the only way out was passing filePath by hand.
+  // normalizeObjectName is what create uses, so the two now agree by
+  // construction rather than by two implementations staying in sync.
+  const effectiveModel = modelName || getConfigManager().getModelName() || undefined;
+  const normalized = normalizeObjectName(objectName, objectType, effectiveModel);
+  if (normalized && normalized.toLowerCase() !== objectName.toLowerCase()) {
+    const viaNormalized = await resolveD365FileByName(symbolIndex, objectType, normalized, modelName, packagePath);
+    if (viaNormalized) {
+      console.error(`[modifyD365File] '${objectName}' not found — resolved via normalized name '${normalized}'`);
+      return viaNormalized;
     }
   }
   return null;
@@ -3657,6 +3669,56 @@ const METADATA_BASE_TYPE_KEYWORDS = new Set([
 
 function isMetadataBaseTypeKeyword(t: string): boolean {
   return METADATA_BASE_TYPE_KEYWORDS.has(t.trim().toLowerCase());
+}
+
+/**
+ * The form control type to bind to a table field: ComboBox for an enum, the
+ * EDT's base type otherwise.
+ *
+ * This used to be `heuristicEdtBaseType(fieldName)` — a guess from the field's
+ * NAME, with a comment saying an index lookup was out of scope because it would
+ * mean resolving the data source back to its table. It costs one query:
+ * resolveFieldEdt() already answers "what type is field F of table T", and a
+ * form data source is conventionally named after its table, which is the case
+ * the fallbacks below cover when it is not.
+ *
+ * The gap it left was enums. A name heuristic has nothing to match on, so an
+ * enum field got the String default and became an AxFormStringControl — a text
+ * box over an enum. Recovering from that took an undo, a re-create and a
+ * re-modify, because a control's type cannot be changed in place.
+ */
+export function resolveControlTypeForField(
+  dataSource: string | undefined,
+  dataField: string | undefined,
+  db: any,
+): string | undefined {
+  if (!dataField) return undefined;
+
+  // The field's declared EDT or enum type, via the data source's table. Form
+  // data sources are conventionally named after the table they bind.
+  const declared = dataSource && db ? resolveFieldEdt(dataSource, dataField, db) : null;
+
+  // resolveEdtBaseType answers "Enum" for an enum-backed EDT, and "Enum" is not
+  // a form control type — left as-is it falls through to the String default and
+  // reintroduces the text-box-over-an-enum this function exists to stop.
+  const asControlType = (baseType: string | undefined): string | undefined =>
+    baseType === 'Enum' ? 'ComboBox' : baseType;
+
+  if (declared && db) {
+    if (isEnumName(declared, db)) return 'ComboBox';
+    const base = asControlType(resolveEdtBaseType(declared, db));
+    if (base) return base;
+  }
+
+  // No data source, no index, or an unindexed field: the field name itself is
+  // conventionally the EDT or enum name in X++, so try it directly before
+  // falling back to the pure name heuristic.
+  if (db) {
+    if (isEnumName(dataField, db)) return 'ComboBox';
+    const base = asControlType(resolveEdtBaseType(dataField, db));
+    if (base) return base;
+  }
+  return asControlType(heuristicEdtBaseType(dataField));
 }
 
 function resolveFieldEdt(tableName: string, fieldName: string, db: any): string | null {

--- a/src/tools/xml/repairFormControls.ts
+++ b/src/tools/xml/repairFormControls.ts
@@ -21,6 +21,7 @@ import { validateFormPatternXml } from '../../validation/formPatternValidator.js
 import { repairFormXml } from '../../utils/formControlRepair.js';
 import { type ExpandFormOptions } from '../../utils/formControlExpander.js';
 import { lookupSymbolNocase } from '../../utils/symbolLookup.js';
+import { resolveIndexedFilePath } from '../../utils/packagesRoot.js';
 
 const RepairArgsSchema = z.object({
   xml: z.string().optional().describe('Complete AxForm XML to repair. Provide this OR formName/filePath.'),
@@ -67,8 +68,11 @@ export async function repairFormControlsTool(
       if (!row?.file_path) {
         return text(`❌ Form "${formName}" not found in the symbol index. Pass filePath or xml directly.`, true);
       }
-      formXml = await fs.readFile(row.file_path, 'utf-8');
-      source = `${formName} (${row.file_path})`;
+      // Package-relative file_path rows resolve against the packages root, not
+      // the process cwd — see resolveIndexedFilePath.
+      const resolved = resolveIndexedFilePath(row.file_path);
+      formXml = await fs.readFile(resolved, 'utf-8');
+      source = `${formName} (${resolved})`;
     }
   } catch (e) {
     return text(`❌ Could not read form XML: ${e instanceof Error ? e.message : String(e)}`, true);

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -1152,6 +1152,23 @@ class ConfigManager {
   }
 
   /**
+   * Every .rnrproj that builds `modelName`, as paths.
+   *
+   * One model is split across as many projects as its owner wants — fifteen, in
+   * the solution that surfaced this. Anything asking "is this object registered
+   * in a project?" has to ask all of them, or a file correctly registered in the
+   * project that owns it reads as missing, and the fix that invites is a second
+   * entry for the same file. See workspace/projectMembership.ts.
+   */
+  getProjectsForModel(modelName: string | null | undefined): string[] {
+    if (!modelName) return [];
+    const needle = modelName.toLowerCase();
+    return this.allDetectedProjects
+      .filter(p => p.modelName.toLowerCase() === needle && p.projectPath)
+      .map(p => p.projectPath!);
+  }
+
+  /**
    * The .rnrproj files found in the WORKSPACE when auto-detection refused to pick
    * one of them. Empty whenever a project was resolved — these are the concrete
    * alternatives createD365File names when addToProject has no projectPath to use.

--- a/src/utils/fieldControlTypes.ts
+++ b/src/utils/fieldControlTypes.ts
@@ -13,6 +13,7 @@
 
 import fs from 'fs';
 import { lookupSymbolNocase } from './symbolLookup.js';
+import { resolveIndexedFilePath } from './packagesRoot.js';
 
 export interface ControlTypeInfo {
   /** AxForm control i:type attribute, e.g. 'AxFormComboBoxControl' */
@@ -205,8 +206,10 @@ export function getFieldControlMap(db: any, table: string): FieldControlMap {
          LIMIT 1`,
       )
       .get(canonical) as { file_path?: string } | undefined;
-    if (!row?.file_path || !fs.existsSync(row.file_path)) return new Map();
-    const xml = fs.readFileSync(row.file_path, 'utf-8');
+    if (!row?.file_path) return new Map();
+    const resolved = resolveIndexedFilePath(row.file_path);
+    if (!fs.existsSync(resolved)) return new Map();
+    const xml = fs.readFileSync(resolved, 'utf-8');
     // An AxView document has no AxTableField to parse — take the view route.
     if (/^\s*<AxView[\s>]/m.test(xml)) return getViewFieldControlMap(db, xml);
     return parseTableFieldControls(xml);
@@ -243,8 +246,10 @@ export function getTableTitleField(db: any, table: string): string | undefined {
          LIMIT 1`,
       )
       .get(canonical) as { file_path?: string } | undefined;
-    if (!row?.file_path || !fs.existsSync(row.file_path)) return undefined;
-    return parseTableTitleField(fs.readFileSync(row.file_path, 'utf-8'));
+    if (!row?.file_path) return undefined;
+    const resolved = resolveIndexedFilePath(row.file_path);
+    if (!fs.existsSync(resolved)) return undefined;
+    return parseTableTitleField(fs.readFileSync(resolved, 'utf-8'));
   } catch {
     return undefined;
   }

--- a/src/utils/objectNaming.ts
+++ b/src/utils/objectNaming.ts
@@ -1,0 +1,113 @@
+/**
+ * The on-disk name an object type + caller-supplied name resolves to.
+ *
+ * This lived inside create_d365fo_file as ninety lines of inline cases, which
+ * meant `create` and `modify` disagreed about what an object is called.
+ * `create` turns `{objectType: "table-extension", objectName: "PurchTable"}`
+ * into `PurchTable.CtsoExtension` and writes that file; `modify` given the same
+ * two arguments looked for a file literally named `PurchTable`, missed, and
+ * answered "File not found for table-extension" — one call after `create` had
+ * printed the path. The caller then had to pass `filePath` by hand, three times
+ * in the session that surfaced this.
+ *
+ * Same inputs, same name, one implementation.
+ */
+
+import {
+  resolveObjectPrefix,
+  applyObjectPrefix,
+  applyObjectSuffix,
+  getObjectSuffix,
+  getExtensionNamingStyle,
+} from './modelClassifier.js';
+
+/**
+ * Extension types whose AOT name is `Base.{Token}Extension`. A bare base name
+ * for one of these has to grow the dot before prefixing, or applyObjectPrefix
+ * reads it as a brand-new object and produces `CtsoPurchTable`.
+ */
+export const DOT_NOTATION_EXTENSION_TYPES: ReadonlySet<string> = new Set([
+  'table-extension', 'form-extension', 'enum-extension', 'edt-extension',
+  'data-entity-extension', 'menu-item-display-extension', 'menu-item-action-extension',
+  'menu-item-output-extension', 'menu-extension',
+  'security-duty-extension', 'security-role-extension',
+]);
+
+export function isExtensionObjectType(objectType: string): boolean {
+  return objectType === 'class-extension' || DOT_NOTATION_EXTENSION_TYPES.has(objectType);
+}
+
+/**
+ * Normalise `objectName` for `objectType` under the active naming style.
+ *
+ * Idempotent: an already-normalised name comes back unchanged, so callers may
+ * apply it without checking whether someone else already did.
+ *
+ * `onNote` receives a line per transformation, for callers that log them.
+ */
+export function normalizeObjectName(
+  objectName: string,
+  objectType: string,
+  modelName: string | undefined,
+  onNote?: (note: string) => void,
+): string {
+  const objectPrefix = resolveObjectPrefix(modelName ?? '');
+  const namingStyle = getExtensionNamingStyle();
+  let effective = objectName;
+
+  const modelDiffersFromPrefix =
+    !!modelName && objectPrefix.toLowerCase() !== modelName.toLowerCase();
+
+  // Case A: dot-notation extension carrying the model name as its token —
+  // "CustTable.MyModelExtension" → "CustTable.Extension", so applyObjectPrefix
+  // can put the right token back.
+  if (
+    namingStyle !== 'model-name' &&
+    effective.includes('.') &&
+    effective.toLowerCase().endsWith('extension') &&
+    modelDiffersFromPrefix
+  ) {
+    const dotIdx = effective.lastIndexOf('.');
+    const basePart = effective.slice(0, dotIdx);
+    const suffixPart = effective.slice(dotIdx + 1);
+    if (suffixPart.toLowerCase().startsWith(modelName!.toLowerCase())) {
+      effective = `${basePart}.${suffixPart.slice(modelName!.length)}`;
+      onNote?.(`Stripped model name from dot-notation extension: ${objectName} → ${effective}`);
+    }
+  }
+
+  // Case B: the same, for extension classes ending in "_Extension".
+  if (
+    namingStyle !== 'model-name' &&
+    effective.endsWith('_Extension') &&
+    modelDiffersFromPrefix
+  ) {
+    const baseName = effective.slice(0, -'_Extension'.length);
+    if (baseName.toLowerCase().endsWith(modelName!.toLowerCase())) {
+      effective = baseName.slice(0, -modelName!.length) + '_Extension';
+      onNote?.(`Stripped model name infix "${modelName}" from extension class: ${objectName} → ${effective}`);
+    }
+  }
+
+  // Case C: a dot-notation extension type given a bare base name.
+  if (DOT_NOTATION_EXTENSION_TYPES.has(objectType) && !effective.includes('.')) {
+    effective = `${effective}.Extension`;
+    onNote?.(`Bare extension name auto-converted to dot-notation: ${objectName} → ${effective}`);
+  }
+
+  // Case D: a class extension given a bare base class name.
+  if (objectType === 'class-extension' && !effective.endsWith('_Extension')) {
+    effective = `${effective}_Extension`;
+    onNote?.(`Bare class-extension name auto-converted to _Extension form: ${objectName} → ${effective}`);
+  }
+
+  let finalName = applyObjectPrefix(effective, objectPrefix, modelName);
+
+  // EXTENSION_SUFFIX applies to NEW objects only — never to extensions. The
+  // model-name style's "Base.ModelName" form has no "Extension" word, so
+  // applyObjectSuffix cannot recognise it on its own; the type check can.
+  if (!isExtensionObjectType(objectType)) {
+    finalName = applyObjectSuffix(finalName, getObjectSuffix());
+  }
+  return finalName;
+}

--- a/src/utils/packagesRoot.ts
+++ b/src/utils/packagesRoot.ts
@@ -142,6 +142,65 @@ export function describePackagesRootScan(): string {
     : `No <drive>:\\AosService\\PackagesLocalDirectory found on any drive (C: to Z: were scanned).`;
 }
 
+/**
+ * Absolute in the Windows sense as well as the POSIX one.
+ *
+ * `path.isAbsolute` on a POSIX host says `K:\AosService\…` is RELATIVE, so a
+ * perfectly good absolute path gets joined onto a packages root — the server
+ * can run on Linux while every path it handles comes from a Windows metadata
+ * store. Mirrors the same check in modifyD365File.ts.
+ */
+function isAbsoluteXPlat(p: string): boolean {
+  return path.isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p) || /^\\\\/.test(p);
+}
+
+/**
+ * Join a Windows-style root to a relative path without letting the host's
+ * separator decide. `path.resolve` on POSIX would prefix the process cwd to a
+ * `K:\…` root, producing `/home/runner/…/K:\…\K:\…`.
+ */
+function joinXPlat(root: string, relative: string): string {
+  if (/^[a-zA-Z]:[\\/]/.test(root) || /^\\\\/.test(root)) {
+    return `${root.replace(/[\\/]+$/, '')}\\${relative.replace(/\//g, '\\')}`;
+  }
+  return path.resolve(root, relative);
+}
+
+/**
+ * An absolute path for a `file_path` read out of the symbol index.
+ *
+ * The index holds both shapes. Most rows are absolute, but a measured 5,345 of
+ * them are package-relative — `ContosoCore/ContosoCore/AxForm/Foo.xml` —
+ * left over from an extraction that ran with the packages root as its cwd.
+ * Handing one of those to `fs.readFile` resolves it against the CURRENT cwd,
+ * which for a server VS Code spawned is the user's home directory. The failure
+ * is a puzzling ENOENT naming a path that could never exist:
+ *
+ *   C:\Users\<user>\ContosoCore\ContosoCore\AxForm\Foo.xml
+ *
+ * Absolute inputs are returned unchanged, so this is safe to apply everywhere a
+ * file_path leaves the index — which is the only way to be sure a caller does
+ * not hit one of the 5,345.
+ *
+ * `roots` is injectable for tests; it defaults to the detected packages roots,
+ * tried in order, with the first existing candidate winning.
+ */
+export function resolveIndexedFilePath(
+  filePath: string,
+  opts: { roots?: readonly string[]; exists?: (p: string) => boolean } = {},
+): string {
+  if (!filePath || isAbsoluteXPlat(filePath)) return filePath;
+  const exists = opts.exists ?? fs.existsSync;
+  const roots = opts.roots ?? packagesRoots();
+  for (const root of roots) {
+    const candidate = joinXPlat(root, filePath);
+    if (exists(candidate)) return candidate;
+  }
+  // Nothing matched: resolve against the best-known root anyway, so the error
+  // names a path the user can recognise instead of one under their home.
+  return joinXPlat(roots[0] ?? FALLBACK_PACKAGES_ROOT, filePath);
+}
+
 /** Test seam — drops the cached scan. */
 export function resetPackagesRootCache(): void {
   cached = null;

--- a/src/utils/xppFormat.ts
+++ b/src/utils/xppFormat.ts
@@ -1,7 +1,7 @@
 /**
  * X++ method-source re-indentation.
  *
- * Re-derives indentation from brace depth alone, discarding whatever leading
+ * Re-derives indentation from block structure alone, discarding whatever leading
  * whitespace the input had, so output is consistent regardless of how the
  * caller indented a method body.
  *
@@ -10,24 +10,40 @@
  * comment + signature line sit at one indent level (4 spaces) — the matching
  * `{`/`}` sit at that same level, and nested content goes one level deeper
  * per brace.
+ *
+ * A `case`/`default` label also opens a level even though it opens no brace
+ * (ApplicationFoundation/AxClass/AVTimeframe.xml). Deriving depth from braces
+ * alone flattened every case body onto its label —
+ *
+ *     case QualityTier::None:
+ *     return "@None";
+ *
+ * — and it did that to correct input too, so a well-formatted switch handed in
+ * came back wrong and had to be repaired by hand afterwards.
  */
 
 const INDENT_UNIT = '    ';
 
-/** Net open/close bracket delta for one line, ignoring string literals and comments. */
-function braceDelta(line: string): { delta: number; leadingCloses: number } {
-  let delta = 0;
+/** A `{ … }` block currently open, and whether a case label is open inside it. */
+interface OpenBlock {
+  /** The block is a switch body, so `case`/`default` labels indent their bodies. */
+  isSwitch: boolean;
+  /** A case label in this switch body has opened a level not yet closed. */
+  caseOpen: boolean;
+}
+
+/** `{` and `}` in source order, ignoring string literals and comments. */
+function braceEvents(line: string): { braces: Array<'{' | '}'>; leadingCloses: number } {
+  const braces: Array<'{' | '}'> = [];
   let leadingCloses = 0;
   let sawNonCloseNonSpace = false;
   let inString = false;
-  let inLineComment = false;
   let inBlockComment = false;
 
   for (let i = 0; i < line.length; i++) {
     const c = line[i];
     const next = line[i + 1];
 
-    if (inLineComment) break;
     if (inBlockComment) {
       if (c === '*' && next === '/') { inBlockComment = false; i++; }
       continue;
@@ -38,18 +54,23 @@ function braceDelta(line: string): { delta: number; leadingCloses: number } {
       continue;
     }
     if (c === "'") { inString = true; continue; }
-    if (c === '/' && next === '/') { inLineComment = true; break; }
+    if (c === '/' && next === '/') break;
     if (c === '/' && next === '*') { inBlockComment = true; i++; continue; }
 
-    if (c === '{') { delta++; sawNonCloseNonSpace = true; }
+    if (c === '{') { braces.push('{'); sawNonCloseNonSpace = true; }
     else if (c === '}') {
-      delta--;
+      braces.push('}');
       if (!sawNonCloseNonSpace) leadingCloses++;
     } else if (c !== ' ' && c !== '\t') {
       sawNonCloseNonSpace = true;
     }
   }
-  return { delta, leadingCloses };
+  return { braces, leadingCloses };
+}
+
+/** A `case X:` or `default:` label — the statements after it belong one level in. */
+function isCaseLabel(trimmed: string): boolean {
+  return /^(case\b|default\s*:)/.test(trimmed);
 }
 
 /**
@@ -62,20 +83,85 @@ export function reindentXppSource(source: string, baseDepth = 1): string {
   const lines = source.replace(/\r\n/g, '\n').split('\n');
 
   // Trim leading/trailing all-blank lines; preserve blank lines in the middle.
+  // Callers that store the result add the trailing blank line D365FO writes
+  // between methods — see xppMethodSourceForXml.
   while (lines.length && lines[0].trim() === '') lines.shift();
   while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
   if (lines.length === 0) return '';
 
-  let depth = baseDepth;
+  const blocks: OpenBlock[] = [];
+  /** A `switch` was seen and its `{` has not opened yet. */
+  let pendingSwitch = false;
+
+  const openCases = () => blocks.reduce((n, b) => n + (b.caseOpen ? 1 : 0), 0);
+  const depthNow = () => Math.max(baseDepth + blocks.length + openCases(), 0);
+  const innermostSwitch = (): OpenBlock | undefined => {
+    for (let i = blocks.length - 1; i >= 0; i--) if (blocks[i].isSwitch) return blocks[i];
+    return undefined;
+  };
+  /** Close the case level of the innermost switch, if one is open. */
+  const closeOpenCase = () => {
+    const sw = innermostSwitch();
+    if (sw?.caseOpen) sw.caseOpen = false;
+  };
+
   const out: string[] = [];
   for (const raw of lines) {
     const trimmed = raw.trim();
     if (trimmed === '') { out.push(''); continue; }
 
-    const { delta, leadingCloses } = braceDelta(trimmed);
-    const thisLineDepth = Math.max(depth - leadingCloses, 0);
-    out.push(INDENT_UNIT.repeat(thisLineDepth) + trimmed);
-    depth = Math.max(depth + delta, 0);
+    const { braces, leadingCloses } = braceEvents(trimmed);
+    const startsCase = isCaseLabel(trimmed);
+
+    // A new label ends the previous one; a `}` that closes the switch body ends
+    // it too, and must do so before the block itself is popped.
+    if (startsCase) closeOpenCase();
+
+    let braceIdx = 0;
+    for (let i = 0; i < leadingCloses; i++) {
+      const top = blocks[blocks.length - 1];
+      if (top?.isSwitch && top.caseOpen) top.caseOpen = false;
+      blocks.pop();
+      braceIdx++;
+    }
+
+    out.push(INDENT_UNIT.repeat(depthNow()) + trimmed);
+
+    // Braces after the leading closes: opens push a block, further closes pop.
+    for (; braceIdx < braces.length; braceIdx++) {
+      if (braces[braceIdx] === '{') {
+        blocks.push({ isSwitch: pendingSwitch, caseOpen: false });
+        pendingSwitch = false;
+      } else {
+        const top = blocks[blocks.length - 1];
+        if (top?.isSwitch && top.caseOpen) top.caseOpen = false;
+        blocks.pop();
+      }
+    }
+
+    // `switch (x)` with its `{` on the following line.
+    if (/^switch\b/.test(trimmed) && !braces.includes('{')) pendingSwitch = true;
+
+    if (startsCase) {
+      const sw = innermostSwitch();
+      // Only indent under the label when we are actually inside a switch body;
+      // a stray "case" outside one must not shift the rest of the method.
+      if (sw) sw.caseOpen = true;
+    }
   }
   return out.join('\n');
+}
+
+/**
+ * A method's X++ as D365FO stores it inside `<Source><![CDATA[ … ]]>`.
+ *
+ * Shipped metadata ends every method with a blank line before the `]]>`, so the
+ * methods of a class are separated by one when the AOT reassembles them. The
+ * re-indenter deliberately trims trailing blanks, and the writers that did not
+ * add one back produced classes whose methods sit directly on top of each
+ * other — visible in Visual Studio, and in the XML against any shipped file.
+ */
+export function xppMethodSourceForXml(source: string): string {
+  const body = reindentXppSource(source);
+  return body === '' ? '' : `${body}\n`;
 }

--- a/src/workspace/projectFile.ts
+++ b/src/workspace/projectFile.ts
@@ -19,7 +19,71 @@ import { Parser, Builder } from '../utils/xml.js';
 // than moved along with the classes.
 import { withFileLock } from '../utils/atomicFileWrite.js';
 import { recordCreatedProjectFolder, takeCreatedProjectFolder } from './createdArtifactLedger.js';
-import { axFolderForObjectType } from './projectMembership.js';
+import {
+  axFolderForObjectType, resolveMembership, projectDisplayName, type Membership,
+} from './projectMembership.js';
+import { getConfigManager } from '../utils/configManager.js';
+
+/**
+ * Register a file that is already on disk into the active project, but only
+ * when no project of its model references it.
+ *
+ * The "only when" is the whole design. A D365FO model is split across many
+ * .rnrproj and each object belongs to exactly one of them, so registering a
+ * file its owning project already lists would put one element in two projects
+ * and build it twice. This closes a genuine gap and declines to open a new one.
+ *
+ * Shared by create and modify, which need it for the same reason: an object
+ * that existed but was unregistered could never BECOME registered — create
+ * bailed before its addToProject block, and modify's flag defaulted off against
+ * a wire schema telling the caller to keep the default.
+ *
+ * Returns the line to append to the tool's response, or '' when there is
+ * nothing worth saying. Never throws: the write it comments on has already
+ * succeeded, and an unreadable project must not turn that into a failure.
+ */
+export async function registerFileIfOrphaned(
+  objectType: string,
+  objectName: string,
+  modelName: string | undefined,
+  projectPath: string | undefined,
+): Promise<string> {
+  const axFolder = axFolderForObjectType(objectType);
+
+  let membership: Membership;
+  try {
+    const siblings = (getConfigManager().getProjectsForModel?.(modelName) ?? [])
+      .filter(p => p !== projectPath);
+    membership = await resolveMembership(axFolder, objectName, projectPath, siblings);
+  } catch {
+    return '';
+  }
+
+  // 'unknown' means no project could be read at all — usually no projectPath is
+  // configured. Saying so on every single write is noise about a config gap the
+  // caller cannot fix mid-task, and it is the same silence renderMembership
+  // keeps: the loud cases only mean something when the quiet ones stay quiet.
+  if (membership.status === 'active' || membership.status === 'unknown') return '';
+  if (membership.status === 'other') {
+    const where = membership.owners.map(projectDisplayName).join(', ');
+    return `\n\n✅ Already registered in ${where} — that project owns it. Nothing to add here.`;
+  }
+
+  if (!projectPath) {
+    return `\n\n⚠️ No project of model "${modelName ?? '(unknown)'}" references \`${axFolder}\\${objectName}\`, ` +
+      `and no active projectPath is configured to add it to. It will not compile until some project does.`;
+  }
+  try {
+    const added = await new ProjectFileManager().addToProject(projectPath, objectType, objectName, '');
+    return added
+      ? `\n\n✅ The file was on disk but in no project of this model — added it to ${projectDisplayName(projectPath)}. ` +
+        `Right-click the project → Reload Project if VS is open.`
+      : '';
+  } catch (e: any) {
+    return `\n\n⚠️ The file is in no project of this model and could not be added to ` +
+      `${projectDisplayName(projectPath)}: ${e?.message ?? e}`;
+  }
+}
 
 /**
  * Project File Finder

--- a/src/workspace/projectFile.ts
+++ b/src/workspace/projectFile.ts
@@ -19,6 +19,7 @@ import { Parser, Builder } from '../utils/xml.js';
 // than moved along with the classes.
 import { withFileLock } from '../utils/atomicFileWrite.js';
 import { recordCreatedProjectFolder, takeCreatedProjectFolder } from './createdArtifactLedger.js';
+import { axFolderForObjectType } from './projectMembership.js';
 
 /**
  * Project File Finder
@@ -161,48 +162,7 @@ export class ProjectFileManager {
    * e.g. class → AxClass, enum → AxEnum, data-entity → AxDataEntityView
    */
   private getAxFolderPrefix(objectType: string): string {
-    const prefixMap: Record<string, string> = {
-      class: 'AxClass',
-      'class-extension': 'AxClass',
-      table: 'AxTable',
-      enum: 'AxEnum',
-      form: 'AxForm',
-      query: 'AxQuery',
-      view: 'AxView',
-      'data-entity': 'AxDataEntityView',
-      'table-extension': 'AxTableExtension',
-      'form-extension': 'AxFormExtension',
-      'data-entity-extension': 'AxDataEntityViewExtension',
-      report: 'AxReport',
-      'menu-item-display': 'AxMenuItemDisplay',
-      'menu-item-action': 'AxMenuItemAction',
-      'menu-item-output': 'AxMenuItemOutput',
-      'menu-item-display-extension': 'AxMenuItemDisplayExtension',
-      'menu-item-action-extension': 'AxMenuItemActionExtension',
-      'menu-item-output-extension': 'AxMenuItemOutputExtension',
-      edt: 'AxEdt',
-      'edt-extension': 'AxEdtExtension',
-      'enum-extension': 'AxEnumExtension',
-      menu: 'AxMenu',
-      'menu-extension': 'AxMenuExtension',
-      'security-privilege': 'AxSecurityPrivilege',
-      'security-duty': 'AxSecurityDuty',
-      'security-role': 'AxSecurityRole',
-      'security-duty-extension': 'AxSecurityDutyExtension',
-      'security-role-extension': 'AxSecurityRoleExtension',
-      'business-event': 'AxClass',
-      tile: 'AxTile',
-      kpi: 'AxKPI',
-      map: 'AxMap',
-      service: 'AxService',
-      'service-group': 'AxServiceGroup',
-      macro: 'AxMacroDictionary',
-      'configuration-key': 'AxConfigurationKey',
-      'security-policy': 'AxSecurityPolicy',
-      'aggregate-measurement': 'AxAggregateMeasurement',
-      'license-code': 'AxLicenseCode',
-    };
-    return prefixMap[objectType] || 'AxClass';
+    return axFolderForObjectType(objectType);
   }
 
   /**

--- a/src/workspace/projectMembership.ts
+++ b/src/workspace/projectMembership.ts
@@ -1,0 +1,223 @@
+/**
+ * "Is this object registered in a Visual Studio project?" — asked model-wide.
+ *
+ * Two callers used to answer this independently and both got it wrong in a
+ * different way.
+ *
+ * `verify_d365fo_project` compared the right thing (the raw `Content Include`)
+ * but only ever looked at the ACTIVE project, so an object registered in the
+ * project that owns it reported `❌ Not in project`. Acting on that is worse
+ * than the warning: adding the entry to the active project too puts one file in
+ * two projects of one model and the element gets compiled twice.
+ *
+ * `inlineWriteVerification` looked at the active project as well, and compared
+ * a resolved absolute path against the include:
+ *
+ *   path.resolve(projectDir, include) === path.resolve(filePath)
+ *
+ * Includes are neither project-dir-relative nor extension-bearing — the writer
+ * emits `AxEnum\Name` (see projectFile.ts) against a file at
+ * `<packages>\<pkg>\<model>\AxEnum\Name.xml`. The two can never be equal, so
+ * every write reported "the .rnrproj does NOT reference this file". Twelve of
+ * those in one run taught the agent to disregard the warning, and it then
+ * disregarded the one that was true.
+ *
+ * Hence one implementation, comparing include-to-include, over every project of
+ * the model, with a definite answer for "registered, but somewhere else".
+ */
+
+import * as fs from 'fs/promises';
+import { Parser } from '../utils/xml.js';
+
+export type MembershipStatus =
+  /** Referenced by the project we are writing into. */
+  | 'active'
+  /** Referenced by another project of the same model — registered, not missing. */
+  | 'other'
+  /** Referenced by no project of this model. This one really does not compile. */
+  | 'missing'
+  /** No project could be read; say nothing rather than guess. */
+  | 'unknown';
+
+export interface Membership {
+  status: MembershipStatus;
+  /** Projects that reference the object, active one first. Paths, as found. */
+  owners: string[];
+}
+
+/**
+ * Object type → the AOT folder its `Content Include` starts with.
+ *
+ * One copy, because the writer and the membership check disagreeing is a bug
+ * that looks exactly like a missing registration. ProjectFileManager builds the
+ * Include from this; verify_d365fo_project and the inline check look it up with
+ * the same function.
+ */
+const AX_FOLDER_BY_OBJECT_TYPE: Record<string, string> = {
+  class: 'AxClass',
+  'class-extension': 'AxClass',
+  table: 'AxTable',
+  enum: 'AxEnum',
+  form: 'AxForm',
+  query: 'AxQuery',
+  view: 'AxView',
+  'data-entity': 'AxDataEntityView',
+  'table-extension': 'AxTableExtension',
+  'form-extension': 'AxFormExtension',
+  'data-entity-extension': 'AxDataEntityViewExtension',
+  report: 'AxReport',
+  'menu-item-display': 'AxMenuItemDisplay',
+  'menu-item-action': 'AxMenuItemAction',
+  'menu-item-output': 'AxMenuItemOutput',
+  'menu-item-display-extension': 'AxMenuItemDisplayExtension',
+  'menu-item-action-extension': 'AxMenuItemActionExtension',
+  'menu-item-output-extension': 'AxMenuItemOutputExtension',
+  edt: 'AxEdt',
+  'edt-extension': 'AxEdtExtension',
+  'enum-extension': 'AxEnumExtension',
+  menu: 'AxMenu',
+  'menu-extension': 'AxMenuExtension',
+  'security-privilege': 'AxSecurityPrivilege',
+  'security-duty': 'AxSecurityDuty',
+  'security-role': 'AxSecurityRole',
+  'security-duty-extension': 'AxSecurityDutyExtension',
+  'security-role-extension': 'AxSecurityRoleExtension',
+  'business-event': 'AxClass',
+  tile: 'AxTile',
+  kpi: 'AxKPI',
+  map: 'AxMap',
+  service: 'AxService',
+  'service-group': 'AxServiceGroup',
+  macro: 'AxMacroDictionary',
+  'configuration-key': 'AxConfigurationKey',
+  'security-policy': 'AxSecurityPolicy',
+  'aggregate-measurement': 'AxAggregateMeasurement',
+  'license-code': 'AxLicenseCode',
+};
+
+export function axFolderForObjectType(objectType: string): string {
+  return AX_FOLDER_BY_OBJECT_TYPE[objectType] || 'AxClass';
+}
+
+/** AOT folder name (any case) → object type. Used to read objects back out of a project. */
+export function objectTypeForAxFolder(axFolder: string): string | undefined {
+  const needle = axFolder.toLowerCase();
+  for (const [type, folder] of Object.entries(AX_FOLDER_BY_OBJECT_TYPE)) {
+    // First wins, so 'class' is returned for AxClass rather than 'class-extension'.
+    if (folder.toLowerCase() === needle) return type;
+  }
+  return undefined;
+}
+
+/**
+ * The `Content Include` a given object has in a .rnrproj: AOT folder, backslash,
+ * object name, no extension. Lowercased — VS is case-insensitive here and the
+ * generators are not consistent about it ("…CtsoFinExtension" on disk against
+ * "…CtsoFINExtension" in the XML, say), which is not a reason to report a miss.
+ */
+export function includeKey(axFolder: string, objectName: string): string {
+  return `${axFolder}\\${objectName}`.toLowerCase();
+}
+
+/**
+ * A project path as a human names it: leaf, no extension.
+ *
+ * Splits on both separators instead of path.basename, which on a POSIX host
+ * treats the backslashes of a Windows project path as ordinary characters and
+ * hands the whole path back — so "registered in <project>" would print an
+ * absolute path where a name belongs.
+ */
+export function projectDisplayName(projectPath: string): string {
+  const leaf = projectPath.split(/[\\/]/).pop() ?? projectPath;
+  return leaf.replace(/\.rnrproj$/i, '');
+}
+
+/** Parsed includes per project file, invalidated by mtime. */
+const includeCache = new Map<string, { mtimeMs: number; includes: Set<string> }>();
+
+/**
+ * Every `Content Include` in a .rnrproj, lowercased. Throws only if the file
+ * cannot be read or parsed; callers treat that as `unknown`, never as `missing`.
+ */
+export async function readProjectIncludes(projectPath: string): Promise<Set<string>> {
+  const stat = await fs.stat(projectPath);
+  const cached = includeCache.get(projectPath);
+  if (cached && cached.mtimeMs === stat.mtimeMs) return cached.includes;
+
+  const xml = await fs.readFile(projectPath, 'utf-8');
+  const parsed = await new Parser({ explicitArray: true }).parseStringPromise(xml);
+
+  const includes = new Set<string>();
+  for (const group of (parsed?.Project?.ItemGroup ?? []) as any[]) {
+    const contents: any[] = Array.isArray(group?.Content) ? group.Content : [];
+    for (const c of contents) {
+      const inc: string | undefined = c?.$?.Include;
+      // Includes are written without .xml, but tolerate one: a hand-edited
+      // project should not read as a miss.
+      if (inc) includes.add(inc.replace(/\.xml$/i, '').toLowerCase());
+    }
+  }
+
+  includeCache.set(projectPath, { mtimeMs: stat.mtimeMs, includes });
+  return includes;
+}
+
+/**
+ * Which projects of this model reference the object.
+ *
+ * `activeProjectPath` is checked first and reported first; `siblingProjectPaths`
+ * are the other .rnrproj of the SAME model — pass them and a file registered in
+ * its owning project stops looking missing. Pass none and this degrades to the
+ * old active-project-only answer, which is still correct, just less useful.
+ */
+export async function resolveMembership(
+  axFolder: string,
+  objectName: string,
+  activeProjectPath: string | undefined,
+  siblingProjectPaths: readonly string[] = [],
+): Promise<Membership> {
+  const key = includeKey(axFolder, objectName);
+
+  const ordered = [
+    ...(activeProjectPath ? [activeProjectPath] : []),
+    ...siblingProjectPaths.filter(p => p && p !== activeProjectPath),
+  ];
+  if (ordered.length === 0) return { status: 'unknown', owners: [] };
+
+  const owners: string[] = [];
+  let readAny = false;
+  for (const projectPath of ordered) {
+    let includes: Set<string>;
+    try {
+      includes = await readProjectIncludes(projectPath);
+    } catch {
+      continue; // unreadable sibling is not evidence of anything
+    }
+    readAny = true;
+    if (includes.has(key)) owners.push(projectPath);
+  }
+
+  if (!readAny) return { status: 'unknown', owners: [] };
+  if (activeProjectPath && owners[0] === activeProjectPath) return { status: 'active', owners };
+  if (owners.length > 0) return { status: 'other', owners };
+  return { status: 'missing', owners: [] };
+}
+
+/**
+ * The one line a write response spends on project membership, or '' when there
+ * is nothing worth saying. Silence is the common case: the file is registered
+ * where it should be and the caller does not need to be told so again.
+ */
+export function renderMembership(m: Membership, axFolder: string, objectName: string): string {
+  switch (m.status) {
+    case 'active':
+    case 'unknown':
+      return '';
+    case 'other': {
+      const where = m.owners.map(projectDisplayName).join(', ');
+      return `\nℹ️ Registered in ${where}, not in the active project — that is where this object belongs; do not add it again here.`;
+    }
+    case 'missing':
+      return `\n⚠️ No .rnrproj of this model references \`${axFolder}\\${objectName}\` — it will not compile until one does.`;
+  }
+}

--- a/src/workspace/projectSelector.ts
+++ b/src/workspace/projectSelector.ts
@@ -1,0 +1,146 @@
+/**
+ * Resolving the `projectName` argument of get_workspace_info to one project.
+ *
+ * The rule this module exists to enforce: a project identifies its model, never
+ * the other way round. A .rnrproj states its model in its own PropertyGroup —
+ *
+ *   <Model>ContosoFin</Model>
+ *
+ * — so going project → model is a read of a declared fact. Going model →
+ * project is a guess, because a model is built by as many projects as its
+ * owner cares to split it into. In the solution this bug was found in, fifteen
+ * .rnrproj files declare `ContosoFin`.
+ *
+ * The previous implementation took the first of those fifteen:
+ *
+ *   allProjects.find(p => p.modelName.toLowerCase() === needle)
+ *     ?? allProjects.find(p => p.modelName.toLowerCase().includes(needle))
+ *
+ * An agent that switched away to read another model and then switched "back"
+ * by model name did not come back — it landed on a same-model project it had
+ * never asked for, and every subsequent write registered itself there. The
+ * workspace's own project was never touched, and nothing in the run said so.
+ *
+ * So: match on project IDENTITY first (its file name, or its path), and fall
+ * back to the model name only when exactly one project claims it. More than
+ * one and this returns `ambiguous` — the caller lists them and picks nothing.
+ * Refusing to choose is the entire point; a wrong project here is silent and
+ * only shows up as a model that does not build.
+ */
+
+import type { D365ProjectInfo } from '../utils/workspaceDetector.js';
+
+/** How a needle was matched, for the switch note the tool prints. */
+export type ProjectMatchKind = 'project-path' | 'project-file' | 'model';
+
+export type ProjectSelection =
+  | { kind: 'resolved'; project: D365ProjectInfo; matchedOn: ProjectMatchKind }
+  | { kind: 'ambiguous'; needle: string; matchedOn: ProjectMatchKind; candidates: D365ProjectInfo[] }
+  | { kind: 'none'; needle: string };
+
+/**
+ * "…\ContosoFin - FeatureManagement.rnrproj" → "contosofin - featuremanagement"
+ *
+ * Splits on BOTH separators rather than using path.basename: the server can run
+ * on a POSIX host while every project path it is handed comes from a Windows
+ * metadata store, and path.basename there treats the backslashes as ordinary
+ * characters and returns the whole path. Every stem comparison below would then
+ * be against a path, so nothing short of a full-path match could resolve.
+ */
+function projectFileStem(p: D365ProjectInfo): string | null {
+  if (!p.projectPath) return null;
+  return projectDisplayName(p.projectPath).toLowerCase();
+}
+
+/** Leaf name of a project path, extension dropped. Cross-platform, as above. */
+function projectDisplayName(projectPath: string): string {
+  const leaf = projectPath.split(/[\\/]/).pop() ?? projectPath;
+  return leaf.replace(/\.rnrproj$/i, '');
+}
+
+/**
+ * Pick the single project a `projectName` refers to.
+ *
+ * The strategies run in order and the FIRST one that matches anything decides
+ * the outcome — including when what it matched is several projects. It must not
+ * fall through to a later strategy after a hit, or the fix defeats itself:
+ * "ContosoFin" matches three projects by model, but it is also a substring of
+ * exactly one project's file name, so a fall-through would quietly resolve to
+ * "ContosoFin - FeatureManagement" — the very landing this module exists to
+ * prevent, reintroduced by the ranking rather than by the guess.
+ *
+ * Every exact strategy therefore precedes every partial one, and a tie inside a
+ * strategy is reported, never broken.
+ */
+const STRATEGIES: ReadonlyArray<{
+  matchedOn: ProjectMatchKind;
+  hits: (p: D365ProjectInfo, needle: string) => boolean;
+}> = [
+  // A full path to the .rnrproj — unambiguous by construction, and lets a
+  // caller holding the path use the friendlier argument name.
+  { matchedOn: 'project-path', hits: (p, n) => p.projectPath?.toLowerCase() === n },
+  // The project's own file name: what VS shows in Solution Explorer, and what
+  // someone means when they name a project rather than a model.
+  { matchedOn: 'project-file', hits: (p, n) => projectFileStem(p) === n },
+  // Model name. Only a selection when the model has exactly one project;
+  // otherwise the caller has named a set.
+  { matchedOn: 'model', hits: (p, n) => p.modelName.toLowerCase() === n },
+  // "FeatureManagement" for "ContosoFin - FeatureManagement".
+  { matchedOn: 'project-file', hits: (p, n) => projectFileStem(p)?.includes(n) ?? false },
+  { matchedOn: 'model', hits: (p, n) => p.modelName.toLowerCase().includes(n) },
+];
+
+export function selectProject(
+  projectName: string,
+  allProjects: readonly D365ProjectInfo[],
+): ProjectSelection {
+  const needle = projectName.trim().toLowerCase();
+  if (!needle) return { kind: 'none', needle: projectName };
+
+  for (const { matchedOn, hits } of STRATEGIES) {
+    const found = allProjects.filter(p => hits(p, needle));
+    if (found.length === 1) return { kind: 'resolved', project: found[0], matchedOn };
+    if (found.length > 1) {
+      return { kind: 'ambiguous', needle: projectName, matchedOn, candidates: found };
+    }
+  }
+
+  return { kind: 'none', needle: projectName };
+}
+
+/** The list an ambiguous or failed selection prints. One line per project. */
+export function renderProjectCandidates(candidates: readonly D365ProjectInfo[]): string {
+  return candidates
+    .map(c => {
+      const stem = c.projectPath ? projectDisplayName(c.projectPath) : '(no .rnrproj)';
+      return `  • ${stem}   [model: ${c.modelName}]\n      ${c.projectPath ?? '(path unknown)'}`;
+    })
+    .join('\n');
+}
+
+/** The whole message for a `projectName` that could not be resolved to one project. */
+export function renderSelectionFailure(
+  selection: Extract<ProjectSelection, { kind: 'ambiguous' | 'none' }>,
+  allProjects: readonly D365ProjectInfo[],
+): string {
+  if (selection.kind === 'none') {
+    const names = allProjects.length
+      ? renderProjectCandidates(allProjects.slice(0, 20)) +
+        (allProjects.length > 20 ? `\n  … and ${allProjects.length - 20} more` : '')
+      : '  (none — set D365FO_SOLUTIONS_PATH)';
+    return (
+      `❌ No project matches "${selection.needle}".\n\n` +
+      `projectName selects a PROJECT, by its .rnrproj file name or full path.\n` +
+      `Known projects:\n${names}`
+    );
+  }
+
+  const what = selection.matchedOn === 'model' ? 'model' : 'partial project name';
+  return (
+    `❌ "${selection.needle}" is a ${what}, not one project — ${selection.candidates.length} projects match it.\n` +
+    `Nothing was switched. Name the project you want, or pass its projectPath:\n\n` +
+    renderProjectCandidates(selection.candidates) +
+    `\n\nReading never needs a switch: get_object_info, search and find_references span every model ` +
+    `regardless of which project is active. Switch only to change where new files get REGISTERED.`
+  );
+}

--- a/tests/tools/inlineWriteVerification.test.ts
+++ b/tests/tools/inlineWriteVerification.test.ts
@@ -1,17 +1,25 @@
 /**
- * Phase 1.4 — verify the write in the call that made it.
+ * Verify the write in the call that made it.
  *
  * The conventional loop was create → verify_d365fo_project → run_bp_check: two
  * extra round trips per object, both asking questions the writing call already
- * had the answers to. It knows the path it wrote and the project it registered
- * the file in; checking that the bytes are on disk and that the .rnrproj really
- * references them is two filesystem reads, not a round trip.
+ * had the answers to.
  *
  * The negative case is the one that earns its keep: this project has a
  * documented history of writes that report ✅ and leave nothing usable behind
  * (empty security objects, tables with no fields, files absent from the
  * .rnrproj). A success message that has actually looked at the disk is a
  * different claim from one that has not.
+ *
+ * But a false alarm costs more than no alarm. The first version of this check
+ * resolved the .rnrproj `Content Include` against the project directory and
+ * compared it to the absolute .xml path, and the fixture below used to make
+ * that work: project and metadata in one tree, `.xml` in the Include. Neither
+ * holds in a real installation — projects live in a repo, metadata under
+ * PackagesLocalDirectory, and Includes are extensionless — so the check was
+ * false on every write. Twelve such warnings in one session taught the agent to
+ * disregard the warning, and it then disregarded the true one. The fixture is
+ * now the real layout, and the tests below are what the old fixture hid.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -19,30 +27,54 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { verifyWrittenFile, renderWriteVerification } from '../../src/tools/write/inlineWriteVerification';
+import type { Membership } from '../../src/workspace/projectMembership';
 
 let base: string;
 let xmlPath: string;
-let projectPath: string;
+let orphanPath: string;
+let activeProject: string;
+let owningProject: string;
+
+/** A .rnrproj whose Content Includes are model-relative and extensionless. */
+function writeProject(at: string, includes: string[]): void {
+  fs.mkdirSync(path.dirname(at), { recursive: true });
+  fs.writeFileSync(
+    at,
+    `<Project><PropertyGroup><Model>MyModel</Model></PropertyGroup><ItemGroup>` +
+      includes.map(i => `<Content Include="${i}"><Name>x</Name></Content>`).join('') +
+      `</ItemGroup></Project>`,
+  );
+}
 
 beforeAll(() => {
   base = fs.mkdtempSync(path.join(os.tmpdir(), 'inlineverify-'));
-  const modelDir = path.join(base, 'MyPackage', 'MyModel', 'AxTable');
+
+  // Metadata: <base>\packages\MyPackage\MyModel\AxTable\*.xml
+  const modelDir = path.join(base, 'packages', 'MyPackage', 'MyModel', 'AxTable');
   fs.mkdirSync(modelDir, { recursive: true });
   xmlPath = path.join(modelDir, 'ContosoXyzTable.xml');
   fs.writeFileSync(xmlPath, '<AxTable><Name>ContosoXyzTable</Name></AxTable>');
+  orphanPath = path.join(modelDir, 'ContosoOrphan.xml');
+  fs.writeFileSync(orphanPath, '<AxTable/>');
 
-  projectPath = path.join(base, 'MyPackage', 'MyModel', 'MyModel.rnrproj');
-  // Includes are project-RELATIVE and Windows-relative — the check has to resolve
-  // them, not string-compare, or a legitimate entry reads as missing.
-  fs.writeFileSync(projectPath,
-    `<Project><ItemGroup><Content Include="AxTable\\ContosoXyzTable.xml" /></ItemGroup></Project>`);
+  // Projects: a different tree entirely, as in a real repo checkout.
+  activeProject = path.join(base, 'repo', 'MyModel - Active', 'MyModel - Active.rnrproj');
+  owningProject = path.join(base, 'repo', 'MyModel - Owning', 'MyModel - Owning.rnrproj');
+  writeProject(activeProject, ['AxTable\\SomethingElse']);
+  writeProject(owningProject, ['AxTable\\ContosoXyzTable']);
 });
 
 afterAll(() => {
   try { fs.rmSync(base, { recursive: true, force: true }); } catch { /* best-effort */ }
 });
 
-describe('verifyWrittenFile', () => {
+const table = (name: string, siblings: string[] = []) => ({
+  axFolder: 'AxTable',
+  objectName: name,
+  siblingProjectPaths: siblings,
+});
+
+describe('verifyWrittenFile — disk', () => {
   it('confirms a file that is really on disk', async () => {
     const v = await verifyWrittenFile(xmlPath);
     expect(v.onDisk).toBe(true);
@@ -50,40 +82,64 @@ describe('verifyWrittenFile', () => {
   });
 
   it('reports a missing file as not on disk', async () => {
-    const v = await verifyWrittenFile(path.join(base, 'nope.xml'));
-    expect(v.onDisk).toBe(false);
+    expect((await verifyWrittenFile(path.join(base, 'nope.xml'))).onDisk).toBe(false);
   });
 
   it('treats an empty file as not written', async () => {
     const empty = path.join(base, 'empty.xml');
     fs.writeFileSync(empty, '');
-    const v = await verifyWrittenFile(empty);
-    expect(v.onDisk).toBe(false);
-  });
-
-  it('resolves a project-relative Include rather than string-comparing it', async () => {
-    const v = await verifyWrittenFile(xmlPath, projectPath);
-    expect(v.inProject).toBe(true);
-  });
-
-  it('reports a file the .rnrproj does not reference', async () => {
-    const orphan = path.join(path.dirname(xmlPath), 'ContosoOrphan.xml');
-    fs.writeFileSync(orphan, '<AxTable/>');
-    const v = await verifyWrittenFile(orphan, projectPath);
-    expect(v.inProject).toBe(false);
-  });
-
-  it('says nothing about the project when the .rnrproj is unreadable', async () => {
-    // An absent project file is not evidence either way — reporting "not
-    // registered" there would be a false alarm on a write that was fine.
-    const v = await verifyWrittenFile(xmlPath, path.join(base, 'missing.rnrproj'));
-    expect(v.inProject).toBeUndefined();
+    expect((await verifyWrittenFile(empty)).onDisk).toBe(false);
   });
 
   it('never throws on a bad path', async () => {
     await expect(verifyWrittenFile(undefined)).resolves.toMatchObject({ onDisk: false });
   });
 });
+
+describe('verifyWrittenFile — project membership', () => {
+  it('matches an extensionless, model-relative Include across separate trees', async () => {
+    // The regression: the project lives in a repo, the file under packages, and
+    // the Include is "AxTable\ContosoXyzTable". Any path resolution says no.
+    const v = await verifyWrittenFile(xmlPath, owningProject, table('ContosoXyzTable'));
+    expect(v.membership?.status).toBe('active');
+  });
+
+  it('reports a file registered in a sibling project as registered, not missing', async () => {
+    const v = await verifyWrittenFile(
+      xmlPath, activeProject, table('ContosoXyzTable', [owningProject]),
+    );
+    expect(v.membership?.status).toBe('other');
+    expect(v.membership?.owners).toEqual([owningProject]);
+  });
+
+  it('reports missing only when no project of the model has it', async () => {
+    const v = await verifyWrittenFile(
+      orphanPath, activeProject, table('ContosoOrphan', [owningProject]),
+    );
+    expect(v.membership?.status).toBe('missing');
+  });
+
+  it('ignores case drift between the file name and the Include', async () => {
+    // The generators write "…CtsoFinExtension" where the XML says
+    // "…CtsoFINExtension"; VS does not care and neither should this.
+    const v = await verifyWrittenFile(xmlPath, owningProject, table('contosoXYZtable'));
+    expect(v.membership?.status).toBe('active');
+  });
+
+  it('says nothing about the project when the .rnrproj is unreadable', async () => {
+    const v = await verifyWrittenFile(
+      xmlPath, path.join(base, 'missing.rnrproj'), table('ContosoXyzTable'),
+    );
+    expect(v.membership?.status).toBe('unknown');
+  });
+
+  it('asks nothing when the caller supplies no membership target', async () => {
+    const v = await verifyWrittenFile(xmlPath, owningProject);
+    expect(v.membership).toBeUndefined();
+  });
+});
+
+const m = (status: Membership['status'], owners: string[] = []): Membership => ({ status, owners });
 
 describe('renderWriteVerification', () => {
   it('contradicts the ✅ when the file is not there', () => {
@@ -92,20 +148,37 @@ describe('renderWriteVerification', () => {
     expect(text).toMatch(/treat this write as failed/i);
   });
 
-  it('warns when the .rnrproj does not reference the file', () => {
-    const text = renderWriteVerification({ onDisk: true, bytes: 120, inProject: false });
-    expect(text).toContain('does NOT reference');
+  it('warns only when no project of the model references the file', () => {
+    const text = renderWriteVerification({
+      onDisk: true, bytes: 120, membership: m('missing'), axFolder: 'AxTable', objectName: 'T',
+    });
+    expect(text).toMatch(/no \.rnrproj of this model/i);
     expect(text).toMatch(/will not compile/i);
   });
 
-  it('stays to one line when everything is fine', () => {
-    const text = renderWriteVerification({ onDisk: true, bytes: 120, inProject: true });
+  it('names the owning project instead of crying missing', () => {
+    const text = renderWriteVerification({
+      onDisk: true,
+      bytes: 120,
+      membership: m('other', ['K:\\repo\\MyModel - Owning.rnrproj']),
+      axFolder: 'AxTable',
+      objectName: 'T',
+    });
+    expect(text).toContain('MyModel - Owning');
+    expect(text).toMatch(/do not add it again/i);
+    expect(text).not.toMatch(/will not compile/i);
+  });
+
+  it('stays to one line when the active project has it', () => {
+    const text = renderWriteVerification({
+      onDisk: true, bytes: 120, membership: m('active', ['p.rnrproj']),
+    });
     expect(text.trim().split('\n')).toHaveLength(1);
     expect(text).toContain('Verified');
   });
 
   it('does not claim anything about the project when it could not tell', () => {
-    const text = renderWriteVerification({ onDisk: true, bytes: 120 });
+    const text = renderWriteVerification({ onDisk: true, bytes: 120, membership: m('unknown') });
     expect(text).not.toMatch(/rnrproj/i);
     expect(text).toContain('Verified');
   });

--- a/tests/tools/resolveControlTypeForField.test.ts
+++ b/tests/tools/resolveControlTypeForField.test.ts
@@ -1,0 +1,136 @@
+/**
+ * add-control picking the control type for a bound field.
+ *
+ * The regression: this used to be a guess from the field NAME, which has
+ * nothing to say about enums, so an enum field became an AxFormStringControl —
+ * a text box over an enum. A control's type cannot be changed in place, so
+ * recovering cost an undo, a re-create and a re-modify.
+ *
+ * The index knows the answer: a field symbol's signature is its EDT or enum
+ * type. These tests use a fake db exposing just the two shapes the resolver
+ * queries, so they stay fast and DB-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveControlTypeForField } from '../../src/tools/write/modifyD365File';
+
+interface Row { [k: string]: unknown }
+
+/**
+ * Minimal stand-in for the symbol-index db.
+ *
+ * `fields` keys are "Table.Field" → the signature stored at index time (the
+ * field's EDT or enum type). `enums` are base enum names. `edts` maps an EDT to
+ * the row edt_metadata holds for it. `tables` are top-level object names that
+ * exist, so the parent-name canonicalisation resolves.
+ *
+ * Both `get` and `all` are implemented: lookupSymbolsNocase queries with `all`
+ * and a type filter spread into the params, and stubbing only `get` makes every
+ * enum probe answer "no" — which is how the first draft of these tests passed
+ * the EDT cases and failed the two that matter.
+ */
+function fakeDb(opts: {
+  fields?: Record<string, string>;
+  enums?: string[];
+  tables?: string[];
+  edts?: Record<string, { extends: string | null; enum_type: string | null; string_size: string | number | null }>;
+}) {
+  const fields = opts.fields ?? {};
+  const enums = new Set((opts.enums ?? []).map(e => e.toLowerCase()));
+  const tables = new Set((opts.tables ?? []).map(t => t.toLowerCase()));
+  const edts = opts.edts ?? {};
+
+  /** Rows lookupSymbolsNocase would return for (name, types). */
+  function symbolHits(name: string, types: string[]): Row[] {
+    const lower = name.toLowerCase();
+    const wants = (t: string) => types.length === 0 || types.includes(t);
+    if (enums.has(lower) && wants('enum')) {
+      return [{ name, type: 'enum', model: 'M', extends_class: null, file_path: null }];
+    }
+    if (tables.has(lower) && wants('table')) {
+      return [{ name, type: 'table', model: 'M', extends_class: null, file_path: null }];
+    }
+    return [];
+  }
+
+  /** Params for the symbols queries are (name, ...types, limit) — FTS prepends its MATCH. */
+  function parseSymbolParams(sql: string, params: unknown[]): { name: string; types: string[] } {
+    const rest = /symbols_fts/.test(sql) ? params.slice(1) : params;
+    const [name, ...tail] = rest as string[];
+    // FTS repeats the name after the MATCH term; drop it, then the trailing limit.
+    const typeArgs = (/symbols_fts/.test(sql) ? tail.slice(1) : tail).slice(0, -1);
+    return { name: String(name ?? ''), types: typeArgs.map(String) };
+  }
+
+  return {
+    prepare(sql: string) {
+      return {
+        get(...params: unknown[]): Row | undefined {
+          if (/FROM symbols WHERE type = 'field'/.test(sql)) {
+            const [table, field] = params as [string, string];
+            const sig = fields[`${table}.${field}`];
+            return sig ? { signature: sig } : undefined;
+          }
+          if (/FROM edt_metadata/.test(sql)) {
+            return edts[String(params[0])];
+          }
+          return undefined;
+        },
+        all(...params: unknown[]): Row[] {
+          if (/FROM symbols s|symbols_fts/.test(sql)) {
+            const { name, types } = parseSymbolParams(sql, params);
+            return symbolHits(name, types);
+          }
+          return [];
+        },
+      };
+    },
+  };
+}
+
+describe('resolveControlTypeForField', () => {
+  it('picks ComboBox for a field whose type is an enum', () => {
+    const db = fakeDb({
+      fields: { 'ContosoCore_ChangeLog.CtsoFin_QualityTier': 'CtsoFin_QualityTier' },
+      enums: ['CtsoFin_QualityTier'],
+    });
+    const t = resolveControlTypeForField(
+      'ContosoCore_ChangeLog', 'CtsoFin_QualityTier', db,
+    );
+    expect(t).toBe('ComboBox');
+  });
+
+  it('picks ComboBox for an enum-backed EDT, which resolves to the bare word "Enum"', () => {
+    // resolveEdtBaseType answers 'Enum' here; 'Enum' is not a control type and
+    // used to fall through to the String default.
+    const db = fakeDb({
+      fields: { 'SalesTable.SalesStatus': 'SalesStatus' },
+      edts: { SalesStatus: { extends: null, enum_type: 'SalesStatus', string_size: null } },
+    });
+    expect(resolveControlTypeForField('SalesTable', 'SalesStatus', db)).toBe('ComboBox');
+  });
+
+  it('resolves an ordinary EDT to its base type', () => {
+    const db = fakeDb({
+      fields: { 'CustTable.AccountNum': 'CustAccount' },
+      edts: { CustAccount: { extends: null, enum_type: null, string_size: 20 } },
+    });
+    expect(resolveControlTypeForField('CustTable', 'AccountNum', db)).toBe('String');
+  });
+
+  it('falls back to the field name when the data source is not the table name', () => {
+    // The field is not found under the data source, but the field name is
+    // conventionally the enum/EDT name in X++.
+    const db = fakeDb({ enums: ['CtsoFin_QualityTier'] });
+    expect(resolveControlTypeForField('SomeDataSource', 'CtsoFin_QualityTier', db)).toBe('ComboBox');
+  });
+
+  it('returns undefined with no field, so the caller keeps its own default', () => {
+    expect(resolveControlTypeForField('CustTable', undefined, fakeDb({}))).toBeUndefined();
+  });
+
+  it('still answers without an index, via the name heuristic', () => {
+    // No db at all: must not throw, and must not claim ComboBox it cannot know.
+    expect(resolveControlTypeForField('CustTable', 'TransDate', undefined)).toBe('Date');
+  });
+});

--- a/tests/tools/runBpCheck.test.ts
+++ b/tests/tools/runBpCheck.test.ts
@@ -868,3 +868,125 @@ describe('extractReportedElements (#25 helper)', () => {
     expect(extractReportedElements('no elements here')).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Audit of run 810e9f6e: a check that never ran, reported as a pass.
+//
+// The call asked for objectType "table-extension" — the same kebab-case
+// vocabulary verify_d365fo_project documents. It was lowercased and handed
+// straight to xppbp, which answered "The element type 'table-extension' is
+// invalid" and evaluated nothing. That output has no BPError and no non-zero
+// counter, so hasIssues() said false and the object rendered as `✅ clean`.
+// Two extensions were declared BP-clean without a single rule running.
+// ---------------------------------------------------------------------------
+
+describe('normalizeElementType', () => {
+  it('translates the kebab-case objectType the other tools take', async () => {
+    const { normalizeElementType } = await import('../../src/tools/sdlc/runBpCheck');
+    expect(normalizeElementType('table-extension')).toBe('tableextension');
+    expect(normalizeElementType('form-extension')).toBe('formextension');
+  });
+
+  it('keeps a class extension checking as a class', async () => {
+    const { normalizeElementType } = await import('../../src/tools/sdlc/runBpCheck');
+    expect(normalizeElementType('class-extension')).toBe('class');
+  });
+
+  it("accepts xppbp's own spelling unchanged", async () => {
+    const { normalizeElementType } = await import('../../src/tools/sdlc/runBpCheck');
+    expect(normalizeElementType('TableExtension')).toBe('tableextension');
+    expect(normalizeElementType('Class')).toBe('class');
+  });
+});
+
+describe('describeNonRun', () => {
+  it('recognises a rejected element type', async () => {
+    const { describeNonRun } = await import('../../src/tools/sdlc/runBpCheck');
+    const out = "The element type 'table-extension' is invalid. Supported types are Class, Table.";
+    expect(describeNonRun(out)).toMatch(/rejected the element type "table-extension"/);
+  });
+
+  it('recognises a filter that matched nothing', async () => {
+    const { describeNonRun } = await import('../../src/tools/sdlc/runBpCheck');
+    expect(describeNonRun('0 elements processed')).toMatch(/not evidence of a clean object/);
+  });
+
+  it('stays quiet on a real run', async () => {
+    const { describeNonRun } = await import('../../src/tools/sdlc/runBpCheck');
+    expect(describeNonRun('1 elements processed\nWarnings: 0\nErrors: 0')).toBe('');
+  });
+});
+
+describe('run_bp_check — a check that did not run is never a pass', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    detectedRoots.splice(0, detectedRoots.length, CHE_PKG);
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    allowPaths([CHE_PKG, CHE_XPPBP]);
+  });
+
+  it('reports a rejected element type as NOT CHECKED, not as passed', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: "The element type 'tableextension' is invalid. Supported types are Class.", stderr: '' });
+    });
+
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', objects: [{ objectType: 'table-extension', objectName: 'MyTable.MyExt' }] },
+      {},
+    );
+
+    expect(result.content[0].text).not.toContain('✅ BP Check passed');
+    expect(result.content[0].text).toContain('did NOT run');
+    expect(result.isError).toBe(true);
+  });
+
+  it('marks only the rejected object in a batch and keeps the rest', async () => {
+    execFileMock.mockImplementation((_f: string, a: string[], _o: any, cb: Function) => {
+      const rejected = a.some(x => x.includes('Rejected'));
+      cb(null, {
+        stdout: rejected
+          ? "The element type 'nope' is invalid. Supported types are Class."
+          : '1 elements processed\nWarnings: 0\nErrors: 0',
+        stderr: '',
+      });
+    });
+
+    const result = await runBpCheckTool(
+      {
+        modelName: 'MyModel',
+        objects: [
+          { objectType: 'class', objectName: 'GoodOne' },
+          { objectType: 'class', objectName: 'Rejected' },
+        ],
+      },
+      {},
+    );
+
+    const text = result.content[0].text;
+    expect(text).toContain('❌ BP Check incomplete');
+    expect(text).toMatch(/Rejected ── ❌ NOT CHECKED/);
+    expect(text).toMatch(/GoodOne ── ✅ clean/);
+    expect(result.isError).toBe(true);
+  });
+
+  it('sends the translated element type to xppbp', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: '1 elements processed\nErrors: 0', stderr: '' });
+    });
+
+    await runBpCheckTool(
+      { modelName: 'MyModel', objects: [{ objectType: 'table-extension', objectName: 'MyTable.MyExt' }] },
+      {},
+    );
+
+    const args = capturedArgs(0);
+    expect(args.join(' ')).toContain('tableextension');
+    expect(args.join(' ')).not.toContain('table-extension');
+  });
+});

--- a/tests/utils/objectNaming.test.ts
+++ b/tests/utils/objectNaming.test.ts
@@ -1,0 +1,93 @@
+/**
+ * One naming implementation for create and modify.
+ *
+ * The regression: `create({objectType:"table-extension", objectName:"PurchTable"})`
+ * writes `PurchTable.CtsoExtension`, but `modify` with the same two arguments
+ * looked for a file literally named `PurchTable`, missed, and answered "File
+ * not found for table-extension" — one call after create had printed the path.
+ * Three such round trips in the session that surfaced it, each ending in the
+ * caller passing `filePath` by hand.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { normalizeObjectName, isExtensionObjectType } from '../../src/utils/objectNaming.js';
+import { registerCustomModel } from '../../src/utils/modelClassifier.js';
+
+const ENV_KEYS = ['EXTENSION_PREFIX', 'EXTENSION_SUFFIX', 'EXTENSION_NAMING_STYLE', 'EXTENSION_PREFIX_SOURCE'];
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map(k => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+  process.env.EXTENSION_PREFIX = 'Ctso';
+  process.env.EXTENSION_PREFIX_SOURCE = 'config';
+  registerCustomModel('ContosoExt');
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('normalizeObjectName', () => {
+  it('turns a bare base name into a dot-notation extension', () => {
+    // The exact shape modify used to miss.
+    const n = normalizeObjectName('PurchTable', 'table-extension', 'ContosoExt');
+    expect(n).toBe('PurchTable.CtsoExtension');
+  });
+
+  it('does the same for a form extension', () => {
+    expect(normalizeObjectName('CustTable', 'form-extension', 'ContosoExt'))
+      .toBe('CustTable.CtsoExtension');
+  });
+
+  it('turns a bare base class name into an _Extension class', () => {
+    expect(normalizeObjectName('SalesFormLetter', 'class-extension', 'ContosoExt'))
+      .toBe('SalesFormLetterCtso_Extension');
+  });
+
+  it('is idempotent — an already-normalised name comes back unchanged', () => {
+    const once = normalizeObjectName('PurchTable', 'table-extension', 'ContosoExt');
+    expect(normalizeObjectName(once, 'table-extension', 'ContosoExt')).toBe(once);
+  });
+
+  it('prefixes an ordinary new object instead of dotting it', () => {
+    expect(normalizeObjectName('RentEquipment', 'table', 'ContosoExt')).toBe('CtsoRentEquipment');
+  });
+
+  it('normalises the casing of a hand-written extension token', () => {
+    expect(normalizeObjectName('PurchTable.CTSOExtension', 'table-extension', 'ContosoExt'))
+      .toBe('PurchTable.CtsoExtension');
+  });
+
+  it('never appends EXTENSION_SUFFIX to an extension', () => {
+    process.env.EXTENSION_SUFFIX = '_Cust';
+    expect(normalizeObjectName('PurchTable', 'table-extension', 'ContosoExt'))
+      .toBe('PurchTable.CtsoExtension');
+  });
+
+  it('appends EXTENSION_SUFFIX to a new object', () => {
+    process.env.EXTENSION_SUFFIX = '_Cust';
+    expect(normalizeObjectName('RentEquipment', 'table', 'ContosoExt')).toBe('CtsoRentEquipment_Cust');
+  });
+
+  it('reports each transformation it made', () => {
+    const notes: string[] = [];
+    normalizeObjectName('PurchTable', 'table-extension', 'ContosoExt', n => notes.push(n));
+    expect(notes.join('\n')).toMatch(/dot-notation/i);
+  });
+});
+
+describe('isExtensionObjectType', () => {
+  it('covers dot-notation extensions and class extensions', () => {
+    expect(isExtensionObjectType('table-extension')).toBe(true);
+    expect(isExtensionObjectType('class-extension')).toBe(true);
+  });
+
+  it('is false for ordinary object types', () => {
+    expect(isExtensionObjectType('table')).toBe(false);
+    expect(isExtensionObjectType('class')).toBe(false);
+  });
+});

--- a/tests/utils/resolveIndexedFilePath.test.ts
+++ b/tests/utils/resolveIndexedFilePath.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Absolute paths for file_path values read out of the symbol index.
+ *
+ * The index holds both shapes: most rows are absolute, but a measured 5,345 are
+ * package-relative, left over from an extraction that ran with the packages
+ * root as its cwd. Passing one of those to fs.readFile resolves it against the
+ * CURRENT cwd — the user's home, for a server VS Code spawned — and produces an
+ * ENOENT naming a path that could never exist. That is exactly how
+ * object_patterns(action="validate") failed on a form that was right there:
+ *
+ *   C:\Users\<user>\ContosoCore\ContosoCore\AxForm\Foo.xml
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveIndexedFilePath } from '../../src/utils/packagesRoot.js';
+
+const K = 'K:\\AosService\\PackagesLocalDirectory';
+const C = 'C:\\AosService\\PackagesLocalDirectory';
+const REL = 'ContosoCore/ContosoCore/AxForm/Foo.xml';
+
+/** What a Windows root + relative path must produce, on any host. */
+const joined = (root: string, rel: string) => `${root}\\${rel.replace(/\//g, '\\')}`;
+
+describe('resolveIndexedFilePath', () => {
+  it('leaves an absolute Windows path untouched, on any host', () => {
+    // path.isAbsolute says a "K:\…" path is RELATIVE on POSIX, so this used to
+    // join an already-absolute path onto a root and produce
+    // /home/runner/…/K:\…\K:\…. CI runs Linux while every path handled here
+    // comes from a Windows metadata store.
+    const abs = `${K}\\M\\M\\AxForm\\Foo.xml`;
+    expect(resolveIndexedFilePath(abs, { roots: [K], exists: () => true })).toBe(abs);
+  });
+
+  it('leaves a UNC path untouched', () => {
+    const unc = '\\\\server\\share\\M\\AxForm\\Foo.xml';
+    expect(resolveIndexedFilePath(unc, { roots: [K], exists: () => true })).toBe(unc);
+  });
+
+  it('resolves a package-relative path against the packages root, not the cwd', () => {
+    const out = resolveIndexedFilePath(REL, { roots: [K], exists: () => true });
+    expect(out).toBe(joined(K, REL));
+    expect(out.toLowerCase()).not.toContain('users');
+    expect(out.toLowerCase()).not.toContain('home');
+  });
+
+  it('picks the root the file actually exists under', () => {
+    const wanted = joined(K, REL);
+    const out = resolveIndexedFilePath(REL, { roots: [C, K], exists: p => p === wanted });
+    expect(out).toBe(wanted);
+  });
+
+  it('names a recognisable path even when the file is under no root', () => {
+    // Better a wrong-but-plausible packages path in the error than one under $HOME.
+    const out = resolveIndexedFilePath(REL, { roots: [K], exists: () => false });
+    expect(out).toBe(joined(K, REL));
+  });
+
+  it('does not double up separators when the root carries a trailing one', () => {
+    const out = resolveIndexedFilePath(REL, { roots: [`${K}\\`], exists: () => true });
+    expect(out).toBe(joined(K, REL));
+  });
+
+  it('falls back to the default root when nothing was detected', () => {
+    const out = resolveIndexedFilePath(REL, { roots: [], exists: () => false });
+    expect(out.toLowerCase()).toContain('packageslocaldirectory');
+  });
+
+  it('passes an empty path through rather than inventing one', () => {
+    expect(resolveIndexedFilePath('', { roots: [K], exists: () => true })).toBe('');
+  });
+});

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -307,8 +307,20 @@ describe('tool inventory contract', () => {
     const projectName = (workspaceInfo.inputSchema as any).properties.projectName.description as string;
 
     expect(projectName).toContain('USER');
-    expect(projectName).toContain('NOT a way to reach another model');
-    expect(projectName).toContain('reads span every model already');
+    expect(projectName).toMatch(/reads span every model already/i);
+  });
+
+  it('tells the agent projectName selects a project, not a model', () => {
+    // A model is built by many projects — fifteen share one model in the
+    // solution where this surfaced — so a model name selects none of them. The
+    // parameter used to say "just the model name", the resolver took the first
+    // match, and every write after that landed in a project nobody chose.
+    const workspaceInfo = toolSchemas.find(t => t.name === 'get_workspace_info')!;
+    const projectName = (workspaceInfo.inputSchema as any).properties.projectName.description as string;
+
+    expect(projectName).toMatch(/PROJECT file name/i);
+    expect(projectName).toMatch(/not a model name/i);
+    expect(projectName).not.toMatch(/just the model name/i);
   });
 
   it('does not advertise update_symbol_index as a follow-up to create/modify', () => {

--- a/tests/utils/xppFormat.test.ts
+++ b/tests/utils/xppFormat.test.ts
@@ -111,3 +111,108 @@ doSomething();
     expect(twice).toBe(once);
   });
 });
+
+// ---------------------------------------------------------------------------
+// A `case` label opens a level even though it opens no brace. Deriving depth
+// from braces alone flattened every case body onto its label, and did it to
+// CORRECT input too — a well-formatted switch handed in came back wrong, which
+// is how a generated method needed hand-repair right after it was written.
+// Verified against shipped code: ApplicationFoundation/AxClass/AVTimeframe.xml.
+// ---------------------------------------------------------------------------
+
+describe('reindentXppSource — switch/case', () => {
+  const flat = [
+    'public str label(QualityTier _t)',
+    '{',
+    'switch (_t)',
+    '{',
+    'case QualityTier::None:',
+    'return "@None";',
+    'case QualityTier::Gold:',
+    'x = 1;',
+    'return "@Gold";',
+    'default:',
+    "return '';",
+    '}',
+    '}',
+  ].join('\n');
+
+  const expected = [
+    '    public str label(QualityTier _t)',
+    '    {',
+    '        switch (_t)',
+    '        {',
+    '            case QualityTier::None:',
+    '                return "@None";',
+    '            case QualityTier::Gold:',
+    '                x = 1;',
+    '                return "@Gold";',
+    '            default:',
+    "                return '';",
+    '        }',
+    '    }',
+  ].join('\n');
+
+  it('indents case bodies one level under their label', () => {
+    expect(reindentXppSource(flat)).toBe(expected);
+  });
+
+  it('leaves an already-correct switch alone', () => {
+    // The regression that made this necessary: correct input came back flattened.
+    expect(reindentXppSource(expected)).toBe(expected);
+  });
+
+  it('closes the case level on the switch closing brace', () => {
+    const input = 'public void m()\n{\nswitch (x)\n{\ncase 1:\na();\n}\nb();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        switch (x)',
+      '        {',
+      '            case 1:',
+      '                a();',
+      '        }',
+      '        b();',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('handles a switch nested inside another block', () => {
+    const input = 'public void m()\n{\nif (x)\n{\nswitch (y)\n{\ncase 1:\nbreak;\n}\n}\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        if (x)',
+      '        {',
+      '            switch (y)',
+      '            {',
+      '                case 1:',
+      '                    break;',
+      '            }',
+      '        }',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('does not shift anything for a "case" outside a switch body', () => {
+    // An identifier that merely starts with "case" must not open a level.
+    const input = 'public void m()\n{\ncaseId = 1;\nreturn;\n}';
+    expect(reindentXppSource(input)).toBe(
+      '    public void m()\n    {\n        caseId = 1;\n        return;\n    }',
+    );
+  });
+});
+
+describe('xppMethodSourceForXml', () => {
+  it('ends the method with the blank line shipped metadata has', async () => {
+    const { xppMethodSourceForXml } = await import('../../src/utils/xppFormat');
+    // Microsoft writes "}\n\n]]></Source>"; writers that omitted it produced
+    // classes whose methods sit directly on top of each other.
+    expect(xppMethodSourceForXml('public void m()\n{\n}')).toBe('    public void m()\n    {\n    }\n');
+  });
+
+  it('returns empty for empty source rather than a lone newline', async () => {
+    const { xppMethodSourceForXml } = await import('../../src/utils/xppFormat');
+    expect(xppMethodSourceForXml('   \n  ')).toBe('');
+  });
+});

--- a/tests/utils/xppFormat.test.ts
+++ b/tests/utils/xppFormat.test.ts
@@ -216,3 +216,96 @@ describe('xppMethodSourceForXml', () => {
     expect(xppMethodSourceForXml('   \n  ')).toBe('');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Shapes below were generated through the real generator, written into a model
+// and compiled with xppc.exe 7.0.7996.33 — "Errors: 0, Warnings: 0". The run
+// was proved to actually reach the file by injecting a missing semicolon and
+// confirming the compiler reported it ("';' expected" with coordinates), so the
+// pass is evidence rather than a check that silently skipped.
+//
+// Indentation does not affect X++ validity; what the compile establishes is
+// that the generator emits code that builds first time, and these expectations
+// pin the layout so it keeps matching shipped platform code.
+// ---------------------------------------------------------------------------
+
+describe('reindentXppSource — compiler-validated switch shapes', () => {
+  it('keeps consecutive fall-through labels on one level and indents the shared body', () => {
+    // 3 of 40 sampled shipped classes put two labels in a row; all of them do
+    // it this way, which is why a label must close the previous label's level
+    // before opening its own rather than stair-stepping.
+    const input = 'public str f(int _k)\n{\nswitch (_k)\n{\ncase 1:\ncase 2:\nreturn \'low\';\ndefault:\nreturn \'none\';\n}\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public str f(int _k)',
+      '    {',
+      '        switch (_k)',
+      '        {',
+      '            case 1:',
+      '            case 2:',
+      "                return 'low';",
+      '            default:',
+      "                return 'none';",
+      '        }',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('restores the outer case level after a nested switch closes', () => {
+    const input = 'public int f(int _a, int _b)\n{\nswitch (_a)\n{\ncase 1:\nswitch (_b)\n{\ncase 10:\nreturn 11;\n}\ncase 2:\nreturn 20;\n}\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public int f(int _a, int _b)',
+      '    {',
+      '        switch (_a)',
+      '        {',
+      '            case 1:',
+      '                switch (_b)',
+      '                {',
+      '                    case 10:',
+      '                        return 11;',
+      '                }',
+      '            case 2:',
+      '                return 20;',
+      '        }',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('handles a case body wrapped in its own braces', () => {
+    const input = 'public str f(int _k)\n{\nswitch (_k)\n{\ncase 1:\n{\nstr local = \'one\';\nreturn local;\n}\ndefault:\n{\nreturn \'other\';\n}\n}\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public str f(int _k)',
+      '    {',
+      '        switch (_k)',
+      '        {',
+      '            case 1:',
+      '                {',
+      "                    str local = 'one';",
+      '                    return local;',
+      '                }',
+      '            default:',
+      '                {',
+      "                    return 'other';",
+      '                }',
+      '        }',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('indents break with the rest of the case body', () => {
+    // 33 of 33 sampled shipped classes indent `break` under its label.
+    const input = 'public void f(NoYes _flag)\n{\nswitch (_flag)\n{\ncase NoYes::Yes:\ncounter++;\nbreak;\ndefault:\nbreak;\n}\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void f(NoYes _flag)',
+      '    {',
+      '        switch (_flag)',
+      '        {',
+      '            case NoYes::Yes:',
+      '                counter++;',
+      '                break;',
+      '            default:',
+      '                break;',
+      '        }',
+      '    }',
+    ].join('\n'));
+  });
+});

--- a/tests/workspace/projectSelector.test.ts
+++ b/tests/workspace/projectSelector.test.ts
@@ -1,0 +1,145 @@
+/**
+ * projectName → one project.
+ *
+ * The regression these guard: a model name shared by many projects used to
+ * resolve to whichever came first in the scan, so switching "back" to your own
+ * model landed you in a stranger's project and every write registered there.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  selectProject,
+  renderSelectionFailure,
+  type ProjectSelection,
+} from '../../src/workspace/projectSelector.js';
+import type { D365ProjectInfo } from '../../src/utils/workspaceDetector.js';
+
+const ROOT = 'K:\\repos\\Contoso\\projects';
+
+function proj(stem: string, modelName: string, folder = stem): D365ProjectInfo {
+  return {
+    projectPath: `${ROOT}\\${folder}\\${stem}.rnrproj`,
+    modelName,
+    solutionPath: `${ROOT}\\${folder}`,
+  };
+}
+
+/** Three projects of one model plus one of another — the shape that broke. */
+const PROJECTS: D365ProjectInfo[] = [
+  proj('ContosoFin - FeatureManagement', 'ContosoFin'),
+  proj('ContosoFin - StatementFormat', 'ContosoFin'),
+  proj('contoso-demo-workspace', 'ContosoFin'),
+  proj('ContosoCore - FeatureManagement', 'ContosoCore'),
+];
+
+function resolvedPath(s: ProjectSelection): string | undefined {
+  return s.kind === 'resolved' ? s.project.projectPath : undefined;
+}
+
+describe('selectProject', () => {
+  it('refuses a model name that several projects build', () => {
+    const s = selectProject('ContosoFin', PROJECTS);
+    expect(s.kind).toBe('ambiguous');
+    if (s.kind !== 'ambiguous') return;
+    expect(s.matchedOn).toBe('model');
+    expect(s.candidates).toHaveLength(3);
+  });
+
+  it('does not fall through to a partial match after an ambiguous exact model match', () => {
+    // "ContosoFin" is also a substring of nothing else here, but the point is
+    // that an ambiguous exact hit must stop, not degrade into another guess.
+    const s = selectProject('contosofin', PROJECTS);
+    expect(s.kind).toBe('ambiguous');
+  });
+
+  it('resolves a model that exactly one project builds', () => {
+    const s = selectProject('ContosoCore', PROJECTS);
+    expect(resolvedPath(s)).toBe(`${ROOT}\\ContosoCore - FeatureManagement\\ContosoCore - FeatureManagement.rnrproj`);
+    expect(s.kind === 'resolved' && s.matchedOn).toBe('model');
+  });
+
+  it('resolves by project file name, case-insensitively', () => {
+    const s = selectProject('CONTOSO-demo-WORKSPACE', PROJECTS);
+    expect(resolvedPath(s)).toBe(`${ROOT}\\contoso-demo-workspace\\contoso-demo-workspace.rnrproj`);
+    expect(s.kind === 'resolved' && s.matchedOn).toBe('project-file');
+  });
+
+  it('prefers the project file name over a model name', () => {
+    // A project named exactly like another project's model must still win as a
+    // project — identity beats classification.
+    const projects = [...PROJECTS, proj('ContosoCore', 'ContosoFin', 'odd-one-out')];
+    const s = selectProject('ContosoCore', projects);
+    expect(resolvedPath(s)).toBe(`${ROOT}\\odd-one-out\\ContosoCore.rnrproj`);
+    expect(s.kind === 'resolved' && s.matchedOn).toBe('project-file');
+  });
+
+  it('resolves a unique partial project name', () => {
+    const s = selectProject('StatementFormat', PROJECTS);
+    expect(resolvedPath(s)).toBe(`${ROOT}\\ContosoFin - StatementFormat\\ContosoFin - StatementFormat.rnrproj`);
+  });
+
+  it('refuses a partial project name that hits several', () => {
+    const s = selectProject('FeatureManagement', PROJECTS);
+    expect(s.kind).toBe('ambiguous');
+    if (s.kind !== 'ambiguous') return;
+    expect(s.matchedOn).toBe('project-file');
+    expect(s.candidates).toHaveLength(2);
+  });
+
+  it('resolves a full .rnrproj path passed as projectName', () => {
+    const target = PROJECTS[1].projectPath!;
+    const s = selectProject(target, PROJECTS);
+    expect(resolvedPath(s)).toBe(target);
+    expect(s.kind === 'resolved' && s.matchedOn).toBe('project-path');
+  });
+
+  it('reports none for an unknown name', () => {
+    expect(selectProject('NoSuchThing', PROJECTS).kind).toBe('none');
+  });
+
+  it('reports none for blank input rather than matching everything', () => {
+    expect(selectProject('   ', PROJECTS).kind).toBe('none');
+  });
+
+  it('reads the project file name out of a Windows path on any host', () => {
+    // path.basename on POSIX treats "\" as an ordinary character and hands back
+    // the whole path, so every stem comparison ran against a path and nothing
+    // short of a full-path match could resolve. CI is Linux; the paths are not.
+    const s = selectProject('ContosoFin - StatementFormat', PROJECTS);
+    expect(s.kind).toBe('resolved');
+    expect(s.kind === 'resolved' && s.matchedOn).toBe('project-file');
+  });
+
+  it('tolerates projects with no .rnrproj path', () => {
+    const modelOnly: D365ProjectInfo = { modelName: 'ContosoOrphan' };
+    const s = selectProject('ContosoOrphan', [...PROJECTS, modelOnly]);
+    expect(s.kind).toBe('resolved');
+    expect(resolvedPath(s)).toBeUndefined();
+  });
+});
+
+describe('renderSelectionFailure', () => {
+  it('lists every candidate with its model so the caller can pick', () => {
+    const s = selectProject('ContosoFin', PROJECTS);
+    if (s.kind !== 'ambiguous') throw new Error('expected ambiguous');
+    const text = renderSelectionFailure(s, PROJECTS);
+    expect(text).toContain('3 projects match');
+    expect(text).toContain('ContosoFin - FeatureManagement');
+    expect(text).toContain('contoso-demo-workspace');
+    expect(text).toContain('Nothing was switched');
+  });
+
+  it('says reading needs no switch, so the agent stops switching to read', () => {
+    const s = selectProject('ContosoFin', PROJECTS);
+    if (s.kind !== 'ambiguous') throw new Error('expected ambiguous');
+    expect(renderSelectionFailure(s, PROJECTS)).toMatch(/Reading never needs a switch/i);
+  });
+
+  it('names projects, not models, when nothing matched', () => {
+    const s = selectProject('NoSuchThing', PROJECTS);
+    if (s.kind !== 'none') throw new Error('expected none');
+    const text = renderSelectionFailure(s, PROJECTS);
+    expect(text).toContain('selects a PROJECT');
+    expect(text).toContain('ContosoFin - StatementFormat');
+  });
+});


### PR DESCRIPTION
Closes #874.

Eight defects from the audit of run `810e9f6e`. They compound, which is why the run looked fine: the defect that lost the objects was masked by the defect that warned about it falsely.

Model, project and path names below are Contoso placeholders, as in the tests.

## A project identifies its model, never the other way round

`get_workspace_info` resolved `projectName` as a **model** name and took the first project that built it:

```ts
allProjects.find(p => p.modelName.toLowerCase() === needle)
  ?? allProjects.find(p => p.modelName.toLowerCase().includes(needle))
```

Measured against the solution this came from: **158 projects, 15 of which declare the same `<Model>`**. So switching away to read another model and then switching "back" by model name did not come back — it landed on a same-model project nobody had asked for, and every subsequent write registered itself there. The workspace's own project was never touched and nothing in the run said so.

A `.rnrproj` states its model in its own `PropertyGroup`, so project → model is a read of a declared fact while model → project is a guess. New `src/workspace/projectSelector.ts` matches project identity first (path, then file name), and treats a model name as a selection only when exactly one project claims it. A name that selects a set is reported, never resolved.

Worth flagging for review: the first draft of the resolver ordered partial file-name matching **before** exact model matching, and its own tests caught that a model name then silently resolved to the one project whose file name happened to contain it — the exact landing this module exists to prevent, reintroduced by the ranking instead of by the guess. Every exact strategy now precedes every partial one, and that ordering is pinned by a test.

Against the real solution:

```
projectName="<model shared by 15 projects>" -> ambiguous (15 projects, nothing switched)
projectName="<the open project's file name>" -> resolved (project-file)
projectName="<model shared by 6 projects>"  -> ambiguous (6 projects)
projectName="FeatureManagement"             -> ambiguous (19 projects)
```

The **second half of the same defect** is fixed too: the compact project list deduped by model — collapsing fifteen `.rnrproj` into a single entry named after the model — and then told the agent to switch by `<ModelName>`. The affordance itself was the bug. The parameter description said "Just the model name"; it now says the opposite, and naming projects costs fewer bytes than naming models did.

## Membership in a .rnrproj is a model-wide question

Two callers asked it independently and both were wrong in a different way; there is one implementation now, in `src/workspace/projectMembership.ts`.

`verify_d365fo_project` compared the right thing but only looked at the **active** project, so a file registered in the project that owns it reported `❌ Not in project`. Acting on that is worse than the warning: adding the entry to the active project too puts one file in two projects of one model and compiles the element twice. Objects found elsewhere now report `✅ in <project>` with an explicit "do not add it again here".

The inline write check compared a resolved absolute path against an extensionless, model-relative `Include`:

```ts
path.resolve(projectDir, include) === path.resolve(filePath)
```

Includes are neither project-dir-relative nor extension-bearing — the writer emits `AxEnum\Name` against a file at `<packages>\<pkg>\<model>\AxEnum\Name.xml`. The two can never be equal, so **every** write reported "the .rnrproj does NOT reference this file". Twelve of those in one run, eleven of them false. The agent's own reasoning trace, verbatim:

> The ".rnrproj does NOT reference this file" warning keeps showing up for the CLASS extension too, even though verify_d365fo_project already confirmed it was properly registered in the project. This looks like a false-positive pattern […]

Having concluded that, it also dismissed the one instance that was true.

## A file on disk in no project could not be registered

`create` early-returned "already exists" before its `addToProject` block, and `modify` only registers behind a flag that is not in the wire schema — so a model cannot pass it. That is how a table extension was edited all session while staying invisible to the build. `create` now registers such a file, and declines when another project of the model already owns it.

## Also fixed, all from the same run

- **`run_bp_check` reported `✅ clean` for objects xppbp refused to check.** A rejected element type yields no findings, and no findings rendered as a pass — two extensions were declared BP-clean without a single rule running. The kebab-case `objectType` every other tool takes was passed through unmapped; it is translated now, and a check that did not run is `❌ NOT CHECKED`.
- **`add-control` bound enum fields to a String control.** The control type came from a guess at the field *name*, which has nothing to say about enums; it now reads the field's declared type from the index. A control's type cannot be changed in place, so the old default cost an undo, a re-create and a re-modify. `resolveEdtBaseType` returning the bare word `Enum` is handled — it was unmapped and would have fallen back to String.
- **5,345 symbol-index rows hold package-relative `file_path` values** (against 1,183,446 absolute). Five callers handed them to `fs`, resolving them against the process cwd — the user's home, for a VS Code-spawned server — and reported ENOENT on paths that never existed.
- **`modify` could not find files `create` had just named.** Name normalisation was ninety lines inline in `create`, so the two disagreed; it moves to `src/utils/objectNaming.ts` and both call it.

## Cross-platform paths

CI caught two defects a Windows-only run could not. `path.isAbsolute` and `path.basename` both treat `K:\…` as a *relative* path on POSIX, and the server runs on Linux while every path it handles comes from a Windows metadata store — so an absolute path was joined onto a root (`/home/runner/…/K:\…\K:\…`) and a project file name came back as a whole path. Both paths are separator-agnostic now, and the tests assert literal strings instead of computing expectations with `path.resolve`, which is what let them pass on one host and fail on the other.

## The verification layer degrades instead of throwing

It runs after a write has already succeeded, and one call sat outside `verifyWrittenFile`'s `try`, where an exception turned a good write into a reported failure. This surfaced as 86 test failures on the first full run and is fixed in the code, not in the test mocks — the module's own comment already said an advisory check must never fail a write.

## Registering on edit, and X++ formatting (second commit)

Two further defects reported against the same run.

**Editing an existing object never registered it.** The wire schema declares one `addToProject` for the whole tool — `default: true`, described as "keep the default". `create` honours that (Zod `.default(true)`); `modify` contradicted it (`.default(false)`, and "Default: false" in its own description). An agent that followed the schema by omitting the parameter got the opposite of what the schema promised, so an object on disk but absent from the .rnrproj stayed absent however many times it was edited — the create-side fix above never applied, because editing does not go through create.

`modify` now defaults it true, and registration is gated on membership rather than done blind: `registerFileIfOrphaned` acts only when **no** project of the model references the object, and names the owner when one does. Unconditional registration was survivable only while the flag was off by default; on by default it would put objects owned by a sibling project into the active one too. The helper moves out of `createD365File` into `workspace/projectFile` so both writers share one implementation.

**Methods and case bodies came out glued together.** Two separate causes:

- Shipped metadata ends every method with a blank line before `]]></Source>`, which is what separates methods when the AOT reassembles a class. `reindentXppSource` deliberately trims trailing blanks, and the writers handing source to the C# bridge never added one back. New `xppMethodSourceForXml` does; the two XML templates that already appended `

` are untouched.
- `reindentXppSource` derived depth from braces alone, and a `case` label opens no brace, so every case body landed on its label's indent. It did this to **correct** input too, so a well-formatted switch handed in came back wrong — which is why a generated method in the audited run needed hand-repair immediately after being written. Depth now comes from a block stack that knows which `{` opened a switch body; the case level closes on the next label or the switch's `}`.

Both verified against shipped platform code (`ApplicationFoundation/AxClass/AVTimeframe.xml`, `AVActionCompletedEventData.xml`).

## Verification

- `261/261` test files, `3268` passed, 2 skipped. `tsc --noEmit`, `biome lint` and `npm run build` all clean.
- Four new test files; three existing ones extended.
- `tests/tools/inlineWriteVerification.test.ts` is rewritten rather than patched: its fixture encoded the wrong model of reality — project and metadata in one tree, `.xml` in the `Include` — which is why the bug shipped past it. The fixture is now the real layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

