### PR TITLE
Stop serving ghosts, register where the work happens, and mind the comments

### DIFF
--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -97,6 +97,99 @@ function sourcePathReplacer(key: string, value: unknown): unknown {
     : value;
 }
 
+/**
+ * Absolute paths of every metadata JSON this run wrote, keyed by model.
+ *
+ * Extraction is additive — each extractor writes one JSON per XML file it finds — so on
+ * its own it can only ever ADD to OUTPUT_PATH. Deleting an object from
+ * PackagesLocalDirectory therefore left its JSON behind in every mode except `all` (the
+ * only mode that wipes OUTPUT_PATH first), and build-database faithfully re-inserted it:
+ * clearModels() emptied the model's rows and the very next pass read the orphan back in.
+ * The symptom was a phantom object that survived a delete + full re-extract + rebuild,
+ * complete with stale metadata, served to callers as if it were on disk.
+ *
+ * Recording the writes lets pruneOrphanedMetadata() sweep whatever a model's extraction
+ * did NOT touch, which is exactly the set of objects that disappeared from the AOT.
+ */
+const writtenByModel = new Map<string, Set<string>>();
+
+/** Write one metadata JSON and record it as live for this run's orphan sweep. */
+async function writeMetadataJson(
+  outputFile: string,
+  data: unknown,
+  isCustom: boolean,
+  modelName: string,
+): Promise<void> {
+  await fs.writeFile(outputFile, JSON.stringify(data, isCustom ? sourcePathReplacer : undefined, 2));
+  let written = writtenByModel.get(modelName);
+  if (!written) {
+    written = new Set<string>();
+    writtenByModel.set(modelName, written);
+  }
+  written.add(path.resolve(outputFile));
+}
+
+/**
+ * Delete every .json under OUTPUT_PATH/<modelName> that this run did not write, then
+ * remove the directories left empty.
+ *
+ * Only ever called for a model whose extraction completed without a single error — a
+ * transient parse failure means "no JSON written", which is indistinguishable here from
+ * "object deleted", and pruning on that signal would delete good metadata.
+ *
+ * Exported for tests.
+ */
+export async function pruneOrphanedMetadata(
+  outputPath: string,
+  modelName: string,
+  written: ReadonlySet<string>,
+): Promise<string[]> {
+  const modelDir = path.join(outputPath, modelName);
+  const removed: string[] = [];
+
+  const sweep = async (dir: string): Promise<boolean> => {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return false; // unreadable — leave it alone
+    }
+    let keptAnything = false;
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const keptBelow = await sweep(full);
+        if (keptBelow) {
+          keptAnything = true;
+        } else {
+          // rmdir, not rm -rf: an empty dir is all that can be left, and a
+          // non-empty one (racing writer, unreadable child) must survive.
+          await fs.rmdir(full).catch(() => { keptAnything = true; });
+        }
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.json')) {
+        keptAnything = true; // never touch anything we did not put there
+        continue;
+      }
+      if (written.has(path.resolve(full))) {
+        keptAnything = true;
+        continue;
+      }
+      try {
+        await fs.unlink(full);
+        removed.push(path.relative(modelDir, full).replace(/\\/g, '/'));
+      } catch {
+        keptAnything = true;
+      }
+    }
+    return keptAnything;
+  };
+
+  await sweep(modelDir);
+  return removed;
+}
+
 let MODELS_TO_EXTRACT: string[] = [];
 let FILTER_MODE: 'all' | 'custom-only' | 'standard-only' = 'all';
 
@@ -678,6 +771,15 @@ async function extractMetadata() {
   let processedModels = 0;
   let cumulativeModelDuration = 0;
 
+  // `all` already wiped OUTPUT_PATH, so nothing there can be an orphan and the sweep would
+  // only cost a second directory walk over every model. Every other mode preserves
+  // OUTPUT_PATH by design (blob-downloaded metadata for out-of-scope models), which is
+  // exactly the case that needs the sweep for the models it DID re-extract.
+  const shouldPrune = EXTRACT_MODE !== 'all';
+  let prunedFiles = 0;
+  const prunedByModel = new Map<string, string[]>();
+  const pruneSkippedModels: string[] = [];
+
   for (const modelItem of modelWorkItems) {
     if (currentPackage !== modelItem.packageName) {
       currentPackage = modelItem.packageName;
@@ -695,11 +797,41 @@ async function extractMetadata() {
     // the denominator cover exactly the same folders.
     const ctx: ModelContext = { parser, modelName, stats, isCustom };
     const dirsByLowerName = await mapModelDirs(modelPath);
+    const errorsBefore = stats.errors;
 
     for (const extractor of AOT_EXTRACTORS) {
       const dirPaths = resolveDirs(dirsByLowerName, extractor.dirs);
       if (dirPaths.length === 0) continue;
       await extractor.run(ctx, dirPaths);
+    }
+
+    // Sweep the JSON this model's extraction did not write — the objects that were
+    // deleted from the AOT since the last run. Models run one at a time, so bracketing
+    // stats.errors around the extractors attributes every failure to this model: a file
+    // that failed to parse produced no JSON, which the sweep cannot tell apart from a
+    // deleted object, so one error is enough to skip the model entirely.
+    //
+    // The second guard is the one that matters when the extractors themselves are
+    // broken rather than the data: a bug that makes EVERY write throw leaves an empty
+    // write set, and an empty write set means "delete everything under this model".
+    // A model that had XML files to read and produced no JSON is a bug in this script,
+    // never a model whose objects were all deleted at once — refuse the sweep and say so.
+    const wroteNothing = (writtenByModel.get(modelName)?.size ?? 0) === 0;
+    if (shouldPrune) {
+      if (stats.errors > errorsBefore || (wroteNothing && modelItem.expectedXmlFiles > 0)) {
+        pruneSkippedModels.push(modelName);
+      } else {
+        const removed = await pruneOrphanedMetadata(
+          OUTPUT_PATH,
+          modelName,
+          writtenByModel.get(modelName) ?? new Set<string>(),
+        );
+        if (removed.length > 0) {
+          prunedFiles += removed.length;
+          prunedByModel.set(modelName, removed);
+          log.detail(`pruned ${formatCount(removed.length)} orphaned JSON file(s): ${removed.slice(0, 5).join(', ')}${removed.length > 5 ? ` (+${removed.length - 5} more)` : ''}`);
+        }
+      }
     }
 
     const modelDuration = Date.now() - modelStart;
@@ -786,6 +918,25 @@ async function extractMetadata() {
     if (value === 0) continue;
     console.log(kv(label, c.cyan(formatCount(value)), statLabelWidth));
   }
+  // The sweep is the only thing standing between a deleted AOT object and a phantom that
+  // survives every rebuild, so say what it did rather than letting it work in silence.
+  if (shouldPrune) {
+    console.log('');
+    if (prunedFiles > 0) {
+      console.log(statusLine('ok', `Pruned ${formatCount(prunedFiles)} orphaned JSON file(s) across ${formatCount(prunedByModel.size)} model(s)`));
+      for (const [modelName, removed] of prunedByModel) {
+        log.detail(`${modelName}: ${removed.slice(0, 10).join(', ')}${removed.length > 10 ? ` (+${removed.length - 10} more)` : ''}`);
+      }
+      log.detail('These objects are gone from PackagesLocalDirectory. Run build-database to drop them from the symbol index.');
+    } else {
+      log.info('No orphaned metadata found - every extracted JSON has a live source file');
+    }
+    if (pruneSkippedModels.length > 0) {
+      console.log(statusLine('warn', c.yellow(`Orphan sweep skipped for ${formatCount(pruneSkippedModels.length)} model(s) with extraction errors: ${pruneSkippedModels.slice(0, 10).join(', ')}`)));
+      log.detail('A parse failure writes no JSON, which is indistinguishable from a deleted object - fix the errors and re-run, or those models may still serve stale metadata.');
+    }
+  }
+
   console.log('');
   if (stats.errors > 0) {
     console.log(statusLine('warn', c.yellow(`${formatCount(stats.errors)} error(s) during extraction - see log above`)));
@@ -826,7 +977,7 @@ async function extractClasses(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'classes');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${classData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(classData, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, classData, isCustom, modelName);
 
       stats.classes++;
 
@@ -862,9 +1013,11 @@ async function writeClassExtensionRecord(
 
   const outputDir = path.join(OUTPUT_PATH, modelName, 'class-extensions');
   await fs.mkdir(outputDir, { recursive: true });
-  await fs.writeFile(
+  await writeMetadataJson(
     path.join(outputDir, `${classInfo.name}.json`),
-    JSON.stringify(record, isCustom ? sourcePathReplacer : undefined, 2),
+    record,
+    isCustom,
+    modelName,
   );
 
   stats.classExtensions++;
@@ -901,7 +1054,7 @@ async function extractTables(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'tables');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${tableData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(tableData, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, tableData, isCustom, modelName);
 
       stats.tables++;
     } catch (error) {
@@ -944,7 +1097,7 @@ async function extractForms(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'forms');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${formInfo.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(formInfo, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, formInfo, isCustom, modelName);
 
       stats.forms++;
     } catch (error) {
@@ -984,7 +1137,7 @@ async function extractQueries(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'queries');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${queryName}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(queryInfo, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, queryInfo, isCustom, modelName);
 
       stats.queries++;
     } catch (error) {
@@ -1027,7 +1180,7 @@ async function extractViews(
         const outputDir = path.join(OUTPUT_PATH, modelName, 'views');
         await fs.mkdir(outputDir, { recursive: true });
         const outputFile = path.join(outputDir, `${viewData.name}.json`);
-        await fs.writeFile(outputFile, JSON.stringify(viewData, isCustom ? sourcePathReplacer : undefined, 2));
+        await writeMetadataJson(outputFile, viewData, isCustom, modelName);
 
         if (viewData.type === 'data-entity') {
           stats.dataEntities++;
@@ -1066,7 +1219,7 @@ async function extractEnums(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'enums');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, file.replace('.xml', '.json'));
-      await fs.writeFile(outputFile, JSON.stringify({ raw: content }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { raw: content }, isCustom, modelName);
 
       stats.enums++;
     } catch (error) {
@@ -1109,7 +1262,7 @@ async function extractEdts(
       const outputDir = path.join(OUTPUT_PATH, modelName, 'edts');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, `${edtInfo.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(edtInfo, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, edtInfo, isCustom, modelName);
 
       stats.edts++;
     } catch (error) {
@@ -1157,7 +1310,7 @@ async function extractReports(
       };
 
       const outputFile = path.join(outputDir, `${name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify(stub, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, stub, isCustom, modelName);
 
       stats.reports++;
     } catch (error) {
@@ -1188,7 +1341,7 @@ async function extractSecurityPrivileges(
       if (!result.success || !result.data) { stats.errors++; return; }
       const privilegeData = result.data;
       const outputFile = path.join(outputDir, `${privilegeData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...privilegeData, model: modelName, type: 'security-privilege' }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { ...privilegeData, model: modelName, type: 'security-privilege' }, isCustom, modelName);
       stats.securityPrivileges++;
     } catch (error) {
       log.err(`Error extracting security privilege ${file}: ${error instanceof Error ? error.message : error}`);
@@ -1218,7 +1371,7 @@ async function extractSecurityDuties(
       if (!result.success || !result.data) { stats.errors++; return; }
       const dutyData = result.data;
       const outputFile = path.join(outputDir, `${dutyData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...dutyData, model: modelName, type: 'security-duty' }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { ...dutyData, model: modelName, type: 'security-duty' }, isCustom, modelName);
       stats.securityDuties++;
     } catch (error) {
       log.err(`Error extracting security duty ${file}: ${error instanceof Error ? error.message : error}`);
@@ -1248,7 +1401,7 @@ async function extractSecurityRoles(
       if (!result.success || !result.data) { stats.errors++; return; }
       const roleData = result.data;
       const outputFile = path.join(outputDir, `${roleData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...roleData, model: modelName, type: 'security-role' }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { ...roleData, model: modelName, type: 'security-role' }, isCustom, modelName);
       stats.securityRoles++;
     } catch (error) {
       log.err(`Error extracting security role ${file}: ${error instanceof Error ? error.message : error}`);
@@ -1283,7 +1436,7 @@ async function extractMenuItems(
       if (!result.success || !result.data) { stats.errors++; return; }
       const menuItemData = result.data;
       const outputFile = path.join(outputDir, `${menuItemData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...menuItemData, model: modelName, type: `menu-item-${itemType}` }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { ...menuItemData, model: modelName, type: `menu-item-${itemType}` }, isCustom, modelName);
       (stats as any)[statKey]++;
     } catch (error) {
       log.err(`Error extracting menu item (${itemType}) ${file}: ${error instanceof Error ? error.message : error}`);
@@ -1333,7 +1486,7 @@ async function extractExtensions(
       if (!result.success || !result.data) { stats.errors++; return; }
       const extensionData = result.data;
       const outputFile = path.join(outputDir, `${extensionData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...extensionData, model: modelName, type: extensionType }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { ...extensionData, model: modelName, type: extensionType }, isCustom, modelName);
       const statKey = statKeyMap[extensionType];
       if (statKey) (stats as any)[statKey]++;
     } catch (error) {
@@ -1364,7 +1517,7 @@ async function extractServices(
       if (!result.success || !result.data) { stats.errors++; return; }
       const serviceData = result.data;
       const outputFile = path.join(outputDir, `${serviceData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...serviceData, model: modelName, type: 'service' }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { ...serviceData, model: modelName, type: 'service' }, isCustom, modelName);
       stats.services++;
     } catch (error) {
       log.err(`Error extracting service ${file}: ${error instanceof Error ? error.message : error}`);
@@ -1394,7 +1547,7 @@ async function extractServiceGroups(
       if (!result.success || !result.data) { stats.errors++; return; }
       const serviceGroupData = result.data;
       const outputFile = path.join(outputDir, `${serviceGroupData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...serviceGroupData, model: modelName, type: 'service-group' }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { ...serviceGroupData, model: modelName, type: 'service-group' }, isCustom, modelName);
       stats.serviceGroups++;
     } catch (error) {
       log.err(`Error extracting service group ${file}: ${error instanceof Error ? error.message : error}`);
@@ -1432,7 +1585,7 @@ async function extractSimpleType(
       if (!result.success || !result.data) { stats.errors++; return; }
       const parsedData = result.data;
       const outputFile = path.join(outputDir, `${parsedData.name}.json`);
-      await fs.writeFile(outputFile, JSON.stringify({ ...parsedData, model: modelName, type }, isCustom ? sourcePathReplacer : undefined, 2));
+      await writeMetadataJson(outputFile, { ...parsedData, model: modelName, type }, isCustom, modelName);
       (stats as any)[statKey]++;
     } catch (error) {
       log.err(`Error extracting ${label} ${file}: ${error instanceof Error ? error.message : error}`);

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -27,6 +27,7 @@ import type { BridgeAttempt } from './bridgeFailure.js';
 import * as debouncedRefresh from './debouncedRefresh.js';
 import { debugLog } from '../utils/logger.js';
 import { xppMethodSourceForXml } from '../utils/xppFormat.js';
+import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
 import { parseXppDeclaration } from '../metadata/xppDeclaration.js';
 import { rankCustomFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
 import {
@@ -1297,6 +1298,35 @@ export function canBridgeModify(objectType: string, operation: string): boolean 
 }
 
 /**
+ * Give a create's X++ the same doc comments and indentation the XML fallback gives it.
+ *
+ * The bridge stores `declaration` / `methods[].source` verbatim, and only the XML
+ * writers ran `ensureXppDocComment` — so the SAME create landed documented when the
+ * bridge was down and undocumented when it was up, and the undocumented one then
+ * failed `run_bp_check` on `BPXmlDocNoDocumentationComments`. The agent's repair for
+ * that was to hand-edit the AOT XML with a plain text tool, which is exactly the
+ * bypass this server exists to remove. Doing it here covers every create type at once.
+ *
+ * Both helpers are idempotent, so a caller that already formatted its own source
+ * (the table path does) is not disturbed.
+ */
+function documentAndFormat<T extends { declaration?: string; methods?: { name: string; source?: string }[] }>(
+  params: T,
+): T {
+  return {
+    ...params,
+    declaration:
+      params.declaration !== undefined
+        ? ensureBlankLineBeforeClosingBrace(ensureXppDocComment(params.declaration))
+        : undefined,
+    methods: params.methods?.map(m => ({
+      ...m,
+      source: m.source !== undefined ? xppMethodSourceForXml(ensureXppDocComment(m.source)) : m.source,
+    })),
+  };
+}
+
+/**
  * Creates a D365FO object via the C# bridge (IMetadataProvider.Create()).
  *
  * Returns { success, filePath, message }, `null` when the bridge is unavailable or
@@ -1326,7 +1356,7 @@ export async function bridgeCreateObject(
   if (!canBridgeCreate(params.objectType)) return null;
 
   try {
-    const result = await bridge.createObject(params);
+    const result = await bridge.createObject(documentAndFormat(params));
     if (result.success) {
       return {
         success: true,
@@ -1403,8 +1433,15 @@ export async function bridgeAddMethod(
   try {
     // The bridge stores sourceCode verbatim — whatever indentation the caller typed
     // (or didn't) ends up in the AOT XML as-is. Re-derive consistent indentation
-    // from brace depth so ragged/flush-left input doesn't produce garbled formatting.
-    const result = await bridge.addMethod(objectType, objectName, methodName, xppMethodSourceForXml(sourceCode));
+    // from brace depth so ragged/flush-left input doesn't produce garbled formatting,
+    // and add the doc comment `BPXmlDocNoDocumentationComments` asks for, so a method
+    // added through the bridge is not the one shape of write that fails BP.
+    const result = await bridge.addMethod(
+      objectType,
+      objectName,
+      methodName,
+      xppMethodSourceForXml(ensureXppDocComment(sourceCode)),
+    );
     return {
       success: result.success,
       message: result.success

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1012,10 +1012,20 @@ export class XppSymbolIndex {
    * Top-level object names belonging to one model — the evidence from which a
    * model's naming prefix is inferred (see utils/modelPrefixInference.ts).
    *
-   * Deliberately narrow and bounded: only `name`, only root objects, capped at
-   * `limit`. Reading whole rows here would pull source snippets across the wire
-   * and turn a 450 ms lookup into a slow one. Extension objects are included on
-   * purpose — a dot-notation extension states the model's infix outright.
+   * Deliberately narrow and bounded: only `name`, capped at `limit`. Reading whole
+   * rows here would pull source snippets across the wire and turn a 450 ms lookup
+   * into a slow one.
+   *
+   * Extension objects are included on purpose — a dot-notation extension states the
+   * model's infix outright — but `parent_name IS NULL` had been quietly excluding
+   * them, because an extension ELEMENT is stored as a child of the base object it
+   * extends. On ContosoFinanceSK that hid 34 of 36: the model spells its extensions
+   * "…ConSKExtension" 35 times and "…ConSkExtension" once, yet inference saw
+   * two names, one of each, fell under the 60 % threshold and derived "ConSk"
+   * from the regular token instead — flattening the "SK" country code. This server
+   * then WROTE a ConSk extension, which became one of the two visible names, so
+   * the wrong answer was feeding itself. Members ('method', 'field') are excluded by
+   * type, which is what this clause was reaching for.
    */
   getModelObjectNames(model: string, limit = 400): string[] {
     if (!model) return [];
@@ -1023,7 +1033,7 @@ export class XppSymbolIndex {
       .prepare(
         `SELECT name FROM symbols
          WHERE model = ?
-           AND parent_name IS NULL
+           AND (parent_name IS NULL OR type LIKE '%-extension')
            AND type NOT IN ('method', 'field')
          LIMIT ?`
       )
@@ -4023,24 +4033,40 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Get all label file IDs for a model (i.e. which AxLabelFiles exist)
+   * Get all label file IDs for a model (i.e. which AxLabelFiles exist).
+   *
+   * Both filters belong in SQL. `labelFileId` used to be applied by the caller to
+   * the finished list, so asking about ONE label file still grouped all 1.4 M rows
+   * into 1602 groups and then threw 1601 of them away — a full index scan measured
+   * at 2.5 s warm, and one cold call in a real session took 28 s against the 40-170 ms
+   * every other call to the same tool costs. Pushed into the WHERE clause the same
+   * lookup is a seek on idx_labels_file_id: 0.4 ms.
    */
-  getLabelFileIds(model?: string): Array<{ labelFileId: string; model: string; languages: string }> {
-    if (model) {
-      return this.labelsDb.prepare(`
-        SELECT label_file_id AS labelFileId, model, GROUP_CONCAT(DISTINCT language) AS languages
-        FROM labels
-        WHERE model = ?
-        GROUP BY label_file_id, model
-        ORDER BY label_file_id
-      `).all(model) as any[];
-    }
-    return this.labelsDb.prepare(`
+  getLabelFileIds(model?: string, labelFileId?: string): Array<{ labelFileId: string; model: string; languages: string }> {
+    const run = (extraWhere: string, params: string[]) => this.labelsDb.prepare(`
       SELECT label_file_id AS labelFileId, model, GROUP_CONCAT(DISTINCT language) AS languages
       FROM labels
+      ${extraWhere}
       GROUP BY label_file_id, model
       ORDER BY label_file_id
-    `).all() as any[];
+    `).all(...params) as Array<{ labelFileId: string; model: string; languages: string }>;
+
+    const where: string[] = [];
+    const params: string[] = [];
+    if (model) { where.push('model = ?'); params.push(model); }
+    if (labelFileId) { where.push('label_file_id = ?'); params.push(labelFileId); }
+    const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const hits = run(clause, params);
+    if (hits.length > 0 || !labelFileId) return hits;
+
+    // The caller-side filter this replaced compared lowercased, and idx_labels_file_id
+    // is BINARY — so a differently-cased ID would silently return nothing. Only when
+    // the fast exact seek misses does it cost the scan to stay case-insensitive.
+    const nocaseWhere: string[] = ['label_file_id = ? COLLATE NOCASE'];
+    const nocaseParams: string[] = [labelFileId];
+    if (model) { nocaseWhere.unshift('model = ?'); nocaseParams.unshift(model); }
+    return run(`WHERE ${nocaseWhere.join(' AND ')}`, nocaseParams);
   }
 
   /**

--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -66,7 +66,7 @@ Model + prefix auto-applied. Classes: member vars inside the class { }, methods 
             '[create] Per-objectType creation properties (label, fields[], extends, enumValues[], primaryTable, …) — ' +
             'NOT in this schema. Fetch yours: get_knowledge(kind="op-spec", topic="<objectType>").'
         },
-        addToProject: { type: 'boolean', description: 'Add to the .rnrproj — keep the default.', default: true },
+        addToProject: { type: 'boolean', description: 'Add to the ACTIVE .rnrproj — keep the default.', default: true },
         projectPath: { type: 'string', description: 'Path to .rnrproj (auto-detected).' },
         xmlContent: { type: 'string', description: 'Complete XML written verbatim (+overwrite=true rewrites an object).' },
         overwrite: { type: 'boolean', description: 'Allow overwriting — never rewrite via PowerShell.', default: false },

--- a/src/server/toolSchemas/getObjectInfo.ts
+++ b/src/server/toolSchemas/getObjectInfo.ts
@@ -37,7 +37,7 @@ export const getObjectInfoTool = {
         },
         options: {
           type: 'object',
-          description: 'Type-specific flags forwarded to the reader: includeRdl, includeFields, searchControl, compact, includeOperations, filter, mode, modelName. For a CLASS, {"method":"validateWrite","include":"signature"} returns ONE method (include: signature | source | both) — required before writing a CoC extension. Big objects are paged — table fieldsOffset/fieldFilter, form maxControls. Applies to every objects[] entry.',
+          description: 'Type-specific flags forwarded to the reader: includeRdl, includeFields, searchControl, compact, includeOperations, filter, mode, modelName. On class/table/view/data-entity, {"method":"validateWrite","include":"signature"} returns ONE method (include: signature | source | both) — required before writing a CoC extension. Big objects are paged — table fieldsOffset/fieldFilter, form maxControls. Applies to every objects[] entry.',
         },
       },
     },

--- a/src/server/toolSchemas/labels.ts
+++ b/src/server/toolSchemas/labels.ts
@@ -52,8 +52,9 @@ export const labelsTool = {
         },
         // action=search
         query: {
-          type: 'string',
-          description: '[search] REQUIRED. Search text — matches label ID, text and developer comment.',
+          type: ['string', 'array'],
+          items: { type: 'string' },
+          description: '[search] REQUIRED. Search text — matches label ID, text and developer comment. ARRAY = try several phrasings in ONE call.',
         },
         // action=info
         labelId: {

--- a/src/tools/analysis/search.ts
+++ b/src/tools/analysis/search.ts
@@ -18,6 +18,7 @@ import {
   formatSuggestions
 } from '../../utils/suggestionEngine.js';
 import { tryBridgeSearch } from '../../bridge/bridgeAdapter.js';
+import { indexedPathIsMissing } from '../../utils/indexedXmlLookup.js';
 import { lookupSymbolsNocase } from '../../utils/symbolLookup.js';
 import { rankCustomFirst, isExactNameMatch } from '../../utils/exactMatchRanking.js';
 import { isCustomModel } from '../../utils/modelClassifier.js';
@@ -89,6 +90,30 @@ export function probeCustomMatches(
   }
 }
 
+/**
+ * Drop probe rows whose object is gone from disk.
+ *
+ * Both probes are index-only reads, and the index is not rebuilt when a file is
+ * deleted — so after a workspace reset the splice kept surfacing objects from the
+ * previous run and ranking them ABOVE the live ones, which is how a search for a
+ * field that did not exist answered "found it". `indexedPathIsMissing` judges only
+ * PackagesLocalDirectory paths, so a build-agent path that merely does not remap
+ * here is still spliced in as before.
+ *
+ * Scoped to the PROBES on purpose. They are a splice that outranks everything
+ * else, so a ghost among them is actively misleading and dropping one costs
+ * nothing — the row is still in the result set the probe was spliced into. The
+ * result set itself is not swept: a symbol index built elsewhere (the shipped
+ * one covers every standard package) routinely names files a given machine has
+ * not installed, and dropping those would answer "no such object" for the whole
+ * of D365FO on a partial install. Marking rather than hiding is the open
+ * question there.
+ */
+async function dropStaleRows<T extends { filePath?: string }>(rows: T[]): Promise<T[]> {
+  const missing = await Promise.all(rows.map(r => indexedPathIsMissing(r.filePath)));
+  return rows.filter((_, i) => !missing[i]);
+}
+
 const SearchArgsSchema = z.object({
   query: z.string().describe('Search query (class name, method name, etc.)'),
   type: z.enum([
@@ -120,8 +145,8 @@ export async function searchTool(request: CallToolRequest, context: XppServerCon
     // of the Microsoft-dominated bridge window are spliced back in and
     // prioritized (never "only Microsoft objects").
     const searchTypes = args.type === 'all' ? undefined : [args.type];
-    const exactMatches = probeExactMatches(symbolIndex, args.query, searchTypes);
-    const customMatches = probeCustomMatches(symbolIndex, args.query, searchTypes);
+    const exactMatches = await dropStaleRows(probeExactMatches(symbolIndex, args.query, searchTypes));
+    const customMatches = await dropStaleRows(probeCustomMatches(symbolIndex, args.query, searchTypes));
     const bridgeResult = await tryBridgeSearch(
       context.bridge,
       args.query,
@@ -326,6 +351,11 @@ async function performExternalSearch(
       .filter(hit => !seen.has(`${hit.name.toLowerCase()} ${hit.type}`));
     for (const hit of missingCustom) seen.add(`${hit.name.toLowerCase()} ${hit.type}`);
 
+    // NOT swept for stale rows, deliberately — see dropStaleRows. This is the
+    // whole answer, not a splice, and a symbol index built elsewhere routinely
+    // covers packages this machine does not have installed. Dropping those would
+    // turn "you do not have that package locally" into "no such object", in the
+    // one tool everything else starts from.
     const combined = [...missingExact, ...missingCustom, ...raw];
     const isCustomHit = (r: any) =>
       (r.model ? isCustomModel(String(r.model)) : false) ||

--- a/src/tools/analysis/searchLabels.ts
+++ b/src/tools/analysis/searchLabels.ts
@@ -20,6 +20,30 @@ import {
   labelProvenanceWarning,
 } from '../../utils/labelReference.js';
 
+/**
+ * Emitted only when a label the current model can actually resolve was found.
+ * `labels` reads it back to decide whether a batch of queries found anything
+ * reusable, so keep the two in step.
+ */
+export const REUSABLE_MARKER = '💡 Use the label reference syntax in X++:';
+
+/**
+ * What to do when nothing reusable came back.
+ *
+ * Rephrasing is the wrong next move and used to be the only one suggested: one
+ * benchmark run spent 19 separate `action="search"` calls guessing English
+ * wordings for the same message ("cannot be decreased", "rating cannot be
+ * lowered", "%1 cannot be lower than %2"), and the answer was "create your own"
+ * from the first call onwards. Every phrasing queries the same index, so say
+ * that, and hand over the call that ends the loop.
+ */
+export const NO_REUSE_ADVICE =
+  `➡️  Nothing reusable here — create your own label and move on:\n` +
+  `      labels(action="create", labelFileId="<your model's label file>", model="<your model>",\n` +
+  `             labelId="<MeaningOfTheText>", translations=[{language:"en-US", text:"…"}])\n` +
+  `   Rephrasing does not help: every wording queries the same index. To try several at once,\n` +
+  `   pass query as an array — labels(action="search", query=["…", "…", "…"]) — one call, not one each.\n`;
+
 const SearchLabelsArgsSchema = z.object({
   query: z
     .string()
@@ -94,7 +118,7 @@ export async function searchLabelsTool(request: CallToolRequest, context: XppSer
               (language !== 'en-US' ? ` in language "${language}"` : '') +
               (model ? ` in model "${model}"` : '') +
               '.\n\n' +
-              `💡 Tip: Use labels(action="create") to add a new label to your custom model.\n` +
+              NO_REUSE_ADVICE +
               `💡 To search a different language use the language parameter (e.g. "cs", "de", "sk").`,
           },
         ],
@@ -173,14 +197,16 @@ export async function searchLabelsTool(request: CallToolRequest, context: XppSer
     const recommended = normalised.find(r => isLabelLikelyResolvable(r.labelFileId, r.model, currentModel));
     if (recommended) {
       const ref = formatLabelReference(recommended.labelFileId, recommended.labelId);
-      lines.push(`💡 Use the label reference syntax in X++:  literalStr("${ref}")`);
+      lines.push(`${REUSABLE_MARKER}  literalStr("${ref}")`);
       lines.push(`💡 Or in metadata XML:  <Label>${ref}</Label>`);
     } else {
       lines.push(
         `⚠️ None of these labels is in a core label file (SYS/…) or in your own model, so none is ` +
         `recommended as-is: referencing one raises BPErrorUnknownLabel unless your model references ` +
-        `its package. Create your own with labels(action="create") instead.`,
+        `its package.`,
       );
+      lines.push('');
+      lines.push(NO_REUSE_ADVICE.trimEnd());
     }
 
     return {

--- a/src/tools/d365foFile.ts
+++ b/src/tools/d365foFile.ts
@@ -95,6 +95,15 @@ async function runModifyBatch(
   const results: Array<{ label: string; ok: boolean; text: string }> = [];
   let stoppedAt = -1;
 
+  // What each operation is travelling with. An entry runs as its own modify
+  // call and cannot otherwise see the batch, which is right for the writes and
+  // wrong for the advice: add-field told the caller to "send the group entry in
+  // the SAME call next time" while the group entry sat two lines below it in
+  // that very call. Internal — not part of the published schema.
+  const peerOperations = operations
+    .map(e => (e && typeof e === 'object' ? String((e as any).operation ?? '') : ''))
+    .filter(Boolean);
+
   for (let i = 0; i < operations.length; i++) {
     const entry = operations[i];
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
@@ -104,7 +113,7 @@ async function runModifyBatch(
     }
     // Per-entry keys win over the shared ones, so objectType/objectName/modelName
     // are stated once at the top level and an entry can still override them.
-    const entryArgs = { ...shared, ...(entry as Record<string, unknown>) };
+    const entryArgs = { ...shared, ...(entry as Record<string, unknown>), peerOperations };
     const opName = String((entry as any).operation ?? '(missing operation)');
 
     if (!(entry as any).operation) {

--- a/src/tools/knowledge/methodSignature.ts
+++ b/src/tools/knowledge/methodSignature.ts
@@ -16,6 +16,7 @@ import type { XppMetadataParser } from '../../metadata/xmlParser.js';
 import { parseXppDeclaration } from '../../metadata/xppDeclaration.js';
 import { canonicalSymbolName } from '../../utils/symbolLookup.js';
 import { inheritedOwnerCandidates } from '../../utils/inheritanceChain.js';
+import { indexedPathIsMissing, renderStaleIndexNote } from '../../utils/indexedXmlLookup.js';
 
 /** Object types that can own methods. */
 const OBJECT_TYPES = ['class', 'table', 'view', 'data-entity'] as const;
@@ -136,7 +137,14 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
       output += `**Model:** ${classRow.model}\n`;
       output += `_Source: SQLite index (signature only — bridge and XML unavailable)_\n\n`;
       output += `\`\`\`xpp\n${sigText}\n\`\`\`\n`;
-      output += `\n> ⚠️ CoC template not available without full method source. Start the C# bridge for full functionality.\n`;
+      // "Bridge and XML unavailable" reads as a degraded read, but it is also what a
+      // DELETED class looks like — the signature row survives the file. Say which,
+      // instead of leaving the agent to prove it with a directory walk.
+      if (await indexedPathIsMissing(classRow.file_path)) {
+        output += `\n${renderStaleIndexNote(className, classRow.file_path)}`;
+      } else {
+        output += `\n> ⚠️ CoC template not available without full method source. Start the C# bridge for full functionality.\n`;
+      }
       return { content: [{ type: 'text', text: output }] };
     }
 

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -14,7 +14,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { searchLabelsTool } from './analysis/searchLabels.js';
+import { searchLabelsTool, REUSABLE_MARKER, NO_REUSE_ADVICE } from './analysis/searchLabels.js';
 import { getLabelInfoTool } from './readers/getLabelInfo.js';
 import { createLabelTool } from './write/createLabel.js';
 import { renameLabelTool } from './write/renameLabel.js';
@@ -128,10 +128,13 @@ export async function labelsTool(request: CallToolRequest, context: XppServerCon
     const r = rest as Record<string, unknown>;
     if (r.query === undefined) {
       const alt = r.searchText ?? r.text ?? r.q;
-      if (typeof alt === 'string') {
+      if (typeof alt === 'string' || Array.isArray(alt)) {
         r.query = alt;
         delete r.searchText; delete r.text; delete r.q;
       }
+    }
+    if (Array.isArray(r.query)) {
+      return batchSearch(r, dispatch.tool, context);
     }
   }
 
@@ -140,6 +143,62 @@ export async function labelsTool(request: CallToolRequest, context: XppServerCon
     params: { name: dispatch.toolName, arguments: rest },
   };
   return dispatch.tool(subRequest, context);
+}
+
+/** Most phrasings one call will try — beyond this the answer is "create your own". */
+const MAX_BATCH_QUERIES = 12;
+
+/**
+ * Run several label searches in one call.
+ *
+ * Looking for a reusable label is inherently a guessing game — the caller does not
+ * know the wording Microsoft used — and one query per call turned that into a
+ * round trip per guess: 19 of them in a single benchmark run, ~150 s of wall clock,
+ * for an answer ("no reusable label exists, create your own") that was already
+ * determined by the first. Batching collapses the guesses into one call and, when
+ * none of them hits, says so once instead of leaving the caller to conclude it.
+ */
+async function batchSearch(
+  args: Record<string, unknown>,
+  search: LabelsTool,
+  context: XppServerContext,
+): Promise<any> {
+  const all = (args.query as unknown[]).map(q => String(q)).filter(q => q.trim() !== '');
+  const queries = all.slice(0, MAX_BATCH_QUERIES);
+  if (queries.length === 0) {
+    return {
+      content: [{ type: 'text', text: `❌ labels(action="search"): query[] is empty — pass at least one search text.` }],
+      isError: true,
+    };
+  }
+
+  const sections: string[] = [];
+  let foundReusable = false;
+
+  for (const query of queries) {
+    const result = await search(
+      { method: 'tools/call', params: { name: 'search_labels', arguments: { ...args, query } } },
+      context,
+    );
+    const text = (result?.content ?? [])
+      .map((c: any) => (typeof c?.text === 'string' ? c.text : ''))
+      .join('\n');
+    if (text.includes(REUSABLE_MARKER)) foundReusable = true;
+    sections.push(`## "${query}"\n\n${text}`);
+  }
+
+  const header = `# Label search — ${queries.length} quer${queries.length === 1 ? 'y' : 'ies'}` +
+    (all.length > queries.length ? ` (${all.length - queries.length} beyond the ${MAX_BATCH_QUERIES}-query cap were not run)` : '') +
+    '\n';
+  // The per-query sections each carry their own advice; the verdict is what the
+  // caller actually needs, so state it once, up front, rather than making them
+  // read every section to work out that no phrasing hit.
+  const verdict = foundReusable
+    ? `**Verdict:** at least one reusable label was found — see the section(s) marked "${REUSABLE_MARKER}".\n`
+    : `**Verdict:** none of these ${queries.length} phrasings found a label this model can resolve. ` +
+      `Stop searching and create your own.\n\n${NO_REUSE_ADVICE}`;
+
+  return { content: [{ type: 'text', text: `${header}\n${verdict}\n---\n\n${sections.join('\n\n---\n\n')}` }] };
 }
 
 // Tool registration (name, description, inputSchema) lives in

--- a/src/tools/prepare/prepareCreate.ts
+++ b/src/tools/prepare/prepareCreate.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import type { XppServerContext } from '../../types/context.js';
 import { createProvenanceToken } from '../../utils/provenanceStore.js';
 import { getConfigManager } from '../../utils/configManager.js';
-import { resolveObjectPrefix, applyObjectPrefix } from '../../utils/modelClassifier.js';
+import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { renderPrepareOpSpec } from '../specs/opSpecs.js';
 import { rankContext, renderRankedContext } from '../../workspace/contextRanker.js';
 import { lookupSymbolsNocase, type SymbolHit } from '../../utils/symbolLookup.js';
@@ -238,8 +238,14 @@ export async function prepareCreateTool(request: any, context: XppServerContext)
 
   const { goal, objectName, objectType, fieldsHint } = parsed.data;
   const modelName = getConfigManager().getModelName() ?? undefined;
-  const prefix = resolveObjectPrefix(modelName ?? '');
-  const finalName = prefix ? applyObjectPrefix(objectName, prefix) : objectName;
+  // Predict the name through the SAME helper d365fo_file(action="create") writes with.
+  // Re-deriving it here from applyObjectPrefix(name, prefix) — without modelName — dropped
+  // the separator for models whose inferred prefix carries one: prepare promised
+  // "ConSKQualityTier" and create wrote "ConSK_QualityTier". The caller then took
+  // prepare at its word, hand-fed a leading "_" to compensate, and got "ConSK__QualityTier"
+  // on disk, which cost a create + undo + re-create. It also made the collision check probe
+  // a name that never gets written, so a real collision read as "No collision".
+  const finalName = normalizeObjectName(objectName, objectType, modelName);
 
   // All lookups are synchronous index queries — run them in one tick.
   const [collisions, naming, similar, edts, labels, propertyDefaults] = [

--- a/src/tools/readers/enumInfo.ts
+++ b/src/tools/readers/enumInfo.ts
@@ -19,6 +19,7 @@ import {
   readXmlFile,
   indexedSourceNote,
   bridgeUnavailableNote,
+  type IndexedObjectRef,
 } from '../../utils/indexedXmlLookup.js';
 import { findD365FileOnDisk } from '../../utils/objectFileLookup.js';
 
@@ -48,7 +49,9 @@ export async function getEnumInfoTool(request: CallToolRequest, context: XppServ
       const xml = extractedXml
         ?? (ref.localPath ? await readXmlFile(ref.localPath) : null);
       const source = extractedXml ? 'symbol index (extracted metadata)' : `XML: ${ref.localPath}`;
-      const formatted = xml && await formatEnumXml(ref.name, ref.model, xml, source, args.includeLabels);
+      // `ref` goes through so a JSON cache that outlived its AxEnum.xml is labelled
+      // a stale row rather than rendered as a live enum — the ghost enum of #874's run.
+      const formatted = xml && await formatEnumXml(ref.name, ref.model, xml, source, args.includeLabels, ref);
       if (formatted) return formatted;
     }
 
@@ -87,6 +90,7 @@ async function formatEnumXml(
   xml: string,
   source: string,
   includeLabels: boolean,
+  ref?: IndexedObjectRef | null,
 ): Promise<{ content: { type: 'text'; text: string }[] } | null> {
   let axEnum: any;
   try {
@@ -107,7 +111,7 @@ async function formatEnumXml(
   out += `**Extensible:** ${axEnum.IsExtensible?.[0] === 'Yes' ? 'Yes' : 'No'}\n`;
   out += `**Use Enum Value:** ${axEnum.UseEnumValue?.[0] === 'Yes' ? 'Yes' : 'No'}\n`;
   if (axEnum.Label?.[0]) out += `**Label:** ${axEnum.Label[0]}\n`;
-  out += indexedSourceNote(source);
+  out += indexedSourceNote(source, ref);
 
   if (values.length > 0) {
     out += `## 📋 Enum Values (${values.length})\n\n`;

--- a/src/tools/readers/getLabelInfo.ts
+++ b/src/tools/readers/getLabelInfo.ts
@@ -33,14 +33,12 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
 
     // Mode A: no labelId → list available AxLabelFile IDs
     if (!labelId) {
-      let files = symbolIndex.getLabelFileIds(model);
-
       // When a specific labelFileId is requested, narrow the listing to it and
       // additionally surface the physical .label.txt path for each language so
-      // the caller never has to shell out to locate the file on disk.
-      if (labelFileId) {
-        files = files.filter(f => f.labelFileId.toLowerCase() === labelFileId.toLowerCase());
-      }
+      // the caller never has to shell out to locate the file on disk. The narrowing
+      // is the query's job — doing it here meant every such call still grouped the
+      // whole labels table first (see getLabelFileIds).
+      const files = symbolIndex.getLabelFileIds(model, labelFileId);
 
       if (files.length === 0) {
         return {

--- a/src/tools/readers/getObjectInfo.ts
+++ b/src/tools/readers/getObjectInfo.ts
@@ -110,6 +110,15 @@ function toObjectRefs(args: z.infer<typeof GetObjectInfoArgsSchema>): ObjectRef[
   return null;
 }
 
+/**
+ * Object types whose methods `options.method` can read.
+ *
+ * Kept in step with `OBJECT_TYPES` in tools/knowledge/methodSignature.ts — that
+ * is the tool this option delegates to, and the two disagreeing is what made a
+ * table's `validateWrite` unreadable through the folded call.
+ */
+const METHOD_OWNER_TYPES = new Set(['class', 'table', 'view', 'data-entity']);
+
 /** Resolve one object through its registered reader, with the shared not-found guidance. */
 async function readObject(ref: ObjectRef, context: XppServerContext) {
   const { objectType, name, options } = ref;
@@ -122,9 +131,18 @@ async function readObject(ref: ObjectRef, context: XppServerContext) {
   // one signature, where the middle call already had the class in hand. Folding
   // it here removes that hop and its ~926 chars from every ListTools payload.
   if (options?.method) {
-    if (objectType !== 'class') {
+    // get_method resolves methods on classes, tables, views and data entities
+    // (its own OBJECT_TYPES), so gating this on `class` alone refused calls the
+    // underlying tool would have answered. `options.method:"validateWrite"` on a
+    // table is the obvious one, and the refusal sent the caller hunting for a
+    // separate tool instead of naming the types that do work.
+    if (!METHOD_OWNER_TYPES.has(objectType)) {
       return {
-        content: [{ type: 'text', text: `❌ get_object_info: options.method is only supported for objectType="class". For "${objectType}" omit it to get full metadata.` }],
+        content: [{
+          type: 'text',
+          text: `❌ get_object_info: options.method works on ${[...METHOD_OWNER_TYPES].join(', ')} — ` +
+            `"${objectType}" stores no methods, so omit it to get full metadata.`,
+        }],
         isError: true,
       };
     }
@@ -136,6 +154,11 @@ async function readObject(ref: ObjectRef, context: XppServerContext) {
           className: name,
           methodName: String(options.method),
           include: options.include,
+          // The schema advertises modelName among the flags forwarded to the
+          // reader, and get_method takes one — dropping it here made the
+          // documented way to disambiguate a name that two models both define
+          // do nothing at all.
+          modelName: options.modelName,
         },
       },
     };

--- a/src/tools/readers/viewInfo.ts
+++ b/src/tools/readers/viewInfo.ts
@@ -22,6 +22,7 @@ import {
   resolveIndexedObject,
   indexedSourceNote,
   bridgeUnavailableNote,
+  type IndexedObjectRef,
 } from '../../utils/indexedXmlLookup.js';
 import { findD365FileOnDisk } from '../../utils/objectFileLookup.js';
 
@@ -118,8 +119,10 @@ async function buildViewResponseFromIndex(
   // Pre-extracted JSON (works without a D365FO installation)
   const extracted = await readViewMetadata(model, ref.name);
   if (extracted) {
+    // The JSON cache outlives a deleted AxView.xml, so `ref` rides along to have a
+    // row that lost its file called out instead of rendered as a live view.
     return {
-      content: [{ type: 'text', text: formatViewLike(extracted, model, 'symbol index (extracted metadata)') }],
+      content: [{ type: 'text', text: formatViewLike(extracted, model, 'symbol index (extracted metadata)', ref) }],
     };
   }
 
@@ -157,7 +160,7 @@ async function buildViewResponseFromDisk(
   return null;
 }
 
-function formatViewLike(v: ViewLike, model: string, source: string): string {
+function formatViewLike(v: ViewLike, model: string, source: string, ref?: IndexedObjectRef | null): string {
   const kind = v.type === 'data-entity' ? 'Data Entity View' : 'View';
   let out = `# ${kind}: ${v.name}\n\n`;
   if (v.label) out += `**Label:** ${v.label}\n`;
@@ -165,7 +168,7 @@ function formatViewLike(v: ViewLike, model: string, source: string): string {
   if (v.isPublic != null) out += `**Public:** ${v.isPublic ? 'Yes' : 'No'}\n`;
   if (v.isReadOnly != null) out += `**Read-Only:** ${v.isReadOnly ? 'Yes' : 'No'}\n`;
   if (v.primaryKey) out += `**Primary Key:** ${v.primaryKey}\n`;
-  out += indexedSourceNote(source);
+  out += indexedSourceNote(source, ref);
 
   const fields = v.fields ?? [];
   if (fields.length > 0) {

--- a/src/tools/sdlc/verifyD365Project.ts
+++ b/src/tools/sdlc/verifyD365Project.ts
@@ -163,8 +163,9 @@ export async function verifyD365ProjectTool(
     }
 
     // The model's OTHER projects. Membership is a model-wide question: a file
-    // registered in the project that owns it is registered, and calling that
-    // "missing" is how one file ends up in two projects.
+    // referenced by a sibling project compiles, and reporting that as "missing"
+    // is a hard error on something that builds. It is still worth flagging when
+    // the ACTIVE project lacks it — see the projCell rendering below.
     // Degrades to the active project alone rather than throwing: a solution
     // scan that has not run yet must narrow this answer, not replace the whole
     // verification with an error.
@@ -248,9 +249,11 @@ export async function verifyD365ProjectTool(
         }
       }
 
-      // Project check, across every project of the model. An object registered
-      // in the project that OWNS it is registered — reporting it as missing
-      // invites a second entry for one file, and then it compiles twice.
+      // Project check, across every project of the model. Three outcomes worth
+      // telling apart: in this project, only in a sibling (compiles, but this
+      // project does not contain it), and in none (does not compile at all).
+      // Collapsing the middle case into 'missing' was a hard error on something
+      // that builds; collapsing it into 'ok' hid a real gap.
       let projectStatus: ObjectResult['projectStatus'] = 'no-project';
       let ownedBy: string[] = [];
       if (resolvedProjectPath || siblingProjectPaths.length > 0) {
@@ -297,7 +300,10 @@ export async function verifyD365ProjectTool(
         r.projectStatus === 'ok'
           ? '✅'
           : r.projectStatus === 'elsewhere'
-          ? `✅ in ${r.ownedBy.map(projectDisplayName).join(', ')}`
+          // Compiles — a sibling project references it — but the active project
+          // does not contain it, so it cannot be built or handed over from here.
+          // Not an error, not a pass either.
+          ? `⚠️ Only in ${r.ownedBy.map(projectDisplayName).join(', ')}`
           : r.projectStatus === 'missing'
           ? `❌ In no project of this model (\`${r.axFolder}\\${r.objectName}\`)`
           : '⚠️ No project path';
@@ -320,12 +326,15 @@ export async function verifyD365ProjectTool(
     if (hasProject) {
       summaryLines.push(
         `- In the active project ✅: ${projOk}` +
-        (projElsewhere > 0 ? `   In another project of this model ✅: ${projElsewhere}` : '') +
+        (projElsewhere > 0 ? `   Only in another project of this model ⚠️: ${projElsewhere}` : '') +
         `   In no project ❌: ${projMissing}`,
       );
       if (projElsewhere > 0) {
         summaryLines.push(
-          `- Objects marked "in <project>" are registered where they belong — do NOT add them to the active project as well.`,
+          `- Objects marked "Only in <project>" do compile — an element may belong to several projects of ` +
+          `a model and is built once regardless. But the active project does not contain them, so a change ` +
+          `made here cannot be built or handed over from it. Add them with ` +
+          `d365fo_file(action="modify", addToProject=true) if you are working on them here.`,
         );
       }
     }

--- a/src/tools/smart/codeGen.ts
+++ b/src/tools/smart/codeGen.ts
@@ -1942,7 +1942,7 @@ export async function codeGenTool(request: CallToolRequest) {
       }
     } else if (args.pattern === 'sysoperation') {
       // sysoperation is handled separately so we can pass the optional serviceMethod param
-      let finalName = applyObjectPrefix(args.name, prefix);
+      let finalName = applyObjectPrefix(args.name, prefix, resolvedModelName || undefined);
       const suffix = getObjectSuffix();
       finalName = applyObjectSuffix(finalName, suffix);
       const serviceMethod = args.serviceMethod?.trim() || 'process';
@@ -1962,7 +1962,7 @@ export async function codeGenTool(request: CallToolRequest) {
           isError: true,
         };
       }
-      let finalName = applyObjectPrefix(args.name, prefix);
+      let finalName = applyObjectPrefix(args.name, prefix, resolvedModelName || undefined);
       const suffix = getObjectSuffix();
       finalName = applyObjectSuffix(finalName, suffix);
       code = newTemplate(finalName);

--- a/src/tools/smart/generateSmartForm.ts
+++ b/src/tools/smart/generateSmartForm.ts
@@ -648,7 +648,7 @@ export async function handleGenerateSmartForm(
 
   // Apply extension prefix to form name (skip when model unknown)
   const objectPrefix = resolvedModel ? resolveObjectPrefix(resolvedModel) : '';
-  let finalName = objectPrefix ? applyObjectPrefix(name, objectPrefix) : name;
+  let finalName = objectPrefix ? applyObjectPrefix(name, objectPrefix, resolvedModel ?? undefined) : name;
   const objectSuffix = getObjectSuffix();
   finalName = applyObjectSuffix(finalName, objectSuffix);
   if (finalName !== name) {

--- a/src/tools/smart/generateSmartReport.ts
+++ b/src/tools/smart/generateSmartReport.ts
@@ -324,7 +324,7 @@ export async function handleGenerateSmartReport(
 
   // Apply prefix
   const objectPrefix = resolvedModel ? resolveObjectPrefix(resolvedModel) : '';
-  let finalName = objectPrefix ? applyObjectPrefix(name, objectPrefix) : name;
+  let finalName = objectPrefix ? applyObjectPrefix(name, objectPrefix, resolvedModel ?? undefined) : name;
   const objectSuffix = getObjectSuffix();
   finalName = applyObjectSuffix(finalName, objectSuffix);
   if (finalName !== name) log(`Applied naming: ${name} → ${finalName}`);

--- a/src/tools/smart/generateSmartTable.ts
+++ b/src/tools/smart/generateSmartTable.ts
@@ -651,7 +651,7 @@ export async function handleGenerateSmartTable(
 
   // Apply extension prefix to table name (skip when model unknown)
   const objectPrefix = resolvedModel ? resolveObjectPrefix(resolvedModel) : '';
-  let finalName = objectPrefix ? applyObjectPrefix(name, objectPrefix) : name;
+  let finalName = objectPrefix ? applyObjectPrefix(name, objectPrefix, resolvedModel ?? undefined) : name;
   const objectSuffix = getObjectSuffix();
   finalName = applyObjectSuffix(finalName, objectSuffix);
   if (finalName !== name) {

--- a/src/tools/specs/d365foFileOpSpecs.ts
+++ b/src/tools/specs/d365foFileOpSpecs.ts
@@ -404,7 +404,10 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
     note:
       'table-extension: a group owned by the BASE table is detected and extended through ' +
       '<FieldGroupExtensions> on its own (reported as a Note) — pass extendBaseFieldGroup=true to state ' +
-      'it up front, or autoCorrect=false to have the mismatch error instead.',
+      'it up front, or autoCorrect=false to have the mismatch error instead. ' +
+      'fieldName follows the prefix add-field applied: send both in one operations[] and the bare name is ' +
+      'retargeted at the prefixed field (reported as a Note), unless the base table declares a field of ' +
+      'that name too — then it is taken as naming the base-table field.',
   },
   'add-field-modification': {
     required: ['fieldName'],
@@ -537,6 +540,13 @@ export const D365FO_FILE_CORE_PARAMS: ReadonlySet<string> = new Set([
   // side options
   'createBackup', 'addToProject', 'projectPath', 'solutionPath', 'groundingToken',
   'autoCorrect',
+  // Internal, injected by runModifyBatch — the operation names travelling in the
+  // same operations[] batch, so an advisory note can tell whether its advice has
+  // already been taken. It is absent from the published schema, so no caller can
+  // send it; omitting it here made every batched entry report
+  // "peerOperations: IGNORED (not a recognised d365fo_file parameter)" — the
+  // exact false warning the batch flow exists to stop producing.
+  'peerOperations',
 ]);
 
 /**

--- a/src/tools/specs/opSpecs.ts
+++ b/src/tools/specs/opSpecs.ts
@@ -40,6 +40,46 @@ const TOOL_PREFIXES = ['d365fo_file.', 'd365fo_file:', 'generate_object.', 'gene
 /** Topics that resolve to the `labels` write-plumbing contract. */
 const LABELS_TOPICS = ['labels', 'label', 'labels.create', 'labels.rename', 'create-label'];
 
+/**
+ * Real questions that are not op-specs, answered with the tool that does answer them.
+ *
+ * These are asked, and the catalogue is the wrong reply: a caller who has just been
+ * told "Final name: X (prefix auto-applied)" and wants to know how the prefix is
+ * chosen reaches for topic="naming" or topic="prefix", gets back the full list of 30
+ * modify operations, and is no closer — twice in one observed session, ~2 round trips
+ * spent on a dead end at the exact moment the caller was already unsure about a name.
+ */
+const TOPIC_REDIRECTS: Record<string, string> = {
+  naming: 'naming',
+  prefix: 'naming',
+  'object-naming': 'naming',
+  'model-prefix': 'naming',
+  'extension-prefix': 'naming',
+  suffix: 'naming',
+};
+
+const REDIRECT_ANSWERS: Record<string, string> = {
+  naming: [
+    'Naming is not an op-spec — it is resolved per model, so ask the tools that know your model:',
+    '',
+    '  validate_object_naming(objectType, proposedName[, baseObjectName])',
+    '      → the rules applied, the effective prefix and where it came from, and a conflict check.',
+    '  get_workspace_info()',
+    '      → the model, the effective prefix, and the extension token this server applies.',
+    '  prepare(mode="create", objectName, objectType)',
+    '      → the exact final name d365fo_file(action="create") will write, collision-checked.',
+    '',
+    'The short version:',
+    '  • Pass the BASE name to d365fo_file(action="create") — the prefix is applied for you.',
+    '    Do NOT pre-apply it and do NOT add a leading separator; both double up.',
+    '  • The prefix is inferred from the model\'s own objects and beats EXTENSION_PREFIX.',
+    '    Pin the configured value instead with EXTENSION_PREFIX_SOURCE=config.',
+    '  • Regular objects keep the model\'s separator (ConSK_MyEnum); extension elements',
+    '    use the PascalCase infix without one (MyTable.ConSkExtension,',
+    '    MyTableConSk_Extension).',
+  ].join('\n'),
+};
+
 function normalize(topic: string): string {
   let t = topic.trim();
   for (const prefix of TOOL_PREFIXES) {
@@ -176,6 +216,9 @@ export function lookupOpSpec(topic?: string): string {
   if (objectType) return renderCreatePropertySpec(objectType);
 
   if (LABELS_TOPICS.includes(needle)) return renderLabelsOpSpec();
+
+  const redirect = TOPIC_REDIRECTS[needle];
+  if (redirect && REDIRECT_ANSWERS[redirect]) return REDIRECT_ANSWERS[redirect];
 
   return renderOpSpecIndex(topic);
 }

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -19,7 +19,7 @@ import { z } from 'zod';
 import { getConfigManager, fallbackPackagePath } from '../../utils/configManager.js';
 import { describePackagesRootScan } from '../../utils/packagesRoot.js';
 import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
-import { ProjectFileManager, ProjectFileFinder, registerFileIfOrphaned } from '../../workspace/projectFile.js';
+import { ProjectFileManager, ProjectFileFinder, registerFileInActiveProject } from '../../workspace/projectFile.js';
 import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck, membershipOf } from './inlineWriteVerification.js';
 import { registerCustomModel } from '../../utils/modelClassifier.js';
 import { normalizeObjectName } from '../../utils/objectNaming.js';
@@ -3614,14 +3614,14 @@ export async function handleCreateD365File(
             `(active naming style/prefix), so this is the file that matches your request.`
           : '';
 
-        // A file on disk that no project of the model references is a real gap,
-        // and this early return was the only place that could close it: `create`
-        // used to bail here, before the addToProject block far below, and
+        // A file on disk that the ACTIVE project does not reference is a real
+        // gap, and this early return was the only place that could close it:
+        // `create` used to bail here, before the addToProject block far below, and
         // `modify` registers nothing unless the caller passes a flag that is not
         // in the wire schema. So an object that existed but was unregistered
         // could never BECOME registered — which is how a table extension got
         // edited through a whole session while staying invisible to the build.
-        const projectNote = await registerFileIfOrphaned(
+        const projectNote = await registerFileInActiveProject(
           args.objectType, finalObjectName, actualModelName, projectPathToUse,
         );
 
@@ -3654,8 +3654,32 @@ export async function handleCreateD365File(
     // EXCEPTION — security-privilege/duty/role: excluded from BRIDGE_CREATE_TYPES
     // entirely (see bridgeAdapter.ts) because the bridge silently drops their
     // structured collections (EntryPoints, DataEntityPermissions, Privileges, Duties).
-    const skipBridgeForExtensibleEnum = args.objectType === 'enum'
-      && Boolean((args.properties as Record<string, unknown> | undefined)?.isExtensible);
+    //
+    // EXCEPTION — any enum whose resolved mode forbids explicit <Value> elements. The
+    // bridge takes UseEnumValue from the scalar property but still serializes a <Value>
+    // for every numbered entry, minus the ones equal to 0, which .NET omits as the type
+    // default. An enum created with useEnumValue:false and values None=0..Platinum=3 came
+    // out as <UseEnumValue>No</UseEnumValue> with <Value>1/2/3</Value> and no <Value>0</Value>
+    // — the combination this server's own knowledge base tells callers xppc rejects the
+    // moment IsExtensible is set, and with the caller's number for entry 0 silently gone.
+    // resolveEnumValueMode is the single place that decides this; when it says the values
+    // must be suppressed and the payload carries some, hand the write to the TypeScript
+    // generator, which is the writer that honours suppressExplicitValues.
+    const skipBridgeForEnumValueMode = (): boolean => {
+      if (args.objectType !== 'enum') return false;
+      const props = args.properties as Record<string, unknown> | undefined;
+      if (props?.isExtensible) return true;
+      const vals = (props?.enumValues ?? props?.values) as Array<{ name?: string; value?: number }> | undefined;
+      if (!Array.isArray(vals) || !vals.some(v => typeof v?.value === 'number')) return false;
+      try {
+        return resolveEnumValueMode(finalObjectName, props, vals).suppressExplicitValues;
+      } catch {
+        // A genuine contradiction (isExtensible + off-positional values, …). Let the
+        // generator path re-run it and surface the one authored error message.
+        return true;
+      }
+    };
+    const skipBridgeForEnum = skipBridgeForEnumValueMode();
 
     // Set only when a bridge create THREW (not when it was unavailable or declined).
     // The XML fallback below is a different writer with a narrower feature set, so a
@@ -3663,7 +3687,7 @@ export async function handleCreateD365File(
     // same ✅ as one the bridge performed.
     let bridgeFailure: BridgeFailure | null = null;
 
-    if (!args.xmlContent && !skipBridgeForExtensibleEnum && context?.bridge && actualModelName && canBridgeCreate(args.objectType)) {
+    if (!args.xmlContent && !skipBridgeForEnum && context?.bridge && actualModelName && canBridgeCreate(args.objectType)) {
       try {
         // Settle any rebuild an earlier write in this session scheduled but did not
         // wait for. Everything below reads the provider — the base object of an

--- a/src/tools/write/inlineWriteVerification.ts
+++ b/src/tools/write/inlineWriteVerification.ts
@@ -77,9 +77,9 @@ export interface WriteVerification {
  * Check that a just-written file is where it should be. Never throws.
  *
  * `siblingProjectPaths` are the other .rnrproj of the same model. Supply them
- * and an object registered in the project that owns it is reported as such
- * rather than as missing — the distinction matters, because "missing" invites a
- * second registration of the same file.
+ * and an object referenced by one of those is reported as such rather than as
+ * missing — the distinction matters, because only one of the two stops the
+ * build, and they call for different fixes.
  */
 export async function verifyWrittenFile(
   filePath: string | undefined,

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -37,7 +37,7 @@ import {
   bridgeRefreshProvider,
 } from '../../bridge/index.js';
 import * as debouncedRefresh from '../../bridge/debouncedRefresh.js';
-import { ProjectFileFinder, registerFileIfOrphaned } from '../../workspace/projectFile.js';
+import { ProjectFileFinder, registerFileInActiveProject } from '../../workspace/projectFile.js';
 import { heuristicEdtBaseType, resolveEdtBaseType, isEnumName } from '../smart/generateSmartTable.js';
 import { normalizeD365Xml } from '../../utils/d365XmlNormalizer.js';
 import {
@@ -325,10 +325,28 @@ const directXmlReplaceCode = serializedOnFile(async (
     }
 
     await writeFileAtomic(filePath, normalizeD365Xml(updated));
+
+    // Read back before claiming it. The bridge declining is normal here (a class
+    // DECLARATION is not a method, so its Methods API never finds the snippet),
+    // but a message that led with that error and only then said ✅ read as a
+    // failure — the caller re-did the same edit by hand with a plain text tool,
+    // which is the AOT-XML bypass this server exists to remove. Confirming the
+    // new code is on disk lets the message lead with the fact instead.
+    const after = (await fs.readFile(filePath, 'utf-8')).replace(/^﻿/, '').replace(/\r\n/g, '\n');
+    if (!after.includes(normNew)) {
+      return {
+        success: false,
+        message: `❌ directXmlReplaceCode: wrote ${filePath} but newCode is not in the file afterwards — ` +
+          `the write did not take effect. Re-read the file and retry; do not assume the change landed.`,
+      };
+    }
+
     console.error(`[modify_d365fo_file] ✅ directXmlReplaceCode fallback (${reason}): replaced in ${filePath}`);
     return {
       success: true,
-      message: `✅ Code replaced via direct XML fallback (${reason}). File: ${filePath}`,
+      message: `✅ Code replaced and verified on disk — newCode is present in ${filePath}. ` +
+        `No further edit is needed; do NOT re-apply it with a text editor.\n` +
+        `   (Written by this server's XML writer rather than the bridge — ${reason})`,
     };
   } catch (err) {
     console.error(`[modify_d365fo_file] directXmlReplaceCode failed: ${err}`);
@@ -1503,11 +1521,12 @@ const ModifyD365FileArgsSchema = z.object({
   // opposite. Editing an existing object that was on disk but absent from the
   // .rnrproj therefore never registered it, no matter how many times it was
   // edited. Registration is idempotent (ProjectFileManager skips an entry that
-  // is already there), and it is scoped to objects that belong in the active
-  // project: an object owned by another project of the model is left alone.
+  // is already there) and targets the ACTIVE project: an element may be
+  // referenced by several projects of a model, and the one being edited in has
+  // to contain it.
   addToProject: z.boolean().optional().default(true).describe(
-    'Add the modified file to the .rnrproj when no project of its model references it yet. ' +
-    'Keep the default — a file missing from every project of its model does not compile. ' +
+    'Add the modified file to the active .rnrproj when it is not already listed there. ' +
+    'Keep the default — a project that does not contain the object cannot build or hand over the change. ' +
     'Set false to skip. Requires projectPath or solutionPath (explicit or via .mcp.json).'
   ),
   projectPath: z.string().optional().describe(
@@ -1519,6 +1538,19 @@ const ModifyD365FileArgsSchema = z.object({
   groundingToken: z.string().optional().describe(
     'Provenance token returned by prepare(mode="change"). Proves the change was grounded in the indexed codebase. ' +
     'Required for *-extension objectTypes when GROUNDING_ENFORCE=true on the server.'
+  ),
+
+  // INTERNAL — set by runModifyBatch, absent from the published wire schema.
+  //
+  // Each entry of operations[] runs as its own modify call, so an operation
+  // cannot see the ones travelling with it. That is fine for the writes, which
+  // are independent, and wrong for the advisory notes, which are about the task:
+  // add-field told the caller "send the group entry in the SAME call next time"
+  // in a call that already contained the group entry. Advice that fires when it
+  // has already been followed is how a response teaches an agent to stop reading
+  // its warnings.
+  peerOperations: z.array(z.string()).optional().describe(
+    'Internal: the operation names travelling in the same operations[] batch.'
   ),
 });
 
@@ -1914,6 +1946,24 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       containment.modelSegment || resolvedModelFromPath || modelName || getConfigManager().getModelName() || '',
     );
     if (memberPrefixNote) generationNote += memberPrefixNote;
+
+    // The other half of that rename: an operation that REFERS to a member the
+    // prefix has already renamed. add-field-to-field-group mints no name, so it
+    // is rightly absent from the table above — but it names the field the
+    // add-field before it just renamed, and pointed the group at a field that
+    // does not exist. Corrected here, where the extension's real fields can be
+    // read, and only when there is one reading (see the helper).
+    if (autoCorrect) {
+      const retargetNote = await resolveFieldNameForFieldGroup(
+        args as Record<string, any>,
+        objectType,
+        operation,
+        containment.modelSegment || resolvedModelFromPath || modelName || getConfigManager().getModelName() || '',
+        actualFilePath,
+        symbolIndex,
+      );
+      if (retargetNote) noteAutoCorrection(autoCorrectNotes, retargetNote);
+    }
 
     // Settle a rebuild an earlier create/modify scheduled but did not wait for, so
     // an object written moments ago resolves on the FIRST attempt. Without this the
@@ -2917,15 +2967,14 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       console.error(`[modify_d365fo_file] Bridge validation skipped: ${e}`);
     });
 
-    // Register the edited file when no project of its model references it.
+    // Register the edited file in the ACTIVE project unless it is already there.
     //
-    // This used to add it to the active project unconditionally whenever the
-    // flag was set — which was safe only because the flag defaulted OFF and
-    // nobody set it. On by default (matching the wire schema, which always
-    // advertised `default: true`), unconditional registration would put objects
-    // owned by another project of the model into the active one as well, and
-    // one file in two projects builds the element twice. registerFileIfOrphaned
-    // makes the membership check the gate: it acts only on a true orphan.
+    // Being referenced by a sibling project of the same model is not a reason to
+    // skip this: an element may belong to several .rnrproj, the model is the
+    // build unit and it compiles once regardless, and a project that does not
+    // contain the object cannot build or hand over the change just made to it.
+    // The previous gate stopped at 'registered somewhere', which left an edited
+    // object missing from the very project it was edited in.
     let projectMessage = '';
     if (args.addToProject) {
       const configManager = getConfigManager();
@@ -2941,7 +2990,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         ) || undefined;
       }
 
-      projectMessage = await registerFileIfOrphaned(
+      projectMessage = await registerFileInActiveProject(
         objectType,
         objectName,
         modelName || configManager.getModelName() || undefined,
@@ -2961,22 +3010,30 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     //
     // The field-group note used to spell out a whole follow-up call, so the agent
     // made one: every add-field manufactured a second round trip. It now points at
-    // operations[], where the group entry travels in the SAME call as the field.
+    // operations[], where the group entry travels in the SAME call as the field —
+    // and stays quiet when that call already carries one.
     let addFieldBpNote = '';
     if (operation === 'add-field' && (objectType === 'table' || objectType === 'table-extension')) {
-      const notes = [
-        `⚠️ BP: a table field must belong to a field group (BPErrorTableFieldNotInFieldGroup). ` +
-        `Send the group entry in the SAME call next time — d365fo_file(action="modify", ` +
-        `objectType="${objectType}", objectName="${objectName}", operations=[{operation:"add-field", …}, ` +
-        `{operation:"add-field-to-field-group", fieldName:"${args.fieldName}", fieldGroupName:"<group>"}]).`,
-      ];
+      const notes: string[] = [];
+      // Silent when the group entry is already in this batch — the advice has
+      // been taken, and repeating it teaches the agent that these warnings do
+      // not track what it actually did.
+      const groupEntryInBatch = (args.peerOperations ?? []).includes('add-field-to-field-group');
+      if (!groupEntryInBatch) {
+        notes.push(
+          `⚠️ BP: a table field must belong to a field group (BPErrorTableFieldNotInFieldGroup). ` +
+          `Send the group entry in the SAME call next time — d365fo_file(action="modify", ` +
+          `objectType="${objectType}", objectName="${objectName}", operations=[{operation:"add-field", …}, ` +
+          `{operation:"add-field-to-field-group", fieldName:"${args.fieldName}", fieldGroupName:"<group>"}]).`,
+        );
+      }
       if ((args as any).fieldEnumType) {
         notes.push(
           `⚠️ BP: the field's Label must be a DIFFERENT label id than the enum's own label ` +
           `(BPErrorFieldLabelIsCopyOfEnumLabel) — same visible text is fine, same id is not.`,
         );
       }
-      addFieldBpNote = `\n\n${notes.join('\n')}`;
+      addFieldBpNote = notes.length > 0 ? `\n\n${notes.join('\n')}` : '';
     }
 
     // Corrections the server applied on its own. Kept in the payload so the agent
@@ -3137,6 +3194,99 @@ export function applyExtensionMemberPrefix(
     `\n\n> 🔖 Named \`${prefixed}\` — members added to an extension carry model ` +
     `"${modelName}"'s prefix \`${token}\`. Use that name in later calls.`
   );
+}
+
+/** Field names declared by a table extension's own `<Fields>`, as spelled there. */
+function extensionFieldNames(xml: string): string[] {
+  const names: string[] = [];
+  // <Name> is the first child of every <AxTableField>, so a non-greedy hop from
+  // the opening tag to the first Name reads one field name per block. Field
+  // GROUP entries use <DataField>, so they cannot be picked up by accident.
+  for (const m of xml.matchAll(/<AxTableField\b[^>]*>[\s\S]*?<Name>([^<]+)<\/Name>/g)) {
+    names.push(m[1].trim());
+  }
+  return names;
+}
+
+/** Whether the base table declares a field of this name. */
+function baseTableDeclaresField(xml: string, fieldName: string): boolean {
+  const needle = fieldName.trim().toLowerCase();
+  return extensionFieldNames(xml).some(n => n.toLowerCase() === needle);
+}
+
+/**
+ * Point `add-field-to-field-group` at the field that actually exists.
+ *
+ * add-field on an extension renames what it adds — `QualityTier` becomes
+ * `CtsoSK_QualityTier`, because a member added to someone else's table has to
+ * carry your prefix — and says so in the response. The group entry that follows
+ * it names the SAME field, and it was left exactly as the caller spelled it:
+ * applyExtensionMemberPrefix mints names for new members and this operation
+ * mints none, so it is correctly absent from EXTENSION_MEMBER_NAME_ARG.
+ *
+ * The result was a dangling reference. The bridge validates no DataField, so
+ * `<DataField>QualityTier</DataField>` was written against a field named
+ * `CtsoSK_QualityTier`, reported as applied, and the group silently pointed at
+ * nothing. Sending both operations in ONE call — which every add-field response
+ * tells the agent to do — hit it every time.
+ *
+ * Blind prefixing is the wrong repair: a group extension may perfectly well
+ * carry a BASE-table field, which has no prefix. So this corrects only the case
+ * with one reading — the name as given is not a field of the extension, the
+ * prefixed name is, and the base table has no field by the given name either.
+ * Anything else is left untouched.
+ *
+ * Advisory, like every other auto-correction: it runs before a write that is
+ * perfectly capable of succeeding without it, so anything unreadable — the
+ * extension file, the base table, the prefix rules — means "no correction", not
+ * a failed modify.
+ */
+export async function resolveFieldNameForFieldGroup(
+  args: Record<string, any>,
+  objectType: string,
+  operation: string,
+  modelName: string,
+  actualFilePath: string,
+  symbolIndex: any,
+): Promise<string> {
+  if (operation !== 'add-field-to-field-group' || objectType !== 'table-extension') return '';
+
+  const given = args.fieldName;
+  if (typeof given !== 'string' || given.trim().length === 0) return '';
+
+  try {
+    const token = resolveRegularObjectPrefixToken(modelName);
+    if (!token) return '';
+    const bare = token.replace(/_+$/, '');
+    const lower = given.toLowerCase();
+    if (lower.startsWith(token.toLowerCase()) || lower.startsWith(bare.toLowerCase())) return '';
+
+    const extensionXml = await fs.readFile(actualFilePath, 'utf-8');
+    const fields = extensionFieldNames(extensionXml);
+    // Already a field of this extension — nothing to correct.
+    if (fields.some(n => n.toLowerCase() === lower)) return '';
+
+    const prefixed = `${token}${given.charAt(0).toUpperCase()}${given.slice(1)}`;
+    const match = fields.find(n => n.toLowerCase() === prefixed.toLowerCase());
+    if (!match) return '';
+
+    // A base-table field of the given name makes both readings valid; say
+    // nothing and let the caller's spelling stand.
+    const baseTable = String(args.objectName ?? '').split('.')[0];
+    if (baseTable) {
+      const baseXml = await findBaseObjectXml('table', baseTable, symbolIndex);
+      if (baseXml && baseTableDeclaresField(baseXml, given)) return '';
+    }
+
+    args.fieldName = match;
+    console.error(`[modifyD365File] Field-group entry retargeted: ${given} → ${match}`);
+    return (
+      `'${given}' is not a field of this extension, but '${match}' is — the group entry now points at it. ` +
+      `Members added to an extension carry the model's prefix \`${token}\`; use that name when referring to them.`
+    );
+  } catch {
+    return '';
+  }
 }
 
 /**

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -1155,10 +1155,10 @@ class ConfigManager {
    * Every .rnrproj that builds `modelName`, as paths.
    *
    * One model is split across as many projects as its owner wants — fifteen, in
-   * the solution that surfaced this. Anything asking "is this object registered
-   * in a project?" has to ask all of them, or a file correctly registered in the
-   * project that owns it reads as missing, and the fix that invites is a second
-   * entry for the same file. See workspace/projectMembership.ts.
+   * the solution that surfaced this — and one object may be referenced by
+   * several of them. Anything asking "is this object registered in a project?"
+   * has to ask all of them, or a file that compiles perfectly reads as missing
+   * from the build. See workspace/projectMembership.ts.
    */
   getProjectsForModel(modelName: string | null | undefined): string[] {
     if (!modelName) return [];

--- a/src/utils/indexedXmlLookup.ts
+++ b/src/utils/indexedXmlLookup.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs';
 import { promises as fsp } from 'fs';
 import { lookupSymbolNocase } from './symbolLookup.js';
 import { resolveDbPathLocally } from './metadataResolver.js';
+import { getConfigManager, fallbackPackagePath } from './configManager.js';
 import { bridgeStartupState, type BridgeReadinessSource } from '../bridge/bridgeReadiness.js';
 
 export interface IndexedObjectRef {
@@ -30,6 +31,15 @@ export interface IndexedObjectRef {
   indexedPath: string | null;
   /** Readable path on this machine (indexed or remapped), null when unreachable. */
   localPath: string | null;
+  /**
+   * The index records a PackagesLocalDirectory path whose file is gone from BOTH
+   * the recorded location and the local remap — the row outlived the object.
+   *
+   * Only set for PackagesLocalDirectory paths: a foreign build-agent path that
+   * simply does not remap here is unreachable, not deleted, and must not be
+   * reported as stale.
+   */
+  sourceFileMissing: boolean;
 }
 
 /** Look up a top-level object in the symbol index and resolve a readable local path. */
@@ -50,11 +60,13 @@ export async function resolveIndexedObject(
   // stub can never make a reader render an unrelated object under the asked name.
   if (hit.name?.toLowerCase() !== name.toLowerCase()) return null;
 
+  const localPath = await resolveLocalPath(hit.file_path);
   return {
     name: hit.name,
     model: modelName || hit.model || 'Unknown',
     indexedPath: hit.file_path,
-    localPath: await resolveLocalPath(hit.file_path),
+    localPath,
+    sourceFileMissing: await isStaleIndexedPath(hit.file_path, localPath),
   };
 }
 
@@ -65,6 +77,46 @@ async function resolveLocalPath(indexedPath: string | null): Promise<string | nu
     if (fs.existsSync(indexedPath)) return indexedPath;
   } catch { /* ignore */ }
   return resolveDbPathLocally(indexedPath);
+}
+
+/**
+ * Can this machine observe the absence of a PackagesLocalDirectory file at all?
+ *
+ * "No file at either location" means the object was deleted only if the packages
+ * root is actually there to be looked at. An unconfigured, mistyped or
+ * momentarily unreachable root (an offline share, a drive not yet mapped) makes
+ * EVERY object's file unreadable — and the stale-row note that follows tells the
+ * agent to treat the object as not existing and create it, without re-checking.
+ * That is a duplicate of something like CustTable on a bad config day, so the
+ * root has to be verified before the row is called a ghost.
+ */
+async function packagesRootReachable(): Promise<boolean> {
+  try {
+    const configManager = getConfigManager();
+    await configManager.ensureLoaded();
+    const root = configManager.getPackagePath() || fallbackPackagePath();
+    if (!root) return false;
+    await fsp.access(root);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The one rule for "this index row outlived its file", shared by the ref-carrying
+ * readers and the raw-path ones so the two can never drift apart.
+ *
+ * Only a PackagesLocalDirectory path can be judged: a foreign build-agent path
+ * that does not remap here is unreachable, not deleted.
+ */
+async function isStaleIndexedPath(
+  indexedPath: string | null | undefined,
+  localPath: string | null,
+): Promise<boolean> {
+  if (localPath !== null) return false;
+  if (!indexedPath || !/PackagesLocalDirectory/i.test(indexedPath)) return false;
+  return packagesRootReachable();
 }
 
 /**
@@ -105,9 +157,55 @@ export async function readIndexedXml(
 /**
  * Standard footer for a reader that answered from the index instead of the bridge —
  * makes the provenance (and its limits) explicit to the agent.
+ *
+ * Pass `ref` whenever one is available so a row that outlived its file is called
+ * out rather than rendered as fact — see `staleIndexNote`.
  */
-export function indexedSourceNote(source: string): string {
-  return `_Source: ${source} — the C# bridge returned no data for this object._\n\n`;
+export function indexedSourceNote(source: string, ref?: IndexedObjectRef | null): string {
+  return `_Source: ${source} — the C# bridge returned no data for this object._\n\n` +
+    (ref ? staleIndexNote(ref) : '');
+}
+
+/**
+ * Warn when the answer came from a cache whose object is no longer on disk.
+ *
+ * The extracted-metadata JSON is written at index time and is NOT removed when the
+ * AOT XML is deleted, so a reset workspace kept answering `get_object_info` with a
+ * complete, confident enum — name, four values, four labels — for a file that did
+ * not exist. The agent believed it (the bridge being quiet is normal for
+ * not-yet-indexed objects), spent about a quarter of its run proving the object was
+ * a ghost, and only then started the real work.
+ *
+ * The bridge disagreeing with the cache is the tell, and it is available right here:
+ * bridge silent + PackagesLocalDirectory path + no file at either the recorded or
+ * the remapped location means the row outlived the object.
+ */
+export function staleIndexNote(ref: IndexedObjectRef): string {
+  if (!ref.sourceFileMissing) return '';
+  return renderStaleIndexNote(ref.name, ref.indexedPath ?? '(unknown)');
+}
+
+/**
+ * Is this indexed path a row that outlived its file?
+ *
+ * For readers that hold a raw `file_path` from a symbol row rather than an
+ * `IndexedObjectRef`. Literally the same rule — both go through
+ * `isStaleIndexedPath`, so the two can never answer differently about one row.
+ */
+export async function indexedPathIsMissing(indexedPath: string | null | undefined): Promise<boolean> {
+  if (!indexedPath || !/PackagesLocalDirectory/i.test(indexedPath)) return false;
+  return isStaleIndexedPath(indexedPath, await resolveLocalPath(indexedPath));
+}
+
+/** The warning text both stale-row paths render. */
+export function renderStaleIndexNote(name: string, indexedPath: string): string {
+  return `⚠️ STALE INDEX ENTRY — everything above is a cache read, not a live object. ` +
+    `The symbol index records \`${indexedPath}\`, and there is no file there or at ` +
+    `the local remap of that path. The object was almost certainly deleted (a workspace ` +
+    `reset, a rolled-back run) without the index being rebuilt.\n` +
+    `➡️  Treat \`${name}\` as NOT EXISTING and create it. Do not spend calls proving ` +
+    `this — the file has already been checked on disk. Run \`update_symbol_index\` to ` +
+    `drop rows like this one.\n\n`;
 }
 
 /**

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -251,6 +251,16 @@ export function resolveRegularObjectPrefixToken(modelName?: string): string {
  * so it strips any existing suffix-prefix and replaces it with the current one.
  *
  * Case-insensitive check prevents double-prefixing.
+ *
+ * ALWAYS pass `modelName` when you know it. Omitting it does not merely lose the
+ * model-name naming style — it changes the regular-object result, because the raw
+ * prefix then falls back to EXTENSION_PREFIX and the model's own separator is
+ * invisible: a model whose objects are "ConSK_*" yields "ConSK_QualityTier"
+ * with the argument and "ConSKQualityTier" without it. prepare(mode="create")
+ * predicted names through the 2-arg form while d365fo_file(action="create") wrote
+ * them through the 3-arg form, so the two disagreed on every underscore-style model.
+ * Prefer normalizeObjectName() (utils/objectNaming.ts), which is the one path
+ * create/modify already share.
  */
 export function applyObjectPrefix(objectName: string, prefix: string, modelName?: string): string {
   if (!prefix) return objectName;

--- a/src/utils/modelPrefixInference.ts
+++ b/src/utils/modelPrefixInference.ts
@@ -196,6 +196,49 @@ function inferInfixFromDotExtensions(dotNames: string[]): string | null {
 }
 
 /**
+ * How the model itself SPELLS `token` in the extension position — the casing taken
+ * from evidence rather than derived.
+ *
+ * Both extension shapes are read, because a model may use only one of them:
+ *   "CustTable.ConSKExtension"        → ConSK
+ *   "CustInvoiceJourConSK_Extension"  → ConSK
+ *
+ * Only spellings that case-insensitively equal `token` are counted, so this decides
+ * casing and never the token itself; the most frequent literal spelling wins. Without
+ * it, a model whose 35 extensions all say "ConSK" could still be handed a derived
+ * "ConSk" — toExtensionInfixCase lowercases each segment, which is right for the
+ * acronym prefix the MS rule was written for ("XY_" → "Xy") and wrong for a token
+ * ending in a country code. The model's own files outrank the rule.
+ */
+function observedInfixCasing(names: string[], token: string): string | null {
+  if (!token) return null;
+  const needle = token.toLowerCase();
+  const counts = new Map<string, number>();
+  const bump = (spelling: string) => {
+    if (spelling.toLowerCase() !== needle) return;
+    counts.set(spelling, (counts.get(spelling) ?? 0) + 1);
+  };
+
+  for (const name of names) {
+    if (name.includes('.')) {
+      const suffix = name.slice(name.lastIndexOf('.') + 1);
+      if (/extension$/i.test(suffix)) bump(suffix.slice(0, -'Extension'.length));
+      continue;
+    }
+    if (name.endsWith('_Extension')) {
+      const base = name.slice(0, -'_Extension'.length);
+      if (base.length >= token.length) bump(base.slice(-token.length));
+    }
+  }
+
+  let winner: { spelling: string; n: number } | null = null;
+  for (const [spelling, n] of counts) {
+    if (!winner || n > winner.n) winner = { spelling, n };
+  }
+  return winner ? winner.spelling : null;
+}
+
+/**
  * The PascalCase form of an underscore-style prefix, applied PER SEGMENT:
  * "DEMO" → "Demo", "WHS" → "Whs", "ConFinSK" → "ConFinSk".
  *
@@ -261,7 +304,10 @@ export function inferPrefixFromObjectNames(
   // Each token is preferred from direct evidence and derived from the other only
   // when its own evidence is missing.
   let regular = regularOk ? best!.token : infixFromElements!;
-  const infix = infixFromElements ?? deriveInfixFrom(regular);
+  // Which token, then how the model spells it. The derivation is only the fallback
+  // for a model that states the token nowhere in an extension name.
+  const infixToken = infixFromElements ?? deriveInfixFrom(regular);
+  const infix = observedInfixCasing(clean, infixToken) ?? infixToken;
 
   // Cross-check the two, because a truncated leading token is invisible on its
   // own: "ConFin" looks like a perfectly good prefix until the model's own

--- a/src/utils/xppDocGen.ts
+++ b/src/utils/xppDocGen.ts
@@ -29,19 +29,27 @@ interface ParsedSig {
  * Returns null when the line cannot be parsed or represents a private/internal member.
  */
 function parseSig(sigLine: string): ParsedSig | null {
-  const isPublic    = /\bpublic\b/.test(sigLine);
-  const isProtected = /\bprotected\b/.test(sigLine);
-  if (!isPublic && !isProtected) return null;
-
   const hasParens = sigLine.includes('(');
 
-  // Class / struct declaration
+  // Class / struct declaration.
+  //
+  // An X++ class is public unless it says otherwise, so the visibility gate that
+  // guards methods must not apply here: it skipped `final class Foo_Extension` —
+  // the exact shape this server emits for a CoC extension
+  // (`d365fo_file(create, objectType="class", properties:{isFinal:true})`) — and
+  // the class then came back from this server's own run_bp_check flagged
+  // BPXmlDocNoDocumentationComments. Only an explicit private/internal opts out.
   if (!hasParens) {
     const classMatch = sigLine.match(/\bclass\s+(\w+)/);
     if (!classMatch) return null;
+    if (/\b(private|internal)\b/.test(sigLine)) return null;
     const baseMatch = sigLine.match(/\bextends\s+(\w+)/);
     return { isClass: true, name: classMatch[1], returnType: '', params: [], baseClass: baseMatch?.[1] };
   }
+
+  const isPublic    = /\bpublic\b/.test(sigLine);
+  const isProtected = /\bprotected\b/.test(sigLine);
+  if (!isPublic && !isProtected) return null;
 
   // Method signature
   const parenIdx    = sigLine.indexOf('(');

--- a/src/utils/xppFormat.ts
+++ b/src/utils/xppFormat.ts
@@ -20,6 +20,26 @@
  *
  * — and it did that to correct input too, so a well-formatted switch handed in
  * came back wrong and had to be repaired by hand afterwards.
+ *
+ * A statement continued onto further lines indents those lines one level past
+ * its first line. Brace depth alone cannot see this — no brace opens — so a
+ * wrapped statement came back flattened onto one level, again including
+ * correct input:
+ *
+ *     select firstonly oldRecord
+ *     where oldRecord.RecId == this.RecId;
+ *
+ * That is what a caller who wrapped the `where` (and the `&&` of a wrapped
+ * `if`) got back after `d365fo_file` wrote the method.
+ *
+ * "Is this statement finished?" is asked of the line's CODE, never its raw text.
+ * Asked of the raw text, a trailing comment hid the `;` —
+ *
+ *     ttsbegin; // start
+ *         ttscommit;
+ *
+ * — and every line after one got a level it had not earned. The result was
+ * stable under re-formatting, so nothing ever put it back.
  */
 
 const INDENT_UNIT = '    ';
@@ -32,13 +52,44 @@ interface OpenBlock {
   caseOpen: boolean;
 }
 
-/** `{` and `}` in source order, ignoring string literals and comments. */
-function braceEvents(line: string): { braces: Array<'{' | '}'>; leadingCloses: number } {
+/** What one line contributes, read once with strings and comments accounted for. */
+interface LineScan {
+  /** `{` and `}` in source order, ignoring string literals and comments. */
+  braces: Array<'{' | '}'>;
+  /** How many of those `}` precede any other code on the line. */
+  leadingCloses: number;
+  /**
+   * The line with its comments removed — the only thing worth asking syntax
+   * questions of. `x = 1; // set it` reads as an unfinished statement until the
+   * comment is gone, and every line after it then got a continuation level it
+   * had not earned.
+   */
+  code: string;
+  /** A `/*` opened on this line (or before it) and is still open at its end. */
+  blockCommentOpen: boolean;
+}
+
+/**
+ * Read one line: brace events, and the code with comments stripped.
+ *
+ * X++ string literals take EITHER quote — `"text"` and `'text'` are the same
+ * literal. Recognising only `'` let a brace inside a double-quoted string count
+ * as real: `info("a } b");` popped a block and shifted every following line of
+ * the method out by one level. Both quote styles escape by doubling (`""`) and
+ * by backslash (`\"`).
+ *
+ * `inBlockCommentAtStart` carries a `/* …` that a previous line left open, so
+ * the body of a multi-line comment is not read as code — a `}` in prose does
+ * not pop a block, and a prose line does not continue the statement above it.
+ */
+function scanLine(line: string, inBlockCommentAtStart = false): LineScan {
   const braces: Array<'{' | '}'> = [];
+  const code: string[] = [];
   let leadingCloses = 0;
   let sawNonCloseNonSpace = false;
-  let inString = false;
-  let inBlockComment = false;
+  /** The quote character that opened the string literal we are inside, if any. */
+  let stringQuote: '"' | "'" | null = null;
+  let inBlockComment = inBlockCommentAtStart;
 
   for (let i = 0; i < line.length; i++) {
     const c = line[i];
@@ -48,15 +99,18 @@ function braceEvents(line: string): { braces: Array<'{' | '}'>; leadingCloses: n
       if (c === '*' && next === '/') { inBlockComment = false; i++; }
       continue;
     }
-    if (inString) {
-      if (c === "'" && next === "'") { i++; continue; } // escaped '' inside a string
-      if (c === "'") inString = false;
+    if (stringQuote) {
+      code.push(c);
+      if (c === '\\' && next !== undefined) { code.push(next); i++; continue; } // \" \\ \n …
+      if (c === stringQuote && next === stringQuote) { code.push(next); i++; continue; } // doubled quote
+      if (c === stringQuote) stringQuote = null;
       continue;
     }
-    if (c === "'") { inString = true; continue; }
+    if (c === "'" || c === '"') { stringQuote = c; code.push(c); continue; }
     if (c === '/' && next === '/') break;
     if (c === '/' && next === '*') { inBlockComment = true; i++; continue; }
 
+    code.push(c);
     if (c === '{') { braces.push('{'); sawNonCloseNonSpace = true; }
     else if (c === '}') {
       braces.push('}');
@@ -65,12 +119,35 @@ function braceEvents(line: string): { braces: Array<'{' | '}'>; leadingCloses: n
       sawNonCloseNonSpace = true;
     }
   }
-  return { braces, leadingCloses };
+  return { braces, leadingCloses, code: code.join('').trim(), blockCommentOpen: inBlockComment };
 }
 
 /** A `case X:` or `default:` label — the statements after it belong one level in. */
 function isCaseLabel(trimmed: string): boolean {
   return /^(case\b|default\s*:)/.test(trimmed);
+}
+
+/**
+ * Does this line leave nothing open, so the next line starts fresh at block depth?
+ *
+ * Takes the line's CODE (see `LineScan.code`), never the raw text: judged on the
+ * raw text, `ttsbegin; // start` does not end in `;` and pushed `ttscommit;` a
+ * level in — and the result was stable under re-formatting, so nothing put it
+ * back. A trailing comment is the most ordinary thing in the language.
+ *
+ * True for a statement end (`;`), a brace, a label/`case` colon, a comment-only
+ * line (which strips to nothing), a macro line, and a one-line attribute — false
+ * for anything that reads as the middle of a statement (`if (a`,
+ * `select firstonly t`, `&& b`, `_p1,`). A line the caller wrapped therefore
+ * gets one extra level; the level does not accumulate, because the flag is
+ * re-derived from the previous line each time, which is what shipped platform
+ * code does for a three-line `if` condition.
+ */
+function terminatesStatement(code: string): boolean {
+  if (code === '') return true; // comment-only line, or the body of a block comment
+  if (code.startsWith('#')) return true; // #define / #macrolib
+  if (code.startsWith('[') && code.endsWith(']')) return true; // [ExtensionOf(…)]
+  return /[;{}:]$/.test(code);
 }
 
 /**
@@ -106,12 +183,20 @@ export function reindentXppSource(source: string, baseDepth = 1): string {
   };
 
   const out: string[] = [];
+  /** The previous non-blank line left a statement open, so this line continues it. */
+  let continues = false;
+  /** A `/* …` from an earlier line is still open, so this line is prose. */
+  let inBlockComment = false;
+
   for (const raw of lines) {
     const trimmed = raw.trim();
+    // A blank line inside a wrapped statement neither opens nor closes one, so
+    // it passes the pending state through untouched.
     if (trimmed === '') { out.push(''); continue; }
 
-    const { braces, leadingCloses } = braceEvents(trimmed);
-    const startsCase = isCaseLabel(trimmed);
+    const { braces, leadingCloses, code, blockCommentOpen } = scanLine(trimmed, inBlockComment);
+    inBlockComment = blockCommentOpen;
+    const startsCase = isCaseLabel(code);
 
     // A new label ends the previous one; a `}` that closes the switch body ends
     // it too, and must do so before the block itself is popped.
@@ -125,7 +210,14 @@ export function reindentXppSource(source: string, baseDepth = 1): string {
       braceIdx++;
     }
 
-    out.push(INDENT_UNIT.repeat(depthNow()) + trimmed);
+    // The brace that opens or closes the wrapped statement's own block belongs
+    // at block depth, not one level in — `if (a\n    && b)\n{` puts the `{`
+    // under the `if`, not under the `&&`.
+    const isBraceOnlyStart = code.startsWith('{') || code.startsWith('}');
+    const continuationIndent = continues && !isBraceOnlyStart ? 1 : 0;
+
+    out.push(INDENT_UNIT.repeat(depthNow() + continuationIndent) + trimmed);
+    continues = !terminatesStatement(code);
 
     // Braces after the leading closes: opens push a block, further closes pop.
     for (; braceIdx < braces.length; braceIdx++) {
@@ -140,7 +232,7 @@ export function reindentXppSource(source: string, baseDepth = 1): string {
     }
 
     // `switch (x)` with its `{` on the following line.
-    if (/^switch\b/.test(trimmed) && !braces.includes('{')) pendingSwitch = true;
+    if (/^switch\b/.test(code) && !braces.includes('{')) pendingSwitch = true;
 
     if (startsCase) {
       const sw = innermostSwitch();

--- a/src/workspace/projectFile.ts
+++ b/src/workspace/projectFile.ts
@@ -25,13 +25,21 @@ import {
 import { getConfigManager } from '../utils/configManager.js';
 
 /**
- * Register a file that is already on disk into the active project, but only
- * when no project of its model references it.
+ * Register a file that is already on disk into the ACTIVE project, whenever the
+ * active project is not already listing it.
  *
- * The "only when" is the whole design. A D365FO model is split across many
- * .rnrproj and each object belongs to exactly one of them, so registering a
- * file its owning project already lists would put one element in two projects
- * and build it twice. This closes a genuine gap and declines to open a new one.
+ * An object may legitimately be referenced by several .rnrproj of one model. A
+ * project is an editing view over a model, not an ownership claim: the model is
+ * the build unit, each element compiles once per model however many projects
+ * name it, and teams routinely group one element into a feature project and a
+ * maintenance project both. So "some other project has it" is not a reason to
+ * leave it out of the one being worked in — you cannot build, check in, or hand
+ * over a change through a project that does not contain the object it changed.
+ *
+ * This used to stop at membership 'other' and report the sibling as the owner.
+ * That inverted the rule: an object edited in the active project stayed absent
+ * from it, and every later verify pass had to re-explain why the gap was fine.
+ * The only case that still writes nothing is 'active' — it is already there.
  *
  * Shared by create and modify, which need it for the same reason: an object
  * that existed but was unregistered could never BECOME registered — create
@@ -42,7 +50,7 @@ import { getConfigManager } from '../utils/configManager.js';
  * nothing worth saying. Never throws: the write it comments on has already
  * succeeded, and an unreadable project must not turn that into a failure.
  */
-export async function registerFileIfOrphaned(
+export async function registerFileInActiveProject(
   objectType: string,
   objectName: string,
   modelName: string | undefined,
@@ -59,28 +67,40 @@ export async function registerFileIfOrphaned(
     return '';
   }
 
-  // 'unknown' means no project could be read at all — usually no projectPath is
-  // configured. Saying so on every single write is noise about a config gap the
-  // caller cannot fix mid-task, and it is the same silence renderMembership
-  // keeps: the loud cases only mean something when the quiet ones stay quiet.
+  // Already in the project being written to — the quiet, common case.
+  //
+  // 'unknown' means no project could be read at all, usually because no
+  // projectPath is configured. Saying so on every single write is noise about a
+  // config gap the caller cannot fix mid-task, and it is the same silence
+  // renderMembership keeps: the loud cases only mean something when the quiet
+  // ones stay quiet.
   if (membership.status === 'active' || membership.status === 'unknown') return '';
-  if (membership.status === 'other') {
-    const where = membership.owners.map(projectDisplayName).join(', ');
-    return `\n\n✅ Already registered in ${where} — that project owns it. Nothing to add here.`;
-  }
+
+  // Registered elsewhere but not here. Still add it — see the note above — and
+  // name the sibling so the agent knows the entry it just made is a second
+  // reference to one file rather than a rescue from oblivion.
+  const alsoIn = membership.status === 'other'
+    ? membership.owners.map(projectDisplayName).join(', ')
+    : '';
 
   if (!projectPath) {
+    // Nothing to add it TO. Only worth saying when no project has it at all;
+    // a sibling already references it, so the element does compile.
+    if (alsoIn) return '';
     return `\n\n⚠️ No project of model "${modelName ?? '(unknown)'}" references \`${axFolder}\\${objectName}\`, ` +
       `and no active projectPath is configured to add it to. It will not compile until some project does.`;
   }
   try {
     const added = await new ProjectFileManager().addToProject(projectPath, objectType, objectName, '');
-    return added
-      ? `\n\n✅ The file was on disk but in no project of this model — added it to ${projectDisplayName(projectPath)}. ` +
-        `Right-click the project → Reload Project if VS is open.`
-      : '';
+    if (!added) return '';
+    const reload = `Right-click the project → Reload Project if VS is open.`;
+    return alsoIn
+      ? `\n\n✅ Added to the active project ${projectDisplayName(projectPath)} (also referenced by ${alsoIn} — ` +
+        `an element may belong to several projects of a model; it still compiles once). ${reload}`
+      : `\n\n✅ The file was on disk but in no project of this model — added it to ${projectDisplayName(projectPath)}. ` +
+        reload;
   } catch (e: any) {
-    return `\n\n⚠️ The file is in no project of this model and could not be added to ` +
+    return `\n\n⚠️ Could not add \`${axFolder}\\${objectName}\` to ` +
       `${projectDisplayName(projectPath)}: ${e?.message ?? e}`;
   }
 }

--- a/src/workspace/projectMembership.ts
+++ b/src/workspace/projectMembership.ts
@@ -5,10 +5,15 @@
  * different way.
  *
  * `verify_d365fo_project` compared the right thing (the raw `Content Include`)
- * but only ever looked at the ACTIVE project, so an object registered in the
- * project that owns it reported `❌ Not in project`. Acting on that is worse
- * than the warning: adding the entry to the active project too puts one file in
- * two projects of one model and the element gets compiled twice.
+ * but only ever looked at the ACTIVE project, so an object registered in a
+ * sibling project of the same model reported `❌ Not in project` — a hard error
+ * for something that compiles perfectly. It is a real distinction, just not a
+ * fatal one: 'other' means registered somewhere, 'missing' means registered
+ * nowhere, and only the second stops the build.
+ *
+ * (An element referenced by two projects of one model is fine. The model is the
+ * build unit; it compiles once either way. Projects are editing views, and the
+ * one you are working in has to contain the object you are changing.)
  *
  * `inlineWriteVerification` looked at the active project as well, and compared
  * a resolved absolute path against the include:
@@ -207,6 +212,14 @@ export async function resolveMembership(
  * The one line a write response spends on project membership, or '' when there
  * is nothing worth saying. Silence is the common case: the file is registered
  * where it should be and the caller does not need to be told so again.
+ *
+ * 'other' used to read "that is where this object belongs; do not add it again
+ * here". That was the wrong rule: an element may be referenced by several
+ * .rnrproj of one model, it still compiles once, and an object being changed in
+ * the active project has to be IN the active project to be built or handed over
+ * from it. So the line now names the gap instead of blessing it — and normally
+ * never fires on a write at all, because registerFileInActiveProject has just
+ * closed it. It survives for writes made with addToProject off.
  */
 export function renderMembership(m: Membership, axFolder: string, objectName: string): string {
   switch (m.status) {
@@ -215,7 +228,8 @@ export function renderMembership(m: Membership, axFolder: string, objectName: st
       return '';
     case 'other': {
       const where = m.owners.map(projectDisplayName).join(', ');
-      return `\nℹ️ Registered in ${where}, not in the active project — that is where this object belongs; do not add it again here.`;
+      return `\nℹ️ Referenced by ${where} but NOT by the active project — it compiles, but the active ` +
+        `project does not contain what you just changed. Re-send with addToProject=true to add it here too.`;
     }
     case 'missing':
       return `\n⚠️ No .rnrproj of this model references \`${axFolder}\\${objectName}\` — it will not compile until one does.`;

--- a/tests/bridge/bridgeCreateFormatting.test.ts
+++ b/tests/bridge/bridgeCreateFormatting.test.ts
@@ -1,0 +1,105 @@
+/**
+ * X++ handed to the bridge gets the same treatment as X++ handed to the XML writer.
+ *
+ * `ensureXppDocComment` was wired into the XML fallback only, so the SAME
+ * `d365fo_file(action="create", objectType="class")` produced a documented class
+ * when the bridge was down and an undocumented one when it was up. The undocumented
+ * one then failed `run_bp_check` on `BPXmlDocNoDocumentationComments`, and the
+ * repair was two hand-edits of the AOT XML with a plain text tool — the bypass this
+ * server exists to remove.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { bridgeCreateObject, bridgeAddMethod } from '../../src/bridge/bridgeAdapter';
+
+const stubBridge = (capture: (params: any) => void) => ({
+  isReady: true,
+  metadataAvailable: true,
+  createObject: vi.fn(async (params: any) => {
+    capture(params);
+    return { success: true, filePath: 'K:\\x\\MyClass.xml', api: 'IMetaClassProvider.Create' };
+  }),
+  addMethod: vi.fn(async (_t: string, _o: string, _m: string, source: string) => {
+    capture({ methods: [{ name: _m, source }] });
+    return { success: true, api: 'IMetaClassProvider.Update' };
+  }),
+}) as any;
+
+describe('bridgeCreateObject — doc comments and indentation', () => {
+  it('adds the doc comment BP asks for to a declaration and to every method', async () => {
+    let sent: any;
+    const bridge = stubBridge(p => { sent = p; });
+
+    await bridgeCreateObject(bridge, {
+      objectType: 'class',
+      objectName: 'MyTable_Extension',
+      modelName: 'MyModel',
+      declaration: '[ExtensionOf(tableStr(MyTable))]\nfinal class MyTable_Extension\n{\n}',
+      methods: [{ name: 'validateWrite', source: 'public boolean validateWrite()\n{\nreturn next validateWrite();\n}' }],
+    });
+
+    expect(sent.declaration).toContain('/// <summary>');
+    expect(sent.methods[0].source).toContain('/// <summary>');
+    // The attribute must stay attached to the class, not be pushed in a level.
+    expect(sent.declaration).toContain('[ExtensionOf(tableStr(MyTable))]\nfinal class MyTable_Extension');
+  });
+
+  it('re-indents the method body to the shipped convention', async () => {
+    let sent: any;
+    const bridge = stubBridge(p => { sent = p; });
+
+    await bridgeCreateObject(bridge, {
+      objectType: 'class',
+      objectName: 'MyClass',
+      modelName: 'MyModel',
+      methods: [{ name: 'm', source: 'public void m()\n{\nx = 1;\n}' }],
+    });
+
+    expect(sent.methods[0].source).toContain('    public void m()');
+    expect(sent.methods[0].source).toContain('        x = 1;');
+  });
+
+  it('keeps the indentation of a wrapped statement instead of flattening it', async () => {
+    let sent: any;
+    const bridge = stubBridge(p => { sent = p; });
+
+    await bridgeCreateObject(bridge, {
+      objectType: 'class',
+      objectName: 'MyClass',
+      modelName: 'MyModel',
+      methods: [{
+        name: 'm',
+        source: 'public void m()\n{\n    select firstonly t\n        where t.RecId == this.RecId;\n}',
+      }],
+    });
+
+    expect(sent.methods[0].source).toContain('        select firstonly t\n            where t.RecId == this.RecId;');
+  });
+
+  it('leaves already-documented, already-formatted source alone', async () => {
+    let first: any;
+    let second: any;
+    const source = 'public void m()\n{\nx = 1;\n}';
+
+    await bridgeCreateObject(stubBridge(p => { first = p; }), {
+      objectType: 'class', objectName: 'MyClass', modelName: 'MyModel',
+      methods: [{ name: 'm', source }],
+    });
+    await bridgeCreateObject(stubBridge(p => { second = p; }), {
+      objectType: 'class', objectName: 'MyClass', modelName: 'MyModel',
+      methods: [{ name: 'm', source: first.methods[0].source }],
+    });
+
+    expect(second.methods[0].source).toBe(first.methods[0].source);
+  });
+
+  it('documents a method added through the bridge too', async () => {
+    let sent: any;
+    const bridge = stubBridge(p => { sent = p; });
+
+    await bridgeAddMethod(bridge, 'class', 'MyClass', 'm', 'public void m()\n{\nx = 1;\n}');
+
+    expect(sent.methods[0].source).toContain('/// <summary>');
+    expect(sent.methods[0].source).toContain('    public void m()');
+  });
+});

--- a/tests/scripts/extractMetadataRun.test.ts
+++ b/tests/scripts/extractMetadataRun.test.ts
@@ -1,0 +1,121 @@
+/**
+ * extract-metadata end-to-end smoke test — the write path, actually executed.
+ *
+ * Why a spawned run and not another unit test: the orphan sweep landed with unit
+ * coverage for pruneOrphanedMetadata and none at all for the function that feeds it,
+ * writeMetadataJson. A search-and-replace that rewrote the 17 `fs.writeFile` call
+ * sites also rewrote the helper's OWN body, so writeMetadataJson called itself —
+ * every file died with "RangeError: Maximum call stack size exceeded", extraction
+ * wrote zero JSON, and 3356 green tests said nothing, because none of them runs the
+ * script. Only the error guard ("a model with errors is not swept") stopped an empty
+ * write set from being read as "every object was deleted".
+ *
+ * So this test asserts the two things unit tests structurally cannot:
+ *   - the script runs to completion over a real directory tree and writes JSON
+ *   - a genuinely orphaned JSON is swept, and live ones are not
+ *
+ * Regression guards:
+ *   - stderr MUST NOT contain a stack-overflow / unhandled rejection
+ *   - extraction MUST report zero errors on well-formed input
+ *   - a model that read XML but wrote nothing MUST NOT be swept (the blast radius
+ *     of exactly the bug above)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const execFileAsync = promisify(execFile);
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+let tmp: string;
+const p = (...seg: string[]) => path.join(tmp, ...seg);
+
+async function write(file: string, body: string): Promise<void> {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, body);
+}
+
+const exists = async (f: string) => fs.access(f).then(() => true, () => false);
+
+/** Run the script over the sandbox tree and return its combined output. */
+async function runExtract(): Promise<string> {
+  const { stdout, stderr } = await execFileAsync(
+    process.execPath,
+    ['--import', 'tsx/esm', path.join(REPO, 'scripts', 'extract-metadata.ts')],
+    {
+      cwd: REPO,
+      maxBuffer: 32 * 1024 * 1024,
+      env: {
+        ...process.env,
+        METADATA_PATH: p('out'),
+        D365FO_PACKAGE_PATH: p('pkg'),
+        EXTRACT_MODE: 'custom',
+        DEV_ENVIRONMENT_TYPE: 'traditional',
+        CUSTOM_MODELS: 'MyModel',
+      },
+    },
+  );
+  return stdout + stderr;
+}
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-run-'));
+  await write(
+    p('pkg', 'MyModel', 'MyModel', 'AxEnum', 'MyEnum.xml'),
+    '<?xml version="1.0" encoding="utf-8"?>\n<AxEnum><Name>MyEnum</Name>' +
+    '<EnumValues><AxEnumValue><Name>A</Name></AxEnumValue></EnumValues></AxEnum>\n',
+  );
+  await write(
+    p('pkg', 'MyModel', 'MyModel', 'AxClass', 'MyClass.xml'),
+    '<?xml version="1.0" encoding="utf-8"?>\n<AxClass><Name>MyClass</Name>' +
+    '<SourceCode><Declaration>class MyClass {}</Declaration></SourceCode></AxClass>\n',
+  );
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe('extract-metadata (spawned)', () => {
+  it('writes JSON for every source file without blowing the stack', async () => {
+    const out = await runExtract();
+
+    expect(out).not.toMatch(/Maximum call stack size exceeded/);
+    expect(out).not.toMatch(/Exception in PromiseRejectCallback/);
+    expect(out).toMatch(/No errors/);
+
+    expect(await exists(p('out', 'MyModel', 'enums', 'MyEnum.json'))).toBe(true);
+    expect(await exists(p('out', 'MyModel', 'classes', 'MyClass.json'))).toBe(true);
+  }, 60_000);
+
+  it('sweeps an orphan and keeps the live files beside it', async () => {
+    await write(p('out', 'MyModel', 'enums', 'GhostEnum.json'), '{"raw":"<AxEnum/>"}');
+
+    const out = await runExtract();
+
+    expect(out).toMatch(/Pruned 1 orphaned JSON file/);
+    expect(await exists(p('out', 'MyModel', 'enums', 'GhostEnum.json'))).toBe(false);
+    expect(await exists(p('out', 'MyModel', 'enums', 'MyEnum.json'))).toBe(true);
+    expect(await exists(p('out', 'MyModel', 'classes', 'MyClass.json'))).toBe(true);
+  }, 60_000);
+
+  it('refuses to sweep a model that read XML but wrote nothing', async () => {
+    // The blast radius of a broken writer: an empty write set otherwise reads as
+    // "every object under this model was deleted". Simulated by making every source
+    // file unparseable, which is the same observable state.
+    await fs.rm(p('pkg', 'MyModel', 'MyModel', 'AxEnum', 'MyEnum.xml'));
+    await fs.rm(p('pkg', 'MyModel', 'MyModel', 'AxClass', 'MyClass.xml'));
+    await write(p('pkg', 'MyModel', 'MyModel', 'AxClass', 'Broken.xml'), '<<<not xml at all');
+    await write(p('out', 'MyModel', 'enums', 'Existing.json'), '{"raw":"<AxEnum/>"}');
+
+    const out = await runExtract();
+
+    expect(out).toMatch(/Orphan sweep skipped/);
+    expect(await exists(p('out', 'MyModel', 'enums', 'Existing.json'))).toBe(true);
+  }, 60_000);
+});

--- a/tests/tools/bridgeFallbackReason.test.ts
+++ b/tests/tools/bridgeFallbackReason.test.ts
@@ -48,13 +48,23 @@ describe('describeBridgeFallbackReason', () => {
   });
 });
 
-const { mockBridgeReplaceCode, mockWriteFile } = vi.hoisted(() => ({
-  mockBridgeReplaceCode: vi.fn(async () => ({
-    success: false,
-    message: 'Bridge replaceCode returned success=false',
-  })),
-  mockWriteFile: vi.fn(async () => {}),
-}));
+// The XML mock is STATEFUL: writeFile keeps what was written and readFile hands it
+// back. A write-only mock made every read return the pristine file, so the fallback's
+// read-back check (added after a ✅ that the caller did not trust and re-applied by
+// hand) could never see its own write.
+const { mockBridgeReplaceCode, mockWriteFile, fsState } = vi.hoisted(() => {
+  const fsState = { xml: '' };
+  return {
+    fsState,
+    mockBridgeReplaceCode: vi.fn(async () => ({
+      success: false,
+      message: 'Bridge replaceCode returned success=false',
+    })),
+    mockWriteFile: vi.fn(async (_p: string, content: string) => {
+      if (typeof content === 'string' && content.includes('<AxForm')) fsState.xml = content;
+    }),
+  };
+});
 
 vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
   const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
@@ -87,7 +97,7 @@ public void clicked()
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(async (p: string) => {
-    if (p.endsWith('.xml')) return FORM_XML;
+    if (p.endsWith('.xml')) return fsState.xml || FORM_XML;
     if (p.endsWith('.rnrproj')) return `<Project><ItemGroup></ItemGroup></Project>`;
     throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
   }),
@@ -190,6 +200,7 @@ describe('replace-code direct-XML fallback message (finding #4)', () => {
   beforeEach(() => {
     mockBridgeReplaceCode.mockClear();
     mockWriteFile.mockClear();
+    fsState.xml = '';
     mockBridgeReplaceCode.mockResolvedValue({
       success: false,
       message: 'Bridge replaceCode returned success=false',
@@ -201,7 +212,6 @@ describe('replace-code direct-XML fallback message (finding #4)', () => {
 
     expect(result.isError).toBeFalsy();
     const text = result.content[0].text as string;
-    expect(text).toMatch(/direct XML fallback/i);
     expect(text).not.toMatch(/unavailable/i);
     expect(text).toContain('Bridge replaceCode returned success=false');
     expect(mockWriteFile).toHaveBeenCalled();
@@ -212,5 +222,25 @@ describe('replace-code direct-XML fallback message (finding #4)', () => {
 
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text as string).toMatch(/the bridge was unavailable/i);
+  });
+
+  it('confirms the new code is on disk and tells the caller not to re-apply it', async () => {
+    // The ✅ that led with the bridge's error read as a failure, so the caller
+    // edited the AOT XML again with a text tool — the bypass this server removes.
+    const result = await replaceCode(buildContext({ isReady: true, metadataAvailable: true }));
+
+    const text = result.content[0].text as string;
+    expect(text).toMatch(/verified on disk/i);
+    expect(text).toMatch(/do NOT re-apply/i);
+    expect(fsState.xml).toContain('ttsbegin; // guarded');
+  });
+
+  it('reports failure rather than ✅ when the write did not land', async () => {
+    mockWriteFile.mockImplementationOnce(async () => {}); // swallow the write
+    const result = await replaceCode(buildContext({ isReady: true, metadataAvailable: true }));
+
+    const text = result.content[0].text as string;
+    expect(text).not.toMatch(/verified on disk/i);
+    expect(text).toMatch(/did not take effect|not in the file afterwards/i);
   });
 });

--- a/tests/tools/fieldGroupEntryRetarget.test.ts
+++ b/tests/tools/fieldGroupEntryRetarget.test.ts
@@ -1,0 +1,210 @@
+/**
+ * The other half of the extension-member rename.
+ *
+ * `add-field` on an extension renames what it adds — a member added to someone
+ * else's table has to carry your prefix — and says so in the response. The
+ * `add-field-to-field-group` that follows names the SAME field, and was left
+ * exactly as the caller spelled it: applyExtensionMemberPrefix mints names for
+ * NEW members and this operation mints none, so it is correctly absent from
+ * EXTENSION_MEMBER_NAME_ARG. Nothing then reconciled the two.
+ *
+ * The bridge validates no DataField, so `<DataField>QualityTier</DataField>`
+ * went into a group against a field called `CtsoSK_QualityTier`, came back
+ * reported as applied, and pointed at nothing. Sending both operations in ONE
+ * call — which every add-field response tells the agent to do — hit it every
+ * time; the run this was found in had to repair the XML by hand afterwards.
+ *
+ * Blind prefixing would be the wrong repair: a group extension may perfectly
+ * well carry a BASE-table field, which has no prefix. Only the one-reading case
+ * is corrected, which is what these pin.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockReadFile, mockPrefixToken, mockFindBaseObjectXml } = vi.hoisted(() => ({
+  mockReadFile: vi.fn(),
+  mockPrefixToken: vi.fn(),
+  mockFindBaseObjectXml: vi.fn(),
+}));
+
+vi.mock('fs/promises', () => ({
+  default: { readFile: mockReadFile },
+  readFile: mockReadFile,
+}));
+
+vi.mock('../../src/utils/modelClassifier', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveRegularObjectPrefixToken: mockPrefixToken,
+}));
+
+import { resolveFieldNameForFieldGroup } from '../../src/tools/write/modifyD365File';
+
+const EXT_PATH = 'K:\\Packages\\CtsoFinSK\\CtsoFinSK\\AxTableExtension\\TaxLog.CtsoSKExtension.xml';
+
+/** A table extension declaring exactly these fields. */
+const extensionXml = (...fields: string[]) => `<?xml version="1.0" encoding="utf-8"?>
+<AxTableExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>TaxLog.CtsoSKExtension</Name>
+  <FieldGroupExtensions>
+    <AxTableFieldGroupExtension>
+      <Name>Administration</Name>
+      <Fields>
+        <AxTableFieldGroupField><DataField>SomethingElse</DataField></AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroupExtension>
+  </FieldGroupExtensions>
+  <Fields>
+${fields.map(f => `    <AxTableField xmlns="" i:type="AxTableFieldEnum"><Name>${f}</Name></AxTableField>`).join('\n')}
+  </Fields>
+</AxTableExtension>`;
+
+/** A base table declaring exactly these fields. */
+const baseTableXml = (...fields: string[]) => `<?xml version="1.0" encoding="utf-8"?>
+<AxTable>
+  <Name>TaxLog</Name>
+  <Fields>
+${fields.map(f => `    <AxTableField i:type="AxTableFieldString"><Name>${f}</Name></AxTableField>`).join('\n')}
+  </Fields>
+</AxTable>`;
+
+const call = (args: Record<string, any>) =>
+  resolveFieldNameForFieldGroup(
+    args,
+    args.objectType ?? 'table-extension',
+    args.operation ?? 'add-field-to-field-group',
+    'CtsoFinanceSK',
+    EXT_PATH,
+    { getReadDb: () => { throw new Error('no index in this test'); } },
+  );
+
+describe('add-field-to-field-group points at the field add-field actually created', () => {
+  beforeEach(() => {
+    mockReadFile.mockReset();
+    mockPrefixToken.mockReset();
+    mockFindBaseObjectXml.mockReset();
+    mockPrefixToken.mockReturnValue('CtsoSK_');
+    // No base table readable unless a test says otherwise: findBaseObjectXml
+    // goes through the symbol index, which throws in this harness.
+    mockReadFile.mockResolvedValue(extensionXml('CtsoSK_QualityTier'));
+  });
+
+  it('retargets the bare name at the prefixed field the extension actually has', async () => {
+    const args: Record<string, any> = {
+      objectName: 'TaxLog.CtsoSKExtension', fieldName: 'QualityTier', fieldGroupName: 'Administration',
+    };
+
+    const note = await call(args);
+
+    expect(args.fieldName).toBe('CtsoSK_QualityTier');
+    expect(note).toMatch(/CtsoSK_QualityTier/);
+  });
+
+  it('leaves a name that already matches a field of the extension alone', async () => {
+    const args: Record<string, any> = {
+      objectName: 'TaxLog.CtsoSKExtension', fieldName: 'CtsoSK_QualityTier', fieldGroupName: 'Administration',
+    };
+
+    expect(await call(args)).toBe('');
+    expect(args.fieldName).toBe('CtsoSK_QualityTier');
+  });
+
+  // The case blind prefixing would break: a group extension may carry a field
+  // the BASE table declares, and that one has no prefix.
+  it('leaves a base-table field alone even when a prefixed namesake exists', async () => {
+    // Both readings are valid here: the extension has CtsoSK_Voucher AND the
+    // base table has Voucher, so "Voucher" in a group entry is not a mistake.
+    mockReadFile.mockImplementation(async (p: string) =>
+      String(p) === EXT_PATH ? extensionXml('CtsoSK_Voucher') : baseTableXml('Voucher'),
+    );
+    const indexWithBaseTable = {
+      getReadDb: () => ({
+        prepare: () => ({ get: () => ({ file_path: 'K:\\base\\TaxLog.xml' }) }),
+      }),
+    };
+    const args: Record<string, any> = {
+      objectName: 'TaxLog.CtsoSKExtension', fieldName: 'Voucher', fieldGroupName: 'Administration',
+    };
+
+    const note = await resolveFieldNameForFieldGroup(
+      args, 'table-extension', 'add-field-to-field-group', 'CtsoFinanceSK', EXT_PATH,
+      indexWithBaseTable,
+    );
+
+    expect(note).toBe('');
+    expect(args.fieldName).toBe('Voucher');
+  });
+
+  // Same setup as above minus the base-table namesake: one reading only, so the
+  // correction must fire. Without this the test above passes for any reason at
+  // all, including the extension file never being read.
+  it('does retarget when the base table has no field of that name', async () => {
+    mockReadFile.mockImplementation(async (p: string) =>
+      String(p) === EXT_PATH ? extensionXml('CtsoSK_Voucher') : baseTableXml('AccountNum'),
+    );
+    const indexWithBaseTable = {
+      getReadDb: () => ({
+        prepare: () => ({ get: () => ({ file_path: 'K:\\base\\TaxLog.xml' }) }),
+      }),
+    };
+    const args: Record<string, any> = {
+      objectName: 'TaxLog.CtsoSKExtension', fieldName: 'Voucher', fieldGroupName: 'Administration',
+    };
+
+    const note = await resolveFieldNameForFieldGroup(
+      args, 'table-extension', 'add-field-to-field-group', 'CtsoFinanceSK', EXT_PATH,
+      indexWithBaseTable,
+    );
+
+    expect(note).toMatch(/CtsoSK_Voucher/);
+    expect(args.fieldName).toBe('CtsoSK_Voucher');
+  });
+
+  it('says nothing when the prefixed field does not exist either', async () => {
+    mockReadFile.mockResolvedValue(extensionXml('CtsoSK_SomethingElse'));
+    const args: Record<string, any> = {
+      objectName: 'TaxLog.CtsoSKExtension', fieldName: 'QualityTier', fieldGroupName: 'Administration',
+    };
+
+    expect(await call(args)).toBe('');
+    expect(args.fieldName).toBe('QualityTier');
+  });
+
+  it('ignores operations that are not a field-group entry', async () => {
+    const args: Record<string, any> = {
+      objectName: 'TaxLog.CtsoSKExtension', fieldName: 'QualityTier', operation: 'add-field',
+    };
+
+    expect(await call(args)).toBe('');
+    expect(args.fieldName).toBe('QualityTier');
+  });
+
+  it('ignores a base table, where members carry no prefix', async () => {
+    const args: Record<string, any> = {
+      objectName: 'TaxLog', fieldName: 'QualityTier', objectType: 'table',
+    };
+
+    expect(await call(args)).toBe('');
+    expect(args.fieldName).toBe('QualityTier');
+  });
+
+  // Advisory: it runs before a write that can succeed without it.
+  it('makes no correction when the extension file cannot be read', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    const args: Record<string, any> = {
+      objectName: 'TaxLog.CtsoSKExtension', fieldName: 'QualityTier', fieldGroupName: 'Administration',
+    };
+
+    expect(await call(args)).toBe('');
+    expect(args.fieldName).toBe('QualityTier');
+  });
+
+  it('makes no correction when the model has no prefix', async () => {
+    mockPrefixToken.mockReturnValue('');
+    const args: Record<string, any> = {
+      objectName: 'TaxLog.CtsoSKExtension', fieldName: 'QualityTier', fieldGroupName: 'Administration',
+    };
+
+    expect(await call(args)).toBe('');
+    expect(args.fieldName).toBe('QualityTier');
+  });
+});

--- a/tests/tools/getObjectInfoMethodOwners.test.ts
+++ b/tests/tools/getObjectInfoMethodOwners.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `get_object_info(options.method)` and the types that own methods.
+ *
+ * The folded get_method accepted `objectType:"class"` only, while get_method
+ * itself resolves methods on classes, tables, views and data entities. So
+ * `options:{method:"validateWrite"}` on a TABLE — the call anyone writing table
+ * CoC makes first — was refused with "only supported for objectType=class", and
+ * the refusal named no working alternative.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../src/tools/readers/getMethod', () => ({
+  getMethodTool: vi.fn(async (req: any) => ({
+    content: [{
+      type: 'text',
+      text: `method:${req.params.arguments.className}.${req.params.arguments.methodName}`,
+    }],
+  })),
+}));
+
+import { getObjectInfoTool } from '../../src/tools/readers/getObjectInfo';
+import { getMethodTool } from '../../src/tools/readers/getMethod';
+
+const req = (args: Record<string, unknown>): any => ({
+  method: 'tools/call',
+  params: { name: 'get_object_info', arguments: args },
+});
+
+const context = {} as any;
+
+const textOf = (result: any) => result.content.map((c: any) => c.text).join('\n');
+
+describe('get_object_info — options.method owner types', () => {
+  for (const objectType of ['class', 'table', 'view', 'data-entity']) {
+    it(`reads a method on a ${objectType}`, async () => {
+      vi.mocked(getMethodTool).mockClear();
+
+      const result = await getObjectInfoTool(
+        req({ objectType, name: 'ConCore_TaxTransReportChangeLog', options: { method: 'validateWrite', include: 'signature' } }),
+        context,
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(textOf(result)).toContain('method:ConCore_TaxTransReportChangeLog.validateWrite');
+      expect(vi.mocked(getMethodTool)).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  it('still refuses a type that stores no methods, and names the ones that work', async () => {
+    const result = await getObjectInfoTool(
+      req({ objectType: 'enum', name: 'ConSK_QualityTier', options: { method: 'validateWrite' } }),
+      context,
+    );
+
+    expect(result.isError).toBe(true);
+    const text = textOf(result);
+    expect(text).toContain('class, table, view, data-entity');
+    expect(text).toContain('"enum" stores no methods');
+  });
+
+  it('works through the plural objects[] form too', async () => {
+    vi.mocked(getMethodTool).mockClear();
+
+    const result = await getObjectInfoTool(
+      req({
+        objects: [
+          { objectType: 'table', objectName: 'MyTable', options: { method: 'validateWrite' } },
+          { objectType: 'class', objectName: 'MyClass', options: { method: 'run' } },
+        ],
+      }),
+      context,
+    );
+
+    const text = textOf(result);
+    expect(text).toContain('method:MyTable.validateWrite');
+    expect(text).toContain('method:MyClass.run');
+  });
+});

--- a/tests/tools/inlineWriteVerification.test.ts
+++ b/tests/tools/inlineWriteVerification.test.ts
@@ -156,16 +156,22 @@ describe('renderWriteVerification', () => {
     expect(text).toMatch(/will not compile/i);
   });
 
-  it('names the owning project instead of crying missing', () => {
+  // 'other' is neither a pass nor a build failure. The element compiles — a
+  // sibling project references it — but the project being worked in does not
+  // contain what was just changed, and an object may belong to several projects
+  // of one model, so the fix is to add it here too rather than to accept the gap.
+  it('names the sibling project and points at the gap, without crying missing', () => {
     const text = renderWriteVerification({
       onDisk: true,
       bytes: 120,
-      membership: m('other', ['K:\\repo\\MyModel - Owning.rnrproj']),
+      membership: m('other', ['K:\\repo\\MyModel - Sibling.rnrproj']),
       axFolder: 'AxTable',
       objectName: 'T',
     });
-    expect(text).toContain('MyModel - Owning');
-    expect(text).toMatch(/do not add it again/i);
+    expect(text).toContain('MyModel - Sibling');
+    expect(text).toMatch(/not by the active project/i);
+    expect(text).toMatch(/addToProject=true/);
+    expect(text).not.toMatch(/do not add it again/i);
     expect(text).not.toMatch(/will not compile/i);
   });
 

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -186,6 +186,92 @@ describe('search_labels', () => {
     const result = await searchLabelsTool(req('search_labels', {}), ctx);
     expect(result.isError).toBe(true);
   });
+
+  it('tells the caller to create rather than rephrase when nothing matches', async () => {
+    // Rephrasing was the only next step the footer suggested, and one run took it
+    // 19 times for a verdict the first call had already reached.
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+    const text = (await searchLabelsTool(req('search_labels', { query: 'cannot be decreased' }), ctx))
+      .content[0].text as string;
+    expect(text).toMatch(/Rephrasing does not help/i);
+    expect(text).toContain('labels(action="create"');
+  });
+
+  it('says the same when every hit belongs to a package the model cannot resolve', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'Downgrade', text: 'Downgrade', labelFileId: 'SubBill', model: 'SubscriptionBilling' }),
+    ]);
+    const text = (await searchLabelsTool(req('search_labels', { query: 'downgrade' }), ctx))
+      .content[0].text as string;
+    expect(text).toMatch(/none is\s+recommended as-is/i);
+    expect(text).toMatch(/Rephrasing does not help/i);
+  });
+});
+
+// ─── labels(action="search") batch ───────────────────────────────────────────
+//
+// One query per call turned "find a reusable label" — inherently a guessing game —
+// into a round trip per guess. An array of phrasings resolves it in one.
+
+describe('labels(action="search") with query[]', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => { ctx = buildContext(); });
+
+  it('runs every phrasing and reports one verdict when none is reusable', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    const text = (await labelsTool(
+      req('labels', { action: 'search', query: ['cannot be decreased', 'downgrade', 'value is lower'] }),
+      ctx,
+    )).content[0].text as string;
+
+    expect((ctx.symbolIndex.searchLabels as any).mock.calls.length).toBe(3);
+    expect(text).toContain('3 queries');
+    expect(text).toMatch(/none of these 3 phrasings/i);
+    expect(text).toContain('Stop searching and create your own.');
+    // Each query still gets its own section.
+    for (const q of ['cannot be decreased', 'downgrade', 'value is lower']) {
+      expect(text).toContain(`## "${q}"`);
+    }
+  });
+
+  it('reports a reusable hit instead of telling the caller to create one', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'CustomerName', text: 'Customer name', labelFileId: 'MyModel', model: 'MyModel' }),
+    ]);
+
+    const text = (await labelsTool(
+      req('labels', { action: 'search', query: ['customer', 'client'] }),
+      ctx,
+    )).content[0].text as string;
+
+    expect(text).toMatch(/at least one reusable label was found/i);
+    expect(text).not.toContain('Stop searching and create your own.');
+  });
+
+  it('caps the batch and says what it did not run', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+    const many = Array.from({ length: 15 }, (_, i) => `phrase ${i}`);
+
+    const text = (await labelsTool(req('labels', { action: 'search', query: many }), ctx))
+      .content[0].text as string;
+
+    expect((ctx.symbolIndex.searchLabels as any).mock.calls.length).toBe(12);
+    expect(text).toContain('3 beyond the 12-query cap were not run');
+  });
+
+  it('rejects an empty query array rather than reporting a clean no-match', async () => {
+    const result = await labelsTool(req('labels', { action: 'search', query: [] }), ctx);
+    expect(result.isError).toBe(true);
+  });
+
+  it('still accepts a single string query', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+    const text = (await labelsTool(req('labels', { action: 'search', query: 'customer' }), ctx))
+      .content[0].text as string;
+    expect(text).not.toContain('# Label search —');
+  });
 });
 
 // ─── search_labels result budget (#832) ──────────────────────────────────────
@@ -327,10 +413,17 @@ describe('get_label_info', () => {
   });
 
   it('returns physical file paths per language when labelFileId is given without labelId', async () => {
-    (ctx.symbolIndex.getLabelFileIds as any).mockReturnValue([
+    // Narrowing is the QUERY's job now — grouping all 1.4 M label rows and then
+    // discarding every group but one is what made a cold call take 28 s. The mock
+    // honours the argument so this pins that the tool actually passes it down.
+    const allFiles = [
       { labelFileId: 'MyModel', model: 'MyModel', languages: 'en-US,cs' },
       { labelFileId: 'SYS', model: 'ApplicationSuite', languages: 'en-US' },
-    ]);
+    ];
+    (ctx.symbolIndex.getLabelFileIds as any).mockImplementation(
+      (_model?: string, labelFileId?: string) =>
+        labelFileId ? allFiles.filter(f => f.labelFileId === labelFileId) : allFiles,
+    );
     (ctx.symbolIndex.getLabelFilePaths as any).mockReturnValue([
       { language: 'en-US', filePath: 'K:\\repos\\meta\\MyModel\\MyModel\\AxLabelFile\\LabelResources\\en-US\\MyModel.en-US.label.txt', model: 'MyModel' },
       { language: 'cs', filePath: 'K:\\repos\\meta\\MyModel\\MyModel\\AxLabelFile\\LabelResources\\cs\\MyModel.cs.label.txt', model: 'MyModel' },
@@ -342,6 +435,7 @@ describe('get_label_info', () => {
     );
 
     expect(result.isError).toBeFalsy();
+    expect(ctx.symbolIndex.getLabelFileIds as any).toHaveBeenCalledWith(undefined, 'MyModel');
     expect(ctx.symbolIndex.getLabelFilePaths as any).toHaveBeenCalledWith('MyModel', undefined);
     const text = result.content[0].text;
     // Narrowed to the requested file only — SYS must not appear.

--- a/tests/tools/modifyBatchOperations.test.ts
+++ b/tests/tools/modifyBatchOperations.test.ts
@@ -152,4 +152,33 @@ describe('d365fo_file(action="modify") with operations[]', () => {
     expect(mockModify).toHaveBeenCalledTimes(1);
     expect(forwarded()[0]).toMatchObject({ operation: 'add-field', fieldName: 'A' });
   });
+
+  // An entry runs as its own modify call and so cannot see the batch. Right for
+  // the writes, wrong for the advisory notes: add-field told the caller to "send
+  // the group entry in the SAME call next time" in a call that already carried
+  // one. Advice that fires when it has already been followed is how a response
+  // teaches an agent to stop reading its warnings.
+  it('tells every entry which operations it is travelling with', async () => {
+    await d365foFileTool(call({
+      objectType: 'table-extension',
+      objectName: 'CustTable.CtsoExtension',
+      operations: [
+        { operation: 'add-field', fieldName: 'Tier' },
+        { operation: 'add-field-to-field-group', fieldName: 'Tier', fieldGroupName: 'Admin' },
+      ],
+    }), ctx);
+
+    const peers = ['add-field', 'add-field-to-field-group'];
+    expect(forwarded()[0].peerOperations).toEqual(peers);
+    expect(forwarded()[1].peerOperations).toEqual(peers);
+  });
+
+  it('reports a single-entry batch as travelling alone', async () => {
+    await d365foFileTool(call({
+      objectType: 'table', objectName: 'T',
+      operations: [{ operation: 'add-field', fieldName: 'A' }],
+    }), ctx);
+
+    expect(forwarded()[0].peerOperations).toEqual(['add-field']);
+  });
 });

--- a/tests/tools/modifyParamSilentDrop.test.ts
+++ b/tests/tools/modifyParamSilentDrop.test.ts
@@ -169,6 +169,9 @@ vi.mock('../../src/utils/modelClassifier', () => ({
   applyObjectSuffix: vi.fn((name: string) => name),
   isCustomModel: vi.fn(() => true),
   isStandardModel: vi.fn(() => false),
+  // No prefix in these fixtures: what is under test here is that the declared
+  // params reach the bridge, not what a member gets renamed to.
+  resolveRegularObjectPrefixToken: vi.fn(() => ''),
 }));
 
 const TABLE_FILE_PATH = 'K:\\PackagesLocalDirectory\\MyPackage\\MyModel\\AxTable\\ConDemoModLifecycle.xml';
@@ -539,6 +542,18 @@ describe('parameter-accounting helpers', () => {
 
   it('accepts an alias of a required param (methodCode for sourceCode)', () => {
     expect(findIgnoredParams('add-method', ['methodName', 'methodCode'])).toEqual([]);
+  });
+
+  it('never flags peerOperations, which this server injects itself', () => {
+    // runModifyBatch adds it to every entry of an operations[] batch so an
+    // advisory note can tell whether its advice is already being followed. It is
+    // not in the published schema, so no caller can send it — flagging it made
+    // EVERY batched entry answer "peerOperations: IGNORED (not a recognised
+    // d365fo_file parameter)", a false drop warning on the one flow the batch
+    // API exists to encourage.
+    expect(findIgnoredParams('add-field', ['fieldName', 'fieldType', 'peerOperations'])).toEqual([]);
+    expect(findIgnoredParams('add-field-to-field-group',
+      ['fieldName', 'fieldGroupName', 'peerOperations'])).toEqual([]);
   });
 
   it('reports the two enum-value drops the audit turned up', () => {

--- a/tests/tools/prepareCreateNameAgreement.test.ts
+++ b/tests/tools/prepareCreateNameAgreement.test.ts
@@ -1,0 +1,129 @@
+/**
+ * prepare(mode="create") must predict the name d365fo_file(action="create") writes.
+ *
+ * prepare re-derived the final name with `applyObjectPrefix(name, prefix)` — two
+ * arguments — while the write path goes through `normalizeObjectName(name, type, model)`,
+ * which passes the model on to the same helper. Without the model, applyObjectPrefix
+ * cannot see the separator the model's own objects use and falls back to
+ * EXTENSION_PREFIX, so for a model whose objects are "ConSK_*":
+ *
+ *   prepare  said : ConSKQualityTier      (no separator)
+ *   create   wrote: ConSK_QualityTier     (separator)
+ *
+ * The caller believed prepare, passed objectName="_QualityTier" to compensate, and got
+ * `ConSK__QualityTier.xml` on disk — a create, an undo_last_modification and a second
+ * create, ~92 s of one session. The same wrong name also fed prepare's collision check
+ * and its grounding token, so a real collision on the name that WOULD be written read
+ * back as "✅ No collision".
+ *
+ * Covers:
+ *   - underscore-style inferred prefix survives the prediction
+ *   - the collision check probes the name that actually gets written
+ *   - extension types get the dot/_Extension form create uses
+ *   - EXTENSION_SUFFIX is reflected, since create applies it too
+ *
+ * Regression guard: prepare's rendered "Final name" MUST equal normalizeObjectName().
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { normalizeObjectName } from '../../src/utils/objectNaming.js';
+import {
+  setModelObjectNameSource, clearInferredModelPrefixes,
+} from '../../src/utils/modelPrefixInference.js';
+
+const MODEL = 'ContosoFinanceSK';
+/** The model's own objects — every one of them "ConSK_"-prefixed, separator included. */
+const MODEL_OBJECTS = [
+  'ConSK_VATCSSection', 'ConSK_VATReportSetup',
+  'ConSK_OrigInvoiceNum', 'ConSK_ControlStatement',
+];
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    getModelName: () => MODEL,
+    getWriteAnchorModel: () => MODEL,
+    getAutoDetectedModelName: async () => MODEL,
+  })),
+}));
+
+const buildContext = () => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  const db = { prepare: vi.fn(() => stmt) };
+  return {
+    symbolIndex: { db, getReadDb: () => db } as any,
+    parser: {} as any,
+    cache: {} as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+  } as any;
+};
+
+/** Run prepare and return the name it printed on the "Final name" line. */
+async function preparedFinalName(objectName: string, objectType: string): Promise<string> {
+  const { prepareCreateTool } = await import('../../src/tools/prepare/prepareCreate.js');
+  const result = await prepareCreateTool(
+    { params: { arguments: { goal: 'test', objectName, objectType } } },
+    buildContext(),
+  );
+  const text = String(result.content[0].text);
+  const match = /^Final name\s*:\s*(\S+)/m.exec(text);
+  expect(match, `no "Final name" line in:\n${text}`).toBeTruthy();
+  return match![1];
+}
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  clearInferredModelPrefixes();
+  setModelObjectNameSource(model => (model === MODEL ? MODEL_OBJECTS : []));
+  delete process.env.EXTENSION_PREFIX_SOURCE;
+  delete process.env.EXTENSION_SUFFIX;
+  delete process.env.EXTENSION_PREFIX;
+});
+
+afterEach(() => {
+  setModelObjectNameSource(null);
+  clearInferredModelPrefixes();
+  process.env = { ...originalEnv };
+});
+
+describe('prepare(mode="create") name prediction', () => {
+  it('keeps the separator of an underscore-style inferred prefix', async () => {
+    // Predicted "ConSKQualityTier" while create wrote "ConSK_QualityTier".
+    expect(await preparedFinalName('QualityTier', 'enum')).toBe('ConSK_QualityTier');
+  });
+
+  it('agrees with the helper the write path uses', async () => {
+    for (const [name, type] of [
+      ['QualityTier', 'enum'],
+      ['TaxAdjustment', 'class'],
+      ['ReportChangeLog', 'table'],
+    ] as const) {
+      expect(await preparedFinalName(name, type)).toBe(normalizeObjectName(name, type, MODEL));
+    }
+  });
+
+  it('does not double-prefix an already-prefixed name', async () => {
+    expect(await preparedFinalName('ConSK_QualityTier', 'enum')).toBe('ConSK_QualityTier');
+  });
+
+  it('reflects EXTENSION_SUFFIX, which create also applies', async () => {
+    process.env.EXTENSION_SUFFIX = '_Custom';
+
+    expect(await preparedFinalName('QualityTier', 'enum'))
+      .toBe(normalizeObjectName('QualityTier', 'enum', MODEL));
+  });
+
+  it('probes the written name in the collision check', async () => {
+    const { prepareCreateTool } = await import('../../src/tools/prepare/prepareCreate.js');
+    const result = await prepareCreateTool(
+      { params: { arguments: { goal: 'test', objectName: 'QualityTier', objectType: 'enum' } } },
+      buildContext(),
+    );
+    const text = String(result.content[0].text);
+
+    // It used to clear "ConSKQualityTier" — a name nothing would ever be written under.
+    expect(text).toContain('"ConSK_QualityTier"');
+    expect(text).not.toContain('"ConSKQualityTier"');
+  });
+});

--- a/tests/utils/extractMetadataPrune.test.ts
+++ b/tests/utils/extractMetadataPrune.test.ts
@@ -1,0 +1,131 @@
+/**
+ * extract-metadata orphan sweep tests (phantom objects surviving a delete + rebuild)
+ *
+ * Extraction only ever wrote JSON — one file per XML found — and the sole cleanup was an
+ * `fs.rm(OUTPUT_PATH)` gated on EXTRACT_MODE='all'. So in the `custom`/`standard` modes
+ * everyone actually runs, deleting an object from PackagesLocalDirectory left its JSON in
+ * extracted-metadata forever, and build-database read it straight back in: clearModels()
+ * emptied the model's rows, then the very next pass re-inserted the orphan. The object
+ * came back from the dead with stale metadata and was served as if it were on disk —
+ * get_object_info answered from "symbol index (extracted metadata)" for a file that did
+ * not exist, and only verify_d365fo_project (which stats the disk) disagreed.
+ *
+ * Observed on model ContosoFinanceSK: a delete + full re-extract + rebuild left 4 of 95 JSON
+ * files untouched — an enum, a class, its class-extension record and a form-extension —
+ * all of which kept answering queries for two further sessions.
+ *
+ * Covers:
+ *   - a JSON with no live source file is deleted
+ *   - a JSON this run rewrote is kept
+ *   - the derived class-extensions record dies with its class
+ *   - emptied folders are removed, non-empty ones survive
+ *   - non-JSON files are never touched
+ *
+ * Regression guards:
+ *   - pruning MUST be scoped to the model's own directory
+ *   - an empty write set MUST NOT be treated as "nothing to do" (that was the bug)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { pruneOrphanedMetadata } from '../../scripts/extract-metadata';
+
+let outputPath: string;
+
+/** Write a metadata JSON under <outputPath>/<model>/<dir>/<name>.json, return its path. */
+async function seed(model: string, dir: string, name: string): Promise<string> {
+  const full = path.join(outputPath, model, dir, `${name}.json`);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, JSON.stringify({ name }));
+  return full;
+}
+
+const exists = async (p: string) => fs.access(p).then(() => true, () => false);
+
+beforeEach(async () => {
+  outputPath = await fs.mkdtemp(path.join(os.tmpdir(), 'extract-prune-'));
+});
+
+afterEach(async () => {
+  await fs.rm(outputPath, { recursive: true, force: true });
+});
+
+describe('pruneOrphanedMetadata', () => {
+  it('deletes the JSON of an object that no longer exists on disk', async () => {
+    const live = await seed('ContosoFinanceSK', 'enums', 'ConSK_VATCSSection');
+    const orphan = await seed('ContosoFinanceSK', 'enums', 'ConSK_QualityTier');
+
+    const removed = await pruneOrphanedMetadata(outputPath, 'ContosoFinanceSK', new Set([live]));
+
+    expect(removed).toEqual(['enums/ConSK_QualityTier.json']);
+    expect(await exists(orphan)).toBe(false);
+    expect(await exists(live)).toBe(true);
+  });
+
+  it('drops a class and its derived class-extension record together', async () => {
+    // A class carrying [ExtensionOf(...)] emits two JSONs. Deleting the AxClass must
+    // retire both, or find_coc_extensions keeps reporting a CoC wrapper that is gone.
+    const cls = await seed('ContosoFinanceSK', 'classes', 'ConCore_ChangeLogConSK_Extension');
+    const ext = await seed('ContosoFinanceSK', 'class-extensions', 'ConCore_ChangeLogConSK_Extension');
+
+    const removed = await pruneOrphanedMetadata(outputPath, 'ContosoFinanceSK', new Set());
+
+    expect(removed.sort()).toEqual([
+      'class-extensions/ConCore_ChangeLogConSK_Extension.json',
+      'classes/ConCore_ChangeLogConSK_Extension.json',
+    ]);
+    expect(await exists(cls)).toBe(false);
+    expect(await exists(ext)).toBe(false);
+  });
+
+  it('sweeps everything when the run wrote nothing for the model', async () => {
+    // An empty write set means the model produced no output at all — every JSON under it
+    // is stale. Short-circuiting on "no writes" would leave the whole model phantom.
+    await seed('ContosoFinanceSK', 'enums', 'Gone');
+    await seed('ContosoFinanceSK', 'tables', 'AlsoGone');
+
+    const removed = await pruneOrphanedMetadata(outputPath, 'ContosoFinanceSK', new Set());
+
+    expect(removed.length).toBe(2);
+  });
+
+  it('removes emptied folders but keeps ones that still hold metadata', async () => {
+    const kept = await seed('ContosoFinanceSK', 'tables', 'Live');
+    await seed('ContosoFinanceSK', 'enums', 'Dead');
+
+    await pruneOrphanedMetadata(outputPath, 'ContosoFinanceSK', new Set([kept]));
+
+    expect(await exists(path.join(outputPath, 'ContosoFinanceSK', 'enums'))).toBe(false);
+    expect(await exists(path.join(outputPath, 'ContosoFinanceSK', 'tables'))).toBe(true);
+  });
+
+  it('never touches another model', async () => {
+    const other = await seed('ContosoFinanceCZ', 'enums', 'ConCZ_Something');
+    await seed('ContosoFinanceSK', 'enums', 'Dead');
+
+    const removed = await pruneOrphanedMetadata(outputPath, 'ContosoFinanceSK', new Set());
+
+    expect(removed).toEqual(['enums/Dead.json']);
+    expect(await exists(other)).toBe(true);
+  });
+
+  it('leaves files it did not write, whatever their extension', async () => {
+    // The extract manifest and any operator scratch files live alongside the metadata.
+    const manifest = path.join(outputPath, 'ContosoFinanceSK', 'notes.txt');
+    await fs.mkdir(path.dirname(manifest), { recursive: true });
+    await fs.writeFile(manifest, 'keep me');
+
+    const removed = await pruneOrphanedMetadata(outputPath, 'ContosoFinanceSK', new Set());
+
+    expect(removed).toEqual([]);
+    expect(await exists(manifest)).toBe(true);
+  });
+
+  it('is a no-op for a model with no extracted metadata directory', async () => {
+    const removed = await pruneOrphanedMetadata(outputPath, 'NeverExtracted', new Set());
+
+    expect(removed).toEqual([]);
+  });
+});

--- a/tests/utils/staleIndexEntry.test.ts
+++ b/tests/utils/staleIndexEntry.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Symbol-index rows that outlived their files.
+ *
+ * The index is not rebuilt when an object is deleted, and the extracted-metadata
+ * JSON written at index time is not removed either. After a workspace reset one
+ * benchmark run therefore got a complete, confident enum back from
+ * `get_object_info` — name, four values, four labels — for a file that did not
+ * exist. Nothing in the answer said "cache", so the agent believed it and spent
+ * roughly a quarter of the run proving the object was a ghost before starting the
+ * actual work.
+ *
+ * The tell was available at the point of the answer: the bridge knew nothing, the
+ * index recorded a PackagesLocalDirectory path, and no file was at that path or at
+ * its local remap. These cover that rule and the ways it must NOT fire.
+ *
+ * The packages root is a REAL directory here (a temp dir), never the host's own:
+ * the rule asks whether this machine can observe the file's absence, so a test
+ * that borrowed the host's configured root would pass on a developer VM with
+ * D365FO installed and fail on CI without one.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import * as realFs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const mockResolveDbPathLocally = vi.fn(async (_p: string): Promise<string | null> => null);
+vi.mock('../../src/utils/metadataResolver', () => ({
+  resolveDbPathLocally: (p: string) => mockResolveDbPathLocally(p),
+}));
+
+/** An existing directory stands in for a reachable PackagesLocalDirectory. */
+const REACHABLE_ROOT = realFs.mkdtempSync(path.join(os.tmpdir(), 'stale-index-root-'));
+const UNREACHABLE_ROOT = path.join(REACHABLE_ROOT, 'not-mounted', 'PackagesLocalDirectory');
+
+const packagesRoot = { value: REACHABLE_ROOT as string | null };
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: () => ({
+    ensureLoaded: async () => {},
+    getPackagePath: () => packagesRoot.value,
+  }),
+  fallbackPackagePath: () => '',
+}));
+
+afterAll(() => {
+  realFs.rmSync(REACHABLE_ROOT, { recursive: true, force: true });
+});
+
+const mockLookupSymbolNocase = vi.fn();
+vi.mock('../../src/utils/symbolLookup', () => ({
+  lookupSymbolNocase: (...args: unknown[]) => mockLookupSymbolNocase(...args),
+}));
+
+import {
+  indexedPathIsMissing,
+  renderStaleIndexNote,
+  staleIndexNote,
+  indexedSourceNote,
+  resolveIndexedObject,
+} from '../../src/utils/indexedXmlLookup';
+
+// A path that is under PackagesLocalDirectory and certainly not on this machine.
+const GHOST = 'Q:\\NoSuchDrive\\PackagesLocalDirectory\\GhostModel\\GhostModel\\AxEnum\\Ghost_QualityTier.xml';
+// A build-agent path the DB may legitimately store; unreachable here, not deleted.
+const BUILD_AGENT = '/mnt/vss/_work/1/s/Metadata/Foundation/AxEnum/NoYes.xml';
+
+describe('indexedPathIsMissing', () => {
+  beforeEach(() => {
+    mockResolveDbPathLocally.mockReset();
+    mockResolveDbPathLocally.mockResolvedValue(null);
+    packagesRoot.value = REACHABLE_ROOT;
+  });
+
+  it('reports a PackagesLocalDirectory path with no file at either location', async () => {
+    expect(await indexedPathIsMissing(GHOST)).toBe(true);
+  });
+
+  it('says nothing when the packages root itself is unreachable', async () => {
+    // A root that is not there makes EVERY object unreadable. Calling that a
+    // deleted object hands the agent "treat it as NOT EXISTING and create it",
+    // and it is told not to re-check — a duplicate CustTable on a bad config day.
+    packagesRoot.value = UNREACHABLE_ROOT;
+    expect(await indexedPathIsMissing(GHOST)).toBe(false);
+  });
+
+  it('says nothing when no packages root is configured at all', async () => {
+    packagesRoot.value = null;
+    expect(await indexedPathIsMissing(GHOST)).toBe(false);
+  });
+
+  it('does not report one that remaps onto a file that is here', async () => {
+    mockResolveDbPathLocally.mockResolvedValue('K:\\other\\ConSK_QualityTier.xml');
+    expect(await indexedPathIsMissing(GHOST)).toBe(false);
+  });
+
+  it('never judges a path outside PackagesLocalDirectory', async () => {
+    // Unreachable is not deleted — calling a build-agent row stale would tell the
+    // agent to re-create objects that exist perfectly well.
+    expect(await indexedPathIsMissing(BUILD_AGENT)).toBe(false);
+    expect(mockResolveDbPathLocally).not.toHaveBeenCalled();
+  });
+
+  it('says nothing for a row with no path at all', async () => {
+    expect(await indexedPathIsMissing(null)).toBe(false);
+    expect(await indexedPathIsMissing(undefined)).toBe(false);
+    expect(await indexedPathIsMissing('')).toBe(false);
+  });
+});
+
+describe('resolveIndexedObject — sourceFileMissing', () => {
+  beforeEach(() => {
+    mockResolveDbPathLocally.mockReset();
+    mockResolveDbPathLocally.mockResolvedValue(null);
+    mockLookupSymbolNocase.mockReset();
+    packagesRoot.value = REACHABLE_ROOT;
+  });
+
+  it('does not flag anything while the packages root is unreachable', async () => {
+    // Same guard as indexedPathIsMissing, and it has to be the same answer: the
+    // two describe one row, and a reader that got them from different helpers
+    // would otherwise print a ghost warning one call and not the next.
+    packagesRoot.value = UNREACHABLE_ROOT;
+    mockLookupSymbolNocase.mockReturnValue({ name: 'ConSK_QualityTier', model: 'ContosoFinanceSK', file_path: GHOST });
+
+    const ref = await resolveIndexedObject({}, 'ConSK_QualityTier', ['enum']);
+
+    expect(ref?.sourceFileMissing).toBe(false);
+  });
+
+  it('flags a row whose file is gone', async () => {
+    mockLookupSymbolNocase.mockReturnValue({ name: 'ConSK_QualityTier', model: 'ContosoFinanceSK', file_path: GHOST });
+
+    const ref = await resolveIndexedObject({}, 'ConSK_QualityTier', ['enum']);
+
+    expect(ref?.sourceFileMissing).toBe(true);
+    expect(ref?.localPath).toBeNull();
+  });
+
+  it('does not flag a row that resolves to a readable file', async () => {
+    mockLookupSymbolNocase.mockReturnValue({ name: 'NoYes', model: 'Foundation', file_path: GHOST });
+    mockResolveDbPathLocally.mockResolvedValue('K:\\real\\NoYes.xml');
+
+    const ref = await resolveIndexedObject({}, 'NoYes', ['enum']);
+
+    expect(ref?.sourceFileMissing).toBe(false);
+    expect(ref?.localPath).toBe('K:\\real\\NoYes.xml');
+  });
+
+  it('does not flag an unreachable build-agent row', async () => {
+    mockLookupSymbolNocase.mockReturnValue({ name: 'NoYes', model: 'Foundation', file_path: BUILD_AGENT });
+
+    const ref = await resolveIndexedObject({}, 'NoYes', ['enum']);
+
+    expect(ref?.sourceFileMissing).toBe(false);
+  });
+});
+
+describe('the warning itself', () => {
+  it('names the path, tells the caller to create, and tells it not to re-check', async () => {
+    const note = renderStaleIndexNote('ConSK_QualityTier', GHOST);
+
+    expect(note).toContain('STALE INDEX ENTRY');
+    expect(note).toContain(GHOST);
+    expect(note).toMatch(/NOT EXISTING/);
+    // The 20-odd calls that went into proving the ghost was a ghost are the cost
+    // this line exists to remove.
+    expect(note).toMatch(/Do not spend calls proving this/i);
+    expect(note).toContain('update_symbol_index');
+  });
+
+  it('is silent for a healthy row', () => {
+    expect(staleIndexNote({
+      name: 'NoYes', model: 'Foundation', indexedPath: GHOST,
+      localPath: 'K:\\real\\NoYes.xml', sourceFileMissing: false,
+    })).toBe('');
+  });
+
+  it('rides along on the provenance footer readers already print', () => {
+    const withRef = indexedSourceNote('symbol index (extracted metadata)', {
+      name: 'ConSK_QualityTier', model: 'ContosoFinanceSK', indexedPath: GHOST,
+      localPath: null, sourceFileMissing: true,
+    });
+    expect(withRef).toContain('the C# bridge returned no data');
+    expect(withRef).toContain('STALE INDEX ENTRY');
+
+    // Callers that pass no ref keep the footer they had.
+    expect(indexedSourceNote('symbol index')).not.toContain('STALE INDEX ENTRY');
+  });
+});

--- a/tests/utils/xppDocGen.test.ts
+++ b/tests/utils/xppDocGen.test.ts
@@ -249,6 +249,52 @@ describe('ensureXppDocComment — completing an existing doc block', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// An X++ class is public unless it says otherwise, so requiring an explicit
+// `public` skipped the one class shape this server generates most —
+// `final class Foo_Extension`, emitted for every CoC extension — and its own
+// run_bp_check then flagged the result BPXmlDocNoDocumentationComments.
+// ---------------------------------------------------------------------------
+
+describe('ensureXppDocComment — class declarations without an explicit modifier', () => {
+  const hasDoc = (s: string) => s.trimStart().startsWith('/// <summary>');
+
+  it('documents a `final class` CoC extension', () => {
+    const decl = '[ExtensionOf(tableStr(MyTable))]\nfinal class MyTable_Extension\n{\n}';
+    const out = ensureXppDocComment(decl);
+    expect(hasDoc(out)).toBe(true);
+    // The attribute keeps its place directly above the class.
+    expect(out).toContain('[ExtensionOf(tableStr(MyTable))]\nfinal class MyTable_Extension');
+  });
+
+  it('documents a bare `class`, an `abstract class` and a `final class extends`', () => {
+    for (const decl of [
+      'class MyClass\n{\n}',
+      'abstract class MyBase\n{\n}',
+      'final class MyLeaf extends MyBase\n{\n}',
+    ]) {
+      expect(hasDoc(ensureXppDocComment(decl))).toBe(true);
+    }
+  });
+
+  it('still leaves an explicitly private or internal class alone', () => {
+    for (const decl of ['private class Hidden\n{\n}', 'internal final class Hidden\n{\n}']) {
+      expect(ensureXppDocComment(decl)).toBe(decl);
+    }
+  });
+
+  it('is idempotent — a class documented once is not documented twice', () => {
+    const once = ensureXppDocComment('final class MyTable_Extension\n{\n}');
+    expect(ensureXppDocComment(once)).toBe(once);
+  });
+
+  it('does not start documenting unmodified METHODS as a side effect', () => {
+    // The visibility gate is deliberate for methods; only classes were wrong.
+    const method = 'void helper()\n{\n}';
+    expect(ensureXppDocComment(method)).toBe(method);
+  });
+});
+
 describe('ensureBlankLineBeforeClosingBrace', () => {
   it('inserts a blank line between last member and closing brace', () => {
     const decl = [

--- a/tests/utils/xppFormat.test.ts
+++ b/tests/utils/xppFormat.test.ts
@@ -309,3 +309,299 @@ describe('reindentXppSource — compiler-validated switch shapes', () => {
     ].join('\n'));
   });
 });
+
+// ---------------------------------------------------------------------------
+// A statement wrapped onto further lines opens no brace, so brace depth alone
+// put its continuation lines at the same level as its first line — and did it
+// to CORRECT input, so a caller who wrapped a `where` clause or an `&&` got the
+// wrap flattened back out by the writer it handed the method to.
+// ---------------------------------------------------------------------------
+
+describe('reindentXppSource — wrapped statements', () => {
+  it('indents the continuation of a wrapped select and a wrapped if condition', () => {
+    // Verbatim shape from a d365fo_file(create, class) call whose wrap the
+    // writer flattened: the `where` and the `&&` came back at `select`/`if` level.
+    const input = [
+      'public boolean validateWrite()',
+      '{',
+      'boolean ret = next validateWrite();',
+      '',
+      'select firstonly oldRecord',
+      'where oldRecord.RecId == this.RecId;',
+      '',
+      'if (oldRecord.RecId',
+      '&& enum2int(this.Tier) < enum2int(oldRecord.Tier))',
+      '{',
+      'ret = checkFailed("@Lbl:X");',
+      '}',
+      '',
+      'return ret;',
+      '}',
+    ].join('\n');
+    expect(reindentXppSource(input)).toBe([
+      '    public boolean validateWrite()',
+      '    {',
+      '        boolean ret = next validateWrite();',
+      '',
+      '        select firstonly oldRecord',
+      '            where oldRecord.RecId == this.RecId;',
+      '',
+      '        if (oldRecord.RecId',
+      '            && enum2int(this.Tier) < enum2int(oldRecord.Tier))',
+      '        {',
+      '            ret = checkFailed("@Lbl:X");',
+      '        }',
+      '',
+      '        return ret;',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('leaves an already-wrapped statement alone', () => {
+    // The regression this pins: correct input came back flattened.
+    const correct = [
+      '    public void m()',
+      '    {',
+      '        select firstonly t',
+      '            where t.RecId == this.RecId;',
+      '    }',
+    ].join('\n');
+    expect(reindentXppSource(correct)).toBe(correct);
+  });
+
+  it('does not stair-step a condition wrapped over three lines', () => {
+    const input = 'public void m()\n{\nif (a\n&& b\n&& c)\n{\nx();\n}\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        if (a',
+      '            && b',
+      '            && c)',
+      '        {',
+      '            x();',
+      '        }',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('keeps a wrapped signature\'s opening brace at the signature level', () => {
+    const input = 'public void m(\nint _a,\nint _b)\n{\nx();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m(',
+      '        int _a,',
+      '        int _b)',
+      '    {',
+      '        x();',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('does not treat an attribute or a doc comment as an open statement', () => {
+    // `[ExtensionOf(…)]` ends in `]` and `/// <summary>` in `>`; neither may
+    // push the declaration that follows it one level in.
+    const input = '/// <summary>\n/// Does a thing.\n/// </summary>\n[SysObsolete("x", false)]\npublic void m()\n{\nx();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    /// <summary>',
+      '    /// Does a thing.',
+      '    /// </summary>',
+      '    [SysObsolete("x", false)]',
+      '    public void m()',
+      '    {',
+      '        x();',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('indents a braceless if body under its condition', () => {
+    const input = 'public void m()\n{\nif (a)\nreturn;\nx();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        if (a)',
+      '            return;',
+      '        x();',
+      '    }',
+    ].join('\n'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// X++ string literals take EITHER quote. Recognising only `'` let a brace
+// inside a double-quoted string count as a real one, so `info("a } b");`
+// popped a block and shifted the whole rest of the method out by a level.
+// ---------------------------------------------------------------------------
+
+describe('reindentXppSource — braces inside string literals', () => {
+  it('ignores a closing brace inside a double-quoted string', () => {
+    const input = 'public void m()\n{\ninfo("a } b");\nx = 1;\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        info("a } b");',
+      '        x = 1;',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('ignores an opening brace inside a double-quoted string', () => {
+    const input = 'public void m()\n{\ninfo("a { b");\nx = 1;\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        info("a { b");',
+      '        x = 1;',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('still ignores braces inside a single-quoted string', () => {
+    const input = "public void m()\n{\ninfo('a } b');\nx = 1;\n}";
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      "        info('a } b');",
+      '        x = 1;',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('does not end the literal on an escaped or doubled quote', () => {
+    const input = 'public void m()\n{\ninfo("say \\" } still in");\ninfo("say "" } still in");\nx = 1;\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        info("say \\" } still in");',
+      '        info("say "" } still in");',
+      '        x = 1;',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('does not cut the line at a // inside a double-quoted string', () => {
+    // The `//` scan runs outside string state, so a URL no longer hides a brace.
+    const input = 'public void m()\n{\nif (a)\n{\ninfo("http://x/y");\n}\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        if (a)',
+      '        {',
+      '            info("http://x/y");',
+      '        }',
+      '    }',
+    ].join('\n'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Continuation depth is judged on the line's CODE, not its raw text. Judged on
+// the raw text, a trailing comment hid the `;` that ends the statement and the
+// NEXT line was indented as its continuation — and the result was stable under
+// re-formatting, so nothing put it back. Trailing comments are ordinary X++.
+// ---------------------------------------------------------------------------
+
+describe('reindentXppSource — comments do not fake a continuation', () => {
+  it('does not indent the line after a statement with a trailing comment', () => {
+    const input = 'public void m()\n{\nttsbegin; // start\nttscommit;\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        ttsbegin; // start',
+      '        ttscommit;',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('does not indent the line after an opening brace with a trailing comment', () => {
+    const input = 'public void m()\n{\nif (x)\n{   // guard\nfoo();\n}\nbar();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        if (x)',
+      '        {   // guard',
+      '            foo();',
+      '        }',
+      '        bar();',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('reads through a multi-line block comment without continuing into it', () => {
+    const input = 'public void m()\n{\n/* explain\nthe thing */\nfoo();\nbar();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        /* explain',
+      '        the thing */',
+      '        foo();',
+      '        bar();',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('does not let a brace inside a multi-line block comment pop a block', () => {
+    // Prose is not code: the `}` below closes nothing, so `after();` stays inside.
+    const input = 'public void m()\n{\n/* a }\nb } c */\nafter();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        /* a }',
+      '        b } c */',
+      '        after();',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('still continues a wrapped statement that carries a trailing comment', () => {
+    const input = 'public void m()\n{\nselect firstonly t // the live one\nwhere t.RecId == this.RecId;\nfoo();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        select firstonly t // the live one',
+      '            where t.RecId == this.RecId;',
+      '        foo();',
+      '    }',
+    ].join('\n'));
+  });
+
+  it('ignores an inline block comment in the middle of a condition', () => {
+    const input = 'public void m()\n{\nif (a /* why */ && b)\n{\nx();\n}\ny();\n}';
+    expect(reindentXppSource(input)).toBe([
+      '    public void m()',
+      '    {',
+      '        if (a /* why */ && b)',
+      '        {',
+      '            x();',
+      '        }',
+      '        y();',
+      '    }',
+    ].join('\n'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotence is the property that keeps a correctly formatted method from
+// being rewritten on every subsequent modify. Each shape above is re-run
+// through the formatter here so a future change cannot make one of them
+// oscillate.
+// ---------------------------------------------------------------------------
+
+describe('reindentXppSource — idempotence across every shape', () => {
+  const shapes: Array<[string, string]> = [
+    ['wrapped select', 'public void m()\n{\nselect firstonly t\nwhere t.RecId == this.RecId;\n}'],
+    ['wrapped condition', 'public void m()\n{\nif (a\n&& b)\n{\nx();\n}\n}'],
+    ['wrapped signature', 'public void m(\nint _a,\nint _b)\n{\nx();\n}'],
+    ['braceless if body', 'public void m()\n{\nif (a)\nreturn;\n}'],
+    ['brace in a string', 'public void m()\n{\ninfo("a } b");\nx = 1;\n}'],
+    ['switch', 'public void m()\n{\nswitch (x)\n{\ncase 1:\na();\nbreak;\n}\n}'],
+    ['attribute + doc comment', '/// <summary>\n/// x\n/// </summary>\n[SysObsolete("x", false)]\npublic void m()\n{\n}'],
+    ['trailing comment', 'public void m()\n{\nttsbegin; // start\nttscommit;\n}'],
+    ['multi-line block comment', 'public void m()\n{\n/* explain\nthe thing */\nfoo();\n}'],
+  ];
+
+  for (const [name, input] of shapes) {
+    it(`is idempotent for a ${name}`, () => {
+      const once = reindentXppSource(input);
+      expect(reindentXppSource(once)).toBe(once);
+    });
+  }
+});

--- a/tests/workspace/registerFileInActiveProject.test.ts
+++ b/tests/workspace/registerFileInActiveProject.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Which project a written object gets registered in.
+ *
+ * The rule this pins reversed once. The previous one treated a .rnrproj as an
+ * ownership claim — "some project of the model already lists it, so leave it
+ * out of this one" — and reported the sibling as the owner. That is not how a
+ * D365FO solution works: the MODEL is the build unit and an element compiles
+ * once however many projects name it, so an object may legitimately be
+ * referenced by several .rnrproj, and teams routinely put one element in both a
+ * feature project and a maintenance project.
+ *
+ * What the old rule actually produced was an object edited in the active
+ * project and absent from it — you cannot build, check in, or hand over a
+ * change through a project that does not contain the object it changed. So the
+ * only silent case is 'already here'; everything else gets an entry.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockResolveMembership, mockAddToProject, mockGetProjectsForModel } = vi.hoisted(() => ({
+  mockResolveMembership: vi.fn(),
+  mockAddToProject: vi.fn(),
+  mockGetProjectsForModel: vi.fn(() => [] as string[]),
+}));
+
+vi.mock('../../src/workspace/projectMembership', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveMembership: mockResolveMembership,
+}));
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: () => ({ getProjectsForModel: mockGetProjectsForModel }),
+}));
+
+import { registerFileInActiveProject, ProjectFileManager } from '../../src/workspace/projectFile';
+
+const ACTIVE = 'K:\\repo\\projects\\Ctso - Feature\\Ctso - Feature.rnrproj';
+const SIBLING = 'K:\\repo\\projects\\Ctso - Maintenance\\Ctso - Maintenance.rnrproj';
+
+// No default for projectPath: a JS default fires on an explicit `undefined`
+// too, which would quietly turn the "no active project" cases into the ordinary
+// ones and pass for the wrong reason.
+const register = (projectPath: string | undefined) =>
+  registerFileInActiveProject('table-extension', 'TaxLog.CtsoExtension', 'CtsoFinance', projectPath);
+
+describe('registerFileInActiveProject', () => {
+  beforeEach(() => {
+    mockResolveMembership.mockReset();
+    mockAddToProject.mockReset();
+    mockAddToProject.mockResolvedValue(true);
+    vi.spyOn(ProjectFileManager.prototype, 'addToProject').mockImplementation(mockAddToProject);
+  });
+
+  it('says nothing and writes nothing when the active project already has it', async () => {
+    mockResolveMembership.mockResolvedValue({ status: 'active', owners: [ACTIVE] });
+
+    expect(await register(ACTIVE)).toBe('');
+    expect(mockAddToProject).not.toHaveBeenCalled();
+  });
+
+  // The reversal. This used to return "Already registered in <sibling> — that
+  // project owns it. Nothing to add here." and leave the active project without
+  // the object it had just been used to edit.
+  it('adds it to the active project even when a sibling project references it', async () => {
+    mockResolveMembership.mockResolvedValue({ status: 'other', owners: [SIBLING] });
+
+    const note = await register(ACTIVE);
+
+    expect(mockAddToProject).toHaveBeenCalledWith(ACTIVE, 'table-extension', 'TaxLog.CtsoExtension', '');
+    expect(note).toMatch(/Added to the active project/);
+    expect(note).toContain('Ctso - Feature');
+    // Names the sibling, so the second reference is understood as deliberate.
+    expect(note).toContain('Ctso - Maintenance');
+    expect(note).not.toMatch(/Nothing to add here/i);
+  });
+
+  it('adds a true orphan and says so differently', async () => {
+    mockResolveMembership.mockResolvedValue({ status: 'missing', owners: [] });
+
+    const note = await register(ACTIVE);
+
+    expect(mockAddToProject).toHaveBeenCalledTimes(1);
+    expect(note).toMatch(/in no project of this model/i);
+  });
+
+  it('stays quiet when no project could be read at all', async () => {
+    mockResolveMembership.mockResolvedValue({ status: 'unknown', owners: [] });
+
+    expect(await register(ACTIVE)).toBe('');
+    expect(mockAddToProject).not.toHaveBeenCalled();
+  });
+
+  it('warns about an orphan it has nowhere to add', async () => {
+    mockResolveMembership.mockResolvedValue({ status: 'missing', owners: [] });
+
+    const note = await register(undefined);
+
+    expect(note).toMatch(/no active projectPath is configured/i);
+    expect(mockAddToProject).not.toHaveBeenCalled();
+  });
+
+  // A sibling has it, so it compiles. Without an active project there is
+  // nothing to add it to and nothing worth saying.
+  it('stays quiet with no active project when a sibling already references it', async () => {
+    mockResolveMembership.mockResolvedValue({ status: 'other', owners: [SIBLING] });
+
+    expect(await register(undefined)).toBe('');
+    expect(mockAddToProject).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed registration without pretending the write failed', async () => {
+    mockResolveMembership.mockResolvedValue({ status: 'missing', owners: [] });
+    mockAddToProject.mockRejectedValue(new Error('project file is locked'));
+
+    const note = await register(ACTIVE);
+
+    expect(note).toMatch(/Could not add/i);
+    expect(note).toContain('project file is locked');
+  });
+
+  it('never throws when membership cannot be resolved', async () => {
+    mockResolveMembership.mockRejectedValue(new Error('unreadable'));
+
+    expect(await register(ACTIVE)).toBe('');
+  });
+});


### PR DESCRIPTION
Eight related repairs plus the audit of them. They share a shape: a tool answering confidently about something it had not actually checked.

## Ghost objects

Extracted-metadata JSON is written at index time and was never removed when the AOT XML was deleted; the symbol row outlived the file too. A reset workspace kept answering `get_object_info` with a complete, confident enum — name, four values, four labels — for a file that did not exist, and the agent spent roughly a quarter of a run proving it was a ghost.

- `extract-metadata` now sweeps the JSON a model's extraction did not write. Skipped for any model with an extraction error, and for one that read XML and wrote nothing — a parse failure is indistinguishable from a delete, and an empty write set would otherwise mean "delete everything".
- The readers now print **STALE INDEX ENTRY** instead of rendering the cache as fact.
- Only a `PackagesLocalDirectory` path **on a reachable packages root** is ever judged. An unmounted share makes every object unreadable, and "treat it as NOT EXISTING and create it" is the wrong thing to say on a bad config day.

## Project membership — this reverses #875

#875 declined to register an object in the active project when a sibling project of the same model listed it, on the grounds that one file in two projects compiles the element twice.

Verified on the dev VM against X++ Compiler 7.0.7996.33:

```
xppc.exe -?
  -modelmodule=model   The module to compile.
  -output=path         The path where the assembly is written.
```

There is no project-level input to the compiler at all. The model is the build unit; a `.rnrproj` is an editing view. So `registerFileIfOrphaned` becomes `registerFileInActiveProject`: an object edited here has to be **here**, or the change cannot be built or handed over from the project it was made in. The sibling is named in the message rather than treated as an owner, and `verify_d365fo_project` reports `elsewhere` as ⚠️ rather than ✅.

Remaining VS-side confirmation (does VS object to a duplicate item? check-in flow?) is #882 — this VM has no `.rnrproj` at all, so that half could not be exercised.

## Round trips

- `labels(action="search")` takes an array. One run spent 19 calls guessing English wordings for a verdict the first call had already reached; the batch states it once and hands over the `create` call that ends the loop.
- `get_object_info(options.method)` works on tables, views and data entities, not only classes — matching `get_method`, the tool it delegates to.
- `get_knowledge(topic="naming"|"prefix")` answers the naming question instead of printing the op-spec index.

## Writes that read as failures

- The direct-XML `replace-code` fallback led with the bridge's decline and only then said ✅, so the caller re-applied the edit by hand with a text tool — the AOT-XML bypass this server exists to remove. It now reads the file back and leads with the fact.
- Bridge creates get the same doc comments and indentation the XML fallback gives them, so one create no longer lands documented or undocumented depending on whether the bridge happened to be up (and then fails `BPXmlDocNoDocumentationComments`).

## Names

- `prepare(mode="create")` predicted names through a helper that did not take the model, promising `ConSKQualityTier` where create wrote `ConSK_QualityTier`. Both go through `normalizeObjectName` now.
- Prefix inference was blind to extension elements (stored as children of their base object) and flattened `ConSK` to `ConSk`; it now reads casing off the model's own files.
- An `add-field-to-field-group` entry travelling with the `add-field` that renamed the field is retargeted at the name that exists — only where there is one reading.

---

## Audit of the above, and four fixes from it

**1. `reindentXppSource` judged "does this line finish the statement?" on the raw line**, so any trailing comment hid the `;` and pushed the *next* line a level in. `ttsbegin; // start` did it, multi-line `/* */` did it, `{   // guard` did it — and the result was stable under re-formatting, so nothing put it back. Syntax questions now go to the comment-stripped code, and block-comment state carries across lines.

Measured against Microsoft's own shipped X++ (20,690 methods from ApplicationSuite + ApplicationFoundation + ApplicationPlatform):

| | before | after |
|---|---|---|
| all methods byte-identical to shipped | 17,092 (82.61 %) | 17,115 (82.72 %) |
| methods with a comment after `;{}:` (118) | 54.24 % | **72.03 %** |

23 methods the old code mangled are now byte-identical; **none regressed**. The residual ~17 % is Microsoft hand-aligning wrapped fluent chains over several columns, against the formatter's deliberate single continuation level — a known simplification, not a defect.

**2. `peerOperations`** — injected into every entry of a modify batch — was missing from `D365FO_FILE_CORE_PARAMS`, so each entry answered `peerOperations: IGNORED (not a recognised d365fo_file parameter)`. A false drop warning on the one flow the batch API exists to encourage. The existing batch test missed it because it mocks `modifyD365FileTool`.

**3. The stale-row rule was split across two helpers** that could answer differently about the same row. They share `isStaleIndexedPath` now, root guard included.

**4. `get_object_info` advertised `options.modelName` as forwarded** and dropped it.

### Deliberately not done

The stale-row sweep is **not** applied to the search result set. Tried it; it broke `discovery.test.ts` and the general case is worse: the shipped symbol index covers every standard package while a machine installs a subset, so sweeping answers "no such object" for most of D365FO on a partial install — in the tool every other workflow starts from. Marking rather than hiding is #876. The code says why.

### Filed rather than fixed

#876 (mark stale rows in search instead of hiding them) · #877 (label-file lookup: the not-found path is now the slow one) · #878 (inference sample is `LIMIT 400` with no `ORDER BY`) · #879 (enum bridge bypass wider than its comment, undeclared `values` alias) · #880 (label batch is sequential, no dedupe, swallows `isError`) · #881 (orphan sweep vs blob-downloaded metadata) · #882 (VS-side project membership)

---

## Reviewer notes

- **One commit covers more than one session.** The working tree already held the eight repairs when the audit started, and the audit fixes touch the same files (`xppFormat.ts`, `indexedXmlLookup.ts`, `d365foFileOpSpecs.ts`, `getObjectInfo.ts`), so they could not be split cleanly. The audit fixes are the four numbered items above.
- **`tests/utils/staleIndexEntry.test.ts` was host-dependent** and only passed because this VM has a real `K:\AosService\PackagesLocalDirectory`; after the root guard it would have failed on CI. It now builds its own temp root.
- **The riskiest change is the project-membership reversal.** The compiler evidence is in the commit message and #882 tracks the rest.

3371 tests green (was 3359), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)