### PR TITLE
fix(guidance): stop telling agents to call method readers that are not published

### DIFF
--- a/src/prompts/codeReview.ts
+++ b/src/prompts/codeReview.ts
@@ -236,7 +236,7 @@ ${classSource}
 Use CoC when you need to wrap or augment an existing method's logic.
 
 ### Prerequisites
-1. Call \`get_method(include="signature")\` to get exact parameter types and return type
+1. Call \`get_object_info(objectType="class", name, options:{"method":"<name>","include":"signature"})\` to get exact parameter types and return type
 2. Call \`extension_info(mode="coc")\` to check if the method is already wrapped
 3. Call \`extension_info(mode="points")\` to verify the method is CoC-eligible (not \`final\` / \`[Hookable(false)]\`)
 

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -57,7 +57,7 @@ You are an AI assistant with access to D365FO MCP tools, assisting with Dynamics
 | Only custom/ISV code | \`search(query, scope="extensions")\` |
 | Full info for KNOWN names | \`get_object_info(objectType, name, options?)\` — objectType ∈ class/table/form/query/view/enum/edt/report/data-entity/menu-item/service/map/config-key/security-policy/macro. 2+ objects: \`get_object_info(objects=[{objectType,objectName},…])\` — ONE call, never a loop |
 | Member names by prefix | \`get_object_info(objectType="class", name, options={members:"names", prefix})\` |
-| Exact signature before CoC | \`get_method(include="signature")\` (included in \`prepare(mode="change")\`) |
+| Exact signature before CoC | \`get_object_info(objectType, name, options={method:"<name>", include:"signature"})\` (included in \`prepare(mode="change")\`) |
 | Where is X used | \`find_references(targetName)\` |
 | Which extension mechanism | \`extension_info(mode="strategy", goal)\` BEFORE any extension work |
 | Existing CoC / event handlers | \`extension_info(mode="coc"|"events"|"points", target)\` |

--- a/src/tools/knowledge/d365foErrorHelp.ts
+++ b/src/tools/knowledge/d365foErrorHelp.ts
@@ -6,6 +6,7 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { READ_METHOD_OPTIONS } from '../../utils/methodBodyHint.js';
 
 // Schema
 
@@ -136,7 +137,7 @@ while (!done && retryCount < 5)
       'Add "next methodName(_params);" inside the CoC method — before, after, or replacing surrounding logic',
       'Store the return value: "ReturnType ret = next methodName(_params);"',
       'Only omit next in extremely rare cases where you intentionally replace (not extend) the method — document this explicitly',
-      'Verify the exact method signature with get_method(include="signature") first',
+      `Verify the exact method signature with ${READ_METHOD_OPTIONS} first`,
     ],
     example: `[ExtensionOf(tableStr(CustTable))]
 final class CustTable_MyModel_Extension

--- a/src/tools/knowledge/extensionStrategyAdvisor.ts
+++ b/src/tools/knowledge/extensionStrategyAdvisor.ts
@@ -6,6 +6,7 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { readMethodCall } from '../../utils/methodBodyHint.js';
 import type { XppServerContext } from '../../types/context.js';
 
 // Schema
@@ -124,7 +125,7 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
     ],
     nextSteps: [
       'extension_info(mode="points", target="TableName") — check initValue availability',
-      'get_method(include="signature", className="TableName", methodName="initValue") — exact signature for the CoC wrapper',
+      `${readMethodCall('table', 'TableName', 'initValue')} — exact signature for the CoC wrapper`,
     ],
     antiPatterns: [
       { wrong: 'Overriding insert()', why: 'insert() is for persistence — defaults belong in initValue()' },
@@ -163,7 +164,7 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
     ],
     nextSteps: [
       'extension_info(mode="points", target="TableName") — confirm modifiedField is CoC-eligible and see existing extensions',
-      'get_method(include="signature", className="TableName", methodName="modifiedField") — exact signature for the CoC wrapper',
+      `${readMethodCall('table', 'TableName', 'modifiedField')} — exact signature for the CoC wrapper`,
       'extension_info(mode="coc", target="TableName", method="modifiedField") — check for existing wrappers',
     ],
     antiPatterns: [
@@ -196,7 +197,7 @@ const STRATEGY_RULES: readonly StrategyRule[] = [
     ],
     nextSteps: [
       'extension_info(mode="points", target="ClassName") — see CoC-eligible methods and delegates',
-      'get_method(include="signature", className="ClassName", methodName="methodName") — exact signature for the CoC wrapper',
+      `${readMethodCall('class', 'ClassName', 'methodName')} — exact signature for the CoC wrapper`,
       'extension_info(mode="coc", target="ClassName", method="methodName") — check for existing CoC wrappers',
     ],
     antiPatterns: [

--- a/src/tools/knowledge/methodSignature.ts
+++ b/src/tools/knowledge/methodSignature.ts
@@ -9,6 +9,7 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { readMethodCall } from '../../utils/methodBodyHint.js';
 import type { XppServerContext } from '../../types/context.js';
 import { buildObjectTypeMismatchMessage } from '../../utils/metadataResolver.js';
 import type { BridgeClient } from '../../bridge/bridgeClient.js';
@@ -156,7 +157,7 @@ export async function getMethodSignatureTool(request: CallToolRequest, context: 
         content: [{
           type: 'text',
           text: `ℹ️ \`${className}.classDeclaration\` is the class header, not a method — it has no signature.\n\n` +
-            `Use \`get_method(className="${className}", methodName="classDeclaration", include="source")\` to read the declaration source, ` +
+            `Use \`${readMethodCall('class', className, 'classDeclaration', 'source')}\` to read the declaration source, ` +
             `or \`get_object_info(objectType="class", name="${className}")\` for the class overview.`,
         }],
         isError: true,

--- a/src/tools/knowledge/xppKnowledge.ts
+++ b/src/tools/knowledge/xppKnowledge.ts
@@ -15,6 +15,7 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { READ_METHOD_OPTIONS } from '../../utils/methodBodyHint.js';
 
 // ─── Schema ─────────────────────────────────────────────────────────────────
 
@@ -346,7 +347,7 @@ while (qr.next())
     rules: [
       'Extension class MUST be [ExtensionOf(classStr/tableStr/formStr(Target))]',
       'Extension class MUST be final',
-      'Method signature MUST match the original exactly (use get_method(include="signature") tool)',
+      `Method signature MUST match the original exactly (use ${READ_METHOD_OPTIONS})`,
       'The target may INHERIT the method rather than declare it — that compiles, and the signature is then validated against the declaring base class. See class-inheritance',
       'ALWAYS call next <methodName>() — skipping it breaks the chain for other extensions',
       'Cannot access private members of the original class',
@@ -616,7 +617,7 @@ class MyReportDP extends SrsReportDataProviderBase
       'systemDateGet() → see the datetime-timezones topic — BPUpgradeCodeSystemDate',
       'SysEntryPointAttribute on CUSTOM SERVICE operations → obsolete in AX7 ("This attribute is deprecated in AX7"); still REQUIRED on SysOperation service entry points — see the custom-services topic',
       '[SysObsolete] attribute: ALWAYS read the message — it names the replacement',
-      'When get_method(include="source") returns a method with [SysObsolete], do NOT call it — use the stated replacement',
+      'When a method read with include:"source" carries [SysObsolete], do NOT call it — use the stated replacement',
       // Everything below is a deprecation an agent is likely to "remember" but that
       // is not real. Listing them here — rather than silently omitting them — is the
       // only way a keyword search for "curext"/"infolog" lands on the correction
@@ -2286,7 +2287,7 @@ select salesTable where salesTable.ShippingDateRequested == cutoffDate;`,
       'validatewrite', 'validatefield', 'validatedelete', 'modifiedfield', 'table coc', 'orig', 'pre-image', 'old value', 'xrecord'],
     summary:
       'Strict rules for authoring CoC wrappers. The most common mistake is copying default parameter values. ' +
-      'next must always be called at first-level scope. Always use get_method(include="signature") before writing any wrapper.',
+      `next must always be called at first-level scope. Always use ${READ_METHOD_OPTIONS} before writing any wrapper.`,
     rules: [
       'NEVER copy default parameter values into the wrapper signature — wrapper uses bare parameter types only',
       'next must be at first-level statement scope: NOT inside if/while/for, NOT after return, NOT inside a logical expression. PU21+: permitted inside try/catch/finally',
@@ -2299,9 +2300,9 @@ select salesTable where salesTable.ShippingDateRequested == cutoffDate;`,
       'Form-nested wrapping uses formdatasourcestr, formdatafieldstr, formControlStr. Cannot ADD new methods via CoC — only wrap existing ones (init, validateWrite, clicked, …)',
       'Wrappers can read/call protected members of the augmented class (PU9+); cannot reach private',
       'Pre-processing: call business logic before next. Post-processing: call next first, then business logic. Wrap: call next inside the logic',
-      'Use get_method(include="signature") tool to get exact parameter types before writing the wrapper',
+      `Use ${READ_METHOD_OPTIONS} to get exact parameter types before writing the wrapper`,
       'On a TABLE wrapper (validateWrite/validateField/update/delete/modifiedField) the record is already in hand: `this` carries the new values and `this.orig()` the values it was fetched with. NEVER re-read the row — no `select … where x.RecId == this.RecId`, no `MyTable::findRecId(this.RecId)`. That is a database round trip on every write and it returns the current stored state, not this buffer\'s pre-image. On an insert `this.orig()` is empty, so `this.orig().RecId == 0` is the "new record" test. Rule COC006 flags the re-read',
-      'The table data methods are declared by kernel types (xRecord/Common), so the symbol index has no row for them and "not found" there is not evidence they do not exist — prepare(mode="change") and get_method answer for them from a built-in contract instead',
+      'The table data methods are declared by kernel types (xRecord/Common), so the symbol index has no row for them and "not found" there is not evidence they do not exist — prepare(mode="change") and get_object_info options:{"method":...} answer for them from a built-in contract instead',
       'REUSE BEFORE CREATING: if a CoC extension class for the target already exists in the custom model (prepare(mode="change") / extension_info(mode="coc") lists them), add the wrapper there — never create a parallel feature-named class (<Target>_<Feature>_Extension) unless the user explicitly requests separation',
       'The class suffix comes from EXTENSION_NAMING_STYLE and existing related artifacts — never from feature names, tickets, or customer names; if it cannot be derived, ask the user',
     ],

--- a/src/tools/readers/getMethod.ts
+++ b/src/tools/readers/getMethod.ts
@@ -15,6 +15,7 @@
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../../types/context.js';
+import { readMethodCall } from '../../utils/methodBodyHint.js';
 import { getMethodSignatureTool } from '../knowledge/methodSignature.js';
 import { getMethodSourceTool } from './getMethodSource.js';
 
@@ -35,7 +36,11 @@ export async function getMethodTool(request: CallToolRequest, context: XppServer
   const parsed = GetMethodArgsSchema.safeParse(request.params.arguments ?? {});
   if (!parsed.success) {
     return {
-      content: [{ type: 'text', text: `❌ get_method: invalid arguments — ${parsed.error.message}` }],
+      // Named for the PUBLISHED route, not this function. Most callers reach
+      // here through get_object_info's folded options.method — get_method is no
+      // longer in ListTools — so an error headed "get_method:" describes a call
+      // they never made and cannot look up.
+      content: [{ type: 'text', text: `❌ get_object_info (options.method): invalid arguments — ${parsed.error.message}` }],
       isError: true,
     };
   }
@@ -47,8 +52,8 @@ export async function getMethodTool(request: CallToolRequest, context: XppServer
       content: [{
         type: 'text',
         text:
-          `❌ get_method: missing required parameter "className".\n\n` +
-          `Usage: get_method(className="MyClass", methodName="myMethod")\n\n` +
+          `❌ Reading one method needs the object that owns it.\n\n` +
+          `Usage: ${readMethodCall('class', 'MyClass', 'myMethod')}\n\n` +
           `If you only know the method name, use search(query="myMethod", type="method") first ` +
           `to find which class it belongs to.`,
       }],

--- a/src/tools/smart/codeGen.ts
+++ b/src/tools/smart/codeGen.ts
@@ -5,6 +5,7 @@
 
 import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
+import { readMethodCall } from '../../utils/methodBodyHint.js';
 import { resolveObjectPrefix, applyObjectPrefix, deriveExtensionInfix, getObjectSuffix, applyObjectSuffix } from '../../utils/modelClassifier.js';
 import { getConfigManager } from '../../utils/configManager.js';
 import { enforceGrounding } from '../../utils/provenanceStore.js';
@@ -303,7 +304,7 @@ function classExtensionTemplate(baseName: string, prefix: string): string {
 final class ${className}
 {
     // ⚠️  DO NOT add CoC methods before checking the original signature:
-    //     get_method_signature("${baseName}", "methodName")
+    //     ${readMethodCall('class', baseName, '<methodName>')}
     //
     // X++ does NOT support method overloading — two methods with the same name
     // will always cause a compile error, even with different signatures.
@@ -448,7 +449,7 @@ function mapExtensionTemplate(baseName: string, prefix: string): string {
 [ExtensionOf(mapStr(${baseName}))]
 final class ${className}
 {
-    // ⚠️  Always call get_method_signature("${baseName}", "methodName") before adding a CoC method.
+    // ⚠️  Always check the original signature with get_object_info(objectType="map", name="${baseName}") before adding a CoC method.
     //     X++ does NOT support method overloading — duplicate method names always cause compile errors.
     //
     // Instance CoC example:
@@ -1926,7 +1927,7 @@ export async function codeGenTool(request: CallToolRequest) {
             : `⚠️ **No prefix resolved** — set \`EXTENSION_PREFIX\` env var or pass \`modelName\` argument.\n  Generated bare name without prefix infix (e.g. \`${baseName}_Extension\`) which is **not MS-compliant**.`;
           namingNote = namingLine + '\n\n' +
             `🚨 **REQUIRED before adding CoC methods:**\n` +
-            `   Call \`get_method(include="signature", "${baseName}", "methodName")\` for EACH method you want to wrap.\n` +
+            `   Call \`${readMethodCall('class', baseName, '<methodName>')}\` for EACH method you want to wrap.\n` +
             `   X++ does NOT support method overloading — adding both \`public boolean foo()\` and \`public static boolean foo()\`\n` +
             `   in the same class will always cause a compile error.\n` +
             `   The signature tool tells you whether the original is \`static\` or instance, so you generate exactly ONE CoC method.`;
@@ -1988,7 +1989,7 @@ export async function codeGenTool(request: CallToolRequest) {
             // (positional, not `className`/`methodName`), so following it cost a
             // failed call before the agent could get anything useful.
             (args.pattern === 'class-extension'
-              ? `\n\n⚠️ Before writing any CoC method call \`get_method(include="signature", className="${displayName}", methodName="<methodName>")\` — ` +
+              ? `\n\n⚠️ Before writing any CoC method call \`${readMethodCall('class', displayName, '<methodName>')}\` — ` +
                 `never guess static vs instance, the return type or the parameter list. ` +
                 `Existing wrappers: \`extension_info(mode="coc", target="${displayName}")\`.`
               : ``),

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs/promises';
 import { escapeXml } from '../../utils/xmlEscape.js';
+import { readMethodCall } from '../../utils/methodBodyHint.js';
 import { buildAxTableXml } from '../xml/tableXml.js';
 import { buildAxFormXml } from '../xml/formXml.js';
 import {
@@ -656,7 +657,7 @@ ${methodsXml}\t</SourceCode>
     const baseClass = properties?.baseClass || extensionName.replace(/_[^_]+_Extension$/, '');
 
     const defaultSource = sourceCode ||
-      `[ExtensionOf(classStr(${baseClass}))]\nfinal class ${extensionName}\n{\n    // ⚠️  ALWAYS call next <methodName>() — verify exact signature with:\n    //     get_method(include="signature", "${baseClass}", "methodName")\n    //\n    // Template for wrapping a method:\n    //   public ReturnType methodName(ParamType _param)\n    //   {\n    //       ReturnType result = next methodName(_param);\n    //       return result;\n    //   }\n}`;
+      `[ExtensionOf(classStr(${baseClass}))]\nfinal class ${extensionName}\n{\n    // ⚠️  ALWAYS call next <methodName>() — verify exact signature with:\n    //     ${readMethodCall('class', baseClass, '<methodName>')}\n    //\n    // Template for wrapping a method:\n    //   public ReturnType methodName(ParamType _param)\n    //   {\n    //       ReturnType result = next methodName(_param);\n    //       return result;\n    //   }\n}`;
 
     return XmlTemplateGenerator.generateAxClassXml(extensionName, defaultSource, { ...properties });
   }
@@ -3690,7 +3691,7 @@ export async function handleCreateD365File(
           const INLINE_LIMIT = 8000;
           inlineContent = existingContent.length <= INLINE_LIMIT
             ? `\n\n----- BEGIN ${path.basename(normalizedFullPath)} -----\n${existingContent}\n----- END -----`
-            : `\n\n(File is ${sizeKb} KB — too large to inline. Use get_method / get_object_info to read specific members.)`;
+            : `\n\n(File is ${sizeKb} KB — too large to inline. Use get_object_info to read specific members.)`;
         }
 
         // When the requested objectName was normalized to a different on-disk name,

--- a/src/tools/write/resolveReferences.ts
+++ b/src/tools/write/resolveReferences.ts
@@ -793,7 +793,7 @@ export function resolveXppReferences(code: string, deps: ResolverDeps): ResolveR
         severity: 'error',
         line,
         identifier: `${typeName}::${member}`,
-        detail: `Static method "${member}" not found on ${typeName} (checked inheritance chain and extensions). Use get_object_info(objectType="class", name="${typeName}") or get_method(include="signature").`,
+        detail: `Static method "${member}" not found on ${typeName} (checked inheritance chain and extensions). Use get_object_info(objectType="class", name="${typeName}") — add options:{"method":"${member}","include":"signature"} for that one method.`,
       });
       continue;
     }

--- a/src/utils/methodBodyHint.ts
+++ b/src/utils/methodBodyHint.ts
@@ -32,3 +32,33 @@ export const SOURCE_UNAVAILABLE_HINT =
 export function fullBodyHint(methodName: string): string {
   return `options:{"method":"${methodName}","include":"source"} for the full body`;
 }
+
+/**
+ * The published call that reads one method, written out in full.
+ *
+ * Every instruction the server hands an agent goes through here so they cannot
+ * drift apart, and so none of them names `get_method` again. That tool is not
+ * in ListTools (toolHandler.ts keeps the route for agents holding the old name,
+ * nothing more), and the even older `get_method_signature` is not routable at
+ * all — it only ever existed as an internal sub-request inside getMethod.ts, so
+ * an agent told to call it gets "unknown tool" with no way to recover.
+ *
+ * `include` is the part worth being exact about: "signature" returns the
+ * signature, "source" the body. Asking for the wrong one is a wasted round trip
+ * at best, and telling an agent to use "signature" to read a body — which the
+ * class readers used to do — sends it away believing no body exists.
+ */
+export function readMethodCall(
+  objectType: 'class' | 'table' | 'view' | 'data-entity',
+  objectName: string,
+  methodName: string,
+  include: 'signature' | 'source' | 'both' = 'signature',
+): string {
+  return `get_object_info(objectType="${objectType}", name="${objectName}", options:{"method":"${methodName}","include":"${include}"})`;
+}
+
+/**
+ * The same call as guidance rather than a concrete invocation, for prose that
+ * has no particular object in hand.
+ */
+export const READ_METHOD_OPTIONS = 'get_object_info options:{"method":"<name>","include":"signature"}';

--- a/tests/tools/guidanceNamesPublishedTools.test.ts
+++ b/tests/tools/guidanceNamesPublishedTools.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Guidance the server hands an agent must name a tool the agent can actually
+ * see in ListTools.
+ *
+ * `get_method` is not published — toolHandler.ts keeps the route only so an
+ * agent still holding the name from an earlier session gets an answer instead
+ * of "unknown tool" — and `get_method_signature` is not routable at all; it
+ * only ever existed as an internal sub-request name inside getMethod.ts. Yet
+ * both were spelled out as call syntax in knowledge entries, CoC prompts, error
+ * details and the comment headers of generated X++ files. An agent following
+ * one of those either calls a name it cannot look up, or (the `include:
+ * "signature"` case that started this) asks for a signature while being told it
+ * is asking for a body.
+ *
+ * Asserted against the source rather than against each rendered string: this
+ * text is spread over knowledge arrays, prompt templates and code generators
+ * that would each need their own fixture, and the rule — do not write
+ * `get_method(...)` into text an agent reads — is checkable directly.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { globSync } from 'node:fs';
+
+const SRC = join(process.cwd(), 'src');
+
+/** Call syntax for the unpublished readers, wherever it appears in text. */
+const UNPUBLISHED_CALL = /\bget_method(_signature|_source)?\s*\(/;
+
+/**
+ * A line that only *talks about* the old name — the docblocks explaining why it
+ * is gone, and the audit note in classInfo.ts recording what the wording used
+ * to be — is the point, not a violation. Only instructions matter here.
+ */
+function isComment(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
+describe('agent-facing guidance', () => {
+  it('never spells out a call to an unpublished method reader', () => {
+    const files = globSync('**/*.ts', { cwd: SRC }).map(f => join(SRC, f));
+    expect(files.length).toBeGreaterThan(100);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf-8').split('\n');
+      lines.forEach((line, i) => {
+        if (isComment(line)) return;
+        if (UNPUBLISHED_CALL.test(line)) {
+          offenders.push(`${relative(process.cwd(), file)}:${i + 1}: ${line.trim().slice(0, 120)}`);
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-on sweep from the #914 audit (#917). That audit found **one** class hint naming `get_method(include="signature")` for a method body. The same name turned out to be spelled out as call syntax in **fourteen** more places.

## Why these are broken, not just outdated

- **`get_method` is not in ListTools.** `toolHandler.ts:308` keeps the route only so an agent still holding the name from an earlier session gets an answer instead of "unknown tool". An agent reading fresh guidance cannot look the name up.
- **`get_method_signature` is not routable at all.** It only ever existed as an internal sub-request name inside `getMethod.ts`. The two generated X++ templates that told the agent to call it named something that has **never** answered.

## What changed

Rewritten to the published `get_object_info(objectType, name, options:{"method":…,"include":…})` form across:

| where | what it is |
|---|---|
| `prompts/codeReview.ts`, `prompts/systemInstructions.ts` | the CoC prerequisites step and the tool-routing table |
| `knowledge/xppKnowledge.ts` (×5) | CoC rules, `[SysObsolete]` rule, table-data-methods note |
| `knowledge/extensionStrategyAdvisor.ts` (×3) | the "exact signature for the CoC wrapper" step |
| `knowledge/d365foErrorHelp.ts`, `knowledge/methodSignature.ts` | error remediation and the `classDeclaration` redirect |
| `smart/codeGen.ts` (×4) | class- and map-extension X++ headers, plus two response notes |
| `write/createD365File.ts` (×2) | the class-extension header written into real X++ files |
| `write/resolveReferences.ts` | the static-method not-found detail |

The **map** template is the one that could not just be re-spelled: `METHOD_OWNER_TYPES` is `class/table/view/data-entity`, so `options.method` on a map is *refused* with "map stores no methods". It now points at the map reader rather than at a call that would come back as an error.

The wording lives in `utils/methodBodyHint.ts` beside the hint from #917 — `readMethodCall()` when an object name is in hand, `READ_METHOD_OPTIONS` for prose with none — because a copy per call site is how the two class readers came to disagree in the first place.

Also renamed `getMethodTool`'s two error messages after the published route: most callers reach that function through `get_object_info`'s folded `options.method`, so an error headed `❌ get_method: …` described a call they never made and could not look up.

## Verification

- The new test asserts the **rule**, not the instances: no non-comment line under `src/` may spell out `get_method(...)` or `get_method_signature(...)`. Against the pre-sweep tree it reports **14 offenders**; comment lines are exempt on purpose, since the docblocks explaining why the name is gone are the point.
- Rendered spot-check of the generated X++ headers, so the replacement reads correctly where it lands in a real file:
  ```
  //     get_object_info(objectType="class", name="CustPostInvoice", options:{"method":"<methodName>","include":"signature"})
  ```
- Full suite green: 312 files, 3921 passed / 2 skipped; `tsc --noEmit` and `biome lint` clean.

## Left alone deliberately

Internal uses of the name — the `case 'get_method'` route, the tool-name lists in `transport.ts` / `bridgeReadiness.ts` / `toolProgressMessage.ts`, the internal `subRequest('get_method_signature', …)` calls, and `get_object_info`'s own description saying it "replaces the former … `get_method` tools" (accurate, and it tells an agent not to go looking). Comments explaining the history stay too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)