### PR TITLE
Match label ids by meaning, not by the byte the file happened to store (#888)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import type { XppSymbol } from './types.js';
 import { renderMethodSignature } from './xppDeclaration.js';
 import { isStandardModel } from '../utils/modelClassifier.js';
+import { labelIdSpellings, parseLabelReference } from '../utils/labelReference.js';
 import { c, log } from '../utils/terminalUi.js';
 
 /**
@@ -4131,7 +4132,22 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Get a single label by exact ID (returns all languages)
+   * Get a single label by ID (returns all languages).
+   *
+   * The ID may be spelled any way the rest of the server emits it: a reference
+   * (`@ContosoExt:EquipmentName`, `@GLS4170035`, even the doubled
+   * `@SYS:@SYS67433`) or the bare key. #888: matching the caller's string
+   * against the stored one verbatim made the natural spelling fail for the 27
+   * legacy label files, whose keys are stored WITH the sigil — 61% of the
+   * indexed rows — and `search` output, which is always a reference, was never
+   * valid input here. Both branches of the IN-list still use `idx_labels_id`
+   * (and `idx_labels_unique` once the file/model filters are added), so the
+   * widening costs nothing; see labelIdSpellings for why the sigil is not
+   * normalised away at storage time instead.
+   *
+   * Rows come back with the id EXACTLY as stored, which is the spelling
+   * callers must keep using for anything that reads the .label.txt (see
+   * labelMissingOnDisk) or writes a reference.
    */
   getLabelById(
     labelId: string,
@@ -4146,14 +4162,22 @@ export class XppSymbolIndex {
     comment: string | null;
     filePath: string;
   }> {
-    const params: any[] = [labelId];
+    const parsed = parseLabelReference(labelId);
+    const spellings = labelIdSpellings(parsed.labelId);
+    if (spellings.length === 0) return [];
+
+    // A `@File:Id` input names its own file; an explicit argument still wins,
+    // and when the two disagree the empty result is the right answer.
+    const fileFilter = labelFileId ?? parsed.labelFileId;
+
+    const params: any[] = [...spellings];
     let sql = `
       SELECT label_id AS labelId, label_file_id AS labelFileId, model, language, text, comment, file_path AS filePath
       FROM labels
-      WHERE label_id = ?
+      WHERE label_id IN (${spellings.map(() => '?').join(', ')})
     `;
-    if (labelFileId) { sql += ` AND label_file_id = ?`; params.push(labelFileId); }
-    if (model)       { sql += ` AND model = ?`;         params.push(model); }
+    if (fileFilter) { sql += ` AND label_file_id = ?`; params.push(fileFilter); }
+    if (model)      { sql += ` AND model = ?`;         params.push(model); }
     sql += ` ORDER BY language`;
     return this.labelsDb.prepare(sql).all(...params) as any[];
   }

--- a/src/server/toolSchemas/labels.ts
+++ b/src/server/toolSchemas/labels.ts
@@ -59,7 +59,9 @@ export const labelsTool = {
         // action=info
         labelId: {
           type: 'string',
-          description: '[info] Exact label ID. Omit for action=info to list available label files for the model.',
+          description:
+            '[info] Label ID, any spelling: SYS67433, @SYS67433, @ContosoExt:MyLabel ' +
+            '(paste search output). labelFileId/model optional. Omit to list label files.',
         },
         // action=create
         labels: {

--- a/src/tools/analysis/validateCode.ts
+++ b/src/tools/analysis/validateCode.ts
@@ -143,19 +143,27 @@ function resolveXmlReferences(
     }
   }
 
-  // <Label> — check @File:Id labels exist (skip raw text labels — those are caught by syntax/BP)
+  // <Label> — check label references exist (skip raw text labels — those are
+  // caught by syntax/BP). Both reference forms: `@File:Id` and the legacy
+  // `@SYSnnnnn`, which used to match neither branch and fell through unverified
+  // (#888) — on the form most likely to appear in metadata that reuses standard
+  // product labels.
   for (const lbl of extractTagValues(xml, 'Label')) {
     if (!lbl.startsWith('@')) continue; // raw text handled by rawLabelBpWarning in create path
     const modern = /^@([A-Za-z0-9_]+):([A-Za-z0-9_]+)$/.exec(lbl);
-    if (modern) {
-      const [, fileId, labelId] = modern;
+    const legacy = /^@([A-Za-z]{2,4}\d+)$/.exec(lbl);
+    if (modern || legacy) {
+      const fileId = modern ? modern[1] : undefined;
       try {
-        const rows = ctx.symbolIndex.getLabelById(labelId, fileId);
+        // getLabelById takes either spelling, so the reference goes in whole.
+        const rows = ctx.symbolIndex.getLabelById(lbl);
         if (rows.length > 0) { verified++; } else {
           violations.push({
             element: 'Label',
             value: lbl,
-            detail: `Label ${lbl} not found in label index (file "${fileId}", id "${labelId}").`,
+            detail: modern
+              ? `Label ${lbl} not found in label index (file "${fileId}", id "${modern[2]}").`
+              : `Legacy label ${lbl} not found in label index.`,
             severity: 'warning',
           });
         }

--- a/src/tools/prepare/prepareCreate.ts
+++ b/src/tools/prepare/prepareCreate.ts
@@ -21,6 +21,7 @@ import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { renderPrepareOpSpec } from '../specs/opSpecs.js';
 import { rankContext, renderRankedContext } from '../../workspace/contextRanker.js';
 import { lookupSymbolsNocase, type SymbolHit } from '../../utils/symbolLookup.js';
+import { formatLabelReference } from '../../utils/labelReference.js';
 import { RESERVED_SYSTEM_FIELD_NAMES } from '../smart/generateSmartTable.js';
 
 export const prepareCreateArgsSchema = z.object({
@@ -188,7 +189,12 @@ function findReusableLabels(baseName: string, context: XppServerContext): string
     const rows = context.symbolIndex.searchLabels(words, { language: 'en-US', limit: 5 });
     if (rows.length > 0) {
       return rows
-        .map(r => `  @${r.labelFileId}:${r.labelId} = "${r.text}" (${r.model})`)
+        // Not `@${labelFileId}:${labelId}` (#888): a legacy row's id already
+        // carries its file id, so hand-building the reference re-created the
+        // doubled `@GLS:@GLS4170035` that #33/#41 removed everywhere else —
+        // xppbp answers BPErrorLabelIsText — and prepare offers these for reuse
+        // immediately before a write.
+        .map(r => `  ${formatLabelReference(r.labelFileId, r.labelId)} = "${r.text}" (${r.model})`)
         .join('\n') + '\n_Reuse instead of creating duplicates (rule: labels before labels)._';
     }
   } catch {

--- a/src/tools/readers/getLabelInfo.ts
+++ b/src/tools/readers/getLabelInfo.ts
@@ -95,16 +95,25 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
     const rows = symbolIndex.getLabelById(labelId, labelFileId, model);
 
     if (rows.length === 0) {
+      // #888: this used to read "Label … not found", a claim about the label —
+      // and a session believed it and concluded a shipped label was absent from
+      // the build. The lookup only ever proves that no KEY matched; say that,
+      // and point at the one call that resolves an id without knowing its text.
       return {
         content: [
           {
             type: 'text',
             text:
-              `Label "${labelId}" not found` +
+              `No label matched the ID "${labelId}"` +
               (labelFileId ? ` in label file "${labelFileId}"` : '') +
               (model ? ` in model "${model}"` : '') +
-              '.\n\n' +
-              `💡 Try labels(action="search") to find labels by text, or omit labelId to list available label files.`,
+              `. This says the key did not match — not that the label is absent from the build.\n\n` +
+              `💡 labels(action="search", query="${labelId}") resolves a known ID in one call ` +
+              `(no model/labelFileId needed) and shows the exact stored key.\n` +
+              (labelFileId || model
+                ? `   The labelFileId/model filters are optional here — drop them and retry.\n`
+                : '') +
+              `   IDs match case-sensitively except for the legacy @XXXnnnnn form.`,
           },
         ],
         isError: true,
@@ -114,7 +123,11 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
     const first = rows[0];
     // #33/#41: never emit `@SYS:@SYS67433` — an id that already carries its label
     // file id is a complete reference, and xppbp rejects the doubled form.
-    const ref = formatLabelReference(first.labelFileId, labelId);
+    //
+    // Formatted from the STORED id, not the caller's spelling (#888): the lookup
+    // now accepts `GLS4170035`, `@GLS4170035` and `@GLS:GLS4170035` alike, and
+    // only the stored one tells us whether the sigil belongs to the key.
+    const ref = formatLabelReference(first.labelFileId, first.labelId);
 
     // An index row is not proof the label exists. Confirm against the .label.txt
     // before handing back a reference the caller will paste into XML — a stale row
@@ -130,7 +143,12 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
     const indexedPaths = symbolIndex
       .getLabelFilePaths(first.labelFileId, first.model)
       .map(p => p.filePath);
-    if (await labelMissingOnDisk(labelId, indexedPaths)) {
+    //
+    // The STORED id goes to the disk check, never the caller's (#888). The file
+    // holds `@GLS4170035=Accountants`, so probing it with the bare `GLS4170035`
+    // the lookup now accepts would report every label in the 27 legacy files as
+    // "in the index but NOT on disk" — a false verdict on 61% of the rows.
+    if (await labelMissingOnDisk(first.labelId, indexedPaths)) {
       return {
         content: [{
           type: 'text',
@@ -141,7 +159,7 @@ export async function getLabelInfoTool(request: CallToolRequest, context: XppSer
             `The index is ahead of the file system (a rolled-back run, a rebuild outside this ` +
             `server, or a checkout). Using this reference compiles to a best-practice error ` +
             `"Unknown label '${ref}'".\n\n` +
-            `Create it: labels(action="create", labelId="${labelId}", labelFileId="${first.labelFileId}", ` +
+            `Create it: labels(action="create", labelId="${first.labelId}", labelFileId="${first.labelFileId}", ` +
             `model="${first.model}", translations=[{language:"en-US", text:"…"}])`,
         }],
         isError: true,

--- a/src/tools/write/createLabel.ts
+++ b/src/tools/write/createLabel.ts
@@ -24,6 +24,7 @@ import { PackageResolver } from '../../utils/packageResolver.js';
 import { crossModelWriteRefusal, standDownNotice } from '../../utils/crossModelWriteGuard.js';
 import { resolveAnchorModel } from './writeAnchorGuard.js';
 import { detectEol } from '../../utils/eolUtils.js';
+import { formatLabelReference, labelIdSpellings } from '../../utils/labelReference.js';
 import { isExtensionLabelFile } from '../../metadata/labelParser.js';
 import { ProjectFileManager, ProjectFileFinder } from '../../workspace/projectFile.js';
 
@@ -480,13 +481,18 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
     ]);
     let collisionWarning = '';
     try {
+      // Both spellings (#888): the 27 legacy files store their keys with the
+      // sigil, so a verbatim `label_id = ?` could never collide with SYS/GLS/
+      // RET/… — the very files this Microsoft-collision guard is about.
+      const spellings = labelIdSpellings(labelId);
       const existing = symbolIndex.labelsDb
         .prepare(
           `SELECT label_id, label_file_id, model, text FROM labels
-           WHERE label_id = ? AND language = 'en-US' AND label_file_id != ?
+           WHERE label_id IN (${spellings.map(() => '?').join(', ')})
+             AND language = 'en-US' AND label_file_id != ?
            LIMIT 10`,
         )
-        .all(labelId, labelFileId) as Array<{ label_id: string; label_file_id: string; model: string; text: string }>;
+        .all(...spellings, labelFileId) as Array<{ label_id: string; label_file_id: string; model: string; text: string }>;
 
       if (existing.length > 0) {
         const msCollisions = existing.filter(r => MICROSOFT_LABEL_FILES.has(r.label_file_id.toUpperCase()));
@@ -495,7 +501,11 @@ export async function createLabelTool(request: CallToolRequest, context: XppServ
         ];
         for (const r of existing) {
           const flag = MICROSOFT_LABEL_FILES.has(r.label_file_id.toUpperCase()) ? ' ← Microsoft standard' : '';
-          lines.push(`  @${r.label_file_id}:${labelId}  [${r.model}]  "${r.text}"${flag}`);
+          // formatLabelReference, not `@file:id` — a legacy row's id already
+          // carries its file id and the doubled form is what xppbp rejects.
+          lines.push(
+            `  ${formatLabelReference(r.label_file_id, r.label_id)}  [${r.model}]  "${r.text}"${flag}`,
+          );
         }
         if (msCollisions.length > 0) {
           lines.push('');

--- a/src/tools/write/resolveReferences.ts
+++ b/src/tools/write/resolveReferences.ts
@@ -671,7 +671,13 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
         });
       }
     } else if (legacy) {
-      if (deps.getLabelById(legacy[1]).length > 0) {
+      // The whole literal, not the capture group (#888). The regex strips the
+      // '@' that the 27 legacy label files store as part of the key, so looking
+      // up `SYS12345` against an index holding `@SYS12345` could never hit and
+      // EVERY legacy label in X++ drew an unknown-label warning during write
+      // validation. getLabelById accepts either spelling; passing the literal
+      // keeps this branch honest even if that ever narrows again.
+      if (deps.getLabelById(s.value).length > 0) {
         verifiedCount++;
       } else {
         violations.push({

--- a/src/utils/labelReference.ts
+++ b/src/utils/labelReference.ts
@@ -47,6 +47,61 @@ export function formatLabelReference(labelFileId: string | undefined, labelId: s
 }
 
 /**
+ * Inverse of {@link formatLabelReference}: a reference (or a bare id) → the
+ * parts a lookup needs.
+ *
+ *   '@ContosoExt:EquipmentName' → { labelFileId: 'ContosoExt', labelId: 'EquipmentName' }
+ *   '@GLS4170035'               → { labelId: 'GLS4170035' }
+ *   'GLS4170035'                → { labelId: 'GLS4170035' }
+ *   '@SYS:@SYS67433'            → { labelFileId: 'SYS', labelId: '@SYS67433' }
+ *
+ * The `@` is dropped from the legacy form on purpose: which spelling the index
+ * holds depends on the file, so callers pair this with
+ * {@link labelIdSpellings} rather than assuming either one.
+ */
+export function parseLabelReference(ref: string): { labelFileId?: string; labelId: string } {
+  const s = (ref ?? '').trim();
+  if (!s) return { labelId: '' };
+
+  // `@File:Id`, including the doubled `@SYS:@SYS67433` the formatter repairs —
+  // there the id half keeps its own '@' because that IS the stored id.
+  const modern = /^@([A-Za-z][A-Za-z0-9_]*):(.+)$/.exec(s);
+  if (modern) return { labelFileId: modern[1], labelId: modern[2] };
+
+  return { labelId: s.startsWith('@') ? s.slice(1) : s };
+}
+
+/** A legacy AX-era id: 2-4 letters naming the label file, then digits. */
+const LEGACY_LABEL_ID = /^[A-Za-z]{2,4}\d+$/;
+
+/**
+ * Every spelling of a label id the index may hold, for one lookup.
+ *
+ * #888: `labelParser` stores the `Key=` token verbatim, and the 27 legacy AX-era
+ * label files (SYS SYP GLS … WAX — 865k of the 1.42M indexed rows on the
+ * reference environment) write theirs WITH the sigil: `@GLS4170035=Accountants`.
+ * Modern files write `EquipmentName=`. A lookup that matches one spelling
+ * therefore misses whichever set it did not guess, which is why
+ * `labels(action="info", labelId="GLS4170035")` reported "not found" for a label
+ * it had just listed the file of.
+ *
+ * Uppercasing is applied to the legacy shape only. Every key in the 27 files is
+ * all-uppercase (verified across them), so `@sys67433` is recoverable for free;
+ * a modern id's casing is the author's and is left alone.
+ */
+export function labelIdSpellings(labelId: string): string[] {
+  const id = (labelId ?? '').trim();
+  if (!id) return [];
+
+  const out = [id, `@${id}`];
+  if (LEGACY_LABEL_ID.test(id)) {
+    const upper = id.toUpperCase();
+    if (upper !== id) out.push(upper, `@${upper}`);
+  }
+  return [...new Set(out)];
+}
+
+/**
  * Label files that every model can resolve without adding a package reference.
  * Deliberately small and conservative — anything else gets flagged rather than
  * silently recommended.

--- a/tests/tools/label-id-spellings.test.ts
+++ b/tests/tools/label-id-spellings.test.ts
@@ -1,0 +1,238 @@
+/**
+ * #888 — label ids were matched against the stored `Key=` token verbatim.
+ *
+ * `labelParser` stores that token as the file writes it, and the 27 legacy
+ * AX-era label files (SYS SYP GLS GEE … WAX) write theirs WITH the sigil:
+ * `@GLS4170035=Accountants`. On the reference environment that is 865k of the
+ * 1.42M indexed rows, so:
+ *   - `labels(action="info", labelId="GLS4170035")` reported "not found" for a
+ *     label whose file it had just listed, and the message read as a claim
+ *     about the label rather than about the key match;
+ *   - `search` output — always a reference — was never valid `info` input;
+ *   - `resolveXppReferences` looked up the regex capture group (`SYS12345`)
+ *     against an index holding `@SYS12345`, so EVERY legacy label in X++ drew
+ *     an unknown-label warning during write validation;
+ *   - `<Label>@SYSnnnnn</Label>` in metadata XML matched no branch at all and
+ *     went unverified.
+ *
+ * These run against a real XppSymbolIndex whose rows are inserted exactly as
+ * the parser writes them — a mock that stores the bare id is what hid the
+ * resolver bug in the first place.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import {
+  formatLabelReference,
+  labelIdSpellings,
+  parseLabelReference,
+} from '../../src/utils/labelReference';
+import { getLabelInfoTool } from '../../src/tools/readers/getLabelInfo';
+import { resolveXppReferences } from '../../src/tools/write/resolveReferences';
+import { validateCodeTool } from '../../src/tools/analysis/validateCode';
+
+let index: XppSymbolIndex;
+let tmpDir: string;
+let glsPath: string;
+
+beforeAll(async () => {
+  index = new XppSymbolIndex(':memory:', ':memory:');
+
+  // A real .label.txt for the legacy file, so the on-disk staleness check has
+  // something to read (it is the half that the naive fix breaks).
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'labels-888-'));
+  glsPath = path.join(tmpDir, 'GLS.en-us.label.txt');
+  await fs.writeFile(glsPath, '﻿@GLS0=GLS label file.\n@GLS4170035=Accountants\n', 'utf-8');
+
+  // Legacy files: key stored WITH '@'.
+  index.addLabel({
+    labelId: '@GLS4170035', labelFileId: 'GLS', model: 'ApplicationPlatform',
+    language: 'en-US', text: 'Accountants', filePath: glsPath,
+  });
+  index.addLabel({
+    labelId: '@SYS12345', labelFileId: 'SYS', model: 'ApplicationPlatform',
+    language: 'en-US', text: 'Customer', filePath: path.join(tmpDir, 'SYS.en-us.label.txt'),
+  });
+  // Modern file: bare key.
+  index.addLabel({
+    labelId: 'EquipmentName', labelFileId: 'ContosoExt', model: 'ContosoExt',
+    language: 'en-US', text: 'Equipment name', filePath: path.join(tmpDir, 'ContosoExt.en-US.label.txt'),
+  });
+});
+
+afterAll(async () => {
+  index?.close?.();
+  if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ── the helper pair ──────────────────────────────────────────────────────────
+
+describe('parseLabelReference — inverse of formatLabelReference', () => {
+  it('splits the modern reference', () => {
+    expect(parseLabelReference('@ContosoExt:EquipmentName'))
+      .toEqual({ labelFileId: 'ContosoExt', labelId: 'EquipmentName' });
+  });
+
+  it('drops the sigil from the legacy form, naming no file', () => {
+    expect(parseLabelReference('@GLS4170035')).toEqual({ labelId: 'GLS4170035' });
+    expect(parseLabelReference('GLS4170035')).toEqual({ labelId: 'GLS4170035' });
+  });
+
+  it('keeps the id half of the doubled form the formatter repairs', () => {
+    expect(parseLabelReference('@SYS:@SYS67433'))
+      .toEqual({ labelFileId: 'SYS', labelId: '@SYS67433' });
+  });
+
+  it('round-trips whatever formatLabelReference emitted', () => {
+    for (const [file, id] of [['GLS', '@GLS4170035'], ['ContosoExt', 'EquipmentName']] as const) {
+      const parsed = parseLabelReference(formatLabelReference(file, id));
+      expect(labelIdSpellings(parsed.labelId)).toContain(id);
+    }
+  });
+});
+
+describe('labelIdSpellings', () => {
+  it('offers both storage spellings', () => {
+    expect(labelIdSpellings('EquipmentName')).toEqual(['EquipmentName', '@EquipmentName']);
+  });
+
+  it('adds the upper-cased legacy form — every key in the 27 files is uppercase', () => {
+    expect(labelIdSpellings('sys67433')).toContain('@SYS67433');
+  });
+
+  it('leaves a modern id\'s casing alone — it is the author\'s', () => {
+    expect(labelIdSpellings('equipmentname')).not.toContain('EquipmentName');
+  });
+});
+
+// ── the lookup ───────────────────────────────────────────────────────────────
+
+describe('getLabelById accepts every spelling the server emits', () => {
+  const ids = (id: string, file?: string, model?: string) =>
+    index.getLabelById(id, file, model).map(r => r.labelId);
+
+  it('bare legacy id, with the file+model filters that used to make it fail', () => {
+    expect(ids('GLS4170035', 'GLS', 'ApplicationPlatform')).toEqual(['@GLS4170035']);
+  });
+
+  it('legacy id with sigil, and the @File:Id spelling of the same label', () => {
+    expect(ids('@GLS4170035')).toEqual(['@GLS4170035']);
+    expect(ids('@GLS:GLS4170035')).toEqual(['@GLS4170035']);
+  });
+
+  it('modern label by bare id and by reference — the form search prints', () => {
+    expect(ids('EquipmentName')).toEqual(['EquipmentName']);
+    expect(ids('@ContosoExt:EquipmentName')).toEqual(['EquipmentName']);
+    expect(ids('@ContosoExt:EquipmentName', 'ContosoExt')).toEqual(['EquipmentName']);
+  });
+
+  it('legacy lookup is case-insensitive', () => {
+    expect(ids('@sys12345')).toEqual(['@SYS12345']);
+  });
+
+  it('a contradicting file filter still narrows to nothing', () => {
+    expect(ids('@ContosoExt:EquipmentName', 'SYS')).toEqual([]);
+    expect(ids('GLS4170035', 'SYS')).toEqual([]);
+  });
+
+  it('returns the id EXACTLY as stored, not as asked', () => {
+    expect(index.getLabelById('gls4170035')[0].labelId).toBe('@GLS4170035');
+  });
+});
+
+// ── the tool ─────────────────────────────────────────────────────────────────
+
+const info = (args: Record<string, unknown>) =>
+  getLabelInfoTool(
+    { method: 'tools/call', params: { name: 'get_label_info', arguments: args } } as any,
+    { symbolIndex: index } as any,
+  );
+const textOf = (r: any) => r.content[0].text as string;
+
+describe('labels(action="info") — the reported matrix', () => {
+  it('resolves the bare legacy id with file+model supplied (the reported failure)', async () => {
+    const r = await info({ labelId: 'GLS4170035', labelFileId: 'GLS', model: 'ApplicationPlatform' });
+    expect(r.isError).toBeUndefined();
+    expect(textOf(r)).toContain('Accountants');
+  });
+
+  it('resolves the @File:Id form', async () => {
+    const r = await info({ labelId: '@ContosoExt:EquipmentName', labelFileId: 'ContosoExt' });
+    expect(r.isError).toBeUndefined();
+    expect(textOf(r)).toContain('Equipment name');
+  });
+
+  it('emits the canonical reference for a legacy label — never the doubled form', async () => {
+    const text = textOf(await info({ labelId: 'GLS4170035' }));
+    expect(text).toContain('@GLS4170035');
+    expect(text).not.toContain(':@');
+  });
+
+  it('does not report a legacy label as missing from its file on disk', async () => {
+    // The trap: the disk check must probe the STORED key. Probing the bare id
+    // the lookup now accepts would condemn every label in the 27 legacy files.
+    const text = textOf(await info({ labelId: 'GLS4170035' }));
+    expect(text).not.toContain('NOT in its label file on disk');
+  });
+
+  it('says the KEY did not match, and does not assert the label is absent', async () => {
+    const r = await info({ labelId: 'NoSuchLabel' });
+    expect(r.isError).toBe(true);
+    const text = textOf(r);
+    expect(text).toContain('No label matched the ID');
+    expect(text).not.toContain('not found in label file');
+    // The remediation must work from an ID, which is all the caller has.
+    expect(text).toContain('labels(action="search", query="NoSuchLabel")');
+  });
+});
+
+// ── the write-validation path ────────────────────────────────────────────────
+
+describe('resolveXppReferences — legacy labels in X++', () => {
+  const deps = () => ({
+    db: index.getReadDb(),
+    getLabelById: index.getLabelById.bind(index),
+    getLabelFileIds: index.getLabelFileIds.bind(index),
+  }) as any;
+
+  it('does not warn about a legacy label that IS in the index', () => {
+    const res = resolveXppReferences('info("@SYS12345");', deps());
+    expect(res.violations).toEqual([]);
+    expect(res.verifiedCount).toBeGreaterThan(0);
+  });
+
+  it('still warns about one that is not', () => {
+    const res = resolveXppReferences('info("@SYS99999");', deps());
+    expect(res.violations.map(v => v.kind)).toEqual(['unknown-label']);
+  });
+
+  it('verifies the modern reference too', () => {
+    expect(resolveXppReferences('info("@ContosoExt:EquipmentName");', deps()).violations).toEqual([]);
+  });
+});
+
+describe('validate_code references mode — <Label> coverage', () => {
+  // Built per call, not at describe time: the index only exists after beforeAll,
+  // and resolveXmlReferences answers "0 verified" for a context without one —
+  // which reads exactly like a clean result.
+  const validate = (xml: string) =>
+    validateCodeTool(
+      { params: { arguments: { mode: 'references', codeType: 'xml-table', code: xml } } } as any,
+      { symbolIndex: index } as any,
+    );
+  const xmlWith = (label: string) =>
+    `<?xml version="1.0"?><AxTable><Name>MyTable</Name><Label>${label}</Label></AxTable>`;
+
+  it('flags a legacy label that is not in the index (was skipped entirely)', async () => {
+    const text = textOf(await validate(xmlWith('@SYS99999')));
+    expect(text).toContain('@SYS99999');
+  });
+
+  it('accepts a legacy label that is', async () => {
+    const text = textOf(await validate(xmlWith('@SYS12345')));
+    expect(text).not.toContain('@SYS12345 not found');
+  });
+});

--- a/tests/tools/resolve-references.test.ts
+++ b/tests/tools/resolve-references.test.ts
@@ -14,6 +14,7 @@ import {
   type ResolverDeps,
 } from '../../src/tools/write/resolveReferences';
 import { validateCodeTool } from '../../src/tools/analysis/validateCode';
+import { labelIdSpellings, parseLabelReference } from '../../src/utils/labelReference';
 
 const ORIGINAL_ENFORCE = process.env.GROUNDING_ENFORCE;
 
@@ -22,18 +23,30 @@ let db: ResolverDeps['db'];
 let deps: ResolverDeps;
 
 const LABELS: Record<string, string[]> = {
-  // labelFileId → known label ids
-  SYS: ['SYS12345'],
+  // labelFileId → known label ids, stored the way labelParser writes them: the
+  // `Key=` token verbatim. The 27 legacy AX-era files keep their sigil
+  // (`@SYS12345=…`), modern ones do not. This mock used to hold a bare
+  // 'SYS12345' — the opposite of the real index — and that is the only reason
+  // the legacy-label test passed while every `@SYSnnnnn` in real X++ drew an
+  // unknown-label warning (#888).
+  SYS: ['@SYS12345'],
   Contoso: ['MyLabel'],
 };
 
 function makeDeps(database: ResolverDeps['db']): ResolverDeps {
   return {
     db: database,
+    // Mirrors symbolIndex.getLabelById: the caller's spelling is normalised, the
+    // STORED id comes back.
     getLabelById: (labelId: string, labelFileId?: string) => {
+      const parsed = parseLabelReference(labelId);
+      const spellings = labelIdSpellings(parsed.labelId);
+      const file = labelFileId ?? parsed.labelFileId;
       const hit = (fileId: string) =>
-        (LABELS[fileId] ?? []).includes(labelId) ? [{ labelId, labelFileId: fileId }] : [];
-      if (labelFileId) return hit(labelFileId);
+        (LABELS[fileId] ?? [])
+          .filter(stored => spellings.includes(stored))
+          .map(stored => ({ labelId: stored, labelFileId: fileId }));
+      if (file) return hit(file);
       return Object.keys(LABELS).flatMap(hit);
     },
     getLabelFileIds: () => Object.keys(LABELS).map(labelFileId => ({ labelFileId })),


### PR DESCRIPTION
Fixes #888 — audited claim by claim against `main` @ `ec0da4a`; all five reported bugs reproduced, plus two more with the same root cause.

## The root cause

`labelParser` stores the `Key=` token verbatim. The 27 legacy AX-era label files write theirs **with** the sigil (`@GLS4170035=Accountants`); modern files do not. Every lookup compared the caller's string to the stored one with `=`, and nothing normalised in between.

Measured on the reference environment: **865k of 1.42M indexed rows** are the `@`-prefixed kind — 61% of the index, including `SYS`. Counted independently on a third box: 27 of 813 `en-US` files, the exact set the issue lists, and all of their keys are uppercase.

## What changed

| Fix | Where |
|---|---|
| `parseLabelReference()` — the inverse `formatLabelReference()` never had — plus `labelIdSpellings()` | `src/utils/labelReference.ts` |
| `getLabelById` accepts bare / legacy / `@File:Id` / doubled; a `@File:Id` input supplies its own file filter | `src/metadata/symbolIndex.ts` |
| Legacy branch looks up the whole literal, not the `@`-stripped capture group | `src/tools/write/resolveReferences.ts` |
| `<Label>@SYSnnnnn</Label>` is checked instead of falling through | `src/tools/analysis/validateCode.ts` |
| Reference, disk check and create-hint all use the **stored** id; not-found message rewritten | `src/tools/readers/getLabelInfo.ts` |
| `formatLabelReference` instead of hand-built `@file:id` (was re-creating the doubled `@GLS:@GLS4170035` from #33/#41) | `src/tools/prepare/prepareCreate.ts`, `src/tools/write/createLabel.ts` |
| Collision check matches both spellings — it could never fire for SYS/GLS/RET/… before | `src/tools/write/createLabel.ts` |
| Accepted spellings documented | `src/server/toolSchemas/labels.ts` |

**Bug 2 is fixed at the input side, not the output.** Every form `search` prints is now valid `info` input, so no raw key is added to each result row — #832 trimmed that output deliberately.

## Two measurements that changed the plan

**The IN-list keeps the index** (on the real 1.2 GB labels DB):

```
WHERE label_id IN (?, ?)                              → SEARCH labels USING INDEX idx_labels_id
WHERE label_id IN (?,?,?,?) AND label_file_id=? AND model=?  → SEARCH labels USING INDEX idx_labels_unique
```

**`COLLATE NOCASE` was measured and rejected** as the issue suggested writing it:

```
WHERE label_id = ? COLLATE NOCASE                     → SCAN labels          (1.42M rows, no NOCASE index)
WHERE (label_id = ? COLLATE NOCASE OR label_id = ('@' || ?) COLLATE NOCASE)
   'sys67433'      → []      ← silently case-SENSITIVE; planner takes the binary index
   '@SYS67433'     → hit
```

Case-insensitivity ships instead as an uppercase spelling for the legacy shape only — free, no new index on a 1.2 GB DB, and it covers exactly the set whose keys are uppercase by construction. A modern id's casing is the author's and is left alone.

## The trap the issue flagged

`labelMissingOnDisk()` greps the file for `^id=`, so it must keep receiving the **stored** id. Verified against the real 10 MB `GLS.en-US.label.txt`:

```
labelMissingOnDisk('@GLS4170035', [GLS]) → false   (declared)
labelMissingOnDisk('GLS4170035',  [GLS]) → true    (would condemn all 27 files)
```

`getLabelInfo` passed the **caller's** spelling there, not `rows[0].labelId`, so the trap would have sprung from the query change alone. It now passes `first.labelId`.

## Tests

`tests/tools/label-id-spellings.test.ts` — 23 cases against a **real** `XppSymbolIndex` with rows inserted exactly as the parser writes them, plus a real `.label.txt` on disk for the staleness check. **18 of the 23 fail on `main`.**

`tests/tools/resolve-references.test.ts` — the mock now stores `@SYS12345`, matching the real index. It held `SYS12345`, and that alone is why `'verifies existing modern and legacy labels'` passed while the resolver warned on every legacy label in production.

Full suite: **3563 passed**. Two failures on the run, both handled:
- `toolSchemaBudget` — my schema text pushed the ListTools payload 95 chars over the 50 700 ceiling; description trimmed, now 50 66x and green.
- `apiSymbols` live gate — timed out at 120 s under parallel load against the 2.3 GB symbols DB. Pre-existing environment flake: identical result on a stashed clean tree, and this PR touches neither the symbols DB nor the knowledge base.

## Not changed

`renameLabelInIndex` matches verbatim on purpose — it rewrites the on-disk key, so the caller's spelling has to be the file's, and renaming a shipped Microsoft label is not a real workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
