### PR TITLE
fix(bp-catalog): audit follow-ups on #913 — wrong install, partial extraction, staleness key, no-throw

### DIFF
--- a/scripts/extract-bp-catalog.ps1
+++ b/scripts/extract-bp-catalog.ps1
@@ -57,6 +57,12 @@
     the instance CLI (`d365fo-mcp instance rebuild/upgrade`) to give each
     instance its own catalog, matching that instance's actual D365FO version,
     instead of everyone sharing the one committed snapshot.
+
+    The JSON carries a `sources` block (how many BPRules.xml files and rule
+    DLLs were seen, and how many of each had to be skipped) next to `entries`.
+    Both scans are best-effort, so a run that could read only part of the
+    install still exits 0 - `sources` is what lets the caller notice that
+    before it treats the result as this instance's current catalog.
 .PARAMETER Version
     Stamped into the JSON output's `version` field alongside PackagesPath, so
     the caller's staleness check has something to compare against on the next
@@ -98,6 +104,15 @@ Write-Host "Scanning: $PackagesPath"
 
 # -- 1. Canonical names: union of every AxRuleSet/BPRules.xml ----------------
 $canonical = [System.Collections.Generic.SortedSet[string]]::new()
+# Every skip is counted, not just warned about. Both scans below are best-effort
+# by design (-ErrorAction SilentlyContinue, per-item catch), so a run that could
+# read only part of the install still reaches the end and exits 0 - and the
+# caller, seeing exit 0, would stamp that truncated catalog with the current
+# version and never regenerate it. The counts go into the JSON payload so the
+# caller can tell a complete extraction from a partial one; the decision about
+# what to do with them lives there (verifyExtraction in commands/bpCatalog.ts),
+# in one testable place rather than split across two languages.
+$ruleSetFailures = 0
 $ruleSetFiles = Get-ChildItem $PackagesPath -Recurse -Filter 'BPRules.xml' -ErrorAction SilentlyContinue |
     Where-Object { $_.FullName -match '\\AxRuleSet\\' }
 Write-Host "AxRuleSet/BPRules.xml files found: $($ruleSetFiles.Count)"
@@ -109,6 +124,7 @@ foreach ($f in $ruleSetFiles) {
             if ($m) { [void]$canonical.Add($m.Trim()) }
         }
     } catch {
+        $ruleSetFailures++
         Write-Warning "Skipped $($f.FullName): $_"
     }
 }
@@ -132,6 +148,7 @@ $searchDirs = @($binDir, (Join-Path $binDir 'BPExtensions'))
 
 # messages[moniker] = @{ message = ...; description = ... }
 $messages = @{}
+$dllFailures = 0
 $dllTargets = @(Get-ChildItem $binDir -Filter '*.dll' -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'BestPractice' })
 $dllTargets += Get-ChildItem (Join-Path $binDir 'BPExtensions') -Filter '*.dll' -ErrorAction SilentlyContinue
 Write-Host "Rule DLLs to reflect over: $($dllTargets.Count)"
@@ -140,6 +157,7 @@ foreach ($dll in $dllTargets) {
     try {
         $asm = [System.Reflection.Assembly]::LoadFrom($dll.FullName)
     } catch {
+        $dllFailures++
         Write-Warning "Load failed, skipped: $($dll.Name) - $($_.Exception.Message)"
         continue
     }
@@ -190,10 +208,21 @@ if ($OutFile) {
             canonical   = $canonical.Contains($m)
         }
     }
+    # `sources` is how the caller tells a complete extraction from a partial
+    # one. Measured against a real 214-model PackagesLocalDirectory: 144
+    # BPRules.xml files, 25 rule DLLs, and zero skips of either kind - a
+    # healthy box loses nothing, so a non-zero failure count here is a genuine
+    # signal rather than routine noise the caller would have to threshold.
     $payload = [PSCustomObject]@{
         generatedAt  = (Get-Date).ToString('o')
         packagesPath = $PackagesPath
         version      = $Version
+        sources      = [PSCustomObject]@{
+            ruleSetFiles    = @($ruleSetFiles).Count
+            ruleSetFailures = $ruleSetFailures
+            ruleDlls        = @($dllTargets).Count
+            dllFailures     = $dllFailures
+        }
         entries      = @($entries)
     }
     $outDir = Split-Path $OutFile -Parent
@@ -211,6 +240,7 @@ if ($OutFile) {
     Write-Host "Wrote $($allMonikers.Count) entries to $fullOut"
     Write-Host "  canonical (in an AxRuleSet):        $($canonical.Count)"
     Write-Host "  with real message/description text: $($messages.Count)"
+    Write-Host "  skipped BPRules.xml / rule DLLs:    $ruleSetFailures / $dllFailures"
     return
 }
 

--- a/src/cli/commands/bpCatalog.ts
+++ b/src/cli/commands/bpCatalog.ts
@@ -16,7 +16,8 @@
  * not this target's (resolveSource), and accept an extraction that only
  * partially read the one that is (verifyExtraction).
  */
-import { existsSync, readFileSync, renameSync, rmSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
 import { settingByPath } from '../../config/settings.js';
 import { findPackagesRoot } from '../../utils/packagesRoot.js';
@@ -67,23 +68,69 @@ function resolveSource(target: Target): ResolvedSource | null {
   // would then be stamped with this target's key and treated as current —
   // the same "catalog from the wrong install" the branch above refuses.
   if (isUdeTarget(target.store)) return null;
-  // Traditional environment: no version string on disk anywhere, so the bin\
-  // folder's mtime stands in for "has this install changed since we last
-  // extracted" — good enough to catch a platform update, which is the only
-  // thing that would actually change the moniker set.
+  // Traditional environment: no version string on disk anywhere, so the state
+  // of the files the catalog is extracted FROM stands in for "has this install
+  // changed since we last extracted".
   const packagesPath = readSetting(target.store, packagePathSetting) as string | undefined
     || findPackagesRoot()
     || undefined;
   if (!packagesPath) return null;
+  const versionKey = ruleSourceKey(packagesPath);
+  return versionKey ? { versionKey, packagesPath } : null;
+}
+
+/**
+ * A key that moves when the rule DLLs move — the actual input to half the
+ * catalog, and the half that cannot be reconstructed from names alone.
+ *
+ * The obvious cheap key, `statSync(packagesPath/bin).mtimeMs`, does not track
+ * that: a directory's mtime changes when its *direct* children are added,
+ * removed or renamed, so a platform hotfix that rewrites DLLs inside
+ * bin\BPExtensions\ in place leaves bin\ untouched, the key matches, and the
+ * catalog is never regenerated — the exact staleness the per-instance catalog
+ * exists to fix. Size and mtime of each rule DLL move whenever its content
+ * does.
+ *
+ * The file set mirrors what extract-bp-catalog.ps1 itself reflects over:
+ * bin\*.dll whose name contains 'BestPractice', plus every DLL in
+ * bin\BPExtensions. Measured on a real install that is 25 files, reached by
+ * two readdirs and 25 stats in ~5 ms — this runs on every rebuild, so it has
+ * to stay far cheaper than the multi-minute scan it decides against.
+ *
+ * What it deliberately does NOT cover: each model's AxRuleSet\BPRules.xml, the
+ * source of the canonical names. Finding those means recursing the whole
+ * packages root, which is most of the cost of the extraction itself. Neither
+ * did the bin\ mtime it replaces, and in practice a platform update that
+ * changes the rule set ships new rule DLLs with it.
+ */
+function ruleSourceKey(packagesPath: string): string | null {
   // join(), not a hardcoded '\bin' — this path is only ever real on Windows in
   // production, but the test suite (and CI) exercises it on Linux too, where a
   // literal backslash is just another filename character, not a separator.
   const binDir = join(packagesPath, 'bin');
-  try {
-    return { versionKey: `mtime:${statSync(binDir).mtimeMs}`, packagesPath };
-  } catch {
-    return null;
+  const extensionsDir = join(binDir, 'BPExtensions');
+  const parts: string[] = [];
+  for (const dir of [binDir, extensionsDir]) {
+    let names: string[];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const name of names.sort()) {
+      if (!/\.dll$/i.test(name)) continue;
+      if (dir === binDir && !/BestPractice/i.test(name)) continue;
+      try {
+        const stat = statSync(join(dir, name));
+        parts.push(`${name}:${stat.size}:${stat.mtimeMs}`);
+      } catch { /* vanished between readdir and stat — just leave it out */ }
+    }
   }
+  // No rule DLL anywhere means this is not a usable packages root, so there is
+  // nothing to extract and nothing to key on. Returning a key for the empty set
+  // would make every such path agree with every other one.
+  if (parts.length === 0) return null;
+  return `rules:${createHash('sha1').update(parts.join('|')).digest('hex').slice(0, 16)}`;
 }
 
 interface StampedCatalog {
@@ -177,8 +224,25 @@ const defaultDeps: BpCatalogDeps = { commandExists, runExe };
  * "never generated" — covers first-time instance creation). A no-op on
  * every other rebuild. Never throws and never fails the caller's reindex —
  * a missing/stale BP catalog degrades one knowledge tool, not the server.
+ *
+ * "Never throws" is enforced here rather than left to the callee getting every
+ * path right. rebuildIndex() awaits this as its last step, unwrapped, *after*
+ * the multi-minute extract and database build have already succeeded and
+ * logged "Index rebuilt" — so anything escaping would turn a finished rebuild
+ * into a crashed command. And plenty can escape: runExe rejects on the child
+ * process's own 'error' event (commandExists only rules out ENOENT, not an
+ * EACCES on the interpreter), and saveStore writes two files that a locked or
+ * read-only instance config will refuse.
  */
 export async function ensureBpCatalogFresh(target: Target, deps: BpCatalogDeps = defaultDeps): Promise<void> {
+  try {
+    await refreshCatalog(target, deps);
+  } catch (err) {
+    p.log.warn(`BP catalog: skipped for ${target.label} (${(err as Error).message}) — the index rebuild itself is unaffected.`);
+  }
+}
+
+async function refreshCatalog(target: Target, deps: BpCatalogDeps): Promise<void> {
   const source = resolveSource(target);
   if (!source) {
     p.log.warn(isUdeTarget(target.store)

--- a/src/cli/commands/bpCatalog.ts
+++ b/src/cli/commands/bpCatalog.ts
@@ -9,8 +9,14 @@
  * version in the target's existing catalog file differs from what this
  * target resolves to now (or the file does not exist yet); every other call
  * is a cheap read-and-compare with no subprocess spawned.
+ *
+ * Two things this module will not do, both because the result would be
+ * self-perpetuating — whatever it stamps with the current version key is what
+ * every later rebuild treats as up to date: extract from an install that is
+ * not this target's (resolveSource), and accept an extraction that only
+ * partially read the one that is (verifyExtraction).
  */
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync, rmSync, statSync } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
 import { settingByPath } from '../../config/settings.js';
 import { findPackagesRoot } from '../../utils/packagesRoot.js';
@@ -19,7 +25,7 @@ import { paths } from '../context.js';
 import { readPath, readSetting, saveStore, writeSetting } from '../settingsStore.js';
 import { Target } from '../target.js';
 import { p } from '../ui.js';
-import { resolvePinnedXppConfig } from '../xppConfig.js';
+import { isUdeTarget, resolvePinnedXppConfig } from '../xppConfig.js';
 
 const bpCatalogPathSetting = settingByPath('index.bpCatalogPath')!;
 const packagePathSetting = settingByPath('environment.packagePath')!;
@@ -50,6 +56,17 @@ function resolveSource(target: Target): ResolvedSource | null {
     if (!xppConfig.frameworkDirectory) return null;
     return { versionKey: xppConfig.version, packagesPath: xppConfig.frameworkDirectory };
   }
+  // A null from resolvePinnedXppConfig does NOT mean "traditional". It also
+  // covers a UDE target whose pin names a config that is gone — the
+  // stale-after-UDE-upgrade state `instance upgrade` exists to fix — and that
+  // function returns null there *deliberately*, rather than substituting a
+  // different environment. Falling through to the box-wide scan below would
+  // undo exactly that: findPackagesRoot() ranks every <drive>:\AosService\
+  // PackagesLocalDirectory on the machine and hands back the most plausible
+  // one, which on a mixed box is some other install entirely. Its catalog
+  // would then be stamped with this target's key and treated as current —
+  // the same "catalog from the wrong install" the branch above refuses.
+  if (isUdeTarget(target.store)) return null;
   // Traditional environment: no version string on disk anywhere, so the bin\
   // folder's mtime stands in for "has this install changed since we last
   // extracted" — good enough to catch a platform update, which is the only
@@ -72,6 +89,9 @@ function resolveSource(target: Target): ResolvedSource | null {
 interface StampedCatalog {
   version?: string;
   packagesPath?: string;
+  /** Extraction coverage reported by the script — see verifyExtraction. */
+  sources?: { ruleSetFiles?: number; ruleSetFailures?: number; ruleDlls?: number; dllFailures?: number };
+  entries?: unknown;
 }
 
 /** The version this target's *existing* catalog file was stamped with, if any. */
@@ -87,6 +107,60 @@ function existingVersionKey(catalogPath: string): string | null {
   } catch {
     return null;
   }
+}
+
+interface CatalogEntry {
+  message?: string | null;
+  description?: string | null;
+  canonical?: boolean;
+}
+
+/**
+ * Why a freshly extracted catalog must not be trusted as this target's current
+ * one — or null when it looks like a complete extraction.
+ *
+ * Exit code 0 does not mean "complete". Both of the script's scans are
+ * best-effort on purpose (`-ErrorAction SilentlyContinue`, a per-file catch on
+ * BPRules.xml, a per-DLL catch on assembly load), so a run that could read half
+ * the models, or none of the rule DLLs, still finishes and exits 0. Stamping
+ * that result is worse than not regenerating at all: the stamp matches on every
+ * later rebuild, so it is never retried, and loadCatalog() only rejects an
+ * exactly-empty override — a merely truncated one REPLACES the compiled
+ * snapshot, and bp_moniker starts answering "not in the extracted catalog" for
+ * monikers that are real.
+ *
+ * The failure counts are the script's own (`sources`), not a guess: measured
+ * against a real 214-model PackagesLocalDirectory, a healthy box skips zero of
+ * its 144 BPRules.xml files and zero of its 25 rule DLLs, so any skip at all is
+ * signal. The content checks below stand in for that on a catalog produced by
+ * an older copy of the script, which carries no `sources` block.
+ */
+function verifyExtraction(catalogPath: string): string | null {
+  let parsed: StampedCatalog;
+  try {
+    // Same BOM strip as existingVersionKey — a catalog an older copy of the
+    // script produced under PowerShell 5.1 carries one, and this must reject a
+    // partial extraction, not a readable-but-BOM'd one.
+    parsed = JSON.parse(readFileSync(catalogPath, 'utf-8').replace(/^\uFEFF/, '')) as StampedCatalog;
+  } catch (err) {
+    return `it could not be read back (${(err as Error).message})`;
+  }
+  if (!Array.isArray(parsed.entries)) return 'it carries no entries array';
+
+  const { ruleSetFailures = 0, dllFailures = 0, ruleSetFiles = 0, ruleDlls = 0 } = parsed.sources ?? {};
+  if (ruleSetFailures > 0 || dllFailures > 0) {
+    return `the extraction skipped ${ruleSetFailures} of ${ruleSetFiles} BPRules.xml files and ${dllFailures} of ${ruleDlls} rule DLLs`;
+  }
+
+  const entries = parsed.entries as CatalogEntry[];
+  if (entries.length === 0) return 'it contains no monikers at all';
+  // Either source failing wholesale leaves a catalog that still looks populated
+  // but has lost the half that answers a question: no canonical name means no
+  // AxRuleSet was read, so `validate` cannot confirm anything; no rule text
+  // means no DLL yielded resources, so `search` matches nothing.
+  if (!entries.some(e => e.canonical)) return 'not one of its monikers came from an AxRuleSet/BPRules.xml';
+  if (!entries.some(e => e.message || e.description)) return 'not one of its monikers carries rule text';
+  return null;
 }
 
 /** Injectable for tests — real implementations by default. */
@@ -107,7 +181,9 @@ const defaultDeps: BpCatalogDeps = { commandExists, runExe };
 export async function ensureBpCatalogFresh(target: Target, deps: BpCatalogDeps = defaultDeps): Promise<void> {
   const source = resolveSource(target);
   if (!source) {
-    p.log.warn(`BP catalog: could not resolve a packages path for ${target.label} — skipped.`);
+    p.log.warn(isUdeTarget(target.store)
+      ? `BP catalog: could not resolve ${target.label}'s own D365FO install (its XPP config is missing or unreadable) — skipped rather than extracting from another install on this box. \`d365fo-mcp instance upgrade\` repoints a pin left behind by a UDE upgrade.`
+      : `BP catalog: could not resolve a packages path for ${target.label} — skipped.`);
     return;
   }
 
@@ -130,16 +206,36 @@ export async function ensureBpCatalogFresh(target: Target, deps: BpCatalogDeps =
   }
 
   p.log.step(`Refreshing BP moniker catalog (${target.label}, ${basename(source.packagesPath)})…`);
+  // Extract beside the real catalog, not over it. The script writes its output
+  // in one go with no staging of its own, so pointing it straight at the live
+  // file means a partial run destroys a good catalog before anything can judge
+  // it — and the caller cannot put it back. The move below is the only thing
+  // that makes this target's catalog change.
+  const stagedPath = `${catalogPath}.new`;
   const exitCode = await deps.runExe(shell, [
     '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', paths.extractBpCatalogScript,
     '-PackagesPath', source.packagesPath,
-    '-OutFile', catalogPath,
+    '-OutFile', stagedPath,
     '-Version', source.versionKey,
   ]);
   if (exitCode !== 0) {
+    rmSync(stagedPath, { force: true });
     p.log.warn(`BP catalog: extraction failed for ${target.label} (exit ${exitCode}) — keeping the previous catalog.`);
     return;
   }
+
+  const problem = verifyExtraction(stagedPath);
+  if (problem) {
+    // Discarded rather than stamped: the file carries this target's current
+    // version key, so keeping it would make every later rebuild a no-op and
+    // freeze a half-read catalog in place. Dropping it leaves the previous
+    // catalog (or the compiled snapshot) in service and the version key stale,
+    // which is exactly what makes the next rebuild try again.
+    rmSync(stagedPath, { force: true });
+    p.log.warn(`BP catalog: discarded the extraction for ${target.label} — ${problem}. Keeping the previous catalog; the next rebuild will retry.`);
+    return;
+  }
+  renameSync(stagedPath, catalogPath);
 
   // Write the RELATIVE literal, not the resolved catalogPath: an absolute path
   // baked into the instance config survives neither a folder rename nor a move,

--- a/src/cli/xppConfig.ts
+++ b/src/cli/xppConfig.ts
@@ -91,6 +91,29 @@ export function resolvePinnedXppConfig(store: SettingsStore): XppConfig | null {
 }
 
 /**
+ * Is this target a UDE target at all — i.e. does a null from
+ * {@link resolvePinnedXppConfig} mean "its pin does not resolve" rather than
+ * "this is a traditional install"?
+ *
+ * That function returns null for three different reasons and a caller cannot
+ * tell them apart, which matters because the two answers call for opposite
+ * behaviour: a traditional target legitimately falls back to detecting the
+ * packages root on this box, while for a UDE target that fallback throws away
+ * the very guarantee the null was there to provide (see resolveSource in
+ * commands/bpCatalog.ts, and the docblock above).
+ *
+ * Mirrors the detection settings.ts documents for an unset environment.type:
+ * UDE when XPP config files exist in %LOCALAPPDATA%\Microsoft\Dynamics365\
+ * XPPConfig. So a box with no configs at all is traditional — the one case
+ * where falling through is correct — and anything else with an explicit
+ * `traditional` type is taken at its word.
+ */
+export function isUdeTarget(store: SettingsStore): boolean {
+  if (readSetting(store, envTypeSetting) === 'traditional') return false;
+  return listXppConfigs().length > 0;
+}
+
+/**
  * Expand a short config name (e.g. "myenv-dev") to the newest full versioned
  * name ("myenv-dev___10.0.2345.153") so a later staleness check is a plain
  * file-exists test, and persist the expansion. No-op for traditional

--- a/tests/cli/bpCatalog.test.ts
+++ b/tests/cli/bpCatalog.test.ts
@@ -69,6 +69,35 @@ function makeUdeTargetWithUnreadableConfig(): Target {
   return { name: 'ude', label: "instance 'ude'", envFile: null, store, port: null };
 }
 
+/**
+ * A UDE target whose pin names a config that is GONE — what a UDE upgrade
+ * leaves behind, and the state `instance upgrade` exists to repair. Another
+ * config is present, so the box is unmistakably UDE.
+ *
+ * environment.packagePath is set deliberately: it gives the traditional
+ * fall-through something real to extract from, so the assertion fails on the
+ * unguarded code instead of passing for the wrong reason on Linux, where
+ * findPackagesRoot() returns nothing anyway.
+ */
+function makeUdeTargetWithVanishedPin(): Target {
+  const xppDir = join(root, 'LocalAppData', 'Microsoft', 'Dynamics365', 'XPPConfig');
+  fs.mkdirSync(xppDir, { recursive: true });
+  fs.writeFileSync(
+    join(xppDir, 'contoso___10.0.2600.9.json'),
+    JSON.stringify({ FrameworkDirectory: packagesPath }),
+    'utf-8',
+  );
+  process.env.LOCALAPPDATA = join(root, 'LocalAppData');
+
+  const configDir = join(root, 'ude-stale');
+  fs.mkdirSync(configDir, { recursive: true });
+  writeConfigFile(join(configDir, 'd365fo-mcp.json'), {
+    environment: { type: 'ude', xppConfigName: 'contoso___10.0.2428.63', packagePath: packagesPath },
+  });
+  const store = openStore(configDir, null);
+  return { name: 'ude-stale', label: "instance 'ude-stale'", envFile: null, store, port: null };
+}
+
 /** The value ensureBpCatalogFresh persisted into the instance config, if any. */
 function readWrittenSetting(): unknown {
   const file = join(root, 'instance', 'd365fo-mcp.json');
@@ -76,21 +105,53 @@ function readWrittenSetting(): unknown {
   return JSON.parse(fs.readFileSync(file, 'utf-8')).index?.bpCatalogPath;
 }
 
+/** The catalog file this target's runs write to, once staging has moved it. */
+function catalogFile(instanceDir = 'instance'): string {
+  return join(root, instanceDir, 'data', 'bp-moniker-catalog.json');
+}
+
+/**
+ * What a COMPLETE extraction looks like: both sources contributed (a canonical
+ * moniker from an AxRuleSet, rule text from a DLL) and `sources` reports that
+ * nothing was skipped. Measured shape — a healthy 214-model packages root
+ * yields 144 BPRules.xml files and 25 rule DLLs with zero skips of either.
+ */
+function completeCatalog(version: string): string {
+  return JSON.stringify({
+    version,
+    packagesPath,
+    sources: { ruleSetFiles: 144, ruleSetFailures: 0, ruleDlls: 25, dllFailures: 0 },
+    entries: [
+      { moniker: 'BPErrorLabelIsText', message: 'Label is a text literal', description: null, canonical: true },
+      { moniker: 'BPCheckNamingConventions', message: null, description: 'Naming', canonical: true },
+    ],
+  });
+}
+
+/**
+ * Mirrors extract-bp-catalog.ps1's -OutFile branch: it creates the parent
+ * directory itself (New-Item -Force) and always exits 0 — the script cannot
+ * fail a run just because a scan came back partial, which is the whole reason
+ * the caller has to inspect what was written.
+ */
+function writeExtraction(args: string[], body: (version: string) => string): number {
+  const outFile = args[args.indexOf('-OutFile') + 1];
+  fs.mkdirSync(join(outFile, '..'), { recursive: true });
+  fs.writeFileSync(outFile, body(args[args.indexOf('-Version') + 1]), 'utf-8');
+  return 0;
+}
+
 function fakeDeps(overrides: Partial<BpCatalogDeps> = {}): BpCatalogDeps {
   return {
     commandExists: async () => true,
-    runExe: async (_cmd, args) => {
-      // Mirrors extract-bp-catalog.ps1's -OutFile branch, which creates the
-      // parent directory itself before writing (New-Item -Force).
-      const outIdx = args.indexOf('-OutFile');
-      const versionIdx = args.indexOf('-Version');
-      const outFile = args[outIdx + 1];
-      fs.mkdirSync(join(outFile, '..'), { recursive: true });
-      fs.writeFileSync(outFile, JSON.stringify({ version: args[versionIdx + 1], entries: [] }), 'utf-8');
-      return 0;
-    },
+    runExe: async (_cmd, args) => writeExtraction(args, completeCatalog),
     ...overrides,
   };
+}
+
+/** Deps whose extraction exits 0 but writes exactly `body`. */
+function depsWriting(body: (version: string) => string): BpCatalogDeps {
+  return { commandExists: async () => true, runExe: async (_cmd, args) => writeExtraction(args, body) };
 }
 
 describe('ensureBpCatalogFresh', () => {
@@ -164,5 +225,111 @@ describe('ensureBpCatalogFresh', () => {
     await ensureBpCatalogFresh(target, fakeDeps({ runExe: async (...runArgs) => { calls++; return fakeDeps().runExe(...runArgs); } }));
 
     expect(calls).toBe(0);
+  });
+
+  it('skips a UDE target whose pin is gone instead of extracting from another install on the box', async () => {
+    // resolvePinnedXppConfig returns null for three different reasons, and only
+    // one of them ("this is a traditional install") makes the box-wide packages
+    // scan the right answer. A pin left dangling by a UDE upgrade is another,
+    // and falling through there hands back whichever PackagesLocalDirectory
+    // findPackagesRoot() ranks highest — then stamps its catalog with THIS
+    // target's version key, so it is never revisited. That is the same
+    // wrong-install swap the empty-FrameworkDirectory branch already refuses.
+    const target = makeUdeTargetWithVanishedPin();
+    let calls = 0;
+    await ensureBpCatalogFresh(target, fakeDeps({ runExe: async (...runArgs) => { calls++; return fakeDeps().runExe(...runArgs); } }));
+
+    expect(calls).toBe(0);
+    expect(fs.existsSync(catalogFile('ude-stale'))).toBe(false);
+  });
+});
+
+/**
+ * Exit code 0 does not mean the extraction was complete. Both of the script's
+ * scans are best-effort (-ErrorAction SilentlyContinue, a per-file catch on
+ * BPRules.xml, a per-DLL catch on assembly load), so a run that reached only
+ * part of the install still finishes and exits 0. Accepting one of those is
+ * worse than not regenerating at all: it is written with the current version
+ * key, so every later rebuild sees a match and never retries, and
+ * loadCatalog() rejects only an exactly-EMPTY override — a merely truncated
+ * catalog replaces the compiled snapshot outright and bp_moniker starts
+ * answering "not in the extracted catalog" for monikers that are real.
+ */
+describe('ensureBpCatalogFresh — partial extractions', () => {
+  it('discards a run that skipped part of the install, despite exit 0', async () => {
+    const target = makeTarget();
+    await ensureBpCatalogFresh(target, depsWriting(version => JSON.stringify({
+      version,
+      sources: { ruleSetFiles: 144, ruleSetFailures: 71, ruleDlls: 25, dllFailures: 0 },
+      entries: [{ moniker: 'BPErrorLabelIsText', message: 'Label is a text literal', description: null, canonical: true }],
+    })));
+
+    expect(fs.existsSync(catalogFile())).toBe(false);
+    expect(readWrittenSetting()).toBeUndefined();
+  });
+
+  it('discards a run where no AxRuleSet was read at all', async () => {
+    // Entries, but every one of them came from a rule DLL's resource strings.
+    // `canonical` is the only field that answers "is this a BP rule", so a
+    // catalog without a single canonical moniker cannot confirm anything.
+    const target = makeTarget();
+    await ensureBpCatalogFresh(target, depsWriting(version => JSON.stringify({
+      version,
+      sources: { ruleSetFiles: 0, ruleSetFailures: 0, ruleDlls: 25, dllFailures: 0 },
+      entries: [{ moniker: 'DECSomeToolMessage', message: 'Not a BP rule', description: null, canonical: false }],
+    })));
+
+    expect(fs.existsSync(catalogFile())).toBe(false);
+    expect(readWrittenSetting()).toBeUndefined();
+  });
+
+  it('discards a run where no rule DLL yielded any text', async () => {
+    // The mirror image: canonical names survived, but `search` matches on rule
+    // text and there is none, so every search would come back empty.
+    const target = makeTarget();
+    await ensureBpCatalogFresh(target, depsWriting(version => JSON.stringify({
+      version,
+      sources: { ruleSetFiles: 144, ruleSetFailures: 0, ruleDlls: 0, dllFailures: 0 },
+      entries: [{ moniker: 'BPErrorLabelIsText', message: null, description: null, canonical: true }],
+    })));
+
+    expect(fs.existsSync(catalogFile())).toBe(false);
+    expect(readWrittenSetting()).toBeUndefined();
+  });
+
+  it('discards an empty run instead of stamping it as this version', async () => {
+    // Reachable from a successful run: a packages root with a bin\ folder but
+    // no AxRuleSet and no rule DLLs exits 0 with zero entries. Stamping it made
+    // the emptiness permanent — the version matched forever after.
+    const target = makeTarget();
+    await ensureBpCatalogFresh(target, depsWriting(version => JSON.stringify({ version, entries: [] })));
+
+    expect(fs.existsSync(catalogFile())).toBe(false);
+    expect(readWrittenSetting()).toBeUndefined();
+  });
+
+  it('leaves the previous good catalog in place, unstamped, so the next rebuild retries', async () => {
+    const target = makeTarget();
+    await ensureBpCatalogFresh(target, fakeDeps());
+    const good = fs.readFileSync(catalogFile(), 'utf-8');
+
+    // A platform update moves bin\'s mtime, so the next call really does run.
+    fs.writeFileSync(join(binDir, 'xppc.exe'), 'x');
+    fs.utimesSync(binDir, new Date(Date.now() + 60_000), new Date(Date.now() + 60_000));
+    await ensureBpCatalogFresh(target, depsWriting(version => JSON.stringify({
+      version,
+      sources: { ruleSetFiles: 144, ruleSetFailures: 3, ruleDlls: 25, dllFailures: 1 },
+      entries: [{ moniker: 'BPErrorLabelIsText', message: 'Label is a text literal', description: null, canonical: true }],
+    })));
+
+    // Untouched, still carrying the OLD version key — which is precisely what
+    // makes the following call extract again rather than report "up to date".
+    expect(fs.readFileSync(catalogFile(), 'utf-8')).toBe(good);
+    expect(fs.readdirSync(join(root, 'instance', 'data'))).toEqual(['bp-moniker-catalog.json']);
+
+    let calls = 0;
+    await ensureBpCatalogFresh(target, fakeDeps({ runExe: async (...runArgs) => { calls++; return fakeDeps().runExe(...runArgs); } }));
+    expect(calls).toBe(1);
+    expect(fs.readFileSync(catalogFile(), 'utf-8')).not.toBe(good);
   });
 });

--- a/tests/cli/bpCatalog.test.ts
+++ b/tests/cli/bpCatalog.test.ts
@@ -5,10 +5,10 @@
  * (first-time instance creation). Every other call must be a cheap no-op:
  * no subprocess, no write.
  *
- * Exercised against a traditional environment, where the version key is the
- * packages root's bin\ folder mtime — no XPP config fixture needed.
- * commandExists/runExe are injected directly (see BpCatalogDeps) rather than
- * mocked, so these tests never spawn a real process.
+ * Exercised against a traditional environment, where the version key is
+ * derived from the rule DLLs under the packages root's bin\ — no XPP config
+ * fixture needed. commandExists/runExe are injected directly (see
+ * BpCatalogDeps) rather than mocked, so these tests never spawn a real process.
  */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -22,15 +22,28 @@ import type { Target } from '../../src/cli/target.js';
 let root: string;
 let packagesPath: string;
 let binDir: string;
+let extensionsDir: string;
+let ruleDll: string;
 let originalLocalAppData: string | undefined;
 
 beforeEach(() => {
   root = fs.mkdtempSync(join(os.tmpdir(), 'bp-catalog-target-'));
   packagesPath = join(root, 'packages');
   binDir = join(packagesPath, 'bin');
-  fs.mkdirSync(binDir, { recursive: true });
+  // A packages root with no rule DLL has nothing to extract from, so the
+  // fixture ships one: this is the file set the version key is built from and
+  // the same set extract-bp-catalog.ps1 reflects over.
+  extensionsDir = join(binDir, 'BPExtensions');
+  fs.mkdirSync(extensionsDir, { recursive: true });
+  ruleDll = join(extensionsDir, 'Dynamics.AX.BestPractices.dll');
+  fs.writeFileSync(ruleDll, 'rules v1');
   originalLocalAppData = process.env.LOCALAPPDATA;
 });
+
+/** A platform update: the rule DLL's content changes, so the key must move. */
+function replaceRuleDll(): void {
+  fs.writeFileSync(ruleDll, 'rules v2 — a different size');
+}
 
 afterEach(() => {
   // The UDE case repoints LOCALAPPDATA at a fixture; the real one must not stay
@@ -172,13 +185,11 @@ describe('ensureBpCatalogFresh', () => {
     expect(calls).toBe(0);
   });
 
-  it('regenerates again once the packages root changes (bin\\ mtime moves)', async () => {
+  it('regenerates again once the rule DLLs change', async () => {
     const target = makeTarget();
     await ensureBpCatalogFresh(target, fakeDeps());
 
-    // Simulate a platform update: something inside bin\ changes, moving its mtime.
-    fs.writeFileSync(join(binDir, 'xppc.exe'), 'x');
-    fs.utimesSync(binDir, new Date(Date.now() + 60_000), new Date(Date.now() + 60_000));
+    replaceRuleDll();
 
     let calls = 0;
     await ensureBpCatalogFresh(target, fakeDeps({ runExe: async (...runArgs) => { calls++; return fakeDeps().runExe(...runArgs); } }));
@@ -313,9 +324,8 @@ describe('ensureBpCatalogFresh — partial extractions', () => {
     await ensureBpCatalogFresh(target, fakeDeps());
     const good = fs.readFileSync(catalogFile(), 'utf-8');
 
-    // A platform update moves bin\'s mtime, so the next call really does run.
-    fs.writeFileSync(join(binDir, 'xppc.exe'), 'x');
-    fs.utimesSync(binDir, new Date(Date.now() + 60_000), new Date(Date.now() + 60_000));
+    // A platform update moves the version key, so the next call really does run.
+    replaceRuleDll();
     await ensureBpCatalogFresh(target, depsWriting(version => JSON.stringify({
       version,
       sources: { ruleSetFiles: 144, ruleSetFailures: 3, ruleDlls: 25, dllFailures: 1 },
@@ -331,5 +341,68 @@ describe('ensureBpCatalogFresh — partial extractions', () => {
     await ensureBpCatalogFresh(target, fakeDeps({ runExe: async (...runArgs) => { calls++; return fakeDeps().runExe(...runArgs); } }));
     expect(calls).toBe(1);
     expect(fs.readFileSync(catalogFile(), 'utf-8')).not.toBe(good);
+  });
+});
+
+describe('ensureBpCatalogFresh — version key', () => {
+  it('regenerates when a rule DLL is replaced in place, which leaves bin\\ untouched', async () => {
+    // The staleness the per-instance catalog exists to fix. A directory's mtime
+    // moves only when its DIRECT children are added, removed or renamed, so
+    // keying on bin\ missed a platform hotfix that rewrites the DLLs inside
+    // bin\BPExtensions\ — the key matched, and the catalog was never rebuilt.
+    const target = makeTarget();
+    await ensureBpCatalogFresh(target, fakeDeps());
+    const binMtimeBefore = fs.statSync(binDir).mtimeMs;
+
+    replaceRuleDll();
+
+    // Precondition, not decoration: if writing the DLL moved bin\'s mtime, this
+    // test would pass against the very key it is here to reject.
+    expect(fs.statSync(binDir).mtimeMs).toBe(binMtimeBefore);
+
+    let calls = 0;
+    await ensureBpCatalogFresh(target, fakeDeps({ runExe: async (...runArgs) => { calls++; return fakeDeps().runExe(...runArgs); } }));
+    expect(calls).toBe(1);
+  });
+
+  it('skips a packages root with no rule DLL rather than keying on the empty set', async () => {
+    fs.rmSync(ruleDll);
+    const target = makeTarget();
+    let calls = 0;
+    await ensureBpCatalogFresh(target, fakeDeps({ runExe: async (...runArgs) => { calls++; return fakeDeps().runExe(...runArgs); } }));
+
+    expect(calls).toBe(0);
+    expect(fs.existsSync(catalogFile())).toBe(false);
+  });
+});
+
+/**
+ * rebuildIndex() awaits ensureBpCatalogFresh as its last step, unwrapped, after
+ * the multi-minute extract and database build have already succeeded and logged
+ * "Index rebuilt". Anything escaping turns a finished rebuild into a crashed
+ * command, so "never throws" has to be enforced rather than merely documented.
+ */
+describe('ensureBpCatalogFresh — never fails the caller', () => {
+  it('survives the extraction subprocess failing to start', async () => {
+    // runExe rejects on the child's own 'error' event, and commandExists only
+    // rules out ENOENT — an EACCES on the interpreter still lands here.
+    const target = makeTarget();
+    await expect(ensureBpCatalogFresh(target, fakeDeps({
+      runExe: async () => { throw Object.assign(new Error('spawn powershell EACCES'), { code: 'EACCES' }); },
+    }))).resolves.toBeUndefined();
+
+    expect(fs.existsSync(catalogFile())).toBe(false);
+    expect(readWrittenSetting()).toBeUndefined();
+  });
+
+  it('survives a filesystem error while putting the verified catalog in place', async () => {
+    // A directory where the catalog belongs makes the move fail on every
+    // platform — standing in for the locked/read-only instance folder that
+    // would otherwise take rebuildIndex down with it.
+    const target = makeTarget();
+    fs.mkdirSync(catalogFile(), { recursive: true });
+
+    await expect(ensureBpCatalogFresh(target, fakeDeps())).resolves.toBeUndefined();
+    expect(readWrittenSetting()).toBeUndefined();
   });
 });


### PR DESCRIPTION
Audit follow-ups on #913 — all four findings. The first two share a shape: whatever `ensureBpCatalogFresh` writes is stamped with the target's current version key, so every later rebuild sees a match and never revisits it. Anything wrong that lands there is **permanent**.

## 1. A UDE target whose pin is gone extracted from another install on the box

`resolveSource` fell through to the box-wide packages scan whenever `resolvePinnedXppConfig` returned `null` — but that function returns `null` for three different reasons, and only one of them ("this is a traditional install") makes the scan the right answer. Another is a UDE target pinned to a config a UDE upgrade removed, where it returns `null` *deliberately*, "rather than substituting a different environment" (its own docblock, and `tests/cli/xppConfigPin.test.ts` pins it down).

One level up, that `null` reached `findPackagesRoot()`, which ranks every `<drive>:\AosService\PackagesLocalDirectory` on the machine and returns the most plausible one — some other install entirely on a mixed box. Its catalog was then stamped as this target's, and never regenerated. That is the same wrong-install swap the empty-`FrameworkDirectory` branch immediately above already refuses.

`isUdeTarget()` now carries the distinction the bare `null` could not, and the skip message says which state it is in and that `instance upgrade` repoints a dangling pin.

## 2. Exit 0 did not mean the extraction was complete

Both of the script's scans are best-effort on purpose — `-ErrorAction SilentlyContinue`, a per-file `catch` on `BPRules.xml`, a per-DLL `catch` on assembly load — so a run that reached half the models, or none of the rule DLLs, still finishes and exits 0.

Downstream, `loadCatalog()` rejects only an **exactly-empty** override. A merely truncated one *replaces* the compiled snapshot outright, so `validateMoniker` starts answering "is not in the extracted catalog" for monikers that are real and that the shipped snapshot knows, and `bp_moniker` search silently loses coverage.

- `extract-bp-catalog.ps1` now counts what it skipped and reports it in a `sources` block next to `entries`.
- `verifyExtraction()` refuses to promote a catalog that skipped anything, that carries no canonical moniker (no AxRuleSet was read → `validate` cannot confirm), or no rule text (no DLL yielded resources → `search` matches nothing).
- The threshold is **measured, not guessed**: against a real 214-model `PackagesLocalDirectory`, a healthy run skips 0 of 144 `BPRules.xml` files and 0 of 25 rule DLLs. Any skip at all is signal, so there is no percentage to tune.
- Extraction stages to `<catalog>.new` and is moved into place only once it verifies, so a partial run can no longer destroy a good catalog on its way to being rejected. The discarded file takes the current version key with it, which is what makes the next rebuild retry instead of reporting "up to date" forever.

Policy lives in one testable place (TypeScript); the script only reports coverage.

## 3. The staleness key did not track the files the catalog is built from

The traditional-environment key was `statSync(packagesPath/bin).mtimeMs`, but neither input lives directly in `bin\`: rule text comes from `bin\BPExtensions\*.dll`, canonical names from each model's `AxRuleSet\BPRules.xml`. A directory's mtime moves only when its **direct** children are added, removed or renamed — so a platform hotfix that rewrites the DLLs inside `bin\BPExtensions\` in place left `bin\` untouched, the key matched, and the catalog was never regenerated. That is precisely the staleness the per-instance catalog exists to fix.

`ruleSourceKey()` hashes name/size/mtime of the same file set the script reflects over: `bin\*.dll` matching `BestPractice` plus every DLL in `bin\BPExtensions`. On a real install that is 25 files — two readdirs and 25 stats, **~5 ms** — against the multi-minute scan it decides against. It deliberately does *not* recurse for `BPRules.xml`: finding those is most of the cost of the extraction itself, the `bin\` mtime it replaces did not cover them either, and a platform update that changes the rule set ships new rule DLLs with it.

The key format changes, so an instance holding a catalog stamped `mtime:…` regenerates once on its next rebuild and is on `rules:…` thereafter.

## 4. "Never throws" was a docblock promise nothing enforced

`rebuildIndex()` awaits `ensureBpCatalogFresh` unwrapped as its last step, *after* the extract and database build already succeeded and logged "Index rebuilt" — so anything escaping turns a finished rebuild into a crashed command. `runExe` rejects on the child process's own `error` event (`commandExists` only rules out ENOENT, not an EACCES on the interpreter), and `saveStore` writes two files a locked or read-only instance config refuses. The body moved into `refreshCatalog()` and the exported function is now the `try`/`catch`, so the contract holds however the callee changes.

## Verification

End to end under Windows PowerShell 5.1 against `K:\AosService\PackagesLocalDirectory`:

- real extraction — 577 entries, 409 canonical, 545 with rule text, **0 / 0** skips — passes the gate, lands as the catalog with **no staging file left behind**, writes `./data/bp-moniker-catalog.json` as the relative literal, and the second call reports "up to date";
- the new key resolves from the real 25 rule DLLs (`rules:19528c6a119b9d33`) and is stable across calls;
- all **10 new tests fail on the pre-fix code** and pass with it — including the in-place-DLL test, which asserts `bin\`'s mtime really did stay put so it cannot pass against the key it exists to reject;
- full suite green: 310 files, 3914 passed / 2 skipped; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)