### PR TITLE
chore: bump version to 1.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
**Minor, not patch**, by the project's own rule in `CHANGELOG.md`:

> Minor versions carry behavioural changes to the MCP tool surface (tools added, merged or retired; parameter contracts changed).

Since v1.13.0 the surface moved in both directions. Tool count is unchanged at **23** — nothing was retired.

## Parameters added

| Tool | Parameter | Effect |
|---|---|---|
| `get_knowledge` | `topics[]` | several lookups in one call (max 10) |
| `validate_code` | `mode="both"` | the two checks in one call, merged |
| `build_d365fo_project` | `bpCheck` | BP report appended to a **green** build |
| `d365fo_file` | `operations[]` | now on `action="create"` as well as `"modify"`, applied to the object just created **under the name it actually got** |

## Parameters removed from the published schema

Each is **still accepted by its handler**, so a caller that passes one is unaffected. But a strict MCP client validates against `tools/list` and will drop it, and **any prompt or instruction file that named one should stop**:

| Tool | Removed |
|---|---|
| `search` | `workspacePath`, `includeWorkspace` (both levels), `globalTypeFilter`, `deduplicate`, `crossReference` |
| `labels` | the `list` / `list-files` action aliases, and `limit` |
| `trigger_db_sync` | `tableName` |
| `build_d365fo_project` | `buildReferencedModels` — the handler hard-codes `false` and ignores it; it never did anything |

## Behaviour worth knowing about (none of it a contract change)

- Metadata **reads run concurrently** in the C# bridge; writes and provider refreshes stay exclusive.
- A **green build** returns its diagnostics and summary instead of the raw phase-timing table.
- **Kernel enums** (`NoYes`, `TableGroup`, `AccessRight`, …) are no longer reported as hallucinated symbols, and an unresolvable `<EnumType>` is a warning rather than an error.
- `tools/list` payload **52,102 → 48,904 chars**.

## Note

`src/version.ts` reads `package.json`, so that plus `package-lock.json` is the only place the number lives. `CHANGELOG.md` is deliberately not touched — release notes are generated by the release workflow.

`331 test files, 4831 passed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)