### PR TITLE
docs: re-align documentation and architecture diagram with the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@ those are called out explicitly below.
 ## [Unreleased]
 
 ### Fixed
+- **Docs and the architecture diagram re-aligned with the code.** The numbers
+  drift audit: the SVG still advertised 26 tools (it is 20 — the same fold this
+  block documents), TESTING.md still said 23 tools and ~2,900 tests across ~220
+  files (5,000+ across ~350), ARCHITECTURE.md carried a pre-fold "80 cases"
+  (87), "~19 patterns + ~20 sub-patterns" (36 + 30), "11 static rules" (20),
+  "31 modify ops" (27 distinct C# dispatcher ops) and a `/health` rate limit
+  that does not exist (`/health` is exempt). MCP_TOOLS.md now documents
+  `labels(action="update")` and `get_knowledge(kind="bp-moniker")`, the
+  extension objectTypes of `get_object_info`, the per-mode tool counts
+  (read-only 14 / write-only 9), and gained a short section on the 8 MCP
+  prompts and 5 workspace resources nothing user-facing listed before. The
+  heaviest table cells (`get_object_info`, `generate_object`, `d365fo_file`,
+  `object_patterns`) were unpacked into bullet lists — same facts, readable
+  shape. CUSTOM_EXTENSIONS.md and SETUP_AZURE.md stopped teaching the legacy
+  `.env`/`PACKAGES_PATH` configuration as the primary route now that the
+  wizard writes `config/d365fo-mcp.json`.
 - **Writes silently landed in whichever project scanned first.** When workspace
   heuristics resolved nothing, the `D365FO_SOLUTIONS_PATH` fallback pinned
   `all[0]` — so in a solution where several `.rnrproj` build one model (the

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-7.0-blue.svg)](https://www.typescriptlang.org/)
-[![Tests](https://img.shields.io/badge/tests-2800%2B-brightgreen.svg)](docs/TESTING.md)
+[![Tests](https://img.shields.io/badge/tests-5000%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
 [![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-100%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Three complementary data sources, one rule: **bridge-first when live metadata ma
 | Method signatures / source | ✅ snapshot | ✅ on demand | ✅ live |
 | Cross-references (callers) | ~ FTS approximation | — | ✅ exact (`DYNAMICSXREFDB`) |
 | Labels (20M+ rows) | ✅ sole source | — | create/rename only |
-| Create / modify objects | validated XML writers for types the provider cannot express | — | ✅ 13 create types, 31 modify ops |
+| Create / modify objects | validated XML writers for types the provider cannot express | — | ✅ 13 create types, 27 modify ops |
 
 SQLite stays essential even with the bridge: it is the **only** data source on Azure/Linux (no bridge), the sole store for 20M+ labels (`IMetadataProvider` has no label API), and the engine for all bulk search, aggregation and pattern mining (the bridge reads one object at a time).
 
@@ -86,7 +86,7 @@ Generated code must *prove* itself before touching disk. All gates are fail-clos
 |------|------------------|-------------|--------|
 | Provenance | `prepare` (mode=change/create) issues a grounding token (30 min TTL, object-bound). In-memory by default; with `GROUNDING_SECRET` set on both instances the token is HMAC-signed and portable, so the hybrid write-only companion (and scaled-out App Service) can validate it — without the secret, write-only mode bypasses enforcement | write called without a valid token | `GROUNDING_ENFORCE` + `GROUNDING_SECRET` |
 | References | `validate_code(mode="references")` — every type, field, method (incl. arity), enum, label checked against the index | any identifier unresolved | `GROUNDING_ENFORCE` |
-| Best practices | `validate_code(mode="syntax")` — 11 static rules (BP, COC, SEL, TTS, XML001/006/007) + 4 data-driven XML rules (XML002–XML005) mined from standard models (`property_stats`) | error-severity violations | — (advisory in output) |
+| Best practices | `validate_code(mode="syntax")` — 20 static rules (BP001–005, COC001–006, SEL001–005, TTS001, XML001/006/007) + 4 data-driven XML rules (XML002–XML005) mined from standard models (`property_stats`) | error-severity violations | — (advisory in output) |
 | Form patterns | `object_patterns (domain=form, action=validate)` — rules FP000–FP010 against the curated pattern catalog | structural violations (FP001–FP005, FP007) | `FORM_PATTERN_ENFORCE` |
 
 Supporting reliability mechanisms:
@@ -102,7 +102,7 @@ Supporting reliability mechanisms:
 
 ```mermaid
 flowchart LR
-    CAT["Curated catalog\n~19 patterns + ~20 sub-patterns\nsrc/knowledge/formPatterns"] --> ADV[object_patterns\ndomain=form, action=analyze]
+    CAT["Curated catalog\n36 patterns + 30 sub-patterns\nsrc/knowledge/formPatterns"] --> ADV[object_patterns\ndomain=form, action=analyze]
     CAT --> SPEC[object_patterns\ndomain=form, action=spec]
     CAT --> VAL[object_patterns domain=form, action=validate\nFP000–FP010]
     MINE[("form_patterns table\nmined from real forms\nduring build-database")] --> ADV
@@ -132,7 +132,7 @@ graph LR
     TS[bridgeClient.ts\nspawn + JSON-RPC + restarts] --> EXE[D365MetadataBridge.exe]
     TS -.->|types the provider cannot express| XMLW[XML writers\nsecurityPrivilegeXml · queryViewXml\ndirectXml fallbacks]
     EXE --> READ[MetadataReadService\nclasses, tables, forms, reports]
-    EXE --> WRITE[MetadataWriteService\n13 create types · 31 modify ops]
+    EXE --> WRITE[MetadataWriteService\n13 create types · 27 modify ops]
     EXE --> XREF[CrossReferenceService\nCoC, event handlers, callers]
     READ & WRITE --> PROV[IMetadataProvider / DiskProvider]
     XREF --> SQL[(DYNAMICSXREFDB)]
@@ -192,7 +192,7 @@ Two agents, one shared store, **no shared in-memory state** — either can run o
 
 | Element | What it is |
 |---|---|
-| Case catalog | 80 cases in `eval/cases/`, tiered L0–L4, each with a JSON spec validated against `schema.json` |
+| Case catalog | 87 cases in `eval/cases/`, tiered L0–L4, each with a JSON spec validated against `schema.json` |
 | Primary oracle | **golden metadata** — a diff of produced XML against the case's captured golden, not merely "it compiled" |
 | Runtime oracle | `run_systest_class` against `eval/systests/<id>.xml` — a SysTest references only standard objects, so it fails when a CoC wrapper is missing or wrong, which a golden cannot detect |
 | Fixtures | shared INPUT objects (e.g. `ConDemoNoteHeader`) live in `eval/fixtures/`, re-provisioned per run and excluded from rollback — case OUTPUTS are never pre-provisioned |
@@ -223,8 +223,8 @@ graph LR
 | Mode | `MCP_SERVER_MODE` | Tools exposed | Typical host |
 |------|-------------------|---------------|--------------|
 | Full | `full` (default) | all 20 | developer VM |
-| Read-only | `read-only` | search/analysis | Azure App Service |
-| Write-only | `write-only` | file ops + bridge reads | hybrid local companion |
+| Read-only | `read-only` | 14 — everything except the six `LOCAL_TOOLS` (build, BP, tests, reindex, workspace, verify) | Azure App Service |
+| Write-only | `write-only` | 9 — the six `LOCAL_TOOLS` + the three `ALWAYS_TOOLS` (`get_object_info`, `labels`, `d365fo_file`) | hybrid local companion |
 
 A second, independent axis controls how many of those tools are worth advertising. `MCP_TOOL_PROFILE=core` publishes only the create-and-build loop (15 tools) instead of all 20, with `MCP_EXTRA_TOOLS` adding individual ones back; `isToolEnabled()` in `serverMode.ts` combines both axes and is the single predicate used by the ListTools filter, the runtime call gate and the startup banner. It exists because hosts stop sending the tool catalogue inline past a limit (VS Code: ~100 tools across all servers) and fall back to a search-based tool surface, which costs a discovery round trip per tool the model needs.
 
@@ -237,7 +237,7 @@ Index refresh is automated via [Azure DevOps pipelines](SETUP_AZURE.md#azure-dev
 | Aspect | Implementation |
 |--------|----------------|
 | Search latency | FTS5 < 10 ms; active invalidation on writes |
-| Rate limits | `/mcp` 500 req / 15 min · `/health` 1000 req / 15 min |
+| Rate limits | `/mcp` 500 req / 15 min (`RATE_LIMIT_MAX_REQUESTS` / `RATE_LIMIT_WINDOW_MS`); `/health` exempt so Azure probes never throttle |
 | Auth (HTTP) | API key / Bearer middleware; HTTPS + TLS 1.2+; Blob access via connection string (`AZURE_STORAGE_CONNECTION_STRING`) |
 | Path safety | every write target validated against `PackagesLocalDirectory/<Package>/<Model>/Ax<Type>/` containment (no traversal) |
 | Error format | JSON-RPC errors with structured `data.detail`; network retries ×3; DB fallbacks logged |
@@ -250,5 +250,5 @@ Index refresh is automated via [Azure DevOps pipelines](SETUP_AZURE.md#azure-dev
 | Transport | MCP SDK — stdio + Express 5 HTTP |
 | Storage | node:sqlite (WAL, FTS5) — core module, no native addon |
 | Bridge | .NET Framework 4.8, Microsoft.Dynamics.AX.Metadata DLLs |
-| Tests | Vitest — ~2,850 tests, golden quality-gate suites |
+| Tests | Vitest — ~5,000 tests, golden quality-gate suites |
 | CI/CD | GitHub Actions — app CI + `eval-gate` (bridge attestation, golden regression, knowledge audit, coverage matrix); Azure DevOps (metadata pipelines) |

--- a/docs/CUSTOM_EXTENSIONS.md
+++ b/docs/CUSTOM_EXTENSIONS.md
@@ -15,21 +15,26 @@ This guide explains how to configure, extract, and index your custom X++ models 
 
 ### Traditional (PackagesLocalDirectory)
 
-Add to your `.env` file:
+The setup wizard (`npm run setup`, or later `npx d365fo-mcp config environment`) asks for all of this and writes it to `config/d365fo-mcp.json`. The keys involved — each overridable by its environment variable (a `.env` from an older installation keeps working as a fallback):
 
-```env
-# Standard D365 packages path
-PACKAGES_PATH=C:\AOSService\PackagesLocalDirectory
-
-# Your custom models (comma-separated package/model names)
-CUSTOM_MODELS=ISV_CustomModule1,ISV_CustomModule2,CompanyExtensions
-
-# ISV prefix — used by search(scope="extensions") for prefix filtering and by code-gen tools
-# for naming validation (e.g. class names must start with this prefix)
-EXTENSION_PREFIX=ISV_
-
-# Extraction mode: 'custom' (your models only), 'standard', or 'all'
-EXTRACT_MODE=custom
+```jsonc
+{
+  "environment": {
+    // Standard D365 packages path                       (env: D365FO_PACKAGE_PATH)
+    "packagePath": "C:\\AOSService\\PackagesLocalDirectory",
+    // Your custom models (comma-separated model names)  (env: CUSTOM_MODELS)
+    "customModels": "ISV_CustomModule1,ISV_CustomModule2,CompanyExtensions"
+  },
+  "naming": {
+    // ISV prefix — used by search(scope="extensions") for prefix filtering and by
+    // code-gen tools for naming validation               (env: EXTENSION_PREFIX)
+    "prefix": "ISV_"
+  },
+  "index": {
+    // 'custom' (your models only), 'standard', or 'all'  (env: EXTRACT_MODE)
+    "extractMode": "custom"
+  }
+}
 ```
 
 **How custom model detection works:** Everything listed in `CUSTOM_MODELS` is treated as your code. All other models are automatically classified as Microsoft standard. The server never requires you to maintain a static list of Microsoft model names — the list auto-adapts to new D365FO versions.
@@ -40,10 +45,14 @@ EXTRACT_MODE=custom
 
 In UDE environments, custom models are **auto-detected** from the custom packages path (`ModelStoreFolder` in your XPP config file). You do not need to set `CUSTOM_MODELS`:
 
-```env
-D365FO_DEV_ENVIRONMENT_TYPE=ude
-XPP_CONFIG_NAME=MyConfig    # name from %LOCALAPPDATA%\Microsoft\Dynamics365\XppConfig\
-EXTENSION_PREFIX=ISV_
+```jsonc
+{
+  "environment": {
+    "type": "ude",                 // env: D365FO_DEV_ENVIRONMENT_TYPE
+    "xppConfigName": "MyConfig"    // env: XPP_CONFIG_NAME — name from %LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\
+  },
+  "naming": { "prefix": "ISV_" }   // env: EXTENSION_PREFIX
+}
 ```
 
 Every model under `ModelStoreFolder` is automatically treated as custom; everything under `FrameworkDirectory` is Microsoft standard. Run `npm run select-config` to list available XPP configs.
@@ -196,13 +205,13 @@ The server uses the two-level workspace path (`PackagesLocalDirectory\PackageNam
 
 ## Multiple Clients / Instances
 
-If you work on several D365FO environments (different clients, different ISV prefixes), use the multi-instance scripts in `instances/`:
+If you work on several D365FO environments (different clients, different ISV prefixes), use the instance commands:
 
 ```powershell
-.\instances\add-instance.ps1    # creates instances\clientA\ with its own .env
+npx d365fo-mcp instance add     # creates instances\clientA\ with its own config, database and port
 ```
 
-Each instance has its own `CUSTOM_MODELS`, `EXTENSION_PREFIX`, and database. See [Scenario F in SETUP.md](SETUP.md#scenario-f--multiple-instances).
+Each instance has its own `customModels`, `naming.prefix`, and database. The `instances\*.ps1` scripts remain for installations still configured through per-instance `.env` files. See [Scenario F in SETUP.md](SETUP.md#scenario-f--multiple-instances).
 
 ---
 

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -103,7 +103,7 @@ Get-Content "C:\Temp\d365fo-bridge.log" -Encoding UTF8 -Wait -Tail 50
 
 The drive scan walks C: to Z: and keeps every volume that has an `AosService\PackagesLocalDirectory`, preferring one that looks populated over an empty stub. That is what makes the server work unconfigured on any VM image — K: on cloud-hosted environments, C: on the downloadable VHD, J: on newer images — without a hardcoded drive letter anywhere. `d365fo-mcp doctor` prints what it found.
 
-**Write target (UDE):** explicit env paths → XPP config auto-detection (`%LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\`, selected by `XPP_CONFIG_NAME` or newest) → `PACKAGES_PATH` fallback
+**Write target (UDE):** explicit env paths → XPP config auto-detection (`%LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\`, selected by `XPP_CONFIG_NAME` or newest) → `D365FO_PACKAGE_PATH` fallback (the legacy `PACKAGES_PATH` spelling still works)
 
 **Model name:** `D365FO_MODEL_NAME` → last segment of `D365FO_WORKSPACE_PATH` (AOT paths only) → auto-detected from `.rnrproj` (MCP roots / `D365FO_SOLUTIONS_PATH` scan)
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -6,7 +6,7 @@ Every tool the server exposes, grouped by purpose. The AI agent picks tools auto
 
 > **C# bridge first:** on Windows D365FO VMs, the bridge-backed read tools (marked †) query the live `IMetadataProvider` (always-fresh metadata) and `DYNAMICSXREFDB` (compiler-resolved cross-references), falling back to SQLite transparently on Azure/Linux. All write operations go exclusively through the bridge. See [ARCHITECTURE.md](ARCHITECTURE.md).
 >
-> **Server modes:** `full` = all 20 tools · `read-only` (Azure) = search/analysis only · `write-only` (hybrid companion) = file operations + bridge-backed reads. Independently, **`MCP_TOOL_PROFILE=core`** publishes only the 15-tool create-and-build loop, for workspaces that already run other MCP servers. See [MCP_CONFIG.md](MCP_CONFIG.md).
+> **Server modes:** `full` = all 20 tools · `read-only` (Azure) = everything except the six local build/verify tools · `write-only` (hybrid companion) = those six local tools plus the three always-on ones (`get_object_info`, `labels`, `d365fo_file`). Independently, **`MCP_TOOL_PROFILE=core`** publishes only the 15-tool create-and-build loop, for workspaces that already run other MCP servers. See [MCP_CONFIG.md](MCP_CONFIG.md).
 
 ---
 
@@ -56,8 +56,15 @@ One unified reader covers every object type via `objectType`; type-specific flag
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `get_object_info` † | Read object metadata by `objectType`: `class`, `table`, `form`, `query`, `view`, `enum`, `edt`, `report`, `data-entity`, `menu-item`, `service`, `map`, `config-key`, `security-policy`, `macro`. **2+ objects: pass `objects:[{objectType,objectName},…]` (max 10)** — one call, all lookups in parallel, per-object sections back (absorbs the former `batch_get_info`). Options: `{includeRdl}` (report), `{searchControl}` (form), `{compact:false}` (class), `{mode:"hierarchy"}` (edt), `{filter}` (macro); with `objects[]` a top-level `options` applies to every entry. For classes, `{members:"names"}` (optional `{prefix}`) returns a fast IntelliSense-style member-name list, and `{method:"validateWrite", include:"signature"}` returns ONE method — `include` is `signature` (exact signature, **mandatory before CoC**), `source` (full X++ body) or `both` (default). This absorbs the former `get_method`. | *"Show the structure of SalesFormLetter"* · *"Get full details of CustTable, SalesLine and CustInvoiceJour"* · *"Methods on SalesTable starting with calc"* |
+| `get_object_info` † | One unified reader for every AOT type — structure, fields, methods, properties; reads up to 10 objects in one call | *"Show the structure of SalesFormLetter"* · *"Get full details of CustTable, SalesLine and CustInvoiceJour"* · *"Methods on SalesTable starting with calc"* |
 | `find_references` † | Where-used analysis, xref-enriched (reference type, caller class/method). Also does **label where-used** — `targetType="label"` or an `@…` id (e.g. `@WAX2194`, `@ApplicationPlatform:AbortButtonText`) — returning every referencing object type (tables, forms, EDTs, enums, reports, menu items, …), grouped by source type | *"Where is updateInventory called from?"* · *"What references label @SYS9694?"* |
+
+`get_object_info` in detail:
+
+- **`objectType`** — `class`, `table`, `form`, `query`, `view`, `enum`, `edt`, `report`, `data-entity`, `menu-item`, `service`, `map`, `config-key`, `security-policy`, `macro`, plus the extension variants (`table-extension`, `class-extension`, `form-extension`, `enum-extension`, `edt-extension`, `data-entity-extension`).
+- **Batch** — for 2+ objects pass `objects: [{objectType, objectName}, …]` (max 10): one call, all lookups in parallel, per-object sections back (absorbs the former `batch_get_info`). A top-level `options` applies to every entry.
+- **Type-specific `options`** — `{includeRdl}` (report), `{searchControl}` (form), `{compact: false}` (class), `{mode: "hierarchy"}` (edt), `{filter}` (macro).
+- **Class members** — `{members: "names"}` (optional `{prefix}`) returns a fast IntelliSense-style member-name list; `{method: "validateWrite", include: "signature"}` returns ONE method, where `include` is `signature` (exact signature, **mandatory before CoC**), `source` (full X++ body) or `both` (default). Absorbs the former `get_method`.
 
 ## 🏷️ Label Management (1)
 
@@ -65,7 +72,7 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `labels` | `action=search` — full-text query across 20M+ label rows, all languages · `action=info` — all translations of a labelId (or list label files when omitted) · `action=create` — add a label to all language files of a model · `action=rename` — rename a label ID across .label.txt, X++ and XML | *"Is there a label for 'payment terms'?"* · *"Show translations of @SYS12345"* · *"Create label 'Priority tier' in en-US, cs, de"* · *"Rename label MyOldId to MyNewId everywhere"* |
+| `labels` | `action=search` — full-text query across 20M+ label rows, all languages · `action=info` — all translations of a labelId (or list label files when omitted) · `action=create` — add a label to all language files of a model · `action=update` — overwrite the text of an existing label (same arguments as create, with the corrected translations) · `action=rename` — rename a label ID across .label.txt, X++ and XML | *"Is there a label for 'payment terms'?"* · *"Show translations of @SYS12345"* · *"Create label 'Priority tier' in en-US, cs, de"* · *"Fix the typo in @MyModel:PriorityTier"* · *"Rename label MyOldId to MyNewId everywhere"* |
 
 > **Label where-used** (which objects reference a label) is not a `labels` action — use `find_references` with `targetType="label"` or an `@…` id. See Advanced Object Info above.
 
@@ -73,14 +80,25 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `get_knowledge` | `kind="knowledge"` — queryable X++ rulebook: select grammar, CoC, SysDa, FormRun lifecycle, form patterns, reading Excel/CSV files, parallel batch, direct SQL, AX2012→D365FO migration · `kind="error"` — compiler / runtime / BP errors explained with concrete fixes · `kind="op-spec"` — the parameter contract for one `d365fo_file` operation/objectType or one `generate_object` mode (`topic="add-index"`, `"table"`, `"scaffold:form"`, …); those two tools keep their parameters out of the wire schema, so this is where they come from. `topics: ["add-index", "add-field"]` answers SEVERAL lookups in one call (max 10) — a run typically needs 4-8 contracts and used to spend a round trip on each | *"What are the rules for crossCompany selects?"* · *"How do I read an uploaded Excel file in X++?"* · *"Explain error 'object not initialized' in batch"* |
+| `get_knowledge` | `kind="knowledge"` — queryable X++ rulebook: select grammar, CoC, SysDa, FormRun lifecycle, form patterns, reading Excel/CSV files, parallel batch, direct SQL, AX2012→D365FO migration · `kind="error"` — compiler / runtime / BP errors explained with concrete fixes · `kind="op-spec"` — the parameter contract for one `d365fo_file` operation/objectType or one `generate_object` mode (`topic="add-index"`, `"table"`, `"scaffold:form"`, …); those two tools keep their parameters out of the wire schema, so this is where they come from · `kind="bp-moniker"` — validate an exact BP-check moniker, search monikers by scenario, or render a `_BPSuppressions.xml` `<Diagnostic>` block, backed by names extracted from a real D365FO install (never invents a moniker). `topics: ["add-index", "add-field"]` answers SEVERAL lookups in one call (max 10) — a run typically needs 4-8 contracts and used to spend a round trip on each | *"What are the rules for crossCompany selects?"* · *"How do I read an uploaded Excel file in X++?"* · *"Explain error 'object not initialized' in batch"* · *"Is BPErrorPrivilegeNotCoveredByDuty a real moniker?"* |
 | `analyze_code` † | `mode="patterns"` — common patterns for a scenario · `mode="implementations"` — real implementations of a similar method · `mode="completeness"` — missing standard methods on a class · `mode="api-usage"` — how an API is initialized and called (compiler-resolved callers) | *"How are number sequences usually implemented here?"* · *"How do other classes implement validateWrite?"* · *"What standard methods is my service class missing?"* |
 
 ## 🎨 Code Generation (1)
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `generate_object` | `mode="pattern"` — named X++ skeleton from a pattern enum (text only): SysOperation, CoC, event handler, business event, custom service, lookup form, … · `mode="scaffold"` — pattern-aware whole-object generation: `objectType=table` (EDT suggestions), `objectType=form` (**clones reference forms** via `cloneFrom` + `tableMapping`, patterns/sub-patterns preserved, optional `includeMethodStubs`), `objectType=report` (complete SSRS stack: TmpTable + Contract + DP + Controller + AxReport/RDL) · `mode="find-methods"` — static `find()`/`findRecId()`/`exists()` for a table, keyed on its primary/unique index · `mode="relation-xpp"` — a table's relations → X++ `select` + `QueryBuildRange` snippets · `mode="fields"` — a field-name list → `AxTableField` XML with auto-resolved EDTs (+ optional field group) · `mode="table-relation"` — EDT-referencing fields → `AxTableRelation` XML (the inverse of `relation-xpp`). Mode-specific parameters go in a single `params` object (flat top-level keys still accepted) and come from `get_knowledge(kind="op-spec", topic="<mode>")`; a missing required one returns the complete per-mode spec (source: `generateObjectOpSpecs.ts`) | *"Generate a SysOperation skeleton for VendRecalc"* · *"Create an audit log table with SalesId, PostedAt, PostedBy"* · *"Create a SimpleList form for MyRentalGroup by cloning CustGroup"* · *"Add find/exists methods to MyOrderTable"* · *"Generate table relations for the EDT fields on MyOrderLine"* |
+| `generate_object` | Grounded code generation, from single-pattern skeletons to whole objects — pick a `mode` | *"Generate a SysOperation skeleton for VendRecalc"* · *"Create an audit log table with SalesId, PostedAt, PostedBy"* · *"Create a SimpleList form for MyRentalGroup by cloning CustGroup"* · *"Add find/exists methods to MyOrderTable"* · *"Generate table relations for the EDT fields on MyOrderLine"* |
+
+`generate_object` modes:
+
+- **`pattern`** — named X++ skeleton from a pattern enum (text only): SysOperation, CoC, event handler, business event, custom service, lookup form, …
+- **`scaffold`** — pattern-aware whole-object generation: `objectType=table` (EDT suggestions), `objectType=form` (**clones reference forms** via `cloneFrom` + `tableMapping`, patterns/sub-patterns preserved, optional `includeMethodStubs`), `objectType=report` (complete SSRS stack: TmpTable + Contract + DP + Controller + AxReport/RDL).
+- **`find-methods`** — static `find()`/`findRecId()`/`exists()` for a table, keyed on its primary/unique index.
+- **`relation-xpp`** — a table's relations → X++ `select` + `QueryBuildRange` snippets.
+- **`fields`** — a field-name list → `AxTableField` XML with auto-resolved EDTs (+ optional field group).
+- **`table-relation`** — EDT-referencing fields → `AxTableRelation` XML (the inverse of `relation-xpp`).
+
+Mode-specific parameters go in a single `params` object (flat top-level keys still accepted) and come from `get_knowledge(kind="op-spec", topic="<mode>")`; a missing required one returns the complete per-mode spec (source: `generateObjectOpSpecs.ts`).
 
 > `suggest_edt` was retired: EDT suggestions come from `prepare(mode="create", fieldsHint=[...])`, which returns them alongside the collision check, naming and mined property defaults in the same call. Its handler stays routable under the old name.
 
@@ -88,13 +106,34 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `object_patterns` | `domain="table"` — field/index/relation patterns for table groups · `domain="form"` — form-pattern toolkit: `action="analyze"` (pattern advisor via `recommend={entityKind, fieldCount, usageIntent, tableName}` → right pattern + reference forms; also analyzes existing forms), `action="spec"` (full pattern spec: required containers/ordering, sub-patterns, versions, lifecycle), `action="validate"` (structural validation FP001–FP010; errors **block form writes** via `FORM_PATTERN_ENFORCE`), `action="repair"` (auto-fill a form's **missing required controls** from its declared pattern — turns the FP003 report into a fix; existing controls preserved verbatim) | *"What do parameter tables typically look like?"* · *"Which form pattern fits a header+lines order entity?"* · *"Validate this form XML before I create it"* · *"Repair the missing controls on MyInquiryForm"* |
+| `object_patterns` | Mined + curated structure patterns: `domain="table"` for table shapes, `domain="form"` for the full form-pattern toolkit | *"What do parameter tables typically look like?"* · *"Which form pattern fits a header+lines order entity?"* · *"Validate this form XML before I create it"* · *"Repair the missing controls on MyInquiryForm"* |
+
+`object_patterns` in detail:
+
+- **`domain="table"`** — field/index/relation patterns for table groups.
+- **`domain="form"`, `action="analyze"`** — pattern advisor: pass `recommend={entityKind, fieldCount, usageIntent, tableName}` to get the right pattern + reference forms to clone; also analyzes existing forms.
+- **`domain="form"`, `action="spec"`** — full pattern spec: required containers/ordering, sub-patterns, versions, lifecycle.
+- **`domain="form"`, `action="validate"`** — structural validation FP001–FP010; errors **block form writes** via `FORM_PATTERN_ENFORCE`.
+- **`domain="form"`, `action="repair"`** — auto-fill a form's **missing required controls** from its declared pattern (turns the FP003 report into a fix; existing controls preserved verbatim).
 
 ## 📝 File Operations (1)
 
 | Tool | What it does | Example prompt |
 |------|--------------|----------------|
-| `d365fo_file` | `action=create` — create any of 39 AOT object types in the correct location + register in `.rnrproj` (gated by grounding token and form-pattern validation) · `action=modify` — safe metadata edits via the C# bridge, 38 operations: add-field, add-control, remove-control, add-entry-point, add-method, replace-code, modify-property, …; op-specific parameters go in a single `params` object (flat top-level keys still accepted) and come from `get_knowledge(kind="op-spec", topic="<operation>")` — the per-objectType `properties` contract for `action=create` from `topic="<objectType>"` — while a missing/wrong parameter returns that same complete per-op spec (error-driven guidance, source: `d365foFileOpSpecs.ts`) · `operations: [{operation, …}]` (max 20) applies SEVERAL edits to the same object in ONE call — on `action=modify` and on `action=create`, where they run against the object just created under the name it ACTUALLY got. Applied in order, stopped at the first failure, and each section of the report is capped so one call cannot return a context window · `action=delete` — remove an object's XML and un-register it from every `.rnrproj` of the model that lists it (irreversible; guarded against standard-model and cross-model targets) · `action=undo` — roll `filePath` back: git-tracked → `git checkout HEAD`, which discards ALL uncommitted changes to that file, not just the last edit; untracked → deleted; the symbol/label index is re-synced either way · `action=generate` — XML preview without writing (cloud-friendly) | *"Create the class file in my project"* · *"Add the field to the General tab of the form extension"* · *"Show me the XML for this enum without creating it"* · *"Undo that last change"* |
+| `d365fo_file` | The single write tool — create / modify / delete / undo AOT objects, or preview the XML without writing | *"Create the class file in my project"* · *"Add the field to the General tab of the form extension"* · *"Show me the XML for this enum without creating it"* · *"Undo that last change"* |
+
+`d365fo_file` actions:
+
+- **`create`** — create any of 39 AOT object types in the correct location + register in `.rnrproj` (gated by grounding token and form-pattern validation).
+- **`modify`** — safe metadata edits via the C# bridge, 38 operations: add-field, add-control, remove-control, add-entry-point, add-method, replace-code, modify-property, …
+- **`delete`** — remove an object's XML and un-register it from every `.rnrproj` of the model that lists it (irreversible; guarded against standard-model and cross-model targets).
+- **`undo`** — roll `filePath` back: git-tracked → `git checkout HEAD`, which discards ALL uncommitted changes to that file, not just the last edit; untracked → deleted; the symbol/label index is re-synced either way.
+- **`generate`** — XML preview without writing (cloud-friendly).
+
+Two things shared by `create` and `modify`:
+
+- **Parameters are fetched, not inlined.** Op-specific parameters go in a single `params` object (flat top-level keys still accepted) and come from `get_knowledge(kind="op-spec", topic="<operation>")` — for `action=create`, the per-objectType `properties` contract from `topic="<objectType>"`. A missing/wrong parameter returns that same complete per-op spec (error-driven guidance, source: `d365foFileOpSpecs.ts`).
+- **Batching.** `operations: [{operation, …}]` (max 20) applies SEVERAL edits to the same object in ONE call — on `action=modify` and on `action=create`, where they run against the object just created under the name it ACTUALLY got. Applied in order, stopped at the first failure, and each section of the report is capped so one call cannot return a context window.
 
 ## 🔐 Security & Extensions (5)
 
@@ -124,13 +163,21 @@ One unified tool covers all label operations via `action` (mirrors the `get_obje
 | `prepare` | `mode="change"` — one call before extending: signature + existing CoC wrappers + eligibility + strategy + **grounding token** · `mode="create"` — one call before creating: collision check + naming + EDT/label suggestions + property defaults + **grounding token** | automatically, before modifications / new objects |
 | `validate_code` | `mode="both"` — runs both checks below in ONE call and merges them; prefer it, since both are wanted before every write · `mode="references"` — proves every type/field/method/label in generated code against the index (anti-hallucination gate) · `mode="syntax"` — offline BP validator, < 50 ms: deprecated APIs, CoC correctness, select anti-patterns, data-driven XML property rules mined from standard models | automatically, after generation |
 
-> **Grounding enforcement:** `prepare` issues a SHA-256 provenance token (30-min TTL) **bound to the object it was issued for**. When `GROUNDING_ENFORCE=true` is set in `.env`:
+> **Grounding enforcement:** `prepare` issues a SHA-256 provenance token (30-min TTL) **bound to the object it was issued for**. When enforcement is on (`behavior.groundingEnforce` in the config, env `GROUNDING_ENFORCE=true`):
 > - extension patterns in `generate_object(mode="pattern")` and extension objectTypes in `d365fo_file(action="create"/"modify")` require a valid token for the target object, and
 > - X++ source passed to `d365fo_file(action="create"/"modify")` is run through `validate_code(mode="references")` — the write is rejected while any identifier cannot be proven against the index.
 >
 > This ensures generated code is grounded in your actual codebase, not AI training data.
 >
 > **Hybrid deployment note:** grounding tokens live in the issuing process's memory by default. In `write-only` mode (local companion) `prepare` is not exposed and in-memory tokens issued by the read-only/Azure instance cannot be validated locally, so `GROUNDING_ENFORCE=true` is **ignored** there (with a startup warning) — otherwise the agent would loop forever between the two servers. To enforce grounding end-to-end in a hybrid deployment, set the same `GROUNDING_SECRET` on **both** instances: tokens are then HMAC-signed and the companion validates them statelessly.
+
+---
+
+## Beyond tools: MCP prompts & resources
+
+The server also publishes **8 MCP prompts** (invoked manually from the client's prompt picker — they are *not* loaded automatically, which is why the instruction file is mandatory): `xpp_system_instructions` (full workflow rules), `xpp_create_file`, `xpp_code_review`, `xpp_explain_class`, `xpp_extension_guide`, `xpp_security_guide`, `xpp_sysoperation_guide`, `xpp_data_entity_guide`.
+
+And **5 workspace resources** (read-only JSON for clients that consume MCP resources): `workspace://context` (model/project snapshot + index freshness), `workspace://active` (most recently modified X++ object), `workspace://stats`, `workspace://files`, `workspace://recent-changes` — plus the `xpp://class/{className}` template serving X++ source.
 
 ---
 

--- a/docs/SETUP_AZURE.md
+++ b/docs/SETUP_AZURE.md
@@ -150,7 +150,7 @@ See [Azure DevOps Pipelines](#azure-devops-pipelines). Pipelines handle extracti
 
 ### Option B — Manual (from your Windows VM)
 
-1. Configure `.env` on your VM — set `PACKAGES_PATH`, `CUSTOM_MODELS`, `AZURE_STORAGE_CONNECTION_STRING`, `BLOB_CONTAINER_NAME`.
+1. Configure the server on your VM — `npm run setup` (or `npx d365fo-mcp config`) writes `environment.packagePath`, `environment.customModels` and the Azure storage secrets; the equivalent environment variables are `D365FO_PACKAGE_PATH`, `CUSTOM_MODELS`, `AZURE_STORAGE_CONNECTION_STRING`, `BLOB_CONTAINER_NAME` ([CONFIGURATION.md](CONFIGURATION.md)).
 
 2. Extract and build:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-The project uses [Vitest](https://vitest.dev/). ~2,900 tests across ~220 files run without a live D365FO environment — all external dependencies (SQLite, filesystem, bridge, cache) are mocked.
+The project uses [Vitest](https://vitest.dev/). ~5,000 tests across ~350 files run without a live D365FO environment — all external dependencies (SQLite, filesystem, bridge, cache) are mocked.
 
 ## Running tests
 
@@ -27,7 +27,7 @@ npx tsx tests/bridge-e2e.ts             # manual bridge E2E (Windows D365FO VM o
 | `tests/metadata/` | XML parser + pattern miner + SQLite indexing against fixture forms |
 | `tests/bridge/` | bridge client behavior (debounced refresh); `bridge-e2e.ts` is manual |
 
-Contract tests worth knowing: `tests/utils/toolInventory.test.ts` asserts the published tool count (23 at the time of writing — branches that add, consolidate or unpublish tools change it, and the test is what makes that deliberate) and keeps `src/server/toolSchemas/`, the startup catalog and `LOCAL_TOOLS` in sync; it also fails when guidance text names a tool retired by a consolidation. See [NEW_TOOL_CHECKLIST.md](NEW_TOOL_CHECKLIST.md). `tests/utils/toolSchemaBudget.test.ts` pins the serialized `tools/list` payload size — that payload ships on every request.
+Contract tests worth knowing: `tests/utils/toolInventory.test.ts` asserts the published tool count (20 at the time of writing — branches that add, consolidate or unpublish tools change it, and the test is what makes that deliberate) and keeps `src/server/toolSchemas/`, the startup catalog and `LOCAL_TOOLS` in sync; it also fails when guidance text names a tool retired by a consolidation. See [NEW_TOOL_CHECKLIST.md](NEW_TOOL_CHECKLIST.md). `tests/utils/toolSchemaBudget.test.ts` pins the serialized `tools/list` payload size — that payload ships on every request.
 
 ## Mock strategy
 

--- a/docs/img/solution-architecture-diagram.svg
+++ b/docs/img/solution-architecture-diagram.svg
@@ -25,7 +25,7 @@
     <text x="928" y="50" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">580K+</text>
     <text x="928" y="64" text-anchor="middle" font-size="9.5" fill="#aab6d3">symbols indexed</text>
     <rect x="1004" y="32" width="128" height="38" rx="8" fill="#ffffff" fill-opacity="0.10" stroke="#5b6aa8"/>
-    <text x="1068" y="50" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">26</text>
+    <text x="1068" y="50" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">20</text>
     <text x="1068" y="64" text-anchor="middle" font-size="9.5" fill="#aab6d3">MCP tools</text>
     <rect x="1144" y="32" width="128" height="38" rx="8" fill="#ffffff" fill-opacity="0.10" stroke="#5b6aa8"/>
     <text x="1208" y="50" text-anchor="middle" font-size="15" font-weight="700" fill="#ffffff">fail-closed</text>
@@ -86,7 +86,7 @@
   <text x="334" y="190" font-size="10.5" fill="#475569">stdio JSON-RPC · Express 5 HTTP (/mcp) · API-key / Bearer auth · rate limiting · dedup cache (60 s) · loop detection</text>
 
   <rect x="320" y="220" width="680" height="92" rx="9" fill="#ffffff" stroke="#6366f1"/>
-  <text x="334" y="242" font-size="12.5" font-weight="600" fill="#4338ca">26 tool handlers</text>
+  <text x="334" y="242" font-size="12.5" font-weight="600" fill="#4338ca">20 tool handlers</text>
   <g font-size="10" fill="#3730a3">
     <rect x="334" y="252" width="96" height="22" rx="11" fill="#eef2ff" stroke="#c7d2fe"/><text x="382" y="267" text-anchor="middle">Search / X-ref</text>
     <rect x="438" y="252" width="110" height="22" rx="11" fill="#eef2ff" stroke="#c7d2fe"/><text x="493" y="267" text-anchor="middle">Code intelligence</text>
@@ -123,7 +123,7 @@
     <circle cx="686" cy="436" r="9" fill="#ea580c"/><text x="686" y="440" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">3</text>
     <text x="702" y="440" font-size="11" font-weight="600" fill="#9a3412">Best practices</text>
     <text x="680" y="462" font-size="9" fill="#7c2d12">validate_code · syntax</text>
-    <text x="680" y="476" font-size="9" fill="#7c2d12">11 static + 4 mined rules</text>
+    <text x="680" y="476" font-size="9" fill="#7c2d12">20 static + 4 mined rules</text>
 
     <rect x="838" y="420" width="152" height="74" rx="8" fill="#ffffff" stroke="#fdba74"/>
     <circle cx="854" cy="436" r="9" fill="#ea580c"/><text x="854" y="440" text-anchor="middle" font-size="11" font-weight="700" fill="#fff">4</text>
@@ -175,7 +175,7 @@
   <rect x="1064" y="306" width="212" height="82" rx="8" fill="#ffffff" stroke="#86c79c"/>
   <text x="1076" y="328" font-size="12" font-weight="600" fill="#15803d">Automation</text>
   <text x="1076" y="344" font-size="10" fill="#475569">Azure DevOps — extract→build→upload</text>
-  <text x="1076" y="360" font-size="10" fill="#475569">GitHub Actions — app CI · 2800+ tests</text>
+  <text x="1076" y="360" font-size="10" fill="#475569">GitHub Actions — app CI · 5000+ tests</text>
   <text x="1076" y="376" font-size="10" fill="#475569">eval gate — goldens · knowledge audit</text>
 
   <text x="560" y="668" font-size="10" fill="#15803d">produces both databases</text>
@@ -185,7 +185,7 @@
   <rect x="1044" y="424" width="252" height="238" rx="12" fill="#f5f3ff" stroke="#ddd6fe" filter="url(#card)"/>
   <circle cx="1064" cy="447" r="5" fill="#7c3aed"/>
   <text x="1078" y="451" font-size="12.5" font-weight="700" fill="#5b21b6" letter-spacing="1.2">EVAL LOOP</text>
-  <text x="1064" y="468" font-size="10" fill="#6d5bb5">self-improving harness · 80 cases</text>
+  <text x="1064" y="468" font-size="10" fill="#6d5bb5">self-improving harness · 87 cases</text>
 
   <rect x="1064" y="476" width="212" height="54" rx="8" fill="#ffffff" stroke="#a78bfa"/>
   <text x="1076" y="494" font-size="11.5" font-weight="600" fill="#6d28d9">Implementer agent</text>
@@ -231,7 +231,7 @@
   <text x="699" y="762" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">C# Metadata Bridge</text>
   <text x="699" y="782" text-anchor="middle" font-size="10.5" fill="#ddd6fe">D365MetadataBridge.exe · .NET Framework 4.8</text>
   <text x="699" y="799" text-anchor="middle" font-size="10.5" fill="#ddd6fe">JSON-RPC over stdio · IMetadataProvider</text>
-  <text x="699" y="816" text-anchor="middle" font-size="10.5" fill="#ddd6fe">primary write path · 13 create · 31 modify ops</text>
+  <text x="699" y="816" text-anchor="middle" font-size="10.5" fill="#ddd6fe">primary write path · 13 create · 27 modify ops</text>
   <text x="699" y="840" text-anchor="middle" font-size="9.5" fill="#c4b5fd">Windows VM only — graceful fallback to SQLite elsewhere</text>
 
   <rect x="898" y="736" width="376" height="120" rx="9" fill="#eff6ff" stroke="#3b82f6"/>

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -10,6 +10,7 @@
  * Resources exposed:
  *   • xpp://class/{className}     — class source (resource template)
  *   • workspace://context        — curated context snapshot (JSON)
+ *   • workspace://active         — most recently modified X++ object (JSON)
  *   • workspace://stats          — symbol-index + workspace statistics (JSON)
  *   • workspace://files          — list of X++ files in the workspace (JSON)
  *   • workspace://recent-changes — uncommitted X++ changes vs HEAD (JSON)


### PR DESCRIPTION
Numbers drift fixed against measured ground truth:
- SVG diagram: 26 -> 20 MCP tools (twice), 80 -> 87 eval cases,
  2800+ -> 5000+ tests, 11 -> 20 static validator rules,
  31 -> 27 bridge modify ops
- TESTING.md: 23 -> 20 published tools; ~2,900 tests / ~220 files ->
  ~5,000 / ~350 (suite measures 5,026 across 352 files)
- ARCHITECTURE.md: same corrections, plus /health is exempt from rate
  limiting (no 1000 req/15 min limit exists), form-pattern catalog is
  36 patterns + 30 sub-patterns, and per-mode tool counts spelled out
- README.md: tests badge 2800+ -> 5000+

Coverage gaps closed in MCP_TOOLS.md:
- labels(action="update") and get_knowledge(kind="bp-moniker") were
  published but undocumented; get_object_info's extension objectTypes
  listed; new section documenting the 8 MCP prompts and 5 workspace
  resources

Readability: the four heaviest table cells (get_object_info,
generate_object, d365fo_file, object_patterns) unpacked into bullet
lists under their tables - same facts, scannable shape.

Modernized configuration guidance: CUSTOM_EXTENSIONS.md and
SETUP_AZURE.md now lead with the setup wizard / config file instead of
the legacy .env + PACKAGES_PATH route; MCP_CONFIG.md names the current
D365FO_PACKAGE_PATH spelling.

Also adds the missing workspace://active line to the resources module
header comment.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bime98u9EwXbURYe8QNaiz