### PR TITLE
feat(d365fo_file): operations[] on create, aimed at the name it actually wrote

### DIFF
--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -106,10 +106,10 @@ Model + prefix auto-applied. Classes: member vars inside the class { }, methods 
           type: 'array',
           maxItems: 20,
           description:
-            '[modify] PREFERRED for 2+ edits to the SAME object — ONE call, not one per edit. ' +
+            '[modify|create] PREFERRED for 2+ edits to the SAME object — ONE call, not one per edit. ' +
+            'On create they run against the just-created object, under the name it actually got. ' +
             'Entries are {operation, …op-spec params}; objectType/objectName/modelName stay top-level. ' +
-            'Applied in order, stopped at the first failure, per-operation results back. ' +
-            '3 fields + their field groups + an index: 7 calls flat, 1 here.',
+            'Applied in order, stopped at the first failure, per-operation results back.',
           items: { type: 'object', additionalProperties: true },
         },
         params: {

--- a/src/tools/d365foFile.ts
+++ b/src/tools/d365foFile.ts
@@ -18,10 +18,11 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { XppServerContext } from '../types/context.js';
 import { handleGenerateD365Xml } from './xml/generateD365Xml.js';
-import { handleCreateD365File } from './write/createD365File.js';
+import { handleCreateD365File, type CreateOutcome } from './write/createD365File.js';
 import { handleDeleteD365File } from './write/deleteD365File.js';
 import { modifyD365FileTool } from './write/modifyD365File.js';
 import { resetRecentPrepares } from './prepare/prepare.js';
+import * as debouncedRefresh from '../bridge/debouncedRefresh.js';
 
 export const D365_FILE_ACTIONS = ['generate', 'create', 'modify', 'delete'] as const;
 export type D365FileAction = (typeof D365_FILE_ACTIONS)[number];
@@ -45,6 +46,20 @@ function subRequest(name: string, args: Record<string, unknown>): CallToolReques
 
 /** Ceiling on one batch — matches get_object_info's objects[] cap. */
 const MAX_BATCH_OPERATIONS = 20;
+
+/**
+ * Add a line to a result without disturbing its verdict.
+ *
+ * Used for the cases where operations[] on a create is deliberately NOT run:
+ * the create's own answer has to survive intact, isError included, with the
+ * reason the edits were skipped appended to it.
+ */
+function appendToResult(result: any, note: string): any {
+  const content = result?.content;
+  const first = Array.isArray(content) ? content[0] : undefined;
+  if (!first || first.type !== 'text' || typeof first.text !== 'string') return result;
+  return { ...result, content: [{ ...first, text: first.text + note }, ...content.slice(1)] };
+}
 
 /** Concatenated text of a tool result, for folding into the batch report. */
 function resultText(result: any): string {
@@ -201,7 +216,60 @@ export async function d365foFileTool(request: CallToolRequest, context: XppServe
   }
 
   if (action === 'create') {
-    return handleCreateD365File(subRequest('create_d365fo_file', rest), context);
+    // 16 of the create -> modify sequences in the sampled sessions targeted the
+    // object that create had just made: a table is created, then its field group,
+    // index or extra fields arrive one MCP call at a time. operations[] on create
+    // applies them in the same call.
+    const { operations, ...createArgs } = rest as { operations?: unknown } & Record<string, unknown>;
+    const outcome: CreateOutcome = {};
+    const created = await handleCreateD365File(subRequest('create_d365fo_file', createArgs), context, outcome);
+
+    if (!Array.isArray(operations) || operations.length === 0) return created;
+    // Never run edits against an object that was not created.
+    if (created?.isError) {
+      return appendToResult(created,
+        `\n\n> ${operations.length} operation(s) were NOT attempted: the create above failed.`);
+    }
+    // The one thing this must not do is guess. create publishes the name it
+    // actually wrote (prefix normalization included); without it, a chained edit
+    // could land on a different object — or on nothing — while reporting success.
+    if (!outcome.finalObjectName) {
+      return appendToResult(created,
+        `\n\n> ${operations.length} operation(s) were NOT attempted: this create did not report the ` +
+        `final object name, so the target cannot be established without guessing. Send them as a ` +
+        `separate d365fo_file(action="modify", operations:[…]) call.`);
+    }
+
+    // Make the bridge SEE the new object before the edits run.
+    //
+    // Between two MCP calls toolHandler settles this via flush(); inside one call
+    // nothing did, so the DiskProvider had not seen the new file and the first
+    // operation failed with "could not resolve table 'Fm-mcpFmChainProbeTbl'" — on
+    // a table that was on disk, 1177 bytes, named in the create's own reply.
+    // Found only by running it live against the sandbox; no mock could show it.
+    //
+    // Scheduled AND flushed: flush() alone is a no-op when nothing is pending, and
+    // the create path that writes XML directly schedules no rebuild of its own.
+    // refresh() queues one, flush() runs it now instead of after the 400 ms settle.
+    if (context.bridge) {
+      void debouncedRefresh.refresh(context.bridge);
+      await debouncedRefresh.flush();
+    }
+
+    const batch = await runModifyBatch({
+      objectType: createArgs.objectType,
+      modelName: createArgs.modelName,
+      // The written name, not the requested one.
+      objectName: outcome.finalObjectName,
+      operations,
+    }, context);
+    return {
+      content: [{
+        type: 'text',
+        text: `${resultText(created)}\n\n---\n\n${resultText(batch)}`,
+      }],
+      ...((batch as { isError?: boolean }).isError ? { isError: true } : {}),
+    };
   }
   if (action === 'modify') {
     if (Array.isArray(rest.operations)) {

--- a/src/tools/write/createD365File.ts
+++ b/src/tools/write/createD365File.ts
@@ -3194,12 +3194,28 @@ async function reconcileCreatedTableProperties(
 /**
  * Create D365FO file handler function
  */
+/**
+ * What the caller needs to chain further work onto a create: the name the object
+ * ACTUALLY got, after prefix/casing normalization, and where it was written.
+ *
+ * An out-parameter because neither alternative is sound. Parsing it back out of
+ * the response text is brittle, and a module-level "last created" would be wrong
+ * under two concurrent creates. Both fields are set at the point create computes
+ * them, so every later return path carries them regardless of which one fires —
+ * and a caller that finds them missing must NOT guess (see d365foFile.ts).
+ */
+export interface CreateOutcome {
+  finalObjectName?: string;
+  filePath?: string;
+}
+
 export async function handleCreateD365File(
   request: CallToolRequest,
   context?: {
     bridge?: import('../../bridge/bridgeClient.js').BridgeClient;
     symbolIndex?: import('../../metadata/symbolIndex.js').XppSymbolIndex;
   },
+  outcome?: CreateOutcome,
 ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
   const timer = createPhaseTimer();
   const args = CreateD365FileArgsSchema.parse(request.params.arguments);
@@ -3455,6 +3471,10 @@ export async function handleCreateD365File(
     if (finalObjectName !== args.objectName) {
       console.error(`[create_d365fo_file] Applied naming: ${args.objectName} → ${finalObjectName}`);
     }
+    // Published here, before any of the return paths below, so a caller chaining
+    // work onto this create targets the name that was WRITTEN rather than the one
+    // that was asked for.
+    if (outcome) outcome.finalObjectName = finalObjectName;
     // Disclose a rename in the RESPONSE, not only on stderr. The XML template
     // path says "prefixed from …"; the bridge path — every extension, class and
     // table — said nothing, so the object came back under a name the caller never
@@ -3600,6 +3620,7 @@ export async function handleCreateD365File(
 
     // Normalize path to Windows format (backslashes) for consistency
     const normalizedFullPath = fullPath.replace(/\//g, '\\');
+    if (outcome) outcome.filePath = normalizedFullPath;
 
     // Ensure directory exists (create if needed)
     const directory = path.dirname(normalizedFullPath);

--- a/tests/tools/createWithOperations.test.ts
+++ b/tests/tools/createWithOperations.test.ts
@@ -1,0 +1,122 @@
+/**
+ * 16 of the create -> modify sequences in the sampled sessions targeted the object
+ * create had just made: a table is created, then its field group, index or extra
+ * fields arrive one MCP call at a time.
+ *
+ * The one thing this must never do is guess the target. create applies prefix and
+ * casing normalization, so the name that was WRITTEN can differ from the one that
+ * was asked for; a chained edit aimed at the requested name would land on a
+ * different object — or on nothing — while reporting success.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const { mockCreate, mockModify } = vi.hoisted(() => ({ mockCreate: vi.fn(), mockModify: vi.fn() }));
+
+vi.mock('../../src/tools/write/createD365File', () => ({ handleCreateD365File: mockCreate }));
+vi.mock('../../src/tools/write/modifyD365File', () => ({ modifyD365FileTool: mockModify }));
+vi.mock('../../src/tools/write/deleteD365File', () => ({ handleDeleteD365File: vi.fn() }));
+vi.mock('../../src/tools/xml/generateD365Xml', () => ({ handleGenerateD365Xml: vi.fn() }));
+
+import { d365foFileTool } from '../../src/tools/d365foFile';
+
+const ctx = {} as any;
+const call = (args: Record<string, unknown>): CallToolRequest => ({
+  method: 'tools/call', params: { name: 'd365fo_file', arguments: args },
+});
+const text = (r: any) => r.content[0].text as string;
+const forwarded = () => mockModify.mock.calls.map(c => (c[0] as CallToolRequest).params.arguments as any);
+
+/** create that reports the name it actually wrote via the out-parameter. */
+const creates = (writtenName: string, opts: { isError?: boolean; report?: boolean } = {}) =>
+  mockCreate.mockImplementation(async (_req: any, _ctx: any, outcome: any) => {
+    if (opts.report !== false && outcome) {
+      outcome.finalObjectName = writtenName;
+      outcome.filePath = 'K:/pkg/' + writtenName + '.xml';
+    }
+    return { content: [{ type: 'text', text: 'created ' + writtenName }], ...(opts.isError ? { isError: true } : {}) };
+  });
+
+const OPS = [{ operation: 'add-field-group', fieldGroupName: 'Grp' }, { operation: 'add-index', indexName: 'Idx' }];
+
+beforeEach(() => { vi.resetAllMocks(); });
+
+describe('d365fo_file(action="create") with operations[]', () => {
+  it('runs the operations against the name the object ACTUALLY got', async () => {
+    // Asked for MyTable, written as ConMyTable — the prefix is the whole point.
+    creates('ConMyTable');
+    mockModify.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    const r: any = await d365foFileTool(
+      call({ action: 'create', objectType: 'table', objectName: 'MyTable', operations: OPS }), ctx);
+
+    expect(mockModify).toHaveBeenCalledTimes(2);
+    for (const args of forwarded()) expect(args.objectName).toBe('ConMyTable');
+    expect(forwarded().map(a => a.operation)).toEqual(['add-field-group', 'add-index']);
+    // Both halves of the answer survive.
+    expect(text(r)).toContain('created ConMyTable');
+    expect(text(r)).toContain('2/2 operation(s) applied');
+    expect(r.isError).toBeFalsy();
+  });
+
+  it('does not forward operations[] into the create itself', async () => {
+    creates('ConMyTable');
+    mockModify.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    await d365foFileTool(call({ action: 'create', objectType: 'table', objectName: 'MyTable', operations: OPS }), ctx);
+    expect((mockCreate.mock.calls[0][0] as CallToolRequest).params.arguments).not.toHaveProperty('operations');
+  });
+
+  it('attempts nothing when the create failed', async () => {
+    creates('ConMyTable', { isError: true });
+    const r: any = await d365foFileTool(
+      call({ action: 'create', objectType: 'table', objectName: 'MyTable', operations: OPS }), ctx);
+
+    expect(mockModify).not.toHaveBeenCalled();
+    expect(r.isError).toBe(true);
+    expect(text(r)).toContain('2 operation(s) were NOT attempted');
+  });
+
+  it('refuses to guess the target when create reports no final name', async () => {
+    // Fails safe: one extra round trip, never an edit aimed at the wrong object.
+    creates('ConMyTable', { report: false });
+    const r: any = await d365foFileTool(
+      call({ action: 'create', objectType: 'table', objectName: 'MyTable', operations: OPS }), ctx);
+
+    expect(mockModify).not.toHaveBeenCalled();
+    expect(text(r)).toContain('NOT attempted');
+    expect(text(r)).toContain('without guessing');
+    // The create itself still succeeded, and says so.
+    expect(r.isError).toBeFalsy();
+    expect(text(r)).toContain('created ConMyTable');
+  });
+
+  it('reports isError when an operation fails, and keeps the create verdict visible', async () => {
+    creates('ConMyTable');
+    mockModify
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'ok' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: 'boom' }], isError: true });
+
+    const r: any = await d365foFileTool(
+      call({ action: 'create', objectType: 'table', objectName: 'MyTable', operations: OPS }), ctx);
+
+    expect(r.isError).toBe(true);
+    expect(text(r)).toContain('created ConMyTable');
+    expect(text(r)).toContain('1/2 operation(s) applied');
+  });
+
+  it('leaves a plain create untouched', async () => {
+    creates('ConMyTable');
+    const r: any = await d365foFileTool(call({ action: 'create', objectType: 'table', objectName: 'MyTable' }), ctx);
+    expect(mockModify).not.toHaveBeenCalled();
+    expect(text(r)).toBe('created ConMyTable');
+  });
+
+  it('treats an empty operations[] as a plain create', async () => {
+    creates('ConMyTable');
+    const r: any = await d365foFileTool(
+      call({ action: 'create', objectType: 'table', objectName: 'MyTable', operations: [] }), ctx);
+    expect(mockModify).not.toHaveBeenCalled();
+    expect(text(r)).toBe('created ConMyTable');
+  });
+});


### PR DESCRIPTION
## Why

16 of the `create` → `modify` sequences in the sampled sessions targeted the object `create` had just made: a table is created, then its field group, index or extra fields arrive one MCP call at a time. Together with the 45 consecutive single-op modifies, this was the largest round-trip saving in the token-efficiency audit (#932).

It is also the one I **declined to build there**, because chaining writes onto a create means resolving the created object's name — and getting that wrong edits a *different* object while reporting success and compiling clean. That needed a live run, which it has now had.

## How the name is resolved

`create` publishes the name it actually wrote through a `CreateOutcome` out-parameter, set at the point it computes it:

```ts
if (finalObjectName !== args.objectName) { … }
// Published here, before any of the return paths below.
if (outcome) outcome.finalObjectName = finalObjectName;
```

The two alternatives are both unsound:

- **Parsing it out of the response text** — brittle against any wording change.
- **A module-level "last created"** — wrong under two concurrent creates.

Every return path after that assignment carries it. The four returns *before* it are all error paths (config resolution, placeholder model, cross-model refusal — "file creation aborted"), so **a create that succeeds always reports its name**.

## Fails safe, three ways

| Situation | Behaviour |
|---|---|
| create errored | operations **not attempted**; create's `isError` and message preserved, with the count that was skipped |
| create reported no final name | operations **not attempted**; reply says the target "cannot be established without guessing" and to send a separate modify. One extra round trip beats an edit aimed at the wrong object. |
| an operation fails | `isError`, create's verdict still visible, `runModifyBatch`'s per-operation report intact (it stops at the first failure, as it already did for `action="modify"`) |

`operations` is stripped from the create's own arguments, and an empty/absent array is an ordinary create. All seven cases are tested.

## The live run earned its keep twice

Sandbox model `fm-mcp`, real bridge (`metadata: true`), real disk.

**1. It confirmed the hazard is handled.** Asked for `FmChainProbeTbl`; written as `Fm-mcpFmChainProbeTbl` (prefix applied); the chained operations were aimed at `Fm-mcpFmChainProbeTbl`. The requested name would have missed.

**2. It found a defect no mock could show.** The first operation failed with:

```
❌ Bridge operation 'add-field' could not resolve table 'Fm-mcpFmChainProbeTbl'.
```

— on a table that was **on disk, 1177 bytes, named in the create's own reply**. Between two MCP calls `toolHandler` settles the provider rebuild via `flush()`; inside *one* call nothing did, so the bridge's DiskProvider had not seen the new file. Fixed by scheduling **and** flushing the rebuild before the edits run:

```ts
if (context.bridge) {
  void debouncedRefresh.refresh(context.bridge);
  await debouncedRefresh.flush();
}
```

`flush()` alone is not enough — it is a no-op when nothing is pending, and the XML-writer create path schedules no rebuild of its own.

## What the live run could not establish

**The operations succeeding end-to-end.** A control experiment settles why it is not this change's doing: the ordinary **two-call** `create` → `modify` flow fails *identically* in the same harness —

```
Bridge error [-32602]: Table or table-extension 'Fm-mcpCtrlProbeTbl' not found
```

The harness spawns its own bridge with `packagesPath` only, without the eval config's `customModels: ["fm-mcp"]`, and `fm-mcp` is a symlink into the ASL tree. So the chaining behaves exactly like the flow the product already ships; confirming the operations themselves needs the properly-configured eval server. Worth doing before this is leaned on hard.

Every probe table was removed after each run; the sandbox is as it was (`AxTable/` contains only `Delta`, as before).

## Cost

The schema grew by 27 chars, paid for out of the sales pitch on the same property ("3 fields + their field groups + an index: 7 calls flat, 1 here"), so the `toolSchemaBudget` ratchet holds without being touched.

## Tests

`326 test files, 4799 passed.` `tsc --noEmit` clean, `biome lint` clean on the touched files. `tests/tools/createWithOperations.test.ts` covers the name-threading guarantee (asked `MyTable`, written `ConMyTable`, operations aimed at `ConMyTable`), all three fail-safe paths, `isError` propagation, and that a plain create is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
