### PR TITLE
Both element-extension suffix forms are legal — the checker was refusing what the writer supports

### DIFF
--- a/src/utils/objectNamingRules.ts
+++ b/src/utils/objectNamingRules.ts
@@ -329,11 +329,33 @@ export async function checkObjectNaming(
                 `Extension base (before '.') must exactly match baseObjectName.\n  Expected: ${baseObjectName}.xxx\n  Got: ${basePart}.xxx`,
               );
             }
-            if (!extPart.endsWith('Extension')) {
-              errors.push(
-                `Extension suffix (after '.') must end with 'Extension'.\n  Expected: ${extensionInfix}Extension\n  Got: ${extPart}`,
+            // Both suffix forms are legal AOT, and the platform's own metadata is
+            // the evidence: a census of all 214 packages in PackagesLocalDirectory
+            // finds 1,453 of 2,563 dotted extension names — 57 % — NOT ending in
+            // "Extension" (CustTable.AdvancedQualityManagement,
+            // AppCopilotAgentType.Foundation, ModuleAxapta.ApplicationCommon).
+            // They use the bare model token, which is what
+            // EXTENSION_NAMING_STYLE=model-name produces and what the branch above
+            // treats as correct. The same fact was a warning under one style and a
+            // hard ERROR under the other (#986), and `prepare` printed that ❌ for a
+            // name d365fo_file writes and xppc builds — applyObjectPrefix has always
+            // returned a bare model-token suffix unchanged ("Bare model-name suffix
+            // — return as-is"), so the checker was refusing what the writer supports.
+            //
+            // The house convention still shows: a suffix that is NEITHER form gets a
+            // warning naming both. What is gone is calling a shipped, buildable name
+            // an error and offering to rename it.
+            const isInfixForm = extPart.endsWith('Extension');
+            const isModelTokenForm =
+              !!modelToken && extPart.toLowerCase() === modelToken.toLowerCase();
+            if (!isInfixForm && !isModelTokenForm) {
+              warnings.push(
+                `Extension suffix (after '.') is neither of the two forms the platform uses.\n` +
+                `  Expected: ${extensionInfix}Extension` +
+                (modelToken ? ` (this model's style) or ${modelToken} (bare model name)` : '') +
+                `\n  Got: ${extPart}`,
               );
-            } else if (extensionInfix && !extPart.toLowerCase().startsWith(extensionInfix.toLowerCase())) {
+            } else if (isInfixForm && extensionInfix && !extPart.toLowerCase().startsWith(extensionInfix.toLowerCase())) {
               warnings.push(
                 `Extension suffix should start with model "${modelName || '(unknown)'}"'s infix "${extensionInfix}".\n  Current: ${extPart}\n  Recommended: ${extensionInfix}Extension`,
               );

--- a/tests/tools/file-ops.test.ts
+++ b/tests/tools/file-ops.test.ts
@@ -2269,3 +2269,70 @@ describe('EDT base-type resolution cost', () => {
     expect(readEdt).toHaveBeenCalledTimes(2);
   });
 });
+
+// ─── validate_object_naming — both element-extension suffix forms (issue #986) ─
+//
+// `Base.{Infix}Extension` and `Base.{ModelToken}` are BOTH shipped AOT. A census
+// of all 214 packages in PackagesLocalDirectory finds 1,453 of 2,563 dotted
+// extension names — 57 % — using the bare model token
+// (CustTable.AdvancedQualityManagement, AppCopilotAgentType.Foundation,
+// ModuleAxapta.ApplicationCommon). Under the prefix style the validator called
+// that an ERROR and offered to rename it, while under the model-name style the
+// same name was correct — and `applyObjectPrefix` has always written a bare
+// model-token suffix through unchanged. The checker was refusing what the writer
+// supports.
+describe('validate_object_naming — element-extension suffix forms', () => {
+  let ctx: XppServerContext;
+
+  beforeEach(() => {
+    ctx = buildContext();
+    (ctx.symbolIndex.db as any).stmt.get.mockReturnValue(undefined);
+    (ctx.symbolIndex.db as any).stmt.all.mockReturnValue([]);
+    // The DEFAULT style — the one that used to error.
+    vi.mocked(getExtensionNamingStyle).mockReturnValue('prefix');
+  });
+
+  const check = (proposedName: string) =>
+    validateObjectNamingTool(
+      req('validate_object_naming', {
+        proposedName,
+        objectType: 'enum-extension',
+        baseObjectName: 'NumberSeqModule',
+        modelName: 'ContosoRobotics',
+        modelPrefix: 'CR',
+      }),
+      ctx,
+    );
+
+  it('accepts the bare model-token suffix under the PREFIX style too', async () => {
+    const result = await check('NumberSeqModule.ContosoRobotics');
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).not.toMatch(/ERRORS \(\d/);
+    expect(result.content[0].text).not.toMatch(/must end with 'Extension'/);
+  });
+
+  it('still accepts the infix form', async () => {
+    const result = await check('NumberSeqModule.CRExtension');
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).not.toMatch(/ERRORS \(\d/);
+    expect(result.content[0].text).not.toMatch(/neither of the two forms/);
+  });
+
+  it('warns — never errors — for a suffix that is neither form, and names both', async () => {
+    const result = await check('NumberSeqModule.ConDemoRent');
+    expect(result.isError).toBeFalsy();
+    // The house convention still shows...
+    expect(result.content[0].text).toMatch(/neither of the two forms/);
+    // Both acceptable forms are named: the model's infix one and the bare token.
+    expect(result.content[0].text).toMatch(/CRExtension/);
+    expect(result.content[0].text).toMatch(/ContosoRobotics \(bare model name\)/);
+    // ...but a legal, buildable AOT name is not an error.
+    expect(result.content[0].text).not.toMatch(/ERRORS \(\d/);
+  });
+
+  it('still errors when the base half does not match the object being extended', async () => {
+    // The rule that IS about correctness, not convention, is untouched.
+    const result = await check('SomeOtherEnum.ContosoRobotics');
+    expect(result.content[0].text).toMatch(/Extension base \(before '\.'\) must exactly match/);
+  });
+});


### PR DESCRIPTION
Closes #986.

Takes **option 2** of the three the issue listed — accept both shipped forms, warn only when the
suffix matches neither — which subsumes option 1 (downgrade to a warning) while keeping the house
convention visible. I picked it rather than asking because the deciding evidence turned out to be
internal rather than a matter of taste; see below. If you want option 3 instead (keep the ❌ and
reword it as a project convention), say so and I'll swap it.

## The census

Complete, not a sample — all 214 packages in `K:\AosService\PackagesLocalDirectory`, every dotted
extension element name:

| kind | dotted names | end in `Extension` | do **not** |
|---|---|---|---|
| `AxEnumExtension` | 278 | 71 (25 %) | **207** |
| `AxTableExtension` | 1093 | 491 (44 %) | **602** |
| `AxFormExtension` | 1179 | 537 (45 %) | **642** |
| `AxEdtExtension` | 13 | 11 (84 %) | 2 |

**1,453 of 2,563 — 57 %** — use the bare model token: `CustTable.AdvancedQualityManagement`,
`AppCopilotAgentType.Foundation`, `ModuleAxapta.ApplicationCommon`.

## The clincher is internal

`applyObjectPrefix` has always returned a bare model-token suffix through **unchanged** — its own
comment says *"Bare model-name suffix (no 'extension' word) — return as-is"*. So `d365fo_file`
writes the name, xppc builds it, and only the checker refused it. That is not a convention
disagreement, it is two halves of this repo contradicting each other.

And the ❌ was not free: in `prepare` it reads as "fix this before writing", and the correction it
offered was a rename to something the caller did not ask for — the same failure shape
`reinterpretExtensionType` exists to prevent (its doc comment cites run f2e7b71a, T56 → T59).

## What changed

`NumberSeqModule.ContosoRobotics` (bare model token) and `NumberSeqModule.CRExtension` (infix
form) are both clean under the default prefix style. A suffix that is neither gets a **warning**
naming both:

```
⚠️  Extension suffix (after '.') is neither of the two forms the platform uses.
  Expected: CRExtension (this model's style) or ContosoRobotics (bare model name)
  Got: ConDemoRent
```

The rule that is about **correctness** rather than convention — the base half must exactly match
the object being extended — is untouched and still an error.

Nothing gates a write on these findings (`validate_object_naming` and `prepare` are the only
callers of `checkObjectNaming`, both advisory), so this changes advice, not behaviour.

## Verification

* `tsc --noEmit` clean; `biome lint` clean on both changed files.
* `vitest run` — **391 files, 5,859 passed, 2 skipped.**
* Four new tests in `tests/tools/file-ops.test.ts` pin both accepted forms, the
  warning-not-error verdict for a third shape, and the base-mismatch error that must survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULksCPwMoC6txP49NsnqT
