### PR TITLE
fix(index): stop trusting a file_path that points at the JSON cache

### DIFF
--- a/scripts/extract-metadata.ts
+++ b/scripts/extract-metadata.ts
@@ -1248,12 +1248,21 @@ async function extractEnums(
     stats.totalFiles++;
 
     try {
-      // Basic enum parsing (simplified)
+      // Basic enum parsing (simplified) — the whole XML is kept as `raw` rather
+      // than modelled into fields.
+      //
+      // sourcePath is what every other extractor records, and enums were the one
+      // type that omitted it. symbolIndex stores `enumData.sourcePath || filePath`,
+      // so without it all 8,262 indexed enums pointed at this JSON cache instead
+      // of the AOT XML — a path that exists, so every downstream existsSync guard
+      // passed and the caller read (or wrote) the wrong file. See isAotSourcePath
+      // in ../src/utils/packagesRoot.ts for the consumer-side guard that still has
+      // to cover databases built before this line.
       const content = await fs.readFile(filePath, 'utf-8');
       const outputDir = path.join(OUTPUT_PATH, modelName, 'enums');
       await fs.mkdir(outputDir, { recursive: true });
       const outputFile = path.join(outputDir, file.replace('.xml', '.json'));
-      await writeMetadataJson(outputFile, { raw: content }, isCustom, modelName);
+      await writeMetadataJson(outputFile, { raw: content, sourcePath: filePath }, isCustom, modelName);
 
       stats.enums++;
     } catch (error) {

--- a/src/tools/analysis/validateFormPattern.ts
+++ b/src/tools/analysis/validateFormPattern.ts
@@ -19,7 +19,7 @@ import {
 } from '../../validation/formPatternValidator.js';
 import { resolveSubPattern } from '../../knowledge/formPatterns/index.js';
 import { canonicalSymbolName } from '../../utils/symbolLookup.js';
-import { resolveIndexedFilePath } from '../../utils/packagesRoot.js';
+import { isAotSourcePath, resolveIndexedFilePath } from '../../utils/packagesRoot.js';
 import {
   walkFormDesign,
   type FormControlNode,
@@ -108,7 +108,12 @@ export async function validateFormPatternTool(
       const row = db
         ?.prepare(`SELECT file_path FROM symbols WHERE type = 'form' AND name = ? LIMIT 1`)
         ?.get(canonicalForm) as { file_path?: string } | undefined;
-      if (!row?.file_path) {
+      // A row whose file_path points at the JSON metadata cache rather than the
+      // AOT source is no more usable than a missing row — reading it would hand
+      // JSON to the XML parser and fail somewhere far less legible than here.
+      // See isAotSourcePath.
+      const indexedPath = row?.file_path;
+      if (!isAotSourcePath(indexedPath)) {
         return {
           isError: true,
           content: [{
@@ -119,7 +124,7 @@ export async function validateFormPatternTool(
       }
       // The index stores some file_path values package-relative; read them
       // against the packages root, not the process cwd. See resolveIndexedFilePath.
-      const resolved = resolveIndexedFilePath(row.file_path);
+      const resolved = resolveIndexedFilePath(indexedPath);
       formXml = await fs.readFile(resolved, 'utf-8');
       source = `${formName} (${resolved})`;
     }

--- a/src/tools/analysis/validateFormPattern.ts
+++ b/src/tools/analysis/validateFormPattern.ts
@@ -19,7 +19,8 @@ import {
 } from '../../validation/formPatternValidator.js';
 import { resolveSubPattern } from '../../knowledge/formPatterns/index.js';
 import { canonicalSymbolName } from '../../utils/symbolLookup.js';
-import { isAotSourcePath, resolveIndexedFilePath } from '../../utils/packagesRoot.js';
+import { resolveIndexedFilePath } from '../../utils/packagesRoot.js';
+import { readXmlFile } from '../../utils/indexedXmlLookup.js';
 import {
   walkFormDesign,
   type FormControlNode,
@@ -108,12 +109,8 @@ export async function validateFormPatternTool(
       const row = db
         ?.prepare(`SELECT file_path FROM symbols WHERE type = 'form' AND name = ? LIMIT 1`)
         ?.get(canonicalForm) as { file_path?: string } | undefined;
-      // A row whose file_path points at the JSON metadata cache rather than the
-      // AOT source is no more usable than a missing row — reading it would hand
-      // JSON to the XML parser and fail somewhere far less legible than here.
-      // See isAotSourcePath.
       const indexedPath = row?.file_path;
-      if (!isAotSourcePath(indexedPath)) {
+      if (!indexedPath) {
         return {
           isError: true,
           content: [{
@@ -125,7 +122,24 @@ export async function validateFormPatternTool(
       // The index stores some file_path values package-relative; read them
       // against the packages root, not the process cwd. See resolveIndexedFilePath.
       const resolved = resolveIndexedFilePath(indexedPath);
-      formXml = await fs.readFile(resolved, 'utf-8');
+      // That path is not always the AOT source: a row whose cached object carried
+      // no sourcePath points at the extracted-metadata JSON instead (see
+      // isAotSourcePath). Handing that to the XML parser fails in a place with no
+      // useful message — but the JSON holds the original XML in `raw`, so the
+      // right move is to unwrap it, not to refuse. readXmlFile reads both shapes
+      // and returns null only when neither yields XML.
+      const indexedXml = await readXmlFile(resolved);
+      if (indexedXml === null) {
+        return {
+          isError: true,
+          content: [{
+            type: 'text',
+            text: `❌ Form "${formName}" is indexed at ${resolved}, but no form XML could be read there. ` +
+              `Pass filePath or xml directly.`,
+          }],
+        };
+      }
+      formXml = indexedXml;
       source = `${formName} (${resolved})`;
     }
   } catch (error) {

--- a/src/tools/smart/generateSmartForm.ts
+++ b/src/tools/smart/generateSmartForm.ts
@@ -11,7 +11,7 @@ import { handleGetFormPatterns } from '../knowledge/getFormPatterns.js';
 import path from 'path';
 import fs from 'fs';
 import { getConfigManager } from '../../utils/configManager.js';
-import { defaultPackagesRoot, resolveIndexedFilePath } from '../../utils/packagesRoot.js';
+import { defaultPackagesRoot, isAotSourcePath, resolveIndexedFilePath } from '../../utils/packagesRoot.js';
 import { resolveObjectPrefix, applyObjectPrefix, getObjectSuffix, applyObjectSuffix } from '../../utils/modelClassifier.js';
 import { ProjectFileManager } from '../../workspace/projectFile.js';
 import { extractModelFromProject, findProjectInSolution } from '../../utils/projectUtils.js';
@@ -1003,7 +1003,14 @@ export async function handleGenerateSmartForm(
       const row = lookupSymbolNocase(db, table, ['table']);
       // Package-relative file_path rows would always miss here and mark a
       // perfectly good table "stale" — see resolveIndexedFilePath.
-      const stale = row?.file_path && !fs.existsSync(resolveIndexedFilePath(row.file_path));
+      //
+      // A row pointing at the JSON metadata cache instead of the AOT source is
+      // stale too, and the existence check alone will not say so: that cache
+      // file exists, so the row would read as fresh. See isAotSourcePath.
+      const indexedPath = row?.file_path;
+      const stale = !!indexedPath && (
+        !isAotSourcePath(indexedPath) || !fs.existsSync(resolveIndexedFilePath(indexedPath))
+      );
       if (row && !stale) continue;
       const stem = table.replace(/s$/i, '');
       const alt = db.prepare(

--- a/src/tools/smart/generateSmartForm.ts
+++ b/src/tools/smart/generateSmartForm.ts
@@ -1004,13 +1004,17 @@ export async function handleGenerateSmartForm(
       // Package-relative file_path rows would always miss here and mark a
       // perfectly good table "stale" — see resolveIndexedFilePath.
       //
-      // A row pointing at the JSON metadata cache instead of the AOT source is
-      // stale too, and the existence check alone will not say so: that cache
-      // file exists, so the row would read as fresh. See isAotSourcePath.
+      // A file_path pointing at the extracted-metadata JSON cache rather than the
+      // AOT source (see isAotSourcePath) is evidence of neither: that cache file
+      // exists whether or not the table still does. Calling it "stale — its file
+      // no longer exists on disk" would be a claim about a file that is right
+      // there, and the advice that follows it (run update_symbol_index) cannot
+      // help, since re-indexing rebuilds the same cache path. Judge only the paths
+      // that can be judged — the same rule isStaleIndexedPath applies in
+      // utils/indexedXmlLookup.ts, so the two do not drift apart.
       const indexedPath = row?.file_path;
-      const stale = !!indexedPath && (
-        !isAotSourcePath(indexedPath) || !fs.existsSync(resolveIndexedFilePath(indexedPath))
-      );
+      const stale = isAotSourcePath(indexedPath)
+        && !fs.existsSync(resolveIndexedFilePath(indexedPath));
       if (row && !stale) continue;
       const stem = table.replace(/s$/i, '');
       const alt = db.prepare(

--- a/src/utils/packagesRoot.ts
+++ b/src/utils/packagesRoot.ts
@@ -201,6 +201,31 @@ export function resolveIndexedFilePath(
   return joinXPlat(roots[0] ?? FALLBACK_PACKAGES_ROOT, filePath);
 }
 
+/**
+ * Is this indexed `file_path` actually an AOT source file, rather than one of
+ * the pre-extracted JSON caches the indexer builds from?
+ *
+ * Twenty sites in symbolIndex.ts store `<object>.sourcePath || filePath`, where
+ * `filePath` is the `.json` cache the object was read from (see indexEnums:
+ * `path.join(enumsPath, file)` over a `.json` listing). Objects whose cache
+ * entry carries no `sourcePath` — the legacy `{ raw: "<xml>…" }` shape —
+ * therefore land in the index with a path to the cache rather than to the AOT
+ * source.
+ *
+ * That is worse than a missing path, because the cache file genuinely exists:
+ * every `fs.existsSync` / `fs.access` guard downstream passes, and the caller
+ * proceeds to read — or write — the wrong file. Existence is not the question;
+ * identity is. Hence an extension test rather than a stat.
+ *
+ * Fixing the twenty write sites would not retire this check: `file_path` is
+ * `TEXT NOT NULL`, and the shipped SQLite database is downloaded prebuilt from
+ * blob storage, so already-poisoned rows outlive any indexer change. Callers
+ * that resolve a `file_path` to read or write have to ask.
+ */
+export function isAotSourcePath(filePath: string | null | undefined): filePath is string {
+  return !!filePath && /\.(xml|xpp)$/i.test(filePath.trim());
+}
+
 /** Test seam — drops the cached scan. */
 export function resetPackagesRootCache(): void {
   cached = null;

--- a/src/utils/packagesRoot.ts
+++ b/src/utils/packagesRoot.ts
@@ -207,20 +207,29 @@ export function resolveIndexedFilePath(
  *
  * Twenty sites in symbolIndex.ts store `<object>.sourcePath || filePath`, where
  * `filePath` is the `.json` cache the object was read from (see indexEnums:
- * `path.join(enumsPath, file)` over a `.json` listing). Objects whose cache
- * entry carries no `sourcePath` — the legacy `{ raw: "<xml>…" }` shape —
- * therefore land in the index with a path to the cache rather than to the AOT
- * source.
+ * `path.join(enumsPath, file)` over a `.json` listing). An object whose cache
+ * entry carries no `sourcePath` therefore lands in the index with a path to the
+ * cache rather than to the AOT source.
  *
  * That is worse than a missing path, because the cache file genuinely exists:
  * every `fs.existsSync` / `fs.access` guard downstream passes, and the caller
  * proceeds to read — or write — the wrong file. Existence is not the question;
  * identity is. Hence an extension test rather than a stat.
  *
- * Fixing the twenty write sites would not retire this check: `file_path` is
- * `TEXT NOT NULL`, and the shipped SQLite database is downloaded prebuilt from
- * blob storage, so already-poisoned rows outlive any indexer change. Callers
- * that resolve a `file_path` to read or write have to ask.
+ * Measured on a full index (1,188,687 rows): 8,262 rows carried a `.json` path,
+ * and all of them were enums — extractEnums was the one extractor writing a bare
+ * `{ raw }` object with no `sourcePath`. That is fixed at the source in
+ * scripts/extract-metadata.ts, so freshly extracted metadata no longer produces
+ * such rows. This check stays because the shipped SQLite database is downloaded
+ * prebuilt from blob storage: every database built before that fix still carries
+ * the poisoned rows, and `file_path` is `TEXT NOT NULL`, so there was never an
+ * honest empty value to store in their place.
+ *
+ * What a caller should do with a `false` here depends on what it wants. To READ,
+ * prefer readXmlFile in utils/indexedXmlLookup.ts — the cache holds the original
+ * XML in `raw`, so it can be unwrapped rather than refused. To WRITE, or to judge
+ * whether the object is still on disk, the path is unusable and no verdict can be
+ * drawn from it.
  */
 export function isAotSourcePath(filePath: string | null | undefined): filePath is string {
   return !!filePath && /\.(xml|xpp)$/i.test(filePath.trim());

--- a/tests/scripts/extractMetadataRun.test.ts
+++ b/tests/scripts/extractMetadataRun.test.ts
@@ -93,6 +93,21 @@ describe('extract-metadata (spawned)', () => {
     expect(await exists(p('out', 'MyModel', 'classes', 'MyClass.json'))).toBe(true);
   }, 60_000);
 
+  it('records the AOT source path on an enum, not just its raw XML', async () => {
+    // extractEnums was the one extractor writing a bare `{ raw }` object. symbolIndex
+    // stores `enumData.sourcePath || filePath`, so the omission put the JSON cache's
+    // own path into the index for every enum in the database — a path that exists,
+    // which is what made it survive every downstream existence check. Measured on a
+    // full index: 8,262 of 8,262 enum rows, and no other type.
+    await runExtract();
+
+    const enumJson = JSON.parse(await fs.readFile(p('out', 'MyModel', 'enums', 'MyEnum.json'), 'utf-8'));
+    expect(typeof enumJson.raw).toBe('string');
+    expect(enumJson.sourcePath.replace(/\\/g, '/')).toMatch(/AxEnum\/MyEnum\.xml$/);
+    // The point of the field: what lands in the index must not be the cache itself.
+    expect(enumJson.sourcePath).not.toMatch(/\.json$/i);
+  }, 60_000);
+
   it('sweeps an orphan and keeps the live files beside it', async () => {
     await write(p('out', 'MyModel', 'enums', 'GhostEnum.json'), '{"raw":"<AxEnum/>"}');
 

--- a/tests/tools/validateFormPatternIndexed.test.ts
+++ b/tests/tools/validateFormPatternIndexed.test.ts
@@ -1,0 +1,106 @@
+/**
+ * object_patterns(domain="form", action="validate") resolving a form by NAME —
+ * the branch that goes through the symbol index instead of caller-supplied XML.
+ *
+ * The trap here is an indexed `file_path` that points at the extracted-metadata
+ * JSON cache rather than the AOT source. symbolIndex stores
+ * `<object>.sourcePath || filePath`, so any cached object written without a
+ * sourcePath lands in the index pointing at the cache — and that file EXISTS, so
+ * no existence check catches it. Handing it to the XML parser fails with a
+ * message about malformed XML that names neither the cause nor the file.
+ *
+ * Refusing such a row would be the easy fix and the wrong one: the cache holds
+ * the original XML in `raw`, so the form can simply be validated from it. These
+ * tests pin that — same verdict from the source XML and from the cache — plus
+ * the two ways the lookup can legitimately come up empty.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { validateFormPatternTool } from '../../src/tools/analysis/validateFormPattern.js';
+import { FormPatternTemplates } from '../../src/utils/formPatternTemplates.js';
+
+const FORM = 'FpvIndexedForm';
+
+const formXml = FormPatternTemplates.buildSimpleList({
+  formName: FORM,
+  dsName: 'TestDS',
+  dsTable: 'TestTable',
+  caption: 'Test',
+  gridFields: ['Field1', 'Field2'],
+});
+
+/**
+ * Minimal stand-in for the symbol index. Both probes the tool makes — the
+ * casing-canonicalising lookup (`.all`) and its own file_path SELECT (`.get`) —
+ * are answered from the same single row, which is what a real index would do.
+ */
+function indexStub(filePath: string | null) {
+  const row = filePath === null ? undefined : { name: FORM, type: 'form', model: 'MyModel', file_path: filePath };
+  return {
+    getReadDb: () => ({
+      prepare: () => ({
+        all: () => (row ? [row] : []),
+        get: () => row,
+      }),
+    }),
+  };
+}
+
+const call = (formName: string, symbolIndex: unknown) =>
+  validateFormPatternTool({ formName }, { symbolIndex });
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'fpv-indexed-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe('validate_form_pattern via the symbol index', () => {
+  it('validates a form whose file_path is the AOT source XML', async () => {
+    const xmlFile = path.join(tmp, 'FpvIndexedForm.xml');
+    await fs.writeFile(xmlFile, formXml);
+
+    const result = await call(FORM, indexStub(xmlFile));
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain(FORM);
+  });
+
+  it('validates from the JSON metadata cache too — unwrapping `raw` rather than refusing', async () => {
+    // The exact row shape that used to break this: a real, readable file that is
+    // not the source. Rejecting it would report "not found" for a form the index
+    // knows and whose XML is right there in the cache.
+    const cacheFile = path.join(tmp, 'FpvIndexedForm.json');
+    await fs.writeFile(cacheFile, JSON.stringify({ raw: formXml }));
+
+    const result = await call(FORM, indexStub(cacheFile));
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain(FORM);
+  });
+
+  it('reports not-found when the index has no row for the name', async () => {
+    const result = await call(FORM, indexStub(null));
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not found in the symbol index/);
+  });
+
+  it('names the path when the indexed file yields no XML', async () => {
+    // A JSON cache with no `raw` — readable, parseable, and still not a form.
+    const cacheFile = path.join(tmp, 'Empty.json');
+    await fs.writeFile(cacheFile, JSON.stringify({ name: FORM }));
+
+    const result = await call(FORM, indexStub(cacheFile));
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(cacheFile);
+  });
+});

--- a/tests/utils/aotSourcePath.test.ts
+++ b/tests/utils/aotSourcePath.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `isAotSourcePath` — regression cover for indexed file_path values that point
+ * at the JSON metadata cache instead of the AOT source.
+ *
+ * The trap this guards is specifically NOT "the file is missing". Twenty sites
+ * in symbolIndex.ts fall back to `path.join(<cacheDir>, '<name>.json')` when a
+ * cached object carries no `sourcePath`, and that cache file is real. Every
+ * existence check downstream passes, so the caller reads — or writes — the
+ * wrong file with no error to show for it. Anything asserting here that a
+ * `.json` path is rejected is asserting the whole point.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isAotSourcePath } from '../../src/utils/packagesRoot.js';
+
+describe('isAotSourcePath', () => {
+  it('accepts AOT metadata and X++ source files', () => {
+    for (const p of [
+      'C:\\AosService\\PackagesLocalDirectory\\ContosoExt\\ContosoExt\\AxForm\\Foo.xml',
+      'ContosoExt/ContosoExt/AxClass/Foo.xml',
+      '/mnt/packages/ContosoExt/AxTable/Bar.xpp',
+    ]) {
+      expect(isAotSourcePath(p), p).toBe(true);
+    }
+  });
+
+  it('rejects the JSON metadata cache — the path that exists but is not the source', () => {
+    for (const p of [
+      'C:\\d365fo-mcp\\extracted-metadata\\ContosoExt\\enums\\MyEnum.json',
+      '/var/cache/extracted-metadata/edts/MyEdt.json',
+      'extracted-metadata/classes/Foo.json',
+    ]) {
+      expect(isAotSourcePath(p), p).toBe(false);
+    }
+  });
+
+  it('is case-insensitive — AOT casing on disk is not guaranteed', () => {
+    expect(isAotSourcePath('AxForm/Foo.XML')).toBe(true);
+    expect(isAotSourcePath('AxClass/Foo.XPP')).toBe(true);
+    expect(isAotSourcePath('enums/MyEnum.JSON')).toBe(false);
+  });
+
+  it('rejects absent, empty and whitespace paths without throwing', () => {
+    for (const p of [undefined, null, '', '   ']) {
+      expect(isAotSourcePath(p as string | null | undefined), String(p)).toBe(false);
+    }
+  });
+
+  it('tolerates surrounding whitespace on an otherwise valid path', () => {
+    expect(isAotSourcePath('  AxForm/Foo.xml  ')).toBe(true);
+  });
+
+  it('matches only a trailing extension, not one embedded in a directory name', () => {
+    // A directory called "Foo.xml" holding a cache file must not read as source.
+    expect(isAotSourcePath('cache/Foo.xml/data.json')).toBe(false);
+    expect(isAotSourcePath('cache/Foo.json/real.xml')).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #896. That PR defends one consumer against a poisoned `file_path`; this one names the condition, fixes it where it originates, and corrects the two other consumers that had to cope with it.

## The condition

Twenty sites in `symbolIndex.ts` store `<object>.sourcePath || filePath`. `filePath` there is the `.json` cache the object was read from — `indexEnums` lists `.json` files and joins their own directory (`symbolIndex.ts:2352`). An object whose cache entry carries no `sourcePath` lands in the index pointing at the cache, not at the AOT source.

That is worse than a missing path, because **the cache file genuinely exists**. Every `fs.existsSync` / `fs.access` guard downstream passes and the caller proceeds against the wrong file. Existence is not the question; identity is — hence an extension test rather than a stat.

## Measured, not assumed

Against a full index (1,188,687 symbol rows):

| | rows | `.json` file_path |
|---|---|---|
| **enum** | 8,262 | **8,262 (100%)** |
| table | 18,466 | 0 |
| form | 9,496 | 0 |
| everything else | 1,160,959 | 0 |

No `file_path` carries any extension other than `.xml` or `.json`, so `isAotSourcePath`'s whitelist has no false negatives. And the poisoning is not spread across object kinds — it is enums, exactly the type #896's comment named.

## The root cause is one line

`scripts/extract-metadata.ts` — `extractEnums` was the only extractor writing a bare `{ raw: content }`, with the comment "Basic enum parsing (simplified)". Every other type records `sourcePath: filePath` (`:1167`, `:1342`, and the parsed shapes from `xmlParser.ts`). Adding it there stops new databases carrying the lie.

An earlier revision of this PR argued the write side could not be fixed because `file_path` is `TEXT NOT NULL` and there is no honest empty value to store. That misidentified the write side: nothing needs to store an empty path — the extractor has the XML path in hand and simply was not recording it.

The consumer-side guard stays regardless. The shipped SQLite database is **downloaded prebuilt from blob storage**, so every database built before this commit still carries all 8,262 poisoned rows.

## The two consumers, corrected

`src/utils/indexedXmlLookup.ts` had already settled how this repo treats a cache path, and both call sites now follow it rather than inventing a second rule:

**`validateFormPattern.ts`** reads through `readXmlFile()`, which unwraps `{ raw: "<xml>…" }` into the original XML. Rejecting the row — as the first revision of this PR did — reports `❌ not found in the symbol index` for a form the index knows and whose XML is sitting in the cache. Failing is only right when neither shape yields XML, and that error now names the path it tried.

**`generateSmartForm.ts`** no longer marks a cache-pathed row *stale*. It had reported `is stale in the index (its file no longer exists on disk — run update_symbol_index)` about a file that is right there, with advice that cannot work: re-indexing rebuilds the same cache path. A path that cannot be judged now yields no verdict — the rule `isStaleIndexedPath` already applies, with the comment "shared … so the two can never drift apart".

## Relationship to #896

#896 fixes the third consumer, `modifyD365File`, with a local `looksLikeAotSourceFile`. Independent — different files, no conflict, either order merges. Once both land, that local copy should call `isAotSourcePath`; I did not touch #896's file to avoid a conflict while it is open. Note that #896 is the one consumer where the bug was actually reachable: it writes, and it targets enums.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 294 files, 3632 passed, 2 skipped
- `npx biome lint` on the touched files — clean
- Tests now cover the call sites, not only the predicate:
  - the extractor's spawned end-to-end run asserts an enum JSON carries a source path — **verified to fail without the extractor fix**, not merely to pass with it
  - four cases pin the validate-by-name branch: source XML, JSON cache, missing row, unreadable file
  - the predicate's own 6 tests stay, including the two that matter: a `.json` path is rejected even though such a file exists, and the extension is matched only at the end of the path
