### PR TITLE
fix(class-info): only promise method bodies a follow-up call can actually deliver

### DIFF
--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -30,6 +30,7 @@ import { xppMethodSourceForXml } from '../utils/xppFormat.js';
 import { ensureXppDocComment, ensureBlankLineBeforeClosingBrace } from '../utils/xppDocGen.js';
 import { parseXppDeclaration, parseXppClassHeader } from '../metadata/xppDeclaration.js';
 import { rankCustomFirst, isExactNameMatch } from '../utils/exactMatchRanking.js';
+import { COMPACT_METHODS_HINT, fullBodyHint } from '../utils/methodBodyHint.js';
 import {
   pageFields, fieldsHeading, fieldsFooter,
   createControlBudget, chargeControl, chargeSkippedSubtree, controlsFooter,
@@ -266,7 +267,10 @@ function formatClass(cls: BridgeClassInfo, compact: boolean, methodOffset: numbe
       out += `### ${m.name}\n\n`;
       if (m.source) {
         const preview = m.source.substring(0, 500);
-        out += `\`\`\`xpp\n${preview}${m.source.length > 500 ? '\n// ... (use get_method(include="source") for full body)' : ''}\n\`\`\`\n\n`;
+        // Same call syntax as COMPACT_METHODS_HINT below — two different ways to
+        // ask for one method body, fifteen lines apart, is the inconsistency
+        // this hint exists to remove.
+        out += `\`\`\`xpp\n${preview}${m.source.length > 500 ? `\n// ... (${fullBodyHint(m.name)})` : ''}\n\`\`\`\n\n`;
       }
     }
   }
@@ -281,8 +285,18 @@ function formatClass(cls: BridgeClassInfo, compact: boolean, methodOffset: numbe
   // the bridge path (the primary, "always available on VM" path) silently gave
   // signatures with no pointer to the escape hatch, which read as "no source
   // available for this class" when it was really "not requested".
-  if (compact && total > 0) {
-    out += `> 💡 Signatures only. Pass \`options:{"compact":false}\` for method bodies, or \`options:{"method":"<name>","include":"source"}\` for one method.\n\n`;
+  //
+  // Gated on the RENDERED page carrying source, not on `total`. Bridge method
+  // source is Safe(() => method.Source) and BridgeMethodInfo.source is
+  // optional, so a class can come back with none: the compact:false branch
+  // above then prints `### name` and no code block at all (`if (m.source)`),
+  // which is strictly LESS than the signature line compact just gave — a round
+  // trip spent to lose information, on exactly the classes where the caller was
+  // already unsure whether source existed. The same guard covers an out-of-range
+  // methodOffset, where `visible` is empty and there is no signature on the page
+  // for "signatures only" to be describing.
+  if (compact && visible.some(m => m.source)) {
+    out += `${COMPACT_METHODS_HINT}\n\n`;
   }
 
   return out;

--- a/src/tools/readers/classInfo.ts
+++ b/src/tools/readers/classInfo.ts
@@ -9,6 +9,7 @@ import type { XppServerContext } from '../../types/context.js';
 import { validateWorkspacePath } from '../../workspace/workspaceUtils.js';
 import { buildObjectTypeMismatchMessage } from '../../utils/metadataResolver.js';
 import { tryBridgeClass } from '../../bridge/bridgeAdapter.js';
+import { COMPACT_METHODS_HINT, SOURCE_UNAVAILABLE_HINT, fullBodyHint } from '../../utils/methodBodyHint.js';
 
 const METHOD_PAGE_SIZE = 15;
 
@@ -73,7 +74,7 @@ export async function classInfoTool(request: CallToolRequest, context: XppServer
 
     // compact=true (default): serve entirely from DB — no filesystem access, instant response
     if (args.compact !== false) {
-      return buildDbOnlyResponse(args.className, classSymbol, symbolIndex, args.methodOffset ?? 0);
+      return buildDbOnlyResponse(args.className, classSymbol, symbolIndex, args.methodOffset ?? 0, 'compact');
     }
 
     // compact=false: parse XML for source bodies, with timeout guard to avoid hanging
@@ -91,7 +92,7 @@ export async function classInfoTool(request: CallToolRequest, context: XppServer
 
     if (!classInfo.success || !classInfo.data) {
       // Fallback to DB when XML not available (build agent, no D365FO install, timeout)
-      return buildDbOnlyResponse(args.className, classSymbol, symbolIndex, args.methodOffset ?? 0);
+      return buildDbOnlyResponse(args.className, classSymbol, symbolIndex, args.methodOffset ?? 0, 'source-unavailable');
     }
 
     const cls = classInfo.data;
@@ -144,7 +145,9 @@ export async function classInfoTool(request: CallToolRequest, context: XppServer
           output += `**Documentation:**\n${method.documentation}\n\n`;
         }
         
-        output += `\`\`\`xpp\n${method.source.substring(0, 200)}${method.source.length > 200 ? '\n// ... (use get_method(include="signature") for full body)' : ''}\n\`\`\`\n\n`;
+        // include="signature" returns the signature INSTEAD of the body, so the
+        // old text here named the one value that cannot answer "full body".
+        output += `\`\`\`xpp\n${method.source.substring(0, 200)}${method.source.length > 200 ? `\n// ... (${fullBodyHint(method.name)})` : ''}\n\`\`\`\n\n`;
       }
     }
 
@@ -182,6 +185,14 @@ async function buildDbOnlyResponse(
   classSymbol: any,
   symbolIndex: any,
   methodOffset: number,
+  /**
+   * Why this response carries signatures only. 'compact' means the caller never
+   * asked for bodies and `compact:false` will get them; 'source-unavailable'
+   * means they DID ask and the XML could not be read (no D365FO install, or the
+   * parse timed out), where repeating "pass compact:false" would send them
+   * round the same loop.
+   */
+  reason: 'compact' | 'source-unavailable',
 ): Promise<any> {
   const methods = symbolIndex.getClassMethods(className) as Array<{ name: string; signature?: string; isStatic?: boolean }>;
 
@@ -208,7 +219,15 @@ async function buildDbOnlyResponse(
   if (hasMore) {
     output += `\n> ⚠️ ${totalMethods - methodOffset - METHOD_PAGE_SIZE} more — call with \`methodOffset: ${methodOffset + METHOD_PAGE_SIZE}\`\n`;
   }
-  output += `\n> 💡 Use \`get_method(include="signature")\` for a full method body.\n`;
+  // Was: `Use get_method(include="signature") for a full method body` — which
+  // named the one `include` value that returns a signature INSTEAD of a body
+  // (getMethod.ts METHOD_INCLUDES is signature|source|both), on a tool that is
+  // no longer published in ListTools. An agent following it either got no body
+  // or called a name it could not see. Same wording as the bridge path now, so
+  // the two never disagree about the escape hatch.
+  output += totalMethods > 0
+    ? `\n${reason === 'compact' ? COMPACT_METHODS_HINT : SOURCE_UNAVAILABLE_HINT}\n`
+    : '';
 
   return { content: [{ type: 'text', text: output }] };
 }

--- a/src/tools/readers/getObjectInfo.ts
+++ b/src/tools/readers/getObjectInfo.ts
@@ -22,6 +22,7 @@ import { READER_DISPATCH, OBJECT_INFO_TYPES, withNotFoundGuidance } from './obje
 import { completionTool } from './completion.js';
 import { getMethodTool } from './getMethod.js';
 import { readObjectXml } from './objectXml.js';
+import { COMPACT_METHODS_HINT } from '../../utils/methodBodyHint.js';
 
 /** Ceiling on one plural call — inherited from the retired batch_get_info. */
 const MAX_OBJECTS = 10;
@@ -254,9 +255,21 @@ async function readObjects(refs: ObjectRef[], context: XppServerContext) {
   }));
 
   const okCount = results.filter(r => r.success).length;
-  const sections = results.map((r, i) =>
-    `## ${i + 1}. ${r.name} [${r.objectType.toUpperCase()}] ${r.success ? '' : '❌'}\n\n${r.text}`,
-  );
+  // The compact-methods hint is advice about how to call this tool, not a fact
+  // about one object, but it is emitted per class because that is the only
+  // place that knows whether bodies were withheld. Ten classes in one call
+  // would otherwise repeat the same two lines of call syntax ten times, in a
+  // response format that exists to save round trips. Keep the first, drop the
+  // rest.
+  let hintShown = false;
+  const sections = results.map((r, i) => {
+    let text = r.text;
+    if (text.includes(COMPACT_METHODS_HINT)) {
+      if (hintShown) text = text.split(`${COMPACT_METHODS_HINT}\n\n`).join('').split(COMPACT_METHODS_HINT).join('');
+      hintShown = true;
+    }
+    return `## ${i + 1}. ${r.name} [${r.objectType.toUpperCase()}] ${r.success ? '' : '❌'}\n\n${text}`;
+  });
 
   const header =
     `# Object Info\n\n` +

--- a/src/utils/methodBodyHint.ts
+++ b/src/utils/methodBodyHint.ts
@@ -1,0 +1,34 @@
+/**
+ * The one sentence that tells a caller a class listing withheld method bodies,
+ * and how to ask for them.
+ *
+ * It lives here, rather than beside either renderer, because three places have
+ * to agree on it and none of them owns the other two: the bridge class view
+ * (bridge/bridgeAdapter.ts), the DB-only view (tools/readers/classInfo.ts), and
+ * the plural response that collapses repeats of it (tools/readers/
+ * getObjectInfo.ts). A copy per renderer is how the two class paths came to
+ * give different, and in one case wrong, advice for the same situation.
+ *
+ * It names `options` on get_object_info, NOT the old `get_method` tool: that
+ * one is no longer published in ListTools (toolHandler.ts keeps the route only
+ * so an agent still holding the name from an earlier session gets an answer
+ * rather than "unknown tool"). And it asks for `include:"source"` — the value
+ * that returns a body. `include:"signature"` returns the signature instead,
+ * which is what the DB-only hint used to advertise for "a full method body".
+ */
+export const COMPACT_METHODS_HINT =
+  '> 💡 Signatures only. Pass `options:{"compact":false}` for method bodies, or `options:{"method":"<name>","include":"source"}` for one method.';
+
+/**
+ * The same situation reached the other way round: bodies WERE requested and the
+ * source could not be read (no D365FO install on this host, or the XML parse
+ * timed out). Repeating "pass compact:false" there would send the caller round
+ * the loop they just came from.
+ */
+export const SOURCE_UNAVAILABLE_HINT =
+  '> 💡 Signatures only — the source file could not be read (no D365FO install here, or the parse timed out). `options:{"method":"<name>","include":"source"}` may still resolve a single method.';
+
+/** How to ask for the rest of a body that was truncated in a listing. */
+export function fullBodyHint(methodName: string): string {
+  return `options:{"method":"${methodName}","include":"source"} for the full body`;
+}

--- a/tests/tools/classInfoCompactHint.test.ts
+++ b/tests/tools/classInfoCompactHint.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The "signatures only" hint on a compact class listing (#914 and its audit).
+ *
+ * A compact class view is signatures with no bodies, and it is the DEFAULT, so
+ * for a caller who never read the tool schema it is indistinguishable from "no
+ * source is available for this class" — which for a standard Microsoft class is
+ * a dead end, since there is no workspace copy to check against. The hint says
+ * which of the two it is.
+ *
+ * What it must NOT do is promise something the follow-up call cannot deliver:
+ * a class whose bridge methods carry no source renders FEWER bytes with
+ * compact:false than without it, so pointing there costs a round trip to lose
+ * information. And it must not name `get_method(include="signature")`, which is
+ * the one include value that returns a signature instead of a body, on a tool
+ * that is no longer published in ListTools.
+ */
+import { describe, it, expect } from 'vitest';
+import { tryBridgeClass } from '../../src/bridge/bridgeAdapter.js';
+import { COMPACT_METHODS_HINT } from '../../src/utils/methodBodyHint.js';
+import type { BridgeClassInfo, BridgeMethodInfo } from '../../src/bridge/bridgeTypes.js';
+
+function method(name: string, source?: string): BridgeMethodInfo {
+  return { name, returnType: 'void', source } as BridgeMethodInfo;
+}
+
+function classInfo(methods: BridgeMethodInfo[]): BridgeClassInfo {
+  return {
+    name: 'CustPostInvoice',
+    isAbstract: false,
+    isFinal: false,
+    isStatic: false,
+    model: 'ApplicationSuite',
+    methods,
+  } as BridgeClassInfo;
+}
+
+/** Minimal stand-in for the bridge client tryBridgeClass talks to. */
+function fakeBridge(cls: BridgeClassInfo): any {
+  return { isReady: true, metadataAvailable: true, readClass: async () => cls };
+}
+
+async function render(cls: BridgeClassInfo, compact: boolean, methodOffset = 0): Promise<string> {
+  const result = await tryBridgeClass(fakeBridge(cls), cls.name, compact, methodOffset);
+  return (result!.content[0] as { text: string }).text;
+}
+
+describe('compact class listing hint', () => {
+  it('tells the caller bodies were withheld rather than absent', async () => {
+    const out = await render(classInfo([method('run', 'public void run() { info("x"); }')]), true);
+
+    expect(out).toContain(COMPACT_METHODS_HINT);
+  });
+
+  it('stays out of the way when bodies were actually asked for', async () => {
+    const out = await render(classInfo([method('run', 'public void run() { info("x"); }')]), false);
+
+    expect(out).not.toContain(COMPACT_METHODS_HINT);
+  });
+
+  it('does not offer compact:false for a class whose methods carry no source', async () => {
+    // Bridge method source is Safe(() => method.Source) and `source` is
+    // optional, so this is a real shape. The compact:false render of the same
+    // class emits `### run` and no code block at all — strictly less than the
+    // signature line compact already gave, for one more round trip.
+    const cls = classInfo([method('run'), method('validate')]);
+    const compactOut = await render(cls, true);
+    const verboseOut = await render(cls, false);
+
+    expect(compactOut).not.toContain(COMPACT_METHODS_HINT);
+    expect(verboseOut).not.toContain('```xpp');
+  });
+
+  it('does not claim "signatures only" on a page that rendered no signatures', async () => {
+    // An out-of-range methodOffset slices to nothing; there is no signature on
+    // the page for the hint to be describing.
+    const cls = classInfo([method('run', 'public void run() {}')]);
+    const out = await render(cls, true, 30);
+
+    expect(out).not.toContain(COMPACT_METHODS_HINT);
+  });
+
+  it('never points at get_method(include="signature") for a body', async () => {
+    // That include value returns the signature INSTEAD of the body, and
+    // get_method is no longer published in ListTools — an agent following it
+    // either gets no body or calls a name it cannot see.
+    const long = `public void run()\n{\n${'    info("x");\n'.repeat(80)}}`;
+    const compactOut = await render(classInfo([method('run', long)]), true);
+    const verboseOut = await render(classInfo([method('run', long)]), false);
+
+    expect(compactOut).not.toContain('get_method(include=');
+    expect(verboseOut).not.toContain('get_method(include=');
+    // The truncated body still has to say how to get the rest of it.
+    expect(verboseOut).toContain('"include":"source"');
+  });
+});
+
+/**
+ * The hint is advice about how to call the tool, not a fact about one object,
+ * but only the per-class renderer knows whether bodies were withheld. The
+ * plural form fans out to as many as MAX_OBJECTS=10 readers, so without a
+ * dedupe a ten-class batch carries ten identical copies of the same two lines
+ * of call syntax — in the very response format that exists to save round trips.
+ */
+describe('compact hint in a multi-object response', () => {
+  it('says it once, not once per class', async () => {
+    const withSource = (name: string) => ({
+      name, isAbstract: false, isFinal: false, isStatic: false, model: 'ApplicationSuite',
+      methods: [{ name: 'run', returnType: 'void', source: 'public void run() { info("x"); }' }],
+    });
+    const classes: Record<string, any> = {
+      CustPostInvoice: withSource('CustPostInvoice'),
+      VendPostInvoice: withSource('VendPostInvoice'),
+      SalesPostInvoice: withSource('SalesPostInvoice'),
+    };
+    const context: any = {
+      bridge: { isReady: true, metadataAvailable: true, readClass: async (n: string) => classes[n] },
+    };
+
+    const { getObjectInfoTool } = await import('../../src/tools/readers/getObjectInfo.js');
+    const result: any = await getObjectInfoTool({
+      method: 'tools/call',
+      params: {
+        name: 'get_object_info',
+        arguments: {
+          objects: Object.keys(classes).map(name => ({ objectType: 'class', objectName: name })),
+        },
+      },
+    } as any, context);
+
+    const text: string = result.content[0].text;
+    // Every class is still there — the dedupe must drop the repeated advice,
+    // not any of the metadata that made the batch worth requesting.
+    for (const name of Object.keys(classes)) expect(text).toContain(name);
+    expect(text.split(COMPACT_METHODS_HINT).length - 1).toBe(1);
+  });
+});


### PR DESCRIPTION
Audit follow-ups on #914. That PR fixed a real silence — the bridge class view gave signatures with no sign that bodies *existed but were withheld*, which reads as "no source available for this class", worst of all on standard Microsoft classes where there is no workspace copy to check against. These are the edges around it.

## 1. The guard never checked that anything was actually withheld

`compact && total > 0` is true for classes the follow-up call cannot help.

- **Methods with no source.** Bridge method source is `Safe(() => method.Source)` (`MetadataReadService.cs:467`) and `BridgeMethodInfo.source` is optional, so a class can come back with none. The `compact:false` branch then prints `### name` and **no code block at all** (`if (m.source)`) — strictly *less* than the signature line compact just gave. The hint was spending a round trip to lose information, on exactly the classes where the caller was already unsure whether source existed.
- **Out-of-range `methodOffset`.** `visible` slices to empty, so the response said "Signatures only…" under a page that rendered no signatures.

Now gated on `visible.some(m => m.source)`.

## 2. The hint multiplied by the batch size

`formatClass` runs per object and `get_object_info` takes up to `MAX_OBJECTS = 10`, so ten classes in one call carried ten identical copies of the same two lines of call syntax — in the response format that exists to save round trips. `readObjects()` keeps the first and drops the rest.

## 3. The prior art it cited was itself wrong

The DB-only hint read ``Use `get_method(include="signature")` for a full method body``. `include:"signature"` returns the signature **instead of** the body (`METHOD_INCLUDES` is `signature|source|both`), and `get_method` is no longer published in ListTools — `toolHandler.ts:308` keeps the route only so an agent holding the name from an earlier session gets an answer rather than "unknown tool". An agent following that line either got no body or called a name it could not see. The same claim appeared a second time on truncated bodies in the XML path (`classInfo.ts:147`). Both now use the shared wording.

## The wording moved to `utils/methodBodyHint.ts`

Three places have to agree on it and none owns the other two — the bridge view, the DB-only view, and the plural response that collapses repeats. A copy per renderer is exactly how the two class paths came to give different, and in one case wrong, advice for the same situation. (It also removes a `tools/readers` → `bridge/` import that only existed to reach the constant.)

`buildDbOnlyResponse` now distinguishes its two callers, which want opposite advice: reached via `compact` it offers `compact:false`; reached *because* the XML could not be parsed (no D365FO install, or the 3 s parse timeout) it says so, instead of sending the caller round the loop they just came from.

## Verification

Behavioural probe against the merged #914 tree, same script before and after:

| case | before | after |
|---|---|---|
| class whose methods carry no source, compact | hint shown | no hint |
| out-of-range `methodOffset` | hint shown | no hint |
| three-class batch | 3 copies | 1 copy |

Six new tests in `tests/tools/classInfoCompactHint.test.ts` cover all of it, including that the truncated-body marker still says how to get the rest. Full suite green: 311 files, 3920 passed / 2 skipped; `tsc --noEmit` and `biome lint` clean.

## Not addressed here

- `get_method(...)` is named in ~15 more places (knowledge entries, prompts, codegen templates). Those mostly ask for `include:"signature"` and genuinely want a signature, so they are not wrong the way #3 was — but they all name a tool that ListTools no longer advertises. That is a separate sweep.
- An out-of-range `methodOffset` still renders the nonsense header `Methods (20 total, showing 31–20)`. Out of scope here; this PR only stops the hint from appearing under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)