### PR TITLE
Extension rows exist in the index — show them, and stop clearing names they hold

### DIFF
--- a/src/tools/prepare/prepareCreate.ts
+++ b/src/tools/prepare/prepareCreate.ts
@@ -22,7 +22,12 @@ import { normalizeObjectName } from '../../utils/objectNaming.js';
 import { renderPrepareOpSpec } from '../specs/opSpecs.js';
 import { rankContext, renderRankedContext } from '../../workspace/contextRanker.js';
 import { budgetRankedContext } from './prepareChange.js';
-import { lookupSymbolsNocase, type SymbolHit } from '../../utils/symbolLookup.js';
+import {
+  canonicalSymbolName,
+  lookupChildSymbolsNocase,
+  lookupSymbolsNocase,
+  type SymbolHit,
+} from '../../utils/symbolLookup.js';
 import { formatLabelReference } from '../../utils/labelReference.js';
 import { RESERVED_SYSTEM_FIELD_NAMES } from '../smart/generateSmartTable.js';
 
@@ -61,6 +66,109 @@ export const prepareCreateArgsSchema = z.object({
   ),
 });
 
+/** A literal newline, kept as a constant so shell-authored patches cannot eat the escape. */
+const NEWLINE = String.fromCharCode(10);
+
+/** Extension objectType → the type of the object it extends. */
+const EXTENSION_BASE_TYPE: Record<string, string> = {
+  'table-extension': 'table',
+  'class-extension': 'class',
+  'form-extension': 'form',
+  'enum-extension': 'enum',
+  'edt-extension': 'edt',
+};
+
+/**
+ * What the caller needs to know about the object an extension EXTENDS.
+ *
+ * Publishing the extension objectTypes (#983) made the write reachable; it did
+ * not make it grounded. Everything that decides whether an enum extension can
+ * work at all lives on the BASE: it has to exist, it has to be extensible (a
+ * sealed enum cannot be extended at all), and a member name already on it is a
+ * build error, not a merge. `prepare(mode="change")` is built around reading the
+ * base object; `prepare(mode="create")` was not, so the one call an agent makes
+ * before writing an extension said nothing about the thing being extended.
+ *
+ * Asked of the BRIDGE first, and that is the point. The existence check in
+ * `checkObjectNaming` reads the symbol index, while `search`, `get_object_info`
+ * and the write path all prefer the metadata provider. On an instance indexed
+ * with `extractMode: "custom"` the index deliberately holds only custom models,
+ * so the index answer for a Microsoft base enum is "not found — ensure it's
+ * indexed": false, and advice that re-indexing can never satisfy.
+ */
+async function describeExtensionBase(
+  baseName: string,
+  objectType: string,
+  context: XppServerContext,
+): Promise<{ exists: boolean | undefined; text: string }> {
+  const baseType = EXTENSION_BASE_TYPE[objectType];
+  if (!baseType || !baseName) return { exists: undefined, text: '' };
+
+  const bridge = context.bridge;
+  const bridgeUsable = Boolean(bridge?.isReady && bridge?.metadataAvailable);
+
+  if (bridgeUsable && baseType === 'enum') {
+    try {
+      const info = await bridge!.readEnum(baseName);
+      if (info) {
+        const taken = info.values.map(v => v.name);
+        const lines = [
+          `\`${info.name}\`${info.model ? ` (${info.model})` : ''} — **Extensible: ${info.isExtensible ? 'Yes' : 'NO'}**`,
+        ];
+        if (!info.isExtensible) {
+          lines.push(
+            '🔴 A non-extensible enum CANNOT be extended — the write will not build. ' +
+            'Add the member to the enum itself, or ask the owner to mark it extensible.',
+          );
+        }
+        if (taken.length > 0) {
+          lines.push(
+            `Member names already taken (${taken.length}): ${taken.join(', ')} — ` +
+            'reusing one is a build error, not a merge.',
+          );
+        }
+        return { exists: true, text: lines.join(String.fromCharCode(10)) };
+      }
+      return {
+        exists: false,
+        text: `🔴 \`${baseName}\` does not exist as an enum (checked via the metadata provider) — ` +
+          'an extension of a missing object cannot build.',
+      };
+    } catch {
+      /* fall through to the generic probe */
+    }
+  }
+
+  if (bridgeUsable) {
+    try {
+      const resolved = await bridge!.resolveObjectInfo(baseType, baseName);
+      if (resolved) {
+        return resolved.exists
+          ? { exists: true, text: `\`${baseName}\`${resolved.model ? ` (${resolved.model})` : ''} — exists.` }
+          : {
+              exists: false,
+              text: `🔴 \`${baseName}\` does not exist as a ${baseType} (checked via the metadata provider).`,
+            };
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  // No bridge: the index is all there is, and it may be scoped to custom models.
+  try {
+    const hit = lookupSymbolsNocase(context.symbolIndex.getReadDb(), baseName, { types: [baseType], limit: 1 })[0];
+    if (hit) return { exists: true, text: `\`${baseName}\` (${hit.model ?? '?'}) — found in the symbol index.` };
+  } catch {
+    /* index unavailable */
+  }
+  return {
+    exists: undefined,
+    text: `\`${baseName}\` — could not be verified (the C# bridge is not available and the symbol ` +
+      'index has no matching ' + baseType + '; an index built with extractMode "custom" holds only custom models).',
+  };
+}
+
 // Lookups below are all index-only, run in parallel.
 
 /** Exact + prefixed collision check. */
@@ -85,10 +193,31 @@ function checkCollisions(
         }
       }
     }
+    // Extension rows are INVISIBLE to the lookup above: it requires
+    // `parent_name IS NULL` (the marker of a top-level object), and every one of
+    // the index's extension rows records its BASE there instead. So
+    // `NumberSeqModule.Kitting` — present in the index as an enum-extension of
+    // NumberSeqModule, in model Kitting — came back as "✅ No collision",
+    // clearing a name that is already taken, immediately before a write (#995).
+    //
+    // Probed by exact name here rather than by relaxing the shared helper, whose
+    // top-level-only contract the rest of the server depends on.
+    for (const n of new Set([finalName, baseName])) {
+      if (!n.includes('.')) continue;
+      const taken = lookupChildSymbolsNocase(db, n);
+      for (const r of taken) {
+        const key = `${r.name} ${r.type} ${r.model ?? ''}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          rows.push(r);
+        }
+      }
+    }
+
     if (rows.length > 0) {
       return rows
         .map(r => `⚠️  "${r.name}" already exists as ${r.type} in model "${r.model}" — pick a different name or extend it instead.`)
-        .join('\n');
+        .join(NEWLINE);
     }
     return `✅ No collision — neither "${finalName}" nor "${baseName}" exists in the index.`;
   } catch {
@@ -204,6 +333,43 @@ function findSimilarObjects(
 ): string {
   try {
     const db = context.symbolIndex.getReadDb();
+
+    // For an EXTENSION, the useful siblings are the other extensions of the same
+    // base — not names that happen to share a token with the suffix (#995).
+    //
+    // The CamelCase heuristic below picks the LAST token of the proposed name,
+    // which for `NumberSeqModule.ConDemoRent` is "Rent": a word out of the half
+    // the caller just invented. It matched nothing, so prepare answered
+    // "greenfield" while the index held 25 extensions of that exact enum —
+    // including NumberSeqModule.RentalManagement, all but a worked example of the
+    // thing being written. (The tokeniser does not know about the dot either, so
+    // it emits "Module." as a token and gets both halves wrong.)
+    //
+    // Extension rows record their base in `parent_name`, which makes this exact
+    // rather than a LIKE, and idx_type_parent serves it directly.
+    const extensionBase = objectType.endsWith('-extension') && baseName.includes('.')
+      ? baseName.slice(0, baseName.indexOf('.'))
+      : '';
+    if (extensionBase) {
+      // BINARY, deliberately. `parent_name = ? COLLATE NOCASE` drops the planner
+      // from `(type=? AND parent_name=?)` to `(type=?)` — it cannot use the
+      // BINARY-collated idx_type_parent — and then walks every extension row of
+      // that type. The module-level rule in symbolLookup.ts is the one to follow:
+      // canonicalize the name ONCE through a nocase lookup, then stay binary.
+      const canonicalBase =
+        canonicalSymbolName(db, extensionBase, [EXTENSION_BASE_TYPE[objectType]]) ?? extensionBase;
+      const siblings = db.prepare(
+        `SELECT name, model FROM symbols INDEXED BY idx_type_parent
+         WHERE type = ? AND parent_name = ?
+         ORDER BY name LIMIT 6`,
+      ).all(objectType, canonicalBase) as Array<{ name: string; model: string }>;
+      if (siblings.length > 0) {
+        return siblings.map(r => `  ${r.name} (${r.model})`).join(NEWLINE) +
+          NEWLINE + `_How the platform's own models name their suffix on this base — evidence, not convention._`;
+      }
+      return `(no other ${objectType} of "${extensionBase}" in the index — this is the first)`;
+    }
+
     // Split CamelCase into tokens and search for the most specific ones
     const tokens = baseName.split(/(?=[A-Z])/).filter(t => t.length >= 4);
     const needle = tokens.length > 0 ? tokens[tokens.length - 1] : baseName;
@@ -321,105 +487,6 @@ function minedPropertyDefaults(objectType: string, context: XppServerContext): s
   return '(no mined statistics — run build-database to mine standard models)';
 }
 
-/** Extension objectType → the type of the object it extends. */
-const EXTENSION_BASE_TYPE: Record<string, string> = {
-  'table-extension': 'table',
-  'class-extension': 'class',
-  'form-extension': 'form',
-  'enum-extension': 'enum',
-  'edt-extension': 'edt',
-};
-
-/**
- * What the caller needs to know about the object an extension EXTENDS.
- *
- * Publishing the extension objectTypes (#983) made the write reachable; it did
- * not make it grounded. Everything that decides whether an enum extension can
- * work at all lives on the BASE: it has to exist, it has to be extensible (a
- * sealed enum cannot be extended at all), and a member name already on it is a
- * build error, not a merge. `prepare(mode="change")` is built around reading the
- * base object; `prepare(mode="create")` was not, so the one call an agent makes
- * before writing an extension said nothing about the thing being extended.
- *
- * Asked of the BRIDGE first, and that is the point. The existence check in
- * `checkObjectNaming` reads the symbol index, while `search`, `get_object_info`
- * and the write path all prefer the metadata provider. On an instance indexed
- * with `extractMode: "custom"` the index deliberately holds only custom models,
- * so the index answer for a Microsoft base enum is "not found — ensure it's
- * indexed": false, and advice that re-indexing can never satisfy.
- */
-async function describeExtensionBase(
-  baseName: string,
-  objectType: string,
-  context: XppServerContext,
-): Promise<{ exists: boolean | undefined; text: string }> {
-  const baseType = EXTENSION_BASE_TYPE[objectType];
-  if (!baseType || !baseName) return { exists: undefined, text: '' };
-
-  const bridge = context.bridge;
-  const bridgeUsable = Boolean(bridge?.isReady && bridge?.metadataAvailable);
-
-  if (bridgeUsable && baseType === 'enum') {
-    try {
-      const info = await bridge!.readEnum(baseName);
-      if (info) {
-        const taken = info.values.map(v => v.name);
-        const lines = [
-          `\`${info.name}\`${info.model ? ` (${info.model})` : ''} — **Extensible: ${info.isExtensible ? 'Yes' : 'NO'}**`,
-        ];
-        if (!info.isExtensible) {
-          lines.push(
-            '🔴 A non-extensible enum CANNOT be extended — the write will not build. ' +
-            'Add the member to the enum itself, or ask the owner to mark it extensible.',
-          );
-        }
-        if (taken.length > 0) {
-          lines.push(
-            `Member names already taken (${taken.length}): ${taken.join(', ')} — ` +
-            'reusing one is a build error, not a merge.',
-          );
-        }
-        return { exists: true, text: lines.join(String.fromCharCode(10)) };
-      }
-      return {
-        exists: false,
-        text: `🔴 \`${baseName}\` does not exist as an enum (checked via the metadata provider) — ` +
-          'an extension of a missing object cannot build.',
-      };
-    } catch {
-      /* fall through to the generic probe */
-    }
-  }
-
-  if (bridgeUsable) {
-    try {
-      const resolved = await bridge!.resolveObjectInfo(baseType, baseName);
-      if (resolved) {
-        return resolved.exists
-          ? { exists: true, text: `\`${baseName}\`${resolved.model ? ` (${resolved.model})` : ''} — exists.` }
-          : {
-              exists: false,
-              text: `🔴 \`${baseName}\` does not exist as a ${baseType} (checked via the metadata provider).`,
-            };
-      }
-    } catch {
-      /* fall through */
-    }
-  }
-
-  // No bridge: the index is all there is, and it may be scoped to custom models.
-  try {
-    const hit = lookupSymbolsNocase(context.symbolIndex.getReadDb(), baseName, { types: [baseType], limit: 1 })[0];
-    if (hit) return { exists: true, text: `\`${baseName}\` (${hit.model ?? '?'}) — found in the symbol index.` };
-  } catch {
-    /* index unavailable */
-  }
-  return {
-    exists: undefined,
-    text: `\`${baseName}\` — could not be verified (the C# bridge is not available and the symbol ` +
-      'index has no matching ' + baseType + '; an index built with extractMode "custom" holds only custom models).',
-  };
-}
 
 export async function prepareCreateTool(request: any, context: XppServerContext): Promise<any> {
   const raw = request?.params?.arguments ?? request;

--- a/src/utils/symbolLookup.ts
+++ b/src/utils/symbolLookup.ts
@@ -140,3 +140,53 @@ export function distinctSymbolTypesNocase(db: DbLike, name: string, limit = 10):
   }
   return [...types].slice(0, limit);
 }
+
+/**
+ * Case-insensitive lookup of NON-top-level symbols by exact name — the rows
+ * `lookupSymbolsNocase` deliberately cannot see.
+ *
+ * Every helper above requires `parent_name IS NULL`, which is the index's marker
+ * for a top-level object. EXTENSION rows do not carry it: they record the object
+ * they extend in `parent_name` instead (all 278 enum extensions in a production
+ * index do). So an extension is invisible to every lookup in this module, and
+ * `prepare`'s collision check cleared `NumberSeqModule.Kitting` — an
+ * enum-extension that is right there in the index — as "no collision", moments
+ * before a write (#995).
+ *
+ * Same two-step as `lookupSymbolsNocase`, and for the same reason: the exact-case
+ * probe rides idx_name_type (0.2 ms), while `name = ? COLLATE NOCASE` alone
+ * cannot use that BINARY index and scans it — measured at 60 SECONDS on a
+ * production-size DB, which node:sqlite would spend blocking the event loop.
+ */
+export function lookupChildSymbolsNocase(
+  db: DbLike,
+  name: string,
+  limit = 3,
+): SymbolHit[] {
+  if (!name) return [];
+  const exact = db.prepare(
+    `SELECT ${HIT_COLS} FROM symbols s INDEXED BY idx_name_type
+     WHERE s.name = ? AND s.parent_name IS NOT NULL
+     LIMIT ?`,
+  ).all(name, limit) as SymbolHit[];
+  if (exact.length >= limit) return exact;
+
+  const fts = db.prepare(
+    `SELECT ${HIT_COLS} FROM symbols_fts fts
+     JOIN symbols s ON s.id = fts.rowid
+     WHERE symbols_fts MATCH ?
+       AND s.name = ? COLLATE NOCASE AND s.parent_name IS NOT NULL
+     LIMIT ?`,
+  ).all(`{name} : ${ftsPhrase(name)}`, name, limit) as SymbolHit[];
+
+  const key = (r: SymbolHit) => `${r.name}\0${r.type}\0${r.model ?? ''}`;
+  const seen = new Set(exact.map(key));
+  const merged = [...exact];
+  for (const r of fts) {
+    if (!seen.has(key(r))) {
+      seen.add(key(r));
+      merged.push(r);
+    }
+  }
+  return merged.slice(0, limit);
+}

--- a/tests/tools/prepareExtensionBaseGrounding.test.ts
+++ b/tests/tools/prepareExtensionBaseGrounding.test.ts
@@ -133,3 +133,83 @@ describe('prepare(create) grounds an extension in its base object', () => {
     expect(text).toMatch(/only the suffix after the dot is yours to choose/);
   });
 });
+
+/**
+ * Extension siblings and extension collisions (issue #995).
+ *
+ * Both come from one fact about the index: an extension row does NOT carry
+ * `parent_name IS NULL`. It records the object it EXTENDS there instead — all 278
+ * enum extensions in a production index do. Every helper in symbolLookup requires
+ * the NULL, so extensions are invisible to all of them.
+ *
+ * Consequences, both measured against a real index:
+ *   • `prepare` answered "greenfield" for NumberSeqModule.ConDemoRent while 25
+ *     extensions of that exact enum sat in the index.
+ *   • the collision check cleared `NumberSeqModule.Kitting` — an enum-extension
+ *     that IS in the index — as "✅ No collision", right before a write.
+ */
+describe('prepare(create) sees extension rows (#995)', () => {
+  const SIBLINGS = [
+    { name: 'NumberSeqModule.Administration', type: 'enum-extension', model: 'ApplicationFoundation', extends_class: null, file_path: null },
+    { name: 'NumberSeqModule.RentalManagement', type: 'enum-extension', model: 'RentalManagement', extends_class: null, file_path: null },
+  ];
+
+  /**
+   * A db that answers only the two shapes extensions live under, so a query that
+   * still demands `parent_name IS NULL` gets nothing — the pre-fix behaviour.
+   */
+  const extensionAwareDb = (opts: { siblings?: unknown[]; taken?: unknown[] } = {}) => {
+    const prepare = vi.fn((sql: string) => ({
+      all: vi.fn((..._p: unknown[]) => {
+        if (sql.includes('parent_name IS NULL')) return [];
+        if (sql.includes('parent_name = ?')) return opts.siblings ?? [];
+        if (sql.includes('parent_name IS NOT NULL')) return opts.taken ?? [];
+        return [];
+      }),
+      get: vi.fn(() => undefined),
+      run: vi.fn(),
+    }));
+    return { prepare };
+  };
+
+  const runWith = async (db: unknown, objectName: string, objectType: string) => {
+    const { prepareCreateTool } = await import('../../src/tools/prepare/prepareCreate.js');
+    const res = await prepareCreateTool(
+      { params: { arguments: { goal: 'test', objectName, objectType } } },
+      {
+        symbolIndex: { db, getReadDb: () => db } as any,
+        bridge: readyBridge(),
+        parser: {} as any, cache: {} as any, workspaceScanner: {} as any, hybridSearch: {} as any,
+      } as any,
+    );
+    return String(res.content[0].text);
+  };
+
+  it('lists the other extensions of the same base instead of "greenfield"', async () => {
+    const text = await runWith(extensionAwareDb({ siblings: SIBLINGS }), 'NumberSeqModule.ConDemoRent', 'enum-extension');
+    expect(text).not.toContain('greenfield');
+    expect(text).toContain('NumberSeqModule.RentalManagement');
+    expect(text).toContain('RentalManagement');
+  });
+
+  it('says "this is the first" rather than "greenfield" when the base truly has none', async () => {
+    const text = await runWith(extensionAwareDb({ siblings: [] }), 'NumberSeqModule.ConDemoRent', 'enum-extension');
+    expect(text).toMatch(/no other enum-extension of "NumberSeqModule" in the index — this is the first/);
+  });
+
+  it('does NOT clear a name an existing extension already holds', async () => {
+    const taken = [{ name: 'NumberSeqModule.Kitting', type: 'enum-extension', model: 'Kitting', extends_class: null, file_path: null }];
+    const text = await runWith(extensionAwareDb({ taken }), 'NumberSeqModule.Kitting', 'enum-extension');
+    expect(text).not.toContain('✅ No collision');
+    expect(text).toContain('already exists as enum-extension');
+    expect(text).toContain('Kitting');
+  });
+
+  it('does not run the child probe for an undotted name', async () => {
+    const db = extensionAwareDb();
+    await runWith(db, 'ImportParameters', 'table');
+    const childProbes = (db.prepare as any).mock.calls
+      .filter((c: unknown[]) => String(c[0]).includes('parent_name IS NOT NULL'));
+    expect(childProbes).toHaveLength(0);
+  });
+});

--- a/tests/utils/symbolLookup.test.ts
+++ b/tests/utils/symbolLookup.test.ts
@@ -11,6 +11,7 @@ import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
 import {
   lookupSymbolNocase,
   lookupSymbolsNocase,
+  lookupChildSymbolsNocase,
   canonicalSymbolName,
   distinctSymbolTypesNocase,
 } from '../../src/utils/symbolLookup';
@@ -29,6 +30,10 @@ beforeAll(() => {
   sym('validateWrite', 'method', 'CustTable');
   sym('SalesStatus', 'enum');
   sym('CustAccount', 'edt');
+  // An EXTENSION row: its `parent_name` is the object it extends, so it is NOT a
+  // top-level row and every helper above is blind to it by design (#995).
+  sym('NumberSeqModule', 'enum');
+  sym('NumberSeqModule.Kitting', 'enum-extension', 'NumberSeqModule');
   db = index.getReadDb();
 });
 
@@ -88,5 +93,74 @@ describe('distinctSymbolTypesNocase', () => {
 
   it('returns [] for unknown names', () => {
     expect(distinctSymbolTypesNocase(db, 'NoSuchObject123')).toEqual([]);
+  });
+});
+
+/**
+ * `lookupChildSymbolsNocase` — the rows the helpers above deliberately cannot see.
+ *
+ * Extension rows do not carry `parent_name IS NULL`; they record the object they
+ * EXTEND there. So `prepare`'s collision check cleared `NumberSeqModule.Kitting`
+ * — an enum-extension sitting in the index — as "no collision", immediately
+ * before a write (#995).
+ *
+ * The index-safety contract is the same one this whole module exists for: the
+ * exact-case probe must ride idx_name_type. Written first as
+ * `name = ? COLLATE NOCASE AND parent_name IS NOT NULL`, it could not use that
+ * BINARY index and scanned it — 60 SECONDS measured on a production-size DB,
+ * which node:sqlite spends blocking the event loop.
+ */
+describe('lookupChildSymbolsNocase', () => {
+  it('finds an extension row that the top-level helpers cannot', () => {
+    expect(lookupSymbolNocase(db, 'NumberSeqModule.Kitting')).toBeUndefined();
+    const hits = lookupChildSymbolsNocase(db, 'NumberSeqModule.Kitting');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({ name: 'NumberSeqModule.Kitting', type: 'enum-extension' });
+  });
+
+  it('matches differently-cased input through the FTS fallback', () => {
+    const hits = lookupChildSymbolsNocase(db, 'numberseqmodule.kitting');
+    expect(hits.map(h => h.name)).toEqual(['NumberSeqModule.Kitting']);
+  });
+
+  it('never returns a top-level row — that is the other helper\'s job', () => {
+    expect(lookupChildSymbolsNocase(db, 'CustTable')).toEqual([]);
+    expect(lookupChildSymbolsNocase(db, 'NumberSeqModule')).toEqual([]);
+  });
+
+  it('returns nothing for an empty name rather than scanning', () => {
+    expect(lookupChildSymbolsNocase(db, '')).toEqual([]);
+  });
+
+  it('keeps the extension-sibling query on idx_type_parent (prepare #995)', () => {
+    // `parent_name = ? COLLATE NOCASE` drops the planner to `(type=?)` and then
+    // walks every extension row of that type. Canonicalize the base once, stay
+    // BINARY — the rule this module's header states.
+    const binary = db.prepare(
+      `EXPLAIN QUERY PLAN
+       SELECT name FROM symbols INDEXED BY idx_type_parent
+       WHERE type = ? AND parent_name = ? LIMIT 6`,
+    ).all('enum-extension', 'NumberSeqModule') as Array<{ detail: string }>;
+    expect(binary.map(r => r.detail).join(' ')).toMatch(/parent_name=\?/);
+
+    const nocase = db.prepare(
+      `EXPLAIN QUERY PLAN
+       SELECT name FROM symbols INDEXED BY idx_type_parent
+       WHERE type = ? AND parent_name = ? COLLATE NOCASE LIMIT 6`,
+    ).all('enum-extension', 'NumberSeqModule') as Array<{ detail: string }>;
+    // Proof the COLLATE really is what costs the seek, not a guess about it.
+    expect(nocase.map(r => r.detail).join(' ')).not.toMatch(/parent_name=\?/);
+  });
+
+  it('keeps the exact-case probe on idx_name_type (the 60-second regression)', () => {
+    const plan = db.prepare(
+      `EXPLAIN QUERY PLAN
+       SELECT s.name FROM symbols s INDEXED BY idx_name_type
+       WHERE s.name = ? AND s.parent_name IS NOT NULL LIMIT 3`,
+    ).all('NumberSeqModule.Kitting') as Array<{ detail: string }>;
+    const detail = plan.map(r => r.detail).join(' ');
+    // SEARCH = index seek. SCAN would be the 60-second shape.
+    expect(detail).toMatch(/SEARCH/);
+    expect(detail).not.toMatch(/SCAN/);
   });
 });


### PR DESCRIPTION
Closes #995 — and a worse defect found while fixing it.

## One fact explains both

An extension row does **not** carry `parent_name IS NULL`. It records the object it *extends*
there instead — all 278 enum extensions in a production index do. Every helper in `symbolLookup`
requires that NULL, because it is the index's marker for a top-level object. So extensions are
invisible to all of them.

## 1. #995 as filed — "greenfield" for an extension with 25 siblings

`findSimilarObjects` splits the proposed name on capitals and searches for the **last** token,
which for `NumberSeqModule.ConDemoRent` is `"Rent"` — a word out of the half the caller just
invented. It matched nothing, while the index held **25 extensions of that exact enum**. The
tokeniser does not know about the dot either, so it emits `"Module."` and gets both halves wrong.

Extensions are now looked up by their base, exactly:

```
  NumberSeqModule.Administration (ApplicationFoundation)
  NumberSeqModule.AssetLease (AssetLeasing)
  NumberSeqModule.CredMan (CreditManagement)
  …
_How the platform's own models name their suffix on this base — evidence, not convention._
```

Which is better guidance than the convention rule printed directly above it: these suffixes are
`Administration`, `AssetLease`, `CredMan`, `Kitting`, `ITM` — mostly **not** ending in "Extension",
the same finding #986 established by census.

## 2. Worse, and not in the issue — the collision check cleared names that are taken

`NumberSeqModule.Kitting` is in the index as an enum-extension. `prepare` answered:

```
✅ No collision — neither "NumberSeqModule.Kitting" nor "NumberSeqModule.Kitting" exists in the index.
```

…immediately before a write. Any dotted name is now probed for child rows too, via the new
`lookupChildSymbolsNocase`.

## Both attempts at that lookup were the 60-second shape

This is the part worth reading. Only measuring against the **real 2.5 GB index** caught either:

| written as | planner does | cost |
|---|---|---|
| `name = ? COLLATE NOCASE AND parent_name IS NOT NULL` | `SCAN idx_name_type` | **60 seconds** |
| `type = ? AND parent_name = ? COLLATE NOCASE` | drops `(type=? AND parent_name=?)` → `(type=?)` | walks every extension row of the type |

`node:sqlite` is synchronous, so either would have blocked the event loop until MCP clients killed
the server — the exact failure `symbolLookup`'s header documents.

Fixed by following that header rather than rediscovering it: the two-step probe (exact binary
0.2 ms, FTS fallback 12 ms) for the collision lookup, and "canonicalize the base once, then stay
BINARY" for the siblings — **2.6 ms end to end** on the real index, returning the real 6 rows.

Both are pinned by `EXPLAIN QUERY PLAN` assertions rather than by timing, and the sibling test
also asserts the `COLLATE` version **loses** the seek — so the claim about *why* is checked, not
merely asserted.

## Verification

* `tsc --noEmit` clean; `biome lint` clean.
* `vitest run` — **396 files, 5,908 passed**, 2 skipped.
* Sibling query measured against `data/xpp-metadata.db` (2.5 GB): 2.6 ms, 6 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TULksCPwMoC6txP49NsnqT
