### PR TITLE
Give the prefix pin a config key (naming.prefixSource), and stop doctor arguing with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,30 @@ those are called out explicitly below.
   form extension), `repairFormControls`, and `fsExtensionScanner` (the fallback
   that exists to stop the agent shelling out to PowerShell).
 
+### Changed
+- `EXTENSION_PREFIX_SOURCE` is now the config key **`naming.prefixSource`**
+  (`model` | `config`), asked in the advanced pass of the `naming` section
+  (#893). It was `env-only` — a tier meant for values whose reader the
+  wizard-managed JSON cannot honestly describe: the cross-model consent
+  switches, re-read from the `.env` before every guard decision, and the lock
+  heartbeat, read in a process the wizard never configures. This one is a static
+  naming preference with no hot-reload path; it landed in that group only
+  because registering it was how the docs generator stopped deleting it. The
+  cost fell on multi-instance installs, where pinning a prefix meant adding an
+  `instances/<name>/.env` holding one line next to the
+  `instances/<name>/d365fo-mcp.json` holding everything else. Precedence is
+  unchanged — the environment variable still works and still outranks the config
+  file — and a legacy `.env` that sets it now migrates into the JSON instead of
+  being skipped.
+
 ### Fixed
+- `d365fo-mcp doctor` reported a prefix conflict that the server does not have
+  to anyone who had already pinned their prefix, and offered as the fix the
+  setting they had already applied. The check called `inferPrefixFromObjectNames`
+  directly, one level below `getInferredModelPrefix`, which is where the pin is
+  honoured. It now states the pinned value and names the model's own prefix as
+  ignored rather than winning — and warns when the pin has nothing to pin
+  because `naming.prefix` is empty.
 - `get_method`'s Chain-of-Command template copied the base method's **default
   parameter values** into the wrapper signature — the exact defect `validate_code`
   reports as `COC001` and the `coc-authoring` topic forbids. It was also

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -74,7 +74,7 @@ How generated objects, extensions and fields are named.
 | Key | Asked | Env var | Default | Description |
 | --- | --- | --- | --- | --- |
 | `naming.prefix` | setup | `EXTENSION_PREFIX` | — | Your ISV/customer prefix. Prepended to every generated object, field and method name and enforced by the naming validator, so BP checks pass on the first build. Used as the **fallback**: when the active model's existing objects already show a prefix, that one wins — see [Where the prefix comes from](CUSTOM_EXTENSIONS.md#where-the-prefix-comes-from). |
-| — | — | `EXTENSION_PREFIX_SOURCE` | — | Set to `config` to make `EXTENSION_PREFIX` authoritative again instead of learning each model's prefix from its own objects. |
+| `naming.prefixSource` | advanced | `EXTENSION_PREFIX_SOURCE` | `model` | Whether the effective prefix is learned from the active model's own objects or pinned to the configured `naming.prefix`. Pin it when one model carries several feature prefixes that share a stem — inference learns the shared stem, while the objects you write need the full one. See [Where the prefix comes from](CUSTOM_EXTENSIONS.md#where-the-prefix-comes-from). Values: `model` — the model's own objects decide, falling back to naming.prefix; `config` — always naming.prefix, inference off (pre-1.8.2 behaviour). |
 | `naming.suffix` | advanced | `EXTENSION_SUFFIX` | — | Optional suffix appended to new object names (MyTableZZ with suffix "ZZ"). Most projects use only a prefix — leave empty unless your convention requires one. |
 | `naming.extensionStyle` | advanced | `EXTENSION_NAMING_STYLE` | `prefix` | Whether extension classes/elements embed the prefix (per the Microsoft prefix guideline) or the model name (the Visual Studio default). Use model-name when your model name is long but your prefix is a short abbreviation. Values: `prefix` — CustTable.CrExtension — embeds the extension prefix; `model-name` — CustTable.ContosoRobotics — embeds the model name (VS default). |
 
@@ -179,6 +179,7 @@ Downloading a pre-built index from blob storage instead of building it locally.
   },
   "naming": {
     "prefix": "ISV_",
+    "prefixSource": "model",
     "suffix": "",
     "extensionStyle": "prefix"
   },

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -94,9 +94,13 @@ Inference is conservative: a model whose objects show no consistent prefix (fewe
 
 Compound prefixes are read in full, up to three PascalCase segments: a model whose objects are `ContosoFinSKVendPaymentTable`, `ContosoFinSKCustInvoiceJour`… yields `ContosoFinSK`, not `ContosoFin`. Where the model's extensions state the infix outright (`VendTable.ContosoFinSKExtension`), that spelling wins over anything derived.
 
-```env
-EXTENSION_PREFIX_SOURCE=config   # pin step 2 above step 1 (pre-1.8.2 behaviour)
+To pin step 2 above step 1 (pre-1.8.2 behaviour) — worth doing when one model carries several feature prefixes sharing a stem, so inference learns the shared stem while your objects need the full one:
+
+```json
+{ "naming": { "prefix": "CRXCore", "prefixSource": "config" } }
 ```
+
+`npx d365fo-mcp config naming` asks for it in the advanced pass. The equivalent environment variable, `EXTENSION_PREFIX_SOURCE=config`, still works and still outranks the config file.
 
 ## Objects owned by another model
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -176,15 +176,43 @@ async function checkWorkspaceDetection(
  * for every model — but the server resolves the model's own naming ABOVE the
  * configuration, so a user reading only their config has the wrong answer. State
  * both, and how to pin the configured one.
+ *
+ * `pinned` is naming.prefixSource=config. This check used to call the inference
+ * directly and so never saw it — modelPrefixInference reads it in
+ * getInferredModelPrefix, one level above inferPrefixFromObjectNames — which
+ * meant a user who had already pinned the prefix was still told their model's
+ * naming wins (it does not) and offered the fix they had already applied (#893).
  */
 export function checkPrefixResolution(
   configuredPrefix: string,
   modelName: string | null,
   modelObjectNames: string[],
   label: string,
+  pinned = false,
 ): CheckResult[] {
   const inferred = modelName ? inferPrefixFromObjectNames(modelObjectNames, modelName) : null;
   const bare = (s: string) => s.replace(/_+$/, '').toLowerCase();
+
+  if (pinned) {
+    // Inference is off, so naming.prefix is the whole answer — and an empty one
+    // is worse here than anywhere else: pinning it leaves nothing to fall back
+    // to but the model name.
+    if (!configuredPrefix) {
+      return [{
+        severity: 'warn',
+        message: `${label}: naming.prefixSource=config pins the configured prefix, but naming.prefix is empty ` +
+          `— new objects will be prefixed with the model name`,
+        fix: `set naming.prefix to your ISV prefix (${SETUP_COMMAND})`,
+      }];
+    }
+    const ignored = inferred?.regular && bare(inferred.regular) !== bare(configuredPrefix)
+      ? ` — model "${modelName}"'s objects use "${inferred.regular}", ignored while the prefix is pinned`
+      : '';
+    return [{
+      severity: 'ok',
+      message: `${label}: prefix "${configuredPrefix}" (naming.prefix, pinned by naming.prefixSource=config)${ignored}`,
+    }];
+  }
 
   if (!inferred?.regular) {
     if (!configuredPrefix) {
@@ -207,7 +235,8 @@ export function checkPrefixResolution(
     message: `${label}: prefix conflict — model "${modelName}"'s objects use "${inferred.regular}" ` +
       `(${inferred.coverage}/${inferred.sampleSize}), naming.prefix says "${configuredPrefix}". ` +
       `The model's own naming wins, so new objects are named "${inferred.regular}…".`,
-    fix: 'EXTENSION_PREFIX_SOURCE=config pins the configured value instead',
+    fix: `set naming.prefixSource=config to pin the configured value instead (${SETUP_COMMAND}, or ` +
+      `EXTENSION_PREFIX_SOURCE=config in the environment)`,
   }];
 }
 
@@ -385,7 +414,15 @@ export async function doctorCommand(): Promise<void> {
   const names = detection.modelName
     ? await modelObjectNames(readPath(root.store, settingByPath('index.dbPath')!, paths.defaultDb), detection.modelName)
     : [];
-  for (const r of checkPrefixResolution(configuredPrefix, detection.modelName, names, 'Naming')) emit(r);
+  // Same precedence the server applies: the real environment outranks the
+  // config file (loadEnv), and the CLI never projects one onto the other.
+  const prefixSource = (
+    process.env.EXTENSION_PREFIX_SOURCE
+    ?? String(readSetting(root.store, settingByPath('naming.prefixSource')!) ?? '')
+  ).trim().toLowerCase();
+  for (const r of checkPrefixResolution(
+    configuredPrefix, detection.modelName, names, 'Naming', prefixSource === 'config',
+  )) emit(r);
 
   // C# bridge: the only write path; Windows-only.
   if (isWindows) {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -43,13 +43,21 @@ export interface Setting {
   /**
    * Dotted path inside the JSON config, e.g. "environment.packagePath".
    *
-   * Absent for `env-only` settings: consent-style switches whose whole point is
-   * that they are re-read from the environment (or the .env file) between tool
-   * calls, so writing them into the wizard-managed JSON would misrepresent when
-   * a change takes effect. They are still registered here — without an entry
-   * the docs generator silently drops them, which is how three cross-model
-   * variables disappeared from docs/CONFIGURATION.md the last time it was
-   * regenerated.
+   * Absent for `env-only` settings: values whose reader is somewhere the
+   * wizard-managed JSON cannot honestly describe — the cross-model consent
+   * switches, re-read from the .env before every guard decision so a grant
+   * applies without a restart (loadEnv.reloadWritePolicy), and the lock
+   * heartbeat, read at acquire time in a process the wizard never configures.
+   * A JSON key would misrepresent when a change takes effect.
+   *
+   * "The runtime reads it straight from process.env" is NOT that reason — every
+   * setting here does, via toEnvRecord. EXTENSION_PREFIX_SOURCE sat in this
+   * group on that basis alone until #893, which cost a multi-instance install a
+   * whole second configuration file for one static naming preference.
+   *
+   * env-only settings are still registered — without an entry the docs
+   * generator silently drops them, which is how three cross-model variables
+   * disappeared from docs/CONFIGURATION.md the last time it was regenerated.
    */
   path?: string;
   /** Environment variable the server/scripts read at runtime. */
@@ -289,14 +297,22 @@ export const SETTINGS: Setting[] = [
     required: true,
   },
   {
+    path: 'naming.prefixSource',
     env: 'EXTENSION_PREFIX_SOURCE',
     section: 'naming',
-    tier: 'env-only',
-    type: 'string',
-    label: 'Pin the configured prefix',
+    tier: 'advanced',
+    type: 'enum',
+    label: 'Where the prefix comes from',
     description:
-      'Set to `config` to make `EXTENSION_PREFIX` authoritative again instead of learning each model\'s prefix from ' +
-      'its own objects.',
+      'Whether the effective prefix is learned from the active model\'s own objects or pinned to the configured ' +
+      '`naming.prefix`. Pin it when one model carries several feature prefixes that share a stem — inference learns ' +
+      'the shared stem, while the objects you write need the full one. See ' +
+      '[Where the prefix comes from](CUSTOM_EXTENSIONS.md#where-the-prefix-comes-from).',
+    default: 'model',
+    choices: [
+      { value: 'model', hint: 'the model\'s own objects decide, falling back to naming.prefix' },
+      { value: 'config', hint: 'always naming.prefix, inference off (pre-1.8.2 behaviour)' },
+    ],
   },
   {
     path: 'naming.suffix',

--- a/src/tools/analysis/prefixDiagnostics.ts
+++ b/src/tools/analysis/prefixDiagnostics.ts
@@ -57,7 +57,7 @@ export function buildPrefixDiagnostics(
     `merely the active project and its own prefix may differ — see the project-switch note below.`;
 
   const disagreeNote =
-    `⚠️  The model's own objects use "${learned?.regular}", which overrides EXTENSION_PREFIX="${extensionPrefixEnv}" — new objects will be named "${effectivePrefix}…". If that is wrong, the model's existing objects are the thing to check; set EXTENSION_PREFIX_SOURCE=config to pin the configured value instead.`;
+    `⚠️  The model's own objects use "${learned?.regular}", which overrides EXTENSION_PREFIX="${extensionPrefixEnv}" — new objects will be named "${effectivePrefix}…". If that is wrong, the model's existing objects are the thing to check; set naming.prefixSource=config (env: EXTENSION_PREFIX_SOURCE=config) to pin the configured value instead.`;
 
   const notConfiguredNote =
     `⚠️  EXTENSION_PREFIX is not set in the server environment. The model name "${writeModel}" will be used as prefix. Add EXTENSION_PREFIX=MY (or your ISV prefix) to the .env file and restart the server.`;

--- a/src/tools/specs/opSpecs.ts
+++ b/src/tools/specs/opSpecs.ts
@@ -73,7 +73,7 @@ const REDIRECT_ANSWERS: Record<string, string> = {
     '  • Pass the BASE name to d365fo_file(action="create") — the prefix is applied for you.',
     '    Do NOT pre-apply it and do NOT add a leading separator; both double up.',
     '  • The prefix is inferred from the model\'s own objects and beats EXTENSION_PREFIX.',
-    '    Pin the configured value instead with EXTENSION_PREFIX_SOURCE=config.',
+    '    Pin the configured value instead with naming.prefixSource=config.',
     '  • Regular objects keep the model\'s separator (ConSK_MyEnum); extension elements',
     '    use the PascalCase infix without one (MyTable.ConSkExtension,',
     '    MyTableConSk_Extension).',

--- a/src/utils/effectivePrefix.ts
+++ b/src/utils/effectivePrefix.ts
@@ -154,6 +154,6 @@ export function prefixConflictWarning(resolution: EffectivePrefix): string | nul
   return (
     `The model's own objects use "${resolution.inferred!.regular}", overriding ` +
     `EXTENSION_PREFIX="${resolution.configured}". ` +
-    `To pin the configured value instead: EXTENSION_PREFIX_SOURCE=config.`
+    `To pin the configured value instead: naming.prefixSource=config (env: EXTENSION_PREFIX_SOURCE=config).`
   );
 }

--- a/tests/cli/doctorWorkspace.test.ts
+++ b/tests/cli/doctorWorkspace.test.ts
@@ -47,4 +47,35 @@ describe('doctor — prefix resolution', () => {
     expect(result.severity).toBe('warn');
     expect(result.message).toContain('no prefix configured');
   });
+
+  // #893: the check called the inference directly, below the layer that honours
+  // the pin, so it reported a conflict that the server does not have and told
+  // the user to apply the setting they had already applied.
+  it('reports no conflict once the configured prefix is pinned', () => {
+    const [result] = checkPrefixResolution('Con', 'ContosoFinanceSK', MODEL_OBJECTS, 'Naming', true);
+
+    expect(result.severity).toBe('ok');
+    expect(result.message).toContain('"Con"');
+    expect(result.message).toContain('pinned by naming.prefixSource=config');
+    // The learned value is still stated — it is why the two disagree — but as
+    // something being ignored, not as the one that wins.
+    expect(result.message).toContain('ignored while the prefix is pinned');
+    expect(result.message).not.toContain('wins');
+    expect(result.fix).toBeUndefined();
+  });
+
+  it('says nothing about the model when the pinned prefix is what it uses anyway', () => {
+    const [result] = checkPrefixResolution('ConSK', 'ContosoFinanceSK', MODEL_OBJECTS, 'Naming', true);
+
+    expect(result.severity).toBe('ok');
+    expect(result.message).not.toContain('ignored');
+  });
+
+  it('warns when the pin has nothing to pin — an empty naming.prefix', () => {
+    const [result] = checkPrefixResolution('', 'ContosoFinanceSK', MODEL_OBJECTS, 'Naming', true);
+
+    expect(result.severity).toBe('warn');
+    expect(result.message).toContain('naming.prefix is empty');
+    expect(result.fix).toContain('naming.prefix');
+  });
 });

--- a/tests/utils/configFile.test.ts
+++ b/tests/utils/configFile.test.ts
@@ -107,6 +107,30 @@ describe('config file', () => {
     expect(env.PORT).toBe('3001');
   });
 
+  it('pins the prefix from the config file alone (#893)', () => {
+    // The whole point of giving EXTENSION_PREFIX_SOURCE a key: an instance can
+    // pin its prefix in the one file that already holds everything else about
+    // it, instead of gaining an instances/<name>/.env for a single line. The
+    // stored value has to be the exact token inferenceDisabled() compares
+    // against in modelPrefixInference.
+    writeConfigFile(join(tmp, 'config', 'd365fo-mcp.json'), {
+      naming: { prefix: 'CRXCore', prefixSource: 'config' },
+    });
+
+    const env = toEnvRecord(resolveConfigFiles(tmp, { allowEnvOverride: false }));
+    expect(env.EXTENSION_PREFIX).toBe('CRXCore');
+    expect(env.EXTENSION_PREFIX_SOURCE).toBe('config');
+  });
+
+  it('leaves the prefix source out of the environment when it is not configured', () => {
+    // Absent must stay absent: the registry default is documentation, and
+    // emitting it would override an ambient .env that sets the variable.
+    writeConfigFile(join(tmp, 'config', 'd365fo-mcp.json'), { naming: { prefix: 'CRXCore' } });
+
+    expect(toEnvRecord(resolveConfigFiles(tmp, { allowEnvOverride: false })).EXTENSION_PREFIX_SOURCE)
+      .toBeUndefined();
+  });
+
   it('resolves relative path settings from the project directory, not config/', () => {
     writeConfigFile(join(tmp, 'config', 'd365fo-mcp.json'), { index: { dbPath: './data/xpp-metadata.db' } });
     const env = toEnvRecord(resolveConfigFiles(tmp, { allowEnvOverride: false }));
@@ -211,6 +235,17 @@ describe('settings store', () => {
     // Empty values carry nothing over, and secrets are never auto-migrated.
     expect(migrated).not.toContain('CUSTOM_MODELS');
     expect(migrated).not.toContain('AZURE_STORAGE_CONNECTION_STRING');
+  });
+
+  it('carries a pinned prefix source out of a legacy .env', () => {
+    // It had no config path, so migration skipped it silently and the .env had
+    // to stay behind for that one line (#893).
+    const envFile = writeEnv('EXTENSION_PREFIX=ISV_\nEXTENSION_PREFIX_SOURCE=config\n');
+    const store = openStore(tmp, envFile);
+    const migrated = migrateLegacyEnv(store).map(s => s.env);
+
+    expect(migrated).toContain('EXTENSION_PREFIX_SOURCE');
+    expect(getAtPath(store.config, 'naming.prefixSource')).toBe('config');
   });
 
   it('leaves behind an enum value the registry no longer offers', () => {


### PR DESCRIPTION
Closes #893.

## What

`EXTENSION_PREFIX_SOURCE` becomes the config key **`naming.prefixSource`** — an `advanced` enum (`model` | `config`) in the `naming` section.

The `env-only` tier is for values whose reader the wizard-managed JSON cannot honestly describe: the two cross-model consent switches, re-read from the `.env` before every guard decision (`loadEnv.reloadWritePolicy`) so a grant applies without a restart, and `OPERATION_LOCK_HEARTBEAT_MS`, read at acquire time in a process the wizard never configures. `EXTENSION_PREFIX_SOURCE` is a static naming preference with neither property, and it sits beside `naming.prefix`, which *is* a config key. It joined the group in `1c99aa2`, where registering it was simply how `generate-config-docs` stopped deleting it from `CONFIGURATION.md`.

The cost fell on multi-instance installs: pinning a prefix meant an `instances/<name>/.env` holding one line, next to the `instances/<name>/d365fo-mcp.json` holding everything else. The `.mcp.json` `env` block is no way out — Scenario F instances are reached over HTTP by `url`, so there is no `env` block to put it in.

An **enum**, not the `string` the entry used to be: with tier `advanced` the wizard asks the question, and a free-text prompt whose only meaningful answer is the literal `config` is not a question worth asking.

## Compatibility

Precedence is unchanged. `toEnvRecord` emits the key only when the config file sets it, so:

- the environment variable still works and still outranks the config file;
- an ambient `.env` that sets it keeps winning over a config file that does not;
- an installation with neither behaves exactly as before.

A legacy `.env` that sets it now migrates into the JSON instead of being silently skipped (it had no `path`, so `migrateLegacyEnv` dropped it).

## Doctor fix (found while auditing the issue)

`checkPrefixResolution` called `inferPrefixFromObjectNames` directly — one level below `getInferredModelPrefix`, where the pin is honoured — so it never saw the pin. Anyone who had already pinned their prefix was told *"prefix conflict … The model's own naming wins"* (it does not) with `fix: EXTENSION_PREFIX_SOURCE=config` — the setting they had just applied.

It now reports the pinned value, names the model's own prefix as ignored rather than winning, and warns when the pin has nothing to pin because `naming.prefix` is empty. The caller resolves the pin with the same precedence the server uses (real environment over config file).

## Also

- The `Setting.path` doc comment described every `env-only` entry as a consent switch re-read from the environment, which was true of two of the four. Rewritten, with the trap named: "the runtime reads it from `process.env`" is not a reason — every setting does, via `toEnvRecord`.
- Messages that only advertised the environment variable now lead with the config key: `effectivePrefix`, `prefixDiagnostics`, the `naming` op-spec, the doctor fix line, and the `CUSTOM_EXTENSIONS.md` snippet. `docs/CONFIGURATION.md` regenerated.

## Verification

`tsc --noEmit`, `biome lint`, `config:docs -- --check`, 3593 unit tests, integration tier — all green. New coverage: three doctor cases for the pinned states, config-file projection of the pin (asserting the stored value is the exact token `inferenceDisabled()` compares against), absence when unconfigured, and the legacy-`.env` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)