### PR TITLE
Eight goldens still assert the output the writer fixes replaced

### DIFF
--- a/eval/goldens/L1-form-detailsmaster/ConDemoNoteHeaderMaster.metadata.xml
+++ b/eval/goldens/L1-form-detailsmaster/ConDemoNoteHeaderMaster.metadata.xml
@@ -213,7 +213,7 @@ public class ConDemoNoteHeaderMaster extends FormRun
 											</AxFormControl>
 										</Controls>
 										<ColumnsMode>Fill</ColumnsMode>
-										<Caption>Overview</Caption>
+										<Caption>@SYS9039</Caption>
 									</AxFormControl>
 									<AxFormControl xmlns=""
 											i:type="AxFormTabPageControl">
@@ -253,7 +253,7 @@ public class ConDemoNoteHeaderMaster extends FormRun
 											</AxFormControl>
 										</Controls>
 										<ColumnsMode>Fill</ColumnsMode>
-										<Caption>General</Caption>
+										<Caption>@SYS2952</Caption>
 									</AxFormControl>
 								</Controls>
 								<Style>FastTabs</Style>

--- a/eval/goldens/L1-form-detailsmaster/README.md
+++ b/eval/goldens/L1-form-detailsmaster/README.md
@@ -1,0 +1,28 @@
+# Golden: L1-form-detailsmaster
+
+## Hand-correction 2026-09-01: the writer changed under this golden
+
+PR #984 fixed two defects in the form pattern templates, and this golden was
+captured before them — so it asserted the OLD, defective output as the expected
+answer, and a faithful rerun would have scored `golden_match: 0` against its own
+correct result.
+
+Changed here, mechanically and by hand (NOT a re-capture):
+
+- `<Caption>Overview</Caption>` → `@SYS9039`, `<Caption>General</Caption>` → `@SYS2952`
+
+Both transformations are deterministic consequences of the writer fix, which is
+why they were applied rather than re-captured:
+
+- **Captions.** `<Caption>` holding raw text is `BPErrorLabelIsText`, and
+  untranslatable. Each replacement id is the exact text in ApplicationPlatform's
+  `SYS.en-us.label.txt` and the most-used caption of that wording across a census
+  of shipped Foundation forms (#980).
+- **Element order.** AOT XML is order-sensitive and the deserializer drops a
+  misplaced element in silence: with `<DataGroup>`/`<DataSource>` above
+  `<Controls>`, the metadata provider read the group with NO children. Verified
+  against the live provider on the VM — same file, only those two lines moved:
+  14 controls before, 16 after (#979).
+
+`tests/eval/goldenFormIntegrity.test.ts` now fails on either shape, so a golden
+captured from a defective writer cannot enshrine the defect again.

--- a/eval/goldens/L1-form-simplelistdetails/ConDemoNoteHeaderDetails.metadata.xml
+++ b/eval/goldens/L1-form-simplelistdetails/ConDemoNoteHeaderDetails.metadata.xml
@@ -163,8 +163,6 @@ public class ConDemoNoteHeaderDetails extends FormRun
 							i:type="AxFormGroupControl">
 						<Name>Overview</Name>
 						<Type>Group</Type>
-						<DataGroup>Overview</DataGroup>
-						<DataSource>ConDemoNoteHeader</DataSource>
 						<FormControlExtension
 							i:nil="true" />
 						<Controls>
@@ -187,6 +185,8 @@ public class ConDemoNoteHeaderDetails extends FormRun
 											<DataSource>ConDemoNoteHeader</DataSource>
 										</AxFormControl>
 						</Controls>
+						<DataGroup>Overview</DataGroup>
+						<DataSource>ConDemoNoteHeader</DataSource>
 						<FrameType>None</FrameType>
 					</AxFormControl>
 				</Controls>
@@ -238,7 +238,7 @@ public class ConDemoNoteHeaderDetails extends FormRun
 							</AxFormControl>
 						</Controls>
 						<ColumnsMode>Fill</ColumnsMode>
-						<Caption>General</Caption>
+						<Caption>@SYS2952</Caption>
 					</AxFormControl>
 				</Controls>
 				<Style>FastTabs</Style>

--- a/eval/goldens/L1-form-simplelistdetails/README.md
+++ b/eval/goldens/L1-form-simplelistdetails/README.md
@@ -1,0 +1,28 @@
+# Golden: L1-form-simplelistdetails
+
+## Hand-correction 2026-09-01: the writer changed under this golden
+
+PR #984 fixed two defects in the form pattern templates, and this golden was
+captured before them — so it asserted the OLD, defective output as the expected
+answer, and a faithful rerun would have scored `golden_match: 0` against its own
+correct result.
+
+Changed here, mechanically and by hand (NOT a re-capture):
+
+- `<Caption>General</Caption>` → `@SYS2952`, **and** the `Overview` group's `<DataGroup>`/`<DataSource>` moved below `</Controls>`
+
+Both transformations are deterministic consequences of the writer fix, which is
+why they were applied rather than re-captured:
+
+- **Captions.** `<Caption>` holding raw text is `BPErrorLabelIsText`, and
+  untranslatable. Each replacement id is the exact text in ApplicationPlatform's
+  `SYS.en-us.label.txt` and the most-used caption of that wording across a census
+  of shipped Foundation forms (#980).
+- **Element order.** AOT XML is order-sensitive and the deserializer drops a
+  misplaced element in silence: with `<DataGroup>`/`<DataSource>` above
+  `<Controls>`, the metadata provider read the group with NO children. Verified
+  against the live provider on the VM — same file, only those two lines moved:
+  14 controls before, 16 after (#979).
+
+`tests/eval/goldenFormIntegrity.test.ts` now fails on either shape, so a golden
+captured from a defective writer cannot enshrine the defect again.

--- a/eval/goldens/L1-form-tableofcontents/ConDemoNoteHeaderToc.metadata.xml
+++ b/eval/goldens/L1-form-tableofcontents/ConDemoNoteHeaderToc.metadata.xml
@@ -120,7 +120,7 @@ public class ConDemoNoteHeaderToc extends FormRun
 										</AxFormControl>
 									</Controls>
 									<ColumnsMode>Fill</ColumnsMode>
-									<Caption>General</Caption>
+									<Caption>@SYS2952</Caption>
 								</AxFormControl>
 							</Controls>
 							<Style>FastTabs</Style>
@@ -204,7 +204,7 @@ public class ConDemoNoteHeaderToc extends FormRun
 										</AxFormControl>
 									</Controls>
 									<ColumnsMode>Fill</ColumnsMode>
-									<Caption>Setup</Caption>
+									<Caption>@SYS2186</Caption>
 								</AxFormControl>
 							</Controls>
 							<Style>FastTabs</Style>

--- a/eval/goldens/L1-form-tableofcontents/README.md
+++ b/eval/goldens/L1-form-tableofcontents/README.md
@@ -1,0 +1,28 @@
+# Golden: L1-form-tableofcontents
+
+## Hand-correction 2026-09-01: the writer changed under this golden
+
+PR #984 fixed two defects in the form pattern templates, and this golden was
+captured before them — so it asserted the OLD, defective output as the expected
+answer, and a faithful rerun would have scored `golden_match: 0` against its own
+correct result.
+
+Changed here, mechanically and by hand (NOT a re-capture):
+
+- `<Caption>General</Caption>` → `@SYS2952`, `<Caption>Setup</Caption>` → `@SYS2186`
+
+Both transformations are deterministic consequences of the writer fix, which is
+why they were applied rather than re-captured:
+
+- **Captions.** `<Caption>` holding raw text is `BPErrorLabelIsText`, and
+  untranslatable. Each replacement id is the exact text in ApplicationPlatform's
+  `SYS.en-us.label.txt` and the most-used caption of that wording across a census
+  of shipped Foundation forms (#980).
+- **Element order.** AOT XML is order-sensitive and the deserializer drops a
+  misplaced element in silence: with `<DataGroup>`/`<DataSource>` above
+  `<Controls>`, the metadata provider read the group with NO children. Verified
+  against the live provider on the VM — same file, only those two lines moved:
+  14 controls before, 16 after (#979).
+
+`tests/eval/goldenFormIntegrity.test.ts` now fails on either shape, so a golden
+captured from a defective writer cannot enshrine the defect again.

--- a/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLogDetails.metadata.xml
+++ b/eval/goldens/L3-enum-field-form-downgrade-guard/ConDemoTaxChangeLogDetails.metadata.xml
@@ -195,7 +195,7 @@ public class ConDemoTaxChangeLogDetails extends FormRun
 							</AxFormControl>
 						</Controls>
 						<ColumnsMode>Fill</ColumnsMode>
-						<Caption>General</Caption>
+						<Caption>@SYS2952</Caption>
 					</AxFormControl>
 				</Controls>
 				<Style>FastTabs</Style>

--- a/eval/goldens/L3-enum-field-form-downgrade-guard/README.md
+++ b/eval/goldens/L3-enum-field-form-downgrade-guard/README.md
@@ -85,3 +85,30 @@ no label), `BPErrorLabelIsText` (the SimpleListDetails scaffold writes
 `EvalL3ServiceTierDowngradeTest`, run via `run_systest_class` — 3/3 green
 (`testDowngradeIsRejected`, `testUpgradeIsAccepted`,
 `testInsertAtAnyTierIsAccepted`). `systest_pending` is `false`.
+
+## Hand-correction 2026-09-01: the writer changed under this golden
+
+PR #984 fixed two defects in the form pattern templates, and this golden was
+captured before them — so it asserted the OLD, defective output as the expected
+answer, and a faithful rerun would have scored `golden_match: 0` against its own
+correct result.
+
+Changed here, mechanically and by hand (NOT a re-capture):
+
+- `<Caption>General</Caption>` → `@SYS2952`
+
+Both transformations are deterministic consequences of the writer fix, which is
+why they were applied rather than re-captured:
+
+- **Captions.** `<Caption>` holding raw text is `BPErrorLabelIsText`, and
+  untranslatable. Each replacement id is the exact text in ApplicationPlatform's
+  `SYS.en-us.label.txt` and the most-used caption of that wording across a census
+  of shipped Foundation forms (#980).
+- **Element order.** AOT XML is order-sensitive and the deserializer drops a
+  misplaced element in silence: with `<DataGroup>`/`<DataSource>` above
+  `<Controls>`, the metadata provider read the group with NO children. Verified
+  against the live provider on the VM — same file, only those two lines moved:
+  14 controls before, 16 after (#979).
+
+`tests/eval/goldenFormIntegrity.test.ts` now fails on either shape, so a golden
+captured from a defective writer cannot enshrine the defect again.

--- a/eval/goldens/L3-form-detailstransaction/DemoNoteTransaction.AxForm.metadata.xml
+++ b/eval/goldens/L3-form-detailstransaction/DemoNoteTransaction.AxForm.metadata.xml
@@ -248,7 +248,7 @@ public class ConDemoNoteTransaction extends FormRun
 															</AxFormControl>
 														</Controls>
 														<ColumnsMode>Fill</ColumnsMode>
-														<Caption>Header</Caption>
+														<Caption>@SYS101051</Caption>
 														<FastTabExpanded>No</FastTabExpanded>
 													</AxFormControl>
 													<AxFormControl xmlns=""
@@ -304,7 +304,7 @@ public class ConDemoNoteTransaction extends FormRun
 																<VisibleRowsMode>Fixed</VisibleRowsMode>
 															</AxFormControl>
 														</Controls>
-														<Caption>Lines</Caption>
+														<Caption>@SYS15451</Caption>
 														<FastTabExpanded>Always</FastTabExpanded>
 													</AxFormControl>
 													<AxFormControl xmlns=""
@@ -344,14 +344,14 @@ public class ConDemoNoteTransaction extends FormRun
 																			</AxFormControl>
 																		</Controls>
 																		<ColumnsMode>Fill</ColumnsMode>
-																		<Caption>General</Caption>
+																		<Caption>@SYS2952</Caption>
 																	</AxFormControl>
 																</Controls>
 																<AlignChild>No</AlignChild>
 																<Style>Tabs</Style>
 															</AxFormControl>
 														</Controls>
-														<Caption>Line details</Caption>
+														<Caption>@SYS23823</Caption>
 														<DataSource>ConDemoNoteHeaderLine</DataSource>
 														<FastTabExpanded>No</FastTabExpanded>
 													</AxFormControl>
@@ -418,7 +418,7 @@ public class ConDemoNoteTransaction extends FormRun
 															</AxFormControl>
 														</Controls>
 														<ColumnsMode>Fill</ColumnsMode>
-														<Caption>General</Caption>
+														<Caption>@SYS2952</Caption>
 													</AxFormControl>
 												</Controls>
 												<AlignChild>No</AlignChild>

--- a/eval/goldens/L3-form-detailstransaction/README.md
+++ b/eval/goldens/L3-form-detailstransaction/README.md
@@ -1,0 +1,28 @@
+# Golden: L3-form-detailstransaction
+
+## Hand-correction 2026-09-01: the writer changed under this golden
+
+PR #984 fixed two defects in the form pattern templates, and this golden was
+captured before them — so it asserted the OLD, defective output as the expected
+answer, and a faithful rerun would have scored `golden_match: 0` against its own
+correct result.
+
+Changed here, mechanically and by hand (NOT a re-capture):
+
+- `Header` → `@SYS101051`, `Lines` → `@SYS15451`, `Line details` → `@SYS23823`, `General` ×2 → `@SYS2952`
+
+Both transformations are deterministic consequences of the writer fix, which is
+why they were applied rather than re-captured:
+
+- **Captions.** `<Caption>` holding raw text is `BPErrorLabelIsText`, and
+  untranslatable. Each replacement id is the exact text in ApplicationPlatform's
+  `SYS.en-us.label.txt` and the most-used caption of that wording across a census
+  of shipped Foundation forms (#980).
+- **Element order.** AOT XML is order-sensitive and the deserializer drops a
+  misplaced element in silence: with `<DataGroup>`/`<DataSource>` above
+  `<Controls>`, the metadata provider read the group with NO children. Verified
+  against the live provider on the VM — same file, only those two lines moved:
+  14 controls before, 16 after (#979).
+
+`tests/eval/goldenFormIntegrity.test.ts` now fails on either shape, so a golden
+captured from a defective writer cannot enshrine the defect again.

--- a/eval/goldens/L3-numberseq-module-slice/ConDemoSliceParametersForm.AxForm.metadata.xml
+++ b/eval/goldens/L3-numberseq-module-slice/ConDemoSliceParametersForm.AxForm.metadata.xml
@@ -112,7 +112,7 @@ public class ConDemoSliceParametersForm extends FormRun
 										</AxFormControl>
 									</Controls>
 									<ColumnsMode>Fill</ColumnsMode>
-									<Caption>General</Caption>
+									<Caption>@SYS2952</Caption>
 								</AxFormControl>
 							</Controls>
 							<Style>FastTabs</Style>
@@ -187,7 +187,7 @@ public class ConDemoSliceParametersForm extends FormRun
 										</AxFormControl>
 									</Controls>
 									<ColumnsMode>Fill</ColumnsMode>
-									<Caption>Setup</Caption>
+									<Caption>@SYS2186</Caption>
 								</AxFormControl>
 							</Controls>
 							<Style>FastTabs</Style>

--- a/eval/goldens/L3-numberseq-module-slice/README.md
+++ b/eval/goldens/L3-numberseq-module-slice/README.md
@@ -1,0 +1,28 @@
+# Golden: L3-numberseq-module-slice
+
+## Hand-correction 2026-09-01: the writer changed under this golden
+
+PR #984 fixed two defects in the form pattern templates, and this golden was
+captured before them — so it asserted the OLD, defective output as the expected
+answer, and a faithful rerun would have scored `golden_match: 0` against its own
+correct result.
+
+Changed here, mechanically and by hand (NOT a re-capture):
+
+- `<Caption>General</Caption>` → `@SYS2952`, `<Caption>Setup</Caption>` → `@SYS2186`
+
+Both transformations are deterministic consequences of the writer fix, which is
+why they were applied rather than re-captured:
+
+- **Captions.** `<Caption>` holding raw text is `BPErrorLabelIsText`, and
+  untranslatable. Each replacement id is the exact text in ApplicationPlatform's
+  `SYS.en-us.label.txt` and the most-used caption of that wording across a census
+  of shipped Foundation forms (#980).
+- **Element order.** AOT XML is order-sensitive and the deserializer drops a
+  misplaced element in silence: with `<DataGroup>`/`<DataSource>` above
+  `<Controls>`, the metadata provider read the group with NO children. Verified
+  against the live provider on the VM — same file, only those two lines moved:
+  14 controls before, 16 after (#979).
+
+`tests/eval/goldenFormIntegrity.test.ts` now fails on either shape, so a golden
+captured from a defective writer cannot enshrine the defect again.

--- a/eval/goldens/L4-headerlines-document-slice/ConDemoRentAgreement.metadata.xml
+++ b/eval/goldens/L4-headerlines-document-slice/ConDemoRentAgreement.metadata.xml
@@ -308,7 +308,7 @@ public class ConDemoRentAgreement extends FormRun
 															</AxFormControl>
 														</Controls>
 														<ColumnsMode>Fill</ColumnsMode>
-														<Caption>Header</Caption>
+														<Caption>@SYS101051</Caption>
 														<FastTabExpanded>No</FastTabExpanded>
 													</AxFormControl>
 													<AxFormControl xmlns=""
@@ -409,7 +409,7 @@ public class ConDemoRentAgreement extends FormRun
 																<VisibleRowsMode>Fixed</VisibleRowsMode>
 															</AxFormControl>
 														</Controls>
-														<Caption>Lines</Caption>
+														<Caption>@SYS15451</Caption>
 														<FastTabExpanded>Always</FastTabExpanded>
 													</AxFormControl>
 													<AxFormControl xmlns=""
@@ -494,14 +494,14 @@ public class ConDemoRentAgreement extends FormRun
 																			</AxFormControl>
 																		</Controls>
 																		<ColumnsMode>Fill</ColumnsMode>
-																		<Caption>General</Caption>
+																		<Caption>@SYS2952</Caption>
 																	</AxFormControl>
 																</Controls>
 																<AlignChild>No</AlignChild>
 																<Style>Tabs</Style>
 															</AxFormControl>
 														</Controls>
-														<Caption>Line details</Caption>
+														<Caption>@SYS23823</Caption>
 														<DataSource>ConDemoRentLine</DataSource>
 														<FastTabExpanded>No</FastTabExpanded>
 													</AxFormControl>
@@ -595,7 +595,7 @@ public class ConDemoRentAgreement extends FormRun
 															</AxFormControl>
 														</Controls>
 														<ColumnsMode>Fill</ColumnsMode>
-														<Caption>General</Caption>
+														<Caption>@SYS2952</Caption>
 													</AxFormControl>
 												</Controls>
 												<AlignChild>No</AlignChild>

--- a/eval/goldens/L4-headerlines-document-slice/README.md
+++ b/eval/goldens/L4-headerlines-document-slice/README.md
@@ -89,3 +89,30 @@ three `BPErrorTablePrimaryKeyEditable` and two
 `BPErrorEDTNotMigrated` / `BPUpgradeMetadataEDTRelation` are inherent to the
 case-mandated standard `CustAccount` EDT. They are recorded rather than hidden:
 the golden is what the tools produce today.
+
+## Hand-correction 2026-09-01: the writer changed under this golden
+
+PR #984 fixed two defects in the form pattern templates, and this golden was
+captured before them — so it asserted the OLD, defective output as the expected
+answer, and a faithful rerun would have scored `golden_match: 0` against its own
+correct result.
+
+Changed here, mechanically and by hand (NOT a re-capture):
+
+- `Header` → `@SYS101051`, `Lines` → `@SYS15451`, `Line details` → `@SYS23823`, `General` ×2 → `@SYS2952`
+
+Both transformations are deterministic consequences of the writer fix, which is
+why they were applied rather than re-captured:
+
+- **Captions.** `<Caption>` holding raw text is `BPErrorLabelIsText`, and
+  untranslatable. Each replacement id is the exact text in ApplicationPlatform's
+  `SYS.en-us.label.txt` and the most-used caption of that wording across a census
+  of shipped Foundation forms (#980).
+- **Element order.** AOT XML is order-sensitive and the deserializer drops a
+  misplaced element in silence: with `<DataGroup>`/`<DataSource>` above
+  `<Controls>`, the metadata provider read the group with NO children. Verified
+  against the live provider on the VM — same file, only those two lines moved:
+  14 controls before, 16 after (#979).
+
+`tests/eval/goldenFormIntegrity.test.ts` now fails on either shape, so a golden
+captured from a defective writer cannot enshrine the defect again.

--- a/tests/eval/goldenFormIntegrity.test.ts
+++ b/tests/eval/goldenFormIntegrity.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Committed goldens must be documents the platform can actually read in full.
+ *
+ * A golden is the oracle: whatever it contains is what a faithful rerun is
+ * scored against. So a golden captured from a defective writer does not just sit
+ * there — it makes the defect the expected answer, and a later fix reads as a
+ * regression.
+ *
+ * Both checks here were written after that happened. The 2026-09-01 writer fixes
+ * (#984) changed form scaffolding in two ways, and eight committed goldens
+ * encoded the OLD output:
+ *
+ *   • 18 raw-text captions across 7 goldens — every one of them a
+ *     BPErrorLabelIsText the scaffold used to write.
+ *   • L1-form-simplelistdetails carried the #979 defect itself: its `Overview`
+ *     group put <DataGroup>/<DataSource> above <Controls>, so the metadata
+ *     provider read that form two controls short. The golden was a form the
+ *     compiler could not fully see.
+ *
+ * Nothing failed at the time — the cost would have landed on the next VM capture
+ * run, as seven cases scoring golden_match: 0 against their own corrected
+ * output. These two tests move that discovery to CI.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import { findControlElementOrderViolations } from '../../src/validation/formControlElementOrder';
+import { CAPTION_LABELS } from '../../src/utils/formPatternTemplates';
+
+const GOLDENS = path.join(process.cwd(), 'eval', 'goldens');
+
+/** Every committed golden artifact that contains form controls. */
+function formGoldens(): Array<{ id: string; file: string; xml: string }> {
+  const out: Array<{ id: string; file: string; xml: string }> = [];
+  for (const caseId of fs.readdirSync(GOLDENS).sort()) {
+    const dir = path.join(GOLDENS, caseId);
+    if (!fs.statSync(dir).isDirectory()) continue;
+    for (const file of fs.readdirSync(dir).filter(f => f.endsWith('.metadata.xml'))) {
+      const xml = fs.readFileSync(path.join(dir, file), 'utf-8');
+      if (!/<(?:AxFormControl|FormControl)[\s>]/.test(xml)) continue;
+      out.push({ id: caseId, file, xml });
+    }
+  }
+  return out;
+}
+
+describe('golden form artifacts', () => {
+  it('is actually looking at the goldens', () => {
+    // A broken path would make both checks below pass forever.
+    expect(formGoldens().length).toBeGreaterThan(15);
+  });
+
+  it('none carries an element the metadata deserializer would drop', () => {
+    const broken: string[] = [];
+    for (const g of formGoldens()) {
+      const dropped = findControlElementOrderViolations(g.xml).filter(v => v.kind === 'order');
+      for (const v of dropped) {
+        broken.push(
+          `${g.id}/${g.file}:${v.line} — ${v.controlType} "${v.controlName}": ` +
+          `<${v.element}> before <${v.beforeElement}>`,
+        );
+      }
+    }
+    expect(
+      broken,
+      'A golden with an out-of-order element asserts, as the expected answer, a document the ' +
+      'compiler reads differently from the file. Re-capture it, or correct the order — the ' +
+      'canonical sequence per control type is in src/validation/formControlElementOrder.generated.ts.',
+    ).toEqual([]);
+  });
+
+  it('none asserts a raw-text caption the templates no longer write', () => {
+    // Only the captions the pattern templates own. A caption a CASE deliberately
+    // sets is the case's business and is not policed here.
+    const owned = new Set(Object.keys(CAPTION_LABELS).map(k => k));
+    const byText: Record<string, string> = {
+      General: 'general', Overview: 'overview', Header: 'header', Lines: 'lines',
+      'Line details': 'lineDetails', Setup: 'setup', Summary: 'summary',
+    };
+    const stale: string[] = [];
+    for (const g of formGoldens()) {
+      for (const m of g.xml.matchAll(/<Caption>([^<@][^<]*)<\/Caption>/g)) {
+        const key = byText[m[1]];
+        if (key && owned.has(key)) {
+          stale.push(`${g.id}/${g.file}: <Caption>${m[1]}</Caption> — expected ${CAPTION_LABELS[key as keyof typeof CAPTION_LABELS]}`);
+        }
+      }
+    }
+    expect(
+      stale,
+      'The pattern templates write platform label ids for these captions (#980). A golden still ' +
+      'asserting the raw text scores golden_match: 0 against correct output, and enshrines a ' +
+      'BPErrorLabelIsText as the expected answer.',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Found by running the **eval tooling** after the 2026-09-01 writer fixes, not just the unit tests —
which were green throughout, and would have stayed green while the eval suite regressed.

## The problem

#984 changed form scaffolding in two ways. Eight committed goldens were captured *before* it, so
they now assert the **old, defective output** as the expected answer. Nothing fails today: the
cost lands on the next VM capture run, as seven cases scoring `golden_match: 0` against their own
**correct** result — and the natural reading of that would be "the fix regressed the eval suite".

Checked before concluding it was real:

* the oracle normalises nothing about `<Caption>` and no case-spec ignore list mentions it, so a
  caption change is a genuine mismatch;
* none of the seven case specs requires a raw caption — the one that *mentions* captions mandates
  the **Design** caption `@TaxTransactionInquiry:HeaderNote`, which is a label and unaffected.

## What changed — 20 lines across 7 artifacts

**18 raw-text captions** → the platform label ids the templates now write (`@SYS2952` General,
`@SYS9039` Overview, `@SYS101051` Header, `@SYS15451` Lines, `@SYS23823` Line details, `@SYS2186`
Setup), in `L1-form-detailsmaster`, `L1-form-simplelistdetails`, `L1-form-tableofcontents`,
`L3-enum-field-form-downgrade-guard`, `L3-form-detailstransaction`, `L3-numberseq-module-slice`,
`L4-headerlines-document-slice`.

**`L1-form-simplelistdetails` additionally carried the #979 defect itself.** Its `Overview` group
put `<DataGroup>`/`<DataSource>` above `<Controls>`, so the metadata provider read that form **two
controls short**. That golden was not merely stale — it was a document the compiler could not
fully see, asserted as correct.

## Why hand-corrected rather than re-captured

Both transformations are deterministic consequences of the writer fix:

* **Captions** — each id is the exact text in ApplicationPlatform's `SYS.en-us.label.txt` *and* the
  most-used caption of that wording across a census of shipped Foundation forms.
* **Element order** — verified against the live provider on the VM: same file, only those two lines
  moved, 14 controls before and 16 after.

Every affected golden's README records the edit, following the convention
`L4-headerlines-document-slice` already set for hand-repaired bytes.

## The ratchet

`tests/eval/goldenFormIntegrity.test.ts`: no committed golden may carry an element the
deserializer would drop, and none may assert a raw-text caption the templates own. A golden
captured from a defective writer cannot enshrine the defect again — which is exactly this episode.

## Verification

* `tsc --noEmit` clean; `biome lint` clean.
* `vitest run` — **393 files, 5,869 passed**, 2 skipped.
* `eval:coverage` — core 65/65, total 109/109, closure queue 0 (unchanged).
* `eval:report` — 117 runs, build=95% bp=52% golden=75% (unchanged; goldens are the oracle, not
  the corpus, so no recorded score moves).
* Diff is 20 lines, no line-ending churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULksCPwMoC6txP49NsnqT
