### PR TITLE
D4: the report-design operation — an AxReport's first write path, paid for with a measured trim

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -128,7 +128,7 @@ Mode-specific parameters go in a single `params` object (flat top-level keys sti
 `d365fo_file` actions:
 
 - **`create`** — create any of 39 AOT object types in the correct location + register in `.rnrproj` (gated by grounding token and form-pattern validation).
-- **`modify`** — safe metadata edits via the C# bridge, 38 operations: add-field, add-control, remove-control, add-entry-point, add-method, replace-code, modify-property, …
+- **`modify`** — safe metadata edits via the C# bridge, 39 operations: add-field, add-control, remove-control, add-entry-point, add-method, replace-code, modify-property, report-design, …
 - **`delete`** — remove an object's XML and un-register it from every `.rnrproj` of the model that lists it (irreversible; guarded against standard-model and cross-model targets).
 - **`undo`** — roll `filePath` back: git-tracked → `git checkout HEAD`, which discards ALL uncommitted changes to that file, not just the last edit; untracked → deleted; the symbol/label index is re-synced either way.
 - **`generate`** — XML preview without writing (cloud-friendly).

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -1481,6 +1481,10 @@ const BRIDGE_MODIFY_OPS = new Set([
   // No C# op exists for query ranges on entities — served entirely by a
   // direct-XML writer (data-entity is already in BRIDGE_MODIFY_TYPES).
   'add-query-range', 'remove-query-range',
+  // Routed straight to the XML writer by XML_ONLY_MODIFY_PAIRS below, but the
+  // dispatch gate is checked FIRST — an op absent here is refused as unknown
+  // before the pair table is ever consulted.
+  'report-design',
 ]);
 
 /**
@@ -1516,6 +1520,12 @@ const XML_ONLY_MODIFY_PAIRS: Record<string, ReadonlySet<string>> = {
   'remove-entry-point': new Set(['security-privilege']),
   'remove-diagnostic-suppression': new Set(['ignore-diagnostic-list']),
   'add-diagnostic-suppression': new Set(['ignore-diagnostic-list']),
+  // An AxReport has no bridge write path at all — IMetadataProvider cannot express
+  // a dataset field or a report parameter through a Dictionary<string,string> — and
+  // `report` is deliberately absent from BRIDGE_MODIFY_TYPES for that reason. Without
+  // this pair the caller would get "the bridge could not resolve the object" instead
+  // of the operation actually running.
+  'report-design': new Set(['report']),
 };
 
 /**

--- a/src/server/toolAnnotations.ts
+++ b/src/server/toolAnnotations.ts
@@ -28,6 +28,28 @@ export interface ToolAnnotations {
   openWorldHint?: boolean;
 }
 
+/**
+ * A HINT IS ONLY WORTH SENDING WHEN IT DISAGREES WITH THE SPEC DEFAULT.
+ *
+ * The MCP defaults are `readOnlyHint: false`, `destructiveHint: true`,
+ * `idempotentHint: false`, `openWorldHint: true`. A field repeating its own
+ * default tells a compliant client exactly what its absence would have told it,
+ * and this payload is rationed — the ListTools response is re-sent on every
+ * request and sits against a 45,000-char ratchet.
+ *
+ * Measured: omitting `readOnlyHint: false` (6 tools) and `idempotentHint: false`
+ * (4 tools) recovers 218 chars, which is what paid for the `report-design`
+ * operation's enum value.
+ *
+ * ONE DEFAULT IS KEPT ON PURPOSE. `destructiveHint: true` is also the spec
+ * default, and it stays explicit on the two tools that carry it. Absence is only
+ * equivalent to the default for a client that implements defaults; a client that
+ * reads absence as "unknown" would become MORE cautious about a missing
+ * `readOnlyHint` and LESS cautious about a missing `destructiveHint`. The first
+ * direction is safe to take, the second is not, and 46 chars is not a reason to
+ * gamble on a confirmation dialog for a destructive write.
+ */
+
 /** Read/analysis tool — no filesystem or DB writes. */
 function read(title: string): ToolAnnotations {
   return { title, readOnlyHint: true, openWorldHint: false };
@@ -40,9 +62,10 @@ function write(
 ): ToolAnnotations {
   return {
     title,
-    readOnlyHint: false,
+    // readOnlyHint omitted: false is the spec default for every tool here.
+    // destructiveHint always sent, with its REAL value — see the note above.
     destructiveHint: opts.destructive ?? false,
-    idempotentHint: opts.idempotent ?? false,
+    ...(opts.idempotent ? { idempotentHint: true } : {}),
     openWorldHint: false,
   };
 }

--- a/src/server/toolSchemas/d365foFile.ts
+++ b/src/server/toolSchemas/d365foFile.ts
@@ -104,6 +104,7 @@ Model + prefix auto-applied.`,
             'add-menu-item-to-menu',
             'modify-property',
             'add-query-range', 'remove-query-range',
+            'report-design',
           ],
           description:
             '[modify] REQUIRED unless using operations[]. add-method also UPDATES in place; ' +

--- a/src/tools/specs/d365foFileOpSpecs.ts
+++ b/src/tools/specs/d365foFileOpSpecs.ts
@@ -291,6 +291,48 @@ export const D365FO_FILE_PARAM_SPECS: Record<string, { type: string; description
       'Name for the range object (<Name>). Defaults to rangeField when omitted. ' +
       'Only ever matched against other ranges of the SAME data source.',
   },
+  reportAction: {
+    type: '"refresh-dataset" | "add-parameter"',
+    description:
+      'report-design: which half to do. "refresh-dataset" copies the temp table fields into the dataset; ' +
+      '"add-parameter" declares a report parameter and binds it to the dataset. There is deliberately no ' +
+      '"add-column" — placing a column edits the RDL, whose failures surface only in the SSRS renderer.',
+  },
+  tableName: {
+    type: 'string',
+    description:
+      'report-design(refresh-dataset): the temp table whose fields the dataset should carry. It is read ' +
+      'off disk, so it must exist; only MISSING fields are added, never rewritten or removed.',
+  },
+  datasetName: {
+    type: 'string',
+    description:
+      'report-design: which dataset to act on. Optional when the report has exactly one; REQUIRED when it ' +
+      'has several, because guessing puts the field on the wrong dataset.',
+  },
+  parameterName: {
+    type: 'string',
+    description: 'report-design(add-parameter): the parameter to declare and bind.',
+  },
+  parameterDataType: {
+    type: 'string',
+    description:
+      'report-design(add-parameter): .NET type name, default System.String. Shipped reports use ' +
+      'System.String / System.Boolean / System.DateTime / System.Int32 / System.Int64.',
+  },
+  parameterHidden: {
+    type: 'boolean',
+    description:
+      'report-design(add-parameter): true writes <UserVisibility>Hidden</UserVisibility>. Leave it off for ' +
+      'a VISIBLE parameter — across 1,057 shipped reports there is no "Visible" value, a visible parameter ' +
+      'omits the element, and an unknown one is dropped silently.',
+  },
+  promptString: {
+    type: 'string',
+    description:
+      'report-design(add-parameter): the dialog caption. Pass a LABEL id ("@MyModel:FromDate") — it is ' +
+      'user-visible text living in metadata, which no BP rule checks.',
+  },
   rangeValue: {
     type: 'string',
     description:
@@ -611,6 +653,26 @@ export const D365FO_FILE_OP_SPECS: Record<string, D365FileOpSpec> = {
     required: ['dataSourceName', 'dataSourceTable'],
     optional: ['joinSource', 'linkType'],
     note: 'form-extension only.',
+  },
+  'report-design': {
+    required: ['reportAction'],
+    optional: ['tableName', 'datasetName', 'parameterName', 'parameterDataType', 'parameterHidden', 'promptString'],
+    note:
+      'objectType="report" only — the FIRST write path an AxReport has. Two actions, both metadata-only: ' +
+      'reportAction="refresh-dataset" (+ tableName, optional datasetName) copies the temp table\'s fields ' +
+      'into the dataset, adding only what is missing; reportAction="add-parameter" (+ parameterName, ' +
+      'optional parameterDataType [default System.String], parameterHidden, promptString, datasetName) ' +
+      'declares a parameter AND binds it to the dataset, which are two elements in two collections that ' +
+      'must agree. ' +
+      'It NEVER touches the RDL in the <![CDATA[…]]> block and never removes anything: a dataset field the ' +
+      'design does not bind is inert, while removing one it does bind breaks the render — and a malformed ' +
+      'RDL fails in the SSRS renderer at run time, where no build and no test can see it. ' +
+      'For the same reason there is no "add-column": placing a column IS layout, and layout stays with the ' +
+      'Report Designer. Both actions are idempotent. ' +
+      'parameterHidden=true writes <UserVisibility>Hidden</UserVisibility>; leave it off for a VISIBLE ' +
+      'parameter — across 1,057 shipped reports and 13,833 parameters there is no "Visible" value, a ' +
+      'visible parameter simply omits the element, and an unknown one is dropped silently ' +
+      '(get_knowledge(topic="axreport-anatomy")).',
   },
   'add-query-range': {
     required: ['dataSourceName', 'rangeField', 'rangeValue'],

--- a/src/tools/write/modifyD365File.ts
+++ b/src/tools/write/modifyD365File.ts
@@ -102,6 +102,7 @@ import {
   directXmlAddDiagnosticSuppression,
   directXmlEnsureRelationProperties,
 } from './directXmlWriters.js';
+import { addReportParameter, refreshReportDataset } from './reportDesignXml.js';
 
 
 /**
@@ -521,6 +522,7 @@ export const ModifyD365FileArgsSchema = z.object({
     'add-enum-value', 'modify-enum-value', 'remove-enum-value',
     'add-display-method', 'add-table-method', 'add-menu-item-to-menu',
     'add-query-range', 'remove-query-range',
+    'report-design',
   ]).describe(
     'Operation to perform. ' +
     'replace-code REQUIRES parameters: oldCode (exact code to find) + newCode (replacement). ' +
@@ -849,6 +851,39 @@ export const ModifyD365FileArgsSchema = z.object({
     'add-query-range: filter value, REQUIRED (e.g. "1" for NoYes, "Sales" for an enum, "1..99" for an ' +
     'interval). Pass the two characters "" for the empty-string filter — a range with no value at all ' +
     'filters nothing and is not a shape D365FO ships.'
+  ),
+  // ── report-design ─────────────────────────────────────────────────────────
+  // Declared here so a strict MCP client can send them: these are top-level keys,
+  // and an undeclared one is dropped before it reaches the handler.
+  reportAction: z.enum(['refresh-dataset', 'add-parameter']).optional().describe(
+    'report-design: which half to do. "refresh-dataset" copies the temp table fields into the ' +
+    'dataset (needs tableName); "add-parameter" declares a parameter and binds it (needs parameterName). ' +
+    'There is deliberately no "add-column" — that edits the RDL, whose failures surface only in the ' +
+    'SSRS renderer.'
+  ),
+  tableName: z.string().optional().describe(
+    'report-design(refresh-dataset): the temp table whose fields the dataset should carry. Read off ' +
+    'disk, so it must exist; only MISSING fields are added, never rewritten or removed.'
+  ),
+  datasetName: z.string().optional().describe(
+    'report-design: which dataset to act on. Optional when the report has exactly one — required when ' +
+    'it has several, because guessing puts the field on the wrong dataset.'
+  ),
+  parameterName: z.string().optional().describe(
+    'report-design(add-parameter): the parameter to declare and bind.'
+  ),
+  parameterDataType: z.string().optional().describe(
+    'report-design(add-parameter): .NET type name, default System.String. The vocabulary shipped ' +
+    'reports use is System.String / System.Boolean / System.DateTime / System.Int32 / System.Int64.'
+  ),
+  parameterHidden: z.boolean().optional().describe(
+    'report-design(add-parameter): true writes <UserVisibility>Hidden</UserVisibility>. Leave it off ' +
+    'for a VISIBLE parameter — there is no "Visible" value in any of the 8,977 shipped parameters, a ' +
+    'visible one omits the element, and an unknown value is dropped silently.'
+  ),
+  promptString: z.string().optional().describe(
+    'report-design(add-parameter): the dialog caption. Pass a LABEL id ("@MyModel:FromDate") — it is ' +
+    'user-visible text in metadata, which no BP rule checks.'
   ),
   joinSource: z.string().optional().describe(
     'Optional name of an existing data source on the form to join the new data source to (add-data-source).'
@@ -2777,6 +2812,42 @@ export async function modifyD365FileTool(
             (args as any).joinSource,
             (args as any).linkType,
           );
+        }
+        break;
+      }
+      case 'report-design': {
+        // The first write path an AxReport has ever had, and deliberately a
+        // narrow one: metadata only, additive only, and the RDL inside the
+        // <![CDATA[…]]> block is never touched. A malformed RDL fails in the
+        // SSRS renderer at run time, where no build and no test can see it.
+        const reportAction = String((args as any).reportAction ?? '').trim();
+        if (reportAction === 'refresh-dataset') {
+          bridgeResult = viaXmlFallback(await refreshReportDataset(
+            actualFilePath,
+            String((args as any).tableName ?? ''),
+            (args as any).datasetName,
+          ));
+        } else if (reportAction === 'add-parameter') {
+          bridgeResult = viaXmlFallback(await addReportParameter(
+            actualFilePath,
+            String((args as any).parameterName ?? ''),
+            {
+              dataType: (args as any).parameterDataType,
+              hidden: (args as any).parameterHidden === true,
+              promptString: (args as any).promptString,
+              datasetName: (args as any).datasetName,
+            },
+          ));
+        } else {
+          bridgeResult = viaXmlFallback({
+            success: false,
+            message:
+              `❌ report-design: reportAction '${reportAction || '(missing)'}' is not one this operation ` +
+              'knows. Pass "refresh-dataset" (sync the dataset with its temp table) or "add-parameter". ' +
+              'There is deliberately no "add-column": placing a column edits the RDL, and a malformed ' +
+              'RDL fails in the SSRS renderer at run time rather than at build time — that half stays ' +
+              'with the Report Designer.',
+          });
         }
         break;
       }

--- a/src/tools/write/reportDesignXml.ts
+++ b/src/tools/write/reportDesignXml.ts
@@ -1,0 +1,366 @@
+/**
+ * `d365fo_file(action="modify", objectType="report", operation="report-design")`
+ * — the first write path an AxReport has ever had.
+ *
+ * Until now every report recipe ended with "open the Report Designer", and for
+ * LAYOUT that is still true and correct. But two of the things a developer needs
+ * after scaffolding a report are not layout at all — they are bookkeeping the
+ * tool already holds every input for, and getting them wrong is silent:
+ *
+ *  - `refresh-dataset` — a field was added to the DP's temp table and the report's
+ *    dataset does not know about it. The information is on disk in the table's own
+ *    XML; nothing about copying it is a design decision.
+ *  - `add-parameter` — a report parameter is two elements in two collections that
+ *    must agree. Hand-writing one and forgetting the other produces a document
+ *    that builds and behaves oddly.
+ *
+ * ── WHAT MAKES THIS SAFE, AND WHY IT IS NOT A FINGERPRINT ────────────────────
+ * The plan proposed refusing "any design the scaffold does not own", enforced by
+ * a marker in the RDL. That guard has the wrong shape: it is a property of the
+ * FILE's provenance, so every report scaffolded before the marker existed — the
+ * committed goldens included — would be refused, and a hand-written report that
+ * acquired the marker would be accepted.
+ *
+ * The guarantee here is a property of the OPERATION instead, and it holds for
+ * every document regardless of origin:
+ *
+ *   1. **Metadata only.** The RDL lives in a `<![CDATA[…]]>` block and is never
+ *      read, parsed or written. A malformed RDL fails in the SSRS renderer at run
+ *      time, where no build and no test can see it, so this code does not go near
+ *      it.
+ *   2. **Additive only.** Fields and parameters are added; nothing is removed or
+ *      renamed. Adding a dataset field the RDL does not reference is inert — the
+ *      design simply does not show it. REMOVING one the RDL does reference breaks
+ *      the render, so removal is not offered at all.
+ *
+ * That is also why there is no `add-column`: putting a column in the layout means
+ * editing the RDL, and the failure mode there is invisible until someone runs the
+ * report.
+ */
+
+import * as fs from 'fs/promises';
+import { findTableXmlPath } from '../../utils/fieldControlTypes.js';
+
+export interface ReportDesignResult {
+  success: boolean;
+  message: string;
+}
+
+/** AOT names are identifiers; anything else is a caller mistake, not a shape to write. */
+function nonIdentifier(value: string | undefined): boolean {
+  return !value || !/^[A-Za-z_]\w*$/.test(value);
+}
+
+/**
+ * X++ base type → the .NET type name a dataset field carries.
+ *
+ * Deliberately the same mapping `generateSmartReport.ts` uses. The two types a
+ * report field has — the X++ one on the temp table and the .NET one in the
+ * dataset — drifting apart is a hard "Data type mismatch" at build time, which
+ * is exactly the defect that mapping was written for.
+ */
+function rdlDataType(iType: string | undefined, enumType: string | undefined): string {
+  if (enumType) return 'System.Int32';
+  switch (iType) {
+    case 'AxTableFieldReal': return 'System.Double';
+    case 'AxTableFieldInt': return 'System.Int32';
+    case 'AxTableFieldInt64': return 'System.Int64';
+    case 'AxTableFieldDate':
+    case 'AxTableFieldUtcDateTime': return 'System.DateTime';
+    case 'AxTableFieldEnum': return 'System.Int32';
+    case 'AxTableFieldContainer': return 'System.Byte[]';
+    default: return 'System.String';
+  }
+}
+
+/** `<AxTableField … i:type="X">` blocks, in declaration order, with their names. */
+function tableFields(tableXml: string): Array<{ name: string; iType: string; enumType?: string }> {
+  const out: Array<{ name: string; iType: string; enumType?: string }> = [];
+  const re = /<AxTableField\b[^>]*?i:type="(AxTableField\w+)"[^>]*>([\s\S]*?)<\/AxTableField>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(tableXml)) !== null) {
+    const name = /<Name>([^<]+)<\/Name>/.exec(m[2])?.[1]?.trim();
+    if (!name) continue;
+    out.push({ name, iType: m[1], enumType: /<EnumType>([^<]+)<\/EnumType>/.exec(m[2])?.[1]?.trim() });
+  }
+  return out;
+}
+
+/**
+ * The `<AxReportDataSet>` block for one dataset, located WITHOUT parsing the RDL.
+ *
+ * The document holds the design's RDL in a CDATA block that reaches megabytes and
+ * contains element names identical to the metadata ones. Every search here runs
+ * on a copy with those blocks blanked, so a `<Fields>` tag inside the RDL can
+ * never be mistaken for the dataset's own.
+ */
+function locateDataSet(content: string, datasetName?: string):
+  | { ok: true; start: number; end: number; name: string }
+  | { ok: false; reason: string; available: string[] } {
+  const masked = content.replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, m => ' '.repeat(m.length));
+  const blocks: Array<{ start: number; end: number; name: string }> = [];
+  const re = /<AxReportDataSet\b[^>]*>([\s\S]*?)<\/AxReportDataSet>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(masked)) !== null) {
+    const name = /<Name>([^<]+)<\/Name>/.exec(m[1])?.[1]?.trim();
+    if (name) blocks.push({ start: m.index, end: m.index + m[0].length, name });
+  }
+  if (blocks.length === 0) return { ok: false, reason: 'no-datasets', available: [] };
+
+  const available = blocks.map(b => b.name);
+  if (!datasetName) {
+    if (blocks.length === 1) return { ok: true, ...blocks[0] };
+    return { ok: false, reason: 'ambiguous', available };
+  }
+  const hit = blocks.find(b => b.name.toLowerCase() === datasetName.trim().toLowerCase());
+  return hit ? { ok: true, ...hit } : { ok: false, reason: 'not-found', available };
+}
+
+/**
+ * The `<Fields>…</Fields>` collection inside a located dataset block.
+ *
+ * ATTRIBUTES ARE THE NORM, not the exception. A literal `<Fields>` search finds
+ * the committed goldens and misses what the scaffold itself writes, because the
+ * generator emits `xmlns=""` on several of these containers — which is how the
+ * first live run of this operation refused a report the scaffold had just made.
+ * Every container search in this file is attribute-tolerant for that reason.
+ *
+ * `<Fields />` is a real shape for a dataset with none yet, and it is not one
+ * this function can insert into — the caller reports that rather than silently
+ * finding nothing.
+ */
+function locateFields(block: string): { innerStart: number; innerEnd: number; indent: string } | undefined {
+  const open = /<Fields\b[^>]*>/.exec(block);
+  if (!open || open[0].endsWith('/>')) return undefined;
+  const closeIdx = block.indexOf('</Fields>', open.index);
+  if (closeIdx < 0) return undefined;
+  const inner = block.slice(open.index + open[0].length, closeIdx);
+  const indent = /\n([ \t]+)</.exec(inner)?.[1] ?? '\t\t\t\t';
+  return { innerStart: open.index + open[0].length, innerEnd: closeIdx, indent };
+}
+
+/**
+ * Sync a report dataset with the temp table it reads.
+ *
+ * ADD-ONLY, by construction: a field the report already declares is left exactly
+ * as it is, even when the table now disagrees about its type. Rewriting it would
+ * be the one edit that can break a render, because the RDL binds by name AND
+ * type, and this operation has no way to see the RDL.
+ */
+export async function refreshReportDataset(
+  filePath: string,
+  tableName: string,
+  datasetName?: string,
+  packageRoots?: readonly string[],
+): Promise<ReportDesignResult> {
+  const raw = await fs.readFile(filePath, 'utf-8');
+  const content = raw.replace(/^﻿/, '');
+
+  if (!/<AxReport\b/.test(content)) {
+    return { success: false, message: `❌ report-design: '${filePath}' is not an AxReport — nothing was written.` };
+  }
+  if (nonIdentifier(tableName)) {
+    return {
+      success: false,
+      message: `❌ report-design(refresh-dataset): tableName '${tableName}' is not a valid AOT name.`,
+    };
+  }
+
+  const tablePath = findTableXmlPath(tableName, packageRoots);
+  if (!tablePath) {
+    return {
+      success: false,
+      message:
+        `❌ report-design(refresh-dataset): table '${tableName}' was not found on disk, so its fields ` +
+        'cannot be read. Create the table first, or check the spelling — this operation copies the ' +
+        'table\'s own field list and will not invent one.',
+    };
+  }
+
+  const located = locateDataSet(content, datasetName);
+  if (!located.ok) {
+    return { success: false, message: datasetError('refresh-dataset', located, datasetName) };
+  }
+
+  const block = content.slice(located.start, located.end);
+  const fields = locateFields(block);
+  if (!fields) {
+    return {
+      success: false,
+      message:
+        `❌ report-design(refresh-dataset): dataset '${located.name}' has no <Fields> collection. ` +
+        'This document was not produced by the report scaffold and its shape is not one this ' +
+        'operation can extend safely.',
+    };
+  }
+
+  const existing = new Set(
+    [...block.matchAll(/<AxReportDataSetField>[\s\S]*?<Name>([^<]+)<\/Name>/g)].map(m => m[1].trim().toLowerCase()),
+  );
+  const tableXml = await fs.readFile(tablePath, 'utf-8');
+  const missing = tableFields(tableXml).filter(f => !existing.has(f.name.toLowerCase()));
+
+  if (missing.length === 0) {
+    return {
+      success: true,
+      message:
+        `✅ report-design(refresh-dataset): dataset '${located.name}' already carries every field of ` +
+        `'${tableName}' (${existing.size} field(s)) — nothing to add.`,
+    };
+  }
+
+  const { indent } = fields;
+  const added = missing.map(f =>
+    `${indent}<AxReportDataSetField>\n` +
+    `${indent}\t<Name>${f.name}</Name>\n` +
+    `${indent}\t<Alias>${located.name}.1.${f.name}</Alias>\n` +
+    `${indent}\t<DataType>${rdlDataType(f.iType, f.enumType)}</DataType>\n` +
+    `${indent}\t<DisplayWidth>Auto</DisplayWidth>\n` +
+    `${indent}\t<UserDefined>false</UserDefined>\n` +
+    `${indent}</AxReportDataSetField>\n`,
+  ).join('');
+
+  const insertAt = located.start + fields.innerEnd;
+  const next = `${content.slice(0, insertAt)}${added}${content.slice(insertAt)}`;
+  await fs.writeFile(filePath, `﻿${next.replace(/^﻿/, '')}`, 'utf-8');
+
+  return {
+    success: true,
+    message:
+      `✅ report-design(refresh-dataset): added ${missing.length} field(s) to dataset '${located.name}' ` +
+      `from table '${tableName}': ${missing.map(f => f.name).join(', ')}.\n` +
+      '⚠️ The DESIGN does not show them yet. A dataset field the RDL does not bind is inert — open the ' +
+      'Report Designer to place it, which is the half no tool here writes.',
+  };
+}
+
+/**
+ * Add a report parameter — both halves of it.
+ *
+ * A parameter is two elements in two collections: an `<AxReportParameterBase>`
+ * that declares it and an `<AxReportDataSetParameter>` that binds it to the
+ * dataset. Writing one without the other is the mistake this exists to prevent.
+ *
+ * The property vocabulary is not invented. Across 1,057 shipped AxReport
+ * documents and 13,833 parameters, `UserVisibility` holds only `Hidden` (8,972)
+ * and `Internal` (5) — a VISIBLE parameter omits the element — and `AllowBlank`
+ * and `Nullable` appear only as `true`, never `false`. So visibility is expressed
+ * by presence, and the flags are written only when they are on.
+ */
+export async function addReportParameter(
+  filePath: string,
+  parameterName: string,
+  opts: { dataType?: string; hidden?: boolean; promptString?: string; datasetName?: string } = {},
+): Promise<ReportDesignResult> {
+  const raw = await fs.readFile(filePath, 'utf-8');
+  const content = raw.replace(/^﻿/, '');
+
+  if (!/<AxReport\b/.test(content)) {
+    return { success: false, message: `❌ report-design: '${filePath}' is not an AxReport — nothing was written.` };
+  }
+  if (nonIdentifier(parameterName)) {
+    return {
+      success: false,
+      message: `❌ report-design(add-parameter): parameterName '${parameterName}' is not a valid AOT name.`,
+    };
+  }
+
+  const masked = content.replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, m => ' '.repeat(m.length));
+  const already = [...masked.matchAll(/<AxReportParameterBase\b[^>]*>[\s\S]*?<Name>([^<]+)<\/Name>/g)]
+    .some(m => m[1].trim().toLowerCase() === parameterName.toLowerCase());
+  if (already) {
+    return {
+      success: true,
+      message: `✅ report-design(add-parameter): '${parameterName}' is already declared — nothing to do.`,
+    };
+  }
+
+  const basesOpen = /<ReportParameterBases\b[^>]*>/.exec(masked);
+  if (!basesOpen) {
+    return {
+      success: false,
+      message:
+        '❌ report-design(add-parameter): the document has no <ReportParameterBases> collection, so it ' +
+        'was not produced by the report scaffold and its shape is not one this operation can extend safely.',
+    };
+  }
+  const basesClose = masked.indexOf('</ReportParameterBases>', basesOpen.index);
+  if (basesClose < 0) {
+    return { success: false, message: '❌ report-design(add-parameter): <ReportParameterBases> is not closed.' };
+  }
+
+  const dataType = opts.dataType?.trim() || 'System.String';
+  const indent = /\n([ \t]+)</.exec(content.slice(basesOpen.index + basesOpen[0].length, basesClose))?.[1] ?? '\t\t\t';
+  // Visibility is expressed by PRESENCE: `Hidden` when hidden, and the element
+  // omitted entirely when the user should see it. There is no "Visible" value in
+  // any of the 8,977 shipped parameters, and an unknown one is dropped silently.
+  const parameterXml =
+    `${indent}<AxReportParameterBase xmlns=""\n` +
+    `${indent}\t\ti:type="AxReportParameter">\n` +
+    `${indent}\t<Name>${parameterName}</Name>\n` +
+    `${indent}\t<AllowBlank>true</AllowBlank>\n` +
+    `${indent}\t<Nullable>true</Nullable>\n` +
+    (opts.hidden ? `${indent}\t<UserVisibility>Hidden</UserVisibility>\n` : '') +
+    (opts.promptString ? `${indent}\t<PromptString>${opts.promptString}</PromptString>\n` : '') +
+    `${indent}\t<DataType>${dataType}</DataType>\n` +
+    `${indent}\t<DefaultValue />\n` +
+    `${indent}\t<Values />\n` +
+    `${indent}</AxReportParameterBase>\n`;
+
+  let next = `${content.slice(0, basesClose)}${parameterXml}${content.slice(basesClose)}`;
+
+  // The dataset half. Without it the parameter exists and binds to nothing.
+  const located = locateDataSet(next, opts.datasetName);
+  let boundTo = '(none — no dataset resolved)';
+  if (located.ok) {
+    const block = next.slice(located.start, located.end);
+    const paramsOpen = /<Parameters\b[^>]*>/.exec(block);
+    const paramsClose = paramsOpen ? block.indexOf('</Parameters>', paramsOpen.index) : -1;
+    if (paramsOpen && !paramsOpen[0].endsWith('/>') && paramsClose > 0) {
+      const dsIndent = /\n([ \t]+)</.exec(block.slice(paramsOpen.index + paramsOpen[0].length, paramsClose))?.[1]
+        ?? `${indent}\t`;
+      const dsParam =
+        `${dsIndent}<AxReportDataSetParameter>\n` +
+        `${dsIndent}\t<Name>${parameterName}</Name>\n` +
+        `${dsIndent}\t<Alias>${parameterName}</Alias>\n` +
+        `${dsIndent}\t<DataType>${dataType}</DataType>\n` +
+        `${dsIndent}\t<Parameter>${parameterName}</Parameter>\n` +
+        `${dsIndent}</AxReportDataSetParameter>\n`;
+      const at = located.start + paramsClose;
+      next = `${next.slice(0, at)}${dsParam}${next.slice(at)}`;
+      boundTo = located.name;
+    }
+  }
+
+  await fs.writeFile(filePath, `﻿${next.replace(/^﻿/, '')}`, 'utf-8');
+
+  return {
+    success: true,
+    message:
+      `✅ report-design(add-parameter): declared '${parameterName}' (${dataType}` +
+      `${opts.hidden ? ', hidden' : ''}) and bound it to dataset '${boundTo}'.\n` +
+      '⚠️ The DESIGN does not use it yet. A parameter the RDL does not reference still appears in the ' +
+      'dialog but changes nothing — open the Report Designer to wire it in.',
+  };
+}
+
+function datasetError(
+  action: string,
+  located: { ok: false; reason: string; available: string[] },
+  requested: string | undefined,
+): string {
+  if (located.reason === 'no-datasets') {
+    return `❌ report-design(${action}): the document declares no datasets — nothing to extend.`;
+  }
+  if (located.reason === 'ambiguous') {
+    return (
+      `❌ report-design(${action}): the report has ${located.available.length} datasets ` +
+      `(${located.available.join(', ')}), so datasetName is required. Guessing which one to extend is ` +
+      'exactly the mistake that puts a field on the wrong dataset.'
+    );
+  }
+  return (
+    `❌ report-design(${action}): no dataset named '${requested}'. The report declares: ` +
+    `${located.available.join(', ')}.`
+  );
+}

--- a/tests/tools/d365foFileOpSpecs.test.ts
+++ b/tests/tools/d365foFileOpSpecs.test.ts
@@ -25,7 +25,7 @@ describe('d365fo_file op-spec registry', () => {
     // Bump deliberately when an operation is added — the count is here so a new op
     // cannot slip in unnoticed, and because each one is also paid for out of the
     // ListTools token budget (tests/utils/toolSchemaBudget.test.ts).
-    expect(publishedOps).toHaveLength(38);
+    expect(publishedOps).toHaveLength(39);
   });
 
   it('every required/optional param has a param-spec entry with type and description', () => {

--- a/tests/tools/reportDesignXml.test.ts
+++ b/tests/tools/reportDesignXml.test.ts
@@ -1,0 +1,338 @@
+/**
+ * `report-design` — the first write path an AxReport has ever had.
+ *
+ * Every recipe used to end with "open the Report Designer", and for LAYOUT that
+ * is still right. What this operation does instead is the bookkeeping the tool
+ * already holds every input for: syncing a dataset with the temp table it reads,
+ * and declaring a parameter in the two collections that must agree about it.
+ *
+ * The safety argument is a property of the OPERATION, not of the file, and these
+ * tests are where it is pinned:
+ *
+ *  1. **The RDL is never touched.** It lives in a `<![CDATA[…]]>` block, a
+ *     malformed one fails in the SSRS renderer at run time where no build and no
+ *     test can see it, so the byte-for-byte survival of that block is asserted
+ *     directly.
+ *  2. **Additive only.** Adding a dataset field the design does not bind is
+ *     inert; removing one it does bind breaks the render. So nothing is removed,
+ *     and an existing field is left alone even when the table now disagrees.
+ *
+ * The parameter vocabulary is not invented either: across 1,057 shipped AxReport
+ * documents and 13,833 parameters, `UserVisibility` holds only `Hidden` and
+ * `Internal` — a visible parameter OMITS the element — and `AllowBlank`/`Nullable`
+ * appear only as `true`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { addReportParameter, refreshReportDataset } from '../../src/tools/write/reportDesignXml';
+
+let root: string;
+let reportPath: string;
+
+/** A report whose RDL block contains markup that would fool a naive search. */
+const REPORT_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxReport xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoNoteReport</Name>
+\t<DataSets>
+\t\t<AxReportDataSet xmlns="">
+\t\t\t<Name>ConDemoNoteReportTmp</Name>
+\t\t\t<DataSourceType>ReportDataProvider</DataSourceType>
+\t\t\t<Query>SELECT * FROM ConDemoNoteReportDP.ConDemoNoteReportTmp</Query>
+\t\t\t<Fields>
+\t\t\t\t<AxReportDataSetField>
+\t\t\t\t\t<Name>NoteId</Name>
+\t\t\t\t\t<Alias>ConDemoNoteReportTmp.1.NoteId</Alias>
+\t\t\t\t\t<DataType>System.String</DataType>
+\t\t\t\t</AxReportDataSetField>
+\t\t\t</Fields>
+\t\t\t<Parameters>
+\t\t\t\t<AxReportDataSetParameter>
+\t\t\t\t\t<Name>AX_PartitionKey</Name>
+\t\t\t\t\t<Parameter>AX_PartitionKey</Parameter>
+\t\t\t\t</AxReportDataSetParameter>
+\t\t\t</Parameters>
+\t\t</AxReportDataSet>
+\t</DataSets>
+\t<ReportParameterBases>
+\t\t<AxReportParameterBase xmlns=""
+\t\t\t\ti:type="AxReportParameter">
+\t\t\t<Name>AX_PartitionKey</Name>
+\t\t\t<UserVisibility>Hidden</UserVisibility>
+\t\t</AxReportParameterBase>
+\t</ReportParameterBases>
+\t<Designs>
+\t\t<AxReportDesign xmlns="" i:type="AxReportPrecisionDesign">
+\t\t\t<Name>Report</Name>
+\t\t\t<Text><![CDATA[<Report><DataSets><DataSet Name="ConDemoNoteReportTmp"><Fields>
+  <Field Name="NoteId"><DataField>NoteId</DataField></Field>
+</Fields></DataSet></DataSets></Report>]]></Text>
+\t\t</AxReportDesign>
+\t</Designs>
+</AxReport>`;
+
+const TABLE_XML = `<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+\t<Name>ConDemoNoteReportTmp</Name>
+\t<Fields>
+\t\t<AxTableField i:type="AxTableFieldString"><Name>NoteId</Name></AxTableField>
+\t\t<AxTableField i:type="AxTableFieldString"><Name>Subject</Name></AxTableField>
+\t\t<AxTableField i:type="AxTableFieldUtcDateTime"><Name>NoteDateTime</Name></AxTableField>
+\t\t<AxTableField i:type="AxTableFieldEnum"><Name>Tier</Name><EnumType>NoYes</EnumType></AxTableField>
+\t\t<AxTableField i:type="AxTableFieldReal"><Name>Amount</Name></AxTableField>
+\t</Fields>
+</AxTable>`;
+
+/** The exact RDL payload, so its survival can be asserted rather than assumed. */
+const rdlOf = (xml: string): string => /<!\[CDATA\[([\s\S]*?)\]\]>/.exec(xml)?.[1] ?? '(no CDATA)';
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'report-design-'));
+  mkdirSync(join(root, 'MyPkg', 'MyPkg', 'AxTable'), { recursive: true });
+  writeFileSync(join(root, 'MyPkg', 'MyPkg', 'AxTable', 'ConDemoNoteReportTmp.xml'), TABLE_XML, 'utf-8');
+  reportPath = join(root, 'ConDemoNoteReport.xml');
+  writeFileSync(reportPath, REPORT_XML, 'utf-8');
+});
+
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+const roots = () => [root];
+
+describe('refresh-dataset', () => {
+  it('adds the fields the table has and the dataset does not', async () => {
+    const r = await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(r.success).toBe(true);
+    const xml = readFileSync(reportPath, 'utf-8');
+    for (const f of ['Subject', 'NoteDateTime', 'Tier', 'Amount']) {
+      expect(xml, `${f} should have been added`).toContain(`<Name>${f}</Name>`);
+    }
+  });
+
+  it('maps X++ field types to the .NET types a dataset carries', async () => {
+    // The X++ type and the .NET type drifting apart is a hard build error, so
+    // this uses the same mapping the report scaffold does.
+    await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    const xml = readFileSync(reportPath, 'utf-8');
+    expect(xml).toMatch(/<Name>NoteDateTime<\/Name>[\s\S]*?<DataType>System\.DateTime<\/DataType>/);
+    expect(xml).toMatch(/<Name>Amount<\/Name>[\s\S]*?<DataType>System\.Double<\/DataType>/);
+    // An enum field is an int in the dataset, not a string.
+    expect(xml).toMatch(/<Name>Tier<\/Name>[\s\S]*?<DataType>System\.Int32<\/DataType>/);
+  });
+
+  it('leaves the RDL byte-for-byte untouched', async () => {
+    const before = rdlOf(readFileSync(reportPath, 'utf-8'));
+    await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(rdlOf(readFileSync(reportPath, 'utf-8'))).toBe(before);
+  });
+
+  it('does not mistake the RDL\'s own <Fields> for the dataset\'s', async () => {
+    // The CDATA contains `<Fields>` and a `<Field Name="NoteId">`. A search that
+    // did not blank it could insert the new fields inside the RDL document.
+    await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(rdlOf(readFileSync(reportPath, 'utf-8'))).not.toContain('Subject');
+  });
+
+  it('is idempotent — a second run adds nothing', async () => {
+    await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    const after = readFileSync(reportPath, 'utf-8');
+    const second = await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(second.success).toBe(true);
+    expect(second.message).toContain('nothing to add');
+    expect(readFileSync(reportPath, 'utf-8')).toBe(after);
+  });
+
+  it('never removes a field the table no longer has', async () => {
+    // Removing a field the RDL binds breaks the render, and this code cannot see
+    // the RDL — so removal is not offered at all.
+    writeFileSync(
+      join(root, 'MyPkg', 'MyPkg', 'AxTable', 'ConDemoNoteReportTmp.xml'),
+      TABLE_XML.replace(/<AxTableField i:type="AxTableFieldString"><Name>NoteId<\/Name><\/AxTableField>\s*/, ''),
+      'utf-8',
+    );
+    await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(readFileSync(reportPath, 'utf-8')).toContain('<Name>NoteId</Name>');
+  });
+
+  it('refuses a table it cannot read rather than inventing fields', async () => {
+    const r = await refreshReportDataset(reportPath, 'NoSuchTable', undefined, roots());
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('was not found on disk');
+  });
+
+  it('refuses a document that is not an AxReport', async () => {
+    const other = join(root, 'NotAReport.xml');
+    writeFileSync(other, '<?xml version="1.0"?><AxTable><Name>X</Name></AxTable>', 'utf-8');
+    const r = await refreshReportDataset(other, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('is not an AxReport');
+  });
+});
+
+/**
+ * Isolate ONE parameter's `<AxReportParameterBase>` block.
+ *
+ * Two traps here, and the operation under test creates the second one itself.
+ *
+ * The obvious regex — open tag, lazy body, the name, lazy body, close tag —
+ * starts at the FIRST `<AxReportParameterBase` in the document and stretches to
+ * whichever name you asked for, so the "block" carries every parameter before
+ * it, `UserVisibility` included.
+ *
+ * Narrowing to chunks split on the closing tag is still not enough, because a
+ * parameter name appears TWICE in a correct document BY DESIGN: once in
+ * `<ReportParameterBases>` and once in the dataset's `<Parameters>`. The dataset
+ * comes first, so a name-only search lands in the chunk that ends with the
+ * PREVIOUS parameter base — and reports a correct write as broken.
+ *
+ * So: narrow to the collection, then to the block. The same
+ * first-match-over-a-nesting-collection shape the XML writers have been bitten
+ * by; here it bit the test twice before the test was right.
+ */
+const parameterBlock = (xml: string, name: string): string => {
+  // Attribute-tolerant for the same reason the writer is: the scaffold emits
+  // `<ReportParameterBases xmlns="">`, and a literal-tag search matches the
+  // committed goldens and nothing the tool itself produces. This helper had the
+  // identical bug, one commit apart.
+  const from = xml.search(/<ReportParameterBases\b[^>]*>/);
+  const to = xml.indexOf('</ReportParameterBases>', from);
+  if (from < 0 || to < 0) return '';
+  const bases = xml.slice(from, to);
+  const hit = bases.split('</AxReportParameterBase>').find(b => b.includes(`<Name>${name}</Name>`)) ?? '';
+  const open = hit.lastIndexOf('<AxReportParameterBase');
+  return open >= 0 ? hit.slice(open) : '';
+};
+
+describe('add-parameter', () => {
+  it('declares the parameter AND binds it to the dataset', async () => {
+    // Two elements in two collections. Writing one is the mistake this prevents.
+    const r = await addReportParameter(reportPath, 'MyDateFrom', { dataType: 'System.DateTime' });
+    expect(r.success).toBe(true);
+    const xml = readFileSync(reportPath, 'utf-8');
+    expect(xml).toMatch(/<AxReportParameterBase[\s\S]*?<Name>MyDateFrom<\/Name>/);
+    expect(xml).toMatch(/<AxReportDataSetParameter>[\s\S]*?<Name>MyDateFrom<\/Name>/);
+    expect(r.message).toContain("dataset 'ConDemoNoteReportTmp'");
+  });
+
+  it('omits UserVisibility for a visible parameter', async () => {
+    // There is no "Visible" value in any of the 8,977 shipped parameters — a
+    // visible one omits the element, and an unknown value is dropped silently.
+    await addReportParameter(reportPath, 'MyVisible', {});
+    const block = parameterBlock(readFileSync(reportPath, 'utf-8'), 'MyVisible');
+    expect(block).not.toContain('UserVisibility');
+    expect(block).toContain('<AllowBlank>true</AllowBlank>');
+  });
+
+  it('writes Hidden when asked, and only then', async () => {
+    await addReportParameter(reportPath, 'MyHidden', { hidden: true });
+    const block = parameterBlock(readFileSync(reportPath, 'utf-8'), 'MyHidden');
+    expect(block).toContain('<UserVisibility>Hidden</UserVisibility>');
+  });
+
+  it('defaults the type to System.String', async () => {
+    await addReportParameter(reportPath, 'MyText', {});
+    expect(readFileSync(reportPath, 'utf-8'))
+      .toMatch(/<Name>MyText<\/Name>[\s\S]*?<DataType>System\.String<\/DataType>/);
+  });
+
+  it('leaves the RDL byte-for-byte untouched', async () => {
+    const before = rdlOf(readFileSync(reportPath, 'utf-8'));
+    await addReportParameter(reportPath, 'MyDateFrom', {});
+    expect(rdlOf(readFileSync(reportPath, 'utf-8'))).toBe(before);
+  });
+
+  it('is idempotent', async () => {
+    await addReportParameter(reportPath, 'MyDateFrom', {});
+    const after = readFileSync(reportPath, 'utf-8');
+    const second = await addReportParameter(reportPath, 'MyDateFrom', {});
+    expect(second.success).toBe(true);
+    expect(second.message).toContain('already declared');
+    expect(readFileSync(reportPath, 'utf-8')).toBe(after);
+  });
+
+  it('refuses a name that is not an AOT identifier', async () => {
+    const r = await addReportParameter(reportPath, 'My-Date From', {});
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('not a valid AOT name');
+  });
+});
+
+describe('choosing a dataset', () => {
+  const TWO_DATASETS = REPORT_XML.replace(
+    '\t</DataSets>',
+    `\t\t<AxReportDataSet xmlns="">
+\t\t\t<Name>ConDemoNoteReportLinesTmp</Name>
+\t\t\t<Fields>
+\t\t\t</Fields>
+\t\t</AxReportDataSet>
+\t</DataSets>`,
+  );
+
+  it('refuses to guess when the report has several datasets', async () => {
+    // Guessing is what puts the field on the wrong dataset.
+    writeFileSync(reportPath, TWO_DATASETS, 'utf-8');
+    const r = await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('datasetName is required');
+    expect(r.message).toContain('ConDemoNoteReportLinesTmp');
+  });
+
+  it('acts on the named one', async () => {
+    writeFileSync(reportPath, TWO_DATASETS, 'utf-8');
+    const r = await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', 'ConDemoNoteReportTmp', roots());
+    expect(r.success).toBe(true);
+  });
+
+  it('names what is available when the dataset does not exist', async () => {
+    const r = await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', 'NoSuchDataSet', roots());
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('ConDemoNoteReportTmp');
+  });
+});
+
+/**
+ * The regression a LIVE run found and no unit test could.
+ *
+ * Every test above uses a report I wrote, so they proved the writer agreed with
+ * my idea of the document. Run against what the SCAFFOLD actually emits, both
+ * operations were refused: the generator writes `<ReportParameterBases xmlns="">`
+ * and `<Fields xmlns="">`, and a literal `<Fields>` search matches the committed
+ * goldens and nothing the tool itself produces.
+ *
+ * Attributes on these containers are the norm, not the exception.
+ */
+describe('containers carry attributes, and the goldens hide that', () => {
+  const withAttributes = REPORT_XML
+    .replace('<Fields>', '<Fields xmlns="">')
+    .replace('<Parameters>', '<Parameters xmlns="">')
+    .replace('<ReportParameterBases>', '<ReportParameterBases xmlns="">');
+
+  beforeEach(() => writeFileSync(reportPath, withAttributes, 'utf-8'));
+
+  it('refreshes a dataset whose <Fields> carries xmlns', async () => {
+    const r = await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(r.success, r.message).toBe(true);
+    expect(readFileSync(reportPath, 'utf-8')).toContain('<Name>Subject</Name>');
+  });
+
+  it('adds a parameter when <ReportParameterBases> carries xmlns', async () => {
+    const r = await addReportParameter(reportPath, 'MyDateFrom', {});
+    expect(r.success, r.message).toBe(true);
+    expect(parameterBlock(readFileSync(reportPath, 'utf-8'), 'MyDateFrom')).toContain('<DataType>');
+  });
+
+  it('binds to the dataset when <Parameters> carries xmlns', async () => {
+    const r = await addReportParameter(reportPath, 'MyDateFrom', {});
+    expect(r.message).toContain("dataset 'ConDemoNoteReportTmp'");
+  });
+
+  it('refuses rather than silently doing nothing when <Fields /> is self-closing', async () => {
+    // A dataset with no fields yet is a real shape and not one this can insert
+    // into. Reporting it beats returning success over an unchanged file.
+    writeFileSync(reportPath, REPORT_XML.replace(/<Fields>[\s\S]*?<\/Fields>/, '<Fields />'), 'utf-8');
+    const r = await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('no <Fields> collection');
+  });
+});

--- a/tests/utils/toolInventory.test.ts
+++ b/tests/utils/toolInventory.test.ts
@@ -248,7 +248,14 @@ describe('tool inventory contract', () => {
       expect(annotated.has(toolName), `missing TOOL_ANNOTATIONS entry for '${toolName}'`).toBe(true);
       const a = TOOL_ANNOTATIONS[toolName];
       expect(a.title.length, `empty title for '${toolName}'`).toBeGreaterThan(0);
-      expect(typeof a.readOnlyHint).toBe('boolean');
+      // readOnlyHint is asserted by MEANING, not by presence. A hint equal to
+      // its MCP spec default (`readOnlyHint: false`) says exactly what its
+      // absence says, and the ListTools payload is re-sent on every request
+      // against a 45,000-char ratchet — so the default-valued ones were dropped
+      // to pay for the report-design operation. What must stay true is that a
+      // read tool CLAIMS to be read-only; a write tool simply must not.
+      expect([true, undefined], `'${toolName}' readOnlyHint must be true or absent`)
+        .toContain(a.readOnlyHint);
       expect(a.openWorldHint).toBe(false);
     }
     // No orphan annotations for tools that no longer exist
@@ -265,7 +272,18 @@ describe('tool inventory contract', () => {
       'run_systest_class',
     ];
     for (const toolName of writeTools) {
-      expect(TOOL_ANNOTATIONS[toolName]?.readOnlyHint, `'${toolName}' must not be read-only`).toBe(false);
+      // `false` and absent both mean "not read-only" — absent because that IS
+      // the MCP default. What must never happen is a write tool claiming true,
+      // which is what makes a client skip its write-confirmation dialog.
+      expect(TOOL_ANNOTATIONS[toolName]?.readOnlyHint, `'${toolName}' must not be read-only`)
+        .not.toBe(true);
+      // …and each one still declares whether it is destructive, explicitly.
+      // That hint is ALSO its own spec default (`true`), and it is kept anyway:
+      // a client that reads absence as "unknown" gets more cautious about a
+      // missing readOnlyHint and less cautious about a missing destructiveHint,
+      // and only the first direction is safe to take for free bytes.
+      expect(typeof TOOL_ANNOTATIONS[toolName]?.destructiveHint,
+        `'${toolName}' must state destructiveHint explicitly`).toBe('boolean');
     }
   });
 


### PR DESCRIPTION
Owner decision **D4**, approved. Follows #999 (H0+H1) and #1000 (H3 reports), both merged.

An AxReport had **no write path at all** — every recipe ended with "open the Report Designer". For LAYOUT that is still right, and it stays that way. This adds the half that is not layout: bookkeeping the tool already holds every input for, where getting it wrong is silent.

## The trim, measured before anything was spent

Headroom was **49 chars of 45,000**, so the operation had to pay for itself.

An MCP tool annotation is only worth sending when it **disagrees with the spec default** (`readOnlyHint: false`, `destructiveHint: true`, `idempotentHint: false`, `openWorldHint: true`). A field repeating its own default tells a compliant client exactly what its absence would tell it, and this payload is re-sent on every request.

| | |
|---|---:|
| `readOnlyHint: false` dropped (6 tools) | −126 |
| `idempotentHint: false` dropped (4 tools) | −92 |
| `report-design` enum value | +16 |
| **headroom after** | **49 → 251** |

**One default is kept on purpose.** `destructiveHint: true` is also a spec default and stays explicit on the two tools that carry it. Absence equals the default only for a client that *implements* defaults; one that reads absence as "unknown" becomes more cautious about a missing `readOnlyHint` and **less** cautious about a missing `destructiveHint`. Only the first direction is safe to take for free bytes, and 46 chars is not a reason to gamble on a write-confirmation dialog. The two inventory tests now assert the **meaning** — a read tool claims read-only, a write tool must not — rather than the encoding.

## What it does

- `refresh-dataset` — a field was added to the DP's temp table and the dataset does not know. The information is on disk in the table's own XML; nothing about copying it is a design decision.
- `add-parameter` — a report parameter is two elements in two collections that must agree. Writing one and forgetting the other produces a document that builds and behaves oddly.

Both are reached through one operation with an op-spec `action`, which is the cheap shape the backlog entry called for.

## Why it is safe, and why that is not a fingerprint

The plan proposed refusing "any design the scaffold does not own", enforced by a marker in the RDL. That guard has the wrong shape: it is a property of the **file's provenance**, so every report scaffolded before the marker existed — the committed goldens included — would be refused, while a hand-written report that acquired the marker would be accepted.

The guarantee here is a property of the **operation**, and it holds for any document regardless of origin:

1. **Metadata only.** The RDL lives in a `<![CDATA[…]]>` block and is never read, parsed or written. A malformed RDL fails in the SSRS renderer at run time, where no build and no test can see it.
2. **Additive only.** A dataset field the RDL does not bind is inert; removing one it *does* bind breaks the render. So nothing is removed — and that is also why there is **no `add-column`**: placing a column is layout, and layout stays with the Designer.

## What the live run found that 18 unit tests could not

Every unit test used a report I had written, so they proved the writer agreed with my idea of the document. Run against what the **scaffold actually emits**, both operations were refused: the generator writes `<ReportParameterBases xmlns="">` and `<Fields xmlns="">`, and a literal `<Fields>` search matches the committed goldens and nothing the tool itself produces. Attributes on these containers are the norm, not the exception.

Every container search is now attribute-tolerant, self-closing shapes are reported instead of silently matching nothing, and four tests pin it. The test helper had the identical bug one commit later, which is in its comment.

The final loop, end to end on the VM:

```
scaffold a report through the real generator   → baseline build OK
add a field to its temp table
refresh-dataset  → added 1 field
add-parameter    → declared and bound
                                               → build OK
RDL intact · sandbox restored
```

Three of the repo's own contract tests caught the rest of the wiring: the op-spec parameter registry, the published-operation count in `MCP_TOOLS.md`, and `canBridgeModify` — which is checked **before** the XML-only pair table and would have refused the operation as unknown.

## Verification

| check | result |
|---|---|
| Full suite | 407 files, **6,040 tests**, green |
| Lint, typecheck, coverage gate | clean |
| ListTools budget | 44,749 of 45,000 — headroom 251 |
| Live build on the VM | scaffold → both operations → build OK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5usqz9R4hmvptrj4hNw5z
