### PR TITLE
chore(release): cut 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ those are called out explicitly below.
 
 ## [Unreleased]
 
+_Nothing released yet._
+
+---
+
+## [1.15.0] — 2026-08-30
+
 ### Added
 - **The TDD loop for X++: `prepare(mode="test")` and a red-first SysTest scaffold.**
   The server could teach SysTest and run a class; it could not help write one, and


### PR DESCRIPTION
Moves the `[Unreleased]` block under a version heading — the release step the process note at the top of `CHANGELOG.md` describes. Six added lines, one file.

**The tag is deliberately not part of this.** `v1.15.0` triggers `release.yml`, which builds the GitHub release **and publishes to npm over OIDC**. That is effectively irreversible for a public package, so it waits on the VM verification.

## What the block covers

65 commits since `v1.14.0`, 49 entries across four waves:

- the tool folds (23 → 20 published tools) and the round-trip work;
- Phase B–F — the X++ language knowledge pack, ten validator rules, the `object_patterns` report domain, the eval catalog reaching 98 cases;
- the compiler-oracle wave — one lexer replacing five partial maskers, compiler-captured facts, ten more rules, the TDD loop (`prepare(mode="test")`), mobile-app and warehouse patterns;
- the release-prep passes that wrote the entries for all of the above and re-measured the docs against them.

Sections: **Added**, **Fixed**, **Changed**, **Breaking** — the last one flagging that `undo_last_modification`, `review_workspace_changes` and `trigger_db_sync` are no longer published, which breaks any prompt or instruction file naming them.

## Layout

Matches what the 1.14.0 cut did: an empty `## [Unreleased]` with `_Nothing released yet._` stays at the top, so the next contributor has somewhere to put an entry.

`package.json` is already at `1.15.0` (bumped in #962), so nothing else changes here — and the release workflow syncs the version from the tag anyway.

## After this merges

```
git tag v1.15.0 && git push origin v1.15.0
```

That is the whole remaining step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bime98u9EwXbURYe8QNaiz)_