### PR TITLE
fix: bound a batch report, answer a bad topics[] in words, and correct the docs

### DIFF
--- a/bridge/D365MetadataBridge/Program.cs
+++ b/bridge/D365MetadataBridge/Program.cs
@@ -278,7 +278,14 @@ namespace D365MetadataBridge
                 // before the next request is even parsed.
                 if (RequestDispatcher.IsConcurrentSafeRead(request.Method))
                 {
-                    inFlight.RemoveAll(t => t.IsCompleted);
+                    // Touch Exception on a faulted task before dropping it, so the fault
+                    // is observed rather than left for the finalizer — a task pruned here
+                    // is never awaited anywhere else.
+                    inFlight.RemoveAll(t =>
+                    {
+                        if (t.IsFaulted) { var _ = t.Exception; }
+                        return t.IsCompleted;
+                    });
                     inFlight.Add(HandleConcurrently(dispatcher, request));
                 }
                 else
@@ -287,7 +294,14 @@ namespace D365MetadataBridge
                     // provider rebuild must not overlap a read of the provider it replaces.
                     if (inFlight.Count > 0)
                     {
-                        await Task.WhenAll(inFlight);
+                        // Guarded. DispatchGuarded turns any handler escape into a
+                        // response, so the only realistic thrower left is WriteResponse on
+                        // a broken stdout — and an unguarded WhenAll rethrows that HERE,
+                        // out of RunStdioLoop and out of Main, killing the bridge because
+                        // an unrelated read could not print. The final drain below was
+                        // already written this way; this one was not.
+                        try { await Task.WhenAll(inFlight); }
+                        catch { /* each read already answered, or failed on its own */ }
                         inFlight.Clear();
                     }
                     for (var i = 0; i < ReadSlots; i++) await _slots.WaitAsync();

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "1b33deb168b008a1f64ac3ffe73434d4d4e3303cfed2eebf53ff6b332b6745a7",
+  "sourceHash": "1d2dd01d55f9d983647acfef22bd15efa4fed03b7d3938a361629179e425e01e",
   "sourceFileCount": 9,
   "metamodelFileVersion": "7.0.7996.33",
-  "builtAt": "2026-08-24T08:25:59.711Z"
+  "builtAt": "2026-08-24T10:53:29.846Z"
 }

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -18,12 +18,12 @@ The grounding chain is what makes generated code compile on the first try:
 flowchart LR
     subgraph Extend["Extending existing code"]
         A1["prepare<br/>(mode=change)"] --> A2[generate code]
-        A2 --> A3["validate_code<br/>(references + syntax)"]
+        A2 --> A3["validate_code<br/>(mode=both)"]
         A3 --> A4["d365fo_file<br/>(action=modify)"]
     end
     subgraph Create["New objects"]
         B1["prepare<br/>(mode=create)"] --> B2[generate code]
-        B2 --> B3["validate_code<br/>(references + syntax)"]
+        B2 --> B3["validate_code<br/>(mode=both)"]
         B3 --> B4["d365fo_file<br/>(action=create)"]
     end
     subgraph Forms["New forms"]
@@ -36,8 +36,8 @@ flowchart LR
 
 | Workflow | Chain | Gate |
 |----------|-------|------|
-| CoC / event handler / extension | `prepare(mode="change")` → generate → `validate_code(mode="references")` + `validate_code(mode="syntax")` → `d365fo_file(action="modify")` | grounding token + reference proof |
-| New class / table / enum | `prepare(mode="create")` → generate → `validate_code(mode="references")` + `validate_code(mode="syntax")` → `d365fo_file(action="create")` | grounding token + collision check |
+| CoC / event handler / extension | `prepare(mode="change")` → generate → `validate_code(mode="both")` → `d365fo_file(action="modify")` | grounding token + reference proof |
+| New class / table / enum | `prepare(mode="create")` → generate → `validate_code(mode="both")` → `d365fo_file(action="create")` | grounding token + collision check |
 | New form | `object_patterns(domain="form", action="analyze", recommend)` → `object_patterns(domain="form", action="spec")` → `generate_object(mode="scaffold", objectType="form", cloneFrom)` → `object_patterns(domain="form", action="validate")` → `d365fo_file(action="create")` | structural pattern gate (FP001–FP010) |
 
 ---
@@ -73,7 +73,7 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `get_knowledge` | `kind="knowledge"` — queryable X++ rulebook: select grammar, CoC, SysDa, FormRun lifecycle, form patterns, reading Excel/CSV files, parallel batch, direct SQL, AX2012→D365FO migration · `kind="error"` — compiler / runtime / BP errors explained with concrete fixes · `kind="op-spec"` — the parameter contract for one `d365fo_file` operation/objectType or one `generate_object` mode (`topic="add-index"`, `"table"`, `"scaffold:form"`, …); those two tools keep their parameters out of the wire schema, so this is where they come from | *"What are the rules for crossCompany selects?"* · *"How do I read an uploaded Excel file in X++?"* · *"Explain error 'object not initialized' in batch"* |
+| `get_knowledge` | `kind="knowledge"` — queryable X++ rulebook: select grammar, CoC, SysDa, FormRun lifecycle, form patterns, reading Excel/CSV files, parallel batch, direct SQL, AX2012→D365FO migration · `kind="error"` — compiler / runtime / BP errors explained with concrete fixes · `kind="op-spec"` — the parameter contract for one `d365fo_file` operation/objectType or one `generate_object` mode (`topic="add-index"`, `"table"`, `"scaffold:form"`, …); those two tools keep their parameters out of the wire schema, so this is where they come from. `topics: ["add-index", "add-field"]` answers SEVERAL lookups in one call (max 10) — a run typically needs 4-8 contracts and used to spend a round trip on each | *"What are the rules for crossCompany selects?"* · *"How do I read an uploaded Excel file in X++?"* · *"Explain error 'object not initialized' in batch"* |
 | `analyze_code` † | `mode="patterns"` — common patterns for a scenario · `mode="implementations"` — real implementations of a similar method · `mode="completeness"` — missing standard methods on a class · `mode="api-usage"` — how an API is initialized and called (compiler-resolved callers) | *"How are number sequences usually implemented here?"* · *"How do other classes implement validateWrite?"* · *"What standard methods is my service class missing?"* |
 
 ## 🎨 Code Generation (2)
@@ -94,7 +94,7 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `d365fo_file` | `action=create` — create any of 39 AOT object types in the correct location + register in `.rnrproj` (gated by grounding token and form-pattern validation) · `action=modify` — safe metadata edits via the C# bridge, 38 operations: add-field, add-control, remove-control, add-entry-point, add-method, replace-code, modify-property, …; op-specific parameters go in a single `params` object (flat top-level keys still accepted) and come from `get_knowledge(kind="op-spec", topic="<operation>")` — the per-objectType `properties` contract for `action=create` from `topic="<objectType>"` — while a missing/wrong parameter returns that same complete per-op spec (error-driven guidance, source: `d365foFileOpSpecs.ts`) · `action=delete` — remove an object's XML and un-register it from every `.rnrproj` of the model that lists it (irreversible; guarded against standard-model and cross-model targets) · `action=generate` — XML preview without writing (cloud-friendly) | *"Create the class file in my project"* · *"Add the field to the General tab of the form extension"* · *"Show me the XML for this enum without creating it"* |
+| `d365fo_file` | `action=create` — create any of 39 AOT object types in the correct location + register in `.rnrproj` (gated by grounding token and form-pattern validation) · `action=modify` — safe metadata edits via the C# bridge, 38 operations: add-field, add-control, remove-control, add-entry-point, add-method, replace-code, modify-property, …; op-specific parameters go in a single `params` object (flat top-level keys still accepted) and come from `get_knowledge(kind="op-spec", topic="<operation>")` — the per-objectType `properties` contract for `action=create` from `topic="<objectType>"` — while a missing/wrong parameter returns that same complete per-op spec (error-driven guidance, source: `d365foFileOpSpecs.ts`) · `operations: [{operation, …}]` (max 20) applies SEVERAL edits to the same object in ONE call — on `action=modify` and on `action=create`, where they run against the object just created under the name it ACTUALLY got. Applied in order, stopped at the first failure, and each section of the report is capped so one call cannot return a context window · `action=delete` — remove an object's XML and un-register it from every `.rnrproj` of the model that lists it (irreversible; guarded against standard-model and cross-model targets) · `action=generate` — XML preview without writing (cloud-friendly) | *"Create the class file in my project"* · *"Add the field to the General tab of the form extension"* · *"Show me the XML for this enum without creating it"* |
 | `undo_last_modification` | Revert the last write: checkout HEAD or delete untracked file (also re-syncs the symbol index) | *"Undo that last change"* |
 
 ## 🔐 Security & Extensions (5)
@@ -113,7 +113,7 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `build_d365fo_project` | MSBuild compilation with structured xppc diagnostics (severity, object, line, fix hints for the first errors) | *"Build the project and show the errors"* |
+| `build_d365fo_project` | MSBuild compilation with structured xppc diagnostics (severity, object, line, fix hints for the first errors). `bpCheck: true` appends the best-practice report to a GREEN build, saving the usual follow-up `run_bp_check`; advisory, never fails the build. A green build returns its diagnostics and summary rather than the raw phase-timing table | *"Build the project and show the errors"* |
 | `trigger_db_sync` | Database sync for the current model | *"Sync the database"* |
 | `run_bp_check` | Microsoft Best Practices (xppbp.exe) analysis — `objects: [{objectType, objectName}]` checks several objects in one call (shared preamble once, findings grouped per object) | *"Run a BP check on my model"* · *"BP check the table, its extension class and the enum"* |
 | `run_systest_class` | Execute SysTest unit tests via SysTestConsole.exe (requires an interactive console session) | *"Run the MyServiceTest class"* |
@@ -124,7 +124,7 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 | Tool | What it does | When it runs |
 |------|--------------|--------------|
 | `prepare` | `mode="change"` — one call before extending: signature + existing CoC wrappers + eligibility + strategy + **grounding token** · `mode="create"` — one call before creating: collision check + naming + EDT/label suggestions + property defaults + **grounding token** | automatically, before modifications / new objects |
-| `validate_code` | `mode="references"` — proves every type/field/method/label in generated code against the index (anti-hallucination gate) · `mode="syntax"` — offline BP validator, < 50 ms: deprecated APIs, CoC correctness, select anti-patterns, data-driven XML property rules mined from standard models | automatically, after generation |
+| `validate_code` | `mode="both"` — runs both checks below in ONE call and merges them; prefer it, since both are wanted before every write · `mode="references"` — proves every type/field/method/label in generated code against the index (anti-hallucination gate) · `mode="syntax"` — offline BP validator, < 50 ms: deprecated APIs, CoC correctness, select anti-patterns, data-driven XML property rules mined from standard models | automatically, after generation |
 | `review_workspace_changes` | AI code review of uncommitted X++ changes (git diff) | on request: *"Review my changes"* |
 
 > **Grounding enforcement:** `prepare` issues a SHA-256 provenance token (30-min TTL) **bound to the object it was issued for**. When `GROUNDING_ENFORCE=true` is set in `.env`:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -27,7 +27,7 @@ npx tsx tests/bridge-e2e.ts             # manual bridge E2E (Windows D365FO VM o
 | `tests/metadata/` | XML parser + pattern miner + SQLite indexing against fixture forms |
 | `tests/bridge/` | bridge client behavior (debounced refresh); `bridge-e2e.ts` is manual |
 
-Contract tests worth knowing: `tests/utils/toolInventory.test.ts` asserts the published tool count (25 on `main` at the time of writing — branches consolidating tools change it) and keeps `src/server/toolSchemas/`, the startup catalog and `LOCAL_TOOLS` in sync; it also fails when guidance text names a tool retired by a consolidation. See [NEW_TOOL_CHECKLIST.md](NEW_TOOL_CHECKLIST.md). `tests/utils/toolSchemaBudget.test.ts` pins the serialized `tools/list` payload size — that payload ships on every request.
+Contract tests worth knowing: `tests/utils/toolInventory.test.ts` asserts the published tool count (23 at the time of writing — branches that add, consolidate or unpublish tools change it, and the test is what makes that deliberate) and keeps `src/server/toolSchemas/`, the startup catalog and `LOCAL_TOOLS` in sync; it also fails when guidance text names a tool retired by a consolidation. See [NEW_TOOL_CHECKLIST.md](NEW_TOOL_CHECKLIST.md). `tests/utils/toolSchemaBudget.test.ts` pins the serialized `tools/list` payload size — that payload ships on every request.
 
 ## Mock strategy
 

--- a/src/tools/d365foFile.ts
+++ b/src/tools/d365foFile.ts
@@ -23,6 +23,7 @@ import { handleDeleteD365File } from './write/deleteD365File.js';
 import { modifyD365FileTool } from './write/modifyD365File.js';
 import { resetRecentPrepares } from './prepare/prepare.js';
 import * as debouncedRefresh from '../bridge/debouncedRefresh.js';
+import { truncateOnBlockBoundary } from '../utils/payloadBudget.js';
 
 export const D365_FILE_ACTIONS = ['generate', 'create', 'modify', 'delete'] as const;
 export type D365FileAction = (typeof D365_FILE_ACTIONS)[number];
@@ -46,6 +47,23 @@ function subRequest(name: string, args: Record<string, unknown>): CallToolReques
 
 /** Ceiling on one batch — matches get_object_info's objects[] cap. */
 const MAX_BATCH_OPERATIONS = 20;
+
+/**
+ * Per-operation output budget inside a batch.
+ *
+ * Each section is bounded because the WHOLE response is not: d365fo_file is
+ * 'uncapped' in TOOL_CAP_SIZES (a truncated create loses the file path), so
+ * nothing downstream trims a batch report. Twenty operations whose per-op text
+ * runs long — replace-code echoes the changed region, an inline bpCheck report is
+ * itself uncapped — measured at 1,000,573 chars from a SINGLE call, roughly 278k
+ * tokens.
+ *
+ * Capping per SECTION rather than the whole response is deliberate: a tail cut
+ * would delete the verdicts of the last operations outright, and which operations
+ * applied is the one thing a half-finished batch has to be able to say. Generous
+ * enough that an ordinary operation is never touched.
+ */
+const MAX_OPERATION_CHARS = 4_000;
 
 /**
  * Add a line to a result without disturbing its verdict.
@@ -174,7 +192,15 @@ async function runModifyBatch(
     (skipped ? `, ${skipped} not attempted` : '');
 
   const body = results
-    .map(r => `\n\n### ${r.ok ? '✅' : '❌'} ${r.label}\n${r.text || '(no output)'}`)
+    .map(r => {
+      const text = r.text || '(no output)';
+      const kept = text.length > MAX_OPERATION_CHARS
+        ? truncateOnBlockBoundary(text, MAX_OPERATION_CHARS) +
+          `\n\n> ✂️ This operation's output was truncated at ${MAX_OPERATION_CHARS} chars ` +
+          `(${text.length - MAX_OPERATION_CHARS} omitted). The operation itself is unaffected.`
+        : text;
+      return `\n\n### ${r.ok ? '✅' : '❌'} ${r.label}\n${kept}`;
+    })
     .join('');
 
   const tail = failed

--- a/src/tools/knowledge/getKnowledge.ts
+++ b/src/tools/knowledge/getKnowledge.ts
@@ -53,8 +53,18 @@ export async function getKnowledgeTool(request: CallToolRequest) {
   // A run picks 4-8 different operations and fetched each contract in its own
   // call: get_knowledge was 40 of 273 tool calls in the sampled sessions, 38 of
   // them op-spec, with 8 back-to-back pairs. topics[] answers them in one.
-  const topics = normalizeTopics((rest as Record<string, unknown>).topics);
+  const rawTopics = (rest as Record<string, unknown>).topics;
+  const topics = normalizeTopics(rawTopics);
   delete (rest as Record<string, unknown>).topics;
+  // `topics` was given but is not usable, and there is no `topic` to fall back on:
+  // say so in words. Letting it through produced a raw zod dump naming a parameter
+  // the caller never passed.
+  if (rawTopics !== undefined && !topics && (rest as Record<string, unknown>).topic == null) {
+    return {
+      content: [{ type: 'text' as const, text: describeTopicsShape(rawTopics) }],
+      isError: true,
+    };
+  }
   const kind: KnowledgeKind =
     explicitKind ?? ((rest as any).errorText || (rest as any).errorCode ? 'error' : 'knowledge');
   if (kind === 'error') {
@@ -118,14 +128,38 @@ export const MAX_TOPICS = 10;
 const SPEC_SEPARATOR = '\n\n---\n\n';
 
 /**
- * topics[] accepted as an array; anything else (including a bare string, which
- * belongs in `topic`) falls through to the single-topic path rather than
- * erroring — a rejected batch just becomes the loop it was meant to replace.
+ * topics[] accepted as an array of non-empty strings; anything else returns null
+ * and the caller falls through to the single-topic path.
+ *
+ * That fallback is only a graceful one when a `topic` was ALSO supplied. It was
+ * not: `topics: "CoC"` with no `topic` reached xppKnowledgeTool with topic
+ * undefined and came back as a raw zod dump —
+ *   Error in get_knowledge(kind="knowledge"): [ { "expected": "string",
+ *     "code": "invalid_type", "path": [ "topic" ] … } ]
+ * — the same unusable shape #937 fixed for d365fo_file. The comment here used to
+ * claim the loop simply resumed; it did not. describeTopicsShape() below is what
+ * makes the claim true.
  */
 function normalizeTopics(raw: unknown): string[] | null {
   if (!Array.isArray(raw)) return null;
   const list = raw.filter(t => typeof t === 'string' && t.trim() !== '').map(t => String(t).trim());
   return list.length > 0 ? list.slice(0, MAX_TOPICS) : null;
+}
+
+/**
+ * The complaint to make when `topics` was supplied but unusable, and no `topic`
+ * can stand in for it. Names the shape and how many entries were dropped, instead
+ * of handing back a serialized validator object.
+ */
+function describeTopicsShape(raw: unknown): string {
+  const shape = Array.isArray(raw)
+    ? `an array of ${raw.length} entr${raw.length === 1 ? 'y' : 'ies'}, none of them a non-empty string`
+    : `a ${typeof raw}`;
+  return (
+    `❌ get_knowledge: \`topics\` must be an array of non-empty strings — got ${shape}.\n` +
+    `  Several topics: topics: ["select-statement", "coc-authoring"]  (max ${MAX_TOPICS})\n` +
+    `  One topic:      topic: "select-statement"`
+  );
 }
 
 function textOf(result: unknown): string {

--- a/tests/tools/batchOutputBudget.test.ts
+++ b/tests/tools/batchOutputBudget.test.ts
@@ -1,0 +1,90 @@
+/**
+ * One d365fo_file call must not be able to return a context window.
+ *
+ * d365fo_file is 'uncapped' in TOOL_CAP_SIZES on purpose — a truncated create
+ * loses the file path — so nothing downstream trims a batch report. With
+ * operations[] concatenating up to 20 full per-operation responses, and per-op
+ * text that can run long (replace-code echoes the changed region, an inline
+ * bpCheck report is itself uncapped), a single call measured at 1,000,573 chars
+ * — roughly 278k tokens. Each SECTION is bounded instead of the whole response,
+ * so the verdict of every operation survives.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const { mockCreate, mockModify } = vi.hoisted(() => ({ mockCreate: vi.fn(), mockModify: vi.fn() }));
+vi.mock('../../src/tools/write/createD365File', () => ({ handleCreateD365File: mockCreate }));
+vi.mock('../../src/tools/write/modifyD365File', () => ({ modifyD365FileTool: mockModify }));
+vi.mock('../../src/tools/write/deleteD365File', () => ({ handleDeleteD365File: vi.fn() }));
+vi.mock('../../src/tools/xml/generateD365Xml', () => ({ handleGenerateD365Xml: vi.fn() }));
+
+import { d365foFileTool } from '../../src/tools/d365foFile';
+
+const ctx = {} as any;
+const call = (args: Record<string, unknown>): CallToolRequest =>
+  ({ method: 'tools/call', params: { name: 'd365fo_file', arguments: args } });
+const text = (r: any) => (r?.content ?? []).map((c: any) => c?.text ?? '').join('');
+
+/** Per-op output of the size a replace-code echo or an inline BP report reaches. */
+const HUGE = 'x'.repeat(50_000);
+const ops = (n: number) => Array.from({ length: n }, (_, i) => ({ operation: 'replace-code', tag: i }));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockCreate.mockImplementation(async (_r: any, _c: any, outcome: any) => {
+    if (outcome) { outcome.finalObjectName = 'ConProbe'; outcome.filePath = 'K:/p/ConProbe.xml'; }
+    return { content: [{ type: 'text', text: 'created ConProbe' }] };
+  });
+});
+
+describe('a batch report is bounded per operation', () => {
+  it('caps a 20-operation modify that would otherwise return ~1 MB', async () => {
+    mockModify.mockResolvedValue({ content: [{ type: 'text', text: HUGE }] });
+
+    const r: any = await d365foFileTool(
+      call({ action: 'modify', objectType: 'table', objectName: 'ConProbe', operations: ops(20) }), ctx);
+
+    const size = text(r).length;
+    // 20 × 50k was 1,000,573 chars before; 20 sections of ~4k plus framing now.
+    expect(size).toBeLessThan(120_000);
+    expect(text(r)).toContain('truncated at 4000 chars');
+    // The write is not what was truncated, and the reply has to say so.
+    expect(text(r)).toContain('The operation itself is unaffected.');
+  });
+
+  it('keeps EVERY operation verdict — the reason the cap is per section', async () => {
+    mockModify.mockResolvedValue({ content: [{ type: 'text', text: HUGE }] });
+
+    const r: any = await d365foFileTool(
+      call({ action: 'modify', objectType: 'table', objectName: 'ConProbe', operations: ops(20) }), ctx);
+
+    const t = text(r);
+    // A whole-response tail cut would have deleted the last sections outright.
+    expect(t).toContain('### ✅ #1 replace-code');
+    expect(t).toContain('### ✅ #20 replace-code');
+    expect(t).toContain('20/20 operation(s) applied');
+  });
+
+  it('leaves an ordinary operation untouched', async () => {
+    const small = '✅ Field added.\nFile: K:/p/ConProbe.xml';
+    mockModify.mockResolvedValue({ content: [{ type: 'text', text: small }] });
+
+    const r: any = await d365foFileTool(
+      call({ action: 'modify', objectType: 'table', objectName: 'ConProbe', operations: ops(3) }), ctx);
+
+    expect(text(r)).toContain(small);
+    expect(text(r)).not.toContain('truncated at');
+  });
+
+  it('bounds the create path too, where the batch rides along with the create output', async () => {
+    mockModify.mockResolvedValue({ content: [{ type: 'text', text: HUGE }] });
+
+    const r: any = await d365foFileTool(
+      call({ action: 'create', objectType: 'table', objectName: 'Probe', operations: ops(20) }), ctx);
+
+    expect(text(r).length).toBeLessThan(120_000);
+    // The create's own answer is never the thing that gets cut.
+    expect(text(r)).toContain('created ConProbe');
+  });
+});

--- a/tests/tools/getKnowledge.test.ts
+++ b/tests/tools/getKnowledge.test.ts
@@ -105,3 +105,38 @@ describe('get_knowledge topics[] — several lookups in one call', () => {
     expect((xppKnowledgeTool as any).mock.calls[0][0].params.arguments.topic).toBe('CoC');
   });
 });
+
+describe('topics[] with an unusable shape answers in words, not a validator dump', () => {
+  // The fallback to the single-topic path is only graceful when a `topic` was ALSO
+  // supplied. It was not: `topics: "CoC"` alone reached xppKnowledgeTool with topic
+  // undefined and came back as a raw zod dump naming a parameter the caller never
+  // passed — the same unusable shape #937 fixed for d365fo_file.
+  const textOf = (r: any) => r.content.map((c: any) => c.text).join('');
+
+  it('names the shape it got and both valid forms', async () => {
+    const r: any = await getKnowledgeTool(req({ kind: 'knowledge', topics: 'CoC' }));
+    expect(r.isError).toBe(true);
+    const t = textOf(r);
+    expect(t).toContain('must be an array of non-empty strings');
+    expect(t).toContain('got a string');
+    expect(t).toContain('topic: "select-statement"');
+    expect(t).not.toContain('invalid_type');
+    expect(xppKnowledgeTool).not.toHaveBeenCalled();
+  });
+
+  it('reports how many entries were unusable', async () => {
+    const r: any = await getKnowledgeTool(req({ kind: 'knowledge', topics: [1, null] }));
+    expect(textOf(r)).toContain('2 entries');
+  });
+
+  it('rejects an empty array rather than silently answering nothing', async () => {
+    const r: any = await getKnowledgeTool(req({ kind: 'knowledge', topics: [] }));
+    expect(r.isError).toBe(true);
+  });
+
+  it('still falls through when a usable topic came along', async () => {
+    await getKnowledgeTool(req({ kind: 'knowledge', topics: 'CoC', topic: 'CoC' }));
+    expect(xppKnowledgeTool).toHaveBeenCalledOnce();
+    expect((xppKnowledgeTool as any).mock.calls[0][0].params.arguments.topic).toBe('CoC');
+  });
+});


### PR DESCRIPTION
Audit of everything since **v1.13.0** (41 commits, 127 files, +6712/−830). Three findings, all in work added since that tag, all verified by running them rather than by reading.

## 1. One `d365fo_file` call could return ~278k tokens

`d365fo_file` is `'uncapped'` in `TOOL_CAP_SIZES` on purpose — a truncated create loses the file path — so **nothing downstream trims a batch report**. `operations[]` concatenates up to 20 full per-operation responses, and per-op text can run long: `replace-code` echoes the changed region with nothing bounding `newCode`, and an inline `bpCheck` report is itself uncapped.

Measured: 20 operations at 50k each →

```
raw response   : 1000573 chars
after cap      : 1000573 chars   <-- UNCAPPED, nothing truncates it
```

Each **section** is now bounded at 4,000 chars rather than the response as a whole. A tail cut would have deleted the verdicts of the *last* operations outright, and which operations applied is the one thing a half-finished batch has to be able to say — so every `### ✅ #N` line survives, and the note makes clear the truncation is the report, not the write.

In a project whose whole point was token efficiency, this was the largest single hole in it.

## 2. A bad `topics` shape answered with a raw validator dump

The comment on `normalizeTopics` claimed anything that is not an array *"falls through to the single-topic path — a rejected batch just becomes the loop it was meant to replace."* That is only true when a `topic` was **also** supplied. `topics: "CoC"` alone reached `xppKnowledgeTool` with `topic` undefined:

```
Error in get_knowledge(kind="knowledge"): [ { "expected": "string",
  "code": "invalid_type", "path": [ "topic" ] … } ]
```

— the same unusable shape #937 fixed for `d365fo_file`, shipped by me in the same week. It now names the shape it got, how many entries were unusable, and both valid forms. The comment that made the false claim is corrected rather than deleted, because a comment that lies is worse than no comment.

## 3. The docs still prescribed the round trips that were just removed

`docs/MCP_TOOLS.md` is the agent-facing tool reference and received **one line of change across all 41 commits**. It still told readers to:

- run `validate_code(mode="references")` **+** `validate_code(mode="syntax")` — in four places, including both workflow flowcharts — while the tool's own description now says *"Call `mode="both"`"*. Schema and docs contradicted each other, and the doc taught the wasteful form.
- …and documented **none** of `operations[]` (on create *or* modify — the largest round-trip saving the tool has), `topics[]`, or `bpCheck`.

`docs/TESTING.md` said the inventory test asserts 25 tools; it asserts 23.

## Verification

`331 test files, 4830 passed.` `tsc --noEmit` clean, `biome lint` clean on the touched files. New `tests/tools/batchOutputBudget.test.ts` (4 cases) pins the per-section cap, that every verdict survives, that an ordinary operation is untouched, and that the create path is bounded too. Four new cases in `getKnowledge.test.ts` pin the shape message.

## Checked and found clean

Payload measured at **48,904 chars** (52,102 at v1.13.0, −6.1 %); the budget ratchet moved only down across every commit in scope (52,150 → 52,000 → 49,500 → 49,000). Coverage 70.17 % lines against a threshold of 61. Bridge attestation OK, and the deployed exe and `dist` are both newer than the last source change. `mode:"both"`, `bpCheck`, the `prepare` workspace header and the create/modify `operations[]` name-threading all behave as advertised.

## Not fixed here — flagged for a decision

- **Release hygiene.** `package.json` is still `1.13.0`, the same as the last tag, after 41 commits that *moved the tool surface* (parameters added AND removed) — which by the project's own versioning policy is a minor bump, and the removals are worth calling out for any prompt that named them. `CHANGELOG.md` has **no headings for 1.10 – 1.13** and nothing at all for these 41 commits, against its own rule: *"Add an entry in the same PR as the change."*
- `.github/workflows/release.yml:56` truncates the curated `CHANGELOG.md` and replaces it with generated `git log` output for the release body — so curated entries would never reach users even once written.
- `search` (`queries[]`) is missing from `PLURAL_FORM_TOOLS` in the session analyzer.
- `trimSucceededLog` matches `Error|Warning:` case-sensitively; a lowercase or MSBuild-shaped warning in a green build log would be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)