### PR TITLE
Report the class access modifier instead of rewriting the declaration

### DIFF
--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -28,7 +28,7 @@ import * as debouncedRefresh from './debouncedRefresh.js';
 import { debugLog } from '../utils/logger.js';
 import { xppMethodSourceForXml } from '../utils/xppFormat.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
-import { parseXppDeclaration } from '../metadata/xppDeclaration.js';
+import { parseXppDeclaration, parseXppClassHeader } from '../metadata/xppDeclaration.js';
 import { rankCustomFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
 import {
   pageFields, fieldsHeading, fieldsFooter,
@@ -226,9 +226,21 @@ function formatClass(cls: BridgeClassInfo, compact: boolean, methodOffset: numbe
   if (cls.isAbstract) modifiers.push('abstract');
   const modStr = modifiers.length > 0 ? ` (${modifiers.join(', ')})` : '';
 
+  // The bridge sends no access modifier of its own, but it does send the
+  // declaration verbatim — and that is where the modifier lives, since AxClass
+  // XML has no element for it either. Parsed rather than regexed so a modifier
+  // named in an attribute or a doc comment cannot be mistaken for the real one.
+  const visibility = cls.declaration
+    ? parseXppClassHeader(cls.declaration)?.visibility
+    : undefined;
+
   let out = `# Class: ${cls.name}${modStr}\n\n`;
   if (cls.extends) out += `**Extends:** ${cls.extends}\n`;
   if (cls.model) out += `**Model:** ${cls.model}\n`;
+  // Printed on every path, so a reader comparing two classes is not left to infer
+  // package scope from a line's absence. Silent only when there was no
+  // declaration to read at all (#902).
+  if (cls.declaration) out += `**Access:** ${visibility ?? 'public'}\n`;
   out += `**Abstract:** ${cls.isAbstract ? 'Yes' : 'No'}\n`;
   out += `**Final:** ${cls.isFinal ? 'Yes' : 'No'}\n`;
   out += `_Source: C# bridge (IMetadataProvider)_\n\n`;

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -261,6 +261,7 @@ export class XppSymbolIndex {
       inlineComments: row.inline_comments || undefined,
       extendsClass: row.extends_class || undefined,
       implementsInterfaces: row.implements_interfaces || undefined,
+      visibility: row.visibility || undefined,
       usageExample: row.usage_example || undefined,
       usageFrequency: row.usage_frequency || undefined,
       patternType: row.pattern_type || undefined,
@@ -293,6 +294,7 @@ export class XppSymbolIndex {
         inline_comments TEXT,
         extends_class TEXT,
         implements_interfaces TEXT,
+        visibility TEXT,
         usage_example TEXT,
         usage_frequency INTEGER DEFAULT 0,
         pattern_type TEXT,
@@ -321,6 +323,10 @@ export class XppSymbolIndex {
         ['inline_comments', 'TEXT'],
         ['extends_class', 'TEXT'],
         ['implements_interfaces', 'TEXT'],
+        // Additive, like every column above it: a database built before this
+        // gets it as NULL and the readers omit the line until a re-index fills
+        // it, rather than being forced into a rebuild (#902).
+        ['visibility', 'TEXT'],
         ['usage_example', 'TEXT'],
         ['usage_frequency', 'INTEGER DEFAULT 0'],
         ['pattern_type', 'TEXT'],
@@ -1192,10 +1198,10 @@ export class XppSymbolIndex {
         INSERT OR REPLACE INTO symbols (
           name, type, parent_name, signature, file_path, model, package_name,
           description, tags, source_snippet, source, complexity, used_types, method_calls,
-          inline_comments, extends_class, implements_interfaces, usage_example,
+          inline_comments, extends_class, implements_interfaces, visibility, usage_example,
           usage_frequency, pattern_type, typical_usages, called_by_count, related_methods, api_patterns
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
       this.stmtCache.set('addSymbol', stmt);
     }
@@ -1218,6 +1224,7 @@ export class XppSymbolIndex {
       symbol.inlineComments || null,
       symbol.extendsClass || null,
       symbol.implementsInterfaces || null,
+      symbol.visibility || null,
       symbol.usageExample || null,
       symbol.usageFrequency || 0,
       symbol.patternType || null,
@@ -2212,6 +2219,7 @@ export class XppSymbolIndex {
           tags: classData.tags?.join(', '),
           extendsClass: classData.extends,
           implementsInterfaces: classData.implements?.join(', '),
+          visibility: classData.visibility,
           usedTypes: classData.usedTypes?.join(', '),
           // Pattern analysis fields
           patternType: classData.patternType,

--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -2,9 +2,9 @@
  * X++ Metadata Type Definitions
  */
 
-import type { XppExtensionOf } from './xppDeclaration.js';
+import type { XppExtensionOf, XppVisibility } from './xppDeclaration.js';
 
-export type { XppExtensionOf };
+export type { XppExtensionOf, XppVisibility };
 
 export interface XppParseResult<T> {
   success: boolean;
@@ -20,6 +20,13 @@ export interface XppClassInfo {
   implements: string[];
   isAbstract: boolean;
   isFinal: boolean;
+  /**
+   * Access modifier as declared; undefined when the class states none, which in
+   * X++ means public. `internal` is package-scoped — a caller outside the owning
+   * package cannot subclass it, extend it with [ExtensionOf] or name the type at
+   * all — so it is reported as a fact for the reader to weigh against **Model:**.
+   */
+  visibility?: XppVisibility;
   declaration: string;
   /**
    * Set when the class carries [ExtensionOf(...)] — i.e. it is a class
@@ -36,7 +43,12 @@ export interface XppClassInfo {
 
 export interface XppMethodInfo {
   name: string;
-  visibility: 'public' | 'private' | 'protected';
+  /**
+   * As declared in the X++ source. `internal` is a legal method modifier too, so
+   * the union carries it — a value the old three-way type could not express even
+   * once the parse was right.
+   */
+  visibility: XppVisibility;
   returnType: string;
   parameters: XppParameterInfo[];
   /**
@@ -175,6 +187,12 @@ export interface XppSymbol {
   extendsClass?: string;
   /** Comma-separated interfaces implemented (classes only). */
   implementsInterfaces?: string;
+  /**
+   * Access modifier as declared (classes only). Undefined both for a class that
+   * declares none and for a row written before the column existed — the readers
+   * therefore print it only when set, and never infer public from its absence.
+   */
+  visibility?: XppVisibility;
   usageExample?: string;
   patternType?: string;
   /** JSON array of typical usage examples. */

--- a/src/metadata/xmlParser.ts
+++ b/src/metadata/xmlParser.ts
@@ -26,8 +26,10 @@ import {
   parseXppClassHeader,
   parseExtensionOfAttribute,
   callsNext,
+  visibilityFromModifiers,
   type XppDeclaration,
   type XppClassHeader,
+  type XppVisibility,
 } from './xppDeclaration.js';
 
 export interface XppExtensionMembers {
@@ -177,6 +179,7 @@ export class XppMetadataParser {
         implements: parsedImplements,
         isAbstract,
         isFinal,
+        visibility: header?.visibility,
         declaration: parsedDeclaration,
         extensionOf,
         methods: parsedMethods,
@@ -302,6 +305,13 @@ export class XppMetadataParser {
   private extractClassDeclaration(axClass: any, header?: XppClassHeader | null): string {
     const modifiers: string[] = [];
     if (header) {
+      // The access modifier leads, as it does in the source: `internal final
+      // class Foo`. Rebuilding from isAbstract/isFinal alone did not merely omit
+      // it — under a heading that reads `## Declaration` it printed `final class
+      // Foo` for a source line saying `internal final class Foo`, with nothing to
+      // tell the reader the block was a reconstruction (#902). Absent from the
+      // source means absent here: no synthesised `public`.
+      if (header.visibility) modifiers.push(header.visibility);
       if (header.isAbstract) modifiers.push('abstract');
       if (header.isFinal) modifiers.push('final');
       let decl = modifiers.length > 0 ? `${modifiers.join(' ')} ` : '';
@@ -333,7 +343,7 @@ export class XppMetadataParser {
 
       const baseMethod: XppMethodInfo = {
         name: methodName,
-        visibility: this.parseVisibility(method.Visibility),
+        visibility: this.parseVisibility(decl?.modifiers, method.Visibility),
         returnType: decl?.returnType || method.ReturnType || 'void',
         parameters: this.toParameterInfo(decl),
         parametersUnknown: decl === null,
@@ -346,11 +356,27 @@ export class XppMetadataParser {
     });
   }
 
-  private parseVisibility(vis?: string): 'public' | 'private' | 'protected' {
+  /**
+   * The method's access modifier, read from the declaration that was just parsed.
+   *
+   * It used to be read from a `<Method><Visibility>` element, which real AxClass
+   * XML does not have — so every method in the AOT fell through to 'public',
+   * including the protected ones, and `get_object_info` printed
+   * `- **Visibility:** public` under each of them (#902). The modifiers were in
+   * hand two lines above the call all along.
+   *
+   * The element is still honoured as a fallback for hand-written/synthetic XML
+   * and for a declaration too malformed to parse; only then does the X++ default
+   * of public apply.
+   */
+  private parseVisibility(modifiers?: string[], vis?: string): XppVisibility {
+    const declared = modifiers ? visibilityFromModifiers(modifiers) : undefined;
+    if (declared) return declared;
+    if (modifiers) return 'public';
+
     if (!vis) return 'public';
     const lower = vis.toLowerCase();
-    if (lower === 'private') return 'private';
-    if (lower === 'protected') return 'protected';
+    if (lower === 'private' || lower === 'protected' || lower === 'internal') return lower;
     return 'public';
   }
 

--- a/src/metadata/xppDeclaration.ts
+++ b/src/metadata/xppDeclaration.ts
@@ -56,6 +56,9 @@ export function renderMethodSignature(method: RenderableMethod): string {
   return `${method.returnType ?? 'void'} ${method.name}(${params})`;
 }
 
+/** X++ access modifiers, as they may appear on a class or method line. */
+export type XppVisibility = 'public' | 'private' | 'protected' | 'internal';
+
 export interface XppClassHeader {
   kind: 'class' | 'interface';
   name: string;
@@ -63,6 +66,16 @@ export interface XppClassHeader {
   implements: string[];
   isAbstract: boolean;
   isFinal: boolean;
+  /**
+   * The access modifier as WRITTEN on the class line; undefined when the source
+   * states none. Deliberately not defaulted to 'public' (which is what an X++
+   * class without a modifier is): callers rebuild the declaration line from this
+   * header, and an effective value would make `class Foo` come back out as
+   * `public class Foo` — a line the source does not contain. Roughly one AOT
+   * class in three is `internal`, and the modifier used to be read here and
+   * dropped, so no reader could see it at all (#902).
+   */
+  visibility?: XppVisibility;
 }
 
 export interface XppDeclarationParameter {
@@ -326,6 +339,10 @@ export function parseXppClassHeader(declaration: string): XppClassHeader | null 
     ? implementsMatch[1].split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
+  // Same slice the abstract/final tests read, so an access modifier hidden in an
+  // attribute or a comment cannot reach it either.
+  const visibilityMatch = /\b(public|private|protected|internal)\b/i.exec(modifiers);
+
   return {
     kind: kw[1] as 'class' | 'interface',
     name: kw[2],
@@ -333,7 +350,21 @@ export function parseXppClassHeader(declaration: string): XppClassHeader | null 
     implements: implementsList,
     isAbstract: /\babstract\b/i.test(modifiers),
     isFinal: /\bfinal\b/i.test(modifiers),
+    visibility: visibilityMatch
+      ? (visibilityMatch[1].toLowerCase() as XppVisibility)
+      : undefined,
   };
+}
+
+/**
+ * The access modifier among a declaration's modifiers, or undefined when none is
+ * stated. X++ defaults to public, and this deliberately does not say so — see
+ * XppClassHeader.visibility.
+ */
+export function visibilityFromModifiers(modifiers: readonly string[]): XppVisibility | undefined {
+  return modifiers.find(m =>
+    m === 'public' || m === 'private' || m === 'protected' || m === 'internal',
+  ) as XppVisibility | undefined;
 }
 
 /**

--- a/src/tools/readers/classInfo.ts
+++ b/src/tools/readers/classInfo.ts
@@ -107,6 +107,11 @@ export async function classInfoTool(request: CallToolRequest, context: XppServer
     }
     
     output += `**Model:** ${cls.model}\n`;
+    // Beside the model, because the two are only useful together: `internal` is
+    // package-scoped, so whether it blocks the reader depends on which model the
+    // reader is writing in. Stated as a fact, with no verdict attached (#902).
+    // The declaration was read here, so an absent modifier really is public.
+    output += `**Access:** ${cls.visibility ?? 'public'}\n`;
     output += `**Abstract:** ${cls.isAbstract ? 'Yes' : 'No'}\n`;
     output += `**Final:** ${cls.isFinal ? 'Yes' : 'No'}\n\n`;
 
@@ -184,6 +189,10 @@ async function buildDbOnlyResponse(
   let output = `# Class: ${className}`;
   if (classSymbol.extendsClass) output += ` extends ${classSymbol.extendsClass}`;
   output += `\n**Model:** ${classSymbol.model}`;
+  // Only when the column holds something. Unlike the XML path this one has not
+  // read the source, and a database built before the column existed answers NULL
+  // for every class — which is "not indexed yet", not "public" (#902).
+  if (classSymbol.visibility) output += `  **Access:** ${classSymbol.visibility}`;
   if (classSymbol.implementsInterfaces) output += `  **Implements:** ${classSymbol.implementsInterfaces}`;
   output += '\n\n';
 

--- a/src/tools/sdlc/updateSymbolIndex.ts
+++ b/src/tools/sdlc/updateSymbolIndex.ts
@@ -427,6 +427,7 @@ export async function indexOneFile(
             tags: classData.tags?.join(', '),
             extendsClass: classData.extends,
             implementsInterfaces: classData.implements?.join(', '),
+            visibility: classData.visibility,
             usedTypes: classData.usedTypes?.join(', '),
           });
           insertedCount++;

--- a/tests/metadata/classAccessModifier.test.ts
+++ b/tests/metadata/classAccessModifier.test.ts
@@ -1,0 +1,294 @@
+/**
+ * The class access modifier — parsed, carried and reported (#902).
+ *
+ * `parseXppClassHeader` sliced the modifier text off the class line and tested it
+ * for exactly two keywords, `abstract` and `final`. The access modifier was read
+ * and dropped, and no field could have held it. Two consequences, both measured
+ * against Microsoft's WHSEWOutboundShipmentOrderUpdateMessageType:
+ *
+ *  1. No get_object_info path reported class access, on any of the three routes.
+ *     Roughly one AxClass in three in 10.0.2645.90 is `internal` (23,540 of
+ *     66,779), and every one of them rendered as `**Final:** Yes` with no access
+ *     line — which reads as "subclassing blocked, CoC still available" when the
+ *     truth is that a caller outside the owning package cannot reference the type
+ *     at all.
+ *  2. `extractClassDeclaration` rebuilt the line from the two surviving booleans,
+ *     so under a heading reading `## Declaration` the source's `internal final
+ *     class …` was printed as `final class …`. Not an omission — a replacement,
+ *     with nothing marking the block as a reconstruction.
+ *
+ * The modifier is reported as a FACT, never as a verdict: whether `internal`
+ * blocks the reader depends on which model the reader is writing in, and the
+ * `**Model:**` line sits directly above it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppMetadataParser } from '../../src/metadata/xmlParser';
+import { parseXppClassHeader } from '../../src/metadata/xppDeclaration';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { classInfoTool } from '../../src/tools/readers/classInfo';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+/** The issue's repro, verbatim from the AOT. */
+const WHSEW_DECLARATION =
+  '[SysMessageTypeFactoryAttribute(SysMessageType::WHSEWOutboundShipmentOrderUpdate)]\n' +
+  'internal final class WHSEWOutboundShipmentOrderUpdateMessageType extends WHSEWShipmentOrderUpdateMessageType\n' +
+  '{\n}';
+
+let tmpDir: string;
+
+const writeClass = async (name: string, declaration: string, methods: string[] = []) => {
+  const xml = [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">',
+    `  <Name>${name}</Name>`,
+    '  <SourceCode>',
+    `    <Declaration><![CDATA[${declaration}]]></Declaration>`,
+    '    <Methods>',
+    ...methods.map(src => [
+      '      <Method>',
+      `        <Name>${/\b(\w+)\s*\(/.exec(src)?.[1] ?? 'unknown'}</Name>`,
+      `        <Source><![CDATA[${src}]]></Source>`,
+      '      </Method>',
+    ].join('\n')),
+    '    </Methods>',
+    '  </SourceCode>',
+    '</AxClass>',
+  ].join('\n');
+  const file = path.join(tmpDir, `${name}.xml`);
+  await fs.writeFile(file, xml, 'utf-8');
+  return file;
+};
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xpp-class-access-'));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('parseXppClassHeader reads the access modifier', () => {
+  it('reports internal on the class the issue was filed against', () => {
+    expect(parseXppClassHeader(WHSEW_DECLARATION)).toMatchObject({
+      name: 'WHSEWOutboundShipmentOrderUpdateMessageType',
+      extends: 'WHSEWShipmentOrderUpdateMessageType',
+      isFinal: true,
+      isAbstract: false,
+      visibility: 'internal',
+    });
+  });
+
+  it('reads the other three modifiers, whatever their case', () => {
+    expect(parseXppClassHeader('public final class C\n{\n}')?.visibility).toBe('public');
+    expect(parseXppClassHeader('PROTECTED abstract class P\n{\n}')?.visibility).toBe('protected');
+    expect(parseXppClassHeader('private class Q\n{\n}')?.visibility).toBe('private');
+  });
+
+  it('leaves it undefined when the source states none', () => {
+    // NOT defaulted to public. The declaration is rebuilt from this header, and a
+    // synthesised modifier would print a line the source does not contain.
+    expect(parseXppClassHeader('class Plain extends Base\n{\n}')?.visibility).toBeUndefined();
+    expect(parseXppClassHeader('interface IThing\n{\n}')?.visibility).toBeUndefined();
+  });
+
+  it('is not fooled by an attribute, a comment or the class body', () => {
+    expect(parseXppClassHeader('[InternalUseOnlyAttribute]\nclass A\n{\n}')?.visibility).toBeUndefined();
+    expect(parseXppClassHeader('// internal helper for posting\nclass B\n{\n}')?.visibility).toBeUndefined();
+    expect(parseXppClassHeader('class C\n{\n    protected void m() {}\n}')?.visibility).toBeUndefined();
+  });
+});
+
+describe('parseClassFile carries the modifier instead of rewriting the line', () => {
+  it('rebuilds the declaration the source actually has', async () => {
+    const file = await writeClass('WHSEWOutboundShipmentOrderUpdateMessageType', WHSEW_DECLARATION);
+    const result = await new XppMetadataParser().parseClassFile(file, 'WarehouseOrdersIntegration');
+
+    expect(result.data?.visibility).toBe('internal');
+    expect(result.data?.declaration).toBe(
+      'internal final class WHSEWOutboundShipmentOrderUpdateMessageType ' +
+      'extends WHSEWShipmentOrderUpdateMessageType',
+    );
+  });
+
+  it('adds no modifier to a class that declares none', async () => {
+    const file = await writeClass('Plain', 'class Plain extends Base\n{\n}');
+    const result = await new XppMetadataParser().parseClassFile(file, 'M');
+
+    expect(result.data?.visibility).toBeUndefined();
+    expect(result.data?.declaration).toBe('class Plain extends Base');
+  });
+});
+
+describe('method visibility comes from the declaration, not from a missing XML element', () => {
+  it('reports each method as the source declares it', async () => {
+    // parseVisibility read <Method><Visibility>, which real AxClass XML has no
+    // element for, so every method in the AOT reported public — including the
+    // protected ones the issue lists on this very class.
+    const file = await writeClass('Visible', 'internal class Visible\n{\n}', [
+      'protected void processMessage(str _payload)\n{\n}',
+      'private boolean markMessageAsReceived()\n{\n    return true;\n}',
+      'internal void markMessageAsFailed()\n{\n}',
+      'public str parmId()\n{\n    return id;\n}',
+      'void noModifier()\n{\n}',
+    ]);
+    const result = await new XppMetadataParser().parseClassFile(file, 'M');
+
+    const byName = Object.fromEntries((result.data?.methods ?? []).map(m => [m.name, m.visibility]));
+    expect(byName).toEqual({
+      processMessage: 'protected',
+      markMessageAsReceived: 'private',
+      markMessageAsFailed: 'internal',
+      parmId: 'public',
+      // X++ defaults to public, and the declaration parsed — so this one is read,
+      // not assumed.
+      noModifier: 'public',
+    });
+  });
+
+  it('still honours a <Visibility> element when the declaration cannot be parsed', async () => {
+    // Synthetic/hand-written XML — the only place the element ever appears.
+    const xml = [
+      '<?xml version="1.0" encoding="utf-8"?>',
+      '<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">',
+      '  <Name>Synthetic</Name>',
+      '  <SourceCode>',
+      '    <Declaration><![CDATA[class Synthetic\n{\n}]]></Declaration>',
+      '    <Methods>',
+      '      <Method>',
+      '        <Name>doWork</Name>',
+      '        <Visibility>protected</Visibility>',
+      '        <Source><![CDATA[// body only, no declaration line]]></Source>',
+      '      </Method>',
+      '    </Methods>',
+      '  </SourceCode>',
+      '</AxClass>',
+    ].join('\n');
+    const file = path.join(tmpDir, 'Synthetic.xml');
+    await fs.writeFile(file, xml, 'utf-8');
+
+    const result = await new XppMetadataParser().parseClassFile(file, 'M');
+    expect(result.data?.methods[0]?.visibility).toBe('protected');
+  });
+});
+
+describe('the symbol index carries class visibility', () => {
+  it('round-trips the column', () => {
+    const index: any = new XppSymbolIndex(':memory:', ':memory:');
+    index.addSymbol({
+      name: 'Scoped', type: 'class', filePath: 'K:\\x\\Scoped.xml', model: 'M', visibility: 'internal',
+    });
+    index.addSymbol({ name: 'Open', type: 'class', filePath: 'K:\\x\\Open.xml', model: 'M' });
+
+    expect(index.getSymbolByName('Scoped', 'class')?.visibility).toBe('internal');
+    // Absent, not 'public': a class indexed without one is indistinguishable from
+    // a row written before the column existed.
+    expect(index.getSymbolByName('Open', 'class')?.visibility).toBeUndefined();
+    index.close?.();
+  });
+});
+
+/** get_object_info(objectType="class") — all three routes render the same fact. */
+describe('get_object_info reports class access', () => {
+  const req = (className: string, compact: boolean): CallToolRequest => ({
+    method: 'tools/call',
+    params: { name: 'get_object_info', arguments: { className, compact } },
+  });
+
+  const contextWith = (over: Record<string, any>) => ({
+    bridge: undefined,
+    parser: new XppMetadataParser(),
+    symbolIndex: {
+      getSymbolByName: vi.fn(() => undefined),
+      getClassMethods: vi.fn(() => []),
+      getReadDb: vi.fn(() => ({ prepare: vi.fn(() => ({ all: vi.fn(() => []), get: vi.fn(() => undefined) })) })),
+    },
+    ...over,
+  }) as any;
+
+  it('names it on the XML path, beside the declaration it belongs to', async () => {
+    const file = await writeClass('WHSEWRendered', WHSEW_DECLARATION.replace(
+      'WHSEWOutboundShipmentOrderUpdateMessageType', 'WHSEWRendered',
+    ));
+    const context = contextWith({
+      symbolIndex: {
+        getSymbolByName: vi.fn(() => ({ name: 'WHSEWRendered', filePath: file, model: 'WarehouseOrdersIntegration' })),
+        getClassMethods: vi.fn(() => []),
+        getReadDb: vi.fn(() => ({ prepare: vi.fn(() => ({ all: vi.fn(() => []), get: vi.fn(() => undefined) })) })),
+      },
+    });
+
+    const text = (await classInfoTool(req('WHSEWRendered', false), context)).content[0].text as string;
+    expect(text).toContain('**Access:** internal');
+    expect(text).toContain('internal final class WHSEWRendered');
+  });
+
+  it('says public on the XML path when the source declares nothing', async () => {
+    const file = await writeClass('OpenClass', 'class OpenClass extends Base\n{\n}');
+    const context = contextWith({
+      symbolIndex: {
+        getSymbolByName: vi.fn(() => ({ name: 'OpenClass', filePath: file, model: 'M' })),
+        getClassMethods: vi.fn(() => []),
+        getReadDb: vi.fn(() => ({ prepare: vi.fn(() => ({ all: vi.fn(() => []), get: vi.fn(() => undefined) })) })),
+      },
+    });
+
+    const text = (await classInfoTool(req('OpenClass', false), context)).content[0].text as string;
+    // The source was read here, so the X++ default is a fact and not a guess…
+    expect(text).toContain('**Access:** public');
+    // …but the declaration block still shows the line as written.
+    expect(text).toContain('class OpenClass extends Base');
+    expect(text).not.toContain('public class OpenClass');
+  });
+
+  it('names it on the DB path when the column holds it, and stays silent when it does not', async () => {
+    const indexed = (visibility?: string) => contextWith({
+      symbolIndex: {
+        getSymbolByName: vi.fn(() => ({ name: 'Scoped', filePath: 'K:\\x.xml', model: 'M', visibility })),
+        getClassMethods: vi.fn(() => []),
+        getReadDb: vi.fn(() => ({ prepare: vi.fn(() => ({ all: vi.fn(() => []), get: vi.fn(() => undefined) })) })),
+      },
+    });
+
+    const withCol = (await classInfoTool(req('Scoped', true), indexed('internal'))).content[0].text as string;
+    expect(withCol).toContain('**Access:** internal');
+
+    // A database built before the column existed answers NULL for every class.
+    // That is "not indexed yet", not "public", so the line is simply absent.
+    const withoutCol = (await classInfoTool(req('Scoped', true), indexed(undefined))).content[0].text as string;
+    expect(withoutCol).not.toContain('**Access:**');
+  });
+
+  it('derives it from the declaration on the bridge path', async () => {
+    const bridgeContext = (declaration?: string) => contextWith({
+      bridge: {
+        isReady: true,
+        metadataAvailable: true,
+        readClass: vi.fn(async () => ({
+          name: 'BridgeClass', isAbstract: false, isFinal: true, isStatic: false,
+          model: 'WarehouseOrdersIntegration', declaration, methods: [],
+        })),
+      },
+    });
+
+    const internal = (await classInfoTool(
+      req('BridgeClass', true),
+      bridgeContext('internal final class BridgeClass extends Base'),
+    )).content[0].text as string;
+    expect(internal).toContain('**Access:** internal');
+
+    const plain = (await classInfoTool(
+      req('BridgeClass', true),
+      bridgeContext('final class BridgeClass extends Base'),
+    )).content[0].text as string;
+    expect(plain).toContain('**Access:** public');
+
+    // Nothing to read means nothing is claimed.
+    const none = (await classInfoTool(req('BridgeClass', true), bridgeContext(undefined)))
+      .content[0].text as string;
+    expect(none).not.toContain('**Access:**');
+  });
+});


### PR DESCRIPTION
Fixes #902.

`parseXppClassHeader` sliced the modifier text off the class line into a local and tested it for exactly two keywords, `abstract` and `final`. The access modifier was read and dropped, and `XppClassHeader` had no field that could hold it.

## What changes

**The modifier is parsed** from the slice the header already computed (`xppDeclaration.ts`), and kept **as written** — `undefined` when the source states none. Not defaulted to `public`: callers rebuild the declaration from this header, and an effective value would round-trip `class Foo` as `public class Foo`.

**`extractClassDeclaration` emits it.** This is the half that was not merely missing but wrong: under a heading reading `## Declaration`, a source saying `internal final class WHSEW…` printed as `final class WHSEW…`, with nothing to tell the reader the block was a reconstruction.

**All three renderers print `**Access:**` beside `**Model:**`** — as a fact, with no verdict attached, exactly as the issue asks. Whether `internal` blocks the reader depends on which model the reader is writing in, and the model line sits directly above.

- XML and bridge paths have read the declaration, so an absent modifier is reported as `public` — that is what an X++ class without one is, and it is the same reading `xppDocGen` already relies on. The bridge sends no modifier of its own but does send `declaration` verbatim, so it is parsed out of that (parsed, not regexed, so an attribute or doc comment cannot be mistaken for the real thing).
- The DB path prints only when the column holds something. It has not read the source, and a database built before the column answers NULL for every class — "not indexed yet", not "public".

**`visibility TEXT` on `symbols`**, through the existing additive `newCols` migration, written at both class `addSymbol` sites (`symbolIndex.indexClasses`, `updateSymbolIndex`). Pre-existing databases get the column as NULL and simply omit the line until re-indexed — no wrong output in the interim, no forced rebuild. `extract-metadata` serialises the class object wholesale, so the field reaches the JSON with no change there, and the FTS schema is untouched.

## The "Related" half, included

`parseVisibility` read a `<Method><Visibility>` element that real AxClass XML does not have, so every method in the AOT fell through to `'public'` — including the three protected ones the issue lists on this very class. The declaration is parsed two lines above the call, so the modifiers were in hand all along; the element stays as a fallback for synthetic XML and for declarations too malformed to parse, and only then does the X++ default apply. `XppMethodInfo.visibility` widens to carry `internal`, which the old three-way union could not express even once the value was right.

It is in this PR because it is the same file, the same output path and the same defect — a modifier parsed and discarded. It is a self-contained hunk if you would rather it were split out.

## Verification

New `tests/metadata/classAccessModifier.test.ts` — 13 cases, 9 of which fail without the source change:

- `parseXppClassHeader` on the issue's verbatim repro (`internal final class WHSEWOutboundShipmentOrderUpdateMessageType extends …`), the other three modifiers in mixed case, `undefined` when none is stated, and not fooled by `[InternalUseOnlyAttribute]`, by `// internal helper`, or by a `protected` method in the body.
- `parseClassFile` rebuilds `internal final class … extends …` for that class, and adds nothing to a class that declares no modifier.
- Method visibility read from the declaration for `protected` / `private` / `internal` / `public` / no modifier, plus the `<Visibility>` fallback.
- The index column round-trips, and stays `undefined` for a class indexed without one.
- `get_object_info` on all three routes, including both DB cases (column set vs NULL) and the bridge case with no declaration at all.

`npm run test:run` — 299 files, 3698 passed, 2 skipped. `npm run typecheck` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
