### PR TITLE
fix(doctor): detect stale legacy .env overrides for UDE path settings

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -13,7 +13,7 @@ import { bridgeBuildCommand, dataRoot, installMode, isWindows, paths, repoRoot }
 import { commandExists } from '../exec.js';
 import { isLegacyInstanceLayout, listInstances, type Instance } from '../instances.js';
 import { checkRelease } from '../npmRegistry.js';
-import { conflictingLegacyValues, readPath, readSetting, type SettingsStore } from '../settingsStore.js';
+import { conflictingLegacyValues, readPath, readSetting, settingSource, type SettingsStore } from '../settingsStore.js';
 import { instanceTarget, rootTarget, type Target } from '../target.js';
 import { isXppConfigStale, listXppConfigs, xppConfigDir } from '../xppConfig.js';
 import { describePackagesRootScan, packagesRoots } from '../../utils/packagesRoot.js';
@@ -98,7 +98,8 @@ function checkConfig(target: Target, label: string): CheckResult {
 function checkPackagesRoot(store: SettingsStore, label: string): CheckResult[] {
   if (!isWindows) return [];
 
-  const configured = String(readSetting(store, settingByPath('environment.packagePath')!) ?? '').trim();
+  const setting = settingByPath('environment.packagePath')!;
+  const configured = String(readSetting(store, setting) ?? '').trim();
   const detected = packagesRoots();
 
   if (!configured) {
@@ -112,14 +113,64 @@ function checkPackagesRoot(store: SettingsStore, label: string): CheckResult[] {
   if (fs.existsSync(configured)) {
     return [{ severity: 'ok', message: `${label}: packages root OK (${configured})` }];
   }
-  return [{
-    severity: 'fail',
-    message: `${label}: packages root does not exist (${configured})` +
+  return [{ severity: 'fail', ...missingPathFix(store, setting, label, 'packages root', configured, detected) }];
+}
+
+/**
+ * customPackagesPath (UDE ModelStoreFolder) / microsoftPackagesPath (UDE
+ * FrameworkDirectory) against what the machine actually has.
+ *
+ * Both are normally left unset and resolved live from the active XPP config —
+ * that's how the server notices a UDE platform update. But the setup wizard
+ * still writes them into an instance's legacy .env at setup time, and once a
+ * platform update deletes the old framework/model-store folder, that hardcoded
+ * .env value keeps outranking the (now-correct) XPP-config auto-detection —
+ * see settingSource in ../settingsStore.js. The bridge then dies silently with
+ * "C# bridge unavailable (ude)" and no indication that a stale .env is why.
+ */
+function checkUdeOverridePath(store: SettingsStore, label: string, path: string, humanName: string): CheckResult[] {
+  if (!isWindows) return [];
+
+  const setting = settingByPath(path)!;
+  const configured = String(readSetting(store, setting) ?? '').trim();
+  // Unset is the normal, healthy state for these two — nothing to report.
+  if (!configured) return [];
+  if (fs.existsSync(configured)) {
+    return [{ severity: 'ok', message: `${label}: ${humanName} OK (${configured})` }];
+  }
+  return [{ severity: 'fail', ...missingPathFix(store, setting, label, humanName, configured, packagesRoots()) }];
+}
+
+/**
+ * Shared "path setting points at a folder that isn't there" message. When the
+ * value is pinned by the legacy .env rather than the JSON config, that is very
+ * likely the actual bug (a stale override silently beating live auto-detection)
+ * rather than a config typo, so the fix steers there instead of just re-pinning
+ * the same kind of static value that caused the problem.
+ */
+function missingPathFix(
+  store: SettingsStore,
+  setting: import('../../config/settings.js').Setting,
+  label: string,
+  humanName: string,
+  configured: string,
+  detected: string[],
+): Omit<CheckResult, 'severity'> {
+  const source = settingSource(store, setting);
+  if (source === 'env') {
+    return {
+      message: `${label}: ${humanName} does not exist (${configured}) — pinned by legacy .env (${setting.env}), not the JSON config`,
+      fix: `remove ${setting.env} from .env; this UDE value is normally auto-detected from the active XPP config, ` +
+        `and a hardcoded copy silently overrides that detection once a platform update moves or deletes this folder`,
+    };
+  }
+  return {
+    message: `${label}: ${humanName} does not exist (${configured})` +
       (detected.length > 0 ? `\n   found instead: ${detected.join(', ')}` : `\n   ${describePackagesRootScan()}`),
     fix: detected.length > 0
-      ? `set environment.packagePath to ${detected[0]} (${SETUP_COMMAND})`
-      : `point environment.packagePath at this machine's PackagesLocalDirectory (${SETUP_COMMAND})`,
-  }];
+      ? `set ${setting.path} to ${detected[0]} (${SETUP_COMMAND})`
+      : `point ${setting.path} at this machine's PackagesLocalDirectory (${SETUP_COMMAND})`,
+  };
 }
 
 /**
@@ -402,6 +453,8 @@ export async function doctorCommand(): Promise<void> {
   emit(checkConfig(root, 'Root'));
   for (const r of legacyEnvChecks(root, 'Root')) emit(r);
   for (const r of checkPackagesRoot(root.store, 'Root')) emit(r);
+  for (const r of checkUdeOverridePath(root.store, 'Root', 'environment.customPackagesPath', 'custom X++ root')) emit(r);
+  for (const r of checkUdeOverridePath(root.store, 'Root', 'environment.microsoftPackagesPath', 'Microsoft X++ root')) emit(r);
 
   // Database (root)
   emit(checkDb(root.store, paths.defaultDb, 'Root'));
@@ -459,6 +512,8 @@ export async function doctorCommand(): Promise<void> {
       for (const r of layoutChecks(inst)) emit(r);
       for (const r of legacyEnvChecks(target, `Instance '${inst.name}'`)) emit(r);
       for (const r of checkPackagesRoot(target.store, `Instance '${inst.name}'`)) emit(r);
+      for (const r of checkUdeOverridePath(target.store, `Instance '${inst.name}'`, 'environment.customPackagesPath', 'custom X++ root')) emit(r);
+      for (const r of checkUdeOverridePath(target.store, `Instance '${inst.name}'`, 'environment.microsoftPackagesPath', 'Microsoft X++ root')) emit(r);
       emit(checkDb(target.store, resolve(inst.dir, 'data', 'xpp-metadata.db'), `Instance '${inst.name}'`));
       if (isWindows && isXppConfigStale(target.store)) {
         emit({

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -98,10 +98,8 @@ function checkConfig(target: Target, label: string): CheckResult {
 function checkPackagesRoot(store: SettingsStore, label: string): CheckResult[] {
   if (!isWindows) return [];
 
-  const setting = settingByPath('environment.packagePath')!;
-  const configured = String(readSetting(store, setting) ?? '').trim();
   const detected = packagesRoots();
-
+  const configured = String(readSetting(store, settingByPath('environment.packagePath')!) ?? '').trim();
   if (!configured) {
     // UDE resolves its roots from the XPP config, so silence here is normal.
     if (detected.length === 0) return [];
@@ -110,66 +108,172 @@ function checkPackagesRoot(store: SettingsStore, label: string): CheckResult[] {
       message: `${label}: packages root not configured — the server will use ${detected[0]}`,
     }];
   }
-  if (fs.existsSync(configured)) {
-    return [{ severity: 'ok', message: `${label}: packages root OK (${configured})` }];
-  }
-  return [{ severity: 'fail', ...missingPathFix(store, setting, label, 'packages root', configured, detected) }];
+  return checkPathSetting(store, label, 'environment.packagePath');
 }
 
 /**
- * customPackagesPath (UDE ModelStoreFolder) / microsoftPackagesPath (UDE
- * FrameworkDirectory) against what the machine actually has.
+ * One configured path setting against what the machine actually has.
  *
- * Both are normally left unset and resolved live from the active XPP config —
- * that's how the server notices a UDE platform update. But the setup wizard
- * still writes them into an instance's legacy .env at setup time, and once a
- * platform update deletes the old framework/model-store folder, that hardcoded
- * .env value keeps outranking the (now-correct) XPP-config auto-detection —
- * see settingSource in ../settingsStore.js. The bridge then dies silently with
- * "C# bridge unavailable (ude)" and no indication that a stale .env is why.
+ * Unset is silent: for the two UDE roots that is the normal and recommended
+ * state (they resolve live from the active XPP config, which is how the server
+ * notices a platform update), and packagePath has its own not-configured
+ * branch above.
  */
-function checkUdeOverridePath(store: SettingsStore, label: string, path: string, humanName: string): CheckResult[] {
+function checkPathSetting(store: SettingsStore, label: string, settingPath: string): CheckResult[] {
   if (!isWindows) return [];
 
-  const setting = settingByPath(path)!;
+  const setting = settingByPath(settingPath)!;
+  const facts = PATH_FACTS[settingPath];
   const configured = String(readSetting(store, setting) ?? '').trim();
-  // Unset is the normal, healthy state for these two — nothing to report.
   if (!configured) return [];
   if (fs.existsSync(configured)) {
-    return [{ severity: 'ok', message: `${label}: ${humanName} OK (${configured})` }];
+    return [{ severity: 'ok', message: `${label}: ${facts.humanName} OK (${configured})` }];
   }
-  return [{ severity: 'fail', ...missingPathFix(store, setting, label, humanName, configured, packagesRoots()) }];
+  return [{
+    severity: 'fail',
+    ...missingPathFix(
+      setting,
+      facts,
+      label,
+      configured,
+      environmentKind(store),
+      settingSource(store, setting) === 'env',
+    ),
+  }];
+}
+
+/** Classic AOSService VM, or Unified Developer Experience. */
+export type EnvKind = 'traditional' | 'ude';
+
+/**
+ * Which of the two this install is. The configured value wins; with nothing
+ * configured this falls back to the same XPP-config detection the server itself
+ * uses (see environment.type in config/settings.ts), so doctor's diagnosis
+ * matches the runtime's behaviour rather than a second guess at it.
+ */
+function environmentKind(store: SettingsStore): EnvKind {
+  const configured = String(readSetting(store, settingByPath('environment.type')!) ?? '').trim().toLowerCase();
+  if (configured === 'ude' || configured === 'traditional') return configured;
+  return listXppConfigs().length > 0 ? 'ude' : 'traditional';
 }
 
 /**
- * Shared "path setting points at a folder that isn't there" message. When the
- * value is pinned by the legacy .env rather than the JSON config, that is very
- * likely the actual bug (a stale override silently beating live auto-detection)
- * rather than a config typo, so the fix steers there instead of just re-pinning
- * the same kind of static value that caused the problem.
+ * What a path setting IS, so that "this folder is missing" can name the right
+ * cause and the right cure for it.
+ *
+ * Without this the three settings shared one message, and it fitted only one of
+ * them: `packagePath` on UDE. It told a traditional VM that its packages root
+ * is "normally auto-detected from the active XPP config" (it is not — the drive
+ * scan finds it), and it offered `<drive>:\AosService\PackagesLocalDirectory`,
+ * a traditional-VM artifact, as the value to give the UDE ModelStoreFolder and
+ * FrameworkDirectory.
+ *
+ * `autoSource` is the load-bearing one: a stale pin is only a *stale pin* where
+ * something would otherwise resolve the value live. Where nothing would, the
+ * pin is the configuration, and telling the user to delete it is telling them
+ * to break their install — `customPackagesPath` on a traditional VM is exactly
+ * that case, the documented fix for junction layouts (docs/MCP_CONFIG.md).
  */
-function missingPathFix(
-  store: SettingsStore,
+interface PathFacts {
+  humanName: string;
+  /** How the value resolves when nothing pins it, or null when nothing does. */
+  autoSource(kind: EnvKind): string | null;
+  /** Values doctor can actually propose — empty when it has no way to know one. */
+  candidates(kind: EnvKind): string[];
+  /** What the setting ought to point at, in words. */
+  target(kind: EnvKind): string;
+  /** Extra context line when there is no candidate to name, or null. */
+  note(kind: EnvKind): string | null;
+}
+
+export const PATH_FACTS: Record<string, PathFacts> = {
+  'environment.packagePath': {
+    humanName: 'packages root',
+    autoSource: kind => kind === 'ude'
+      ? 'the active XPP config'
+      : (packagesRoots().length > 0 ? 'the drive scan for AosService\\PackagesLocalDirectory' : null),
+    // On UDE the XPP config is the authority; a stray empty C:\AosService stub
+    // is exactly the wrong thing to propose there.
+    candidates: kind => kind === 'ude' ? [] : packagesRoots(),
+    target: () => "this machine's PackagesLocalDirectory",
+    note: kind => kind === 'ude' ? null : describePackagesRootScan(),
+  },
+  'environment.customPackagesPath': {
+    humanName: 'custom X++ root',
+    // Traditional: not auto-detected at all. It is a deliberate pin naming the
+    // repo that holds custom metadata outside PackagesLocalDirectory.
+    autoSource: kind => kind === 'ude' ? 'the active XPP config (ModelStoreFolder)' : null,
+    candidates: () => [],
+    target: kind => kind === 'ude'
+      ? 'the ModelStoreFolder of the active XPP config'
+      : 'the folder your custom model metadata actually lives in',
+    note: () => null,
+  },
+  'environment.microsoftPackagesPath': {
+    humanName: 'Microsoft X++ root',
+    autoSource: kind => kind === 'ude' ? 'the active XPP config (FrameworkDirectory)' : null,
+    candidates: () => [],
+    target: () => 'the read-only Microsoft packages folder (FrameworkDirectory)',
+    note: kind => kind === 'ude' ? null : 'this setting applies to UDE installs only',
+  },
+};
+
+/**
+ * "Path setting points at a folder that isn't there" — with the cause named.
+ *
+ * A value pinned by the legacy .env instead of the JSON config is the likely bug
+ * whenever something else would have resolved it live: the .env copy goes stale
+ * the moment a platform update moves the folder, and it keeps outranking the
+ * now-correct detection at every startup (see configManager's envContext, which
+ * reads these env vars before consulting the XPP config). The server then dies
+ * with "C# bridge unavailable (ude)" and nothing points at the .env.
+ *
+ * Pure — every input is passed in — so the messages can be tested without a
+ * Windows box, an XPP config or a real .env.
+ */
+export function missingPathFix(
   setting: import('../../config/settings.js').Setting,
+  facts: PathFacts,
   label: string,
-  humanName: string,
   configured: string,
-  detected: string[],
+  kind: EnvKind,
+  pinnedByEnv: boolean,
 ): Omit<CheckResult, 'severity'> {
-  const source = settingSource(store, setting);
-  if (source === 'env') {
+  const auto = facts.autoSource(kind);
+  const candidates = facts.candidates(kind);
+  const note = candidates.length > 0 ? `found instead: ${candidates.join(', ')}` : facts.note(kind);
+
+  const message = `${label}: ${facts.humanName} does not exist (${configured})` +
+    (pinnedByEnv ? `\n   pinned by legacy .env (${setting.env}), not the JSON config` : '') +
+    (note ? `\n   ${note}` : '');
+
+  // Deleting the key IS the whole fix here: the value it hides is already right.
+  if (pinnedByEnv && auto) {
     return {
-      message: `${label}: ${humanName} does not exist (${configured}) — pinned by legacy .env (${setting.env}), not the JSON config`,
-      fix: `remove ${setting.env} from .env; this UDE value is normally auto-detected from the active XPP config, ` +
-        `and a hardcoded copy silently overrides that detection once a platform update moves or deletes this folder`,
+      message,
+      fix: `remove ${setting.env} from .env — ${facts.humanName} is resolved from ${auto}, and a hardcoded ` +
+        `copy silently overrides that once a platform update moves or deletes the folder`,
     };
   }
+  const dropEnvFirst = pinnedByEnv ? `remove ${setting.env} from .env, then set` : `set`;
+  if (candidates.length > 0) {
+    return { message, fix: `${dropEnvFirst} ${setting.path} to ${candidates[0]} (${SETUP_COMMAND})` };
+  }
+  if (auto) {
+    // Naming `target` again here would only repeat `auto` in other words — on
+    // UDE the folder to point at IS the one the XPP config would have supplied.
+    return {
+      message,
+      fix: `clear ${setting.path} so it resolves from ${auto}, or repoint it if this install genuinely ` +
+        `keeps ${facts.humanName} elsewhere (${SETUP_COMMAND})`,
+    };
+  }
+  // Nothing would resolve this value on its own, so the pin is the configuration
+  // — it needs correcting, not deleting.
   return {
-    message: `${label}: ${humanName} does not exist (${configured})` +
-      (detected.length > 0 ? `\n   found instead: ${detected.join(', ')}` : `\n   ${describePackagesRootScan()}`),
-    fix: detected.length > 0
-      ? `set ${setting.path} to ${detected[0]} (${SETUP_COMMAND})`
-      : `point ${setting.path} at this machine's PackagesLocalDirectory (${SETUP_COMMAND})`,
+    message,
+    fix: `point ${setting.path} at ${facts.target(kind)} (${SETUP_COMMAND})` +
+      (pinnedByEnv ? `, and note that ${setting.env} in .env currently outranks the JSON config` : ''),
   };
 }
 
@@ -453,8 +557,8 @@ export async function doctorCommand(): Promise<void> {
   emit(checkConfig(root, 'Root'));
   for (const r of legacyEnvChecks(root, 'Root')) emit(r);
   for (const r of checkPackagesRoot(root.store, 'Root')) emit(r);
-  for (const r of checkUdeOverridePath(root.store, 'Root', 'environment.customPackagesPath', 'custom X++ root')) emit(r);
-  for (const r of checkUdeOverridePath(root.store, 'Root', 'environment.microsoftPackagesPath', 'Microsoft X++ root')) emit(r);
+  for (const r of checkPathSetting(root.store, 'Root', 'environment.customPackagesPath')) emit(r);
+  for (const r of checkPathSetting(root.store, 'Root', 'environment.microsoftPackagesPath')) emit(r);
 
   // Database (root)
   emit(checkDb(root.store, paths.defaultDb, 'Root'));
@@ -512,8 +616,8 @@ export async function doctorCommand(): Promise<void> {
       for (const r of layoutChecks(inst)) emit(r);
       for (const r of legacyEnvChecks(target, `Instance '${inst.name}'`)) emit(r);
       for (const r of checkPackagesRoot(target.store, `Instance '${inst.name}'`)) emit(r);
-      for (const r of checkUdeOverridePath(target.store, `Instance '${inst.name}'`, 'environment.customPackagesPath', 'custom X++ root')) emit(r);
-      for (const r of checkUdeOverridePath(target.store, `Instance '${inst.name}'`, 'environment.microsoftPackagesPath', 'Microsoft X++ root')) emit(r);
+      for (const r of checkPathSetting(target.store, `Instance '${inst.name}'`, 'environment.customPackagesPath')) emit(r);
+      for (const r of checkPathSetting(target.store, `Instance '${inst.name}'`, 'environment.microsoftPackagesPath')) emit(r);
       emit(checkDb(target.store, resolve(inst.dir, 'data', 'xpp-metadata.db'), `Instance '${inst.name}'`));
       if (isWindows && isXppConfigStale(target.store)) {
         emit({

--- a/src/cli/settingsStore.ts
+++ b/src/cli/settingsStore.ts
@@ -58,6 +58,22 @@ export function openInstanceStore(instanceDir: string): SettingsStore {
   return openStore(instanceDir, join(instanceDir, '.env'), join(instanceDir, 'd365fo-mcp.json'));
 }
 
+/**
+ * Where a setting's effective value actually comes from — the JSON config,
+ * the legacy .env fallback, or nowhere. Mirrors readSetting's own precedence
+ * so callers can tell "explicitly configured" apart from "inherited from a
+ * .env that may have gone stale" without re-deriving the value themselves.
+ */
+export function settingSource(store: SettingsStore, setting: Setting): 'config' | 'env' | 'none' {
+  const fromJson = getAtPath(setting.tier === 'secret' ? store.secrets : store.config, setting.path);
+  if (fromJson !== undefined && fromJson !== null && fromJson !== '') return 'config';
+  if (store.legacyEnvFile) {
+    const raw = readEnvValue(store.legacyEnvFile, setting.env);
+    if (raw !== null && raw !== '') return 'env';
+  }
+  return 'none';
+}
+
 /** Effective value of a setting, or undefined when nothing configures it. */
 export function readSetting(store: SettingsStore, setting: Setting): unknown {
   const fromJson = getAtPath(setting.tier === 'secret' ? store.secrets : store.config, setting.path);

--- a/src/cli/settingsStore.ts
+++ b/src/cli/settingsStore.ts
@@ -68,8 +68,11 @@ export function settingSource(store: SettingsStore, setting: Setting): 'config' 
   const fromJson = getAtPath(setting.tier === 'secret' ? store.secrets : store.config, setting.path);
   if (fromJson !== undefined && fromJson !== null && fromJson !== '') return 'config';
   if (store.legacyEnvFile) {
+    // stripInlineComment, exactly as readSetting applies it: `KEY=  # note` has
+    // no value, and reporting 'env' for one would have this function disagree
+    // with the value the caller reads a line later.
     const raw = readEnvValue(store.legacyEnvFile, setting.env);
-    if (raw !== null && raw !== '') return 'env';
+    if (raw !== null && stripInlineComment(raw) !== '') return 'env';
   }
   return 'none';
 }

--- a/tests/cli/doctorPathSettings.test.ts
+++ b/tests/cli/doctorPathSettings.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `d365fo-mcp doctor` — the message it prints when a configured path setting
+ * names a folder that is not there.
+ *
+ * Three settings share this message and they are not the same kind of thing:
+ *
+ *   environment.packagePath            traditional: found by the drive scan
+ *                                      UDE:         read from the XPP config
+ *   environment.customPackagesPath     UDE:         XPP config ModelStoreFolder
+ *                                      traditional: a deliberate pin, the
+ *                                                   documented fix for junction
+ *                                                   layouts (docs/MCP_CONFIG.md)
+ *   environment.microsoftPackagesPath  UDE only:    XPP config FrameworkDirectory
+ *
+ * The distinction is not cosmetic. "Delete the stale pin" is the right fix only
+ * where something else would resolve the value live; where nothing would, that
+ * advice breaks a working install. And a fix line may only propose a value
+ * doctor can actually know — `<drive>:\AosService\PackagesLocalDirectory` is a
+ * traditional-VM artifact and is never the UDE ModelStoreFolder.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { missingPathFix, PATH_FACTS, type EnvKind } from '../../src/cli/commands/doctor.js';
+import { settingByPath } from '../../src/config/settings.js';
+
+const GONE = 'K:\\gone\\platform-7.0.1234';
+
+function fix(settingPath: string, kind: EnvKind, pinnedByEnv: boolean) {
+  const setting = settingByPath(settingPath)!;
+  return missingPathFix(setting, PATH_FACTS[settingPath], 'Root', GONE, kind, pinnedByEnv);
+}
+
+describe('doctor — missing path setting', () => {
+  it('names the stale .env pin as the cause where auto-detection exists', () => {
+    // The bug this check was built for: the wizard wrote the value into .env, a
+    // platform update deleted the folder, and the .env copy kept outranking the
+    // now-correct XPP-config detection at every startup.
+    const r = fix('environment.customPackagesPath', 'ude', true);
+
+    expect(r.message).toContain('pinned by legacy .env (D365FO_CUSTOM_PACKAGES_PATH)');
+    expect(r.fix).toContain('remove D365FO_CUSTOM_PACKAGES_PATH from .env');
+    expect(r.fix).toContain('ModelStoreFolder');
+  });
+
+  it('does not tell a traditional VM to delete a pin nothing would replace', () => {
+    // customPackagesPath on a traditional VM is the documented junction-layout
+    // fix — deleting it is how you break `modify`, not how you repair it.
+    const r = fix('environment.customPackagesPath', 'traditional', true);
+
+    expect(r.fix).not.toMatch(/remove .* from \.env —/);
+    expect(r.fix).toContain('point environment.customPackagesPath at');
+    expect(r.fix).toContain('outranks the JSON config');
+    expect(r.fix).not.toMatch(/XPP config/);
+  });
+
+  it('does not call packagePath a UDE value on a traditional VM', () => {
+    // The regression this guards: one message written for UDE, applied to all
+    // three settings, telling a traditional VM its packages root comes from an
+    // XPP config it does not have.
+    const r = fix('environment.packagePath', 'traditional', true);
+
+    expect(r.fix).not.toMatch(/XPP config/);
+  });
+
+  it('keeps the detected-root hint that makes packagePath actionable', () => {
+    const r = fix('environment.packagePath', 'traditional', false);
+
+    // Either a concrete "found instead" or the scan summary — never nothing.
+    expect(r.message).toMatch(/found instead:|AosService/);
+    expect(r.fix).toContain('environment.packagePath');
+  });
+
+  it('never proposes a PackagesLocalDirectory for the UDE roots', () => {
+    for (const settingPath of ['environment.customPackagesPath', 'environment.microsoftPackagesPath']) {
+      for (const kind of ['ude', 'traditional'] as EnvKind[]) {
+        for (const pinned of [true, false]) {
+          const r = fix(settingPath, kind, pinned);
+          expect(`${r.message}\n${r.fix}`, `${settingPath} / ${kind} / env=${pinned}`)
+            .not.toMatch(/AosService|PackagesLocalDirectory/);
+        }
+      }
+    }
+  });
+
+  it('offers unsetting as the cure when the JSON config pins a UDE root', () => {
+    const r = fix('environment.microsoftPackagesPath', 'ude', false);
+
+    expect(r.message).not.toContain('legacy .env');
+    expect(r.fix).toContain('clear environment.microsoftPackagesPath');
+    expect(r.fix).toContain('XPP config');
+    expect(r.fix).toContain('FrameworkDirectory');
+  });
+
+  it('always names the setting and the folder that is missing', () => {
+    for (const settingPath of Object.keys(PATH_FACTS)) {
+      for (const kind of ['ude', 'traditional'] as EnvKind[]) {
+        const r = fix(settingPath, kind, false);
+        expect(r.message, settingPath).toContain(GONE);
+        expect(r.fix, settingPath).toContain(settingPath);
+      }
+    }
+  });
+});

--- a/tests/cli/settingsStore.settingSource.test.ts
+++ b/tests/cli/settingsStore.settingSource.test.ts
@@ -1,0 +1,53 @@
+/**
+ * settingSource — distinguishes "explicitly set in the JSON config" from
+ * "inherited from a legacy .env fallback" for a given setting.
+ *
+ * This is the piece doctor needs to tell apart a genuine config mistake from
+ * a stale .env override silently outranking live UDE auto-detection (see
+ * checkUdeOverridePath in ../commands/doctor.ts) — readSetting alone only
+ * returns the effective value, not where it came from.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { settingByPath } from '../../src/config/settings.js';
+import { openStore, settingSource, writeSetting, saveStore } from '../../src/cli/settingsStore.js';
+
+const packagePath = settingByPath('environment.packagePath')!;
+
+function tempDir(): string {
+  return fs.mkdtempSync(join(os.tmpdir(), 'd365fo-settingsource-'));
+}
+
+describe('settingSource', () => {
+  it('reports "none" when neither the config nor a .env sets the value', () => {
+    const store = openStore(tempDir(), null);
+    expect(settingSource(store, packagePath)).toBe('none');
+  });
+
+  it('reports "config" once the JSON config carries the value', () => {
+    const store = openStore(tempDir(), null);
+    writeSetting(store, packagePath, 'K:\\AosService\\PackagesLocalDirectory');
+    saveStore(store);
+    expect(settingSource(store, packagePath)).toBe('config');
+  });
+
+  it('reports "env" when only a legacy .env carries the value', () => {
+    const dir = tempDir();
+    const envFile = join(dir, '.env');
+    fs.writeFileSync(envFile, `${packagePath.env}=K:\\AosService\\PackagesLocalDirectory\n`);
+    const store = openStore(dir, envFile);
+    expect(settingSource(store, packagePath)).toBe('env');
+  });
+
+  it('prefers "config" over a .env that also sets the same key', () => {
+    const dir = tempDir();
+    const envFile = join(dir, '.env');
+    fs.writeFileSync(envFile, `${packagePath.env}=K:\\stale\\path\n`);
+    const store = openStore(dir, envFile);
+    writeSetting(store, packagePath, 'K:\\current\\path');
+    saveStore(store);
+    expect(settingSource(store, packagePath)).toBe('config');
+  });
+});

--- a/tests/cli/settingsStore.settingSource.test.ts
+++ b/tests/cli/settingsStore.settingSource.test.ts
@@ -12,7 +12,7 @@ import * as os from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { settingByPath } from '../../src/config/settings.js';
-import { openStore, settingSource, writeSetting, saveStore } from '../../src/cli/settingsStore.js';
+import { openStore, readSetting, settingSource, writeSetting, saveStore } from '../../src/cli/settingsStore.js';
 
 const packagePath = settingByPath('environment.packagePath')!;
 
@@ -39,6 +39,20 @@ describe('settingSource', () => {
     fs.writeFileSync(envFile, `${packagePath.env}=K:\\AosService\\PackagesLocalDirectory\n`);
     const store = openStore(dir, envFile);
     expect(settingSource(store, packagePath)).toBe('env');
+  });
+
+  it('reports "none" for a key whose value is only an inline comment', () => {
+    // readSetting strips the comment and is left holding an empty value, which
+    // every caller reads as "not configured" (doctor: `String(…).trim()`).
+    // Calling that 'env' would name a source for a setting nothing sets, and
+    // would have doctor blame a .env line that pins nothing.
+    const dir = tempDir();
+    const envFile = join(dir, '.env');
+    fs.writeFileSync(envFile, `${packagePath.env}=   # set this later\n`);
+    const store = openStore(dir, envFile);
+
+    expect(readSetting(store, packagePath)).toBe('');
+    expect(settingSource(store, packagePath)).toBe('none');
   });
 
   it('prefers "config" over a .env that also sets the same key', () => {


### PR DESCRIPTION
customPackagesPath/microsoftPackagesPath/packagePath are meant to be derived live from the active XPP config on UDE, so a platform update is picked up automatically. But the setup wizard still writes these into an instance's legacy .env at setup time, and once  deleted the old framework/model-store folder, that hardcoded .env value keeps outranking the (now-correct) XPP-config auto-detection at every startup — see configManager.ts's envContext, which checks these env vars before ever consulting the XPP config. The bridge then dies silently with "C# bridge unavailable (ude)", with nothing pointing at the actual cause.

doctor's existing legacyEnvChecks only flags a *disagreement* between .env and the JSON config — it stays silent when the JSON config has no value at all for a setting, which is the normal (and recommended) state for these three on UDE, so the stale-but-unopposed .env value was invisible to it.

Add settingSource() to tell "explicitly configured" apart from "inherited from .env", and extend doctor's path-existence checks (previously packagePath only) to customPackagesPath and microsoftPackagesPath too, with a fix message that points at the actual cause (a stale, legacy .env pin) instead of suggesting to re-pin the same kind of static value.

Verified against two real local instances: correctly reports OK for one whose .env was already fixed, and catches the same bug live on a second instance still pinned to a deleted platform-version folder.