### PR TITLE
Write extension_metadata on an incremental reindex, so a field added this session resolves

### DIFF
--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -30,6 +30,19 @@ export interface SymbolCounts {
   byType: Record<string, number>;
 }
 
+/** One extension_metadata row, as both the full build and a reindex write it. */
+export interface ExtensionMetadataRecord {
+  extensionName: string;
+  extensionType: string;
+  baseObjectName: string;
+  addedFields?: string[];
+  addedMethods?: string[];
+  addedIndexes?: string[];
+  cocMethods?: string[];
+  eventSubscriptions?: string[];
+  model: string;
+}
+
 export class XppSymbolIndex {
   public db: Database; // Public for direct pragma access in build scripts
   public labelsDb: Database; // Separate DB for labels (performance optimization)
@@ -3054,6 +3067,57 @@ export class XppSymbolIndex {
       } catch (error) {
         log.warn(`Skipped ${extensionType} ${file}: ${error instanceof Error ? error.message : error}`);
       }
+    }
+  }
+
+  /**
+   * Replace the extension_metadata row for a single extension.
+   *
+   * indexExtensions above is the full build's path and reads the extracted JSON;
+   * an incremental reindex has only the AOT file, and until it could write here
+   * an extension changed in-session was invisible to every reader keyed on
+   * base_object_name — resolve_references' field and method checks above all,
+   * which report an unknown identifier as an ERROR and, under
+   * GROUNDING_ENFORCE, refuse the write carrying it.
+   *
+   * Delete-then-insert: the table has no unique constraint, so the INSERT OR
+   * REPLACE the full build uses only ever appends. Keyed by name + type + model,
+   * which is what identifies one extension across a rebuild.
+   */
+  upsertExtensionMetadata(record: ExtensionMetadataRecord): void {
+    const json = (values: string[] | undefined): string | null =>
+      values && values.length > 0 ? JSON.stringify(values) : null;
+
+    this.db.transaction(() => {
+      this.removeExtensionMetadata(record.extensionName, record.extensionType, record.model);
+      this.db.prepare(`
+        INSERT INTO extension_metadata
+          (extension_name, extension_type, base_object_name, added_fields, added_methods,
+           added_indexes, coc_methods, event_subscriptions, model)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        record.extensionName,
+        record.extensionType,
+        record.baseObjectName,
+        json(record.addedFields),
+        json(record.addedMethods),
+        json(record.addedIndexes),
+        json(record.cocMethods),
+        json(record.eventSubscriptions),
+        record.model,
+      );
+    })();
+  }
+
+  /** Drop the extension_metadata row(s) for one extension. Returns rows removed. */
+  removeExtensionMetadata(extensionName: string, extensionType: string, model: string): number {
+    try {
+      return this.db.prepare(
+        `DELETE FROM extension_metadata
+         WHERE extension_name = ? AND extension_type = ? AND model = ?`,
+      ).run(extensionName, extensionType, model).changes;
+    } catch {
+      return 0;
     }
   }
 

--- a/src/tools/sdlc/updateSymbolIndex.ts
+++ b/src/tools/sdlc/updateSymbolIndex.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { XppMetadataParser } from '../../metadata/xmlParser.js';
+import { XppMetadataParser, buildClassExtensionRecord } from '../../metadata/xmlParser.js';
 import { parseLabelFile } from '../../metadata/labelParser.js';
 import type { XppServerContext } from '../../types/context.js';
 import type { XppSymbol } from '../../metadata/types.js';
@@ -64,6 +64,18 @@ const AOT_FOLDER_TYPE_MAP: Record<string, XppSymbol['type']> = {
  */
 /** Any AOT element folder, mapped or not (AxMenu, AxWorkflowType, …). */
 const AOT_FOLDER_PATTERN = /^ax[a-z]/i;
+
+/**
+ * The types that own an extension_metadata row, taken from the map above so a
+ * new Ax*Extension folder cannot be added without one.
+ *
+ * class-extension is deliberately absent: the AOT has no AxClassExtension
+ * artifact, so a class extension arrives as an AxClass file and is recognised by
+ * its [ExtensionOf] attribute in the class branch instead.
+ */
+const EXTENSION_OBJECT_TYPES = new Set<string>(
+  Object.values(AOT_FOLDER_TYPE_MAP).filter(t => t.endsWith('-extension')),
+);
 
 /** True for an AOT element folder segment — mapped types plus everything else Ax*. */
 export function isAotFolder(segment: string): boolean {
@@ -303,6 +315,37 @@ async function refreshOnly(context: XppServerContext) {
  * update_symbol_index — which was the last legitimate mid-task reason to call
  * that tool at all.
  */
+/**
+ * Refresh the extension_metadata row for one Ax*Extension file.
+ *
+ * Returns the identity the caller needs for the symbol row, or null when the
+ * file does not parse as an extension — in which case the caller falls back to
+ * the bare object row, which is what every extension used to get.
+ */
+async function reindexExtensionMetadata(
+  filePath: string,
+  objectType: string,
+  model: string,
+  symbolIndex: XppServerContext['symbolIndex'],
+  parser: XppMetadataParser,
+): Promise<{ name: string; baseObjectName: string } | null> {
+  const parsed = await parser.parseExtensionFile(filePath, objectType);
+  if (!parsed.success || !parsed.data?.name) return null;
+  const data = parsed.data;
+  symbolIndex.upsertExtensionMetadata?.({
+    extensionName: data.name,
+    extensionType: objectType,
+    baseObjectName: data.baseObjectName,
+    addedFields: data.addedFields,
+    addedMethods: data.addedMethods,
+    addedIndexes: data.addedIndexes,
+    cocMethods: data.cocMethods,
+    eventSubscriptions: data.eventSubscriptions,
+    model,
+  });
+  return { name: data.name, baseObjectName: data.baseObjectName };
+}
+
 export async function indexOneFile(
   filePath: string,
   context: XppServerContext,
@@ -328,6 +371,17 @@ export async function indexOneFile(
       // 2. Remove labels from labels DB (label files live alongside XML)
       const labelCount = symbolIndex.removeLabelsByFile(filePath);
 
+      // 2b. extension_metadata is keyed by name + type + model, not by path, so
+      // removeSymbolsByFile above cannot reach it. Both spellings are tried
+      // because a class extension is an AxClass file; each is a no-op when the
+      // row is not there.
+      const deletedModel = extractModelFromPath(filePath) ?? 'Unknown';
+      const metaCount =
+        (symbolIndex.removeExtensionMetadata?.(objectName, objectType, deletedModel) ?? 0) +
+        (objectType === 'class'
+          ? (symbolIndex.removeExtensionMetadata?.(objectName, 'class-extension', deletedModel) ?? 0)
+          : 0);
+
       // The bridge refresh that stops it seeing the deleted file is the caller's
       // per-batch one.
       symbolIndex.touchLastIndexed?.();
@@ -335,6 +389,7 @@ export async function indexOneFile(
       const parts_cleaned: string[] = [];
       if (deletedCount > 0) parts_cleaned.push(`${deletedCount} symbol(s)`);
       if (labelCount > 0) parts_cleaned.push(`${labelCount} label(s)`);
+      if (metaCount > 0) parts_cleaned.push(`${metaCount} extension record(s)`);
       const summary = parts_cleaned.length > 0 ? parts_cleaned.join(' + ') : 'no stale entries found';
 
       return ok(`🗑️ File deleted — cleaned up ${summary} for **${objectName}** (${objectType}).`);
@@ -452,6 +507,23 @@ export async function indexOneFile(
           }
         });
         insert();
+        // A class carrying [ExtensionOf(...)] is also an extension — the AOT has
+        // no separate artifact for one — and resolveReferences resolves an
+        // extension-added or CoC-wrapped method through extension_metadata.
+        const extension = buildClassExtensionRecord(classData, model);
+        if (extension) {
+          symbolIndex.upsertExtensionMetadata?.({
+            extensionName: extension.name,
+            extensionType: 'class-extension',
+            baseObjectName: extension.baseObjectName,
+            addedFields: extension.addedFields,
+            addedMethods: extension.addedMethods,
+            addedIndexes: extension.addedIndexes,
+            cocMethods: extension.cocMethods,
+            eventSubscriptions: extension.eventSubscriptions,
+            model,
+          });
+        }
       } else {
         // Fallback: just index the object name
         tx();
@@ -605,7 +677,27 @@ export async function indexOneFile(
       } else {
         tx();
       }
-    } else if (objectType === 'form' || objectType === 'form-extension') {
+    } else if (EXTENSION_OBJECT_TYPES.has(objectType)) {
+      // One branch for every Ax*Extension kind, form extensions included: they
+      // differ only in which tag holds the added members, which
+      // parseExtensionFile already knows. The symbol row carries the base object
+      // the way the full build writes it, so the two paths agree.
+      const extension = await reindexExtensionMetadata(filePath, objectType, model, symbolIndex, parser);
+      if (extension) {
+        symbolIndex.addSymbol({
+          name: extension.name,
+          type: objectType,
+          parentName: extension.baseObjectName || undefined,
+          extendsClass: extension.baseObjectName || undefined,
+          signature: extension.baseObjectName || undefined,
+          filePath,
+          model,
+        });
+        insertedCount++;
+      } else {
+        tx();
+      }
+    } else if (objectType === 'form') {
       const result = await parser.parseFormFile(filePath, model);
       if (result.success && result.data) {
         const formData = result.data as any;

--- a/tests/tools/extensionMetadataIncremental.test.ts
+++ b/tests/tools/extensionMetadataIncremental.test.ts
@@ -1,0 +1,211 @@
+/**
+ * An extension reindexed from its AOT file must land in extension_metadata, the
+ * way the full build writes it.
+ *
+ * Only the full pipeline used to write that table, so a field added to a table
+ * extension — or a method added to a CoC class — was invisible to every reader
+ * keyed on base_object_name until the next rebuild. resolve_references reports
+ * such an identifier as an ERROR, and under GROUNDING_ENFORCE that error refuses
+ * the write carrying it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { indexOneFile } from '../../src/tools/sdlc/updateSymbolIndex';
+import { resolveXppReferences, type ResolverDeps } from '../../src/tools/write/resolveReferences';
+
+const MODEL = 'ContosoExt';
+const BASE_TABLE = 'ContosoOrderLog';
+
+const TABLE_EXTENSION_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxTableExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>${BASE_TABLE}.ContosoExtension</Name>
+	<Fields>
+		<AxTableField i:type="AxTableFieldEnum">
+			<Name>Contoso_QualityTier</Name>
+			<EnumType>Contoso_QualityTier</EnumType>
+		</AxTableField>
+	</Fields>
+</AxTableExtension>`;
+
+const COC_CLASS_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>${BASE_TABLE}Contoso_Extension</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+[ExtensionOf(tableStr(${BASE_TABLE}))]
+final class ${BASE_TABLE}Contoso_Extension
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>validateWrite</Name>
+				<Source><![CDATA[
+    public boolean validateWrite()
+    {
+        return next validateWrite();
+    }
+]]></Source>
+			</Method>
+			<Method>
+				<Name>contosoTierRank</Name>
+				<Source><![CDATA[
+    public int contosoTierRank()
+    {
+        return 0;
+    }
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>`;
+
+/** A wrapper reading the field the extension adds. */
+const USES_FIELD = `[ExtensionOf(tableStr(${BASE_TABLE}))]
+final class ${BASE_TABLE}Contoso_Extension
+{
+    public boolean validateWrite()
+    {
+        ${BASE_TABLE} rec;
+        boolean ret = next validateWrite();
+
+        if (rec.Contoso_QualityTier)
+        {
+            ret = false;
+        }
+
+        return ret;
+    }
+}`;
+
+/** The same, calling the method the CoC class adds. */
+const USES_METHOD = USES_FIELD.replace('rec.Contoso_QualityTier', 'rec.contosoTierRank()');
+
+let tmpDir: string;
+let tableExtensionFile: string;
+let cocClassFile: string;
+let index: XppSymbolIndex;
+let deps: ResolverDeps;
+
+const write = async (aotFolder: string, fileName: string, xml: string): Promise<string> => {
+  const dir = path.join(tmpDir, MODEL, aotFolder);
+  await fs.mkdir(dir, { recursive: true });
+  const file = path.join(dir, fileName);
+  await fs.writeFile(file, xml, 'utf-8');
+  return file;
+};
+
+const reindex = (file: string) => indexOneFile(file, { symbolIndex: index } as any);
+
+const errorsFor = (code: string, kind: string) =>
+  resolveXppReferences(code, deps).violations.filter(v => v.kind === kind);
+
+const metadataRows = (extensionType: string) =>
+  index.getReadDb().prepare(
+    `SELECT extension_name, base_object_name, added_fields, added_methods, coc_methods
+     FROM extension_metadata WHERE extension_type = ?`,
+  ).all(extensionType) as Array<Record<string, string | null>>;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xpp-ext-meta-'));
+  tableExtensionFile = await write('AxTableExtension', `${BASE_TABLE}.ContosoExtension.xml`, TABLE_EXTENSION_XML);
+  cocClassFile = await write('AxClass', `${BASE_TABLE}Contoso_Extension.xml`, COC_CLASS_XML);
+
+  index = new XppSymbolIndex(':memory:', ':memory:');
+  // The base table, as a full build of the shared model left it.
+  index.addSymbol({ name: BASE_TABLE, type: 'table', filePath: 'K:\\base\\ContosoOrderLog.xml', model: 'ContosoBase' });
+  index.addSymbol({
+    name: 'Voucher', type: 'field', parentName: BASE_TABLE,
+    filePath: 'K:\\base\\ContosoOrderLog.xml', model: 'ContosoBase',
+  });
+
+  deps = {
+    db: index.getReadDb(),
+    getLabelById: () => [],
+    getLabelFileIds: () => [],
+  };
+});
+
+afterAll(async () => {
+  index.close();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('a table extension reindexed from its file', () => {
+  it('starts out unable to resolve the field — the state this fixes', () => {
+    expect(errorsFor(USES_FIELD, 'unknown-field')).toHaveLength(1);
+  });
+
+  it('resolves the field once the file has been reindexed', async () => {
+    const result = await reindex(tableExtensionFile);
+    expect(result.isError).toBe(false);
+    expect(errorsFor(USES_FIELD, 'unknown-field')).toHaveLength(0);
+  });
+
+  it('writes one row carrying the base object and the added field', () => {
+    const rows = metadataRows('table-extension');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].extension_name).toBe(`${BASE_TABLE}.ContosoExtension`);
+    expect(rows[0].base_object_name).toBe(BASE_TABLE);
+    expect(JSON.parse(rows[0].added_fields as string)).toEqual(['Contoso_QualityTier']);
+  });
+
+  it('replaces that row rather than appending on every reindex', async () => {
+    await reindex(tableExtensionFile);
+    await reindex(tableExtensionFile);
+    expect(metadataRows('table-extension')).toHaveLength(1);
+  });
+
+  it('records the base object on the symbol row too, as the full build does', () => {
+    const row = index.getReadDb().prepare(
+      `SELECT parent_name, extends_class FROM symbols WHERE type = 'table-extension' AND name = ?`,
+    ).get(`${BASE_TABLE}.ContosoExtension`) as { parent_name: string; extends_class: string } | undefined;
+    expect(row?.parent_name).toBe(BASE_TABLE);
+    expect(row?.extends_class).toBe(BASE_TABLE);
+  });
+});
+
+describe('a CoC class reindexed from its file', () => {
+  it('starts out unable to resolve the method it adds', () => {
+    expect(errorsFor(USES_METHOD, 'unknown-method')).toHaveLength(1);
+  });
+
+  it('resolves it once the class has been reindexed', async () => {
+    const result = await reindex(cocClassFile);
+    expect(result.isError).toBe(false);
+    expect(errorsFor(USES_METHOD, 'unknown-method')).toHaveLength(0);
+  });
+
+  it('reads the base object off [ExtensionOf], and tells a wrapper from an addition', () => {
+    const rows = metadataRows('class-extension');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].base_object_name).toBe(BASE_TABLE);
+    expect(JSON.parse(rows[0].added_methods as string)).toEqual(['validateWrite', 'contosoTierRank']);
+    // Only the one that calls next is a wrapper.
+    expect(JSON.parse(rows[0].coc_methods as string)).toEqual(['validateWrite']);
+  });
+
+  it('leaves a plain class out of extension_metadata', async () => {
+    const plain = await write('AxClass', 'ContosoPlainHelper.xml', COC_CLASS_XML
+      .replace(`${BASE_TABLE}Contoso_Extension`, 'ContosoPlainHelper')
+      .replace(`[ExtensionOf(tableStr(${BASE_TABLE}))]\n`, ''));
+    await reindex(plain);
+    expect(metadataRows('class-extension')).toHaveLength(1);
+  });
+});
+
+describe('an extension whose file is gone', () => {
+  it('takes its extension_metadata row with it', async () => {
+    await fs.rm(tableExtensionFile);
+    const result = await reindex(tableExtensionFile);
+
+    expect(result.isError).toBe(false);
+    expect(result.text).toContain('extension record(s)');
+    expect(metadataRows('table-extension')).toHaveLength(0);
+    expect(errorsFor(USES_FIELD, 'unknown-field')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
In run `6da5e9d4`, `validate_code(mode="references")` reported this 66 seconds after the write that added the field:

The write that added it had answered `🔎 Symbol index updated in place — no update_symbol_index call needed`.

## Why

`extension_metadata` had exactly one writer: `indexExtensions`, reading the JSON that `extract-metadata` produces. The incremental indexer never wrote to it — and had no branch for an `Ax*Extension` file either, so `table-extension`, `enum-extension`, `edt-extension` and the rest fell through the closing `else` of `indexOneFile` into a single bare object row. No fields, no base object, no metadata. Reindexing the file again changed nothing.

That is the table `resolveReferences` resolves extension members through:

- `fieldExists` → `extension_metadata.added_fields` for `table-extension`
- `findMethod` → `added_methods` / `coc_methods` for any extension

So nothing written in the session could be resolved, and an unresolvable identifier is an **error**.

## What it costs

**With `GROUNDING_ENFORCE=true` the write is refused.** `gateOnReferenceErrors` runs the same resolver over the source of a `create` or a `modify` and returns `isError` before anything reaches disk. So "add a field to a table extension, then write the CoC that reads it" — the shape of nearly every extension task — cannot complete, and the message tells the caller to fix identifiers that are already correct. There is no way through short of a full rebuild.

**With it off** (the benchmark's setting) it is one false error. In `6da5e9d4` that was one round trip and a `get_object_info` to disprove it, ~2.5 AIU. The lasting cost is what it teaches: the only red light in that whole run was the false one, and the correct response was to override it.

## What changes

`indexOneFile` gets one branch for every `Ax*Extension` kind, form extensions included — `parseExtensionFile` already knows which tag each of them keeps its members in. The symbol row now carries the base object in `parent_name` / `extends_class` / `signature` the way `indexExtensions` writes it, so the incremental and full paths agree instead of producing two different rows for the same file.

A class carrying `[ExtensionOf(...)]` is an extension too — the AOT has no `AxClassExtension` artifact — so the class branch feeds `buildClassExtensionRecord`, the helper extraction already uses, into the same upsert. That is what makes a CoC wrapper written this session resolvable, and what lets `extension_info(mode="coc")` see it.

Deleting a file now clears its row as well: `extension_metadata` is keyed by name + type + model, not by path, so `removeSymbolsByFile` could never reach it.

`upsertExtensionMetadata` deletes before inserting. The table has no unique constraint, so the full build's `INSERT OR REPLACE` only ever appends — harmless there because `clearModels` runs first, wrong for an in-place update. Both new calls are optional-chained like `touchLastIndexed` beside them: the create path threads a narrowed context, and a lint of the index must never turn a successful write into a failure.

## Verification

`tests/tools/extensionMetadataIncremental.test.ts` — 10 cases against a real in-memory `XppSymbolIndex` and real files on disk, since the bug lived in the seam between the two.

Each pair asserts the before state as well as the after: the field and the added method are unresolvable first, resolve once `indexOneFile` has run, and are unresolvable again once the file is deleted. Plus: three reindexes leave one row, the symbol row carries the base object, `[ExtensionOf]` is what separates a class extension from a plain class, and only the method calling `next` is recorded as a wrapper.

Full suite **300 files / 3708 passed**, `tsc --noEmit` and `biome lint` clean.

## Relationship to #909

Independent — different files, no conflict. #909 is the missing guardrail that let a non-idiomatic `validateWrite` through; this one is the false alarm that fired at the same moment in the same run. This is the one that blocks a write, so it is the one to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
