### PR TITLE
fix(build): point -compilermetadata at the model store, not the framework dir

### DIFF
--- a/src/tools/sdlc/buildProject.ts
+++ b/src/tools/sdlc/buildProject.ts
@@ -1,7 +1,7 @@
 import { execFile, spawn } from 'child_process';
 import util from 'util';
 import path from 'path';
-import { access, writeFile, readFile, unlink, appendFile, readdir, stat } from 'fs/promises';
+import { access, writeFile, readFile, unlink, appendFile, readdir, rm, stat } from 'fs/promises';
 import { openSync as openSyncFs, closeSync as closeSyncFs } from 'fs';
 import os from 'os';
 import crypto from 'crypto';
@@ -404,14 +404,36 @@ async function readWholeLog(logFile: string): Promise<string> {
   }
 }
 
+/** First and last line of the verbatim xppc invocation written at the top of every build log. */
+const INVOCATION_HEADER_START = '=== xppc invocation ===';
+const INVOCATION_HEADER_END   = '=======================';
+
+/**
+ * Line indices of that invocation header, or [] if the log does not start with one.
+ *
+ * The header exists so a failed build can be traced back to the arguments that produced it —
+ * which root `-compilermetadata` pointed at, above all. A failed build is also the only time
+ * readFullLog takes its diagnostic-window path, and that path returns windows plus a tail, so
+ * without this the header reached the response only for logs short enough to be returned whole.
+ */
+function invocationHeaderRange(all: string[]): number[] {
+  if (all[0]?.trim() !== INVOCATION_HEADER_START) return [];
+  const end = all.findIndex((line, i) => i > 0 && line.trim() === INVOCATION_HEADER_END);
+  if (end === -1) return [];
+  // Bounded: a long extraReferenceFolders list must not crowd out the diagnostics.
+  const last = Math.min(end, 60);
+  return Array.from({ length: last + 1 }, (_, i) => i);
+}
+
 /**
  * Log excerpt for a failed build that always includes diagnostic lines. A
  * naive head+tail can miss errors when long phase-timing tables precede them,
  * so instead: find every diagnostic line, include a context window around
- * each, always include the trailing summary lines, and cap the number of
- * diagnostic windows shown (MAX_DIAGS) to bound the response size.
+ * each, always include the invocation header and the trailing summary lines,
+ * and cap the number of diagnostic windows shown (MAX_DIAGS) to bound the
+ * response size.
  */
-async function readFullLog(logFile: string, maxLines = 300): Promise<string> {
+export async function readFullLog(logFile: string, maxLines = 300): Promise<string> {
   const CONTEXT = 3;     // lines before/after each diagnostic
   const TAIL_LINES = 30; // always-included trailing lines
   const MAX_DIAGS = 30;  // cap on diagnostic windows to bound response size
@@ -431,6 +453,7 @@ async function readFullLog(logFile: string, maxLines = 300): Promise<string> {
       const shownDiags = diagIndices.slice(0, MAX_DIAGS);
 
       const included = new Set<number>();
+      for (const i of invocationHeaderRange(all)) included.add(i);
       for (const idx of shownDiags) {
         for (let i = Math.max(0, idx - CONTEXT); i <= Math.min(all.length - 1, idx + CONTEXT); i++) {
           included.add(i);
@@ -587,6 +610,65 @@ interface XppcBuildContext {
   extraReferenceFolders: string[];
 }
 
+/** Windows path comparison: case-insensitive, trailing separator and `.`/`..` normalised away. */
+function samePath(a: string, b: string): boolean {
+  const norm = (p: string) => path.resolve(p).replace(/[\\/]+$/, '').toLowerCase();
+  return norm(a) === norm(b);
+}
+
+/**
+ * Delete the compiler-metadata stub an earlier build left in the framework directory.
+ *
+ * While `-compilermetadata` pointed at the framework directory, every build of a customer
+ * model deposited `<FrameworkDirectory>\<Model>\XppMetadata` there. Now that the write-back
+ * goes to the model store, those trees are never refreshed again — and the framework
+ * directory is still passed as a `-referenceFolder`, so xppc keeps finding a `<Model>` folder
+ * that looks like a package and holds metadata frozen at the last build before the switch.
+ * That is how "has not been successfully compiled since it was last changed" gets reported
+ * for source that was just compiled cleanly. Anything else enumerating the framework
+ * directory keeps seeing phantom customer models for the same reason.
+ *
+ * Deliberately narrow, because the framework directory is shared by every environment on the
+ * box: only when the two roots actually differ (UDE), only for a model that really lives in
+ * the model store, and only when the folder holds nothing but XppMetadata — i.e. it is a
+ * write-back stub and not a package deployed there on purpose. Anything unexpected is left
+ * alone and reported; a build is never failed over it.
+ */
+async function removeStaleFrameworkCompilerMetadata(
+  ctx: XppcBuildContext,
+  modelName: string,
+): Promise<void> {
+  const { microsoftPackagesPath, customPackagesPath, compilerMetadataPath } = ctx;
+
+  // CHE: one root, so the stub IS the live metadata.
+  if (samePath(microsoftPackagesPath, compilerMetadataPath)) return;
+  if (samePath(microsoftPackagesPath, customPackagesPath)) return;
+
+  const stubDir = path.join(microsoftPackagesPath, modelName);
+  try {
+    // Only a model whose authoritative copy is in the model store — never one that is
+    // genuinely installed in the framework directory and merely also named here.
+    await access(path.join(customPackagesPath, modelName));
+    const entries = await readdir(stubDir);
+    if (entries.length === 0) return;
+    if (entries.some(e => e.toLowerCase() !== 'xppmetadata')) {
+      await buildLog(
+        'INFO',
+        `Left ${stubDir} alone — it holds more than XppMetadata (${entries.join(', ')}), so it is not a stale write-back stub`,
+      );
+      return;
+    }
+    await rm(stubDir, { recursive: true, force: true });
+    await buildLog('INFO', `Removed stale compiler-metadata stub left by an earlier build: ${stubDir}`);
+  } catch (err: any) {
+    // ENOENT on either probe is the normal case: no stub, or the model is not in the
+    // model store. Anything else (a lock, a permission) is worth saying out loud once.
+    if (err?.code !== 'ENOENT') {
+      await buildLog('WARN', `Could not clean up ${stubDir}: ${err?.message ?? err}`);
+    }
+  }
+}
+
 /**
  * Spawns xppc.exe for state.modelName, writes the updated state (with real
  * PID) to disk, and wires up close/error handlers. The close handler
@@ -608,6 +690,8 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
   assertSafePath(customPackagesPath, 'Custom packages path');
   assertSafePath(microsoftPackagesPath, 'Microsoft packages path');
   assertSafePath(compilerMetadataPath, 'Compiler metadata path');
+
+  await removeStaleFrameworkCompilerMetadata(ctx, modelName);
 
   const outputPath = path.join(customPackagesPath, modelName, 'bin');
   const xppcErrLog = state.logFile.replace('.log', '.xppc.err');
@@ -663,11 +747,13 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
   // when auditing a build afterwards, so a question as basic as "which root did
   // -compilermetadata point at" could not be answered from the build log at all.
   // Recording it here makes a regression in these arguments directly greppable.
+  // The markers are shared with invocationHeaderRange(), which keeps these lines in the
+  // excerpt readFullLog returns for a failed build — the case the header is written for.
   const invocationHeader = [
-    '=== xppc invocation ===',
+    INVOCATION_HEADER_START,
     xppcExe,
     ...xppcArgs.map(arg => `  ${arg}`),
-    '=======================',
+    INVOCATION_HEADER_END,
     '',
     '',
   ].join('\n');
@@ -1364,18 +1450,6 @@ export const buildProjectTool = async (params: any, context: any, onProgress?: P
     const firstLogFile = logFilePath(targetModel, 0, customPackagesPath);
 
     // ------------------------------------------------------------------
-    // Log build parameters
-    // ------------------------------------------------------------------
-    await buildLog('INFO', `Starting build — model: ${targetModel} | fullBuild: ${fullBuild} | queue: ${buildQueue.length}`);
-    await buildLog('INFO', `  xppc.exe:              ${xppcExe}`);
-    await buildLog('INFO', `  customPackagesPath:    ${customPackagesPath}`);
-    await buildLog('INFO', `  microsoftPackagesPath: ${microsoftPackagesPath}`);
-    await buildLog('INFO', `  compilerMetadataPath:  ${customPackagesPath} (xppc write-back target)`);
-    if (extraReferenceFolders.length > 0) {
-      await buildLog('INFO', `  extraReferenceFolders: ${extraReferenceFolders.join(', ')}`);
-    }
-
-    // ------------------------------------------------------------------
     // Build context (shared across the entire queue)
     // ------------------------------------------------------------------
     const ctx: XppcBuildContext = {
@@ -1387,6 +1461,21 @@ export const buildProjectTool = async (params: any, context: any, onProgress?: P
       compilerMetadataPath: customPackagesPath,
       extraReferenceFolders,
     };
+
+    // ------------------------------------------------------------------
+    // Log build parameters
+    // ------------------------------------------------------------------
+    // Read from ctx, not from the variables it was built out of: this line exists to answer
+    // "which root did -compilermetadata point at", and a copy of the expression would keep
+    // reporting the old answer the moment the field is derived any other way.
+    await buildLog('INFO', `Starting build — model: ${targetModel} | fullBuild: ${fullBuild} | queue: ${buildQueue.length}`);
+    await buildLog('INFO', `  xppc.exe:              ${ctx.xppcExe}`);
+    await buildLog('INFO', `  customPackagesPath:    ${ctx.customPackagesPath}`);
+    await buildLog('INFO', `  microsoftPackagesPath: ${ctx.microsoftPackagesPath}`);
+    await buildLog('INFO', `  compilerMetadataPath:  ${ctx.compilerMetadataPath} (xppc write-back target)`);
+    if (ctx.extraReferenceFolders.length > 0) {
+      await buildLog('INFO', `  extraReferenceFolders: ${ctx.extraReferenceFolders.join(', ')}`);
+    }
 
     // ------------------------------------------------------------------
     // Initial state

--- a/src/tools/sdlc/buildProject.ts
+++ b/src/tools/sdlc/buildProject.ts
@@ -563,6 +563,27 @@ interface XppcBuildContext {
   xppcExe: string;
   customPackagesPath: string;
   microsoftPackagesPath: string;
+  /**
+   * The `-compilermetadata` root — where xppc READS the compiler metadata of
+   * referenced modules and, in its "Metadata Write-Back" phase, WRITES its own
+   * back. The write-back half is easy to miss, and it is why this is not simply
+   * `microsoftPackagesPath`: pointing it at the framework directory made every
+   * build deposit `<FrameworkDirectory>\<CustomModel>\XppMetadata`, leaving
+   * customer model names in a directory shared by every environment on the box.
+   *
+   * Pointing it at the model store instead is what VS does. Microsoft's own
+   * compiler metadata still resolves, because the framework directory is passed
+   * as a `-referenceFolder` (verified against 10.0.2645.90: a full compile of a
+   * customer model succeeded with `Errors: 0` and no unresolved-metadata
+   * diagnostic, and the write-back landed in the model store rather than the
+   * framework directory).
+   *
+   * It also removes an asymmetry that could only hurt `-incremental`, which is
+   * the DEFAULT here: VS wrote its baseline to the model store and nothing
+   * copied it back, so an MCP build following a VS build compared against
+   * metadata predating it. Both tools now share one baseline.
+   */
+  compilerMetadataPath: string;
   extraReferenceFolders: string[];
 }
 
@@ -573,7 +594,7 @@ interface XppcBuildContext {
  * Returns the PID of the spawned process.
  */
 async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): Promise<number> {
-  const { xppcExe, customPackagesPath, microsoftPackagesPath, extraReferenceFolders } = ctx;
+  const { xppcExe, customPackagesPath, microsoftPackagesPath, compilerMetadataPath, extraReferenceFolders } = ctx;
   const { modelName, fullBuild, targetModel } = state;
 
   // fullBuild only applies to the TARGET model — dependencies always run
@@ -586,6 +607,7 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
   assertSafePath(modelName, 'Model name');
   assertSafePath(customPackagesPath, 'Custom packages path');
   assertSafePath(microsoftPackagesPath, 'Microsoft packages path');
+  assertSafePath(compilerMetadataPath, 'Compiler metadata path');
 
   const outputPath = path.join(customPackagesPath, modelName, 'bin');
   const xppcErrLog = state.logFile.replace('.log', '.xppc.err');
@@ -605,7 +627,8 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
 
   const xppcArgs = [
     `-metadata=${customPackagesPath}`,
-    `-compilermetadata=${microsoftPackagesPath}`,
+    // Not microsoftPackagesPath — see XppcBuildContext.compilerMetadataPath.
+    `-compilermetadata=${compilerMetadataPath}`,
     `-modelmodule=${modelName}`,
     ...referenceFolderArgs,
     `-output=${outputPath}`,
@@ -634,9 +657,25 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
     await buildLog('WARN', `labelc did not compile ${modelName} labels: ${labelResult.message}`);
   }
 
-  // Truncate the log with the label outcome, then append xppc's output to it,
-  // so a single tail read shows the whole build in the order it happened.
-  await writeFile(state.logFile, labelHeader, 'utf-8');
+  // The invocation, verbatim, at the top of the log. buildLog() already reports
+  // it, but only to stderr and to bridgeLogFile — and bridgeLogFile only exists
+  // when D365FO_BRIDGE_LOG_FILE is configured. Neither is the file anyone opens
+  // when auditing a build afterwards, so a question as basic as "which root did
+  // -compilermetadata point at" could not be answered from the build log at all.
+  // Recording it here makes a regression in these arguments directly greppable.
+  const invocationHeader = [
+    '=== xppc invocation ===',
+    xppcExe,
+    ...xppcArgs.map(arg => `  ${arg}`),
+    '=======================',
+    '',
+    '',
+  ].join('\n');
+
+  // Truncate the log with the invocation and label outcome, then append xppc's
+  // output to it, so a single tail read shows the whole build in the order it
+  // happened.
+  await writeFile(state.logFile, invocationHeader + labelHeader, 'utf-8');
   const logFd = openSyncFs(state.logFile, 'a');
 
   const child = spawn(xppcExe, xppcArgs, {
@@ -771,6 +810,7 @@ async function spawnXppcForState(ctx: XppcBuildContext, state: BuildJobState): P
       microsoftPackagesPath,
       customPackagesPath,
       liveState.targetModel,
+      compilerMetadataPath,
     );
     if (metaResult.skipped) {
       await buildLog('WARN', `Runtime metadata regeneration skipped: ${metaResult.message}`);
@@ -1330,6 +1370,7 @@ export const buildProjectTool = async (params: any, context: any, onProgress?: P
     await buildLog('INFO', `  xppc.exe:              ${xppcExe}`);
     await buildLog('INFO', `  customPackagesPath:    ${customPackagesPath}`);
     await buildLog('INFO', `  microsoftPackagesPath: ${microsoftPackagesPath}`);
+    await buildLog('INFO', `  compilerMetadataPath:  ${customPackagesPath} (xppc write-back target)`);
     if (extraReferenceFolders.length > 0) {
       await buildLog('INFO', `  extraReferenceFolders: ${extraReferenceFolders.join(', ')}`);
     }
@@ -1341,6 +1382,9 @@ export const buildProjectTool = async (params: any, context: any, onProgress?: P
       xppcExe,
       customPackagesPath,
       microsoftPackagesPath,
+      // The model store, so the write-back stays with the source it describes.
+      // In CHE the two roots are the same path anyway, so this is a no-op there.
+      compilerMetadataPath: customPackagesPath,
       extraReferenceFolders,
     };
 

--- a/src/tools/sdlc/runBpCheck.ts
+++ b/src/tools/sdlc/runBpCheck.ts
@@ -105,7 +105,7 @@ export function normalizeElementType(raw: string): string {
  * `✅ clean`, which is the one BP outcome worse than a failure: it is a pass the
  * caller will act on.
  */
-export function describeNonRun(output: string): string {
+export function describeNonRun(output: string, targetName?: string): string {
   const invalidType = output.match(/The element type '([^']*)' is invalid/i);
   if (invalidType) {
     return `xppbp rejected the element type "${invalidType[1]}", so no rules were evaluated for this object. ` +
@@ -114,7 +114,26 @@ export function describeNonRun(output: string): string {
   if (/\b0 elements processed\b/i.test(output)) {
     return `xppbp processed 0 elements — the filter matched nothing, so this result is not evidence of a clean object.`;
   }
+  // When xppbp cannot find an element's compiler metadata it still runs the metadata-only
+  // rules and reports nothing for the rest — so a checked object can come back with no
+  // findings from rules that never looked at its X++ at all. Only the requested object is
+  // judged here: a module-wide run routinely carries this warning for unrelated elements
+  // (e.g. extensions of a class the environment does not have installed).
+  if (targetName && uncompiledElements(output).some(n => n.toLowerCase() === targetName.toLowerCase())) {
+    return `xppbp found no compiled metadata for "${targetName}" (CompilerMetadataMissing), so every rule that reads compiled X++ was skipped — ` +
+      `only the metadata-only rules ran. Build the model and check again. If it was just built successfully, then the -compilerMetadata root ` +
+      `xppbp was given is not the root the build wrote its XppMetadata to.`;
+  }
   return '';
+}
+
+/** Elements xppbp reported as not compiled (its CompilerMetadataMissing warning). */
+export function uncompiledElements(output: string): string[] {
+  const names = new Set<string>();
+  for (const m of output.matchAll(/The element '([A-Za-z0-9_]+)'[^\n]*appears not to have been compiled/gi)) {
+    names.add(m[1]);
+  }
+  return [...names];
 }
 
 // Tool registration (name, description, inputSchema) lives in
@@ -469,10 +488,27 @@ export const runBpCheckTool = async (params: any, context: any) => {
       }
     }
 
-    // metadataPath: X++ source XML (custom model metadata). compilerMetadataPath: compiled
-    // binaries + framework metadata (UDE: Microsoft packages root; CHE: same as metadataPath).
+    // metadataPath:         X++ source XML — the model store (UDE) or PLD (CHE).
+    // frameworkPath:        Microsoft packages root — labelc.exe lives there, and it holds the
+    //                       compiled binaries of the referenced Microsoft modules (-packagesRoot).
+    // compilerMetadataPath: the root xppc wrote its compiler metadata back to, i.e. where
+    //                       `<root>\<Module>\XppMetadata` actually is. That is the MODEL STORE,
+    //                       not the framework directory — build_d365fo_project passes
+    //                       `-compilermetadata=<model store>` (see XppcBuildContext.compilerMetadataPath).
+    //
+    // These are two different flags on xppbp, not two spellings of one:
+    //   -compilerMetadata = "the path to the compiler metadata"
+    //   -packagesRoot     = "the packages root containing binaries for modules"
+    // Pointing -compilerMetadata at the framework directory on UDE makes xppbp report EVERY
+    // element of the module as "appears not to have been compiled" (CompilerMetadataMissing)
+    // and skip the rules that need compiled X++. Verified against xppbp 7.0.7996.33: with a
+    // compiler-metadata root that held the module's XppMetadata the run was `Errors: 0` with the
+    // rules evaluated; with a root that lacked it, the checked class itself was reported
+    // uncompiled, every other element of the module followed, and xppbp exited non-zero.
+    // On CHE the two roots are the same path, so the split is a no-op there.
     const metadataPath = customPackagesPath || packagesRoot;
-    const compilerMetadataPath = microsoftPackagesPath || packagesRoot;
+    const frameworkPath = microsoftPackagesPath || packagesRoot;
+    const compilerMetadataPath = customPackagesPath || packagesRoot;
 
     // xppbp resolves @Model:Id against the compiled label assembly, so labels
     // that exist only as text in AxLabelFile are reported as BPErrorUnknownLabel
@@ -480,7 +516,7 @@ export const runBpCheckTool = async (params: any, context: any) => {
     // without a build in between — recompile stale labels here too, otherwise
     // creating a label and checking it immediately still produces the bogus
     // errors this costs about a second to prevent. Batch runs pay it once.
-    const labelResult = await compileModelLabels(compilerMetadataPath, metadataPath, modelName);
+    const labelResult = await compileModelLabels(frameworkPath, metadataPath, modelName);
     if (!labelResult.success) {
       console.error(`[run_bp_check] label compilation failed: ${labelResult.message}`);
     }
@@ -516,6 +552,10 @@ export const runBpCheckTool = async (params: any, context: any) => {
       `-module:${modelName}`,
       `-model:${modelName}`,
       `${compilerMetadataFlag}${compilerMetadataPath}`,
+      // Referenced Microsoft modules resolve from their binaries here, so that
+      // -compilerMetadata can stay on the model store where the module's own
+      // XppMetadata lives. Same path as -compilerMetadata on CHE.
+      `-packagesRoot:${frameworkPath}`,
       selector(target),
     ];
 
@@ -527,8 +567,14 @@ export const runBpCheckTool = async (params: any, context: any) => {
       `-metadata=${metadataPath}`,
       `-module=${modelName}`,
       `-model=${modelName}`,
-      // -compilerMetadata= is the newer flag; fall back to -packagesRoot= for older xppbp
-      compilerMetadata ? `-compilerMetadata=${compilerMetadataPath}` : `-packagesRoot=${compilerMetadataPath}`,
+      // -compilerMetadata= is the newer flag. When it is supported the two roots are passed
+      // separately — compiler metadata from the model store, referenced binaries from the
+      // framework directory. Older xppbp has only -packagesRoot, which then has to serve both;
+      // the framework directory is the historical choice and stays, since no version old enough
+      // to need it has been observed on a UDE split-root box.
+      ...(compilerMetadata
+        ? [`-compilerMetadata=${compilerMetadataPath}`, `-packagesRoot=${frameworkPath}`]
+        : [`-packagesRoot=${frameworkPath}`]),
       // `-all` is mutually exclusive with the positional filter: passing both
       // checks the whole model (#25).
       selector(target),
@@ -537,7 +583,7 @@ export const runBpCheckTool = async (params: any, context: any) => {
     // Style C — fallback when -compilerMetadata is not recognized
     const buildArgsFallbackStyle = (target: { name: string; elementType: string } | null): string[] => [
       `-metadata:${metadataPath}`,
-      `-packagesRoot:${compilerMetadataPath}`,
+      `-packagesRoot:${frameworkPath}`,
       `-module:${modelName}`,
       `-model:${modelName}`,
       selector(target),
@@ -626,7 +672,7 @@ export const runBpCheckTool = async (params: any, context: any) => {
     if (runTargets.length === 1) {
       const combined = combinedByTarget[0];
       const target = runTargets[0];
-      const notRun = describeNonRun(combined);
+      const notRun = describeNonRun(combined, target?.name);
       if (notRun) {
         return {
           content: [{
@@ -658,7 +704,8 @@ export const runBpCheckTool = async (params: any, context: any) => {
 
     // Batch: one preamble, findings grouped per object (#828).
     const { preamble, bodies } = splitSharedPreamble(combinedByTarget);
-    const nonRunByTarget = combinedByTarget.map(describeNonRun);
+    // Not `.map(describeNonRun)` — that would pass the array index as the target name.
+    const nonRunByTarget = combinedByTarget.map((output, i) => describeNonRun(output, runTargets[i]?.name));
     const notRunCount = nonRunByTarget.filter(Boolean).length;
     const issueCount = combinedByTarget.filter((o, i) => !nonRunByTarget[i] && hasIssues(o)).length;
 

--- a/src/tools/xml/generateMetadata.ts
+++ b/src/tools/xml/generateMetadata.ts
@@ -129,11 +129,16 @@ async function compileHelper(
 }
 
 // Compiler-metadata sync: xppc writes compiled X++ compiler metadata (XppMetadata tree) to the
-// -compilermetadata root, which can differ from the -metadata source root in an MCP-only build.
+// -compilermetadata root, which CAN differ from the -metadata source root.
 // RuntimeMetadataWriter needs both source and compiler metadata under one root, so we overlay the
 // freshly written XppMetadata onto the source root before generating runtime manifests. Overlay
 // (not mirror) is safe — orphan compiler metadata with no matching source is harmless since the
 // provider enumerates classes from the source XML.
+//
+// Since the build points -compilermetadata at the model store, the two roots normally coincide and
+// this is a no-op returning "already co-located". It stays because the roots are separate arguments
+// and a caller may still pass them apart — and because a silent no-op is cheaper than the failure
+// it prevents: without the overlay, newly added classes are missing from the runtime manifests.
 
 async function syncCompilerMetadata(
   compilerMetadataRoot: string,
@@ -170,14 +175,19 @@ export interface GenerateMetadataResult {
  * Regenerate the .md runtime metadata manifests for `modelName` from its XML
  * source. Called after a successful xppc build.
  *
- * @param microsoftPackagesPath  Framework directory (FrameworkDirectory / PackagesLocalDirectory for CHE)
+ * @param microsoftPackagesPath  Framework directory (FrameworkDirectory / PackagesLocalDirectory for CHE).
+ *                               Used ONLY to locate the Dynamics DLLs and the cached helper exe.
  * @param customPackagesPath     Model store root — the directory that contains the model folder
  * @param modelName              Model to regenerate manifests for
+ * @param compilerMetadataPath   Root xppc was given as `-compilermetadata`, i.e. where it wrote its
+ *                               compiler metadata back. Defaults to `microsoftPackagesPath` for
+ *                               callers predating the split; the build passes the model store.
  */
 export async function generateRuntimeMetadata(
   microsoftPackagesPath: string,
   customPackagesPath: string,
   modelName: string,
+  compilerMetadataPath: string = microsoftPackagesPath,
 ): Promise<GenerateMetadataResult> {
   const frameworkBinDir = path.join(microsoftPackagesPath, 'bin');
   const outputDir       = path.join(customPackagesPath, modelName, 'bin');
@@ -225,7 +235,7 @@ export async function generateRuntimeMetadata(
   // for newly added classes in an MCP-only build).
   let syncMessage: string;
   try {
-    syncMessage = await syncCompilerMetadata(microsoftPackagesPath, customPackagesPath, modelName);
+    syncMessage = await syncCompilerMetadata(compilerMetadataPath, customPackagesPath, modelName);
   } catch (syncErr: any) {
     return {
       skipped: false,

--- a/tests/tools/buildProject.test.ts
+++ b/tests/tools/buildProject.test.ts
@@ -341,8 +341,61 @@ describe('build_d365fo_project', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnMock.mock.calls[0];
     expect(args).toContain(`-metadata=${CUSTOM}`);
-    expect(args).toContain(`-compilermetadata=${MSFT}`);
     expect(args).toContain(`-modelmodule=${MODEL_NAME}`);
+    // The framework directory stays reachable as a reference folder, so Microsoft's
+    // compiler metadata still resolves.
+    expect(args).toContain(`-referenceFolder=${MSFT}`);
+  });
+
+  it('points -compilermetadata at the model store, never the framework directory', async () => {
+    // xppc writes its compiler metadata BACK to the -compilermetadata root. Aimed at
+    // the framework directory it deposits <FrameworkDirectory>\<CustomModel>\XppMetadata,
+    // putting customer model names in a directory shared by every environment on the box
+    // and splitting the -incremental baseline from the one VS maintains.
+    const CUSTOM = 'C:\\Repos\\MyCode\\Metadata';
+    const MSFT = 'C:\\AOSService\\PackagesLocalDirectory';
+    const xppc = path.join(MSFT, 'bin', 'xppc.exe');
+
+    cfgGetCustomPackagesPath.mockResolvedValue(CUSTOM);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(MSFT);
+
+    const child = makeFakeChild(56);
+    spawnMock.mockReturnValue(child);
+    allowPaths([PROJECT_PATH, xppc]);
+
+    await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
+
+    const [, args] = spawnMock.mock.calls[0];
+    expect(args).toContain(`-compilermetadata=${CUSTOM}`);
+    expect(args).not.toContain(`-compilermetadata=${MSFT}`);
+  });
+
+  it('records the xppc invocation in the build log', async () => {
+    // Validating this patch on a real instance could only confirm it by its
+    // effects, because the build log recorded no command line — buildLog() sends
+    // that to stderr and to bridgeLogFile, and bridgeLogFile is optional. The
+    // arguments belong in the log that is actually read after the fact.
+    const CUSTOM = 'C:\\Repos\\MyCode\\Metadata';
+    const MSFT = 'C:\\AOSService\\PackagesLocalDirectory';
+    const xppc = path.join(MSFT, 'bin', 'xppc.exe');
+
+    cfgGetCustomPackagesPath.mockResolvedValue(CUSTOM);
+    cfgGetMicrosoftPackagesPath.mockResolvedValue(MSFT);
+
+    const child = makeFakeChild(57);
+    spawnMock.mockReturnValue(child);
+    allowPaths([PROJECT_PATH, xppc]);
+
+    await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
+
+    const logWrite = writeFileMock.mock.calls.find(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('d365build_log'),
+    );
+    expect(logWrite).toBeDefined();
+    const written = String(logWrite![1]);
+    expect(written).toContain('=== xppc invocation ===');
+    expect(written).toContain(`-compilermetadata=${CUSTOM}`);
+    expect(written).toContain(`-metadata=${CUSTOM}`);
   });
 
   it('force=true kills orphaned build and restarts', async () => {

--- a/tests/tools/buildProject.test.ts
+++ b/tests/tools/buildProject.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // --- hoisted mocks -----------------------------------------------------------
 const {
-  accessMock, writeFileMock, appendFileMock, unlinkMock, readFileMock, readdirMock, statMock, spawnMock, execFileMock,
+  accessMock, writeFileMock, appendFileMock, unlinkMock, readFileMock, readdirMock, rmMock, statMock, spawnMock, execFileMock,
   cfgEnsureLoaded, cfgGetProjectPath, cfgGetPackagePath, cfgGetContext,
   cfgGetCustomPackagesPath, cfgGetMicrosoftPackagesPath,
   cfgGetActiveXppConfig, cfgGetModelName, detectedRoots,
@@ -15,6 +15,7 @@ const {
   const unlinkMock = vi.fn().mockResolvedValue(undefined);
   const readFileMock = vi.fn();
   const readdirMock = vi.fn().mockRejectedValue(new Error('not found'));
+  const rmMock = vi.fn().mockResolvedValue(undefined);
   // Source-staleness scan (hasSourceChangesSince). mtimeMs 0 = "older than any
   // build", so a mocked tree never looks modified unless a test says so.
   const statMock = vi.fn().mockResolvedValue({ mtimeMs: 0 });
@@ -32,7 +33,7 @@ const {
   const cfgGetActiveXppConfig = vi.fn().mockResolvedValue(null);
   const cfgGetModelName = vi.fn().mockReturnValue(null);
   return {
-    accessMock, writeFileMock, appendFileMock, unlinkMock, readFileMock, readdirMock, statMock, spawnMock, execFileMock,
+    accessMock, writeFileMock, appendFileMock, unlinkMock, readFileMock, readdirMock, rmMock, statMock, spawnMock, execFileMock,
     cfgEnsureLoaded, cfgGetProjectPath, cfgGetPackagePath, cfgGetContext,
     cfgGetCustomPackagesPath, cfgGetMicrosoftPackagesPath,
     cfgGetActiveXppConfig, cfgGetModelName, detectedRoots,
@@ -51,6 +52,7 @@ vi.mock('fs/promises', () => ({
   readFile: readFileMock,
   appendFile: appendFileMock,
   readdir: readdirMock,
+  rm: rmMock,
   stat: statMock,
 }));
 vi.mock('../../src/utils/configManager.js', () => ({
@@ -84,7 +86,7 @@ vi.mock('../../src/utils/packagesRoot.js', async () => {
 });
 
 import path from 'path';
-import { buildProjectTool } from '../../src/tools/sdlc/buildProject';
+import { buildProjectTool, readFullLog } from '../../src/tools/sdlc/buildProject';
 
 const PROJECT_PATH = 'C:\\MyProject\\MyProject.rnrproj';
 const MODEL_NAME = 'MyModel';
@@ -117,6 +119,7 @@ describe('build_d365fo_project', () => {
     appendFileMock.mockResolvedValue(undefined);
     unlinkMock.mockResolvedValue(undefined);
     readdirMock.mockRejectedValue(new Error('not found'));
+    rmMock.mockResolvedValue(undefined);
     // resetAllMocks() above wipes the hoisted implementation, and an unarmed
     // stat resolves undefined — which the staleness scan reads as "unreadable,
     // assume changed", so every finished result would be refused and rebuilt.
@@ -398,6 +401,75 @@ describe('build_d365fo_project', () => {
     expect(written).toContain(`-metadata=${CUSTOM}`);
   });
 
+  // ---------------------------------------------------------------------------
+  // Stale compiler-metadata stubs in the framework directory
+  // ---------------------------------------------------------------------------
+  describe('stale framework compiler-metadata stubs', () => {
+    const CUSTOM = 'C:\\Repos\\MyCode\\Metadata';
+    const MSFT   = 'C:\\AOSService\\PackagesLocalDirectory';
+    const XPPC_UDE = path.join(MSFT, 'bin', 'xppc.exe');
+    const STUB   = path.join(MSFT, MODEL_NAME);
+
+    /** readdir answers for the stub folder only; every other path stays "not found". */
+    function stubContains(entries: string[]) {
+      readdirMock.mockImplementation(async (p: string) => {
+        if (p === STUB) return entries;
+        throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+      });
+    }
+
+    beforeEach(() => {
+      cfgGetCustomPackagesPath.mockResolvedValue(CUSTOM);
+      cfgGetMicrosoftPackagesPath.mockResolvedValue(MSFT);
+      spawnMock.mockReturnValue(makeFakeChild(58));
+    });
+
+    // Every build made before -compilermetadata moved deposited one of these. Nothing
+    // refreshes them now, yet the framework directory is still a -referenceFolder, so
+    // xppc keeps reading metadata frozen at the last pre-move build.
+    it('deletes a write-back stub left in the framework directory', async () => {
+      allowPaths([PROJECT_PATH, XPPC_UDE, path.join(CUSTOM, MODEL_NAME)]);
+      stubContains(['XppMetadata']);
+
+      await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
+
+      expect(rmMock).toHaveBeenCalledWith(STUB, { recursive: true, force: true });
+    });
+
+    it('leaves a package genuinely installed in the framework directory alone', async () => {
+      allowPaths([PROJECT_PATH, XPPC_UDE, path.join(CUSTOM, MODEL_NAME)]);
+      stubContains(['bin', 'Descriptor', 'XppMetadata']);
+
+      await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
+
+      expect(rmMock).not.toHaveBeenCalled();
+    });
+
+    it('leaves it alone when the model is not in the model store', async () => {
+      // No <modelStore>\<Model> — nothing establishes that the framework copy is the stale one.
+      allowPaths([PROJECT_PATH, XPPC_UDE]);
+      stubContains(['XppMetadata']);
+
+      await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
+
+      expect(rmMock).not.toHaveBeenCalled();
+    });
+
+    it('never touches the framework directory on CHE, where it holds the live metadata', async () => {
+      cfgGetCustomPackagesPath.mockResolvedValue(PKG);
+      cfgGetMicrosoftPackagesPath.mockResolvedValue(PKG);
+      allowPaths([PROJECT_PATH, XPPC, path.join(PKG, MODEL_NAME)]);
+      readdirMock.mockImplementation(async (p: string) => {
+        if (p === path.join(PKG, MODEL_NAME)) return ['XppMetadata'];
+        throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+      });
+
+      await buildProjectTool({ projectPath: PROJECT_PATH, wait: false }, {});
+
+      expect(rmMock).not.toHaveBeenCalled();
+    });
+  });
+
   it('force=true kills orphaned build and restarts', async () => {
     const stateJson = JSON.stringify({
       pid: 1234,
@@ -511,6 +583,7 @@ describe('build_d365fo_project', () => {
     writeFileMock.mockResolvedValue(undefined);
     unlinkMock.mockResolvedValue(undefined);
     readdirMock.mockRejectedValue(new Error('not found'));
+    rmMock.mockResolvedValue(undefined);
     cfgGetActiveXppConfig.mockResolvedValue(null);
     cfgGetModelName.mockReturnValue(null);
     cfgGetCustomPackagesPath.mockResolvedValue(null);
@@ -710,5 +783,69 @@ describe('build_d365fo_project', () => {
     expect(args).toContain('-modelmodule=ExplicitModel');
     expect(result.content[0].text).toContain('build started');
     expect(result.isError).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readFullLog — the excerpt returned for a FAILED build
+// ---------------------------------------------------------------------------
+describe('readFullLog', () => {
+  const HEADER = [
+    '=== xppc invocation ===',
+    'C:\\AOSService\\PackagesLocalDirectory\\bin\\xppc.exe',
+    '  -metadata=C:\\Repos\\MyCode\\Metadata',
+    '  -compilermetadata=C:\\Repos\\MyCode\\Metadata',
+    '  -modelmodule=MyModel',
+    '=======================',
+    '',
+  ];
+
+  /** A log too long to be returned whole, with one diagnostic buried in the middle. */
+  function longLog(header: string[] = HEADER) {
+    return [
+      ...header,
+      ...Array.from({ length: 400 }, (_, i) => `Phase timing row ${i}`),
+      "Compile Error: Class dynamics://MyModel/MyClass: [(1,1),(1,2)]: ';' expected.",
+      ...Array.from({ length: 400 }, (_, i) => `More phase timing ${i}`),
+      'Errors: 1',
+    ].join('\n');
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // The header is written so that a failed build can be traced back to its arguments —
+  // and a failed build is precisely when this excerpt path runs. It used to return only
+  // diagnostic windows plus a tail, so the header never reached the response.
+  it('keeps the invocation header when the log is trimmed to diagnostic windows', async () => {
+    readFileMock.mockResolvedValue(longLog());
+
+    const out = await readFullLog('C:\\Temp\\d365build_log.log');
+
+    // The diagnostic-window path, not the head+tail fallback — which would include the
+    // top of the log anyway and make this assertion vacuous.
+    expect(out).toContain('Phase table omitted');
+    expect(out).toContain('=== xppc invocation ===');
+    expect(out).toContain('-compilermetadata=C:\\Repos\\MyCode\\Metadata');
+    expect(out).toContain('Compile Error:');
+  });
+
+  it('is unaffected by a log that has no invocation header', async () => {
+    readFileMock.mockResolvedValue(longLog([]));
+
+    const out = await readFullLog('C:\\Temp\\d365build_log.log');
+
+    expect(out).not.toContain('=== xppc invocation ===');
+    expect(out).toContain('Compile Error:');
+  });
+
+  it('returns a short log whole', async () => {
+    readFileMock.mockResolvedValue([...HEADER, 'Errors: 0'].join('\n'));
+
+    const out = await readFullLog('C:\\Temp\\d365build_log.log');
+
+    expect(out).toContain('=== xppc invocation ===');
+    expect(out).toContain('Errors: 0');
   });
 });

--- a/tests/tools/runBpCheck.test.ts
+++ b/tests/tools/runBpCheck.test.ts
@@ -203,16 +203,34 @@ describe('run_bp_check — path resolution', () => {
       expect(metaArg).toContain(UDE_CUSTOM);
     });
 
-    it('passes -compilerMetadata= / -packagesRoot= pointing to microsoftPackagesPath', async () => {
+    // The build writes `<modelStore>\<Model>\XppMetadata` (build_d365fo_project passes
+    // -compilermetadata=<model store>), so that is the only root on a UDE box where the
+    // module's compiler metadata exists. Aiming -compilerMetadata at the framework
+    // directory instead makes xppbp report the checked element as never compiled and skip
+    // every rule that reads compiled X++.
+    it('passes -compilerMetadata= pointing to customPackagesPath (where the build writes it)', async () => {
       allowPaths([UDE_CUSTOM, UDE_MS, UDE_XPPBP]);
 
       await runBpCheckTool({ modelName: 'MyModel' }, {});
 
       const args    = capturedArgs(0);
-      const compArg = args.find(a => a.includes('compilerMetadata') || a.includes('packagesRoot'));
-      expect(compArg).toContain(UDE_MS);
-      // Must NOT point to the custom metadata dir
-      expect(compArg).not.toContain(UDE_CUSTOM);
+      const compArg = args.find(a => a.includes('compilerMetadata'));
+      expect(compArg).toContain(UDE_CUSTOM);
+      expect(compArg).not.toContain(UDE_MS);
+    });
+
+    // Separate flag, separate root: referenced Microsoft modules resolve from their
+    // binaries in the framework directory, which is what lets -compilerMetadata stay on
+    // the model store.
+    it('passes -packagesRoot= pointing to microsoftPackagesPath alongside it', async () => {
+      allowPaths([UDE_CUSTOM, UDE_MS, UDE_XPPBP]);
+
+      await runBpCheckTool({ modelName: 'MyModel' }, {});
+
+      const args    = capturedArgs(0);
+      const pkgArg  = args.find(a => a.includes('packagesRoot'));
+      expect(pkgArg).toContain(UDE_MS);
+      expect(pkgArg).not.toContain(UDE_CUSTOM);
     });
 
     it('does NOT consult configManager.getCustomPackagesPath when xppConfig is present', async () => {
@@ -1107,6 +1125,50 @@ describe('describeNonRun', () => {
   it('stays quiet on a real run', async () => {
     const { describeNonRun } = await import('../../src/tools/sdlc/runBpCheck');
     expect(describeNonRun('1 elements processed\nWarnings: 0\nErrors: 0')).toBe('');
+  });
+
+  // Verbatim shape of the xppbp 7.0.7996.33 warning, emitted when -compilerMetadata points
+  // at a root that has no XppMetadata for the module. The rules that read compiled X++ then
+  // never run, and their silence used to be reported as findings-free.
+  const UNCOMPILED = (name: string) =>
+    `BestPractices Warning: Class dynamics://Class/${name}: The element '${name}' in module ` +
+    `'MyModel' appears not to have been compiled. Ensure the element has been compiled before ` +
+    `invoking xppbp.exe, and provide the -compilerMetadata argument if necessary.`;
+
+  it('recognises the requested element being reported as never compiled', async () => {
+    const { describeNonRun } = await import('../../src/tools/sdlc/runBpCheck');
+    const out = `1 elements processed.\n${UNCOMPILED('MyClass')}\nCompilerMetadataMissing: 1`;
+    expect(describeNonRun(out, 'MyClass')).toMatch(/no compiled metadata for "MyClass"/);
+  });
+
+  it('ignores the warning when it names a different element', async () => {
+    const { describeNonRun } = await import('../../src/tools/sdlc/runBpCheck');
+    // A module-wide run routinely carries this for extensions of classes the environment
+    // does not have installed — that says nothing about the object under check.
+    const out = `1 elements processed.\n${UNCOMPILED('SomeOther_Extension')}\nCompilerMetadataMissing: 1`;
+    expect(describeNonRun(out, 'MyClass')).toBe('');
+  });
+
+  it('does not judge an unfiltered whole-model run by it', async () => {
+    const { describeNonRun } = await import('../../src/tools/sdlc/runBpCheck');
+    const out = `283 elements processed.\n${UNCOMPILED('SomeOther_Extension')}\nCompilerMetadataMissing: 1`;
+    expect(describeNonRun(out)).toBe('');
+  });
+});
+
+describe('uncompiledElements', () => {
+  it('collects every element xppbp reported as uncompiled, once each', async () => {
+    const { uncompiledElements } = await import('../../src/tools/sdlc/runBpCheck');
+    const line = (n: string) =>
+      `BestPractices Warning: Class dynamics://Class/${n}: The element '${n}' in module 'MyModel' ` +
+      `appears not to have been compiled.`;
+    const out = [line('A'), line('B'), line('A')].join('\n');
+    expect(uncompiledElements(out)).toEqual(['A', 'B']);
+  });
+
+  it('returns nothing for a clean run', async () => {
+    const { uncompiledElements } = await import('../../src/tools/sdlc/runBpCheck');
+    expect(uncompiledElements('1 elements processed\nWarnings: 0\nErrors: 0')).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Scope

This applies to **UDE only**. A UDE box keeps custom source in a model store
(`ModelStoreFolder`) that is a different directory from Microsoft's binaries
(`FrameworkDirectory`). On CHE the two are the same `PackagesLocalDirectory`, so the
problem below cannot occur there and the fix is a no-op.

## Issue

xppc writes its compiler metadata back to the `-compilermetadata` root during its
"Metadata Write-Back" phase. The build tool aimed that at the `FrameworkDirectory`, so
every UDE build deposited `<FrameworkDirectory>\<Model>\XppMetadata`.

Two consequences:

- **Custom model names accumulate in a shared directory.** Nothing cleans them up, and
  each stub is indistinguishable from a real package to anything enumerating that
  folder — it carries only an `XppMetadata` child, no `Descriptor`, no `bin`, no source
  XML.
- **The `-incremental` baseline is split.** Visual Studio writes its compiler metadata
  to the model store; this tool wrote to the `FrameworkDirectory` and copied forward
  into the model store via `syncCompilerMetadata`, with nothing copying back. A build
  here following a VS build compared against metadata that predated it. `-incremental`
  is the default path, so this is the common case.

## Fix

Point `-compilermetadata` at the model store — what VS does. The `FrameworkDirectory`
keeps its other roles (locating `xppc.exe` and `labelc.exe`, the Dynamics DLLs, and
`-referenceFolder`), and Microsoft's compiler metadata still resolves through the
reference folder.

`generateRuntimeMetadata` now takes the compiler-metadata root as a parameter,
defaulting to `microsoftPackagesPath` for existing callers, so `syncCompilerMetadata`
looks where xppc actually wrote. With both roots equal it becomes a no-op reporting
"already co-located" rather than a misleading "no compiler metadata to sync".

Additionally, the xppc invocation is now recorded at the top of the build log.
`buildLog()` sends it to stderr and to `bridgeLogFile` (which requires
`D365FO_BRIDGE_LOG_FILE`), so the build log carried no record of the arguments that
produced it. That part applies to every environment.
