### PR TITLE
Four write-path fixes from run 81803f01: naming, rename disclosure, undo cleanup, field-group reach

### DIFF
--- a/src/tools/analysis/validateFormPattern.ts
+++ b/src/tools/analysis/validateFormPattern.ts
@@ -303,6 +303,48 @@ export interface DataGroupRenderer {
   dataSource?: string;
   /** Control the compiler generates for a member field: <DataGroup>_<FieldName> */
   generatedNameFor: (fieldName: string) => string;
+  /** The field group it renders, as spelled in the form XML */
+  dataGroup: string;
+}
+
+/**
+ * Every container in a form that renders a table field group via <DataGroup>.
+ *
+ * {@link findDataGroupRenderers} answers "is THIS group on the form"; this one
+ * answers "which groups are", which is what a caller needs when the answer to
+ * the first is no — a field group nothing renders puts the field on no form, and
+ * naming the groups that ARE rendered turns that dead end into one call.
+ *
+ * Returns [] when the XML is unparseable or no container carries a <DataGroup>.
+ */
+export async function listDataGroupRenderers(baseFormXml: string): Promise<DataGroupRenderer[]> {
+  let parsed: any;
+  try {
+    const parser = new Parser({ explicitArray: false, mergeAttrs: true, trim: true });
+    parsed = await parser.parseStringPromise(baseFormXml);
+  } catch {
+    return [];
+  }
+  if (!parsed?.AxForm?.Design) return [];
+
+  const found: DataGroupRenderer[] = [];
+  const visit = (nodes: FormControlNode[]): void => {
+    for (const n of nodes) {
+      const dataGroup = n.properties?.DataGroup;
+      if (dataGroup) {
+        found.push({
+          controlName: n.name,
+          dataSource: n.properties?.DataSource,
+          generatedNameFor: (fieldName: string) => `${dataGroup}_${fieldName}`,
+          dataGroup,
+        });
+      }
+      visit(n.children);
+    }
+  };
+  visit(walkFormDesign(parsed.AxForm.Design).controls);
+
+  return found;
 }
 
 /**
@@ -321,35 +363,9 @@ export async function findDataGroupRenderers(
   baseFormXml: string,
   fieldGroupName: string,
 ): Promise<DataGroupRenderer[]> {
-  let parsed: any;
-  try {
-    const parser = new Parser({ explicitArray: false, mergeAttrs: true, trim: true });
-    parsed = await parser.parseStringPromise(baseFormXml);
-  } catch {
-    return [];
-  }
-  if (!parsed?.AxForm?.Design) return [];
-
-  const design = walkFormDesign(parsed.AxForm.Design);
   const needle = fieldGroupName.toLowerCase();
-  const found: DataGroupRenderer[] = [];
-
-  const visit = (nodes: FormControlNode[]): void => {
-    for (const n of nodes) {
-      const dataGroup = n.properties?.DataGroup;
-      if (dataGroup && dataGroup.toLowerCase() === needle) {
-        found.push({
-          controlName: n.name,
-          dataSource: n.properties?.DataSource,
-          generatedNameFor: (fieldName: string) => `${dataGroup}_${fieldName}`,
-        });
-      }
-      visit(n.children);
-    }
-  };
-  visit(design.controls);
-
-  return found;
+  return (await listDataGroupRenderers(baseFormXml))
+    .filter(r => r.dataGroup.toLowerCase() === needle);
 }
 
 /**

--- a/src/tools/sdlc/undoLastModification.ts
+++ b/src/tools/sdlc/undoLastModification.ts
@@ -164,9 +164,14 @@ export const undoLastModificationTool = async (params: any, context: XppServerCo
     }
 
     fs.unlinkSync(absolutePath);
+    // The create registered this file in a .rnrproj; deleting it without that
+    // entry leaves a <Content Include> pointing at nothing, which nothing else in
+    // the session removes and only VS reports. A model directory under source
+    // control takes this path, not the ledger one below.
+    const projectNote = await removeFromProjectAndForget(absolutePath);
     await cleanupIndexAfterUndo(context, absolutePath, 'deleted');
     return {
-      content: [{ type: 'text', text: 'Successfully undid file creation (deleted untracked file): ' + absolutePath + '\nStale index entries cleaned up.' }],
+      content: [{ type: 'text', text: 'Successfully undid file creation (deleted untracked file): ' + absolutePath + projectNote + '\nStale index entries cleaned up.' }],
     };
   } catch (error: any) {
     return {
@@ -193,8 +198,7 @@ async function undoViaLedger(
   if (!fs.existsSync(absolutePath)) {
     // Already gone (e.g. removed by hand). Still clean the project + index and
     // forget the ledger entry so the run's state is consistent.
-    await removeFromProjectSafe(entry);
-    forgetCreatedArtifact(absolutePath);
+    await removeFromProjectAndForget(absolutePath);
     await cleanupIndexAfterUndo(context, absolutePath, 'deleted');
     return {
       content: [{ type: 'text', text: 'File already removed; cleaned project + index entries for session-created object: ' + absolutePath }],
@@ -210,16 +214,30 @@ async function undoViaLedger(
   }
 
   fs.unlinkSync(absolutePath);
-  await removeFromProjectSafe(entry);
-  forgetCreatedArtifact(absolutePath);
+  const projectNote = await removeFromProjectAndForget(absolutePath);
   await cleanupIndexAfterUndo(context, absolutePath, 'deleted');
 
-  const projectNote = entry.projectPath
-    ? '\nRemoved its project entry from ' + path.basename(entry.projectPath) + '.'
-    : '';
   return {
     content: [{ type: 'text', text: 'Successfully undid file creation (deleted session-created file outside git): ' + absolutePath + projectNote + '\nStale index entries cleaned up.' }],
   };
+}
+
+/**
+ * Reverse the create's project registration for a deleted path and drop its
+ * ledger entry. Returns the line the undo message appends — '' when the ledger
+ * never saw this path (a file from an earlier session, or one created outside
+ * this server), in which case the .rnrproj is deliberately left alone.
+ *
+ * Both undo paths go through here so neither can forget the project entry.
+ */
+async function removeFromProjectAndForget(absolutePath: string): Promise<string> {
+  const entry = lookupCreatedArtifact(absolutePath);
+  if (!entry) return '';
+  await removeFromProjectSafe(entry);
+  forgetCreatedArtifact(absolutePath);
+  return entry.projectPath
+    ? '\nRemoved its project entry from ' + path.basename(entry.projectPath) + '.'
+    : '';
 }
 
 /**

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -3457,6 +3457,14 @@ export async function handleCreateD365File(
     if (finalObjectName !== args.objectName) {
       console.error(`[create_d365fo_file] Applied naming: ${args.objectName} → ${finalObjectName}`);
     }
+    // Disclose a rename in the RESPONSE, not only on stderr. The XML template
+    // path says "prefixed from …"; the bridge path — every extension, class and
+    // table — said nothing, so the object came back under a name the caller never
+    // chose and could only infer from the file path.
+    const renameNote = finalObjectName !== args.objectName
+      ? `\n🔖 Named \`${finalObjectName}\`, not \`${args.objectName}\` as passed — the model's naming ` +
+        `style decides this. The declaration inside the file matches; use this name in later calls.`
+      : '';
 
     // Determine object folder based on type
     const objectFolderMap: Record<string, string> = {
@@ -4084,7 +4092,7 @@ export async function handleCreateD365File(
                 content: [
                   {
                     type: 'text',
-                    text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create() (Smart)${crossModelNotice}\n` +
+                    text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create() (Smart)${crossModelNotice}${renameNote}\n` +
                       `📁 ${smartResult.filePath}${projectMsg}\n` +
                       `🔧 API: ${smartResult.api ?? 'IMetaTableProvider.Create (Smart)'}${bpSummary}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}` +
                       validateWrittenXpp(sourceAsWritten(args.sourceCode, finalObjectName)),
@@ -4192,7 +4200,7 @@ export async function handleCreateD365File(
             content: [
               {
                 type: 'text',
-                text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create()${crossModelNotice}\n` +
+                text: `✅ Created ${args.objectType} '${finalObjectName}' via IMetadataProvider.Create()${crossModelNotice}${renameNote}\n` +
                   `📁 ${bridgeResult.filePath}${projectMsg}\n` +
                   `🔧 API: ${bridgeResult.message}${honestyReport}${rawLabelWarning}${verifyNote}${indexNote}${bpNote}${xppRuleNote}${timer.render()}`,
               },

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -52,6 +52,7 @@ import {
   checkAddControlAgainstParentPattern,
   checkAddControlAgainstDataGroup,
   findDataGroupRenderers,
+  listDataGroupRenderers,
   isFormPatternEnforceEnabled,
 } from '../analysis/validateFormPattern.js';
 import { validateEdtExtensionChange } from '../../utils/edtExtensionValidator.js';
@@ -3282,19 +3283,25 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
 
     // A field group already rendered on a form via <DataGroup> puts the field on
     // that form by itself — said now, before a form extension gets created for it.
+    // And when the group is rendered by nothing, say THAT, naming the groups that
+    // are: a new group on a table extension reaches no form on its own, and an
+    // agent that does not know it goes and builds the form extension anyway.
     let fieldGroupRenderNote = '';
     if (
-      operation === 'add-field-to-field-group' &&
+      (operation === 'add-field-to-field-group' || operation === 'add-field-group') &&
       (objectType === 'table' || objectType === 'table-extension') &&
-      (args as any).fieldGroupName && args.fieldName
+      (args as any).fieldGroupName
     ) {
-      fieldGroupRenderNote = await timer.time('field-group render probe', () =>
-        describeFieldGroupRendering(
-          objectType === 'table' ? objectName : objectName.split('.')[0],
-          (args as any).fieldGroupName,
-          args.fieldName!,
-          symbolIndex,
-        ));
+      const baseTableName = objectType === 'table' ? objectName : objectName.split('.')[0];
+      const groupName = (args as any).fieldGroupName as string;
+      if (operation === 'add-field-to-field-group' && args.fieldName) {
+        fieldGroupRenderNote = await timer.time('field-group render probe', () =>
+          describeFieldGroupRendering(baseTableName, groupName, args.fieldName!, symbolIndex));
+      }
+      if (!fieldGroupRenderNote) {
+        fieldGroupRenderNote = await timer.time('field-group reach probe', () =>
+          describeUnrenderedFieldGroup(baseTableName, groupName, symbolIndex));
+      }
     }
 
     // Corrections the server applied on its own. Kept in the payload so the agent
@@ -4044,6 +4051,70 @@ export async function describeFieldGroupRendering(
         `generated one collide as a duplicate name, which only the build reports.`
       );
     }
+  } catch {
+    // A hint must never be the reason a successful write reports failure.
+  }
+  return '';
+}
+
+/**
+ * The other half of {@link describeFieldGroupRendering}: the field group reaches
+ * no form, and these are the groups on this table that do.
+ *
+ * A field group a form does not name in `<DataGroup>` generates no controls, so a
+ * field parked in a brand-new group on a table extension is on no form at all.
+ * Nothing said so, and the two paths look identical from the outside: put the
+ * field in a rendered base group and it appears for free, or invent a group and
+ * then need a form extension, an add-control, the duplicate-name guard and an
+ * undo. Run 81803f01 spent ~24 AIU discovering the difference.
+ *
+ * Returns '' whenever the answer would be a guess — no form on the table, no
+ * `<DataGroup>` anywhere, an unreadable form, an index that cannot answer — and
+ * also when the group IS rendered, which is the sibling's sentence to say.
+ */
+export async function describeUnrenderedFieldGroup(
+  baseTableName: string,
+  groupName: string,
+  symbolIndex: any,
+): Promise<string> {
+  try {
+    const rdb = symbolIndex?.getReadDb?.();
+    if (!rdb) return '';
+
+    const sql = (collate: string) =>
+      `SELECT DISTINCT form_name, datasource_name FROM form_datasources ` +
+      `WHERE table_name = ?${collate} LIMIT ${DATA_GROUP_FORM_PROBE_LIMIT}`;
+    let rows = rdb.prepare(sql('')).all(baseTableName) as
+      Array<{ form_name: string; datasource_name: string }>;
+    if (rows.length === 0) {
+      rows = rdb.prepare(sql(' COLLATE NOCASE')).all(baseTableName) as typeof rows;
+    }
+
+    const needle = groupName.trim().toLowerCase();
+    const rendered = new Map<string, string>();
+    for (const row of rows) {
+      const xml = await findBaseFormXml(row.form_name, symbolIndex);
+      if (!xml) continue;
+      for (const r of await listDataGroupRenderers(xml)) {
+        // A container bound to another datasource renders another table's group.
+        if (r.dataSource && r.dataSource.toLowerCase() !== row.datasource_name.toLowerCase()) continue;
+        // Rendered after all — describeFieldGroupRendering owns this case.
+        if (r.dataGroup.toLowerCase() === needle) return '';
+        if (!rendered.has(r.dataGroup.toLowerCase())) {
+          rendered.set(r.dataGroup.toLowerCase(), `\`${r.dataGroup}\` (form \`${row.form_name}\`, control "${r.controlName}")`);
+        }
+      }
+    }
+    if (rendered.size === 0) return '';
+
+    return (
+      `\n\n🖼️ No form checked on \`${baseTableName}\` renders field group **${groupName}** — a group ` +
+      `no container names in \`<DataGroup>\` generates no controls, so a field in it is on no form.\n` +
+      `Rendered instead: ${[...rendered.values()].join(', ')}.\n` +
+      `Add the field to one of those (\`add-field-to-field-group\` with \`extendBaseFieldGroup=true\`) and it ` +
+      `appears with no form extension. Keeping **${groupName}** means a form extension plus an explicit ` +
+      `control — and that control must not collide with a generated one.`
+    );
   } catch {
     // A hint must never be the reason a successful write reports failure.
   }

--- a/src/utils/objectNaming.ts
+++ b/src/utils/objectNaming.ts
@@ -17,6 +17,7 @@ import {
   resolveObjectPrefix,
   applyObjectPrefix,
   applyObjectSuffix,
+  deriveExtensionInfix,
   getObjectSuffix,
   getExtensionNamingStyle,
 } from './modelClassifier.js';
@@ -36,6 +37,31 @@ export const DOT_NOTATION_EXTENSION_TYPES: ReadonlySet<string> = new Set([
 
 export function isExtensionObjectType(objectType: string): boolean {
   return objectType === 'class-extension' || DOT_NOTATION_EXTENSION_TYPES.has(objectType);
+}
+
+/**
+ * Strip an element-style "Extension" word — and the infix or model token in front
+ * of it — off a class-extension name, leaving the base class.
+ *
+ * `Base.CtsoExtension` is how the dot-notation types spell it, so a caller writes
+ * a CoC class the same way: `Base_CtsoExtension`. Only the `_Extension` form was
+ * recognised, so that name read as a brand-new base class and grew a SECOND
+ * suffix — `Base_CtsoExtensionCtso_Extension`. Returns `name` unchanged when
+ * there is no "Extension" word, or when stripping would leave nothing.
+ */
+function stripElementStyleExtensionWord(name: string, tokens: readonly string[]): string {
+  if (!/extension$/i.test(name)) return name;
+  let base = name.slice(0, -'Extension'.length);
+  // Infix first: the token that would be re-applied is the one to take off, and
+  // for most models these are all the same string anyway.
+  for (const token of tokens) {
+    if (token && base.toLowerCase().endsWith(token.toLowerCase())) {
+      base = base.slice(0, -token.length);
+      break;
+    }
+  }
+  base = base.replace(/_+$/, '');
+  return base || name;
 }
 
 /**
@@ -101,10 +127,18 @@ export function normalizeObjectName(
     onNote?.(`Bare extension name auto-converted to dot-notation: ${objectName} → ${effective}`);
   }
 
-  // Case D: a class extension given a bare base class name.
+  // Case D: a class extension given a base class name — bare, or already carrying
+  // an element-style "Extension" word.
   if (objectType === 'class-extension' && !effective.endsWith('_Extension')) {
-    effective = `${effective}_Extension`;
-    onNote?.(`Bare class-extension name auto-converted to _Extension form: ${objectName} → ${effective}`);
+    const base = stripElementStyleExtensionWord(
+      effective,
+      [deriveExtensionInfix(objectPrefix, modelName), objectPrefix, modelToken],
+    );
+    const hadExtensionWord = base !== effective;
+    effective = `${base}_Extension`;
+    onNote?.(hadExtensionWord
+      ? `Element-style extension name rewritten to the class form: ${objectName} → ${effective}`
+      : `Bare class-extension name auto-converted to _Extension form: ${objectName} → ${effective}`);
   }
 
   let finalName = applyObjectPrefix(effective, objectPrefix, modelName);

--- a/tests/tools/createRenameDisclosure.test.ts
+++ b/tests/tools/createRenameDisclosure.test.ts
@@ -1,0 +1,170 @@
+/**
+ * A create that renames the object must say so in its RESPONSE.
+ *
+ * `normalizeObjectName` renames on nearly every extension create — that is its
+ * job — but only the XML-template path disclosed it (`(prefixed from "…")`). The
+ * bridge path, which owns every class, table and extension create, printed the
+ * final name and nothing else, so a caller that passed `SalesFormLetter_CtsoExtension`
+ * got back a ✅ for `SalesFormLetterCtso_Extension` with no statement that the two
+ * are the same object. Run 81803f01 read the difference as a failed create and
+ * created it a second time.
+ *
+ * The real modelClassifier runs here (only configManager and the bridge are
+ * mocked), so the name asserted is the one the naming code actually produces.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { handleCreateD365File } from '../../src/tools/write/createD365File';
+import { registerCustomModel } from '../../src/utils/modelClassifier';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const { files } = vi.hoisted(() => ({ files: new Map<string, string>() }));
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (files.has(p)) return files.get(p)!;
+    if (p.endsWith('.rnrproj')) return `<Project><ItemGroup /></Project>`;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  writeFile: vi.fn(async (p: string, content: string) => { files.set(p, content); }),
+  copyFile: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => {}),
+  access: vi.fn(async (p: string) => {
+    if (/^[A-Za-z]:[\\/]?$/.test(p) || p === '/') return;
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false, size: 1024 })),
+  readdir: vi.fn(async () => []),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter', async (orig) => {
+  const actual = await orig<typeof import('../../src/bridge/bridgeAdapter')>();
+  return { ...actual, bridgeValidateAfterWrite: vi.fn(async () => null) };
+});
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    ensureLoaded: vi.fn(async () => {}),
+    getPackagePath: vi.fn(() => 'K:\\PackagesLocalDirectory'),
+    getModelName: vi.fn(() => 'ContosoExt'),
+    getWriteAnchorModel: vi.fn(() => 'ContosoExt'),
+    getToolProjectSwitch: vi.fn(() => null),
+    getPackageNameFromWorkspacePath: vi.fn(() => 'ContosoExt'),
+    getProjectPath: vi.fn(async () => null),
+    getSolutionPath: vi.fn(async () => null),
+    getDevEnvironmentType: vi.fn(async () => 'traditional'),
+    getCustomPackagesPath: vi.fn(async () => null),
+    getMicrosoftPackagesPath: vi.fn(async () => null),
+  })),
+  fallbackPackagePath: vi.fn(() => 'C:\\AosService\\PackagesLocalDirectory'),
+  extractModelFromFilePath: vi.fn(() => null),
+}));
+
+vi.mock('../../src/utils/packageResolver', () => ({
+  PackageResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn(async (modelName: string) => ({
+      packageName: modelName, modelName, rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+    resolveWithPackage: vi.fn((m: string, p: string) => ({
+      packageName: p, modelName: m, rootPath: 'K:\\PackagesLocalDirectory',
+    })),
+  })),
+}));
+
+const createObject = vi.fn(async (request: { objectName: string }) => ({
+  success: true,
+  filePath: `K:\\PackagesLocalDirectory\\ContosoExt\\ContosoExt\\AxClass\\${request.objectName}.xml`,
+  api: 'IMetadataProvider',
+  message: 'IMetadataProvider.Create',
+}));
+
+const buildContext = () => ({
+  bridge: {
+    isReady: true,
+    metadataAvailable: true,
+    createObject,
+    validateObject: vi.fn(async () => null),
+    refreshProvider: vi.fn(async () => ({ refreshed: true, elapsedMs: 1 })),
+  },
+  symbolIndex: {
+    searchSymbols: vi.fn(() => []),
+    getSymbolByName: vi.fn(() => undefined),
+    getCustomModels: vi.fn(() => ['ContosoExt']),
+    db: { prepare: vi.fn(() => ({ all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() })) },
+    getReadDb: vi.fn(function (this: any) { return this.db; }),
+  },
+} as any);
+
+const req = (objectType: string, objectName: string, rest: Record<string, unknown> = {}): CallToolRequest => ({
+  method: 'tools/call',
+  params: {
+    name: 'create_d365fo_file',
+    arguments: {
+      objectType,
+      objectName,
+      modelName: 'ContosoExt',
+      packageName: 'ContosoExt',
+      packagePath: 'K:\\PackagesLocalDirectory',
+      addToProject: false,
+      ...rest,
+    },
+  },
+});
+
+const ENV_KEYS = ['EXTENSION_PREFIX', 'EXTENSION_SUFFIX', 'EXTENSION_NAMING_STYLE', 'EXTENSION_PREFIX_SOURCE'];
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  files.clear();
+  vi.clearAllMocks();
+  saved = Object.fromEntries(ENV_KEYS.map(k => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+  process.env.EXTENSION_PREFIX = 'Ctso';
+  process.env.EXTENSION_PREFIX_SOURCE = 'config';
+  registerCustomModel('ContosoExt');
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('create discloses the name it actually wrote', () => {
+  it('names both spellings when the bridge path renames a class extension', async () => {
+    const result = await handleCreateD365File(
+      req('class-extension', 'SalesFormLetter_CtsoExtension', {
+        sourceCode:
+          '[ExtensionOf(classStr(SalesFormLetter))]\n' +
+          'final class SalesFormLetterCtso_Extension\n{\n}',
+      }),
+      buildContext(),
+    );
+
+    const text = result.content[0].text as string;
+    expect(result.isError).toBeFalsy();
+    // The name the write used…
+    expect(createObject).toHaveBeenCalledWith(
+      expect.objectContaining({ objectName: 'SalesFormLetterCtso_Extension' }),
+    );
+    // …stated against the name the caller passed, so the two are one object.
+    expect(text).toContain('SalesFormLetterCtso_Extension');
+    expect(text).toContain('SalesFormLetter_CtsoExtension');
+    expect(text).toMatch(/not `SalesFormLetter_CtsoExtension` as passed/);
+    // And says which name the follow-up calls take.
+    expect(text).toMatch(/later calls/i);
+  });
+
+  it('says nothing when the name came back unchanged', async () => {
+    const result = await handleCreateD365File(
+      req('class', 'CtsoDemoNoteService', { sourceCode: 'class CtsoDemoNoteService\n{\n}' }),
+      buildContext(),
+    );
+
+    const text = result.content[0].text as string;
+    expect(result.isError).toBeFalsy();
+    expect(text).not.toMatch(/as passed/);
+    expect(text).not.toContain('🔖');
+  });
+});

--- a/tests/tools/fieldGroupRenderHint.test.ts
+++ b/tests/tools/fieldGroupRenderHint.test.ts
@@ -19,7 +19,10 @@ vi.mock('fs/promises', () => ({
   readFile: mockReadFile,
 }));
 
-import { describeFieldGroupRendering } from '../../src/tools/write/modifyD365File';
+import {
+  describeFieldGroupRendering,
+  describeUnrenderedFieldGroup,
+} from '../../src/tools/write/modifyD365File';
 
 const FORM_PATH = 'K:\\Packages\\AslFinanceCore\\AslFinanceCore\\AxForm\\TaxLog.xml';
 
@@ -119,5 +122,59 @@ describe('add-field-to-field-group names the form the group already renders on',
     const broken = { getReadDb: () => { throw new Error('no index'); } };
     expect(await describeFieldGroupRendering('TaxLog', 'Modified', 'F', broken)).toBe('');
     expect(await describeFieldGroupRendering('TaxLog', 'Modified', 'F', undefined)).toBe('');
+  });
+});
+
+/**
+ * The other half. A field group no container renders generates no controls, so a
+ * field parked in a new group on a table extension is on no form — and the agent
+ * that does not know it builds the form extension, hits the add-control guard and
+ * undoes the lot (run 81803f01, ~24 AIU).
+ */
+describe('a field group nothing renders names the groups that are rendered', () => {
+  beforeEach(() => {
+    mockReadFile.mockReset();
+    mockReadFile.mockResolvedValue(FORM_XML);
+  });
+
+  it('says the group reaches no form, and names the one that does', async () => {
+    const note = await describeUnrenderedFieldGroup('TaxLog', 'QualityAssessment', indexWith(ON_TAX_LOG));
+
+    expect(note).toContain('QualityAssessment');
+    expect(note).toMatch(/no form/i);
+    expect(note).toContain('`Modified`');
+    expect(note).toContain('TaxLog');
+    // The cheap path, named as such.
+    expect(note).toMatch(/extendBaseFieldGroup=true/);
+  });
+
+  it('stays quiet when the group IS rendered — that is the other note\'s sentence', async () => {
+    expect(await describeUnrenderedFieldGroup('TaxLog', 'Modified', indexWith(ON_TAX_LOG))).toBe('');
+    // Case-insensitively, as the form XML spells it however it likes.
+    expect(await describeUnrenderedFieldGroup('TaxLog', 'modified', indexWith(ON_TAX_LOG))).toBe('');
+  });
+
+  it('says nothing when no form uses the table, or none carries a DataGroup', async () => {
+    expect(await describeUnrenderedFieldGroup('TaxLog', 'QualityAssessment', indexWith([]))).toBe('');
+
+    mockReadFile.mockResolvedValue('<AxForm><Name>TaxLog</Name><Design><Controls /></Design></AxForm>');
+    expect(await describeUnrenderedFieldGroup('TaxLog', 'QualityAssessment', indexWith(ON_TAX_LOG))).toBe('');
+  });
+
+  it('ignores a container bound to a different datasource', async () => {
+    const note = await describeUnrenderedFieldGroup(
+      'TaxLog', 'QualityAssessment',
+      indexWith([{ form_name: 'TaxLog', datasource_name: 'SomeOtherTable' }]),
+    );
+    expect(note).toBe('');
+  });
+
+  it('survives an unreadable form and an index that cannot answer', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    expect(await describeUnrenderedFieldGroup('TaxLog', 'QualityAssessment', indexWith(ON_TAX_LOG))).toBe('');
+
+    const broken = { getReadDb: () => { throw new Error('no index'); } };
+    expect(await describeUnrenderedFieldGroup('TaxLog', 'QualityAssessment', broken)).toBe('');
+    expect(await describeUnrenderedFieldGroup('TaxLog', 'QualityAssessment', undefined)).toBe('');
   });
 });

--- a/tests/tools/undo-ledger.test.ts
+++ b/tests/tools/undo-ledger.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -39,6 +40,19 @@ afterEach(() => {
   _clearCreatedArtifactLedger();
   try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
 });
+
+/**
+ * `git init` in `dir`, returning the path git itself will report as the repo
+ * root. On Windows os.tmpdir() comes back as an 8.3 short path (ADMIN7~1) while
+ * `git rev-parse --show-toplevel` answers with the long one, and the tool's
+ * containment check — correctly — refuses a target that appears to sit outside
+ * its repo. Resolving here keeps that a real check rather than a test artefact.
+ */
+function gitRepoIn(dir: string): string {
+  const root = fs.realpathSync.native(dir);
+  execFileSync('git', ['init'], { cwd: root, windowsHide: true });
+  return root;
+}
 
 describe('undo_last_modification — non-git ledger fallback', () => {
   it('deletes a file the create tool recorded creating (main: returns git-repo error, file survives)', async () => {
@@ -104,6 +118,57 @@ describe('undo_last_modification — non-git ledger fallback', () => {
     // Corpus 2026-07-30T11__L3-dualwrite-entity-mapping — pruning it on the
     // "no Content of this type remains" test alone deleted three pre-existing orphans.
     expect(proj).toContain('Services\\"');
+  });
+
+  it('cleans the .rnrproj on the GIT path too — PackagesLocalDirectory usually is a repo', async () => {
+    // The two undo paths did not agree: the ledger one removed the project entry,
+    // the git-untracked one deleted the file and stopped there. A model directory
+    // under source control takes the git path, so the run that undid a class
+    // extension and a form extension left both <Content Include> entries behind,
+    // pointing at files that no longer exist (run 81803f01).
+    const repoDir = gitRepoIn(tmpDir);
+
+    const filePath = path.join(repoDir, 'ConDemoNoteService.xml');
+    fs.writeFileSync(filePath, '<AxService><Name>ConDemoNoteService</Name></AxService>', 'utf-8');
+
+    const projectPath = path.join(repoDir, 'Contoso.rnrproj');
+    fs.writeFileSync(projectPath, [
+      '<?xml version="1.0" encoding="utf-8"?>',
+      '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">',
+      '  <ItemGroup>',
+      '    <Content Include="AxService\\ConDemoNoteService">',
+      '      <SubType>Content</SubType>',
+      '      <Name>ConDemoNoteService</Name>',
+      '    </Content>',
+      '  </ItemGroup>',
+      '</Project>',
+    ].join('\n'), 'utf-8');
+
+    recordCreatedArtifact({ filePath, objectType: 'service', objectName: 'ConDemoNoteService', projectPath });
+
+    const result = await undoLastModificationTool({ filePath }, {} as any);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/deleted untracked file/i);   // the git path, not the ledger one
+    expect(result.content[0].text).toMatch(/Removed its project entry from Contoso\.rnrproj/);
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(fs.readFileSync(projectPath, 'utf-8')).not.toContain('AxService\\ConDemoNoteService');
+    expect(lookupCreatedArtifact(filePath)).toBeUndefined();
+  });
+
+  it('leaves the project alone on the git path when the ledger never saw the file', async () => {
+    // Safety: an untracked file this session did not create carries no project
+    // entry to reverse, and undo must not go looking for one to delete.
+    const repoDir = gitRepoIn(tmpDir);
+
+    const filePath = path.join(repoDir, 'Unrecorded.xml');
+    fs.writeFileSync(filePath, '<AxClass/>', 'utf-8');
+
+    const result = await undoLastModificationTool({ filePath }, {} as any);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).not.toMatch(/project entry/i);
+    expect(fs.existsSync(filePath)).toBe(false);
   });
 
   it('drops the <Folder Include> when addToProject added it in this session', async () => {

--- a/tests/utils/objectNaming.test.ts
+++ b/tests/utils/objectNaming.test.ts
@@ -48,6 +48,34 @@ describe('normalizeObjectName', () => {
       .toBe('SalesFormLetterCtso_Extension');
   });
 
+  it('rewrites an element-style class-extension name instead of suffixing it twice', () => {
+    // `Base.CtsoExtension` is how the dot-notation types spell it, so callers
+    // write a CoC class the same way. Only `_Extension` was recognised, so this
+    // name read as a brand-new base class and came back with a SECOND suffix:
+    // SalesFormLetter_CtsoExtensionCtso_Extension (run 81803f01, created silently
+    // and undone one call later).
+    expect(normalizeObjectName('SalesFormLetter_CtsoExtension', 'class-extension', 'ContosoExt'))
+      .toBe('SalesFormLetterCtso_Extension');
+    expect(normalizeObjectName('SalesFormLetterCtsoExtension', 'class-extension', 'ContosoExt'))
+      .toBe('SalesFormLetterCtso_Extension');
+  });
+
+  it('keeps the base class when the Extension word carries no token', () => {
+    expect(normalizeObjectName('SalesFormLetterExtension', 'class-extension', 'ContosoExt'))
+      .toBe('SalesFormLetterCtso_Extension');
+  });
+
+  it('is idempotent over the rewritten class-extension name', () => {
+    const once = normalizeObjectName('SalesFormLetter_CtsoExtension', 'class-extension', 'ContosoExt');
+    expect(normalizeObjectName(once, 'class-extension', 'ContosoExt')).toBe(once);
+  });
+
+  it('says so when it rewrites an element-style name', () => {
+    const notes: string[] = [];
+    normalizeObjectName('SalesFormLetter_CtsoExtension', 'class-extension', 'ContosoExt', n => notes.push(n));
+    expect(notes.join('\n')).toMatch(/element-style/i);
+  });
+
   it('is idempotent — an already-normalised name comes back unchanged', () => {
     const once = normalizeObjectName('PurchTable', 'table-extension', 'ContosoExt');
     expect(normalizeObjectName(once, 'table-extension', 'ContosoExt')).toBe(once);


### PR DESCRIPTION
Four defects from one live run (81803f01), all on the create → modify → undo path. Each is a separate commit with its own regression test.

## `fix(naming)` — an element-style class-extension name grew a second suffix

`Base.CtsoExtension` is how every dot-notation extension type spells itself, so a caller writing a CoC class reaches for `Base_CtsoExtension`. `normalizeObjectName` recognised only the `_Extension` form, so that name read as a brand-new base class:

```
SalesFormLetter_CtsoExtension → SalesFormLetter_CtsoExtensionCtso_Extension
```

Created silently under that name, undone one call later. The Extension word is now stripped together with whatever token precedes it (infix, then prefix, then model token) and the class form rebuilt from the base — idempotent, and a name carrying no token keeps its base class.

## `fix(create)` — the rename was disclosed on stderr only

Renaming is `normalizeObjectName`'s job and it fires on nearly every extension create. Only the XML-template path said so (`(prefixed from "…")`); the bridge path — every class, table and extension — printed the final name alone, so the ✅ named an object the caller never asked for and could only match up by reading the file path. Both bridge responses now name the passed spelling next to the written one, and say which of the two later calls take.

## `fix(undo)` — the git path skipped the project cleanup

The ledger path reversed the create's `.rnrproj` registration; the git-untracked path deleted the file and stopped. A model directory under source control takes the git path — the normal case — so undo left a `<Content Include>` pointing at a deleted file, which nothing else removes and only Visual Studio reports. Both paths now go through one helper. It keys off the ledger, so a file this session did not create has no entry to reverse and its project is left alone.

## `feat(modify)` — a field group that reaches no form now says so

`describeFieldGroupRendering` answers the cheap case ("this group is already rendered; the field appears by itself"). The expensive one said nothing: a group no container names in `<DataGroup>` generates no controls, so a field in a brand-new group on a table extension is on no form. The difference only surfaces as a form extension, an add-control, the duplicate-name guard and an undo — ~24 AIU in the run. `add-field-group` / `add-field-to-field-group` now name the groups the table's forms do render and point at `extendBaseFieldGroup=true`.

The probe stays silent whenever the answer would be a guess: no form on the table, no `<DataGroup>` anywhere, an unreadable form, an index that cannot answer, a container bound to another datasource, or the group turning out to be rendered after all. `findDataGroupRenderers` is now the filtered view of a new `listDataGroupRenderers`, so both questions read the form the same way.

## Verification

`npm run test:run` — 298 files, 3685 passed, 2 skipped. `npm run typecheck` and `npm run lint` clean.

New coverage: 2 undo-ledger cases (git path cleans the project; an unrecorded file's project is untouched), 4 `normalizeObjectName` cases (rewrite in both spellings, no-token name, idempotence, the note), 5 `describeUnrenderedFieldGroup` cases (all four silent paths plus the note itself), and a new `createRenameDisclosure` file that drives the real naming code through a bridge create and asserts the disclosure appears — and does not appear when nothing was renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
