### PR TITLE
Index every label language, and stop reporting green without a compile

### DIFF
--- a/src/metadata/labelParser.ts
+++ b/src/metadata/labelParser.ts
@@ -240,7 +240,7 @@ export async function indexAllLabels(
   opts?: { ftsStrategy?: 'rebuild' | 'incremental' },
 ): Promise<{ totalLabels: number; modelsIndexed: number }> {
   // 'incremental' keeps the labels_fts triggers live so only the scanned models' labels are
-  // tokenised, instead of re-inserting every en-US label in the database afterwards. Only
+  // tokenised, instead of re-inserting every label in the database afterwards. Only
   // worth it when modelFilter narrows the scan to a small set (a custom-model build).
   const incrementalFts = opts?.ftsStrategy === 'incremental';
   let totalLabels = 0;

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -68,6 +68,14 @@ export class XppSymbolIndex {
   // their originating connection and cannot be shared across connections.
   private perConnStmtCache = new WeakMap<Database, Map<string, Statement>>();
 
+  /**
+   * Directory holding the metadata databases. Sibling marker files (the blob-download
+   * note, the last-build record) live here so they travel with the index they describe.
+   */
+  get dataDir(): string {
+    return path.dirname(this.dbPath);
+  }
+
   constructor(dbPath: string, labelsDbPath?: string) {
     this.dbPath = dbPath;
     // Ensure database directory exists
@@ -416,9 +424,15 @@ export class XppSymbolIndex {
       CREATE INDEX IF NOT EXISTS idx_labels_language ON labels(language);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_labels_unique
         ON labels(label_id, label_file_id, model, language);
+      -- Every language comparison in this file is LOWER(language) = LOWER(?), because
+      -- Microsoft packages unzipped on Linux store 'en-us' while custom packages write
+      -- 'en-US'. A plain index on language cannot serve that predicate, so the LIKE
+      -- fallback degraded to a scan of all four locales instead of one.
+      CREATE INDEX IF NOT EXISTS idx_labels_language_lower ON labels(LOWER(language));
     `);
 
-    // FTS5 full-text search for labels (en-US text only – primary search language)
+    // FTS5 full-text search for labels — every indexed language, not just en-US.
+    // See rebuildLabelsFts() for why the en-US-only index had to go.
     this.labelsDb.exec(`
       CREATE VIRTUAL TABLE IF NOT EXISTS labels_fts USING fts5(
         label_id,
@@ -430,6 +444,7 @@ export class XppSymbolIndex {
     `);
 
     this.createLabelsFtsTriggers();
+    this.migrateLabelsFtsLanguageCoverage();
 
     // Extended metadata tables for smart generation
 
@@ -873,16 +888,17 @@ export class XppSymbolIndex {
   /**
    * (Re)create the labels_fts sync triggers — the single definition of them.
    *
-   * The language test is LOWER(...) = 'en-us', never a literal comparison against
-   * 'en-US': Microsoft packages unzipped on Linux store the locale lowercased while
-   * custom packages write 'en-US', and a case-sensitive WHEN clause silently skips
-   * every lowercase row. Its effect is one-directional and therefore invisible until
-   * a search goes wrong — inserts never reach the index, and, worse, DELETEs never
-   * remove the entries a full rebuild had put there, so searchLabels keeps returning
-   * labels that no longer exist.
+   * There is deliberately no language filter here. The triggers used to carry
+   * `WHEN LOWER(language) = 'en-us'`, which kept the index one quarter of its size
+   * on a four-locale build but made every non-English search fall through to the
+   * LIKE scan in searchLabelsLike — measured at 152 s for a four-term `cs` query
+   * against a 1.4 M-row table, run synchronously on the event loop so the whole
+   * server stalled behind it. The rows are indexed; the space is the cheaper half
+   * of that trade. Whatever LABEL_LANGUAGES ingested is what gets tokenised, so a
+   * default en-US-only build is unaffected.
    *
    * Dropped and recreated (not CREATE-IF-NOT-EXISTS alone) so a database still
-   * carrying the earlier case-sensitive definitions is repaired on the next open —
+   * carrying the earlier language-filtered definitions is repaired on the next open —
    * mirrors createFTSTriggers on the symbols side.
    */
   private createLabelsFtsTriggers(): void {
@@ -891,23 +907,63 @@ export class XppSymbolIndex {
       DROP TRIGGER IF EXISTS labels_ad;
       DROP TRIGGER IF EXISTS labels_au;
 
-      CREATE TRIGGER labels_ai AFTER INSERT ON labels WHEN LOWER(new.language) = 'en-us' BEGIN
+      CREATE TRIGGER labels_ai AFTER INSERT ON labels BEGIN
         INSERT INTO labels_fts(rowid, label_id, text, comment)
         VALUES (new.id, new.label_id, new.text, new.comment);
       END;
 
-      CREATE TRIGGER labels_ad AFTER DELETE ON labels WHEN LOWER(old.language) = 'en-us' BEGIN
+      CREATE TRIGGER labels_ad AFTER DELETE ON labels BEGIN
         INSERT INTO labels_fts(labels_fts, rowid, label_id, text, comment)
         VALUES ('delete', old.id, old.label_id, old.text, old.comment);
       END;
 
-      CREATE TRIGGER labels_au AFTER UPDATE ON labels WHEN LOWER(old.language) = 'en-us' OR LOWER(new.language) = 'en-us' BEGIN
+      CREATE TRIGGER labels_au AFTER UPDATE ON labels BEGIN
         INSERT INTO labels_fts(labels_fts, rowid, label_id, text, comment)
         VALUES ('delete', old.id, old.label_id, old.text, old.comment);
         INSERT INTO labels_fts(rowid, label_id, text, comment)
         VALUES (new.id, new.label_id, new.text, new.comment);
       END;
     `);
+  }
+
+  /**
+   * Databases built before labels_fts covered every language carry an index holding
+   * only en-US rows. Recreating the triggers fixes rows written from now on but
+   * cannot retroactively tokenise the ones already there, so the non-English search
+   * would stay silently empty until the next full rebuild — exactly the failure this
+   * change exists to remove.
+   *
+   * `PRAGMA user_version` on the labels DB records the coverage generation. It is 0
+   * on every database that predates this, so the one-time rebuild is self-triggering
+   * and costs nothing on an already-migrated file.
+   */
+  private migrateLabelsFtsLanguageCoverage(): void {
+    const LABELS_FTS_ALL_LANGUAGES = 1;
+    try {
+      const version = Number(this.labelsDb.pragma('user_version', { simple: true }) ?? 0);
+      if (version >= LABELS_FTS_ALL_LANGUAGES) return;
+
+      // An empty labels table needs no rebuild — a fresh DB is already correct, and
+      // stamping it here keeps the first real build off the slow path.
+      const { n } = this.labelsDb
+        .prepare('SELECT COUNT(*) AS n FROM labels')
+        .get() as { n: number };
+      if (n > 0) {
+        // Measured at ~23 s for 1.4 M labels, and it blocks startup. Announced rather
+        // than done quietly, because a silent 23 s stall reads as a hung server.
+        log.detail(
+          `Re-tokenising ${n.toLocaleString('en-US')} labels so every language is searchable (one-off, ~20 s)…`,
+        );
+        this.rebuildLabelsFts();
+      }
+      this.labelsDb.pragma(`user_version = ${LABELS_FTS_ALL_LANGUAGES}`);
+    } catch (e) {
+      // A read-only file, or a writer holding the lock, must not take the server down.
+      // Leaving user_version unstamped means the next open retries; until then the
+      // non-English searches fall back to searchLabelsLike — the old behaviour, slow
+      // but correct.
+      console.error(`[SymbolIndex] labels_fts language migration skipped: ${e}`);
+    }
   }
 
   /**
@@ -1095,7 +1151,7 @@ export class XppSymbolIndex {
   removeLabelsByFile(filePath: string): number {
     const forms = this.filePathForms(filePath);
     const placeholders = forms.map(() => '?').join(', ');
-    // The labels_ad trigger handles FTS cleanup for en-US rows
+    // The labels_ad trigger handles FTS cleanup, for every language
     const result = this.labelsDb.prepare(
       `DELETE FROM labels WHERE file_path COLLATE NOCASE IN (${placeholders})`
     ).run(...forms);
@@ -3835,7 +3891,7 @@ export class XppSymbolIndex {
     const keepTriggers = !!opts?.keepTriggers;
     if (keepTriggers) {
       // Scoped/incremental insert: let the triggers maintain labels_fts per row instead of
-      // re-tokenising every en-US label afterwards. Recursive triggers are required so the
+      // re-tokenising every label in the database afterwards. Recursive triggers are required so the
       // rows displaced by INSERT OR REPLACE fire labels_ad and don't leave orphaned FTS
       // entries pointing at dead rowids.
       this.labelsDb.pragma('recursive_triggers = ON');
@@ -3880,18 +3936,22 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Rebuild the FTS index for labels from scratch.
-   * Only indexes en-US rows — the primary search language — keeping the
-   * index ~(N_languages)x smaller compared to indexing all translations.
+   * Rebuild the FTS index for labels from scratch — every row in `labels`, whatever
+   * its language.
+   *
+   * This used to filter to en-US on the theory that it was "the primary search
+   * language", which held only as long as nobody searched in another one. On a build
+   * with LABEL_LANGUAGES=en-US,cs,sk,de the other three quarters were unreachable
+   * through the index, and searchLabels quietly answered them with a LIKE scan of
+   * the whole table instead. The index is ~4x larger on such a build; the alternative
+   * was a 150 s query.
    */
   rebuildLabelsFts(): void {
     // Clear existing FTS index
     this.labelsDb.exec(`INSERT INTO labels_fts(labels_fts) VALUES('delete-all')`);
-    // Re-populate with en-US rows only (case-insensitive: Microsoft packages store
-    // locale as 'en-us' from Linux-unzipped directory names, custom packages use 'en-US')
     this.labelsDb.exec(`
       INSERT INTO labels_fts(rowid, label_id, text, comment)
-      SELECT id, label_id, text, comment FROM labels WHERE LOWER(language) = 'en-us'
+      SELECT id, label_id, text, comment FROM labels
     `);
   }
 
@@ -3927,7 +3987,10 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Full-text search labels (default language: en-US, falls back to any)
+   * Full-text search labels within one language (default en-US).
+   *
+   * Answered from labels_fts, which covers every indexed locale. Only queries FTS5
+   * cannot tokenise fall through to the LIKE scan in searchLabelsLike.
    */
   searchLabels(
     query: string,
@@ -3944,25 +4007,18 @@ export class XppSymbolIndex {
   }> {
     const { language = 'en-US', model, labelFileId, limit = 30 } = opts;
 
-    // labels_fts only indexes en-US rows. For any other language, skip straight to
-    // LIKE-based search — attempting FTS would always produce 0 results and then
-    // fall through to LIKE anyway, wasting two round-trips.
-    // Compare case-insensitively: callers pass variants like 'en-us', and a
-    // false mismatch here degrades to a LIKE full scan of the labels table
-    // (200+ s on a production DB, synchronously blocking the event loop).
-    if (language.toLowerCase() !== 'en-us') {
-      return this.searchLabelsLike(query, opts);
-    }
-
     // Sanitize query for FTS5 (strip chars that would cause a syntax error)
     const ftsQuery = query.replace(/['"*()]/g, ' ').trim();
     // Route to LIKE when FTS5 would silently return 0 results:
     // • '_' and '%' — word separators in the unicode61 tokenizer (also LIKE wildcards);
     //   literal underscore/percent searches must go through LIKE with proper escaping.
-    // • Any query whose alphanumeric content disappears after sanitization (e.g. '-',
+    // • Any query whose letter/digit content disappears after sanitization (e.g. '-',
     //   '.', '@', ':', '@SYS:') produces zero FTS5 tokens and no exception to trigger
     //   the catch-based fallback below.
-    if (/[_%]/.test(query) || !/[a-zA-Z0-9]/.test(ftsQuery)) {
+    //   The test is Unicode-aware on purpose: unicode61 tokenises 'Přístup' and
+    //   'Qualität' perfectly well, and an [a-zA-Z0-9] test would have shunted any
+    //   query without ASCII letters onto the LIKE scan this method exists to avoid.
+    if (/[_%]/.test(query) || !/[\p{L}\p{N}]/u.test(ftsQuery)) {
       return this.searchLabelsLike(query, opts);
     }
 
@@ -3970,13 +4026,17 @@ export class XppSymbolIndex {
     const stmtKey = `searchLabels_${model ? 'model' : 'nomodel'}_${labelFileId ? 'lfid' : 'nolfid'}`;
     let stmt = this.labelsStmtCache.get(stmtKey);
     if (!stmt) {
+      // The language predicate is not optional. labels_fts now holds every locale,
+      // so without it a `cs` search happily returns the en-US and de rows that share
+      // a token — the index no longer does the filtering the caller assumed.
       let sql = `
         SELECT l.label_id AS labelId, l.label_file_id AS labelFileId, l.model, l.language,
                l.text, l.comment, l.file_path AS filePath,
                f.rank
         FROM labels_fts f
         JOIN labels l ON l.id = f.rowid
-        WHERE labels_fts MATCH ?`;
+        WHERE labels_fts MATCH ?
+          AND LOWER(l.language) = ?`;
       if (model)       sql += `\n          AND l.model = ?`;
       if (labelFileId) sql += `\n          AND l.label_file_id = ?`;
       sql += `\n          ORDER BY f.rank\n          LIMIT ?`;
@@ -3984,7 +4044,7 @@ export class XppSymbolIndex {
       this.labelsStmtCache.set(stmtKey, stmt);
     }
 
-    const params: any[] = [ftsQuery];
+    const params: any[] = [ftsQuery, language.toLowerCase()];
     if (model)       params.push(model);
     if (labelFileId) params.push(labelFileId);
     params.push(limit);
@@ -3998,7 +4058,14 @@ export class XppSymbolIndex {
   }
 
   /**
-   * LIKE-based fallback label search (for queries with special characters)
+   * LIKE-based fallback label search, for the queries FTS5 cannot tokenise
+   * (literal '_'/'%', or nothing but punctuation once sanitised).
+   *
+   * A leading-wildcard LIKE cannot use an index, so this scans the labels table.
+   * The language predicate is written to hit idx_labels_language_lower, which keeps
+   * the scan inside one locale instead of all of them; there is no way to make the
+   * text comparison itself cheaper here, which is exactly why the FTS path above now
+   * covers every language rather than only en-US.
    */
   private searchLabelsLike(
     query: string,
@@ -4018,7 +4085,7 @@ export class XppSymbolIndex {
                text, comment, file_path AS filePath, 0 as rank
         FROM labels
         WHERE (text LIKE ? ESCAPE '\\' OR label_id LIKE ? ESCAPE '\\')
-          AND LOWER(language) = LOWER(?)`;
+          AND LOWER(language) = ?`;
       if (model)       sql += `\n          AND model = ?`;
       if (labelFileId) sql += `\n          AND label_file_id = ?`;
       sql += `\n        LIMIT ?`;
@@ -4026,7 +4093,9 @@ export class XppSymbolIndex {
       this.labelsStmtCache.set(stmtKey, stmt);
     }
 
-    const params: any[] = [pattern, pattern, language];
+    // Lowercased here, not as LOWER(?) in SQL: the expression index is on
+    // LOWER(language), and matching it requires the bound side to be a plain value.
+    const params: any[] = [pattern, pattern, language.toLowerCase()];
     if (model)       params.push(model);
     if (labelFileId) params.push(labelFileId);
     params.push(limit);
@@ -4125,7 +4194,7 @@ export class XppSymbolIndex {
     const placeholders = models.map(() => '?').join(',');
     this.labelsDb.prepare(`DELETE FROM labels WHERE model IN (${placeholders})`).run(...models);
     // 'incremental': the labels_ad trigger already dropped each deleted row from labels_fts,
-    // so the full delete-all + re-INSERT of every en-US label (O(all labels)) is pure waste
+    // so the full delete-all + re-INSERT of every label (O(all labels)) is pure waste
     // when only a handful of models were cleared.
     if (opts?.ftsStrategy !== 'incremental') this.rebuildLabelsFts();
   }

--- a/src/tools/analysis/validateObjectNaming.ts
+++ b/src/tools/analysis/validateObjectNaming.ts
@@ -7,38 +7,107 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../../types/context.js';
+import { getObjectSuffix, getExtensionNamingStyle, deriveExtensionInfix } from '../../utils/modelClassifier.js';
 import {
-  getObjectSuffix, getExtensionNamingStyle, deriveExtensionInfix,
-} from '../../utils/modelClassifier.js';
-import {
-  matchPrefixCandidate, modelWritesLandIn, prefixCandidates, prefixConflictWarning,
-  resolveEffectivePrefix, type PrefixCandidate,
+  matchPrefixCandidate,
+  modelWritesLandIn,
+  prefixCandidates,
+  prefixConflictWarning,
+  resolveEffectivePrefix,
+  type PrefixCandidate,
 } from '../../utils/effectivePrefix.js';
 import { getConfigManager } from '../../utils/configManager.js';
 import { lookupSymbolNocase, lookupSymbolsNocase } from '../../utils/symbolLookup.js';
 
 const ValidateObjectNamingArgsSchema = z.object({
   proposedName: z.string().describe('The proposed object name to validate'),
-  objectType: z.enum([
-    'class', 'table', 'form', 'enum', 'edt', 'query', 'view',
-    'table-extension', 'class-extension', 'form-extension',
-    'enum-extension', 'edt-extension',
-    'menu-item', 'security-privilege', 'security-duty', 'security-role',
-    'data-entity',
-  ]).describe('Type of the D365FO object'),
-  baseObjectName: z.string().optional()
-    .describe('Required for extension types: name of the object being extended'),
-  modelPrefix: z.string().optional()
+  objectType: z
+    .enum([
+      'class',
+      'table',
+      'form',
+      'enum',
+      'edt',
+      'query',
+      'view',
+      'table-extension',
+      'class-extension',
+      'form-extension',
+      'enum-extension',
+      'edt-extension',
+      'menu-item',
+      'security-privilege',
+      'security-duty',
+      'security-role',
+      'data-entity',
+    ])
+    .describe('Type of the D365FO object'),
+  baseObjectName: z.string().optional().describe('Required for extension types: name of the object being extended'),
+  modelPrefix: z
+    .string()
+    .optional()
     .describe('Expected ISV/model prefix (2-4 uppercase letters, e.g. "WHS", "CONT"). Auto-detected if omitted.'),
-  modelName: z.string().optional()
-    .describe('Target model name. Only relevant when EXTENSION_NAMING_STYLE=model-name, where the extension token is the model name (e.g. CustTable_ContosoRobotics_Extension). Auto-detected from the active workspace if omitted.'),
+  modelName: z
+    .string()
+    .optional()
+    .describe(
+      'Target model name. Only relevant when EXTENSION_NAMING_STYLE=model-name, where the extension token is the model name (e.g. CustTable_ContosoRobotics_Extension). Auto-detected from the active workspace if omitted.',
+    ),
 });
 
 // Extension types that require base object name
 const EXTENSION_TYPES = new Set([
-  'table-extension', 'class-extension', 'form-extension',
-  'enum-extension', 'edt-extension',
+  'table-extension',
+  'class-extension',
+  'form-extension',
+  'enum-extension',
+  'edt-extension',
 ]);
+
+/** Non-extension type → the extension type that extends it. */
+const EXTENSION_COUNTERPART: Record<string, string> = {
+  table: 'table-extension',
+  class: 'class-extension',
+  form: 'form-extension',
+  enum: 'enum-extension',
+  edt: 'edt-extension',
+};
+
+/**
+ * A name that can only be an extension: `Base.PrefixExtension` (element extensions) or
+ * `BasePrefix_Extension` (class CoC).
+ */
+const DOTTED_EXTENSION = /^[A-Za-z]\w*\.\w*Extension$/;
+const UNDERSCORE_EXTENSION = /^[A-Za-z]\w*_Extension$/;
+
+/**
+ * Reinterpret `objectType` when the proposed name is unmistakably an extension.
+ *
+ * Callers reach for the base type — "is this a valid *form* name?" — while proposing
+ * `AslFinCore_TaxTransReportChangeLog.AslFinSKExtension`. Validated as a plain form
+ * that trips the "non-extension objects must not contain underscores" rule and comes
+ * back as a hard ERROR, which is both wrong and a wasted round trip: run f2e7b71a
+ * asked with `form`, was refused, and asked again with `form-extension` (T56 → T59).
+ *
+ * Only the shapes above qualify, so a genuinely bad non-extension name — the case the
+ * underscore rule exists for — still fails.
+ */
+function reinterpretExtensionType(
+  objectType: string,
+  proposedName: string,
+): { objectType: string; note: string } | undefined {
+  const counterpart = EXTENSION_COUNTERPART[objectType];
+  if (!counterpart) return undefined;
+  const dotted = DOTTED_EXTENSION.test(proposedName);
+  const underscored = objectType === 'class' && UNDERSCORE_EXTENSION.test(proposedName);
+  if (!dotted && !underscored) return undefined;
+  return {
+    objectType: counterpart,
+    note:
+      `Read as **${counterpart}**, not "${objectType}" — "${proposedName}" is an extension name. ` +
+      `Pass objectType="${counterpart}" directly next time.`,
+  };
+}
 
 export async function validateObjectNamingTool(request: CallToolRequest, context: XppServerContext) {
   try {
@@ -50,15 +119,33 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
     const suggestions: string[] = [];
 
     const name = args.proposedName;
+
+    // Before any rule runs: an extension name asked about under its base type is a
+    // question about the extension. Answer that question instead of refusing.
+    const reinterpreted = reinterpretExtensionType(args.objectType, name);
+    if (reinterpreted) {
+      args.objectType = reinterpreted.objectType as typeof args.objectType;
+      // The base is the part before the dot; supplying it here keeps the
+      // "baseObjectName is required for extension types" check from firing on a
+      // name that spells its base out.
+      if (!args.baseObjectName && name.includes('.')) {
+        args.baseObjectName = name.slice(0, name.indexOf('.'));
+      }
+    }
+
     const isExtension = EXTENSION_TYPES.has(args.objectType);
 
     // D365FO has a hard 81-character limit on AOT names; exceeding it is a build error.
     const MAX_NAME_LENGTH = 81;
     if (name.length > MAX_NAME_LENGTH) {
-      errors.push(`Name "${name}" is ${name.length} characters — exceeds the D365FO AOT maximum of ${MAX_NAME_LENGTH} characters. This will cause a build error.`);
+      errors.push(
+        `Name "${name}" is ${name.length} characters — exceeds the D365FO AOT maximum of ${MAX_NAME_LENGTH} characters. This will cause a build error.`,
+      );
       suggestions.push(`Shortened name (${MAX_NAME_LENGTH} chars max): ${name.slice(0, MAX_NAME_LENGTH)}`);
     } else if (name.length > 70) {
-      warnings.push(`Name is ${name.length} characters — approaching the ${MAX_NAME_LENGTH}-char AOT limit. Consider a shorter name to leave room for extensions.`);
+      warnings.push(
+        `Name is ${name.length} characters — approaching the ${MAX_NAME_LENGTH}-char AOT limit. Consider a shorter name to leave room for extensions.`,
+      );
     }
 
     // The model whose convention is being validated against: explicit arg, else the
@@ -71,8 +158,10 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
     await configManager.getAutoDetectedModelName();
     const activeModel = configManager.getModelName();
     const namingStyle = getExtensionNamingStyle();
-    const modelName = args.modelName?.trim() ||
-      modelWritesLandIn(configManager.getWriteAnchorModel() ?? activeModel, activeModel) || '';
+    const modelName =
+      args.modelName?.trim() ||
+      modelWritesLandIn(configManager.getWriteAnchorModel() ?? activeModel, activeModel) ||
+      '';
     const useModelName = namingStyle === 'model-name' && !!modelName;
 
     // Resolve model prefix: explicit arg → the effective prefix for that model
@@ -119,7 +208,9 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
           const expectedToken = useModelName ? modelName : extensionInfix;
 
           if (!name.startsWith(baseObjectName)) {
-            errors.push(`Class extension names must start with the base class name.\n  Expected format: ${expectedPattern}`);
+            errors.push(
+              `Class extension names must start with the base class name.\n  Expected format: ${expectedPattern}`,
+            );
             if (expectedToken) suggestions.push(`Correct name: ${expectedPattern}`);
           } else if (!name.endsWith('_Extension')) {
             errors.push(`Class extension names must end with '_Extension'.\n  Expected format: ${expectedPattern}`);
@@ -128,13 +219,15 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
             // Structure is correct — check the expected token is included. Strip a leading
             // separator so "_ContosoRobotics" compares cleanly to the model name.
             const middle = name.slice(baseObjectName.length, -'_Extension'.length).replace(/^_+/, '');
-            if (expectedToken &&
-                middle.toLowerCase() !== expectedToken.toLowerCase() &&
-                !middle.toLowerCase().includes(expectedToken.toLowerCase())) {
+            if (
+              expectedToken &&
+              middle.toLowerCase() !== expectedToken.toLowerCase() &&
+              !middle.toLowerCase().includes(expectedToken.toLowerCase())
+            ) {
               warnings.push(
                 useModelName
                   ? `Extension name does not embed the model name "${modelName}" (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${name}\n  Recommended: ${expectedPattern}`
-                  : `Extension name does not include model "${modelName || '(unknown)'}"'s extension infix "${extensionInfix}".\n  Current: ${name}\n  Recommended: ${expectedPattern}`
+                  : `Extension name does not include model "${modelName || '(unknown)'}"'s extension infix "${extensionInfix}".\n  Current: ${name}\n  Recommended: ${expectedPattern}`,
               );
             }
           }
@@ -142,60 +235,79 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
           suggestions.push(
             useModelName
               ? `AOT name for an element extension instead: ${baseObjectName}.${modelName}`
-              : `AOT label for extension file: ${baseObjectName}.${extensionInfix}Extension (if creating table-extension AOT object instead)`
+              : `AOT label for extension file: ${baseObjectName}.${extensionInfix}Extension (if creating table-extension AOT object instead)`,
           );
-
         } else if (useModelName) {
           // AOT extensions (table/form/enum/edt), model-name style: {Base}.{ModelName} — bare model
           // name, no "Extension" word.
           const expectedPattern = `${baseObjectName}.${modelName}`;
 
           if (!name.includes('.')) {
-            errors.push(`${args.objectType} names must use dot notation: {Base}.{ModelName}.\n  Expected: ${expectedPattern}`);
+            errors.push(
+              `${args.objectType} names must use dot notation: {Base}.{ModelName}.\n  Expected: ${expectedPattern}`,
+            );
             suggestions.push(`Correct name: ${expectedPattern}`);
           } else {
             const [basePart, extPart] = name.split('.', 2);
 
             if (basePart !== baseObjectName) {
-              errors.push(`Extension base (before '.') must exactly match baseObjectName.\n  Expected: ${baseObjectName}.xxx\n  Got: ${basePart}.xxx`);
+              errors.push(
+                `Extension base (before '.') must exactly match baseObjectName.\n  Expected: ${baseObjectName}.xxx\n  Got: ${basePart}.xxx`,
+              );
             }
             if (extPart.toLowerCase() !== modelName.toLowerCase()) {
-              warnings.push(`Extension token (after '.') should be the model name "${modelName}" (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${extPart}\n  Recommended: ${modelName}`);
+              warnings.push(
+                `Extension token (after '.') should be the model name "${modelName}" (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${extPart}\n  Recommended: ${modelName}`,
+              );
             }
           }
-
         } else {
           // AOT extensions (table/form/enum/edt), prefix style: {Base}.{Infix}Extension.
           const expectedPattern = `${baseObjectName}.${extensionInfix}Extension`;
 
           if (!name.includes('.')) {
-            errors.push(`${args.objectType} names must use dot notation: {Base}.{Prefix}Extension.\n  Expected: ${expectedPattern}`);
+            errors.push(
+              `${args.objectType} names must use dot notation: {Base}.{Prefix}Extension.\n  Expected: ${expectedPattern}`,
+            );
             if (prefix) suggestions.push(`Correct name: ${expectedPattern}`);
           } else {
             const [basePart, extPart] = name.split('.', 2);
 
             if (basePart !== baseObjectName) {
-              errors.push(`Extension base (before '.') must exactly match baseObjectName.\n  Expected: ${baseObjectName}.xxx\n  Got: ${basePart}.xxx`);
+              errors.push(
+                `Extension base (before '.') must exactly match baseObjectName.\n  Expected: ${baseObjectName}.xxx\n  Got: ${basePart}.xxx`,
+              );
             }
             if (!extPart.endsWith('Extension')) {
-              errors.push(`Extension suffix (after '.') must end with 'Extension'.\n  Expected: ${extensionInfix}Extension\n  Got: ${extPart}`);
+              errors.push(
+                `Extension suffix (after '.') must end with 'Extension'.\n  Expected: ${extensionInfix}Extension\n  Got: ${extPart}`,
+              );
             } else if (extensionInfix && !extPart.toLowerCase().startsWith(extensionInfix.toLowerCase())) {
-              warnings.push(`Extension suffix should start with model "${modelName || '(unknown)'}"'s infix "${extensionInfix}".\n  Current: ${extPart}\n  Recommended: ${extensionInfix}Extension`);
+              warnings.push(
+                `Extension suffix should start with model "${modelName || '(unknown)'}"'s infix "${extensionInfix}".\n  Current: ${extPart}\n  Recommended: ${extensionInfix}Extension`,
+              );
             }
           }
         }
 
-        const dbTypes = args.objectType.includes('class') ? ['class'] :
-          args.objectType.includes('table') ? ['table'] :
-          args.objectType.includes('form') ? ['form'] :
-          args.objectType.includes('enum') ? ['enum'] : ['edt'];
+        const dbTypes = args.objectType.includes('class')
+          ? ['class']
+          : args.objectType.includes('table')
+            ? ['table']
+            : args.objectType.includes('form')
+              ? ['form']
+              : args.objectType.includes('enum')
+                ? ['enum']
+                : ['edt'];
 
         // Case-insensitive: the base object may be spelled with different casing
         // than the canonical AOT name (#686).
         const baseExists = lookupSymbolNocase(db, baseObjectName, dbTypes);
 
         if (!baseExists) {
-          warnings.push(`Base object "${baseObjectName}" not found in symbol index for types: ${dbTypes.join(', ')}. Ensure it's indexed.`);
+          warnings.push(
+            `Base object "${baseObjectName}" not found in symbol index for types: ${dbTypes.join(', ')}. Ensure it's indexed.`,
+          );
         }
       }
     }
@@ -219,23 +331,24 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
         if (!separator) {
           errors.push(
             `Non-extension objects must not contain underscores. ` +
-            `The only allowed underscore is as a prefix separator: ` +
-            `${prefix ? prefix + '_MyObject' : 'Prefix_MyObject'}. ` +
-            `For extension classes use: VendTable${prefix || 'Prefix'}_Extension.`
+              `The only allowed underscore is as a prefix separator: ` +
+              `${prefix ? prefix + '_MyObject' : 'Prefix_MyObject'}. ` +
+              `For extension classes use: VendTable${prefix || 'Prefix'}_Extension.`,
           );
         }
       }
 
       if (prefix) {
-        const leading = separator ??
-          candidates.find(c => name.toLowerCase().startsWith(c.token.toLowerCase()));
+        const leading = separator ?? candidates.find(c => name.toLowerCase().startsWith(c.token.toLowerCase()));
         if (!leading) {
-          warnings.push(`Proposed name does not start with model prefix "${prefix}". All custom objects should be prefixed to avoid conflicts.`);
+          warnings.push(
+            `Proposed name does not start with model prefix "${prefix}". All custom objects should be prefixed to avoid conflicts.`,
+          );
           suggestions.push(`Prefixed name: ${prefix}${name}`);
         } else if (!leading.effective) {
           warnings.push(
             `"${name}" carries "${leading.token}" (${leading.label}), not the prefix this server ` +
-            `applies, "${prefix}" (${resolution.source}).`
+              `applies, "${prefix}" (${resolution.source}).`,
           );
         }
       }
@@ -243,20 +356,26 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
       const configuredSuffix = getObjectSuffix();
       if (configuredSuffix) {
         if (!name.toLowerCase().endsWith(configuredSuffix.toLowerCase())) {
-          warnings.push(`EXTENSION_SUFFIX="${configuredSuffix}" is configured but the proposed name does not end with it. Expected: ${name}${configuredSuffix}`);
+          warnings.push(
+            `EXTENSION_SUFFIX="${configuredSuffix}" is configured but the proposed name does not end with it. Expected: ${name}${configuredSuffix}`,
+          );
           suggestions.push(`Suffixed name: ${name}${configuredSuffix}`);
         }
       }
 
       if (args.objectType === 'security-privilege') {
         if (!/(View|Maintain|Delete|Admin|Invoke|Approve|FullControl)$/.test(name)) {
-          warnings.push(`Security privileges typically end with an action suffix: View, Maintain, Delete, Admin, Invoke, Approve, or FullControl.\n  Examples: ${name}View, ${name}Maintain`);
+          warnings.push(
+            `Security privileges typically end with an action suffix: View, Maintain, Delete, Admin, Invoke, Approve, or FullControl.\n  Examples: ${name}View, ${name}Maintain`,
+          );
         }
       }
 
       if (args.objectType === 'security-duty') {
-        if (!/(Maintain|View|Inquire|Admin|Approve|Process)$/.test(name) &&
-            !(name.toLowerCase().includes('maintain') || name.toLowerCase().includes('view'))) {
+        if (
+          !/(Maintain|View|Inquire|Admin|Approve|Process)$/.test(name) &&
+          !(name.toLowerCase().includes('maintain') || name.toLowerCase().includes('view'))
+        ) {
           warnings.push(`Security duties typically end with: Maintain, View, Inquire, Admin, Approve, or Process.`);
         }
       }
@@ -276,13 +395,20 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
     if (conflictWarning) warnings.push(conflictWarning);
 
     // Rule set 3: conflict detection
-    const dbType = args.objectType === 'class-extension' ? 'class-extension' :
-      args.objectType === 'table-extension' ? 'table-extension' :
-      args.objectType === 'form-extension' ? 'form-extension' :
-      args.objectType === 'enum-extension' ? 'enum-extension' :
-      args.objectType === 'edt-extension' ? 'edt-extension' :
-      args.objectType === 'data-entity' ? 'view' :
-      args.objectType;
+    const dbType =
+      args.objectType === 'class-extension'
+        ? 'class-extension'
+        : args.objectType === 'table-extension'
+          ? 'table-extension'
+          : args.objectType === 'form-extension'
+            ? 'form-extension'
+            : args.objectType === 'enum-extension'
+              ? 'enum-extension'
+              : args.objectType === 'edt-extension'
+                ? 'edt-extension'
+                : args.objectType === 'data-entity'
+                  ? 'view'
+                  : args.objectType;
 
     // AOT names are case-insensitive, so an existing object differing only in
     // casing IS a conflict — a case-sensitive probe here reported a false
@@ -290,11 +416,12 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
     // field sharing the name is not an AOT naming conflict.
     const exactConflict = lookupSymbolsNocase(db, name, { limit: 5 });
 
-    const similarSymbols = db.prepare(
-      `SELECT name, type, model FROM symbols WHERE name LIKE ? AND type = ? ORDER BY name LIMIT 5`
-    ).all(`${name.slice(0, Math.max(4, name.length - 3))}%`, dbType) as any[];
+    const similarSymbols = db
+      .prepare(`SELECT name, type, model FROM symbols WHERE name LIKE ? AND type = ? ORDER BY name LIMIT 5`)
+      .all(`${name.slice(0, Math.max(4, name.length - 3))}%`, dbType) as any[];
 
     let output = `Validation: "${name}" as ${args.objectType}\n`;
+    if (reinterpreted) output += `ℹ️ ${reinterpreted.note}\n`;
     if (args.baseObjectName) output += `Base Object: ${args.baseObjectName}\n`;
     if (prefix) {
       // The origin comes along, because the same prefix line in get_workspace_info
@@ -389,17 +516,34 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
  * Looks for 2-4 char prefix shared by many objects in the index.
  */
 function detectModelPrefix(db: any, proposedName: string): string {
-  const stdPrefixes = ['Cust', 'Vend', 'Sales', 'Purch', 'Ledger', 'Invent', 'Proj', 'WHS',
-    'Sma', 'MCR', 'Retail', 'Ax', 'Sys', 'Global', 'Common', 'Tax', 'Bank'];
+  const stdPrefixes = [
+    'Cust',
+    'Vend',
+    'Sales',
+    'Purch',
+    'Ledger',
+    'Invent',
+    'Proj',
+    'WHS',
+    'Sma',
+    'MCR',
+    'Retail',
+    'Ax',
+    'Sys',
+    'Global',
+    'Common',
+    'Tax',
+    'Bank',
+  ];
   for (const p of stdPrefixes) {
     if (proposedName.startsWith(p)) return '';
   }
 
   try {
     const prefix3 = proposedName.slice(0, 3).toUpperCase();
-    const sample = db.prepare(
-      `SELECT name FROM symbols WHERE type = 'class' AND name LIKE ? LIMIT 20`
-    ).all(`${prefix3}%`) as any[];
+    const sample = db
+      .prepare(`SELECT name FROM symbols WHERE type = 'class' AND name LIKE ? LIMIT 20`)
+      .all(`${prefix3}%`) as any[];
 
     if (sample.length >= 3) return prefix3;
 

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -14,10 +14,12 @@
  *   COC001  Default param value copied into CoC wrapper signature
  *   COC002  [ExtensionOf] class not declared final
  *   COC003  [ExtensionOf] class name not ending _Extension
+ *   COC004  next not reached exactly once and unconditionally (SYS10028)
  *   BP001   Hardcoded string literal in info/warning/error/checkFailed
  *   BP002   doInsert/doUpdate/doDelete outside explicit migration comment
  *   BP003   Generic doc-comment (/// Foo class. / /// methodName.)
  *   BP004   Developer-only statements left in code (pause / print)
+ *   BP005   enum2str() in user-facing text (emits the symbol, never the translation)
  *   TTS001  Unbalanced ttsbegin / ttscommit
  *   XML001  AxTable XML missing an index with <AlternateKey>Yes</AlternateKey>
  *   XML006  AxTable elements out of canonical order (silently dropped by the AOT)
@@ -390,6 +392,162 @@ function checkExtensionOfNaming(code: string): ValidationViolation[] {
 }
 
 /**
+ * BP005 — enum2str() feeding user-facing text.
+ *
+ * enum2str returns the enum's symbolic NAME ('Gold'), never its <Label>, so a message
+ * built with it stays English on a Czech or Slovak client no matter how carefully the
+ * enum was labelled. The runtime API that resolves the translation is
+ * `new DictEnum(enumNum(MyEnum)).value2Label(enum2int(value))`.
+ *
+ * Scoped to the message builders (info/warning/error/checkFailed/strFmt) because
+ * enum2str is perfectly correct for a log line, a filename or a comparison key.
+ */
+function checkEnum2StrInMessage(code: string): ValidationViolation[] {
+  const violations: ValidationViolation[] = [];
+  const masked = maskStringsAndComments(code).split('\n');
+  const lines = code.split('\n');
+
+  masked.forEach((clean, i) => {
+    if (!/\benum2str\s*\(/.test(clean)) return;
+    if (!/\b(?:info|warning|error|checkFailed|strFmt)\s*\(/.test(clean)) return;
+    violations.push({
+      rule: 'BP005',
+      severity: 'warning',
+      line: i + 1,
+      excerpt: lines[i].trim(),
+      fix:
+        'enum2str() returns the symbolic name, not the label — this message stays English in every locale. ' +
+        'Use "new DictEnum(enumNum(MyEnum)).value2Label(enum2int(value))" to get the translated text.',
+    });
+  });
+
+  return violations;
+}
+
+/**
+ * COC004 — `next` not reached exactly once and unconditionally (compiler SYS10028).
+ *
+ * The X++ compiler rejects a CoC method whose `next` sits inside an `if`, is called
+ * twice, or can be skipped by an earlier `return`. It is the one CoC mistake that
+ * looks completely reasonable as ordinary X++ — `if (ret) { ret = next foo(); }` is
+ * how you would write a short-circuit anywhere else — and neither run_bp_check nor
+ * the reference checks catch it, because xppbp does not diagnose it and every symbol
+ * in the method resolves fine. Only a build did, which meant it was only ever found
+ * by whoever remembered to run one.
+ *
+ * Brace depths are counted on the masked copy, so a '{' inside a literal or a doc
+ * comment cannot shift the method boundaries.
+ */
+function checkCocNextUnconditional(code: string): ValidationViolation[] {
+  const violations: ValidationViolation[] = [];
+  if (!/\[ExtensionOf\s*\(/i.test(code)) return violations;
+
+  const lines = code.split('\n');
+  const masked = maskStringsAndComments(code).split('\n');
+  const METHOD_DECL =
+    /^\s*(?:(?:public|protected|private|internal|static|final|display|edit|server|client)\s+)*[A-Za-z_]\w*\s+([A-Za-z_]\w*)\s*\([^;]*\)\s*$/;
+
+  let depth = 0;
+  let classBodyDepth: number | null = null;
+  // The method currently being walked, if any.
+  let method: { name: string; bodyDepth: number; nexts: Array<{ line: number; excerpt: string; conditional: boolean }>; earlyReturn: number | null } | null = null;
+
+  const closeMethod = (): void => {
+    if (!method) return;
+    const { name, nexts, earlyReturn } = method;
+
+    for (const n of nexts) {
+      if (n.conditional) {
+        violations.push({
+          rule: 'COC004',
+          severity: 'error',
+          line: n.line,
+          excerpt: n.excerpt,
+          fix:
+            `"next ${name}" is inside a conditional block. The compiler rejects this with ` +
+            'SYS10028 "Call to \'next\' should be done only once and unconditionally". ' +
+            `Call it as the first statement instead — "ret = next ${name}();" — then apply the ` +
+            'business rule afterwards and use "ret = checkFailed(\'@Model:Label\')" to fail the write.',
+        });
+      }
+    }
+
+    if (nexts.length > 1) {
+      violations.push({
+        rule: 'COC004',
+        severity: 'error',
+        line: nexts[1].line,
+        excerpt: nexts[1].excerpt,
+        fix:
+          `"next ${name}" is called ${nexts.length} times in one CoC method; SYS10028 allows exactly one. ` +
+          'Store the single result in a local and reuse it.',
+      });
+    }
+
+    if (earlyReturn !== null && nexts.length > 0 && earlyReturn < nexts[0].line) {
+      violations.push({
+        rule: 'COC004',
+        severity: 'error',
+        line: earlyReturn,
+        excerpt: lines[earlyReturn - 1].trim(),
+        fix:
+          `This "return" can skip "next ${name}" below it, so the call is not unconditional (SYS10028). ` +
+          `Call "next ${name}" first, then let the rule decide the return value.`,
+      });
+    }
+
+    method = null;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const clean = masked[i] ?? '';
+    const depthAtLineStart = depth;
+
+    if (classBodyDepth === null && /\bclass\b/i.test(clean) && clean.includes('{')) {
+      classBodyDepth = depthAtLineStart + 1;
+    } else if (classBodyDepth === null && /\bclass\b/i.test(clean)) {
+      // Brace on the following line — the class body opens one deeper than here.
+      classBodyDepth = depthAtLineStart + 1;
+    }
+
+    if (method) {
+      const nextCall = new RegExp(`\\bnext\\s+${method.name}\\b`).exec(clean);
+      if (nextCall) {
+        method.nexts.push({
+          line: i + 1,
+          excerpt: lines[i].trim(),
+          // Deeper than the method body means it sits inside if/while/switch/try;
+          // the same-line form "if (ret) ret = next foo();" never opens a block.
+          conditional: depthAtLineStart > method.bodyDepth || /\b(if|while|for|switch|case)\b/.test(clean),
+        });
+      } else if (
+        method.earlyReturn === null &&
+        depthAtLineStart > method.bodyDepth &&
+        /\breturn\b/.test(clean)
+      ) {
+        method.earlyReturn = i + 1;
+      }
+    } else if (classBodyDepth !== null && depthAtLineStart === classBodyDepth) {
+      const decl = METHOD_DECL.exec(clean);
+      if (decl && !/\bnew\s*\(/.test(clean)) {
+        method = { name: decl[1], bodyDepth: classBodyDepth + 1, nexts: [], earlyReturn: null };
+      }
+    }
+
+    for (const ch of clean) {
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (method && depth < method.bodyDepth) closeMethod();
+      }
+    }
+  }
+  closeMethod();
+
+  return violations;
+}
+
+/**
  * BP001 — Hardcoded string literal in info/warning/error/checkFailed.
  * Flags: info("literal") — must use label @Module:LabelId.
  * Excludes strFmt(labelRef, ...) and calls where the first arg is a label ref (@...).
@@ -684,6 +842,8 @@ const XPP_RULES = [
   checkCocDefaultParam,
   checkExtensionOfNotFinal,
   checkExtensionOfNaming,
+  checkCocNextUnconditional,
+  checkEnum2StrInMessage,
   checkHardcodedStrings,
   checkDoMethods,
   checkGenericDocComment,

--- a/src/tools/d365foFile.ts
+++ b/src/tools/d365foFile.ts
@@ -19,6 +19,7 @@ import type { XppServerContext } from '../types/context.js';
 import { handleGenerateD365Xml } from './xml/generateD365Xml.js';
 import { handleCreateD365File } from './write/createD365File.js';
 import { modifyD365FileTool } from './write/modifyD365File.js';
+import { resetRecentPrepares } from './prepare/prepare.js';
 
 export const D365_FILE_ACTIONS = ['generate', 'create', 'modify'] as const;
 export type D365FileAction = (typeof D365_FILE_ACTIONS)[number];
@@ -176,6 +177,13 @@ export async function d365foFileTool(request: CallToolRequest, context: XppServe
     params && typeof params === 'object' && !Array.isArray(params)
       ? { ...flat, ...params }
       : flat;
+
+  // A write changes the AOT out from under anything prepare aggregated earlier, so
+  // the remembered answers stop being answers. Cleared before the write rather than
+  // after: a handler that throws half-way has still touched disk.
+  if (action === 'create' || action === 'modify') {
+    resetRecentPrepares();
+  }
 
   if (action === 'create') {
     return handleCreateD365File(subRequest('create_d365fo_file', rest), context);

--- a/src/tools/prepare/prepare.ts
+++ b/src/tools/prepare/prepare.ts
@@ -22,10 +22,13 @@ export type PrepareMode = (typeof PREPARE_MODES)[number];
 
 const PrepareArgsSchema = z
   .object({
-    mode: z.enum(PREPARE_MODES).default('change').describe(
-      'change (default) → aggregate context for extending/modifying an existing object; ' +
-      'create → aggregate context for a brand-new object.',
-    ),
+    mode: z
+      .enum(PREPARE_MODES)
+      .default('change')
+      .describe(
+        'change (default) → aggregate context for extending/modifying an existing object; ' +
+          'create → aggregate context for a brand-new object.',
+      ),
   })
   .passthrough();
 
@@ -33,14 +36,72 @@ function subRequest(name: string, args: Record<string, unknown>): CallToolReques
   return { method: 'tools/call', params: { name, arguments: args } };
 }
 
+/**
+ * Repeat suppression.
+ *
+ * prepare answers a question about an OBJECT ("what do I need to know to add a field
+ * to this table"), but its `goal` is free text, so re-asking the same question in
+ * different words looks like a new call. Run f2e7b71a did exactly that: four prepares,
+ * then two more that repeated the add-field and add-control ones verbatim except for
+ * the goal wording. Each reply is capped at ~5 KB and stays in the transcript for the
+ * rest of the session, and every later request pays to resend it.
+ *
+ * The grounding token from the first call is still valid — it is object-bound with a
+ * 30-minute TTL — so the honest answer to a repeat is that token plus a pointer, not
+ * another 5 KB of identical context.
+ */
+const REPEAT_TTL_MS = 30 * 60 * 1000;
+
+interface PriorPrepare {
+  token: string;
+  at: number;
+  goal: string;
+}
+
+const recentPrepares = new Map<string, PriorPrepare>();
+
+/** Same question = same (mode, type, operation, object, method). `goal` is deliberately excluded. */
+function prepareKey(mode: string, args: Record<string, unknown>): string {
+  const s = (v: unknown): string => (typeof v === 'string' ? v.toLowerCase() : '');
+  return [mode, s(args['objectType']), s(args['operation']), s(args['objectName']), s(args['methodName'])].join('|');
+}
+
+function extractToken(result: unknown): string | undefined {
+  const text = (result as { content?: Array<{ text?: string }> })?.content?.[0]?.text;
+  if (typeof text !== 'string') return undefined;
+  return /\*\*Grounding token:\*\*\s*`([^`]+)`/.exec(text)?.[1];
+}
+
+/** Exported for tests — a long-lived process must not accumulate dead keys. */
+export function pruneRecentPrepares(now = Date.now()): void {
+  for (const [key, prior] of recentPrepares.entries()) {
+    if (now - prior.at > REPEAT_TTL_MS) recentPrepares.delete(key);
+  }
+}
+
+/**
+ * Drop every remembered prepare. Called by d365fo_file after a successful write:
+ * once the AOT changes, the aggregated context describes a state that no longer
+ * exists, and answering a repeat from it would be worse than re-aggregating —
+ * "add-field" prepared before the field existed is exactly the wrong answer after.
+ *
+ * Deliberately a full clear rather than a targeted eviction: a write to a table
+ * invalidates the form context that referenced its fields too, and getting that
+ * dependency graph wrong fails silently.
+ */
+export function resetRecentPrepares(): void {
+  recentPrepares.clear();
+}
+
 export async function prepareTool(request: CallToolRequest, context: XppServerContext) {
   const parsed = PrepareArgsSchema.safeParse(request.params.arguments ?? {});
   if (!parsed.success) {
     const args = (request.params.arguments ?? {}) as Record<string, unknown>;
     const modeArg = args['mode'];
-    const modeMsg = modeArg === undefined
-      ? `❌ prepare: missing required parameter "mode".\n\nUsage:\n  prepare(mode="change", objectName="...", methodName="...")  — extend/modify an existing object\n  prepare(mode="create", objectName="...", objectType="...")   — plan a new object`
-      : `❌ prepare: invalid mode "${modeArg}". Valid values: "change", "create".\n\n  prepare(mode="change", objectName="...", methodName="...")  — extend/modify an existing object\n  prepare(mode="create", objectName="...", objectType="...")   — plan a new object`;
+    const modeMsg =
+      modeArg === undefined
+        ? `❌ prepare: missing required parameter "mode".\n\nUsage:\n  prepare(mode="change", objectName="...", methodName="...")  — extend/modify an existing object\n  prepare(mode="create", objectName="...", objectType="...")   — plan a new object`
+        : `❌ prepare: invalid mode "${modeArg}". Valid values: "change", "create".\n\n  prepare(mode="change", objectName="...", methodName="...")  — extend/modify an existing object\n  prepare(mode="create", objectName="...", objectType="...")   — plan a new object`;
     return {
       content: [{ type: 'text', text: modeMsg }],
       isError: true,
@@ -48,10 +109,49 @@ export async function prepareTool(request: CallToolRequest, context: XppServerCo
   }
 
   const { mode, ...rest } = parsed.data;
-  if (mode === 'create') {
-    return prepareCreateTool(subRequest('prepare_create', rest), context);
+
+  pruneRecentPrepares();
+  const key = prepareKey(mode, rest);
+  const prior = recentPrepares.get(key);
+  if (prior) {
+    const goal = typeof rest['goal'] === 'string' ? rest['goal'] : '';
+    const minutes = Math.max(1, Math.round((Date.now() - prior.at) / 60000));
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            `ℹ️ Already prepared — this is the same request as ${minutes} min ago ` +
+            `(same mode/objectType/operation/objectName${rest['methodName'] ? '/methodName' : ''}), ` +
+            'so the context has not changed and is not repeated here.\n\n' +
+            `**Grounding token:** \`${prior.token}\`\n\n` +
+            `Earlier goal: ${prior.goal || '(none given)'}\n` +
+            (goal && goal !== prior.goal ? `This goal:    ${goal}\n` : '') +
+            '\nThe token above is still valid (30-min TTL, bound to this object) — pass it to ' +
+            '`d365fo_file(action="create"/"modify")` or `generate_object(mode="pattern")` and proceed. ' +
+            'Scroll up for the full context if you need it again; to force a fresh aggregation, ' +
+            'change the object, operation or method you are asking about.',
+        },
+      ],
+    };
   }
-  return prepareChangeTool(subRequest('prepare_change', rest), context);
+
+  const result =
+    mode === 'create'
+      ? await prepareCreateTool(subRequest('prepare_create', rest), context)
+      : await prepareChangeTool(subRequest('prepare_change', rest), context);
+
+  // Only a call that actually issued a token is worth suppressing: an error reply has
+  // no context to reuse, and repeating it is how the caller retries after fixing args.
+  const token = extractToken(result);
+  if (token && !(result as { isError?: boolean }).isError) {
+    recentPrepares.set(key, {
+      token,
+      at: Date.now(),
+      goal: typeof rest['goal'] === 'string' ? rest['goal'] : '',
+    });
+  }
+  return result;
 }
 
 // Tool registration (name, description, inputSchema) lives in

--- a/src/tools/sdlc/buildProject.ts
+++ b/src/tools/sdlc/buildProject.ts
@@ -13,6 +13,7 @@ import { lookupErrorFix } from '../knowledge/d365foErrorHelp.js';
 import { generateRuntimeMetadata } from '../xml/generateMetadata.js';
 import { compileModelLabels, type CompileLabelsResult } from '../write/compileLabels.js';
 import { readModuleReferences } from '../../metadata/modelDescriptor.js';
+import { recordBuild } from '../../utils/buildMarker.js';
 import type { ProgressReporter } from '../../utils/progressReporter.js';
 
 const execFileAsync = util.promisify(execFile);
@@ -729,6 +730,8 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
 async function renderFinishedBuildResult(
   finalState: BuildJobState,
   targetModel: string,
+  /** Where to leave the last-build note; omitted when no symbol index is attached. */
+  dataDir?: string,
 ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
   const succeeded  = finalState.status === 'succeeded';
   const isQueued   = !!(finalState.buildQueue && finalState.buildQueue.length > 1);
@@ -774,6 +777,16 @@ async function renderFinishedBuildResult(
   const structured    = succeeded
     ? ''
     : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(finalState.logFile)));
+
+  // The note run_bp_check and verify_d365fo_project read, so a green verdict from a
+  // tool that compiles nothing can say whether anything ever did.
+  if (dataDir) {
+    recordBuild(dataDir, targetModel, {
+      builtAt: new Date().toISOString(),
+      fullBuild: !!finalState.fullBuild,
+      succeeded,
+    });
+  }
 
   return {
     content: [{
@@ -932,7 +945,8 @@ function renderWaitTimeoutGuidance(elapsedSec: number, timeoutMs: number): strin
 // Tool handler
 // ---------------------------------------------------------------------------
 
-export const buildProjectTool = async (params: any, _context: any, onProgress?: ProgressReporter) => {
+export const buildProjectTool = async (params: any, context: any, onProgress?: ProgressReporter) => {
+  const dataDir: string | undefined = context?.symbolIndex?.dataDir;
   try {
     const force                 = params.force                === true;
     const fullBuild             = params.fullBuild            === true;
@@ -1087,7 +1101,7 @@ export const buildProjectTool = async (params: any, _context: any, onProgress?: 
           );
           if (wait.outcome === 'finished' && wait.state) {
             await clearBuildState(targetModel, customPackagesPath);
-            return await renderFinishedBuildResult(wait.state, targetModel);
+            return await renderFinishedBuildResult(wait.state, targetModel, dataDir);
           }
           const tailLog = await readLogTail(existingState.logFile);
           if (wait.outcome === 'orphaned') {
@@ -1157,7 +1171,7 @@ export const buildProjectTool = async (params: any, _context: any, onProgress?: 
       );
       await clearBuildState(targetModel, customPackagesPath);
       if (stillCurrent) {
-        const result = await renderFinishedBuildResult(existingState, targetModel);
+        const result = await renderFinishedBuildResult(existingState, targetModel, dataDir);
         // Say plainly that nothing was compiled just now, so a reader can never
         // mistake a collected result for a fresh one.
         const collected =
@@ -1283,7 +1297,7 @@ export const buildProjectTool = async (params: any, _context: any, onProgress?: 
       );
       if (wait.outcome === 'finished' && wait.state) {
         await clearBuildState(targetModel, customPackagesPath);
-        return await renderFinishedBuildResult(wait.state, targetModel);
+        return await renderFinishedBuildResult(wait.state, targetModel, dataDir);
       }
       const elapsed = Math.round((Date.now() - startedAt) / 1000);
       const tailLog = await readLogTail(wait.state?.logFile ?? firstLogFile);

--- a/src/tools/sdlc/runBpCheck.ts
+++ b/src/tools/sdlc/runBpCheck.ts
@@ -7,6 +7,7 @@ import { defaultPackagesRoot, findPackagesRoot } from '../../utils/packagesRoot.
 import { withOperationLock } from '../../utils/operationLocks.js';
 import { lookupSymbolsNocase, type DbLike } from '../../utils/symbolLookup.js';
 import { compileModelLabels } from '../write/compileLabels.js';
+import { describeBuildFreshness } from '../../utils/buildMarker.js';
 
 const execFileAsync = util.promisify(execFile);
 
@@ -539,11 +540,20 @@ export const runBpCheckTool = async (params: any, context: any) => {
       : issueCount > 0 ? '⚠️ BP Check completed with issues'
       : '✅ BP Check passed';
 
+    // A clean xppbp run is routinely read as "the task is done". It is not a compile:
+    // run f2e7b71a shipped a CoC method that violates SYS10028 with this line reading
+    // "0 with findings". Say what has actually compiled the model.
+    const buildNote = context?.symbolIndex?.dataDir
+      ? `\n\n${describeBuildFreshness(context.symbolIndex.dataDir, modelName)}`
+      : '';
+
     return {
       content: [{
         type: 'text',
         text: `${verdict} — ` +
-          `${runTargets.length} objects checked, ${issueCount} with findings\n\n${header}` +
+          `${runTargets.length} objects checked, ${issueCount} with findings` +
+          buildNote +
+          `\n\n${header}` +
           labelNote +
           (preamble.length > 0
             ? `\n\nShared xppbp preamble (identical for all ${runTargets.length} objects, shown once):\n${preamble.join('\n').trim()}`

--- a/src/tools/sdlc/verifyD365Project.ts
+++ b/src/tools/sdlc/verifyD365Project.ts
@@ -13,6 +13,7 @@ import { getConfigManager } from '../../utils/configManager.js';
 import { readProjectIncludes, resolveMembership, projectDisplayName } from '../../workspace/projectMembership.js';
 import { defaultPackagesRoot } from '../../utils/packagesRoot.js';
 import { PackageResolver } from '../../utils/packageResolver.js';
+import { describeBuildFreshness } from '../../utils/buildMarker.js';
 
 const OBJECT_TYPES = [
   'class', 'table', 'enum', 'form', 'query', 'view', 'data-entity', 'report',
@@ -94,7 +95,7 @@ const VerifyD365ProjectArgsSchema = z.object({
 
 export async function verifyD365ProjectTool(
   request: CallToolRequest,
-  _context: XppServerContext
+  context: XppServerContext
 ) {
   try {
     const args = VerifyD365ProjectArgsSchema.parse(request.params.arguments);
@@ -358,6 +359,12 @@ export async function verifyD365ProjectTool(
       '',
       '### Summary',
       ...summaryLines,
+      // Every row above can be ✅ for code that does not compile: this tool proves a
+      // file is on disk and in the .rnrproj, nothing more. Run f2e7b71a read a fully
+      // green table as done and shipped a SYS10028 violation.
+      ...(context?.symbolIndex?.dataDir
+        ? ['', `- ${describeBuildFreshness(context.symbolIndex.dataDir, actualModelName, results.map(r => r.filePath))}`]
+        : []),
     ];
 
     return {

--- a/src/utils/buildMarker.ts
+++ b/src/utils/buildMarker.ts
@@ -1,0 +1,120 @@
+/**
+ * Build marker — the note `build_d365fo_project` leaves for the tools that report a
+ * verdict without compiling anything.
+ *
+ * Why it exists: run_bp_check and verify_d365fo_project both answer confidently and
+ * neither one compiles. xppbp does not diagnose the SYS-class compiler errors (an
+ * `if (ret) { ret = next foo(); }` in a CoC method is SYS10028, and xppbp is silent),
+ * and verify only proves a file is on disk and in the .rnrproj. Benchmark run
+ * f2e7b71a skipped the build entirely, was told "✅ BP Check passed — 0 with findings"
+ * plus a fully green verification table, and shipped a class that does not compile.
+ *
+ * Nothing here blocks anything. It records when a model last built cleanly so those
+ * tools can say "and nothing has compiled this since you changed it" instead of
+ * implying a green light they never checked for.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Written next to the metadata databases, one entry per model. */
+export const BUILD_MARKER_FILENAME = '.last-build.json';
+
+export interface ModelBuildRecord {
+  /** ISO timestamp of the build that produced this record. */
+  builtAt: string;
+  /** Whether it was a full build; an incremental green is not proof the model compiles. */
+  fullBuild: boolean;
+  /** True only for a build with zero errors. Warnings still count as succeeded. */
+  succeeded: boolean;
+}
+
+export type BuildMarker = Record<string, ModelBuildRecord>;
+
+function markerPath(dataDir: string): string {
+  return path.join(dataDir, BUILD_MARKER_FILENAME);
+}
+
+function readAll(dataDir: string): BuildMarker {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(markerPath(dataDir), 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as BuildMarker;
+  } catch {
+    // No marker yet, or unreadable — the caller degrades to "never built here".
+    return {};
+  }
+}
+
+/**
+ * Record the outcome of a build. Best-effort: a build succeeds even if this write
+ * fails, so callers do not need to handle an error here.
+ */
+export function recordBuild(dataDir: string, modelName: string, record: ModelBuildRecord): void {
+  try {
+    const all = readAll(dataDir);
+    all[modelName] = record;
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(markerPath(dataDir), JSON.stringify(all, null, 2));
+  } catch {
+    /* diagnostics only — never fail a build over its own bookkeeping */
+  }
+}
+
+/** The last recorded build for `modelName`, or undefined if it never built here. */
+export function readBuildRecord(dataDir: string, modelName: string): ModelBuildRecord | undefined {
+  const rec = readAll(dataDir)[modelName];
+  if (!rec || typeof rec.builtAt !== 'string') return undefined;
+  return {
+    builtAt: rec.builtAt,
+    fullBuild: rec.fullBuild === true,
+    succeeded: rec.succeeded === true,
+  };
+}
+
+/**
+ * One line describing whether this model has been compiled since the objects were
+ * last written — the caveat a non-compiling verdict carries.
+ *
+ * `files` is optional because the callers differ: verify_d365fo_project already
+ * resolves each object's path and can prove staleness, while run_bp_check only knows
+ * names. With no paths the answer is coarser ("nothing has built this model") but it
+ * is the case that actually went wrong, so it is worth saying either way.
+ *
+ * Phrased as a statement of fact rather than an instruction: the caller is reporting
+ * its own result, and this is what that result does not cover.
+ */
+export function describeBuildFreshness(dataDir: string, modelName: string, files: string[] = []): string {
+  let newestWrite = 0;
+  for (const f of files) {
+    try {
+      const t = fs.statSync(f).mtimeMs;
+      if (t > newestWrite) newestWrite = t;
+    } catch {
+      /* the caller already reports missing files */
+    }
+  }
+
+  const rec = readBuildRecord(dataDir, modelName);
+  if (!rec || !rec.succeeded) {
+    return (
+      `⚠️ Not compiled — no successful build of ${modelName} is recorded on this machine. ` +
+      'This is not a compile check: xppbp does not diagnose SYS-class compiler errors ' +
+      '(SYS10028 "next must be called once and unconditionally" is the common one). ' +
+      'Run build_d365fo_project(fullBuild: true) before scoring the task done.'
+    );
+  }
+
+  const builtAt = Date.parse(rec.builtAt);
+  if (newestWrite > 0 && (Number.isNaN(builtAt) || builtAt < newestWrite)) {
+    return (
+      `⚠️ Stale — ${modelName} last built ${rec.builtAt}, but these objects were written after that. ` +
+      'Nothing has compiled the current state; run build_d365fo_project(fullBuild: true).'
+    );
+  }
+
+  return rec.fullBuild
+    ? `✅ Compiled — full build of ${modelName} succeeded at ${rec.builtAt}.`
+    : `ℹ️ Last build of ${modelName} (${rec.builtAt}) was INCREMENTAL — only changed elements were compiled. ` +
+        'Use build_d365fo_project(fullBuild: true) before trusting a green result.';
+}

--- a/tests/metadata/incremental-fts.test.ts
+++ b/tests/metadata/incremental-fts.test.ts
@@ -157,14 +157,18 @@ describe('labels FTS: incremental strategy', () => {
    * Label ids reachable through the index for a term. As on the symbols side, only a MATCH
    * query is answered from the index — labels_fts is external-content too.
    *
-   * No integrity-check counterpart here: labels_fts deliberately indexes en-US rows only,
-   * so FTS5 would report that partial index as corrupt by design.
+   * Reported as `id/language`: the index covers every locale, so one label id is present
+   * once per translation and a bare id could not tell an en-US hit from a Czech one.
    */
   function ftsLabelSearch(index: XppSymbolIndex, term: string): string[] {
     return index.labelsDb
-      .prepare('SELECT label_id FROM labels_fts WHERE labels_fts MATCH ? ORDER BY label_id')
+      .prepare(
+        `SELECT l.label_id, l.language FROM labels_fts f
+         JOIN labels l ON l.id = f.rowid
+         WHERE labels_fts MATCH ? ORDER BY l.label_id, l.language`,
+      )
       .all(term)
-      .map((r: any) => r.label_id);
+      .map((r: any) => `${r.label_id}/${r.language}`);
   }
 
   it('matches a full rebuild, and clearing a model prunes its FTS rows', () => {
@@ -179,23 +183,27 @@ describe('labels FTS: incremental strategy', () => {
       ],
       { skipFtsRebuild: true, keepTriggers: true },
     );
-    expect(ftsLabelSearch(index, 'Hello')).toEqual(['@Cus:Hello']);
-    expect(ftsLabelSearch(index, 'Keep')).toEqual(['@Std:Keep']);
-    // Non-en-US rows stay out of the index.
-    expect(ftsLabelSearch(index, 'Ahoj')).toEqual([]);
+    // 'Hello' is the en-US text and the label id both translations share, so the Czech
+    // row answers on its id — it is in the index now, which is the point.
+    expect(ftsLabelSearch(index, 'Hello')).toEqual(['@Cus:Hello/cs', '@Cus:Hello/en-US']);
+    expect(ftsLabelSearch(index, 'Keep')).toEqual(['@Std:Keep/en-US']);
+    // The Czech text itself is reachable — it used to be indexed nowhere.
+    expect(ftsLabelSearch(index, 'Ahoj')).toEqual(['@Cus:Hello/cs']);
 
     index.clearLabelsForModels(['CustomModel'], { ftsStrategy: 'incremental' });
     expect(ftsLabelSearch(index, 'Hello')).toEqual([]);
     expect(ftsLabelSearch(index, 'Goodbye')).toEqual([]);
+    // Pruning has to reach the translations too, not just the en-US row.
+    expect(ftsLabelSearch(index, 'Ahoj')).toEqual([]);
     // The untouched standard model must survive both the clear and the FTS pruning.
-    expect(ftsLabelSearch(index, 'Keep')).toEqual(['@Std:Keep']);
+    expect(ftsLabelSearch(index, 'Keep')).toEqual(['@Std:Keep/en-US']);
     expect(index.labelsDb.prepare('SELECT COUNT(*) n FROM labels').get()).toEqual({ n: 1 });
 
     index.bulkAddLabels([label('@Cus:Hello', 'CustomModel', 'Hello again')], {
       skipFtsRebuild: true,
       keepTriggers: true,
     });
-    expect(ftsLabelSearch(index, 'again')).toEqual(['@Cus:Hello']);
+    expect(ftsLabelSearch(index, 'again')).toEqual(['@Cus:Hello/en-US']);
 
     // Same oracle as the symbols side: the incrementally maintained index must answer
     // exactly like one rebuilt from scratch.
@@ -221,7 +229,7 @@ describe('labels FTS: incremental strategy', () => {
 
     // The replaced row must be gone from the index, not merely shadowed by the new one.
     expect(ftsLabelSearch(index, 'First')).toEqual([]);
-    expect(ftsLabelSearch(index, 'Second')).toEqual(['@Cus:Hello']);
+    expect(ftsLabelSearch(index, 'Second')).toEqual(['@Cus:Hello/en-US']);
 
     index.close?.();
   });

--- a/tests/metadata/labelsFtsAllLanguages.test.ts
+++ b/tests/metadata/labelsFtsAllLanguages.test.ts
@@ -1,0 +1,191 @@
+/**
+ * labels_fts must cover every indexed language, not only en-US.
+ *
+ * The index used to be filtered to en-US in three places (the three sync triggers,
+ * rebuildLabelsFts, and an early return in searchLabels). On a build configured with
+ * LABEL_LANGUAGES=en-US,cs,sk,de that left three quarters of the rows unreachable
+ * through the index, and searchLabels answered those languages with a LIKE scan of
+ * the whole labels table instead — 152 s for a four-term `cs` query against 1.4 M
+ * rows, run synchronously so the whole MCP server stalled behind it.
+ *
+ * Indexing every language makes the language predicate load-bearing: without it a
+ * `cs` search returns the en-US and de rows that share a token.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+const opened: XppSymbolIndex[] = [];
+const dirs: string[] = [];
+
+function memoryIndex(): XppSymbolIndex {
+  const idx = new XppSymbolIndex(':memory:', ':memory:');
+  opened.push(idx);
+  return idx;
+}
+
+afterEach(() => {
+  for (const idx of opened) {
+    try {
+      idx.close();
+    } catch {
+      /* already closed */
+    }
+  }
+  opened.length = 0;
+  for (const d of dirs) {
+    try {
+      fs.rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* locked */
+    }
+  }
+  dirs.length = 0;
+});
+
+const label = (labelId: string, language: string, text: string, filePath = 'C:/pkg/Contoso/Con.label.txt') => ({
+  labelId,
+  labelFileId: 'Con',
+  model: 'Contoso',
+  language,
+  text,
+  filePath,
+});
+
+/** The four locales this workspace actually ships. */
+const FOUR_LOCALES = [
+  label('@Con:Tier', 'en-US', 'Quality tier'),
+  label('@Con:Tier', 'cs', 'Úroveň kvality'),
+  label('@Con:Tier', 'sk', 'Úroveň kvality SK'),
+  label('@Con:Tier', 'de', 'Qualitätsstufe'),
+];
+
+describe('searchLabels across languages', () => {
+  it('finds a Czech label by a Czech word', () => {
+    const index = memoryIndex();
+    index.bulkAddLabels(FOUR_LOCALES);
+
+    const hits = index.searchLabels('kvality', { language: 'cs' });
+
+    expect(hits.map(h => h.text)).toEqual(['Úroveň kvality']);
+  });
+
+  it('finds a German label whose only distinguishing token is non-ASCII', () => {
+    const index = memoryIndex();
+    index.bulkAddLabels(FOUR_LOCALES);
+
+    // 'Qualitätsstufe' has no ASCII-only token. The old [a-zA-Z0-9] sanitisation
+    // test would have routed this to the LIKE scan even once the rows were indexed.
+    expect(index.searchLabels('Qualitätsstufe', { language: 'de' }).map(h => h.text)).toEqual(['Qualitätsstufe']);
+  });
+
+  it('does not leak other languages into a scoped search', () => {
+    const index = memoryIndex();
+    index.bulkAddLabels([
+      ...FOUR_LOCALES,
+      // 'Tier' is a German word here and an English one in '@Con:Tier'/'Quality tier'.
+      label('@Con:Animal', 'de', 'Tier'),
+    ]);
+
+    const de = index.searchLabels('Tier', { language: 'de' });
+
+    // Both German rows match — @Con:Animal on its text, @Con:Tier on its label_id,
+    // which is an indexed FTS column too. What must not appear is the en-US row
+    // 'Quality tier', which matches the same token in a language nobody asked for.
+    expect(de.every(h => h.language === 'de')).toBe(true);
+    expect(de.map(h => h.text).sort()).toEqual(['Qualitätsstufe', 'Tier']);
+
+    expect(index.searchLabels('Tier', { language: 'en-US' }).map(h => h.text)).toEqual(['Quality tier']);
+  });
+
+  it('still defaults to en-US when no language is passed', () => {
+    const index = memoryIndex();
+    index.bulkAddLabels(FOUR_LOCALES);
+
+    expect(index.searchLabels('quality').map(h => h.language)).toEqual(['en-US']);
+  });
+
+  it('accepts the lowercase locale spelling Linux-unzipped packages carry', () => {
+    const index = memoryIndex();
+    index.bulkAddLabels([label('@Con:Lower', 'en-us', 'Photosynthesis')]);
+
+    expect(index.searchLabels('Photosynthesis', { language: 'en-US' }).map(h => h.labelId)).toEqual(['@Con:Lower']);
+  });
+
+  it('keeps a non-en-US row in sync when it is deleted', () => {
+    const index = memoryIndex();
+    const filePath = 'C:/pkg/Contoso/Ghost.label.txt';
+    index.bulkAddLabels([label('@Con:Ghost', 'cs', 'Fotosyntéza', filePath)]);
+    expect(index.searchLabels('Fotosyntéza', { language: 'cs' })).toHaveLength(1);
+
+    index.removeLabelsByFile(filePath);
+
+    // Before the fix the labels_ad trigger skipped non-en-US rows, so a deleted
+    // Czech label stayed in the index only if a rebuild happened to follow.
+    expect(index.searchLabels('Fotosyntéza', { language: 'cs' })).toEqual([]);
+  });
+
+  it('indexes a label added one row at a time, not only via bulk', () => {
+    const index = memoryIndex();
+    index.addLabel(label('@Con:Single', 'sk', 'Prístup do Finstatu'));
+
+    expect(index.searchLabels('Prístup', { language: 'sk' }).map(h => h.labelId)).toEqual(['@Con:Single']);
+  });
+});
+
+describe('labels_fts language-coverage migration', () => {
+  it('re-tokenises a database whose index was built en-US-only', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'd365fo-labels-migrate-'));
+    dirs.push(dir);
+    const symbolsPath = path.join(dir, 'symbols.db');
+    const labelsPath = path.join(dir, 'labels.db');
+
+    const index = new XppSymbolIndex(symbolsPath, labelsPath);
+    index.bulkAddLabels(FOUR_LOCALES);
+    // Recreate the pre-fix state: an index holding en-US rows only, and a
+    // user_version that predates the coverage change.
+    index.labelsDb.exec(`INSERT INTO labels_fts(labels_fts) VALUES('delete-all')`);
+    index.labelsDb.exec(`
+      INSERT INTO labels_fts(rowid, label_id, text, comment)
+      SELECT id, label_id, text, comment FROM labels WHERE LOWER(language) = 'en-us'
+    `);
+    index.labelsDb.pragma('user_version = 0');
+    expect(index.searchLabels('kvality', { language: 'cs' })).toEqual([]);
+    index.close();
+
+    const reopened = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(reopened);
+
+    expect(reopened.searchLabels('kvality', { language: 'cs' }).map(h => h.text)).toEqual(['Úroveň kvality']);
+    expect(Number(reopened.labelsDb.pragma('user_version', { simple: true }))).toBe(1);
+  });
+
+  it('does not rebuild a database that is already migrated', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'd365fo-labels-nomigrate-'));
+    dirs.push(dir);
+    const symbolsPath = path.join(dir, 'symbols.db');
+    const labelsPath = path.join(dir, 'labels.db');
+
+    const index = new XppSymbolIndex(symbolsPath, labelsPath);
+    index.bulkAddLabels(FOUR_LOCALES);
+    index.close();
+
+    const reopened = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(reopened);
+    let rebuilt = false;
+    const spy = reopened.rebuildLabelsFts.bind(reopened);
+    reopened.rebuildLabelsFts = () => {
+      rebuilt = true;
+      spy();
+    };
+    // A second open must not pay the O(all labels) re-tokenisation again.
+    const third = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(third);
+
+    expect(rebuilt).toBe(false);
+    expect(Number(third.labelsDb.pragma('user_version', { simple: true }))).toBe(1);
+  });
+});

--- a/tests/tools/cocNextUnconditional.test.ts
+++ b/tests/tools/cocNextUnconditional.test.ts
@@ -1,0 +1,166 @@
+/**
+ * COC004 — the CoC mistake that only a build used to catch.
+ *
+ * Benchmark run f2e7b71a (9.8.) skipped build_d365fo_project, ran run_bp_check
+ * instead, was told "✅ BP Check passed — 0 with findings", and shipped a
+ * validateWrite whose `next` sat inside `if (ret) { ... }`. xppbp does not diagnose
+ * SYS10028 and every symbol in the method resolved, so nothing else objected. The
+ * previous run hit the same shape, but only because it built.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runRules } from '../../src/tools/analysis/validateXpp';
+
+const coc = (body: string): string =>
+  `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
+final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
+{
+${body}
+}`;
+
+const rules = (code: string): string[] =>
+  runRules(code, 'xpp')
+    .filter(v => v.rule === 'COC004')
+    .map(v => v.fix);
+
+describe('COC004 — next must be unconditional', () => {
+  it('flags the exact shape run f2e7b71a shipped', () => {
+    // Verbatim from AxClass/AslFinCore_TaxTransReportChangeLogAslFinSK_Extension.xml.
+    const code = coc(`    public boolean validateWrite()
+    {
+        boolean ret = true;
+
+        if (enum2int(this.AslFinSK_QualityTier) < enum2int(this.orig().AslFinSK_QualityTier))
+        {
+            ret = checkFailed("@AslFinSK:QualityTierDowngradeNotAllowed");
+        }
+
+        if (ret)
+        {
+            ret = next validateWrite();
+        }
+
+        return ret;
+    }`);
+
+    const found = rules(code);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain('SYS10028');
+  });
+
+  it('accepts the corrected form the previous run arrived at', () => {
+    const code = coc(`    public boolean validateWrite()
+    {
+        boolean ret;
+
+        ret = next validateWrite();
+
+        if (ret && enum2int(this.AslFinSK_QualityTier) < enum2int(this.orig().AslFinSK_QualityTier))
+        {
+            ret = checkFailed("@AslFinSK:QualityTierDowngradeNotAllowed");
+        }
+
+        return ret;
+    }`);
+
+    expect(rules(code)).toEqual([]);
+  });
+
+  it('flags a return that can skip the next below it', () => {
+    const code = coc(`    public boolean validateWrite()
+    {
+        if (!this.RecId)
+        {
+            return false;
+        }
+
+        boolean ret = next validateWrite();
+        return ret;
+    }`);
+
+    expect(rules(code)[0]).toContain('not unconditional');
+  });
+
+  it('flags next called twice in one method', () => {
+    const code = coc(`    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        ret = next validateWrite();
+        return ret;
+    }`);
+
+    expect(rules(code).some(f => f.includes('exactly one'))).toBe(true);
+  });
+
+  it('does not confuse a next in a sibling method with this one', () => {
+    const code = coc(`    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        return ret;
+    }
+
+    public boolean validateDelete()
+    {
+        boolean ret = next validateDelete();
+        return ret;
+    }`);
+
+    expect(rules(code)).toEqual([]);
+  });
+
+  it('is not fooled by a brace inside a string or a doc comment', () => {
+    const code = coc(`    /// <summary>Guards { and } in prose.</summary>
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        info("a { brace } in a literal");
+        return ret;
+    }`);
+
+    expect(rules(code)).toEqual([]);
+  });
+
+  it('flags enum2str in the downgrade message the run shipped (BP005)', () => {
+    const code = coc(`    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        if (!ret)
+        {
+            ret = checkFailed(strFmt("@AslFinSK:Downgrade", enum2str(this.orig().AslFinSK_QualityTier)));
+        }
+        return ret;
+    }`);
+
+    const bp005 = runRules(code, 'xpp').filter(v => v.rule === 'BP005');
+    expect(bp005).toHaveLength(1);
+    expect(bp005[0].fix).toContain('value2Label');
+  });
+
+  it('leaves enum2str alone outside a user-facing message', () => {
+    const code = coc(`    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        str key = enum2str(this.AslFinSK_QualityTier);
+        return ret;
+    }`);
+
+    expect(runRules(code, 'xpp').filter(v => v.rule === 'BP005')).toEqual([]);
+  });
+
+  it('stays silent on a plain table method that is not a CoC extension', () => {
+    const code = `public class SomeTable
+{
+    public boolean validateWrite()
+    {
+        boolean ret = true;
+        if (ret)
+        {
+            ret = next validateWrite();
+        }
+        return ret;
+    }
+}`;
+
+    expect(rules(code)).toEqual([]);
+  });
+});

--- a/tests/tools/namingExtensionTypeInference.test.ts
+++ b/tests/tools/namingExtensionTypeInference.test.ts
@@ -1,0 +1,137 @@
+/**
+ * An extension name asked about under its base type is a question about the extension.
+ *
+ * Run f2e7b71a asked validate_object_naming for
+ * "AslFinCore_TaxTransReportChangeLog.AslFinSKExtension" with objectType="form". The
+ * non-extension underscore rule fired and returned a hard ERROR — "Non-extension
+ * objects must not contain underscores" — for a name that is obviously an extension.
+ * The agent then re-asked with objectType="form-extension" (T56 → T59): one wasted
+ * round trip, and a misleading error in the transcript for the rest of the session.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { validateObjectNamingTool } from '../../src/tools/analysis/validateObjectNaming.js';
+import { setModelObjectNameSource, clearInferredModelPrefixes } from '../../src/utils/modelPrefixInference.js';
+
+const MODEL = 'ContosoFinanceSK';
+const MODEL_OBJECTS = [
+  'ConSK_VendPaymentTable',
+  'ConSK_CustInvoiceJour',
+  'ConSK_LedgerJournalTrans',
+  'ConSK_TaxReportTable',
+];
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    getModelName: () => MODEL,
+    getWriteAnchorModel: () => MODEL,
+    getAutoDetectedModelName: async () => MODEL,
+  })),
+}));
+
+const req = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'validate_object_naming', arguments: args },
+});
+
+const buildContext = (): XppServerContext => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  const db = { prepare: vi.fn(() => stmt) };
+  return {
+    symbolIndex: { db, getReadDb: () => db } as any,
+    parser: {} as any,
+    cache: {} as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+  };
+};
+
+const validate = async (args: Record<string, unknown>): Promise<string> => {
+  const result = await validateObjectNamingTool(req(args), buildContext());
+  return String(result.content[0].text);
+};
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  clearInferredModelPrefixes();
+  setModelObjectNameSource(model => (model === MODEL ? MODEL_OBJECTS : []));
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  clearInferredModelPrefixes();
+  setModelObjectNameSource(null as never);
+});
+
+describe('extension type inferred from the proposed name', () => {
+  it('answers the form-extension question the caller meant', async () => {
+    const out = await validate({
+      objectType: 'form',
+      proposedName: 'ConSK_TaxReportTable.ConSKExtension',
+      baseObjectName: 'ConSK_TaxReportTable',
+    });
+
+    expect(out).toContain('as form-extension');
+    expect(out).toContain('Read as **form-extension**');
+    // The false alarm that cost the extra call.
+    expect(out).not.toContain('Non-extension objects must not contain underscores');
+  });
+
+  it('infers the base object from the dotted name when none was passed', async () => {
+    const out = await validate({
+      objectType: 'table',
+      proposedName: 'ConSK_TaxReportTable.ConSKExtension',
+    });
+
+    expect(out).toContain('as table-extension');
+    expect(out).toContain('Base Object: ConSK_TaxReportTable');
+    expect(out).not.toContain('baseObjectName is required');
+  });
+
+  it('reads the class CoC suffix form too', async () => {
+    const out = await validate({
+      objectType: 'class',
+      proposedName: 'ConSK_TaxReportTableConSK_Extension',
+      baseObjectName: 'ConSK_TaxReportTable',
+    });
+
+    expect(out).toContain('as class-extension');
+  });
+
+  it('still rejects a genuinely bad non-extension name', async () => {
+    // The underscore rule exists for exactly this: a plain form whose underscore is not
+    // the model's prefix separator (the prefix here is "ConSK"), and nothing about the
+    // name that says "extension". This is the shape the run's name shared — it began
+    // "AslFinCore_" while the prefix was "AslFinSK" — minus the extension suffix.
+    const out = await validate({
+      objectType: 'form',
+      proposedName: 'ConCore_TaxReportDetail',
+    });
+
+    expect(out).toContain('as form');
+    expect(out).toContain('Non-extension objects must not contain underscores');
+  });
+
+  it('leaves an explicit extension type alone', async () => {
+    const out = await validate({
+      objectType: 'form-extension',
+      proposedName: 'ConSK_TaxReportTable.ConSKExtension',
+      baseObjectName: 'ConSK_TaxReportTable',
+    });
+
+    expect(out).toContain('as form-extension');
+    expect(out).not.toContain('Read as **form-extension**');
+  });
+
+  it('does not reinterpret a type that has no extension counterpart', async () => {
+    const out = await validate({
+      objectType: 'query',
+      proposedName: 'ConSK_Something.ConSKExtension',
+    });
+
+    expect(out).toContain('as query');
+  });
+});

--- a/tests/tools/prepare-inheritance.test.ts
+++ b/tests/tools/prepare-inheritance.test.ts
@@ -23,13 +23,13 @@
  * parent still fails the grandparent case.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
 import { XppMetadataParser } from '../../src/metadata/xmlParser';
-import { prepareTool } from '../../src/tools/prepare/prepare';
+import { prepareTool, resetRecentPrepares } from '../../src/tools/prepare/prepare';
 import type { XppServerContext } from '../../src/types/context';
 
 const MODEL = 'MyCustomModel';
@@ -123,6 +123,12 @@ async function prepareChange(objectName: string, methodName: string): Promise<st
 }
 
 describe('prepare(mode="change") resolves inherited methods', () => {
+  // prepare remembers a repeated question and answers it with a pointer instead of
+  // re-aggregating (see prepareRepeatSuppression.test.ts). That store is module-level,
+  // and several cases below ask the same question to assert different parts of the
+  // answer, so each one needs a clean slate.
+  beforeEach(() => resetRecentPrepares());
+
   it('finds a method declared on the DIRECT parent', async () => {
     const text = await prepareChange('P_Leaf', 'parentOnly');
     expect(text).not.toContain('(not found in symbol index)');

--- a/tests/tools/prepareRepeatSuppression.test.ts
+++ b/tests/tools/prepareRepeatSuppression.test.ts
@@ -1,0 +1,123 @@
+/**
+ * prepare answers a question about an object, but `goal` is free text — so re-asking
+ * the same question in different words looked like a new call.
+ *
+ * Run f2e7b71a issued four prepares, then two more that repeated the add-field and
+ * add-control ones verbatim except for the goal wording. Each reply is capped at ~5 KB
+ * and stays in the transcript for the rest of the session, so every later request pays
+ * to resend it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prepareChangeTool = vi.fn();
+const prepareCreateTool = vi.fn();
+
+vi.mock('../../src/tools/prepare/prepareChange.js', () => ({
+  prepareChangeTool: (...a: unknown[]) => prepareChangeTool(...a),
+}));
+vi.mock('../../src/tools/prepare/prepareCreate.js', () => ({
+  prepareCreateTool: (...a: unknown[]) => prepareCreateTool(...a),
+}));
+
+const { prepareTool, pruneRecentPrepares } = await import('../../src/tools/prepare/prepare.js');
+
+const reply = (token: string, body = 'x'.repeat(4000)) => ({
+  content: [{ type: 'text', text: `${body}\n**Grounding token:** \`${token}\`` }],
+});
+
+const call = (args: Record<string, unknown>) =>
+  prepareTool({ method: 'tools/call', params: { name: 'prepare', arguments: args } } as never, {} as never);
+
+const text = (r: unknown): string => (r as { content: Array<{ text: string }> }).content[0].text;
+
+const ADD_FIELD = {
+  mode: 'change',
+  objectType: 'table',
+  operation: 'add-field',
+  objectName: 'AslFinCore_TaxTransReportChangeLog',
+};
+
+beforeEach(() => {
+  prepareChangeTool.mockReset();
+  prepareCreateTool.mockReset();
+  // The store is module-level; age every entry out between tests.
+  pruneRecentPrepares(Date.now() + 60 * 60 * 1000);
+});
+
+describe('prepare repeat suppression', () => {
+  it('does not re-aggregate when only the goal wording changed', async () => {
+    prepareChangeTool.mockResolvedValue(reply('tok-abc'));
+
+    const first = await call({ ...ADD_FIELD, goal: 'Add new enum-typed field QualityTier via a table extension' });
+    const second = await call({ ...ADD_FIELD, goal: 'Add QualityTier enum field via table extension' });
+
+    expect(prepareChangeTool).toHaveBeenCalledTimes(1);
+    expect(text(first).length).toBeGreaterThan(3000);
+    expect(text(second)).toContain('Already prepared');
+    // The point of the exercise: the repeat is a fraction of the payload.
+    expect(text(second).length).toBeLessThan(1000);
+  });
+
+  it('hands back the still-valid token so the caller can proceed', async () => {
+    prepareChangeTool.mockResolvedValue(reply('5f04aa8a56c7ea7d05eb433c2831ba8d'));
+
+    await call({ ...ADD_FIELD, goal: 'first' });
+    const repeat = await call({ ...ADD_FIELD, goal: 'second' });
+
+    expect(text(repeat)).toContain('**Grounding token:** `5f04aa8a56c7ea7d05eb433c2831ba8d`');
+  });
+
+  it('treats a different operation on the same object as a new question', async () => {
+    prepareChangeTool.mockResolvedValue(reply('tok-1'));
+
+    await call({ ...ADD_FIELD, goal: 'g' });
+    await call({ ...ADD_FIELD, operation: 'add-field-to-field-group', goal: 'g' });
+
+    expect(prepareChangeTool).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a different object as a new question', async () => {
+    prepareChangeTool.mockResolvedValue(reply('tok-1'));
+
+    await call({ ...ADD_FIELD, goal: 'g' });
+    await call({ ...ADD_FIELD, objectName: 'SomeOtherTable', goal: 'g' });
+
+    expect(prepareChangeTool).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps change and create apart', async () => {
+    prepareChangeTool.mockResolvedValue(reply('tok-change'));
+    prepareCreateTool.mockResolvedValue(reply('tok-create'));
+
+    await call({ mode: 'change', objectType: 'enum', objectName: 'QualityTier', goal: 'g' });
+    await call({ mode: 'create', objectType: 'enum', objectName: 'QualityTier', goal: 'g' });
+
+    expect(prepareChangeTool).toHaveBeenCalledTimes(1);
+    expect(prepareCreateTool).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not suppress after a failed call — that is how a caller retries', async () => {
+    prepareChangeTool.mockResolvedValueOnce({
+      content: [{ type: 'text', text: '❌ objectName not found' }],
+      isError: true,
+    });
+    prepareChangeTool.mockResolvedValueOnce(reply('tok-ok'));
+
+    await call({ ...ADD_FIELD, goal: 'g' });
+    const second = await call({ ...ADD_FIELD, goal: 'g' });
+
+    expect(prepareChangeTool).toHaveBeenCalledTimes(2);
+    expect(text(second)).not.toContain('Already prepared');
+  });
+
+  it('re-aggregates once the entry has aged out', async () => {
+    prepareChangeTool.mockResolvedValue(reply('tok-1'));
+
+    await call({ ...ADD_FIELD, goal: 'g' });
+    pruneRecentPrepares(Date.now() + 31 * 60 * 1000);
+    await call({ ...ADD_FIELD, goal: 'g' });
+
+    expect(prepareChangeTool).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/utils/buildMarker.test.ts
+++ b/tests/utils/buildMarker.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The caveat that run_bp_check and verify_d365fo_project were missing.
+ *
+ * Both answer confidently without compiling anything. Run f2e7b71a never called
+ * build_d365fo_project, was told "✅ BP Check passed — 0 with findings" and given a
+ * fully green verification table, and shipped a CoC method that violates SYS10028.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { recordBuild, readBuildRecord, describeBuildFreshness } from '../../src/utils/buildMarker';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'd365fo-buildmarker-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const touch = (name: string): string => {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, 'x');
+  return p;
+};
+
+describe('describeBuildFreshness', () => {
+  it('says nothing has compiled the model when no build was ever recorded', () => {
+    const note = describeBuildFreshness(dir, 'AslFinanceSK');
+
+    expect(note).toContain('Not compiled');
+    expect(note).toContain('SYS10028');
+    expect(note).toContain('fullBuild: true');
+  });
+
+  it('treats a failed build as no build', () => {
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date().toISOString(),
+      fullBuild: true,
+      succeeded: false,
+    });
+
+    expect(describeBuildFreshness(dir, 'AslFinanceSK')).toContain('Not compiled');
+  });
+
+  it('flags a green build that predates the objects it is being credited for', () => {
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date(Date.now() - 60_000).toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+    const written = touch('AslFinSK_QualityTier.xml');
+
+    expect(describeBuildFreshness(dir, 'AslFinanceSK', [written])).toContain('Stale');
+  });
+
+  it('confirms a full build that came after the last write', () => {
+    const written = touch('AslFinSK_QualityTier.xml');
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date(Date.now() + 60_000).toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+
+    expect(describeBuildFreshness(dir, 'AslFinanceSK', [written])).toContain('✅ Compiled');
+  });
+
+  it('keeps the incremental caveat — a green incremental is not proof the model compiles', () => {
+    const written = touch('AslFinSK_QualityTier.xml');
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date(Date.now() + 60_000).toISOString(),
+      fullBuild: false,
+      succeeded: true,
+    });
+
+    expect(describeBuildFreshness(dir, 'AslFinanceSK', [written])).toContain('INCREMENTAL');
+  });
+
+  it('keeps models apart', () => {
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date().toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+
+    expect(describeBuildFreshness(dir, 'AslFinanceCZ')).toContain('Not compiled');
+    expect(readBuildRecord(dir, 'AslFinanceSK')?.fullBuild).toBe(true);
+  });
+
+  it('survives an unreadable marker rather than throwing into the caller', () => {
+    fs.writeFileSync(path.join(dir, '.last-build.json'), '{ this is not json');
+
+    expect(() => describeBuildFreshness(dir, 'AslFinanceSK')).not.toThrow();
+    expect(readBuildRecord(dir, 'AslFinanceSK')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Found auditing benchmark run `f2e7b71a` (9.8., 120.3 AIU) against the previous run (94.0 AIU).

The cost difference between those two runs was **not** the server — it was Copilot's repo memory. The 94 AIU run had a cheat sheet written by the run before it (`memory-tool/memories/repo/aslfinancesk-conventions.md`); by `f2e7b71a` that file was gone, so discovery ran cold. Phase split: discovery 30.6 → 74.0 AIU, execution 63.4 → **46.3** AIU. The recent optimizations really did make execution ~27 % cheaper and cut 11 tool calls; the memory loss swamped them.

What the run *did* expose is below. All of it is real, and none of it depends on the memory story.

## `labels_fts` covered only en-US

The filter sat in three places — the three sync triggers, `rebuildLabelsFts()`, and an early return in `searchLabels()` that sent every non-English search to `searchLabelsLike()`. That fallback is a leading-wildcard `LIKE` over the whole labels table, run synchronously on the event loop.

In the run: `language:"cs"` (4 terms) took **152.8 s**, `language:"sk"` (3 terms) **155.8 s** — 308 s and ~7.5 AIU for nothing usable, with the server stalled throughout. `bc8089b`'s `mapWithConcurrency` cannot help, because better-sqlite3 is synchronous; the "parallel" workers just queue behind each other, which is why both calls report ~150 s. The code's own comment at `symbolIndex.ts` already predicted it: *"200+ s on a production DB, synchronously blocking the event loop"*. And `searchLabels.ts` advertises the trap on every zero-result search — `💡 To search a different language use the language parameter`. `f2e7b71a` is the first run of ten to take that bait.

Verified against the live 1.4 M-row database before the change: `nelze` → 0 hits, `znížiť` → 0, `Qualität` → 0, `Quality` → 925 (all en-US). (`SELECT COUNT(*) FROM labels_fts` returns 1 420 743 and looks fine — it is an external-content table, so the count reads `labels`, not the index.)

Removing the filter makes the language predicate load-bearing, so the FTS query gains `AND LOWER(l.language) = ?` — without it a `cs` search returns the en-US and `de` rows sharing a token. Two neighbours moved with it:

- the tokenisation guard was `[a-zA-Z0-9]`, which would have shunted `Qualitätsstufe` onto the LIKE scan *even once indexed* — now `[\p{L}\p{N}]`;
- `idx_labels_language_lower` lets the remaining fallback narrow to one locale instead of all four.

Migration is `PRAGMA user_version` on the labels DB (0 → 1), wrapped in try/catch so a read-only or locked file cannot take startup down.

**Measured on the real database:** one-off rebuild **23 s**, file **+90 MB (+8 %**, not 4× — the content table dominates). The run's seven cs/sk queries: **7.5 s → 16 ms** (warm cache; 308 s in the actual run).

## A green verdict without a compile

The run never called `build_d365fo_project`. It ran `validate_code` ×3 instead — which itself says *"build_d365fo_project remains the only proof it compiles"* — got `✅ BP Check passed — 4 objects checked, 0 with findings` and a fully green verification table, and shipped this:

```xpp
if (ret)
{
    ret = next validateWrite();
}
```

`next` inside a conditional is **SYS10028**. xppbp does not diagnose it and every symbol in the method resolves, so nothing objected. The previous run hit the identical shape — but only because it built.

- **COC004** (`validateXpp.ts`) catches `next` that is conditional, called twice, or skippable by an earlier `return`. The test feeds it the file the run actually wrote.
- **`utils/buildMarker.ts`** — `build_d365fo_project` records `data/.last-build.json` per model; `run_bp_check` and `verify_d365fo_project` append a line saying whether anything has compiled the model, and whether the build predates the writes. Nothing blocks; it just stops a green verdict from implying a compile it never performed.
- **BP005** flags `enum2str()` inside `info/warning/error/checkFailed/strFmt` — the reason the shipped error message would have stayed English on a Czech client (`DictEnum.value2Label` is the API that resolves the translation, and it was already documented; the run just didn't look).

## Two round trips the tools caused

- **`prepare`** re-aggregated ~5 KB of identical context when only the free-text `goal` differed (T26/T31 and T28/T32 were the same object, type and operation). It now returns the still-valid grounding token plus a pointer. A `d365fo_file` write clears the memo, so a repeat *after* a change re-aggregates rather than answering from a state that no longer exists.
- **`validate_object_naming`** rejected `AslFinCore_TaxTransReportChangeLog.AslFinSKExtension` asked as a `form` with a hard *"non-extension objects must not contain underscores"*, forcing the caller to ask again as `form-extension` (T56 → T59). An unmistakably-extension name is now read as the extension type it is; a genuinely bad non-extension name still fails.

## Verification

- 278 files / **3431 tests pass**, 2 skipped; `tsc --noEmit` clean; `biome lint` clean on every touched file.
- FTS fix proven against the live 1.4 M-row DB, not only in unit tests.
- One pre-existing caveat, unrelated: `tests/knowledge/apiSymbols.test.ts` times out under full-suite parallel I/O. It is gated on the live 2.3 GB symbol index, never touches the labels DB, and behaves identically with these changes stashed.

## Note for whoever runs the benchmark next

The Copilot repo-memory store (`GitHub.copilot-chat/memory-tool/memories/`) survives between sessions and the agent reads it on turn 1, so runs are not comparable unless it is controlled — either wipe it before every run, or seed it deterministically (e.g. a committed `.github/copilot-instructions.md`). Leaving the agent to write its own is what produced the 94-vs-120 swing this audit started from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwKQ1TDbTeMTbUYEcqLkjK
