### PR TITLE
fix(package): publish the SysTest XML parser the server imports at runtime — 1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,34 @@ _Nothing released yet._
 
 ---
 
+## [1.16.2] — 2026-09-01
+
+### Fixed
+- **The installed server would not start: `ERR_MODULE_NOT_FOUND` on
+  `dist/eval/oracle/systest.js`.** `run_systest_class` reads per-method results
+  out of the XML document SysTestConsole writes, and since the TDD-loop work it
+  imported that parser from the eval oracle — `src/eval/oracle/systest.ts`.
+  But `src/eval/**` is a dev-only tree that package.json keeps out of the
+  published tarball (`"!dist/eval/**"`), so every `npm i -g d365fo-mcp` got a
+  `sysTestRunner.js` importing a file that is not there, and the MCP server died
+  on load with the whole tool surface gone.
+
+  Nothing in the repo could see it: typecheck, lint and the test suite all
+  resolve against `src/`, where the excluded tree is present. It only exists in
+  the tarball.
+
+  The parser moved to `src/tools/sdlc/sysTestXml.ts` — beside the runner that
+  loads it, inside a published tree — and the eval oracle re-exports it, so the
+  dependency now runs eval → tools and never back. The published `files` list is
+  unchanged; the eval tree stays out.
+
+  `tests/packaging/publishedFiles.test.ts` now walks the import closure of every
+  packed `dist/**/*.js` and fails on any specifier that resolves to a file the
+  tarball excludes, so the next tree cut out of the package is covered too, not
+  just this pair.
+
+---
+
 ## [1.16.1] — 2026-09-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/eval/oracle/systest.ts
+++ b/src/eval/oracle/systest.ts
@@ -109,56 +109,8 @@ export function parseSysTestResult(output: string | null | undefined): SysTestRe
   return { ran: true, passed, failures };
 }
 
-/** One test method's outcome, read from the runner's XML result document. */
-export interface SysTestCaseOutcome {
-  name: string;
-  passed: boolean;
-  message?: string;
-}
-
-/**
- * Per-method outcomes from the `/xml:` document SysTestConsole writes.
- *
- * The shape is the platform's own: SysTestListenerXML builds
- * `<test-results><results><test-case name="…" success="true|false">` and adds a
- * `<failure><message>…</message></failure>` child for a failing one (the element
- * names are #define'd at the top of that class). Reading it beats the regex over
- * combined stdout that the runner used to classify with: a class named
- * …ErrorHandlingTest made "error" appear in the output of a passing run, and a
- * green run was reported as failed.
- *
- * Returns [] when the text is not such a document, so callers can fall back.
- */
-export function parseSysTestXml(xml: string | null | undefined): SysTestCaseOutcome[] {
-  if (!xml || !/<test-case\b/i.test(xml)) return [];
-
-  const outcomes: SysTestCaseOutcome[] = [];
-  // The SELF-CLOSING form has to be tried first. With the paired form leading, its
-  // `[^>]*` happily consumed the `/` of `<test-case … />` and the lazy body then ran
-  // on to the NEXT `</test-case>`, swallowing two results into one.
-  const caseRe = /<test-case\b([^>]*?)\/>|<test-case\b([^>]*)>([\s\S]*?)<\/test-case>/gi;
-  let m: RegExpExecArray | null;
-
-  while ((m = caseRe.exec(xml)) !== null) {
-    const attrs = m[1] ?? m[2] ?? '';
-    const body = m[3] ?? '';
-    const name = /\bname\s*=\s*"([^"]*)"/i.exec(attrs)?.[1] ?? '';
-    const successAttr = /\bsuccess\s*=\s*"([^"]*)"/i.exec(attrs)?.[1];
-    const failure = /<failure\b[^>]*>([\s\S]*?)<\/failure>/i.exec(body)?.[1];
-    const message = failure
-      ? (/<message\b[^>]*>([\s\S]*?)<\/message>/i.exec(failure)?.[1] ?? failure)
-        .replace(/<[^>]+>/g, ' ')
-        .replace(/\s+/g, ' ')
-        .trim()
-      : undefined;
-
-    // `success` is authoritative when present; a <failure> child decides otherwise.
-    const passed = successAttr !== undefined
-      ? /^(true|1)$/i.test(successAttr)
-      : failure === undefined;
-
-    outcomes.push(message ? { name, passed, message } : { name, passed });
-  }
-
-  return outcomes;
-}
+// The XML reader itself ships with the server (sysTestRunner.ts loads it at
+// runtime), so it lives under src/tools/ — src/eval/** is excluded from the
+// published package. Re-exported here so the oracle keeps one import surface.
+export type { SysTestCaseOutcome } from '../../tools/sdlc/sysTestXml.js';
+export { parseSysTestXml } from '../../tools/sdlc/sysTestXml.js';

--- a/src/tools/sdlc/sysTestRunner.ts
+++ b/src/tools/sdlc/sysTestRunner.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import { parseSysTestXml } from '../../eval/oracle/systest.js';
+import { parseSysTestXml } from './sysTestXml.js';
 import util from 'util';
 import path from 'path';
 import os from 'os';

--- a/src/tools/sdlc/sysTestXml.ts
+++ b/src/tools/sdlc/sysTestXml.ts
@@ -1,0 +1,65 @@
+/**
+ * Reader for the `/xml:` result document SysTestConsole writes.
+ *
+ * This lives beside the runner rather than in `src/eval/` because it is loaded
+ * at runtime by `sysTestRunner.ts`, and `src/eval/**` is a dev-only tree that
+ * package.json's `files` list keeps out of the published tarball
+ * (`"!dist/eval/**"`). A shipped module importing across that boundary makes
+ * the installed server fail to start with ERR_MODULE_NOT_FOUND. The eval
+ * oracle re-exports this from `src/eval/oracle/systest.ts`; the dependency
+ * runs eval → tools, never the other way.
+ */
+
+/** One test method's outcome, read from the runner's XML result document. */
+export interface SysTestCaseOutcome {
+  name: string;
+  passed: boolean;
+  message?: string;
+}
+
+/**
+ * Per-method outcomes from the `/xml:` document SysTestConsole writes.
+ *
+ * The shape is the platform's own: SysTestListenerXML builds
+ * `<test-results><results><test-case name="…" success="true|false">` and adds a
+ * `<failure><message>…</message></failure>` child for a failing one (the element
+ * names are #define'd at the top of that class). Reading it beats the regex over
+ * combined stdout that the runner used to classify with: a class named
+ * …ErrorHandlingTest made "error" appear in the output of a passing run, and a
+ * green run was reported as failed.
+ *
+ * Returns [] when the text is not such a document, so callers can fall back.
+ */
+export function parseSysTestXml(xml: string | null | undefined): SysTestCaseOutcome[] {
+  if (!xml || !/<test-case\b/i.test(xml)) return [];
+
+  const outcomes: SysTestCaseOutcome[] = [];
+  // The SELF-CLOSING form has to be tried first. With the paired form leading, its
+  // `[^>]*` happily consumed the `/` of `<test-case … />` and the lazy body then ran
+  // on to the NEXT `</test-case>`, swallowing two results into one.
+  const caseRe = /<test-case\b([^>]*?)\/>|<test-case\b([^>]*)>([\s\S]*?)<\/test-case>/gi;
+  let m: RegExpExecArray | null;
+
+  while ((m = caseRe.exec(xml)) !== null) {
+    const attrs = m[1] ?? m[2] ?? '';
+    const body = m[3] ?? '';
+    const name = /\bname\s*=\s*"([^"]*)"/i.exec(attrs)?.[1] ?? '';
+    const successAttr = /\bsuccess\s*=\s*"([^"]*)"/i.exec(attrs)?.[1];
+    const failure = /<failure\b[^>]*>([\s\S]*?)<\/failure>/i.exec(body)?.[1];
+    const message = failure
+      ? (/<message\b[^>]*>([\s\S]*?)<\/message>/i.exec(failure)?.[1] ?? failure)
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+      : undefined;
+
+    // `success` is authoritative when present; a <failure> child decides otherwise.
+    const passed = successAttr !== undefined
+      ? /^(true|1)$/i.test(successAttr)
+      : failure === undefined;
+
+    outcomes.push(message ? { name, passed, message } : { name, passed });
+  }
+
+  return outcomes;
+}

--- a/tests/packaging/publishedFiles.test.ts
+++ b/tests/packaging/publishedFiles.test.ts
@@ -24,6 +24,15 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { describe, it, expect, beforeAll } from 'vitest';
 
+/** Drop block comments and whole-line // comments, so examples in docs are not read as imports. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split(/\r?\n/)
+    .filter(line => !/^\s*\/\//.test(line))
+    .join('\n');
+}
+
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
 /** Whether `npm run build` has produced anything for `npm pack` to publish. */
@@ -109,5 +118,44 @@ describe.skipIf(!isBuilt)('published package contents', () => {
     expect(packed.filter(p => p.endsWith('.map'))).toEqual([]);
     expect(packed.filter(p => p.startsWith('dist/eval/'))).toEqual([]);
     expect(packed.filter(p => p.startsWith('data/'))).toEqual([]);
+  });
+
+  /**
+   * The exclusions above cut whole trees out of a tarball that is otherwise
+   * built from one tsc run — so a shipped module can still `import` a file that
+   * was left behind, and nothing in the repo notices: typecheck, lint and the
+   * whole test suite resolve against src/, where the excluded tree is present.
+   * The failure lands on the user, at startup, as
+   *   ERR_MODULE_NOT_FOUND: Cannot find module '<pkg>/dist/eval/oracle/systest.js'
+   *   imported from '<pkg>/dist/tools/sdlc/sysTestRunner.js'
+   * with the server dead — which is exactly what `!dist/eval/**` did to
+   * v1.16.x once run_systest_class started reading its XML parser from the eval
+   * oracle. Checking the closure rather than that one pair means the next
+   * exclusion is covered too.
+   */
+  it('publishes every module its published modules import', () => {
+    const packedSet = new Set(packed);
+    // Static `from '…'`, bare side-effect `import '…'`, and literal `import('…')`.
+    const SPECIFIER =
+      /(?:\bfrom\s*|\bimport\s*\(?\s*|\brequire\s*\(\s*)['"](\.[^'"]*)['"]/g;
+    const dangling: string[] = [];
+
+    for (const file of packed.filter(p => p.startsWith('dist/') && p.endsWith('.js'))) {
+      // Comments first: src/bridge/index.ts documents its own import path in a
+      // JSDoc example, and a doc line is not a module edge.
+      const source = stripComments(fs.readFileSync(path.join(REPO_ROOT, file), 'utf8'));
+      for (const [, specifier] of source.matchAll(SPECIFIER)) {
+        const target = path.posix.join(path.posix.dirname(file), specifier);
+        if (!packedSet.has(target)) dangling.push(`${file} → ${specifier}`);
+      }
+    }
+
+    expect(
+      dangling,
+      'these published modules import files the `files` list excludes; the installed ' +
+      'server fails to start with ERR_MODULE_NOT_FOUND. Move the imported code into a ' +
+      'published tree (see src/tools/sdlc/sysTestXml.ts) rather than publishing the ' +
+      'excluded one',
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## The bug

The installed server would not start. Every `npm i -g d365fo-mcp` on **1.16.1** dies on load with:

```
ERR_MODULE_NOT_FOUND: Cannot find module
'<pkg>/dist/eval/oracle/systest.js' imported from
'<pkg>/dist/tools/sdlc/sysTestRunner.js'
```

and the whole tool surface goes with it. Reported from a real install.

## Why

`run_systest_class` reads per-method results out of the XML document SysTestConsole writes, and since the TDD-loop work (0887d9f) it imported that parser from the eval oracle:

```ts
// src/tools/sdlc/sysTestRunner.ts — a file that ships
import { parseSysTestXml } from '../../eval/oracle/systest.js';
```

But `src/eval/**` is a dev-only tree that `package.json` deliberately keeps out of the tarball (`"!dist/eval/**"`). Confirmed with `npm pack --dry-run`: the tarball ships `sysTestRunner.js` and **zero** `dist/eval` entries.

Nothing in the repo could see it. Typecheck, lint and all 5,916 tests resolve against `src/`, where the excluded tree is present — the breakage exists only in the tarball, which is why a fully green suite shipped it.

## The fix

`parseSysTestXml` moves to `src/tools/sdlc/sysTestXml.ts` — beside the runner that loads it, inside a published tree — and `src/eval/oracle/systest.ts` re-exports it, so the dependency runs eval → tools and never back. The `files` list is **unchanged**; the eval tree stays out of the package, as intended.

## The gate

`tests/packaging/publishedFiles.test.ts` now walks every specifier in every packed `dist/**/*.js` and fails on any that resolves outside the tarball — so this checks the **closure**, not just this one pair, and the next tree cut out of the package is covered too.

Verified as a negative control: restoring the old import makes it report exactly

```
dist/tools/sdlc/sysTestRunner.js → ../../eval/oracle/systest.js
```

Comments are stripped before the scan — `src/bridge/index.ts` documents its own import path in a JSDoc example, and a doc line is not a module edge.

## Release

Patch bump to **1.16.2** (no tool-surface change), following the 1.16.1 convention of cutting the version in the fix commit itself.

Until it is published, an existing broken install can be unblocked by dropping the parser into the missing path — the old `sysTestRunner.js` imports only `parseSysTestXml` from there:

```powershell
$dst = "$env:APPDATA\npm\node_modules\d365fo-mcp\dist\eval\oracle"
New-Item -ItemType Directory -Force $dst | Out-Null
Copy-Item "<checkout>\dist\tools\sdlc\sysTestXml.js" "$dst\systest.js"
```

## Testing

- Full suite: **397 files, 5,916 passed**, 2 skipped.
- `npm pack --dry-run` closure clean.
- Negative control on the new gate reproduces the reported failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rc4k7F4Sp86gnz9p8qdpP
