### PR TITLE
chore(release): fold PR #967 into the 1.15.0 changelog block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,40 +28,7 @@ those are called out explicitly below.
 
 ## [Unreleased]
 
-### Fixed (golden re-verification)
-- **`d365fo_file(action="create", objectType="table")` also dropped
-  `properties.indexes`** — the third collection it lost after field groups, and
-  the one with no way back: `createTablePropertyHonesty` correctly reported the
-  loss and offered `add-index` as the repair, but that operation requires the C#
-  bridge, so a create running on the XML-template path could not produce an index
-  at all. `<Indexes>` is now rendered by a builder shared with the
-  table-extension path, so the two cannot drift. `<Relations />` is still a
-  literal and stays reported by that same honesty check.
-- **The form templates named a field group they had no reason to believe
-  existed.** `<DataGroup>Overview</DataGroup>` was hardcoded on the grid in three
-  patterns. Binding a grid to a field group is right — shipped forms do it, and
-  `CustGroup` and `VendGroup` both bind `Overview` — but naming a group the table
-  does not declare is a build error, and an *incremental* build passes it
-  silently, which is how it survived several captures. The builder now reads the
-  bound table and omits the element only when it has **positively** established
-  the group is absent; a table it cannot read leaves the binding alone, because
-  absence of evidence is not evidence of absence.
-- **Three goldens that could not build have been re-captured on the VM**, closing
-  the "Fixture ⇄ golden mismatch" row of `eval/golden-build-verification.json`.
-  `L1-form-basic`'s table golden did not satisfy its own case instruction, which
-  asks for an `Overview` field group *and spells out why* ("a form whose grid
-  names a field group the table does not declare fails FormPatternValidation at
-  build time") — it carried `<FieldGroups />`, because the create path had
-  silently dropped it. `L1-form-simplelistdetails`'s form carried a `<DataGroup>`
-  with no sibling `<DataSource>`, so the group could not be resolved against any
-  table. `L1-form-detailsmaster` needed no re-capture and went green once the
-  fixture table was correct. All three now build clean in isolation, and
-  `eval/fixtures/ConDemoNoteHeader.metadata.xml` is re-synchronised with the
-  re-captured golden — a copy of a golden again rather than a hand repair of one.
-  Golden re-verification: **93/100 clean over 224 artifacts** (was 57/65 over
-  143; the catalog grew by 35 cases in between, so a third of it got its first
-  isolated verdict here). Exactly three cases changed state — the three above.
-  Nothing regressed.
+_Nothing released yet._
 
 ---
 
@@ -539,6 +506,39 @@ those are called out explicitly below.
   label in that model's file, and that file has no undo outside git. The two
   remaining plain writes in `createLabel.ts` create a NEW file behind an
   `fs.access` miss and are correctly left alone.
+- **`d365fo_file(action="create", objectType="table")` also dropped
+  `properties.indexes`** — the third collection it lost after field groups, and
+  the one with no way back: `createTablePropertyHonesty` correctly reported the
+  loss and offered `add-index` as the repair, but that operation requires the C#
+  bridge, so a create running on the XML-template path could not produce an index
+  at all. `<Indexes>` is now rendered by a builder shared with the
+  table-extension path, so the two cannot drift. `<Relations />` is still a
+  literal and stays reported by that same honesty check.
+- **The form templates named a field group they had no reason to believe
+  existed.** `<DataGroup>Overview</DataGroup>` was hardcoded on the grid in three
+  patterns. Binding a grid to a field group is right — shipped forms do it, and
+  `CustGroup` and `VendGroup` both bind `Overview` — but naming a group the table
+  does not declare is a build error, and an *incremental* build passes it
+  silently, which is how it survived several captures. The builder now reads the
+  bound table and omits the element only when it has **positively** established
+  the group is absent; a table it cannot read leaves the binding alone, because
+  absence of evidence is not evidence of absence.
+- **Three goldens that could not build have been re-captured on the VM**, closing
+  the "Fixture ⇄ golden mismatch" row of `eval/golden-build-verification.json`.
+  `L1-form-basic`'s table golden did not satisfy its own case instruction, which
+  asks for an `Overview` field group *and spells out why* ("a form whose grid
+  names a field group the table does not declare fails FormPatternValidation at
+  build time") — it carried `<FieldGroups />`, because the create path had
+  silently dropped it. `L1-form-simplelistdetails`'s form carried a `<DataGroup>`
+  with no sibling `<DataSource>`, so the group could not be resolved against any
+  table. `L1-form-detailsmaster` needed no re-capture and went green once the
+  fixture table was correct. All three now build clean in isolation, and
+  `eval/fixtures/ConDemoNoteHeader.metadata.xml` is re-synchronised with the
+  re-captured golden — a copy of a golden again rather than a hand repair of one.
+  Golden re-verification: **93/100 clean over 224 artifacts** (was 57/65 over
+  143; the catalog grew by 35 cases in between, so a third of it got its first
+  isolated verdict here). Exactly three cases changed state — the three above.
+  Nothing regressed.
 
 ### Changed
 - **The compiler is the oracle for the validator now.** Measured against the


### PR DESCRIPTION
## Why

PR #967 merged after the 1.15.0 cut (#966) and put its notes under `[Unreleased]`, while the `## [1.15.0] — 2026-08-30` heading is dated today and `v1.15.0` has not been tagged. Release audit on `59239c5` (CI green, typecheck/lint/build green, 370 test files / 5,469 tests green, `bridge:attest` OK, `npm audit --omit=dev` 0, `npm pack` sane) found this as the only thing standing between HEAD and the tag: shipping 1.15.0 from the cut commit would ship a `create(table)` that drops `properties.indexes`, which HEAD already fixes.

## What

CHANGELOG.md only. The three `### Fixed (golden re-verification)` entries move to the end of the 1.15.0 `### Fixed` section; `[Unreleased]` returns to `_Nothing released yet._`, the shape the 1.15.0 and 1.14.0 cuts restored. 34 lines moved, none rewritten.

## After merge

Tag the merge commit — see tracking issue #969. `release.yml` builds, creates the GitHub release and publishes `d365fo-mcp@1.15.0` to npm over OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PPXYm7g5Zz1kVNzE6nJjS