### PR TITLE
feat(reports): Phase D — report-pattern domain, report naming, uiBuilder scaffold, reporting topics

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
 
   // Biome was added to ~86k lines of TypeScript that had never been linted.
   // The default recommended set produced 3,391 findings, which is a gate nobody

--- a/bridge/D365MetadataBridge/Models/Models.cs
+++ b/bridge/D365MetadataBridge/Models/Models.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace D365MetadataBridge.Models
@@ -255,6 +255,14 @@ namespace D365MetadataBridge.Models
         [JsonPropertyName("extends")]
         public string? Extends { get; set; }
 
+        /// <summary>
+        /// Root of the Extends chain, or null for a root EDT. Reported for orientation in a
+        /// multi-level hierarchy; it is not necessarily the element that declares the
+        /// StringSize -- see StringSizeInheritedFrom for that.
+        /// </summary>
+        [JsonPropertyName("rootEdt")]
+        public string? RootEdt { get; set; }
+
         [JsonPropertyName("label")]
         public string? Label { get; set; }
 
@@ -263,6 +271,14 @@ namespace D365MetadataBridge.Models
 
         [JsonPropertyName("stringSize")]
         public int? StringSize { get; set; }
+
+        /// <summary>
+        /// Ancestor the reported StringSize came from. Null when the number is what this EDT's
+        /// own XML declares. Set both when the EDT declares nothing (the common case) and when
+        /// an ancestor's value overrode one the EDT did declare.
+        /// </summary>
+        [JsonPropertyName("stringSizeInheritedFrom")]
+        public string? StringSizeInheritedFrom { get; set; }
 
         [JsonPropertyName("referenceTable")]
         public string? ReferenceTable { get; set; }

--- a/bridge/D365MetadataBridge/Models/Models.cs
+++ b/bridge/D365MetadataBridge/Models/Models.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace D365MetadataBridge.Models
@@ -256,9 +256,13 @@ namespace D365MetadataBridge.Models
         public string? Extends { get; set; }
 
         /// <summary>
-        /// Root of the Extends chain, or null for a root EDT. Reported for orientation in a
-        /// multi-level hierarchy; it is not necessarily the element that declares the
-        /// StringSize -- see StringSizeInheritedFrom for that.
+        /// Root of the Extends chain. Reported for orientation in a multi-level hierarchy; it is
+        /// not necessarily the element that declares the StringSize -- see StringSizeInheritedFrom
+        /// for that.
+        ///
+        /// Null for a root EDT, and also null when the chain could not be walked to its end -- a
+        /// dangling Extends or a cycle -- because the last ancestor reached is not the root and
+        /// naming it as one would be a wrong answer rather than a missing one.
         /// </summary>
         [JsonPropertyName("rootEdt")]
         public string? RootEdt { get; set; }

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -438,7 +438,7 @@ namespace D365MetadataBridge.Services
 
             try { var mi = prov.Tables.GetModelInfo(tableName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
 
-            try { foreach (var f in table.Fields) result.Fields.Add(MapField(f)); } catch (Exception ex) { Warn("fields", tableName, ex); }
+            try { foreach (var f in table.Fields) result.Fields.Add(MapField(f, prov)); } catch (Exception ex) { Warn("fields", tableName, ex); }
             try { foreach (var g in table.FieldGroups) { var gm = new FieldGroupModel { Name = g.Name, Label = Safe(() => g.Label) }; try { foreach (var f in g.Fields) gm.Fields.Add(Safe(() => f.DataField) ?? f.Name); } catch { } result.FieldGroups.Add(gm); } } catch (Exception ex) { Warn("fieldGroups", tableName, ex); }
             try { foreach (var i in table.Indexes) { var im = new IndexInfoModel { Name = i.Name, AllowDuplicates = IsYes(() => i.AllowDuplicates), AlternateKey = IsYes(() => i.AlternateKey) }; try { foreach (var f in i.Fields) im.Fields.Add(new IndexFieldModel { DataField = Safe(() => f.DataField) ?? f.Name, IncludedColumn = IsYes(() => f.IncludedColumn) }); } catch { } result.Indexes.Add(im); } } catch (Exception ex) { Warn("indexes", tableName, ex); }
 
@@ -652,17 +652,45 @@ namespace D365MetadataBridge.Services
             var edt = prov.Edts.Read(edtName);
             if (edt == null) return null;
 
+            // The provider hands the EDT back exactly as its own XML declares it and does NOT
+            // fill in what it inherits. When a derived string EDT declares no StringSize of its
+            // own, the instance reports the AxEdtString constructor default of 10 instead of
+            // the inherited size. Measured against 10.0.2645: ItemFreeTxt read back as 10 and
+            // is really 1000 (from ItemFreeTxtBase); ItemId and CustAccount read back as 10 and
+            // are really 20.
+            //
+            // A child CAN declare its own StringSize -- 228 derived EDTs in the shipped corpus
+            // do. The platform allows it when the base carries StringSizeIsExtensible = Yes
+            // ("StringSize cannot be set on child edt when StringSizeIsExtensible is not set to
+            // Yes"). A declared value is left alone here; only the unset case is filled in.
+            var inherited = FindInheritedStringSize(edt, prov);
+            var declaredLocally = edt is AxEdtString local
+                ? SafeInt(() => local.StringSize, UnsetStringSize)
+                : 0;
+            ResolveInheritedEdtProperties(edt, inherited, prov);
+
             var result = new EdtInfoModel
             {
                 Name = edt.Name,
                 BaseType = edt.GetType().Name.Replace("AxEdt", ""),
                 Extends = Safe(() => edt.Extends),
+                RootEdt = inherited.Root,
                 Label = Safe(() => edt.Label),
                 HelpText = Safe(() => edt.HelpText),
             };
 
             try { var mi = prov.Edts.GetModelInfo(edtName); if (mi?.Count > 0) result.Model = mi.First().Name; } catch { }
-            if (edt is AxEdtString s) result.StringSize = SafeInt(() => s.StringSize, 0);
+            if (edt is AxEdtString s)
+            {
+                result.StringSize = SafeInt(() => s.StringSize, 0);
+                // Provenance only when the reported number is not what this EDT's own XML said.
+                // That covers the unset case, and the case where an ancestor's value overrode a
+                // declared one (PartyName declares 100, reports DirPartyName's 160).
+                if (result.StringSize != declaredLocally)
+                {
+                    result.StringSizeInheritedFrom = inherited.DeclaredBy;
+                }
+            }
             if (edt is AxEdtEnum en) result.EnumType = Safe(() => en.EnumType);
             try { result.ReferenceTable = Safe(() => ((dynamic)edt).ReferenceTable?.Table); } catch { }
 
@@ -670,7 +698,10 @@ namespace D365MetadataBridge.Services
             try { result.FormHelp = Safe(() => edt.FormHelp); } catch { }
             try { result.ConfigurationKey = Safe(() => ((dynamic)edt).ConfigurationKey); } catch { }
             try { result.Alignment = Safe(() => ((dynamic)edt).Alignment?.ToString()); } catch { }
-            try { result.DisplayLength = SafeInt(() => ((dynamic)edt).DisplayLength, 0); if (result.DisplayLength == 0) result.DisplayLength = null; } catch { }
+            // "Not set" for DisplayLength is -1, not 0 (verified against the AxEdtString
+            // constructor on 10.0.2645) — so the old `== 0` test never fired and every EDT
+            // without a local DisplayLength, 24 446 of the 25 332 indexed, reported -1.
+            try { result.DisplayLength = SafeInt(() => ((dynamic)edt).DisplayLength, -1); if (result.DisplayLength < 0) result.DisplayLength = null; } catch { }
             try { result.RelationType = Safe(() => ((dynamic)edt).RelationType?.ToString()); } catch { }
 
             // AxEdtReal specific
@@ -1863,11 +1894,134 @@ namespace D365MetadataBridge.Services
         private static int SafeInt(Func<int> f, int d) { try { return f(); } catch { return d; } }
         private static void Warn(string section, string obj, Exception ex) => Console.Error.WriteLine($"[WARN] Error reading {section} for {obj}: {ex.Message}");
 
+        /// <summary>
+        /// The value an AxEdtString reports when its XML declares no StringSize: the constructor
+        /// default. The serializer omits a property equal to its default, so a declared 10 and an
+        /// undeclared one are the same bytes on disk and the same value here -- and the compiler
+        /// treats both the same way, by inheriting. Verified against 10.0.2645, where an explicit
+        /// StringSize of 10 appears in none of the 25 332 shipped EDTs.
+        /// </summary>
+        private const int UnsetStringSize = 10;
+
+        /// <summary>Where a derived EDT's string size comes from, when it does not declare one.</summary>
+        private sealed class InheritedStringSize
+        {
+            /// <summary>Root of the Extends chain; null when the EDT is itself a root.</summary>
+            public string? Root;
+            /// <summary>Nearest ancestor that declares a StringSize; null when none does.</summary>
+            public string? DeclaredBy;
+            /// <summary>That ancestor's declared StringSize.</summary>
+            public int? Value;
+        }
+
+        /// <summary>
+        /// Walks <c>Extends</c> once, recording both the root of the hierarchy and the nearest
+        /// ancestor that actually declares a StringSize -- the value an undeclared child takes.
+        ///
+        /// Each hop goes back through <see cref="PickProvider"/> because an ancestor can live in
+        /// the other packages root (UDE: a custom EDT extending a Microsoft one). A dangling
+        /// <c>Extends</c> ends the walk where it breaks -- AmountMST names MoneyMST, which ships
+        /// no AxEdt file -- and a name already seen ends it too, so a metadata cycle cannot spin.
+        /// </summary>
+        private InheritedStringSize FindInheritedStringSize(AxEdt edt, IMetadataProvider prov)
+        {
+            var found = new InheritedStringSize();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { edt.Name };
+            var next = Safe(() => edt.Extends);
+
+            while (!string.IsNullOrEmpty(next) && seen.Add(next!))
+            {
+                var name = next!;
+                var parentProv = PickProvider(p => p.Edts.Exists(name)) ?? prov;
+                AxEdt? parent = null;
+                try { parent = parentProv.Edts.Read(name); } catch { }
+                if (parent == null) break;
+
+                found.Root = parent.Name;
+                if (found.DeclaredBy == null && parent is AxEdtString ps)
+                {
+                    var size = SafeInt(() => ps.StringSize, UnsetStringSize);
+                    if (size != UnsetStringSize)
+                    {
+                        found.DeclaredBy = parent.Name;
+                        found.Value = size;
+                    }
+                }
+                next = Safe(() => parent.Extends);
+            }
+            return found;
+        }
+
+        /// <summary>
+        /// Fills in the string size a derived EDT inherits rather than declares, so the reported
+        /// value is the one X++ compiles against.
+        /// </summary>
+        private void ResolveInheritedEdtProperties(AxEdt edt, InheritedStringSize inherited, IMetadataProvider prov)
+        {
+            if (string.IsNullOrEmpty(Safe(() => edt.Extends))) return;
+
+            try
+            {
+                // Microsoft's own resolver, which encodes a rule a reimplementation would get
+                // wrong: a declared size does not always win. Measured over the 182 derived EDTs
+                // that declare a size and have a declaring ancestor --
+                //   StringSizeIsExtensible = Yes  -> the declaration wins either way
+                //                                    (InvoiceId 50 over Num 20; CustInvoiceId 20
+                //                                    under InvoiceId 50)
+                //   otherwise, declared smaller   -> the ancestor's value wins (4 EDTs: PartyName
+                //                                    declares 100 under DirPartyName's 160 and
+                //                                    reports 160, ITMJourneyId, TAMRebateInvoice,
+                //                                    PSNPurchasingCardProviderName)
+                //   otherwise, declared larger    -> UNVERIFIED; no such EDT ships, so this code
+                //                                    does not assume a direction and simply lets
+                //                                    the resolver decide.
+                //
+                // isFlightEnabled: false, and the flag is not a detail. With true, an EDT-level
+                // read of CustInvoiceId returns 50 while the FIELD-level resolver returns 20 for
+                // CustInvoiceJour.InvoiceId -- a field typed with that very EDT -- so the bridge
+                // would contradict itself between get_object_info(edt) and
+                // get_object_info(table). With false the two agree at 20. false also confines
+                // this to the actual defect (an undeclared size) rather than rewriting values an
+                // EDT does declare, and the flag changes nothing for any of the broken cases
+                // (ItemFreeTxt 1000, ItemId 20, AccountNumber_IN 20 under either value).
+                Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaEdtExtensions
+                    .ResolveVirtualProperties(edt, prov, false);
+                return;
+            }
+            catch (Exception ex)
+            {
+                // The bridge is compiled against one environment's Microsoft assemblies and
+                // loaded against another's, so the resolver can simply be absent.
+                Warn("resolveVirtualProperties", edt.Name, ex);
+            }
+
+            // Fallback: fill in ONLY an undeclared size, from the nearest ancestor that declares
+            // one. That is exactly the population the defect affects, and the rule matched the
+            // resolver on 148 of 148 such EDTs. It deliberately does not reproduce the rule for
+            // a declared-but-smaller value -- leaving a declared number alone is the honest
+            // failure mode, and that case covers 4 EDTs in the shipped corpus.
+            //
+            // NoOfDecimals is left alone throughout. It looks similar but is NOT virtual: a child
+            // real EDT may declare its own (AccruedAmountMST_IT declares 2 while its base reports
+            // -1), so copying an ancestor's would overwrite a real local value.
+            if (edt is AxEdtString derived && inherited.Value.HasValue)
+            {
+                try
+                {
+                    if (derived.StringSize == UnsetStringSize)
+                    {
+                        derived.StringSize = inherited.Value.Value;
+                    }
+                }
+                catch { }
+            }
+        }
+
         // ========================
         // DIAGNOSTIC: Probe IMetadataProvider write capability
         // ========================
 
-        private FieldInfoModel MapField(AxTableField field)
+        private FieldInfoModel MapField(AxTableField field, IMetadataProvider prov)
         {
             var m = new FieldInfoModel
             {
@@ -1879,9 +2033,73 @@ namespace D365MetadataBridge.Services
                 Mandatory = IsYes(() => field.Mandatory),
                 AllowEdit = Safe(() => field.AllowEdit.ToString()),
             };
-            if (field is AxTableFieldString s) m.StringSize = SafeInt(() => s.StringSize, 0);
+            if (field is AxTableFieldString s) m.StringSize = EffectiveFieldStringSize(s, prov);
             if (field is AxTableFieldEnum en) m.EnumType = Safe(() => en.EnumType);
             return m;
+        }
+
+        /// <summary>
+        /// Cleared the first time Microsoft's field-level resolver throws, so an environment whose
+        /// assemblies predate it takes the hand-rolled path directly from then on.
+        /// </summary>
+        private bool _fieldStringSizeHelperUsable = true;
+
+        /// <summary>
+        /// The string size a field really has. An EDT-typed field almost never declares its own
+        /// size -- it takes the EDT's, and through the EDT its ancestors' -- but the raw property
+        /// returns the AxTableFieldString constructor default of 10 regardless. Measured across
+        /// ten core tables on 10.0.2645, that was wrong for 310 of 564 string fields (55 %):
+        /// InventTable.ItemId reported 10 against a real 20, InventTable.AltConfigId reported 10
+        /// against a real 50.
+        /// </summary>
+        private int EffectiveFieldStringSize(AxTableFieldString field, IMetadataProvider prov)
+        {
+            if (_fieldStringSizeHelperUsable)
+            {
+                try
+                {
+                    // Microsoft's own resolver: field -> EDT -> its ancestors. isFlightEnabled is
+                    // passed false to match ReadEdt, so the two agree on the same type; measured,
+                    // this resolver returned the same value under either flag for every field
+                    // tried (CustInvoiceJour.InvoiceId 20, DirPartyTable.Name 160,
+                    // InventTable.ItemId 20).
+                    return Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaTableFieldExtensions
+                        .GetStringSize(field, prov, false);
+                }
+                catch (Exception ex)
+                {
+                    // Latched off, and warned about exactly once: this runs per field, so a missing
+                    // helper would otherwise put one warning per string field per table read on
+                    // stderr (103 for CustTable alone).
+                    _fieldStringSizeHelperUsable = false;
+                    Warn("effectiveStringSize", field.Name, ex);
+                }
+            }
+
+            // Fallback for an environment whose assemblies predate the helper. A field that
+            // declares its own size keeps it; otherwise take the field's EDT, and from there the
+            // nearest declaring ancestor, exactly as ReadEdt does.
+            var declared = SafeInt(() => field.StringSize, UnsetStringSize);
+            if (declared != UnsetStringSize) return declared;
+
+            var edtName = Safe(() => field.ExtendedDataType);
+            if (!string.IsNullOrEmpty(edtName))
+            {
+                var edtProv = PickProvider(p => p.Edts.Exists(edtName!)) ?? prov;
+                AxEdt? edt = null;
+                try { edt = edtProv.Edts.Read(edtName!); } catch { }
+                if (edt != null)
+                {
+                    if (edt is AxEdtString es)
+                    {
+                        var own = SafeInt(() => es.StringSize, UnsetStringSize);
+                        if (own != UnsetStringSize) return own;
+                    }
+                    var inherited = FindInheritedStringSize(edt, edtProv);
+                    if (inherited.Value.HasValue) return inherited.Value.Value;
+                }
+            }
+            return declared;
         }
     }
 }

--- a/bridge/D365MetadataBridge/Services/MetadataReadService.cs
+++ b/bridge/D365MetadataBridge/Services/MetadataReadService.cs
@@ -663,10 +663,16 @@ namespace D365MetadataBridge.Services
             // do. The platform allows it when the base carries StringSizeIsExtensible = Yes
             // ("StringSize cannot be set on child edt when StringSizeIsExtensible is not set to
             // Yes"). A declared value is left alone here; only the unset case is filled in.
-            var inherited = FindInheritedStringSize(edt, prov);
             var declaredLocally = edt is AxEdtString local
                 ? SafeInt(() => local.StringSize, UnsetStringSize)
                 : 0;
+
+            // ONE walk of the Extends chain, shared by the Root EDT row, the provenance label
+            // and the resolver fallback. It costs a full XML deserialize per hop and readEdt is
+            // a loop caller -- createD365File issues one per distinct EDT of a new table -- so
+            // the walk returns immediately for a root EDT and reads each hop from the child's
+            // own provider before paying for a two-provider Exists probe.
+            var inherited = FindInheritedStringSize(edt, prov);
             ResolveInheritedEdtProperties(edt, inherited, prov);
 
             var result = new EdtInfoModel
@@ -674,7 +680,11 @@ namespace D365MetadataBridge.Services
                 Name = edt.Name,
                 BaseType = edt.GetType().Name.Replace("AxEdt", ""),
                 Extends = Safe(() => edt.Extends),
-                RootEdt = inherited.Root,
+                // Only when the walk actually reached a root. A chain that broke on a dangling
+                // Extends (AmountMST names MoneyMST, which ships no AxEdt file) or on a cycle
+                // ends at an ancestor that is NOT the root, and reporting that one as the root
+                // would be a wrong answer rather than a missing one.
+                RootEdt = inherited.ChainComplete ? inherited.Root : null,
                 Label = Safe(() => edt.Label),
                 HelpText = Safe(() => edt.HelpText),
             };
@@ -686,7 +696,14 @@ namespace D365MetadataBridge.Services
                 // Provenance only when the reported number is not what this EDT's own XML said.
                 // That covers the unset case, and the case where an ancestor's value overrode a
                 // declared one (PartyName declares 100, reports DirPartyName's 160).
-                if (result.StringSize != declaredLocally)
+                //
+                // The second half of the test is what keeps the label honest. The NUMBER comes
+                // from Microsoft's resolver and the ATTRIBUTION from the walk above -- two
+                // different algorithms -- so without agreeing on the value they can disagree on
+                // the ancestor, and the report would credit one that declares something else.
+                // When they disagree the number still stands; only the claim about where it
+                // came from is dropped.
+                if (result.StringSize != declaredLocally && inherited.Value == result.StringSize)
                 {
                     result.StringSizeInheritedFrom = inherited.DeclaredBy;
                 }
@@ -1903,25 +1920,130 @@ namespace D365MetadataBridge.Services
         /// </summary>
         private const int UnsetStringSize = 10;
 
+        /// <summary>
+        /// Microsoft's EDT-level virtual-property resolver, bound by name. Null on a platform
+        /// whose assemblies do not carry it. See <see cref="FindStaticHelper"/> for why this is
+        /// reflection and not a call.
+        /// </summary>
+        private static readonly Lazy<System.Reflection.MethodInfo?> ResolveVirtualPropertiesHelper =
+            new Lazy<System.Reflection.MethodInfo?>(() => FindStaticHelper(
+                "Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaEdtExtensions",
+                "ResolveVirtualProperties", typeof(AxEdt), typeof(IMetadataProvider), typeof(bool)));
+
+        /// <summary>
+        /// Microsoft's field-level string-size resolver, bound the same way and for the same
+        /// reason.
+        /// </summary>
+        private static readonly Lazy<System.Reflection.MethodInfo?> GetStringSizeHelper =
+            new Lazy<System.Reflection.MethodInfo?>(() => FindStaticHelper(
+                "Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaTableFieldExtensions",
+                "GetStringSize", typeof(AxTableFieldString), typeof(IMetadataProvider), typeof(bool)));
+
+        /// <summary>
+        /// Finds a public static method by type name and method name, accepting any parameter
+        /// list the given argument types fit. Returns null when the type or the method is absent,
+        /// which is the signal to take the hand-rolled path.
+        ///
+        /// Why by name and not by a call. A direct call binds this project to a helper that only
+        /// some platform versions ship, and wrapping that call in try/catch does NOT make the
+        /// binding optional: the CLR resolves a method token when it JITs the method CONTAINING
+        /// the call, so a MissingMethodException surfaces at that method's own call site, one
+        /// frame up, and the inner catch never runs. Measured on .NET Framework 4 x64 against an
+        /// assembly with the helper removed: the inner catch did not fire, the fallback below it
+        /// was unreachable, and the exception escaped into the caller.
+        ///
+        /// The compile side matters more. The bridge ships as source and is built on each user's
+        /// own machine against that machine's PackagesLocalDirectory bin, so a direct call would
+        /// not merely lose the fallback on an older platform -- it would fail the build there and
+        /// leave the user with no bridge at all, where today they get one that reports the wrong
+        /// number. Binding by name keeps both the compile and the fallback intact.
+        ///
+        /// Both helpers live in Microsoft.Dynamics.AX.Metadata.dll, the same assembly as AxEdt,
+        /// which this process has loaded long before anything asks for them -- so the lookup
+        /// starts there and only then scans what else is loaded.
+        /// </summary>
+        private static System.Reflection.MethodInfo? FindStaticHelper(
+            string typeName, string methodName, params Type[] argTypes)
+        {
+            try
+            {
+                Type? type = null;
+                try { type = typeof(AxEdt).Assembly.GetType(typeName, false); } catch { }
+                if (type == null)
+                {
+                    foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        try { type = asm.GetType(typeName, false); } catch { }
+                        if (type != null) break;
+                    }
+                }
+                if (type == null)
+                {
+                    Console.Error.WriteLine(
+                        $"[WARN] {typeName} is absent from this platform's metadata assemblies; " +
+                        "falling back to the hand-rolled string-size walk.");
+                    return null;
+                }
+
+                foreach (var m in type.GetMethods(
+                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
+                {
+                    if (m.Name != methodName) continue;
+                    var ps = m.GetParameters();
+                    if (ps.Length != argTypes.Length) continue;
+                    var fits = true;
+                    for (var i = 0; i < ps.Length; i++)
+                    {
+                        if (!ps[i].ParameterType.IsAssignableFrom(argTypes[i])) { fits = false; break; }
+                    }
+                    if (fits) return m;
+                }
+
+                Console.Error.WriteLine(
+                    $"[WARN] {typeName}.{methodName} has no overload this bridge can call on this " +
+                    "platform; falling back to the hand-rolled string-size walk.");
+            }
+            catch (Exception ex)
+            {
+                Warn("bindStaticHelper", $"{typeName}.{methodName}", ex);
+            }
+            return null;
+        }
+
+        /// <summary>Unwraps the TargetInvocationException reflection wraps a callee's throw in.</summary>
+        private static Exception Unwrap(Exception ex) =>
+            ex is System.Reflection.TargetInvocationException tie && tie.InnerException != null
+                ? tie.InnerException
+                : ex;
+
         /// <summary>Where a derived EDT's string size comes from, when it does not declare one.</summary>
         private sealed class InheritedStringSize
         {
-            /// <summary>Root of the Extends chain; null when the EDT is itself a root.</summary>
+            /// <summary>
+            /// Last ancestor the walk reached. It is the root of the hierarchy only when
+            /// <see cref="ChainComplete"/> is true; null when the EDT is itself a root.
+            /// </summary>
             public string? Root;
             /// <summary>Nearest ancestor that declares a StringSize; null when none does.</summary>
             public string? DeclaredBy;
             /// <summary>That ancestor's declared StringSize.</summary>
             public int? Value;
+            /// <summary>
+            /// True when the walk ended at an EDT that extends nothing. False when it stopped
+            /// early -- a dangling Extends, a cycle, or a provider that could not answer -- in
+            /// which case <see cref="Root"/> is simply the last thing seen.
+            /// </summary>
+            public bool ChainComplete;
         }
 
         /// <summary>
-        /// Walks <c>Extends</c> once, recording both the root of the hierarchy and the nearest
-        /// ancestor that actually declares a StringSize -- the value an undeclared child takes.
+        /// Walks <c>Extends</c> once, recording the end of the hierarchy and the nearest ancestor
+        /// that actually declares a StringSize -- the value an undeclared child takes.
         ///
-        /// Each hop goes back through <see cref="PickProvider"/> because an ancestor can live in
-        /// the other packages root (UDE: a custom EDT extending a Microsoft one). A dangling
-        /// <c>Extends</c> ends the walk where it breaks -- AmountMST names MoneyMST, which ships
-        /// no AxEdt file -- and a name already seen ends it too, so a metadata cycle cannot spin.
+        /// A dangling <c>Extends</c> ends the walk where it breaks -- AmountMST names MoneyMST,
+        /// which ships no AxEdt file -- and a name already seen ends it too, so a metadata cycle
+        /// cannot spin. Either way the result is marked incomplete rather than passed off as a
+        /// root.
         /// </summary>
         private InheritedStringSize FindInheritedStringSize(AxEdt edt, IMetadataProvider prov)
         {
@@ -1929,13 +2051,12 @@ namespace D365MetadataBridge.Services
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { edt.Name };
             var next = Safe(() => edt.Extends);
 
-            while (!string.IsNullOrEmpty(next) && seen.Add(next!))
+            while (!string.IsNullOrEmpty(next))
             {
-                var name = next!;
-                var parentProv = PickProvider(p => p.Edts.Exists(name)) ?? prov;
-                AxEdt? parent = null;
-                try { parent = parentProv.Edts.Read(name); } catch { }
-                if (parent == null) break;
+                if (!seen.Add(next!)) return found;
+
+                var parent = ReadAncestorEdt(next!, prov);
+                if (parent == null) return found;
 
                 found.Root = parent.Name;
                 if (found.DeclaredBy == null && parent is AxEdtString ps)
@@ -1949,7 +2070,43 @@ namespace D365MetadataBridge.Services
                 }
                 next = Safe(() => parent.Extends);
             }
+
+            found.ChainComplete = true;
             return found;
+        }
+
+        /// <summary>
+        /// Reads one ancestor for the chain walk, or null when nobody has it.
+        ///
+        /// The child's own provider answers for very nearly every hop, so it is asked first and
+        /// <see cref="PickProvider"/> -- which costs an Exists probe against both providers -- is
+        /// only paid when that misses. That case is real (UDE: a custom EDT extending a Microsoft
+        /// one), just rare.
+        ///
+        /// The catch around PickProvider is load-bearing: PickProvider THROWS when a provider
+        /// fails, deliberately, so that a single-kind lookup can never report "does not exist"
+        /// for "could not look". Here the lookup is a side quest of a read that has already
+        /// succeeded, and letting that throw would turn a good EDT read -- or, from MapField, a
+        /// whole table's field list -- into an error over an ancestor nobody asked about.
+        /// </summary>
+        private AxEdt? ReadAncestorEdt(string name, IMetadataProvider prov)
+        {
+            try { var own = prov.Edts.Read(name); if (own != null) return own; } catch { }
+
+            var other = PickProviderForEdt(name);
+            if (other == null || ReferenceEquals(other, prov)) return null;
+
+            try { return other.Edts.Read(name); } catch { return null; }
+        }
+
+        /// <summary>
+        /// <see cref="PickProvider"/> for an EDT lookup that is a side quest of a read which has
+        /// already succeeded, and so must not be able to fail that read. See
+        /// <see cref="ReadAncestorEdt"/> for why the throw is swallowed here.
+        /// </summary>
+        private IMetadataProvider? PickProviderForEdt(string edtName)
+        {
+            try { return PickProvider(p => p.Edts.Exists(edtName)); } catch { return null; }
         }
 
         /// <summary>
@@ -1960,39 +2117,44 @@ namespace D365MetadataBridge.Services
         {
             if (string.IsNullOrEmpty(Safe(() => edt.Extends))) return;
 
-            try
+            // Microsoft's own resolver, which encodes a rule a reimplementation would get
+            // wrong: a declared size does not always win. Measured over the 182 derived EDTs
+            // that declare a size and have a declaring ancestor --
+            //   StringSizeIsExtensible = Yes  -> the declaration wins either way
+            //                                    (InvoiceId 50 over Num 20; CustInvoiceId 20
+            //                                    under InvoiceId 50)
+            //   otherwise, declared smaller   -> the ancestor's value wins (4 EDTs: PartyName
+            //                                    declares 100 under DirPartyName's 160 and
+            //                                    reports 160, ITMJourneyId, TAMRebateInvoice,
+            //                                    PSNPurchasingCardProviderName)
+            //   otherwise, declared larger    -> UNVERIFIED; no such EDT ships, so this code
+            //                                    does not assume a direction and simply lets
+            //                                    the resolver decide.
+            var helper = ResolveVirtualPropertiesHelper.Value;
+            if (helper != null)
             {
-                // Microsoft's own resolver, which encodes a rule a reimplementation would get
-                // wrong: a declared size does not always win. Measured over the 182 derived EDTs
-                // that declare a size and have a declaring ancestor --
-                //   StringSizeIsExtensible = Yes  -> the declaration wins either way
-                //                                    (InvoiceId 50 over Num 20; CustInvoiceId 20
-                //                                    under InvoiceId 50)
-                //   otherwise, declared smaller   -> the ancestor's value wins (4 EDTs: PartyName
-                //                                    declares 100 under DirPartyName's 160 and
-                //                                    reports 160, ITMJourneyId, TAMRebateInvoice,
-                //                                    PSNPurchasingCardProviderName)
-                //   otherwise, declared larger    -> UNVERIFIED; no such EDT ships, so this code
-                //                                    does not assume a direction and simply lets
-                //                                    the resolver decide.
-                //
-                // isFlightEnabled: false, and the flag is not a detail. With true, an EDT-level
-                // read of CustInvoiceId returns 50 while the FIELD-level resolver returns 20 for
-                // CustInvoiceJour.InvoiceId -- a field typed with that very EDT -- so the bridge
-                // would contradict itself between get_object_info(edt) and
-                // get_object_info(table). With false the two agree at 20. false also confines
-                // this to the actual defect (an undeclared size) rather than rewriting values an
-                // EDT does declare, and the flag changes nothing for any of the broken cases
-                // (ItemFreeTxt 1000, ItemId 20, AccountNumber_IN 20 under either value).
-                Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaEdtExtensions
-                    .ResolveVirtualProperties(edt, prov, false);
-                return;
-            }
-            catch (Exception ex)
-            {
-                // The bridge is compiled against one environment's Microsoft assemblies and
-                // loaded against another's, so the resolver can simply be absent.
-                Warn("resolveVirtualProperties", edt.Name, ex);
+                try
+                {
+                    // isFlightEnabled: false, and the flag is not a detail. With true, an
+                    // EDT-level read of CustInvoiceId returns 50 while the FIELD-level resolver
+                    // returns 20 for CustInvoiceJour.InvoiceId -- a field typed with that very
+                    // EDT -- so the bridge would contradict itself between get_object_info(edt)
+                    // and get_object_info(table). With false the two agree at 20. false also
+                    // confines this to the actual defect (an undeclared size) rather than
+                    // rewriting values an EDT does declare, and the flag changes nothing for any
+                    // of the broken cases (ItemFreeTxt 1000, ItemId 20, AccountNumber_IN 20 under
+                    // either value).
+                    helper.Invoke(null, new object?[] { edt, prov, false });
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    // The resolver was found but threw. Unlike an absent one -- which is already
+                    // handled by helper == null -- this is a genuine per-EDT failure, so it warns
+                    // and drops through to the walk rather than being taken as a verdict on the
+                    // platform.
+                    Warn("resolveVirtualProperties", edt.Name, Unwrap(ex));
+                }
             }
 
             // Fallback: fill in ONLY an undeclared size, from the nearest ancestor that declares
@@ -2039,10 +2201,15 @@ namespace D365MetadataBridge.Services
         }
 
         /// <summary>
-        /// Cleared the first time Microsoft's field-level resolver throws, so an environment whose
-        /// assemblies predate it takes the hand-rolled path directly from then on.
+        /// Set once the field-level resolver has thrown, so a systemic failure puts one line on
+        /// stderr instead of one per string field per table read (103 for CustTable alone).
+        ///
+        /// It gates the WARNING only, never the call. An absent helper is already handled by
+        /// binding it by name, so what reaches the catch is a per-field failure -- one malformed
+        /// field, a dangling ExtendedDataType -- and letting that permanently downgrade every
+        /// later table read in the process would trade a loud narrow fault for a silent wide one.
         /// </summary>
-        private bool _fieldStringSizeHelperUsable = true;
+        private bool _fieldStringSizeHelperWarned;
 
         /// <summary>
         /// The string size a field really has. An EDT-typed field almost never declares its own
@@ -2054,7 +2221,8 @@ namespace D365MetadataBridge.Services
         /// </summary>
         private int EffectiveFieldStringSize(AxTableFieldString field, IMetadataProvider prov)
         {
-            if (_fieldStringSizeHelperUsable)
+            var helper = GetStringSizeHelper.Value;
+            if (helper != null)
             {
                 try
                 {
@@ -2063,29 +2231,36 @@ namespace D365MetadataBridge.Services
                     // this resolver returned the same value under either flag for every field
                     // tried (CustInvoiceJour.InvoiceId 20, DirPartyTable.Name 160,
                     // InventTable.ItemId 20).
-                    return Microsoft.Dynamics.AX.Metadata.MetaModel.Extensions.MetaTableFieldExtensions
-                        .GetStringSize(field, prov, false);
+                    var resolved = helper.Invoke(null, new object?[] { field, prov, false });
+                    if (resolved is int size) return size;
                 }
                 catch (Exception ex)
                 {
-                    // Latched off, and warned about exactly once: this runs per field, so a missing
-                    // helper would otherwise put one warning per string field per table read on
-                    // stderr (103 for CustTable alone).
-                    _fieldStringSizeHelperUsable = false;
-                    Warn("effectiveStringSize", field.Name, ex);
+                    if (!_fieldStringSizeHelperWarned)
+                    {
+                        _fieldStringSizeHelperWarned = true;
+                        Warn("effectiveStringSize", field.Name, Unwrap(ex));
+                    }
                 }
             }
 
-            // Fallback for an environment whose assemblies predate the helper. A field that
-            // declares its own size keeps it; otherwise take the field's EDT, and from there the
-            // nearest declaring ancestor, exactly as ReadEdt does.
+            // Fallback for a platform without the helper, and for the single field it could not
+            // answer for. A field that declares its own size keeps it; otherwise take the field's
+            // EDT, and from there the nearest declaring ancestor, exactly as ReadEdt does.
+            //
+            // Note what "declares its own size" can and cannot mean here. The 10-is-unset
+            // argument was MEASURED for EDTs (no explicit 10 among the 25 332 shipped) and is
+            // only carried over to fields, where it rests on the AxTableFieldString constructor
+            // default alone. A field that really did declare 10 over a 20-character EDT would be
+            // reported as 20 on this path. Microsoft's resolver above has no such gap, so this
+            // costs nothing on a current platform.
             var declared = SafeInt(() => field.StringSize, UnsetStringSize);
             if (declared != UnsetStringSize) return declared;
 
             var edtName = Safe(() => field.ExtendedDataType);
             if (!string.IsNullOrEmpty(edtName))
             {
-                var edtProv = PickProvider(p => p.Edts.Exists(edtName!)) ?? prov;
+                var edtProv = PickProviderForEdt(edtName!) ?? prov;
                 AxEdt? edt = null;
                 try { edt = edtProv.Edts.Read(edtName!); } catch { }
                 if (edt != null)

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "b7df3780df39ee432fad5ddcc771f72dfa4bffccf9eb0300f052117710467725",
+  "sourceHash": "53e837dc322f05b307e6e35c30ddc35e99b1d054108b90ee23ae1c2fd7e7e1a1",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7996.88",
-  "builtAt": "2026-08-27T17:31:14.692Z"
+  "metamodelFileVersion": "7.0.7996.33",
+  "builtAt": "2026-08-29T18:16:15.015Z"
 }

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "167cd1c211024c2b0bcb84e006ba21c76c8e4b2897abc9ef187bbce0480926fc",
+  "sourceHash": "b7df3780df39ee432fad5ddcc771f72dfa4bffccf9eb0300f052117710467725",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7996.33",
-  "builtAt": "2026-08-25T15:08:27.699Z"
+  "metamodelFileVersion": "7.0.7996.88",
+  "builtAt": "2026-08-27T17:31:14.692Z"
 }

--- a/docs/XPP_LANGUAGE_COVERAGE_PLAN.md
+++ b/docs/XPP_LANGUAGE_COVERAGE_PLAN.md
@@ -1,6 +1,13 @@
 # X++ Language & Reporting Coverage Plan
 
-Status: **Phases A+B done (2026-08-29); C–E pending; E/F require the D365FO VM.**
+Status: **Phases A–C done (2026-08-29); D–E pending; E/F require the D365FO VM.**
+Phase C deltas vs. the original table: `CS001` (C#-isms) implemented as planned; `RPT003`/`RPT004`
+were dropped (the TempDB/preprocess-attribute claims could not be verified off-VM and risked false
+errors); `RPT005` landed as two cheaper checks — `ssrsReportStr` joined the FN001 fixed-arity table
+(2 args) and the references mode now resolves `ssrsReportStr`/`reportStr` first arguments against
+the index ('report' type). `FN001` grew from 4 to 27 functions — **Phase F must re-verify the new
+arities against xppc** before trusting them further. New `xml-report` codeType runs report-only
+rules (RPT101/102) so the X++ keyword rules never scan RDL CDATA.
 Phase B note: new-topic AOT references are constrained to prose + `My…` placeholders (the
 apiSymbols snapshot is entry-scoped and can only be re-captured on the VM). Phase F should
 re-capture the snapshot and may then upgrade prose mentions (e.g. `Exception::DuplicateKeyException`

--- a/docs/XPP_LANGUAGE_COVERAGE_PLAN.md
+++ b/docs/XPP_LANGUAGE_COVERAGE_PLAN.md
@@ -1,6 +1,14 @@
 # X++ Language & Reporting Coverage Plan
 
-Status: **Phases A–C done (2026-08-29); D–E pending; E/F require the D365FO VM.**
+Status: **Phases A–D done (2026-08-29); E pending; E/F require the D365FO VM.**
+Phase D deltas: the report-pattern catalog is a RECIPE catalog (`src/knowledge/reportPatterns/`,
+7 patterns) rather than a FormPatternSpec mirror — reports have no pattern XML to validate against.
+The generator gained only `uiBuilder` (UIBuilder class + SysOperationContractProcessing binding);
+the planned PreProcessTempDB switch was NOT made — the preProcess path is unproven on the VM
+(no golden uses it) and the TempDB pairing claim awaits Phase F verification. Op-specs for
+`scaffold:report` now advertise the previously hidden aotQuery/callerTableName/preProcess/
+controllerType params. New knowledge: `ssrs-contracts`, `ssrs-rdp-preprocess`, `ssrs-ui-builder`
+(rules-only — zero extracted AOT refs pending the Phase F snapshot capture; examples then).
 Phase C deltas vs. the original table: `CS001` (C#-isms) implemented as planned; `RPT003`/`RPT004`
 were dropped (the TempDB/preprocess-attribute claims could not be verified off-VM and risked false
 errors); `RPT005` landed as two cheaper checks — `ssrsReportStr` joined the FN001 fixed-arity table

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.8.tgz",
-      "integrity": "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.11.tgz",
+      "integrity": "sha512-Tj0dnkLPdW0ASjHfj2D/ZkkvPU2wrFmnE1jWTD2xzV1ycapV1DutbYXk4NDnR3rYTi1ZCbNFD4G2gRMEY65WaA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -318,20 +318,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.8",
-        "@biomejs/cli-darwin-x64": "2.5.8",
-        "@biomejs/cli-linux-arm64": "2.5.8",
-        "@biomejs/cli-linux-arm64-musl": "2.5.8",
-        "@biomejs/cli-linux-x64": "2.5.8",
-        "@biomejs/cli-linux-x64-musl": "2.5.8",
-        "@biomejs/cli-win32-arm64": "2.5.8",
-        "@biomejs/cli-win32-x64": "2.5.8"
+        "@biomejs/cli-darwin-arm64": "2.5.11",
+        "@biomejs/cli-darwin-x64": "2.5.11",
+        "@biomejs/cli-linux-arm64": "2.5.11",
+        "@biomejs/cli-linux-arm64-musl": "2.5.11",
+        "@biomejs/cli-linux-x64": "2.5.11",
+        "@biomejs/cli-linux-x64-musl": "2.5.11",
+        "@biomejs/cli-win32-arm64": "2.5.11",
+        "@biomejs/cli-win32-x64": "2.5.11"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.8.tgz",
-      "integrity": "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.11.tgz",
+      "integrity": "sha512-6SGZxoKbXvUjMn1t6A98HqWISPnGNbYs0R/Rt2JarmXBSev+lva4QxUMWEBX9lX1Wo1XTJ78uk5xVDtG58SRZg==",
       "cpu": [
         "arm64"
       ],
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.8.tgz",
-      "integrity": "sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.11.tgz",
+      "integrity": "sha512-nYkXY7tLBEgnGbYapDKAyKzgt44ZEyG+AKalvTXtCWKYgepI9dw327q+cVgedxm+Udi1ZzHKUyZrIusHi/KQbw==",
       "cpu": [
         "x64"
       ],
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.8.tgz",
-      "integrity": "sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.11.tgz",
+      "integrity": "sha512-3PVLSTD9RR73rvVPt5G3T1gc+ycggWEGfTD7RvzzbtcDPD27NxgxBbAFfpm7DXJKW6VLHWE1lLMGvFt2Qxjcow==",
       "cpu": [
         "arm64"
       ],
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.8.tgz",
-      "integrity": "sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.11.tgz",
+      "integrity": "sha512-qhyZUMyCbWYFV2bAwRNVvfMVZ+hv7WYl6mossGrxC+uiQQXhvsuWWU8zz6jYX0mChZd9MgQZbm4vozTmG/5iGw==",
       "cpu": [
         "arm64"
       ],
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.8.tgz",
-      "integrity": "sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.11.tgz",
+      "integrity": "sha512-JOytptlsgM33B2MMFUg8iBrb4IKpbD5JnJrSeYiaFEeAj4vuXx0iQSQZ4qK7sqyMtfjZxxPdNdMZZVL4y/mFyA==",
       "cpu": [
         "x64"
       ],
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.8.tgz",
-      "integrity": "sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.11.tgz",
+      "integrity": "sha512-oRRlrchG5EfrEL/EmtT1qUjSNHk3/5LGeZhQqADBBAJF1b1ET6964xEKe7aGlGARzDfza8H/seEsFJl7S6Ql9w==",
       "cpu": [
         "x64"
       ],
@@ -443,9 +443,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.8.tgz",
-      "integrity": "sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.11.tgz",
+      "integrity": "sha512-e49E6K9hzH/ohJNx8Y26mY8HaV4I4ZViIeoqhKsmoXLKHhQnMeBAVqCgsGf2Wa3lXlS7RkporDXMHHWkzvZzFw==",
       "cpu": [
         "arm64"
       ],
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.8.tgz",
-      "integrity": "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==",
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.11.tgz",
+      "integrity": "sha512-QSQr/KjOgXA7OzXJUWS+oguKyAZ3Q0l/lnlDGbu397eKo83atuWUjBPJrsqbKNF6CARGw8XXJLGzpHC8Ryhd4Q==",
       "cpu": [
         "x64"
       ],
@@ -969,9 +969,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1039,19 +1039,36 @@
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.144.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
-      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
-      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
       "cpu": [
         "arm64"
       ],
@@ -1066,9 +1083,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
       "cpu": [
         "arm64"
       ],
@@ -1083,9 +1100,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
       "cpu": [
         "x64"
       ],
@@ -1100,9 +1117,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
-      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
       "cpu": [
         "x64"
       ],
@@ -1117,9 +1134,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
-      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
       "cpu": [
         "arm"
       ],
@@ -1134,9 +1151,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
-      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
       "cpu": [
         "arm64"
       ],
@@ -1154,9 +1171,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
-      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
       "cpu": [
         "arm64"
       ],
@@ -1174,9 +1191,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
-      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1194,9 +1211,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
-      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
       "cpu": [
         "s390x"
       ],
@@ -1214,9 +1231,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
-      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
       "cpu": [
         "x64"
       ],
@@ -1234,9 +1251,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
-      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
       "cpu": [
         "x64"
       ],
@@ -1254,9 +1271,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
-      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
       "cpu": [
         "arm64"
       ],
@@ -1271,9 +1288,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
-      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
       "cpu": [
         "arm64"
       ],
@@ -1288,9 +1305,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
-      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
       "cpu": [
         "x64"
       ],
@@ -1408,9 +1425,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1817,14 +1834,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1838,8 +1855,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.10",
-        "vitest": "4.1.10"
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1848,16 +1865,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1866,13 +1883,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1893,9 +1910,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1906,13 +1923,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1920,14 +1937,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1936,9 +1953,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1946,13 +1963,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1973,13 +1990,33 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/accepts/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+    "node_modules/accepts/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/agent-base": {
@@ -2540,9 +2577,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -2626,9 +2663,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -2667,9 +2704,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz",
-      "integrity": "sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+      "integrity": "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==",
       "funding": [
         {
           "type": "github",
@@ -2877,9 +2914,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
-      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3007,9 +3044,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3031,9 +3068,9 @@
       "license": "MIT"
     },
     "node_modules/is-unsafe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
-      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
       "funding": [
         {
           "type": "github",
@@ -3088,9 +3125,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
-      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3642,9 +3679,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3759,13 +3796,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
-      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.144.0",
+        "@oxc-project/types": "=0.147.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3775,20 +3812,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.4",
-        "@rolldown/binding-darwin-arm64": "1.2.4",
-        "@rolldown/binding-darwin-x64": "1.2.4",
-        "@rolldown/binding-freebsd-x64": "1.2.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
-        "@rolldown/binding-linux-arm64-musl": "1.2.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
-        "@rolldown/binding-linux-x64-gnu": "1.2.4",
-        "@rolldown/binding-linux-x64-musl": "1.2.4",
-        "@rolldown/binding-openharmony-arm64": "1.2.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
-        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
       }
     },
     "node_modules/router": {
@@ -4289,16 +4327,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -4315,7 +4353,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.4.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -4367,19 +4405,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4407,12 +4445,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4532,9 +4570,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -499,10 +499,18 @@ function formatEdt(edt: BridgeEdtInfo): string {
   out += `## 🔧 Core Properties\n\n`;
   out += `| Property | Value |\n|---|---|\n`;
   out += `| Base Type | ${edt.baseType ?? '—'}${edt.extends ? ` (Extends: ${edt.extends})` : ''} |\n`;
+  if (edt.rootEdt && edt.rootEdt !== edt.extends) out += `| Root EDT | ${edt.rootEdt} |\n`;
   if (edt.enumType) out += `| Enum Type | ${edt.enumType} |\n`;
   if (edt.referenceTable) out += `| Reference Table | ${edt.referenceTable} |\n`;
   if (edt.relationType) out += `| Relation Type | ${edt.relationType} |\n`;
-  if (edt.stringSize) out += `| String Size | ${edt.stringSize} |\n`;
+  // A derived EDT usually inherits its StringSize rather than declaring one, and a value it
+  // does declare can still be overridden by an ancestor's. Say where the number came from
+  // whenever it is not what this EDT's own XML said.
+  if (edt.stringSize) {
+    const from = edt.stringSizeInheritedFrom ? ` (inherited from ${edt.stringSizeInheritedFrom})` : '';
+    const size = edt.stringSize === -1 ? '-1 (memo, unlimited)' : String(edt.stringSize);
+    out += `| String Size | ${size}${from} |\n`;
+  }
   if (edt.displayLength) out += `| Display Length | ${edt.displayLength} |\n`;
   if (edt.label) out += `| Label | ${edt.label} |\n`;
   if (edt.helpText) out += `| Help Text | ${edt.helpText} |\n`;

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -154,9 +154,17 @@ export interface BridgeEdtInfo {
   name: string;
   baseType?: string;
   extends?: string;
+  /** Root of the Extends chain, for orientation in a multi-level hierarchy. */
+  rootEdt?: string;
   label?: string;
   helpText?: string;
   stringSize?: number;
+  /**
+   * Ancestor the reported `stringSize` came from. Absent when the number is what this EDT's
+   * own XML declares. Present both when the EDT declares nothing (the common case) and when
+   * an ancestor's value overrode one the EDT did declare.
+   */
+  stringSizeInheritedFrom?: string;
   enumType?: string;
   referenceTable?: string;
   model?: string;

--- a/src/knowledge/reportPatterns/catalog.ts
+++ b/src/knowledge/reportPatterns/catalog.ts
@@ -1,0 +1,275 @@
+/**
+ * Report-pattern catalog — 7 implementation recipes for D365FO SSRS reports.
+ *
+ * Every recipe is grounded in what generate_object(mode="scaffold",
+ * objectType="report") actually emits (src/tools/smart/generateSmartReport.ts):
+ * a pattern here never describes a shape the scaffold cannot produce, so
+ * "scaffold" is always the fastest correct path. Deviations that need hand
+ * work (print-management document types, preProcess staging) say so in
+ * methodNotes rather than pretending the tool covers them.
+ */
+
+import type { ReportObjectSpec, ReportPatternSpec } from './types.js';
+
+/** The roster every RDP-based report shares; patterns extend or replace rows. */
+function baseRoster(): ReportObjectSpec[] {
+  return [
+    {
+      role: 'TmpTable',
+      naming: '{Name}Tmp',
+      baseOrType: 'AxTable, TableType=TempDB',
+      notes: 'MUST be TempDB (not InMemory) — required for the SSRS data connection.',
+    },
+    {
+      role: 'Data contract',
+      naming: '{Name}Contract',
+      baseOrType: 'class, [DataContractAttribute]',
+      notes: 'Dialog parameters as [DataMemberAttribute] parm methods; mandatory checks live in validate(), not attributes.',
+    },
+    {
+      role: 'Data provider',
+      naming: '{Name}DP',
+      baseOrType: 'class extends SrsReportDataProviderBase',
+      notes: '[SRSReportParameterAttribute(classStr({Name}Contract))]; processReport() fills the TmpTable; one [SRSReportDataSetAttribute] getter per dataset.',
+    },
+    {
+      role: 'Controller',
+      naming: '{Name}Controller',
+      baseOrType: 'class extends SrsReportRunController',
+      notes: 'main() sets parmReportName(ssrsReportStr({Name}, Report)) — the scaffolded design is named "Report".',
+    },
+    {
+      role: 'Menu item',
+      naming: '{Name}',
+      baseOrType: 'AxMenuItemOutput',
+      notes: 'Object=Controller class, ObjectType=Class.',
+    },
+    {
+      role: 'Report',
+      naming: '{Name}',
+      baseOrType: 'AxReport with embedded RDL precision design named "Report"',
+    },
+  ];
+}
+
+const SHARED_CROSS_CHECKS = [
+  'validate_code(mode="both") on the DP and Controller — RPT001/RPT002 catch a missing parameter attribute or dataset getter, FN001 catches a one-argument ssrsReportStr.',
+  'validate_object_naming(objectType="report") — checks the name and lists the companion-object roster.',
+  'The controller design name must match the AxReport design ("Report" for scaffolded reports) — ssrsReportStr is compile-time checked.',
+  'Build the project (build_d365fo_project) — reports only fail some errors (wrong design name, bad dataset query) at build/deploy.',
+];
+
+export const REPORT_PATTERN_CATALOG: ReportPatternSpec[] = [
+  {
+    id: 'SimpleList',
+    displayName: 'Simple List report',
+    aliases: ['list', 'basic'],
+    purpose: 'A flat tabular report: one TmpTable dataset rendered as a single tablix with a page header.',
+    whenToUse: [
+      'Row-per-record listing with a handful of filter parameters',
+      'The default choice — start here unless another pattern clearly applies',
+    ],
+    whenNotToUse: [
+      'Subtotals/grouping needed → GroupedWithTotals',
+      'Header + lines document → HeaderDetail',
+      'Posted-document output (invoice, confirmation) → PrintMgmtFormLetter',
+    ],
+    objects: baseRoster(),
+    scaffold:
+      'generate_object(mode="scaffold", objectType="report", name="InventByZones", fieldsHint="ItemId, ItemName, Qty, Zone", caption="Inventory by zones", contractParams=[{name:"FromDate", type:"TransDate"}])',
+    methodNotes: [
+      'processReport(): read contract parms into locals, delete_from tmpTable, then insert_recordset (set-based) or while select + insert.',
+      'Keep the dataset getter exactly as scaffolded: [SRSReportDataSetAttribute(tableStr({Name}Tmp))] select * from the buffer.',
+    ],
+    crossChecks: SHARED_CROSS_CHECKS,
+    referenceReports: ['CustTransList'],
+    relatedTopics: ['ssrs-reports', 'temp-tables'],
+  },
+  {
+    id: 'GroupedWithTotals',
+    displayName: 'Grouped list with totals',
+    aliases: ['grouped', 'totals', 'subtotals'],
+    purpose: 'Tablix with a row group and SUM aggregates on the numeric columns — subtotal per group, grand total at the end.',
+    whenToUse: [
+      'Same flat data as SimpleList but users need per-group subtotals (per customer, per warehouse, …)',
+    ],
+    whenNotToUse: [
+      'No aggregation needed → SimpleList (simpler RDL)',
+    ],
+    objects: baseRoster(),
+    scaffold:
+      'generate_object(mode="scaffold", objectType="report", name="SalesByCust", fieldsHint="CustAccount, Name, Amount", designStyle="GroupedWithTotals")',
+    methodNotes: [
+      'The FIRST field in fieldsHint becomes the group key in the generated tablix — order the hint accordingly.',
+      'Aggregation happens in RDL (SUM), not in X++ — processReport() still writes detail rows.',
+    ],
+    crossChecks: SHARED_CROSS_CHECKS,
+    relatedTopics: ['ssrs-reports'],
+  },
+  {
+    id: 'HeaderDetail',
+    displayName: 'Header + lines (multi-dataset)',
+    aliases: ['multidataset', 'headerlines', 'master-detail'],
+    purpose: 'Two or more datasets from one DP — a header TmpTable and a lines TmpTable, each exposed by its own getter.',
+    whenToUse: [
+      'Document-style output: order header with its lines, journal with entries',
+      'Any report needing more than one dataset (summary + detail)',
+    ],
+    whenNotToUse: [
+      'Posted documents managed by Print management → PrintMgmtFormLetter',
+    ],
+    objects: [
+      ...baseRoster(),
+      {
+        role: 'Extra TmpTable(s)',
+        naming: '{Name}{Dataset}Tmp',
+        baseOrType: 'AxTable, TableType=TempDB',
+        notes: 'One per additionalDatasets entry; the DP gains a member + [SRSReportDataSetAttribute] getter for each.',
+      },
+    ],
+    scaffold:
+      'generate_object(mode="scaffold", objectType="report", name="SalesOrderDoc", fieldsHint="SalesId, CustAccount, OrderDate", additionalDatasets=[{name:"Lines", fieldsHint:"ItemId, Qty, LineAmount"}])',
+    methodNotes: [
+      'processReport() fills ALL tmp tables in one pass — link lines to their header by the header key field.',
+      'Each dataset getter returns its own buffer; SSRS joins them by dataset name in the RDL, not by table relation.',
+    ],
+    crossChecks: SHARED_CROSS_CHECKS,
+    relatedTopics: ['ssrs-reports', 'temp-tables'],
+  },
+  {
+    id: 'PreProcess',
+    displayName: 'Pre-processed data provider (long-running)',
+    aliases: ['long-running', 'staged'],
+    purpose: 'Stages data BEFORE the SSRS render request so heavy queries do not hit the ~10-minute interactive rendering timeout.',
+    whenToUse: [
+      'processReport() takes minutes on production volumes',
+      'The report times out interactively but the same query succeeds in batch',
+    ],
+    whenNotToUse: [
+      'Normal volumes — the extra staging machinery costs complexity for nothing',
+    ],
+    objects: [
+      ...baseRoster().map(o =>
+        o.role === 'Data provider'
+          ? {
+              ...o,
+              baseOrType: 'class extends SrsReportDataProviderPreProcess',
+              notes:
+                'Scaffolded WITHOUT [SRSReportParameterAttribute] (contract travels via the controller) and WITH a preProcess() stub. ' +
+                'VERIFY ON VM: the TempDB-table pairing (SrsReportDataProviderPreProcessTempDB) is not yet compile-proven by this repo — see the coverage plan.',
+            }
+          : o,
+      ),
+    ],
+    scaffold:
+      'generate_object(mode="scaffold", objectType="report", name="HeavyLedgerRecap", fieldsHint="AccountNum, Amount", preProcess=true)',
+    methodNotes: [
+      'preProcess() runs before the dialog/render — do the heavy population there.',
+      'Regular-table staging variants key rows by createdTransactionId so concurrent runs do not read each other\'s rows.',
+    ],
+    crossChecks: [
+      ...SHARED_CROSS_CHECKS,
+      'This is the one pattern the repo has not compile-proven on the VM — build and run it there before trusting the scaffolded shape.',
+    ],
+    relatedTopics: ['ssrs-reports', 'temp-tables'],
+  },
+  {
+    id: 'PrintMgmtFormLetter',
+    displayName: 'Print-management document',
+    aliases: ['printmgmt', 'print-management', 'formletter', 'document'],
+    purpose: 'A posted-document report (invoice, confirmation, packing slip) whose destination/copies are governed by Print management setup.',
+    whenToUse: [
+      'Output for a posted business document that users configure per customer/vendor in Print management',
+    ],
+    whenNotToUse: [
+      'Ad-hoc inquiry listing → SimpleList; the Print management machinery is for documents',
+    ],
+    objects: [
+      ...baseRoster().map(o =>
+        o.role === 'Controller'
+          ? {
+              ...o,
+              baseOrType: 'class extends SrsPrintMgmtController',
+              notes: 'main() sets parmPrintMgmtDocType(PrintMgmtDocumentType::…) — replace the scaffolded placeholder with the real document type.',
+            }
+          : o,
+      ),
+    ],
+    scaffold:
+      'generate_object(mode="scaffold", objectType="report", name="ConsignmentNote", fieldsHint="SalesId, DeliveryAddress", controllerType="printMgmt")',
+    methodNotes: [
+      'A NEW document type needs hand work the scaffold does not do: extend the PrintMgmtDocumentType base enum, subscribe to the getDefaultReportFormatDelegate to map it to ssrsReportStr({Name}, Report), and add the module\'s PrintMgmtNode handling — see the print-management knowledge topic.',
+      'For an EXISTING document type, set parmPrintMgmtDocType to it and Print management setup takes over destinations/copies.',
+    ],
+    crossChecks: SHARED_CROSS_CHECKS,
+    referenceReports: ['SalesInvoice', 'PurchPurchaseOrder'],
+    relatedTopics: ['print-management', 'ssrs-reports'],
+  },
+  {
+    id: 'QueryBased',
+    displayName: 'AOT-query data provider',
+    aliases: ['query', 'aotquery'],
+    purpose: 'The DP consumes a modeled AOT query (user gets the standard query filter dialog) instead of hand-written selects.',
+    whenToUse: [
+      'Users should filter with the full query dialog (ranges on any field, joins already modeled)',
+      'An AOT query for the data shape already exists',
+    ],
+    whenNotToUse: [
+      'The data needs computation/aggregation the query cannot express → SimpleList with hand-written processReport()',
+    ],
+    objects: [
+      ...baseRoster().map(o =>
+        o.role === 'Data provider'
+          ? {
+              ...o,
+              notes:
+                'Adds [SRSReportQueryAttribute(queryStr(MyQuery))]; processReport() runs this.parmQuery() through a QueryRun and copies rows into the TmpTable.',
+            }
+          : o,
+      ),
+    ],
+    scaffold:
+      'generate_object(mode="scaffold", objectType="report", name="CustOpenItems", fieldsHint="CustAccount, Amount, DueDate", aotQuery="CustOpenTrans")',
+    methodNotes: [
+      'Keep contract parameters for values the query ranges cannot express (a threshold, a mode toggle) — both can coexist.',
+    ],
+    crossChecks: SHARED_CROSS_CHECKS,
+    relatedTopics: ['ssrs-reports', 'query-object-model'],
+  },
+  {
+    id: 'UIBuilderDialog',
+    displayName: 'Custom dialog (UI builder)',
+    aliases: ['uibuilder', 'dialog'],
+    purpose: 'Adds a UI-builder class so the parameter dialog gets custom lookups, dependent fields, or field events.',
+    whenToUse: [
+      'A parameter needs a filtered lookup, cascading enable/disable, or a modified() reaction',
+    ],
+    whenNotToUse: [
+      'Plain parameters render fine automatically — no builder class needed',
+    ],
+    objects: [
+      ...baseRoster().map(o =>
+        o.role === 'Data contract'
+          ? {
+              ...o,
+              notes: 'Additionally carries [SysOperationContractProcessing(classStr({Name}UIBuilder))] binding the builder to the dialog.',
+            }
+          : o,
+      ),
+      {
+        role: 'UI builder',
+        naming: '{Name}UIBuilder',
+        baseOrType: 'class extends SrsReportDataContractUIBuilder',
+        notes: 'Override build(); fetch fields via this.bindInfo().getDialogField(contract, methodStr(...)) and attach lookups/events.',
+      },
+    ],
+    scaffold:
+      'generate_object(mode="scaffold", objectType="report", name="CustAging", fieldsHint="CustAccount, Balance", contractParams=[{name:"CustGroup", type:"CustGroupId"}], uiBuilder=true)',
+    methodNotes: [
+      'build(): call super() first, then customize the dialog fields.',
+      'Register overrides (lookup/modified) on the dialog field, not on the form control directly.',
+    ],
+    crossChecks: SHARED_CROSS_CHECKS,
+    relatedTopics: ['ssrs-reports', 'sysoperation'],
+  },
+];

--- a/src/knowledge/reportPatterns/index.ts
+++ b/src/knowledge/reportPatterns/index.ts
@@ -1,0 +1,76 @@
+/**
+ * Report-pattern catalog — resolution and rendering.
+ * Served through object_patterns(domain="report"); see catalog.ts for content.
+ */
+
+import { REPORT_PATTERN_CATALOG } from './catalog.js';
+import type { ReportPatternSpec } from './types.js';
+
+/** Case-insensitive, separator-insensitive key. */
+function key(s: string): string {
+  return s.toLowerCase().replace(/[-_\s]/g, '');
+}
+
+/** Resolve a pattern by id or alias — exact (normalized) match only. */
+export function resolveReportPattern(nameOrAlias: string): ReportPatternSpec | undefined {
+  const k = key(nameOrAlias);
+  return REPORT_PATTERN_CATALOG.find(
+    p => key(p.id) === k || (p.aliases ?? []).some(a => key(a) === k),
+  );
+}
+
+export function listReportPatterns(): ReportPatternSpec[] {
+  return REPORT_PATTERN_CATALOG;
+}
+
+/** One-line-per-pattern overview. */
+export function renderReportPatternList(): string {
+  const lines: string[] = [
+    '📊 SSRS report patterns — implementation recipes. object_patterns(domain="report", pattern=<id>) for the full spec.',
+    '',
+  ];
+  for (const p of REPORT_PATTERN_CATALOG) {
+    lines.push(`• ${p.id} — ${p.purpose}`);
+  }
+  lines.push('');
+  lines.push('Deeper rules: get_knowledge(topic="ssrs-reports"); generation: generate_object(mode="scaffold", objectType="report", …).');
+  return lines.join('\n');
+}
+
+/** Full spec of one pattern. */
+export function renderReportPatternSpec(spec: ReportPatternSpec): string {
+  const lines: string[] = [];
+  lines.push(`📊 Report pattern: ${spec.displayName} (${spec.id})`);
+  lines.push('');
+  lines.push(spec.purpose);
+  lines.push('');
+  lines.push('When to use:');
+  for (const w of spec.whenToUse) lines.push(`  • ${w}`);
+  if (spec.whenNotToUse?.length) {
+    lines.push('When NOT to use:');
+    for (const w of spec.whenNotToUse) lines.push(`  • ${w}`);
+  }
+  lines.push('');
+  lines.push('Objects:');
+  for (const o of spec.objects) {
+    lines.push(`  • ${o.role}: ${o.naming} — ${o.baseOrType}`);
+    if (o.notes) lines.push(`      ${o.notes}`);
+  }
+  lines.push('');
+  lines.push('Scaffold (one call creates the full roster):');
+  lines.push(`  ${spec.scaffold}`);
+  lines.push('');
+  lines.push('Method guidance:');
+  for (const m of spec.methodNotes) lines.push(`  • ${m}`);
+  lines.push('');
+  lines.push('Verify:');
+  for (const c of spec.crossChecks) lines.push(`  • ${c}`);
+  if (spec.referenceReports?.length) {
+    lines.push('');
+    lines.push(`Standard examples: ${spec.referenceReports.join(', ')} (get_object_info(objectType="report", name=…))`);
+  }
+  if (spec.relatedTopics?.length) {
+    lines.push(`Related knowledge: ${spec.relatedTopics.map(t => `"${t}"`).join(', ')} (get_knowledge)`);
+  }
+  return lines.join('\n');
+}

--- a/src/knowledge/reportPatterns/types.ts
+++ b/src/knowledge/reportPatterns/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Report-pattern catalog types.
+ *
+ * Unlike form patterns — which are metadata patterns validated against AxForm
+ * XML — a report "pattern" is an implementation RECIPE: which objects to
+ * create, what each extends, which scaffold call produces the whole set, and
+ * what to verify afterwards. The catalog is the report-side counterpart of
+ * src/knowledge/formPatterns/, served through object_patterns(domain="report").
+ */
+
+/** One object in a pattern's roster. */
+export interface ReportObjectSpec {
+  /** Role in the pattern (e.g. "TmpTable", "Data provider"). */
+  role: string;
+  /** Naming convention relative to the report name (e.g. "{Name}DP"). */
+  naming: string;
+  /** AOT kind plus the base class / table type it must carry. */
+  baseOrType: string;
+  /** Role-specific guidance. */
+  notes?: string;
+}
+
+export interface ReportPatternSpec {
+  /** Stable id, matched case-insensitively (also without hyphens). */
+  id: string;
+  displayName: string;
+  /** Alternative names agents reach for. */
+  aliases?: string[];
+  purpose: string;
+  whenToUse: string[];
+  whenNotToUse?: string[];
+  /** Object roster the pattern produces. */
+  objects: ReportObjectSpec[];
+  /** The generate_object call that scaffolds the full roster in one step. */
+  scaffold: string;
+  /** Key method overrides / stubs, in build order. */
+  methodNotes: string[];
+  /** What to verify after generation (validators, design name, build). */
+  crossChecks: string[];
+  /** Standard AOT reports demonstrating the pattern. */
+  referenceReports?: string[];
+  /** Knowledge topic ids with the deeper rules. */
+  relatedTopics?: string[];
+}

--- a/src/prompts/systemInstructions.ts
+++ b/src/prompts/systemInstructions.ts
@@ -140,6 +140,7 @@ You are an AI assistant with access to D365FO MCP tools, assisting with Dynamics
 | \`xpp-class-rules\`, \`sysda\`, \`query-object-model\`, \`formrun-lifecycle\` | Class rules, SysDa, Query API, form lifecycle |
 | \`operators-precedence\`, \`switch-loops\`, \`xpp-data-types\`, \`xpp-declarations\` | Core grammar: precedence traps, switch fallthrough, literals/conversions, const/using |
 | \`intrinsic-functions\`, \`attributes-authoring\`, \`date-effective\` | Compile-time functions, custom attributes, date-effective tables |
+| \`ssrs-reports\`, \`ssrs-contracts\`, \`ssrs-rdp-preprocess\`, \`ssrs-ui-builder\` | SSRS: DP/RDL lifecycle, contract taxonomy, preprocess, dialog builders |
 
 When uncertain about syntax, consult Microsoft Learn (\`dynamics365/fin-ops-core/dev-itpro\`) — not AX 2012 training data.
 

--- a/src/server/toolSchemas/objectPatterns.ts
+++ b/src/server/toolSchemas/objectPatterns.ts
@@ -11,15 +11,16 @@ export const objectPatternsTool = {
       '• table → common field types, index patterns and relation structures for D365FO tables. Filter by tableGroup (Main, Transaction, …) or similarTo a given table.\n' +
       '• form → form-pattern toolkit; pick an `action`:\n' +
       '   - analyze → pattern advisor + usage analysis. RECOMMEND (preferred for a new form): pass recommend={entityKind, hasHeaderLines, fieldCount, usageIntent, tableName} for the right pattern via the Microsoft decision tree + reference forms to clone. Or filter by formPattern / dataSource / similarTo.\n' +
-      '   - spec → full structure spec of a pattern or sub-pattern (required hierarchy/ordering, allowed children, reference forms, lifecycle). Call after analyze, before building.\n' +
-      '   - validate → structural validator of AxForm XML (<50 ms, offline): container hierarchy/order, sub-patterns, PatternVersion. Returns FP001-FP010 violations. Call before action=create on d365fo_file.',
+      '   - spec → full structure spec of a pattern or sub-pattern (required hierarchy/ordering, allowed children, reference forms, lifecycle).\n' +
+      '   - validate → structural validator of AxForm XML: container hierarchy/order, sub-patterns, PatternVersion. Returns FP001-FP010 violations. Call before action=create on d365fo_file.\n' +
+      '• report → SSRS implementation recipes: object roster, scaffold call, checks. Optional pattern=<id> for one recipe.',
     inputSchema: {
       type: 'object',
       properties: {
         domain: {
           type: 'string',
-          enum: ['table', 'form'],
-          description: 'Optional — inferred from the other params (action/pattern/xml/formName → form; tableGroup → table). ⚠️ NOT a free-form "pattern type": a concept like "number-sequence"/"SysOperation" belongs to get_knowledge, not here.',
+          enum: ['table', 'form', 'report'],
+          description: 'Optional — inferred from the other params (action/pattern/xml/formName → form; tableGroup → table). ⚠️ NOT a free-form "pattern type": a concept like "number-sequence"/"SysOperation" belongs to get_knowledge.',
         },
         // domain=table
         tableGroup: {
@@ -45,7 +46,7 @@ export const objectPatternsTool = {
         },
         similarTo: {
           type: 'string',
-          description: '[table] table name to find similar table patterns; [form/analyze] form name to find similar form patterns.',
+          description: '[table] table / [form-analyze] form name to find similar patterns.',
         },
         recommend: {
           type: 'object',
@@ -77,13 +78,13 @@ export const objectPatternsTool = {
         },
         limit: {
           type: 'number',
-          description: '[analyze] Maximum number of pattern examples (default: 10)',
+          description: '[analyze] Max pattern examples (default 10)',
           default: 10,
         },
         // action=spec
         pattern: {
           type: 'string',
-          description: '[spec] REQUIRED. Pattern name (id, xmlName, or alias) — e.g. "SimpleList", "DetailsMaster", or a sub-pattern like "FieldsFieldGroups".',
+          description: '[spec|report] Pattern name (id, xmlName, or alias) — e.g. "SimpleList", a sub-pattern like "FieldsFieldGroups", or a report recipe like "PrintMgmtFormLetter".',
         },
         // action=validate
         xml: {
@@ -96,7 +97,7 @@ export const objectPatternsTool = {
         },
         filePath: {
           type: 'string',
-          description: '[form/validate] Explicit path to an AxForm XML file (e.g. a freshly created form not yet indexed).',
+          description: '[form/validate] Path to an AxForm XML file not yet indexed.',
         },
       },
       // domain is optional: inferred from other params (also accepts `patternType` alias).

--- a/src/server/toolSchemas/validateCode.ts
+++ b/src/server/toolSchemas/validateCode.ts
@@ -9,7 +9,7 @@ export const validateCodeTool = {
     description:
       'Static validator for generated X++/XML (paste the text). Choose a `mode`:\n' +
       '• syntax → offline best-practice/BP validator (no xppbp.exe). Structured violations {rule, severity, line, excerpt, fix}. Covers select, CoC, BP and table-XML rules mined from standard models.\n' +
-      '• references → semantic reference resolver (index-only): verifies every type, field, method (incl. arity), enum, label and intrinsic (tableStr/fieldStr/…) EXISTS in the indexed codebase — catches hallucinated symbols before the compiler. codeType="xml-table" checks XML refs instead: EDT/enum/relation/extends/label.\n' +
+      '• references → semantic reference resolver (index-only): verifies every type, field, method (incl. arity), enum, label and intrinsic (tableStr/fieldStr/…) EXISTS in the indexed codebase. codeType="xml-table" checks XML refs instead: EDT/enum/relation/extends/label.\n' +
       'Call mode="both" AFTER generating, BEFORE writes; fix errors in the same turn. Write tools run references internally when GROUNDING_ENFORCE=true.',
     inputSchema: {
       type: 'object',
@@ -25,9 +25,9 @@ export const validateCodeTool = {
         },
         codeType: {
           type: 'string',
-          enum: ['xpp', 'xml-table', 'xml-any'],
+          enum: ['xpp', 'xml-table', 'xml-any', 'xml-report'],
           default: 'xpp',
-          description: '[syntax] "xpp" for X++ source (default), "xml-table" for AxTable XML, "xml-any" for other XML.',
+          description: '[syntax] "xpp" X++ source (default), "xml-table" AxTable, "xml-report" AxReport, "xml-any" other XML.',
         },
         context: {
           type: 'string',

--- a/src/server/toolSchemas/validateObjectNaming.ts
+++ b/src/server/toolSchemas/validateObjectNaming.ts
@@ -13,7 +13,7 @@ export const validateObjectNamingTool = {
         proposedName: { type: 'string', description: 'The proposed object name to validate' },
         objectType: {
           type: 'string',
-          enum: ['class', 'table', 'form', 'enum', 'edt', 'query', 'view',
+          enum: ['class', 'table', 'form', 'enum', 'edt', 'query', 'view', 'report',
             'table-extension', 'class-extension', 'form-extension', 'enum-extension', 'edt-extension',
             'menu-item', 'security-privilege', 'security-duty', 'security-role', 'data-entity'],
           description: 'Type of the D365FO object',

--- a/src/tools/analysis/validateObjectNaming.ts
+++ b/src/tools/analysis/validateObjectNaming.ts
@@ -21,6 +21,7 @@ const ValidateObjectNamingArgsSchema = z.object({
       'edt',
       'query',
       'view',
+      'report',
       'table-extension',
       'class-extension',
       'form-extension',

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -24,6 +24,15 @@
  *   BP005   an enum SYMBOL (enum2Symbol / value2Symbol) in user-facing text — never translated
  *   FN001   fixed-arity built-in called with the wrong number of arguments
  *   TTS001  Unbalanced ttsbegin / ttscommit
+ *   TTS002  Dead catch inside an open tts scope (only UpdateConflict/DuplicateKeyException reach it)
+ *   TTS003  retry with no visible guard in its catch block (infinite-loop risk)
+ *   SEL006  index hint without allowIndexHint(true)
+ *   SEL007  left/right join or join…on — SQL/C# join syntax that is not X++
+ *   CS001   C# constructs that do not compile in X++ ($"…", =>, foreach, ??, string type)
+ *   RPT001  DP reads parmDataContract() but declares no [SRSReportParameterAttribute]
+ *   RPT002  DP has processReport() but no [SRSReportDataSetAttribute] getter
+ *   RPT101  AxReport XML without a design node (codeType="xml-report")
+ *   RPT102  AxReport dataset without <Query> (codeType="xml-report")
  *   XML001  AxTable XML missing an index with <AlternateKey>Yes</AlternateKey>
  *   XML006  AxTable elements out of canonical order (silently dropped by the AOT)
  *   XML007  Table-level property that does not exist in the AxTable model
@@ -52,8 +61,8 @@ export const validateXppArgsSchema = z.object({
   code: z.string().describe(
     'X++ source code or XML metadata to validate. Paste the full generated text.'
   ),
-  codeType: z.enum(['xpp', 'xml-table', 'xml-any']).optional().default('xpp').describe(
-    '"xpp" for X++ source (default), "xml-table" for AxTable XML, "xml-any" for other XML.'
+  codeType: z.enum(['xpp', 'xml-table', 'xml-any', 'xml-report']).optional().default('xpp').describe(
+    '"xpp" for X++ source (default), "xml-table" for AxTable XML, "xml-report" for AxReport XML, "xml-any" for other XML.'
   ),
   context: z.string().optional().describe(
     'Optional: owning class/table name, used in diagnostic messages.'
@@ -603,6 +612,34 @@ const FIXED_ARITY_BUILTINS: Record<string, { name: string; arity: number; note: 
   enum2symbol: { name: 'enum2Symbol', arity: 2, note: 'enum2Symbol(enumNum(MyEnum), value) — enum id AND value' },
   symbol2enum: { name: 'symbol2Enum', arity: 2, note: 'symbol2Enum(enumNum(MyEnum), symbolString) — enum id AND symbol' },
   enumnum:     { name: 'enumNum',     arity: 1, note: 'enumNum(MyEnum) — the enum TYPE name alone, not a value' },
+  // Runtime string/container/date/math functions with genuinely fixed arity.
+  // Arities are taken from the X++ language reference; re-verify against xppc
+  // on the VM before extending further (Phase F of the coverage plan).
+  strlen:      { name: 'strLen',      arity: 1, note: 'strLen(text)' },
+  strupr:      { name: 'strUpr',      arity: 1, note: 'strUpr(text)' },
+  strlwr:      { name: 'strLwr',      arity: 1, note: 'strLwr(text)' },
+  substr:      { name: 'subStr',      arity: 3, note: 'subStr(text, position, number) — position is 1-based' },
+  strdel:      { name: 'strDel',      arity: 3, note: 'strDel(text, position, number)' },
+  strins:      { name: 'strIns',      arity: 3, note: 'strIns(text, insert, position)' },
+  strrep:      { name: 'strRep',      arity: 2, note: 'strRep(text, count)' },
+  strfind:     { name: 'strFind',     arity: 4, note: 'strFind(text, characters, start, count)' },
+  strscan:     { name: 'strScan',     arity: 4, note: 'strScan(text, pattern, start, count)' },
+  conlen:      { name: 'conLen',      arity: 1, note: 'conLen(container)' },
+  conpeek:     { name: 'conPeek',     arity: 2, note: 'conPeek(container, position) — 1-based' },
+  condel:      { name: 'conDel',      arity: 3, note: 'conDel(container, start, number)' },
+  conins:      { name: 'conIns',      arity: 3, note: 'conIns(container, start, value)' },
+  mkdate:      { name: 'mkDate',      arity: 3, note: 'mkDate(day, month, year)' },
+  year:        { name: 'year',        arity: 1, note: 'year(date)' },
+  mthofyr:     { name: 'mthOfYr',     arity: 1, note: 'mthOfYr(date)' },
+  dayofmth:    { name: 'dayOfMth',    arity: 1, note: 'dayOfMth(date)' },
+  endmth:      { name: 'endMth',      arity: 1, note: 'endMth(date)' },
+  nextmth:     { name: 'nextMth',     arity: 1, note: 'nextMth(date)' },
+  prevmth:     { name: 'prevMth',     arity: 1, note: 'prevMth(date)' },
+  datemthfwd:  { name: 'dateMthFwd',  arity: 2, note: 'dateMthFwd(date, months)' },
+  decround:    { name: 'decRound',    arity: 2, note: 'decRound(value, decimals)' },
+  power:       { name: 'power',       arity: 2, note: 'power(value, exponent)' },
+  abs:         { name: 'abs',         arity: 1, note: 'abs(value)' },
+  ssrsreportstr: { name: 'ssrsReportStr', arity: 2, note: 'ssrsReportStr(MyReport, MyDesign) — report AND design name; the design must exist inside that AxReport (scaffolded reports name it "Report")' },
 };
 
 /**
@@ -962,6 +999,241 @@ function checkDevArtifacts(code: string): ValidationViolation[] {
   );
 }
 
+/**
+ * CS001 — C# constructs that do not exist in X++.
+ *
+ * Every one of these is a guaranteed compile failure that reads perfectly
+ * naturally to anyone who writes C# all day, which is exactly why they slip
+ * into generated X++: string interpolation, lambdas, foreach, ?? and the
+ * `string` type name. The fix message carries the X++ equivalent so the
+ * repair is one edit, not a search.
+ */
+function checkCSharpIsms(code: string): ValidationViolation[] {
+  const masked = maskStringsAndComments(code);
+  const violations: ValidationViolation[] = [];
+  const patterns: Array<{ re: RegExp; fix: string }> = [
+    {
+      re: /\$"/g,
+      fix: 'X++ has no string interpolation ($"…") — use strFmt("%1 / %2", a, b).',
+    },
+    {
+      re: /=>/g,
+      fix: 'X++ has no lambdas/anonymous methods (=>) — use a named (private) method, or a delegate plus an eventhandler subscription.',
+    },
+    {
+      re: /\bforeach\b/g,
+      fix: 'X++ has no foreach — iterate collections with their Enumerator (while (en.moveNext()) { en.current(); }) and tables with while select.',
+    },
+    {
+      re: /\?\?/g,
+      fix: 'X++ has no null-coalescing operator (??) — value types hold null-EQUIVALENT values (0, empty string, 1900-01-01); test explicitly.',
+    },
+    {
+      re: /\bstring\s+\w+\s*[;=]/g,
+      fix: 'The X++ string type is str (or an EDT) — "string" is C#.',
+    },
+  ];
+  for (const p of patterns) {
+    violations.push(...matchAll(masked, p.re, 'CS001', 'error', p.fix));
+  }
+  return violations;
+}
+
+/**
+ * TTS002 — a catch inside an open ttsbegin/ttscommit scope that can never fire.
+ *
+ * Inside a transaction only Exception::UpdateConflict and
+ * Exception::DuplicateKeyException are deliverable to an INNER catch, and only
+ * when named explicitly — everything else aborts the transaction and unwinds
+ * to the first catch OUTSIDE the tts block. A bare `catch` inside tts is the
+ * classic shape (see the WRONG example in the transactions knowledge topic):
+ * it looks defensive and is dead code.
+ *
+ * Depth is approximated by counting ttsbegin minus ttscommit/ttsabort before
+ * the catch on the masked source — heuristic, hence warning severity.
+ */
+function checkCatchInsideTts(code: string): ValidationViolation[] {
+  const masked = maskStringsAndComments(code);
+  if (!/\bttsbegin\b/i.test(masked)) return [];
+  const violations: ValidationViolation[] = [];
+  const catchRe = /\bcatch\b\s*(?:\(([^)]*)\))?/g;
+  let m: RegExpExecArray | null;
+  while ((m = catchRe.exec(masked)) !== null) {
+    const before = masked.slice(0, m.index);
+    const depth =
+      (before.match(/\bttsbegin\b/gi)?.length ?? 0) -
+      (before.match(/\bttscommit\b/gi)?.length ?? 0) -
+      (before.match(/\bttsabort\b/gi)?.length ?? 0);
+    if (depth <= 0) continue;
+    const filter = m[1] ?? '';
+    if (/(?:UpdateConflict|DuplicateKeyException)\b/i.test(filter) && !/NotRecovered/i.test(filter)) continue;
+    violations.push({
+      rule: 'TTS002',
+      severity: 'warning',
+      line: lineNumber(code, m.index),
+      excerpt: m[0].trim() || 'catch',
+      fix:
+        'Inside an open transaction only Exception::UpdateConflict and Exception::DuplicateKeyException reach an inner catch, ' +
+        'and only when named explicitly — this catch is dead code; every other exception unwinds to the first catch OUTSIDE the tts block. ' +
+        'Move the try/catch outside ttsbegin/ttscommit (knowledge topic: transactions).',
+    });
+  }
+  return violations;
+}
+
+/**
+ * TTS003 — `retry` with no visible guard in its catch block.
+ *
+ * retry jumps back to the START of the try block and discards the infolog
+ * entries logged since try entry; on a deterministic error an unguarded retry
+ * loops forever. The heuristic asks only that the catch block containing the
+ * retry shows SOME guard shape (a counter ++/+=, or an if) before it.
+ */
+function checkUnguardedRetry(code: string): ValidationViolation[] {
+  const masked = maskStringsAndComments(code);
+  const violations: ValidationViolation[] = [];
+  const retryRe = /\bretry\s*;/g;
+  let m: RegExpExecArray | null;
+  while ((m = retryRe.exec(masked)) !== null) {
+    const before = masked.slice(0, m.index);
+    const catchIdx = before.search(/\bcatch\b(?![\s\S]*\bcatch\b)/);
+    if (catchIdx === -1) continue; // retry outside catch — the compiler rejects it
+    const segment = masked.slice(catchIdx, m.index);
+    if (/(\+\+|\+=|\bif\s*\()/.test(segment)) continue;
+    violations.push({
+      rule: 'TTS003',
+      severity: 'warning',
+      line: lineNumber(code, m.index),
+      excerpt: 'retry;',
+      fix:
+        'retry jumps back to the start of the try block and discards infolog messages logged since try entry — ' +
+        'unguarded, it loops forever on a deterministic error. Guard it with a counter ' +
+        '(retryCount++; if (retryCount > maxRetries) throw …; retry;).',
+    });
+  }
+  return violations;
+}
+
+/** SEL006 — `index hint` used without evidence of allowIndexHint(true). */
+function checkIndexHint(code: string): ValidationViolation[] {
+  const masked = maskStringsAndComments(code);
+  if (/\ballowIndexHint\s*\(\s*true\s*\)/i.test(masked)) return [];
+  return matchAll(
+    masked,
+    /\bindex\s+hint\s+\w+/gi,
+    'SEL006',
+    'warning',
+    '"index hint" is silently IGNORED unless the buffer called allowIndexHint(true) first — and it overrides the ' +
+    'optimizer, so use it only when measured. For sort order use plain "index IndexName" (no hint).',
+  );
+}
+
+/** SEL007 — SQL/C# join syntax that does not exist in X++. */
+function checkForeignJoinSyntax(code: string): ValidationViolation[] {
+  const masked = maskStringsAndComments(code);
+  const violations = matchAll(
+    masked,
+    /\b(?:left|right)\s+(?:outer\s+)?join\b/gi,
+    'SEL007',
+    'error',
+    'X++ has no left/right join keywords — "outer join" IS the left outer join; there is no right outer (swap the buffers). ' +
+    'Join kinds: join, outer join, exists join, notexists join.',
+  );
+  violations.push(...matchAll(
+    masked,
+    /\bjoin\s+\w+\s+on\b/gi,
+    'SEL007',
+    'error',
+    'X++ joins have no "on" keyword — put the join criteria in the joined buffer\'s own where clause: ' +
+    'join otherTable where otherTable.Field == driver.Field.',
+  ));
+  return violations;
+}
+
+/**
+ * RPT001/RPT002 — SSRS data-provider class shape.
+ *
+ * A DP that reads parmDataContract() without [SRSReportParameterAttribute]
+ * binds no contract (the dialog values never arrive), and a DP without a
+ * single [SRSReportDataSetAttribute] getter gives SSRS no dataset to read.
+ * Both compile clean and fail only at report run time, which is why they are
+ * worth catching at write time. PreProcess variants are exempt from RPT001
+ * (their contract can travel via the controller).
+ */
+function checkReportDpShape(code: string): ValidationViolation[] {
+  const masked = maskStringsAndComments(code);
+  const extendsMatch = masked.match(/\bextends\s+(SRSReportDataProvider(?:Base|PreProcess(?:TempDB)?))\b/i);
+  if (!extendsMatch) return [];
+  const violations: ValidationViolation[] = [];
+  const isPreProcess = /PreProcess/i.test(extendsMatch[1]);
+
+  if (!isPreProcess
+      && /\bparmDataContract\s*\(/i.test(masked)
+      && !/SRSReportParameterAttribute/i.test(code)) {
+    violations.push({
+      rule: 'RPT001',
+      severity: 'error',
+      line: lineNumber(code, masked.search(/\bparmDataContract\s*\(/i)),
+      excerpt: 'parmDataContract() without [SRSReportParameterAttribute]',
+      fix:
+        'The DP reads parmDataContract() but declares no contract — add ' +
+        '[SRSReportParameterAttribute(classStr(MyContract))] on the DP class, or the dialog values never reach processReport(). ' +
+        'Compiles clean, fails at report run time.',
+    });
+  }
+
+  if (/\bprocessReport\s*\(/i.test(masked) && !/SRSReportDataSetAttribute/i.test(code)) {
+    violations.push({
+      rule: 'RPT002',
+      severity: 'warning',
+      line: lineNumber(code, masked.search(/\bprocessReport\s*\(/i)),
+      excerpt: 'processReport() without any [SRSReportDataSetAttribute] getter',
+      fix:
+        'SSRS reads report data through [SRSReportDataSetAttribute(tableStr(MyTmp))] getter methods — without one this DP ' +
+        'fills a table nothing reads. Add the getter (returns the tmp buffer after select * from it), or ignore if the ' +
+        'getters live in a separate partial listing.',
+    });
+  }
+  return violations;
+}
+
+// AxReport XML rules (codeType="xml-report")
+
+/** RPT101 — AxReport without a design node. */
+function checkReportHasDesign(code: string): ValidationViolation[] {
+  if (!/<AxReport[\s>]/i.test(code)) return [];
+  if (/<AxReportDesign\b/i.test(code)) return [];
+  return [{
+    rule: 'RPT101',
+    severity: 'error',
+    excerpt: '<AxReport> — no <AxReportDesign>',
+    fix:
+      'The report declares no design — ssrsReportStr(report, design) can never reference it and the report cannot run. ' +
+      'Scaffolded reports carry one precision design named "Report" (generate_object(mode="scaffold", objectType="report")).',
+  }];
+}
+
+/** RPT102 — report dataset without a Query. */
+function checkReportDatasetShape(code: string): ValidationViolation[] {
+  if (!/<AxReport[\s>]/i.test(code)) return [];
+  const violations: ValidationViolation[] = [];
+  const dsRe = /<AxReportDataSet\b[\s\S]*?<\/AxReportDataSet>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = dsRe.exec(code)) !== null) {
+    if (/<Query>/i.test(m[0])) continue;
+    violations.push({
+      rule: 'RPT102',
+      severity: 'warning',
+      line: lineNumber(code, m.index),
+      excerpt: '<AxReportDataSet> without <Query>',
+      fix:
+        'A ReportDataProvider dataset needs <Query>SELECT * FROM DPClass.TmpTable</Query> (with ' +
+        '<DataSourceType>ReportDataProvider</DataSourceType>) — without it the dataset is empty at run time.',
+    });
+  }
+  return violations;
+}
+
 // Data-driven property rules (XML002-XML005)
 
 /**
@@ -1110,6 +1382,17 @@ const XPP_RULES = [
   checkGenericDocComment,
   checkUnbalancedTts,
   checkDevArtifacts,
+  checkCSharpIsms,
+  checkCatchInsideTts,
+  checkUnguardedRetry,
+  checkIndexHint,
+  checkForeignJoinSyntax,
+  checkReportDpShape,
+];
+
+const REPORT_XML_RULES = [
+  checkReportHasDesign,
+  checkReportDatasetShape,
 ];
 
 /**
@@ -1232,12 +1515,18 @@ const XML_PROPERTY_RULES = [
 
 export function runRules(
   code: string,
-  codeType: 'xpp' | 'xml-table' | 'xml-any',
+  codeType: 'xpp' | 'xml-table' | 'xml-any' | 'xml-report',
   stats?: PropertyStatsProvider,
 ): ValidationViolation[] {
   const violations: ValidationViolation[] = [];
   if (codeType === 'xpp') {
     for (const rule of XPP_RULES) {
+      violations.push(...rule(code));
+    }
+  } else if (codeType === 'xml-report') {
+    // AxReport XML embeds RDL in CDATA — running the X++ keyword rules over it
+    // would only produce noise, so the report document gets its own rule set.
+    for (const rule of REPORT_XML_RULES) {
       violations.push(...rule(code));
     }
   } else if (codeType === 'xml-table') {

--- a/src/tools/knowledge/getReportPatterns.ts
+++ b/src/tools/knowledge/getReportPatterns.ts
@@ -1,0 +1,40 @@
+/**
+ * object_patterns(domain="report") handler.
+ *
+ * list (no pattern) → one-line overview of every recipe;
+ * pattern=<id|alias> → full spec (roster, scaffold call, method notes, checks).
+ * Pure catalog — no index/DB access, mirrors the shape of getFormPatterns.
+ */
+
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+import {
+  listReportPatterns,
+  renderReportPatternList,
+  renderReportPatternSpec,
+  resolveReportPattern,
+} from '../../knowledge/reportPatterns/index.js';
+
+export async function getReportPatternsTool(request: CallToolRequest) {
+  const a = (request.params.arguments ?? {}) as Record<string, any>;
+  const requested = a.pattern ?? a.reportPattern;
+
+  if (requested === undefined || requested === null || requested === '') {
+    return { content: [{ type: 'text' as const, text: renderReportPatternList() }] };
+  }
+
+  const spec = resolveReportPattern(String(requested));
+  if (!spec) {
+    const ids = listReportPatterns().map(p => p.id).join(', ');
+    return {
+      content: [{
+        type: 'text' as const,
+        text:
+          `❌ Unknown report pattern "${requested}". Available: ${ids}.\n` +
+          `Call object_patterns(domain="report") without a pattern for the overview.`,
+      }],
+      isError: true,
+    };
+  }
+
+  return { content: [{ type: 'text' as const, text: renderReportPatternSpec(spec) }] };
+}

--- a/src/tools/knowledge/objectPatterns.ts
+++ b/src/tools/knowledge/objectPatterns.ts
@@ -15,7 +15,9 @@ import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { XppServerContext } from '../../types/context.js';
 import { getTablePatternsTool } from './getTablePatterns.js';
 import { formPatternTool } from './formPattern.js';
+import { getReportPatternsTool } from './getReportPatterns.js';
 import { resolvePatternExact } from '../../knowledge/formPatterns/index.js';
+import { resolveReportPattern } from '../../knowledge/reportPatterns/index.js';
 
 function err(text: string) {
   return { content: [{ type: 'text' as const, text }], isError: true };
@@ -35,16 +37,27 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
   // (exact, case-insensitive), so concept nouns like "number-sequence" still fall
   // through to the get_knowledge redirect below.
   let inferredPattern: string | undefined;
-  if (domain !== 'table' && domain !== 'form' && typeof aliasRaw === 'string') {
+  if (domain !== 'table' && domain !== 'form' && domain !== 'report' && typeof aliasRaw === 'string') {
     const spec = resolvePatternExact(aliasRaw);
     if (spec) {
       inferredPattern = spec.xmlName;
       domain = 'form';
+    } else if (resolveReportPattern(aliasRaw)) {
+      // A report pattern id (e.g. "PrintMgmtFormLetter") passed as the domain.
+      inferredPattern = aliasRaw;
+      domain = 'report';
     }
   }
 
+  // A pattern name that only the report catalog recognizes routes to it even
+  // when the caller said nothing about domains.
+  if (domain !== 'table' && domain !== 'form' && domain !== 'report'
+      && typeof a.pattern === 'string' && !resolvePatternExact(a.pattern) && resolveReportPattern(a.pattern)) {
+    domain = 'report';
+  }
+
   // Infer the discriminator from form/table-specific params when omitted.
-  if (domain !== 'table' && domain !== 'form') {
+  if (domain !== 'table' && domain !== 'form' && domain !== 'report') {
     const formSignals = ['action', 'pattern', 'recommend', 'formPattern', 'similarTo', 'dataSource', 'xml', 'formName'];
     const tableSignals = ['tableGroup'];
     if (formSignals.some(k => a[k] !== undefined)) {
@@ -56,6 +69,13 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
 
   if (domain === 'table') {
     return getTablePatternsTool(request, context);
+  }
+
+  if (domain === 'report') {
+    const reportRequest: CallToolRequest = inferredPattern !== undefined && a.pattern === undefined
+      ? { ...request, params: { ...request.params, arguments: { ...a, pattern: inferredPattern } } }
+      : request;
+    return getReportPatternsTool(reportRequest);
   }
 
   if (domain === 'form') {
@@ -80,8 +100,9 @@ export async function objectPatternsTool(request: CallToolRequest, context: XppS
   const got = a.domain ?? a.patternType ?? a.type ?? a.objectType ?? '';
   return err(
     `object_patterns: could not determine domain (got domain/objectType="${got}"). ` +
-    `This tool only covers table and form patterns — pass domain="table" (table field/index/relation patterns) ` +
-    `or domain="form" (form-pattern toolkit; with action=analyze|spec|validate). ` +
+    `This tool covers table, form and report patterns — pass domain="table" (field/index/relation patterns), ` +
+    `domain="form" (form-pattern toolkit; with action=analyze|spec|validate) ` +
+    `or domain="report" (SSRS implementation recipes; optional pattern=<id>). ` +
     `Domain is also inferred from action/pattern/xml/formName (→ form) or tableGroup (→ table).\n\n` +
     `If you were after a feature/concept (e.g. "number-sequence", SysOperation, RunBase, data events), ` +
     `that is a knowledge topic — use get_knowledge(topic="${typeof got === 'string' && got ? got : '<topic>'}") instead.`,

--- a/src/tools/knowledge/xppKnowledge.ts
+++ b/src/tools/knowledge/xppKnowledge.ts
@@ -1291,8 +1291,10 @@ while select crosscompany : companies
       'To open the Print management setup: go to Accounts receivable → Setup → Print management',
       'For new document types: also add an entry in PrintMgmtReportFormat (links document type to report design)',
       'Original vs copy: the base enum is PrintCopyOriginal (Original/Copy), carried on the report contract as parmPrintCopyOriginal() — there is no PrintCopyType enum or parmPrintCopyType()',
+      'Wiring a NEW document type to its report happens through the delegate subscriptions on PrintMgmtDocType — getDefaultReportFormatDelegate answers with the report design reference, getQueryTableIdDelegate with the driving table — plus the module\'s PrintMgmtNode subclass so the type appears in the setup tree',
+      'Scaffold the controller side with generate_object(mode="scaffold", objectType="report", controllerType="printMgmt") — then replace the scaffolded parmPrintMgmtDocType placeholder with the real document type',
     ],
-    related: ['ssrs-reports'],
+    related: ['ssrs-reports', 'ssrs-contracts'],
   },
 
   // ── Unit Testing ─────────────────────────────────────────────────────────
@@ -1713,6 +1715,8 @@ MySalesConfirmedBusinessEvent::newFromContract(contract).send();`,
       'ER classes ARE extensible by CoC (ERParameters, ERInvoicingServiceParameters and others carry class extensions); what cannot be edited in code is the configuration, not the framework',
       'ER format file path: System administration > Electronic reporting > Reporting configurations',
       'Country-specific ER formats loaded via localization features — check ERSolutionRepositoryTable',
+      'Choosing the technology: SSRS (RDP) for interactive/analytical documents and print-management output; ER for regulatory and localizable FILES (XML, JSON, TEXT, SEPA, VAT) and formats customers reconfigure without deployment; Business document management (Word/Excel templates on ER) when power users should edit document layouts themselves',
+      'SSRS platform notes (2024-26): custom code/assemblies in report properties are unsupported in the cloud service, and embedded drill-through links in service-rendered documents were removed — keep new designs free of both',
     ],
     examples: [
       {
@@ -1908,7 +1912,66 @@ public class MyReportDP extends SrsReportDataProviderBase
 }`,
       },
     ],
-    related: ['temp-tables', 'sysoperation', 'print-management'],
+    related: ['temp-tables', 'sysoperation', 'print-management', 'ssrs-contracts', 'ssrs-rdp-preprocess', 'ssrs-ui-builder'],
+  },
+  {
+    id: 'ssrs-contracts',
+    title: 'SSRS Contract Taxonomy (RDP / RDL / print / composite)',
+    keywords: ['report contract', 'rdl contract', 'print settings', 'print destination', 'srsprintdestinationsettings',
+               'srsreportdatacontract', 'parmreportcontract', 'composite contract', 'report parameters'],
+    summary:
+      'Four contract kinds meet in one report run: the RDP contract (your DataContractAttribute class), the RDL ' +
+      'contract (design-level parameters), the print contract (destination/format/copies) and the COMPOSITE that ' +
+      'aggregates them for the controller. Mutate the parts — never replace the composite.',
+    rules: [
+      'RDP contract: your DataContractAttribute-decorated class with DataMemberAttribute parm methods — the one your DP reads via parmDataContract(); nested contracts are supported (a parm method returning another contract)',
+      'RDL contract (SrsReportRdlDataContract): parameters modeled in the report DESIGN (query ranges, company, language) — set them in controller overrides, do not subclass it',
+      'Print contract (SRSPrintDestinationSettings): destination medium, file format, printer, copies, orientation — reachable as parmPrintSettings() on the composite',
+      'Composite (SrsReportDataContract): aggregates RDP + RDL + print + query contracts; the controller hands it out via parmReportContract() — MUTATE its parts, never assign a new composite',
+      'Controller override points: prePromptModifyContract (before the dialog — pre-fill from args.record()), preRunModifyContract (after OK, before render — company/language/print defaults)',
+      '"Print straight to PDF/file": in preRunModifyContract fetch parmPrintSettings(), set the file medium + format + fileName, and run with controller.parmShowDialog(false) when no dialog is wanted',
+      'Dialog persistence is automatic: parameter values round-trip via SysLastValue per user+report — no code needed',
+      'Mandatory parameters: enforce in the RDP contract validate() with checkFailed — a false blocks the dialog OK (there is no per-parameter mandatory attribute)',
+    ],
+    related: ['ssrs-reports', 'sysoperation', 'ssrs-ui-builder', 'print-management'],
+  },
+  {
+    id: 'ssrs-rdp-preprocess',
+    title: 'Pre-Processed Report Data Providers (long-running reports)',
+    keywords: ['preprocess', 'pre-process', 'long running report', 'report timeout', 'srsreportdataproviderpreprocess',
+               'createdtransactionid', 'staging', 'report performance'],
+    summary:
+      'Interactive SSRS rendering times out around 10 minutes — a DP whose processReport() runs longer must stage ' +
+      'its data BEFORE the render request via a pre-processed base class.',
+    rules: [
+      'Trigger: the report times out interactively but the same query succeeds in batch, or processReport() takes minutes on production volumes',
+      'Two staging bases: SrsReportDataProviderPreProcess (stages into a REGULAR table whose rows are keyed by createdTransactionId) and SrsReportDataProviderPreProcessTempDB (stages into TempDB tables)',
+      'Regular-table staging: the staging table needs a createdTransactionId column; the platform deletes the rows after rendering, and concurrent runs are isolated by transaction id',
+      'Migration from a plain DP: swap the base class, adjust the staging table type to match it, keep the SRSReportDataSetAttribute getters unchanged, and make sure the menu item points at the CONTROLLER',
+      'Scaffold: generate_object(mode="scaffold", objectType="report", preProcess=true) — emits the PreProcess base and a preProcess() stub. NOTE: this pairing is not yet compile-proven by the repo\'s eval goldens — build on the VM before trusting the generated shape',
+      'Do NOT default to preprocess — the staging machinery costs complexity; profile processReport() first and try set-based population (insert_recordset) before reaching for it',
+    ],
+    related: ['ssrs-reports', 'temp-tables', 'transactions'],
+  },
+  {
+    id: 'ssrs-ui-builder',
+    title: 'Report Dialog UI Builders (SrsReportDataContractUIBuilder)',
+    keywords: ['ui builder', 'uibuilder', 'report dialog', 'dialog field', 'custom lookup', 'sysoperationcontractprocessing',
+               'srsreportdatacontractuibuilder', 'dialog customization', 'dependent fields'],
+    summary:
+      'A UI builder customizes the report parameter dialog — filtered lookups, dependent fields, field events. ' +
+      'It derives from SrsReportDataContractUIBuilder and is bound on the CONTRACT via the ' +
+      'SysOperationContractProcessing attribute.',
+    rules: [
+      'The builder class derives from SrsReportDataContractUIBuilder; the CONTRACT declares it via the SysOperationContractProcessing attribute naming the builder class — the controller needs no change',
+      'Override build(): call super() FIRST, then fetch fields with this.bindInfo().getDialogField(contractInstance, the parm method) and attach behaviour',
+      'Custom lookup / events: dialogField.registerOverrideMethod binds a FormControl event to a method ON THE BUILDER (FormStringControl-style signature)',
+      'Dependent fields: react in one field\'s modified override, then enable/disable or re-filter the other via its DialogField',
+      'The automatic dialog needs NO builder — plain parameters render themselves; reach for a builder only for filtered lookups, cascading fields, or layout beyond group attributes',
+      'Scaffold: generate_object(mode="scaffold", objectType="report", uiBuilder=true) emits the builder class and binds it on the contract',
+      'Identical mechanics drive SysOperation dialogs (SysOperationAutomaticUIBuilder base) — see sysoperation',
+    ],
+    related: ['ssrs-reports', 'ssrs-contracts', 'sysoperation', 'form-patterns'],
   },
 
   // ── Inventory Management ────────────────────────────────────────────────

--- a/src/tools/readers/edtInfo.ts
+++ b/src/tools/readers/edtInfo.ts
@@ -144,7 +144,15 @@ function getEdtFromIndex(symbolIndex: any, edtName: string, modelName?: string) 
   if (row.enum_type) out += `| Enum Type | ${row.enum_type} |\n`;
   if (row.reference_table) out += `| Reference Table | ${row.reference_table} |\n`;
   if (row.relation_type) out += `| Relation Type | ${row.relation_type} |\n`;
-  if (row.string_size) out += `| String Size | ${row.string_size} |\n`;
+  // A derived EDT usually declares no StringSize, so `string_size` is null for 12 354 of
+  // the 25 332 indexed EDTs and this row used to be silently omitted for all of them.
+  // The value sits on the nearest ancestor that does declare one.
+  const size = resolveIndexedStringSize(db, row);
+  if (size) {
+    const from = size.inheritedFrom ? ` (inherited from ${size.inheritedFrom})` : '';
+    const shown = size.value === '-1' ? '-1 (memo, unlimited)' : size.value;
+    out += `| String Size | ${shown}${from} |\n`;
+  }
   if (row.database_string_size) out += `| Database String Size | ${row.database_string_size} |\n`;
   if (row.display_length) out += `| Display Length | ${row.display_length} |\n`;
   if (row.label) out += `| Label | ${row.label} |\n`;
@@ -152,6 +160,55 @@ function getEdtFromIndex(symbolIndex: any, edtName: string, modelName?: string) 
     `(HelpText, FormHelp, ConfigurationKey, Alignment…) are absent here, not absent from the EDT.\n`;
 
   return { content: [{ type: 'text', text: out }] };
+}
+
+/**
+ * The string size an indexed EDT really has, plus the ancestor it came from.
+ *
+ * A derived EDT usually declares no StringSize, leaving `edt_metadata.string_size` empty for
+ * 12 354 of the 25 332 indexed EDTs -- and this row used to be omitted for all of them even
+ * though the value sits an `extends` hop or two away. So: use the EDT's own size when it has
+ * one, otherwise walk `extends` to the nearest ancestor that stores one. Guards against a
+ * cycle and against a dangling `extends` (AmountMST names MoneyMST, which ships no AxEdt
+ * file).
+ *
+ * A child MAY declare its own size -- 228 do, permitted when the base carries
+ * StringSizeIsExtensible = Yes -- so a stored value is authoritative here and is not
+ * overridden.
+ *
+ * Known limitation of this path: `edt_metadata` does not store StringSizeIsExtensible, so it
+ * cannot tell when a declared size is overridden by an ancestor's. Where StringSizeIsExtensible
+ * is not Yes and the declared value is smaller than the nearest declaring ancestor's, the
+ * platform uses the ancestor's -- PartyName declares 100 under DirPartyName's 160 and really is
+ * 160, and this path reports the declared 100. That affects 4 EDTs in the shipped corpus, and
+ * only here: the bridge, which is the normal source, defers to Microsoft's resolver.
+ */
+function resolveIndexedStringSize(
+  db: any,
+  row: any,
+): { value: string; inheritedFrom?: string } | null {
+  if (row.string_size) return { value: String(row.string_size) };
+
+  const seen = new Set<string>([String(row.edt_name ?? '').toLowerCase()]);
+  let next: string | undefined = row.extends || undefined;
+
+  while (next && !seen.has(next.toLowerCase())) {
+    seen.add(next.toLowerCase());
+    let ancestor: any;
+    try {
+      ancestor = db.prepare(
+        'SELECT edt_name, extends, string_size FROM edt_metadata WHERE edt_name = ? LIMIT 1',
+      ).get(next);
+    } catch {
+      return null;
+    }
+    if (!ancestor) return null;
+    if (ancestor.string_size) {
+      return { value: String(ancestor.string_size), inheritedFrom: ancestor.edt_name };
+    }
+    next = ancestor.extends || undefined;
+  }
+  return null;
 }
 
 /** True when edt_metadata holds a row for exactly this spelling. */

--- a/src/tools/readers/edtInfo.ts
+++ b/src/tools/readers/edtInfo.ts
@@ -168,9 +168,8 @@ function getEdtFromIndex(symbolIndex: any, edtName: string, modelName?: string) 
  * A derived EDT usually declares no StringSize, leaving `edt_metadata.string_size` empty for
  * 12 354 of the 25 332 indexed EDTs -- and this row used to be omitted for all of them even
  * though the value sits an `extends` hop or two away. So: use the EDT's own size when it has
- * one, otherwise walk `extends` to the nearest ancestor that stores one. Guards against a
- * cycle and against a dangling `extends` (AmountMST names MoneyMST, which ships no AxEdt
- * file).
+ * one, otherwise walk `extends` to the nearest ancestor that stores one. The walk itself, with
+ * its cycle and dangling-`extends` guards, is `walkEdtChain`, shared with hierarchy mode.
  *
  * A child MAY declare its own size -- 228 do, permitted when the base carries
  * StringSizeIsExtensible = Yes -- so a stored value is authoritative here and is not
@@ -190,25 +189,55 @@ function resolveIndexedStringSize(
   if (row.string_size) return { value: String(row.string_size) };
 
   const seen = new Set<string>([String(row.edt_name ?? '').toLowerCase()]);
-  let next: string | undefined = row.extends || undefined;
-
-  while (next && !seen.has(next.toLowerCase())) {
-    seen.add(next.toLowerCase());
-    let ancestor: any;
-    try {
-      ancestor = db.prepare(
-        'SELECT edt_name, extends, string_size FROM edt_metadata WHERE edt_name = ? LIMIT 1',
-      ).get(next);
-    } catch {
-      return null;
-    }
-    if (!ancestor) return null;
+  for (const ancestor of walkEdtChain(db, row.extends, { seen })) {
     if (ancestor.string_size) {
       return { value: String(ancestor.string_size), inheritedFrom: ancestor.edt_name };
     }
-    next = ancestor.extends || undefined;
   }
   return null;
+}
+
+/**
+ * Yields the `edt_metadata` row for `startName` and then each `extends` ancestor in turn.
+ *
+ * Both modes of this tool walk the same chain over the same table with the same two stop
+ * conditions — a dangling `extends` (AmountMST names MoneyMST, which ships no AxEdt file) and a
+ * name already seen, so a metadata cycle cannot spin — so they walk it through here rather than
+ * each keeping their own copy of those rules.
+ *
+ * `modelName` filters the START row only. Ancestors are looked up across every model on purpose:
+ * a child in an ISV model almost always extends something in ApplicationPlatform or Foundation,
+ * and carrying the filter up the chain would cut it at the first hop and report the child as a
+ * root. Names are compared case-insensitively because X++ identifiers are.
+ */
+function* walkEdtChain(
+  db: any,
+  startName: string | undefined | null,
+  opts: { modelName?: string; seen?: Set<string> } = {},
+): Generator<any> {
+  const seen = opts.seen ?? new Set<string>();
+  let next: string | undefined = startName || undefined;
+  let first = true;
+
+  while (next && !seen.has(next.toLowerCase())) {
+    seen.add(next.toLowerCase());
+    const useModel = first ? opts.modelName : undefined;
+    first = false;
+
+    let row: any;
+    try {
+      row = db.prepare(
+        `SELECT edt_name, model, extends, label, string_size FROM edt_metadata
+          WHERE edt_name = ?${useModel ? ' AND model = ?' : ''} LIMIT 1`,
+      ).get(...(useModel ? [next, useModel] : [next]));
+    } catch {
+      return;
+    }
+    if (!row) return;
+
+    yield row;
+    next = row.extends || undefined;
+  }
 }
 
 /** True when edt_metadata holds a row for exactly this spelling. */
@@ -283,23 +312,11 @@ function getEdtHierarchy(db: any, edtName: string, modelName?: string) {
     ? edtName
     : (canonicalSymbolName(db, edtName, ['edt']) ?? edtName);
 
-  // Ancestor chain walk
+  // Ancestor chain walk — shared with basic mode's string-size resolution, so both modes stop
+  // on the same dangling `extends` and the same cycle, and agree on what the chain is.
   const chain: Array<{ name: string; model: string; extends?: string; label?: string; stringSize?: string }> = [];
-  let current = startName;
-  const visited = new Set<string>();
-
-  while (current && !visited.has(current)) {
-    visited.add(current);
-    const row = db.prepare(`
-      SELECT edt_name, model, extends, label, string_size
-      FROM edt_metadata WHERE edt_name = ?
-      ${modelName ? 'AND model = ?' : ''}
-      LIMIT 1
-    `).get(...(modelName ? [current, modelName] : [current])) as any;
-
-    if (!row) break;
+  for (const row of walkEdtChain(db, startName, { modelName })) {
     chain.push({ name: row.edt_name, model: row.model, extends: row.extends, label: row.label, stringSize: row.string_size });
-    current = row.extends;
   }
 
   if (chain.length === 0) {
@@ -326,6 +343,20 @@ function getEdtHierarchy(db: any, edtName: string, modelName?: string) {
     if (e.stringSize) output += `, StringSize: ${e.stringSize}`;
     if (e.extends) output += ` [extends ${e.extends}]`;
     output += '\n';
+  }
+
+  // The per-level StringSize above is only what each level DECLARES, so the queried EDT — which
+  // usually declares nothing — showed no size at all while basic mode reported the inherited
+  // one. Same resolution, same answer, stated once.
+  const effective = resolveIndexedStringSize(db, {
+    edt_name: chain[0].name,
+    extends: chain[0].extends,
+    string_size: chain[0].stringSize,
+  });
+  if (effective) {
+    const from = effective.inheritedFrom ? ` (inherited from ${effective.inheritedFrom})` : '';
+    const shown = effective.value === '-1' ? '-1 (memo, unlimited)' : effective.value;
+    output += `\nEffective String Size: ${shown}${from}\n`;
   }
 
   // Children

--- a/src/tools/smart/generateSmartReport.ts
+++ b/src/tools/smart/generateSmartReport.ts
@@ -94,6 +94,8 @@ interface GenerateSmartReportArgs {
   preProcess?: boolean;
   /** Controller variant: "simple" (SrsReportRunController) or "printMgmt" (SrsPrintMgmtController) */
   controllerType?: 'simple' | 'printMgmt';
+  /** When true, also emits a <Name>UIBuilder class bound on the Contract via [SysOperationContractProcessing] */
+  uiBuilder?: boolean;
   /** Additional datasets — each generates an extra TmpTable (TempDB) and a get<Table>() method in the DP */
   additionalDatasets?: Array<{ name: string; fieldsHint?: string; fields?: ReportFieldSpec[] }>;
   /** Model name (auto-detected from projectPath) */
@@ -129,6 +131,7 @@ Strategies:
 - callerTableName: pre-fill contract from args.record() in prePromptModifyContract()
 - controllerType: "simple" (default) or "printMgmt" (SrsPrintMgmtController)
 - preProcess: true → SrsReportDataProviderPreProcess with preProcess() stub
+- uiBuilder: true → <Name>UIBuilder class bound via [SysOperationContractProcessing]
 - additionalDatasets: extra TmpTables + DP getters for multi-dataset reports
 
 Examples:
@@ -226,6 +229,10 @@ Examples:
         type: 'string',
         description: '"simple" (default — SrsReportRunController) or "printMgmt" (SrsPrintMgmtController with parmPrintMgmtDocType). Only relevant when generateController=true.',
       },
+      uiBuilder: {
+        type: 'boolean',
+        description: 'When true, also generates <Name>UIBuilder (extends SrsReportDataContractUIBuilder) and binds it on the Contract via [SysOperationContractProcessing] — for custom dialog lookups/field events.',
+      },
       additionalDatasets: {
         type: 'array',
         description: 'Extra datasets. Each entry generates an additional TmpTable (TempDB) and a corresponding get<Table>() method in the DP.',
@@ -265,6 +272,7 @@ export async function handleGenerateSmartReport(
     callerTableName,
     preProcess = false,
     controllerType = 'simple',
+    uiBuilder = false,
     additionalDatasets = [],
     modelName,
     projectPath,
@@ -345,6 +353,7 @@ export async function handleGenerateSmartReport(
   const contractClassName = `${finalName}Contract`;
   const dpClassName = `${finalName}DP`;
   const controllerClassName = `${finalName}Controller`;
+  const uiBuilderClassName = `${finalName}UIBuilder`;
   const reportCaption = caption || finalName;
 
   // Only decorate a plain-text caption with the suffix; appending to a label
@@ -632,12 +641,17 @@ export async function handleGenerateSmartReport(
     `    }`,
   ].join('\n') : '';
 
+  // With a UI builder the contract binds it via SysOperationContractProcessing.
+  const contractClassAttr = uiBuilder
+    ? `[\n    DataContractAttribute,\n    SysOperationContractProcessing(classStr(${uiBuilderClassName}))\n]`
+    : `[DataContractAttribute]`;
+
   const contractSourceCode = [
     `/// <summary>`,
     `/// Data contract for the ${reportCaption} report.`,
     `/// Defines dialog parameters shown to the user before report execution.`,
     `/// </summary>`,
-    `[DataContractAttribute]`,
+    contractClassAttr,
     `public class ${contractClassName}`,
     `{`,
     contractMemberDecls || '    // No dialog parameters',
@@ -659,6 +673,48 @@ export async function handleGenerateSmartReport(
     content: contractXml,
   });
   log(`Generated Contract: ${contractClassName} (${contractParms.length} params)`);
+
+  // 2b. UI builder class (optional) — custom dialog behaviour for the contract
+  if (uiBuilder) {
+    const exampleParm = contractParms[0]
+      ? `parm${contractParms[0].name.charAt(0).toUpperCase()}${contractParms[0].name.slice(1)}`
+      : 'parmMyParameter';
+    const uiBuilderSourceCode = [
+      `/// <summary>`,
+      `/// UI builder for the ${reportCaption} report dialog.`,
+      `/// Customizes dialog fields (lookups, dependent fields, events).`,
+      `/// </summary>`,
+      `public class ${uiBuilderClassName} extends SrsReportDataContractUIBuilder`,
+      `{`,
+      `}`,
+      ``,
+      `    /// <summary>`,
+      `    /// Builds the dialog and customizes its fields.`,
+      `    /// </summary>`,
+      `    public void build()`,
+      `    {`,
+      `        super();`,
+      ``,
+      `        // TODO: customize dialog fields, e.g.:`,
+      `        // ${contractClassName} contract = this.dataContractObject() as ${contractClassName};`,
+      `        // DialogField df = this.bindInfo().getDialogField(contract, methodStr(${contractClassName}, ${exampleParm}));`,
+      `        // df.registerOverrideMethod(methodStr(FormStringControl, lookup), methodStr(${uiBuilderClassName}, myParameterLookup), this);`,
+      `    }`,
+    ].join('\n');
+
+    const uiBuilderXml = XmlTemplateGenerator.generateAxClassXml(
+      uiBuilderClassName,
+      uiBuilderSourceCode
+    );
+
+    generatedObjects.push({
+      objectType: 'class',
+      objectName: uiBuilderClassName,
+      aotFolder: 'AxClass',
+      content: uiBuilderXml,
+    });
+    log(`Generated UI builder: ${uiBuilderClassName}`);
+  }
 
   // ──────────────────────────────────────────────────────────────────────────
   // 3. DP class (Data Provider)

--- a/src/tools/specs/generateObjectOpSpecs.ts
+++ b/src/tools/specs/generateObjectOpSpecs.ts
@@ -120,6 +120,26 @@ export const GENERATE_OBJECT_PARAM_SPECS: Record<string, { type: string; descrip
       '("Header" → <Report>HeaderTmp).',
   },
   generateController: { type: 'boolean', description: 'Generate the Controller class (default: true).' },
+  aotQuery: {
+    type: 'string',
+    description: 'AOT query name — DP gains [SRSReportQueryAttribute] and a query-based processReport() via this.parmQuery().',
+  },
+  callerTableName: {
+    type: 'string',
+    description: 'Caller record table (e.g. "CustTable") — Controller pre-fills the contract from args.record() in prePromptModifyContract().',
+  },
+  preProcess: {
+    type: 'boolean',
+    description: 'DP extends SrsReportDataProviderPreProcess (long-running reports; preProcess() stub, contract via Controller instead of [SRSReportParameterAttribute]).',
+  },
+  controllerType: {
+    type: 'string',
+    description: '"simple" (default — SrsReportRunController) or "printMgmt" (SrsPrintMgmtController + parmPrintMgmtDocType placeholder).',
+  },
+  uiBuilder: {
+    type: 'boolean',
+    description: 'Also emit a <Name>UIBuilder class (extends SrsReportDataContractUIBuilder) and bind it on the contract via [SysOperationContractProcessing] — for custom dialog lookups/events.',
+  },
   designStyle: {
     type: 'string',
     description: 'RDL design pattern: "SimpleList" (default) or "GroupedWithTotals".',
@@ -197,7 +217,9 @@ export const GENERATE_OBJECT_MODE_SPECS: Record<string, GenerateObjectModeSpec> 
     optional: [
       'caption', 'packagePath', 'fields', 'fieldsHint', 'contractParams', 'additionalDatasets',
       'generateController', 'designStyle', 'copyFrom', 'modelName', 'projectPath', 'solutionPath',
+      'aotQuery', 'callerTableName', 'preProcess', 'controllerType', 'uiBuilder',
     ],
+    note: 'Pattern recipes (roster + when-to-use): object_patterns(domain="report").',
   },
   'find-methods': {
     required: ['name'],

--- a/src/tools/write/directXmlWriters.ts
+++ b/src/tools/write/directXmlWriters.ts
@@ -606,7 +606,7 @@ function maskXmlNonMarkup(content: string): string {
  * of the one that was asked for — valid XML, different query.
  */
 function findDirectChild(block: string, childName: string): DirectChild | null {
-  const openTag = new RegExp(`^<[A-Za-z_][\\w.-]*(?:"[^"]*"|'[^']*'|[^>"'])*?>`).exec(block);
+  const openTag = /^<[A-Za-z_][\w.-]*(?:"[^"]*"|'[^']*'|[^>"'])*?>/.exec(block);
   if (!openTag) return null;
 
   const tagRe = new RegExp(XML_TAG_SOURCE, 'g');

--- a/src/tools/write/resolveReferences.ts
+++ b/src/tools/write/resolveReferences.ts
@@ -230,6 +230,16 @@ const INTRINSIC_TARGET_TYPES: Record<string, string[] | null> = {
   menuitemoutputstr: null,
   tilestr: null,
   resourcestr: null,
+  reportstr: ['report'],
+  // 2nd argument is the DESIGN name inside the report — not an indexed symbol,
+  // so only the report itself is resolved here (design existence is a build check).
+  ssrsreportstr: ['report'],
+  delegatestr: ['class', 'table', 'form', 'class-extension'],
+  staticdelegatestr: ['class', 'table', 'form', 'class-extension'],
+  attributestr: ['class', 'class-extension'],
+  indexstr: ['table', 'view', 'data-entity', 'table-extension'],
+  tablemethodstr: ['table', 'view', 'map', 'data-entity', 'table-extension'],
+  tablestaticmethodstr: ['table', 'view', 'map', 'data-entity', 'table-extension'],
 };
 
 interface CleanedCode {

--- a/src/utils/objectNamingRules.ts
+++ b/src/utils/objectNamingRules.ts
@@ -407,6 +407,23 @@ export async function checkObjectNaming(
           suggestions.push(`Data entity name: ${name}Entity`);
         }
       }
+
+      if (args.objectType === 'report') {
+        // The AxReport name itself carries no suffix; what matters is that the
+        // companion classes follow the role-suffix convention, so hand the full
+        // roster to the caller in one place.
+        if (/(DP|Contract|Controller|UIBuilder|Tmp)$/.test(name)) {
+          warnings.push(
+            `"${name}" ends with a report COMPANION-class suffix — the AxReport itself is normally the bare document name ` +
+            `(the suffixed names belong to its classes/table).`,
+          );
+        }
+        suggestions.push(
+          `SSRS companion objects for "${name}": ${name}Tmp (TempDB table), ${name}Contract, ${name}DP, ` +
+          `${name}Controller, ${name}UIBuilder (optional), plus an AxMenuItemOutput named ${name}. ` +
+          `generate_object(mode="scaffold", objectType="report") emits the full roster.`,
+        );
+      }
     }
 
     // The model's own naming and EXTENSION_PREFIX disagree. Reported wherever the

--- a/tests/knowledge/reportPatternCatalog.test.ts
+++ b/tests/knowledge/reportPatternCatalog.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Report-pattern catalog gates — the report-side counterpart of
+ * formPatternCatalog.test.ts. The catalog is served straight to the agent, so
+ * ids must be unique/resolvable, every relatedTopics id must be a real
+ * knowledge topic (a dangling id costs the agent a wasted round trip), and
+ * every scaffold line must reference the real generation call.
+ */
+import { describe, it, expect } from 'vitest';
+import { REPORT_PATTERN_CATALOG } from '../../src/knowledge/reportPatterns/catalog';
+import {
+  resolveReportPattern,
+  renderReportPatternList,
+  renderReportPatternSpec,
+} from '../../src/knowledge/reportPatterns/index';
+import { KNOWLEDGE_BASE } from '../../src/tools/knowledge/xppKnowledge';
+
+describe('report pattern catalog integrity', () => {
+  it('ids and aliases are unique (normalized)', () => {
+    const seen = new Set<string>();
+    for (const p of REPORT_PATTERN_CATALOG) {
+      for (const k of [p.id, ...(p.aliases ?? [])]) {
+        const norm = k.toLowerCase().replace(/[-_\s]/g, '');
+        expect(seen.has(norm), `duplicate pattern key "${k}"`).toBe(false);
+        seen.add(norm);
+      }
+    }
+  });
+
+  it('every relatedTopics id resolves to a real knowledge topic', () => {
+    const ids = new Set(KNOWLEDGE_BASE.map(e => e.id));
+    for (const p of REPORT_PATTERN_CATALOG) {
+      for (const t of p.relatedTopics ?? []) {
+        expect(ids.has(t), `${p.id} → dangling knowledge id "${t}"`).toBe(true);
+      }
+    }
+  });
+
+  it('every pattern has a scaffold line that references generate_object', () => {
+    for (const p of REPORT_PATTERN_CATALOG) {
+      expect(p.scaffold).toContain('generate_object(mode="scaffold", objectType="report"');
+      expect(p.objects.length).toBeGreaterThan(0);
+      expect(p.whenToUse.length).toBeGreaterThan(0);
+      expect(p.crossChecks.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolver matches ids and aliases case/separator-insensitively', () => {
+    expect(resolveReportPattern('SimpleList')?.id).toBe('SimpleList');
+    expect(resolveReportPattern('print-mgmt-form-letter')?.id).toBe('PrintMgmtFormLetter');
+    expect(resolveReportPattern('PREPROCESS')?.id).toBe('PreProcess');
+    expect(resolveReportPattern('ui builder')?.id).toBe('UIBuilderDialog');
+    expect(resolveReportPattern('nonsense')).toBeUndefined();
+  });
+
+  it('renderers include the roster and the scaffold call', () => {
+    const list = renderReportPatternList();
+    for (const p of REPORT_PATTERN_CATALOG) expect(list).toContain(p.id);
+
+    const spec = renderReportPatternSpec(REPORT_PATTERN_CATALOG[0]);
+    expect(spec).toContain('Objects:');
+    expect(spec).toContain('generate_object(mode="scaffold"');
+    expect(spec).toContain('Verify:');
+  });
+
+  it('the design-name invariant is stated (controller ↔ AxReport agreement)', () => {
+    // The Phase A bug (Design vs Report) must stay visible in the catalog.
+    const base = REPORT_PATTERN_CATALOG.find(p => p.id === 'SimpleList')!;
+    const roster = JSON.stringify(base.objects);
+    expect(roster).toContain('ssrsReportStr({Name}, Report)');
+  });
+});

--- a/tests/tools/edtStringSizeInheritance.test.ts
+++ b/tests/tools/edtStringSizeInheritance.test.ts
@@ -40,7 +40,7 @@ import { describe, it, expect, vi } from 'vitest';
 import Database from '../../src/database/sqlite.js';
 import { getEdtInfoTool } from '../../src/tools/readers/edtInfo';
 
-function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: string }>) {
+function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: string; model?: string }>) {
   const db = new Database(':memory:');
   db.exec(`
     CREATE TABLE edt_metadata (
@@ -59,9 +59,9 @@ function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: strin
     CREATE VIRTUAL TABLE symbols_fts USING fts5(name, type, parent_name, signature, description, tags);
   `);
   const insEdt = db.prepare(
-    `INSERT INTO edt_metadata (edt_name, extends, string_size, model) VALUES (?, ?, ?, 'Foundation')`,
+    `INSERT INTO edt_metadata (edt_name, extends, string_size, model) VALUES (?, ?, ?, ?)`,
   );
-  for (const r of rows) insEdt.run(r.name, r.extends ?? null, r.stringSize ?? null);
+  for (const r of rows) insEdt.run(r.name, r.extends ?? null, r.stringSize ?? null, r.model ?? 'Foundation');
   return db;
 }
 
@@ -234,5 +234,73 @@ describe('EDT StringSize inheritance — SQLite fallback path', () => {
 
     const out = text(await getEdtInfoTool(req('LoopA'), ctx(db, null)));
     expect(out).not.toContain('| String Size |');
+  });
+});
+
+/**
+ * Both modes answer out of the same table over the same `extends` chain, and used to walk it
+ * with two separate loops — so they could disagree about the same EDT. They now share
+ * `walkEdtChain`.
+ */
+describe('EDT StringSize inheritance — the two SQLite modes agree', () => {
+  const hierReq = (edtName: string, modelName?: string) => ({
+    method: 'tools/call' as const,
+    params: {
+      name: 'get_edt_info',
+      arguments: { edtName, mode: 'hierarchy', ...(modelName ? { modelName } : {}) },
+    },
+  });
+
+  it('states the inherited size in hierarchy mode, which used to show none', async () => {
+    // The per-level list only ever showed what each level DECLARES, so the EDT the caller
+    // actually asked about — which declares nothing — showed no size at all.
+    const rows = [
+      { name: 'AccountNumber_IN', extends: 'CustVendAC' },
+      { name: 'CustVendAC', extends: 'ExternalAccount' },
+      { name: 'ExternalAccount', stringSize: '20' },
+    ];
+
+    const hier = text(await getEdtInfoTool(hierReq('AccountNumber_IN'), ctx(makeDb(rows), null)));
+    expect(hier).toContain('Effective String Size: 20 (inherited from ExternalAccount)');
+
+    // …and it is the same number basic mode reports for the same EDT.
+    const basic = text(await getEdtInfoTool(req('AccountNumber_IN'), ctx(makeDb(rows), null)));
+    expect(basic).toContain('| String Size | 20 (inherited from ExternalAccount) |');
+  });
+
+  it('claims no inheritance in hierarchy mode when the EDT declares its own size', async () => {
+    const db = makeDb([
+      { name: 'InvoiceId', extends: 'Num', stringSize: '50' },
+      { name: 'Num', stringSize: '20' },
+    ]);
+
+    const out = text(await getEdtInfoTool(hierReq('InvoiceId'), ctx(db, null)));
+    expect(out).toContain('Effective String Size: 50');
+    expect(out).not.toContain('inherited from');
+  });
+
+  it('follows the chain into other models instead of cutting it at the first hop', async () => {
+    // A child in an ISV model extending a Microsoft one is the normal case, not the exotic one.
+    // modelName pins WHICH EDT the caller means; carrying it up the chain would end the walk at
+    // ExtendedName and report an ISV EDT as a root with no size.
+    const db = makeDb([
+      { name: 'ExtendedName', extends: 'DirPartyName', model: 'ISVModel' },
+      { name: 'DirPartyName', stringSize: '160', model: 'ApplicationPlatform' },
+    ]);
+
+    const out = text(await getEdtInfoTool(hierReq('ExtendedName', 'ISVModel'), ctx(db, null)));
+    expect(out).toContain('ExtendedName → DirPartyName');
+    expect(out).toContain('Effective String Size: 160 (inherited from DirPartyName)');
+  });
+
+  it('does not spin on a cycle in hierarchy mode either', async () => {
+    const db = makeDb([
+      { name: 'LoopA', extends: 'LoopB' },
+      { name: 'LoopB', extends: 'LoopA' },
+    ]);
+
+    const out = text(await getEdtInfoTool(hierReq('LoopA'), ctx(db, null)));
+    expect(out).toContain('Ancestor Chain (2 level(s))');
+    expect(out).not.toContain('Effective String Size');
   });
 });

--- a/tests/tools/edtStringSizeInheritance.test.ts
+++ b/tests/tools/edtStringSizeInheritance.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Reported 2026-08-27: `get_object_info(objectType="edt", name="ItemFreeTxt")` answered
+ * StringSize 10. The real size is 1000, inherited from ItemFreeTxtBase.
+ *
+ * Root cause: IMetadataProvider hands back an EDT exactly as its own XML declares it and does
+ * not fill in what it inherits. When a derived string EDT declares no StringSize, the instance
+ * reports the AxEdtString constructor default of 10. Verified against 10.0.2645: ItemFreeTxt
+ * read back as 10 (really 1000), ItemId and CustAccount as 10 (really 20), and 310 of 564
+ * string fields across ten core tables carried the same wrong number.
+ *
+ * What is NOT true — an earlier revision of this fix claimed it, on the strength of a
+ * validation-message identifier alone — is that a child EDT cannot declare StringSize. The
+ * message reads in full "StringSize cannot be set on child edt when StringSizeIsExtensible is
+ * not set to Yes", i.e. the prohibition is conditional, and 228 derived EDTs in the shipped
+ * corpus do declare their own size (InvoiceId declares 50 over Num's 20). A declared value is
+ * therefore authoritative and must survive.
+ *
+ * Nor does a declared size always win. Measured over the 182 derived EDTs that declare a size
+ * and have a declaring ancestor:
+ *   - StringSizeIsExtensible = Yes -> the declaration wins in either direction (InvoiceId 50
+ *     over Num's 20; CustInvoiceId 20 under InvoiceId's 50).
+ *   - Otherwise, a declared value SMALLER than the nearest declaring ancestor's loses to it.
+ *     Four EDTs corpus-wide: PartyName declares 100 under DirPartyName's 160 and is 160, plus
+ *     ITMJourneyId, TAMRebateInvoice, PSNPurchasingCardProviderName.
+ *   - Otherwise, a declared value LARGER than the ancestor's: no such EDT ships, so the
+ *     behaviour is unverified and nothing here assumes it.
+ *
+ * And `ResolveVirtualProperties`' isFlightEnabled flag matters. With true, CustInvoiceId reads
+ * 50 at EDT level while the field-level resolver says 20 for CustInvoiceJour.InvoiceId, typed
+ * with that same EDT. The bridge passes false so the two agree at 20.
+ *
+ * All of the above comes from the metamodel resolvers, which is the source the compiler uses
+ * but not an independent oracle; none of it was cross-checked against live SQL column widths.
+ *
+ * These tests cover the two Node-side halves: rendering the value with its provenance, and
+ * resolving the chain in the SQLite fallback that answers when the bridge is absent.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import Database from '../../src/database/sqlite.js';
+import { getEdtInfoTool } from '../../src/tools/readers/edtInfo';
+
+function makeDb(rows: Array<{ name: string; extends?: string; stringSize?: string }>) {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE edt_metadata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      edt_name TEXT NOT NULL, extends TEXT, enum_type TEXT, reference_table TEXT,
+      relation_type TEXT, string_size TEXT, database_string_size TEXT,
+      display_length TEXT, label TEXT, model TEXT NOT NULL
+    );
+    CREATE INDEX idx_edt_metadata_name ON edt_metadata(edt_name);
+    CREATE TABLE symbols (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL, type TEXT NOT NULL, parent_name TEXT,
+      signature TEXT, file_path TEXT, model TEXT, description TEXT, extends_class TEXT
+    );
+    CREATE INDEX idx_name_type ON symbols(name, type);
+    CREATE VIRTUAL TABLE symbols_fts USING fts5(name, type, parent_name, signature, description, tags);
+  `);
+  const insEdt = db.prepare(
+    `INSERT INTO edt_metadata (edt_name, extends, string_size, model) VALUES (?, ?, ?, 'Foundation')`,
+  );
+  for (const r of rows) insEdt.run(r.name, r.extends ?? null, r.stringSize ?? null);
+  return db;
+}
+
+const req = (edtName: string) => ({
+  method: 'tools/call' as const,
+  params: { name: 'get_edt_info', arguments: { edtName } },
+});
+
+/** Context whose bridge answers with the given payload (null = bridge has no data). */
+function ctx(db: any, bridgeEdt: any) {
+  return {
+    symbolIndex: { getReadDb: () => db },
+    bridge: { isReady: true, metadataAvailable: true, readEdt: vi.fn(async () => bridgeEdt) },
+  } as any;
+}
+
+const text = (r: any) => r.content[0].text as string;
+
+describe('EDT StringSize inheritance — bridge path', () => {
+  it('reports the inherited size and names the EDT it came from', async () => {
+    const result = await getEdtInfoTool(
+      req('ItemFreeTxt'),
+      ctx(makeDb([]), {
+        name: 'ItemFreeTxt',
+        baseType: 'String',
+        extends: 'ItemFreeTxtBase',
+        rootEdt: 'ItemFreeTxtBase',
+        stringSize: 1000,
+        stringSizeInheritedFrom: 'ItemFreeTxtBase',
+        model: 'Foundation',
+      }),
+    );
+
+    const out = text(result);
+    expect(out).toContain('| String Size | 1000 (inherited from ItemFreeTxtBase) |');
+    // The old answer must not survive anywhere in the report.
+    expect(out).not.toContain('| String Size | 10 |');
+  });
+
+  it('names the declaring ancestor, not the immediate parent, on a multi-level chain', async () => {
+    // AccountNumber_IN -> CustVendAC -> ExternalAccount(20). Only the last declares a size.
+    const result = await getEdtInfoTool(
+      req('AccountNumber_IN'),
+      ctx(makeDb([]), {
+        name: 'AccountNumber_IN',
+        baseType: 'String',
+        extends: 'CustVendAC',
+        rootEdt: 'ExternalAccount',
+        stringSize: 20,
+        stringSizeInheritedFrom: 'ExternalAccount',
+      }),
+    );
+
+    const out = text(result);
+    expect(out).toContain('| Root EDT | ExternalAccount |');
+    expect(out).toContain('| String Size | 20 (inherited from ExternalAccount) |');
+  });
+
+  it("claims no inheritance when the derived EDT declares its own size", async () => {
+    // InvoiceId declares 50 over Num's 20 — permitted, because Num is extensible. The number
+    // is the EDT's own, so it must not be labelled as inherited from anywhere.
+    const result = await getEdtInfoTool(
+      req('InvoiceId'),
+      ctx(makeDb([]), {
+        name: 'InvoiceId',
+        baseType: 'String',
+        extends: 'Num',
+        rootEdt: 'Num',
+        stringSize: 50,
+      }),
+    );
+
+    const out = text(result);
+    expect(out).toContain('| String Size | 50 |');
+    expect(out).not.toContain('inherited from');
+  });
+
+  it("labels a value an ancestor overrode", async () => {
+    // PartyName declares 100 but is not StringSizeIsExtensible, and its base DirPartyName
+    // declares 160, so the base's value is the effective one.
+    const result = await getEdtInfoTool(
+      req('PartyName'),
+      ctx(makeDb([]), {
+        name: 'PartyName',
+        baseType: 'String',
+        extends: 'DirPartyName',
+        rootEdt: 'DirPartyName',
+        stringSize: 160,
+        stringSizeInheritedFrom: 'DirPartyName',
+      }),
+    );
+
+    expect(text(result)).toContain('| String Size | 160 (inherited from DirPartyName) |');
+  });
+
+  it('claims no inheritance for a root EDT, and spells out the memo sentinel', async () => {
+    const result = await getEdtInfoTool(
+      req('Notes'),
+      ctx(makeDb([]), { name: 'Notes', baseType: 'String', stringSize: -1 }),
+    );
+
+    const out = text(result);
+    expect(out).toContain('| String Size | -1 (memo, unlimited) |');
+    expect(out).not.toContain('inherited from');
+    expect(out).not.toContain('| Root EDT |');
+  });
+});
+
+describe('EDT StringSize inheritance — SQLite fallback path', () => {
+  it('walks extends to the declaring ancestor instead of omitting String Size', async () => {
+    const db = makeDb([
+      { name: 'ItemFreeTxt', extends: 'ItemFreeTxtBase' },
+      { name: 'ItemFreeTxtBase', stringSize: '1000' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('ItemFreeTxt'), ctx(db, null)));
+    expect(out).toContain('| String Size | 1000 (inherited from ItemFreeTxtBase) |');
+  });
+
+  it('skips ancestors that declare no size of their own', async () => {
+    const db = makeDb([
+      { name: 'AccountNumber_IN', extends: 'CustVendAC' },
+      { name: 'CustVendAC', extends: 'ExternalAccount' },
+      { name: 'ExternalAccount', stringSize: '20' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('AccountNumber_IN'), ctx(db, null)));
+    expect(out).toContain('| String Size | 20 (inherited from ExternalAccount) |');
+  });
+
+  it('stops at the NEAREST declaring ancestor, not the root', async () => {
+    // CorrectedInvoiceId_RU -> InvoiceId(50) -> Num(20). The real size is 50; taking the root
+    // would report 20.
+    const db = makeDb([
+      { name: 'CorrectedInvoiceId_RU', extends: 'InvoiceId' },
+      { name: 'InvoiceId', extends: 'Num', stringSize: '50' },
+      { name: 'Num', stringSize: '20' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('CorrectedInvoiceId_RU'), ctx(db, null)));
+    expect(out).toContain('| String Size | 50 (inherited from InvoiceId) |');
+    expect(out).not.toContain('inherited from Num');
+  });
+
+  it('keeps a size the derived EDT declares for itself', async () => {
+    // 228 shipped derived EDTs declare their own size; InvoiceId declares 50 over Num's 20.
+    const db = makeDb([
+      { name: 'Num', stringSize: '20' },
+      { name: 'InvoiceId', extends: 'Num', stringSize: '50' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('InvoiceId'), ctx(db, null)));
+    expect(out).toContain('| String Size | 50 |');
+    expect(out).not.toContain('inherited from');
+  });
+
+  it('says nothing rather than guessing when the chain dangles', async () => {
+    // AmountMST names MoneyMST in its Extends, and no AxEdt file ships for MoneyMST.
+    const db = makeDb([{ name: 'AmountMST', extends: 'MoneyMST' }]);
+
+    const out = text(await getEdtInfoTool(req('AmountMST'), ctx(db, null)));
+    expect(out).not.toContain('| String Size |');
+  });
+
+  it('terminates on a cyclic extends chain', async () => {
+    const db = makeDb([
+      { name: 'LoopA', extends: 'LoopB' },
+      { name: 'LoopB', extends: 'LoopA' },
+    ]);
+
+    const out = text(await getEdtInfoTool(req('LoopA'), ctx(db, null)));
+    expect(out).not.toContain('| String Size |');
+  });
+});

--- a/tests/tools/generateSmartReport.test.ts
+++ b/tests/tools/generateSmartReport.test.ts
@@ -243,3 +243,58 @@ describe('generate_object(scaffold, report) EDT/field-type reconciliation', () =
     expect(text).not.toMatch(/<Name>LineCount<\/Name>[\s\S]{0,300}?System\.String/);
   });
 });
+
+/**
+ * Phase D: uiBuilder=true emits the UI-builder class and binds it on the
+ * Contract via [SysOperationContractProcessing] — and stays absent otherwise,
+ * so the default scaffold shape (compile-proven by the L4 goldens) is unchanged.
+ */
+describe('generate_object(scaffold, report) uiBuilder option', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('emits <Name>UIBuilder and the SysOperationContractProcessing binding', async () => {
+    const result = await handleGenerateSmartReport(
+      {
+        name: 'CustAgingReport',
+        fieldsHint: 'CustAccount, Balance',
+        contractParams: [{ name: 'CustGroup', type: 'CustGroupId' }],
+        uiBuilder: true,
+        modelName: 'MyModel',
+      } as any,
+      createSymbolIndexStub()
+    );
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('CustAgingReportUIBuilder');
+    expect(text).toContain('extends SrsReportDataContractUIBuilder');
+    expect(text).toContain('SysOperationContractProcessing(classStr(CustAgingReportUIBuilder))');
+    // build() calls super() first, per the ssrs-ui-builder topic
+    expect(text).toContain('public void build()');
+    expect(text).toContain('parmCustGroup');
+  });
+
+  it('default scaffold carries no UI builder and a plain [DataContractAttribute]', async () => {
+    const result = await handleGenerateSmartReport(
+      {
+        name: 'PlainReport',
+        fieldsHint: 'ItemId, Qty',
+        modelName: 'MyModel',
+      } as any,
+      createSymbolIndexStub()
+    );
+    const text = result.content[0].text as string;
+
+    expect(text).not.toContain('UIBuilder');
+    expect(text).not.toContain('SysOperationContractProcessing');
+    expect(text).toContain('[DataContractAttribute]');
+  });
+});

--- a/tests/tools/namingExtensionTypeInference.test.ts
+++ b/tests/tools/namingExtensionTypeInference.test.ts
@@ -135,3 +135,25 @@ describe('extension type inferred from the proposed name', () => {
     expect(out).toContain('as query');
   });
 });
+
+describe('objectType="report" (Phase D)', () => {
+  it('suggests the SSRS companion-object roster', async () => {
+    const out = await validate({
+      objectType: 'report',
+      proposedName: 'ConSK_CustAging',
+    });
+    expect(out).toContain('ConSK_CustAgingTmp');
+    expect(out).toContain('ConSK_CustAgingContract');
+    expect(out).toContain('ConSK_CustAgingDP');
+    expect(out).toContain('ConSK_CustAgingController');
+    expect(out).toContain('generate_object(mode="scaffold", objectType="report")');
+  });
+
+  it('warns when the report name carries a companion-class suffix', async () => {
+    const out = await validate({
+      objectType: 'report',
+      proposedName: 'ConSK_CustAgingDP',
+    });
+    expect(out).toContain('COMPANION-class suffix');
+  });
+});

--- a/tests/tools/reportPatterns.test.ts
+++ b/tests/tools/reportPatterns.test.ts
@@ -1,0 +1,56 @@
+/**
+ * object_patterns(domain="report") — dispatcher routing + handler output.
+ * The report domain is pure catalog (no index), so a bare context suffices.
+ */
+import { describe, it, expect } from 'vitest';
+import { objectPatternsTool } from '../../src/tools/knowledge/objectPatterns';
+import { getReportPatternsTool } from '../../src/tools/knowledge/getReportPatterns';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const req = (args: Record<string, unknown> = {}): CallToolRequest => ({
+  method: 'tools/call',
+  params: { name: 'object_patterns', arguments: args },
+});
+
+const getText = (r: any): string => r.content?.[0]?.text ?? '';
+const ctx = {} as any;
+
+describe('object_patterns domain="report"', () => {
+  it('lists all report patterns without a pattern arg', async () => {
+    const r = await objectPatternsTool(req({ domain: 'report' }), ctx);
+    const text = getText(r);
+    expect(r.isError).toBeFalsy();
+    expect(text).toContain('SimpleList');
+    expect(text).toContain('PrintMgmtFormLetter');
+    expect(text).toContain('generate_object(mode="scaffold"');
+  });
+
+  it('returns one spec for pattern=<id> with roster and scaffold', async () => {
+    const r = await objectPatternsTool(req({ domain: 'report', pattern: 'HeaderDetail' }), ctx);
+    const text = getText(r);
+    expect(text).toContain('Header + lines');
+    expect(text).toContain('Objects:');
+    expect(text).toContain('additionalDatasets');
+  });
+
+  it('routes a report-only pattern name without an explicit domain', async () => {
+    const r = await objectPatternsTool(req({ pattern: 'PrintMgmtFormLetter' }), ctx);
+    expect(getText(r)).toContain('Print-management document');
+  });
+
+  it('a report pattern id passed AS the domain routes to its spec', async () => {
+    const r = await objectPatternsTool(req({ domain: 'GroupedWithTotals' }), ctx);
+    expect(getText(r)).toContain('Grouped list with totals');
+  });
+
+  it('unknown pattern lists the available ids', async () => {
+    const r = await getReportPatternsTool(req({ pattern: 'nope' }));
+    expect(r.isError).toBe(true);
+    expect(getText(r)).toContain('SimpleList');
+  });
+
+  it('the no-domain error text now offers the report domain', async () => {
+    const r = await objectPatternsTool(req({ domain: 'bogus-domain' }), ctx);
+    expect(getText(r)).toContain('domain="report"');
+  });
+});

--- a/tests/tools/validate-xpp.test.ts
+++ b/tests/tools/validate-xpp.test.ts
@@ -461,3 +461,283 @@ describe('XML property rules — mined statistics', () => {
     expect(getText(result)).toContain('XML005');
   });
 });
+
+// ─── Phase C rules (CS001 / TTS002 / TTS003 / SEL006 / SEL007 / RPT / FN001 ext) ─
+
+describe('CS001 — C# constructs', () => {
+  it('flags string interpolation, lambda, foreach, ?? and string type', async () => {
+    const code = `
+      string name = custTable.Name;
+      str greeting = $"hello";
+      list.ForEach(x => x.run());
+      foreach (var item in items) {}
+      str fallback = a ?? b;
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    const text = getText(result);
+    const hits = (text.match(/\[CS001\]/g) ?? []).length;
+    expect(hits).toBeGreaterThanOrEqual(5);
+    expect(result.isError).toBe(true);
+  });
+
+  it('stays quiet on plain X++ (>= is not =>, quotes mask $")', async () => {
+    const code = `
+      if (qty >= minQty)
+      {
+          info(strFmt("@MyModel:Msg", qty));
+      }
+      str note = "uses => and foreach in prose";
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('CS001');
+  });
+});
+
+describe('TTS002 — dead catch inside tts', () => {
+  it('flags a catch-all inside an open tts scope', async () => {
+    const code = `
+      ttsbegin;
+      try
+      {
+          custTable.update();
+      }
+      catch
+      {
+          info("never reached");
+      }
+      ttscommit;
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).toContain('TTS002');
+  });
+
+  it('allows catch (Exception::UpdateConflict) inside tts and any catch outside', async () => {
+    const code = `
+      try
+      {
+          ttsbegin;
+          custTable.update();
+          ttscommit;
+      }
+      catch (Exception::Deadlock)
+      {
+          info("outside tts - fine");
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('TTS002');
+  });
+});
+
+describe('TTS003 — unguarded retry', () => {
+  it('flags retry with no counter or condition in its catch', async () => {
+    const code = `
+      try
+      {
+          this.run();
+      }
+      catch (Exception::Deadlock)
+      {
+          retry;
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).toContain('TTS003');
+  });
+
+  it('accepts a counter-guarded retry', async () => {
+    const code = `
+      try
+      {
+          this.run();
+      }
+      catch (Exception::Deadlock)
+      {
+          retryCount++;
+          if (retryCount > 5)
+          {
+              throw error("@MyModel:TooManyRetries");
+          }
+          retry;
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('TTS003');
+  });
+});
+
+describe('SEL006 / SEL007 — index hint and foreign join syntax', () => {
+  it('SEL006: flags index hint without allowIndexHint(true)', async () => {
+    const code = `select firstOnly custTable index hint AccountIdx where custTable.AccountNum == acc;`;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).toContain('SEL006');
+  });
+
+  it('SEL006: quiet when allowIndexHint(true) is present', async () => {
+    const code = `
+      custTable.allowIndexHint(true);
+      select firstOnly custTable index hint AccountIdx where custTable.AccountNum == acc;
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('SEL006');
+  });
+
+  it('SEL007: flags left join and join…on', async () => {
+    const code = `
+      select custTable
+          left join custTrans on custTrans.AccountNum == custTable.AccountNum;
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    const text = getText(result);
+    expect(text).toContain('SEL007');
+    expect(result.isError).toBe(true);
+  });
+
+  it('SEL007: quiet on valid X++ joins', async () => {
+    const code = `
+      select custTable
+          outer join custTrans where custTrans.AccountNum == custTable.AccountNum
+          notexists join custBlocked where custBlocked.AccountNum == custTable.AccountNum;
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('SEL007');
+  });
+});
+
+describe('RPT001/RPT002 — DP class shape', () => {
+  it('RPT001: DP reads parmDataContract() without SRSReportParameterAttribute', async () => {
+    const code = `
+      public class MyReportDP extends SRSReportDataProviderBase
+      {
+          public void processReport()
+          {
+              MyReportContract contract = this.parmDataContract() as MyReportContract;
+          }
+
+          [SRSReportDataSetAttribute(tableStr(MyReportTmp))]
+          public MyReportTmp getMyReportTmp()
+          {
+              select * from tmpTable;
+              return tmpTable;
+          }
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).toContain('RPT001');
+  });
+
+  it('RPT002: processReport without any dataset getter', async () => {
+    const code = `
+      [SRSReportParameterAttribute(classStr(MyReportContract))]
+      public class MyReportDP extends SRSReportDataProviderBase
+      {
+          public void processReport()
+          {
+          }
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).toContain('RPT002');
+  });
+
+  it('quiet on a well-formed DP', async () => {
+    const code = `
+      [SRSReportParameterAttribute(classStr(MyReportContract))]
+      public class MyReportDP extends SRSReportDataProviderBase
+      {
+          [SRSReportDataSetAttribute(tableStr(MyReportTmp))]
+          public MyReportTmp getMyReportTmp()
+          {
+              select * from tmpTable;
+              return tmpTable;
+          }
+
+          public void processReport()
+          {
+              MyReportContract contract = this.parmDataContract() as MyReportContract;
+          }
+      }
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    const text = getText(result);
+    expect(text).not.toContain('RPT001');
+    expect(text).not.toContain('RPT002');
+  });
+});
+
+describe('codeType xml-report — RPT101/RPT102', () => {
+  it('RPT101: AxReport without a design', async () => {
+    const code = `<?xml version="1.0" encoding="utf-8"?>
+<AxReport>
+  <Name>MyReport</Name>
+  <Datasets>
+    <AxReportDataSet>
+      <Name>MyReportTmp</Name>
+      <Query>SELECT * FROM MyReportDP.MyReportTmp</Query>
+    </AxReportDataSet>
+  </Datasets>
+</AxReport>`;
+    const result = await validateXppTool(req({ code, codeType: 'xml-report' }));
+    expect(getText(result)).toContain('RPT101');
+  });
+
+  it('RPT102: dataset without Query', async () => {
+    const code = `<?xml version="1.0" encoding="utf-8"?>
+<AxReport>
+  <Name>MyReport</Name>
+  <Datasets>
+    <AxReportDataSet>
+      <Name>MyReportTmp</Name>
+    </AxReportDataSet>
+  </Datasets>
+  <Designs>
+    <AxReportDesign>
+      <Name>Report</Name>
+    </AxReportDesign>
+  </Designs>
+</AxReport>`;
+    const result = await validateXppTool(req({ code, codeType: 'xml-report' }));
+    const text = getText(result);
+    expect(text).toContain('RPT102');
+    expect(text).not.toContain('RPT101');
+  });
+
+  it('X++ keyword rules do NOT run over the RDL CDATA', async () => {
+    const code = `<?xml version="1.0" encoding="utf-8"?>
+<AxReport>
+  <Name>MyReport</Name>
+  <Designs>
+    <AxReportDesign>
+      <Name>Report</Name>
+      <Text><![CDATA[ print this; pause; select * from x; ]]></Text>
+    </AxReportDesign>
+  </Designs>
+</AxReport>`;
+    const result = await validateXppTool(req({ code, codeType: 'xml-report' }));
+    expect(getText(result)).toMatch(/no violations/i);
+  });
+});
+
+describe('FN001 — extended fixed-arity set', () => {
+  it('flags subStr with 2 arguments and ssrsReportStr with 1', async () => {
+    const code = `
+      str part = subStr(fullName, 3);
+      controller.parmReportName(ssrsReportStr(MyReport));
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    const text = getText(result);
+    const hits = (text.match(/\[FN001\]/g) ?? []).length;
+    expect(hits).toBe(2);
+  });
+
+  it('accepts correct arities (subStr 3, conPeek 2, mkDate 3, ssrsReportStr 2)', async () => {
+    const code = `
+      str part = subStr(fullName, 3, 5);
+      str first = conPeek(values, 1);
+      date d = mkDate(1, 7, 2026);
+      controller.parmReportName(ssrsReportStr(MyReport, Report));
+    `;
+    const result = await validateXppTool(req({ code, codeType: 'xpp' }));
+    expect(getText(result)).not.toContain('FN001');
+  });
+});


### PR DESCRIPTION
Phase D of the X++ coverage plan (`docs/XPP_LANGUAGE_COVERAGE_PLAN.md`). **Based on `feat/xpp-coverage-phase-a`**, which accumulated phases A–C after #953/#954 were merged inward — merging this PR completes A–D on that branch (a final PR from `feat/xpp-coverage-phase-a` → `main` is still needed).

## `object_patterns` gains `domain="report"`
A recipe catalog (`src/knowledge/reportPatterns/`, 7 patterns: SimpleList, GroupedWithTotals, HeaderDetail, PreProcess, PrintMgmtFormLetter, QueryBased, UIBuilderDialog). Reports have no pattern XML to validate, so each pattern is an implementation **recipe**: object roster + base classes, the one scaffold call that produces it, method guidance, and post-checks (incl. the Phase A design-name invariant). Pattern names route even without an explicit domain.

## `validate_object_naming` gains `objectType="report"`
Warns when the AxReport name carries a companion-class suffix (DP/Contract/Controller/UIBuilder/Tmp); suggests the full companion roster.

## `generate_object(scaffold, report)` gains `uiBuilder=true`
Emits `<Name>UIBuilder` (extends `SrsReportDataContractUIBuilder`) bound on the contract via `[SysOperationContractProcessing]`. The planned PreProcessTempDB switch was **deliberately not made** — the preProcess path has no VM-proven golden, so its emitted shape stays untouched until Phase F verifies the pairing.

## Op-spec drift fixed
`scaffold:report` now advertises `aotQuery`, `callerTableName`, `preProcess`, `controllerType`, `uiBuilder` — all implemented but previously invisible to the agent.

## Knowledge
New rules-only topics `ssrs-contracts` (RDP/RDL/print/composite taxonomy), `ssrs-rdp-preprocess`, `ssrs-ui-builder`; `print-management` gains new-document-type delegate wiring; `electronic-reporting` gains the SSRS-vs-ER-vs-BDM decision rule + 2024-26 SSRS platform notes. Zero new extracted AOT refs (examples wait for the Phase F snapshot capture).

## Tests
Catalog gates (uniqueness, dangling-topic check, design-name invariant), dispatcher routing, uiBuilder emission + default-shape guard, naming roster. Full suite 5070 passed (known .NET-8 bridge env failure only). Schema-byte ratchet green — additions funded by trims inside the same two schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)