### PR TITLE
fix: invalidate the workspace scan cache on write, stop swallowing served MCP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,29 @@ those are called out explicitly below.
 ## [Unreleased]
 
 ### Fixed
+- **A write did not invalidate the workspace scan cache.** `WorkspaceScanner`'s
+  own doc comment said its 15s TTL was "paired with invalidate() (called after
+  writes)"; `invalidate()` had no production caller at all — only tests and its
+  own `clearCache()` alias. So for up to 15 seconds after a create, the
+  workspace-backed readers and the `workspace://files` / `workspace://active`
+  resources could not see a file this same server had just written. The
+  dispatcher now clears it at the same choke point that bumps the write epoch,
+  which is the sibling cache with the same failure mode and the same fix.
+- **Four served MCP methods were logged as if unimplemented.** The HTTP
+  transport's `SILENT_PROBES` set carried `resources/list`,
+  `resources/templates/list`, `prompts/list` and `logging/setLevel` under a
+  comment reading "capability-probe methods that always return Method not
+  found". All four are served — the first three since resources and prompts got
+  handlers, and `logging/setLevel` by the SDK itself off the declared
+  `logging: {}` capability, which is why no grep for a request schema in this
+  repo ever found it. Nothing was broken for clients; what it cost was evidence.
+  A client that reads `workspace://active` and one that ignores our resources
+  produced byte-identical logs, and that difference is precisely the trigger two
+  `docs/BACKLOG.md` entries (context-pipeline Phase 3b, VSIX shim) have been
+  waiting on. The resource and prompt handlers now log each list/read
+  themselves, so the signal survives stdio too — where VS Code and VS 2022, i.e.
+  every target client, connect and the transport logs nothing per request.
+  `SILENT_PROBES` is now pinned against the SDK's real handler registry.
 - **Docs and the architecture diagram re-aligned with the code.** The numbers
   drift audit: the SVG still advertised 26 tools (it is 20 — the same fold this
   block documents), TESTING.md still said 23 tools and ~2,900 tests across ~220

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -8,6 +8,12 @@ the design.
 > Add a new item when you defer something during a PR. Move it to a commit (and
 > delete it here) when it ships. Keep entries small and honest about the unknowns.
 
+> **When something is rejected rather than shipped, it stays here** — rewritten as
+> a decision (`Status: rejected <date>`), with the reasons and with what evidence
+> would reopen it. A deleted rejection is indistinguishable from an idea nobody
+> ever had, so the next person proposes it again and re-derives the whole
+> argument. Deferrals expire into decisions; the decision is the valuable part.
+
 > **Restored 2026-08-08.** This file was deleted by `5ef1413` ("clean up repo and
 > consolidate docs") with all three items still open and not migrated anywhere —
 > so the deferral rationale, the triggers and the design sketches were lost. It is
@@ -28,6 +34,14 @@ the design.
     [`src/types/context.ts`](../src/types/context.ts), currently unpopulated).
   - Add `fs.watch` on the model metadata dir with debounce to invalidate the
     `WorkspaceScanner` cache on change, instead of the 15s lazy TTL added in 3a.
+  - *[2026-08-29] The watcher's main job is already done without it.* 3a's TTL
+    comment claimed `invalidate()` ran after writes; nothing called it — the
+    dispatcher now does, on every `MUTATING_TOOLS` call
+    ([`src/tools/toolHandler.ts`](../src/tools/toolHandler.ts)), so a file this
+    server wrote is visible to the workspace readers immediately instead of up to
+    15s later. What `fs.watch` would still add is picking up edits made **outside**
+    this server (the developer typing in the IDE) — a smaller prize, and one only
+    worth the platform-flakiness once the focus half below has a consumer.
 
 **Why deferred**
 - MCP exposes workspace **roots**, not the focused file in the editor — there is
@@ -43,6 +57,17 @@ the design.
 - We verify a target client reads `workspace://active` / `workspace://context`
   (or sends editor focus in `_meta`). At that point a precise active file is
   worth the watcher complexity.
+- *[2026-08-29] That verification is now possible — it was not before.* The
+  resource and prompt handlers log every list/read
+  ([`src/resources/index.ts`](../src/resources/index.ts),
+  [`src/prompts/codeReview.ts`](../src/prompts/codeReview.ts)), and the HTTP
+  transport stopped classifying `resources/list`, `resources/templates/list`,
+  `prompts/list` and `logging/setLevel` as unimplemented probes to swallow — all
+  four are served. Until then a client that read `workspace://active` and one
+  that ignored our resources entirely produced identical logs, so this trigger
+  could never fire. **Read the logs before doing any of the work below**; if the
+  target client never lists our resources, the honest resolution of this entry
+  and of the VSIX one is to close them, not to build them.
 
 **Sketch**
 - `EditorContext.activeFile` ← from client-supplied focus when available; else
@@ -60,37 +85,56 @@ the design.
 
 ---
 
-## Context ranker in `search`
+## Context ranker in `search` — REJECTED
 
-**Status:** deferred · **Area:** `src/tools/analysis/search.ts`, `src/workspace/contextRanker.ts` · **Depends on:** Phase 2 (shipped)
+**Status:** **rejected 2026-08-29** · **Area:** `src/tools/analysis/search.ts`, `src/workspace/contextRanker.ts`
 
-**What**
+**What was proposed**
 - Optionally let `search` re-rank / append a `rankContext()` "related" block when
-  the caller passes an intent, reusing the ranker already wired into `prepare`.
+  the caller passes an intent, reusing the ranker already wired into `prepare` —
+  via an optional `intent`/`rankRelated` param on the single-search path.
 
-**Why deferred**
-- `search` already returns FTS5-ranked results, so the ranker is largely
-  redundant there — and `search` is the hottest, most-tested path. Adding a new
-  param means threading it through the schema plus `searchUnified` and tests, for
-  marginal gain.
-  - *[2026-08] The cost argument is weaker than when this was written: commit
-    `a49488a` moved the schema out of the large inline block in `mcpServer.ts`
-    into its own file, [`src/server/toolSchemas/search.ts`](../src/server/toolSchemas/search.ts).
-    The "search is the hottest path" half of the rationale still stands.*
+**Why it is rejected, not deferred**
+Deferred twice (2026-06, 2026-08) on a cost argument. Re-examined on 2026-08-29
+against the current code, every leg of the case got *worse*, so this is a "no",
+not a "not yet". Four independent reasons, any one of which would be enough:
 
-**Trigger to pick this up**
-- A concrete case where plain FTS ordering misses relevance that the xref/usage
-  signals would catch (e.g. users repeatedly searching then manually pulling the
-  same neighbors).
+1. **There is no room to publish the parameter.** `TOTAL_BUDGET` in
+   [`tests/utils/toolSchemaBudget.test.ts`](../tests/utils/toolSchemaBudget.test.ts)
+   is 45,000 chars against a measured 44,998 — **2 chars of headroom** — and that
+   ratchet's own rule is *"fit the change to the budget, never the budget to the
+   change"*. The param could only ship by trimming a different tool's schema
+   first, i.e. by making some other tool harder to call. Leaving it unpublished
+   is not a way out: a parameter the model cannot see is a parameter nobody
+   passes.
+2. **The output slot is already occupied.** `search` ships an opt-in related
+   block today — `verbose` → related-searches / patterns / tips
+   ([`search.ts:429`](../src/tools/analysis/search.ts)). A second, differently-ranked
+   "related" section next to it is the double-ranking confusion the original
+   entry listed under *Risks*, now with a concrete collision.
+3. **The path got hotter, not cooler.** The 2026-08-25 audit cut untyped `search`
+   from 17.9s to 91ms. The "hottest, most-tested path" half of the original
+   rationale was never the weak half, and it is now stronger.
+4. **The trigger never fired in two months.** It asked for a concrete case where
+   FTS ordering misses relevance the xref/usage signals would catch. Across two
+   full usage audits — the second over 1,515 real MCP calls — no such case
+   appeared. `prepare` remains the right home for the ranker: it is where an
+   intent actually exists.
 
-**Sketch**
-- Add an optional `intent`/`rankRelated` param on the single-search path; when
-  set, append `renderRankedContext(rankContext(...))` after the FTS results.
-  Keep it off by default so existing behaviour/tests are untouched.
+**The correction that made this decidable**
+The 2026-08 note on this entry claimed the cost argument had *weakened*, because
+commit `a49488a` moved the schema into its own file. That measured the wrong
+cost. Moving a file cut the *editing* friction; what a published parameter
+actually costs is bytes in the ListTools payload, which are rationed and were
+not being counted. That note is retained here as the reason to be suspicious of
+"this got cheaper" claims that name no unit.
 
-**Risks**
-- Schema churn on a high-traffic tool; double-ranking confusion. Keep it additive
-  and clearly separated from the primary results.
+**What would reopen it**
+Nothing about implementation convenience — only demand. Concretely: corpus
+evidence of callers issuing a `search`, then immediately hand-pulling the same
+neighbours the ranker would have surfaced, often enough to beat the schema bytes
+it would cost. Reopen by re-adding an entry with that evidence attached; do not
+reopen it on the grounds that it would now be easy to build.
 
 ---
 
@@ -113,6 +157,11 @@ the design.
 **Trigger to pick this up**
 - Evidence that Copilot-in-VS / target clients do NOT consume our MCP resources
   or send focus, AND the proactive-context UX gap is costing real adoption.
+- *[2026-08-29] The first half of that trigger is now measurable — see the same
+  note under Phase 3b. Both entries hang on one unanswered question, and the
+  handlers finally log the answer. Note the asymmetry before reading the logs:
+  silence here argues for building the VSIX and against building 3b, so "no
+  client reads our resources" is not a null result for this entry.*
 
 **Sketch**
 - VSIX sends active file + open docs via `_meta` on tool calls (already partially

--- a/src/prompts/codeReview.ts
+++ b/src/prompts/codeReview.ts
@@ -21,6 +21,10 @@ export function registerCodeReviewPrompt(server: Server, context: XppServerConte
   const { symbolIndex, parser } = context;
 
   server.setRequestHandler(ListPromptsRequestSchema, async () => {
+    // Same reason as the resource handlers (src/resources/index.ts): stdio logs
+    // nothing per request, so without this line a client that reads our prompts
+    // and one that ignores them look identical.
+    process.stderr.write('[prompts] 💬 prompts/list — client enumerated the MCP prompts\n');
     return {
       prompts: [
         getSystemInstructionsPromptDefinition(),
@@ -96,6 +100,7 @@ export function registerCodeReviewPrompt(server: Server, context: XppServerConte
   // Handle prompt requests
   server.setRequestHandler(GetPromptRequestSchema, async (request) => {
     const promptName = request.params.name;
+    process.stderr.write(`[prompts] 💬 prompts/get ${promptName}\n`);
 
     // Handle system instructions prompt
     if (promptName === 'xpp_system_instructions') {

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -77,26 +77,50 @@ function json(uri: string, data: unknown) {
   };
 }
 
+/**
+ * Whether any client has actually LISTED or READ a resource this session.
+ *
+ * These handlers are the only place that knows. The HTTP transport logs its own
+ * request line, but the stdio transport — which is what VS Code and VS 2022 use,
+ * i.e. every target client — logs nothing per request, so without this a read of
+ * `workspace://active` was indistinguishable from no client ever asking.
+ *
+ * That distinction is the open question behind two docs/BACKLOG.md entries
+ * (context-pipeline Phase 3b and the VSIX shim): both are deferred *until we
+ * verify a client consumes these resources*, and neither can be answered while
+ * the evidence is discarded. One line per event, not gated behind a debug flag,
+ * because the events are rare (a list at session start, a read on demand) and a
+ * flag nobody sets collects nothing.
+ */
+function noteResourceUse(event: string): void {
+  process.stderr.write(`[resources] 📄 ${event}\n`);
+}
+
 export function registerResources(server: Server, context: XppServerContext): void {
-  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-    resources: WORKSPACE_RESOURCES.map((r) => ({ ...r })),
-  }));
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    noteResourceUse(`resources/list — client enumerated ${WORKSPACE_RESOURCES.length} workspace resources`);
+    return { resources: WORKSPACE_RESOURCES.map((r) => ({ ...r })) };
+  });
 
   // Classes are exposed as a template instead of being enumerated (100k+ entries) —
   // clients resolve xpp://class/<ClassName> on demand.
-  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
-    resourceTemplates: [
-      {
-        uriTemplate: `${CLASS_URI_PREFIX}{className}`,
-        name: 'X++ Class Source',
-        description: 'Full source of an X++ class by name, e.g. xpp://class/CustTable',
-        mimeType: 'text/x-xpp',
-      },
-    ],
-  }));
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+    noteResourceUse('resources/templates/list — client enumerated the xpp://class/{name} template');
+    return {
+      resourceTemplates: [
+        {
+          uriTemplate: `${CLASS_URI_PREFIX}{className}`,
+          name: 'X++ Class Source',
+          description: 'Full source of an X++ class by name, e.g. xpp://class/CustTable',
+          mimeType: 'text/x-xpp',
+        },
+      ],
+    };
+  });
 
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     const uri = request.params.uri;
+    noteResourceUse(`resources/read ${uri}`);
 
     if (isClassUri(uri)) {
       const source = await readClassSource(context, uri);

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -28,6 +28,28 @@ const TOOL_TIMEOUT_MS = Math.max(10_000,
 const TOOL_TIMEOUT_FAST_MS  = Math.max(5_000,  parseInt(process.env.MCP_TOOL_TIMEOUT_FAST_MS  || '30000',  10) || 30_000);
 const TOOL_TIMEOUT_HEAVY_MS = Math.max(60_000, parseInt(process.env.MCP_TOOL_TIMEOUT_HEAVY_MS || '600000', 10) || 600_000);
 
+/**
+ * MCP methods this server does NOT implement: they always come back
+ * "Method not found", so logging them is noise.
+ *
+ * Keep this list to methods with NO registered handler — tests/server/silentProbes.test.ts
+ * pins that invariant against the SDK's real handler registry. Four of the five
+ * entries it used to hold were served, not probed: `resources/list`,
+ * `resources/templates/list` and `prompts/list` have had handlers since
+ * src/resources/index.ts and src/prompts/codeReview.ts registered them, and
+ * `logging/setLevel` is auto-registered by the SDK because the capabilities
+ * block declares `logging: {}` — a fact no grep for a request schema in this
+ * repo can find, which is how it stayed hidden.
+ *
+ * What the mistake cost was visibility, not correctness: silencing them
+ * discarded the only signal that says whether any client actually reads what we
+ * volunteer — which is exactly the evidence docs/BACKLOG.md's context-pipeline
+ * Phase 3b and VSIX entries are waiting on before either is worth building.
+ */
+export const SILENT_PROBES = new Set<string>([
+  'completion/complete',
+]);
+
 const HEAVY_TOOLS = new Set<string>([
   'build_d365fo_project',
   'trigger_db_sync',
@@ -256,14 +278,6 @@ export class CustomHttpTransport implements Transport {
         // Handle requests - send to MCP server via onmessage
         // Wait for response via Promise
         if (this.onmessage) {
-          // MCP capability-probe methods that always return "Method not found" — log silently
-          const SILENT_PROBES = new Set([
-            'resources/templates/list',
-            'resources/list',
-            'prompts/list',
-            'logging/setLevel',
-            'completion/complete',
-          ]);
           const isSilentProbe = SILENT_PROBES.has(request.method);
 
           // Log incoming request (skip silent probes)

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -463,7 +463,18 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
       // Invalidate every cached read, whatever the outcome: a write that threw
       // may still have changed the disk, and serving a pre-write body afterwards
       // is the failure this guards against.
-      if (MUTATING_TOOLS.has(toolName)) bumpWriteEpoch();
+      if (MUTATING_TOOLS.has(toolName)) {
+        bumpWriteEpoch();
+        // Same reasoning, second cache: WorkspaceScanner holds a 15s TTL cache of
+        // the .xml files on disk, and its own doc comment claimed writes invalidated
+        // it — nothing did, so for up to 15s after a create the workspace-backed
+        // readers (hybridSearch, get_object_info/completion with includeWorkspace)
+        // and workspace://files, workspace://active could not see a file this
+        // server had just written. Full clear, not per-path: the write's workspace
+        // is not reliably known here, and clearing a Map is cheaper than guessing
+        // wrong. The next scan re-globs.
+        context.workspaceScanner?.invalidate();
+      }
       inFlightHandle?.resolve(capped);
       clearInFlight(callKey);
     }

--- a/src/workspace/workspaceScanner.ts
+++ b/src/workspace/workspaceScanner.ts
@@ -55,7 +55,7 @@ export interface FieldMetadata {
 export class WorkspaceScanner {
   private workspaceCache: Map<string, { files: WorkspaceFile[]; scannedAt: number }> = new Map();
 
-  /** Cache TTL; paired with invalidate() (called after writes) to keep results current without an fs.watch. Lazy expiry — no background timer. */
+  /** Cache TTL; paired with invalidate() (called by the dispatcher after every MUTATING_TOOLS call) to keep results current without an fs.watch. Lazy expiry — no background timer. */
   private static readonly CACHE_TTL_MS = 15_000;
 
   /**

--- a/tests/server/silentProbes.test.ts
+++ b/tests/server/silentProbes.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The HTTP transport's SILENT_PROBES list must only ever hold methods this
+ * server does NOT serve.
+ *
+ * The defect this pins: four of the list's five entries were served, not probed.
+ * `resources/list`, `resources/templates/list` and `prompts/list` sat there under
+ * a comment reading "capability-probe methods that always return Method not
+ * found" long after they got real handlers, and `logging/setLevel` is registered
+ * by the SDK itself off the declared `logging: {}` capability — so no grep for a
+ * request schema in this repo turns it up. Nothing was broken for the client,
+ * which is why it survived; what it cost was visibility.
+ * A client that reads workspace://active and one that ignores our resources
+ * entirely produced byte-identical logs, and that difference is the trigger two
+ * docs/BACKLOG.md entries are explicitly waiting on.
+ *
+ * Asserted against the server's real handler registry rather than a hand-copied
+ * list, so registering a handler for a silenced method fails here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SILENT_PROBES } from '../../src/server/transport';
+import { createXppMcpServer } from '../../src/server/mcpServer';
+
+function registeredMethods(): Set<string> {
+  const server: any = createXppMcpServer({ symbolIndex: {}, parser: {} } as any);
+  const handlers: Map<string, unknown> | undefined = server._requestHandlers;
+  if (!handlers) throw new Error('_requestHandlers is not exposed by the MCP SDK Server');
+  return new Set(handlers.keys());
+}
+
+describe('SILENT_PROBES', () => {
+  it('contains no method this server actually serves', () => {
+    const served = registeredMethods();
+    const wronglySilenced = [...SILENT_PROBES].filter((m) => served.has(m));
+    expect(
+      wronglySilenced,
+      `these methods have a handler but are logged silently, hiding real client traffic: ${wronglySilenced.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('still silences the one genuine no-handler probe', () => {
+    // Not merely "the set is non-empty": this is the reason it exists. Clients
+    // probe completion/complete on connect and get -32601 every time.
+    const served = registeredMethods();
+    expect(served.has('completion/complete'), 'completion/complete unexpectedly has a handler now').toBe(false);
+    expect(SILENT_PROBES.has('completion/complete')).toBe(true);
+  });
+
+  it('serves the four methods that used to be silenced', () => {
+    const served = registeredMethods();
+    // logging/setLevel is in this list precisely because it is the non-obvious
+    // one: no request schema for it appears anywhere in src/ — the SDK registers
+    // the handler itself off the `logging: {}` capability in mcpServer.ts.
+    for (const method of ['resources/list', 'resources/templates/list', 'prompts/list', 'logging/setLevel']) {
+      expect(served.has(method), `${method} must stay served — the capabilities block advertises it`).toBe(true);
+    }
+  });
+});

--- a/tests/tools/workspaceScannerWriteInvalidation.test.ts
+++ b/tests/tools/workspaceScannerWriteInvalidation.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A write must invalidate the WORKSPACE SCAN cache too — through the dispatcher.
+ *
+ * Sibling of dedupWriteInvalidation.test.ts, which pins the same wiring for the
+ * per-call dedup cache. This one pins the second cache in that path:
+ * WorkspaceScanner keeps a 15s TTL map of the .xml files found on disk, and its
+ * own doc comment claimed writes invalidated it. Nothing did — `invalidate()`
+ * had no production caller at all, only tests and its own `clearCache()` alias.
+ *
+ * The consequence was a stale window of up to 15s after any write, during which
+ * the workspace-backed readers (hybridSearch, includeWorkspace lookups) and the
+ * workspace://files / workspace://active resources could not see a file this
+ * same server had just created.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { clearAllInFlight, clearDedupCache } from '../../src/utils/callDedup';
+
+vi.mock('../../src/tools/readers/getObjectInfo', () => ({
+  getObjectInfoTool: vi.fn(async () => ({ content: [{ type: 'text', text: 'read' }] })),
+}));
+
+vi.mock('../../src/tools/d365foFile', () => ({
+  d365foFileTool: vi.fn(async () => ({ content: [{ type: 'text', text: '✅ written' }] })),
+}));
+
+type CallHandler = (request: any, extra: any) => Promise<any>;
+
+/** Records invalidate() calls so the test can assert the dispatcher wiring, not the scanner. */
+function fakeScanner() {
+  return { invalidated: [] as Array<string | undefined>, invalidate(p?: string) { this.invalidated.push(p); } };
+}
+
+async function buildHandler(scanner: unknown): Promise<CallHandler> {
+  const { registerToolHandler } = await import('../../src/tools/toolHandler');
+  let handler: CallHandler | undefined;
+  const server: any = {
+    setRequestHandler(schema: unknown, h: CallHandler) {
+      if (schema === CallToolRequestSchema) handler = h;
+    },
+    async sendLoggingMessage() {},
+  };
+  registerToolHandler(server, { symbolIndex: {}, workspaceScanner: scanner } as any);
+  if (!handler) throw new Error('CallTool handler was not registered');
+  return handler;
+}
+
+const READ = {
+  params: { name: 'get_object_info', arguments: { objectType: 'table', name: 'ConDemoRangeSource' } },
+};
+const WRITE = {
+  params: {
+    name: 'd365fo_file',
+    arguments: {
+      action: 'create', objectType: 'table', objectName: 'ConDemoNewTable',
+    },
+  },
+};
+
+beforeEach(() => {
+  clearAllInFlight();
+  clearDedupCache();
+});
+
+describe('workspace scan cache is invalidated by writes (dispatcher wiring)', () => {
+  it('invalidates the scan cache after a mutating tool call', async () => {
+    const scanner = fakeScanner();
+    const handler = await buildHandler(scanner);
+
+    await handler(WRITE, {});
+
+    // Full clear, not per-path: the write's workspace is not reliably known at
+    // this point, so scoping the blast radius would be a guess.
+    expect(scanner.invalidated, 'a write must clear the workspace scan cache').toEqual([undefined]);
+  });
+
+  it('leaves the scan cache alone for a read', async () => {
+    const scanner = fakeScanner();
+    const handler = await buildHandler(scanner);
+
+    await handler(READ, {});
+
+    // Re-globbing the workspace on every read would undo the cache entirely.
+    expect(scanner.invalidated).toEqual([]);
+  });
+
+  it('survives a context with no scanner (stub/HTTP paths construct one late)', async () => {
+    const { registerToolHandler } = await import('../../src/tools/toolHandler');
+    let handler: CallHandler | undefined;
+    const server: any = {
+      setRequestHandler(schema: unknown, h: CallHandler) {
+        if (schema === CallToolRequestSchema) handler = h;
+      },
+      async sendLoggingMessage() {},
+    };
+    registerToolHandler(server, { symbolIndex: {} } as any);
+
+    await expect(handler!(WRITE, {})).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
Started as an audit of `docs/BACKLOG.md` — which of the three deferred items are still real, and which were quietly fixed or overtaken. Two of them turned out to be pointing at live defects, and the third was the backlog misdescribing its own reasoning.

## 1. A write did not invalidate the workspace scan cache

`WorkspaceScanner`'s doc comment said its 15s TTL was *"paired with invalidate() (called after writes)"*. Nothing called it — the only callers were tests and its own `clearCache()` alias.

So for up to 15 seconds after a create, the workspace-backed readers and the `workspace://files` / `workspace://active` resources could not see a file **this same server had just written**. The dispatcher now clears it at the same choke point that bumps the write epoch — the sibling cache with the same failure mode, fixed one line apart.

## 2. Four served MCP methods were logged as if unimplemented

The HTTP transport's `SILENT_PROBES` set held `resources/list`, `resources/templates/list`, `prompts/list` and `logging/setLevel` under a comment reading *"capability-probe methods that always return Method not found"*. All four are served:

- the first three since `src/resources/index.ts` and `src/prompts/codeReview.ts` registered handlers;
- `logging/setLevel` by the SDK itself, off the declared `logging: {}` capability — which is why no grep for a request schema in this repo turns it up. The invariant test found it; reading the code did not.

Nothing was broken for clients. **What it cost was evidence.** A client that reads `workspace://active` and one that ignores our resources entirely produced byte-identical logs — and that is precisely the trigger the context-pipeline Phase 3b and VSIX backlog entries have been deferred on for two months. It could never fire, because we were discarding the only signal that would fire it.

The transport fix alone would not have been enough: `transport.ts` is HTTP-only, and every target client (VS Code, VS 2022) connects over **stdio**, which logs nothing per request. So the resource and prompt handlers now log each list/read themselves. `SILENT_PROBES` is exported and pinned against the SDK's real handler registry, so registering a handler for a silenced method fails the test.

## 3. Context ranker in `search` — rejected, not deferred

Its 2026-08 note claimed the cost had *weakened* because the schema had moved into its own file. That measured the wrong thing: moving a file cut editing friction, while what a published parameter actually costs is ListTools bytes — and those are rationed. The budget ratchet sits at **44,998 of 45,000 chars**, so the param could only ship by making some other tool harder to call. Add that `verbose` already owns the related-results slot, that the path is now 91ms after the 2026-08-25 audit, and that the trigger never fired across two audits (the second over 1,515 real MCP calls), and it stops being a "not yet".

The entry is rewritten as a decision and **kept**, not deleted: a deleted rejection is indistinguishable from an idea nobody ever had, so the next person proposes it again and re-derives the whole argument. The backlog header gained that rule, since it previously only said what to do with items that *ship*.

## What this deliberately does not do

Phase 3b and the VSIX shim stay open. Their shared question is now measurable but **not yet measured** — nobody has read the logs from a real session. Worth noting the asymmetry before someone does: silence argues *for* the VSIX and *against* 3b, so "no client reads our resources" is not a null result. The honest outcome may well be closing both rather than building either; that is a call for a human with the log in hand.

## Verification

- Full suite: **355 files, 5,046 passed, 2 skipped**
- `tsc --noEmit`: clean
- New: `tests/server/silentProbes.test.ts` (3), `tests/tools/workspaceScannerWriteInvalidation.test.ts` (3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY7A29TsPjkXAbQk6tCAHH
