### PR TITLE
Ground an extension in the object it extends, and stop the index vetoing the bridge

### DIFF
--- a/src/tools/prepare/prepareCreate.ts
+++ b/src/tools/prepare/prepareCreate.ts
@@ -115,6 +115,14 @@ async function validateNaming(
   objectType: string,
   modelName: string | undefined,
   context: XppServerContext,
+  /**
+   * Whether the object an extension EXTENDS exists, as answered by the metadata
+   * provider. `undefined` leaves the shared rules to probe the symbol index, which
+   * is the only option without a bridge — and is wrong on an index scoped to
+   * custom models, where a Microsoft base reads as "not found — ensure it's
+   * indexed" and no amount of re-indexing will change that.
+   */
+  baseObjectExists?: boolean,
 ): Promise<string> {
   const issues: string[] = [];
   if (finalName.length > 81) {
@@ -163,6 +171,7 @@ async function validateNaming(
       proposedName: baseName,
       objectType,
       modelName,
+      baseObjectExists,
     });
   } catch {
     // index unavailable
@@ -312,6 +321,106 @@ function minedPropertyDefaults(objectType: string, context: XppServerContext): s
   return '(no mined statistics — run build-database to mine standard models)';
 }
 
+/** Extension objectType → the type of the object it extends. */
+const EXTENSION_BASE_TYPE: Record<string, string> = {
+  'table-extension': 'table',
+  'class-extension': 'class',
+  'form-extension': 'form',
+  'enum-extension': 'enum',
+  'edt-extension': 'edt',
+};
+
+/**
+ * What the caller needs to know about the object an extension EXTENDS.
+ *
+ * Publishing the extension objectTypes (#983) made the write reachable; it did
+ * not make it grounded. Everything that decides whether an enum extension can
+ * work at all lives on the BASE: it has to exist, it has to be extensible (a
+ * sealed enum cannot be extended at all), and a member name already on it is a
+ * build error, not a merge. `prepare(mode="change")` is built around reading the
+ * base object; `prepare(mode="create")` was not, so the one call an agent makes
+ * before writing an extension said nothing about the thing being extended.
+ *
+ * Asked of the BRIDGE first, and that is the point. The existence check in
+ * `checkObjectNaming` reads the symbol index, while `search`, `get_object_info`
+ * and the write path all prefer the metadata provider. On an instance indexed
+ * with `extractMode: "custom"` the index deliberately holds only custom models,
+ * so the index answer for a Microsoft base enum is "not found — ensure it's
+ * indexed": false, and advice that re-indexing can never satisfy.
+ */
+async function describeExtensionBase(
+  baseName: string,
+  objectType: string,
+  context: XppServerContext,
+): Promise<{ exists: boolean | undefined; text: string }> {
+  const baseType = EXTENSION_BASE_TYPE[objectType];
+  if (!baseType || !baseName) return { exists: undefined, text: '' };
+
+  const bridge = context.bridge;
+  const bridgeUsable = Boolean(bridge?.isReady && bridge?.metadataAvailable);
+
+  if (bridgeUsable && baseType === 'enum') {
+    try {
+      const info = await bridge!.readEnum(baseName);
+      if (info) {
+        const taken = info.values.map(v => v.name);
+        const lines = [
+          `\`${info.name}\`${info.model ? ` (${info.model})` : ''} — **Extensible: ${info.isExtensible ? 'Yes' : 'NO'}**`,
+        ];
+        if (!info.isExtensible) {
+          lines.push(
+            '🔴 A non-extensible enum CANNOT be extended — the write will not build. ' +
+            'Add the member to the enum itself, or ask the owner to mark it extensible.',
+          );
+        }
+        if (taken.length > 0) {
+          lines.push(
+            `Member names already taken (${taken.length}): ${taken.join(', ')} — ` +
+            'reusing one is a build error, not a merge.',
+          );
+        }
+        return { exists: true, text: lines.join(String.fromCharCode(10)) };
+      }
+      return {
+        exists: false,
+        text: `🔴 \`${baseName}\` does not exist as an enum (checked via the metadata provider) — ` +
+          'an extension of a missing object cannot build.',
+      };
+    } catch {
+      /* fall through to the generic probe */
+    }
+  }
+
+  if (bridgeUsable) {
+    try {
+      const resolved = await bridge!.resolveObjectInfo(baseType, baseName);
+      if (resolved) {
+        return resolved.exists
+          ? { exists: true, text: `\`${baseName}\`${resolved.model ? ` (${resolved.model})` : ''} — exists.` }
+          : {
+              exists: false,
+              text: `🔴 \`${baseName}\` does not exist as a ${baseType} (checked via the metadata provider).`,
+            };
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  // No bridge: the index is all there is, and it may be scoped to custom models.
+  try {
+    const hit = lookupSymbolsNocase(context.symbolIndex.getReadDb(), baseName, { types: [baseType], limit: 1 })[0];
+    if (hit) return { exists: true, text: `\`${baseName}\` (${hit.model ?? '?'}) — found in the symbol index.` };
+  } catch {
+    /* index unavailable */
+  }
+  return {
+    exists: undefined,
+    text: `\`${baseName}\` — could not be verified (the C# bridge is not available and the symbol ` +
+      'index has no matching ' + baseType + '; an index built with extractMode "custom" holds only custom models).',
+  };
+}
+
 export async function prepareCreateTool(request: any, context: XppServerContext): Promise<any> {
   const raw = request?.params?.arguments ?? request;
   const parsed = prepareCreateArgsSchema.safeParse(raw);
@@ -333,9 +442,15 @@ export async function prepareCreateTool(request: any, context: XppServerContext)
   // a name that never gets written, so a real collision read as "No collision".
   const finalName = normalizeObjectName(objectName, objectType, modelName);
 
+  // For an extension type, the BASE object decides whether the write can work at
+  // all — so it is resolved FIRST and its verdict feeds the naming check, which
+  // would otherwise answer from the symbol index alone (#983 follow-up).
+  const baseObjectName = objectName.includes('.') ? objectName.slice(0, objectName.indexOf('.')) : '';
+  const base = await describeExtensionBase(baseObjectName, objectType, context);
+
   // Naming is the one asynchronous check (the shared rules await model detection),
   // so it is started first and collected below — the rest still run in one tick.
-  const namingPromise = validateNaming(objectName, finalName, objectType, modelName, context);
+  const namingPromise = validateNaming(objectName, finalName, objectType, modelName, context, base.exists);
 
   // All lookups are synchronous index queries — run them in one tick.
   const [collisions, naming, similar, edts, labels, propertyDefaults] = [
@@ -380,7 +495,10 @@ export async function prepareCreateTool(request: any, context: XppServerContext)
   // cached context.
   lines.push(
     `Next: call \`d365fo_file(action="create", objectType="${objectType}", objectName="${objectName}", groundingToken=...)\` ` +
-    '— pass the BASE name, the prefix is applied for you. Syntax/BP linting and (under GROUNDING_ENFORCE=true) ' +
+    (objectName.includes('.')
+      ? '— the name is written as given; only the suffix after the dot is yours to choose. '
+      : '— pass the BASE name, the prefix is applied for you. ') +
+    'Syntax/BP linting and (under GROUNDING_ENFORCE=true) ' +
     'reference resolution run INSIDE that call, so no separate validate_code round trip is needed; ' +
     'use `validate_code(mode="both")` only as an optional pre-check on hand-written X++. ' +
     'The token is bound to this object and expires in 30 minutes.',
@@ -391,6 +509,9 @@ export async function prepareCreateTool(request: any, context: XppServerContext)
 
   lines.push('### Collision check _(symbol index)_', collisions, '');
   lines.push('### Naming', naming, '');
+  if (base.text) {
+    lines.push('### Base object _(the thing this extends)_', base.text, '');
+  }
   lines.push('### Similar existing objects _(copy patterns from these)_', similar, '');
   if (edts) {
     lines.push('### EDT suggestions for planned fields _(edt index)_', edts, '');

--- a/src/utils/objectNamingRules.ts
+++ b/src/utils/objectNamingRules.ts
@@ -98,6 +98,18 @@ export interface ObjectNamingInput {
   baseObjectName?: string;
   modelPrefix?: string;
   modelName?: string;
+  /**
+   * Whether the object an extension EXTENDS exists, already answered by a caller
+   * that has a better source than this one.
+   *
+   * These rules can only probe the SYMBOL INDEX, while `search`, `get_object_info`
+   * and the write path all prefer the C# bridge. On an instance indexed with
+   * `extractMode: "custom"` the index deliberately holds only custom models, so
+   * the index answer for a Microsoft base enum is "not found in symbol index —
+   * ensure it's indexed": false, and advice that re-indexing can never satisfy.
+   * `undefined` keeps the index probe, which is the only option without a bridge.
+   */
+  baseObjectExists?: boolean;
 }
 
 /** Every verdict the rules reach, before anything decides how to print it. */
@@ -373,14 +385,24 @@ export async function checkObjectNaming(
                 ? ['enum']
                 : ['edt'];
 
-        // Case-insensitive: the base object may be spelled with different casing
-        // than the canonical AOT name (#686).
-        const baseExists = lookupSymbolNocase(db, baseObjectName, dbTypes);
-
-        if (!baseExists) {
+        // A caller with a metadata provider has already answered this better than
+        // the index can — see ObjectNamingInput.baseObjectExists.
+        if (args.baseObjectExists === false) {
           warnings.push(
-            `Base object "${baseObjectName}" not found in symbol index for types: ${dbTypes.join(', ')}. Ensure it's indexed.`,
+            `Base object "${baseObjectName}" does not exist as a ${dbTypes.join('/')} ` +
+            `(checked against the metadata provider). An extension of a missing object cannot build.`,
           );
+        } else if (args.baseObjectExists === undefined) {
+          // Case-insensitive: the base object may be spelled with different casing
+          // than the canonical AOT name (#686).
+          const baseExists = lookupSymbolNocase(db, baseObjectName, dbTypes);
+          if (!baseExists) {
+            warnings.push(
+              `Base object "${baseObjectName}" not found in the symbol index for types: ${dbTypes.join(', ')}. ` +
+              `If the base is a standard Microsoft object this may just mean the index is scoped to custom ` +
+              `models (extractMode "custom") — confirm with get_object_info before treating it as missing.`,
+            );
+          }
         }
       }
     }

--- a/tests/tools/prepareExtensionBaseGrounding.test.ts
+++ b/tests/tools/prepareExtensionBaseGrounding.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `prepare(mode="create")` on an extension type must ground the caller in the
+ * object being EXTENDED (issue #983 follow-up, found by reading the live tool
+ * output after the fix shipped).
+ *
+ * Publishing the extension objectTypes made the write reachable; it did not make
+ * it grounded. Everything that decides whether an enum extension can work lives
+ * on the BASE: it has to exist, it has to be extensible — a sealed enum cannot be
+ * extended at all — and a member name already on it is a build error, not a
+ * merge. `prepare(mode="change")` is built around reading the base object;
+ * `prepare(mode="create")` said nothing about it, so the one call an agent makes
+ * before writing an extension covered everything except the precondition.
+ *
+ * The second half is where the answer comes FROM. `checkObjectNaming` can only
+ * probe the symbol index, while `search`, `get_object_info` and the write path
+ * all prefer the C# bridge. On the eval instance — indexed with
+ * `extractMode: "custom"`, `customModels: ["fm-mcp"]` — the index holds no
+ * standard models, so `NumberSeqModule` (ApplicationPlatform, Extensible: Yes,
+ * 7 members, read instantly by the bridge) came back as "not found in symbol
+ * index … Ensure it's indexed": false, with advice re-indexing can never satisfy.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/utils/configManager', () => ({
+  getConfigManager: vi.fn(() => ({
+    getModelName: () => 'fm-mcp',
+    getWriteAnchorModel: () => 'fm-mcp',
+    getAutoDetectedModelName: async () => 'fm-mcp',
+  })),
+}));
+
+const NUMBER_SEQ_MODULE = {
+  name: 'NumberSeqModule',
+  model: 'ApplicationPlatform',
+  isExtensible: true,
+  values: [
+    { name: 'General', value: 0 },
+    { name: 'Docu', value: 1 },
+    { name: 'Workflow', value: 3 },
+  ],
+};
+
+/** A context whose symbol index is EMPTY — as an extractMode:"custom" one is for standard models. */
+const buildContext = (bridge?: Record<string, unknown>) => {
+  const stmt = { all: vi.fn(() => []), get: vi.fn(() => undefined), run: vi.fn() };
+  const db = { prepare: vi.fn(() => stmt) };
+  return {
+    symbolIndex: { db, getReadDb: () => db } as any,
+    bridge,
+    parser: {} as any,
+    cache: {} as any,
+    workspaceScanner: {} as any,
+    hybridSearch: {} as any,
+  } as any;
+};
+
+const readyBridge = (over: Record<string, unknown> = {}) => ({
+  isReady: true,
+  metadataAvailable: true,
+  readEnum: vi.fn(async () => NUMBER_SEQ_MODULE),
+  resolveObjectInfo: vi.fn(async () => ({ exists: true, objectType: 'table', objectName: 'CustTable', model: 'ApplicationSuite' })),
+  ...over,
+});
+
+async function prepareCreate(objectName: string, objectType: string, bridge?: Record<string, unknown>) {
+  const { prepareCreateTool } = await import('../../src/tools/prepare/prepareCreate.js');
+  const res = await prepareCreateTool(
+    { params: { arguments: { goal: 'test', objectName, objectType } } },
+    buildContext(bridge),
+  );
+  return String(res.content[0].text);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('prepare(create) grounds an extension in its base object', () => {
+  it('reports the base enum, its extensibility and the member names already taken', async () => {
+    const text = await prepareCreate('NumberSeqModule.ConDemoRent', 'enum-extension', readyBridge());
+    expect(text).toContain('### Base object');
+    expect(text).toContain('NumberSeqModule');
+    expect(text).toContain('Extensible: Yes');
+    // A member name already on the base is a build error, not a merge.
+    expect(text).toMatch(/General, Docu, Workflow/);
+  });
+
+  it('does NOT claim a bridge-verified base is missing from the index', async () => {
+    // The index is empty here, exactly as an extractMode:"custom" one is for a
+    // Microsoft base. The bridge answered, so the index must not get a vote.
+    const text = await prepareCreate('NumberSeqModule.ConDemoRent', 'enum-extension', readyBridge());
+    expect(text).not.toMatch(/not found in the symbol index/);
+    expect(text).not.toMatch(/Ensure it's indexed/);
+  });
+
+  it('calls a non-extensible base what it is — the write cannot build', async () => {
+    const sealed = readyBridge({
+      readEnum: vi.fn(async () => ({ ...NUMBER_SEQ_MODULE, isExtensible: false })),
+    });
+    const text = await prepareCreate('NumberSeqModule.ConDemoRent', 'enum-extension', sealed);
+    expect(text).toContain('Extensible: NO');
+    expect(text).toMatch(/CANNOT be extended/);
+  });
+
+  it('says so plainly when the base does not exist', async () => {
+    const missing = readyBridge({ readEnum: vi.fn(async () => null) });
+    const text = await prepareCreate('NoSuchEnum.ConDemoRent', 'enum-extension', missing);
+    expect(text).toMatch(/does not exist as an enum/);
+    expect(text).toMatch(/cannot build/);
+  });
+
+  it('falls back to a generic existence probe for non-enum extension types', async () => {
+    const bridge = readyBridge();
+    const text = await prepareCreate('CustTable.ConDemoExtension', 'table-extension', bridge);
+    expect(bridge.resolveObjectInfo).toHaveBeenCalledWith('table', 'CustTable');
+    expect(text).toContain('### Base object');
+    expect(text).toContain('CustTable');
+  });
+
+  it('without a bridge, says the index may simply be scoped — not that the base is missing', async () => {
+    const text = await prepareCreate('NumberSeqModule.ConDemoRent', 'enum-extension', undefined);
+    expect(text).toMatch(/could not be verified|scoped to custom models/);
+    // The old wording told the agent to re-index, which cannot help here.
+    expect(text).not.toMatch(/Ensure it's indexed\./);
+  });
+
+  it('adds no Base object section for a non-extension type', async () => {
+    const text = await prepareCreate('ImportParameters', 'table', readyBridge());
+    expect(text).not.toContain('### Base object');
+  });
+
+  it('does not tell the caller a dotted extension name will be prefixed for them', async () => {
+    const text = await prepareCreate('NumberSeqModule.ConDemoRent', 'enum-extension', readyBridge());
+    expect(text).not.toContain('the prefix is applied for you');
+    expect(text).toMatch(/only the suffix after the dot is yours to choose/);
+  });
+});


### PR DESCRIPTION
Found by scrutinising the **live** `prepare` output after #993 merged. Making the extension
objectTypes reachable did not make them *grounded*.

## 1. `prepare(create)` on an extension said nothing about the base

Everything that decides whether an enum extension can work lives on the object being extended:

* it has to **exist**;
* it has to be **extensible** — a sealed enum cannot be extended, full stop;
* a **member name already on it** is a build error, not a merge.

`prepare(mode="change")` is built around reading the base. `prepare(mode="create")` was not — so
the one call an agent makes before writing an extension covered collisions, naming, labels and
property defaults, and omitted the precondition.

A new **Base object** section answers all three from the bridge, which returns them in one read:

```
### Base object _(the thing this extends)_
`NumberSeqModule` (ApplicationPlatform) — **Extensible: Yes**
Member names already taken (7): General, Docu, DIR, Workflow, Event, OrganizationModel, EInvoice —
reusing one is a build error, not a merge.
```

A non-extensible base is called what it is, in red, because no amount of correct XML makes that
write build.

## 2. The naming check let the symbol index veto the metadata provider

`checkObjectNaming` can only probe the index, while `search`, `get_object_info` and the write path
all prefer the bridge. The eval instance is configured `extractMode: "custom"` with
`customModels: ["fm-mcp"]`, so its index holds **no standard models** — and `NumberSeqModule`, an
ApplicationPlatform enum the bridge reads instantly, came back as:

```
⚠️ Base object "NumberSeqModule" not found in symbol index for types: enum. Ensure it's indexed.
```

False, and the remedy it names **can never succeed** in that configuration: the index excludes
standard models by design.

`ObjectNamingInput` gains an optional `baseObjectExists`, so a caller with a better source answers
instead of the index. When nobody can answer, the message no longer asserts absence — it says the
index may simply be scoped, and points at `get_object_info`.

**Why this was latent rather than visible:** the same two calls behaved *differently* on the same
name minutes apart — the `enum` route warned, the `enum-extension` route did not — because the
index changed underneath, not because the code differs. The path is identical for both, since
`'enum-extension'.includes('enum')`.

This is the third time today the disagreement was only visible from outside the process (#983,
#993, this).

## Also

"pass the BASE name, the prefix is applied for you" is boilerplate that does not hold for a dotted
extension, where `Final name == Base name` and only the suffix is the caller's to choose.

## Verification

* `tsc --noEmit` clean; `biome lint` clean.
* `vitest run` — **396 files, 5,898 passed**, 2 skipped.
* The new suite drives an **empty** symbol index — exactly what an `extractMode: "custom"` one
  looks like for a Microsoft base — so "the bridge wins" is a real assertion, not a mocked one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULksCPwMoC6txP49NsnqT
