### PR TITLE
Make label indexing 2x faster and the labels DB 2x smaller

### DIFF
--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -333,14 +333,37 @@ async function buildDatabase() {
         }
         // else: no filter — index all models
 
-        for (const rootPath of validRoots) {
-          const { totalLabels, modelsIndexed } = await indexAllLabels(
-            symbolIndex,
-            rootPath,
-            labelModelFilter,
-          );
-          grandTotalLabels += totalLabels;
-          grandTotalModels += modelsIndexed;
+        // Bulk load with only the UNIQUE index live — see dropLabelSecondaryIndexes().
+        // Deferred across ALL roots, not per root, so the CREATE INDEX pass runs once.
+        const droppedIndexes = symbolIndex.dropLabelSecondaryIndexes();
+        let ftsPending = false;
+        let indexMs = 0;
+        try {
+          for (const rootPath of validRoots) {
+            // skipFtsRebuild: the rebuild reads every label row in the database, so
+            // running it inside this loop would repeat that whole pass per root.
+            const { totalLabels, modelsIndexed, ftsRebuildPending } = await indexAllLabels(
+              symbolIndex,
+              rootPath,
+              labelModelFilter,
+              { skipFtsRebuild: true },
+            );
+            grandTotalLabels += totalLabels;
+            grandTotalModels += modelsIndexed;
+            ftsPending ||= ftsRebuildPending;
+          }
+        } finally {
+          // finally, not the happy path only: a database left without its label
+          // indexes answers every later lookup with a full-table scan, and nothing
+          // recreates them until the next successful build.
+          indexMs = symbolIndex.createLabelSecondaryIndexes(droppedIndexes);
+        }
+        log.detail(`Label indexes rebuilt in ${(indexMs / 1000).toFixed(2)}s`);
+
+        if (ftsPending) {
+          const ftsStart = Date.now();
+          symbolIndex.rebuildLabelsFts();
+          log.detail(`Labels FTS rebuilt in ${((Date.now() - ftsStart) / 1000).toFixed(2)}s`);
         }
       }
 

--- a/scripts/build-fts.ts
+++ b/scripts/build-fts.ts
@@ -104,14 +104,41 @@ async function buildFts(): Promise<void> {
       }
       // else: no filter — index all models
 
-      const { totalLabels, modelsIndexed } = await indexAllLabels(
-        symbolIndex,
-        PACKAGES_PATH,
-        labelModelFilter,
-      );
+      // Bulk load with only the UNIQUE index live; the read accelerators are rebuilt
+      // below. Cheaper as one CREATE INDEX per index over the finished table than as
+      // eight B-tree updates on every one of ~500 K inserts.
+      const droppedIndexes = symbolIndex.dropLabelSecondaryIndexes();
+
+      let totalLabels = 0;
+      let modelsIndexed = 0;
+      let ftsPending = false;
+      let indexMs = 0;
+      try {
+        ({ totalLabels, modelsIndexed, ftsRebuildPending: ftsPending } = await indexAllLabels(
+          symbolIndex,
+          PACKAGES_PATH,
+          labelModelFilter,
+          { skipFtsRebuild: true },
+        ));
+      } finally {
+        // finally, not the happy path only: leaving the database without its label
+        // indexes turns every later label lookup into a full-table scan, and nothing
+        // would recreate them until the next successful build.
+        indexMs = symbolIndex.createLabelSecondaryIndexes(droppedIndexes);
+      }
+
+      const insertDuration = ((Date.now() - labelStart) / 1000).toFixed(2);
+      console.log(`   ✅ ${totalLabels} label entries indexed across ${modelsIndexed} models in ${insertDuration}s`);
+      console.log(`   🔑 Label indexes rebuilt in ${(indexMs / 1000).toFixed(2)}s`);
+
+      if (ftsPending) {
+        const ftsStart = Date.now();
+        symbolIndex.rebuildLabelsFts();
+        console.log(`   🔍 Labels FTS rebuilt in ${((Date.now() - ftsStart) / 1000).toFixed(2)}s`);
+      }
 
       const labelDuration = ((Date.now() - labelStart) / 1000).toFixed(2);
-      console.log(`   ✅ ${totalLabels} label entries indexed across ${modelsIndexed} models in ${labelDuration}s`);
+      console.log(`   ⏱️  Label phase total: ${labelDuration}s`);
 
       const labelCount = symbolIndex.getLabelCount();
       console.log(`   📊 Total labels in database: ${labelCount}`);

--- a/src/metadata/labelParser.ts
+++ b/src/metadata/labelParser.ts
@@ -16,6 +16,7 @@ import * as fs from 'fs/promises';
 import * as fsSync from 'fs';
 import * as path from 'path';
 import { settingByEnv } from '../config/settings.js';
+import { defaultFileConcurrency, mapWithConcurrency } from '../utils/concurrency.js';
 import type { XppSymbolIndex } from './symbolIndex.js';
 
 /**
@@ -200,15 +201,27 @@ async function indexModelLabels(
 
   const allEntries: Parameters<XppSymbolIndex['bulkAddLabels']>[0] = [];
 
-  for (const { labelFileId, language, filePath } of labelFiles) {
-    let content: string;
-    try {
-      content = await fs.readFile(filePath, 'utf-8');
-    } catch {
-      continue;
-    }
+  // Read the model's label files with a bounded number in flight rather than one at
+  // a time. Barely matters on a default en-US build (813 files / ~38 MB across the
+  // whole PackagesLocalDirectory), but LABEL_LANGUAGES=all multiplies that by the ~74
+  // shipped locales — ~60 K files and a few GB — and a serial await per file makes
+  // that phase cost the sum of every read's latency. mapWithConcurrency preserves
+  // input order, so the rows still go in deterministically.
+  const perFile = await mapWithConcurrency(
+    labelFiles,
+    defaultFileConcurrency(),
+    async ({ labelFileId, language, filePath }) => {
+      let content: string;
+      try {
+        content = await fs.readFile(filePath, 'utf-8');
+      } catch {
+        return [];
+      }
+      return parseLabelFile(content, labelFileId, model, language, filePath);
+    },
+  );
 
-    const labels = parseLabelFile(content, labelFileId, model, language, filePath);
+  for (const labels of perFile) {
     for (const lbl of labels) {
       allEntries.push({
         labelId: lbl.labelId,
@@ -237,8 +250,8 @@ export async function indexAllLabels(
   symbolIndex: XppSymbolIndex,
   packagesPath: string,
   modelFilter?: (modelName: string) => boolean,
-  opts?: { ftsStrategy?: 'rebuild' | 'incremental' },
-): Promise<{ totalLabels: number; modelsIndexed: number }> {
+  opts?: { ftsStrategy?: 'rebuild' | 'incremental'; skipFtsRebuild?: boolean },
+): Promise<{ totalLabels: number; modelsIndexed: number; ftsRebuildPending: boolean }> {
   // 'incremental' keeps the labels_fts triggers live so only the scanned models' labels are
   // tokenised, instead of re-inserting every label in the database afterwards. Only
   // worth it when modelFilter narrows the scan to a small set (a custom-model build).
@@ -253,7 +266,7 @@ export async function indexAllLabels(
     models = entries.filter(e => e.isDirectory() || e.isSymbolicLink()).map(e => e.name);
   } catch {
     console.error(`[LabelParser] Cannot read packages path: ${packagesPath}`);
-    return { totalLabels, modelsIndexed };
+    return { totalLabels, modelsIndexed, ftsRebuildPending: false };
   }
 
   let skippedByFilter = 0;
@@ -321,9 +334,13 @@ export async function indexAllLabels(
     }
   }
 
-  // Rebuild FTS once for all models rather than per-model (avoids O(n^2) rebuild cost).
-  // Skipped under 'incremental': the triggers already kept labels_fts in sync per row.
-  if (totalLabels > 0 && !incrementalFts) {
+  // The rebuild is O(every label in the database) no matter how narrow this scan was,
+  // so a caller looping over several package roots must not pay it once per root —
+  // `skipFtsRebuild` lets it hoist the single rebuild out of its own loop and run it
+  // when `ftsRebuildPending` comes back true. Skipped under 'incremental' regardless:
+  // the triggers already kept labels_fts in sync per row.
+  const ftsRebuildPending = totalLabels > 0 && !incrementalFts;
+  if (ftsRebuildPending && !opts?.skipFtsRebuild) {
     symbolIndex.rebuildLabelsFts();
   }
 
@@ -335,5 +352,9 @@ export async function indexAllLabels(
     console.log(`      - Total models found: ${models.length}`);
   }
 
-  return { totalLabels, modelsIndexed };
+  return {
+    totalLabels,
+    modelsIndexed,
+    ftsRebuildPending: ftsRebuildPending && !!opts?.skipFtsRebuild,
+  };
 }

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -405,6 +405,25 @@ export class XppSymbolIndex {
     `);
 
     // Labels live in the separate labelsDb (keeps the main symbol DB fast for search).
+    //
+    // file_path is a foreign key, not a string. Every label in a .label.txt shares
+    // one ~130-character absolute path, so storing it inline repeated it per row and
+    // then indexed it twice (BINARY + NOCASE) — 813 distinct paths carried across
+    // 374 K rows on a default en-US build. Measured: 310 MB inline versus 130 MB
+    // through label_files, and the CREATE INDEX pass over the loaded table drops
+    // from 4.0 s to 1.4 s. See migrateLabelPathsToLabelFiles().
+    this.labelsDb.exec(`
+      CREATE TABLE IF NOT EXISTS label_files (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        file_path TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_label_files_path ON label_files(file_path);
+      -- removeLabelsByFile compares COLLATE NOCASE (Windows paths differ only in case
+      -- between the indexer and a tool argument), and SQLite only uses an index whose
+      -- collation matches the comparison.
+      CREATE INDEX IF NOT EXISTS idx_label_files_path_nocase
+        ON label_files(file_path COLLATE NOCASE);
+    `);
     this.labelsDb.exec(`
       CREATE TABLE IF NOT EXISTS labels (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -414,7 +433,7 @@ export class XppSymbolIndex {
         language TEXT NOT NULL,
         text TEXT NOT NULL,
         comment TEXT,
-        file_path TEXT NOT NULL
+        file_path_id INTEGER NOT NULL
       );
     `);
 
@@ -442,7 +461,11 @@ export class XppSymbolIndex {
     `);
 
     this.createLabelsFtsTriggers();
-    this.migrateLabelsFtsLanguageCoverage();
+    // Ascending order, and it matters: both migrations advance the same
+    // PRAGMA user_version counter, so a later one running first would stamp its own
+    // number over a step that had not happened yet and skip it forever.
+    this.migrateLabelsFtsLanguageCoverage();  // user_version 0 -> 1
+    this.migrateLabelPathsToLabelFiles();     // user_version 1 -> 2
 
     // Extended metadata tables for smart generation
 
@@ -746,28 +769,28 @@ export class XppSymbolIndex {
     { name: 'idx_labels_id', sql: 'CREATE INDEX IF NOT EXISTS idx_labels_id ON labels(label_id);' },
     { name: 'idx_labels_file_id', sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_id ON labels(label_file_id);' },
     { name: 'idx_labels_model', sql: 'CREATE INDEX IF NOT EXISTS idx_labels_model ON labels(model);' },
-    { name: 'idx_labels_language', sql: 'CREATE INDEX IF NOT EXISTS idx_labels_language ON labels(language);' },
     // Every language comparison in this file is LOWER(language) = LOWER(?), because
     // Microsoft packages unzipped on Linux store 'en-us' while custom packages write
     // 'en-US'. A plain index on language cannot serve that predicate, so the LIKE
     // fallback degraded to a scan of all four locales instead of one.
+    //
+    // There is deliberately no plain idx_labels_language beside it: no query in this
+    // file compares language for equality — the three that mention it at all only
+    // ORDER BY / GROUP_CONCAT it, after filtering on label_id or label_file_id — so
+    // it was a B-tree maintained on every insert and read by nothing.
     {
       name: 'idx_labels_language_lower',
       sql: 'CREATE INDEX IF NOT EXISTS idx_labels_language_lower ON labels(LOWER(language));',
     },
     {
-      name: 'idx_labels_file_path',
-      sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path ON labels(file_path);',
-    },
-    {
-      name: 'idx_labels_file_path_nocase',
-      sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path_nocase ON labels(file_path COLLATE NOCASE);',
+      name: 'idx_labels_file_path_id',
+      sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path_id ON labels(file_path_id);',
     },
   ];
 
-  /** The subset created at schema-init time; the file_path pair is left to ensureFilePathIndexes(). */
+  /** The subset created at schema-init time; the file_path_id index is left to ensureFilePathIndexes(). */
   private static readonly LABEL_SECONDARY_INDEX_SQL = XppSymbolIndex.LABEL_SECONDARY_INDEXES
-    .filter(i => !i.name.startsWith('idx_labels_file_path'))
+    .filter(i => i.name !== 'idx_labels_file_path_id')
     .map(i => i.sql)
     .join('\n');
 
@@ -858,12 +881,12 @@ export class XppSymbolIndex {
         sql: 'CREATE INDEX IF NOT EXISTS idx_symbols_file_path ON symbols(file_path);',
       });
     }
-    if (missing(this.labelsDb, 'idx_labels_file_path')) {
+    if (missing(this.labelsDb, 'idx_labels_file_path_id')) {
       work.push({
         db: this.labelsDb,
         dbFile: labelsPath,
-        name: 'idx_labels_file_path',
-        sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path ON labels(file_path);',
+        name: 'idx_labels_file_path_id',
+        sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path_id ON labels(file_path_id);',
       });
     }
     // NOCASE twins. removeSymbolsByFile/removeLabelsByFile compare COLLATE NOCASE
@@ -879,14 +902,10 @@ export class XppSymbolIndex {
         sql: 'CREATE INDEX IF NOT EXISTS idx_symbols_file_path_nocase ON symbols(file_path COLLATE NOCASE);',
       });
     }
-    if (missing(this.labelsDb, 'idx_labels_file_path_nocase')) {
-      work.push({
-        db: this.labelsDb,
-        dbFile: labelsPath,
-        name: 'idx_labels_file_path_nocase',
-        sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path_nocase ON labels(file_path COLLATE NOCASE);',
-      });
-    }
+    // No labels NOCASE twin any more: the case-insensitive path comparison moved to
+    // label_files, whose two indexes are created with the table — it holds one row per
+    // .label.txt (813 on a default build), so building them is instant and needs
+    // neither the deferral nor the worker dispatch the per-label table needed.
 
     for (const item of work) {
       if (isLarge(item.dbFile)) {
@@ -1018,11 +1037,126 @@ export class XppSymbolIndex {
    * on every database that predates this, so the one-time rebuild is self-triggering
    * and costs nothing on an already-migrated file.
    */
+  /**
+   * Move an existing database from the inline `labels.file_path` column to the
+   * `label_files` lookup table.
+   *
+   * Runs once, gated on `PRAGMA user_version` like the FTS coverage migration below.
+   * A database built before this carries the path spelled out on every row; the
+   * column cannot simply be dropped, because the rows have to be rewritten to point
+   * at the extracted paths instead.
+   *
+   * This is a full table rewrite, so it is minutes on a multi-GB labels database
+   * rather than the ~23 s the FTS migration costs — announced up front for the same
+   * reason: a silent stall of that length reads as a hung server. It is worth paying
+   * once. The rewritten table is less than half the size, and every full-table
+   * operation on it afterwards (FTS rebuild, ANALYZE, VACUUM, any cold-cache scan)
+   * moves proportionally less disk.
+   *
+   * Row ids are carried over deliberately: `labels_fts` is an external-content index
+   * keyed on `labels.id`, so preserving them keeps it valid. It is rebuilt at the end
+   * anyway, because the content table it points at is a different table object by then.
+   */
+  private migrateLabelPathsToLabelFiles(): void {
+    const LABEL_FILES_NORMALISED = 2;
+    try {
+      const version = Number(this.labelsDb.pragma('user_version', { simple: true }) ?? 0);
+      if (version >= LABEL_FILES_NORMALISED) return;
+
+      // A database that never had the old column (a fresh build, :memory:, the test
+      // suite) only needs the version stamp.
+      const columns = this.labelsDb.pragma('table_info(labels)') as Array<{ name: string }>;
+      if (!columns.some(c => c.name === 'file_path')) {
+        this.labelsDb.pragma(`user_version = ${LABEL_FILES_NORMALISED}`);
+        return;
+      }
+
+      const { n } = this.labelsDb.prepare('SELECT COUNT(*) AS n FROM labels').get() as { n: number };
+      if (n > 0) {
+        log.detail(
+          `Normalising ${n.toLocaleString('en-US')} label file paths into label_files ` +
+            `(one-off; several minutes on a multi-GB labels database)…`,
+        );
+      }
+
+      // Triggers first: they reference the table about to be dropped, and the rewrite
+      // must not fire per-row FTS maintenance for rows that are only moving house.
+      this.labelsDb.exec(`
+        DROP TRIGGER IF EXISTS labels_ai;
+        DROP TRIGGER IF EXISTS labels_ad;
+        DROP TRIGGER IF EXISTS labels_au;
+      `);
+
+      this.labelsDb.exec('BEGIN');
+      try {
+        this.labelsDb.exec(`
+          INSERT OR IGNORE INTO label_files (file_path) SELECT DISTINCT file_path FROM labels;
+
+          CREATE TABLE labels_migrated (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label_id TEXT NOT NULL,
+            label_file_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            language TEXT NOT NULL,
+            text TEXT NOT NULL,
+            comment TEXT,
+            file_path_id INTEGER NOT NULL
+          );
+
+          INSERT INTO labels_migrated (id, label_id, label_file_id, model, language, text, comment, file_path_id)
+            SELECT l.id, l.label_id, l.label_file_id, l.model, l.language, l.text, l.comment, lf.id
+            FROM labels l
+            JOIN label_files lf ON lf.file_path = l.file_path;
+
+          DROP TABLE labels;
+          ALTER TABLE labels_migrated RENAME TO labels;
+        `);
+        this.labelsDb.exec('COMMIT');
+      } catch (e) {
+        this.labelsDb.exec('ROLLBACK');
+        throw e;
+      }
+
+      // The rename dropped every index that lived on the old table.
+      this.labelsDb.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_labels_unique
+          ON labels(label_id, label_file_id, model, language);
+      `);
+      this.labelsDb.exec(XppSymbolIndex.LABEL_SECONDARY_INDEX_SQL);
+      this.createLabelsFtsTriggers();
+      this.rebuildLabelsFts();
+
+      this.labelsDb.pragma(`user_version = ${LABEL_FILES_NORMALISED}`);
+      if (n > 0) log.detail(`Label file paths normalised (${n.toLocaleString('en-US')} rows).`);
+    } catch (e) {
+      // Same posture as the FTS migration: a read-only file or a writer holding the
+      // lock must not take the server down. Leaving user_version unstamped means the
+      // next open retries. Unlike that one there is no degraded-but-correct fallback,
+      // so make the failure loud rather than a detail line.
+      console.error(`[SymbolIndex] label_files migration failed, will retry on next open: ${e}`);
+      // Whatever went wrong, the triggers must not stay dropped.
+      try {
+        this.createLabelsFtsTriggers();
+      } catch { /* the connection is beyond help; the error above is the signal */ }
+    }
+  }
+
   private migrateLabelsFtsLanguageCoverage(): void {
     const LABELS_FTS_ALL_LANGUAGES = 1;
     try {
       const version = Number(this.labelsDb.pragma('user_version', { simple: true }) ?? 0);
       if (version >= LABELS_FTS_ALL_LANGUAGES) return;
+
+      // A database still on the inline file_path column is about to be rewritten by
+      // migrateLabelPathsToLabelFiles, which rebuilds labels_fts from scratch over
+      // every language — the whole of what this step does. Stamp and let it, rather
+      // than re-tokenising a 1.4 M-row table twice in one startup.
+      const legacyPathColumn = (this.labelsDb.pragma('table_info(labels)') as Array<{ name: string }>)
+        .some(c => c.name === 'file_path');
+      if (legacyPathColumn) {
+        this.labelsDb.pragma(`user_version = ${LABELS_FTS_ALL_LANGUAGES}`);
+        return;
+      }
 
       // An empty labels table needs no rebuild — a fresh DB is already correct, and
       // stamping it here keeps the first real build off the slow path.
@@ -1232,9 +1366,15 @@ export class XppSymbolIndex {
   removeLabelsByFile(filePath: string): number {
     const forms = this.filePathForms(filePath);
     const placeholders = forms.map(() => '?').join(', ');
-    // The labels_ad trigger handles FTS cleanup, for every language
+    // The path spellings are matched against label_files — one row per .label.txt —
+    // and the labels themselves are deleted by the resulting id. The NOCASE
+    // comparison this replaced ran over every label row; it now runs over ~800.
+    // The labels_ad trigger handles FTS cleanup, for every language.
     const result = this.labelsDb.prepare(
-      `DELETE FROM labels WHERE file_path COLLATE NOCASE IN (${placeholders})`
+      `DELETE FROM labels
+       WHERE file_path_id IN (
+         SELECT id FROM label_files WHERE file_path COLLATE NOCASE IN (${placeholders})
+       )`
     ).run(...forms);
     return result.changes;
   }
@@ -3964,7 +4104,7 @@ export class XppSymbolIndex {
     let stmt = this.stmtCache.get('labels::addLabel');
     if (!stmt) {
       stmt = this.labelsDb.prepare(`
-        INSERT OR REPLACE INTO labels (label_id, label_file_id, model, language, text, comment, file_path)
+        INSERT OR REPLACE INTO labels (label_id, label_file_id, model, language, text, comment, file_path_id)
         VALUES (?, ?, ?, ?, ?, ?, ?)
       `);
       this.stmtCache.set('labels::addLabel', stmt);
@@ -3976,9 +4116,50 @@ export class XppSymbolIndex {
       entry.language,
       entry.text,
       entry.comment ?? null,
-      entry.filePath,
+      this.labelFilePathId(entry.filePath),
     );
   }
+
+  /**
+   * Row id of `filePath` in `label_files`, inserting it if it is new.
+   *
+   * Memoised for the process: a bulk load calls this once per label but there is
+   * one distinct path per .label.txt (813 across a default en-US build of 374 K
+   * rows), so without the cache it would be ~374 K index probes to learn 813 answers.
+   * The cache is only ever added to — rows in label_files are never deleted, since a
+   * path that had labels once may have them again after the next scan and the table
+   * is trivially small either way.
+   */
+  private labelFilePathId(filePath: string): number {
+    const cached = this.labelFilePathIds.get(filePath);
+    if (cached !== undefined) return cached;
+
+    let select = this.stmtCache.get('labels::selectFilePathId');
+    if (!select) {
+      select = this.labelsDb.prepare('SELECT id FROM label_files WHERE file_path = ?');
+      this.stmtCache.set('labels::selectFilePathId', select);
+    }
+    let insert = this.stmtCache.get('labels::insertFilePath');
+    if (!insert) {
+      insert = this.labelsDb.prepare('INSERT OR IGNORE INTO label_files (file_path) VALUES (?)');
+      this.stmtCache.set('labels::insertFilePath', insert);
+    }
+
+    let row = select.get(filePath) as { id: number } | undefined;
+    if (!row) {
+      insert.run(filePath);
+      row = select.get(filePath) as { id: number } | undefined;
+    }
+    // A missing row here would mean the INSERT was rejected by something other than
+    // the uniqueness it is told to ignore; there is no sane id to invent.
+    if (!row) throw new Error(`Could not resolve label file path to an id: ${filePath}`);
+
+    this.labelFilePathIds.set(filePath, row.id);
+    return row.id;
+  }
+
+  /** filePath -> label_files.id, populated lazily by labelFilePathId(). */
+  private readonly labelFilePathIds = new Map<string, number>();
 
   /**
    * Bulk-insert labels (drops FTS triggers for speed).
@@ -4017,13 +4198,21 @@ export class XppSymbolIndex {
     // connection was missing from labels_fts with nothing to signal it.
     try {
       const insert = this.labelsDb.prepare(`
-        INSERT OR REPLACE INTO labels (label_id, label_file_id, model, language, text, comment, file_path)
+        INSERT OR REPLACE INTO labels (label_id, label_file_id, model, language, text, comment, file_path_id)
         VALUES (?, ?, ?, ?, ?, ?, ?)
       `);
 
       const insertMany = this.labelsDb.transaction((rows: typeof entries) => {
         for (const e of rows) {
-          insert.run(e.labelId, e.labelFileId, e.model, e.language, e.text, e.comment ?? null, e.filePath);
+          insert.run(
+            e.labelId,
+            e.labelFileId,
+            e.model,
+            e.language,
+            e.text,
+            e.comment ?? null,
+            this.labelFilePathId(e.filePath),
+          );
         }
       });
 
@@ -4140,10 +4329,11 @@ export class XppSymbolIndex {
       // a token — the index no longer does the filtering the caller assumed.
       let sql = `
         SELECT l.label_id AS labelId, l.label_file_id AS labelFileId, l.model, l.language,
-               l.text, l.comment, l.file_path AS filePath,
+               l.text, l.comment, lf.file_path AS filePath,
                f.rank
         FROM labels_fts f
         JOIN labels l ON l.id = f.rowid
+        JOIN label_files lf ON lf.id = l.file_path_id
         WHERE labels_fts MATCH ?
           AND LOWER(l.language) = ?`;
       if (model)       sql += `\n          AND l.model = ?`;
@@ -4190,13 +4380,14 @@ export class XppSymbolIndex {
     let stmt = this.labelsStmtCache.get(stmtKey);
     if (!stmt) {
       let sql = `
-        SELECT label_id AS labelId, label_file_id AS labelFileId, model, language,
-               text, comment, file_path AS filePath, 0 as rank
-        FROM labels
-        WHERE (text LIKE ? ESCAPE '\\' OR label_id LIKE ? ESCAPE '\\')
-          AND LOWER(language) = ?`;
-      if (model)       sql += `\n          AND model = ?`;
-      if (labelFileId) sql += `\n          AND label_file_id = ?`;
+        SELECT l.label_id AS labelId, l.label_file_id AS labelFileId, l.model, l.language,
+               l.text, l.comment, lf.file_path AS filePath, 0 as rank
+        FROM labels l
+        JOIN label_files lf ON lf.id = l.file_path_id
+        WHERE (l.text LIKE ? ESCAPE '\\' OR l.label_id LIKE ? ESCAPE '\\')
+          AND LOWER(l.language) = ?`;
+      if (model)       sql += `\n          AND l.model = ?`;
+      if (labelFileId) sql += `\n          AND l.label_file_id = ?`;
       sql += `\n        LIMIT ?`;
       stmt = this.labelsDb.prepare(sql);
       this.labelsStmtCache.set(stmtKey, stmt);
@@ -4252,13 +4443,15 @@ export class XppSymbolIndex {
 
     const params: any[] = [...spellings];
     let sql = `
-      SELECT label_id AS labelId, label_file_id AS labelFileId, model, language, text, comment, file_path AS filePath
-      FROM labels
-      WHERE label_id IN (${spellings.map(() => '?').join(', ')})
+      SELECT l.label_id AS labelId, l.label_file_id AS labelFileId, l.model, l.language,
+             l.text, l.comment, lf.file_path AS filePath
+      FROM labels l
+      JOIN label_files lf ON lf.id = l.file_path_id
+      WHERE l.label_id IN (${spellings.map(() => '?').join(', ')})
     `;
-    if (fileFilter) { sql += ` AND label_file_id = ?`; params.push(fileFilter); }
-    if (model)      { sql += ` AND model = ?`;         params.push(model); }
-    sql += ` ORDER BY language`;
+    if (fileFilter) { sql += ` AND l.label_file_id = ?`; params.push(fileFilter); }
+    if (model)      { sql += ` AND l.model = ?`;         params.push(model); }
+    sql += ` ORDER BY l.language`;
     return this.labelsDb.prepare(sql).all(...params) as any[];
   }
 
@@ -4310,12 +4503,13 @@ export class XppSymbolIndex {
   ): Array<{ language: string; filePath: string; model: string }> {
     const params: any[] = [labelFileId];
     let sql = `
-      SELECT DISTINCT language, file_path AS filePath, model
-      FROM labels
-      WHERE label_file_id = ? AND file_path IS NOT NULL AND file_path != ''
+      SELECT DISTINCT l.language, lf.file_path AS filePath, l.model
+      FROM labels l
+      JOIN label_files lf ON lf.id = l.file_path_id
+      WHERE l.label_file_id = ? AND lf.file_path IS NOT NULL AND lf.file_path != ''
     `;
-    if (model) { sql += ` AND model = ?`; params.push(model); }
-    sql += ` ORDER BY language`;
+    if (model) { sql += ` AND l.model = ?`; params.push(model); }
+    sql += ` ORDER BY l.language`;
     return this.labelsDb.prepare(sql).all(...params) as any[];
   }
 

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -418,19 +418,16 @@ export class XppSymbolIndex {
       );
     `);
 
+    // idx_labels_unique is created separately from the rest, and deliberately so:
+    // it is the only one a bulk load cannot run without. INSERT OR REPLACE dedupes
+    // through it, so dropping it for the load would let duplicate rows in and the
+    // CREATE UNIQUE INDEX afterwards would fail the whole build. The others are pure
+    // read accelerators — see dropLabelSecondaryIndexes().
     this.labelsDb.exec(`
-      CREATE INDEX IF NOT EXISTS idx_labels_id ON labels(label_id);
-      CREATE INDEX IF NOT EXISTS idx_labels_file_id ON labels(label_file_id);
-      CREATE INDEX IF NOT EXISTS idx_labels_model ON labels(model);
-      CREATE INDEX IF NOT EXISTS idx_labels_language ON labels(language);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_labels_unique
         ON labels(label_id, label_file_id, model, language);
-      -- Every language comparison in this file is LOWER(language) = LOWER(?), because
-      -- Microsoft packages unzipped on Linux store 'en-us' while custom packages write
-      -- 'en-US'. A plain index on language cannot serve that predicate, so the LIKE
-      -- fallback degraded to a scan of all four locales instead of one.
-      CREATE INDEX IF NOT EXISTS idx_labels_language_lower ON labels(LOWER(language));
     `);
+    this.labelsDb.exec(XppSymbolIndex.LABEL_SECONDARY_INDEX_SQL);
 
     // FTS5 full-text search for labels — every indexed language, not just en-US.
     // See rebuildLabelsFts() for why the en-US-only index had to go.
@@ -732,6 +729,89 @@ export class XppSymbolIndex {
     `);
 
     this.ensureFilePathIndexes();
+  }
+
+  /**
+   * The `labels` indexes that exist purely to accelerate reads, keyed by name so
+   * they can be dropped for a bulk load and rebuilt afterwards.
+   *
+   * `idx_labels_unique` is NOT in here — it enforces the dedupe that
+   * INSERT OR REPLACE relies on and has to stay live through the load.
+   *
+   * The two file_path entries are also created on demand by ensureFilePathIndexes()
+   * (which adds the large-DB worker dispatch that startup needs); this list is the
+   * single definition of their SQL so the two paths cannot drift apart.
+   */
+  private static readonly LABEL_SECONDARY_INDEXES: ReadonlyArray<{ name: string; sql: string }> = [
+    { name: 'idx_labels_id', sql: 'CREATE INDEX IF NOT EXISTS idx_labels_id ON labels(label_id);' },
+    { name: 'idx_labels_file_id', sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_id ON labels(label_file_id);' },
+    { name: 'idx_labels_model', sql: 'CREATE INDEX IF NOT EXISTS idx_labels_model ON labels(model);' },
+    { name: 'idx_labels_language', sql: 'CREATE INDEX IF NOT EXISTS idx_labels_language ON labels(language);' },
+    // Every language comparison in this file is LOWER(language) = LOWER(?), because
+    // Microsoft packages unzipped on Linux store 'en-us' while custom packages write
+    // 'en-US'. A plain index on language cannot serve that predicate, so the LIKE
+    // fallback degraded to a scan of all four locales instead of one.
+    {
+      name: 'idx_labels_language_lower',
+      sql: 'CREATE INDEX IF NOT EXISTS idx_labels_language_lower ON labels(LOWER(language));',
+    },
+    {
+      name: 'idx_labels_file_path',
+      sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path ON labels(file_path);',
+    },
+    {
+      name: 'idx_labels_file_path_nocase',
+      sql: 'CREATE INDEX IF NOT EXISTS idx_labels_file_path_nocase ON labels(file_path COLLATE NOCASE);',
+    },
+  ];
+
+  /** The subset created at schema-init time; the file_path pair is left to ensureFilePathIndexes(). */
+  private static readonly LABEL_SECONDARY_INDEX_SQL = XppSymbolIndex.LABEL_SECONDARY_INDEXES
+    .filter(i => !i.name.startsWith('idx_labels_file_path'))
+    .map(i => i.sql)
+    .join('\n');
+
+  /**
+   * Drop the read-only `labels` indexes ahead of a bulk load, and report which ones
+   * were actually there so the caller can put back exactly that set.
+   *
+   * Every row of a bulk load otherwise maintains eight B-trees, two of them keyed on
+   * a ~130-character absolute path. Measured on a 400 K-row / 150-model reproduction
+   * of this exact write path: 17.2 s with the indexes live versus 10.6 s dropping
+   * these seven and rebuilding them at the end (the insert itself, 14.9 s → 4.4 s).
+   * This is the same trade the symbols side already makes in ensureFilePathIndexes().
+   *
+   * Build-time only. Do NOT call this on a server that is answering queries — label
+   * search degrades to a full scan until createLabelSecondaryIndexes() finishes.
+   */
+  dropLabelSecondaryIndexes(): string[] {
+    const dropped: string[] = [];
+    for (const { name } of XppSymbolIndex.LABEL_SECONDARY_INDEXES) {
+      const exists = this.labelsDb
+        .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`)
+        .get(name);
+      if (!exists) continue;
+      this.labelsDb.exec(`DROP INDEX IF EXISTS ${name}`);
+      dropped.push(name);
+    }
+    return dropped;
+  }
+
+  /**
+   * Rebuild the indexes dropped by dropLabelSecondaryIndexes().
+   *
+   * Pass the array that call returned to restore exactly the set that was there;
+   * omit it to create all of them. Returns the elapsed milliseconds so build scripts
+   * can report the cost they moved out of the insert loop.
+   */
+  createLabelSecondaryIndexes(only?: string[]): number {
+    const wanted = only ? new Set(only) : null;
+    const started = Date.now();
+    for (const { name, sql } of XppSymbolIndex.LABEL_SECONDARY_INDEXES) {
+      if (wanted && !wanted.has(name)) continue;
+      this.labelsDb.exec(sql);
+    }
+    return Date.now() - started;
   }
 
   /**
@@ -4261,8 +4341,15 @@ export class XppSymbolIndex {
 
   /**
    * Rename a label ID in the index (used by rename_label tool).
-   * Updates all rows for the given labelId + labelFileId + model combination
-   * and rebuilds the FTS index.
+   * Updates all rows for the given labelId + labelFileId + model combination.
+   *
+   * No FTS rebuild: the `labels_au` trigger deletes the old term and inserts the new
+   * one for each updated row, which is the whole of the work a rebuild would redo.
+   * This used to call rebuildLabelsFts() afterwards — re-tokenising every label in
+   * the database (~105 s on the production DB) to reflect a handful of renamed rows,
+   * and because node:sqlite is synchronous the server answered nothing for its whole
+   * duration. create_label and update_symbol_index were moved off that pattern
+   * earlier; this was the last caller still on it.
    */
   renameLabelInIndex(
     oldLabelId: string,
@@ -4277,6 +4364,5 @@ export class XppSymbolIndex {
         AND label_file_id = ?
         AND model = ?
     `).run(newLabelId, oldLabelId, labelFileId, model);
-    this.rebuildLabelsFts();
   }
 }

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -17,6 +17,7 @@ import type { XppServerContext } from '../types/context.js';
 import {
   searchLabelsTool, REUSABLE_MARKER, NO_HITS_MARKER, NO_REUSE_ADVICE, SOME_REUSE_ADVICE,
 } from './analysis/searchLabels.js';
+import { mapWithConcurrency } from '../utils/concurrency.js';
 import { repeatSearchNotice } from './analysis/labelSearchHistory.js';
 import { getLabelInfoTool } from './readers/getLabelInfo.js';
 import { createLabelTool } from './write/createLabel.js';
@@ -162,23 +163,11 @@ const MAX_BATCH_QUERIES = 12;
  */
 const BATCH_CONCURRENCY = 4;
 
-/** Run `fn` over `items` with at most `limit` in flight, preserving input order. Exported for tests. */
-export async function mapWithConcurrency<T, R>(
-  items: T[],
-  limit: number,
-  fn: (item: T, index: number) => Promise<R>,
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let next = 0;
-  const worker = async (): Promise<void> => {
-    while (next < items.length) {
-      const i = next++;
-      results[i] = await fn(items[i], i);
-    }
-  };
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-  return results;
-}
+/**
+ * Re-exported from utils/concurrency so the label indexer can share the same helper
+ * without importing from the tools layer. Kept exported here for existing callers/tests.
+ */
+export { mapWithConcurrency };
 
 /**
  * Run several label searches in one call.

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,46 @@
+/**
+ * Bounded-concurrency helpers.
+ *
+ * Both the label indexer and the batch label search need the same thing: run N
+ * independent async jobs with a cap on how many are in flight, so the batch costs
+ * the slowest job rather than the sum of all of them, without opening an unbounded
+ * number of file handles or SQLite queries at once.
+ */
+
+import * as os from 'os';
+
+/** Run `fn` over `items` with at most `limit` in flight, preserving input order. */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i], i);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+/**
+ * How many file reads to keep in flight.
+ *
+ * Same shape as the extract phase's DEFAULT_FILE_CONCURRENCY (scripts/extract-metadata.ts):
+ * host parallelism, floored at 2 so a single-core CI box still overlaps I/O with
+ * parsing, capped at 24 because past that the disk is the limit and the extra
+ * handles only add queueing.
+ */
+export function defaultFileConcurrency(): number {
+  let hosts: number;
+  try {
+    hosts = typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length;
+  } catch {
+    hosts = 4;
+  }
+  return Math.max(2, Math.min(24, hosts));
+}

--- a/tests/metadata/filePathIndex.test.ts
+++ b/tests/metadata/filePathIndex.test.ts
@@ -42,12 +42,18 @@ describe('file_path indexes', () => {
     const symbolIdx = idx.db
       .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_symbols_file_path'`)
       .get();
+    // Labels reach their path through label_files now, so the indexed column is the
+    // foreign key, and the path text itself is indexed once on the lookup table.
     const labelIdx = idx.labelsDb
-      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_labels_file_path'`)
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_labels_file_path_id'`)
+      .get();
+    const labelFilesIdx = idx.labelsDb
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_label_files_path'`)
       .get();
 
     expect(symbolIdx).toBeTruthy();
     expect(labelIdx).toBeTruthy();
+    expect(labelFilesIdx).toBeTruthy();
   });
 
   it('makes removeSymbolsByFile look up by index instead of scanning', () => {

--- a/tests/metadata/labelFilesMigration.test.ts
+++ b/tests/metadata/labelFilesMigration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Migration of an existing labels database from the inline `labels.file_path`
+ * column to the `label_files` lookup table.
+ *
+ * The fixtures below build the OLD schema by hand — a database written by a version
+ * of the server before the normalisation — and then open it with the current one.
+ * That is the only way to exercise the path real users hit; every other test starts
+ * from the new schema, where the migration is a no-op.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+import Database from '../../src/database/sqlite.js';
+
+const dirs: string[] = [];
+const opened: XppSymbolIndex[] = [];
+
+afterEach(() => {
+  for (const idx of opened) {
+    try { idx.close(); } catch { /* already closed */ }
+  }
+  opened.length = 0;
+  for (const dir of dirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+  dirs.length = 0;
+});
+
+const PATH_A = 'K:\\AosService\\PackagesLocalDirectory\\Contoso\\Contoso\\AxLabelFile\\LabelResources\\en-US\\Con.en-US.label.txt';
+const PATH_B = 'K:\\AosService\\PackagesLocalDirectory\\Contoso\\Contoso\\AxLabelFile\\LabelResources\\cs\\Con.cs.label.txt';
+
+/** Write a labels DB in the pre-normalisation shape and return its path. */
+function legacyLabelsDb(rows: Array<[string, string, string, string]>): { symbolsPath: string; labelsPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'd365fo-labelfiles-'));
+  dirs.push(dir);
+  const symbolsPath = path.join(dir, 'symbols.db');
+  const labelsPath = path.join(dir, 'labels.db');
+
+  const db = new Database(labelsPath);
+  db.exec(`
+    CREATE TABLE labels (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      label_id TEXT NOT NULL,
+      label_file_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      language TEXT NOT NULL,
+      text TEXT NOT NULL,
+      comment TEXT,
+      file_path TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX idx_labels_unique ON labels(label_id, label_file_id, model, language);
+    CREATE INDEX idx_labels_file_path ON labels(file_path);
+    CREATE INDEX idx_labels_file_path_nocase ON labels(file_path COLLATE NOCASE);
+    CREATE VIRTUAL TABLE labels_fts USING fts5(label_id, text, comment, content='labels', content_rowid='id');
+  `);
+  const insert = db.prepare(
+    `INSERT INTO labels (label_id, label_file_id, model, language, text, comment, file_path)
+     VALUES (?, 'Con', 'Contoso', ?, ?, NULL, ?)`,
+  );
+  for (const [labelId, language, text, filePath] of rows) insert.run(labelId, language, text, filePath);
+  db.exec(`INSERT INTO labels_fts(rowid, label_id, text, comment) SELECT id, label_id, text, comment FROM labels`);
+  db.pragma('user_version = 0');
+  db.close();
+
+  return { symbolsPath, labelsPath };
+}
+
+describe('label_files migration', () => {
+  it('moves inline paths into label_files and keeps every row reachable', () => {
+    const { symbolsPath, labelsPath } = legacyLabelsDb([
+      ['Quality', 'en-US', 'Quality tier', PATH_A],
+      ['Access', 'en-US', 'Access to posting', PATH_A],
+      ['Quality', 'cs', 'Úroveň kvality', PATH_B],
+    ]);
+
+    const idx = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(idx);
+
+    expect(idx.getLabelCount()).toBe(3);
+
+    // Two distinct on-disk files behind three labels — the whole point of the table.
+    const files = idx.labelsDb
+      .prepare(`SELECT file_path FROM label_files ORDER BY file_path`)
+      .all() as Array<{ file_path: string }>;
+    expect(files.map(f => f.file_path).sort()).toEqual([PATH_A, PATH_B].sort());
+
+    // The old column is gone, not merely unused.
+    const columns = (idx.labelsDb.pragma('table_info(labels)') as Array<{ name: string }>).map(c => c.name);
+    expect(columns).toContain('file_path_id');
+    expect(columns).not.toContain('file_path');
+
+    expect(Number(idx.labelsDb.pragma('user_version', { simple: true }))).toBe(2);
+  });
+
+  it('serves the migrated path back through every read that exposes it', () => {
+    const { symbolsPath, labelsPath } = legacyLabelsDb([
+      ['Quality', 'en-US', 'Quality tier', PATH_A],
+      ['Quality', 'cs', 'Úroveň kvality', PATH_B],
+    ]);
+
+    const idx = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(idx);
+
+    expect(idx.searchLabels('Quality', { language: 'en-US' }).map(h => h.filePath)).toEqual([PATH_A]);
+    expect(idx.getLabelById('@Con:Quality').map(h => h.filePath).sort()).toEqual([PATH_A, PATH_B].sort());
+    expect(idx.getLabelFilePaths('Con').map(h => h.filePath).sort()).toEqual([PATH_A, PATH_B].sort());
+    // '_' routes to the LIKE fallback, which is a separate SQL statement.
+    expect(idx.searchLabels('Quality_tier', { language: 'en-US' })).toEqual([]);
+    expect(idx.searchLabelsLike('Quality', { language: 'en-US' }).map(h => h.filePath)).toEqual([PATH_A]);
+  });
+
+  it('rebuilds labels_fts so non-en-US rows survive the rewrite', () => {
+    const { symbolsPath, labelsPath } = legacyLabelsDb([
+      ['Quality', 'cs', 'Úroveň kvality', PATH_B],
+    ]);
+
+    const idx = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(idx);
+
+    // The rewrite replaces the table labels_fts points at, so a stale index would
+    // leave this empty — and the row ids are carried over precisely to avoid that.
+    expect(idx.searchLabels('kvality', { language: 'cs' }).map(h => h.text)).toEqual(['Úroveň kvality']);
+  });
+
+  it('keeps removeLabelsByFile working against the migrated shape', () => {
+    const { symbolsPath, labelsPath } = legacyLabelsDb([
+      ['Quality', 'en-US', 'Quality tier', PATH_A],
+      ['Access', 'en-US', 'Access to posting', PATH_A],
+      ['Quality', 'cs', 'Úroveň kvality', PATH_B],
+    ]);
+
+    const idx = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(idx);
+
+    // Lowercased, as a tool argument routinely is on Windows — the NOCASE index on
+    // label_files is what keeps this matching.
+    expect(idx.removeLabelsByFile(PATH_A.toLowerCase())).toBe(2);
+    expect(idx.getLabelCount()).toBe(1);
+    expect(idx.searchLabels('Quality', { language: 'en-US' })).toEqual([]);
+    expect(idx.searchLabels('kvality', { language: 'cs' })).toHaveLength(1);
+  });
+
+  it('is a no-op on the second open', () => {
+    const { symbolsPath, labelsPath } = legacyLabelsDb([
+      ['Quality', 'en-US', 'Quality tier', PATH_A],
+    ]);
+
+    const first = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(first);
+    first.close();
+
+    const second = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(second);
+    let rebuilt = false;
+    const real = second.rebuildLabelsFts.bind(second);
+    second.rebuildLabelsFts = () => { rebuilt = true; real(); };
+
+    const third = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(third);
+
+    expect(rebuilt).toBe(false);
+    expect(third.getLabelCount()).toBe(1);
+    expect(Number(third.labelsDb.pragma('user_version', { simple: true }))).toBe(2);
+  });
+
+  it('writes new labels into the migrated database without duplicating file rows', () => {
+    const { symbolsPath, labelsPath } = legacyLabelsDb([
+      ['Quality', 'en-US', 'Quality tier', PATH_A],
+    ]);
+
+    const idx = new XppSymbolIndex(symbolsPath, labelsPath);
+    opened.push(idx);
+
+    idx.bulkAddLabels(
+      [
+        { labelId: 'New', labelFileId: 'Con', model: 'Contoso', language: 'en-US', text: 'Brand new label', filePath: PATH_A },
+        { labelId: 'Other', labelFileId: 'Con', model: 'Contoso', language: 'en-US', text: 'Another label', filePath: PATH_A },
+      ],
+      { skipFtsRebuild: true, keepTriggers: true },
+    );
+
+    // Same path as the migrated row: it must reuse that label_files row, not add one.
+    const { n } = idx.labelsDb.prepare(`SELECT COUNT(*) AS n FROM label_files`).get() as { n: number };
+    expect(n).toBe(1);
+    expect(idx.getLabelCount()).toBe(3);
+    expect(idx.searchLabels('Brand', { language: 'en-US' }).map(h => h.filePath)).toEqual([PATH_A]);
+  });
+});

--- a/tests/metadata/labelsBulkLoadIndexes.test.ts
+++ b/tests/metadata/labelsBulkLoadIndexes.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Bulk-load index deferral + the FTS maintenance that has to survive it.
+ *
+ * The build scripts drop the `labels` read-accelerator indexes for the insert pass
+ * and rebuild them afterwards, which is only safe if three things hold: the UNIQUE
+ * index stays live (it is what INSERT OR REPLACE dedupes through), the dropped set
+ * comes back exactly, and label search returns the same rows either way.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex.js';
+
+const LABEL_INDEXES = [
+  'idx_labels_id',
+  'idx_labels_file_id',
+  'idx_labels_model',
+  'idx_labels_language',
+  'idx_labels_language_lower',
+];
+
+function indexNames(index: XppSymbolIndex): string[] {
+  return (
+    index.labelsDb
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_labels%' ORDER BY name`)
+      .all() as Array<{ name: string }>
+  ).map(r => r.name);
+}
+
+function entry(n: number, overrides: Partial<Record<string, string>> = {}) {
+  return {
+    labelId: `@Fm:Label${n}`,
+    labelFileId: 'FmLabels',
+    model: 'FleetManagement',
+    language: 'en-US',
+    text: `posting profile ${n}`,
+    comment: `comment ${n}`,
+    filePath: `K:\\PLD\\FleetManagement\\FleetManagement\\AxLabelFile\\LabelResources\\en-US\\FmLabels.en-US.label.txt`,
+    ...overrides,
+  };
+}
+
+describe('labels bulk-load index deferral', () => {
+  let index: XppSymbolIndex;
+
+  beforeEach(() => {
+    index = new XppSymbolIndex(':memory:', ':memory:');
+  });
+
+  afterEach(() => {
+    index.close();
+  });
+
+  it('keeps idx_labels_unique live so INSERT OR REPLACE still dedupes', () => {
+    index.dropLabelSecondaryIndexes();
+
+    expect(indexNames(index)).toContain('idx_labels_unique');
+
+    // Same (label_id, label_file_id, model, language) twice — the second must replace
+    // the first, not add a row. Without the UNIQUE index this silently duplicates and
+    // the CREATE UNIQUE INDEX below would fail.
+    index.bulkAddLabels([entry(1), entry(1, { text: 'replaced text' })], {
+      skipFtsRebuild: true,
+    });
+
+    expect(index.getLabelCount()).toBe(1);
+    expect(() => index.createLabelSecondaryIndexes()).not.toThrow();
+  });
+
+  it('drops only the read accelerators and restores exactly that set', () => {
+    const before = indexNames(index);
+    for (const name of LABEL_INDEXES) expect(before).toContain(name);
+
+    const dropped = index.dropLabelSecondaryIndexes();
+    expect(dropped).toEqual(expect.arrayContaining(LABEL_INDEXES));
+    expect(dropped).not.toContain('idx_labels_unique');
+
+    const during = indexNames(index);
+    for (const name of LABEL_INDEXES) expect(during).not.toContain(name);
+
+    index.createLabelSecondaryIndexes(dropped);
+    expect(indexNames(index).sort()).toEqual(before.sort());
+  });
+
+  it('only recreates the indexes it was told about', () => {
+    index.dropLabelSecondaryIndexes();
+    index.createLabelSecondaryIndexes(['idx_labels_model']);
+
+    const names = indexNames(index);
+    expect(names).toContain('idx_labels_model');
+    expect(names).not.toContain('idx_labels_language_lower');
+  });
+
+  it('returns the same search results whether or not the indexes were deferred', () => {
+    const rows = Array.from({ length: 50 }, (_unused, i) => entry(i));
+
+    const dropped = index.dropLabelSecondaryIndexes();
+    index.bulkAddLabels(rows, { skipFtsRebuild: true });
+    index.createLabelSecondaryIndexes(dropped);
+    index.rebuildLabelsFts();
+    const deferred = index.searchLabels('posting', { language: 'en-US', limit: 100 });
+
+    const plain = new XppSymbolIndex(':memory:', ':memory:');
+    try {
+      plain.bulkAddLabels(rows, { skipFtsRebuild: true });
+      plain.rebuildLabelsFts();
+      const direct = plain.searchLabels('posting', { language: 'en-US', limit: 100 });
+
+      expect(deferred.length).toBe(50);
+      expect(deferred.map(r => r.labelId).sort()).toEqual(direct.map(r => r.labelId).sort());
+    } finally {
+      plain.close();
+    }
+  });
+});
+
+describe('renameLabelInIndex keeps FTS current without a full rebuild', () => {
+  let index: XppSymbolIndex;
+
+  beforeEach(() => {
+    index = new XppSymbolIndex(':memory:', ':memory:');
+    // keepTriggers, as create_label does — the triggers must be live afterwards for
+    // the rename to be reflected in labels_fts.
+    index.bulkAddLabels([entry(1, { text: 'unique posting phrase' })], {
+      skipFtsRebuild: true,
+      keepTriggers: true,
+    });
+  });
+
+  afterEach(() => {
+    index.close();
+  });
+
+  it('finds the label under its new id and not the old one, with no explicit rebuild', () => {
+    expect(index.searchLabels('posting', { language: 'en-US' }).map(r => r.labelId)).toEqual([
+      '@Fm:Label1',
+    ]);
+
+    index.renameLabelInIndex('@Fm:Label1', '@Fm:Renamed', 'FmLabels', 'FleetManagement');
+
+    const hits = index.searchLabels('posting', { language: 'en-US' });
+    expect(hits.map(r => r.labelId)).toEqual(['@Fm:Renamed']);
+
+    // The FTS row for the old id must be gone, not merely shadowed by the join.
+    const stale = index.labelsDb
+      .prepare(`SELECT COUNT(*) AS n FROM labels_fts WHERE labels_fts MATCH ?`)
+      .get('"@Fm:Label1"') as { n: number };
+    expect(stale.n).toBe(0);
+  });
+});

--- a/tests/metadata/labelsBulkLoadIndexes.test.ts
+++ b/tests/metadata/labelsBulkLoadIndexes.test.ts
@@ -14,7 +14,6 @@ const LABEL_INDEXES = [
   'idx_labels_id',
   'idx_labels_file_id',
   'idx_labels_model',
-  'idx_labels_language',
   'idx_labels_language_lower',
 ];
 

--- a/tests/metadata/labelsFtsAllLanguages.test.ts
+++ b/tests/metadata/labelsFtsAllLanguages.test.ts
@@ -160,7 +160,9 @@ describe('labels_fts language-coverage migration', () => {
     opened.push(reopened);
 
     expect(reopened.searchLabels('kvality', { language: 'cs' }).map(h => h.text)).toEqual(['Úroveň kvality']);
-    expect(Number(reopened.labelsDb.pragma('user_version', { simple: true }))).toBe(1);
+    // 2, not 1: the label_files normalisation shares this counter and stamps its own
+    // step on the way past. See the migration ordering in initializeDatabase().
+    expect(Number(reopened.labelsDb.pragma('user_version', { simple: true }))).toBe(2);
   });
 
   it('does not rebuild a database that is already migrated', () => {
@@ -186,6 +188,6 @@ describe('labels_fts language-coverage migration', () => {
     opened.push(third);
 
     expect(rebuilt).toBe(false);
-    expect(Number(third.labelsDb.pragma('user_version', { simple: true }))).toBe(1);
+    expect(Number(third.labelsDb.pragma('user_version', { simple: true }))).toBe(2);
   });
 });

--- a/tests/metadata/symbolIndexStaleRowCase.test.ts
+++ b/tests/metadata/symbolIndexStaleRowCase.test.ts
@@ -125,8 +125,10 @@ describe('NOCASE file_path index', () => {
     expect(
       idx.db.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_symbols_file_path_nocase'`).get(),
     ).toBeTruthy();
+    // The labels NOCASE index moved to label_files: removeLabelsByFile matches the
+    // path spellings there (one row per .label.txt) and deletes labels by the id.
     expect(
-      idx.labelsDb.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_labels_file_path_nocase'`).get(),
+      idx.labelsDb.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_label_files_path_nocase'`).get(),
     ).toBeTruthy();
 
     // Enough rows that the planner has a real choice — on a handful it picks a


### PR DESCRIPTION
## Why

The label phase of a build cost more than indexing the whole X++ codebase. Investigating showed the reason is **not** the volume of input — a default `en-US` build reads 813 files totalling 38 MB off PackagesLocalDirectory, seconds of I/O — and then spends all its time inside SQLite.

The symbols side already defers its expensive indexes (`ensureFilePathIndexes()` builds them after the table is populated, on a worker once the DB is large). The labels table never got that treatment: all eight of its indexes were created in `initializeDatabase()`, before any data existed, so every insert of the ~374 K-row load maintained eight B-trees — two of them keyed on a ~130-character absolute path that is identical for every label in a file.

## Measured

Against the real `K:\AosService\PackagesLocalDirectory`, 373,928 labels across 178 models, `LABEL_LANGUAGES=en-US`, warm cache, alternating runs:

| | read+insert | createIdx | FTS | **total** | labels DB |
|---|---|---|---|---|---|
| before | 14.6 s | – | 2.8 s | **17.4 s** | 310 MB |
| commit 1 | 4.5 s | 4.0 s | 2.8 s | **11.3 s** | 293 MB |
| commit 2 | 4.5 s | 1.5 s | 2.8 s | **8.7 s** | 143 MB |

**2.0x faster, 2.2x smaller.** The size matters as much as the seconds: every full-table operation on this DB (FTS rebuild, ANALYZE, VACUUM, any cold-cache scan) now moves less than half the disk, and those are exactly the operations behind the 105 s and 284 s figures recorded in comments elsewhere in the file.

## What changed

**Commit 1 — defer the label indexes for the bulk load.** Drop the seven read accelerators for the insert pass, rebuild them over the finished table. `idx_labels_unique` deliberately stays live: `INSERT OR REPLACE` dedupes through it, and dropping it would admit duplicates that make the closing `CREATE UNIQUE INDEX` fail the build. Also in this commit:

- `rename_label` no longer re-tokenises every label in the database. The `labels_au` trigger already does the work the rebuild redid — ~105 s on the production DB, with the event loop blocked throughout since `node:sqlite` is synchronous. `create_label` and `update_symbol_index` were moved off that pattern earlier; this was the last caller still on it.
- The FTS rebuild is hoisted out of `indexAllLabels`. It reads every label row regardless of scan scope, so a caller looping over several package roots paid that whole pass once per root.
- Label files within a model are read with bounded concurrency. Barely matters at `en-US` breadth; `LABEL_LANGUAGES=all` multiplies it by the ~74 shipped locales.

**Commit 2 — normalise `file_path` into a `label_files` table.** 1,601 distinct paths were carried across 373,928 rows. `removeLabelsByFile` gets the same benefit for free — it matches path spellings against ~1,600 rows instead of running a NOCASE comparison over every label. `idx_labels_language` is dropped as dead (no query compares language for equality).

Existing databases migrate in place on first open, announced up front because a full table rewrite is minutes on a multi-GB labels DB. Migration ordering needed care: both migrations advance the same `PRAGMA user_version`, so they now run in ascending order, and the FTS coverage step stamps without re-tokenising when the rewrite is about to do that anyway.

## Hypotheses this replaces

Two plausible-sounding causes were measured and **rejected** before landing this:

- Swapping the manual `delete-all` + `INSERT…SELECT` for FTS5's native `'rebuild'` is a wash — 2.4 s vs 2.5 s on 400 K rows, identical results.
- Hoisting the per-model trigger DDL out of `bulkAddLabels` changes nothing — 17.192 s vs 17.194 s.

## Testing

- Full suite green: **289 files, 3,576 passed, 2 skipped**.
- New `tests/metadata/labelsBulkLoadIndexes.test.ts` — UNIQUE index survives the drop and still dedupes; exact drop/restore set; search results identical deferred vs not; rename reflected in FTS with no explicit rebuild.
- New `tests/metadata/labelFilesMigration.test.ts` — builds the **old** schema by hand and opens it with the current code: rows preserved, old column gone, every read path that exposes `filePath` still serves it, non-en-US rows survive the rewrite, `removeLabelsByFile` still matches case-insensitively, no-op on second open, and new writes reuse existing `label_files` rows.

## Not done

`id INTEGER PRIMARY KEY AUTOINCREMENT` on `labels` is left alone. Removing it measured ~0.5 s of 5.9 s in a synthetic run, which did not seem worth changing rowid-reuse semantics for on a table whose ids `labels_fts` is keyed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)