### PR TITLE
Stop putting the model name's space inside AOT object names

### DIFF
--- a/src/tools/prepare/prepareCreate.ts
+++ b/src/tools/prepare/prepareCreate.ts
@@ -97,6 +97,16 @@ function validateNaming(baseName: string, finalName: string, modelName: string |
   if (!/^[A-Z]/.test(baseName)) {
     issues.push('❌ Name must start with an uppercase letter (PascalCase).');
   }
+  // The charset check above sees the name the CALLER typed. The name that actually
+  // gets written is finalName, which the prefix/model-name step composed — and that
+  // step is where an unrepresentable character can enter a name the caller never
+  // typed (#892). Extension forms legitimately carry one dot.
+  if (!/^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)?$/.test(finalName)) {
+    issues.push(
+      `❌ Final name "${finalName}" is not a valid AOT name — letters, digits and underscores only ` +
+        '(plus one dot for extension elements). Check the model name and prefix configuration.'
+    );
+  }
   const lines = [
     `Base name   : ${baseName}`,
     `Final name  : ${finalName}${finalName !== baseName ? ' _(prefix auto-applied by d365fo_file(action="create"))_' : ''}`,

--- a/src/utils/modelClassifier.ts
+++ b/src/utils/modelClassifier.ts
@@ -11,6 +11,7 @@
  */
 
 import { getInferredModelPrefix, toExtensionInfixCase } from './modelPrefixInference.js';
+import { normalizeModelToken } from './modelToken.js';
 
 // Runtime registry for auto-detected custom models
 const autoDetectedCustomModels = new Set<string>();
@@ -269,6 +270,10 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
   // elements/classes only (VS default); regular new objects are unaffected.
   const useModelName = !!modelName && getExtensionNamingStyle() === 'model-name';
 
+  // The model name as it may appear inside an object name — identical to modelName
+  // unless the name carries characters an AOT identifier cannot (see #892).
+  const modelToken = modelName ? normalizeModelToken(modelName) : '';
+
   // Extension infix form — PascalCase without underscore (e.g. "XY" → "Xy" when env had "XY_"),
   // or the model's own infix when its existing extensions state one.
   const extensionInfix = deriveExtensionInfix(prefix, modelName);
@@ -293,7 +298,7 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
 
     // Replaces whatever follows the dot, so re-running is idempotent.
     if (useModelName) {
-      return `${basePart}.${modelName}`;
+      return `${basePart}.${modelToken}`;
     }
 
     if (suffixPart.toLowerCase().endsWith('extension')) {
@@ -315,14 +320,17 @@ export function applyObjectPrefix(objectName: string, prefix: string, modelName?
     // (avoids Base_ModelName_ModelName_Extension).
     if (useModelName) {
       let cleanBase = baseName.replace(/_+$/, '');
-      const lowerModel = modelName!.toLowerCase();
+      // Match on the TOKEN, not the raw model name: the token is what an existing
+      // name can contain, so comparing against "contoso robotics" never fired and
+      // CustTable_ContosoRobotics_Extension grew a second token on every pass.
+      const lowerModel = modelToken.toLowerCase();
       if (cleanBase.toLowerCase().endsWith('_' + lowerModel)) {
         cleanBase = cleanBase.slice(0, cleanBase.length - lowerModel.length - 1);
       } else if (cleanBase.toLowerCase().endsWith(lowerModel)) {
         cleanBase = cleanBase.slice(0, cleanBase.length - lowerModel.length);
       }
       cleanBase = cleanBase.replace(/_+$/, '');
-      return `${cleanBase}_${modelName}_Extension`;
+      return `${cleanBase}_${modelToken}_Extension`;
     }
 
     // Check if the extension infix is already present at the end (case-insensitive)

--- a/src/utils/modelToken.ts
+++ b/src/utils/modelToken.ts
@@ -1,0 +1,31 @@
+/**
+ * The spelling of a model name that may appear INSIDE an AOT object name.
+ *
+ * A model name is free text — "Contoso Robotics" is an ordinary thing for Visual
+ * Studio to create — but an AOT element name is an identifier and cannot carry a
+ * space. Embedding the raw name (EXTENSION_NAMING_STYLE=model-name) therefore
+ * produced `CustTable.Contoso Robotics`, which no build accepts (issue #892).
+ *
+ * Stripping everything outside [A-Za-z0-9_] is not a guess at what the platform
+ * does — it IS what the platform does. The descriptor of the one shipped model
+ * whose name has a space states:
+ *   <Name>Monitoring and Telemetry</Name> → <ModelModule>MonitoringandTelemetry</ModelModule>
+ * i.e. the name with whitespace removed, character for character, lowercase "and"
+ * intact. Visual Studio names extensions in that model-derived spelling too, so
+ * the token computed here matches the extensions a model already contains.
+ *
+ * Deriving the token from <ModelModule> instead was considered and rejected:
+ * ModelModule is per-PACKAGE, not per-model (all five models in ApplicationSuite
+ * report ModelModule=ApplicationSuite), so every model sharing a package would
+ * collapse onto one token.
+ *
+ * Returns the name unchanged for any model whose name is already an identifier,
+ * which is every model that does not contain a space.
+ *
+ * Lives in its own module rather than in modelClassifier because the naming
+ * surface of that module is mocked wholesale by a dozen write-path test files;
+ * a helper added there is a helper every one of those mocks has to re-declare.
+ */
+export function normalizeModelToken(modelName: string): string {
+  return modelName.replace(/[^A-Za-z0-9_]/g, '');
+}

--- a/src/utils/objectNaming.ts
+++ b/src/utils/objectNaming.ts
@@ -20,6 +20,7 @@ import {
   getObjectSuffix,
   getExtensionNamingStyle,
 } from './modelClassifier.js';
+import { normalizeModelToken } from './modelToken.js';
 
 /**
  * Extension types whose AOT name is `Base.{Token}Extension`. A bare base name
@@ -55,8 +56,13 @@ export function normalizeObjectName(
   const namingStyle = getExtensionNamingStyle();
   let effective = objectName;
 
+  // Cases A and B below strip a model-name token off a name that already carries
+  // one, so they have to compare against the spelling a NAME can hold — the token,
+  // not the raw model name. They are the same string for any model whose name is
+  // already an identifier; for "Contoso Robotics" the raw form matches nothing (#892).
+  const modelToken = modelName ? normalizeModelToken(modelName) : '';
   const modelDiffersFromPrefix =
-    !!modelName && objectPrefix.toLowerCase() !== modelName.toLowerCase();
+    !!modelToken && objectPrefix.toLowerCase() !== modelToken.toLowerCase();
 
   // Case A: dot-notation extension carrying the model name as its token —
   // "CustTable.MyModelExtension" → "CustTable.Extension", so applyObjectPrefix
@@ -70,8 +76,8 @@ export function normalizeObjectName(
     const dotIdx = effective.lastIndexOf('.');
     const basePart = effective.slice(0, dotIdx);
     const suffixPart = effective.slice(dotIdx + 1);
-    if (suffixPart.toLowerCase().startsWith(modelName!.toLowerCase())) {
-      effective = `${basePart}.${suffixPart.slice(modelName!.length)}`;
+    if (suffixPart.toLowerCase().startsWith(modelToken.toLowerCase())) {
+      effective = `${basePart}.${suffixPart.slice(modelToken.length)}`;
       onNote?.(`Stripped model name from dot-notation extension: ${objectName} → ${effective}`);
     }
   }
@@ -83,9 +89,9 @@ export function normalizeObjectName(
     modelDiffersFromPrefix
   ) {
     const baseName = effective.slice(0, -'_Extension'.length);
-    if (baseName.toLowerCase().endsWith(modelName!.toLowerCase())) {
-      effective = baseName.slice(0, -modelName!.length) + '_Extension';
-      onNote?.(`Stripped model name infix "${modelName}" from extension class: ${objectName} → ${effective}`);
+    if (baseName.toLowerCase().endsWith(modelToken.toLowerCase())) {
+      effective = baseName.slice(0, -modelToken.length) + '_Extension';
+      onNote?.(`Stripped model name infix "${modelToken}" from extension class: ${objectName} → ${effective}`);
     }
   }
 

--- a/tests/utils/spacedModelName.test.ts
+++ b/tests/utils/spacedModelName.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Model names that are not identifiers (issue #892).
+ *
+ * A model name is free text; an AOT element name is an identifier. Under
+ * EXTENSION_NAMING_STYLE=model-name the model name is embedded INTO object names,
+ * so a model called "Contoso Robotics" produced `CustTable.Contoso Robotics` and
+ * `CustTable_Contoso Robotics_Extension` — names no build accepts.
+ *
+ * The second, quieter half of the same defect: the idempotency guard compared
+ * against the raw model name, which an existing name can never contain, so the
+ * already-correct `CustTable_ContosoRobotics_Extension` grew a SECOND token on
+ * every pass — and `CustTable.ContosoRobotics` was silently renamed, pointing
+ * modify at an object that does not exist.
+ *
+ * The token is the model name with non-identifier characters removed, which is
+ * what the platform itself derives:
+ *   <Name>Monitoring and Telemetry</Name> → <ModelModule>MonitoringandTelemetry</ModelModule>
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { applyObjectPrefix, resolveObjectPrefix } from '../../src/utils/modelClassifier';
+import { normalizeModelToken } from '../../src/utils/modelToken';
+import { normalizeObjectName } from '../../src/utils/objectNaming';
+import { primeInferredModelPrefix, clearInferredModelPrefixes } from '../../src/utils/modelPrefixInference';
+
+const MODEL = 'Contoso Robotics';
+const TOKEN = 'ContosoRobotics';
+
+/** 152 regular objects, all on the short prefix — the shape the issue reports. */
+const MODEL_OBJECTS = Array.from({ length: 152 }, (_, i) => `CRObject${i}`);
+
+const originalPrefix = process.env.EXTENSION_PREFIX;
+const originalStyle = process.env.EXTENSION_NAMING_STYLE;
+
+beforeEach(() => {
+  clearInferredModelPrefixes();
+  process.env.EXTENSION_PREFIX = 'CR';
+  process.env.EXTENSION_NAMING_STYLE = 'model-name';
+  primeInferredModelPrefix(MODEL, MODEL_OBJECTS);
+});
+
+afterEach(() => {
+  clearInferredModelPrefixes();
+  if (originalPrefix === undefined) delete process.env.EXTENSION_PREFIX;
+  else process.env.EXTENSION_PREFIX = originalPrefix;
+  if (originalStyle === undefined) delete process.env.EXTENSION_NAMING_STYLE;
+  else process.env.EXTENSION_NAMING_STYLE = originalStyle;
+});
+
+describe('normalizeModelToken', () => {
+  it('removes the space, keeping the platform spelling', () => {
+    expect(normalizeModelToken(MODEL)).toBe(TOKEN);
+    expect(normalizeModelToken('Monitoring and Telemetry')).toBe('MonitoringandTelemetry');
+  });
+
+  it('leaves an already-valid model name untouched', () => {
+    expect(normalizeModelToken('ContosoRobotics')).toBe('ContosoRobotics');
+    expect(normalizeModelToken('Fleet_Management2')).toBe('Fleet_Management2');
+  });
+});
+
+describe('#892 — model-name style with a spaced model name', () => {
+  it('dot-notation extension carries no space', () => {
+    const prefix = resolveObjectPrefix(MODEL);
+    expect(applyObjectPrefix('CustTable.Extension', prefix, MODEL)).toBe(`CustTable.${TOKEN}`);
+  });
+
+  it('extension class carries no space', () => {
+    const prefix = resolveObjectPrefix(MODEL);
+    expect(applyObjectPrefix('CustTable_Extension', prefix, MODEL)).toBe(`CustTable_${TOKEN}_Extension`);
+  });
+
+  it('regular objects still take the short prefix', () => {
+    expect(normalizeObjectName('QualityTier', 'table', MODEL)).toBe('CRQualityTier');
+  });
+
+  it('the shared create/modify path agrees on both extension forms', () => {
+    expect(normalizeObjectName('CustTable', 'table-extension', MODEL)).toBe(`CustTable.${TOKEN}`);
+    expect(normalizeObjectName('CustTable', 'class-extension', MODEL)).toBe(`CustTable_${TOKEN}_Extension`);
+  });
+
+  it('REGRESSION: an existing VS-spelled extension class is not given a second token', () => {
+    const prefix = resolveObjectPrefix(MODEL);
+    expect(applyObjectPrefix(`CustTable_${TOKEN}_Extension`, prefix, MODEL))
+      .toBe(`CustTable_${TOKEN}_Extension`);
+    expect(normalizeObjectName(`CustTable_${TOKEN}_Extension`, 'class-extension', MODEL))
+      .toBe(`CustTable_${TOKEN}_Extension`);
+  });
+
+  it('REGRESSION: an existing VS-spelled dot extension is not renamed', () => {
+    expect(normalizeObjectName(`CustTable.${TOKEN}`, 'table-extension', MODEL))
+      .toBe(`CustTable.${TOKEN}`);
+  });
+
+  it('is idempotent across repeated passes', () => {
+    const prefix = resolveObjectPrefix(MODEL);
+    const once = applyObjectPrefix('CustTable_Extension', prefix, MODEL);
+    expect(applyObjectPrefix(once, prefix, MODEL)).toBe(once);
+    const dotOnce = applyObjectPrefix('CustTable.Extension', prefix, MODEL);
+    expect(applyObjectPrefix(dotOnce, prefix, MODEL)).toBe(dotOnce);
+  });
+});
+
+describe('#892 — prefix style is unaffected by the spaced model name', () => {
+  beforeEach(() => {
+    process.env.EXTENSION_NAMING_STYLE = 'prefix';
+  });
+
+  it('extensions take the prefix infix, not the model name', () => {
+    const prefix = resolveObjectPrefix(MODEL);
+    expect(applyObjectPrefix('CustTable.Extension', prefix, MODEL)).toBe('CustTable.CRExtension');
+    expect(applyObjectPrefix('CustTable_Extension', prefix, MODEL)).toBe('CustTableCR_Extension');
+  });
+
+  it('a model-name token on an incoming name is stripped, not stacked', () => {
+    expect(normalizeObjectName(`CustTable.${TOKEN}Extension`, 'table-extension', MODEL))
+      .toBe('CustTable.CRExtension');
+    expect(normalizeObjectName(`CustTable${TOKEN}_Extension`, 'class-extension', MODEL))
+      .toBe('CustTableCR_Extension');
+  });
+});


### PR DESCRIPTION
Fixes #892.

`EXTENSION_NAMING_STYLE=model-name` embedded the model name verbatim, so a model named `Contoso Robotics` produced `CustTable.Contoso Robotics` and `CustTable_Contoso Robotics_Extension`. An AOT element name is an identifier and cannot hold a space, so neither builds.

The model name itself has to keep the space — `PackageResolver` keys its map on the descriptor `<Name>` (`packageResolver.ts:139-142`) and the on-disk model directory carries the space (`getWorkspaceInfo.ts:230` joins the write path with it), so a de-spaced config value resolves to nothing. There was no setting that produced correct names.

## The half the report did not cover

The idempotency guard compared against the raw model name, which no existing name can contain, so the model's **own** correctly-named extensions were mangled:

```
'CustTable_ContosoRobotics_Extension' → 'CustTable_ContosoRobotics_Contoso Robotics_Extension'
'CustTable.ContosoRobotics'           → 'CustTable.Contoso Robotics'
```

The second silently renames an existing extension, so a `modify` targets an object that does not exist — the create/modify divergence `objectNaming.ts` exists to prevent. The reporter has 82 extensions in that spelling, so this hit every edit of an existing extension, not just new creates. Fixing the emitted name without fixing the comparison would have left it in place.

## Why whitespace-stripping and not `<ModelModule>`

The issue proposed `ModelModule` as the more faithful option. It is not safe: `ModelModule` is per-**package**, not per-model — all five model descriptors in `ApplicationSuite` state `<ModelModule>ApplicationSuite</ModelModule>`, so models sharing a package collapse onto one token. It works in the reported case only because that package holds a single model. It is also not reachable where naming runs: `PackageResolver` is async and `modelClassifier` does not import it, while `applyObjectPrefix` is synchronous.

Stripping is what the platform derives itself — the one shipped model whose name has a space:

```xml
<Name>Monitoring and Telemetry</Name> → <ModelModule>MonitoringandTelemetry</ModelModule>
```

character for character, lowercase "and" intact. (Its package *directory* is `MonitoringAndTelemetry`, capital A — another reason not to take the folder name.) Across the whole PackagesLocalDirectory no model `<Name>` holds anything but letters, digits and spaces, and no `ModelModule` holds a space.

## Changes

- **`src/utils/modelToken.ts`** (new) — `normalizeModelToken()`. A no-op for any model whose name is already an identifier. Its own module because a dozen write-path test files mock `modelClassifier` wholesale by enumerating its exports; a helper added there is a helper every one of those mocks has to re-declare (adding it there failed 39 tests).
- **`src/utils/modelClassifier.ts`** — token in both emitted forms and, crucially, in the idempotency guard's comparison.
- **`src/utils/objectNaming.ts`** — same substitution in cases A and B, which carried the same raw-name comparison on the `prefix`-style path.
- **`src/tools/prepare/prepareCreate.ts`** — the charset check ran on the name the caller typed while the composed `finalName` got only a length check, so the one guard that would have caught this never saw the string that had the problem. Now validates `finalName` too, allowing the single dot of extension forms.

## Verification

- `tests/utils/spacedModelName.test.ts` — 11 tests: both naming styles, both extension forms, regular objects, the already-correct-input case, idempotency across repeated passes.
- `tsc --noEmit` and `biome lint` clean.
- Full suite green: 290 files, 3587 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
