### PR TITLE
perf(search): bound the zero-row LIKE fallback from #912 to queries it can answer

### DIFF
--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -1463,8 +1463,17 @@ export class XppSymbolIndex {
    * Search symbols by query with full-text search
    * PERFORMANCE: Only select essential columns (name, type, parent_name, signature, model, file_path)
    * Uses prepared statement caching for common queries
+   *
+   * `opts.substringFallback: false` keeps the search strictly on the FTS index —
+   * see substringScanIsWorthIt() for what the fallback costs and why hot,
+   * non-user-facing callers opt out of it.
    */
-  searchSymbols(query: string, limit: number = 20, types?: string[]): XppSymbol[] {
+  searchSymbols(
+    query: string,
+    limit: number = 20,
+    types?: string[],
+    opts?: { substringFallback?: boolean }
+  ): XppSymbol[] {
     const ftsQuery = this.sanitizeFtsQuery(query);
     const cacheKey = types?.length ? `search_typed_${types.join('_')}` : 'search_all';
     
@@ -1491,8 +1500,11 @@ export class XppSymbolIndex {
       // matches token PREFIXES, so a mid-token substring query (e.g. "CategoryPropert"
       // against "ProcurementProductCategoryPropertyEntity") is a syntactically valid
       // query that legitimately returns zero rows. Fall back to LIKE in that case too,
-      // not only when FTS5 throws a syntax error.
+      // not only when FTS5 throws a syntax error — but only where that scan can pay
+      // for itself, since unlike the syntax-error path this one is reachable on every
+      // ordinary miss.
       if (rows.length > 0) return rows;
+      if (opts?.substringFallback === false || !this.substringScanIsWorthIt(query)) return rows;
       return this.likeFallbackSearch(db, query, limit, types);
     } catch {
       // FTS5 syntax error (e.g. user typed *, ", (, ), -) — fall back to LIKE contains search
@@ -1501,8 +1513,35 @@ export class XppSymbolIndex {
   }
 
   /**
+   * Is a leading-wildcard LIKE scan justified for this query?
+   *
+   * `name LIKE '%q%'` cannot use idx_symbols_name — SQLite scans the whole index
+   * (measured: 1.19M rows, ~300 ms warm and far worse cold, versus ~1 ms for the
+   * FTS miss it follows), synchronously, on exactly the path an agent hits when it
+   * guesses a name wrong. The syntax-error fallback could afford that because it
+   * was rare; the zero-row fallback happens on every ordinary miss, so it is only
+   * taken where it can actually return something:
+   *   - an empty query would match the entire corpus (LIKE '%%') and answer a
+   *     no-hit search with an arbitrary alphabetical slice of the index,
+   *   - a query containing whitespace can never match a symbol name, so the scan
+   *     is guaranteed to come back empty (contextRanker joins intent tokens with
+   *     spaces and would pay it on every miss),
+   *   - one or two characters are too unselective to be a useful substring probe.
+   *
+   * Known limitation: the fallback only fires when FTS returns *nothing*, so one
+   * incidental hit (e.g. query "Propert" matching PropertyType by prefix) still
+   * hides the mid-token matches. Widening it to "fewer rows than limit" would put
+   * the scan back on the common path, which is the cost this guard exists to avoid.
+   */
+  private substringScanIsWorthIt(query: string): boolean {
+    const trimmed = query.trim();
+    return trimmed.length >= 3 && !/\s/.test(trimmed);
+  }
+
+  /**
    * LIKE-based contains search used as a fallback when FTS5 either throws
-   * (syntax error) or returns no rows (valid query, prefix-only tokenizer miss).
+   * (syntax error) or returns no rows (valid query, prefix-only tokenizer miss —
+   * gated by substringScanIsWorthIt, which documents what this scan costs).
    * PERFORMANCE: Only select essential columns, not s.* (avoids loading large text fields)
    */
   private likeFallbackSearch(db: Database, query: string, limit: number, types?: string[]): XppSymbol[] {
@@ -1517,7 +1556,9 @@ export class XppSymbolIndex {
         .replace(/\\/g, '\\\\')
         .replace(/[%_]/g, '\\$&');
     };
-    const fallbackParams: any[] = [`%${escapeLikePattern(query)}%`];
+    // Trimmed: no symbol name starts or ends with whitespace, so padding in the
+    // raw query would only ever turn a real match into a miss.
+    const fallbackParams: any[] = [`%${escapeLikePattern(query.trim())}%`];
     if (types && types.length > 0) {
       fallbackSql += ` AND s.type IN (${types.map(() => '?').join(',')})`;
       fallbackParams.push(...types);
@@ -3486,8 +3527,9 @@ export class XppSymbolIndex {
    * custom hits back in, ranked directly after exact-name matches.
    *
    * Index-safe: the FTS5 MATCH drives the query and the `model IN (...)` filter
-   * (idx_symbols_model) narrows to the small custom set. The LIKE fallback (only
-   * reached on an FTS5 syntax error) is also model-scoped, so the selective
+   * (idx_symbols_model) narrows to the small custom set. The LIKE fallback here is
+   * still reached only on an FTS5 syntax error — unlike searchSymbols, this method
+   * has no zero-row fallback — and it is model-scoped either way, so the selective
    * `model IN` predicate keeps it off a full `%query%` scan of the whole corpus.
    */
   searchCustomModelSymbols(query: string, types?: string[], limit: number = 15): XppSymbol[] {

--- a/src/workspace/contextRanker.ts
+++ b/src/workspace/contextRanker.ts
@@ -118,12 +118,17 @@ export function rankContext(
     });
   };
 
+  // substringFallback: false — this runs on every proactive-context call, and a miss
+  // here (an object not in the index yet, which is the normal state for something the
+  // user just created) would otherwise pay a full ~1.2M-row LIKE scan for candidates
+  // that ranking treats as optional anyway.
+  const ftsOnly = { substringFallback: false };
   try {
     if (tokens.length > 0) {
-      addList(context.symbolIndex.searchSymbols(tokens.join(' '), CANDIDATE_POOL, input.types));
+      addList(context.symbolIndex.searchSymbols(tokens.join(' '), CANDIDATE_POOL, input.types, ftsOnly));
     }
     if (input.activeObject?.name) {
-      addList(context.symbolIndex.searchSymbols(input.activeObject.name, 20, input.types));
+      addList(context.symbolIndex.searchSymbols(input.activeObject.name, 20, input.types, ftsOnly));
     }
   } catch {
     // Index unavailable — return an empty, well-formed result.

--- a/tests/metadata/symbolIndex-substringFallback.test.ts
+++ b/tests/metadata/symbolIndex-substringFallback.test.ts
@@ -1,18 +1,39 @@
 /**
  * searchSymbols LIKE fallback on a zero-row FTS5 result (not just a thrown
- * syntax error).
+ * syntax error), and the guard that keeps that fallback off the queries it
+ * cannot answer.
  *
  * Regression: FTS5's default tokenizer treats each symbol name as one
  * indivisible token and only matches token PREFIXES. A mid-token substring
  * query (e.g. "CategoryPropert" against "ProcurementProductCategoryPropertyEntity")
  * is a syntactically valid FTS5 query that legitimately returns zero rows —
  * so the LIKE fallback must also trigger there, not only when FTS5 throws.
+ *
+ * The other half is cost: `name LIKE '%q%'` cannot use idx_symbols_name, so it
+ * scans the whole index (1.19M rows, ~300 ms warm on the production DB) and the
+ * zero-row path is reachable on every ordinary miss. The scan must therefore be
+ * skipped whenever it provably cannot match — asserted here by spying on the
+ * statement cache, since a guarded and an unguarded miss both return [].
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
 
 let index: XppSymbolIndex;
+
+/** Statement-cache keys likeFallbackSearch prepares under; nothing else uses them. */
+const isFallbackKey = (key: string) => key.startsWith('fallback_');
+
+/** Run `fn` and report whether it reached the LIKE fallback statement. */
+function scanned(fn: () => unknown): boolean {
+  const spy = vi.spyOn(index, 'getReadStmt');
+  try {
+    fn();
+    return spy.mock.calls.some(([, key]) => isFallbackKey(key as string));
+  } finally {
+    spy.mockRestore();
+  }
+}
 
 beforeAll(() => {
   index = new XppSymbolIndex(':memory:', ':memory:');
@@ -30,5 +51,32 @@ describe('searchSymbols substring fallback', () => {
     const names = index.searchSymbols('CategoryPropert', 20).map(s => s.name);
 
     expect(names).toContain('ProcurementProductCategoryPropertyEntity');
+  });
+
+  it('answers an empty query with nothing, not an alphabetical slice of the index', () => {
+    // LIKE '%%' matches every row, so an unguarded fallback turns "no query" into
+    // "here are the first N symbols alphabetically" — and skips the caller's
+    // no-results/"did you mean" path.
+    expect(index.searchSymbols('', 20)).toEqual([]);
+    expect(index.searchSymbols('   ', 20)).toEqual([]);
+  });
+
+  it('does not scan for a query containing whitespace — no name can contain one', () => {
+    expect(scanned(() => index.searchSymbols('procurement category propert', 20))).toBe(false);
+  });
+
+  it('does not scan for a query too short to be a useful substring probe', () => {
+    expect(scanned(() => index.searchSymbols('Ca', 20))).toBe(false);
+  });
+
+  it('does not scan when the caller opts out, even for a query that would match', () => {
+    expect(
+      scanned(() => index.searchSymbols('CategoryPropert', 20, undefined, { substringFallback: false }))
+    ).toBe(false);
+    expect(index.searchSymbols('CategoryPropert', 20, undefined, { substringFallback: false })).toEqual([]);
+  });
+
+  it('still scans for a plain single-token miss', () => {
+    expect(scanned(() => index.searchSymbols('CategoryPropert', 20))).toBe(true);
   });
 });


### PR DESCRIPTION
Follow-up to #912 (merged). That PR's fix is right; this one bounds what the path it opened costs. Rebased onto `main` after the merge, so it is now a single commit on top of it.

## Why the follow-up

#912's diagnosis is correct: FTS5's default tokenizer indexes each symbol name as one indivisible token and only matches token prefixes, so `CategoryPropert` against `ProcurementProductCategoryPropertyEntity` is a syntactically valid query that legitimately returns zero rows. Falling back to LIKE there is the right fix, and its regression test is a real one (it fails on `main`).

The problem is the cost of the path it opens. `name LIKE '%q%'` cannot use `idx_symbols_name`, so SQLite does `SCAN s USING INDEX idx_symbols_name` over the whole table. Until now that only happened on an FTS5 syntax error, which is rare; the zero-row branch happens on *every* ordinary miss — which is exactly what an agent produces when it guesses a name wrong. It is the same cost `getAllSymbolNames` was rewritten to avoid (see its doc comment: "SQLite scans all 1.17M rows, synchronously, on exactly the path an agent hits when it guessed a name wrong, which it does routinely").

Measured against the production index (`data/xpp-metadata.db`, 2.5 GB, 1,188,690 symbols):

| query | FTS | LIKE fallback, no type filter |
|---|---|---|
| `CategoryPropert` (the PR's example) | 1.1 ms | **317 ms** |
| `zzqqxxnope` (typo, no match at all) | 0.4 ms | **276 ms** |
| `sales order posting` | 49.8 ms | **307 ms** |
| first scan after start, cold page cache | — | **154 s** (measured once) |

The call is synchronous (`node:sqlite`), so it blocks the server. The search tool's default is `type='all'` → `types=undefined` → the unfiltered variant above; with a type filter the planner can use `idx_type_name` and the same scan costs ~25 ms.

## What this adds

**A guard on the zero-row branch only** (the syntax-error branch is untouched). The scan is taken only when it can actually return something:

- **empty query** — `LIKE '%%'` matches the entire corpus, so `searchSymbols('')` went from `[]` to the first 20 symbols alphabetically (`-SYSADMIN-`, `A`, `AAAllowPurchase`, …), which also skips the caller's no-results/"did you mean" path. The tool schema is `z.string()` with no `.min(1)`, so this is reachable from a caller.
- **query containing whitespace** — no symbol name contains one, so the scan is guaranteed to return nothing. `contextRanker` passes `tokens.join(' ')`, so it paid this on every intent miss.
- **one or two characters** — too unselective to be a useful substring probe.

**An opt-out for hot, non-user-facing callers**: `searchSymbols(query, limit, types, { substringFallback: false })`. The default stays on, so `search.ts` and `hybridSearch.ts` keep #912's fix unchanged. `contextRanker` opts out — it runs on every proactive-context call, and an active object that is not in the index yet (the normal state for something the user just created) would otherwise pay the full scan every time.

Also: the LIKE pattern is now built from the trimmed query, and the `searchCustomModelSymbols` doc comment is corrected — it still asserted the invariant "LIKE fallback (only reached on an FTS5 syntax error)", which #912 made untrue for the sibling method.

## Known limitation, deliberately kept

The fallback fires only when FTS returns *nothing*, so a single incidental hit still hides mid-token matches — verified against the production DB:

```
query "Propert"          FTS rows=20 -> fallback suppressed  (PropertyIdItem, PropertyType, …)
query "CategoryPropert"  FTS rows=0  -> fallback fires        (ProcurementProductCategoryPropertyEntity, …)
```

Widening the trigger to "fewer rows than `limit`" would put the scan back on the common path, which is the cost the guard exists to remove. The proper fix is a trigram or camelCase-split FTS column over `name`, which needs a reindex; the limitation is written into the code comment so the next reader does not "fix" it by widening the trigger.

## Verification

- 6 tests in `tests/metadata/symbolIndex-substringFallback.test.ts` (#912's one plus five). With the guard reverted, **4 of the 6 fail** — they are regression tests, not tautologies. The "does not scan" cases assert on the statement-cache key (`fallback_*`) via a spy, because a guarded and an unguarded miss both return `[]`.
- Full suite green: 302 files, 3735 passed, 2 skipped. `tsc --noEmit` and `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzofLMJPRgKjZWBPBExCnS
