### PR TITLE
fix(class-info): tell callers when method bodies were withheld by compact default

### DIFF
--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -275,6 +275,16 @@ function formatClass(cls: BridgeClassInfo, compact: boolean, methodOffset: numbe
     out += `> ⚠️ **${total - methodOffset - CLASS_METHOD_PAGE_SIZE} more methods.** Call again with \`methodOffset: ${methodOffset + CLASS_METHOD_PAGE_SIZE}\`.\n\n`;
   }
 
+  // compact=true is the default, and this list is the only place a caller who
+  // didn't read the tool schema learns that bodies exist but were withheld —
+  // the DB-only fallback (classInfo.ts buildDbOnlyResponse) already says this;
+  // the bridge path (the primary, "always available on VM" path) silently gave
+  // signatures with no pointer to the escape hatch, which read as "no source
+  // available for this class" when it was really "not requested".
+  if (compact && total > 0) {
+    out += `> 💡 Signatures only. Pass \`options:{"compact":false}\` for method bodies, or \`options:{"method":"<name>","include":"source"}\` for one method.\n\n`;
+  }
+
   return out;
 }
 


### PR DESCRIPTION
The bridge-backed class reader (the primary path — always available on VM) rendered compact=true output as a bare signature list with no indication that method source exists but wasn't requested, unlike the DB-only fallback path which already carries this hint. That silence read as "no source available for this class" (especially confusing for standard Microsoft classes, where users have no XML fallback to check against), when the actual fix is passing options:{compact:false} or options:{method,include:"source"}.