### PR TITLE
fix: the two loose ends from the audit

### DIFF
--- a/src/cli/session/analyze.ts
+++ b/src/cli/session/analyze.ts
@@ -52,6 +52,7 @@ const PLURAL_FORM_TOOLS = [
   'get_object_info', 'run_bp_check', 'verify_d365fo_project',
   'd365fo_file',    // operations[] applies many edits to one object in a call
   'get_knowledge',  // topics[] answers several lookups in a call
+  'search',         // queries[] runs several searches in one call, in parallel
 ];
 
 export interface CostRates {

--- a/src/tools/sdlc/buildProject.ts
+++ b/src/tools/sdlc/buildProject.ts
@@ -416,7 +416,7 @@ export function trimSucceededLog(logTail: string, keepTail = 12): string {
   const diagnostics: string[] = [];
   let omitted = 0;
   for (let i = 0; i < summaryFrom; i++) {
-    if (DIAG_LINE_TEST.test(all[i].trim())) diagnostics.push(all[i]);
+    if (isWorthKeeping(all[i])) diagnostics.push(all[i]);
     else omitted++;
   }
   if (omitted === 0) return logTail;
@@ -425,6 +425,28 @@ export function trimSucceededLog(logTail: string, keepTail = 12): string {
     `[${omitted} phase-timing line(s) omitted — build succeeded]\n` +
     [...diagnostics, ...all.slice(summaryFrom)].join('\n').trim()
   );
+}
+
+/**
+ * Which lines of a GREEN build's tail survive the trim.
+ *
+ * DIAG_LINE_TEST is anchored and case-sensitive — it wants `[Kind ]Error: ` or
+ * `[Kind ]Warning: ` at the start of the line, which is exactly xppc's shape and
+ * nothing else. Verified: it keeps `Metadata Warning:`, `Compile Error:`,
+ * `BEST PRACTICE Warning:` and a bare `Warning:`, and drops a lowercase
+ * `warning:` and the MSBuild shape `MyTable.xpp(12,3): warning CS1234:`.
+ *
+ * On the FAILURE path that is harmless — non-matching lines still arrive through
+ * the head/tail fallback. On this path they are dropped outright, so a warning in
+ * a shape xppc does not normally emit would vanish from a green build entirely;
+ * hasWarnings uses the same test, so it would not even set the ⚠️ icon.
+ *
+ * The costs are not symmetric: a handful of extra lines is nothing, a silently
+ * dropped warning is the thing this function must not do. So anything that
+ * MENTIONS an error or a warning is kept too, whatever its shape.
+ */
+function isWorthKeeping(line: string): boolean {
+  return DIAG_LINE_TEST.test(line.trim()) || /\b(error|warning)s?\b/i.test(line);
 }
 
 /** Read the entire log without truncation — used for diagnostics parsing only. */

--- a/tests/tools/buildProject.test.ts
+++ b/tests/tools/buildProject.test.ts
@@ -125,6 +125,25 @@ describe('trimSucceededLog', () => {
     const raw = [...timing(57), ...SUMMARY].join('\n');
     expect(trimSucceededLog(raw).length).toBeLessThan(raw.length / 2);
   });
+
+  it('keeps a warning whatever shape it arrives in', () => {
+    // DIAG_LINE_TEST is anchored and case-sensitive — it wants xppc's exact shape
+    // and nothing else. On the FAILURE path a non-matching line still arrives via
+    // the head/tail fallback; here it would be dropped outright, and hasWarnings
+    // uses the same test, so such a warning would not even set the ⚠️ icon.
+    // Verified dropped before this widening: the lowercase and MSBuild shapes.
+    const shapes = [
+      'Metadata Warning: dynamics://M/T: [(1,1)]: label missing.',
+      'warning: lowercase generic',
+      'MyTable.xpp(12,3): warning CS1234: unused variable',
+    ];
+    const out = trimSucceededLog([...timing(20), ...shapes, ...timing(20), ...SUMMARY].join('\n'));
+
+    for (const line of shapes) expect(out, line).toContain(line);
+    // Still a trim, not a passthrough.
+    expect(out).toContain('phase-timing line(s) omitted');
+    expect(out).not.toContain('Phase timing row 3');
+  });
 });
 
 const PROJECT_PATH = 'C:\\MyProject\\MyProject.rnrproj';


### PR DESCRIPTION
These were the two items #939's description listed as *"not fixed here"*. I fixed them and pushed to that branch — but the merge had already happened, so the commit never reached `main`. This is that commit, cherry-picked onto current `main`.

## 1. A green build could swallow a warning

`trimSucceededLog` kept only lines matching `DIAG_LINE_TEST`, which is anchored and case-sensitive — it wants `[Kind ]Error: ` / `[Kind ]Warning: ` at the start of the line. Measured against the real matcher, it **keeps**

```
Metadata Warning: dynamics://…       Compile Error: Class dynamics://…
BEST PRACTICE Warning: …             Warning: something generic
```

and **drops**

```
warning: lowercase generic
MyTable.xpp(12,3): warning CS1234: unused variable
```

On the **failure** path that is harmless — a non-matching line still arrives through the head/tail fallback. On the **success** path it is dropped outright, and `hasWarnings` uses the same test, so such a warning would not even set the ⚠️ icon. Invisible twice over. Confirmed by running it: an MSBuild-shaped warning did not survive a green build.

The costs are not symmetric. A handful of extra lines is nothing; a silently dropped warning is the one thing this function must not do. Anything that **mentions** an error or a warning is now kept too, whatever its shape.

## 2. `search` was missing from `PLURAL_FORM_TOOLS`

It has `queries[]` (max 10), and the batch covers the tool's primary use — exactly the criterion the list's own comment states for inclusion. Its absence meant the session analyzer scored **zero** avoidable round trips for repeated single searches, which is the most common repeat pattern there is.

The audited fixture is unchanged: that session had no consecutive `search` turns, so the watch is added without inventing a finding.

## Not changed

A tail with no trailing summary still keeps 12 arbitrary rows under an accurate `[N phase-timing line(s) omitted]` label. Detecting "summary" would be guesswork and the cost is twelve lines.

`331 test files, 4831 passed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)