### PR TITLE
fix(form-extension): place an added control by resolving its parent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Line endings are decided here rather than by each contributor's core.autocrlf.
+#
+# Without this file the answer came from whatever the local Git setting happened
+# to be, and an editor that rewrote a file's endings turned a 50-line change into
+# an 800-line diff — the content edit becomes unreviewable, and `git diff` needs
+# --ignore-cr-at-eol to say anything useful. Everything here is text and normal
+# to read as a diff, so everything is LF, in the repository and in the working
+# tree, on every platform.
+
+* text=auto eol=lf
+
+# Shell scripts break outright with CRLF; stated explicitly so the rule survives
+# any future narrowing of the wildcard above.
+*.sh text eol=lf
+
+# Binary: never normalise, never diff as text.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.dll binary
+*.exe binary
+*.snk binary

--- a/src/tools/specs/d365foFileOpSpecs.ts
+++ b/src/tools/specs/d365foFileOpSpecs.ts
@@ -165,11 +165,14 @@ export const D365FO_FILE_PARAM_SPECS: Record<string, { type: string; description
   controlLabel: { type: 'string', description: 'Optional label for the new control.' },
   positionType: {
     type: 'string',
-    description: 'AfterItem | BeforeItem. Omit to append at the end of the parent.',
+    description:
+      'AfterItem (needs previousSibling) | Begin | End. Omit to append at the end of the parent. ' +
+      'These are the values D365FO form-extension metadata actually carries; anything else is refused.',
   },
   previousSibling: {
     type: 'string',
-    description: 'Name of the sibling control to position after (used with positionType=AfterItem).',
+    description:
+      'Name of the sibling control to position after. Implies positionType=AfterItem when that is omitted.',
   },
   baseFormName: {
     type: 'string',
@@ -436,10 +439,15 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
       + 'Otherwise pass the exact name of an existing container (Tab, TabPage, Group, Grid). '
       + 'objectType="form-extension": parentControl may name a base-form container OR a container '
       + 'the extension itself defines — the writer picks the right XML shape from which it is, so '
-      + 'just pass the name. A parent bound to a table field group via <DataGroup> is REFUSED: its '
-      + 'children mirror that field group, so add the field to the field group instead '
-      + '(add-field-to-field-group) and refresh the group in the designer. previousSibling positions '
-      + 'the control only under an extension-defined parent.',
+      + 'just pass the name. A BASE-FORM parent bound to a table field group via <DataGroup> is '
+      + 'REFUSED: the compiler generates that group\'s members, so an explicit control collides — add '
+      + 'the field to the field group instead (add-field-to-field-group) and refresh the group in the '
+      + 'designer. On an EXTENSION-OWNED <DataGroup> parent the control IS written, with a warning: '
+      + 'nothing tops that group up, so the explicit control is what puts the field on the form, and '
+      + 'the field group entry is needed as well so a later designer Refresh does not discard it. '
+      + 'previousSibling works under either parent — under an extension-defined parent it orders the '
+      + 'control in the XML, under a base-form parent it is written as '
+      + '<PositionType>AfterItem</PositionType> + <PreviousSibling>.',
   },
   'add-enum-value': {
     required: ['enumValueName'],

--- a/src/tools/specs/d365foFileOpSpecs.ts
+++ b/src/tools/specs/d365foFileOpSpecs.ts
@@ -433,7 +433,13 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
     ],
     note: 'objectType="form": parentControl="Design" adds the control at the TOP LEVEL of the '
       + 'form design — use it for the first control on a form whose design is still empty. '
-      + 'Otherwise pass the exact name of an existing container (Tab, TabPage, Group, Grid).',
+      + 'Otherwise pass the exact name of an existing container (Tab, TabPage, Group, Grid). '
+      + 'objectType="form-extension": parentControl may name a base-form container OR a container '
+      + 'the extension itself defines — the writer picks the right XML shape from which it is, so '
+      + 'just pass the name. A parent bound to a table field group via <DataGroup> is REFUSED: its '
+      + 'children mirror that field group, so add the field to the field group instead '
+      + '(add-field-to-field-group) and refresh the group in the designer. previousSibling positions '
+      + 'the control only under an extension-defined parent.',
   },
   'add-enum-value': {
     required: ['enumValueName'],

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -38,8 +38,9 @@ import {
 } from '../../bridge/index.js';
 import * as debouncedRefresh from '../../bridge/debouncedRefresh.js';
 import { ProjectFileFinder, registerFileInActiveProject } from '../../workspace/projectFile.js';
-import { heuristicEdtBaseType, resolveEdtBaseType, isEnumName } from '../smart/generateSmartTable.js';
+import { heuristicEdtBaseType, resolveEdtBaseType, isEnumName, resolveEdtEnumType } from '../smart/generateSmartTable.js';
 import { normalizeD365Xml } from '../../utils/d365XmlNormalizer.js';
+import { insertFormExtensionControl } from '../../utils/formExtensionControlXml.js';
 import {
   upsertAxTableProperty,
   AX_TABLE_NON_EXISTENT_PROPERTIES,
@@ -704,6 +705,21 @@ const CONTROL_TYPE_TO_FORM_CONTROL: Record<string, { iType: string; typeValue: s
 };
 const DEFAULT_FORM_CONTROL = { iType: 'AxFormStringControl', typeValue: 'String' };
 
+/**
+ * Mark a write result as having come from this server's XML writer rather than
+ * the bridge, so the success banner can name the path that actually did the work.
+ *
+ * The headline used to read "applied via IMetadataProvider.Update()"
+ * unconditionally, while the line below it said "via direct XML fallback" — the
+ * reply named an API that never ran. That matters beyond tidiness: a reader who
+ * believes the metadata API performed the write also believes the write was
+ * validated by it, which is exactly the assumption that let a silently-discarded
+ * control read as a success.
+ */
+function viaXmlFallback<T extends { success: boolean; message: string } | null>(result: T): T {
+  return (result ? { ...result, viaXmlFallback: true } : result) as T;
+}
+
 /** Random 9-char lowercase-alphanumeric suffix, matching the SDK's
  *  `FormExtensionControl<rand>` wrapper-name convention (e.g. "fh5riowy1"). */
 function formExtensionControlName(): string {
@@ -719,11 +735,14 @@ function formExtensionControlName(): string {
  * which can NEVER find a form EXTENSION (named "BaseForm.Suffix") — it always
  * reports 'Form "<ext>" not found'. add-control on a form-extension therefore has
  * no working bridge path at all (independent of metadata-root freshness). This
- * writes an <AxFormExtensionControl> element straight into the extension's
- * <Controls> collection, in the exact shape the D365FO SDK serializes (verified
- * against shipped standard extensions): an empty-namespace <FormControl i:type="…">
- * wrapped by <AxFormExtensionControl xmlns=""> with a <Parent> reference. It edits
- * the file on disk, so it is unaffected by what the bridge has loaded.
+ * edits the file on disk, so it is unaffected by what the bridge has loaded.
+ *
+ * The shape and the insertion point both come from where `parentControl` lives:
+ * an <AxFormExtensionControl> envelope in the extension's ROOT <Controls> for a
+ * base-form parent, a bare <AxFormControl> in the parent's NESTED <Controls>
+ * when the extension defines that parent itself. See formExtensionControlXml.ts
+ * — the placement logic lives there, pure and unit-tested, because getting it
+ * wrong writes structurally invalid metadata under a ✅.
  */
 const directXmlAddControl = serializedOnFile(async (
   filePath: string,
@@ -733,59 +752,47 @@ const directXmlAddControl = serializedOnFile(async (
   dataSource?: string,
   dataField?: string,
   label?: string,
+  previousSibling?: string,
 ): Promise<{ success: boolean; message: string } | null> => {
   try {
     const rawContent = await fs.readFile(filePath, 'utf-8');
     const content = rawContent.replace(/^﻿/, '').replace(/\r\n/g, '\n');
 
-    // Idempotency: a control with this Name already present → skip.
-    // (controlName is a D365 identifier, so a literal substring match is safe.)
-    if (content.includes(`<Name>${controlName}</Name>`)) {
-      return {
-        success: true,
-        message: `✅ Control '${controlName}' already present in ${filePath} — skipped (idempotent).`,
-      };
-    }
-
     const { iType, typeValue } = CONTROL_TYPE_TO_FORM_CONTROL[(controlType || 'String').toLowerCase()] ?? DEFAULT_FORM_CONTROL;
 
-    // Inner <FormControl> children, in the order shipped extensions serialize them:
-    // Name → Type → FormControlExtension(nil) → DataField → DataSource → Label → [Items].
-    const inner = [
-      `\t\t\t\t<Name>${controlName}</Name>`,
-      `\t\t\t\t<Type>${typeValue}</Type>`,
-      `\t\t\t\t<FormControlExtension i:nil="true" />`,
-    ];
-    if (dataField) inner.push(`\t\t\t\t<DataField>${dataField}</DataField>`);
-    if (dataSource) inner.push(`\t\t\t\t<DataSource>${dataSource}</DataSource>`);
-    if (label) inner.push(`\t\t\t\t<Label>${label}</Label>`);
-    if (typeValue === 'ComboBox') inner.push(`\t\t\t\t<Items />`);
+    const outcome = insertFormExtensionControl(content, {
+      controlName, parentControl, iType, typeValue,
+      dataSource, dataField, label,
+      wrapperName: formExtensionControlName(),
+      previousSibling,
+    });
 
-    const newElement =
-      `\t\t<AxFormExtensionControl xmlns="">\n` +
-      `\t\t\t<Name>${formExtensionControlName()}</Name>\n` +
-      `\t\t\t<FormControl xmlns="" i:type="${iType}">\n` +
-      inner.join('\n') + '\n' +
-      `\t\t\t</FormControl>\n` +
-      `\t\t\t<Parent>${parentControl}</Parent>\n` +
-      `\t\t</AxFormExtensionControl>`;
-
-    let updated: string;
-    if (content.includes('<Controls />')) {
-      updated = content.replace('<Controls />', `<Controls>\n${newElement}\n\t</Controls>`);
-    } else if (content.includes('</Controls>')) {
-      updated = content.replace('</Controls>', `${newElement}\n\t</Controls>`);
-    } else {
-      return null; // no <Controls> collection — not a form-extension shape we recognise
+    switch (outcome.kind) {
+      case 'unsupported':
+        return null; // not a form-extension shape we recognise — caller falls through
+      case 'exists':
+        return {
+          success: true,
+          message: `✅ Control '${controlName}' already present in ${filePath} — skipped (idempotent).`,
+        };
+      case 'refused':
+        return { success: false, message: outcome.message };
     }
 
-    if (updated === content) return null;
-
-    await writeFileAtomic(filePath, normalizeD365Xml(updated));
+    await writeFileAtomic(filePath, normalizeD365Xml(outcome.xml));
     console.error(`[modify_d365fo_file] ✅ directXmlAddControl: added '${controlName}' (${iType}) to ${filePath}`);
+
+    const shape = outcome.representation === 'nested'
+      ? `nested <AxFormControl> under extension-owned parent`
+      : `<AxFormExtensionControl> in the extension's root <Controls>`;
+    const notes = outcome.notes.length
+      ? '\n' + outcome.notes.map(n => `⚠️ ${n}`).join('\n')
+      : '';
     return {
       success: true,
-      message: `✅ Control '${controlName}' (${iType}) added to '${parentControl}' via direct XML fallback. File: ${filePath}`,
+      message:
+        `✅ Control '${controlName}' (${iType}) added to '${parentControl}' via direct XML fallback ` +
+        `as a ${shape}. File: ${filePath}${notes}`,
     };
   } catch (err) {
     console.error(`[modify_d365fo_file] directXmlAddControl failed: ${err}`);
@@ -2172,7 +2179,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     // trip plus a full rebuild. Free when no write is outstanding.
     await timer.time('provider refresh (pending writes)', () => debouncedRefresh.flush());
 
-    let bridgeResult: { success: boolean; message: string } | null = null;
+    let bridgeResult: { success: boolean; message: string; viaXmlFallback?: boolean } | null = null;
     /** File content captured before a replace-code, to diff the reply against. */
     let replaceCodeBefore: string | null = null;
     let _bridgeRetried = false;
@@ -2355,7 +2362,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               args.fieldLabel,
               (args as any).fieldGroupName,
             );
-            if (xmlFallbackResult) bridgeResult = xmlFallbackResult;
+            if (xmlFallbackResult) bridgeResult = viaXmlFallback(xmlFallbackResult);
           }
           break;
         }
@@ -2609,7 +2616,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               allowDuplicates,
               alternateKey,
             );
-            if (xmlFallbackResult) bridgeResult = xmlFallbackResult;
+            if (xmlFallbackResult) bridgeResult = viaXmlFallback(xmlFallbackResult);
           }
         }
         break;
@@ -2741,13 +2748,13 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         // No bridge op exists for DeleteActions (#36) — this is the only path.
         const daName = (args as any).deleteActionName ?? (args as any).deleteActionTable;
         if (daName) {
-          bridgeResult = await directXmlDeleteAction(
+          bridgeResult = viaXmlFallback(await directXmlDeleteAction(
             actualFilePath,
             operation === 'add-delete-action' ? 'add' : 'remove',
             daName,
             (args as any).deleteActionTable,
             (args as any).deleteActionType,
-          );
+          ));
         }
         break;
       }
@@ -2864,7 +2871,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               describeBridgeFallbackReason(context.bridge, objectType, 'modify-property', bridgeResult),
             );
             if (xmlFallbackResult) {
-              bridgeResult = xmlFallbackResult;
+              bridgeResult = viaXmlFallback(xmlFallbackResult);
             }
           }
         }
@@ -2932,7 +2939,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               describeBridgeFallbackReason(context.bridge, objectType, 'replace-code', bridgeResult),
             );
             if (xmlFallbackResult) {
-              bridgeResult = xmlFallbackResult;
+              bridgeResult = viaXmlFallback(xmlFallbackResult);
             }
           }
         } else {
@@ -3023,8 +3030,9 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               (args as any).controlDataSource,
               (args as any).controlDataField,
               (args as any).controlLabel,
+              (args as any).previousSibling,
             );
-            if (xmlFallbackResult) bridgeResult = xmlFallbackResult;
+            if (xmlFallbackResult) bridgeResult = viaXmlFallback(xmlFallbackResult);
           }
         }
         break;
@@ -3072,7 +3080,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               (args as any).menuItemToAddType ?? 'display',
             );
             if (xmlFallbackResult) {
-              bridgeResult = xmlFallbackResult;
+              bridgeResult = viaXmlFallback(xmlFallbackResult);
             }
           }
         }
@@ -3341,7 +3349,9 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
         {
           type: 'text',
           text:
-            `✅ ${operation} on ${objectType} "${objectName}" — applied via IMetadataProvider.Update()${crossModelNotice}${autoCorrectNote}\n\n` +
+            `✅ ${operation} on ${objectType} "${objectName}" — applied via ${bridgeResult.viaXmlFallback
+              ? "this server's XML writer (no bridge path for this operation)"
+              : 'IMetadataProvider.Update()'}${crossModelNotice}${autoCorrectNote}\n\n` +
             `**File:** ${actualFilePath}${addControlNote}${generationNote}${bridgeValidation}${projectMessage}\n` +
             `🔧 API: ${bridgeResult.message}${changedLinesNote}${xppLintNote}${xppRuleNote}${addFieldBpNote}${fieldGroupRenderNote}${backupNote}${verifyNote}${indexNote}${bpNote}${timer.render()}` +
             (ignoredParamsWarning ? `\n\n${ignoredParamsWarning}` : '') + `\n\n` +
@@ -4266,7 +4276,13 @@ export function resolveControlTypeForField(
     baseType === 'Enum' ? 'ComboBox' : baseType;
 
   if (declared && db) {
-    if (isEnumName(declared, db)) return 'ComboBox';
+    if (isEnumName(declared, db)) return enumControlType(declared);
+    // Which enum, not just "an enum": a NoYes-backed EDT (the overwhelmingly
+    // common flag field) is a CheckBox everywhere in the product, and a ComboBox
+    // over it compiles fine but reads as a two-item dropdown the designer would
+    // never have produced.
+    const enumType = resolveEdtEnumType(declared, db);
+    if (enumType) return enumControlType(enumType);
     const base = asControlType(resolveEdtBaseType(declared, db));
     if (base) return base;
   }
@@ -4275,11 +4291,25 @@ export function resolveControlTypeForField(
   // conventionally the EDT or enum name in X++, so try it directly before
   // falling back to the pure name heuristic.
   if (db) {
-    if (isEnumName(dataField, db)) return 'ComboBox';
+    if (isEnumName(dataField, db)) return enumControlType(dataField);
+    const enumType = resolveEdtEnumType(dataField, db);
+    if (enumType) return enumControlType(enumType);
     const base = asControlType(resolveEdtBaseType(dataField, db));
     if (base) return base;
   }
   return asControlType(heuristicEdtBaseType(dataField));
+}
+
+/**
+ * The form control an enum binds to. Every enum is a ComboBox EXCEPT the boolean
+ * ones: D365FO renders NoYes / NoYesId as a CheckBox, and the VS designer emits
+ * AxFormCheckBoxControl for such a field. NoYesCombo is deliberately absent — it
+ * is the enum you pick precisely when you DO want the dropdown.
+ */
+const BOOLEAN_ENUMS = new Set(['noyes', 'noyesid']);
+
+function enumControlType(enumName: string): string {
+  return BOOLEAN_ENUMS.has(enumName.toLowerCase()) ? 'CheckBox' : 'ComboBox';
 }
 
 function resolveFieldEdt(tableName: string, fieldName: string, db: any): string | null {

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -3144,6 +3144,10 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
       !bridgeResult.success &&
       !_bridgeRetried &&
       context.bridge &&
+      // A refusal from this server's own XML writer never touched the bridge, so
+      // there is no provider state a refresh could change — replaying it costs a
+      // provider reload and a full retry to reach the identical answer.
+      !bridgeResult.viaXmlFallback &&
       isUnresolvedObjectError(bridgeResult.message)
     ) {
       console.error(
@@ -3162,6 +3166,13 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     timer.add(`C# bridge ${operation}`, Date.now() - bridgeStartedAt);
 
     if (!bridgeResult!.success) {
+      // A refusal from this server's own XML writer is not a bridge failure and
+      // must not be rendered as one. Naming an API that never ran is the problem
+      // viaXmlFallback was added to fix on the success branch; on this branch it
+      // also sends the reader after provider and metadata-root causes that cannot
+      // apply, past a message that already says exactly what to do.
+      if (bridgeResult!.viaXmlFallback) throw new Error(bridgeResult!.message);
+
       // Surface the real bridge error. For an object-resolution failure keep the
       // actionable same-session fallback guidance, now including exactly what the
       // bridge reported instead of a generic "could not resolve" guess.

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -753,6 +753,7 @@ const directXmlAddControl = serializedOnFile(async (
   dataField?: string,
   label?: string,
   previousSibling?: string,
+  positionType?: string,
 ): Promise<{ success: boolean; message: string } | null> => {
   try {
     const rawContent = await fs.readFile(filePath, 'utf-8');
@@ -764,7 +765,7 @@ const directXmlAddControl = serializedOnFile(async (
       controlName, parentControl, iType, typeValue,
       dataSource, dataField, label,
       wrapperName: formExtensionControlName(),
-      previousSibling,
+      previousSibling, positionType,
     });
 
     switch (outcome.kind) {
@@ -1459,10 +1460,11 @@ const ModifyD365FileArgsSchema = z.object({
     'Optional label for the new control (add-control). Becomes the control <Label>.'
   ),
   positionType: z.string().optional().describe(
-    'Optional positioning: AfterItem | BeforeItem. Omit to append at the end of the parent.'
+    'Optional positioning: AfterItem (needs previousSibling) | Begin | End. Omit to append at the ' +
+    'end of the parent. Other values are refused — these are the ones D365FO metadata carries.'
   ),
   previousSibling: z.string().optional().describe(
-    'Name of the sibling control to position after (used with positionType=AfterItem).'
+    'Name of the sibling control to position after. Implies positionType=AfterItem when that is omitted.'
   ),
   baseFormName: z.string().optional().describe(
     'Base form name used for auto-resolving parentControl when the extension name does not contain it. ' +
@@ -3031,6 +3033,7 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
               (args as any).controlDataField,
               (args as any).controlLabel,
               (args as any).previousSibling,
+              (args as any).positionType,
             );
             if (xmlFallbackResult) bridgeResult = viaXmlFallback(xmlFallbackResult);
           }

--- a/src/utils/formExtensionControlXml.ts
+++ b/src/utils/formExtensionControlXml.ts
@@ -1,0 +1,577 @@
+/**
+ * Placement + serialization for a control added to an AxFormExtension.
+ *
+ * A form extension expresses a new control in one of TWO mutually exclusive
+ * shapes, and which one is correct depends entirely on WHERE the parent lives:
+ *
+ *   1. Parent is a control of the BASE FORM → an <AxFormExtensionControl>
+ *      envelope in the extension's ROOT <Controls>, carrying its own wrapper
+ *      <Name>, the real control under <FormControl>, and a <Parent> reference:
+ *
+ *        <Controls>                                   ← root, child of AxFormExtension
+ *          <AxFormExtensionControl xmlns="">
+ *            <Name>FormExtensionControlfse38xiwz</Name>
+ *            <FormControl xmlns="" i:type="AxFormCheckBoxControl"> … </FormControl>
+ *            <Parent>Grid</Parent>
+ *          </AxFormExtensionControl>
+ *        </Controls>
+ *
+ *   2. Parent is a container THE EXTENSION ITSELF DEFINES → a bare
+ *      <AxFormControl i:type="…"> in that container's NESTED <Controls>. No
+ *      envelope and no <Parent>: the nesting already encodes parentage, so a
+ *      <Parent> element there is meaningless.
+ *
+ *        <FormControl xmlns="" i:type="AxFormGroupControl">
+ *          <Name>QualityOrders</Name>
+ *          <Controls>                                 ← nested
+ *            <AxFormControl xmlns="" i:type="AxFormCheckBoxControl"> … </AxFormControl>
+ *          </Controls>
+ *          <DataGroup>QualityOrders</DataGroup>
+ *        </FormControl>
+ *
+ * The previous implementation built shape 1 unconditionally and spliced it in
+ * with `content.replace('</Controls>', …)`. A string pattern replaces the FIRST
+ * occurrence, and when the extension defines its own container the nested
+ * </Controls> closes first — so the envelope landed inside the nested
+ * collection, which is typed to AxFormControl. `parentControl` was never
+ * resolved to a node at all; it only supplied the <Parent> text. The result was
+ * well-formed XML in the wrong collection, reported as a success.
+ *
+ * This module resolves the parent against the extension's own control tree and
+ * derives BOTH the representation and the insertion offset from where that
+ * parent turns out to live. Pure and side-effect-free so it is trivially
+ * testable — the file I/O stays in the caller.
+ */
+
+// ─── Minimal offset-preserving XML reader ────────────────────────────────────
+//
+// A real parse + re-serialize would reformat the whole file (D365FO metadata XML
+// is diffed by humans and by TFVC), so this walks the tags and records offsets
+// instead, leaving every byte we don't touch exactly as it was.
+
+interface XmlNode {
+  name: string;
+  /** Offset of '<' of the open tag. */
+  start: number;
+  /** Offset just past '>' of the open tag. */
+  openEnd: number;
+  /** Offset of '<' of the close tag (=== start when self-closing). */
+  closeStart: number;
+  /** Offset just past '>' of the close tag. */
+  end: number;
+  selfClosing: boolean;
+  children: XmlNode[];
+}
+
+/** Find the '>' that ends the tag opening at `from`, ignoring '>' inside attribute values. */
+function findTagEnd(xml: string, from: number): number {
+  let quote: string | null = null;
+  for (let i = from + 1; i < xml.length; i++) {
+    const c = xml[i];
+    if (quote) {
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") { quote = c; continue; }
+    if (c === '>') return i;
+  }
+  return -1;
+}
+
+/**
+ * Build an offset-carrying element tree. Returns null when the document is
+ * unbalanced or otherwise not something we should be splicing into — the caller
+ * then declines rather than guessing.
+ */
+function parseNodes(xml: string): XmlNode | null {
+  const stack: XmlNode[] = [];
+  let root: XmlNode | null = null;
+  let i = 0;
+
+  while (i < xml.length) {
+    const lt = xml.indexOf('<', i);
+    if (lt < 0) break;
+
+    // Prologue / comments / CDATA / doctype carry no structure we care about,
+    // but they DO carry '<' and '>' that would otherwise be read as tags.
+    // (AxFormExtension can hold <SourceCode> methods wrapped in CDATA.)
+    if (xml.startsWith('<?', lt)) { const e = xml.indexOf('?>', lt); if (e < 0) return null; i = e + 2; continue; }
+    if (xml.startsWith('<!--', lt)) { const e = xml.indexOf('-->', lt); if (e < 0) return null; i = e + 3; continue; }
+    if (xml.startsWith('<![CDATA[', lt)) { const e = xml.indexOf(']]>', lt); if (e < 0) return null; i = e + 3; continue; }
+    if (xml.startsWith('<!', lt)) { const e = xml.indexOf('>', lt); if (e < 0) return null; i = e + 1; continue; }
+
+    const gt = findTagEnd(xml, lt);
+    if (gt < 0) return null;
+    const raw = xml.slice(lt, gt + 1);
+
+    if (raw.startsWith('</')) {
+      const name = raw.slice(2, -1).trim();
+      const top = stack.pop();
+      if (!top || top.name !== name) return null; // mismatched close → decline
+      top.closeStart = lt;
+      top.end = gt + 1;
+      i = gt + 1;
+      continue;
+    }
+
+    const nameMatch = /^<([^\s/>]+)/.exec(raw);
+    if (!nameMatch) return null;
+    const selfClosing = raw.endsWith('/>');
+    const node: XmlNode = {
+      name: nameMatch[1],
+      start: lt,
+      openEnd: gt + 1,
+      closeStart: selfClosing ? lt : -1,
+      end: selfClosing ? gt + 1 : -1,
+      selfClosing,
+      children: [],
+    };
+    if (stack.length > 0) stack[stack.length - 1].children.push(node);
+    else if (!root) root = node;
+    if (!selfClosing) stack.push(node);
+    i = gt + 1;
+  }
+
+  if (stack.length > 0) return null; // unclosed element → decline
+  return root;
+}
+
+const firstChild = (n: XmlNode, name: string): XmlNode | undefined =>
+  n.children.find(c => c.name === name);
+
+const textOf = (xml: string, n: XmlNode): string =>
+  n.selfClosing ? '' : xml.slice(n.openEnd, n.closeStart).trim();
+
+/**
+ * Every control the EXTENSION itself defines, keyed by lowercased name.
+ *
+ * Only <FormControl> (inside an envelope) and <AxFormControl> (nested) are
+ * controls. <AxFormExtensionControl>'s own <Name> is the auto-generated wrapper
+ * id, NOT a control name, so reading names off the wrapper would make
+ * `parentControl: "FormExtensionControlfse38xiwz"` resolve to something real.
+ */
+function collectExtensionControls(xml: string, root: XmlNode): Map<string, XmlNode> {
+  const byName = new Map<string, XmlNode>();
+  const visit = (n: XmlNode): void => {
+    if (n.name === 'FormControl' || n.name === 'AxFormControl') {
+      const nameNode = firstChild(n, 'Name');
+      if (nameNode) {
+        const name = textOf(xml, nameNode);
+        if (name && !byName.has(name.toLowerCase())) byName.set(name.toLowerCase(), n);
+      }
+    }
+    for (const c of n.children) visit(c);
+  };
+  visit(root);
+  return byName;
+}
+
+/** Leading whitespace of the line `offset` sits on, for matching the file's indentation. */
+function lineIndentOf(xml: string, offset: number): string {
+  const lineStart = xml.lastIndexOf('\n', offset - 1) + 1;
+  const seg = xml.slice(lineStart, offset);
+  return /^[ \t]*$/.test(seg) ? seg : '\t';
+}
+
+const indentBlock = (lines: string[], indent: string): string =>
+  lines.map(l => (l === '' ? '' : indent + l)).join('\n');
+
+// ─── Placement validation ────────────────────────────────────────────────────
+
+export interface FormExtPlacementProblem {
+  /** The misplaced element. */
+  element: string;
+  /** 1-based line in the supplied XML. */
+  line: number;
+  detail: string;
+}
+
+/**
+ * Check that every control element sits in a collection typed to hold it.
+ *
+ * This exists because of how the platform actually behaves, measured 2026-08-12
+ * by compiling the malformed file: an <AxFormExtensionControl> inside a nested
+ * <Controls> does NOT fail the build. xppc returns 0 errors — the deserializer
+ * silently DISCARDS the node. The control never reaches the form, and the only
+ * trace is a metadata WARNING, and only when the parent happens to be
+ * <DataGroup>-bound so there are two field sets to compare:
+ *
+ *   Metadata Warning: …/Controls/FormExtensionControl…/…/DataGroup: The form
+ *   control has different fields from the field group '…' it is bound to.
+ *   Use restore on the form control.
+ *
+ * That warning names neither the malformed node nor the control, and it arrived
+ * among 52 pre-existing warnings. For a parent that is NOT DataGroup-bound there
+ * is nothing to compare, so the discard is expected to be entirely silent.
+ *
+ * A compiler that stays quiet is the whole problem: nothing downstream will ever
+ * catch this, so the check has to happen here, before the write. Name-based
+ * validation (formExtensionShapeValidator) cannot see it — every element in the
+ * malformed file is spelled correctly; only its POSITION is wrong.
+ */
+export function findFormExtensionPlacementProblems(xml: string): FormExtPlacementProblem[] {
+  const root = parseNodes(xml);
+  if (!root || root.name !== 'AxFormExtension') return [];
+
+  const problems: FormExtPlacementProblem[] = [];
+  const lineAt = (offset: number): number => {
+    let line = 1;
+    for (let i = 0; i < offset && i < xml.length; i++) if (xml[i] === '\n') line++;
+    return line;
+  };
+
+  // The extension's ROOT <Controls> holds envelopes, and only envelopes.
+  const rootControls = firstChild(root, 'Controls');
+  if (rootControls && !rootControls.selfClosing) {
+    for (const child of rootControls.children) {
+      if (child.name !== 'AxFormExtensionControl') {
+        problems.push({
+          element: child.name,
+          line: lineAt(child.start),
+          detail:
+            `<${child.name}> is in the extension's ROOT <Controls>, which holds ` +
+            `<AxFormExtensionControl> envelopes. A control attached to a base-form parent needs the ` +
+            `envelope (wrapper <Name>, <FormControl i:type="…">, <Parent>); a control nested under a ` +
+            `container this extension defines belongs in THAT container's <Controls> instead.`,
+        });
+      }
+    }
+  }
+
+  // A NESTED <Controls> holds bare controls, and only bare controls.
+  const visit = (n: XmlNode): void => {
+    if (n.name === 'FormControl' || n.name === 'AxFormControl') {
+      const nested = firstChild(n, 'Controls');
+      if (nested && !nested.selfClosing) {
+        const ownerName = firstChild(n, 'Name');
+        const owner = ownerName ? textOf(xml, ownerName) : '(unnamed)';
+        for (const child of nested.children) {
+          if (child.name !== 'AxFormControl') {
+            problems.push({
+              element: child.name,
+              line: lineAt(child.start),
+              detail:
+                `<${child.name}> is nested inside the <Controls> of "${owner}", which is typed to ` +
+                `<AxFormControl>. The D365FO deserializer DISCARDS it — the build reports no error and ` +
+                `the control simply never appears on the form. Nesting already encodes parentage, so a ` +
+                `child control here is a bare <AxFormControl i:type="…"> with no wrapper and no <Parent>.`,
+            });
+          }
+        }
+      }
+    }
+    for (const c of n.children) visit(c);
+  };
+  visit(root);
+
+  return problems;
+}
+
+/** Render placement problems as a blocking, self-explaining error. */
+export function buildFormExtensionPlacementError(
+  objectName: string,
+  problems: FormExtPlacementProblem[],
+): string {
+  const rows = problems
+    .map(p => `  • line ${p.line}: <${p.element}>\n    ${p.detail}`)
+    .join('\n');
+  return (
+    `⛔ form-extension "${objectName}" — a control element is in a collection that cannot hold it.\n\n` +
+    `${rows}\n\n` +
+    `This does NOT fail the build. The deserializer drops the misplaced node and xppc reports 0 errors, ` +
+    `so the change looks applied and simply has no effect (verified by compiling the malformed shape).`
+  );
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export interface FormExtensionControlSpec {
+  controlName: string;
+  parentControl: string;
+  /** Element name emitted as i:type, e.g. "AxFormCheckBoxControl". */
+  iType: string;
+  /** <Type> value, e.g. "CheckBox". */
+  typeValue: string;
+  dataSource?: string;
+  dataField?: string;
+  label?: string;
+  /**
+   * Wrapper <Name> for the envelope shape. Injected rather than generated here so
+   * this module stays deterministic; ignored for the nested shape, which has no
+   * wrapper.
+   */
+  wrapperName: string;
+  /** Insert directly after this existing sibling instead of at the end (nested shape only). */
+  previousSibling?: string;
+}
+
+export type InsertFormExtensionControlResult =
+  /** Control written. `representation` says which of the two shapes was emitted. */
+  | { kind: 'inserted'; xml: string; representation: 'envelope' | 'nested'; notes: string[] }
+  /** A control with this name is already present — nothing to do. */
+  | { kind: 'exists' }
+  /** Understood the file, but writing would be wrong. `message` is caller-facing. */
+  | { kind: 'refused'; message: string }
+  /** Not a shape this writer recognises; the caller should fall through. */
+  | { kind: 'unsupported' };
+
+/**
+ * Insert a control into an AxFormExtension, choosing shape AND location from
+ * where `parentControl` actually lives.
+ */
+export function insertFormExtensionControl(
+  xml: string,
+  spec: FormExtensionControlSpec,
+): InsertFormExtensionControlResult {
+  const root = parseNodes(xml);
+  // Refuse anything that isn't a form extension outright, so a mis-typed
+  // objectType can never splice control XML into an unrelated metadata file.
+  if (!root || root.name !== 'AxFormExtension') return { kind: 'unsupported' };
+
+  const owned = collectExtensionControls(xml, root);
+
+  // Idempotency, by resolved control name rather than a bare `<Name>X</Name>`
+  // substring search — the latter also matches data sources, fields and the
+  // extension's own <Name>, turning a real add into a silent no-op "success".
+  if (owned.has(spec.controlName.toLowerCase())) return { kind: 'exists' };
+
+  const parentNode = owned.get(spec.parentControl.toLowerCase());
+  const notes: string[] = [];
+
+  if (parentNode) {
+    // ── Shape 2: parent is extension-owned → bare AxFormControl, nested ──────
+    const dataGroup = firstChild(parentNode, 'DataGroup');
+    if (dataGroup) {
+      const dsNode = firstChild(parentNode, 'DataSource');
+      notes.push(dataGroupWarning(
+        spec,
+        textOf(xml, dataGroup),
+        dsNode ? textOf(xml, dsNode) : undefined,
+      ));
+    }
+
+    const controls = firstChild(parentNode, 'Controls');
+    if (!controls) {
+      return {
+        kind: 'refused',
+        message:
+          `Parent control "${spec.parentControl}" is defined by this extension but has no <Controls> ` +
+          `collection, and the position of a new one is property-order sensitive — writing it blind ` +
+          `risks a file the deserializer rejects.\n\n` +
+          `Add the first child in the form designer (it emits <Controls>), then re-run add-control for ` +
+          `any further children.`,
+      };
+    }
+
+    const block = nestedControlLines(spec);
+    const updated = insertIntoControls(xml, controls, block, spec.previousSibling, notes);
+    return finish(updated, spec, 'nested', notes);
+  }
+
+  // ── Shape 1: parent is a base-form control → envelope in the ROOT Controls ─
+  const rootControls = firstChild(root, 'Controls');
+  if (!rootControls) return { kind: 'unsupported' };
+
+  if (spec.previousSibling) {
+    notes.push(
+      `previousSibling "${spec.previousSibling}" was ignored: "${spec.parentControl}" is a base-form ` +
+      `control, so the new control is an <AxFormExtensionControl> whose siblings are other extension ` +
+      `entries, not form controls. Order within the extension's root <Controls> does not affect layout.`,
+    );
+  }
+
+  const block = envelopeControlLines(spec);
+  const updated = insertIntoControls(xml, rootControls, block, undefined, notes);
+  return finish(updated, spec, 'envelope', notes);
+}
+
+/**
+ * Post-write invariant check. The fallback path used to report ✅ off a raw
+ * string splice with nothing verifying the result, and the compiler will not
+ * catch the mistake for us — a misplaced control is silently discarded at 0
+ * errors (see findFormExtensionPlacementProblems). So this is the only gate
+ * there is, and it has to check POSITION, not just presence.
+ *
+ * Presence alone is not enough: the malformed shape this module exists to
+ * prevent keeps the control's <Name> perfectly readable — it is the enclosing
+ * collection that is wrong. An earlier draft of this function asked only
+ * "is the control findable?" and would have waved the bad output straight
+ * through.
+ */
+function finish(
+  updated: string,
+  spec: FormExtensionControlSpec,
+  representation: 'envelope' | 'nested',
+  notes: string[],
+): InsertFormExtensionControlResult {
+  const reparsed = parseNodes(updated);
+  if (!reparsed || reparsed.name !== 'AxFormExtension') {
+    return {
+      kind: 'refused',
+      message:
+        `Internal check failed: inserting "${spec.controlName}" produced XML that no longer parses as ` +
+        `an AxFormExtension. The file was left unchanged. Please report this with the extension XML.`,
+    };
+  }
+  if (!collectExtensionControls(updated, reparsed).has(spec.controlName.toLowerCase())) {
+    return {
+      kind: 'refused',
+      message:
+        `Internal check failed: "${spec.controlName}" is not readable as a control after insertion. ` +
+        `The file was left unchanged. Please report this with the extension XML.`,
+    };
+  }
+  const misplaced = findFormExtensionPlacementProblems(updated);
+  if (misplaced.length > 0) {
+    return {
+      kind: 'refused',
+      message:
+        `Internal check failed — the write was ABANDONED and the file left unchanged.\n\n` +
+        buildFormExtensionPlacementError(spec.controlName, misplaced) +
+        `\n\nThis is a bug in the writer, not in your call. Please report it with the extension XML.`,
+    };
+  }
+  return { kind: 'inserted', xml: updated, representation, notes };
+}
+
+/**
+ * Advisory, deliberately NOT a refusal.
+ *
+ * The base-form guard elsewhere refuses, and is right to: a base-form
+ * <DataGroup> container has its members generated by the compiler, so an
+ * explicit control for one of them collides ("The duplicate name … was
+ * detected"). That reasoning does not carry over here. A group created by a form
+ * EXTENSION renders exactly its explicit <Controls> list and nothing ever tops
+ * it up (measured 2026-08-12: a field-group member with no explicit control does
+ * not appear on the running form). So on an extension-owned parent the explicit
+ * control is not a duplicate — it is the only thing that puts the field on the
+ * form, and refusing would send the caller to the Visual Studio designer for the
+ * one job this tool exists to do without it.
+ *
+ * What remains true is that the control has to AGREE with the field group, or
+ * the build warns ("different fields from the field group … use restore on the
+ * form control") and the next designer Refresh rewrites the collection from the
+ * field group. That is worth saying every time and not worth blocking on —
+ * whether the written control agrees cannot be answered without reading the
+ * table's field group, which this pure function has no access to.
+ */
+function dataGroupWarning(
+  spec: FormExtensionControlSpec,
+  dataGroup: string,
+  dataSource: string | undefined,
+): string {
+  const onTable = dataSource ? ` on \`${dataSource}\`` : '';
+  const field = spec.dataField ?? spec.controlName;
+  const generated = `${dataGroup}_${field}`;
+  return (
+    `parent "${spec.parentControl}" renders field group **${dataGroup}**${onTable} via \`<DataGroup>\`, ` +
+    `so its children are expected to mirror that field group.\n` +
+    `  • If \`${field}\` IS a member of ${dataGroup}, name the control \`${generated}\` and type it from ` +
+    `the field — that is what the designer's Refresh generates, so the two agree and a later Refresh ` +
+    `has nothing to rewrite.\n` +
+    `  • If \`${field}\` is NOT a member, the build warns ("different fields from the field group … use ` +
+    `restore on the form control") and the next Refresh discards this control. Add the field to the ` +
+    `field group instead — d365fo_file(action="modify", objectType="table-extension", ` +
+    `operations=[{operation:"add-field-to-field-group", fieldGroupName:"${dataGroup}", ` +
+    `fieldName:"${field}", extendBaseFieldGroup:true}]).\n` +
+    `  • Note this parent belongs to the form EXTENSION, not the base form. Only a BASE-FORM ` +
+    `<DataGroup> group auto-generates its missing members, so adding the field to the field group ` +
+    `alone will NOT put it on the form here — an explicit control is required.`
+  );
+}
+
+/** The bare nested shape — no wrapper, no <Parent>; nesting encodes parentage. */
+function nestedControlLines(spec: FormExtensionControlSpec): string[] {
+  return [
+    `<AxFormControl xmlns="" i:type="${spec.iType}">`,
+    ...innerControlLines(spec).map(l => `\t${l}`),
+    `</AxFormControl>`,
+  ];
+}
+
+/** The envelope shape — wrapper <Name>, the control under <FormControl>, then <Parent>. */
+function envelopeControlLines(spec: FormExtensionControlSpec): string[] {
+  return [
+    `<AxFormExtensionControl xmlns="">`,
+    `\t<Name>${spec.wrapperName}</Name>`,
+    `\t<FormControl xmlns="" i:type="${spec.iType}">`,
+    ...innerControlLines(spec).map(l => `\t\t${l}`),
+    `\t</FormControl>`,
+    `\t<Parent>${spec.parentControl}</Parent>`,
+    `</AxFormExtensionControl>`,
+  ];
+}
+
+/**
+ * Control body, in the order the D365FO SDK serializes it:
+ * Name → Type → FormControlExtension(nil) → DataField → DataSource → Label → [Items].
+ */
+function innerControlLines(spec: FormExtensionControlSpec): string[] {
+  const lines = [
+    `<Name>${spec.controlName}</Name>`,
+    `<Type>${spec.typeValue}</Type>`,
+    `<FormControlExtension i:nil="true" />`,
+  ];
+  if (spec.dataField) lines.push(`<DataField>${spec.dataField}</DataField>`);
+  if (spec.dataSource) lines.push(`<DataSource>${spec.dataSource}</DataSource>`);
+  if (spec.label) lines.push(`<Label>${spec.label}</Label>`);
+  if (spec.typeValue === 'ComboBox') lines.push(`<Items />`);
+  return lines;
+}
+
+/**
+ * Splice `blockLines` into `controls`, at the end or directly after
+ * `previousSibling`. Indentation is derived from the collection's own line so
+ * the result matches whatever convention the file already uses.
+ */
+function insertIntoControls(
+  xml: string,
+  controls: XmlNode,
+  blockLines: string[],
+  previousSibling: string | undefined,
+  notes: string[],
+): string {
+  const closeIndent = lineIndentOf(xml, controls.start);
+  const childIndent = closeIndent + '\t';
+  const block = indentBlock(blockLines, childIndent);
+
+  // Empty collection: <Controls /> (attributes such as xmlns="" must survive).
+  if (controls.selfClosing) {
+    if (previousSibling) {
+      notes.push(
+        `previousSibling "${previousSibling}" was ignored: the parent's <Controls> collection is empty.`,
+      );
+    }
+    const openTag = xml.slice(controls.start, controls.openEnd).replace(/\s*\/>$/, '>');
+    return (
+      xml.slice(0, controls.start) +
+      openTag + '\n' + block + '\n' + closeIndent + `</${controls.name}>` +
+      xml.slice(controls.openEnd)
+    );
+  }
+
+  let at = controls.closeStart; // default: last position in the collection
+
+  if (previousSibling) {
+    const sibling = controls.children.find(c => {
+      const nameNode = firstChild(c, 'Name');
+      return nameNode && textOf(xml, nameNode).toLowerCase() === previousSibling.toLowerCase();
+    });
+    if (sibling) {
+      at = sibling.end;
+    } else {
+      notes.push(
+        `previousSibling "${previousSibling}" was not found among the parent's existing children — ` +
+        `the control was appended last instead.`,
+      );
+    }
+  }
+
+  if (at === controls.closeStart) {
+    let before = xml.slice(0, at).replace(/[ \t]*$/, '');
+    if (!before.endsWith('\n')) before += '\n';
+    return before + block + '\n' + closeIndent + xml.slice(at);
+  }
+  // After a sibling: the sibling's own line already ends where we splice.
+  return xml.slice(0, at) + '\n' + block + xml.slice(at);
+}

--- a/src/utils/formExtensionControlXml.ts
+++ b/src/utils/formExtensionControlXml.ts
@@ -143,6 +143,25 @@ const textOf = (xml: string, n: XmlNode): string =>
   n.selfClosing ? '' : xml.slice(n.openEnd, n.closeStart).trim();
 
 /**
+ * Element text as the caller spelled it, undoing the escaping the emitters apply
+ * (see escapeXmlText). Without this the round trip breaks: a name written as
+ * `A &amp; B` would never match the `A & B` the caller passes back, so the
+ * idempotency check would miss it and add the control a second time.
+ *
+ * `&amp;` last, mirroring the escape order.
+ */
+const decodeXmlText = (value: string): string =>
+  value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+
+/** Element text, decoded — the form to compare against caller input or display. */
+const textValueOf = (xml: string, n: XmlNode): string => decodeXmlText(textOf(xml, n));
+
+/**
  * The extension's own <Name> — the object the caller and the file are named
  * after, which is what an error banner has to identify. The control name is not
  * a substitute: in the report-a-bug path the reader needs to know WHICH FILE to
@@ -150,7 +169,7 @@ const textOf = (xml: string, n: XmlNode): string =>
  */
 const extensionNameOf = (xml: string, root: XmlNode): string => {
   const nameNode = firstChild(root, 'Name');
-  return (nameNode ? textOf(xml, nameNode) : '') || '(unnamed form extension)';
+  return (nameNode ? textValueOf(xml, nameNode) : '') || '(unnamed form extension)';
 };
 
 /**
@@ -187,7 +206,7 @@ function collectExtensionControls(
     if (n.name === 'FormControl' || n.name === 'AxFormControl') {
       const nameNode = firstChild(n, 'Name');
       if (nameNode) {
-        const name = textOf(xml, nameNode).toLowerCase();
+        const name = textValueOf(xml, nameNode).toLowerCase();
         const target = discardedRoots.some(d => isWithin(n, d)) ? discarded : live;
         if (name && !target.has(name)) target.set(name, n);
       }
@@ -295,7 +314,7 @@ function findPlacementIssues(xml: string, root: XmlNode): FormExtPlacementIssue[
       const nested = firstChild(n, 'Controls');
       if (nested && !nested.selfClosing) {
         const ownerName = firstChild(n, 'Name');
-        const owner = ownerName ? textOf(xml, ownerName) : '(unnamed)';
+        const owner = ownerName ? textValueOf(xml, ownerName) : '(unnamed)';
         for (const child of nested.children) {
           if (child.name !== 'AxFormControl') {
             issues.push({
@@ -469,8 +488,8 @@ export function insertFormExtensionControl(
       const dsNode = firstChild(parentNode, 'DataSource');
       notes.push(dataGroupWarning(
         spec,
-        textOf(xml, dataGroup),
-        dsNode ? textOf(xml, dsNode) : undefined,
+        textValueOf(xml, dataGroup),
+        dsNode ? textValueOf(xml, dsNode) : undefined,
       ));
     }
 
@@ -647,16 +666,38 @@ function finish(
   }
 
   if (introduced.length > 0) {
-    return {
-      kind: 'refused',
-      message:
-        `Internal check failed while adding "${spec.controlName}" — the write was ABANDONED and the ` +
-        `file left unchanged.\n\n` +
-        buildFormExtensionPlacementError(extensionNameOf(updated, reparsed), introduced) +
-        `\n\nThis is a bug in the writer, not in your call. Please report it with the extension XML.`,
-    };
+    return { kind: 'refused', message: buildAbandonedWriteMessage(updated, spec.controlName, introduced) };
   }
   return { kind: 'inserted', xml: updated, representation, notes };
+}
+
+/**
+ * The message for output this writer refuses to persist.
+ *
+ * It takes the DOCUMENT and derives the object name itself rather than accepting
+ * a pre-picked string, because picking it at the call site is what went wrong:
+ * the control name was passed into a parameter named `objectName`, so the banner
+ * read `form-extension "NewCtl"` and never named the file the very next sentence
+ * asks the reader to attach. Two names are in play and only one identifies the
+ * object; deriving it here leaves the call site nothing to get wrong.
+ *
+ * Exported for tests. Ordinary input cannot reach it — the writer's output is
+ * clean on all 1088 shipped extensions, and escaping closed the one route that
+ * made it reachable — so a caller-level test cannot cover it.
+ */
+export function buildAbandonedWriteMessage(
+  xml: string,
+  controlName: string,
+  introduced: FormExtPlacementProblem[],
+): string {
+  const root = parseNodes(xml);
+  const objectName = root ? extensionNameOf(xml, root) : '(unparseable form extension)';
+  return (
+    `Internal check failed while adding "${controlName}" — the write was ABANDONED and the ` +
+    `file left unchanged.\n\n` +
+    buildFormExtensionPlacementError(objectName, introduced) +
+    `\n\nThis is a bug in the writer, not in your call. Please report it with the extension XML.`
+  );
 }
 
 /**
@@ -734,10 +775,29 @@ function dataGroupWarning(
   );
 }
 
+/**
+ * Escape a value on its way into element text.
+ *
+ * Every value below is interpolated into markup, and none of them were escaped:
+ * a label reading "Cost & freight" produced XML with a bare & in it, which is
+ * not well-formed and which the D365FO deserializer rejects. Object names cannot
+ * carry markup, so the exposure was narrow, but "the input cannot be hostile" is
+ * not a property this module can check — and the post-write guard catching the
+ * damage afterwards is a worse answer than not causing it.
+ *
+ * `&` first: escaping it after the others would double-escape their output.
+ */
+const escapeXmlText = (value: string): string =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/** As above, plus the quote that would otherwise close the attribute early. */
+const escapeXmlAttr = (value: string): string =>
+  escapeXmlText(value).replace(/"/g, '&quot;');
+
 /** The bare nested shape — no wrapper, no <Parent>; nesting encodes parentage. */
 function nestedControlLines(spec: FormExtensionControlSpec): string[] {
   return [
-    `<AxFormControl xmlns="" i:type="${spec.iType}">`,
+    `<AxFormControl xmlns="" i:type="${escapeXmlAttr(spec.iType)}">`,
     ...innerControlLines(spec).map(l => `\t${l}`),
     `</AxFormControl>`,
   ];
@@ -755,16 +815,17 @@ function envelopeControlLines(
 ): string[] {
   const lines = [
     `<AxFormExtensionControl xmlns="">`,
-    `\t<Name>${spec.wrapperName}</Name>`,
-    `\t<FormControl xmlns="" i:type="${spec.iType}">`,
+    `\t<Name>${escapeXmlText(spec.wrapperName)}</Name>`,
+    `\t<FormControl xmlns="" i:type="${escapeXmlAttr(spec.iType)}">`,
     ...innerControlLines(spec).map(l => `\t\t${l}`),
     `\t</FormControl>`,
-    `\t<Parent>${spec.parentControl}</Parent>`,
+    `\t<Parent>${escapeXmlText(spec.parentControl)}</Parent>`,
   ];
   if (position.kind === 'placed') {
+    // positionType is one of two literals this module chose, never caller text.
     lines.push(`\t<PositionType>${position.positionType}</PositionType>`);
     if (position.previousSibling) {
-      lines.push(`\t<PreviousSibling>${position.previousSibling}</PreviousSibling>`);
+      lines.push(`\t<PreviousSibling>${escapeXmlText(position.previousSibling)}</PreviousSibling>`);
     }
   }
   lines.push(`</AxFormExtensionControl>`);
@@ -777,13 +838,13 @@ function envelopeControlLines(
  */
 function innerControlLines(spec: FormExtensionControlSpec): string[] {
   const lines = [
-    `<Name>${spec.controlName}</Name>`,
-    `<Type>${spec.typeValue}</Type>`,
+    `<Name>${escapeXmlText(spec.controlName)}</Name>`,
+    `<Type>${escapeXmlText(spec.typeValue)}</Type>`,
     `<FormControlExtension i:nil="true" />`,
   ];
-  if (spec.dataField) lines.push(`<DataField>${spec.dataField}</DataField>`);
-  if (spec.dataSource) lines.push(`<DataSource>${spec.dataSource}</DataSource>`);
-  if (spec.label) lines.push(`<Label>${spec.label}</Label>`);
+  if (spec.dataField) lines.push(`<DataField>${escapeXmlText(spec.dataField)}</DataField>`);
+  if (spec.dataSource) lines.push(`<DataSource>${escapeXmlText(spec.dataSource)}</DataSource>`);
+  if (spec.label) lines.push(`<Label>${escapeXmlText(spec.label)}</Label>`);
   if (spec.typeValue === 'ComboBox') lines.push(`<Items />`);
   return lines;
 }
@@ -824,7 +885,7 @@ function insertIntoControls(
   if (previousSibling) {
     const sibling = controls.children.find(c => {
       const nameNode = firstChild(c, 'Name');
-      return nameNode && textOf(xml, nameNode).toLowerCase() === previousSibling.toLowerCase();
+      return nameNode && textValueOf(xml, nameNode).toLowerCase() === previousSibling.toLowerCase();
     });
     if (sibling) {
       at = sibling.end;

--- a/src/utils/formExtensionControlXml.ts
+++ b/src/utils/formExtensionControlXml.ts
@@ -143,6 +143,17 @@ const textOf = (xml: string, n: XmlNode): string =>
   n.selfClosing ? '' : xml.slice(n.openEnd, n.closeStart).trim();
 
 /**
+ * The extension's own <Name> — the object the caller and the file are named
+ * after, which is what an error banner has to identify. The control name is not
+ * a substitute: in the report-a-bug path the reader needs to know WHICH FILE to
+ * attach, and every extension has controls.
+ */
+const extensionNameOf = (xml: string, root: XmlNode): string => {
+  const nameNode = firstChild(root, 'Name');
+  return (nameNode ? textOf(xml, nameNode) : '') || '(unnamed form extension)';
+};
+
+/**
  * Every control the EXTENSION itself defines, keyed by lowercased name and
  * split by whether the deserializer will actually read it.
  *
@@ -639,8 +650,9 @@ function finish(
     return {
       kind: 'refused',
       message:
-        `Internal check failed — the write was ABANDONED and the file left unchanged.\n\n` +
-        buildFormExtensionPlacementError(spec.controlName, introduced) +
+        `Internal check failed while adding "${spec.controlName}" — the write was ABANDONED and the ` +
+        `file left unchanged.\n\n` +
+        buildFormExtensionPlacementError(extensionNameOf(updated, reparsed), introduced) +
         `\n\nThis is a bug in the writer, not in your call. Please report it with the extension XML.`,
     };
   }

--- a/src/utils/formExtensionControlXml.ts
+++ b/src/utils/formExtensionControlXml.ts
@@ -143,27 +143,48 @@ const textOf = (xml: string, n: XmlNode): string =>
   n.selfClosing ? '' : xml.slice(n.openEnd, n.closeStart).trim();
 
 /**
- * Every control the EXTENSION itself defines, keyed by lowercased name.
+ * Every control the EXTENSION itself defines, keyed by lowercased name and
+ * split by whether the deserializer will actually read it.
  *
  * Only <FormControl> (inside an envelope) and <AxFormControl> (nested) are
  * controls. <AxFormExtensionControl>'s own <Name> is the auto-generated wrapper
  * id, NOT a control name, so reading names off the wrapper would make
  * `parentControl: "FormExtensionControlfse38xiwz"` resolve to something real.
+ *
+ * The split matters because a control inside a misplaced element is discarded
+ * whole (see findFormExtensionPlacementProblems) — it is in the file and it is
+ * not on the form. Treating it as present made the two things a caller does
+ * with a damaged file both wrong: re-adding the control reported "already
+ * present, skipped", and naming it as a parent nested the new control inside
+ * the dead subtree, so that one was discarded too.
  */
-function collectExtensionControls(xml: string, root: XmlNode): Map<string, XmlNode> {
-  const byName = new Map<string, XmlNode>();
+interface ExtensionControls {
+  /** Controls the deserializer reads. */
+  live: Map<string, XmlNode>;
+  /** Controls present in the file but inside a discarded subtree. */
+  discarded: Map<string, XmlNode>;
+}
+
+function collectExtensionControls(
+  xml: string,
+  root: XmlNode,
+  discardedRoots: XmlNode[] = [],
+): ExtensionControls {
+  const live = new Map<string, XmlNode>();
+  const discarded = new Map<string, XmlNode>();
   const visit = (n: XmlNode): void => {
     if (n.name === 'FormControl' || n.name === 'AxFormControl') {
       const nameNode = firstChild(n, 'Name');
       if (nameNode) {
-        const name = textOf(xml, nameNode);
-        if (name && !byName.has(name.toLowerCase())) byName.set(name.toLowerCase(), n);
+        const name = textOf(xml, nameNode).toLowerCase();
+        const target = discardedRoots.some(d => isWithin(n, d)) ? discarded : live;
+        if (name && !target.has(name)) target.set(name, n);
       }
     }
     for (const c of n.children) visit(c);
   };
   visit(root);
-  return byName;
+  return { live, discarded };
 }
 
 /** Leading whitespace of the line `offset` sits on, for matching the file's indentation. */
@@ -212,8 +233,24 @@ export interface FormExtPlacementProblem {
 export function findFormExtensionPlacementProblems(xml: string): FormExtPlacementProblem[] {
   const root = parseNodes(xml);
   if (!root || root.name !== 'AxFormExtension') return [];
+  return findPlacementIssues(xml, root).map(i => i.problem);
+}
 
-  const problems: FormExtPlacementProblem[] = [];
+/**
+ * A misplaced element paired with its node.
+ *
+ * The node is what makes the difference between "this file has a problem" and
+ * "THIS control is the problem": everything inside a misplaced element is
+ * discarded along with it, so the writer has to be able to ask whether a
+ * particular control it just resolved happens to live in the dead subtree.
+ */
+interface FormExtPlacementIssue {
+  node: XmlNode;
+  problem: FormExtPlacementProblem;
+}
+
+function findPlacementIssues(xml: string, root: XmlNode): FormExtPlacementIssue[] {
+  const issues: FormExtPlacementIssue[] = [];
   const lineAt = (offset: number): number => {
     let line = 1;
     for (let i = 0; i < offset && i < xml.length; i++) if (xml[i] === '\n') line++;
@@ -225,7 +262,9 @@ export function findFormExtensionPlacementProblems(xml: string): FormExtPlacemen
   if (rootControls && !rootControls.selfClosing) {
     for (const child of rootControls.children) {
       if (child.name !== 'AxFormExtensionControl') {
-        problems.push({
+        issues.push({
+          node: child,
+          problem: {
           element: child.name,
           line: lineAt(child.start),
           detail:
@@ -233,6 +272,7 @@ export function findFormExtensionPlacementProblems(xml: string): FormExtPlacemen
             `<AxFormExtensionControl> envelopes. A control attached to a base-form parent needs the ` +
             `envelope (wrapper <Name>, <FormControl i:type="…">, <Parent>); a control nested under a ` +
             `container this extension defines belongs in THAT container's <Controls> instead.`,
+          },
         });
       }
     }
@@ -247,7 +287,9 @@ export function findFormExtensionPlacementProblems(xml: string): FormExtPlacemen
         const owner = ownerName ? textOf(xml, ownerName) : '(unnamed)';
         for (const child of nested.children) {
           if (child.name !== 'AxFormControl') {
-            problems.push({
+            issues.push({
+              node: child,
+              problem: {
               element: child.name,
               line: lineAt(child.start),
               detail:
@@ -255,6 +297,7 @@ export function findFormExtensionPlacementProblems(xml: string): FormExtPlacemen
                 `<AxFormControl>. The D365FO deserializer DISCARDS it — the build reports no error and ` +
                 `the control simply never appears on the form. Nesting already encodes parentage, so a ` +
                 `child control here is a bare <AxFormControl i:type="…"> with no wrapper and no <Parent>.`,
+              },
             });
           }
         }
@@ -264,8 +307,27 @@ export function findFormExtensionPlacementProblems(xml: string): FormExtPlacemen
   };
   visit(root);
 
-  return problems;
+  return issues;
 }
+
+/**
+ * Stable identity for a placement problem, deliberately excluding the line
+ * number: inserting a control shifts every line below it, so line-bearing keys
+ * would make untouched pre-existing problems look brand new. Element + detail
+ * still distinguishes the cases that matter, and equal keys are compared by
+ * COUNT, so a genuinely new duplicate of an existing problem is still caught.
+ */
+const problemKey = (p: FormExtPlacementProblem): string => `${p.element} ${p.detail}`;
+
+const tallyProblems = (problems: FormExtPlacementProblem[]): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const p of problems) counts.set(problemKey(p), (counts.get(problemKey(p)) ?? 0) + 1);
+  return counts;
+};
+
+/** True when `n` is the misplaced node itself or lives inside its discarded subtree. */
+const isWithin = (n: XmlNode, container: XmlNode): boolean =>
+  n.start >= container.start && n.end <= container.end;
 
 /** Render placement problems as a blocking, self-explaining error. */
 export function buildFormExtensionPlacementError(
@@ -301,8 +363,17 @@ export interface FormExtensionControlSpec {
    * wrapper.
    */
   wrapperName: string;
-  /** Insert directly after this existing sibling instead of at the end (nested shape only). */
+  /**
+   * Name of the existing sibling to place the control after.
+   *
+   * Nested shape: the control is spliced directly after that sibling in the
+   * parent's <Controls>. Envelope shape: position among the BASE FORM's children
+   * is not expressible by splice order, so it is written as
+   * <PositionType>AfterItem</PositionType><PreviousSibling>…</PreviousSibling>.
+   */
   previousSibling?: string;
+  /** "AfterItem" (needs previousSibling), "Begin", or "End" (default). Envelope shape only. */
+  positionType?: string;
 }
 
 export type InsertFormExtensionControlResult =
@@ -328,15 +399,57 @@ export function insertFormExtensionControl(
   // objectType can never splice control XML into an unrelated metadata file.
   if (!root || root.name !== 'AxFormExtension') return { kind: 'unsupported' };
 
-  const owned = collectExtensionControls(xml, root);
+  // Problems the file arrived with. The post-write check compares against these
+  // rather than against zero: a file damaged by an earlier writer must still
+  // accept a correct write, or the release that fixes the bug is also the
+  // release that locks every already-damaged file out of the repair.
+  const preExisting = findPlacementIssues(xml, root);
+  const baseline = tallyProblems(preExisting.map(i => i.problem));
+  const discardedRoots = preExisting.map(i => i.node);
+
+  const owned = collectExtensionControls(xml, root, discardedRoots);
+  const notes: string[] = [];
+
+  if (preExisting.length > 0) {
+    notes.push(
+      `this file already contained ${preExisting.length} misplaced control ` +
+      `element(s) (line(s) ${preExisting.map(i => i.problem.line).join(', ')}), which the D365FO ` +
+      `deserializer discards. They were left exactly as they are — this write neither caused nor ` +
+      `fixed them. Delete them once the replacement control is confirmed on the form.`,
+    );
+  }
 
   // Idempotency, by resolved control name rather than a bare `<Name>X</Name>`
   // substring search — the latter also matches data sources, fields and the
   // extension's own <Name>, turning a real add into a silent no-op "success".
-  if (owned.has(spec.controlName.toLowerCase())) return { kind: 'exists' };
+  // Only a LIVE control counts: a discarded one is not on the form, and the
+  // caller re-running the identical add is precisely how it gets repaired.
+  if (owned.live.has(spec.controlName.toLowerCase())) return { kind: 'exists' };
 
-  const parentNode = owned.get(spec.parentControl.toLowerCase());
-  const notes: string[] = [];
+  const discardedTwin = owned.discarded.get(spec.controlName.toLowerCase());
+  if (discardedTwin) {
+    notes.push(
+      `a control named "${spec.controlName}" already exists in this file but sits in a collection the ` +
+      `deserializer discards, so it never reached the form. A correctly-placed one was written; the ` +
+      `dead copy is still there and should be deleted.`,
+    );
+  }
+
+  const parentNode = owned.live.get(spec.parentControl.toLowerCase());
+
+  // A parent that is itself discarded cannot host anything: nesting into it
+  // buys a second discarded control and another silent ✅.
+  if (!parentNode && owned.discarded.has(spec.parentControl.toLowerCase())) {
+    return {
+      kind: 'refused',
+      message:
+        `Parent control "${spec.parentControl}" exists in this extension but sits inside a misplaced ` +
+        `element that the D365FO deserializer discards, so it is not on the form and cannot hold a ` +
+        `child — anything nested under it would be discarded with it.\n\n` +
+        `Fix the misplaced element first (see the placement problems reported for this file), then ` +
+        `re-run add-control.`,
+    };
+  }
 
   if (parentNode) {
     // ── Shape 2: parent is extension-owned → bare AxFormControl, nested ──────
@@ -350,39 +463,123 @@ export function insertFormExtensionControl(
       ));
     }
 
+    const block = nestedControlLines(spec);
     const controls = firstChild(parentNode, 'Controls');
+
+    // No <Controls> yet — the parent is childless. This is the normal state of a
+    // group this very tool just created (innerControlLines emits Name, Type and
+    // FormControlExtension, never Controls), so refusing here broke the tool's
+    // own create-group-then-fill-it workflow and sent the caller to Visual Studio
+    // for the one job add-control exists to do.
     if (!controls) {
-      return {
-        kind: 'refused',
-        message:
-          `Parent control "${spec.parentControl}" is defined by this extension but has no <Controls> ` +
-          `collection, and the position of a new one is property-order sensitive — writing it blind ` +
-          `risks a file the deserializer rejects.\n\n` +
-          `Add the first child in the form designer (it emits <Controls>), then re-run add-control for ` +
-          `any further children.`,
-      };
+      const created = createControlsCollection(xml, parentNode, block);
+      if (!created) {
+        return {
+          kind: 'refused',
+          message:
+            `Parent control "${spec.parentControl}" is defined by this extension, has no <Controls> ` +
+            `collection, and carries no <FormControlExtension> element to position one after — the ` +
+            `serializer's property order cannot be reproduced from this file, and guessing risks XML ` +
+            `the deserializer rejects.\n\n` +
+            `Add the first child in the form designer (it emits <Controls>), then re-run add-control ` +
+            `for any further children.`,
+        };
+      }
+      if (spec.previousSibling) {
+        notes.push(
+          `previousSibling "${spec.previousSibling}" was ignored: "${spec.parentControl}" had no ` +
+          `children yet, so the new control is the first one.`,
+        );
+      }
+      return finish(created, spec, 'nested', notes, baseline);
     }
 
-    const block = nestedControlLines(spec);
     const updated = insertIntoControls(xml, controls, block, spec.previousSibling, notes);
-    return finish(updated, spec, 'nested', notes);
+    return finish(updated, spec, 'nested', notes, baseline);
   }
 
   // ── Shape 1: parent is a base-form control → envelope in the ROOT Controls ─
   const rootControls = firstChild(root, 'Controls');
   if (!rootControls) return { kind: 'unsupported' };
 
-  if (spec.previousSibling) {
-    notes.push(
-      `previousSibling "${spec.previousSibling}" was ignored: "${spec.parentControl}" is a base-form ` +
-      `control, so the new control is an <AxFormExtensionControl> whose siblings are other extension ` +
-      `entries, not form controls. Order within the extension's root <Controls> does not affect layout.`,
-    );
+  // Position among the BASE FORM's children is carried by the envelope itself,
+  // via <PositionType>/<PreviousSibling> next to <Parent> — not by where the
+  // envelope sits in the extension's root <Controls>. Order in that collection
+  // really is irrelevant to layout; the earlier note was right about that and
+  // wrong to conclude the request could not be honoured.
+  const position = resolvePosition(spec);
+  if (position.kind === 'invalid') return { kind: 'refused', message: position.message };
+  if (position.note) notes.push(position.note);
+
+  const block = envelopeControlLines(spec, position);
+  const updated = insertIntoControls(xml, rootControls, block, undefined, notes);
+  return finish(updated, spec, 'envelope', notes, baseline);
+}
+
+/**
+ * Where the control sits among its parent's existing children, as the two
+ * elements the envelope carries for it.
+ *
+ * Only `AfterItem` and `Begin` appear in shipped metadata (765 and 182
+ * occurrences across the 1088 AxFormExtension files in PackagesLocalDirectory;
+ * no other value occurs), so those are the two that get written. `End` is
+ * spelled by omitting both elements — 1594 shipped envelopes carry no
+ * <PositionType> at all — and anything else is refused rather than guessed at,
+ * because an unknown enum value is exactly the kind of thing that deserializes
+ * to a discarded node under a silent build.
+ */
+type ResolvedPosition =
+  | { kind: 'none'; note?: string }
+  | { kind: 'placed'; positionType: 'AfterItem' | 'Begin'; previousSibling?: string; note?: string }
+  | { kind: 'invalid'; message: string };
+
+function resolvePosition(spec: FormExtensionControlSpec): ResolvedPosition {
+  const requested = spec.positionType?.trim();
+  const sibling = spec.previousSibling?.trim() || undefined;
+
+  if (!requested) {
+    // previousSibling alone means "after this one" — the only reading that has one.
+    return sibling
+      ? { kind: 'placed', positionType: 'AfterItem', previousSibling: sibling }
+      : { kind: 'none' };
   }
 
-  const block = envelopeControlLines(spec);
-  const updated = insertIntoControls(xml, rootControls, block, undefined, notes);
-  return finish(updated, spec, 'envelope', notes);
+  const normalized = requested.toLowerCase();
+  if (normalized === 'afteritem') {
+    if (!sibling) {
+      return {
+        kind: 'invalid',
+        message:
+          `positionType="AfterItem" needs previousSibling — the name of the existing control in ` +
+          `"${spec.parentControl}" to place this one after. Pass previousSibling, or use ` +
+          `positionType="Begin" for first / "End" (the default) for last.`,
+      };
+    }
+    return { kind: 'placed', positionType: 'AfterItem', previousSibling: sibling };
+  }
+  if (normalized === 'begin') {
+    return {
+      kind: 'placed',
+      positionType: 'Begin',
+      note: sibling
+        ? `previousSibling "${sibling}" was ignored: positionType="Begin" places the control first.`
+        : undefined,
+    };
+  }
+  if (normalized === 'end') {
+    return {
+      kind: 'none',
+      note: sibling
+        ? `previousSibling "${sibling}" was ignored: positionType="End" places the control last.`
+        : undefined,
+    };
+  }
+  return {
+    kind: 'invalid',
+    message:
+      `positionType="${requested}" is not a value D365FO form-extension metadata uses. Supported: ` +
+      `"AfterItem" (with previousSibling), "Begin", "End" (default).`,
+  };
 }
 
 /**
@@ -403,6 +600,7 @@ function finish(
   spec: FormExtensionControlSpec,
   representation: 'envelope' | 'nested',
   notes: string[],
+  baseline: Map<string, number>,
 ): InsertFormExtensionControlResult {
   const reparsed = parseNodes(updated);
   if (!reparsed || reparsed.name !== 'AxFormExtension') {
@@ -413,25 +611,68 @@ function finish(
         `an AxFormExtension. The file was left unchanged. Please report this with the extension XML.`,
     };
   }
-  if (!collectExtensionControls(updated, reparsed).has(spec.controlName.toLowerCase())) {
+  const issues = findPlacementIssues(updated, reparsed);
+  const after = collectExtensionControls(updated, reparsed, issues.map(i => i.node));
+  if (!after.live.has(spec.controlName.toLowerCase())) {
     return {
       kind: 'refused',
       message:
-        `Internal check failed: "${spec.controlName}" is not readable as a control after insertion. ` +
-        `The file was left unchanged. Please report this with the extension XML.`,
+        `Internal check failed: "${spec.controlName}" is not readable as a live control after ` +
+        `insertion. The file was left unchanged. Please report this with the extension XML.`,
     };
   }
-  const misplaced = findFormExtensionPlacementProblems(updated);
-  if (misplaced.length > 0) {
+
+  // Only problems this write INTRODUCED are the writer's fault. Comparing
+  // against the file's own baseline by count (never by line, which insertion
+  // shifts) keeps a pre-existing misplacement from vetoing a correct write,
+  // while still catching a new duplicate of a problem that already existed.
+  const introduced: FormExtPlacementProblem[] = [];
+  const remaining = new Map(baseline);
+  for (const { problem } of issues) {
+    const key = problemKey(problem);
+    const left = remaining.get(key) ?? 0;
+    if (left > 0) remaining.set(key, left - 1);
+    else introduced.push(problem);
+  }
+
+  if (introduced.length > 0) {
     return {
       kind: 'refused',
       message:
         `Internal check failed — the write was ABANDONED and the file left unchanged.\n\n` +
-        buildFormExtensionPlacementError(spec.controlName, misplaced) +
+        buildFormExtensionPlacementError(spec.controlName, introduced) +
         `\n\nThis is a bug in the writer, not in your call. Please report it with the extension XML.`,
     };
   }
   return { kind: 'inserted', xml: updated, representation, notes };
+}
+
+/**
+ * Give a childless parent a <Controls> collection holding `blockLines`.
+ *
+ * Position is not a guess: across the 1088 shipped AxFormExtension files an
+ * opening <Controls> is preceded by <FormControlExtension> 2176 times and by
+ * <ControlModifications> 996 times (the extension's own root collection) — and
+ * by nothing else, ever. So inside a control, <Controls> goes immediately after
+ * <FormControlExtension>, ahead of every other derived property regardless of
+ * alphabetical order (shipped groups read Controls, ArrangeMethod, FrameType…).
+ * Without that anchor element there is no evidence to place it from, and the
+ * caller is told so rather than handed a plausible guess.
+ */
+function createControlsCollection(
+  xml: string,
+  parentNode: XmlNode,
+  blockLines: string[],
+): string | null {
+  const anchor = firstChild(parentNode, 'FormControlExtension');
+  if (!anchor) return null;
+
+  const controlsIndent = lineIndentOf(xml, anchor.start);
+  const block = indentBlock(blockLines, controlsIndent + '\t');
+  const collection =
+    '\n' + controlsIndent + '<Controls>\n' + block + '\n' + controlsIndent + '</Controls>';
+
+  return xml.slice(0, anchor.end) + collection + xml.slice(anchor.end);
 }
 
 /**
@@ -471,12 +712,13 @@ function dataGroupWarning(
     `has nothing to rewrite.\n` +
     `  • If \`${field}\` is NOT a member, the build warns ("different fields from the field group … use ` +
     `restore on the form control") and the next Refresh discards this control. Add the field to the ` +
-    `field group instead — d365fo_file(action="modify", objectType="table-extension", ` +
+    `field group AS WELL — d365fo_file(action="modify", objectType="table-extension", ` +
     `operations=[{operation:"add-field-to-field-group", fieldGroupName:"${dataGroup}", ` +
-    `fieldName:"${field}", extendBaseFieldGroup:true}]).\n` +
-    `  • Note this parent belongs to the form EXTENSION, not the base form. Only a BASE-FORM ` +
-    `<DataGroup> group auto-generates its missing members, so adding the field to the field group ` +
-    `alone will NOT put it on the form here — an explicit control is required.`
+    `fieldName:"${field}", extendBaseFieldGroup:true}]) — and keep this control, named ` +
+    `\`${generated}\`, so the two agree.\n` +
+    `  • The field group alone is NOT enough here: this parent belongs to the form EXTENSION, and only ` +
+    `a BASE-FORM <DataGroup> group auto-generates its missing members. Both halves are required — the ` +
+    `field group entry so a Refresh keeps the control, and the explicit control so the field renders.`
   );
 }
 
@@ -489,17 +731,32 @@ function nestedControlLines(spec: FormExtensionControlSpec): string[] {
   ];
 }
 
-/** The envelope shape — wrapper <Name>, the control under <FormControl>, then <Parent>. */
-function envelopeControlLines(spec: FormExtensionControlSpec): string[] {
-  return [
+/**
+ * The envelope shape — wrapper <Name>, the control under <FormControl>, then
+ * <Parent>, then the optional position pair, in exactly the order shipped
+ * metadata uses (`Name, FormControl, Parent, PositionType, PreviousSibling` —
+ * 753 files, with the shorter prefixes accounting for the rest).
+ */
+function envelopeControlLines(
+  spec: FormExtensionControlSpec,
+  position: ResolvedPosition,
+): string[] {
+  const lines = [
     `<AxFormExtensionControl xmlns="">`,
     `\t<Name>${spec.wrapperName}</Name>`,
     `\t<FormControl xmlns="" i:type="${spec.iType}">`,
     ...innerControlLines(spec).map(l => `\t\t${l}`),
     `\t</FormControl>`,
     `\t<Parent>${spec.parentControl}</Parent>`,
-    `</AxFormExtensionControl>`,
   ];
+  if (position.kind === 'placed') {
+    lines.push(`\t<PositionType>${position.positionType}</PositionType>`);
+    if (position.previousSibling) {
+      lines.push(`\t<PreviousSibling>${position.previousSibling}</PreviousSibling>`);
+    }
+  }
+  lines.push(`</AxFormExtensionControl>`);
+  return lines;
 }
 
 /**

--- a/src/utils/formExtensionShapeValidator.ts
+++ b/src/utils/formExtensionShapeValidator.ts
@@ -22,6 +22,8 @@
  *   </AxFormExtensionControl>
  */
 
+import { findFormExtensionPlacementProblems } from './formExtensionControlXml.js';
+
 export interface FormExtShapeProblem {
   found: string;
   expected: string;
@@ -94,6 +96,21 @@ export function validateFormExtensionControlShape(xml: string): FormExtShapeProb
       detail:
         'The integer form control class is AxFormIntegerControl (with <Type>Integer</Type>). ' +
         'AxFormIntControl does not exist and fails deserialization.',
+    });
+  }
+
+  // Right element names, wrong collection. Every check above is a spelling check,
+  // and a control can be spelled perfectly and still sit somewhere the
+  // deserializer will not read it — most commonly an <AxFormExtensionControl>
+  // envelope dropped into a nested <Controls>. Unlike the problems above, that one
+  // does NOT fail deserialization loudly: the node is discarded, the build reports
+  // 0 errors, and the control is simply absent from the form. Nothing later in the
+  // pipeline will report it, so it has to be caught here.
+  for (const p of findFormExtensionPlacementProblems(xml)) {
+    problems.push({
+      found: `<${p.element}> at line ${p.line}`,
+      expected: 'the collection typed to hold it',
+      detail: p.detail,
     });
   }
 

--- a/tests/tools/addIndexSameSession.test.ts
+++ b/tests/tools/addIndexSameSession.test.ts
@@ -297,6 +297,24 @@ describe('add-index on a same-session table (bridge cannot resolve it)', () => {
     expect(xml).not.toContain('<AlternateKey>');
   });
 
+  // The direct-XML writer's refusals are deterministic and file-based: no bridge
+  // call was made. Rendering them through the shared bridge-error path named an
+  // API that never ran — the same "name a path that did not do the work" defect
+  // viaXmlFallback was introduced to fix on the SUCCESS branch — and pointed the
+  // reader at provider/metadata-root causes that cannot apply.
+  it('does not dress an XML-writer refusal up as a bridge failure', async () => {
+    mockBridgeAddIndex.mockResolvedValue(RESOLUTION_FAILURE);
+
+    const result = await modifyD365FileTool(addIndexReq({ indexFields: [] }), ctx);
+    const text = result.content[0].text as string;
+
+    expect(result.isError).toBeTruthy();
+    expect(text).toMatch(/has no fields/);
+    expect(text).not.toMatch(/Bridge operation/i);
+    // Nothing about the provider's model could change this answer.
+    expect(mockBridgeRefreshProvider).not.toHaveBeenCalled();
+  });
+
   it('does not run the fallback when the bridge itself succeeded', async () => {
     mockBridgeAddIndex.mockResolvedValue({
       success: true,

--- a/tests/tools/resolveControlTypeForField.test.ts
+++ b/tests/tools/resolveControlTypeForField.test.ts
@@ -125,6 +125,46 @@ describe('resolveControlTypeForField', () => {
     expect(resolveControlTypeForField('SomeDataSource', 'CtsoFin_QualityTier', db)).toBe('ComboBox');
   });
 
+  // A boolean flag is a CheckBox, not a two-item dropdown. Reported 2026-08-12:
+  // the auto-pick returned ComboBox for a NoYes-backed EDT while the VS designer
+  // emitted AxFormCheckBoxControl for the very same field, so a tool-added
+  // control silently disagreed with the one sitting next to it.
+  it('picks CheckBox for a NoYes-backed EDT', () => {
+    const db = fakeDb({
+      fields: { 'InventTestGroup.CtsoDisableProdQty': 'CtsoDisableProdQty' },
+      edts: { CtsoDisableProdQty: { extends: null, enum_type: 'NoYes', string_size: null } },
+    });
+    expect(resolveControlTypeForField('InventTestGroup', 'CtsoDisableProdQty', db)).toBe('CheckBox');
+  });
+
+  it('picks CheckBox when the field binds the NoYes enum directly', () => {
+    const db = fakeDb({
+      fields: { 'CustTable.Blocked': 'NoYes' },
+      enums: ['NoYes'],
+    });
+    expect(resolveControlTypeForField('CustTable', 'Blocked', db)).toBe('CheckBox');
+  });
+
+  it('follows an EDT chain down to NoYes', () => {
+    // A custom EDT extending the standard NoYesId is still a checkbox.
+    const db = fakeDb({
+      fields: { 'CustTable.CtsoFlag': 'CtsoFlag' },
+      edts: {
+        CtsoFlag: { extends: 'NoYesId', enum_type: null, string_size: null },
+        NoYesId: { extends: null, enum_type: 'NoYes', string_size: null },
+      },
+    });
+    expect(resolveControlTypeForField('CustTable', 'CtsoFlag', db)).toBe('CheckBox');
+  });
+
+  it('leaves a non-boolean enum as a ComboBox', () => {
+    const db = fakeDb({
+      fields: { 'SalesTable.Posted': 'CtsoPosted' },
+      edts: { CtsoPosted: { extends: null, enum_type: 'CtsoApprovalState', string_size: null } },
+    });
+    expect(resolveControlTypeForField('SalesTable', 'Posted', db)).toBe('ComboBox');
+  });
+
   it('returns undefined with no field, so the caller keeps its own default', () => {
     expect(resolveControlTypeForField('CustTable', undefined, fakeDb({}))).toBeUndefined();
   });

--- a/tests/utils/formExtensionControlXml.test.ts
+++ b/tests/utils/formExtensionControlXml.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Regression tests — control placement in an AxFormExtension.
+ *
+ * Field report (2026-08-12): `add-control` on a form extension emitted an
+ * <AxFormExtensionControl> envelope INTO the nested <Controls> of a group the
+ * extension itself defines, and reported ✅. Root cause was not a missing
+ * branch but a blind splice:
+ *
+ *     content.replace('</Controls>', `${envelope}\n\t</Controls>`)
+ *
+ * A string pattern replaces the FIRST occurrence, and the nested </Controls>
+ * closes before the root one — so `parentControl` never influenced the
+ * insertion point at all (it only supplied the <Parent> text). Every fixture at
+ * the time was flat, where first-</Controls> happens to be the right one; this
+ * file pins the nested case in both directions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  insertFormExtensionControl,
+  findFormExtensionPlacementProblems,
+  type FormExtensionControlSpec,
+} from '../../src/utils/formExtensionControlXml';
+import { validateFormExtensionControlShape } from '../../src/utils/formExtensionShapeValidator';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/** Flat extension: one control attached to a base-form parent. Matches the golden. */
+const FLAT_EXT = `<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>CustGroup.ConExtension</Name>
+\t<ControlModifications />
+\t<Controls>
+\t\t<AxFormExtensionControl xmlns="">
+\t\t\t<Name>FormExtensionControlfse38xiwz</Name>
+\t\t\t<FormControl xmlns="" i:type="AxFormCheckBoxControl">
+\t\t\t\t<Name>Grid_ConHasNotes</Name>
+\t\t\t\t<Type>CheckBox</Type>
+\t\t\t\t<FormControlExtension i:nil="true" />
+\t\t\t\t<DataField>ConHasNotes</DataField>
+\t\t\t\t<DataSource>CustGroup</DataSource>
+\t\t\t</FormControl>
+\t\t\t<Parent>Grid</Parent>
+\t\t</AxFormExtensionControl>
+\t</Controls>
+\t<DataSourceModifications />
+\t<DataSources />
+</AxFormExtension>`;
+
+/**
+ * The reported shape: the extension defines its OWN group container, so the file
+ * has a nested <Controls> that closes before the root one.
+ * `dataGroup` toggles the <DataGroup> binding described in the report's §6b.
+ */
+const nestedExt = (opts: { dataGroup?: boolean } = {}) => `<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>InventTestGroup.ConExtension</Name>
+\t<ControlModifications />
+\t<Controls>
+\t\t<AxFormExtensionControl xmlns="">
+\t\t\t<Name>FormExtensionControlabc123xyz</Name>
+\t\t\t<FormControl xmlns="" i:type="AxFormGroupControl">
+\t\t\t\t<Name>ConQualityOrders</Name>
+\t\t\t\t<Type>Group</Type>
+\t\t\t\t<FormControlExtension i:nil="true" />
+\t\t\t\t<Controls>
+\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormCheckBoxControl">
+\t\t\t\t\t\t<Name>ConQualityOrders_ConDisableInventoryBlocking</Name>
+\t\t\t\t\t\t<Type>CheckBox</Type>
+\t\t\t\t\t\t<FormControlExtension i:nil="true" />
+\t\t\t\t\t\t<DataField>ConDisableInventoryBlocking</DataField>
+\t\t\t\t\t\t<DataSource>InventTestGroup</DataSource>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t</Controls>
+${opts.dataGroup ? '\t\t\t\t<DataGroup>ConQualityOrders</DataGroup>\n' : ''}\t\t\t\t<DataSource>InventTestGroup</DataSource>
+\t\t\t</FormControl>
+\t\t\t<Parent>TabHeaderGeneral</Parent>
+\t\t</AxFormExtensionControl>
+\t</Controls>
+\t<DataSourceModifications />
+\t<DataSources />
+</AxFormExtension>`;
+
+const spec = (over: Partial<FormExtensionControlSpec> = {}): FormExtensionControlSpec => ({
+  controlName: 'ConQualityOrders_ConDisableProdQty',
+  parentControl: 'ConQualityOrders',
+  iType: 'AxFormCheckBoxControl',
+  typeValue: 'CheckBox',
+  dataSource: 'InventTestGroup',
+  dataField: 'ConDisableProdQty',
+  wrapperName: 'FormExtensionControlnew000001',
+  ...over,
+});
+
+const count = (s: string, needle: string) => s.split(needle).length - 1;
+
+/** Text between the extension-owned group's nested <Controls> … </Controls>. */
+function nestedControlsBody(xml: string): string {
+  const open = xml.indexOf('<Controls>', xml.indexOf('<Name>ConQualityOrders</Name>'));
+  const close = xml.indexOf('</Controls>', open);
+  expect(open).toBeGreaterThan(-1);
+  expect(close).toBeGreaterThan(-1);
+  return xml.slice(open, close);
+}
+
+const inserted = (r: ReturnType<typeof insertFormExtensionControl>) => {
+  expect(r.kind).toBe('inserted');
+  return r as Extract<typeof r, { kind: 'inserted' }>;
+};
+
+// ─── The primary defect ──────────────────────────────────────────────────────
+
+describe('parent defined by the extension itself → bare nested AxFormControl', () => {
+  it('writes the control into the parent group, not the root collection', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec()));
+
+    expect(r.representation).toBe('nested');
+    expect(nestedControlsBody(r.xml)).toContain('<Name>ConQualityOrders_ConDisableProdQty</Name>');
+  });
+
+  it('emits NO envelope and NO <Parent> for the new control', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec()));
+
+    // Exactly the one envelope and the one <Parent> the fixture started with.
+    expect(count(r.xml, '<AxFormExtensionControl')).toBe(count(nestedExt(), '<AxFormExtensionControl'));
+    expect(count(r.xml, '<Parent>')).toBe(1);
+    expect(r.xml).toContain('<Parent>TabHeaderGeneral</Parent>');
+    expect(r.xml).not.toContain('<Parent>ConQualityOrders</Parent>');
+  });
+
+  it('never puts an AxFormExtensionControl inside the nested collection (the reported bug)', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec()));
+
+    expect(nestedControlsBody(r.xml)).not.toContain('AxFormExtensionControl');
+  });
+
+  it('leaves the group\'s trailing properties in place after </Controls>', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec()));
+
+    // The bad output stranded these behind a collection closed at the wrong depth.
+    expect(r.xml).toMatch(/<\/Controls>\s*\n\s*<DataSource>InventTestGroup<\/DataSource>/);
+  });
+
+  it('appends after the existing sibling, preserving field order', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec()));
+    const body = nestedControlsBody(r.xml);
+
+    expect(body.indexOf('ConDisableInventoryBlocking'))
+      .toBeLessThan(body.indexOf('ConQualityOrders_ConDisableProdQty'));
+  });
+
+  it('matches the designer shape byte-for-byte in the control body', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec()));
+
+    expect(r.xml).toContain(
+      '\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormCheckBoxControl">\n' +
+      '\t\t\t\t\t\t<Name>ConQualityOrders_ConDisableProdQty</Name>\n' +
+      '\t\t\t\t\t\t<Type>CheckBox</Type>\n' +
+      '\t\t\t\t\t\t<FormControlExtension i:nil="true" />\n' +
+      '\t\t\t\t\t\t<DataField>ConDisableProdQty</DataField>\n' +
+      '\t\t\t\t\t\t<DataSource>InventTestGroup</DataSource>\n' +
+      '\t\t\t\t\t</AxFormControl>\n'
+    );
+  });
+});
+
+// Report §11.3, reproduced in a second environment: two add-control calls against
+// one file, naming two different sibling groups. The SECOND call inserted into the
+// FIRST call's parent while writing the requested name into <Parent> — because the
+// insertion point was found positionally (first </Controls>) and `parentControl`
+// only ever supplied that text. Two sibling groups is the smallest shape that
+// exposes it; a single-group fixture cannot.
+describe('two sibling groups defined by the same extension', () => {
+  const TWO_GROUPS = `<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>ProdSetupReportFinished.ConExtension</Name>
+\t<Controls>
+\t\t<AxFormExtensionControl xmlns="">
+\t\t\t<Name>FormExtensionControlgrp000001</Name>
+\t\t\t<FormControl xmlns="" i:type="AxFormGroupControl">
+\t\t\t\t<Name>ConFirstGroup</Name>
+\t\t\t\t<Type>Group</Type>
+\t\t\t\t<Controls>
+\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormStringControl">
+\t\t\t\t\t\t<Name>ConFirstGroup_Existing</Name>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t</Controls>
+\t\t\t</FormControl>
+\t\t\t<Parent>ProdSetupReportFinishedFields</Parent>
+\t\t</AxFormExtensionControl>
+\t\t<AxFormExtensionControl xmlns="">
+\t\t\t<Name>FormExtensionControlgrp000002</Name>
+\t\t\t<FormControl xmlns="" i:type="AxFormGroupControl">
+\t\t\t\t<Name>ConSecondGroup</Name>
+\t\t\t\t<Type>Group</Type>
+\t\t\t\t<Controls>
+\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormStringControl">
+\t\t\t\t\t\t<Name>ConSecondGroup_Existing</Name>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t</Controls>
+\t\t\t</FormControl>
+\t\t\t<Parent>ProdSetupReportFinishedFields</Parent>
+\t\t</AxFormExtensionControl>
+\t</Controls>
+</AxFormExtension>`;
+
+  /** Children of the named group's nested <Controls>, in order. */
+  const childrenOf = (xml: string, group: string): string[] => {
+    const from = xml.indexOf(`<Name>${group}</Name>`);
+    const open = xml.indexOf('<Controls>', from);
+    const close = xml.indexOf('</Controls>', open);
+    return [...xml.slice(open, close).matchAll(/<Name>([^<]+)<\/Name>/g)].map(m => m[1]);
+  };
+
+  it('inserts into the SECOND group when that is the one named', () => {
+    const r = inserted(insertFormExtensionControl(TWO_GROUPS, spec({
+      controlName: 'ConSecondGroup_Probe',
+      parentControl: 'ConSecondGroup',
+      dataField: 'AcceptError',
+      dataSource: 'ProdParmReportFinished',
+    })));
+
+    expect(childrenOf(r.xml, 'ConSecondGroup')).toEqual([
+      'ConSecondGroup_Existing', 'ConSecondGroup_Probe',
+    ]);
+    // The first group — which used to receive it — is untouched.
+    expect(childrenOf(r.xml, 'ConFirstGroup')).toEqual(['ConFirstGroup_Existing']);
+  });
+
+  it('inserts into the FIRST group when that is the one named', () => {
+    const r = inserted(insertFormExtensionControl(TWO_GROUPS, spec({
+      controlName: 'ConFirstGroup_Probe',
+      parentControl: 'ConFirstGroup',
+    })));
+
+    expect(childrenOf(r.xml, 'ConFirstGroup')).toEqual([
+      'ConFirstGroup_Existing', 'ConFirstGroup_Probe',
+    ]);
+    expect(childrenOf(r.xml, 'ConSecondGroup')).toEqual(['ConSecondGroup_Existing']);
+  });
+
+  it('survives two successive calls naming different groups', () => {
+    // The exact §11.3 sequence, which a single call cannot reproduce.
+    const first = inserted(insertFormExtensionControl(TWO_GROUPS, spec({
+      controlName: 'ConFirstGroup_Probe',
+      parentControl: 'ConFirstGroup',
+    })));
+    const second = inserted(insertFormExtensionControl(first.xml, spec({
+      controlName: 'ConSecondGroup_Probe',
+      parentControl: 'ConSecondGroup',
+    })));
+
+    expect(childrenOf(second.xml, 'ConFirstGroup')).toEqual([
+      'ConFirstGroup_Existing', 'ConFirstGroup_Probe',
+    ]);
+    expect(childrenOf(second.xml, 'ConSecondGroup')).toEqual([
+      'ConSecondGroup_Existing', 'ConSecondGroup_Probe',
+    ]);
+    expect(findFormExtensionPlacementProblems(second.xml)).toEqual([]);
+  });
+});
+
+describe('parent belonging to the base form → AxFormExtensionControl envelope', () => {
+  it('wraps the control and references the parent by name', () => {
+    const r = inserted(insertFormExtensionControl(FLAT_EXT, spec({
+      controlName: 'Grid_ConDisableProdQty',
+      parentControl: 'Grid',
+    })));
+
+    expect(r.representation).toBe('envelope');
+    expect(r.xml).toContain('<Name>FormExtensionControlnew000001</Name>');
+    expect(r.xml).toContain('<Parent>Grid</Parent>');
+    expect(count(r.xml, '<AxFormExtensionControl')).toBe(2);
+  });
+
+  it('targets the ROOT collection even when a nested one closes first', () => {
+    // The exact trap: parent is on the base form, but the file also contains an
+    // extension-owned group whose </Controls> comes earlier in document order.
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec({
+      controlName: 'TabHeaderGeneral_ConNote',
+      parentControl: 'TabHeaderGeneral',
+      dataField: 'ConNote',
+    })));
+
+    expect(r.representation).toBe('envelope');
+    expect(nestedControlsBody(r.xml)).not.toContain('ConNote');
+    expect(r.xml).toContain('<Parent>TabHeaderGeneral</Parent>');
+    expect(count(r.xml, '<AxFormExtensionControl')).toBe(2);
+  });
+});
+
+// ─── DataGroup-bound parent (report §6b) ─────────────────────────────────────
+
+describe('parent bound to a table field group via <DataGroup>', () => {
+  // Deliberately a warning, not a refusal. The base-form guard refuses because a
+  // base-form <DataGroup> container generates its members, so an explicit control
+  // duplicates one. An extension-created group generates nothing (§11.2 of the
+  // report: a field-group member with no explicit control does not render), so
+  // here the explicit control is the ONLY way to get the field onto the form —
+  // refusing would send the caller to the VS designer to do the tool's job.
+  it('writes the control and warns instead of refusing', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt({ dataGroup: true }), spec()));
+
+    expect(nestedControlsBody(r.xml)).toContain('ConQualityOrders_ConDisableProdQty');
+    expect(r.notes.join('\n')).toMatch(/DataGroup/);
+  });
+
+  it('names the control the designer Refresh would generate', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt({ dataGroup: true }), spec()));
+    const note = r.notes.join('\n');
+
+    expect(note).toContain('ConQualityOrders_ConDisableProdQty');
+    expect(note).toContain('add-field-to-field-group');
+  });
+
+  it('says the field group alone will not render the field on an extension-owned group', () => {
+    const note = inserted(insertFormExtensionControl(nestedExt({ dataGroup: true }), spec()))
+      .notes.join('\n');
+
+    expect(note).toMatch(/BASE-FORM/);
+    expect(note).toMatch(/explicit control is required/);
+  });
+
+  it('stays quiet when the parent has no DataGroup', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec()));
+    expect(r.notes.join('\n')).not.toMatch(/DataGroup/);
+  });
+});
+
+// ─── Collection variants ─────────────────────────────────────────────────────
+
+describe('empty and self-closing collections', () => {
+  const emptyGroup = nestedExt().replace(
+    /\t\t\t\t<Controls>[\s\S]*?<\/Controls>\n/,
+    '\t\t\t\t<Controls />\n',
+  );
+
+  it('expands a self-closing nested <Controls />, preserving its attributes', () => {
+    const withAttrs = emptyGroup.replace('<Controls />', '<Controls xmlns="" />');
+    const r = inserted(insertFormExtensionControl(withAttrs, spec()));
+
+    expect(r.representation).toBe('nested');
+    expect(r.xml).toContain('<Controls xmlns="">');
+    expect(r.xml).toContain('<Name>ConQualityOrders_ConDisableProdQty</Name>');
+    expect(r.xml).not.toContain('<Controls xmlns="" />');
+  });
+
+  it('expands a self-closing ROOT <Controls /> for a base-form parent', () => {
+    const bare = FLAT_EXT.replace(/\t<Controls>[\s\S]*?\t<\/Controls>/, '\t<Controls />');
+    const r = inserted(insertFormExtensionControl(bare, spec({ parentControl: 'Grid' })));
+
+    expect(r.representation).toBe('envelope');
+    expect(r.xml).toContain('<AxFormExtensionControl xmlns="">');
+    expect(r.xml).not.toContain('<Controls />');
+  });
+
+  it('refuses an extension-owned parent that has no <Controls> at all', () => {
+    const noControls = nestedExt().replace(/\t\t\t\t<Controls>[\s\S]*?<\/Controls>\n/, '');
+    const r = insertFormExtensionControl(noControls, spec());
+
+    expect(r.kind).toBe('refused');
+    expect((r as { message: string }).message).toMatch(/no <Controls> collection/);
+  });
+});
+
+// ─── Idempotency ─────────────────────────────────────────────────────────────
+
+describe('idempotency', () => {
+  it('skips when the control already exists', () => {
+    const r = insertFormExtensionControl(nestedExt(), spec({
+      controlName: 'ConQualityOrders_ConDisableInventoryBlocking',
+    }));
+    expect(r.kind).toBe('exists');
+  });
+
+  it('is not fooled by a data source or field of the same name', () => {
+    // The old check was `content.includes('<Name>' + controlName + '</Name>')`,
+    // which also matched the extension's own <Name> and any element carrying one.
+    const r = insertFormExtensionControl(nestedExt(), spec({
+      controlName: 'InventTestGroup',
+      parentControl: 'ConQualityOrders',
+    }));
+    expect(r.kind).toBe('inserted');
+  });
+
+  it('does not treat the auto-generated wrapper id as a control name', () => {
+    const r = insertFormExtensionControl(nestedExt(), spec({
+      parentControl: 'FormExtensionControlabc123xyz',
+    }));
+    // Resolves as a base-form parent (it is not a control), never as a nested one.
+    expect(inserted(r).representation).toBe('envelope');
+  });
+});
+
+// ─── previousSibling ─────────────────────────────────────────────────────────
+
+describe('previousSibling', () => {
+  const twoChildren = nestedExt().replace(
+    '\t\t\t\t</Controls>',
+    '\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormStringControl">\n' +
+    '\t\t\t\t\t\t<Name>ConQualityOrders_ConComment</Name>\n' +
+    '\t\t\t\t\t\t<Type>String</Type>\n' +
+    '\t\t\t\t\t\t<FormControlExtension i:nil="true" />\n' +
+    '\t\t\t\t\t</AxFormControl>\n' +
+    '\t\t\t\t</Controls>',
+  );
+
+  it('inserts directly after the named sibling', () => {
+    const r = inserted(insertFormExtensionControl(twoChildren, spec({
+      previousSibling: 'ConQualityOrders_ConDisableInventoryBlocking',
+    })));
+    const body = nestedControlsBody(r.xml);
+
+    expect(body.indexOf('ConDisableInventoryBlocking'))
+      .toBeLessThan(body.indexOf('ConQualityOrders_ConDisableProdQty'));
+    expect(body.indexOf('ConQualityOrders_ConDisableProdQty'))
+      .toBeLessThan(body.indexOf('ConQualityOrders_ConComment'));
+  });
+
+  it('appends last and says so when the sibling is not found', () => {
+    const r = inserted(insertFormExtensionControl(twoChildren, spec({
+      previousSibling: 'NotAControl',
+    })));
+
+    expect(r.notes.join('\n')).toMatch(/NotAControl.*not found/);
+  });
+
+  it('reports that it cannot apply to the envelope shape', () => {
+    const r = inserted(insertFormExtensionControl(FLAT_EXT, spec({
+      parentControl: 'Grid',
+      previousSibling: 'Grid_ConHasNotes',
+    })));
+
+    expect(r.representation).toBe('envelope');
+    expect(r.notes.join('\n')).toMatch(/ignored/);
+  });
+});
+
+// ─── Refusing shapes we don't understand ─────────────────────────────────────
+
+describe('safety', () => {
+  it('declines anything that is not an AxFormExtension', () => {
+    const table = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConTable</Name>
+\t<Controls>
+\t</Controls>
+</AxTable>`;
+    expect(insertFormExtensionControl(table, spec()).kind).toBe('unsupported');
+  });
+
+  it('declines unbalanced XML instead of splicing into it', () => {
+    const broken = nestedExt().replace('</AxFormExtension>', '');
+    expect(insertFormExtensionControl(broken, spec()).kind).toBe('unsupported');
+  });
+
+  it('declines an extension with no <Controls> collection', () => {
+    const noControls = FLAT_EXT.replace(/\t<Controls>[\s\S]*?\t<\/Controls>\n/, '');
+    expect(insertFormExtensionControl(noControls, spec({ parentControl: 'Grid' })).kind)
+      .toBe('unsupported');
+  });
+
+  it('is not confused by CDATA containing angle brackets', () => {
+    const withSource = nestedExt().replace(
+      '\t<ControlModifications />',
+      '\t<SourceCode>\n' +
+      '\t\t<Methods>\n' +
+      '\t\t\t<Method>\n' +
+      '\t\t\t\t<Name>init</Name>\n' +
+      '\t\t\t\t<Source><![CDATA[\npublic void init()\n{\n    if (a < b) { }\n    // </Controls>\n}\n]]></Source>\n' +
+      '\t\t\t</Method>\n' +
+      '\t\t</Methods>\n' +
+      '\t</SourceCode>',
+    );
+    const r = inserted(insertFormExtensionControl(withSource, spec()));
+
+    expect(r.representation).toBe('nested');
+    expect(nestedControlsBody(r.xml)).toContain('ConQualityOrders_ConDisableProdQty');
+  });
+
+  it('preserves every byte outside the insertion point (control)', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec()));
+    // Anchor on the NEW control so the pre-existing sibling isn't what gets cut.
+    const stripped = r.xml.replace(
+      /\n\t{5}<AxFormControl [^>]*>\n\t{6}<Name>ConQualityOrders_ConDisableProdQty<\/Name>[\s\S]*?<\/AxFormControl>/,
+      '',
+    );
+
+    expect(stripped).toBe(nestedExt());
+  });
+});
+
+// ─── Placement validation ────────────────────────────────────────────────────
+//
+// Build test, 2026-08-12 (xppc framework 10.0.2645.99): the malformed
+// file compiles at exit 0 / 0 errors. The deserializer DISCARDS the misplaced
+// node — the control never reaches the form. The only trace was a single extra
+// metadata warning ("The form control has different fields from the field group
+// … Use restore on the form control"), which names neither the control nor the
+// malformed node, arrived among 52 pre-existing warnings, and only exists
+// because this parent is DataGroup-bound and so had two field sets to compare.
+//
+// That makes validation the last line of defence rather than a nicety: nothing
+// downstream reports it, so anything that slips past here ships silently.
+
+/** The exact bad output from the report: an envelope inside the nested <Controls>. */
+const SHAPE_C = `<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>InventTestGroup.ConExtension</Name>
+\t<Controls>
+\t\t<AxFormExtensionControl xmlns="">
+\t\t\t<Name>FormExtensionControlabc123xyz</Name>
+\t\t\t<FormControl xmlns="" i:type="AxFormGroupControl">
+\t\t\t\t<Name>ConQualityOrders</Name>
+\t\t\t\t<Controls>
+\t\t\t\t\t<AxFormControl xmlns="" i:type="AxFormCheckBoxControl">
+\t\t\t\t\t\t<Name>ConQualityOrders_ConDisableInventoryBlocking</Name>
+\t\t\t\t\t</AxFormControl>
+\t\t\t\t\t<AxFormExtensionControl xmlns="">
+\t\t\t\t\t\t<Name>FormExtensionControllhc7hmswk</Name>
+\t\t\t\t\t\t<FormControl xmlns="" i:type="AxFormComboBoxControl">
+\t\t\t\t\t\t\t<Name>ConQualityOrders_ConDisableProdQty</Name>
+\t\t\t\t\t\t\t<Type>ComboBox</Type>
+\t\t\t\t\t\t\t<Items />
+\t\t\t\t\t\t</FormControl>
+\t\t\t\t\t\t<Parent>ConQualityOrders</Parent>
+\t\t\t\t\t</AxFormExtensionControl>
+\t\t\t\t</Controls>
+\t\t\t\t<DataGroup>ConQualityOrders</DataGroup>
+\t\t\t</FormControl>
+\t\t\t<Parent>TabHeaderGeneral</Parent>
+\t\t</AxFormExtensionControl>
+\t</Controls>
+</AxFormExtension>`;
+
+describe('placement validation', () => {
+  it('flags an AxFormExtensionControl nested inside a control\'s <Controls>', () => {
+    const problems = findFormExtensionPlacementProblems(SHAPE_C);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0].element).toBe('AxFormExtensionControl');
+    expect(problems[0].line).toBe(13);
+    // The consequence has to be stated: a reader who sees "0 errors" otherwise
+    // concludes the file is fine.
+    expect(problems[0].detail).toMatch(/DISCARDS/);
+  });
+
+  it('flags a bare AxFormControl left in the extension\'s root <Controls>', () => {
+    // The inverse mistake: nested shape used where the envelope belongs.
+    const inverted = `<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+\t<Name>CustGroup.ConExtension</Name>
+\t<Controls>
+\t\t<AxFormControl xmlns="" i:type="AxFormCheckBoxControl">
+\t\t\t<Name>Grid_ConHasNotes</Name>
+\t\t</AxFormControl>
+\t</Controls>
+</AxFormExtension>`;
+    const problems = findFormExtensionPlacementProblems(inverted);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0].element).toBe('AxFormControl');
+  });
+
+  it('passes both correct shapes', () => {
+    expect(findFormExtensionPlacementProblems(FLAT_EXT)).toEqual([]);
+    expect(findFormExtensionPlacementProblems(nestedExt())).toEqual([]);
+    expect(findFormExtensionPlacementProblems(nestedExt({ dataGroup: true }))).toEqual([]);
+  });
+
+  it('passes everything this writer produces', () => {
+    for (const [xml, s] of [
+      [nestedExt(), spec()],
+      [FLAT_EXT, spec({ parentControl: 'Grid' })],
+      [nestedExt(), spec({ parentControl: 'TabHeaderGeneral' })],
+    ] as const) {
+      const r = inserted(insertFormExtensionControl(xml, s));
+      expect(findFormExtensionPlacementProblems(r.xml)).toEqual([]);
+    }
+  });
+
+  it('is reachable from the hand-written xmlContent gate', () => {
+    // Every element in SHAPE_C is spelled correctly, so the name-based checks
+    // alone returned 0 problems and let it through.
+    expect(validateFormExtensionControlShape(SHAPE_C).length).toBeGreaterThan(0);
+    expect(validateFormExtensionControlShape(FLAT_EXT)).toEqual([]);
+  });
+
+  it('stays quiet on files it does not understand', () => {
+    expect(findFormExtensionPlacementProblems('<AxTable><Controls><Foo /></Controls></AxTable>')).toEqual([]);
+    expect(findFormExtensionPlacementProblems('not xml at all')).toEqual([]);
+  });
+});

--- a/tests/utils/formExtensionControlXml.test.ts
+++ b/tests/utils/formExtensionControlXml.test.ts
@@ -19,6 +19,7 @@ import { describe, it, expect } from 'vitest';
 import {
   insertFormExtensionControl,
   findFormExtensionPlacementProblems,
+  buildAbandonedWriteMessage,
   type FormExtensionControlSpec,
 } from '../../src/utils/formExtensionControlXml';
 import { validateFormExtensionControlShape } from '../../src/utils/formExtensionShapeValidator';
@@ -548,6 +549,122 @@ describe('positionType', () => {
     const r = inserted(onBaseForm({ positionType: 'Begin', previousSibling: 'Grid_ConHasNotes' }));
 
     expect(r.notes.join('\n')).toMatch(/ignored/);
+  });
+});
+
+// ─── Escaping ────────────────────────────────────────────────────────────────
+//
+// Every value here is interpolated into markup. None were escaped, so a label
+// carrying an ampersand emitted XML that is not well-formed, and a value
+// carrying markup could close its own element and smuggle a whole envelope into
+// the nested <Controls> — the exact shape the deserializer silently discards.
+// Real object names cannot contain either, which is why this never surfaced;
+// labels are free text and can.
+
+describe('escaping values on the way into XML', () => {
+  it('escapes an ampersand in a label instead of emitting malformed XML', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec({
+      label: 'Cost & freight',
+    })));
+
+    expect(r.xml).toContain('<Label>Cost &amp; freight</Label>');
+    expect(r.xml).not.toContain('<Label>Cost & freight</Label>');
+  });
+
+  it('escapes markup in a field value rather than letting it become structure', () => {
+    const payload =
+      'ConDisableProdQty</DataField></AxFormControl>' +
+      '<AxFormExtensionControl xmlns=""><Name>FormExtensionControlbad00001</Name>' +
+      '<FormControl xmlns="" i:type="AxFormStringControl"><Name>Smuggled</Name></FormControl>' +
+      '<Parent>ConQualityOrders</Parent></AxFormExtensionControl>' +
+      '<AxFormControl xmlns="" i:type="AxFormStringControl"><DataField>Filler';
+
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec({ dataField: payload })));
+
+    // Before escaping this produced a real <AxFormExtensionControl> inside the
+    // parent's nested <Controls> and the write was abandoned by the post-write
+    // guard. Now it is text, so there is nothing to abandon.
+    expect(findFormExtensionPlacementProblems(r.xml)).toEqual([]);
+    expect(r.xml).not.toContain('<Name>Smuggled</Name>');
+    expect(r.xml).toContain('&lt;AxFormExtensionControl');
+  });
+
+  it('escapes the quote that would close an i:type attribute early', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec({
+      iType: 'AxFormStringControl" evil="1',
+    })));
+
+    expect(r.xml).toContain('i:type="AxFormStringControl&quot; evil=&quot;1"');
+    expect(r.xml).not.toContain('evil="1"');
+  });
+
+  it('does not double-escape an ampersand', () => {
+    const r = inserted(insertFormExtensionControl(nestedExt(), spec({ label: 'A &lt; B' })));
+
+    expect(r.xml).toContain('<Label>A &amp;lt; B</Label>');
+    expect(r.xml).not.toContain('&amp;amp;');
+  });
+
+  // Escaping on write only holds up if reading undoes it: the idempotency check
+  // compares the caller's spelling against the name in the file, so an escaped
+  // name that decodes to something else would let the control be added twice.
+  it('round-trips an escaped name through the idempotency check', () => {
+    const first = inserted(insertFormExtensionControl(nestedExt(), spec({
+      controlName: 'Weird & Name',
+    })));
+    const second = insertFormExtensionControl(first.xml, spec({ controlName: 'Weird & Name' }));
+
+    expect(first.xml).toContain('<Name>Weird &amp; Name</Name>');
+    expect(second.kind).toBe('exists');
+  });
+
+  it('resolves an escaped parent name and an escaped previousSibling', () => {
+    const withOddParent = nestedExt().replace(
+      '<Name>ConQualityOrders</Name>',
+      '<Name>Quality &amp; Orders</Name>',
+    );
+    const r = inserted(insertFormExtensionControl(withOddParent, spec({
+      parentControl: 'Quality & Orders',
+      previousSibling: 'ConQualityOrders_ConDisableInventoryBlocking',
+    })));
+
+    expect(r.representation).toBe('nested');
+  });
+});
+
+// ─── The abandoned-write message ─────────────────────────────────────────────
+//
+// Not reachable from ordinary input: the writer's output is clean on all 1088
+// shipped extensions, and escaping closed the one route that reached it (a
+// dataField payload that smuggled an envelope into the nested <Controls>). The
+// message builder is exported so the naming it does is still pinned.
+
+describe('buildAbandonedWriteMessage', () => {
+  // Lazy: SHAPE_C is declared further down the file, so reading it while the
+  // describe body runs would hit the temporal dead zone.
+  const problems = () => findFormExtensionPlacementProblems(SHAPE_C);
+
+  it('names the form extension in the banner, not the control', () => {
+    const message = buildAbandonedWriteMessage(SHAPE_C, 'ConQualityOrders_ConDisableProdQty', problems());
+
+    // The banner slot identifies the object whose XML is wrong — the control
+    // name used to be passed straight into it.
+    expect(message).toContain('form-extension "InventTestGroup.ConExtension"');
+    expect(message).not.toContain('form-extension "ConQualityOrders_ConDisableProdQty"');
+  });
+
+  it('still names the control, in the sentence that describes the action', () => {
+    const message = buildAbandonedWriteMessage(SHAPE_C, 'ConQualityOrders_ConDisableProdQty', problems());
+
+    expect(message).toMatch(/while adding "ConQualityOrders_ConDisableProdQty"/);
+    expect(message).toMatch(/ABANDONED/);
+    expect(message).toMatch(/report it with the extension XML/);
+  });
+
+  it('says so rather than inventing a name when the document will not parse', () => {
+    const message = buildAbandonedWriteMessage('not xml at all', 'SomeControl', problems());
+
+    expect(message).toContain('(unparseable form extension)');
   });
 });
 

--- a/tests/utils/formExtensionControlXml.test.ts
+++ b/tests/utils/formExtensionControlXml.test.ts
@@ -318,7 +318,20 @@ describe('parent bound to a table field group via <DataGroup>', () => {
       .notes.join('\n');
 
     expect(note).toMatch(/BASE-FORM/);
-    expect(note).toMatch(/explicit control is required/);
+    expect(note).toMatch(/field group alone is NOT enough/);
+  });
+
+  // The advisory used to say "add the field to the field group INSTEAD" one
+  // bullet before saying that doing so "will NOT put it on the form here", and
+  // the op spec repeated the first half — so the model was told to take the
+  // action the runtime documents as ineffective.
+  it('asks for both halves rather than offering the field group as a substitute', () => {
+    const note = inserted(insertFormExtensionControl(nestedExt({ dataGroup: true }), spec()))
+      .notes.join('\n');
+
+    expect(note).toMatch(/AS WELL/);
+    expect(note).toMatch(/Both halves are required/);
+    expect(note).not.toMatch(/field group instead/);
   });
 
   it('stays quiet when the parent has no DataGroup', () => {
@@ -354,12 +367,44 @@ describe('empty and self-closing collections', () => {
     expect(r.xml).not.toContain('<Controls />');
   });
 
-  it('refuses an extension-owned parent that has no <Controls> at all', () => {
+  // Refusing here broke the tool's own two-step workflow: add-control can create
+  // a group, and the group it writes has no <Controls> (innerControlLines emits
+  // Name/Type/FormControlExtension only), so every "create a group, then fill
+  // it" sequence failed on step two and sent the caller to Visual Studio.
+  it('creates the <Controls> collection for a childless extension-owned parent', () => {
     const noControls = nestedExt().replace(/\t\t\t\t<Controls>[\s\S]*?<\/Controls>\n/, '');
-    const r = insertFormExtensionControl(noControls, spec());
+    const r = inserted(insertFormExtensionControl(noControls, spec()));
+
+    expect(r.representation).toBe('nested');
+    expect(nestedControlsBody(r.xml)).toContain('ConQualityOrders_ConDisableProdQty');
+    expect(findFormExtensionPlacementProblems(r.xml)).toEqual([]);
+  });
+
+  // Position is not a guess: across the 1088 shipped AxFormExtension files an
+  // opening <Controls> follows <FormControlExtension> 2176 times and
+  // <ControlModifications> 996 times, and nothing else — so inside a control it
+  // goes straight after FormControlExtension, ahead of DataGroup/DataSource.
+  it('puts the new collection after <FormControlExtension>, before the other properties', () => {
+    const noControls = nestedExt({ dataGroup: true })
+      .replace(/\t\t\t\t<Controls>[\s\S]*?<\/Controls>\n/, '');
+    const r = inserted(insertFormExtensionControl(noControls, spec()));
+
+    const ext = r.xml.indexOf('<FormControlExtension i:nil="true" />', r.xml.indexOf('ConQualityOrders'));
+    const controls = r.xml.indexOf('<Controls>', ext);
+    const dataGroup = r.xml.indexOf('<DataGroup>', ext);
+
+    expect(ext).toBeLessThan(controls);
+    expect(controls).toBeLessThan(dataGroup);
+  });
+
+  it('still refuses when there is no <FormControlExtension> to position against', () => {
+    const noAnchor = nestedExt()
+      .replace(/\t\t\t\t<Controls>[\s\S]*?<\/Controls>\n/, '')
+      .replace('\t\t\t\t<FormControlExtension i:nil="true" />\n', '');
+    const r = insertFormExtensionControl(noAnchor, spec());
 
     expect(r.kind).toBe('refused');
-    expect((r as { message: string }).message).toMatch(/no <Controls> collection/);
+    expect((r as { message: string }).message).toMatch(/no <FormControlExtension>/);
   });
 });
 
@@ -425,13 +470,83 @@ describe('previousSibling', () => {
     expect(r.notes.join('\n')).toMatch(/NotAControl.*not found/);
   });
 
-  it('reports that it cannot apply to the envelope shape', () => {
+  // The envelope's position among the BASE FORM's children is carried by
+  // <PositionType>/<PreviousSibling> next to <Parent>, not by splice order in
+  // the extension's root <Controls>. Shipped evidence: 753 of the 1088
+  // AxFormExtension files use exactly `Name, FormControl, Parent, PositionType,
+  // PreviousSibling` (e.g. BusinessProcessActionLookup.Foundation.xml, which
+  // positions RetailTaskActionType after TaskActionType in base-form group View).
+  it('carries previousSibling into the envelope as PositionType/PreviousSibling', () => {
     const r = inserted(insertFormExtensionControl(FLAT_EXT, spec({
       parentControl: 'Grid',
       previousSibling: 'Grid_ConHasNotes',
     })));
 
     expect(r.representation).toBe('envelope');
+    expect(r.xml).toContain('<PositionType>AfterItem</PositionType>');
+    expect(r.xml).toContain('<PreviousSibling>Grid_ConHasNotes</PreviousSibling>');
+    expect(r.notes.join('\n')).not.toMatch(/ignored/);
+  });
+
+  it('emits the position pair in the order shipped metadata uses', () => {
+    const r = inserted(insertFormExtensionControl(FLAT_EXT, spec({
+      parentControl: 'Grid',
+      previousSibling: 'Grid_ConHasNotes',
+    })));
+    const at = (t: string) => r.xml.indexOf(t, r.xml.indexOf('FormExtensionControlnew000001'));
+
+    expect(at('</FormControl>')).toBeLessThan(at('<Parent>'));
+    expect(at('<Parent>')).toBeLessThan(at('<PositionType>'));
+    expect(at('<PositionType>')).toBeLessThan(at('<PreviousSibling>'));
+  });
+
+  it('omits the pair entirely when no position was asked for', () => {
+    const r = inserted(insertFormExtensionControl(FLAT_EXT, spec({ parentControl: 'Grid' })));
+
+    expect(r.xml).not.toContain('<PositionType>');
+    expect(r.xml).not.toContain('<PreviousSibling>');
+  });
+});
+
+// ─── positionType ────────────────────────────────────────────────────────────
+
+describe('positionType', () => {
+  const onBaseForm = (over: Partial<FormExtensionControlSpec> = {}) =>
+    insertFormExtensionControl(FLAT_EXT, spec({ parentControl: 'Grid', ...over }));
+
+  it('writes Begin without a sibling', () => {
+    const r = inserted(onBaseForm({ positionType: 'Begin' }));
+
+    expect(r.xml).toContain('<PositionType>Begin</PositionType>');
+    expect(r.xml).not.toContain('<PreviousSibling>');
+  });
+
+  it('treats End as the default and writes neither element', () => {
+    const r = inserted(onBaseForm({ positionType: 'End' }));
+
+    expect(r.xml).not.toContain('<PositionType>');
+  });
+
+  it('refuses AfterItem with no previousSibling to anchor it', () => {
+    const r = onBaseForm({ positionType: 'AfterItem' });
+
+    expect(r.kind).toBe('refused');
+    expect((r as { message: string }).message).toMatch(/needs previousSibling/);
+  });
+
+  // Only AfterItem (765×) and Begin (182×) occur in the shipped corpus. An
+  // unknown enum value is the failure mode this module exists to prevent —
+  // it deserializes to a discarded node with the build reporting 0 errors.
+  it('refuses a value that shipped metadata never uses', () => {
+    const r = onBaseForm({ positionType: 'BeforeItem', previousSibling: 'Grid_ConHasNotes' });
+
+    expect(r.kind).toBe('refused');
+    expect((r as { message: string }).message).toMatch(/not a value D365FO/);
+  });
+
+  it('ignores previousSibling for Begin and says so', () => {
+    const r = inserted(onBaseForm({ positionType: 'Begin', previousSibling: 'Grid_ConHasNotes' }));
+
     expect(r.notes.join('\n')).toMatch(/ignored/);
   });
 });
@@ -589,5 +704,62 @@ describe('placement validation', () => {
   it('stays quiet on files it does not understand', () => {
     expect(findFormExtensionPlacementProblems('<AxTable><Controls><Foo /></Controls></AxTable>')).toEqual([]);
     expect(findFormExtensionPlacementProblems('not xml at all')).toEqual([]);
+  });
+});
+
+// ─── Repairing a file an earlier release damaged ─────────────────────────────
+//
+// SHAPE_C is not a hypothetical: it is the output the shipped writer produced.
+// Whoever hits this bug has files in this state, and the release that fixes the
+// writer is the one they will run against them — so every guard added here has
+// to leave the repair path open. The post-write check gates on problems this
+// write INTRODUCED, never on the file's existing ones.
+
+describe('a file already damaged by the old writer', () => {
+  it('accepts a correct write instead of refusing over the pre-existing damage', () => {
+    const r = inserted(insertFormExtensionControl(SHAPE_C, spec({
+      controlName: 'ConQualityOrders_ConComment',
+    })));
+
+    expect(nestedControlsBody(r.xml)).toContain('ConQualityOrders_ConComment');
+    // Untouched: the write neither caused nor silently cleaned up the old node.
+    expect(findFormExtensionPlacementProblems(r.xml)).toHaveLength(1);
+  });
+
+  it('reports the pre-existing damage rather than blaming the caller for it', () => {
+    const r = inserted(insertFormExtensionControl(SHAPE_C, spec({
+      controlName: 'ConQualityOrders_ConComment',
+    })));
+
+    expect(r.notes.join('\n')).toMatch(/already contained 1 misplaced control/);
+    expect(r.notes.join('\n')).toMatch(/neither caused nor fixed/);
+  });
+
+  // The natural repair — re-run the identical add-control — used to answer
+  // "already present, skipped (idempotent)" and write nothing, because the
+  // discarded control's <Name> is perfectly readable where it lies.
+  it('does not count a discarded control as already present', () => {
+    const r = insertFormExtensionControl(SHAPE_C, spec());
+
+    expect(r.kind).toBe('inserted');
+    expect(inserted(r).notes.join('\n')).toMatch(/dead copy/);
+  });
+
+  it('leaves the file repaired, so a second identical call is idempotent again', () => {
+    const first = inserted(insertFormExtensionControl(SHAPE_C, spec()));
+    const second = insertFormExtensionControl(first.xml, spec());
+
+    expect(second.kind).toBe('exists');
+  });
+
+  // Nesting into a dead parent buys a second discarded control and another ✅.
+  it('refuses to use a discarded control as the parent', () => {
+    const r = insertFormExtensionControl(SHAPE_C, spec({
+      controlName: 'ConSomethingNew',
+      parentControl: 'ConQualityOrders_ConDisableProdQty',
+    }));
+
+    expect(r.kind).toBe('refused');
+    expect((r as { message: string }).message).toMatch(/discards/);
   });
 });


### PR DESCRIPTION
## Issue

`add-control` on a form extension inserted the new control with
`content.replace('</Controls>', …)`. A string pattern replaces the **first**
occurrence, so when the extension defines its own container the nested
`</Controls>` — which closes earlier in document order — received the control.
`parentControl` was never resolved to a node at all; it only supplied the
`<Parent>` text.

Two defects follow from that one line:

1. The control was wrapped in an `AxFormExtensionControl` envelope regardless of
   where the parent lived, so a parent the extension itself defines got the
   base-form representation. A form extension has two mutually exclusive shapes —
   an envelope in the root `<Controls>` for a base-form parent, a bare
   `<AxFormControl>` in the parent's nested `<Controls>` for an extension-owned
   one — and only the parent's location distinguishes them.
2. With two sibling groups in one file, a second call inserted into the **first**
   call's parent while writing the requested name into `<Parent>`.

**Neither fails the build.** The malformed file compiles at exit 0, 0 errors: the
deserializer discards the misplaced node, and the control is absent from compiled
metadata and from the running form. On a `DataGroup`-bound parent the sole trace
is a metadata warning naming the field group — never the control, the node, or
the tool. On a plain group the compile logs are byte-identical with and without
the control, so there is no diagnostic anywhere in the toolchain.

## Fix

Placement now comes from where the resolved parent lives: an
`AxFormExtensionControl` envelope in the extension's root `<Controls>` for a
base-form parent, a bare `<AxFormControl>` in the parent's nested `<Controls>`
for one the extension defines. The file is walked by offset rather than
re-serialized, so untouched bytes stay untouched.

Because the compiler will not catch this for us, the write is validated before it
lands. `findFormExtensionPlacementProblems` asserts that every
`AxFormExtensionControl` is a direct child of the root collection and that every
nested collection holds only `AxFormControl`. It gates both the writer's own
output and hand-written `xmlContent`, where the existing name-based checks passed
the malformed shape clean — every element in it is spelled correctly; only its
position is wrong.

Also on this path:

- The success banner reported `applied via IMetadataProvider.Update()` for writes
  the XML fallback performed, naming an API that never ran — and with it, implying
  a validation that never happened. It now names the path that did the write.
- The control-type auto-pick answered `ComboBox` for every enum. `NoYes` and
  `NoYesId` now resolve to `CheckBox`, matching what the designer emits, via the
  EDT chain so a custom EDT extending `NoYesId` resolves too.
- `previousSibling` positions the control instead of being silently dropped, and
  says so when it cannot apply.
- Idempotency keys on resolved control names instead of a `<Name>` substring
  search, which also matched data sources, fields and the extension's own name —
  turning a real add into a silent no-op.
- An extension-owned parent carrying `<DataGroup>` now warns rather than refuses.
  The base-form guard refuses because a base-form `<DataGroup>` container
  generates its members and an explicit control collides; an extension-created
  group generates nothing — a field-group member with no explicit control does not
  render — so there the explicit control is the only thing that puts the field on
  the form.
