### PR TITLE
fix: stop the label-search loop by call count, and catch built-in arity before the build

### DIFF
--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -135,7 +135,7 @@ Nothing uncovered.
 
 ## Orphans
 
-- Knowledge entries no leaf claims (**unproven knowledge**): extensible-enums
+- Knowledge entries no leaf claims (**unproven knowledge**): enum-conversions, extensible-enums
 - Eval cases no leaf claims (**unmapped proof**): L0-create-readback-no-reindex, L2-batched-object-reads, L2-oracle-discriminator-random-wrapper-name, L3-enum-field-form-downgrade-guard, L4-headerlines-document-slice
 
-_Generated 2026-08-08._
+_Generated 2026-08-12._

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -135,7 +135,7 @@ Nothing uncovered.
 
 ## Orphans
 
-- Knowledge entries no leaf claims (**unproven knowledge**): enum-conversions, extensible-enums
-- Eval cases no leaf claims (**unmapped proof**): L0-create-readback-no-reindex, L2-batched-object-reads, L2-oracle-discriminator-random-wrapper-name, L3-enum-field-form-downgrade-guard, L4-headerlines-document-slice
+- Knowledge entries no leaf claims (**unproven knowledge**): extensible-enums
+- Eval cases no leaf claims (**unmapped proof**): L0-create-readback-no-reindex, L2-batched-object-reads, L2-oracle-discriminator-random-wrapper-name, L4-headerlines-document-slice
 
 _Generated 2026-08-12._

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -1245,6 +1245,7 @@
   ],
   "orphans": {
     "knowledge": [
+      "enum-conversions",
       "extensible-enums"
     ],
     "cases": [

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -1245,14 +1245,12 @@
   ],
   "orphans": {
     "knowledge": [
-      "enum-conversions",
       "extensible-enums"
     ],
     "cases": [
       "L0-create-readback-no-reindex",
       "L2-batched-object-reads",
       "L2-oracle-discriminator-random-wrapper-name",
-      "L3-enum-field-form-downgrade-guard",
       "L4-headerlines-document-slice"
     ]
   }

--- a/eval/knowledge-audit.snapshot.json
+++ b/eval/knowledge-audit.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "capturedAt": "2026-07-30T05:28:34.893Z",
-  "indexedAt": "2026-07-29T18:58:39.113Z",
+  "capturedAt": "2026-08-12T12:45:19.851Z",
+  "indexedAt": "2026-08-12T11:53:47.533Z",
   "ok": [
     "alerts-business-events|attribute|DataContract",
     "alerts-business-events|attribute|DataContractAttribute",
@@ -59,7 +59,6 @@
     "datetime-timezones|declaration|Timezone",
     "datetime-timezones|static-call|Timezone::GMTCOORDINATEDUNIVERSALTIME",
     "deprecated|attribute|SysObsolete",
-    "deprecated|static-call|CompanyInfo::findDataArea",
     "deprecated|static-call|DateTimeUtil::getToday",
     "deprecated|static-call|DateTimeUtil::getUserPreferredTimeZone",
     "deprecated|static-call|Ledger::primaryForLegalEntity",
@@ -85,6 +84,9 @@
     "electronic-reporting|new|ERModelDefinitionInputParametersAction",
     "electronic-reporting|static-call|ERModelDefinitionInputParametersAction::addParameter",
     "electronic-reporting|static-call|ERObjectsFactory::createFormatMappingRunByFormatMappingId",
+    "enum-conversions|attribute|ExtensionOf",
+    "enum-conversions|declaration|DictEnum",
+    "enum-conversions|new|DictEnum",
     "error-handling|static-call|CLRInterop::getLastException",
     "error-handling|static-call|Exception::CLRError",
     "error-handling|static-call|Global::error",

--- a/src/eval/coverage/taxonomy.ts
+++ b/src/eval/coverage/taxonomy.ts
@@ -79,8 +79,21 @@ export const TAXONOMY: CoverageLeaf[] = [
     note: 'Eval case authored (EDT + EDT extension via PropertyModifications); golden pending VM capture.',
   },
   {
+    // Creating a base enum is half of this leaf; consuming one is the other half,
+    // and that half is where the money went — a benchmark run wrote enum2Str with
+    // enum2Symbol's two arguments and paid a 76 s failed build for it, because the
+    // base documented the conversions nowhere. enum-conversions covers it now.
+    //
+    // The L3 case builds a four-value ladder enum, types a table field on it and
+    // compares it in a validateWrite guard. Note what it does NOT do: it compares
+    // through enum2int and messages through a bare label, so it exercises the
+    // creation and the ordinal comparison, not the label/symbol split that
+    // motivated the knowledge entry. It is the right case for this leaf and it is
+    // not proof of that part; a case that renders an enum into a message would be.
+    // It is golden_pending in any event, so it claims the case without flipping E.
     id: 'enum', label: 'Base enum', domain: 'Data model', source: 'aot', tier: 'core', weight: 5,
-    aotTypes: ['enum'], knowledgeIds: ['xpp-class-rules'], caseIds: ['L0-enum-basic'],
+    aotTypes: ['enum'], knowledgeIds: ['xpp-class-rules', 'enum-conversions'],
+    caseIds: ['L0-enum-basic', 'L3-enum-field-form-downgrade-guard'],
   },
   {
     id: 'enum-extension', label: 'Enum extension', domain: 'Data model', source: 'aot', tier: 'core', weight: 4,

--- a/src/tools/analysis/labelSearchHistory.ts
+++ b/src/tools/analysis/labelSearchHistory.ts
@@ -1,5 +1,5 @@
 /**
- * The phrasings already tried against the labels index.
+ * The phrasings already tried against the labels index, and how many calls tried them.
  *
  * Every search result says rephrasing does not help; callers rephrase anyway.
  * Naming the wordings they already tried is harder to argue with than the same
@@ -15,6 +15,17 @@ const HISTORY_TTL_MS = 30 * 60 * 1000;
 /** Beyond this many remembered phrasings, the list is summarised rather than printed. */
 const MAX_LISTED = 12;
 
+/**
+ * Search calls allowed before the answer is declared settled.
+ *
+ * Two, because the second call is the one that establishes the index has nothing
+ * new to give: the first is an honest look, the second is the rephrase everyone
+ * tries anyway. Counted in CALLS, not phrasings — a call is a round trip, which
+ * is what the loop actually costs (~2-3 AIU each), and a batched
+ * `query=["…","…","…"]` is the cheap shape this must not punish.
+ */
+const SEARCH_CALL_BUDGET = 2;
+
 interface Entry {
   /** The phrasing as the caller spelled it — echoing it back is the point. */
   query: string;
@@ -25,8 +36,12 @@ interface Entry {
 
 const history: Entry[] = [];
 
+/** One timestamp per search CALL, so the TTL prunes calls the way it prunes phrasings. */
+const calls: number[] = [];
+
 function prune(now: number): void {
   while (history.length > 0 && now - history[0].at > HISTORY_TTL_MS) history.shift();
+  while (calls.length > 0 && now - calls[0] > HISTORY_TTL_MS) calls.shift();
 }
 
 /** Record one search and whether it came back empty-handed. */
@@ -50,6 +65,53 @@ export function recordLabelSearch(query: string, fruitless: boolean): void {
 export function fruitlessLabelSearches(): string[] {
   prune(Date.now());
   return history.filter(e => e.fruitless).map(e => e.query);
+}
+
+/**
+ * Count one search CALL, whatever it is about to return.
+ *
+ * Separate from recordLabelSearch because that one only counts what a phrasing
+ * found, and a phrasing that hit something irrelevant is invisible to it. Run
+ * 7b8de4ba is the case: six batches / 24 phrasings in, the notice was still
+ * reporting "11 phrasing(s) already came back empty", because the other thirteen
+ * had each landed on some unrelated SYS label and were never counted.
+ */
+export function recordLabelSearchCall(): void {
+  const now = Date.now();
+  prune(now);
+  calls.push(now);
+}
+
+/** Search calls made in this session. */
+export function labelSearchCallCount(): number {
+  prune(Date.now());
+  return calls.length;
+}
+
+/**
+ * The hard stop, once the caller is past the budget. Empty until then.
+ *
+ * Unlike repeatSearchNotice this does not care whether the searches came back
+ * empty: the expensive loop is the one where every batch DOES return something,
+ * none of it about the caller's subject, and the verdict reads as encouragement
+ * to try another wording. Both branches carry this, so the count is the thing
+ * that ends the loop rather than the luck of the phrasing.
+ *
+ * Names the escalations that follow the loop in practice — reading the
+ * .label.txt files by hand, asking the user — because those cost more than the
+ * searches did and are what the caller reaches for once it stops rephrasing.
+ */
+export function searchBudgetNotice(): string {
+  prune(Date.now());
+  if (calls.length <= SEARCH_CALL_BUDGET) return '';
+
+  return (
+    `🛑 **STOP — that was label search call ${calls.length} this session** ` +
+    `(${history.length} phrasing(s) in total). They all query the same index, so the answer stopped ` +
+    `changing after the first call: what has come back IS what exists. Do not search again, do not ` +
+    `read the .label.txt files by hand, and do not ask the user. Take a hit from above if one says ` +
+    `what you need; otherwise create your own label with the call below and move on.\n`
+  );
 }
 
 /**
@@ -78,4 +140,5 @@ export function repeatSearchNotice(excluding: readonly string[] = []): string {
 /** Forget everything. Tests only. */
 export function resetLabelSearchHistory(): void {
   history.length = 0;
+  calls.length = 0;
 }

--- a/src/tools/analysis/searchLabels.ts
+++ b/src/tools/analysis/searchLabels.ts
@@ -19,7 +19,7 @@ import {
   isLabelLikelyResolvable,
   labelProvenanceWarning,
 } from '../../utils/labelReference.js';
-import { recordLabelSearch, repeatSearchNotice } from './labelSearchHistory.js';
+import { recordLabelSearch, repeatSearchNotice, searchBudgetNotice } from './labelSearchHistory.js';
 
 /**
  * Emitted only when a label the current model can actually resolve was found.
@@ -135,7 +135,7 @@ export async function searchLabelsTool(request: CallToolRequest, context: XppSer
     if (results.length === 0) {
       // Named before the advice: a caller that has already tried five wordings
       // needs to hear that it has, not the same paragraph a sixth time.
-      const repeatNotice = repeatSearchNotice([query]);
+      const repeatNotice = `${searchBudgetNotice()}${repeatSearchNotice([query])}`;
       recordLabelSearch(query, true);
       return {
         content: [
@@ -174,7 +174,14 @@ export async function searchLabelsTool(request: CallToolRequest, context: XppSer
     const total = `${results.length}${atProbeCap ? '+' : ''}`;
     const scope = `[language: ${language}${model ? `, model: ${model}` : ''}]`;
 
+    // The stop rides on the branch that FOUND something too. A hit means the
+    // model can resolve that label, not that it says what the caller needs, so
+    // this branch is the one a rephrasing loop actually lives on — it used to be
+    // the only one carrying no count at all.
+    const budgetStop = searchBudgetNotice();
+
     const lines: string[] = [
+      ...(budgetStop ? [budgetStop] : []),
       hidden > 0
         ? `Found ${total} label(s) matching "${query}" ${scope} — showing first ${maxResults}:`
         : `Found ${results.length} label(s) matching "${query}" ${scope}:`,

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -21,6 +21,7 @@
  *   BP003   Generic doc-comment (/// Foo class. / /// methodName.)
  *   BP004   Developer-only statements left in code (pause / print)
  *   BP005   an enum SYMBOL (enum2Symbol / value2Symbol) in user-facing text — never translated
+ *   FN001   fixed-arity built-in called with the wrong number of arguments
  *   TTS001  Unbalanced ttsbegin / ttscommit
  *   XML001  AxTable XML missing an index with <AlternateKey>Yes</AlternateKey>
  *   XML006  AxTable elements out of canonical order (silently dropped by the AOT)
@@ -510,6 +511,101 @@ function checkEnumSymbolInMessage(code: string): ValidationViolation[] {
 }
 
 /**
+ * The built-ins FN001 knows the arity of.
+ *
+ * Deliberately tiny, and all one family: these convert between an enum, its
+ * label and its symbol, they are the ones a caller reaches for in the same
+ * breath, and they do NOT agree on how many arguments they take. That is the
+ * whole trap — enum2Str takes the value alone, its neighbours take an enum id
+ * AND a value, so the wrong one of the pair compiles in the head and not in
+ * xppc. Adding a built-in here is only safe when its arity is genuinely fixed:
+ * one with an optional parameter belongs nowhere near this rule.
+ */
+const FIXED_ARITY_BUILTINS: Record<string, { name: string; arity: number; note: string }> = {
+  enum2str:    { name: 'enum2Str',    arity: 1, note: 'enum2Str(value) — the value alone. It resolves that value\'s <Label> in the session language, which is why it needs no enum id' },
+  enum2symbol: { name: 'enum2Symbol', arity: 2, note: 'enum2Symbol(enumNum(MyEnum), value) — enum id AND value' },
+  symbol2enum: { name: 'symbol2Enum', arity: 2, note: 'symbol2Enum(enumNum(MyEnum), symbolString) — enum id AND symbol' },
+  enumnum:     { name: 'enumNum',     arity: 1, note: 'enumNum(MyEnum) — the enum TYPE name alone, not a value' },
+};
+
+/**
+ * Arguments in the call whose '(' sits at `open`, or null when the parentheses
+ * never close — a snippet cut mid-call is not something to have an opinion about.
+ *
+ * Counts top-level commas only, so a nested call or an indexer contributes none.
+ * Runs on masked source, where a comma inside a string literal is already a space.
+ */
+function countCallArguments(masked: string, open: number): number | null {
+  let parens = 0;
+  let brackets = 0;
+  let commas = 0;
+  let hasContent = false;
+
+  for (let i = open; i < masked.length; i++) {
+    const ch = masked[i];
+    if (ch === '(') { parens++; continue; }
+    if (ch === ')') {
+      parens--;
+      if (parens === 0) return hasContent ? commas + 1 : 0;
+      continue;
+    }
+    if (ch === '[') { brackets++; continue; }
+    if (ch === ']') { brackets--; continue; }
+    if (parens === 1 && brackets === 0 && ch === ',') { commas++; continue; }
+    if (!/\s/.test(ch)) hasContent = true;
+  }
+
+  return null;
+}
+
+/**
+ * FN001 — a fixed-arity built-in called with the wrong number of arguments.
+ *
+ * xppc catches every one of these, but only after a build, and that is the cost:
+ * run 7b8de4ba shipped `enum2Str(this.orig().X), enum2Str(this.X)` as a 2-argument
+ * call, which bought a 76 s failed compile, a repair round trip and two more
+ * builds — ~9 AIU and 130 s for a mistake visible in the source as written. The
+ * knowledge base offers `enum2Symbol(enumNum(…), any2Int(…))` as its only
+ * conversion example, so reaching for the 2-argument shape is the documented
+ * confusion, not a careless one.
+ *
+ * Runs on every write through inlineXppValidation, which is the point: the reply
+ * to the d365fo_file call that creates the CoC class already carries the finding.
+ *
+ * severity 'error' — this is a compile failure, not a preference.
+ */
+function checkBuiltinArity(code: string): ValidationViolation[] {
+  const violations: ValidationViolation[] = [];
+  const masked = maskStringsAndComments(code);
+  const lines = code.split('\n');
+
+  const callRe = /\b([A-Za-z_]\w*)\s*\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(masked)) !== null) {
+    const spec = FIXED_ARITY_BUILTINS[m[1].toLowerCase()];
+    if (!spec) continue;
+    // `something.enum2Str(…)` is a method on another type, not the global.
+    if (masked.slice(0, m.index).trimEnd().endsWith('.')) continue;
+
+    const actual = countCallArguments(masked, m.index + m[0].length - 1);
+    if (actual === null || actual === spec.arity) continue;
+
+    const lineNo = lineNumber(masked, m.index);
+    violations.push({
+      rule: 'FN001',
+      severity: 'error',
+      line: lineNo,
+      excerpt: lines[lineNo - 1].trim(),
+      fix:
+        `${spec.name} takes ${spec.arity} argument(s); ${actual} given. xppc rejects this with ` +
+        `"'${spec.name}' expects ${spec.arity} argument(s), but ${actual} specified". ${spec.note}.`,
+    });
+  }
+
+  return violations;
+}
+
+/**
  * COC004 — `next` not reached exactly once and unconditionally (compiler SYS10028).
  *
  * The X++ compiler rejects a CoC method whose `next` sits inside an `if`, is called
@@ -930,6 +1026,7 @@ const XPP_RULES = [
   checkCocNextUnconditional,
   checkGlobalFunctionOnTableBuffer,
   checkEnumSymbolInMessage,
+  checkBuiltinArity,
   checkHardcodedStrings,
   checkDoMethods,
   checkGenericDocComment,

--- a/src/tools/knowledge/xppKnowledge.ts
+++ b/src/tools/knowledge/xppKnowledge.ts
@@ -707,6 +707,9 @@ switch (category)
 }
 
 // ✅ Persist/transport the symbol, never the ordinal
+// NB: two arguments because the symbol functions need the enum id. The
+//     LABEL function does not — enum2Str(category), one argument. The two
+//     are not interchangeable in either respect; see enum-conversions.
 str symbol = enum2Symbol(enumNum(MyVehicleCategory), any2Int(category));
 
 // ❌ WRONG — the ordinal of an extension value is assigned at deployment
@@ -714,7 +717,86 @@ str symbol = enum2Symbol(enumNum(MyVehicleCategory), any2Int(category));
 // if (any2Int(category) == 3) { … }`,
       },
     ],
-    related: ['sysextension', 'labels', 'feature-management'],
+    related: ['sysextension', 'labels', 'feature-management', 'enum-conversions'],
+  },
+
+  // ── Enum ↔ text conversions ─────────────────────────────────────────────
+  // Documented because the base used to teach these ONLY as a by-product of the
+  // extensible-enum topic above, whose single conversion example is the
+  // 2-argument enum2Symbol. Asked point-blank for "enum2str … convert enum value
+  // to label text", the base answered with that topic and no mention of enum2Str
+  // at all; the caller generalised the shape it had been shown and shipped
+  // `enum2Str(enumNum(X), value)`, which cost a 76 s failed build and two more.
+  // These functions disagree about their arity, so the arity IS the topic.
+  {
+    id: 'enum-conversions',
+    title: 'Enum ↔ text: enum2Str, enum2Symbol, symbol2Enum, DictEnum (and their argument counts)',
+    keywords: ['enum2str', 'enum2symbol', 'symbol2enum', 'enumnum', 'enum2int', 'value2label', 'value2symbol',
+      'dictenum', 'sysdictenum', 'convert enum', 'enum conversion', 'enum to string', 'enum to text',
+      'enum label', 'enum symbol', 'enum name', 'global function', 'session language', 'arity'],
+    summary:
+      'Converting an enum to text has two answers and they are not interchangeable: enum2Str returns the value\'s translated LABEL, enum2Symbol returns its untranslated AOT NAME. ' +
+      'They also disagree about how many arguments they take — enum2Str takes the value alone, the symbol functions take an enum id AND a value — which is the mistake xppc reports as ' +
+      '"\'enum2Str\' expects 1 argument(s), but 2 specified".',
+    rules: [
+      'enum2Str(value) — ONE argument. Returns the <Label> of that value in the session language. It needs no enum id because the type is known at compile time from the value itself. This is the one for user-facing text',
+      'enum2Symbol(enumNum(MyEnum), value) — TWO arguments. Returns the AOT element name ("Gold"), which is never translated. Correct for logs, filenames, keys and anything persisted; wrong in a message (see BP005)',
+      'symbol2Enum(enumNum(MyEnum), symbolString) — TWO arguments, the inverse of enum2Symbol',
+      'enumNum(MyEnum) — ONE argument, and it is the enum TYPE name, not a value. It yields the compile-time enum id the two-argument functions ask for, which is exactly why those take two and enum2Str does not',
+      'enum2int(value) — ONE argument, returns the underlying ordinal. Safe for a base enum; for an EXTENSIBLE enum the ordinal is assigned at deployment time and differs per environment — see extensible-enums',
+      'When the enum type is known only at RUNTIME, none of the above applies: new DictEnum(enumId).value2Label(value) for the label, .value2Symbol(value) for the symbol',
+      'Getting the count wrong is a compile error, not a warning, and it is caught offline: the FN001 rule reports it in the reply to the d365fo_file call that writes the code, before any build',
+      'In a validateWrite/CoC message the idiom is checkFailed(strFmt("@MyModel:MyLabel", enum2Str(a), enum2Str(b))) — the label carries the %1/%2 placeholders and enum2Str fills them with translated text',
+    ],
+    examples: [
+      {
+        label: 'The two conversions side by side',
+        code: `MyQualityTier tier = this.MyQualityTier;
+
+// ✅ Translated label — ONE argument. For anything a user reads.
+str shown = enum2Str(tier);
+
+// ✅ Untranslated AOT name — TWO arguments. For logs, keys, persistence.
+str symbol = enum2Symbol(enumNum(MyQualityTier), enum2int(tier));
+
+// ✅ Back again
+MyQualityTier restored = symbol2Enum(enumNum(MyQualityTier), symbol);
+
+// ❌ WRONG — enum2Str does not take an enum id. xppc:
+//    "'enum2Str' expects 1 argument(s), but 2 specified."
+// str shown = enum2Str(enumNum(MyQualityTier), tier);`,
+      },
+      {
+        label: 'Blocking a downgrade with a translated message',
+        code: `[ExtensionOf(tableStr(MyTable))]
+final class MyTable_Extension
+{
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+
+        if (ret && this.MyQualityTier < this.orig().MyQualityTier)
+        {
+            // ✅ enum2Str on each value — one argument each, both translated
+            ret = checkFailed(strFmt("@MyModel:QualityTierDowngradeError",
+                enum2Str(this.orig().MyQualityTier),
+                enum2Str(this.MyQualityTier)));
+        }
+
+        return ret;
+    }
+}`,
+      },
+      {
+        label: 'Enum type known only at runtime',
+        code: `// No compile-time type, so the global functions cannot help.
+DictEnum dictEnum = new DictEnum(enumId);
+
+str shown  = dictEnum.value2Label(value);   // translated
+str symbol = dictEnum.value2Symbol(value);  // AOT name`,
+      },
+    ],
+    related: ['extensible-enums', 'labels', 'coc-authoring'],
   },
 
   // ── Number Sequences ────────────────────────────────────────────────────
@@ -3611,6 +3693,84 @@ function tokenize(topic: string): string[] {
  */
 const CONFIDENT_SCORE = 3;
 
+/**
+ * Query words that read as an API name rather than prose: a digit wedged against
+ * letters (enum2str, any2Int, SYS10028), internal camelCase (validateWrite,
+ * DictEnum) or an underscore. These carry the intent of a lookup — everything
+ * else in "enum2str global function convert enum value to label text" is filler.
+ *
+ * Case matters here and is lost by tokenize(), so this reads the raw topic.
+ */
+function distinctiveTokens(topic: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of topic.split(/[\s,;/()[\]]+/)) {
+    const tok = raw.replace(/[^A-Za-z0-9_]/g, '');
+    if (tok.length < 4) continue;
+    const identifierLike =
+      /[A-Za-z][0-9]|[0-9][A-Za-z]/.test(tok) || /[a-z][A-Z]/.test(tok) || tok.includes('_');
+    if (!identifierLike) continue;
+    const key = tok.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(tok);
+  }
+
+  return out;
+}
+
+/**
+ * Whether the base documents this token by NAME — as an id, a keyword, or a word
+ * in a title or summary. A keyword may be longer than the token ("enum value"
+ * covers "value"); the reverse is deliberately not accepted.
+ *
+ * That asymmetry is the whole point. scoreEntry's partial rule also credits
+ * `token.includes(k)`, so `enum2str` scores against the keyword `enum` and the
+ * extensible-enum topic comes back looking authoritative — which is how a query
+ * about a 1-argument function was answered with a topic whose only conversion
+ * example takes 2, and the caller shipped `enum2Str(enumNum(X), v)`. A token
+ * that is MORE specific than anything the base knows has not been matched; it
+ * has been approximated, and saying so is the difference between a related read
+ * and a wrong answer.
+ */
+function isDocumentedByName(token: string): boolean {
+  const t = token.toLowerCase();
+  return KNOWLEDGE_BASE.some(entry =>
+    entry.id === t ||
+    entry.keywords.some(k => k === t || k.includes(t)) ||
+    entry.title.toLowerCase().includes(t) ||
+    entry.summary.toLowerCase().includes(t));
+}
+
+/** Identifier-shaped words in the query that the base does not document by name. */
+export function unknownDistinctiveTokens(topic: string): string[] {
+  return distinctiveTokens(topic).filter(t => !isDocumentedByName(t));
+}
+
+/** Named in the warning before it stops listing and starts counting. */
+const MAX_NAMED_UNKNOWN = 3;
+
+/**
+ * The "I do not have this" line. Empty when every identifier-shaped word in the
+ * query is documented, which is the normal case.
+ */
+function unknownTokenNotice(topic: string): string {
+  const unknown = unknownDistinctiveTokens(topic);
+  if (unknown.length === 0) return '';
+
+  const named = unknown.slice(0, MAX_NAMED_UNKNOWN).map(t => `\`${t}\``).join(', ');
+  const rest = unknown.length > MAX_NAMED_UNKNOWN ? ` (and ${unknown.length - MAX_NAMED_UNKNOWN} more)` : '';
+  const isPlural = unknown.length > 1;
+
+  return (
+    `⚠️ ${named}${rest} ${isPlural ? 'are' : 'is'} not documented by name in this knowledge base. ` +
+    `The entries below are the closest match to the REST of your query — related reading, not an ` +
+    `answer about ${isPlural ? 'those names' : `\`${unknown[0]}\``}. In particular, do NOT infer a ` +
+    `signature, an argument count or a property shape from a neighbouring example.`
+  );
+}
+
 function searchKnowledge(topic: string): { entries: KnowledgeEntry[]; topScore: number } {
   const tokens = tokenize(topic);
 
@@ -3744,15 +3904,28 @@ export async function xppKnowledgeTool(request: CallToolRequest) {
         ? formatDetailed(entries)
         : formatConcise(entries);
 
+      // Two guards, and they answer different questions. The score one asks
+      // whether ANYTHING matched well; the token one asks whether the specific
+      // name the caller came for is in here at all — a query can score highly on
+      // its filler words while the one word that carried the intent matched
+      // nothing. They stack when both apply.
+      const notices: string[] = [];
+
+      const unknownNotice = unknownTokenNotice(args.topic);
+      if (entries.length > 0 && unknownNotice) notices.push(unknownNotice);
+
       // Low-confidence guard: when something matched but only weakly (incidental
       // substring overlap, no title/keyword/ID hit), warn so the caller doesn't
       // treat unrelated content as authoritative.
       if (entries.length > 0 && topScore < CONFIDENT_SCORE) {
-        formatted =
+        notices.push(
           `⚠️ No strong match for "${args.topic}" — showing the closest entries below, which may be ` +
           `unrelated. Browse the full list with \`get_knowledge(kind="knowledge")\` and an empty topic, ` +
-          `or refine your query.\n\n${formatted}`;
+          `or refine your query.`,
+        );
       }
+
+      if (notices.length > 0) formatted = `${notices.join('\n\n')}\n\n${formatted}`;
     }
 
     return {

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -18,7 +18,9 @@ import {
   searchLabelsTool, REUSABLE_MARKER, NO_HITS_MARKER, NO_REUSE_ADVICE, SOME_REUSE_ADVICE,
 } from './analysis/searchLabels.js';
 import { mapWithConcurrency } from '../utils/concurrency.js';
-import { repeatSearchNotice } from './analysis/labelSearchHistory.js';
+import {
+  recordLabelSearchCall, repeatSearchNotice, searchBudgetNotice,
+} from './analysis/labelSearchHistory.js';
 import { getLabelInfoTool } from './readers/getLabelInfo.js';
 import { createLabelTool } from './write/createLabel.js';
 import { renameLabelTool } from './write/renameLabel.js';
@@ -137,6 +139,12 @@ export async function labelsTool(request: CallToolRequest, context: XppServerCon
         delete r.searchText; delete r.text; delete r.q;
       }
     }
+    // Counted here rather than in either handler: this is the one point both the
+    // batched and the single-string path pass through, so a caller cannot escape
+    // the budget by switching shapes. (The legacy `search_labels` handler,
+    // reached directly, is not counted — nothing in the tool surface routes there.)
+    recordLabelSearchCall();
+
     if (Array.isArray(r.query)) {
       return batchSearch(r, dispatch.tool, context);
     }
@@ -262,7 +270,24 @@ async function batchSearch(
   // returned a clean report whose verdict said "no label exists — create your own".
   // That is the one thing this line exists to state unambiguously, so failures
   // either replace the verdict or are named alongside it.
+  // What earlier calls already established, stated on WHICHEVER verdict follows.
+  //
+  // Both of these used to hang off the no-hit branch alone, which made the
+  // expensive path the quiet one: a batch where every phrasing missed got a hard
+  // "stop searching and create your own", while a batch where one phrasing landed
+  // on an unrelated SYS label got "at least one label this model can resolve came
+  // back" and no count at all. Run 7b8de4ba drew that encouraging verdict five
+  // times in a row and kept rephrasing — then escalated to reading the .label.txt
+  // files and asking the user. ~49 AIU, for an answer settled by call one.
+  //
+  // Excludes this batch's own phrasings — they are the current answer, not
+  // evidence of repetition. What is left is what earlier calls already asked.
+  const budgetStop = searchBudgetNotice();
+  const repeated = repeatSearchNotice(queries);
+  const priorWork = (budgetStop ? `\n${budgetStop}` : '') + (repeated ? `\n${repeated}` : '');
+
   const verdict = searched === 0
+    // A batch that never ran establishes nothing, so it inherits nothing either.
     ? `**Verdict:** NONE of these ${runs.length} searches ran — every one failed (see the sections below). ` +
       `This says nothing about whether a reusable label exists; fix the error and search again ` +
       `rather than creating a label on the strength of this answer.\n`
@@ -275,6 +300,7 @@ async function batchSearch(
         `see the section(s) marked "${REUSABLE_MARKER}". Read the TEXT of those hits before adopting one: ` +
         `the index matches wording, not meaning, so a hit is a candidate, not a verdict. ` +
         `If none of them says what you need, do NOT rephrase and search again — nothing new will surface.\n` +
+        priorWork +
         `\n${SOME_REUSE_ADVICE}`
       : `**Verdict:** none of these ${searched} phrasings found a label this model can resolve. ` +
         `Stop searching and create your own.\n` +
@@ -282,9 +308,7 @@ async function batchSearch(
           ? `\n⚠️ ${failed.length} of ${runs.length} searches FAILED and were not part of that verdict: ` +
             `${failed.map(f => `"${f.query}"`).join(', ')}.\n`
           : '') +
-        // Excludes this batch's own phrasings — they are the current answer, not
-        // evidence of repetition. What is left is what earlier calls already asked.
-        (repeatSearchNotice(queries) ? `\n${repeatSearchNotice(queries)}` : '') +
+        priorWork +
         `\n${NO_REUSE_ADVICE}`;
 
   return {

--- a/src/tools/sdlc/runBpCheck.ts
+++ b/src/tools/sdlc/runBpCheck.ts
@@ -7,7 +7,7 @@ import { defaultPackagesRoot, findPackagesRoot } from '../../utils/packagesRoot.
 import { withOperationLock } from '../../utils/operationLocks.js';
 import { lookupSymbolsNocase, lookupSymbolNocase, type DbLike } from '../../utils/symbolLookup.js';
 import { compileModelLabels } from '../write/compileLabels.js';
-import { describeBuildFreshness } from '../../utils/buildMarker.js';
+import { buildFreshness, type BuildFreshnessStatus } from '../../utils/buildMarker.js';
 
 const execFileAsync = util.promisify(execFile);
 
@@ -48,6 +48,32 @@ const INDEX_TYPE_TO_ELEMENT_TYPE: Record<string, string> = {
 };
 
 const RESOLVABLE_INDEX_TYPES = Object.keys(INDEX_TYPE_TO_ELEMENT_TYPE);
+
+/**
+ * The verdict line for a run that found nothing, given what has compiled the model.
+ *
+ * "✅ BP Check passed" is the line a caller reads and acts on, and it said that
+ * even when nothing had ever compiled the model — the caveat went on the line
+ * below, where it contradicted a green tick that had already been believed.
+ * Benchmark run 7b8de4ba spent 54 s on a check that answered "✅ BP Check passed
+ * — 3 objects checked, 0 with findings" directly above "⚠️ Not compiled", and
+ * then met two build failures. A verdict that depends on the next line being
+ * read is not a verdict; when the state is known to be uncompiled, the tick does
+ * not belong on it.
+ *
+ * The check itself still runs and still reports — xppbp findings are real
+ * without a build, and refusing would throw away the half that works. What
+ * changes is only the claim made about them.
+ *
+ * Unknown freshness (no dataDir, so no marker to read) stays green: nothing has
+ * been learned that would justify a warning, and inventing one would train the
+ * caller to ignore it.
+ */
+function passVerdict(status?: BuildFreshnessStatus): string {
+  if (status === 'never') return '⚠️ BP clean, NOT compiled';
+  if (status === 'stale') return '⚠️ BP clean, build is STALE';
+  return '✅ BP Check passed';
+}
 
 /**
  * Translate a caller-supplied objectType into the token xppbp accepts.
@@ -502,9 +528,11 @@ export const runBpCheckTool = async (params: any, context: any) => {
     // "0 with findings". Say what has actually compiled the model — for a batch and
     // for a single object alike; a one-object check is no more of a compile than a
     // three-object one, and it used to carry no caveat at all.
-    const buildNote = context?.symbolIndex?.dataDir
-      ? `\n\n${describeBuildFreshness(context.symbolIndex.dataDir, modelName, targetFiles)}`
-      : '';
+    const freshness = context?.symbolIndex?.dataDir
+      ? buildFreshness(context.symbolIndex.dataDir, modelName, targetFiles)
+      : undefined;
+    const buildNote = freshness ? `\n\n${freshness.message}` : '';
+    const cleanVerdict = passVerdict(freshness?.status);
 
     // Single target (and the whole-model run) keep the original layout — there
     // is no preamble to share and existing callers read this shape.
@@ -529,7 +557,7 @@ export const runBpCheckTool = async (params: any, context: any) => {
       return {
         content: [{
           type: 'text',
-          text: `${hasIssues(combined) ? '⚠️ BP Check completed with issues' : '✅ BP Check passed'}` +
+          text: `${hasIssues(combined) ? '⚠️ BP Check completed with issues' : cleanVerdict}` +
             buildNote +
             `\n\n${header}` +
             (target ? `\nFilter: ${selector(target)}` : '') +
@@ -565,7 +593,7 @@ export const runBpCheckTool = async (params: any, context: any) => {
     const verdict =
       notRunCount > 0 ? `❌ BP Check incomplete — ${notRunCount} object(s) were NOT checked`
       : issueCount > 0 ? '⚠️ BP Check completed with issues'
-      : '✅ BP Check passed';
+      : cleanVerdict;
 
     return {
       content: [{

--- a/src/utils/buildMarker.ts
+++ b/src/utils/buildMarker.ts
@@ -73,8 +73,23 @@ export function readBuildRecord(dataDir: string, modelName: string): ModelBuildR
 }
 
 /**
- * One line describing whether this model has been compiled since the objects were
- * last written — the caveat a non-compiling verdict carries.
+ * What a build record says about the state these objects are in.
+ *
+ * `never` and `stale` are the two that mean the same thing to a caller — nothing
+ * has compiled what is on disk right now — and they are why this is a status and
+ * not just a sentence. A verdict that wants to stay honest has to branch on it,
+ * and matching on the emoji in the message would be a worse way to ask.
+ */
+export type BuildFreshnessStatus = 'never' | 'stale' | 'incremental' | 'full';
+
+export interface BuildFreshness {
+  status: BuildFreshnessStatus;
+  /** The one-line caveat, ready to print. */
+  message: string;
+}
+
+/**
+ * Whether this model has been compiled since the objects were last written.
  *
  * `files` is optional because the callers differ: verify_d365fo_project already
  * resolves each object's path and can prove staleness, while run_bp_check only knows
@@ -84,7 +99,7 @@ export function readBuildRecord(dataDir: string, modelName: string): ModelBuildR
  * Phrased as a statement of fact rather than an instruction: the caller is reporting
  * its own result, and this is what that result does not cover.
  */
-export function describeBuildFreshness(dataDir: string, modelName: string, files: string[] = []): string {
+export function buildFreshness(dataDir: string, modelName: string, files: string[] = []): BuildFreshness {
   let newestWrite = 0;
   for (const f of files) {
     try {
@@ -97,24 +112,40 @@ export function describeBuildFreshness(dataDir: string, modelName: string, files
 
   const rec = readBuildRecord(dataDir, modelName);
   if (!rec || !rec.succeeded) {
-    return (
-      `⚠️ Not compiled — no successful build of ${modelName} is recorded on this machine. ` +
-      'This is not a compile check: xppbp does not diagnose SYS-class compiler errors ' +
-      '(SYS10028 "next must be called once and unconditionally" is the common one). ' +
-      'Run build_d365fo_project(fullBuild: true) before scoring the task done.'
-    );
+    return {
+      status: 'never',
+      message:
+        `⚠️ Not compiled — no successful build of ${modelName} is recorded on this machine. ` +
+        'This is not a compile check: xppbp does not diagnose SYS-class compiler errors ' +
+        '(SYS10028 "next must be called once and unconditionally" is the common one). ' +
+        'Run build_d365fo_project(fullBuild: true) before scoring the task done.',
+    };
   }
 
   const builtAt = Date.parse(rec.builtAt);
   if (newestWrite > 0 && (Number.isNaN(builtAt) || builtAt < newestWrite)) {
-    return (
-      `⚠️ Stale — ${modelName} last built ${rec.builtAt}, but these objects were written after that. ` +
-      'Nothing has compiled the current state; run build_d365fo_project(fullBuild: true).'
-    );
+    return {
+      status: 'stale',
+      message:
+        `⚠️ Stale — ${modelName} last built ${rec.builtAt}, but these objects were written after that. ` +
+        'Nothing has compiled the current state; run build_d365fo_project(fullBuild: true).',
+    };
   }
 
   return rec.fullBuild
-    ? `✅ Compiled — full build of ${modelName} succeeded at ${rec.builtAt}.`
-    : `ℹ️ Last build of ${modelName} (${rec.builtAt}) was INCREMENTAL — only changed elements were compiled. ` +
-        'Use build_d365fo_project(fullBuild: true) before trusting a green result.';
+    ? {
+        status: 'full',
+        message: `✅ Compiled — full build of ${modelName} succeeded at ${rec.builtAt}.`,
+      }
+    : {
+        status: 'incremental',
+        message:
+          `ℹ️ Last build of ${modelName} (${rec.builtAt}) was INCREMENTAL — only changed elements were compiled. ` +
+          'Use build_d365fo_project(fullBuild: true) before trusting a green result.',
+      };
+}
+
+/** The caveat line alone, for callers that only print it. */
+export function describeBuildFreshness(dataDir: string, modelName: string, files: string[] = []): string {
+  return buildFreshness(dataDir, modelName, files).message;
 }

--- a/tests/tools/buildDiagnostics.test.ts
+++ b/tests/tools/buildDiagnostics.test.ts
@@ -153,3 +153,53 @@ final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
     expect(bp005('// info(strFmt("@X:Y", enum2Symbol(enumNum(Tier), i)));')).toHaveLength(0);
   });
 });
+
+/**
+ * Run 7b8de4ba wrote enum2Str with enum2Symbol's two arguments. xppc caught it,
+ * but only after a 76 s compile — then a repair call and two more builds, ~9 AIU
+ * and 130 s for a mistake that is visible in the source as written.
+ */
+describe('FN001 — fixed-arity built-ins', () => {
+  const fn001 = (code: string) => runRules(code, 'xpp').filter(v => v.rule === 'FN001');
+
+  it('flags the 2-argument enum2Str that failed the build', () => {
+    const code = `ret = checkFailed(strFmt("@AslFinSK:QualityTierDowngradeError",
+                enum2Str(enumNum(AslFinSK_QualityTier), this.orig().AslFinSK_QualityTier),
+                enum2Str(enumNum(AslFinSK_QualityTier), this.AslFinSK_QualityTier)));`;
+    const found = fn001(code);
+    expect(found).toHaveLength(2);
+    expect(found.map(v => v.line)).toEqual([2, 3]);
+    expect(found[0].severity).toBe('error');
+    // The compiler's own wording, so the finding and the build log read alike.
+    expect(found[0].fix).toContain("'enum2Str' expects 1 argument(s), but 2 specified");
+  });
+
+  it('says nothing about the correct arities', () => {
+    expect(fn001('ret = checkFailed(strFmt("@X:Y", enum2Str(a), enum2Str(b)));')).toHaveLength(0);
+    expect(fn001('str key = enum2Symbol(enumNum(Tier), i);')).toHaveLength(0);
+    expect(fn001('Tier t = symbol2Enum(enumNum(Tier), s);')).toHaveLength(0);
+  });
+
+  it('flags the mirrored mistake — a neighbour called with one argument', () => {
+    const found = fn001('str key = enum2Symbol(this.Tier);');
+    expect(found).toHaveLength(1);
+    expect(found[0].fix).toContain('enum2Symbol(enumNum(MyEnum), value)');
+  });
+
+  it('counts nested calls and string commas as one argument each', () => {
+    // enum2Str's single argument is itself a call; the comma inside the literal
+    // is masked. Neither is a top-level separator.
+    expect(fn001('info(enum2Str(this.orig().Tier));')).toHaveLength(0);
+    expect(fn001('info(strFmt("a, b, c", enum2Str(t)));')).toHaveLength(0);
+  });
+
+  it('leaves a same-named method on another object alone', () => {
+    expect(fn001('s = converter.enum2Str(id, value);')).toHaveLength(0);
+  });
+
+  it('ignores comments, strings and a call cut off mid-snippet', () => {
+    expect(fn001('// enum2Str(enumNum(Tier), v)')).toHaveLength(0);
+    expect(fn001('str doc = "call enum2Str(enumNum(Tier), v) here";')).toHaveLength(0);
+    expect(fn001('ret = enum2Str(enumNum(Tier), v')).toHaveLength(0);
+  });
+});

--- a/tests/tools/labels.test.ts
+++ b/tests/tools/labels.test.ts
@@ -345,6 +345,58 @@ describe('labels(action="search") with query[]', () => {
     expect(text).not.toContain('This is not new information');
   });
 
+  // Run 7b8de4ba: five batches in a row drew "at least one label this model can
+  // resolve came back" — each because ONE phrasing had landed on an unrelated SYS
+  // label — so the repeat notice (fruitless phrasings only) stayed nearly silent
+  // and nothing ever said stop. ~49 AIU, then the caller went off to read the
+  // .label.txt files by hand and ask the user. The count is what ends that, so it
+  // counts calls and rides on whichever verdict follows.
+  it('stops the caller by call count even when every batch keeps hitting', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([
+      makeLabelResult({ labelId: 'OrderType', text: 'Order type cannot be changed', labelFileId: 'SYS', model: 'ApplicationSuite' }),
+    ]);
+
+    const search = (q: string[]) => labelsTool(req('labels', { action: 'search', query: q }), ctx);
+
+    const first = (await search(['cannot be decreased'])).content[0].text as string;
+    const second = (await search(['downgrade not allowed'])).content[0].text as string;
+    expect(first).not.toContain('STOP');
+    expect(second).not.toContain('STOP');
+
+    const third = (await search(['value cannot be lower'])).content[0].text as string;
+    expect(third).toContain('that was label search call 3 this session');
+    // The hits verdict is still the hits verdict — the stop rides on it.
+    expect(third).toMatch(/at least one label this model can resolve came back/i);
+    // Names the escalations that follow the loop, which cost more than it did.
+    expect(third).toContain('read the .label.txt files by hand');
+    expect(third).toContain('do not ask the user');
+    // And the way out is right there.
+    expect(third).toContain('labels(action="create"');
+  });
+
+  it('counts phrasings that missed and phrasings that hit as the same call', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+    await labelsTool(req('labels', { action: 'search', query: ['a', 'b', 'c'] }), ctx);
+    await labelsTool(req('labels', { action: 'search', query: ['d'] }), ctx);
+
+    const text = (await labelsTool(req('labels', { action: 'search', query: ['e'] }), ctx))
+      .content[0].text as string;
+
+    expect(text).toContain('that was label search call 3 this session');
+    expect(text).toContain('(5 phrasing(s) in total)');
+  });
+
+  it('stops a single-string caller on the same count', async () => {
+    (ctx.symbolIndex.searchLabels as any).mockReturnValue([]);
+    await labelsTool(req('labels', { action: 'search', query: 'first' }), ctx);
+    await labelsTool(req('labels', { action: 'search', query: 'second' }), ctx);
+
+    const text = (await labelsTool(req('labels', { action: 'search', query: 'third' }), ctx))
+      .content[0].text as string;
+
+    expect(text).toContain('that was label search call 3 this session');
+  });
+
   it('does not report a failed batch as "no reusable label exists"', async () => {
     // isError used to be dropped: a batch in which every query blew up returned a
     // clean report whose verdict was "none of these phrasings found a label" —

--- a/tests/tools/runBpCheck.test.ts
+++ b/tests/tools/runBpCheck.test.ts
@@ -845,6 +845,106 @@ describe('run_bp_check — build freshness reflects THESE objects', () => {
 
     expect(result.content[0].text as string).toContain('✅ Compiled');
   });
+
+  // Run 7b8de4ba read "✅ BP Check passed — 3 objects checked, 0 with findings"
+  // sitting directly above "⚠️ Not compiled", 54 s before its first build, and
+  // met two build failures after it. The caveat was already on the next line; the
+  // tick above it is what got believed. So the tick has to go.
+  it('withholds the tick when nothing has ever compiled the model', async () => {
+    realFs.writeFileSync(objectPath, '<AxTable/>');
+    // No recordBuild at all — the state run 7b8de4ba was in.
+
+    const result = await runBpCheckTool(
+      { modelName: 'MyModel', objects: [{ objectType: 'table', objectName: 'ConDemoTicket' }] },
+      contextWithPath(),
+    );
+
+    const text = result.content[0].text as string;
+    expect(text).toContain('⚠️ BP clean, NOT compiled');
+    expect(text).not.toContain('✅ BP Check passed');
+    // The check still ran and still reports — this changes the claim, not the
+    // check. Scope and xppbp's own output survive untouched.
+    expect(text).toContain('Filter: table:ConDemoTicket');
+    expect(text).toContain('Not compiled');
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('withholds it for a stale build too — same thing to the caller', async () => {
+    recordBuild(dataDir, 'MyModel', {
+      builtAt: new Date(Date.now() - 60_000).toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+    realFs.writeFileSync(objectPath, '<AxTable/>');
+
+    const text = (await runBpCheckTool(
+      { modelName: 'MyModel', objects: [{ objectType: 'table', objectName: 'ConDemoTicket' }] },
+      contextWithPath(),
+    )).content[0].text as string;
+
+    expect(text).toContain('⚠️ BP clean, build is STALE');
+    expect(text).not.toContain('✅ BP Check passed');
+  });
+
+  it('gives the tick back once a full build covers the write', async () => {
+    realFs.writeFileSync(objectPath, '<AxTable/>');
+    recordBuild(dataDir, 'MyModel', {
+      builtAt: new Date(Date.now() + 60_000).toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+
+    const text = (await runBpCheckTool(
+      { modelName: 'MyModel', objects: [{ objectType: 'table', objectName: 'ConDemoTicket' }] },
+      contextWithPath(),
+    )).content[0].text as string;
+
+    expect(text).toContain('✅ BP Check passed');
+  });
+
+  it('leaves a findings verdict alone — it was never the misleading one', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: 'BPError: LocalVariableNotUsed\nErrors: 1', stderr: '' });
+    });
+    realFs.writeFileSync(objectPath, '<AxTable/>');
+
+    const text = (await runBpCheckTool(
+      { modelName: 'MyModel', objects: [{ objectType: 'table', objectName: 'ConDemoTicket' }] },
+      contextWithPath(),
+    )).content[0].text as string;
+
+    expect(text).toContain('⚠️ BP Check completed with issues');
+    expect(text).not.toContain('BP clean');
+  });
+});
+
+// Unknown freshness must not manufacture a warning: with no dataDir there is no
+// marker to read, so the tool has learned nothing that would justify one. A
+// caveat printed on no evidence is the kind that gets tuned out.
+describe('run_bp_check — no build marker to read', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    detectedRoots.splice(0, detectedRoots.length, CHE_PKG);
+    cfgEnsureLoaded.mockResolvedValue(undefined);
+    cfgGetModelName.mockReturnValue('MyModel');
+    cfgGetProjectPath.mockResolvedValue(null);
+    cfgGetPackagePath.mockReturnValue(null);
+    cfgGetCustomPackagesPath.mockResolvedValue(null);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(null);
+    cfgGetActiveXppConfig.mockResolvedValue(null);
+    allowPaths([CHE_PKG, CHE_XPPBP]);
+  });
+
+  it('keeps the plain pass when freshness is unknown', async () => {
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: any, cb: Function) => {
+      cb(null, { stdout: 'Errors: 0\nWarnings: 0', stderr: '' });
+    });
+
+    const text = (await runBpCheckTool({ modelName: 'MyModel' }, {})).content[0].text as string;
+
+    expect(text).toContain('✅ BP Check passed');
+    expect(text).not.toContain('BP clean');
+  });
 });
 
 describe('run_bp_check — omitted element type never defaults to class (#828)', () => {

--- a/tests/tools/xpp-knowledge.test.ts
+++ b/tests/tools/xpp-knowledge.test.ts
@@ -304,3 +304,57 @@ describe('get_xpp_knowledge', () => {
     expect(text).toContain('init');
   });
 });
+
+/**
+ * Run 7b8de4ba asked for "enum2str global function convert enum value to label
+ * text" and was answered — without a caveat — by the extensible-enum topic,
+ * because the token `enum2str` CONTAINS the keyword `enum` and scoreEntry credits
+ * that direction. The only conversion example in the answer takes two arguments,
+ * so the caller wrote enum2Str with two, and paid a 76 s failed build.
+ *
+ * The base now documents enum2Str, so that exact query is answered properly. What
+ * is pinned here is the general guard: a name the base does not carry must come
+ * back saying so, instead of quietly serving its nearest neighbour.
+ */
+describe('unknown distinctive tokens', () => {
+  it('says so when an identifier-shaped word is not documented by name', async () => {
+    const text = getText(await xppKnowledgeTool(req({ topic: 'SysFooBar2Baz conversion helper' })));
+    expect(text).toContain('`SysFooBar2Baz` is not documented by name');
+    // The results still come — this annotates them, it does not withhold them.
+    expect(text).toContain('##');
+    // The lesson from the run that motivated it.
+    expect(text).toContain('do NOT infer a signature, an argument count');
+  });
+
+  it('names several unknowns and counts the rest', async () => {
+    const text = getText(await xppKnowledgeTool(
+      req({ topic: 'aslFooOne aslFooTwo aslFooThree aslFooFour enum' }),
+    ));
+    expect(text).toContain('are not documented by name');
+    expect(text).toContain('(and 1 more)');
+  });
+
+  it('stays quiet for a name the base does document', async () => {
+    // enum2Str earns its silence the only way that counts: it is in the base.
+    const text = getText(await xppKnowledgeTool(
+      req({ topic: 'enum2str global function convert enum value to label text' }),
+    ));
+    expect(text).not.toContain('is not documented by name');
+    expect(text).toContain('ONE argument');
+  });
+
+  it('stays quiet for ordinary prose, however unmatched', async () => {
+    // Only identifier-shaped words qualify: a digit against letters, internal
+    // camelCase or an underscore. Plain words are the score guard's business.
+    const text = getText(await xppKnowledgeTool(req({ topic: 'batch job' })));
+    expect(text).not.toContain('not documented by name');
+  });
+
+  it('leaves every shipped entry id unflagged', async () => {
+    // An id that tripped its own guard would be a scoring bug, not a warning.
+    for (const topic of ['set-based', 'coc-authoring', 'enum-conversions', 'formrun-lifecycle']) {
+      const text = getText(await xppKnowledgeTool(req({ topic })));
+      expect(text, topic).not.toContain('not documented by name');
+    }
+  });
+});

--- a/tests/utils/buildMarker.test.ts
+++ b/tests/utils/buildMarker.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { recordBuild, readBuildRecord, describeBuildFreshness } from '../../src/utils/buildMarker';
+import { recordBuild, readBuildRecord, describeBuildFreshness, buildFreshness } from '../../src/utils/buildMarker';
 
 let dir: string;
 
@@ -26,6 +26,51 @@ const touch = (name: string): string => {
   fs.writeFileSync(p, 'x');
   return p;
 };
+
+// The status exists so a caller can branch on "nothing compiled this" without
+// matching on the emoji in the sentence. run_bp_check withholds its green tick on
+// never/stale; the message is unchanged either way.
+describe('buildFreshness status', () => {
+  it('reports never, stale, incremental and full', () => {
+    expect(buildFreshness(dir, 'AslFinanceSK').status).toBe('never');
+
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date(Date.now() - 60_000).toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+    const written = touch('AslFinSK_QualityTier.xml');
+    expect(buildFreshness(dir, 'AslFinanceSK', [written]).status).toBe('stale');
+
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date(Date.now() + 60_000).toISOString(),
+      fullBuild: false,
+      succeeded: true,
+    });
+    expect(buildFreshness(dir, 'AslFinanceSK', [written]).status).toBe('incremental');
+
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date(Date.now() + 60_000).toISOString(),
+      fullBuild: true,
+      succeeded: true,
+    });
+    expect(buildFreshness(dir, 'AslFinanceSK', [written]).status).toBe('full');
+  });
+
+  it('calls a FAILED build never, not full — succeeded is the flag that counts', () => {
+    recordBuild(dir, 'AslFinanceSK', {
+      builtAt: new Date().toISOString(),
+      fullBuild: true,
+      succeeded: false,
+    });
+
+    expect(buildFreshness(dir, 'AslFinanceSK').status).toBe('never');
+  });
+
+  it('carries the same message describeBuildFreshness prints', () => {
+    expect(buildFreshness(dir, 'AslFinanceSK').message).toBe(describeBuildFreshness(dir, 'AslFinanceSK'));
+  });
+});
 
 describe('describeBuildFreshness', () => {
   it('says nothing has compiled the model when no build was ever recorded', () => {


### PR DESCRIPTION
Two benchmark runs of the same prompt, eleven hours apart, on the same model and with no repo memory in either: `a616562b` cost **71.6 AIU**, `7b8de4ba` cost **145.5**. Both reached the same end state — enum, table-extension field in the `Administration` field group, CoC class, green full build, clean BP. The work was identical; the difference is all overhead, and discovery is where it landed (20.7 → 89.8 AIU before the first write).

Three causes, three fixes.

## 1. Label search: the soft verdict never counted (~49 AIU)

Two independent defects, and they compounded.

The repeat notice hung off the no-hit branch alone, and the counter behind it (`fruitlessLabelSearches`) only ever counted phrasings that came back **empty**. So the expensive path was the quiet one: a batch where every phrasing missed got a hard "stop searching and create your own"; a batch where one phrasing landed on an unrelated SYS label got *"at least one label this model can resolve came back"* and no count at all.

`a616562b` got the hard verdict on its second search and created a label immediately — 2 calls, ~10 AIU. `7b8de4ba` drew the encouraging one five times running, because in each batch of 3–6 phrasings at least one hit something irrelevant. Six batches / 24 phrasings in, the notice was still reporting *"11 phrasing(s) already came back empty"* — the other thirteen were invisible to it. Then it escalated past the tool: six `labels(action="info")` calls, five raw reads of the `.label.txt` files, and a question to the user (which this harness answers *"user is not available, work autonomously"* — 7 AIU into the bin).

**Fix:** count *calls*, not fruitless phrasings, and carry the stop on **whichever** verdict follows. Calls rather than phrasings because a call is a round trip (~2–3 AIU), which is what the loop actually costs, and because the batched `query=[…]` shape is the cheap one and must not be punished for using it. Budget is 2 — first call is an honest look, second is the rephrase everyone tries anyway, third has nothing left to learn. The counter sits at the single point both the array and single-string paths pass through, so it can't be dodged by switching argument shape.

The notice names the escalations that follow the loop, since those cost more than the searches did.

## 2. `enum2Str` called with two arguments (~9 AIU + 130 s)

The causal chain is intact in the log.

`get_knowledge("enum2str global function convert enum value to label text")` returned the **extensible-enum** topic — no caveat, no mention of `enum2Str`. The base had no entry for enum↔string conversion at all; its only conversion example anywhere was `enum2Symbol(enumNum(MyVehicleCategory), any2Int(category))`, a **2-argument** call. `search(query="enum2str", type="method")` returned two unrelated WHS classes. So the agent generalised the shape it had been shown:

```
'enum2Str' expects 1 argument(s), but 2 specified.  (line 19, 20)
```

Three builds instead of one (76 s failed + 17 s + 36 s full).

**Fix a — `FN001`.** An arity rule over four built-ins that convert between an enum, its label and its symbol: `enum2Str`/1, `enum2Symbol`/2, `symbol2Enum`/2, `enumNum`/1. Deliberately one family, because their *disagreement* about arity is the trap — the wrong one of the pair compiles in the head and not in xppc. `severity: 'error'`, so it rides on every write through `inlineXppValidation`: the finding now arrives in the reply to the `d365fo_file` call that writes the code, before any build. Counting runs on the masked source (a comma in a literal is already a space) and counts top-level commas only.

**Fix b — the `enum-conversions` entry.** Arity is the topic: every rule opens with the argument count and says *why* they differ. Alongside it the semantic half of the same confusion, which is what BP005 polices — `enum2Str` returns the translated label and belongs in messages, `enum2Symbol` returns the untranslated AOT name and belongs in logs, keys and anything persisted. Three examples, including the wrong form commented out with xppc's own wording, and the `validateWrite` downgrade guard the benchmark prompt asks for. Cross-linked from `extensible-enums`, whose `enum2Symbol` example now notes that the label function takes one.

Verified: that exact query now returns the new entry **first**; it used to return `extensible-enums` first.

## 3. A name the base does not have comes back as its nearest neighbour

The general form of the same bug. `scoreEntry` credits partial matches in both directions, so `enum2str` scores against the keyword `enum`, clears `CONFIDENT_SCORE` and its neighbour reads as authoritative.

A token *more specific* than anything the base knows has not been matched — it has been approximated. Identifier-shaped query words (a digit against letters, internal camelCase, an underscore) are now checked for a by-name match that accepts only the keyword-longer-than-token direction; the ones that fail are named up front. Results are still returned — this annotates them — and the notice ends with the lesson: **do not infer a signature or an argument count from a neighbouring example.**

Both guards stack and answer different questions: the score guard asks whether *anything* matched well, this one asks whether the name the caller came for is in here at all — which a query can fail while scoring highly on its filler words.

Noise check against ten real queries from `7b8de4ba` and `367bbc3e`: quiet on eight, fires on `returnLabel` (genuinely absent — the base documents `DictEnum.value2Label`) and on a bare table name (not a knowledge topic). Quiet on `validateWrite`, `SimpleList`, `SysOperation`, `orig()` and on every shipped entry id.

## Not in scope

`run_bp_check` ran 54 s *before* any build and printed "Not compiled" under a ✅ — `describeBuildFreshness` already knows there is no build record at that point. Latency, not AIU; left for a separate change.

## Verification

- `npx tsc --noEmit` clean, `biome lint` clean
- **296 test files / 3658 tests green** (14 new)
- Knowledge-audit snapshot re-captured against the real symbol index on the VM — 287 references, 208 resolved, 79 allowlisted, **0 defects** — not hand-edited
- New tests pin the historical failures: the exact source that failed the build in `7b8de4ba`, the call-count budget across mixed hit/miss batches, and the by-name guard on a token the base lacks

Expected effect on the benchmark: fixes 1 and 2 target ~58 of the 74 AIU gap. The next cold run is the test of whether the budget holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
