### PR TITLE
get_object_info(form) now says when a form holds controls the platform cannot see

### DIFF
--- a/src/tools/readers/formInfo.ts
+++ b/src/tools/readers/formInfo.ts
@@ -14,7 +14,13 @@ import type { XppServerContext } from '../../types/context.js';
 import { promises as fs } from 'fs';
 import { parseStringPromise } from '../../utils/xml.js';
 import { tryBridgeForm } from '../../bridge/bridgeAdapter.js';
-import { readIndexedXml } from '../../utils/indexedXmlLookup.js';
+import { readIndexedXml, resolveIndexedObject } from '../../utils/indexedXmlLookup.js';
+import { isCustomModel } from '../../utils/modelClassifier.js';
+import {
+  countFormControls,
+  findControlElementOrderViolations,
+  formatElementOrderViolations,
+} from '../../validation/formControlElementOrder.js';
 import { describeBridgeStartup } from '../../bridge/bridgeReadiness.js';
 import { assertWritePathAllowed } from '../../utils/pathContainment.js';
 import {
@@ -131,7 +137,14 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
 
     if (!wantsSearch) {
       const bridgeResult = await tryBridgeForm(context.bridge, formName, maxControls);
-      if (bridgeResult) return bridgeResult;
+      if (bridgeResult) {
+        // The bridge cannot know it is short — whatever the deserializer dropped
+        // was gone before it looked. Compare against the file (#985).
+        const note = await bridgeCrossCheckWarning(
+          context, formName, bridgeResult.content?.[0]?.text ?? '', args.modelName,
+        );
+        return prefixResult(bridgeResult, note);
+      }
     }
 
     // Symbol index → form XML. A silent bridge is not proof the form is missing:
@@ -205,6 +218,107 @@ export async function getFormInfoTool(request: CallToolRequest, context: XppServ
   }
 }
 
+// Elements the platform cannot see (issue #985)
+
+/**
+ * The warning block for a form whose XML writes elements out of the order the
+ * metadata deserializer expects, or '' when the document is clean.
+ *
+ * AOT metadata XML is order-sensitive and the deserializer drops a misplaced
+ * element in silence. When the dropped element is a container's `<Controls>`,
+ * every control under it is in the file and invisible to the platform — that is
+ * #979, where a scaffolded form carried 16 controls of which the compiler could
+ * reach 14. The reader is where an agent finds out what a form contains before
+ * writing to it, so it is where the discrepancy has to be said out loud.
+ *
+ * `providerCount` is the number the bridge reported, when a bridge answer is
+ * being cross-checked; omit it on the pure-XML paths, where there is no second
+ * number and inventing one would be worse than saying nothing.
+ */
+function elementOrderWarning(xml: string, providerCount?: number): string {
+  const violations = findControlElementOrderViolations(xml).filter(v => v.kind === 'order');
+  const documentCount = countFormControls(xml);
+  const countsDiffer = providerCount !== undefined && providerCount !== documentCount;
+  if (violations.length === 0 && !countsDiffer) return '';
+
+  const lines: string[] = [];
+  if (countsDiffer) {
+    lines.push(
+      `⚠️ **This form's XML holds ${documentCount} controls; the metadata provider reports ` +
+      `${providerCount}.** The ${documentCount - providerCount} missing one(s) are in the file and ` +
+      `invisible to the platform — the compiler will not see them either.`,
+    );
+  } else {
+    lines.push(
+      `⚠️ **${violations.length} element(s) in this form are written out of order, and the ` +
+      `metadata deserializer drops those silently.** Anything under a dropped \`<Controls>\` is ` +
+      `in the file and invisible to the platform.`,
+    );
+  }
+
+  if (violations.length > 0) {
+    lines.push('', formatElementOrderViolations(violations));
+    lines.push(
+      '',
+      'Fix the ORDER in the AxForm XML — the canonical sequence per control type is mined from ' +
+      'shipped metadata in `src/validation/formControlElementOrder.generated.ts` ' +
+      '(e.g. on a group control `<DataGroup>` and `<DataSource>` come AFTER `</Controls>`).',
+    );
+  } else {
+    lines.push(
+      '',
+      'No element-order violation was found, so the cause is something else the provider ' +
+      'rejected — compare the file against a shipped form of the same shape.',
+    );
+  }
+  return `${lines.join('\n')}\n\n---\n\n`;
+}
+
+/** Prefix a tool result's first text block with `note`, if there is anything to say. */
+function prefixResult<T extends { content?: Array<{ text?: string }> }>(result: T, note: string): T {
+  if (!note) return result;
+  const first = result.content?.[0];
+  if (first && typeof first.text === 'string') first.text = note + first.text;
+  return result;
+}
+
+/**
+ * Cross-check a bridge answer against the form's XML on disk.
+ *
+ * The bridge reads through `IMetadataProvider` — the same reader the compiler
+ * uses — so anything dropped for being out of order is ALREADY gone by the time
+ * it answers, and it cannot know it is short. The only way to notice from that
+ * path is to compare against the raw file.
+ *
+ * Restricted to CUSTOM models on purpose. Microsoft's own forms were written by
+ * Microsoft's tooling and are not the ones this server or its user can have
+ * broken; reading SalesTable.xml off disk on every `get_object_info(form)` call
+ * would be a real cost for a warning that will never fire. The index row is
+ * consulted first (cheap) precisely so the file read can be skipped.
+ */
+async function bridgeCrossCheckWarning(
+  context: XppServerContext,
+  formName: string,
+  bridgeText: string,
+  modelName?: string,
+): Promise<string> {
+  try {
+    const ref = await resolveIndexedObject(context.symbolIndex.getReadDb(), formName, ['form'], modelName);
+    if (!ref?.localPath || !isCustomModel(ref.model)) return '';
+
+    // The rendered tree is capped by maxControls, but the Summary line is not —
+    // it reports the true total the bridge saw.
+    const reported = /Controls:\s*(\d+)/.exec(bridgeText.slice(bridgeText.indexOf('📈 Summary')));
+    if (!reported) return '';
+
+    const xml = await fs.readFile(ref.localPath, 'utf-8');
+    return elementOrderWarning(xml, Number(reported[1]));
+  } catch {
+    // A cross-check that cannot run is not a finding — the bridge answer stands.
+    return '';
+  }
+}
+
 // Shared XML parse + format helper
 
 /**
@@ -246,14 +360,24 @@ async function parseAndFormatForm(
     formInfo.methods = extractMethods(axForm.SourceCode[0].Methods[0]);
   }
 
+  // This path reads the RAW document, so it sees every control — including the
+  // ones the metadata provider has already dropped for being out of order, which
+  // is exactly why the two disagree (#979, #985). Say so before reporting a tree
+  // the platform cannot fully see. The search branch gets it too: a control name
+  // looked up here is about to be written against.
+  const orderNote = elementOrderWarning(xmlContent);
+
   if (searchControl) {
     const matches = searchControlsInHierarchy(formInfo.design, searchControl);
-    return {
+    return prefixResult({
       content: [{ type: 'text', text: formatControlSearchResults(formInfo.name, formInfo.model, matches, searchControl) }],
-    };
+    }, orderNote);
   }
 
-  return formatFormOutput(formInfo, includeControls, includeDataSources, includeMethods, maxControls);
+  return prefixResult(
+    formatFormOutput(formInfo, includeControls, includeDataSources, includeMethods, maxControls),
+    orderNote,
+  );
 }
 
 // Control search helpers

--- a/src/tools/smart/generateSmartForm.ts
+++ b/src/tools/smart/generateSmartForm.ts
@@ -18,6 +18,7 @@ import { extractModelFromProject, findProjectInSolution } from '../../utils/proj
 import { normalizeD365Xml } from '../../utils/d365XmlNormalizer.js';
 import { validateFormPatternXml } from '../../validation/formPatternValidator.js';
 import {
+  countFormControls,
   findControlElementOrderViolations,
   formatElementOrderViolations,
 } from '../../validation/formControlElementOrder.js';
@@ -30,7 +31,6 @@ import { getFieldControlMap, getTableTitleField, type FieldControlMap } from '..
 import { lookupSymbolNocase } from '../../utils/symbolLookup.js';
 import { scaffoldWriteRefusalResult } from '../write/writeAnchorGuard.js';
 import { upsertWrittenFileIntoIndex } from '../write/inlineIndexUpsert.js';
-import { createXmlTokenScanner } from '../../utils/xmlScan.js';
 
 /**
  * Symbol types a form datasource may bind to. Views are indexed as 'view'
@@ -152,22 +152,6 @@ export const generateSmartFormTool: Tool = {
  * BPErrorCaptionNotDefined on unlabeled ActionPane/ButtonGroups). Reusing
  * the bound table's Label when available is both more correct and BP-clean.
  */
-/**
- * How many `<AxFormControl>` elements a form document actually contains.
- *
- * Uses the shared token scanner, so a control written inside an XML COMMENT (the
- * Workspace template ships two such examples) is not counted as a real one.
- */
-export function countFormControls(xml: string): number {
-  const scanner = createXmlTokenScanner();
-  let count = 0;
-  let token: RegExpExecArray | null;
-  while ((token = scanner.exec(xml)) !== null) {
-    if (token[2] === 'AxFormControl') count++;
-  }
-  return count;
-}
-
 export function resolveFormCaption(
   explicitCaption: string | undefined,
   explicitLabel: string | undefined,

--- a/src/validation/formControlElementOrder.ts
+++ b/src/validation/formControlElementOrder.ts
@@ -69,6 +69,25 @@ interface Frame {
 }
 
 /**
+ * How many `<AxFormControl>` elements a form document actually contains.
+ *
+ * Uses the shared token scanner, so a control written inside an XML COMMENT (the
+ * Workspace pattern template ships two such examples) is not counted as a real
+ * one. Lives here rather than beside its first caller because the number is now
+ * used to answer two different questions: what the scaffold wrote, and whether
+ * the document disagrees with what the metadata provider can see.
+ */
+export function countFormControls(xml: string): number {
+  const scanner = createXmlTokenScanner();
+  let count = 0;
+  let token: RegExpExecArray | null;
+  while ((token = scanner.exec(xml)) !== null) {
+    if (token[2] === 'AxFormControl') count++;
+  }
+  return count;
+}
+
+/**
  * Every place a form control writes a child element earlier than the canonical
  * order for its `i:type` allows.
  *

--- a/tests/tools/formInfoElementOrder.test.ts
+++ b/tests/tools/formInfoElementOrder.test.ts
@@ -1,0 +1,182 @@
+/**
+ * `get_object_info(objectType="form")` warns about controls the platform cannot
+ * see (issue #985).
+ *
+ * #979 established the failure: a form whose XML writes `<DataGroup>`/`<DataSource>`
+ * above `<Controls>` loses that `<Controls>` element to the metadata deserializer,
+ * silently. The scaffold that produced that shape is fixed — but nothing told a
+ * reader about a form written by an older build, by hand, or by another tool.
+ *
+ * The two paths are asymmetric, and the tests below pin both:
+ *   XML path    — reads the file, sees all 16 controls, and CAN spot the disagreement.
+ *   bridge path — reads through IMetadataProvider, which already dropped them; it
+ *                 can only notice by cross-checking the file, and only bothers for
+ *                 custom models.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/utils/pathContainment.js', () => ({
+  assertWritePathAllowed: vi.fn(async () => ({ ok: true })),
+}));
+
+// `vi.mock` factories are hoisted above every top-level binding, so the spies
+// they close over have to live in `vi.hoisted`.
+const h = vi.hoisted(() => ({
+  tryBridgeForm: vi.fn(),
+  resolveIndexedObject: vi.fn(),
+  isCustomModel: vi.fn(() => true),
+}));
+
+vi.mock('../../src/bridge/bridgeAdapter.js', () => ({ tryBridgeForm: h.tryBridgeForm }));
+vi.mock('../../src/utils/indexedXmlLookup.js', () => ({
+  readIndexedXml: vi.fn(async () => null),
+  resolveIndexedObject: h.resolveIndexedObject,
+}));
+vi.mock('../../src/utils/modelClassifier.js', () => ({ isCustomModel: h.isCustomModel }));
+
+const mockTryBridgeForm = h.tryBridgeForm;
+const mockResolveIndexedObject = h.resolveIndexedObject;
+const mockIsCustomModel = h.isCustomModel;
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return { ...actual, promises: { ...actual.promises, readFile: vi.fn() } };
+});
+
+import { promises as fs } from 'fs';
+import { getFormInfoTool } from '../../src/tools/readers/formInfo';
+
+/** A group control with `n` children; `broken` puts <DataGroup>/<DataSource> above <Controls>. */
+const groupForm = (broken: boolean) => `<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConDemoProbe</Name>
+  <Design>
+    <Controls>
+      <AxFormControl i:type="AxFormGroupControl">
+        <Name>Overview</Name>
+        <Type>Group</Type>
+${broken ? '        <DataGroup>Overview</DataGroup>\n        <DataSource>ConDemoTable</DataSource>\n' : ''}        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl i:type="AxFormStringControl">
+            <Name>Overview_NoteId</Name>
+            <Type>String</Type>
+            <DataField>NoteId</DataField>
+            <DataSource>ConDemoTable</DataSource>
+          </AxFormControl>
+          <AxFormControl i:type="AxFormStringControl">
+            <Name>Overview_Subject</Name>
+            <Type>String</Type>
+            <DataField>Subject</DataField>
+            <DataSource>ConDemoTable</DataSource>
+          </AxFormControl>
+        </Controls>
+${broken ? '' : '        <DataGroup>Overview</DataGroup>\n        <DataSource>ConDemoTable</DataSource>\n'}      </AxFormControl>
+    </Controls>
+  </Design>
+</AxForm>`;
+
+const ctx = () => ({
+  symbolIndex: { getReadDb: () => ({}) },
+  bridge: { isReady: true, metadataAvailable: true },
+} as any);
+
+const readForm = (args: Record<string, unknown>) =>
+  getFormInfoTool({ params: { arguments: { formName: 'ConDemoProbe', ...args } } } as any, ctx());
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockTryBridgeForm.mockResolvedValue(null);
+  mockResolveIndexedObject.mockResolvedValue(null);
+  mockIsCustomModel.mockReturnValue(true);
+});
+
+describe('XML path — the reader holds the evidence', () => {
+  it('warns, and names the misplaced element, for the #979 shape', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(groupForm(true) as never);
+    const res: any = await readForm({ filePath: 'K:/pkg/fm-mcp/fm-mcp/AxForm/ConDemoProbe.xml' });
+    const text = res.content[0].text as string;
+
+    expect(text).toMatch(/written out of order/);
+    expect(text).toMatch(/<Controls> must come AFTER <DataSource>/);
+    expect(text).toMatch(/Overview/);
+    // It must point at the fix, not just at the problem.
+    expect(text).toMatch(/formControlElementOrder\.generated/);
+    // The warning comes FIRST — an agent that stops reading still sees it.
+    expect(text.indexOf('out of order')).toBeLessThan(text.indexOf('# Form:'));
+  });
+
+  it('says nothing for a well-ordered form', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(groupForm(false) as never);
+    const res: any = await readForm({ filePath: 'K:/pkg/fm-mcp/fm-mcp/AxForm/ConDemoProbe.xml' });
+    expect(res.content[0].text).not.toMatch(/out of order/);
+  });
+
+  it('warns on the searchControl branch too — that name is about to be written against', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(groupForm(true) as never);
+    const res: any = await readForm({
+      filePath: 'K:/pkg/fm-mcp/fm-mcp/AxForm/ConDemoProbe.xml',
+      searchControl: 'Overview',
+    });
+    expect(res.content[0].text).toMatch(/written out of order/);
+  });
+});
+
+describe('bridge path — cross-checked against the file', () => {
+  const bridgeAnswer = (controls: number) => ({
+    content: [{
+      type: 'text',
+      text: `# Form: ConDemoProbe\n\n## 📈 Summary\nData Sources: 1 | Controls: ${controls} | Methods: 0\n`,
+    }],
+  });
+
+  it('reports the disagreement between the file and the provider', async () => {
+    mockTryBridgeForm.mockResolvedValue(bridgeAnswer(1)); // the group, minus its two children
+    mockResolveIndexedObject.mockResolvedValue({
+      name: 'ConDemoProbe', model: 'fm-mcp', localPath: 'K:/pkg/ConDemoProbe.xml',
+      indexedPath: 'K:/pkg/ConDemoProbe.xml', sourceFileMissing: false,
+    });
+    vi.mocked(fs.readFile).mockResolvedValue(groupForm(true) as never);
+
+    const res: any = await readForm({});
+    const text = res.content[0].text as string;
+    expect(text).toMatch(/holds 3 controls; the metadata provider reports 1/);
+    expect(text).toMatch(/invisible to the platform/);
+    expect(text).toMatch(/<Controls> must come AFTER <DataSource>/);
+  });
+
+  it('stays quiet when the two agree', async () => {
+    mockTryBridgeForm.mockResolvedValue(bridgeAnswer(3));
+    mockResolveIndexedObject.mockResolvedValue({
+      name: 'ConDemoProbe', model: 'fm-mcp', localPath: 'K:/pkg/ConDemoProbe.xml',
+      indexedPath: 'K:/pkg/ConDemoProbe.xml', sourceFileMissing: false,
+    });
+    vi.mocked(fs.readFile).mockResolvedValue(groupForm(false) as never);
+
+    const res: any = await readForm({});
+    expect(res.content[0].text).not.toMatch(/invisible to the platform/);
+  });
+
+  it('does not read Microsoft form XML off disk for a warning that cannot apply', async () => {
+    mockTryBridgeForm.mockResolvedValue(bridgeAnswer(600));
+    mockResolveIndexedObject.mockResolvedValue({
+      name: 'SalesTable', model: 'ApplicationSuite', localPath: 'K:/pkg/SalesTable.xml',
+      indexedPath: 'K:/pkg/SalesTable.xml', sourceFileMissing: false,
+    });
+    mockIsCustomModel.mockReturnValue(false);
+
+    const res: any = await readForm({});
+    expect(fs.readFile).not.toHaveBeenCalled();
+    expect(res.content[0].text).not.toMatch(/invisible to the platform/);
+  });
+
+  it('lets the bridge answer stand when the cross-check cannot run', async () => {
+    mockTryBridgeForm.mockResolvedValue(bridgeAnswer(1));
+    mockResolveIndexedObject.mockRejectedValue(new Error('index unavailable'));
+
+    const res: any = await readForm({});
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toMatch(/# Form: ConDemoProbe/);
+    expect(res.content[0].text).not.toMatch(/invisible to the platform/);
+  });
+});


### PR DESCRIPTION
Closes #985.

#979 fixed the writer that produced the shape; the check it added ran on the scaffold's own
output and nowhere else. This puts it where a form the server did **not** write gets seen.

## Both paths, two mechanisms — because they are asymmetric

| path | sees the dropped controls? | how it warns |
|---|---|---|
| XML (`options={filePath}`, symbol-index fallback) | **yes** — reads the raw file | runs the check on XML already in hand, no extra cost |
| bridge (answers first in full mode) | **no** — reads through `IMetadataProvider`, which dropped them before it looked | compares its count against the file |

The bridge genuinely cannot know it is short: whatever the deserializer rejected was gone before
it read anything. So the only signal available there is the disagreement itself — which is exactly
the signal that made #979 findable in the first place.

## What it looks like

```
⚠️ **This form's XML holds 16 controls; the metadata provider reports 14.** The 2 missing
one(s) are in the file and invisible to the platform — the compiler will not see them either.

🔴 [ORDER] AxFormGroupControl "Overview" line 149: <Controls> must come AFTER <DataSource> —
the metadata deserializer drops out-of-order elements silently.

Fix the ORDER in the AxForm XML — the canonical sequence per control type is mined from
shipped metadata in `src/validation/formControlElementOrder.generated.ts` (e.g. on a group
control `<DataGroup>` and `<DataSource>` come AFTER `</Controls>`).
```

The warning is prefixed, so an agent that stops reading after the first line still sees it. The
`searchControl` branch gets it too — a control name looked up there is about to be written
against.

## Cost

The bridge cross-check is restricted to **custom models**, and the index row is consulted first
precisely so the file read can be skipped. Microsoft's forms were written by Microsoft's tooling
and are not the ones this server or its user can have broken; reading `SalesTable.xml` off disk on
every `get_object_info(form)` call would be a real cost for a warning that can never fire. A
cross-check that throws is not a finding either — the bridge answer stands unmodified.

`countFormControls` moves from `generateSmartForm` into the validation module, since the number
now answers two questions rather than one.

## Not done here, deliberately

`d365fo_file(action="create", objectType="form")` and `validate_code` still do not run this check
on caller-supplied XML. A write gate *prevents* what a reader can only *report*, so it is the
higher-value place — but it is a different call site with a different failure mode (refuse vs.
report), and the issue itself flagged it as possibly deserving its own split. Say the word and
I'll open it.

## Verification

* `tsc --noEmit` clean; `biome lint` clean on all four changed files.
* `vitest run` — **392 files, 5,862 passed, 2 skipped.**
* Seven new tests in `tests/tools/formInfoElementOrder.test.ts` drive the real #979 shape through
  both paths, including the custom-model gate (asserts `fs.readFile` is never called for an
  `ApplicationSuite` form) and a cross-check that throws without taking the answer down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULksCPwMoC6txP49NsnqT
