### PR TITLE
fix(bridge): fill in an EDT's inherited StringSize instead of the type default

### DIFF
--- a/bridge/D365MetadataBridge/Models/Models.cs
+++ b/bridge/D365MetadataBridge/Models/Models.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace D365MetadataBridge.Models
@@ -255,6 +255,14 @@ namespace D365MetadataBridge.Models
         [JsonPropertyName("extends")]
         public string? Extends { get; set; }
 
+        /// <summary>
+        /// Root of the Extends chain, or null for a root EDT. Reported for orientation in a
+        /// multi-level hierarchy; it is not necessarily the element that declares the
+        /// StringSize -- see StringSizeInheritedFrom for that.
+        /// </summary>
+        [JsonPropertyName("rootEdt")]
+        public string? RootEdt { get; set; }
+
         [JsonPropertyName("label")]
         public string? Label { get; set; }
 
@@ -263,6 +271,14 @@ namespace D365MetadataBridge.Models
 
         [JsonPropertyName("stringSize")]
         public int? StringSize { get; set; }
+
+        /// <summary>
+        /// Ancestor the reported StringSize came from. Null when the number is what this EDT's
+        /// own XML declares. Set both when the EDT declares nothing (the common case) and when
+        /// an ancestor's value overrode one the EDT did declare.
+        /// </summary>
+        [JsonPropertyName("stringSizeInheritedFrom")]
+        public string? StringSizeInheritedFrom { get; set; }
 
         [JsonPropertyName("referenceTable")]
         public string? ReferenceTable { get; set; }

--- a/bridge/D365MetadataBridge/Models/Models.cs
+++ b/bridge/D365MetadataBridge/Models/Models.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace D365MetadataBridge.Models
@@ -256,9 +256,13 @@ namespace D365MetadataBridge.Models
         public string? Extends { get; set; }
 
         /// <summary>
-        /// Root of the Extends chain, or null for a root EDT. Reported for orientation in a
-        /// multi-level hierarchy; it is not necessarily the element that declares the
-        /// StringSize -- see StringSizeInheritedFrom for that.
+        /// Root of the Extends chain. Reported for orientation in a multi-level hierarchy; it is
+        /// not necessarily the element that declares the StringSize -- see StringSizeInheritedFrom
+        /// for that.
+        ///
+        /// Null for a root EDT, and also null when the chain could not be walked to its end -- a
+        /// dangling Extends or a cycle -- because the last ancestor reached is not the root and
+        /// naming it as one would be a wrong answer rather than a missing one.
         /// </summary>
         [JsonPropertyName("rootEdt")]
         public string? RootEdt { get; set; }

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -438,7 +438,7 @@ namespace D365MetadataBridge.Services
 
             try { var mi = prov.Tables.GetModelInfo(tableName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
 
-            try { foreach (var f in table.Fields) result.Fields.Add(MapField(f)); } catch (Exception ex) { Warn("fields", tableName, ex); }
+            try { foreach (var f in table.Fields) result.Fields.Add(MapField(f, prov)); } catch (Exception ex) { Warn("fields", tableName, ex); }
             try { foreach (var g in table.FieldGroups) { var gm = new FieldGroupModel { Name = g.Name, Label = Safe(() => g.Label) }; try { foreach (var f in g.Fields) gm.Fields.Add(Safe(() => f.DataField) ?? f.Name); } catch { } result.FieldGroups.Add(gm); } } catch (Exception ex) { Warn("fieldGroups", tableName, ex); }
             try { foreach (var i in table.Indexes) { var im = new IndexInfoModel { Name = i.Name, AllowDuplicates = IsYes(() => i.AllowDuplicates), AlternateKey = IsYes(() => i.AlternateKey) }; try { foreach (var f in i.Fields) im.Fields.Add(new IndexFieldModel { DataField = Safe(() => f.DataField) ?? f.Name, IncludedColumn = IsYes(() => f.IncludedColumn) }); } catch { } result.Indexes.Add(im); } } catch (Exception ex) { Warn("indexes", tableName, ex); }
 
@@ -652,17 +652,45 @@ namespace D365MetadataBridge.Services
             var edt = prov.Edts.Read(edtName);
             if (edt == null) return null;
 
+            // The provider hands the EDT back exactly as its own XML declares it and does NOT
+            // fill in what it inherits. When a derived string EDT declares no StringSize of its
+            // own, the instance reports the AxEdtString constructor default of 10 instead of
+            // the inherited size. Measured against 10.0.2645: ItemFreeTxt read back as 10 and
+            // is really 1000 (from ItemFreeTxtBase); ItemId and CustAccount read back as 10 and
+            // are really 20.
+            //
+            // A child CAN declare its own StringSize -- 228 derived EDTs in the shipped corpus
+            // do. The platform allows it when the base carries StringSizeIsExtensible = Yes
+            // ("StringSize cannot be set on child edt when StringSizeIsExtensible is not set to
+            // Yes"). A declared value is left alone here; only the unset case is filled in.
+            var inherited = FindInheritedStringSize(edt, prov);
+            var declaredLocally = edt is AxEdtString local
+                ? SafeInt(() => local.StringSize, UnsetStringSize)
+                : 0;
+            ResolveInheritedEdtProperties(edt, inherited, prov);
+
             var result = new EdtInfoModel
             {
                 Name = edt.Name,
                 BaseType = edt.GetType().Name.Replace("AxEdt", ""),
                 Extends = Safe(() => edt.Extends),
+                RootEdt = inherited.Root,
                 Label = Safe(() => edt.Label),
                 HelpText = Safe(() => edt.HelpText),
             };
 
             try { var mi = prov.Edts.GetModelInfo(edtName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
-            if (edt is AxEdtString s) result.StringSize = SafeInt(() => s.StringSize, 0);
+            if (edt is AxEdtString s)
+            {
+                result.StringSize = SafeInt(() => s.StringSize, 0);
+                // Provenance only when the reported number is not what this EDT's own XML said.
+                // That covers the unset case, and the case where an ancestor's value overrode a
+                // declared one (PartyName declares 100, reports DirPartyName's 160).
+                if (result.StringSize != declaredLocally)
+                {
+                    result.StringSizeInheritedFrom = inherited.DeclaredBy;
+                }
+            }
             if (edt is AxEdtEnum en) result.EnumType = Safe(() => en.EnumType);
             try { result.ReferenceTable = Safe(() => ((dynamic)edt).ReferenceTable?.Table); } catch { }
 
@@ -670,7 +698,10 @@ namespace D365MetadataBridge.Services
             try { result.FormHelp = Safe(() => edt.FormHelp); } catch { }
             try { result.ConfigurationKey = Safe(() => ((dynamic)edt).ConfigurationKey); } catch { }
             try { result.Alignment = Safe(() => ((dynamic)edt).Alignment?.ToString()); } catch { }
-            try { result.DisplayLength = SafeInt(() => ((dynamic)edt).DisplayLength, 0); if (result.DisplayLength == 0) result.DisplayLength = null; } catch { }
+            // "Not set" for DisplayLength is -1, not 0 (verified against the AxEdtString
+            // constructor on 10.0.2645) — so the old `== 0` test never fired and every EDT
+            // without a local DisplayLength, 24 446 of the 25 332 indexed, reported -1.
+            try { result.DisplayLength = SafeInt(() => ((dynamic)edt).DisplayLength, -1); if (result.DisplayLength < 0) result.DisplayLength = null; } catch { }
             try { result.RelationType = Safe(() => ((dynamic)edt).RelationType?.ToString()); } catch { }
 
             // AxEdtReal specific
@@ -1863,11 +1894,134 @@ namespace D365MetadataBridge.Services
         private static int SafeInt(Func<int> f, int d) { try { return f(); } catch { return d; } }
         private static void Warn(string section, string obj, Exception ex) => Console.Error.WriteLine($"[WARN] Error reading {section} for {obj}: {ex.Message}");
 
+        /// <summary>
+        /// The value an AxEdtString reports when its XML declares no StringSize: the constructor
+        /// default. The serializer omits a property equal to its default, so a declared 10 and an
+        /// undeclared one are the same bytes on disk and the same value here -- and the compiler
+        /// treats both the same way, by inheriting. Verified against 10.0.2645, where an explicit
+        /// StringSize of 10 appears in none of the 25 332 shipped EDTs.
+        /// </summary>
+        private const int UnsetStringSize = 10;
+
+        /// <summary>Where a derived EDT's string size comes from, when it does not declare one.</summary>
+        private sealed class InheritedStringSize
+        {
+            /// <summary>Root of the Extends chain; null when the EDT is itself a root.</summary>
+            public string? Root;
+            /// <summary>Nearest ancestor that declares a StringSize; null when none does.</summary>
+            public string? DeclaredBy;
+            /// <summary>That ancestor's declared StringSize.</summary>
+            public int? Value;
+        }
+
+        /// <summary>
+        /// Walks <c>Extends</c> once, recording both the root of the hierarchy and the nearest
+        /// ancestor that actually declares a StringSize -- the value an undeclared child takes.
+        ///
+        /// Each hop goes back through <see cref="PickProvider"/> because an ancestor can live in
+        /// the other packages root (UDE: a custom EDT extending a Microsoft one). A dangling
+        /// <c>Extends</c> ends the walk where it breaks -- AmountMST names MoneyMST, which ships
+        /// no AxEdt file -- and a name already seen ends it too, so a metadata cycle cannot spin.
+        /// </summary>
+        private InheritedStringSize FindInheritedStringSize(AxEdt edt, IMetadataProvider prov)
+        {
+            var found = new InheritedStringSize();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { edt.Name };
+            var next = Safe(() => edt.Extends);
+
+            while (!string.IsNullOrEmpty(next) && seen.Add(next!))
+            {
+                var name = next!;
+                var parentProv = PickProvider(p => p.Edts.Exists(name)) ?? prov;
+                AxEdt? parent = null;
+                try { parent = parentProv.Edts.Read(name); } catch { }
+                if (parent == null) break;
+
+                found.Root = parent.Name;
+                if (found.DeclaredBy == null && parent is AxEdtString ps)
+                {
+                    var size = SafeInt(() => ps.StringSize, UnsetStringSize);
+                    if (size != UnsetStringSize)
+                    {
+                        found.DeclaredBy = parent.Name;
+                        found.Value = size;
+                    }
+                }
+                next = Safe(() => parent.Extends);
+            }
+            return found;
+        }
+
+        /// <summary>
+        /// Fills in the string size a derived EDT inherits rather than declares, so the reported
+        /// value is the one X++ compiles against.
+        /// </summary>
+        private void ResolveInheritedEdtProperties(AxEdt edt, InheritedStringSize inherited, IMetadataProvider prov)
+        {
+            if (string.IsNullOrEmpty(Safe(() => edt.Extends))) return;
+
+            try
+            {
+                // Microsoft's own resolver, which encodes a rule a reimplementation would get
+                // wrong: a declared size does not always win. Measured over the 182 derived EDTs
+                // that declare a size and have a declaring ancestor --
+                //   StringSizeIsExtensible = Yes  -> the declaration wins either way
+                //                                    (InvoiceId 50 over Num 20; CustInvoiceId 20
+                //                                    under InvoiceId 50)
+                //   otherwise, declared smaller   -> the ancestor's value wins (4 EDTs: PartyName
+                //                                    declares 100 under DirPartyName's 160 and
+                //                                    reports 160, ITMJourneyId, TAMRebateInvoice,
+                //                                    PSNPurchasingCardProviderName)
+                //   otherwise, declared larger    -> UNVERIFIED; no such EDT ships, so this code
+                //                                    does not assume a direction and simply lets
+                //                                    the resolver decide.
+                //
+                // isFlightEnabled: false, and the flag is not a detail. With true, an EDT-level
+                // read of CustInvoiceId returns 50 while the FIELD-level resolver returns 20 for
+                // CustInvoiceJour.InvoiceId -- a field typed with that very EDT -- so the bridge
+                // would contradict itself between get_object_info(edt) and
+                // get_object_info(table). With false the two agree at 20. false also confines
+                // this to the actual defect (an undeclared size) rather than rewriting values an
+                // EDT does declare, and the flag changes nothing for any of the broken cases
+                // (ItemFreeTxt 1000, ItemId 20, AccountNumber_IN 20 under either value).
+                Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaEdtExtensions
+                    .ResolveVirtualProperties(edt, prov, false);
+                return;
+            }
+            catch (Exception ex)
+            {
+                // The bridge is compiled against one environment's Microsoft assemblies and
+                // loaded against another's, so the resolver can simply be absent.
+                Warn("resolveVirtualProperties", edt.Name, ex);
+            }
+
+            // Fallback: fill in ONLY an undeclared size, from the nearest ancestor that declares
+            // one. That is exactly the population the defect affects, and the rule matched the
+            // resolver on 148 of 148 such EDTs. It deliberately does not reproduce the rule for
+            // a declared-but-smaller value -- leaving a declared number alone is the honest
+            // failure mode, and that case covers 4 EDTs in the shipped corpus.
+            //
+            // NoOfDecimals is left alone throughout. It looks similar but is NOT virtual: a child
+            // real EDT may declare its own (AccruedAmountMST_IT declares 2 while its base reports
+            // -1), so copying an ancestor's would overwrite a real local value.
+            if (edt is AxEdtString derived && inherited.Value.HasValue)
+            {
+                try
+                {
+                    if (derived.StringSize == UnsetStringSize)
+                    {
+                        derived.StringSize = inherited.Value.Value;
+                    }
+                }
+                catch { }
+            }
+        }
+
         // ========================
         // DIAGNOSTIC: Probe IMetadataProvider write capability
         // ========================
 
-        private FieldInfoModel MapField(AxTableField field)
+        private FieldInfoModel MapField(AxTableField field, IMetadataProvider prov)
         {
             var m = new FieldInfoModel
             {
@@ -1879,9 +2033,73 @@ namespace D365MetadataBridge.Services
                 Mandatory = IsYes(() => field.Mandatory),
                 AllowEdit = Safe(() => field.AllowEdit.ToString()),
             };
-            if (field is AxTableFieldString s) m.StringSize = SafeInt(() => s.StringSize, 0);
+            if (field is AxTableFieldString s) m.StringSize = EffectiveFieldStringSize(s, prov);
             if (field is AxTableFieldEnum en) m.EnumType = Safe(() => en.EnumType);
             return m;
+        }
+
+        /// <summary>
+        /// Cleared the first time Microsoft's field-level resolver throws, so an environment whose
+        /// assemblies predate it takes the hand-rolled path directly from then on.
+        /// </summary>
+        private bool _fieldStringSizeHelperUsable = true;
+
+        /// <summary>
+        /// The string size a field really has. An EDT-typed field almost never declares its own
+        /// size -- it takes the EDT's, and through the EDT its ancestors' -- but the raw property
+        /// returns the AxTableFieldString constructor default of 10 regardless. Measured across
+        /// ten core tables on 10.0.2645, that was wrong for 310 of 564 string fields (55 %):
+        /// InventTable.ItemId reported 10 against a real 20, InventTable.AltConfigId reported 10
+        /// against a real 50.
+        /// </summary>
+        private int EffectiveFieldStringSize(AxTableFieldString field, IMetadataProvider prov)
+        {
+            if (_fieldStringSizeHelperUsable)
+            {
+                try
+                {
+                    // Microsoft's own resolver: field -> EDT -> its ancestors. isFlightEnabled is
+                    // passed false to match ReadEdt, so the two agree on the same type; measured,
+                    // this resolver returned the same value under either flag for every field
+                    // tried (CustInvoiceJour.InvoiceId 20, DirPartyTable.Name 160,
+                    // InventTable.ItemId 20).
+                    return Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaTableFieldExtensions
+                        .GetStringSize(field, prov, false);
+                }
+                catch (Exception ex)
+                {
+                    // Latched off, and warned about exactly once: this runs per field, so a missing
+                    // helper would otherwise put one warning per string field per table read on
+                    // stderr (103 for CustTable alone).
+                    _fieldStringSizeHelperUsable = false;
+                    Warn("effectiveStringSize", field.Name, ex);
+                }
+            }
+
+            // Fallback for an environment whose assemblies predate the helper. A field that
+            // declares its own size keeps it; otherwise take the field's EDT, and from there the
+            // nearest declaring ancestor, exactly as ReadEdt does.
+            var declared = SafeInt(() => field.StringSize, UnsetStringSize);
+            if (declared != UnsetStringSize) return declared;
+
+            var edtName = Safe(() => field.ExtendedDataType);
+            if (!string.IsNullOrEmpty(edtName))
+            {
+                var edtProv = PickProvider(p => p.Edts.Exists(edtName!)) ?? prov;
+                AxEdt? edt = null;
+                try { edt = edtProv.Edts.Read(edtName!); } catch { }
+                if (edt != null)
+                {
+                    if (edt is AxEdtString es)
+                    {
+                        var own = SafeInt(() => es.StringSize, UnsetStringSize);
+                        if (own != UnsetStringSize) return own;
+                    }
+                    var inherited = FindInheritedStringSize(edt, edtProv);
+                    if (inherited.Value.HasValue) return inherited.Value.Value;
+                }
+            }
+            return declared;
         }
     }
 }

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -663,10 +663,16 @@ namespace D365MetadataBridge.Services
             // do. The platform allows it when the base carries StringSizeIsExtensible = Yes
             // ("StringSize cannot be set on child edt when StringSizeIsExtensible is not set to
             // Yes"). A declared value is left alone here; only the unset case is filled in.
-            var inherited = FindInheritedStringSize(edt, prov);
             var declaredLocally = edt is AxEdtString local
                 ? SafeInt(() => local.StringSize, UnsetStringSize)
                 : 0;
+
+            // ONE walk of the Extends chain, shared by the Root EDT row, the provenance label
+            // and the resolver fallback. It costs a full XML deserialize per hop and readEdt is
+            // a loop caller -- createD365File issues one per distinct EDT of a new table -- so
+            // the walk returns immediately for a root EDT and reads each hop from the child's
+            // own provider before paying for a two-provider Exists probe.
+            var inherited = FindInheritedStringSize(edt, prov);
             ResolveInheritedEdtProperties(edt, inherited, prov);
 
             var result = new EdtInfoModel
@@ -674,7 +680,11 @@ namespace D365MetadataBridge.Services
                 Name = edt.Name,
                 BaseType = edt.GetType().Name.Replace("AxEdt", ""),
                 Extends = Safe(() => edt.Extends),
-                RootEdt = inherited.Root,
+                // Only when the walk actually reached a root. A chain that broke on a dangling
+                // Extends (AmountMST names MoneyMST, which ships no AxEdt file) or on a cycle
+                // ends at an ancestor that is NOT the root, and reporting that one as the root
+                // would be a wrong answer rather than a missing one.
+                RootEdt = inherited.ChainComplete ? inherited.Root : null,
                 Label = Safe(() => edt.Label),
                 HelpText = Safe(() => edt.HelpText),
             };
@@ -686,7 +696,14 @@ namespace D365MetadataBridge.Services
                 // Provenance only when the reported number is not what this EDT's own XML said.
                 // That covers the unset case, and the case where an ancestor's value overrode a
                 // declared one (PartyName declares 100, reports DirPartyName's 160).
-                if (result.StringSize != declaredLocally)
+                //
+                // The second half of the test is what keeps the label honest. The NUMBER comes
+                // from Microsoft's resolver and the ATTRIBUTION from the walk above -- two
+                // different algorithms -- so without agreeing on the value they can disagree on
+                // the ancestor, and the report would credit one that declares something else.
+                // When they disagree the number still stands; only the claim about where it
+                // came from is dropped.
+                if (result.StringSize != declaredLocally && inherited.Value == result.StringSize)
                 {
                     result.StringSizeInheritedFrom = inherited.DeclaredBy;
                 }
@@ -1903,25 +1920,130 @@ namespace D365MetadataBridge.Services
         /// </summary>
         private const int UnsetStringSize = 10;
 
+        /// <summary>
+        /// Microsoft's EDT-level virtual-property resolver, bound by name. Null on a platform
+        /// whose assemblies do not carry it. See <see cref="FindStaticHelper"/> for why this is
+        /// reflection and not a call.
+        /// </summary>
+        private static readonly Lazy<System.Reflection.MethodInfo?> ResolveVirtualPropertiesHelper =
+            new Lazy<System.Reflection.MethodInfo?>(() => FindStaticHelper(
+                "Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaEdtExtensions",
+                "ResolveVirtualProperties", typeof(AxEdt), typeof(IMetadataProvider), typeof(bool)));
+
+        /// <summary>
+        /// Microsoft's field-level string-size resolver, bound the same way and for the same
+        /// reason.
+        /// </summary>
+        private static readonly Lazy<System.Reflection.MethodInfo?> GetStringSizeHelper =
+            new Lazy<System.Reflection.MethodInfo?>(() => FindStaticHelper(
+                "Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaTableFieldExtensions",
+                "GetStringSize", typeof(AxTableFieldString), typeof(IMetadataProvider), typeof(bool)));
+
+        /// <summary>
+        /// Finds a public static method by type name and method name, accepting any parameter
+        /// list the given argument types fit. Returns null when the type or the method is absent,
+        /// which is the signal to take the hand-rolled path.
+        ///
+        /// Why by name and not by a call. A direct call binds this project to a helper that only
+        /// some platform versions ship, and wrapping that call in try/catch does NOT make the
+        /// binding optional: the CLR resolves a method token when it JITs the method CONTAINING
+        /// the call, so a MissingMethodException surfaces at that method's own call site, one
+        /// frame up, and the inner catch never runs. Measured on .NET Framework 4 x64 against an
+        /// assembly with the helper removed: the inner catch did not fire, the fallback below it
+        /// was unreachable, and the exception escaped into the caller.
+        ///
+        /// The compile side matters more. The bridge ships as source and is built on each user's
+        /// own machine against that machine's PackagesLocalDirectory bin, so a direct call would
+        /// not merely lose the fallback on an older platform -- it would fail the build there and
+        /// leave the user with no bridge at all, where today they get one that reports the wrong
+        /// number. Binding by name keeps both the compile and the fallback intact.
+        ///
+        /// Both helpers live in Microsoft.Dynamics.AX.Metadata.dll, the same assembly as AxEdt,
+        /// which this process has loaded long before anything asks for them -- so the lookup
+        /// starts there and only then scans what else is loaded.
+        /// </summary>
+        private static System.Reflection.MethodInfo? FindStaticHelper(
+            string typeName, string methodName, params Type[] argTypes)
+        {
+            try
+            {
+                Type? type = null;
+                try { type = typeof(AxEdt).Assembly.GetType(typeName, false); } catch { }
+                if (type == null)
+                {
+                    foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        try { type = asm.GetType(typeName, false); } catch { }
+                        if (type != null) break;
+                    }
+                }
+                if (type == null)
+                {
+                    Console.Error.WriteLine(
+                        $"[WARN] {typeName} is absent from this platform's metadata assemblies; " +
+                        "falling back to the hand-rolled string-size walk.");
+                    return null;
+                }
+
+                foreach (var m in type.GetMethods(
+                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
+                {
+                    if (m.Name != methodName) continue;
+                    var ps = m.GetParameters();
+                    if (ps.Length != argTypes.Length) continue;
+                    var fits = true;
+                    for (var i = 0; i < ps.Length; i++)
+                    {
+                        if (!ps[i].ParameterType.IsAssignableFrom(argTypes[i])) { fits = false; break; }
+                    }
+                    if (fits) return m;
+                }
+
+                Console.Error.WriteLine(
+                    $"[WARN] {typeName}.{methodName} has no overload this bridge can call on this " +
+                    "platform; falling back to the hand-rolled string-size walk.");
+            }
+            catch (Exception ex)
+            {
+                Warn("bindStaticHelper", $"{typeName}.{methodName}", ex);
+            }
+            return null;
+        }
+
+        /// <summary>Unwraps the TargetInvocationException reflection wraps a callee's throw in.</summary>
+        private static Exception Unwrap(Exception ex) =>
+            ex is System.Reflection.TargetInvocationException tie && tie.InnerException != null
+                ? tie.InnerException
+                : ex;
+
         /// <summary>Where a derived EDT's string size comes from, when it does not declare one.</summary>
         private sealed class InheritedStringSize
         {
-            /// <summary>Root of the Extends chain; null when the EDT is itself a root.</summary>
+            /// <summary>
+            /// Last ancestor the walk reached. It is the root of the hierarchy only when
+            /// <see cref="ChainComplete"/> is true; null when the EDT is itself a root.
+            /// </summary>
             public string? Root;
             /// <summary>Nearest ancestor that declares a StringSize; null when none does.</summary>
             public string? DeclaredBy;
             /// <summary>That ancestor's declared StringSize.</summary>
             public int? Value;
+            /// <summary>
+            /// True when the walk ended at an EDT that extends nothing. False when it stopped
+            /// early -- a dangling Extends, a cycle, or a provider that could not answer -- in
+            /// which case <see cref="Root"/> is simply the last thing seen.
+            /// </summary>
+            public bool ChainComplete;
         }
 
         /// <summary>
-        /// Walks <c>Extends</c> once, recording both the root of the hierarchy and the nearest
-        /// ancestor that actually declares a StringSize -- the value an undeclared child takes.
+        /// Walks <c>Extends</c> once, recording the end of the hierarchy and the nearest ancestor
+        /// that actually declares a StringSize -- the value an undeclared child takes.
         ///
-        /// Each hop goes back through <see cref="PickProvider"/> because an ancestor can live in
-        /// the other packages root (UDE: a custom EDT extending a Microsoft one). A dangling
-        /// <c>Extends</c> ends the walk where it breaks -- AmountMST names MoneyMST, which ships
-        /// no AxEdt file -- and a name already seen ends it too, so a metadata cycle cannot spin.
+        /// A dangling <c>Extends</c> ends the walk where it breaks -- AmountMST names MoneyMST,
+        /// which ships no AxEdt file -- and a name already seen ends it too, so a metadata cycle
+        /// cannot spin. Either way the result is marked incomplete rather than passed off as a
+        /// root.
         /// </summary>
         private InheritedStringSize FindInheritedStringSize(AxEdt edt, IMetadataProvider prov)
         {
@@ -1929,13 +2051,12 @@ namespace D365MetadataBridge.Services
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { edt.Name };
             var next = Safe(() => edt.Extends);
 
-            while (!string.IsNullOrEmpty(next) && seen.Add(next!))
+            while (!string.IsNullOrEmpty(next))
             {
-                var name = next!;
-                var parentProv = PickProvider(p => p.Edts.Exists(name)) ?? prov;
-                AxEdt? parent = null;
-                try { parent = parentProv.Edts.Read(name); } catch { }
-                if (parent == null) break;
+                if (!seen.Add(next!)) return found;
+
+                var parent = ReadAncestorEdt(next!, prov);
+                if (parent == null) return found;
 
                 found.Root = parent.Name;
                 if (found.DeclaredBy == null && parent is AxEdtString ps)
@@ -1949,7 +2070,43 @@ namespace D365MetadataBridge.Services
                 }
                 next = Safe(() => parent.Extends);
             }
+
+            found.ChainComplete = true;
             return found;
+        }
+
+        /// <summary>
+        /// Reads one ancestor for the chain walk, or null when nobody has it.
+        ///
+        /// The child's own provider answers for very nearly every hop, so it is asked first and
+        /// <see cref="PickProvider"/> -- which costs an Exists probe against both providers -- is
+        /// only paid when that misses. That case is real (UDE: a custom EDT extending a Microsoft
+        /// one), just rare.
+        ///
+        /// The catch around PickProvider is load-bearing: PickProvider THROWS when a provider
+        /// fails, deliberately, so that a single-kind lookup can never report "does not exist"
+        /// for "could not look". Here the lookup is a side quest of a read that has already
+        /// succeeded, and letting that throw would turn a good EDT read -- or, from MapField, a
+        /// whole table's field list -- into an error over an ancestor nobody asked about.
+        /// </summary>
+        private AxEdt? ReadAncestorEdt(string name, IMetadataProvider prov)
+        {
+            try { var own = prov.Edts.Read(name); if (own != null) return own; } catch { }
+
+            var other = PickProviderForEdt(name);
+            if (other == null || ReferenceEquals(other, prov)) return null;
+
+            try { return other.Edts.Read(name); } catch { return null; }
+        }
+
+        /// <summary>
+        /// <see cref="PickProvider"/> for an EDT lookup that is a side quest of a read which has
+        /// already succeeded, and so must not be able to fail that read. See
+        /// <see cref="ReadAncestorEdt"/> for why the throw is swallowed here.
+        /// </summary>
+        private IMetadataProvider? PickProviderForEdt(string edtName)
+        {
+            try { return PickProvider(p => p.Edts.Exists(edtName)); } catch { return null; }
         }
 
         /// <summary>
@@ -1960,39 +2117,44 @@ namespace D365MetadataBridge.Services
         {
             if (string.IsNullOrEmpty(Safe(() => edt.Extends))) return;
 
-            try
+            // Microsoft's own resolver, which encodes a rule a reimplementation would get
+            // wrong: a declared size does not always win. Measured over the 182 derived EDTs
+            // that declare a size and have a declaring ancestor --
+            //   StringSizeIsExtensible = Yes  -> the declaration wins either way
+            //                                    (InvoiceId 50 over Num 20; CustInvoiceId 20
+            //                                    under InvoiceId 50)
+            //   otherwise, declared smaller   -> the ancestor's value wins (4 EDTs: PartyName
+            //                                    declares 100 under DirPartyName's 160 and
+            //                                    reports 160, ITMJourneyId, TAMRebateInvoice,
+            //                                    PSNPurchasingCardProviderName)
+            //   otherwise, declared larger    -> UNVERIFIED; no such EDT ships, so this code
+            //                                    does not assume a direction and simply lets
+            //                                    the resolver decide.
+            var helper = ResolveVirtualPropertiesHelper.Value;
+            if (helper != null)
             {
-                // Microsoft's own resolver, which encodes a rule a reimplementation would get
-                // wrong: a declared size does not always win. Measured over the 182 derived EDTs
-                // that declare a size and have a declaring ancestor --
-                //   StringSizeIsExtensible = Yes  -> the declaration wins either way
-                //                                    (InvoiceId 50 over Num 20; CustInvoiceId 20
-                //                                    under InvoiceId 50)
-                //   otherwise, declared smaller   -> the ancestor's value wins (4 EDTs: PartyName
-                //                                    declares 100 under DirPartyName's 160 and
-                //                                    reports 160, ITMJourneyId, TAMRebateInvoice,
-                //                                    PSNPurchasingCardProviderName)
-                //   otherwise, declared larger    -> UNVERIFIED; no such EDT ships, so this code
-                //                                    does not assume a direction and simply lets
-                //                                    the resolver decide.
-                //
-                // isFlightEnabled: false, and the flag is not a detail. With true, an EDT-level
-                // read of CustInvoiceId returns 50 while the FIELD-level resolver returns 20 for
-                // CustInvoiceJour.InvoiceId -- a field typed with that very EDT -- so the bridge
-                // would contradict itself between get_object_info(edt) and
-                // get_object_info(table). With false the two agree at 20. false also confines
-                // this to the actual defect (an undeclared size) rather than rewriting values an
-                // EDT does declare, and the flag changes nothing for any of the broken cases
-                // (ItemFreeTxt 1000, ItemId 20, AccountNumber_IN 20 under either value).
-                Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaEdtExtensions
-                    .ResolveVirtualProperties(edt, prov, false);
-                return;
-            }
-            catch (Exception ex)
-            {
-                // The bridge is compiled against one environment's Microsoft assemblies and
-                // loaded against another's, so the resolver can simply be absent.
-                Warn("resolveVirtualProperties", edt.Name, ex);
+                try
+                {
+                    // isFlightEnabled: false, and the flag is not a detail. With true, an
+                    // EDT-level read of CustInvoiceId returns 50 while the FIELD-level resolver
+                    // returns 20 for CustInvoiceJour.InvoiceId -- a field typed with that very
+                    // EDT -- so the bridge would contradict itself between get_object_info(edt)
+                    // and get_object_info(table). With false the two agree at 20. false also
+                    // confines this to the actual defect (an undeclared size) rather than
+                    // rewriting values an EDT does declare, and the flag changes nothing for any
+                    // of the broken cases (ItemFreeTxt 1000, ItemId 20, AccountNumber_IN 20 under
+                    // either value).
+                    helper.Invoke(null, new object?[] { edt, prov, false });
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    // The resolver was found but threw. Unlike an absent one -- which is already
+                    // handled by helper == null -- this is a genuine per-EDT failure, so it warns
+                    // and drops through to the walk rather than being taken as a verdict on the
+                    // platform.
+                    Warn("resolveVirtualProperties", edt.Name, Unwrap(ex));
+                }
             }
 
             // Fallback: fill in ONLY an undeclared size, from the nearest ancestor that declares
@@ -2039,10 +2201,15 @@ namespace D365MetadataBridge.Services
         }
 
         /// <summary>
-        /// Cleared the first time Microsoft's field-level resolver throws, so an environment whose
-        /// assemblies predate it takes the hand-rolled path directly from then on.
+        /// Set once the field-level resolver has thrown, so a systemic failure puts one line on
+        /// stderr instead of one per string field per table read (103 for CustTable alone).
+        ///
+        /// It gates the WARNING only, never the call. An absent helper is already handled by
+        /// binding it by name, so what reaches the catch is a per-field failure -- one malformed
+        /// field, a dangling ExtendedDataType -- and letting that permanently downgrade every
+        /// later table read in the process would trade a loud narrow fault for a silent wide one.
         /// </summary>
-        private bool _fieldStringSizeHelperUsable = true;
+        private bool _fieldStringSizeHelperWarned;
 
         /// <summary>
         /// The string size a field really has. An EDT-typed field almost never declares its own
@@ -2054,7 +2221,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         private int EffectiveFieldStringSize(AxTableFieldString field, IMetadataProvider prov)
         {
-            if (_fieldStringSizeHelperUsable)
+            var helper = GetStringSizeHelper.Value;
+            if (helper != null)
             {
                 try
                 {
@@ -2063,29 +2231,36 @@ namespace D365MetadataBridge.Services
                     // this resolver returned the same value under either flag for every field
                     // tried (CustInvoiceJour.InvoiceId 20, DirPartyTable.Name 160,
                     // InventTable.ItemId 20).
-                    return Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaTableFieldExtensions
-                        .GetStringSize(field, prov, false);
+                    var resolved = helper.Invoke(null, new object?[] { field, prov, false });
+                    if (resolved is int size) return size;
                 }
                 catch (Exception ex)
                 {
-                    // Latched off, and warned about exactly once: this runs per field, so a missing
-                    // helper would otherwise put one warning per string field per table read on
-                    // stderr (103 for CustTable alone).
-                    _fieldStringSizeHelperUsable = false;
-                    Warn("effectiveStringSize", field.Name, ex);
+                    if (!_fieldStringSizeHelperWarned)
+                    {
+                        _fieldStringSizeHelperWarned = true;
+                        Warn("effectiveStringSize", field.Name, Unwrap(ex));
+                    }
                 }
             }
 
-            // Fallback for an environment whose assemblies predate the helper. A field that
-            // declares its own size keeps it; otherwise take the field's EDT, and from there the
-            // nearest declaring ancestor, exactly as ReadEdt does.
+            // Fallback for a platform without the helper, and for the single field it could not
+            // answer for. A field that declares its own size keeps it; otherwise take the field's
+            // EDT, and from there the nearest declaring ancestor, exactly as ReadEdt does.
+            //
+            // Note what "declares its own size" can and cannot mean here. The 10-is-unset
+            // argument was MEASURED for EDTs (no explicit 10 among the 25 332 shipped) and is
+            // only carried over to fields, where it rests on the AxTableFieldString constructor
+            // default alone. A field that really did declare 10 over a 20-character EDT would be
+            // reported as 20 on this path. Microsoft's resolver above has no such gap, so this
+            // costs nothing on a current platform.
             var declared = SafeInt(() => field.StringSize, UnsetStringSize);
             if (declared != UnsetStringSize) return declared;
 
             var edtName = Safe(() => field.ExtendedDataType);
             if (!string.IsNullOrEmpty(edtName))
             {
-                var edtProv = PickProvider(p => p.Edts.Exists(edtName!)) ?? prov;
+                var edtProv = PickProviderForEdt(edtName!) ?? prov;
                 AxEdt? edt = null;
                 try { edt = edtProv.Edts.Read(edtName!); } catch { }
                 if (edt != null)

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "b7df3780df39ee432fad5ddcc771f72dfa4bffccf9eb0300f052117710467725",
+  "sourceHash": "53e837dc322f05b307e6e35c30ddc35e99b1d054108b90ee23ae1c2fd7e7e1a1",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7996.88",
-  "builtAt": "2026-08-27T17:31:14.692Z"
+  "metamodelFileVersion": "7.0.7996.33",
+  "builtAt": "2026-08-29T18:16:15.015Z"
 }

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "167cd1c211024c2b0bcb84e006ba21c76c8e4b2897abc9ef187bbce0480926fc",
+  "sourceHash": "b7df3780df39ee432fad5ddcc771f72dfa4bffccf9eb0300f052117710467725",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7996.33",
-  "builtAt": "2026-08-25T15:08:27.699Z"
+  "metamodelFileVersion": "7.0.7996.88",
+  "builtAt": "2026-08-27T17:31:14.692Z"
 }

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -499,10 +499,18 @@ function formatEdt(edt: BridgeEdtInfo): string {
   out += `## 🔧 Core Properties\n\n`;
   out += `| Property | Value |\n|---|---|\n`;
   out += `| Base Type | ${edt.baseType ?? '—'}${edt.extends ? ` (Extends: ${edt.extends})` : ''} |\n`;
+  if (edt.rootEdt && edt.rootEdt !== edt.extends) out += `| Root EDT | ${edt.rootEdt} |\n`;
   if (edt.enumType) out += `| Enum Type | ${edt.enumType} |\n`;
   if (edt.referenceTable) out += `| Reference Table | ${edt.referenceTable} |\n`;
   if (edt.relationType) out += `| Relation Type | ${edt.relationType} |\n`;
-  if (edt.stringSize) out += `| String Size | ${edt.stringSize} |\n`;
+  // A derived EDT usually inherits its StringSize rather than declaring one, and a value it
+  // does declare can still be overridden by an ancestor's. Say where the number came from
+  // whenever it is not what this EDT's own XML said.
+  if (edt.stringSize) {
+    const from = edt.stringSizeInheritedFrom ? ` (inherited from ${edt.stringSizeInheritedFrom})` : '';
+    const size = edt.stringSize === -1 ? '-1 (memo, unlimited)' : String(edt.stringSize);
+    out += `| String Size | ${size}${from} |\n`;
+  }
   if (edt.displayLength) out += `| Display Length | ${edt.displayLength} |\n`;
   if (edt.label) out += `| Label | ${edt.label} |\n`;
   if (edt.helpText) out += `| Help Text | ${edt.helpText} |\n`;

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -154,9 +154,17 @@ export interface BridgeEdtInfo {
   name: string;
   baseType?: string;
   extends?: string;
+  /** Root of the Extends chain, for orientation in a multi-level hierarchy. */
+  rootEdt?: string;
   label?: string;
   helpText?: string;
   stringSize?: number;
+  /**
+   * Ancestor the reported `stringSize` came from. Absent when the number is what this EDT's
+   * own XML declares. Present both when the EDT declares nothing (the common case) and when
+   * an ancestor's value overrode one the EDT did declare.
+   */
+  stringSizeInheritedFrom?: string;
   enumType?: string;
   referenceTable?: string;
   model?: string;

--- a/src/tools/readers/edtInfo.ts
+++ b/src/tools/readers/edtInfo.ts
@@ -144,7 +144,15 @@ function getEdtFromIndex(symbolIndex: any, edtName: string, modelName?: string) 
   if (row.enum_type) out += `| Enum Type | ${row.enum_type} |\n`;
   if (row.reference_table) out += `| Reference Table | ${row.reference_table} |\n`;
   if (row.relation_type) out += `| Relation Type | ${row.relation_type} |\n`;
-  if (row.string_size) out += `| String Size | ${row.string_size} |\n`;
+  // A derived EDT usually declares no StringSize, so `string_size` is null for 12 354 of
+  // the 25 332 indexed EDTs and this row used to be silently omitted for all of them.
+  // The value sits on the nearest ancestor that does declare one.
+  const size = resolveIndexedStringSize(db, row);
+  if (size) {
+    const from = size.inheritedFrom ? ` (inherited from ${size.inheritedFrom})` : '';
+    const shown = size.value === '-1' ? '-1 (memo, unlimited)' : size.value;
+    out += `| String Size | ${shown}${from} |\n`;
+  }
   if (row.database_string_size) out += `| Database String Size | ${row.database_string_size} |\n`;
   if (row.display_length) out += `| Display Length | ${row.display_length} |\n`;
   if (row.label) out += `| Label | ${row.label} |\n`;
@@ -152,6 +160,55 @@ function getEdtFromIndex(symbolIndex: any, edtName: string, modelName?: string) 
     `(HelpText, FormHelp, ConfigurationKey, Alignment…) are absent here, not absent from the EDT.\n`;
 
   return { content: [{ type: 'text', text: out }] };
+}
+
+/**
+ * The string size an indexed EDT really has, plus the ancestor it came from.
+ *
+ * A derived EDT usually declares no StringSize, leaving `edt_metadata.string_size` empty for
+ * 12 354 of the 25 332 indexed EDTs -- and this row used to be omitted for all of them even
+ * though the value sits an `extends` hop or two away. So: use the EDT's own size when it has
+ * one, otherwise walk `extends` to the nearest ancestor that stores one. Guards against a
+ * cycle and against a dangling `extends` (AmountMST names MoneyMST, which ships no AxEdt
+ * file).
+ *
+ * A child MAY declare its own size -- 228 do, permitted when the base carries
+ * StringSizeIsExtensible = Yes -- so a stored value is authoritative here and is not
+ * overridden.
+ *
+ * Known limitation of this path: `edt_metadata` does not store StringSizeIsExtensible, so it
+ * cannot tell when a declared size is overridden by an ancestor's. Where StringSizeIsExtensible
+ * is not Yes and the declared value is smaller than the nearest declaring ancestor's, the
+ * platform uses the ancestor's -- PartyName declares 100 under DirPartyName's 160 and really is
+ * 160, and this path reports the declared 100. That affects 4 EDTs in the shipped corpus, and
+ * only here: the bridge, which is the normal source, defers to Microsoft's resolver.
+ */
+function resolveIndexedStringSize(
+  db: any,
+  row: any,
+): { value: string; inheritedFrom?: string } | null {
+  if (row.string_size) return { value: String(row.string_size) };
+
+  const seen = new Set<string>([String(row.edt_name ?? '').toLowerCase()]);
+  let next: string | undefined = row.extends || undefined;
+
+  while (next && !seen.has(next.toLowerCase())) {
+    seen.add(next.toLowerCase());
+    let ancestor: any;
+    try {
+      ancestor = db.prepare(
+        'SELECT edt_name, extends, string_size FROM edt_metadata WHERE edt_name = ? LIMIT 1',
+      ).get(next);
+    } catch {
+      return null;
+    }
+    if (!ancestor) return null;
+    if (ancestor.string_size) {
+      return { value: String(ancestor.string_size), inheritedFrom: ancestor.edt_name };
+    }
+    next = ancestor.extends || undefined;
+  }
+  return null;
 }
 
 /** True when edt_metadata holds a row for exactly this spelling. */

--- a/src/tools/readers/edtInfo.ts
+++ b/src/tools/readers/edtInfo.ts
@@ -168,9 +168,8 @@ function getEdtFromIndex(symbolIndex: any, edtName: string, modelName?: string) 
  * A derived EDT usually declares no StringSize, leaving `edt_metadata.string_size` empty for
  * 12 354 of the 25 332 indexed EDTs -- and this row used to be omitted for all of them even
  * though the value sits an `extends` hop or two away. So: use the EDT's own size when it has
- * one, otherwise walk `extends` to the nearest ancestor that stores one. Guards against a
- * cycle and against a dangling `extends` (AmountMST names MoneyMST, which ships no AxEdt
- * file).
+ * one, otherwise walk `extends` to the nearest ancestor that stores one. The walk itself, with
+ * its cycle and dangling-`extends` guards, is `walkEdtChain`, shared with hierarchy mode.
  *
  * A child MAY declare its own size -- 228 do, permitted when the base carries
  * StringSizeIsExtensible = Yes -- so a stored value is authoritative here and is not
@@ -190,25 +189,55 @@ function resolveIndexedStringSize(
   if (row.string_size) return { value: String(row.string_size) };
 
   const seen = new Set<string>([String(row.edt_name ?? '').toLowerCase()]);
-  let next: string | undefined = row.extends || undefined;
-
-  while (next && !seen.has(next.toLowerCase())) {
-    seen.add(next.toLowerCase());
-    let ancestor: any;
-    try {
-      ancestor = db.prepare(
-        'SELECT edt_name, extends, string_size FROM edt_metadata WHERE edt_name = ? LIMIT 1',
-      ).get(next);
-    } catch {
-      return null;
-    }
-    if (!ancestor) return null;
+  for (const ancestor of walkEdtChain(db, row.extends, { seen })) {
     if (ancestor.string_size) {
       return { value: String(ancestor.string_size), inheritedFrom: ancestor.edt_name };
     }
-    next = ancestor.extends || undefined;
   }
   return null;
+}
+
+/**
+ * Yields the `edt_metadata` row for `startName` and then each `extends` ancestor in turn.
+ *
+ * Both modes of this tool walk the same chain over the same table with the same two stop
+ * conditions — a dangling `extends` (AmountMST names MoneyMST, which ships no AxEdt file) and a
+ * name already seen, so a metadata cycle cannot spin — so they walk it through here rather than
+ * each keeping their own copy of those rules.
+ *
+ * `modelName` filters the START row only. Ancestors are looked up across every model on purpose:
+ * a child in an ISV model almost always extends something in ApplicationPlatform or Foundation,
+ * and carrying the filter up the chain would cut it at the first hop and report the child as a
+ * root. Names are compared case-insensitively because X++ identifiers are.
+ */
+function* walkEdtChain(
+  db: any,
+  startName: string | undefined | null,
+  opts: { modelName?: string; seen?: Set<string> } = {},
+): Generator<any> {
+  const seen = opts.seen ?? new Set<string>();
+  let next: string | undefined = startName || undefined;
+  let first = true;
+
+  while (next && !seen.has(next.toLowerCase())) {
+    seen.add(next.toLowerCase());
+    const useModel = first ? opts.modelName : undefined;
+    first = false;
+
+    let row: any;
+    try {
+      row = db.prepare(
+        `SELECT edt_name, model, extends, label, string_size FROM edt_metadata
+          WHERE edt_name = ?${useModel ? ' AND model = ?' : ''} LIMIT 1`,
+      ).get(...(useModel ? [next, useModel] : [next]));
+    } catch {
+      return;
+    }
+    if (!row) return;
+
+    yield row;
+    next = row.extends || undefined;
+  }
 }
 
 /** True when edt_metadata holds a row for exactly this spelling. */
@@ -283,23 +312,11 @@ function getEdtHierarchy(db: any, edtName: string, modelName?: string) {
     ? edtName
     : (canonicalSymbolName(db, edtName, ['edt']) ?? edtName);
 
-  // Ancestor chain walk
+  // Ancestor chain walk — shared with basic mode's string-size resolution, so both modes stop
+  // on the same dangling `extends` and the same cycle, and agree on what the chain is.
   const chain: Array<{ name: string; model: string; extends?: string; label?: string; stringSize?: string }> = [];
-  let current = startName;
-  const visited = new Set<string>();
-
-  while (current && !visited.has(current)) {
-    visited.add(current);
-    const row = db.prepare(`
-      SELECT edt_name, model, extends, label, string_size
-      FROM edt_metadata WHERE edt_name = ?
-      ${modelName ? 'AND model = ?' : ''}
-      LIMIT 1
-    `).get(...(modelName ? [current, modelName] : [current])) as any;
-
-    if (!row) break;
+  for (const row of walkEdtChain(db, startName, { modelName })) {
     chain.push({ name: row.edt_name, model: row.model, extends: row.extends, label: row.label, stringSize: row.string_size });
-    current = row.extends;
   }
 
   if (chain.length === 0) {
@@ -326,6 +343,20 @@ function getEdtHierarchy(db: any, edtName: string, modelName?: string) {
     if (e.stringSize) output += `, StringSize: ${e.stringSize}`;
     if (e.extends) output += ` [extends ${e.extends}]`;
     output += '\n';
+  }
+
+  // The per-level StringSize above is only what each level DECLARES, so the queried EDT — which
+  // usually declares nothing — showed no size at all while basic mode reported the inherited
+  // one. Same resolution, same answer, stated once.
+  const effective = resolveIndexedStringSize(db, {
+    edt_name: chain[0].name,
+    extends: chain[0].extends,
+    string_size: chain[0].stringSize,
+  });
+  if (effective) {
+    const from = effective.inheritedFrom ? ` (inherited from ${effective.inheritedFrom})` : '';
+    const shown = effective.value === '-1' ? '-1 (memo, unlimited)' : effective.value;
+    output += `\nEffective String Size: ${shown}${from}\n`;
   }
 
   // Children

--- a/tests/tools/edtStringSizeInheritance.test.ts
+++ b/tests/tools/edtStringSizeInheritance.test.ts
@@ -40,7 +40,7 @@ import { describe, it, expect, vi } from 'vitest';
 import Database from '../../src/database/sqlite.js';
 import { getEdtInfoTool } from '../../src/tools/readers/edtInfo';
 
-function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: string }>) {
+function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: string; model?: string }>) {
   const db = new Database(':memory:');
   db.exec(`
     CREATE TABLE edt_metadata (
@@ -59,9 +59,9 @@ function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: strin
     CREATE VIRTUAL TABLE symbols_fts USING fts5(name, type, parent_name, signature, description, tags);
   `);
   const insEdt = db.prepare(
-    `INSERT INTO edt_metadata (edt_name, extends, string_size, model) VALUES (?, ?, ?, 'Foundation')`,
+    `INSERT INTO edt_metadata (edt_name, extends, string_size, model) VALUES (?, ?, ?, ?)`,
   );
-  for (const r of rows) insEdt.run(r.name, r.extends ?? null, r.stringSize ?? null);
+  for (const r of rows) insEdt.run(r.name, r.extends ?? null, r.stringSize ?? null, r.model ?? 'Foundation');
   return db;
 }
 
@@ -234,5 +234,73 @@ describe('EDT StringSize inheritance — SQLite fallback path', () => {
 
     const out = text(await getEdtInfoTool(req('LoopA'), ctx(db, null)));
     expect(out).not.toContain('| String Size |');
+  });
+});
+
+/**
+ * Both modes answer out of the same table over the same `extends` chain, and used to walk it
+ * with two separate loops — so they could disagree about the same EDT. They now share
+ * `walkEdtChain`.
+ */
+describe('EDT StringSize inheritance — the two SQLite modes agree', () => {
+  const hierReq = (edtName: string, modelName?: string) => ({
+    method: 'tools/call' as const,
+    params: {
+      name: 'get_edt_info',
+      arguments: { edtName, mode: 'hierarchy', ...(modelName ? { modelName } : {}) },
+    },
+  });
+
+  it('states the inherited size in hierarchy mode, which used to show none', async () => {
+    // The per-level list only ever showed what each level DECLARES, so the EDT the caller
+    // actually asked about — which declares nothing — showed no size at all.
+    const rows = [
+      { name: 'AccountNumber_IN', extends: 'CustVendAC' },
+      { name: 'CustVendAC', extends: 'ExternalAccount' },
+      { name: 'ExternalAccount', stringSize: '20' },
+    ];
+
+    const hier = text(await getEdtInfoTool(hierReq('AccountNumber_IN'), ctx(makeDb(rows), null)));
+    expect(hier).toContain('Effective String Size: 20 (inherited from ExternalAccount)');
+
+    // …and it is the same number basic mode reports for the same EDT.
+    const basic = text(await getEdtInfoTool(req('AccountNumber_IN'), ctx(makeDb(rows), null)));
+    expect(basic).toContain('| String Size | 20 (inherited from ExternalAccount) |');
+  });
+
+  it('claims no inheritance in hierarchy mode when the EDT declares its own size', async () => {
+    const db = makeDb([
+      { name: 'InvoiceId', extends: 'Num', stringSize: '50' },
+      { name: 'Num', stringSize: '20' },
+    ]);
+
+    const out = text(await getEdtInfoTool(hierReq('InvoiceId'), ctx(db, null)));
+    expect(out).toContain('Effective String Size: 50');
+    expect(out).not.toContain('inherited from');
+  });
+
+  it('follows the chain into other models instead of cutting it at the first hop', async () => {
+    // A child in an ISV model extending a Microsoft one is the normal case, not the exotic one.
+    // modelName pins WHICH EDT the caller means; carrying it up the chain would end the walk at
+    // ExtendedName and report an ISV EDT as a root with no size.
+    const db = makeDb([
+      { name: 'ExtendedName', extends: 'DirPartyName', model: 'ISVModel' },
+      { name: 'DirPartyName', stringSize: '160', model: 'ApplicationPlatform' },
+    ]);
+
+    const out = text(await getEdtInfoTool(hierReq('ExtendedName', 'ISVModel'), ctx(db, null)));
+    expect(out).toContain('ExtendedName → DirPartyName');
+    expect(out).toContain('Effective String Size: 160 (inherited from DirPartyName)');
+  });
+
+  it('does not spin on a cycle in hierarchy mode either', async () => {
+    const db = makeDb([
+      { name: 'LoopA', extends: 'LoopB' },
+      { name: 'LoopB', extends: 'LoopA' },
+    ]);
+
+    const out = text(await getEdtInfoTool(hierReq('LoopA'), ctx(db, null)));
+    expect(out).toContain('Ancestor Chain (2 level(s))');
+    expect(out).not.toContain('Effective String Size');
   });
 });

--- a/tests/tools/edtStringSizeInheritance.test.ts
+++ b/tests/tools/edtStringSizeInheritance.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Reported 2026-08-27: `get_object_info(objectType="edt", name="ItemFreeTxt")` answered
+ * StringSize 10. The real size is 1000, inherited from ItemFreeTxtBase.
+ *
+ * Root cause: IMetadataProvider hands back an EDT exactly as its own XML declares it and does
+ * not fill in what it inherits. When a derived string EDT declares no StringSize, the instance
+ * reports the AxEdtString constructor default of 10. Verified against 10.0.2645: ItemFreeTxt
+ * read back as 10 (really 1000), ItemId and CustAccount as 10 (really 20), and 310 of 564
+ * string fields across ten core tables carried the same wrong number.
+ *
+ * What is NOT true — an earlier revision of this fix claimed it, on the strength of a
+ * validation-message identifier alone — is that a child EDT cannot declare StringSize. The
+ * message reads in full "StringSize cannot be set on child edt when StringSizeIsExtensible is
+ * not set to Yes", i.e. the prohibition is conditional, and 228 derived EDTs in the shipped
+ * corpus do declare their own size (InvoiceId declares 50 over Num's 20). A declared value is
+ * therefore authoritative and must survive.
+ *
+ * Nor does a declared size always win. Measured over the 182 derived EDTs that declare a size
+ * and have a declaring ancestor:
+ *   - StringSizeIsExtensible = Yes -> the declaration wins in either direction (InvoiceId 50
+ *     over Num's 20; CustInvoiceId 20 under InvoiceId's 50).
+ *   - Otherwise, a declared value SMALLER than the nearest declaring ancestor's loses to it.
+ *     Four EDTs corpus-wide: PartyName declares 100 under DirPartyName's 160 and is 160, plus
+ *     ITMJourneyId, TAMRebateInvoice, PSNPurchasingCardProviderName.
+ *   - Otherwise, a declared value LARGER than the ancestor's: no such EDT ships, so the
+ *     behaviour is unverified and nothing here assumes it.
+ *
+ * And `ResolveVirtualProperties`' isFlightEnabled flag matters. With true, CustInvoiceId reads
+ * 50 at EDT level while the field-level resolver says 20 for CustInvoiceJour.InvoiceId, typed
+ * with that same EDT. The bridge passes false so the two agree at 20.
+ *
+ * All of the above comes from the metamodel resolvers, which is the source the compiler uses
+ * but not an independent oracle; none of it was cross-checked against live SQL column widths.
+ *
+ * These tests cover the two Node-side halves: rendering the value with its provenance, and
+ * resolving the chain in the SQLite fallback that answers when the bridge is absent.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Database from '../../src/database/sqlite.js';
+import { getEdtInfoTool } from '../../src/tools/readers/edtInfo';
+
+function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: string }>) {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE edt_metadata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      edt_name TEXT NOT NULL, extends TEXT, enum_type TEXT, reference_table TEXT,
+      relation_type TEXT, string_size TEXT, database_string_size TEXT,
+      display_length TEXT, label TEXT, model TEXT NOT NULL
+    );
+    CREATE INDEX idx_edt_metadata_name ON edt_metadata(edt_name);
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL, type TEXT NOT NULL, parent_name TEXT,
+      signature TEXT, file_path TEXT, model TEXT, description TEXT, extends_class TEXT
+    );
+    CREATE INDEX idx_name_type ON symbols(name, type);
+    CREATE VIRTUAL TABLE symbols_fts USING fts5(name, type, parent_name, signature, description, tags);
+  `);
+  const insEdt = db.prepare(
+    `INSERT INTO edt_metadata (edt_name, extends, string_size, model) VALUES (?, ?, ?, 'Foundation')`,
+  );
+  for (const r of rows) insEdt.run(r.name, r.extends ?? null, r.stringSize ?? null);
+  return db;
+}
+
+const req = (edtName: string) => ({
+  method: 'tools/call' as const,
+  params: { name: 'get_edt_info', arguments: { edtName } },
+});
+
+/** Context whose bridge answers with the given payload (null = bridge has no data). */
+function ctx(db: any, bridgeEdt: any) {
+  return {
+    symbolIndex: { getReadDb: () => db },
+    bridge: { isReady: true, metadataAvailable: true, readEdt: vi.fn(async () => bridgeEdt) },
+  } as any;
+}
+
+const text = (r: any) => r.content[0].text as string;
+
+describe('EDT StringSize inheritance — bridge path', () => {
+  it('reports the inherited size and names the EDT it came from', async () => {
+    const result = await getEdtInfoTool(
+      req('ItemFreeTxt'),
+      ctx(makeDb([]), {
+        name: 'ItemFreeTxt',
+        baseType: 'String',
+        extends: 'ItemFreeTxtBase',
+        rootEdt: 'ItemFreeTxtBase',
+        stringSize: 1000,
+        stringSizeInheritedFrom: 'ItemFreeTxtBase',
+        model: 'Foundation',
+      }),
+    );
+
+    const out = text(result);
+    expect(out).toContain('| String Size | 1000 (inherited from ItemFreeTxtBase) |');
+    // The old answer must not survive anywhere in the report.
+    expect(out).not.toContain('| String Size | 10 |');
+  });
+
+  it('names the declaring ancestor, not the immediate parent, on a multi-level chain', async () => {
+    // AccountNumber_IN -> CustVendAC -> ExternalAccount(20). Only the last declares a size.
+    const result = await getEdtInfoTool(
+      req('AccountNumber_IN'),
+      ctx(makeDb([]), {
+        name: 'AccountNumber_IN',
+        baseType: 'String',
+        extends: 'CustVendAC',
+        rootEdt: 'ExternalAccount',
+        stringSize: 20,
+        stringSizeInheritedFrom: 'ExternalAccount',
+      }),
+    );
+
+    const out = text(result);
+    expect(out).toContain('| Root EDT | ExternalAccount |');
+    expect(out).toContain('| String Size | 20 (inherited from ExternalAccount) |');
+  });
+
+  it("claims no inheritance when the derived EDT declares its own size", async () => {
+    // InvoiceId declares 50 over Num's 20 — permitted, because Num is extensible. The number
+    // is the EDT's own, so it must not be labelled as inherited from anywhere.
+    const result = await getEdtInfoTool(
+      req('InvoiceId'),
+      ctx(makeDb([]), {
+        name: 'InvoiceId',
+        baseType: 'String',
+        extends: 'Num',
+        rootEdt: 'Num',
+        stringSize: 50,
+      }),
+    );
+
+    const out = text(result);
+    expect(out).toContain('| String Size | 50 |');
+    expect(out).not.toContain('inherited from');
+  });
+
+  it("labels a value an ancestor overrode", async () => {
+    // PartyName declares 100 but is not StringSizeIsExtensible, and its base DirPartyName
+    // declares 160, so the base's value is the effective one.
+    const result = await getEdtInfoTool(
+      req('PartyName'),
+      ctx(makeDb([]), {
+        name: 'PartyName',
+        baseType: 'String',
+        extends: 'DirPartyName',
+        rootEdt: 'DirPartyName',
+        stringSize: 160,
+        stringSizeInheritedFrom: 'DirPartyName',
+      }),
+    );
+
+    expect(text(result)).toContain('| String Size | 160 (inherited from DirPartyName) |');
+  });
+
+  it('claims no inheritance for a root EDT, and spells out the memo sentinel', async () => {
+    const result = await getEdtInfoTool(
+      req('Notes'),
+      ctx(makeDb([]), { name: 'Notes', baseType: 'String', stringSize: -1 }),
+    );
+
+    const out = text(result);
+    expect(out).toContain('| String Size | -1 (memo, unlimited) |');
+    expect(out).not.toContain('inherited from');
+    expect(out).not.toContain('| Root EDT |');
+  });
+});
+
+describe('EDT StringSize inheritance — SQLite fallback path', () => {
+  it('walks extends to the declaring ancestor instead of omitting String Size', async () => {
+    const db = makeDb([
+      { name: 'ItemFreeTxt', extends: 'ItemFreeTxtBase' },
+      { name: 'ItemFreeTxtBase', stringSize: '1000' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('ItemFreeTxt'), ctx(db, null)));
+    expect(out).toContain('| String Size | 1000 (inherited from ItemFreeTxtBase) |');
+  });
+
+  it('skips ancestors that declare no size of their own', async () => {
+    const db = makeDb([
+      { name: 'AccountNumber_IN', extends: 'CustVendAC' },
+      { name: 'CustVendAC', extends: 'ExternalAccount' },
+      { name: 'ExternalAccount', stringSize: '20' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('AccountNumber_IN'), ctx(db, null)));
+    expect(out).toContain('| String Size | 20 (inherited from ExternalAccount) |');
+  });
+
+  it('stops at the NEAREST declaring ancestor, not the root', async () => {
+    // CorrectedInvoiceId_RU -> InvoiceId(50) -> Num(20). The real size is 50; taking the root
+    // would report 20.
+    const db = makeDb([
+      { name: 'CorrectedInvoiceId_RU', extends: 'InvoiceId' },
+      { name: 'InvoiceId', extends: 'Num', stringSize: '50' },
+      { name: 'Num', stringSize: '20' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('CorrectedInvoiceId_RU'), ctx(db, null)));
+    expect(out).toContain('| String Size | 50 (inherited from InvoiceId) |');
+    expect(out).not.toContain('inherited from Num');
+  });
+
+  it('keeps a size the derived EDT declares for itself', async () => {
+    // 228 shipped derived EDTs declare their own size; InvoiceId declares 50 over Num's 20.
+    const db = makeDb([
+      { name: 'Num', stringSize: '20' },
+      { name: 'InvoiceId', extends: 'Num', stringSize: '50' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('InvoiceId'), ctx(db, null)));
+    expect(out).toContain('| String Size | 50 |');
+    expect(out).not.toContain('inherited from');
+  });
+
+  it('says nothing rather than guessing when the chain dangles', async () => {
+    // AmountMST names MoneyMST in its Extends, and no AxEdt file ships for MoneyMST.
+    const db = makeDb([{ name: 'AmountMST', extends: 'MoneyMST' }]);
+
+    const out = text(await getEdtInfoTool(req('AmountMST'), ctx(db, null)));
+    expect(out).not.toContain('| String Size |');
+  });
+
+  it('terminates on a cyclic extends chain', async () => {
+    const db = makeDb([
+      { name: 'LoopA', extends: 'LoopB' },
+      { name: 'LoopB', extends: 'LoopA' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('LoopA'), ctx(db, null)));
+    expect(out).not.toContain('| String Size |');
+  });
+});


### PR DESCRIPTION
## Issue

`get_object_info(objectType="edt", name="ItemFreeTxt")` reports `StringSize` **10**. The real size is **1000**, inherited from `ItemFreeTxtBase`.

`IMetadataProvider` returns an EDT exactly as its own XML declares it and does not fill in what it inherits. When a derived string EDT declares no `StringSize`, the instance reports the `AxEdtString` constructor default of 10 rather than the inherited size. `ItemFreeTxt` reads back as 10 and is really 1000; `ItemId` and `CustAccount` read back as 10 and are really 20.

The table reader carried the same defect at `MapField`, and is the higher-traffic consumer: across ten core tables, **310 of 564 string fields (55%)** reported the wrong size. `InventTable.ItemId` said 10 against a real 20; `InventTable.AltConfigId` said 10 against a real 50.

Two rules constrain any fix, both measured against 10.0.2645 rather than assumed:

- **A derived EDT can declare its own `StringSize`**, and 228 in the shipped corpus do (`InvoiceId` declares 50 over `Num`'s 20). The platform permits it when the base carries `StringSizeIsExtensible = Yes`. A declared value is authoritative and must survive.
- **A declared value does not always win.** Over the 182 derived EDTs that declare a size and have a declaring ancestor: with `StringSizeIsExtensible = Yes` the declaration wins in either direction (`CustInvoiceId` keeps 20 under `InvoiceId`'s 50); otherwise a declared value *smaller* than the nearest declaring ancestor's loses to it (4 EDTs — `PartyName` declares 100 under `DirPartyName`'s 160 and is 160, plus `ITMJourneyId`, `TAMRebateInvoice`, `PSNPurchasingCardProviderName`). No `Auto`-and-larger EDT ships, so that direction is unverified and the fix assumes nothing about it.

The value an undeclared child takes comes from the **nearest** ancestor that declares one, not the root: `CorrectedInvoiceId_RU` → `InvoiceId(50)` → `Num(20)` resolves to 50.

## Fix

Defer to the metamodel's own resolvers rather than reimplementing the rules above:

- `ReadEdt` calls `MetaEdtExtensions.ResolveVirtualProperties`
- `MapField` calls `MetaTableFieldExtensions.GetStringSize`

Both are passed `isFlightEnabled: false`, which is not a detail. With `true`, an EDT-level read of `CustInvoiceId` returns 50 while the field-level resolver returns 20 for `CustInvoiceJour.InvoiceId` — a field typed with that very EDT — so the bridge would contradict itself between `get_object_info(edt)` and `get_object_info(table)`. With `false` the two agree at 20. The flag changes nothing for any of the broken cases (`ItemFreeTxt` 1000, `ItemId` 20, `AccountNumber_IN` 20 under either value).

Each has a hand-rolled fallback, because the bridge is compiled against one environment's Microsoft assemblies and loaded against another's, where the helper may be absent. The fallback fills in **only** an undeclared size, from the nearest declaring ancestor — that rule matched the resolver on 148 of 148 affected EDTs. It deliberately does not reproduce the override rule for a declared-but-smaller value: leaving a declared number alone is the honest failure mode, and that case covers 4 EDTs corpus-wide. The field-level fallback latches off after the first failure so a missing helper cannot emit one warning per string field per table read.

Mutating the returned instance is safe — the `DiskProvider` deserializes a fresh object on every `Read`, verified by reference-comparing two reads, so nothing leaks into a later read or into the write path.

`NoOfDecimals` is left alone throughout. It looks similar but is not virtual: a child real EDT may declare its own (`AccruedAmountMST_IT` declares 2 while its base reports -1), so copying an ancestor's would overwrite a real local value.

Also fixed on the way: the "not set" sentinel for `DisplayLength` is **-1, not 0**, so the old `== 0` test never fired and every EDT without a local `DisplayLength` (24,446 of 25,332) reported -1.

Reporting changes:

- The EDT report names where the number came from — `| String Size | 1000 (inherited from ItemFreeTxtBase) |` — and says nothing when the number is the EDT's own. A `Root EDT` row is added for orientation in multi-level hierarchies.
- The SQLite fallback used to omit `String Size` entirely for derived EDTs (12,354 of 25,332 indexed EDTs declare none) and now walks `edt_metadata.extends` to the nearest declaring ancestor. It cannot see `StringSizeIsExtensible`, so the override rule is documented as a known limitation of that path.

Every figure above comes from the metamodel resolvers against 10.0.2645 — the same source the compiler uses, but not an independent oracle. None of it was cross-checked against live SQL column widths.
