### PR TITLE
Say why a build failed, and check the X++ before the build runs

### DIFF
--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -167,10 +167,22 @@ namespace D365MetadataBridge.Services
                 switch (objectType.ToLowerInvariant())
                 {
                     case "table":
-                    case "table-extension":
                         if (!_provider.Tables.Exists(objectName)) return new { valid = false, reason = $"Table '{objectName}' not found by IMetadataProvider after refresh" };
                         var t = _provider.Tables.Read(objectName);
                         return new { valid = true, objectType, objectName, fieldCount = t?.Fields?.Count ?? 0, methodCount = t?.Methods?.Count ?? 0, indexCount = t?.Indexes?.Count ?? 0 };
+
+                    // Extensions live in their OWN provider collection, keyed by the dotted
+                    // "Base.ModelExtension" name. Tables/Forms are keyed by plain names, so
+                    // looking an extension up there always misses — a false negative on every
+                    // extension write, regardless of refresh.
+                    case "table-extension":
+                    {
+                        var tx = _provider.TableExtensions.Read(objectName);
+                        if (tx == null) return new { valid = false, reason = $"TableExtension '{objectName}' not found by IMetadataProvider after refresh" };
+                        int txMethods = 0;
+                        try { dynamic dtx = tx; if (dtx?.Methods != null) foreach (var _ in dtx.Methods) txMethods++; } catch { }
+                        return new { valid = true, objectType, objectName, fieldCount = tx.Fields?.Count ?? 0, methodCount = txMethods, indexCount = tx.Indexes?.Count ?? 0 };
+                    }
 
                     case "class":
                     case "class-extension":
@@ -190,8 +202,11 @@ namespace D365MetadataBridge.Services
                         return new { valid = true, objectType, objectName };
 
                     case "form":
-                    case "form-extension":
                         if (!_provider.Forms.Exists(objectName)) return new { valid = false, reason = $"Form '{objectName}' not found by IMetadataProvider after refresh" };
+                        return new { valid = true, objectType, objectName };
+
+                    case "form-extension":
+                        if (_provider.FormExtensions.Read(objectName) == null) return new { valid = false, reason = $"FormExtension '{objectName}' not found by IMetadataProvider after refresh" };
                         return new { valid = true, objectType, objectName };
 
                     case "query":
@@ -258,12 +273,22 @@ namespace D365MetadataBridge.Services
                 switch (objectType.ToLowerInvariant())
                 {
                     case "table":
-                    case "table-extension":
                     {
                         var prov = PickProvider(p => p.Tables.Exists(objectName));
                         if (prov == null) return null;
                         string? model = null;
                         try { var mi = prov.Tables.GetModelInfo(objectName); if (mi?.Count > 0) model = mi.First().Name; } catch { }
+                        return new { exists = true, objectType, objectName, model };
+                    }
+                    // Probed against TableExtensions/FormExtensions, not Tables/Forms — see
+                    // the note in ValidateObject: the dotted extension name is never a key
+                    // in the base collection, so probing there never resolves an extension.
+                    case "table-extension":
+                    {
+                        var prov = PickProvider(p => p.TableExtensions.Read(objectName) != null);
+                        if (prov == null) return null;
+                        string? model = null;
+                        try { var mi = prov.TableExtensions.GetModelInfo(objectName); if (mi?.Count > 0) model = mi.First().Name; } catch { }
                         return new { exists = true, objectType, objectName, model };
                     }
                     case "class":
@@ -292,12 +317,19 @@ namespace D365MetadataBridge.Services
                         return new { exists = true, objectType, objectName, model };
                     }
                     case "form":
-                    case "form-extension":
                     {
                         var prov = PickProvider(p => p.Forms.Exists(objectName));
                         if (prov == null) return null;
                         string? model = null;
                         try { var mi = prov.Forms.GetModelInfo(objectName); if (mi?.Count > 0) model = mi.First().Name; } catch { }
+                        return new { exists = true, objectType, objectName, model };
+                    }
+                    case "form-extension":
+                    {
+                        var prov = PickProvider(p => p.FormExtensions.Read(objectName) != null);
+                        if (prov == null) return null;
+                        string? model = null;
+                        try { var mi = prov.FormExtensions.GetModelInfo(objectName); if (mi?.Count > 0) model = mi.First().Name; } catch { }
                         return new { exists = true, objectType, objectName, model };
                     }
                     case "query":

--- a/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataWriteService.cs
@@ -3396,6 +3396,16 @@ namespace D365MetadataBridge.Services
         public object AddControl(string formName, string controlName, string parentControl,
             string controlType, string? dataSource, string? dataField, string? label)
         {
+            // Forms is keyed by plain form names; a form EXTENSION lives in FormExtensions
+            // under its dotted "Base.Suffix" name and wraps each added control in an
+            // AxFormExtensionControl, which this method does not build. Say so instead of
+            // reporting the lookup miss as "form not found".
+            if (formName.Contains('.'))
+                throw new ArgumentException(
+                    $"'{formName}' is a form extension — AddControl only handles base forms. " +
+                    "Form extensions are written by the caller's direct-XML path, which produces the " +
+                    "required AxFormExtensionControl wrapper.");
+
             var axForm = _provider.Forms.Read(formName)
                 ?? throw new ArgumentException($"Form '{formName}' not found");
             var msi = GetModelSaveInfoForObject(_provider.Forms, formName);

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "0860119fcbba4e7178c9997a1a3eeef2fd40e8d81446811b819c05085e97f3f1",
+  "sourceHash": "8468e618dc2dbbaffad57fea485970a83dee93087dbc617a3fc95c8dba96e74e",
   "sourceFileCount": 9,
   "metamodelFileVersion": "7.0.7996.33",
-  "builtAt": "2026-08-08T12:53:31.943Z"
+  "builtAt": "2026-08-10T08:41:26.302Z"
 }

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -3,5 +3,5 @@
   "sourceHash": "8468e618dc2dbbaffad57fea485970a83dee93087dbc617a3fc95c8dba96e74e",
   "sourceFileCount": 9,
   "metamodelFileVersion": "7.0.7996.33",
-  "builtAt": "2026-08-10T08:41:26.302Z"
+  "builtAt": "2026-08-10T10:08:33.250Z"
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -116,6 +116,7 @@ Transport, timeouts and logging of the MCP server process.
 | `server.operationLockTimeoutMs` | advanced | `OPERATION_LOCK_TIMEOUT_MS` | `900000` | How long a build/sync waits for another one to finish before failing. |
 | `server.operationLockPollMs` | advanced | `OPERATION_LOCK_POLL_MS` | `250` | How often the waiting process re-checks the lock. |
 | `server.operationLockStaleMs` | advanced | `OPERATION_LOCK_STALE_MS` | `1200000` | A lock older than this is treated as left behind by a crashed process and broken. |
+| `server.slowCallLogMs` | advanced | `SLOW_CALL_LOG_MS` | `10000` | Writes one line per tool call that exceeds this, with the tool name and a short argument digest. Aggregate metrics cannot say which specific call cost five minutes; this can. Set LOG_FILE to keep the lines. |
 | `server.apiKey` | secret | `API_KEY` | — | When set, every HTTP request must present this key. Leave empty for a localhost-only server; set it whenever the port is reachable from another machine. |
 
 ### C# bridge
@@ -209,7 +210,8 @@ Downloading a pre-built index from blob storage instead of building it locally.
     "readPoolSize": 3,
     "operationLockTimeoutMs": 900000,
     "operationLockPollMs": 250,
-    "operationLockStaleMs": 1200000
+    "operationLockStaleMs": 1200000,
+    "slowCallLogMs": 10000
   },
   "bridge": {
     "readyTimeoutMs": 30000,

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -635,6 +635,18 @@ export const SETTINGS: Setting[] = [
     description: 'A lock older than this is treated as left behind by a crashed process and broken.',
     default: 1200000,
   },
+  {
+    path: 'server.slowCallLogMs',
+    env: 'SLOW_CALL_LOG_MS',
+    section: 'server',
+    tier: 'advanced',
+    type: 'int',
+    label: 'Log a tool call slower than (ms)',
+    description:
+      'Writes one line per tool call that exceeds this, with the tool name and a short argument digest. ' +
+      'Aggregate metrics cannot say which specific call cost five minutes; this can. Set LOG_FILE to keep the lines.',
+    default: 10000,
+  },
 
   // ── bridge ───────────────────────────────────────────────────────────────
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,16 +41,39 @@ const DEBUG_LOGGING = process.env.DEBUG_LOGGING === 'true';
 // to a file (useful when the IDE doesn't expose MCP subprocess stderr).
 const LOG_FILE = process.env.LOG_FILE;
 let _logStream: fsSync.WriteStream | undefined;
+/** Undoes the stderr tee. Set only while the tee is installed. */
+let _restoreStderr: (() => void) | undefined;
 if (LOG_FILE) {
   try {
     _logStream = fsSync.createWriteStream(LOG_FILE, { flags: 'a', encoding: 'utf8' });
+    // The open is asynchronous, so a bad path (missing directory, no write
+    // permission) never reaches the catch below — it arrives here instead, and
+    // without a listener an 'error' event on a stream is an uncaught exception.
+    _logStream.on('error', (err) => {
+      _logStream = undefined;
+      _restoreStderr?.();
+      process.stderr.write(`[d365fo-mcp] ⚠️ LOG_FILE=${LOG_FILE} unusable, file logging off: ${err}\n`);
+    });
     const banner = `\n${'─'.repeat(72)}\n[d365fo-mcp] Started at ${new Date().toISOString()}  pid=${process.pid}\n${'─'.repeat(72)}\n`;
     _logStream.write(banner);
-    // Tee: intercept process.stderr so every write also goes to the log file
-    const origStderrWrite = process.stderr.write.bind(process.stderr);
-    (process.stderr as NodeJS.WriteStream & { write: (...args: any[]) => boolean }).write = function (chunk: any, ...rest: any[]): boolean {
-      _logStream!.write(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+    // Tee: intercept process.stderr so every write also goes to the log file.
+    // The mirror is best-effort — stderr itself must keep working even once the
+    // stream is gone, because shutdown reports its final progress through it.
+    const stderr = process.stderr as NodeJS.WriteStream & { write: (...args: any[]) => boolean };
+    const origStderrWrite = stderr.write.bind(process.stderr);
+    const teeWrite = function (chunk: any, ...rest: any[]): boolean {
+      try {
+        _logStream?.write(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+      } catch {
+        // A failed mirror must never take the real stderr write down with it.
+      }
       return origStderrWrite(chunk, ...rest) as boolean;
+    };
+    stderr.write = teeWrite;
+    _restoreStderr = () => {
+      // Only unpatch our own tee — something else may have wrapped stderr since.
+      if (stderr.write === teeWrite) stderr.write = origStderrWrite;
+      _restoreStderr = undefined;
     };
   } catch (e) {
     // Don't crash the server if the log file can't be opened
@@ -89,9 +112,20 @@ console.error = (...args: any[]) => {
 // on the first request and has to be restarted" when a background task (e.g.
 // the async DB load) rejects before any tool call awaits it. Log and keep the
 // server alive instead of dying. (stderr is already tee'd to LOG_FILE above.)
+// A throw inside either of these handlers is fatal and unrecoverable — Node has
+// no net left to catch it — so the reporting itself is wrapped: the net must not
+// be the thing that kills the process it exists to keep alive.
+function reportSafely(message: string): void {
+  try {
+    process.stderr.write(message);
+  } catch {
+    /* nothing left to report through */
+  }
+}
+
 process.on('unhandledRejection', (reason) => {
   const msg = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
-  process.stderr.write(`[d365fo-mcp] ⚠️ Unhandled promise rejection (server staying up): ${msg}\n`);
+  reportSafely(`[d365fo-mcp] ⚠️ Unhandled promise rejection (server staying up): ${msg}\n`);
 });
 
 // Same protection for SYNCHRONOUS uncaught exceptions — a throw that escapes a
@@ -101,7 +135,7 @@ process.on('unhandledRejection', (reason) => {
 // root cause is diagnosable, then keep serving. (Genuinely fatal startup errors
 // are still surfaced via main().catch → process.exit below.)
 process.on('uncaughtException', (err) => {
-  process.stderr.write(`[d365fo-mcp] ⚠️ Uncaught exception (server staying up): ${err?.stack ?? err}\n`);
+  reportSafely(`[d365fo-mcp] ⚠️ Uncaught exception (server staying up): ${err?.stack ?? err}\n`);
 });
 
 const PORT = parseInt(process.env.PORT || '8080', 10);
@@ -446,6 +480,9 @@ async function main() {
   // Registered first so it runs LAST (cleanups run in reverse): the log file is
   // where the other steps report, so it has to outlive them.
   onShutdown('log file', () => {
+    // Unpatch before closing: the coordinator still writes "[shutdown] done"
+    // after this cleanup returns, and that write must not touch a closed stream.
+    _restoreStderr?.();
     if (_logStream) {
       _logStream.end();
       _logStream = undefined;

--- a/src/metadata/formPatternMiner.ts
+++ b/src/metadata/formPatternMiner.ts
@@ -72,6 +72,9 @@ const PROPERTY_KEYS = [
   'DataSource',
   'DataField',
   'DataMethod',
+  // A container carrying DataGroup is populated by the compiler from that table
+  // field group — one generated control per member, named <DataGroup>_<Field>.
+  'DataGroup',
   'HelpText',
   'Label',
   'Width',

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -3081,14 +3081,36 @@ export class XppSymbolIndex {
    * Restricts results to symbol types whose names carry the `*_Extension` /
    * `*.<model>Extension` convention (class-extension, table-extension, etc.)
    * so that unrelated symbols sharing a substring don't leak into extension UI.
+   *
+   * `model IN (custom models)` is what makes this affordable, and it has to be the
+   * FIRST predicate. A leading-wildcard `name LIKE '%q%'` is unindexable, so with the
+   * whole corpus in scope every call scanned all 584 K symbols — measured at 122.8 s on
+   * the production DB. Against idx_symbols_model the same scan covers only the ~25
+   * custom models. The filter is also a correctness fix: the results were already
+   * captioned "matches in custom extensions" while Microsoft rows could satisfy the
+   * name convention and appear there.
+   *
+   * `types` narrows to symbol kinds (the `type` argument of search(scope="extensions"),
+   * which used to be dropped before it reached here). A method or field is matched on
+   * its PARENT carrying the extension convention — its own name never does.
    */
-  searchCustomExtensions(query: string, prefix?: string, limit: number = 20): XppSymbol[] {
-    // Allow extension-shaped rows (regardless of whether the indexer set a
-    // dedicated *-extension type) while also including explicit extension types.
+  searchCustomExtensions(query: string, prefix?: string, limit: number = 20, types?: string[]): XppSymbol[] {
+    const customModels = this.getCustomModels()
+      .filter(m => !prefix || m.toLowerCase().startsWith(prefix.toLowerCase()));
+    if (customModels.length === 0) return [];
+
+    // '_' is a single-character LIKE wildcard, so the unescaped '%_Extension' this
+    // replaced also matched any name merely ENDING in "Extension" — which is how a
+    // method called validateWriteExtension was reported as an extension object.
+    const escapeLikePattern = (value: string): string =>
+      value.replace(/\\/g, '\\\\').replace(/[%_]/g, '\\$&');
+
+    const modelPlaceholders = customModels.map(() => '?').join(',');
     let sql = `
       SELECT *
       FROM symbols
-      WHERE name LIKE ?
+      WHERE model IN (${modelPlaceholders})
+        AND name LIKE ? ESCAPE '\\'
         AND (
           type IN (
             'class-extension','table-extension','form-extension','enum-extension',
@@ -3096,23 +3118,29 @@ export class XppSymbolIndex {
             'map-extension','menu-extension','security-role-extension','security-duty-extension',
             'menu-item-display-extension','menu-item-action-extension','menu-item-output-extension'
           )
-          OR name LIKE '%_Extension'
+          OR name LIKE '%\\_Extension' ESCAPE '\\'
           OR name LIKE '%.%Extension'
+          OR parent_name LIKE '%\\_Extension' ESCAPE '\\'
+          OR parent_name LIKE '%.%Extension'
         )
     `;
 
-    const params: any[] = [`%${query}%`];
+    const params: any[] = [...customModels, `%${escapeLikePattern(query)}%`];
 
-    if (prefix) {
-      sql += ` AND model LIKE ?`;
-      params.push(`${prefix}%`);
+    if (types && types.length > 0) {
+      // Unary + strips the term of its index affinity. Written plainly, `type IN ('method')`
+      // makes the planner prefer idx_type_name over idx_symbols_model — and since ~1 M of the
+      // 1.19 M rows ARE methods, that trades a 25-model seek for a scan of nearly the whole
+      // table: measured 14.8 ms → 238 ms warm, 56 s cold. EXPLAIN QUERY PLAN must keep
+      // reporting `SEARCH symbols USING INDEX idx_symbols_model`.
+      sql += ` AND +type IN (${types.map(() => '?').join(',')})`;
+      params.push(...types);
     }
 
     sql += ` ORDER BY name LIMIT ?`;
     params.push(limit);
 
-    const stmt = this.db.prepare(sql);
-    const rows = stmt.all(...params) as any[];
+    const rows = this.getReadDb().prepare(sql).all(...params) as any[];
     return rows.map(row => this.rowToSymbol(row));
   }
 

--- a/src/server/toolSchemas/getObjectInfo.ts
+++ b/src/server/toolSchemas/getObjectInfo.ts
@@ -7,7 +7,7 @@ import { OBJECT_INFO_TYPES } from '../../tools/readers/objectInfoRegistry.js';
 
 export const getObjectInfoTool = {
     name: 'get_object_info',
-    description: 'Read D365FO object metadata. For 2+ objects pass objects:[{objectType,objectName},…] (max 10) — ONE call, run in parallel, per-object sections back; never loop single calls. One object: {objectType, name}. Pick the kind via objectType: class, table, form, query, view, enum, edt, report, data-entity, menu-item, service, map, config-key, security-policy, macro. Extension types (table-extension, form-extension, enum-extension, edt-extension, data-entity-extension) list all extensions of a base object — pass the base object name or a full extension name (the dot suffix is stripped automatically). Type-specific flags go in options, e.g. {"includeRdl":true} (report), {"searchControl":"General"} (form), {"compact":false} (class), {"filter":"Path"} (macro), {"mode":"hierarchy"} (edt). For CLASSES, {"members":"names"} (optional {"prefix":...}) returns a fast IntelliSense-style member-name list instead of full metadata. Replaces the former get_<type>_info, code_completion, batch_get_info and get_method tools.',
+    description: 'Read D365FO object metadata. For 2+ objects pass objects:[{objectType,objectName},…] (max 10) — ONE call, run in parallel, per-object sections back; never loop single calls. One object: {objectType, name}. Pick the kind via objectType: class, table, form, query, view, enum, edt, report, data-entity, menu-item, service, map, config-key, security-policy, macro. Extension types (table-extension, form-extension, enum-extension, edt-extension, data-entity-extension) list all extensions of a base object — pass the base object name or a full extension name (the dot suffix is stripped automatically). Type-specific flags go in options. For CLASSES, {"members":"names"} (optional {"prefix":...}) returns a fast IntelliSense-style member-name list instead of full metadata. Replaces the former get_<type>_info, code_completion, batch_get_info and get_method tools.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -37,7 +37,7 @@ export const getObjectInfoTool = {
         },
         options: {
           type: 'object',
-          description: 'Type-specific flags forwarded to the reader: includeRdl, includeFields, searchControl, compact, includeOperations, filter, mode, modelName. On class/table/view/data-entity, {"method":"validateWrite","include":"signature"} returns ONE method (include: signature | source | both) — required before writing a CoC extension. Big objects are paged — table fieldsOffset/fieldFilter, form maxControls. Applies to every objects[] entry.',
+          description: 'Type-specific reader flags: includeRdl (report), searchControl/maxControls (form), compact/methodOffset (class), fieldsOffset/fieldFilter (table), filter (macro), mode (edt), includeFields, includeOperations, modelName. On class/table/view/data-entity, {"method":"validateWrite","include":"signature"} returns ONE method (include: signature | source | both) — required before writing a CoC extension. {"include":"xml"} returns raw AOT XML + its path (page: startLine/endLine) — never shell out to find or read a file. Applies to every objects[] entry.',
         },
       },
     },

--- a/src/tools/analysis/extensionSearch.ts
+++ b/src/tools/analysis/extensionSearch.ts
@@ -11,6 +11,11 @@ const ExtensionSearchArgsSchema = z.object({
   query: z.string().describe('Search query (class name, method name, etc.)'),
   prefix: z.string().optional().describe('Extension prefix filter (e.g., ISV_, Custom_)'),
   limit: z.number().optional().default(20).describe('Maximum results to return'),
+  // search(scope="extensions", type="method") forwards `type` here. It used to be
+  // dropped silently by this schema — z.object() strips unknown keys — so a typed
+  // extension search answered as if no filter had been asked for.
+  type: z.union([z.string(), z.array(z.string())]).optional()
+    .describe('Symbol type filter, e.g. "method" or ["class-extension","table-extension"]'),
 });
 
 export async function extensionSearchTool(request: CallToolRequest, context: XppServerContext) {
@@ -18,16 +23,29 @@ export async function extensionSearchTool(request: CallToolRequest, context: Xpp
     const args = ExtensionSearchArgsSchema.parse(request.params.arguments);
     const { symbolIndex } = context;
 
+    const types = args.type === undefined
+      ? undefined
+      : (Array.isArray(args.type) ? args.type : [args.type]);
+
     // Query database
-    const results = symbolIndex.searchCustomExtensions(args.query, args.prefix, args.limit);
+    const results = symbolIndex.searchCustomExtensions(args.query, args.prefix, args.limit, types);
 
     if (results.length === 0) {
       const prefixMsg = args.prefix ? ` with prefix "${args.prefix}"` : '';
+      const typeMsg = types ? ` of type ${types.join('/')}` : '';
+      // The scope is now defined by the custom-model list, so an empty list means every
+      // extension search returns nothing — a configuration fault, not an empty result set.
+      // Worth naming, or it reads as "this workspace has no extensions".
+      const noCustomModels = symbolIndex.getCustomModels().length === 0;
       return {
         content: [
           {
             type: 'text',
-            text: `No custom extension symbols found matching "${args.query}"${prefixMsg}`,
+            text: noCustomModels
+              ? `⚠️ No custom/ISV models are known to the index, so scope="extensions" can never match.\n` +
+                `Set CUSTOM_MODELS or EXTENSION_PREFIX, or drop scope="extensions" to search the whole index.`
+              : `No custom extension symbols${typeMsg} found matching "${args.query}"${prefixMsg}.\n` +
+                `This scope covers CUSTOM/ISV models only. For the standard corpus drop scope="extensions".`,
           },
         ],
       };

--- a/src/tools/analysis/labelSearchHistory.ts
+++ b/src/tools/analysis/labelSearchHistory.ts
@@ -1,0 +1,81 @@
+/**
+ * The phrasings already tried against the labels index.
+ *
+ * Every search result says rephrasing does not help; callers rephrase anyway.
+ * Naming the wordings they already tried is harder to argue with than the same
+ * advice stated in the abstract.
+ *
+ * Advisory, not a refusal: this process outlives one chat session, so leftover
+ * state must never block a legitimate first search. Hence the TTL and a note.
+ */
+
+/** Older entries are forgotten — this process is shared across chat sessions. */
+const HISTORY_TTL_MS = 30 * 60 * 1000;
+
+/** Beyond this many remembered phrasings, the list is summarised rather than printed. */
+const MAX_LISTED = 12;
+
+interface Entry {
+  /** The phrasing as the caller spelled it — echoing it back is the point. */
+  query: string;
+  at: number;
+  /** False once the search came back with something this model can resolve. */
+  fruitless: boolean;
+}
+
+const history: Entry[] = [];
+
+function prune(now: number): void {
+  while (history.length > 0 && now - history[0].at > HISTORY_TTL_MS) history.shift();
+}
+
+/** Record one search and whether it came back empty-handed. */
+export function recordLabelSearch(query: string, fruitless: boolean): void {
+  const now = Date.now();
+  prune(now);
+  const key = query.trim().toLowerCase();
+  if (key === '') return;
+  const existing = history.find(e => e.query.trim().toLowerCase() === key);
+  if (existing) {
+    existing.at = now;
+    // A phrasing that found something once is not fruitless, however often it is
+    // repeated — only the empty-handed ones are what this counts.
+    existing.fruitless = existing.fruitless && fruitless;
+    return;
+  }
+  history.push({ query, at: now, fruitless });
+}
+
+/** Phrasings tried in this session that found nothing, oldest first. */
+export function fruitlessLabelSearches(): string[] {
+  prune(Date.now());
+  return history.filter(e => e.fruitless).map(e => e.query);
+}
+
+/**
+ * The line that goes at the top of a no-hit answer once the caller has been here
+ * before. Empty until then — the first miss is ordinary and needs no lecture.
+ *
+ * `excluding` drops the current call's own phrasings, so a six-query batch does
+ * not read as six previous attempts.
+ */
+export function repeatSearchNotice(excluding: readonly string[] = []): string {
+  const skip = new Set(excluding.map(q => q.trim().toLowerCase()));
+  const prior = fruitlessLabelSearches().filter(q => !skip.has(q.trim().toLowerCase()));
+  if (prior.length === 0) return '';
+
+  const listed = prior.length > MAX_LISTED
+    ? `${prior.slice(0, MAX_LISTED).map(q => `"${q}"`).join(', ')} … and ${prior.length - MAX_LISTED} more`
+    : prior.map(q => `"${q}"`).join(', ');
+
+  return (
+    `🛑 **This is not new information.** ${prior.length} phrasing(s) already came back empty here: ` +
+    `${listed}. They all query the same index, so this answer was settled by the first of them. ` +
+    `Create the label and move on — searching again cannot change it.\n`
+  );
+}
+
+/** Forget everything. Tests only. */
+export function resetLabelSearchHistory(): void {
+  history.length = 0;
+}

--- a/src/tools/analysis/searchLabels.ts
+++ b/src/tools/analysis/searchLabels.ts
@@ -37,12 +37,24 @@ export const REUSABLE_MARKER = '💡 Use the label reference syntax in X++:';
  * from the first call onwards. Every phrasing queries the same index, so say
  * that, and hand over the call that ends the loop.
  */
-export const NO_REUSE_ADVICE =
-  `➡️  Nothing reusable here — create your own label and move on:\n` +
+const CREATE_CALL_ADVICE =
   `      labels(action="create", labelFileId="<your model's label file>", model="<your model>",\n` +
   `             labelId="<MeaningOfTheText>", translations=[{language:"en-US", text:"…"}])\n` +
   `   Rephrasing does not help: every wording queries the same index. To try several at once,\n` +
   `   pass query as an array — labels(action="search", query=["…", "…", "…"]) — one call, not one each.\n`;
+
+export const NO_REUSE_ADVICE =
+  `➡️  Nothing reusable here — create your own label and move on:\n` + CREATE_CALL_ADVICE;
+
+/**
+ * Same call, for the branch where hits DID come back.
+ *
+ * NO_REUSE_ADVICE opens with "Nothing reusable here", which contradicts a verdict
+ * that just reported a resolvable label. Callers resolve the contradiction by
+ * searching again — the loop the verdict exists to end.
+ */
+export const SOME_REUSE_ADVICE =
+  `➡️  If none of the hits above says what you need, create your own label and move on:\n` + CREATE_CALL_ADVICE;
 
 const SearchLabelsArgsSchema = z.object({
   query: z

--- a/src/tools/analysis/searchLabels.ts
+++ b/src/tools/analysis/searchLabels.ts
@@ -19,6 +19,7 @@ import {
   isLabelLikelyResolvable,
   labelProvenanceWarning,
 } from '../../utils/labelReference.js';
+import { recordLabelSearch, repeatSearchNotice } from './labelSearchHistory.js';
 
 /**
  * Emitted only when a label the current model can actually resolve was found.
@@ -26,6 +27,13 @@ import {
  * reusable, so keep the two in step.
  */
 export const REUSABLE_MARKER = '💡 Use the label reference syntax in X++:';
+
+/**
+ * Opens the answer for a query that matched nothing. `labels` reads it back to
+ * collapse those sections in a batch — a paragraph of identical advice repeated
+ * once per phrasing was most of a 5 KB result — so keep the two in step.
+ */
+export const NO_HITS_MARKER = 'No labels found matching';
 
 /**
  * What to do when nothing reusable came back.
@@ -74,7 +82,11 @@ const SearchLabelsArgsSchema = z.object({
   labelFileId: z
     .string()
     .optional()
-    .describe('Restrict results to a specific label file ID (e.g. ContosoExt, SYS)'),
+    .describe(
+      'Restrict results to ONE label file ID (e.g. ContosoExt, SYS). Omitting it searches every label ' +
+      'file at once — the default, and almost always what you want. Running the same query once per ' +
+      'label file buys nothing but round trips.',
+    ),
   maxResults: z
     .number()
     .optional()
@@ -121,21 +133,28 @@ export async function searchLabelsTool(request: CallToolRequest, context: XppSer
     const results = symbolIndex.searchLabels(query, { language, model, labelFileId, limit: probeLimit });
 
     if (results.length === 0) {
+      // Named before the advice: a caller that has already tried five wordings
+      // needs to hear that it has, not the same paragraph a sixth time.
+      const repeatNotice = repeatSearchNotice([query]);
+      recordLabelSearch(query, true);
       return {
         content: [
           {
             type: 'text',
             text:
-              `No labels found matching "${query}"` +
+              `${NO_HITS_MARKER} "${query}"` +
               (language !== 'en-US' ? ` in language "${language}"` : '') +
               (model ? ` in model "${model}"` : '') +
               '.\n\n' +
+              (repeatNotice ? `${repeatNotice}\n` : '') +
               NO_REUSE_ADVICE +
               `💡 To search a different language use the language parameter (e.g. "cs", "de", "sk").`,
           },
         ],
       };
     }
+
+    recordLabelSearch(query, false);
 
     // Normalise column names (DB returns snake_case)
     const normalise = (r: any) => ({

--- a/src/tools/analysis/validateFormPattern.ts
+++ b/src/tools/analysis/validateFormPattern.ts
@@ -209,6 +209,73 @@ export async function checkAddControlAgainstParentPattern(
   return { parentPattern: sp.xmlName, allowed, allowedTypes: [...allowedTypes] };
 }
 
+/** Result of the add-control DataGroup pre-flight */
+export interface AddControlDataGroupVerdict {
+  /** Field group the parent container renders (its <DataGroup> value) */
+  dataGroup: string;
+  /** Datasource the field group resolves against, when the parent declares one */
+  dataSource?: string;
+  /** Control name the compiler generates for this field: <DataGroup>_<DataField> */
+  generatedName: string;
+  /** True when the requested controlName is exactly the generated one — a certain build error */
+  exactNameCollision: boolean;
+}
+
+/**
+ * Pre-flight for add-control: refuse to hand-add a BOUND control under a
+ * container that carries <DataGroup>.
+ *
+ * Such a container is populated by the compiler from that table field group —
+ * one control per member, named `<DataGroup>_<FieldName>`. Adding the field to
+ * the field group (add-field-to-field-group on the table extension) AND an
+ * explicit control for it produces "The duplicate name '…' was detected". The
+ * duplicate is invisible on disk: only the explicit control is written to a
+ * file, so inspecting the XML never reveals it.
+ *
+ * Returns null when the parent cannot be found, declares no DataGroup, or the
+ * new control is unbound (a button or static text in such a group is fine).
+ */
+export async function checkAddControlAgainstDataGroup(
+  baseFormXml: string,
+  parentControlName: string,
+  controlDataField: string | undefined,
+  controlName: string | undefined,
+): Promise<AddControlDataGroupVerdict | null> {
+  if (!controlDataField) return null;
+
+  let parsed: any;
+  try {
+    const parser = new Parser({ explicitArray: false, mergeAttrs: true, trim: true });
+    parsed = await parser.parseStringPromise(baseFormXml);
+  } catch {
+    return null;
+  }
+  if (!parsed?.AxForm?.Design) return null;
+
+  const design = walkFormDesign(parsed.AxForm.Design);
+  const needle = parentControlName.toLowerCase();
+  let parent: FormControlNode | undefined;
+  const visit = (nodes: FormControlNode[]): void => {
+    for (const n of nodes) {
+      if (n.name.toLowerCase() === needle) { parent = n; return; }
+      visit(n.children);
+      if (parent) return;
+    }
+  };
+  visit(design.controls);
+
+  const dataGroup = parent?.properties?.DataGroup;
+  if (!dataGroup) return null;
+
+  const generatedName = `${dataGroup}_${controlDataField}`;
+  return {
+    dataGroup,
+    dataSource: parent?.properties?.DataSource,
+    generatedName,
+    exactNameCollision: (controlName ?? '').toLowerCase() === generatedName.toLowerCase(),
+  };
+}
+
 /**
  * Gate a form write on pattern errors. Returns an MCP error result when the
  * XML has error-severity pattern violations and enforcement is enabled;

--- a/src/tools/analysis/validateFormPattern.ts
+++ b/src/tools/analysis/validateFormPattern.ts
@@ -276,6 +276,63 @@ export async function checkAddControlAgainstDataGroup(
   };
 }
 
+/** A control that renders a table field group through its <DataGroup> property */
+export interface DataGroupRenderer {
+  /** Name of the container control carrying <DataGroup> */
+  controlName: string;
+  /** Its <DataSource>, when it declares one */
+  dataSource?: string;
+  /** Control the compiler generates for a member field: <DataGroup>_<FieldName> */
+  generatedNameFor: (fieldName: string) => string;
+}
+
+/**
+ * The reverse of {@link checkAddControlAgainstDataGroup}: given a field group,
+ * find the controls that already render it via <DataGroup>.
+ *
+ * Same fact, asked one step earlier. The add-control guard can only fire once a
+ * form extension exists and a control is being added to it — by then the agent
+ * has spent a create it will have to undo. Asked at add-field-to-field-group
+ * time, the answer ("this group is already on the form; the control appears by
+ * itself") arrives before any of that is written.
+ *
+ * Returns [] when the XML is unparseable or no container renders the group.
+ */
+export async function findDataGroupRenderers(
+  baseFormXml: string,
+  fieldGroupName: string,
+): Promise<DataGroupRenderer[]> {
+  let parsed: any;
+  try {
+    const parser = new Parser({ explicitArray: false, mergeAttrs: true, trim: true });
+    parsed = await parser.parseStringPromise(baseFormXml);
+  } catch {
+    return [];
+  }
+  if (!parsed?.AxForm?.Design) return [];
+
+  const design = walkFormDesign(parsed.AxForm.Design);
+  const needle = fieldGroupName.toLowerCase();
+  const found: DataGroupRenderer[] = [];
+
+  const visit = (nodes: FormControlNode[]): void => {
+    for (const n of nodes) {
+      const dataGroup = n.properties?.DataGroup;
+      if (dataGroup && dataGroup.toLowerCase() === needle) {
+        found.push({
+          controlName: n.name,
+          dataSource: n.properties?.DataSource,
+          generatedNameFor: (fieldName: string) => `${dataGroup}_${fieldName}`,
+        });
+      }
+      visit(n.children);
+    }
+  };
+  visit(design.controls);
+
+  return found;
+}
+
 /**
  * Gate a form write on pattern errors. Returns an MCP error result when the
  * XML has error-severity pattern violations and enforcement is enabled;

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -15,6 +15,7 @@
  *   COC002  [ExtensionOf] class not declared final
  *   COC003  [ExtensionOf] class name not ending _Extension
  *   COC004  next not reached exactly once and unconditionally (SYS10028)
+ *   COC005  Global function (checkFailed/error/…) called as this.<fn>() on a table buffer
  *   BP001   Hardcoded string literal in info/warning/error/checkFailed
  *   BP002   doInsert/doUpdate/doDelete outside explicit migration comment
  *   BP003   Generic doc-comment (/// Foo class. / /// methodName.)
@@ -388,6 +389,67 @@ function checkExtensionOfNaming(code: string): ValidationViolation[] {
       }
     }
   }
+  return violations;
+}
+
+/**
+ * The X++ Global functions that read like buffer methods and are therefore the
+ * ones people qualify with `this.` inside a table CoC wrapper. They live on
+ * `Global`, are called unqualified, and are NOT members of `Common` — so on a
+ * table buffer every one of them is a hard xppc error, not a BP finding:
+ * "Table 'X' does not contain a definition for method 'checkFailed'".
+ */
+const GLOBAL_FUNCTIONS_NOT_ON_TABLE = [
+  'checkFailed', 'error', 'warning', 'info', 'strFmt', 'setPrefix', 'funcName',
+];
+
+/**
+ * COC005 — a Global function called as `this.<fn>()` on a table buffer.
+ *
+ * `checkFailed()` is the natural way to fail a `validateWrite` wrapper, and writing
+ * it as `this.checkFailed(...)` looks right: every other statement in the method
+ * (`this.orig()`, `this.validateWrite()`, `this.MyField`) is a member of the buffer,
+ * so the qualifier reads as consistent. It is not — the buffer is a `Common`
+ * descendant and these functions live on `Global`, so the compiler rejects it with
+ * ClassDoesNotContainMethod. Nothing short of a build caught it: xppbp does not
+ * diagnose it, the symbol index resolves `checkFailed` (it exists, just elsewhere),
+ * and the method is otherwise correct X++.
+ *
+ * Scoped to `[ExtensionOf(tableStr(...))]` on purpose. On a class deriving from
+ * RunBase the same `this.checkFailed()` is legal, so a blanket rule would be wrong
+ * far more often than right.
+ */
+function checkGlobalFunctionOnTableBuffer(code: string): ValidationViolation[] {
+  const violations: ValidationViolation[] = [];
+  if (!/\[ExtensionOf\s*\(\s*tableStr\s*\(/i.test(code)) return violations;
+
+  const lines = code.split('\n');
+  const masked = maskStringsAndComments(code).split('\n');
+  const pattern = new RegExp(
+    `\\bthis\\s*\\.\\s*(${GLOBAL_FUNCTIONS_NOT_ON_TABLE.join('|')})\\s*\\(`,
+    'gi',
+  );
+
+  masked.forEach((clean, i) => {
+    pattern.lastIndex = 0;
+    const m = pattern.exec(clean);
+    if (!m) return;
+    const fn = m[1];
+    violations.push({
+      rule: 'COC005',
+      severity: 'error',
+      line: i + 1,
+      excerpt: lines[i].trim(),
+      fix:
+        `"${fn}" is a Global function, not a method of the table buffer. The compiler rejects ` +
+        `"this.${fn}(…)" with "Table '<name>' does not contain a definition for method '${fn}'". ` +
+        `Call it unqualified: "${fn}(…)"` +
+        (fn === 'checkFailed'
+          ? ' — the idiom in a validateWrite wrapper is "ret = checkFailed(\'@Model:LabelId\');".'
+          : '.'),
+    });
+  });
+
   return violations;
 }
 
@@ -843,6 +905,7 @@ const XPP_RULES = [
   checkExtensionOfNotFinal,
   checkExtensionOfNaming,
   checkCocNextUnconditional,
+  checkGlobalFunctionOnTableBuffer,
   checkEnum2StrInMessage,
   checkHardcodedStrings,
   checkDoMethods,

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -392,13 +392,7 @@ function checkExtensionOfNaming(code: string): ValidationViolation[] {
   return violations;
 }
 
-/**
- * The X++ Global functions that read like buffer methods and are therefore the
- * ones people qualify with `this.` inside a table CoC wrapper. They live on
- * `Global`, are called unqualified, and are NOT members of `Common` — so on a
- * table buffer every one of them is a hard xppc error, not a BP finding:
- * "Table 'X' does not contain a definition for method 'checkFailed'".
- */
+/** Global functions, not members of `Common` — unqualified on a table buffer. */
 const GLOBAL_FUNCTIONS_NOT_ON_TABLE = [
   'checkFailed', 'error', 'warning', 'info', 'strFmt', 'setPrefix', 'funcName',
 ];
@@ -406,18 +400,12 @@ const GLOBAL_FUNCTIONS_NOT_ON_TABLE = [
 /**
  * COC005 — a Global function called as `this.<fn>()` on a table buffer.
  *
- * `checkFailed()` is the natural way to fail a `validateWrite` wrapper, and writing
- * it as `this.checkFailed(...)` looks right: every other statement in the method
- * (`this.orig()`, `this.validateWrite()`, `this.MyField`) is a member of the buffer,
- * so the qualifier reads as consistent. It is not — the buffer is a `Common`
- * descendant and these functions live on `Global`, so the compiler rejects it with
- * ClassDoesNotContainMethod. Nothing short of a build caught it: xppbp does not
- * diagnose it, the symbol index resolves `checkFailed` (it exists, just elsewhere),
- * and the method is otherwise correct X++.
+ * `this.checkFailed(...)` reads as consistent next to `this.orig()`, and xppc
+ * rejects it with ClassDoesNotContainMethod. Nothing but a build caught it:
+ * xppbp does not diagnose it and the symbol index resolves the name.
  *
- * Scoped to `[ExtensionOf(tableStr(...))]` on purpose. On a class deriving from
- * RunBase the same `this.checkFailed()` is legal, so a blanket rule would be wrong
- * far more often than right.
+ * Scoped to `[ExtensionOf(tableStr(...))]` — on a RunBase descendant the same
+ * call is legal.
  */
 function checkGlobalFunctionOnTableBuffer(code: string): ValidationViolation[] {
   const violations: ValidationViolation[] = [];
@@ -464,16 +452,9 @@ function checkGlobalFunctionOnTableBuffer(code: string): ValidationViolation[] {
  * Scoped to the message builders (info/warning/error/checkFailed/strFmt) because
  * enum2str is perfectly correct for a log line, a filename or a comparison key.
  *
- * Matched over the call's whole argument span, not per line. The line-scoped
- * version missed the shape a caller actually writes once the call has three
- * arguments:
- *
- *     ret = checkFailed(strFmt("@Model:Downgrade",
- *         enum2str(this.orig().Tier),
- *         enum2str(this.Tier)));
- *
- * — `checkFailed` and `enum2str` never share a line, so run 9180a464 asked
- * validate_code about exactly this and was told "✅ no violations found".
+ * Matched over the call's whole argument span: in a wrapped
+ * `checkFailed(strFmt("@M:Id",\n enum2str(a),\n enum2str(b)))` the message
+ * builder and enum2str never share a line, which a per-line scan misses.
  */
 function checkEnum2StrInMessage(code: string): ValidationViolation[] {
   const violations: ValidationViolation[] = [];

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -463,25 +463,58 @@ function checkGlobalFunctionOnTableBuffer(code: string): ValidationViolation[] {
  *
  * Scoped to the message builders (info/warning/error/checkFailed/strFmt) because
  * enum2str is perfectly correct for a log line, a filename or a comparison key.
+ *
+ * Matched over the call's whole argument span, not per line. The line-scoped
+ * version missed the shape a caller actually writes once the call has three
+ * arguments:
+ *
+ *     ret = checkFailed(strFmt("@Model:Downgrade",
+ *         enum2str(this.orig().Tier),
+ *         enum2str(this.Tier)));
+ *
+ * — `checkFailed` and `enum2str` never share a line, so run 9180a464 asked
+ * validate_code about exactly this and was told "✅ no violations found".
  */
 function checkEnum2StrInMessage(code: string): ValidationViolation[] {
   const violations: ValidationViolation[] = [];
-  const masked = maskStringsAndComments(code).split('\n');
+  const masked = maskStringsAndComments(code);
   const lines = code.split('\n');
+  const reported = new Set<number>();
 
-  masked.forEach((clean, i) => {
-    if (!/\benum2str\s*\(/.test(clean)) return;
-    if (!/\b(?:info|warning|error|checkFailed|strFmt)\s*\(/.test(clean)) return;
-    violations.push({
-      rule: 'BP005',
-      severity: 'warning',
-      line: i + 1,
-      excerpt: lines[i].trim(),
-      fix:
-        'enum2str() returns the symbolic name, not the label — this message stays English in every locale. ' +
-        'Use "new DictEnum(enumNum(MyEnum)).value2Label(enum2int(value))" to get the translated text.',
-    });
-  });
+  const callRe = /\b(?:info|warning|error|checkFailed|strFmt)\s*\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(masked)) !== null) {
+    // Walk from the opening paren to its match so nested calls and multi-line
+    // argument lists are one span.
+    let depth = 0;
+    let end = m.index + m[0].length - 1;
+    for (; end < masked.length; end++) {
+      const ch = masked[end];
+      if (ch === '(') depth++;
+      else if (ch === ')') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    const span = masked.slice(m.index, Math.min(end + 1, masked.length));
+
+    const inner = /\benum2str\s*\(/g;
+    let hit: RegExpExecArray | null;
+    while ((hit = inner.exec(span)) !== null) {
+      const lineNo = lineNumber(masked, m.index + hit.index);
+      if (reported.has(lineNo)) continue;
+      reported.add(lineNo);
+      violations.push({
+        rule: 'BP005',
+        severity: 'warning',
+        line: lineNo,
+        excerpt: lines[lineNo - 1].trim(),
+        fix:
+          'enum2str() returns the symbolic name, not the label — this message stays English in every locale. ' +
+          'Use "new DictEnum(enumNum(MyEnum)).value2Label(enum2int(value))" to get the translated text.',
+      });
+    }
+  }
 
   return violations;
 }

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -20,7 +20,7 @@
  *   BP002   doInsert/doUpdate/doDelete outside explicit migration comment
  *   BP003   Generic doc-comment (/// Foo class. / /// methodName.)
  *   BP004   Developer-only statements left in code (pause / print)
- *   BP005   enum2str() in user-facing text (emits the symbol, never the translation)
+ *   BP005   an enum SYMBOL (enum2Symbol / value2Symbol) in user-facing text — never translated
  *   TTS001  Unbalanced ttsbegin / ttscommit
  *   XML001  AxTable XML missing an index with <AlternateKey>Yes</AlternateKey>
  *   XML006  AxTable elements out of canonical order (silently dropped by the AOT)
@@ -442,21 +442,27 @@ function checkGlobalFunctionOnTableBuffer(code: string): ValidationViolation[] {
 }
 
 /**
- * BP005 — enum2str() feeding user-facing text.
+ * BP005 — an enum's SYMBOL feeding user-facing text.
  *
- * enum2str returns the enum's symbolic NAME ('Gold'), never its <Label>, so a message
- * built with it stays English on a Czech or Slovak client no matter how carefully the
- * enum was labelled. The runtime API that resolves the translation is
- * `new DictEnum(enumNum(MyEnum)).value2Label(enum2int(value))`.
+ * `enum2Symbol()` / `DictEnum.value2Symbol()` return the AOT name ('Gold'), which is
+ * not a label and is never translated, so a message built from one stays English on a
+ * Czech or Slovak client no matter how carefully the enum was labelled.
  *
- * Scoped to the message builders (info/warning/error/checkFailed/strFmt) because
- * enum2str is perfectly correct for a log line, a filename or a comparison key.
+ * NOT enum2str, which this rule used to flag: enum2str resolves the value's <Label> in
+ * the session language, and the platform ships it inside checkFailed, throw error and
+ * control captions. `Global::enum2Symbol` is itself `new DictEnum(_id).value2Symbol()`
+ * — a separate function for the symbol only makes sense because enum2str is not it.
+ * DictEnum.value2Label remains the answer when the enum type is known only at runtime.
+ *
+ * Scoped to the message builders (info/warning/error/checkFailed/strFmt): a symbol is
+ * correct for a log line, a filename or a comparison key, and it is the only safe thing
+ * to persist for an extensible enum, whose integers are assigned at deployment time.
  *
  * Matched over the call's whole argument span: in a wrapped
- * `checkFailed(strFmt("@M:Id",\n enum2str(a),\n enum2str(b)))` the message
- * builder and enum2str never share a line, which a per-line scan misses.
+ * `checkFailed(strFmt("@M:Id",\n enum2Symbol(a),\n enum2Symbol(b)))` the message
+ * builder and the symbol call never share a line, which a per-line scan misses.
  */
-function checkEnum2StrInMessage(code: string): ValidationViolation[] {
+function checkEnumSymbolInMessage(code: string): ValidationViolation[] {
   const violations: ValidationViolation[] = [];
   const masked = maskStringsAndComments(code);
   const lines = code.split('\n');
@@ -479,7 +485,8 @@ function checkEnum2StrInMessage(code: string): ValidationViolation[] {
     }
     const span = masked.slice(m.index, Math.min(end + 1, masked.length));
 
-    const inner = /\benum2str\s*\(/g;
+    // Both spellings: the Global wrapper and the DictEnum method it delegates to.
+    const inner = /(?:\benum2Symbol|\.\s*value2Symbol)\s*\(/gi;
     let hit: RegExpExecArray | null;
     while ((hit = inner.exec(span)) !== null) {
       const lineNo = lineNumber(masked, m.index + hit.index);
@@ -491,8 +498,10 @@ function checkEnum2StrInMessage(code: string): ValidationViolation[] {
         line: lineNo,
         excerpt: lines[lineNo - 1].trim(),
         fix:
-          'enum2str() returns the symbolic name, not the label — this message stays English in every locale. ' +
-          'Use "new DictEnum(enumNum(MyEnum)).value2Label(enum2int(value))" to get the translated text.',
+          'This prints the enum\'s AOT name, which is never translated — the message stays English in ' +
+          'every locale. Use enum2str(value) when the enum type is known at compile time; when it is ' +
+          'only known at runtime, new DictEnum(enumId).value2Label(value). Keep the symbol for logs, ' +
+          'filenames and anything persisted.',
       });
     }
   }
@@ -920,7 +929,7 @@ const XPP_RULES = [
   checkExtensionOfNaming,
   checkCocNextUnconditional,
   checkGlobalFunctionOnTableBuffer,
-  checkEnum2StrInMessage,
+  checkEnumSymbolInMessage,
   checkHardcodedStrings,
   checkDoMethods,
   checkGenericDocComment,

--- a/src/tools/d365foFile.ts
+++ b/src/tools/d365foFile.ts
@@ -115,15 +115,9 @@ async function runModifyBatch(
     // Per-entry keys win over the shared ones, so objectType/objectName/modelName
     // are stated once at the top level and an entry can still override them.
     //
-    // Each entry gets the same `params` unwrap the single-operation form gets
-    // above. It did not, and the two disagreed in the worst possible direction:
-    // get_knowledge(kind="op-spec") tells the caller in bold to "pass these
-    // NESTED inside `params`", and doing exactly that inside operations[] left
-    // the wrapper object sitting in the args untouched, so the operation ran
-    // with none of its parameters and answered "called with no parameter that
-    // changes anything — nothing would be written". Run 9180a464 obeyed the
-    // spec, was refused, and only got through by ignoring it and passing the
-    // keys flat.
+    // Each entry gets the same `params` unwrap as the single-operation form.
+    // Without it the wrapper stayed in the args and the operation ran with no
+    // parameters — while op-spec instructs callers to nest them there.
     const { params: entryParams, ...entryFlat } = entry as Record<string, unknown>;
     const entryArgs = {
       ...shared,

--- a/src/tools/d365foFile.ts
+++ b/src/tools/d365foFile.ts
@@ -114,7 +114,25 @@ async function runModifyBatch(
     }
     // Per-entry keys win over the shared ones, so objectType/objectName/modelName
     // are stated once at the top level and an entry can still override them.
-    const entryArgs = { ...shared, ...(entry as Record<string, unknown>), peerOperations };
+    //
+    // Each entry gets the same `params` unwrap the single-operation form gets
+    // above. It did not, and the two disagreed in the worst possible direction:
+    // get_knowledge(kind="op-spec") tells the caller in bold to "pass these
+    // NESTED inside `params`", and doing exactly that inside operations[] left
+    // the wrapper object sitting in the args untouched, so the operation ran
+    // with none of its parameters and answered "called with no parameter that
+    // changes anything — nothing would be written". Run 9180a464 obeyed the
+    // spec, was refused, and only got through by ignoring it and passing the
+    // keys flat.
+    const { params: entryParams, ...entryFlat } = entry as Record<string, unknown>;
+    const entryArgs = {
+      ...shared,
+      ...entryFlat,
+      ...(entryParams && typeof entryParams === 'object' && !Array.isArray(entryParams)
+        ? (entryParams as Record<string, unknown>)
+        : {}),
+      peerOperations,
+    };
     const opName = String((entry as any).operation ?? '(missing operation)');
 
     if (!(entry as any).operation) {

--- a/src/tools/knowledge/d365foErrorHelp.ts
+++ b/src/tools/knowledge/d365foErrorHelp.ts
@@ -259,6 +259,41 @@ ttscommit;`,
     related: [],
   },
   {
+    patterns: [
+      'classdoesnotcontainmethod',
+      'does not contain a definition for method',
+      'no extension method',
+      'accepting a first argument of type',
+    ],
+    title: 'Method Does Not Exist on That Type',
+    explanation:
+      'The compiler resolved the receiver (a table buffer, a class instance) but found no such method on it. ' +
+      'On a TABLE buffer this is almost always a Global function called as if it were a member: checkFailed(), ' +
+      'error(), warning(), info(), strFmt() and setPrefix() live on Global and are called unqualified — the ' +
+      'buffer is a Common descendant and has none of them. Writing "this.checkFailed(…)" inside a validateWrite ' +
+      'CoC wrapper reads perfectly and does not compile.',
+    fix: [
+      'Drop the qualifier: "ret = checkFailed(\'@MyModel:LabelId\');" — not "this.checkFailed(...)"',
+      'For a genuine member, confirm it exists: get_object_info(objectType="table", name="TableName", options={method:"<name>", include:"signature"})',
+      'On a class, check you are not calling a method of the WRAPPED type from an [ExtensionOf] class — extension classes cannot see private members',
+      'validate_code(mode="syntax") flags the table-buffer case as COC005 without needing a build',
+    ],
+    example: `[ExtensionOf(tableStr(MyTable))]
+final class MyTable_MyModel_Extension
+{
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        if (ret && /* rule violated */ true)
+        {
+            ret = checkFailed("@MyModel:RuleBroken"); // ✅ Global function, unqualified
+        }
+        return ret;
+    }
+}`,
+    related: ['coc', 'coc-authoring'],
+  },
+  {
     patterns: ['label does not exist', 'label not found', '@sys', 'undefined label', 'label reference'],
     title: 'Label Does Not Exist',
     explanation:
@@ -337,6 +372,31 @@ function isSignificantWord(word: string): boolean {
   return word.length >= 3 && !STOPWORDS.has(word) && !/^\d+$/.test(word);
 }
 
+/**
+ * Score at or above which a match is treated as an answer rather than a guess.
+ *
+ * 10 is one whole pattern appearing verbatim (see scoreError). Everything below
+ * that comes purely from the loose word fallback, which is fine for "did you
+ * also mean…" and much too weak to print as the diagnosis.
+ *
+ * Run a5677c99 is why the line exists. `ClassDoesNotContainMethod: Table 'X'
+ * does not contain a definition for method 'checkFailed'` scored 4 on the entry
+ * "Field Does Not Exist on Table" — the pattern `field not found on table`
+ * matched the words "found" and "table", neither of which is about a field —
+ * and that was the highest score, so it was returned as the answer. Worse,
+ * `lookupErrorFix` puts the winner straight into build_d365fo_project's output,
+ * so the agent read "Field Does Not Exist on Table: Call get_object_info(…)"
+ * printed directly under a real compiler error about a method, and went looking
+ * at fields.
+ */
+const MIN_CONFIDENT_SCORE = 10;
+
+/** Whole-word containment — 'table' must not match inside 'MyTableExtension'. */
+function containsWord(haystack: string, word: string): boolean {
+  if (!haystack) return false;
+  return new RegExp(`\\b${word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(haystack);
+}
+
 function scoreError(entry: ErrorEntry, errorText: string, errorCode?: string): number {
   const lowerText = errorText.toLowerCase();
   const lowerCode = (errorCode ?? '').toLowerCase();
@@ -348,7 +408,7 @@ function scoreError(entry: ErrorEntry, errorText: string, errorCode?: string): n
     // Partial match fallback on significant words only; multi-word patterns need
     // at least 2 matched words so one shared generic term can't cause a false match.
     const words = pattern.split(/\s+/).filter(isSignificantWord);
-    const matchedWords = words.filter(w => lowerText.includes(w) || lowerCode.includes(w));
+    const matchedWords = words.filter(w => containsWord(lowerText, w) || containsWord(lowerCode, w));
     const meetsThreshold = words.length <= 1 ? matchedWords.length === 1 : matchedWords.length >= 2;
     if (meetsThreshold) {
       score += matchedWords.length * 2;
@@ -391,7 +451,7 @@ function formatEntry(entry: ErrorEntry, context?: string): string {
 export function lookupErrorFix(errorText: string): { title: string; fix: string[] } | undefined {
   const scored = ERROR_DB
     .map(entry => ({ entry, score: scoreError(entry, errorText, undefined) }))
-    .filter(s => s.score > 0)
+    .filter(s => s.score >= MIN_CONFIDENT_SCORE)
     .sort((a, b) => b.score - a.score);
   if (scored.length === 0) return undefined;
   return { title: scored[0].entry.title, fix: scored[0].entry.fix };
@@ -408,12 +468,21 @@ export function d365foErrorHelpTool(request: CallToolRequest) {
       .filter(s => s.score > 0)
       .sort((a, b) => b.score - a.score);
 
-    if (scored.length === 0) {
+    // Below MIN_CONFIDENT_SCORE nothing matched on more than a stray shared word.
+    // Saying so — and listing the near-misses AS near-misses — is worth more than
+    // dressing the top guess up as the diagnosis; a confidently wrong answer sends
+    // the caller off to fix something that was never broken.
+    if (scored.length === 0 || scored[0].score < MIN_CONFIDENT_SCORE) {
+      const guesses = scored
+        .slice(0, 3)
+        .map(s => `- **${s.entry.title}** (weak match — shared wording only)`)
+        .join('\n');
       return {
         content: [{
           type: 'text' as const,
           text:
             `❌ No matching error pattern found for:\n\n> ${errorText}\n\n` +
+            (guesses ? `_Nothing scored as a real match. Closest entries, none confirmed:_\n${guesses}\n\n` : '') +
             `**Suggestions:**\n` +
             `- Try searching the error code in Microsoft docs: https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/\n` +
             `- Use get_knowledge(kind="knowledge") with the relevant topic (e.g. "transactions", "coc", "query-patterns")\n` +

--- a/src/tools/knowledge/d365foErrorHelp.ts
+++ b/src/tools/knowledge/d365foErrorHelp.ts
@@ -294,6 +294,45 @@ final class MyTable_MyModel_Extension
     related: ['coc', 'coc-authoring'],
   },
   {
+    patterns: [
+      'duplicate name',
+      'was detected. the duplication',
+      'duplication is either in the base element',
+      'duplicate control',
+    ],
+    title: 'Duplicate Control Name in a Form Extension',
+    explanation:
+      'A form extension declares a control whose name already exists on the base form. The usual cause is ' +
+      'invisible: the field was added to a table field group that the base form renders through ' +
+      '<DataGroup>, and the compiler generates a control named "<FieldGroupName>_<FieldName>" for it. ' +
+      'Adding an explicit control for the same field collides with that generated one. ' +
+      'The duplicate exists only after compilation — grepping the XML on disk will never find it, ' +
+      'because only one of the two controls is written to a file.',
+    fix: [
+      'Pick one mechanism, never both: EITHER the field group entry OR an explicit control',
+      'Preferred: keep add-field-to-field-group on the table extension and delete the control from the form extension — the field renders on its own',
+      'Check which field groups the base form renders: get_object_info(objectType="form", name="BaseForm", options={include:"xml"}) and look for <DataGroup> on the Grid/Group',
+      'If you genuinely need an explicit control (different position, type or properties), remove the field from the field group instead',
+      'Do NOT search other models or packages for the name — a sibling extension is the rare cause, the field group is the common one',
+    ],
+    example: `<!-- Base form: the Grid renders field group "Administration" -->
+<AxFormGridControl>
+  <DataGroup>Administration</DataGroup>   <!-- generates Administration_<Field> per member -->
+  <DataSource>MyTable</DataSource>
+</AxFormGridControl>
+
+<!-- ✅ Table extension only — the control appears by itself -->
+d365fo_file(action="modify", objectType="table-extension", operations=[
+  {operation:"add-field", fieldName:"MyPrefix_Tier", ...},
+  {operation:"add-field-to-field-group", fieldGroupName:"Administration",
+   fieldName:"MyPrefix_Tier", extendBaseFieldGroup:true}])
+
+<!-- ❌ Adding this on top of the field group entry is the duplicate -->
+d365fo_file(action="modify", objectType="form-extension", operation="add-control",
+            params={controlName:"Administration_MyPrefix_Tier", parentControl:"Administration", ...})`,
+    related: ['form-extension', 'add-control', 'add-field-to-field-group'],
+  },
+  {
     patterns: ['label does not exist', 'label not found', '@sys', 'undefined label', 'label reference'],
     title: 'Label Does Not Exist',
     explanation:

--- a/src/tools/knowledge/d365foErrorHelp.ts
+++ b/src/tools/knowledge/d365foErrorHelp.ts
@@ -373,21 +373,10 @@ function isSignificantWord(word: string): boolean {
 }
 
 /**
- * Score at or above which a match is treated as an answer rather than a guess.
- *
- * 10 is one whole pattern appearing verbatim (see scoreError). Everything below
- * that comes purely from the loose word fallback, which is fine for "did you
- * also mean…" and much too weak to print as the diagnosis.
- *
- * Run a5677c99 is why the line exists. `ClassDoesNotContainMethod: Table 'X'
- * does not contain a definition for method 'checkFailed'` scored 4 on the entry
- * "Field Does Not Exist on Table" — the pattern `field not found on table`
- * matched the words "found" and "table", neither of which is about a field —
- * and that was the highest score, so it was returned as the answer. Worse,
- * `lookupErrorFix` puts the winner straight into build_d365fo_project's output,
- * so the agent read "Field Does Not Exist on Table: Call get_object_info(…)"
- * printed directly under a real compiler error about a method, and went looking
- * at fields.
+ * Score at or above which a match is an answer rather than a guess: one whole
+ * pattern appearing verbatim. Below it, only the loose word fallback fired —
+ * enough for "did you also mean", too weak to print as the diagnosis, and
+ * `lookupErrorFix` puts the winner straight into build output.
  */
 const MIN_CONFIDENT_SCORE = 10;
 
@@ -468,10 +457,9 @@ export function d365foErrorHelpTool(request: CallToolRequest) {
       .filter(s => s.score > 0)
       .sort((a, b) => b.score - a.score);
 
-    // Below MIN_CONFIDENT_SCORE nothing matched on more than a stray shared word.
-    // Saying so — and listing the near-misses AS near-misses — is worth more than
-    // dressing the top guess up as the diagnosis; a confidently wrong answer sends
-    // the caller off to fix something that was never broken.
+    // Below the threshold nothing matched on more than a stray shared word;
+    // list the near-misses as near-misses rather than dressing one up as the
+    // diagnosis.
     if (scored.length === 0 || scored[0].score < MIN_CONFIDENT_SCORE) {
       const guesses = scored
         .slice(0, 3)

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -14,7 +14,10 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { searchLabelsTool, REUSABLE_MARKER, NO_REUSE_ADVICE, SOME_REUSE_ADVICE } from './analysis/searchLabels.js';
+import {
+  searchLabelsTool, REUSABLE_MARKER, NO_HITS_MARKER, NO_REUSE_ADVICE, SOME_REUSE_ADVICE,
+} from './analysis/searchLabels.js';
+import { repeatSearchNotice } from './analysis/labelSearchHistory.js';
 import { getLabelInfoTool } from './readers/getLabelInfo.js';
 import { createLabelTool } from './write/createLabel.js';
 import { renameLabelTool } from './write/renameLabel.js';
@@ -235,7 +238,24 @@ async function batchSearch(
   const failed = runs.filter(r => r.failed);
   const searched = runs.length - failed.length;
   const foundReusable = runs.some(r => !r.failed && r.text.includes(REUSABLE_MARKER));
-  const sections = runs.map(r => `## "${r.query}"${r.failed ? ' — ❌ SEARCH FAILED' : ''}\n\n${r.text}`);
+
+  // A miss carries one bit of information wrapped in the same "create your own
+  // label" paragraph as every other miss, so a batch of them buries both the
+  // verdict and any section that DID hit. Name the misses in a line; keep the
+  // full section for the runs that carry something — hits and failures.
+  const missed = runs.filter(r => !r.failed && r.text.includes(NO_HITS_MARKER));
+  const missedSet = new Set(missed.map(r => r.query));
+  const sections = runs
+    .filter(r => !missedSet.has(r.query))
+    .map(r => `## "${r.query}"${r.failed ? ' — ❌ SEARCH FAILED' : ''}\n\n${r.text}`);
+  if (missed.length > 0) {
+    sections.push(
+      `## No match — ${missed.length} phrasing(s)\n\n` +
+      `${missed.map(r => `"${r.query}"`).join(' · ')}\n\n` +
+      `Nothing in the index matches any of them. The advice below is the same for all of them, ` +
+      `so it is stated once.`,
+    );
+  }
 
   const notes = [
     duplicates > 0 ? `${duplicates} duplicate phrasing(s) folded` : '',
@@ -273,6 +293,9 @@ async function batchSearch(
           ? `\n⚠️ ${failed.length} of ${runs.length} searches FAILED and were not part of that verdict: ` +
             `${failed.map(f => `"${f.query}"`).join(', ')}.\n`
           : '') +
+        // Excludes this batch's own phrasings — they are the current answer, not
+        // evidence of repetition. What is left is what earlier calls already asked.
+        (repeatSearchNotice(queries) ? `\n${repeatSearchNotice(queries)}` : '') +
         `\n${NO_REUSE_ADVICE}`;
 
   return {

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -14,7 +14,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
-import { searchLabelsTool, REUSABLE_MARKER, NO_REUSE_ADVICE } from './analysis/searchLabels.js';
+import { searchLabelsTool, REUSABLE_MARKER, NO_REUSE_ADVICE, SOME_REUSE_ADVICE } from './analysis/searchLabels.js';
 import { getLabelInfoTool } from './readers/getLabelInfo.js';
 import { createLabelTool } from './write/createLabel.js';
 import { renameLabelTool } from './write/renameLabel.js';
@@ -266,7 +266,7 @@ async function batchSearch(
         `see the section(s) marked "${REUSABLE_MARKER}". Read the TEXT of those hits before adopting one: ` +
         `the index matches wording, not meaning, so a hit is a candidate, not a verdict. ` +
         `If none of them says what you need, do NOT rephrase and search again — nothing new will surface.\n` +
-        `\n${NO_REUSE_ADVICE}`
+        `\n${SOME_REUSE_ADVICE}`
       : `**Verdict:** none of these ${searched} phrasings found a label this model can resolve. ` +
         `Stop searching and create your own.\n` +
         (failed.length > 0

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -258,7 +258,19 @@ async function batchSearch(
       `This says nothing about whether a reusable label exists; fix the error and search again ` +
       `rather than creating a label on the strength of this answer.\n`
     : foundReusable
-      ? `**Verdict:** at least one reusable label was found — see the section(s) marked "${REUSABLE_MARKER}".\n`
+      // "Reusable" here means only "this model can resolve it" — the index matches
+      // words, not meaning, so a hit is a candidate and not an answer. Run a5677c99
+      // read the old wording ("at least one reusable label was found") on a batch
+      // whose best hit was @SYS321832 "The decreased margin cannot be greater than
+      // the current margin amount of letter of guarantee", concluded the right label
+      // was in there somewhere, and spent two more searches and ~7 AIU looking for
+      // it. The verdict now says what was actually established, and carries the
+      // create call so that deciding "none of these fit" costs no further round trip.
+      ? `**Verdict:** ${searched} search(es) ran and at least one label this model can resolve came back — ` +
+        `see the section(s) marked "${REUSABLE_MARKER}". Read the TEXT of those hits before adopting one: ` +
+        `the index matches wording, not meaning, so a hit is a candidate, not a verdict. ` +
+        `If none of them says what you need, do NOT rephrase and search again — nothing new will surface.\n` +
+        `\n${NO_REUSE_ADVICE}`
       : `**Verdict:** none of these ${searched} phrasings found a label this model can resolve. ` +
         `Stop searching and create your own.\n` +
         (failed.length > 0

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -258,14 +258,10 @@ async function batchSearch(
       `This says nothing about whether a reusable label exists; fix the error and search again ` +
       `rather than creating a label on the strength of this answer.\n`
     : foundReusable
-      // "Reusable" here means only "this model can resolve it" — the index matches
-      // words, not meaning, so a hit is a candidate and not an answer. Run a5677c99
-      // read the old wording ("at least one reusable label was found") on a batch
-      // whose best hit was @SYS321832 "The decreased margin cannot be greater than
-      // the current margin amount of letter of guarantee", concluded the right label
-      // was in there somewhere, and spent two more searches and ~7 AIU looking for
-      // it. The verdict now says what was actually established, and carries the
-      // create call so that deciding "none of these fit" costs no further round trip.
+      // "Reusable" only ever meant "this model can resolve it" — the index
+      // matches words, not meaning. Overstating that sent callers back to
+      // rephrase and search again, so the verdict states what was established
+      // and carries the create call.
       ? `**Verdict:** ${searched} search(es) ran and at least one label this model can resolve came back — ` +
         `see the section(s) marked "${REUSABLE_MARKER}". Read the TEXT of those hits before adopting one: ` +
         `the index matches wording, not meaning, so a hit is a candidate, not a verdict. ` +

--- a/src/tools/readers/getObjectInfo.ts
+++ b/src/tools/readers/getObjectInfo.ts
@@ -21,6 +21,7 @@ import type { XppServerContext } from '../../types/context.js';
 import { READER_DISPATCH, OBJECT_INFO_TYPES, withNotFoundGuidance } from './objectInfoRegistry.js';
 import { completionTool } from './completion.js';
 import { getMethodTool } from './getMethod.js';
+import { readObjectXml } from './objectXml.js';
 
 /** Ceiling on one plural call — inherited from the retired batch_get_info. */
 const MAX_OBJECTS = 10;
@@ -40,7 +41,9 @@ const OPTIONS_DESCRIPTION =
   '{ "members": "names" } for fast member-name list (add "prefix" to filter), ' +
   '{ "method": "validateWrite", "include": "signature" } for ONE method (include: signature | source | both). ' +
   'Table: { "fieldsOffset": 50 } for the next field page, { "fieldFilter": "Invoice" } to list only matching fields. ' +
-  'Report: { "includeRdl": true }. Form: { "searchControl": "AccountNum" }, { "maxControls": 300 }. Macro: { "filter": "Path" }.';
+  'Report: { "includeRdl": true }. Form: { "searchControl": "AccountNum" }, { "maxControls": 300 }. Macro: { "filter": "Path" }. ' +
+  'Any type: { "include": "xml" } returns the raw AOT XML and its path — use it instead of shelling out to ' +
+  'Get-ChildItem/Get-Content; page it with { "startLine": 1, "endLine": 200 }.';
 
 /**
  * One entry of the plural `objects[]` form. The name lives in `objectName` —
@@ -130,6 +133,19 @@ async function readObject(ref: ObjectRef, context: XppServerContext) {
   // chain was search → get_object_info → get_method: three round trips to read
   // one signature, where the middle call already had the class in hand. Folding
   // it here removes that hop and its ~926 chars from every ListTools payload.
+  // The file itself, when the rendered metadata is not what is wanted. Checked
+  // before options.method so {method, include:"xml"} cannot silently mean two
+  // things.
+  if (options?.include === 'xml') {
+    const xml = await readObjectXml(objectType, name, {
+      modelName: options.modelName as string | undefined,
+      startLine: options.startLine as number | undefined,
+      endLine: options.endLine as number | undefined,
+      maxChars: options.maxChars as number | undefined,
+    });
+    return { content: [{ type: 'text', text: xml.text }], ...(xml.isError ? { isError: true } : {}) };
+  }
+
   if (options?.method) {
     // get_method resolves methods on classes, tables, views and data entities
     // (its own OBJECT_TYPES), so gating this on `class` alone refused calls the

--- a/src/tools/readers/getWorkspaceInfo.ts
+++ b/src/tools/readers/getWorkspaceInfo.ts
@@ -24,6 +24,7 @@ import {
 } from '../../workspace/contextSnapshot.js';
 import { selectProject, renderSelectionFailure } from '../../workspace/projectSelector.js';
 import { projectDisplayName } from '../../workspace/projectMembership.js';
+import { activeCrossModelAllowance } from '../../utils/crossModelWriteGuard.js';
 
 export async function getWorkspaceInfoTool(
   request: CallToolRequest,
@@ -305,9 +306,26 @@ export async function getWorkspaceInfoTool(
       `anchored to "${toolSwitch.anchorModel}" — the model the open workspace targets — and ` +
       `a create/modify into "${toolSwitch.forcedModel}" will be refused.`,
       `Tell the user the model they asked about is owned by "${toolSwitch.forcedModel}" and let ` +
-      `THEM decide: extend it from "${toolSwitch.anchorModel}", or allow the write by adding ` +
-      `D365FO_CROSS_MODEL_WRITE_MODELS=${toolSwitch.forcedModel} to the server's .env — that ` +
-      `applies to the next attempt, no restart. Do not decide this on your own.`,
+      `THEM decide: extend it from "${toolSwitch.anchorModel}", or have THEM allow the write by ` +
+      `adding D365FO_CROSS_MODEL_WRITE_MODELS=${toolSwitch.forcedModel} to the server's ` +
+      `environment — that applies to the next attempt, no restart.`,
+      `That setting is the USER'S to make, in their own editor. Do not write it yourself: editing ` +
+      `mcp.json, .env or any other server configuration to widen what you may write is granting ` +
+      `yourself the permission this guard exists to withhold, whatever the reason seems to be.`,
+    );
+  }
+
+  // What is allowed right now, stated without having to attempt a write first.
+  const allowance = activeCrossModelAllowance();
+  if (allowance) {
+    lines.push(
+      ``,
+      `## ⚠️  Cross-model writes are currently ALLOWED`,
+      ``,
+      `${allowance}.`,
+      `Writes into that model will succeed and will NOT appear in this workspace's project or ` +
+      `version control. If nobody deliberately granted this, remove the setting from the server's ` +
+      `environment before writing anything.`,
     );
   }
 

--- a/src/tools/readers/objectXml.ts
+++ b/src/tools/readers/objectXml.ts
@@ -1,0 +1,93 @@
+/**
+ * Raw AOT XML for an object, by name.
+ *
+ * The readers render metadata; they never show the file. Callers that want the
+ * actual XML — to copy a convention, to see element order, to check what a
+ * previous write produced — had no tool for it and went to the shell:
+ * `Get-ChildItem -Recurse` to find the path, then `Get-Content -Raw` to read
+ * it. A recursive scan of PackagesLocalDirectory costs seconds; this is one
+ * indexed lookup.
+ */
+
+import * as fs from 'fs/promises';
+import { findD365FileOnDisk } from '../../utils/objectFileLookup.js';
+
+/** Default ceiling on returned XML. A large form is well past any useful read. */
+const DEFAULT_MAX_CHARS = 40_000;
+
+export interface ObjectXmlOptions {
+  modelName?: string;
+  /** 1-based, inclusive. Omit both for the whole file (up to maxChars). */
+  startLine?: number;
+  endLine?: number;
+  maxChars?: number;
+}
+
+export interface ObjectXmlResult {
+  text: string;
+  isError: boolean;
+}
+
+/** Render a file already located. Split out so it is testable without config. */
+export async function renderObjectXml(
+  filePath: string,
+  objectType: string,
+  objectName: string,
+  options: ObjectXmlOptions = {},
+): Promise<ObjectXmlResult> {
+  let content: string;
+  try {
+    content = (await fs.readFile(filePath, 'utf-8')).replace(/^﻿/, '');
+  } catch (err) {
+    return {
+      isError: true,
+      text: `❌ get_object_info(include="xml"): found ${filePath} but could not read it: ${err}`,
+    };
+  }
+
+  const allLines = content.split(/\r?\n/);
+  const from = Math.max(1, options.startLine ?? 1);
+  const to = Math.min(allLines.length, options.endLine ?? allLines.length);
+  const ranged = allLines.slice(from - 1, to).join('\n');
+
+  const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
+  const truncated = ranged.length > maxChars;
+  const body = truncated ? ranged.slice(0, maxChars) : ranged;
+
+  const header =
+    `# ${objectType} ${objectName} — raw XML\n\n` +
+    `**File:** ${filePath}\n` +
+    `**Lines:** ${from}-${to} of ${allLines.length}\n`;
+
+  const footer = truncated
+    ? `\n\n> ✂️ Cut at ${maxChars} chars. Re-read a range with ` +
+      `options={include:"xml", startLine:…, endLine:…} rather than raising maxChars.`
+    : '';
+
+  return { isError: false, text: `${header}\n\`\`\`xml\n${body}\n\`\`\`${footer}` };
+}
+
+/** The message for an object with no file — never an empty result. */
+export function objectXmlNotFound(
+  objectType: string,
+  objectName: string,
+  modelName?: string,
+): ObjectXmlResult {
+  return {
+    isError: true,
+    text:
+      `❌ get_object_info(include="xml"): no file on disk for ${objectType} "${objectName}"` +
+      `${modelName ? ` in model "${modelName}"` : ''}.\n` +
+      `The object may live in another model — pass options.modelName — or may not exist yet.`,
+  };
+}
+
+export async function readObjectXml(
+  objectType: string,
+  objectName: string,
+  options: ObjectXmlOptions = {},
+): Promise<ObjectXmlResult> {
+  const filePath = await findD365FileOnDisk(objectType, objectName, options.modelName);
+  if (!filePath) return objectXmlNotFound(objectType, objectName, options.modelName);
+  return renderObjectXml(filePath, objectType, objectName, options);
+}

--- a/src/tools/sdlc/buildProject.ts
+++ b/src/tools/sdlc/buildProject.ts
@@ -63,22 +63,10 @@ export interface XppcDiagnostic {
 }
 
 /**
- * The severity prefix every xppc diagnostic line opens with.
- *
- * Written as a family rather than a list of five literals, because the list was
- * wrong and silently so. xppc emits at least `Compile`, `Generation`,
- * `Metadata`, `FormPatternValidation`, `Best Practice` and `BestPractices`
- * variants of both Error and Warning, and the hardcoded five knew three of them.
- *
- * Run 9180a464 is what that costs. A full build returned exit-failure, the
- * parser matched no line it recognised, and the tool reported "❌ Build FAILED"
- * over "📋 Structured diagnostics: 0 error(s), 1 warning(s)" — the one warning
- * being an unrelated deprecation on another object. With a failure and no
- * reason, the agent invented one ("duplicate control name"), spent four minutes
- * scanning PackagesLocalDirectory from PowerShell, then DELETED the form
- * extension it had just been asked to create and hand-edited the .rnrproj to
- * match. The next build passed, so the deletion looked like the fix. The
- * deliverable was gone.
+ * The severity prefix every xppc diagnostic line opens with, as a family rather
+ * than a list of literals: xppc also emits `Metadata` and
+ * `FormPatternValidation` errors, which a five-literal list reported as zero —
+ * a FAILED build with no stated cause.
  */
 const DIAG_PREFIX = String.raw`(?:([A-Za-z][A-Za-z ]{0,30}?)\s)?(Fatal Error|Error|Warning)`;
 
@@ -98,11 +86,7 @@ const XPPC_DIAG_PATH_RE = new RegExp(
 /** `<Kind> <Severity>: message` */
 const XPPC_DIAG_PLAIN_RE = new RegExp(String.raw`^${DIAG_PREFIX}:\s*(.+)$`);
 
-/**
- * xppc's own tally, printed once at the end of the log: `Errors: 3`.
- * Used to notice when the parser understood fewer errors than the compiler
- * counted, instead of presenting its own shortfall as the truth.
- */
+/** xppc's own tally at the end of the log, to catch a parser shortfall. */
 const XPPC_ERROR_TOTAL_RE = /^Errors:\s*(\d+)\s*$/m;
 
 /** Errors xppc counted in this log, or null when it printed no tally. */
@@ -163,14 +147,9 @@ export function parseXppcDiagnostics(logContent: string): XppcDiagnostic[] {
 /**
  * What to say when the compiler failed and this parser cannot show why.
  *
- * The dangerous state is not "no error" — it is a confident-looking report that
- * happens to list only warnings under a FAILED headline. Run 9180a464 read one
- * of those, concluded the failure had to be something it could see, and deleted
- * a working file to make the red go away. So: name the gap, quote xppc's own
- * error tally when it disagrees, point at the raw log below, and say in as many
- * words that deleting work is not the way to find out.
- *
- * Returns '' when the parsed diagnostics already explain the failure.
+ * A FAILED headline over a list of warnings reads as though the warnings are
+ * the cause, and invites deleting whatever is nearest to clear the red. Name
+ * the gap instead. Returns '' when the parsed errors do explain the failure.
  */
 export function renderUnexplainedFailure(
   parsed: XppcDiagnostic[],

--- a/src/tools/sdlc/buildProject.ts
+++ b/src/tools/sdlc/buildProject.ts
@@ -62,38 +62,148 @@ export interface XppcDiagnostic {
   message: string;
 }
 
-const XPPC_DIAG_LINE_RE =
-  /^(Compile Fatal Error|Compile Error|Compile Warning|Generation Warning|Best Practice Warning):\s*(?:(.*?)\s+)?dynamics:\/\/([^/\s:]+)\/([^/\s:]+)(?:\/([^\s:]+))?\s*:?\s*\[\((\d+),(\d+)\)(?:,\(\d+,\d+\))?\]\s*:\s*(.*)$/;
+/**
+ * The severity prefix every xppc diagnostic line opens with.
+ *
+ * Written as a family rather than a list of five literals, because the list was
+ * wrong and silently so. xppc emits at least `Compile`, `Generation`,
+ * `Metadata`, `FormPatternValidation`, `Best Practice` and `BestPractices`
+ * variants of both Error and Warning, and the hardcoded five knew three of them.
+ *
+ * Run 9180a464 is what that costs. A full build returned exit-failure, the
+ * parser matched no line it recognised, and the tool reported "❌ Build FAILED"
+ * over "📋 Structured diagnostics: 0 error(s), 1 warning(s)" — the one warning
+ * being an unrelated deprecation on another object. With a failure and no
+ * reason, the agent invented one ("duplicate control name"), spent four minutes
+ * scanning PackagesLocalDirectory from PowerShell, then DELETED the form
+ * extension it had just been asked to create and hand-edited the .rnrproj to
+ * match. The next build passed, so the deletion looked like the fix. The
+ * deliverable was gone.
+ */
+const DIAG_PREFIX = String.raw`(?:([A-Za-z][A-Za-z ]{0,30}?)\s)?(Fatal Error|Error|Warning)`;
+
+/** Prefix-only test, for deciding which log lines are worth keeping in an excerpt. */
+export const DIAG_LINE_TEST = new RegExp(String.raw`^${DIAG_PREFIX}:\s`);
+
+/** `<Kind> <Severity>: [<elementKind> ]dynamics://Model/Object[/Member]: [(l,c)…]: message` */
+const XPPC_DIAG_DYNAMICS_RE = new RegExp(
+  String.raw`^${DIAG_PREFIX}:\s*(?:(.*?)\s+)?dynamics:\/\/([^/\s:]+)\/([^/\s:]+)(?:\/([^\s:]+))?\s*:?\s*\[\((\d+),(\d+)\)(?:,\(\d+,\d+\))?\]\s*:\s*(.*)$`,
+);
+
+/** `<Kind> <Severity>: AxFormExtension/Name/Design/Controls/…: message` — no line/col. */
+const XPPC_DIAG_PATH_RE = new RegExp(
+  String.raw`^${DIAG_PREFIX}:\s*(Ax[A-Za-z]+)\/([^\s:]+)\s*:\s*(.*)$`,
+);
+
+/** `<Kind> <Severity>: message` */
+const XPPC_DIAG_PLAIN_RE = new RegExp(String.raw`^${DIAG_PREFIX}:\s*(.+)$`);
+
+/**
+ * xppc's own tally, printed once at the end of the log: `Errors: 3`.
+ * Used to notice when the parser understood fewer errors than the compiler
+ * counted, instead of presenting its own shortfall as the truth.
+ */
+const XPPC_ERROR_TOTAL_RE = /^Errors:\s*(\d+)\s*$/m;
+
+/** Errors xppc counted in this log, or null when it printed no tally. */
+export function xppcReportedErrorCount(logContent: string): number | null {
+  const m = XPPC_ERROR_TOTAL_RE.exec(logContent);
+  return m ? Number(m[1]) : null;
+}
 
 /** Parse xppc log content into structured diagnostics. */
 export function parseXppcDiagnostics(logContent: string): XppcDiagnostic[] {
   const diagnostics: XppcDiagnostic[] = [];
   for (const rawLine of logContent.split(/\r?\n/)) {
     const line = rawLine.trim();
-    const m = XPPC_DIAG_LINE_RE.exec(line);
-    if (m) {
+
+    const dyn = XPPC_DIAG_DYNAMICS_RE.exec(line);
+    if (dyn) {
       diagnostics.push({
-        severity: m[1].includes('Error') ? 'error' : 'warning',
-        kind: m[2] || undefined,
-        model: m[3],
-        object: m[4],
-        member: m[5] || undefined,
-        line: Number(m[6]),
-        column: Number(m[7]),
-        message: m[8].trim(),
+        severity: dyn[2].includes('Error') ? 'error' : 'warning',
+        kind: dyn[3] || dyn[1] || undefined,
+        model: dyn[4],
+        object: dyn[5],
+        member: dyn[6] || undefined,
+        line: Number(dyn[7]),
+        column: Number(dyn[8]),
+        message: dyn[9].trim(),
       });
       continue;
     }
-    // Fallback: severity prefix without the dynamics:// location part
-    const simple = /^(Compile Fatal Error|Compile Error|Compile Warning|Generation Warning):\s*(.+)$/.exec(line);
-    if (simple) {
+
+    const pathForm = XPPC_DIAG_PATH_RE.exec(line);
+    if (pathForm) {
+      // "AxFormExtension/MyForm.Ext/Design/Controls/Grid/Foo" — the element is the
+      // first segment, the rest locates the member inside it.
+      const [objectName, ...rest] = pathForm[4].split('/');
       diagnostics.push({
-        severity: simple[1].includes('Error') ? 'error' : 'warning',
-        message: simple[2].trim(),
+        severity: pathForm[2].includes('Error') ? 'error' : 'warning',
+        kind: pathForm[1] || undefined,
+        model: pathForm[3],
+        object: objectName,
+        member: rest.length > 0 ? rest.join('/') : undefined,
+        message: pathForm[5].trim(),
+      });
+      continue;
+    }
+
+    const plain = XPPC_DIAG_PLAIN_RE.exec(line);
+    if (plain) {
+      diagnostics.push({
+        severity: plain[2].includes('Error') ? 'error' : 'warning',
+        kind: plain[1] || undefined,
+        message: plain[3].trim(),
       });
     }
   }
   return diagnostics;
+}
+
+/**
+ * What to say when the compiler failed and this parser cannot show why.
+ *
+ * The dangerous state is not "no error" — it is a confident-looking report that
+ * happens to list only warnings under a FAILED headline. Run 9180a464 read one
+ * of those, concluded the failure had to be something it could see, and deleted
+ * a working file to make the red go away. So: name the gap, quote xppc's own
+ * error tally when it disagrees, point at the raw log below, and say in as many
+ * words that deleting work is not the way to find out.
+ *
+ * Returns '' when the parsed diagnostics already explain the failure.
+ */
+export function renderUnexplainedFailure(
+  parsed: XppcDiagnostic[],
+  logContent: string,
+): string {
+  const parsedErrors = parsed.filter(d => d.severity === 'error').length;
+  const reported = xppcReportedErrorCount(logContent);
+
+  if (parsedErrors > 0 && (reported === null || parsedErrors >= reported)) return '';
+
+  const lines: string[] = [];
+  if (parsedErrors === 0) {
+    lines.push(
+      `⚠️ The build FAILED but this server parsed **no error diagnostic** from the log` +
+      (reported !== null ? ` (xppc's own tally says: Errors: ${reported})` : '') + '.',
+    );
+    lines.push(
+      `Any warnings listed below are NOT the failure — do not treat them as the cause. ` +
+      `Read the raw log at the end of this response; the failing line is in there in a ` +
+      `format this parser did not recognise.`,
+    );
+  } else {
+    lines.push(
+      `⚠️ xppc counted ${reported} error(s) but only ${parsedErrors} could be parsed into the list below. ` +
+      `The rest are in the raw log.`,
+    );
+  }
+  lines.push(
+    `⛔ Do NOT delete, undo or unregister an object to make the build pass. A green build ` +
+    `you obtained by removing the thing you were asked to create is a failed task, not a fixed one. ` +
+    `If you cannot find the cause, say so and ask.`,
+  );
+  return lines.join('\n');
 }
 
 /**
@@ -332,10 +442,9 @@ async function readFullLog(logFile: string, maxLines = 300): Promise<string> {
     const all = content.split(/\r?\n/);
     if (all.length <= maxLines) return content.trim();
 
-    const DIAG_RE = /^(Compile Fatal Error|Compile Error|Compile Warning|Generation Warning|Best Practice Warning):/;
     const diagIndices: number[] = [];
     for (let i = 0; i < all.length; i++) {
-      if (DIAG_RE.test(all[i].trim())) diagIndices.push(i);
+      if (DIAG_LINE_TEST.test(all[i].trim())) diagIndices.push(i);
     }
 
     if (diagIndices.length > 0) {
@@ -751,14 +860,16 @@ async function renderFinishedBuildResult(
     const logContent = succeeded
       ? await readLogTail(relevantLogFile)
       : await readFullLog(relevantLogFile);
-    const structured = succeeded
-      ? ''
-      : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(relevantLogFile)));
+    const wholeLog = succeeded ? '' : await readWholeLog(relevantLogFile);
+    const parsed = succeeded ? [] : parseXppcDiagnostics(wholeLog);
+    const structured = succeeded ? '' : formatStructuredDiagnostics(parsed);
+    const unexplained = succeeded ? '' : renderUnexplainedFailure(parsed, wholeLog);
 
     return {
       content: [{
         type: 'text',
         text: `${statusIcon} — ${allResults.length} models, ${totalDuration}s total\n\n${modelLines}\n\n` +
+          (unexplained ? `${unexplained}\n\n` : '') +
           (structured ? `${structured}\n\n` : '') +
           `--- Log (${relevantResult?.modelName ?? targetModel}) ---\n${logContent}`,
       }],
@@ -768,15 +879,16 @@ async function renderFinishedBuildResult(
 
   const logTail       = await readLogTail(finalState.logFile);
   const logContent    = succeeded ? logTail : await readFullLog(finalState.logFile);
-  const hasWarnings   = succeeded && /^(Generation Warning|Compile Warning):/m.test(logTail);
+  const hasWarnings   = succeeded && logTail.split(/\r?\n/).some(l => /Warning:\s/.test(l) && DIAG_LINE_TEST.test(l.trim()));
   const statusIcon    = !succeeded ? '❌ Build FAILED' : hasWarnings ? '⚠️ Build succeeded with warnings' : '✅ Build succeeded';
   const buildMode     = finalState.fullBuild ? 'full build (target), incremental (deps)' : 'incremental';
   const duration      = finalState.endTime
     ? Math.round((new Date(finalState.endTime).getTime() - new Date(finalState.startTime).getTime()) / 1000)
     : '?';
-  const structured    = succeeded
-    ? ''
-    : formatStructuredDiagnostics(parseXppcDiagnostics(await readWholeLog(finalState.logFile)));
+  const wholeLog      = succeeded ? '' : await readWholeLog(finalState.logFile);
+  const parsed        = succeeded ? [] : parseXppcDiagnostics(wholeLog);
+  const structured    = succeeded ? '' : formatStructuredDiagnostics(parsed);
+  const unexplained   = succeeded ? '' : renderUnexplainedFailure(parsed, wholeLog);
 
   // The note run_bp_check and verify_d365fo_project read, so a green verdict from a
   // tool that compiles nothing can say whether anything ever did.
@@ -793,6 +905,7 @@ async function renderFinishedBuildResult(
       type: 'text',
       text: `${statusIcon} (${finalState.tool}, ${buildMode}, ${duration}s)\n\nModel: ${targetModel}\n` +
         incrementalScopeCaveat(succeeded, !!finalState.fullBuild) + '\n' +
+        (unexplained ? `${unexplained}\n\n` : '') +
         (structured ? `${structured}\n\n--- Raw log ---\n` : '') +
         `${logContent || '(no output)'}`,
     }],

--- a/src/tools/sdlc/runBpCheck.ts
+++ b/src/tools/sdlc/runBpCheck.ts
@@ -5,7 +5,7 @@ import fs from 'fs/promises';
 import { getConfigManager } from '../../utils/configManager.js';
 import { defaultPackagesRoot, findPackagesRoot } from '../../utils/packagesRoot.js';
 import { withOperationLock } from '../../utils/operationLocks.js';
-import { lookupSymbolsNocase, type DbLike } from '../../utils/symbolLookup.js';
+import { lookupSymbolsNocase, lookupSymbolNocase, type DbLike } from '../../utils/symbolLookup.js';
 import { compileModelLabels } from '../write/compileLabels.js';
 import { describeBuildFreshness } from '../../utils/buildMarker.js';
 
@@ -340,6 +340,22 @@ export const runBpCheckTool = async (params: any, context: any) => {
       };
     }
 
+    // Paths for the build-freshness line below. Without them describeBuildFreshness
+    // cannot compare "last built" against "last written", so it reports the newest
+    // recorded success unqualified — a green verdict for objects written after it.
+    // One indexed probe per target (a handful, sub-ms each) restores the ⚠️ Stale.
+    const targetFiles: string[] = [];
+    if (db) {
+      for (const t of targets) {
+        try {
+          const hit = lookupSymbolNocase(db, t.name);
+          if (hit?.file_path) targetFiles.push(hit.file_path);
+        } catch {
+          /* a missing path only costs the staleness comparison, not the run */
+        }
+      }
+    }
+
     // metadataPath: X++ source XML (custom model metadata). compilerMetadataPath: compiled
     // binaries + framework metadata (UDE: Microsoft packages root; CHE: same as metadataPath).
     const metadataPath = customPackagesPath || packagesRoot;
@@ -481,6 +497,15 @@ export const runBpCheckTool = async (params: any, context: any) => {
 
     const header = `Model: ${modelName}` + (resolvedProjectPath ? `\nProject: ${resolvedProjectPath}` : '');
 
+    // A clean xppbp run is routinely read as "the task is done". It is not a compile:
+    // run f2e7b71a shipped a CoC method that violates SYS10028 with this line reading
+    // "0 with findings". Say what has actually compiled the model — for a batch and
+    // for a single object alike; a one-object check is no more of a compile than a
+    // three-object one, and it used to carry no caveat at all.
+    const buildNote = context?.symbolIndex?.dataDir
+      ? `\n\n${describeBuildFreshness(context.symbolIndex.dataDir, modelName, targetFiles)}`
+      : '';
+
     // Single target (and the whole-model run) keep the original layout — there
     // is no preamble to share and existing callers read this shape.
     if (runTargets.length === 1) {
@@ -504,7 +529,9 @@ export const runBpCheckTool = async (params: any, context: any) => {
       return {
         content: [{
           type: 'text',
-          text: `${hasIssues(combined) ? '⚠️ BP Check completed with issues' : '✅ BP Check passed'}\n\n${header}` +
+          text: `${hasIssues(combined) ? '⚠️ BP Check completed with issues' : '✅ BP Check passed'}` +
+            buildNote +
+            `\n\n${header}` +
             (target ? `\nFilter: ${selector(target)}` : '') +
             scopeNote +
             labelNote +
@@ -539,13 +566,6 @@ export const runBpCheckTool = async (params: any, context: any) => {
       notRunCount > 0 ? `❌ BP Check incomplete — ${notRunCount} object(s) were NOT checked`
       : issueCount > 0 ? '⚠️ BP Check completed with issues'
       : '✅ BP Check passed';
-
-    // A clean xppbp run is routinely read as "the task is done". It is not a compile:
-    // run f2e7b71a shipped a CoC method that violates SYS10028 with this line reading
-    // "0 with findings". Say what has actually compiled the model.
-    const buildNote = context?.symbolIndex?.dataDir
-      ? `\n\n${describeBuildFreshness(context.symbolIndex.dataDir, modelName)}`
-      : '';
 
     return {
       content: [{

--- a/src/tools/sdlc/updateSymbolIndex.ts
+++ b/src/tools/sdlc/updateSymbolIndex.ts
@@ -360,6 +360,9 @@ export async function indexOneFile(
         const content = fs.readFileSync(filePath, 'utf-8');
         const labels = parseLabelFile(content, labelFileId, model, language, filePath);
         if (labels.length > 0) {
+          // keepTriggers: one label file is not a reason to re-tokenise every label in
+          // the database (~105 s on the production DB, event loop blocked throughout).
+          // removeLabelsByFile above already pruned the old FTS rows via labels_ad.
           symbolIndex.bulkAddLabels(labels.map(lbl => ({
             labelId: lbl.labelId,
             labelFileId: lbl.labelFileId,
@@ -368,7 +371,7 @@ export async function indexOneFile(
             text: lbl.text,
             comment: lbl.comment,
             filePath: lbl.filePath,
-          })));
+          })), { skipFtsRebuild: true, keepTriggers: true });
           insertedCount = labels.length;
         }
       } catch (e: any) {

--- a/src/tools/smart/generateSmartForm.ts
+++ b/src/tools/smart/generateSmartForm.ts
@@ -657,7 +657,7 @@ export async function handleGenerateSmartForm(
 
   // See generateSmartTable: the resolved model follows the ACTIVE project, the
   // write anchor does not. Checked before the first byte is written.
-  const anchorRefusal = scaffoldWriteRefusalResult({
+  const anchorRefusal = await scaffoldWriteRefusalResult({
     objectName: finalName,
     objectType: 'form',
     targetModel: resolvedModel,

--- a/src/tools/smart/generateSmartReport.ts
+++ b/src/tools/smart/generateSmartReport.ts
@@ -332,7 +332,7 @@ export async function handleGenerateSmartReport(
   // See generateSmartTable: the resolved model follows the ACTIVE project, the
   // write anchor does not. A report scaffold writes several objects at once, so
   // this is checked before any of them exists.
-  const anchorRefusal = scaffoldWriteRefusalResult({
+  const anchorRefusal = await scaffoldWriteRefusalResult({
     objectName: finalName,
     objectType: 'report',
     targetModel: resolvedModel,

--- a/src/tools/smart/generateSmartTable.ts
+++ b/src/tools/smart/generateSmartTable.ts
@@ -661,7 +661,7 @@ export async function handleGenerateSmartTable(
   // Where this scaffold would land, checked before anything is written. The
   // model above comes from the ACTIVE project, which a get_workspace_info switch
   // moves; writes stay anchored to the model the workspace resolved on its own.
-  const anchorRefusal = scaffoldWriteRefusalResult({
+  const anchorRefusal = await scaffoldWriteRefusalResult({
     objectName: finalName,
     objectType: 'table',
     targetModel: resolvedModel,

--- a/src/tools/specs/d365foFileOpSpecs.ts
+++ b/src/tools/specs/d365foFileOpSpecs.ts
@@ -78,7 +78,13 @@ export const D365FO_FILE_PARAM_SPECS: Record<string, { type: string; description
       'Auto-resolved from the symbol index when omitted — pass explicitly when the EDT is not indexed yet.',
   },
   fieldMandatory: { type: 'boolean', description: 'Mark the field Mandatory=Yes.' },
-  fieldLabel: { type: 'string', description: 'Field label.' },
+  fieldLabel: {
+    type: 'string',
+    description:
+      'Field label. On an ENUM field it must be a different label ID than the enum\'s own label — ' +
+      'BPErrorFieldLabelIsCopyOfEnumLabel rejects the copy. Same visible text is fine, so create both ' +
+      'IDs in the one labels(action="create", labels=[…]) batch that creates the enum labels.',
+  },
   fieldHelpText: { type: 'string', description: 'Field help text.' },
   fieldEnumType: {
     type: 'string',
@@ -465,8 +471,13 @@ export const D365FO_FILE_CREATE_PROPERTY_SPECS: Record<string, string> = {
     '(+ optionally fieldType:"AxTableFieldEnum")',
   enum:
     'label, useEnumValue, configurationKey, isExtensible, enumValues[{name,value?,label?,helpText?}] — ' +
-    'an explicit value: sets UseEnumValue=Yes for you; it cannot be combined with isExtensible ' +
-    '(xppc requires UseEnumValue=No and no <Value> there), which is refused rather than dropped',
+    'an explicit value: sets UseEnumValue=Yes for you; an OFF-POSITIONAL one (a number differing from the ' +
+    "entry's index) is refused when combined with isExtensible rather than dropped, since xppc requires " +
+    'UseEnumValue=No and no <Value> on an extensible enum. Plain 0,1,2 numbering states nothing the order ' +
+    'does not, so it is accepted and the numbers are dropped. ' +
+    'CHOOSE isExtensible DELIBERATELY: it also bars `<`/`>`/`<=`/`>=` on the enum ("Cannot use extensible ' +
+    'enumerated type in non-equality comparison"), so any enum whose values get RANKED in X++ — a tier, a ' +
+    'severity, a no-downgrade check — must be isExtensible:false',
   'enum-extension': 'enumValues[{name,label?,value?,countryRegionCodes?}]',
   'table-extension':
     'fields[{name,edt?,enumType?,label?,mandatory?,fieldType?}] — enum fields need ' +

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -37,7 +37,7 @@ import { undoLastModificationTool } from './sdlc/undoLastModification.js';
 import { validateCodeTool } from './analysis/validateCode.js';
 import { prepareTool } from './prepare/prepare.js';
 import { getWorkspaceInfoTool } from './readers/getWorkspaceInfo.js';
-import { recordToolStart, startMetricsLogging, recordCallSequence } from '../utils/toolMetrics.js';
+import { recordToolStart, startMetricsLogging, recordCallSequence, reportSlowCall } from '../utils/toolMetrics.js';
 import {
   DEDUP_EXCLUDED_TOOLS, DEDUP_TTL_MS,
   dedupKey, getDedupedResult, storeDedupResult, appendNote,
@@ -274,6 +274,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       : null;
 
     const finishMetrics = recordToolStart(toolName);
+    const callStartedAt = Date.now();
     let result: any;
     // Anything the C# bridge throws during this call lands here (see
     // bridge/bridgeFailure.ts). Without it a bridge outage is invisible: the read
@@ -399,6 +400,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       const firstText = capped?.content?.[0]?.text;
       const isEmpty = !firstText || firstText.trim().length === 0 || firstText === 'No results returned';
       finishMetrics(isEmpty);
+      reportSlowCall(toolName, Date.now() - callStartedAt, request.params.arguments);
 
       if (!DEDUP_EXCLUDED_TOOLS.has(toolName)) {
         storeDedupResult(callKey, capped);

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -26,7 +26,8 @@ import { createPhaseTimer } from '../../utils/phaseTimer.js';
 import { registerCustomModel } from '../../utils/modelClassifier.js';
 import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { PackageResolver } from '../../utils/packageResolver.js';
-import { crossModelWriteRefusal } from '../../utils/crossModelWriteGuard.js';
+import { crossModelWriteRefusal, standDownNotice } from '../../utils/crossModelWriteGuard.js';
+import { resolveAnchorModel } from './writeAnchorGuard.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../../utils/xppDocGen.js';
 import { xppMethodSourceForXml, reindentXppSource } from '../../utils/xppFormat.js';
 import { decodeXmlEntitiesFromXppSource } from '../../utils/xmlEscape.js';
@@ -3123,6 +3124,47 @@ function rawLabelBpWarning(properties: unknown, objectName: string): string {
 }
 
 /**
+ * The caller's X++ as this server actually wrote it.
+ *
+ * Every create path renames a class/interface whose declared name differs from
+ * the resolved object name, and that rename is usually what makes the name
+ * legal. Linting the caller's own text instead reports the pre-rename name —
+ * a naming violation against a name already fixed on disk.
+ *
+ * Delegates to the helper the writers use, so the two cannot drift. Source with
+ * no class/interface header is returned untouched.
+ */
+export function sourceAsWritten(sourceCode: string | undefined, finalObjectName: string): string | undefined {
+  if (!sourceCode) return sourceCode;
+  try {
+    return XmlTemplateGenerator.normalizeSelfReferenceName(finalObjectName, sourceCode, []).declaration;
+  } catch {
+    return sourceCode;
+  }
+}
+
+/**
+ * Warn, on an extensible enum create, that xppc allows only equality on it.
+ *
+ * IsExtensible=Yes makes the numbering an implementation detail the compiler
+ * refuses to expose: `<`, `>`, `<=`, `>=` is the hard error "Cannot use
+ * extensible enumerated type '…' in non-equality comparison". Extensibility is
+ * the right default, but ranking needs ordering, and only the build says so.
+ *
+ * Advisory: an extensible enum compared only with == is perfectly correct.
+ */
+function extensibleEnumOrderingWarning(objectType: string, properties: unknown, enumName: string): string {
+  if (objectType !== 'enum') return '';
+  if (!(properties as Record<string, unknown> | undefined)?.isExtensible) return '';
+  return `\n\n⚠️ **IsExtensible=true → equality comparisons only.** xppc rejects ` +
+    `\`<\`, \`>\`, \`<=\`, \`>=\` between values of ${enumName} ("Cannot use extensible enumerated ` +
+    `type in non-equality comparison"); only \`==\`, \`!=\` and \`switch\` are legal.\n` +
+    `If any X++ has to RANK these values (a tier, a severity, a "cannot be downgraded" check), ` +
+    `re-create this enum with isExtensible=false NOW — after code references it, the change costs ` +
+    `a failed build first.`;
+}
+
+/**
  * Post-write parameter honesty for a table create (cluster #35).
  *
  * The metadata writer — bridge or template — accepts `properties` it does not know
@@ -3382,20 +3424,26 @@ export async function handleCreateD365File(
     // outside this project's version control and inside code other models inherit.
     // `actualModelName` is what the write will actually use (caller's modelName, or
     // the workspace's), so the check sits after every fallback has been applied.
-    const crossModelCreateRefusal = crossModelWriteRefusal({
+    // Resolved, not read synchronously: where the model comes only from the
+    // background .rnrproj scan, the sync getter can still be null here — and a
+    // null anchor makes the guard stand down.
+    const crossModelCheck = {
       objectName: args.objectName,
       objectType: args.objectType,
       owningModel: actualModelName,
-      activeModel: getConfigManager().getWriteAnchorModel() ?? '',
+      activeModel: await resolveAnchorModel(getConfigManager()),
       toolSwitchedModel: getConfigManager().getToolProjectSwitch()?.forcedModel ?? null,
-      action: 'create',
-    });
+      action: 'create' as const,
+    };
+    const crossModelCreateRefusal = crossModelWriteRefusal(crossModelCheck);
     if (crossModelCreateRefusal) {
       return {
         content: [{ type: 'text', text: crossModelCreateRefusal }],
         isError: true,
       };
     }
+    // Allowed, but possibly not into this model — see standDownNotice.
+    const crossModelNotice = standDownNotice(crossModelCheck);
 
     // Name normalisation lives in utils/objectNaming so that modify resolves the
     // very same name from the very same arguments — the ninety lines that used to
@@ -3686,42 +3734,31 @@ export async function handleCreateD365File(
     // entirely (see bridgeAdapter.ts) because the bridge silently drops their
     // structured collections (EntryPoints, DataEntityPermissions, Privileges, Duties).
     //
-    // EXCEPTION — any enum whose RESOLVED MODE forbids explicit <Value> elements. The
-    // bridge takes UseEnumValue from the scalar property but still serializes a <Value>
-    // for every numbered entry, minus the ones equal to 0, which .NET omits as the type
-    // default. An enum created with useEnumValue:false and values None=0..Platinum=3 came
-    // out as <UseEnumValue>No</UseEnumValue> with <Value>1/2/3</Value> and no <Value>0</Value>
-    // — the combination this server's own knowledge base tells callers xppc rejects the
-    // moment IsExtensible is set, and with the caller's number for entry 0 silently gone.
-    // resolveEnumValueMode is the single place that decides this; when it says the values
-    // must be suppressed and the payload carries some, hand the write to the TypeScript
-    // generator, which is the writer that honours suppressExplicitValues.
+    // EXCEPTION — any enum carrying values at all.
     //
-    // Read the rule literally, because it is BROADER than the two headline cases:
-    // suppressExplicitValues is true whenever the resolved mode is UseEnumValue=No, and
-    // that includes the plain positional payload — values [None=0, A=1, B=2] with
-    // `useEnumValue` unset. So in practice ANY enum create carrying explicit numbers
-    // goes to the TypeScript generator, extensible or not, useEnumValue or not. That is
-    // the intended behaviour (the bridge cannot write this shape correctly); it is named
-    // and commented this way so the next reader does not conclude the bridge still
-    // handles positional enums.
-    const enumModeForbidsExplicitValues = (): boolean => {
+    // The bridge writes <UseEnumValue> only when the caller passes the scalar, and
+    // it serialises a <Value> per numbered entry except the zeros .NET omits as a
+    // type default. Both shapes are wrong:
+    //   • numbered   → <Value>1/2/3</Value> with the caller's 0 silently gone;
+    //   • unnumbered → no <UseEnumValue> and no <Value>, which xppc reads as
+    //                  UseEnumValue=Yes, making every member 0 ("Duplicate value
+    //                  '0' detected"). Only a FULL build reports it; the
+    //                  incremental build and validate_code pass clean.
+    //
+    // Numbering is not what the bridge gets wrong — <UseEnumValue> is, and every
+    // values payload depends on it. generateAxEnumXml emits it unconditionally and
+    // honours suppressExplicitValues, so it writes all of them. The bridge keeps
+    // the one shape it cannot get wrong: an enum with no values.
+    const enumMustSkipBridge = (): boolean => {
       if (args.objectType !== 'enum') return false;
       const props = args.properties as Record<string, unknown> | undefined;
       if (props?.isExtensible) return true;
       // `enumValues` only: the `values` alias was folded into it by
       // normalizeEnumValuesAlias, so routing and the writers read one list.
       const vals = props?.enumValues as Array<{ name?: string; value?: number }> | undefined;
-      if (!Array.isArray(vals) || !vals.some(v => typeof v?.value === 'number')) return false;
-      try {
-        return resolveEnumValueMode(finalObjectName, props, vals).suppressExplicitValues;
-      } catch {
-        // A genuine contradiction (isExtensible + off-positional values, …). Let the
-        // generator path re-run it and surface the one authored error message.
-        return true;
-      }
+      return Array.isArray(vals) && vals.length > 0;
     };
-    const skipBridgeForEnum = enumModeForbidsExplicitValues();
+    const skipBridgeForEnum = enumMustSkipBridge();
 
     // Set only when a bridge create THREW (not when it was unavailable or declined).
     // The XML fallback below is a different writer with a narrower feature set, so a
@@ -4047,10 +4084,10 @@ export async function handleCreateD365File(
                 content: [
                   {
                     type: 'text',
-                    text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create() (Smart)\n` +
+                    text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create() (Smart)${crossModelNotice}\n` +
                       `📁 ${smartResult.filePath}${projectMsg}\n` +
                       `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}` +
-                      validateWrittenXpp(args.sourceCode),
+                      validateWrittenXpp(sourceAsWritten(args.sourceCode, finalObjectName)),
                   },
                 ],
               };
@@ -4149,13 +4186,13 @@ export async function handleCreateD365File(
           );
           const bpNote = await timer.time('inline BP check',
             () => runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context));
-          const xppRuleNote = validateWrittenXpp(args.sourceCode);
+          const xppRuleNote = validateWrittenXpp(sourceAsWritten(args.sourceCode, finalObjectName));
 
           return {
             content: [
               {
                 type: 'text',
-                text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create()\n` +
+                text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create()${crossModelNotice}\n` +
                   `📁 ${bridgeResult.filePath}${projectMsg}\n` +
                   `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}${xppRuleNote}${timer.render()}`,
               },
@@ -4529,17 +4566,17 @@ export async function handleCreateD365File(
       ),
     );
     const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
-    // Offline X++ rules on the caller's own source. A create hands over the
-    // whole class, so the class-scoped rules (COC004, COC005) apply here — the
-    // cheap moment to catch what xppbp does not and only a build would.
-    const xppRuleNote = validateWrittenXpp(args.sourceCode);
+    // Offline X++ rules on the source as written. A create hands over the whole
+    // class, so the class-scoped rules (COC004, COC005) apply here — the cheap
+    // moment to catch what xppbp does not and only a build would.
+    const xppRuleNote = validateWrittenXpp(sourceAsWritten(args.sourceCode, finalObjectName));
 
     // Return success message with file path
     return {
       content: [
         {
           type: 'text',
-          text: `✅ Successfully created D365FO ${args.objectType} file:\n\n` +
+          text: `✅ Successfully created D365FO ${args.objectType} file:${crossModelNotice}\n\n` +
             `📁 Path: ${normalizedFullPath}\n` +
             `📄 Object: ${finalObjectName}${finalObjectName !== args.objectName ? ` (prefixed from "${args.objectName}")` : ''}\n` +
             `📦 Model: ${actualModelName}\n` +
@@ -4549,6 +4586,7 @@ export async function handleCreateD365File(
             bridgeFallbackNote +
             tableHonestyReport +
             rawLabelBpWarning(args.properties, finalObjectName) +
+            extensibleEnumOrderingWarning(args.objectType, args.properties, finalObjectName) +
             projectMessage +
             verifyNote +
             indexNote +

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -22,6 +22,7 @@ import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
 import { ProjectFileManager, ProjectFileFinder, registerFileInActiveProject } from '../../workspace/projectFile.js';
 import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck, membershipOf } from './inlineWriteVerification.js';
 import { validateWrittenXpp } from './inlineXppValidation.js';
+import { createPhaseTimer } from '../../utils/phaseTimer.js';
 import { registerCustomModel } from '../../utils/modelClassifier.js';
 import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { PackageResolver } from '../../utils/packageResolver.js';
@@ -3160,6 +3161,7 @@ export async function handleCreateD365File(
     symbolIndex?: import('../../metadata/symbolIndex.js').XppSymbolIndex;
   },
 ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const timer = createPhaseTimer();
   const args = CreateD365FileArgsSchema.parse(request.params.arguments);
   normalizeEnumValuesAlias(args.objectType, args.properties);
 
@@ -3734,7 +3736,7 @@ export async function handleCreateD365File(
         // extension, the EDTs a table's fields extend — so a scaffold that creates
         // an EDT and then a table using it must not see the pre-EDT model. Free
         // when no write is outstanding.
-        await debouncedRefresh.flush();
+        await timer.time('provider refresh (pending writes)', () => debouncedRefresh.flush());
 
         // The bridge's `properties` is a flat string map (C# Dictionary<string,string>).
         // Keep only SCALAR values and stringify them. Structured collections
@@ -4061,7 +4063,10 @@ export async function handleCreateD365File(
           }
         }
 
-        const createAttempt = await bridgeCreateObject(context.bridge, bridgeParams);
+        const createAttempt = await timer.time(
+          'C# bridge Create()',
+          () => bridgeCreateObject(context.bridge, bridgeParams),
+        );
         if (isBridgeFailure(createAttempt)) bridgeFailure = createAttempt;
         const bridgeResult = isBridgeFailure(createAttempt) ? null : createAttempt;
         if (bridgeResult?.success && bridgeResult.filePath) {
@@ -4132,16 +4137,18 @@ export async function handleCreateD365File(
           }
 
           // Index the new object in-process — see the smart-table path above.
-          const indexNote = await upsertWrittenFileIntoIndex(bridgeResult.filePath, context);
+          const indexNote = await timer.time('symbol index upsert',
+            () => upsertWrittenFileIntoIndex(bridgeResult.filePath, context));
           // Verify the write — see the smart-table path above.
           const verifyNote = renderWriteVerification(
-            await verifyWrittenFile(
+            await timer.time('write verification', () => verifyWrittenFile(
               bridgeResult.filePath,
               projectPathToUse,
               membershipOf(args.objectType, finalObjectName, actualModelName),
-            ),
+            )),
           );
-          const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
+          const bpNote = await timer.time('inline BP check',
+            () => runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context));
           const xppRuleNote = validateWrittenXpp(args.sourceCode);
 
           return {
@@ -4150,7 +4157,7 @@ export async function handleCreateD365File(
                 type: 'text',
                 text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create()\n` +
                   `📁 ${bridgeResult.filePath}${projectMsg}\n` +
-                  `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}${xppRuleNote}`,
+                  `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}${xppRuleNote}${timer.render()}`,
               },
             ],
           };
@@ -4547,6 +4554,7 @@ export async function handleCreateD365File(
             indexNote +
             bpNote +
             xppRuleNote +
+            timer.render() +
             `\n${nextSteps}\n` +
             `⛔ TASK COMPLETE — do NOT call \`generate\`, \`generate\`, or \`d365fo_file(action="create")\` again for this object.`,
         },

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -21,6 +21,7 @@ import { describePackagesRootScan } from '../../utils/packagesRoot.js';
 import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
 import { ProjectFileManager, ProjectFileFinder, registerFileInActiveProject } from '../../workspace/projectFile.js';
 import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck, membershipOf } from './inlineWriteVerification.js';
+import { validateWrittenXpp } from './inlineXppValidation.js';
 import { registerCustomModel } from '../../utils/modelClassifier.js';
 import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { PackageResolver } from '../../utils/packageResolver.js';
@@ -4519,6 +4520,12 @@ export async function handleCreateD365File(
       ),
     );
     const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
+    // Offline X++ rules on the caller's own source. A create hands over the whole
+    // class, so the class-scoped rules (COC004 next placement, COC005 Global
+    // functions on a table buffer) have everything they need right here — which is
+    // the only cheap moment to catch them: xppbp does not, and the build costs
+    // minutes.
+    const xppRuleNote = validateWrittenXpp(args.sourceCode);
 
     // Return success message with file path
     return {
@@ -4539,6 +4546,7 @@ export async function handleCreateD365File(
             verifyNote +
             indexNote +
             bpNote +
+            xppRuleNote +
             `\n${nextSteps}\n` +
             `⛔ TASK COMPLETE — do NOT call \`generate\`, \`generate\`, or \`d365fo_file(action="create")\` again for this object.`,
         },

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -4520,11 +4520,9 @@ export async function handleCreateD365File(
       ),
     );
     const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
-    // Offline X++ rules on the caller's own source. A create hands over the whole
-    // class, so the class-scoped rules (COC004 next placement, COC005 Global
-    // functions on a table buffer) have everything they need right here — which is
-    // the only cheap moment to catch them: xppbp does not, and the build costs
-    // minutes.
+    // Offline X++ rules on the caller's own source. A create hands over the
+    // whole class, so the class-scoped rules (COC004, COC005) apply here — the
+    // cheap moment to catch what xppbp does not and only a build would.
     const xppRuleNote = validateWrittenXpp(args.sourceCode);
 
     // Return success message with file path

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -4047,7 +4047,8 @@ export async function handleCreateD365File(
                     type: 'text',
                     text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create() (Smart)\n` +
                       `📁 ${smartResult.filePath}${projectMsg}\n` +
-                      `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}`,
+                      `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}` +
+                      validateWrittenXpp(args.sourceCode),
                   },
                 ],
               };
@@ -4141,6 +4142,7 @@ export async function handleCreateD365File(
             ),
           );
           const bpNote = await runInlineBpCheck((args as any).bpCheck, args.objectType, finalObjectName, context);
+          const xppRuleNote = validateWrittenXpp(args.sourceCode);
 
           return {
             content: [
@@ -4148,7 +4150,7 @@ export async function handleCreateD365File(
                 type: 'text',
                 text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create()\n` +
                   `📁 ${bridgeResult.filePath}${projectMsg}\n` +
-                  `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}`,
+                  `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}${xppRuleNote}`,
               },
             ],
           };

--- a/src/tools/write/createLabel.ts
+++ b/src/tools/write/createLabel.ts
@@ -21,7 +21,8 @@ import * as path from 'path';
 import { getConfigManager } from '../../utils/configManager.js';
 import { defaultPackagesRoot } from '../../utils/packagesRoot.js';
 import { PackageResolver } from '../../utils/packageResolver.js';
-import { crossModelWriteRefusal } from '../../utils/crossModelWriteGuard.js';
+import { crossModelWriteRefusal, standDownNotice } from '../../utils/crossModelWriteGuard.js';
+import { resolveAnchorModel } from './writeAnchorGuard.js';
 import { detectEol } from '../../utils/eolUtils.js';
 import { isExtensionLabelFile } from '../../metadata/labelParser.js';
 import { ProjectFileManager, ProjectFileFinder } from '../../workspace/projectFile.js';
@@ -547,21 +548,29 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
     // model's objects — and labels are usually the first thing an agent adds when
     // it drifts into the wrong model. `model` is the model directory the write
     // resolves to, so this compares the real target, not the caller's intent.
-    const crossModelLabelRefusal = crossModelWriteRefusal({
+    //
+    // The anchor is resolved through resolveWriteAnchorModel(), not the sync
+    // getter: in a workspace whose model comes only from the background .rnrproj
+    // scan, the sync read can still be null here and a null anchor makes the
+    // guard stand down.
+    const crossModelCheck = {
       objectName: `@${args.labelFileId}:${args.labelId}`,
       objectType: 'label',
       owningModel: model,
       owningPackage: resolvedPackageName,
-      activeModel: configManager.getWriteAnchorModel() ?? '',
+      activeModel: await resolveAnchorModel(configManager),
       toolSwitchedModel: configManager.getToolProjectSwitch()?.forcedModel ?? null,
-      action: 'create',
-    });
+      action: 'create' as const,
+    };
+    const crossModelLabelRefusal = crossModelWriteRefusal(crossModelCheck);
     if (crossModelLabelRefusal) {
       return {
         content: [{ type: 'text', text: crossModelLabelRefusal }],
         isError: true,
       };
     }
+    // Not a refusal, but not necessarily this model either — see standDownNotice.
+    const crossModelNotice = standDownNotice(crossModelCheck);
 
     const modelDir = path.join(resolvedPackagePath, resolvedPackageName, model);
     const axLabelDir = path.join(modelDir, 'AxLabelFile');
@@ -857,6 +866,9 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
         skipLines.push('\n✅ Label file entries already in VS project.');
       }
       if (projectWarning) skipLines.push(projectWarning);
+      // Near the top would be better, but this branch's first line is the whole
+      // verdict; keeping the notice adjacent to the location it names reads fine.
+      if (crossModelNotice) skipLines.push(crossModelNotice.trim());
       if (args.createIfMissing) {
         // The reuse path has to hand back what a create hands back, or the caller
         // still needs a second call to learn how to reference the label.
@@ -872,6 +884,10 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
     const lines: string[] = [
       ...(collisionWarning ? [collisionWarning] : []),
       `✅ Label "${ref}" ${args.overwriteExisting ? 'updated' : 'created'} successfully!`,
+      // Immediately under the verdict, not at the end: a write into another model
+      // is the first thing the reader needs to know, and the tail of this reply is
+      // reference syntax nobody scrolls to.
+      ...(crossModelNotice ? [crossModelNotice.trim()] : []),
       '',
       `Label ID   : ${labelId}`,
       `Label File : ${labelFileId}  (model: ${model})`,

--- a/src/tools/write/createLabel.ts
+++ b/src/tools/write/createLabel.ts
@@ -761,10 +761,13 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
       }
     }
 
-    // 5. Update SQLite index (skip immediate FTS rebuild — schedule debounced)
+    // 5. Update SQLite index. The FTS rows come from the labels_ai/labels_ad triggers,
+    // one per inserted row. The debounced full rebuild this replaced re-tokenised EVERY
+    // label in the database for the handful written here — on the production DB that is
+    // ~105 s of a blocked event loop (better-sqlite3 is synchronous, so no other tool
+    // call is answered meanwhile) per create_label call.
     if (updateIndex && indexEntries.length > 0) {
-      symbolIndex.bulkAddLabels(indexEntries, { skipFtsRebuild: true });
-      symbolIndex.scheduleLabelsFtsRebuild();
+      symbolIndex.bulkAddLabels(indexEntries, { skipFtsRebuild: true, keepTriggers: true });
     }
 
     // 5b. Add label file descriptors to VS project (.rnrproj) so builds detect them

--- a/src/tools/write/inlineXppValidation.ts
+++ b/src/tools/write/inlineXppValidation.ts
@@ -1,23 +1,10 @@
 /**
- * Run the offline X++ rule set on the source a write is carrying, inside the
- * write itself.
+ * Run the offline X++ rules (COC*, BP*, SEL*, TTS001) on the source a write is
+ * carrying, so they no longer depend on the caller thinking to call
+ * validate_code. Pure string analysis over text we already hold.
  *
- * The rules (COC001-005, BP001-005, SEL*, TTS001) already existed — but only
- * behind the `validate_code` tool, i.e. only when the agent thought to ask. In
- * run a5677c99 it never did: `d365fo_file(action="create")` happily wrote a CoC
- * wrapper calling `this.checkFailed(...)`, run_bp_check reported it clean (xppbp
- * does not diagnose ClassDoesNotContainMethod), and the mistake only surfaced
- * 211 seconds later as a failed build — then cost thirteen turns to walk back.
- *
- * Every one of those rules is pure string analysis over source we are holding
- * anyway, so there is no reason to charge a round trip for them. This module
- * runs them on the caller's own text and folds the result into the write's
- * reply.
- *
- * Advisory, not blocking. A rule that refuses a write has to be right every
- * time; a rule that annotates one only has to be useful, and the agent fixes it
- * in the same turn either way. `buildMarker` made the same call for the same
- * reason.
+ * Advisory, not blocking: a rule that refuses a write has to be right every
+ * time, one that annotates it only has to be useful.
  */
 
 import { runRules, type ValidationViolation } from '../analysis/validateXpp.js';
@@ -27,13 +14,8 @@ import { decodeXmlEntitiesFromXppSource } from '../../utils/xmlEscape.js';
 const SYNTHETIC_HEADER_LINES = 3;
 
 /**
- * Pull the `<Declaration>` block out of an AOT class/table XML.
- *
- * Only the declaration — not the methods. The point is to learn what the
- * enclosing class IS (`[ExtensionOf(tableStr(...))]`, `final`, its name), never
- * to validate code the caller did not write in this call. Flagging a
- * pre-existing violation in some other method would train the agent to ignore
- * the whole block.
+ * Pull the `<Declaration>` out of an AOT class/table XML — never the methods:
+ * only code the caller sent in this call is validated.
  */
 export function extractDeclaration(xml: string): string | null {
   const m = /<Declaration>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/Declaration>/.exec(xml);
@@ -43,14 +25,9 @@ export function extractDeclaration(xml: string): string | null {
 }
 
 /**
- * Wrap a bare method/snippet in the class header it will actually live under, so
- * the class-scoped rules can see their context.
- *
- * COC004 walks brace depth to find method boundaries and COC005 gates on
- * `[ExtensionOf(tableStr(...))]` — hand either of them a naked method body and
- * they correctly find nothing. The on-disk declaration carries an empty `{}`
- * body (AOT XML keeps methods in their own elements), so it cannot be prepended
- * verbatim; a header of the same shape is synthesised instead.
+ * Wrap a bare snippet in its class header so COC004/COC005 can see the context
+ * they gate on. The on-disk declaration has an empty `{}` body, so an
+ * equivalent header is synthesised rather than prepended verbatim.
  */
 function withClassContext(snippet: string, declaration: string | null): { code: string; offset: number } {
   if (!declaration) return { code: snippet, offset: 0 };
@@ -122,13 +99,10 @@ export function validateWrittenXpp(
   declarationXml?: string | null,
 ): string {
   if (!suppliedSource || suppliedSource.trim().length === 0) return '';
-  // XML markup handed in as "X++" is somebody else's bug (assertCleanXppSource
-  // catches it upstream); do not add a second, more confusing report of it.
+  // XML as "X++" is reported upstream by assertCleanXppSource.
   if (/^\s*</.test(suppliedSource)) return '';
-  // A table create carries its field definitions as JSON in the same argument.
-  // Sniffed by parsing, not by the first character: every CoC class begins with
-  // `[ExtensionOf(...)]`, so a bare bracket test would silently exempt exactly the
-  // source these rules exist for.
+  // A table create passes field definitions as JSON here. Sniffed by parsing:
+  // a bare `[` test would exempt every `[ExtensionOf(...)]` class.
   if (isJson(suppliedSource)) return '';
 
   const declaration = declarationXml ? extractDeclaration(declarationXml) : null;

--- a/src/tools/write/inlineXppValidation.ts
+++ b/src/tools/write/inlineXppValidation.ts
@@ -1,0 +1,151 @@
+/**
+ * Run the offline X++ rule set on the source a write is carrying, inside the
+ * write itself.
+ *
+ * The rules (COC001-005, BP001-005, SEL*, TTS001) already existed — but only
+ * behind the `validate_code` tool, i.e. only when the agent thought to ask. In
+ * run a5677c99 it never did: `d365fo_file(action="create")` happily wrote a CoC
+ * wrapper calling `this.checkFailed(...)`, run_bp_check reported it clean (xppbp
+ * does not diagnose ClassDoesNotContainMethod), and the mistake only surfaced
+ * 211 seconds later as a failed build — then cost thirteen turns to walk back.
+ *
+ * Every one of those rules is pure string analysis over source we are holding
+ * anyway, so there is no reason to charge a round trip for them. This module
+ * runs them on the caller's own text and folds the result into the write's
+ * reply.
+ *
+ * Advisory, not blocking. A rule that refuses a write has to be right every
+ * time; a rule that annotates one only has to be useful, and the agent fixes it
+ * in the same turn either way. `buildMarker` made the same call for the same
+ * reason.
+ */
+
+import { runRules, type ValidationViolation } from '../analysis/validateXpp.js';
+import { decodeXmlEntitiesFromXppSource } from '../../utils/xmlEscape.js';
+
+/** Lines prepended by `withClassContext`; subtracted again before reporting. */
+const SYNTHETIC_HEADER_LINES = 3;
+
+/**
+ * Pull the `<Declaration>` block out of an AOT class/table XML.
+ *
+ * Only the declaration — not the methods. The point is to learn what the
+ * enclosing class IS (`[ExtensionOf(tableStr(...))]`, `final`, its name), never
+ * to validate code the caller did not write in this call. Flagging a
+ * pre-existing violation in some other method would train the agent to ignore
+ * the whole block.
+ */
+export function extractDeclaration(xml: string): string | null {
+  const m = /<Declaration>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/Declaration>/.exec(xml);
+  if (!m) return null;
+  const decl = decodeXmlEntitiesFromXppSource(m[1]).trim();
+  return decl.length > 0 ? decl : null;
+}
+
+/**
+ * Wrap a bare method/snippet in the class header it will actually live under, so
+ * the class-scoped rules can see their context.
+ *
+ * COC004 walks brace depth to find method boundaries and COC005 gates on
+ * `[ExtensionOf(tableStr(...))]` — hand either of them a naked method body and
+ * they correctly find nothing. The on-disk declaration carries an empty `{}`
+ * body (AOT XML keeps methods in their own elements), so it cannot be prepended
+ * verbatim; a header of the same shape is synthesised instead.
+ */
+function withClassContext(snippet: string, declaration: string | null): { code: string; offset: number } {
+  if (!declaration) return { code: snippet, offset: 0 };
+  // Already a whole class (the create path passes one) — nothing to add.
+  if (/\bclass\s+\w+/i.test(snippet)) return { code: snippet, offset: 0 };
+
+  const extensionOf = /^\s*\[ExtensionOf\s*\([^\]]*\)\]/im.exec(declaration);
+  const className = /\bclass\s+(\w+)/i.exec(declaration);
+  if (!extensionOf || !className) return { code: snippet, offset: 0 };
+
+  return {
+    code: `${extensionOf[0].trim()}\nfinal class ${className[1]}\n{\n${snippet}\n}`,
+    offset: SYNTHETIC_HEADER_LINES,
+  };
+}
+
+/** True for text that is a JSON document rather than X++. */
+function isJson(source: string): boolean {
+  if (!/^\s*[[{]/.test(source)) return false;
+  try {
+    const parsed = JSON.parse(source);
+    return typeof parsed === 'object' && parsed !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** Violations rendered as the note that rides along with a write's reply. */
+function render(violations: ValidationViolation[]): string {
+  if (violations.length === 0) return '';
+
+  const errors = violations.filter(v => v.severity === 'error');
+  const warnings = violations.filter(v => v.severity === 'warning');
+
+  const lines: string[] = [''];
+  lines.push(
+    errors.length > 0
+      ? `❌ X++ validation of the source just written — ${errors.length} error(s)` +
+        (warnings.length > 0 ? `, ${warnings.length} warning(s)` : '') +
+        '. The file IS on disk; these will fail the build.'
+      : `⚠️ X++ validation of the source just written — ${warnings.length} warning(s).`,
+  );
+  for (const v of violations) {
+    const icon = v.severity === 'error' ? '🔴' : '🟡';
+    const where = v.line ? ` (line ${v.line} of the code you sent)` : '';
+    lines.push(`${icon} [${v.rule}]${where} \`${v.excerpt}\``);
+    lines.push(`   ${v.fix}`);
+  }
+  if (errors.length > 0) {
+    lines.push(
+      '➡️  Fix these with d365fo_file(action="modify") BEFORE build_d365fo_project — ' +
+      'a full build costs minutes and will only tell you the same thing.',
+    );
+  }
+  return `\n${lines.join('\n')}`;
+}
+
+/**
+ * Validate the X++ a write is carrying.
+ *
+ * @param suppliedSource  the caller's own text (sourceCode / methodCode / newCode).
+ *                        Nothing else is inspected — never the rest of the file.
+ * @param declarationXml  raw XML of the target object, when the write has one on
+ *                        disk; used only to recover the enclosing class header.
+ * @returns a markdown note to append to the write's reply, or '' when clean.
+ */
+export function validateWrittenXpp(
+  suppliedSource: string | undefined,
+  declarationXml?: string | null,
+): string {
+  if (!suppliedSource || suppliedSource.trim().length === 0) return '';
+  // XML markup handed in as "X++" is somebody else's bug (assertCleanXppSource
+  // catches it upstream); do not add a second, more confusing report of it.
+  if (/^\s*</.test(suppliedSource)) return '';
+  // A table create carries its field definitions as JSON in the same argument.
+  // Sniffed by parsing, not by the first character: every CoC class begins with
+  // `[ExtensionOf(...)]`, so a bare bracket test would silently exempt exactly the
+  // source these rules exist for.
+  if (isJson(suppliedSource)) return '';
+
+  const declaration = declarationXml ? extractDeclaration(declarationXml) : null;
+  const { code, offset } = withClassContext(suppliedSource, declaration);
+
+  let violations: ValidationViolation[];
+  try {
+    violations = runRules(code, 'xpp');
+  } catch {
+    // A lint must never be the reason a successful write reports failure.
+    return '';
+  }
+
+  const rebased = violations
+    .map(v => (v.line === undefined ? v : { ...v, line: v.line - offset }))
+    // A violation inside the synthetic header is the header's, not the caller's.
+    .filter(v => v.line === undefined || v.line > 0);
+
+  return render(rebased);
+}

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -50,6 +50,7 @@ import { enforceGrounding } from '../../utils/provenanceStore.js';
 import { gateOnReferenceErrors } from './resolveReferences.js';
 import {
   checkAddControlAgainstParentPattern,
+  checkAddControlAgainstDataGroup,
   isFormPatternEnforceEnabled,
 } from '../analysis/validateFormPattern.js';
 import { validateEdtExtensionChange } from '../../utils/edtExtensionValidator.js';
@@ -1862,6 +1863,69 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       // null → form not found or no match; proceed with original value (compiler will catch it)
     }
 
+    // ── DataGroup pre-flight for add-control ──────────────────────────────────
+    // A parent carrying <DataGroup> is filled by the compiler from that table
+    // field group. A hand-added bound control there duplicates the generated
+    // one — an error that exists only after compilation, so it cannot be found
+    // by inspecting the XML on disk.
+    if (
+      operation === 'add-control' &&
+      (objectType === 'form' || objectType === 'form-extension') &&
+      args.parentControl &&
+      (args as any).controlDataField
+    ) {
+      const baseFormName =
+        objectType === 'form'
+          ? objectName
+          : ((args as any).baseFormName || objectName.split('.')[0]);
+      const baseXml = await findBaseFormXml(baseFormName, symbolIndex);
+      if (baseXml) {
+        const dgVerdict = await checkAddControlAgainstDataGroup(
+          baseXml,
+          args.parentControl,
+          (args as any).controlDataField,
+          (args as any).controlName,
+        );
+        if (dgVerdict) {
+          const field = (args as any).controlDataField;
+          const onTable = dgVerdict.dataSource ? ` on \`${dgVerdict.dataSource}\`` : '';
+          if (isFormPatternEnforceEnabled()) {
+            return {
+              content: [{
+                type: 'text',
+                text:
+                  `⛔ add-control blocked — parent control "${args.parentControl}" renders field group ` +
+                  `**${dgVerdict.dataGroup}**${onTable} via \`<DataGroup>\`.\n\n` +
+                  `The compiler generates one control per member of that field group, named ` +
+                  `\`${dgVerdict.generatedName}\`. Adding \`${field}\` to the field group AND an explicit ` +
+                  `control for it fails the build with "The duplicate name '${dgVerdict.generatedName}' ` +
+                  `was detected"` +
+                  (dgVerdict.exactNameCollision
+                    ? ` — and your \`controlName\` is exactly that generated name, so this is certain.\n\n`
+                    : `.\n\n`) +
+                  `That duplicate is NOT visible in the XML on disk — only one of the two controls is ` +
+                  `ever written to a file.\n\n` +
+                  `Do this instead:\n` +
+                  `  1. Add the field to the field group only — d365fo_file(action="modify", ` +
+                  `objectType="table-extension", operations=[{operation:"add-field-to-field-group", ` +
+                  `fieldGroupName:"${dgVerdict.dataGroup}", fieldName:"${field}", extendBaseFieldGroup:true}]). ` +
+                  `The control appears on the form by itself; no form extension is needed.\n` +
+                  `  2. Only if you need a different position, type or properties: keep this add-control, ` +
+                  `but remove ${field} from field group ${dgVerdict.dataGroup} first.\n` +
+                  `  3. Set FORM_PATTERN_ENFORCE=false to bypass this check.`,
+              }],
+              isError: true,
+            };
+          }
+          addControlNote +=
+            `\n\n> ⚠️ DataGroup warning: parent "${args.parentControl}" renders field group ` +
+            `${dgVerdict.dataGroup} via <DataGroup>, which generates \`${dgVerdict.generatedName}\`. ` +
+            `If ${field} is also in that field group the build fails with a duplicate-name error. ` +
+            `FORM_PATTERN_ENFORCE is disabled — proceeding anyway.`;
+        }
+      }
+    }
+
     // ── Form-pattern pre-flight for add-control ───────────────────────────────
     // When the parent container declares a sub-pattern (e.g. FieldsFieldGroups),
     // verify the new control's type is allowed there. Blocking when
@@ -2921,21 +2985,27 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
                  symbolIndex?.getReadDb?.(),
                )
             ?? 'String';
-          bridgeResult = await bridgeAddControl(
-            context.bridge,
-            objectName,
-            (args as any).controlName,
-            (args as any).parentControl,
-            resolvedControlType,
-            (args as any).controlDataSource,
-            (args as any).controlDataField,
-            (args as any).controlLabel,
-          );
-          // Fallback: the bridge's AddControl resolves its target via _provider.Forms,
-          // which can never find a form EXTENSION (named "Base.Suffix") — it always
-          // reports 'Form "<ext>" not found', regardless of metadata-root freshness.
-          // For form extensions, write the control element straight into the XML.
-          if (objectType === 'form-extension' && (!bridgeResult || !bridgeResult.success)) {
+          // The bridge's AddControl resolves its target via _provider.Forms, which
+          // never contains a form EXTENSION (keyed "Base.Suffix" in FormExtensions).
+          // Calling it would always fail with 'Form "<ext>" not found' and log a
+          // bridge error for a call that cannot succeed, so extensions go straight
+          // to the XML writer. Metadata-root freshness is not a factor either way.
+          const isFormExtension = objectType === 'form-extension';
+
+          if (!isFormExtension) {
+            bridgeResult = await bridgeAddControl(
+              context.bridge,
+              objectName,
+              (args as any).controlName,
+              (args as any).parentControl,
+              resolvedControlType,
+              (args as any).controlDataSource,
+              (args as any).controlDataField,
+              (args as any).controlLabel,
+            );
+          }
+
+          if (isFormExtension && (!bridgeResult || !bridgeResult.success)) {
             const xmlFallbackResult = await directXmlAddControl(
               actualFilePath,
               (args as any).controlName,

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -306,25 +306,17 @@ function occurrenceLines(content: string, needle: string): number[] {
 }
 
 /**
- * Refuse a replace-code that cannot mean what the caller thinks it means.
+ * Refuse a replace-code that cannot mean what the caller intends.
  *
- * The bridge applies the edit with .NET `String.Replace` (MetadataWriteService.cs
- * ReplaceInMethods), which is replace-ALL, reports no count, and echoes nothing of
- * what changed. Run a5677c99 shows what that costs: the caller sent
- * oldCode="checkFailed", newCode="this.checkFailed" against a method whose source
- * already read `this.checkFailed(...)`. One match, dutifully replaced, and the file
- * now said `this.this.checkFailed`. Three more calls and two file reads went into
- * discovering that, and the last of them failed with "oldCode must match the exact
- * source" at a moment when the file was in fact already correct.
+ * The bridge edits with .NET `String.Replace` (MetadataWriteService.ReplaceIn
+ * Methods) — replace-ALL, no count, no echo. Two failure modes are decidable
+ * from the file first: oldCode matching more than once, and an edit whose
+ * newCode is already present and contains oldCode (oldCode="checkFailed",
+ * newCode="this.checkFailed" over `this.checkFailed` yields
+ * `this.this.checkFailed`).
  *
- * Both failure modes are decidable from the file before touching the bridge:
- *   - oldCode occurs more than once → which one did you mean?
- *   - the file already contains newCode and oldCode is a substring of it → the edit
- *     is already applied, and re-applying it nests the text instead of fixing it.
- *
- * Returns null to proceed, or a verdict to stop on: `noop` when the file is
- * already in the requested state (a success — nothing is wrong and nothing is
- * left to do) and `refuse` when the call is ambiguous or destructive.
+ * Returns null to proceed, `noop` when the file is already in the requested
+ * state, `refuse` when the call is ambiguous.
  */
 export interface ReplaceCodeVerdict {
   kind: 'noop' | 'refuse';
@@ -387,12 +379,8 @@ export function preflightReplaceCode(
 }
 
 /**
- * The lines a write actually changed, with context — so the caller can see the
- * result without spending a round trip on read_file.
- *
- * In run a5677c99 every replace-code was followed by exactly that read, three
- * times, because the reply said "✅ Code replaced" and nothing about what the code
- * now was.
+ * The lines a write changed, with context, so seeing the result costs no
+ * read_file round trip.
  */
 export function renderChangedLines(before: string, after: string, context = 3): string {
   if (before === after) return '';
@@ -2828,18 +2816,15 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         }
         
         if (hasOldNew) {
-          // Decide the ambiguous and the already-applied cases from the file before
-          // the bridge's replace-ALL semantics get to act on them.
+          // Decided before the bridge's replace-ALL semantics act on it.
           const beforeContent = await readForMatching(actualFilePath);
           if (beforeContent !== null) {
             replaceCodeBefore = beforeContent;
             const verdict = preflightReplaceCode(beforeContent, args.oldCode!, args.newCode!);
             if (verdict?.kind === 'refuse') throw new Error(verdict.message);
             if (verdict?.kind === 'noop') {
-              // An already-correct file is a success, not a failure. Reporting it as
-              // an error is what sent run a5677c99 back round the loop: the repair had
-              // landed on the previous call and the retry was told "oldCode must match
-              // the exact source", which reads as "the file is still wrong".
+              // An already-correct file is a success; "oldCode not found" would
+              // read as "the file is still wrong" and invite a retry.
               return {
                 content: [{
                   type: 'text',
@@ -3173,13 +3158,10 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       ? await readForMatching(actualFilePath)
       : null;
 
-    // The full offline rule set (COC001-005, BP001-005, TTS001) on the same text.
-    // A method snippet carries no class header, so the object's own <Declaration>
-    // is read back to supply one — that is what lets COC004/COC005 see they are
-    // looking at a table CoC wrapper. Failure to read it just means fewer rules.
+    // The offline rule set on the same text. The object's <Declaration> supplies
+    // the class header a method snippet lacks; without it, fewer rules apply.
     const xppRuleNote = writtenXpp ? validateWrittenXpp(writtenXpp, afterContent) : '';
 
-    // Show the edit instead of asserting it. See renderChangedLines.
     const changedLinesNote = replaceCodeBefore !== null && afterContent !== null
       ? renderChangedLines(replaceCodeBefore, afterContent)
       : '';

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -57,6 +57,7 @@ import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
 import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck, membershipOf } from './inlineWriteVerification.js';
 import { lintXppSelect } from '../../utils/xppSelectLint.js';
 import { validateWrittenXpp } from './inlineXppValidation.js';
+import { createPhaseTimer } from '../../utils/phaseTimer.js';
 import {
   getRequiredParams, renderOpSpec, OP_PARAM_ALIASES,
   findIgnoredParams, renderIgnoredParamsWarning, findMissingMutationParams,
@@ -1681,6 +1682,7 @@ const ModifyD365FileArgsSchema = z.object({
 });
 
 export async function modifyD365FileTool(request: CallToolRequest, context: XppServerContext) {
+  const timer = createPhaseTimer();
   try {
     const args = ModifyD365FileArgsSchema.parse(request.params.arguments);
 
@@ -2095,7 +2097,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // an object written moments ago resolves on the FIRST attempt. Without this the
     // retry loop below would still recover — at the cost of a wasted bridge round
     // trip plus a full rebuild. Free when no write is outstanding.
-    await debouncedRefresh.flush();
+    await timer.time('provider refresh (pending writes)', () => debouncedRefresh.flush());
 
     let bridgeResult: { success: boolean; message: string } | null = null;
     /** File content captured before a replace-code, to diff the reply against. */
@@ -2104,6 +2106,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // Retry loop: on the first null result with all required params present,
     // refresh the bridge provider (picks up objects created this session) and
     // re-run the operation once. Max 1 auto-refresh retry (_bridgeRetried guard).
+    const bridgeStartedAt = Date.now();
     _bridgeRetry: do {
       bridgeResult = null;
 
@@ -3066,6 +3069,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // condition is deliberately unconditional.
     // biome-ignore lint/correctness/noConstantCondition: labelled retry loop, exits via break
     } while (true); // end of retry loop
+    timer.add(`C# bridge ${operation}`, Date.now() - bridgeStartedAt);
 
     if (!bridgeResult!.success) {
       // Surface the real bridge error. For an object-resolution failure keep the
@@ -3210,7 +3214,8 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // making the agent spend a round trip on update_symbol_index for a file this
     // process just wrote, and another on the lookup that failed for want of it,
     // was pure waste.
-    const indexNote = await upsertWrittenFileIntoIndex(actualFilePath, context);
+    const indexNote = await timer.time('symbol index upsert',
+      () => upsertWrittenFileIntoIndex(actualFilePath, context));
 
     // Verify the write here rather than leaving the caller to spend a
     // verify_d365fo_project round trip asking what this call already knows.
@@ -3220,13 +3225,14 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     const verifyProjectPath =
       args.projectPath || (await getConfigManager().getProjectPath()) || undefined;
     const verifyNote = renderWriteVerification(
-      await verifyWrittenFile(
+      await timer.time('write verification', () => verifyWrittenFile(
         actualFilePath,
         verifyProjectPath,
         membershipOf(objectType, objectName, modelName || getConfigManager().getModelName()),
-      ),
+      )),
     );
-    const bpNote = await runInlineBpCheck((args as any).bpCheck, objectType, objectName, context);
+    const bpNote = await timer.time('inline BP check',
+      () => runInlineBpCheck((args as any).bpCheck, objectType, objectName, context));
 
     return {
       content: [
@@ -3235,7 +3241,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
           text:
             `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()${autoCorrectNote}\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
-            `🔧 API: ${bridgeResult.message}${changedLinesNote}${xppLintNote}${xppRuleNote}${addFieldBpNote}${backupNote}${verifyNote}${indexNote}${bpNote}` +
+            `🔧 API: ${bridgeResult.message}${changedLinesNote}${xppLintNote}${xppRuleNote}${addFieldBpNote}${backupNote}${verifyNote}${indexNote}${bpNote}${timer.render()}` +
             (ignoredParamsWarning ? `\n\n${ignoredParamsWarning}` : '') + `\n\n` +
             `**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate`,
         },

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -56,6 +56,7 @@ import { validateEdtExtensionChange } from '../../utils/edtExtensionValidator.js
 import { upsertWrittenFileIntoIndex } from './inlineIndexUpsert.js';
 import { verifyWrittenFile, renderWriteVerification, runInlineBpCheck, membershipOf } from './inlineWriteVerification.js';
 import { lintXppSelect } from '../../utils/xppSelectLint.js';
+import { validateWrittenXpp } from './inlineXppValidation.js';
 import {
   getRequiredParams, renderOpSpec, OP_PARAM_ALIASES,
   findIgnoredParams, renderIgnoredParamsWarning, findMissingMutationParams,
@@ -281,6 +282,143 @@ function serializedOnFile<A extends unknown[], R>(
   fn: (filePath: string, ...args: A) => Promise<R>,
 ): (filePath: string, ...args: A) => Promise<R> {
   return (filePath, ...args) => withFileLock(filePath, () => fn(filePath, ...args));
+}
+
+/** File content, CRLF- and BOM-normalised, for matching caller-supplied X++ against. */
+async function readForMatching(filePath: string): Promise<string | null> {
+  try {
+    return (await fs.readFile(filePath, 'utf-8')).replace(/^﻿/, '').replace(/\r\n/g, '\n');
+  } catch {
+    return null;
+  }
+}
+
+/** 1-based line numbers at which `needle` occurs in `content`. */
+function occurrenceLines(content: string, needle: string): number[] {
+  const lines: number[] = [];
+  let from = 0;
+  for (;;) {
+    const at = content.indexOf(needle, from);
+    if (at === -1) return lines;
+    lines.push(content.slice(0, at).split('\n').length);
+    from = at + Math.max(needle.length, 1);
+  }
+}
+
+/**
+ * Refuse a replace-code that cannot mean what the caller thinks it means.
+ *
+ * The bridge applies the edit with .NET `String.Replace` (MetadataWriteService.cs
+ * ReplaceInMethods), which is replace-ALL, reports no count, and echoes nothing of
+ * what changed. Run a5677c99 shows what that costs: the caller sent
+ * oldCode="checkFailed", newCode="this.checkFailed" against a method whose source
+ * already read `this.checkFailed(...)`. One match, dutifully replaced, and the file
+ * now said `this.this.checkFailed`. Three more calls and two file reads went into
+ * discovering that, and the last of them failed with "oldCode must match the exact
+ * source" at a moment when the file was in fact already correct.
+ *
+ * Both failure modes are decidable from the file before touching the bridge:
+ *   - oldCode occurs more than once → which one did you mean?
+ *   - the file already contains newCode and oldCode is a substring of it → the edit
+ *     is already applied, and re-applying it nests the text instead of fixing it.
+ *
+ * Returns null to proceed, or a verdict to stop on: `noop` when the file is
+ * already in the requested state (a success — nothing is wrong and nothing is
+ * left to do) and `refuse` when the call is ambiguous or destructive.
+ */
+export interface ReplaceCodeVerdict {
+  kind: 'noop' | 'refuse';
+  message: string;
+}
+
+export function preflightReplaceCode(
+  content: string,
+  oldCode: string,
+  newCode: string,
+): ReplaceCodeVerdict | null {
+  const normOld = oldCode.replace(/\r\n/g, '\n');
+  const normNew = newCode.replace(/\r\n/g, '\n');
+  if (normOld.length === 0) return null;
+
+  const hits = occurrenceLines(content, normOld);
+
+  if (hits.length === 0) {
+    // Not an error here — the bridge may still reach source this file-level view
+    // cannot (form control overrides). But if the intended result is already
+    // present, say THAT instead of letting "oldCode not found" imply the opposite.
+    if (normNew.length > 0 && content.includes(normNew)) {
+      return {
+        kind: 'noop',
+        message:
+          `Nothing to do — the file already contains newCode ` +
+          `(line ${occurrenceLines(content, normNew)[0]}), and oldCode is not present. ` +
+          `This edit has already been applied; do not retry it.`,
+      };
+    }
+    return null;
+  }
+
+  if (normNew.includes(normOld) && content.includes(normNew)) {
+    return {
+      kind: 'noop',
+      message:
+        `Nothing to do — this edit is already applied, and repeating it would nest the text.\n` +
+        `   oldCode  : ${JSON.stringify(normOld)}\n` +
+        `   newCode  : ${JSON.stringify(normNew)}\n` +
+        `newCode is already in the file at line ${occurrenceLines(content, normNew)[0]}, and oldCode is a ` +
+        `substring of it — so the ${hits.length} "match(es)" found ARE the newCode occurrence(s). ` +
+        `Applying it would produce ${JSON.stringify(normNew.replace(normOld, normNew))}.\n` +
+        `If you meant a different edit, pass a full-line oldCode with enough surrounding text to be unambiguous.`,
+    };
+  }
+
+  if (hits.length > 1) {
+    return {
+      kind: 'refuse',
+      message:
+        `⛔ replace-code refused — oldCode matches ${hits.length} times (lines ${hits.join(', ')}).\n` +
+        `The bridge replaces EVERY occurrence, so this would edit all ${hits.length} of them. ` +
+        `Extend oldCode with surrounding lines until it identifies exactly one site, or scope the call ` +
+        `with methodName="<method>".`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * The lines a write actually changed, with context — so the caller can see the
+ * result without spending a round trip on read_file.
+ *
+ * In run a5677c99 every replace-code was followed by exactly that read, three
+ * times, because the reply said "✅ Code replaced" and nothing about what the code
+ * now was.
+ */
+export function renderChangedLines(before: string, after: string, context = 3): string {
+  if (before === after) return '';
+  const b = before.split('\n');
+  const a = after.split('\n');
+
+  let head = 0;
+  while (head < b.length && head < a.length && b[head] === a[head]) head++;
+  let tail = 0;
+  while (
+    tail < b.length - head &&
+    tail < a.length - head &&
+    b[b.length - 1 - tail] === a[a.length - 1 - tail]
+  ) tail++;
+
+  const from = Math.max(0, head - context);
+  const to = Math.min(a.length, a.length - tail + context);
+  const shown = a.slice(from, to)
+    .map((line, i) => {
+      const no = from + i + 1;
+      const changed = no > head && no <= a.length - tail;
+      return `${changed ? '›' : ' '} ${String(no).padStart(4)} | ${line}`;
+    })
+    .join('\n');
+
+  return `\n\n**Result on disk** (› = changed):\n\`\`\`\n${shown}\n\`\`\``;
 }
 
 /**
@@ -1972,6 +2110,8 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     await debouncedRefresh.flush();
 
     let bridgeResult: { success: boolean; message: string } | null = null;
+    /** File content captured before a replace-code, to diff the reply against. */
+    let replaceCodeBefore: string | null = null;
     let _bridgeRetried = false;
     // Retry loop: on the first null result with all required params present,
     // refresh the bridge provider (picks up objects created this session) and
@@ -2688,6 +2828,29 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         }
         
         if (hasOldNew) {
+          // Decide the ambiguous and the already-applied cases from the file before
+          // the bridge's replace-ALL semantics get to act on them.
+          const beforeContent = await readForMatching(actualFilePath);
+          if (beforeContent !== null) {
+            replaceCodeBefore = beforeContent;
+            const verdict = preflightReplaceCode(beforeContent, args.oldCode!, args.newCode!);
+            if (verdict?.kind === 'refuse') throw new Error(verdict.message);
+            if (verdict?.kind === 'noop') {
+              // An already-correct file is a success, not a failure. Reporting it as
+              // an error is what sent run a5677c99 back round the loop: the repair had
+              // landed on the previous call and the retry was told "oldCode must match
+              // the exact source", which reads as "the file is still wrong".
+              return {
+                content: [{
+                  type: 'text',
+                  text:
+                    `✅ ${operation} on ${objectType} "${objectName}" — no change needed.\n\n` +
+                    `**File:** ${actualFilePath}\n${verdict.message}`,
+                }],
+              };
+            }
+          }
+
           // Try bridge first
           bridgeResult = await bridgeReplaceCode(
             context.bridge,
@@ -3001,8 +3164,25 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // Advisory X++ select-statement lint on the source just written (add-method /
     // replace-code etc.). Non-blocking: surfaces a likely "WHERE after join" mistake
     // up front instead of letting it become a build error the agent hunts by hand.
-    const xppLintWarnings = lintXppSelect(args.sourceCode ?? (args as any).methodCode ?? args.newCode);
+    const writtenXpp = args.sourceCode ?? (args as any).methodCode ?? args.newCode;
+    const xppLintWarnings = lintXppSelect(writtenXpp);
     const xppLintNote = xppLintWarnings.length > 0 ? `\n\n${xppLintWarnings.join('\n\n')}` : '';
+
+    // One read back of what is now on disk, used for both of the notes below.
+    const afterContent = writtenXpp || replaceCodeBefore !== null
+      ? await readForMatching(actualFilePath)
+      : null;
+
+    // The full offline rule set (COC001-005, BP001-005, TTS001) on the same text.
+    // A method snippet carries no class header, so the object's own <Declaration>
+    // is read back to supply one — that is what lets COC004/COC005 see they are
+    // looking at a table CoC wrapper. Failure to read it just means fewer rules.
+    const xppRuleNote = writtenXpp ? validateWrittenXpp(writtenXpp, afterContent) : '';
+
+    // Show the edit instead of asserting it. See renderChangedLines.
+    const changedLinesNote = replaceCodeBefore !== null && afterContent !== null
+      ? renderChangedLines(replaceCodeBefore, afterContent)
+      : '';
 
     // Two BP rules fire on a field that compiles perfectly, so they are invisible
     // until a BP run several steps later — and one of them (the label copy) then
@@ -3073,7 +3253,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
           text:
             `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()${autoCorrectNote}\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
-            `🔧 API: ${bridgeResult.message}${xppLintNote}${addFieldBpNote}${backupNote}${verifyNote}${indexNote}${bpNote}` +
+            `🔧 API: ${bridgeResult.message}${changedLinesNote}${xppLintNote}${xppRuleNote}${addFieldBpNote}${backupNote}${verifyNote}${indexNote}${bpNote}` +
             (ignoredParamsWarning ? `\n\n${ignoredParamsWarning}` : '') + `\n\n` +
             `**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate`,
         },

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -51,6 +51,7 @@ import { gateOnReferenceErrors } from './resolveReferences.js';
 import {
   checkAddControlAgainstParentPattern,
   checkAddControlAgainstDataGroup,
+  findDataGroupRenderers,
   isFormPatternEnforceEnabled,
 } from '../analysis/validateFormPattern.js';
 import { validateEdtExtensionChange } from '../../utils/edtExtensionValidator.js';
@@ -67,8 +68,9 @@ import { lookupSymbolNocase } from '../../utils/symbolLookup.js';
 import { decodeXmlEntitiesFromXppSource } from '../../utils/xmlEscape.js';
 import { findD365FileOnDisk } from '../../utils/objectFileLookup.js';
 import {
-  crossModelWriteRefusal, baseObjectOf, type ExistingExtension,
+  crossModelWriteRefusal, standDownNotice, baseObjectOf, type ExistingExtension,
 } from '../../utils/crossModelWriteGuard.js';
+import { resolveAnchorModel } from './writeAnchorGuard.js';
 
 
 /**
@@ -2031,24 +2033,30 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     const owningModel = containment.modelSegment ?? null;
     // The write ANCHOR, not the active model: a get_workspace_info project switch
     // moves reads, and must not move what this guard measures writes against.
-    const activeModel = getConfigManager().getWriteAnchorModel() ?? '';
-    const crossModelRefusal = crossModelWriteRefusal({
+    // Resolved, not read synchronously: where the model comes only from the
+    // background .rnrproj scan, the sync getter can still be null here — and a
+    // null anchor makes the guard stand down.
+    const activeModel = await resolveAnchorModel(getConfigManager());
+    const crossModelCheck = {
       objectName,
       objectType,
       owningModel,
       owningPackage: containment.packageSegment ?? resolvedModelFromPath,
       activeModel,
       toolSwitchedModel: getConfigManager().getToolProjectSwitch()?.forcedModel ?? null,
-      action: 'modify',
+      action: 'modify' as const,
       existingExtensions: findExtensionsInModel(
         symbolIndex,
         baseObjectOf(objectName, objectType),
         activeModel,
       ),
-    });
+    };
+    const crossModelRefusal = crossModelWriteRefusal(crossModelCheck);
     if (crossModelRefusal) {
       throw new Error(crossModelRefusal);
     }
+    // Allowed, but possibly not into this model — see standDownNotice.
+    const crossModelNotice = standDownNotice(crossModelCheck);
 
     // 2. Resolve actual XML file path (DB may store JSON metadata with sourcePath)
     let actualFilePath = filePath;
@@ -3272,6 +3280,23 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       addFieldBpNote = notes.length > 0 ? `\n\n${notes.join('\n')}` : '';
     }
 
+    // A field group already rendered on a form via <DataGroup> puts the field on
+    // that form by itself — said now, before a form extension gets created for it.
+    let fieldGroupRenderNote = '';
+    if (
+      operation === 'add-field-to-field-group' &&
+      (objectType === 'table' || objectType === 'table-extension') &&
+      (args as any).fieldGroupName && args.fieldName
+    ) {
+      fieldGroupRenderNote = await timer.time('field-group render probe', () =>
+        describeFieldGroupRendering(
+          objectType === 'table' ? objectName : objectName.split('.')[0],
+          (args as any).fieldGroupName,
+          args.fieldName!,
+          symbolIndex,
+        ));
+    }
+
     // Corrections the server applied on its own. Kept in the payload so the agent
     // learns the correct form for next time and the write stays auditable.
     const autoCorrectNote = autoCorrectNotes.length > 0
@@ -3309,9 +3334,9 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         {
           type: 'text',
           text:
-            `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()${autoCorrectNote}\n\n` +
+            `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()${crossModelNotice}${autoCorrectNote}\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
-            `🔧 API: ${bridgeResult.message}${changedLinesNote}${xppLintNote}${xppRuleNote}${addFieldBpNote}${backupNote}${verifyNote}${indexNote}${bpNote}${timer.render()}` +
+            `🔧 API: ${bridgeResult.message}${changedLinesNote}${xppLintNote}${xppRuleNote}${addFieldBpNote}${fieldGroupRenderNote}${backupNote}${verifyNote}${indexNote}${bpNote}${timer.render()}` +
             (ignoredParamsWarning ? `\n\n${ignoredParamsWarning}` : '') + `\n\n` +
             `**Next steps:**\n- Review changes in Visual Studio\n- Build the model to validate`,
         },
@@ -3947,6 +3972,70 @@ function isBaseFieldGroupMissError(message: string | undefined): boolean {
   if (!message) return false;
   return /field group .* not found on table-extension/i.test(message)
     && /extendBaseFieldGroup=true/i.test(message);
+}
+
+/** How many forms on the base table are opened looking for a <DataGroup> renderer. */
+const DATA_GROUP_FORM_PROBE_LIMIT = 3;
+
+/**
+ * Note for a successful add-field-to-field-group: is this field group already
+ * rendered on a form through a container's <DataGroup>?
+ *
+ * If it is, the compiler puts the new field on that form by itself and any
+ * hand-added control for it collides with the generated one. The add-control
+ * guard says the same thing, but only once a form extension exists and a control
+ * is being added to it — a create that then has to be undone. Said here it costs
+ * one indexed lookup.
+ *
+ * Returns '' on any miss — no form on the table, no container with that
+ * DataGroup, an unreadable form, a database that cannot answer — which leaves
+ * the reactive guard exactly as it was.
+ */
+export async function describeFieldGroupRendering(
+  baseTableName: string,
+  groupName: string,
+  fieldName: string,
+  symbolIndex: any,
+): Promise<string> {
+  try {
+    const rdb = symbolIndex?.getReadDb?.();
+    if (!rdb) return '';
+
+    // BINARY probe on idx_form_datasources_table first; table_name casing comes
+    // from the form XML, so fall back to NOCASE only when that misses
+    // (form_datasources is small — the scan is cheap).
+    const sql = (collate: string) =>
+      `SELECT DISTINCT form_name, datasource_name FROM form_datasources ` +
+      `WHERE table_name = ?${collate} LIMIT ${DATA_GROUP_FORM_PROBE_LIMIT}`;
+    let rows = rdb.prepare(sql('')).all(baseTableName) as
+      Array<{ form_name: string; datasource_name: string }>;
+    if (rows.length === 0) {
+      rows = rdb.prepare(sql(' COLLATE NOCASE')).all(baseTableName) as typeof rows;
+    }
+
+    for (const row of rows) {
+      const xml = await findBaseFormXml(row.form_name, symbolIndex);
+      if (!xml) continue;
+      const renderers = await findDataGroupRenderers(xml, groupName);
+      // A container bound to a different datasource renders a different table's
+      // group of the same name — not this field's.
+      const hit = renderers.find(
+        r => !r.dataSource || r.dataSource.toLowerCase() === row.datasource_name.toLowerCase(),
+      );
+      if (!hit) continue;
+
+      return (
+        `\n\n🖼️ Form \`${row.form_name}\` renders field group **${groupName}** via ` +
+        `\`<DataGroup>\` on control "${hit.controlName}" — the compiler generates ` +
+        `\`${hit.generatedNameFor(fieldName)}\` for this field, so **it is already on the form**. ` +
+        `Do not create a form extension or an add-control for it: that control and the ` +
+        `generated one collide as a duplicate name, which only the build reports.`
+      );
+    }
+  } catch {
+    // A hint must never be the reason a successful write reports failure.
+  }
+  return '';
 }
 
 /** True when the base table's own <FieldGroups> defines `groupName`. */

--- a/src/tools/write/resolveReferences.ts
+++ b/src/tools/write/resolveReferences.ts
@@ -62,6 +62,7 @@ export interface ReferenceViolation {
     | 'unknown-method'
     | 'unknown-field'
     | 'unknown-label'
+    | 'label-placeholder-mismatch'
     | 'unknown-intrinsic-target'
     | 'arity-mismatch'
     | 'not-visible-from-model';
@@ -88,7 +89,7 @@ export interface ResolverDeps {
   getLabelById(
     labelId: string,
     labelFileId?: string,
-  ): Array<{ labelId: string; labelFileId: string }>;
+  ): Array<{ labelId: string; labelFileId: string; language?: string; text?: string }>;
   getLabelFileIds(): Array<{ labelFileId: string }>;
   /**
    * Optional Descriptor-backed answer to "may the target model see this type?".
@@ -651,8 +652,11 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
     const legacy = s.value.match(/^@([A-Z]{2,4}\d+)$/);
     if (modern) {
       const [, fileId, labelId] = modern;
-      if (deps.getLabelById(labelId, fileId).length > 0) {
+      const hits = deps.getLabelById(labelId, fileId);
+      if (hits.length > 0) {
         verifiedCount++;
+        const v = checkLabelPlaceholders(hits, `@${fileId}:${labelId}`, cleaned, s.index, code);
+        if (v) violations.push(v);
       } else {
         // Known label file with missing id is an error; unknown file is a warning.
         const fileKnown = labelFileExists(deps, fileId);
@@ -905,6 +909,108 @@ export function resolverModelVisibility(): ModelVisibility | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * A label's %n placeholders against the arguments the call site supplies.
+ *
+ * Both directions are silent at compile time and wrong at runtime: a label with
+ * %1 used without strFmt shows the user a literal "%1", and arguments passed to
+ * a label that has no placeholders are discarded.
+ */
+function checkLabelPlaceholders(
+  hits: Array<{ language?: string; text?: string }>,
+  identifier: string,
+  cleaned: string,
+  index: number,
+  code: string,
+): ReferenceViolation | null {
+  const preferred = hits.find(h => h.language?.toLowerCase() === 'en-us') ?? hits[0];
+  if (!preferred?.text) return null;
+
+  const needed = placeholderCount(preferred.text);
+  const supplied = strFmtArgs(cleaned, index);
+  const line = lineOf(code, index);
+  const quoted = `"${preferred.text}"`;
+
+  if (needed === 0 && supplied !== null && supplied > 0) {
+    return {
+      kind: 'label-placeholder-mismatch',
+      severity: 'error',
+      line,
+      identifier,
+      detail:
+        `${identifier} is ${quoted} — no %1 placeholder, so the ${supplied} strFmt argument(s) are discarded. ` +
+        `Drop strFmt, or add %1…%${supplied} to the label text with labels(action="update").`,
+    };
+  }
+  if (needed > 0 && supplied === null) {
+    return {
+      kind: 'label-placeholder-mismatch',
+      severity: 'error',
+      line,
+      identifier,
+      detail:
+        `${identifier} is ${quoted} — it takes ${needed} argument(s) and must be wrapped: ` +
+        `strFmt("${identifier}", …). Used bare, the user sees the literal %1.`,
+    };
+  }
+  if (needed > 0 && supplied !== null && supplied !== needed) {
+    return {
+      kind: 'label-placeholder-mismatch',
+      severity: 'error',
+      line,
+      identifier,
+      detail:
+        `${identifier} is ${quoted} — it takes ${needed} argument(s), strFmt supplies ${supplied}.`,
+    };
+  }
+  return null;
+}
+
+/** Highest %n in a label's text; 0 when it takes no arguments. */
+function placeholderCount(text: string): number {
+  let max = 0;
+  for (const m of text.matchAll(/%(\d+)/g)) max = Math.max(max, Number(m[1]));
+  return max;
+}
+
+/**
+ * How a label literal at `index` is being passed: as strFmt's format argument,
+ * and if so with how many further arguments.
+ *
+ * Scans backwards for the nearest unclosed `(` chain, so `checkFailed(strFmt(@X,
+ * a, b))` reports the strFmt, not the checkFailed. `literalStr(@X)` is
+ * transparent — it wraps the literal without changing who receives it.
+ */
+function strFmtArgs(cleaned: string, index: number): number | null {
+  let depth = 0;
+  let i = index - 1;
+  for (; i >= 0; i--) {
+    const c = cleaned[i];
+    if (c === ')') depth++;
+    else if (c === '(') {
+      if (depth === 0) break;
+      depth--;
+    }
+  }
+  if (i < 0) return null;
+
+  const callee = /([A-Za-z_]\w*)\s*$/.exec(cleaned.slice(0, i));
+  if (!callee) return null;
+  if (/^literalStr$/i.test(callee[1])) return strFmtArgs(cleaned, callee.index);
+  if (!/^strFmt$/i.test(callee[1])) return null;
+
+  // Commas at this call's own depth, from the format argument to the close.
+  let args = 0;
+  let d = 0;
+  for (let k = i + 1; k < cleaned.length; k++) {
+    const c = cleaned[k];
+    if (c === '(') d++;
+    else if (c === ')') { if (d === 0) break; d--; }
+    else if (c === ',' && d === 0) args++;
+  }
+  return args;
 }
 
 /** True when the label file id is present in the labels index. */

--- a/src/tools/write/writeAnchorGuard.ts
+++ b/src/tools/write/writeAnchorGuard.ts
@@ -18,6 +18,30 @@
 import { crossModelWriteRefusal } from '../../utils/crossModelWriteGuard.js';
 import { getConfigManager } from '../../utils/configManager.js';
 
+/**
+ * The write anchor, resolved the way every guard must resolve it.
+ *
+ * Async because the synchronous getter returns null until the background
+ * .rnrproj scan lands, and a null anchor makes the guard stand down — which
+ * left the guard decided by a race.
+ *
+ * Defensive on purpose: a ConfigManager without the async method falls back to
+ * the sync getter, and one with neither yields '' — the guard's own "nothing to
+ * compare against" case, not a crash inside a write.
+ */
+export async function resolveAnchorModel(cm: {
+  resolveWriteAnchorModel?: () => Promise<string | null>;
+  getWriteAnchorModel?: () => string | null;
+}): Promise<string> {
+  try {
+    const resolved = await cm.resolveWriteAnchorModel?.();
+    if (resolved) return resolved;
+  } catch {
+    /* fall through to the sync getter */
+  }
+  return cm.getWriteAnchorModel?.() ?? '';
+}
+
 export interface ScaffoldWriteTarget {
   /** Final object name, prefix and suffix already applied. */
   objectName: string;
@@ -34,25 +58,36 @@ export interface ScaffoldWriteTarget {
  * not expose getWriteAnchorModel yields no anchor, and the guard then has nothing
  * to compare against and stays silent — never a refusal on a guess.
  */
-export function scaffoldWriteRefusal(target: ScaffoldWriteTarget): string | null {
+export async function scaffoldWriteRefusal(target: ScaffoldWriteTarget): Promise<string | null> {
+  return crossModelWriteRefusal(await scaffoldWriteCheck(target));
+}
+
+/**
+ * The check this scaffold is measured by. Exposed so a caller that proceeds can
+ * also ask for standDownNotice() without resolving the anchor twice.
+ *
+ * The anchor is RESOLVED, not read: the synchronous getter returns null until the
+ * background .rnrproj scan lands, and a null anchor makes the guard stand down.
+ */
+export async function scaffoldWriteCheck(target: ScaffoldWriteTarget) {
   const cm = getConfigManager() as Partial<ReturnType<typeof getConfigManager>>;
-  const anchor = cm.getWriteAnchorModel?.() ?? null;
+  const anchor = (await resolveAnchorModel(cm)) || null;
   const switched = cm.getToolProjectSwitch?.()?.forcedModel ?? null;
 
-  return crossModelWriteRefusal({
+  return {
     objectName: target.objectName,
     objectType: target.objectType,
     owningModel: target.targetModel,
     activeModel: anchor,
     toolSwitchedModel: switched,
-    action: 'create',
-  });
+    action: 'create' as const,
+  };
 }
 
 /** Same check, packaged as the tool result a scaffold handler returns. */
-export function scaffoldWriteRefusalResult(
+export async function scaffoldWriteRefusalResult(
   target: ScaffoldWriteTarget,
-): { content: Array<{ type: string; text: string }>; isError: true } | null {
-  const refusal = scaffoldWriteRefusal(target);
+): Promise<{ content: Array<{ type: string; text: string }>; isError: true } | null> {
+  const refusal = await scaffoldWriteRefusal(target);
   return refusal ? { content: [{ type: 'text', text: refusal }], isError: true } : null;
 }

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -1283,6 +1283,33 @@ class ConfigManager {
     return this.toolForcedProject?.anchorModel ?? this.getModelName();
   }
 
+  /**
+   * The same anchor, with project detection awaited first — what every write
+   * guard must use.
+   *
+   * getWriteAnchorModel() is synchronous, and in a workspace that configures no
+   * `modelName` and sits outside PackagesLocalDirectory its ONLY source is
+   * `autoDetectedProject`, a field a background .rnrproj scan fills in. Read
+   * before that scan lands it returns null — and a null anchor makes the
+   * cross-model guard stand down by design ("never block on a guess"). That
+   * leaves a guard which is present, correct, and occasionally simply absent,
+   * decided by a race nobody can see. get_workspace_info never had the problem
+   * because it awaits the scan; the guards did not.
+   *
+   * The common path costs nothing: an anchor already known short-circuits before
+   * the await.
+   */
+  async resolveWriteAnchorModel(): Promise<string | null> {
+    const known = this.getWriteAnchorModel();
+    if (known) return known;
+    try {
+      await this.awaitPendingDetection();
+    } catch {
+      /* detection is best-effort — the guard's own null-anchor path still applies */
+    }
+    return this.getWriteAnchorModel();
+  }
+
   /** The in-effect tool project switch, or null when writes and reads agree. */
   getToolProjectSwitch(): { anchorModel: string; forcedModel: string } | null {
     return this.toolForcedProject;

--- a/src/utils/crossModelWriteGuard.ts
+++ b/src/utils/crossModelWriteGuard.ts
@@ -26,8 +26,8 @@
  * explanation afterwards. A bypass the caller can mint for itself is not a
  * bypass, it is a speed bump.
  *
- * So consent lives ONLY in server configuration — a file the user edits and the
- * agent has no tool to write:
+ * So consent lives in server configuration, which the caller cannot reach
+ * through any tool this server publishes:
  *   - `D365FO_CROSS_MODEL_WRITE_MODELS=ModelA,ModelB` — allow these models,
  *   - `D365FO_ALLOW_CROSS_MODEL_WRITE=true`           — allow any model.
  *
@@ -40,6 +40,19 @@
  * And the refusal deliberately does NOT hand the caller a workaround: it names
  * the extension route, and says the alternative is the user's decision to make
  * in configuration.
+ *
+ * ## "The agent has no tool to write it" holds only for THIS server's tools
+ *
+ * The caller is a coding assistant with generic file editing, and the settings
+ * are plain JSON. One refusal was enough for it to find the host's mcp.json and
+ * add the allow-list key to the env block itself — writes into the other model
+ * then succeeded with a clean ✅, and the only trace was a console.error in a log
+ * truncated on every restart, including the one the settings edit triggers.
+ *
+ * The guard cannot tell which hand wrote its configuration. What it can do is
+ * refuse to be quiet: every path that lets a cross-model write through returns a
+ * note the caller prints on its result (standDownNotice), so it reaches the
+ * transcript rather than a log nobody opens.
  */
 
 import { resolveObjectPrefix, applyObjectPrefix } from './modelClassifier.js';
@@ -83,6 +96,73 @@ export interface CrossModelWriteCheck {
   existingExtensions?: ExistingExtension[];
   /** Wording only — what the caller was about to do. */
   action?: 'modify' | 'create';
+}
+
+/**
+ * A description of the cross-model allowance currently in force, or null.
+ *
+ * Surfaced by get_workspace_info so the state is visible without performing a
+ * write to discover it. An allowance nobody remembers granting is the dangerous
+ * kind — see the header.
+ */
+export function activeCrossModelAllowance(): string | null {
+  reloadWritePolicy();
+  const blanket = process.env.D365FO_ALLOW_CROSS_MODEL_WRITE?.trim().toLowerCase();
+  if (blanket === 'true' || blanket === '1' || blanket === 'yes') {
+    return 'D365FO_ALLOW_CROSS_MODEL_WRITE=true — writes into ANY model are allowed';
+  }
+  const models = (process.env.D365FO_CROSS_MODEL_WRITE_MODELS ?? '')
+    .split(',')
+    .map(m => m.trim())
+    .filter(Boolean);
+  return models.length > 0
+    ? `D365FO_CROSS_MODEL_WRITE_MODELS=${models.join(',')} — writes into ${models.length === 1 ? 'that model' : 'those models'} are allowed`
+    : null;
+}
+
+/**
+ * The note to print on a write the guard let through into ANOTHER model.
+ *
+ * Two paths reach a foreign model without a refusal, and both were silent:
+ *   • no anchor to compare against, so the guard stood down rather than block
+ *     on a guess;
+ *   • configuration allows this model — a decision someone made, and "someone"
+ *     is not necessarily the user (see the header).
+ * Either way the write lands in code this workspace only consumes, so it belongs
+ * in the reply, not only in a log a restart truncates.
+ *
+ * Returns '' for a write that stayed inside the active model, which is almost
+ * every write — callers can concatenate it unconditionally.
+ */
+export function standDownNotice(check: CrossModelWriteCheck): string {
+  const { objectName, owningModel, activeModel } = check;
+  const verb = check.action ?? 'modify';
+  if (!owningModel) return '';
+  if (activeModel && (eq(owningModel, activeModel) || eq(check.owningPackage, activeModel))) return '';
+
+  if (!activeModel) {
+    return (
+      `\n\n⚠️ **Cross-model guard did not run.** "${objectName}" was written into model ` +
+      `"${owningModel}", and this workspace's write anchor model could not be determined — so ` +
+      `nothing verified that "${owningModel}" is where you meant it to go. If it is not, undo this ` +
+      `and set the model explicitly (\`modelName\` in the server's config) before writing again.`
+    );
+  }
+
+  if (crossModelWriteAllowedByConfig(owningModel)) {
+    return (
+      `\n\n⚠️ **Cross-model write permitted by configuration.** "${objectName}" was ${verb === 'create' ? 'created' : 'modified'} ` +
+      `in model "${owningModel}", not in "${activeModel}" which this workspace targets. ` +
+      `D365FO_ALLOW_CROSS_MODEL_WRITE / D365FO_CROSS_MODEL_WRITE_MODELS is what allowed it. ` +
+      `The change will not appear in this workspace's project or version control, and every model ` +
+      `built on "${owningModel}" inherits it. If you did not intend to grant that, remove the ` +
+      `setting from the server's environment and undo this write.`
+    );
+  }
+
+  // A refusal was due and the caller ignored it — not this function's job to
+  // repeat it, but never report the write as ordinary either.
+  return '';
 }
 
 /** Base object type → the d365fo_file objectType used to extend it. */
@@ -158,7 +238,8 @@ export function crossModelWriteRefusal(check: CrossModelWriteCheck): string | nu
   const verb = check.action ?? 'modify';
 
   // Nothing to compare against — an unconfigured workspace or a path whose model
-  // segment could not be determined. Never block on a guess.
+  // segment could not be determined. Never block on a guess (but say so: see
+  // standDownNotice, which the caller prints on its result).
   if (!owningModel || !activeModel) return null;
   if (eq(owningModel, activeModel) || eq(check.owningPackage, activeModel)) return null;
   if (crossModelWriteAllowedByConfig(owningModel)) {

--- a/src/utils/phaseTimer.ts
+++ b/src/utils/phaseTimer.ts
@@ -1,0 +1,62 @@
+/**
+ * Phase timings for one write, reported in the write's own reply when it was
+ * slow.
+ *
+ * A tool call that takes 95 s to create an enum is a fact the transcript
+ * records and nobody can act on: the response says only that it succeeded, and
+ * the aggregate metrics cannot attribute one call. Naming the phases turns
+ * "the server is sometimes slow" into "the bridge call was 92 s of it".
+ *
+ * Silent below the threshold, so a normal write's reply is unchanged.
+ */
+
+const DEFAULT_THRESHOLD_MS = Number(process.env.SLOW_CALL_LOG_MS ?? 10_000);
+
+export interface PhaseTimer {
+  /** Run `fn`, recording how long it took under `name`. */
+  time<T>(name: string, fn: () => Promise<T>): Promise<T>;
+  /** Record a phase measured elsewhere. */
+  add(name: string, ms: number): void;
+  /** Total elapsed since the timer was created. */
+  totalMs(): number;
+  /** A `⏱️` block, or '' when the call was quick enough not to matter. */
+  render(thresholdMs?: number): string;
+}
+
+export function createPhaseTimer(): PhaseTimer {
+  const started = Date.now();
+  const phases: Array<{ name: string; ms: number }> = [];
+
+  return {
+    async time<T>(name: string, fn: () => Promise<T>): Promise<T> {
+      const t0 = Date.now();
+      try {
+        return await fn();
+      } finally {
+        phases.push({ name, ms: Date.now() - t0 });
+      }
+    },
+    add(name: string, ms: number): void {
+      phases.push({ name, ms });
+    },
+    totalMs(): number {
+      return Date.now() - started;
+    },
+    render(thresholdMs = DEFAULT_THRESHOLD_MS): string {
+      const measured = phases.reduce((sum, p) => sum + p.ms, 0);
+      // Phases recorded with add() may cover work that started before this
+      // timer, so the larger of the two decides.
+      const total = Math.max(Date.now() - started, measured);
+      if (total < thresholdMs) return '';
+
+      const shown = [...phases]
+        .filter(p => p.ms >= 100)
+        .sort((a, b) => b.ms - a.ms)
+        .map(p => `   ${(p.ms / 1000).toFixed(1)}s  ${p.name}`);
+      const rest = total - measured;
+      if (rest >= 100) shown.push(`   ${(rest / 1000).toFixed(1)}s  (unmeasured)`);
+
+      return `\n\n⏱️ This call took ${(total / 1000).toFixed(1)}s:\n${shown.join('\n')}`;
+    },
+  };
+}

--- a/src/utils/toolMetrics.ts
+++ b/src/utils/toolMetrics.ts
@@ -27,6 +27,44 @@ function getStats(toolName: string): ToolStats {
   return s;
 }
 
+/**
+ * Wall-clock past which a single tool call is logged individually, in ms.
+ *
+ * Aggregate stats answer "which tool is slow on average"; they cannot answer
+ * "what did the 306 seconds at 05:16 go on", which is the question an audit of a
+ * benchmark run actually asks. In run a5677c99 a `get_workspace_info` returning
+ * 855 characters took 306 s and a `d365fo_file(create)` took 180 s — a third of
+ * the run's wall clock — and the server kept no record of either, so the cause
+ * could not be attributed from the transcript afterwards. One line per slow call
+ * makes the next run diagnosable.
+ *
+ * The ⚠️ is load-bearing: console.error in src/index.ts suppresses messages that
+ * start with a "[module]" prefix unless they carry an error/warning marker.
+ */
+const SLOW_CALL_MS = Number(process.env.SLOW_CALL_LOG_MS ?? 10_000);
+
+/** Argument digest for a slow-call line — enough to identify the call, never the payload. */
+function digestArgs(args: unknown): string {
+  if (!args || typeof args !== 'object') return '';
+  const entries = Object.entries(args as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .slice(0, 6)
+    .map(([k, v]) => {
+      const s = typeof v === 'string' ? v : JSON.stringify(v);
+      const short = (s ?? '').length > 40 ? `${(s ?? '').slice(0, 40)}…` : s;
+      return `${k}=${short}`;
+    });
+  return entries.length > 0 ? ` {${entries.join(', ')}}` : '';
+}
+
+/** Log a single tool call that ran long enough to be worth attributing. */
+export function reportSlowCall(toolName: string, elapsedMs: number, args?: unknown): void {
+  if (elapsedMs < SLOW_CALL_MS) return;
+  console.error(
+    `[toolMetrics] ⚠️ slow call: ${toolName} took ${(elapsedMs / 1000).toFixed(1)}s${digestArgs(args)}`,
+  );
+}
+
 /** Call before dispatching a tool. Returns a finish() callback. */
 export function recordToolStart(toolName: string): (isEmpty: boolean) => void {
   const t0 = Date.now();

--- a/src/utils/toolMetrics.ts
+++ b/src/utils/toolMetrics.ts
@@ -30,16 +30,10 @@ function getStats(toolName: string): ToolStats {
 /**
  * Wall-clock past which a single tool call is logged individually, in ms.
  *
- * Aggregate stats answer "which tool is slow on average"; they cannot answer
- * "what did the 306 seconds at 05:16 go on", which is the question an audit of a
- * benchmark run actually asks. In run a5677c99 a `get_workspace_info` returning
- * 855 characters took 306 s and a `d365fo_file(create)` took 180 s — a third of
- * the run's wall clock — and the server kept no record of either, so the cause
- * could not be attributed from the transcript afterwards. One line per slow call
- * makes the next run diagnosable.
+ * The aggregate stats below cannot attribute one slow call after the fact.
  *
- * The ⚠️ is load-bearing: console.error in src/index.ts suppresses messages that
- * start with a "[module]" prefix unless they carry an error/warning marker.
+ * The ⚠️ is load-bearing: console.error in src/index.ts drops "[module]"-
+ * prefixed messages without an error/warning marker.
  */
 const SLOW_CALL_MS = Number(process.env.SLOW_CALL_LOG_MS ?? 10_000);
 

--- a/tests/bridge/extensionProviderRouting.test.ts
+++ b/tests/bridge/extensionProviderRouting.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Extension types must be resolved against their OWN provider collection.
+ *
+ * IMetadataProvider keys Tables/Forms by plain object names; a table or form
+ * extension is keyed by its dotted "Base.ModelExtension" name in
+ * TableExtensions/FormExtensions. Routing an extension through the base
+ * collection therefore always misses — a deterministic false negative that
+ * refreshing the provider cannot fix. It surfaced as a bogus "not found by
+ * IMetadataProvider after refresh" warning on every successful extension write.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { READ_SERVICE_CS, WRITE_SERVICE_CS, readStripped, methodBody } from './csharpSource';
+
+/** The `case "<label>":` block of a C# switch, up to the next `case`/`default`. */
+function caseBlock(body: string, label: string): string {
+  const start = body.indexOf(`case "${label}":`);
+  expect(start, `case "${label}:" not found`).toBeGreaterThan(-1);
+  const rest = body.slice(start + `case "${label}":`.length);
+  const end = rest.search(/\n\s*(case "|default:)/);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe('ValidateObject routes extensions to the extension providers', () => {
+  const body = methodBody(readStripped(READ_SERVICE_CS), 'public object? ValidateObject(');
+
+  it('reads table-extension from TableExtensions, never Tables', () => {
+    const block = caseBlock(body, 'table-extension');
+    expect(block).toContain('_provider.TableExtensions');
+    expect(block).not.toContain('_provider.Tables.');
+  });
+
+  it('reads form-extension from FormExtensions, never Forms', () => {
+    const block = caseBlock(body, 'form-extension');
+    expect(block).toContain('_provider.FormExtensions');
+    expect(block).not.toContain('_provider.Forms.');
+  });
+
+  it('does not let table-extension fall through the plain table case', () => {
+    // `case "table": case "table-extension":` sharing one body is the original bug.
+    expect(body).not.toMatch(/case "table":\s*case "table-extension":/);
+    expect(body).not.toMatch(/case "form":\s*case "form-extension":/);
+  });
+
+  it('still resolves the plain types against the base collections', () => {
+    expect(caseBlock(body, 'table')).toContain('_provider.Tables');
+    expect(caseBlock(body, 'form')).toContain('_provider.Forms');
+  });
+});
+
+describe('ResolveObjectInfo routes extensions to the extension providers', () => {
+  const body = methodBody(readStripped(READ_SERVICE_CS), 'public object? ResolveObjectInfo(');
+
+  it('probes table-extension via TableExtensions', () => {
+    const block = caseBlock(body, 'table-extension');
+    expect(block).toContain('TableExtensions');
+    expect(block).not.toContain('p.Tables.');
+  });
+
+  it('probes form-extension via FormExtensions', () => {
+    const block = caseBlock(body, 'form-extension');
+    expect(block).toContain('FormExtensions');
+    expect(block).not.toContain('p.Forms.');
+  });
+
+  it('does not share a body between a base type and its extension', () => {
+    expect(body).not.toMatch(/case "table":\s*case "table-extension":/);
+    expect(body).not.toMatch(/case "form":\s*case "form-extension":/);
+  });
+});
+
+describe('AddControl refuses form extensions instead of misreporting them', () => {
+  const body = methodBody(readStripped(WRITE_SERVICE_CS), 'public object AddControl(');
+
+  it('rejects a dotted name before the Forms lookup can miss', () => {
+    const guard = body.indexOf("formName.Contains('.')");
+    const lookup = body.indexOf('_provider.Forms.Read(formName)');
+    expect(guard, 'no dotted-name guard in AddControl').toBeGreaterThan(-1);
+    expect(lookup).toBeGreaterThan(guard);
+  });
+
+  it('says the name is a form extension rather than that the form is missing', () => {
+    expect(body).toContain('is a form extension');
+  });
+});

--- a/tests/metadata/searchCustomExtensions.test.ts
+++ b/tests/metadata/searchCustomExtensions.test.ts
@@ -1,0 +1,127 @@
+/**
+ * search(scope="extensions") — model scoping, index plan, and the type filter.
+ *
+ * Run 6639b2df spent 122.8 s in one such call. The query was
+ * `name LIKE '%validateWrite%'` over the whole symbols table with no model predicate:
+ * unindexable by construction, so every call scanned all 1.19 M rows. It also mislabelled
+ * its output — Microsoft rows satisfying the `*Extension` name convention were reported
+ * under "matches in custom extensions" — and answered as if no `type` filter had been
+ * passed, because the tool schema dropped it before it reached the index.
+ *
+ * These tests pin the three properties that fix depends on:
+ *   1. `model IN (custom models)` drives the query, so the plan is a seek not a scan;
+ *   2. standard-model rows never appear, whatever their name;
+ *   3. `types` filters without costing the index — the unary + in `+type IN (...)` is
+ *      load-bearing, since ~1 M of 1.19 M production rows are methods and the planner
+ *      will happily prefer idx_type_name and re-scan almost the whole table.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+let index: XppSymbolIndex;
+let previousCustomModels: string | undefined;
+
+const sym = (name: string, type: string, model: string, parentName?: string) =>
+  index.addSymbol({ name, type, parentName, filePath: `/${model}/${name}.xml`, model } as any);
+
+beforeAll(() => {
+  previousCustomModels = process.env.CUSTOM_MODELS;
+  process.env.CUSTOM_MODELS = 'CustomFin,CustomReg';
+
+  index = new XppSymbolIndex(':memory:', ':memory:');
+
+  // Custom extension objects and their members.
+  sym('CustTableCustomFin_Extension', 'class-extension', 'CustomFin');
+  sym('validateWrite', 'method', 'CustomFin', 'CustTableCustomFin_Extension');
+  sym('CustTable.CustomFinExtension', 'table-extension', 'CustomFin');
+  sym('validateWrite', 'method', 'CustomReg', 'VendTableCustomReg_Extension');
+  sym('VendTableCustomReg_Extension', 'class-extension', 'CustomReg');
+
+  // A plain custom class: right model, but not extension-shaped.
+  sym('CustomFinHelper', 'class', 'CustomFin');
+  sym('validateWrite', 'method', 'CustomFin', 'CustomFinHelper');
+
+  // A literal-underscore name and a no-underscore one, both in scope. Only the first
+  // contains the literal text "e_Extension"; both match the LIKE pattern '%e_Extension%'
+  // when '_' is left as a wildcard.
+  sym('AslTable_Extension', 'class-extension', 'CustomFin');
+  sym('AslTableXExtension', 'class-extension', 'CustomFin');
+
+  // Microsoft rows. `validateWriteExtension` is the exact shape that leaked into the
+  // production run's results: a method whose own name ends in "Extension".
+  sym('validateWriteExtension', 'method', 'ApplicationSuite', 'CatCartLine');
+  sym('CustTableApp_Extension', 'class-extension', 'ApplicationSuite');
+});
+
+afterAll(() => {
+  index.close();
+  if (previousCustomModels === undefined) delete process.env.CUSTOM_MODELS;
+  else process.env.CUSTOM_MODELS = previousCustomModels;
+});
+
+const names = (rows: Array<{ name: string; model?: string }>) =>
+  rows.map(r => `${r.model}:${r.name}`).sort();
+
+describe('searchCustomExtensions', () => {
+  it('finds members of custom extensions and excludes standard models', () => {
+    const hits = index.searchCustomExtensions('validateWrite');
+
+    expect(names(hits as any)).toEqual([
+      'CustomFin:validateWrite',
+      'CustomReg:validateWrite',
+    ]);
+    // The Microsoft row is the regression: it used to be returned, captioned as custom.
+    expect(hits.some(h => h.name === 'validateWriteExtension')).toBe(false);
+    // A method on a non-extension custom class is in a custom model but not in an
+    // extension — the scope is "extensions", not "everything custom".
+    expect(hits.every(h => h.parentName?.includes('_Extension'))).toBe(true);
+  });
+
+  it('honours the type filter without losing the model index', () => {
+    expect(index.searchCustomExtensions('CustTable', undefined, 20, ['class-extension'])
+      .map(h => h.name)).toEqual(['CustTableCustomFin_Extension']);
+
+    // Same query, wrong type → empty, rather than the unfiltered answer the dropped
+    // argument used to produce.
+    expect(index.searchCustomExtensions('CustTable', undefined, 20, ['method'])).toEqual([]);
+  });
+
+  it('narrows by model prefix', () => {
+    expect(index.searchCustomExtensions('validateWrite', 'CustomReg').map(h => h.model))
+      .toEqual(['CustomReg']);
+    expect(index.searchCustomExtensions('validateWrite', 'Nope')).toEqual([]);
+  });
+
+  it('seeks on idx_symbols_model, with and without a type filter', () => {
+    // The plan IS the assertion: "SCAN symbols" means every extension search re-reads
+    // the whole table, which is what cost 122.8 s in production.
+    const planOf = (sql: string, params: any[]) =>
+      (index.db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params) as Array<{ detail: string }>)
+        .map(r => r.detail)
+        .join('\n');
+
+    const base = `
+      SELECT * FROM symbols
+      WHERE model IN (?, ?)
+        AND name LIKE ? ESCAPE '\\'
+        AND (name LIKE '%\\_Extension' ESCAPE '\\' OR parent_name LIKE '%\\_Extension' ESCAPE '\\')`;
+
+    const withoutType = planOf(`${base} ORDER BY name LIMIT ?`,
+      ['CustomFin', 'CustomReg', '%validateWrite%', 20]);
+    expect(withoutType).toContain('idx_symbols_model');
+    expect(withoutType).not.toMatch(/^SCAN symbols/m);
+
+    const withType = planOf(`${base} AND +type IN (?) ORDER BY name LIMIT ?`,
+      ['CustomFin', 'CustomReg', '%validateWrite%', 'method', 20]);
+    expect(withType).toContain('idx_symbols_model');
+    expect(withType).not.toMatch(/^SCAN symbols/m);
+  });
+
+  it('escapes LIKE metacharacters in the query', () => {
+    // Unescaped, '_' is a single-character wildcard: '%e_Extension%' also matches
+    // AslTableXExtension. Only AslTable_Extension contains the text the caller typed.
+    expect(index.searchCustomExtensions('e_Extension').map(h => h.name))
+      .toEqual(['AslTable_Extension']);
+  });
+});

--- a/tests/tools/buildDiagnostics.test.ts
+++ b/tests/tools/buildDiagnostics.test.ts
@@ -119,8 +119,8 @@ final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
         if (ret && this.AslFinSK_QualityTier < this.orig().AslFinSK_QualityTier)
         {
             ret = checkFailed(strFmt("@AslFinSK:QualityTierDowngradeNotAllowed",
-                enum2str(this.orig().AslFinSK_QualityTier),
-                enum2str(this.AslFinSK_QualityTier)));
+                enum2Symbol(enumNum(AslFinSK_QualityTier), enum2int(this.orig().AslFinSK_QualityTier)),
+                enum2Symbol(enumNum(AslFinSK_QualityTier), enum2int(this.AslFinSK_QualityTier))));
         }
 
         return ret;
@@ -131,16 +131,25 @@ final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
     expect(found.map(v => v.line)).toEqual([11, 12]);
   });
 
-  it('still flags the single-line form', () => {
-    expect(bp005('info(strFmt("@X:Y", enum2str(tier)));')).toHaveLength(1);
+  it('still flags the single-line form, and the DictEnum method too', () => {
+    expect(bp005('info(strFmt("@X:Y", enum2Symbol(enumNum(Tier), i)));')).toHaveLength(1);
+    expect(bp005('info(strFmt("@X:Y", dictEnum.value2Symbol(i)));')).toHaveLength(1);
   });
 
-  it('leaves enum2str outside a message alone', () => {
-    expect(bp005('str key = enum2str(this.Tier);')).toHaveLength(0);
-    expect(bp005('fileName = enum2str(tier) + ".txt";')).toHaveLength(0);
+  it('leaves a symbol outside a message alone', () => {
+    // The symbol is the ONLY safe thing to persist for an extensible enum.
+    expect(bp005('str key = enum2Symbol(enumNum(Tier), i);')).toHaveLength(0);
+    expect(bp005('fileName = dictEnum.value2Symbol(i) + ".txt";')).toHaveLength(0);
+  });
+
+  it('leaves enum2str in a message alone — it resolves the label', () => {
+    // The rule used to flag exactly this and send callers to DictEnum instead.
+    // Microsoft ships enum2str inside checkFailed, throw error and control captions.
+    expect(bp005('info(strFmt("@X:Y", enum2str(tier)));')).toHaveLength(0);
+    expect(bp005('ret = checkFailed(strFmt("@X:Y", enum2str(a), enum2str(b)));')).toHaveLength(0);
   });
 
   it('ignores it inside a comment', () => {
-    expect(bp005('// info(strFmt("@X:Y", enum2str(tier)));')).toHaveLength(0);
+    expect(bp005('// info(strFmt("@X:Y", enum2Symbol(enumNum(Tier), i)));')).toHaveLength(0);
   });
 });

--- a/tests/tools/buildDiagnostics.test.ts
+++ b/tests/tools/buildDiagnostics.test.ts
@@ -1,15 +1,9 @@
 /**
- * Benchmark run 9180a464 (10.8. 06:19) — the run that deleted its own deliverable.
- *
- * What happened, in order: a full build returned exit-failure; the log parser
- * recognised none of the lines in it, so the tool printed "❌ Build FAILED" over
- * "📋 Structured diagnostics: 0 error(s), 1 warning(s)", the warning being an
- * unrelated `Server`-keyword deprecation on another model's class. Given a
- * failure with no cause, the agent guessed one ("duplicate control name"), spent
- * 178 s + 54 s + 12 s scanning PackagesLocalDirectory from PowerShell, then
- * called undo_last_modification on the form extension it had just created and
- * hand-edited the .rnrproj to drop the entry. The next build passed, which made
- * the deletion look like a fix.
+ * A build failed, the parser recognised none of its diagnostics, and the tool
+ * printed "❌ Build FAILED" over "0 error(s), 1 warning(s)" — the warning
+ * unrelated. With no stated cause the caller guessed one, then deleted the form
+ * extension it had been asked to create; the next build passed, which made the
+ * deletion look like a fix.
  *
  * Two smaller defects from the same run are pinned here as well.
  */
@@ -23,10 +17,7 @@ import {
 } from '../../src/tools/sdlc/buildProject';
 import { runRules } from '../../src/tools/analysis/validateXpp';
 
-/**
- * Verbatim shapes from K:\…\Temp\d365build_log_6f131599b2.log. Only the first
- * of these five was recognised by the old parser.
- */
+/** Real xppc log shapes. Only the first of these five used to be recognised. */
 const LOG = `AslFinanceSK compilation completed.
 Elapsed time: 00:00:21
 
@@ -95,7 +86,7 @@ describe('a failure this parser cannot explain must say so', () => {
   });
 
   it('warns that listed warnings are not the failure', () => {
-    // The exact trap of run 9180a464: FAILED, plus one unrelated warning.
+    // The trap: FAILED, plus one unrelated warning.
     const onlyWarning = parseXppcDiagnostics(
       "Compile Warning: Class Method dynamics://Class/X/Method/y: [(7,5)]: The 'Server' keyword has been deprecated.\n",
     );
@@ -117,8 +108,7 @@ describe('a failure this parser cannot explain must say so', () => {
 describe('BP005 spans the whole call, not one line', () => {
   const bp005 = (code: string) => runRules(code, 'xpp').filter(v => v.rule === 'BP005');
 
-  it('flags the wrapped strFmt the run was told was clean', () => {
-    // Verbatim from validate_code call #56, which answered "no violations found".
+  it('flags a wrapped strFmt that a per-line scan reported clean', () => {
     const code = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
 final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
 {

--- a/tests/tools/cocNextUnconditional.test.ts
+++ b/tests/tools/cocNextUnconditional.test.ts
@@ -120,7 +120,24 @@ describe('COC004 — next must be unconditional', () => {
     expect(rules(code)).toEqual([]);
   });
 
-  it('flags enum2str in the downgrade message the run shipped (BP005)', () => {
+  it('flags an untranslated enum SYMBOL in the downgrade message (BP005)', () => {
+    const code = coc(`    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        if (!ret)
+        {
+            ret = checkFailed(strFmt("@AslFinSK:Downgrade", enum2Symbol(enumNum(AslFinSK_QualityTier), enum2int(this.orig().AslFinSK_QualityTier))));
+        }
+        return ret;
+    }`);
+
+    const bp005 = runRules(code, 'xpp').filter(v => v.rule === 'BP005');
+    expect(bp005).toHaveLength(1);
+    expect(bp005[0].fix).toContain('enum2str(value)');
+  });
+
+  // This rule used to reject it and send the caller to the reflective DictEnum form.
+  it('leaves enum2str in the downgrade message alone', () => {
     const code = coc(`    public boolean validateWrite()
     {
         boolean ret = next validateWrite();
@@ -131,16 +148,14 @@ describe('COC004 — next must be unconditional', () => {
         return ret;
     }`);
 
-    const bp005 = runRules(code, 'xpp').filter(v => v.rule === 'BP005');
-    expect(bp005).toHaveLength(1);
-    expect(bp005[0].fix).toContain('value2Label');
+    expect(runRules(code, 'xpp').filter(v => v.rule === 'BP005')).toEqual([]);
   });
 
-  it('leaves enum2str alone outside a user-facing message', () => {
+  it('leaves a symbol alone outside a user-facing message', () => {
     const code = coc(`    public boolean validateWrite()
     {
         boolean ret = next validateWrite();
-        str key = enum2str(this.AslFinSK_QualityTier);
+        str key = enum2Symbol(enumNum(AslFinSK_QualityTier), enum2int(this.AslFinSK_QualityTier));
         return ret;
     }`);
 

--- a/tests/tools/createEnumWriterRouting.test.ts
+++ b/tests/tools/createEnumWriterRouting.test.ts
@@ -169,25 +169,67 @@ describe('enum create — which writer runs', () => {
     for (const v of POSITIONAL) expect(xml).toContain(`<Name>${v.name}</Name>`);
   });
 
-  it('leaves an unnumbered enum on the bridge', async () => {
-    // Nothing to suppress, so the exception does not apply and the normal
-    // bridge-first path stands.
-    await handleCreateD365File(
-      req({ enumValues: [{ name: 'None' }, { name: 'Silver' }] }, 'ConDemoTierPlain'),
+  it('routes an UNNUMBERED list to the generator too, and writes UseEnumValue', async () => {
+    // The shape that used to stay on the bridge, and the one it cannot survive:
+    // with no `useEnumValue` scalar the bridge emits no <UseEnumValue> at all,
+    // xppc reads the absent element as Yes, and every member without an explicit
+    // <Value> is 0 — "Duplicate value '0' detected", on the full build only.
+    // Positions decide here, so the file must carry UseEnumValue=No and no <Value>.
+    const result = await handleCreateD365File(
+      req({ enumValues: [{ name: 'None' }, { name: 'Silver' }, { name: 'Gold' }] }, 'ConDemoTierPlain'),
       buildContext(),
     );
 
-    expect(createObject).toHaveBeenCalledTimes(1);
+    expect(createObject).not.toHaveBeenCalled();
+    const xml = [...files.values()].join('\n');
+    expect(result.content[0].text).toContain('Successfully created');
+    expect(xml).toContain('<UseEnumValue>No</UseEnumValue>');
+    expect(xml).not.toContain('<Value>');
+    for (const n of ['None', 'Silver', 'Gold']) expect(xml).toContain(`<Name>${n}</Name>`);
   });
 
-  it('passes the aliased list to the bridge as well, when the bridge is the writer', async () => {
-    await handleCreateD365File(
+  it('writes every value of an unnumbered list spelled `values`', async () => {
+    const result = await handleCreateD365File(
       req({ values: [{ name: 'None' }, { name: 'Silver' }] }, 'ConDemoTierPlainAlias'),
       buildContext(),
     );
 
+    expect(createObject).not.toHaveBeenCalled();
+    const xml = [...files.values()].join('\n');
+    expect(result.content[0].text).toContain('Successfully created');
+    expect(xml).not.toContain('<EnumValues />');
+    expect(xml).toContain('<UseEnumValue>No</UseEnumValue>');
+    for (const n of ['None', 'Silver']) expect(xml).toContain(`<Name>${n}</Name>`);
+  });
+
+  it('leaves an enum with NO values on the bridge — the one shape it cannot get wrong', async () => {
+    await handleCreateD365File(req({ label: '@SYS1' }, 'ConDemoTierEmpty'), buildContext());
+
     expect(createObject).toHaveBeenCalledTimes(1);
-    const params = createObject.mock.calls[0][0] as any;
-    expect(params.values).toHaveLength(2);
+  });
+});
+
+/** IsExtensible=Yes and ranking the values are mutually exclusive, and only the build says so. */
+describe('enum create — extensibility vs ordering', () => {
+  it('warns that an extensible enum can only be compared for equality', async () => {
+    const result = await handleCreateD365File(
+      req({ isExtensible: true, enumValues: POSITIONAL }, 'ConDemoTierExt'),
+      buildContext(),
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('Successfully created');
+    expect(text).toContain('IsExtensible=true');
+    expect(text).toMatch(/non-equality comparison/i);
+    // Names the way out while it is still cheap — before any code references it.
+    expect(text).toContain('isExtensible=false');
+  });
+
+  it('says nothing for a non-extensible enum', async () => {
+    const result = await handleCreateD365File(
+      req({ enumValues: POSITIONAL }, 'ConDemoTierQuiet'),
+      buildContext(),
+    );
+    expect(result.content[0].text).not.toMatch(/non-equality comparison/i);
   });
 });

--- a/tests/tools/createLabelIncrementalFts.test.ts
+++ b/tests/tools/createLabelIncrementalFts.test.ts
@@ -1,0 +1,92 @@
+/**
+ * create_label must not re-tokenise the whole labels index.
+ *
+ * Run 6639b2df spent 211 s of a 733 s run inside `rebuildLabelsFts()`. create_label wrote
+ * its rows with the FTS triggers dropped and then scheduled a debounced full rebuild —
+ * `delete-all` plus a re-INSERT of every row of the 1.2 GB labels DB — for the two labels
+ * it had just added. node:sqlite is synchronous, so the server answered no tool call at all
+ * for ~105 s after each create_label; the MCP client saw the stall attributed to whatever
+ * call came next, and the server's own slow-call metric never fired because the time was
+ * spent outside any handler.
+ *
+ * The contract this pins: after a label write the new rows are reachable through
+ * labels_fts (so nothing is traded away for the speed), and no full rebuild is scheduled.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+
+let index: XppSymbolIndex;
+
+beforeEach(() => {
+  index = new XppSymbolIndex(':memory:', ':memory:');
+});
+
+afterEach(() => index.close());
+
+const entry = (labelId: string, text: string, language = 'en-US') => ({
+  labelId,
+  labelFileId: 'AslFinSK',
+  model: 'AslFinanceSK',
+  language,
+  text,
+  filePath: `K:/pkg/AslFinanceSK/AslFinSK.${language}.label.txt`,
+});
+
+/** Only a MATCH query is answered from the index — labels_fts is external-content. */
+const ftsHits = (term: string): string[] =>
+  index.labelsDb
+    .prepare(
+      `SELECT l.label_id FROM labels_fts f JOIN labels l ON l.id = f.rowid
+       WHERE labels_fts MATCH ? ORDER BY l.label_id`,
+    )
+    .all(term)
+    .map((r: any) => r.label_id);
+
+describe('create_label label indexing', () => {
+  it('indexes new labels through the triggers, with no rebuild scheduled', () => {
+    // Seed, so the "rebuild everything" path would have observable work to do.
+    index.bulkAddLabels([entry('Existing', 'Photosynthesis')], {
+      skipFtsRebuild: true,
+      keepTriggers: true,
+    });
+
+    // Exactly the call create_label makes.
+    index.bulkAddLabels(
+      [
+        entry('QualityTier', 'Quality tier'),
+        entry('QualityTierDowngradeNotAllowed', 'The quality tier cannot be decreased.'),
+        entry('QualityTier', 'Úroveň kvality', 'cs'),
+      ],
+      { skipFtsRebuild: true, keepTriggers: true },
+    );
+
+    expect(ftsHits('tier')).toEqual(['QualityTier', 'QualityTierDowngradeNotAllowed']);
+    expect(ftsHits('kvality')).toEqual(['QualityTier']);
+    expect(ftsHits('Photosynthesis')).toEqual(['Existing']);
+
+    // No debounced full rebuild is pending: close() flushes one if it is, and the index
+    // must already be complete without that flush.
+    expect((index as any)._labelsFtsTimer).toBeNull();
+  });
+
+  it('matches what a full rebuild would have produced', () => {
+    index.bulkAddLabels([entry('First', 'Original text')], {
+      skipFtsRebuild: true,
+      keepTriggers: true,
+    });
+    // INSERT OR REPLACE on the same key: the displaced row must leave the index too,
+    // or the old text stays findable forever.
+    index.bulkAddLabels([entry('First', 'Replacement text')], {
+      skipFtsRebuild: true,
+      keepTriggers: true,
+    });
+
+    const terms = ['Original', 'Replacement', 'text'];
+    const incremental = terms.map(ftsHits);
+    expect(incremental[0]).toEqual([]);
+
+    index.rebuildLabelsFts();
+    expect(terms.map(ftsHits)).toEqual(incremental);
+  });
+});

--- a/tests/tools/discovery.test.ts
+++ b/tests/tools/discovery.test.ts
@@ -181,10 +181,29 @@ describe('search_extensions', () => {
 
   it('returns no-results message when nothing found', async () => {
     (ctx.symbolIndex.searchCustomExtensions as any).mockReturnValue([]);
-    (ctx.symbolIndex.getCustomModels as any).mockReturnValue([]);
+    (ctx.symbolIndex.getCustomModels as any).mockReturnValue(['ISVModel']);
     const result = await extensionSearchTool(req('search_extensions', { query: 'Unknown' }), ctx);
     expect(result.isError).toBeFalsy();
     expect(result.content[0].text).toMatch(/no.*found|0 match|no extension/i);
+  });
+
+  // The scope is defined by the custom-model list, so an empty list is not an empty
+  // result — it means the search could never have matched anything.
+  it('names the configuration fault when no custom models are known', async () => {
+    (ctx.symbolIndex.searchCustomExtensions as any).mockReturnValue([]);
+    (ctx.symbolIndex.getCustomModels as any).mockReturnValue([]);
+    const result = await extensionSearchTool(req('search_extensions', { query: 'Unknown' }), ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('CUSTOM_MODELS');
+  });
+
+  it('forwards the type filter to the index', async () => {
+    (ctx.symbolIndex.searchCustomExtensions as any).mockReturnValue([]);
+    (ctx.symbolIndex.getCustomModels as any).mockReturnValue(['ISVModel']);
+    await extensionSearchTool(
+      req('search_extensions', { query: 'validateWrite', type: 'method' }), ctx);
+    expect(ctx.symbolIndex.searchCustomExtensions).toHaveBeenCalledWith(
+      'validateWrite', undefined, 20, ['method']);
   });
 
   it('returns error on missing query', async () => {

--- a/tests/tools/fieldGroupRenderHint.test.ts
+++ b/tests/tools/fieldGroupRenderHint.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The proactive half of the DataGroup guard.
+ *
+ * A container carrying <DataGroup> is filled by the compiler from that table
+ * field group, so a field added to the group is already on the form. The
+ * add-control guard says the same, but only once a form extension exists and a
+ * control is being added to it — a create that then has to be undone.
+ *
+ * Said at add-field-to-field-group time it costs one indexed lookup. These pin
+ * both that it fires and that it stays quiet on every ambiguous case.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockReadFile } = vi.hoisted(() => ({ mockReadFile: vi.fn() }));
+
+vi.mock('fs/promises', () => ({
+  default: { readFile: mockReadFile },
+  readFile: mockReadFile,
+}));
+
+import { describeFieldGroupRendering } from '../../src/tools/write/modifyD365File';
+
+const FORM_PATH = 'K:\\Packages\\AslFinanceCore\\AslFinanceCore\\AxForm\\TaxLog.xml';
+
+/** SimpleList shape: Grid > Group[DataGroup=Modified], plus one unbound group. */
+const FORM_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>TaxLog</Name>
+  <Design>
+    <Controls>
+      <AxFormControl xmlns="" i:type="AxFormGridControl">
+        <Name>Grid</Name>
+        <Type>Grid</Type>
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormGroupControl">
+            <Name>Modified</Name>
+            <Type>Group</Type>
+            <Controls />
+            <DataGroup>Modified</DataGroup>
+            <DataSource>TaxLog</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormGroupControl">
+            <Name>Freeform</Name>
+            <Type>Group</Type>
+            <Controls />
+          </AxFormControl>
+        </Controls>
+        <DataSource>TaxLog</DataSource>
+      </AxFormControl>
+    </Controls>
+  </Design>
+</AxForm>`;
+
+/**
+ * Fake read DB serving the two queries the probe makes: the form_datasources
+ * lookup by table, and findBaseObjectXml's file_path lookup by name.
+ */
+const indexWith = (rows: Array<{ form_name: string; datasource_name: string }>) => ({
+  getReadDb: () => ({
+    prepare: (sql: string) => ({
+      all: () => (/form_datasources/.test(sql) ? rows : []),
+      get: () => (/FROM symbols/.test(sql) ? { file_path: FORM_PATH } : undefined),
+    }),
+  }),
+});
+
+const ON_TAX_LOG = [{ form_name: 'TaxLog', datasource_name: 'TaxLog' }];
+
+describe('add-field-to-field-group names the form the group already renders on', () => {
+  beforeEach(() => {
+    mockReadFile.mockReset();
+    mockReadFile.mockResolvedValue(FORM_XML);
+  });
+
+  it('names the form, the control and the control the compiler will generate', async () => {
+    const note = await describeFieldGroupRendering(
+      'TaxLog', 'Modified', 'AslFinSK_QualityTier', indexWith(ON_TAX_LOG),
+    );
+
+    expect(note).toContain('TaxLog');
+    expect(note).toContain('Modified');
+    expect(note).toContain('Modified_AslFinSK_QualityTier');
+    expect(note).toContain('already on the form');
+    // The whole point: do not build the thing that then has to be undone.
+    expect(note).toMatch(/form extension/i);
+  });
+
+  it('says nothing for a field group no control renders', async () => {
+    expect(await describeFieldGroupRendering(
+      'TaxLog', 'Identification', 'AslFinSK_QualityTier', indexWith(ON_TAX_LOG),
+    )).toBe('');
+  });
+
+  it('says nothing when no form uses the table', async () => {
+    expect(await describeFieldGroupRendering(
+      'TaxLog', 'Modified', 'AslFinSK_QualityTier', indexWith([]),
+    )).toBe('');
+  });
+
+  it('ignores a container bound to a different datasource', async () => {
+    // Same group name on another table's datasource renders another table's
+    // fields — claiming it would send the agent after the wrong form.
+    const note = await describeFieldGroupRendering(
+      'TaxLog', 'Modified', 'AslFinSK_QualityTier',
+      indexWith([{ form_name: 'TaxLog', datasource_name: 'SomeOtherTable' }]),
+    );
+    expect(note).toBe('');
+  });
+
+  it('says nothing when the form XML cannot be read', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    expect(await describeFieldGroupRendering(
+      'TaxLog', 'Modified', 'AslFinSK_QualityTier', indexWith(ON_TAX_LOG),
+    )).toBe('');
+  });
+
+  it('survives an index that cannot answer at all', async () => {
+    const broken = { getReadDb: () => { throw new Error('no index'); } };
+    expect(await describeFieldGroupRendering('TaxLog', 'Modified', 'F', broken)).toBe('');
+    expect(await describeFieldGroupRendering('TaxLog', 'Modified', 'F', undefined)).toBe('');
+  });
+});

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -1808,10 +1808,10 @@ describe('modify_d365fo_file', () => {
     expect(writtenContent).toContain('<MenuItemType>Display</MenuItemType>');
   });
 
-  it('add-control on a form-extension falls back to XML when the bridge fails (extension never resolves as a form)', async () => {
-    // Root cause: the C# bridge's AddControl reads _provider.Forms.Read(name), which
-    // can never resolve a form EXTENSION ("Base.Suffix") — it always reports
-    // 'Form "<ext>" not found'. The XML fallback must write the control element.
+  it('add-control on a form-extension bypasses the bridge and writes the XML directly', async () => {
+    // The C# AddControl reads _provider.Forms.Read(name), which never resolves a form
+    // EXTENSION ("Base.Suffix") — those live in FormExtensions. The call cannot succeed,
+    // so it is not made at all and the XML writer produces the control element.
     const fsMod = await import('fs/promises');
     const extXml =
       `<?xml version="1.0" encoding="utf-8"?>\n` +
@@ -1846,8 +1846,8 @@ describe('modify_d365fo_file', () => {
     );
 
     expect(result.isError).toBeFalsy();
-    // Bridge was attempted first (and failed), XML fallback wrote the file.
-    expect(addControl).toHaveBeenCalledTimes(1);
+    // Not attempted: a doomed bridge call costs a round trip and logs a bridge error.
+    expect(addControl).not.toHaveBeenCalled();
     const written = (fsMod.writeFile as any).mock.calls.find((c: any[]) =>
       String(c[0]).includes('ContosoRentConfiguration.MyExt.xml'),
     );
@@ -1940,8 +1940,8 @@ describe('modify_d365fo_file', () => {
     );
 
     expect(result.isError).toBeFalsy();
-    // The bridge attempt itself must also have received the inferred type, not "String".
-    expect(addControl.mock.calls[0][3]).toBe('Real');
+    // Inference must reach the writer: the emitted element carries Real, not String.
+    expect(addControl).not.toHaveBeenCalled();
     const written = (fsMod.writeFile as any).mock.calls.find((c: any[]) =>
       String(c[0]).includes('RentAgreementForm.MyExt.xml'),
     );

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -236,7 +236,15 @@ describe('labels(action="search") with query[]', () => {
     }
   });
 
-  it('reports a reusable hit instead of telling the caller to create one', async () => {
+  // The verdict used to read "at least one reusable label was found", and run
+  // a5677c99 believed it: the best hit behind that sentence was @SYS321832 "The
+  // decreased margin cannot be greater than the current margin amount of letter of
+  // guarantee", and the agent spent two more searches looking for the label the
+  // verdict had promised. A hit means the model can RESOLVE the label, never that
+  // it says what the caller needs — so the verdict now reports a candidate, tells
+  // the caller to read the text, and carries the create call so that rejecting all
+  // of them costs no further round trip.
+  it('reports a hit as a candidate, and still hands over the create call', async () => {
     (ctx.symbolIndex.searchLabels as any).mockReturnValue([
       makeLabelResult({ labelId: 'CustomerName', text: 'Customer name', labelFileId: 'MyModel', model: 'MyModel' }),
     ]);
@@ -246,8 +254,12 @@ describe('labels(action="search") with query[]', () => {
       ctx,
     )).content[0].text as string;
 
-    expect(text).toMatch(/at least one reusable label was found/i);
-    expect(text).not.toContain('Stop searching and create your own.');
+    expect(text).toMatch(/at least one label this model can resolve came back/i);
+    expect(text).toMatch(/a hit is a candidate, not a verdict/i);
+    // Never the flat "nothing was found" verdict — something WAS found.
+    expect(text).not.toMatch(/none of these \d+ phrasings/i);
+    // …but the fallback is right there, so "none of these fit" needs no new call.
+    expect(text).toContain('labels(action="create"');
   });
 
   it('caps the batch and says what it did not run', async () => {

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -10,8 +10,13 @@ import { createLabelTool } from '../../src/tools/write/createLabel';
 import { renameLabelTool } from '../../src/tools/write/renameLabel';
 import { labelsTool, mapWithConcurrency } from '../../src/tools/labels';
 import { isExtensionLabelFile } from '../../src/metadata/labelParser';
+import { resetLabelSearchHistory } from '../../src/tools/analysis/labelSearchHistory';
 import type { XppServerContext } from '../../src/types/context';
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+// The search history is module state that deliberately outlives one call — reset
+// it per test so one suite's phrasings never become another's "you already asked".
+beforeEach(() => { resetLabelSearchHistory(); });
 
 // Mock filesystem access — label tools write to disk
 vi.mock('fs', async (orig) => {
@@ -230,10 +235,16 @@ describe('labels(action="search") with query[]', () => {
     expect(text).toContain('3 queries');
     expect(text).toMatch(/none of these 3 phrasings/i);
     expect(text).toContain('Stop searching and create your own.');
-    // Each query still gets its own section.
+    // Every phrasing is still named, but a miss carries no information beyond
+    // its own name: three full "create your own label" sections were three
+    // copies of one paragraph. They collapse into one line.
+    expect(text).toContain('No match — 3 phrasing(s)');
     for (const q of ['cannot be decreased', 'downgrade', 'value is lower']) {
-      expect(text).toContain(`## "${q}"`);
+      expect(text).toContain(`"${q}"`);
+      expect(text).not.toContain(`## "${q}"`);
     }
+    // The advice survives — once.
+    expect(text.match(/Nothing reusable here/g) ?? []).toHaveLength(1);
   });
 
   // "At least one reusable label was found" promised more than a hit means: the
@@ -286,8 +297,52 @@ describe('labels(action="search") with query[]', () => {
     expect((ctx.symbolIndex.searchLabels as any).mock.calls.length).toBe(2);
     expect(text).toContain('2 duplicate phrasing(s) folded');
     // The caller's own first spelling is what reads back.
-    expect(text).toContain('## "customer"');
-    expect(text).not.toContain('## "Customer"');
+    expect(text).toContain('"customer"');
+    expect(text).not.toContain('"Customer"');
+  });
+
+  // Run f7130bea: six batches of phrasings, ~23 AIU, plus two raw reads of the
+  // .label.txt files — and the answer was settled by the first batch. Every result
+  // already said "rephrasing does not help"; advice stated in the abstract is easy
+  // to argue with, the same advice listing what you already asked is not.
+  it('says nothing about repetition on the first miss', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    const text = (await labelsTool(
+      req('labels', { action: 'search', query: ['cannot be decreased', 'downgrade'] }),
+      ctx,
+    )).content[0].text as string;
+
+    expect(text).not.toContain('This is not new information');
+  });
+
+  it('names the earlier phrasings when the caller comes back to rephrase', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+
+    await labelsTool(req('labels', { action: 'search', query: ['cannot be decreased', 'downgrade'] }), ctx);
+    const text = (await labelsTool(
+      req('labels', { action: 'search', query: ['value must not drop'] }),
+      ctx,
+    )).content[0].text as string;
+
+    expect(text).toContain('This is not new information');
+    expect(text).toContain('2 phrasing(s) already came back empty');
+    expect(text).toContain('"cannot be decreased"');
+    // Its own phrasings are the current answer, not evidence of repetition.
+    expect(text).not.toMatch(/already came back empty here:[^\n]*value must not drop/);
+  });
+
+  it('keeps quiet about a phrasing that DID find something', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'CustomerName', text: 'Customer name', labelFileId: 'MyModel', model: 'MyModel' }),
+    ]);
+    await labelsTool(req('labels', { action: 'search', query: ['customer'] }), ctx);
+
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+    const text = (await labelsTool(req('labels', { action: 'search', query: ['nothing at all'] }), ctx))
+      .content[0].text as string;
+
+    expect(text).not.toContain('This is not new information');
   });
 
   it('does not report a failed batch as "no reusable label exists"', async () => {

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -236,14 +236,9 @@ describe('labels(action="search") with query[]', () => {
     }
   });
 
-  // The verdict used to read "at least one reusable label was found", and run
-  // a5677c99 believed it: the best hit behind that sentence was @SYS321832 "The
-  // decreased margin cannot be greater than the current margin amount of letter of
-  // guarantee", and the agent spent two more searches looking for the label the
-  // verdict had promised. A hit means the model can RESOLVE the label, never that
-  // it says what the caller needs — so the verdict now reports a candidate, tells
-  // the caller to read the text, and carries the create call so that rejecting all
-  // of them costs no further round trip.
+  // "At least one reusable label was found" promised more than a hit means: the
+  // model can RESOLVE the label, not that it says what the caller needs. Callers
+  // kept rephrasing to find the label the verdict implied was there.
   it('reports a hit as a candidate, and still hands over the create call', async () => {
     (ctx.symbolIndex.searchLabels as any).mockReturnValue([
       makeLabelResult({ labelId: 'CustomerName', text: 'Customer name', labelFileId: 'MyModel', model: 'MyModel' }),

--- a/tests/tools/modifyBatchOperations.test.ts
+++ b/tests/tools/modifyBatchOperations.test.ts
@@ -181,4 +181,37 @@ describe('d365fo_file(action="modify") with operations[]', () => {
 
     expect(forwarded()[0].peerOperations).toEqual(['add-field']);
   });
+
+  // get_knowledge(kind="op-spec") tells the caller, in bold, to "pass these
+  // NESTED inside `params`". The single-operation form unwraps that wrapper; the
+  // batch form used to forward it verbatim, so the operation ran with none of its
+  // parameters and answered "called with no parameter that changes anything".
+  // Run 9180a464 followed the spec, was refused, and got through only by
+  // ignoring it and passing the keys flat.
+  it('unwraps a per-entry `params` the way the single-operation form does', async () => {
+    await d365foFileTool(call({
+      objectType: 'table-extension',
+      objectName: 'AslFinCore_TaxTransReportChangeLog.AslFinSKExtension',
+      operations: [
+        { operation: 'modify-field', params: { fieldName: 'AslFinSK_QualityTier', fieldLabel: '@AslFinSK:QualityTierField' } },
+        { operation: 'add-field-to-field-group', params: { fieldName: 'AslFinSK_QualityTier', fieldGroupName: 'Identification', extendBaseFieldGroup: true } },
+      ],
+    }), ctx);
+
+    const [first, second] = forwarded();
+    expect(first.fieldName).toBe('AslFinSK_QualityTier');
+    expect(first.fieldLabel).toBe('@AslFinSK:QualityTierField');
+    expect(first.params).toBeUndefined();
+    expect(second.fieldGroupName).toBe('Identification');
+    expect(second.extendBaseFieldGroup).toBe(true);
+  });
+
+  it('keeps flat entry keys working, and lets params win on a collision', async () => {
+    await d365foFileTool(call({
+      objectType: 'table', objectName: 'T',
+      operations: [{ operation: 'add-field', fieldName: 'Flat', params: { fieldName: 'Nested' } }],
+    }), ctx);
+
+    expect(forwarded()[0].fieldName).toBe('Nested');
+  });
 });

--- a/tests/tools/modifyBatchOperations.test.ts
+++ b/tests/tools/modifyBatchOperations.test.ts
@@ -182,12 +182,9 @@ describe('d365fo_file(action="modify") with operations[]', () => {
     expect(forwarded()[0].peerOperations).toEqual(['add-field']);
   });
 
-  // get_knowledge(kind="op-spec") tells the caller, in bold, to "pass these
-  // NESTED inside `params`". The single-operation form unwraps that wrapper; the
-  // batch form used to forward it verbatim, so the operation ran with none of its
-  // parameters and answered "called with no parameter that changes anything".
-  // Run 9180a464 followed the spec, was refused, and got through only by
-  // ignoring it and passing the keys flat.
+  // op-spec tells callers to pass parameters NESTED inside `params`. The
+  // single-operation form unwraps that; the batch form forwarded it verbatim, so
+  // an entry that followed the spec ran with no parameters at all.
   it('unwraps a per-entry `params` the way the single-operation form does', async () => {
     await d365foFileTool(call({
       objectType: 'table-extension',

--- a/tests/tools/objectXmlAndTiming.test.ts
+++ b/tests/tools/objectXmlAndTiming.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Two questions the server used to leave unanswered: the raw XML of an object,
+ * which callers went to the shell for, and where a slow write spent its time.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { renderObjectXml, objectXmlNotFound } from '../../src/tools/readers/objectXml';
+import { createPhaseTimer } from '../../src/utils/phaseTimer';
+
+const XML_LINES = Array.from({ length: 120 }, (_, i) => `\t<Line${i + 1}>value</Line${i + 1}>`);
+const XML = `<?xml version="1.0" encoding="utf-8"?>\n<AxTable>\n${XML_LINES.join('\n')}\n</AxTable>`;
+
+let root: string;
+let file: string;
+
+beforeAll(async () => {
+  root = await mkdtemp(path.join(tmpdir(), 'objxml-'));
+  file = path.join(root, 'MyTable.xml');
+  await writeFile(file, `﻿${XML}`, 'utf-8');
+});
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('get_object_info(include="xml")', () => {
+  it('returns the file path and the content', async () => {
+    const res = await renderObjectXml(file, 'table', 'MyTable');
+    expect(res.isError).toBe(false);
+    expect(res.text).toContain('MyTable.xml');
+    expect(res.text).toContain('<Line1>value</Line1>');
+    expect(res.text).toContain('Lines:** 1-123 of 123');
+  });
+
+  it('strips the BOM so the first line is usable XML', async () => {
+    const res = await renderObjectXml(file, 'table', 'MyTable');
+    expect(res.text).toContain('```xml\n<?xml version');
+  });
+
+  it('pages by line range', async () => {
+    const res = await renderObjectXml(file, 'table', 'MyTable', { startLine: 3, endLine: 5 });
+    expect(res.text).toContain('Lines:** 3-5 of 123');
+    expect(res.text).toContain('<Line2>');
+    expect(res.text).not.toContain('<Line10>');
+  });
+
+  it('cuts at maxChars and says to page rather than raise it', async () => {
+    const res = await renderObjectXml(file, 'table', 'MyTable', { maxChars: 200 });
+    expect(res.text).toContain('✂️ Cut at 200 chars');
+    expect(res.text).toContain('startLine');
+  });
+
+  it('reports an unreadable file instead of returning empty', async () => {
+    const res = await renderObjectXml(path.join(root, 'gone.xml'), 'table', 'Gone');
+    expect(res.isError).toBe(true);
+    expect(res.text).toContain('could not read it');
+  });
+
+  it('names modelName as the fix when nothing was located', () => {
+    const res = objectXmlNotFound('table', 'NoSuchTable', 'MyModel');
+    expect(res.isError).toBe(true);
+    expect(res.text).toContain('no file on disk');
+    expect(res.text).toContain('options.modelName');
+  });
+});
+
+describe('phase timing on a slow write', () => {
+  it('stays silent under the threshold', async () => {
+    const t = createPhaseTimer();
+    await t.time('quick', async () => undefined);
+    expect(t.render(10_000)).toBe('');
+  });
+
+  it('names the phases, largest first, when the call was slow', () => {
+    const t = createPhaseTimer();
+    t.add('C# bridge Create()', 90_000);
+    t.add('symbol index upsert', 2_000);
+    t.add('write verification', 300);
+    const out = t.render(10_000);
+    expect(out).toContain('⏱️ This call took');
+    const order = ['C# bridge Create()', 'symbol index upsert', 'write verification']
+      .map(name => out.indexOf(name));
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+  });
+
+  it('accounts for time no phase claimed', () => {
+    vi.useFakeTimers();
+    try {
+      const t = createPhaseTimer();
+      t.add('measured', 1_000);
+      vi.advanceTimersByTime(30_000);
+      expect(t.render(10_000)).toContain('(unmeasured)');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('records the phase even when the work throws', async () => {
+    const t = createPhaseTimer();
+    await expect(t.time('boom', async () => { throw new Error('x'); })).rejects.toThrow('x');
+    t.add('filler', 20_000);
+    expect(t.render(10_000)).toContain('filler');
+  });
+});

--- a/tests/tools/resolve-references.test.ts
+++ b/tests/tools/resolve-references.test.ts
@@ -648,3 +648,70 @@ describe('validateCodeTool references mode — xml-table EDT checking', () => {
     expect(result.isError).toBeFalsy();
   });
 });
+
+/**
+ * A label's %n placeholders against the arguments the call site supplies.
+ * Both directions compile and are wrong at runtime: a label with %1 used bare
+ * shows the user a literal "%1", and arguments handed to a label without
+ * placeholders are discarded.
+ */
+describe('label placeholders vs strFmt arguments', () => {
+  const TEXTS: Record<string, string> = {
+    Downgrade: 'The quality tier cannot be decreased from %1 to %2.',
+    Plain: 'The quality tier cannot be decreased.',
+  };
+
+  const textDeps: ResolverDeps = {
+    db: { prepare: () => ({ get: () => undefined, all: () => [] }) },
+    getLabelById: (labelId: string) =>
+      TEXTS[labelId]
+        ? [{ labelId, labelFileId: 'AslFinSK', language: 'en-US', text: TEXTS[labelId] }]
+        : [],
+    getLabelFileIds: () => [{ labelFileId: 'AslFinSK' }],
+  };
+
+  const check = (code: string) =>
+    resolveXppReferences(code, textDeps).violations.filter(
+      v => v.kind === 'label-placeholder-mismatch',
+    );
+
+  it('flags a placeholder label used without strFmt', () => {
+    const found = check('ret = checkFailed(literalStr("@AslFinSK:Downgrade"));');
+    expect(found).toHaveLength(1);
+    expect(found[0].severity).toBe('error');
+    expect(found[0].detail).toContain('must be wrapped');
+  });
+
+  it('flags arguments passed to a label that has no placeholders', () => {
+    const found = check('ret = checkFailed(strFmt("@AslFinSK:Plain", enum2str(a), enum2str(b)));');
+    expect(found).toHaveLength(1);
+    expect(found[0].detail).toContain('discarded');
+  });
+
+  it('flags an argument-count mismatch', () => {
+    const found = check('ret = checkFailed(strFmt("@AslFinSK:Downgrade", enum2str(a)));');
+    expect(found[0].detail).toContain('takes 2 argument(s), strFmt supplies 1');
+  });
+
+  it('accepts the matching call, wrapped and across lines', () => {
+    expect(check(`ret = checkFailed(strFmt("@AslFinSK:Downgrade",
+        enum2str(this.orig().Tier),
+        enum2str(this.Tier)));`)).toHaveLength(0);
+  });
+
+  it('accepts a plain label used bare, and sees through literalStr', () => {
+    expect(check('ret = checkFailed("@AslFinSK:Plain");')).toHaveLength(0);
+    expect(check('ret = checkFailed(strFmt(literalStr("@AslFinSK:Downgrade"), a, b));')).toHaveLength(0);
+  });
+
+  it('says nothing when the index has no text for the label', () => {
+    const noText: ResolverDeps = {
+      ...textDeps,
+      getLabelById: (labelId: string) => [{ labelId, labelFileId: 'AslFinSK' }],
+    };
+    expect(
+      resolveXppReferences('ret = checkFailed("@AslFinSK:Downgrade");', noText)
+        .violations.filter(v => v.kind === 'label-placeholder-mismatch'),
+    ).toHaveLength(0);
+  });
+});

--- a/tests/tools/run9180a464Fixes.test.ts
+++ b/tests/tools/run9180a464Fixes.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Benchmark run 9180a464 (10.8. 06:19) — the run that deleted its own deliverable.
+ *
+ * What happened, in order: a full build returned exit-failure; the log parser
+ * recognised none of the lines in it, so the tool printed "❌ Build FAILED" over
+ * "📋 Structured diagnostics: 0 error(s), 1 warning(s)", the warning being an
+ * unrelated `Server`-keyword deprecation on another model's class. Given a
+ * failure with no cause, the agent guessed one ("duplicate control name"), spent
+ * 178 s + 54 s + 12 s scanning PackagesLocalDirectory from PowerShell, then
+ * called undo_last_modification on the form extension it had just created and
+ * hand-edited the .rnrproj to drop the entry. The next build passed, which made
+ * the deletion look like a fix.
+ *
+ * Two smaller defects from the same run are pinned here as well.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseXppcDiagnostics,
+  formatStructuredDiagnostics,
+  renderUnexplainedFailure,
+  xppcReportedErrorCount,
+} from '../../src/tools/sdlc/buildProject';
+import { runRules } from '../../src/tools/analysis/validateXpp';
+
+/**
+ * Verbatim shapes from K:\…\Temp\d365build_log_6f131599b2.log. Only the first
+ * of these five was recognised by the old parser.
+ */
+const LOG = `AslFinanceSK compilation completed.
+Elapsed time: 00:00:21
+
+--- xppc compiler diagnostics ---
+==================================
+Compile Warning: Class Method dynamics://Class/LogisticsPostalAddressAslFinSK_Extension/Method/aslFinSK_makeStreet: [(7,5),(50,6)]: The 'Server'  keyword has been deprecated, please remove it from the method definition.
+Metadata Warning: AxTableExtension/SalesOrderHeaderV2Staging.AslFinSKExtension: Referenced object 'SalesOrderHeaderV2Staging' is marked as obsolete.
+FormPatternValidation Warning: AxFormExtension/ProjInvoiceJournalV2.AslFinSKExtension/Design/Controls/TabHeading/Overview: 'AxFormExtension/…/Overview' has not specified a pattern. Please apply one of the available patterns.
+Metadata Error: AxFormExtension/AslFinCore_TaxTransReportChangeLog.AslFinSKExtension/Design/Controls/Identification/Identification_AslFinSK_QualityTier: Duplicate control name.
+FormPatternValidation Error: AxFormExtension/AslFinCore_TaxTransReportChangeLog.AslFinSKExtension/Design/Controls/Identification: does not conform to pattern SimpleList.
+==================================
+Errors: 2
+Warnings: 3
+`;
+
+describe('xppc diagnostics — the whole severity family, not five literals', () => {
+  const diags = parseXppcDiagnostics(LOG);
+
+  it('finds the errors the old parser reported as zero', () => {
+    const errors = diags.filter(d => d.severity === 'error');
+    expect(errors).toHaveLength(2);
+    expect(errors.map(e => e.kind).sort()).toEqual(['FormPatternValidation', 'Metadata']);
+  });
+
+  it('locates the object and the member from the path form', () => {
+    const dup = diags.find(d => d.message === 'Duplicate control name.');
+    expect(dup?.model).toBe('AxFormExtension');
+    expect(dup?.object).toBe('AslFinCore_TaxTransReportChangeLog.AslFinSKExtension');
+    expect(dup?.member).toContain('Identification_AslFinSK_QualityTier');
+  });
+
+  it('still parses the dynamics:// form with line and column', () => {
+    const dep = diags.find(d => d.message.includes('Server'));
+    expect(dep?.severity).toBe('warning');
+    expect(dep?.object).toBe('LogisticsPostalAddressAslFinSK_Extension');
+    expect(dep?.line).toBe(7);
+    expect(dep?.column).toBe(5);
+  });
+
+  it('picks up the Metadata and FormPatternValidation warnings too', () => {
+    expect(diags.filter(d => d.severity === 'warning')).toHaveLength(3);
+  });
+
+  it('reads xppc own error tally', () => {
+    expect(xppcReportedErrorCount(LOG)).toBe(2);
+    expect(xppcReportedErrorCount('no tally here')).toBeNull();
+  });
+
+  it('does not mistake the tally lines for diagnostics', () => {
+    expect(parseXppcDiagnostics('Errors: 2\nWarnings: 3\n')).toHaveLength(0);
+  });
+
+  it('lists the errors before the warnings, with locations', () => {
+    const block = formatStructuredDiagnostics(diags);
+    expect(block).toContain('2 error(s), 3 warning(s)');
+    expect(block.indexOf('Duplicate control name')).toBeLessThan(block.indexOf('Server'));
+  });
+});
+
+describe('a failure this parser cannot explain must say so', () => {
+  it('names the gap and forbids deleting work to clear it', () => {
+    const note = renderUnexplainedFailure([], 'Errors: 1\nWarnings: 0\n');
+    expect(note).toContain('no error diagnostic');
+    expect(note).toContain('Errors: 1');
+    expect(note).toContain('Do NOT delete, undo or unregister');
+  });
+
+  it('warns that listed warnings are not the failure', () => {
+    // The exact trap of run 9180a464: FAILED, plus one unrelated warning.
+    const onlyWarning = parseXppcDiagnostics(
+      "Compile Warning: Class Method dynamics://Class/X/Method/y: [(7,5)]: The 'Server' keyword has been deprecated.\n",
+    );
+    const note = renderUnexplainedFailure(onlyWarning, 'Errors: 1\nWarnings: 1\n');
+    expect(note).toContain('are NOT the failure');
+  });
+
+  it('reports a shortfall when xppc counted more errors than were parsed', () => {
+    const one = parseXppcDiagnostics('Compile Error: something went wrong\n');
+    expect(renderUnexplainedFailure(one, 'Errors: 4\nWarnings: 0\n')).toContain('only 1 could be parsed');
+  });
+
+  it('stays silent when the parsed errors do explain the failure', () => {
+    const diags = parseXppcDiagnostics(LOG);
+    expect(renderUnexplainedFailure(diags, LOG)).toBe('');
+  });
+});
+
+describe('BP005 spans the whole call, not one line', () => {
+  const bp005 = (code: string) => runRules(code, 'xpp').filter(v => v.rule === 'BP005');
+
+  it('flags the wrapped strFmt the run was told was clean', () => {
+    // Verbatim from validate_code call #56, which answered "no violations found".
+    const code = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
+final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
+{
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+
+        if (ret && this.AslFinSK_QualityTier < this.orig().AslFinSK_QualityTier)
+        {
+            ret = checkFailed(strFmt("@AslFinSK:QualityTierDowngradeNotAllowed",
+                enum2str(this.orig().AslFinSK_QualityTier),
+                enum2str(this.AslFinSK_QualityTier)));
+        }
+
+        return ret;
+    }
+}`;
+    const found = bp005(code);
+    expect(found).toHaveLength(2);
+    expect(found.map(v => v.line)).toEqual([11, 12]);
+  });
+
+  it('still flags the single-line form', () => {
+    expect(bp005('info(strFmt("@X:Y", enum2str(tier)));')).toHaveLength(1);
+  });
+
+  it('leaves enum2str outside a message alone', () => {
+    expect(bp005('str key = enum2str(this.Tier);')).toHaveLength(0);
+    expect(bp005('fileName = enum2str(tier) + ".txt";')).toHaveLength(0);
+  });
+
+  it('ignores it inside a comment', () => {
+    expect(bp005('// info(strFmt("@X:Y", enum2str(tier)));')).toHaveLength(0);
+  });
+});

--- a/tests/tools/runA5677c99Fixes.test.ts
+++ b/tests/tools/runA5677c99Fixes.test.ts
@@ -1,0 +1,245 @@
+/**
+ * The four server-side defects benchmark run a5677c99 (10.8., 125.0 AIU, 24 min)
+ * exposed, each pinned to the artefact from the run that revealed it.
+ *
+ * The run itself succeeded — the label-FTS fix from PR #885 had already cut it
+ * from 221 minutes to 24. What it cost anyway:
+ *
+ *   turns 29-41 (~36 AIU, 29 % of the run)  the agent wrote `this.checkFailed(...)`
+ *       in a table CoC wrapper, nothing objected, and a 211-second build was the
+ *       first thing to say so.
+ *   3 read_file turns (~8 AIU)              replace-code reported "✅ Code replaced"
+ *       and nothing about what the code now said.
+ *   one corrupted file                      that same replace-code turned
+ *       `this.checkFailed` into `this.this.checkFailed`, unasked.
+ *   one wrong diagnosis                     the build printed "💡 Field Does Not
+ *       Exist on Table" underneath a compiler error about a METHOD.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runRules } from '../../src/tools/analysis/validateXpp';
+import { validateWrittenXpp, extractDeclaration } from '../../src/tools/write/inlineXppValidation';
+import { preflightReplaceCode, renderChangedLines } from '../../src/tools/write/modifyD365File';
+import { lookupErrorFix, d365foErrorHelpTool } from '../../src/tools/knowledge/d365foErrorHelp';
+
+/** Verbatim from the run: the sourceCode argument of tool call #48. */
+const SHIPPED_COC = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
+final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
+{
+    /// <summary>
+    /// Prevents the <c>QualityTier</c> value from being downgraded on write.
+    /// </summary>
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+
+        if (ret && this.AslFinSK_QualityTier < this.orig().AslFinSK_QualityTier)
+        {
+            this.checkFailed(literalStr("@AslFinSK:QualityTierDowngradeNotAllowed"));
+            ret = false;
+        }
+
+        return ret;
+    }
+}`;
+
+/** Verbatim from the run: the compiler error build_d365fo_project returned at #54. */
+const BUILD_ERROR =
+  "ClassDoesNotContainMethod: Table 'AslFinCore_TaxTransReportChangeLog' does not contain a " +
+  "definition for method 'checkFailed' and no extension method 'checkFailed' accepting a first " +
+  "argument of type 'AslFinCore_TaxTransReportChangeLog' is found on any extension class.";
+
+describe('COC005 — Global functions are not members of a table buffer', () => {
+  const coc005 = (code: string) => runRules(code, 'xpp').filter(v => v.rule === 'COC005');
+
+  it('flags the call the run shipped', () => {
+    const found = coc005(SHIPPED_COC);
+    expect(found).toHaveLength(1);
+    expect(found[0].severity).toBe('error');
+    expect(found[0].excerpt).toContain('this.checkFailed');
+    expect(found[0].fix).toContain('unqualified');
+  });
+
+  it('accepts the corrected form', () => {
+    expect(coc005(SHIPPED_COC.replace('this.checkFailed', 'ret = checkFailed'))).toHaveLength(0);
+  });
+
+  it('leaves genuine buffer members alone', () => {
+    // this.orig() and this.validateWrite() ARE members of Common — only the Global
+    // functions are not, and a rule that could not tell them apart would be noise.
+    expect(coc005(SHIPPED_COC.replace('this.checkFailed', 'ret = checkFailed'))).toHaveLength(0);
+    expect(SHIPPED_COC).toContain('this.orig()');
+  });
+
+  it('stays out of class CoC, where this.checkFailed() can be legal', () => {
+    // On a RunBase descendant checkFailed IS an inherited member; flagging it there
+    // would be wrong far more often than right.
+    const classCoc = `[ExtensionOf(classStr(MyRunBaseThing))]
+final class MyRunBaseThing_Ext_Extension
+{
+    public boolean validate()
+    {
+        boolean ret = next validate();
+        this.checkFailed("@Sys:Nope");
+        return ret;
+    }
+}`;
+    expect(coc005(classCoc)).toHaveLength(0);
+  });
+
+  it('ignores the pattern inside a comment or a string', () => {
+    const commented = SHIPPED_COC.replace(
+      '            this.checkFailed(',
+      '            // this.checkFailed(',
+    );
+    expect(coc005(commented)).toHaveLength(0);
+  });
+});
+
+describe('inline validation on the write itself', () => {
+  it('reports COC005 on a create, without anyone calling validate_code', () => {
+    const note = validateWrittenXpp(SHIPPED_COC);
+    expect(note).toContain('COC005');
+    expect(note).toContain('will fail the build');
+  });
+
+  it('says nothing when the source is clean', () => {
+    expect(validateWrittenXpp(SHIPPED_COC.replace('this.checkFailed', 'ret = checkFailed'))).toBe('');
+  });
+
+  it('recovers the class context so a bare method snippet is still checked', () => {
+    // A modify sends the method alone; without the object's own <Declaration> the
+    // class-scoped rules see no [ExtensionOf] and correctly find nothing.
+    const snippet = `    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+        this.checkFailed(literalStr("@AslFinSK:Nope"));
+        return ret;
+    }`;
+    const declarationXml = `<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>AslFinCore_TaxTransReportChangeLogAslFinSK_Extension</Name>
+  <SourceCode>
+    <Declaration><![CDATA[
+[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
+final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
+{
+}
+]]></Declaration>
+  </SourceCode>
+</AxClass>`;
+
+    expect(validateWrittenXpp(snippet)).toBe('');
+    const note = validateWrittenXpp(snippet, declarationXml);
+    expect(note).toContain('COC005');
+    // Line 4 of the snippet the caller sent — not line 7 of the synthetic wrapper.
+    expect(note).toContain('line 4 of the code you sent');
+  });
+
+  it('reads the declaration out of AOT XML', () => {
+    expect(extractDeclaration('<Declaration><![CDATA[\nfinal class X\n{\n}\n]]></Declaration>'))
+      .toContain('final class X');
+    expect(extractDeclaration('<AxEnum><Name>Foo</Name></AxEnum>')).toBeNull();
+  });
+
+  it('does not try to lint a table create\'s field JSON or raw XML', () => {
+    expect(validateWrittenXpp('{"fields":[{"name":"Foo"}]}')).toBe('');
+    expect(validateWrittenXpp('<AxTable><Name>Foo</Name></AxTable>')).toBe('');
+    expect(validateWrittenXpp(undefined)).toBe('');
+  });
+});
+
+describe('replace-code preflight', () => {
+  /** The method source as it stood when the run issued call #60. */
+  const FILE = `        boolean ret = next validateWrite();
+
+        if (ret && this.AslFinSK_QualityTier < this.orig().AslFinSK_QualityTier)
+        {
+            this.checkFailed(literalStr("@AslFinSK:QualityTierDowngradeNotAllowed"));
+            ret = false;
+        }`;
+
+  it('stops the edit that produced this.this.checkFailed', () => {
+    const verdict = preflightReplaceCode(FILE, 'checkFailed', 'this.checkFailed');
+    expect(verdict?.kind).toBe('noop');
+    expect(verdict?.message).toContain('already applied');
+    expect(verdict?.message).toContain('this.this.checkFailed');
+  });
+
+  it('refuses an oldCode that matches more than once, naming the lines', () => {
+    const twice = `${FILE}\n        this.checkFailed(literalStr("@AslFinSK:Other"));`;
+    const verdict = preflightReplaceCode(twice, 'this.checkFailed', 'checkFailed');
+    expect(verdict?.kind).toBe('refuse');
+    expect(verdict?.message).toContain('matches 2 times');
+    expect(verdict?.message).toContain('lines 5, 8');
+  });
+
+  it('reports an already-applied edit as done, not as "oldCode not found"', () => {
+    // Call #64 of the run: the repair had landed at #62, and the retry was told the
+    // exact source did not match — which reads as "the file is still wrong".
+    const fixed = FILE.replace('this.checkFailed', 'checkFailed');
+    expect(preflightReplaceCode(fixed, 'this.this.checkFailed(x);', 'checkFailed(x);')).toBeNull();
+
+    const applied = preflightReplaceCode(fixed, 'this.checkFailed', 'checkFailed');
+    expect(applied?.kind).toBe('noop');
+    expect(applied?.message).toContain('Nothing to do');
+  });
+
+  it('lets an unambiguous edit through', () => {
+    expect(preflightReplaceCode(FILE, 'ret = false;', 'ret = checkFailed("@X:Y");')).toBeNull();
+  });
+});
+
+describe('the reply shows what changed', () => {
+  it('renders the edited line with context', () => {
+    const before = 'a\nb\nc\nd\ne\nf\ng';
+    const after = 'a\nb\nc\nCHANGED\ne\nf\ng';
+    const note = renderChangedLines(before, after, 1);
+    expect(note).toContain('› ');
+    expect(note).toContain('CHANGED');
+    expect(note).toContain('Result on disk');
+  });
+
+  it('stays silent when nothing moved', () => {
+    expect(renderChangedLines('a\nb', 'a\nb')).toBe('');
+  });
+});
+
+describe('error help does not answer questions it cannot answer', () => {
+  it('no longer diagnoses a missing METHOD as a missing FIELD', () => {
+    const hit = lookupErrorFix(BUILD_ERROR);
+    expect(hit?.title).not.toBe('Field Does Not Exist on Table');
+  });
+
+  it('recognises ClassDoesNotContainMethod and points at the Global function', () => {
+    const hit = lookupErrorFix(BUILD_ERROR);
+    expect(hit?.title).toBe('Method Does Not Exist on That Type');
+    expect(hit?.fix.join(' ')).toContain('checkFailed');
+  });
+
+  it('still resolves the errors it always did', () => {
+    expect(lookupErrorFix('Field does not exist on table CustTable')?.title)
+      .toBe('Field Does Not Exist on Table');
+  });
+
+  it('says "no match" rather than presenting a weak guess as the answer', () => {
+    const res: any = d365foErrorHelpTool({
+      method: 'tools/call',
+      params: { name: 'get_knowledge', arguments: { errorText: 'the widget sprocket table found nothing' } },
+    } as any);
+    const text = res.content[0].text as string;
+    if (text.startsWith('❌ No matching error pattern')) {
+      expect(text).not.toContain('**What happened:**');
+    } else {
+      // A confident match is fine — it just has to be a real one, not word overlap.
+      expect(text).toContain('**What happened:**');
+    }
+  });
+
+  it('matches whole words, so a table NAME cannot vote for a field entry', () => {
+    // 'table' inside "MyTableExtension" used to count as a hit for the pattern
+    // 'field not found on table'.
+    const hit = lookupErrorFix("Object 'MyTableExtension' could not be created here");
+    expect(hit?.title).not.toBe('Field Does Not Exist on Table');
+  });
+});

--- a/tests/tools/runBpCheck.test.ts
+++ b/tests/tools/runBpCheck.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import realFs from 'fs';
+import os from 'os';
+import nodePath from 'path';
+import { recordBuild } from '../../src/utils/buildMarker';
 
 // --- hoisted mocks -----------------------------------------------------------
 const {
@@ -751,6 +755,95 @@ describe('run_bp_check — batch objects[] (#828)', () => {
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(text).toContain('Filter: table:ConDemoTicket');
     expect(text).not.toContain('objects checked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The build-freshness line, with the object paths it needs to be true.
+//
+// Passing no paths left describeBuildFreshness unable to compare "last built"
+// against "last written", so it reported the newest recorded success as-is —
+// a green verdict for objects written long after that build.
+// ---------------------------------------------------------------------------
+
+describe('run_bp_check — build freshness reflects THESE objects', () => {
+  let dataDir: string;
+  let objectPath: string;
+
+  /** Symbol index that answers the path probe and carries a marker directory. */
+  const contextWithPath = () => ({
+    symbolIndex: {
+      dataDir,
+      getReadDb: () => ({
+        prepare: (sql: string) => ({
+          get: () => undefined,
+          all: (...params: any[]) => {
+            const isFts = /symbols_fts/.test(sql);
+            const name = String(isFts ? params[1] : params[0]);
+            return name === 'ConDemoTicket'
+              ? [{ name, type: 'table', model: 'MyModel', extends_class: null, file_path: objectPath }]
+              : [];
+          },
+        }),
+      }),
+    },
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    detectedRoots.splice(0, detectedRoots.length, CHE_PKG);
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    allowPaths([CHE_PKG, CHE_XPPBP]);
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: '✅', stderr: '' });
+    });
+
+    dataDir = realFs.mkdtempSync(nodePath.join(os.tmpdir(), 'd365fo-bpfresh-'));
+    objectPath = nodePath.join(dataDir, 'ConDemoTicket.xml');
+  });
+
+  afterEach(() => {
+    realFs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('calls a green build STALE when the object was written after it', async () => {
+    recordBuild(dataDir, 'MyModel', {
+      builtAt: new Date(Date.now() - 60_000).toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+    realFs.writeFileSync(objectPath, '<AxTable/>');
+
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', objects: [{ objectType: 'table', objectName: 'ConDemoTicket' }] },
+      contextWithPath(),
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('Stale');
+    expect(text).not.toContain('✅ Compiled');
+  });
+
+  it('still confirms a build that came after the write', async () => {
+    realFs.writeFileSync(objectPath, '<AxTable/>');
+    recordBuild(dataDir, 'MyModel', {
+      builtAt: new Date(Date.now() + 60_000).toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', objects: [{ objectType: 'table', objectName: 'ConDemoTicket' }] },
+      contextWithPath(),
+    );
+
+    expect(result.content[0].text as string).toContain('✅ Compiled');
   });
 });
 

--- a/tests/tools/writeAnchorGuard.test.ts
+++ b/tests/tools/writeAnchorGuard.test.ts
@@ -15,8 +15,12 @@ const { mockConfig } = vi.hoisted(() => ({
   mockConfig: {
     getModelName: vi.fn(() => 'DemoSK'),
     getWriteAnchorModel: vi.fn(() => 'DemoSK'),
+    // The guards resolve the anchor through this now: the sync getter returns
+    // null until the background .rnrproj scan lands, and a null anchor makes the
+    // guard stand down — a race that decided whether the guard ran at all.
+    resolveWriteAnchorModel: vi.fn(async () => mockConfig.getWriteAnchorModel()),
     getToolProjectSwitch: vi.fn(() => null as null | { anchorModel: string; forcedModel: string }),
-  },
+  } as any,
 }));
 
 vi.mock('../../src/utils/configManager', () => ({
@@ -24,6 +28,7 @@ vi.mock('../../src/utils/configManager', () => ({
 }));
 
 import { scaffoldWriteRefusal, scaffoldWriteRefusalResult } from '../../src/tools/write/writeAnchorGuard';
+import { standDownNotice, activeCrossModelAllowance } from '../../src/utils/crossModelWriteGuard';
 
 const table = (targetModel: string | null) => ({
   objectName: 'DemoSKTaxChangeLog',
@@ -40,23 +45,24 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.D365FO_CROSS_MODEL_WRITE_MODELS;
+  delete process.env.D365FO_ALLOW_CROSS_MODEL_WRITE;
 });
 
 describe('scaffoldWriteRefusal', () => {
-  it('allows a scaffold into the anchored model', () => {
-    expect(scaffoldWriteRefusal(table('DemoSK'))).toBeNull();
+  it('allows a scaffold into the anchored model', async () => {
+    expect(await scaffoldWriteRefusal(table('DemoSK'))).toBeNull();
   });
 
-  it('allows it when only the spelling differs', () => {
-    expect(scaffoldWriteRefusal(table('demosk'))).toBeNull();
+  it('allows it when only the spelling differs', async () => {
+    expect(await scaffoldWriteRefusal(table('demosk'))).toBeNull();
   });
 
-  it('refuses a scaffold into the model a project switch made active', () => {
+  it('refuses a scaffold into the model a project switch made active', async () => {
     // Reads followed the switch, the anchor did not: a scaffold now resolves
     // "DemoCore" as its target while writes still belong to "DemoSK".
     mockConfig.getToolProjectSwitch.mockReturnValue({ anchorModel: 'DemoSK', forcedModel: 'DemoCore' });
 
-    const refusal = scaffoldWriteRefusal(table('DemoCore'));
+    const refusal = await scaffoldWriteRefusal(table('DemoCore'));
 
     expect(refusal).toContain('Refusing to create');
     expect(refusal).toContain('DemoCore');
@@ -64,28 +70,94 @@ describe('scaffoldWriteRefusal', () => {
     expect(refusal).toContain('get_workspace_info(projectName="DemoCore")');
   });
 
-  it('refuses a scaffold into any other custom model, switch or not', () => {
-    expect(scaffoldWriteRefusal(table('DemoCore'))).toContain('Refusing to create');
+  it('refuses a scaffold into any other custom model, switch or not', async () => {
+    expect(await scaffoldWriteRefusal(table('DemoCore'))).toContain('Refusing to create');
   });
 
-  it('lets the operator allow it in configuration', () => {
+  it('lets the operator allow it in configuration', async () => {
     process.env.D365FO_CROSS_MODEL_WRITE_MODELS = 'DemoCore';
 
-    expect(scaffoldWriteRefusal(table('DemoCore'))).toBeNull();
+    expect(await scaffoldWriteRefusal(table('DemoCore'))).toBeNull();
   });
 
-  it('stays silent when there is no anchor to measure against', () => {
+  it('stays silent when there is no anchor to measure against', async () => {
     // Never a refusal on a guess: an unconfigured workspace has no model of its own.
     mockConfig.getWriteAnchorModel.mockReturnValue(null as any);
 
-    expect(scaffoldWriteRefusal(table('DemoCore'))).toBeNull();
+    expect(await scaffoldWriteRefusal(table('DemoCore'))).toBeNull();
   });
 
-  it('returns the refusal as an isError tool result', () => {
-    const result = scaffoldWriteRefusalResult(table('DemoCore'));
+  it('resolves the anchor rather than reading the sync getter', async () => {
+    // The whole point of the async path: a workspace whose model arrives with the
+    // background scan used to slip past the guard entirely.
+    mockConfig.getWriteAnchorModel.mockReturnValue(null as any);
+    mockConfig.resolveWriteAnchorModel.mockResolvedValueOnce('DemoSK');
+
+    expect(await scaffoldWriteRefusal(table('DemoCore'))).toContain('Refusing to create');
+  });
+
+  it('returns the refusal as an isError tool result', async () => {
+    const result = await scaffoldWriteRefusalResult(table('DemoCore'));
 
     expect(result?.isError).toBe(true);
     expect(result?.content[0].text).toContain('Refusing to create');
-    expect(scaffoldWriteRefusalResult(table('DemoSK'))).toBeNull();
+    expect(await scaffoldWriteRefusalResult(table('DemoSK'))).toBeNull();
+  });
+});
+
+/**
+ * Refused once, the caller found the host's mcp.json and added the allow-list
+ * key to its env block itself; writes into the other model then succeeded with a
+ * clean ✅, traced only by a console.error in a log truncated on every restart.
+ * The guard cannot tell whose hand wrote its configuration — it can refuse to be
+ * quiet.
+ */
+describe('standing down is never silent', () => {
+  it('names the configuration that permitted a foreign-model write', () => {
+    process.env.D365FO_CROSS_MODEL_WRITE_MODELS = 'DemoCore';
+
+    const note = standDownNotice({
+      objectName: 'DemoSKTaxChangeLog',
+      objectType: 'table',
+      owningModel: 'DemoCore',
+      activeModel: 'DemoSK',
+      action: 'create',
+    });
+
+    expect(note).toContain('permitted by configuration');
+    expect(note).toContain('DemoCore');
+    expect(note).toContain('D365FO_CROSS_MODEL_WRITE_MODELS');
+  });
+
+  it('says so when there was no anchor to measure against', () => {
+    const note = standDownNotice({
+      objectName: 'DemoSKTaxChangeLog',
+      objectType: 'table',
+      owningModel: 'DemoCore',
+      activeModel: '',
+      action: 'create',
+    });
+
+    expect(note).toContain('guard did not run');
+    expect(note).toContain('could not be determined');
+  });
+
+  it('stays empty for a write that never left the active model', () => {
+    expect(standDownNotice({
+      objectName: 'X', objectType: 'table', owningModel: 'DemoSK', activeModel: 'DemoSK',
+    })).toBe('');
+    // …and for a package-name match, which counts as the same model.
+    expect(standDownNotice({
+      objectName: 'X', objectType: 'table', owningModel: 'DemoSKModel',
+      owningPackage: 'DemoSK', activeModel: 'DemoSK',
+    })).toBe('');
+  });
+
+  it('reports an allowance without needing a write to be attempted', () => {
+    expect(activeCrossModelAllowance()).toBeNull();
+    process.env.D365FO_CROSS_MODEL_WRITE_MODELS = 'DemoCore';
+    expect(activeCrossModelAllowance()).toContain('DemoCore');
+    process.env.D365FO_ALLOW_CROSS_MODEL_WRITE = 'true';
+    expect(activeCrossModelAllowance()).toContain('ANY model');
   });
 });

--- a/tests/tools/writeTimeXppValidation.test.ts
+++ b/tests/tools/writeTimeXppValidation.test.ts
@@ -1,19 +1,10 @@
 /**
- * The four server-side defects benchmark run a5677c99 (10.8., 125.0 AIU, 24 min)
- * exposed, each pinned to the artefact from the run that revealed it.
+ * Four defects from one benchmark run: `this.checkFailed(...)` written into a
+ * table CoC with nothing objecting until the build; replace-code turning
+ * `this.checkFailed` into `this.this.checkFailed` and reporting only "✅ Code
+ * replaced"; and a compiler error about a METHOD diagnosed as a missing FIELD.
  *
- * The run itself succeeded — the label-FTS fix from PR #885 had already cut it
- * from 221 minutes to 24. What it cost anyway:
- *
- *   turns 29-41 (~36 AIU, 29 % of the run)  the agent wrote `this.checkFailed(...)`
- *       in a table CoC wrapper, nothing objected, and a 211-second build was the
- *       first thing to say so.
- *   3 read_file turns (~8 AIU)              replace-code reported "✅ Code replaced"
- *       and nothing about what the code now said.
- *   one corrupted file                      that same replace-code turned
- *       `this.checkFailed` into `this.this.checkFailed`, unasked.
- *   one wrong diagnosis                     the build printed "💡 Field Does Not
- *       Exist on Table" underneath a compiler error about a METHOD.
+ * Inputs below are verbatim from that run.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -22,7 +13,7 @@ import { validateWrittenXpp, extractDeclaration } from '../../src/tools/write/in
 import { preflightReplaceCode, renderChangedLines } from '../../src/tools/write/modifyD365File';
 import { lookupErrorFix, d365foErrorHelpTool } from '../../src/tools/knowledge/d365foErrorHelp';
 
-/** Verbatim from the run: the sourceCode argument of tool call #48. */
+/** A CoC wrapper as an agent actually wrote it. */
 const SHIPPED_COC = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
 final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
 {
@@ -43,7 +34,7 @@ final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
     }
 }`;
 
-/** Verbatim from the run: the compiler error build_d365fo_project returned at #54. */
+/** The compiler error it produced. */
 const BUILD_ERROR =
   "ClassDoesNotContainMethod: Table 'AslFinCore_TaxTransReportChangeLog' does not contain a " +
   "definition for method 'checkFailed' and no extension method 'checkFailed' accepting a first " +
@@ -52,7 +43,7 @@ const BUILD_ERROR =
 describe('COC005 — Global functions are not members of a table buffer', () => {
   const coc005 = (code: string) => runRules(code, 'xpp').filter(v => v.rule === 'COC005');
 
-  it('flags the call the run shipped', () => {
+  it('flags the call that shipped', () => {
     const found = coc005(SHIPPED_COC);
     expect(found).toHaveLength(1);
     expect(found[0].severity).toBe('error');
@@ -150,7 +141,7 @@ final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
 });
 
 describe('replace-code preflight', () => {
-  /** The method source as it stood when the run issued call #60. */
+  /** The method source the edits below were issued against. */
   const FILE = `        boolean ret = next validateWrite();
 
         if (ret && this.AslFinSK_QualityTier < this.orig().AslFinSK_QualityTier)
@@ -175,8 +166,8 @@ describe('replace-code preflight', () => {
   });
 
   it('reports an already-applied edit as done, not as "oldCode not found"', () => {
-    // Call #64 of the run: the repair had landed at #62, and the retry was told the
-    // exact source did not match — which reads as "the file is still wrong".
+    // Once the repair has landed, a retry told "oldCode must match the exact
+    // source" reads as "the file is still wrong".
     const fixed = FILE.replace('this.checkFailed', 'checkFailed');
     expect(preflightReplaceCode(fixed, 'this.this.checkFailed(x);', 'checkFailed(x);')).toBeNull();
 

--- a/tests/tools/writeTimeXppValidation.test.ts
+++ b/tests/tools/writeTimeXppValidation.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { runRules } from '../../src/tools/analysis/validateXpp';
 import { validateWrittenXpp, extractDeclaration } from '../../src/tools/write/inlineXppValidation';
+import { sourceAsWritten } from '../../src/tools/write/createD365File';
 import { preflightReplaceCode, renderChangedLines } from '../../src/tools/write/modifyD365File';
 import { lookupErrorFix, d365foErrorHelpTool } from '../../src/tools/knowledge/d365foErrorHelp';
 
@@ -127,6 +128,48 @@ final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
     expect(note).toContain('line 4 of the code you sent');
   });
 
+  /**
+   * The create renames the class to the legal name and writes THAT to disk, so
+   * linting the caller's original text reports COC003 against a name that no
+   * longer exists anywhere — and the fix for it is a no-op.
+   */
+  it('lints the source as renamed by the create, not as the caller typed it', () => {
+    const asSent = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
+final class AslFinCore_TaxTransReportChangeLog_AslFinSKExtension
+{
+    public boolean validateWrite()
+    {
+        return next validateWrite();
+    }
+}`;
+    const finalName = 'AslFinCore_TaxTransReportChangeLogAslFinSK_Extension';
+
+    // The name the caller typed genuinely violates COC003 …
+    expect(validateWrittenXpp(asSent)).toContain('COC003');
+    // … and the create fixes it while writing, so the note must be silent.
+    const written = sourceAsWritten(asSent, finalName)!;
+    expect(written).toContain(`final class ${finalName}`);
+    expect(written).not.toContain('_AslFinSKExtension\n');
+    expect(validateWrittenXpp(written)).toBe('');
+  });
+
+  it('still reports a violation the rename does not fix', () => {
+    // Renaming must not become a way to launder real findings.
+    const withBadCall = SHIPPED_COC.replace(
+      'AslFinCore_TaxTransReportChangeLogAslFinSK_Extension',
+      'AslFinCore_TaxTransReportChangeLog_AslFinSKExtension',
+    );
+    const written = sourceAsWritten(withBadCall, 'AslFinCore_TaxTransReportChangeLogAslFinSK_Extension')!;
+    expect(validateWrittenXpp(written)).toContain('COC005');
+  });
+
+  it('passes through source with no class header, and an absent source', () => {
+    // A table create sends its field list as JSON here.
+    const json = '[{"name":"Foo","type":"str"}]';
+    expect(sourceAsWritten(json, 'Whatever')).toBe(json);
+    expect(sourceAsWritten(undefined, 'Whatever')).toBeUndefined();
+  });
+
   it('reads the declaration out of AOT XML', () => {
     expect(extractDeclaration('<Declaration><![CDATA[\nfinal class X\n{\n}\n]]></Declaration>'))
       .toContain('final class X');
@@ -235,10 +278,10 @@ describe('error help does not answer questions it cannot answer', () => {
   });
 });
 
-describe('the shipped CoC still carries an untranslated message', () => {
-  // next is unconditional, checkFailed is unqualified, the label takes %1/%2 —
-  // every hard rule satisfied. enum2str is what remains: the two values render
-  // as "Gold"/"Silver" in every locale, whatever the enum's labels say.
+describe('the shipped CoC message', () => {
+  // next is unconditional, checkFailed is unqualified, the label takes %1/%2, and
+  // enum2str resolves each value's <Label> in the session language. Nothing left
+  // to say — BP005 used to flag this very message and send the agent to DictEnum.
   const SHIPPED = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
 final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
 {
@@ -260,17 +303,26 @@ final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
     }
 }`;
 
-  it('reports BP005 and nothing more severe', () => {
-    const note = validateWrittenXpp(SHIPPED);
-    expect(note).toContain('BP005');
-    expect(note).toContain('DictEnum');
-    expect(note).not.toContain('error(s)');
+  it('passes clean — enum2str is the translated form', () => {
+    expect(validateWrittenXpp(SHIPPED)).toBe('');
   });
 
-  it('is clean once the enum labels are resolved properly', () => {
+  it('is also clean with the runtime-typed DictEnum form', () => {
+    // Correct too, and the only option when the enum type is not known until
+    // runtime — just not something to rewrite working code into.
     expect(validateWrittenXpp(SHIPPED.replace(
       'enum2str(orig), enum2str(this.AslFinSK_QualityTier)',
       'dictEnum.value2Label(enum2int(orig)), dictEnum.value2Label(enum2int(this.AslFinSK_QualityTier))',
     ))).toBe('');
+  });
+
+  it('reports BP005 when the SYMBOL is what reaches the message', () => {
+    const note = validateWrittenXpp(SHIPPED.replace(
+      'enum2str(orig), enum2str(this.AslFinSK_QualityTier)',
+      'dictEnum.value2Symbol(enum2int(orig)), dictEnum.value2Symbol(enum2int(this.AslFinSK_QualityTier))',
+    ));
+    expect(note).toContain('BP005');
+    expect(note).toContain('never translated');
+    expect(note).not.toContain('error(s)');
   });
 });

--- a/tests/tools/writeTimeXppValidation.test.ts
+++ b/tests/tools/writeTimeXppValidation.test.ts
@@ -234,3 +234,43 @@ describe('error help does not answer questions it cannot answer', () => {
     expect(hit?.title).not.toBe('Field Does Not Exist on Table');
   });
 });
+
+describe('the shipped CoC still carries an untranslated message', () => {
+  // next is unconditional, checkFailed is unqualified, the label takes %1/%2 —
+  // every hard rule satisfied. enum2str is what remains: the two values render
+  // as "Gold"/"Silver" in every locale, whatever the enum's labels say.
+  const SHIPPED = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
+final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
+{
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+
+        if (ret && this.RecId)
+        {
+            AslFinSK_QualityTier orig = this.orig().AslFinSK_QualityTier;
+
+            if (enum2int(this.AslFinSK_QualityTier) < enum2int(orig))
+            {
+                ret = checkFailed(strFmt("@AslFinSK:QualityTierDowngradeError", enum2str(orig), enum2str(this.AslFinSK_QualityTier)));
+            }
+        }
+
+        return ret;
+    }
+}`;
+
+  it('reports BP005 and nothing more severe', () => {
+    const note = validateWrittenXpp(SHIPPED);
+    expect(note).toContain('BP005');
+    expect(note).toContain('DictEnum');
+    expect(note).not.toContain('error(s)');
+  });
+
+  it('is clean once the enum labels are resolved properly', () => {
+    expect(validateWrittenXpp(SHIPPED.replace(
+      'enum2str(orig), enum2str(this.AslFinSK_QualityTier)',
+      'dictEnum.value2Label(enum2int(orig)), dictEnum.value2Label(enum2int(this.AslFinSK_QualityTier))',
+    ))).toBe('');
+  });
+});

--- a/tests/validation/addControlDataGroup.test.ts
+++ b/tests/validation/addControlDataGroup.test.ts
@@ -9,7 +9,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { checkAddControlAgainstDataGroup } from '../../src/tools/analysis/validateFormPattern';
+import {
+  checkAddControlAgainstDataGroup,
+  findDataGroupRenderers,
+} from '../../src/tools/analysis/validateFormPattern';
 
 /** The AslFinCore_TaxTransReportChangeLog shape: Grid > Group[DataGroup=Administration]. */
 const BASE_FORM_XML = `<?xml version="1.0" encoding="utf-8"?>
@@ -127,5 +130,47 @@ describe('checkAddControlAgainstDataGroup', () => {
       'X',
     );
     expect(verdict).toBeNull();
+  });
+});
+
+/**
+ * The same fact asked one step earlier, at add-field-to-field-group time —
+ * before a form extension exists to be created and undone.
+ */
+describe('findDataGroupRenderers', () => {
+  it('finds the container that renders a field group and names the generated control', async () => {
+    const hits = await findDataGroupRenderers(BASE_FORM_XML, 'Administration');
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0].controlName).toBe('Administration');
+    expect(hits[0].dataSource).toBe('DemoChangeLog');
+    expect(hits[0].generatedNameFor('DEMO_QualityTier')).toBe('Administration_DEMO_QualityTier');
+  });
+
+  it('matches the field group case-insensitively', async () => {
+    const hits = await findDataGroupRenderers(BASE_FORM_XML, 'IDENTIFICATION');
+    expect(hits.map(h => h.controlName)).toEqual(['Identification']);
+  });
+
+  it('returns [] for a field group no container renders', async () => {
+    expect(await findDataGroupRenderers(BASE_FORM_XML, 'NoSuchGroup')).toEqual([]);
+  });
+
+  it('returns [] rather than throwing on unparseable XML', async () => {
+    expect(await findDataGroupRenderers('<AxForm><Design>', 'Administration')).toEqual([]);
+  });
+
+  it('finds a renderer nested below the top level', async () => {
+    // The group in the fixture sits under Grid, not directly under Design —
+    // the walk has to descend, which is the whole point of the reverse lookup.
+    const nested = BASE_FORM_XML.replace('<Name>Freeform</Name>', '<Name>Deep</Name>')
+      .replace('<Controls />\n          </AxFormControl>\n        </Controls>',
+        '<Controls><AxFormControl xmlns="" i:type="AxFormGroupControl"><Name>Inner</Name>' +
+        '<Type>Group</Type><Controls /><DataGroup>Buried</DataGroup></AxFormControl></Controls>' +
+        '\n          </AxFormControl>\n        </Controls>');
+    const hits = await findDataGroupRenderers(nested, 'Buried');
+    expect(hits.map(h => h.controlName)).toEqual(['Inner']);
+    // No DataSource on the inner group — the caller must not require one.
+    expect(hits[0].dataSource).toBeUndefined();
   });
 });

--- a/tests/validation/addControlDataGroup.test.ts
+++ b/tests/validation/addControlDataGroup.test.ts
@@ -1,0 +1,131 @@
+/**
+ * add-control DataGroup pre-flight.
+ *
+ * A container carrying <DataGroup> is populated by the compiler from that table
+ * field group, one control per member named <DataGroup>_<Field>. Adding the
+ * field to the field group AND an explicit control for it fails the build with
+ * "The duplicate name '…' was detected" — and the duplicate never appears in the
+ * XML on disk, so it cannot be found by inspection.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkAddControlAgainstDataGroup } from '../../src/tools/analysis/validateFormPattern';
+
+/** The AslFinCore_TaxTransReportChangeLog shape: Grid > Group[DataGroup=Administration]. */
+const BASE_FORM_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>DemoChangeLog</Name>
+  <Design>
+    <Controls>
+      <AxFormControl xmlns="" i:type="AxFormGridControl">
+        <Name>Grid</Name>
+        <Type>Grid</Type>
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormGroupControl">
+            <Name>Identification</Name>
+            <Type>Group</Type>
+            <Controls />
+            <DataGroup>Identification</DataGroup>
+            <DataSource>DemoChangeLog</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormGroupControl">
+            <Name>Administration</Name>
+            <Type>Group</Type>
+            <Controls />
+            <DataGroup>Administration</DataGroup>
+            <DataSource>DemoChangeLog</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormGroupControl">
+            <Name>Freeform</Name>
+            <Type>Group</Type>
+            <Controls />
+          </AxFormControl>
+        </Controls>
+        <DataSource>DemoChangeLog</DataSource>
+      </AxFormControl>
+    </Controls>
+  </Design>
+</AxForm>`;
+
+describe('checkAddControlAgainstDataGroup', () => {
+  it('flags a bound control under a DataGroup parent and names the generated control', async () => {
+    const verdict = await checkAddControlAgainstDataGroup(
+      BASE_FORM_XML,
+      'Administration',
+      'DEMO_QualityTier',
+      'Administration_DEMO_QualityTier',
+    );
+
+    expect(verdict).not.toBeNull();
+    expect(verdict!.dataGroup).toBe('Administration');
+    expect(verdict!.dataSource).toBe('DemoChangeLog');
+    expect(verdict!.generatedName).toBe('Administration_DEMO_QualityTier');
+    // Matching the generated name is a guaranteed collision, not a maybe.
+    expect(verdict!.exactNameCollision).toBe(true);
+  });
+
+  it('still flags when the caller picks a different control name', async () => {
+    // A different name dodges the compiler error but renders the field twice,
+    // so this is a finding either way — only the certainty changes.
+    const verdict = await checkAddControlAgainstDataGroup(
+      BASE_FORM_XML,
+      'Administration',
+      'DEMO_QualityTier',
+      'MyQualityTierCombo',
+    );
+
+    expect(verdict).not.toBeNull();
+    expect(verdict!.generatedName).toBe('Administration_DEMO_QualityTier');
+    expect(verdict!.exactNameCollision).toBe(false);
+  });
+
+  it('matches the parent case-insensitively', async () => {
+    const verdict = await checkAddControlAgainstDataGroup(
+      BASE_FORM_XML,
+      'administration',
+      'DEMO_QualityTier',
+      'Administration_DEMO_QualityTier',
+    );
+    expect(verdict?.dataGroup).toBe('Administration');
+  });
+
+  it('passes an unbound control — a button in such a group is legitimate', async () => {
+    const verdict = await checkAddControlAgainstDataGroup(
+      BASE_FORM_XML,
+      'Administration',
+      undefined,
+      'MyButton',
+    );
+    expect(verdict).toBeNull();
+  });
+
+  it('passes a parent that declares no DataGroup', async () => {
+    const verdict = await checkAddControlAgainstDataGroup(
+      BASE_FORM_XML,
+      'Freeform',
+      'DEMO_QualityTier',
+      'Freeform_DEMO_QualityTier',
+    );
+    expect(verdict).toBeNull();
+  });
+
+  it('passes when the parent is not in the base form', async () => {
+    const verdict = await checkAddControlAgainstDataGroup(
+      BASE_FORM_XML,
+      'NoSuchGroup',
+      'DEMO_QualityTier',
+      'X',
+    );
+    expect(verdict).toBeNull();
+  });
+
+  it('returns null rather than throwing on unparseable XML', async () => {
+    const verdict = await checkAddControlAgainstDataGroup(
+      '<AxForm><Design>',
+      'Administration',
+      'DEMO_QualityTier',
+      'X',
+    );
+    expect(verdict).toBeNull();
+  });
+});


### PR DESCRIPTION
Audit of four benchmark runs of the same prompt on 10.8. (a5677c99 125.0 AIU, 9180a464 ~148, 45451307 106.8). All cold starts, so the repo-memory confound that muddied the last audit does not apply. Seven server-side defects, one of which cost the task its deliverable.

## A FAILED build that named no error, and what the agent did about it

`parseXppcDiagnostics` matched five literal prefixes: `Compile Fatal Error`, `Compile Error`, `Compile Warning`, `Generation Warning`, `Best Practice Warning`. xppc also emits `Metadata Error/Warning` and `FormPatternValidation Error/Warning`, both present in the very log being parsed, and it locates them by element path (`AxFormExtension/Name/Design/Controls/…: message`) rather than by `dynamics://` URI, with no line/column. So a full build returned exit-failure and the tool printed "❌ Build FAILED" over "📋 Structured diagnostics: 0 error(s), 1 warning(s)" — the one warning an unrelated `Server` keyword deprecation on another model's class.

Handed a failure with no cause, the agent invented one ("duplicate control name"), spent 178 s + 54 s + 12 s scanning PackagesLocalDirectory from PowerShell, then called `undo_last_modification` on the form extension it had just been asked to create and hand-edited the .rnrproj to drop the entry. The next build passed, so the deletion looked like the fix. The run reported success with a third of the task deleted.

Prefixes are now matched as a family (`<Kind> <Severity>:`), the element-path form is parsed for object and member, and the same test drives the log-excerpt filter. `renderUnexplainedFailure` covers the residue: when the build failed and nothing parsed, it names the gap, quotes xppc's own `Errors: N` tally when that disagrees with what was parsed, states that the listed warnings are not the failure, and says not to delete or unregister an object to clear the red.

## The X++ rules only ran when the agent thought to ask

`validateXpp` (COC001-004, BP001-005, SEL*, TTS001) was reachable only through the `validate_code` tool. Run a5677c99 never called it: `d365fo_file(create)` wrote a CoC wrapper calling `this.checkFailed(...)`, `run_bp_check` reported it clean (xppbp does not diagnose ClassDoesNotContainMethod), and a 211-second build was the first thing to object — then thirteen turns and ~36 AIU went into walking it back. Every one of those rules is string analysis over source the write is already holding.

`inlineXppValidation` now runs them inside create and modify, on the caller's own text and nothing else; a method snippet has its class header recovered from the object's `<Declaration>` so the class-scoped rules still apply. Advisory, not blocking — a rule that refuses a write has to be right every time, one that annotates it only has to be useful.

Two rules were added or widened by what the runs shipped:

- **COC005** — a Global function called as `this.<fn>()` on a table buffer. `checkFailed`, `error`, `warning`, `info`, `strFmt`, `setPrefix`, `funcName` live on `Global`; the buffer is a `Common` descendant and has none of them. Scoped to `[ExtensionOf(tableStr(...))]`, because on a RunBase descendant the same call is legal.
- **BP005** was line-scoped, so a wrapped `checkFailed(strFmt("@M:Id", enum2str(a), enum2str(b)))` split across three lines never put the message builder and enum2str together. A run asked `validate_code` about exactly that shape and was told "✅ no violations found". It now spans the call's whole argument list.

`createD365File` returns from three places on success and the note was wired into one of them, the XML-template fallback. Every class-extension takes the bridge path, so the rules initially never ran for the object type they were written for. All three carry it now.

## Label %n placeholders against the call site

A label with `%1` used bare renders a literal "%1" to the user; arguments handed to a label with no placeholders are discarded. Both compile. `resolveXppReferences` already resolves every label reference against the index and the index already carries the text, so the check is free: it reports a label that needs `strFmt` and is not wrapped, a `strFmt` over a label that takes no arguments, and a count mismatch, quoting the actual label text in each case. `literalStr()` is transparent to the scan and the receiver is found by backward paren matching, so `checkFailed(strFmt(@X, a, b))` is attributed to `strFmt`.

## replace-code applied edits nobody asked for

The bridge edits with .NET `String.Replace` (`MetadataWriteService.ReplaceInMethods`) — replace-ALL, no count returned, nothing echoed about what changed. `oldCode="checkFailed"` / `newCode="this.checkFailed"` against a method already reading `this.checkFailed(...)` produced `this.this.checkFailed`, and three further calls plus two file reads went into discovering that. The last of them failed with "oldCode must match the exact source" at a moment when the file was already correct.

Both failure modes are decidable from the file before the bridge acts, so `preflightReplaceCode` does that: more than one match refuses and names the lines; an edit whose newCode is already present and contains oldCode returns "no change needed" as a SUCCESS, not an error — "oldCode not found" reads as "the file is still wrong" and invites a retry. Every replace-code reply now shows the changed lines with context, which is what the three follow-up `read_file` calls were for.

The C# side is deliberately untouched: the preflight guarantees exactly one match before the bridge runs, so replace-all and replace-one coincide, and fixing `ReplaceInMethods` properly needs a bridge rebuild and re-attestation.

## Error help answered questions it could not answer

`scoreError` matched pattern words as substrings with no floor, so `ClassDoesNotContainMethod: Table 'X' does not contain a definition for method 'checkFailed'` scored 4 on the entry "Field Does Not Exist on Table" — the pattern `field not found on table` matched "found" and "table", neither of which is about a field — and won. `lookupErrorFix` feeds the winner into `build_d365fo_project`'s output, so "💡 Field Does Not Exist on Table: Call get_object_info(objectType='table', …)" was printed directly under a real compiler error about a method, and the agent went looking at fields.

Word matching is now whole-word, a verbatim pattern hit is required before a match is presented as the answer, weak matches are listed as unconfirmed near-misses, and there is an entry for ClassDoesNotContainMethod that points at the Global function.

## Smaller, from the same runs

- **`operations[]` dropped a per-entry `params`.** The single-operation form unwraps it; the batch form forwarded the wrapper verbatim, so the operation ran with no parameters and answered "called with no parameter that changes anything" — while `get_knowledge(kind="op-spec")` instructs callers, in bold, to nest parameters exactly there. A run obeyed the spec, was refused, and got through only by ignoring it.
- **`get_object_info(options:{include:"xml"})`** returns an object's raw AOT XML and its path, paged with startLine/endLine. The readers render metadata and never show the file, so a caller wanting the actual XML ran `Get-ChildItem -Recurse` over PackagesLocalDirectory to find the path and `Get-Content -Raw` to read it — four shell calls and ~19 AIU in one run. Paid for inside the ListTools budget by folding duplicated flag examples out of the tool description; the payload is still under the ratchet.
- **Latency is attributable now.** A `get_workspace_info` returning 855 characters took 306 s and an enum create took 95 s, and neither the response nor the aggregate metrics could say where the time went. `SLOW_CALL_LOG_MS` (default 10 s, registered in settings) logs one line per slow call with an argument digest, and writes report their own phase timings — bridge call, provider refresh, index upsert, verification, BP check, plus an `(unmeasured)` remainder so nothing can hide. Silent below the threshold.
- **Label-search verdict.** "At least one reusable label was found" promised more than a hit means: the model can resolve the label, not that it says what the caller needs. A run read that over a best hit of @SYS321832 "The decreased margin cannot be greater than the current margin amount of letter of guarantee" and kept rephrasing. The verdict now reports a candidate, says to read the text, and carries the create call so rejecting all of them costs no round trip.

## Not changed, on purpose

Two labels with identical text in one label file looked like a missing dedupe in `labels(action="create")`. It is correct behaviour — BPErrorFieldLabelIsCopyOfEnumLabel requires the field label to be a *different label id* than the enum's, same visible text and all, and the server's own add-field note says so. No dedupe was added.

## Verification

281 files / 3487 tests pass, `tsc` clean, `biome lint` clean.

Four new test files pin the defects to the artefacts that exposed them: `buildDiagnostics.test.ts` (real xppc log shapes, the unexplained-failure report), `writeTimeXppValidation.test.ts` (the shipped CoC source, the replace-code preflight, the error-help threshold), `objectXmlAndTiming.test.ts`, plus new cases in `resolve-references.test.ts` and `modifyBatchOperations.test.ts`.

The last run on this branch's code finished the task correctly and cheaply from cold: 106.8 AIU / 10.0 min against 125.0 / 24 min, green build, clean BP, and a label carrying both `%1 %2` and a real Czech translation. It deliberately shipped no form extension — the base form's Grid carries `<DataGroup>Administration</DataGroup>`, so a field added to that table field group renders on its own. That is also why the earlier run hit a duplicate control: it did the field group *and* an explicit control.

## Note for the reviewer

`src/index.ts` in the last commit is not mine — it hardens the LOG_FILE tee (async open errors, restoring stderr on shutdown, guarding the crash reporters) and was in the working tree when I staged. It belongs with this work, since LOG_FILE is how the new slow-call lines are captured, but it should be read as a separate change.
