### PR TITLE
Describe the extension token the write path actually embeds

### DIFF
--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -158,7 +158,7 @@ EXTENSION_NAMING_STYLE=prefix        # default — or "model-name"
 | `model-name` | `CustTable.ContosoRobotics` | `CustTable_ContosoRobotics_Extension` |
 
 - **`prefix`** embeds the `EXTENSION_PREFIX` infix (Microsoft's prefix-based naming guideline).
-- **`model-name`** embeds the **model name**, matching the Visual Studio developer-tools default (which uses the model name because it is already guaranteed unique). Use this when your model name is long/customer-specific (e.g. `ContosoRobotics`) but your prefix is a short abbreviation (e.g. `CR`) — the prefix still applies to **new** objects (`CRMyTable`) and to fields/methods added inside extensions (`CRApprovingWorker`); only the extension element/class token switches to the model name.
+- **`model-name`** embeds the **model name** — with any character an AOT identifier cannot hold removed, so a model called `Contoso Robotics` yields `CustTable.ContosoRobotics` (the same spelling the platform itself derives: `<Name>Monitoring and Telemetry</Name>` → `<ModelModule>MonitoringandTelemetry</ModelModule>`) — matching the Visual Studio developer-tools default (which uses the model name because it is already guaranteed unique). Use this when your model name is long/customer-specific (e.g. `ContosoRobotics`) but your prefix is a short abbreviation (e.g. `CR`) — the prefix still applies to **new** objects (`CRMyTable`) and to fields/methods added inside extensions (`CRApprovingWorker`); only the extension element/class token switches to the model name.
 
 Run `get_workspace_info` to see the active style and worked examples of exactly what the tools will emit.
 

--- a/src/tools/analysis/validateObjectNaming.ts
+++ b/src/tools/analysis/validateObjectNaming.ts
@@ -17,6 +17,7 @@ import {
   type PrefixCandidate,
 } from '../../utils/effectivePrefix.js';
 import { getConfigManager } from '../../utils/configManager.js';
+import { normalizeModelToken } from '../../utils/modelToken.js';
 import { lookupSymbolNocase, lookupSymbolsNocase } from '../../utils/symbolLookup.js';
 
 const ValidateObjectNamingArgsSchema = z.object({
@@ -163,6 +164,18 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
       modelWritesLandIn(configManager.getWriteAnchorModel() ?? activeModel, activeModel) ||
       '';
     const useModelName = namingStyle === 'model-name' && !!modelName;
+    // The spelling of the model name that may appear INSIDE an object name — what the
+    // write path embeds (applyObjectPrefix → normalizeModelToken, #892). Comparing the
+    // raw name instead flagged the very name d365fo_file(create) writes and recommended
+    // one carrying a space, which no build accepts (#901).
+    const modelToken = modelName ? normalizeModelToken(modelName) : '';
+    // Prose has to carry BOTH halves when the token is not the model name itself,
+    // otherwise "should be the model name X" is followed by "Recommended: Y". Collapses
+    // to the plain form for every model whose name is already an identifier.
+    const modelTokenPhrase =
+      modelToken === modelName
+        ? `model name "${modelName}"`
+        : `model-name token "${modelToken}" (from model "${modelName}")`;
 
     // Resolve model prefix: explicit arg → the effective prefix for that model
     // (resolveEffectivePrefix: learned from the model's own objects, else
@@ -201,11 +214,11 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
         errors.push(`baseObjectName is required for extension types (${args.objectType}).`);
       } else {
         if (args.objectType === 'class-extension') {
-          // prefix style → {Base}{Prefix}_Extension; model-name style → {Base}_{ModelName}_Extension
+          // prefix style → {Base}{Prefix}_Extension; model-name style → {Base}_{ModelToken}_Extension
           const expectedPattern = useModelName
-            ? `${baseObjectName}_${modelName}_Extension`
+            ? `${baseObjectName}_${modelToken}_Extension`
             : `${baseObjectName}${extensionInfix}_Extension`;
-          const expectedToken = useModelName ? modelName : extensionInfix;
+          const expectedToken = useModelName ? modelToken : extensionInfix;
 
           if (!name.startsWith(baseObjectName)) {
             errors.push(
@@ -217,7 +230,7 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
             if (expectedToken) suggestions.push(`Correct name: ${expectedPattern}`);
           } else {
             // Structure is correct — check the expected token is included. Strip a leading
-            // separator so "_ContosoRobotics" compares cleanly to the model name.
+            // separator so "_ContosoRobotics" compares cleanly to the model token.
             const middle = name.slice(baseObjectName.length, -'_Extension'.length).replace(/^_+/, '');
             if (
               expectedToken &&
@@ -226,7 +239,7 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
             ) {
               warnings.push(
                 useModelName
-                  ? `Extension name does not embed the model name "${modelName}" (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${name}\n  Recommended: ${expectedPattern}`
+                  ? `Extension name does not embed the ${modelTokenPhrase} (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${name}\n  Recommended: ${expectedPattern}`
                   : `Extension name does not include model "${modelName || '(unknown)'}"'s extension infix "${extensionInfix}".\n  Current: ${name}\n  Recommended: ${expectedPattern}`,
               );
             }
@@ -234,13 +247,13 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
 
           suggestions.push(
             useModelName
-              ? `AOT name for an element extension instead: ${baseObjectName}.${modelName}`
+              ? `AOT name for an element extension instead: ${baseObjectName}.${modelToken}`
               : `AOT label for extension file: ${baseObjectName}.${extensionInfix}Extension (if creating table-extension AOT object instead)`,
           );
         } else if (useModelName) {
-          // AOT extensions (table/form/enum/edt), model-name style: {Base}.{ModelName} — bare model
-          // name, no "Extension" word.
-          const expectedPattern = `${baseObjectName}.${modelName}`;
+          // AOT extensions (table/form/enum/edt), model-name style: {Base}.{ModelToken} — bare
+          // model token, no "Extension" word.
+          const expectedPattern = `${baseObjectName}.${modelToken}`;
 
           if (!name.includes('.')) {
             errors.push(
@@ -255,9 +268,9 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
                 `Extension base (before '.') must exactly match baseObjectName.\n  Expected: ${baseObjectName}.xxx\n  Got: ${basePart}.xxx`,
               );
             }
-            if (extPart.toLowerCase() !== modelName.toLowerCase()) {
+            if (extPart.toLowerCase() !== modelToken.toLowerCase()) {
               warnings.push(
-                `Extension token (after '.') should be the model name "${modelName}" (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${extPart}\n  Recommended: ${modelName}`,
+                `Extension token (after '.') should be the ${modelTokenPhrase} (EXTENSION_NAMING_STYLE=model-name).\n  Current: ${extPart}\n  Recommended: ${modelToken}`,
               );
             }
           }
@@ -434,7 +447,7 @@ export async function validateObjectNamingTool(request: CallToolRequest, context
     }
     if (isExtension) {
       output += useModelName
-        ? `Extension Style: model-name (token = model name "${modelName}")\n`
+        ? `Extension Style: model-name (token = ${modelTokenPhrase})\n`
         : `Extension Style: prefix (token = "${extensionInfix}")\n`;
       if (namingStyle === 'model-name' && !modelName) {
         output += `  ⚠ EXTENSION_NAMING_STYLE=model-name but no model name could be resolved — validated structure only. Pass modelName to validate the extension token.\n`;

--- a/src/tools/readers/getWorkspaceInfo.ts
+++ b/src/tools/readers/getWorkspaceInfo.ts
@@ -18,6 +18,7 @@ import { checkIndexStaleness } from '../../utils/indexStaleness.js';
 import {
   isCustomModel, getObjectSuffix, getExtensionNamingStyle, deriveExtensionInfix,
 } from '../../utils/modelClassifier.js';
+import { normalizeModelToken } from '../../utils/modelToken.js';
 import { buildPrefixDiagnostics, modelWritesLandIn } from '../analysis/prefixDiagnostics.js';
 import {
   buildContextSnapshot, renderContextSnapshotSection, renderContextSnapshotCompact,
@@ -164,11 +165,15 @@ export async function getWorkspaceInfoTool(
   // extensions that model already has ("…DEMOExtension") instead of being
   // derived from the prefix ("…DemoExtension").
   const extInfix = deriveExtensionInfix(effectivePrefix, writeModel ?? undefined);
-  const sampleClassExt = extNamingStyle === 'model-name' && writeModel
-    ? `CustTable_${writeModel}_Extension`
+  // The samples are names a write would PRODUCE, so they carry the same token the write
+  // path embeds — the model name with non-identifier characters removed (#892). The model
+  // name itself stays raw everywhere else here: the write path on disk is joined with it.
+  const writeModelToken = writeModel ? normalizeModelToken(writeModel) : '';
+  const sampleClassExt = extNamingStyle === 'model-name' && writeModelToken
+    ? `CustTable_${writeModelToken}_Extension`
     : `CustTable${extInfix}_Extension`;
-  const sampleElemExt = extNamingStyle === 'model-name' && writeModel
-    ? `CustTable.${writeModel}`
+  const sampleElemExt = extNamingStyle === 'model-name' && writeModelToken
+    ? `CustTable.${writeModelToken}`
     : `CustTable.${extInfix}Extension`;
   if (diagnostics) {
     lines.push(

--- a/tests/tools/namingValidatorAgreement.test.ts
+++ b/tests/tools/namingValidatorAgreement.test.ts
@@ -1,0 +1,189 @@
+/**
+ * validate_object_naming and get_workspace_info must not describe a name the write
+ * path would never write (#901).
+ *
+ * #892/PR #894 moved the WRITE path onto normalizeModelToken, so a model called
+ * "Contoso Robotics" produces `CustTable.ContosoRobotics` — an AOT element name is an
+ * identifier and cannot hold the space. Four sites that DESCRIBE the expected name kept
+ * interpolating the raw model name, and two of them are validation rules: the validator
+ * flagged the exact name create had just written and recommended "Contoso Robotics" back.
+ * An agent that trusted it either renamed a correct object into an unbuildable one, or
+ * reported a correct name as a violation.
+ *
+ * These tests run the REAL modelClassifier (only configManager is mocked), so the name
+ * fed to the validator is literally applyObjectPrefix's output — the pin that ties the
+ * two paths together.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { XppServerContext } from '../../src/types/context.js';
+import { validateObjectNamingTool } from '../../src/tools/analysis/validateObjectNaming.js';
+import { getWorkspaceInfoTool } from '../../src/tools/readers/getWorkspaceInfo.js';
+import { applyObjectPrefix } from '../../src/utils/modelClassifier.js';
+import { setModelObjectNameSource, clearInferredModelPrefixes } from '../../src/utils/modelPrefixInference.js';
+
+/** A model name Visual Studio creates without a second thought — and not an identifier. */
+const MODEL = 'Contoso Robotics';
+const TOKEN = 'ContosoRobotics';
+const PREFIX = 'CR';
+
+/** The model's own objects, all on the short prefix — the shape #892 reported. */
+const MODEL_OBJECTS = Array.from({ length: 40 }, (_, i) => `CRObject${i}`);
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    getModelName: () => MODEL,
+    getWriteAnchorModel: () => MODEL,
+    getAutoDetectedModelName: async () => MODEL,
+    getRawAutoDetectedModelName: () => MODEL,
+    getAllDetectedProjects: () => [],
+    getToolProjectSwitch: () => null,
+    getDevEnvironmentType: async () => 'local',
+    getMicrosoftPackagesPath: async () => null,
+    getWorkspaceInfoDiagnostics: async () => ({
+      modelName: MODEL,
+      modelSource: 'test',
+      isModelSourceAutoDetected: false,
+      projectPath: null,
+      projectSource: 'test',
+      packagePath: null,
+      packageSource: 'test',
+      customPackagesPath: null,
+      customPackagesSource: 'test',
+    }),
+  })),
+}));
+
+/**
+ * `CustTable` is the only symbol in this index — enough for the base-object probe to
+ * succeed, so a clean response really is clean and an unrelated "not found in symbol
+ * index" warning cannot mask a naming one. Nothing else resolves, so the conflict check
+ * over the proposed name stays empty.
+ */
+const buildContext = (): XppServerContext => {
+  const hit = (params: unknown[]) =>
+    params.some(p => typeof p === 'string' && p.replace(/"/g, '') === 'CustTable')
+      ? { name: 'CustTable', type: 'table', model: 'Application', extends_class: null, file_path: null }
+      : undefined;
+  const stmt = {
+    all: vi.fn((...params: unknown[]) => (hit(params) ? [hit(params)] : [])),
+    get: vi.fn((...params: unknown[]) => hit(params)),
+    run: vi.fn(),
+  };
+  const db = { prepare: vi.fn(() => stmt) };
+  return {
+    symbolIndex: { db, getReadDb: () => db, getLastIndexedAt: () => null } as any,
+    parser: {} as any,
+    cache: {} as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+  };
+};
+
+const req = (name: string, args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name, arguments: args },
+});
+
+const validate = async (args: Record<string, unknown>): Promise<string> => {
+  const result = await validateObjectNamingTool(
+    req('validate_object_naming', { modelName: MODEL, modelPrefix: PREFIX, ...args }),
+    buildContext(),
+  );
+  return String(result.content[0].text);
+};
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  clearInferredModelPrefixes();
+  setModelObjectNameSource(model => (model === MODEL ? MODEL_OBJECTS : []));
+  process.env.EXTENSION_PREFIX = PREFIX;
+  process.env.EXTENSION_NAMING_STYLE = 'model-name';
+  delete process.env.EXTENSION_SUFFIX;
+  delete process.env.EXTENSION_PREFIX_SOURCE;
+});
+
+afterEach(() => {
+  setModelObjectNameSource(null);
+  clearInferredModelPrefixes();
+  process.env = { ...originalEnv };
+});
+
+describe('validate_object_naming accepts what the write path produces (spaced model name)', () => {
+  it('the element-extension name applyObjectPrefix builds passes clean', async () => {
+    const written = applyObjectPrefix('CustTable.Extension', PREFIX, MODEL);
+    expect(written).toBe(`CustTable.${TOKEN}`);
+
+    const out = await validate({
+      proposedName: written,
+      objectType: 'table-extension',
+      baseObjectName: 'CustTable',
+    });
+    expect(out).not.toMatch(/ERRORS \(\d/);
+    expect(out).not.toMatch(/WARNINGS \(\d/);
+  });
+
+  it('the class-extension name applyObjectPrefix builds passes clean', async () => {
+    const written = applyObjectPrefix('CustTable_Extension', PREFIX, MODEL);
+    expect(written).toBe(`CustTable_${TOKEN}_Extension`);
+
+    const out = await validate({
+      proposedName: written,
+      objectType: 'class-extension',
+      baseObjectName: 'CustTable',
+    });
+    expect(out).not.toMatch(/ERRORS \(\d/);
+    expect(out).not.toMatch(/WARNINGS \(\d/);
+  });
+
+  it('never recommends a name carrying the space', async () => {
+    // Both the correct name and a wrong one — the recommendation has to be buildable
+    // either way. `CustTable.Contoso Robotics` is what the validator used to print.
+    for (const [proposedName, objectType] of [
+      [`CustTable.${TOKEN}`, 'table-extension'],
+      ['CustTable.CRExtension', 'table-extension'],
+      [`CustTable_${TOKEN}_Extension`, 'class-extension'],
+      ['CustTableCR_Extension', 'class-extension'],
+    ] as const) {
+      const out = await validate({ proposedName, objectType, baseObjectName: 'CustTable' });
+      expect(out, `for ${proposedName}`).not.toMatch(/CustTable[._]Contoso Robotics/);
+      expect(out, `for ${proposedName}`).not.toMatch(/Recommended: Contoso Robotics$/m);
+    }
+  });
+
+  it('still warns on a genuinely wrong token, and recommends the buildable one', async () => {
+    const out = await validate({
+      proposedName: 'CustTable.CRExtension',
+      objectType: 'table-extension',
+      baseObjectName: 'CustTable',
+    });
+    // The prose names both halves: the token that belongs in the name, and the model
+    // it came from — "should be the model name X … Recommended: Y" reads as a bug.
+    expect(out).toMatch(/should be the model-name token "ContosoRobotics" \(from model "Contoso Robotics"\)/);
+    expect(out).toMatch(/Recommended: ContosoRobotics/);
+  });
+
+  it('names both halves in the Extension Style header', async () => {
+    const out = await validate({
+      proposedName: `CustTable.${TOKEN}`,
+      objectType: 'table-extension',
+      baseObjectName: 'CustTable',
+    });
+    expect(out).toMatch(
+      /Extension Style: model-name \(token = model-name token "ContosoRobotics" \(from model "Contoso Robotics"\)\)/,
+    );
+  });
+});
+
+describe('get_workspace_info samples are names a write would produce', () => {
+  it('neither extension sample carries the space', async () => {
+    const result = await getWorkspaceInfoTool(req('get_workspace_info', {}), buildContext());
+    const out = String(result.content[0].text);
+
+    expect(out).toMatch(/CustTable_ContosoRobotics_Extension/);
+    expect(out).toMatch(/CustTable\.ContosoRobotics/);
+    expect(out).not.toMatch(/CustTable[._]Contoso Robotics/);
+  });
+});


### PR DESCRIPTION
Fixes #901.

#892/#894 moved the **write** path onto `normalizeModelToken`, so a model called `Contoso Robotics` produces `CustTable.ContosoRobotics` and `CustTable_ContosoRobotics_Extension` — an AOT element name is an identifier and cannot hold the space.

Four sites that **describe** the expected name kept interpolating the raw model name. Two of them are validation rules, so `validate_object_naming` flagged the exact name `d365fo_file(create)` had just written and recommended `Contoso Robotics` back — a name #892 established cannot build. An agent that trusted the validator either renamed a correct object into an unbuildable one, or reported a correct name as a violation. The conflict check in the same response listed `CustTable.ContosoRobotics` as an existing object of that model, so the response contradicted itself.

## The half the report did not spell out

Substituting the token alone would have produced a new contradiction inside a single warning:

```
Extension token (after '.') should be the model name "Contoso Robotics" …
  Recommended: ContosoRobotics
```

Prose that names the model and a recommendation that names an object are two different strings once the model name is not an identifier. Both now come from one phrase that carries both halves:

```
  ⚠ Extension token (after '.') should be the model-name token "ContosoRobotics"
    (from model "Contoso Robotics") (EXTENSION_NAMING_STYLE=model-name).
    Current: CRExtension
    Recommended: ContosoRobotics
```

For every model whose name is already an identifier — which is every model without a space — the token equals the name and the phrase collapses to today's exact wording, so no existing output changes and the existing assertions in `tests/tools/file-ops.test.ts` stay green untouched.

## Changes

- **`src/tools/analysis/validateObjectNaming.ts`** — one `modelToken` beside `useModelName`, used for `expectedPattern`/`expectedToken` on both extension branches, for the `extPart` comparison, and for every `Recommended:`/`Correct name:` value. The `Extension Style:` header and the two warnings take the both-halves phrase.
- **`src/tools/readers/getWorkspaceInfo.ts`** — `sampleClassExt`/`sampleElemExt` take the same token. Its own comment calls those samples the instruction (*"The samples ARE the instruction"*), so they have to be names a write would produce. The model name stays raw everywhere it identifies a model — `:230` joins the on-disk write path with it, and `PackageResolver` keys on the descriptor `<Name>`, the reason #894 did not de-space the config value.
- **`docs/CUSTOM_EXTENSIONS.md`** — one clause so the naming table cannot be read as disagreeing with the tools.

## Verification

`tests/tools/namingValidatorAgreement.test.ts` (new, 6 tests), modelled on the existing two-tools-must-not-disagree precedent `prefixResolutionAgreement.test.ts`: it mocks **only** `configManager`, so the real `applyObjectPrefix` runs and the name handed to the validator is literally the write path's output. All six fail on `main` and pass here.

- both extension forms: `applyObjectPrefix(…)` → validator, asserting no `ERRORS`/`WARNINGS` block at all
- no rendered line embeds the spaced name inside an object name, for correct and incorrect input alike
- a genuinely wrong token still warns, and prints a buildable `Recommended:`
- the `get_workspace_info` samples carry no space

`npm run test:run` — 297 files, 3672 tests, 2 skipped, all green. `tsc --noEmit` and `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
