### PR TITLE
fix(d365fo_file): a wrong parameter shape now answers with the contract

### DIFF
--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -4482,6 +4482,34 @@ export async function modifyD365FileTool(request: CallToolRequest, context: XppS
     };
 
   } catch (error) {
+    // A parameter of the RIGHT name but the WRONG shape used to escape to the
+    // generic message below, which renders a ZodError as its raw issue array:
+    //
+    //   ❌ Error modifying D365FO file: [ { "expected": "object", "code":
+    //     "invalid_type", "path": [ "indexFields", 0 ], … } ]
+    //
+    // observed live on add-index called with indexFields: ["ProbeId"] instead of
+    // [{fieldName:"ProbeId"}]. The published schema promises "A missing/wrong one
+    // returns that COMPLETE spec — follow it, do not guess", and the missing-param
+    // path above keeps that promise; this one did not, so the caller either guessed
+    // or spent a round trip on get_knowledge to find out what it already asked for.
+    const rawArgs = (request.params.arguments ?? {}) as Record<string, unknown>;
+    const opName = typeof rawArgs.operation === 'string' ? rawArgs.operation : undefined;
+    if (error instanceof z.ZodError && opName) {
+      const issues = error.issues
+        .map(i => `  • ${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join(String.fromCharCode(10));
+      return {
+        content: [{
+          type: 'text',
+          text:
+            `❌ '${opName}': a parameter does not match the contract.\n` +
+            issues + '\n\n' +
+            renderOpSpec(opName),
+        }],
+        isError: true,
+      };
+    }
     return {
       content: [
         {

--- a/tests/tools/modifyParamShapeSpec.test.ts
+++ b/tests/tools/modifyParamShapeSpec.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The published d365fo_file schema promises: "A missing/wrong one returns that
+ * COMPLETE spec — follow it, do not guess."
+ *
+ * The missing-parameter path kept that promise. A parameter of the right NAME but
+ * the wrong SHAPE did not: it escaped to the generic catch, which renders a
+ * ZodError as its raw issue array. Observed live on 2026-08-24 calling add-index
+ * with indexFields: ["ProbeId"] instead of [{fieldName:"ProbeId"}]:
+ *
+ *   ❌ Error modifying D365FO file: [ { "expected": "object", "code":
+ *     "invalid_type", "path": [ "indexFields", 0 ], … } ]
+ *
+ * The caller then either guesses or spends a round trip on get_knowledge to be told
+ * the contract it had already asked about.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { modifyD365FileTool } from '../../src/tools/write/modifyD365File';
+
+const call = (args: Record<string, unknown>) => modifyD365FileTool(
+  { method: 'tools/call', params: { name: 'd365fo_file', arguments: args } } as never,
+  { symbolIndex: { getReadDb: () => ({ prepare: () => ({ all: () => [], get: () => undefined }) }) } } as never,
+);
+const text = (r: any) => r.content.map((c: any) => c.text).join('');
+
+describe('a wrong parameter SHAPE answers with the operation contract', () => {
+  it('names the offending parameter and returns the add-index spec', async () => {
+    const r: any = await call({
+      objectType: 'table', objectName: 'SomeTable', operation: 'add-index',
+      // Flat, as d365foFileTool hands them over after merging `params` up.
+      indexName: 'Idx', indexFields: ['ProbeId'],
+    });
+
+    expect(r.isError).toBe(true);
+    const t = text(r);
+    // Which parameter, in words rather than a serialized validator object.
+    expect(t).toContain('indexFields');
+    expect(t).not.toContain('"code": "invalid_type"');
+    // And the contract itself, which is what the schema promised.
+    expect(t).toContain("Parameter spec for operation 'add-index'");
+    expect(t).toContain('fieldName');
+  });
+
+  it('does the same for any other operation, not just add-index', async () => {
+    const r: any = await call({
+      objectType: 'table', objectName: 'SomeTable', operation: 'add-relation',
+      relationName: 'Rel', relatedTable: 'CustTable', relationConstraints: ['AccountNum'],
+    });
+    const t = text(r);
+    expect(t).toContain('relationConstraints');
+    expect(t).toContain("Parameter spec for operation 'add-relation'");
+  });
+
+  it('leaves the generic message in place when no operation was named', async () => {
+    // Nothing to render a spec for — the old text is still the best available.
+    const r: any = await call({ objectType: 'table', objectName: 'SomeTable' });
+    expect(r.isError).toBe(true);
+    expect(text(r)).not.toContain('Parameter spec for operation');
+  });
+});


### PR DESCRIPTION
Found by using the tool during the live verification of #934, not by reading it.

## The promise, and where it was not kept

The published `d365fo_file` schema says of `params`:

> A missing/wrong one returns that COMPLETE spec — follow it, do not guess.

The **missing**-parameter path keeps that promise: it renders `renderOpSpec(operation)`. A parameter of the right **name** but the wrong **shape** did not — it escaped to the generic catch, which renders a `ZodError` as its raw issue array. Calling `add-index` live with `indexFields: ["ProbeId"]` instead of `[{fieldName:"ProbeId"}]` answered:

```
❌ Error modifying D365FO file: [
  {
    "expected": "object",
    "code": "invalid_type",
    "path": [ "indexFields", 0 ],
    "message": "Invalid input: expected object, received string"
  }
]
```

That names the parameter only inside a serialized validator object, and never says what the right shape *is*. The caller then either guesses or spends a round trip on `get_knowledge(kind="op-spec", topic="add-index")` to be told the contract it had already asked about — the exact waste #932 was about.

## After

```
❌ 'add-index': a parameter does not match the contract.
  • indexFields.0: Invalid input: expected object, received string

Parameter spec for operation 'add-index' — pass these NESTED inside `params` …
  REQUIRED indexName (string): Index name.
  REQUIRED indexFields (array of { fieldName, direction? ("Asc"|"Desc") }): Fields that make up the index.
  …
```

A `ZodError` on a call that named an operation renders the offending parameters as prose and appends the same contract the missing-parameter path returns. Everything else keeps the generic message — including a call that named no operation, where there is no spec to render.

## Note on where the check lives

`indexFields` is part of `ModifyD365FileArgsSchema`, parsed at the top of `modifyD365FileTool`, so this lands in that function's outer catch. Worth knowing when reading the test: the dispatcher merges `params` **up** to the top level before calling, so a unit test must pass those keys flat to reproduce what the live call does.

## Tests

`329 test files, 4815 passed.` `tsc --noEmit` clean; `biome lint` adds nothing (the finding at `modifyD365File.ts:988` is pre-existing on main). New `tests/tools/modifyParamShapeSpec.test.ts` covers `add-index`, a second operation (`add-relation`, whose `relationConstraints` has the same array-of-object shape), and the no-operation case that must keep the generic message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)