### PR TITLE
perf(bridge): let metadata reads overlap, keep writes exclusive

### DIFF
--- a/bridge/D365MetadataBridge/Program.cs
+++ b/bridge/D365MetadataBridge/Program.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using D365MetadataBridge.Protocol;
 
@@ -219,9 +221,33 @@ namespace D365MetadataBridge
             }
         }
 
+        /// <summary>
+        /// How many reads may be inside the provider at once. Bounded on purpose: the
+        /// win is in overlapping a handful of fan-out reads, not in handing an unbounded
+        /// number of threads to a metadata provider whose thread-safety is undocumented.
+        /// </summary>
+        private const int ReadSlots = 6;
+
+        /// <summary>
+        /// A read takes one slot; anything else takes ALL of them, which is what makes a
+        /// write or a provider refresh exclusive against every in-flight read. Simple
+        /// enough to reason about without an async reader/writer lock.
+        ///
+        /// A writer waits for the slots, so a continuous stream of reads could delay it.
+        /// In practice requests come from one MCP client that awaits its own calls, so
+        /// there is no such stream.
+        /// </summary>
+        private static readonly SemaphoreSlim _slots = new SemaphoreSlim(ReadSlots, ReadSlots);
+
+        /// <summary>stdout is one stream: concurrent handlers must not interleave lines on it.</summary>
+        private static readonly SemaphoreSlim _stdoutLock = new SemaphoreSlim(1, 1);
+        private static readonly StreamWriter _stdout =
+            new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+
         private static async Task<int> RunStdioLoop(RequestDispatcher dispatcher)
         {
             var reader = new StreamReader(Console.OpenStandardInput());
+            var inFlight = new List<Task>();
 
             string? line;
             while ((line = await reader.ReadLineAsync()) != null)
@@ -229,45 +255,113 @@ namespace D365MetadataBridge
                 if (string.IsNullOrWhiteSpace(line))
                     continue;
 
-                BridgeResponse response;
+                BridgeRequest? request = null;
                 try
                 {
-                    var request = JsonSerializer.Deserialize<BridgeRequest>(line, JsonOptions.Default);
-                    if (request == null || string.IsNullOrEmpty(request.Method))
-                    {
-                        response = BridgeResponse.CreateError("?", -32600, "Invalid request");
-                    }
-                    else
-                    {
-                        Log.WriteLine($"[DEBUG] → {request.Method} (id={request.Id})");
-                        response = await dispatcher.Dispatch(request);
-                        Log.WriteLine($"[DEBUG] ← {request.Method} OK (id={request.Id})");
-                    }
+                    request = JsonSerializer.Deserialize<BridgeRequest>(line, JsonOptions.Default);
                 }
                 catch (JsonException ex)
                 {
                     Log.WriteLine($"[ERROR] JSON parse error: {ex.Message}");
-                    response = BridgeResponse.CreateError("?", -32700, $"Parse error: {ex.Message}");
-                }
-                catch (Exception ex)
-                {
-                    Log.WriteLine($"[ERROR] Unhandled: {ex.Message}\n{ex.StackTrace}");
-                    response = BridgeResponse.CreateError("?", -32603, $"Internal error: {ex.Message}");
+                    await WriteResponse(BridgeResponse.CreateError("?", -32700, $"Parse error: {ex.Message}"));
+                    continue;
                 }
 
-                await WriteResponse(response);
+                if (request == null || string.IsNullOrEmpty(request.Method))
+                {
+                    await WriteResponse(BridgeResponse.CreateError("?", -32600, "Invalid request"));
+                    continue;
+                }
+
+                // Reads go to the thread pool so the loop can read the next line at once;
+                // everything else keeps the original behaviour of running to completion
+                // before the next request is even parsed.
+                if (RequestDispatcher.IsConcurrentSafeRead(request.Method))
+                {
+                    inFlight.RemoveAll(t => t.IsCompleted);
+                    inFlight.Add(HandleConcurrently(dispatcher, request));
+                }
+                else
+                {
+                    // Drain the reads already running, then take every slot: a write or a
+                    // provider rebuild must not overlap a read of the provider it replaces.
+                    if (inFlight.Count > 0)
+                    {
+                        await Task.WhenAll(inFlight);
+                        inFlight.Clear();
+                    }
+                    for (var i = 0; i < ReadSlots; i++) await _slots.WaitAsync();
+                    try
+                    {
+                        await WriteResponse(await DispatchGuarded(dispatcher, request));
+                    }
+                    finally
+                    {
+                        _slots.Release(ReadSlots);
+                    }
+                }
             }
 
+            if (inFlight.Count > 0)
+            {
+                try { await Task.WhenAll(inFlight); } catch { /* each response was already sent */ }
+            }
             Log.WriteLine("[INFO] stdin closed, bridge exiting");
             return 0;
+        }
+
+        /// <summary>One read: take a slot, dispatch, answer. Never throws back into the loop.</summary>
+        private static async Task HandleConcurrently(RequestDispatcher dispatcher, BridgeRequest request)
+        {
+            await _slots.WaitAsync();
+            try
+            {
+                // Task.Run, not a bare await: every read handler returns
+                // Task.FromResult(...), so Dispatch runs to completion SYNCHRONOUSLY on
+                // whichever thread calls it. Awaiting it here left the work on the stdio
+                // loop thread and measured 1.06x against 1.04x for the serial build —
+                // the change did nothing until the work actually left this thread.
+                var response = await Task.Run(() => DispatchGuarded(dispatcher, request));
+                await WriteResponse(response);
+            }
+            finally
+            {
+                _slots.Release();
+            }
+        }
+
+        /// <summary>Dispatch, turning any escape into a response rather than a lost request.</summary>
+        private static async Task<BridgeResponse> DispatchGuarded(RequestDispatcher dispatcher, BridgeRequest request)
+        {
+            try
+            {
+                Log.WriteLine($"[DEBUG] → {request.Method} (id={request.Id})");
+                var response = await dispatcher.Dispatch(request);
+                Log.WriteLine($"[DEBUG] ← {request.Method} OK (id={request.Id})");
+                return response;
+            }
+            catch (Exception ex)
+            {
+                Log.WriteLine($"[ERROR] Unhandled: {ex.Message}\n{ex.StackTrace}");
+                return BridgeResponse.CreateError(request.Id, -32603, $"Internal error: {ex.Message}");
+            }
         }
 
         private static async Task WriteResponse(BridgeResponse response)
         {
             var json = JsonSerializer.Serialize(response, JsonOptions.Default);
-            var stdout = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
-            await stdout.WriteLineAsync(json);
-            await stdout.FlushAsync();
+            // Serialized, and on ONE cached writer: concurrent handlers each opening their
+            // own StreamWriter over the same handle is how a JSON-RPC stream gets interleaved.
+            await _stdoutLock.WaitAsync();
+            try
+            {
+                await _stdout.WriteLineAsync(json);
+                await _stdout.FlushAsync();
+            }
+            finally
+            {
+                _stdoutLock.Release();
+            }
         }
 
         /// <summary>

--- a/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
+++ b/bridge/D365MetadataBridge/Protocol/RequestDispatcher.cs
@@ -813,6 +813,43 @@ namespace D365MetadataBridge.Protocol
             }
         }
 
+        /// <summary>
+        /// Methods that only READ metadata, and may therefore run concurrently with
+        /// each other.
+        ///
+        /// Measured on this VM: six reads issued together took 674 ms against 689 ms
+        /// issued one at a time — a 1.02x "speedup", because the stdio loop awaited each
+        /// Dispatch before reading the next line. Every fan-out the TS side performs
+        /// (get_object_info objects[], search queries[], prepare's five probes) was
+        /// therefore pipelining into a queue of one.
+        ///
+        /// The list is explicit and the DEFAULT IS FALSE: anything not named here —
+        /// including a method added later — keeps the old exclusive behaviour. A write
+        /// misfiled as a read would corrupt metadata; a read misfiled as a write is
+        /// merely as slow as it is today.
+        /// </summary>
+        private static readonly HashSet<string> ConcurrentSafeReads =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "ping", "getcapabilities", "getinfo", "getxrefschema",
+                // Typed readers
+                "readtable", "readclass", "readenum", "readedt", "readform", "readquery",
+                "readview", "readreport", "readdataentity", "readmenuitem",
+                "readsecurityprivilege", "readsecurityduty", "readsecurityrole",
+                "readtableextensions",
+                // Short aliases of the same readers
+                "table", "class", "enum", "edt", "form", "query", "view", "menu",
+                // Lookup / search
+                "searchobjects", "listobjects", "resolveobjectinfo", "getcompletionmembers",
+                "getmethodsource", "validateobject", "discoverformpatterns",
+                // Cross-reference queries
+                "findreferences", "findeventsubscribers", "findextensionclasses",
+                "findapiusagecallers", "samplexrefrows",
+            };
+
+        /// <summary>True when <paramref name="method"/> may run alongside other reads.</summary>
+        public static bool IsConcurrentSafeRead(string? method)
+            => !string.IsNullOrEmpty(method) && ConcurrentSafeReads.Contains(method!);
         private Task<BridgeResponse> HandleMetadata(BridgeRequest request, Func<object?> handler)
         {
             if (_metadataService == null)

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "bb3a36662b65f4122cb66b890a5d2dec9dfbc1680fdfe0cdeb6014ede1835310",
+  "sourceHash": "1b33deb168b008a1f64ac3ffe73434d4d4e3303cfed2eebf53ff6b332b6745a7",
   "sourceFileCount": 9,
   "metamodelFileVersion": "7.0.7996.33",
-  "builtAt": "2026-08-24T05:45:59.252Z"
+  "builtAt": "2026-08-24T08:25:59.711Z"
 }


### PR DESCRIPTION
Closes the last open item from the token-efficiency audit (#932) that needed a live run to judge. All three architectural candidates were **measured first**; only one of them turned out to be worth building.

## The measurement that started it

Six metadata reads, issued together vs one at a time, against real Microsoft metadata:

| | sequential | pipelined | speedup |
|---|---|---|---|
| deployed bridge | 689 ms | 674 ms | **1.02×** |

The stdio loop awaited each `Dispatch` before reading the next line, so every fan-out the TS side performs — `get_object_info` `objects[]`, `search` `queries[]`, `prepare`'s five parallel probes — was pipelining into a queue of one. The batching features the audit pushed agents toward were paying MCP round-trip savings and getting nothing back on the bridge side.

## What this changes

Reads run on the thread pool; everything else keeps the old behaviour.

The gate is a **semaphore of 6 slots**: a read takes one, a write or a provider refresh takes **all** of them — that is what makes it exclusive against every in-flight read, without an async reader/writer lock. Bounded deliberately: the win is overlapping a handful of fan-out reads, not handing an unbounded number of threads to a provider whose thread-safety is undocumented.

The read list is **explicit, and the default is `false`**. A method not named there — including one added later — stays exclusive. A write misfiled as a read would corrupt metadata; a read misfiled as a write is merely as slow as it is today.

## Two things the measurement caught that reasoning did not

**1. The first version changed nothing** — 1.06× against a 1.04× baseline. Every read handler returns `Task.FromResult(...)`, so `Dispatch` runs to completion *synchronously* on whichever thread calls it; awaiting it left the work sitting on the stdio loop thread. It takes an explicit `Task.Run` for the work to actually leave. Without a before/after number this would have shipped as a no-op that looked like a concurrency feature.

**2. `stdout` is one stream, and the old `WriteResponse` opened its own `StreamWriter` per response.** Concurrent handlers doing that is exactly how a JSON-RPC stream gets interleaved. Writes now go through one cached writer under a lock.

## Verification, against real Microsoft metadata

| check | result |
|---|---|
| 6-read fan-out | **659 ms → 427 ms (1.54×)**; the serial build measures 1.08× on the same probe |
| Equivalence | `searchObjects` / `readTable` / `readClass` / `readEnum` / `readEdt` fired together return **byte-identical** payloads to the serial build |
| Stress | **240 concurrent mixed reads: 0 mismatches, 0 nulls, 0 errors** |
| Exclusivity | 3 `refreshProvider` calls interleaved with 72 reads — all three returned `{"refreshed":true,"elapsedMs":313}` and every read stayed correct |

1.54× is short of the theoretical 6×, so the provider serialises internally. This buys wall-clock on fan-out, not linear scaling — worth saying plainly, because the guard rails cost something and a reader should know what they bought.

Absence of failure across 240 concurrent reads is evidence, not proof, of `DiskProvider` read thread-safety. The conservative design is the other half of the argument: reads never overlap a write or a rebuild, and the concurrency ceiling is 6.

## The two candidates I did NOT build

**Caching the primary-key lists** — rejected on measurement. The laziness change already merged in #932 (`Search` takes the getter and stops enumerating when the result budget fills) does the work:

| search | eager (deployed) | lazy (merged) |
|---|---|---|
| common + typed, limit 20 | 121 ms | 121 ms |
| **common + `all`, limit 20** | **1319 ms** | **110 ms** |
| **common + `all`, limit 500** | **1277 ms** | **129 ms** |
| no match + `all` (full enumeration) | 1390 ms | 1320 ms |

A **12× improvement on the default `type=all` search**, and results verified byte-identical across four query shapes. The only case left slow is a search that matches nothing, where every collection genuinely has to be enumerated — a cache would help exactly there, cost a large in-memory string set, and be invalidated by every write. Not worth it.

**Incremental provider refresh** — `refreshProvider` measures **313 ms**, and `debouncedRefresh` already coalesces bursts into one rebuild that is settled between calls. Replacing it with per-object invalidation depends on metamodel SDK behaviour I cannot establish here. The measured cost does not justify the risk.

## ⚠️ Operational note, worth acting on separately

**The deployed bridge binary is stale.** `bridge/D365MetadataBridge/bin/Release/D365MetadataBridge.exe` is dated **2026-08-17**, so the live MCP server is running a build from before #932 merged — the 12× `type=all` win in the table above **is not deployed**. `npm run bridge:build` writes to a scratch temp dir and says so explicitly; it does not touch the deployed binary. Someone has to build into `bin/Release` for a merged bridge change to take effect.

## Tests

`328 test files, 4812 passed.` Bridge builds clean (0 warnings, 0 errors) and `bridge/build-attestation.json` is refreshed — CI's `bridge-attestation` check is what proves a C# change was actually compiled, since no runner can compile it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
