### PR TITLE
Clear the issue log: stale rows, prefix sampling, enum routing, label batching, orphan sweep

### DIFF
--- a/scripts/azure-blob-manager.ts
+++ b/scripts/azure-blob-manager.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { BlobServiceClient, ContainerClient } from '@azure/storage-blob';
 import { isCustomModel } from '../src/utils/modelClassifier.js';
+import { writeBlobDownloadMarker } from '../src/utils/blobDownloadMarker.js';
 
 console.log('✅ Imports loaded');
 console.log(`🔑 Connection string configured: ${process.env.AZURE_STORAGE_CONNECTION_STRING ? 'YES' : 'NO'}`);
@@ -125,7 +126,12 @@ export class AzureBlobMetadataManager {
    */
   async downloadMetadata(modelType: 'standard' | 'custom' | 'all', specificModels?: string[]): Promise<void> {
     console.log(`\n📥 Downloading ${modelType} metadata from Azure Blob Storage`);
-    
+
+    // Which models this download populated. Recorded in the marker below so a later
+    // `extract-metadata` run can name the interaction between its orphan sweep and
+    // this download instead of leaving it to be discovered as apparent data loss.
+    const downloadedModels = new Set<string>();
+
     const prefixes: string[] = [];
     if (modelType === 'all' || modelType === 'standard') {
       prefixes.push('metadata/standard/');
@@ -161,6 +167,8 @@ export class AzureBlobMetadataManager {
           }
         }
         
+        const blobModel = this.extractModelNameFromBlobPath(blob.name);
+        if (blobModel) downloadedModels.add(blobModel);
         blobsToDownload.push({ name: blob.name, size: blob.properties.contentLength });
       }
       
@@ -225,6 +233,20 @@ export class AzureBlobMetadataManager {
       console.log(`   ✅ Completed: ${blobsToDownload.length} files`);
     }
     
+    // Leave the note extract-metadata reads. Best-effort: a failure here must not turn
+    // a completed download into an error — the marker only affects what a later run
+    // can EXPLAIN, never what it does.
+    try {
+      writeBlobDownloadMarker(LOCAL_METADATA_PATH, {
+        downloadedAt: new Date().toISOString(),
+        modelType,
+        models: [...downloadedModels].sort(),
+        fileCount: downloadCount,
+      });
+    } catch (error) {
+      console.warn(`   ⚠️  Could not record the blob-download marker (non-fatal): ${error instanceof Error ? error.message : error}`);
+    }
+
     console.log(`\n✅ Download complete! Total files: ${downloadCount}`);
   }
 

--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -13,6 +13,7 @@ import { XppMetadataParser, buildClassExtensionRecord } from '../src/metadata/xm
 import type { XppClassInfo } from '../src/metadata/types.js';
 import { isCustomModel as checkIsCustomModel, getCustomModels } from '../src/utils/modelClassifier.js';
 import { writeExtractManifest } from '../src/utils/extractManifest.js';
+import { readBlobDownloadMarker } from '../src/utils/blobDownloadMarker.js';
 import { XppConfigProvider } from '../src/utils/xppConfigProvider.js';
 import { defaultPackagesRoot } from '../src/utils/packagesRoot.js';
 import { box, kv, sectionTitle, statusLine, spread, c, glyph, log, shortPath, supportsUnicode, sanitize } from '../src/utils/terminalUi.js';
@@ -136,6 +137,14 @@ async function writeMetadataJson(
  * Only ever called for a model whose extraction completed without a single error — a
  * transient parse failure means "no JSON written", which is indistinguishable here from
  * "object deleted", and pruning on that signal would delete good metadata.
+ *
+ * INTERACTION WITH BLOB-DOWNLOADED METADATA: scripts/azure-blob-manager.ts downloads
+ * into this same OUTPUT_PATH/<model>/… layout. For a model that is BOTH downloaded and
+ * re-extracted here, "the blob had it, this disk does not" is indistinguishable from
+ * "it was deleted from the AOT", and the sweep removes it. That precedence is intended —
+ * local disk is authoritative for a model you just extracted — but on a machine with a
+ * partial PackagesLocalDirectory it reads as data loss, so the run summary says so
+ * whenever a blob-download marker is present (see src/utils/blobDownloadMarker.ts).
  *
  * Exported for tests.
  */
@@ -928,6 +937,31 @@ async function extractMetadata() {
         log.detail(`${modelName}: ${removed.slice(0, 10).join(', ')}${removed.length > 10 ? ` (+${removed.length - 10} more)` : ''}`);
       }
       log.detail('These objects are gone from PackagesLocalDirectory. Run build-database to drop them from the symbol index.');
+      // "Gone from PackagesLocalDirectory" is the whole story only when this machine
+      // is the sole source of what lives under OUTPUT_PATH. The blob manager downloads
+      // into the same layout, and for a model that is both downloaded and re-extracted
+      // here the sweep cannot tell "the blob had it, this disk does not" apart from a
+      // delete. Naming that is the difference between intended precedence and apparent
+      // data loss.
+      const blobMarker = readBlobDownloadMarker(OUTPUT_PATH);
+      if (blobMarker) {
+        const overlap = [...prunedByModel.keys()].filter(
+          m => blobMarker.models.length === 0 || blobMarker.models.includes(m),
+        );
+        if (overlap.length > 0) {
+          console.log(statusLine('warn', c.yellow(
+            `${formatCount(overlap.length)} of these model(s) also hold metadata downloaded from blob storage ` +
+            `on ${blobMarker.downloadedAt} (${blobMarker.modelType}): ${overlap.slice(0, 10).join(', ')}` +
+            `${overlap.length > 10 ? ` (+${overlap.length - 10} more)` : ''}`
+          )));
+          log.detail(
+            'Local disk is authoritative for a model this run re-extracted, so JSON the blob copy had and this ' +
+            "machine's PackagesLocalDirectory does not was removed as an orphan. That is the intended precedence, " +
+            'not a bug — but if this machine holds only part of the AOT, re-run the blob download afterwards or ' +
+            'exclude those models from extraction.'
+          );
+        }
+      }
     } else {
       log.info('No orphaned metadata found - every extracted JSON has a live source file');
     }

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1026,19 +1026,48 @@ export class XppSymbolIndex {
    * then WROTE a ConSk extension, which became one of the two visible names, so
    * the wrong answer was feeding itself. Members ('method', 'field') are excluded by
    * type, which is what this clause was reaching for.
+   *
+   * The sample is drawn in two BANDS rather than as one `LIMIT` over the union,
+   * because a model with more names than `limit` otherwise lets SQLite decide which
+   * ones inference sees — no ORDER BY means no defined subset, and inference is
+   * threshold-based (MIN_COVERAGE 60 %), so a skewed sample can flip the answer.
+   * The bands also protect the signal: extensions are rare and state the infix
+   * outright, regular objects are many and carry the leading token, and
+   * inferPrefixFromObjectNames needs BOTH — a single window ordered any way at all
+   * would let the larger band crowd the other one out entirely. Each band is capped
+   * at half the budget, gives back what it does not use, and is ordered (type, name)
+   * so the same model always yields the same sample — a silent, self-reinforcing
+   * failure otherwise, since this server writes names with the inferred prefix and
+   * those names become evidence for the next inference.
    */
   getModelObjectNames(model: string, limit = 400): string[] {
     if (!model) return [];
-    const rows = this.getReadDb()
-      .prepare(
-        `SELECT name FROM symbols
-         WHERE model = ?
-           AND (parent_name IS NULL OR type LIKE '%-extension')
-           AND type NOT IN ('method', 'field')
-         LIMIT ?`
-      )
-      .all(model, limit) as Array<{ name: string }>;
-    return rows.map(r => r.name);
+    if (limit <= 0) return [];
+    const db = this.getReadDb();
+
+    const band = (extensions: boolean, cap: number): string[] => {
+      if (cap <= 0) return [];
+      const rows = db
+        .prepare(
+          `SELECT name FROM symbols
+           WHERE model = ?
+             AND type ${extensions ? 'LIKE' : 'NOT LIKE'} '%-extension'
+             ${extensions ? '' : 'AND parent_name IS NULL'}
+             AND type NOT IN ('method', 'field')
+           ORDER BY type, name
+           LIMIT ?`
+        )
+        .all(model, cap) as Array<{ name: string }>;
+      return rows.map(r => r.name);
+    };
+
+    // Extensions first so their (smaller) band can hand its leftover budget to the
+    // regular one; the reverse would let a large model spend the whole budget on
+    // regular objects before the infix evidence is ever read.
+    const half = Math.max(1, Math.ceil(limit / 2));
+    const extensionNames = band(true, half);
+    const regularNames = band(false, limit - extensionNames.length);
+    return [...extensionNames, ...regularNames];
   }
 
   removeSymbolsByFile(filePath: string): { deletedCount: number; objectNames: string[] } {

--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -180,6 +180,12 @@ export interface XppSymbol {
   /** JSON array of typical usage examples. */
   typicalUsages?: string;
   usageFrequency?: number;
+  /**
+   * Set by `search` when this row's file is gone from disk (see
+   * indexedPathIsMissing). Not a stored column — a rendering flag, so the reader
+   * sees both the hit and the fact that it is a cache row.
+   */
+  staleIndexRow?: boolean;
   calledByCount?: number;
   /** Comma-separated related methods. */
   relatedMethods?: string;

--- a/src/tools/analysis/search.ts
+++ b/src/tools/analysis/search.ts
@@ -18,7 +18,7 @@ import {
   formatSuggestions
 } from '../../utils/suggestionEngine.js';
 import { tryBridgeSearch } from '../../bridge/bridgeAdapter.js';
-import { indexedPathIsMissing } from '../../utils/indexedXmlLookup.js';
+import { indexedPathIsMissing, renderStaleSearchRowsNote } from '../../utils/indexedXmlLookup.js';
 import { lookupSymbolsNocase } from '../../utils/symbolLookup.js';
 import { rankCustomFirst, isExactNameMatch } from '../../utils/exactMatchRanking.js';
 import { isCustomModel } from '../../utils/modelClassifier.js';
@@ -103,15 +103,35 @@ export function probeCustomMatches(
  * Scoped to the PROBES on purpose. They are a splice that outranks everything
  * else, so a ghost among them is actively misleading and dropping one costs
  * nothing — the row is still in the result set the probe was spliced into. The
- * result set itself is not swept: a symbol index built elsewhere (the shipped
- * one covers every standard package) routinely names files a given machine has
- * not installed, and dropping those would answer "no such object" for the whole
- * of D365FO on a partial install. Marking rather than hiding is the open
- * question there.
+ * result set itself is MARKED rather than swept; see markStaleRows.
  */
 async function dropStaleRows<T extends { filePath?: string }>(rows: T[]): Promise<T[]> {
   const missing = await Promise.all(rows.map(r => indexedPathIsMissing(r.filePath)));
   return rows.filter((_, i) => !missing[i]);
+}
+
+/**
+ * Flag the rows of an index-only answer whose file is gone from disk.
+ *
+ * This is the answer the whole of `search` reduces to when the bridge returns
+ * nothing — and a stale index outlives a deleted file precisely when the bridge is
+ * silent, so the one answer made entirely of index rows was the one still reporting
+ * ghosts as fact.
+ *
+ * Marked, not dropped. `indexedPathIsMissing` fires for any PackagesLocalDirectory
+ * path with no file here, the shipped index covers every standard package, and a
+ * machine installs a subset — sweeping this set would answer "no X++ symbols found"
+ * for most of D365FO on a partial install, in the tool every other workflow starts
+ * from. (Measured: with a packages root present, sweeping turned search("CustTable")
+ * into a no-match.) So the row stays, says what it is, and ranks below the live ones.
+ *
+ * Cost is one existsSync + one access per row over a `limit`-bounded set.
+ */
+async function markStaleRows<T extends { filePath?: string }>(
+  rows: T[],
+): Promise<Array<T & { staleIndexRow?: boolean }>> {
+  const missing = await Promise.all(rows.map(r => indexedPathIsMissing(r.filePath)));
+  return rows.map((row, i) => (missing[i] ? { ...row, staleIndexRow: true } : row));
 }
 
 const SearchArgsSchema = z.object({
@@ -351,16 +371,24 @@ async function performExternalSearch(
       .filter(hit => !seen.has(`${hit.name.toLowerCase()} ${hit.type}`));
     for (const hit of missingCustom) seen.add(`${hit.name.toLowerCase()} ${hit.type}`);
 
-    // NOT swept for stale rows, deliberately — see dropStaleRows. This is the
-    // whole answer, not a splice, and a symbol index built elsewhere routinely
-    // covers packages this machine does not have installed. Dropping those would
-    // turn "you do not have that package locally" into "no such object", in the
-    // one tool everything else starts from.
-    const combined = [...missingExact, ...missingCustom, ...raw];
+    // Marked, not swept — see markStaleRows. This is the whole answer rather than a
+    // splice, and a symbol index built elsewhere routinely covers packages this
+    // machine does not have installed, so dropping those rows would turn "you do not
+    // have that package locally" into "no such object" in the one tool everything
+    // else starts from.
+    const combined = await markStaleRows([...missingExact, ...missingCustom, ...raw]);
     const isCustomHit = (r: any) =>
       (r.model ? isCustomModel(String(r.model)) : false) ||
       customKeys.has(`${String(r.name).toLowerCase()} ${r.type}`);
-    const results: any[] = rankCustomFirst(args.query, combined, r => String(r.name), isCustomHit);
+    const ranked: any[] = rankCustomFirst(args.query, combined, r => String(r.name), isCustomHit);
+    // Below the live rows, keeping the ranking within each band: a cache row must
+    // never outrank an object that is actually here, least of all as the exact match
+    // the renderer calls out at the top.
+    const results: any[] = [
+      ...ranked.filter(r => !r.staleIndexRow),
+      ...ranked.filter(r => r.staleIndexRow),
+    ];
+    const staleCount = results.filter(r => r.staleIndexRow).length;
 
     if (!results || results.length === 0) {
       const allSymbolNames = symbolIndex.getAllSymbolNames(args.query);
@@ -408,11 +436,14 @@ async function performExternalSearch(
     let output = `Found ${results.length} matches:\n`;
 
     // #15: the grouped renderer below hides ordering, so call the exact match out
-    // explicitly — that is the whole point of the exact-first repair.
+    // explicitly — that is the whole point of the exact-first repair. A stale exact
+    // match is still called out (hiding it is what this used to get wrong) but it
+    // says so right here, where the caller is most likely to act on that one line
+    // without reading further.
     const exactHits = results.filter(r => isExactNameMatch(args.query, String(r.name)));
     if (exactHits.length > 0) {
       output += `\n⭐ **Exact name match:** ` +
-        exactHits.map(r => `${r.name} (${r.type})`).join(', ') + '\n';
+        exactHits.map(r => `${r.name} (${r.type})${r.staleIndexRow ? ' — ⚠️ STALE index row, no file on this machine' : ''}`).join(', ') + '\n';
     }
 
     output += formatRichContext(args.query, results, {
@@ -420,6 +451,8 @@ async function performExternalSearch(
       commonPatterns,
       tips
     });
+
+    if (staleCount > 0) output += `\n${renderStaleSearchRowsNote(staleCount)}`;
 
     return {
       content: [

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -149,6 +149,35 @@ export async function labelsTool(request: CallToolRequest, context: XppServerCon
 const MAX_BATCH_QUERIES = 12;
 
 /**
+ * How many of the batch's searches are in flight at once.
+ *
+ * They are independent reads, so running them one after another made the batch
+ * cost the SUM of its queries when it only needs to cost the slowest — the very
+ * latency batching exists to remove. Bounded rather than unbounded because they
+ * all land on the same SQLite connection: twelve concurrent FTS queries buy
+ * nothing over a handful and only lengthen the queue behind them.
+ */
+const BATCH_CONCURRENCY = 4;
+
+/** Run `fn` over `items` with at most `limit` in flight, preserving input order. Exported for tests. */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+/**
  * Run several label searches in one call.
  *
  * Looking for a reusable label is inherently a guessing game — the caller does not
@@ -163,8 +192,21 @@ async function batchSearch(
   search: LabelsTool,
   context: XppServerContext,
 ): Promise<any> {
-  const all = (args.query as unknown[]).map(q => String(q)).filter(q => q.trim() !== '');
-  const queries = all.slice(0, MAX_BATCH_QUERIES);
+  const all = (args.query as unknown[]).map(q => String(q).trim()).filter(q => q !== '');
+  // Fold phrasings that differ only in case or surrounding space: the index is
+  // case-insensitive, so ["customer","customer","Customer"] is one query printed
+  // three times — and passing near-duplicates is exactly the guessing behaviour
+  // this feature exists to absorb. First spelling wins, so the sections still read
+  // back in the caller's own words.
+  const seen = new Set<string>();
+  const unique = all.filter(q => {
+    const key = q.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  const duplicates = all.length - unique.length;
+  const queries = unique.slice(0, MAX_BATCH_QUERIES);
   if (queries.length === 0) {
     return {
       content: [{ type: 'text', text: `❌ labels(action="search"): query[] is empty — pass at least one search text.` }],
@@ -172,33 +214,63 @@ async function batchSearch(
     };
   }
 
-  const sections: string[] = [];
-  let foundReusable = false;
-
-  for (const query of queries) {
-    const result = await search(
-      { method: 'tools/call', params: { name: 'search_labels', arguments: { ...args, query } } },
-      context,
-    );
+  const runs = await mapWithConcurrency(queries, BATCH_CONCURRENCY, async (query) => {
+    let result: any;
+    try {
+      result = await search(
+        { method: 'tools/call', params: { name: 'search_labels', arguments: { ...args, query } } },
+        context,
+      );
+    } catch (error) {
+      // A handler that throws is a failure like any other — it must not read back
+      // as "this phrasing found nothing".
+      return { query, text: `❌ ${error instanceof Error ? error.message : String(error)}`, failed: true };
+    }
     const text = (result?.content ?? [])
       .map((c: any) => (typeof c?.text === 'string' ? c.text : ''))
       .join('\n');
-    if (text.includes(REUSABLE_MARKER)) foundReusable = true;
-    sections.push(`## "${query}"\n\n${text}`);
-  }
+    return { query, text, failed: result?.isError === true };
+  });
 
+  const failed = runs.filter(r => r.failed);
+  const searched = runs.length - failed.length;
+  const foundReusable = runs.some(r => !r.failed && r.text.includes(REUSABLE_MARKER));
+  const sections = runs.map(r => `## "${r.query}"${r.failed ? ' — ❌ SEARCH FAILED' : ''}\n\n${r.text}`);
+
+  const notes = [
+    duplicates > 0 ? `${duplicates} duplicate phrasing(s) folded` : '',
+    unique.length > queries.length ? `${unique.length - queries.length} beyond the ${MAX_BATCH_QUERIES}-query cap were not run` : '',
+  ].filter(Boolean);
   const header = `# Label search — ${queries.length} quer${queries.length === 1 ? 'y' : 'ies'}` +
-    (all.length > queries.length ? ` (${all.length - queries.length} beyond the ${MAX_BATCH_QUERIES}-query cap were not run)` : '') +
-    '\n';
+    (notes.length > 0 ? ` (${notes.join('; ')})` : '') + '\n';
+
   // The per-query sections each carry their own advice; the verdict is what the
   // caller actually needs, so state it once, up front, rather than making them
   // read every section to work out that no phrasing hit.
-  const verdict = foundReusable
-    ? `**Verdict:** at least one reusable label was found — see the section(s) marked "${REUSABLE_MARKER}".\n`
-    : `**Verdict:** none of these ${queries.length} phrasings found a label this model can resolve. ` +
-      `Stop searching and create your own.\n\n${NO_REUSE_ADVICE}`;
+  //
+  // A failed sub-search is NOT a miss, and the two used to be indistinguishable:
+  // isError was dropped on the floor, so a batch in which every query blew up
+  // returned a clean report whose verdict said "no label exists — create your own".
+  // That is the one thing this line exists to state unambiguously, so failures
+  // either replace the verdict or are named alongside it.
+  const verdict = searched === 0
+    ? `**Verdict:** NONE of these ${runs.length} searches ran — every one failed (see the sections below). ` +
+      `This says nothing about whether a reusable label exists; fix the error and search again ` +
+      `rather than creating a label on the strength of this answer.\n`
+    : foundReusable
+      ? `**Verdict:** at least one reusable label was found — see the section(s) marked "${REUSABLE_MARKER}".\n`
+      : `**Verdict:** none of these ${searched} phrasings found a label this model can resolve. ` +
+        `Stop searching and create your own.\n` +
+        (failed.length > 0
+          ? `\n⚠️ ${failed.length} of ${runs.length} searches FAILED and were not part of that verdict: ` +
+            `${failed.map(f => `"${f.query}"`).join(', ')}.\n`
+          : '') +
+        `\n${NO_REUSE_ADVICE}`;
 
-  return { content: [{ type: 'text', text: `${header}\n${verdict}\n---\n\n${sections.join('\n\n---\n\n')}` }] };
+  return {
+    content: [{ type: 'text', text: `${header}\n${verdict}\n---\n\n${sections.join('\n\n---\n\n')}` }],
+    ...(searched === 0 ? { isError: true } : {}),
+  };
 }
 
 // Tool registration (name, description, inputSchema) lives in

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -3078,6 +3078,33 @@ async function normalizeCreatedArtifactEol(filePath: string): Promise<void> {
 }
 
 /**
+ * Resolve the `values` / `enumValues` alias ONCE, before anything routes on it.
+ *
+ * `values` is a legacy spelling the bridge create path has always accepted
+ * (`props.enumValues ?? props.values` → bridgeParams.values), but the TypeScript
+ * XML generator reads `properties.enumValues` and nothing else. Two writers
+ * disagreeing about the same payload is only harmless while both of them run;
+ * they don't. An enum passed `values: [None=0, A=1]` routes AWAY from the bridge
+ * (the resolved mode forbids explicit <Value> elements — see
+ * enumModeForbidsExplicitValues below) and lands on the generator, which finds no
+ * `enumValues`, writes `<EnumValues />`, and reports a clean ✅ for an enum with no
+ * values at all.
+ *
+ * So normalise here, at the top of the handler, where every later reader — routing
+ * predicate, bridge params, generator — sees the same list. Mutates in place: `args`
+ * is this call's own parsed object.
+ */
+export function normalizeEnumValuesAlias(
+  objectType: string,
+  properties: Record<string, unknown> | undefined,
+): void {
+  if (objectType !== 'enum' && objectType !== 'enum-extension') return;
+  if (!properties) return;
+  if (properties.enumValues !== undefined) return;
+  if (Array.isArray(properties.values)) properties.enumValues = properties.values;
+}
+
+/**
  * Returns a BP warning string when a `label` property is raw text (not a @File:Id reference).
  * xppbp raises BPErrorLabelIsText for any object-level label that is not a label ID.
  * Use the `labels` tool to find or create a label ID before writing the object.
@@ -3133,6 +3160,7 @@ export async function handleCreateD365File(
   },
 ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
   const args = CreateD365FileArgsSchema.parse(request.params.arguments);
+  normalizeEnumValuesAlias(args.objectType, args.properties);
 
   // Grounding enforcement: extension objects modify the behaviour of existing
   // code, so when GROUNDING_ENFORCE=true the model must prove (via prepare_change)
@@ -3655,7 +3683,7 @@ export async function handleCreateD365File(
     // entirely (see bridgeAdapter.ts) because the bridge silently drops their
     // structured collections (EntryPoints, DataEntityPermissions, Privileges, Duties).
     //
-    // EXCEPTION — any enum whose resolved mode forbids explicit <Value> elements. The
+    // EXCEPTION — any enum whose RESOLVED MODE forbids explicit <Value> elements. The
     // bridge takes UseEnumValue from the scalar property but still serializes a <Value>
     // for every numbered entry, minus the ones equal to 0, which .NET omits as the type
     // default. An enum created with useEnumValue:false and values None=0..Platinum=3 came
@@ -3665,11 +3693,22 @@ export async function handleCreateD365File(
     // resolveEnumValueMode is the single place that decides this; when it says the values
     // must be suppressed and the payload carries some, hand the write to the TypeScript
     // generator, which is the writer that honours suppressExplicitValues.
-    const skipBridgeForEnumValueMode = (): boolean => {
+    //
+    // Read the rule literally, because it is BROADER than the two headline cases:
+    // suppressExplicitValues is true whenever the resolved mode is UseEnumValue=No, and
+    // that includes the plain positional payload — values [None=0, A=1, B=2] with
+    // `useEnumValue` unset. So in practice ANY enum create carrying explicit numbers
+    // goes to the TypeScript generator, extensible or not, useEnumValue or not. That is
+    // the intended behaviour (the bridge cannot write this shape correctly); it is named
+    // and commented this way so the next reader does not conclude the bridge still
+    // handles positional enums.
+    const enumModeForbidsExplicitValues = (): boolean => {
       if (args.objectType !== 'enum') return false;
       const props = args.properties as Record<string, unknown> | undefined;
       if (props?.isExtensible) return true;
-      const vals = (props?.enumValues ?? props?.values) as Array<{ name?: string; value?: number }> | undefined;
+      // `enumValues` only: the `values` alias was folded into it by
+      // normalizeEnumValuesAlias, so routing and the writers read one list.
+      const vals = props?.enumValues as Array<{ name?: string; value?: number }> | undefined;
       if (!Array.isArray(vals) || !vals.some(v => typeof v?.value === 'number')) return false;
       try {
         return resolveEnumValueMode(finalObjectName, props, vals).suppressExplicitValues;
@@ -3679,7 +3718,7 @@ export async function handleCreateD365File(
         return true;
       }
     };
-    const skipBridgeForEnum = skipBridgeForEnumValueMode();
+    const skipBridgeForEnum = enumModeForbidsExplicitValues();
 
     // Set only when a bridge create THREW (not when it was unavailable or declined).
     // The XML fallback below is a different writer with a narrower feature set, so a

--- a/src/utils/blobDownloadMarker.ts
+++ b/src/utils/blobDownloadMarker.ts
@@ -1,0 +1,65 @@
+/**
+ * Blob-download marker — the note `azure-blob-manager` leaves for `extract-metadata`.
+ *
+ * Both scripts write into the same `OUTPUT_PATH/<model>/…` layout: the blob manager
+ * downloads metadata produced elsewhere, extraction writes metadata read from THIS
+ * machine's PackagesLocalDirectory. Extraction then sweeps every `.json` under a model
+ * it re-extracted that this run did not write (see pruneOrphanedMetadata), which is
+ * how a deleted AOT object stops surviving rebuilds as a phantom.
+ *
+ * For a model that is BOTH downloaded and locally re-extracted, that sweep cannot tell
+ * "the blob had it, this disk does not" apart from "it was deleted from the AOT", and
+ * removes it. Local disk is meant to be authoritative for a model you just extracted,
+ * so the precedence is intended — but on a machine with a partial PackagesLocalDirectory
+ * it reads as data loss, and neither script said a word about the other.
+ *
+ * This marker is what lets the extract run SAY so. It is written at the metadata
+ * directory root, not inside a model folder, so the sweep (which walks
+ * OUTPUT_PATH/<model> only) can never touch it.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** File written into the metadata output directory. Not a model dir — scanners skip files. */
+export const BLOB_DOWNLOAD_MARKER_FILENAME = '.blob-download.json';
+
+export interface BlobDownloadMarker {
+  /** ISO timestamp of the download that produced this marker. */
+  downloadedAt: string;
+  /** What was asked for: 'standard' | 'custom' | 'all'. */
+  modelType: string;
+  /** Models the download actually wrote into, as on-disk directory names. */
+  models: string[];
+  /** How many files the download wrote (diagnostics only). */
+  fileCount: number;
+}
+
+function markerPath(metadataDir: string): string {
+  return path.join(metadataDir, BLOB_DOWNLOAD_MARKER_FILENAME);
+}
+
+/** Record a completed blob download. Best-effort: a download succeeds even if this fails. */
+export function writeBlobDownloadMarker(metadataDir: string, marker: BlobDownloadMarker): void {
+  fs.writeFileSync(markerPath(metadataDir), JSON.stringify(marker, null, 2));
+}
+
+/**
+ * Read the last blob download's marker, or `undefined` when this metadata directory
+ * was never populated from blob storage (the normal local-only case).
+ */
+export function readBlobDownloadMarker(metadataDir: string): BlobDownloadMarker | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(markerPath(metadataDir), 'utf-8')) as Partial<BlobDownloadMarker>;
+    if (typeof parsed.downloadedAt !== 'string') return undefined;
+    return {
+      downloadedAt: parsed.downloadedAt,
+      modelType: typeof parsed.modelType === 'string' ? parsed.modelType : 'unknown',
+      models: Array.isArray(parsed.models) ? parsed.models.filter((m): m is string => typeof m === 'string') : [],
+      fileCount: typeof parsed.fileCount === 'number' ? parsed.fileCount : 0,
+    };
+  } catch {
+    // No marker (ENOENT) or unparseable — the caller says nothing about blob storage.
+    return undefined;
+  }
+}

--- a/src/utils/indexedXmlLookup.ts
+++ b/src/utils/indexedXmlLookup.ts
@@ -197,6 +197,32 @@ export async function indexedPathIsMissing(indexedPath: string | null | undefine
   return isStaleIndexedPath(indexedPath, await resolveLocalPath(indexedPath));
 }
 
+/**
+ * The same fact, told to a LIST rather than to a reader of one object.
+ *
+ * `renderStaleIndexNote` answers "you asked for this object and the cache answered
+ * for it", so it can end in "treat it as NOT EXISTING and create it". A search
+ * result set cannot say that. `indexedPathIsMissing` fires for any
+ * PackagesLocalDirectory path with no file here, and the shipped symbol index covers
+ * every standard package while a given machine installs a subset — so on a partial
+ * install these rows are mostly "that package is not installed", not "deleted". Both
+ * causes matter to the caller and neither justifies hiding the row (that would answer
+ * "no such object" for most of D365FO, in the tool every other workflow starts from),
+ * so name them and let the caller decide.
+ */
+export function renderStaleSearchRowsNote(count: number): string {
+  return `\n⚠️ ${count} result${count === 1 ? '' : 's'} marked STALE: the symbol index records a ` +
+    `PackagesLocalDirectory path with no file there or at its local remap, so ${count === 1 ? 'it is' : 'they are'} ` +
+    `an index row without an object on this machine — either deleted without the index being rebuilt ` +
+    `(a workspace reset, a rolled-back run), or belonging to a package this machine does not have ` +
+    `installed. ${count === 1 ? 'It is' : 'They are'} listed last and ${count === 1 ? 'is' : 'are'} NOT ` +
+    `evidence the object is usable: read it with get_object_info before building on it, and run ` +
+    `update_symbol_index if this workspace was reset.\n`;
+}
+
+/** The per-row marker for a stale search hit — see renderStaleSearchRowsNote. */
+export const STALE_ROW_MARKER = '⚠️ STALE index row — no file on this machine';
+
 /** The warning text both stale-row paths render. */
 export function renderStaleIndexNote(name: string, indexedPath: string): string {
   return `⚠️ STALE INDEX ENTRY — everything above is a cache read, not a live object. ` +

--- a/src/utils/richContext.ts
+++ b/src/utils/richContext.ts
@@ -4,6 +4,7 @@
  */
 
 import type { XppSymbol } from '../metadata/types.js';
+import { STALE_ROW_MARKER } from './indexedXmlLookup.js';
 
 export interface RichContextOptions {
   includeRelated?: boolean;
@@ -390,6 +391,12 @@ function groupResultsByType(results: XppSymbol[]): Record<string, XppSymbol[]> {
  */
 function formatSymbolWithMetadata(symbol: XppSymbol): string {
   let output = `📦 **${symbol.name}**\n`;
+
+  // Marked, never hidden: the row is a real index hit whose file is not on this
+  // machine, and the caller needs both halves of that. See renderStaleSearchRowsNote.
+  if (symbol.staleIndexRow) {
+    output += `   └─ ${STALE_ROW_MARKER}\n`;
+  }
 
   if (symbol.parentName) {
     output += `   └─ Parent: ${symbol.parentName}\n`;

--- a/src/workspace/projectFile.ts
+++ b/src/workspace/projectFile.ts
@@ -36,6 +36,19 @@ import { getConfigManager } from '../utils/configManager.js';
  * leave it out of the one being worked in — you cannot build, check in, or hand
  * over a change through a project that does not contain the object it changed.
  *
+ * Both halves of that are measured, not assumed (#882):
+ *  • Compiler — xppc.exe takes `-modelmodule=<model>` and writes one assembly per
+ *    module. There is no project-level input at all, so a .rnrproj cannot cause a
+ *    second compilation. (X++ Compiler 7.0.7996.33.)
+ *  • Visual Studio / ALM — surveyed a real 187-project ISV solution authored in VS
+ *    over years: 280 of its 1899 AOT elements are listed in two or more projects of
+ *    the SAME model, across 20 element types (92 AxClass, plus forms, tables,
+ *    form/table extensions, security duties, EDTs…). Shared membership is routine
+ *    practice in a shipping codebase, not an edge case, and that solution's own
+ *    build projects list no elements whatsoever — they declare `<Model>` and let
+ *    the build task compile the module, which is the packaging flow agreeing with
+ *    the compiler.
+ *
  * This used to stop at membership 'other' and report the sibling as the owner.
  * That inverted the rule: an object edited in the active project stayed absent
  * from it, and every later verify pass had to re-explain why the gap was fine.

--- a/tests/metadata/modelObjectNamesSample.test.ts
+++ b/tests/metadata/modelObjectNamesSample.test.ts
@@ -1,0 +1,102 @@
+/**
+ * getModelObjectNames — the sample prefix inference is derived from (#878).
+ *
+ * The query had no ORDER BY, so on a model with more objects than the cap SQLite
+ * chose which ones inference saw. That matters because inference is threshold-based
+ * (MIN_COVERAGE 60 %) and reads two DIFFERENT bands of evidence: extension names
+ * state the model's infix outright ("CustTable.ConSKExtension"), regular names carry
+ * the leading token. Extensions are rare, so an undefined window over the union can
+ * drop every one of them — and the failure is silent AND self-reinforcing, because
+ * this server writes new names with the inferred prefix and those names are the
+ * evidence for the next inference.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { inferPrefixFromObjectNames } from '../../src/utils/modelPrefixInference';
+
+let index: XppSymbolIndex;
+
+const add = (name: string, type: string, parentName?: string) =>
+  index.addSymbol({
+    name,
+    type,
+    parentName,
+    filePath: `Pkg/ConSK/${name.replace(/[.\\/]/g, '_')}.xml`,
+    model: 'ContosoFinanceSK',
+  } as any);
+
+beforeEach(() => {
+  index = new XppSymbolIndex(':memory:', ':memory:');
+});
+
+afterEach(() => index.close());
+
+describe('getModelObjectNames', () => {
+  it('is deterministic — the same model yields the same sample every call', () => {
+    for (let i = 0; i < 50; i++) add(`ConSKTable${String(i).padStart(3, '0')}`, 'table');
+
+    const first = index.getModelObjectNames('ContosoFinanceSK', 10);
+    const second = index.getModelObjectNames('ContosoFinanceSK', 10);
+
+    expect(first).toHaveLength(10);
+    expect(second).toEqual(first);
+  });
+
+  it('keeps extensions in the sample when regular objects outnumber the cap', () => {
+    // The shape that broke inference: a handful of extensions spelling the infix,
+    // buried under hundreds of regular objects. An undefined window over the union
+    // returns 400 tables and not one extension.
+    for (let i = 0; i < 500; i++) add(`ConSKTable${String(i).padStart(3, '0')}`, 'table');
+    for (let i = 0; i < 6; i++) {
+      add(`CustTable${i}.ConSKExtension`, 'table-extension', `CustTable${i}`);
+    }
+
+    const names = index.getModelObjectNames('ContosoFinanceSK');
+
+    expect(names).toHaveLength(400);
+    expect(names.filter(n => n.endsWith('.ConSKExtension'))).toHaveLength(6);
+  });
+
+  it('gives the unused half of the budget back to the other band', () => {
+    // Two extensions must not cost 200 regular-object slots: the regular band
+    // carries the leading token, and starving it is the other way to skew the
+    // sample.
+    for (let i = 0; i < 500; i++) add(`ConSKTable${String(i).padStart(3, '0')}`, 'table');
+    add('CustTable.ConSKExtension', 'table-extension', 'CustTable');
+    add('VendTable.ConSKExtension', 'table-extension', 'VendTable');
+
+    const names = index.getModelObjectNames('ContosoFinanceSK', 100);
+
+    expect(names).toHaveLength(100);
+    expect(names.filter(n => n.includes('.'))).toHaveLength(2);
+  });
+
+  it('still excludes members and non-extension children', () => {
+    add('ConSKPriceEngine', 'class');
+    add('calculate', 'method', 'ConSKPriceEngine');
+    add('AmountMST', 'field', 'ConSKTable');
+    add('CustTable.ConSKExtension', 'table-extension', 'CustTable');
+
+    const names = index.getModelObjectNames('ContosoFinanceSK');
+
+    expect(names.sort()).toEqual(['ConSKPriceEngine', 'CustTable.ConSKExtension']);
+  });
+
+  it('infers the model infix from a sample that regular objects would have flooded', () => {
+    // End to end: the 34-of-36 case from the issue, scaled past the cap. With the
+    // extensions crowded out, inference sees only the regular token and flattens
+    // the "SK" country code to "Sk".
+    for (let i = 0; i < 450; i++) add(`ConSkTable${String(i).padStart(3, '0')}`, 'table');
+    for (let i = 0; i < 35; i++) {
+      add(`CustTable${i}.ConSKExtension`, 'table-extension', `CustTable${i}`);
+    }
+
+    const inferred = inferPrefixFromObjectNames(
+      index.getModelObjectNames('ContosoFinanceSK'),
+      'ContosoFinanceSK',
+    );
+
+    expect(inferred?.infix).toBe('ConSK');
+  });
+});

--- a/tests/tools/createEnumWriterRouting.test.ts
+++ b/tests/tools/createEnumWriterRouting.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Which writer an enum create lands on, and whether both writers read the same
+ * payload (#879).
+ *
+ * Routing: `enumModeForbidsExplicitValues` sends an enum to the TypeScript XML
+ * generator whenever the resolved mode is UseEnumValue=No and the payload carries
+ * numbers — which includes the plain positional case ([None=0, A=1, B=2] with
+ * `useEnumValue` unset), not just the two headline cases the comment used to
+ * describe. The bridge cannot write that shape: it takes UseEnumValue from the
+ * scalar property but still serialises a <Value> per numbered entry, minus the
+ * zeros .NET omits as a type default.
+ *
+ * The alias: `values` is a legacy spelling of `enumValues` that only the BRIDGE
+ * path ever read. Routing on it while the generator reads `enumValues` meant a
+ * payload could be routed away from the bridge and then land on a writer that
+ * could not see its values at all — a clean ✅ for an enum with none.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleCreateD365File } from '../../src/tools/write/createD365File';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const { files } = vi.hoisted(() => ({ files: new Map<string, string>() }));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (files.has(p)) return files.get(p)!;
+    if (p.endsWith('.rnrproj')) return `<Project><ItemGroup /></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: vi.fn(async (p: string, content: string) => { files.set(p, content); }),
+  copyFile: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async (p: string) => {
+    if (/^[A-Za-z]:[\\/]?$/.test(p) || p === '/') return;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false, size: 1024 })),
+  readdir: vi.fn(async () => []),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return { ...actual, bridgeValidateAfterWrite: vi.fn(async () => null) };
+});
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'Contoso'),
+    getWriteAnchorModel: vi.fn(() => 'Contoso'),
+    getToolProjectSwitch: vi.fn(() => null),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'Contoso'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (modelName: string) => ({
+      packageName: modelName, modelName, rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({
+      packageName: p, modelName: m, rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+  })),
+}));
+
+vi.mock('../../src/utils/modelClassifier', () => ({
+  registerCustomModel: vi.fn(),
+  resolveObjectPrefix: vi.fn(() => ''),
+  applyObjectPrefix: vi.fn((name: string) => name),
+  getObjectSuffix: vi.fn(() => ''),
+  applyObjectSuffix: vi.fn((name: string) => name),
+  getExtensionNamingStyle: vi.fn(() => 'prefix'),
+  isCustomModel: vi.fn(() => true),
+  isStandardModel: vi.fn(() => false),
+}));
+
+const createObject = vi.fn(async () => ({
+  success: true,
+  filePath: 'K:\\PackagesLocalDirectory\\Contoso\\Contoso\\AxEnum\\ConDemoTier.xml',
+  api: 'IMetadataProvider',
+}));
+
+/** A healthy bridge that would happily take the create if routing let it. */
+const liveBridge = () => ({
+  isReady: true,
+  metadataAvailable: true,
+  createObject,
+  validateObject: vi.fn(async () => null),
+  refreshProvider: vi.fn(async () => ({ refreshed: true, elapsedMs: 1 })),
+} as any);
+
+const buildContext = () => ({
+  bridge: liveBridge(),
+  symbolIndex: {
+    searchSymbols: vi.fn(() => []),
+    getSymbolByName: vi.fn(() => undefined),
+    getCustomModels: vi.fn(() => ['Contoso']),
+    db: { prepare: vi.fn(() => ({ all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() })) },
+    getReadDb: vi.fn(function (this: any) { return this.db; }),
+  },
+} as any);
+
+const req = (properties: Record<string, unknown>, objectName = 'ConDemoTier'): CallToolRequest => ({
+  method: 'tools/call',
+  params: {
+    name: 'create_d365fo_file',
+    arguments: {
+      objectType: 'enum',
+      objectName,
+      modelName: 'Contoso',
+      packageName: 'Contoso',
+      packagePath: 'K:\\PackagesLocalDirectory',
+      addToProject: false,
+      properties,
+    },
+  },
+});
+
+const POSITIONAL = [
+  { name: 'None', value: 0 },
+  { name: 'Silver', value: 1 },
+  { name: 'Gold', value: 2 },
+];
+
+beforeEach(() => {
+  files.clear();
+  vi.clearAllMocks();
+  process.env.D365FO_CROSS_MODEL_WRITE_MODELS = 'Contoso';
+});
+
+describe('enum create — which writer runs', () => {
+  it('routes a plain positional payload (useEnumValue unset) to the XML generator', async () => {
+    // The predicate is broader than "extensible or useEnumValue:false": the resolved
+    // mode for [None=0, Silver=1, Gold=2] is UseEnumValue=No, and the bridge would
+    // write <Value>1</Value><Value>2</Value> with the 0 dropped.
+    const result = await handleCreateD365File(req({ enumValues: POSITIONAL }), buildContext());
+
+    expect(createObject).not.toHaveBeenCalled();
+    const xml = [...files.values()].join('\n');
+    expect(result.content[0].text).toContain('Successfully created');
+    expect(xml).toContain('<UseEnumValue>No</UseEnumValue>');
+    expect(xml).not.toContain('<Value>');
+    for (const v of POSITIONAL) expect(xml).toContain(`<Name>${v.name}</Name>`);
+  });
+
+  it('writes every value when the payload spells the list `values` instead of `enumValues`', async () => {
+    // The alias used to be read by the routing predicate and by the bridge, but not
+    // by the generator — so this payload was routed to the generator and came out as
+    // an empty <EnumValues />, reported as a clean success.
+    const result = await handleCreateD365File(
+      req({ values: POSITIONAL }, 'ConDemoTierAlias'),
+      buildContext(),
+    );
+
+    expect(createObject).not.toHaveBeenCalled();
+    const xml = [...files.values()].join('\n');
+    expect(result.content[0].text).toContain('Successfully created');
+    expect(xml).not.toContain('<EnumValues />');
+    for (const v of POSITIONAL) expect(xml).toContain(`<Name>${v.name}</Name>`);
+  });
+
+  it('leaves an unnumbered enum on the bridge', async () => {
+    // Nothing to suppress, so the exception does not apply and the normal
+    // bridge-first path stands.
+    await handleCreateD365File(
+      req({ enumValues: [{ name: 'None' }, { name: 'Silver' }] }, 'ConDemoTierPlain'),
+      buildContext(),
+    );
+
+    expect(createObject).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the aliased list to the bridge as well, when the bridge is the writer', async () => {
+    await handleCreateD365File(
+      req({ values: [{ name: 'None' }, { name: 'Silver' }] }, 'ConDemoTierPlainAlias'),
+      buildContext(),
+    );
+
+    expect(createObject).toHaveBeenCalledTimes(1);
+    const params = createObject.mock.calls[0][0] as any;
+    expect(params.values).toHaveLength(2);
+  });
+});

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -8,7 +8,7 @@ import { searchLabelsTool } from '../../src/tools/analysis/searchLabels';
 import { getLabelInfoTool } from '../../src/tools/readers/getLabelInfo';
 import { createLabelTool } from '../../src/tools/write/createLabel';
 import { renameLabelTool } from '../../src/tools/write/renameLabel';
-import { labelsTool } from '../../src/tools/labels';
+import { labelsTool, mapWithConcurrency } from '../../src/tools/labels';
 import { isExtensionLabelFile } from '../../src/metadata/labelParser';
 import type { XppServerContext } from '../../src/types/context';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
@@ -264,6 +264,79 @@ describe('labels(action="search") with query[]', () => {
   it('rejects an empty query array rather than reporting a clean no-match', async () => {
     const result = await labelsTool(req('labels', { action: 'search', query: [] }), ctx);
     expect(result.isError).toBe(true);
+  });
+
+  it('folds phrasings that differ only in case or spacing', async () => {
+    // The index is case-insensitive, so these are one query — running it three
+    // times costs three FTS scans and prints three identical sections.
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    const text = (await labelsTool(
+      req('labels', { action: 'search', query: ['customer', 'customer', ' Customer ', 'client'] }),
+      ctx,
+    )).content[0].text as string;
+
+    expect((ctx.symbolIndex.searchLabels as any).mock.calls.length).toBe(2);
+    expect(text).toContain('2 duplicate phrasing(s) folded');
+    // The caller's own first spelling is what reads back.
+    expect(text).toContain('## "customer"');
+    expect(text).not.toContain('## "Customer"');
+  });
+
+  it('does not report a failed batch as "no reusable label exists"', async () => {
+    // isError used to be dropped: a batch in which every query blew up returned a
+    // clean report whose verdict was "none of these phrasings found a label" —
+    // indistinguishable from a real miss, and the caller then created a duplicate.
+    (ctx.symbolIndex.searchLabels as any).mockImplementation(() => { throw new Error('labels DB is locked'); });
+
+    const result = await labelsTool(
+      req('labels', { action: 'search', query: ['customer', 'client'] }),
+      ctx,
+    );
+    const text = result.content[0].text as string;
+
+    expect(result.isError).toBe(true);
+    expect(text).toMatch(/every one failed/i);
+    expect(text).not.toContain('Stop searching and create your own.');
+    expect(text).toContain('SEARCH FAILED');
+  });
+
+  it('runs the phrasings with bounded concurrency, in order', async () => {
+    // Batching exists to turn N round trips into one; a serial loop keeps the cost
+    // at the SUM of the queries when it only needs to be the slowest of them. The
+    // bound is there because they all land on one SQLite connection.
+    let inFlight = 0;
+    let peak = 0;
+    const out = await mapWithConcurrency([1, 2, 3, 4, 5, 6, 7, 8], 4, async (n) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise(r => setTimeout(r, 5));
+      inFlight--;
+      return n * 10;
+    });
+
+    expect(out).toEqual([10, 20, 30, 40, 50, 60, 70, 80]);
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+
+  it('keeps the verdict but names the queries that failed when only some did', async () => {
+    let call = 0;
+    (ctx.symbolIndex.searchLabels as any).mockImplementation(() => {
+      call++;
+      if (call === 1) throw new Error('labels DB is locked');
+      return [];
+    });
+
+    const result = await labelsTool(
+      req('labels', { action: 'search', query: ['customer', 'client'] }),
+      ctx,
+    );
+    const text = result.content[0].text as string;
+
+    expect(result.isError).toBeUndefined();
+    expect(text).toMatch(/none of these 1 phrasings/i);
+    expect(text).toMatch(/1 of 2 searches FAILED/);
   });
 
   it('still accepts a single string query', async () => {

--- a/tests/tools/searchStaleRowMarking.test.ts
+++ b/tests/tools/searchStaleRowMarking.test.ts
@@ -1,0 +1,134 @@
+/**
+ * search — index rows whose file is gone are MARKED, never hidden (#876).
+ *
+ * The stale-row sweep only covered the two probes spliced into a bridge answer,
+ * which is the wrong way round for the failure it was written for: a stale index
+ * outlives a deleted file precisely when the bridge is silent, so the one answer
+ * made entirely of index rows was the one still reporting ghosts as fact.
+ *
+ * Sweeping that answer too is worse, and these tests pin why: `indexedPathIsMissing`
+ * fires for any PackagesLocalDirectory path with no file here, the shipped symbol
+ * index covers every standard package, and a machine installs a subset — so dropping
+ * those rows answers "no X++ symbols found" for most of D365FO on a partial install,
+ * in the tool every other workflow starts from. The row stays, says what it is, and
+ * ranks below the live ones.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockIndexedPathIsMissing = vi.fn(async (_p?: string | null) => false);
+vi.mock('../../src/utils/indexedXmlLookup', async (orig) => {
+  const actual = await orig<typeof import('../../src/utils/indexedXmlLookup')>();
+  return { ...actual, indexedPathIsMissing: (p?: string | null) => mockIndexedPathIsMissing(p) };
+});
+
+import { searchTool } from '../../src/tools/analysis/search';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'search', arguments: args },
+});
+
+const GHOST_PATH = 'K:\\PackagesLocalDirectory\\Contoso\\Contoso\\AxTable\\ConGhostTable.xml';
+const LIVE_PATH = 'K:\\PackagesLocalDirectory\\MyPkg\\MyModel\\AxTable\\ConLiveTable.xml';
+
+const sym = (name: string, filePath: string, type = 'table', model = 'Contoso') => ({
+  id: 1, name, type, parentName: undefined, signature: undefined, filePath, model,
+});
+
+/** No bridge — the index-only answer, which is the path under test. */
+const buildContext = (rows: any[]): XppServerContext => ({
+  symbolIndex: {
+    searchSymbols: vi.fn(() => rows),
+    searchCustomModelSymbols: vi.fn(() => []),
+    getAllSymbolNames: vi.fn(() => []),
+    getSymbolsByTerm: vi.fn(() => new Map()),
+    getCustomModels: vi.fn(() => ['Contoso']),
+    db: { prepare: vi.fn(() => ({ all: vi.fn(() => []), get: vi.fn(() => undefined) })) },
+    getReadDb: vi.fn(function (this: any) { return this.db; }),
+  } as any,
+  cache: {} as any,
+  parser: {} as any,
+  workspaceScanner: {} as any,
+  hybridSearch: {} as any,
+} as any);
+
+beforeEach(() => {
+  mockIndexedPathIsMissing.mockReset();
+  mockIndexedPathIsMissing.mockResolvedValue(false);
+});
+
+describe('index-only search answer', () => {
+  it('marks a row whose file is gone instead of dropping it', async () => {
+    mockIndexedPathIsMissing.mockImplementation(async (p) => p === GHOST_PATH);
+
+    const text = (await searchTool(
+      req({ query: 'ConGhostTable' }),
+      buildContext([sym('ConGhostTable', GHOST_PATH)]),
+    )).content[0].text as string;
+
+    // The hit is still reported — hiding it is what would answer "no such object".
+    expect(text).toContain('ConGhostTable');
+    expect(text).not.toContain('No X++ symbols found');
+    // …and it says what it is, both on the row and once in full.
+    expect(text).toContain('STALE index row');
+    expect(text).toMatch(/1 result marked STALE/);
+    expect(text).toContain('update_symbol_index');
+  });
+
+  it('ranks stale rows below live ones', async () => {
+    mockIndexedPathIsMissing.mockImplementation(async (p) => p === GHOST_PATH);
+
+    const text = (await searchTool(
+      req({ query: 'Con' }),
+      buildContext([sym('ConGhostTable', GHOST_PATH), sym('ConLiveTable', LIVE_PATH)]),
+    )).content[0].text as string;
+
+    expect(text.indexOf('ConLiveTable')).toBeLessThan(text.indexOf('ConGhostTable'));
+  });
+
+  it('says so on the exact-match line, where a caller acts without reading on', async () => {
+    mockIndexedPathIsMissing.mockImplementation(async (p) => p === GHOST_PATH);
+
+    const text = (await searchTool(
+      req({ query: 'ConGhostTable' }),
+      buildContext([sym('ConGhostTable', GHOST_PATH)]),
+    )).content[0].text as string;
+
+    const exactLine = text.split('\n').find(l => l.includes('Exact name match')) ?? '';
+    expect(exactLine).toContain('ConGhostTable');
+    expect(exactLine).toMatch(/STALE/);
+  });
+
+  it('keeps a partial install searchable — every row missing locally is still an answer', async () => {
+    // The shipped index covers every standard package; this machine has a subset.
+    // Sweeping here is what turned search("CustTable") into a no-match.
+    mockIndexedPathIsMissing.mockResolvedValue(true);
+
+    const result = await searchTool(
+      req({ query: 'CustTable' }),
+      buildContext([
+        sym('CustTable', 'K:\\PackagesLocalDirectory\\App\\Foundation\\AxTable\\CustTable.xml', 'table', 'Foundation'),
+        sym('CustTableType', 'K:\\PackagesLocalDirectory\\App\\Foundation\\AxClass\\CustTableType.xml', 'class', 'Foundation'),
+      ]),
+    );
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('Found 2 matches');
+    expect(text).toContain('CustTable');
+    expect(text).not.toContain('No X++ symbols found');
+    expect(text).toMatch(/2 results marked STALE/);
+  });
+
+  it('says nothing at all when every row is live', async () => {
+    const text = (await searchTool(
+      req({ query: 'ConLiveTable' }),
+      buildContext([sym('ConLiveTable', LIVE_PATH)]),
+    )).content[0].text as string;
+
+    expect(text).toContain('ConLiveTable');
+    expect(text).not.toMatch(/STALE/);
+  });
+});

--- a/tests/utils/blobDownloadMarker.test.ts
+++ b/tests/utils/blobDownloadMarker.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The note azure-blob-manager leaves for extract-metadata (#881).
+ *
+ * Both scripts write into OUTPUT_PATH/<model>/…, and the orphan sweep deletes every
+ * .json under a re-extracted model that the run did not write. For a model that is
+ * both blob-downloaded and locally re-extracted, "the blob had it, this disk does
+ * not" is indistinguishable from "deleted from the AOT". The precedence is intended;
+ * being unable to SAY so is what made it read as data loss.
+ *
+ * Two things have to hold: the marker survives a sweep (it is a .json file, so its
+ * location at the metadata root is load-bearing, not cosmetic), and an absent or
+ * corrupt marker degrades to "say nothing" rather than throwing inside a run summary.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  writeBlobDownloadMarker,
+  readBlobDownloadMarker,
+  BLOB_DOWNLOAD_MARKER_FILENAME,
+} from '../../src/utils/blobDownloadMarker';
+import { pruneOrphanedMetadata } from '../../scripts/extract-metadata';
+
+let outputPath: string;
+
+beforeEach(async () => {
+  outputPath = await fs.mkdtemp(path.join(os.tmpdir(), 'blob-marker-'));
+});
+
+afterEach(async () => {
+  await fs.rm(outputPath, { recursive: true, force: true });
+});
+
+describe('blob-download marker', () => {
+  it('round-trips what the extract run needs to name the interaction', () => {
+    writeBlobDownloadMarker(outputPath, {
+      downloadedAt: '2026-08-09T10:00:00.000Z',
+      modelType: 'custom',
+      models: ['ContosoFinanceSK', 'Contoso'],
+      fileCount: 1234,
+    });
+
+    const marker = readBlobDownloadMarker(outputPath);
+
+    expect(marker?.modelType).toBe('custom');
+    expect(marker?.models).toContain('ContosoFinanceSK');
+    expect(marker?.downloadedAt).toBe('2026-08-09T10:00:00.000Z');
+  });
+
+  it('says nothing when the metadata directory was never populated from blob storage', () => {
+    expect(readBlobDownloadMarker(outputPath)).toBeUndefined();
+  });
+
+  it('says nothing rather than throwing on a corrupt marker', async () => {
+    await fs.writeFile(path.join(outputPath, BLOB_DOWNLOAD_MARKER_FILENAME), '{ not json');
+    expect(readBlobDownloadMarker(outputPath)).toBeUndefined();
+  });
+
+  it('survives the orphan sweep', async () => {
+    // It is a .json file and the sweep deletes every .json a run did not write —
+    // it is only safe because it lives at the metadata ROOT, outside any model dir.
+    writeBlobDownloadMarker(outputPath, {
+      downloadedAt: '2026-08-09T10:00:00.000Z', modelType: 'all', models: ['ContosoFinanceSK'], fileCount: 1,
+    });
+    const orphan = path.join(outputPath, 'ContosoFinanceSK', 'enums', 'ConSK_QualityTier.json');
+    await fs.mkdir(path.dirname(orphan), { recursive: true });
+    await fs.writeFile(orphan, '{}');
+
+    const removed = await pruneOrphanedMetadata(outputPath, 'ContosoFinanceSK', new Set());
+
+    expect(removed).toContain('enums/ConSK_QualityTier.json');
+    expect(readBlobDownloadMarker(outputPath)).toBeDefined();
+  });
+});


### PR DESCRIPTION
Works the six open issues from the current-tree audit. One commit per issue.

### #876 — search: mark the ghosts, don't hide them
`dropStaleRows` swept the probes spliced into a *bridge* answer but not the index-only path served when the bridge is silent — the wrong way round, since a stale index outlives a deleted file precisely when the bridge says nothing.

Sweeping that path too is worse and stays rejected: `indexedPathIsMissing` fires for any PackagesLocalDirectory path with no file here, the shipped index covers every standard package, and a machine installs a subset, so it answers "no X++ symbols found" for most of D365FO on a partial install. Rows are now annotated, ranked below live ones, called out on the exact-match line, and the footer names *both* causes (deleted without a rebuild / package not installed here).

### #878 — `getModelObjectNames`: deterministic, two-band sample
No `ORDER BY` meant SQLite chose which 400 rows prefix inference saw. Inference is threshold-based and reads two bands (extensions state the infix, regular names carry the leading token), so an undefined window can drop every extension — silently, and self-reinforcingly, because this server writes names with the inferred prefix. Each band is now drawn separately, ordered `(type, name)`, capped at half the budget with the unused half handed back.

### #879 — enum create: name the rule, resolve the alias once
The comment described `useEnumValue:false`; the predicate actually fires for any resolved `UseEnumValue=No`, positional payloads included. Renamed and documented to say so.

The alias was a real defect, not untidiness: `values` was read by the routing predicate and the bridge but **not** by the TypeScript generator, so `values: [None=0, Silver=1]` routed *away* from the bridge and landed on a writer that could not see the list — `<EnumValues />`, reported as a clean ✅. Resolved once at the top of the handler. Test covers it.

### #880 — label batch: parallel, deduped, failures no longer swallowed
4 searches in flight instead of a serial loop; case/space-duplicate phrasings folded; `isError` read. A wholly failed batch used to return a clean report whose verdict was "no reusable label exists — create your own", indistinguishable from a real miss. It now says so and is itself `isError`; a partly failed batch keeps the verdict for the queries that ran and names the ones that did not.

### #881 — orphan sweep vs blob-downloaded metadata
Both scripts write into `OUTPUT_PATH/<model>/…`, so for a model that is both downloaded and locally re-extracted the sweep cannot tell "the blob had it, this disk does not" from "deleted from the AOT". The precedence is intended; being unable to say so is what made it read as data loss. The download now leaves a marker at the metadata root (outside every model dir, so the sweep can never eat it) and the prune summary names the interaction.

### #882 — VS side of "one element, several projects of one model"
Closed with evidence rather than code. The compiler side was already settled (`xppc` takes `-modelmodule`, no project-level input). The VS side was untestable on a VM with no `.rnrproj`; measured it on a machine that has one — a real 187-project ISV solution authored in VS over years lists **280 of its 1899 AOT elements in two or more projects of the same model** (92 classes, plus forms, tables, form/table extensions, security duties, EDTs — 20 element types). That solution's own build projects list no elements at all: they declare `<Model>` and let the build task compile the module, so packaging agrees with the compiler. Recorded in `registerFileInActiveProject`'s doc comment.

Not covered: driving the VS GUI to see whether it pops a warning when you interactively add an element to a second project. The corpus above answers the question that mattered — shared membership is routine in shipping code.

### Tests
`tests/tools + metadata + utils + workspace + scripts` → 210 files, 2657 passed. Each new test was confirmed red before its fix. Full-suite note: `tests/knowledge/apiSymbols.test.ts` times out under full-suite parallelism on this VM (live 2 GB DB) and passes standalone in 2.6 s — pre-existing contention, untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NonFe4P6afzEzam6bcXLhn