### PR TITLE
fix(setup): stop the index workers racing the build script's EXCLUSIVE lock (1.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,47 @@ _Nothing released yet._
 
 ---
 
+## [1.16.1] — 2026-09-01
+
+### Fixed
+- **`d365fo-mcp setup` died on a database lock it took out on itself.** Opening an
+  existing large index hands the deferred `file_path` index builds to worker
+  threads, and each worker opens its own *write* connection to the same file.
+  `build-database` then sets `locking_mode = EXCLUSIVE` on the writer, which
+  cannot coexist with a second writer — whoever lost the race failed with
+  SQLITE_BUSY, on a machine where the build had already run for minutes. The
+  script did call `closeReadPool()` first, exactly as that method's doc comment
+  instructs, but the pool is not the only other connection the class opens: it
+  drains readers and knows nothing about the workers.
+
+  Three separate things were wrong and all three are fixed:
+  - `XppSymbolIndex` takes `{ backgroundIndexBuilds: false }`, and both
+    `build-database` and `build-fts` pass it. The worker exists to keep the
+    server's event loop answering; a one-shot CLI has no event loop to protect,
+    so it builds inline on the connection that already holds the lock.
+  - The worker dispatch no longer *assumes* WAL — it checks `journal_mode` and
+    refuses to spawn off it. Build scripts switch to `journal_mode = MEMORY` two
+    steps later, where a second connection cannot work by construction, so the
+    race is now closed even if a future caller forgets the flag.
+  - `closeReadPool()` documents what it does not cover and warns on stderr when
+    it is called with index builds still running; `close()` tears them down.
+
+  Deliberately not fixed by raising `busy_timeout` (masks the race) or by
+  retrying `createFTSTriggers` (one of many places that hit the same lock).
+
+### Changed
+- Build scripts defer the `file_path` indexes past their bulk load
+  (`{ deferFilePathIndexes: true }`) and build them once at the end. Every row of
+  the load previously maintained two extra B-trees, and a full rebuild threw the
+  result away in `clear()` anyway.
+- `XppSymbolIndex` accepts a `largeDbThresholdBytes` override. The existing tests
+  could not have caught this bug: they run on databases far below the 200 MB
+  threshold, where the worker never starts. With the threshold injectable, the
+  worker path is reachable in a unit test — and the new tests fail against the
+  old code.
+
+---
+
 ## [1.16.0] — 2026-09-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -64,8 +64,21 @@ async function buildDatabase() {
   console.log(kv('VACUUM', EXTRACT_MODE === 'all' || FORCE_VACUUM ? c.green('enabled') : c.dim('disabled (incremental build)')));
   console.log('');
 
-  // Create symbol index with separate labels database
-  const symbolIndex = new XppSymbolIndex(OUTPUT_DB, OUTPUT_LABELS_DB);
+  // Create symbol index with separate labels database.
+  //
+  // backgroundIndexBuilds: false — this script takes locking_mode = EXCLUSIVE a few
+  // lines below, and an index worker holds a second write connection to the same
+  // file, which EXCLUSIVE cannot coexist with (the setup run died on that lock).
+  // The worker exists to keep the server's event loop free; a one-shot CLI has no
+  // event loop to protect, so inline is strictly better here.
+  //
+  // deferFilePathIndexes: true — building them now would make every row of the bulk
+  // load maintain two more B-trees, and on a full rebuild clear() throws the result
+  // away regardless. They are created after the load instead (see below).
+  const symbolIndex = new XppSymbolIndex(OUTPUT_DB, OUTPUT_LABELS_DB, {
+    backgroundIndexBuilds: false,
+    deferFilePathIndexes: true,
+  });
 
   // The extract phase is the only place that knows which models are non-Microsoft on UDE
   // (path rule under the custom root; CUSTOM_MODELS is empty there by design). Read the
@@ -377,6 +390,15 @@ async function buildDatabase() {
     console.log('');
     log.info('Skipping label indexing (INCLUDE_LABELS=false)');
   }
+
+  // Deferred at construction so the bulk load did not have to maintain them.
+  // Runs inline on the writer connection, which already holds the EXCLUSIVE lock —
+  // no second connection, so nothing to contend with.
+  console.log('');
+  log.step('Building file_path indexes...');
+  const filePathIdxStart = Date.now();
+  symbolIndex.ensureFilePathIndexes();
+  log.ok(`file_path indexes built in ${((Date.now() - filePathIdxStart) / 1000).toFixed(2)}s`);
 
   if (SKIP_FTS) {
     console.log('');

--- a/scripts/build-fts.ts
+++ b/scripts/build-fts.ts
@@ -59,7 +59,14 @@ async function buildFts(): Promise<void> {
     process.exit(1);
   }
 
-  const symbolIndex = new XppSymbolIndex(OUTPUT_DB, OUTPUT_LABELS_DB);
+  // Same two opt-outs as build-database.ts: this script takes locking_mode =
+  // EXCLUSIVE below, which an index worker's second write connection cannot
+  // coexist with, and the label load should not maintain the indexes it will
+  // build once at the end. See XppSymbolIndexOptions.
+  const symbolIndex = new XppSymbolIndex(OUTPUT_DB, OUTPUT_LABELS_DB, {
+    backgroundIndexBuilds: false,
+    deferFilePathIndexes: true,
+  });
 
   // Close read-pool connections before setting EXCLUSIVE locking mode.
   // SQLite cannot grant locking_mode = EXCLUSIVE while any other connection
@@ -146,6 +153,12 @@ async function buildFts(): Promise<void> {
   } else {
     console.log('\n⏭️  Skipping label indexing (INCLUDE_LABELS=false)');
   }
+
+  // ── file_path indexes: deferred past the load, built inline on the writer ──
+  console.log('\n🔑 Building file_path indexes...');
+  const filePathIdxStart = Date.now();
+  symbolIndex.ensureFilePathIndexes();
+  console.log(`   ✅ Done in ${((Date.now() - filePathIdxStart) / 1000).toFixed(2)}s`);
 
   // ── Finalize: convert to WAL mode for production ───────────────────────────
   console.log('\n🔄 Converting databases to WAL mode for production...');

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -65,6 +65,36 @@ export interface ExtensionMetadataRecord {
   model: string;
 }
 
+/**
+ * Construction-time switches for the deferred file_path index builds.
+ *
+ * The defaults describe the long-running server: build in the background, treat
+ * anything over 200 MB as big enough to be worth a thread. A one-shot CLI wants
+ * the opposite of both — see scripts/build-database.ts.
+ */
+export interface XppSymbolIndexOptions {
+  /**
+   * Dispatch large index builds to a worker thread (default true).
+   *
+   * Set false in one-shot scripts. A worker writes through a SECOND connection to
+   * the same file, which cannot coexist with `locking_mode = EXCLUSIVE` on the
+   * writer — the build script takes that lock and the worker (or the writer,
+   * depending on who gets there first) fails with SQLITE_BUSY. Blocking the event
+   * loop, the reason the worker exists at all, costs a CLI nothing.
+   */
+  backgroundIndexBuilds?: boolean;
+  /**
+   * Skip the file_path index builds during construction; the caller runs
+   * ensureFilePathIndexes() itself once its bulk load is done (default false).
+   *
+   * Building them up front makes a bulk load maintain two extra B-trees per row,
+   * and on a full rebuild the work is thrown away by clear() anyway.
+   */
+  deferFilePathIndexes?: boolean;
+  /** Byte size at which a DB is "large" enough to hand its index build to a worker. */
+  largeDbThresholdBytes?: number;
+}
+
 export class XppSymbolIndex {
   public db: Database; // Public for direct pragma access in build scripts
   public labelsDb: Database; // Separate DB for labels (performance optimization)
@@ -103,6 +133,15 @@ export class XppSymbolIndex {
   // Per-connection prepared-statement cache.  Prepared statements are bound to
   // their originating connection and cannot be shared across connections.
   private perConnStmtCache = new WeakMap<Database, Map<string, Statement>>();
+  // See XppSymbolIndexOptions. Held as fields so ensureFilePathIndexes() reads the
+  // same answer whether it runs from the constructor or from a build script later.
+  private backgroundIndexBuilds: boolean;
+  private deferFilePathIndexes: boolean;
+  private largeDbThresholdBytes: number;
+  // Index-build workers still running. closeReadPool() cannot drain these (it only
+  // owns the read pool), so track them to warn about the EXCLUSIVE-lock race and to
+  // tear them down in close().
+  private pendingIndexWorkers = new Set<Worker>();
 
   /**
    * Directory holding the metadata databases. Sibling marker files (the blob-download
@@ -112,8 +151,11 @@ export class XppSymbolIndex {
     return path.dirname(this.dbPath);
   }
 
-  constructor(dbPath: string, labelsDbPath?: string) {
+  constructor(dbPath: string, labelsDbPath?: string, options: XppSymbolIndexOptions = {}) {
     this.dbPath = dbPath;
+    this.backgroundIndexBuilds = options.backgroundIndexBuilds !== false;
+    this.deferFilePathIndexes = options.deferFilePathIndexes === true;
+    this.largeDbThresholdBytes = options.largeDbThresholdBytes ?? 200 * 1024 * 1024;
     // Ensure database directory exists
     const dbDir = path.dirname(dbPath);
     if (!fs.existsSync(dbDir)) {
@@ -205,13 +247,32 @@ export class XppSymbolIndex {
     return this.readPool[this.readPoolRR++ % this.readPool.length];
   }
 
+  /** True while a background file_path index build is still running. */
+  hasPendingIndexBuilds(): boolean {
+    return this.pendingIndexWorkers.size > 0;
+  }
+
   /**
    * Close and drain all read-pool connections.
    * Must be called before setting locking_mode = EXCLUSIVE on the writer
    * connection (e.g. in build scripts) — SQLite cannot grant EXCLUSIVE while
    * any other connection (even read-only, even in-process) holds a shared lock.
+   *
+   * The read pool is NOT the only other connection this class opens: an index
+   * build dispatched to a worker holds a writer connection to the same file, and
+   * this method cannot drain it (worker shutdown is asynchronous; this is not).
+   * Callers that take an EXCLUSIVE lock must construct with
+   * `backgroundIndexBuilds: false` so no such worker ever exists — the warning
+   * below is the tripwire for the ones that forget.
    */
   closeReadPool(): void {
+    if (this.pendingIndexWorkers.size > 0) {
+      console.error(
+        `[SymbolIndex] closeReadPool() with ${this.pendingIndexWorkers.size} background index ` +
+        `build(s) still running — these hold their own write connections and will contend ` +
+        `with locking_mode = EXCLUSIVE. Construct with { backgroundIndexBuilds: false }.`
+      );
+    }
     for (const conn of this.readPool) {
       try { conn.close(); } catch { /* ignore */ }
     }
@@ -792,7 +853,9 @@ export class XppSymbolIndex {
       CREATE INDEX IF NOT EXISTS idx_md_model ON macro_defines(model);
     `);
 
-    this.ensureFilePathIndexes();
+    if (!this.deferFilePathIndexes) {
+      this.ensureFilePathIndexes();
+    }
   }
 
   /**
@@ -896,8 +959,11 @@ export class XppSymbolIndex {
    * build is instant and runs here; on a large existing DB it is handed to a
    * worker thread, and until it finishes those deletes simply stay as slow as
    * they are today.
+   *
+   * Public because build scripts defer it (see XppSymbolIndexOptions) and run it
+   * themselves after their bulk load, with the worker dispatch turned off.
    */
-  private ensureFilePathIndexes(): void {
+  ensureFilePathIndexes(): void {
     const missing = (db: Database, indexName: string): boolean =>
       !db.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`).get(indexName);
 
@@ -906,7 +972,7 @@ export class XppSymbolIndex {
     const isLarge = (dbFile: string): boolean => {
       if (dbFile === ':memory:') return false;
       try {
-        return fs.statSync(dbFile).size > 200 * 1024 * 1024;
+        return fs.statSync(dbFile).size > this.largeDbThresholdBytes;
       } catch {
         return false;
       }
@@ -949,7 +1015,12 @@ export class XppSymbolIndex {
     // neither the deferral nor the worker dispatch the per-label table needed.
 
     for (const item of work) {
-      if (isLarge(item.dbFile)) {
+      // A worker writes through its own connection, which only works while the
+      // database is in WAL mode and nothing holds an EXCLUSIVE lock. Build scripts
+      // switch to journal_mode = MEMORY and take that lock, so the journal mode is
+      // checked here rather than assumed — off WAL the only safe build is inline.
+      const inWal = (item.db.pragma('journal_mode', { simple: true }) as string) === 'wal';
+      if (isLarge(item.dbFile) && this.backgroundIndexBuilds && inWal) {
         this.buildIndexInWorker(item.dbFile, item.sql, item.name);
       } else {
         item.db.exec(item.sql);
@@ -959,7 +1030,12 @@ export class XppSymbolIndex {
 
   /**
    * Build one index on a separate thread so the main event loop keeps serving.
-   * WAL mode allows the worker's write to proceed alongside main-thread readers.
+   *
+   * The worker opens its OWN write connection to the same file, so this is only
+   * legal while the database stays in WAL mode and no one takes an EXCLUSIVE lock
+   * on it for the duration — both guaranteed by the caller (ensureFilePathIndexes
+   * checks the journal mode, and build scripts opt out of workers entirely).
+   *
    * Best-effort: a failure leaves the index absent, which is exactly the state
    * the server ran in before, so it is logged and never thrown.
    */
@@ -968,6 +1044,7 @@ export class XppSymbolIndex {
       const worker = new Worker(new URL('./buildIndexWorker.js', import.meta.url), {
         workerData: { dbPath, sql, indexName },
       });
+      this.pendingIndexWorkers.add(worker);
       // unref() so a pending index build never keeps the process alive on exit.
       worker.unref();
       worker.once('message', (msg: { ok: boolean; elapsedMs?: number; error?: string }) => {
@@ -976,9 +1053,14 @@ export class XppSymbolIndex {
         } else {
           console.error(`[SymbolIndex] Background build of ${indexName} failed: ${msg.error}`);
         }
+        this.pendingIndexWorkers.delete(worker);
         void worker.terminate();
       });
-      worker.once('error', e => console.error(`[SymbolIndex] ${indexName} worker error: ${e}`));
+      worker.once('error', e => {
+        this.pendingIndexWorkers.delete(worker);
+        console.error(`[SymbolIndex] ${indexName} worker error: ${e}`);
+      });
+      worker.once('exit', () => this.pendingIndexWorkers.delete(worker));
     } catch (e) {
       console.error(`[SymbolIndex] Could not start ${indexName} worker: ${e}`);
     }
@@ -4274,6 +4356,15 @@ export class XppSymbolIndex {
       console.error(`[SymbolIndex] Final labels FTS flush failed: ${e}`);
       this._labelsFtsTimer = null;
     }
+
+    // Background index builds hold their own write connection to the same file;
+    // leaving one running past close() writes into a database the owner considers
+    // shut. terminate() is async and best-effort — we do not await it, we only stop
+    // the build from outliving us.
+    for (const worker of this.pendingIndexWorkers) {
+      void worker.terminate();
+    }
+    this.pendingIndexWorkers.clear();
 
     // Drain read pools first — writer close will fail on WAL if readers hold a lock.
     this.closeReadPool();

--- a/tests/metadata/filePathIndexBuildMode.test.ts
+++ b/tests/metadata/filePathIndexBuildMode.test.ts
@@ -1,0 +1,135 @@
+/**
+ * How the deferred file_path indexes get built — worker thread or inline.
+ *
+ * `d365fo-mcp setup` died holding a database lock: build-database.ts sets
+ * locking_mode = EXCLUSIVE on the writer, but the XppSymbolIndex constructor had
+ * already handed the file_path index builds to worker threads, and each of those
+ * opens its OWN write connection to the same file. EXCLUSIVE and a second writer
+ * cannot coexist, so whoever lost the race failed with SQLITE_BUSY.
+ *
+ * closeReadPool(), which the build script dutifully calls first, only drains the
+ * read pool — it never knew about the workers.
+ *
+ * The old tests could not catch this: they run on tiny databases, where isLarge()
+ * is false and the worker never starts. Hence largeDbThresholdBytes — with it at
+ * 0 every build takes the "large" path, and the mode becomes observable: an index
+ * that exists the instant the synchronous call returns was built inline; one that
+ * does not was handed to a thread.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { XppSymbolIndex, type XppSymbolIndexOptions } from '../../src/metadata/symbolIndex.js';
+
+const dirs: string[] = [];
+const opened: XppSymbolIndex[] = [];
+
+function tempIndex(options: XppSymbolIndexOptions): XppSymbolIndex {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'd365fo-index-build-mode-'));
+  dirs.push(dir);
+  const idx = new XppSymbolIndex(path.join(dir, 'symbols.db'), path.join(dir, 'labels.db'), options);
+  opened.push(idx);
+  return idx;
+}
+
+function hasIndex(db: any, name: string): boolean {
+  return !!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(name);
+}
+
+afterEach(() => {
+  for (const idx of opened) { try { idx.close(); } catch { /* already closed */ } }
+  opened.length = 0;
+  for (const d of dirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* locked */ } }
+  dirs.length = 0;
+});
+
+describe('file_path index build mode', () => {
+  it('hands a large database to a worker by default (the behaviour the server wants)', () => {
+    const idx = tempIndex({ largeDbThresholdBytes: 0 });
+
+    // Nothing synchronous built it, so it is not there yet — that is the whole
+    // point of the worker, and the reason it collides with an EXCLUSIVE lock.
+    expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(false);
+    expect(idx.hasPendingIndexBuilds()).toBe(true);
+  });
+
+  it('builds inline with backgroundIndexBuilds: false, however large the database', () => {
+    const idx = tempIndex({ largeDbThresholdBytes: 0, backgroundIndexBuilds: false });
+
+    expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(true);
+    expect(hasIndex(idx.db, 'idx_symbols_file_path_nocase')).toBe(true);
+    expect(hasIndex(idx.labelsDb, 'idx_labels_file_path_id')).toBe(true);
+    // No second write connection exists, so nothing can contend with EXCLUSIVE.
+    expect(idx.hasPendingIndexBuilds()).toBe(false);
+  });
+
+  it('skips the builds entirely with deferFilePathIndexes, until the caller asks', () => {
+    const idx = tempIndex({
+      largeDbThresholdBytes: 0,
+      backgroundIndexBuilds: false,
+      deferFilePathIndexes: true,
+    });
+
+    expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(false);
+    expect(idx.hasPendingIndexBuilds()).toBe(false);
+
+    idx.ensureFilePathIndexes();
+
+    expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(true);
+    expect(hasIndex(idx.labelsDb, 'idx_labels_file_path_id')).toBe(true);
+  });
+
+  it('never dispatches a worker off WAL, even when background builds are enabled', () => {
+    // The build scripts' pragmas: no WAL to write through, and the writer holds the
+    // file exclusively. A worker here is unserviceable by construction, so the
+    // journal mode — not just the opt-out flag — has to veto it.
+    const idx = tempIndex({ largeDbThresholdBytes: 0, deferFilePathIndexes: true });
+    idx.closeReadPool();
+    idx.db.pragma('journal_mode = MEMORY');
+    idx.db.pragma('locking_mode = EXCLUSIVE');
+    idx.labelsDb.pragma('journal_mode = MEMORY');
+    idx.labelsDb.pragma('locking_mode = EXCLUSIVE');
+
+    idx.ensureFilePathIndexes();
+
+    expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(true);
+    expect(hasIndex(idx.labelsDb, 'idx_labels_file_path_id')).toBe(true);
+    expect(idx.hasPendingIndexBuilds()).toBe(false);
+  });
+
+  it('keeps the small-database default: inline, no worker, no flags needed', () => {
+    const idx = tempIndex({});
+
+    expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(true);
+    expect(idx.hasPendingIndexBuilds()).toBe(false);
+  });
+});
+
+/**
+ * The crash was in a build script, and no unit test can run a 2 GB rebuild — so
+ * pin the contract at the source level instead: any script that takes an
+ * EXCLUSIVE lock must have opted out of background index builds.
+ */
+describe('build scripts and the EXCLUSIVE lock', () => {
+  const scripts = ['scripts/build-database.ts', 'scripts/build-fts.ts'];
+
+  for (const rel of scripts) {
+    it(`${rel} opts out of background index builds before locking EXCLUSIVE`, () => {
+      const src = fs.readFileSync(path.resolve(process.cwd(), rel), 'utf8');
+
+      expect(src).toContain('locking_mode = EXCLUSIVE');
+      expect(src).toContain('backgroundIndexBuilds: false');
+      // And it must actually build the indexes it deferred, or the production DB
+      // ships without them and every single-object re-index scans the whole table.
+      expect(src).toContain('deferFilePathIndexes: true');
+      expect(src).toContain('ensureFilePathIndexes()');
+
+      // Order matters: the opt-out is a constructor argument, so it has to appear
+      // before the pragma that would otherwise race the worker it prevents.
+      expect(src.indexOf('backgroundIndexBuilds: false'))
+        .toBeLessThan(src.indexOf('locking_mode = EXCLUSIVE'));
+    });
+  }
+});


### PR DESCRIPTION
`d365fo-mcp setup` fails on a database lock it takes out on itself. Root cause is
three things, not one.

## What happens

Opening an existing large index hands the deferred `file_path` index builds to
worker threads (`XppSymbolIndex.ensureFilePathIndexes` → `buildIndexInWorker`),
and each worker opens its **own write connection** to the same file.
`buildDatabase` then sets `locking_mode = EXCLUSIVE` on the writer. SQLite cannot
grant that while a second writer is live, so whoever loses the race fails with
SQLITE_BUSY — on a machine where the build has already been running for minutes.

The script does call `closeReadPool()` first, and that method's doc comment
explicitly says to: *"Must be called before setting locking_mode = EXCLUSIVE on
the writer."* The author knew about contention and guarded this exact line. But
the read pool is not the only other connection the class opens — `closeReadPool`
drains readers and knows nothing about the workers.

## The three fixes

| # | Problem | Fix |
|---|---------|-----|
| a | `closeReadPool()` promises more than it delivers | Doc comment says what it does *not* cover; warns on stderr when called with builds outstanding; `close()` tears them down; new `hasPendingIndexBuilds()` |
| b | `locking_mode = EXCLUSIVE` is incompatible with a worker on the same file | `XppSymbolIndex` takes `{ backgroundIndexBuilds: false }`; `build-database` and `build-fts` pass it. The worker exists to keep the *server's* event loop answering — a one-shot CLI has no event loop to protect, so it builds inline on the connection that already holds the lock |
| c | `buildIndexInWorker`'s comment assumes WAL, which the build script cancels two steps later | The dispatch checks `journal_mode` and refuses to spawn off WAL. The race is now closed structurally, even if a future caller forgets the flag |

Also: both scripts defer the `file_path` indexes past their bulk load
(`{ deferFilePathIndexes: true }`) and build them once at the end. Every row of
the load previously maintained two extra B-trees, and a full rebuild threw the
result away in `clear()` anyway.

## Deliberately not done

- **Raising `busy_timeout`** — masks the race rather than removing it.
- **Wrapping `createFTSTriggers` in a retry loop** — treats one of many places
  that hit the same lock.

## Why the existing tests missed it

They run on databases far below the 200 MB worker threshold, so the worker never
starts and the whole failing path is unreachable. `largeDbThresholdBytes` makes
that threshold injectable, which is what makes the bug testable at all.

`tests/metadata/filePathIndexBuildMode.test.ts` covers: the worker path is real
and observable at threshold 0; inline mode; defer mode; the non-WAL veto; the
small-DB default is unchanged. Plus a source-level ratchet that both build
scripts opt out *before* they take the lock — no unit test can run a 2 GB
rebuild, so that contract is pinned at the source instead.

**Negative control:** reverting the dispatch guard to the old
`if (isLarge(item.dbFile))` fails 3 of the new tests. They catch the bug, they do
not merely describe it.

## Verification

- Full suite: **5915 passed / 2 skipped, 397 files**
- `tsc --noEmit` clean, `biome lint` clean on all changed files
- Smoke run of both scripts end to end on a scratch database: `build-database`
  and `build-fts` complete, and the resulting DBs carry
  `idx_symbols_file_path`, `idx_symbols_file_path_nocase`,
  `idx_labels_file_path_id`

Version bumped to **1.16.1** (patch — no MCP tool-surface change) with a CHANGELOG
entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2yvn5ovrhvrycKfRvF2qZ
