### PR TITLE
fix(build): bundle buildIndexWorker beside the scripts that load it

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "build": "tsc && npm run build:scripts",
-    "build:scripts": "esbuild scripts/extract-metadata.ts scripts/build-database.ts scripts/build-fts.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts && esbuild src/metadata/symbolCountsWorker.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts",
+    "build:scripts": "esbuild scripts/extract-metadata.ts scripts/build-database.ts scripts/build-fts.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts && esbuild src/metadata/symbolCountsWorker.ts src/metadata/buildIndexWorker.ts src/metadata/indexWarmupWorker.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts",
     "bridge:build": "node scripts/bridgeBuild.mjs",
     "bridge:attest": "node scripts/bridgeAttest.mjs check",
     "prepublishOnly": "npm run build",

--- a/tests/packaging/publishedFiles.test.ts
+++ b/tests/packaging/publishedFiles.test.ts
@@ -74,9 +74,11 @@ describe.skipIf(!isBuilt)('published package contents', () => {
     // without them `d365fo-mcp index` has nothing to run outside a checkout.
     expect(packed).toContain('dist/scripts/extract-metadata.js');
     expect(packed).toContain('dist/scripts/build-database.js');
-    // Loaded by `new Worker(new URL('./symbolCountsWorker.js', import.meta.url))`
-    // from inside the build-database bundle, so it must sit beside it.
+    // Loaded by `new Worker(new URL('./<name>.js', import.meta.url))` from
+    // inside the build-database bundle, so they must sit beside it rather than
+    // in dist/metadata/ where tsc puts them. See tests/packaging/workerBundles.
     expect(packed).toContain('dist/scripts/symbolCountsWorker.js');
+    expect(packed).toContain('dist/scripts/buildIndexWorker.js');
   });
 
   it('ships the C# bridge sources, so the wizard can build the write path', () => {

--- a/tests/packaging/workerBundles.test.ts
+++ b/tests/packaging/workerBundles.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Every worker a bundled script can reach must be bundled beside it.
+ *
+ * `d365fo-mcp index` on an npm install runs dist/scripts/build-database.js —
+ * an esbuild bundle that inlines src/metadata/symbolIndex.ts. Inside that
+ * bundle `new URL('./someWorker.js', import.meta.url)` resolves against
+ * dist/scripts/, not dist/metadata/ where tsc emitted the worker, so a worker
+ * that is not listed as its own esbuild entry point fails at runtime with
+ *
+ *   [SymbolIndex] idx_symbols_file_path worker error:
+ *     Error: Cannot find module ...\dist\scripts\buildIndexWorker.js
+ *
+ * and only on a big enough database, only on an npm install, and only as a
+ * logged best-effort failure — the index is silently never built. That is
+ * about as invisible as a packaging bug gets, hence this gate.
+ *
+ * Reads the sources rather than dist/, so it decides something on a fresh
+ * clone with nothing built.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const METADATA_DIR = path.join(REPO_ROOT, 'src', 'metadata');
+
+/** Worker entry points referenced as `new URL('./x.js', import.meta.url)`. */
+function referencedWorkers(): string[] {
+  const found = new Set<string>();
+  for (const file of fs.readdirSync(METADATA_DIR).filter(f => f.endsWith('.ts'))) {
+    const src = fs.readFileSync(path.join(METADATA_DIR, file), 'utf8');
+    for (const m of src.matchAll(/new URL\(\s*'\.\/([A-Za-z0-9_]+)\.js'\s*,\s*import\.meta\.url\s*\)/g)) {
+      found.add(m[1]);
+    }
+  }
+  return [...found].sort();
+}
+
+const buildScripts = (
+  JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8')) as {
+    scripts: Record<string, string>;
+  }
+).scripts['build:scripts'];
+
+describe('worker bundling', () => {
+  it('finds the worker references it is meant to guard', () => {
+    // A regex that silently stops matching would turn every assertion below
+    // into a vacuous pass.
+    expect(referencedWorkers()).toContain('buildIndexWorker');
+  });
+
+  it('bundles every src/metadata worker into dist/scripts', () => {
+    const missing = referencedWorkers().filter(
+      w => !buildScripts.includes(`src/metadata/${w}.ts`),
+    );
+    expect(
+      missing,
+      'these workers are loaded relative to a bundle in dist/scripts but are only ' +
+      'emitted to dist/metadata — add them as esbuild entry points in build:scripts',
+    ).toEqual([]);
+  });
+
+  it('bundles them with dist/scripts as the output directory', () => {
+    // build:scripts is a chain of esbuild invocations; the entry point is only
+    // in the right place if the invocation carrying it also targets dist/scripts.
+    for (const worker of referencedWorkers()) {
+      const carrying = buildScripts
+        .split('&&')
+        .filter(cmd => cmd.includes(`src/metadata/${worker}.ts`));
+      expect(carrying.length, `${worker} is not an esbuild entry point`).toBeGreaterThan(0);
+      for (const cmd of carrying) {
+        expect(cmd, `${worker} is bundled somewhere other than dist/scripts`)
+          .toContain('--outdir=dist/scripts');
+      }
+    }
+  });
+});


### PR DESCRIPTION
Reported from a VM reindex on an npm install of 1.16.0:

```
[SymbolIndex] idx_labels_file_path_id worker error: Error: Cannot find module ...\d365fo-mcp\dist\scripts\buildIndexWorker.js
[SymbolIndex] idx_symbols_file_path worker error: Error: Cannot find module ...\d365fo-mcp\dist\scripts\buildIndexWorker.js
[SymbolIndex] idx_symbols_file_path_nocase worker error: Error: Cannot find module ...\d365fo-mcp\dist\scripts\buildIndexWorker.js
```

## Cause

`d365fo-mcp index` does not run the tsc output — it runs the esbuild bundle
`dist/scripts/build-database.js` (`src/cli/context.ts:184`), which has
`src/metadata/symbolIndex.ts` inlined. Inside that bundle the worker URL in
`symbolIndex.ts:968`

```js
new Worker(new URL('./buildIndexWorker.js', import.meta.url), ...)
```

resolves against `dist/scripts/`, while tsc emits the worker to
`dist/metadata/`. `symbolCountsWorker.ts` was already listed as its own
esbuild entry point in `build:scripts` for exactly this reason;
`buildIndexWorker.ts` — and `indexWarmupWorker.ts`, reachable the same way —
were not.

## Impact

Reindexing completes, but the three `file_path` indexes are never built, so
`removeSymbolsByFile` / `removeLabelsByFile` fall back to the full-table
scans those indexes exist to avoid.

Invisible three ways over: it only happens above the 200 MB `isLarge()`
threshold that dispatches the build to a worker at all, only on an npm
install rather than a checkout, and only as a best-effort log line rather
than a failure.

## Change

- `build:scripts` bundles `buildIndexWorker.ts` and `indexWarmupWorker.ts`
  into `dist/scripts/` alongside `symbolCountsWorker.ts`.
- `tests/packaging/workerBundles.test.ts` (new) derives every
  `new URL('./xWorker.js', import.meta.url)` reference from `src/metadata/`
  and requires each to be an esbuild entry point targeting `dist/scripts` —
  so the next worker added does not repeat this. It reads `src/`, not
  `dist/`, so it decides something on an unbuilt clone.
- `tests/packaging/publishedFiles.test.ts` asserts
  `dist/scripts/buildIndexWorker.js` survives `npm pack`.

## Verification

- `npm run build:scripts` now emits `dist/scripts/buildIndexWorker.js` (4.3 kb)
  and `indexWarmupWorker.js` (5.8 kb).
- Packaging suite 15/15, `tsc --noEmit` clean, biome clean.
- Negative control: with the entry point removed again, the new guard fails
  with `expected [ 'buildIndexWorker' ] to deeply equal []`.

Based on #976 so it ships with 1.16.0 — the release has not gone out yet, so
no patch version is needed.

Note for anyone already on an affected install: copying
`dist/metadata/buildIndexWorker.js` into `dist/scripts/` does **not** work —
it is tsc output whose relative `../database/sqlite.js` import breaks one
directory over. The missing indexes can be created directly against the two
databases instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kx59NARK7tbq2tdxdd5Yme
