### PR TITLE
Answer for the table methods xRecord declares, and flag a CoC that re-reads its own record

### DIFF
--- a/src/knowledge/tableDataMethods.ts
+++ b/src/knowledge/tableDataMethods.ts
@@ -1,0 +1,181 @@
+/**
+ * The data methods every table inherits from `xRecord` / `Common`.
+ *
+ * Those are kernel types with no AOT metadata, and the symbol index stores
+ * declared members only, so a table's `validateWrite` has no row anywhere.
+ * prepare(mode="change") and get_method both reported that as "not found",
+ * which reads as "the method does not exist" for the most common CoC target
+ * there is and leaves the caller to invent the wrapper unaided.
+ *
+ * The contract below is the part a green build cannot teach — above all that
+ * the pre-image is `this.orig()`, already in memory, so re-reading the row by
+ * its own RecId is a database round trip per write AND a different value: the
+ * current stored state rather than what this buffer was fetched with.
+ *
+ * A FALLBACK only: consulted when neither index, bridge nor XML declares the
+ * method, so a table that overrides `insert()` still reports its own signature.
+ */
+
+export interface TableDataMethod {
+  /** Canonical AOT spelling. */
+  name: string;
+  /** The declaration a CoC wrapper has to match exactly. */
+  signature: string;
+  /** Kernel type that declares it. */
+  declaredOn: 'xRecord' | 'Common';
+  /** What wrapping it is for, in one line. */
+  purpose: string;
+  /** Non-negotiables a green build will not teach. */
+  contract: string[];
+}
+
+/**
+ * The pre-image rule, on every method where a pre-image exists.
+ *
+ * Stated as a prohibition as well as an instruction: "use orig()" alone does not
+ * dislodge a re-select the caller has already reasoned its way into.
+ */
+const PRE_IMAGE: string[] = [
+  '`this.orig()` IS the pre-image — a buffer already in memory, filled when the record was fetched. ' +
+  'Read the old value from it: `this.orig().MyField`.',
+  'Do NOT re-read the row (`select … where x.RecId == this.RecId`, `MyTable::find(this.RecId)`). It costs a ' +
+  'database round trip on every single write of the table, and it returns the CURRENT stored state, which ' +
+  'inside a transaction is not the same thing as the values this buffer was fetched with.',
+  'On an insert the pre-image is empty, so `this.orig().RecId == 0` is the test for "new record" — the same ' +
+  'test the re-select spells as "the select found nothing".',
+];
+
+const NEXT_ONCE =
+  '`next <method>()` must be reached exactly once and unconditionally — not inside an `if`, not after a ' +
+  '`return`. The compiler rejects the alternative with SYS10028 (rule COC004).';
+
+const VALIDATION_RETURN =
+  'Report a failure by RETURNING false, not by throwing: `ret = checkFailed("@MyModel:MyLabel");` ' +
+  '— checkFailed writes the message to the infolog and returns false, so every failed validation ' +
+  'is presented at once. `checkFailed` is a Global function, never `this.checkFailed(…)` (rule COC005).';
+
+/** Keyed by lower-cased method name. */
+export const TABLE_DATA_METHODS: Record<string, TableDataMethod> = {
+  validatewrite: {
+    name: 'validateWrite',
+    signature: 'public boolean validateWrite()',
+    declaredOn: 'xRecord',
+    purpose: 'Gate an insert or an update of the whole record; runs for UI and X++ writes alike.',
+    contract: [...PRE_IMAGE, NEXT_ONCE, VALIDATION_RETURN],
+  },
+  validatefield: {
+    name: 'validateField',
+    signature: 'public boolean validateField(FieldId _fieldIdToCheck)',
+    declaredOn: 'xRecord',
+    purpose: 'Gate one field as it is modified, before validateWrite runs.',
+    contract: [
+      'Test which field you were called for: `if (_fieldIdToCheck == fieldNum(MyTable, MyField))`.',
+      ...PRE_IMAGE,
+      NEXT_ONCE,
+      VALIDATION_RETURN,
+    ],
+  },
+  validatedelete: {
+    name: 'validateDelete',
+    signature: 'public boolean validateDelete()',
+    declaredOn: 'xRecord',
+    purpose: 'Gate a delete.',
+    contract: [
+      'The buffer holds the record being deleted — no lookup is needed to see what is about to go.',
+      NEXT_ONCE,
+      VALIDATION_RETURN,
+    ],
+  },
+  insert: {
+    name: 'insert',
+    signature: 'public void insert()',
+    declaredOn: 'xRecord',
+    purpose: 'Run logic around the physical insert of this buffer.',
+    contract: [
+      'There is no pre-image: `this.orig()` is an empty buffer and `this.RecId` is still 0 until next insert() returns.',
+      'Validation belongs in validateWrite, which the framework calls first — insert() is for side effects.',
+      NEXT_ONCE,
+    ],
+  },
+  update: {
+    name: 'update',
+    signature: 'public void update()',
+    declaredOn: 'xRecord',
+    purpose: 'Run logic around the physical update of this buffer.',
+    contract: [
+      ...PRE_IMAGE,
+      'Validation belongs in validateWrite, which the framework calls first — update() is for side effects.',
+      NEXT_ONCE,
+    ],
+  },
+  delete: {
+    name: 'delete',
+    signature: 'public void delete()',
+    declaredOn: 'xRecord',
+    purpose: 'Run logic around the physical delete of this buffer.',
+    contract: [
+      'The buffer still holds the record while the wrapper runs — read what you need before next delete().',
+      NEXT_ONCE,
+    ],
+  },
+  initvalue: {
+    name: 'initValue',
+    signature: 'public void initValue()',
+    declaredOn: 'xRecord',
+    purpose: 'Seed defaults on a new, not yet inserted record.',
+    contract: [
+      'Runs on a record that does not exist yet — there is nothing stored to read, and `this.orig()` is empty.',
+      NEXT_ONCE,
+    ],
+  },
+  modifiedfield: {
+    name: 'modifiedField',
+    signature: 'public void modifiedField(FieldId _fieldId)',
+    declaredOn: 'xRecord',
+    purpose: 'React to one field changing, typically to derive others.',
+    contract: [
+      'Test which field you were called for: `if (_fieldId == fieldNum(MyTable, MyField))`.',
+      ...PRE_IMAGE,
+      NEXT_ONCE,
+    ],
+  },
+};
+
+/** The inherited data method by that name, or undefined. Case-insensitive, as X++ is. */
+export function lookupTableDataMethod(methodName: string): TableDataMethod | undefined {
+  return TABLE_DATA_METHODS[methodName.trim().toLowerCase()];
+}
+
+/**
+ * True for the object types this fallback speaks for.
+ *
+ * Tables only, deliberately. Views, maps and data entities descend from `Common`
+ * too, but they do not all wrap through `tableStr` and not every one of these
+ * methods fires on them — a fallback that guessed there would be inventing a
+ * signature, which is the failure it exists to prevent.
+ */
+export function hasTableDataMethods(objectType: string | undefined): boolean {
+  return objectType?.toLowerCase() === 'table';
+}
+
+/** The `### Method signature` body when only this fallback knows the method. */
+export function renderTableDataMethodSignature(method: TableDataMethod, objectName: string): string {
+  return [
+    `Signature : ${method.signature}`,
+    `ℹ️  Inherited — \`${objectName}\` does not declare \`${method.name}\`; every table gets it from ` +
+    `\`${method.declaredOn}\`, a kernel type with no AOT metadata, which is why the symbol index has no row ` +
+    `for it. The signature above is the one a CoC wrapper must match exactly.`,
+  ].join('\n');
+}
+
+/** The `### CoC eligibility` body, plus the contract that is the reason this exists. */
+export function renderTableDataMethodEligibility(method: TableDataMethod, objectName: string): string {
+  return [
+    `✅ CoC-eligible — \`[ExtensionOf(tableStr(${objectName}))] final class …\` wrapping ` +
+    `\`${method.signature}\`.`,
+    `_${method.purpose}_`,
+    '',
+    `**Contract for \`${method.name}\`:**`,
+    ...method.contract.map(line => `- ${line}`),
+  ].join('\n');
+}

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -16,6 +16,7 @@
  *   COC003  [ExtensionOf] class name not ending _Extension
  *   COC004  next not reached exactly once and unconditionally (SYS10028)
  *   COC005  Global function (checkFailed/error/…) called as this.<fn>() on a table buffer
+ *   COC006  Re-reading the record the buffer already holds, instead of this.orig()
  *   BP001   Hardcoded string literal in info/warning/error/checkFailed
  *   BP002   doInsert/doUpdate/doDelete outside explicit migration comment
  *   BP003   Generic doc-comment (/// Foo class. / /// methodName.)
@@ -438,6 +439,82 @@ function checkGlobalFunctionOnTableBuffer(code: string): ValidationViolation[] {
           : '.'),
     });
   });
+
+  return violations;
+}
+
+/**
+ * COC006 — re-reading the record the buffer already holds, instead of `this.orig()`.
+ *
+ * Inside `[ExtensionOf(tableStr(X))]`, `this` IS the record: the current values are
+ * its fields and the values it was fetched with are `this.orig()`, a buffer already
+ * in memory. Fetching the row again by its own RecId buys nothing and costs a
+ * database round trip on every write of the table — and it is not even the same
+ * answer, because it reads the CURRENT stored state rather than this buffer's
+ * pre-image.
+ *
+ * It compiles, xppbp has nothing to say about it and the build is green, so
+ * nothing else in the toolchain reports it: SEL004 only sees a nested
+ * `while select`, and the rest of the set is about compile failures.
+ *
+ * `RecId == this.RecId` is the whole signal and it is self-identifying: RecIds are
+ * unique per table, so comparing another buffer's to this one's is only meaningful
+ * when the other buffer is this same record. The static-find spelling
+ * (`MyTable::findRecId(this.RecId)`) is the same defect and is matched too.
+ *
+ * severity 'warning' — the code runs and returns the right answer in the common
+ * case. It is a round trip and a semantic drift, not a broken build.
+ */
+function checkRecordReReadInTableCoc(code: string): ValidationViolation[] {
+  const violations: ValidationViolation[] = [];
+  if (!/\[ExtensionOf\s*\(\s*tableStr\s*\(/i.test(code)) return violations;
+
+  const masked = maskStringsAndComments(code);
+  const lines = code.split('\n');
+  const reported = new Set<number>();
+
+  const report = (offset: number, excerptSuffix: string, spelling: string) => {
+    const lineNo = lineNumber(masked, offset);
+    if (reported.has(lineNo)) return;
+    reported.add(lineNo);
+    violations.push({
+      rule: 'COC006',
+      severity: 'warning',
+      line: lineNo,
+      excerpt: lines[lineNo - 1]?.trim() ?? excerptSuffix,
+      fix:
+        `This re-reads the record the buffer already holds. Inside a table CoC, ${spelling} ` +
+        'the pre-image is `this.orig()` — already in memory, filled when the record was fetched — ' +
+        'and the new values are `this` itself. Compare `this.MyField` against `this.orig().MyField` ' +
+        'and delete the lookup: it costs a database round trip on every write of the table, and it ' +
+        'returns the CURRENT stored state, not the values this buffer was fetched with. ' +
+        'On an insert `this.orig()` is empty, so `this.orig().RecId == 0` is the "new record" test.',
+    });
+  };
+
+  // A select whose where clause ties another buffer's RecId to this one's. The
+  // where clause is usually on its own line, so the statement — up to its ';' or
+  // the '{' of a while select — is the unit to scan, not the line.
+  const selectRe = /\bselect\b/gi;
+  const sameRecId =
+    /(?:\w+\s*\.\s*RecId\s*==\s*this\s*\.\s*RecId)|(?:this\s*\.\s*RecId\s*==\s*\w+\s*\.\s*RecId)/i;
+  let m: RegExpExecArray | null;
+  while ((m = selectRe.exec(masked)) !== null) {
+    const semi = masked.indexOf(';', m.index);
+    const brace = masked.indexOf('{', m.index);
+    const ends = [semi, brace].filter(i => i !== -1);
+    const end = ends.length > 0 ? Math.min(...ends) : masked.length;
+    const span = masked.slice(m.index, end);
+    const hit = sameRecId.exec(span);
+    if (hit) report(m.index + hit.index, hit[0], 'a select on the same table is never the way to it —');
+  }
+
+  // The same fetch spelled as a static find.
+  const findRe = /\b\w+\s*::\s*find\w*\s*\(([^)]*)\)/gi;
+  while ((m = findRe.exec(masked)) !== null) {
+    if (!/\bthis\s*\.\s*RecId\b/i.test(m[1])) continue;
+    report(m.index, m[0], 'a find() on your own RecId is never the way to it —');
+  }
 
   return violations;
 }
@@ -1025,6 +1102,7 @@ const XPP_RULES = [
   checkExtensionOfNaming,
   checkCocNextUnconditional,
   checkGlobalFunctionOnTableBuffer,
+  checkRecordReReadInTableCoc,
   checkEnumSymbolInMessage,
   checkBuiltinArity,
   checkHardcodedStrings,

--- a/src/tools/knowledge/methodSignature.ts
+++ b/src/tools/knowledge/methodSignature.ts
@@ -17,6 +17,7 @@ import { parseXppDeclaration } from '../../metadata/xppDeclaration.js';
 import { canonicalSymbolName } from '../../utils/symbolLookup.js';
 import { inheritedOwnerCandidates } from '../../utils/inheritanceChain.js';
 import { indexedPathIsMissing, renderStaleIndexNote } from '../../utils/indexedXmlLookup.js';
+import { hasTableDataMethods, lookupTableDataMethod } from '../../knowledge/tableDataMethods.js';
 
 /** Object types that can own methods. */
 const OBJECT_TYPES = ['class', 'table', 'view', 'data-entity'] as const;
@@ -160,6 +161,32 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
         }],
         isError: true,
       };
+    }
+
+    // A table's data methods come from a kernel type with no AOT metadata, so
+    // every reader above misses them and the "not found" underneath would be
+    // false — for the single most common CoC target there is (see
+    // src/knowledge/tableDataMethods.ts).
+    if (!methodRow && hasTableDataMethods(classRow.type)) {
+      const inherited = lookupTableDataMethod(methodName);
+      if (inherited) {
+        return {
+          content: [{
+            type: 'text',
+            text:
+              `# Method: \`${className}.${inherited.name}\`\n` +
+              `**Model:** ${classRow.model}\n` +
+              `_Source: inherited from \`${inherited.declaredOn}\` — a kernel type with no AOT metadata, ` +
+              `so neither the index nor the bridge has a row for it._\n\n` +
+              '```xpp\n' +
+              `${inherited.signature}\n` +
+              '```\n\n' +
+              `${inherited.purpose}\n\n` +
+              `**Contract for \`${inherited.name}\`:**\n` +
+              inherited.contract.map(line => `- ${line}`).join('\n') + '\n',
+          }],
+        };
+      }
     }
 
     // Delegates and SubscribesTo handlers are commonly absent from the index.

--- a/src/tools/knowledge/xppKnowledge.ts
+++ b/src/tools/knowledge/xppKnowledge.ts
@@ -2282,7 +2282,8 @@ select salesTable where salesTable.ShippingDateRequested == cutoffDate;`,
   {
     id: 'coc-authoring',
     title: 'CoC Authoring Non-negotiables',
-    keywords: ['coc', 'chain of command', 'next', 'default parameter', 'wrappable', 'hookable', 'final', 'extensionof', 'wrapper', 'form coc', 'formdatasourcestr', 'static coc', 'replaceable', 'pre', 'post', 'wrap'],
+    keywords: ['coc', 'chain of command', 'next', 'default parameter', 'wrappable', 'hookable', 'final', 'extensionof', 'wrapper', 'form coc', 'formdatasourcestr', 'static coc', 'replaceable', 'pre', 'post', 'wrap',
+      'validatewrite', 'validatefield', 'validatedelete', 'modifiedfield', 'table coc', 'orig', 'pre-image', 'old value', 'xrecord'],
     summary:
       'Strict rules for authoring CoC wrappers. The most common mistake is copying default parameter values. ' +
       'next must always be called at first-level scope. Always use get_method(include="signature") before writing any wrapper.',
@@ -2299,6 +2300,8 @@ select salesTable where salesTable.ShippingDateRequested == cutoffDate;`,
       'Wrappers can read/call protected members of the augmented class (PU9+); cannot reach private',
       'Pre-processing: call business logic before next. Post-processing: call next first, then business logic. Wrap: call next inside the logic',
       'Use get_method(include="signature") tool to get exact parameter types before writing the wrapper',
+      'On a TABLE wrapper (validateWrite/validateField/update/delete/modifiedField) the record is already in hand: `this` carries the new values and `this.orig()` the values it was fetched with. NEVER re-read the row — no `select … where x.RecId == this.RecId`, no `MyTable::findRecId(this.RecId)`. That is a database round trip on every write and it returns the current stored state, not this buffer\'s pre-image. On an insert `this.orig()` is empty, so `this.orig().RecId == 0` is the "new record" test. Rule COC006 flags the re-read',
+      'The table data methods are declared by kernel types (xRecord/Common), so the symbol index has no row for them and "not found" there is not evidence they do not exist — prepare(mode="change") and get_method answer for them from a built-in contract instead',
       'REUSE BEFORE CREATING: if a CoC extension class for the target already exists in the custom model (prepare(mode="change") / extension_info(mode="coc") lists them), add the wrapper there — never create a parallel feature-named class (<Target>_<Feature>_Extension) unless the user explicitly requests separation',
       'The class suffix comes from EXTENSION_NAMING_STYLE and existing related artifacts — never from feature names, tickets, or customer names; if it cannot be derived, ask the user',
     ],
@@ -2339,7 +2342,10 @@ public void post()
 }`,
       },
     ],
-    related: ['coc', 'event-handlers', 'class-inheritance'],
+    // enum-conversions carries the worked validateWrite example (orig() + enum2Str
+    // + a label with placeholders). The link was one-directional, so a query about
+    // validateWrite reached these rules and never the example.
+    related: ['coc', 'event-handlers', 'class-inheritance', 'enum-conversions'],
   },
 
   // ── X++ Class & Method Rules ─────────────────────────────────────────────

--- a/src/tools/prepare/prepareChange.ts
+++ b/src/tools/prepare/prepareChange.ts
@@ -25,6 +25,12 @@ import { tryBridgeCocExtensions } from '../../bridge/bridgeAdapter.js';
 import { getConfigManager } from '../../utils/configManager.js';
 import { lookupSymbolNocase } from '../../utils/symbolLookup.js';
 import { findDeclaringAncestor } from '../../utils/inheritanceChain.js';
+import {
+  hasTableDataMethods,
+  lookupTableDataMethod,
+  renderTableDataMethodEligibility,
+  renderTableDataMethodSignature,
+} from '../../knowledge/tableDataMethods.js';
 import { renderPrepareOpSpec } from '../specs/opSpecs.js';
 import { rankContext, renderRankedContext } from '../../workspace/contextRanker.js';
 
@@ -131,6 +137,7 @@ function readMethodRow(
 async function fetchMethodSignature(
   objectName: string,
   methodName: string,
+  objectType: string | undefined,
   context: XppServerContext,
 ): Promise<string> {
   const found = readMethodRow(context, objectName, methodName);
@@ -151,6 +158,11 @@ async function fetchMethodSignature(
     }
     return lines.join('\n');
   }
+  // A table's data methods are declared by a kernel type, so "not in the index"
+  // is the normal answer for them rather than evidence that they do not exist.
+  const inherited = hasTableDataMethods(objectType) ? lookupTableDataMethod(methodName) : undefined;
+  if (inherited) return renderTableDataMethodSignature(inherited, objectName);
+
   return '(not found in symbol index)';
 }
 
@@ -198,6 +210,7 @@ async function fetchCocExtensions(
 async function fetchEligibility(
   objectName: string,
   methodName: string | undefined,
+  objectType: string | undefined,
   context: XppServerContext,
 ): Promise<string> {
   if (!methodName) return 'No specific method targeted — check base class documentation.';
@@ -222,6 +235,12 @@ async function fetchEligibility(
       `Either way the signature must match \`${owner}\`'s declaration exactly — the compiler validates against it and names \`${owner}\` in any mismatch error.`,
     ].join('\n');
   }
+  // Same fallback as the signature above, and the contract it carries is the
+  // point: this section is the last thing prepare says before the model writes
+  // the wrapper, so the pre-image rule belongs here rather than a topic away.
+  const inherited = hasTableDataMethods(objectType) ? lookupTableDataMethod(methodName) : undefined;
+  if (inherited) return renderTableDataMethodEligibility(inherited, objectName);
+
   return '(could not determine — method not found in symbol index)';
 }
 
@@ -331,10 +350,10 @@ export async function prepareChangeTool(request: any, context: XppServerContext)
   // Run all fact-gathering queries in parallel
   const [sigText, cocText, eligText, patternText, namingText] = await Promise.all([
     methodName
-      ? fetchMethodSignature(objectName, methodName, context)
+      ? fetchMethodSignature(objectName, methodName, resolvedType, context)
       : Promise.resolve(null as string | null),
     fetchCocExtensions(objectName, methodName, context),
-    fetchEligibility(objectName, methodName, context),
+    fetchEligibility(objectName, methodName, resolvedType, context),
     fetchPatterns(objectName, resolvedType, context),
     proposedName
       ? fetchNamingValidation(proposedName, context)

--- a/tests/tools/tableCocPreImage.test.ts
+++ b/tests/tools/tableCocPreImage.test.ts
@@ -1,0 +1,282 @@
+/**
+ * A table CoC that re-reads the record it already holds instead of reading
+ * `this.orig()`: COC006 flags it, and the two readers that answered "not found"
+ * for an inherited table method now answer with the signature and the contract.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runRules } from '../../src/tools/analysis/validateXpp';
+import { validateWrittenXpp } from '../../src/tools/write/inlineXppValidation';
+import { prepareChangeTool } from '../../src/tools/prepare/prepareChange';
+import { getMethodSignatureTool } from '../../src/tools/knowledge/methodSignature';
+import {
+  hasTableDataMethods,
+  lookupTableDataMethod,
+} from '../../src/knowledge/tableDataMethods';
+import type { XppServerContext } from '../../src/types/context';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+/** A wrapper that fetches its own row again. */
+const SHIPPED = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
+final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
+{
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+
+        if (ret)
+        {
+            AslFinCore_TaxTransReportChangeLog oldRecord;
+
+            select firstonly AslFinSK_QualityTier from oldRecord
+                where oldRecord.RecId == this.RecId;
+
+            if (oldRecord.RecId && this.AslFinSK_QualityTier < oldRecord.AslFinSK_QualityTier)
+            {
+                ret = checkFailed(strFmt("@AslFinSK:QualityTierDowngradeNotAllowed",
+                    enum2str(oldRecord.AslFinSK_QualityTier),
+                    enum2str(this.AslFinSK_QualityTier)));
+            }
+        }
+
+        return ret;
+    }
+}`;
+
+/** The same guard written against the pre-image. */
+const WITH_ORIG = `[ExtensionOf(tableStr(AslFinCore_TaxTransReportChangeLog))]
+final class AslFinCore_TaxTransReportChangeLogAslFinSK_Extension
+{
+    public boolean validateWrite()
+    {
+        boolean ret = next validateWrite();
+
+        if (ret
+            && this.RecId
+            && this.AslFinSK_QualityTier < this.orig().AslFinSK_QualityTier)
+        {
+            ret = checkFailed(strFmt(literalStr("@AslFinSK:QualityTierDowngradeNotAllowed"),
+                enum2str(this.orig().AslFinSK_QualityTier),
+                enum2str(this.AslFinSK_QualityTier)));
+        }
+
+        return ret;
+    }
+}`;
+
+describe('COC006 — the record is already in hand', () => {
+  const coc006 = (code: string) => runRules(code, 'xpp').filter(v => v.rule === 'COC006');
+
+  it('flags a select that fetches the buffer\'s own row', () => {
+    const found = coc006(SHIPPED);
+    expect(found).toHaveLength(1);
+    expect(found[0].severity).toBe('warning');
+    expect(found[0].fix).toContain('this.orig()');
+    // The where clause is on its own line — a per-line scan would miss it.
+    expect(found[0].excerpt).toContain('oldRecord.RecId == this.RecId');
+  });
+
+  it('accepts the same guard written against the pre-image', () => {
+    expect(coc006(WITH_ORIG)).toHaveLength(0);
+  });
+
+  it('flags the same fetch spelled as a static find', () => {
+    const viaFind = SHIPPED.replace(
+      `select firstonly AslFinSK_QualityTier from oldRecord
+                where oldRecord.RecId == this.RecId;`,
+      'oldRecord = AslFinCore_TaxTransReportChangeLog::findRecId(this.RecId);',
+    );
+    const found = coc006(viaFind);
+    expect(found).toHaveLength(1);
+    expect(found[0].excerpt).toContain('findRecId(this.RecId)');
+  });
+
+  it('leaves a select of a genuinely different record alone', () => {
+    // A related record fetched by a foreign key is not the buffer you hold.
+    const related = SHIPPED.replace(
+      'where oldRecord.RecId == this.RecId;',
+      'where oldRecord.Voucher == this.Voucher;',
+    );
+    expect(coc006(related)).toHaveLength(0);
+  });
+
+  it('leaves the insert/update guard alone', () => {
+    // `this.RecId` on its own says "am I an update" — only the comparison to
+    // ANOTHER buffer's RecId means a re-read.
+    expect(coc006(WITH_ORIG.replace('&& this.RecId', '&& this.RecId != 0'))).toHaveLength(0);
+  });
+
+  it('stays out of class CoC, where this is not a table buffer', () => {
+    expect(coc006(SHIPPED.replace('tableStr(', 'classStr('))).toHaveLength(0);
+  });
+
+  it('ignores the pattern inside a comment', () => {
+    expect(coc006(SHIPPED.replace(
+      '                where oldRecord.RecId == this.RecId;',
+      '                // where oldRecord.RecId == this.RecId;',
+    ))).toHaveLength(0);
+  });
+
+  it('rides along with the write, as a warning and not a build failure', () => {
+    const note = validateWrittenXpp(SHIPPED);
+    expect(note).toContain('COC006');
+    expect(note).toContain('warning(s)');
+    expect(note).not.toContain('error(s)');
+  });
+
+  it('says nothing about the pre-image version', () => {
+    expect(validateWrittenXpp(WITH_ORIG)).toBe('');
+  });
+});
+
+describe('the inherited table data methods', () => {
+  it('knows validateWrite, and answers case-insensitively as X++ does', () => {
+    expect(lookupTableDataMethod('validateWrite')?.signature).toBe('public boolean validateWrite()');
+    expect(lookupTableDataMethod('VALIDATEWRITE')?.name).toBe('validateWrite');
+  });
+
+  it('carries the pre-image rule on every method that has a pre-image', () => {
+    for (const name of ['validateWrite', 'validateField', 'update', 'modifiedField']) {
+      const contract = lookupTableDataMethod(name)!.contract.join(' ');
+      expect(contract).toContain('this.orig()');
+      expect(contract).toMatch(/do NOT re-read/i);
+    }
+  });
+
+  it('does not claim a pre-image on insert, where there is none', () => {
+    const insert = lookupTableDataMethod('insert')!.contract.join(' ');
+    expect(insert).toMatch(/no pre-image/i);
+  });
+
+  it('speaks for tables only', () => {
+    expect(hasTableDataMethods('table')).toBe(true);
+    expect(hasTableDataMethods('class')).toBe(false);
+    expect(hasTableDataMethods(undefined)).toBe(false);
+  });
+
+  it('has nothing to say about a method it does not know', () => {
+    expect(lookupTableDataMethod('promptAndRun')).toBeUndefined();
+  });
+});
+
+// ─── The two readers that answered "not found" ───────────────────────────────
+
+const emptyDb = () => ({
+  prepare: vi.fn(() => ({
+    all: vi.fn(() => []),
+    get: vi.fn(() => undefined),
+    run: vi.fn(),
+  })),
+});
+
+const prepareContext = (): XppServerContext => ({
+  symbolIndex: {
+    db: emptyDb(),
+    getReadDb: vi.fn(function (this: any) { return this.db; }),
+  } as any,
+  parser: {} as any,
+  cache: {} as any,
+  workspaceScanner: {} as any,
+  hybridSearch: {} as any,
+  bridge: undefined,
+} as any);
+
+describe('prepare(mode="change") on a table method the index cannot hold', () => {
+  const call = async (methodName: string, objectType = 'table') => {
+    const request: CallToolRequest = {
+      method: 'tools/call',
+      params: {
+        name: 'prepare_change',
+        arguments: {
+          goal: 'Block a QualityTier downgrade on write',
+          objectName: 'AslFinCore_TaxTransReportChangeLog',
+          objectType,
+          methodName,
+        },
+      },
+    };
+    const result: any = await prepareChangeTool(request, prepareContext());
+    return result.content?.[0]?.text ?? '';
+  };
+
+  it('answers with the signature instead of "(not found in symbol index)"', async () => {
+    const text = await call('validateWrite');
+    expect(text).toContain('public boolean validateWrite()');
+    expect(text).not.toContain('(not found in symbol index)');
+  });
+
+  it('answers eligibility instead of "could not determine"', async () => {
+    const text = await call('validateWrite');
+    expect(text).toContain('CoC-eligible');
+    expect(text).not.toContain('could not determine');
+  });
+
+  it('states the pre-image rule where the wrapper gets written', async () => {
+    const text = await call('validateWrite');
+    expect(text).toContain('this.orig()');
+    expect(text).toMatch(/do NOT re-read/i);
+  });
+
+  it('still says "not found" for a method nothing knows', async () => {
+    const text = await call('someBespokeMethod');
+    expect(text).toContain('(not found in symbol index)');
+  });
+
+  it('does not answer for a class, whose methods the index really does hold', async () => {
+    const text = await call('validateWrite', 'class');
+    expect(text).toContain('(not found in symbol index)');
+  });
+});
+
+describe('get_method(include="signature") on an inherited table method', () => {
+  const tableOwnerDb = () => ({
+    prepare: vi.fn((sql: string) => ({
+      all: vi.fn(() => []),
+      get: vi.fn(() =>
+        sql.includes('file_path, model, name, type')
+          ? {
+              file_path: 'K:/AosService/.../AslFinCore_TaxTransReportChangeLog.xml',
+              model: 'AslFinanceCore',
+              name: 'AslFinCore_TaxTransReportChangeLog',
+              type: 'table',
+            }
+          : undefined,
+      ),
+      run: vi.fn(),
+    })),
+  });
+
+  const context = () => ({
+    symbolIndex: {
+      db: tableOwnerDb(),
+      getReadDb: vi.fn(function (this: any) { return this.db; }),
+    },
+    parser: { parseClassFile: vi.fn(async () => ({ success: false })) },
+    bridge: undefined,
+  } as any as XppServerContext);
+
+  const call = async (methodName: string) => {
+    const request: CallToolRequest = {
+      method: 'tools/call',
+      params: {
+        name: 'get_method_signature',
+        arguments: { className: 'AslFinCore_TaxTransReportChangeLog', methodName },
+      },
+    };
+    return (await getMethodSignatureTool(request, context())) as any;
+  };
+
+  it('returns the signature and the contract, not a "not found" error', async () => {
+    const result = await call('validateWrite');
+    expect(result.isError).toBeFalsy();
+    const text = result.content?.[0]?.text ?? '';
+    expect(text).toContain('public boolean validateWrite()');
+    expect(text).toContain('this.orig()');
+    expect(text).toContain('xRecord');
+  });
+
+  it('leaves a genuinely missing method reporting missing', async () => {
+    const result = await call('someBespokeMethod');
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
Run `6da5e9d4` (12.8. 19:20) is the cheapest post-#903 run at **88.5 AIU / 51 tool calls / 8.3 min**, one full build, green, correct end state. It is also the first of twenty-one runs of that prompt to write `validateWrite` like this:

Instead of `this.orig()` — the pre-image already in memory. A database round trip on every write of a table the VAT report fills in batch, and the current stored state rather than the values the buffer was fetched with.

## Why it got through

The deterministic inputs were identical to the runs that got it right; the model drifted, and nothing was holding it.

- **`orig()` was never the server's.** Across all 25 sessions in the log, `orig()` appears in a tool RESULT only as an echo of code the agent had already written. `a616562b` and `7b8de4ba` carried it in the *query* (`get_knowledge(topic="coc-authoring table validateWrite orig()")`). It was model memory every single time.
- **`prepare` had nothing to say.** `prepare(mode="change", operation="add-method", methodName="validateWrite")` returns `(not found in symbol index)` for the signature, `(could not determine)` for CoC eligibility and `(no similar patterns found)` — because `validateWrite` is declared by `xRecord`/`Common`, kernel types with no AOT metadata. Byte-identical in `a616562b` and `81803f01`, which both produced `orig()`, so this is a permanent missing guardrail rather than a regression. `get_method(include="signature")`, which `coc-authoring` tells the caller to reach for next, returned a hard "not found" for the same reason.
- **The idiom was documented one door away.** The `enum-conversions` entry (#903) carries the worked example — `validateWrite` + `this.orig()` + `enum2Str` — and `related` pointed `enum-conversions → coc-authoring` but never back. The run wrote `enum2Str` correctly from memory, so it never asked the question that opens that door.
- **No rule covered it.** `validate_code(syntax)` answered "✅ no violations found, 17 rule groups". `SEL004` only sees a nested `while select`; everything else in the set is about compile failures.

## What changes

**1. `src/knowledge/tableDataMethods.ts` (new)** — the eight data methods every table inherits from `xRecord`/`Common`, each with the exact wrapper signature and the contract a green build cannot teach: the pre-image is `this.orig()`, never re-read the row, `this.orig().RecId == 0` is the insert test, `next` exactly once. A **fallback only** — consulted after index, bridge and XML have all missed, so a table that overrides `insert()` still reports its own signature. Tables only; views, maps and entities descend from `Common` too but do not all wrap through `tableStr`, and guessing there would be the failure this prevents.

Wired into `prepare(mode="change")` (both the signature and the eligibility section, the last thing prepare says before the wrapper gets written) and into `get_method(include="signature")`.

**2. `COC006` in `validateXpp.ts`** — a `select` whose where clause ties another buffer's RecId to this one's, or a `MyTable::findRecId(this.RecId)`, inside `[ExtensionOf(tableStr(…))]`. `RecId == this.RecId` is self-identifying: RecIds are unique per table, so the comparison is only meaningful when the other buffer is this same record. The **statement** is the unit scanned, not the line — the where clause is usually on its own line, which is exactly how this one was written. `severity: 'warning'`, because the code runs and is right in the common case; it rides on writes through `inlineXppValidation`, so the finding lands in the reply to the `d365fo_file` call.

**3. `coc-authoring` states the rule itself** — plus the fact that a table's data methods are declared by kernel types, so "not found in the index" is not evidence they do not exist. Both as *rules*, which is what survives the 5000-char response truncation; `related` gains `enum-conversions` so the worked example is one hop away, and the keywords gain the method names a caller actually types.

## Verification

- 21 new cases in `tests/tools/tableCocPreImage.test.ts`. Negatives: the same guard against the pre-image, a select of a genuinely different record by foreign key, the plain "am I an update" RecId guard, the same code under `classStr`, the whole thing commented out.
- Full suite **300 files / 3719 passed**, `tsc --noEmit` clean, `biome lint` clean.
- `npm run eval:coverage -- --check` ✅ (core 44/44) and `npm run eval:knowledge-audit` ✅ (287 references) — editing an entry's rules/`related` moves neither, so no regenerated artifacts in this PR.

## Not addressed here

The other finding from the same run: `validate_code(mode="references")` reported `unknown-field` for a field written 66 seconds earlier by a call that had answered "🔎 Symbol index updated in place". The agent confirmed the field with `get_object_info` and correctly overrode the validator — but the only red light in the whole run being false is its own problem, and a separate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
