### PR TITLE
The tool list did not offer what the handler accepts, and the order message said the opposite of the fix

### DIFF
--- a/src/server/toolSchemas/prepare.ts
+++ b/src/server/toolSchemas/prepare.ts
@@ -31,7 +31,7 @@ export const prepareTool = {
         },
         objectName: {
           type: 'string',
-          description: '[change] Name of the object to extend/modify (e.g. "CustTable"). [create] Proposed BASE name WITHOUT model prefix (same value you would pass to d365fo_file create).',
+          description: '[change] Name of the object to extend/modify (e.g. "CustTable"). [create] Proposed BASE name WITHOUT model prefix.',
         },
         objectType: {
           type: 'string',
@@ -41,8 +41,15 @@ export const prepareTool = {
             'menu-item-output', 'menu', 'security-privilege', 'security-duty', 'security-role',
             'business-event', 'tile', 'kpi', 'service', 'service-group',
             'macro', 'configuration-key', 'security-policy', 'aggregate-measurement', 'license-code',
+            // Extension artefacts, published here as well as in prepareCreate's zod
+            // schema. #983 added them to the zod schema only — the handler accepted
+            // them and the tool list did not offer them, so an agent still could not
+            // pick one. That is the very disagreement #983 was filed about, one level
+            // up. tests/server/toolSchemaAgreement.test.ts now pins the two together.
+            'table-extension', 'class-extension', 'form-extension', 'enum-extension', 'edt-extension',
           ],
-          description: '[change] D365FO object type — auto-detected when omitted. [create] REQUIRED — type of the new object.',
+          description:
+            '[change] type — auto-detected when omitted. [create] REQUIRED; an extension is Base.Suffix.',
         },
         methodName: {
           type: 'string',
@@ -53,7 +60,7 @@ export const prepareTool = {
           // Comma-separated rather than a second array parameter: a table change
           // is normally add-field AND add-index AND add-field-to-field-group, and
           // one clause here is far cheaper per session than another schema block.
-          description: '[change] The modify operation(s) you intend to run — comma-separated for several ("add-field,add-index"). Their full parameter contracts come back in THIS response, so no separate op-spec call. Defaults to add-method when methodName is given.',
+          description: '[change] The modify operation(s) you intend to run — comma-separated for several ("add-field,add-index"). Their full parameter contracts come back in THIS response. Defaults to add-method when methodName is given.',
         },
         proposedName: {
           type: 'string',

--- a/src/server/toolSchemas/validateCode.ts
+++ b/src/server/toolSchemas/validateCode.ts
@@ -27,7 +27,7 @@ export const validateCodeTool = {
           type: 'string',
           enum: ['xpp', 'xml-table', 'xml-form', 'xml-any', 'xml-report'],
           default: 'xpp',
-          description: '[syntax] "xpp" X++ source (default), "xml-table" AxTable, "xml-form" AxForm/AxFormExtension, "xml-report" AxReport, "xml-any" other XML.',
+          description: '[syntax] "xpp" X++ (default), "xml-table" AxTable, "xml-form" AxForm(+Extension), "xml-report" AxReport, "xml-any" other.',
         },
         context: {
           type: 'string',

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -2527,11 +2527,12 @@ function checkFormControlElementOrder(code: string): ValidationViolation[] {
       rule: 'XML010',
       severity: 'error' as const,
       line: v.line,
-      excerpt: `${v.controlType} "${v.controlName}": <${v.element}> appears before <${v.beforeElement}>`,
+      excerpt: `${v.controlType} "${v.controlName}": <${v.element}> is written after <${v.beforeElement}>`,
       fix:
         `AxForm XML is order-sensitive and a misordered element is dropped SILENTLY — ` +
         `anything under a dropped <Controls> is in the file and invisible to the compiler. ` +
-        `Move <${v.element}> after <${v.beforeElement}>. The canonical sequence per control ` +
+        `Move <${v.element}> BEFORE <${v.beforeElement}> (equivalently: move <${v.beforeElement}> ` +
+        `down past it). The canonical sequence per control ` +
         `type is in src/validation/formControlElementOrder.generated.ts (e.g. on a group ` +
         `control, <DataGroup> and <DataSource> come AFTER </Controls>).`,
     }));

--- a/src/validation/formControlElementOrder.ts
+++ b/src/validation/formControlElementOrder.ts
@@ -42,8 +42,14 @@ export interface ElementOrderViolation {
   /** The element that appears too early. */
   element: string;
   /**
-   * The element it wrongly precedes, or `null` for an `unknown` violation —
-   * one this control type carries nowhere in the census.
+   * The element `element` must come BEFORE but was written AFTER, or `null` for
+   * an `unknown` violation — one this control type carries nowhere in the census.
+   *
+   * The name reads as "the element this one belongs before". Getting the
+   * DIRECTION right in the message matters more than it looks: the first version
+   * said `<element> must come AFTER <beforeElement>`, which is the exact opposite
+   * of the fix, and it shipped — the tests pinned the wrong string, so only
+   * reading the live tool output caught it.
    */
   beforeElement: string | null;
   /**
@@ -215,7 +221,7 @@ export function formatElementOrderViolations(violations: ElementOrderViolation[]
     .map((v) =>
       v.kind === 'order'
         ? `🔴 [ORDER] ${v.controlType} "${v.controlName}" line ${v.line}: ` +
-          `<${v.element}> must come AFTER <${v.beforeElement}> — ` +
+          `<${v.element}> is written after <${v.beforeElement}>, but must come BEFORE it — ` +
           `the metadata deserializer drops out-of-order elements silently.`
         : `🟠 [UNKNOWN] ${v.controlType} "${v.controlName}" line ${v.line}: ` +
           `<${v.element}> appears on no ${v.controlType} in shipped metadata — ` +

--- a/tests/server/toolSchemaAgreement.test.ts
+++ b/tests/server/toolSchemaAgreement.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The PUBLISHED tool schema and the handler's own schema must agree.
+ *
+ * A tool has two descriptions of its arguments: `src/server/toolSchemas/*.ts`,
+ * which is what ListTools sends to the client and therefore what an agent can
+ * actually choose from, and the zod schema in the handler, which is what the
+ * call is validated against. Nothing tied them together.
+ *
+ * That bit immediately. #983 was filed because `prepare` refused the only name an
+ * enum extension can have while `d365fo_file` published `enum-extension` happily
+ * — two tools disagreeing about what exists. The fix added the extension types to
+ * prepareCreate's ZOD schema and its tests passed, because they call the handler
+ * directly. The published schema still did not list them, so the handler accepted
+ * a value the tool list never offered: the same disagreement, one level up, and
+ * invisible until the MCP server was reconnected and its real schema read back.
+ *
+ * These tests compare the two enums directly. They are deliberately about the
+ * arguments an agent PICKS FROM — a published enum missing a value the handler
+ * accepts is a capability nobody can reach.
+ */
+import { describe, it, expect } from 'vitest';
+import { prepareTool } from '../../src/server/toolSchemas/prepare';
+import { validateCodeTool } from '../../src/server/toolSchemas/validateCode';
+import { prepareCreateArgsSchema } from '../../src/tools/prepare/prepareCreate';
+import { prepareChangeArgsSchema } from '../../src/tools/prepare/prepareChange';
+import { validateXppArgsSchema } from '../../src/tools/analysis/validateXpp';
+
+/** The string values of a zod enum field, however it is wrapped (optional/default). */
+function zodEnumValues(field: unknown): string[] {
+  let def = (field as { _def?: Record<string, unknown> })._def;
+  while (def && !def.values && !def.entries) {
+    const inner = (def.innerType ?? def.schema) as { _def?: Record<string, unknown> } | undefined;
+    if (!inner?._def) break;
+    def = inner._def;
+  }
+  const values = (def?.values ?? def?.entries) as string[] | Record<string, string> | undefined;
+  if (!values) throw new Error('not a zod enum');
+  return Array.isArray(values) ? [...values] : Object.values(values);
+}
+
+const publishedEnum = (tool: { inputSchema: any }, prop: string): string[] =>
+  tool.inputSchema.properties[prop].enum;
+
+describe('published tool schema vs handler schema', () => {
+  it('prepare publishes every objectType its handlers accept', () => {
+    const published = new Set(publishedEnum(prepareTool, 'objectType'));
+    const accepted = new Set([
+      ...zodEnumValues(prepareCreateArgsSchema.shape.objectType),
+      ...zodEnumValues(prepareChangeArgsSchema.shape.objectType),
+    ]);
+    const unreachable = [...accepted].filter(v => !published.has(v)).sort();
+    expect(
+      unreachable,
+      'These objectTypes are accepted by the handler but absent from the tool list, so no agent ' +
+      'can choose them — a capability that exists and cannot be reached.',
+    ).toEqual([]);
+  });
+
+  it('prepare does not advertise an objectType its handlers would reject', () => {
+    const accepted = new Set([
+      ...zodEnumValues(prepareCreateArgsSchema.shape.objectType),
+      ...zodEnumValues(prepareChangeArgsSchema.shape.objectType),
+    ]);
+    const rejected = publishedEnum(prepareTool, 'objectType').filter(v => !accepted.has(v)).sort();
+    expect(rejected, 'Advertised in the tool list but rejected on arrival.').toEqual([]);
+  });
+
+  it('validate_code publishes exactly the codeTypes its handler accepts', () => {
+    expect(publishedEnum(validateCodeTool, 'codeType').sort())
+      .toEqual(zodEnumValues(validateXppArgsSchema.shape.codeType).sort());
+  });
+
+  it('specifically: the extension types #983 added are reachable from the tool list', () => {
+    const published = publishedEnum(prepareTool, 'objectType');
+    for (const t of ['enum-extension', 'table-extension', 'form-extension', 'edt-extension', 'class-extension']) {
+      expect(published, t).toContain(t);
+    }
+  });
+});

--- a/tests/tools/formInfoElementOrder.test.ts
+++ b/tests/tools/formInfoElementOrder.test.ts
@@ -98,7 +98,7 @@ describe('XML path — the reader holds the evidence', () => {
     const text = res.content[0].text as string;
 
     expect(text).toMatch(/written out of order/);
-    expect(text).toMatch(/<Controls> must come AFTER <DataSource>/);
+    expect(text).toMatch(/<Controls> is written after <DataSource>, but must come BEFORE it/);
     expect(text).toMatch(/Overview/);
     // It must point at the fix, not just at the problem.
     expect(text).toMatch(/formControlElementOrder\.generated/);
@@ -142,7 +142,7 @@ describe('bridge path — cross-checked against the file', () => {
     const text = res.content[0].text as string;
     expect(text).toMatch(/holds 3 controls; the metadata provider reports 1/);
     expect(text).toMatch(/invisible to the platform/);
-    expect(text).toMatch(/<Controls> must come AFTER <DataSource>/);
+    expect(text).toMatch(/<Controls> is written after <DataSource>, but must come BEFORE it/);
   });
 
   it('stays quiet when the two agree', async () => {

--- a/tests/tools/formModifyOrderVerification.test.ts
+++ b/tests/tools/formModifyOrderVerification.test.ts
@@ -39,7 +39,7 @@ describe('verifyFormElementOrder', () => {
     vi.mocked(readFile).mockResolvedValue(BROKEN as never);
     const note = await verifyFormElementOrder('K:/pkg/AxForm/F.xml', 'form');
     expect(note).toMatch(/will DROP silently/);
-    expect(note).toMatch(/<Controls> must come AFTER <DataSource>/);
+    expect(note).toMatch(/<Controls> is written after <DataSource>, but must come BEFORE it/);
     // It must name the remedy and own the fault — the caller did not do this.
     expect(note).toMatch(/undo_last_modification/);
     expect(note).toMatch(/defect in the write, not in your request/);

--- a/tests/utils/toolSchemaBudget.test.ts
+++ b/tests/utils/toolSchemaBudget.test.ts
@@ -169,6 +169,14 @@ const CHARS_PER_TOKEN = 4;
 // op-spec pointer that the tool description already carries. 73 chars of new
 // enum, 138 chars of restatement removed. Measured payload after: 44_936 —
 // below where it stood before the patterns were added.
+//
+// Then `prepare` published the five extension objectTypes (#983 — the handler
+// accepted them while the tool list did not offer them), paid for the same way
+// inside prepare's own schema: `operation` said the parameter contracts come
+// back in this response AND "so no separate op-spec call", and `objectName`
+// carried a cross-reference to d365fo_file that an agent at that point in the
+// flow does not need. ~100 chars of new enum, ~150 of restatement and prose
+// removed. Measured payload after: 44_951.
 const TOTAL_BUDGET = 45_000;
 const LARGEST_TOOL_BUDGET = 5_700;
 

--- a/tests/validation/formControlElementOrder.test.ts
+++ b/tests/validation/formControlElementOrder.test.ts
@@ -84,7 +84,11 @@ describe('findControlElementOrderViolations', () => {
     expect(controlsFinding).toBeDefined();
     expect(controlsFinding!.controlName).toBe('Overview');
     expect(controlsFinding!.controlType).toBe('AxFormGroupControl');
-    expect(formatElementOrderViolations(v)).toContain('must come AFTER');
+    // The DIRECTION is the whole point of the message: the misplaced element must
+    // come BEFORE the one it was written after. The first version said the
+    // opposite and shipped, because this assertion pinned the wrong string.
+    expect(formatElementOrderViolations(v)).toContain('must come BEFORE it');
+    expect(formatElementOrderViolations(v)).not.toContain('must come AFTER');
   });
 
   it('accepts the same control once the two lines move below </Controls>', () => {
@@ -196,7 +200,7 @@ describe('gateOnControlElementOrder', () => {
     const text = gate.blocked!.content[0].text;
     expect(text).toMatch(/blocked/);
     expect(text).toMatch(/DROPS those silently/);
-    expect(text).toMatch(/<Controls> must come AFTER <DataSource>/);
+    expect(text).toMatch(/<Controls> is written after <DataSource>, but must come BEFORE it/);
     // It must say how to bypass, like the pattern gate does.
     expect(text).toMatch(/FORM_PATTERN_ENFORCE=false/);
   });


### PR DESCRIPTION
Two defects, both **mine**, both found only by reconnecting the MCP server and reading its real
output. Neither was reachable from the unit tests.

## 1. #983's fix was half-applied — the tool list never offered what the handler accepts

A tool has two descriptions of its arguments:

* `src/server/toolSchemas/*.ts` — what ListTools sends the client, and therefore **what an agent
  can choose from**;
* the zod schema in the handler — what the call is **validated against**.

Nothing tied them together. #983 added the five extension objectTypes to `prepareCreate`'s **zod**
schema only. Its test passed because it calls the handler directly and asserted against that same
zod schema — the wrong source of truth. The published enum still had no extension type, so the
handler accepted a value the tool list never offered.

That is the disagreement #983 was filed about, one level up: *"two tools disagreeing about what
exists"* became *"one tool disagreeing with itself"*.

`tests/server/toolSchemaAgreement.test.ts` now compares the published enums against the handlers'
for `prepare` and `validate_code`, in **both** directions — accepted-but-unpublished is a
capability nobody can reach, published-but-rejected is a promise broken on arrival. Verified to
fail without the fix (2 of 4 tests red).

## 2. The element-order message told the caller to do the opposite of the fix

The finding pairs the misplaced element with the one it was written after, and the message
rendered that as:

```
<Controls> must come AFTER <DataSource>
```

The canonical order — and the parenthetical in the very same message — put `Controls` **before**
it. Detection was always right; only the remediation was inverted, and it was inverted everywhere
at once: the reader warning (#988), the write gate and XML010 (#990).

It shipped because four assertions pinned the inverted string verbatim. They now pin the
direction, and one asserts the old wording is **absent**.

```
<Controls> is written after <DataSource>, but must come BEFORE it
```

## Budget

The 5 new enum values are paid for inside `prepare`'s own schema, per the rule the ratchet states
— `operation` said the contracts come back in this response **and** "so no separate op-spec call";
`objectName` carried a cross-reference to `d365fo_file` an agent does not need at that point.
~100 chars of enum in, ~150 of restatement out. ListTools measures **44,951** against its 45,000
ceiling, and the accounting is recorded in the ratchet's own comment.

## Verification

* `tsc --noEmit` clean; `biome lint` clean.
* `vitest run` — **395 files, 5,890 passed**, 2 skipped.
* Rebased onto `main` after #992; the branch touches only its own 9 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULksCPwMoC6txP49NsnqT
