### PR TITLE
eval: the last eight goldens, the three SysTests that had never run, and what they found

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-7.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://img.shields.io/badge/tests-5000%2B-brightgreen.svg)](docs/TESTING.md)
 <!-- coverage-badge:start -->
-[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-99.1%25-lightgrey.svg)](eval/COVERAGE.md)
+[![Core coverage](https://img.shields.io/badge/core_coverage-100%25-brightgreen.svg)](eval/COVERAGE.md) [![Total coverage](https://img.shields.io/badge/total_coverage-100%25-lightgrey.svg)](eval/COVERAGE.md)
 <!-- coverage-badge:end -->
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot and Claude Code*

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -23,12 +23,12 @@ the design.
 
 ---
 
-## Live SysTest runs — UNBLOCKED 2026-08-31
+## Live SysTest runs — UNBLOCKED and CLOSED 2026-08-31
 
-**Status:** **resolved 2026-08-31.** The owner applied the config copy on the VM and
-the runner now reaches the database. Kept here (rather than deleted) because the
-diagnosis was wrong twice before it was right, and because the four cases below
-still have to RUN before their flags flip.
+**Status:** **resolved and closed 2026-08-31.** The owner applied the config copy on
+the VM, the runner reached the database, and all four cases have since RUN their
+tests. Kept here (rather than deleted) because the diagnosis was wrong twice before
+it was right.
 
 **What changed.** `compareSysTestDataAccess` reports all four `DataAccess.*`
 settings in agreement with `WebRoot\web.config`, and `SysTestConsole.exe
@@ -42,11 +42,16 @@ UNKNOWN this entry carried: the 828-character encrypted password blob **is**
 decryptable by the account the runner executes as, so no second blocker was hiding
 behind the first.
 
-**What is still owed.** The four cases keep `systest_pending: true` until each one
-actually runs: their SysTest classes were rolled back after their goldens were
-captured, so re-running them means an `eval-run` per case. And `L2-tdd-red-green-cycle`
-— the case that proves the loop rather than the authoring — can now be authored
-honestly, which it could not be while no test had ever executed.
+**What was owed, and is now done.** The four cases have each been re-run.
+`L2-coc-extension`, `L2-event-handler-basic` and `L3-batch-basic` passed **2/2**
+apiece under `SysTestConsole.exe` ("Rainier Test Suite : 2 Run, 0 Failed"), and
+`L3-enum-field-form-downgrade-guard` ran green too; the corpus records
+(`eval/corpus/runs/2026-08-31T2*__*__278eee3.json`) carry
+`systest: {"ran": true, "passed": true}` and `score.systest: 1`. **No case carries
+`systest_pending` any more**, and 0 of the 120 cases are `golden_pending`.
+`L2-tdd-red-green-cycle` — the case that proves the loop rather than the authoring
+— can now be authored honestly, which it could not be while no test had ever
+executed. That is the only item this entry still points at.
 
 <details>
 <summary>The original entry, kept for the diagnosis history</summary>
@@ -59,6 +64,7 @@ this repo can close it.
 Their goldens are captured and they build clean; what has never run is the live
 SysTest, which is the runtime-correctness half of the oracle (§6.3). Until it does,
 those cases prove that the code COMPILES and nothing more.
+*[2026-08-31] All four have now run and passed; none carries `systest_pending`.*
 
 **Why it is stuck — and why the recorded reason was wrong.** `SysTestConsole.exe`
 now starts (two earlier assembly faults were fixed by config edits, each with a
@@ -85,6 +91,8 @@ tool's — and an assistant's sandbox classifier blocks it outright, correctly.
 retype), re-run `run_systest_class`. If it then connects, flip the four cases'
 `systest_pending` to false as each one actually runs, and record the runs in the
 corpus.
+*[2026-08-31] Applied, and the trigger fired: all four ran, all four flags are
+false, and the corpus records are committed.*
 
 **What was done instead.** `run_systest_class` performs the comparison itself and
 names the settings that differ, never printing the password — only "the shipped

--- a/docs/XPP_LANGUAGE_COVERAGE_PLAN.md
+++ b/docs/XPP_LANGUAGE_COVERAGE_PLAN.md
@@ -14,11 +14,14 @@ held. The runs found **31 defects**, including five errors in knowledge written
 the same day and one write-path bug that had silently corrupted a committed
 golden. §9 lists them.
 
-**What is left** — evidence, not code: eight older `golden_pending` cases from
-earlier waves, four `systest_pending` runs (the first is in flight), one
-re-capture (`L3-sysoperation-dialog-attributes`, whose golden was removed after
-the attribute-drop bug was found in it), and a `bp_clean` top-up for
-`L3-warehouse-work-slice`.
+**What is left** — as of 2026-08-31 the capture wave is DONE: **0 of the 120 cases
+are `golden_pending` and none carries `systest_pending`.** The eight older
+`golden_pending` cases were captured, all four SysTest runs executed (three of
+them 2/2 under `SysTestConsole.exe`), and `L3-sysoperation-dialog-attributes` was
+re-captured after the attribute-drop bug found in its golden. The one item still
+outstanding is the `bp_clean` top-up for `L3-warehouse-work-slice`, whose only
+corpus record (2026-08-03) still scores `bp_clean: null`. That also means this
+file's own delete-condition below is met — the owner's call, not an automatic one.
 
 **Lifecycle.** v1 (A–F) and v2.1 (G0–G5, G-VM) were executed and their content
 removed; the durable record is `eval/COVERAGE.md`, `eval/README.md`, the goldens'

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -9,7 +9,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
 | core | 65 | 65 | **100%** |
-| total | 108 | 109 | 99.1% |
+| total | 109 | 109 | 100% |
 
 ## Data model (12/12)
 
@@ -19,8 +19,8 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Table extension | core | ✅ | ✅ | ✅ | L2-table-extension |
 | Extended data type | core | ✅ | ✅ | ✅ | L0-edt-basic |
 | EDT extension | total | ✅ | ✅ | ✅ | L2-edt-extension-basic |
-| Base enum | core | ✅ | ✅ | ✅ | L0-enum-basic |
-| Enum extension | core | ✅ | ✅ | ✅ | L2-enum-extension-empty-values |
+| Base enum | core | ✅ | ✅ | ✅ | L0-enum-basic, L3-enum-field-form-downgrade-guard |
+| Enum extension | core | ✅ | ✅ | ✅ | L2-enum-extension-empty-values, L2-enum-modify-values |
 | View | core | ✅ | ✅ | ✅ | L1-query-view-basic, L2-form-over-view |
 | AOT query | core | ✅ | ✅ | ✅ | L1-query-view-basic |
 | Map | total | ✅ | ✅ | ✅ | L1-map-basic |
@@ -46,8 +46,8 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Error handling & infolog | core | ✅ | ✅ | ✅ | L2-error-handling-infolog |
 | SysExtension plug-in pattern | total | ✅ | ✅ | ✅ | L2-sysextension-plugin |
 | Performance patterns | core | ✅ | ✅ | ✅ | L2-performance-set-based |
-| Best-practice (BP) compliance | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +61 |
-| Deprecated APIs & migration | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +60 |
+| Best-practice (BP) compliance | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +63 |
+| Deprecated APIs & migration | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +62 |
 | Optimistic concurrency & UnitOfWork | core | ✅ | ✅ | ✅ | L2-occ-retry-basic |
 | Caching (CacheLookup, SysGlobalObjectCache, RecordViewCache) | total | ✅ | ✅ | ✅ | L2-table-caching-basic |
 | X++ collections & containers (List/Map/Set/Struct) | total | ✅ | ✅ | ✅ | L2-collections-map-list-container |
@@ -100,14 +100,14 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Report design & RDL expressions | core | ✅ | ✅ | ✅ | L4-ssrs-report-design-rdl |
 | Report print destinations (file, e-mail, archive, batch) | core | ✅ | ✅ | ✅ | L4-ssrs-report-print-destinations |
 
-## Frameworks (20/21)
+## Frameworks (21/21)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | SysOperation / batch | core | ✅ | ✅ | ✅ | L3-batch-basic |
 | Parallel batch processing | total | ✅ | ✅ | ✅ | L3-parallel-batch-tasks |
 | Async & retryable batch (BatchRetryable/runAsync) | total | ✅ | ✅ | ✅ | L3-batch-retryable-basic |
-| Number sequences | core | ✅ | ✅ | ✅ | L2-numberseq-basic |
+| Number sequences | core | ✅ | ✅ | ✅ | L2-numberseq-basic, L3-numberseq-module-slice |
 | Financial dimensions | core | ✅ | ✅ | ✅ | L2-dimension-basic |
 | Posting engine (LedgerVoucher) | total | ✅ | ✅ | ✅ | L4-posting-ledgervoucher-slice |
 | Workflow | core | ✅ | ✅ | ✅ | L3-workflow-document-submit |
@@ -122,7 +122,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Warehouse app / barcode scanning | total | ✅ | ✅ | ✅ | L3-warehouse-scan-resolve-slice |
 | Warehouse-app screens (ProcessGuide / legacy) | total | ✅ | ✅ | ✅ | L2-processguide-page-control, L3-legacy-workexecutedisplay-extend, L3-processguide-flow-slice |
 | Trade agreements & pricing | total | ✅ | ✅ | ✅ | L3-trade-agreement-price-lookup |
-| SysOperation dialog from contract attributes | total | ✅ | — | ✅ | missing E |
+| SysOperation dialog from contract attributes | total | ✅ | ✅ | ✅ | L3-sysoperation-dialog-attributes |
 | SysOperation query parameter (batch with a filter) | core | ✅ | ✅ | ✅ | L3-sysoperation-query-parameter-batch |
 | RunBase lifecycle & packed state | total | ✅ | ✅ | ✅ | L3-runbase-coc-pack-unpack |
 
@@ -130,7 +130,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
-| Data entity (OData) | core | ✅ | ✅ | ✅ | L4-entity-security |
+| Data entity (OData) | core | ✅ | ✅ | ✅ | L4-bridge-drops-data-entity-primarytable-fields-on-create, L4-entity-security |
 | Data entity extension | total | ✅ | ✅ | ✅ | L3-data-entity-extension-field |
 | Custom services / OData actions | core | ✅ | ✅ | ✅ | L3-custom-service-basic |
 | Data management framework (DMF/DIXF) | total | ✅ | ✅ | ✅ | L3-dmf-entity-import-slice |
@@ -157,18 +157,16 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
 | SysTest unit testing | core | ✅ | ✅ | ✅ | L2-coc-extension, L2-event-handler-basic, L2-systest-authoring-basic +1 |
-| Labels & localisation | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +60 |
+| Labels & localisation | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +62 |
 | TDD loop (red-first SysTest authoring) | core | ✅ | ✅ | ✅ | L2-systest-authoring-basic |
 
 ## Closure queue (uncovered, by frequency weight)
 
-| Weight | Leaf | Missing |
-| ---: | --- | --- |
-| 3 | SysOperation dialog from contract attributes | missing E |
+Nothing uncovered.
 
 ## Orphans
 
 - Knowledge entries no leaf claims (**unproven knowledge**): none
 - Eval cases no leaf claims (**unmapped proof**): L0-create-readback-no-reindex, L2-batched-object-reads, L2-entity-query-range-roundtrip, L2-form-control-removal-lifecycle, L2-object-delete-and-entry-point-cleanup, L2-oracle-discriminator-random-wrapper-name, L4-headerlines-document-slice
 
-_Generated 2026-08-31._
+_Generated 2026-09-01._

--- a/eval/README.md
+++ b/eval/README.md
@@ -327,8 +327,9 @@ core 44/44. The three newest families are the ones that matter — `remove-contr
 audit PR to close real defects, and the catalog had nothing to say about any of
 them. Four cases now cover the first three families end-to-end
 (`L2-form-control-removal-lifecycle`, `L2-object-delete-and-entry-point-cleanup`,
-`L2-bp-suppression-lifecycle`, `L2-entity-query-range-roundtrip`, all
-`golden_pending` and tagged `write-op-coverage`). They land in COVERAGE.md's
+`L2-bp-suppression-lifecycle`, `L2-entity-query-range-roundtrip`, tagged
+`write-op-coverage`; all four goldens are captured as of the 2026-08-31 wave).
+They land in COVERAGE.md's
 **Orphans** list, because no leaf claims them — which is the honest reading:
 until the taxonomy grows a write-operation axis, a missing op cannot make the
 percentage fall. Still uncovered by any case: `replace-all-fields`,
@@ -384,21 +385,23 @@ them, the next day.
 
 Standing queues:
 
-- **Capture the pending goldens (VM).** Cases with `golden_pending: true` have
-  been authored but never run; coverage counts them as uncovered because they
-  prove nothing until captured. `eval-run` captures each on the VM — flip the
-  flag as each lands.
+- ~~**Capture the pending goldens (VM).**~~ **CLOSED 2026-08-31.** Cases with
+  `golden_pending: true` had been authored but never run, and coverage counted
+  them as uncovered because they prove nothing until captured. **0 of the 120
+  cases are `golden_pending` today** — the queue is empty.
 
-  Nine of them arrived together on 2026-08-30 with the compiler-verified language
-  work, and they are why core coverage reads 86.4% rather than 100%:
+  The last nine arrived together on 2026-08-30 with the compiler-verified
+  language work, and they were why core coverage read 86.4% rather than 100%:
   `L2-runtime-functions-arity`, `L2-implicit-conversions`,
   `L2-select-find-options-joins`, `L2-args-record-caller`,
   `L2-display-edit-methods`, `L3-form-event-handler-class`,
   `L3-sysoperation-dialog-attributes`, `L2-systest-authoring-basic`,
-  `L3-report-dataset-extension`. Each has a knowledge entry written from a
-  compiler probe and a tool path that can produce it; what none of them has yet is
-  a build that proves the two agree. The number is supposed to fall when the
-  taxonomy grows honestly — it climbs back one captured golden at a time.
+  `L3-report-dataset-extension`. Each had a knowledge entry written from a
+  compiler probe and a tool path that could produce it; what none of them had was
+  a build proving the two agree. They now do. The number is supposed to fall when
+  the taxonomy grows honestly — it climbed back one captured golden at a time.
+  Re-open this queue the moment `eval-author` drafts the next case, which starts
+  life `golden_pending: true` by design.
 - **Coverage closure loop** (~2–4 leaves/week): `eval-author` drafts a case for
   each leaf missing **E** → `eval-run` captures the golden → MODEL_ERROR
   clusters flow through `knowledgeFeedback` into proposed knowledge entries
@@ -480,16 +483,19 @@ Blocked / declined (not planned):
   and returned the same 3 outcomes with both messages — so the repo's own reader
   agrees with the runner, which is the half a passing run cannot show.
 
-  **The runtime oracle is therefore trustworthy, not merely alive.** What remains
-  is ordinary work: the four `systest_pending` cases still have to RUN their own
-  tests, because the control proves the instrument, not those cases. The sandbox
-  was restored and a full build is green.
-  The four cases (`L2-coc-extension`, `L3-batch-basic`, `L2-event-handler-basic`,
-  `L3-enum-field-form-downgrade-guard`) keep `systest_pending: true` until each one
-  actually RUNS: their test classes were rolled back after their goldens were
-  captured, so re-running them means an `eval-run` per case. `L2-tdd-red-green-cycle`
-  — the case that proves the loop rather than the authoring — can now be authored
-  honestly, which it could not be while no test had ever executed.
+  **The runtime oracle is therefore trustworthy, not merely alive** — and the
+  four cases that owed a run have now all made it. `L2-coc-extension`,
+  `L2-event-handler-basic` and `L3-batch-basic` each ran under
+  `SysTestConsole.exe` on 2026-08-31 and passed **2/2** ("Rainier Test Suite :
+  2 Run, 0 Failed"), and `L3-enum-field-form-downgrade-guard` ran green as well;
+  all four corpus records carry `systest: {"ran": true, "passed": true}` and
+  `score.systest: 1`. **No case carries `systest_pending` any more**, and 0 of the
+  120 cases are `golden_pending`. The sandbox was restored and a full build is
+  green. `L2-tdd-red-green-cycle` — the case that proves the loop rather than the
+  authoring — can now be authored honestly, which it could not be while no test
+  had ever executed. The one runtime-tagged case still scoring `systest: null` is
+  `L2-systest-authoring-basic`, whose most recent run (2026-08-30) predates the
+  config fix.
   `vstest.console.exe` + `RunnableDropSysTest.TestAdapter.dll` discovers zero
   tests: still a dead end, and no longer needed as a fallback.
 - CI-workflow half of the autonomous improver. The VM-free fix-brief generator

--- a/eval/cases/L0-create-readback-no-reindex.json
+++ b/eval/cases/L0-create-readback-no-reindex.json
@@ -7,7 +7,7 @@
     "AxEnum"
   ],
   "golden_path": "eval/goldens/L0-create-readback-no-reindex/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "AxEnum/@Id",
     "AxEnum/EnumValues/AxEnumValue/@Id",

--- a/eval/cases/L2-batched-object-reads.json
+++ b/eval/cases/L2-batched-object-reads.json
@@ -4,10 +4,12 @@
   "tier": 2,
   "instruction": "In the sandbox model, add the SAME new field to three standard Microsoft tables via table extensions: VendGroup, PaymTerm and InventItemGroup. The field is EvalNoteText, backed by the existing standard Notes EDT (do NOT invent a new EDT), and must be added to a field group so it surfaces on forms. Do NOT modify any base-table field. TOOL-PATH REQUIREMENT (this is what the case scores, on top of the artifacts): resolve all three base tables in a SINGLE get_object_info call using the plural form -- get_object_info(objects=[{objectType:\"table\",objectName:\"VendGroup\"},{objectType:\"table\",objectName:\"PaymTerm\"},{objectType:\"table\",objectName:\"InventItemGroup\"}]) -- NOT three sequential single-object get_object_info calls. The run record must show exactly ONE get_object_info call covering all three tables; N sequential calls is the failure this case exists to catch (issue #831: get_object_info was called 13 times in one audited session, one object per call, and the batched path was never chosen). All three extensions must build clean.",
   "target_artifact_types": [
+    "AxTableExtension",
+    "AxTableExtension",
     "AxTableExtension"
   ],
   "golden_path": "eval/goldens/L2-batched-object-reads/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "AxTableExtension/@Id",
     "**/AxTableField/@Id",

--- a/eval/cases/L2-coc-extension.json
+++ b/eval/cases/L2-coc-extension.json
@@ -7,7 +7,7 @@
     "AxClass"
   ],
   "golden_path": "eval/goldens/L2-coc-extension/",
-  "systest_pending": true,
+  "systest_pending": false,
   "systest": "eval/systests/L2-coc-extension.xml",
   "ignore": [
     "AxClass/@Id",

--- a/eval/cases/L2-enum-modify-values.json
+++ b/eval/cases/L2-enum-modify-values.json
@@ -7,7 +7,7 @@
     "AxEnum"
   ],
   "golden_path": "eval/goldens/L2-enum-modify-values/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/cases/L2-event-handler-basic.json
+++ b/eval/cases/L2-event-handler-basic.json
@@ -8,7 +8,7 @@
   ],
   "golden_path": "eval/goldens/L2-event-handler-basic/",
   "systest": "eval/systests/L2-event-handler-basic.xml",
-  "systest_pending": true,
+  "systest_pending": false,
   "ignore": [
     "AxClass/@Id",
     "**/ModelSaveInfo"

--- a/eval/cases/L3-batch-basic.json
+++ b/eval/cases/L3-batch-basic.json
@@ -11,7 +11,7 @@
   ],
   "golden_path": "eval/goldens/L3-batch-basic/",
   "systest": "eval/systests/L3-batch-basic.xml",
-  "systest_pending": true,
+  "systest_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/cases/L3-enum-field-form-downgrade-guard.json
+++ b/eval/cases/L3-enum-field-form-downgrade-guard.json
@@ -6,12 +6,13 @@
   "target_artifact_types": [
     "AxEnum",
     "AxTable",
-    "AxForm"
+    "AxForm",
+    "AxMenuItemDisplay"
   ],
   "golden_path": "eval/goldens/L3-enum-field-form-downgrade-guard/",
-  "golden_pending": true,
+  "golden_pending": false,
   "systest": "eval/systests/L3-enum-field-form-downgrade-guard.xml",
-  "systest_pending": true,
+  "systest_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo",

--- a/eval/cases/L3-numberseq-module-slice.json
+++ b/eval/cases/L3-numberseq-module-slice.json
@@ -12,7 +12,6 @@
     "AxForm"
   ],
   "golden_path": "eval/goldens/L3-numberseq-module-slice/",
-  "golden_pending": true,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/cases/L3-sysoperation-dialog-attributes.json
+++ b/eval/cases/L3-sysoperation-dialog-attributes.json
@@ -9,7 +9,7 @@
     "AxClass"
   ],
   "golden_path": "eval/goldens/L3-sysoperation-dialog-attributes/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/cases/L4-bridge-drops-data-entity-primarytable-fields-on-create.json
+++ b/eval/cases/L4-bridge-drops-data-entity-primarytable-fields-on-create.json
@@ -7,7 +7,6 @@
     "AxDataEntityView"
   ],
   "golden_path": "eval/goldens/L4-bridge-drops-data-entity-primarytable-fields-on-create/",
-  "golden_pending": true,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/cases/L4-headerlines-document-slice.json
+++ b/eval/cases/L4-headerlines-document-slice.json
@@ -17,7 +17,7 @@
     "AxSecurityRole"
   ],
   "golden_path": "eval/goldens/L4-headerlines-document-slice/",
-  "golden_pending": true,
+  "golden_pending": false,
   "ignore": [
     "**/@Id",
     "**/ModelSaveInfo"

--- a/eval/corpus/runs/2026-08-31T20__L0-create-readback-no-reindex__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T20__L0-create-readback-no-reindex__278eee3.json
@@ -1,0 +1,63 @@
+{
+  "run_id": "2026-08-31T20__L0-create-readback-no-reindex__278eee3",
+  "case_id": "L0-create-readback-no-reindex",
+  "tier": 0,
+  "timestamp": "2026-08-31T20:08:28.460Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "ConDemoIndexProbeStatus.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "code": "BPErrorLabelIsText",
+        "object": "ConDemoIndexProbeStatus",
+        "message": "Property 'Label' must have a label ID as its value, and 'ConDemoIndexProbeStatus' is not a label ID.",
+        "fixHint": "The Label was never supplied by the caller - the enum XML generator defaulted it to the object name. Omit <Label> (shipped enums do) or route the default through the same auto-label resolution the value labels went through."
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 0
+  },
+  "classification": "TOOL_DEFECT",
+  "platform_build": "7.0.7996.33",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "THE CASE SUBJECT PASSED: d365fo_file(action=\"create\") reported \"Symbol index updated in place - no update_symbol_index call needed\", and the single get_object_info(objectType=\"enum\") read-back that followed resolved ConDemoIndexProbeStatus immediately, returning both values with the right numbers (Open = 0 - @ConDemo:Open, Closed = 1 - @ConDemo:Closed, Extensible: Yes) from _Source: C# bridge. Zero update_symbol_index calls in the run; exactly one read-back call. #830 does not reproduce. The failing dimension is bp_clean, and its cause is a DIFFERENT tool defect the case surfaced incidentally: generateAxEnumXml does `const label = properties?.label || enumName` and then emits <Label> UNCONDITIONALLY (src/tools/xml/xmlTemplateGenerator.ts:542 and :591), so an enum created without an explicit label gets its own NAME written into Label as raw text - a guaranteed BPErrorLabelIsText on every such enum. The guard that exists cannot catch it: autoResolveRawLabels runs resolveInto(properties, \"Label\") BEFORE generation (src/tools/write/createD365File.ts:522), sees properties.label === undefined, and does nothing; the raw text is invented AFTER it, by the generator, and is never re-inspected. The same call converted both VALUE labels correctly (\"created @ConDemo:Open and wrote that reference\"), so the caller reads two reassuring auto-correct notes about the labels that were fine and no note about the one that was not. The correct shape is already implemented elsewhere in the server: generateSmartReport.ts:385 deliberately omits Label when the caption is not a label ID, citing this exact BP rule and the fact that shipped metadata omits Label freely - AxEnum AccountOrder.xml in ApplicationSuite/Foundation has no <Label> at all. SECONDARY, VALIDATOR_GAP: validate_code(mode=\"both\", codeType=\"xml-any\") was run on the produced XML and returned \"no violations found ... Checked 42 rule groups\", then xppbp flagged it - the offline BP validator carries the label-is-text rule only for X++ literals (validateXpp.ts:1007), not for a metadata <Label> element whose value is not an @Ref, so the gate cannot see a class of defect the write path can produce. Two incidental observations, neither a defect: the generator emits <IsExtensible> AFTER <EnumValues>, which matches shipped enums (AccountOrder.xml) - it is the older L0-enum-basic golden that has the non-canonical order; and prepare(create) infers prefix \"ConDemo\" from the sandbox contents, overriding EXTENSION_PREFIX=Con, so the case instruction name \"DemoIndexProbeStatus\" had to be passed as base name \"IndexProbeStatus\" to land on the corpus-conventional ConDemoIndexProbeStatus (prepare warns about the override clearly, so this is friction, not a fault).",
+  "suggested_fix_area": "src/tools/xml/xmlTemplateGenerator.ts generateAxEnumXml (~line 542/591): stop defaulting <Label> to the object name. Omit the element when properties.label is absent - shipped AxEnum metadata omits it freely - and surface a labelAdvisory the way generateSmartReport.ts:385 already does; alternatively re-run the auto-label resolution over generator-supplied defaults. Audit the same `|| objectName` label default in the other generators in that file. Secondary (VALIDATOR_GAP): add an xml-any/xml-table syntax rule to src/tools/analysis/validateXpp.ts that flags a <Label>/<HelpText> element whose value does not start with @, so the offline gate catches what xppbp catches.",
+  "evidence_refs": [
+    "eval/goldens/L0-create-readback-no-reindex/ConDemoIndexProbeStatus.metadata.xml",
+    "eval/goldens/L0-create-readback-no-reindex/README.md",
+    "src/tools/xml/xmlTemplateGenerator.ts",
+    "src/tools/write/createD365File.ts",
+    "src/tools/smart/generateSmartReport.ts",
+    "src/tools/analysis/validateXpp.ts"
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T20__L2-batched-object-reads__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T20__L2-batched-object-reads__278eee3.json
@@ -1,0 +1,58 @@
+{
+  "run_id": "2026-08-31T20__L2-batched-object-reads__278eee3",
+  "case_id": "L2-batched-object-reads",
+  "tier": 2,
+  "timestamp": "2026-08-31T20:36:44.097Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "InventItemGroup.ConDemoExtension.metadata.xml",
+    "PaymTerm.ConDemoExtension.metadata.xml",
+    "VendGroup.ConDemoExtension.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "VALIDATOR_GAP",
+  "platform_build": "7.0.7996.33",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "THE CASE SUBJECT PASSED, MEASURED HONESTLY. Exactly ONE get_object_info call was made in the whole run, and it used the plural objects[] form: get_object_info(objects=[{table,VendGroup},{table,PaymTerm},{table,InventItemGroup},{edt,Notes}]). The response header proves the batch executed as a batch and not as a loop: \"Fetched: 4 object(s) in parallel | Success: 4/4 | Time: 692ms\". Four objects, one round trip, 692 ms total - the Notes EDT was folded into the same call rather than costing a second one. Issue #831 (13 sequential single-object reads in one audited session) does not reproduce on this path: the batched form is discoverable from the tool description, accepts a MIXED objectType array, and returns per-object sections. get_object_info call count for the run: 1.\n\nARTIFACTS. Three AxTableExtension files, produced by the server write path only (d365fo_file action=create with properties.fields[] plus operations[] on the same call, and one d365fo_file action=modify for a shape correction), zero hand-edited XML, zero overwrite=true. Each carries the SAME field EvalNoteText as AxTableFieldString with <ExtendedDataType>Notes</ExtendedDataType> - the existing standard ApplicationPlatform EDT (base String, StringSize -1 memo), not an invented one - and each adds that field to the base-table group Overview through <FieldGroupExtensions>. <FieldModifications /> is empty in all three, so no base-table field was touched. xppc full build of fm-mcp: 0 errors, 0 warnings, 15 s.\n\nTHE INVERTED-KEY CONTRACT DID NOT BITE. The historical table-extension defect (normalizeFieldSpecsForBridge emitted fieldType/extendedDataType while the bridge reads type/edt, so the field, and later its EDT, vanished silently under a green build - see eval/goldens/L2-table-extension, whose case still has to ignore AxTableExtension/Fields/AxTableField/ExtendedDataType for exactly that reason) is fixed on this SHA. properties.fields[{name:\"EvalNoteText\", edt:\"Notes\"}] round-tripped intact. Verified by READING all three files back off disk rather than trusting the success message, and then again by a negative control: deleting the <ExtendedDataType> line from a copy makes the oracle report missing VendGroup.metadata.xml::AxTableExtension/Fields/AxTableField[EvalNoteText]/ExtendedDataType, and renaming one <DataField> makes it report the field-group delta. The golden therefore FAILS on the exact defect it exists to catch; it is not a vacuous snapshot.\n\nVALIDATOR_GAP - THE FINDING, deterministic and VM-free to reproduce. validate_code(mode=\"references\", codeType=\"xml-table\") resolves only the EDT inside an AxTableExtension and reports \"all 1 reference(s) verified\"; it never checks the base table named by the <Name> stem, nor the base field group being extended in <FieldGroupExtensions>. Probe run in this session: the same XML with <Name>VendGroupZZZNotATable.ConDemoExtension</Name> and <AxTableFieldGroupExtension><Name>ZZZNoSuchBaseGroup</Name> came back \"all 1 reference(s) verified against the index. No hallucinated symbols detected.\" Both of those are hard xppc errors - extending a table that does not exist, and extending a field group the base table does not declare - so the gate is a false negative on precisely the two references that are unique to the extension shape. It is also the reference an agent is most likely to get wrong when it has NOT read the base table, i.e. the very shortcut this case is about. Repro needs no VM: feed those two XML strings to the references validator with an index that has Notes but not VendGroupZZZNotATable.\n\nKNOWLEDGE / UX OBSERVATION, NOT A DEFECT - the field-group advisory was the most valuable tool output in the run. The first write created a NEW field group ConDemoNotes inside the extension (the shape the sibling case L2-table-extension approved golden uses). The tool answered: \"No form checked on VendGroup renders field group ConDemoNotes - a group no container names in <DataGroup> generates no controls, so a field in it is on no form. Rendered instead: Overview (form VendGroup, control Grid).\" That is correct, and it contradicted the instruction requirement that the field surface on forms. The run followed the advisory: remove-field-group, then add-field-to-field-group(fieldGroupName:\"Overview\", extendBaseFieldGroup:true, autoCorrect:false), after which the tool confirmed \"Form VendGroup renders field group Overview via <DataGroup> on control Grid - the compiler generates Overview_EvalNoteText for this field, so it is already on the form\". Same confirmation for PaymTerm. Consequence for the catalog: the sibling golden eval/goldens/L2-table-extension/CustGroup.ConExtension.metadata.xml encodes a new group ConNoteInfo that by this same advisory renders on NO form - it builds clean and does not satisfy its own instruction - and it carries two raw-text labels (\"Note info\", \"Note priority\"), which is BPErrorLabelIsText. Worth review when that case is next run; not touched here.\n\nTHIRD-TABLE ASYMMETRY, RECORDED DELIBERATELY. InventItemGroup DOES own a base field group Overview - add-field-to-field-group with extendBaseFieldGroup=true and autoCorrect=false succeeded in strict mode, so it was not silently converted into a new group - but the advisory reports that no form renders it: \"Rendered instead: Forecast, PurchaseTax, SalesTax, Payment, RetailSAFT (form InventItemGroup)\". The run kept Overview on all three tables anyway: uniform artifacts, the semantically right group for a note field, and the instruction reads as a general best-practice statement rather than a per-form audit. Flagged because a future reviewer of this golden will ask, and because the advisory that surfaced it is a load-bearing signal that a plain builds-clean verdict would have hidden.\n\nBP PROVENANCE. xppbp ran via build_d365fo_project(bpCheck:true) and reported 6 warnings, ALL SIX against the shared INPUT fixture table ConDemoNoteHeader (no AutoReport group, no field-group label, no DeveloperDocumentation, no caching, no form ref, no alternate key) and ZERO against any of the three extensions this case produced. bp_clean:1 is scored for the case artifacts; the fixture warnings belong to eval/fixtures/ConDemoNoteHeader.metadata.xml. No labels were authored at all - the field inherits its label from the Notes EDT (@SYS13887) and the extended group is the base table own group - so the sandbox needed no model label file and none was created.\n\nGOLDEN PROVENANCE. Captured with the build-gated capture script: it refuses unless data/.last-build.json shows the model last build succeeded AND was a full build, and refuses any source whose mtime is newer than that build. Sources 20:32, build 20:34 - gate satisfied, three files copied verbatim, byte for byte, no hand authoring. golden_pending was flipped to false and target_artifact_types expanded to one entry per file in the same change.",
+  "suggested_fix_area": "src/tools/validation - validate_code(mode=\"references\", codeType=\"xml-table\") AxTableExtension branch: it resolves <ExtendedDataType> but not (a) the base table in the <Name> stem Base.PrefixExtension and (b) the <Name> of each <AxTableFieldGroupExtension> / <AxTableRelationExtension> / <AxTableIndexExtension> against that base table own collections. Both are compile errors when wrong and both are unique to the extension shape. Secondary, catalog rather than code: eval/goldens/L2-table-extension/CustGroup.ConExtension.metadata.xml pins a never-rendered new field group plus two raw-text labels, which this run advisory shows is the wrong answer to the same instruction wording.",
+  "evidence_refs": [
+    "eval/goldens/L2-batched-object-reads/VendGroup.ConDemoExtension.metadata.xml",
+    "eval/goldens/L2-batched-object-reads/PaymTerm.ConDemoExtension.metadata.xml",
+    "eval/goldens/L2-batched-object-reads/InventItemGroup.ConDemoExtension.metadata.xml",
+    "eval/goldens/L2-batched-object-reads/README.md",
+    "eval/corpus/runs/2026-08-31T20__L2-batched-object-reads__278eee3.json",
+    "eval/goldens/L2-table-extension/CustGroup.ConExtension.metadata.xml"
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T20__L2-enum-modify-values__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T20__L2-enum-modify-values__278eee3.json
@@ -1,0 +1,55 @@
+{
+  "run_id": "2026-08-31T20__L2-enum-modify-values__278eee3",
+  "case_id": "L2-enum-modify-values",
+  "tier": 2,
+  "timestamp": "2026-08-31T20:23:11.356Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "ConDemoModStatus.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 2
+  },
+  "classification": "PASS",
+  "platform_build": "7.0.7996.33",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "THE CASE SUBJECT PASSED. One d365fo_file(action=\"create\") laid the enum down, then every later change went through d365fo_file(action=\"modify\"): add-enum-value Archived=3; modify-enum-value Closed -> Completed (enumValueInt 2 kept); a 2-op batch add-enum-value Temp=4 + remove-enum-value Temp; remove-enum-value Draft. No create overwrite=true anywhere, no hand-edited XML. The final file was READ (not trusted from the success message) and holds exactly Active=1, Completed=2, Archived=3 - no Draft, no Closed, no Temp - and the model full-built with xppc: 0 errors, 0 warnings.\n\nWHAT MADE IT WORK, AND HOW CLOSE IT CAME TO SILENTLY BUILDING THE WRONG ENUM. The final numbering is only correct because the created XML carries EXPLICIT <Value> elements (<Value>1</Value>, <Value>2</Value>; value 0 is omitted by AOT convention). remove-enum-value Draft deletes the positional-zero member, so had the values been positional the survivors would have renumbered to Active=0, Completed=1, Archived=2 - a build-clean enum with the wrong members, exactly the \"compiles is not correct\" failure. The enum op-spec warns that plain positional 0,1,2 numbering is accepted and the numbers are DROPPED, so this run passed useEnumValue:\"Yes\" together with the values at create time. That kept the <Value> elements. A run that trusts the default here would produce a wrong enum that passes build.\n\nOBSERVATION 1 (cosmetic, not scored): the create path emits <UseEnumValue>Yes</UseEnumValue>; the first bridge-backed modify (IMetaEnumProvider.Update) strips it. The bridge is right - Yes is the metamodel default: 0 of 488 shipped ApplicationPlatform AxEnum files serialize Yes, 78 serialize No. Consequence: a create-then-modify enum changes bytes even when the modify op is unrelated to that property, so a golden captured BEFORE any modify would churn on the next run. This golden was captured after the modify chain, so it records the canonical shape.\n\nOBSERVATION 2 - THE NEGATIVE RESULT THE BRIEF ASKED FOR. The known create-path defect (xmlTemplateGenerator.ts:542, `const label = properties?.label || enumName`, which writes the object NAME into <Label> as raw text and earns BPErrorLabelIsText) has NO analogue on the modify path. Probed on a throwaway enum ConDemoProbeLblEnum (created, probed, deleted in this run): add-enum-value with NO enumValueLabel wrote <AxEnumValue><Name>NoLabelValue</Name><Value>1</Value></AxEnumValue> - element omitted, nothing invented; add-enum-value with raw text \"Raw text label\" auto-resolved it to @ConDemo:RawTextLabel and disclosed the correction in the response. add-enum-value / modify-enum-value are clean on this axis. (The case itself never exercised the defect either, because it passes explicit @SYS refs for the enum and every value, as the instruction demands.)\n\nOBSERVATION 3 (friction, already recorded once in the L0-create-readback-no-reindex record): prepare(mode=\"create\", objectName=\"DemoModStatus\") previewed the final name ConDemoDemoModStatus, and create confirmed it - normalizeObjectName concatenates prefix + base and does not collapse the overlapping \"Demo\". The catalog convention is ConDemo<X> (ConDemoNoteStatus, ConDemoModLifecycle), so the object had to be created from base name \"ModStatus\". This run created ConDemoDemoModStatus first, deleted it via d365fo_file(action=\"delete\"), and re-created from the shorter base; both calls behaved correctly, so this is agent-facing friction rather than a tool fault - but it is now the second capture to pay for it.\n\nBP PROVENANCE: xppbp ran (build_d365fo_project bpCheck:true) and reported 6 warnings, ALL SIX against the shared INPUT fixture table ConDemoNoteHeader (missing AutoReport group, no field-group label, no DeveloperDocumentation, no caching, no form ref, no alternate key) and ZERO against ConDemoModStatus. bp_clean:1 is scored for the case artifact; the fixture warnings belong to eval/fixtures/ConDemoNoteHeader.metadata.xml, not to this case.\n\nLABELS: all six labels are standard @SYS refs found through labels(action=\"search\", labelFileId=\"SYS\") - @SYS36398 Status (enum), @SYS95227 Active, @SYS111310 Completed, @SYS89555 Archived, plus @SYS75939 Draft and @SYS14403 Closed on the members the chain later removes. The case therefore needs no model label file at all; the ConDemo label file that appeared during the run was created solely by the observation-2 probe and was removed at rollback.",
+  "suggested_fix_area": "Optional/cosmetic only - nothing in the enum modify-op surface needs a fix. (a) src/tools/xml/xmlTemplateGenerator.ts generateAxEnumXml: stop emitting <UseEnumValue>Yes</UseEnumValue>; it is the metamodel default (0/488 shipped ApplicationPlatform enums serialize it), the C# bridge strips it on the first modify, and its presence makes create-then-modify mutate the file for free. (b) Consider making the enum op-spec note about positional values LOUDER at the create call site: dropping explicit values silently converts a later remove-enum-value into a renumbering, which builds clean and is wrong.",
+  "evidence_refs": [
+    "eval/goldens/L2-enum-modify-values/ConDemoModStatus.metadata.xml",
+    "eval/goldens/L2-enum-modify-values/README.md",
+    "eval/corpus/runs/2026-08-31T20__L2-enum-modify-values__278eee3.json",
+    "src/tools/xml/xmlTemplateGenerator.ts",
+    "src/utils/objectNaming.ts"
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T21__L3-sysoperation-dialog-attributes__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T21__L3-sysoperation-dialog-attributes__278eee3.json
@@ -1,0 +1,59 @@
+{
+  "run_id": "2026-08-31T21__L3-sysoperation-dialog-attributes__278eee3",
+  "case_id": "L3-sysoperation-dialog-attributes",
+  "tier": 3,
+  "timestamp": "2026-08-31T21:25:26.677Z",
+  "server_git_sha": "278eee3",
+  "platform_build": "7.0.7996.33",
+  "generated_artifacts": [
+    "ConDemoRebateContract.metadata.xml",
+    "ConDemoRebateController.metadata.xml",
+    "ConDemoRebateService.metadata.xml"
+  ],
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "PASS",
+  "root_cause_hypothesis": "RE-CAPTURE after 10a8fe2 deleted the 2026-08-30 golden. VERIFIED ON THIS SHA: multi-line attribute blocks now survive d365fo_file(action=\"create\", objectType=\"class\") verbatim in CONTENT - all four attributes on parmCustGroup and on parmIncludeBlocked, both on parmCallerRecId, in order, on the right member, read back off disk. RESIDUAL DEFECT FOUND (does not fail any score dimension, filed as evidence): reindentXppSource in src/utils/xppFormat.ts mis-indents the same construct. terminatesStatement() only treats a SINGLE-LINE attribute as terminating (code.startsWith('[') && code.endsWith(']')); for a multi-line block the opening line does not end in ']' and the closing line does not start with '[' and ']' is not in the /[;{}:]$/ set, so `continues` never clears. Every continuation line AND the method signature line that follows the block get one extra indent level - the signature ends up at 8 spaces while its own '{' sits at 4. Single-line attribute blocks are unaffected (negative control). Cosmetic only: xppc 0/0, xppbp 0 errors, and the golden diff is insensitive because normalize.ts runs both sides through the same reindenter. Same construct family as 10a8fe2: that fix restored the attribute CONTENT, the formatter still does not understand the construct.",
+  "suggested_fix_area": "src/utils/xppFormat.ts - terminatesStatement()/reindentXppSource(): track bracket depth across lines (the same way xmlTemplateGenerator.extractInnerClassMethods was fixed in 10a8fe2) so a multi-line [Attr,\n Attr] block terminates at its ']' and its continuation lines align with the opening '[' instead of gaining a continuation level. VM-free repro: reindentXppSource(\"[A('x'),\n B('y')]\npublic void m()\n{\n}\").",
+  "evidence_refs": [
+    "eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateContract.metadata.xml",
+    "eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateService.metadata.xml",
+    "eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateController.metadata.xml",
+    "eval/corpus/runs/2026-08-30T14__L3-sysoperation-dialog-attributes__f01dfa7.json",
+    "commit 10a8fe2 (deleted the corrupted golden this run replaces)",
+    "src/utils/xppFormat.ts:146-151 terminatesStatement",
+    "src/tools/xml/xmlTemplateGenerator.ts:286-322 (the fixed backward attribute walk)"
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T21__L4-bridge-drops-data-entity-primarytable-fields-on-create__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T21__L4-bridge-drops-data-entity-primarytable-fields-on-create__278eee3.json
@@ -1,0 +1,102 @@
+{
+  "run_id": "2026-08-31T21__L4-bridge-drops-data-entity-primarytable-fields-on-create__278eee3",
+  "case_id": "L4-bridge-drops-data-entity-primarytable-fields-on-create",
+  "tier": 4,
+  "timestamp": "2026-08-31T21:07:12.508Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "AxDataEntityView/ConDemoNoteHeaderProbeEntity"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "rule": "DataEntitySecurityPrivilegeCheck",
+        "severity": "Error",
+        "object": "AxDataEntityView/ConDemoNoteHeaderProbeEntity",
+        "message": "The data entity 'ConDemoNoteHeaderProbeEntity' is not assigned to a security privilege.",
+        "fixHint": "EXPECTED, out of case scope: target_artifact_types is [AxDataEntityView] only, so no AxSecurityPrivilege may be written. xppbp raises this Error for EVERY standalone data entity. The entity/privilege/duty/role chain is covered by case L4-entity-security."
+      },
+      {
+        "rule": "BPCheckAlternateKeyAbsent",
+        "severity": "Warning",
+        "object": "AxTable/ConDemoNoteHeader",
+        "message": "Table ConDemoNoteHeader does not have an alternate key",
+        "fixHint": "Pre-existing on the harness FIXTURE table, not on the artifact this case produced; present in the post-rollback baseline build too."
+      },
+      {
+        "rule": "BPErrorTableMissingGroupAutoReport",
+        "severity": "Warning",
+        "object": "AxTable/ConDemoNoteHeader",
+        "fixHint": "Pre-existing fixture warning."
+      },
+      {
+        "rule": "BPErrorLabelNotDefined",
+        "severity": "Warning",
+        "object": "AxTable/ConDemoNoteHeader/TableFieldGroup/Overview",
+        "fixHint": "Pre-existing fixture warning."
+      },
+      {
+        "rule": "BPErrorDeveloperDocumentationNotDefined",
+        "severity": "Warning",
+        "object": "AxTable/ConDemoNoteHeader",
+        "fixHint": "Pre-existing fixture warning."
+      },
+      {
+        "rule": "BPErrorTableNoCaching",
+        "severity": "Warning",
+        "object": "AxTable/ConDemoNoteHeader",
+        "fixHint": "Pre-existing fixture warning."
+      },
+      {
+        "rule": "BPErrorTableMissingFormRef",
+        "severity": "Warning",
+        "object": "AxTable/ConDemoNoteHeader",
+        "fixHint": "Pre-existing fixture warning."
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "PASS",
+  "platform_build": "7.0.7996.33",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "VERDICT: the mined 2026-06-30 TOOL_DEFECT does NOT reproduce on 278eee3, and neither does the 2026-07-07 follow-up. Classified PASS. Method: ONE d365fo_file(action=create, objectType=data-entity) passing properties.primaryTable=ConDemoNoteHeader and properties.fields=[{NoteId},{Subject}] (plus primaryKeyFields, isPublic, entityCategory=Master, label). The file was then READ BACK OFF DISK from K:/AosService/PackagesLocalDirectory/fm-mcp/fm-mcp/AxDataEntityView/ConDemoNoteHeaderProbeEntity.xml, because the whole point of the mined defect is that the empty skeleton compiled clean - a green build proves nothing here. Evidence in the produced XML (captured verbatim as the golden): (a) <Fields> carries TWO AxDataEntityViewField / i:type=AxDataEntityViewMappedField entries (NoteId, Subject), each with <DataSource>ConDemoNoteHeader</DataSource> - NOT an empty <Fields /> element; (b) <ViewMetadata><DataSources> carries AxQuerySimpleRootDataSource with Name=ConDemoNoteHeader and Table=ConDemoNoteHeader plus both AxQuerySimpleDataSourceField entries - i.e. the query IS rooted on the passed table, NOT an empty <ViewMetadata /> element; (c) <Keys> carries EntityKey over NoteId, derived from primaryKeyFields - the empty-skeleton branch cannot emit it either. Runtime corroboration beyond metadata: SyncEngine built and installed the SQL view CONDEMONOTEHEADERPROBEENTITY over CONDEMONOTEHEADER. An earlier identical run under the first name logged the literal DDL: CREATE VIEW [DBO].[CONDEMONOTEHEADERENTITY] AS SELECT T1.NOTEID AS NOTEID, T1.SUBJECT AS SUBJECT, T1.RECVERSION, T1.PARTITION, T1.RECID FROM CONDEMONOTEHEADER T1. An entity with no data source cannot produce that SQL. The 2026-07-07 follow-up defect is also fixed: create no longer emits DataManagementEnabled=Yes plus DataManagementStagingTable=(EntityName)Staging for a staging table it never creates. Both elements are ABSENT from the output and dataManagementEnabled is now an explicit opt-in. NEGATIVE CONTROL run in the same session so the PASS is discriminating rather than merely unobserved: the same create with primaryTable and fields OMITTED is REFUSED - \"Data entity ConDemoNegControlEntity: missing primaryTable and fields - nothing was written\" - and no file appears on disk (assertDataEntityIsFunctional). The silent-empty-entity failure mode is now unreachable. Where the fix lives: src/tools/xml/dataEntityXml.ts (buildAxDataEntityXml plus assertDataEntityIsFunctional). The data-entity path is no longer inline in xmlTemplateGenerator.ts (it delegates), and data-entity is deliberately absent from BRIDGE_CREATE_TYPES in src/bridge/bridgeAdapter.ts, so create goes through this TS builder, not the C# bridge. CROSS-CHECK: the captured XML is byte-identical to the independently captured 2026-07-23 golden of case L4-entity-security (eval/goldens/L4-entity-security/ConDemoNoteHeaderEntity.metadata.xml) except for the object name and the two public-name values, which that case passed explicitly - two captures a month apart, on different platform builds, agreeing on the shape. bp_clean=0 is EXPECTED and NOT a defect: xppbp raises DataEntitySecurityPrivilegeCheck at severity Error for ANY data entity not covered by an AxSecurityPrivilege, and this case may write exactly one artifact file. The other 6 BP warnings are all on the harness FIXTURE table and are present in the post-rollback baseline build too. Backing-table choice (deliberate): the committed sandbox fixture ConDemoNoteHeader rather than a standard table, because (i) it lives in the SAME model as the entity so no Descriptor package reference can confound the build, (ii) it is repo-committed and byte-stable (eval/fixtures/ConDemoNoteHeader.metadata.xml, verified unmutated before and after the run) so the golden is reproducible, and (iii) it is fixture-excluded from rollback, keeping this case output to exactly the one AxDataEntityView file it declares. HARNESS FINDING (not a server defect; the guardrail worked): the first capture used the obvious name ConDemoNoteHeaderEntity, which case L4-entity-security already owns as artifact 1 of 5. tests/eval/goldenNameCollision.test.ts caught it, and the artifact was renamed to ConDemoNoteHeaderProbeEntity and re-created, rebuilt and re-captured through the same path. prepare(mode=create) had reported no collision for the clashing name - correctly, since it consults the LIVE sandbox index, which the previous rollback had emptied. That blind spot is exactly what the collision test exists to cover; no change requested. RESIDUAL, low severity, recorded as an observation and not a defect claim: prepare(mode=create, objectType=data-entity) prints the properties contract but omits (i) the label property entirely - a real supported property whose default is the ENTITY NAME as raw text, which trips BPErrorLabelIsText unless the caller passes an at-Ref (this run passed @TaxTransactionInquiry:HeaderNote and stayed clean), and (ii) any warning that a standalone entity always trips DataEntitySecurityPrivilegeCheck. Fact (ii) IS in get_knowledge for data entities, but only inside the data-entity-EXTENSION bullet list, so neither prepare nor the op-spec surfaces it for a plain create.",
+  "suggested_fix_area": "NOTHING TO FIX for the mined defect - recommend the improver close it as CONFIRMED FIXED and cite this record plus the negative control. Optional, low priority (single observation, do not act on one data point): add the label property and a DataEntitySecurityPrivilegeCheck heads-up to the data-entity create contract emitted by the op-spec lookup and by prepare(mode=create) - the op-spec entry for objectType=data-entity and the prepare create-mode write-contract renderer. The underlying rule already exists in src/tools/knowledge/xppKnowledge.ts under data-entities.",
+  "evidence_refs": [
+    "eval/goldens/L4-bridge-drops-data-entity-primarytable-fields-on-create/ConDemoNoteHeaderProbeEntity.metadata.xml (byte-identical capture of the produced file)",
+    "K:/AosService/PackagesLocalDirectory/fm-mcp/fm-mcp/AxDataEntityView/ConDemoNoteHeaderProbeEntity.xml (rolled back after capture)",
+    "eval/fixtures/ConDemoNoteHeader.metadata.xml (backing table; harness fixture, kept through rollback, verified unmutated)",
+    "src/tools/xml/dataEntityXml.ts (buildAxDataEntityXml + assertDataEntityIsFunctional - where both defects were fixed)",
+    "src/bridge/bridgeAdapter.ts BRIDGE_CREATE_TYPES (data-entity absent, so create uses the TS builder, not the C# bridge)",
+    "eval/goldens/L4-entity-security/ConDemoNoteHeaderEntity.metadata.xml (independent 2026-07-23 capture; same shape)",
+    "eval/corpus/runs/2026-07-07T12__L4-bridge-drops-data-entity-primarytable-fields-on-create__cb1b73d.json (prior run)"
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T22__L3-enum-field-form-downgrade-guard__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T22__L3-enum-field-form-downgrade-guard__278eee3.json
@@ -1,0 +1,91 @@
+{
+  "run_id": "2026-08-31T22__L3-enum-field-form-downgrade-guard__278eee3",
+  "case_id": "L3-enum-field-form-downgrade-guard",
+  "tier": 3,
+  "timestamp": "2026-08-31T22:01:17.538Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "ConDemoServiceTier.metadata.xml",
+    "ConDemoTaxChangeLog.metadata.xml",
+    "ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml",
+    "ConDemoTaxChangeLogDetails.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "object": "ConDemoTaxChangeLog",
+        "moniker": "BPErrorTablePrimaryKeyEditable",
+        "severity": "Warning",
+        "path": "dynamics://Table/ConDemoTaxChangeLog/TableIndex/ChangeLogIdx/TableIndexField/ChangeLogId"
+      },
+      {
+        "object": "ConDemoTaxChangeLog",
+        "moniker": "BPErrorLabelNotDefined",
+        "severity": "Warning",
+        "path": "dynamics://Table/ConDemoTaxChangeLog/TableFieldGroup/Overview"
+      },
+      {
+        "object": "ConDemoTaxChangeLog",
+        "moniker": "BPErrorDeveloperDocumentationNotDefined",
+        "severity": "Warning",
+        "path": "dynamics://Table/ConDemoTaxChangeLog"
+      },
+      {
+        "object": "ConDemoTaxChangeLogDetails",
+        "moniker": "BPErrorLabelIsText",
+        "severity": "Warning",
+        "path": "dynamics://Form/ConDemoTaxChangeLogDetails/FormDesign/FormDesign/FormTabControl/Tab/FormTabPageControl/TabPageGeneral",
+        "note": "scaffold wrote Caption=General as raw text"
+      },
+      {
+        "object": "ConDemoTaxChangeLogDetails",
+        "moniker": "BPErrorMenuItemNotCoveredByPrivilege",
+        "severity": "Warning",
+        "path": "dynamics://MenuItemDisplay/ConDemoTaxChangeLogDetails"
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": true,
+    "passed": true,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": 1,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT",
+  "platform_build": "7.0.7996.33",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "d365fo_file(action=\"create\", objectType=\"enum\") DROPS explicit positional <Value> elements (documented as \"plain 0,1,2 numbering states nothing the order does not, so the numbers are dropped\"). That premise is false for AxEnum XML: an <AxEnumValue> WITHOUT a <Value> child is 0, not \"the next ordinal\". The enum was written with None/Silver/Gold/Platinum ALL equal to 0. It compiled with 0 errors, was xppbp-clean, and the golden shape looked right - only the SysTest caught it (testDowngradeIsRejected: expected False, actual True; probe class read enum2int(cur)=0, enum2int(orig())=0 for a Gold row). Repairing it needed a second, undocumented step: d365fo_file(modify, operation=\"modify-enum-value\", enumValueInt=n), which DOES write <Value> - and which then also dropped <UseEnumValue>No</UseEnumValue> that create had written. Shipped enums (e.g. Foundation/CustVendDisputeStatus) carry BOTH <UseEnumValue>No</UseEnumValue> AND explicit <Value> on every member after the first, and are IsExtensible=true at the same time - contradicting the op-spec claim that xppc requires no <Value> on an extensible enum. SECOND, independent defect: modify-property on a table accepted propertyPath=\"FormRef\" with a FORM name and wrote it verbatim; FormRef resolves to a MENU ITEM DISPLAY, so the next build failed with \"Menu item display ConDemoTaxChangeLogDetails does not exist\". THIRD: get_object_info(objectType=\"form\") did not list the two child controls of the DataGroup-bound Overview group that the scaffold had written (reported Controls: 14, XML had 16) - the case instruction tells the agent to read the group back with exactly that call. FOURTH: the SimpleListDetails scaffold writes <Caption>General</Caption> as raw text on TabPageGeneral, which is BPErrorLabelIsText.",
+  "suggested_fix_area": "tools/fileOperations enum create (stop dropping <Value>; write it for every member after index 0, keep <UseEnumValue> stable across create/modify); table modify-property (validate FormRef against menu-item-display, not form); tools/objectInfo form reader (children of a DataGroup-bound group); generateObject form scaffold (TabPage Caption must be a label id); op-spec text for enum create + add-field-group label.",
+  "evidence_refs": [
+    "eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoServiceTier.metadata.xml",
+    "eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLog.metadata.xml",
+    "eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLogDetails.metadata.xml",
+    "eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml",
+    "eval/systests/L3-enum-field-form-downgrade-guard.xml",
+    "K:/AosService/PackagesLocalDirectory/ApplicationSuite/Foundation/AxEnum/CustVendDisputeStatus.xml"
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T22__L3-numberseq-module-slice__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T22__L3-numberseq-module-slice__278eee3.json
@@ -1,0 +1,58 @@
+{
+  "run_id": "2026-08-31T22__L3-numberseq-module-slice__278eee3",
+  "case_id": "L3-numberseq-module-slice",
+  "tier": 3,
+  "timestamp": "2026-08-31T22:20:36.364Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "ConDemoNumberSeqModuleSlice.metadata.xml",
+    "ConDemoSliceId.metadata.xml",
+    "ConDemoSliceNumberSeqHandler.metadata.xml",
+    "ConDemoSliceParameters.metadata.xml",
+    "ConDemoSliceParametersForm.metadata.xml",
+    "NumberSeqModule.ConDemoExtension.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {},
+      {},
+      {},
+      {},
+      {}
+    ]
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 3
+  },
+  "classification": "TOOL_DEFECT",
+  "root_cause_hypothesis": "(1) TOOL_DEFECT — d365fo_file(modify, operation=\"modify-field\") drops allowEdit: src/tools/write/modifyD365File.ts:2084-2100 maps only fieldLabel/fieldHelpText/fieldMandatory/fieldType/fieldEnumType/fieldStringSize onto the bridge props, while the C# bridge already supports it (SupportedTableFieldProperties = { label, helpText, mandatory, allowEdit, extendedDataType, stringSize, enumType }, MetadataWriteService.cs:4164-4183). add-field/create(table) have no allowEdit either. Consequence measured here: the singleton parameters table cannot get AllowEdit=No on its Key field through any grounded path, so xppbp raises BPErrorTablePrimaryKeyEditable (shipped AssetParameters.Key carries AllowEdit=No + AllowEditOnCreate=No + Visible=No). | (2) TOOL_DEFECT — the TableOfContents form scaffold writes raw-text tab captions and leaves the TabPage Caption unset: 4 of the 5 BP warnings on this case output (BPErrorLabelIsText x2 for Caption \"General\"/\"Setup\", BPErrorCaptionNotDefined x2 on TabPageGeneral/TabPageSetup). Same generator shape is already frozen in the committed L1-form-tableofcontents golden, so this recurs on every TOC capture. Recurrence of the already-recorded raw-text-caption class, now with xppbp evidence. | (3) VALIDATOR_GAP (oracle) — prefix canonicalisation in the multi-artifact resolver does not handle DOT-NOTATION extension filenames. Measured: golden NumberSeqModule.ConDemoExtension.metadata.xml vs byte-identical actual NumberSeqModule.ConExtension.xml scores 3 missing / golden_match 0 (golden canonicalises to NumberSeqModule.PFXDemoExtension, actual to NumberSeqModule.PFXExtension). Same subsystem makes the COMMITTED L2-numberseq-basic golden filename NumberSeqModuleExt.AxEnumExtension.metadata.xml unresolvable against the real AOT file NumberSeqModule.ConExtension.xml: re-running that case reports a phantom 3-missing mismatch. src/eval/oracle/actualArtifactResolution.ts + artifactKey.ts. | (4) KNOWLEDGE_GAP (low) — get_knowledge(topic=\"number-sequences\") states \"override loadModule() and call super() at the top\". No shipped NumberSeqApplicationModule subclass does (NumberSeqModuleAsset, NumberSeqModuleCustomer, ContactPerson handler), and the base loadModule() body is empty. Harmless at compile time, but it is asserted as a rule. | NOT a defect (probed, negative result): d365fo_file(create, objectType=\"enum-extension\") PRESERVES explicit <Value> elements — probe WHSWorkExecuteMode.ConDemoExtension with value 4100/4200 read back off disk with both <Value> nodes intact. The case own enum extension deliberately carries NO <Value>, which matches shipped NEW-value extensions (FleetManagement/CostAccounting/AssetLeasing); only legacy AX2012-migrated ones (ApplicationSuiteExtension/Retail/Ledger) pin numbers.",
+  "suggested_fix_area": "src/tools/write/modifyD365File.ts (modify-field: forward fieldAllowEdit -> bridge allowEdit; add-field/create-table field spec) ; src/utils/formPatternTemplates.ts (TableOfContents sub-pattern tab captions) ; src/eval/oracle/artifactKey.ts + actualArtifactResolution.ts (dot-notation extension prefix canonicalisation) ; src/tools/knowledge/xppKnowledge.ts (number-sequences: drop the super() rule)",
+  "evidence_refs": [
+    "eval/goldens/L3-numberseq-module-slice/ (6 artifacts, build-gated capture)",
+    "K:/AosService/PackagesLocalDirectory/fm-mcp/fm-mcp/AxTable/ConDemoSliceParameters.xml",
+    "K:/AosService/PackagesLocalDirectory/fm-mcp/fm-mcp/AxForm/ConDemoSliceParametersForm.xml",
+    "K:/AosService/PackagesLocalDirectory/ApplicationSuite/Foundation/AxTable/AssetParameters.xml (AllowEdit=No on Key)",
+    "K:/AosService/PackagesLocalDirectory/ApplicationSuite/Foundation/AxClass/NumberSeqModuleAsset.xml (buildModulesMapSubsciber)",
+    "bridge/D365MetadataBridge/Services/MetadataWriteService.cs:4164-4183 (allowEdit supported by the bridge)",
+    "src/tools/write/modifyD365File.ts:2084-2100 (allowEdit not forwarded)"
+  ],
+  "notes": "xppc: 0 errors, 0 warnings (fullBuild). xppbp: 11 warnings total, 6 of which belong to the ConDemoNoteHeader FIXTURE (pre-existing, not this case output); the 5 counted here are this case own objects. No dbSync run — no SQL tables created."
+}

--- a/eval/corpus/runs/2026-08-31T22__L4-headerlines-document-slice__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T22__L4-headerlines-document-slice__278eee3.json
@@ -1,0 +1,163 @@
+{
+  "run_id": "2026-08-31T22__L4-headerlines-document-slice__278eee3",
+  "case_id": "L4-headerlines-document-slice",
+  "tier": 4,
+  "timestamp": "2026-08-31T22:51:11.650Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "AxEnum/ConDemoRentStatus.xml",
+    "AxEdt/ConDemoRentAgreementId.xml",
+    "AxTable/ConDemoRentHeader.xml",
+    "AxTable/ConDemoRentLine.xml",
+    "AxEnumExtension/NumberSeqModule.ConDemoRent.xml",
+    "AxClass/ConDemoNumberSeqModuleRent.xml",
+    "AxForm/ConDemoRentAgreement.xml",
+    "AxMenuItemDisplay/ConDemoRentAgreementMI.xml",
+    "AxSecurityPrivilege/ConDemoRentMaintain.xml",
+    "AxSecurityDuty/ConDemoRentDuty.xml",
+    "AxSecurityRole/ConDemoRentClerk.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "code": "BPErrorLabelIsText",
+        "object": "AxForm/ConDemoRentAgreement/LineViewHeader",
+        "message": "Property Caption must have a label ID as its value, and Header is not a label ID.",
+        "fixHint": "DetailsTransaction scaffold writes raw-text tab captions."
+      },
+      {
+        "code": "BPErrorLabelIsText",
+        "object": "AxForm/ConDemoRentAgreement/LineViewLines",
+        "message": "Caption Lines is not a label ID."
+      },
+      {
+        "code": "BPErrorLabelIsText",
+        "object": "AxForm/ConDemoRentAgreement/LineViewLineDetails",
+        "message": "Caption Line details is not a label ID."
+      },
+      {
+        "code": "BPErrorLabelIsText",
+        "object": "AxForm/ConDemoRentAgreement/TabLineGeneral",
+        "message": "Caption General is not a label ID."
+      },
+      {
+        "code": "BPErrorLabelIsText",
+        "object": "AxForm/ConDemoRentAgreement/TabHeaderGeneral",
+        "message": "Caption General is not a label ID."
+      },
+      {
+        "code": "BPCheckPassiveJoinUse",
+        "object": "AxForm/ConDemoRentAgreement/LineViewLineDetails",
+        "message": "Use passive join on the datasource ConDemoRentLine which is bound to a tab page control.",
+        "fixHint": "Scaffold emits LinkType=Delayed; a tab page bound to its own datasource needs a passive join."
+      },
+      {
+        "code": "BPUpgradeMetadataDeleteAction",
+        "object": "AxTable/ConDemoRentHeader",
+        "message": "DeleteAction ConDemoRentLine has no explicit relation set.",
+        "fixHint": "Same delete-action element the bridge round-trip corrupted - see root_cause_hypothesis reproduction 2."
+      },
+      {
+        "code": "BPErrorTablePrimaryKeyEditable",
+        "object": "AxTable/ConDemoRentHeader/RentAgreementIdx/RentAgreementId",
+        "message": "The primary key must not be editable.",
+        "fixHint": "table create sets PrimaryIndex/ReplacementKey/AlternateKey but never AllowEdit=No on the key fields."
+      },
+      {
+        "code": "BPErrorTablePrimaryKeyEditable",
+        "object": "AxTable/ConDemoRentLine/RentLineIdx/RentAgreementId",
+        "message": "The primary key must not be editable."
+      },
+      {
+        "code": "BPErrorTablePrimaryKeyEditable",
+        "object": "AxTable/ConDemoRentLine/RentLineIdx/LineNum",
+        "message": "The primary key must not be editable."
+      },
+      {
+        "code": "BPErrorDeveloperDocumentationNotDefined",
+        "object": "AxTable/ConDemoRentHeader",
+        "message": "The mandatory property DeveloperDocumentation is not specified.",
+        "fixHint": "developerDocumentation is not in the d365fo_file create table contract at all."
+      },
+      {
+        "code": "BPErrorDeveloperDocumentationNotDefined",
+        "object": "AxTable/ConDemoRentLine",
+        "message": "The mandatory property DeveloperDocumentation is not specified."
+      },
+      {
+        "code": "BPErrorEDTNotMigrated",
+        "object": "AxTable/ConDemoRentHeader/CustAccount",
+        "message": "The relation under the EDT CustAccount must be migrated to a table relation.",
+        "fixHint": "Inherent to the case-mandated standard CustAccount EDT; an explicit CustTable table relation IS present."
+      },
+      {
+        "code": "BPUpgradeMetadataEDTRelation",
+        "object": "AxTable/ConDemoRentHeader",
+        "message": "EDT relation found in field CustAccount; should be migrated to a regular table relation."
+      }
+    ],
+    "note": "xppc: 0 errors, 0 warnings on a FULL build (fullBuild:true) after a clean incremental build. The 2026-07-07 run of this same case FAILED to build; that form-scaffold defect is fixed.",
+    "bp_warnings_note": "xppbp reported 20 warnings for the whole model; 6 belong to the repo FIXTURE table ConDemoNoteHeader (BPCheckAlternateKeyAbsent, BPErrorTableMissingGroupAutoReport, BPErrorLabelNotDefined, BPErrorDeveloperDocumentationNotDefined, BPErrorTableNoCaching, BPErrorTableMissingFormRef) and are NOT attributable to this case. The 14 recorded here belong to this case."
+  },
+  "golden_diff": {
+    "matched": true,
+    "missing": [],
+    "extra": [],
+    "changed": []
+  },
+  "systest": {
+    "ran": false,
+    "passed": null,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 1,
+    "systest": null,
+    "tier_weight": 4
+  },
+  "classification": "TOOL_DEFECT",
+  "platform_build": "10.0.40",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": [],
+      "note": "validate_code(mode=references) on ConDemoNumberSeqModuleRent verified 21/21 references, including the brand-new enum-extension value NumberSeqModule::DemoRent and the kernel enum NoYes. The NoYes false positive recorded in the 2026-07-07 run of this case and in L3-numberseq-module-slice did NOT reproduce - the kernel-enum fix has landed. Both AxTable XMLs were written by d365fo_file, whose create path runs reference resolution internally under GROUNDING_ENFORCE."
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    },
+    "form_pattern_validate": {
+      "passed": true,
+      "violations": [],
+      "note": "object_patterns(domain=form, action=validate, formName=ConDemoRentAgreement): 0 errors, 3 FP002 warnings (sub-pattern FieldsFieldGroups v1.1 older than current v1.2) - the generator emits the version its own validator flags. It did NOT flag the five raw-text tab Captions that xppbp then rejected with BPErrorLabelIsText."
+    }
+  },
+  "root_cause_hypothesis": "HEADLINE TOOL_DEFECT (new, reproduced TWICE in this run): any table property or collection element that d365fo_file writes through the server's OWN XML-writer fallback is SILENTLY DESTROYED by the next bridge-backed modify (IMetadataProvider.Update()) on the same object. Both writes report \"applied\" and \"Verified: on disk\", because that verification only checks file existence/size, never that the value survived. REPRODUCTION 1 - CacheLookup: d365fo_file(create, table ConDemoRentLine, cacheLookup:\"None\") reported \"Written after the create (the metadata writer dropped it): <CacheLookup>None</CacheLookup> - the C# bridge SetAxTableProperty() does not know CacheLookup\", i.e. the TS layer patched the XML directly. The very next call, modify(add-relation) via IMetaTableProvider.Update, round-tripped the file and CacheLookup was gone. grep confirms ConDemoRentLine.xml has no CacheLookup element, while ConDemoRentHeader.xml (whose Found value came from the bridge own BP-defaults path) still has it. Effect: a Transaction table silently falls back to default caching instead of the requested None. REPRODUCTION 2 - DeleteAction, and this one breaks a MANDATED requirement of the case: modify(add-delete-action, deleteActionType:\"Cascade\") on ConDemoRentHeader ran through the XML writer (\"applied via this server XML writer (no bridge path for this operation)\") and correctly produced <AxTableDeleteAction><Name>ConDemoRentLine</Name><Table>ConDemoRentLine</Table><DeleteAction>Cascade</DeleteAction>. This is PROVEN by the backup ConDemoRentHeader.xml.backup-2026-08-31T22-38-50-394, which the NEXT operation took immediately before writing. That next operation was modify(modify-property, FormRef) via IMetadataProvider.Update, after which the on-disk element is <Name> + <Table> with NO <DeleteAction> - the cascade degraded to the metamodel default. xppbp independently corroborates with BPUpgradeMetadataDeleteAction \"DeleteAction ConDemoRentLine has no explicit relation set\". The model still builds with 0 errors, so ONLY a golden/metadata oracle catches this: exactly the \"compiles clean but wrong shape\" class the oracle exists for. SECOND-ORDER DEFECT that blocks the forward-only repair: src/tools/write/directXmlWriters.ts:1194 keys its idempotency guard on the delete action NAME alone (blockRe matches <AxTableDeleteAction><Name>X</Name>) and returns \"already present - skipped (idempotent)\" without comparing the requested DeleteAction TYPE to the one on disk. Re-running add-delete-action(Cascade) would therefore NOT restore Cascade; restoring it needs remove-delete-action + add-delete-action, i.e. the delete-and-recreate this case explicitly forbids. The run left both corrupted writes in place. THIS IS THE TERMINAL FINDING: the composite shape this case specifies cannot be produced correctly through the grounded tool path today, even though it builds clean. CONSEQUENCE FOR THE GOLDEN: the captured ConDemoRentHeader.metadata.xml carries the CORRUPTED delete action. golden_pending was deliberately LEFT TRUE - approving this golden would enshrine the bug as the contract and would make a future FIXED server score golden_match=0. Re-capture that one artifact after the fix, then flip the flag. ORDERING WORKAROUND for anyone re-running before the fix: perform every XML-writer-backed operation (add-delete-action, explicit CacheLookup) LAST, after all bridge-backed modifies on that object. KNOWLEDGE_GAP (documentation defect, directly caused the 2026-07-07 failure of this same case): get_knowledge(kind=\"op-spec\", topic=\"scaffold:form\") omits linesTable and linesDataSource from its optional list (src/tools/specs/generateObjectOpSpecs.ts:259-267), although src/tools/smart/generateSmartForm.ts:41-42,76-88 implements them and they are the ONLY way to get a correct DetailsTransaction lines datasource. An agent following the documented contract passes dataSource alone and gets the 2026-07-07 outcome: a fabricated ConDemoRentHeaderLine datasource pointing at a nonexistent table, and a build failure. Passing the undocumented linesTable produced a correct two-datasource form (ConDemoRentLine, JoinSource=ConDemoRentHeader, LinkType=Delayed, lines grid bound to the real table) that builds clean - so the GENERATOR bug is fixed but is unreachable from the documented surface. TOOL_DEFECT (naming, forced a non-conventional object name): applyObjectPrefix (src/utils/modelClassifier.ts:304-308) unconditionally rewrites ANY dot-notation extension suffix ending in \"extension\" to {Infix}Extension, so a second, differently-named extension of the same base enum in one model is impossible: \"NumberSeqModule.ConDemoRentExtension\" would silently become \"NumberSeqModule.ConDemoExtension\", which is already the golden artifact of L3-numberseq-module-slice and would fail tests/eval/goldenNameCollision.test.ts. Worked around by passing the model-name-style suffix \"NumberSeqModule.ConDemoRent\" (no \"Extension\" word), which lines 310-311 preserve verbatim. Legal AOT, builds clean, but non-conventional. ORACLE DEFECT (minor, hit while writing THIS record): in the goldenUnavailable + --actual-dir branch of src/eval/oracle/cli.ts, generated_artifacts is filled by filtering the actual dir for *.metadata.xml only, while an actual-dir idiomatically holds bare AOT *.xml (resolveActualFile / aotToMetadataName support both everywhere else). Every golden_pending CAPTURE run therefore records generated_artifacts: [] - a silent zero. The list in this record was filled in afterwards. VALIDATOR_GAP: object_patterns(action=\"validate\") passed the form with 0 errors while xppbp then raised 5 BPErrorLabelIsText on tab Captions the scaffold itself wrote as raw text, plus BPCheckPassiveJoinUse on the datasource the scaffold itself bound. The form validator could catch both pre-build; it instead emitted 3 FP002 warnings that the generator own PatternVersion 1.1 is older than the catalog 1.2 - the server flagging itself. KNOWLEDGE_GAP (BP defaults): d365fo_file(create, table) advertises \"BP defaults\" and sets CacheLookup/TitleField/PrimaryIndex/ClusteredIndex, yet leaves three BP warnings per table that it is positioned to prevent: BPErrorTablePrimaryKeyEditable (x3 - it sets ReplacementKey/AlternateKey but never AllowEdit=No on the key fields) and BPErrorDeveloperDocumentationNotDefined (x2 - developerDocumentation is not even in the create contract). FIXED SINCE THE 2026-07-07 RUN, each verified by disk read-back this run: (a) the DetailsTransaction lines-datasource fabrication (via linesTable); (b) security-duty emitting AxSecurityRolePermissionSet - it now emits AxSecurityPrivilegeReference, and the role emits AxSecurityDutyReference; (c) add-delete-action now exists as an operation; (d) the NoYes reference false positive; (e) the enum explicit-value drop, mitigated by useEnumValue:\"Yes\" (values 1/2/3 present on disk, 0 correctly implicit).",
+  "suggested_fix_area": "1. HIGHEST VALUE - src/tools/write/modifyD365File.ts plus the C# bridge Update path: make a bridge-backed modify PRESERVE table properties/elements the bridge metamodel writer does not itself round-trip (CacheLookup, AxTableDeleteAction/DeleteAction). Either re-apply the TS XML patches after every bridge Update, or read the pre-modify file, diff the post-modify file, and restore any element the operation did not intend to touch. Add regression tests: create(cacheLookup:\"None\") then add-relation, assert CacheLookup survives; add-delete-action(Cascade) then modify-property, assert DeleteAction survives. 2. Make the write-verification honest: \"Verified: on disk\" currently proves only existence/size. It should re-read the file and assert the value the operation claimed to set is actually present. That alone would have turned both of this run silent corruptions into loud failures. 3. src/tools/write/directXmlWriters.ts:1194 - the add-delete-action idempotency guard must compare the DeleteAction TYPE (and Table), not just the Name, and UPDATE a differing entry in place instead of reporting \"already present - skipped\". Without this there is no forward-only repair path at all. 4. src/tools/specs/generateObjectOpSpecs.ts:259-267 - add linesTable and linesDataSource to the scaffold:form optional list, and mention them in the DetailsTransaction pattern/knowledge spec. A one-line fix that closes the exact gap that failed this case on 2026-07-07. 5. src/eval/oracle/cli.ts goldenUnavailable branch - accept bare *.xml when listing generated_artifacts, consistent with aotToMetadataName elsewhere, so capture runs stop recording an empty artifact list. 6. src/tools/smart/generateSmartForm.ts - emit label refs (or leave Caption unset) instead of raw-text tab captions; bump the FieldsFieldGroups sub-pattern to PatternVersion 1.2 so the generator stops failing its own validator; set a passive join on a lines datasource bound to a tab page control. 7. object_patterns(action=\"validate\") - flag raw-text Caption/Label values and non-passive joins on tab-page-bound datasources, so these are caught before a multi-minute build. 8. d365fo_file(create, table) - add developerDocumentation to the contract and set AllowEdit=No on ReplacementKey/AlternateKey index fields, as part of the \"BP defaults\" it already advertises. 9. src/utils/modelClassifier.ts:304-308 - let an explicitly supplied dot-notation extension suffix survive instead of being rewritten to {Infix}Extension, so one model can carry two differently-named extensions of one base object.",
+  "evidence_refs": [
+    "K:/AosService/PackagesLocalDirectory/fm-mcp/fm-mcp/AxTable/ConDemoRentHeader.xml (delete action WITHOUT a DeleteAction element) [SANDBOX FILE - DELETED BY THE MANDATED POST-RUN ROLLBACK; its exact content is transcribed verbatim in root_cause_hypothesis and in eval/goldens/L4-headerlines-document-slice/]",
+    "K:/AosService/PackagesLocalDirectory/fm-mcp/fm-mcp/AxTable/ConDemoRentHeader.xml.backup-2026-08-31T22-38-50-394 (the SAME element WITH DeleteAction Cascade, taken immediately before the modify-property that dropped it) [SANDBOX FILE - DELETED BY THE MANDATED POST-RUN ROLLBACK; its exact content is transcribed verbatim in root_cause_hypothesis and in eval/goldens/L4-headerlines-document-slice/]",
+    "K:/AosService/PackagesLocalDirectory/fm-mcp/fm-mcp/AxTable/ConDemoRentLine.xml (no CacheLookup element) [SANDBOX FILE - DELETED BY THE MANDATED POST-RUN ROLLBACK; its exact content is transcribed verbatim in root_cause_hypothesis and in eval/goldens/L4-headerlines-document-slice/]",
+    "K:/AosService/PackagesLocalDirectory/fm-mcp/fm-mcp/AxForm/ConDemoRentAgreement.xml (correct 2-datasource DetailsTransaction; raw-text captions) [SANDBOX FILE - DELETED BY THE MANDATED POST-RUN ROLLBACK; its exact content is transcribed verbatim in root_cause_hypothesis and in eval/goldens/L4-headerlines-document-slice/]",
+    "eval/goldens/L4-headerlines-document-slice/ (11 artifacts, build-gated capture)",
+    "src/tools/specs/generateObjectOpSpecs.ts:259-267 (scaffold:form op-spec missing linesTable/linesDataSource)",
+    "src/tools/smart/generateSmartForm.ts:41-42,76-88 (linesTable/linesDataSource implemented)",
+    "src/tools/write/directXmlWriters.ts:1194 (name-only delete-action idempotency guard)",
+    "src/utils/modelClassifier.ts:304-308 (extension suffix unconditionally rewritten)",
+    "eval/corpus/runs/2026-07-07T14__L4-headerlines-document-slice__cb1b73d.json (prior run: build FAILED on the fabricated lines datasource)",
+    "REPRODUCTION RECIPE for the headline defect, no sandbox state needed: (1) d365fo_file(create, table, cacheLookup:\"None\") then d365fo_file(modify, add-relation) -> CacheLookup element is gone; (2) d365fo_file(modify, add-delete-action, deleteActionType:\"Cascade\") then d365fo_file(modify, modify-property) -> the DeleteAction element is gone while Name and Table survive. Both report success and \"Verified: on disk\"."
+  ],
+  "forward_only": "YES. No overwrite:true, no hand-edited XML, no delete-and-recreate, no rollback-and-retry of any written object. The two corrupted writes (CacheLookup=None on ConDemoRentLine, DeleteAction=Cascade on ConDemoRentHeader) were deliberately LEFT CORRUPTED rather than repaired, and the case fails on that dimension. The one documented workaround used, useEnumValue Yes on the enum, was passed on the ORIGINAL create, not as a repair.",
+  "capture_run": true,
+  "capture_notes": [
+    "GOLDEN CAPTURE RUN: this is the run that AUTHORED eval/goldens/L4-headerlines-document-slice/ (11 artifacts, build-gated copy of the exact bytes the full build consumed). golden_match:1 is therefore TAUTOLOGICAL - the actual and the golden are the same bytes by construction - and is NOT an independent correctness signal for this run. It becomes a real signal from the next run of this case onward.",
+    "The golden deliberately records what the tools ACTUALLY produce today, including the corrupted delete action on ConDemoRentHeader (no <DeleteAction>Cascade</DeleteAction>). Per docs/AGENT_EVAL_LOOP.md section 6.4 the fix PR that repairs the bridge round-trip MUST update ConDemoRentHeader.metadata.xml in the same PR, where the diff line +<DeleteAction>Cascade</DeleteAction> is the reviewable evidence the defect is gone. Do NOT treat that golden update as a regression.",
+    "CATALOG SIDE EFFECT: this was the LAST golden_pending case (0 of 120 remain). tests/eval/oracleCli.test.ts picks whichever case is still golden_pending to exercise the scorer degrade-gracefully path, and now fails by design with its own message: \"no case is golden_pending any more - rewrite this suite against a synthetic case spec\". That suite needs a synthetic fixture case; it was NOT touched by this run."
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T23__L2-coc-extension__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T23__L2-coc-extension__278eee3.json
@@ -1,0 +1,62 @@
+{
+  "run_id": "2026-08-31T23__L2-coc-extension__278eee3",
+  "case_id": "L2-coc-extension",
+  "tier": 2,
+  "timestamp": "2026-08-31T23:06:06.450Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "FMVehicleDataContractConDemo_Extension.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": []
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/Name",
+        "expected": "FMVehicleDataContractCon_Extension",
+        "actual": "FMVehicleDataContractConDemo_Extension"
+      },
+      {
+        "path": "AxClass/SourceCode/Declaration",
+        "expected": "[ExtensionOf(classStr(FMVehicleDataContract))]\nfinal class FMVehicleDataContractCon_Extension\n{\n}",
+        "actual": "/// <xmldoc/>\n[ExtensionOf(classStr(FMVehicleDataContract))]\nfinal class FMVehicleDataContractConDemo_Extension\n{\n}"
+      }
+    ]
+  },
+  "systest": {
+    "ran": true,
+    "passed": true,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 1,
+    "golden_match": 0,
+    "systest": 1,
+    "tier_weight": 2
+  },
+  "classification": "VALIDATOR_GAP",
+  "static_gate": {
+    "passed": true,
+    "violations": []
+  },
+  "root_cause_hypothesis": "The IMPLEMENTATION is correct and runtime-verified: full xppc build 0 errors / 0 warnings, xppbp on the artifact 0 warnings, and the committed runtime oracle EvalL2CocCarFactsTest passed 2/2 (testCarFactsSummaryAppendsVerifiedSuffix, testWrapperPreservesBaseValueForDifferentInput) - i.e. `next CarFactsSummary(...)` really is invoked and ' [verified]' is observably appended at the call site. golden_match=0 is entirely an ORACLE/GOLDEN artifact, from two independent causes.\n\n(1) VALIDATOR_GAP - canonicalizePrefix() cannot canonicalise an EXTENSION-CLASS INFIX prefix. Its regex is (^|[^A-Za-z0-9])<token>(?=[A-Z]): it requires the prefix at an IDENTIFIER-START boundary AND followed by an uppercase letter. The MS extension-class convention is {Base}{Prefix}_Extension, where the prefix is MID-identifier (preceded by an alphanumeric) and followed by an underscore. So NEITHER side is canonicalised, and the golden (name normalised to prefix Con) false-mismatches the actual (produced under this session's prefix ConDemo) on AxClass/Name and on the class-name line inside Declaration. MEASURED: with lookahead [A-Z] no substitution happens on either side; with lookahead [A-Z_] STILL no substitution on either side; only dropping the leading identifier-start boundary yields FMVehicleDataContractPFX_Extension on BOTH sides. That means the fix proposed in the earlier corpus record for this very case (2026-07-07T04__L2-coc-extension__cb1b73d: 'change (?=[A-Z]) to (?=[A-Z_])') is INSUFFICIENT and would not have closed the gap - the leading boundary is the blocker, not the lookahead. Every _Extension-suffixed CoC golden in the corpus is affected across any two prefix sessions.\n\n(2) STALE GOLDEN - the committed golden Declaration carries NO class-level /// doc comment, but the current grounded write path always injects one (src/utils/xppDocGen.ts: 'Extension of the <c>FMVehicleDataContract</c> class.'), and generate_object(mode=pattern, pattern=class-extension) also emits one. normalize.ts deliberately COLLAPSES a doc-comment run to a placeholder but keeps its PRESENCE load-bearing (tied to BPXmlDocNoDocumentationComments / bp_clean), so a golden with no class doc comment can never be reproduced through the current tool path. History: the golden was originally captured as FMVehicleDataContractAsl_Extension in 828bcea and then MECHANICALLY renamed Asl -> Con in 39c747c ('eval: replace internal fixture prefixes with generic Con/Demo'), so its Con infix is a repo-normalisation artifact, not a real capture under prefix Con.\n\n(3) TOOL_DEFECT (independent; found while deploying the runtime oracle) - d365fo_file(action=create, objectType=class, xmlContent=<verbatim AxClass XML>) produced a SELF-INCONSISTENT artifact and reported success. Passing objectName=EvalL2CocCarFactsTest together with the full XML, the tool applied the model prefix to the FILENAME (ConDemoEvalL2CocCarFactsTest.xml) and to the X++ CDATA declaration (class ConDemoEvalL2CocCarFactsTest extends SysTestCase) but LEFT the <Name> element at EvalL2CocCarFactsTest - three identities in one file. It answered 'Created class ConDemoEvalL2CocCarFactsTest' and 'Verified: on disk (2683 bytes)', and the next build failed fatally: 'Class dynamics://Class/EvalL2CocCarFactsTest: The element must be named ConDemoEvalL2CocCarFactsTest instead of EvalL2CocCarFactsTest to be consistent with its file name.' Either xmlContent is honoured verbatim (as the tool schema states: 'Complete XML written verbatim') or prefixing is applied consistently to <Name>, filename AND declaration - doing two of the three always yields a broken object. Workaround used: delete + direct verbatim file write + update_symbol_index (harness plumbing only; the case artifact itself went through the grounded path).\n\n(4) minor TOOL_DEFECT - the structured build diagnostic for that naming-consistency fatal error attached an irrelevant remediation hint: 'UpdateConflict (OCC - Optimistic Concurrency Control): Wrap the tts block in a retry loop with a maximum retry count (e.g. 5)'. The error-diagnosis heuristic misfires on a metadata naming error and points the agent at transaction retry logic.",
+  "suggested_fix_area": "src/eval/oracle/prefix.ts - canonicalizePrefix(): add an infix branch for the {Base}{Prefix}_Extension extension-class convention (match the token when it is immediately followed by _Extension, WITHOUT requiring the leading non-alphanumeric boundary). Measured here: widening only the lookahead to [A-Z_] does NOT work. Add a regression test pinning FMVehicleDataContractCon_Extension == FMVehicleDataContractConDemo_Extension.\n\neval/goldens/L2-coc-extension/FMVehicleDataContractCon_Extension.metadata.xml - RE-CAPTURE (or promote this run's artifact to golden): the committed Declaration predates/bypasses the writer's auto-XmlDoc injection, so no faithful grounded rerun can ever match it.\n\nd365fo_file create, xmlContent path - make prefixing all-or-nothing across <Name>, filename and the X++ declaration, or reject/warn when objectName prefixing would contradict the <Name> carried by a caller-supplied xmlContent.\n\nbuild_d365fo_project structured diagnostics - suppress the OCC/UpdateConflict remediation hint for metadata naming-consistency errors.",
+  "evidence_refs": [
+    "eval/corpus/runs/2026-08-31T23__L2-coc-extension__278eee3.json",
+    "eval/corpus/runs/2026-07-07T04__L2-coc-extension__cb1b73d.json (same prefix-infix gap reported 8 weeks ago; its proposed fix is insufficient - measured here)",
+    "src/eval/oracle/prefix.ts (canonicalizePrefix regex: leading boundary + uppercase lookahead)",
+    "src/utils/xppDocGen.ts:177 (auto class-level XmlDoc for extension classes)",
+    "src/eval/oracle/normalize.ts (canonicalizeXppDocComments - doc-comment PRESENCE deliberately load-bearing)",
+    "git 828bcea (original capture as FMVehicleDataContractAsl_Extension) / git 39c747c (mechanical Asl -> Con rename)",
+    "xppc fatal: Class dynamics://Class/EvalL2CocCarFactsTest: The element must be named ConDemoEvalL2CocCarFactsTest instead of EvalL2CocCarFactsTest to be consistent with its file name.",
+    "SysTestConsole.exe: Rainier Test Suite : 2 Run, 0 Failed (both test-case elements success=true)"
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T23__L2-event-handler-basic__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T23__L2-event-handler-basic__278eee3.json
@@ -1,0 +1,78 @@
+{
+  "run_id": "2026-08-31T23__L2-event-handler-basic__278eee3",
+  "case_id": "L2-event-handler-basic",
+  "tier": 2,
+  "timestamp": "2026-08-31T23:22:59.252Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "ConDemoNoteHeaderEH.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "moniker": "BPParameterNotUsed",
+        "path": "dynamics://Class/ConDemoNoteHeaderEH/Method/onInserting",
+        "message": "The parameter '_e' is not used.",
+        "note": "Inherent to the mandatory DataEventHandler signature (Common _sender, DataEventArgs _e); the committed golden carries the identical signature and would produce the identical warning. The other 6 BP warnings in the build belong to the shared fixture table ConDemoNoteHeader, not to this case artifact."
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "AxClass/SourceCode/Declaration",
+        "expected": "class PFXDemoNoteHeaderEH\n{\n}",
+        "actual": "/// <xmldoc/>\nclass PFXDemoNoteHeaderEH\n{\n}"
+      },
+      {
+        "path": "AxClass/SourceCode/Methods/Method[onInserting]/Source",
+        "expected": "[DataEventHandler(tableStr(PFXDemoNoteHeader), DataEventType::Inserting)]\npublic static void onInserting(Common _sender, DataEventArgs _e)\n{\n    PFXDemoNoteHeader noteHeader = _sender as PFXDemoNoteHeader;\n\n    if (!noteHeader.Subject)\n    {\n        noteHeader.Subject = '(no subject)';\n    }\n}",
+        "actual": "/// <xmldoc/>\n[DataEventHandler(tableStr(PFXDemoNoteHeader), DataEventType::Inserting)]\npublic static void onInserting(Common _sender, DataEventArgs _e)\n{\n    PFXDemoNoteHeader noteHeader = _sender as PFXDemoNoteHeader;\n\n    if (!noteHeader.Subject)\n    {\n        noteHeader.Subject = '(no subject)';\n    }\n}"
+      }
+    ]
+  },
+  "systest": {
+    "ran": true,
+    "passed": true,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": 1,
+    "tier_weight": 2
+  },
+  "classification": "TOOL_DEFECT",
+  "platform_build": "X++ Compiler 7.0.7996.33",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": [
+        "DataEventArgs (kernel class - informational warning, not an error)"
+      ]
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "Two findings. (1) PRIMARY, reproducible TOOL_DEFECT (harness plumbing, not the case artifact): d365fo_file(action=\"create\", objectType=\"class\", xmlContent=<verbatim AxClass XML>) produces a self-inconsistent object and still reports \"Created\" + \"Verified: on disk\". Passing objectName=\"EvalL2EventHandlerDefaultSubjectTest\" with verbatim XML wrote filename ConDemoEvalL2EventHandlerDefaultSubjectTest.xml and X++ declaration \"class ConDemoEvalL2EventHandlerDefaultSubjectTest extends SysTestCase\", while <Name> stayed EvalL2EventHandlerDefaultSubjectTest - three identities in one file, which xppc rejects with \"must be named X instead of Y to be consistent with its file name\". Either the prefix must be applied to all three identities or to none when xmlContent is supplied verbatim; the create verification only checks file existence, so it cannot see the inconsistency. Worked around with delete + direct verbatim write + update_symbol_index (harness plumbing only - the case artifact went through the full grounded path). (2) SECONDARY, oracle staleness explaining golden_match=0: the sole diff is a /// XmlDoc block that d365fo_file injects unconditionally via ensureXppDocComment. Commit 0a95198 (2026-08-09, \"Bridge creates get the same doc comments and indentation the XML fallback gives them\") deliberately unified doc-comment injection across the bridge and XML-fallback write paths. This golden was captured 2026-07-01/committed 2026-07-07, i.e. BEFORE that change, so no faithful rerun through the current grounded path can ever match it. This is systematic, not local: all 17 AxClass goldens that lack /// comments were committed 2026-07-07 or 2026-07-23 (8 cases: L1-class-basic, L1-macro-library-flight, L2-business-event-basic, L2-class-method-ops, L2-delegate-basic, L2-enum-extension-empty-values, L2-event-handler-basic, L2-interface-abstract-basic, L2-numberseq-basic, L3-batch-basic, L4-ssrs-report-basic), every one predating 0a95198; every class golden captured after it carries doc comments. The oracle intentionally keeps doc-comment PRESENCE load-bearing (src/eval/oracle/normalize.ts, canonicalizeXppDocComments) because BPXmlDocNoDocumentationComments measures it, so the fix is to RE-CAPTURE those goldens, not to relax the normaliser. The implementation itself is behaviourally correct: full build 0 errors / 0 warnings and the runtime oracle passed 2/2.",
+  "suggested_fix_area": "(1) src/tools/*/d365fo_file create path - prefix canonicalisation when xmlContent is supplied verbatim (all three identities: filename, <Name>, X++ declaration) + strengthen the post-write verification to compare filename/<Name>/declaration rather than only asserting file existence. (2) eval/goldens - re-capture the 17 pre-0a95198 AxClass goldens (8 cases) so they carry the doc comments the current write path emits; do NOT relax src/eval/oracle/normalize.ts.",
+  "evidence_refs": [
+    "d365fo_file(create, xmlContent) response: \"Created class ConDemoEvalL2EventHandlerDefaultSubjectTest (prefixed from EvalL2EventHandlerDefaultSubjectTest)\" + \"Verified: on disk (1572 bytes)\"; file on disk had <Name>EvalL2EventHandlerDefaultSubjectTest</Name> at line 3 but \"class ConDemoEvalL2EventHandlerDefaultSubjectTest extends SysTestCase\" at line 9",
+    "commit 0a95198 (2026-08-09) src/bridge/bridgeAdapter.ts imports ensureXppDocComment; message: \"Bridge creates get the same doc comments and indentation the XML fallback gives them, so the same create no longer lands documented or undocumented depending on whether the bridge was up.\"",
+    "src/utils/xppDocGen.ts ensureXppDocComment is unconditional when the source has no leading /// run (lines 367-409) - no opt-out parameter exists",
+    "prior corpus record 2026-07-07T05__L2-event-handler-basic__cb1b73d.json shows the same case previously produced NO doc comments (its only diff was indentation, since fixed by reindent canonicalisation)",
+    "SysTest raw output: \"Rainier Test Suite : 2 Run, 0 Failed\"; both methods success=true; Isolation: AutoRollback",
+    "run_systest_class per-method: testInsertingWithBlankSubjectGetsDefaulted PASS (asserts Subject == '(no subject)' after insert with blank Subject), testInsertingWithExplicitSubjectIsPreserved PASS (asserts Subject == 'Explicit subject' untouched)",
+    "dbSync NOT needed: CONDEMONOTEHEADER already present in AxDB with NOTEID/SUBJECT/DATAAREAID/PARTITION/RECID/RECVERSION, 0 rows before and after; SysTest isolation AutoRollback left no rows",
+    "build_d365fo_project(fullBuild=true) after test deploy: Errors: 0, Warnings: 0"
+  ]
+}

--- a/eval/corpus/runs/2026-08-31T23__L3-batch-basic__278eee3.json
+++ b/eval/corpus/runs/2026-08-31T23__L3-batch-basic__278eee3.json
@@ -1,0 +1,112 @@
+{
+  "run_id": "2026-08-31T23__L3-batch-basic__278eee3",
+  "case_id": "L3-batch-basic",
+  "tier": 3,
+  "timestamp": "2026-08-31T23:42:37.131Z",
+  "server_git_sha": "278eee3",
+  "generated_artifacts": [
+    "ConDemoBatchContract.metadata.xml",
+    "ConDemoBatchController.metadata.xml",
+    "ConDemoBatchService.metadata.xml",
+    "ConDemoProcessBatch.metadata.xml"
+  ],
+  "build": {
+    "succeeded": true,
+    "errors": [],
+    "bp_checked": true,
+    "bpWarnings": [
+      {
+        "code": "BPErrorMenuItemNotCoveredByPrivilege",
+        "message": "AxMenuItemAction ConDemoProcessBatch is not covered by privilege.",
+        "object": "dynamics://MenuItemAction/ConDemoProcessBatch",
+        "fixHint": "The four target_artifact_types of this case contain no AxSecurityPrivilege, so an action menu item produced exactly to spec can never be xppbp-clean. Either the case spec grows a fifth artifact (a privilege naming the menu item as an entry point) or this moniker becomes a documented, accepted warning for the case."
+      }
+    ]
+  },
+  "golden_diff": {
+    "matched": false,
+    "missing": [],
+    "extra": [],
+    "changed": [
+      {
+        "path": "DemoBatchContract.metadata.xml::AxClass/SourceCode/Declaration",
+        "expected": "[DataContractAttribute]\nclass PFXDemoBatchContract\n{\n    int batchSize;\n    int priorityFactor;\n}",
+        "actual": "/// <xmldoc/>\n[DataContractAttribute]\nclass PFXDemoBatchContract\n{\n    int batchSize;\n    int priorityFactor;\n\n}"
+      },
+      {
+        "path": "DemoBatchContract.metadata.xml::AxClass/SourceCode/Methods/Method[parmBatchSize]/Source",
+        "expected": "[DataMemberAttribute,\n    SysOperationLabelAttribute(literalStr(\"@PFXRent:DemoBatchSize\")),\n    SysOperationDisplayOrderAttribute('1')]\n    public int parmBatchSize(int _batchSize = batchSize)\n{\n    batchSize = _batchSize;\n    return batchSize;\n}",
+        "actual": "[DataMemberAttribute,\n    SysOperationLabelAttribute(literalStr(\"@SYS93619\")),\n    SysOperationDisplayOrderAttribute('1')]\n    public int parmBatchSize(int _batchSize = batchSize)\n{\n    batchSize = _batchSize;\n    return batchSize;\n}"
+      },
+      {
+        "path": "DemoBatchContract.metadata.xml::AxClass/SourceCode/Methods/Method[parmPriorityFactor]/Source",
+        "expected": "[DataMemberAttribute,\n    SysOperationLabelAttribute(literalStr(\"@PFXRent:DemoPriorityFactor\")),\n    SysOperationDisplayOrderAttribute('2')]\n    public int parmPriorityFactor(int _priorityFactor = priorityFactor)\n{\n    priorityFactor = _priorityFactor;\n    return priorityFactor;\n}",
+        "actual": "[DataMemberAttribute,\n    SysOperationLabelAttribute(literalStr(\"@SYS130699\")),\n    SysOperationDisplayOrderAttribute('2')]\n    public int parmPriorityFactor(int _priorityFactor = priorityFactor)\n{\n    priorityFactor = _priorityFactor;\n    return priorityFactor;\n}"
+      },
+      {
+        "path": "DemoBatchController.metadata.xml::AxClass/SourceCode/Declaration",
+        "expected": "class PFXDemoBatchController extends SysOperationServiceController\n{\n}",
+        "actual": "/// <xmldoc/>\nclass PFXDemoBatchController extends SysOperationServiceController\n{\n}"
+      },
+      {
+        "path": "DemoBatchController.metadata.xml::AxClass/SourceCode/Methods/Method[main]/Source",
+        "expected": "/// <xmldoc/>\npublic static void main(Args _args)\n{\n    PFXDemoBatchController controller = PFXDemoBatchController::construct();\n    controller.parmDialogCaption(literalStr(\"@PFXRent:DemoProcessBatch\"));\n    controller.startOperation();\n}",
+        "actual": "/// <xmldoc/>\npublic static void main(Args _args)\n{\n    PFXDemoBatchController controller = PFXDemoBatchController::construct();\n    controller.parmDialogCaption(literalStr(\"@SYS2312\"));\n    controller.startOperation();\n}"
+      },
+      {
+        "path": "DemoBatchService.metadata.xml::AxClass/SourceCode/Declaration",
+        "expected": "class PFXDemoBatchService\n{\n}",
+        "actual": "/// <xmldoc/>\nclass PFXDemoBatchService\n{\n}"
+      },
+      {
+        "path": "DemoBatchService.metadata.xml::AxClass/SourceCode/Methods/Method[process]/Source",
+        "expected": "/// <xmldoc/>\npublic void process(PFXDemoBatchContract _contract)\n{\n    info(strFmt(\"Effective batch size: %1\", this.calculateEffectiveBatchSize(_contract)));\n}",
+        "actual": "/// <xmldoc/>\npublic void process(PFXDemoBatchContract _contract)\n{\n    info(strFmt(\"@SYS97212\", this.calculateEffectiveBatchSize(_contract)));\n}"
+      },
+      {
+        "path": "DemoProcessBatch.metadata.xml::AxMenuItemAction/Label",
+        "expected": "@PFXRent:DemoProcessBatch",
+        "actual": "@SYS2312"
+      }
+    ]
+  },
+  "systest": {
+    "ran": true,
+    "passed": true,
+    "failures": []
+  },
+  "score": {
+    "build": 1,
+    "bp_clean": 0,
+    "golden_match": 0,
+    "systest": 1,
+    "tier_weight": 3
+  },
+  "classification": "VALIDATOR_GAP",
+  "platform_build": "xppc 7.0.7996.33",
+  "static_gate": {
+    "references": {
+      "passed": true,
+      "unresolved": []
+    },
+    "syntax": {
+      "passed": true,
+      "violations": []
+    }
+  },
+  "root_cause_hypothesis": "The IMPLEMENTATION is correct and RUNTIME-VERIFIED. Full xppc build of fm-mcp: 0 errors / 0 warnings (fullBuild, so not an incremental illusion). The committed runtime oracle EvalL3BatchCalcTest ran under SysTestConsole.exe and passed 2/2 - testEffectiveBatchSizeMultipliesByPriorityFactor (10*3=30) and testEffectiveBatchSizeWithDifferentInputs (7*5=35), both test-case elements success=\"true\", \"Rainier Test Suite : 2 Run, 0 Failed\". The batch-size arithmetic is therefore PROVEN at runtime, which is the one thing a golden diff cannot establish.\n\ngolden_match=0 (8 changed, 0 missing, 0 extra) is ENTIRELY an oracle/golden artifact, from THREE independent causes. Positive control: the Source of ConDemoBatchController::construct is NOT in the diff - it reproduced the 2026-06-30 golden body byte-for-byte after prefix canonicalisation, so the write path itself is faithful.\n\n(1) STALE GOLDEN - unconditional XmlDoc injection (3 of the 8 changed paths; expected and pre-root-caused). ensureXppDocComment (src/utils/xppDocGen.ts) injects a class-level /// <summary> unconditionally, and commit 0a95198 (2026-08-09) deliberately extended that to the bridge create path. This golden was captured 2026-06-30 (server SHA 7f836a6) and its three class Declarations carry NO doc comment, so no faithful grounded rerun can reproduce them. normalize.ts COLLAPSES a doc run to \"/// <xmldoc/>\" but deliberately keeps its PRESENCE load-bearing (tied to BPXmlDocNoDocumentationComments and therefore to bp_clean), so presence-vs-absence still diffs. Affected paths: DemoBatchService.metadata.xml::AxClass/SourceCode/Declaration and DemoBatchController.metadata.xml::AxClass/SourceCode/Declaration are byte-identical to the golden apart from the single injected \"/// <xmldoc/>\" line; DemoBatchContract.metadata.xml::AxClass/SourceCode/Declaration is the same PLUS cause (3) below.\n\n(2) STALE GOLDEN - a SECOND, previously unreported staleness axis: the golden references a label file that DOES NOT EXIST in this sandbox generation (5 of the 8 changed paths). It uses @ConRent:DemoBatchSize, @ConRent:DemoPriorityFactor and @ConRent:DemoProcessBatch, and it hard-codes the raw text \"Effective batch size: %1\" inside info(strFmt(...)). There is no ConRent label file anywhere in PackagesLocalDirectory (labels action=info misses it; no ConRent* file on disk), and the fm-mcp Descriptor references no package that could supply one. Reproducing the golden literally would therefore trade golden_match for xppbp BPErrorUnknownLabel three times over, plus the BPErrorLabelIsText that the golden header comment already admits to - i.e. THE COMMITTED GOLDEN CANNOT BE REPRODUCED BP-CLEAN ON THIS VM AT ALL. This run instead used shipped, resolvable ApplicationPlatform label ids, the house style that the sibling capture L3-sysoperation-dialog-attributes (SHA 278eee3, same day) explicitly adopted and documented: @SYS93619 \"Maximum batch size\", @SYS130699 \"Priority\", @SYS2312 \"Batch processing\", @SYS97212 \"Number of records: %1\". Changed paths: Method[parmBatchSize]/Source and Method[parmPriorityFactor]/Source on the contract, Method[main]/Source on the controller, Method[process]/Source on the service, and AxMenuItemAction/Label. In every one of those the ONLY delta is the label id or format string - each remaining character of the body is identical.\n\n(3) NORMALISER GAP - a blank line the writer emits and normalize.ts does not canonicalise. In DemoBatchContract.metadata.xml::AxClass/SourceCode/Declaration the actual carries an extra empty line between the last member variable (int priorityFactor;) and the closing brace, which the golden does not. reindentXppSource re-derives INDENTATION but preserves blank lines, so it survives canonicalisation. It is a pure writer artefact (the submitted sourceCode had no such blank line), it is invisible to xppc and to xppbp, and it means that even if causes (1) and (2) were both resolved the Contract Declaration would STILL false-mismatch. A THIRD, independent reason a re-capture alone will not make this case reproducible run-to-run.\n\n(4) TOOL_DEFECT REPRODUCED A THIRD TIME (independent of the case; hit while deploying the oracle). d365fo_file(action=\"create\", objectType=\"class\", objectName=\"EvalL3BatchCalcTest\", xmlContent=<verbatim AxClass XML>) wrote THREE identities into one file and reported success: filename K:\\AosService\\PackagesLocalDirectory\\fm-mcp\\fm-mcp\\AxClass\\ConDemoEvalL3BatchCalcTest.xml (prefixed), X++ CDATA declaration \"class ConDemoEvalL3BatchCalcTest extends SysTestCase\" (prefixed), but <Name>EvalL3BatchCalcTest</Name> (NOT prefixed). It answered \"Created class ConDemoEvalL3BatchCalcTest (prefixed from EvalL3BatchCalcTest)\" and \"Verified: on disk (2350 bytes)\". Identical to the reports in the L2-coc-extension and L2-event-handler-basic runs earlier today; the on-disk verification confirms bytes exist but never that the three identity sites agree. Caught here BEFORE building, by reading the file back, so the fatal \"The element must be named X instead of Y to be consistent with its file name\" did not occur this time. Workaround: delete + direct verbatim file write to AxClass\\EvalL3BatchCalcTest.xml + update_symbol_index. HARNESS PLUMBING ONLY - all four CASE artifacts went through the full grounded path (prepare -> validate_code(both) -> d365fo_file create with groundingToken and sourceCode); no hand-edited XML.\n\n(5) CASE-SPEC / KNOWLEDGE observation behind bp_clean=0. The only xppbp warning attributable to this case is BPErrorMenuItemNotCoveredByPrivilege on ConDemoProcessBatch. The target_artifact_types of the case are exactly [AxClass, AxClass, AxClass, AxMenuItemAction] - no privilege - so an implementation that follows the spec EXACTLY is structurally incapable of being BP-clean. The other 6 warnings in the model all belong to the pre-existing committed fixture table ConDemoNoteHeader and are not attributable to this run, so bp-warnings was reported as 1, not 7. The two prior L3-batch-basic corpus records (2026-07-07, SHA cb1b73d) also scored bp_clean=0, so this is a stable property of the case rather than a regression.",
+  "suggested_fix_area": "eval/goldens/L3-batch-basic/ - RE-CAPTURE all four artifacts (or promote the artifacts from this run). The 2026-06-30 capture is stale on TWO axes at once: it predates the unconditional XmlDoc injection AND it references a @ConRent label file that exists on no VM today, which makes it unreproducible bp-clean. A normalize.ts-only change cannot fix the label axis. Note the wave-owner decision (re-capture vs a directional change in normalize.ts) is broader than this case: 17 other AxClass goldens committed 2026-07-07 / 2026-07-23 sit in the same XmlDoc-affected set.\n\nsrc/eval/oracle/normalize.ts - canonicalizeXppSourceText re-derives indentation but preserves blank lines. Collapsing runs of blank lines, or at minimum dropping a blank line immediately before a closing brace, would remove the writer-artefact false-mismatch in cause (3). Regression test: a Declaration with and without a trailing blank line before the closing brace must normalise equal.\n\nd365fo_file(action=\"create\") xmlContent path - make prefixing ALL-OR-NOTHING across <Name>, filename and the X++ declaration, or reject the call when objectName prefixing would contradict the <Name> carried by caller-supplied xmlContent. Third independent reproduction today. Cheap interim fix: extend the existing post-write on-disk verification to also assert filename == <Name> == the declared class name, and fail loudly instead of reporting success.\n\neval/cases/L3-batch-basic.json - either add a fifth artifact (an AxSecurityPrivilege whose entry point is ConDemoProcessBatch) so the case is achievable BP-clean, or record BPErrorMenuItemNotCoveredByPrivilege as an accepted, documented warning for this case so that bp_clean stops reading as a defect signal.",
+  "evidence_refs": [
+    "eval/corpus/runs/2026-08-31T23__L3-batch-basic__278eee3.json",
+    "eval/corpus/runs/2026-08-31T23__L2-coc-extension__278eee3.json (same three-identity create defect, first report today)",
+    "eval/corpus/runs/2026-08-31T23__L2-event-handler-basic__278eee3.json (second report today)",
+    "eval/corpus/runs/2026-07-07T11__L3-batch-basic__cb1b73d__{contract,service,controller,menuitem}.json (prior runs of this case; also bp_clean=0, golden_match=0, systest null)",
+    "eval/goldens/L3-batch-basic/*.metadata.xml (captured 2026-06-30, server SHA 7f836a6, xppc 7.0.7858.27)",
+    "eval/goldens/L3-sysoperation-dialog-attributes/README.md (2026-08-31 sibling SysOperation capture: shipped @SYS label ids, no SysEntryPointAttribute)",
+    "src/utils/xppDocGen.ts (ensureXppDocComment, unconditional injection) and git 0a95198 (2026-08-09, extended to the bridge path)",
+    "src/eval/oracle/normalize.ts (canonicalizeXppDocComments keeps doc PRESENCE load-bearing; reindentXppSource preserves blank lines)",
+    "SysTestConsole.exe raw output: Rainier Test Suite : 2 Run, 0 Failed; both test-case elements success=true (406 ms and 141 ms)",
+    "xppbp fm-mcp: 7 warnings total, 1 attributable (BPErrorMenuItemNotCoveredByPrivilege on ConDemoProcessBatch), 6 on the pre-existing fixture table ConDemoNoteHeader",
+    "K:AosServicePackagesLocalDirectory\fm-mcp\fm-mcpAxClassConDemoEvalL3BatchCalcTest.xml (the three-identity artifact, before the workaround)"
+  ]
+}

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -8,8 +8,8 @@
   "total": {
     "tier": "all",
     "total": 109,
-    "covered": 108,
-    "percent": 99.1
+    "covered": 109,
+    "percent": 100
   },
   "leaves": [
     {
@@ -80,7 +80,8 @@
       "t": true,
       "covered": true,
       "cases": [
-        "L0-enum-basic"
+        "L0-enum-basic",
+        "L3-enum-field-form-downgrade-guard"
       ]
     },
     {
@@ -94,7 +95,8 @@
       "t": true,
       "covered": true,
       "cases": [
-        "L2-enum-extension-empty-values"
+        "L2-enum-extension-empty-values",
+        "L2-enum-modify-values"
       ]
     },
     {
@@ -429,6 +431,7 @@
         "L2-display-edit-methods",
         "L2-dotnet-interop-clrerror",
         "L2-edt-extension-basic",
+        "L2-enum-modify-values",
         "L2-feature-management-flight",
         "L2-global-statics-access-checks",
         "L2-implicit-conversions",
@@ -458,6 +461,7 @@
         "L3-form-event-handler-class",
         "L3-report-dataset-extension",
         "L3-runbase-coc-pack-unpack",
+        "L3-sysoperation-dialog-attributes",
         "L3-sysoperation-query-parameter-batch",
         "L4-ssrs-report-design-rdl",
         "L4-ssrs-report-print-destinations"
@@ -505,6 +509,7 @@
         "L2-display-edit-methods",
         "L2-dotnet-interop-clrerror",
         "L2-edt-extension-basic",
+        "L2-enum-modify-values",
         "L2-feature-management-flight",
         "L2-global-statics-access-checks",
         "L2-implicit-conversions",
@@ -534,6 +539,7 @@
         "L3-form-event-handler-class",
         "L3-report-dataset-extension",
         "L3-runbase-coc-pack-unpack",
+        "L3-sysoperation-dialog-attributes",
         "L3-sysoperation-query-parameter-batch",
         "L4-ssrs-report-design-rdl",
         "L4-ssrs-report-print-destinations"
@@ -999,7 +1005,8 @@
       "t": true,
       "covered": true,
       "cases": [
-        "L2-numberseq-basic"
+        "L2-numberseq-basic",
+        "L3-numberseq-module-slice"
       ]
     },
     {
@@ -1211,6 +1218,7 @@
       "t": true,
       "covered": true,
       "cases": [
+        "L4-bridge-drops-data-entity-primarytable-fields-on-create",
         "L4-entity-security"
       ]
     },
@@ -1472,6 +1480,7 @@
         "L2-display-edit-methods",
         "L2-dotnet-interop-clrerror",
         "L2-edt-extension-basic",
+        "L2-enum-modify-values",
         "L2-feature-management-flight",
         "L2-global-statics-access-checks",
         "L2-implicit-conversions",
@@ -1501,6 +1510,7 @@
         "L3-form-event-handler-class",
         "L3-report-dataset-extension",
         "L3-runbase-coc-pack-unpack",
+        "L3-sysoperation-dialog-attributes",
         "L3-sysoperation-query-parameter-batch",
         "L4-ssrs-report-design-rdl",
         "L4-ssrs-report-print-destinations"
@@ -1597,10 +1607,12 @@
       "tier": "total",
       "weight": 3,
       "k": true,
-      "e": false,
+      "e": true,
       "t": true,
-      "covered": false,
-      "cases": []
+      "covered": true,
+      "cases": [
+        "L3-sysoperation-dialog-attributes"
+      ]
     },
     {
       "id": "report-extension",

--- a/eval/goldens/L0-create-readback-no-reindex/ConDemoIndexProbeStatus.metadata.xml
+++ b/eval/goldens/L0-create-readback-no-reindex/ConDemoIndexProbeStatus.metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoIndexProbeStatus</Name>
+	<Label>ConDemoIndexProbeStatus</Label>
+	<UseEnumValue>No</UseEnumValue>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>Open</Name>
+			<Label>@ConDemo:Open</Label>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Closed</Name>
+			<Label>@ConDemo:Closed</Label>
+		</AxEnumValue>
+	</EnumValues>
+	<IsExtensible>true</IsExtensible>
+</AxEnum>

--- a/eval/goldens/L0-create-readback-no-reindex/README.md
+++ b/eval/goldens/L0-create-readback-no-reindex/README.md
@@ -1,0 +1,45 @@
+# Golden: L0-create-readback-no-reindex — CAPTURED, PENDING HUMAN REVIEW (§6.4)
+
+Captured 2026-08-31, server SHA 278eee3, xppc 7.0.7996.33 (VM), sandbox model
+`fm-mcp`, effective prefix `ConDemo`. Written through the server's own
+`d365fo_file(action="create")` path — no hand-edited XML — then full-built with
+xppc (0 errors, 0 warnings) and checked with xppbp; the capture script refuses to
+copy a golden out of a build that was not clean. Sandbox rolled back afterwards.
+
+## Artifacts
+
+_an extensible enum, created and then read back in the same turn_
+
+`ConDemoIndexProbeStatus.metadata.xml`
+
+| | What it has to keep showing |
+|---|---|
+| `UseEnumValue` | `No`, and **no `<Value>` elements** — required by xppc for `IsExtensible=true`; the numbers are carried by position |
+| `EnumValues` | exactly two, `Open` then `Closed`, in that order — the order IS the 0/1 |
+| value `Label`s | real `@ConDemo:` references, not prose: the create call auto-resolved the raw text it was given |
+| `IsExtensible` | `true`, placed **after** `<EnumValues>` — the shipped order (`ApplicationSuite/Foundation/AxEnum/AccountOrder.xml`) |
+
+## Notes from the capture
+
+**The case subject passed.** One `d365fo_file(action="create")` — which ended with
+"Symbol index updated in place — no `update_symbol_index` call needed" — then
+exactly ONE `get_object_info(objectType="enum")`, which resolved the enum and
+returned `Open = 0 - @ConDemo:Open`, `Closed = 1 - @ConDemo:Closed`,
+`Extensible: Yes` (`_Source: C# bridge`). No `update_symbol_index` call anywhere
+in the run. #830 does not reproduce.
+
+**`<Label>ConDemoIndexProbeStatus</Label>` is a tool defect this golden pins, not
+a requirement of the instruction.** The instruction asks for no enum-level label;
+`generateAxEnumXml` defaults `label` to the object's own NAME and emits `<Label>`
+unconditionally, which is the run's single BP warning
+(`BPErrorLabelIsText`, `bp_clean: 0`). The auto-label pass that fixed both VALUE
+labels runs *before* generation and never sees this invented value. Shipped enums
+omit `<Label>` freely, and `generateSmartReport.ts` already omits it for exactly
+this reason. **When that defect is fixed, this golden must be re-captured in the
+same PR** — the `<Label>` line is expected to disappear, not to change value.
+See the corpus record for the full hypothesis.
+
+The name: the instruction says `DemoIndexProbeStatus`, but `prepare` infers the
+prefix `ConDemo` from the sandbox (overriding `EXTENSION_PREFIX=Con`, and it says
+so), so the base name passed to `create` was `IndexProbeStatus` to land on the
+corpus-conventional `ConDemoIndexProbeStatus`.

--- a/eval/goldens/L2-batched-object-reads/InventItemGroup.ConDemoExtension.metadata.xml
+++ b/eval/goldens/L2-batched-object-reads/InventItemGroup.ConDemoExtension.metadata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTableExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>InventItemGroup.ConDemoExtension</Name>
+	<FieldGroupExtensions>
+		<AxTableFieldGroupExtension>
+			<Name>Overview</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>EvalNoteText</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroupExtension>
+	</FieldGroupExtensions>
+	<FieldGroups />
+	<FieldModifications />
+	<Fields>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>EvalNoteText</Name>
+			<ExtendedDataType>Notes</ExtendedDataType>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes />
+	<Mappings />
+	<PropertyModifications />
+	<RelationExtensions />
+	<RelationModifications />
+	<Relations />
+</AxTableExtension>

--- a/eval/goldens/L2-batched-object-reads/PaymTerm.ConDemoExtension.metadata.xml
+++ b/eval/goldens/L2-batched-object-reads/PaymTerm.ConDemoExtension.metadata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTableExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>PaymTerm.ConDemoExtension</Name>
+	<FieldGroupExtensions>
+		<AxTableFieldGroupExtension>
+			<Name>Overview</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>EvalNoteText</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroupExtension>
+	</FieldGroupExtensions>
+	<FieldGroups />
+	<FieldModifications />
+	<Fields>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>EvalNoteText</Name>
+			<ExtendedDataType>Notes</ExtendedDataType>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes />
+	<Mappings />
+	<PropertyModifications />
+	<RelationExtensions />
+	<RelationModifications />
+	<Relations />
+</AxTableExtension>

--- a/eval/goldens/L2-batched-object-reads/README.md
+++ b/eval/goldens/L2-batched-object-reads/README.md
@@ -1,0 +1,96 @@
+# Golden: L2-batched-object-reads — CAPTURED, PENDING HUMAN REVIEW (§6.4)
+
+Captured 2026-08-31, server SHA 278eee3, xppc 7.0.7996.33 (VM), sandbox model
+`fm-mcp`, effective prefix `ConDemo`. Written through the server's own write
+path only — three `d365fo_file(action="create")` calls carrying
+`properties.fields[]` plus an `operations[]` entry, and one
+`d365fo_file(action="modify")` for a shape correction. No `overwrite=true`, no
+hand-edited XML. Full-built with xppc (0 errors, 0 warnings) and checked with
+xppbp; the capture script refuses to copy a golden out of a build that was not
+clean, or out of a file edited after that build. Sandbox rolled back afterwards.
+
+## What the case actually scores
+
+The artifacts are ordinary table extensions — the point of the case is the
+**read path**. The run made **exactly one** `get_object_info` call, in the plural
+`objects=[…]` form, covering all three base tables *and* the EDT:
+
+```
+get_object_info(objects=[{table,VendGroup},{table,PaymTerm},
+                         {table,InventItemGroup},{edt,Notes}])
+→ "Fetched: 4 object(s) in parallel | Success: 4/4 | Time: 692ms"
+```
+
+Four objects, one round trip, 692 ms. Issue #831 (13 sequential single-object
+reads in one audited session) does not reproduce: the batched form is
+discoverable from the tool description, takes a **mixed** `objectType` array, and
+returns per-object sections. `tests/eval/batchedObjectReadsCase.test.ts` pins the
+tool-path requirement in the instruction so it cannot be edited away silently.
+
+## Artifacts
+
+`VendGroup.ConDemoExtension.metadata.xml`,
+`PaymTerm.ConDemoExtension.metadata.xml`,
+`InventItemGroup.ConDemoExtension.metadata.xml` — identical apart from `<Name>`.
+
+| | What it has to keep showing |
+|---|---|
+| `Fields` | one `AxTableField` `i:type="AxTableFieldString"` named `EvalNoteText` |
+| `ExtendedDataType` | `Notes` — the **existing** ApplicationPlatform EDT (String, StringSize -1 memo). This is the load-bearing element; see below |
+| `FieldGroupExtensions` | the **base** table's `Overview` group, extended with `<DataField>EvalNoteText</DataField>` |
+| `FieldGroups` | empty — no new group is invented |
+| `FieldModifications` | empty — no base-table field is modified, as the instruction demands |
+| labels | none authored at all: the field inherits the EDT label (`@SYS13887`) and the group is the base table's own, so the case needs no model label file |
+
+## Notes from the capture
+
+**`<ExtendedDataType>Notes</ExtendedDataType>` is what makes this golden
+non-vacuous.** The historical table-extension defect wrote the field with no EDT
+— or dropped the field entirely — because `normalizeFieldSpecsForBridge` emitted
+`fieldType`/`extendedDataType` while the bridge reads `type`/`edt`; the result
+built clean, which is exactly why the sibling case `L2-table-extension` still has
+to `ignore` `AxTableExtension/Fields/AxTableField/ExtendedDataType`. This case
+does **not** ignore it. The run read all three files back off disk instead of
+trusting the success message, and then ran a negative control: deleting the
+`<ExtendedDataType>` line from a copy makes the oracle report
+
+```
+− missing: VendGroup.metadata.xml::AxTableExtension/Fields/AxTableField[EvalNoteText]/ExtendedDataType
+```
+
+and renaming one `<DataField>` produces the matching field-group delta. The
+golden fails on the defect it exists to catch.
+
+**The field group shape came from the tool, not from a guess.** The first write
+created a *new* group `ConDemoNotes` inside the extension — the shape the
+`L2-table-extension` golden uses — and the tool answered:
+
+> No form checked on `VendGroup` renders field group **ConDemoNotes** — a group no
+> container names in `<DataGroup>` generates no controls, so a field in it is on
+> no form. Rendered instead: `Overview` (form `VendGroup`, control "Grid").
+
+That contradicts the instruction ("added to a field group **so it surfaces on
+forms**"), so the run removed the new group and used
+`add-field-to-field-group(fieldGroupName:"Overview", extendBaseFieldGroup:true,
+autoCorrect:false)` instead. The tool then confirmed the field is rendered:
+"the compiler generates `Overview_EvalNoteText` for this field, so it is already
+on the form" (same for `PaymTerm`).
+
+**Third-table asymmetry, kept deliberately.** `InventItemGroup` *does* own an
+`Overview` group (the strict, `autoCorrect:false` call succeeded, so it was not
+silently turned into a new group), but the advisory reports no form renders it —
+`Forecast`, `PurchaseTax`, `SalesTax`, `Payment`, `RetailSAFT` are the rendered
+ones. The golden keeps `Overview` on all three: uniform artifacts, the
+semantically right group for a note field, and the instruction reads as a general
+best-practice statement rather than a per-form audit. Worth knowing before
+someone "fixes" the third file.
+
+**Follow-up for a different case, not changed here:** by that same advisory,
+`eval/goldens/L2-table-extension/CustGroup.ConExtension.metadata.xml` pins a new
+group (`ConNoteInfo`) that renders on no form, and carries two raw-text labels
+("Note info", "Note priority") — `BPErrorLabelIsText`. It builds clean and does
+not satisfy its own instruction.
+
+**BP provenance:** xppbp ran and reported 6 warnings, all six against the shared
+INPUT fixture table `ConDemoNoteHeader` and **zero** against these three
+extensions, so `bp_clean: 1` is scored for the case artifacts.

--- a/eval/goldens/L2-batched-object-reads/VendGroup.ConDemoExtension.metadata.xml
+++ b/eval/goldens/L2-batched-object-reads/VendGroup.ConDemoExtension.metadata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTableExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>VendGroup.ConDemoExtension</Name>
+	<FieldGroupExtensions>
+		<AxTableFieldGroupExtension>
+			<Name>Overview</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>EvalNoteText</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroupExtension>
+	</FieldGroupExtensions>
+	<FieldGroups />
+	<FieldModifications />
+	<Fields>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>EvalNoteText</Name>
+			<ExtendedDataType>Notes</ExtendedDataType>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes />
+	<Mappings />
+	<PropertyModifications />
+	<RelationExtensions />
+	<RelationModifications />
+	<Relations />
+</AxTableExtension>

--- a/eval/goldens/L2-enum-modify-values/ConDemoModStatus.metadata.xml
+++ b/eval/goldens/L2-enum-modify-values/ConDemoModStatus.metadata.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoModStatus</Name>
+	<Label>@SYS36398</Label>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>Active</Name>
+			<Label>@SYS95227</Label>
+			<Value>1</Value>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Completed</Name>
+			<Label>@SYS111310</Label>
+			<Value>2</Value>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Archived</Name>
+			<Label>@SYS89555</Label>
+			<Value>3</Value>
+		</AxEnumValue>
+	</EnumValues>
+</AxEnum>

--- a/eval/goldens/L2-enum-modify-values/README.md
+++ b/eval/goldens/L2-enum-modify-values/README.md
@@ -1,0 +1,55 @@
+# Golden: L2-enum-modify-values — CAPTURED, PENDING HUMAN REVIEW (§6.4)
+
+Captured 2026-08-31, server SHA 278eee3, xppc 7.0.7996.33 (VM), sandbox model
+`fm-mcp`, effective prefix `ConDemo`. Written through the server's own write
+path only — one `d365fo_file(action="create")` and then five
+`d365fo_file(action="modify")` operations, no `overwrite=true` full-XML rewrite,
+no hand-edited XML — then full-built with xppc (0 errors, 0 warnings) and checked
+with xppbp. The capture script refuses to copy a golden out of a build that was
+not clean, or out of a file edited after that build. Sandbox rolled back
+afterwards.
+
+## Artifacts
+
+_one enum, created with three values and then maintained through the
+add/modify/remove-enum-value operation surface_
+
+`ConDemoModStatus.metadata.xml`
+
+| | What it has to keep showing |
+|---|---|
+| `EnumValues` | exactly three: `Active`, `Completed`, `Archived` — **no `Draft`** (removed), **no `Closed`** (renamed), **no `Temp`** (added then removed) |
+| `<Value>` | `1`, `2`, `3` — **explicit**, and this is the load-bearing part (see below). Value `0` is absent because no member holds it any more |
+| member order | `Active`, `Completed`, `Archived` — the order the ops produced; the numbers are carried by `<Value>`, not by position |
+| every `Label` | a standard `@SYS` reference (`@SYS95227`, `@SYS111310`, `@SYS89555`), never prose — the instruction requires reuse from the labels index |
+| enum `Label` | `@SYS36398` ("Status") — supplied explicitly, so the create-path raw-text-label defect never fires |
+| `UseEnumValue` | **absent**, and that is canonical: `Yes` is the metamodel default and 0 of 488 shipped `ApplicationPlatform` enums serialize it |
+
+## Notes from the capture
+
+**The explicit `<Value>` elements are what make this case correct rather than
+merely green.** The chain ends by removing `Draft`, the member at 0. If the
+enum had been created with positional numbering — which the `create(enum)`
+op-spec says happens to "plain 0,1,2" values, they are accepted and then
+*dropped* — the survivors would have renumbered to `Active=0`, `Completed=1`,
+`Archived=2`. That enum builds perfectly cleanly and is wrong. The run avoided
+it by passing `useEnumValue: "Yes"` alongside the values at create time; the
+`<Value>` elements then survived every subsequent bridge round trip, including
+the removal.
+
+**`modify-enum-value` renames without renumbering.** `Closed` → `Completed`
+with `enumValueInt: 2` kept the member in place, kept its value, and swapped the
+label to `@SYS111310`.
+
+**The create-path label defect does not extend to the modify path** (checked
+deliberately, on a throwaway enum, not on this artifact): `add-enum-value`
+without `enumValueLabel` omits `<Label>` entirely instead of inventing the
+member's own name, and `add-enum-value` given raw text auto-resolves it to a
+real `@Ref` and says so. Only `generateAxEnumXml` invents a raw-text label, and
+only for the enum's own `<Label>`.
+
+The name: the instruction says `DemoModStatus`, but the prefix inferred from the
+sandbox is `ConDemo` and `normalizeObjectName` concatenates rather than
+collapsing the shared `Demo`, so the base name passed to `create` was
+`ModStatus` — landing on the catalog-conventional `ConDemoModStatus`
+(cf. `ConDemoModLifecycle`, `ConDemoNoteStatus`).

--- a/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoServiceTier.metadata.xml
+++ b/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoServiceTier.metadata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoServiceTier</Name>
+	<Label>@SCM:Code</Label>
+	<UseEnumValue>No</UseEnumValue>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>None</Name>
+			<Label>@SYS80100</Label>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Silver</Name>
+			<Label>@SYS118646</Label>
+			<Value>1</Value>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Gold</Name>
+			<Label>@SYS118647</Label>
+			<Value>2</Value>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Platinum</Name>
+			<Label>@SYS118653</Label>
+			<Value>3</Value>
+		</AxEnumValue>
+	</EnumValues>
+</AxEnum>

--- a/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLog.metadata.xml
+++ b/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLog.metadata.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoTaxChangeLog</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// The <c>ConDemoTaxChangeLog</c> table.
+/// </summary>
+public class ConDemoTaxChangeLog extends common
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>validateWrite</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Validates the record and blocks a downgrade of <c>ServiceTier</c>.
+    /// </summary>
+    /// <returns>true when the record may be written; otherwise false.</returns>
+    public boolean validateWrite()
+    {
+        boolean ret = super();
+
+        if (ret && this.RecId != 0 && enum2int(this.ServiceTier) < enum2int(this.orig().ServiceTier))
+        {
+            ret = checkFailed("@TaxTransactionInquiry:HeaderNote");
+        }
+
+        return ret;
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+	<FormRef>ConDemoTaxChangeLogDetails</FormRef>
+	<Label>@TaxTransactionInquiry:HeaderNote</Label>
+	<TableGroup>Main</TableGroup>
+	<TitleField1>ChangeLogId</TitleField1>
+	<CacheLookup>Found</CacheLookup>
+	<ClusteredIndex>ChangeLogIdx</ClusteredIndex>
+	<PrimaryIndex>ChangeLogIdx</PrimaryIndex>
+	<ReplacementKey>ChangeLogIdx</ReplacementKey>
+	<DeleteActions />
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>ChangeLogId</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>ChangeLogId</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>Overview</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>ChangeLogId</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>ServiceTier</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+	</FieldGroups>
+	<Fields>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>ChangeLogId</Name>
+			<ExtendedDataType>Num</ExtendedDataType>
+			<Mandatory>Yes</Mandatory>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldEnum">
+			<Name>ServiceTier</Name>
+			<Label>@SCM:Description</Label>
+			<EnumType>ConDemoServiceTier</EnumType>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes>
+		<AxTableIndex>
+			<Name>ChangeLogIdx</Name>
+			<AlternateKey>Yes</AlternateKey>
+			<Fields>
+				<AxTableIndexField>
+					<DataField>ChangeLogId</DataField>
+				</AxTableIndexField>
+			</Fields>
+		</AxTableIndex>
+	</Indexes>
+	<Mappings />
+	<Relations />
+	<StateMachines />
+</AxTable>

--- a/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml
+++ b/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemDisplay xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+	<Name>ConDemoTaxChangeLogDetails</Name>
+	<Label>@TaxTransactionInquiry:HeaderNote</Label>
+	<Object>ConDemoTaxChangeLogDetails</Object>
+</AxMenuItemDisplay>

--- a/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLogDetails.metadata.xml
+++ b/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLogDetails.metadata.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+	<Name>ConDemoTaxChangeLogDetails</Name>
+	<SourceCode>
+		<Methods xmlns="">
+			<Method>
+				<Name>classDeclaration</Name>
+				<Source><![CDATA[
+[Form]
+public class ConDemoTaxChangeLogDetails extends FormRun
+{
+}
+
+]]></Source>
+			</Method>
+		</Methods>
+		<DataSources xmlns="" />
+		<DataControls xmlns="" />
+		<Members xmlns="" />
+	</SourceCode>
+	<DataSources>
+		<AxFormDataSource xmlns="">
+			<Name>ConDemoTaxChangeLog</Name>
+			<Table>ConDemoTaxChangeLog</Table>
+			<Fields />
+			<ReferencedDataSources />
+			<InsertIfEmpty>No</InsertIfEmpty>
+			<DataSourceLinks />
+			<DerivedDataSources />
+		</AxFormDataSource>
+	</DataSources>
+	<Design>
+		<Caption xmlns="">@TaxTransactionInquiry:HeaderNote</Caption>
+		<DataSource xmlns="">ConDemoTaxChangeLog</DataSource>
+		<Pattern xmlns="">SimpleListDetails</Pattern>
+		<PatternVersion xmlns="">1.3</PatternVersion>
+		<Style xmlns="">SimpleListDetails</Style>
+		<TitleDataSource xmlns="">ConDemoTaxChangeLog</TitleDataSource>
+		<Controls xmlns="">
+			<AxFormControl xmlns=""
+				i:type="AxFormActionPaneControl">
+				<Name>ActionPane</Name>
+				<ElementPosition>134217727</ElementPosition>
+				<FilterExpression>%1</FilterExpression>
+				<Type>ActionPane</Type>
+				<VerticalSpacing>-1</VerticalSpacing>
+				<FormControlExtension
+					i:nil="true" />
+				<Controls>
+					<AxFormControl xmlns=""
+						i:type="AxFormButtonGroupControl">
+						<Name>ButtonGroup</Name>
+						<Type>ButtonGroup</Type>
+						<FormControlExtension
+							i:nil="true" />
+						<Controls />
+						<ArrangeMethod>Vertical</ArrangeMethod>
+					</AxFormControl>
+				</Controls>
+				<AlignChild>No</AlignChild>
+				<AlignChildren>No</AlignChildren>
+				<ArrangeMethod>Vertical</ArrangeMethod>
+			</AxFormControl>
+			<AxFormControl xmlns=""
+				i:type="AxFormGroupControl">
+				<Name>GridContainer</Name>
+				<HeightMode>SizeToAvailable</HeightMode>
+				<Type>Group</Type>
+				<FormControlExtension
+					i:nil="true" />
+				<Controls>
+					<AxFormControl>
+						<Name>QuickFilterControl</Name>
+						<WidthMode>SizeToAvailable</WidthMode>
+						<FormControlExtension>
+							<Name>QuickFilterControl</Name>
+							<ExtensionComponents />
+							<ExtensionProperties>
+								<AxFormControlExtensionProperty>
+									<Name>targetControlName</Name>
+									<Type>String</Type>
+									<Value>Grid</Value>
+								</AxFormControlExtensionProperty>
+								<AxFormControlExtensionProperty>
+									<Name>defaultColumnName</Name>
+									<Type>String</Type>
+									<Value>Grid_ChangeLogId</Value>
+								</AxFormControlExtensionProperty>
+								<AxFormControlExtensionProperty>
+									<Name>placeholderText</Name>
+									<Type>String</Type>
+								</AxFormControlExtensionProperty>
+							</ExtensionProperties>
+						</FormControlExtension>
+					</AxFormControl>
+					<AxFormControl xmlns=""
+						i:type="AxFormGridControl">
+						<Name>Grid</Name>
+						<AllowEdit>No</AllowEdit>
+						<Type>Grid</Type>
+						<WidthMode>SizeToContent</WidthMode>
+						<FormControlExtension
+							i:nil="true" />
+						<Controls>
+							<AxFormControl xmlns=""
+								i:type="AxFormStringControl">
+								<Name>Grid_ChangeLogId</Name>
+								<Type>String</Type>
+								<FormControlExtension
+									i:nil="true" />
+								<DataField>ChangeLogId</DataField>
+								<DataSource>ConDemoTaxChangeLog</DataSource>
+							</AxFormControl>
+						</Controls>
+						<AlternateRowShading>No</AlternateRowShading>
+						<DataSource>ConDemoTaxChangeLog</DataSource>
+						<GridLinesStyle>Vertical</GridLinesStyle>
+						<MultiSelect>No</MultiSelect>
+						<ShowRowLabels>No</ShowRowLabels>
+						<Style>List</Style>
+					</AxFormControl>
+				</Controls>
+				<FrameType>None</FrameType>
+				<Style>SidePanel</Style>
+			</AxFormControl>
+			<AxFormControl xmlns=""
+				i:type="AxFormGroupControl">
+				<Name>DetailsHeader</Name>
+				<Pattern>FieldsFieldGroups</Pattern>
+				<PatternVersion>1.1</PatternVersion>
+				<Type>Group</Type>
+				<WidthMode>SizeToAvailable</WidthMode>
+				<FormControlExtension
+					i:nil="true" />
+				<Controls>
+					<AxFormControl xmlns=""
+						i:type="AxFormGroupControl">
+						<Name>Overview</Name>
+						<Type>Group</Type>
+						<FormControlExtension
+							i:nil="true" />
+						<Controls />
+						<DataGroup>Overview</DataGroup>
+						<DataSource>ConDemoTaxChangeLog</DataSource>
+						<FrameType>None</FrameType>
+					</AxFormControl>
+				</Controls>
+				<ColumnsMode>Fill</ColumnsMode>
+				<FrameType>None</FrameType>
+			</AxFormControl>
+			<AxFormControl xmlns=""
+				i:type="AxFormTabControl">
+				<Name>Tab</Name>
+				<Type>Tab</Type>
+				<FormControlExtension
+					i:nil="true" />
+				<Controls>
+					<AxFormControl xmlns=""
+						i:type="AxFormTabPageControl">
+						<Name>TabPageGeneral</Name>
+						<Pattern>FieldsFieldGroups</Pattern>
+						<PatternVersion>1.1</PatternVersion>
+						<Type>TabPage</Type>
+						<FormControlExtension
+							i:nil="true" />
+						<Controls>
+							<AxFormControl xmlns=""
+								i:type="AxFormGroupControl">
+								<Name>GeneralGroup</Name>
+								<Type>Group</Type>
+								<FormControlExtension
+									i:nil="true" />
+								<Controls>
+									<AxFormControl xmlns=""
+										i:type="AxFormStringControl">
+										<Name>Tab_ChangeLogId</Name>
+										<Type>String</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>ChangeLogId</DataField>
+										<DataSource>ConDemoTaxChangeLog</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+										i:type="AxFormComboBoxControl">
+										<Name>ServiceTier</Name>
+										<Type>ComboBox</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>ServiceTier</DataField>
+										<DataSource>ConDemoTaxChangeLog</DataSource>
+										<Label>@SCM:Description</Label>
+										<Items />
+									</AxFormControl>
+								</Controls>
+							</AxFormControl>
+						</Controls>
+						<ColumnsMode>Fill</ColumnsMode>
+						<Caption>General</Caption>
+					</AxFormControl>
+				</Controls>
+				<Style>FastTabs</Style>
+			</AxFormControl>
+		</Controls>
+	</Design>
+	<Parts />
+</AxForm>

--- a/eval/goldens/L3-enum-field-form-downgrade-guard/README.md
+++ b/eval/goldens/L3-enum-field-form-downgrade-guard/README.md
@@ -1,9 +1,10 @@
-# Golden: L3-enum-field-form-downgrade-guard — PENDING
+# Golden: L3-enum-field-form-downgrade-guard
 
-`golden_pending: true`. Nothing here is captured yet: this folder is a
-placeholder so the case can be reviewed before the VM run. The golden itself is
-captured from a real, human-reviewed build (docs/AGENT_EVAL_LOOP.md §6.4) by the
-**eval-implementer** role — do not hand-author any `*.metadata.xml` here.
+Captured 2026-08-31 on the VM (model `fm-mcp`, prefix `ConDemo`, xppc 7.0.7996.33)
+by the **eval-implementer** role, from a full build that reported 0 errors and an
+xppbp run with 0 BP **errors**, and with the runtime oracle green (3/3).
+The XML was copied byte-for-byte off `PackagesLocalDirectory` by a build-gated
+capture script — nothing here is hand-authored.
 
 ## Where the case comes from
 
@@ -13,16 +14,47 @@ Adding one enum-typed field, exposing it on the matching form and blocking a
 value downgrade in `validateWrite()` cost several failed builds. The sandbox
 equivalent of that task is this case.
 
-## What the run must capture
+## What the run captured
 
 | File | Object | Notes |
 |---|---|---|
 | `ConDemoServiceTier.metadata.xml` | `AxEnum` | None(0) / Silver(1) / Gold(2) / Platinum(3), `Label` = `@SCM:Code` |
 | `ConDemoTaxChangeLog.metadata.xml` | `AxTable` | `ServiceTier` as `AxTableFieldEnum` + `EnumType`, **no** `ExtendedDataType`; in field group `Overview`; `FormRef`; `validateWrite()` |
 | `ConDemoTaxChangeLogDetails.metadata.xml` | `AxForm` | SimpleListDetails scaffold + ComboBox bound to `ServiceTier` in the details group |
+| `ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml` | `AxMenuItemDisplay` | required by `FormRef` — see below |
 
-No `AxEdt*` artifact may appear in this folder — an enum table field needs no
-EDT, and producing one is a case failure, not a golden variant.
+No `AxEdt*` artifact appears in this folder, and none may — an enum table field
+needs no EDT, and producing one is a case failure, not a golden variant. The run
+confirmed this: `add-field` with `fieldEnumType` and no `fieldType` wrote
+`<AxTableField i:type="AxTableFieldEnum">` with `<EnumType>` and no
+`<ExtendedDataType>`, and `AxEdt/` stayed empty.
+
+### Why there is a fourth artifact (`AxMenuItemDisplay`)
+
+A table's `FormRef` property does **not** reference a form — it references a
+**display menu item**. The case instruction (step 6) says "set the table's
+FormRef property to the created form", and `modify-property` accepted the form
+name without complaint, but the build then failed with
+
+    Metadata Error: AxTable/ConDemoTaxChangeLog/FormRef:
+    Menu item display 'ConDemoTaxChangeLogDetails' does not exist.
+
+So the metadata chain the case asks for is table → menu item → form, and the
+menu item is part of the case's output. It is named after the form (the D365FO
+convention), which is why its golden file carries the legacy `.Ax<Type>` infix:
+two objects of different types share one name, and `artifactKey` needs the two
+files to stay distinguishable. `scripts/verify-goldens-build.ts` compiles this
+folder in isolation, so a golden holding the `FormRef` without the menu item
+would not build.
+
+### The `<Value>` elements on the enum are load-bearing
+
+`None` has no `<Value>` child (that IS 0); `Silver`/`Gold`/`Platinum` carry
+`<Value>1/2/3`. An `<AxEnumValue>` without a `<Value>` is **zero**, not "the next
+ordinal" — an enum written without them has every member equal to 0, compiles
+with 0 errors, passes xppbp, and looks right in a golden diff, while
+`enum2int()` returns 0 for every tier and the ladder silently collapses. That is
+what the SysTest is for; see the 2026-08-31 corpus record.
 
 ## Why `**/AxEnumValue/Label` is on the case's ignore list
 
@@ -34,16 +66,22 @@ about ID identity, and because the method body is diffed token-exact. The four
 per-VALUE labels are left to the agent's own labels-index lookup (there is no
 standard label for "Platinum" to pin), so their IDs are normalised out of the
 diff. What is still scored for them: they must be label references, never raw
-text (`BPErrorLabelIsText`).
+text (`BPErrorLabelIsText`). This capture used `@SYS80100`, `@SYS118646`,
+`@SYS118647`, `@SYS118653`.
 
-## Capture checklist (implementer)
+## BP state at capture
 
-1. Provision nothing extra — every object in this case is its own OUTPUT; there
-   is no fixture dependency (`npm run eval:fixtures` lists no INPUT for it).
-2. Run the case end to end on the VM through the grounded `d365fo_file` path.
-3. Build with a build that actually recompiles these objects, then run BP with an
-   explicit per-object target (an untargeted `run_bp_check` reports a false clean).
-4. Human-review the metadata, commit it here, flip `golden_pending` to `false`.
-5. Live SysTest (`eval/systests/L3-enum-field-form-downgrade-guard.xml`,
-   class `EvalL3ServiceTierDowngradeTest`) is tracked separately by
-   `systest_pending`.
+0 BP **errors**. 5 BP warnings, none of which the case instruction asks the agent
+to remove, all reproducible from the instruction:
+`BPErrorTablePrimaryKeyEditable` + `BPErrorDeveloperDocumentationNotDefined`
+(table-create defaults), `BPErrorLabelNotDefined` (the `Overview` field group has
+no label), `BPErrorLabelIsText` (the SimpleListDetails scaffold writes
+`Caption=General` as raw text on `TabPageGeneral`) and
+`BPErrorMenuItemNotCoveredByPrivilege` (a standalone menu item).
+
+## Runtime oracle
+
+`eval/systests/L3-enum-field-form-downgrade-guard.xml`, class
+`EvalL3ServiceTierDowngradeTest`, run via `run_systest_class` — 3/3 green
+(`testDowngradeIsRejected`, `testUpgradeIsAccepted`,
+`testInsertAtAnyTierIsAccepted`). `systest_pending` is `false`.

--- a/eval/goldens/L3-numberseq-module-slice/ConDemoNumberSeqModuleSlice.AxClass.metadata.xml
+++ b/eval/goldens/L3-numberseq-module-slice/ConDemoNumberSeqModuleSlice.AxClass.metadata.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L3-numberseq-module-slice (3 of 6): NumberSeqApplicationModule subclass: loadModule() registers the datatype via NumberSeqDatatype::construct()+parm*()+this.create(), numberSeqModule() returns the new enum value. Captured 2026-08-31, SHA 278eee3. -->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoNumberSeqModuleSlice</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Number sequence module that registers the data types of the demo slice.
+/// </summary>
+public class ConDemoNumberSeqModuleSlice extends NumberSeqApplicationModule
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>loadModule</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Configures all the data types that are in use by the module.
+    /// </summary>
+    protected void loadModule()
+    {
+        NumberSeqDatatype datatype = NumberSeqDatatype::construct();
+
+        datatype.parmDatatypeId(extendedTypeNum(ConDemoSliceId));
+        datatype.parmReferenceHelp(literalStr("@SYS319207"));
+        datatype.parmWizardIsContinuous(false);
+        datatype.parmWizardIsManual(NoYes::No);
+        datatype.parmWizardIsChangeDownAllowed(NoYes::Yes);
+        datatype.parmWizardIsChangeUpAllowed(NoYes::Yes);
+        datatype.parmSortField(1);
+
+        datatype.addParameterType(NumberSeqParameterType::DataArea, true, false);
+        this.create(datatype);
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>numberSeqModule</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Retrieves the ID of the application-specific module for this class.
+    /// </summary>
+    /// <returns>The module-specific ID.</returns>
+    public NumberSeqModule numberSeqModule()
+    {
+        return NumberSeqModule::DemoSlice;
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-numberseq-module-slice/ConDemoSliceId.AxEdt.metadata.xml
+++ b/eval/goldens/L3-numberseq-module-slice/ConDemoSliceId.AxEdt.metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L3-numberseq-module-slice (1 of 6): the EDT used as the number sequence datatype (String, extends Num). Captured 2026-08-31, SHA 278eee3. -->
+<AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns=""
+	i:type="AxEdtString">
+	<Name>ConDemoSliceId</Name>
+	<Extends>Num</Extends>
+	<Label>@SYS22304</Label>
+	<ArrayElements />
+	<Relations />
+	<TableReferences />
+</AxEdt>

--- a/eval/goldens/L3-numberseq-module-slice/ConDemoSliceNumberSeqHandler.AxClass.metadata.xml
+++ b/eval/goldens/L3-numberseq-module-slice/ConDemoSliceNumberSeqHandler.AxClass.metadata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L3-numberseq-module-slice (4 of 6): the registration hook: [SubscribesTo(NumberSeqGlobal, buildModulesMapDelegate)] + NumberSeqGlobal::addModuleToMap(classNum(module)) — the shipped mechanism (see NumberSeqModuleAsset.buildModulesMapSubsciber). Captured 2026-08-31, SHA 278eee3. -->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoSliceNumberSeqHandler</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Registers the demo slice number sequence module with <c>NumberSeqGlobal</c>.
+/// </summary>
+public class ConDemoSliceNumberSeqHandler
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>buildModulesMapSubscriber</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Appends the demo slice module class to the map that links modules to number sequence data type generators.
+    /// </summary>
+    /// <param name = "_numberSeqModuleNamesMap">The map that links modules to their number sequence module classes.</param>
+    [SubscribesTo(classStr(NumberSeqGlobal), delegateStr(NumberSeqGlobal, buildModulesMapDelegate))]
+    public static void buildModulesMapSubscriber(Map _numberSeqModuleNamesMap)
+    {
+        NumberSeqGlobal::addModuleToMap(classNum(ConDemoNumberSeqModuleSlice), _numberSeqModuleNamesMap);
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-numberseq-module-slice/ConDemoSliceParameters.AxTable.metadata.xml
+++ b/eval/goldens/L3-numberseq-module-slice/ConDemoSliceParameters.AxTable.metadata.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L3-numberseq-module-slice (5 of 6): singleton parameters table (Key/ParametersKey, unique Key index, TableGroup=Parameter) with find() createIfNotExist and numRefConDemoSliceId(). Captured 2026-08-31, SHA 278eee3. -->
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoSliceParameters</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// The <c>ConDemoSliceParameters</c> table.
+/// </summary>
+public class ConDemoSliceParameters extends common
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>find</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Finds the single parameters record, creating it when it does not yet exist.
+    /// </summary>
+    /// <param name = "_forUpdate">Selects the record for update when true.</param>
+    /// <param name = "_concurrencyModel">The concurrency model applied when selecting for update.</param>
+    /// <returns>The <c>ConDemoSliceParameters</c> record.</returns>
+    public static ConDemoSliceParameters find(boolean _forUpdate = false, ConcurrencyModel _concurrencyModel = ConcurrencyModel::Auto)
+    {
+        ConDemoSliceParameters parameters, newParameters;
+        int                    loopOnce = 0;
+
+        while (!parameters && loopOnce <= 1)
+        {
+            parameters.selectForUpdate(_forUpdate);
+
+            if (_forUpdate && _concurrencyModel != ConcurrencyModel::Auto)
+            {
+                parameters.concurrencyModel(_concurrencyModel);
+            }
+
+            select firstonly parameters
+                index Key
+                where parameters.Key == 0;
+
+            if (!parameters)
+            {
+                Company::createParameter(newParameters);
+            }
+            else
+            {
+                break;
+            }
+
+            loopOnce++;
+        }
+
+        return parameters;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>numRefConDemoSliceId</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Returns the number sequence reference of the <c>ConDemoSliceId</c> data type.
+    /// </summary>
+    /// <returns>The <c>NumberSequenceReference</c> record for the data type.</returns>
+    public static NumberSequenceReference numRefConDemoSliceId()
+    {
+        return NumberSeqReference::findReference(extendedTypeNum(ConDemoSliceId));
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+	<DeveloperDocumentation>@SYS127376</DeveloperDocumentation>
+	<Label>@SYS40628</Label>
+	<TableGroup>Parameter</TableGroup>
+	<TitleField1>Key</TitleField1>
+	<CacheLookup>Found</CacheLookup>
+	<ClusteredIndex>Key</ClusteredIndex>
+	<PrimaryIndex>Key</PrimaryIndex>
+	<ReplacementKey>Key</ReplacementKey>
+	<DeleteActions />
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>Key</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>Key</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+	</FieldGroups>
+	<Fields>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldInt">
+			<Name>Key</Name>
+			<ExtendedDataType>ParametersKey</ExtendedDataType>
+			<Label>@SYS40628</Label>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes>
+		<AxTableIndex>
+			<Name>Key</Name>
+			<AlternateKey>Yes</AlternateKey>
+			<Fields>
+				<AxTableIndexField>
+					<DataField>Key</DataField>
+				</AxTableIndexField>
+			</Fields>
+		</AxTableIndex>
+	</Indexes>
+	<Mappings />
+	<Relations />
+	<StateMachines />
+</AxTable>

--- a/eval/goldens/L3-numberseq-module-slice/ConDemoSliceParametersForm.AxForm.metadata.xml
+++ b/eval/goldens/L3-numberseq-module-slice/ConDemoSliceParametersForm.AxForm.metadata.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L3-numberseq-module-slice (6 of 6): TableOfContents parameters form, produced by generate_object(mode="scaffold", formPattern="TableOfContents"). Captured 2026-08-31, SHA 278eee3. -->
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+	<Name>ConDemoSliceParametersForm</Name>
+	<SourceCode>
+		<Methods xmlns="">
+			<Method>
+				<Name>classDeclaration</Name>
+				<Source><![CDATA[
+[Form]
+public class ConDemoSliceParametersForm extends FormRun
+{
+}
+
+]]></Source>
+			</Method>
+		</Methods>
+		<DataSources xmlns="" />
+		<DataControls xmlns="" />
+		<Members xmlns="" />
+	</SourceCode>
+	<DataSources>
+		<AxFormDataSource xmlns="">
+			<Name>ConDemoSliceParameters</Name>
+			<Table>ConDemoSliceParameters</Table>
+			<Fields />
+			<ReferencedDataSources />
+			<InsertIfEmpty>No</InsertIfEmpty>
+			<DataSourceLinks />
+			<DerivedDataSources />
+		</AxFormDataSource>
+	</DataSources>
+	<Design>
+		<Caption xmlns="">@SYS40628</Caption>
+		<DataSource xmlns="">ConDemoSliceParameters</DataSource>
+		<Pattern xmlns="">TableOfContents</Pattern>
+		<PatternVersion xmlns="">1.1</PatternVersion>
+		<Style xmlns="">TableOfContents</Style>
+		<Controls xmlns="">
+			<AxFormControl xmlns=""
+					i:type="AxFormTabControl">
+				<Name>Tab</Name>
+				<Type>Tab</Type>
+				<FormControlExtension
+					i:nil="true" />
+				<Controls>
+				<AxFormControl xmlns=""
+						i:type="AxFormTabPageControl">
+					<Name>TabPageGeneral</Name>
+					<Type>TabPage</Type>
+					<FormControlExtension
+						i:nil="true" />
+					<Controls>
+						<AxFormControl xmlns=""
+								i:type="AxFormGroupControl">
+							<Name>TabPageGeneralTitle</Name>
+							<Skip>Yes</Skip>
+							<Type>Group</Type>
+							<WidthMode>SizeToAvailable</WidthMode>
+							<FormControlExtension
+								i:nil="true" />
+							<Controls>
+								<AxFormControl xmlns=""
+										i:type="AxFormStaticTextControl">
+									<Name>TabPageGeneralInstruction</Name>
+									<Skip>Yes</Skip>
+									<Type>StaticText</Type>
+									<WidthMode>SizeToAvailable</WidthMode>
+									<FormControlExtension
+										i:nil="true" />
+									<Style>MainInstruction</Style>
+									<Text>General</Text>
+								</AxFormControl>
+							</Controls>
+							<AllowUserSetup>No</AllowUserSetup>
+							<FrameType>None</FrameType>
+							<Style>TOCTitleContainer</Style>
+						</AxFormControl>
+						<AxFormControl xmlns=""
+								i:type="AxFormTabControl">
+							<Name>TabPageGeneralFastTab</Name>
+							<Type>Tab</Type>
+							<FormControlExtension
+								i:nil="true" />
+							<Controls>
+								<AxFormControl xmlns=""
+										i:type="AxFormTabPageControl">
+									<Name>TabPageGeneralPage</Name>
+									<Pattern>FieldsFieldGroups</Pattern>
+									<PatternVersion>1.1</PatternVersion>
+									<Type>TabPage</Type>
+									<FormControlExtension
+										i:nil="true" />
+									<Controls>
+										<AxFormControl xmlns=""
+												i:type="AxFormGroupControl">
+											<Name>TabPageGeneralGroup</Name>
+											<Type>Group</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<Controls>
+										<AxFormControl xmlns=""
+												i:type="AxFormIntegerControl">
+											<Name>TabPageGeneral_Key</Name>
+											<Type>Integer</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>Key</DataField>
+											<DataSource>ConDemoSliceParameters</DataSource>
+										</AxFormControl>
+											</Controls>
+										</AxFormControl>
+									</Controls>
+									<ColumnsMode>Fill</ColumnsMode>
+									<Caption>General</Caption>
+								</AxFormControl>
+							</Controls>
+							<Style>FastTabs</Style>
+						</AxFormControl>
+					</Controls>
+				</AxFormControl>
+				<AxFormControl xmlns=""
+						i:type="AxFormTabPageControl">
+					<Name>TabPageSetup</Name>
+					<Type>TabPage</Type>
+					<FormControlExtension
+						i:nil="true" />
+					<Controls>
+						<AxFormControl xmlns=""
+								i:type="AxFormGroupControl">
+							<Name>TabPageSetupTitle</Name>
+							<Skip>Yes</Skip>
+							<Type>Group</Type>
+							<WidthMode>SizeToAvailable</WidthMode>
+							<FormControlExtension
+								i:nil="true" />
+							<Controls>
+								<AxFormControl xmlns=""
+										i:type="AxFormStaticTextControl">
+									<Name>TabPageSetupInstruction</Name>
+									<Skip>Yes</Skip>
+									<Type>StaticText</Type>
+									<WidthMode>SizeToAvailable</WidthMode>
+									<FormControlExtension
+										i:nil="true" />
+									<Style>MainInstruction</Style>
+									<Text>Setup</Text>
+								</AxFormControl>
+							</Controls>
+							<AllowUserSetup>No</AllowUserSetup>
+							<FrameType>None</FrameType>
+							<Style>TOCTitleContainer</Style>
+						</AxFormControl>
+						<AxFormControl xmlns=""
+								i:type="AxFormTabControl">
+							<Name>TabPageSetupFastTab</Name>
+							<Type>Tab</Type>
+							<FormControlExtension
+								i:nil="true" />
+							<Controls>
+								<AxFormControl xmlns=""
+										i:type="AxFormTabPageControl">
+									<Name>TabPageSetupPage</Name>
+									<Pattern>FieldsFieldGroups</Pattern>
+									<PatternVersion>1.1</PatternVersion>
+									<Type>TabPage</Type>
+									<FormControlExtension
+										i:nil="true" />
+									<Controls>
+										<AxFormControl xmlns=""
+												i:type="AxFormGroupControl">
+											<Name>TabPageSetupGroup</Name>
+											<Type>Group</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<Controls>
+										<AxFormControl xmlns=""
+												i:type="AxFormIntegerControl">
+											<Name>TabPageSetup_Key</Name>
+											<Type>Integer</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>Key</DataField>
+											<DataSource>ConDemoSliceParameters</DataSource>
+										</AxFormControl>
+											</Controls>
+										</AxFormControl>
+									</Controls>
+									<ColumnsMode>Fill</ColumnsMode>
+									<Caption>Setup</Caption>
+								</AxFormControl>
+							</Controls>
+							<Style>FastTabs</Style>
+						</AxFormControl>
+					</Controls>
+				</AxFormControl>
+				</Controls>
+				<Style>VerticalTabs</Style>
+			</AxFormControl>
+		</Controls>
+	</Design>
+	<Parts />
+</AxForm>

--- a/eval/goldens/L3-numberseq-module-slice/NumberSeqModule.ConDemoExtension.metadata.xml
+++ b/eval/goldens/L3-numberseq-module-slice/NumberSeqModule.ConDemoExtension.metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Golden for L3-numberseq-module-slice (2 of 6): enum-extension adding NumberSeqModule::DemoSlice. Shape matches the shipped NEW-value extensions (FleetManagement/CostAccounting/AssetLeasing): Name + Label, NO <Value> — the platform assigns an extensible enum value. Captured 2026-08-31, SHA 278eee3. -->
+<AxEnumExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>NumberSeqModule.ConDemoExtension</Name>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>DemoSlice</Name>
+			<Label>@SYS334317</Label>
+		</AxEnumValue>
+	</EnumValues>
+	<PropertyModifications />
+	<ValueModifications />
+</AxEnumExtension>

--- a/eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateContract.metadata.xml
+++ b/eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateContract.metadata.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Golden metadata for eval case: L3-sysoperation-dialog-attributes (artifact 1 of 3: DataContract - the whole dialog, from attributes)
+  Captured: 2026-08-31, server SHA: 278eee3
+  Platform: xppc 7.0.7996.33
+-->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRebateContract</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Parameters of the customer rebate run.
+/// </summary>
+/// <remarks>
+/// Everything the dialog shows comes from the attributes on this contract:
+/// there is no dialog code and no UI builder.
+/// </remarks>
+[DataContractAttribute,
+ SysOperationGroupAttribute('Selection', "@SYS152429", '1')]
+public class ConDemoRebateContract implements SysOperationInitializable
+{
+    private CustGroupId custGroup;
+    private NoYes       includeBlocked;
+    private RecId       callerRecId;
+
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>initialize</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Fills the defaults before the generated dialog is shown.
+    /// </summary>
+    /// <remarks>
+    /// SysOperationInitializable: the framework calls this before it builds the
+    /// dialog, so the defaults are already in the controls when the user sees them.
+    /// </remarks>
+    public void initialize()
+    {
+        includeBlocked = NoYes::No;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmCustGroup</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Gets or sets the customer group the rebate run is limited to.
+    /// </summary>
+    /// <param name = "_custGroup">The customer group.</param>
+    /// <returns>The customer group.</returns>
+    [DataMemberAttribute('CustGroup'),
+        SysOperationLabelAttribute(literalStr("@SYS11904")),
+        SysOperationGroupMemberAttribute('Selection'),
+        SysOperationDisplayOrderAttribute('1')]
+        public CustGroupId parmCustGroup(CustGroupId _custGroup = custGroup)
+    {
+        custGroup = _custGroup;
+
+        return custGroup;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmIncludeBlocked</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Gets or sets whether blocked customers take part in the run.
+    /// </summary>
+    /// <param name = "_includeBlocked">Whether blocked customers are included.</param>
+    /// <returns>Whether blocked customers are included.</returns>
+    /// <remarks>
+    /// The display order is a STRING, not an int.
+    /// </remarks>
+    [DataMemberAttribute('IncludeBlocked'),
+        SysOperationLabelAttribute(literalStr("@SYS103795")),
+        SysOperationGroupMemberAttribute('Selection'),
+        SysOperationDisplayOrderAttribute('2')]
+        public NoYes parmIncludeBlocked(NoYes _includeBlocked = includeBlocked)
+    {
+        includeBlocked = _includeBlocked;
+
+        return includeBlocked;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>parmCallerRecId</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Gets or sets the record the run was started from.
+    /// </summary>
+    /// <param name = "_callerRecId">The record the run was started from.</param>
+    /// <returns>The record the run was started from.</returns>
+    /// <remarks>
+    /// On the contract, but not in the dialog: the caller sets it in code.
+    /// </remarks>
+    [DataMemberAttribute('CallerRecId'),
+        SysOperationControlVisibilityAttribute(false)]
+        public RecId parmCallerRecId(RecId _callerRecId = callerRecId)
+    {
+        callerRecId = _callerRecId;
+
+        return callerRecId;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>validate</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Checks that the dialog holds usable parameters.
+    /// </summary>
+    /// <returns>true when the parameters are usable; otherwise false.</returns>
+    /// <remarks>
+    /// Returning false keeps the dialog open. checkFailed writes the reason to
+    /// the infolog and returns false itself.
+    /// </remarks>
+    public boolean validate()
+    {
+        boolean ret = true;
+
+        if (!custGroup)
+        {
+            ret = checkFailed(strFmt("@SYS110217", "@SYS11904"));
+        }
+
+        return ret;
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateController.metadata.xml
+++ b/eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateController.metadata.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Golden metadata for eval case: L3-sysoperation-dialog-attributes (artifact 3 of 3: Controller - binds the service method)
+  Captured: 2026-08-31, server SHA: 278eee3
+  Platform: xppc 7.0.7996.33
+-->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRebateController</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Starts the customer rebate run, from a menu item or from code.
+/// </summary>
+public class ConDemoRebateController extends SysOperationServiceController
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>construct</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Builds a controller bound to the service method it runs.
+    /// </summary>
+    /// <returns>The controller.</returns>
+    public static ConDemoRebateController construct()
+    {
+        return new ConDemoRebateController(
+            classStr(ConDemoRebateService),
+            methodStr(ConDemoRebateService, process),
+            SysOperationExecutionMode::Synchronous);
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>main</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Entry point for the menu item.
+    /// </summary>
+    /// <param name = "_args">The arguments the menu item was started with.</param>
+    public static void main(Args _args)
+    {
+        ConDemoRebateController controller = ConDemoRebateController::construct();
+
+        controller.parmArgs(_args);
+        controller.startOperation();
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>defaultCaption</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// The caption of the generated dialog.
+    /// </summary>
+    /// <returns>The caption.</returns>
+    protected ClassDescription defaultCaption()
+    {
+        return "@SYS345067";
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateService.metadata.xml
+++ b/eval/goldens/L3-sysoperation-dialog-attributes/ConDemoRebateService.metadata.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Golden metadata for eval case: L3-sysoperation-dialog-attributes (artifact 2 of 3: Service - the work, with NO SysEntryPointAttribute)
+  Captured: 2026-08-31, server SHA: 278eee3
+  Platform: xppc 7.0.7996.33
+-->
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRebateService</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// Does the work of the customer rebate run.
+/// </summary>
+public class ConDemoRebateService extends SysOperationServiceBase
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>process</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Counts the customers the rebate run applies to.
+    /// </summary>
+    /// <param name = "_contract">The parameters of the run.</param>
+    /// <remarks>
+    /// No SysEntryPointAttribute here: xppc answers that it is obsolete and
+    /// deprecated in AX7.
+    /// </remarks>
+    public void process(ConDemoRebateContract _contract)
+    {
+        CustTable   custTable;
+        CustGroupId custGroup;
+
+        custGroup = _contract.parmCustGroup();
+
+        if (_contract.parmIncludeBlocked() == NoYes::Yes)
+        {
+            select count(RecId) from custTable
+                where custTable.CustGroup == custGroup;
+        }
+        else
+        {
+            select count(RecId) from custTable
+                where custTable.CustGroup == custGroup
+                && custTable.Blocked == CustVendorBlocked::No;
+        }
+
+        info(strFmt("@SYS97212", int642Str(custTable.RecId)));
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L3-sysoperation-dialog-attributes/README.md
+++ b/eval/goldens/L3-sysoperation-dialog-attributes/README.md
@@ -1,10 +1,20 @@
-# Golden: L3-sysoperation-dialog-attributes — CAPTURED, PENDING HUMAN REVIEW (§6.4)
+# Golden: L3-sysoperation-dialog-attributes — RE-CAPTURED, PENDING HUMAN REVIEW (§6.4)
 
-Captured 2026-08-30, server SHA f01dfa7, xppc 7.0.7996.33 (VM), sandbox model
-`fm-mcp`, `EXTENSION_PREFIX=Con`. Written through the server's own
+Re-captured 2026-08-31, server SHA 278eee3, xppc 7.0.7996.33 (VM), sandbox model
+`fm-mcp`, effective prefix `ConDemo`. Written through the server's own
 `d365fo_file(action="create")` path — no hand-edited XML — then full-built with
-xppc and checked with xppbp; the capture script refuses to copy a golden out of
-a build that was not clean. Sandbox rolled back afterwards.
+xppc (0 errors, 0 warnings) and checked with xppbp (0 errors; the only warnings
+in the model belong to the pre-existing fixture table `ConDemoNoteHeader`). The
+capture script refuses to copy a golden out of a build that was not clean, and
+its four refusal paths were exercised before the real capture. Sandbox rolled
+back afterwards.
+
+**This replaces the 2026-08-30 capture (SHA f01dfa7), which commit `10a8fe2`
+deleted.** That one was written while `create(class)` silently dropped every
+multi-line method attribute block, so it contained NONE of the five method-level
+attributes this README describes — for a case whose entire subject is "the
+dialog is produced only by attributes on the contract". The contract table below
+is unchanged; the artifacts are new.
 
 ## Artifacts
 
@@ -35,8 +45,31 @@ _a SysOperation dialog produced only by attributes on the contract_
 ## Notes from the capture
 
 Built clean on the first attempt, xppbp clean — all six SysOperation attributes
-stacking in one bracket, which was the part the knowledge entry claimed and this
-now compiles.
+stacking in one bracket, which is what the `sysoperation-ui-attributes`
+knowledge entry claims.
 
 Labels are shipped SYS ids, checked in the platform label file rather than
-invented: raw text in a label slot fails xppbp with `BPErrorLabelIsText`.
+invented: raw text in a label slot fails xppbp with `BPErrorLabelIsText`. The
+`@SYS100074` the previous capture passed to the service's `info()` was replaced
+— it reads "There is no record with sorting ID %1 and sort code %2", which is
+not what that message says. `defaultCaption` is declared `protected` here, as it
+is on `SysOperationServiceController`.
+
+**Regression guard — the whole point of this golden.** Every method-level
+attribute block here was SENT as a multi-line block and read back off disk to
+confirm it survived; that is the defect `10a8fe2` fixed and the deleted golden
+is the evidence it once shipped. A future capture that comes back without
+`[DataMemberAttribute]`, `[SysOperationLabelAttribute]`,
+`[SysOperationGroupMemberAttribute]`, `[SysOperationDisplayOrderAttribute]` or
+`[SysOperationControlVisibilityAttribute]` on the parm methods is that defect
+returning, not a valid variant — a class with the attributes stripped still
+compiles clean and still passes xppbp.
+
+**Known cosmetic deviation, deliberately captured as-is.** The continuation
+lines of each multi-line attribute block, and the method signature line that
+follows the block, carry one extra indent level (8 spaces) while the method's
+own `{` sits at 4. That is `reindentXppSource` in `src/utils/xppFormat.ts`:
+`terminatesStatement()` only recognises a SINGLE-line `[Attr]` as terminating, so
+the statement never closes. It is whitespace only — the golden diff normalises
+both sides through the same function — so fixing it does not invalidate this
+golden. See the corpus record for this capture.

--- a/eval/goldens/L4-bridge-drops-data-entity-primarytable-fields-on-create/ConDemoNoteHeaderProbeEntity.metadata.xml
+++ b/eval/goldens/L4-bridge-drops-data-entity-primarytable-fields-on-create/ConDemoNoteHeaderProbeEntity.metadata.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxDataEntityView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoNoteHeaderProbeEntity</Name>
+	<Label>@TaxTransactionInquiry:HeaderNote</Label>
+	<EntityCategory>Master</EntityCategory>
+	<IsPublic>Yes</IsPublic>
+	<PrimaryKey>EntityKey</PrimaryKey>
+	<PublicCollectionName>ConDemoNoteHeaderProbeEntityCollection</PublicCollectionName>
+	<PublicEntityName>ConDemoNoteHeaderProbeEntity</PublicEntityName>
+	<Fields>
+		<AxDataEntityViewField xmlns=""
+			i:type="AxDataEntityViewMappedField">
+			<Name>NoteId</Name>
+			<DataField>NoteId</DataField>
+			<DataSource>ConDemoNoteHeader</DataSource>
+		</AxDataEntityViewField>
+		<AxDataEntityViewField xmlns=""
+			i:type="AxDataEntityViewMappedField">
+			<Name>Subject</Name>
+			<DataField>Subject</DataField>
+			<DataSource>ConDemoNoteHeader</DataSource>
+		</AxDataEntityViewField>
+	</Fields>
+	<Keys>
+		<AxDataEntityViewKey>
+			<Name>EntityKey</Name>
+			<Fields>
+				<AxDataEntityViewKeyField>
+					<DataField>NoteId</DataField>
+				</AxDataEntityViewKeyField>
+			</Fields>
+		</AxDataEntityViewKey>
+	</Keys>
+	<Mappings />
+	<Ranges />
+	<Relations />
+	<ViewMetadata>
+		<Name>Metadata</Name>
+		<SourceCode>
+			<Methods>
+				<Method>
+					<Name>classDeclaration</Name>
+					<Source><![CDATA[
+[Query]
+public class Metadata extends QueryRun
+{
+}
+]]></Source>
+				</Method>
+			</Methods>
+		</SourceCode>
+		<DataSources>
+			<AxQuerySimpleRootDataSource>
+				<Name>ConDemoNoteHeader</Name>
+				<Table>ConDemoNoteHeader</Table>
+				<DataSources />
+				<DerivedDataSources />
+				<Fields>
+					<AxQuerySimpleDataSourceField>
+						<Name>NoteId</Name>
+						<Field>NoteId</Field>
+					</AxQuerySimpleDataSourceField>
+					<AxQuerySimpleDataSourceField>
+						<Name>Subject</Name>
+						<Field>Subject</Field>
+					</AxQuerySimpleDataSourceField>
+				</Fields>
+				<Ranges />
+				<GroupBy />
+				<Having />
+				<OrderBy />
+			</AxQuerySimpleRootDataSource>
+		</DataSources>
+	</ViewMetadata>
+</AxDataEntityView>

--- a/eval/goldens/L4-bridge-drops-data-entity-primarytable-fields-on-create/README.md
+++ b/eval/goldens/L4-bridge-drops-data-entity-primarytable-fields-on-create/README.md
@@ -1,0 +1,71 @@
+# Golden: L4-bridge-drops-data-entity-primarytable-fields-on-create — CAPTURED, PENDING HUMAN REVIEW (§6.4)
+
+Captured 2026-08-31, server SHA `278eee3`, xppc 7.0.7996.33 (VM), sandbox model
+`fm-mcp`, effective prefix `ConDemo`. Produced by **one**
+`d365fo_file(action="create", objectType="data-entity")` call — no
+`overwrite=true` rewrite, no `modify`, no hand-edited XML — then full-built with
+xppc (0 errors, 0 warnings), best-practice-checked with xppbp, and DB-synced
+(SyncEngine actually created the SQL view). The capture script refuses to copy a
+golden out of a build that was not clean, or out of a source file whose mtime is
+newer than its compiled `XppMetadata` artifact. Sandbox rolled back afterwards;
+the backing table is a harness fixture and was kept (§4a).
+
+## Artifacts
+
+_one public data entity over the committed fixture table `ConDemoNoteHeader`_
+
+`ConDemoNoteHeaderProbeEntity.metadata.xml`
+
+| | What it has to keep showing |
+|---|---|
+| `<Fields>` | **two** `AxDataEntityViewField` / `i:type="AxDataEntityViewMappedField"` entries — `NoteId`, `Subject` — each with `<DataSource>ConDemoNoteHeader</DataSource>`. **Never `<Fields />`.** This is the whole point of the case |
+| `<ViewMetadata><DataSources>` | an `AxQuerySimpleRootDataSource` whose `<Name>` **and** `<Table>` are `ConDemoNoteHeader`, carrying both `AxQuerySimpleDataSourceField`s. **Never `<ViewMetadata />`** |
+| `<Keys>` | `EntityKey` over `NoteId` — from `primaryKeyFields`; the empty-skeleton branch cannot produce it either |
+| `<DataManagementEnabled>` / `<DataManagementStagingTable>` | **both ABSENT** — the 2026-07-07 regression emitted `Yes` + `<Name>Staging` for a staging table nothing creates, and every generated entity then failed its next build with "Table '…Staging' does not exist" |
+| `<Label>` | `@TaxTransactionInquiry:HeaderNote` — a real `@Ref`, reused from the backing table. Supplied explicitly, because `label` defaults to the **entity name as raw text**, which trips `BPErrorLabelIsText` |
+| `<IsPublic>` + the two public names | present — the instruction asks for a *public* entity |
+| element order | `Name, Label, EntityCategory, IsPublic, PrimaryKey, PublicCollectionName, PublicEntityName, Fields, Keys, Mappings, Ranges, Relations, ViewMetadata` — the platform deserializer silently DROPS mis-ordered elements, so a green build proves nothing about this row |
+
+## Notes from the capture
+
+**The mined defect does not reproduce.** This case was mined from a 2026-06-30
+`TOOL_DEFECT` in which the data-entity create path silently dropped
+`properties.primaryTable` and `properties.fields` and wrote an entity with
+`<Fields />` and no `ViewMetadata` query — which compiled, synced and returned
+nothing, so neither xppc nor xppbp ever flagged it. On `278eee3` both properties
+are honoured; the golden above is the proof, read back off disk rather than
+inferred from a green build.
+
+**A negative control was run in the same session, deliberately.** The same
+`create` with `primaryTable` and `fields` omitted is now *refused* by
+`assertDataEntityIsFunctional` — "missing primaryTable and fields — nothing was
+written" — and no file appears on disk. The silent-empty-entity failure mode is
+unreachable, not merely unobserved this time.
+
+**Runtime corroboration beyond the metadata.** `SyncEngine` built the SQL view
+from this metadata; an earlier identical run logged the DDL verbatim —
+`CREATE VIEW [DBO].[CONDEMONOTEHEADERENTITY] AS SELECT T1.NOTEID, T1.SUBJECT …
+FROM CONDEMONOTEHEADER T1` — which an entity with no data source cannot produce.
+
+**Why `ConDemoNoteHeader` and not a standard table.** It lives in the same model
+as the entity (no Descriptor package reference can confound the build), it is
+repo-committed and byte-stable (`eval/fixtures/ConDemoNoteHeader.metadata.xml`),
+and it is fixture-excluded from rollback — so the case writes exactly the one
+`AxDataEntityView` file its `target_artifact_types` declares.
+
+**Why the odd name.** The obvious `ConDemoNoteHeaderEntity` is already owned by
+`L4-entity-security` (artifact 1 of its 5). `tests/eval/goldenNameCollision.test.ts`
+caught the clash after the first capture and the artifact was renamed to
+`ConDemoNoteHeaderProbeEntity` and re-created through the same path.
+`prepare(mode="create")` had said "No collision" — correctly, since it consults
+the live sandbox index, which the previous rollback had emptied. That is exactly
+the blind spot the collision test exists to cover. For the record, the first
+capture was byte-identical to `L4-entity-security`'s independently captured
+2026-07-23 golden apart from the name and the two explicitly-passed public names.
+
+**`bp_clean` is 0 by construction, and that is not a defect.** xppbp raises
+`DataEntitySecurityPrivilegeCheck` (severity **Error**) for *any* data entity not
+covered by an `AxSecurityPrivilege`, and this case may write only one artifact
+file. The other six BP warnings are all on the fixture table and are present in
+the post-rollback baseline build too. Scoring this case `bp_clean: 1` would
+require widening it into the entity+privilege chain `L4-entity-security` covers.

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoNumberSeqModuleRent.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoNumberSeqModuleRent.metadata.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoNumberSeqModuleRent</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// The <c>ConDemoNumberSeqModuleRent</c> class registers the number sequence data types
+/// that the rental agreement module uses.
+/// </summary>
+public class ConDemoNumberSeqModuleRent extends NumberSeqApplicationModule
+{
+}
+]]></Declaration>
+		<Methods>
+			<Method>
+				<Name>loadModule</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Configures all the data types that are used by the rental agreement module.
+    /// </summary>
+    protected void loadModule()
+    {
+        NumberSeqDatatype datatype = NumberSeqDatatype::construct();
+
+        datatype.parmDatatypeId(extendedTypeNum(ConDemoRentAgreementId));
+        datatype.parmReferenceHelp(literalstr("@ConDemo:RentAgreementIdRefHelp"));
+        datatype.parmWizardIsContinuous(false);
+        datatype.parmWizardIsManual(NoYes::No);
+        datatype.parmWizardIsChangeDownAllowed(NoYes::No);
+        datatype.parmWizardIsChangeUpAllowed(NoYes::No);
+        datatype.parmSortField(1);
+
+        datatype.addParameterType(NumberSeqParameterType::DataArea, true, false);
+        this.create(datatype);
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>numberSeqModule</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Retrieves the ID of the application-specific module for this class.
+    /// </summary>
+    /// <returns>
+    /// The module-specific ID.
+    /// </returns>
+    public NumberSeqModule numberSeqModule()
+    {
+        return NumberSeqModule::DemoRent;
+    }
+
+]]></Source>
+			</Method>
+			<Method>
+				<Name>buildModulesMapSubsciber</Name>
+				<Source><![CDATA[
+    /// <summary>
+    /// Appends the current class to the map that links modules to number sequence data type generators.
+    /// </summary>
+    /// <param name = "_numberSeqModuleNamesMap">The map of modules to number sequence generators.</param>
+    [SubscribesTo(classstr(NumberSeqGlobal), delegatestr(NumberSeqGlobal, buildModulesMapDelegate))]
+    static void buildModulesMapSubsciber(Map _numberSeqModuleNamesMap)
+    {
+        NumberSeqGlobal::addModuleToMap(classnum(ConDemoNumberSeqModuleRent), _numberSeqModuleNamesMap);
+    }
+
+]]></Source>
+			</Method>
+		</Methods>
+	</SourceCode>
+</AxClass>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentAgreement.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentAgreement.metadata.xml
@@ -1,0 +1,735 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+	<Name>ConDemoRentAgreement</Name>
+	<SourceCode>
+		<Methods xmlns="">
+			<Method>
+				<Name>classDeclaration</Name>
+				<Source><![CDATA[
+[Form]
+public class ConDemoRentAgreement extends FormRun
+{
+}
+
+]]></Source>
+			</Method>
+		</Methods>
+		<DataSources xmlns="" />
+		<DataControls xmlns="" />
+		<Members xmlns="" />
+	</SourceCode>
+	<DataSources>
+		<AxFormDataSource xmlns="">
+			<Name>ConDemoRentHeader</Name>
+			<Table>ConDemoRentHeader</Table>
+			<Fields>
+				<AxFormDataSourceField>
+					<DataField>CustAccount</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>FromDate</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>RentAgreementId</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>Status</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>ToDate</DataField>
+				</AxFormDataSourceField>
+			</Fields>
+			<ReferencedDataSources />
+			<InsertIfEmpty>No</InsertIfEmpty>
+			<DataSourceLinks />
+			<DerivedDataSources />
+		</AxFormDataSource>
+		<AxFormDataSource xmlns="">
+			<Name>ConDemoRentLine</Name>
+			<Table>ConDemoRentLine</Table>
+			<Fields>
+				<AxFormDataSourceField>
+					<DataField>ItemName</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>LineAmount</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>LineNum</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>Qty</DataField>
+				</AxFormDataSourceField>
+				<AxFormDataSourceField>
+					<DataField>RentAgreementId</DataField>
+				</AxFormDataSourceField>
+			</Fields>
+			<ReferencedDataSources />
+			<JoinSource>ConDemoRentHeader</JoinSource>
+			<LinkType>Delayed</LinkType>
+			<InsertIfEmpty>No</InsertIfEmpty>
+			<DataSourceLinks />
+			<DerivedDataSources />
+		</AxFormDataSource>
+	</DataSources>
+	<Design>
+		<Caption xmlns="">@ConDemo:RentAgreement</Caption>
+		<DataSource xmlns="">ConDemoRentHeader</DataSource>
+		<Pattern xmlns="">DetailsTransaction</Pattern>
+		<PatternVersion xmlns="">1.4</PatternVersion>
+		<Style xmlns="">DetailsFormTransaction</Style>
+		<TitleDataSource xmlns="">ConDemoRentHeader</TitleDataSource>
+		<Controls xmlns="">
+			<AxFormControl xmlns=""
+					i:type="AxFormActionPaneControl">
+				<Name>ActionPane</Name>
+				<ElementPosition>134217727</ElementPosition>
+				<FilterExpression>%1</FilterExpression>
+				<Type>ActionPane</Type>
+				<VerticalSpacing>-1</VerticalSpacing>
+				<FormControlExtension
+					i:nil="true" />
+				<Controls>
+					<AxFormControl xmlns=""
+							i:type="AxFormButtonGroupControl">
+						<Name>ButtonGroup</Name>
+						<Type>ButtonGroup</Type>
+						<FormControlExtension
+							i:nil="true" />
+						<Controls />
+						<ArrangeMethod>Vertical</ArrangeMethod>
+					</AxFormControl>
+				</Controls>
+				<AlignChild>No</AlignChild>
+				<AlignChildren>No</AlignChildren>
+				<ArrangeMethod>Vertical</ArrangeMethod>
+			</AxFormControl>
+			<AxFormControl xmlns=""
+					i:type="AxFormGroupControl">
+				<Name>NavigationList</Name>
+				<HeightMode>SizeToAvailable</HeightMode>
+				<Type>Group</Type>
+				<Visible>No</Visible>
+				<FormControlExtension
+					i:nil="true" />
+				<Controls>
+					<AxFormControl>
+						<Name>NavigationListFilter</Name>
+						<WidthMode>SizeToAvailable</WidthMode>
+						<FormControlExtension>
+							<Name>QuickFilterControl</Name>
+							<ExtensionComponents />
+							<ExtensionProperties>
+								<AxFormControlExtensionProperty>
+									<Name>targetControlName</Name>
+									<Type>String</Type>
+									<Value>NavigationListGrid</Value>
+								</AxFormControlExtensionProperty>
+							</ExtensionProperties>
+						</FormControlExtension>
+					</AxFormControl>
+					<AxFormControl xmlns=""
+							i:type="AxFormGridControl">
+						<Name>NavigationListGrid</Name>
+						<AllowEdit>No</AllowEdit>
+						<Type>Grid</Type>
+						<WidthMode>SizeToContent</WidthMode>
+						<FormControlExtension
+							i:nil="true" />
+						<Controls>
+							<AxFormControl xmlns=""
+									i:type="AxFormStringControl">
+								<Name>Nav_CustAccount</Name>
+								<Type>String</Type>
+								<FormControlExtension
+									i:nil="true" />
+								<DataField>CustAccount</DataField>
+								<DataSource>ConDemoRentHeader</DataSource>
+							</AxFormControl>
+							<AxFormControl xmlns=""
+									i:type="AxFormDateControl">
+								<Name>Nav_FromDate</Name>
+								<Type>Date</Type>
+								<FormControlExtension
+									i:nil="true" />
+								<DataField>FromDate</DataField>
+								<DataSource>ConDemoRentHeader</DataSource>
+							</AxFormControl>
+							<AxFormControl xmlns=""
+									i:type="AxFormStringControl">
+								<Name>Nav_RentAgreementId</Name>
+								<Type>String</Type>
+								<FormControlExtension
+									i:nil="true" />
+								<DataField>RentAgreementId</DataField>
+								<DataSource>ConDemoRentHeader</DataSource>
+							</AxFormControl>
+						</Controls>
+						<DataSource>ConDemoRentHeader</DataSource>
+						<MultiSelect>No</MultiSelect>
+						<ShowRowLabels>No</ShowRowLabels>
+						<Style>List</Style>
+					</AxFormControl>
+				</Controls>
+				<FrameType>None</FrameType>
+				<Style>SidePanel</Style>
+			</AxFormControl>
+			<AxFormControl xmlns=""
+					i:type="AxFormTabControl">
+				<Name>MainTab</Name>
+				<AlignControl>No</AlignControl>
+				<Type>Tab</Type>
+				<FormControlExtension
+					i:nil="true" />
+				<Controls>
+					<AxFormControl xmlns=""
+							i:type="AxFormTabPageControl">
+						<Name>TabPageDetails</Name>
+						<AutoDeclaration>Yes</AutoDeclaration>
+						<HeightMode>SizeToAvailable</HeightMode>
+						<Type>TabPage</Type>
+						<WidthMode>SizeToAvailable</WidthMode>
+						<FormControlExtension
+							i:nil="true" />
+						<Controls>
+							<AxFormControl xmlns=""
+									i:type="AxFormGroupControl">
+								<Name>HeaderInfo</Name>
+								<Type>Group</Type>
+								<WidthMode>SizeToAvailable</WidthMode>
+								<FormControlExtension
+									i:nil="true" />
+								<Controls>
+									<AxFormControl xmlns=""
+											i:type="AxFormStringControl">
+										<Name>HeaderTitle</Name>
+										<Skip>Yes</Skip>
+										<Type>String</Type>
+										<WidthMode>SizeToAvailable</WidthMode>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>CustAccount</DataField>
+										<DataSource>ConDemoRentHeader</DataSource>
+										<ShowLabel>No</ShowLabel>
+										<Style>TitleField</Style>
+									</AxFormControl>
+								</Controls>
+								<ArrangeMethod>HorizontalLeft</ArrangeMethod>
+								<FrameType>None</FrameType>
+								<Style>DetailTitleContainer</Style>
+							</AxFormControl>
+							<AxFormControl xmlns=""
+									i:type="AxFormTabControl">
+								<Name>DetailsTab</Name>
+								<Type>Tab</Type>
+								<FormControlExtension
+									i:nil="true" />
+								<Controls>
+									<AxFormControl xmlns=""
+											i:type="AxFormTabPageControl">
+										<Name>LineView</Name>
+										<AutoDeclaration>Yes</AutoDeclaration>
+										<HeightMode>SizeToAvailable</HeightMode>
+										<Type>TabPage</Type>
+										<WidthMode>SizeToAvailable</WidthMode>
+										<FormControlExtension
+											i:nil="true" />
+										<Controls>
+											<AxFormControl xmlns=""
+													i:type="AxFormTabControl">
+												<Name>LineViewTab</Name>
+												<AutoDeclaration>Yes</AutoDeclaration>
+												<Type>Tab</Type>
+												<FormControlExtension
+													i:nil="true" />
+												<Controls>
+													<AxFormControl xmlns=""
+															i:type="AxFormTabPageControl">
+														<Name>LineViewHeader</Name>
+														<Pattern>FieldsFieldGroups</Pattern>
+														<PatternVersion>1.1</PatternVersion>
+														<Type>TabPage</Type>
+														<FormControlExtension
+															i:nil="true" />
+														<Controls>
+															<AxFormControl xmlns=""
+																	i:type="AxFormGroupControl">
+																<Name>HeaderGeneralGroup</Name>
+																<Type>Group</Type>
+																<FormControlExtension
+																	i:nil="true" />
+																<Controls>
+									<AxFormControl xmlns=""
+											i:type="AxFormStringControl">
+										<Name>Header_CustAccount</Name>
+										<Type>String</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>CustAccount</DataField>
+										<DataSource>ConDemoRentHeader</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormDateControl">
+										<Name>Header_FromDate</Name>
+										<Type>Date</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>FromDate</DataField>
+										<DataSource>ConDemoRentHeader</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormStringControl">
+										<Name>Header_RentAgreementId</Name>
+										<Type>String</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>RentAgreementId</DataField>
+										<DataSource>ConDemoRentHeader</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormComboBoxControl">
+										<Name>Header_Status</Name>
+										<Type>ComboBox</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>Status</DataField>
+										<DataSource>ConDemoRentHeader</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormDateControl">
+										<Name>Header_ToDate</Name>
+										<Type>Date</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>ToDate</DataField>
+										<DataSource>ConDemoRentHeader</DataSource>
+									</AxFormControl>
+																</Controls>
+															</AxFormControl>
+														</Controls>
+														<ColumnsMode>Fill</ColumnsMode>
+														<Caption>Header</Caption>
+														<FastTabExpanded>No</FastTabExpanded>
+													</AxFormControl>
+													<AxFormControl xmlns=""
+															i:type="AxFormTabPageControl">
+														<Name>LineViewLines</Name>
+														<HeightMode>SizeToAvailable</HeightMode>
+														<Type>TabPage</Type>
+														<FormControlExtension
+															i:nil="true" />
+														<Controls>
+															<AxFormControl xmlns=""
+																	i:type="AxFormActionPaneControl">
+																<Name>LinesActionPaneStrip</Name>
+																<Type>ActionPane</Type>
+																<FormControlExtension
+																	i:nil="true" />
+																<Controls>
+																	<AxFormControl xmlns=""
+																			i:type="AxFormActionPaneTabControl">
+																		<Name>LinesActionTab</Name>
+																		<Type>ActionPaneTab</Type>
+																		<FormControlExtension
+																			i:nil="true" />
+																		<Controls>
+																			<AxFormControl xmlns=""
+																					i:type="AxFormButtonGroupControl">
+																				<Name>LinesStripButtonGroup</Name>
+																				<Type>ButtonGroup</Type>
+																				<FormControlExtension
+																					i:nil="true" />
+																				<Controls />
+																			</AxFormControl>
+																		</Controls>
+																	</AxFormControl>
+																</Controls>
+																<AlignChild>No</AlignChild>
+																<AlignChildren>No</AlignChildren>
+																<ArrangeMethod>Vertical</ArrangeMethod>
+																<DataSource>ConDemoRentLine</DataSource>
+																<Style>Strip</Style>
+															</AxFormControl>
+															<AxFormControl xmlns=""
+																	i:type="AxFormGridControl">
+																<Name>LinesGrid</Name>
+																<Type>Grid</Type>
+																<FormControlExtension
+																	i:nil="true" />
+																<Controls>
+									<AxFormControl xmlns=""
+											i:type="AxFormStringControl">
+										<Name>Line_ItemName</Name>
+										<Type>String</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>ItemName</DataField>
+										<DataSource>ConDemoRentLine</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormRealControl">
+										<Name>Line_LineAmount</Name>
+										<Type>Real</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>LineAmount</DataField>
+										<DataSource>ConDemoRentLine</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormRealControl">
+										<Name>Line_LineNum</Name>
+										<Type>Real</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>LineNum</DataField>
+										<DataSource>ConDemoRentLine</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormRealControl">
+										<Name>Line_Qty</Name>
+										<Type>Real</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>Qty</DataField>
+										<DataSource>ConDemoRentLine</DataSource>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormStringControl">
+										<Name>Line_RentAgreementId</Name>
+										<Type>String</Type>
+										<FormControlExtension
+											i:nil="true" />
+										<DataField>RentAgreementId</DataField>
+										<DataSource>ConDemoRentLine</DataSource>
+									</AxFormControl>
+																</Controls>
+																<DataSource>ConDemoRentLine</DataSource>
+																<Style>Tabular</Style>
+																<VisibleRows>5</VisibleRows>
+																<VisibleRowsMode>Fixed</VisibleRowsMode>
+															</AxFormControl>
+														</Controls>
+														<Caption>Lines</Caption>
+														<FastTabExpanded>Always</FastTabExpanded>
+													</AxFormControl>
+													<AxFormControl xmlns=""
+															i:type="AxFormTabPageControl">
+														<Name>LineViewLineDetails</Name>
+														<HeightMode>SizeToAvailable</HeightMode>
+														<Type>TabPage</Type>
+														<WidthMode>SizeToAvailable</WidthMode>
+														<FormControlExtension
+															i:nil="true" />
+														<Controls>
+															<AxFormControl xmlns=""
+																	i:type="AxFormTabControl">
+																<Name>LineDetailsTab</Name>
+																<AutoDeclaration>Yes</AutoDeclaration>
+																<Type>Tab</Type>
+																<FormControlExtension
+																	i:nil="true" />
+																<Controls>
+																	<AxFormControl xmlns=""
+																			i:type="AxFormTabPageControl">
+																		<Name>TabLineGeneral</Name>
+																		<Pattern>FieldsFieldGroups</Pattern>
+																		<PatternVersion>1.1</PatternVersion>
+																		<Type>TabPage</Type>
+																		<FormControlExtension
+																			i:nil="true" />
+																		<Controls>
+																			<AxFormControl xmlns=""
+																					i:type="AxFormGroupControl">
+																				<Name>LineDetailsGroup</Name>
+																				<Type>Group</Type>
+																				<FormControlExtension
+																					i:nil="true" />
+																				<Controls>
+										<AxFormControl xmlns=""
+												i:type="AxFormStringControl">
+											<Name>LineDtl_ItemName</Name>
+											<Type>String</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>ItemName</DataField>
+											<DataSource>ConDemoRentLine</DataSource>
+										</AxFormControl>
+										<AxFormControl xmlns=""
+												i:type="AxFormRealControl">
+											<Name>LineDtl_LineAmount</Name>
+											<Type>Real</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>LineAmount</DataField>
+											<DataSource>ConDemoRentLine</DataSource>
+										</AxFormControl>
+										<AxFormControl xmlns=""
+												i:type="AxFormRealControl">
+											<Name>LineDtl_LineNum</Name>
+											<Type>Real</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>LineNum</DataField>
+											<DataSource>ConDemoRentLine</DataSource>
+										</AxFormControl>
+										<AxFormControl xmlns=""
+												i:type="AxFormRealControl">
+											<Name>LineDtl_Qty</Name>
+											<Type>Real</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>Qty</DataField>
+											<DataSource>ConDemoRentLine</DataSource>
+										</AxFormControl>
+										<AxFormControl xmlns=""
+												i:type="AxFormStringControl">
+											<Name>LineDtl_RentAgreementId</Name>
+											<Type>String</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>RentAgreementId</DataField>
+											<DataSource>ConDemoRentLine</DataSource>
+										</AxFormControl>
+																		</Controls>
+																			</AxFormControl>
+																		</Controls>
+																		<ColumnsMode>Fill</ColumnsMode>
+																		<Caption>General</Caption>
+																	</AxFormControl>
+																</Controls>
+																<AlignChild>No</AlignChild>
+																<Style>Tabs</Style>
+															</AxFormControl>
+														</Controls>
+														<Caption>Line details</Caption>
+														<DataSource>ConDemoRentLine</DataSource>
+														<FastTabExpanded>No</FastTabExpanded>
+													</AxFormControl>
+												</Controls>
+												<AlignChild>No</AlignChild>
+												<Style>FastTabs</Style>
+											</AxFormControl>
+										</Controls>
+										<PanelStyle>DetailsLine</PanelStyle>
+										<Style>DetailsFormDetails</Style>
+									</AxFormControl>
+									<AxFormControl xmlns=""
+											i:type="AxFormTabPageControl">
+										<Name>HeaderView</Name>
+										<HeightMode>SizeToAvailable</HeightMode>
+										<Type>TabPage</Type>
+										<WidthMode>SizeToAvailable</WidthMode>
+										<FormControlExtension
+											i:nil="true" />
+										<Controls>
+											<AxFormControl xmlns=""
+													i:type="AxFormTabControl">
+												<Name>HeaderDetailsTab</Name>
+												<AutoDeclaration>Yes</AutoDeclaration>
+												<Type>Tab</Type>
+												<FormControlExtension
+													i:nil="true" />
+												<Controls>
+													<AxFormControl xmlns=""
+															i:type="AxFormTabPageControl">
+														<Name>TabHeaderGeneral</Name>
+														<Pattern>FieldsFieldGroups</Pattern>
+														<PatternVersion>1.1</PatternVersion>
+														<Type>TabPage</Type>
+														<FormControlExtension
+															i:nil="true" />
+														<Controls>
+															<AxFormControl xmlns=""
+																	i:type="AxFormGroupControl">
+																<Name>HeaderViewGroup</Name>
+																<Type>Group</Type>
+																<FormControlExtension
+																	i:nil="true" />
+																<Controls>
+										<AxFormControl xmlns=""
+												i:type="AxFormStringControl">
+											<Name>HView_CustAccount</Name>
+											<Type>String</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>CustAccount</DataField>
+											<DataSource>ConDemoRentHeader</DataSource>
+										</AxFormControl>
+										<AxFormControl xmlns=""
+												i:type="AxFormDateControl">
+											<Name>HView_FromDate</Name>
+											<Type>Date</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>FromDate</DataField>
+											<DataSource>ConDemoRentHeader</DataSource>
+										</AxFormControl>
+										<AxFormControl xmlns=""
+												i:type="AxFormStringControl">
+											<Name>HView_RentAgreementId</Name>
+											<Type>String</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>RentAgreementId</DataField>
+											<DataSource>ConDemoRentHeader</DataSource>
+										</AxFormControl>
+										<AxFormControl xmlns=""
+												i:type="AxFormComboBoxControl">
+											<Name>HView_Status</Name>
+											<Type>ComboBox</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>Status</DataField>
+											<DataSource>ConDemoRentHeader</DataSource>
+										</AxFormControl>
+										<AxFormControl xmlns=""
+												i:type="AxFormDateControl">
+											<Name>HView_ToDate</Name>
+											<Type>Date</Type>
+											<FormControlExtension
+												i:nil="true" />
+											<DataField>ToDate</DataField>
+											<DataSource>ConDemoRentHeader</DataSource>
+										</AxFormControl>
+																</Controls>
+															</AxFormControl>
+														</Controls>
+														<ColumnsMode>Fill</ColumnsMode>
+														<Caption>General</Caption>
+													</AxFormControl>
+												</Controls>
+												<AlignChild>No</AlignChild>
+												<Style>FastTabs</Style>
+											</AxFormControl>
+										</Controls>
+										<PanelStyle>DetailsHeader</PanelStyle>
+										<Style>DetailsFormDetails</Style>
+									</AxFormControl>
+								</Controls>
+								<AlignChild>No</AlignChild>
+								<ShowTabs>No</ShowTabs>
+							</AxFormControl>
+						</Controls>
+						<PanelStyle>Details</PanelStyle>
+						<Style>DetailsFormDetails</Style>
+					</AxFormControl>
+					<AxFormControl xmlns=""
+							i:type="AxFormTabPageControl">
+						<Name>TabPageGrid</Name>
+						<Type>TabPage</Type>
+						<FormControlExtension
+							i:nil="true" />
+						<Controls>
+							<AxFormControl xmlns=""
+									i:type="AxFormGroupControl">
+								<Name>GridFilterGroup</Name>
+								<Pattern>CustomAndQuickFilters</Pattern>
+								<PatternVersion>1.1</PatternVersion>
+								<Type>Group</Type>
+								<WidthMode>SizeToAvailable</WidthMode>
+								<FormControlExtension
+									i:nil="true" />
+								<Controls>
+									<AxFormControl>
+										<Name>GridQuickFilter</Name>
+										<WidthMode>SizeToAvailable</WidthMode>
+										<FormControlExtension>
+											<Name>QuickFilterControl</Name>
+											<ExtensionComponents />
+											<ExtensionProperties>
+												<AxFormControlExtensionProperty>
+													<Name>targetControlName</Name>
+													<Type>String</Type>
+													<Value>OverviewGrid</Value>
+												</AxFormControlExtensionProperty>
+											</ExtensionProperties>
+										</FormControlExtension>
+									</AxFormControl>
+								</Controls>
+								<ArrangeMethod>HorizontalLeft</ArrangeMethod>
+								<FrameType>None</FrameType>
+								<Style>CustomFilter</Style>
+								<ViewEditMode>Edit</ViewEditMode>
+							</AxFormControl>
+							<AxFormControl xmlns=""
+									i:type="AxFormGridControl">
+								<Name>OverviewGrid</Name>
+								<AllowEdit>Yes</AllowEdit>
+								<Type>Grid</Type>
+								<FormControlExtension
+									i:nil="true" />
+								<Controls>
+								<AxFormControl xmlns=""
+										i:type="AxFormStringControl">
+									<Name>GridPanel_CustAccount</Name>
+									<Type>String</Type>
+									<FormControlExtension
+										i:nil="true" />
+									<DataField>CustAccount</DataField>
+									<DataSource>ConDemoRentHeader</DataSource>
+								</AxFormControl>
+								<AxFormControl xmlns=""
+										i:type="AxFormDateControl">
+									<Name>GridPanel_FromDate</Name>
+									<Type>Date</Type>
+									<FormControlExtension
+										i:nil="true" />
+									<DataField>FromDate</DataField>
+									<DataSource>ConDemoRentHeader</DataSource>
+								</AxFormControl>
+								<AxFormControl xmlns=""
+										i:type="AxFormStringControl">
+									<Name>GridPanel_RentAgreementId</Name>
+									<Type>String</Type>
+									<FormControlExtension
+										i:nil="true" />
+									<DataField>RentAgreementId</DataField>
+									<DataSource>ConDemoRentHeader</DataSource>
+								</AxFormControl>
+								<AxFormControl xmlns=""
+										i:type="AxFormComboBoxControl">
+									<Name>GridPanel_Status</Name>
+									<Type>ComboBox</Type>
+									<FormControlExtension
+										i:nil="true" />
+									<DataField>Status</DataField>
+									<DataSource>ConDemoRentHeader</DataSource>
+								</AxFormControl>
+								<AxFormControl xmlns=""
+										i:type="AxFormDateControl">
+									<Name>GridPanel_ToDate</Name>
+									<Type>Date</Type>
+									<FormControlExtension
+										i:nil="true" />
+									<DataField>ToDate</DataField>
+									<DataSource>ConDemoRentHeader</DataSource>
+								</AxFormControl>
+								</Controls>
+								<DataSource>ConDemoRentHeader</DataSource>
+								<DefaultAction>OverviewGridDefaultAction</DefaultAction>
+								<MultiSelect>No</MultiSelect>
+								<ShowRowLabels>No</ShowRowLabels>
+								<Style>Tabular</Style>
+							</AxFormControl>
+							<AxFormControl xmlns=""
+									i:type="AxFormCommandButtonControl">
+								<Name>OverviewGridDefaultAction</Name>
+								<Type>CommandButton</Type>
+								<Visible>No</Visible>
+								<FormControlExtension
+									i:nil="true" />
+								<Command>DetailsView</Command>
+							</AxFormControl>
+						</Controls>
+						<PanelStyle>Grid</PanelStyle>
+						<Style>DetailsFormGrid</Style>
+					</AxFormControl>
+				</Controls>
+				<AlignChild>No</AlignChild>
+				<ArrangeMethod>Vertical</ArrangeMethod>
+				<ShowTabs>No</ShowTabs>
+			</AxFormControl>
+		</Controls>
+	</Design>
+	<Parts />
+</AxForm>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentAgreementId.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentAgreementId.metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns=""
+	i:type="AxEdtString">
+	<Name>ConDemoRentAgreementId</Name>
+	<Extends>Num</Extends>
+	<Label>@SYS344002</Label>
+	<ArrayElements />
+	<Relations />
+	<TableReferences />
+</AxEdt>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentAgreementMI.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentAgreementMI.metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemDisplay xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+	<Name>ConDemoRentAgreementMI</Name>
+	<Label>@ConDemo:RentAgreement</Label>
+	<Object>ConDemoRentAgreement</Object>
+</AxMenuItemDisplay>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentClerk.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentClerk.metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRole xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRentClerk</Name>
+	<Label>@ConDemo:RentClerk</Label>
+	<DirectAccessPermissions />
+	<Duties>
+		<AxSecurityDutyReference>
+			<Name>ConDemoRentDuty</Name>
+		</AxSecurityDutyReference>
+	</Duties>
+	<Privileges />
+	<SubRoles />
+</AxSecurityRole>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentDuty.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentDuty.metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDuty xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRentDuty</Name>
+	<Label>@ConDemo:RentDuty</Label>
+	<Privileges>
+		<AxSecurityPrivilegeReference>
+			<Name>ConDemoRentMaintain</Name>
+		</AxSecurityPrivilegeReference>
+	</Privileges>
+</AxSecurityDuty>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentHeader.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentHeader.metadata.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRentHeader</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// The <c>ConDemoRentHeader</c> table.
+/// </summary>
+public class ConDemoRentHeader extends common
+{
+}
+]]></Declaration>
+		<Methods />
+	</SourceCode>
+	<FormRef>ConDemoRentAgreementMI</FormRef>
+	<Label>@ConDemo:RentHeaderTable</Label>
+	<TableGroup>Main</TableGroup>
+	<TitleField1>RentAgreementId</TitleField1>
+	<TitleField2>CustAccount</TitleField2>
+	<CacheLookup>Found</CacheLookup>
+	<ClusteredIndex>RentAgreementIdx</ClusteredIndex>
+	<PrimaryIndex>RentAgreementIdx</PrimaryIndex>
+	<ReplacementKey>RentAgreementIdx</ReplacementKey>
+	<DeleteActions>
+		<AxTableDeleteAction>
+			<Name>ConDemoRentLine</Name>
+			<Table>ConDemoRentLine</Table>
+		</AxTableDeleteAction>
+	</DeleteActions>
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>RentAgreementId</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>CustAccount</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>FromDate</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>ToDate</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>Status</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>RentAgreementId</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>CustAccount</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>FromDate</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>Overview</Name>
+			<Label>@SYS9039</Label>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>RentAgreementId</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>CustAccount</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>FromDate</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>ToDate</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>Status</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+	</FieldGroups>
+	<Fields>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>RentAgreementId</Name>
+			<ExtendedDataType>ConDemoRentAgreementId</ExtendedDataType>
+			<Mandatory>Yes</Mandatory>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>CustAccount</Name>
+			<ExtendedDataType>CustAccount</ExtendedDataType>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldDate">
+			<Name>FromDate</Name>
+			<ExtendedDataType>TransDate</ExtendedDataType>
+			<Label>@ConDemo:RentFromDate</Label>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldDate">
+			<Name>ToDate</Name>
+			<ExtendedDataType>TransDate</ExtendedDataType>
+			<Label>@ConDemo:RentToDate</Label>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldEnum">
+			<Name>Status</Name>
+			<EnumType>ConDemoRentStatus</EnumType>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes>
+		<AxTableIndex>
+			<Name>RentAgreementIdx</Name>
+			<AlternateKey>Yes</AlternateKey>
+			<Fields>
+				<AxTableIndexField>
+					<DataField>RentAgreementId</DataField>
+				</AxTableIndexField>
+			</Fields>
+		</AxTableIndex>
+	</Indexes>
+	<Mappings />
+	<Relations>
+		<AxTableRelation>
+			<Name>CustTable</Name>
+			<Cardinality>ZeroMore</Cardinality>
+			<RelatedTable>CustTable</RelatedTable>
+			<RelatedTableCardinality>ZeroOne</RelatedTableCardinality>
+			<RelationshipType>Association</RelationshipType>
+			<Constraints>
+				<AxTableRelationConstraint xmlns=""
+					i:type="AxTableRelationConstraintField">
+					<Name>CustAccount</Name>
+					<Field>CustAccount</Field>
+					<RelatedField>AccountNum</RelatedField>
+				</AxTableRelationConstraint>
+			</Constraints>
+		</AxTableRelation>
+	</Relations>
+	<StateMachines />
+</AxTable>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentLine.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentLine.metadata.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRentLine</Name>
+	<SourceCode>
+		<Declaration><![CDATA[
+/// <summary>
+/// The <c>ConDemoRentLine</c> table.
+/// </summary>
+public class ConDemoRentLine extends common
+{
+}
+]]></Declaration>
+		<Methods />
+	</SourceCode>
+	<Label>@ConDemo:RentLineTable</Label>
+	<TableGroup>Transaction</TableGroup>
+	<TitleField1>RentAgreementId</TitleField1>
+	<TitleField2>ItemName</TitleField2>
+	<ClusteredIndex>RentLineIdx</ClusteredIndex>
+	<PrimaryIndex>RentLineIdx</PrimaryIndex>
+	<ReplacementKey>RentLineIdx</ReplacementKey>
+	<DeleteActions />
+	<FieldGroups>
+		<AxTableFieldGroup>
+			<Name>AutoReport</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>RentAgreementId</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>LineNum</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>ItemName</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>Qty</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>LineAmount</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoLookup</Name>
+			<Fields>
+				<AxTableFieldGroupField>
+					<DataField>RentAgreementId</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>LineNum</DataField>
+				</AxTableFieldGroupField>
+				<AxTableFieldGroupField>
+					<DataField>ItemName</DataField>
+				</AxTableFieldGroupField>
+			</Fields>
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoIdentification</Name>
+			<AutoPopulate>Yes</AutoPopulate>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoSummary</Name>
+			<Fields />
+		</AxTableFieldGroup>
+		<AxTableFieldGroup>
+			<Name>AutoBrowse</Name>
+			<Fields />
+		</AxTableFieldGroup>
+	</FieldGroups>
+	<Fields>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>RentAgreementId</Name>
+			<ExtendedDataType>ConDemoRentAgreementId</ExtendedDataType>
+			<Mandatory>Yes</Mandatory>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldReal">
+			<Name>LineNum</Name>
+			<ExtendedDataType>LineNum</ExtendedDataType>
+			<Mandatory>Yes</Mandatory>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldString">
+			<Name>ItemName</Name>
+			<ExtendedDataType>Name</ExtendedDataType>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldReal">
+			<Name>Qty</Name>
+			<ExtendedDataType>Qty</ExtendedDataType>
+		</AxTableField>
+		<AxTableField xmlns=""
+			i:type="AxTableFieldReal">
+			<Name>LineAmount</Name>
+			<ExtendedDataType>AmountCur</ExtendedDataType>
+		</AxTableField>
+	</Fields>
+	<FullTextIndexes />
+	<Indexes>
+		<AxTableIndex>
+			<Name>RentLineIdx</Name>
+			<AlternateKey>Yes</AlternateKey>
+			<Fields>
+				<AxTableIndexField>
+					<DataField>RentAgreementId</DataField>
+				</AxTableIndexField>
+				<AxTableIndexField>
+					<DataField>LineNum</DataField>
+				</AxTableIndexField>
+			</Fields>
+		</AxTableIndex>
+	</Indexes>
+	<Mappings />
+	<Relations>
+		<AxTableRelation>
+			<Name>ConDemoRentHeader</Name>
+			<Cardinality>ZeroMore</Cardinality>
+			<RelatedTable>ConDemoRentHeader</RelatedTable>
+			<RelatedTableCardinality>ExactlyOne</RelatedTableCardinality>
+			<RelationshipType>Association</RelationshipType>
+			<Constraints>
+				<AxTableRelationConstraint xmlns=""
+					i:type="AxTableRelationConstraintField">
+					<Name>RentAgreementId</Name>
+					<Field>RentAgreementId</Field>
+					<RelatedField>RentAgreementId</RelatedField>
+				</AxTableRelationConstraint>
+			</Constraints>
+		</AxTableRelation>
+	</Relations>
+	<StateMachines />
+</AxTable>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentMaintain.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentMaintain.metadata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRentMaintain</Name>
+	<Label>@ConDemo:RentMaintain</Label>
+	<DataEntityPermissions />
+	<DirectAccessPermissions />
+	<EntryPoints>
+		<AxSecurityEntryPointReference>
+			<Name>ConDemoRentAgreementMI</Name>
+			<Grant>
+				<Correct>Allow</Correct>
+				<Create>Allow</Create>
+				<Delete>Allow</Delete>
+				<Read>Allow</Read>
+				<Update>Allow</Update>
+			</Grant>
+			<ObjectName>ConDemoRentAgreementMI</ObjectName>
+			<ObjectType>MenuItemDisplay</ObjectType>
+			<Forms />
+		</AxSecurityEntryPointReference>
+	</EntryPoints>
+	<FormControlOverrides />
+</AxSecurityPrivilege>

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentStatus.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentStatus.metadata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>ConDemoRentStatus</Name>
+	<Label>@SYS36398</Label>
+	<UseEnumValue>Yes</UseEnumValue>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>Open</Name>
+			<Label>@SYS16011</Label>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Confirmed</Name>
+			<Label>@SYS8985</Label>
+			<Value>1</Value>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Returned</Name>
+			<Label>@SYS109905</Label>
+			<Value>2</Value>
+		</AxEnumValue>
+		<AxEnumValue>
+			<Name>Cancelled</Name>
+			<Label>@SYS:CancelledState</Label>
+			<Value>3</Value>
+		</AxEnumValue>
+	</EnumValues>
+</AxEnum>

--- a/eval/goldens/L4-headerlines-document-slice/NumberSeqModule.ConDemoRent.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/NumberSeqModule.ConDemoRent.metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEnumExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>NumberSeqModule.ConDemoRent</Name>
+	<EnumValues>
+		<AxEnumValue>
+			<Name>DemoRent</Name>
+			<Label>@ConDemo:RentModule</Label>
+		</AxEnumValue>
+	</EnumValues>
+	<PropertyModifications />
+	<ValueModifications />
+</AxEnumExtension>

--- a/src/eval/coverage/taxonomy.ts
+++ b/src/eval/coverage/taxonomy.ts
@@ -90,7 +90,9 @@ export const TAXONOMY: CoverageLeaf[] = [
     // creation and the ordinal comparison, not the label/symbol split that
     // motivated the knowledge entry. It is the right case for this leaf and it is
     // not proof of that part; a case that renders an enum into a message would be.
-    // It is golden_pending in any event, so it claims the case without flipping E.
+    // Its golden was captured on 2026-08-31, so it now flips E for this leaf —
+    // read that E as "creation + ordinal comparison proven", not as proof of the
+    // label/symbol split.
     id: 'enum', label: 'Base enum', domain: 'Data model', source: 'aot', tier: 'core', weight: 5,
     aotTypes: ['enum'], knowledgeIds: ['xpp-class-rules', 'enum-conversions'],
     caseIds: ['L0-enum-basic', 'L3-enum-field-form-downgrade-guard'],
@@ -585,15 +587,20 @@ export const TAXONOMY: CoverageLeaf[] = [
   {
     id: 'unit-testing', label: 'SysTest unit testing', domain: 'Quality', source: 'topic', tier: 'core', weight: 4,
     aotTypes: ['class'], knowledgeIds: ['unit-testing', 'testing'], caseTags: ['runtime'],
-    // Read this ✅ narrowly. E comes from three cases that SHIP a SysTest class and
-    // whose goldens are captured — L2-coc-extension, L2-event-handler-basic and
-    // L3-batch-basic — not from a passing test run: all three are systest_pending,
-    // and the systest oracle has never executed once, because SysTestConsole.exe
-    // gates on an interactive console (eval/README.md, "Blocked / declined"). So the
-    // leaf proves the framework is authored correctly, not that a test went green.
-    // The knowledge behind it is now read from the shipped SysTestCase/SysTestAssert
-    // rather than from memory (there is no assertExpectedException).
-    note: 'Authoring is proven by three captured goldens. No SysTest has RUN yet — but as of 2026-08-31 the runner CONNECTS to the AOS database for the first time (the config drift was fixed on the VM), so the four cases whose runtime score is still null now wait on an eval-run rather than on a blocker.',
+    // This ✅ is now backed by EXECUTION, not only by authoring. The three cases
+    // that ship a SysTest class — L2-coc-extension, L2-event-handler-basic and
+    // L3-batch-basic — all ran under SysTestConsole.exe on 2026-08-31 and passed
+    // 2/2 each ("Rainier Test Suite : 2 Run, 0 Failed"), and no case carries
+    // `systest_pending` any more. The earlier claim here — that the oracle had
+    // never executed once because SysTestConsole.exe gates on an interactive
+    // console — was DISPROVED that day: the blocker was configuration drift (the
+    // runner could not reach the AOS database), not an interactive-console gate.
+    // The negative control committed alongside the wave proves the oracle
+    // discriminates (tests/eval/systestNegativeControl.test.ts), so a green
+    // runtime score here means a test really went green.
+    // The knowledge behind the leaf is read from the shipped SysTestCase/
+    // SysTestAssert rather than from memory (there is no assertExpectedException).
+    note: 'Authoring AND execution are both proven: L2-coc-extension, L2-event-handler-basic and L3-batch-basic each ran under SysTestConsole.exe on 2026-08-31 and passed 2/2 (corpus records …__278eee3.json), and L3-enum-field-form-downgrade-guard ran green too. The 2026-08-31 config fix on the VM removed the last blocker; the only runtime-tagged case still scoring null is L2-systest-authoring-basic, whose last run predates the fix.',
   },
   {
     id: 'labels', label: 'Labels & localisation', domain: 'Quality', source: 'topic', tier: 'core', weight: 5,
@@ -604,9 +611,12 @@ export const TAXONOMY: CoverageLeaf[] = [
   //
   // These nine leaves exist because the compiler answered questions this server
   // used to answer from memory (see docs/XPP_LANGUAGE_COVERAGE_PLAN.md §1). Each
-  // has a knowledge entry written from a probe and an eval case that is authored
-  // but NOT captured: golden_pending means E stays false, so the published number
-  // falls until a VM run proves them. That is the intended direction.
+  // has a knowledge entry written from a probe and an eval case. Those cases were
+  // authored but NOT captured when these leaves were written, so `golden_pending`
+  // held E false and the published number fell — the intended direction. As of
+  // 2026-08-31 the capture wave is complete: 0 of the 120 cases are
+  // `golden_pending`, so E here is now decided by the goldens, not by their
+  // absence.
   {
     id: 'runtime-functions', label: 'Run-time (predefined) functions', domain: 'Code', source: 'topic', tier: 'core', weight: 4,
     aotTypes: ['class'], knowledgeIds: ['runtime-functions'],

--- a/src/eval/oracle/actualArtifactResolution.ts
+++ b/src/eval/oracle/actualArtifactResolution.ts
@@ -6,66 +6,236 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { artifactKey } from './artifactKey.js';
+import { artifactKey, artifactIdentity, artifactType } from './artifactKey.js';
 import { type PrefixSpec } from './prefix.js';
 
-/**
- * Resolve the actual-dir file matching a golden artifact filename. Tries an
- * exact filename match first (fast path, and the only path when golden and
- * actual happen to share the same EXTENSION_PREFIX session); if that misses,
- * falls back to matching on the PREFIX-CANONICALISED filename (the golden's
- * filename is itself typically a prefixed object name, e.g.
- * "ContosoMyContract.metadata.xml", produced under a different session than the
- * one that generated the actual artifacts) so a whole L3/L4 multi-artifact
- * case doesn't spuriously score every artifact as missing/extra under prefix
- * drift alone.
- *
- * The fallback compares LOGICAL ARTIFACT KEYS (`artifactKey`), not merely
- * prefix-canonicalised filenames, so a legacy golden filename
- * (`DemoEnumExtProbe.AxClass.metadata.xml` — unprefixed stem, `.Ax<Type>`
- * infix) still pairs with the actual file the VM produced
- * (`ConDemoEnumExtProbe.metadata.xml`). See artifactKey.ts and
- * the 2026-07-21 eval sweep, finding #2.
- *
- * A bare `<Name>.xml` counts too. Goldens are committed as `*.metadata.xml`,
- * but AOT files on the VM are plain `.xml`, so pointing `--actual-dir` straight
- * at `<Model>/<Model>/AxClass` — the obvious thing to do during a capture —
- * used to match nothing and score every artifact `missing`: a silent zero, not
- * an error (L2-attribute-authoring-reflection capture, 2026-08-30). A
- * `.metadata.xml` neighbour still wins when both are present.
- */
 /**
  * A bare AOT filename in the shape `artifactKey` expects for a golden. Already-
  * committed `.metadata.xml` names pass through untouched — they end in `.xml` too,
  * and a blind replace turns them into `.metadata.metadata.xml`.
  */
 function aotToMetadataName(filename: string): string {
-  return /.metadata.xml$/i.test(filename)
+  return /\.metadata\.xml$/i.test(filename)
     ? filename
-    : filename.replace(/.xml$/i, '.metadata.xml');
+    : filename.replace(/\.xml$/i, '.metadata.xml');
 }
 
+/** Bytes read from a candidate to learn its root element / declared name. */
+const HEAD_BYTES = 8192;
+
+/**
+ * Read just the head of an actual file — enough for the root element and the
+ * object's own `<Name>`, both of which sit in the first few hundred bytes of
+ * every AOT document. Keeps identity resolution cheap when `--actual-dir` is
+ * pointed straight at a package folder.
+ */
+function readHead(file: string): string | undefined {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(file, 'r');
+    const buf = Buffer.alloc(HEAD_BYTES);
+    const read = fs.readSync(fd, buf, 0, HEAD_BYTES, 0);
+    return buf.subarray(0, read).toString('utf8');
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Every artifact file an actual dir holds, sorted, or `[]` when the dir is absent.
+ *
+ * BOTH shapes count: goldens are committed as `*.metadata.xml`, but the AOT
+ * files a VM session produces are bare `<Name>.xml`, and `--actual-dir` is
+ * routinely pointed straight at `<Model>/<Model>/Ax<Type>`. Every consumer of an
+ * actual dir must use THIS filter — the CLI's `golden_pending` branch grew its
+ * own `.metadata.xml`-only copy and consequently recorded
+ * `generated_artifacts: []` for every capture run (corpus:
+ * eval/corpus/runs/2026-08-31T22__L4-headerlines-document-slice__278eee3.json,
+ * "ORACLE DEFECT").
+ */
+export function listActualArtifactFiles(dir: string): string[] {
+  return fs.existsSync(dir)
+    ? fs.readdirSync(dir).filter(f => f.toLowerCase().endsWith('.xml')).sort()
+    : [];
+}
+
+/** Lazily-read `.xml` inventory of an actual dir, so one dir is read once per run. */
+class ActualDirIndex {
+  private readonly heads = new Map<string, string | undefined>();
+  readonly files: string[];
+
+  constructor(readonly dir: string) {
+    this.files = listActualArtifactFiles(dir);
+  }
+
+  /** The on-disk spelling of `name`, matched case-insensitively (NTFS is). */
+  find(name: string): string | undefined {
+    const wanted = name.toLowerCase();
+    return this.files.find(f => f.toLowerCase() === wanted);
+  }
+
+  head(file: string): string | undefined {
+    if (!this.heads.has(file)) this.heads.set(file, readHead(path.join(this.dir, file)));
+    return this.heads.get(file);
+  }
+
+  typeOf(file: string): string | undefined {
+    return artifactType(file, this.head(file));
+  }
+
+  identityOf(file: string, prefix: PrefixSpec): { stem: string; type?: string } {
+    return artifactIdentity(file, this.head(file), prefix);
+  }
+}
+
+export interface ActualFileResolution {
+  /** The paired actual file (absolute path), or undefined when none could be pinned. */
+  file?: string;
+  /**
+   * Set when >1 actual file matched and no signal separates them. The pair is
+   * NOT guessed: a silently wrong pairing (diffing a form against the menu item
+   * that opens it) is worse than a reported miss.
+   */
+  ambiguous?: string[];
+}
+
+/**
+ * Resolve the actual-dir file matching a golden artifact filename.
+ *
+ * Signals, strongest first:
+ *
+ *   1. the golden's own filename, verbatim or as the bare `.xml` the VM writes —
+ *      an operator naming a file exactly like the golden means that file. It is
+ *      still TYPE-CHECKED: `--actual-dir` is flat, so the operator has to give
+ *      one of two same-named objects (a form and its display menu item) the
+ *      undecorated name, and which one gets it is their choice, not a contract.
+ *   2. LOGICAL IDENTITY — the object name the document itself declares, plus its
+ *      root element. Survives every filename convention in the corpus (legacy
+ *      `.Ax<Type>` stems, `.menuitem` suffixes, hand-abbreviated stems, the
+ *      session-chosen suffix of a dot-notation extension) and every prefix drift.
+ *   3. the LOGICAL ARTIFACT KEY (`artifactKey`), for files whose content is
+ *      unreadable or nameless; ties are broken by AOT type.
+ *
+ * Historic notes kept because each is a regression this function owns:
+ *
+ * - The key fallback is what lets a legacy golden filename
+ *   (`DemoEnumExtProbe.AxClass.metadata.xml` — unprefixed stem, `.Ax<Type>`
+ *   infix) pair with the file the VM produced (`ConDemoEnumExtProbe.metadata.xml`).
+ *   See artifactKey.ts and the 2026-07-21 eval sweep, finding #2.
+ * - A bare `<Name>.xml` counts too. Goldens are committed as `*.metadata.xml`,
+ *   but AOT files on the VM are plain `.xml`, so pointing `--actual-dir` straight
+ *   at `<Model>/<Model>/AxClass` — the obvious thing to do during a capture —
+ *   used to match nothing and score every artifact `missing`: a silent zero, not
+ *   an error (L2-attribute-authoring-reflection capture, 2026-08-30). A
+ *   `.metadata.xml` neighbour still wins when both are present.
+ * - Matching used to be `artifactKey` + `Array.prototype.find` — FIRST MATCH
+ *   WINS. `artifactKey` deliberately strips the `.Ax<Type>` infix, so a golden
+ *   dir holding `ConX.metadata.xml` (AxForm) and `ConX.AxMenuItemDisplay.metadata.xml`
+ *   reduced both to one key and the form's golden was paired with the menu
+ *   item's file — two unrelated objects diffed against each other — or both
+ *   goldens were paired with the SAME file and one artifact vanished from the
+ *   run. (Corpus: 2026-08-31T22__L3-enum-field-form-downgrade-guard__278eee3;
+ *   that case needs both objects because a table's `FormRef` takes a MENU ITEM
+ *   name.)
+ */
+export function resolveActualFileDetailed(
+  actualDir: string,
+  goldenName: string,
+  goldenPrefix: PrefixSpec,
+  actualPrefix: PrefixSpec,
+  goldenXml?: string,
+): ActualFileResolution {
+  return resolveAgainstIndex(new ActualDirIndex(actualDir), goldenName, goldenPrefix, actualPrefix, goldenXml);
+}
+
+/** As `resolveActualFileDetailed`, over an index shared across a whole golden dir. */
+function resolveAgainstIndex(
+  index: ActualDirIndex,
+  goldenName: string,
+  goldenPrefix: PrefixSpec,
+  actualPrefix: PrefixSpec,
+  goldenXml?: string,
+): ActualFileResolution {
+  const goldenTypeIsKnown = artifactType(goldenName, goldenXml);
+  const abs = (f: string): string => path.join(index.dir, f);
+
+  /** A candidate is usable unless BOTH types are known and they disagree. */
+  const typeFits = (file: string): boolean => {
+    const actualType = index.typeOf(file);
+    return !goldenTypeIsKnown || !actualType || actualType === goldenTypeIsKnown;
+  };
+
+  // 1. The golden's own name, verbatim then as a bare AOT `.xml`.
+  for (const literal of [goldenName, goldenName.replace(/\.metadata\.xml$/i, '.xml')]) {
+    const onDisk = index.find(literal);
+    if (onDisk && typeFits(onDisk)) return { file: abs(onDisk) };
+  }
+
+  // 2. Logical identity — declared object name + root element.
+  const goldenIdentity = artifactIdentity(goldenName, goldenXml, goldenPrefix);
+  if (goldenIdentity.type) {
+    const byIdentity = index.files.filter(f => {
+      const id = index.identityOf(f, actualPrefix);
+      return id.stem === goldenIdentity.stem && id.type === goldenIdentity.type;
+    });
+    const picked = preferMetadataShape(byIdentity);
+    if (picked.length === 1) return { file: abs(picked[0]) };
+    if (picked.length > 1) return { ambiguous: picked };
+  }
+
+  // 3. Logical artifact key, ties broken by type.
+  const canonGolden = artifactKey(goldenName, goldenPrefix);
+  const byKey = index.files.filter(
+    f => artifactKey(aotToMetadataName(f), actualPrefix) === canonGolden,
+  );
+  const typed = goldenTypeIsKnown ? byKey.filter(f => index.typeOf(f) === goldenTypeIsKnown) : [];
+  const candidates = preferMetadataShape(typed.length > 0 ? typed : byKey.filter(typeFits));
+  if (candidates.length === 1) return { file: abs(candidates[0]) };
+  if (candidates.length > 1) return { ambiguous: candidates };
+  return {};
+}
+
+/**
+ * When a dir holds both shapes of the same object, the committed-golden
+ * (`.metadata.xml`) shape is the one the caller meant.
+ */
+function preferMetadataShape(files: string[]): string[] {
+  const metadata = files.filter(f => /\.metadata\.xml$/i.test(f));
+  return metadata.length > 0 ? metadata : files;
+}
+
+/**
+ * Back-compatible wrapper: the paired file, or undefined when there is none OR
+ * when the pairing is ambiguous. Callers that must report ambiguity rather than
+ * swallow it use `resolveActualFileDetailed`.
+ */
 export function resolveActualFile(
   actualDir: string,
   goldenName: string,
   goldenPrefix: PrefixSpec,
   actualPrefix: PrefixSpec,
+  goldenXml?: string,
 ): string | undefined {
-  const direct = path.join(actualDir, goldenName);
-  if (fs.existsSync(direct)) return direct;
-  const asAotFile = path.join(actualDir, goldenName.replace(/.metadata.xml$/i, '.xml'));
-  if (asAotFile !== direct && fs.existsSync(asAotFile)) return asAotFile;
+  return resolveActualFileDetailed(actualDir, goldenName, goldenPrefix, actualPrefix, goldenXml).file;
+}
 
-  const canonGolden = artifactKey(goldenName, goldenPrefix);
-  const files = fs.readdirSync(actualDir);
-  // .metadata.xml first: when a dir holds both shapes of the same object, the
-  // committed-golden shape is the one the caller meant.
-  const candidate =
-    files.filter(f => f.endsWith('.metadata.xml'))
-      .find(f => artifactKey(f, actualPrefix) === canonGolden)
-    ?? files.filter(f => f.endsWith('.xml') && !f.endsWith('.metadata.xml'))
-      .find(f => artifactKey(aotToMetadataName(f), actualPrefix) === canonGolden);
-  return candidate ? path.join(actualDir, candidate) : undefined;
+/** A golden artifact that could not be pinned to exactly one actual file. */
+export interface ArtifactPairingProblem {
+  golden: string;
+  /** The actual files that matched equally well (empty when nothing matched). */
+  candidates: string[];
+  reason: 'ambiguous' | 'claimed-by-another-golden';
+  /** For a conflict: the golden artifact that claimed the file first. */
+  claimedBy?: string;
+}
+
+export interface ActualArtifactsMap {
+  actualArtifacts: Record<string, string>;
+  matchedActualFiles: Set<string>;
+  /** Non-empty when a pairing was refused rather than guessed — the caller must say so. */
+  pairingProblems: ArtifactPairingProblem[];
 }
 
 /**
@@ -94,29 +264,67 @@ export function resolveActualFile(
  * content — unchanged from before; there is no real actual basename to key it
  * by, and the empty content correctly registers every one of that artifact's
  * paths as `missing`.
+ *
+ * `goldenContents` (optional, filename → golden XML) lets the resolver use the
+ * golden's own declared name and root element, which is what separates two
+ * artifacts of the SAME object name and different types. Two goldens are never
+ * allowed to claim the same actual file: the second claim is refused and
+ * reported, because one of the two pairings is necessarily wrong and the
+ * shared key would silently drop one golden from the run.
  */
 export function buildActualArtifactsMap(
   actualDir: string,
   artifactNames: string[],
   goldenPrefix: PrefixSpec,
   actualPrefix: PrefixSpec,
-): { actualArtifacts: Record<string, string>; matchedActualFiles: Set<string> } {
+  goldenContents?: Record<string, string>,
+): ActualArtifactsMap {
   const actualArtifacts: Record<string, string> = {};
   const matchedActualFiles = new Set<string>();
+  const pairingProblems: ArtifactPairingProblem[] = [];
+  const claimedBy = new Map<string, string>();
+  // One inventory (and one head-read per file) for the whole golden dir, however
+  // large the directory `--actual-dir` points at.
+  const index = new ActualDirIndex(actualDir);
+
   for (const name of artifactNames) {
-    const actualFile = resolveActualFile(actualDir, name, goldenPrefix, actualPrefix);
-    if (actualFile) {
-      const actualBasename = path.basename(actualFile);
+    const res = resolveAgainstIndex(
+      index, name, goldenPrefix, actualPrefix, goldenContents?.[name],
+    );
+    const basename = res.file ? path.basename(res.file) : undefined;
+
+    if (res.ambiguous) {
+      pairingProblems.push({ golden: name, candidates: res.ambiguous, reason: 'ambiguous' });
+    } else if (basename && claimedBy.has(basename)) {
+      pairingProblems.push({
+        golden: name, candidates: [basename], reason: 'claimed-by-another-golden',
+        claimedBy: claimedBy.get(basename),
+      });
+    } else if (res.file && basename) {
+      claimedBy.set(basename, name);
       // Key in the committed-golden filename shape. A bare AOT `.xml` keys to
       // `.xml`, which never equals the golden side's `.metadata.xml` key, so the
       // pair diffed as missing + extra even though resolveActualFile had matched
       // them. The key still carries actualPrefix, which is all canonicalisation
       // needs; matchedActualFiles keeps the real on-disk name for the caller.
-      actualArtifacts[aotToMetadataName(actualBasename)] = fs.readFileSync(actualFile, 'utf8');
-      matchedActualFiles.add(actualBasename);
-    } else {
-      actualArtifacts[name] = '';
+      actualArtifacts[aotToMetadataName(basename)] = fs.readFileSync(res.file, 'utf8');
+      matchedActualFiles.add(basename);
+      continue;
     }
+    // Unresolved, ambiguous or double-claimed: the golden keeps its own key with
+    // empty content, so every one of its paths is reported `missing`.
+    actualArtifacts[name] = '';
   }
-  return { actualArtifacts, matchedActualFiles };
+  return { actualArtifacts, matchedActualFiles, pairingProblems };
+}
+
+/** One line per refused pairing, for the CLI to print. Empty when all pairings are clean. */
+export function renderPairingProblems(problems: readonly ArtifactPairingProblem[]): string {
+  return problems.map(p => p.reason === 'ambiguous'
+    ? `AMBIGUOUS: golden ${p.golden} matches ${p.candidates.length} actual files ` +
+      `(${p.candidates.join(', ')}) and no type/name signal separates them — ` +
+      'scored as missing rather than paired by guess.'
+    : `CONFLICT: golden ${p.golden} resolved to ${p.candidates[0]}, which golden ` +
+      `${p.claimedBy} already claimed — scored as missing rather than double-counted.`,
+  ).join('\n');
 }

--- a/src/eval/oracle/artifactKey.ts
+++ b/src/eval/oracle/artifactKey.ts
@@ -21,25 +21,52 @@
  *
  *   1. drop the `.metadata.xml` suffix,
  *   2. drop a legacy `.Ax<Type>` type infix,
- *   3. drop a `.<prefix>Extension` dot-notation extension marker,
+ *   3. drop a `.<prefix>…Extension` dot-notation extension marker,
  *   4. canonicalise the EXTENSION_PREFIX to `PFX` (see `canonicalizePrefix`),
  *   5. drop a LEADING `PFX` — legacy golden filenames omit the prefix the file
  *      content carries, so prefixed and unprefixed stems must compare equal.
  *
  * Steps 2/3/5 are lossy, so `artifactKeyMap` refuses to apply them where they
  * would make two DIFFERENT filenames on the same side collide (e.g. a dir
- * holding both `CustGroup` and `CustGroup.ConExtension`): a colliding name keeps
- * its raw filename as its key, degrading to the previous exact-match behaviour
- * instead of silently diffing an extension against its base object.
+ * holding both `CustGroup` and `CustGroup.ConExtension`): a colliding name is
+ * qualified by its AOT TYPE where the type is known (`…#AxTable` vs
+ * `…#AxTableExtension` — still prefix-agnostic, so both sides of a diff derive
+ * the same key), and otherwise keeps its raw filename, degrading to the previous
+ * exact-match behaviour instead of silently diffing an extension against its
+ * base object.
+ *
+ * THE TYPE IS INFORMATION, NOT NOISE. Step 2 exists for the legacy convention,
+ * but a display menu item named after the form it opens is a standard D365FO
+ * shape (a table's `FormRef` takes a MENU ITEM name, so the pairing is forced),
+ * and a flat `--actual-dir` cannot hold two files called `Foo.xml` — the
+ * `.Ax<Type>` infix is then the ONLY thing telling them apart. So the key is
+ * deliberately lossy and every CALLER that must not guess (see
+ * `actualArtifactResolution.ts`) disambiguates with `artifactType` on top of it.
  */
 
 import { canonicalizePrefix, PREFIX_PLACEHOLDER, type PrefixSpec } from './prefix.js';
 
 const METADATA_SUFFIX = /\.metadata\.xml$/i;
+/** Any AOT/golden xml suffix — `.metadata.xml` or the bare `.xml` the VM writes. */
+const ANY_XML_SUFFIX = /(\.metadata)?\.xml$/i;
 /** Legacy `<Name>.AxClass` / `.AxTable` / `.AxEnumExtension` … type infix. */
-const TYPE_INFIX = /\.Ax[A-Z][A-Za-z]*$/;
-/** Dot-notation extension marker, once the prefix has been canonicalised. */
-const EXTENSION_MARKER = new RegExp(`\\.${PREFIX_PLACEHOLDER}Extension$`);
+const TYPE_INFIX = /\.(Ax[A-Z][A-Za-z0-9]*)$/;
+/**
+ * Dot-notation extension marker, once the prefix has been canonicalised.
+ * Matches `.PFXExtension` AND `.PFX<Anything>Extension`: the extension object's
+ * own suffix is session-chosen, so the same enum extension was captured as
+ * `NumberSeqModule.ConDemoExtension` and reproduced as
+ * `NumberSeqModule.ConExtension` — byte-identical content, 3 paths reported
+ * missing (corpus: 2026-08-31T22__L3-numberseq-module-slice__278eee3, finding 3).
+ */
+const EXTENSION_MARKER = new RegExp(`\\.${PREFIX_PLACEHOLDER}[A-Za-z0-9_]*Extension$`);
+
+/** Reduce a bare stem (no `.xml` suffix, no type infix) to its prefix-agnostic form. */
+function canonicalStem(stem: string, prefix: PrefixSpec): string {
+  let out = canonicalizePrefix(stem, prefix).replace(EXTENSION_MARKER, '');
+  if (out.startsWith(PREFIX_PLACEHOLDER)) out = out.slice(PREFIX_PLACEHOLDER.length);
+  return out;
+}
 
 /**
  * Reduce one artifact filename to its logical key. Exported for tests; callers
@@ -48,27 +75,141 @@ const EXTENSION_MARKER = new RegExp(`\\.${PREFIX_PLACEHOLDER}Extension$`);
  */
 export function artifactKey(filename: string, prefix: PrefixSpec = ''): string {
   const hadMetadataSuffix = METADATA_SUFFIX.test(filename);
-  let stem = filename.replace(METADATA_SUFFIX, '').replace(TYPE_INFIX, '');
-  stem = canonicalizePrefix(stem, prefix).replace(EXTENSION_MARKER, '');
-  if (stem.startsWith(PREFIX_PLACEHOLDER)) stem = stem.slice(PREFIX_PLACEHOLDER.length);
+  const stem = canonicalStem(
+    filename.replace(METADATA_SUFFIX, '').replace(TYPE_INFIX, ''),
+    prefix,
+  );
   return hadMetadataSuffix ? `${stem}.metadata.xml` : stem;
+}
+
+/**
+ * The `.Ax<Type>` type infix a filename carries, if any
+ * (`ConX.AxMenuItemDisplay.metadata.xml` → `AxMenuItemDisplay`). This is the
+ * capture convention for "two objects of different types share one name", so it
+ * must survive the lossy key.
+ */
+export function typeInfixOf(filename: string): string | undefined {
+  return TYPE_INFIX.exec(filename.replace(ANY_XML_SUFFIX, ''))?.[1];
+}
+
+/**
+ * The document's root element — `AxForm`, `AxMenuItemDisplay`, `AxTableExtension`,
+ * … — i.e. the artifact's AOT type as the file itself declares it. Ground truth,
+ * and available for both goldens and actual files, so it beats any filename
+ * convention. Returns undefined for a document with no readable root element.
+ */
+export function aotRootElement(xml: string | undefined): string | undefined {
+  if (!xml) return undefined;
+  const head = xml
+    .replace(/^﻿/, '')
+    .replace(/<\?[\s\S]*?\?>/g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<!DOCTYPE[^>]*>/gi, '');
+  return /<\s*([A-Za-z_][\w.\-]*)[\s>/]/.exec(head)?.[1];
+}
+
+/** The object name the document declares (its first `<Name>`), if readable. */
+export function declaredObjectNameOf(xml: string | undefined): string | undefined {
+  if (!xml) return undefined;
+  return /<Name>([^<]+)<\/Name>/.exec(xml)?.[1]?.trim() || undefined;
+}
+
+/**
+ * The artifact's AOT type: what the file says it is, else what its filename's
+ * `.Ax<Type>` infix says. Content wins — a filename convention is a hint, the
+ * root element is the object.
+ */
+export function artifactType(filename: string, xml?: string): string | undefined {
+  return aotRootElement(xml) ?? typeInfixOf(filename);
+}
+
+/**
+ * The artifact's prefix-agnostic logical identity: `{ stem, type }`.
+ *
+ * `stem` comes from the object name the document DECLARES when the content is
+ * available (the only signal that survives every filename convention in the
+ * corpus — legacy `.Ax<Type>` stems, `.menuitem` suffixes, hand-abbreviated
+ * stems like `NumberSeqModuleExt`), and from the filename otherwise.
+ */
+export function artifactIdentity(
+  filename: string,
+  xml: string | undefined,
+  prefix: PrefixSpec,
+): { stem: string; type?: string } {
+  const declared = declaredObjectNameOf(xml);
+  const fromFilename = filename.replace(ANY_XML_SUFFIX, '').replace(TYPE_INFIX, '');
+  return {
+    stem: canonicalStem(declared ?? fromFilename, prefix),
+    type: artifactType(filename, xml),
+  };
+}
+
+/** Qualify a logical key with an AOT type, keeping the `.metadata.xml` shape readable. */
+function qualify(key: string, type: string): string {
+  return METADATA_SUFFIX.test(key)
+    ? `${key.replace(METADATA_SUFFIX, '')}#${type}.metadata.xml`
+    : `${key}#${type}`;
 }
 
 /**
  * Key every name in `names` (one side of a diff), keeping a name's RAW filename
  * as its key whenever the reduced key is not unique within that side. Returns a
  * `filename → key` map.
+ *
+ * `contentOf` (optional) supplies each artifact's XML so a collision can be
+ * broken by AOT TYPE first. That fallback is strictly better than the raw
+ * filename, because it stays prefix- and convention-agnostic: a golden pair
+ * (`ConX.metadata.xml` = AxForm, `ConX.AxMenuItemDisplay.metadata.xml`) and the
+ * files reproducing it under a different prefix session
+ * (`ContosoX.xml`, `ContosoX.AxMenuItemDisplay.xml`) derive the SAME two keys,
+ * where raw-filename degradation made every path of both artifacts
+ * missing + extra.
+ *
+ * KNOWN GAP (measured 2026-08-31, not fixed here). Qualification is applied only
+ * to a side that COLLIDES, so it is asymmetric when one side collides and the
+ * other does not: a golden pair named `X.metadata.xml` + `X.menuitem.metadata.xml`
+ * (the `.menuitem` convention, 6 dirs) does not collide, while the AOT files
+ * reproducing it (`X.xml` + `X.AxMenuItemOutput.xml`) do — so the two sides key
+ * differently and the diff reports wholesale missing + extra even though
+ * `resolveActualFile` paired them correctly. Same for a hand-abbreviated golden
+ * stem (`CustGroupFormExt`, `NumberSeqModuleExt`). 9 golden dirs are affected
+ * under an AOT-named `--actual-dir`; none under the mirrored filenames captures
+ * actually use today, which is why this is latent rather than live. The real fix
+ * is to derive the multi-artifact key from the artifact's IDENTITY
+ * (`artifactIdentity`) rather than its filename — a change to the `<key>::` path
+ * format that also appears in committed corpus records, so it wants its own
+ * review rather than a ride-along.
  */
-export function artifactKeyMap(names: readonly string[], prefix: PrefixSpec = ''): Map<string, string> {
-  const counts = new Map<string, number>();
+export function artifactKeyMap(
+  names: readonly string[],
+  prefix: PrefixSpec = '',
+  contentOf?: (name: string) => string | undefined,
+): Map<string, string> {
+  const base = new Map(names.map(n => [n, artifactKey(n, prefix)]));
+  const count = (keys: Iterable<string>): Map<string, number> => {
+    const c = new Map<string, number>();
+    for (const k of keys) c.set(k, (c.get(k) ?? 0) + 1);
+    return c;
+  };
+
+  // Type-qualify only the names whose plain key collides, so a dir with no
+  // collision keeps exactly the keys it has always had.
+  const collides = count(base.values());
+  const qualified = new Map<string, string>();
   for (const name of names) {
-    const key = artifactKey(name, prefix);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
+    const key = base.get(name)!;
+    if ((collides.get(key) ?? 0) < 2) { qualified.set(name, key); continue; }
+    const type = artifactType(name, contentOf?.(name));
+    qualified.set(name, type ? qualify(key, type) : key);
   }
+
+  // Whatever still collides (same object name AND same type, or no type at all)
+  // keeps its raw filename — exact-match behaviour, never a silent cross-diff.
+  const stillCollides = count(qualified.values());
   const out = new Map<string, string>();
   for (const name of names) {
-    const key = artifactKey(name, prefix);
-    out.set(name, (counts.get(key) ?? 0) > 1 ? name : key);
+    const key = qualified.get(name)!;
+    out.set(name, (stillCollides.get(key) ?? 0) > 1 ? name : key);
   }
   return out;
 }

--- a/src/eval/oracle/artifactKey.ts
+++ b/src/eval/oracle/artifactKey.ts
@@ -93,6 +93,21 @@ export function typeInfixOf(filename: string): string | undefined {
 }
 
 /**
+ * One prologue token: a comment, a processing instruction, a doctype, or the
+ * start tag whose name is captured. Ordered so the skippable forms win, which is
+ * what makes this safe without a sanitising `replace()`.
+ *
+ * The UNTERMINATED comment and PI branches are load-bearing, not defensive
+ * padding. Without them the scanner merely fails to match at the `<!--` and
+ * then advances one position and happily matches an element name INSIDE the
+ * comment — which is the same class of bug as the single-pass strip this
+ * replaced. Consuming to end-of-input instead stops the scan, so a document
+ * whose remainder is commented out reports no root element, which is the honest
+ * answer.
+ */
+const PROLOGUE_TOKEN = /<!--[\s\S]*?-->|<!--[\s\S]*$|<\?[\s\S]*?\?>|<\?[\s\S]*$|<!DOCTYPE[^>]*>|<\s*([A-Za-z_][\w.\-]*)[\s>/]/gi;
+
+/**
  * The document's root element — `AxForm`, `AxMenuItemDisplay`, `AxTableExtension`,
  * … — i.e. the artifact's AOT type as the file itself declares it. Ground truth,
  * and available for both goldens and actual files, so it beats any filename
@@ -100,12 +115,17 @@ export function typeInfixOf(filename: string): string | undefined {
  */
 export function aotRootElement(xml: string | undefined): string | undefined {
   if (!xml) return undefined;
-  const head = xml
-    .replace(/^﻿/, '')
-    .replace(/<\?[\s\S]*?\?>/g, '')
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/<!DOCTYPE[^>]*>/gi, '');
-  return /<\s*([A-Za-z_][\w.\-]*)[\s>/]/.exec(head)?.[1];
+  // Walk the prologue token by token rather than stripping comments/PIs with
+  // replace(): a single-pass strip leaves a stray `<!--` behind on malformed
+  // input (CodeQL js/incomplete-multi-character-sanitization) and can then read
+  // markup out of a comment. Consuming alternatives IN ORDER cannot: an
+  // unterminated comment simply never matches the element branch.
+  PROLOGUE_TOKEN.lastIndex = 0;
+  let token: RegExpExecArray | null;
+  while ((token = PROLOGUE_TOKEN.exec(xml)) !== null) {
+    if (token[1]) return token[1];
+  }
+  return undefined;
 }
 
 /** The object name the document declares (its first `<Name>`), if readable. */

--- a/src/eval/oracle/cli.ts
+++ b/src/eval/oracle/cli.ts
@@ -12,6 +12,10 @@
  *     --bp-warnings <n>   number of BP warnings xppbp reported (OMIT = BP not checked -> bp_clean: null)
  *     --systest <file>    text file with the `run_systest_class` output (runtime oracle)
  *     --classification <C> rubric class for the record (default: derived)
+ *     --case-spec <path>  score against THIS case-spec JSON instead of
+ *                         eval/cases/<caseId>.json — for a spec that is not (yet)
+ *                         committed to the catalog, e.g. one `eval:mine` just
+ *                         drafted, or a synthetic spec in a test.
  *     --golden-prefix <p> EXTENSION_PREFIX the golden was captured under (default: every GOLDEN_CAPTURE_PREFIXES token)
  *     --actual-prefix <p> EXTENSION_PREFIX the actual was produced under (default: read from THIS
  *                         process's EXTENSION_PREFIX env var — the session that ran the case)
@@ -36,7 +40,9 @@ import {
   scoreRun, GOLDEN_CAPTURE_PREFIXES, type CaseSpec, type GoldenDiff, type Score,
 } from './index.js';
 import { resolveRegularObjectPrefixToken } from '../../utils/modelClassifier.js';
-import { buildActualArtifactsMap } from './actualArtifactResolution.js';
+import {
+  buildActualArtifactsMap, listActualArtifactFiles, renderPairingProblems,
+} from './actualArtifactResolution.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
@@ -78,7 +84,7 @@ const CLASSIFICATIONS = ['PASS', 'TOOL_DEFECT', 'KNOWLEDGE_GAP', 'VALIDATOR_GAP'
 /** Flags that consume the following argv element as their value. */
 const VALUE_FLAGS = [
   '--golden', '--actual-dir', '--bp-warnings', '--systest', '--classification',
-  '--golden-prefix', '--actual-prefix',
+  '--golden-prefix', '--actual-prefix', '--case-spec',
 ];
 
 function positionalArgs(argv: string[]): string[] {
@@ -105,8 +111,14 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  // `--case-spec` lets the oracle score a spec that isn't in the committed catalog
+  // (a freshly mined draft, or a synthetic spec under test), so nothing has to be
+  // written into eval/cases/ just to exercise a scoring path.
+  const caseSpecPath = arg('--case-spec')
+    ? path.resolve(arg('--case-spec')!)
+    : path.join(REPO_ROOT, 'eval', 'cases', `${caseId}.json`);
   const caseSpec = JSON.parse(
-    fs.readFileSync(path.join(REPO_ROOT, 'eval', 'cases', `${caseId}.json`), 'utf8'),
+    fs.readFileSync(caseSpecPath, 'utf8'),
   ) as CaseSpec & { ignore?: string[]; golden_pending?: boolean };
 
   const buildSucceeded = !flagSet('--build-failed');
@@ -174,13 +186,23 @@ async function main(): Promise<void> {
     score = { ...scoreRun({ build, goldenDiff: { matched: false, missing: [], extra: [], changed: [] }, tier: caseSpec.tier, systest }), golden_match: null };
     systestOut = systest && 'ran' in systest ? systest : { ran: false as const, passed: null, failures: [] as [] };
     if (actualDir) {
-      const resolvedActualDir = path.resolve(actualDir);
-      generatedArtifacts = fs.existsSync(resolvedActualDir)
-        ? fs.readdirSync(resolvedActualDir).filter(f => f.endsWith('.metadata.xml')).sort()
-        : [];
+      // Bare `<Name>.xml` counts. This used to filter for `*.metadata.xml` only,
+      // while an actual dir idiomatically holds the AOT files a VM session wrote
+      // (`--actual-dir <Model>/<Model>/AxClass`) — so EVERY golden-capture run
+      // recorded `generated_artifacts: []` and the operator had to reconstruct the
+      // list by hand afterwards. Silent zero, not an error. (Corpus:
+      // eval/corpus/runs/2026-08-31T22__L4-headerlines-document-slice__278eee3.json,
+      // "ORACLE DEFECT"; the resolver has always accepted both shapes, hence the
+      // now-shared `listActualArtifactFiles`.)
+      generatedArtifacts = listActualArtifactFiles(path.resolve(actualDir));
     } else {
       generatedArtifacts = actualPath ? [path.basename(actualPath)] : [];
     }
+    // Say what a `--write` would record: with no golden diff this list is the only
+    // account of what the run produced, so it must not be silently empty.
+    console.error(
+      `generated_artifacts (${generatedArtifacts.length}): ${generatedArtifacts.join(', ') || '(none found)'}`,
+    );
     debugLabel = `not evaluated — ${reason}`;
   } else if (actualDir) {
     const resolvedActualDir = path.resolve(actualDir);
@@ -190,8 +212,18 @@ async function main(): Promise<void> {
     for (const name of artifactNames) {
       goldenArtifacts[name] = fs.readFileSync(path.join(goldenDir(caseId), name), 'utf8');
     }
-    const { actualArtifacts, matchedActualFiles } =
-      buildActualArtifactsMap(resolvedActualDir, artifactNames, goldenPrefix, actualPrefix);
+    // Golden contents go in so the resolver can pair on the object each document
+    // DECLARES (name + root element), not just on its filename — the only signal
+    // that separates two artifacts sharing one object name, e.g. a form and the
+    // display menu item a table's `FormRef` requires.
+    const { actualArtifacts, matchedActualFiles, pairingProblems } =
+      buildActualArtifactsMap(resolvedActualDir, artifactNames, goldenPrefix, actualPrefix, goldenArtifacts);
+    if (pairingProblems.length > 0) {
+      // Loud, never silent: a refused pairing scores as `missing`, and the
+      // operator needs to know it was refused rather than genuinely absent.
+      console.error(`\n# Artifact pairing refused for ${pairingProblems.length} golden artifact(s):`);
+      console.error(renderPairingProblems(pairingProblems));
+    }
     // Surface extra actual files (produced but not golden-expected, and not already
     // matched to a golden artifact above under prefix-canonicalised filename matching) too.
     for (const f of fs.readdirSync(resolvedActualDir).filter(f => f.endsWith('.metadata.xml'))) {

--- a/src/eval/oracle/diff.ts
+++ b/src/eval/oracle/diff.ts
@@ -2,7 +2,15 @@
  * Structural diff for the eval golden oracle. Compares two normalized
  * `path → value` maps (see normalize.ts) and classifies each delta as
  * missing / extra / changed, mirroring eval/corpus/schema.json `golden_diff`.
+ *
+ * Value equality is NOT `===`: it goes through `valuesEquivalent`, which makes
+ * the collapsed XmlDoc placeholder DIRECTIONAL (an actual may carry a doc
+ * comment its golden lacks; the reverse still fails). The rationale, and the
+ * deliberate decision not to batch-re-capture the goldens, live on that
+ * function in normalize.ts — read them before changing this.
  */
+
+import { valuesEquivalent } from './normalize.js';
 
 export interface GoldenDiff {
   matched: boolean;
@@ -31,7 +39,7 @@ export function diffNormalized(
       missing.push(path);
     } else {
       const actVal = actual.get(path)!;
-      if (actVal !== expVal) changed.push({ path, expected: expVal, actual: actVal });
+      if (!valuesEquivalent(expVal, actVal)) changed.push({ path, expected: expVal, actual: actVal });
     }
   }
   for (const path of actual.keys()) {

--- a/src/eval/oracle/index.ts
+++ b/src/eval/oracle/index.ts
@@ -14,6 +14,7 @@ import { type SysTestResult } from './systest.js';
 export {
   normalizeAotXml, normalizeMultiArtifact, renderNormalized, globToRegExp,
   GOLDEN_CAPTURE_PREFIX, GOLDEN_CAPTURE_PREFIXES, canonicalizePrefix, type PrefixSpec,
+  valuesEquivalent, XMLDOC_PLACEHOLDER,
 } from './normalize.js';
 export { artifactKey, artifactKeyMap } from './artifactKey.js';
 export { diffNormalized, renderDiff, type GoldenDiff } from './diff.js';

--- a/src/eval/oracle/index.ts
+++ b/src/eval/oracle/index.ts
@@ -16,7 +16,7 @@ export {
   GOLDEN_CAPTURE_PREFIX, GOLDEN_CAPTURE_PREFIXES, canonicalizePrefix, type PrefixSpec,
   valuesEquivalent, XMLDOC_PLACEHOLDER,
 } from './normalize.js';
-export { artifactKey, artifactKeyMap } from './artifactKey.js';
+export { artifactKey, artifactKeyMap, aotRootElement, declaredObjectNameOf } from './artifactKey.js';
 export { diffNormalized, renderDiff, type GoldenDiff } from './diff.js';
 export { scoreRun, type Score, type BuildResult, type ScoreInput } from './score.js';
 export { parseSysTestResult, type SysTestResult, type SysTestFailure } from './systest.js';

--- a/src/eval/oracle/normalize.ts
+++ b/src/eval/oracle/normalize.ts
@@ -120,7 +120,7 @@ function isXppSourcePath(pathPrefix: string): boolean {
  * canonicalisation — it never rewrites a stored artifact.
  */
 function canonicalizeXppSourceText(s: string): string {
-  return canonicalizeXppDocComments(reindentXppSource(s, 0));
+  return canonicalizeXppBlankLines(canonicalizeXppDocComments(reindentXppSource(s, 0)));
 }
 
 /**
@@ -128,7 +128,57 @@ function canonicalizeXppSourceText(s: string): string {
  * Deliberately still a `///` line: PRESENCE of a doc comment survives the
  * canonicalisation, only its PROSE is discarded (see below).
  */
-const XMLDOC_PLACEHOLDER = '/// <xmldoc/>';
+export const XMLDOC_PLACEHOLDER = '/// <xmldoc/>';
+
+/** Is this line the collapsed XmlDoc placeholder (at any indent)? */
+function isXmlDocPlaceholderLine(line: string): boolean {
+  return line.trim() === XMLDOC_PLACEHOLDER;
+}
+
+/**
+ * Drop blank lines that sit immediately before a closing `}`.
+ *
+ * `reindentXppSource` re-derives indentation but deliberately PRESERVES blank
+ * lines ("preserve blank lines in the middle"), so a purely cosmetic blank line
+ * survives canonicalisation and reaches the diff. The writer emits exactly one
+ * such line: `ensureBlankLineBeforeClosingBrace` (src/utils/xppDocGen.ts) puts a
+ * blank line between the last member-variable declaration and the class body's
+ * `}`, matching the shipped-Microsoft convention. Goldens captured before that
+ * convention was applied do not have it, so
+ *
+ *     class PFXDemoBatchContract     class PFXDemoBatchContract
+ *     {                              {
+ *         int batchSize;                 int batchSize;
+ *         int priorityFactor;            int priorityFactor;
+ *     }                                              ← writer's blank line
+ *                                    }
+ *
+ * false-mismatched on a Declaration whose tokens are identical. Measured on
+ * `L3-batch-basic`'s `DemoBatchContract`
+ * (eval/corpus/runs/2026-08-31T23__L3-batch-basic__278eee3.json).
+ *
+ * Unlike the doc-comment rule below this one is SYMMETRIC: blank lines are not
+ * scored by anything — no best-practice rule fires on their presence or absence
+ * — so there is no direction in which losing them hides a real defect. It is
+ * kept narrow (only before a `}`) rather than "strip every blank line", so a
+ * golden that deliberately asserts paragraph structure inside a method body
+ * still asserts it.
+ */
+function canonicalizeXppBlankLines(s: string): string {
+  const lines = s.split('\n');
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== '') { out.push(lines[i]); continue; }
+    let end = i;
+    while (end < lines.length && lines[end].trim() === '') end++;
+    // Keep the run unless a closing brace follows it.
+    if (!(end < lines.length && lines[end].trim().startsWith('}'))) {
+      for (let k = i; k < end; k++) out.push(lines[k]);
+    }
+    i = end - 1;
+  }
+  return out.join('\n');
+}
 
 /**
  * Collapse every contiguous run of `///` XmlDoc lines to a single placeholder
@@ -167,6 +217,63 @@ function canonicalizeXppDocComments(s: string): string {
     out.push(line);
   }
   return out.join('\n');
+}
+
+/**
+ * Are two normalised values equal, treating a doc comment that exists ONLY on
+ * the ACTUAL side as equal? DIRECTIONAL — see the two halves below.
+ *
+ * ── Why the actual side may carry MORE documentation ────────────────────────
+ * `ensureXppDocComment` (src/utils/xppDocGen.ts) injects a class-level `///`
+ * block unconditionally, and commit 0a95198 (2026-08-09) extended that to the
+ * bridge create path — FIVE WEEKS after the affected goldens were captured
+ * (2026-07-07 / 2026-07-23). The writer changed underneath the goldens, so no
+ * faithful rerun of those cases can ever reproduce them: 34 of the 159
+ * committed goldens carrying a class/interface `<Declaration>` have no `///`
+ * block at all, and the writer now puts one on 32 of them.
+ *
+ * An actual that carries MORE documentation than its golden is strictly
+ * BP-BETTER: `BPXmlDocNoDocumentationComments` fires on ABSENCE, and
+ * `bp_clean` already scores that separately. `canonicalizeXppDocComments` above
+ * has always collapsed doc-comment CONTENT to a placeholder, so PRESENCE was
+ * the only thing a golden ever asserted here — and the writer now guarantees
+ * it. Failing `golden_match` on it measures the writer's release date, not the
+ * agent's work.
+ *
+ * ── Why the reverse still fails ─────────────────────────────────────────────
+ * A doc comment present in the GOLDEN and MISSING from the actual is a real
+ * regression — documentation the corpus proved reachable that a run stopped
+ * producing — and the oracle keeps catching it. That direction is pinned by an
+ * explicit test; it is the whole reason this is not simply "ignore doc
+ * comments".
+ *
+ * ── Policy: the goldens are NOT being re-captured in a batch ────────────────
+ * DO NOT "clean up" this softened rule, and DO NOT mass-regenerate
+ * `eval/goldens/` to make it unnecessary. Each affected case re-captures its
+ * own golden naturally the next time it runs on the VM; the moment it does, its
+ * golden carries the doc comment and full strictness returns for that case, on
+ * its own, one case at a time. Removing the rule before the corpus has caught
+ * up re-breaks every case that has not run yet; batch-regenerating the goldens
+ * would rewrite evidence wholesale to match the current writer, which is
+ * exactly the overfitting the golden corpus exists to prevent.
+ */
+export function valuesEquivalent(expected: string, actual: string): boolean {
+  if (expected === actual) return true;
+
+  const exp = expected.split('\n');
+  const act = actual.split('\n');
+  let i = 0;
+  let j = 0;
+  while (i < exp.length && j < act.length) {
+    if (exp[i] === act[j]) { i++; j++; continue; }
+    // The ONLY tolerated asymmetry: an extra doc-comment line on the actual
+    // side. A placeholder on the EXPECTED side that the actual does not have
+    // falls through to `return false`.
+    if (isXmlDocPlaceholderLine(act[j]) && !isXmlDocPlaceholderLine(exp[i])) { j++; continue; }
+    return false;
+  }
+  while (j < act.length && isXmlDocPlaceholderLine(act[j])) j++;
+  return i === exp.length && j === act.length;
 }
 
 /**
@@ -408,7 +515,13 @@ export async function normalizeMultiArtifact(
 ): Promise<Map<string, string>> {
   const out = new Map<string, string>();
   const names = Object.keys(artifacts).sort();
-  const keys = artifactKeyMap(names, prefix);
+  // Content is passed so a COLLIDING key (two artifacts of the same object name —
+  // e.g. a form and the display menu item that opens it, the shape a table's
+  // `FormRef` forces) is broken by AOT type rather than by raw filename: the raw
+  // filename differs between the golden and the files reproducing it, so
+  // raw-filename degradation reported every path of both artifacts as
+  // missing + extra. See artifactKeyMap.
+  const keys = artifactKeyMap(names, prefix, n => artifacts[n]);
   for (const name of names) {
     const single = await normalizeAotXml(artifacts[name], ignore, prefix);
     const canonName = keys.get(name) ?? canonicalizePrefix(name, prefix);

--- a/src/eval/oracle/prefix.ts
+++ b/src/eval/oracle/prefix.ts
@@ -17,19 +17,65 @@ export const PREFIX_PLACEHOLDER = 'PFX';
 export type PrefixSpec = string | readonly string[];
 
 /**
+ * The Microsoft extension-class suffix, as an anchored lookahead: the prefix
+ * token must be IMMEDIATELY followed by `_Extension`, and `_Extension` must END
+ * the identifier.
+ *
+ * Both halves are load-bearing:
+ *
+ *  - "immediately" is what keeps the branch non-greedy. It would be tempting to
+ *    consume the whole PascalCase run before `_Extension` (`Con[A-Za-z0-9]*`),
+ *    since the session-chosen prefix can be longer than the golden's
+ *    (`Con` vs `ConDemo`) — but then `FMVehicleDataContractConfig_Extension`
+ *    would canonicalise onto `FMVehicleDataContractCon_Extension` and a diff
+ *    between two DIFFERENT objects would silently pass. Each side is
+ *    canonicalised against ITS OWN prefix token, so exact adjacency is enough.
+ *  - the end-of-identifier guard keeps the branch confined to the naming
+ *    convention it is named after; `…Con_ExtensionHelper` is left alone.
+ */
+const EXTENSION_CLASS_SUFFIX = '(?=_Extension(?![A-Za-z0-9_]))';
+
+/**
  * Canonicalise occurrences of `prefix` — the model-naming EXTENSION_PREFIX in
  * effect for THIS document (the golden's fixed capture-time prefix, or the
  * actual's current session-configured prefix) — into a stable placeholder, so
  * a value/key built under one prefix session compares equal to the same
  * value/key built under a different one.
  *
- * Matches are anchored at an identifier-start boundary (string start, or
- * immediately after a non-alphanumeric character — `.`, `(`, `,`, `_`,
- * whitespace, …) AND require the prefix to be immediately followed by an
- * uppercase letter (the PascalCase continuation of the object's own name,
- * e.g. `ContosoXyzNoteSubject`, `CustGroup.ContosoExtension`, `classStr(ContosoXyzNoteSubject)`).
- * This keeps the substitution narrow: an incidental occurrence of the prefix
- * text inside unrelated free-form content (e.g. a label) is left alone.
+ * TWO placements are recognised, because D365FO names prefixed objects in two
+ * different shapes:
+ *
+ *   PREFIX (`{Prefix}{Name}`) — the prefix leads the identifier. Matched at an
+ *     identifier-start boundary (string start, or immediately after a
+ *     non-alphanumeric character — `.`, `(`, `,`, `_`, whitespace, …) AND
+ *     required to be followed by an uppercase letter, i.e. the PascalCase
+ *     continuation of the object's own name: `ContosoXyzNoteSubject`,
+ *     `CustGroup.ContosoExtension`, `classStr(ContosoXyzNoteSubject)`.
+ *
+ *   INFIX (`{Base}{Prefix}_Extension`) — the Microsoft extension-class
+ *     convention, where the prefix sits MID-identifier (preceded by the base
+ *     object's name) and is followed by an underscore, so NEITHER half of the
+ *     prefix rule applies: `FMVehicleDataContractCon_Extension`. Matched only
+ *     when the token is immediately followed by a terminal `_Extension`
+ *     (`EXTENSION_CLASS_SUFFIX`), with no leading-boundary requirement.
+ *
+ * Both keep the substitution narrow: an incidental occurrence of the prefix text
+ * inside unrelated free-form content (e.g. a label), or as a PascalCase word
+ * inside a longer name (`SalesConNote`, `…Config_Extension`), is left alone. That
+ * narrowness is the point — this function is deliberately lossy and is used to
+ * compare artifact names ACROSS prefix sessions, so a rule greedy enough to
+ * canonicalise a prefix-shaped substring of an unrelated identifier would make
+ * two different objects compare equal and let a real diff pass silently. That is
+ * a worse failure than a false mismatch, and `tests/eval/oraclePrefixExtensionInfix.test.ts`
+ * pins the boundaries in both directions.
+ *
+ * Regression: without the INFIX branch, a CoC extension class captured as
+ * `FMVehicleDataContractCon_Extension` and reproduced under session prefix
+ * `ConDemo` scored `golden_match: 0` on a runtime-verified-correct
+ * implementation (corpus: 2026-08-31T23__L2-coc-extension__278eee3; the same gap
+ * reported in 2026-07-07T04__L2-coc-extension__cb1b73d, whose proposed fix —
+ * widening the lookahead to `[A-Z_]` — was measured insufficient, since the
+ * leading boundary is the actual blocker).
  *
  * `prefix` may be a SET of tokens (see `GOLDEN_CAPTURE_PREFIXES`). Tokens are
  * applied longest-first so a longer prefix is consumed before a shorter one
@@ -41,8 +87,17 @@ export function canonicalizePrefix(value: string, prefix: PrefixSpec): string {
     .sort((a, b) => b.length - a.length);
   let out = value;
   for (const token of tokens) {
-    const re = new RegExp(`(^|[^A-Za-z0-9])${escapeRegExp(token)}(?=[A-Z])`, 'g');
-    out = out.replace(re, `$1${PREFIX_PLACEHOLDER}`);
+    const t = escapeRegExp(token);
+    // Prefix placement: `{Prefix}{Name}` at an identifier start.
+    out = out.replace(
+      new RegExp(`(^|[^A-Za-z0-9])${t}(?=[A-Z])`, 'g'),
+      `$1${PREFIX_PLACEHOLDER}`,
+    );
+    // Infix placement: `{Base}{Prefix}_Extension`.
+    out = out.replace(
+      new RegExp(`${t}${EXTENSION_CLASS_SUFFIX}`, 'g'),
+      PREFIX_PLACEHOLDER,
+    );
   }
   return out;
 }

--- a/tests/eval/batchedObjectReadsCase.test.ts
+++ b/tests/eval/batchedObjectReadsCase.test.ts
@@ -9,7 +9,7 @@
  *
  * The behavioural half (3 objects → ONE call → 3 sections) is asserted in
  * tests/tools/getObjectInfoPlural.test.ts; the live run is captured on the VM,
- * hence golden_pending.
+ * captured 2026-08-31 (three AxTableExtension artifacts).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -32,9 +32,10 @@ describe(`${CASE_ID} — eval case spec`, () => {
     expect(spec.tier).toBe(2);
     expect(spec.id.startsWith(`L${spec.tier}-`)).toBe(true);
     expect(spec.golden_path).toBe(`eval/goldens/${CASE_ID}/`);
-    expect(spec.golden_pending).toBe(true); // captured on the VM (§6.4)
+    expect(spec.golden_pending).toBe(false); // golden captured on the VM 2026-08-31 (§6.4)
     expect(spec.split).toBe('holdout');
-    expect(spec.target_artifact_types).toEqual(['AxTableExtension']);
+    // one entry per FILE: the case produces three sibling table extensions
+    expect(spec.target_artifact_types).toEqual(['AxTableExtension', 'AxTableExtension', 'AxTableExtension']);
   });
 
   it('names 3+ objects, all of a type get_object_info can actually read', () => {
@@ -56,5 +57,43 @@ describe(`${CASE_ID} — eval case spec`, () => {
 
   it('never tells the agent to reach for the retired batch_get_info tool', () => {
     expect(spec.instruction).not.toContain('batch_get_info');
+  });
+});
+
+/**
+ * Captured-golden contract. The three artifacts are ordinary table extensions, so
+ * nothing else in the suite would notice if the field lost its EDT again: the
+ * historical table-extension defect wrote the field with NO <ExtendedDataType> (the
+ * bridge reads {type, edt}, the caller sent {fieldType, extendedDataType}) and still
+ * built clean, which is why the sibling case L2-table-extension has to ignore that
+ * very path. These assertions pin what the live 2026-08-31 capture proved.
+ */
+describe(`${CASE_ID} — captured golden`, () => {
+  const goldenDir = path.join(REPO_ROOT, 'eval', 'goldens', CASE_ID);
+  const files = fs.existsSync(goldenDir)
+    ? fs.readdirSync(goldenDir).filter(f => f.endsWith('.metadata.xml')).sort()
+    : [];
+
+  it('holds one AxTableExtension artifact per base table', () => {
+    expect(files).toEqual([
+      'InventItemGroup.ConDemoExtension.metadata.xml',
+      'PaymTerm.ConDemoExtension.metadata.xml',
+      'VendGroup.ConDemoExtension.metadata.xml',
+    ]);
+  });
+
+  it.each(files)('%s adds EvalNoteText backed by the standard Notes EDT, in a field group, without touching a base field', (file) => {
+    const xml = fs.readFileSync(path.join(goldenDir, file), 'utf8');
+    expect(xml).toContain('<AxTableExtension');
+    expect(xml).toContain('<Name>EvalNoteText</Name>');
+    // The EDT is the load-bearing part: it is what silently vanished before.
+    expect(xml).toContain('<ExtendedDataType>Notes</ExtendedDataType>');
+    expect(xml).toMatch(/i:type="AxTableFieldString"/);
+    // Surfaces on forms by extending the BASE table group, not by inventing a new
+    // group that no container names in <DataGroup> (which renders nothing).
+    expect(xml).toContain('<AxTableFieldGroupExtension>');
+    expect(xml).toContain('<DataField>EvalNoteText</DataField>');
+    // No base-table field may be modified.
+    expect(xml).toContain('<FieldModifications />');
   });
 });

--- a/tests/eval/oracleArtifactPairing.test.ts
+++ b/tests/eval/oracleArtifactPairing.test.ts
@@ -24,7 +24,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { evaluateMulti, artifactKey, GOLDEN_CAPTURE_PREFIXES } from '../../src/eval/oracle/index';
+import { evaluateMulti, artifactKey, GOLDEN_CAPTURE_PREFIXES, aotRootElement } from '../../src/eval/oracle/index';
 import {
   resolveActualFile, resolveActualFileDetailed, buildActualArtifactsMap,
 } from '../../src/eval/oracle/actualArtifactResolution';
@@ -248,5 +248,39 @@ describe('dot-notation extension filenames (corpus: L3-numberseq-module-slice, f
     }, dir => {
       expect(resolveActualFile(dir, goldenName, P, P, goldenXml)).toBeUndefined();
     });
+  });
+});
+
+describe('aotRootElement reads the real root, not markup inside the prologue', () => {
+  it('ignores an element name that only appears inside a comment', () => {
+    expect(aotRootElement('<!-- <AxForm> was here --><AxMenuItemDisplay><Name>X</Name>'))
+      .toBe('AxMenuItemDisplay');
+  });
+
+  it('ignores an element name inside the XML declaration and a doctype', () => {
+    expect(aotRootElement('<?xml version="1.0" encoding="utf-8"?><AxTable><Name>X</Name>'))
+      .toBe('AxTable');
+    expect(aotRootElement('<!DOCTYPE AxForm SYSTEM "x.dtd"><AxTableExtension>'))
+      .toBe('AxTableExtension');
+  });
+
+  it('does not read a type out of an UNTERMINATED comment', () => {
+    // Ordered alternation alone is NOT enough here, which this test caught:
+    // the scanner fails at the `<!--`, advances one character, and then matches
+    // `<AxForm>` inside the comment — the same bug as the single-pass strip it
+    // replaced. It takes an explicit unterminated-comment branch that consumes
+    // to end-of-input to stop the scan.
+    expect(aotRootElement('<!-- <AxForm><Name>Injected</Name>')).toBeUndefined();
+  });
+
+  it('still returns undefined for a document with no element at all', () => {
+    expect(aotRootElement('')).toBeUndefined();
+    expect(aotRootElement(undefined)).toBeUndefined();
+  });
+
+  it('is not left stateful by a previous call (global regex lastIndex)', () => {
+    const xml = '<AxForm><Name>A</Name></AxForm>';
+    expect(aotRootElement(xml)).toBe('AxForm');
+    expect(aotRootElement(xml)).toBe('AxForm');
   });
 });

--- a/tests/eval/oracleArtifactPairing.test.ts
+++ b/tests/eval/oracleArtifactPairing.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Golden ↔ actual-file PAIRING for multi-artifact (`--actual-dir`) runs.
+ *
+ * Corpus evidence:
+ *   eval/corpus/runs/2026-08-31T22__L3-enum-field-form-downgrade-guard__278eee3.json
+ *     — the case's own README says the display menu item's golden "carries the
+ *       legacy `.Ax<Type>` infix … because two objects of different types share
+ *       one name, and `artifactKey` needs the two files to stay distinguishable".
+ *       `artifactKey` STRIPS that infix, so they were not distinguishable at all.
+ *   eval/corpus/runs/2026-08-31T22__L3-numberseq-module-slice__278eee3.json (finding 3)
+ *     — a dot-notation extension captured as `NumberSeqModule.ConDemoExtension`
+ *       and reproduced as `NumberSeqModule.ConExtension` scored 3 missing on
+ *       byte-identical content.
+ *
+ * A display menu item named exactly after the form it opens is a standard
+ * D365FO shape — a table's `FormRef` takes a MENU ITEM name, so the pairing is
+ * forced — and a flat `--actual-dir` cannot hold two files called `Foo.xml`.
+ * So the corpus legitimately contains colliding logical keys, and the oracle
+ * has to pair on more than the key. Every test here is VM-free and fails on the
+ * pre-fix code.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { evaluateMulti, artifactKey, GOLDEN_CAPTURE_PREFIXES } from '../../src/eval/oracle/index';
+import {
+  resolveActualFile, resolveActualFileDetailed, buildActualArtifactsMap,
+} from '../../src/eval/oracle/actualArtifactResolution';
+
+const P = GOLDEN_CAPTURE_PREFIXES;
+const BUILD_OK = { succeeded: true, bpWarnings: [] };
+
+const formXml = (name: string): string =>
+  `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>${name}</Name>
+  <SourceCode><Methods/></SourceCode>
+  <DataSources><AxFormDataSource><Name>${name}Ds</Name></AxFormDataSource></DataSources>
+</AxForm>`;
+
+const menuItemXml = (name: string): string =>
+  `<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemDisplay xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>${name}</Name>
+  <Label>@TaxTransactionInquiry:HeaderNote</Label>
+  <Object>${name}</Object>
+</AxMenuItemDisplay>`;
+
+/** The committed golden pair: a form and the display menu item that opens it. */
+const GOLDENS: Record<string, string> = {
+  'ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml': menuItemXml('ConDemoTaxChangeLogDetails'),
+  'ConDemoTaxChangeLogDetails.metadata.xml': formXml('ConDemoTaxChangeLogDetails'),
+};
+const GOLDEN_NAMES = Object.keys(GOLDENS);
+
+function withDir<T>(files: Record<string, string>, fn: (dir: string) => T): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-pairing-'));
+  try {
+    for (const [name, content] of Object.entries(files)) fs.writeFileSync(path.join(dir, name), content);
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** golden filename → the basename of the actual file it was paired with. */
+function pairing(dir: string): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const name of GOLDEN_NAMES) {
+    const hit = resolveActualFile(dir, name, P, P, GOLDENS[name]);
+    out[name] = hit ? path.basename(hit) : undefined;
+  }
+  return out;
+}
+
+describe('a form and its same-named display menu item pair with their OWN files', () => {
+  it('the logical keys DO collide — which is why the key alone must not decide', () => {
+    // Not a defect in the corpus: this is the shape D365FO forces. The oracle
+    // has to carry the type through, not ban the shape.
+    expect(artifactKey('ConDemoTaxChangeLogDetails.metadata.xml', P))
+      .toBe(artifactKey('ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml', P));
+  });
+
+  it('capture convention: bare name = form, `.Ax<Type>` = menu item', () => {
+    withDir({
+      'ConDemoTaxChangeLogDetails.xml': formXml('ConDemoTaxChangeLogDetails'),
+      'ConDemoTaxChangeLogDetails.AxMenuItemDisplay.xml': menuItemXml('ConDemoTaxChangeLogDetails'),
+    }, dir => {
+      expect(pairing(dir)).toEqual({
+        'ConDemoTaxChangeLogDetails.metadata.xml': 'ConDemoTaxChangeLogDetails.xml',
+        'ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml': 'ConDemoTaxChangeLogDetails.AxMenuItemDisplay.xml',
+      });
+    });
+  });
+
+  it('REPRO: the operator gave the bare name to the MENU ITEM — the pair used to cross over', () => {
+    // Which of the two same-named objects gets the undecorated filename is the
+    // capturing operator's choice, not a contract. Pre-fix, `artifactKey` +
+    // `find` paired the form's golden with the menu item's file and vice versa:
+    // two unrelated objects diffed against each other under a green-looking run.
+    withDir({
+      'ConDemoTaxChangeLogDetails.xml': menuItemXml('ConDemoTaxChangeLogDetails'),
+      'ConDemoTaxChangeLogDetails.AxForm.xml': formXml('ConDemoTaxChangeLogDetails'),
+    }, dir => {
+      expect(pairing(dir)).toEqual({
+        'ConDemoTaxChangeLogDetails.metadata.xml': 'ConDemoTaxChangeLogDetails.AxForm.xml',
+        'ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml': 'ConDemoTaxChangeLogDetails.xml',
+      });
+    });
+  });
+
+  it('REPRO: under prefix drift BOTH goldens used to claim the SAME actual file', () => {
+    // Pre-fix, `find` returned the alphabetically-first key match for both
+    // goldens, so the form's file was never read at all and the run silently
+    // scored two goldens against one menu item.
+    withDir({
+      'ContosoDemoTaxChangeLogDetails.xml': formXml('ContosoDemoTaxChangeLogDetails'),
+      'ContosoDemoTaxChangeLogDetails.AxMenuItemDisplay.xml': menuItemXml('ContosoDemoTaxChangeLogDetails'),
+    }, dir => {
+      expect(pairing(dir)).toEqual({
+        'ConDemoTaxChangeLogDetails.metadata.xml': 'ContosoDemoTaxChangeLogDetails.xml',
+        'ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml': 'ContosoDemoTaxChangeLogDetails.AxMenuItemDisplay.xml',
+      });
+      const { matchedActualFiles, pairingProblems } =
+        buildActualArtifactsMap(dir, GOLDEN_NAMES, P, P, GOLDENS);
+      expect(pairingProblems).toEqual([]);
+      expect(matchedActualFiles.size).toBe(2); // a bijection, not one file twice
+    });
+  });
+
+  it('end-to-end: the drifted pair scores golden_match 1, not a wholesale mismatch', async () => {
+    await withDir({
+      'ContosoDemoTaxChangeLogDetails.xml': formXml('ContosoDemoTaxChangeLogDetails'),
+      'ContosoDemoTaxChangeLogDetails.AxMenuItemDisplay.xml': menuItemXml('ContosoDemoTaxChangeLogDetails'),
+    }, async dir => {
+      const { actualArtifacts } = buildActualArtifactsMap(dir, GOLDEN_NAMES, P, P, GOLDENS);
+      const res = await evaluateMulti({
+        caseSpec: { id: 'L3-enum-field-form-downgrade-guard', tier: 3 },
+        goldenArtifacts: GOLDENS, actualArtifacts, build: BUILD_OK,
+        goldenPrefix: P, actualPrefix: P,
+      });
+      expect({ missing: res.goldenDiff.missing, extra: res.goldenDiff.extra }).toEqual({ missing: [], extra: [] });
+      expect(res.score.golden_match).toBe(1);
+    });
+  });
+});
+
+describe('ANTI-MASKING: a pairing that cannot be decided is reported, never guessed', () => {
+  it('a genuinely absent artifact stays absent — the menu item is not lent to the form', async () => {
+    await withDir({
+      'ConDemoTaxChangeLogDetails.xml': menuItemXml('ConDemoTaxChangeLogDetails'),
+    }, async dir => {
+      const { actualArtifacts, matchedActualFiles, pairingProblems } =
+        buildActualArtifactsMap(dir, GOLDEN_NAMES, P, P, GOLDENS);
+      expect(actualArtifacts['ConDemoTaxChangeLogDetails.metadata.xml']).toBe('');
+      expect(matchedActualFiles.size).toBe(1);
+      expect(pairingProblems).toEqual([]);
+      const res = await evaluateMulti({
+        caseSpec: { id: 'L3-enum-field-form-downgrade-guard', tier: 3 },
+        goldenArtifacts: GOLDENS, actualArtifacts, build: BUILD_OK,
+        goldenPrefix: P, actualPrefix: P,
+      });
+      expect(res.score.golden_match).toBe(0);
+      expect(res.goldenDiff.missing.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('two indistinguishable candidates are REPORTED as ambiguous, not resolved by file order', () => {
+    // Same object name, same type, two files: nothing can separate them. The
+    // resolver must say so rather than take whichever `readdir` listed first.
+    withDir({
+      'ConDemoTaxChangeLogDetails.xml': menuItemXml('ConDemoTaxChangeLogDetails'),
+      'ContosoDemoTaxChangeLogDetails.xml': menuItemXml('ContosoDemoTaxChangeLogDetails'),
+    }, dir => {
+      const menuGolden = 'ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml';
+      const res = resolveActualFileDetailed(dir, menuGolden, P, P, GOLDENS[menuGolden]);
+      expect(res.file).toBeUndefined();
+      expect(res.ambiguous?.length).toBe(2);
+      const { actualArtifacts, pairingProblems } =
+        buildActualArtifactsMap(dir, [menuGolden], P, P, GOLDENS);
+      expect(pairingProblems.map(p => p.reason)).toEqual(['ambiguous']);
+      expect(actualArtifacts[menuGolden]).toBe(''); // scored missing, not guessed
+    });
+  });
+
+  it('two goldens are never paired with the same actual file', () => {
+    // If the second golden's best match is already spoken for, one of the two
+    // pairings is wrong AND the shared key would drop an artifact from the run.
+    withDir({
+      'ConDemoTaxChangeLogDetails.xml': formXml('ConDemoTaxChangeLogDetails'),
+      'ConDemoTaxChangeLogDetails.AxForm.xml': formXml('ConDemoTaxChangeLogDetails'),
+    }, dir => {
+      const { matchedActualFiles, pairingProblems } =
+        buildActualArtifactsMap(dir, GOLDEN_NAMES, P, P, GOLDENS);
+      // The menu-item golden has no menu item to pair with, whatever the names say.
+      expect(matchedActualFiles.size).toBeLessThanOrEqual(1);
+      expect(pairingProblems.every(p => p.reason === 'ambiguous' || p.reason === 'claimed-by-another-golden')).toBe(true);
+    });
+  });
+});
+
+describe('dot-notation extension filenames (corpus: L3-numberseq-module-slice, finding 3)', () => {
+  const enumExtXml = (name: string): string =>
+    `<?xml version="1.0" encoding="utf-8"?>
+<AxEnumExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>${name}</Name>
+  <EnumValues><AxEnumValue><Name>DemoSlice</Name><Label>@SYS334317</Label></AxEnumValue></EnumValues>
+</AxEnumExtension>`;
+
+  it('the extension SUFFIX is session-chosen, so it must not survive in the key', () => {
+    // Pre-fix: "NumberSeqModule.PFXDemoExtension" vs "NumberSeqModule" — the
+    // marker only stripped a bare `.<prefix>Extension`.
+    expect(artifactKey('NumberSeqModule.ConDemoExtension.metadata.xml', P))
+      .toBe(artifactKey('NumberSeqModule.ConExtension.metadata.xml', P));
+    // …and an extension is still never confused with its base object's own file.
+    expect(artifactKey('NumberSeqModule.ConExtension.metadata.xml', P))
+      .toBe(artifactKey('NumberSeqModule.metadata.xml', P));
+  });
+
+  it('a golden captured as `.ConDemoExtension` pairs with an actual `.ConExtension`', () => {
+    const goldenName = 'NumberSeqModule.ConDemoExtension.metadata.xml';
+    const goldenXml = enumExtXml('NumberSeqModule.ConDemoExtension');
+    withDir({ 'NumberSeqModule.ConExtension.xml': enumExtXml('NumberSeqModule.ConExtension') }, dir => {
+      const hit = resolveActualFile(dir, goldenName, P, P, goldenXml);
+      expect(hit && path.basename(hit)).toBe('NumberSeqModule.ConExtension.xml');
+    });
+  });
+
+  it('the hand-abbreviated committed golden stem `NumberSeqModuleExt` still finds its AOT file', () => {
+    // eval/goldens/L2-numberseq-basic/NumberSeqModuleExt.AxEnumExtension.metadata.xml
+    // declares <Name>NumberSeqModule.ConExtension</Name>. No filename rule maps
+    // "NumberSeqModuleExt" onto that — but the document says what it is.
+    const goldenName = 'NumberSeqModuleExt.AxEnumExtension.metadata.xml';
+    const goldenXml = enumExtXml('NumberSeqModule.ConExtension');
+    withDir({ 'NumberSeqModule.ConExtension.xml': goldenXml }, dir => {
+      const hit = resolveActualFile(dir, goldenName, P, P, goldenXml);
+      expect(hit && path.basename(hit)).toBe('NumberSeqModule.ConExtension.xml');
+    });
+  });
+
+  it('an extension is not paired with its BASE object of a different type', () => {
+    const goldenName = 'NumberSeqModuleExt.AxEnumExtension.metadata.xml';
+    const goldenXml = enumExtXml('NumberSeqModule.ConExtension');
+    withDir({
+      'NumberSeqModule.xml': '<?xml version="1.0"?>\n<AxEnum><Name>NumberSeqModule</Name></AxEnum>',
+    }, dir => {
+      expect(resolveActualFile(dir, goldenName, P, P, goldenXml)).toBeUndefined();
+    });
+  });
+});

--- a/tests/eval/oracleCli.test.ts
+++ b/tests/eval/oracleCli.test.ts
@@ -22,7 +22,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
-import { buildActualArtifactsMap } from '../../src/eval/oracle/actualArtifactResolution';
+import { buildActualArtifactsMap, listActualArtifactFiles } from '../../src/eval/oracle/actualArtifactResolution';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..', '..');
@@ -122,48 +122,137 @@ describe('buildActualArtifactsMap', () => {
  *   "src/eval/oracle/cli.ts:66 listGoldenArtifacts").
  * Class: TOOL_DEFECT (harness/oracle). The scorer must degrade gracefully — score `build`
  * and `bp_clean` normally and report golden_match: null (not 0, not a crash).
+ *
+ * SYNTHETIC BY CONSTRUCTION. These tests used to run against whichever case in
+ * eval/cases/ still carried `golden_pending: true`. That pinned the live catalog's
+ * CONTENTS, not the CLI's behaviour, and the premise expired the moment the last
+ * golden was captured (2026-08-31: 0 of 120 cases pending) — the suite then failed
+ * by design. The behaviour it protects has NOT expired: every newly authored case
+ * is golden_pending until its golden is captured on the VM (§6.4). So the case
+ * spec, the missing golden and the actual dir are all built here, in a temp dir,
+ * and handed to the CLI via `--case-spec`. The suite is now independent of the
+ * catalog in BOTH directions — zero pending cases and fifty pending cases behave
+ * identically — and it writes nothing into eval/.
  */
 describe('oracle CLI degrades gracefully when the golden is unavailable (golden_pending)', () => {
-  // Pick whichever case is still golden_pending rather than pinning one by name: goldens get
-  // captured on the VM one at a time (§6.4), so a hardcoded id turns every capture into a
-  // spurious test failure. The premise is "some case is pending", not "this case is pending".
-  const casesDir = path.join(REPO_ROOT, 'eval', 'cases');
-  const PENDING_CASE = fs
-    .readdirSync(casesDir)
-    .filter((f) => f.endsWith('.json') && f !== 'schema.json')
-    .sort()
-    .find((f) => JSON.parse(fs.readFileSync(path.join(casesDir, f), 'utf8')).golden_pending === true)
-    ?.replace(/\.json$/, '');
+  /** Deliberately un-catalogued: no eval/cases/ spec and no eval/goldens/ dir may exist for it. */
+  const SYNTHETIC_CASE_ID = 'L2-synthetic-oracle-cli-probe';
 
-  let emptyDir: string;
+  let tmp: string;
+  let actualDir: string;
+
+  /** Write a synthetic case spec (schema-shaped) to the temp dir and return its path. */
+  function writeCaseSpec(overrides: Record<string, unknown> = {}): string {
+    const spec = {
+      id: SYNTHETIC_CASE_ID,
+      title: 'Synthetic case spec for the oracle CLI golden-unavailable path',
+      tier: 2,
+      instruction: 'Not executed — this spec only drives the VM-free scorer.',
+      target_artifact_types: ['AxClass'],
+      golden_path: `eval/goldens/${SYNTHETIC_CASE_ID}`,
+      golden_pending: true,
+      ...overrides,
+    };
+    const file = path.join(tmp, 'case.json');
+    fs.writeFileSync(file, JSON.stringify(spec, null, 2), 'utf8');
+    return file;
+  }
 
   beforeEach(() => {
-    // Once every golden is captured this path can no longer be exercised against the real
-    // catalog. Fail loudly rather than silently passing on a premise that no longer holds.
-    expect(
-      PENDING_CASE,
-      'no case is golden_pending any more — rewrite this suite against a synthetic case spec',
-    ).toBeDefined();
-    emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-pending-'));
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-pending-'));
+    actualDir = path.join(tmp, 'actual');
+    fs.mkdirSync(actualDir);
+    // The synthetic id must stay un-catalogued, or these tests would silently start
+    // scoring a real golden instead of the golden-unavailable path.
+    expect(fs.existsSync(path.join(REPO_ROOT, 'eval', 'goldens', SYNTHETIC_CASE_ID))).toBe(false);
+    expect(fs.existsSync(path.join(REPO_ROOT, 'eval', 'cases', `${SYNTHETIC_CASE_ID}.json`))).toBe(false);
   });
 
   afterEach(() => {
-    fs.rmSync(emptyDir, { recursive: true, force: true });
+    fs.rmSync(tmp, { recursive: true, force: true });
   });
 
   it('reports golden_match: null and exits 0 (clean build) instead of throwing ENOENT scandir', () => {
-    const { status, out } = runOracleCli([PENDING_CASE, '--actual-dir', emptyDir]);
+    const { status, out } = runOracleCli([
+      SYNTHETIC_CASE_ID, '--case-spec', writeCaseSpec(), '--actual-dir', actualDir,
+    ]);
     expect(out).not.toMatch(/ENOENT/);
     expect(out).not.toMatch(/scandir/);
     expect(out).toMatch(/"golden_match":null/);
+    expect(out).toMatch(/golden_pending/);
     expect(status).toBe(0);
   }, 60_000);
 
   it('still scores build/bp_clean (golden_match: null) and exits 1 when the build failed', () => {
-    const { status, out } = runOracleCli([PENDING_CASE, '--actual-dir', emptyDir, '--build-failed']);
+    const { status, out } = runOracleCli([
+      SYNTHETIC_CASE_ID, '--case-spec', writeCaseSpec(), '--actual-dir', actualDir, '--build-failed',
+    ]);
     expect(out).not.toMatch(/ENOENT/);
     expect(out).toMatch(/"build":0/);
     expect(out).toMatch(/"golden_match":null/);
     expect(status).toBe(1);
   }, 60_000);
+
+  it('degrades the same way for a NON-pending case whose golden dir is simply absent', () => {
+    // The second half of the `goldenUnavailable` condition: the flag is not the only
+    // way to reach this branch, and a missing golden dir must not crash the scorer either.
+    const { status, out } = runOracleCli([
+      SYNTHETIC_CASE_ID, '--case-spec', writeCaseSpec({ golden_pending: false }),
+      '--actual-dir', actualDir,
+    ]);
+    expect(out).not.toMatch(/ENOENT/);
+    expect(out).toMatch(/"golden_match":null/);
+    expect(out).toMatch(/no \*\.metadata\.xml golden/);
+    expect(status).toBe(0);
+  }, 60_000);
+
+  /**
+   * ORACLE DEFECT (corpus: eval/corpus/runs/2026-08-31T22__L4-headerlines-document-slice__278eee3.json,
+   * root_cause_hypothesis -> "ORACLE DEFECT"): the golden-unavailable + `--actual-dir`
+   * branch listed `generated_artifacts` with its own `*.metadata.xml`-only filter,
+   * while an actual dir idiomatically holds the bare `<Name>.xml` files a VM session
+   * wrote (that is what `--actual-dir <Model>/<Model>/AxClass` points at, and what
+   * every other consumer of an actual dir already accepts). Every golden-CAPTURE run —
+   * i.e. exactly the runs that take this branch — therefore recorded an empty artifact
+   * list, and the operator had to reconstruct it by hand.
+   */
+  it('lists the bare AOT *.xml files a VM session writes as generated_artifacts, not just *.metadata.xml', () => {
+    fs.writeFileSync(path.join(actualDir, 'ConDemoProbe.xml'), '<AxClass><Name>ConDemoProbe</Name></AxClass>', 'utf8');
+    fs.writeFileSync(path.join(actualDir, 'ConDemoOther.metadata.xml'), '<AxClass><Name>ConDemoOther</Name></AxClass>', 'utf8');
+    fs.writeFileSync(path.join(actualDir, 'README.md'), 'not an artifact', 'utf8');
+
+    const { status, out } = runOracleCli([
+      SYNTHETIC_CASE_ID, '--case-spec', writeCaseSpec(), '--actual-dir', actualDir,
+    ]);
+    const line = out.split(/\r?\n/).find(l => l.startsWith('generated_artifacts'));
+    expect(line, `no generated_artifacts line in:\n${out}`).toBeDefined();
+    expect(line).toContain('ConDemoProbe.xml');       // the bare AOT name — the defect
+    expect(line).toContain('ConDemoOther.metadata.xml');
+    expect(line).not.toContain('README.md');
+    expect(line).toMatch(/\(2\)/);
+    expect(status).toBe(0);
+  }, 60_000);
+});
+
+/**
+ * The one filter both consumers of an actual dir share. It used to be duplicated —
+ * the resolver accepted `*.xml`, the CLI's capture path accepted only
+ * `*.metadata.xml` — which is how the empty-`generated_artifacts` defect above
+ * survived: two copies of "what counts as an artifact" that could drift apart.
+ */
+describe('listActualArtifactFiles', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-list-')); });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  it('accepts both the bare AOT and the committed-golden shape, sorted, and nothing else', () => {
+    for (const f of ['b.xml', 'a.metadata.xml', 'c.XML', 'notes.md', 'ConDemo.en-US.label.txt']) {
+      fs.writeFileSync(path.join(dir, f), 'x', 'utf8');
+    }
+    expect(listActualArtifactFiles(dir)).toEqual(['a.metadata.xml', 'b.xml', 'c.XML']);
+  });
+
+  it('returns [] for a directory that does not exist (never throws ENOENT)', () => {
+    expect(listActualArtifactFiles(path.join(dir, 'nope'))).toEqual([]);
+  });
 });

--- a/tests/eval/oracleDocCommentDirection.test.ts
+++ b/tests/eval/oracleDocCommentDirection.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The doc-comment presence signal is DIRECTIONAL, and the blank line the writer
+ * puts before a class body's closing brace is canonicalised away.
+ *
+ * Both are the same root cause seen twice: the WRITER changed after the goldens
+ * were captured.
+ *
+ *  - `ensureXppDocComment` injects a class-level `///` block unconditionally,
+ *    and commit 0a95198 (2026-08-09) extended that to the bridge create path —
+ *    five weeks after the affected goldens were captured (2026-07-07 /
+ *    2026-07-23). 34 of the 159 committed goldens carrying a class/interface
+ *    `<Declaration>` have no `///` block at all.
+ *  - `ensureBlankLineBeforeClosingBrace` adds a blank line between the last
+ *    member variable and `}`, and `reindentXppSource` preserves blank lines, so
+ *    that one survives canonicalisation too.
+ *
+ * Evidence: eval/corpus/runs/2026-08-31T23__L3-batch-basic__278eee3.json, whose
+ * `DemoBatchContract` Declaration differs from its golden in EXACTLY those two
+ * ways and nothing else.
+ *
+ * What this file pins is the DIRECTION, because that is the part a future
+ * "simplify this" change would quietly drop: a golden that HAS a doc comment
+ * and an actual that does not must still FAIL. See `valuesEquivalent` in
+ * src/eval/oracle/normalize.ts for the rationale and for the deliberate policy
+ * of NOT re-capturing the goldens in a batch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeAotXml, valuesEquivalent } from '../../src/eval/oracle/normalize';
+import { diffNormalized } from '../../src/eval/oracle/diff';
+
+/** Wrap an X++ class declaration in the AxClass shape the oracle reads. */
+const axClass = (declaration: string) => `<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConDemoBatchContract</Name>
+  <SourceCode>
+    <Declaration><![CDATA[${declaration}]]></Declaration>
+  </SourceCode>
+</AxClass>`;
+
+/** The golden as captured 2026-07: no doc comment, no blank line before `}`. */
+const GOLDEN_DECLARATION = `
+[DataContractAttribute]
+class ConDemoBatchContract
+{
+    int batchSize;
+    int priorityFactor;
+}
+`;
+
+/** What the writer produces today: doc comment injected, blank line added. */
+const ACTUAL_DECLARATION = `
+/// <summary>
+/// Data contract class that defines parameters for the demo batch operation.
+/// </summary>
+[DataContractAttribute]
+class ConDemoBatchContract
+{
+    int batchSize;
+    int priorityFactor;
+
+}
+`;
+
+const DECLARATION_PATH = 'AxClass/SourceCode/Declaration';
+
+async function diffDeclarations(golden: string, actual: string) {
+  const [g, a] = await Promise.all([
+    normalizeAotXml(axClass(golden)),
+    normalizeAotXml(axClass(actual)),
+  ]);
+  return diffNormalized(g, a);
+}
+
+describe('doc-comment presence is directional', () => {
+  it('an actual carrying a doc comment its golden lacks compares EQUAL', () => {
+    expect(valuesEquivalent('class Foo\n{\n}', '/// <xmldoc/>\nclass Foo\n{\n}')).toBe(true);
+  });
+
+  it('a golden carrying a doc comment the actual lacks still FAILS', () => {
+    // The regression direction. Documentation the corpus proved reachable that a
+    // run stopped producing is a real defect, and must never be softened away.
+    expect(valuesEquivalent('/// <xmldoc/>\nclass Foo\n{\n}', 'class Foo\n{\n}')).toBe(false);
+  });
+
+  it('is directional per METHOD too, not only at the top of a value', () => {
+    const withDoc = 'class Foo\n{\n/// <xmldoc/>\npublic void bar()\n{\n}\n}';
+    const withoutDoc = 'class Foo\n{\npublic void bar()\n{\n}\n}';
+    expect(valuesEquivalent(withoutDoc, withDoc)).toBe(true);
+    expect(valuesEquivalent(withDoc, withoutDoc)).toBe(false);
+  });
+
+  it('does not make two values differing in anything else equal', () => {
+    expect(valuesEquivalent('class Foo\n{\n}', '/// <xmldoc/>\nclass Bar\n{\n}')).toBe(false);
+    expect(
+      valuesEquivalent('class Foo\n{\n    int a;\n}', '/// <xmldoc/>\nclass Foo\n{\n    int b;\n}'),
+    ).toBe(false);
+    // An extra NON-doc line on the actual side is a real diff, not a doc comment.
+    expect(valuesEquivalent('class Foo\n{\n}', 'class Foo\n{\n    int a;\n}')).toBe(false);
+  });
+
+  it('survives the whole normalize→diff path, doc comment alone', async () => {
+    // The doc-comment half in isolation (no blank line involved), so reverting
+    // only the diff-layer rule fails a test.
+    const golden = 'class ConDemoBatchContract\n{\n}\n';
+    const actual = '/// <summary>\n/// Generated prose.\n/// </summary>\nclass ConDemoBatchContract\n{\n}\n';
+    expect((await diffDeclarations(golden, actual)).matched).toBe(true);
+    expect((await diffDeclarations(actual, golden)).matched).toBe(false);
+  });
+
+  it('still collapses doc-comment CONTENT (unchanged behaviour)', async () => {
+    const a = await normalizeAotXml(axClass('/// <summary>\n/// One wording.\n/// </summary>\nclass ConDemoBatchContract\n{\n}\n'));
+    const b = await normalizeAotXml(axClass('/// <summary>\n/// A completely different wording.\n/// </summary>\nclass ConDemoBatchContract\n{\n}\n'));
+    expect(diffNormalized(a, b).matched).toBe(true);
+  });
+});
+
+describe('blank line before a closing brace is canonicalised away', () => {
+  it('the writer-added blank line before `}` does not register as a diff', async () => {
+    const noBlank = 'class ConDemoBatchContract\n{\n    int batchSize;\n}\n';
+    const withBlank = 'class ConDemoBatchContract\n{\n    int batchSize;\n\n}\n';
+    const [g, a] = await Promise.all([
+      normalizeAotXml(axClass(noBlank)),
+      normalizeAotXml(axClass(withBlank)),
+    ]);
+    expect(diffNormalized(g, a).matched).toBe(true);
+    // Symmetric — nothing scores blank lines, so neither direction hides a defect.
+    expect(diffNormalized(a, g).matched).toBe(true);
+  });
+
+  it('keeps a blank line that separates statements inside a body', async () => {
+    // Narrow by design: only a blank run immediately before `}` is dropped, so a
+    // golden that asserts paragraph structure inside a body still asserts it.
+    const withGap = 'class Foo\n{\n    int a;\n\n    int b;\n}\n';
+    const withoutGap = 'class Foo\n{\n    int a;\n    int b;\n}\n';
+    const [g, a] = await Promise.all([
+      normalizeAotXml(axClass(withGap)),
+      normalizeAotXml(axClass(withoutGap)),
+    ]);
+    expect(diffNormalized(g, a).matched).toBe(false);
+  });
+});
+
+describe('L3-batch-basic DemoBatchContract Declaration (corpus repro)', () => {
+  it('matched=false on main, matched=true with both rules', async () => {
+    const diff = await diffDeclarations(GOLDEN_DECLARATION, ACTUAL_DECLARATION);
+    expect(diff.matched).toBe(true);
+    expect(diff.changed).toEqual([]);
+  });
+
+  it('a genuine token change in the same Declaration still fails', async () => {
+    const broken = ACTUAL_DECLARATION.replace('int priorityFactor;', 'str priorityFactor;');
+    const diff = await diffDeclarations(GOLDEN_DECLARATION, broken);
+    expect(diff.matched).toBe(false);
+    expect(diff.changed.map(c => c.path)).toEqual([DECLARATION_PATH]);
+  });
+
+  it('dropping a doc comment the golden HAS still fails', async () => {
+    // Same case, mirrored: give the golden the doc comment and take it off the
+    // actual. The oracle must not call that a match.
+    const diff = await diffDeclarations(ACTUAL_DECLARATION, GOLDEN_DECLARATION);
+    expect(diff.matched).toBe(false);
+    expect(diff.changed.map(c => c.path)).toEqual([DECLARATION_PATH]);
+  });
+});

--- a/tests/eval/oraclePrefixExtensionInfix.test.ts
+++ b/tests/eval/oraclePrefixExtensionInfix.test.ts
@@ -1,0 +1,202 @@
+/**
+ * EXTENSION_PREFIX canonicalisation for the MS extension-class convention
+ * `{Base}{Prefix}_Extension`, where the prefix is an INFIX — mid-identifier and
+ * followed by an underscore, not by the PascalCase continuation of an object
+ * name.
+ *
+ * Corpus evidence:
+ *   eval/corpus/runs/2026-08-31T23__L2-coc-extension__278eee3.json
+ *     — build 0 errors / 0 BP warnings and the committed runtime oracle
+ *       (EvalL2CocCarFactsTest) passed 2/2, i.e. the CoC wrapper is
+ *       runtime-verified correct, yet golden_match scored 0 with the ONLY
+ *       differences being `AxClass/Name` and the class-name line inside
+ *       `AxClass/SourceCode/Declaration`:
+ *         expected FMVehicleDataContractCon_Extension
+ *         actual   FMVehicleDataContractConDemo_Extension
+ *   eval/corpus/runs/2026-07-07T04__L2-coc-extension__cb1b73d.json
+ *     — the SAME gap, reported eight weeks earlier. Its proposed fix ("change
+ *       `(?=[A-Z])` to `(?=[A-Z_])`") is insufficient and is pinned as such
+ *       below: the leading identifier-start boundary, not the lookahead, is what
+ *       blocks the substitution.
+ *
+ * `canonicalizePrefix` is deliberately LOSSY — it exists so an artifact captured
+ * under one prefix session compares equal to the same artifact produced under
+ * another. Loosening it too far is a WORSE defect than the one fixed here,
+ * because two genuinely different objects would compare equal and a real diff
+ * would silently pass. The `anti-greedy` block therefore pins the boundary that
+ * must NOT move; treat a failure there as a scoring-integrity regression.
+ *
+ * Every test in this file is VM-free.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  canonicalizePrefix, artifactKey, evaluate, normalizeAotXml, diffNormalized,
+  GOLDEN_CAPTURE_PREFIXES,
+} from '../../src/eval/oracle/index';
+import { resolveActualFile } from '../../src/eval/oracle/actualArtifactResolution';
+
+/** The default golden-side prefix set (src/eval/oracle/normalize.ts). */
+const P = GOLDEN_CAPTURE_PREFIXES;
+/** The prefix the VM session that produced the run record was configured with. */
+const SESSION = 'ConDemo';
+
+/** The CoC extension class of eval/goldens/L2-coc-extension, under one prefix token. */
+const cocExtensionXml = (name: string): string =>
+  `<?xml version="1.0" encoding="utf-8"?>
+<AxClass xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>${name}</Name>
+  <SourceCode>
+    <Declaration><![CDATA[
+[ExtensionOf(classStr(FMVehicleDataContract))]
+final class ${name}
+{
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>CarFactsSummary</Name>
+        <Source><![CDATA[
+    public str CarFactsSummary()
+    {
+        return next CarFactsSummary() + ' [verified]';
+    }
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>`;
+
+describe('EXTENSION_PREFIX as an extension-class INFIX (regression: 2026-08-31T23__L2-coc-extension__278eee3)', () => {
+  it('canonicalises `{Base}{Prefix}_Extension` on both sides of the run that failed', () => {
+    const golden = canonicalizePrefix('FMVehicleDataContractCon_Extension', P);
+    const actual = canonicalizePrefix('FMVehicleDataContractConDemo_Extension', SESSION);
+    expect(golden).toBe('FMVehicleDataContractPFX_Extension');
+    expect(actual).toBe(golden);
+  });
+
+  it('canonicalises the ORIGINAL capture prefix too (`Asl`, git 828bcea, before the mechanical Asl→Con rename in 39c747c)', () => {
+    expect(canonicalizePrefix('FMVehicleDataContractAsl_Extension', 'Asl'))
+      .toBe(canonicalizePrefix('FMVehicleDataContractCon_Extension', P));
+    expect(canonicalizePrefix('FMVehicleDataContractAsl_Extension', 'Asl'))
+      .toBe(canonicalizePrefix('FMVehicleDataContractConDemo_Extension', SESSION));
+  });
+
+  it('canonicalises the class name inside the X++ Declaration text, not just the `<Name>` element', () => {
+    const decl = (n: string): string =>
+      `[ExtensionOf(classStr(FMVehicleDataContract))]\nfinal class ${n}\n{\n}`;
+    expect(canonicalizePrefix(decl('FMVehicleDataContractCon_Extension'), P))
+      .toBe(canonicalizePrefix(decl('FMVehicleDataContractConDemo_Extension'), SESSION));
+  });
+
+  it('a bare `{Prefix}_Extension` (no base) canonicalises as well', () => {
+    expect(canonicalizePrefix('Con_Extension', P)).toBe('PFX_Extension');
+    expect(canonicalizePrefix('ConDemo_Extension', SESSION)).toBe('PFX_Extension');
+  });
+
+  it('the fix proposed 8 weeks ago — widening the lookahead to [A-Z_] — would NOT have closed this', () => {
+    // Documented as a MEASUREMENT, not as behaviour under test: with the leading
+    // identifier-start boundary in place, no lookahead widening can match a
+    // prefix that is preceded by an alphanumeric character.
+    const withLookaheadOnly = 'FMVehicleDataContractCon_Extension'
+      .replace(/(^|[^A-Za-z0-9])Con(?=[A-Z_])/g, '$1PFX');
+    expect(withLookaheadOnly).toBe('FMVehicleDataContractCon_Extension');
+  });
+
+  it('normalizeAotXml + evaluate: the two prefix sessions diff clean', async () => {
+    const goldenXml = cocExtensionXml('FMVehicleDataContractCon_Extension');
+    const actualXml = cocExtensionXml('FMVehicleDataContractConDemo_Extension');
+
+    const g = await normalizeAotXml(goldenXml, [], P);
+    const a = await normalizeAotXml(actualXml, [], SESSION);
+    expect(g.get('AxClass/Name')).toBe(a.get('AxClass/Name'));
+    expect(diffNormalized(g, a).matched).toBe(true);
+
+    const res = await evaluate({
+      caseSpec: { id: 'L2-coc-extension', tier: 2 },
+      goldenXml, actualXml,
+      goldenPrefix: P, actualPrefix: SESSION,
+      build: { succeeded: true, bpWarnings: [] },
+      systest: { ran: true, passed: true, failures: [] },
+    });
+    expect(res.goldenDiff.changed).toEqual([]);
+    expect(res.goldenDiff.matched).toBe(true);
+    expect(res.score.golden_match).toBe(1);
+  });
+
+  it('pairs the golden with the actual file the session wrote (`artifactKey` / `resolveActualFile`)', () => {
+    expect(artifactKey('FMVehicleDataContractCon_Extension.metadata.xml', P))
+      .toBe(artifactKey('FMVehicleDataContractConDemo_Extension.metadata.xml', SESSION));
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-infix-'));
+    try {
+      const actualName = 'FMVehicleDataContractConDemo_Extension.xml';
+      fs.writeFileSync(
+        path.join(dir, actualName),
+        cocExtensionXml('FMVehicleDataContractConDemo_Extension'),
+      );
+      const hit = resolveActualFile(
+        dir, 'FMVehicleDataContractCon_Extension.metadata.xml', P, SESSION,
+        cocExtensionXml('FMVehicleDataContractCon_Extension'),
+      );
+      expect(hit && path.basename(hit)).toBe(actualName);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('anti-greedy: canonicalizePrefix must not collapse two DIFFERENT objects (scoring integrity)', () => {
+  it('leaves a mid-identifier prefix token alone when it is a normal PascalCase word', () => {
+    // The leading identifier-start boundary of the general branch must NOT move.
+    // If it did, `SalesConNote` would canonicalise to `SalesPFXNote` and a real
+    // diff against an unrelated object would silently pass.
+    expect(canonicalizePrefix('SalesConNote', P)).toBe('SalesConNote');
+    expect(canonicalizePrefix('CustContosoThing', 'Contoso')).toBe('CustContosoThing');
+    expect(canonicalizePrefix('FMVehicleDataContractConDemo', SESSION))
+      .toBe('FMVehicleDataContractConDemo');
+  });
+
+  it('does not swallow the PascalCase run before `_Extension` (a longer name is a DIFFERENT object)', () => {
+    // `Con` here is the head of the word "Config", not the prefix: the infix
+    // branch requires the token to be IMMEDIATELY followed by `_Extension`.
+    expect(canonicalizePrefix('FMVehicleDataContractConfig_Extension', P))
+      .toBe('FMVehicleDataContractConfig_Extension');
+    expect(canonicalizePrefix('FMVehicleDataContractConfig_Extension', P))
+      .not.toBe(canonicalizePrefix('FMVehicleDataContractCon_Extension', P));
+  });
+
+  it('leaves an UNPREFIXED extension class alone (base merely contains the token)', () => {
+    expect(canonicalizePrefix('FMVehicleDataContract_Extension', P))
+      .toBe('FMVehicleDataContract_Extension');
+    expect(canonicalizePrefix('ReconciliationJournal_Extension', P))
+      .toBe('ReconciliationJournal_Extension');
+  });
+
+  it('requires `_Extension` to END the identifier', () => {
+    expect(canonicalizePrefix('FMVehicleDataContractCon_ExtensionHelper', P))
+      .toBe('FMVehicleDataContractCon_ExtensionHelper');
+    expect(canonicalizePrefix('FMVehicleDataContractCon_Extension2', P))
+      .toBe('FMVehicleDataContractCon_Extension2');
+  });
+
+  it('two different extension classes under the SAME prefix stay different', () => {
+    const a = canonicalizePrefix('FMVehicleDataContractCon_Extension', P);
+    const b = canonicalizePrefix('FMVehicleServiceCon_Extension', P);
+    expect(a).not.toBe(b);
+  });
+
+  it('normalizeAotXml still REPORTS a real name difference between two extension classes', async () => {
+    const g = await normalizeAotXml(cocExtensionXml('FMVehicleDataContractCon_Extension'), [], P);
+    const a = await normalizeAotXml(cocExtensionXml('FMVehicleServiceConDemo_Extension'), [], SESSION);
+    expect(diffNormalized(g, a).matched).toBe(false);
+  });
+
+  it('free-form text keeps its incidental prefix occurrences', () => {
+    expect(canonicalizePrefix('Contoso at the wheel', 'Contoso')).toBe('Contoso at the wheel');
+    expect(canonicalizePrefix('Con is not a prefix here', P)).toBe('Con is not a prefix here');
+  });
+});

--- a/tests/eval/oracleScoringIntegrity.test.ts
+++ b/tests/eval/oracleScoringIntegrity.test.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import {
   evaluate, evaluateMulti, scoreRun, canonicalizePrefix, normalizeAotXml,
   artifactKey, artifactKeyMap, GOLDEN_CAPTURE_PREFIXES,
+  aotRootElement, declaredObjectNameOf,
 } from '../../src/eval/oracle/index';
 import { resolveActualFile, buildActualArtifactsMap } from '../../src/eval/oracle/actualArtifactResolution';
 import { buildReport, bpState, renderReport, type RunForReport } from '../../src/eval/improver/report';
@@ -366,9 +367,11 @@ describe('committed goldens under the tolerant default prefixes', () => {
    * So the invariant is the one that matters: simulate the capture directory
    * from the goldens' own contents and require a bijection.
    */
-  const declaredName = (xml: string): string | undefined => /<Name>([^<]+)<\/Name>/.exec(xml)?.[1]?.trim();
-  const rootElement = (xml: string): string | undefined =>
-    /<\s*([A-Za-z_][\w.\-]*)[\s>/]/.exec(xml.replace(/<\?[\s\S]*?\?>/g, '').replace(/<!--[\s\S]*?-->/g, ''))?.[1];
+  // Use the shipped readers rather than re-deriving them here: a duplicate
+  // regex drifts from the code under test, and the comment-stripping version
+  // this used to carry was the same fragile single-pass strip CodeQL flags.
+  const declaredName = declaredObjectNameOf;
+  const rootElement = aotRootElement;
 
   /**
    * The flat `--actual-dir` a capture produces: every AOT file is named after the

--- a/tests/eval/oracleScoringIntegrity.test.ts
+++ b/tests/eval/oracleScoringIntegrity.test.ts
@@ -354,14 +354,120 @@ describe('committed goldens under the tolerant default prefixes', () => {
     }
   });
 
-  it('no golden DIR contains two artifacts whose logical keys collide', () => {
-    const dirs = fs.existsSync(GOLDENS) ? fs.readdirSync(GOLDENS) : [];
-    for (const d of dirs) {
-      const dir = path.join(GOLDENS, d);
-      if (!fs.statSync(dir).isDirectory()) continue;
-      const names = fs.readdirSync(dir).filter(f => f.endsWith('.metadata.xml'));
-      const keys = new Set(names.map(n => artifactKey(n, GOLDEN_CAPTURE_PREFIXES)));
-      expect(keys.size, `${d}: ${names.join(', ')}`).toBe(names.length);
+  /**
+   * This used to assert "no golden DIR contains two artifacts whose logical keys
+   * collide", which banned a legitimate D365FO shape: a display menu item named
+   * after the form it opens (a table's `FormRef` takes a MENU ITEM name, so the
+   * pairing is forced — L3-enum-field-form-downgrade-guard). `artifactKey` is
+   * DELIBERATELY lossy (it strips the `.Ax<Type>` infix so legacy golden names
+   * pair at all), so colliding keys are expected; what must never happen is a
+   * golden that cannot be pinned to its OWN actual file.
+   *
+   * So the invariant is the one that matters: simulate the capture directory
+   * from the goldens' own contents and require a bijection.
+   */
+  const declaredName = (xml: string): string | undefined => /<Name>([^<]+)<\/Name>/.exec(xml)?.[1]?.trim();
+  const rootElement = (xml: string): string | undefined =>
+    /<\s*([A-Za-z_][\w.\-]*)[\s>/]/.exec(xml.replace(/<\?[\s\S]*?\?>/g, '').replace(/<!--[\s\S]*?-->/g, ''))?.[1];
+
+  /**
+   * The flat `--actual-dir` a capture produces: every AOT file is named after the
+   * object it holds (`<Name>.xml`). Two objects sharing one name cannot both have
+   * it, so all but one carry a type marker — and WHICH one gets the undecorated
+   * name is the operator's choice, not a contract, so `rotate` tries the other
+   * assignment as well (only where the types actually differ; artifacts that
+   * share a name AND a type can be told apart by nothing but their filename).
+   */
+  function simulateCaptureDir(dir: string, names: string[], rotate: boolean): Map<string, string> {
+    const contents = new Map(names.map(n => [n, fs.readFileSync(path.join(dir, n), 'utf8')]));
+    const groups = new Map<string, string[]>();
+    for (const n of names) {
+      const key = declaredName(contents.get(n)!) ?? n;
+      groups.set(key, [...(groups.get(key) ?? []), n]);
     }
+    const out = new Map<string, string>();
+    const taken = new Set<string>();
+    const claim = (name: string): string => {
+      expect(taken.has(name), `simulated capture dir would need two files called ${name}`).toBe(false);
+      taken.add(name);
+      return name;
+    };
+    for (const [objectName, members] of groups) {
+      const types = members.map(m => rootElement(contents.get(m)!));
+      const typed = types.every(t => !!t) && new Set(types).size === members.length;
+      // The member the capture would name plainly: the one whose golden stem IS
+      // the object name, else the first.
+      const ordered = [...members].sort((a, b) =>
+        Number(b.replace(/\.metadata\.xml$/i, '') === objectName) -
+        Number(a.replace(/\.metadata\.xml$/i, '') === objectName));
+      const bare = rotate && typed ? ordered[ordered.length - 1] : ordered[0];
+      for (const m of members) {
+        if (m === bare) { out.set(m, claim(`${objectName}.xml`)); continue; }
+        const type = rootElement(contents.get(m)!);
+        out.set(m, claim(typed && type
+          ? `${objectName}.${type}.xml`
+          : `${m.replace(/\.metadata\.xml$/i, '')}.xml`));
+      }
+    }
+    return out;
+  }
+
+  const goldenDirs = (fs.existsSync(GOLDENS) ? fs.readdirSync(GOLDENS) : [])
+    .filter(d => fs.statSync(path.join(GOLDENS, d)).isDirectory())
+    .map(d => ({ id: d, dir: path.join(GOLDENS, d) }))
+    .map(g => ({ ...g, names: fs.readdirSync(g.dir).filter(f => f.endsWith('.metadata.xml')) }))
+    .filter(g => g.names.length > 0);
+
+  it.each([false, true])(
+    'every golden artifact resolves to its OWN actual file (rotated capture names: %s)',
+    rotate => {
+      expect(goldenDirs.length).toBeGreaterThan(50); // a silent empty scan would pass forever
+      const failures: string[] = [];
+      for (const { id, dir, names } of goldenDirs) {
+        const goldenContents: Record<string, string> = Object.fromEntries(
+          names.map(n => [n, fs.readFileSync(path.join(dir, n), 'utf8')]),
+        );
+        const simulated = simulateCaptureDir(dir, names, rotate);
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'golden-capture-'));
+        try {
+          for (const [golden, actualName] of simulated) {
+            fs.writeFileSync(path.join(tmp, actualName), goldenContents[golden]);
+          }
+          for (const golden of names) {
+            const hit = resolveActualFile(tmp, golden, GOLDEN_CAPTURE_PREFIXES, GOLDEN_CAPTURE_PREFIXES, goldenContents[golden]);
+            const got = hit ? path.basename(hit) : '(unresolved)';
+            if (got !== simulated.get(golden)) {
+              failures.push(`${id}: ${golden} → ${got}, expected ${simulated.get(golden)}`);
+            }
+          }
+          const { matchedActualFiles, pairingProblems } = buildActualArtifactsMap(
+            tmp, names, GOLDEN_CAPTURE_PREFIXES, GOLDEN_CAPTURE_PREFIXES, goldenContents);
+          if (pairingProblems.length > 0) {
+            failures.push(`${id}: ${pairingProblems.map(p => `${p.golden} ${p.reason}`).join('; ')}`);
+          }
+          if (matchedActualFiles.size !== names.length) {
+            failures.push(`${id}: ${matchedActualFiles.size} of ${names.length} artifacts paired`);
+          }
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
+      }
+      expect(failures, failures.join('\n')).toEqual([]);
+    });
+
+  it('two artifacts CAN share a logical key — the type is what keeps them apart', () => {
+    // The shape the old assertion banned: a form and the display menu item a
+    // table's FormRef requires. Both are needed and both are named alike.
+    const dir = path.join(GOLDENS, 'L3-enum-field-form-downgrade-guard');
+    const names = fs.existsSync(dir) ? fs.readdirSync(dir).filter(f => f.endsWith('.metadata.xml')) : [];
+    const collide = names.filter(n => artifactKey(n, GOLDEN_CAPTURE_PREFIXES)
+      === artifactKey('ConDemoTaxChangeLogDetails.metadata.xml', GOLDEN_CAPTURE_PREFIXES));
+    expect(collide.sort()).toEqual([
+      'ConDemoTaxChangeLogDetails.AxMenuItemDisplay.metadata.xml',
+      'ConDemoTaxChangeLogDetails.metadata.xml',
+    ]);
+    // …and their AOT types differ, which is what the resolver pairs on.
+    const types = collide.map(n => rootElement(fs.readFileSync(path.join(dir, n), 'utf8')));
+    expect(new Set(types).size).toBe(collide.length);
   });
 });

--- a/tests/eval/systestCase.test.ts
+++ b/tests/eval/systestCase.test.ts
@@ -4,13 +4,28 @@
  * Locks in each committed SysTest class and its wiring to the case spec, so a
  * malformed test class or a broken systest path is caught in CI without the
  * D365FO platform. Goldens for all three cases below were captured on the VM
- * — see eval/goldens/<case_id>/. Live SysTest runs are still pending
- * (`systest_pending: true`) for all three: SysTestConsole.exe unconditionally
- * waits on a debugger-attach keypress (Console.ReadKey) even in local-AOS mode,
- * which fails in this non-interactive automation session regardless of the
- * run_systest_class binary/args fix (src/tools/sysTestRunner.ts). This only
- * validates the static contract and that parseSysTestResult scores each class's
- * output; the live run needs an interactive console session.
+ * — see eval/goldens/<case_id>/.
+ *
+ * L2-coc-extension's live run has now EXECUTED on the VM
+ * (`systest_pending: false`): SysTestConsole.exe reported
+ * "Rainier Test Suite : 2 Run, 0 Failed", both methods success=true, proving the
+ * CoC wrapper really calls `next` and appends ' [verified]' at the call site
+ * (corpus: eval/corpus/runs/2026-08-31T23__L2-coc-extension__278eee3.json).
+ * L2-event-handler-basic's live run has now EXECUTED on the VM too
+ * (`systest_pending: false`): SysTestConsole.exe reported
+ * "Rainier Test Suite : 2 Run, 0 Failed", both methods success=true, proving the
+ * [DataEventHandler] on Inserting really applies the '(no subject)' default to a
+ * blank Subject and leaves an explicit one untouched
+ * (corpus: eval/corpus/runs/2026-08-31T23__L2-event-handler-basic__278eee3.json).
+ * L3-batch-basic's live run has now EXECUTED on the VM as well
+ * (`systest_pending: false`): SysTestConsole.exe reported
+ * "Rainier Test Suite : 2 Run, 0 Failed", both methods success=true, proving
+ * that calculateEffectiveBatchSize really multiplies (10*3=30 and 7*5=35) —
+ * arithmetic no golden diff can reach
+ * (corpus: eval/corpus/runs/2026-08-31T23__L3-batch-basic__278eee3.json).
+ * These gates still only validate the STATIC contract plus that
+ * parseSysTestResult scores the class's output — the live run itself is a VM
+ * step, not a CI one.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -40,11 +55,12 @@ describe('L2-coc-extension SysTest asset', () => {
     expect(fs.existsSync(path.join(REPO_ROOT, caseSpec.systest))).toBe(true);
   });
 
-  it('has a committed golden and a pending live SysTest run, in the holdout split', () => {
+  it('has a committed golden and an EXECUTED live SysTest run, in the holdout split', () => {
     expect(caseSpec.golden_pending).toBeFalsy();
     const goldenDir = path.join(REPO_ROOT, 'eval', 'goldens', CASE_ID);
     expect(fs.existsSync(goldenDir) && fs.readdirSync(goldenDir).some(f => f.endsWith('.metadata.xml'))).toBe(true);
-    expect(caseSpec.systest_pending).toBe(true);
+    // Flipped true -> false once the runtime oracle actually ran on the VM.
+    expect(caseSpec.systest_pending).toBe(false);
     expect(caseSpec.split).toBe('holdout');
   });
 
@@ -99,12 +115,12 @@ describe('L3-batch-basic SysTest asset', () => {
     expect(fs.existsSync(path.join(REPO_ROOT, caseSpec3.systest))).toBe(true);
   });
 
-  it('has all 4 committed golden artifacts and a pending live SysTest run, in the holdout split', () => {
+  it('has all 4 committed golden artifacts and an EXECUTED live SysTest run, in the holdout split', () => {
     expect(caseSpec3.golden_pending).toBeFalsy();
     const goldenDir = path.join(REPO_ROOT, 'eval', 'goldens', CASE_ID);
     const goldenFiles = fs.existsSync(goldenDir) ? fs.readdirSync(goldenDir).filter(f => f.endsWith('.metadata.xml')) : [];
     expect(goldenFiles.length).toBe(4);
-    expect(caseSpec3.systest_pending).toBe(true);
+    expect(caseSpec3.systest_pending).toBe(false);
     expect(caseSpec3.split).toBe('holdout');
   });
 
@@ -159,11 +175,12 @@ describe('L2-event-handler-basic SysTest asset', () => {
     expect(fs.existsSync(path.join(REPO_ROOT, caseSpec4.systest))).toBe(true);
   });
 
-  it('has a committed golden and a pending live SysTest run, in the holdout split', () => {
+  it('has a committed golden and an EXECUTED live SysTest run, in the holdout split', () => {
     expect(caseSpec4.golden_pending).toBeFalsy();
     const goldenDir = path.join(REPO_ROOT, 'eval', 'goldens', CASE_ID);
     expect(fs.existsSync(goldenDir) && fs.readdirSync(goldenDir).some(f => f.endsWith('.metadata.xml'))).toBe(true);
-    expect(caseSpec4.systest_pending).toBe(true);
+    // Flipped true -> false once the runtime oracle actually ran on the VM.
+    expect(caseSpec4.systest_pending).toBe(false);
     expect(caseSpec4.split).toBe('holdout');
   });
 


### PR DESCRIPTION
Clears the eval catalog's remaining backlog. **0 of 120 cases are `golden_pending` and 0 are `systest_pending`** — both for the first time. Twelve serial VM runs against the `fm-mcp` sandbox, each rolled back to the committed baseline, plus the repo-side fixes the runs earned.

## What the runtime oracle found that a green suite could not

Every defect below **built with 0 errors, was xppbp-clean, and read back as plausible metadata**. A 5,774-test suite and a golden diff pass all of them.

| | Defect |
|---|---|
| 1 | **`create(enum)` drops explicit `<Value>` elements** when the numbering is plain sequential — deliberately, per its op-spec: *"plain 0,1,2 numbering states nothing the order does not."* The premise is false. An `<AxEnumValue>` with no `<Value>` is **0**, not the next ordinal, so a four-tier ladder collapsed to all-zero and `enum2int()` returned 0 for every member. Found only because a SysTest probe printed the runtime values. Shipped `CustVendDisputeStatus.xml` carries `UseEnumValue=No` **and** an explicit `<Value>` per member **and** `IsExtensible=true`, contradicting the rule twice over. |
| 2 | **Any table property written by the server's XML-writer fallback is silently destroyed by the next bridge-backed `modify` on the same object.** Reproduced twice — `CacheLookup`, then `DeleteAction=Cascade`, the latter proven present by a backup taken *between* the two calls. `✅ Verified: on disk` only checks that the file exists, never that the value survived. |
| 3 | **`create(class, xmlContent=…)` writes three identities into one file** — the prefix reaches the filename and the X++ declaration but not `<Name>`. Reports success; the next build dies with a naming-consistency fatal error. Reproduced in all three SysTest runs. |

`L3-enum-field-form-downgrade-guard` is the clearest illustration: its **first SysTest run genuinely failed**, which is how defect 1 was found at all.

## One case FAILS on purpose, and its golden enshrines the corruption

`L4-headerlines-document-slice` **cannot be produced correctly through the grounded path today**. `add-delete-action` is idempotent on the delete-action *name*, so re-running it reports *"already present — skipped"* without restoring the value, and restoring it needs the delete-and-re-add the case forbids. The run stayed forward-only and left both bad writes in place rather than repairing its way to green.

> **Reviewers: the committed `ConDemoRentHeader.metadata.xml` is missing `<DeleteAction>Cascade</DeleteAction>` on purpose.** It is evidence, not a bad capture. The fix PR must update that golden in the same change; the line `+<DeleteAction>Cascade</DeleteAction>` is how we will know the defect is gone.

## Two known defects did NOT reproduce — each checked with a negative control

- **Data-entity create** no longer drops `primaryTable`/`fields`: the empty skeleton is now *refused outright*, and SyncEngine built a real `CREATE VIEW` from the metadata.
- **Multi-line attribute blocks** survive `create(class)` verbatim: 12 sent, 12 on disk, identical in content and order.

## Oracle defects that were corrupting scores corpus-wide

Both measured across the committed corpus, not argued from one case.

**Artifact pairing** matched on a lossy key with `Array.prototype.find` — first match wins. Sweeping the new invariant over all 119 golden dirs against pre-fix code: **10 artifacts mispair** under canonical naming, **18** under the other assignment of the undecorated filename, 8 of them outright cross-pairings — two unrelated objects diffed against each other, or both goldens resolving to the same file with one artifact silently vanishing. Pairing now resolves by declared identity + AOT type, and an undecidable pairing is **reported, never guessed**.

**Prefix canonicalisation** could not see a prefix used as an *infix* — the Microsoft `{Base}{Prefix}_Extension` convention — silently costing **7 golden dirs**. Notably, the fix proposed for this exact case eight weeks ago (`(?=[A-Z])` → `(?=[A-Z_])`) was measured here and **does not work**: the leading boundary is the blocker, not the lookahead. Anti-greedy behaviour is pinned by a collision sweep over 7,095 corpus identifiers — 1 colliding form before, 1 after, zero new.

**`generated_artifacts` was always `[]`** in the golden-pending branch: it kept a private `*.metadata.xml` filter while a capture points `--actual-dir` at an AOT folder holding bare `.xml`. A silent zero the operator had to reconstruct by hand.

## The one judgement call, flagged for review

Commit `0a95198` (2026-08-09) started injecting class-level `///` blocks five weeks *after* the 2026-07 goldens were captured — the writer changed under the goldens, so **34 of 159** goldens with a `<Declaration>` can never be matched by a faithful rerun.

Chosen: make the presence signal **directional** — a doc comment present only on the *actual* side compares equal (`BPXmlDocNoDocumentationComments` fires on *absence*, so the actual is strictly BP-better, and `bp_clean` scores it separately), while one present in the *golden* and missing from the actual **still fails**. Goldens are re-captured **opportunistically**, each case refreshing its own the next time it runs, so strictness returns case by case. Deliberately not a batch re-capture and not a blanket relaxation; the policy is recorded in the function's own doc comment, where anyone "cleaning this up" will land.

**Two agents disagreed here** — re-capture only, versus the directional rule — and the split is preserved in the commit message rather than smoothed over. Replayed over the corpus, the rule resolves 14 real false-mismatches across 69 stored `changed` entries and suppresses nothing else.

## Verification

| Check | Result |
|---|---|
| `npx vitest run` | 386 files, **5,774 passed**, 2 skipped |
| `npx tsc --noEmit` | clean |
| `npm run lint` | 774 files, clean |
| `npm run eval:coverage -- --check` | clean — core 65/65, total **109/109 (100%)**, closure queue 0 |

`npm run format:check` reports pre-existing repo-wide failures; it is not a CI gate and is untouched here.

## Known follow-ups, not in this PR

- The three write-path defects above (`src/tools/**`) — this PR records them, it does not fix them.
- `modify-field` cannot set `allowEdit` though the bridge supports it, so a singleton parameters table cannot get `AllowEdit=No` on its `Key` field by any grounded path.
- `modify-property` accepts a **form** name for a table's `FormRef`, which takes a **menu item**, unvalidated — the next build dies on it.
- `validate_code(mode="references")` on an `AxTableExtension` resolves only the EDT; a non-existent base table or base field group passes as "verified".
- Multi-line attribute blocks are content-correct but **mis-indented** by `src/utils/xppFormat.ts`.
- **No committed capture script**: every golden README claims a build-gated capture that lives in no repo file; each implementer re-implements ~50 lines from memory. `scripts/capture-golden.ts` is the fix.
- `src/server/serverMode.ts` still repeats the disproved interactive-console claim.
- An inert orphan SQL table `CONDEMOTAXCHANGELOG` remains on the VM from a partial `dbSync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PicZ8GL8PYLZX8xCToUJjb
